### PR TITLE
[network-data] remove stale network data with best efforts

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -79,6 +79,24 @@ void CoapBase::ClearRequestsAndResponses(void)
     mResponsesQueue.DequeueAllResponses();
 }
 
+void CoapBase::ClearRequests(const Ip6::Address &aAddress)
+{
+    Message *nextMessage;
+
+    // Remove pending messages with the specified source.
+    for (Message *message = static_cast<Message *>(mPendingRequests.GetHead()); message != NULL; message = nextMessage)
+    {
+        CoapMetadata coapMetadata;
+        nextMessage = static_cast<Message *>(message->GetNext());
+        coapMetadata.ReadFrom(*message);
+
+        if (coapMetadata.mSourceAddress == aAddress)
+        {
+            FinalizeCoapTransaction(*message, coapMetadata, NULL, NULL, OT_ERROR_ABORT);
+        }
+    }
+}
+
 otError CoapBase::AddResource(Resource &aResource)
 {
     return mResources.Add(aResource);

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -429,6 +429,14 @@ public:
     void ClearRequestsAndResponses(void);
 
     /**
+     * This method clears requests with specified source address used by this CoAP agent.
+     *
+     * @param[in]  aAddress A reference to the specified address.
+     *
+     */
+    void ClearRequests(const Ip6::Address &aAddress);
+
+    /**
      * This method adds a resource to the CoAP server.
      *
      * @param[in]  aResource  A reference to the resource.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -969,6 +969,12 @@ void Mle::SetRloc16(uint16_t aRloc16)
     if (aRloc16 != oldRloc16)
     {
         otLogNoteMle("RLOC16 %04x -> %04x", oldRloc16, aRloc16);
+
+        // Clear cached CoAP with old RLOC source
+        if (oldRloc16 != Mac::kShortAddrInvalid)
+        {
+            Get<Coap::Coap>().ClearRequests(mMeshLocal16.GetAddress());
+        }
     }
 
     Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal16);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3821,6 +3821,11 @@ otError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, I
         {
             ExitNow();
         }
+        else if (IsAnycastLocator(aIp6Header.GetDestination()))
+        {
+            // Proactively notify Leader of the expired child to de-register the stale service if any.
+            Get<NetworkData::Leader>().SendServerDataNotification(aMeshDest);
+        }
     }
     else if (GetNextHop(aMeshDest) != Mac::kShortAddrInvalid)
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2606,6 +2606,24 @@ void MleRouter::HandleNetworkDataUpdateRouter(void)
 
     SynchronizeChildNetworkData();
 
+    // Detect if any server entry with invalid child RLOC16
+    {
+        NetworkData::Iterator iterator = NetworkData::kIteratorInit;
+        uint16_t              rloc16   = Mac::kShortAddrInvalid;
+
+        while (Get<NetworkData::Leader>().GetNextServer(iterator, rloc16) == OT_ERROR_NONE)
+        {
+            if (!IsActiveRouter(rloc16) && RouterIdMatch(GetRloc16(), rloc16) &&
+                mChildTable.FindChild(rloc16, Child::kInStateValid) == NULL)
+            {
+                Get<NetworkData::Leader>().SendServerDataNotification(rloc16);
+                // In Thread 1.1 Specification 5.15.6.1, only one RLOC16 TLV entry may appear in SRV_DATA.ntf.
+                // So break here.
+                break;
+            }
+        }
+    }
+
 exit:
     return;
 }

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -977,8 +977,16 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16)
     Coap::Message *  message = NULL;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit(mLastAttempt.GetValue() == 0 || ((TimerMilli::GetNow() - mLastAttempt) > kDataResubmitDelay),
-                 error = OT_ERROR_ALREADY);
+    if (mLastAttempt.GetValue() != 0)
+    {
+        uint32_t diff = TimerMilli::GetNow() - mLastAttempt;
+
+        if (((mType == kTypeLocal) && (diff > kDataResubmitDelay)) ||
+            ((mType == kTypeLeader) && (diff > kProxyResubmitDelay)))
+        {
+            ExitNow(error = OT_ERROR_ALREADY);
+        }
+    }
 
     VerifyOrExit((message = Get<Coap::Coap>().NewMessage()) != NULL, error = OT_ERROR_NO_BUFS);
 
@@ -1007,16 +1015,13 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16)
     messageInfo.SetPeerPort(kCoapUdpPort);
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, messageInfo));
 
-    if (mType == kTypeLocal)
-    {
-        mLastAttempt = TimerMilli::GetNow();
+    mLastAttempt = TimerMilli::GetNow();
 
-        // `0` is a special value to indicate no delay limitation on sending SRV_DATA.ntf.
-        // Here avoids possible impact in rate limitation of SRV_DATA.ntf in case of wrap.
-        if (mLastAttempt.GetValue() == 0)
-        {
-            mLastAttempt.SetValue(1);
-        }
+    // `0` is a special value to indicate no delay limitation on sending SRV_DATA.ntf.
+    // Here avoids possible impact in rate limitation of SRV_DATA.ntf in case of wrap.
+    if (mLastAttempt.GetValue() == 0)
+    {
+        mLastAttempt.SetValue(1);
     }
 
     otLogInfoNetData("Sent server data notification");

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -977,7 +977,7 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16)
     Coap::Message *  message = NULL;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit(mLastAttempt.GetValue() == 0 || ((TimerMilli::GetNow() - mLastAttempt) < kDataResubmitDelay),
+    VerifyOrExit(mLastAttempt.GetValue() == 0 || ((TimerMilli::GetNow() - mLastAttempt) > kDataResubmitDelay),
                  error = OT_ERROR_ALREADY);
 
     VerifyOrExit((message = Get<Coap::Coap>().NewMessage()) != NULL, error = OT_ERROR_NO_BUFS);

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -1036,6 +1036,110 @@ exit:
     return error;
 }
 
+otError NetworkData::GetNextServer(Iterator &aIterator, uint16_t &aRloc16)
+{
+    otError             error = OT_ERROR_NOT_FOUND;
+    NetworkDataIterator iterator(aIterator);
+    NetworkDataTlv *    cur = reinterpret_cast<NetworkDataTlv *>(mTlvs + iterator.GetTlvOffset());
+    NetworkDataTlv *    end = reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength);
+
+    for (; cur < end; cur = cur->GetNext(), iterator.SetSubTlvOffset(0), iterator.SetEntryIndex(0))
+    {
+        NetworkDataTlv *subCur;
+        NetworkDataTlv *subEnd;
+
+        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, error = OT_ERROR_PARSE);
+
+        switch (cur->GetType())
+        {
+        case NetworkDataTlv::kTypePrefix:
+        {
+            PrefixTlv *prefix = static_cast<PrefixTlv *>(cur);
+            subCur            = reinterpret_cast<NetworkDataTlv *>(reinterpret_cast<uint8_t *>(prefix->GetSubTlvs()) +
+                                                        iterator.GetSubTlvOffset());
+            subEnd            = cur->GetNext();
+
+            for (; subCur < subEnd; subCur = subCur->GetNext(), iterator.SetEntryIndex(0))
+            {
+                VerifyOrExit((subCur + 1) <= subEnd && subCur->GetNext() <= subEnd, error = OT_ERROR_PARSE);
+
+                if (subCur->GetType() == NetworkDataTlv::kTypeBorderRouter)
+                {
+                    BorderRouterTlv *borderRouter = static_cast<BorderRouterTlv *>(subCur);
+                    uint8_t          index        = iterator.GetEntryIndex();
+
+                    if (index < borderRouter->GetNumEntries())
+                    {
+                        aRloc16 = borderRouter->GetEntry(index)->GetRloc();
+
+                        iterator.SaveTlvOffset(cur, mTlvs);
+                        iterator.SaveSubTlvOffset(subCur, prefix->GetSubTlvs());
+                        iterator.SetEntryIndex(index + 1);
+
+                        ExitNow(error = OT_ERROR_NONE);
+                    }
+                }
+                else if (subCur->GetType() == NetworkDataTlv::kTypeHasRoute)
+                {
+                    HasRouteTlv *hasRoute = static_cast<HasRouteTlv *>(subCur);
+                    uint8_t      index    = iterator.GetEntryIndex();
+
+                    if (index < hasRoute->GetNumEntries())
+                    {
+                        aRloc16 = hasRoute->GetEntry(index)->GetRloc();
+
+                        iterator.SaveTlvOffset(cur, mTlvs);
+                        iterator.SaveSubTlvOffset(subCur, prefix->GetSubTlvs());
+                        iterator.SetEntryIndex(index + 1);
+
+                        ExitNow(error = OT_ERROR_NONE);
+                    }
+                }
+            }
+
+            break;
+        }
+        case NetworkDataTlv::kTypeService:
+        {
+            ServiceTlv *service = static_cast<ServiceTlv *>(cur);
+            subCur = reinterpret_cast<NetworkDataTlv *>(reinterpret_cast<uint8_t *>(service->GetSubTlvs()) +
+                                                        iterator.GetSubTlvOffset());
+            subEnd = cur->GetNext();
+
+            for (; subCur < subEnd; subCur = subCur->GetNext())
+            {
+                VerifyOrExit((subCur + 1) <= subEnd && subCur->GetNext() <= subEnd, error = OT_ERROR_PARSE);
+
+                if (subCur->GetType() == NetworkDataTlv::kTypeServer)
+                {
+                    ServerTlv *server = static_cast<ServerTlv *>(subCur);
+                    aRloc16           = server->GetServer16();
+
+                    if (subCur->GetNext() >= cur->GetNext())
+                    {
+                        iterator.SaveTlvOffset(cur->GetNext(), mTlvs);
+                        iterator.SetSubTlvOffset(0);
+                    }
+                    else
+                    {
+                        iterator.SaveTlvOffset(cur, mTlvs);
+                        iterator.SaveSubTlvOffset(subCur->GetNext(), service->GetSubTlvs());
+                    }
+
+                    ExitNow(error = OT_ERROR_NONE);
+                }
+            }
+            break;
+        }
+        default:
+            break;
+        }
+    }
+
+exit:
+    return error;
+}
+
 void NetworkData::ClearResubmitDelayTimer(void)
 {
     mLastAttempt.SetValue(0);

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -496,7 +496,9 @@ protected:
 private:
     enum
     {
-        kDataResubmitDelay = 300000, ///< DATA_RESUBMIT_DELAY (milliseconds)
+        kDataResubmitDelay  = 300000, ///< DATA_RESUBMIT_DELAY (milliseconds) if the device itself is the server.
+        kProxyResubmitDelay = 5000,   ///< Resubmit delay (milliseconds) if deregister as the child server proxy.
+
     };
 
     class NetworkDataIterator

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -305,6 +305,18 @@ public:
     bool ContainsService(uint8_t aServiceId, uint16_t aRloc16);
 
     /**
+     * This method provides the next server RLOC16 in the Thread Network Data.
+     *
+     * @param[inout]  aIterator  A reference to the Network Data iterator.
+     * @param[out]    aRloc16    The RLOC16 value.
+     *
+     * @retval OT_ERROR_NONE       Successfully found the next server.
+     * @retval OT_ERROR_NOT_FOUND  No subsequent server exists in the Thread Network Data.
+     *
+     */
+    otError GetNextServer(Iterator &aIterator, uint16_t &aRloc16);
+
+    /**
      * This method cancels the data resubmit delay timer.
      *
      */

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -537,7 +537,6 @@ private:
     };
 
     const Type mType;
-    bool       mLastAttemptWait;
     TimeMilli  mLastAttempt;
 };
 

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -344,8 +344,6 @@ void Local::UpdateRloc(void)
             break;
         }
     }
-
-    ClearResubmitDelayTimer();
 }
 
 otError Local::SendServerDataNotification(void)

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -383,7 +383,12 @@ exit:
 const Router *RouterTable::GetRouter(uint8_t aRouterId) const
 {
     const Router *router = NULL;
-    uint16_t      rloc16 = Mle::Mle::Rloc16FromRouterId(aRouterId);
+    uint16_t      rloc16;
+
+    // Skip if invalid router id is passed.
+    VerifyOrExit(aRouterId < Mle::kInvalidRouterId);
+
+    rloc16 = Mle::Mle::Rloc16FromRouterId(aRouterId);
 
     for (router = GetFirstEntry(); router != NULL; router = GetNextEntry(router))
     {
@@ -393,6 +398,7 @@ const Router *RouterTable::GetRouter(uint8_t aRouterId) const
         }
     }
 
+exit:
     return router;
 }
 


### PR DESCRIPTION
Rebase and refine previous updates, also introduce network data check for invalid child entry when network data changes according to feedbacks.

See per commit message below for details.

commit1

    [core] clear cached coap requests with rloc source when rloc changes

    This commit helps to reduce unnecessary CoAP retransmission when rloc
    changes. When comes to SRV_DATA.ntf, it also helps to avoid invalid
    network data registration. Take the issue reported in #4472 as example,
    in a Thread Network with packet loss, the child server may switch parents
    frequently, there might be cached SRV_DATA.ntf including old rloc16,
    both the cached one and new one might be sent after switched, causing
    Leader contain two server entries in the Network Data.

commit2

    [network_data] reuse `mLastAttempt` for the function of `mLastAttemptWait`

    This enhancement is based on that `mLastAttempt` with value `0` is
    equivalent to `mLastAttemptWait` with value `false`

commit3

    [network_data] remove `ClearResubmitDelayTimer()` in `UpdateRloc()`

    `UpdateRloc()`, which happens before checking network data consistence,
    should not `ClearResubmitDelayTimer()` to guarantee the DATA_RESUBMIT_DELAY
    before resending when there is inconsistence.

commit4

    [network_data] fix to ensure DATA_RESUBMIT_DELAY between successive SRV_DATA.ntf for server

commit5

    [network_data] introduce 5s delay between successive SRV_DATA.ntf when deregister on behalf of the child server

commit6

    [network-data] deregister for invalid child server if any when receiving new network data

commit7

    [network-data] deregister stale network data when receiving packet destined to ALOC.

    This commit assists the previous commit to help to remove invalid
    server entry in some extreme scenario, for example if child server
    switches parent in a Thread Network with packet loss, and
      a) SRV_DATA.ntf from the old parent to deregister fails
      b) the first attempt of SRV_DATA.ntf from the child fails
    When the child tries to resend SRV_DATA.ntf due to network data inconsistence,
    there will be no old rloc16, that is, the network data may have invalid server entry.

    Though previous commit introduces the invalid child server detection when there is
    new network data, however if the deregister there fails and there is no new
    network data further, there is chance there invalid server entry would
    stick there.
    Here provides one invalid child server detection and recover mechanism
    according to the ALOC destined traffic.

commit8

    [service] fix the minimum cost server selection

commit9

    [router_table] exit earlier when `GetRouter()` for invalid router id

---
> [outdated]
> This PR aims to resolve issues in high packet loss network reported in #4472 
> 
> On one hand, this PR aims to reduce invalid SRV_DATA.ntf, for example
> First commit is used to clear cached CoAP message when RLOC changes in case before successfully register SRV_DATA, the child server switches to a different parent.
> Second commit ensures the SRV_DATA.ntf intervals when detecting network data inconsistence after hearing neighboring MLE Advertisement
> 
> On the other hand, this PR aims to remove stale network data. In the high packet loss network, there is chance that both SRV_DATA.ntf from the server child after switching parent and the SRV_DATA.ntf from old parent for deregister and lost, when the child tries to register again (without old child rloc16 now), the old child rloc16 server entry would be still there. This PR introduce a feedback mechanism - the parent
> of the old child rloc16 would explicitly deregister the service again if destination unreachable when receiving ALOC destined packet.
> However as to how long would it take to recover fresh network data, it may depend on Service Aloc destined traffic. 