### PR TITLE
[efr32] remove SDKVERSION in makefiles to fix SDK v2.7 build

### DIFF
--- a/examples/Makefile-efr32mg12
+++ b/examples/Makefile-efr32mg12
@@ -26,8 +26,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-export SDKVERSION              ?= v2.7
-
 .NOTPARALLEL:
 
 AR                              = arm-none-eabi-ar
@@ -91,12 +89,12 @@ EFR32_MBEDTLS_CPPFLAGS  = -DMBEDTLS_CONFIG_FILE='\"mbedtls-config.h\"'
 EFR32_MBEDTLS_CPPFLAGS += -DMBEDTLS_USER_CONFIG_FILE='\"efr32-mbedtls-config.h\"'
 EFR32_MBEDTLS_CPPFLAGS += -D$(MCU)
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/examples/platforms/efr32mg12/crypto
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/util/third_party/mbedtls/configs
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/platform/CMSIS/Include
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/util/third_party/mbedtls/sl_crypto/include
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/platform/Device/SiliconLabs/EFR32MG12P/Include
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/platform/emlib/inc
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/platform/radio/rail_lib/chip/efr32/efr32xg1x
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.7/util/third_party/mbedtls/configs
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.7/platform/CMSIS/Include
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/include
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.7/platform/Device/SiliconLabs/EFR32MG12P/Include
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.7/platform/emlib/inc
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.7/platform/radio/rail_lib/chip/efr32/efr32xg1x
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include/mbedtls

--- a/examples/Makefile-efr32mg21
+++ b/examples/Makefile-efr32mg21
@@ -26,8 +26,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-export SDKVERSION              ?= v2.7
-
 .NOTPARALLEL:
 
 AR                              = arm-none-eabi-ar
@@ -76,13 +74,13 @@ EFR32_MBEDTLS_CPPFLAGS  = -DMBEDTLS_CONFIG_FILE='\"mbedtls-config.h\"'
 EFR32_MBEDTLS_CPPFLAGS += -DMBEDTLS_USER_CONFIG_FILE='\"efr32-mbedtls-config.h\"'
 EFR32_MBEDTLS_CPPFLAGS += -D$(MCU)
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/examples/platforms/efr32mg21/crypto
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/util/third_party/mbedtls/configs
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/platform/CMSIS/Include
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/util/third_party/mbedtls/sl_crypto/include
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/platform/Device/SiliconLabs/EFR32MG21/Include
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/platform/emlib/inc
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/platform/radio/rail_lib/chip/efr32/efr32xg2x
-EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/hardware/kit/common/drivers
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.7/util/third_party/mbedtls/configs
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.7/platform/CMSIS/Include
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/include
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.7/platform/Device/SiliconLabs/EFR32MG21/Include
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.7/platform/emlib/inc
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.7/platform/radio/rail_lib/chip/efr32/efr32xg2x
+EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suite/v2.7/hardware/kit/common/drivers
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include/mbedtls

--- a/examples/platforms/efr32mg12/Makefile.am
+++ b/examples/platforms/efr32mg12/Makefile.am
@@ -44,7 +44,7 @@ override CXXFLAGS                            := $(filter-out -Wundef,$(CXXFLAGS)
 
 EFR32_BOARD_DIR                               = $(shell echo $(BOARD) | tr A-Z a-z)
 
-EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)
+EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.7
 
 libopenthread_efr32mg12_a_CPPFLAGS                                            = \
     -DPLATFORM_HEADER=\"platform/base/hal/micro/cortexm3/compiler/gcc.h\" \

--- a/examples/platforms/efr32mg12/Makefile.platform.am
+++ b/examples/platforms/efr32mg12/Makefile.platform.am
@@ -40,9 +40,9 @@ fi )
 LDADD_COMMON                                                                  += \
     $(top_builddir)/examples/platforms/efr32mg12/libopenthread-efr32mg12.a       \
     $(top_builddir)/third_party/silabs/libsilabs-efr32mg12-sdk.a                 \
-    $(top_srcdir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/platform/radio/rail_lib/autogen/librail_release/$(LIBRAIL) \
+    $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.7/platform/radio/rail_lib/autogen/librail_release/$(LIBRAIL) \
     $(NULL)
 
 LDFLAGS_COMMON                                                                += \
-    -T $(top_srcdir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/platform/Device/SiliconLabs/EFR32MG12P/Source/GCC/efr32mg12p.ld \
+    -T $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.7/platform/Device/SiliconLabs/EFR32MG12P/Source/GCC/efr32mg12p.ld \
     $(NULL)

--- a/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-ftd/Makefile.am
+++ b/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-ftd/Makefile.am
@@ -33,7 +33,7 @@ override CFLAGS                              := $(filter-out -Wconversion,$(CFLA
 override CXXFLAGS                            := $(filter-out -Wconversion,$(CXXFLAGS))
 
 EFR32_BOARD_DIR                               = $(shell echo $(BOARD) | tr A-Z a-z)
-EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)
+EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.7
 
 $(top_builddir)/examples/platforms/efr32mg12/libopenthread-efr32mg12.a:
 	(cd $(top_builddir)/examples/platforms/efr32mg12/ && $(MAKE) $(AM_MAKEFLAGS) libopenthread-efr32mg12.a )

--- a/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-mtd/Makefile.am
+++ b/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-mtd/Makefile.am
@@ -33,7 +33,7 @@ override CFLAGS                              := $(filter-out -Wconversion,$(CFLA
 override CXXFLAGS                            := $(filter-out -Wconversion,$(CXXFLAGS))
 
 EFR32_BOARD_DIR                               = $(shell echo $(BOARD) | tr A-Z a-z)
-EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)
+EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.7
 
 $(top_builddir)/examples/platforms/efr32mg12/libopenthread-efr32mg12.a:
 	(cd $(top_builddir)/examples/platforms/efr32mg12/ && $(MAKE) $(AM_MAKEFLAGS) libopenthread-efr32mg12.a )

--- a/examples/platforms/efr32mg21/Makefile.am
+++ b/examples/platforms/efr32mg21/Makefile.am
@@ -44,7 +44,7 @@ override CXXFLAGS                            := $(filter-out -Wundef,$(CXXFLAGS)
 
 EFR32_BOARD_DIR                               = $(shell echo $(BOARD) | tr A-Z a-z)
 
-EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)
+EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.7
 
 libopenthread_efr32mg21_a_CPPFLAGS                                            = \
     -DEFR32_SERIES2_CONFIG1_MICRO                                               \

--- a/examples/platforms/efr32mg21/Makefile.platform.am
+++ b/examples/platforms/efr32mg21/Makefile.platform.am
@@ -40,9 +40,9 @@ fi )
 LDADD_COMMON                                                                  += \
     $(top_builddir)/examples/platforms/efr32mg21/libopenthread-efr32mg21.a       \
     $(top_builddir)/third_party/silabs/libsilabs-efr32mg21-sdk.a                 \
-    $(top_srcdir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/platform/radio/rail_lib/autogen/librail_release/$(LIBRAIL) \
+    $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.7/platform/radio/rail_lib/autogen/librail_release/$(LIBRAIL) \
     $(NULL)
 
 LDFLAGS_COMMON                                                                += \
-    -T $(top_srcdir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)/platform/Device/SiliconLabs/EFR32MG21/Source/GCC/efr32mg21.ld \
+    -T $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.7/platform/Device/SiliconLabs/EFR32MG21/Source/GCC/efr32mg21.ld \
     $(NULL)

--- a/examples/platforms/efr32mg21/sleepy-demo/sleepy-demo-ftd/Makefile.am
+++ b/examples/platforms/efr32mg21/sleepy-demo/sleepy-demo-ftd/Makefile.am
@@ -33,7 +33,7 @@ override CFLAGS                              := $(filter-out -Wconversion,$(CFLA
 override CXXFLAGS                            := $(filter-out -Wconversion,$(CXXFLAGS))
 
 EFR32_BOARD_DIR                               = $(shell echo $(BOARD) | tr A-Z a-z)
-EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)
+EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.7
 
 $(top_builddir)/examples/platforms/efr32mg21/libopenthread-efr32mg21.a:
 	(cd $(top_builddir)/examples/platforms/efr32mg21/ && $(MAKE) $(AM_MAKEFLAGS) libopenthread-efr32mg21.a )

--- a/examples/platforms/efr32mg21/sleepy-demo/sleepy-demo-mtd/Makefile.am
+++ b/examples/platforms/efr32mg21/sleepy-demo/sleepy-demo-mtd/Makefile.am
@@ -33,7 +33,7 @@ override CFLAGS                              := $(filter-out -Wconversion,$(CFLA
 override CXXFLAGS                            := $(filter-out -Wconversion,$(CXXFLAGS))
 
 EFR32_BOARD_DIR                               = $(shell echo $(BOARD) | tr A-Z a-z)
-EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)
+EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.7
 
 $(top_builddir)/examples/platforms/efr32mg21/libopenthread-efr32mg21.a:
 	(cd $(top_builddir)/examples/platforms/efr32mg21/ && $(MAKE) $(AM_MAKEFLAGS) libopenthread-efr32mg21.a )

--- a/third_party/silabs/Makefile.am
+++ b/third_party/silabs/Makefile.am
@@ -58,7 +58,7 @@ override CXXFLAGS                            := $(filter-out -Wundef,$(CXXFLAGS)
 
 EFR32_BOARD_DIR                             = $(shell echo $(BOARD) | tr A-Z a-z)
 
-EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/$(SDKVERSION)
+EFR32MG_SDK_SRCDIR                            = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.7
 
 COMMONCPPFLAGS                                                                                = \
     -D__STARTUP_CLEAR_BSS                                                                       \
@@ -107,51 +107,51 @@ SILABS_EFR32MG21_CPPFLAGS                                                       
 
 SILABS_COMMON_SOURCES                                                                         = \
     rail_config/rail_config.c                                                                   \
-    gecko_sdk_suite/$(SDKVERSION)/hardware/kit/common/bsp/bsp_bcc.c                                      \
-    gecko_sdk_suite/$(SDKVERSION)/hardware/kit/common/bsp/bsp_init.c                                     \
-    gecko_sdk_suite/$(SDKVERSION)/hardware/kit/common/bsp/bsp_stk.c                                      \
-    gecko_sdk_suite/$(SDKVERSION)/hardware/kit/common/bsp/bsp_stk_leds.c                                 \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emdrv/dmadrv/src/dmadrv.c                                     \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emdrv/gpiointerrupt/src/gpiointerrupt.c                       \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emdrv/uartdrv/src/uartdrv.c                                   \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emdrv/ustimer/src/ustimer.c                                   \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_adc.c                                            \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_cmu.c                                            \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_core.c                                           \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_crypto.c                                         \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_emu.c                                            \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_gpio.c                                           \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_ldma.c                                           \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_leuart.c                                         \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_msc.c                                            \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_rmu.c                                            \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_rtcc.c                                           \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_system.c                                         \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_timer.c                                          \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_usart.c                                          \
-    gecko_sdk_suite/$(SDKVERSION)/platform/radio/rail_lib/hal/efr32/hal_efr.c                            \
-    gecko_sdk_suite/$(SDKVERSION)/platform/radio/rail_lib/hal/hal_common.c                               \
-    gecko_sdk_suite/$(SDKVERSION)/platform/service/mpu/src/sl_mpu.c                                      \
-    gecko_sdk_suite/$(SDKVERSION)/platform/service/sleeptimer/src/sl_sleeptimer.c                        \
-    gecko_sdk_suite/$(SDKVERSION)/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c               \
-    gecko_sdk_suite/$(SDKVERSION)/util/third_party/mbedtls/library/ecp.c                                 \
-    gecko_sdk_suite/$(SDKVERSION)/util/third_party/mbedtls/sl_crypto/src/crypto_aes.c                    \
-    gecko_sdk_suite/$(SDKVERSION)/util/third_party/mbedtls/sl_crypto/src/crypto_ecp.c                    \
-    gecko_sdk_suite/$(SDKVERSION)/util/third_party/mbedtls/sl_crypto/src/crypto_management.c             \
+    gecko_sdk_suite/v2.7/hardware/kit/common/bsp/bsp_bcc.c                                      \
+    gecko_sdk_suite/v2.7/hardware/kit/common/bsp/bsp_init.c                                     \
+    gecko_sdk_suite/v2.7/hardware/kit/common/bsp/bsp_stk.c                                      \
+    gecko_sdk_suite/v2.7/hardware/kit/common/bsp/bsp_stk_leds.c                                 \
+    gecko_sdk_suite/v2.7/platform/emdrv/dmadrv/src/dmadrv.c                                     \
+    gecko_sdk_suite/v2.7/platform/emdrv/gpiointerrupt/src/gpiointerrupt.c                       \
+    gecko_sdk_suite/v2.7/platform/emdrv/uartdrv/src/uartdrv.c                                   \
+    gecko_sdk_suite/v2.7/platform/emdrv/ustimer/src/ustimer.c                                   \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_adc.c                                            \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_cmu.c                                            \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_core.c                                           \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_crypto.c                                         \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_emu.c                                            \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_gpio.c                                           \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_ldma.c                                           \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_leuart.c                                         \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_msc.c                                            \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_rmu.c                                            \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_rtcc.c                                           \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_system.c                                         \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_timer.c                                          \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_usart.c                                          \
+    gecko_sdk_suite/v2.7/platform/radio/rail_lib/hal/efr32/hal_efr.c                            \
+    gecko_sdk_suite/v2.7/platform/radio/rail_lib/hal/hal_common.c                               \
+    gecko_sdk_suite/v2.7/platform/service/mpu/src/sl_mpu.c                                      \
+    gecko_sdk_suite/v2.7/platform/service/sleeptimer/src/sl_sleeptimer.c                        \
+    gecko_sdk_suite/v2.7/platform/service/sleeptimer/src/sl_sleeptimer_hal_rtcc.c               \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/library/ecp.c                                 \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/crypto_aes.c                    \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/crypto_ecp.c                    \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/crypto_management.c             \
     $(NULL)
 
 SILABS_EFR32MG12_SOURCES                                                                      = \
-    gecko_sdk_suite/$(SDKVERSION)/platform/Device/SiliconLabs/EFR32MG12P/Source/system_efr32mg12p.c      \
-    gecko_sdk_suite/$(SDKVERSION)/platform/Device/SiliconLabs/EFR32MG12P/Source/GCC/startup_efr32mg12p.c \
+    gecko_sdk_suite/v2.7/platform/Device/SiliconLabs/EFR32MG12P/Source/system_efr32mg12p.c      \
+    gecko_sdk_suite/v2.7/platform/Device/SiliconLabs/EFR32MG12P/Source/GCC/startup_efr32mg12p.c \
     $(NULL)
 
 SILABS_EFR32MG21_SOURCES                                                                      = \
-    gecko_sdk_suite/$(SDKVERSION)/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c        \
-    gecko_sdk_suite/$(SDKVERSION)/platform/Device/SiliconLabs/EFR32MG21/Source/GCC/startup_efr32mg21.c   \
-    gecko_sdk_suite/$(SDKVERSION)/platform/emlib/src/em_se.c                                             \
-    gecko_sdk_suite/$(SDKVERSION)/util/third_party/mbedtls/sl_crypto/src/se_trng.c                       \
-    gecko_sdk_suite/$(SDKVERSION)/util/third_party/mbedtls/sl_crypto/src/se_aes.c                        \
-    gecko_sdk_suite/$(SDKVERSION)/util/third_party/mbedtls/sl_crypto/src/se_management.c                 \
+    gecko_sdk_suite/v2.7/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c        \
+    gecko_sdk_suite/v2.7/platform/Device/SiliconLabs/EFR32MG21/Source/GCC/startup_efr32mg21.c   \
+    gecko_sdk_suite/v2.7/platform/emlib/src/em_se.c                                             \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/se_trng.c                       \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/se_aes.c                        \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/se_management.c                 \
     $(NULL)
 
 libsilabs_efr32mg12_sdk_a_CPPFLAGS                                                            = \


### PR DESCRIPTION
Fix for build issue with recent change to using Silicon Labs SDK v2.7.