### PR TITLE
[ip6] allow hoplimit 0

### DIFF
--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -139,13 +139,16 @@ typedef struct otSockAddr
  */
 typedef struct otMessageInfo
 {
-    otIp6Address mSockAddr;            ///< The local IPv6 address.
-    otIp6Address mPeerAddr;            ///< The peer IPv6 address.
-    uint16_t     mSockPort;            ///< The local transport-layer port.
-    uint16_t     mPeerPort;            ///< The peer transport-layer port.
-    const void * mLinkInfo;            ///< A pointer to link-specific information.
-    uint8_t      mHopLimit;            ///< The IPv6 hop limit.
-    bool         mIsHostInterface : 1; ///< TRUE if packets sent/received via host interface, FALSE otherwise.
+    otIp6Address mSockAddr;      ///< The local IPv6 address.
+    otIp6Address mPeerAddr;      ///< The peer IPv6 address.
+    uint16_t     mSockPort;      ///< The local transport-layer port.
+    uint16_t     mPeerPort;      ///< The peer transport-layer port.
+    const void * mLinkInfo;      ///< A pointer to link-specific information.
+    uint8_t      mHopLimit;      ///< The IPv6 Hop Limit value. Only applies if `mAllowZeroHopLimit` is FALSE.
+                                 ///< If `0`, IPv6 Hop Limit is default value `OPENTHREAD_CONFIG_IP6_HOP_LIMIT_DEFAULT`.
+                                 ///< Otherwise, specifies the IPv6 Hop Limit.
+    bool mIsHostInterface : 1;   ///< TRUE if packets sent/received via host interface, FALSE otherwise.
+    bool mAllowZeroHopLimit : 1; ///< TRUE to allow IPv6 Hop Limit 0 in `mHopLimit`, FALSE otherwise.
 } otMessageInfo;
 
 /**

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -53,7 +53,7 @@ OpenThread test scripts use the CLI to execute test cases.
 * [panid](#panid)
 * [parent](#parent)
 * [parentpriority](#parentpriority)
-* [ping](#ping-ipaddr-size-count-interval)
+* [ping](#ping-ipaddr-size-count-interval-hoplimit)
 * [pollperiod](#pollperiod-pollperiod)
 * [prefix](#prefix-add-prefix-pvdcsr-prf)
 * [promiscuous](#promiscuous)
@@ -937,17 +937,20 @@ Set the assigned parent priority value: 1, 0, -1 or -2.
 Done
 ```
 
-### ping \<ipaddr\> [size] [count] [interval]
+### ping \<ipaddr\> [size] [count] [interval] [hoplimit]
 
 Send an ICMPv6 Echo Request.
 
 * size: The number of data bytes to be sent.
 * count: The number of ICMPv6 Echo Requests to be sent.
 * interval: The interval between two consecutive ICMPv6 Echo Requests in seconds. The value may have fractional form, for example `0.5`.
+* hoplimit: The hoplimit of ICMPv6 Echo Request to be sent.
 
 ```bash
 > ping fdde:ad00:beef:0:558:f56b:d688:799
 16 bytes from fdde:ad00:beef:0:558:f56b:d688:799: icmp_seq=1 hlim=64 time=28ms
+
+> ping ff05::1 100 1 1 1
 ```
 
 ### ping stop

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2033,6 +2033,7 @@ void Interpreter::ProcessPing(int argc, char *argv[])
 
     VerifyOrExit(!mPingTimer.IsRunning(), error = OT_ERROR_BUSY);
 
+    mMessageInfo = Ip6::MessageInfo();
     SuccessOrExit(error = mMessageInfo.GetPeerAddr().FromString(argv[0]));
 
     mLength   = 8;
@@ -2057,6 +2058,16 @@ void Interpreter::ProcessPing(int argc, char *argv[])
             SuccessOrExit(error = ParsePingInterval(argv[index], interval));
             VerifyOrExit(0 < interval && interval <= Timer::kMaxDelay, error = OT_ERROR_INVALID_ARGS);
             mInterval = interval;
+            break;
+
+        case 4:
+            SuccessOrExit(error = ParseLong(argv[index], value));
+            VerifyOrExit(0 <= value && value <= 255, error = OT_ERROR_INVALID_ARGS);
+            mMessageInfo.mHopLimit = static_cast<uint8_t>(value);
+            if (value == 0)
+            {
+                mMessageInfo.mAllowZeroHopLimit = true;
+            }
             break;
 
         default:

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -460,7 +460,15 @@ otError Ip6::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, IpProto 
     header.SetDscp(PriorityToDscp(aMessage.GetPriority()));
     header.SetPayloadLength(payloadLength);
     header.SetNextHeader(aIpProto);
-    header.SetHopLimit(aMessageInfo.mHopLimit ? aMessageInfo.mHopLimit : static_cast<uint8_t>(kDefaultHopLimit));
+
+    if (aMessageInfo.GetHopLimit() != 0 || aMessageInfo.ShouldAllowZeroHopLimit())
+    {
+        header.SetHopLimit(aMessageInfo.GetHopLimit());
+    }
+    else
+    {
+        header.SetHopLimit(static_cast<uint8_t>(kDefaultHopLimit));
+    }
 
     if (aMessageInfo.GetSockAddr().IsUnspecified() || aMessageInfo.GetSockAddr().IsMulticast())
     {

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -183,6 +183,15 @@ public:
     bool IsHostInterface(void) const { return mIsHostInterface; }
 
     /**
+     * This method indicates whether or not to apply hop limit 0.
+     *
+     * @retval TRUE  if applying hop limit 0 when `mHopLimit` field is 0.
+     * @retval FALSE if applying default `OPENTHREAD_CONFIG_IP6_HOP_LIMIT_DEFAULT` when `mHopLimit` field is 0.
+     *
+     */
+    bool ShouldAllowZeroHopLimit(void) const { return mAllowZeroHopLimit; }
+
+    /**
      * This method sets whether the peer is via the host interface.
      *
      * @param[in]  aIsHost  TRUE if the peer is via the host interface, FALSE otherwise.


### PR DESCRIPTION
HopLimit 0 is required for TC defined in Thread 1.2 Test Plan. And also as pointed out by @bukepo in #3089, 0 is a valid value.
> From section IPV6_UNICAST_HOPS and IPV6_MULTICAST_HOPS of http://man7.org/linux/man-pages/man7/ipv6.7.html, 0 is a valid value, and -1 means using the default value

Here were some relative PRs and discussions regarding hop limit 0 (#3077, #3089, #3092).

The first commit in PR introduces one flag to indicate whether to apply hop limit 0 to meet the hoplimit 0 requirement, as well as keep previous usage as is. 

The second commit extends existing `ping` command to allow hoplimit configuration.