### PR TITLE
[mle] link sync enhancement

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1397,8 +1397,8 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
         router = mRouterTable.GetRouter(routerId);
         VerifyOrExit(router != NULL);
 
-        // Send link request if no link to router
-        if (!router->IsStateValid() && !router->IsStateLinkRequest() &&
+        // Send unicast link request if no link to router and no unicast/multicast link request in progress
+        if (!router->IsStateValid() && !router->IsStateLinkRequest() && mChallengeTimeout == 0 &&
             (linkMargin >= OPENTHREAD_CONFIG_MLE_LINK_REQUEST_MARGIN_MIN))
         {
             router->SetExtAddress(macAddr);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1398,7 +1398,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
         VerifyOrExit(router != NULL);
 
         // Send unicast link request if no link to router and no unicast/multicast link request in progress
-        if (!router->IsStateValid() && !router->IsStateLinkRequest() && mChallengeTimeout == 0 &&
+        if (!router->IsStateValid() && !router->IsStateLinkRequest() && (mChallengeTimeout == 0) &&
             (linkMargin >= OPENTHREAD_CONFIG_MLE_LINK_REQUEST_MARGIN_MIN))
         {
             router->SetExtAddress(macAddr);


### PR DESCRIPTION
There is chance for below scenario (as shown in below screenshot)
1) Device newly becomes router and sends multicast Link Request
   (challenge1),
2) Device receives MLE advertisement from one neighbor, and sends
   unicast Link Request (challenge2),
3) The neighbor ignores the unicast link Request in 2) and sends
   out Link Accept and Request message as response for 1)
4) Device would drop the Link Accept adn Request message
   in 3) as it compares the Response TLV value with challenge2, which
   in fact matches challenge1.
<img width="1403" alt="Screen Shot 2019-12-24 at 5 56 11 PM" src="https://user-images.githubusercontent.com/19217991/71409321-177ba200-267c-11ea-8f8a-0312679b6648.png">

The link between Device and the neighbor could not be established until
Device receives next MLE advertisement from the neighbor.

This commit suppresses unicast Link Request in 2) if there is multicast
Link Request ongoing. Thus the three-handshakes link sync could go well.