### PR TITLE
Best-effort to wait for the leave process to complete

### DIFF
--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -434,7 +434,12 @@ class Node(object):
         return self.wpanctl('status')
 
     def leave(self):
-        return self.wpanctl('leave')
+        res = self.wpanctl('leave')
+        for _ in range(5):
+            if self.get(WPAN_STATE) != STATE_OFFLINE:
+                print('***WARN***: Not in offline state')
+                time.sleep(1)
+        return res
 
     def form(
             self,


### PR DESCRIPTION
This change adds a five second wait period for the NCP state to really
change to offline. This will avoid forming the network in an invalid
state which causes the test to fail.