### PR TITLE
[coap] add support for RFC7641

### DIFF
--- a/examples/Makefile-simulation
+++ b/examples/Makefile-simulation
@@ -38,6 +38,7 @@ DEBUG                          ?= 0
 BORDER_AGENT                   ?= 1
 BORDER_ROUTER                  ?= 1
 COAP                           ?= 1
+COAP_OBSERVE                   ?= 1
 COAPS                          ?= 1
 COMMISSIONER                   ?= 1
 CHANNEL_MANAGER                ?= 1

--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -32,6 +32,7 @@ BIG_ENDIAN          ?= 0
 BORDER_AGENT        ?= 0
 BORDER_ROUTER       ?= 0
 COAP                ?= 0
+COAP_OBSERVE        ?= 0
 COAPS               ?= 0
 COMMISSIONER        ?= 0
 COVERAGE            ?= 0
@@ -88,6 +89,10 @@ endif
 
 ifeq ($(COAPS),1)
 COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE=1
+endif
+
+ifeq ($(COAP_OBSERVE),1)
+COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE=1
 endif
 
 ifeq ($(COMMISSIONER),1)

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -682,6 +682,18 @@ const uint8_t *otCoapMessageGetToken(const otMessage *aMessage);
 otError otCoapOptionIteratorInit(otCoapOptionIterator *aIterator, const otMessage *aMessage);
 
 /**
+ * This function returns a pointer to the first option matching the specified option number.
+ *
+ * @param[in]  aIterator A pointer to the CoAP message option iterator.
+ * @param[in]  aOption   The option number sought.
+ *
+ * @returns A pointer to the first matching option. If no matching option is present NULL pointer is returned.
+ *
+ */
+const otCoapOption *otCoapOptionIteratorGetFirstOptionMatching(otCoapOptionIterator *aIterator,
+                                                               otCoapOptionType      aOption);
+
+/**
  * This function returns a pointer to the first option.
  *
  * @param[inout]  aIterator A pointer to the CoAP message option iterator.
@@ -690,6 +702,18 @@ otError otCoapOptionIteratorInit(otCoapOptionIterator *aIterator, const otMessag
  *
  */
 const otCoapOption *otCoapOptionIteratorGetFirstOption(otCoapOptionIterator *aIterator);
+
+/**
+ * This function returns a pointer to the next option matching the specified option number.
+ *
+ * @param[in]  aIterator A pointer to the CoAP message option iterator.
+ * @param[in]  aOption   The option number sought.
+ *
+ * @returns A pointer to the next matching option. If no further matching option is present NULL pointer is returned.
+ *
+ */
+const otCoapOption *otCoapOptionIteratorGetNextOptionMatching(otCoapOptionIterator *aIterator,
+                                                              otCoapOptionType      aOption);
 
 /**
  * This function returns a pointer to the next option.

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -127,7 +127,7 @@ typedef enum otCoapOptionType
     OT_COAP_OPTION_URI_HOST       = 3,  ///< Uri-Host
     OT_COAP_OPTION_E_TAG          = 4,  ///< ETag
     OT_COAP_OPTION_IF_NONE_MATCH  = 5,  ///< If-None-Match
-    OT_COAP_OPTION_OBSERVE        = 6,  ///< Observe
+    OT_COAP_OPTION_OBSERVE        = 6,  ///< Observe [RFC7641]
     OT_COAP_OPTION_URI_PORT       = 7,  ///< Uri-Port
     OT_COAP_OPTION_LOCATION_PATH  = 8,  ///< Location-Path
     OT_COAP_OPTION_URI_PATH       = 11, ///< Uri-Path

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -491,6 +491,7 @@ otError otCoapMessageAppendOption(otMessage *aMessage, uint16_t aNumber, uint16_
  * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
  * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
  *
+ * @see otCoapMessageGetOptionUintValue
  */
 otError otCoapMessageAppendUintOption(otMessage *aMessage, uint16_t aNumber, uint32_t aValue);
 
@@ -724,6 +725,21 @@ const otCoapOption *otCoapOptionIteratorGetNextOptionMatching(otCoapOptionIterat
  *
  */
 const otCoapOption *otCoapOptionIteratorGetNextOption(otCoapOptionIterator *aIterator);
+
+/**
+ * This function fills current option value into @p aValue assuming the current value is an unsigned integer encoded
+ * according to https://tools.ietf.org/html/rfc7252#section-3.2
+ *
+ * @param[inout]    aIterator   A pointer to the CoAP message option iterator.
+ * @param[out]      aValue      A pointer to an unsigned integer to receive the option value.
+ *
+ * @retval  OT_ERROR_NONE       Successfully filled value.
+ * @retval  OT_ERROR_NOT_FOUND  No current option.
+ * @retval  OT_ERROR_NO_BUFS    Value is too long to fit in a uint64_t.
+ *
+ * @see otCoapMessageAppendUintOption
+ */
+otError otCoapOptionIteratorGetOptionUintValue(otCoapOptionIterator *aIterator, uint64_t *const aValue);
 
 /**
  * This function fills current option value into @p aValue.

--- a/src/cli/README_COAP.md
+++ b/src/cli/README_COAP.md
@@ -55,12 +55,15 @@ coap response sent
 ## Command List
 
 * [help](#help)
+* [cancel](#cancel)
 * [delete](#delete-address-uri-path-type-payload)
 * [get](#get-address-uri-path-type)
+* [observe](#observe-address-uri-path-type)
 * [parameters](#parameters)
 * [post](#post-address-uri-path-type-payload)
 * [put](#put-address-uri-path-type-payload)
 * [resource](#resource-uri-path)
+* [set](#set-new-content)
 * [start](#start)
 * [stop](#stop)
 
@@ -71,18 +74,31 @@ coap response sent
 ```bash
 > coap help
 help
+cancel
 delete
 get
+observe
 parameters
 post
 put
 resource
+set
 start
 stop
 Done
 ```
 
 List the CoAP CLI commands.
+
+### cancel
+
+Request the cancellation of an existing observation subscription to a remote
+resource.
+
+```bash
+> coap cancel
+Done
+```
 
 ### delete \<address\> \<uri-path\> \[type\] \[payload\]
 
@@ -104,6 +120,20 @@ Done
 
 ```bash
 > coap get fdde:ad00:beef:0:2780:9423:166c:1aac test-resource
+Done
+```
+
+### observe \<address\> \<uri-path\> \[type\]
+
+This is the same a `get`, but the `Observe` parameter will be sent, set to 0
+triggering a subscription request.
+
+* address: IPv6 address of the CoAP server.
+* uri-path: URI path of the resource.
+* type: "con" for Confirmable or "non-con" for Non-confirmable (default).
+
+```bash
+> coap observe fdde:ad00:beef:0:2780:9423:166c:1aac test-resource
 Done
 ```
 
@@ -177,6 +207,15 @@ Sets the URI path for the test resource.
 Done
 > coap resource
 test-resource
+Done
+```
+
+### set \[new-content\]
+
+Sets the content sent by the test resource.  If a CoAP client is observing the resource, a notification is sent to that client.
+
+```bash
+> coap set Testing123
 Done
 ```
 

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -100,6 +100,12 @@ otError Coap::CancelResourceSubscription(void)
     mRequestTokenLength = 0;
 
 exit:
+
+    if ((error != OT_ERROR_NONE) && (message != NULL))
+    {
+        otMessageFree(message);
+    }
+
     return error;
 }
 

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -57,6 +57,10 @@ Coap::Coap(Interpreter &aInterpreter)
     : mInterpreter(aInterpreter)
     , mUseDefaultRequestTxParameters(true)
     , mUseDefaultResponseTxParameters(true)
+    , mObserveSerial(0)
+    , mRequestTokenLength(0)
+    , mSubscriberTokenLength(0)
+    , mSubscriberConfirmableNotifications(false)
 {
     memset(&mResource, 0, sizeof(mResource));
     memset(&mRequestAddr, 0, sizeof(mRequestAddr));
@@ -66,9 +70,6 @@ Coap::Coap(Interpreter &aInterpreter)
     memset(&mUriPath, 0, sizeof(mUriPath));
     memset(&mRequestUri, 0, sizeof(mRequestUri));
     strlcpy(mResourceContent, "0", kMaxBufferSize);
-    mRequestTokenLength    = 0;
-    mSubscriberTokenLength = 0;
-    mObserveSerial         = 0;
 }
 
 otError Coap::CancelResourceSubscription(void)

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -226,6 +226,12 @@ otError Coap::ProcessSet(int argc, char *argv[])
     }
 
 exit:
+
+    if ((error != OT_ERROR_NONE) && (message != NULL))
+    {
+        otMessageFree(message);
+    }
+
     return error;
 }
 

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -69,7 +69,7 @@ Coap::Coap(Interpreter &aInterpreter)
     memset(&mSubscriberToken, 0, sizeof(mSubscriberToken));
     memset(&mUriPath, 0, sizeof(mUriPath));
     memset(&mRequestUri, 0, sizeof(mRequestUri));
-    strlcpy(mResourceContent, "0", kMaxBufferSize);
+    strncpy(mResourceContent, "0", sizeof(mResourceContent) - 1);
 }
 
 otError Coap::CancelResourceSubscription(void)
@@ -189,7 +189,7 @@ otError Coap::ProcessSet(int argc, char *argv[])
     if (argc > 1)
     {
         VerifyOrExit(strlen(argv[1]) < (kMaxBufferSize - 1), error = OT_ERROR_INVALID_ARGS);
-        strlcpy(mResourceContent, argv[1], kMaxBufferSize);
+        strncpy(mResourceContent, argv[1], sizeof(mResourceContent) - 1);
 
         if (mSubscriberTokenLength > 0)
         {
@@ -439,7 +439,7 @@ otError Coap::ProcessRequest(int argc, char *argv[])
         memcpy(&mRequestAddr, &coapDestinationIp, sizeof(mRequestAddr));
         mRequestTokenLength = otCoapMessageGetTokenLength(message);
         memcpy(mRequestToken, otCoapMessageGetToken(message), mRequestTokenLength);
-        strlcpy(mRequestUri, coapUri, kMaxUriLength);
+        strncpy(mRequestUri, coapUri, sizeof(mRequestUri) - 1);
     }
 
     if ((coapType == OT_COAP_TYPE_CONFIRMABLE) || (coapCode == OT_COAP_CODE_GET))

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -226,7 +226,7 @@ otError Coap::ProcessSet(int argc, char *argv[])
     }
 
 exit:
-    return OT_ERROR_NONE;
+    return error;
 }
 
 otError Coap::ProcessStart(int argc, char *argv[])

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -508,7 +508,7 @@ void Coap::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo)
     {
     case OT_COAP_CODE_GET:
         mInterpreter.mServer->OutputFormat("GET");
-        otCoapOptionIteratorInit(&iterator, aMessage);
+        SuccessOrExit(error = otCoapOptionIteratorInit(&iterator, aMessage));
         if (otCoapOptionIteratorGetFirstOptionMatching(&iterator, OT_COAP_OPTION_OBSERVE) != NULL)
         {
             SuccessOrExit(error = otCoapOptionIteratorGetOptionUintValue(&iterator, &observe));
@@ -661,26 +661,28 @@ void Coap::HandleResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo
     }
     else if ((aMessageInfo != NULL) && (aMessage != NULL))
     {
-        const otCoapOption * observeOpt;
         otCoapOptionIterator iterator;
 
-        otCoapOptionIteratorInit(&iterator, aMessage);
-        observeOpt = otCoapOptionIteratorGetFirstOptionMatching(&iterator, OT_COAP_OPTION_OBSERVE);
-
-        mInterpreter.mServer->OutputFormat("coap response from ");
-        mInterpreter.OutputIp6Address(aMessageInfo->mPeerAddr);
-
-        if (observeOpt != NULL)
+        if (otCoapOptionIteratorInit(&iterator, aMessage) == OT_ERROR_NONE)
         {
-            uint64_t observeVal = 0;
-            otError  error      = otCoapOptionIteratorGetOptionUintValue(&iterator, &observeVal);
-            if (error == OT_ERROR_NONE)
-            {
-                mInterpreter.mServer->OutputFormat(" Obs=%u", observeVal);
-            }
-        }
+            const otCoapOption *observeOpt =
+                otCoapOptionIteratorGetFirstOptionMatching(&iterator, OT_COAP_OPTION_OBSERVE);
 
-        PrintPayload(aMessage);
+            mInterpreter.mServer->OutputFormat("coap response from ");
+            mInterpreter.OutputIp6Address(aMessageInfo->mPeerAddr);
+
+            if (observeOpt != NULL)
+            {
+                uint64_t observeVal = 0;
+                otError  error      = otCoapOptionIteratorGetOptionUintValue(&iterator, &observeVal);
+                if (error == OT_ERROR_NONE)
+                {
+                    mInterpreter.mServer->OutputFormat(" Obs=%u", observeVal);
+                }
+            }
+
+            PrintPayload(aMessage);
+        }
     }
 }
 

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -572,6 +572,14 @@ void Coap::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo)
                     mSubscriberTokenLength   = otCoapMessageGetTokenLength(aMessage);
                     memcpy(mSubscriberToken, otCoapMessageGetToken(aMessage), mSubscriberTokenLength);
 
+                    /*
+                     * Implementer note.
+                     *
+                     * Here, we try to match a confirmable GET request with confirmable
+                     * notifications, however this is not a requirement of RFC7641:
+                     * the server can send notifications of either type regardless of
+                     * what the client used to subscribe initially.
+                     */
                     mSubscriberConfirmableNotifications = (otCoapMessageGetType(aMessage) == OT_COAP_TYPE_CONFIRMABLE);
                 }
                 else if (observe == 1)

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -545,10 +545,10 @@ void Coap::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo)
     otMessage *responseMessage = NULL;
     otCoapCode responseCode    = OT_COAP_CODE_EMPTY;
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
-    uint64_t observe        = 0;
-    bool     observePresent = false;
-#endif
+    uint64_t             observe        = 0;
+    bool                 observePresent = false;
     otCoapOptionIterator iterator;
+#endif
 
     mInterpreter.mServer->OutputFormat("coap request from ");
     mInterpreter.OutputIp6Address(aMessageInfo->mPeerAddr);
@@ -558,8 +558,8 @@ void Coap::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo)
     {
     case OT_COAP_CODE_GET:
         mInterpreter.mServer->OutputFormat("GET");
-        SuccessOrExit(error = otCoapOptionIteratorInit(&iterator, aMessage));
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
+        SuccessOrExit(error = otCoapOptionIteratorInit(&iterator, aMessage));
         if (otCoapOptionIteratorGetFirstOptionMatching(&iterator, OT_COAP_OPTION_OBSERVE) != NULL)
         {
             SuccessOrExit(error = otCoapOptionIteratorGetOptionUintValue(&iterator, &observe));

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -730,15 +730,18 @@ void Coap::HandleResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo
     }
     else if ((aMessageInfo != NULL) && (aMessage != NULL))
     {
+#if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
         otCoapOptionIterator iterator;
+#endif
 
+        mInterpreter.mServer->OutputFormat("coap response from ");
+        mInterpreter.OutputIp6Address(aMessageInfo->mPeerAddr);
+
+#if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
         if (otCoapOptionIteratorInit(&iterator, aMessage) == OT_ERROR_NONE)
         {
             const otCoapOption *observeOpt =
                 otCoapOptionIteratorGetFirstOptionMatching(&iterator, OT_COAP_OPTION_OBSERVE);
-
-            mInterpreter.mServer->OutputFormat("coap response from ");
-            mInterpreter.OutputIp6Address(aMessageInfo->mPeerAddr);
 
             if (observeOpt != NULL)
             {
@@ -750,9 +753,9 @@ void Coap::HandleResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo
                     mInterpreter.mServer->OutputFormat(" OBS=%u", observeVal);
                 }
             }
-
-            PrintPayload(aMessage);
         }
+#endif
+        PrintPayload(aMessage);
     }
 }
 

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -746,7 +746,7 @@ void Coap::HandleResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo
 
                 if (error == OT_ERROR_NONE)
                 {
-                    mInterpreter.mServer->OutputFormat(" Obs=%u", observeVal);
+                    mInterpreter.mServer->OutputFormat(" OBS=%u", observeVal);
                 }
             }
 

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -233,9 +233,9 @@ otError Coap::ProcessSet(int argc, char *argv[])
 
 exit:
 
-    if ((error != OT_ERROR_NONE) && (message != NULL))
+    if ((error != OT_ERROR_NONE) && (notificationMessage != NULL))
     {
-        otMessageFree(message);
+        otMessageFree(notificationMessage);
     }
 
     return error;

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -696,6 +696,7 @@ void Coap::HandleResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo
             {
                 uint64_t observeVal = 0;
                 otError  error      = otCoapOptionIteratorGetOptionUintValue(&iterator, &observeVal);
+
                 if (error == OT_ERROR_NONE)
                 {
                     mInterpreter.mServer->OutputFormat(" Obs=%u", observeVal);

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -485,6 +485,7 @@ otError Coap::ProcessRequest(int argc, char *argv[])
         mRequestTokenLength = otCoapMessageGetTokenLength(message);
         memcpy(mRequestToken, otCoapMessageGetToken(message), mRequestTokenLength);
         strncpy(mRequestUri, coapUri, sizeof(mRequestUri) - 1);
+        mRequestUri[sizeof(mRequestUri) - 1] = '\0'; // Fix gcc-9.2 warning
     }
 #endif
 

--- a/src/cli/cli_coap.hpp
+++ b/src/cli/cli_coap.hpp
@@ -103,11 +103,13 @@ private:
     static void HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
+#if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
     static void HandleNotificationResponse(void *               aContext,
                                            otMessage *          aMessage,
                                            const otMessageInfo *aMessageInfo,
                                            otError              aError);
     void        HandleNotificationResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo, otError aError);
+#endif
 
     static void HandleResponse(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo, otError aError);
     void        HandleResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo, otError aError);

--- a/src/cli/cli_coap.hpp
+++ b/src/cli/cli_coap.hpp
@@ -82,13 +82,17 @@ private:
         otError (Coap::*mCommand)(int argc, char *argv[]);
     };
 
+#if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
     otError CancelResourceSubscription(void);
     void    CancelSubscriber(void);
+#endif
 
     void PrintPayload(otMessage *aMessage) const;
 
     otError ProcessHelp(int argc, char *argv[]);
+#if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
     otError ProcessCancel(int argc, char *argv[]);
+#endif
     otError ProcessParameters(int argc, char *argv[]);
     otError ProcessRequest(int argc, char *argv[]);
     otError ProcessResource(int argc, char *argv[]);
@@ -128,17 +132,21 @@ private:
     otCoapTxParameters mResponseTxParameters;
 
     otCoapResource mResource;
-    otIp6Address   mRequestAddr;
-    otSockAddr     mSubscriberSock;
-    char           mRequestUri[kMaxUriLength];
-    uint8_t        mRequestToken[OT_COAP_MAX_TOKEN_LENGTH];
-    uint8_t        mSubscriberToken[OT_COAP_MAX_TOKEN_LENGTH];
-    char           mUriPath[kMaxUriLength];
-    char           mResourceContent[kMaxBufferSize];
-    uint32_t       mObserveSerial;
-    uint8_t        mRequestTokenLength;
-    uint8_t        mSubscriberTokenLength;
-    bool           mSubscriberConfirmableNotifications;
+#if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
+    otIp6Address mRequestAddr;
+    otSockAddr   mSubscriberSock;
+    char         mRequestUri[kMaxUriLength];
+    uint8_t      mRequestToken[OT_COAP_MAX_TOKEN_LENGTH];
+    uint8_t      mSubscriberToken[OT_COAP_MAX_TOKEN_LENGTH];
+#endif
+    char mUriPath[kMaxUriLength];
+    char mResourceContent[kMaxBufferSize];
+#if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
+    uint32_t mObserveSerial;
+    uint8_t  mRequestTokenLength;
+    uint8_t  mSubscriberTokenLength;
+    bool     mSubscriberConfirmableNotifications;
+#endif
 };
 
 } // namespace Cli

--- a/src/cli/cli_coap.hpp
+++ b/src/cli/cli_coap.hpp
@@ -82,17 +82,28 @@ private:
         otError (Coap::*mCommand)(int argc, char *argv[]);
     };
 
+    otError CancelResourceSubscription(void);
+    void    CancelSubscriber(void);
+
     void PrintPayload(otMessage *aMessage) const;
 
     otError ProcessHelp(int argc, char *argv[]);
+    otError ProcessCancel(int argc, char *argv[]);
     otError ProcessParameters(int argc, char *argv[]);
     otError ProcessRequest(int argc, char *argv[]);
     otError ProcessResource(int argc, char *argv[]);
+    otError ProcessSet(int argc, char *argv[]);
     otError ProcessStart(int argc, char *argv[]);
     otError ProcessStop(int argc, char *argv[]);
 
     static void HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo);
+
+    static void HandleNotificationResponse(void *               aContext,
+                                           otMessage *          aMessage,
+                                           const otMessageInfo *aMessageInfo,
+                                           otError              aError);
+    void        HandleNotificationResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo, otError aError);
 
     static void HandleResponse(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo, otError aError);
     void        HandleResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo, otError aError);
@@ -117,7 +128,17 @@ private:
     otCoapTxParameters mResponseTxParameters;
 
     otCoapResource mResource;
+    otIp6Address   mRequestAddr;
+    otSockAddr     mSubscriberSock;
+    char           mRequestUri[kMaxUriLength];
+    uint8_t        mRequestToken[OT_COAP_MAX_TOKEN_LENGTH];
+    uint8_t        mSubscriberToken[OT_COAP_MAX_TOKEN_LENGTH];
     char           mUriPath[kMaxUriLength];
+    char           mResourceContent[kMaxBufferSize];
+    uint32_t       mObserveSerial;
+    uint8_t        mRequestTokenLength;
+    uint8_t        mSubscriberTokenLength;
+    bool           mSubscriberConfirmableNotifications;
 };
 
 } // namespace Cli

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -201,6 +201,11 @@ const otCoapOption *otCoapOptionIteratorGetNextOption(otCoapOptionIterator *aIte
     return static_cast<Coap::OptionIterator *>(aIterator)->GetNextOption();
 }
 
+otError otCoapOptionIteratorGetOptionUintValue(otCoapOptionIterator *aIterator, uint64_t *const aValue)
+{
+    return static_cast<Coap::OptionIterator *>(aIterator)->GetOptionValue(*aValue);
+}
+
 otError otCoapOptionIteratorGetOptionValue(otCoapOptionIterator *aIterator, void *aValue)
 {
     return static_cast<Coap::OptionIterator *>(aIterator)->GetOptionValue(aValue);

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -180,9 +180,20 @@ otError otCoapOptionIteratorInit(otCoapOptionIterator *aIterator, const otMessag
     return static_cast<Coap::OptionIterator *>(aIterator)->Init(static_cast<const Coap::Message *>(aMessage));
 }
 
+const otCoapOption *otCoapOptionIteratorGetFirstOptionMatching(otCoapOptionIterator *aIterator,
+                                                               otCoapOptionType      aOption)
+{
+    return static_cast<Coap::OptionIterator *>(aIterator)->GetFirstOptionMatching(aOption);
+}
+
 const otCoapOption *otCoapOptionIteratorGetFirstOption(otCoapOptionIterator *aIterator)
 {
     return static_cast<Coap::OptionIterator *>(aIterator)->GetFirstOption();
+}
+
+const otCoapOption *otCoapOptionIteratorGetNextOptionMatching(otCoapOptionIterator *aIterator, otCoapOptionType aOption)
+{
+    return static_cast<Coap::OptionIterator *>(aIterator)->GetNextOptionMatching(aOption);
 }
 
 const otCoapOption *otCoapOptionIteratorGetNextOption(otCoapOptionIterator *aIterator)

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -307,6 +307,12 @@ void CoapBase::HandleRetransmissionTimer(void)
 
         if (now >= metadata.mNextTimerShot)
         {
+            if (message->IsRequest() && metadata.mObserve && metadata.mAcknowledged)
+            {
+                // This is a RFC7641 subscription.  Do not time out.
+                continue;
+            }
+
             if (!metadata.mConfirmable || (metadata.mRetransmissionsRemaining == 0))
             {
                 // No expected response or acknowledgment.

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -173,7 +173,7 @@ otError CoapBase::SendMessage(Message &               aMessage,
         OptionIterator iterator;
         bool           observe;
 
-        iterator.Init(&aMessage);
+        SuccessOrExit(error = iterator.Init(&aMessage));
         observe = (iterator.GetFirstOptionMatching(OT_COAP_OPTION_OBSERVE) != NULL);
 
         // Special case, if we're sending a GET with Observe=1, that is a cancellation.
@@ -549,7 +549,7 @@ void CoapBase::ProcessReceivedResponse(Message &aMessage, const Ip6::MessageInfo
         // We sent Observe in our request, see if we received Observe in the response too.
         OptionIterator iterator;
 
-        iterator.Init(&aMessage);
+        SuccessOrExit(error = iterator.Init(&aMessage));
         responseObserve = (iterator.GetFirstOptionMatching(OT_COAP_OPTION_OBSERVE) != NULL);
     }
 

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -169,7 +169,14 @@ otError CoapBase::SendMessage(Message &               aMessage,
     {
         Metadata metadata;
 
-        metadata.Init(aMessage.IsConfirmable(), aMessageInfo, aHandler, aContext, aTxParameters);
+        // Whether or not to turn on special "Observe" handling.
+        OptionIterator iterator;
+        bool           observe;
+
+        iterator.Init(&aMessage);
+        observe = (iterator.GetFirstOptionMatching(OT_COAP_OPTION_OBSERVE) != NULL);
+
+        metadata.Init(aMessage.IsConfirmable(), observe, aMessageInfo, aHandler, aContext, aTxParameters);
         storedCopy = CopyAndEnqueueMessage(aMessage, copyLength, metadata);
         VerifyOrExit(storedCopy != NULL, error = OT_ERROR_NO_BUFS);
     }
@@ -665,6 +672,7 @@ exit:
 }
 
 void CoapBase::Metadata::Init(bool                    aConfirmable,
+                              bool                    aObserve,
                               const Ip6::MessageInfo &aMessageInfo,
                               ResponseHandler         aHandler,
                               void *                  aContext,
@@ -679,6 +687,7 @@ void CoapBase::Metadata::Init(bool                    aConfirmable,
     mRetransmissionTimeout    = aTxParameters.CalculateInitialRetransmissionTimeout();
     mAcknowledged             = false;
     mConfirmable              = aConfirmable;
+    mObserve                  = aObserve;
     mNextTimerShot =
         TimerMilli::GetNow() + (aConfirmable ? mRetransmissionTimeout : aTxParameters.CalculateMaxTransmitWait());
 }

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -169,6 +169,7 @@ otError CoapBase::SendMessage(Message &               aMessage,
     {
         Metadata metadata;
 
+#if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
         // Whether or not to turn on special "Observe" handling.
         OptionIterator iterator;
         bool           observe;
@@ -199,6 +200,7 @@ otError CoapBase::SendMessage(Message &               aMessage,
                 }
             }
         }
+#endif // OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
 
         // Enqueue and send
         metadata.Init(aMessage.IsConfirmable(),

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -526,6 +526,7 @@ private:
     struct Metadata
     {
         void Init(bool                    aConfirmable,
+                  bool                    aObserve,
                   const Ip6::MessageInfo &aMessageInfo,
                   ResponseHandler         aHandler,
                   void *                  aContext,
@@ -545,6 +546,7 @@ private:
         uint8_t         mRetransmissionsRemaining; // Number of retransmissions remaining.
         bool            mAcknowledged : 1;         // Information that request was acknowledged.
         bool            mConfirmable : 1;          // Information that message is confirmable.
+        bool            mObserve : 1;              // Information that this request involves Observations.
     };
 
     static void HandleRetransmissionTimer(Timer &aTimer);

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -525,8 +525,10 @@ protected:
 private:
     struct Metadata
     {
-        void Init(bool                    aConfirmable,
-                  bool                    aObserve,
+        void Init(bool aConfirmable,
+#if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
+                  bool aObserve,
+#endif
                   const Ip6::MessageInfo &aMessageInfo,
                   ResponseHandler         aHandler,
                   void *                  aContext,
@@ -546,7 +548,9 @@ private:
         uint8_t         mRetransmissionsRemaining; // Number of retransmissions remaining.
         bool            mAcknowledged : 1;         // Information that request was acknowledged.
         bool            mConfirmable : 1;          // Information that message is confirmable.
-        bool            mObserve : 1;              // Information that this request involves Observations.
+#if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
+        bool mObserve : 1; // Information that this request involves Observations.
+#endif
     };
 
     static void HandleRetransmissionTimer(Timer &aTimer);

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -572,7 +572,7 @@ otError OptionIterator::GetOptionValue(uint64_t &aValue) const
     uint8_t value[sizeof(aValue)];
     uint8_t pos = 0;
 
-    VerifyOrExit(mOption.mLength < sizeof(aValue), error = OT_ERROR_NO_BUFS);
+    VerifyOrExit(mOption.mLength <= sizeof(aValue), error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = GetOptionValue(value));
 
     aValue = 0;

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -564,6 +564,26 @@ exit:
     return rval;
 }
 
+otError OptionIterator::GetOptionValue(uint64_t &aValue) const
+{
+    otError error = OT_ERROR_NONE;
+    uint8_t value[sizeof(aValue)];
+    uint8_t pos = 0;
+
+    VerifyOrExit(mOption.mLength < sizeof(aValue), error = OT_ERROR_NO_BUFS);
+    SuccessOrExit(error = GetOptionValue(value));
+
+    aValue = 0;
+    for (pos = 0; pos < mOption.mLength; pos++)
+    {
+        aValue <<= 8;
+        aValue |= value[pos];
+    }
+
+exit:
+    return error;
+}
+
 otError OptionIterator::GetOptionValue(void *aValue) const
 {
     otError error = OT_ERROR_NONE;

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -432,6 +432,22 @@ exit:
     return err;
 }
 
+const otCoapOption *OptionIterator::GetFirstOptionMatching(otCoapOptionType aOption)
+{
+    const otCoapOption *rval = NULL;
+    for (const otCoapOption *option = GetFirstOption(); option != NULL; option = GetNextOption())
+    {
+        if (option->mNumber == aOption)
+        {
+            // Found, stop searching
+            rval = option;
+            break;
+        }
+    }
+
+    return rval;
+}
+
 const otCoapOption *OptionIterator::GetFirstOption(void)
 {
     const otCoapOption *option  = NULL;
@@ -447,6 +463,22 @@ const otCoapOption *OptionIterator::GetFirstOption(void)
     }
 
     return option;
+}
+
+const otCoapOption *OptionIterator::GetNextOptionMatching(otCoapOptionType aOption)
+{
+    const otCoapOption *rval = NULL;
+    for (const otCoapOption *option = GetNextOption(); option != NULL; option = GetNextOption())
+    {
+        if (option->mNumber == aOption)
+        {
+            // Found, stop searching
+            rval = option;
+            break;
+        }
+    }
+
+    return rval;
 }
 
 const otCoapOption *OptionIterator::GetNextOption(void)

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -435,6 +435,7 @@ exit:
 const otCoapOption *OptionIterator::GetFirstOptionMatching(otCoapOptionType aOption)
 {
     const otCoapOption *rval = NULL;
+
     for (const otCoapOption *option = GetFirstOption(); option != NULL; option = GetNextOption())
     {
         if (option->mNumber == aOption)
@@ -468,6 +469,7 @@ const otCoapOption *OptionIterator::GetFirstOption(void)
 const otCoapOption *OptionIterator::GetNextOptionMatching(otCoapOptionType aOption)
 {
     const otCoapOption *rval = NULL;
+
     for (const otCoapOption *option = GetNextOption(); option != NULL; option = GetNextOption())
     {
         if (option->mNumber == aOption)

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -641,13 +641,14 @@ public:
 
     /**
      * This method returns a pointer to the first option matching the given option number.
+     *
      * The internal option pointer is advanced until matching option is seen, if no matching
      * option is seen, the iterator will advance to the end of the options block.
      *
      * @param[in]   aOption         Option number to look for.
      *
      * @returns A pointer to the first matching option. If no option matching @p aOption is seen, NULL pointer is
-     * returned.
+     *          returned.
      */
     const otCoapOption *GetFirstOptionMatching(otCoapOptionType aOption);
 
@@ -660,13 +661,14 @@ public:
 
     /**
      * This method returns a pointer to the next option matching the given option number.
+     *
      * The internal option pointer is advanced until matching option is seen, if no matching
      * option is seen, the iterator will advance to the end of the options block.
      *
      * @param[in]   aOption         Option number to look for.
      *
      * @returns A pointer to the next matching option (relative to current iterator position). If no option matching @p
-     * aOption is seen, NULL pointer is returned.
+     *          aOption is seen, NULL pointer is returned.
      */
     const otCoapOption *GetNextOptionMatching(otCoapOptionType aOption);
 
@@ -680,7 +682,7 @@ public:
     /**
      * This function fills current option value into @p aValue.  The option is assumed to be an unsigned integer.
      *
-     * @param[out]  aValue	    Buffer to store the option value.
+     * @param[out]  aValue          Buffer to store the option value.
      *
      * @retval  OT_ERROR_NONE       Successfully filled value.
      * @retval  OT_ERROR_NOT_FOUND  No more options, aIterator->mNextOptionOffset is set to offset of payload.
@@ -692,8 +694,8 @@ public:
     /**
      * This function fills current option value into @p aValue.
      *
-     * @param[out]  aValue	    Buffer to store the option value.  This buffer is assumed to be sufficiently large (see
-     * @ref otCoapOption::mLength).
+     * @param[out]  aValue          Buffer to store the option value.  This buffer is assumed to be sufficiently large (see
+     *                              @ref otCoapOption::mLength).
      *
      * @retval  OT_ERROR_NONE       Successfully filled value.
      * @retval  OT_ERROR_NOT_FOUND  No more options, mNextOptionOffset is set to offset of payload.

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -668,6 +668,16 @@ public:
     const otCoapOption *GetNextOption(void);
 
     /**
+     * This function fills current option value into @p aValue.  The option is assumed to be an unsigned integer.
+     *
+     * @retval  OT_ERROR_NONE       Successfully filled value.
+     * @retval  OT_ERROR_NOT_FOUND  No more options, aIterator->mNextOptionOffset is set to offset of payload.
+     * @retval  OT_ERROR_NO_BUFS    Value is too long to fit in a uint64_t.
+     *
+     */
+    otError GetOptionValue(uint64_t &aValue) const;
+
+    /**
      * This function fills current option value into @p aValue.
      *
      * @retval  OT_ERROR_NONE       Successfully filled value.

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -694,8 +694,8 @@ public:
     /**
      * This function fills current option value into @p aValue.
      *
-     * @param[out]  aValue          Buffer to store the option value.  This buffer is assumed to be sufficiently large (see
-     *                              @ref otCoapOption::mLength).
+     * @param[out]  aValue          Buffer to store the option value.  This buffer is assumed to be sufficiently large
+     *                              (see @ref otCoapOption::mLength).
      *
      * @retval  OT_ERROR_NONE       Successfully filled value.
      * @retval  OT_ERROR_NOT_FOUND  No more options, mNextOptionOffset is set to offset of payload.

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -640,11 +640,25 @@ public:
     otError Init(const Message *aMessage);
 
     /**
+     * This method returns a pointer to the first option matching the given option number.
+     *
+     * @param[in]   aOption         Option number to look for.
+     */
+    const otCoapOption *GetFirstOptionMatching(otCoapOptionType aOption);
+
+    /**
      * This method returns a pointer to the first option.
      *
      * @returns A pointer to the first option. If no option is present NULL pointer is returned.
      */
     const otCoapOption *GetFirstOption(void);
+
+    /**
+     * This method returns a pointer to the next option matching the given option number.
+     *
+     * @param[in]   aOption         Option number to look for.
+     */
+    const otCoapOption *GetNextOptionMatching(otCoapOptionType aOption);
 
     /**
      * This method returns a pointer to the next option.

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -641,8 +641,13 @@ public:
 
     /**
      * This method returns a pointer to the first option matching the given option number.
+     * The internal option pointer is advanced until matching option is seen, if no matching
+     * option is seen, the iterator will advance to the end of the options block.
      *
      * @param[in]   aOption         Option number to look for.
+     *
+     * @returns A pointer to the first matching option. If no option matching @p aOption is seen, NULL pointer is
+     * returned.
      */
     const otCoapOption *GetFirstOptionMatching(otCoapOptionType aOption);
 
@@ -655,8 +660,13 @@ public:
 
     /**
      * This method returns a pointer to the next option matching the given option number.
+     * The internal option pointer is advanced until matching option is seen, if no matching
+     * option is seen, the iterator will advance to the end of the options block.
      *
      * @param[in]   aOption         Option number to look for.
+     *
+     * @returns A pointer to the next matching option (relative to current iterator position). If no option matching @p
+     * aOption is seen, NULL pointer is returned.
      */
     const otCoapOption *GetNextOptionMatching(otCoapOptionType aOption);
 
@@ -670,6 +680,8 @@ public:
     /**
      * This function fills current option value into @p aValue.  The option is assumed to be an unsigned integer.
      *
+     * @param[out]  aValue	    Buffer to store the option value.
+     *
      * @retval  OT_ERROR_NONE       Successfully filled value.
      * @retval  OT_ERROR_NOT_FOUND  No more options, aIterator->mNextOptionOffset is set to offset of payload.
      * @retval  OT_ERROR_NO_BUFS    Value is too long to fit in a uint64_t.
@@ -679,6 +691,9 @@ public:
 
     /**
      * This function fills current option value into @p aValue.
+     *
+     * @param[out]  aValue	    Buffer to store the option value.  This buffer is assumed to be sufficiently large (see
+     * @ref otCoapOption::mLength).
      *
      * @retval  OT_ERROR_NONE       Successfully filled value.
      * @retval  OT_ERROR_NOT_FOUND  No more options, mNextOptionOffset is set to offset of payload.

--- a/src/core/config/coap.h
+++ b/src/core/config/coap.h
@@ -101,6 +101,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
+ *
+ * Define to 1 to enable the CoAP Observe (RFC7641) API.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
+#define OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE 0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
  *
  * Define to 1 to enable the CoAP Secure API.

--- a/src/posix/Makefile-posix
+++ b/src/posix/Makefile-posix
@@ -38,6 +38,7 @@ DEBUG                                ?= 0
 BORDER_AGENT                         ?= 1
 BORDER_ROUTER                        ?= 1
 COAP                                 ?= 1
+COAP_OBSERVE                         ?= 1
 COAPS                                ?= 1
 COMMISSIONER                         ?= 1
 CHANNEL_MANAGER                      ?= 1

--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -143,6 +143,7 @@ EXTRA_DIST                                                         = \
     sniffer.py                                                       \
     sniffer_transport.py                                             \
     test_coap.py                                                     \
+    test_coap_observe.py                                             \
     test_coaps.py                                                    \
     test_common.py                                                   \
     test_crypto.py                                                   \
@@ -164,6 +165,7 @@ check_PROGRAMS                                                     = \
 
 check_SCRIPTS                                                      = \
     test_coap.py                                                     \
+    test_coap_observe.py                                             \
     test_coaps.py                                                    \
     test_common.py                                                   \
     test_crypto.py                                                   \

--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -286,6 +286,7 @@ TESTS                                                              = \
 
 XFAIL_NCP_TESTS                                                    = \
     test_coaps.py                                                    \
+    test_coap_observe.py                                             \
     test_diag.py                                                     \
     test_ipv6_fragmentation.py                                       \
     test_ipv6_source_selection.py                                    \

--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -460,6 +460,7 @@ def create_default_based_on_src_dst_ports_udp_payload_factory(master_key):
             19788: mle_message_factory,
             61631: coap_message_factory,
             1000: dtls_message_factory,
+            5683: coap_message_factory,
             5684: dtls_message_factory,
         })
 

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1068,7 +1068,7 @@ class Node:
             cmd += ' %s' % payload
 
         self.send_command(cmd)
-        self.coap_wait_response()
+        return self.coap_wait_response()
 
     def coap_wait_response(self):
         """

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1068,7 +1068,12 @@ class Node:
             cmd += ' %s' % payload
 
         self.send_command(cmd)
+        self.coap_wait_response()
 
+    def coap_wait_response(self):
+        """
+        Wait for a CoAP response, and return it.
+        """
         if isinstance(self.simulator, simulator.VirtualTime):
             self.simulator.go(5)
             timeout = 1

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1082,7 +1082,8 @@ class Node:
 
         self._expect(
             r'coap response from ([\da-f:]+)(?: OBS=(\d+))?'
-            r'(?: with payload: ([\da-f]+))?\b', timeout=timeout)
+            r'(?: with payload: ([\da-f]+))?\b',
+            timeout=timeout)
         (source, observe, payload) = self.pexpect.match.groups()
         source = source.decode('UTF-8')
 
@@ -1107,7 +1108,8 @@ class Node:
 
         self._expect(
             r'coap request from ([\da-f:]+)(?: OBS=(\d+))?'
-            r'(?: with payload: ([\da-f]+))?\b', timeout=timeout)
+            r'(?: with payload: ([\da-f]+))?\b',
+            timeout=timeout)
         (source, observe, payload) = self.pexpect.match.groups()
         source = source.decode('UTF-8')
 
@@ -1144,8 +1146,9 @@ class Node:
 
         self._expect(
             r'Received ACK in reply to notification '
-            r'from ([\da-f:]+)\b', timeout=timeout)
-        (source, ) = self.pexpect.match.groups()
+            r'from ([\da-f:]+)\b',
+            timeout=timeout)
+        (source,) = self.pexpect.match.groups()
         source = source.decode('UTF-8')
 
         return source

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1076,8 +1076,8 @@ class Node:
             timeout = 5
 
         self._expect(
-                r'coap response from ([\da-f:]+)(?: OBS=(\d+))?'
-                r'(?: with payload: ([\da-f]+))?\b', timeout=timeout)
+            r'coap response from ([\da-f:]+)(?: OBS=(\d+))?'
+            r'(?: with payload: ([\da-f]+))?\b', timeout=timeout)
         (source, observe, payload) = self.pexpect.match.groups()
 
         if observe is not None:
@@ -1100,8 +1100,8 @@ class Node:
             timeout = 5
 
         self._expect(
-                r'coap request from ([\da-f:]+)(?: OBS=(\d+))?'
-                r'(?: with payload: ([\da-f]+))?\b', timeout=timeout)
+            r'coap request from ([\da-f:]+)(?: OBS=(\d+))?'
+            r'(?: with payload: ([\da-f]+))?\b', timeout=timeout)
         (source, observe, payload) = self.pexpect.match.groups()
 
         if observe is not None:
@@ -1136,8 +1136,8 @@ class Node:
             timeout = 5
 
         self._expect(
-                r'Received ACK in reply to notification '
-                r'from ([\da-f:]+)\b', timeout=timeout)
+            r'Received ACK in reply to notification '
+            r'from ([\da-f:]+)\b', timeout=timeout)
         (source, ) = self.pexpect.match.groups()
 
         return source

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1075,7 +1075,9 @@ class Node:
         else:
             timeout = 5
 
-        self._expect(r'coap response from ([\da-f:]+)(?: OBS=(\d+))?(?: with payload: ([\da-f]+))?\b', timeout=timeout)
+        self._expect(
+                r'coap response from ([\da-f:]+)(?: OBS=(\d+))?'
+                r'(?: with payload: ([\da-f]+))?\b', timeout=timeout)
         (source, observe, payload) = self.pexpect.match.groups()
 
         if observe is not None:
@@ -1097,7 +1099,9 @@ class Node:
         else:
             timeout = 5
 
-        self._expect(r'coap request from ([\da-f:]+)(?: OBS=(\d+))?(?: with payload: ([\da-f]+))?\b', timeout=timeout)
+        self._expect(
+                r'coap request from ([\da-f:]+)(?: OBS=(\d+))?'
+                r'(?: with payload: ([\da-f]+))?\b', timeout=timeout)
         (source, observe, payload) = self.pexpect.match.groups()
 
         if observe is not None:
@@ -1131,7 +1135,9 @@ class Node:
         else:
             timeout = 5
 
-        self._expect(r'Received ACK in reply to notification from ([\da-f:]+)\b', timeout=timeout)
+        self._expect(
+                r'Received ACK in reply to notification '
+                r'from ([\da-f:]+)\b', timeout=timeout)
         (source, ) = self.pexpect.match.groups()
 
         return source

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1015,6 +1015,76 @@ class Node:
         self.send_command(cmd)
         self._expect('Done')
 
+    def coap_cancel(self):
+        cmd = 'coap cancel'
+        self.send_command(cmd)
+        self._expect('Done')
+
+    def coap_delete(self, ipaddr, uri, con=False, payload=None):
+        self._coap_rq('delete', ipaddr, uri, con, payload)
+
+    def coap_get(self, ipaddr, uri, con=False, payload=None):
+        self._coap_rq('get', ipaddr, uri, con, payload)
+
+    def coap_observe(self, ipaddr, uri, con=False, payload=None):
+        self._coap_rq('observe', ipaddr, uri, con, payload)
+
+    def coap_post(self, ipaddr, uri, con=False, payload=None):
+        self._coap_rq('post', ipaddr, uri, con, payload)
+
+    def coap_put(self, ipaddr, uri, con=False, payload=None):
+        self._coap_rq('put', ipaddr, uri, con, payload)
+
+    def _coap_rq(self, method, ipaddr, uri, con=False, payload=None):
+        """
+        Issue a GET/POST/PUT/DELETE/OBSERVE request.
+        """
+        cmd = 'coap %s %s %s' % (method, ipaddr, uri)
+        if con:
+            cmd += ' con'
+        else:
+            cmd += ' non'
+
+        if payload is not None:
+            cmd += ' %s' % payload
+
+        self.send_command(cmd)
+
+        if isinstance(self.simulator, simulator.VirtualTime):
+            self.simulator.go(5)
+            timeout = 1
+        else:
+            timeout = 5
+
+        self._expect('coap response', timeout=timeout)
+
+    def coap_set_resource_path(self, path):
+        cmd = 'coap resource %s' % path
+        self.send_command(cmd)
+        self._expect('Done')
+
+    def coap_set_content(self, content):
+        cmd = 'coap set %s' % content
+        self.send_command(cmd)
+        self._expect('Done')
+
+    def coap_start(self):
+        cmd = 'coap start'
+        self.send_command(cmd)
+        self._expect('Done')
+
+    def coap_stop(self):
+        cmd = 'coap stop'
+        self.send_command(cmd)
+
+        if isinstance(self.simulator, simulator.VirtualTime):
+            self.simulator.go(5)
+            timeout = 1
+        else:
+            timeout = 5
+
+        self._expect('Done', timeout=timeout)
+
     def coaps_start_psk(self, psk, pskIdentity):
         cmd = 'coaps psk %s %s' % (psk, pskIdentity)
         self.send_command(cmd)

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1084,6 +1084,7 @@ class Node:
             r'coap response from ([\da-f:]+)(?: OBS=(\d+))?'
             r'(?: with payload: ([\da-f]+))?\b', timeout=timeout)
         (source, observe, payload) = self.pexpect.match.groups()
+        source = source.decode('UTF-8')
 
         if observe is not None:
             observe = int(observe, base=10)
@@ -1108,6 +1109,7 @@ class Node:
             r'coap request from ([\da-f:]+)(?: OBS=(\d+))?'
             r'(?: with payload: ([\da-f]+))?\b', timeout=timeout)
         (source, observe, payload) = self.pexpect.match.groups()
+        source = source.decode('UTF-8')
 
         if observe is not None:
             observe = int(observe, base=10)
@@ -1144,6 +1146,7 @@ class Node:
             r'Received ACK in reply to notification '
             r'from ([\da-f:]+)\b', timeout=timeout)
         (source, ) = self.pexpect.match.groups()
+        source = source.decode('UTF-8')
 
         return source
 

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1143,21 +1143,33 @@ class Node:
         return source
 
     def coap_set_resource_path(self, path):
+        """
+        Set the path for the CoAP resource.
+        """
         cmd = 'coap resource %s' % path
         self.send_command(cmd)
         self._expect('Done')
 
     def coap_set_content(self, content):
+        """
+        Set the content of the CoAP resource.
+        """
         cmd = 'coap set %s' % content
         self.send_command(cmd)
         self._expect('Done')
 
     def coap_start(self):
+        """
+        Start the CoAP service.
+        """
         cmd = 'coap start'
         self.send_command(cmd)
         self._expect('Done')
 
     def coap_stop(self):
+        """
+        Stop the CoAP service.
+        """
         cmd = 'coap stop'
         self.send_command(cmd)
 

--- a/tests/scripts/thread-cert/test_coap_observe.py
+++ b/tests/scripts/thread-cert/test_coap_observe.py
@@ -41,6 +41,7 @@ class TestCoapObserve(unittest.TestCase):
     """
     Test suite for CoAP Observations (RFC7641).
     """
+
     def setUp(self):
         """
         Start up two nodes and get them on the virtual network.

--- a/tests/scripts/thread-cert/test_coap_observe.py
+++ b/tests/scripts/thread-cert/test_coap_observe.py
@@ -133,7 +133,7 @@ class TestCoapObserve(unittest.TestCase):
         self.nodes[LEADER].coap_set_content('Test123')
 
         self.nodes[ROUTER].coap_start()
-        response = self.nodes[ROUTER].coap_observe(mleid, 'test', con=True)
+        response = self.nodes[ROUTER].coap_observe(mleid, 'test', con=False)
 
         first_observe = response['observe']
         self.assertIsNotNone(first_observe)

--- a/tests/scripts/thread-cert/test_coap_observe.py
+++ b/tests/scripts/thread-cert/test_coap_observe.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import unittest
+
+import config
+import node
+
+LEADER = 1
+ROUTER = 2
+
+
+class TestCoapObserve(unittest.TestCase):
+    def setUp(self):
+        self.simulator = config.create_default_simulator()
+
+        self.nodes = {}
+        for i in range(1, 3):
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
+
+        self.nodes[LEADER].set_panid(0xface)
+        self.nodes[LEADER].set_mode('rsdn')
+        self.nodes[LEADER].add_whitelist(self.nodes[ROUTER].get_addr64())
+        self.nodes[LEADER].enable_whitelist()
+
+        self.nodes[ROUTER].set_panid(0xface)
+        self.nodes[ROUTER].set_mode('rsdn')
+        self.nodes[ROUTER].add_whitelist(self.nodes[LEADER].get_addr64())
+        self.nodes[ROUTER].enable_whitelist()
+        self.nodes[ROUTER].set_router_selection_jitter(1)
+
+    def tearDown(self):
+        for n in list(self.nodes.values()):
+            n.stop()
+            n.destroy()
+        self.simulator.stop()
+
+    def test_con(self):
+        self.nodes[LEADER].start()
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+
+        self.nodes[ROUTER].start()
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
+
+        mleid = self.nodes[LEADER].get_ip6_address(config.ADDRESS_TYPE.ML_EID)
+
+        self.nodes[LEADER].coap_start()
+        self.nodes[LEADER].coap_set_resource_path('test')
+        self.nodes[LEADER].coap_set_content('Test123')
+
+        self.nodes[ROUTER].coap_start()
+        response = self.nodes[ROUTER].coap_observe(mleid, 'test', con=True)
+
+        self.assertEqual(response['observe'], 0)
+        self.assertEqual(response['payload'], 'Test123')
+        self.assertEqual(response['source'], mleid)
+
+        # This should have been emitted already, so should return immediately
+        self.nodes[LEADER].coap_wait_subscribe()
+
+        # Now change the content on the leader and wait for it to show up
+        # on the router.
+        self.nodes[LEADER].coap_set_content('Test321')
+
+        response = self.nodes[ROUTER].coap_wait_response()
+        self.assertEqual(response['observe'], 0)
+        self.assertEqual(response['payload'], 'Test321')
+        self.assertEqual(response['source'], mleid)
+
+        self.nodes[ROUTER].coap_stop()
+        self.nodes[LEADER].coap_stop()
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
The following pull request implements support for [RFC7641 Observations](https://tools.ietf.org/html/rfc7641).

Observations was based on an earlier proof-of-concept which was tested against `node-coap`.

The implementation given here has been successfully been tested with `aiocoap-client` (with OpenThread implementing the server) and with Californium (with OpenThread implementing the client), as well as between two OpenThread nodes.