### PR TITLE
[platform/utils] RTT: remove non-functional config of Up Buffer's size

### DIFF
--- a/examples/platforms/utils/logging_rtt.c
+++ b/examples/platforms/utils/logging_rtt.c
@@ -58,8 +58,11 @@
 #define RTT_COLOR_CODE_CYAN ""
 #endif // LOG_RTT_COLOR_ENABLE == 1
 
-static bool    sLogInitialized = false;
+static bool sLogInitialized = false;
+
+#if LOG_RTT_BUFFER_INDEX != 0
 static uint8_t sLogBuffer[LOG_RTT_BUFFER_SIZE];
+#endif
 
 /**
  * Function for getting color of a given level log.
@@ -119,8 +122,13 @@ static inline int logLevel(char *aLogString, uint16_t aMaxSize, otLogLevel aLogL
 
 void utilsLogRttInit(void)
 {
+#if LOG_RTT_BUFFER_INDEX != 0
     int res = SEGGER_RTT_ConfigUpBuffer(LOG_RTT_BUFFER_INDEX, LOG_RTT_BUFFER_NAME, sLogBuffer, LOG_RTT_BUFFER_SIZE,
                                         SEGGER_RTT_MODE_NO_BLOCK_TRIM);
+#else
+    int res = SEGGER_RTT_SetFlagsUpBuffer(LOG_RTT_BUFFER_INDEX, SEGGER_RTT_MODE_NO_BLOCK_TRIM);
+#endif
+
     otEXPECT(res >= 0);
 
     sLogInitialized = true;

--- a/examples/platforms/utils/logging_rtt.h
+++ b/examples/platforms/utils/logging_rtt.h
@@ -59,7 +59,8 @@ extern "C" {
 /**
  * @def LOG_RTT_BUFFER_NAME
  *
- * RTT's name.
+ * RTT's name. Only used if LOG_RTT_BUFFER_INDEX is not 0. Otherwise,
+ * the buffer name is fixed to "Terminal".
  *
  */
 #ifndef LOG_RTT_BUFFER_NAME
@@ -69,7 +70,9 @@ extern "C" {
 /**
  * @def LOG_RTT_BUFFER_SIZE
  *
- * LOG RTT's buffer size.
+ * LOG RTT's buffer size. Only used if LOG_RTT_BUFFER_INDEX is not 0. To
+ * configure buffer #0 size, check the BUFFER_SIZE_UP definition in
+ * SEGGER_RTT_Conf.h
  *
  */
 #ifndef LOG_RTT_BUFFER_SIZE


### PR DESCRIPTION
Buffer configuration is **fixed at compile time** for BufferIndex=0. See `SEGGER_RTT_ConfigUpBuffer`:

https://github.com/openthread/openthread/blob/5b0af03afb8e70e8216f69623bd18bcd3d4b8b43/third_party/jlink/SEGGER_RTT_V640/RTT/SEGGER_RTT.c#L1415-L1435