### PR TITLE
[ip6] replace IpProto type with uint8_t

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -174,7 +174,7 @@ uint16_t Ip6::UpdateChecksum(uint16_t aChecksum, const Address &aAddress)
 uint16_t Ip6::ComputePseudoheaderChecksum(const Address &aSource,
                                           const Address &aDestination,
                                           uint16_t       aLength,
-                                          IpProto        aProto)
+                                          uint8_t        aProto)
 {
     uint16_t checksum;
 
@@ -448,7 +448,7 @@ void Ip6::EnqueueDatagram(Message &aMessage)
     mSendQueueTask.Post();
 }
 
-otError Ip6::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, IpProto aIpProto)
+otError Ip6::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aIpProto)
 {
     otError                    error = OT_ERROR_NONE;
     Header                     header;
@@ -623,7 +623,7 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_IP6_FRAGMENTATION_ENABLE
-otError Ip6::FragmentDatagram(Message &aMessage, IpProto aIpProto)
+otError Ip6::FragmentDatagram(Message &aMessage, uint8_t aIpProto)
 {
     otError        error = OT_ERROR_NONE;
     Header         header;
@@ -801,7 +801,7 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
         // creates the header for the reassembled ipv6 package
         VerifyOrExit(aMessage.Read(0, sizeof(header), &header) == sizeof(header), error = OT_ERROR_PARSE);
         header.SetPayloadLength(message->GetLength() - sizeof(header));
-        header.SetNextHeader(static_cast<IpProto>(fragmentHeader.GetNextHeader()));
+        header.SetNextHeader(fragmentHeader.GetNextHeader());
         assertValue = message->Write(0, sizeof(header), &header);
         assert(assertValue == sizeof(header));
 
@@ -901,7 +901,7 @@ exit:
 }
 
 #else
-otError Ip6::FragmentDatagram(Message &aMessage, IpProto aIpProto)
+otError Ip6::FragmentDatagram(Message &aMessage, uint8_t aIpProto)
 {
     OT_UNUSED_VARIABLE(aIpProto);
 
@@ -1427,7 +1427,7 @@ exit:
 
 // LCOV_EXCL_START
 
-const char *Ip6::IpProtoToString(IpProto aIpProto)
+const char *Ip6::IpProtoToString(uint8_t aIpProto)
 {
     const char *retval;
 

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -182,7 +182,7 @@ public:
      * @retval OT_ERROR_NO_BUFS  Insufficient available buffer to add the IPv6 headers.
      *
      */
-    otError SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, IpProto aIpProto);
+    otError SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aIpProto);
 
     /**
      * This method sends a raw IPv6 datagram with a fully formed IPv6 header.
@@ -250,7 +250,7 @@ public:
     static uint16_t ComputePseudoheaderChecksum(const Address &aSource,
                                                 const Address &aDestination,
                                                 uint16_t       aLength,
-                                                IpProto        aProto);
+                                                uint8_t        aProto);
 
     /**
      * This method registers a callback to provide received raw IPv6 datagrams.
@@ -332,7 +332,7 @@ public:
      * @returns The string representation of an IP protocol enumeration.
      *
      */
-    static const char *IpProtoToString(IpProto aIpProto);
+    static const char *IpProtoToString(uint8_t aIpProto);
 
 private:
     enum
@@ -357,7 +357,7 @@ private:
                                    bool         aForward,
                                    bool         aFromNcpHost,
                                    bool         aReceive);
-    otError FragmentDatagram(Message &aMessage, IpProto aIpProto);
+    otError FragmentDatagram(Message &aMessage, uint8_t aIpProto);
     otError HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMessageInfo, bool aFromNcpHost);
 #if OPENTHREAD_CONFIG_IP6_FRAGMENTATION_ENABLE
     void        CleanupFragmentationBuffer(void);

--- a/src/core/net/ip6_headers.hpp
+++ b/src/core/net/ip6_headers.hpp
@@ -88,7 +88,7 @@ using ot::Encoding::BigEndian::HostSwap32;
 /**
  * Internet Protocol Numbers
  */
-enum IpProto
+enum
 {
     kProtoHopOpts  = 0,  ///< IPv6 Hop-by-Hop Option
     kProtoTcp      = 6,  ///< Transmission Control Protocol
@@ -241,7 +241,7 @@ public:
      * @returns The IPv6 Next Header value.
      *
      */
-    IpProto GetNextHeader(void) const { return static_cast<IpProto>(mNextHeader); }
+    uint8_t GetNextHeader(void) const { return mNextHeader; }
 
     /**
      * This method sets the IPv6 Next Header value.
@@ -249,7 +249,7 @@ public:
      * @param[in]  aNextHeader  The IPv6 Next Header value.
      *
      */
-    void SetNextHeader(IpProto aNextHeader) { mNextHeader = static_cast<uint8_t>(aNextHeader); }
+    void SetNextHeader(uint8_t aNextHeader) { mNextHeader = aNextHeader; }
 
     /**
      * This method returns the IPv6 Hop Limit value.
@@ -355,7 +355,7 @@ public:
      * @returns The IPv6 Next Header value.
      *
      */
-    IpProto GetNextHeader(void) const { return static_cast<IpProto>(mNextHeader); }
+    uint8_t GetNextHeader(void) const { return mNextHeader; }
 
     /**
      * This method sets the IPv6 Next Header value.
@@ -363,7 +363,7 @@ public:
      * @param[in]  aNextHeader  The IPv6 Next Header value.
      *
      */
-    void SetNextHeader(IpProto aNextHeader) { mNextHeader = static_cast<uint8_t>(aNextHeader); }
+    void SetNextHeader(uint8_t aNextHeader) { mNextHeader = aNextHeader; }
 
     /**
      * This method returns the IPv6 Header Extension Length value.
@@ -561,7 +561,7 @@ public:
      * @returns The IPv6 Next Header value.
      *
      */
-    IpProto GetNextHeader(void) const { return static_cast<IpProto>(mNextHeader); }
+    uint8_t GetNextHeader(void) const { return mNextHeader; }
 
     /**
      * This method sets the IPv6 Next Header value.
@@ -569,7 +569,7 @@ public:
      * @param[in]  aNextHeader  The IPv6 Next Header value.
      *
      */
-    void SetNextHeader(IpProto aNextHeader) { mNextHeader = static_cast<uint8_t>(aNextHeader); }
+    void SetNextHeader(uint8_t aNextHeader) { mNextHeader = aNextHeader; }
 
     /**
      * This method returns the Fragment Offset value.

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -265,7 +265,7 @@ Message *Udp::NewMessage(uint16_t aReserved, const otMessageSettings *aSettings)
     return Get<Ip6>().NewMessage(sizeof(UdpHeader) + aReserved, aSettings);
 }
 
-otError Udp::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, IpProto aIpProto)
+otError Udp::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aIpProto)
 {
     otError error = OT_ERROR_NONE;
 

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -291,7 +291,7 @@ public:
      * @retval OT_ERROR_NO_BUFS  Insufficient available buffer to add the IPv6 headers.
      *
      */
-    otError SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, IpProto aIpProto);
+    otError SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aIpProto);
 
     /**
      * This method handles a received UDP message.

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -616,7 +616,7 @@ exit:
     return error;
 }
 
-otError Lowpan::DispatchToNextHeader(uint8_t aDispatch, Ip6::IpProto &aNextHeader)
+otError Lowpan::DispatchToNextHeader(uint8_t aDispatch, uint8_t &aNextHeader)
 {
     otError error = OT_ERROR_NONE;
 
@@ -671,7 +671,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     uint16_t             hcCtl;
     Context              srcContext, dstContext;
     bool                 srcContextValid = true, dstContextValid = true;
-    Ip6::IpProto         nextHeader;
+    uint8_t              nextHeader;
     uint8_t *            bytes;
 
     VerifyOrExit(remaining >= 2);
@@ -743,7 +743,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     if ((hcCtl & kHcNextHeader) == 0)
     {
         VerifyOrExit(remaining >= 1);
-        aIp6Header.SetNextHeader(static_cast<Ip6::IpProto>(cur[0]));
+        aIp6Header.SetNextHeader(cur[0]);
         cur++;
         remaining--;
         aCompressedNextHeader = false;
@@ -956,7 +956,7 @@ int Lowpan::DecompressExtensionHeader(Message &aMessage, const uint8_t *aBuf, ui
     uint16_t        remaining = aBufLength;
     uint8_t         hdr[2];
     uint8_t         len;
-    Ip6::IpProto    nextHeader;
+    uint8_t         nextHeader;
     uint8_t         ctl = cur[0];
     uint8_t         padLength;
     Ip6::OptionPad1 optionPad1;

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -379,7 +379,7 @@ private:
 
     int     DecompressExtensionHeader(Message &aMessage, const uint8_t *aBuf, uint16_t aBufLength);
     int     DecompressUdpHeader(Message &aMessage, const uint8_t *aBuf, uint16_t aBufLength, uint16_t aDatagramLength);
-    otError DispatchToNextHeader(uint8_t aDispatch, Ip6::IpProto &aNextHeader);
+    otError DispatchToNextHeader(uint8_t aDispatch, uint8_t &aNextHeader);
 
     static void    CopyContext(const Context &aContext, Ip6::Address &aAddress);
     static otError ComputeIid(const Mac::Address &aMacAddr, const Context &aContext, Ip6::Address &aIpAddress);

--- a/tests/unit/test_lowpan.hpp
+++ b/tests/unit/test_lowpan.hpp
@@ -109,12 +109,12 @@ public:
      * @param aDestination      String represents IPv6 destination address.
      *
      */
-    void SetIpHeader(uint32_t     aVersionClassFlow,
-                     uint16_t     aPayloadLength,
-                     Ip6::IpProto aNextHeader,
-                     uint8_t      aHopLimit,
-                     const char * aSource,
-                     const char * aDestination)
+    void SetIpHeader(uint32_t    aVersionClassFlow,
+                     uint16_t    aPayloadLength,
+                     uint8_t     aNextHeader,
+                     uint8_t     aHopLimit,
+                     const char *aSource,
+                     const char *aDestination)
     {
         mIpHeader.Init(aVersionClassFlow);
         mIpHeader.SetPayloadLength(aPayloadLength);
@@ -135,12 +135,12 @@ public:
      * @param aDestination      String represents IPv6 destination address.
      *
      */
-    void SetIpTunneledHeader(uint32_t     aVersionClassFlow,
-                             uint16_t     aPayloadLength,
-                             Ip6::IpProto aNextHeader,
-                             uint8_t      aHopLimit,
-                             const char * aSource,
-                             const char * aDestination)
+    void SetIpTunneledHeader(uint32_t    aVersionClassFlow,
+                             uint16_t    aPayloadLength,
+                             uint8_t     aNextHeader,
+                             uint8_t     aHopLimit,
+                             const char *aSource,
+                             const char *aDestination)
     {
         mIpTunneledHeader.Init(aVersionClassFlow);
         mIpTunneledHeader.SetPayloadLength(aPayloadLength);


### PR DESCRIPTION
To avoid operating on unspecified values.