### PR TITLE
[posix-host] add spinel_interface to extend transport layers

### DIFF
--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -57,6 +57,7 @@ noinst_HEADERS                            = \
     platform-posix.h                        \
     hdlc_interface.hpp                      \
     radio_spinel.hpp                        \
+    spinel_interface.hpp                    \
     $(NULL)
 
 openthread_HEADERS                        = \

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -123,10 +123,10 @@ namespace ot {
 namespace PosixApp {
 
 HdlcInterface::HdlcInterface(Callbacks &aCallbacks)
-    : mCallbacks(aCallbacks)
+    : SpinelInterface()
+    , mCallbacks(aCallbacks)
     , mSockFd(-1)
-    , mRxFrameBuffer()
-    , mHdlcDecoder(mRxFrameBuffer, HandleHdlcFrame, this)
+    , mHdlcDecoder(GetRxFrameBuffer(), HandleHdlcFrame, this)
 {
 }
 
@@ -612,11 +612,11 @@ void HdlcInterface::HandleHdlcFrame(otError aError)
 {
     if (aError == OT_ERROR_NONE)
     {
-        mCallbacks.HandleReceivedFrame(*this);
+        mCallbacks.HandleReceivedFrame();
     }
     else
     {
-        mRxFrameBuffer.DiscardFrame();
+        GetRxFrameBuffer().DiscardFrame();
         otLogWarnPlat("Error decoding hdlc frame: %s", otThreadErrorToString(aError));
     }
 }

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -126,7 +126,7 @@ HdlcInterface::HdlcInterface(Callbacks &aCallbacks)
     : SpinelInterface()
     , mCallbacks(aCallbacks)
     , mSockFd(-1)
-    , mHdlcDecoder(GetRxFrameBuffer(), HandleHdlcFrame, this)
+    , mHdlcDecoder(mRxFrameBuffer, HandleHdlcFrame, this)
 {
 }
 
@@ -616,7 +616,7 @@ void HdlcInterface::HandleHdlcFrame(otError aError)
     }
     else
     {
-        GetRxFrameBuffer().DiscardFrame();
+        mRxFrameBuffer.DiscardFrame();
         otLogWarnPlat("Error decoding hdlc frame: %s", otThreadErrorToString(aError));
     }
 }

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -35,6 +35,7 @@
 #define POSIX_APP_HDLC_INTERFACE_HPP_
 
 #include "platform-config.h"
+#include "spinel_interface.hpp"
 
 #include "ncp/hdlc.hpp"
 
@@ -45,45 +46,9 @@ namespace PosixApp {
  * This class defines an HDLC interface to the Radio Co-processor (RCP)
  *
  */
-class HdlcInterface
+class HdlcInterface : public SpinelInterface
 {
 public:
-    enum
-    {
-        kMaxFrameSize = 2048, ///< Maximum frame size (number of bytes).
-        kMaxWaitTime  = 2000, ///< Maximum wait time in Milliseconds for socket to become writable (see `SendFrame`).
-    };
-
-    /**
-     * This type defines a receive frame buffer to store received (and decoded) frame(s).
-     *
-     * @note The receive frame buffer is an `Hdlc::MultiFrameBuffer` and therefore it is capable of storing multiple
-     * frames in a FIFO queue manner.
-     *
-     */
-    typedef Hdlc::MultiFrameBuffer<kMaxFrameSize> RxFrameBuffer;
-
-    /**
-     * This class defines the callbacks provided by `HdlcInterfac` to its owner/user.
-     *
-     */
-    class Callbacks
-    {
-    public:
-        /**
-         * This callback is invoked to notify owner/user of `HdlcInterface` of a received (and decoded) frame.
-         *
-         * The newly received frame is available in `RxFrameBuffer` from `HdlcInterface::GetRxFrameBuffer()`. The
-         * user can read and process the frame. The callback is expected to either discard the new frame using
-         * `RxFrameBuffer::DiscardFrame()` or save the frame using `RxFrameBuffer::SaveFrame()` to be read and
-         * processed later.
-         *
-         * @param[in] aHdlcInterface    A reference to the `HdlcInterface` object.
-         *
-         */
-        void HandleReceivedFrame(HdlcInterface &aHdlcInterface);
-    };
-
     /**
      * This constructor initializes the object.
      *
@@ -101,7 +66,7 @@ public:
     /**
      * This method initializes the interface to the Radio Co-processor (RCP)
      *
-     * @note This method should be called before reading and sending frames to the interface.
+     * @note This method should be called before reading and sending spinel frames to the interface.
      *
      * @param[in]  aPlatformConfig  Platform configuration structure.
      *
@@ -119,31 +84,15 @@ public:
     void Deinit(void);
 
     /**
-     * This method gets the `RxFrameBuffer`.
-     *
-     * The receive frame buffer is an `Hdlc::MultiFrameBuffer` and therefore it is capable of storing multiple
-     * frames in a FIFO queue manner. The `RxFrameBuffer` contains the decoded received frames.
-     *
-     * Wen during `Read()` the `Callbacks::HandleReceivedFrame()` is invoked, the newly received decoded frame is
-     * available in the receive frame buffer. The callback is expected to either process and then discard the frame
-     * (using `RxFrameBuffer::DiscardFrame()` method) or save the frame (using `RxFrameBuffer::SaveFrame()` so that
-     * it can be read later.
-     *
-     * @returns A reference to receive frame buffer containing newly received frame or previously saved frames.
-     *
-     */
-    RxFrameBuffer &GetRxFrameBuffer(void) { return mRxFrameBuffer; }
-
-    /**
-     * This method encodes and sends a frame to Radio Co-processor (RCP) over the socket.
+     * This method encodes and sends a spinel frame to Radio Co-processor (RCP) over the socket.
      *
      * This is blocking call, i.e., if the socket is not writable, this method waits for it to become writable for
      * up to `kMaxWaitTime` interval.
      *
-     * @param[in] aFrame     A pointer to buffer containing the frame to send.
+     * @param[in] aFrame     A pointer to buffer containing the spinel frame to send.
      * @param[in] aLength    The length (number of bytes) in the frame.
      *
-     * @retval OT_ERROR_NONE     Successfully encoded and sent the frame.
+     * @retval OT_ERROR_NONE     Successfully encoded and sent the spinel frame.
      * @retval OT_ERROR_NO_BUFS  Insufficient buffer space available to encode the frame.
      * @retval OT_ERROR_FAILED   Failed to send due to socket not becoming writable within `kMaxWaitTime`.
      *
@@ -252,8 +201,6 @@ private:
 
     Callbacks &   mCallbacks;
     int           mSockFd;
-    bool          mIsDecoding;
-    RxFrameBuffer mRxFrameBuffer;
     Hdlc::Decoder mHdlcDecoder;
 };
 

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -37,13 +37,14 @@
 #include <openthread/platform/radio.h>
 
 #include "hdlc_interface.hpp"
+#include "spinel_interface.hpp"
 #include "ncp/ncp_config.h"
 #include "ncp/spinel.h"
 
 namespace ot {
 namespace PosixApp {
 
-class RadioSpinel : public HdlcInterface::Callbacks
+class RadioSpinel : public SpinelInterface::Callbacks
 {
 public:
     /**
@@ -511,11 +512,12 @@ public:
     uint32_t GetRadioChannelMask(bool aPreferred);
 
     /**
-     *  This method processes a received Spinel frame.
+     * This method processes a received Spinel frame.
      *
-     * @param[in] aFrameBuffer The frame buffer constaining the newly received frame.
+     * The newly received frame is available in `RxFrameBuffer` from `SpinelInterface::GetRxFrameBuffer()`.
+     *
      */
-    void HandleSpinelFrame(HdlcInterface::RxFrameBuffer &aFrameBuffer);
+    void HandleReceivedFrame(void);
 
 private:
     enum

--- a/src/posix/platform/spinel_interface.hpp
+++ b/src/posix/platform/spinel_interface.hpp
@@ -170,7 +170,7 @@ public:
      */
     virtual void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet) = 0;
 
-private:
+protected:
     RxFrameBuffer mRxFrameBuffer;
 };
 

--- a/src/posix/platform/spinel_interface.hpp
+++ b/src/posix/platform/spinel_interface.hpp
@@ -1,0 +1,180 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for the spinel interface to Radio Co-processor (RCP)
+ *
+ */
+
+#ifndef POSIX_APP_SPINEL_INTERFACE_HPP_
+#define POSIX_APP_SPINEL_INTERFACE_HPP_
+
+#include "ncp/hdlc.hpp"
+
+namespace ot {
+namespace PosixApp {
+
+class SpinelInterface
+{
+public:
+    enum
+    {
+        kMaxWaitTime  = 2000, ///< Maximum wait time in Milliseconds for socket to become writable (see `SendFrame`).
+        kMaxFrameSize = 2048, ///< Maximum frame size (number of bytes).
+    };
+
+    /**
+     * This type defines a receive frame buffer to store received spinel frame(s).
+     *
+     * @note The receive frame buffer is an `Hdlc::MultiFrameBuffer` and therefore it is capable of storing multiple
+     * frames in a FIFO queue manner.
+     *
+     */
+    typedef Hdlc::MultiFrameBuffer<kMaxFrameSize> RxFrameBuffer;
+
+    /**
+     * This class defines the callbacks provided by `SpinelInterface` to its owner/user.
+     *
+     */
+    class Callbacks
+    {
+    public:
+        /**
+         * This callback is invoked to notify owner/user of `SpinelInterface` of a received spinel frame.
+         *
+         * The newly received frame is available in `RxFrameBuffer` from `SpinelInterface::GetRxFrameBuffer()`.
+         * User can read and process the frame. The callback is expected to either discard the new frame using
+         * `RxFrameBuffer::DiscardFrame()` or save the frame using `RxFrameBuffer::SaveFrame()` to be read and
+         * processed later.
+         *
+         */
+        virtual void HandleReceivedFrame(void) = 0;
+    };
+
+    /**
+     * This constructor initializes the object.
+     *
+     */
+    SpinelInterface()
+        : mRxFrameBuffer()
+    {
+    }
+
+    /**
+     * This method gets the `RxFrameBuffer`.
+     *
+     * The receive frame buffer is an `Hdlc::MultiFrameBuffer` and therefore it is capable of storing multiple
+     * spinel frames in a FIFO queue manner. The `RxFrameBuffer` contains the received spinel frames.
+     *
+     * When during `Process()` or `WaitForFrame()` the `Callbacks::HandleReceivedFrame()` is invoked, the newly
+     * received spinel frame is available in the receive frame buffer. The callback is expected to either process
+     * and then discard the frame (using `RxFrameBuffer::DiscardFrame()` method) or save the frame
+     * (using `RxFrameBuffer::SaveFrame()` so that it can be read later.
+     *
+     * @returns A reference to receive frame buffer containing newly received spinel frame or previously saved spinel
+     *          frames.
+     *
+     */
+    RxFrameBuffer &GetRxFrameBuffer(void) { return mRxFrameBuffer; }
+
+    /**
+     * This method initializes the interface to the Radio Co-processor (RCP)
+     *
+     * @note This method should be called before reading and sending spinel frames to the interface.
+     *
+     * @param[in]   aConfig  Parameters to be given to the device or executable.
+     *
+     * @retval OT_ERROR_NONE          The interface is initialized successfully
+     * @retval OT_ERROR_ALREADY       The interface is already initialized.
+     * @retval OT_ERROR_INVALID_ARGS  The device or executable cannot be found or failed to open/run.
+     *
+     */
+    virtual otError Init(const char *aRadioFile, const char *aRadioConfig) = 0;
+
+    /**
+     * This method deinitializes the interface to the Radio Co-processor (RCP).
+     *
+     */
+    virtual void Deinit(void) = 0;
+
+    /**
+     * This method encodes and sends a spinel frame to Radio Co-processor (RCP) over the socket.
+     *
+     * This is blocking call, i.e., if the socket is not writable, this method waits for it to become writable for
+     * up to `kMaxWaitTime` interval.
+     *
+     * @param[in] aFrame     A pointer to buffer containing the spinel frame to send.
+     * @param[in] aLength    The length (number of bytes) in the frame.
+     *
+     * @retval OT_ERROR_NONE     Successfully encoded and sent the spinel frame.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffer space available to encode the frame.
+     * @retval OT_ERROR_FAILED   Failed to send due to socket not becoming writable within `kMaxWaitTime`.
+     *
+     */
+    virtual otError SendFrame(const uint8_t *aFrame, uint16_t aLength) = 0;
+
+    /**
+     * This method waits for receiving part or all of spinel frame within specified interval.
+     *
+     * @param[in]  aTimeout  A reference to the timeout.
+     *
+     * @retval OT_ERROR_NONE             Part or all of spinel frame is received.
+     * @retval OT_ERROR_RESPONSE_TIMEOUT No spinel frame is received within @p aTimeout.
+     *
+     */
+    virtual otError WaitForFrame(struct timeval &aTimeout) = 0;
+
+    /**
+     * This method updates the file descriptor sets with file descriptors used by the radio driver.
+     *
+     * @param[inout]  aReadFdSet   A reference to the read file descriptors.
+     * @param[inout]  aWriteFdSet  A reference to the write file descriptors.
+     * @param[inout]  aMaxFd       A reference to the max file descriptor.
+     * @param[inout]  aTimeout     A reference to the timeout.
+     *
+     */
+    virtual void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, int &aMaxFd, struct timeval &aTimeout) = 0;
+
+    /**
+     * This method performs radio driver processing.
+     *
+     * @param[in]   aReadFdSet      A reference to the read file descriptors.
+     * @param[in]   aWriteFdSet     A reference to the write file descriptors.
+     *
+     */
+    virtual void Process(const fd_set &aReadFdSet, const fd_set &aWriteFdSet) = 0;
+
+private:
+    RxFrameBuffer mRxFrameBuffer;
+};
+
+} // namespace PosixApp
+} // namespace ot
+
+#endif // POSIX_APP_SPINEL_INTERFACE_HPP_

--- a/src/posix/platform/spinel_interface.hpp
+++ b/src/posix/platform/spinel_interface.hpp
@@ -108,14 +108,14 @@ public:
      *
      * @note This method should be called before reading and sending spinel frames to the interface.
      *
-     * @param[in]   aConfig  Parameters to be given to the device or executable.
+     * @param[in]  aPlatformConfig  Platform configuration structure.
      *
      * @retval OT_ERROR_NONE          The interface is initialized successfully
      * @retval OT_ERROR_ALREADY       The interface is already initialized.
      * @retval OT_ERROR_INVALID_ARGS  The device or executable cannot be found or failed to open/run.
      *
      */
-    virtual otError Init(const char *aRadioFile, const char *aRadioConfig) = 0;
+    virtual otError Init(const otPlatformConfig &aPlatformConfig) = 0;
 
     /**
      * This method deinitializes the interface to the Radio Co-processor (RCP).


### PR DESCRIPTION
This commit abstracts the API between radio_spinel and hdlc_interface into a common interface `spinel_interface`.  Users can use this interface to add new transport layers to send/receive spinel frames.