### PR TITLE
[toolchain] remove unnecessary OT_TOOL_ALIGN

### DIFF
--- a/include/openthread/platform/toolchain.h
+++ b/include/openthread/platform/toolchain.h
@@ -86,13 +86,6 @@ extern "C" {
  */
 
 /**
- * @def OT_TOOL_ALIGN
- *
- * Compiler-specific alignment modifier.
- *
- */
-
-/**
  * @def OT_TOOL_WEAK
  *
  * Compiler-specific weak symbol modifier.
@@ -111,8 +104,6 @@ extern "C" {
 #define OT_TOOL_PACKED_END __attribute__((packed))
 #define OT_TOOL_WEAK __attribute__((weak))
 
-#define OT_TOOL_ALIGN(X)
-
 #elif defined(__ICCARM__) || defined(__ICC8051__)
 
 // http://supp.iar.com/FilesPublic/UPDINFO/004916/arm/doc/EWARM_DevelopmentGuide.ENU.pdf
@@ -124,8 +115,6 @@ extern "C" {
 #define OT_TOOL_PACKED_END
 #define OT_TOOL_WEAK __weak
 
-#define OT_TOOL_ALIGN(X)
-
 #elif defined(__SDCC)
 
 // Structures are packed by default in sdcc, as it primarily targets 8-bit MCUs.
@@ -134,8 +123,6 @@ extern "C" {
 #define OT_TOOL_PACKED_FIELD
 #define OT_TOOL_PACKED_END
 #define OT_TOOL_WEAK
-
-#define OT_TOOL_ALIGN(X)
 
 #else
 
@@ -147,8 +134,6 @@ extern "C" {
 #define OT_TOOL_PACKED_FIELD
 #define OT_TOOL_PACKED_END
 #define OT_TOOL_WEAK
-
-#define OT_TOOL_ALIGN(X)
 
 #endif
 

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -74,7 +74,6 @@ typedef enum
 /**
  * This structure represents an MLE Link Mode configuration.
  */
-OT_TOOL_ALIGN(4)
 typedef struct otLinkModeConfig
 {
     bool mRxOnWhenIdle : 1;       ///< 1, if the sender has its receiver on when not transmitting. 0, otherwise.
@@ -130,7 +129,6 @@ typedef struct otLeaderData
  * This structure holds diagnostic information for a Thread Router
  *
  */
-OT_TOOL_ALIGN(4)
 typedef struct
 {
     otExtAddress mExtAddress;          ///< IEEE 802.15.4 Extended Address


### PR DESCRIPTION
This commit contains two small related commits:

**[thread] remove unnecessary use of OT_TOOL_ALIGN (#4344)**
    
This commit removes the use of `OT_TOOL_ALIGN` in definitions of `otLinkModeConfig` and `otRouterInfo` structures.

 **[toolchain] remove OT_TOOL_ALIGN (#4344)**

@jwhui , I am not sure if we need the `otLinkModeConfig` and `otRouterInfo` to be defined as `OT_TOOL_ALIGN(4)` (history of change shows that these were added during windows API DLL from #882). Do you agree? 
