### PR TITLE
[netif] allow addition of external multicast addresses in any state

### DIFF
--- a/src/core/common/linked_list.hpp
+++ b/src/core/common/linked_list.hpp
@@ -303,6 +303,72 @@ public:
         return error;
     }
 
+    /**
+     * This method searches within the linked list to find an entry and if found returns a pointer to previous entry.
+     *
+     * @param[in]  aEntry      A reference to an entry to find.
+     * @param[out] aPrevEntry  A pointer to output previous entry on success (when @p aEntry is found is the list).
+     *                         @p aPrevEntry is set to NULL if the @p aEntry is head of the list. Otherwise it
+     *                         is updated to point to previous entry before @p aEntry in the list.
+     *
+     * @retval OT_ERROR_NONE       The entry was found in the list and @p aPrevEntry was updated successfully.
+     * @retval OT_ERROR_NOT_FOUND  The entry was not found in the list.
+     *
+     */
+    otError Find(const Type &aEntry, Type *&aPrevEntry) const
+    {
+        otError error = OT_ERROR_NOT_FOUND;
+
+        if (mHead == &aEntry)
+        {
+            aPrevEntry = NULL;
+            error      = OT_ERROR_NONE;
+        }
+        else
+        {
+            for (Type *cur = mHead; cur->GetNext() != NULL; cur = cur->GetNext())
+            {
+                if (cur->GetNext() == &aEntry)
+                {
+                    aPrevEntry = cur;
+                    error      = OT_ERROR_NONE;
+                    break;
+                }
+            }
+        }
+
+        return error;
+    }
+
+    /**
+     * This method returns the tail of the linked list (i.e., the last entry in the list).
+     *
+     * @returns A pointer to tail entry in the linked list or NULL if list is empty.
+     *
+     */
+    const Type *GetTail(void) const
+    {
+        const Type *tail = mHead;
+
+        if (tail != NULL)
+        {
+            while (tail->GetNext() != NULL)
+            {
+                tail = tail->GetNext();
+            }
+        }
+
+        return tail;
+    }
+
+    /**
+     * This method returns the tail of the linked list (i.e., the last entry in the list).
+     *
+     * @returns A pointer to tail entry in the linked list or NULL if list is empty.
+     *
+     */
+    Type *GetTail(void) { return const_cast<Type *>(const_cast<const LinkedList<Type> *>(this)->GetTail()); }
+
 private:
     Type *mHead;
 };

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -119,79 +119,144 @@ exit:
     return rval;
 }
 
-void Netif::SubscribeAllNodesMulticast(void)
+otError Netif::SubscribeAllNodesMulticast(void)
 {
-    assert(mMulticastAddresses.IsEmpty());
+    otError                error = OT_ERROR_NONE;
+    NetifMulticastAddress *tail;
+    NetifMulticastAddress &linkLocalAllNodesAddress =
+        static_cast<NetifMulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
 
-    mMulticastAddresses.SetHead(static_cast<NetifMulticastAddress *>(
-        const_cast<otNetifMulticastAddress *>(&kLinkLocalAllNodesMulticastAddress)));
+    VerifyOrExit(!mMulticastAddresses.Contains(linkLocalAllNodesAddress), error = OT_ERROR_ALREADY);
 
-    if (mAddressCallback != NULL)
+    // Append the fixed chain of three multicast addresses to the
+    // tail of the list:
+    //
+    //    LinkLocalAll -> RealmLocalAll -> RealmLocalAllMpl.
+
+    tail = mMulticastAddresses.GetTail();
+
+    if (tail == NULL)
     {
-        for (const otNetifMulticastAddress *entry = &kLinkLocalAllNodesMulticastAddress; entry != NULL;
-             entry                                = entry->mNext)
-        {
-            mAddressCallback(&entry->mAddress, kMulticastPrefixLength, true, mAddressCallbackContext);
-        }
+        mMulticastAddresses.SetHead(&linkLocalAllNodesAddress);
+    }
+    else
+    {
+        tail->SetNext(&linkLocalAllNodesAddress);
     }
 
     Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_SUBSCRIBED);
+
+    VerifyOrExit(mAddressCallback != NULL);
+
+    for (const NetifMulticastAddress *entry = &linkLocalAllNodesAddress; entry; entry = entry->GetNext())
+    {
+        mAddressCallback(&entry->GetAddress(), kMulticastPrefixLength, /* IsAdded */ true, mAddressCallbackContext);
+    }
+
+exit:
+    return error;
 }
 
-void Netif::UnsubscribeAllNodesMulticast(void)
+otError Netif::UnsubscribeAllNodesMulticast(void)
 {
-    assert(mMulticastAddresses.IsEmpty() || mMulticastAddresses.GetHead() == &kLinkLocalAllNodesMulticastAddress);
+    otError                      error = OT_ERROR_NONE;
+    NetifMulticastAddress *      prev;
+    const NetifMulticastAddress &linkLocalAllNodesAddress =
+        static_cast<NetifMulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
 
-    mMulticastAddresses.SetHead(NULL);
+    // The tail of multicast address linked list contains the
+    // fixed addresses. Search if LinkLocalAll is present
+    // in the list and find entry before it.
+    //
+    //    LinkLocalAll -> RealmLocalAll -> RealmLocalAllMpl.
 
-    if (mAddressCallback != NULL)
+    SuccessOrExit(error = mMulticastAddresses.Find(linkLocalAllNodesAddress, prev));
+
+    // This method MUST be called after `UnsubscribeAllRoutersMulticast().
+    // Verify this by checking the chain at the end of the list only
+    // contains three entries and not the five fixed addresses (check that
+    // `prev` entry before `LinkLocalAll` is not `RealmLocalRouters`):
+    //
+    //    LinkLocalAllRouters -> RealmLocalAllRouters -> LinkLocalAll
+    //         -> RealmLocalAll -> RealmLocalAllMpl.
+
+    assert(prev != static_cast<NetifMulticastAddress *>(
+                       const_cast<otNetifMulticastAddress *>(&kRealmLocalAllRoutersMulticastAddress)));
+
+    if (prev == NULL)
     {
-        for (const otNetifMulticastAddress *entry = &kLinkLocalAllNodesMulticastAddress; entry != NULL;
-             entry                                = entry->mNext)
-        {
-            mAddressCallback(&entry->mAddress, kMulticastPrefixLength, false, mAddressCallbackContext);
-        }
+        mMulticastAddresses.Clear();
+    }
+    else
+    {
+        prev->SetNext(NULL);
     }
 
     Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED);
+
+    VerifyOrExit(mAddressCallback != NULL);
+
+    for (const NetifMulticastAddress *entry = &linkLocalAllNodesAddress; entry; entry = entry->GetNext())
+    {
+        mAddressCallback(&entry->GetAddress(), kMulticastPrefixLength, /* IsAdded */ false, mAddressCallbackContext);
+    }
+
+exit:
+    return error;
 }
 
 otError Netif::SubscribeAllRoutersMulticast(void)
 {
-    otError error = OT_ERROR_NONE;
+    otError                error = OT_ERROR_NONE;
+    NetifMulticastAddress *prev;
+    NetifMulticastAddress &linkLocalAllRoutersAddress = static_cast<NetifMulticastAddress &>(
+        const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
+    NetifMulticastAddress &linkLocalAllNodesAddress =
+        static_cast<NetifMulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
+    NetifMulticastAddress &realmLocalAllRoutersAddress = static_cast<NetifMulticastAddress &>(
+        const_cast<otNetifMulticastAddress &>(kRealmLocalAllRoutersMulticastAddress));
 
-    if (mMulticastAddresses.GetHead() == &kLinkLocalAllNodesMulticastAddress)
+    error = mMulticastAddresses.Find(linkLocalAllNodesAddress, prev);
+
+    // This method MUST be called after `SubscribeAllNodesMulticast()`
+    // Ensure that the `LinkLocalAll` was found on the list.
+
+    assert(error == OT_ERROR_NONE);
+
+    // The tail of multicast address linked list contains the
+    // fixed addresses. We either have a chain of five addresses
+    //
+    //    LinkLocalAllRouters -> RealmLocalAllRouters ->
+    //        LinkLocalAll -> RealmLocalAll -> RealmLocalAllMpl.
+    //
+    // or just the last three addresses
+    //
+    //    LinkLocalAll -> RealmLocalAll -> RealmLocalAllMpl.
+    //
+    // If the previous entry behind `LinkLocalAll` is
+    // `RealmLocalAllRouters` then all five addresses are on
+    // the list already.
+
+    VerifyOrExit(prev != &realmLocalAllRoutersAddress, error = OT_ERROR_ALREADY);
+
+    if (prev == NULL)
     {
-        mMulticastAddresses.SetHead(static_cast<NetifMulticastAddress *>(
-            const_cast<otNetifMulticastAddress *>(&kLinkLocalAllRoutersMulticastAddress)));
+        mMulticastAddresses.SetHead(&linkLocalAllRoutersAddress);
     }
     else
     {
-        for (NetifMulticastAddress *cur = mMulticastAddresses.GetHead(); cur; cur = cur->GetNext())
-        {
-            if (cur == &kLinkLocalAllRoutersMulticastAddress)
-            {
-                ExitNow(error = OT_ERROR_ALREADY);
-            }
-
-            if (cur->mNext == &kLinkLocalAllNodesMulticastAddress)
-            {
-                cur->mNext = &kLinkLocalAllRoutersMulticastAddress;
-                break;
-            }
-        }
-    }
-
-    if (mAddressCallback != NULL)
-    {
-        for (const otNetifMulticastAddress *entry                = &kLinkLocalAllRoutersMulticastAddress;
-             entry != &kLinkLocalAllNodesMulticastAddress; entry = entry->mNext)
-        {
-            mAddressCallback(&entry->mAddress, kMulticastPrefixLength, true, mAddressCallbackContext);
-        }
+        prev->SetNext(&linkLocalAllRoutersAddress);
     }
 
     Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_SUBSCRIBED);
+
+    VerifyOrExit(mAddressCallback != NULL);
+
+    for (const NetifMulticastAddress *entry = &linkLocalAllRoutersAddress; entry != &linkLocalAllNodesAddress;
+         entry                              = entry->GetNext())
+    {
+        mAddressCallback(&entry->GetAddress(), kMulticastPrefixLength, /* IsAdded */ true, mAddressCallbackContext);
+    }
 
 exit:
     return error;
@@ -199,42 +264,45 @@ exit:
 
 otError Netif::UnsubscribeAllRoutersMulticast(void)
 {
-    otError error = OT_ERROR_NONE;
+    otError                error;
+    NetifMulticastAddress *prev;
+    NetifMulticastAddress &linkLocalAllRoutersAddress = static_cast<NetifMulticastAddress &>(
+        const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
+    NetifMulticastAddress &linkLocalAllNodesAddress =
+        static_cast<NetifMulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
 
-    if (mMulticastAddresses.GetHead() == &kLinkLocalAllRoutersMulticastAddress)
+    // The tail of multicast address linked list contains the
+    // fixed addresses. We check for the chain of five addresses:
+    //
+    //    LinkLocalAllRouters -> RealmLocalAllRouters ->
+    //        LinkLocalAll -> RealmLocalAll -> RealmLocalAllMpl.
+    //
+    // If found, we then replace the entry behind `LinkLocalAllRouters`
+    // to point to `LinkLocalAll` instead (so that tail contains the
+    // three fixed addresses at end of the chain).
+
+    SuccessOrExit(error = mMulticastAddresses.Find(linkLocalAllRoutersAddress, prev));
+
+    if (prev == NULL)
     {
-        mMulticastAddresses.SetHead(static_cast<NetifMulticastAddress *>(
-            const_cast<otNetifMulticastAddress *>(&kLinkLocalAllNodesMulticastAddress)));
-        ExitNow();
+        mMulticastAddresses.SetHead(&linkLocalAllNodesAddress);
+    }
+    else
+    {
+        prev->SetNext(&linkLocalAllNodesAddress);
     }
 
-    for (NetifMulticastAddress *cur = mMulticastAddresses.GetHead(); cur; cur = cur->GetNext())
-    {
-        if (cur->mNext == &kLinkLocalAllRoutersMulticastAddress)
-        {
-            cur->mNext = &kLinkLocalAllNodesMulticastAddress;
-            ExitNow();
-        }
-    }
+    Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED);
 
-    error = OT_ERROR_NOT_FOUND;
+    VerifyOrExit(mAddressCallback != NULL);
+
+    for (const NetifMulticastAddress *entry = &linkLocalAllRoutersAddress; entry != &linkLocalAllNodesAddress;
+         entry                              = entry->GetNext())
+    {
+        mAddressCallback(&entry->GetAddress(), kMulticastPrefixLength, /* IsAdded */ false, mAddressCallbackContext);
+    }
 
 exit:
-
-    if (error != OT_ERROR_NOT_FOUND)
-    {
-        if (mAddressCallback != NULL)
-        {
-            for (const otNetifMulticastAddress *entry                = &kLinkLocalAllRoutersMulticastAddress;
-                 entry != &kLinkLocalAllNodesMulticastAddress; entry = entry->mNext)
-            {
-                mAddressCallback(&entry->mAddress, kMulticastPrefixLength, false, mAddressCallbackContext);
-            }
-        }
-
-        Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED);
-    }
-
     return error;
 }
 
@@ -244,12 +312,10 @@ otError Netif::SubscribeMulticast(NetifMulticastAddress &aAddress)
 
     SuccessOrExit(error = mMulticastAddresses.Add(aAddress));
 
-    if (mAddressCallback != NULL)
-    {
-        mAddressCallback(&aAddress.mAddress, kMulticastPrefixLength, true, mAddressCallbackContext);
-    }
-
     Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_SUBSCRIBED);
+
+    VerifyOrExit(mAddressCallback != NULL);
+    mAddressCallback(&aAddress.mAddress, kMulticastPrefixLength, /* IsAdded */ true, mAddressCallbackContext);
 
 exit:
     return error;
@@ -261,12 +327,10 @@ otError Netif::UnsubscribeMulticast(const NetifMulticastAddress &aAddress)
 
     SuccessOrExit(error = mMulticastAddresses.Remove(aAddress));
 
-    if (mAddressCallback != NULL)
-    {
-        mAddressCallback(&aAddress.mAddress, kMulticastPrefixLength, false, mAddressCallbackContext);
-    }
-
     Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED);
+
+    VerifyOrExit(mAddressCallback != NULL);
+    mAddressCallback(&aAddress.mAddress, kMulticastPrefixLength, /* IsAdded */ false, mAddressCallbackContext);
 
 exit:
     return error;
@@ -301,13 +365,19 @@ otError Netif::SubscribeExternalMulticast(const Address &aAddress)
 {
     otError                error = OT_ERROR_NONE;
     NetifMulticastAddress *entry;
+    NetifMulticastAddress &linkLocalAllRoutersAddress = static_cast<NetifMulticastAddress &>(
+        const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
 
-    VerifyOrExit(!mMulticastAddresses.IsEmpty(), error = OT_ERROR_INVALID_STATE);
+    // Check that the address is not one of the fixed addresses:
+    // LinkLocalAllRouters -> RealmLocalAllRouters -> LinkLocalAllNodes
+    // -> RealmLocalAllNodes -> RealmLocalAllMpl.
 
-    if (IsMulticastSubscribed(aAddress))
+    for (const NetifMulticastAddress *cur = &linkLocalAllRoutersAddress; cur; cur = cur->GetNext())
     {
-        ExitNow(error = OT_ERROR_ALREADY);
+        VerifyOrExit(cur->GetAddress() != aAddress, error = OT_ERROR_INVALID_ARGS);
     }
+
+    VerifyOrExit(!IsMulticastSubscribed(aAddress), error = OT_ERROR_ALREADY);
 
     // Find an available entry in the `mExtMulticastAddresses` array.
     for (entry = &mExtMulticastAddresses[0]; entry < OT_ARRAY_END(mExtMulticastAddresses); entry++)
@@ -321,7 +391,7 @@ otError Netif::SubscribeExternalMulticast(const Address &aAddress)
 
     VerifyOrExit(entry < OT_ARRAY_END(mExtMulticastAddresses), error = OT_ERROR_NO_BUFS);
 
-    // Copy the address into the available entry and add it to linked-list.
+    // Copy the address into the available entry and add it to the list.
     entry->mAddress = aAddress;
     mMulticastAddresses.Push(*entry);
     Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_SUBSCRIBED);
@@ -394,12 +464,10 @@ otError Netif::AddUnicastAddress(NetifUnicastAddress &aAddress)
 
     SuccessOrExit(error = mUnicastAddresses.Add(aAddress));
 
-    if (mAddressCallback != NULL)
-    {
-        mAddressCallback(&aAddress.mAddress, aAddress.mPrefixLength, true, mAddressCallbackContext);
-    }
-
     Get<Notifier>().Signal(aAddress.mRloc ? OT_CHANGED_THREAD_RLOC_ADDED : OT_CHANGED_IP6_ADDRESS_ADDED);
+
+    VerifyOrExit(mAddressCallback != NULL);
+    mAddressCallback(&aAddress.mAddress, aAddress.mPrefixLength, /* IsAdded */ true, mAddressCallbackContext);
 
 exit:
     return error;
@@ -411,12 +479,10 @@ otError Netif::RemoveUnicastAddress(const NetifUnicastAddress &aAddress)
 
     SuccessOrExit(error = mUnicastAddresses.Remove(aAddress));
 
-    if (mAddressCallback != NULL)
-    {
-        mAddressCallback(&aAddress.mAddress, aAddress.mPrefixLength, false, mAddressCallbackContext);
-    }
-
     Get<Notifier>().Signal(aAddress.mRloc ? OT_CHANGED_THREAD_RLOC_REMOVED : OT_CHANGED_IP6_ADDRESS_REMOVED);
+
+    VerifyOrExit(mAddressCallback != NULL);
+    mAddressCallback(&aAddress.mAddress, aAddress.mPrefixLength, /* IsAdded */ false, mAddressCallbackContext);
 
 exit:
     return error;

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -262,9 +262,11 @@ public:
     bool IsMulticastSubscribed(const Address &aAddress) const;
 
     /**
-     * This method subscribes the network interface to the link-local and realm-local all routers address.
+     * This method subscribes the network interface to the link-local and realm-local all routers addresses.
      *
-     * @retval OT_ERROR_NONE     Successfully subscribed to the link-local and realm-local all routers address
+     * @note This method MUST be called after `SubscribeAllNodesMulticast()` or its behavior is undefined.
+     *
+     * @retval OT_ERROR_NONE     Successfully subscribed to the link-local and realm-local all routers addresses.
      * @retval OT_ERROR_ALREADY  The multicast addresses are already subscribed.
      *
      */
@@ -331,7 +333,6 @@ public:
      * @retval OT_ERROR_NONE           Successfully subscribed to @p aAddress.
      * @retval OT_ERROR_ALREADY        The multicast address is already subscribed.
      * @retval OT_ERROR_INVALID_ARGS   The address indicated by @p aAddress is an internal multicast address.
-     * @retval OT_ERROR_INVALID_STATE  The Network Interface is not up.
      * @retval OT_ERROR_NO_BUFS        The maximum number of allowed external multicast addresses are already added.
      *
      */
@@ -373,18 +374,26 @@ public:
 
 protected:
     /**
-     * This method subscribes the network interface to the realm-local all MPL forwarders, link-local and
-     * realm-local all nodes address.
+     * This method subscribes the network interface to the realm-local all MPL forwarders, link-local, and realm-local
+     * all nodes address.
+     *
+     * @retval OT_ERROR_NONE     Successfully subscribed to all addresses.
+     * @retval OT_ERROR_ALREADY  The multicast addresses are already subscribed.
      *
      */
-    void SubscribeAllNodesMulticast(void);
+    otError SubscribeAllNodesMulticast(void);
 
     /**
      * This method unsubscribes the network interface from the realm-local all MPL forwarders, link-local and
      * realm-local all nodes address.
      *
+     * @note This method MUST be called after `UnsubscribeAllRoutersMulticast()` or its behavior is undefined
+     *
+     * @retval OT_ERROR_NONE          Successfully unsubscribed from all addresses.
+     * @retval OT_ERROR_NOT_FOUND     The multicast addresses were not found.
+     *
      */
-    void UnsubscribeAllNodesMulticast(void);
+    otError UnsubscribeAllNodesMulticast(void);
 
 private:
     enum

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -115,6 +115,7 @@ check_PROGRAMS                                                     += \
     test-mac-frame                                                    \
     test-message                                                      \
     test-message-queue                                                \
+    test-netif                                                        \
     test-network-data                                                 \
     test-priority-queue                                               \
     test-pskc                                                         \
@@ -205,6 +206,9 @@ test_message_queue_SOURCES   = $(COMMON_SOURCES) test_message_queue.cpp
 test_ncp_buffer_LDADD        = $(COMMON_LDADD)
 test_ncp_buffer_SOURCES      = $(COMMON_SOURCES) test_ncp_buffer.cpp
 
+test_netif_LDADD             = $(COMMON_LDADD)
+test_netif_SOURCES           = $(COMMON_SOURCES) test_netif.cpp
+
 test_network_data_LDADD      = $(COMMON_LDADD)
 test_network_data_SOURCES    = $(COMMON_SOURCES) test_network_data.cpp
 
@@ -254,6 +258,7 @@ PRETTY_FILES                                                        = \
     $(test_message_queue_SOURCES)                                     \
     $(test_message_SOURCES)                                           \
     $(test_ncp_buffer_SOURCES)                                        \
+    $(test_netif_SOURCES)                                             \
     $(test_network_data_SOURCES)                                      \
     $(test_priority_queue_SOURCES)                                    \
     $(test_pskc_SOURCES)                                              \

--- a/tests/unit/test_linked_list.cpp
+++ b/tests/unit/test_linked_list.cpp
@@ -52,19 +52,29 @@ void VerifyLinkedListContent(const ot::LinkedList<Entry> &aList, ...)
 {
     va_list args;
     Entry * argEntry;
+    Entry * argPrev = NULL;
 
     va_start(args, aList);
 
     for (const Entry *entry = aList.GetHead(); entry; entry = entry->GetNext())
     {
+        Entry *prev;
+
         argEntry = va_arg(args, Entry *);
         VerifyOrQuit(argEntry != NULL, "List contains more entries than expected");
         VerifyOrQuit(argEntry == entry, "List does not contain the same entry");
         VerifyOrQuit(aList.Contains(*argEntry), "List::Contains() failed");
+
+        SuccessOrQuit(aList.Find(*argEntry, prev), "List::Find() failed");
+        VerifyOrQuit(prev == argPrev, "List::Find() returned prev entry is incorrect");
+
+        argPrev = argEntry;
     }
 
     argEntry = va_arg(args, Entry *);
     VerifyOrQuit(argEntry == NULL, "List contains less entries than expected");
+
+    VerifyOrQuit(aList.GetTail() == argPrev, "List::GetTail() failed");
 }
 
 void TestLinkedList(void)

--- a/tests/unit/test_netif.cpp
+++ b/tests/unit/test_netif.cpp
@@ -1,0 +1,215 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdarg.h>
+
+#include "test_platform.h"
+
+#include <openthread/config.h>
+
+#include "common/debug.hpp"
+#include "common/instance.hpp"
+#include "net/netif.hpp"
+
+#include "test_util.h"
+
+namespace ot {
+
+class TestNetif : public Ip6::Netif
+{
+public:
+    TestNetif(Instance &aInstance)
+        : Ip6::Netif(aInstance)
+    {
+    }
+
+    // Provide `protected` methods in `Netif` as `public` from `TestNetif`
+    // so that we can verify their behavior in this test
+    otError SubscribeAllNodesMulticast(void) { return Ip6::Netif::SubscribeAllNodesMulticast(); }
+    otError UnsubscribeAllNodesMulticast(void) { return Ip6::Netif::UnsubscribeAllNodesMulticast(); }
+};
+
+// This function verifies the multicast addresses on Netif matches the list of given addresses.
+void VerifyMulticastAddressList(const Ip6::Netif &aNetif, Ip6::Address aAddresses[], uint8_t aLength)
+{
+    uint8_t count = 0;
+
+    for (uint8_t i = 0; i < aLength; i++)
+    {
+        VerifyOrQuit(aNetif.IsMulticastSubscribed(aAddresses[i]), "IsMulticastSubscribed() failed");
+    }
+
+    for (const Ip6::NetifMulticastAddress *addr = aNetif.GetMulticastAddresses(); addr; addr = addr->GetNext())
+    {
+        bool didFind = false;
+
+        for (uint8_t i = 0; i < aLength; i++)
+        {
+            if (addr->GetAddress() == aAddresses[i])
+            {
+                didFind = true;
+                break;
+            }
+        }
+
+        VerifyOrQuit(didFind, "Netif multicast address is missing from expected address list");
+        count++;
+    }
+
+    VerifyOrQuit(count == aLength, "Expected address is missing from Netif address list");
+}
+
+void TestNetifMulticastAddresses(void)
+{
+    const uint8_t kMaxAddresses = 8;
+
+    Instance *   instance = testInitInstance();
+    TestNetif    netif(*instance);
+    Ip6::Address addresses[kMaxAddresses];
+
+    Ip6::Address               address;
+    Ip6::NetifMulticastAddress netifAddress;
+
+    const char *kLinkLocalAllNodes    = "ff02::01";
+    const char *kRealmLocalAllNodes   = "ff03::01";
+    const char *kRealmLocalAllMpl     = "ff03::fc";
+    const char *kLinkLocalAllRouters  = "ff02::02";
+    const char *kRealmLocalAllRouters = "ff03::02";
+    const char *kTestAddress1         = "ff02::114";
+    const char *kTestAddress2         = "ff03::114";
+    const char *kTestAddress3         = "ff04::114";
+
+    addresses[0].FromString(kLinkLocalAllRouters);
+    addresses[1].FromString(kRealmLocalAllRouters);
+    addresses[2].FromString(kLinkLocalAllNodes);
+    addresses[3].FromString(kRealmLocalAllNodes);
+    addresses[4].FromString(kRealmLocalAllMpl);
+    addresses[5].FromString(kTestAddress1);
+    addresses[6].FromString(kTestAddress2);
+    addresses[7].FromString(kTestAddress3);
+
+    VerifyMulticastAddressList(netif, addresses, 0);
+
+    SuccessOrQuit(netif.SubscribeAllNodesMulticast(), "SubscribeAllNodesMulticast() failed");
+
+    VerifyMulticastAddressList(netif, &addresses[2], 3);
+
+    VerifyOrQuit(netif.SubscribeAllNodesMulticast() == OT_ERROR_ALREADY,
+                 "SubscribeAllNodesMulticast() did not fail when already subscribed");
+
+    SuccessOrQuit(netif.SubscribeAllRoutersMulticast(), "SubscribeAllRoutersMulticast() failed");
+    VerifyMulticastAddressList(netif, &addresses[0], 5);
+
+    VerifyOrQuit(netif.SubscribeAllRoutersMulticast() == OT_ERROR_ALREADY,
+                 "SubscribeAllRoutersMulticast() did not fail when already subscribed");
+
+    SuccessOrQuit(netif.UnsubscribeAllRoutersMulticast(), "UnsubscribeAllRoutersMulticast() failed");
+    VerifyMulticastAddressList(netif, &addresses[2], 3);
+
+    VerifyOrQuit(netif.UnsubscribeAllRoutersMulticast() == OT_ERROR_NOT_FOUND,
+                 "UnsubscribeAllRoutersMulticast() did not fail when not subscribed");
+
+    netifAddress.GetAddress().FromString(kTestAddress1);
+    SuccessOrQuit(netif.SubscribeMulticast(netifAddress), "SubscribeMulticast() failed");
+    VerifyMulticastAddressList(netif, &addresses[2], 4);
+
+    VerifyOrQuit(netif.SubscribeMulticast(netifAddress) == OT_ERROR_ALREADY,
+                 "SubscribeMulticast() did not fail when address was already subscribed");
+
+    SuccessOrQuit(netif.UnsubscribeAllNodesMulticast(), "UnsubscribeAllNodesMulticast() failed");
+    VerifyMulticastAddressList(netif, &addresses[5], 1);
+
+    VerifyOrQuit(netif.UnsubscribeAllNodesMulticast() == OT_ERROR_NOT_FOUND,
+                 "UnsubscribeAllNodesMulticast() did not fail when not subscribed");
+
+    address.FromString(kTestAddress2);
+    SuccessOrQuit(netif.SubscribeExternalMulticast(address), "SubscribeExternalMulticast() failed");
+    VerifyMulticastAddressList(netif, &addresses[5], 2);
+
+    SuccessOrQuit(netif.SubscribeAllNodesMulticast(), "SubscribeAllNodesMulticast() failed");
+    VerifyMulticastAddressList(netif, &addresses[2], 5);
+
+    VerifyOrQuit(netif.SubscribeExternalMulticast(address) == OT_ERROR_ALREADY,
+                 "SubscribeExternalMulticast() did not fail when address was already subscribed");
+
+    SuccessOrQuit(netif.SubscribeAllRoutersMulticast(), "SubscribeAllRoutersMulticast() failed");
+    VerifyMulticastAddressList(netif, &addresses[0], 7);
+
+    VerifyOrQuit(netif.SubscribeAllRoutersMulticast() == OT_ERROR_ALREADY,
+                 "SubscribeAllRoutersMulticast() did not fail when already subscribed");
+
+    address.FromString(kTestAddress3);
+    SuccessOrQuit(netif.SubscribeExternalMulticast(address), "SubscribeExternalMulticast() failed");
+    VerifyMulticastAddressList(netif, &addresses[0], 8);
+
+    address.FromString(kTestAddress1); // same as netifAddress (internal)
+    VerifyOrQuit(netif.UnsubscribeExternalMulticast(address) == OT_ERROR_INVALID_ARGS,
+                 "UnsubscribeExternalMulticast() did not fail when address was not external");
+
+    address.FromString(kRealmLocalAllMpl);
+    VerifyOrQuit(netif.UnsubscribeExternalMulticast(address) == OT_ERROR_INVALID_ARGS,
+                 "UnsubscribeExternalMulticast() did not fail when address was fixed address");
+
+    SuccessOrQuit(netif.UnsubscribeAllRoutersMulticast(), "UnsubscribeAllRoutersMulticast() failed");
+    VerifyMulticastAddressList(netif, &addresses[2], 6);
+
+    VerifyOrQuit(netif.UnsubscribeAllRoutersMulticast() == OT_ERROR_NOT_FOUND,
+                 "UnsubscribeAllRoutersMulticast() did not fail when not subscribed");
+
+    netif.UnsubscribeAllExternalMulticastAddresses();
+    VerifyMulticastAddressList(netif, &addresses[2], 4);
+
+    SuccessOrQuit(netif.UnsubscribeMulticast(netifAddress), "UnsubscribeMulticast() failed");
+    VerifyMulticastAddressList(netif, &addresses[2], 3);
+
+    VerifyOrQuit(netif.UnsubscribeMulticast(netifAddress) == OT_ERROR_NOT_FOUND,
+                 "UnsubscribeMulticast() did not fail when address was not subscribed");
+
+    SuccessOrQuit(netif.UnsubscribeAllNodesMulticast(), "UnsubscribeAllNodesMulticast() failed");
+    VerifyMulticastAddressList(netif, NULL, 0);
+
+    // The first five elements in `addresses[]` are the default/fixed addresses:
+    // kLinkLocalAllRouters, kRealmLocalAllRouters, kLinkLocalAllNodes,
+    // kRealmLocalAllNodes, and kRealmLocalAllMpl. Verify that we cannot add
+    // any of them as an external multicast address.
+
+    for (uint8_t i = 0; i < 5; i++)
+    {
+        VerifyOrQuit(netif.SubscribeExternalMulticast(addresses[i]) == OT_ERROR_INVALID_ARGS,
+                     "SubscribeExternalMulticast() did not fail when address was a default/fixed address");
+    }
+}
+
+} // namespace ot
+
+int main(void)
+{
+    ot::TestNetifMulticastAddresses();
+    printf("All tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
This PR contains three related commits.

**[linked-list] add Find() and GetTail() methods (#4388)**

The `LinkedList::Find()` method searches for a given entry in the
linked list and if found returns a pointer to the previous entry
behind it. The `LinkedList::GetTail()` returns the tail of the list
(last entry in the list). This commit also updates the unit test
`test_linked_list` to verify the behavior of newly added methods.


**[netif] allow addition of external multicast addresses in any state (#4388)**

This commit updates the Netif's handling of multicast addresses to
allow user to subscribe to (or unsubscribe from) an external multicast
address in any state. This aligns the behavior of external multicast
addresses with how external unicast addresses are handled (user can
already add/remove unicast addresses in any state).

This commit also adds checks to ensure user cannot subscribe to fixed
multicast addresses (e.g., link-local all nodes, realm-local all
routers, etc.) using `SubscribeExternalMulticast()`.

This commit also updates the implementation of methods dealing with
fixed multicast addresses to use the newly added `LinkedList` methods.

**[unit-test] add test covering netif multicast address methods (#4388)**
