### PR TITLE
[build] define OPENTHREAD_FTD/MTD/RADIO in posix-app and unit test makefiles

### DIFF
--- a/src/posix/Makefile.am
+++ b/src/posix/Makefile.am
@@ -51,6 +51,9 @@ CPPFLAGS_COMMON                                                        = \
     -I$(top_srcdir)/src/core                                             \
     -I$(top_srcdir)/src/posix/platform                                   \
     -D_GNU_SOURCE                                                        \
+    -DOPENTHREAD_FTD=1                                                   \
+    -DOPENTHREAD_MTD=0                                                   \
+    -DOPENTHREAD_RADIO=0                                                 \
     $(NULL)
 
 LIBTOOLFLAGS_COMMON = --preserve-dup-deps

--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -36,6 +36,9 @@ libopenthread_posix_a_CPPFLAGS            = \
     -I$(top_srcdir)/src/core                \
     -I$(top_srcdir)/src/posix/platform      \
     -D_GNU_SOURCE                           \
+    -DOPENTHREAD_FTD=1                      \
+    -DOPENTHREAD_MTD=0                      \
+    -DOPENTHREAD_RADIO=0                    \
     $(NULL)
 
 libopenthread_posix_a_SOURCES             = \

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -51,6 +51,8 @@ if OPENTHREAD_BUILD_TESTS
 
 AM_CPPFLAGS                                                         = \
     -DOPENTHREAD_FTD=1                                                \
+    -DOPENTHREAD_MTD=0                                                \
+    -DOPENTHREAD_RADIO=0                                              \
     -I$(top_srcdir)/include                                           \
     -I$(top_srcdir)/src                                               \
     -I$(top_srcdir)/src/core                                          \


### PR DESCRIPTION
This helps address undefined config macro warnings.