### PR TITLE
[mac] scope timeIeOffset variable to code block where it is being used

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -954,9 +954,6 @@ void Mac::BeginTransmit(void)
     bool     applyTransmitSecurity = true;
     bool     processTransmitAesCcm = true;
     TxFrame &sendFrame             = mSubMac.GetTransmitFrame();
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    uint8_t timeIeOffset = 0;
-#endif
 
     VerifyOrExit(mEnabled, error = OT_ERROR_ABORT);
 
@@ -1021,15 +1018,18 @@ void Mac::BeginTransmit(void)
     }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    timeIeOffset = GetTimeIeOffset(sendFrame);
-    sendFrame.SetTimeIeOffset(timeIeOffset);
-
-    if (timeIeOffset != 0)
     {
-        // Transmit security will be processed after time IE content is updated.
-        processTransmitAesCcm = false;
-        sendFrame.SetTimeSyncSeq(Get<TimeSync>().GetTimeSyncSeq());
-        sendFrame.SetNetworkTimeOffset(Get<TimeSync>().GetNetworkTimeOffset());
+        uint8_t timeIeOffset = GetTimeIeOffset(sendFrame);
+
+        sendFrame.SetTimeIeOffset(timeIeOffset);
+
+        if (timeIeOffset != 0)
+        {
+            // Transmit security will be processed after time IE content is updated.
+            processTransmitAesCcm = false;
+            sendFrame.SetTimeSyncSeq(Get<TimeSync>().GetTimeSyncSeq());
+            sendFrame.SetNetworkTimeOffset(Get<TimeSync>().GetNetworkTimeOffset());
+        }
     }
 #endif
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -661,7 +661,6 @@ private:
     bool    IsJoinable(void) const;
     void    BeginTransmit(void);
     bool    HandleMacCommand(RxFrame &aFrame);
-    Frame * GetOperationFrame(void);
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);


### PR DESCRIPTION
This PR contains two small enhancements/changes in `Mac` class:

- [mac] scope timeIeOffset variable to code block where it is being used
- [mac] remove unused method definition