### PR TITLE
[mle] clean up MleRouter::HandleAdvertisement

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2834,7 +2834,7 @@ otError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo
     {
         if (IsFullThreadDevice())
         {
-            SuccessOrExit(error = Get<MleRouter>().HandleAdvertisement(aMessage, aMessageInfo));
+            SuccessOrExit(error = Get<MleRouter>().HandleAdvertisement(aMessage, aMessageInfo, aNeighbor));
         }
         else if ((aNeighbor == &mParent) && (mParent.GetRloc16() != sourceAddress.GetRloc16()))
         {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -600,12 +600,6 @@ otError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::Message
 
         rloc16 = sourceAddress.GetRloc16();
 
-        if (aNeighbor && aNeighbor->IsStateValid() && aNeighbor->GetRloc16() != rloc16)
-        {
-            // remove stale neighbors
-            RemoveNeighbor(*aNeighbor);
-        }
-
         if (IsActiveRouter(rloc16))
         {
             Mac::ExtAddress macAddr;

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -688,7 +688,7 @@ private:
                                        const Ip6::MessageInfo &aMessageInfo,
                                        uint32_t                aKeySequence,
                                        Neighbor *              aNeighbor);
-    otError HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, Neighbor *);
     otError HandleParentRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     otError HandleChildIdRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, uint32_t aKeySequence);
     otError HandleChildUpdateRequest(const Message &         aMessage,

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -139,7 +139,7 @@ private:
     {
         return OT_ERROR_DROP;
     }
-    otError HandleAdvertisement(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
+    otError HandleAdvertisement(const Message &, const Ip6::MessageInfo &, Neighbor *) { return OT_ERROR_DROP; }
     otError HandleParentRequest(const Message &, const Ip6::MessageInfo &) { return OT_ERROR_DROP; }
     otError HandleChildIdRequest(const Message &, const Ip6::MessageInfo &, uint32_t) { return OT_ERROR_DROP; }
     otError HandleChildUpdateRequest(const Message &, const Ip6::MessageInfo &, uint32_t) { return OT_ERROR_DROP; }


### PR DESCRIPTION
- Ensure there are no side effects if MLE frame counters have not yet
been synchronized.

- Do not remove stale neighbor until end of processing
Advertisement. This allows for complete processing of Advertisement
if frame counters have already been established.