### PR TITLE
[efr32] Enhancements to radio driver (2/3)

### DIFF
--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -805,9 +805,7 @@ static void processNextRxPacket(otInstance *aInstance)
     packetInfo.packetBytes--;
 
     // read packet
-    memcpy(sReceiveFrame.mPsdu, packetInfo.firstPortionData, packetInfo.firstPortionBytes);
-    memcpy(sReceiveFrame.mPsdu + packetInfo.firstPortionBytes, packetInfo.lastPortionData,
-           packetInfo.packetBytes - packetInfo.firstPortionBytes);
+    RAIL_CopyRxPacket(sReceiveFrame.mPsdu, &packetInfo);
 
     status = RAIL_ReleaseRxPacket(gRailHandle, packetHandle);
     if (status == RAIL_STATUS_NO_ERROR)


### PR DESCRIPTION
This is the second of 3 PRs addressing the efr32mg12 radio driver.

PR# 2: Implements correctly setting `mAckedWithFramePending` (See #4358).

**The idea is the following:** when receiving an IEEE802.15.4 Data Request Command, RAIL generates an event and calls `RAILCb_Generic` as early as possible (even before the packet is fully received; i.e. the CRC could be still wrong), from interrupt context.

In `RAILCb_Generic`, the driver calls `ieee802154DataRequestCommand`, which in turn decides whether to set the Frame Pending flag for the outgoing ACK, by analysing the soft source match table. If the Frame Pending flag is set, we have to report `mAckedWithFramePending = true` when we pass the Data Request Command packet to the upper layers.

Since the Data Request Command packet is held in the callback and passed to the upper layers in `processNextRxPacket`, and the Parent can receive multiple Data Request Commands from different children back-to-back before calling `processNextRxPacket`, one cannot simply set a flag in the callback to signal `processNextRxPacket` that the Data Request Command was acked with Frame Pending.

The proposed solution is to insert a "unique identifier" of the Data Request Command packet into a FIFO when the ACK was sent with the Frame Pending flag is set. Then, for each Data Request Command packet that `processNextRxPacket` will pass to the upper layer, it will pop the "unique identifiers" from the FIFO searching for a match. If the identifier is found, `mAckedWithFramePending` will be set to `true`.

The "unique identifier" is actually the contents of the packet being received (PHR + MAC Header), because the `RAIL_GetRxIncomingPacketInfo` does not return a `RAIL_RxPacketHandle_t`.

When `processNextRxPacket` pops a unique identifier from the FIFO:
- It pops the Data Request Command packets in sync with the RAIL RX FIFO, so that the packets are correctly matched.
- It discards the packets which could be inserted to the FIFO without passing the CRC check.

The FIFO size is set to 16 entries, which should be the maximum that RAIL can hold in its internal metadata FIFO (see https://docs.silabs.com/rail/latest/efr32-main).

Note: I think this method (with some modifications) could be compatible with the Thread 1.2 Enhanced Frame Pending feature.

Without this PR (empty data packets):
![image](https://user-images.githubusercontent.com/17166563/72649213-cf3e5f80-395b-11ea-85d4-1d6ee4f13dad.png)

With this PR (no empty data packets):
![image](https://user-images.githubusercontent.com/17166563/72649252-eaa96a80-395b-11ea-997f-69eb79f01c5e.png)

@andrasbiro-silabs please review. If you have a better idea on how to uniquely identify the packets, please let me know; you are the RAIL expert.

Thanks!