### PR TITLE
[ncp-vendor-hook] fix example code, update example, add travis build

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -490,6 +490,22 @@ build_samr21() {
         --enable-radio-only                 \
         --with-examples=posix || die
     make -j 8 || die
+
+    export CPPFLAGS="                               \
+        -DOPENTHREAD_CONFIG_NCP_UART_ENABLE=1"
+
+    git checkout -- . || die
+    git clean -xfd || die
+    ./bootstrap || die
+    ./configure                             \
+        --enable-ncp                        \
+        --enable-ftd                        \
+        --enable-mtd                        \
+        --with-examples=posix               \
+        --disable-docs                      \
+        --disable-tests                     \
+        --with-ncp-vendor-hook-source=./src/ncp/example_vendor_hook.cpp || die
+    make -j 8 || die
 }
 
 [ $BUILD_TARGET != posix-distcheck ] || {

--- a/src/ncp/example_vendor_hook.cpp
+++ b/src/ncp/example_vendor_hook.cpp
@@ -119,4 +119,40 @@ otError NcpBase::VendorSetPropertyHandler(spinel_prop_key_t aPropKey)
 }  // namespace Ncp
 }  // namespace ot
 
-#endif
+//-------------------------------------------------------------------------------------------------------------------
+// When OPENTHREAD_ENABLE_NCP_VENDOR_HOOK is enabled, vendor code is
+// expected to provide the `otNcpInit()` function. The reason behind
+// this is to enable vendor code to define its own sub-class of
+// `NcpBase` or `NcpUart`/`NcpSpi`.
+//
+// Example below show how to add a vendor sub-class over `NcpUart`.
+
+#include "ncp_uart.hpp"
+#include "common/new.hpp"
+
+class NcpVendorUart : public ot::Ncp::NcpUart
+{
+public:
+    NcpVendorUart(ot::Instance *aInstance)
+        : ot::Ncp::NcpUart(aInstance)
+    {}
+
+    // Add public/private methods or member variables
+};
+
+static OT_DEFINE_ALIGNED_VAR(sNcpVendorRaw, sizeof(NcpVendorUart), uint64_t);
+
+extern "C" void otNcpInit(otInstance *aInstance)
+{
+    NcpVendorUart *ncpVendor = NULL;
+    ot::Instance * instance  = static_cast<ot::Instance *>(aInstance);
+
+    ncpVendor = new (&sNcpVendorRaw) NcpVendorUart(instance);
+
+    if (ncpVendor == NULL || ncpVendor != ot::Ncp::NcpBase::GetNcpInstance())
+    {
+        assert(false);
+    }
+}
+
+#endif // #if OPENTHREAD_ENABLE_NCP_VENDOR_HOOK

--- a/src/ncp/example_vendor_hook.cpp
+++ b/src/ncp/example_vendor_hook.cpp
@@ -47,7 +47,7 @@ otError NcpBase::VendorCommandHandler(uint8_t aHeader, unsigned int aCommand)
     // TODO: Implement your command handlers here.
 
     default:
-        error = SendLastStatus(aHeader, SPINEL_STATUS_INVALID_COMMAND);
+        error = PrepareLastStatusResponse(aHeader, SPINEL_STATUS_INVALID_COMMAND);
     }
 
     return error;


### PR DESCRIPTION
This PR contains 3 commit related to ncp vendor hook example:
- [ncp-vendor-hook] fix example code to use new NcpBase method (#4405)
- [travis] check vendor ncp hook example build under posix (#4405)
- [ncp-vendor-hook] update example to show how to subclass (#4405)
