### PR TITLE
[mle] add backbone-link link type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,6 +49,10 @@ stages:
 
 jobs:
   include:
+    - env: BUILD_TARGET="posix-backbone-link" VERBOSE=1 COVERAGE=1
+      os: linux
+      compiler: clang
+      script: script/test bblink
     - env: BUILD_TARGET="posix-app-cli" VERBOSE=1 VIRTUAL_TIME=1
       os: linux
       compiler: gcc

--- a/.travis/check-backbone-link
+++ b/.travis/check-backbone-link
@@ -1,0 +1,209 @@
+#!/bin/bash
+#
+#  Copyright (c) 2019, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+set -e -x -o pipefail
+
+readonly LEADER_OUTPUT=/tmp/ot-leader.log
+readonly CORNER_NETNS=corner
+
+at_exit()
+{
+    EXIT_CODE=$?
+
+    sudo killall ot-cli-ftd || true
+    sudo killall ot-cli || true
+    sudo kill ${TSHARK_PID} || true
+    sudo kill ${TSHARK_PID1} || true
+    delete_netns || true
+
+    return $EXIT_CODE
+}
+
+delete_netns()
+{
+    sudo ip link del veth1 netns "${CORNER_NETNS}" || true
+    sudo ip link del veth0 || true
+    sudo ip netns del "${CORNER_NETNS}" || true
+}
+
+create_netns()
+{
+    sudo ip netns add "${CORNER_NETNS}"
+    sudo ip link add veth0 type veth peer name veth1
+    sudo ip link set veth1 netns "${CORNER_NETNS}"
+    sudo ip netns exec "${CORNER_NETNS}" ip link set veth1 multicast on
+    sudo ip netns exec "${CORNER_NETNS}" ip link set veth1 up
+    sudo ip netns exec "${CORNER_NETNS}" ip addr add 192.168.66.2/24 dev veth1
+    sudo ip link set veth0 multicast on
+    sudo ip link set veth0 up
+    sudo ip addr add 192.168.66.1/24 dev veth0
+    sudo ip netns exec "${CORNER_NETNS}" ip addr add 127.0.0.1 dev lo
+    sudo ip netns exec "${CORNER_NETNS}" sudo ip link set lo up
+    sudo ip netns exec "${CORNER_NETNS}" ip addr
+    ping -c 1 192.168.66.2
+}
+
+start_leader()
+{
+    sudo rm -rf tmp
+    expect <<EOF | tee "${LEADER_OUTPUT}"
+spawn ${OT_CLI} -B 192.168.66.1 ${OT_RCP} 1
+send "panid 0xface\r\n"
+expect "Done"
+send "ifconfig up\r\n"
+expect "Done"
+send "routerselectionjitter 1\r\n"
+expect "Done"
+send "thread start\r\n"
+expect "Done"
+sleep 5
+send "state\r\n"
+expect {
+    "leader" { send_user "Successfully attached as Leader\n" }
+    timeout { exit 1 }
+}
+expect "Done"
+wait
+EOF
+}
+
+start_child()
+{
+    if which tshark; then
+        sudo -E ip netns exec "${CORNER_NETNS}" tshark -i lo -w /tmp/corner.pcap & TSHARK_PID1=$!
+        echo 'Waiting 5s for tshark ready'
+        sleep 5
+    fi
+
+    BACKBONE_LINK=192.168.66.2 sudo -E ip netns exec "${CORNER_NETNS}" sudo -E -u ${USER} expect <<EOF
+spawn ${OT_CLI_FTD} 2
+send "mode rsn\r\n"
+expect "Done"
+send "panid 0xface\r\n"
+expect "Done"
+send "ifconfig up\r\n"
+expect "Done"
+send "thread start\r\n"
+expect "Done"
+sleep 5
+send "state\r\n"
+expect {
+    "child" { send_user "Successfully attached as Child\n" }
+    timeout { exit 1 }
+}
+expect "Done"
+send "reset\r\n"
+sleep 20
+send "\r\n"
+expect "> "
+send "ifconfig up\r\n"
+expect "Done"
+send "thread start\r\n"
+expect "Done"
+sleep 5
+send "state\r\n"
+expect {
+    "child" { send_user "Successfully attached as Child after reset\n" }
+    timeout { exit 1 }
+}
+EOF
+}
+
+file_expect()
+{
+    times=3
+
+    while [[ ${times} -gt 0 ]]; do
+        sleep 5
+        if grep -q "$1" "$2"; then
+            return 0
+        else
+            echo "Waiting 5s for '$1'"
+        fi
+        times=$((times - 1))
+    done
+    echo "Timeout waiting for '$1'"
+    return 1
+}
+
+setup()
+{
+    sudo apt-get install expect
+    ./bootstrap
+    BBLINK=1 NODE_MODE=transceiver VIRTUAL_TIME=0 READLINE=no ./script/test build
+}
+
+check()
+{
+    readonly OT_CLI_FTD="$(ls output/*/bin/ot-cli-ftd)"
+    readonly OT_RCP="$(ls output/*/bin/ot-rcp)"
+    readonly OT_CLI="$(ls output/posix/*/bin/ot-cli)"
+
+    create_netns
+    trap at_exit INT TERM EXIT
+    echo 'Waiting 5s for network ready'
+    sleep 5
+
+    if which tshark; then
+        tshark -i veth0 -w current.pcap & TSHARK_PID=$!
+        echo 'Waiting 5s for tshark ready'
+        sleep 5
+    fi
+
+    start_leader &
+    file_expect '^leader' "${LEADER_OUTPUT}"
+    start_child
+}
+
+main()
+{
+    case "$1" in
+        create-netns)
+            create_netns
+            ;;
+        delete-netns)
+            delete_netns
+            ;;
+        divein-netns)
+            sudo ip netns exec corner su - $USER
+            ;;
+        setup)
+            setup
+            ;;
+        check)
+            check
+            ;;
+        '')
+            setup
+            check
+            ;;
+    esac
+}
+
+main "$@"

--- a/Android.mk
+++ b/Android.mk
@@ -32,15 +32,16 @@ OPENTHREAD_DEFAULT_VERSION := $(shell cat $(LOCAL_PATH)/.default-version)
 OPENTHREAD_SOURCE_VERSION := $(shell git -C $(LOCAL_PATH) describe --always --match "[0-9].*" 2> /dev/null)
 
 OPENTHREAD_COMMON_FLAGS                                          := \
+    -DOPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL=1                  \
+    -DOPENTHREAD_CONFIG_MAC_FILTER_ENABLE=1                         \
     -DPACKAGE=\"openthread\"                                        \
     -DPACKAGE_BUGREPORT=\"openthread-devel@googlegroups.com\"       \
     -DPACKAGE_NAME=\"OPENTHREAD\"                                   \
     -DPACKAGE_STRING=\"OPENTHREAD\ $(OPENTHREAD_DEFAULT_VERSION)\"  \
-    -DPACKAGE_VERSION=\"$(OPENTHREAD_SOURCE_VERSION)\"              \
     -DPACKAGE_TARNAME=\"openthread\"                                \
-    -DVERSION=\"$(OPENTHREAD_DEFAULT_VERSION)\"                     \
     -DPACKAGE_URL=\"http://github.com/openthread/openthread\"       \
-    -DOPENTHREAD_CONFIG_MAC_FILTER_ENABLE=1                         \
+    -DPACKAGE_VERSION=\"$(OPENTHREAD_SOURCE_VERSION)\"              \
+    -DVERSION=\"$(OPENTHREAD_DEFAULT_VERSION)\"                     \
     $(NULL)
 
 # Enable required features for on-device tests.
@@ -235,6 +236,8 @@ LOCAL_SRC_FILES                                          := \
     src/posix/platform/hdlc_interface.cpp                   \
     src/posix/platform/logging.c                            \
     src/posix/platform/misc.c                               \
+    src/posix/platform/radio.cpp                            \
+    src/posix/platform/radio_bblink.cpp                     \
     src/posix/platform/radio_spinel.cpp                     \
     src/posix/platform/settings.cpp                         \
     src/posix/platform/system.c                             \

--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -28,6 +28,7 @@
 
 # OpenThread Features (Makefile default configuration).
 
+BBLINK              ?= 0
 BIG_ENDIAN          ?= 0
 BORDER_AGENT        ?= 0
 BORDER_ROUTER       ?= 0
@@ -43,6 +44,7 @@ DHCP6_CLIENT        ?= 0
 DHCP6_SERVER        ?= 0
 DIAGNOSTIC          ?= 0
 DISABLE_DOC         ?= 0
+DYNAMIC_LOG_LEVEL   ?= 0
 DNS_CLIENT          ?= 0
 ECDSA               ?= 0
 EXTERNAL_HEAP       ?= 0
@@ -66,6 +68,9 @@ SNTP_CLIENT         ?= 0
 TIME_SYNC           ?= 0
 UDP_FORWARD         ?= 0
 
+ifeq ($(BBLINK),1)
+COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE=1
+endif
 
 ifeq ($(BIG_ENDIAN),1)
 COMMONCFLAGS                   += -DBYTE_ORDER_BIG_ENDIAN=1
@@ -129,6 +134,10 @@ endif
 
 ifeq ($(DNS_CLIENT),1)
 COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_DNS_CLIENT_ENABLE=1
+endif
+
+ifeq ($(DYNAMIC_LOG_LEVEL),1)
+COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_ENABLE_DYNAMIC_LOG_LEVEL=1
 endif
 
 ifeq ($(ECDSA),1)

--- a/examples/platforms/nrf528xx/nrf52811/platform-config.h
+++ b/examples/platforms/nrf528xx/nrf52811/platform-config.h
@@ -447,4 +447,14 @@
 #define NRF_802154_TX_STARTED_NOTIFY_ENABLED 1
 #endif
 
+/**
+ * @def NRF_802154_RX_BUFFERS
+ *
+ * Number of buffers in receive queue.
+ *
+ */
+#ifndef NRF_802154_RX_BUFFERS
+#define NRF_802154_RX_BUFFERS 8
+#endif
+
 #endif // PLATFORM_CONFIG_H_

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -59,6 +59,8 @@ extern "C" {
  */
 typedef struct otThreadLinkInfo
 {
+    otRadioInfo mRadioInfo; ///< Radio information
+
     uint16_t mPanId;        ///< Source PAN ID
     uint8_t  mChannel;      ///< 802.15.4 Channel
     int8_t   mRss;          ///< Received Signal Strength in dBm.

--- a/include/openthread/platform/Makefile.am
+++ b/include/openthread/platform/Makefile.am
@@ -31,6 +31,7 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 ot_platform_headers                     = \
     alarm-micro.h                         \
     alarm-milli.h                         \
+    bblink.h                              \
     ble.h                                 \
     diag.h                                \
     entropy.h                             \

--- a/include/openthread/platform/bblink.h
+++ b/include/openthread/platform/bblink.h
@@ -1,0 +1,50 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OPENTHREAD_BBLINK_H
+#define OPENTHREAD_BBLINK_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * The source and destination port for UDP encapsulation.
+ */
+#define OT_BACKBONE_LINK_PORT 19787
+
+/**
+ * The multicast group for transmitting UDP encapsulation over IPv4.
+ */
+#define OT_BACKBONE_LINK_GROUP "224.0.0.84"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // OPENTHREAD_BBLINK_H

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -169,6 +169,28 @@ typedef struct otRadioIeInfo
     uint8_t mTimeSyncSeq;       ///< The Time sync sequence.
 } otRadioIeInfo;
 
+#define OT_RADIO_ADDRESS_SIZE 16 ///< Max radio address size.
+
+/**
+ * This structure represents the radio info.
+ *
+ *          value        | link type
+ * ----------------------|-----------------
+ *      all 0x00         | 15.4 radio link
+ *      all 0xff         | all links(for tx only)
+ * ::ffff:<IPv4 address> | IPv4 link
+ *     IPv6 address      | IPv6 link
+ *
+ */
+typedef struct otRadioInfo
+{
+    union
+    {
+        uint64_t m64[OT_RADIO_ADDRESS_SIZE / sizeof(uint64_t)];
+        uint8_t  m8[OT_RADIO_ADDRESS_SIZE];
+    } mFields;
+} otRadioInfo;
+
 /**
  * This structure represents an IEEE 802.15.4 radio frame.
  */
@@ -178,6 +200,8 @@ typedef struct otRadioFrame
 
     uint16_t mLength;  ///< Length of the PSDU.
     uint8_t  mChannel; ///< Channel used to transmit/receive the frame.
+
+    otRadioInfo mRadioInfo; ///< Radio info for tx or rx.
 
     /**
      * The union of transmit and receive information for a radio frame.

--- a/script/test
+++ b/script/test
@@ -33,7 +33,7 @@
 set -e
 set -o pipefail
 
-readonly SYSTEM_TRIPLET="$(third_party/nlbuild-autotools/repo/third_party/autoconf/config.guess | sed -e 's/[[:digit:].]*$//g')"
+export SYSTEM_TRIPLET="$(third_party/nlbuild-autotools/repo/third_party/autoconf/config.guess | sed -e 's/[[:digit:].]*$//g')"
 export top_builddir="build/${SYSTEM_TRIPLET}"
 
 do_build() {
@@ -123,6 +123,12 @@ main()
             cert)
                 shift
                 do_cert "$1"
+                break
+                ;;
+            bblink)
+                shift
+                .travis/check-backbone-link "$@"
+                break
                 ;;
             help)
                 print_usage

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -104,6 +104,7 @@ public:
     struct ParentInfo
     {
         Mac::ExtAddress mExtAddress; ///< Extended Address
+        otRadioInfo     mRadioInfo;  ///< Radio info
     };
 
     /**

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -798,6 +798,7 @@ void Mac::PrepareBeaconRequest(TxFrame &aFrame)
     aFrame.SetDstPanId(kShortAddrBroadcast);
     aFrame.SetDstAddr(kShortAddrBroadcast);
     aFrame.SetCommandId(Frame::kMacCmdBeaconRequest);
+    memset(&aFrame.mRadioInfo, 0xff, sizeof(aFrame.mRadioInfo));
 
     otLogInfoMac("Sending Beacon Request");
 }

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -363,6 +363,15 @@ public:
     uint8_t GetType(void) const { return GetPsdu()[0] & kFcfFrameTypeMask; }
 
     /**
+     * This method checks if this is an ACK frame.
+     *
+     * @retval TRUE     This is an ACK frame.
+     * @retval FALSE    This is not an ACK frame.
+     *
+     */
+    bool IsAck(void) const { return GetType() == kFcfFrameAck; }
+
+    /**
      * This method returns the IEEE 802.15.4 Frame Version.
      *
      * @returns The IEEE 802.15.4 Frame Version.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -474,6 +474,16 @@ otError MeshForwarder::HandleFrameRequest(Mac::TxFrame &aFrame)
     VerifyOrExit(mSendMessage != NULL, error = OT_ERROR_ABORT);
 
     mSendBusy = true;
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    if (!mMacDest.IsBroadcast())
+    {
+        aFrame.mRadioInfo = Get<Mle::MleRouter>().GetRadioInfo(mMacDest);
+    }
+    else
+    {
+        memset(&aFrame.mRadioInfo, 0xff, sizeof(aFrame.mRadioInfo));
+    }
+#endif
 
     switch (mSendMessage->GetType())
     {
@@ -1057,6 +1067,9 @@ void MeshForwarder::HandleReceivedFrame(Mac::RxFrame &aFrame)
     linkInfo.mRss          = aFrame.GetRssi();
     linkInfo.mLqi          = aFrame.GetLqi();
     linkInfo.mLinkSecurity = aFrame.GetSecurityEnabled();
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    linkInfo.mRadioInfo = aFrame.mRadioInfo;
+#endif
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     if (aFrame.GetTimeIe() != NULL)
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -428,6 +428,10 @@ otError Mle::Restore(void)
         mParent.SetRloc16(GetRloc16(GetRouterId(networkInfo.mRloc16)));
         mParent.SetState(Neighbor::kStateRestored);
 
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+        memcpy(&mParent.GetRadioInfo(), &parentInfo.mRadioInfo, sizeof(mParent.GetRadioInfo()));
+#endif
+
 #if OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
         mPreviousParentRloc = mParent.GetRloc16();
 #endif
@@ -468,6 +472,9 @@ otError Mle::Store(void)
 
             memset(&parentInfo, 0, sizeof(parentInfo));
             parentInfo.mExtAddress = mParent.GetExtAddress();
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+            parentInfo.mRadioInfo = mParent.GetRadioInfo();
+#endif
 
             SuccessOrExit(error = Get<Settings>().SaveParentInfo(parentInfo));
         }
@@ -3301,6 +3308,9 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
     mChildIdRequest.mChallengeLength = challenge.GetChallengeLength();
     memcpy(mChildIdRequest.mChallenge, challenge.GetChallenge(), mChildIdRequest.mChallengeLength);
 
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    mParentCandidate.SetRadioInfo(static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo())->mRadioInfo);
+#endif
     mParentCandidate.SetExtAddress(extAddress);
     mParentCandidate.SetRloc16(sourceAddress.GetRloc16());
     mParentCandidate.SetLinkFrameCounter(linkFrameCounter.GetFrameCounter());

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -665,6 +665,10 @@ otError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::Message
     }
 #endif
 
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    neighbor->SetRadioInfo(static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo())->mRadioInfo);
+#endif
+
     SuccessOrExit(error = SendLinkAccept(aMessageInfo, neighbor, tlvRequest, challenge));
 
 exit:
@@ -1646,6 +1650,9 @@ otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::Messa
         child->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
         child->ResetLinkFailures();
         child->SetState(Neighbor::kStateParentRequest);
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+        child->SetRadioInfo(static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo())->mRadioInfo);
+#endif
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
         if (Tlv::GetTlv(aMessage, Tlv::kTimeRequest, sizeof(timeRequest), timeRequest) == OT_ERROR_NONE)
         {
@@ -2173,6 +2180,9 @@ otError MleRouter::HandleChildIdRequest(const Message &         aMessage,
     child->SetDeviceMode(mode.GetMode());
     child->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
     child->SetTimeout(timeout.GetTimeout());
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    child->SetRadioInfo(static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo())->mRadioInfo);
+#endif
 
     if (mode.GetMode().IsFullNetworkData())
     {
@@ -3175,6 +3185,59 @@ void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
     aNeighbor.SetState(Neighbor::kStateInvalid);
 }
 
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+const otRadioInfo &MleRouter::GetRadioInfo(const Mac::Address &aAddress)
+{
+    Neighbor *neighbor = NULL;
+    assert(!aAddress.IsBroadcast());
+
+    switch (mRole)
+    {
+    case OT_DEVICE_ROLE_DISABLED:
+        break;
+
+    case OT_DEVICE_ROLE_DETACHED:
+    case OT_DEVICE_ROLE_CHILD:
+        neighbor = Mle::GetNeighbor(aAddress);
+        break;
+
+    case OT_DEVICE_ROLE_ROUTER:
+    case OT_DEVICE_ROLE_LEADER:
+        neighbor = mChildTable.FindChild(aAddress, ChildTable::kInStateAnyExceptInvalid);
+        VerifyOrExit(neighbor == NULL);
+
+        for (RouterTable::Iterator iter(GetInstance()); !iter.IsDone(); iter++)
+        {
+            neighbor = iter.GetRouter();
+
+            if (neighbor->GetState() == Neighbor::kStateInvalid)
+            {
+                continue;
+            }
+
+            if ((aAddress.GetType() == Mac::Address::kTypeShort && neighbor->GetRloc16() == aAddress.GetShort()) ||
+                neighbor->GetExtAddress() == aAddress.GetExtended())
+            {
+                break;
+            }
+        }
+
+        VerifyOrExit(neighbor == NULL);
+
+        if (mAttachState != kAttachStateIdle)
+        {
+            neighbor = Mle::GetNeighbor(aAddress);
+        }
+
+        break;
+    }
+
+exit:
+    assert(neighbor != NULL);
+    return neighbor->GetRadioInfo();
+}
+#endif // OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+
 Neighbor *MleRouter::GetNeighbor(uint16_t aAddress)
 {
     Neighbor *rval = NULL;
@@ -3525,6 +3588,9 @@ void MleRouter::RestoreChildren(void)
         child->SetDeviceMode(DeviceMode(childInfo.mMode));
         child->SetState(Neighbor::kStateRestored);
         child->SetLastHeard(TimerMilli::GetNow());
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+        memset(&child->GetRadioInfo(), 0xff, sizeof(child->GetRadioInfo()));
+#endif
         Get<IndirectSender>().SetChildUseShortAddress(*child, true);
         numChildren++;
     }

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -392,6 +392,18 @@ public:
      */
     Neighbor *GetNeighbor(const Ip6::Address &aAddress);
 
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    /**
+     * This method gets the radio information of the neighbor of address @p aAddress.
+     *
+     * @param[in]   aAddress    A reference to the neighbor's address.
+     *
+     * @returns the radio information of the neighbor.
+     *
+     */
+    const otRadioInfo &GetRadioInfo(const Mac::Address &aAddress);
+#endif
+
     /**
      * This method returns a pointer to a Neighbor object if a one-way link is maintained
      * as in the instance of an FTD child with neighbor routers.

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -93,6 +93,19 @@ public:
     Neighbor *GetNeighbor(const Mac::ExtAddress &aAddress) { return Mle::GetNeighbor(aAddress); }
     Neighbor *GetNeighbor(const Mac::Address &aAddress) { return Mle::GetNeighbor(aAddress); }
     Neighbor *GetNeighbor(const Ip6::Address &aAddress) { return Mle::GetNeighbor(aAddress); }
+
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    /**
+     * This method gets the radio information of the neighbor of address @p aAddress.
+     *
+     * @param[in]   aAddress    A reference to the neighbor's address.
+     *
+     * @returns the radio information of the neighbor.
+     *
+     */
+    const otRadioInfo &GetRadioInfo(const Mac::Address &aAddress) { return Mle::GetNeighbor(aAddress)->GetRadioInfo(); }
+#endif
+
     Neighbor *GetRxOnlyNeighborRouter(const Mac::Address &aAddress)
     {
         OT_UNUSED_VARIABLE(aAddress);

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -383,7 +383,28 @@ public:
     void SetTimeSyncEnabled(bool aEnabled) { mTimeSyncEnabled = aEnabled; }
 #endif
 
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    /**
+     * This method sets the radio information of this neighbor.
+     *
+     * @param[in]   aRadioInfo  A reference to the radio information of this neighbor.
+     *
+     */
+    void SetRadioInfo(const otRadioInfo &aRadioInfo) { mRadioInfo = aRadioInfo; }
+
+    /**
+     * This method gets the radio information of this neighbor.
+     *
+     * @returns the radio information of this neighbor.
+     *
+     */
+    otRadioInfo &GetRadioInfo(void) { return mRadioInfo; }
+#endif // OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+
 private:
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    otRadioInfo mRadioInfo;
+#endif
     Mac::ExtAddress mMacAddr;   ///< The IEEE 802.15.4 Extended Address
     TimeMilli       mLastHeard; ///< Time when last heard.
     union

--- a/src/posix/Makefile-posix
+++ b/src/posix/Makefile-posix
@@ -48,6 +48,7 @@ DHCP6_CLIENT                         ?= 1
 DHCP6_SERVER                         ?= 1
 DIAGNOSTIC                           ?= 1
 DNS_CLIENT                           ?= 1
+DYNAMIC_LOG_LEVEL                    ?= 1
 ECDSA                                ?= 1
 IP6_FRAGM                            ?= 1
 JAM_DETECTION                        ?= 1

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -46,6 +46,7 @@
 #define OPENTHREAD_POSIX_APP_TYPE_CLI 2
 
 #include <openthread/diag.h>
+#include <openthread/logging.h>
 #include <openthread/tasklet.h>
 #include <openthread/platform/radio.h>
 #if OPENTHREAD_POSIX_APP_TYPE == OPENTHREAD_POSIX_APP_TYPE_NCP
@@ -65,7 +66,9 @@ static jmp_buf gResetJump;
 
 void __gcov_flush();
 
-static const struct option kOptions[] = {{"dry-run", no_argument, NULL, 'n'},
+static const struct option kOptions[] = {{"backbone-link", required_argument, NULL, 'B'},
+                                         {"debug-level", required_argument, NULL, 'd'},
+                                         {"dry-run", no_argument, NULL, 'n'},
                                          {"help", no_argument, NULL, 'h'},
                                          {"interface-name", required_argument, NULL, 'I'},
                                          {"no-reset", no_argument, NULL, 0},
@@ -80,11 +83,13 @@ static void PrintUsage(const char *aProgramName, FILE *aStream, int aExitCode)
             "Syntax:\n"
             "    %s [Options] NodeId|Device|Command [DeviceConfig|CommandArgs]\n"
             "Options:\n"
+            "    -B  --backbone-link  addr   The backbone link address.\n"
             "    -I  --interface-name name   Thread network interface name.\n"
             "    -n  --dry-run               Just verify if arguments is valid and radio spinel is compatible.\n"
             "        --no-reset              Do not reset RCP on initialization\n"
             "        --radio-version         Print radio firmware version\n"
             "    -s  --time-speed factor     Time speed up factor.\n"
+            "    -d  --debug-level           Debug level of logging.\n"
             "    -v  --verbose               Also log to stderr.\n"
             "    -h  --help                  Display this usage information.\n",
             aProgramName);
@@ -95,6 +100,7 @@ static otInstance *InitInstance(int aArgCount, char *aArgVector[])
 {
     otPlatformConfig config;
     otInstance *     instance          = NULL;
+    int              logLevel          = OT_LOG_LEVEL_INFO;
     bool             isDryRun          = false;
     bool             printRadioVersion = false;
     bool             isVerbose         = false;
@@ -109,7 +115,7 @@ static otInstance *InitInstance(int aArgCount, char *aArgVector[])
     while (true)
     {
         int index  = 0;
-        int option = getopt_long(aArgCount, aArgVector, "hI:ns:v", kOptions, &index);
+        int option = getopt_long(aArgCount, aArgVector, "B:d:hI:ns:v", kOptions, &index);
 
         if (option == -1)
         {
@@ -123,6 +129,12 @@ static otInstance *InitInstance(int aArgCount, char *aArgVector[])
             break;
         case 'I':
             config.mInterfaceName = optarg;
+            break;
+        case 'B':
+            config.mBackboneLink = optarg;
+            break;
+        case 'd':
+            logLevel = atoi(optarg);
             break;
         case 'n':
             isDryRun = true;
@@ -191,6 +203,7 @@ static otInstance *InitInstance(int aArgCount, char *aArgVector[])
         exit(OT_EXIT_SUCCESS);
     }
 
+    otLoggingSetLevel(logLevel);
     return instance;
 }
 

--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -46,6 +46,7 @@ libopenthread_posix_a_SOURCES             = \
     logging.c                               \
     misc.c                                  \
     netif.cpp                               \
+    radio.cpp                               \
     radio_spinel.cpp                        \
     settings.cpp                            \
     sim.c                                   \
@@ -54,9 +55,21 @@ libopenthread_posix_a_SOURCES             = \
     udp.cpp                                 \
     $(NULL)
 
+if OPENTHREAD_ENABLE_FTD
+libopenthread_posix_a_CPPFLAGS           += \
+    -DOPENTHREAD_FTD=1                      \
+    $(NULL)
+
+libopenthread_posix_a_SOURCES            += \
+    radio_bblink.cpp                        \
+    $(NULL)
+endif
+
 noinst_HEADERS                            = \
     platform-posix.h                        \
     hdlc_interface.hpp                      \
+    radio.h                                 \
+    radio_bblink.hpp                        \
     radio_spinel.hpp                        \
     $(NULL)
 

--- a/src/posix/platform/alarm.c
+++ b/src/posix/platform/alarm.c
@@ -38,6 +38,7 @@
 #include <openthread/platform/alarm-micro.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
+#include <openthread/platform/time.h>
 
 #include "code_utils.h"
 
@@ -206,4 +207,9 @@ void platformAlarmProcess(otInstance *aInstance)
     }
 
 #endif // OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+}
+
+uint64_t otPlatTimeGet(void)
+{
+    return platformGetTime();
 }

--- a/src/posix/platform/openthread-system.h
+++ b/src/posix/platform/openthread-system.h
@@ -91,9 +91,11 @@ enum
 typedef struct otPlatformConfig
 {
     uint64_t    mNodeId;        /// Unique node ID.
+    const char *mBackboneLink;  /// The backbone link descriptor.
     const char *mInterfaceName; /// Thread network interface name.
     const char *mRadioFile;     /// Radio file path.
     const char *mRadioConfig;   /// Radio configurations.
+    int         mDebugLevel;    /// The debug level.
     uint32_t    mSpeedUpFactor; /// Speed up factor.
     bool        mResetRadio;    /// Whether to reset RCP when initializing.
 } otPlatformConfig;

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -198,9 +198,10 @@ void platformAlarmAdvanceNow(uint64_t aDelta);
  * @param[in]  aRadioFile       A pointer to the radio file.
  * @param[in]  aRadioConfig     A pointer to the radio config.
  * @param[in]  aReset           Whether to reset RCP when initializing.
+ * @param[in]  aBackboneLink    A pointer to the backbone link descriptor.
  *
  */
-void platformRadioInit(const char *aRadioFile, const char *aRadioConfig, bool aReset);
+void platformRadioInit(const char *aRadioFile, const char *aRadioConfig, bool aReset, const char *aBackboneLink);
 
 /**
  * This function shuts down the radio service used by OpenThread.

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -1,0 +1,568 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the radio driver that delegates all radio interactions with OpenThread core.
+ */
+
+#include "radio.h"
+
+#include <openthread/platform/diag.h>
+#include <openthread/platform/radio.h>
+
+#include "platform-posix.h"
+
+#include "radio_bblink.hpp"
+#include "radio_spinel.hpp"
+
+static ot::PosixApp::RadioSpinel sRadioSpinel;
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+static ot::PosixApp::RadioBackboneLink sRadioBackboneLink;
+#endif
+
+static uint8_t sTxWait    = 0;
+static uint8_t sState     = OT_RADIO_STATE_DISABLED;
+static bool    sTxStarted = false;
+
+void platformOnRadioTxStarted(otInstance *aInstance, const otRadioFrame *aFrame)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aFrame);
+
+    if (!sTxStarted)
+    {
+        otPlatRadioTxStarted(aInstance, const_cast<otRadioFrame *>(aFrame));
+        sTxStarted = true;
+    }
+}
+
+void platformOnRadioTxDone(otInstance *aInstance, const otRadioFrame *aFrame, otRadioFrame *aAckFrame, otError aError)
+{
+    assert(sTxWait > 0);
+
+    --sTxWait;
+
+    if (sTxWait == 0)
+    {
+        sTxStarted = false;
+        otPlatRadioTxDone(aInstance, const_cast<otRadioFrame *>(aFrame), aAckFrame, aError);
+    }
+}
+
+void platformOnRadioRxDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
+{
+    otPlatRadioReceiveDone(aInstance, aFrame, aError);
+}
+
+static void TxInfoFromRadioInfo(const otRadioInfo *aRadioInfo, bool *aLink802154, bool *aLinkBackbone, bool *aMulticast)
+{
+    bool multicast = (aRadioInfo->mFields.m64[0] == -1ULL && aRadioInfo->mFields.m64[1] == -1ULL);
+
+    if (aLink802154 != NULL)
+    {
+        *aLink802154 = multicast || (aRadioInfo->mFields.m64[0] == 0 && aRadioInfo->mFields.m64[1] == 0);
+    }
+
+    if (aLinkBackbone != NULL)
+    {
+        *aLinkBackbone = multicast || (aRadioInfo->mFields.m64[0] != 0 || aRadioInfo->mFields.m64[1] != 0);
+    }
+
+    if (aMulticast != NULL)
+    {
+        *aMulticast = multicast;
+    }
+}
+
+void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeeeEui64)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    SuccessOrDie(sRadioSpinel.GetIeeeEui64(aIeeeEui64));
+}
+
+void otPlatRadioSetPanId(otInstance *aInstance, uint16_t panid)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    sRadioBackboneLink.SetPanId(panid);
+#endif
+    SuccessOrDie(sRadioSpinel.SetPanId(panid));
+}
+
+void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aAddress)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    otExtAddress addr;
+
+    for (size_t i = 0; i < sizeof(addr); i++)
+    {
+        addr.m8[i] = aAddress->m8[sizeof(addr) - 1 - i];
+    }
+
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    sRadioBackboneLink.SetExtendedAddress(addr);
+#endif
+    SuccessOrDie(sRadioSpinel.SetExtendedAddress(addr));
+}
+
+void otPlatRadioSetShortAddress(otInstance *aInstance, uint16_t aAddress)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    sRadioBackboneLink.SetShortAddress(aAddress);
+#endif
+    SuccessOrDie(sRadioSpinel.SetShortAddress(aAddress));
+}
+
+void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable)
+{
+    SuccessOrDie(sRadioSpinel.SetPromiscuous(aEnable));
+    OT_UNUSED_VARIABLE(aInstance);
+}
+
+void platformRadioInit(const char *aRadioFile, const char *aRadioConfig, bool aReset, const char *aBackboneLink)
+{
+    OT_UNUSED_VARIABLE(aBackboneLink);
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    sRadioBackboneLink.Init(aBackboneLink);
+#endif
+    sRadioSpinel.Init(aRadioFile, aRadioConfig, aReset);
+}
+
+void platformRadioDeinit(void)
+{
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    sRadioBackboneLink.Deinit();
+#endif
+    sRadioSpinel.Deinit();
+}
+
+bool otPlatRadioIsEnabled(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+        sRadioBackboneLink.IsEnabled() ||
+#endif
+        sRadioSpinel.IsEnabled();
+}
+
+otError otPlatRadioEnable(otInstance *aInstance)
+{
+    otError error;
+
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    sRadioBackboneLink.Enable(aInstance);
+#endif
+    SuccessOrExit(error = sRadioSpinel.Enable(aInstance));
+
+exit:
+    if (error == OT_ERROR_NONE)
+    {
+        sState = OT_RADIO_STATE_SLEEP;
+    }
+
+    return error;
+}
+
+otError otPlatRadioDisable(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    otError error;
+
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    sRadioBackboneLink.Disable();
+#endif
+    SuccessOrExit(error = sRadioSpinel.Disable());
+
+exit:
+    if (error == OT_ERROR_NONE)
+    {
+        sState = OT_RADIO_STATE_DISABLED;
+    }
+
+    return error;
+}
+
+otError otPlatRadioSleep(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    otError error;
+
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    SuccessOrExit(error = sRadioBackboneLink.Sleep());
+#endif
+    SuccessOrExit(error = sRadioSpinel.Sleep());
+
+exit:
+    if (error == OT_ERROR_NONE)
+    {
+        sState = OT_RADIO_STATE_SLEEP;
+    }
+
+    return error;
+}
+
+otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    otError error;
+
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    SuccessOrExit(error = sRadioBackboneLink.Receive(aChannel));
+#endif
+
+    SuccessOrExit(error = sRadioSpinel.Receive(aChannel));
+
+    sState  = OT_RADIO_STATE_RECEIVE;
+    sTxWait = 0;
+
+exit:
+    return error;
+}
+
+otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    bool    to802154;
+    bool    toBackbone;
+    bool    multicast;
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(sState == OT_RADIO_STATE_RECEIVE, error = OT_ERROR_INVALID_STATE);
+    assert(sTxWait == 0);
+
+    sTxStarted = false;
+    TxInfoFromRadioInfo(&aFrame->mRadioInfo, &to802154, &toBackbone, &multicast);
+
+    if (to802154)
+    {
+        if ((error = sRadioSpinel.Transmit(*aFrame)) == OT_ERROR_NONE)
+        {
+            ++sTxWait;
+        }
+    }
+
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    if (toBackbone)
+    {
+        otError err = error;
+
+        if ((error = sRadioBackboneLink.Transmit(*aFrame)) == OT_ERROR_NONE)
+        {
+            ++sTxWait;
+        }
+        else // either succeeds is OK
+        {
+            error = err;
+        }
+    }
+#endif
+
+    if (error == OT_ERROR_NONE)
+    {
+        sState = OT_RADIO_STATE_TRANSMIT;
+    }
+
+exit:
+
+    return error;
+}
+
+otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return &sRadioSpinel.GetTransmitFrame();
+}
+
+int8_t otPlatRadioGetRssi(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.GetRssi();
+}
+
+otRadioCaps otPlatRadioGetCaps(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.GetRadioCaps();
+}
+
+const char *otPlatRadioGetVersionString(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.GetVersion();
+}
+
+bool otPlatRadioGetPromiscuous(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.IsPromiscuous();
+}
+
+void platformRadioUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, int *aMaxFd, struct timeval *aTimeout)
+{
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    sRadioBackboneLink.UpdateFdSet(*aReadFdSet, *aWriteFdSet, *aMaxFd, *aTimeout);
+#endif
+    sRadioSpinel.UpdateFdSet(*aReadFdSet, *aWriteFdSet, *aMaxFd, *aTimeout);
+}
+
+void platformRadioProcess(otInstance *aInstance, const fd_set *aReadFdSet, const fd_set *aWriteFdSet)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+    sRadioBackboneLink.Process(*aReadFdSet, *aWriteFdSet);
+#endif
+    sRadioSpinel.Process(*aReadFdSet, *aWriteFdSet);
+}
+
+void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable)
+{
+    SuccessOrDie(sRadioSpinel.EnableSrcMatch(aEnable));
+    OT_UNUSED_VARIABLE(aInstance);
+}
+
+otError otPlatRadioAddSrcMatchShortEntry(otInstance *aInstance, uint16_t aShortAddress)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return sRadioSpinel.AddSrcMatchShortEntry(aShortAddress);
+}
+
+otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress *aExtAddress)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    otExtAddress addr;
+
+    for (size_t i = 0; i < sizeof(addr); i++)
+    {
+        addr.m8[i] = aExtAddress->m8[sizeof(addr) - 1 - i];
+    }
+
+    return sRadioSpinel.AddSrcMatchExtEntry(addr);
+}
+
+otError otPlatRadioClearSrcMatchShortEntry(otInstance *aInstance, uint16_t aShortAddress)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return sRadioSpinel.ClearSrcMatchShortEntry(aShortAddress);
+}
+
+otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddress *aExtAddress)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    otExtAddress addr;
+
+    for (size_t i = 0; i < sizeof(addr); i++)
+    {
+        addr.m8[i] = aExtAddress->m8[sizeof(addr) - 1 - i];
+    }
+
+    return sRadioSpinel.ClearSrcMatchExtEntry(addr);
+}
+
+void otPlatRadioClearSrcMatchShortEntries(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    SuccessOrDie(sRadioSpinel.ClearSrcMatchShortEntries());
+}
+
+void otPlatRadioClearSrcMatchExtEntries(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    SuccessOrDie(sRadioSpinel.ClearSrcMatchExtEntries());
+}
+
+otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint16_t aScanDuration)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.EnergyScan(aScanChannel, aScanDuration);
+}
+
+otError otPlatRadioGetTransmitPower(otInstance *aInstance, int8_t *aPower)
+{
+    assert(aPower != NULL);
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.GetTransmitPower(*aPower);
+}
+
+otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.SetTransmitPower(aPower);
+}
+
+int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.GetReceiveSensitivity();
+}
+
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+{
+    // deliver the platform specific diags commands to radio only ncp.
+    OT_UNUSED_VARIABLE(aInstance);
+    char  cmd[OPENTHREAD_CONFIG_DIAG_CMD_LINE_BUFFER_SIZE] = {'\0'};
+    char *cur                                              = cmd;
+    char *end                                              = cmd + sizeof(cmd);
+
+    for (int index = 0; index < argc; index++)
+    {
+        cur += snprintf(cur, static_cast<size_t>(end - cur), "%s ", argv[index]);
+    }
+
+    sRadioSpinel.PlatDiagProcess(cmd, aOutput, aOutputMaxLen);
+}
+
+void otPlatDiagModeSet(bool aMode)
+{
+    SuccessOrExit(sRadioSpinel.PlatDiagProcess(aMode ? "start" : "stop", NULL, 0));
+    sRadioSpinel.SetDiagEnabled(aMode);
+
+exit:
+    return;
+}
+
+bool otPlatDiagModeGet(void)
+{
+    return sRadioSpinel.IsDiagEnabled();
+}
+
+void otPlatDiagTxPowerSet(int8_t aTxPower)
+{
+    char cmd[OPENTHREAD_CONFIG_DIAG_CMD_LINE_BUFFER_SIZE];
+
+    snprintf(cmd, sizeof(cmd), "power %d", aTxPower);
+    SuccessOrExit(sRadioSpinel.PlatDiagProcess(cmd, NULL, 0));
+
+exit:
+    return;
+}
+
+void otPlatDiagChannelSet(uint8_t aChannel)
+{
+    char cmd[OPENTHREAD_CONFIG_DIAG_CMD_LINE_BUFFER_SIZE];
+
+    snprintf(cmd, sizeof(cmd), "channel %d", aChannel);
+    SuccessOrExit(sRadioSpinel.PlatDiagProcess(cmd, NULL, 0));
+
+exit:
+    return;
+}
+
+void otPlatDiagRadioReceived(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aFrame);
+    OT_UNUSED_VARIABLE(aError);
+}
+
+void otPlatDiagAlarmCallback(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+}
+#endif // OPENTHREAD_CONFIG_DIAG_ENABLE
+
+uint32_t otPlatRadioGetSupportedChannelMask(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.GetRadioChannelMask(false);
+}
+
+uint32_t otPlatRadioGetPreferredChannelMask(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.GetRadioChannelMask(true);
+}
+
+otError otPlatRadioGetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t *aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return sRadioSpinel.GetCcaEnergyDetectThreshold(*aThreshold);
+}
+
+otError otPlatRadioSetCcaEnergyDetectThreshold(otInstance *aInstance, int8_t aThreshold)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return sRadioSpinel.SetCcaEnergyDetectThreshold(aThreshold);
+}
+
+#if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
+otError otPlatRadioSetCoexEnabled(otInstance *aInstance, bool aEnabled)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.SetCoexEnabled(aEnabled);
+}
+
+bool otPlatRadioIsCoexEnabled(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.IsCoexEnabled();
+}
+
+otError otPlatRadioGetCoexMetrics(otInstance *aInstance, otRadioCoexMetrics *aCoexMetrics)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(aCoexMetrics != NULL, error = OT_ERROR_INVALID_ARGS);
+
+    error = sRadioSpinel.GetCoexMetrics(*aCoexMetrics);
+
+exit:
+    return error;
+}
+#endif
+
+#if OPENTHREAD_POSIX_VIRTUAL_TIME
+void platformSimRadioSpinelUpdate(struct timeval *aTimeout)
+{
+    sRadioSpinel.Update(*aTimeout);
+}
+
+void platformSimRadioSpinelProcess(otInstance *aInstance, const struct Event *aEvent)
+{
+    sRadioSpinel.Process(*aEvent);
+    OT_UNUSED_VARIABLE(aInstance);
+}
+#endif // OPENTHREAD_POSIX_VIRTUAL_TIME

--- a/src/posix/platform/radio.h
+++ b/src/posix/platform/radio.h
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OPENTHREAD_POSIX_RADIO_H
+
+#include "openthread-core-config.h"
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
+#include <openthread/platform/radio.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * This function notifies the radio driver that a radio transceiver started transmitting.
+ */
+void platformOnRadioTxStarted(otInstance *aInstance, const otRadioFrame *aFrame);
+
+/**
+ * This function notifies the radio driver that a radio transceiver stopped transmitting.
+ */
+void platformOnRadioTxDone(otInstance *aInstance, const otRadioFrame *aFrame, otRadioFrame *aAckFrame, otError aError);
+
+/**
+ * This function notifies the radio driver that a radio transceiver received a frame.
+ */
+void platformOnRadioRxDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError);
+
+#ifdef __cplusplus
+} // end of extern "C"
+#endif
+
+#endif

--- a/src/posix/platform/radio_bblink.cpp
+++ b/src/posix/platform/radio_bblink.cpp
@@ -1,0 +1,476 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the backbone link based radio transceiver.
+ */
+
+#include "radio_bblink.hpp"
+
+#include "openthread-core-config.h"
+
+#include <arpa/inet.h>
+#include <assert.h>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <unistd.h>
+
+#include <openthread/platform/bblink.h>
+#include <openthread/platform/radio.h>
+#include <openthread/platform/time.h>
+
+#include "platform-posix.h"
+#include "radio.h"
+#include "common/instance.hpp"
+#include "common/logging.hpp"
+#include "thread/child_table.hpp"
+
+#if OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE
+
+enum
+{
+    IEEE802154_ACK_LENGTH = 5,
+
+    IEEE802154_FRAME_TYPE_ACK = 2 << 0,
+    IEEE802154_FRAME_PENDING  = 1 << 4,
+
+    IEEE802154_BROADCAST = 0xffff,
+};
+
+static uint16_t crc16_citt(uint16_t aFcs, uint8_t aByte)
+{
+    // CRC-16/CCITT, CRC-16/CCITT-TRUE, CRC-CCITT
+    // width=16 poly=0x1021 init=0x0000 refin=true refout=true xorout=0x0000 check=0x2189 name="KERMIT"
+    // http://reveng.sourceforge.net/crc-catalogue/16.htm#crc.cat.kermit
+    static const uint16_t sFcsTable[256] = {
+        0x0000, 0x1189, 0x2312, 0x329b, 0x4624, 0x57ad, 0x6536, 0x74bf, 0x8c48, 0x9dc1, 0xaf5a, 0xbed3, 0xca6c, 0xdbe5,
+        0xe97e, 0xf8f7, 0x1081, 0x0108, 0x3393, 0x221a, 0x56a5, 0x472c, 0x75b7, 0x643e, 0x9cc9, 0x8d40, 0xbfdb, 0xae52,
+        0xdaed, 0xcb64, 0xf9ff, 0xe876, 0x2102, 0x308b, 0x0210, 0x1399, 0x6726, 0x76af, 0x4434, 0x55bd, 0xad4a, 0xbcc3,
+        0x8e58, 0x9fd1, 0xeb6e, 0xfae7, 0xc87c, 0xd9f5, 0x3183, 0x200a, 0x1291, 0x0318, 0x77a7, 0x662e, 0x54b5, 0x453c,
+        0xbdcb, 0xac42, 0x9ed9, 0x8f50, 0xfbef, 0xea66, 0xd8fd, 0xc974, 0x4204, 0x538d, 0x6116, 0x709f, 0x0420, 0x15a9,
+        0x2732, 0x36bb, 0xce4c, 0xdfc5, 0xed5e, 0xfcd7, 0x8868, 0x99e1, 0xab7a, 0xbaf3, 0x5285, 0x430c, 0x7197, 0x601e,
+        0x14a1, 0x0528, 0x37b3, 0x263a, 0xdecd, 0xcf44, 0xfddf, 0xec56, 0x98e9, 0x8960, 0xbbfb, 0xaa72, 0x6306, 0x728f,
+        0x4014, 0x519d, 0x2522, 0x34ab, 0x0630, 0x17b9, 0xef4e, 0xfec7, 0xcc5c, 0xddd5, 0xa96a, 0xb8e3, 0x8a78, 0x9bf1,
+        0x7387, 0x620e, 0x5095, 0x411c, 0x35a3, 0x242a, 0x16b1, 0x0738, 0xffcf, 0xee46, 0xdcdd, 0xcd54, 0xb9eb, 0xa862,
+        0x9af9, 0x8b70, 0x8408, 0x9581, 0xa71a, 0xb693, 0xc22c, 0xd3a5, 0xe13e, 0xf0b7, 0x0840, 0x19c9, 0x2b52, 0x3adb,
+        0x4e64, 0x5fed, 0x6d76, 0x7cff, 0x9489, 0x8500, 0xb79b, 0xa612, 0xd2ad, 0xc324, 0xf1bf, 0xe036, 0x18c1, 0x0948,
+        0x3bd3, 0x2a5a, 0x5ee5, 0x4f6c, 0x7df7, 0x6c7e, 0xa50a, 0xb483, 0x8618, 0x9791, 0xe32e, 0xf2a7, 0xc03c, 0xd1b5,
+        0x2942, 0x38cb, 0x0a50, 0x1bd9, 0x6f66, 0x7eef, 0x4c74, 0x5dfd, 0xb58b, 0xa402, 0x9699, 0x8710, 0xf3af, 0xe226,
+        0xd0bd, 0xc134, 0x39c3, 0x284a, 0x1ad1, 0x0b58, 0x7fe7, 0x6e6e, 0x5cf5, 0x4d7c, 0xc60c, 0xd785, 0xe51e, 0xf497,
+        0x8028, 0x91a1, 0xa33a, 0xb2b3, 0x4a44, 0x5bcd, 0x6956, 0x78df, 0x0c60, 0x1de9, 0x2f72, 0x3efb, 0xd68d, 0xc704,
+        0xf59f, 0xe416, 0x90a9, 0x8120, 0xb3bb, 0xa232, 0x5ac5, 0x4b4c, 0x79d7, 0x685e, 0x1ce1, 0x0d68, 0x3ff3, 0x2e7a,
+        0xe70e, 0xf687, 0xc41c, 0xd595, 0xa12a, 0xb0a3, 0x8238, 0x93b1, 0x6b46, 0x7acf, 0x4854, 0x59dd, 0x2d62, 0x3ceb,
+        0x0e70, 0x1ff9, 0xf78f, 0xe606, 0xd49d, 0xc514, 0xb1ab, 0xa022, 0x92b9, 0x8330, 0x7bc7, 0x6a4e, 0x58d5, 0x495c,
+        0x3de3, 0x2c6a, 0x1ef1, 0x0f78};
+    return (aFcs >> 8) ^ sFcsTable[(aFcs ^ aByte) & 0xff];
+}
+
+static void radioComputeCrc(otRadioFrame &aFrame)
+{
+    uint16_t crc        = 0;
+    uint16_t crc_offset = aFrame.mLength - sizeof(uint16_t);
+
+    for (uint16_t i = 0; i < crc_offset; i++)
+    {
+        crc = crc16_citt(crc, aFrame.mPsdu[i]);
+    }
+
+    aFrame.mPsdu[crc_offset]     = crc & 0xff;
+    aFrame.mPsdu[crc_offset + 1] = crc >> 8;
+}
+
+namespace ot {
+namespace PosixApp {
+
+void RadioBackboneLink::Init(const char *aBackboneLink)
+{
+    if (aBackboneLink != NULL)
+    {
+        mBackbboneLink    = inet_addr(aBackboneLink);
+        mAckTxFrame.mPsdu = &mAckTxBuffer[1];
+        mRxFrame.mPsdu    = &mRxBuffer[1];
+        mState            = kStateSleep;
+    }
+    else // Disable backbone link type if BACKBONE_LINK is not set.
+    {
+        memset(&mBackbboneLink, 0, sizeof(mBackbboneLink));
+        mState = kStateDisabled;
+    }
+}
+
+void RadioBackboneLink::Enable(otInstance *aInstance)
+{
+    if (mState == kStateSleep)
+    {
+        mInstance = aInstance;
+    }
+}
+
+void RadioBackboneLink::Disable(void)
+{
+    mInstance = NULL;
+}
+
+otError RadioBackboneLink::Sleep(void)
+{
+    VerifyOrExit(IsEnabled());
+
+    if (mFd != -1)
+    {
+        close(mFd);
+        mFd = -1;
+    }
+
+    mState = kStateSleep;
+
+exit:
+    return OT_ERROR_NONE;
+}
+
+otError RadioBackboneLink::Receive(uint8_t aChannel)
+{
+    int     fd    = -1;
+    int     one   = 1;
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(IsEnabled(), error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mFd == -1, mState = kStateReceive);
+
+    VerifyOrDie((fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) != -1, OT_EXIT_ERROR_ERRNO);
+
+    VerifyOrDie(setsockopt(fd, IPPROTO_IP, IP_MULTICAST_TTL, &one, sizeof(one)) != -1, OT_EXIT_ERROR_ERRNO);
+
+    VerifyOrDie(setsockopt(fd, IPPROTO_IP, IP_TTL, &one, sizeof(one)) != -1, OT_EXIT_ERROR_ERRNO);
+
+#if __linux__
+    {
+        int priority = 6;
+
+        VerifyOrDie(setsockopt(fd, SOL_SOCKET, SO_PRIORITY, &priority, sizeof(priority)) != -1, OT_EXIT_ERROR_ERRNO);
+    }
+#endif
+
+    {
+        struct ip_mreqn mreq;
+
+        memset(&mreq, 0, sizeof(mreq));
+        inet_pton(AF_INET, OT_BACKBONE_LINK_GROUP, &mreq.imr_multiaddr);
+
+        // Always use loopback device to send simulation packets.
+        mreq.imr_address.s_addr = mBackbboneLink;
+
+        VerifyOrDie(setsockopt(fd, IPPROTO_IP, IP_MULTICAST_IF, &mreq.imr_address, sizeof(mreq.imr_address)) != -1,
+                    OT_EXIT_ERROR_ERRNO);
+        VerifyOrDie(setsockopt(fd, IPPROTO_IP, IP_ADD_MEMBERSHIP, &mreq, sizeof(mreq)) != -1, OT_EXIT_ERROR_ERRNO);
+    }
+
+    {
+        sockaddr_in sockaddr;
+
+        memset(&sockaddr, 0, sizeof(sockaddr));
+        sockaddr.sin_family = AF_INET;
+        sockaddr.sin_port   = htons(OT_BACKBONE_LINK_PORT);
+
+        VerifyOrDie(bind(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != -1, OT_EXIT_ERROR_ERRNO);
+    }
+
+    mFd      = fd;
+    mChannel = aChannel;
+
+    mState = kStateReceive;
+
+exit:
+    otLogInfoPlat("%s: %s", __PRETTY_FUNCTION__, otThreadErrorToString(error));
+    return error;
+}
+
+otError RadioBackboneLink::Transmit(otRadioFrame &aFrame)
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(mState == kStateReceive, error = OT_ERROR_INVALID_STATE);
+
+    radioComputeCrc(aFrame);
+    mTxFrame     = static_cast<Mac::TxFrame *>(&aFrame);
+    mTxBuffer[0] = aFrame.mChannel;
+    memcpy(&mTxBuffer[1], mTxFrame->mPsdu, mTxFrame->mLength);
+
+    mState = kStateTransmit;
+
+exit:
+    otLogInfoPlat("%s: %s", __PRETTY_FUNCTION__, otThreadErrorToString(error));
+    return error;
+}
+
+void RadioBackboneLink::DoReceive(void)
+{
+    bool isAck = mRxFrame.IsAck();
+
+    otLogInfoPlat("%s channel=%u state=%d len=%u ack=%d rxc=%u", __PRETTY_FUNCTION__, mChannel, mState,
+                  mRxFrame.GetLength(), isAck, mRxFrame.mChannel);
+
+    VerifyOrExit(mRxFrame.mChannel == mChannel);
+
+    if (mRxFrame.IsAck())
+    {
+        VerifyOrExit(mState == kStateTransmitAckPending && mTxFrame->GetAckRequest() &&
+                     mRxFrame.GetSequence() == mTxFrame->GetSequence());
+
+        mState = kStateReceive;
+        platformOnRadioTxDone(mInstance, const_cast<Mac::TxFrame *>(mTxFrame), (isAck ? &mRxFrame : NULL),
+                              OT_ERROR_NONE);
+    }
+    else
+    {
+        Mac::PanId   panid;
+        Mac::Address dst;
+
+        VerifyOrExit(mState == kStateReceive || mState == kStateTransmit || mState == kStateTransmitAckPending);
+
+        if (mRxFrame.GetDstPanId(panid) == OT_ERROR_NONE && mRxFrame.GetDstAddr(dst) == OT_ERROR_NONE)
+        {
+            VerifyOrExit(panid == mPanId &&
+                         ((dst.GetType() == Mac::Address::kTypeShort &&
+                           (dst.GetShort() == mShortAddress || dst.GetShort() == IEEE802154_BROADCAST)) ||
+                          (dst.GetType() == Mac::Address::kTypeExtended &&
+                           !memcmp(&dst.GetExtended(), &mExtAddress, sizeof(mExtAddress)))));
+        }
+
+        mRxFrame.mInfo.mRxInfo.mRssi = -20;
+        mRxFrame.mInfo.mRxInfo.mLqi  = OT_RADIO_LQI_NONE;
+
+        mRxFrame.mInfo.mRxInfo.mAckedWithFramePending = false;
+
+        // generate acknowledgment
+        if (mRxFrame.GetAckRequest())
+        {
+            Mac::Address src;
+            Child *      child;
+
+            mAckTxFrame.mLength  = IEEE802154_ACK_LENGTH;
+            mAckTxFrame.mPsdu[0] = IEEE802154_FRAME_TYPE_ACK;
+
+            mRxFrame.GetSrcAddr(src);
+            child = static_cast<Instance *>(mInstance)->Get<ChildTable>().FindChild(src, ChildTable::kInStateValid);
+            if (mRxFrame.IsDataRequestCommand() && child != NULL && child->GetIndirectMessageCount() > 0)
+            {
+                mAckTxFrame.mPsdu[0] |= IEEE802154_FRAME_PENDING;
+                mRxFrame.mInfo.mRxInfo.mAckedWithFramePending = true;
+            }
+
+            mAckTxFrame.mPsdu[1] = 0;
+            mAckTxFrame.mPsdu[2] = mRxFrame.GetSequence();
+
+            mAckTxFrame.mPsdu[-1]  = mRxFrame.mChannel;
+            mAckTxFrame.mRadioInfo = mRxFrame.mRadioInfo;
+
+            radioComputeCrc(mAckTxFrame);
+            DoTransmit(mRxFrame.mRadioInfo, mAckTxBuffer, mAckTxFrame.mLength + 1);
+        }
+
+        platformOnRadioRxDone(mInstance, &mRxFrame, OT_ERROR_NONE);
+    }
+
+exit:
+    otLogInfoPlat("%s", __PRETTY_FUNCTION__);
+}
+
+otError RadioBackboneLink::DoTransmit(const otRadioInfo &aRadioInfo, const uint8_t *aBuffer, uint16_t aLength)
+{
+    otError            error = OT_ERROR_NONE;
+    struct sockaddr_in sockaddr;
+    ssize_t            rval;
+    bool               multicast = (aRadioInfo.mFields.m64[0] == -1ULL && aRadioInfo.mFields.m64[1] == -1ULL);
+
+    assert(mFd != -1);
+
+    memset(&sockaddr, 0, sizeof(sockaddr));
+    sockaddr.sin_family = AF_INET;
+    sockaddr.sin_port   = htons(OT_BACKBONE_LINK_PORT);
+
+    if (!multicast)
+    {
+        memcpy(&sockaddr.sin_addr, &aRadioInfo.mFields.m8[12], sizeof(sockaddr.sin_addr));
+    }
+    else
+    {
+        sockaddr.sin_addr.s_addr = inet_addr(OT_BACKBONE_LINK_GROUP);
+    }
+
+    rval = sendto(mFd, aBuffer, aLength, 0, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
+
+    if (rval > 0)
+    {
+        assert(rval == aLength);
+        mState = kStateReceive;
+    }
+    else if (rval == 0)
+    {
+        // TODO deal with this case
+    }
+    else if (rval == EINTR)
+    {
+        otLogWarnPlat("Transmit is interrupted, will try again later.");
+    }
+
+    otLogInfoPlat("%s 2", __PRETTY_FUNCTION__);
+    return error;
+}
+
+void RadioBackboneLink::UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, int &aMaxFd, struct timeval &aTimeout)
+{
+    OT_UNUSED_VARIABLE(aTimeout);
+
+    VerifyOrExit(mFd != -1);
+
+    FD_SET(mFd, &aReadFdSet);
+
+    if (mState == kStateTransmit)
+    {
+        FD_SET(mFd, &aWriteFdSet);
+    }
+
+    // TODO poll error event when the backbone link interface changed
+
+    if (aMaxFd < mFd)
+    {
+        aMaxFd = mFd;
+    }
+
+    if (mState == kStateTransmitAckPending)
+    {
+        TimeMilli now = TimerMilli::GetNow();
+
+        if (now >= mAckTimeout)
+        {
+            aTimeout.tv_sec  = 0;
+            aTimeout.tv_usec = 0;
+        }
+        else
+        {
+            uint32_t timeout = mAckTimeout - now;
+
+            if (aTimeout.tv_sec > 0 || aTimeout.tv_usec > timeout * 1000)
+            {
+                aTimeout.tv_sec  = 0;
+                aTimeout.tv_usec = timeout * 1000;
+            }
+        }
+    }
+
+exit:
+    return;
+}
+
+void RadioBackboneLink::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet)
+{
+    VerifyOrExit(mFd != -1);
+
+    if (FD_ISSET(mFd, &aReadFdSet))
+    {
+        ssize_t            rval;
+        struct sockaddr_in sockaddr;
+        socklen_t          socklen = sizeof(sockaddr);
+
+        // Channel is the receive channel.
+        rval = recvfrom(mFd, &mRxFrame.mPsdu[-1], sizeof(mRxBuffer), 0, (struct sockaddr *)&sockaddr, &socklen);
+
+        if (rval > 0)
+        {
+            mRxFrame.mLength  = static_cast<uint8_t>(rval - 1);
+            mRxFrame.mChannel = mRxFrame.mPsdu[-1];
+            // Unable to simulate SFD, so use the rx done timestamp instead.
+            mRxFrame.mInfo.mRxInfo.mTimestamp = otPlatTimeGet();
+        }
+        else if (rval == 0)
+        {
+            // TODO figure when this can return 0 for an UDP socket
+            ExitNow();
+        }
+        else if (errno == EINTR)
+        {
+            // interrupted, give up in case there are some high priority tasks.
+            ExitNow();
+        }
+        else
+        {
+            // Oops, socket is broken
+            // TODO Need to recover when the link is recovered.
+            ExitNow(Sleep());
+        }
+
+        // IPv4 address ::ffff:<IPv4>
+        mRxFrame.mRadioInfo.mFields.m8[10] = 0xff;
+        mRxFrame.mRadioInfo.mFields.m8[11] = 0xff;
+        memcpy(&mRxFrame.mRadioInfo.mFields.m8[12], &sockaddr.sin_addr, sizeof(sockaddr.sin_addr));
+
+        if (htons(sockaddr.sin_port) != OT_BACKBONE_LINK_PORT)
+        {
+            // Silently drop packets with a wrong source port.
+            otLogWarnPlat("Unexpected source address of backbone encapsulation");
+        }
+        else
+        {
+            DoReceive();
+        }
+    }
+
+    // For simplicity, send message after both link types are writable
+    if (mState == kStateTransmit && FD_ISSET(mFd, &aWriteFdSet))
+    {
+        otError error = DoTransmit(mTxFrame->mRadioInfo, mTxBuffer, mTxFrame->mLength + 1);
+
+        platformOnRadioTxStarted(mInstance, const_cast<Mac::TxFrame *>(mTxFrame));
+
+        if (error == OT_ERROR_NONE && mTxFrame->GetAckRequest())
+        {
+            mState      = kStateTransmitAckPending;
+            mAckTimeout = TimerMilli::GetNow() + kAckTimeout;
+        }
+        else
+        {
+            mState = kStateReceive;
+            platformOnRadioTxDone(mInstance, mTxFrame, NULL, error);
+        }
+    }
+
+    if (mState == kStateTransmitAckPending && TimerMilli::GetNow() >= mAckTimeout)
+    {
+        mState = kStateReceive;
+        platformOnRadioTxDone(mInstance, mTxFrame, NULL, OT_ERROR_NO_ACK);
+    }
+
+exit:
+    return;
+}
+
+} // namespace PosixApp
+} // namespace ot
+
+#endif // OPENTHREAD_CONFIG_BACKBONE_LINK_TYPE_ENABLE

--- a/src/posix/platform/radio_bblink.hpp
+++ b/src/posix/platform/radio_bblink.hpp
@@ -1,0 +1,102 @@
+#ifndef OPENTHREAD_POSIX_RADIO_BBLINK_HPP_
+#define OPENTHREAD_POSIX_RADIO_BBLINK_HPP_
+
+#include <netinet/in.h>
+#include <stdint.h>
+#include <sys/select.h>
+
+#include <openthread/instance.h>
+#include <openthread/platform/radio.h>
+
+#include "common/time.hpp"
+#include "mac/mac_frame.hpp"
+
+namespace ot {
+namespace PosixApp {
+
+/**
+ */
+class RadioBackboneLink
+{
+public:
+    /**
+     * This constructor initializes the backbone based OpenThread radio.
+     *
+     */
+    RadioBackboneLink(void)
+        : mFd(-1)
+        , mInstance(NULL)
+    {
+    }
+
+    /**
+     * Initialize this radio driver.
+     *
+     * If successfully initialized, it switches to SLEEP state.
+     * Otherwise stays in DISABLED state.
+     *
+     * @param[in]   aBackboneLink   The backbone link configuration.
+     *
+     */
+    void Init(const char *aBackboneLink);
+
+    /**
+     * Deinitialize this radio driver.
+     *
+     */
+    void Deinit(void) {}
+
+    void Enable(otInstance *aInstance);
+    void Disable(void);
+
+    bool IsEnabled(void) const { return mState != kStateDisabled && mInstance != NULL; }
+
+    void SetPanId(uint16_t aPanId) { mPanId = aPanId; }
+    void SetShortAddress(uint16_t &aShortAddress) { mShortAddress = aShortAddress; }
+    void SetExtendedAddress(otExtAddress &aExtAddress) { mExtAddress = aExtAddress; }
+
+    otError Receive(uint8_t aChannel);
+    otError Sleep(void);
+    otError Transmit(otRadioFrame &aFrame);
+
+    void    DoReceive(void);
+    otError DoTransmit(const otRadioInfo &aRadioInfo, const uint8_t *aBuffer, uint16_t aLength);
+
+    void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, int &aMaxFd, struct timeval &aTimeout);
+    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet);
+
+private:
+    enum State
+    {
+        kStateDisabled,
+        kStateSleep,
+        kStateReceive,
+        kStateTransmit,
+        kStateTransmitAckPending,
+    };
+
+    static const uint32_t kAckTimeout = 10; ///< Ack timeout in milliseconds.
+    TimeMilli             mAckTimeout;
+
+    State     mState;
+    uint8_t   mRxBuffer[OT_RADIO_FRAME_MAX_SIZE + 1];    ///< Receiving buffer. The additional byte for the channel.
+    uint8_t   mTxBuffer[OT_RADIO_FRAME_MAX_SIZE + 1];    ///< Transmitting buffer. The additional byte for the channel.
+    uint8_t   mAckTxBuffer[OT_RADIO_FRAME_MAX_SIZE + 1]; ///< Transmitting buffer. The additional byte for the channel.
+    uint8_t   mChannel;
+    in_addr_t mBackbboneLink;
+    int       mFd;
+
+    Mac::RxFrame        mRxFrame;
+    const Mac::TxFrame *mTxFrame;
+    Mac::TxFrame        mAckTxFrame;
+
+    uint16_t     mPanId;
+    uint16_t     mShortAddress;
+    otExtAddress mExtAddress;
+    otInstance * mInstance;
+};
+
+} // namespace PosixApp
+} // namespace ot
+
+#endif // OPENTHREAD_POSIX_RADIO_BBLINK_HPP_

--- a/src/posix/platform/system.c
+++ b/src/posix/platform/system.c
@@ -52,7 +52,8 @@ otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
     platformSimInit();
 #endif
     platformAlarmInit(aPlatformConfig->mSpeedUpFactor);
-    platformRadioInit(aPlatformConfig->mRadioFile, aPlatformConfig->mRadioConfig, aPlatformConfig->mResetRadio);
+    platformRadioInit(aPlatformConfig->mRadioFile, aPlatformConfig->mRadioConfig, aPlatformConfig->mResetRadio,
+                      aPlatformConfig->mBackboneLink);
     platformRandomInit();
 
     instance = otInstanceInitSingle();


### PR DESCRIPTION
This PR introduces a new Thread link type: backbone-link link type,
which enables transmitting Thread packets over the backbone link, so
that Thread nodes that cannot hear from each other through 15.4 link can
attach the same Thread partition, thus Thread network fragments can be
avoided or reduced.

The backbone link is part of an external IPv4 or IPv6 network, either
physical or virtual. Here's a structure example.

```
                  Backbone Link          Backbone Link
                     Ethernet                Wi-Fi
                 ---------------        -----------------
                  |           |          |             |
Router     R1 -- R2          R3 ------- R4 --- R5 ..   |
                /  \         / \        /|\        .   |
 Child         C1  C2       C3 C4     C5 | \       ... C6
                                         |  \
 ToBLE                                  C7   C8

                Figure 1 - Example network
```

The backbone link can be seen as other PHYs of Thread. Each Thread node
can have multiple PHYs, and it can hear another node through multiple
PHYs. A node can only establish a single link with another node, either
via backbone-link link type or the 15.4 link type. This simplifies the
design and allows supporting multiple link types with only a few changes
in OpenThread's core stack.