### PR TITLE
[posix-app] remove dependency on OPENTHREAD_TARGET_DEFINES

### DIFF
--- a/src/posix/Makefile.am
+++ b/src/posix/Makefile.am
@@ -51,7 +51,6 @@ CPPFLAGS_COMMON                                                        = \
     -I$(top_srcdir)/src/core                                             \
     -I$(top_srcdir)/src/posix/platform                                   \
     -D_GNU_SOURCE                                                        \
-    $(OPENTHREAD_TARGET_DEFINES)                                         \
     $(NULL)
 
 LIBTOOLFLAGS_COMMON = --preserve-dup-deps

--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -36,7 +36,6 @@ libopenthread_posix_a_CPPFLAGS            = \
     -I$(top_srcdir)/src/core                \
     -I$(top_srcdir)/src/posix/platform      \
     -D_GNU_SOURCE                           \
-    $(OPENTHREAD_TARGET_DEFINES)            \
     $(NULL)
 
 libopenthread_posix_a_SOURCES             = \

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -40,7 +40,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #if OPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE
-#ifdef OPENTHREAD_TARGET_DARWIN
+#ifdef __APPLE__
 #include <util.h>
 #else
 #include <pty.h>


### PR DESCRIPTION
This PR removes from posix-app dependency on `$(OPENTHREAD_TARGET_DEFINES)` which is defined by autoconf only.