### PR TITLE
[diag] send frames only from the alarm handler in repeat mode

### DIFF
--- a/examples/platforms/nrf528xx/src/diag.c
+++ b/examples/platforms/nrf528xx/src/diag.c
@@ -415,6 +415,9 @@ void otPlatDiagModeSet(bool aMode)
     {
         otPlatRadioReceive(NULL, sChannel);
         otPlatRadioSleep(NULL);
+
+        // Clear all remaining events before switching to MAC callbacks.
+        nrf5RadioClearPendingEvents();
     }
     else
     {

--- a/examples/platforms/nrf528xx/src/platform-nrf5.h
+++ b/examples/platforms/nrf528xx/src/platform-nrf5.h
@@ -167,6 +167,12 @@ void nrf5RadioDeinit(void);
 void nrf5RadioProcess(otInstance *aInstance);
 
 /**
+ * Function for clearing Radio driver pending events.
+ *
+ */
+void nrf5RadioClearPendingEvents(void);
+
+/**
  * Initialization of hardware crypto engine.
  *
  */

--- a/examples/platforms/nrf528xx/src/radio.c
+++ b/examples/platforms/nrf528xx/src/radio.c
@@ -254,6 +254,21 @@ void nrf5RadioDeinit(void)
     sPendingEvents = 0;
 }
 
+void nrf5RadioClearPendingEvents(void)
+{
+    sPendingEvents = 0;
+
+    for (uint32_t i = 0; i < NRF_802154_RX_BUFFERS; i++)
+    {
+        if (sReceivedFrames[i].mPsdu != NULL)
+        {
+            uint8_t *bufferAddress   = &sReceivedFrames[i].mPsdu[-1];
+            sReceivedFrames[i].mPsdu = NULL;
+            nrf_802154_buffer_free_raw(bufferAddress);
+        }
+    }
+}
+
 otRadioState otPlatRadioGetState(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -423,13 +423,18 @@ void Diags::TransmitDone(otError aError)
         if (mTxPackets > 1)
         {
             mTxPackets--;
-            TransmitPacket();
+        }
+        else
+        {
+            ExitNow();
         }
     }
-    else
-    {
-        TransmitPacket();
-    }
+
+    VerifyOrExit(!mRepeatActive);
+    TransmitPacket();
+
+exit:
+    return;
 }
 
 #endif // OPENTHREAD_RADIO


### PR DESCRIPTION
This PR includes two commits:

**[diag] send frames only from the alarm handler in repeat mode**

In the current code base, when `diag repeat X Y` command is executed, we expect to transmit frame in regular intervals. For this purpose the alarm handler is used from which the `Diags::TransmitPacket()` method is executed. However, even in Diag repeat mode, also the `Diags::TransmitDone()` triggers the transmission of the frame via `Diags::TransmitPacket()` method in case of failure. This PR ensures this is not the case in repeat mode.

**[nrf528xx] ensure there is no radio pending events after diag is disabled**

Several times, with our WiFi/BLE coex feature, I was able to get this [assert](https://github.com/openthread/openthread/blob/master/src/core/mac/mac.cpp#L1287).
The root cause for that is that the pending event in the radio platform (for example Tx Done event) was handled after diag module was disabled. Because of that MAC didn't expect call to `Mac::HandleTransmitDone()` method since it hadn't transmitted anything.
 