### PR TITLE
[tests] multiple enhancements/clean-ups

### DIFF
--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -86,7 +86,7 @@
  * This macro checks for the specified status, which is expected to commonly be successful, and branches to the local
  * label 'exit' if the status is unsuccessful.
  *
- *  @param[in]  aStatus     A scalar status to be evaluated against zero (0).
+ * @param[in]  aStatus     A scalar status to be evaluated against zero (0).
  *
  */
 #define SuccessOrExit(aStatus) \
@@ -102,8 +102,8 @@
  * This macro checks for the specified condition, which is expected to commonly be true, and both executes @a ... and
  * branches to the local label 'exit' if the condition is false.
  *
- *  @param[in]  aCondition  A Boolean expression to be evaluated.
- *  @param[in]  ...         An expression or block to execute when the assertion fails.
+ * @param[in]  aCondition  A Boolean expression to be evaluated.
+ * @param[in]  ...         An expression or block to execute when the assertion fails.
  *
  */
 #define VerifyOrExit(aCondition, ...) \

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -160,61 +160,63 @@ TESTS_ENVIRONMENT                                                   = \
     top_srcdir='$(top_srcdir)'                                        \
     $(NULL)
 
+COMMON_SOURCES               = test_platform.cpp test_util.cpp
+
 # Source, compiler, and linker options for test programs.
 
 test_aes_LDADD               = $(COMMON_LDADD)
-test_aes_SOURCES             = test_platform.cpp test_aes.cpp
+test_aes_SOURCES             = $(COMMON_SOURCES) test_aes.cpp
 
 test_child_LDADD             = $(COMMON_LDADD)
-test_child_SOURCES           = test_platform.cpp test_child.cpp
+test_child_SOURCES           = $(COMMON_SOURCES) test_child.cpp
 
 test_child_table_LDADD       = $(COMMON_LDADD)
-test_child_table_SOURCES     = test_platform.cpp test_child_table.cpp
+test_child_table_SOURCES     = $(COMMON_SOURCES) test_child_table.cpp
 
 test_hdlc_LDADD              = $(COMMON_LDADD)
-test_hdlc_SOURCES            = test_platform.cpp test_hdlc.cpp
+test_hdlc_SOURCES            = $(COMMON_SOURCES) test_hdlc.cpp
 
 test_heap_LDADD              = $(COMMON_LDADD)
-test_heap_SOURCES            = test_platform.cpp test_heap.cpp
+test_heap_SOURCES            = $(COMMON_SOURCES) test_heap.cpp
 
 test_hmac_sha256_LDADD       = $(COMMON_LDADD)
-test_hmac_sha256_SOURCES     = test_platform.cpp test_hmac_sha256.cpp
+test_hmac_sha256_SOURCES     = $(COMMON_SOURCES) test_hmac_sha256.cpp
 
 test_ip6_address_LDADD       = $(COMMON_LDADD)
-test_ip6_address_SOURCES     = test_platform.cpp test_ip6_address.cpp
+test_ip6_address_SOURCES     = $(COMMON_SOURCES) test_ip6_address.cpp
 
 test_link_quality_LDADD      = $(COMMON_LDADD)
-test_link_quality_SOURCES    = test_platform.cpp test_link_quality.cpp
+test_link_quality_SOURCES    = $(COMMON_SOURCES) test_link_quality.cpp
 
 test_linked_list_LDADD       = $(COMMON_LDADD)
-test_linked_list_SOURCES     = test_platform.cpp test_linked_list.cpp
+test_linked_list_SOURCES     = $(COMMON_SOURCES) test_linked_list.cpp
 
 test_lowpan_LDADD            = $(COMMON_LDADD)
-test_lowpan_SOURCES          = test_platform.cpp test_lowpan.cpp test_util.cpp
+test_lowpan_SOURCES          = $(COMMON_SOURCES) test_lowpan.cpp
 
 test_mac_frame_LDADD         = $(COMMON_LDADD)
-test_mac_frame_SOURCES       = test_platform.cpp test_mac_frame.cpp
+test_mac_frame_SOURCES       = $(COMMON_SOURCES) test_mac_frame.cpp
 
 test_message_LDADD           = $(COMMON_LDADD)
-test_message_SOURCES         = test_platform.cpp test_message.cpp
+test_message_SOURCES         = $(COMMON_SOURCES) test_message.cpp
 
 test_message_queue_LDADD     = $(COMMON_LDADD)
-test_message_queue_SOURCES   = test_platform.cpp test_message_queue.cpp
+test_message_queue_SOURCES   = $(COMMON_SOURCES) test_message_queue.cpp
 
 test_ncp_buffer_LDADD        = $(COMMON_LDADD)
-test_ncp_buffer_SOURCES      = test_platform.cpp test_ncp_buffer.cpp
+test_ncp_buffer_SOURCES      = $(COMMON_SOURCES) test_ncp_buffer.cpp
 
 test_network_data_LDADD      = $(COMMON_LDADD)
-test_network_data_SOURCES    = test_platform.cpp test_network_data.cpp
+test_network_data_SOURCES    = $(COMMON_SOURCES) test_network_data.cpp
 
 test_priority_queue_LDADD    = $(COMMON_LDADD)
-test_priority_queue_SOURCES  = test_platform.cpp test_priority_queue.cpp
+test_priority_queue_SOURCES  = $(COMMON_SOURCES) test_priority_queue.cpp
 
 test_pskc_LDADD              = $(COMMON_LDADD)
-test_pskc_SOURCES            = test_platform.cpp test_pskc.cpp
+test_pskc_SOURCES            = $(COMMON_SOURCES) test_pskc.cpp
 
 test_string_LDADD            = $(COMMON_LDADD)
-test_string_SOURCES          = test_platform.cpp test_string.cpp
+test_string_SOURCES          = $(COMMON_SOURCES) test_string.cpp
 
 test_strlcat_LDADD           = $(COMMON_LDADD)
 test_strlcat_SOURCES         = test_strlcat.c
@@ -226,13 +228,13 @@ test_strnlen_LDADD           = $(COMMON_LDADD)
 test_strnlen_SOURCES         = test_strnlen.c
 
 test_spinel_decoder_LDADD    = $(COMMON_LDADD)
-test_spinel_decoder_SOURCES  = test_platform.cpp test_spinel_decoder.cpp
+test_spinel_decoder_SOURCES  = $(COMMON_SOURCES) test_spinel_decoder.cpp
 
 test_spinel_encoder_LDADD    = $(COMMON_LDADD)
-test_spinel_encoder_SOURCES  = test_platform.cpp test_spinel_encoder.cpp
+test_spinel_encoder_SOURCES  = $(COMMON_SOURCES) test_spinel_encoder.cpp
 
 test_timer_LDADD             = $(COMMON_LDADD)
-test_timer_SOURCES           = test_platform.cpp test_timer.cpp
+test_timer_SOURCES           = $(COMMON_SOURCES) test_timer.cpp
 
 test_toolchain_LDADD         = $(NULL)
 test_toolchain_SOURCES       = test_toolchain.cpp test_toolchain_c.c

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -51,7 +51,6 @@ if OPENTHREAD_BUILD_TESTS
 
 AM_CPPFLAGS                                                         = \
     -DOPENTHREAD_FTD=1                                                \
-    -DOPENTHREAD_CONFIG_LOG_PLATFORM=0                                \
     -I$(top_srcdir)/include                                           \
     -I$(top_srcdir)/src                                               \
     -I$(top_srcdir)/src/core                                          \

--- a/tests/unit/test_address_sanitizer.cpp
+++ b/tests/unit/test_address_sanitizer.cpp
@@ -30,7 +30,6 @@
 
 #include "test_util.h"
 
-#ifdef ENABLE_TEST_MAIN
 int main(int argc, char *argv[])
 {
     (void)argv;
@@ -46,4 +45,3 @@ int main(int argc, char *argv[])
 
     return 0;
 }
-#endif

--- a/tests/unit/test_aes.cpp
+++ b/tests/unit/test_aes.cpp
@@ -134,7 +134,6 @@ void TestMacCommandFrame()
     VerifyOrQuit(memcmp(test, decrypted, sizeof(decrypted)) == 0, "TestMacCommandFrame decrypt failed\n");
 }
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     TestMacBeaconFrame();
@@ -142,4 +141,3 @@ int main(void)
     printf("All tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_child.cpp
+++ b/tests/unit/test_child.cpp
@@ -54,7 +54,7 @@ void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, co
 
     for (uint8_t index = 0; index < aAddressListLength; index++)
     {
-        VerifyOrQuit(aChild.HasIp6Address(*sInstance, aAddressList[index]), "HasIp6Address() failed\n");
+        VerifyOrQuit(aChild.HasIp6Address(*sInstance, aAddressList[index]), "HasIp6Address() failed");
     }
 
     memset(addressObserved, 0, sizeof(addressObserved));
@@ -81,18 +81,18 @@ void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, co
             }
         }
 
-        VerifyOrQuit(addressIsInList, "Child::GetNextIp6Address() returned an address not in the expected list\n");
+        VerifyOrQuit(addressIsInList, "Child::GetNextIp6Address() returned an address not in the expected list");
     }
 
     for (uint8_t index = 0; index < aAddressListLength; index++)
     {
-        VerifyOrQuit(addressObserved[index], "Child::GetNextIp6Address() missed an entry from the expected list\n");
+        VerifyOrQuit(addressObserved[index], "Child::GetNextIp6Address() missed an entry from the expected list");
 
         if (sInstance->Get<Mle::MleRouter>().IsMeshLocalAddress(aAddressList[index]))
         {
             SuccessOrQuit(aChild.GetMeshLocalIp6Address(*sInstance, address),
                           "Child::GetMeshLocalIp6Address() failed\n");
-            VerifyOrQuit(address == aAddressList[index], "GetMeshLocalIp6Address() did not return expected address\n");
+            VerifyOrQuit(address == aAddressList[index], "GetMeshLocalIp6Address() did not return expected address");
             hasMeshLocal = true;
         }
     }
@@ -100,7 +100,7 @@ void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, co
     if (!hasMeshLocal)
     {
         VerifyOrQuit(aChild.GetMeshLocalIp6Address(*sInstance, address) == OT_ERROR_NOT_FOUND,
-                     "Child::GetMeshLocalIp6Address() returned an address not in the exptect list\n");
+                     "Child::GetMeshLocalIp6Address() returned an address not in the expected list");
     }
 }
 

--- a/tests/unit/test_child.cpp
+++ b/tests/unit/test_child.cpp
@@ -258,11 +258,9 @@ void TestChildIp6Address(void)
 
 } // namespace ot
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     ot::TestChildIp6Address();
     printf("\nAll tests passed.\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_child_table.cpp
+++ b/tests/unit/test_child_table.cpp
@@ -402,11 +402,9 @@ void TestChildTable(void)
 
 } // namespace ot
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     ot::TestChildTable();
     printf("\nAll tests passed.\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_hdlc.cpp
+++ b/tests/unit/test_hdlc.cpp
@@ -571,7 +571,6 @@ void TestFuzzEncoderDecoder(void)
 } // namespace Ncp
 } // namespace ot
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     ot::Ncp::TestHdlcFrameBuffer();
@@ -581,4 +580,3 @@ int main(void)
     printf("\nAll tests passed.\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_heap.cpp
+++ b/tests/unit/test_heap.cpp
@@ -172,11 +172,9 @@ void RunTimerTests(void)
     TestAllocateMultiple();
 }
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     RunTimerTests();
     printf("All tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_heap.cpp
+++ b/tests/unit/test_heap.cpp
@@ -61,7 +61,7 @@ void TestAllocateSingle(void)
 
     for (size_t size = 1; size <= heap.GetCapacity(); ++size)
     {
-        Log("%s allocating %zu bytes...", __func__, size);
+        printf("%s allocating %zu bytes...\n", __func__, size);
         void *p = heap.CAlloc(1, size);
         VerifyOrQuit(p != NULL && !heap.IsClean() && heap.GetFreeSize() + size <= totalSize, "allocating failed!");
         memset(p, 0xff, size);
@@ -97,7 +97,7 @@ void TestAllocateRandomly(size_t aSizeLimit, unsigned int aSeed)
     do
     {
         size_t size = sizeof(Node) + static_cast<size_t>(rand()) % aSizeLimit;
-        Log("TestAllocateRandomly allocating %zu bytes...", size);
+        printf("TestAllocateRandomly allocating %zu bytes...\n", size);
         last->mNext = static_cast<Node *>(heap.CAlloc(1, size));
 
         // No more memory for allocation.
@@ -126,7 +126,7 @@ void TestAllocateRandomly(size_t aSizeLimit, unsigned int aSeed)
             }
 
             Node *curr = prev->mNext;
-            Log("TestAllocateRandomly freeing %zu bytes...", curr->mSize);
+            printf("TestAllocateRandomly freeing %zu bytes...\n", curr->mSize);
             prev->mNext = curr->mNext;
             heap.Free(curr);
 
@@ -144,7 +144,7 @@ void TestAllocateRandomly(size_t aSizeLimit, unsigned int aSeed)
     while (last)
     {
         Node *next = last->mNext;
-        Log("TestAllocateRandomly freeing %zu bytes...", last->mSize);
+        printf("TestAllocateRandomly freeing %zu bytes...\n", last->mSize);
         heap.Free(last);
         last = next;
     }
@@ -161,7 +161,7 @@ void TestAllocateMultiple(void)
     for (unsigned int seed = 0; seed < 10; ++seed)
     {
         size_t sizeLimit = (1 << seed);
-        Log("TestAllocateRandomly(%zu, %u)...", sizeLimit, seed);
+        printf("TestAllocateRandomly(%zu, %u)...\n", sizeLimit, seed);
         TestAllocateRandomly(sizeLimit, seed);
     }
 }

--- a/tests/unit/test_heap.cpp
+++ b/tests/unit/test_heap.cpp
@@ -51,11 +51,11 @@ void TestAllocateSingle(void)
 
     {
         void *p = heap.CAlloc(1, 0);
-        VerifyOrQuit(p == NULL && totalSize == heap.GetFreeSize(), "TestAllocateSingle allocate 1 x 0 byte failed!\n");
+        VerifyOrQuit(p == NULL && totalSize == heap.GetFreeSize(), "TestAllocateSingle allocate 1 x 0 byte failed!");
         heap.Free(p);
 
         p = heap.CAlloc(0, 1);
-        VerifyOrQuit(p == NULL && totalSize == heap.GetFreeSize(), "TestAllocateSingle allocate 0 x 1 byte failed!\n");
+        VerifyOrQuit(p == NULL && totalSize == heap.GetFreeSize(), "TestAllocateSingle allocate 0 x 1 byte failed!");
         heap.Free(p);
     }
 
@@ -63,7 +63,7 @@ void TestAllocateSingle(void)
     {
         Log("%s allocating %zu bytes...", __func__, size);
         void *p = heap.CAlloc(1, size);
-        VerifyOrQuit(p != NULL && !heap.IsClean() && heap.GetFreeSize() + size <= totalSize, "allocating failed!\n");
+        VerifyOrQuit(p != NULL && !heap.IsClean() && heap.GetFreeSize() + size <= totalSize, "allocating failed!");
         memset(p, 0xff, size);
         heap.Free(p);
         VerifyOrQuit(heap.IsClean() && heap.GetFreeSize() == totalSize, "freeing failed!\n");
@@ -106,7 +106,7 @@ void TestAllocateRandomly(size_t aSizeLimit, unsigned int aSeed)
             break;
         }
 
-        VerifyOrQuit(last->mNext->mNext == NULL, "TestAllocateRandomly memory not initialized to zero!\n");
+        VerifyOrQuit(last->mNext->mNext == NULL, "TestAllocateRandomly memory not initialized to zero!");
         last        = last->mNext;
         last->mSize = size;
         ++nnodes;
@@ -150,7 +150,7 @@ void TestAllocateRandomly(size_t aSizeLimit, unsigned int aSeed)
     }
 
     VerifyOrQuit(heap.IsClean() && heap.GetFreeSize() == totalSize,
-                 "TestAllocateRandomly heap not clean after freeing all!\n");
+                 "TestAllocateRandomly heap not clean after freeing all!");
 }
 
 /**

--- a/tests/unit/test_hmac_sha256.cpp
+++ b/tests/unit/test_hmac_sha256.cpp
@@ -73,7 +73,7 @@ void TestHmacSha256(void)
             hmac.Update(reinterpret_cast<const uint8_t *>(tests[i].data), static_cast<uint16_t>(strlen(tests[i].data)));
             hmac.Finish(hash);
 
-            VerifyOrQuit(memcmp(hash, tests[i].hash, sizeof(tests[i].hash)) == 0, "HMAC-SHA-256 failed\n");
+            VerifyOrQuit(memcmp(hash, tests[i].hash, sizeof(tests[i].hash)) == 0, "HMAC-SHA-256 failed");
         }
     }
 

--- a/tests/unit/test_hmac_sha256.cpp
+++ b/tests/unit/test_hmac_sha256.cpp
@@ -80,11 +80,9 @@ void TestHmacSha256(void)
     testFreeInstance(instance);
 }
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     TestHmacSha256();
     printf("All tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_ip6_address.cpp
+++ b/tests/unit/test_ip6_address.cpp
@@ -44,12 +44,12 @@ static void checkAddressFromString(Ip6AddressStringTestVector *aTestVector)
 
     error = address.FromString(aTestVector->mString);
 
-    VerifyOrQuit(error == aTestVector->mError, "Ip6::Address::FromString returned unexpected error code\n");
+    VerifyOrQuit(error == aTestVector->mError, "Ip6::Address::FromString returned unexpected error code");
 
     if (error == OT_ERROR_NONE)
     {
         VerifyOrQuit(0 == memcmp(address.mFields.m8, aTestVector->mAddr, OT_IP6_ADDRESS_SIZE),
-                     "Ip6::Address::FromString parsing failed\n");
+                     "Ip6::Address::FromString parsing failed");
     }
 }
 

--- a/tests/unit/test_ip6_address.cpp
+++ b/tests/unit/test_ip6_address.cpp
@@ -204,11 +204,9 @@ void TestIp6AddressFromString(void)
     }
 }
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     TestIp6AddressFromString();
     printf("All tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -486,7 +486,6 @@ void TestSuccessRateTracker(void)
 
 } // namespace ot
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     ot::TestRssAveraging();
@@ -495,4 +494,3 @@ int main(void)
     printf("\nAll tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_linked_list.cpp
+++ b/tests/unit/test_linked_list.cpp
@@ -142,11 +142,9 @@ void TestLinkedList(void)
     VerifyLinkedListContent(list, NULL);
 }
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     TestLinkedList();
     printf("All tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -1841,7 +1841,6 @@ void TestLowpanIphc(void)
 
 } // namespace ot
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     TestLowpanIphc();
@@ -1849,4 +1848,3 @@ int main(void)
     printf("All tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -167,13 +167,8 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
     printf("LOWPAN_IPHC length ---------- %d\n", aVector.mIphcHeader.mLength);
     printf("IPv6 uncompressed offset ---- %d\n\n", aVector.mPayloadOffset);
 
-    printf("Expected IPv6 uncompressed packet: \n");
-    otTestPrintHex(ip6, ip6Length);
-    printf("\n");
-
-    printf("Expected LOWPAN_IPHC compressed frame: \n");
-    otTestPrintHex(iphc, iphcLength);
-    printf("\n");
+    DumpBuffer("Expected IPv6 uncompressed packet", ip6, ip6Length);
+    DumpBuffer("Expected LOWPAN_IPHC compressed frame", iphc, iphcLength);
 
     if (aCompress)
     {
@@ -194,9 +189,8 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
             // Append payload to the LOWPAN_IPHC.
             message->Read(message->GetOffset(), message->GetLength() - message->GetOffset(), result + compressBytes);
 
-            printf("Resulted LOWPAN_IPHC compressed frame: \n");
-            otTestPrintHex(result, compressBytes + message->GetLength() - message->GetOffset());
-            printf("\n");
+            DumpBuffer("Resulted LOWPAN_IPHC compressed frame", result,
+                       compressBytes + message->GetLength() - message->GetOffset());
 
             VerifyOrQuit(compressBytes == aVector.mIphcHeader.mLength, "6lo: Lowpan::Compress failed");
             VerifyOrQuit(message->GetOffset() == aVector.mPayloadOffset, "6lo: Lowpan::Compress failed");
@@ -223,9 +217,8 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
             memcpy(result + message->GetLength(), iphc + decompressedBytes,
                    iphcLength - static_cast<uint16_t>(decompressedBytes));
 
-            printf("Resulted IPv6 uncompressed packet: \n");
-            otTestPrintHex(result, message->GetLength() + iphcLength - decompressedBytes);
-            printf("\n");
+            DumpBuffer("Resulted IPv6 uncompressed packet", result,
+                       message->GetLength() + iphcLength - decompressedBytes);
 
             VerifyOrQuit(decompressedBytes == aVector.mIphcHeader.mLength, "6lo: Lowpan::Decompress failed");
             VerifyOrQuit(message->GetOffset() == aVector.mPayloadOffset, "6lo: Lowpan::Decompress failed");

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -99,7 +99,7 @@ void TestIphcVector::GetUncompressedStream(Message &aMessage)
                       "6lo: Message::Append failed");
     }
 
-    SuccessOrQuit(aMessage.Append(mPayload.mData, mPayload.mLength), "6lo: Message::Append failed5");
+    SuccessOrQuit(aMessage.Append(mPayload.mData, mPayload.mLength), "6lo: Message::Append failed");
 }
 
 /**

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -70,87 +70,87 @@ void TestMacAddress(void)
     // Mac::ExtAddress
 
     extAddr.GenerateRandom();
-    VerifyOrQuit(extAddr.IsLocal(), "Random Extended Address should have its Local bit set\n");
-    VerifyOrQuit(!extAddr.IsGroup(), "Random Extended Address should not have its Group bit set\n");
+    VerifyOrQuit(extAddr.IsLocal(), "Random Extended Address should have its Local bit set");
+    VerifyOrQuit(!extAddr.IsGroup(), "Random Extended Address should not have its Group bit set");
 
     extAddr.CopyTo(buffer);
-    VerifyOrQuit(memcmp(extAddr.m8, buffer, OT_EXT_ADDRESS_SIZE) == 0, "ExtAddress::CopyTo() failed\n");
+    VerifyOrQuit(memcmp(extAddr.m8, buffer, OT_EXT_ADDRESS_SIZE) == 0, "ExtAddress::CopyTo() failed");
 
     extAddr.CopyTo(buffer, Mac::ExtAddress::kReverseByteOrder);
-    VerifyOrQuit(CompareReversed(extAddr.m8, buffer, OT_EXT_ADDRESS_SIZE), "ExtAddress::CopyTo() failed\n");
+    VerifyOrQuit(CompareReversed(extAddr.m8, buffer, OT_EXT_ADDRESS_SIZE), "ExtAddress::CopyTo() failed");
 
     extAddr.Set(kExtAddr);
-    VerifyOrQuit(memcmp(extAddr.m8, kExtAddr, OT_EXT_ADDRESS_SIZE) == 0, "ExtAddress::Set() failed\n");
+    VerifyOrQuit(memcmp(extAddr.m8, kExtAddr, OT_EXT_ADDRESS_SIZE) == 0, "ExtAddress::Set() failed");
 
     extAddr.Set(kExtAddr, Mac::ExtAddress::kReverseByteOrder);
-    VerifyOrQuit(CompareReversed(extAddr.m8, kExtAddr, OT_EXT_ADDRESS_SIZE), "ExtAddress::Set() failed\n");
+    VerifyOrQuit(CompareReversed(extAddr.m8, kExtAddr, OT_EXT_ADDRESS_SIZE), "ExtAddress::Set() failed");
 
     extAddr.SetLocal(true);
-    VerifyOrQuit(extAddr.IsLocal(), "ExtAddress::SetLocal() failed\n");
+    VerifyOrQuit(extAddr.IsLocal(), "ExtAddress::SetLocal() failed");
     extAddr.SetLocal(false);
-    VerifyOrQuit(!extAddr.IsLocal(), "ExtAddress::SetLocal() failed\n");
+    VerifyOrQuit(!extAddr.IsLocal(), "ExtAddress::SetLocal() failed");
     extAddr.ToggleLocal();
-    VerifyOrQuit(extAddr.IsLocal(), "ExtAddress::SetLocal() failed\n");
+    VerifyOrQuit(extAddr.IsLocal(), "ExtAddress::SetLocal() failed");
     extAddr.ToggleLocal();
-    VerifyOrQuit(!extAddr.IsLocal(), "ExtAddress::SetLocal() failed\n");
+    VerifyOrQuit(!extAddr.IsLocal(), "ExtAddress::SetLocal() failed");
 
     extAddr.SetGroup(true);
-    VerifyOrQuit(extAddr.IsGroup(), "ExtAddress::SetGroup() failed\n");
+    VerifyOrQuit(extAddr.IsGroup(), "ExtAddress::SetGroup() failed");
     extAddr.SetGroup(false);
-    VerifyOrQuit(!extAddr.IsGroup(), "ExtAddress::SetGroup() failed\n");
+    VerifyOrQuit(!extAddr.IsGroup(), "ExtAddress::SetGroup() failed");
     extAddr.ToggleGroup();
-    VerifyOrQuit(extAddr.IsGroup(), "ExtAddress::SetGroup() failed\n");
+    VerifyOrQuit(extAddr.IsGroup(), "ExtAddress::SetGroup() failed");
     extAddr.ToggleGroup();
-    VerifyOrQuit(!extAddr.IsGroup(), "ExtAddress::SetGroup() failed\n");
+    VerifyOrQuit(!extAddr.IsGroup(), "ExtAddress::SetGroup() failed");
 
     // Mac::Address
 
-    VerifyOrQuit(addr.IsNone(), "Address constructor failed\n");
-    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeNone, "Address::GetType() failed\n");
+    VerifyOrQuit(addr.IsNone(), "Address constructor failed");
+    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeNone, "Address::GetType() failed");
 
     addr.SetShort(kShortAddr);
-    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeShort, "Address::GetType() failed\n");
-    VerifyOrQuit(addr.IsShort(), "Address::SetShort() failed\n");
-    VerifyOrQuit(!addr.IsExtended(), "Address::SetShort() failed\n");
-    VerifyOrQuit(addr.GetShort() == kShortAddr, "Address::GetShort() failed\n");
+    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeShort, "Address::GetType() failed");
+    VerifyOrQuit(addr.IsShort(), "Address::SetShort() failed");
+    VerifyOrQuit(!addr.IsExtended(), "Address::SetShort() failed");
+    VerifyOrQuit(addr.GetShort() == kShortAddr, "Address::GetShort() failed");
 
     addr.SetExtended(extAddr);
-    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeExtended, "Address::GetType() failed\n");
-    VerifyOrQuit(!addr.IsShort(), "Address::SetExtended() failed\n");
-    VerifyOrQuit(addr.IsExtended(), "Address::SetExtended() failed\n");
-    VerifyOrQuit(addr.GetExtended() == extAddr, "Address::GetExtended() failed\n");
+    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeExtended, "Address::GetType() failed");
+    VerifyOrQuit(!addr.IsShort(), "Address::SetExtended() failed");
+    VerifyOrQuit(addr.IsExtended(), "Address::SetExtended() failed");
+    VerifyOrQuit(addr.GetExtended() == extAddr, "Address::GetExtended() failed");
 
     addr.SetExtended(extAddr.m8, Mac::ExtAddress::kReverseByteOrder);
-    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeExtended, "Address::GetType() failed\n");
-    VerifyOrQuit(!addr.IsShort(), "Address::SetExtended() failed\n");
-    VerifyOrQuit(addr.IsExtended(), "Address::SetExtended() failed\n");
+    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeExtended, "Address::GetType() failed");
+    VerifyOrQuit(!addr.IsShort(), "Address::SetExtended() failed");
+    VerifyOrQuit(addr.IsExtended(), "Address::SetExtended() failed");
     VerifyOrQuit(CompareReversed(addr.GetExtended().m8, extAddr.m8, OT_EXT_ADDRESS_SIZE),
                  "Address::SetExtended() reverse byte order failed");
 
     addr.SetNone();
-    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeNone, "Address::GetType() failed\n");
-    VerifyOrQuit(addr.IsNone(), "Address:SetNone() failed\n");
-    VerifyOrQuit(!addr.IsShort(), "Address::SetNone() failed\n");
-    VerifyOrQuit(!addr.IsExtended(), "Address::SetNone() failed\n");
+    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeNone, "Address::GetType() failed");
+    VerifyOrQuit(addr.IsNone(), "Address:SetNone() failed");
+    VerifyOrQuit(!addr.IsShort(), "Address::SetNone() failed");
+    VerifyOrQuit(!addr.IsExtended(), "Address::SetNone() failed");
 
-    VerifyOrQuit(!addr.IsBroadcast(), "Address:IsBroadcast() failed\n");
-    VerifyOrQuit(!addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed\n");
+    VerifyOrQuit(!addr.IsBroadcast(), "Address:IsBroadcast() failed");
+    VerifyOrQuit(!addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed");
 
     addr.SetExtended(extAddr);
-    VerifyOrQuit(!addr.IsBroadcast(), "Address:IsBroadcast() failed\n");
-    VerifyOrQuit(!addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed\n");
+    VerifyOrQuit(!addr.IsBroadcast(), "Address:IsBroadcast() failed");
+    VerifyOrQuit(!addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed");
 
     addr.SetShort(kShortAddr);
-    VerifyOrQuit(!addr.IsBroadcast(), "Address:IsBroadcast() failed\n");
-    VerifyOrQuit(!addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed\n");
+    VerifyOrQuit(!addr.IsBroadcast(), "Address:IsBroadcast() failed");
+    VerifyOrQuit(!addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed");
 
     addr.SetShort(Mac::kShortAddrBroadcast);
-    VerifyOrQuit(addr.IsBroadcast(), "Address:IsBroadcast() failed\n");
-    VerifyOrQuit(!addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed\n");
+    VerifyOrQuit(addr.IsBroadcast(), "Address:IsBroadcast() failed");
+    VerifyOrQuit(!addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed");
 
     addr.SetShort(Mac::kShortAddrInvalid);
-    VerifyOrQuit(!addr.IsBroadcast(), "Address:IsBroadcast() failed\n");
-    VerifyOrQuit(addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed\n");
+    VerifyOrQuit(!addr.IsBroadcast(), "Address:IsBroadcast() failed");
+    VerifyOrQuit(addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed");
 
     testFreeInstance(instance);
 }
@@ -159,11 +159,11 @@ void CompareNetworkName(const Mac::NetworkName &aNetworkName, const char *aNameS
 {
     uint8_t len = static_cast<uint8_t>(strlen(aNameString));
 
-    VerifyOrQuit(strcmp(aNetworkName.GetAsCString(), aNameString) == 0, "NetworkName does not match expected value\n");
+    VerifyOrQuit(strcmp(aNetworkName.GetAsCString(), aNameString) == 0, "NetworkName does not match expected value");
 
-    VerifyOrQuit(aNetworkName.GetAsData().GetLength() == len, "NetworkName:GetAsData().GetLength() is incorrect\n");
+    VerifyOrQuit(aNetworkName.GetAsData().GetLength() == len, "NetworkName:GetAsData().GetLength() is incorrect");
     VerifyOrQuit(memcmp(aNetworkName.GetAsData().GetBuffer(), aNameString, len) == 0,
-                 "NetworkName:GetAsData().GetBuffer() is incorrect\n");
+                 "NetworkName:GetAsData().GetBuffer() is incorrect");
 }
 
 void TestMacNetworkName(void)
@@ -180,7 +180,7 @@ void TestMacNetworkName(void)
 
     CompareNetworkName(networkName, kEmptyName);
 
-    SuccessOrQuit(networkName.Set(Mac::NetworkName::Data(kName1, sizeof(kName1))), "NetworkName::Set() failed\n");
+    SuccessOrQuit(networkName.Set(Mac::NetworkName::Data(kName1, sizeof(kName1))), "NetworkName::Set() failed");
     CompareNetworkName(networkName, kName1);
 
     VerifyOrQuit(networkName.Set(Mac::NetworkName::Data(kName1, sizeof(kName1))) == OT_ERROR_ALREADY,
@@ -190,45 +190,45 @@ void TestMacNetworkName(void)
     VerifyOrQuit(networkName.Set(Mac::NetworkName::Data(kName1, sizeof(kName1) - 1)) == OT_ERROR_ALREADY,
                  "NetworkName::Set() accepted same name without returning OT_ERROR_ALREADY");
 
-    SuccessOrQuit(networkName.Set(Mac::NetworkName::Data(kName2, sizeof(kName2))), "NetworkName::Set() failed\n");
+    SuccessOrQuit(networkName.Set(Mac::NetworkName::Data(kName2, sizeof(kName2))), "NetworkName::Set() failed");
     CompareNetworkName(networkName, kName2);
 
-    SuccessOrQuit(networkName.Set(Mac::NetworkName::Data(kEmptyName, 0)), "NetworkName::Set() failed\n");
+    SuccessOrQuit(networkName.Set(Mac::NetworkName::Data(kEmptyName, 0)), "NetworkName::Set() failed");
     CompareNetworkName(networkName, kEmptyName);
 
-    SuccessOrQuit(networkName.Set(Mac::NetworkName::Data(kLongName, sizeof(kLongName))), "NetworkName::Set() failed\n");
+    SuccessOrQuit(networkName.Set(Mac::NetworkName::Data(kLongName, sizeof(kLongName))), "NetworkName::Set() failed");
     CompareNetworkName(networkName, kLongName);
 
     VerifyOrQuit(networkName.Set(Mac::NetworkName::Data(kLongName, sizeof(kLongName) - 1)) == OT_ERROR_ALREADY,
                  "NetworkName::Set() accepted same name without returning OT_ERROR_ALREADY");
 
-    SuccessOrQuit(networkName.Set(Mac::NetworkName::Data(NULL, 0)), "NetworkName::Set() failed\n");
+    SuccessOrQuit(networkName.Set(Mac::NetworkName::Data(NULL, 0)), "NetworkName::Set() failed");
     CompareNetworkName(networkName, kEmptyName);
 
-    SuccessOrQuit(networkName.Set(Mac::NetworkName::Data(kName1, sizeof(kName1))), "NetworkName::Set() failed\n");
+    SuccessOrQuit(networkName.Set(Mac::NetworkName::Data(kName1, sizeof(kName1))), "NetworkName::Set() failed");
 
     VerifyOrQuit(networkName.Set(Mac::NetworkName::Data(kTooLongName, sizeof(kTooLongName))) == OT_ERROR_INVALID_ARGS,
-                 "NetworkName::Set() accepted an invalid (too long) name\n");
+                 "NetworkName::Set() accepted an invalid (too long) name");
 
     CompareNetworkName(networkName, kName1);
 
     memset(buffer, 'a', sizeof(buffer));
     len = networkName.GetAsData().CopyTo(buffer, 1);
-    VerifyOrQuit(len == 1, "NetworkName::Data::CopyTo() failed\n");
-    VerifyOrQuit(buffer[0] == kName1[0], "NetworkName::Data::CopyTo() failed\n");
-    VerifyOrQuit(buffer[1] == 'a', "NetworkName::Data::CopyTo() failed\n");
+    VerifyOrQuit(len == 1, "NetworkName::Data::CopyTo() failed");
+    VerifyOrQuit(buffer[0] == kName1[0], "NetworkName::Data::CopyTo() failed");
+    VerifyOrQuit(buffer[1] == 'a', "NetworkName::Data::CopyTo() failed");
 
     memset(buffer, 'a', sizeof(buffer));
     len = networkName.GetAsData().CopyTo(buffer, sizeof(kName1) - 1);
-    VerifyOrQuit(len == sizeof(kName1) - 1, "NetworkName::Data::CopyTo() failed\n");
-    VerifyOrQuit(memcmp(buffer, kName1, sizeof(kName1) - 1) == 0, "NetworkName::Data::CopyTo() failed\n");
-    VerifyOrQuit(buffer[sizeof(kName1)] == 'a', "NetworkName::Data::CopyTo() failed\n");
+    VerifyOrQuit(len == sizeof(kName1) - 1, "NetworkName::Data::CopyTo() failed");
+    VerifyOrQuit(memcmp(buffer, kName1, sizeof(kName1) - 1) == 0, "NetworkName::Data::CopyTo() failed");
+    VerifyOrQuit(buffer[sizeof(kName1)] == 'a', "NetworkName::Data::CopyTo() failed");
 
     memset(buffer, 'a', sizeof(buffer));
     len = networkName.GetAsData().CopyTo(buffer, sizeof(buffer));
-    VerifyOrQuit(len == sizeof(kName1) - 1, "NetworkName::Data::CopyTo() failed\n");
-    VerifyOrQuit(memcmp(buffer, kName1, sizeof(kName1) - 1) == 0, "NetworkName::Data::CopyTo() failed\n");
-    VerifyOrQuit(buffer[sizeof(kName1)] == 0, "NetworkName::Data::CopyTo() failed\n");
+    VerifyOrQuit(len == sizeof(kName1) - 1, "NetworkName::Data::CopyTo() failed");
+    VerifyOrQuit(memcmp(buffer, kName1, sizeof(kName1) - 1) == 0, "NetworkName::Data::CopyTo() failed");
+    VerifyOrQuit(buffer[sizeof(kName1)] == 0, "NetworkName::Data::CopyTo() failed");
 }
 
 void TestMacHeader(void)
@@ -279,7 +279,7 @@ void TestMacHeader(void)
 
         frame.InitMacHeader(tests[i].fcf, tests[i].secCtl);
         printf("%d\n", frame.GetHeaderLength());
-        VerifyOrQuit(frame.GetHeaderLength() == tests[i].headerLength, "MacHeader test failed\n");
+        VerifyOrQuit(frame.GetHeaderLength() == tests[i].headerLength, "MacHeader test failed");
     }
 }
 
@@ -295,11 +295,11 @@ void VerifyChannelMaskContent(const Mac::ChannelMask &aMask, uint8_t *aChannels,
             if (channel == aChannels[index])
             {
                 index++;
-                VerifyOrQuit(aMask.ContainsChannel(channel), "ChannelMask.ContainsChannel() failed\n");
+                VerifyOrQuit(aMask.ContainsChannel(channel), "ChannelMask.ContainsChannel() failed");
             }
             else
             {
-                VerifyOrQuit(!aMask.ContainsChannel(channel), "ChannelMask.ContainsChannel() failed\n");
+                VerifyOrQuit(!aMask.ContainsChannel(channel), "ChannelMask.ContainsChannel() failed");
             }
         }
     }
@@ -309,21 +309,21 @@ void VerifyChannelMaskContent(const Mac::ChannelMask &aMask, uint8_t *aChannels,
 
     while (aMask.GetNextChannel(channel) == OT_ERROR_NONE)
     {
-        VerifyOrQuit(channel == aChannels[index++], "ChannelMask.GetNextChannel() failed\n");
+        VerifyOrQuit(channel == aChannels[index++], "ChannelMask.GetNextChannel() failed");
     }
 
-    VerifyOrQuit(index == aLength, "ChannelMask.GetNextChannel() failed\n");
+    VerifyOrQuit(index == aLength, "ChannelMask.GetNextChannel() failed");
 
     if (aLength == 1)
     {
-        VerifyOrQuit(aMask.IsSingleChannel(), "ChannelMask.IsSingleChannel() failed\n");
+        VerifyOrQuit(aMask.IsSingleChannel(), "ChannelMask.IsSingleChannel() failed");
     }
     else
     {
-        VerifyOrQuit(!aMask.IsSingleChannel(), "ChannelMask.IsSingleChannel() failed\n");
+        VerifyOrQuit(!aMask.IsSingleChannel(), "ChannelMask.IsSingleChannel() failed");
     }
 
-    VerifyOrQuit(aLength == aMask.GetNumberOfChannels(), "ChannelMask.GetNumberOfChannels() failed\n");
+    VerifyOrQuit(aLength == aMask.GetNumberOfChannels(), "ChannelMask.GetNumberOfChannels() failed");
 }
 
 void TestMacChannelMask(void)
@@ -339,16 +339,16 @@ void TestMacChannelMask(void)
 
     printf("Testing Mac::ChannelMask\n");
 
-    VerifyOrQuit(mask1.IsEmpty(), "ChannelMask.IsEmpty failed\n");
+    VerifyOrQuit(mask1.IsEmpty(), "ChannelMask.IsEmpty failed");
     printf("empty = %s\n", mask1.ToString().AsCString());
 
-    VerifyOrQuit(!mask2.IsEmpty(), "ChannelMask.IsEmpty failed\n");
-    VerifyOrQuit(mask2.GetMask() == Radio::kSupportedChannels, "ChannelMask.GetMask() failed\n");
+    VerifyOrQuit(!mask2.IsEmpty(), "ChannelMask.IsEmpty failed");
+    VerifyOrQuit(mask2.GetMask() == Radio::kSupportedChannels, "ChannelMask.GetMask() failed");
     printf("all_channels = %s\n", mask2.ToString().AsCString());
 
     mask1.SetMask(Radio::kSupportedChannels);
-    VerifyOrQuit(!mask1.IsEmpty(), "ChannelMask.IsEmpty failed\n");
-    VerifyOrQuit(mask1.GetMask() == Radio::kSupportedChannels, "ChannelMask.GetMask() failed\n");
+    VerifyOrQuit(!mask1.IsEmpty(), "ChannelMask.IsEmpty failed");
+    VerifyOrQuit(mask1.GetMask() == Radio::kSupportedChannels, "ChannelMask.GetMask() failed");
 
     VerifyChannelMaskContent(mask1, all_channels, sizeof(all_channels));
 
@@ -360,7 +360,7 @@ void TestMacChannelMask(void)
     }
 
     mask1.Clear();
-    VerifyOrQuit(mask1.IsEmpty(), "ChannelMask.IsEmpty failed\n");
+    VerifyOrQuit(mask1.IsEmpty(), "ChannelMask.IsEmpty failed");
     VerifyChannelMaskContent(mask1, NULL, 0);
 
     for (uint16_t index = 0; index < sizeof(channels1); index++)
@@ -370,7 +370,7 @@ void TestMacChannelMask(void)
 
     printf("channels1 = %s\n", mask1.ToString().AsCString());
 
-    VerifyOrQuit(!mask1.IsEmpty(), "ChannelMask.IsEmpty failed\n");
+    VerifyOrQuit(!mask1.IsEmpty(), "ChannelMask.IsEmpty failed");
     VerifyChannelMaskContent(mask1, channels1, sizeof(channels1));
 
     mask2.Clear();
@@ -382,7 +382,7 @@ void TestMacChannelMask(void)
 
     printf("channels2 = %s\n", mask2.ToString().AsCString());
 
-    VerifyOrQuit(!mask2.IsEmpty(), "ChannelMask.IsEmpty failed\n");
+    VerifyOrQuit(!mask2.IsEmpty(), "ChannelMask.IsEmpty failed");
     VerifyChannelMaskContent(mask2, channels2, sizeof(channels2));
 
     mask1.Intersect(mask2);
@@ -396,14 +396,14 @@ void TestMacChannelMask(void)
 
     mask1.Clear();
     mask2.Clear();
-    VerifyOrQuit(mask1 == mask2, "ChannelMask.operator== failed\n");
+    VerifyOrQuit(mask1 == mask2, "ChannelMask.operator== failed");
 
     mask1.SetMask(Radio::kSupportedChannels);
     mask2.SetMask(Radio::kSupportedChannels);
-    VerifyOrQuit(mask1 == mask2, "ChannelMask.operator== failed\n");
+    VerifyOrQuit(mask1 == mask2, "ChannelMask.operator== failed");
 
     mask1.Clear();
-    VerifyOrQuit(mask1 != mask2, "ChannelMask.operator== failed\n");
+    VerifyOrQuit(mask1 != mask2, "ChannelMask.operator== failed");
 }
 
 } // namespace ot

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -408,7 +408,6 @@ void TestMacChannelMask(void)
 
 } // namespace ot
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     ot::TestMacAddress();
@@ -418,4 +417,3 @@ int main(void)
     printf("All tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -63,11 +63,9 @@ void TestMessage(void)
     testFreeInstance(instance);
 }
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     TestMessage();
     printf("All tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -52,12 +52,12 @@ void TestMessage(void)
         writeBuffer[i] = static_cast<uint8_t>(random());
     }
 
-    VerifyOrQuit((message = messagePool->New(ot::Message::kTypeIp6, 0)) != NULL, "Message::New failed\n");
-    SuccessOrQuit(message->SetLength(sizeof(writeBuffer)), "Message::SetLength failed\n");
-    VerifyOrQuit(message->Write(0, sizeof(writeBuffer), writeBuffer) == sizeof(writeBuffer), "Message::Write failed\n");
-    VerifyOrQuit(message->Read(0, sizeof(readBuffer), readBuffer) == sizeof(readBuffer), "Message::Read failed\n");
-    VerifyOrQuit(memcmp(writeBuffer, readBuffer, sizeof(writeBuffer)) == 0, "Message compare failed\n");
-    VerifyOrQuit(message->GetLength() == 1024, "Message::GetLength failed\n");
+    VerifyOrQuit((message = messagePool->New(ot::Message::kTypeIp6, 0)) != NULL, "Message::New failed");
+    SuccessOrQuit(message->SetLength(sizeof(writeBuffer)), "Message::SetLength failed");
+    VerifyOrQuit(message->Write(0, sizeof(writeBuffer), writeBuffer) == sizeof(writeBuffer), "Message::Write failed");
+    VerifyOrQuit(message->Read(0, sizeof(readBuffer), readBuffer) == sizeof(readBuffer), "Message::Read failed");
+    VerifyOrQuit(memcmp(writeBuffer, readBuffer, sizeof(writeBuffer)) == 0, "Message compare failed");
+    VerifyOrQuit(message->GetLength() == 1024, "Message::GetLength failed");
     message->Free();
 
     testFreeInstance(instance);

--- a/tests/unit/test_message_queue.cpp
+++ b/tests/unit/test_message_queue.cpp
@@ -56,21 +56,21 @@ void VerifyMessageQueueContent(ot::MessageQueue &aMessageQueue, int aExpectedLen
     if (aExpectedLength == 0)
     {
         message = aMessageQueue.GetHead();
-        VerifyOrQuit(message == NULL, "MessageQueue is not empty when expected len is zero.\n");
+        VerifyOrQuit(message == NULL, "MessageQueue is not empty when expected len is zero.");
     }
     else
     {
         for (message = aMessageQueue.GetHead(); message != NULL; message = message->GetNext())
         {
-            VerifyOrQuit(aExpectedLength != 0, "MessageQueue contains more entries than expected\n");
+            VerifyOrQuit(aExpectedLength != 0, "MessageQueue contains more entries than expected");
 
             msgArg = va_arg(args, ot::Message *);
-            VerifyOrQuit(msgArg == message, "MessageQueue content does not match what is expected.\n");
+            VerifyOrQuit(msgArg == message, "MessageQueue content does not match what is expected.");
 
             aExpectedLength--;
         }
 
-        VerifyOrQuit(aExpectedLength == 0, "MessageQueue contains less entries than expected\n");
+        VerifyOrQuit(aExpectedLength == 0, "MessageQueue contains less entries than expected");
     }
 
     va_end(args);
@@ -91,102 +91,102 @@ void TestMessageQueue(void)
     for (int i = 0; i < kNumTestMessages; i++)
     {
         msg[i] = sMessagePool->New(ot::Message::kTypeIp6, 0);
-        VerifyOrQuit(msg[i] != NULL, "Message::New failed\n");
+        VerifyOrQuit(msg[i] != NULL, "Message::New failed");
     }
 
     VerifyMessageQueueContent(messageQueue, 0);
 
     // Enqueue 1 message and remove it
-    SuccessOrQuit(messageQueue.Enqueue(*msg[0]), "MessageQueue::Enqueue() failed.\n");
+    SuccessOrQuit(messageQueue.Enqueue(*msg[0]), "MessageQueue::Enqueue() failed.");
     VerifyMessageQueueContent(messageQueue, 1, msg[0]);
-    SuccessOrQuit(messageQueue.Dequeue(*msg[0]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msg[0]), "MessageQueue::Dequeue() failed.");
     VerifyMessageQueueContent(messageQueue, 0);
 
     // Enqueue 1 message at head and remove it
     SuccessOrQuit(messageQueue.Enqueue(*msg[0], ot::MessageQueue::kQueuePositionHead),
-                  "MessageQueue::Enqueue() failed.\n");
+                  "MessageQueue::Enqueue() failed.");
     VerifyMessageQueueContent(messageQueue, 1, msg[0]);
-    SuccessOrQuit(messageQueue.Dequeue(*msg[0]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msg[0]), "MessageQueue::Dequeue() failed.");
     VerifyMessageQueueContent(messageQueue, 0);
 
     // Enqueue 5 messages
-    SuccessOrQuit(messageQueue.Enqueue(*msg[0]), "MessageQueue::Enqueue() failed.\n");
+    SuccessOrQuit(messageQueue.Enqueue(*msg[0]), "MessageQueue::Enqueue() failed.");
     VerifyMessageQueueContent(messageQueue, 1, msg[0]);
-    SuccessOrQuit(messageQueue.Enqueue(*msg[1]), "MessageQueue::Enqueue() failed.\n");
+    SuccessOrQuit(messageQueue.Enqueue(*msg[1]), "MessageQueue::Enqueue() failed.");
     VerifyMessageQueueContent(messageQueue, 2, msg[0], msg[1]);
-    SuccessOrQuit(messageQueue.Enqueue(*msg[2]), "MessageQueue::Enqueue() failed.\n");
+    SuccessOrQuit(messageQueue.Enqueue(*msg[2]), "MessageQueue::Enqueue() failed.");
     VerifyMessageQueueContent(messageQueue, 3, msg[0], msg[1], msg[2]);
-    SuccessOrQuit(messageQueue.Enqueue(*msg[3]), "MessageQueue::Enqueue() failed.\n");
+    SuccessOrQuit(messageQueue.Enqueue(*msg[3]), "MessageQueue::Enqueue() failed.");
     VerifyMessageQueueContent(messageQueue, 4, msg[0], msg[1], msg[2], msg[3]);
-    SuccessOrQuit(messageQueue.Enqueue(*msg[4]), "MessageQueue::Enqueue() failed.\n");
+    SuccessOrQuit(messageQueue.Enqueue(*msg[4]), "MessageQueue::Enqueue() failed.");
     VerifyMessageQueueContent(messageQueue, 5, msg[0], msg[1], msg[2], msg[3], msg[4]);
 
     // Check the GetInfo()
     messageQueue.GetInfo(msgCount, bufferCount);
-    VerifyOrQuit(msgCount == 5, "MessageQueue::GetInfo() failed.\n");
+    VerifyOrQuit(msgCount == 5, "MessageQueue::GetInfo() failed.");
 
     // Remove from head
-    SuccessOrQuit(messageQueue.Dequeue(*msg[0]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msg[0]), "MessageQueue::Dequeue() failed.");
     VerifyMessageQueueContent(messageQueue, 4, msg[1], msg[2], msg[3], msg[4]);
 
     // Remove a message in middle
-    SuccessOrQuit(messageQueue.Dequeue(*msg[3]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msg[3]), "MessageQueue::Dequeue() failed.");
     VerifyMessageQueueContent(messageQueue, 3, msg[1], msg[2], msg[4]);
 
     // Remove from tail
-    SuccessOrQuit(messageQueue.Dequeue(*msg[4]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msg[4]), "MessageQueue::Dequeue() failed.");
     VerifyMessageQueueContent(messageQueue, 2, msg[1], msg[2]);
 
     // Add after remove
-    SuccessOrQuit(messageQueue.Enqueue(*msg[0]), "MessageQueue::Enqueue() failed.\n");
+    SuccessOrQuit(messageQueue.Enqueue(*msg[0]), "MessageQueue::Enqueue() failed.");
     VerifyMessageQueueContent(messageQueue, 3, msg[1], msg[2], msg[0]);
-    SuccessOrQuit(messageQueue.Enqueue(*msg[3]), "MessageQueue::Enqueue() failed.\n");
+    SuccessOrQuit(messageQueue.Enqueue(*msg[3]), "MessageQueue::Enqueue() failed.");
     VerifyMessageQueueContent(messageQueue, 4, msg[1], msg[2], msg[0], msg[3]);
 
     // Remove from middle
-    SuccessOrQuit(messageQueue.Dequeue(*msg[2]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msg[2]), "MessageQueue::Dequeue() failed.");
     VerifyMessageQueueContent(messageQueue, 3, msg[1], msg[0], msg[3]);
 
     // Add to head
     SuccessOrQuit(messageQueue.Enqueue(*msg[2], ot::MessageQueue::kQueuePositionHead),
-                  "MessageQueue::Enqueue() failed.\n");
+                  "MessageQueue::Enqueue() failed.");
     VerifyMessageQueueContent(messageQueue, 4, msg[2], msg[1], msg[0], msg[3]);
 
     // Remove from head
-    SuccessOrQuit(messageQueue.Dequeue(*msg[2]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msg[2]), "MessageQueue::Dequeue() failed.");
     VerifyMessageQueueContent(messageQueue, 3, msg[1], msg[0], msg[3]);
 
     // Remove from head
-    SuccessOrQuit(messageQueue.Dequeue(*msg[1]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msg[1]), "MessageQueue::Dequeue() failed.");
     VerifyMessageQueueContent(messageQueue, 2, msg[0], msg[3]);
 
     // Add to head
     SuccessOrQuit(messageQueue.Enqueue(*msg[1], ot::MessageQueue::kQueuePositionHead),
-                  "MessageQueue::Enqueue() failed.\n");
+                  "MessageQueue::Enqueue() failed.");
     VerifyMessageQueueContent(messageQueue, 3, msg[1], msg[0], msg[3]);
 
     // Add to tail
     SuccessOrQuit(messageQueue.Enqueue(*msg[2], ot::MessageQueue::kQueuePositionTail),
-                  "MessageQueue::Enqueue() failed.\n");
+                  "MessageQueue::Enqueue() failed.");
     VerifyMessageQueueContent(messageQueue, 4, msg[1], msg[0], msg[3], msg[2]);
 
     // Remove all messages.
-    SuccessOrQuit(messageQueue.Dequeue(*msg[3]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msg[3]), "MessageQueue::Dequeue() failed.");
     VerifyMessageQueueContent(messageQueue, 3, msg[1], msg[0], msg[2]);
-    SuccessOrQuit(messageQueue.Dequeue(*msg[1]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msg[1]), "MessageQueue::Dequeue() failed.");
     VerifyMessageQueueContent(messageQueue, 2, msg[0], msg[2]);
-    SuccessOrQuit(messageQueue.Dequeue(*msg[2]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msg[2]), "MessageQueue::Dequeue() failed.");
     VerifyMessageQueueContent(messageQueue, 1, msg[0]);
-    SuccessOrQuit(messageQueue.Dequeue(*msg[0]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msg[0]), "MessageQueue::Dequeue() failed.");
     VerifyMessageQueueContent(messageQueue, 0);
 
     // Check the failure cases: Enqueue an already queued message or dequeue a message not in the queue.
-    SuccessOrQuit(messageQueue.Enqueue(*msg[0]), "MessageQueue::Enqueue() failed.\n");
+    SuccessOrQuit(messageQueue.Enqueue(*msg[0]), "MessageQueue::Enqueue() failed.");
     VerifyMessageQueueContent(messageQueue, 1, msg[0]);
     error = messageQueue.Enqueue(*msg[0]);
-    VerifyOrQuit(error == OT_ERROR_ALREADY, "Enqueuing an already queued message did not fail as expected.\n");
+    VerifyOrQuit(error == OT_ERROR_ALREADY, "Enqueuing an already queued message did not fail as expected.");
     error = messageQueue.Dequeue(*msg[1]);
-    VerifyOrQuit(error == OT_ERROR_NOT_FOUND, "Dequeuing a message not in the queue did not fail as expected.\n");
+    VerifyOrQuit(error == OT_ERROR_NOT_FOUND, "Dequeuing a message not in the queue did not fail as expected.");
 
     testFreeInstance(sInstance);
 }
@@ -203,21 +203,21 @@ void VerifyMessageQueueContentUsingOtApi(otMessageQueue *aQueue, int aExpectedLe
     if (aExpectedLength == 0)
     {
         message = otMessageQueueGetHead(aQueue);
-        VerifyOrQuit(message == NULL, "MessageQueue is not empty when expected len is zero.\n");
+        VerifyOrQuit(message == NULL, "MessageQueue is not empty when expected len is zero.");
     }
     else
     {
         for (message = otMessageQueueGetHead(aQueue); message != NULL; message = otMessageQueueGetNext(aQueue, message))
         {
-            VerifyOrQuit(aExpectedLength != 0, "MessageQueue contains more entries than expected\n");
+            VerifyOrQuit(aExpectedLength != 0, "MessageQueue contains more entries than expected");
 
             msgArg = va_arg(args, otMessage *);
-            VerifyOrQuit(msgArg == message, "MessageQueue content does not match what is expected.\n");
+            VerifyOrQuit(msgArg == message, "MessageQueue content does not match what is expected.");
 
             aExpectedLength--;
         }
 
-        VerifyOrQuit(aExpectedLength == 0, "MessageQueue contains less entries than expected\n");
+        VerifyOrQuit(aExpectedLength == 0, "MessageQueue contains less entries than expected");
     }
 
     va_end(args);
@@ -237,7 +237,7 @@ void TestMessageQueueOtApis(void)
     for (int i = 0; i < kNumTestMessages; i++)
     {
         msg[i] = otIp6NewMessage(sInstance, NULL);
-        VerifyOrQuit(msg[i] != NULL, "otIp6NewMessage() failed.\n");
+        VerifyOrQuit(msg[i] != NULL, "otIp6NewMessage() failed.");
     }
 
     otMessageQueueInit(&queue);
@@ -247,48 +247,48 @@ void TestMessageQueueOtApis(void)
     VerifyMessageQueueContentUsingOtApi(&queue, 0);
 
     // Add message to the queue and check the content
-    SuccessOrQuit(otMessageQueueEnqueue(&queue, msg[0]), "Failed to enqueue a message to otMessageQueue.\n");
+    SuccessOrQuit(otMessageQueueEnqueue(&queue, msg[0]), "Failed to enqueue a message to otMessageQueue.");
     VerifyMessageQueueContentUsingOtApi(&queue, 1, msg[0]);
-    SuccessOrQuit(otMessageQueueEnqueue(&queue, msg[1]), "Failed to enqueue a message to otMessageQueue.\n");
+    SuccessOrQuit(otMessageQueueEnqueue(&queue, msg[1]), "Failed to enqueue a message to otMessageQueue.");
     VerifyMessageQueueContentUsingOtApi(&queue, 2, msg[0], msg[1]);
-    SuccessOrQuit(otMessageQueueEnqueueAtHead(&queue, msg[2]), "Failed to enqueue a message to otMessageQueue.\n");
+    SuccessOrQuit(otMessageQueueEnqueueAtHead(&queue, msg[2]), "Failed to enqueue a message to otMessageQueue.");
     VerifyMessageQueueContentUsingOtApi(&queue, 3, msg[2], msg[0], msg[1]);
-    SuccessOrQuit(otMessageQueueEnqueue(&queue, msg[3]), "Failed to enqueue a message to otMessageQueue.\n");
+    SuccessOrQuit(otMessageQueueEnqueue(&queue, msg[3]), "Failed to enqueue a message to otMessageQueue.");
     VerifyMessageQueueContentUsingOtApi(&queue, 4, msg[2], msg[0], msg[1], msg[3]);
 
     // Remove elements and check the content
-    SuccessOrQuit(otMessageQueueDequeue(&queue, msg[1]), "Failed to dequeue a message from otMessageQueue.\n");
+    SuccessOrQuit(otMessageQueueDequeue(&queue, msg[1]), "Failed to dequeue a message from otMessageQueue.");
     VerifyMessageQueueContentUsingOtApi(&queue, 3, msg[2], msg[0], msg[3]);
-    SuccessOrQuit(otMessageQueueDequeue(&queue, msg[0]), "Failed to dequeue a message from otMessageQueue.\n");
+    SuccessOrQuit(otMessageQueueDequeue(&queue, msg[0]), "Failed to dequeue a message from otMessageQueue.");
     VerifyMessageQueueContentUsingOtApi(&queue, 2, msg[2], msg[3]);
-    SuccessOrQuit(otMessageQueueDequeue(&queue, msg[3]), "Failed to dequeue a message from otMessageQueue.\n");
+    SuccessOrQuit(otMessageQueueDequeue(&queue, msg[3]), "Failed to dequeue a message from otMessageQueue.");
     VerifyMessageQueueContentUsingOtApi(&queue, 1, msg[2]);
 
     // Check the expected failure cases for the enqueue and dequeue:
     error = otMessageQueueEnqueue(&queue, msg[2]);
-    VerifyOrQuit(error == OT_ERROR_ALREADY, "Enqueuing an already queued message did not fail as expected.\n");
+    VerifyOrQuit(error == OT_ERROR_ALREADY, "Enqueuing an already queued message did not fail as expected.");
     error = otMessageQueueDequeue(&queue, msg[0]);
-    VerifyOrQuit(error == OT_ERROR_NOT_FOUND, "Dequeuing a message not in the queue did not fail as expected.\n");
+    VerifyOrQuit(error == OT_ERROR_NOT_FOUND, "Dequeuing a message not in the queue did not fail as expected.");
 
     // Check the failure cases for otMessageQueueGetNext()
     message = otMessageQueueGetNext(&queue, NULL);
-    VerifyOrQuit(message == NULL, "otMessageQueueGetNext(queue, NULL) did not return NULL.\n");
+    VerifyOrQuit(message == NULL, "otMessageQueueGetNext(queue, NULL) did not return NULL.");
     message = otMessageQueueGetNext(&queue, msg[1]);
-    VerifyOrQuit(message == NULL, "otMessageQueueGetNext() did not return NULL for a message not in the queue.\n");
+    VerifyOrQuit(message == NULL, "otMessageQueueGetNext() did not return NULL for a message not in the queue.");
 
     // Check the failure case when attempting to do otMessageQueueGetNext() but passing in a wrong queue pointer.
-    SuccessOrQuit(otMessageQueueEnqueue(&queue2, msg[0]), "Failed to enqueue a message to otMessageQueue.\n");
+    SuccessOrQuit(otMessageQueueEnqueue(&queue2, msg[0]), "Failed to enqueue a message to otMessageQueue.");
     VerifyMessageQueueContentUsingOtApi(&queue2, 1, msg[0]);
-    SuccessOrQuit(otMessageQueueEnqueue(&queue2, msg[1]), "Failed to enqueue a message to otMessageQueue.\n");
+    SuccessOrQuit(otMessageQueueEnqueue(&queue2, msg[1]), "Failed to enqueue a message to otMessageQueue.");
     VerifyMessageQueueContentUsingOtApi(&queue2, 2, msg[0], msg[1]);
 
     message = otMessageQueueGetNext(&queue2, msg[0]);
-    VerifyOrQuit(message == msg[1], "otMessageQueueGetNext() failed\n");
+    VerifyOrQuit(message == msg[1], "otMessageQueueGetNext() failed");
     message = otMessageQueueGetNext(&queue, msg[0]);
-    VerifyOrQuit(message == NULL, "otMessageQueueGetNext() did not return NULL for message not in  the queue.\n");
+    VerifyOrQuit(message == NULL, "otMessageQueueGetNext() did not return NULL for message not in  the queue.");
 
     // Remove all element and make sure queue is empty
-    SuccessOrQuit(otMessageQueueDequeue(&queue, msg[2]), "Failed to dequeue a message from otMessageQueue.\n");
+    SuccessOrQuit(otMessageQueueDequeue(&queue, msg[2]), "Failed to dequeue a message from otMessageQueue.");
     VerifyMessageQueueContentUsingOtApi(&queue, 0);
 
     testFreeInstance(sInstance);

--- a/tests/unit/test_message_queue.cpp
+++ b/tests/unit/test_message_queue.cpp
@@ -294,7 +294,6 @@ void TestMessageQueueOtApis(void)
     testFreeInstance(sInstance);
 }
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     TestMessageQueue();
@@ -302,4 +301,3 @@ int main(void)
     printf("All tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_ncp_buffer.cpp
+++ b/tests/unit/test_ncp_buffer.cpp
@@ -1098,7 +1098,6 @@ void TestFuzzNcpFrameBuffer(void)
 } // namespace Ncp
 } // namespace ot
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     ot::Ncp::TestNcpFrameBuffer();
@@ -1106,4 +1105,3 @@ int main(void)
     printf("\nAll tests passed.\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_ncp_buffer.cpp
+++ b/tests/unit/test_ncp_buffer.cpp
@@ -35,7 +35,7 @@
 #include "ncp/ncp_buffer.hpp"
 
 #include "test_platform.h"
-#include "test_util.h"
+#include "test_util.hpp"
 
 namespace ot {
 namespace Ncp {
@@ -157,47 +157,6 @@ void FrameRemovedCallback(void *                   aContext,
     VerifyAndRemoveTagFromHistory(aTag, aPriority);
 
     callbackContext->mFrameRemovedCount++;
-}
-
-// Dump the buffer content to screen.
-void DumpBuffer(const char *aTextMessage, uint8_t *aBuffer, uint16_t aBufferLength)
-{
-    enum
-    {
-        kBytesPerLine = 32, // Number of bytes per line.
-    };
-
-    char     charBuff[kBytesPerLine + 1];
-    uint16_t counter;
-    uint8_t  byte;
-
-    printf("\n%s - len = %u\n    ", aTextMessage, aBufferLength);
-
-    counter = 0;
-
-    while (aBufferLength--)
-    {
-        byte = *aBuffer++;
-        printf("%02X ", byte);
-        charBuff[counter] = isprint(byte) ? static_cast<char>(byte) : '.';
-        counter++;
-
-        if (counter == kBytesPerLine)
-        {
-            charBuff[counter] = 0;
-            printf("    %s\n    ", charBuff);
-            counter = 0;
-        }
-    }
-
-    charBuff[counter] = 0;
-
-    while (counter++ < kBytesPerLine)
-    {
-        printf("   ");
-    }
-
-    printf("    %s\n", charBuff);
 }
 
 // Reads bytes from the ncp buffer, and verifies that it matches with the given content buffer.

--- a/tests/unit/test_network_data.cpp
+++ b/tests/unit/test_network_data.cpp
@@ -112,7 +112,7 @@ void TestNetworkDataIterator(void)
 
         for (uint8_t i = 0; i < OT_ARRAY_LENGTH(routes); i++)
         {
-            SuccessOrQuit(netData.GetNextExternalRoute(iter, config), "GetNextExternalRoute() failed\n");
+            SuccessOrQuit(netData.GetNextExternalRoute(iter, config), "GetNextExternalRoute() failed");
             PrintExternalRouteConfig(config);
             VerifyOrQuit(CompareExternalRouteConfig(config, routes[i]) == true,
                          "external route config does not match expectation");
@@ -162,7 +162,7 @@ void TestNetworkDataIterator(void)
 
         for (uint8_t i = 0; i < OT_ARRAY_LENGTH(routes); i++)
         {
-            SuccessOrQuit(netData.GetNextExternalRoute(iter, config), "GetNextExternalRoute() failed\n");
+            SuccessOrQuit(netData.GetNextExternalRoute(iter, config), "GetNextExternalRoute() failed");
             PrintExternalRouteConfig(config);
             VerifyOrQuit(CompareExternalRouteConfig(config, routes[i]) == true,
                          "external route config does not match expectation");

--- a/tests/unit/test_network_data.cpp
+++ b/tests/unit/test_network_data.cpp
@@ -175,7 +175,6 @@ void TestNetworkDataIterator(void)
 } // namespace NetworkData
 } // namespace ot
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     ot::NetworkData::TestNetworkDataIterator();
@@ -183,4 +182,3 @@ int main(void)
     printf("\nAll tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_priority_queue.cpp
+++ b/tests/unit/test_priority_queue.cpp
@@ -51,30 +51,30 @@ void VerifyPriorityQueueContent(ot::PriorityQueue &aPriorityQueue, int aExpected
 
     // Check the `GetInfo`
     aPriorityQueue.GetInfo(msgCount, bufCount);
-    VerifyOrQuit(msgCount == aExpectedLength, "GetInfo() result does not match expected len.\n");
+    VerifyOrQuit(msgCount == aExpectedLength, "GetInfo() result does not match expected len.");
 
     va_start(args, aExpectedLength);
 
     if (aExpectedLength == 0)
     {
         message = aPriorityQueue.GetHead();
-        VerifyOrQuit(message == NULL, "PriorityQueue is not empty when expected len is zero.\n");
+        VerifyOrQuit(message == NULL, "PriorityQueue is not empty when expected len is zero.");
 
         VerifyOrQuit(aPriorityQueue.GetHeadForPriority(ot::Message::kPriorityLow) == NULL,
-                     "GetHeadForPriority() non-NULL when empty\n");
+                     "GetHeadForPriority() non-NULL when empty");
         VerifyOrQuit(aPriorityQueue.GetHeadForPriority(ot::Message::kPriorityNormal) == NULL,
-                     "GetHeadForPriority() non-NULL when empty\n");
+                     "GetHeadForPriority() non-NULL when empty");
         VerifyOrQuit(aPriorityQueue.GetHeadForPriority(ot::Message::kPriorityHigh) == NULL,
-                     "GetHeadForPriority() non-NULL when empty\n");
+                     "GetHeadForPriority() non-NULL when empty");
         VerifyOrQuit(aPriorityQueue.GetHeadForPriority(ot::Message::kPriorityNet) == NULL,
-                     "GetHeadForPriority() non-NULL when empty\n");
+                     "GetHeadForPriority() non-NULL when empty");
     }
     else
     {
         // Go through all messages in the queue and verify they match the passed-in messages
         for (message = aPriorityQueue.GetHead(); message != NULL; message = message->GetNext())
         {
-            VerifyOrQuit(aExpectedLength != 0, "PriorityQueue contains more entries than expected.\n");
+            VerifyOrQuit(aExpectedLength != 0, "PriorityQueue contains more entries than expected.");
 
             msgArg = va_arg(args, ot::Message *);
 
@@ -85,27 +85,27 @@ void VerifyPriorityQueueContent(ot::PriorityQueue &aPriorityQueue, int aExpected
                     // Check the `GetHeadForPriority` is NULL if there are no expected message for this priority level.
                     VerifyOrQuit(
                         aPriorityQueue.GetHeadForPriority(static_cast<uint8_t>(curPriority)) == NULL,
-                        "PriorityQueue::GetHeadForPriority is non-NULL when no expected msg for this priority.\n");
+                        "PriorityQueue::GetHeadForPriority is non-NULL when no expected msg for this priority.");
                 }
 
                 // Check the `GetHeadForPriority`.
                 VerifyOrQuit(aPriorityQueue.GetHeadForPriority(static_cast<uint8_t>(curPriority)) == msgArg,
-                             "PriorityQueue::GetHeadForPriority failed.\n");
+                             "PriorityQueue::GetHeadForPriority failed.");
             }
 
             // Check the queued message to match the one from argument list
-            VerifyOrQuit(msgArg == message, "PriorityQueue content does not match what is expected.\n");
+            VerifyOrQuit(msgArg == message, "PriorityQueue content does not match what is expected.");
 
             aExpectedLength--;
         }
 
-        VerifyOrQuit(aExpectedLength == 0, "PriorityQueue contains less entries than expected.\n");
+        VerifyOrQuit(aExpectedLength == 0, "PriorityQueue contains less entries than expected.");
 
         // Check the `GetHeadForPriority` is NULL if there are no expected message for any remaining priority level.
         for (curPriority--; curPriority >= 0; curPriority--)
         {
             VerifyOrQuit(aPriorityQueue.GetHeadForPriority(static_cast<uint8_t>(curPriority)) == NULL,
-                         "PriorityQueue::GetHeadForPriority is non-NULL when no expected msg for this priority.\n");
+                         "PriorityQueue::GetHeadForPriority is non-NULL when no expected msg for this priority.");
         }
     }
 
@@ -124,21 +124,21 @@ void VerifyMsgQueueContent(ot::MessageQueue &aMessageQueue, int aExpectedLength,
     if (aExpectedLength == 0)
     {
         message = aMessageQueue.GetHead();
-        VerifyOrQuit(message == NULL, "MessageQueue is not empty when expected len is zero.\n");
+        VerifyOrQuit(message == NULL, "MessageQueue is not empty when expected len is zero.");
     }
     else
     {
         for (message = aMessageQueue.GetHead(); message != NULL; message = message->GetNext())
         {
-            VerifyOrQuit(aExpectedLength != 0, "MessageQueue contains more entries than expected\n");
+            VerifyOrQuit(aExpectedLength != 0, "MessageQueue contains more entries than expected");
 
             msgArg = va_arg(args, ot::Message *);
-            VerifyOrQuit(msgArg == message, "MessageQueue content does not match what is expected.\n");
+            VerifyOrQuit(msgArg == message, "MessageQueue content does not match what is expected.");
 
             aExpectedLength--;
         }
 
-        VerifyOrQuit(aExpectedLength == 0, "MessageQueue contains less entries than expected\n");
+        VerifyOrQuit(aExpectedLength == 0, "MessageQueue contains less entries than expected");
     }
 
     va_end(args);
@@ -156,7 +156,7 @@ void TestPriorityQueue(void)
     ot::Message *     msgLow[kNumTestMessages];
 
     instance = testInitInstance();
-    VerifyOrQuit(instance != NULL, "Null OpenThread instance\n");
+    VerifyOrQuit(instance != NULL, "Null OpenThread instance");
 
     messagePool = &instance->Get<ot::MessagePool>();
 
@@ -164,159 +164,159 @@ void TestPriorityQueue(void)
     for (int i = 0; i < kNumNewPriorityTestMessages; i++)
     {
         msgNet[i] = messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kPriorityNet);
-        VerifyOrQuit(msgNet[i] != NULL, "Message::New failed\n");
+        VerifyOrQuit(msgNet[i] != NULL, "Message::New failed");
         msgHigh[i] = messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kPriorityHigh);
-        VerifyOrQuit(msgHigh[i] != NULL, "Message::New failed\n");
+        VerifyOrQuit(msgHigh[i] != NULL, "Message::New failed");
         msgNor[i] = messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kPriorityNormal);
-        VerifyOrQuit(msgNor[i] != NULL, "Message::New failed\n");
+        VerifyOrQuit(msgNor[i] != NULL, "Message::New failed");
         msgLow[i] = messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kPriorityLow);
-        VerifyOrQuit(msgLow[i] != NULL, "Message::New failed\n");
+        VerifyOrQuit(msgLow[i] != NULL, "Message::New failed");
     }
 
     // Check the failure case for `New()` for invalid argument.
     VerifyOrQuit(messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kNumPriorities) == NULL,
-                 "Message::New() with out of range value did not fail as expected.\n");
+                 "Message::New() with out of range value did not fail as expected.");
 
     // Use the function "SetPriority()" to allocate messages with different priorities
     for (int i = kNumNewPriorityTestMessages; i < kNumTestMessages; i++)
     {
         msgNet[i] = messagePool->New(ot::Message::kTypeIp6, 0);
-        VerifyOrQuit(msgNet[i] != NULL, "Message::New failed\n");
-        SuccessOrQuit(msgNet[i]->SetPriority(ot::Message::kPriorityNet), "Message:SetPriority failed\n");
+        VerifyOrQuit(msgNet[i] != NULL, "Message::New failed");
+        SuccessOrQuit(msgNet[i]->SetPriority(ot::Message::kPriorityNet), "Message:SetPriority failed");
         msgHigh[i] = messagePool->New(ot::Message::kTypeIp6, 0);
-        VerifyOrQuit(msgHigh[i] != NULL, "Message::New failed\n");
-        SuccessOrQuit(msgHigh[i]->SetPriority(ot::Message::kPriorityHigh), "Message:SetPriority failed\n");
+        VerifyOrQuit(msgHigh[i] != NULL, "Message::New failed");
+        SuccessOrQuit(msgHigh[i]->SetPriority(ot::Message::kPriorityHigh), "Message:SetPriority failed");
         msgNor[i] = messagePool->New(ot::Message::kTypeIp6, 0);
-        VerifyOrQuit(msgNor[i] != NULL, "Message::New failed\n");
-        SuccessOrQuit(msgNor[i]->SetPriority(ot::Message::kPriorityNormal), "Message:SetPriority failed\n");
+        VerifyOrQuit(msgNor[i] != NULL, "Message::New failed");
+        SuccessOrQuit(msgNor[i]->SetPriority(ot::Message::kPriorityNormal), "Message:SetPriority failed");
         msgLow[i] = messagePool->New(ot::Message::kTypeIp6, 0);
-        VerifyOrQuit(msgLow[i] != NULL, "Message::New failed\n");
-        SuccessOrQuit(msgLow[i]->SetPriority(ot::Message::kPriorityLow), "Message:SetPriority failed\n");
+        VerifyOrQuit(msgLow[i] != NULL, "Message::New failed");
+        SuccessOrQuit(msgLow[i]->SetPriority(ot::Message::kPriorityLow), "Message:SetPriority failed");
     }
 
     // Check the failure case for `SetPriority()` for invalid argument.
     VerifyOrQuit(msgNet[2]->SetPriority(ot::Message::kNumPriorities) == OT_ERROR_INVALID_ARGS,
-                 "Message::SetPriority() with out of range value did not fail as expected.\n");
+                 "Message::SetPriority() with out of range value did not fail as expected.");
 
     // Check the `GetPriority()`
     for (int i = 0; i < kNumTestMessages; i++)
     {
-        VerifyOrQuit(msgLow[i]->GetPriority() == ot::Message::kPriorityLow, "Message::GetPriority failed.\n");
-        VerifyOrQuit(msgNor[i]->GetPriority() == ot::Message::kPriorityNormal, "Message::GetPriority failed.\n");
-        VerifyOrQuit(msgHigh[i]->GetPriority() == ot::Message::kPriorityHigh, "Message::GetPriority failed.\n");
-        VerifyOrQuit(msgNet[i]->GetPriority() == ot::Message::kPriorityNet, "Message::GetPriority failed.\n");
+        VerifyOrQuit(msgLow[i]->GetPriority() == ot::Message::kPriorityLow, "Message::GetPriority failed.");
+        VerifyOrQuit(msgNor[i]->GetPriority() == ot::Message::kPriorityNormal, "Message::GetPriority failed.");
+        VerifyOrQuit(msgHigh[i]->GetPriority() == ot::Message::kPriorityHigh, "Message::GetPriority failed.");
+        VerifyOrQuit(msgNet[i]->GetPriority() == ot::Message::kPriorityNet, "Message::GetPriority failed.");
     }
 
     // Verify case of an empty queue.
     VerifyPriorityQueueContent(queue, 0);
 
     // Add msgs in different orders and check the content of queue.
-    SuccessOrQuit(queue.Enqueue(*msgHigh[0]), "PriorityQueue::Enqueue() failed.\n");
+    SuccessOrQuit(queue.Enqueue(*msgHigh[0]), "PriorityQueue::Enqueue() failed.");
     VerifyPriorityQueueContent(queue, 1, msgHigh[0]);
-    SuccessOrQuit(queue.Enqueue(*msgHigh[1]), "PriorityQueue::Enqueue() failed.\n");
+    SuccessOrQuit(queue.Enqueue(*msgHigh[1]), "PriorityQueue::Enqueue() failed.");
     VerifyPriorityQueueContent(queue, 2, msgHigh[0], msgHigh[1]);
-    SuccessOrQuit(queue.Enqueue(*msgNet[0]), "PriorityQueue::Enqueue() failed.\n");
+    SuccessOrQuit(queue.Enqueue(*msgNet[0]), "PriorityQueue::Enqueue() failed.");
     VerifyPriorityQueueContent(queue, 3, msgNet[0], msgHigh[0], msgHigh[1]);
-    SuccessOrQuit(queue.Enqueue(*msgNet[1]), "PriorityQueue::Enqueue() failed.\n");
+    SuccessOrQuit(queue.Enqueue(*msgNet[1]), "PriorityQueue::Enqueue() failed.");
     VerifyPriorityQueueContent(queue, 4, msgNet[0], msgNet[1], msgHigh[0], msgHigh[1]);
-    SuccessOrQuit(queue.Enqueue(*msgHigh[2]), "PriorityQueue::Enqueue() failed.\n");
+    SuccessOrQuit(queue.Enqueue(*msgHigh[2]), "PriorityQueue::Enqueue() failed.");
     VerifyPriorityQueueContent(queue, 5, msgNet[0], msgNet[1], msgHigh[0], msgHigh[1], msgHigh[2]);
-    SuccessOrQuit(queue.Enqueue(*msgLow[0]), "PriorityQueue::Enqueue() failed.\n");
+    SuccessOrQuit(queue.Enqueue(*msgLow[0]), "PriorityQueue::Enqueue() failed.");
     VerifyPriorityQueueContent(queue, 6, msgNet[0], msgNet[1], msgHigh[0], msgHigh[1], msgHigh[2], msgLow[0]);
-    SuccessOrQuit(queue.Enqueue(*msgNor[0]), "PriorityQueue::Enqueue() failed.\n");
+    SuccessOrQuit(queue.Enqueue(*msgNor[0]), "PriorityQueue::Enqueue() failed.");
     VerifyPriorityQueueContent(queue, 7, msgNet[0], msgNet[1], msgHigh[0], msgHigh[1], msgHigh[2], msgNor[0],
                                msgLow[0]);
-    SuccessOrQuit(queue.Enqueue(*msgHigh[3]), "PriorityQueue::Enqueue() failed.\n");
+    SuccessOrQuit(queue.Enqueue(*msgHigh[3]), "PriorityQueue::Enqueue() failed.");
     VerifyPriorityQueueContent(queue, 8, msgNet[0], msgNet[1], msgHigh[0], msgHigh[1], msgHigh[2], msgHigh[3],
                                msgNor[0], msgLow[0]);
 
     // Remove messages in different order and check the content of queue in each step.
-    SuccessOrQuit(queue.Dequeue(*msgNet[0]), "PriorityQueue::Dequeue() failed.\n");
+    SuccessOrQuit(queue.Dequeue(*msgNet[0]), "PriorityQueue::Dequeue() failed.");
     VerifyPriorityQueueContent(queue, 7, msgNet[1], msgHigh[0], msgHigh[1], msgHigh[2], msgHigh[3], msgNor[0],
                                msgLow[0]);
-    SuccessOrQuit(queue.Dequeue(*msgHigh[2]), "PriorityQueue::Dequeue() failed.\n");
+    SuccessOrQuit(queue.Dequeue(*msgHigh[2]), "PriorityQueue::Dequeue() failed.");
     VerifyPriorityQueueContent(queue, 6, msgNet[1], msgHigh[0], msgHigh[1], msgHigh[3], msgNor[0], msgLow[0]);
-    SuccessOrQuit(queue.Dequeue(*msgNor[0]), "PriorityQueue::Dequeue() failed.\n");
+    SuccessOrQuit(queue.Dequeue(*msgNor[0]), "PriorityQueue::Dequeue() failed.");
     VerifyPriorityQueueContent(queue, 5, msgNet[1], msgHigh[0], msgHigh[1], msgHigh[3], msgLow[0]);
-    SuccessOrQuit(queue.Dequeue(*msgHigh[1]), "PriorityQueue::Dequeue() failed.\n");
+    SuccessOrQuit(queue.Dequeue(*msgHigh[1]), "PriorityQueue::Dequeue() failed.");
     VerifyPriorityQueueContent(queue, 4, msgNet[1], msgHigh[0], msgHigh[3], msgLow[0]);
-    SuccessOrQuit(queue.Dequeue(*msgLow[0]), "PriorityQueue::Dequeue() failed.\n");
+    SuccessOrQuit(queue.Dequeue(*msgLow[0]), "PriorityQueue::Dequeue() failed.");
     VerifyPriorityQueueContent(queue, 3, msgNet[1], msgHigh[0], msgHigh[3]);
-    SuccessOrQuit(queue.Dequeue(*msgNet[1]), "PriorityQueue::Dequeue() failed.\n");
+    SuccessOrQuit(queue.Dequeue(*msgNet[1]), "PriorityQueue::Dequeue() failed.");
     VerifyPriorityQueueContent(queue, 2, msgHigh[0], msgHigh[3]);
-    SuccessOrQuit(queue.Dequeue(*msgHigh[0]), "PriorityQueue::Dequeue() failed.\n");
+    SuccessOrQuit(queue.Dequeue(*msgHigh[0]), "PriorityQueue::Dequeue() failed.");
     VerifyPriorityQueueContent(queue, 1, msgHigh[3]);
-    SuccessOrQuit(queue.Dequeue(*msgHigh[3]), "PriorityQueue::Dequeue() failed.\n");
+    SuccessOrQuit(queue.Dequeue(*msgHigh[3]), "PriorityQueue::Dequeue() failed.");
     VerifyPriorityQueueContent(queue, 0);
 
     // Check the failure cases: Enqueuing an already queued message, or dequeuing a message not queued.
-    SuccessOrQuit(queue.Enqueue(*msgNet[0]), "PriorityQueue::Enqueue() failed.\n");
+    SuccessOrQuit(queue.Enqueue(*msgNet[0]), "PriorityQueue::Enqueue() failed.");
     VerifyPriorityQueueContent(queue, 1, msgNet[0]);
     VerifyOrQuit(queue.Enqueue(*msgNet[0]) == OT_ERROR_ALREADY,
-                 "Enqueuing an already queued message did not fail as expected.\n");
+                 "Enqueuing an already queued message did not fail as expected.");
     VerifyOrQuit(queue.Dequeue(*msgHigh[0]) == OT_ERROR_NOT_FOUND,
-                 "Dequeuing a message not queued, did not fail as expected.\n");
-    SuccessOrQuit(queue.Dequeue(*msgNet[0]), "PriorityQueue::Dequeue() failed.\n");
+                 "Dequeuing a message not queued, did not fail as expected.");
+    SuccessOrQuit(queue.Dequeue(*msgNet[0]), "PriorityQueue::Dequeue() failed.");
     VerifyPriorityQueueContent(queue, 0);
 
     // Change the priority of an already queued message and check the order change in the queue.
-    SuccessOrQuit(queue.Enqueue(*msgNor[0]), "PriorityQueue::Enqueue() failed.\n");
+    SuccessOrQuit(queue.Enqueue(*msgNor[0]), "PriorityQueue::Enqueue() failed.");
     VerifyPriorityQueueContent(queue, 1, msgNor[0]);
-    SuccessOrQuit(queue.Enqueue(*msgHigh[0]), "PriorityQueue::Enqueue() failed.\n");
+    SuccessOrQuit(queue.Enqueue(*msgHigh[0]), "PriorityQueue::Enqueue() failed.");
     VerifyPriorityQueueContent(queue, 2, msgHigh[0], msgNor[0]);
-    SuccessOrQuit(queue.Enqueue(*msgLow[0]), "PriorityQueue::Enqueue() failed.\n");
+    SuccessOrQuit(queue.Enqueue(*msgLow[0]), "PriorityQueue::Enqueue() failed.");
     VerifyPriorityQueueContent(queue, 3, msgHigh[0], msgNor[0], msgLow[0]);
 
     SuccessOrQuit(msgNor[0]->SetPriority(ot::Message::kPriorityNet),
-                  "SetPriority failed for an already queued message.\n");
+                  "SetPriority failed for an already queued message.");
     VerifyPriorityQueueContent(queue, 3, msgNor[0], msgHigh[0], msgLow[0]);
     SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityLow),
-                  "SetPriority failed for an already queued message.\n");
+                  "SetPriority failed for an already queued message.");
     VerifyPriorityQueueContent(queue, 3, msgNor[0], msgHigh[0], msgLow[0]);
     SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityNormal),
-                  "SetPriority failed for an already queued message.\n");
+                  "SetPriority failed for an already queued message.");
     VerifyPriorityQueueContent(queue, 3, msgNor[0], msgHigh[0], msgLow[0]);
     SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityHigh),
-                  "SetPriority failed for an already queued message.\n");
+                  "SetPriority failed for an already queued message.");
     VerifyPriorityQueueContent(queue, 3, msgNor[0], msgHigh[0], msgLow[0]);
     SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityNet),
-                  "SetPriority failed for an already queued message.\n");
+                  "SetPriority failed for an already queued message.");
     VerifyPriorityQueueContent(queue, 3, msgNor[0], msgLow[0], msgHigh[0]);
     SuccessOrQuit(msgNor[0]->SetPriority(ot::Message::kPriorityNormal),
-                  "SetPriority failed for an already queued message.\n");
+                  "SetPriority failed for an already queued message.");
     SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityLow),
-                  "SetPriority failed for an already queued message.\n");
+                  "SetPriority failed for an already queued message.");
     VerifyPriorityQueueContent(queue, 3, msgHigh[0], msgNor[0], msgLow[0]);
 
-    SuccessOrQuit(messageQueue.Enqueue(*msgNor[1]), "MessageQueue::Enqueue() failed.\n");
-    SuccessOrQuit(messageQueue.Enqueue(*msgHigh[1]), "MessageQueue::Enqueue() failed.\n");
-    SuccessOrQuit(messageQueue.Enqueue(*msgNet[1]), "MessageQueue::Enqueue() failed.\n");
+    SuccessOrQuit(messageQueue.Enqueue(*msgNor[1]), "MessageQueue::Enqueue() failed.");
+    SuccessOrQuit(messageQueue.Enqueue(*msgHigh[1]), "MessageQueue::Enqueue() failed.");
+    SuccessOrQuit(messageQueue.Enqueue(*msgNet[1]), "MessageQueue::Enqueue() failed.");
     VerifyMsgQueueContent(messageQueue, 3, msgNor[1], msgHigh[1], msgNet[1]);
 
     // Change priority of message and check for not in messageQueue.
     SuccessOrQuit(msgNor[1]->SetPriority(ot::Message::kPriorityNet),
-                  "SetPriority failed for an already queued message.\n");
+                  "SetPriority failed for an already queued message.");
     VerifyMsgQueueContent(messageQueue, 3, msgNor[1], msgHigh[1], msgNet[1]);
 
     SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityHigh),
-                  "SetPriority failed for an already queued message.\n");
+                  "SetPriority failed for an already queued message.");
     VerifyPriorityQueueContent(queue, 3, msgHigh[0], msgLow[0], msgNor[0]);
     VerifyMsgQueueContent(messageQueue, 3, msgNor[1], msgHigh[1], msgNet[1]);
 
     // Remove messages from the two queues
-    SuccessOrQuit(queue.Dequeue(*msgHigh[0]), "PriorityQueue::Dequeue() failed.\n");
+    SuccessOrQuit(queue.Dequeue(*msgHigh[0]), "PriorityQueue::Dequeue() failed.");
     VerifyPriorityQueueContent(queue, 2, msgLow[0], msgNor[0]);
     VerifyMsgQueueContent(messageQueue, 3, msgNor[1], msgHigh[1], msgNet[1]);
 
-    SuccessOrQuit(messageQueue.Dequeue(*msgNet[1]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msgNet[1]), "MessageQueue::Dequeue() failed.");
     VerifyPriorityQueueContent(queue, 2, msgLow[0], msgNor[0]);
     VerifyMsgQueueContent(messageQueue, 2, msgNor[1], msgHigh[1]);
 
-    SuccessOrQuit(messageQueue.Dequeue(*msgHigh[1]), "MessageQueue::Dequeue() failed.\n");
+    SuccessOrQuit(messageQueue.Dequeue(*msgHigh[1]), "MessageQueue::Dequeue() failed.");
     VerifyPriorityQueueContent(queue, 2, msgLow[0], msgNor[0]);
     VerifyMsgQueueContent(messageQueue, 1, msgNor[1]);
 
-    SuccessOrQuit(queue.Dequeue(*msgLow[0]), "PriorityQueue::Dequeue() failed.\n");
+    SuccessOrQuit(queue.Dequeue(*msgLow[0]), "PriorityQueue::Dequeue() failed.");
     VerifyPriorityQueueContent(queue, 1, msgNor[0]);
     VerifyMsgQueueContent(messageQueue, 1, msgNor[1]);
 

--- a/tests/unit/test_priority_queue.cpp
+++ b/tests/unit/test_priority_queue.cpp
@@ -323,11 +323,9 @@ void TestPriorityQueue(void)
     testFreeInstance(instance);
 }
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     TestPriorityQueue();
     printf("All tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_pskc.cpp
+++ b/tests/unit/test_pskc.cpp
@@ -82,7 +82,6 @@ void TestMaximumPassphrase(void)
     testFreeInstance(instance);
 }
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     TestMinimumPassphrase();
@@ -90,16 +89,13 @@ int main(void)
     printf("All tests passed\n");
     return 0;
 }
-#endif
 
 #else // #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     printf("Commissioenr role disabled\n");
     return 0;
 }
-#endif
 
 #endif // #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE

--- a/tests/unit/test_spinel_decoder.cpp
+++ b/tests/unit/test_spinel_decoder.cpp
@@ -26,13 +26,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <ctype.h>
-
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "ncp/spinel_decoder.hpp"
 
-#include "test_util.h"
+#include "test_util.hpp"
 
 namespace ot {
 namespace Ncp {
@@ -41,47 +39,6 @@ enum
 {
     kTestBufferSize = 800,
 };
-
-// Dump the buffer content to screen.
-void DumpBuffer(const char *aTextMessage, uint8_t *aBuffer, uint16_t aBufferLength)
-{
-    enum
-    {
-        kBytesPerLine = 32, // Number of bytes per line.
-    };
-
-    char     charBuff[kBytesPerLine + 1];
-    uint16_t counter;
-    uint8_t  byte;
-
-    printf("\n%s - len = %u\n    ", aTextMessage, aBufferLength);
-
-    counter = 0;
-
-    while (aBufferLength--)
-    {
-        byte = *aBuffer++;
-        printf("%02X ", byte);
-        charBuff[counter] = isprint(byte) ? static_cast<char>(byte) : '.';
-        counter++;
-
-        if (counter == kBytesPerLine)
-        {
-            charBuff[counter] = 0;
-            printf("    %s\n    ", charBuff);
-            counter = 0;
-        }
-    }
-
-    charBuff[counter] = 0;
-
-    while (counter++ < kBytesPerLine)
-    {
-        printf("   ");
-    }
-
-    printf("    %s\n", charBuff);
-}
 
 void TestSpinelDecoder(void)
 {

--- a/tests/unit/test_spinel_decoder.cpp
+++ b/tests/unit/test_spinel_decoder.cpp
@@ -684,11 +684,9 @@ void TestSpinelDecoder(void)
 } // namespace Ncp
 } // namespace ot
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     ot::Ncp::TestSpinelDecoder();
     printf("\nAll tests passed.\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_spinel_encoder.cpp
+++ b/tests/unit/test_spinel_encoder.cpp
@@ -26,13 +26,11 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include <ctype.h>
-
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "ncp/spinel_encoder.hpp"
 
-#include "test_util.h"
+#include "test_util.hpp"
 
 namespace ot {
 namespace Ncp {
@@ -41,47 +39,6 @@ enum
 {
     kTestBufferSize = 800,
 };
-
-// Dump the buffer content to screen.
-void DumpBuffer(const char *aTextMessage, uint8_t *aBuffer, uint16_t aBufferLength)
-{
-    enum
-    {
-        kBytesPerLine = 32, // Number of bytes per line.
-    };
-
-    char     charBuff[kBytesPerLine + 1];
-    uint16_t counter;
-    uint8_t  byte;
-
-    printf("\n%s - len = %u\n    ", aTextMessage, aBufferLength);
-
-    counter = 0;
-
-    while (aBufferLength--)
-    {
-        byte = *aBuffer++;
-        printf("%02X ", byte);
-        charBuff[counter] = isprint(byte) ? static_cast<char>(byte) : '.';
-        counter++;
-
-        if (counter == kBytesPerLine)
-        {
-            charBuff[counter] = 0;
-            printf("    %s\n    ", charBuff);
-            counter = 0;
-        }
-    }
-
-    charBuff[counter] = 0;
-
-    while (counter++ < kBytesPerLine)
-    {
-        printf("   ");
-    }
-
-    printf("    %s\n", charBuff);
-}
 
 otError ReadFrame(NcpFrameBuffer &aNcpBuffer, uint8_t *aFrame, uint16_t &aFrameLen)
 {

--- a/tests/unit/test_spinel_encoder.cpp
+++ b/tests/unit/test_spinel_encoder.cpp
@@ -403,11 +403,9 @@ void TestSpinelEncoder(void)
 } // namespace Ncp
 } // namespace ot
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     ot::Ncp::TestSpinelEncoder();
     printf("\nAll tests passed.\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_string.cpp
+++ b/tests/unit/test_string.cpp
@@ -119,11 +119,9 @@ void TestString(void)
 
 } // namespace ot
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     ot::TestString();
     printf("\nAll tests passed.\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_timer.cpp
+++ b/tests/unit/test_timer.cpp
@@ -657,7 +657,6 @@ void RunTimerTests(void)
     TestTenTimers();
 }
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     RunTimerTests();
@@ -665,4 +664,3 @@ int main(void)
     printf("All tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_timer.cpp
+++ b/tests/unit/test_timer.cpp
@@ -128,22 +128,22 @@ int TestOneTimer(void)
     sNow = kTimeT0;
     timer.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.\n");
-    VerifyOrQuit(sPlatT0 == 1000 && sPlatDt == 10, "TestOneTimer: Start params Failed.\n");
-    VerifyOrQuit(timer.IsRunning(), "TestOneTimer: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn, "TestOneTimer: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == 1000 && sPlatDt == 10, "TestOneTimer: Start params Failed.");
+    VerifyOrQuit(timer.IsRunning(), "TestOneTimer: Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "TestOneTimer: Platform Timer State Failed.");
 
     sNow += kTimerInterval;
 
     otPlatAlarmMilliFired(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestOneTimer: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestOneTimer: Handler CallCount Failed.\n");
-    VerifyOrQuit(timer.IsRunning() == false, "TestOneTimer: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn == false, "TestOneTimer: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestOneTimer: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestOneTimer: Handler CallCount Failed.");
+    VerifyOrQuit(timer.IsRunning() == false, "TestOneTimer: Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "TestOneTimer: Platform Timer State Failed.");
 
     // Test one Timer that spans the 32-bit wrap.
 
@@ -152,22 +152,22 @@ int TestOneTimer(void)
     sNow = 0 - (kTimerInterval - 2);
     timer.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.\n");
-    VerifyOrQuit(sPlatT0 == 0 - (kTimerInterval - 2) && sPlatDt == 10, "TestOneTimer: Start params Failed.\n");
-    VerifyOrQuit(timer.IsRunning(), "TestOneTimer: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn, "TestOneTimer: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == 0 - (kTimerInterval - 2) && sPlatDt == 10, "TestOneTimer: Start params Failed.");
+    VerifyOrQuit(timer.IsRunning(), "TestOneTimer: Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "TestOneTimer: Platform Timer State Failed.");
 
     sNow += kTimerInterval;
 
     otPlatAlarmMilliFired(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestOneTimer: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestOneTimer: Handler CallCount Failed.\n");
-    VerifyOrQuit(timer.IsRunning() == false, "TestOneTimer: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn == false, "TestOneTimer: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestOneTimer: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestOneTimer: Handler CallCount Failed.");
+    VerifyOrQuit(timer.IsRunning() == false, "TestOneTimer: Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "TestOneTimer: Platform Timer State Failed.");
 
     // Test one Timer that is late by several msec
 
@@ -176,22 +176,22 @@ int TestOneTimer(void)
     sNow = kTimeT0;
     timer.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.\n");
-    VerifyOrQuit(sPlatT0 == 1000 && sPlatDt == 10, "TestOneTimer: Start params Failed.\n");
-    VerifyOrQuit(timer.IsRunning(), "TestOneTimer: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn, "TestOneTimer: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == 1000 && sPlatDt == 10, "TestOneTimer: Start params Failed.");
+    VerifyOrQuit(timer.IsRunning(), "TestOneTimer: Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "TestOneTimer: Platform Timer State Failed.");
 
     sNow += kTimerInterval + 5;
 
     otPlatAlarmMilliFired(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestOneTimer: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestOneTimer: Handler CallCount Failed.\n");
-    VerifyOrQuit(timer.IsRunning() == false, "TestOneTimer: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn == false, "TestOneTimer: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestOneTimer: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestOneTimer: Handler CallCount Failed.");
+    VerifyOrQuit(timer.IsRunning() == false, "TestOneTimer: Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "TestOneTimer: Platform Timer State Failed.");
 
     // Test one Timer that is early by several msec
 
@@ -200,32 +200,32 @@ int TestOneTimer(void)
     sNow = kTimeT0;
     timer.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.\n");
-    VerifyOrQuit(sPlatT0 == 1000 && sPlatDt == 10, "TestOneTimer: Start params Failed.\n");
-    VerifyOrQuit(timer.IsRunning(), "TestOneTimer: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn, "TestOneTimer: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == 1000 && sPlatDt == 10, "TestOneTimer: Start params Failed.");
+    VerifyOrQuit(timer.IsRunning(), "TestOneTimer: Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "TestOneTimer: Platform Timer State Failed.");
 
     sNow += kTimerInterval - 2;
 
     otPlatAlarmMilliFired(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestOneTimer: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.\n");
-    VerifyOrQuit(timer.IsRunning() == true, "TestOneTimer: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn == true, "TestOneTimer: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestOneTimer: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.");
+    VerifyOrQuit(timer.IsRunning() == true, "TestOneTimer: Timer running Failed.");
+    VerifyOrQuit(sTimerOn == true, "TestOneTimer: Platform Timer State Failed.");
 
     sNow += kTimerInterval;
 
     otPlatAlarmMilliFired(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestOneTimer: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestOneTimer: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestOneTimer: Handler CallCount Failed.\n");
-    VerifyOrQuit(timer.IsRunning() == false, "TestOneTimer: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn == false, "TestOneTimer: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestOneTimer: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestOneTimer: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestOneTimer: Handler CallCount Failed.");
+    VerifyOrQuit(timer.IsRunning() == false, "TestOneTimer: Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "TestOneTimer: Platform Timer State Failed.");
 
     printf(" --> PASSED\n");
 
@@ -255,47 +255,47 @@ int TestTwoTimers(void)
     sNow = kTimeT0;
     timer1.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.\n");
-    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.\n");
-    VerifyOrQuit(timer1.IsRunning(), "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning(), "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.");
 
     sNow += kTimerInterval;
 
     timer2.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.\n");
-    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.\n");
-    VerifyOrQuit(timer1.IsRunning() == true, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.");
 
     otPlatAlarmMilliFired(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTwoTimers: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestTwoTimers: Handler CallCount Failed.\n");
-    VerifyOrQuit(timer1.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.\n");
-    VerifyOrQuit(sPlatT0 == sNow && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.\n");
-    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn == true, "TestTwoTimers: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTwoTimers: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestTwoTimers: Handler CallCount Failed.");
+    VerifyOrQuit(timer1.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.");
+    VerifyOrQuit(sPlatT0 == sNow && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(sTimerOn == true, "TestTwoTimers: Platform Timer State Failed.");
 
     sNow += kTimerInterval;
     otPlatAlarmMilliFired(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTwoTimers: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestTwoTimers: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 2, "TestTwoTimers: Handler CallCount Failed.\n");
-    VerifyOrQuit(timer2.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.\n");
-    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn == false, "TestTwoTimers: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTwoTimers: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestTwoTimers: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 2, "TestTwoTimers: Handler CallCount Failed.");
+    VerifyOrQuit(timer2.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.");
+    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "TestTwoTimers: Platform Timer State Failed.");
 
     // Test when second timer starts at the fire time of first timer (before otPlatAlarmMilliFired()) and its fire time
     // is before the first timer. Ensure that the second timer handler is invoked before the first one.
@@ -307,41 +307,41 @@ int TestTwoTimers(void)
     sNow = kTimeT0;
     timer1.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.\n");
-    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.\n");
-    VerifyOrQuit(timer1.IsRunning(), "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning(), "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.");
 
     sNow += kTimerInterval;
 
     timer2.StartAt(ot::TimeMilli(kTimeT0), kTimerInterval - 2); // Timer 2 is even before timer 1
 
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.\n");
-    VerifyOrQuit(timer1.IsRunning() == true, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.");
+    VerifyOrQuit(timer1.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.");
 
     otPlatAlarmMilliFired(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestTwoTimers: Handler CallCount Failed.\n");
-    VerifyOrQuit(timer2.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.\n");
-    VerifyOrQuit(sPlatT0 == sNow && sPlatDt == 0, "TestTwoTimers: Start params Failed.\n");
-    VerifyOrQuit(timer1.IsRunning() == true, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn == true, "TestTwoTimers: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestTwoTimers: Handler CallCount Failed.");
+    VerifyOrQuit(timer2.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.");
+    VerifyOrQuit(sPlatT0 == sNow && sPlatDt == 0, "TestTwoTimers: Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(sTimerOn == true, "TestTwoTimers: Platform Timer State Failed.");
 
     otPlatAlarmMilliFired(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestTwoTimers: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 2, "TestTwoTimers: Handler CallCount Failed.\n");
-    VerifyOrQuit(timer1.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.\n");
-    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn == false, "TestTwoTimers: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestTwoTimers: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 2, "TestTwoTimers: Handler CallCount Failed.");
+    VerifyOrQuit(timer1.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.");
+    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "TestTwoTimers: Platform Timer State Failed.");
 
     // Timer 1 fire callback is late by some ticks/ms, and second timer is scheduled (before call to
     // otPlatAlarmMilliFired) with a maximum interval. This is to test (corner-case) scenario where the fire time of two
@@ -354,47 +354,47 @@ int TestTwoTimers(void)
     sNow = kTimeT0;
     timer1.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.\n");
-    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.\n");
-    VerifyOrQuit(timer1.IsRunning(), "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning(), "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.");
 
     sNow += kTimerInterval + 5;
 
     timer2.Start(ot::Timer::kMaxDelay);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.\n");
-    VerifyOrQuit(timer1.IsRunning() == true, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.");
+    VerifyOrQuit(timer1.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.");
 
     otPlatAlarmMilliFired(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTwoTimers: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestTwoTimers: Handler CallCount Failed.\n");
-    VerifyOrQuit(timer1.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.\n");
-    VerifyOrQuit(sPlatT0 == sNow, "TestTwoTimers: Start params Failed.\n");
-    VerifyOrQuit(sPlatDt == ot::Timer::kMaxDelay, "TestTwoTimers: Start params Failed.\n");
-    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn == true, "TestTwoTimers: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTwoTimers: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestTwoTimers: Handler CallCount Failed.");
+    VerifyOrQuit(timer1.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.");
+    VerifyOrQuit(sPlatT0 == sNow, "TestTwoTimers: Start params Failed.");
+    VerifyOrQuit(sPlatDt == ot::Timer::kMaxDelay, "TestTwoTimers: Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(sTimerOn == true, "TestTwoTimers: Platform Timer State Failed.");
 
     sNow += ot::Timer::kMaxDelay;
     otPlatAlarmMilliFired(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTwoTimers: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestTwoTimers: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 2, "TestTwoTimers: Handler CallCount Failed.\n");
-    VerifyOrQuit(timer2.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.\n");
-    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.\n");
-    VerifyOrQuit(sTimerOn == false, "TestTwoTimers: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTwoTimers: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestTwoTimers: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 2, "TestTwoTimers: Handler CallCount Failed.");
+    VerifyOrQuit(timer2.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.");
+    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "TestTwoTimers: Platform Timer State Failed.");
 
     printf(" --> PASSED\n");
 
@@ -488,16 +488,16 @@ static void TenTimers(uint32_t aTimeShift)
 
     // given the order in which timers are started, the TimerScheduler should call otPlatAlarmMilliStartAt 2 times.
     // one for timer[0] and one for timer[5] which will supercede timer[0].
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTenTimer: Start CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTenTimer: Stop CallCount Failed.\n");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTenTimer: Handler CallCount Failed.\n");
-    VerifyOrQuit(sPlatT0 == kTimeT0[5] + aTimeShift, "TestTenTimer: Start params Failed.\n");
-    VerifyOrQuit(sPlatDt == kTimerInterval[5], "TestTenTimer: Start params Failed.\n");
-    VerifyOrQuit(sTimerOn, "TestTenTimer: Platform Timer State Failed.\n");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTenTimer: Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTenTimer: Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTenTimer: Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == kTimeT0[5] + aTimeShift, "TestTenTimer: Start params Failed.");
+    VerifyOrQuit(sPlatDt == kTimerInterval[5], "TestTenTimer: Start params Failed.");
+    VerifyOrQuit(sTimerOn, "TestTenTimer: Platform Timer State Failed.");
 
     for (i = 0; i < kNumTimers; i++)
     {
-        VerifyOrQuit(timers[i]->IsRunning(), "TestTenTimer: Timer running Failed.\n");
+        VerifyOrQuit(timers[i]->IsRunning(), "TestTenTimer: Timer running Failed.");
     }
 
     // Issue the triggers and test the State after each trigger.
@@ -518,23 +518,23 @@ static void TenTimers(uint32_t aTimeShift)
         } while (sPlatDt == 0);
 
         VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == kTimerStartCountAfterTrigger[trigger],
-                     "TestTenTimer: Start CallCount Failed.\n");
+                     "TestTenTimer: Start CallCount Failed.");
         VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == kTimerStopCountAfterTrigger[trigger],
-                     "TestTenTimer: Stop CallCount Failed.\n");
+                     "TestTenTimer: Stop CallCount Failed.");
         VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == kTimerHandlerCountAfterTrigger[trigger],
-                     "TestTenTimer: Handler CallCount Failed.\n");
-        VerifyOrQuit(sTimerOn == kSchedulerStateAfterTrigger[trigger], "TestTenTimer: Platform Timer State Failed.\n");
+                     "TestTenTimer: Handler CallCount Failed.");
+        VerifyOrQuit(sTimerOn == kSchedulerStateAfterTrigger[trigger], "TestTenTimer: Platform Timer State Failed.");
 
         for (i = 0; i < kNumTimers; i++)
         {
             VerifyOrQuit(timers[i]->IsRunning() == kTimerStateAfterTrigger[trigger][i],
-                         "TestTenTimer: Timer running Failed.\n");
+                         "TestTenTimer: Timer running Failed.");
         }
     }
 
     for (i = 0; i < kNumTimers; i++)
     {
-        VerifyOrQuit(timers[i]->GetFiredCounter() == 1, "TestTenTimer: Timer fired counter Failed.\n");
+        VerifyOrQuit(timers[i]->GetFiredCounter() == 1, "TestTenTimer: Timer fired counter Failed.");
     }
 
     printf("--> PASSED\n");
@@ -582,66 +582,66 @@ int TestTimerTime(void)
             printf("TestTimerTime() start=%-10x  duration=%-10x ", start, duration);
 
             t1.SetValue(start);
-            VerifyOrQuit(t1.GetValue() == start, "Time::SetValue() failed.\n");
+            VerifyOrQuit(t1.GetValue() == start, "Time::SetValue() failed.");
 
             t2 = t1;
-            VerifyOrQuit(t1.GetValue() == start, "Time assignment failed.\n");
+            VerifyOrQuit(t1.GetValue() == start, "Time assignment failed.");
 
-            VerifyOrQuit(t1 == t2, "Time == failed.\n");
-            VerifyOrQuit(!(t1 != t2), "Time != failed.\n");
-            VerifyOrQuit(!(t1 < t2), "Time < failed.\n");
-            VerifyOrQuit((t1 <= t2), "Time <= failed.\n");
-            VerifyOrQuit(!(t1 > t2), "Time > failed.\n");
-            VerifyOrQuit((t1 >= t2), "Time >= failed.\n");
-            VerifyOrQuit(t2 - t1 == 0, "Time difference failed\n");
+            VerifyOrQuit(t1 == t2, "Time == failed.");
+            VerifyOrQuit(!(t1 != t2), "Time != failed.");
+            VerifyOrQuit(!(t1 < t2), "Time < failed.");
+            VerifyOrQuit((t1 <= t2), "Time <= failed.");
+            VerifyOrQuit(!(t1 > t2), "Time > failed.");
+            VerifyOrQuit((t1 >= t2), "Time >= failed.");
+            VerifyOrQuit(t2 - t1 == 0, "Time difference failed");
 
             t2 = t1 + duration;
-            VerifyOrQuit(!(t1 == t2), "Time == failed.\n");
-            VerifyOrQuit((t1 != t2), "Time != failed.\n");
-            VerifyOrQuit((t1 < t2), "Time < failed.\n");
-            VerifyOrQuit((t1 <= t2), "Time <= failed.\n");
-            VerifyOrQuit(!(t1 > t2), "Time > failed.\n");
-            VerifyOrQuit(!(t1 >= t2), "Time >= failed.\n");
-            VerifyOrQuit(t2 - t1 == duration, "Time difference failed\n");
+            VerifyOrQuit(!(t1 == t2), "Time == failed.");
+            VerifyOrQuit((t1 != t2), "Time != failed.");
+            VerifyOrQuit((t1 < t2), "Time < failed.");
+            VerifyOrQuit((t1 <= t2), "Time <= failed.");
+            VerifyOrQuit(!(t1 > t2), "Time > failed.");
+            VerifyOrQuit(!(t1 >= t2), "Time >= failed.");
+            VerifyOrQuit(t2 - t1 == duration, "Time difference failed");
 
             t2 = t1;
             t2 += duration;
-            VerifyOrQuit(!(t1 == t2), "Time == failed.\n");
-            VerifyOrQuit((t1 != t2), "Time != failed.\n");
-            VerifyOrQuit((t1 < t2), "Time < failed.\n");
-            VerifyOrQuit((t1 <= t2), "Time <= failed.\n");
-            VerifyOrQuit(!(t1 > t2), "Time > failed.\n");
-            VerifyOrQuit(!(t1 >= t2), "Time >= failed.\n");
-            VerifyOrQuit(t2 - t1 == duration, "Time difference failed\n");
+            VerifyOrQuit(!(t1 == t2), "Time == failed.");
+            VerifyOrQuit((t1 != t2), "Time != failed.");
+            VerifyOrQuit((t1 < t2), "Time < failed.");
+            VerifyOrQuit((t1 <= t2), "Time <= failed.");
+            VerifyOrQuit(!(t1 > t2), "Time > failed.");
+            VerifyOrQuit(!(t1 >= t2), "Time >= failed.");
+            VerifyOrQuit(t2 - t1 == duration, "Time difference failed");
 
             t2 = t1 - duration;
-            VerifyOrQuit(!(t1 == t2), "Time == failed.\n");
-            VerifyOrQuit((t1 != t2), "Time != failed.\n");
-            VerifyOrQuit(!(t1 < t2), "Time < failed.\n");
-            VerifyOrQuit(!(t1 <= t2), "Time <= failed.\n");
-            VerifyOrQuit((t1 > t2), "Time > failed.\n");
-            VerifyOrQuit((t1 >= t2), "Time >= failed.\n");
-            VerifyOrQuit(t1 - t2 == duration, "Time difference failed\n");
+            VerifyOrQuit(!(t1 == t2), "Time == failed.");
+            VerifyOrQuit((t1 != t2), "Time != failed.");
+            VerifyOrQuit(!(t1 < t2), "Time < failed.");
+            VerifyOrQuit(!(t1 <= t2), "Time <= failed.");
+            VerifyOrQuit((t1 > t2), "Time > failed.");
+            VerifyOrQuit((t1 >= t2), "Time >= failed.");
+            VerifyOrQuit(t1 - t2 == duration, "Time difference failed");
 
             t2 = t1;
             t2 -= duration;
-            VerifyOrQuit(!(t1 == t2), "Time == failed.\n");
-            VerifyOrQuit((t1 != t2), "Time != failed.\n");
-            VerifyOrQuit(!(t1 < t2), "Time < failed.\n");
-            VerifyOrQuit(!(t1 <= t2), "Time <= failed.\n");
-            VerifyOrQuit((t1 > t2), "Time > failed.\n");
-            VerifyOrQuit((t1 >= t2), "Time >= failed.\n");
-            VerifyOrQuit(t1 - t2 == duration, "Time difference failed\n");
+            VerifyOrQuit(!(t1 == t2), "Time == failed.");
+            VerifyOrQuit((t1 != t2), "Time != failed.");
+            VerifyOrQuit(!(t1 < t2), "Time < failed.");
+            VerifyOrQuit(!(t1 <= t2), "Time <= failed.");
+            VerifyOrQuit((t1 > t2), "Time > failed.");
+            VerifyOrQuit((t1 >= t2), "Time >= failed.");
+            VerifyOrQuit(t1 - t2 == duration, "Time difference failed");
 
             t2 = t1.GetDistantFuture();
-            VerifyOrQuit((t1 < t2), "GetDistanceFuture() failed\n");
+            VerifyOrQuit((t1 < t2), "GetDistanceFuture() failed");
             t2 += 1;
-            VerifyOrQuit(!(t1 < t2), "GetDistanceFuture() failed\n");
+            VerifyOrQuit(!(t1 < t2), "GetDistanceFuture() failed");
 
             t2 = t1.GetDistantPast();
-            VerifyOrQuit((t1 > t2), "GetDistantPast() failed\n");
+            VerifyOrQuit((t1 > t2), "GetDistantPast() failed");
             t2 -= 1;
-            VerifyOrQuit(!(t1 > t2), "GetDistantPast() failed\n");
+            VerifyOrQuit(!(t1 > t2), "GetDistantPast() failed");
 
             printf("--> PASSED\n");
         }

--- a/tests/unit/test_toolchain.cpp
+++ b/tests/unit/test_toolchain.cpp
@@ -124,11 +124,9 @@ void TestToolchain(void)
     test_addr_bitfield();
 }
 
-#ifdef ENABLE_TEST_MAIN
 int main(void)
 {
     TestToolchain();
     printf("All tests passed\n");
     return 0;
 }
-#endif

--- a/tests/unit/test_toolchain.cpp
+++ b/tests/unit/test_toolchain.cpp
@@ -53,7 +53,7 @@ void test_packed1()
 
     CompileTimeAssert(sizeof(packed_t) == 7, "packed_t should be packed to 7 bytes");
 
-    VerifyOrQuit(sizeof(packed_t) == 7, "Toolchain::OT_TOOL_PACKED failed 1\n");
+    VerifyOrQuit(sizeof(packed_t) == 7, "Toolchain::OT_TOOL_PACKED failed 1");
 }
 
 void test_packed2()
@@ -67,7 +67,7 @@ void test_packed2()
 
     CompileTimeAssert(sizeof(packed_t) == 4, "packed_t should be packed to 4 bytes");
 
-    VerifyOrQuit(sizeof(packed_t) == 4, "Toolchain::OT_TOOL_PACKED failed 2\n");
+    VerifyOrQuit(sizeof(packed_t) == 4, "Toolchain::OT_TOOL_PACKED failed 2");
 }
 
 void test_packed_union()
@@ -90,7 +90,7 @@ void test_packed_union()
 
     CompileTimeAssert(sizeof(packed_t) == 5, "packed_t should be packed to 5 bytes");
 
-    VerifyOrQuit(sizeof(packed_t) == 5, "Toolchain::OT_TOOL_PACKED failed 3\n");
+    VerifyOrQuit(sizeof(packed_t) == 5, "Toolchain::OT_TOOL_PACKED failed 3");
 }
 
 void test_packed_enum()
@@ -99,7 +99,7 @@ void test_packed_enum()
     neighbor.SetState(ot::Neighbor::kStateValid);
 
     // Make sure that when we read the 3 bit field it is read as unsigned, so it return '4'
-    VerifyOrQuit(neighbor.GetState() == ot::Neighbor::kStateValid, "Toolchain::OT_TOOL_PACKED failed 4\n");
+    VerifyOrQuit(neighbor.GetState() == ot::Neighbor::kStateValid, "Toolchain::OT_TOOL_PACKED failed 4");
 }
 
 void test_addr_sizes()
@@ -111,7 +111,7 @@ void test_addr_sizes()
 
 void test_addr_bitfield()
 {
-    VerifyOrQuit(CreateNetif_c().mScopeOverrideValid == true, "Toolchain::test_addr_size_cpp\n");
+    VerifyOrQuit(CreateNetif_c().mScopeOverrideValid == true, "Toolchain::test_addr_size_cpp");
 }
 
 void TestToolchain(void)

--- a/tests/unit/test_toolchain.cpp
+++ b/tests/unit/test_toolchain.cpp
@@ -34,6 +34,7 @@
 
 #include "test_util.h"
 #include "thread/topology.hpp"
+#include "utils/static_assert.hpp"
 
 extern "C" {
 uint32_t       otNetifAddress_Size_c();
@@ -51,7 +52,7 @@ void test_packed1()
         uint16_t mShort;
     } OT_TOOL_PACKED_END;
 
-    CompileTimeAssert(sizeof(packed_t) == 7, "packed_t should be packed to 7 bytes");
+    OT_STATIC_ASSERT(sizeof(packed_t) == 7, "packed_t should be packed to 7 bytes");
 
     VerifyOrQuit(sizeof(packed_t) == 7, "Toolchain::OT_TOOL_PACKED failed 1");
 }
@@ -65,7 +66,7 @@ void test_packed2()
         uint8_t mByte;
     } OT_TOOL_PACKED_END;
 
-    CompileTimeAssert(sizeof(packed_t) == 4, "packed_t should be packed to 4 bytes");
+    OT_STATIC_ASSERT(sizeof(packed_t) == 4, "packed_t should be packed to 4 bytes");
 
     VerifyOrQuit(sizeof(packed_t) == 4, "Toolchain::OT_TOOL_PACKED failed 2");
 }
@@ -88,7 +89,7 @@ void test_packed_union()
         } OT_TOOL_PACKED_FIELD;
     } OT_TOOL_PACKED_END;
 
-    CompileTimeAssert(sizeof(packed_t) == 5, "packed_t should be packed to 5 bytes");
+    OT_STATIC_ASSERT(sizeof(packed_t) == 5, "packed_t should be packed to 5 bytes");
 
     VerifyOrQuit(sizeof(packed_t) == 5, "Toolchain::OT_TOOL_PACKED failed 3");
 }

--- a/tests/unit/test_util.cpp
+++ b/tests/unit/test_util.cpp
@@ -26,55 +26,46 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "test_util.h"
+#include "test_util.hpp"
 
-#include <iostream>
-#include <sstream>
-#include <string>
-#include <vector>
+#include <ctype.h>
 
-#include <stdint.h>
-
-void otTestHexToVector(std::string &aHex, std::vector<uint8_t> &aOutBytes)
+void DumpBuffer(const char *aTextMessage, uint8_t *aBuffer, uint16_t aBufferLength)
 {
-    std::istringstream ss(aHex);
-    std::string        word;
-
-    while (ss >> word)
+    enum
     {
-        uint8_t n = static_cast<uint8_t>(strtol(word.data(), NULL, 16));
-        aOutBytes.push_back(n);
-    }
-}
+        kBytesPerLine = 16, // Number of bytes per line.
+    };
 
-void otTestPrintHex(uint8_t *aBuffer, int aLength)
-{
-    int i;
+    char     charBuff[kBytesPerLine + 1];
+    uint16_t counter;
+    uint8_t  byte;
 
-    for (i = 0; i < aLength; i++)
+    printf("\n%s - len = %u\n    ", aTextMessage ? aTextMessage : "Buffer", aBufferLength);
+
+    counter = 0;
+
+    while (aBufferLength--)
     {
-        printf("%02x ", aBuffer[i]);
+        byte = *aBuffer++;
+        printf("%02X ", byte);
+        charBuff[counter] = isprint(byte) ? static_cast<char>(byte) : '.';
+        counter++;
 
-        if (i % 16 == 7)
+        if (counter == kBytesPerLine)
         {
-            printf(" ");
-        }
-
-        if (i % 16 == 15 && aLength != i + 1)
-        {
-            printf("\n");
+            charBuff[counter] = 0;
+            printf("    %s\n    ", charBuff);
+            counter = 0;
         }
     }
 
-    printf("\n");
-}
+    charBuff[counter] = 0;
 
-void otTestPrintHex(std::string &aString)
-{
-    otTestPrintHex((uint8_t *)aString.data(), static_cast<int>(aString.size()));
-}
+    while (counter++ < kBytesPerLine)
+    {
+        printf("   ");
+    }
 
-void otTestPrintHex(std::vector<uint8_t> &aBytes)
-{
-    otTestPrintHex((uint8_t *)&aBytes[0], static_cast<int>(aBytes.size()));
+    printf("    %s\n", charBuff);
 }

--- a/tests/unit/test_util.h
+++ b/tests/unit/test_util.h
@@ -81,8 +81,6 @@ extern "C" {
 //
 #define CompileTimeAssert(COND, MSG)
 
-#define Log(aFormat, ...) printf(aFormat "\n", ##__VA_ARGS__)
-
 #ifdef __cplusplus
 }
 #endif

--- a/tests/unit/test_util.h
+++ b/tests/unit/test_util.h
@@ -36,9 +36,6 @@
 extern "C" {
 #endif
 
-// Enable main functions
-#define ENABLE_TEST_MAIN
-
 /**
  * This macro verifies a given error status to be successful (compared against value zero (0)), otherwise, it emits a
  * given error messages and exits the program.

--- a/tests/unit/test_util.h
+++ b/tests/unit/test_util.h
@@ -39,24 +39,40 @@ extern "C" {
 // Enable main functions
 #define ENABLE_TEST_MAIN
 
-#define SuccessOrQuit(ERR, MSG)                                                    \
-    do                                                                             \
-    {                                                                              \
-        if ((ERR) != OT_ERROR_NONE)                                                \
-        {                                                                          \
-            fprintf(stderr, "\nFAILED %s:%d - %s\n", __FUNCTION__, __LINE__, MSG); \
-            exit(-1);                                                              \
-        }                                                                          \
+/**
+ * This macro verifies a given error status to be successful (compared against value zero (0)), otherwise, it emits a
+ * given error messages and exits the program.
+ *
+ * @param[in]  aStatus     A scalar error status to be evaluated against zero (0).
+ * @param[in]  aMessage    A message (text string) to print on failure.
+ *
+ */
+#define SuccessOrQuit(aStatus, aMessage)                                                \
+    do                                                                                  \
+    {                                                                                   \
+        if ((aStatus) != 0)                                                             \
+        {                                                                               \
+            fprintf(stderr, "\nFAILED %s:%d - %s\n", __FUNCTION__, __LINE__, aMessage); \
+            exit(-1);                                                                   \
+        }                                                                               \
     } while (false)
 
-#define VerifyOrQuit(TST, MSG)                                                     \
-    do                                                                             \
-    {                                                                              \
-        if (!(TST))                                                                \
-        {                                                                          \
-            fprintf(stderr, "\nFAILED %s:%d - %s\n", __FUNCTION__, __LINE__, MSG); \
-            exit(-1);                                                              \
-        }                                                                          \
+/**
+ * This macro verifies that a given boolean condition is true, otherwise, it emits a given error message and exits the
+ * program.
+ *
+ * @param[in]  aCondition  A Boolean expression to be evaluated.
+ * @param[in]  aMessage    A message (text string) to print on failure.
+ *
+ */
+#define VerifyOrQuit(aCondition, aMessage)                                              \
+    do                                                                                  \
+    {                                                                                   \
+        if (!(aCondition))                                                              \
+        {                                                                               \
+            fprintf(stderr, "\nFAILED %s:%d - %s\n", __FUNCTION__, __LINE__, aMessage); \
+            exit(-1);                                                                   \
+        }                                                                               \
     } while (false)
 
 //#define CompileTimeAssert(COND, MSG) typedef char __C_ASSERT__[(COND)?1:-1]

--- a/tests/unit/test_util.h
+++ b/tests/unit/test_util.h
@@ -72,15 +72,6 @@ extern "C" {
         }                                                                               \
     } while (false)
 
-//#define CompileTimeAssert(COND, MSG) typedef char __C_ASSERT__[(COND)?1:-1]
-
-// I would use the above definition for CompileTimeAssert, but I am getting the following errors
-// when I run 'make -f examples/Makefile-posix distcheck':
-//
-//      error: typedef "__C_ASSERT__" locally defined but not used [-Werror=unused-local-typedefs]
-//
-#define CompileTimeAssert(COND, MSG)
-
 #ifdef __cplusplus
 }
 #endif

--- a/tests/unit/test_util.hpp
+++ b/tests/unit/test_util.hpp
@@ -29,18 +29,18 @@
 #ifndef TEST_UTIL_HPP
 #define TEST_UTIL_HPP
 
+#include <stdint.h>
+
 #include "test_util.h"
 
-// STL is okay in unit tests.
-#include <string>
-#include <vector>
-
-void otTestHexToVector(std::string &aHex, std::vector<uint8_t> &aOutBytes);
-
-void otTestPrintHex(uint8_t *aBuffer, int aLength);
-
-void otTestPrintHex(std::vector<uint8_t> &aBytes);
-
-void otTestPrintHex(std::string &aString);
+/**
+ * This function prints the content of a given buffer to screen as a hex dump along with ASCII text translation.
+ *
+ * @param[in] aTextMessag    A text message to describe the buffer content (printed before the buffer content)
+ * @param[in] aBuffer        A pointer to the buffer
+ * @param[in] aBufferLength  Number of bytes in the buffer.
+ *
+ */
+void DumpBuffer(const char *aTextMessage, uint8_t *aBuffer, uint16_t aBufferLength);
 
 #endif


### PR DESCRIPTION
This PR contains a bunch of smaller commits all related to unit-tests:

**[unit-test] allow project to specify platform log config in unit tests (#4367)**

This commit removes the hard-coded `OPENTHREAD_CONFIG_LOG_PLATFORM=0`
configuration in the unit test makefile. This allows the project build
to specify whether the platform logging should be enabled in unit
tests or not (and removes the complier warning for possible re-definition
of this configuration option).

**[unit-test] add a common function to dump buffer content (#4367)**

This commit updates `test_utils.hpp/cpp` to include a common helper
function `DumpBuffer` to print the content of a buffer (as hex and char string)
to screen. It also removes unused helper functions and use of STL header
files and types.

**[unit-test] use OT_STATIC_ASSERT in unit tests (#4367)**

This commit removes `CompileTimeAssert` (which was an empty macro).
Instead `OT_STATIC_ASSERT` is used in `test_toolchain.cpp`.

**[unit-test] remove Log() from test_utils.h (#4367)**

**[unit-test] remove (unnecessary) ENABLE_TEST_MAIN definition (#4367)**

**[unit-test] remove extra \n at end of error message (#4367)**

This commit removes the extra `\n` at the end of error message strings
used in `VerifyOrQuit()` or `SuccessOrQuit()` macros in different unit
test modules. This help make the style (usage of macros) consistent
across all unit tests.

**[unit-test] update test_util SuccessOrQuit/VerifyOrQuit macros (#4367)**