### PR TITLE
[script] fix linking clang-format-6.0 on Mac OS X

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -87,7 +87,7 @@ install_packages_brew()
     CLANG_FORMAT_VERSION="clang-format version 6.0"
     which clang-format-6.0 || (which clang-format && (clang-format --version | grep -q "${CLANG_FORMAT_VERSION}")) || {
         brew install llvm@6
-        sudo ln -s "$(brew --repo)/opt/llvm@6/bin/clang-format" /usr/local/bin/clang-format-6.0
+        sudo ln -s "$(brew --prefix llvm@6)/bin/clang-format" /usr/local/bin/clang-format-6.0
     }
 }
 


### PR DESCRIPTION
`brew --prefix` is the correct way to find brew package location:

```shell
☁  ~  brew --prefix --help
Usage: brew --prefix [formula]

Display Homebrew's install path. Default: /usr/local on macOS and
/home/linuxbrew/.linuxbrew on Linux.

If formula is provided, display the location in the cellar where formula is
or would be installed.

    -h, --help                       Show this message.
```

```shell
☁  ~  brew --repo --help  
Usage: brew --repository, --repo [user/repo]

Display where Homebrew's .git directory is located.

If user/repo are provided, display where tap user/repo's directory
is located.

    -h, --help                       Show this message.
```