### PR TITLE
[posix-app] optimize the interface between radio_spinel and hdlc_interface

### DIFF
--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -271,7 +271,7 @@ otError HdlcInterface::WaitForFrame(struct timeval &aTimeout)
         assert(false);
         break;
     }
-#else // OPENTHREAD_POSIX_VIRTUAL_TIME
+#else  // OPENTHREAD_POSIX_VIRTUAL_TIME
     fd_set read_fds;
     fd_set error_fds;
     int rval;
@@ -306,7 +306,7 @@ otError HdlcInterface::WaitForFrame(struct timeval &aTimeout)
     {
         DieNowWithMessage("wait response", OT_EXIT_FAILURE);
     }
-#endif
+#endif // OPENTHREAD_POSIX_VIRTUAL_TIME
 
 exit:
     return error;
@@ -314,15 +314,15 @@ exit:
 
 void HdlcInterface::UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, int &aMaxFd, struct timeval &aTimeout)
 {
+    OT_UNUSED_VARIABLE(aWriteFdSet);
+    OT_UNUSED_VARIABLE(aTimeout);
+
     FD_SET(mSockFd, &aReadFdSet);
 
     if (aMaxFd < mSockFd)
     {
         aMaxFd = mSockFd;
     }
-
-    OT_UNUSED_VARIABLE(aWriteFdSet);
-    OT_UNUSED_VARIABLE(aTimeout);
 }
 
 void HdlcInterface::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet)

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -327,12 +327,12 @@ void HdlcInterface::UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, int &aM
 
 void HdlcInterface::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet)
 {
+    OT_UNUSED_VARIABLE(aWriteFdSet);
+
     if (FD_ISSET(mSockFd, &aReadFdSet))
     {
         Read();
     }
-
-    OT_UNUSED_VARIABLE(aWriteFdSet);
 }
 
 otError HdlcInterface::WaitForWritable(void)

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -247,7 +247,7 @@ exit:
     return error;
 }
 
-otError HdlcInterface::WaitResponse(struct timeval &aTimeout)
+otError HdlcInterface::WaitForFrame(struct timeval &aTimeout)
 {
     otError error = OT_ERROR_NONE;
 

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -223,8 +223,6 @@ otError HdlcInterface::Write(const uint8_t *aFrame, uint16_t aLength)
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
     platformSimSendRadioSpinelWriteEvent(aFrame, aLength);
 #else
-    SuccessOrExit(error = WaitForWritable());
-
     while (aLength)
     {
         ssize_t rval = write(mSockFd, aFrame, aLength);

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -155,6 +155,8 @@ public:
     /**
      * This method waits for receiving part or all of spinel frame within specified interval.
      *
+     * @param[in]  aTimeout  A reference to the timeout.
+     *
      * @retval OT_ERROR_NONE             Part or all of spinel frame is received.
      * @retval OT_ERROR_RESPONSE_TIMEOUT No spinel frame is received within @p aTimeout.
      *

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -121,24 +121,6 @@ public:
     void Deinit(void);
 
     /**
-     *
-     * This method returns the socket file descriptor associated with the interface.
-     *
-     * @returns The associated socket file descriptor, or -1 if interface is not initializes.
-     *
-     */
-    int GetSocket(void) const { return mSockFd; }
-
-    /**
-     * This method instructs `HdlcInterface` to read and decode data from radio over the socket.
-     *
-     * If a full HDLC frame is decoded while reading data, this method invokes the `HandleReceivedFrame()` (on the
-     * `aCallback` object from constructor) to pass the received frame to be processed.
-     *
-     */
-    void Read(void);
-
-    /**
      * This method gets the `RxFrameBuffer`.
      *
      * The receive frame buffer is an `Hdlc::MultiFrameBuffer` and therefore it is capable of storing multiple
@@ -170,6 +152,35 @@ public:
      */
     otError SendFrame(const uint8_t *aFrame, uint16_t aLength);
 
+    /**
+     * This method waits for receiving any spinel response frame within specified interval.
+     *
+     * @retval OT_ERROR_NONE             Spinel response frame is received.
+     * @retval OT_ERROR_RESPONSE_TIMEOUT No spinel response frame is received within @p aTimeout.
+     *
+     */
+    otError WaitResponse(struct timeval &aTimeout);
+
+    /**
+     * This method updates the file descriptor sets with file descriptors used by the radio driver.
+     *
+     * @param[inout]  aReadFdSet   A reference to the read file descriptors.
+     * @param[inout]  aWriteFdSet  A reference to the write file descriptors.
+     * @param[inout]  aMaxFd       A reference to the max file descriptor.
+     * @param[inout]  aTimeout     A reference to the timeout.
+     *
+     */
+    void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, int &aMaxFd, struct timeval &aTimeout);
+
+    /**
+     * This method performs radio driver processing.
+     *
+     * @param[in]   aReadFdSet      A reference to the read file descriptors.
+     * @param[in]   aWriteFdSet     A reference to the write file descriptors.
+     *
+     */
+    void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet);
+
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
     /**
      * This method process read data (decode the data).
@@ -185,6 +196,15 @@ public:
 #endif
 
 private:
+    /**
+     * This method instructs `HdlcInterface` to read and decode data from radio over the socket.
+     *
+     * If a full HDLC frame is decoded while reading data, this method invokes the `HandleReceivedFrame()` (on the
+     * `aCallback` object from constructor) to pass the received frame to be processed.
+     *
+     */
+    void Read(void);
+
     /**
      * This method waits for the socket file descriptor associated with the HDLC interface to become writable within
      * `kMaxWaitTime` interval.

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -153,13 +153,13 @@ public:
     otError SendFrame(const uint8_t *aFrame, uint16_t aLength);
 
     /**
-     * This method waits for receiving part or all of spinel response frame within specified interval.
+     * This method waits for receiving part or all of spinel frame within specified interval.
      *
-     * @retval OT_ERROR_NONE             Part or all of spinel response frame is received.
-     * @retval OT_ERROR_RESPONSE_TIMEOUT No spinel response frame is received within @p aTimeout.
+     * @retval OT_ERROR_NONE             Part or all of spinel frame is received.
+     * @retval OT_ERROR_RESPONSE_TIMEOUT No spinel frame is received within @p aTimeout.
      *
      */
-    otError WaitResponse(struct timeval &aTimeout);
+    otError WaitForFrame(struct timeval &aTimeout);
 
     /**
      * This method updates the file descriptor sets with file descriptors used by the radio driver.

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -153,9 +153,9 @@ public:
     otError SendFrame(const uint8_t *aFrame, uint16_t aLength);
 
     /**
-     * This method waits for receiving any spinel response frame within specified interval.
+     * This method waits for receiving part or all of spinel response frame within specified interval.
      *
-     * @retval OT_ERROR_NONE             Spinel response frame is received.
+     * @retval OT_ERROR_NONE             Part or all of spinel response frame is received.
      * @retval OT_ERROR_RESPONSE_TIMEOUT No spinel response frame is received within @p aTimeout.
      *
      */

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -370,15 +370,6 @@ void platformSimReceiveEvent(struct Event *aEvent);
 void platformSimSendSleepEvent(const struct timeval *aTimeout);
 
 /**
- * This function updates the file descriptor sets with file descriptors
- * used by radio spinel of virtual time simulation.
- *
- * @param[out]   aTimeout    A pointer to the timeout event to be updated.
- *
- */
-void platformSimRadioSpinelUpdate(struct timeval *atimeout);
-
-/**
  * This function performs radio spinel processing of virtual time simulation.
  *
  * @param[in]   aInstance   A pointer to the OpenThread instance.

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -772,7 +772,7 @@ void RadioSpinel::Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet)
     }
     else if (mState == kStateTransmitting && platformGetTime() >= mTxRadioEndUs)
     {
-        // Frame has been successfully passed to radio, but no `TransmitDone` event received wthin TX_WAIT_US.
+        // Frame has been successfully passed to radio, but no `TransmitDone` event received within TX_WAIT_US.
         DieNowWithMessage("radio tx timeout", OT_EXIT_FAILURE);
     }
 }

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -1040,7 +1040,7 @@ otError RadioSpinel::WaitResponse(void)
 
     do
     {
-        if (mHdlcInterface.WaitResponse(timeout) == OT_ERROR_RESPONSE_TIMEOUT)
+        if (mHdlcInterface.WaitForFrame(timeout) == OT_ERROR_RESPONSE_TIMEOUT)
         {
             FreeTid(mWaitingTid);
             mWaitingTid = 0;

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -1673,7 +1673,7 @@ void ot::PosixApp::RadioSpinel::Process(const Event &aEvent)
     }
     else if (mState == kStateTransmitting && platformGetTime() >= mTxRadioEndUs)
     {
-        // Frame has been successfully passed to radio, but no `TransmitDone` event received wthin TX_WAIT_US.
+        // Frame has been successfully passed to radio, but no `TransmitDone` event received within TX_WAIT_US.
         DieNowWithMessage("radio tx timeout", OT_EXIT_FAILURE);
     }
 }

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -531,12 +531,11 @@ private:
 
     enum State
     {
-        kStateDisabled,        ///< Radio is disabled.
-        kStateSleep,           ///< Radio is sleep.
-        kStateReceive,         ///< Radio is in receive mode.
-        kStateTransmitPending, ///< Frame transmission requested, waiting to pass frame to radio.
-        kStateTransmitting,    ///< Frame passed to radio for transmission, waiting for done event from radio.
-        kStateTransmitDone,    ///< Radio indicated frame transmission is done.
+        kStateDisabled,     ///< Radio is disabled.
+        kStateSleep,        ///< Radio is sleep.
+        kStateReceive,      ///< Radio is in receive mode.
+        kStateTransmitting, ///< Frame passed to radio for transmission, waiting for done event from radio.
+        kStateTransmitDone, ///< Radio indicated frame transmission is done.
     };
 
     otError CheckSpinelVersion(void);
@@ -640,7 +639,8 @@ private:
     void HandleWaitingResponse(uint32_t aCommand, spinel_prop_key_t aKey, const uint8_t *aBuffer, uint16_t aLength);
 
     void RadioReceive(void);
-    void RadioTransmit(void);
+
+    void TransmitDone(otRadioFrame *aFrame, otRadioFrame *aAckFrame, otError aError);
 
     otInstance *mInstance;
 

--- a/src/posix/platform/sim.c
+++ b/src/posix/platform/sim.c
@@ -171,14 +171,13 @@ void platformSimUpdateFdSet(fd_set *        aReadFdSet,
 {
     OT_UNUSED_VARIABLE(aWriteFdSet);
     OT_UNUSED_VARIABLE(aErrorFdSet);
+    OT_UNUSED_VARIABLE(aTimeout);
 
     FD_SET(sSockFd, aReadFdSet);
     if (*aMaxFd < sSockFd)
     {
         *aMaxFd = sSockFd;
     }
-
-    platformSimRadioSpinelUpdate(aTimeout);
 }
 
 void platformSimProcess(otInstance *  aInstance,


### PR DESCRIPTION
This PR simplifies the API between RadioSpinel and HdlcInterface to improve the extensibility of
the API. So that we can easily add other low layer interfaces to send/receive spinel frames later.
The RadioSpinel is only responsible for encoding/decoding spinel frames. Lower layer interface is only responsible for sending/receiving spinel frames.
Some lower layer interfaces can't provide a file descriptor for RadioSpinel to wait for the file descriptor to become writable, so this PR removes the kStateTransmitPending state from RadioSpinel.c and directly calls the function Request() to send frames in method RadioSpinel::Transmit().