### PR TITLE
[cmake] add OT_CONFIG to specify project core config header file

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -59,6 +59,14 @@ if(NOT OT_PLATFORM IN_LIST OT_EXAMPLE_PLATFORMS)
     endif()
 endif()
 
+# OT_CONFIG allows users to specify the path to OpenThread project core
+# config header file. The default value of this parameter is empty string.
+# When not specified by user (value is ""), a platform cmake file may
+# choose to change this variable to provide its own core config header
+# file instead.
+
+set(OT_CONFIG "" CACHE STRING "OpenThread project-specific config header file chosen by user at configure time")
+
 list(APPEND OT_PUBLIC_INCLUDES ${PROJECT_BINARY_DIR}/etc/cmake)
 list(APPEND OT_PUBLIC_INCLUDES ${PROJECT_SOURCE_DIR}/etc/cmake)
 list(APPEND OT_PUBLIC_INCLUDES ${PROJECT_SOURCE_DIR}/include)
@@ -69,6 +77,11 @@ if(OT_PLATFORM STREQUAL "posix-host")
 elseif(NOT OT_PLATFORM MATCHES "none")
     list(APPEND OT_PRIVATE_INCLUDES ${PROJECT_SOURCE_DIR}/examples/platforms/${OT_PLATFORM})
     add_subdirectory("${PROJECT_SOURCE_DIR}/examples/platforms/${OT_PLATFORM}")
+endif()
+
+if(OT_CONFIG)
+    list(APPEND OT_PRIVATE_DEFINES "OPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"${OT_CONFIG}\"")
+    message(STATUS "Project core config: \"${OT_CONFIG}\"")
 endif()
 
 list(APPEND OT_PRIVATE_DEFINES ${OT_PLATFORM_DEFINES})

--- a/examples/platforms/cc2538/CMakeLists.txt
+++ b/examples/platforms/cc2538/CMakeLists.txt
@@ -28,12 +28,18 @@
 
 set(OT_PLATFORM_LIB "openthread-cc2538" PARENT_SCOPE)
 
+if(NOT OT_CONFIG)
+    set(OT_CONFIG "openthread-core-cc2538-config.h")
+    set(OT_CONFIG ${OT_CONFIG} PARENT_SCOPE)
+endif()
+
 list(APPEND OT_PLATFORM_DEFINES
-    "OPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"openthread-core-cc2538-config.h\""
     "OPENTHREAD_CORE_CONFIG_PLATFORM_CHECK_FILE=\"openthread-core-cc2538-config-check.h\""
     "OPENTHREAD_CONFIG_NCP_UART_ENABLE=1"
 )
 set(OT_PLATFORM_DEFINES ${OT_PLATFORM_DEFINES} PARENT_SCOPE)
+
+list(APPEND OT_PLATFORM_DEFINES "OPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"${OT_CONFIG}\"")
 
 add_library(openthread-cc2538
     alarm.c

--- a/examples/platforms/posix/CMakeLists.txt
+++ b/examples/platforms/posix/CMakeLists.txt
@@ -28,13 +28,19 @@
 
 set(OT_PLATFORM_LIB "openthread-posix" PARENT_SCOPE)
 
+if(NOT OT_CONFIG)
+    set(OT_CONFIG "openthread-core-posix-config.h")
+    set(OT_CONFIG ${OT_CONFIG} PARENT_SCOPE)
+endif()
+
 list(APPEND OT_PLATFORM_DEFINES
-    "OPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"openthread-core-posix-config.h\""
     "OPENTHREAD_EXAMPLES_POSIX=1"
     "OPENTHREAD_POSIX=1"
     "OPENTHREAD_CONFIG_NCP_UART_ENABLE=1"
 )
 set(OT_PLATFORM_DEFINES ${OT_PLATFORM_DEFINES} PARENT_SCOPE)
+
+list(APPEND OT_PLATFORM_DEFINES "OPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"${OT_CONFIG}\"")
 
 add_library(openthread-posix
     alarm.c

--- a/tests/toranj/build.sh
+++ b/tests/toranj/build.sh
@@ -39,6 +39,7 @@ display_usage() {
     echo "        ncp        : Build OpenThread NCP FTD mode with POSIX platform"
     echo "        rcp        : Build OpenThread RCP (NCP in radio mode) with POSIX platform"
     echo "        posix-app  : Build OpenThread POSIX App NCP"
+    echo "        cmake      : Configure and build OpenThread using cmake/ninja (RCP and NCP) only"
     echo ""
     echo "Options:"
     echo "        -c/--enable-coverage  Enable code coverage"
@@ -129,6 +130,14 @@ case ${build_config} in
             --enable-posix-app                  \
             $configure_options || die
         make -j 8 || die
+        ;;
+
+    cmake)
+        echo "===================================================================================================="
+        echo "Building OpenThread (NCP/CLI for FTD/MTD/RCP mode) with POSIX platform using cmake"
+        echo "===================================================================================================="
+        cmake -GNinja -DOT_PLATFORM=posix -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config.h . || die
+        ninja || die
         ;;
 
     *)


### PR DESCRIPTION
This PR contains two commits:

**[cmake] add OT_CONFIG to specify project core config header file (#4374)**

This commit adds new parameter `OT_CONFIG` to main `CMakeLists.txt`
file. This parameter allows users to specify a project-specific core
config header file (mapped to `OPENTHREAD_PROJECT_CORE_CONFIG_FILE`)
during build configuration.
    
The default value for this parameter is "none". When not specified
(value is "none"), a platform cmake file may choose to change
`OT_COFNIG` variable to provide its own core config header file. This
commit updates platform 'posix' and 'cc2548' cmake files to provide
platform specific header files when `OT_CONFIG` is not specified by
user.

------

**[toranj] add cmake option to build script (#4374)**
    
This commit adds a `cmake` option to the `build.sh` to configure and
build OpenThread NCP/CLI for FTD/MTD/RCP modes using cmake/ninja.
