### PR TITLE
[network-data] support registration on child devices

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2880,6 +2880,12 @@ otError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo
         delay = Random::NonCrypto::GetUint16InRange(0, kMleMaxResponseDelay);
         SendDataRequest(aMessageInfo.GetPeerAddr(), tlvs, sizeof(tlvs), delay);
     }
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+    else
+    {
+        Get<NetworkData::Local>().SendServerDataNotification();
+    }
+#endif
 
 exit:
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1417,10 +1417,6 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
 
     UpdateRoutes(route, routerId);
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    Get<NetworkData::Local>().SendServerDataNotification();
-#endif
-
 exit:
     if (aNeighbor && aNeighbor->GetRloc16() != sourceAddress.GetRloc16())
     {


### PR DESCRIPTION
A device's request to register network data information is triggered
by a call to NetworkData::Local::SendServerDataNotification().
However, the call was only made by devices operating in the router
or leader roles.

This commit moves the call so that network data registration is
triggered in the child role, in addition to the router and leader
roles.

Resolves #4424 