### PR TITLE
[ncp] conform with c++11 constexpr and static_assert

### DIFF
--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -213,7 +213,7 @@ protected:
     otError HandleCommand(uint8_t aHeader);
 
 #if __cplusplus >= 201103L
-    static constexpr bool IsHandlerEntriesSorted(const HandlerEntry *aHandlerEntries, size_t aSize);
+    static constexpr bool AreHandlerEntriesSorted(const HandlerEntry *aHandlerEntries, size_t aSize);
 #endif
 
     static PropertyHandler FindPropertyHandler(const HandlerEntry *aHandlerEntries,

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -38,17 +38,9 @@ namespace Ncp {
 #if __cplusplus >= 201103L
 constexpr bool NcpBase::IsHandlerEntriesSorted(const HandlerEntry *aHandlerEntries, size_t aSize)
 {
-    bool rval = true;
-
-    for (size_t i = 1; i < aSize; ++i)
-    {
-        if (aHandlerEntries[i].mKey <= aHandlerEntries[i - 1].mKey)
-        {
-            rval = false;
-        }
-    }
-
-    return rval;
+    return aSize < 2 ? true
+                     : ((aHandlerEntries[aSize - 1].mKey > aHandlerEntries[aSize - 2].mKey) &&
+                        IsHandlerEntriesSorted(aHandlerEntries, aSize - 1));
 }
 #endif
 
@@ -352,7 +344,8 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
     };
 
 #if __cplusplus >= 201103L
-    static_assert(IsHandlerEntriesSorted(sHandlerEntries, OT_ARRAY_LENGTH(sHandlerEntries)));
+    static_assert(IsHandlerEntriesSorted(sHandlerEntries, OT_ARRAY_LENGTH(sHandlerEntries)),
+                  "NCP property getter entries not sorted!");
 #endif
 
     return FindPropertyHandler(sHandlerEntries, OT_ARRAY_LENGTH(sHandlerEntries), aKey);
@@ -568,7 +561,8 @@ NcpBase::PropertyHandler NcpBase::FindSetPropertyHandler(spinel_prop_key_t aKey)
     };
 
 #if __cplusplus >= 201103L
-    static_assert(IsHandlerEntriesSorted(sHandlerEntries, OT_ARRAY_LENGTH(sHandlerEntries)));
+    static_assert(IsHandlerEntriesSorted(sHandlerEntries, OT_ARRAY_LENGTH(sHandlerEntries)),
+                  "NCP property setter entries not sorted!");
 #endif
 
     return FindPropertyHandler(sHandlerEntries, OT_ARRAY_LENGTH(sHandlerEntries), aKey);

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -36,11 +36,11 @@ namespace ot {
 namespace Ncp {
 
 #if __cplusplus >= 201103L
-constexpr bool NcpBase::IsHandlerEntriesSorted(const HandlerEntry *aHandlerEntries, size_t aSize)
+constexpr bool NcpBase::AreHandlerEntriesSorted(const HandlerEntry *aHandlerEntries, size_t aSize)
 {
     return aSize < 2 ? true
                      : ((aHandlerEntries[aSize - 1].mKey > aHandlerEntries[aSize - 2].mKey) &&
-                        IsHandlerEntriesSorted(aHandlerEntries, aSize - 1));
+                        AreHandlerEntriesSorted(aHandlerEntries, aSize - 1));
 }
 #endif
 
@@ -344,7 +344,7 @@ NcpBase::PropertyHandler NcpBase::FindGetPropertyHandler(spinel_prop_key_t aKey)
     };
 
 #if __cplusplus >= 201103L
-    static_assert(IsHandlerEntriesSorted(sHandlerEntries, OT_ARRAY_LENGTH(sHandlerEntries)),
+    static_assert(AreHandlerEntriesSorted(sHandlerEntries, OT_ARRAY_LENGTH(sHandlerEntries)),
                   "NCP property getter entries not sorted!");
 #endif
 
@@ -561,7 +561,7 @@ NcpBase::PropertyHandler NcpBase::FindSetPropertyHandler(spinel_prop_key_t aKey)
     };
 
 #if __cplusplus >= 201103L
-    static_assert(IsHandlerEntriesSorted(sHandlerEntries, OT_ARRAY_LENGTH(sHandlerEntries)),
+    static_assert(AreHandlerEntriesSorted(sHandlerEntries, OT_ARRAY_LENGTH(sHandlerEntries)),
                   "NCP property setter entries not sorted!");
 #endif
 


### PR DESCRIPTION
C++11 constexpr doesn't support local variables and loop. This PR uses
recursive way to assert handlers are sorted.
C++11 static_assert requires a message, this PR adds the missing
messages to static_assert calls.