### PR TITLE
[dataset] check if dataset is present in otDatasetIsCommissioned

### DIFF
--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -44,12 +44,16 @@ using namespace ot;
 bool otDatasetIsCommissioned(otInstance *aInstance)
 {
     otOperationalDataset dataset;
+    bool                 rval = false;
 
-    otDatasetGetActive(aInstance, &dataset);
+    SuccessOrExit(otDatasetGetActive(aInstance, &dataset));
 
-    return ((dataset.mComponents.mIsMasterKeyPresent) && (dataset.mComponents.mIsNetworkNamePresent) &&
+    rval = ((dataset.mComponents.mIsMasterKeyPresent) && (dataset.mComponents.mIsNetworkNamePresent) &&
             (dataset.mComponents.mIsExtendedPanIdPresent) && (dataset.mComponents.mIsPanIdPresent) &&
             (dataset.mComponents.mIsChannelPresent));
+
+exit:
+    return rval;
 }
 
 otError otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset)


### PR DESCRIPTION
otDatasetIsCommissioned API first reads out the Active Dataset from
settings (i.e. non-volatile storage). However, the existing
implementation does not check if the Active Dataset is actually
present, as indicated by OT_ERROR_NOT_FOUND.

This commit adds a necessary check and returns false if the Active
Dataset is not present.