### PR TITLE
[ip6] select RLOC source if destination is RLOC

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1309,15 +1309,16 @@ const NetifUnicastAddress *Ip6::SelectSourceAddress(MessageInfo &aMessageInfo)
         uint8_t overrideScope;
         uint8_t candidatePrefixMatched;
 
-        candidateAddr          = &addr->GetAddress();
-        candidatePrefixMatched = destination->PrefixMatch(*candidateAddr);
-        overrideScope          = (candidatePrefixMatched >= addr->mPrefixLength) ? addr->GetScope() : destinationScope;
+        candidateAddr = &addr->GetAddress();
 
         if (candidateAddr->IsAnycastRoutingLocator())
         {
             // Don't use anycast address as source address.
             continue;
         }
+
+        candidatePrefixMatched = destination->PrefixMatch(*candidateAddr);
+        overrideScope          = (candidatePrefixMatched >= addr->mPrefixLength) ? addr->GetScope() : destinationScope;
 
         if (rvalAddr == NULL)
         {
@@ -1358,8 +1359,9 @@ const NetifUnicastAddress *Ip6::SelectSourceAddress(MessageInfo &aMessageInfo)
         }
         else if ((rvalAddr->GetScope() == Address::kRealmLocalScope) && (addr->GetScope() == Address::kRealmLocalScope))
         {
-            // Additional rule: Prefer EID
-            if (rvalAddr->GetAddress().IsRoutingLocator())
+            // Additional rule: Prefer EID for non RLOC destination
+            //                  (stick to RLOC source selection for RLOC destination)
+            if (rvalAddr->GetAddress().IsRoutingLocator() && !destination->IsRoutingLocator())
             {
                 rvalAddr          = addr;
                 rvalPrefixMatched = candidatePrefixMatched;


### PR DESCRIPTION
#3284 was introduced to prefer MLEID as realm-local scope source to resolve issue #3268.
However when destination is RLOC,  it would likely to be the Thread Management traffic, RLOC source should be preferred.