### PR TITLE
[spinel] use direct uint type instead of enum

### DIFF
--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -1116,7 +1116,7 @@ spinel_ssize_t spinel_datatype_vpack(uint8_t *     data_out,
 
 // LCOV_EXCL_START
 
-const char *spinel_command_to_cstr(unsigned int command)
+const char *spinel_command_to_cstr(spinel_command_t command)
 {
     const char *ret = "UNKNOWN";
 
@@ -2422,7 +2422,7 @@ const char *spinel_status_to_cstr(spinel_status_t status)
     return ret;
 }
 
-const char *spinel_capability_to_cstr(unsigned int capability)
+const char *spinel_capability_to_cstr(spinel_capability_t capability)
 {
     const char *ret = "UNKNOWN";
 

--- a/src/ncp/spinel.c
+++ b/src/ncp/spinel.c
@@ -2239,7 +2239,7 @@ const char *spinel_net_role_to_cstr(uint8_t net_role)
     return ret;
 }
 
-const char *spinel_mcu_power_state_to_cstr(spinel_mcu_power_state_t mcu_power_state)
+const char *spinel_mcu_power_state_to_cstr(uint8_t mcu_power_state)
 {
     const char *ret = "MCU_POWER_STATE_UNKNOWN";
 
@@ -2255,6 +2255,9 @@ const char *spinel_mcu_power_state_to_cstr(spinel_mcu_power_state_t mcu_power_st
 
     case SPINEL_MCU_POWER_STATE_OFF:
         ret = "MCU_POWER_STATE_OFF";
+        break;
+
+    default:
         break;
     }
 

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -658,7 +658,6 @@ typedef struct
 typedef int          spinel_ssize_t;
 typedef unsigned int spinel_size_t;
 typedef uint8_t      spinel_tid_t;
-typedef unsigned int spinel_cid_t;
 
 enum
 {

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -374,7 +374,7 @@
 extern "C" {
 #endif
 
-typedef enum
+enum
 {
     SPINEL_STATUS_OK                       = 0,  ///< Operation has completed successfully.
     SPINEL_STATUS_FAILURE                  = 1,  ///< Operation has failed for some undefined reason.
@@ -469,7 +469,9 @@ typedef enum
 
     SPINEL_STATUS_EXPERIMENTAL__BEGIN = 2000000,
     SPINEL_STATUS_EXPERIMENTAL__END   = 2097152,
-} spinel_status_t;
+};
+
+typedef uint32_t spinel_status_t;
 
 typedef enum
 {
@@ -1106,7 +1108,7 @@ enum
  *    Experimental |          2,000,000 - 2,097,151 | Experimental use only
  *
  */
-typedef enum
+enum
 {
     /// Last Operation Status
     /** Format: `i` - Read-only
@@ -3898,7 +3900,9 @@ typedef enum
 
     SPINEL_PROP_EXPERIMENTAL__BEGIN = 2000000,
     SPINEL_PROP_EXPERIMENTAL__END   = 2097152,
-} spinel_prop_key_t;
+};
+
+typedef uint32_t spinel_prop_key_t;
 
 // ----------------------------------------------------------------------------
 

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -4085,7 +4085,7 @@ SPINEL_API_EXTERN const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key
 
 SPINEL_API_EXTERN const char *spinel_net_role_to_cstr(uint8_t net_role);
 
-SPINEL_API_EXTERN const char *spinel_mcu_power_state_to_cstr(spinel_mcu_power_state_t mcu_power_state);
+SPINEL_API_EXTERN const char *spinel_mcu_power_state_to_cstr(uint8_t mcu_power_state);
 
 SPINEL_API_EXTERN const char *spinel_status_to_cstr(spinel_status_t status);
 

--- a/src/ncp/spinel.h
+++ b/src/ncp/spinel.h
@@ -994,6 +994,8 @@ enum
     SPINEL_CMD_EXPERIMENTAL__END   = 2097152,
 };
 
+typedef uint32_t spinel_command_t;
+
 enum
 {
     SPINEL_CAP_LOCK       = 1,
@@ -1080,6 +1082,8 @@ enum
     SPINEL_CAP_EXPERIMENTAL__BEGIN = 2000000,
     SPINEL_CAP_EXPERIMENTAL__END   = 2097152,
 };
+
+typedef uint32_t spinel_capability_t;
 
 /**
  * Property Keys
@@ -4075,7 +4079,7 @@ SPINEL_API_EXTERN const char *spinel_next_packed_datatype(const char *pack_forma
 
 // ----------------------------------------------------------------------------
 
-SPINEL_API_EXTERN const char *spinel_command_to_cstr(unsigned int command);
+SPINEL_API_EXTERN const char *spinel_command_to_cstr(spinel_command_t command);
 
 SPINEL_API_EXTERN const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key);
 
@@ -4085,7 +4089,7 @@ SPINEL_API_EXTERN const char *spinel_mcu_power_state_to_cstr(spinel_mcu_power_st
 
 SPINEL_API_EXTERN const char *spinel_status_to_cstr(spinel_status_t status);
 
-SPINEL_API_EXTERN const char *spinel_capability_to_cstr(unsigned int capability);
+SPINEL_API_EXTERN const char *spinel_capability_to_cstr(spinel_capability_t capability);
 
 // ----------------------------------------------------------------------------
 


### PR DESCRIPTION
This PR contains smaller changes/fixes in spinel:

**[spinel] define spinel_prop_key_t and spinel_status_t as uint32_t (#4402)**

This commit defines `spinel_prop_key_t` and `spinel_status_t` as
`uint32_t` instead of `enum` value. This allows these types to
take values not included in `enum` (e.g., vendor or experimental
values) and addresses "out-of-range enumeration value" compiler
warnings.

**[spinel] add spinel_command_t & spinel_capability_t types as uint32_t (#4402)**

**[spinel] relax spinel_mcu_power_state_to_cstr input to allow any uint8_t (#4402)**

**[spinel] remove unused type definition (spinel_cit_t) (#4402)**


