### PR TITLE
[tlv] add AppendTo to resolve mutual dependency

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -402,15 +402,6 @@ exit:
     return error;
 }
 
-otError Message::AppendTlv(const Tlv &aTlv)
-{
-    uint32_t size = aTlv.GetSize();
-
-    assert(size <= UINT16_MAX);
-
-    return Append(&aTlv, static_cast<uint16_t>(size));
-}
-
 otError Message::Prepend(const void *aBuf, uint16_t aLength)
 {
     otError error     = OT_ERROR_NONE;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -44,8 +44,8 @@
 #include <openthread/platform/messagepool.h>
 
 #include "common/code_utils.hpp"
+#include "common/encoding.hpp"
 #include "common/locator.hpp"
-#include "common/tlvs.hpp"
 #include "mac/mac_types.hpp"
 #include "thread/link_quality.hpp"
 
@@ -400,19 +400,6 @@ public:
      *
      */
     otError Append(const void *aBuf, uint16_t aLength);
-
-    /**
-     * This method appends a TLV to the end of the message.
-     *
-     * On success, this method grows the message by the size of the TLV.
-     *
-     * @param[in]  aTlv     A reference to a TLV.
-     *
-     * @retval OT_ERROR_NONE     Successfully appended the TLV to the message.
-     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
-     *
-     */
-    otError AppendTlv(const Tlv &aTlv);
 
     /**
      * This method reads bytes from the message.

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -34,6 +34,7 @@
 #include "tlvs.hpp"
 
 #include "common/code_utils.hpp"
+#include "common/debug.hpp"
 #include "common/message.hpp"
 
 namespace ot {
@@ -162,6 +163,15 @@ otError Tlv::Find(const Message &aMessage, uint8_t aType, uint16_t *aOffset, uin
 
 exit:
     return error;
+}
+
+otError Tlv::AppendTo(Message &aMessage) const
+{
+    uint32_t size = GetSize();
+
+    assert(size <= UINT16_MAX);
+
+    return aMessage.Append(this, static_cast<uint16_t>(size));
 }
 
 } // namespace ot

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -212,6 +212,19 @@ public:
      */
     static otError GetValueOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset, uint16_t &aLength);
 
+    /**
+     * This method appends a TLV to the end of the message.
+     *
+     * On success, this method grows the message by the size of the TLV.
+     *
+     * @param[in]  aMessage      A reference to the message to append to.
+     *
+     * @retval OT_ERROR_NONE     Successfully appended the TLV to the message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
+     *
+     */
+    otError AppendTo(Message &aMessage) const;
+
 protected:
     enum
     {

--- a/src/core/meshcop/announce_begin_client.cpp
+++ b/src/core/meshcop/announce_begin_client.cpp
@@ -77,19 +77,19 @@ otError AnnounceBeginClient::SendRequest(uint32_t            aChannelMask,
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(Get<MeshCoP::Commissioner>().GetSessionId());
-    SuccessOrExit(error = message->AppendTlv(sessionId));
+    SuccessOrExit(error = sessionId.AppendTo(*message));
 
     channelMask.Init();
     channelMask.SetChannelMask(aChannelMask);
-    SuccessOrExit(error = message->AppendTlv(channelMask));
+    SuccessOrExit(error = channelMask.AppendTo(*message));
 
     count.Init();
     count.SetCount(aCount);
-    SuccessOrExit(error = message->AppendTlv(count));
+    SuccessOrExit(error = count.AppendTo(*message));
 
     period.Init();
     period.SetPeriod(aPeriod);
-    SuccessOrExit(error = message->AppendTlv(period));
+    SuccessOrExit(error = period.AppendTo(*message));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerAddr(aAddress);

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -444,7 +444,7 @@ bool BorderAgent::HandleUdpReceive(const Message &aMessage, const Ip6::MessageIn
 
         tlv.Init();
         tlv.SetAddress(aMessageInfo.GetPeerAddr());
-        SuccessOrExit(error = message->AppendTlv(tlv));
+        SuccessOrExit(error = tlv.AppendTo(*message));
     }
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().SendMessage(*message, Get<Coap::CoapSecure>().GetPeerAddress()));

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -571,7 +571,7 @@ otError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDatase
         MeshCoP::BorderAgentLocatorTlv locator;
         locator.Init();
         locator.SetBorderAgentLocator(aDataset.mLocator);
-        SuccessOrExit(error = message->AppendTlv(locator));
+        SuccessOrExit(error = locator.AppendTo(*message));
     }
 
     if (aDataset.mIsSessionIdSet)
@@ -579,7 +579,7 @@ otError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDatase
         MeshCoP::CommissionerSessionIdTlv sessionId;
         sessionId.Init();
         sessionId.SetCommissionerSessionId(aDataset.mSessionId);
-        SuccessOrExit(error = message->AppendTlv(sessionId));
+        SuccessOrExit(error = sessionId.AppendTo(*message));
     }
 
     if (aDataset.mIsSteeringDataSet)
@@ -596,7 +596,7 @@ otError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDatase
         MeshCoP::JoinerUdpPortTlv joinerUdpPort;
         joinerUdpPort.Init();
         joinerUdpPort.SetUdpPort(aDataset.mJoinerUdpPort);
-        SuccessOrExit(error = message->AppendTlv(joinerUdpPort));
+        SuccessOrExit(error = joinerUdpPort.AppendTo(*message));
     }
 
     if (aLength > 0)
@@ -667,7 +667,7 @@ otError Commissioner::SendPetition(void)
     commissionerId.Init();
     commissionerId.SetCommissionerId("OpenThread Commissioner");
 
-    SuccessOrExit(error = message->AppendTlv(commissionerId));
+    SuccessOrExit(error = commissionerId.AppendTo(*message));
 
     SuccessOrExit(error = Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr()));
     messageInfo.SetPeerPort(kCoapUdpPort);
@@ -759,11 +759,11 @@ otError Commissioner::SendKeepAlive(void)
 
     state.Init();
     state.SetState(mState == OT_COMMISSIONER_STATE_ACTIVE ? StateTlv::kAccept : StateTlv::kReject);
-    SuccessOrExit(error = message->AppendTlv(state));
+    SuccessOrExit(error = state.AppendTo(*message));
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(mSessionId);
-    SuccessOrExit(error = message->AppendTlv(sessionId));
+    SuccessOrExit(error = sessionId.AppendTo(*message));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     SuccessOrExit(error = Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr()));
@@ -994,7 +994,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Message &aRequest, State
 
     stateTlv.Init();
     stateTlv.SetState(aState);
-    SuccessOrExit(error = message->AppendTlv(stateTlv));
+    SuccessOrExit(error = stateTlv.AppendTo(*message));
 
     joinerMessageInfo.SetPeerAddr(Get<Mle::MleRouter>().GetMeshLocal64());
     joinerMessageInfo.GetPeerAddr().SetIid(mJoinerIid);
@@ -1056,22 +1056,22 @@ otError Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::MessageInf
 
     udpPort.Init();
     udpPort.SetUdpPort(mJoinerPort);
-    SuccessOrExit(error = message->AppendTlv(udpPort));
+    SuccessOrExit(error = udpPort.AppendTo(*message));
 
     iid.Init();
     iid.SetIid(mJoinerIid);
-    SuccessOrExit(error = message->AppendTlv(iid));
+    SuccessOrExit(error = iid.AppendTo(*message));
 
     rloc.Init();
     rloc.SetJoinerRouterLocator(mJoinerRloc);
-    SuccessOrExit(error = message->AppendTlv(rloc));
+    SuccessOrExit(error = rloc.AppendTo(*message));
 
     if (aMessage.GetSubType() == Message::kSubTypeJoinerFinalizeResponse)
     {
         JoinerRouterKekTlv kek;
         kek.Init();
         kek.SetKek(Get<KeyManager>().GetKek());
-        SuccessOrExit(error = message->AppendTlv(kek));
+        SuccessOrExit(error = kek.AppendTo(*message));
     }
 
     tlv.SetType(Tlv::kJoinerDtlsEncapsulation);

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -489,11 +489,11 @@ otError Dataset::AppendMleDatasetTlv(Message &aMessage) const
                 delayTimer.SetDelayTimer(0);
             }
 
-            SuccessOrExit(error = aMessage.AppendTlv(delayTimer));
+            SuccessOrExit(error = delayTimer.AppendTo(aMessage));
         }
         else
         {
-            SuccessOrExit(error = aMessage.AppendTlv(*cur));
+            SuccessOrExit(error = cur->AppendTo(aMessage));
         }
 
         cur = cur->GetNext();

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -364,7 +364,7 @@ void DatasetManager::SendGetResponse(const Coap::Message &   aRequest,
             if (cur->GetType() != Tlv::kNetworkMasterKey ||
                 (Get<KeyManager>().GetSecurityPolicyFlags() & OT_SECURITY_POLICY_OBTAIN_MASTER_KEY))
             {
-                SuccessOrExit(error = message->AppendTlv(*cur));
+                SuccessOrExit(error = cur->AppendTo(*message));
             }
 
             cur = cur->GetNext();
@@ -384,7 +384,7 @@ void DatasetManager::SendGetResponse(const Coap::Message &   aRequest,
 
             if ((tlv = dataset.Get(static_cast<Tlv::Type>(aTlvs[index]))) != NULL)
             {
-                SuccessOrExit(error = message->AppendTlv(*tlv));
+                SuccessOrExit(error = tlv->AppendTo(*message));
             }
         }
     }
@@ -442,7 +442,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
             CommissionerSessionIdTlv sessionId;
             sessionId.Init();
             sessionId.SetCommissionerSessionId(Get<Commissioner>().GetSessionId());
-            SuccessOrExit(error = message->AppendTlv(sessionId));
+            SuccessOrExit(error = sessionId.AppendTo(*message));
         }
     }
 
@@ -454,7 +454,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         timestamp.Init();
         static_cast<Timestamp *>(&timestamp)->SetSeconds(aDataset.mActiveTimestamp);
         static_cast<Timestamp *>(&timestamp)->SetTicks(0);
-        SuccessOrExit(error = message->AppendTlv(timestamp));
+        SuccessOrExit(error = timestamp.AppendTo(*message));
     }
 
     if (aDataset.mComponents.mIsPendingTimestampPresent)
@@ -463,7 +463,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         timestamp.Init();
         static_cast<Timestamp *>(&timestamp)->SetSeconds(aDataset.mPendingTimestamp);
         static_cast<Timestamp *>(&timestamp)->SetTicks(0);
-        SuccessOrExit(error = message->AppendTlv(timestamp));
+        SuccessOrExit(error = timestamp.AppendTo(*message));
     }
 
     if (aDataset.mComponents.mIsMasterKeyPresent)
@@ -471,7 +471,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         NetworkMasterKeyTlv masterkey;
         masterkey.Init();
         masterkey.SetNetworkMasterKey(static_cast<const MasterKey &>(aDataset.mMasterKey));
-        SuccessOrExit(error = message->AppendTlv(masterkey));
+        SuccessOrExit(error = masterkey.AppendTo(*message));
     }
 
     if (aDataset.mComponents.mIsNetworkNamePresent)
@@ -479,7 +479,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         NetworkNameTlv networkname;
         networkname.Init();
         networkname.SetNetworkName(static_cast<const Mac::NetworkName &>(aDataset.mNetworkName).GetAsData());
-        SuccessOrExit(error = message->AppendTlv(networkname));
+        SuccessOrExit(error = networkname.AppendTo(*message));
     }
 
     if (aDataset.mComponents.mIsExtendedPanIdPresent)
@@ -487,7 +487,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         ExtendedPanIdTlv extpanid;
         extpanid.Init();
         extpanid.SetExtendedPanId(static_cast<const Mac::ExtendedPanId &>(aDataset.mExtendedPanId));
-        SuccessOrExit(error = message->AppendTlv(extpanid));
+        SuccessOrExit(error = extpanid.AppendTo(*message));
     }
 
     if (aDataset.mComponents.mIsMeshLocalPrefixPresent)
@@ -495,7 +495,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         MeshLocalPrefixTlv localprefix;
         localprefix.Init();
         localprefix.SetMeshLocalPrefix(aDataset.mMeshLocalPrefix);
-        SuccessOrExit(error = message->AppendTlv(localprefix));
+        SuccessOrExit(error = localprefix.AppendTo(*message));
     }
 
     if (aDataset.mComponents.mIsDelayPresent)
@@ -503,7 +503,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         DelayTimerTlv delaytimer;
         delaytimer.Init();
         delaytimer.SetDelayTimer(aDataset.mDelay);
-        SuccessOrExit(error = message->AppendTlv(delaytimer));
+        SuccessOrExit(error = delaytimer.AppendTo(*message));
     }
 
     if (aDataset.mComponents.mIsPanIdPresent)
@@ -511,7 +511,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         PanIdTlv panid;
         panid.Init();
         panid.SetPanId(aDataset.mPanId);
-        SuccessOrExit(error = message->AppendTlv(panid));
+        SuccessOrExit(error = panid.AppendTo(*message));
     }
 
     if (aDataset.mComponents.mIsChannelPresent)
@@ -519,7 +519,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         ChannelTlv channel;
         channel.Init();
         channel.SetChannel(aDataset.mChannel);
-        SuccessOrExit(error = message->AppendTlv(channel));
+        SuccessOrExit(error = channel.AppendTo(*message));
     }
 
     if (aDataset.mComponents.mIsChannelMaskPresent)
@@ -527,7 +527,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         ChannelMaskTlv channelMask;
         channelMask.Init();
         channelMask.SetChannelMask(aDataset.mChannelMask);
-        SuccessOrExit(error = message->AppendTlv(channelMask));
+        SuccessOrExit(error = channelMask.AppendTo(*message));
     }
 
     if (aDataset.mComponents.mIsPskcPresent)
@@ -535,7 +535,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         PskcTlv pskc;
         pskc.Init();
         pskc.SetPskc(static_cast<const Pskc &>(aDataset.mPskc));
-        SuccessOrExit(error = message->AppendTlv(pskc));
+        SuccessOrExit(error = pskc.AppendTo(*message));
     }
 
     if (aDataset.mComponents.mIsSecurityPolicyPresent)
@@ -544,7 +544,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
         securityPolicy.Init();
         securityPolicy.SetRotationTime(aDataset.mSecurityPolicy.mRotationTime);
         securityPolicy.SetFlags(aDataset.mSecurityPolicy.mFlags);
-        SuccessOrExit(error = message->AppendTlv(securityPolicy));
+        SuccessOrExit(error = securityPolicy.AppendTo(*message));
     }
 
     if (aLength > 0)

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -297,7 +297,7 @@ void DatasetManager::SendSetResponse(const Coap::Message &   aRequest,
 
     state.Init();
     state.SetState(aState);
-    SuccessOrExit(error = message->AppendTlv(state));
+    SuccessOrExit(error = state.AppendTo(*message));
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, aMessageInfo));
 

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -85,23 +85,23 @@ otError EnergyScanClient::SendQuery(uint32_t                           aChannelM
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(Get<MeshCoP::Commissioner>().GetSessionId());
-    SuccessOrExit(error = message->AppendTlv(sessionId));
+    SuccessOrExit(error = sessionId.AppendTo(*message));
 
     channelMask.Init();
     channelMask.SetChannelMask(aChannelMask);
-    SuccessOrExit(error = message->AppendTlv(channelMask));
+    SuccessOrExit(error = channelMask.AppendTo(*message));
 
     count.Init();
     count.SetCount(aCount);
-    SuccessOrExit(error = message->AppendTlv(count));
+    SuccessOrExit(error = count.AppendTo(*message));
 
     period.Init();
     period.SetPeriod(aPeriod);
-    SuccessOrExit(error = message->AppendTlv(period));
+    SuccessOrExit(error = period.AppendTo(*message));
 
     scanDuration.Init();
     scanDuration.SetScanDuration(aScanDuration);
-    SuccessOrExit(error = message->AppendTlv(scanDuration));
+    SuccessOrExit(error = scanDuration.AppendTo(*message));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerAddr(aAddress);

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -402,33 +402,33 @@ otError Joiner::PrepareJoinerFinalizeMessage(const char *aProvisioningUrl,
 
     stateTlv.Init();
     stateTlv.SetState(MeshCoP::StateTlv::kAccept);
-    SuccessOrExit(error = mFinalizeMessage->AppendTlv(stateTlv));
+    SuccessOrExit(error = stateTlv.AppendTo(*mFinalizeMessage));
 
     vendorNameTlv.Init();
     vendorNameTlv.SetVendorName(aVendorName);
-    SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorNameTlv));
+    SuccessOrExit(error = vendorNameTlv.AppendTo(*mFinalizeMessage));
 
     vendorModelTlv.Init();
     vendorModelTlv.SetVendorModel(aVendorModel);
-    SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorModelTlv));
+    SuccessOrExit(error = vendorModelTlv.AppendTo(*mFinalizeMessage));
 
     vendorSwVersionTlv.Init();
     vendorSwVersionTlv.SetVendorSwVersion(aVendorSwVersion);
-    SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorSwVersionTlv));
+    SuccessOrExit(error = vendorSwVersionTlv.AppendTo(*mFinalizeMessage));
 
     vendorStackVersionTlv.Init();
     vendorStackVersionTlv.SetOui(OPENTHREAD_CONFIG_STACK_VENDOR_OUI);
     vendorStackVersionTlv.SetMajor(OPENTHREAD_CONFIG_STACK_VERSION_MAJOR);
     vendorStackVersionTlv.SetMinor(OPENTHREAD_CONFIG_STACK_VERSION_MINOR);
     vendorStackVersionTlv.SetRevision(OPENTHREAD_CONFIG_STACK_VERSION_REV);
-    SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorStackVersionTlv));
+    SuccessOrExit(error = vendorStackVersionTlv.AppendTo(*mFinalizeMessage));
 
     if (aVendorData != NULL)
     {
         VendorDataTlv vendorDataTlv;
         vendorDataTlv.Init();
         vendorDataTlv.SetVendorData(aVendorData);
-        SuccessOrExit(error = mFinalizeMessage->AppendTlv(vendorDataTlv));
+        SuccessOrExit(error = vendorDataTlv.AppendTo(*mFinalizeMessage));
     }
 
     provisioningUrlTlv.Init();
@@ -436,7 +436,7 @@ otError Joiner::PrepareJoinerFinalizeMessage(const char *aProvisioningUrl,
 
     if (provisioningUrlTlv.GetLength() > 0)
     {
-        SuccessOrExit(error = mFinalizeMessage->AppendTlv(provisioningUrlTlv));
+        SuccessOrExit(error = provisioningUrlTlv.AppendTo(*mFinalizeMessage));
     }
 
 exit:

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -153,15 +153,15 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
 
     udpPort.Init();
     udpPort.SetUdpPort(aMessageInfo.GetPeerPort());
-    SuccessOrExit(error = message->AppendTlv(udpPort));
+    SuccessOrExit(error = udpPort.AppendTo(*message));
 
     iid.Init();
     iid.SetIid(aMessageInfo.GetPeerAddr().mFields.m8 + 8);
-    SuccessOrExit(error = message->AppendTlv(iid));
+    SuccessOrExit(error = iid.AppendTo(*message));
 
     rloc.Init();
     rloc.SetJoinerRouterLocator(Get<Mle::MleRouter>().GetRloc16());
-    SuccessOrExit(error = message->AppendTlv(rloc));
+    SuccessOrExit(error = rloc.AppendTo(*message));
 
     tlv.SetType(Tlv::kJoinerDtlsEncapsulation);
     tlv.SetLength(aMessage.GetLength() - aMessage.GetOffset());
@@ -270,69 +270,69 @@ otError JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessage
 
     masterKey.Init();
     masterKey.SetNetworkMasterKey(Get<KeyManager>().GetMasterKey());
-    SuccessOrExit(error = message->AppendTlv(masterKey));
+    SuccessOrExit(error = masterKey.AppendTo(*message));
 
     meshLocalPrefix.Init();
     meshLocalPrefix.SetMeshLocalPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-    SuccessOrExit(error = message->AppendTlv(meshLocalPrefix));
+    SuccessOrExit(error = meshLocalPrefix.AppendTo(*message));
 
     extendedPanId.Init();
     extendedPanId.SetExtendedPanId(Get<Mac::Mac>().GetExtendedPanId());
-    SuccessOrExit(error = message->AppendTlv(extendedPanId));
+    SuccessOrExit(error = extendedPanId.AppendTo(*message));
 
     networkName.Init();
     networkName.SetNetworkName(Get<Mac::Mac>().GetNetworkName().GetAsData());
-    SuccessOrExit(error = message->AppendTlv(networkName));
+    SuccessOrExit(error = networkName.AppendTo(*message));
 
     Get<ActiveDataset>().Read(dataset);
 
     if ((tlv = dataset.Get(Tlv::kActiveTimestamp)) != NULL)
     {
-        SuccessOrExit(error = message->AppendTlv(*tlv));
+        SuccessOrExit(error = tlv->AppendTo(*message));
     }
     else
     {
         ActiveTimestampTlv activeTimestamp;
         activeTimestamp.Init();
-        SuccessOrExit(error = message->AppendTlv(activeTimestamp));
+        SuccessOrExit(error = activeTimestamp.AppendTo(*message));
     }
 
     if ((tlv = dataset.Get(Tlv::kChannelMask)) != NULL)
     {
-        SuccessOrExit(error = message->AppendTlv(*tlv));
+        SuccessOrExit(error = tlv->AppendTo(*message));
     }
     else
     {
         ChannelMaskBaseTlv channelMask;
         channelMask.Init();
-        SuccessOrExit(error = message->AppendTlv(channelMask));
+        SuccessOrExit(error = channelMask.AppendTo(*message));
     }
 
     if ((tlv = dataset.Get(Tlv::kPskc)) != NULL)
     {
-        SuccessOrExit(error = message->AppendTlv(*tlv));
+        SuccessOrExit(error = tlv->AppendTo(*message));
     }
     else
     {
         PskcTlv pskc;
         pskc.Init();
-        SuccessOrExit(error = message->AppendTlv(pskc));
+        SuccessOrExit(error = pskc.AppendTo(*message));
     }
 
     if ((tlv = dataset.Get(Tlv::kSecurityPolicy)) != NULL)
     {
-        SuccessOrExit(error = message->AppendTlv(*tlv));
+        SuccessOrExit(error = tlv->AppendTo(*message));
     }
     else
     {
         SecurityPolicyTlv securityPolicy;
         securityPolicy.Init();
-        SuccessOrExit(error = message->AppendTlv(securityPolicy));
+        SuccessOrExit(error = securityPolicy.AppendTo(*message));
     }
 
     networkKeySequence.Init();
     networkKeySequence.SetNetworkKeySequence(Get<KeyManager>().GetCurrentKeySequence());
-    SuccessOrExit(error = message->AppendTlv(networkKeySequence));
+    SuccessOrExit(error = networkKeySequence.AppendTo(*message));
 
     messageInfo = aMessageInfo;
     messageInfo.SetPeerPort(kCoapUdpPort);

--- a/src/core/meshcop/leader.cpp
+++ b/src/core/meshcop/leader.cpp
@@ -135,18 +135,18 @@ otError Leader::SendPetitionResponse(const Coap::Message &   aRequest,
 
     state.Init();
     state.SetState(aState);
-    SuccessOrExit(error = message->AppendTlv(state));
+    SuccessOrExit(error = state.AppendTo(*message));
 
     if (mTimer.IsRunning())
     {
-        SuccessOrExit(error = message->AppendTlv(mCommissionerId));
+        SuccessOrExit(error = mCommissionerId.AppendTo(*message));
     }
 
     if (aState == StateTlv::kAccept)
     {
         sessionId.Init();
         sessionId.SetCommissionerSessionId(mSessionId);
-        SuccessOrExit(error = message->AppendTlv(sessionId));
+        SuccessOrExit(error = sessionId.AppendTo(*message));
     }
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, aMessageInfo));
@@ -231,7 +231,7 @@ otError Leader::SendKeepAliveResponse(const Coap::Message &   aRequest,
 
     state.Init();
     state.SetState(aState);
-    SuccessOrExit(error = message->AppendTlv(state));
+    SuccessOrExit(error = state.AppendTo(*message));
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, aMessageInfo));
 

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -80,15 +80,15 @@ otError PanIdQueryClient::SendQuery(uint16_t                            aPanId,
 
     sessionId.Init();
     sessionId.SetCommissionerSessionId(Get<MeshCoP::Commissioner>().GetSessionId());
-    SuccessOrExit(error = message->AppendTlv(sessionId));
+    SuccessOrExit(error = sessionId.AppendTo(*message));
 
     channelMask.Init();
     channelMask.SetChannelMask(aChannelMask);
-    SuccessOrExit(error = message->AppendTlv(channelMask));
+    SuccessOrExit(error = channelMask.AppendTo(*message));
 
     panId.Init();
     panId.SetPanId(aPanId);
-    SuccessOrExit(error = message->AppendTlv(panId));
+    SuccessOrExit(error = panId.AppendTo(*message));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerAddr(aAddress);

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -384,7 +384,7 @@ otError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
 
     targetTlv.Init();
     targetTlv.SetTarget(aEid);
-    SuccessOrExit(error = message->AppendTlv(targetTlv));
+    SuccessOrExit(error = targetTlv.AppendTo(*message));
 
     messageInfo.GetPeerAddr().mFields.m16[0] = HostSwap16(0xff03);
     messageInfo.GetPeerAddr().mFields.m16[7] = HostSwap16(0x0002);
@@ -520,8 +520,8 @@ otError AddressResolver::SendAddressError(const ThreadTargetTlv &      aTarget,
     SuccessOrExit(error = message->AppendUriPathOptions(OT_URI_PATH_ADDRESS_ERROR));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = message->AppendTlv(aTarget));
-    SuccessOrExit(error = message->AppendTlv(aEid));
+    SuccessOrExit(error = aTarget.AppendTo(*message));
+    SuccessOrExit(error = aEid.AppendTo(*message));
 
     if (aDestination == NULL)
     {
@@ -704,16 +704,16 @@ void AddressResolver::SendAddressQueryResponse(const ThreadTargetTlv &          
     SuccessOrExit(error = message->AppendUriPathOptions(OT_URI_PATH_ADDRESS_NOTIFY));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = message->AppendTlv(aTargetTlv));
-    SuccessOrExit(error = message->AppendTlv(aMlEidTlv));
+    SuccessOrExit(error = aTargetTlv.AppendTo(*message));
+    SuccessOrExit(error = aMlEidTlv.AppendTo(*message));
 
     rloc16Tlv.Init();
     rloc16Tlv.SetRloc16(Get<Mle::MleRouter>().GetRloc16());
-    SuccessOrExit(error = message->AppendTlv(rloc16Tlv));
+    SuccessOrExit(error = rloc16Tlv.AppendTo(*message));
 
     if (aLastTransactionTimeTlv != NULL)
     {
-        SuccessOrExit(error = message->AppendTlv(*aLastTransactionTimeTlv));
+        SuccessOrExit(error = aLastTransactionTimeTlv->AppendTo(*message));
     }
 
     messageInfo.SetPeerAddr(aDestination);

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -187,7 +187,7 @@ otError EnergyScanServer::SendReport(void)
 
     channelMask.Init();
     channelMask.SetChannelMask(mChannelMask);
-    SuccessOrExit(error = message->AppendTlv(channelMask));
+    SuccessOrExit(error = channelMask.AppendTo(*message));
 
     energyList.Init();
     energyList.SetLength(mScanResultsLength);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -557,7 +557,7 @@ otError Mle::Discover(const Mac::ChannelMask &aScanChannels,
     discoveryRequest.Init();
     discoveryRequest.SetVersion(kThreadVersion);
     discoveryRequest.SetJoiner(aJoiner);
-    SuccessOrExit(error = message->AppendTlv(discoveryRequest));
+    SuccessOrExit(error = discoveryRequest.AppendTo(*message));
 
     tlv.SetLength(static_cast<uint8_t>(message->GetLength() - startOffset));
     message->Write(startOffset - sizeof(tlv), sizeof(tlv), &tlv);
@@ -1126,7 +1126,7 @@ otError Mle::AppendSourceAddress(Message &aMessage)
     tlv.Init();
     tlv.SetRloc16(GetRloc16());
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 otError Mle::AppendStatus(Message &aMessage, StatusTlv::Status aStatus)
@@ -1136,7 +1136,7 @@ otError Mle::AppendStatus(Message &aMessage, StatusTlv::Status aStatus)
     tlv.Init();
     tlv.SetStatus(aStatus);
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 otError Mle::AppendMode(Message &aMessage, DeviceMode aMode)
@@ -1146,7 +1146,7 @@ otError Mle::AppendMode(Message &aMessage, DeviceMode aMode)
     tlv.Init();
     tlv.SetMode(aMode);
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 otError Mle::AppendTimeout(Message &aMessage, uint32_t aTimeout)
@@ -1156,7 +1156,7 @@ otError Mle::AppendTimeout(Message &aMessage, uint32_t aTimeout)
     tlv.Init();
     tlv.SetTimeout(aTimeout);
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 otError Mle::AppendChallenge(Message &aMessage, const uint8_t *aChallenge, uint8_t aChallengeLength)
@@ -1195,7 +1195,7 @@ otError Mle::AppendLinkFrameCounter(Message &aMessage)
     tlv.Init();
     tlv.SetFrameCounter(Get<KeyManager>().GetMacFrameCounter());
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 otError Mle::AppendMleFrameCounter(Message &aMessage)
@@ -1205,7 +1205,7 @@ otError Mle::AppendMleFrameCounter(Message &aMessage)
     tlv.Init();
     tlv.SetFrameCounter(Get<KeyManager>().GetMleFrameCounter());
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 otError Mle::AppendAddress16(Message &aMessage, uint16_t aRloc16)
@@ -1215,7 +1215,7 @@ otError Mle::AppendAddress16(Message &aMessage, uint16_t aRloc16)
     tlv.Init();
     tlv.SetRloc16(aRloc16);
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 otError Mle::AppendLeaderData(Message &aMessage)
@@ -1224,7 +1224,7 @@ otError Mle::AppendLeaderData(Message &aMessage)
     mLeaderData.SetDataVersion(Get<NetworkData::Leader>().GetVersion());
     mLeaderData.SetStableDataVersion(Get<NetworkData::Leader>().GetStableVersion());
 
-    return aMessage.AppendTlv(mLeaderData);
+    return mLeaderData.AppendTo(aMessage);
 }
 
 void Mle::FillNetworkDataTlv(NetworkDataTlv &aTlv, bool aStableOnly)
@@ -1246,7 +1246,7 @@ otError Mle::AppendNetworkData(Message &aMessage, bool aStableOnly)
     tlv.Init();
     FillNetworkDataTlv(tlv, aStableOnly);
 
-    error = aMessage.AppendTlv(tlv);
+    error = tlv.AppendTo(aMessage);
 
 exit:
     return error;
@@ -1274,7 +1274,7 @@ otError Mle::AppendScanMask(Message &aMessage, uint8_t aScanMask)
     tlv.Init();
     tlv.SetMask(aScanMask);
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 otError Mle::AppendLinkMargin(Message &aMessage, uint8_t aLinkMargin)
@@ -1284,7 +1284,7 @@ otError Mle::AppendLinkMargin(Message &aMessage, uint8_t aLinkMargin)
     tlv.Init();
     tlv.SetLinkMargin(aLinkMargin);
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 otError Mle::AppendVersion(Message &aMessage)
@@ -1294,7 +1294,7 @@ otError Mle::AppendVersion(Message &aMessage)
     tlv.Init();
     tlv.SetVersion(kThreadVersion);
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 bool Mle::HasUnregisteredAddress(void)
@@ -1417,7 +1417,7 @@ otError Mle::AppendTimeRequest(Message &aMessage)
 
     tlv.Init();
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 otError Mle::AppendTimeParameter(Message &aMessage)
@@ -1428,7 +1428,7 @@ otError Mle::AppendTimeParameter(Message &aMessage)
     tlv.SetTimeSyncPeriod(Get<TimeSync>().GetTimeSyncPeriod());
     tlv.SetXtalThreshold(Get<TimeSync>().GetXtalThreshold());
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 otError Mle::AppendXtalAccuracy(Message &aMessage)
@@ -1438,7 +1438,7 @@ otError Mle::AppendXtalAccuracy(Message &aMessage)
     tlv.Init();
     tlv.SetXtalAccuracy(otPlatTimeGetXtalAccuracy());
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
@@ -1453,7 +1453,7 @@ otError Mle::AppendActiveTimestamp(Message &aMessage)
 
     timestampTlv.Init();
     *static_cast<MeshCoP::Timestamp *>(&timestampTlv) = *timestamp;
-    error                                             = aMessage.AppendTlv(timestampTlv);
+    error                                             = timestampTlv.AppendTo(aMessage);
 
 exit:
     return error;
@@ -1470,7 +1470,7 @@ otError Mle::AppendPendingTimestamp(Message &aMessage)
 
     timestampTlv.Init();
     *static_cast<MeshCoP::Timestamp *>(&timestampTlv) = *timestamp;
-    error                                             = aMessage.AppendTlv(timestampTlv);
+    error                                             = timestampTlv.AppendTo(aMessage);
 
 exit:
     return error;
@@ -2435,7 +2435,7 @@ otError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Add
 
     channel.Init();
     channel.SetChannel(Get<Mac::Mac>().GetPanChannel());
-    SuccessOrExit(error = message->AppendTlv(channel));
+    SuccessOrExit(error = channel.AppendTo(*message));
 
     if (aOrphanAnnounce)
     {
@@ -2444,7 +2444,7 @@ otError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Add
         activeTimestamp.SetTicks(0);
         activeTimestamp.SetAuthoritative(true);
 
-        SuccessOrExit(error = message->AppendTlv(activeTimestamp));
+        SuccessOrExit(error = activeTimestamp.AppendTo(*message));
     }
     else
     {
@@ -2453,7 +2453,7 @@ otError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Add
 
     panid.Init();
     panid.SetPanId(Get<Mac::Mac>().GetPanId());
-    SuccessOrExit(error = message->AppendTlv(panid));
+    SuccessOrExit(error = panid.AppendTo(*message));
     SuccessOrExit(error = SendMessage(*message, aDestination));
 
     otLogInfoMle("Send Announce on channel %d", aChannel);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2786,7 +2786,7 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
 
         commissionerUdpPort.Init();
         commissionerUdpPort.SetUdpPort(MeshCoP::kBorderAgentUdpPort);
-        SuccessOrExit(error = message->AppendTlv(commissionerUdpPort));
+        SuccessOrExit(error = commissionerUdpPort.AppendTo(*message));
 
         discoveryResponse.SetNativeCommissioner(true);
     }
@@ -2795,17 +2795,17 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
         discoveryResponse.SetNativeCommissioner(false);
     }
 
-    SuccessOrExit(error = message->AppendTlv(discoveryResponse));
+    SuccessOrExit(error = discoveryResponse.AppendTo(*message));
 
     // Extended PAN ID TLV
     extPanId.Init();
     extPanId.SetExtendedPanId(Get<Mac::Mac>().GetExtendedPanId());
-    SuccessOrExit(error = message->AppendTlv(extPanId));
+    SuccessOrExit(error = extPanId.AppendTo(*message));
 
     // Network Name TLV
     networkName.Init();
     networkName.SetNetworkName(Get<Mac::Mac>().GetNetworkName().GetAsData());
-    SuccessOrExit(error = message->AppendTlv(networkName));
+    SuccessOrExit(error = networkName.AppendTo(*message));
 
 #if OPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE
 
@@ -2813,7 +2813,7 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
     // Otherwise use the one from commissioning data.
     if (!mSteeringData.IsCleared())
     {
-        SuccessOrExit(error = message->AppendTlv(mSteeringData));
+        SuccessOrExit(error = mSteeringData.AppendTo(*message));
     }
     else
 #endif // OPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE
@@ -2823,14 +2823,14 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
 
         if (steeringData != NULL)
         {
-            SuccessOrExit(error = message->AppendTlv(*steeringData));
+            SuccessOrExit(error = steeringData->AppendTo(*message));
         }
     }
 
     // Joiner UDP Port TLV
     joinerUdpPort.Init();
     joinerUdpPort.SetUdpPort(Get<MeshCoP::JoinerRouter>().GetJoinerUdpPort());
-    SuccessOrExit(error = message->AppendTlv(joinerUdpPort));
+    SuccessOrExit(error = joinerUdpPort.AppendTo(*message));
 
     tlv.SetLength(static_cast<uint8_t>(message->GetLength() - startOffset));
     message->Write(startOffset - sizeof(tlv), sizeof(tlv), &tlv);
@@ -3839,18 +3839,18 @@ otError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
 
     macAddr64Tlv.Init();
     macAddr64Tlv.SetMacAddr(Get<Mac::Mac>().GetExtAddress());
-    SuccessOrExit(error = message->AppendTlv(macAddr64Tlv));
+    SuccessOrExit(error = macAddr64Tlv.AppendTo(*message));
 
     if (IsRouterIdValid(mPreviousRouterId))
     {
         rlocTlv.Init();
         rlocTlv.SetRloc16(GetRloc16(mPreviousRouterId));
-        SuccessOrExit(error = message->AppendTlv(rlocTlv));
+        SuccessOrExit(error = rlocTlv.AppendTo(*message));
     }
 
     statusTlv.Init();
     statusTlv.SetStatus(aStatus);
-    SuccessOrExit(error = message->AppendTlv(statusTlv));
+    SuccessOrExit(error = statusTlv.AppendTo(*message));
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     SuccessOrExit(error = AppendXtalAccuracy(*message));
@@ -3891,11 +3891,11 @@ otError MleRouter::SendAddressRelease(void)
 
     rlocTlv.Init();
     rlocTlv.SetRloc16(GetRloc16(mRouterId));
-    SuccessOrExit(error = message->AppendTlv(rlocTlv));
+    SuccessOrExit(error = rlocTlv.AppendTo(*message));
 
     macAddr64Tlv.Init();
     macAddr64Tlv.SetMacAddr(Get<Mac::Mac>().GetExtAddress());
-    SuccessOrExit(error = message->AppendTlv(macAddr64Tlv));
+    SuccessOrExit(error = macAddr64Tlv.AppendTo(*message));
 
     messageInfo.SetSockAddr(GetMeshLocal16());
     SuccessOrExit(error = GetLeaderAddress(messageInfo.GetPeerAddr()));
@@ -4126,13 +4126,13 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Message &   aRequest,
 
     statusTlv.Init();
     statusTlv.SetStatus(aRouter == NULL ? statusTlv.kNoAddressAvailable : statusTlv.kSuccess);
-    SuccessOrExit(error = message->AppendTlv(statusTlv));
+    SuccessOrExit(error = statusTlv.AppendTo(*message));
 
     if (aRouter != NULL)
     {
         rlocTlv.Init();
         rlocTlv.SetRloc16(aRouter->GetRloc16());
-        SuccessOrExit(error = message->AppendTlv(rlocTlv));
+        SuccessOrExit(error = rlocTlv.AppendTo(*message));
 
         routerMaskTlv.Init();
         routerMaskTlv.SetIdSequence(mRouterTable.GetRouterIdSequence());
@@ -4146,7 +4146,7 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Message &   aRequest,
             }
         }
 
-        SuccessOrExit(error = message->AppendTlv(routerMaskTlv));
+        SuccessOrExit(error = routerMaskTlv.AppendTo(*message));
     }
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, aMessageInfo));
@@ -4333,7 +4333,7 @@ otError MleRouter::AppendConnectivity(Message &aMessage)
     tlv.Init();
     FillConnectivityTlv(tlv);
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 otError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
@@ -4443,7 +4443,7 @@ otError MleRouter::AppendRoute(Message &aMessage)
     tlv.Init();
     FillRouteTlv(tlv);
 
-    return aMessage.AppendTlv(tlv);
+    return tlv.AppendTo(aMessage);
 }
 
 otError MleRouter::AppendActiveDataset(Message &aMessage)

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -1000,7 +1000,7 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16)
         ThreadRloc16Tlv rloc16Tlv;
         rloc16Tlv.Init();
         rloc16Tlv.SetRloc16(aRloc16);
-        SuccessOrExit(error = message->AppendTlv(rloc16Tlv));
+        SuccessOrExit(error = rloc16Tlv.AppendTo(*message));
     }
 
     Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr());

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -341,7 +341,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Message &   aRequest,
             {
                 if (cur->GetType() == type)
                 {
-                    SuccessOrExit(error = message->AppendTlv(*cur));
+                    SuccessOrExit(error = cur->AppendTo(*message));
                     break;
                 }
             }
@@ -381,7 +381,7 @@ void Leader::SendCommissioningSetResponse(const Coap::Message &    aRequest,
 
     state.Init();
     state.SetState(aState);
-    SuccessOrExit(error = message->AppendTlv(state));
+    SuccessOrExit(error = state.AppendTo(*message));
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, aMessageInfo));
 

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -313,7 +313,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             ExtMacAddressTlv tlv;
             tlv.Init();
             tlv.SetMacAddr(Get<Mac::Mac>().GetExtAddress());
-            SuccessOrExit(error = aResponse.AppendTlv(tlv));
+            SuccessOrExit(error = tlv.AppendTo(aResponse));
             break;
         }
 
@@ -322,7 +322,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             Address16Tlv tlv;
             tlv.Init();
             tlv.SetRloc16(Get<Mle::MleRouter>().GetRloc16());
-            SuccessOrExit(error = aResponse.AppendTlv(tlv));
+            SuccessOrExit(error = tlv.AppendTo(aResponse));
             break;
         }
 
@@ -331,7 +331,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             ModeTlv tlv;
             tlv.Init();
             tlv.SetMode(Get<Mle::MleRouter>().GetDeviceMode());
-            SuccessOrExit(error = aResponse.AppendTlv(tlv));
+            SuccessOrExit(error = tlv.AppendTo(aResponse));
             break;
         }
 
@@ -342,7 +342,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
                 TimeoutTlv tlv;
                 tlv.Init();
                 tlv.SetTimeout(Get<Mle::MleRouter>().GetTimeout());
-                SuccessOrExit(error = aResponse.AppendTlv(tlv));
+                SuccessOrExit(error = tlv.AppendTo(aResponse));
             }
 
             break;
@@ -353,7 +353,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             ConnectivityTlv tlv;
             tlv.Init();
             Get<Mle::MleRouter>().FillConnectivityTlv(reinterpret_cast<Mle::ConnectivityTlv &>(tlv));
-            SuccessOrExit(error = aResponse.AppendTlv(tlv));
+            SuccessOrExit(error = tlv.AppendTo(aResponse));
             break;
         }
 
@@ -363,7 +363,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             RouteTlv tlv;
             tlv.Init();
             Get<Mle::MleRouter>().FillRouteTlv(reinterpret_cast<Mle::RouteTlv &>(tlv));
-            SuccessOrExit(error = aResponse.AppendTlv(tlv));
+            SuccessOrExit(error = tlv.AppendTo(aResponse));
             break;
         }
 #endif
@@ -372,7 +372,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
         {
             LeaderDataTlv tlv(reinterpret_cast<const LeaderDataTlv &>(Get<Mle::MleRouter>().GetLeaderDataTlv()));
             tlv.Init();
-            SuccessOrExit(error = aResponse.AppendTlv(tlv));
+            SuccessOrExit(error = tlv.AppendTo(aResponse));
             break;
         }
 
@@ -382,7 +382,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             tlv.Init();
 
             Get<Mle::MleRouter>().FillNetworkDataTlv((reinterpret_cast<Mle::NetworkDataTlv &>(tlv)), false);
-            SuccessOrExit(error = aResponse.AppendTlv(tlv));
+            SuccessOrExit(error = tlv.AppendTo(aResponse));
             break;
         }
 
@@ -398,7 +398,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             memset(&tlv, 0, sizeof(tlv));
             tlv.Init();
             FillMacCountersTlv(tlv);
-            SuccessOrExit(error = aResponse.AppendTlv(tlv));
+            SuccessOrExit(error = tlv.AppendTo(aResponse));
             break;
         }
 
@@ -446,7 +446,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             }
 
             tlv.SetLength(length);
-            SuccessOrExit(error = aResponse.AppendTlv(tlv));
+            SuccessOrExit(error = tlv.AppendTo(aResponse));
             break;
         }
 
@@ -459,7 +459,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
                 MaxChildTimeoutTlv tlv;
                 tlv.Init();
                 tlv.SetTimeout(maxTimeout);
-                SuccessOrExit(error = aResponse.AppendTlv(tlv));
+                SuccessOrExit(error = tlv.AppendTo(aResponse));
             }
 
             break;

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -128,11 +128,11 @@ otError PanIdQueryServer::SendConflict(void)
 
     channelMask.Init();
     channelMask.SetChannelMask(mChannelMask);
-    SuccessOrExit(error = message->AppendTlv(channelMask));
+    SuccessOrExit(error = channelMask.AppendTo(*message));
 
     panId.Init();
     panId.SetPanId(mPanId);
-    SuccessOrExit(error = message->AppendTlv(panId));
+    SuccessOrExit(error = panId.AppendTo(*message));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerAddr(mCommissioner);


### PR DESCRIPTION
This PR adds AppendTo(Message) to Tlv, so that Message doesn't depend
on Tlv any more. This allows a concrete Tlv overriding its
serialization. This was discussed in #4104.