### PR TITLE
[posix-app] remove function "HdlcInterface::IsDecoding()"

### DIFF
--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -125,7 +125,6 @@ namespace PosixApp {
 HdlcInterface::HdlcInterface(Callbacks &aCallbacks)
     : mCallbacks(aCallbacks)
     , mSockFd(-1)
-    , mIsDecoding(false)
     , mRxFrameBuffer()
     , mHdlcDecoder(mRxFrameBuffer, HandleHdlcFrame, this)
 {
@@ -199,9 +198,7 @@ void HdlcInterface::Read(void)
 
 void HdlcInterface::Decode(const uint8_t *aBuffer, uint16_t aLength)
 {
-    mIsDecoding = true;
     mHdlcDecoder.Decode(aBuffer, aLength);
-    mIsDecoding = false;
 }
 
 otError HdlcInterface::SendFrame(const uint8_t *aFrame, uint16_t aLength)

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -130,14 +130,6 @@ public:
     int GetSocket(void) const { return mSockFd; }
 
     /**
-     * This method indicates whether the `HdclInterface` is currently decoding a received frame or not.
-     *
-     * @returns  TRUE if currently decoding a received frame, FALSE otherwise.
-     *
-     */
-    bool IsDecoding(void) const { return mIsDecoding; }
-
-    /**
      * This method instructs `HdlcInterface` to read and decode data from radio over the socket.
      *
      * If a full HDLC frame is decoded while reading data, this method invokes the `HandleReceivedFrame()` (on the

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -603,7 +603,8 @@ private:
      */
     bool IsSafeToHandleNow(spinel_prop_key_t aKey) const
     {
-        return !(aKey == SPINEL_PROP_STREAM_RAW || aKey == SPINEL_PROP_MAC_ENERGY_SCAN_RESULT);
+        return !((mWaitingKey != SPINEL_PROP_LAST_STATUS) &&
+                 (aKey == SPINEL_PROP_STREAM_RAW || aKey == SPINEL_PROP_MAC_ENERGY_SCAN_RESULT));
     }
 
     void HandleNotification(HdlcInterface::RxFrameBuffer &aFrameBuffer);

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -603,8 +603,7 @@ private:
      */
     bool IsSafeToHandleNow(spinel_prop_key_t aKey) const
     {
-        return !((mHdlcInterface.IsDecoding() || mWaitingKey != SPINEL_PROP_LAST_STATUS) &&
-                 (aKey == SPINEL_PROP_STREAM_RAW || aKey == SPINEL_PROP_MAC_ENERGY_SCAN_RESULT));
+        return !(aKey == SPINEL_PROP_STREAM_RAW || aKey == SPINEL_PROP_MAC_ENERGY_SCAN_RESULT);
     }
 
     void HandleNotification(HdlcInterface::RxFrameBuffer &aFrameBuffer);


### PR DESCRIPTION
The function "RadioSpinel::IsSafeToHandleNow()" is finally called by the
function "HdlcInterface::Decode()". However, the variable "mIsDecoding"
is set to TRUE before calling "RadioSpinel::IsSafeToHandleNow()" in
function "HdlcInterface::Decode()". So the function "IsDecoding()"
always return TURE in function "RadioSpinel::IsSafeToHandleNow()". This
CL removes the function "IsDecoding()" to make the logic of the code easier.