### PR TITLE
[network-diagnostic] remove useless include

### DIFF
--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -43,7 +43,6 @@
 #include "common/encoding.hpp"
 #include "common/message.hpp"
 #include "common/tlvs.hpp"
-#include "meshcop/meshcop_tlvs.hpp"
 #include "net/ip6_address.hpp"
 #include "radio/radio.hpp"
 #include "thread/device_mode.hpp"


### PR DESCRIPTION
The main reason for this PR is that I got failure when compiling ot-br on OpenWRT:

>   CXX      otbr_agent-otubus.o
> In file included from ../../third_party/openthread/repo/src/core/thread/key_manager.hpp:45:0,
>                  from ../../third_party/openthread/repo/src/core/meshcop/meshcop_tlvs.hpp:54,
>                  from ../../third_party/openthread/repo/src/core/thread/network_diagnostic_tlvs.hpp:46,
>                  from otubus.cpp:43:
> ../../third_party/openthread/repo/src/core/common/timer.hpp:77:40: error: 'Time' has not been declared
>      static const uint32_t kMaxDelay = (Time::kMaxDuration >> 1);
>                                         ^~~~
> ../../third_party/openthread/repo/src/core/common/timer.hpp:110:5: error: 'Time' does not name a type; did you mean 'Timer'?
>      Time GetFireTime(void) const { return mFireTime; }
>      ^~~~
>      Timer
> ../../third_party/openthread/repo/src/core/common/timer.hpp:132:52: error: 'Time' has not been declared
>      bool DoesFireBefore(const Timer &aSecondTimer, Time aNow);
>                                                     ^~~~
> ../../third_party/openthread/repo/src/core/common/timer.hpp:137:5: error: 'Time' does not name a type; did you mean 'Timer'?
>      Time    mFireTime;
>      ^~~~
>      Timer
> ../../third_party/openthread/repo/src/core/common/timer.hpp: In constructor 'ot::Timer::Timer(ot::Instance&, ot::Timer::Handler, void*)':
> ../../third_party/openthread/repo/src/core/common/timer.hpp:99:11: error: class 'ot::Timer' does not have any field named 'mFireTime'
>          , mFireTime()
>            ^~~~~~~~~
> ../../third_party/openthread/repo/src/core/common/timer.hpp: At global scope:
> ../../third_party/openthread/repo/src/core/common/timer.hpp:176:18: error: 'TimeMilli' has not been declared
>      void StartAt(TimeMilli sStartTime, uint32_t aDelay);
>                   ^~~~~~~~~
> ../../third_party/openthread/repo/src/core/common/timer.hpp:190:12: error: 'TimeMilli' does not name a type; did you mean 'TimerMilli'?
>      static TimeMilli GetNow(void) { return TimeMilli(otPlatAlarmMilliGetNow()); }
>             ^~~~~~~~~
>             TimerMilli

The actual reason for the above 'has not been declared' error is that the `common/time.hpp` in otbr repo overrides the `common/time.hpp` in openthread repo. We discussed offline @bukepo and agreed that this is not a good way to include openthread's internal header from ot-br-posix. But for now we don't have a good solution.  To fix the current compilation problem, I happen to find that the original header file(`src/core/meshcop/meshcop_tlvs.hpp`) that finally causes the inclusion of `time.hpp` is actually not used in `src/core/thread/network_diagnostic_tlvs.hpp`. So I removed this header file to fix the problem.