### PR TITLE
[network-data] always support service registration at Leader

### DIFF
--- a/include/openthread/netdata.h
+++ b/include/openthread/netdata.h
@@ -179,7 +179,7 @@ typedef struct otServerConfig
  */
 typedef struct otServiceConfig
 {
-    uint8_t        mServiceID;         ///< Used to return service ID when iterating over network data from leader.
+    uint8_t        mServiceID;         ///< Used to return service ID when iterating over the partition's Network Data.
     uint32_t       mEnterpriseNumber;  ///< IANA Enterprise Number.
     uint8_t        mServiceDataLength; ///< Length of service data.
     uint8_t        mServiceData[OT_SERVICE_DATA_MAX_SIZE]; ///< Service data bytes.
@@ -187,7 +187,7 @@ typedef struct otServiceConfig
 } otServiceConfig;
 
 /**
- * This method provides a full or stable copy of the Leader's Thread Network Data.
+ * This method provides a full or stable copy of the Parition's Thread Network Data.
  *
  * @param[in]     aInstance    A pointer to an OpenThread instance.
  * @param[in]     aStable      TRUE when copying the stable version, FALSE when copying the full version.
@@ -237,7 +237,7 @@ otError otNetDataGetNextRoute(otInstance *aInstance, otNetworkDataIterator *aIte
  * @param[out]    aConfig    A pointer to where the service information will be placed.
  *
  * @retval OT_ERROR_NONE       Successfully found the next service.
- * @retval OT_ERROR_NOT_FOUND  No subsequent service exists in the leader Network Data.
+ * @retval OT_ERROR_NOT_FOUND  No subsequent service exists in the partition's Network Data.
  *
  */
 otError otNetDataGetNextService(otInstance *aInstance, otNetworkDataIterator *aIterator, otServiceConfig *aConfig);

--- a/include/openthread/netdata.h
+++ b/include/openthread/netdata.h
@@ -157,6 +157,35 @@ typedef enum otRoutePreference
     OT_ROUTE_PREFERENCE_HIGH = 1,  ///< High route preference.
 } otRoutePreference;
 
+#define OT_SERVICE_DATA_MAX_SIZE 252 ///< Maximum size of Service Data in bytes.
+#define OT_SERVER_DATA_MAX_SIZE \
+    248 ///< Maximum size of Server Data in bytes. This is theoretical limit, practical one is much lower.
+
+/**
+ * This structure represents a Server configuration.
+ *
+ */
+typedef struct otServerConfig
+{
+    bool     mStable : 1;       ///< TRUE, if this configuration is considered Stable Network Data. FALSE, otherwise.
+    uint8_t  mServerDataLength; ///< Length of server data.
+    uint8_t  mServerData[OT_SERVER_DATA_MAX_SIZE]; ///< Server data bytes.
+    uint16_t mRloc16;                              ///< The Server RLOC16.
+} otServerConfig;
+
+/**
+ * This structure represents a Service configuration.
+ *
+ */
+typedef struct otServiceConfig
+{
+    uint8_t        mServiceID;         ///< Used to return service ID when iterating over network data from leader.
+    uint32_t       mEnterpriseNumber;  ///< IANA Enterprise Number.
+    uint8_t        mServiceDataLength; ///< Length of service data.
+    uint8_t        mServiceData[OT_SERVICE_DATA_MAX_SIZE]; ///< Service data bytes.
+    otServerConfig mServerConfig;                          ///< The Server configuration.
+} otServiceConfig;
+
 /**
  * This method provides a full or stable copy of the Leader's Thread Network Data.
  *
@@ -198,6 +227,20 @@ otError otNetDataGetNextOnMeshPrefix(otInstance *           aInstance,
  *
  */
 otError otNetDataGetNextRoute(otInstance *aInstance, otNetworkDataIterator *aIterator, otExternalRouteConfig *aConfig);
+
+/**
+ * This function gets the next service in the partition's Network Data.
+ *
+ * @param[in]     aInstance  A pointer to an OpenThread instance.
+ * @param[inout]  aIterator  A pointer to the Network Data iterator context. To get the first service entry
+                             it should be set to OT_NETWORK_DATA_ITERATOR_INIT.
+ * @param[out]    aConfig    A pointer to where the service information will be placed.
+ *
+ * @retval OT_ERROR_NONE       Successfully found the next service.
+ * @retval OT_ERROR_NOT_FOUND  No subsequent service exists in the leader Network Data.
+ *
+ */
+otError otNetDataGetNextService(otInstance *aInstance, otNetworkDataIterator *aIterator, otServiceConfig *aConfig);
 
 /**
  * Get the Network Data Version.

--- a/include/openthread/server.h
+++ b/include/openthread/server.h
@@ -51,35 +51,6 @@ extern "C" {
  *
  */
 
-#define OT_SERVICE_DATA_MAX_SIZE 252 ///< Maximum size of Service Data in bytes.
-#define OT_SERVER_DATA_MAX_SIZE \
-    248 ///< Maximum size of Server Data in bytes. This is theoretical limit, practical one is much lower.
-
-/**
- * This structure represents a Server configuration.
- *
- */
-typedef struct otServerConfig
-{
-    bool     mStable : 1;       ///< TRUE, if this configuration is considered Stable Network Data. FALSE, otherwise.
-    uint8_t  mServerDataLength; ///< Length of server data.
-    uint8_t  mServerData[OT_SERVER_DATA_MAX_SIZE]; ///< Server data bytes.
-    uint16_t mRloc16;                              ///< The Server RLOC16.
-} otServerConfig;
-
-/**
- * This structure represents a Service configuration.
- *
- */
-typedef struct otServiceConfig
-{
-    uint8_t        mServiceID;         ///< Used to return service ID when iterating over network data from leader.
-    uint32_t       mEnterpriseNumber;  ///< IANA Enterprise Number.
-    uint8_t        mServiceDataLength; ///< Length of service data.
-    uint8_t        mServiceData[OT_SERVICE_DATA_MAX_SIZE]; ///< Service data bytes.
-    otServerConfig mServerConfig;                          ///< The Server configuration.
-} otServiceConfig;
-
 /**
  * This method provides a full or stable copy of the local Thread Network Data.
  *
@@ -141,20 +112,6 @@ otError otServerRemoveService(otInstance *   aInstance,
  *
  */
 otError otServerGetNextService(otInstance *aInstance, otNetworkDataIterator *aIterator, otServiceConfig *aConfig);
-
-/**
- * This function gets the next service in the leader Network Data.
- *
- * @param[in]     aInstance  A pointer to an OpenThread instance.
- * @param[inout]  aIterator  A pointer to the Network Data iterator context. To get the first service entry
-                             it should be set to OT_NETWORK_DATA_ITERATOR_INIT.
- * @param[out]    aConfig    A pointer to where the service information will be placed.
- *
- * @retval OT_ERROR_NONE       Successfully found the next service.
- * @retval OT_ERROR_NOT_FOUND  No subsequent service exists in the leader Network Data.
- *
- */
-otError otServerGetNextLeaderService(otInstance *aInstance, otNetworkDataIterator *aIterator, otServiceConfig *aConfig);
 
 /**
  * Immediately register the local network data with the Leader.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1596,6 +1596,8 @@ Add service to the Network Data.
 ```bash
 > service add 44970 foo bar
 Done
+> netdataregister
+Done
 > ipaddr
 fdde:ad00:beef:0:0:ff:fe00:fc10
 fdde:ad00:beef:0:0:ff:fe00:fc00
@@ -1611,6 +1613,14 @@ Remove service from Network Data.
 
 ```bash
 > service remove 44970 foo
+Done
+> netdataregister
+Done
+> ipaddr
+fdde:ad00:beef:0:0:ff:fe00:fc00
+fdde:ad00:beef:0:0:ff:fe00:7c00
+fe80:0:0:0:1486:2f57:3c:6e10
+fdde:ad00:beef:0:8ca4:19ed:217a:eff9
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -42,6 +42,7 @@
 #include <openthread/icmp6.h>
 #include <openthread/link.h>
 #include <openthread/ncp.h>
+#include <openthread/netdata.h>
 #include <openthread/thread.h>
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 #include <openthread/network_time.h>
@@ -167,9 +168,7 @@ const struct Command Interpreter::sCommands[] = {
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     {"netdataregister", &Interpreter::ProcessNetworkDataRegister},
 #endif
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     {"netdatashow", &Interpreter::ProcessNetworkDataShow},
-#endif
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
     {"networkdiagnostic", &Interpreter::ProcessNetworkDiagnostic},
 #endif // OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
@@ -1723,7 +1722,6 @@ exit:
 }
 #endif
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 void Interpreter::ProcessNetworkDataShow(int argc, char *argv[])
 {
     OT_UNUSED_VARIABLE(argc);
@@ -1742,6 +1740,7 @@ exit:
     AppendResult(error);
 }
 
+#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 void Interpreter::ProcessService(int argc, char *argv[])
 {
     otError error = OT_ERROR_NONE;

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -272,8 +272,8 @@ private:
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     void ProcessNetworkDataRegister(int argc, char *argv[]);
 #endif
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     void ProcessNetworkDataShow(int argc, char *argv[]);
+#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     void ProcessService(int argc, char *argv[]);
 #endif
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -77,6 +77,19 @@ exit:
     return error;
 }
 
+otError otNetDataGetNextService(otInstance *aInstance, otNetworkDataIterator *aIterator, otServiceConfig *aConfig)
+{
+    otError   error    = OT_ERROR_NONE;
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    VerifyOrExit(aIterator && aConfig, error = OT_ERROR_INVALID_ARGS);
+
+    error = instance.Get<NetworkData::Leader>().GetNextService(*aIterator, *aConfig);
+
+exit:
+    return error;
+}
+
 uint8_t otNetDataGetVersion(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);

--- a/src/core/api/server_api.cpp
+++ b/src/core/api/server_api.cpp
@@ -84,19 +84,6 @@ exit:
     return error;
 }
 
-otError otServerGetNextLeaderService(otInstance *aInstance, otNetworkDataIterator *aIterator, otServiceConfig *aConfig)
-{
-    otError   error    = OT_ERROR_NONE;
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    VerifyOrExit(aIterator && aConfig, error = OT_ERROR_INVALID_ARGS);
-
-    error = instance.Get<NetworkData::Leader>().GetNextService(*aIterator, *aConfig);
-
-exit:
-    return error;
-}
-
 otError otServerRegister(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -416,13 +416,11 @@ otError MeshForwarder::UpdateIp6RouteFtd(Ip6::Header &ip6Header)
                 mMeshDest = Mle::Mle::GetRloc16(routerId);
             }
         }
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
         else if ((aloc16 >= Mle::kAloc16ServiceStart) && (aloc16 <= Mle::kAloc16ServiceEnd))
         {
             SuccessOrExit(error = GetDestinationRlocByServiceAloc(aloc16, mMeshDest));
         }
 
-#endif
         else
         {
             // TODO: support for Neighbor Discovery Agent ALOC
@@ -768,7 +766,6 @@ exit:
     return error;
 }
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 otError MeshForwarder::GetDestinationRlocByServiceAloc(uint16_t aServiceAloc, uint16_t &aMeshDest)
 {
     otError                  error      = OT_ERROR_NONE;
@@ -826,7 +823,6 @@ otError MeshForwarder::GetDestinationRlocByServiceAloc(uint16_t aServiceAloc, ui
 exit:
     return error;
 }
-#endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
 // LCOV_EXCL_START
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1027,7 +1027,6 @@ exit:
     return error;
 }
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 otError Mle::GetServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const
 {
     otError error = OT_ERROR_NONE;
@@ -1043,7 +1042,6 @@ otError Mle::GetServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const
 exit:
     return error;
 }
-#endif
 
 otError Mle::AddLeaderAloc(void)
 {

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -864,7 +864,6 @@ public:
         return GetAlocAddress(aAddress, GetCommissionerAloc16FromId(aSessionId));
     }
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     /**
      * This method retrieves the Service ALOC for given Service ID.
      *
@@ -876,7 +875,6 @@ public:
      *
      */
     otError GetServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const;
-#endif
 
     /**
      * This method adds Leader's ALOC to its Thread interface.

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -228,7 +228,6 @@ exit:
     return error;
 }
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 otError NetworkData::GetNextService(Iterator &aIterator, ServiceConfig &aConfig)
 {
     return GetNextService(aIterator, Mac::kShortAddrBroadcast, aConfig);
@@ -370,7 +369,6 @@ otError NetworkData::GetNextServiceId(Iterator &aIterator, uint16_t aRloc16, uin
 exit:
     return error;
 }
-#endif
 
 bool NetworkData::ContainsOnMeshPrefixes(NetworkData &aCompare, uint16_t aRloc16)
 {
@@ -432,7 +430,6 @@ exit:
     return rval;
 }
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 bool NetworkData::ContainsServices(NetworkData &aCompare, uint16_t aRloc16)
 {
     Iterator      outerIterator = kIteratorInit;
@@ -519,19 +516,16 @@ bool NetworkData::ContainsService(uint8_t aServiceId, uint16_t aRloc16)
 exit:
     return rval;
 }
-#endif
 
 void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength)
 {
     NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(aData);
     NetworkDataTlv *end;
     PrefixTlv *     prefix;
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    ServiceTlv *service;
-#endif
-    uint8_t  length;
-    uint8_t *dst;
-    uint8_t *src;
+    ServiceTlv *    service;
+    uint8_t         length;
+    uint8_t *       dst;
+    uint8_t *       src;
 
     while (1)
     {
@@ -563,8 +557,6 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength)
             break;
         }
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-
         case NetworkDataTlv::kTypeService:
         {
             service = static_cast<ServiceTlv *>(cur);
@@ -583,8 +575,6 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength)
             otDumpDebgNetData("remove service done", mTlvs, mLength);
             break;
         }
-
-#endif
 
         default:
         {
@@ -701,7 +691,6 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Pref
     }
 }
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, ServiceTlv &aService)
 {
     NetworkDataTlv *cur = aService.GetSubTlvs();
@@ -752,7 +741,6 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Serv
         }
     }
 }
-#endif
 
 BorderRouterTlv *NetworkData::FindBorderRouter(PrefixTlv &aPrefix)
 {
@@ -928,7 +916,6 @@ int8_t NetworkData::PrefixMatch(const uint8_t *a, const uint8_t *b, uint8_t aLen
     return (rval >= aLength) ? rval : -1;
 }
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,
                                      const uint8_t *aServiceData,
                                      uint8_t        aServiceDataLength)
@@ -970,7 +957,6 @@ ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,
 exit:
     return compare;
 }
-#endif
 
 void NetworkData::Insert(uint8_t *aStart, uint8_t aLength)
 {

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -107,13 +107,11 @@ typedef otBorderRouterConfig OnMeshPrefixConfig;
  */
 typedef otExternalRouteConfig ExternalRouteConfig;
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 /**
  * This type represents a Service configuration.
  *
  */
 typedef otServiceConfig ServiceConfig;
-#endif
 
 /**
  * This class implements Network Data processing.
@@ -216,7 +214,6 @@ public:
      */
     otError GetNextExternalRoute(Iterator &aIterator, uint16_t aRloc16, ExternalRouteConfig &aConfig);
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     /**
      * This method provides the next service in the Thread Network Data.
      *
@@ -254,7 +251,6 @@ public:
      *
      */
     otError GetNextServiceId(Iterator &aIterator, uint16_t aRloc16, uint8_t &aServiceId);
-#endif
 
     /**
      * This method indicates whether or not the Thread Network Data contains all of the on mesh prefix information
@@ -282,7 +278,6 @@ public:
      */
     bool ContainsExternalRoutes(NetworkData &aCompare, uint16_t aRloc16);
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     /**
      * This method indicates whether or not the Thread Network Data contains all of the service information
      * in @p aCompare associated with @p aRloc16.
@@ -308,7 +303,6 @@ public:
      *
      */
     bool ContainsService(uint8_t aServiceId, uint16_t aRloc16);
-#endif
 
     /**
      * This method cancels the data resubmit delay timer.
@@ -393,7 +387,6 @@ protected:
      */
     PrefixTlv *FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, uint8_t *aTlvs, uint8_t aTlvsLength);
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     /**
      * This method returns a pointer to a matching Service TLV.
      *
@@ -423,7 +416,6 @@ protected:
                             uint8_t        aServiceDataLength,
                             uint8_t *      aTlvs,
                             uint8_t        aTlvsLength);
-#endif
 
     /**
      * This method inserts bytes into the Network Data.
@@ -464,7 +456,6 @@ protected:
      */
     void RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, PrefixTlv &aPrefix);
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     /**
      * This method strips non-stable Sub-TLVs from a Service TLV.
      *
@@ -475,7 +466,6 @@ protected:
      *
      */
     void RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, ServiceTlv &aService);
-#endif
 
     /**
      * This method computes the number of IPv6 Prefix bits that match.

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -431,10 +431,8 @@ otError Leader::RlocLookup(uint16_t  aRloc16,
     HasRouteTlv *      hasRoute;
     BorderRouterEntry *borderRouterEntry;
     HasRouteEntry *    hasRouteEntry;
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    ServiceTlv *service;
-    ServerTlv * server;
-#endif
+    ServiceTlv *       service;
+    ServerTlv *        server;
 
     while (cur < end)
     {
@@ -520,8 +518,6 @@ otError Leader::RlocLookup(uint16_t  aRloc16,
         }
         break;
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-
         case NetworkDataTlv::kTypeService:
         {
             service = static_cast<ServiceTlv *>(cur);
@@ -573,8 +569,6 @@ otError Leader::RlocLookup(uint16_t  aRloc16,
             break;
         }
 
-#endif
-
         default:
             break;
         }
@@ -591,9 +585,7 @@ bool Leader::IsStableUpdated(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvs
     bool            rval = false;
     NetworkDataTlv *cur  = reinterpret_cast<NetworkDataTlv *>(aTlvs);
     NetworkDataTlv *end  = reinterpret_cast<NetworkDataTlv *>(aTlvs + aTlvsLength);
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    ServiceTlv *service;
-#endif
+    ServiceTlv *    service;
 
     while (cur < end)
     {
@@ -643,8 +635,6 @@ bool Leader::IsStableUpdated(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvs
 
             break;
         }
-
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
         case NetworkDataTlv::kTypeService:
             service = static_cast<ServiceTlv *>(cur);
@@ -715,7 +705,6 @@ bool Leader::IsStableUpdated(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvs
             }
 
             break;
-#endif
 
         default:
             break;
@@ -785,11 +774,6 @@ exit:
 
 otError Leader::AddNetworkData(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aOldTlvs, uint8_t aOldTlvsLength)
 {
-#if !OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    OT_UNUSED_VARIABLE(aOldTlvs);
-    OT_UNUSED_VARIABLE(aOldTlvsLength);
-#endif
-
     otError         error = OT_ERROR_NONE;
     NetworkDataTlv *cur   = reinterpret_cast<NetworkDataTlv *>(aTlvs);
     NetworkDataTlv *end   = reinterpret_cast<NetworkDataTlv *>(aTlvs + aTlvsLength);
@@ -805,13 +789,10 @@ otError Leader::AddNetworkData(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aOl
             otDumpDebgNetData("add prefix done", mTlvs, mLength);
             break;
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-
         case NetworkDataTlv::kTypeService:
             SuccessOrExit(error = AddService(*static_cast<ServiceTlv *>(cur), aOldTlvs, aOldTlvsLength));
             otDumpDebgNetData("add service done", mTlvs, mLength);
             break;
-#endif
 
         default:
             break;
@@ -861,7 +842,6 @@ exit:
     return error;
 }
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 otError Leader::AddService(ServiceTlv &aService, uint8_t *aOldTlvs, uint8_t aOldTlvsLength)
 {
     otError         error = OT_ERROR_NONE;
@@ -892,7 +872,6 @@ otError Leader::AddService(ServiceTlv &aService, uint8_t *aOldTlvs, uint8_t aOld
 exit:
     return error;
 }
-#endif
 
 otError Leader::AddHasRoute(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute)
 {
@@ -956,7 +935,6 @@ exit:
     return error;
 }
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 otError Leader::AddServer(ServiceTlv &aService, ServerTlv &aServer, uint8_t *aOldTlvs, uint8_t aOldTlvsLength)
 {
     otError     error               = OT_ERROR_NONE;
@@ -1070,7 +1048,6 @@ ServiceTlv *Leader::FindServiceById(uint8_t aServiceId)
 exit:
     return compare;
 }
-#endif
 
 otError Leader::AddBorderRouter(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter)
 {
@@ -1227,9 +1204,7 @@ void Leader::RemoveRloc(uint16_t aRloc16, MatchMode aMatchMode)
     NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
     NetworkDataTlv *end;
     PrefixTlv *     prefix;
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    ServiceTlv *service;
-#endif
+    ServiceTlv *    service;
 
     while (1)
     {
@@ -1257,8 +1232,6 @@ void Leader::RemoveRloc(uint16_t aRloc16, MatchMode aMatchMode)
             break;
         }
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-
         case NetworkDataTlv::kTypeService:
         {
             service = static_cast<ServiceTlv *>(cur);
@@ -1274,8 +1247,6 @@ void Leader::RemoveRloc(uint16_t aRloc16, MatchMode aMatchMode)
 
             break;
         }
-
-#endif
 
         default:
             break;
@@ -1352,7 +1323,6 @@ void Leader::RemoveRloc(PrefixTlv &aPrefix, uint16_t aRloc16, MatchMode aMatchMo
     }
 }
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 void Leader::RemoveRloc(ServiceTlv &aService, uint16_t aRloc16, MatchMode aMatchMode)
 {
     NetworkDataTlv *cur = aService.GetSubTlvs();
@@ -1391,7 +1361,6 @@ void Leader::RemoveRloc(ServiceTlv &aService, uint16_t aRloc16, MatchMode aMatch
         cur = cur->GetNext();
     }
 }
-#endif
 
 void Leader::RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint16_t aRloc16, MatchMode aMatchMode)
 {

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -159,7 +159,6 @@ public:
      */
     void UpdateContextsAfterReset(void);
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     /**
      * This method scans network data for given service ID and returns pointer to the respective TLV, if present.
      *
@@ -168,7 +167,6 @@ public:
      *
      */
     ServiceTlv *FindServiceById(uint8_t aServiceId);
-#endif
 
 private:
     static void HandleServerData(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
@@ -183,10 +181,8 @@ private:
     otError AddBorderRouter(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter);
     otError AddNetworkData(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aOldTlvs, uint8_t aOldTlvsLength);
     otError AddPrefix(PrefixTlv &aPrefix);
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     otError AddServer(ServiceTlv &aService, ServerTlv &aServer, uint8_t *aOldTlvs, uint8_t aOldTlvsLength);
     otError AddService(ServiceTlv &aService, uint8_t *aOldTlvs, uint8_t aOldTlvsLength);
-#endif
 
     int  AllocateContext(void);
     void FreeContext(uint8_t aContextId);
@@ -200,9 +196,7 @@ private:
 
     void RemoveRloc(uint16_t aRloc16, MatchMode aMatchMode);
     void RemoveRloc(PrefixTlv &aPrefix, uint16_t aRloc16, MatchMode aMatchMode);
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     void RemoveRloc(ServiceTlv &aService, uint16_t aRloc16, MatchMode aMatchMode);
-#endif
     void RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint16_t aRloc16, MatchMode aMatchMode);
     void RemoveRloc(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter, uint16_t aRloc16, MatchMode aMatchMode);
 

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -41,10 +41,10 @@
 #include "mac/mac_types.hpp"
 #include "thread/thread_netif.hpp"
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-
 namespace ot {
 namespace NetworkData {
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
 Local::Local(Instance &aInstance)
     : NetworkData(aInstance, kTypeLocal)
@@ -52,6 +52,7 @@ Local::Local(Instance &aInstance)
 {
 }
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 otError Local::AddOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, int8_t aPrf, uint8_t aFlags, bool aStable)
 {
     otError          error             = OT_ERROR_NONE;
@@ -175,6 +176,53 @@ exit:
     return error;
 }
 
+void Local::UpdateRloc(PrefixTlv &aPrefix)
+{
+    for (NetworkDataTlv *cur = aPrefix.GetSubTlvs(); cur < aPrefix.GetNext(); cur = cur->GetNext())
+    {
+        switch (cur->GetType())
+        {
+        case NetworkDataTlv::kTypeHasRoute:
+            UpdateRloc(*static_cast<HasRouteTlv *>(cur));
+            break;
+
+        case NetworkDataTlv::kTypeBorderRouter:
+            UpdateRloc(*static_cast<BorderRouterTlv *>(cur));
+            break;
+
+        default:
+            assert(false);
+            break;
+        }
+    }
+}
+
+void Local::UpdateRloc(HasRouteTlv &aHasRoute)
+{
+    HasRouteEntry *entry = aHasRoute.GetEntry(0);
+    entry->SetRloc(Get<Mle::MleRouter>().GetRloc16());
+}
+
+void Local::UpdateRloc(BorderRouterTlv &aBorderRouter)
+{
+    BorderRouterEntry *entry = aBorderRouter.GetEntry(0);
+    entry->SetRloc(Get<Mle::MleRouter>().GetRloc16());
+}
+
+bool Local::IsOnMeshPrefixConsistent(void)
+{
+    return (Get<Leader>().ContainsOnMeshPrefixes(*this, Get<Mle::MleRouter>().GetRloc16()) &&
+            ContainsOnMeshPrefixes(Get<Leader>(), Get<Mle::MleRouter>().GetRloc16()));
+}
+
+bool Local::IsExternalRouteConsistent(void)
+{
+    return (Get<Leader>().ContainsExternalRoutes(*this, Get<Mle::MleRouter>().GetRloc16()) &&
+            ContainsExternalRoutes(Get<Leader>(), Get<Mle::MleRouter>().GetRloc16()));
+}
+
+#endif
+
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 otError Local::AddService(uint32_t       aEnterpriseNumber,
                           const uint8_t *aServiceData,
@@ -240,69 +288,7 @@ exit:
     otDumpDebgNetData("remove service done", mTlvs, mLength);
     return error;
 }
-#endif
 
-void Local::UpdateRloc(void)
-{
-    for (NetworkDataTlv *cur                                            = reinterpret_cast<NetworkDataTlv *>(mTlvs);
-         cur < reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength); cur = cur->GetNext())
-    {
-        switch (cur->GetType())
-        {
-        case NetworkDataTlv::kTypePrefix:
-            UpdateRloc(*static_cast<PrefixTlv *>(cur));
-            break;
-
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-
-        case NetworkDataTlv::kTypeService:
-            UpdateRloc(*static_cast<ServiceTlv *>(cur));
-            break;
-#endif
-
-        default:
-            assert(false);
-            break;
-        }
-    }
-
-    ClearResubmitDelayTimer();
-}
-
-void Local::UpdateRloc(PrefixTlv &aPrefix)
-{
-    for (NetworkDataTlv *cur = aPrefix.GetSubTlvs(); cur < aPrefix.GetNext(); cur = cur->GetNext())
-    {
-        switch (cur->GetType())
-        {
-        case NetworkDataTlv::kTypeHasRoute:
-            UpdateRloc(*static_cast<HasRouteTlv *>(cur));
-            break;
-
-        case NetworkDataTlv::kTypeBorderRouter:
-            UpdateRloc(*static_cast<BorderRouterTlv *>(cur));
-            break;
-
-        default:
-            assert(false);
-            break;
-        }
-    }
-}
-
-void Local::UpdateRloc(HasRouteTlv &aHasRoute)
-{
-    HasRouteEntry *entry = aHasRoute.GetEntry(0);
-    entry->SetRloc(Get<Mle::MleRouter>().GetRloc16());
-}
-
-void Local::UpdateRloc(BorderRouterTlv &aBorderRouter)
-{
-    BorderRouterEntry *entry = aBorderRouter.GetEntry(0);
-    entry->SetRloc(Get<Mle::MleRouter>().GetRloc16());
-}
-
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 void Local::UpdateRloc(ServiceTlv &aService)
 {
     for (NetworkDataTlv *cur = aService.GetSubTlvs(); cur < aService.GetNext(); cur = cur->GetNext())
@@ -324,27 +310,43 @@ void Local::UpdateRloc(ServerTlv &aServer)
 {
     aServer.SetServer16(Get<Mle::MleRouter>().GetRloc16());
 }
-#endif
 
-bool Local::IsOnMeshPrefixConsistent(void)
-{
-    return (Get<Leader>().ContainsOnMeshPrefixes(*this, Get<Mle::MleRouter>().GetRloc16()) &&
-            ContainsOnMeshPrefixes(Get<Leader>(), Get<Mle::MleRouter>().GetRloc16()));
-}
-
-bool Local::IsExternalRouteConsistent(void)
-{
-    return (Get<Leader>().ContainsExternalRoutes(*this, Get<Mle::MleRouter>().GetRloc16()) &&
-            ContainsExternalRoutes(Get<Leader>(), Get<Mle::MleRouter>().GetRloc16()));
-}
-
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 bool Local::IsServiceConsistent(void)
 {
     return (Get<Leader>().ContainsServices(*this, Get<Mle::MleRouter>().GetRloc16()) &&
             ContainsServices(Get<Leader>(), Get<Mle::MleRouter>().GetRloc16()));
 }
+
 #endif
+
+void Local::UpdateRloc(void)
+{
+    for (NetworkDataTlv *cur                                            = reinterpret_cast<NetworkDataTlv *>(mTlvs);
+         cur < reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength); cur = cur->GetNext())
+    {
+        switch (cur->GetType())
+        {
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
+        case NetworkDataTlv::kTypePrefix:
+            UpdateRloc(*static_cast<PrefixTlv *>(cur));
+            break;
+#endif
+
+#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+
+        case NetworkDataTlv::kTypeService:
+            UpdateRloc(*static_cast<ServiceTlv *>(cur));
+            break;
+#endif
+
+        default:
+            assert(false);
+            break;
+        }
+    }
+
+    ClearResubmitDelayTimer();
+}
 
 otError Local::SendServerDataNotification(void)
 {
@@ -365,12 +367,15 @@ otError Local::SendServerDataNotification(void)
 
     UpdateRloc();
 
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    VerifyOrExit(!IsOnMeshPrefixConsistent() || !IsExternalRouteConsistent() || !IsServiceConsistent(),
-                 ClearResubmitDelayTimer());
-#else
-    VerifyOrExit(!IsOnMeshPrefixConsistent() || !IsExternalRouteConsistent(), ClearResubmitDelayTimer());
+    VerifyOrExit(
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
+        !IsOnMeshPrefixConsistent() || !IsExternalRouteConsistent()
 #endif
+#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+            || !IsServiceConsistent()
+#endif
+            ,
+        ClearResubmitDelayTimer());
 
     if (mOldRloc == rloc)
     {
@@ -384,7 +389,7 @@ exit:
     return error;
 }
 
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+
 } // namespace NetworkData
 } // namespace ot
-
-#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -221,7 +221,7 @@ bool Local::IsExternalRouteConsistent(void)
             ContainsExternalRoutes(Get<Leader>(), Get<Mle::MleRouter>().GetRloc16()));
 }
 
-#endif
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 otError Local::AddService(uint32_t       aEnterpriseNumber,
@@ -317,7 +317,7 @@ bool Local::IsServiceConsistent(void)
             ContainsServices(Get<Leader>(), Get<Mle::MleRouter>().GetRloc16()));
 }
 
-#endif
+#endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
 void Local::UpdateRloc(void)
 {

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -41,10 +41,10 @@
 #include "mac/mac_types.hpp"
 #include "thread/thread_netif.hpp"
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+
 namespace ot {
 namespace NetworkData {
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
 Local::Local(Instance &aInstance)
     : NetworkData(aInstance, kTypeLocal)
@@ -389,7 +389,7 @@ exit:
     return error;
 }
 
-#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-
 } // namespace NetworkData
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -38,6 +38,8 @@
 
 #include "thread/network_data.hpp"
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+
 namespace ot {
 
 /**
@@ -51,7 +53,6 @@ namespace ot {
 
 namespace NetworkData {
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 /**
  * This class implements the Thread Network Data contributed by the local device.
  *
@@ -186,7 +187,6 @@ private:
 
     uint16_t mOldRloc;
 };
-#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
 } // namespace NetworkData
 
@@ -195,5 +195,7 @@ private:
  */
 
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
 #endif // NETWORK_DATA_LOCAL_HPP_

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -51,6 +51,7 @@ namespace ot {
 
 namespace NetworkData {
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 /**
  * This class implements the Thread Network Data contributed by the local device.
  *
@@ -66,6 +67,7 @@ public:
      */
     explicit Local(Instance &aInstance);
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
     /**
      * This method adds a Border Router entry to the Thread Network Data.
      *
@@ -119,6 +121,7 @@ public:
      *
      */
     otError RemoveHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLength);
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     /**
@@ -167,22 +170,23 @@ public:
 
 private:
     void UpdateRloc(void);
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
     void UpdateRloc(PrefixTlv &aPrefix);
     void UpdateRloc(HasRouteTlv &aHasRoute);
     void UpdateRloc(BorderRouterTlv &aBorderRouter);
+    bool IsOnMeshPrefixConsistent(void);
+    bool IsExternalRouteConsistent(void);
+#endif
+
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     void UpdateRloc(ServiceTlv &aService);
     void UpdateRloc(ServerTlv &aServer);
-#endif
-
-    bool IsOnMeshPrefixConsistent(void);
-    bool IsExternalRouteConsistent(void);
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     bool IsServiceConsistent(void);
 #endif
 
     uint16_t mOldRloc;
 };
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
 } // namespace NetworkData
 

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -543,10 +543,10 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
     case SPINEL_PROP_SERVER_SERVICES:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_SERVER_SERVICES>;
         break;
+#endif
     case SPINEL_PROP_SERVER_LEADER_SERVICES:
         handler = &NcpBase::HandlePropertyGet<SPINEL_PROP_SERVER_LEADER_SERVICES>;
         break;
-#endif
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
         // --------------------------------------------------------------------------

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -950,6 +950,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_SERVER_SERVICES>(void
 exit:
     return error;
 }
+#endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_SERVER_LEADER_SERVICES>(void)
 {
@@ -957,7 +958,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_SERVER_LEADER_SERVICE
     otNetworkDataIterator iterator = OT_NETWORK_DATA_ITERATOR_INIT;
     otServiceConfig       cfg;
 
-    while (otServerGetNextLeaderService(mInstance, &iterator, &cfg) == OT_ERROR_NONE)
+    while (otNetDataGetNextService(mInstance, &iterator, &cfg) == OT_ERROR_NONE)
     {
         SuccessOrExit(error = mEncoder.OpenStruct());
 
@@ -974,8 +975,6 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_SERVER_LEADER_SERVICE
 exit:
     return error;
 }
-
-#endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_DISCOVERY_SCAN_JOINER_FLAG>(void)
 {

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -3481,8 +3481,6 @@ typedef enum
      *
      * This property provides all services registered on the leader
      *
-     * Required capability: SPINEL_CAP_THREAD_SERVICE
-     *
      * Array of structures containing:
      *
      *  `C`: Service ID


### PR DESCRIPTION
The thought behind this commit is that Leader should be able to
process service registration by default, like prefix registration.

This commit:
- limit SERVICE to wrap code relative to service provider.
- support service traffic forwarding when SERVICE is disabled (as
  a following up update after #4219).
- other minor updates.