### PR TITLE
[efr32] Enhancements to radio driver (1/3)

### DIFF
--- a/examples/platforms/efr32mg12/openthread-core-efr32-config.h
+++ b/examples/platforms/efr32mg12/openthread-core-efr32-config.h
@@ -93,7 +93,7 @@
  * Define to 1 if you want to enable software CSMA-CA backoff logic.
  *
  */
-#define OPENTHREAD_CONFIG_SOFTWARE_CSMA_BACKOFF_ENABLE 1
+#define OPENTHREAD_CONFIG_SOFTWARE_CSMA_BACKOFF_ENABLE 0
 
 /**
  * @def OPENTHREAD_CONFIG_SOFTWARE_ENERGY_SCAN_ENABLE
@@ -101,7 +101,7 @@
  * Define to 1 if you want to enable software energy scanning logic.
  *
  */
-#define OPENTHREAD_CONFIG_SOFTWARE_ENERGY_SCAN_ENABLE 1
+#define OPENTHREAD_CONFIG_SOFTWARE_ENERGY_SCAN_ENABLE 0
 
 /**
  * @def SETTINGS_CONFIG_BASE_ADDRESS
@@ -126,22 +126,6 @@
  *
  */
 #define SETTINGS_CONFIG_PAGE_NUM 4
-
-/**
- * @def RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM
- *
- * The number of short source address table entries.
- *
- */
-#define RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM 6
-
-/**
- * @def RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM
- *
- * The number of extended source address table entries.
- *
- */
-#define RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM 6
 
 /**
  * @def OPENTHREAD_CONFIG_NCP_UART_ENABLE

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -608,6 +608,7 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
 #endif
         sTransmitError = OT_ERROR_CHANNEL_ACCESS_FAILURE;
         sTransmitBusy  = false;
+        otSysEventSignalPending();
     }
 
 exit:

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -398,11 +398,8 @@ void otPlatRadioSetPanId(otInstance *aInstance, uint16_t aPanId)
 
     utilsSoftSrcMatchSetPanId(aPanId);
 
-    for (uint8_t i = 0; i < EFR32_NUM_BAND_CONFIGS; i++)
-    {
-        status = RAIL_IEEE802154_SetPanId(gRailHandle, aPanId, 0);
-        assert(status == RAIL_STATUS_NO_ERROR);
-    }
+    status = RAIL_IEEE802154_SetPanId(gRailHandle, aPanId, 0);
+    assert(status == RAIL_STATUS_NO_ERROR);
 }
 
 void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aAddress)
@@ -414,11 +411,8 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aA
     otLogInfoPlat("ExtAddr=%X%X%X%X%X%X%X%X", aAddress->m8[7], aAddress->m8[6], aAddress->m8[5], aAddress->m8[4],
                   aAddress->m8[3], aAddress->m8[2], aAddress->m8[1], aAddress->m8[0]);
 
-    for (uint8_t i = 0; i < EFR32_NUM_BAND_CONFIGS; i++)
-    {
-        status = RAIL_IEEE802154_SetLongAddress(gRailHandle, (uint8_t *)aAddress->m8, 0);
-        assert(status == RAIL_STATUS_NO_ERROR);
-    }
+    status = RAIL_IEEE802154_SetLongAddress(gRailHandle, (uint8_t *)aAddress->m8, 0);
+    assert(status == RAIL_STATUS_NO_ERROR);
 }
 
 void otPlatRadioSetShortAddress(otInstance *aInstance, uint16_t aAddress)
@@ -429,11 +423,8 @@ void otPlatRadioSetShortAddress(otInstance *aInstance, uint16_t aAddress)
 
     otLogInfoPlat("ShortAddr=%X", aAddress);
 
-    for (uint8_t i = 0; i < EFR32_NUM_BAND_CONFIGS; i++)
-    {
-        status = RAIL_IEEE802154_SetShortAddress(gRailHandle, aAddress, 0);
-        assert(status == RAIL_STATUS_NO_ERROR);
-    }
+    status = RAIL_IEEE802154_SetShortAddress(gRailHandle, aAddress, 0);
+    assert(status == RAIL_STATUS_NO_ERROR);
 }
 
 bool otPlatRadioIsEnabled(otInstance *aInstance)
@@ -670,11 +661,8 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable)
 
     sPromiscuous = aEnable;
 
-    for (uint8_t i = 0; i < EFR32_NUM_BAND_CONFIGS; i++)
-    {
-        status = RAIL_IEEE802154_SetPromiscuousMode(gRailHandle, aEnable);
-        assert(status == RAIL_STATUS_NO_ERROR);
-    }
+    status = RAIL_IEEE802154_SetPromiscuousMode(gRailHandle, aEnable);
+    assert(status == RAIL_STATUS_NO_ERROR);
 }
 
 void otPlatRadioEnableSrcMatch(otInstance *aInstance, bool aEnable)

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -748,9 +748,12 @@ static void processNextRxPacket(otInstance *aInstance)
         sReceiveFrame.mInfo.mRxInfo.mRssi = packetDetails.rssi;
         sReceiveFrame.mInfo.mRxInfo.mLqi  = packetDetails.lqi;
 
-        // TODO: grab timestamp and handle conversion to msec/usec and RAIL_GetRxTimeSyncWordEndAlt
-        // sReceiveFrame.mInfo.mRxInfo.mMsec = packetDetails.packetTime;
-        // sReceiveFrame.mInfo.mRxInfo.mUsec = packetDetails.packetTime;
+        // Get the timestamp when the SFD was received
+        assert(packetDetails.timeReceived.timePosition != RAIL_PACKET_TIME_INVALID);
+        packetDetails.timeReceived.totalPacketBytes = length + 1;
+        status = RAIL_GetRxTimeSyncWordEndAlt(gRailHandle, &packetDetails);
+        assert(status == RAIL_STATUS_NO_ERROR);
+        sReceiveFrame.mInfo.mRxInfo.mTimestamp = packetDetails.timeReceived.packetTime;
 
         // TODO Set this flag only when the packet is really acknowledged with frame pending set.
         // See https://github.com/openthread/openthread/pull/3785
@@ -826,6 +829,7 @@ static void RAILCb_Generic(RAIL_Handle_t aRailHandle, RAIL_Events_t aEvents)
     {
         ieee802154DataRequestCommand(aRailHandle);
     }
+
     if (aEvents & RAIL_EVENTS_TX_COMPLETION)
     {
         if (aEvents & RAIL_EVENT_TX_PACKET_SENT)

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -739,7 +739,9 @@ static void processNextRxPacket(otInstance *aInstance)
     }
     else
     {
-        otEXPECT(length != IEEE802154_ACK_LENGTH);
+        // signal MAC layer for each received frame if promiscous is enabled
+        // otherwise only signal MAC layer for non-ACK frame
+        otEXPECT(sPromiscuous || (length != IEEE802154_ACK_LENGTH));
 
         sReceiveError = OT_ERROR_NONE;
 
@@ -763,16 +765,11 @@ static void processNextRxPacket(otInstance *aInstance)
         else
 #endif
         {
-            // signal MAC layer for each received frame if promiscous is enabled
-            // otherwise only signal MAC layer for non-ACK frame
-            if (sPromiscuous || sReceiveFrame.mLength > IEEE802154_ACK_LENGTH)
-            {
-                otLogInfoPlat("Received %d bytes", sReceiveFrame.mLength);
-                otPlatRadioReceiveDone(aInstance, &sReceiveFrame, sReceiveError);
+            otLogInfoPlat("Received %d bytes", sReceiveFrame.mLength);
+            otPlatRadioReceiveDone(aInstance, &sReceiveFrame, sReceiveError);
 #if RADIO_CONFIG_DEBUG_COUNTERS_SUPPORT
-                sRailDebugCounters.mRailPlatRadioReceiveDoneCbCount++;
+            sRailDebugCounters.mRailPlatRadioReceiveDoneCbCount++;
 #endif
-            }
         }
     }
 

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -698,11 +698,11 @@ static void processNextRxPacket(otInstance *aInstance)
 
     length = packetInfo.packetBytes + 1;
 
-    // check the length in recv packet info structure
-    otEXPECT(length == packetInfo.firstPortionData[0]);
+    // check the length in recv packet info structure; RAIL should take care of this.
+    assert(length == packetInfo.firstPortionData[0]);
 
-    // check the length validity of recv packet
-    otEXPECT(length >= IEEE802154_MIN_LENGTH && length <= IEEE802154_MAX_LENGTH);
+    // check the length validity of recv packet; RAIL should take care of this.
+    assert(length >= IEEE802154_MIN_LENGTH && length <= IEEE802154_MAX_LENGTH);
 
     otLogInfoPlat("Received data:%d", length);
 

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -140,7 +140,7 @@ static const RAIL_IEEE802154_Config_t sRailIeee802154Config = {
     .ackConfig =
         {
             .enable     = true,
-            .ackTimeout = 894,
+            .ackTimeout = 864,
             .rxTransitions =
                 {
                     .success = RAIL_RF_STATE_RX,


### PR DESCRIPTION
This is the first of 3 PR addressing the efr32mg12 radio driver.

PR# 1: 
- Features:
   * 18b70b2 Implemented get/set CcaEnergyDetectThreshold.

- Sniffer mode fix:
   * 981ee39 Implemented RX timestamping (at the SFD reception).
   * 21f442a Handled promiscuous mode for ACK packets (ACK packets were discarded for sniffer mode).

- Misc bug corrections:
   * 1042eda Corrected macAckWaitDuration (from 894us to 864us; it was a typo).
   * 18b70b2 Honor mMaxCsmaBackoffs.
   * f4dbf62 Signalled event pending when failed to start TX (event pending was not signalled for this case, even if TX operation was actually finished).

- Minor enhancements
   * 1027145 Removed duplicate calls of RAIL functions which were called once per band, and did not need to (the call was exactly the same for all bands).
   * f2e2755 Correct hardware capabilities.
   * f2e2755 Correct soft source match table size.
   * f9c65d0 Used assert instead of otEXPECT to detect issues when interacting with RAIL.

@andrasbiro-silabs please review.

Thanks