### PR TITLE
[mle] MTD prioritizes ML-EID registration

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1342,7 +1342,7 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
     tlv.SetType(Tlv::kAddressRegistration);
     SuccessOrExit(error = aMessage.Append(&tlv, sizeof(tlv)));
 
-    // Prioritize MlEid
+    // Prioritize ML-EID
     entry.SetContextId(kMeshLocalPrefixContextId);
     entry.SetIid(GetMeshLocal64().GetIid());
     SuccessOrExit(error = aMessage.Append(&entry, entry.GetLength()));
@@ -1355,14 +1355,8 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
     for (const Ip6::NetifUnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr; addr = addr->GetNext())
     {
         if (addr->GetAddress().IsLinkLocal() || IsRoutingLocator(addr->GetAddress()) ||
-            IsAnycastLocator(addr->GetAddress()))
+            IsAnycastLocator(addr->GetAddress()) || addr->GetAddress() == GetMeshLocal64())
         {
-            continue;
-        }
-
-        if (addr->GetAddress() == GetMeshLocal64())
-        {
-            // skip MlEid which was appended already.
             continue;
         }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1331,35 +1331,58 @@ exit:
 
 otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMode aMode)
 {
-    otError                  error = OT_ERROR_NONE;
-    Tlv                      tlv;
-    AddressRegistrationEntry entry;
-    Lowpan::Context          context;
-    bool                     done        = false;
-    uint8_t                  length      = 0;
-    uint8_t                  counter     = 0;
-    uint16_t                 startOffset = aMessage.GetLength();
+    otError                         error = OT_ERROR_NONE;
+    Tlv                             tlv;
+    AddressRegistrationEntry        entry;
+    Lowpan::Context                 context;
+    bool                            meshLocalOnlyDone = false;
+    bool                            meshLocalDone     = false;
+    uint8_t                         length            = 0;
+    uint8_t                         counter           = 0;
+    uint16_t                        startOffset       = aMessage.GetLength();
+    const Ip6::NetifUnicastAddress *next              = NULL;
 
     tlv.SetType(Tlv::kAddressRegistration);
     SuccessOrExit(error = aMessage.Append(&tlv, sizeof(tlv)));
 
-    for (const Ip6::NetifUnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr; addr = addr->GetNext())
+    for (const Ip6::NetifUnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr; addr = next)
     {
+        next = addr->GetNext();
+
         if (addr->GetAddress().IsLinkLocal() || IsRoutingLocator(addr->GetAddress()) ||
             IsAnycastLocator(addr->GetAddress()))
         {
             continue;
         }
 
-        if (aMode == kAppendMeshLocalOnly)
+        if (addr->GetAddress() == GetMeshLocal64())
         {
-            if (addr->GetAddress() != GetMeshLocal64())
+            if (aMode == kAppendMeshLocalOnly)
+            {
+                // Set `meshLocalOnlyDone` to `true` to exit after the address is appended
+                meshLocalOnlyDone = true;
+            }
+            else if (!meshLocalDone)
+            {
+                // Prioritize MlEid.
+                meshLocalDone = true;
+
+                // restart from the unicast address list head after append MlEid
+                next = Get<ThreadNetif>().GetUnicastAddresses();
+            }
+            else
+            {
+                // skip MlEid which was appended already.
+                continue;
+            }
+        }
+        else
+        {
+            // The other unicast addresses to register
+            if (aMode == kAppendMeshLocalOnly || !meshLocalDone)
             {
                 continue;
             }
-
-            // Set `done` to `true` to exit after the address is appended.
-            done = true;
         }
 
         if (Get<NetworkData::Leader>().GetContext(addr->GetAddress(), context) == OT_ERROR_NONE)
@@ -1379,7 +1402,7 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
         length += entry.GetLength();
         counter++;
         // only continue to append if there is available entry.
-        VerifyOrExit(!done && (counter < OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER));
+        VerifyOrExit(!meshLocalOnlyDone && (counter < OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER));
     }
 
     // For sleepy end device, register external multicast addresses to the parent for indirect transmission


### PR DESCRIPTION
This commit ensures that the important MlEid would be the
first one in Address Registration TLV so that the parent
would always be able to store it.

(SPEC-899: A recipient MUST process address entries in an
Address Registration TLV sequentially from first entry to
last entry)