### PR TITLE
[posix-host] update IsSafeToHandleNow() to avoid re-entrant issue

### DIFF
--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -626,8 +626,7 @@ private:
      */
     bool IsSafeToHandleNow(spinel_prop_key_t aKey) const
     {
-        return !((mWaitingKey != SPINEL_PROP_LAST_STATUS) &&
-                 (aKey == SPINEL_PROP_STREAM_RAW || aKey == SPINEL_PROP_MAC_ENERGY_SCAN_RESULT));
+        return !(aKey == SPINEL_PROP_STREAM_RAW || aKey == SPINEL_PROP_MAC_ENERGY_SCAN_RESULT);
     }
 
     void HandleNotification(HdlcInterface::RxFrameBuffer &aFrameBuffer);


### PR DESCRIPTION
`mWaitingKey != SPINEL_PROP_LAST_STATUS` means the NCP is waiting for a spinel
response from RCP. When `mWaitingKey` is set to `SPINEL_PROP_LAST_STATUS` and
`HdlcInterface` receives a `ChildIdResponse` message from RCP，`HdlcInterface`
calls the function `Decode()` to decode the received HDLC frame. Then the decoded
spinel frame is sent to `RadioSpinel` module. Because the function `IsSafeToHandleNow()`
returns true now. The `RadioSpinel` sends the received `ChildIdResponse` frame to
up layer immediately. Then the MLE layer calls the function `otPlatRadioSetShortAddress()`
to set short address. The function `otPlatRadioSetShortAddress()` sends spinel
frame `MAC_15_4_SADDR` to RCP and waits for the spinel response. When the
response frame is received, the `HdlcInterface` calls the function `Decode()`
again, the function `Decode()` uses previous calculated FCS value to calculate
the current received HDLC frame. The wrong FCS value caused the parsing error for
the received response frame. 