### PR TITLE
[nrf528xx] disable soft source match

### DIFF
--- a/examples/platforms/nrf528xx/nrf52811/openthread-core-nrf52811-config.h
+++ b/examples/platforms/nrf528xx/nrf52811/openthread-core-nrf52811-config.h
@@ -224,6 +224,26 @@
 #define OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT 1
 #endif
 
+/**
+ * @def RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM
+ *
+ * The number of short source address table entries.
+ *
+ */
+#ifndef RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM
+#define RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM 0
+#endif
+
+/**
+ * @def RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM
+ *
+ * The number of extended source address table entries.
+ *
+ */
+#ifndef RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM
+#define RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM 0
+#endif
+
 /*
  * Suppress the ARMCC warning on unreachable statement,
  * e.g. break after assert(false) or ExitNow() macro.

--- a/examples/platforms/nrf528xx/nrf52833/openthread-core-nrf52833-config.h
+++ b/examples/platforms/nrf528xx/nrf52833/openthread-core-nrf52833-config.h
@@ -256,6 +256,26 @@
 #define OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT 1
 #endif
 
+/**
+ * @def RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM
+ *
+ * The number of short source address table entries.
+ *
+ */
+#ifndef RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM
+#define RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM 0
+#endif
+
+/**
+ * @def RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM
+ *
+ * The number of extended source address table entries.
+ *
+ */
+#ifndef RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM
+#define RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM 0
+#endif
+
 /*
  * Suppress the ARMCC warning on unreachable statement,
  * e.g. break after assert(false) or ExitNow() macro.

--- a/examples/platforms/nrf528xx/nrf52840/openthread-core-nrf52840-config.h
+++ b/examples/platforms/nrf528xx/nrf52840/openthread-core-nrf52840-config.h
@@ -256,6 +256,26 @@
 #define OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT 1
 #endif
 
+/**
+ * @def RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM
+ *
+ * The number of short source address table entries.
+ *
+ */
+#ifndef RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM
+#define RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM 0
+#endif
+
+/**
+ * @def RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM
+ *
+ * The number of extended source address table entries.
+ *
+ */
+#ifndef RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM
+#define RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM 0
+#endif
+
 /*
  * Suppress the ARMCC warning on unreachable statement,
  * e.g. break after assert(false) or ExitNow() macro.


### PR DESCRIPTION
This causes all platforms to have source match both in utils and in platform code - which may lead to erroneous behaviour if the wrong one is included by the linker.