### PR TITLE
[neighbor-table] adding NeighborTable

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -211,6 +211,7 @@ LOCAL_SRC_FILES                                          := \
     src/core/thread/mesh_forwarder_mtd.cpp                  \
     src/core/thread/mle.cpp                                 \
     src/core/thread/mle_router.cpp                          \
+    src/core/thread/neighbor_table.cpp                      \
     src/core/thread/network_data.cpp                        \
     src/core/thread/network_data_leader.cpp                 \
     src/core/thread/network_data_leader_ftd.cpp             \

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -143,6 +143,7 @@ static_library("lib-ot-core") {
     "src/core/thread/mesh_forwarder_mtd.cpp",
     "src/core/thread/mle.cpp",
     "src/core/thread/mle_router.cpp",
+    "src/core/thread/neighbor_table.cpp",
     "src/core/thread/network_data.cpp",
     "src/core/thread/network_data_leader.cpp",
     "src/core/thread/network_data_leader_ftd.cpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -162,6 +162,7 @@ set(COMMON_SOURCES
     thread/mesh_forwarder_mtd.cpp
     thread/mle.cpp
     thread/mle_router.cpp
+    thread/neighbor_table.cpp
     thread/network_data.cpp
     thread/network_data_leader.cpp
     thread/network_data_leader_ftd.cpp

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -213,6 +213,7 @@ SOURCES_COMMON                             = \
     thread/mesh_forwarder_mtd.cpp            \
     thread/mle.cpp                           \
     thread/mle_router.cpp                    \
+    thread/neighbor_table.cpp                \
     thread/network_data.cpp                  \
     thread/network_data_leader.cpp           \
     thread/network_data_leader_ftd.cpp       \
@@ -418,6 +419,7 @@ HEADERS_COMMON                             = \
     thread/mle_router_ftd.hpp                \
     thread/mle_router_mtd.hpp                \
     thread/mle_tlvs.hpp                      \
+    thread/neighbor_table.hpp                \
     thread/network_data.hpp                  \
     thread/network_data_leader.hpp           \
     thread/network_data_leader_ftd.hpp       \

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -311,7 +311,7 @@ otError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
     VerifyOrExit(instance.Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_CHILD, error = OT_ERROR_INVALID_STATE);
 #endif
 
-    parent = instance.Get<Mle::MleRouter>().GetParent();
+    parent = &instance.Get<Mle::MleRouter>().GetParent();
 
     aParentInfo->mExtAddress     = parent->GetExtAddress();
     aParentInfo->mRloc16         = parent->GetRloc16();
@@ -334,12 +334,10 @@ otError otThreadGetParentAverageRssi(otInstance *aInstance, int8_t *aParentRssi)
 {
     otError   error    = OT_ERROR_NONE;
     Instance &instance = *static_cast<Instance *>(aInstance);
-    Router *  parent;
 
     assert(aParentRssi != NULL);
 
-    parent       = instance.Get<Mle::MleRouter>().GetParent();
-    *aParentRssi = parent->GetLinkInfo().GetAverageRss();
+    *aParentRssi = instance.Get<Mle::MleRouter>().GetParent().GetLinkInfo().GetAverageRss();
 
     VerifyOrExit(*aParentRssi != OT_RADIO_RSSI_INVALID, error = OT_ERROR_FAILED);
 
@@ -351,12 +349,10 @@ otError otThreadGetParentLastRssi(otInstance *aInstance, int8_t *aLastRssi)
 {
     otError   error    = OT_ERROR_NONE;
     Instance &instance = *static_cast<Instance *>(aInstance);
-    Router *  parent;
 
     assert(aLastRssi != NULL);
 
-    parent     = instance.Get<Mle::MleRouter>().GetParent();
-    *aLastRssi = parent->GetLinkInfo().GetLastRss();
+    *aLastRssi = instance.Get<Mle::MleRouter>().GetParent().GetLinkInfo().GetLastRss();
 
     VerifyOrExit(*aLastRssi != OT_RADIO_RSSI_INVALID, error = OT_ERROR_FAILED);
 

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -448,6 +448,11 @@ template <> inline Mle::MleRouter &Instance::Get(void)
     return mThreadNetif.mMleRouter;
 }
 
+template <> inline NeighborTable &Instance::Get(void)
+{
+    return mThreadNetif.mMleRouter.mNeighborTable;
+}
+
 template <> inline ChildTable &Instance::Get(void)
 {
     return mThreadNetif.mMleRouter.mChildTable;

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -79,7 +79,7 @@ DataPollHandler::DataPollHandler(Instance &aInstance)
 
 void DataPollHandler::Clear(void)
 {
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
     {
         Child &child = *iter.GetChild();
         child.SetDataPollPending(false);
@@ -134,7 +134,7 @@ void DataPollHandler::HandleDataPoll(Mac::RxFrame &aFrame)
     VerifyOrExit(Get<Mle::MleRouter>().GetRole() != OT_DEVICE_ROLE_DETACHED);
 
     SuccessOrExit(aFrame.GetSrcAddr(macSource));
-    child = Get<ChildTable>().FindChild(macSource, ChildTable::kInStateValidOrRestoring);
+    child = Get<ChildTable>().FindChild(macSource, Child::kInStateValidOrRestoring);
     VerifyOrExit(child != NULL);
 
     child->SetLastHeard(TimerMilli::GetNow());
@@ -289,7 +289,7 @@ exit:
 
 void DataPollHandler::ProcessPendingPolls(void)
 {
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValidOrRestoring); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValidOrRestoring); !iter.IsDone(); iter++)
     {
         Child *child = iter.GetChild();
 

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -138,7 +138,7 @@ otError DataPollSender::GetPollDestinationAddress(Mac::Address &aDest) const
 
     VerifyOrExit((parent != NULL) && parent->IsStateValidOrRestoring(), error = OT_ERROR_ABORT);
 
-    if ((Get<Mac::Mac>().GetShortAddress() == Mac::kShortAddrInvalid) || (parent != Get<Mle::MleRouter>().GetParent()))
+    if ((Get<Mac::Mac>().GetShortAddress() == Mac::kShortAddrInvalid) || (parent != &Get<Mle::MleRouter>().GetParent()))
     {
         aDest.SetExtended(parent->GetExtAddress());
     }

--- a/src/core/mac/data_poll_sender.hpp
+++ b/src/core/mac/data_poll_sender.hpp
@@ -40,6 +40,7 @@
 #include "common/locator.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_frame.hpp"
+#include "thread/topology.hpp"
 
 namespace ot {
 
@@ -266,10 +267,11 @@ private:
         kRecalculatePollPeriod,
     };
 
-    void        ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector);
-    uint32_t    CalculatePollPeriod(void) const;
-    static void HandlePollTimer(Timer &aTimer);
-    static void UpdateIfLarger(uint32_t &aPeriod, uint32_t aNewPeriod);
+    void            ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector);
+    uint32_t        CalculatePollPeriod(void) const;
+    const Neighbor &GetParent(void) const;
+    static void     HandlePollTimer(Timer &aTimer);
+    static void     UpdateIfLarger(uint32_t &aPeriod, uint32_t aNewPeriod);
 
     TimeMilli mTimerStartTime;
     uint32_t  mPollPeriod;

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1099,7 +1099,7 @@ void Mac::RecordFrameTransmitStatus(const TxFrame &aFrame,
     VerifyOrExit(!aFrame.IsEmpty());
 
     aFrame.GetDstAddr(dstAddr);
-    neighbor = Get<Mle::MleRouter>().GetNeighbor(dstAddr);
+    neighbor = Get<NeighborTable>().FindNeighbor(dstAddr, Neighbor::kInStateValidOrRestoring);
 
 #if OPENTHREAD_CONFIG_ENABLE_TX_ERROR_RATE_TRACKING
 
@@ -1482,7 +1482,7 @@ void Mac::HandleReceivedFrame(RxFrame *aFrame, otError aError)
 
     aFrame->GetSrcAddr(srcaddr);
     aFrame->GetDstAddr(dstaddr);
-    neighbor = Get<Mle::MleRouter>().GetNeighbor(srcaddr);
+    neighbor = Get<NeighborTable>().FindNeighbor(srcaddr, Neighbor::kInStateValidOrRestoring);
 
     // Destination Address Filtering
     switch (dstaddr.GetType())
@@ -1496,11 +1496,13 @@ void Mac::HandleReceivedFrame(RxFrame *aFrame, otError aError)
                          ((mRxOnWhenIdle && dstaddr.IsBroadcast()) || dstaddr.GetShort() == GetShortAddress()),
                      error = OT_ERROR_DESTINATION_ADDRESS_FILTERED);
 
+#if OPENTHREAD_FTD
         // Allow  multicasts from neighbor routers if FTD
         if (neighbor == NULL && dstaddr.IsBroadcast() && Get<Mle::MleRouter>().IsFullThreadDevice())
         {
-            neighbor = Get<Mle::MleRouter>().GetRxOnlyNeighborRouter(srcaddr);
+            neighbor = Get<NeighborTable>().FindRxOnlyNeighbor(srcaddr, Neighbor::kInStateValidOrRestoring);
         }
+#endif
 
         break;
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -600,7 +600,7 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
     macAddr.Set(mlIidTlv.GetIid());
     macAddr.ToggleLocal();
 
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValid); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValid); !iter.IsDone(); iter++)
     {
         Child &child = *iter.GetChild();
 
@@ -666,7 +666,7 @@ void AddressResolver::HandleAddressQuery(Coap::Message &aMessage, const Ip6::Mes
         ExitNow();
     }
 
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValid); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValid); !iter.IsDone(); iter++)
     {
         Child &child = *iter.GetChild();
 

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -41,7 +41,7 @@ namespace ot {
 
 #if OPENTHREAD_FTD
 
-ChildTable::Iterator::Iterator(Instance &aInstance, StateFilter aFilter)
+ChildTable::Iterator::Iterator(Instance &aInstance, Child::StateFilter aFilter)
     : InstanceLocator(aInstance)
     , mFilter(aFilter)
     , mStart(NULL)
@@ -50,7 +50,7 @@ ChildTable::Iterator::Iterator(Instance &aInstance, StateFilter aFilter)
     Reset();
 }
 
-ChildTable::Iterator::Iterator(Instance &aInstance, StateFilter aFilter, Child *aStartingChild)
+ChildTable::Iterator::Iterator(Instance &aInstance, Child::StateFilter aFilter, Child *aStartingChild)
     : InstanceLocator(aInstance)
     , mFilter(aFilter)
     , mStart(aStartingChild)
@@ -68,7 +68,7 @@ void ChildTable::Iterator::Reset(void)
 
     mChild = mStart;
 
-    if (!MatchesFilter(*mChild, mFilter))
+    if (!mChild->MatchesFilter(mFilter))
     {
         Advance();
     }
@@ -92,7 +92,7 @@ void ChildTable::Iterator::Advance(void)
         }
 
         VerifyOrExit(mChild != mStart, mChild = NULL);
-    } while (!MatchesFilter(*mChild, mFilter));
+    } while (!mChild->MatchesFilter(mFilter));
 
 exit:
     return;
@@ -143,13 +143,13 @@ exit:
     return child;
 }
 
-Child *ChildTable::FindChild(uint16_t aRloc16, StateFilter aFilter)
+Child *ChildTable::FindChild(uint16_t aRloc16, Child::StateFilter aFilter)
 {
     Child *child = mChildren;
 
     for (uint16_t num = mMaxChildrenAllowed; num != 0; num--, child++)
     {
-        if (MatchesFilter(*child, aFilter) && (child->GetRloc16() == aRloc16))
+        if (child->MatchesFilter(aFilter) && (child->GetRloc16() == aRloc16))
         {
             ExitNow();
         }
@@ -161,13 +161,13 @@ exit:
     return child;
 }
 
-Child *ChildTable::FindChild(const Mac::ExtAddress &aAddress, StateFilter aFilter)
+Child *ChildTable::FindChild(const Mac::ExtAddress &aAddress, Child::StateFilter aFilter)
 {
     Child *child = mChildren;
 
     for (uint16_t num = mMaxChildrenAllowed; num != 0; num--, child++)
     {
-        if (MatchesFilter(*child, aFilter) && (child->GetExtAddress() == aAddress))
+        if (child->MatchesFilter(aFilter) && (child->GetExtAddress() == aAddress))
         {
             ExitNow();
         }
@@ -179,7 +179,7 @@ exit:
     return child;
 }
 
-Child *ChildTable::FindChild(const Mac::Address &aAddress, StateFilter aFilter)
+Child *ChildTable::FindChild(const Mac::Address &aAddress, Child::StateFilter aFilter)
 {
     Child *child = NULL;
 
@@ -200,14 +200,14 @@ Child *ChildTable::FindChild(const Mac::Address &aAddress, StateFilter aFilter)
     return child;
 }
 
-bool ChildTable::HasChildren(StateFilter aFilter) const
+bool ChildTable::HasChildren(Child::StateFilter aFilter) const
 {
     bool         rval  = false;
     const Child *child = mChildren;
 
     for (uint16_t num = mMaxChildrenAllowed; num != 0; num--, child++)
     {
-        if (MatchesFilter(*child, aFilter))
+        if (child->MatchesFilter(aFilter))
         {
             ExitNow(rval = true);
         }
@@ -217,14 +217,14 @@ exit:
     return rval;
 }
 
-uint16_t ChildTable::GetNumChildren(StateFilter aFilter) const
+uint16_t ChildTable::GetNumChildren(Child::StateFilter aFilter) const
 {
     uint16_t     numChildren = 0;
     const Child *child       = mChildren;
 
     for (uint16_t num = mMaxChildrenAllowed; num != 0; num--, child++)
     {
-        if (MatchesFilter(*child, aFilter))
+        if (child->MatchesFilter(aFilter))
         {
             numChildren++;
         }
@@ -238,46 +238,12 @@ otError ChildTable::SetMaxChildrenAllowed(uint16_t aMaxChildren)
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aMaxChildren > 0 && aMaxChildren <= kMaxChildren, error = OT_ERROR_INVALID_ARGS);
-    VerifyOrExit(!HasChildren(kInStateAnyExceptInvalid), error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(!HasChildren(Child::kInStateAnyExceptInvalid), error = OT_ERROR_INVALID_STATE);
 
     mMaxChildrenAllowed = aMaxChildren;
 
 exit:
     return error;
-}
-
-bool ChildTable::MatchesFilter(const Child &aChild, StateFilter aFilter)
-{
-    bool rval = false;
-
-    switch (aFilter)
-    {
-    case kInStateValid:
-        rval = aChild.IsStateValid();
-        break;
-
-    case kInStateValidOrRestoring:
-        rval = aChild.IsStateValidOrRestoring();
-        break;
-
-    case kInStateChildIdRequest:
-        rval = aChild.IsStateChildIdRequest();
-        break;
-
-    case kInStateValidOrAttaching:
-        rval = aChild.IsStateValidOrAttaching();
-        break;
-
-    case kInStateAnyExceptInvalid:
-        rval = !aChild.IsStateInvalid();
-        break;
-
-    case kInStateAnyExceptValidOrRestoring:
-        rval = !aChild.IsStateValidOrRestoring();
-        break;
-    }
-
-    return rval;
 }
 
 #endif // OPENTHREAD_FTD

--- a/src/core/thread/child_table.hpp
+++ b/src/core/thread/child_table.hpp
@@ -51,22 +51,6 @@ class ChildTable : public InstanceLocator
 {
 public:
     /**
-     * This enumeration defines child state filters used for finding a child or iterating through the child table.
-     *
-     * Each filter definition accepts a subset of `Child:State` values.
-     *
-     */
-    enum StateFilter
-    {
-        kInStateValid,                     ///< Accept child only in `Child::kStateValid`.
-        kInStateValidOrRestoring,          ///< Accept child with `Child::IsStateValidOrRestoring()` being `true`.
-        kInStateChildIdRequest,            ///< Accept child only in `Child:kStateChildIdRequest`.
-        kInStateValidOrAttaching,          ///< Accept child with `Child::IsStateValidOrAttaching()` being `true`.
-        kInStateAnyExceptInvalid,          ///< Accept child in any state except `Child:kStateInvalid`.
-        kInStateAnyExceptValidOrRestoring, ///< Accept child in any state except `Child::IsStateValidOrRestoring()`.
-    };
-
-    /**
      * This class represents an iterator for iterating through the child entries in the child table.
      *
      */
@@ -80,7 +64,7 @@ public:
          * @param[in] aFilter    A child state filter.
          *
          */
-        Iterator(Instance &aInstance, StateFilter aFilter);
+        Iterator(Instance &aInstance, Child::StateFilter aFilter);
 
         /**
          * This constructor initializes an `Iterator` instance to start from a given child.
@@ -96,7 +80,7 @@ public:
          * @param[in] aStartingChild   A pointer to a child. If non-NULL, the iterator starts from the given entry.
          *
          */
-        Iterator(Instance &aInstance, StateFilter aFilter, Child *aStartingChild);
+        Iterator(Instance &aInstance, Child::StateFilter aFilter, Child *aStartingChild);
 
         /**
          * This method resets the iterator to start over.
@@ -153,9 +137,9 @@ public:
         Child *GetChild(void) { return mChild; }
 
     private:
-        StateFilter mFilter;
-        Child *     mStart;
-        Child *     mChild;
+        Child::StateFilter mFilter;
+        Child *            mStart;
+        Child *            mChild;
     };
 
     /**
@@ -212,7 +196,7 @@ public:
      * @returns  A pointer to the `Child` entry if one is found, or `NULL` otherwise.
      *
      */
-    Child *FindChild(uint16_t aRloc16, StateFilter aFilter);
+    Child *FindChild(uint16_t aRloc16, Child::StateFilter aFilter);
 
     /**
      * This method searches the child table for a `Child` with a given extended address also matching a given state
@@ -224,7 +208,7 @@ public:
      * @returns  A pointer to the `Child` entry if one is found, or `NULL` otherwise.
      *
      */
-    Child *FindChild(const Mac::ExtAddress &aAddress, StateFilter aFilter);
+    Child *FindChild(const Mac::ExtAddress &aAddress, Child::StateFilter aFilter);
 
     /**
      * This method searches the child table for a `Child` with a given address also matching a given state filter.
@@ -235,7 +219,7 @@ public:
      * @returns  A pointer to the `Child` entry if one is found, or `NULL` otherwise.
      *
      */
-    Child *FindChild(const Mac::Address &aAddress, StateFilter aFilter);
+    Child *FindChild(const Mac::Address &aAddress, Child::StateFilter aFilter);
 
     /**
      * This method indicates whether the child table contains any child matching a given state filter.
@@ -245,7 +229,7 @@ public:
      * @returns  TRUE if the table contains at least one child table matching the given filter, FALSE otherwise.
      *
      */
-    bool HasChildren(StateFilter aFilter) const;
+    bool HasChildren(Child::StateFilter aFilter) const;
 
     /**
      * This method returns the number of children in the child table matching a given state filter.
@@ -255,7 +239,7 @@ public:
      * @returns Number of children matching the given state filer.
      *
      */
-    uint16_t GetNumChildren(StateFilter aFilter) const;
+    uint16_t GetNumChildren(Child::StateFilter aFilter) const;
 
     /**
      * This method returns the maximum number of children that can be supported (build-time constant).
@@ -297,8 +281,6 @@ private:
         kMaxChildren = OPENTHREAD_CONFIG_MLE_MAX_CHILDREN,
     };
 
-    static bool MatchesFilter(const Child &aChild, StateFilter aFilter);
-
     uint16_t mMaxChildrenAllowed;
     Child    mChildren[kMaxChildren];
 };
@@ -310,20 +292,11 @@ private:
 class ChildTable : public InstanceLocator
 {
 public:
-    enum StateFilter
-    {
-        kInStateValid,
-        kInStateValidOrRestoring,
-        kInStateChildIdRequest,
-        kInStateValidOrAttaching,
-        kInStateAnyExceptInvalid,
-    };
-
     class Iterator
     {
     public:
-        Iterator(Instance &, StateFilter) {}
-        Iterator(Instance &, StateFilter, Child *) {}
+        Iterator(Instance &, Child::StateFilter) {}
+        Iterator(Instance &, Child::StateFilter, Child *) {}
         void   Reset(void) {}
         bool   IsDone(void) const { return true; }
         void   Advance(void) {}
@@ -343,12 +316,12 @@ public:
 
     Child *GetNewChild(void) { return NULL; }
 
-    Child *FindChild(uint16_t, StateFilter) { return NULL; }
-    Child *FindChild(const Mac::ExtAddress &, StateFilter) { return NULL; }
-    Child *FindChild(const Mac::Address &, StateFilter) { return NULL; }
+    Child *FindChild(uint16_t, Child::StateFilter) { return NULL; }
+    Child *FindChild(const Mac::ExtAddress &, Child::StateFilter) { return NULL; }
+    Child *FindChild(const Mac::Address &, Child::StateFilter) { return NULL; }
 
-    bool     HasChildren(StateFilter) const { return false; }
-    uint16_t GetNumChildren(StateFilter) const { return 0; }
+    bool     HasChildren(Child::StateFilter) const { return false; }
+    uint16_t GetNumChildren(Child::StateFilter) const { return 0; }
     uint16_t GetMaxChildren(void) const { return 0; }
     uint16_t GetMaxChildrenAllowed(void) const { return 0; }
     otError  SetMaxChildrenAllowed(uint16_t) { return OT_ERROR_INVALID_STATE; }

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -72,7 +72,7 @@ void IndirectSender::Stop(void)
 {
     VerifyOrExit(mEnabled);
 
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
     {
         iter.GetChild()->SetIndirectMessage(NULL);
         mSourceMatchController.ResetMessageCount(*iter.GetChild());
@@ -557,8 +557,7 @@ exit:
 
 void IndirectSender::ClearMessagesForRemovedChildren(void)
 {
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptValidOrRestoring); !iter.IsDone();
-         iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateAnyExceptValidOrRestoring); !iter.IsDone(); iter++)
     {
         if (iter.GetChild()->GetIndirectMessageCount() == 0)
         {

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -133,7 +133,7 @@ otError KeyManager::SetMasterKey(const MasterKey &aKey)
     }
 
     // reset child frame counters
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
     {
         iter.GetChild()->SetKeySequence(0);
         iter.GetChild()->SetLinkFrameCounter(0);

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -119,7 +119,7 @@ otError KeyManager::SetMasterKey(const MasterKey &aKey)
     ComputeKey(mKeySequence, mKey);
 
     // reset parent frame counters
-    parent = Get<Mle::MleRouter>().GetParent();
+    parent = &Get<Mle::MleRouter>().GetParent();
     parent->SetKeySequence(0);
     parent->SetLinkFrameCounter(0);
     parent->SetMleFrameCounter(0);

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -848,7 +848,7 @@ Neighbor *MeshForwarder::UpdateNeighborOnSentFrame(Mac::TxFrame &aFrame, otError
 
     VerifyOrExit(mEnabled);
 
-    neighbor = Get<Mle::MleRouter>().GetNeighbor(aMacDest);
+    neighbor = Get<NeighborTable>().FindNeighbor(aMacDest, Neighbor::kInStateValidOrRestoring);
     VerifyOrExit(neighbor != NULL);
 
     VerifyOrExit(aFrame.GetAckRequest());

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -140,7 +140,7 @@ exit:
 void MeshForwarder::RemoveMessage(Message &aMessage)
 {
 #if OPENTHREAD_FTD
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
     {
         IgnoreReturnValue(mIndirectSender.RemoveMessageFromSleepyChild(aMessage, *iter.GetChild()));
     }

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -80,7 +80,7 @@ otError MeshForwarder::SendMessage(Message &aMessage)
                     ip6Header.GetDestination() == mle.GetRealmLocalAllThreadNodesAddress())
                 {
                     // destined for all sleepy children
-                    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValidOrRestoring); !iter.IsDone();
+                    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValidOrRestoring); !iter.IsDone();
                          iter++)
                     {
                         Child &child = *iter.GetChild();
@@ -94,7 +94,7 @@ otError MeshForwarder::SendMessage(Message &aMessage)
                 else
                 {
                     // destined for some sleepy children which subscribed the multicast address.
-                    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValidOrRestoring); !iter.IsDone();
+                    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValidOrRestoring); !iter.IsDone();
                          iter++)
                     {
                         Child &child = *iter.GetChild();
@@ -296,7 +296,7 @@ void MeshForwarder::RemoveDataResponseMessages(void)
 
         if (!(ip6Header.GetDestination().IsMulticast()))
         {
-            for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
+            for (ChildTable::Iterator iter(GetInstance(), Child::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
             {
                 IgnoreReturnValue(mIndirectSender.RemoveMessageFromSleepyChild(*message, *iter.GetChild()));
             }

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3959,22 +3959,6 @@ bool Mle::IsMeshLocalAddress(const Ip6::Address &aAddress) const
     return aAddress.PrefixMatch(GetMeshLocal16()) >= Ip6::Address::kMeshLocalPrefixLength;
 }
 
-Router *Mle::GetParentCandidate(void)
-{
-    Router *rval;
-
-    if (mParentCandidate.IsStateValid())
-    {
-        rval = &mParentCandidate;
-    }
-    else
-    {
-        rval = &mParent;
-    }
-
-    return rval;
-}
-
 otError Mle::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, Ip6::Header &aIp6Header)
 {
     otError          error = OT_ERROR_DROP;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3959,11 +3959,6 @@ bool Mle::IsMeshLocalAddress(const Ip6::Address &aAddress) const
     return aAddress.PrefixMatch(GetMeshLocal16()) >= Ip6::Address::kMeshLocalPrefixLength;
 }
 
-Router *Mle::GetParent(void)
-{
-    return &mParent;
-}
-
 Router *Mle::GetParentCandidate(void)
 {
     Router *rval;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -603,6 +603,19 @@ public:
     bool IsAttached(void) const;
 
     /**
+     * This method indicates whether device is currently attaching or not.
+     *
+     * Note that an already attached device may also be in attaching state. Examples of this include a leader/router
+     * trying to attach to a better partition, or a child trying to find a better parent (when feature
+     * `OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE` is enabled).
+     *
+     * @retval TRUE   Device is currently trying to attach.
+     * @retval FALSE  Device is not in middle of attach process.
+     *
+     */
+    bool IsAttaching(void) const { return (mAttachState != kAttachStateIdle); }
+
+    /**
      * This method returns the current Thread interface state.
      *
      * @returns The current Thread interface state.

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -747,12 +747,12 @@ public:
     }
 
     /**
-     * This method returns a pointer to the parent when operating in End Device mode.
+     * This method gets the parent when operating in End Device mode.
      *
-     * @returns A pointer to the parent.
+     * @returns A reference to the parent.
      *
      */
-    Router *GetParent(void);
+    Router &GetParent(void) { return mParent; }
 
     /**
      * This method returns a pointer to the parent candidate or parent.

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -755,15 +755,12 @@ public:
     Router &GetParent(void) { return mParent; }
 
     /**
-     * This method returns a pointer to the parent candidate or parent.
+     * This method get the parent candidate.
      *
-     * This method is useful when sending IEEE 802.15.4 Data Request frames while attempting to attach to a new parent.
-     *
-     * If attempting to attach to a new parent, this method returns the parent candidate.
-     * If not attempting to attach, this method returns the parent.
+     * The parent candidate is valid when attempting to attach to a new parent.
      *
      */
-    Router *GetParentCandidate(void);
+    Router &GetParentCandidate(void) { return mParentCandidate; }
 
     /**
      * This method indicates whether or not an IPv6 address is an RLOC.

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -45,6 +45,7 @@
 #include "thread/device_mode.hpp"
 #include "thread/mle_constants.hpp"
 #include "thread/mle_tlvs.hpp"
+#include "thread/neighbor_table.hpp"
 #include "thread/topology.hpp"
 
 namespace ot {
@@ -1412,50 +1413,6 @@ protected:
     otError CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, Ip6::Header &aIp6Header);
 
     /**
-     * This method returns a pointer to the neighbor object.
-     *
-     * @param[in]  aAddress  A reference to the MAC address.
-     *
-     * @returns A pointer to the neighbor object.
-     *
-     */
-    Neighbor *GetNeighbor(const Mac::Address &aAddress);
-
-    /**
-     * This method returns a pointer to the neighbor object.
-     *
-     * @param[in]  aAddress  A reference to the MAC short address.
-     *
-     * @returns A pointer to the neighbor object.
-     *
-     */
-    Neighbor *GetNeighbor(Mac::ShortAddress aAddress);
-
-    /**
-     * This method returns a pointer to the neighbor object.
-     *
-     * @param[in]  aAddress  A reference to the MAC extended address.
-     *
-     * @returns A pointer to the neighbor object.
-     *
-     */
-    Neighbor *GetNeighbor(const Mac::ExtAddress &aAddress);
-
-    /**
-     * This method returns a pointer to the neighbor object.
-     *
-     * @param[in]  aAddress  A reference to the IPv6 address.
-     *
-     * @returns A pointer to the neighbor object.
-     *
-     */
-    Neighbor *GetNeighbor(const Ip6::Address &aAddress)
-    {
-        OT_UNUSED_VARIABLE(aAddress);
-        return NULL;
-    }
-
-    /**
      * This method returns the next hop towards an RLOC16 destination.
      *
      * @param[in]  aDestination  The RLOC16 of the destination.
@@ -1632,6 +1589,7 @@ protected:
     bool          mRetrieveNewNetworkData;   ///< Indicating new Network Data is needed if set.
     otDeviceRole  mRole;                     ///< Current Thread role.
     Router        mParent;                   ///< Parent information.
+    NeighborTable mNeighborTable;            ///< The neighbor table.
     DeviceMode    mDeviceMode;               ///< Device mode setting.
     AttachState   mAttachState;              ///< The parent request state.
     ReattachState mReattachState;            ///< Reattach state

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -416,7 +416,7 @@ otError MleRouter::SendAdvertisement(void)
     // Without this suppression, a device may send an MLE Advertisement before receiving the MLE Child ID Response.
     // The candidate parent then removes the attaching device because the Source Address TLV includes an RLOC16 that
     // indicates a Router role (i.e. a Child ID equal to zero).
-    VerifyOrExit(mAttachState == kAttachStateIdle);
+    VerifyOrExit(!IsAttaching());
 
     // Suppress MLE Advertisements when transitioning to the router role.
     //
@@ -573,7 +573,7 @@ otError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::Message
 
     VerifyOrExit(mRole == OT_DEVICE_ROLE_ROUTER || mRole == OT_DEVICE_ROLE_LEADER, error = OT_ERROR_INVALID_STATE);
 
-    VerifyOrExit(mAttachState == kAttachStateIdle, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(!IsAttaching(), error = OT_ERROR_INVALID_STATE);
 
     // Challenge
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kChallenge, sizeof(challenge), challenge));
@@ -1603,7 +1603,7 @@ otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::Messa
     // A Router MUST NOT send an MLE Parent Response if:
 
     // 0. It is detached or attempting to another partition
-    VerifyOrExit((mRole != OT_DEVICE_ROLE_DETACHED) && (mAttachState == kAttachStateIdle), error = OT_ERROR_DROP);
+    VerifyOrExit((mRole != OT_DEVICE_ROLE_DETACHED) && !IsAttaching(), error = OT_ERROR_DROP);
 
     // 1. It has no available Child capacity (if Max Child Count minus
     // Child Count would be equal to zero)
@@ -3287,7 +3287,7 @@ Neighbor *MleRouter::GetNeighbor(const Mac::ExtAddress &aAddress)
             ExitNow();
         }
 
-        if (mAttachState != kAttachStateIdle)
+        if (IsAttaching())
         {
             rval = Mle::GetNeighbor(aAddress);
         }

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3253,7 +3253,7 @@ Neighbor *MleRouter::GetNeighbor(uint16_t aAddress)
         rval = mChildTable.FindChild(aAddress, Child::kInStateValidOrRestoring);
         VerifyOrExit(rval == NULL);
 
-        rval = mRouterTable.GetNeighbor(aAddress);
+        rval = mRouterTable.FindNeighbor(aAddress, Router::kInStateValidOrRestoring);
         break;
     }
 
@@ -3280,7 +3280,7 @@ Neighbor *MleRouter::GetNeighbor(const Mac::ExtAddress &aAddress)
         rval = mChildTable.FindChild(aAddress, Child::kInStateValidOrRestoring);
         VerifyOrExit(rval == NULL);
 
-        rval = mRouterTable.GetNeighbor(aAddress);
+        rval = mRouterTable.FindNeighbor(aAddress, Router::kInStateValidOrRestoring);
 
         if (rval != NULL)
         {
@@ -3369,7 +3369,7 @@ Neighbor *MleRouter::GetNeighbor(const Ip6::Address &aAddress)
     if (aAddress.mFields.m16[4] == HostSwap16(0x0000) && aAddress.mFields.m16[5] == HostSwap16(0x00ff) &&
         aAddress.mFields.m16[6] == HostSwap16(0xfe00))
     {
-        rval = mRouterTable.GetNeighbor(HostSwap16(aAddress.mFields.m16[7]));
+        rval = mRouterTable.FindNeighbor(HostSwap16(aAddress.mFields.m16[7]), Router::kInStateValidOrRestoring);
     }
 
 exit:
@@ -3381,20 +3381,7 @@ Neighbor *MleRouter::GetRxOnlyNeighborRouter(const Mac::Address &aAddress)
     Neighbor *rval = NULL;
 
     VerifyOrExit(mRole == OT_DEVICE_ROLE_CHILD, rval = NULL);
-
-    switch (aAddress.GetType())
-    {
-    case Mac::Address::kTypeShort:
-        rval = mRouterTable.GetNeighbor(aAddress.GetShort());
-        break;
-
-    case Mac::Address::kTypeExtended:
-        rval = mRouterTable.GetNeighbor(aAddress.GetExtended());
-        break;
-
-    default:
-        break;
-    }
+    rval = mRouterTable.FindNeighbor(aAddress, Router::kInStateValidOrRestoring);
 
 exit:
     return rval;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -319,7 +319,7 @@ void MleRouter::SetStateRouter(uint16_t aRloc16)
     Get<Mac::Mac>().SetBeaconEnabled(true);
 
     // remove children that do not have matching RLOC16
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValidOrRestoring); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValidOrRestoring); !iter.IsDone(); iter++)
     {
         if (GetRouterId(iter.GetChild()->GetRloc16()) != mRouterId)
         {
@@ -356,7 +356,7 @@ void MleRouter::SetStateLeader(uint16_t aRloc16)
     Get<AddressResolver>().Clear();
 
     // remove children that do not have matching RLOC16
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValidOrRestoring); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValidOrRestoring); !iter.IsDone(); iter++)
     {
         if (GetRouterId(iter.GetChild()->GetRloc16()) != mRouterId)
         {
@@ -1653,7 +1653,7 @@ otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::Messa
     SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kChallenge, sizeof(challenge), challenge));
     VerifyOrExit(challenge.IsValid(), error = OT_ERROR_PARSE);
 
-    child = mChildTable.FindChild(macAddr, ChildTable::kInStateAnyExceptInvalid);
+    child = mChildTable.FindChild(macAddr, Child::kInStateAnyExceptInvalid);
 
     if (child == NULL)
     {
@@ -1799,7 +1799,7 @@ void MleRouter::HandleStateUpdateTimer(void)
     }
 
     // update children state
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
     {
         Child &  child   = *iter.GetChild();
         uint32_t timeout = 0;
@@ -2052,7 +2052,7 @@ otError MleRouter::UpdateChildAddresses(const Message &aMessage, uint16_t aOffse
         // table is timed out and then trying to register its globally unique
         // IPv6 address as the new child.
 
-        for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValidOrRestoring); !iter.IsDone(); iter++)
+        for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValidOrRestoring); !iter.IsDone(); iter++)
         {
             if (iter.GetChild() == &aChild)
             {
@@ -2112,7 +2112,7 @@ otError MleRouter::HandleChildIdRequest(const Message &         aMessage,
     // Find Child
     aMessageInfo.GetPeerAddr().ToExtAddress(macAddr);
 
-    child = mChildTable.FindChild(macAddr, ChildTable::kInStateAnyExceptInvalid);
+    child = mChildTable.FindChild(macAddr, Child::kInStateAnyExceptInvalid);
     VerifyOrExit(child != NULL, error = OT_ERROR_ALREADY);
 
     // Response
@@ -2289,7 +2289,7 @@ otError MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
 
     // Find Child
     aMessageInfo.GetPeerAddr().ToExtAddress(macAddr);
-    child = mChildTable.FindChild(macAddr, ChildTable::kInStateAnyExceptInvalid);
+    child = mChildTable.FindChild(macAddr, Child::kInStateAnyExceptInvalid);
 
     tlvs[tlvslength++] = Tlv::kSourceAddress;
 
@@ -2616,7 +2616,7 @@ void MleRouter::SynchronizeChildNetworkData(void)
 {
     VerifyOrExit(mRole == OT_DEVICE_ROLE_ROUTER || mRole == OT_DEVICE_ROLE_LEADER);
 
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValid); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValid); !iter.IsDone(); iter++)
     {
         Child & child = *iter.GetChild();
         uint8_t version;
@@ -2889,7 +2889,7 @@ otError MleRouter::SendChildIdResponse(Child &aChild)
 
             rloc16 = Get<Mac::Mac>().GetShortAddress() | mNextChildId;
 
-        } while (mChildTable.FindChild(rloc16, ChildTable::kInStateAnyExceptInvalid) != NULL);
+        } while (mChildTable.FindChild(rloc16, Child::kInStateAnyExceptInvalid) != NULL);
 
         // allocate Child ID
         aChild.SetRloc16(rloc16);
@@ -3250,7 +3250,7 @@ Neighbor *MleRouter::GetNeighbor(uint16_t aAddress)
 
     case OT_DEVICE_ROLE_ROUTER:
     case OT_DEVICE_ROLE_LEADER:
-        rval = mChildTable.FindChild(aAddress, ChildTable::kInStateValidOrRestoring);
+        rval = mChildTable.FindChild(aAddress, Child::kInStateValidOrRestoring);
         VerifyOrExit(rval == NULL);
 
         rval = mRouterTable.GetNeighbor(aAddress);
@@ -3277,7 +3277,7 @@ Neighbor *MleRouter::GetNeighbor(const Mac::ExtAddress &aAddress)
 
     case OT_DEVICE_ROLE_ROUTER:
     case OT_DEVICE_ROLE_LEADER:
-        rval = mChildTable.FindChild(aAddress, ChildTable::kInStateValidOrRestoring);
+        rval = mChildTable.FindChild(aAddress, Child::kInStateValidOrRestoring);
         VerifyOrExit(rval == NULL);
 
         rval = mRouterTable.GetNeighbor(aAddress);
@@ -3347,7 +3347,7 @@ Neighbor *MleRouter::GetNeighbor(const Ip6::Address &aAddress)
         context.mContextId = 0xff;
     }
 
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValidOrRestoring); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValidOrRestoring); !iter.IsDone(); iter++)
     {
         child = iter.GetChild();
 
@@ -3507,7 +3507,7 @@ otError MleRouter::GetChildInfoById(uint16_t aChildId, otChildInfo &aChildInfo)
     }
 
     rloc16 = Get<Mac::Mac>().GetShortAddress() | aChildId;
-    child  = mChildTable.FindChild(rloc16, ChildTable::kInStateAnyExceptInvalid);
+    child  = mChildTable.FindChild(rloc16, Child::kInStateAnyExceptInvalid);
     VerifyOrExit(child != NULL, error = OT_ERROR_NOT_FOUND);
 
     error = GetChildInfo(*child, aChildInfo);
@@ -3559,7 +3559,7 @@ void MleRouter::RestoreChildren(void)
         const Settings::ChildInfo &childInfo = iter.GetChildInfo();
 
         child = mChildTable.FindChild(*static_cast<const Mac::ExtAddress *>(&childInfo.mExtAddress),
-                                      ChildTable::kInStateAnyExceptInvalid);
+                                      Child::kInStateAnyExceptInvalid);
 
         if (child == NULL)
         {
@@ -3635,7 +3635,7 @@ otError MleRouter::RefreshStoredChildren(void)
 
     SuccessOrExit(error = Get<Settings>().DeleteChildInfo());
 
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
     {
         SuccessOrExit(error = StoreChild(*iter.GetChild()));
     }
@@ -3808,7 +3808,7 @@ otError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, I
     else if (GetRouterId(aMeshDest) == mRouterId)
     {
         // mesh destination is a child of this device
-        if (mChildTable.FindChild(aMeshDest, ChildTable::kInStateValidOrRestoring))
+        if (mChildTable.FindChild(aMeshDest, Child::kInStateValidOrRestoring))
         {
             ExitNow();
         }
@@ -4014,7 +4014,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
     SendLinkRequest(NULL);
 
     // send child id responses
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateChildIdRequest); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateChildIdRequest); !iter.IsDone(); iter++)
     {
         SendChildIdResponse(*iter.GetChild());
     }
@@ -4221,7 +4221,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
     }
     else
     {
-        uint16_t numChildren = mChildTable.GetNumChildren(ChildTable::kInStateValid);
+        uint16_t numChildren = mChildTable.GetNumChildren(Child::kInStateValid);
         uint16_t maxAllowed  = mChildTable.GetMaxChildrenAllowed();
 
         if ((maxAllowed - numChildren) < (maxAllowed / 3))
@@ -4581,12 +4581,12 @@ exit:
 
 bool MleRouter::HasChildren(void)
 {
-    return mChildTable.HasChildren(ChildTable::kInStateValidOrAttaching);
+    return mChildTable.HasChildren(Child::kInStateValidOrAttaching);
 }
 
 void MleRouter::RemoveChildren(void)
 {
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValidOrRestoring); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValidOrRestoring); !iter.IsDone(); iter++)
     {
         RemoveNeighbor(*iter.GetChild());
     }
@@ -4599,7 +4599,7 @@ bool MleRouter::HasSmallNumberOfChildren(void)
 
     VerifyOrExit(routerCount > mRouterDowngradeThreshold);
 
-    numChildren = mChildTable.GetNumChildren(ChildTable::kInStateValid);
+    numChildren = mChildTable.GetNumChildren(Child::kInStateValid);
 
     return numChildren < (routerCount - mRouterDowngradeThreshold) * 3;
 
@@ -4626,7 +4626,7 @@ otError MleRouter::GetMaxChildTimeout(uint32_t &aTimeout) const
 
     VerifyOrExit(mRole == OT_DEVICE_ROLE_ROUTER || mRole == OT_DEVICE_ROLE_LEADER, error = OT_ERROR_INVALID_STATE);
 
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValid); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValid); !iter.IsDone(); iter++)
     {
         Child &child = *iter.GetChild();
 
@@ -4692,7 +4692,7 @@ bool MleRouter::HasSleepyChildrenSubscribed(const Ip6::Address &aAddress)
 {
     bool rval = false;
 
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValidOrRestoring); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValidOrRestoring); !iter.IsDone(); iter++)
     {
         Child &child = *iter.GetChild();
 

--- a/src/core/thread/mle_router_ftd.hpp
+++ b/src/core/thread/mle_router_ftd.hpp
@@ -356,57 +356,6 @@ public:
     otError StoreChild(const Child &aChild);
 
     /**
-     * This method returns a pointer to a Neighbor object.
-     *
-     * @param[in]  aAddress  The address of the Neighbor.
-     *
-     * @returns A pointer to the Neighbor corresponding to @p aAddress, NULL otherwise.
-     *
-     */
-    Neighbor *GetNeighbor(uint16_t aAddress);
-
-    /**
-     * This method returns a pointer to a Neighbor object.
-     *
-     * @param[in]  aAddress  The address of the Neighbor.
-     *
-     * @returns A pointer to the Neighbor corresponding to @p aAddress, NULL otherwise.
-     *
-     */
-    Neighbor *GetNeighbor(const Mac::ExtAddress &aAddress);
-
-    /**
-     * This method returns a pointer to a Neighbor object.
-     *
-     * @param[in]  aAddress  The address of the Neighbor.
-     *
-     * @returns A pointer to the Neighbor corresponding to @p aAddress, NULL otherwise.
-     *
-     */
-    Neighbor *GetNeighbor(const Mac::Address &aAddress);
-
-    /**
-     * This method returns a pointer to a Neighbor object.
-     *
-     * @param[in]  aAddress  The address of the Neighbor.
-     *
-     * @returns A pointer to the Neighbor corresponding to @p aAddress, NULL otherwise.
-     *
-     */
-    Neighbor *GetNeighbor(const Ip6::Address &aAddress);
-
-    /**
-     * This method returns a pointer to a Neighbor object if a one-way link is maintained
-     * as in the instance of an FTD child with neighbor routers.
-     *
-     * @param[in]  aAddress  The address of the Neighbor.
-     *
-     * @returns A pointer to the Neighbor corresponding to @p aAddress, NULL otherwise.
-     *
-     */
-    Neighbor *GetRxOnlyNeighborRouter(const Mac::Address &aAddress);
-
-    /**
      * This method retains diagnostic information for an attached child by Child ID or RLOC16.
      *
      * @param[in]   aChildId    The Child ID or RLOC16 for an attached child.

--- a/src/core/thread/mle_router_mtd.hpp
+++ b/src/core/thread/mle_router_mtd.hpp
@@ -89,16 +89,6 @@ public:
     otError RemoveStoredChild(uint16_t) { return OT_ERROR_NOT_IMPLEMENTED; }
     otError StoreChild(const Child &) { return OT_ERROR_NOT_IMPLEMENTED; }
 
-    Neighbor *GetNeighbor(uint16_t aAddress) { return Mle::GetNeighbor(aAddress); }
-    Neighbor *GetNeighbor(const Mac::ExtAddress &aAddress) { return Mle::GetNeighbor(aAddress); }
-    Neighbor *GetNeighbor(const Mac::Address &aAddress) { return Mle::GetNeighbor(aAddress); }
-    Neighbor *GetNeighbor(const Ip6::Address &aAddress) { return Mle::GetNeighbor(aAddress); }
-    Neighbor *GetRxOnlyNeighborRouter(const Mac::Address &aAddress)
-    {
-        OT_UNUSED_VARIABLE(aAddress);
-        return NULL;
-    }
-
     otError GetNextNeighborInfo(otNeighborInfoIterator &, otNeighborInfo &) { return OT_ERROR_NOT_IMPLEMENTED; }
 
     static int ComparePartitions(bool, const LeaderDataTlv &, bool, const LeaderDataTlv &) { return 0; }

--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -1,0 +1,274 @@
+/*
+ *  Copyright (c) 2016-2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for Thread neighbor table.
+ */
+
+#include "neighbor_table.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/instance.hpp"
+#include "common/locator-getters.hpp"
+
+namespace ot {
+
+NeighborTable::NeighborTable(Instance &aInstance)
+    : InstanceLocator(aInstance)
+{
+}
+
+Neighbor *NeighborTable::FindParentNeighbor(Mac::ShortAddress aAddress, Neighbor::StateFilter aFilter)
+{
+    Neighbor *neighbor = &Get<Mle::Mle>().GetParent();
+
+    if (neighbor->MatchesFilter(aFilter) && (neighbor->GetRloc16() == aAddress))
+    {
+        ExitNow();
+    }
+
+    neighbor = &Get<Mle::Mle>().GetParentCandidate();
+
+    if (neighbor->MatchesFilter(aFilter) && (neighbor->GetRloc16() == aAddress))
+    {
+        ExitNow();
+    }
+
+    neighbor = NULL;
+
+exit:
+    return neighbor;
+}
+
+Neighbor *NeighborTable::FindParentNeighbor(const Mac::ExtAddress &aAddress, Neighbor::StateFilter aFilter)
+{
+    Neighbor *neighbor = &Get<Mle::Mle>().GetParent();
+
+    if (neighbor->MatchesFilter(aFilter) && (neighbor->GetExtAddress() == aAddress))
+    {
+        ExitNow();
+    }
+
+    neighbor = &Get<Mle::Mle>().GetParentCandidate();
+
+    if (neighbor->MatchesFilter(aFilter) && (neighbor->GetExtAddress() == aAddress))
+    {
+        ExitNow();
+    }
+
+    neighbor = NULL;
+
+exit:
+    return neighbor;
+}
+
+Neighbor *NeighborTable::FindParentNeighbor(const Mac::Address &aAddress, Neighbor::StateFilter aFilter)
+{
+    Neighbor *neighbor = NULL;
+
+    switch (aAddress.GetType())
+    {
+    case Mac::Address::kTypeShort:
+        neighbor = FindParentNeighbor(aAddress.GetShort(), aFilter);
+        break;
+
+    case Mac::Address::kTypeExtended:
+        neighbor = FindParentNeighbor(aAddress.GetExtended(), aFilter);
+        break;
+
+    default:
+        break;
+    }
+
+    return neighbor;
+}
+
+#if OPENTHREAD_MTD
+
+Neighbor *NeighborTable::FindNeighbor(Mac::ShortAddress aAddress, Neighbor::StateFilter aFilter)
+{
+    return FindParentNeighbor(aAddress, aFilter);
+}
+
+Neighbor *NeighborTable::FindNeighbor(const Mac::ExtAddress &aAddress, Neighbor::StateFilter aFilter)
+{
+    return FindParentNeighbor(aAddress, aFilter);
+}
+
+#elif OPENTHREAD_FTD
+
+Neighbor *NeighborTable::FindNeighbor(Mac::ShortAddress aAddress, Neighbor::StateFilter aFilter)
+{
+    Neighbor *neighbor = NULL;
+
+    VerifyOrExit((aAddress != Mac::kShortAddrBroadcast) && (aAddress != Mac::kShortAddrInvalid));
+
+    switch (Get<Mle::MleRouter>().GetRole())
+    {
+    case OT_DEVICE_ROLE_DISABLED:
+        break;
+
+    case OT_DEVICE_ROLE_DETACHED:
+    case OT_DEVICE_ROLE_CHILD:
+        neighbor = FindParentNeighbor(aAddress, aFilter);
+        break;
+
+    case OT_DEVICE_ROLE_ROUTER:
+    case OT_DEVICE_ROLE_LEADER:
+        neighbor = Get<ChildTable>().FindChild(aAddress, aFilter);
+        VerifyOrExit(neighbor == NULL);
+        neighbor = Get<RouterTable>().FindNeighbor(aAddress, aFilter);
+        break;
+    }
+
+exit:
+    return neighbor;
+}
+
+Neighbor *NeighborTable::FindNeighbor(const Mac::ExtAddress &aAddress, Neighbor::StateFilter aFilter)
+{
+    Neighbor *neighbor = NULL;
+
+    switch (Get<Mle::MleRouter>().GetRole())
+    {
+    case OT_DEVICE_ROLE_DISABLED:
+        break;
+
+    case OT_DEVICE_ROLE_DETACHED:
+    case OT_DEVICE_ROLE_CHILD:
+        neighbor = FindParentNeighbor(aAddress, aFilter);
+        break;
+
+    case OT_DEVICE_ROLE_ROUTER:
+    case OT_DEVICE_ROLE_LEADER:
+        neighbor = Get<ChildTable>().FindChild(aAddress, aFilter);
+        VerifyOrExit(neighbor == NULL);
+        neighbor = Get<RouterTable>().FindNeighbor(aAddress, aFilter);
+        VerifyOrExit(neighbor == NULL);
+        // If we are attaching, check if the address matches the parent
+        // or the parent candidate.
+        VerifyOrExit(Get<Mle::MleRouter>().IsAttaching());
+        neighbor = FindParentNeighbor(aAddress, aFilter);
+        break;
+    }
+
+exit:
+    return neighbor;
+}
+
+Neighbor *NeighborTable::FindNeighbor(const Ip6::Address &aAddress, Neighbor::StateFilter aFilter)
+{
+    Mac::Address    macAddr;
+    Lowpan::Context context;
+    Neighbor *      neighbor = NULL;
+
+    if (aAddress.IsLinkLocal())
+    {
+        if (aAddress.mFields.m16[4] == HostSwap16(0x0000) && aAddress.mFields.m16[5] == HostSwap16(0x00ff) &&
+            aAddress.mFields.m16[6] == HostSwap16(0xfe00))
+        {
+            macAddr.SetShort(HostSwap16(aAddress.mFields.m16[7]));
+        }
+        else
+        {
+            aAddress.ToExtAddress(macAddr);
+        }
+
+        ExitNow(neighbor = FindNeighbor(macAddr, aFilter));
+    }
+
+    if (Get<NetworkData::Leader>().GetContext(aAddress, context) != OT_ERROR_NONE)
+    {
+        context.mContextId = 0xff;
+    }
+
+    for (ChildTable::Iterator iter(GetInstance(), aFilter); !iter.IsDone(); iter++)
+    {
+        Child *child = iter.GetChild();
+
+        if (context.mContextId == Mle::kMeshLocalPrefixContextId && aAddress.mFields.m16[4] == HostSwap16(0x0000) &&
+            aAddress.mFields.m16[5] == HostSwap16(0x00ff) && aAddress.mFields.m16[6] == HostSwap16(0xfe00) &&
+            aAddress.mFields.m16[7] == HostSwap16(child->GetRloc16()))
+        {
+            ExitNow(neighbor = child);
+        }
+
+        if (child->HasIp6Address(GetInstance(), aAddress))
+        {
+            ExitNow(neighbor = child);
+        }
+    }
+
+    VerifyOrExit(context.mContextId == Mle::kMeshLocalPrefixContextId);
+
+    if (aAddress.mFields.m16[4] == HostSwap16(0x0000) && aAddress.mFields.m16[5] == HostSwap16(0x00ff) &&
+        aAddress.mFields.m16[6] == HostSwap16(0xfe00))
+    {
+        neighbor = Get<RouterTable>().FindNeighbor(HostSwap16(aAddress.mFields.m16[7]), aFilter);
+    }
+
+exit:
+    return neighbor;
+}
+
+Neighbor *NeighborTable::FindRxOnlyNeighbor(const Mac::Address &aAddress, Neighbor::StateFilter aFilter)
+{
+    Neighbor *neighbor = NULL;
+
+    VerifyOrExit(Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_CHILD);
+    neighbor = Get<RouterTable>().FindNeighbor(aAddress, aFilter);
+
+exit:
+    return neighbor;
+}
+
+#endif // OPENTHREAD_FTD
+
+Neighbor *NeighborTable::FindNeighbor(const Mac::Address &aAddress, Neighbor::StateFilter aFilter)
+{
+    Neighbor *neighbor = NULL;
+
+    switch (aAddress.GetType())
+    {
+    case Mac::Address::kTypeShort:
+        neighbor = FindNeighbor(aAddress.GetShort(), aFilter);
+        break;
+
+    case Mac::Address::kTypeExtended:
+        neighbor = FindNeighbor(aAddress.GetExtended(), aFilter);
+        break;
+
+    default:
+        break;
+    }
+
+    return neighbor;
+}
+
+} // namespace ot

--- a/src/core/thread/neighbor_table.hpp
+++ b/src/core/thread/neighbor_table.hpp
@@ -1,0 +1,162 @@
+/*
+ *  Copyright (c) 2016-2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for Thread neighbor table.
+ */
+
+#ifndef NEIGHBOR_TABLE_HPP_
+#define NEIGHBOR_TABLE_HPP_
+
+#include "openthread-core-config.h"
+
+#include "common/locator.hpp"
+#include "net/ip6_address.hpp"
+#include "thread/topology.hpp"
+
+namespace ot {
+
+/**
+ * This class represents the Thread neighbor table.
+ *
+ */
+class NeighborTable : public InstanceLocator
+{
+public:
+    /**
+     * This constructor initializes a `NeighborTable` instance.
+     *
+     * @param[in]  aInstance     A reference to the OpenThread instance.
+     *
+     */
+    explicit NeighborTable(Instance &aInstance);
+
+    /**
+     * This method searches among parent and parent candidate for a `Neighbor` matching a given short address and a
+     * state filter.
+     *
+     * @param[in]  aAddress A short address
+     * @param[in]  aFilter  A neighbor state filter.
+     *
+     * @returns  A pointer to the `Neighbor` entry if one is found, or `NULL` otherwise.
+     *
+     */
+    Neighbor *FindParentNeighbor(Mac::ShortAddress aAddress, Neighbor::StateFilter aFilter);
+
+    /**
+     * This method searches among parent and parent candidate for a `Neighbor` matching an extended address and a state
+     * filter.
+     *
+     * @param[in]  aAddress A reference to an extended address.
+     * @param[in]  aFilter  A neighbor state filter.
+     *
+     * @returns  A pointer to the `Neighbor` entry if one is found, or `NULL` otherwise.
+     *
+     */
+    Neighbor *FindParentNeighbor(const Mac::ExtAddress &aAddress, Neighbor::StateFilter aFilter);
+
+    /**
+     * This method searches among parent and parent candidate for a `Neighbor` matching a given address and a state
+     * filter.
+     *
+     * @param[in]  aAddress A reference to a MAC address.
+     * @param[in]  aFilter  A neighbor state filter.
+     *
+     * @returns  A pointer to the `Neighbor` entry if one is found, or `NULL` otherwise.
+     *
+     */
+    Neighbor *FindParentNeighbor(const Mac::Address &aAddress, Neighbor::StateFilter aFilter);
+
+    /**
+     * This method searches for a `Neighbor` matching a given short address and a state filter.
+     *
+     * @param[in]  aAddress A short address
+     * @param[in]  aFilter  A neighbor state filter.
+     *
+     * @returns  A pointer to the `Neighbor` entry if one is found, or `NULL` otherwise.
+     *
+     */
+    Neighbor *FindNeighbor(Mac::ShortAddress aAddress, Neighbor::StateFilter aFilter);
+
+    /**
+     * This method searches for a `Neighbor` matching an extended address and a state filter.
+     *
+     * @param[in]  aAddress A reference to an extended address.
+     * @param[in]  aFilter  A neighbor state filter.
+     *
+     * @returns  A pointer to the `Neighbor` entry if one is found, or `NULL` otherwise.
+     *
+     */
+    Neighbor *FindNeighbor(const Mac::ExtAddress &aAddress, Neighbor::StateFilter aFilter);
+
+    /**
+     * This method searches for a `Neighbor` matching a given address and a state filter.
+     *
+     * @param[in]  aAddress A reference to a MAC address.
+     * @param[in]  aFilter  A neighbor state filter.
+     *
+     * @returns  A pointer to the `Neighbor` entry if one is found, or `NULL` otherwise.
+     *
+     */
+    Neighbor *FindNeighbor(const Mac::Address &aAddress, Neighbor::StateFilter aFilter);
+
+#if OPENTHREAD_FTD
+
+    /**
+     * This method searches for a `Neighbor` matching a given IPv6 address and a state filter.
+     *
+     * @param[in]  aAddress A reference to an IPv6 address.
+     * @param[in]  aFilter  A neighbor state filter.
+     *
+     * @returns  A pointer to the `Neighbor` entry if one is found, or `NULL` otherwise.
+     *
+     */
+    Neighbor *FindNeighbor(const Ip6::Address &aAddress, Neighbor::StateFilter aFilter);
+
+    /**
+     * This method searches for a `Neighbor` router (where a one-way link is maintained) matching a given address and a
+     * state filter.
+     *
+     * This is used while and FTD device is in  child role to allow it to receive multicast/broadcast frames from
+     * other routers.
+     *
+     * @param[in]  aAddress  The address of the Neighbor.
+     * @param[in]  aFilter   A neighbor state filter
+     *
+     * @returns A pointer to the `Neighbor` entry if one is found, or `NULL` otherwise.
+     *
+     */
+    Neighbor *FindRxOnlyNeighbor(const Mac::Address &aAddress, Neighbor::StateFilter aFilter);
+
+#endif // OPENTHREAD_FTD
+};
+
+} // namespace ot
+
+#endif // NEIGHBOR_TABLE_HPP_

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -230,7 +230,7 @@ otError NetworkDiagnostic::AppendChildTable(Message &aMessage)
 
     tlv.Init();
 
-    count = Get<ChildTable>().GetNumChildren(ChildTable::kInStateValid);
+    count = Get<ChildTable>().GetNumChildren(Child::kInStateValid);
 
     // The length of the Child Table TLV may exceed the outgoing link's MTU (1280B).
     // As a workaround we limit the number of entries in the Child Table TLV,
@@ -245,7 +245,7 @@ otError NetworkDiagnostic::AppendChildTable(Message &aMessage)
 
     SuccessOrExit(error = aMessage.Append(&tlv, sizeof(ChildTableTlv)));
 
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValid); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValid); !iter.IsDone(); iter++)
     {
         VerifyOrExit(count--);
 

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -344,7 +344,7 @@ uint8_t RouterTable::GetActiveLinkCount(void) const
     return activeLinks;
 }
 
-Router *RouterTable::GetNeighbor(uint16_t aRloc16)
+Router *RouterTable::FindNeighbor(uint16_t aRloc16, Neighbor::StateFilter aFilter)
 {
     Router *router = NULL;
 
@@ -352,7 +352,7 @@ Router *RouterTable::GetNeighbor(uint16_t aRloc16)
 
     for (router = GetFirstEntry(); router != NULL; router = GetNextEntry(router))
     {
-        if (router->IsStateValid() && router->GetRloc16() == aRloc16)
+        if (router->MatchesFilter(aFilter) && router->GetRloc16() == aRloc16)
         {
             ExitNow();
         }
@@ -362,7 +362,7 @@ exit:
     return router;
 }
 
-Router *RouterTable::GetNeighbor(const Mac::ExtAddress &aExtAddress)
+Router *RouterTable::FindNeighbor(const Mac::ExtAddress &aExtAddress, Neighbor::StateFilter aFilter)
 {
     Router *router = NULL;
 
@@ -370,13 +370,34 @@ Router *RouterTable::GetNeighbor(const Mac::ExtAddress &aExtAddress)
 
     for (router = GetFirstEntry(); router != NULL; router = GetNextEntry(router))
     {
-        if (router->IsStateValid() && router->GetExtAddress() == aExtAddress)
+        if (router->MatchesFilter(aFilter) && router->GetExtAddress() == aExtAddress)
         {
             ExitNow();
         }
     }
 
 exit:
+    return router;
+}
+
+Router *RouterTable::FindNeighbor(const Mac::Address &aAddress, Neighbor::StateFilter aFilter)
+{
+    Router *router = NULL;
+
+    switch (aAddress.GetType())
+    {
+    case Mac::Address::kTypeShort:
+        router = FindNeighbor(aAddress.GetShort(), aFilter);
+        break;
+
+    case Mac::Address::kTypeExtended:
+        router = FindNeighbor(aAddress.GetExtended(), aFilter);
+        break;
+
+    default:
+        break;
+    }
+
     return router;
 }
 

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -211,24 +211,38 @@ public:
     uint8_t GetLinkCost(Router &aRouter);
 
     /**
-     * This method returns the neighbor for a given RLOC16.
+     * This method searches the router table for an entry with a given RLOC16 also matching a given state filter.
      *
-     * @param[in]  aRloc16  The RLOC16 value.
+     * @param[in]  aRloc16  A RLOC16 address.
+     * @param[in]  aFilter  A neighbor state filter.
      *
-     * @returns A pointer to the router or NULL if the router could not be found.
+     * @returns  A pointer to the `Router` entry if one is found, or `NULL` otherwise.
      *
      */
-    Router *GetNeighbor(uint16_t aRloc16);
+    Router *FindNeighbor(uint16_t aRloc16, Neighbor::StateFilter aFilter);
 
     /**
-     * This method returns the neighbor for a given IEEE Extended Address.
+     * This method searches the router table for an entry with a given extended address also matching a given state
+     * filter.
      *
-     * @param[in]  aExtAddress  A reference to the IEEE Extended Address.
+     * @param[in]  aAddress A reference to an extended address.
+     * @param[in]  aFilter  A neighbor state filter.
      *
-     * @returns A pointer to the router or NULL if the router could not be found.
+     * @returns  A pointer to the `Router` entry if one is found, or `NULL` otherwise.
      *
      */
-    Router *GetNeighbor(const Mac::ExtAddress &aExtAddress);
+    Router *FindNeighbor(const Mac::ExtAddress &aAddress, Neighbor::StateFilter aFilter);
+
+    /**
+     * This method searches the router table for an entry with a given address also matching a given state filter.
+     *
+     * @param[in]  aAddress A reference to a MAC address.
+     * @param[in]  aFilter  A neighbor state filter.
+     *
+     * @returns  A pointer to the `Router` entry if one is found, or `NULL` otherwise.
+     *
+     */
+    Router *FindNeighbor(const Mac::Address &aAddress, Neighbor::StateFilter aFilter);
 
     /**
      * This method returns the router for a given router id.

--- a/src/core/thread/src_match_controller.cpp
+++ b/src/core/thread/src_match_controller.cpp
@@ -210,7 +210,7 @@ otError SourceMatchController::AddPendingEntries(void)
 {
     otError error = OT_ERROR_NONE;
 
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValidOrRestoring); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValidOrRestoring); !iter.IsDone(); iter++)
     {
         if (iter.GetChild()->IsIndirectSourceMatchPending())
         {

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -64,6 +64,40 @@ bool Neighbor::IsStateValidOrAttaching(void) const
     return rval;
 }
 
+bool Neighbor::MatchesFilter(StateFilter aFilter) const
+{
+    bool matches = false;
+
+    switch (aFilter)
+    {
+    case kInStateValid:
+        matches = IsStateValid();
+        break;
+
+    case kInStateValidOrRestoring:
+        matches = IsStateValidOrRestoring();
+        break;
+
+    case kInStateChildIdRequest:
+        matches = IsStateChildIdRequest();
+        break;
+
+    case kInStateValidOrAttaching:
+        matches = IsStateValidOrAttaching();
+        break;
+
+    case kInStateAnyExceptInvalid:
+        matches = !IsStateInvalid();
+        break;
+
+    case kInStateAnyExceptValidOrRestoring:
+        matches = !IsStateValidOrRestoring();
+        break;
+    }
+
+    return matches;
+}
+
 void Neighbor::GenerateChallenge(void)
 {
     Random::Crypto::FillBuffer(mValidPending.mPending.mChallenge, sizeof(mValidPending.mPending.mChallenge));

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -41,18 +41,7 @@
 
 namespace ot {
 
-void Neighbor::GenerateChallenge(void)
-{
-    Random::Crypto::FillBuffer(mValidPending.mPending.mChallenge, sizeof(mValidPending.mPending.mChallenge));
-}
-
-void Child::Clear(void)
-{
-    memset(reinterpret_cast<void *>(this), 0, sizeof(Child));
-    SetState(kStateInvalid);
-}
-
-bool Child::IsStateValidOrAttaching(void) const
+bool Neighbor::IsStateValidOrAttaching(void) const
 {
     bool rval = false;
 
@@ -73,6 +62,17 @@ bool Child::IsStateValidOrAttaching(void) const
     }
 
     return rval;
+}
+
+void Neighbor::GenerateChallenge(void)
+{
+    Random::Crypto::FillBuffer(mValidPending.mPending.mChallenge, sizeof(mValidPending.mPending.mChallenge));
+}
+
+void Child::Clear(void)
+{
+    memset(reinterpret_cast<void *>(this), 0, sizeof(Child));
+    SetState(kStateInvalid);
 }
 
 void Child::ClearIp6Addresses(void)

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -76,6 +76,22 @@ public:
     };
 
     /**
+     * This enumeration defines state filters used for finding a neighbor or iterating through the child/neighbor table.
+     *
+     * Each filter definition accepts a subset of `State` values.
+     *
+     */
+    enum StateFilter
+    {
+        kInStateValid,                     ///< Accept child only in `kStateValid`.
+        kInStateValidOrRestoring,          ///< Accept child with `IsStateValidOrRestoring()` being `true`.
+        kInStateChildIdRequest,            ///< Accept child only in `Child:kStateChildIdRequest`.
+        kInStateValidOrAttaching,          ///< Accept child with `IsStateValidOrAttaching()` being `true`.
+        kInStateAnyExceptInvalid,          ///< Accept child in any state except `kStateInvalid`.
+        kInStateAnyExceptValidOrRestoring, ///< Accept child in any state except `IsStateValidOrRestoring()`.
+    };
+
+    /**
      * This method returns the current state.
      *
      * @returns The current state.
@@ -167,6 +183,16 @@ public:
      *
      */
     bool IsStateValidOrAttaching(void) const;
+
+    /**
+     * This method indicates whether neighbor state matches a given state filter.
+     *
+     * @param[in] aFilter   A state filter (`StateFilter` enumeration) to match against.
+     *
+     * @returns TRUE if the neighbor state matches the filter, FALSE otherwise.
+     *
+     */
+    bool MatchesFilter(StateFilter aFilter) const;
 
     /**
      * This method gets the device mode flags.

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -158,6 +158,17 @@ public:
     bool IsStateValidOrRestoring(void) const { return (mState == kStateValid) || IsStateRestoring(); }
 
     /**
+     * This method indicates if the neighbor state is valid or being attached or being restored.
+     *
+     * The states `kStateRestored`, `kStateChildIdRequest`, `kStateChildUpdateRequest`, `kStateValid`, and
+     * `kStateLinkRequest` are considered as attached or being restored.
+     *
+     * @returns TRUE if the neighbor is attached or being restored.
+     *
+     */
+    bool IsStateValidOrAttaching(void) const;
+
+    /**
      * This method gets the device mode flags.
      *
      * @returns The device mode flags.
@@ -479,17 +490,6 @@ public:
      *
      */
     void Clear(void);
-
-    /**
-     * This method indicates if the child state is valid or being attached or being restored.
-     *
-     * The states `kStateRestored`, `kStateChildIdRequest`, `kStateChildUpdateRequest`, `kStateValid`, (and
-     * `kStateLinkRequest) are considered as attached or being restored.
-     *
-     * @returns TRUE if the child is attached or being restored.
-     *
-     */
-    bool IsStateValidOrAttaching(void) const;
 
     /**
      * This method clears the IPv6 address list for the child.

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -209,7 +209,7 @@ void SupervisionListener::UpdateOnReceive(const Mac::Address &aSourceAddress, bo
     // If listener is enabled and device is a child and it received a secure frame from its parent, restart the timer.
 
     VerifyOrExit(mTimer.IsRunning() && aIsSecure && (Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_CHILD) &&
-                 (Get<Mle::MleRouter>().GetNeighbor(aSourceAddress) == Get<Mle::MleRouter>().GetParent()));
+                 (Get<Mle::MleRouter>().GetNeighbor(aSourceAddress) == &Get<Mle::MleRouter>().GetParent()));
 
     RestartTimer();
 

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -120,7 +120,7 @@ void ChildSupervisor::HandleTimer(void)
 {
     VerifyOrExit(mSupervisionInterval != 0);
 
-    for (ChildTable::Iterator iter(GetInstance(), ChildTable::kInStateValid); !iter.IsDone(); iter++)
+    for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValid); !iter.IsDone(); iter++)
     {
         Child &child = *iter.GetChild();
 
@@ -147,7 +147,7 @@ void ChildSupervisor::CheckState(void)
     // "valid" child in the child table.
 
     shouldRun = ((mSupervisionInterval != 0) && (Get<Mle::MleRouter>().GetRole() != OT_DEVICE_ROLE_DISABLED) &&
-                 Get<ChildTable>().HasChildren(ChildTable::kInStateValid));
+                 Get<ChildTable>().HasChildren(Child::kInStateValid));
 
     if (shouldRun && !mTimer.IsRunning())
     {

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -206,10 +206,14 @@ void SupervisionListener::SetTimeout(uint16_t aTimeout)
 
 void SupervisionListener::UpdateOnReceive(const Mac::Address &aSourceAddress, bool aIsSecure)
 {
+    Neighbor *neighbor;
+
     // If listener is enabled and device is a child and it received a secure frame from its parent, restart the timer.
 
-    VerifyOrExit(mTimer.IsRunning() && aIsSecure && (Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_CHILD) &&
-                 (Get<Mle::MleRouter>().GetNeighbor(aSourceAddress) == &Get<Mle::MleRouter>().GetParent()));
+    VerifyOrExit(mTimer.IsRunning() && aIsSecure && (Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_CHILD));
+
+    neighbor = Get<NeighborTable>().FindNeighbor(aSourceAddress, Neighbor::kInStateValidOrRestoring);
+    VerifyOrExit(neighbor == &Get<Mle::MleRouter>().GetParent());
 
     RestartTimer();
 

--- a/tests/unit/test_child_table.cpp
+++ b/tests/unit/test_child_table.cpp
@@ -51,12 +51,12 @@ struct TestChild
     otExtAddress mExtAddress;
 };
 
-const ChildTable::StateFilter kAllFilters[] = {
-    ChildTable::kInStateValid,
-    ChildTable::kInStateValidOrRestoring,
-    ChildTable::kInStateChildIdRequest,
-    ChildTable::kInStateValidOrAttaching,
-    ChildTable::kInStateAnyExceptInvalid,
+const Child::StateFilter kAllFilters[] = {
+    Child::kInStateValid,
+    Child::kInStateValidOrRestoring,
+    Child::kInStateChildIdRequest,
+    Child::kInStateValidOrAttaching,
+    Child::kInStateAnyExceptInvalid,
 };
 
 // Checks whether a `Child` matches the `TestChild` struct.
@@ -66,8 +66,8 @@ static bool ChildMatches(const Child &aChild, const TestChild &aTestChild)
            (aChild.GetExtAddress() == static_cast<const Mac::ExtAddress &>(aTestChild.mExtAddress));
 }
 
-// Checks whether a `Child::State` matches a `ChildTable::StateFilter`.
-static bool StateMatchesFilter(Child::State aState, ChildTable::StateFilter aFilter)
+// Checks whether a `Child::State` matches a `Child::StateFilter`.
+static bool StateMatchesFilter(Child::State aState, Child::StateFilter aFilter)
 {
     bool  rval = false;
     Child child;
@@ -76,27 +76,27 @@ static bool StateMatchesFilter(Child::State aState, ChildTable::StateFilter aFil
 
     switch (aFilter)
     {
-    case ChildTable::kInStateAnyExceptInvalid:
+    case Child::kInStateAnyExceptInvalid:
         rval = (aState != Child::kStateInvalid);
         break;
 
-    case ChildTable::kInStateValid:
+    case Child::kInStateValid:
         rval = (aState == Child::kStateValid);
         break;
 
-    case ChildTable::kInStateValidOrRestoring:
+    case Child::kInStateValidOrRestoring:
         rval = child.IsStateValidOrRestoring();
         break;
 
-    case ChildTable::kInStateChildIdRequest:
+    case Child::kInStateChildIdRequest:
         rval = (aState == Child::kStateChildIdRequest);
         break;
 
-    case ChildTable::kInStateValidOrAttaching:
+    case Child::kInStateValidOrAttaching:
         rval = child.IsStateValidOrAttaching();
         break;
 
-    case ChildTable::kInStateAnyExceptValidOrRestoring:
+    case Child::kInStateAnyExceptValidOrRestoring:
         rval = !child.IsStateValidOrRestoring();
         break;
     }
@@ -111,7 +111,7 @@ void VerifyChildTableContent(ChildTable &aTable, uint16_t aChildListLength, cons
 
     for (uint16_t k = 0; k < OT_ARRAY_LENGTH(kAllFilters); k++)
     {
-        ChildTable::StateFilter filter = kAllFilters[k];
+        Child::StateFilter filter = kAllFilters[k];
 
         // Verify that we can find all children from given list by rloc or extended address.
 
@@ -152,7 +152,7 @@ void VerifyChildTableContent(ChildTable &aTable, uint16_t aChildListLength, cons
 
             if (listIndex < aChildListLength)
             {
-                startingChild = aTable.FindChild(aChildList[listIndex].mRloc16, ChildTable::kInStateAnyExceptInvalid);
+                startingChild = aTable.FindChild(aChildList[listIndex].mRloc16, Child::kInStateAnyExceptInvalid);
                 VerifyOrQuit(startingChild != NULL, "FindChild() failed");
             }
 
@@ -316,7 +316,7 @@ void TestChildTable(void)
 
     for (uint16_t i = 0; i < OT_ARRAY_LENGTH(kAllFilters); i++)
     {
-        ChildTable::StateFilter filter = kAllFilters[i];
+        Child::StateFilter filter = kAllFilters[i];
 
         VerifyOrQuit(table->HasChildren(filter) == false, "HasChildren() failed after init");
         VerifyOrQuit(table->GetNumChildren(filter) == 0, "GetNumChildren() failed after init");


### PR DESCRIPTION
This PR contains a group of related commits with overall goal of adding a `NeighborTable` class to allow us to search for neighbors matching a given MAC/IPv6 address and a state filter (so we can find a neighbor entry in any state (not just valid or restoring)).

**[neighbor-table] adding NeighborTable (#4411)**

This commit moves the methods for finding a neighbor (based on short,
extedned MAC address or IPv6 address) from `Mle` and  `MleRouter`
into a newly added class `NeighborTable`. The methods in
`NeighborTable` allow finding a neighbor mathching a given
`Neighbor::StateFilter`.

**[router-table] add StateFilter to methods finding neighbor routers (#4411)**

**[child-table] move StatFilter definition to Neighbor (#4411)**

**[topology] move IsStateValidOrAttaching to Neighbor (#4411)**

**[data-poll-sender] add GetParent() (#4411)**

This commit changes the `Mle::GetParentCandidate()` to return a
reference to the parent candidate and moves the selection logic
between parent or parent candidate when sending data polls to
`DataPollSender` from the newly added `GetParent()` method.

**[mle] update Mle::GetParent() to return reference (#4411)**

**[mle] add Mle::IsAttaching() method (#4411)**