### PR TITLE
[lowpan] simplify MeshHeader/FragHeader and their use in MeshForwarder

### DIFF
--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -92,9 +92,9 @@ public:
      *
      */
     BufferWriter(uint8_t *aBuf, uint16_t aLength)
+        : mWritePointer(aBuf)
+        , mEndPointer(aBuf + aLength)
     {
-        mWritePointer    = aBuf;
-        mRemainingLength = aLength;
     }
 
     /**
@@ -106,7 +106,7 @@ public:
      * @retval  FALSE  Insufficient buffer space to write the requested number of bytes.
      *
      */
-    bool CanWrite(uint8_t aLength) const { return mRemainingLength >= aLength; }
+    bool CanWrite(uint8_t aLength) const { return (mWritePointer + aLength) <= mEndPointer; }
 
     /**
      * This method returns the current write pointer value.
@@ -121,8 +121,8 @@ public:
      *
      * @param[in]  aLength  Number of bytes to advance.
      *
-     * @retval  TRUE   Enough buffer space is available to advance the requested number of bytes.
-     * @retval  FALSE  Insufficient buffer space to advance the requested number of bytes.
+     * @retval OT_ERROR_NONE     Enough buffer space is available to advance the requested number of bytes.
+     * @retval OT_ERROR_NO_BUFS  Insufficient buffer space to advance the requested number of bytes.
      *
      */
     otError Advance(uint8_t aLength)
@@ -130,9 +130,7 @@ public:
         otError error = OT_ERROR_NONE;
 
         VerifyOrExit(CanWrite(aLength), error = OT_ERROR_NO_BUFS);
-
         mWritePointer += aLength;
-        mRemainingLength -= aLength;
 
     exit:
         return error;
@@ -154,7 +152,6 @@ public:
         VerifyOrExit(CanWrite(sizeof(aByte)), error = OT_ERROR_NO_BUFS);
 
         *mWritePointer++ = aByte;
-        mRemainingLength--;
 
     exit:
         return error;
@@ -178,7 +175,6 @@ public:
 
         memcpy(mWritePointer, aBuf, aLength);
         mWritePointer += aLength;
-        mRemainingLength -= aLength;
 
     exit:
         return error;
@@ -207,7 +203,6 @@ public:
         assert(rval == aLength);
 
         mWritePointer += aLength;
-        mRemainingLength -= aLength;
 
     exit:
         return error;
@@ -215,7 +210,7 @@ public:
 
 private:
     uint8_t *mWritePointer;
-    uint16_t mRemainingLength;
+    uint8_t *mEndPointer;
 };
 
 /**

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -389,21 +389,6 @@ void MeshForwarder::GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::
     }
 }
 
-otError MeshForwarder::SkipMeshHeader(const uint8_t *&aFrame, uint16_t &aFrameLength)
-{
-    otError            error = OT_ERROR_NONE;
-    Lowpan::MeshHeader meshHeader;
-    uint16_t           headerLength;
-
-    VerifyOrExit(Lowpan::MeshHeader::IsMeshHeader(aFrame, aFrameLength));
-    SuccessOrExit(error = meshHeader.ParseFrom(aFrame, aFrameLength, headerLength));
-    aFrame += headerLength;
-    aFrameLength -= headerLength;
-
-exit:
-    return error;
-}
-
 otError MeshForwarder::GetFragmentHeader(const uint8_t *         aFrame,
                                          uint16_t                aFrameLength,
                                          Lowpan::FragmentHeader &aFragmentHeader)
@@ -431,8 +416,6 @@ otError MeshForwarder::DecompressIp6Header(const uint8_t *     aFrame,
     const uint8_t *        start = aFrame;
     Lowpan::FragmentHeader fragmentHeader;
     int                    headerLength;
-
-    SuccessOrExit(error = SkipMeshHeader(aFrame, aFrameLength));
 
     if (GetFragmentHeader(aFrame, aFrameLength, fragmentHeader) == OT_ERROR_NONE)
     {

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -389,18 +389,6 @@ void MeshForwarder::GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::
     }
 }
 
-otError MeshForwarder::GetMeshHeader(const uint8_t *&aFrame, uint16_t &aFrameLength, Lowpan::MeshHeader &aMeshHeader)
-{
-    otError error;
-
-    VerifyOrExit(aFrameLength >= 1 && reinterpret_cast<const Lowpan::MeshHeader *>(aFrame)->IsMeshHeader(),
-                 error = OT_ERROR_NOT_FOUND);
-    SuccessOrExit(error = aMeshHeader.Init(aFrame, aFrameLength));
-
-exit:
-    return error;
-}
-
 otError MeshForwarder::SkipMeshHeader(const uint8_t *&aFrame, uint16_t &aFrameLength)
 {
     otError            error = OT_ERROR_NONE;

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -345,7 +345,6 @@ private:
                          const Mac::Address &aMeshSource,
                          const Mac::Address &aMeshDest);
 
-    otError  GetMeshHeader(const uint8_t *&aFrame, uint16_t &aFrameLength, Lowpan::MeshHeader &aMeshHeader);
     otError  SkipMeshHeader(const uint8_t *&aFrame, uint16_t &aFrameLength);
     otError  DecompressIp6Header(const uint8_t *     aFrame,
                                  uint16_t            aFrameLength,
@@ -425,8 +424,8 @@ private:
     otError GetFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader, uint16_t aSrcRloc16, uint8_t &aPriority);
     otError GetForwardFramePriority(const uint8_t *     aFrame,
                                     uint16_t            aFrameLength,
-                                    const Mac::Address &aMacDest,
-                                    const Mac::Address &aMacSource,
+                                    const Mac::Address &aMeshSource,
+                                    const Mac::Address &aMeshDest,
                                     uint8_t &           aPriority);
 
     FragmentPriorityEntry *FindFragmentPriorityEntry(uint16_t aTag, uint16_t aSrcRloc16);

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -345,7 +345,6 @@ private:
                          const Mac::Address &aMeshSource,
                          const Mac::Address &aMeshDest);
 
-    otError  SkipMeshHeader(const uint8_t *&aFrame, uint16_t &aFrameLength);
     otError  DecompressIp6Header(const uint8_t *     aFrame,
                                  uint16_t            aFrameLength,
                                  const Mac::Address &aMacSource,

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -375,11 +375,6 @@ private:
                             const Mac::Address &    aMacSource,
                             const Mac::Address &    aMacDest,
                             const otThreadLinkInfo &aLinkInfo);
-
-    static otError GetFragmentHeader(const uint8_t *         aFrame,
-                                     uint16_t                aFrameLength,
-                                     Lowpan::FragmentHeader &aFragmentHeader);
-
     uint16_t PrepareDataFrame(Mac::TxFrame &      aFrame,
                               Message &           aMessage,
                               const Mac::Address &aMacSource,

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -516,14 +516,14 @@ void MeshForwarder::HandleMesh(uint8_t *               aFrame,
     meshSource.SetShort(meshHeader.GetSource());
     meshDest.SetShort(meshHeader.GetDestination());
 
+    aFrame += headerLength;
+    aFrameLength -= headerLength;
+
     UpdateRoutes(aFrame, aFrameLength, meshSource, meshDest);
 
     if (meshDest.GetShort() == Get<Mac::Mac>().GetShortAddress() ||
         Get<Mle::MleRouter>().IsMinimalChild(meshDest.GetShort()))
     {
-        aFrame += headerLength;
-        aFrameLength -= headerLength;
-
         if (reinterpret_cast<Lowpan::FragmentHeader *>(aFrame)->IsFragmentHeader())
         {
             HandleFragment(aFrame, aFrameLength, meshSource, meshDest, aLinkInfo);
@@ -547,9 +547,6 @@ void MeshForwarder::HandleMesh(uint8_t *               aFrame,
         SuccessOrExit(error = CheckReachability(aFrame, aFrameLength, meshSource, meshDest));
 
         meshHeader.DecrementHopsLeft();
-
-        aFrame += headerLength;
-        aFrameLength -= headerLength;
 
         GetForwardFramePriority(aFrame, aFrameLength, meshSource, meshDest, priority);
         message = Get<MessagePool>().New(Message::kType6lowpan, priority);

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -625,13 +625,13 @@ bool MeshForwarder::UpdateFragmentLifetime(void)
 {
     bool shouldRun = false;
 
-    for (size_t i = 0; i < OT_ARRAY_LENGTH(mFragmentEntries); i++)
+    for (FragmentPriorityEntry *entry = &mFragmentEntries[0]; entry < OT_ARRAY_END(mFragmentEntries); entry++)
     {
-        if (mFragmentEntries[i].GetLifetime() != 0)
+        if (entry->GetLifetime() != 0)
         {
-            mFragmentEntries[i].DecrementLifetime();
+            entry->DecrementLifetime();
 
-            if (mFragmentEntries[i].GetLifetime() != 0)
+            if (entry->GetLifetime() != 0)
             {
                 shouldRun = true;
             }
@@ -680,33 +680,38 @@ exit:
 
 FragmentPriorityEntry *MeshForwarder::FindFragmentPriorityEntry(uint16_t aTag, uint16_t aSrcRloc16)
 {
-    size_t i;
+    FragmentPriorityEntry *entry;
 
-    for (i = 0; i < OT_ARRAY_LENGTH(mFragmentEntries); i++)
+    for (entry = &mFragmentEntries[0]; entry < OT_ARRAY_END(mFragmentEntries); entry++)
     {
-        if ((mFragmentEntries[i].GetLifetime() != 0) && (mFragmentEntries[i].GetDatagramTag() == aTag) &&
-            (mFragmentEntries[i].GetSrcRloc16() == aSrcRloc16))
+        if ((entry->GetLifetime() != 0) && (entry->GetDatagramTag() == aTag) && (entry->GetSrcRloc16() == aSrcRloc16))
         {
-            break;
+            ExitNow();
         }
     }
 
-    return (i >= OT_ARRAY_LENGTH(mFragmentEntries)) ? NULL : &mFragmentEntries[i];
+    entry = NULL;
+
+exit:
+    return entry;
 }
 
 FragmentPriorityEntry *MeshForwarder::GetUnusedFragmentPriorityEntry(void)
 {
-    size_t i;
+    FragmentPriorityEntry *entry;
 
-    for (i = 0; i < OT_ARRAY_LENGTH(mFragmentEntries); i++)
+    for (entry = &mFragmentEntries[0]; entry < OT_ARRAY_END(mFragmentEntries); entry++)
     {
-        if (mFragmentEntries[i].GetLifetime() == 0)
+        if (entry->GetLifetime() == 0)
         {
-            break;
+            ExitNow();
         }
     }
 
-    return (i >= OT_ARRAY_LENGTH(mFragmentEntries)) ? NULL : &mFragmentEntries[i];
+    entry = NULL;
+
+exit:
+    return entry;
 }
 
 otError MeshForwarder::GetFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader,
@@ -716,8 +721,8 @@ otError MeshForwarder::GetFragmentPriority(Lowpan::FragmentHeader &aFragmentHead
     otError                error = OT_ERROR_NONE;
     FragmentPriorityEntry *entry;
 
-    VerifyOrExit((entry = FindFragmentPriorityEntry(aFragmentHeader.GetDatagramTag(), aSrcRloc16)) != NULL,
-                 error = OT_ERROR_NOT_FOUND);
+    entry = FindFragmentPriorityEntry(aFragmentHeader.GetDatagramTag(), aSrcRloc16);
+    VerifyOrExit(entry != NULL, error = OT_ERROR_NOT_FOUND);
     aPriority = entry->GetPriority();
 
 exit:

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -1832,11 +1832,203 @@ void TestLowpanIphc(void)
     testFreeInstance(sInstance);
 }
 
+void TestLowpanMeshHeader(void)
+{
+    enum
+    {
+        kMaxFrameSize = 127,
+        kSourceAddr   = 0x100,
+        kDestAddr     = 0x200,
+    };
+
+    const uint8_t kMeshHeader1[] = {0xb1, 0x01, 0x00, 0x02, 0x00};       // src:0x100, dest:0x200, hop:0x1
+    const uint8_t kMeshHeader2[] = {0xbf, 0x20, 0x01, 0x00, 0x02, 0x00}; // src:0x100, dest:0x200, hop:0x20
+    const uint8_t kMeshHeader3[] = {0xbf, 0x01, 0x01, 0x00, 0x02, 0x00}; // src:0x100, dest:0x200, hop:0x1 (deepHops)
+
+    uint8_t            frame[kMaxFrameSize];
+    uint16_t           length;
+    uint16_t           headerLength;
+    Lowpan::MeshHeader meshHeader;
+
+    meshHeader.Init(kSourceAddr, kDestAddr, 1);
+    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "MeshHeader::GetSource() failed after Init()");
+    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "MeshHeader::GetDestination() failed after Init()");
+    VerifyOrQuit(meshHeader.GetHopsLeft() == 1, "MeshHeader::GetHopsLeft() failed after Init()");
+
+    length = meshHeader.WriteTo(frame);
+    VerifyOrQuit(length == meshHeader.GetHeaderLength(), "MeshHeader::GetHeaderLength() failed");
+    VerifyOrQuit(length == sizeof(kMeshHeader1), "MeshHeader::WriteTo() returned length is incorrect");
+    VerifyOrQuit(memcmp(frame, kMeshHeader1, length) == 0, "MeshHeader::WriteTo() failed");
+
+    memset(&meshHeader, 0, sizeof(meshHeader));
+    VerifyOrQuit(Lowpan::MeshHeader::IsMeshHeader(frame, length), "IsMeshHeader() failed");
+    SuccessOrQuit(meshHeader.ParseFrom(frame, length, headerLength), "MeshHeader::ParseFrom() failed");
+    VerifyOrQuit(headerLength == length, "MeshHeader::ParseFrom() returned length is incorrect");
+    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "MeshHeader::GetSource() failed after ParseFrom()");
+    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "MeshHeader::GetDestination() failed after ParseFrom()");
+    VerifyOrQuit(meshHeader.GetHopsLeft() == 1, "MeshHeader::GetHopsLeft() failed after ParseFrom()");
+
+    VerifyOrQuit(meshHeader.ParseFrom(frame, length - 1, headerLength) == OT_ERROR_PARSE,
+                 "MeshHeader::ParseFrom() did not fail with incorrect length");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    meshHeader.Init(kSourceAddr, kDestAddr, 0x20);
+    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "MeshHeader::GetSource() failed after Init()");
+    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "MeshHeader::GetDestination() failed after Init()");
+    VerifyOrQuit(meshHeader.GetHopsLeft() == 0x20, "MeshHeader::GetHopsLeft() failed after Init()");
+
+    length = meshHeader.WriteTo(frame);
+    VerifyOrQuit(length == sizeof(kMeshHeader2), "MeshHeader::WriteTo() returned length is incorrect");
+    VerifyOrQuit(length == meshHeader.GetHeaderLength(), "MeshHeader::GetHeaderLength() failed");
+    VerifyOrQuit(memcmp(frame, kMeshHeader2, length) == 0, "MeshHeader::WriteTo() failed");
+
+    memset(&meshHeader, 0, sizeof(meshHeader));
+    VerifyOrQuit(Lowpan::MeshHeader::IsMeshHeader(frame, length), "IsMeshHeader() failed");
+    SuccessOrQuit(meshHeader.ParseFrom(frame, length, headerLength), "MeshHeader::ParseFrom() failed");
+    VerifyOrQuit(headerLength == length, "MeshHeader::ParseFrom() returned length is incorrect");
+    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "MeshHeader::GetSource() failed after ParseFrom()");
+    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "MeshHeader::GetDestination() failed after ParseFrom()");
+    VerifyOrQuit(meshHeader.GetHopsLeft() == 0x20, "MeshHeader::GetHopsLeft() failed after ParseFrom()");
+
+    VerifyOrQuit(meshHeader.ParseFrom(frame, length - 1, headerLength) == OT_ERROR_PARSE,
+                 "MeshHeader::ParseFrom() did not fail with incorrect length");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    SuccessOrQuit(meshHeader.ParseFrom(kMeshHeader3, sizeof(kMeshHeader3), headerLength),
+                  "MeshHeader::ParseFrom() failed");
+    VerifyOrQuit(headerLength == sizeof(kMeshHeader3), "MeshHeader::ParseFrom() returned length is incorrect");
+    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "MeshHeader::GetSource() failed after Init()");
+    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "MeshHeader::GetDestination() failed after Init()");
+    VerifyOrQuit(meshHeader.GetHopsLeft() == 1, "MeshHeader::GetHopsLeft() failed after Init()");
+
+    VerifyOrQuit(meshHeader.WriteTo(frame) == sizeof(kMeshHeader1), "MeshHeader::WriteTo() failed");
+
+    VerifyOrQuit(meshHeader.ParseFrom(kMeshHeader3, sizeof(kMeshHeader3) - 1, headerLength) == OT_ERROR_PARSE,
+                 "MeshHeader::ParseFrom() did not fail with incorrect length");
+}
+
+void TestLowpanFragmentHeader(void)
+{
+    enum
+    {
+        kMaxFrameSize = 127,
+        kSize         = 0x7ef,
+        kTag          = 0x1234,
+        kOffset       = (100 * 8),
+    };
+
+    const uint8_t kFragHeader1[] = {0xc7, 0xef, 0x12, 0x34};       // size:0x7ef, tag:0x1234, offset:0 (first frag)
+    const uint8_t kFragHeader2[] = {0xe7, 0xef, 0x12, 0x34, 0x64}; // size:0x7ef, tag:0x1234, offset:100 (next frag)
+    const uint8_t kFragHeader3[] = {0xe7, 0xef, 0x12, 0x34, 0x00}; // size:0x7ef, tag:0x1234, offset:0 (next frag)
+
+    const uint8_t kInvalidFragHeader1[] = {0xe8, 0xef, 0x12, 0x34, 0x64};
+    const uint8_t kInvalidFragHeader2[] = {0xd0, 0xef, 0x12, 0x34, 0x64};
+    const uint8_t kInvalidFragHeader3[] = {0x90, 0xef, 0x12, 0x34, 0x64};
+
+    uint8_t                frame[kMaxFrameSize];
+    uint16_t               length;
+    uint16_t               headerLength;
+    Lowpan::FragmentHeader fragHeader;
+
+    fragHeader.InitFirstFragment(kSize, kTag);
+    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "FragmentHeader::GetDatagramSize() failed after Init");
+    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "FragmentHeader::GetDatagramTag() failed after Init()");
+    VerifyOrQuit(fragHeader.GetDatagramOffset() == 0, "FragmentHeader::GetDatagramOffset() failed after Init()");
+
+    length = fragHeader.WriteTo(frame);
+    VerifyOrQuit(length == Lowpan::FragmentHeader::kFirstFragmentHeaderSize,
+                 "FragmentHeader::WriteTo() returned length is incorrect");
+    VerifyOrQuit(length == sizeof(kFragHeader1), "FragmentHeader::WriteTo() returned length is incorrect");
+    VerifyOrQuit(memcmp(frame, kFragHeader1, length) == 0, "FragmentHeader::WriteTo() failed");
+
+    memset(&fragHeader, 0, sizeof(fragHeader));
+    VerifyOrQuit(Lowpan::FragmentHeader::IsFragmentHeader(frame, length), "IsFragmentHeader() failed");
+    SuccessOrQuit(fragHeader.ParseFrom(frame, length, headerLength), "FragmentHeader::ParseFrom() failed");
+    VerifyOrQuit(headerLength == length, "FragmentHeader::ParseFrom() returned length is incorrect");
+    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "FragmentHeader::GetDatagramSize() failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "FragmentHeader::GetDatagramTag() failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramOffset() == 0, "FragmentHeader::GetDatagramOffset() failed after ParseFrom()");
+
+    VerifyOrQuit(fragHeader.ParseFrom(frame, length - 1, headerLength) == OT_ERROR_PARSE,
+                 "FragmentHeader::ParseFrom() did not fail with incorrect length");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    fragHeader.Init(kSize, kTag, kOffset);
+    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "FragmentHeader::GetDatagramSize() failed after Init");
+    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "FragmentHeader::GetDatagramTag() failed after Init()");
+    VerifyOrQuit(fragHeader.GetDatagramOffset() == kOffset, "FragmentHeader::GetDatagramOffset() failed after Init()");
+
+    // Check the truncation of offset (to be multiple of 8).
+    fragHeader.Init(kSize, kTag, kOffset + 1);
+    VerifyOrQuit(fragHeader.GetDatagramOffset() == kOffset, "FragmentHeader::GetDatagramOffset() did not truncate");
+    fragHeader.Init(kSize, kTag, kOffset + 7);
+    VerifyOrQuit(fragHeader.GetDatagramOffset() == kOffset, "FragmentHeader::GetDatagramOffset() did not truncate");
+
+    length = fragHeader.WriteTo(frame);
+    VerifyOrQuit(length == Lowpan::FragmentHeader::kSubsequentFragmentHeaderSize,
+                 "FragmentHeader::WriteTo() returned length is incorrect");
+    VerifyOrQuit(length == sizeof(kFragHeader2), "FragmentHeader::WriteTo() returned length is incorrect");
+    VerifyOrQuit(memcmp(frame, kFragHeader2, length) == 0, "FragmentHeader::WriteTo() failed");
+
+    memset(&fragHeader, 0, sizeof(fragHeader));
+    VerifyOrQuit(Lowpan::FragmentHeader::IsFragmentHeader(frame, length), "IsFragmentHeader() failed");
+    SuccessOrQuit(fragHeader.ParseFrom(frame, length, headerLength), "FragmentHeader::ParseFrom() failed");
+    VerifyOrQuit(headerLength == length, "FragmentHeader::ParseFrom() returned length is incorrect");
+    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "FragmentHeader::GetDatagramSize() failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "FragmentHeader::GetDatagramTag() failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramOffset() == kOffset,
+                 "FragmentHeader::GetDatagramOffset() failed after ParseFrom()");
+
+    VerifyOrQuit(fragHeader.ParseFrom(frame, length - 1, headerLength) == OT_ERROR_PARSE,
+                 "FragmentHeader::ParseFrom() did not fail with incorrect length");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    length = sizeof(kFragHeader3);
+    memcpy(frame, kFragHeader3, length);
+    SuccessOrQuit(fragHeader.ParseFrom(frame, length, headerLength), "FragmentHeader::ParseFrom() failed");
+    VerifyOrQuit(headerLength == length, "FragmentHeader::ParseFrom() returned length is incorrect");
+    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "FragmentHeader::GetDatagramSize() failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "FragmentHeader::GetDatagramTag() failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramOffset() == 0, "FragmentHeader::GetDatagramOffset() failed after ParseFrom()");
+
+    VerifyOrQuit(fragHeader.ParseFrom(frame, length - 1, headerLength) == OT_ERROR_PARSE,
+                 "FragmentHeader::ParseFrom() did not fail with incorrect length");
+
+    //- - - - - - - - - - - - - - - - - - - - - - - - - -
+
+    length = sizeof(kInvalidFragHeader1);
+    memcpy(frame, kInvalidFragHeader1, length);
+    VerifyOrQuit(!Lowpan::FragmentHeader::IsFragmentHeader(frame, length),
+                 "IsFragmentHeader() did not detect invalid header");
+    VerifyOrQuit(fragHeader.ParseFrom(frame, length, headerLength) != OT_ERROR_NONE,
+                 "FragmentHeader::ParseFrom() did not fail with invalid header");
+
+    length = sizeof(kInvalidFragHeader2);
+    memcpy(frame, kInvalidFragHeader2, length);
+    VerifyOrQuit(!Lowpan::FragmentHeader::IsFragmentHeader(frame, length),
+                 "IsFragmentHeader() did not detect invalid header");
+    VerifyOrQuit(fragHeader.ParseFrom(frame, length, headerLength) != OT_ERROR_NONE,
+                 "FragmentHeader::ParseFrom() did not fail with invalid header");
+
+    length = sizeof(kInvalidFragHeader3);
+    memcpy(frame, kInvalidFragHeader3, length);
+    VerifyOrQuit(!Lowpan::FragmentHeader::IsFragmentHeader(frame, length),
+                 "IsFragmentHeader() did not detect invalid header");
+    VerifyOrQuit(fragHeader.ParseFrom(frame, length, headerLength) != OT_ERROR_NONE,
+                 "FragmentHeader::ParseFrom() did not fail with invalid header");
+}
+
 } // namespace ot
 
 int main(void)
 {
     TestLowpanIphc();
+    TestLowpanMeshHeader();
+    TestLowpanFragmentHeader();
 
     printf("All tests passed\n");
     return 0;


### PR DESCRIPTION
This PR contains a group of related commits changing how `Lowpan::MeshHeader` is parsed and generated and its use in `MeshForwarder`. 

**[lowpan] simplify MeshHeader and its use in MeshForwarder**

This commit updates the `Lowpan::MeshHeader` class to provide methods to parse/write the Mesh Header from/to a given frame or message. The `MeshHeader` no longer provides a direct representation of the header (instead, it contains all fields required to generate the header). This is mainly due to fact the header format itself may vary depending on the "hops left" value. This change also removes the need for the `MeshHeader` to be a packed `OT_TOOL_PACKED` structure.


**[mesh-forwarder] skip mesh header immediately after parsing it**

This commit updates `HandleMesh()` method to skip the mesh header in the frame immediately after parsing it. This in turn removes the need for other methods (`CheckReachability` or `UpdateRoutes()` calling through `GetIp6Header()` to `DecompressIp6Header()`) to redo the parsing to skip the mesh header. With this change we can also remove the now unused `SkipMeshHeader()`.

**[mesh-forwarder] simplify GetForwardFramePriority() and remove GetMeshHeader()**
    
Before passing the frame to `GetForwardFramePriority()` the mesh header is skipped (to avoid re-reading the mesh header). Also the src/dest parameters are renamed to indicate they are mesh source and mesh destination (also the order of parameters changed to start with source and then dest). With this change we can remove `GetMeshHeader()` (since no longer used/needed).

**[unit-test] add unit test for Lowpan::MeshHeader class**

----------

This PR also has few smaller changes in `MeshForwarder`:

- **[mesh-forwarder] use pointer to iterate through mFragmentEntries**
- **[mesh-forwarder] use SuccessOrExit, update comments**