### PR TITLE
[mesh-forwarder] fix incorrect cast to uint8_t when setting frame length

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -913,7 +913,7 @@ otError Frame::AppendHeaderIe(HeaderIe *aIeList, uint8_t aIeCount)
         cur += aIeList[i].GetLength();
     }
 
-    SetPsduLength(GetPsduLength() + static_cast<uint8_t>(cur - base));
+    SetPsduLength(GetPsduLength() + static_cast<uint16_t>(cur - base));
 
 exit:
     return error;

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -796,7 +796,7 @@ start:
 
         // copy IPv6 Payload
         aMessage.Read(aMessage.GetOffset(), payloadLength, payload);
-        aFrame.SetPayloadLength(static_cast<uint8_t>(headerLength + payloadLength));
+        aFrame.SetPayloadLength(headerLength + payloadLength);
 
         nextOffset = aMessage.GetOffset() + payloadLength;
         aMessage.SetOffset(0);
@@ -826,7 +826,7 @@ start:
 
         // Copy IPv6 Payload
         aMessage.Read(aMessage.GetOffset(), payloadLength, payload);
-        aFrame.SetPayloadLength(static_cast<uint8_t>(headerLength + payloadLength));
+        aFrame.SetPayloadLength(headerLength + payloadLength);
 
         nextOffset = aMessage.GetOffset() + payloadLength;
     }

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -330,7 +330,7 @@ void MeshForwarder::SendMesh(Message &aMessage, Mac::TxFrame &aFrame)
     // write payload
     assert(aMessage.GetLength() <= aFrame.GetMaxPayloadLength());
     aMessage.Read(0, aMessage.GetLength(), aFrame.GetPayload());
-    aFrame.SetPayloadLength(static_cast<uint8_t>(aMessage.GetLength()));
+    aFrame.SetPayloadLength(aMessage.GetLength());
 
     mMessageNextOffset = aMessage.GetLength();
 }


### PR DESCRIPTION
----
Background on this: 
Originally the frame length was `uint8_t`, but  PR https://github.com/openthread/openthread/pull/3939 changed the MAC frame length (from `uint8_t` to `uint16_t`) to enable support for different radio MTU sizes. This fix is needed to allow multi radio link support and TREL (from #4440) to use larger MTU sizes.
