### PR TITLE
[spi-hdlc-adapter] add HDLC Flag in front of the HDLC frame

### DIFF
--- a/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
+++ b/tools/spi-hdlc-adapter/spi-hdlc-adapter.c
@@ -820,6 +820,8 @@ static int push_hdlc(void)
 
             unescaped_frame_len = sSpiRxPayloadSize;
 
+            escaped_frame_buffer[escaped_frame_len++] = HDLC_BYTE_FLAG;
+
             for (i = 0; i < sSpiRxPayloadSize; i++)
             {
                 c   = spiRxFrameBuffer[i + HEADER_LEN];


### PR DESCRIPTION
`spi-hdlc-adapter` forgot to add HDLC Flag in front of HDLC frames. RCP fortunately works with `spi-hdlc-adapter`, but in some special environments, they do not work properly. This commit fixes this issue.