### PR TITLE
[nrf528xx] return the TX power which was actually set in the register

### DIFF
--- a/examples/platforms/nrf528xx/src/radio.c
+++ b/examples/platforms/nrf528xx/src/radio.c
@@ -571,7 +571,7 @@ otError otPlatRadioGetTransmitPower(otInstance *aInstance, int8_t *aPower)
     }
     else
     {
-        *aPower = sDefaultTxPower;
+        *aPower = nrf_802154_tx_power_get();
     }
 
     return error;


### PR DESCRIPTION
This PR ensures that TX Power return via `otPlatRadioGetTransmitPower` is one that is actually set in the register. E.g. even if TX power is set to 100 via `otPlatRadioSetTransmitPower`, the maximum power is 8 for nRF52840.