### PR TITLE
[mle] misc - log msg change, static method renames

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -315,7 +315,7 @@ otError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
 
     aParentInfo->mExtAddress     = parent->GetExtAddress();
     aParentInfo->mRloc16         = parent->GetRloc16();
-    aParentInfo->mRouterId       = Mle::Mle::GetRouterId(parent->GetRloc16());
+    aParentInfo->mRouterId       = Mle::Mle::RouterIdFromRloc16(parent->GetRloc16());
     aParentInfo->mNextHop        = parent->GetNextHop();
     aParentInfo->mPathCost       = parent->GetCost();
     aParentInfo->mLinkQualityIn  = parent->GetLinkInfo().GetLinkQuality();

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -167,7 +167,7 @@ void AddressResolver::MarkCacheEntryAsUsed(Cache &aEntry)
     aEntry.mAge = 0;
 }
 
-const char *AddressResolver::ConvertInvalidationReasonToString(InvalidationReason aReason)
+const char *AddressResolver::InvalidationReasonToString(InvalidationReason aReason)
 {
     const char *str = "";
 
@@ -213,13 +213,13 @@ void AddressResolver::InvalidateCacheEntry(Cache &aEntry, InvalidationReason aRe
     {
     case Cache::kStateCached:
         otLogNoteArp("Cache entry removed: %s, 0x%04x - %s", aEntry.mTarget.ToString().AsCString(), aEntry.mRloc16,
-                     ConvertInvalidationReasonToString(aReason));
+                     InvalidationReasonToString(aReason));
         break;
 
     case Cache::kStateQuery:
         otLogNoteArp("Cache entry (query mode) removed: %s, timeout:%d, retry:%d - %s",
                      aEntry.mTarget.ToString().AsCString(), aEntry.mTimeout, aEntry.mRetryTimeout,
-                     ConvertInvalidationReasonToString(aReason));
+                     InvalidationReasonToString(aReason));
         break;
 
     default:

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -97,7 +97,7 @@ void AddressResolver::Remove(uint8_t aRouterId)
 {
     for (int i = 0; i < kCacheEntries; i++)
     {
-        if (Mle::Mle::GetRouterId(mCache[i].mRloc16) == aRouterId)
+        if (Mle::Mle::RouterIdFromRloc16(mCache[i].mRloc16) == aRouterId)
         {
             InvalidateCacheEntry(mCache[i], kReasonRemovingRouterId);
         }

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -208,7 +208,7 @@ private:
         kReasonRemovingEid,
     };
 
-    static const char *ConvertInvalidationReasonToString(InvalidationReason aReason);
+    static const char *InvalidationReasonToString(InvalidationReason aReason);
 
     Cache *NewCacheEntry(void);
     void   MarkCacheEntryAsUsed(Cache &aEntry);

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -658,12 +658,12 @@ start:
 
             if (hopsLeft != Mle::kMaxRouteCost)
             {
-                hopsLeft += mle.GetLinkCost(Mle::Mle::GetRouterId(mle.GetNextHop(aMeshDest)));
+                hopsLeft += mle.GetLinkCost(Mle::Mle::RouterIdFromRloc16(mle.GetNextHop(aMeshDest)));
             }
             else
             {
                 // In case there is no route to the destination router (only link).
-                hopsLeft = mle.GetLinkCost(Mle::Mle::GetRouterId(aMeshDest));
+                hopsLeft = mle.GetLinkCost(Mle::Mle::RouterIdFromRloc16(aMeshDest));
             }
         }
 

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -389,7 +389,7 @@ otError MeshForwarder::UpdateIp6RouteFtd(Ip6::Header &ip6Header)
 
         if (aloc16 == Mle::kAloc16Leader)
         {
-            mMeshDest = Mle::Mle::GetRloc16(mle.GetLeaderId());
+            mMeshDest = Mle::Mle::Rloc16FromRouterId(mle.GetLeaderId());
         }
         else if ((aloc16 >= Mle::kAloc16CommissionerStart) && (aloc16 <= Mle::kAloc16CommissionerEnd))
         {
@@ -406,14 +406,14 @@ otError MeshForwarder::UpdateIp6RouteFtd(Ip6::Header &ip6Header)
             routerId = Mle::Mle::GetRouterId(agentRloc16);
 
             // if agent is active router or the child of the device
-            if ((Mle::Mle::IsActiveRouter(agentRloc16)) || (Mle::Mle::GetRloc16(routerId) == mle.GetRloc16()))
+            if ((Mle::Mle::IsActiveRouter(agentRloc16)) || (Mle::Mle::Rloc16FromRouterId(routerId) == mle.GetRloc16()))
             {
                 mMeshDest = agentRloc16;
             }
             else
             {
                 // use the parent of the ED Agent as Dest
-                mMeshDest = Mle::Mle::GetRloc16(routerId);
+                mMeshDest = Mle::Mle::Rloc16FromRouterId(routerId);
             }
         }
         else if ((aloc16 >= Mle::kAloc16ServiceStart) && (aloc16 <= Mle::kAloc16ServiceEnd))

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -380,7 +380,7 @@ otError MeshForwarder::UpdateIp6RouteFtd(Ip6::Header &ip6Header)
     if (mle.IsRoutingLocator(ip6Header.GetDestination()))
     {
         uint16_t rloc16 = HostSwap16(ip6Header.GetDestination().mFields.m16[7]);
-        VerifyOrExit(mle.IsRouterIdValid(mle.GetRouterId(rloc16)), error = OT_ERROR_DROP);
+        VerifyOrExit(mle.IsRouterIdValid(Mle::Mle::RouterIdFromRloc16(rloc16)), error = OT_ERROR_DROP);
         mMeshDest = rloc16;
     }
     else if (mle.IsAnycastLocator(ip6Header.GetDestination()))
@@ -403,7 +403,7 @@ otError MeshForwarder::UpdateIp6RouteFtd(Ip6::Header &ip6Header)
                               static_cast<uint8_t>(aloc16 & Mle::kAloc16DhcpAgentMask), agentRloc16) == OT_ERROR_NONE),
                          error = OT_ERROR_DROP);
 
-            routerId = Mle::Mle::GetRouterId(agentRloc16);
+            routerId = Mle::Mle::RouterIdFromRloc16(agentRloc16);
 
             // if agent is active router or the child of the device
             if ((Mle::Mle::IsActiveRouter(agentRloc16)) || (Mle::Mle::Rloc16FromRouterId(routerId) == mle.GetRloc16()))
@@ -614,7 +614,8 @@ void MeshForwarder::UpdateRoutes(uint8_t *           aFrame,
     neighbor = Get<Mle::MleRouter>().GetNeighbor(ip6Header.GetSource());
     VerifyOrExit(neighbor != NULL && !neighbor->IsFullThreadDevice());
 
-    if (Mle::Mle::GetRouterId(aMeshSource.GetShort()) != Mle::Mle::GetRouterId(Get<Mac::Mac>().GetShortAddress()))
+    if (Mle::Mle::RouterIdFromRloc16(aMeshSource.GetShort()) !=
+        Mle::Mle::RouterIdFromRloc16(Get<Mac::Mac>().GetShortAddress()))
     {
         Get<Mle::MleRouter>().RemoveNeighbor(*neighbor);
     }

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -614,8 +614,7 @@ void MeshForwarder::UpdateRoutes(uint8_t *           aFrame,
     neighbor = Get<Mle::MleRouter>().GetNeighbor(ip6Header.GetSource());
     VerifyOrExit(neighbor != NULL && !neighbor->IsFullThreadDevice());
 
-    if (Mle::Mle::RouterIdFromRloc16(aMeshSource.GetShort()) !=
-        Mle::Mle::RouterIdFromRloc16(Get<Mac::Mac>().GetShortAddress()))
+    if (!Mle::Mle::RouterIdMatch(aMeshSource.GetShort(), Get<Mac::Mac>().GetShortAddress()))
     {
         Get<Mle::MleRouter>().RemoveNeighbor(*neighbor);
     }

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -776,7 +776,7 @@ exit:
 otError MeshForwarder::GetDestinationRlocByServiceAloc(uint16_t aServiceAloc, uint16_t &aMeshDest)
 {
     otError                  error      = OT_ERROR_NONE;
-    uint8_t                  serviceId  = Mle::Mle::GetServiceIdFromAloc(aServiceAloc);
+    uint8_t                  serviceId  = Mle::Mle::ServiceIdFromAloc(aServiceAloc);
     NetworkData::ServiceTlv *serviceTlv = Get<NetworkData::Leader>().FindServiceById(serviceId);
 
     if (serviceTlv != NULL)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -423,7 +423,7 @@ otError Mle::Restore(void)
         mParent.SetExtAddress(*static_cast<Mac::ExtAddress *>(&parentInfo.mExtAddress));
         mParent.SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                          DeviceMode::kModeFullNetworkData | DeviceMode::kModeSecureDataRequest));
-        mParent.SetRloc16(Rloc16FromRouterId(GetRouterId(networkInfo.mRloc16)));
+        mParent.SetRloc16(Rloc16FromRouterId(RouterIdFromRloc16(networkInfo.mRloc16)));
         mParent.SetState(Neighbor::kStateRestored);
 
 #if OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
@@ -432,7 +432,7 @@ otError Mle::Restore(void)
     }
     else
     {
-        Get<MleRouter>().SetRouterId(GetRouterId(GetRloc16()));
+        Get<MleRouter>().SetRouterId(RouterIdFromRloc16(GetRloc16()));
         Get<MleRouter>().SetPreviousPartitionId(networkInfo.mPreviousPartitionId);
         Get<MleRouter>().RestoreChildren();
     }
@@ -3642,7 +3642,7 @@ otError Mle::HandleChildUpdateResponse(const Message &         aMessage,
         SuccessOrExit(error = Tlv::GetTlv(aMessage, Tlv::kSourceAddress, sizeof(sourceAddress), sourceAddress));
         VerifyOrExit(sourceAddress.IsValid(), error = OT_ERROR_PARSE);
 
-        if (GetRouterId(sourceAddress.GetRloc16()) != GetRouterId(GetRloc16()))
+        if (RouterIdFromRloc16(sourceAddress.GetRloc16()) != RouterIdFromRloc16(GetRloc16()))
         {
             BecomeDetached();
             ExitNow();

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -962,6 +962,13 @@ uint16_t Mle::GetRloc16(void) const
 
 void Mle::SetRloc16(uint16_t aRloc16)
 {
+    uint16_t oldRloc16 = GetRloc16();
+
+    if (aRloc16 != oldRloc16)
+    {
+        otLogNoteMle("RLOC16 %04x -> %04x", oldRloc16, aRloc16);
+    }
+
     Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal16);
 
     Get<Mac::Mac>().SetShortAddress(aRloc16);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -423,7 +423,7 @@ otError Mle::Restore(void)
         mParent.SetExtAddress(*static_cast<Mac::ExtAddress *>(&parentInfo.mExtAddress));
         mParent.SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                          DeviceMode::kModeFullNetworkData | DeviceMode::kModeSecureDataRequest));
-        mParent.SetRloc16(GetRloc16(GetRouterId(networkInfo.mRloc16)));
+        mParent.SetRloc16(Rloc16FromRouterId(GetRouterId(networkInfo.mRloc16)));
         mParent.SetState(Neighbor::kStateRestored);
 
 #if OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
@@ -1013,7 +1013,7 @@ otError Mle::GetLeaderAddress(Ip6::Address &aAddress) const
     aAddress.mFields.m16[4] = HostSwap16(0x0000);
     aAddress.mFields.m16[5] = HostSwap16(0x00ff);
     aAddress.mFields.m16[6] = HostSwap16(0xfe00);
-    aAddress.mFields.m16[7] = HostSwap16(GetRloc16(mLeaderData.GetLeaderRouterId()));
+    aAddress.mFields.m16[7] = HostSwap16(Rloc16FromRouterId(mLeaderData.GetLeaderRouterId()));
 
 exit:
     return error;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1042,7 +1042,7 @@ otError Mle::GetServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const
     aAddress.mFields.m16[4] = HostSwap16(0x0000);
     aAddress.mFields.m16[5] = HostSwap16(0x00ff);
     aAddress.mFields.m16[6] = HostSwap16(0xfe00);
-    aAddress.mFields.m16[7] = HostSwap16(GetServiceAlocFromId(aServiceId));
+    aAddress.mFields.m16[7] = HostSwap16(ServiceAlocFromId(aServiceId));
 
 exit:
     return error;
@@ -1601,7 +1601,7 @@ void Mle::UpdateServiceAlocs(void)
         serviceAloc = HostSwap16(mServiceAlocs[i].GetAddress().mFields.m16[7]);
 
         if ((serviceAloc != Mac::kShortAddrInvalid) &&
-            (!Get<NetworkData::Leader>().ContainsService(Mle::GetServiceIdFromAloc(serviceAloc), rloc)))
+            (!Get<NetworkData::Leader>().ContainsService(Mle::ServiceIdFromAloc(serviceAloc), rloc)))
         {
             Get<ThreadNetif>().RemoveUnicastAddress(mServiceAlocs[i]);
             mServiceAlocs[i].GetAddress().mFields.m16[7] = HostSwap16(Mac::kShortAddrInvalid);
@@ -1615,7 +1615,7 @@ void Mle::UpdateServiceAlocs(void)
         {
             serviceAloc = HostSwap16(mServiceAlocs[i].GetAddress().mFields.m16[7]);
 
-            if ((serviceAloc != Mac::kShortAddrInvalid) && (Mle::GetServiceIdFromAloc(serviceAloc) == serviceId))
+            if ((serviceAloc != Mac::kShortAddrInvalid) && (Mle::ServiceIdFromAloc(serviceAloc) == serviceId))
             {
                 break;
             }

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -989,14 +989,17 @@ public:
     }
 
     /**
-     * This method returns the RLOC16 of a given Router ID.
+     * This method derives RLOC16 from a given Router ID.
      *
      * @param[in]  aRouterId  The Router ID value.
      *
-     * @returns The RLOC16 of the given Router ID.
+     * @returns The RLOC16 corresponding to the given Router ID.
      *
      */
-    static uint16_t GetRloc16(uint8_t aRouterId) { return static_cast<uint16_t>(aRouterId << kRouterIdOffset); }
+    static uint16_t Rloc16FromRouterId(uint8_t aRouterId)
+    {
+        return static_cast<uint16_t>(aRouterId << kRouterIdOffset);
+    }
 
     /**
      * This method indicates whether or not @p aRloc16 refers to an active router.

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -946,7 +946,7 @@ public:
      */
     static bool RouterIdMatch(uint16_t aRloc16A, uint16_t aRloc16B)
     {
-        return ((aRloc16A >> kRouterIdOffset) == (aRloc16B >> kRouterIdOffset));
+        return RouterIdFromRloc16(aRloc16A) == RouterIdFromRloc16(aRloc16B);
     }
 
     /**

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -926,14 +926,14 @@ public:
     static uint16_t GetChildId(uint16_t aRloc16) { return aRloc16 & kMaxChildId; }
 
     /**
-     * This method returns the Router ID portion of an RLOC16.
+     * This method derives the Router ID portion from a given RLOC16.
      *
      * @param[in]  aRloc16  The RLOC16 value.
      *
      * @returns The Router ID portion of an RLOC16.
      *
      */
-    static uint8_t GetRouterId(uint16_t aRloc16) { return aRloc16 >> kRouterIdOffset; }
+    static uint8_t RouterIdFromRloc16(uint16_t aRloc16) { return aRloc16 >> kRouterIdOffset; }
 
     /**
      * This method returns whether the two RLOC16 have the same Router ID.

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -871,7 +871,7 @@ public:
      */
     otError GetCommissionerAloc(Ip6::Address &aAddress, uint16_t aSessionId) const
     {
-        return GetAlocAddress(aAddress, GetCommissionerAloc16FromId(aSessionId));
+        return GetAlocAddress(aAddress, CommissionerAloc16FromId(aSessionId));
     }
 
     /**
@@ -957,10 +957,7 @@ public:
      * @returns The Service ID corresponding to given ALOC16.
      *
      */
-    static uint8_t GetServiceIdFromAloc(uint16_t aAloc16)
-    {
-        return static_cast<uint8_t>(aAloc16 - kAloc16ServiceStart);
-    }
+    static uint8_t ServiceIdFromAloc(uint16_t aAloc16) { return static_cast<uint8_t>(aAloc16 - kAloc16ServiceStart); }
 
     /**
      * This method returns the Service Aloc corresponding to a Service ID.
@@ -970,7 +967,7 @@ public:
      * @returns The Service ALOC16 corresponding to given ID.
      *
      */
-    static uint16_t GetServiceAlocFromId(uint8_t aServiceId)
+    static uint16_t ServiceAlocFromId(uint8_t aServiceId)
     {
         return static_cast<uint16_t>(aServiceId + kAloc16ServiceStart);
     }
@@ -983,7 +980,7 @@ public:
      * @returns The Commissioner ALOC16 corresponding to given ID.
      *
      */
-    static uint16_t GetCommissionerAloc16FromId(uint16_t aSessionId)
+    static uint16_t CommissionerAloc16FromId(uint16_t aSessionId)
     {
         return static_cast<uint16_t>((aSessionId & kAloc16CommissionerMask) + kAloc16CommissionerStart);
     }

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -916,14 +916,14 @@ public:
     otError GetLeaderData(otLeaderData &aLeaderData);
 
     /**
-     * This method returns the Child ID portion of an RLOC16.
+     * This method derives the Child ID from a given RLOC16.
      *
      * @param[in]  aRloc16  The RLOC16 value.
      *
      * @returns The Child ID portion of an RLOC16.
      *
      */
-    static uint16_t GetChildId(uint16_t aRloc16) { return aRloc16 & kMaxChildId; }
+    static uint16_t ChildIdFromRloc16(uint16_t aRloc16) { return aRloc16 & kMaxChildId; }
 
     /**
      * This method derives the Router ID portion from a given RLOC16.
@@ -1010,7 +1010,7 @@ public:
      * @retval FALSE  If @p aRloc16 does not refer to an active router.
      *
      */
-    static bool IsActiveRouter(uint16_t aRloc16) { return GetChildId(aRloc16) == 0; }
+    static bool IsActiveRouter(uint16_t aRloc16) { return ChildIdFromRloc16(aRloc16) == 0; }
 
     /**
      * This method fills the NetworkDataTlv.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3501,7 +3501,7 @@ otError MleRouter::GetChildInfoById(uint16_t aChildId, otChildInfo &aChildInfo)
 
     if ((aChildId & ~kMaxChildId) != 0)
     {
-        aChildId = GetChildId(aChildId);
+        aChildId = ChildIdFromRloc16(aChildId);
     }
 
     rloc16 = Get<Mac::Mac>().GetShortAddress() | aChildId;
@@ -3652,7 +3652,7 @@ otError MleRouter::GetChildInfo(Child &aChild, otChildInfo &aChildInfo)
     aChildInfo.mExtAddress         = aChild.GetExtAddress();
     aChildInfo.mTimeout            = aChild.GetTimeout();
     aChildInfo.mRloc16             = aChild.GetRloc16();
-    aChildInfo.mChildId            = GetChildId(aChild.GetRloc16());
+    aChildInfo.mChildId            = ChildIdFromRloc16(aChild.GetRloc16());
     aChildInfo.mNetworkDataVersion = aChild.GetNetworkDataVersion();
     aChildInfo.mAge                = Time::MsecToSec(TimerMilli::GetNow() - aChild.GetLastHeard());
     aChildInfo.mLinkQualityIn      = aChild.GetLinkInfo().GetLinkQuality();

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1139,9 +1139,9 @@ bool MleRouter::IsSingleton(const RouteTlv &aRouteTlv)
     }
 
     // Check if 2 or more active routers
-    for (uint8_t i = 0; i <= kMaxRouterId; i++)
+    for (uint8_t routerId = 0; routerId <= kMaxRouterId; routerId++)
     {
-        if (aRouteTlv.IsRouterIdSet(i) && (++count >= 2))
+        if (aRouteTlv.IsRouterIdSet(routerId) && (++count >= 2))
         {
             ExitNow(rval = false);
         }
@@ -1316,14 +1316,14 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
 
                 if (leader != NULL)
                 {
-                    for (uint8_t i = 0, routeCount = 0; i <= kMaxRouterId; i++)
+                    for (uint8_t id = 0, routeCount = 0; id <= kMaxRouterId; id++)
                     {
-                        if (!route.IsRouterIdSet(i))
+                        if (!route.IsRouterIdSet(id))
                         {
                             continue;
                         }
 
-                        if (i != GetLeaderId())
+                        if (id != GetLeaderId())
                         {
                             routeCount++;
                             continue;
@@ -1331,7 +1331,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
 
                         if (route.GetRouteCost(routeCount) > 0)
                         {
-                            leader->SetNextHop(routerId);
+                            leader->SetNextHop(id);
                             leader->SetCost(route.GetRouteCost(routeCount));
                         }
                         else
@@ -1376,9 +1376,9 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
         // check current active router number
         routerCount = 0;
 
-        for (uint8_t i = 0; i <= kMaxRouterId; i++)
+        for (uint8_t id = 0; id <= kMaxRouterId; id++)
         {
-            if (route.IsRouterIdSet(i))
+            if (route.IsRouterIdSet(id))
             {
                 routerCount++;
             }
@@ -1440,19 +1440,19 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
     changed = UpdateLinkQualityOut(aRoute, *neighbor, resetAdvInterval);
 
     // update routes
-    for (uint8_t i = 0, routeCount = 0; i <= kMaxRouterId; i++)
+    for (uint8_t routerId = 0, routeCount = 0; routerId <= kMaxRouterId; routerId++)
     {
         Router *router;
         Router *nextHop;
         uint8_t oldNextHop;
         uint8_t cost;
 
-        if (!aRoute.IsRouterIdSet(i))
+        if (!aRoute.IsRouterIdSet(routerId))
         {
             continue;
         }
 
-        router = mRouterTable.GetRouter(i);
+        router = mRouterTable.GetRouter(routerId);
 
         if (router == NULL || router->GetRloc16() == GetRloc16() || router == neighbor)
         {
@@ -1556,9 +1556,9 @@ bool MleRouter::UpdateLinkQualityOut(const RouteTlv &aRoute, Router &aNeighbor, 
     VerifyOrExit(aRoute.IsRouterIdSet(myRouterId));
 
     myRouteCount = 0;
-    for (uint8_t i = 0; i < myRouterId; i++)
+    for (uint8_t routerId = 0; routerId < myRouterId; routerId++)
     {
-        myRouteCount += aRoute.IsRouterIdSet(i);
+        myRouteCount += aRoute.IsRouterIdSet(routerId);
     }
 
     linkQuality = aRoute.GetLinkQualityIn(myRouteCount);
@@ -4140,11 +4140,11 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Message &   aRequest,
         routerMaskTlv.SetIdSequence(mRouterTable.GetRouterIdSequence());
         routerMaskTlv.ClearAssignedRouterIdMask();
 
-        for (uint8_t i = 0; i <= kMaxRouterId; i++)
+        for (uint8_t routerId = 0; routerId <= kMaxRouterId; routerId++)
         {
-            if (mRouterTable.IsAllocated(i))
+            if (mRouterTable.IsAllocated(routerId))
             {
-                routerMaskTlv.SetAssignedRouterId(i);
+                routerMaskTlv.SetAssignedRouterId(routerId);
             }
         }
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -197,7 +197,7 @@ otError MleRouter::BecomeLeader(void)
     Get<NetworkData::Leader>().Reset();
     Get<MeshCoP::Leader>().SetEmptyCommissionerData();
 
-    SetStateLeader(GetRloc16(leaderId));
+    SetStateLeader(Rloc16FromRouterId(leaderId));
 
 exit:
     return error;
@@ -1529,7 +1529,7 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
         Router &router = *iter.GetRouter();
 
         otLogInfoMle("    %04x -> %04x, cost:%d %d, lqin:%d, lqout:%d, link:%s", router.GetRloc16(),
-                     (router.GetNextHop() == kInvalidRouterId) ? 0xffff : GetRloc16(router.GetNextHop()),
+                     (router.GetNextHop() == kInvalidRouterId) ? 0xffff : Rloc16FromRouterId(router.GetNextHop()),
                      router.GetCost(), mRouterTable.GetLinkCost(router), router.GetLinkInfo().GetLinkQuality(),
                      router.GetLinkQualityOut(),
                      router.GetRloc16() == GetRloc16() ? "device" : (router.IsStateValid() ? "yes" : "no"));
@@ -3429,11 +3429,11 @@ uint16_t MleRouter::GetNextHop(uint16_t aDestination)
         nextHop = mRouterTable.GetRouter(router->GetNextHop());
         VerifyOrExit(nextHop != NULL && !nextHop->IsStateInvalid());
 
-        rval = GetRloc16(router->GetNextHop());
+        rval = Rloc16FromRouterId(router->GetNextHop());
     }
     else if (linkCost < kMaxRouteCost)
     {
-        rval = GetRloc16(destinationId);
+        rval = Rloc16FromRouterId(destinationId);
     }
 
 exit:
@@ -3846,7 +3846,7 @@ otError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
     if (IsRouterIdValid(mPreviousRouterId))
     {
         rlocTlv.Init();
-        rlocTlv.SetRloc16(GetRloc16(mPreviousRouterId));
+        rlocTlv.SetRloc16(Rloc16FromRouterId(mPreviousRouterId));
         SuccessOrExit(error = rlocTlv.AppendTo(*message));
     }
 
@@ -3892,7 +3892,7 @@ otError MleRouter::SendAddressRelease(void)
     SuccessOrExit(error = message->SetPayloadMarker());
 
     rlocTlv.Init();
-    rlocTlv.SetRloc16(GetRloc16(mRouterId));
+    rlocTlv.SetRloc16(Rloc16FromRouterId(mRouterId));
     SuccessOrExit(error = rlocTlv.AppendTo(*message));
 
     macAddr64Tlv.Init();
@@ -3974,7 +3974,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
     // assign short address
     SetRouterId(routerId);
 
-    SetStateRouter(GetRloc16(mRouterId));
+    SetStateRouter(Rloc16FromRouterId(mRouterId));
     mRouterTable.Clear();
     mRouterTable.ProcessTlv(routerMaskTlv);
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -321,7 +321,7 @@ void MleRouter::SetStateRouter(uint16_t aRloc16)
     // remove children that do not have matching RLOC16
     for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValidOrRestoring); !iter.IsDone(); iter++)
     {
-        if (GetRouterId(iter.GetChild()->GetRloc16()) != mRouterId)
+        if (RouterIdFromRloc16(iter.GetChild()->GetRloc16()) != mRouterId)
         {
             RemoveNeighbor(*iter.GetChild());
         }
@@ -358,7 +358,7 @@ void MleRouter::SetStateLeader(uint16_t aRloc16)
     // remove children that do not have matching RLOC16
     for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValidOrRestoring); !iter.IsDone(); iter++)
     {
-        if (GetRouterId(iter.GetChild()->GetRloc16()) != mRouterId)
+        if (RouterIdFromRloc16(iter.GetChild()->GetRloc16()) != mRouterId)
         {
             RemoveNeighbor(*iter.GetChild());
         }
@@ -605,7 +605,7 @@ otError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::Message
 
             aMessageInfo.GetPeerAddr().ToExtAddress(macAddr);
 
-            neighbor = mRouterTable.GetRouter(GetRouterId(rloc16));
+            neighbor = mRouterTable.GetRouter(RouterIdFromRloc16(rloc16));
             VerifyOrExit(neighbor != NULL, error = OT_ERROR_PARSE);
             VerifyOrExit(!neighbor->IsStateLinkRequest(), error = OT_ERROR_ALREADY);
 
@@ -828,7 +828,7 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
 
     VerifyOrExit(IsActiveRouter(sourceAddress.GetRloc16()), error = OT_ERROR_PARSE);
 
-    routerId      = GetRouterId(sourceAddress.GetRloc16());
+    routerId      = RouterIdFromRloc16(sourceAddress.GetRloc16());
     router        = mRouterTable.GetRouter(routerId);
     neighborState = (router != NULL) ? router->GetState() : Neighbor::kStateInvalid;
 
@@ -918,7 +918,7 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
         router = mRouterTable.GetRouter(routerId);
         VerifyOrExit(router != NULL);
 
-        if (mLeaderData.GetLeaderRouterId() == GetRouterId(GetRloc16()))
+        if (mLeaderData.GetLeaderRouterId() == RouterIdFromRloc16(GetRloc16()))
         {
             SetStateLeader(GetRloc16());
         }
@@ -1236,7 +1236,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
     }
 
     VerifyOrExit(IsActiveRouter(sourceAddress.GetRloc16()) && route.IsValid());
-    routerId = GetRouterId(sourceAddress.GetRloc16());
+    routerId = RouterIdFromRloc16(sourceAddress.GetRloc16());
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     Get<TimeSync>().HandleTimeSyncMessage(aMessage);
@@ -1552,7 +1552,7 @@ bool MleRouter::UpdateLinkQualityOut(const RouteTlv &aRoute, Router &aNeighbor, 
     uint8_t oldLinkCost;
     Router *nextHop;
 
-    myRouterId = GetRouterId(GetRloc16());
+    myRouterId = RouterIdFromRloc16(GetRloc16());
     VerifyOrExit(aRoute.IsRouterIdSet(myRouterId));
 
     myRouteCount = 0;
@@ -3178,7 +3178,7 @@ bool MleRouter::IsMinimalChild(uint16_t aRloc16)
 {
     bool rval = false;
 
-    if (GetRouterId(aRloc16) == GetRouterId(Get<Mac::Mac>().GetShortAddress()))
+    if (RouterIdFromRloc16(aRloc16) == RouterIdFromRloc16(Get<Mac::Mac>().GetShortAddress()))
     {
         Neighbor *neighbor;
 
@@ -3400,7 +3400,7 @@ exit:
 
 uint16_t MleRouter::GetNextHop(uint16_t aDestination)
 {
-    uint8_t       destinationId = GetRouterId(aDestination);
+    uint8_t       destinationId = RouterIdFromRloc16(aDestination);
     uint8_t       routeCost;
     uint8_t       linkCost;
     uint16_t      rval = Mac::kShortAddrInvalid;
@@ -3442,7 +3442,7 @@ exit:
 
 uint8_t MleRouter::GetCost(uint16_t aRloc16)
 {
-    uint8_t routerId = GetRouterId(aRloc16);
+    uint8_t routerId = RouterIdFromRloc16(aRloc16);
     uint8_t cost     = GetLinkCost(routerId);
     Router *router   = mRouterTable.GetRouter(routerId);
     uint8_t routeCost;
@@ -3465,7 +3465,7 @@ uint8_t MleRouter::GetRouteCost(uint16_t aRloc16) const
     uint8_t       rval = kMaxRouteCost;
     const Router *router;
 
-    router = mRouterTable.GetRouter(GetRouterId(aRloc16));
+    router = mRouterTable.GetRouter(RouterIdFromRloc16(aRloc16));
     VerifyOrExit(router != NULL && mRouterTable.GetRouter(router->GetNextHop()) != NULL);
 
     rval = router->GetCost();
@@ -3761,7 +3761,7 @@ void MleRouter::ResolveRoutingLoops(uint16_t aSourceMac, uint16_t aDestRloc16)
     }
 
     // loop exists
-    router = mRouterTable.GetRouter(GetRouterId(aDestRloc16));
+    router = mRouterTable.GetRouter(RouterIdFromRloc16(aDestRloc16));
     VerifyOrExit(router != NULL);
 
     // invalidate next hop
@@ -3797,7 +3797,7 @@ otError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, I
             ExitNow();
         }
     }
-    else if (GetRouterId(aMeshDest) == mRouterId)
+    else if (RouterIdFromRloc16(aMeshDest) == mRouterId)
     {
         // mesh destination is a child of this device
         if (mChildTable.FindChild(aMeshDest, Child::kInStateValidOrRestoring))
@@ -3966,7 +3966,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
 
     SuccessOrExit(ThreadTlv::GetTlv(*aMessage, ThreadTlv::kRloc16, sizeof(rlocTlv), rlocTlv));
     VerifyOrExit(rlocTlv.IsValid());
-    routerId = GetRouterId(rlocTlv.GetRloc16());
+    routerId = RouterIdFromRloc16(rlocTlv.GetRloc16());
 
     SuccessOrExit(ThreadTlv::GetTlv(*aMessage, ThreadTlv::kRouterMask, sizeof(routerMaskTlv), routerMaskTlv));
     VerifyOrExit(routerMaskTlv.IsValid());
@@ -3999,7 +3999,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
     {
         // Keep route path to the Leader reported by the parent before it is updated.
         leader->SetCost(mParentLeaderCost);
-        leader->SetNextHop(GetRouterId(mParent.GetRloc16()));
+        leader->SetNextHop(RouterIdFromRloc16(mParent.GetRloc16()));
     }
 
     // send link request
@@ -4081,7 +4081,7 @@ void MleRouter::HandleAddressSolicit(Coap::Message &aMessage, const Ip6::Message
     if (ThreadTlv::GetTlv(aMessage, ThreadTlv::kRloc16, sizeof(rlocTlv), rlocTlv) == OT_ERROR_NONE)
     {
         VerifyOrExit(rlocTlv.IsValid(), error = OT_ERROR_PARSE);
-        router = mRouterTable.Allocate(GetRouterId(rlocTlv.GetRloc16()));
+        router = mRouterTable.Allocate(RouterIdFromRloc16(rlocTlv.GetRloc16()));
     }
 
     // allocate new router id
@@ -4186,7 +4186,7 @@ void MleRouter::HandleAddressRelease(Coap::Message &aMessage, const Ip6::Message
     SuccessOrExit(ThreadTlv::GetTlv(aMessage, ThreadTlv::kExtMacAddress, sizeof(macAddr64Tlv), macAddr64Tlv));
     VerifyOrExit(macAddr64Tlv.IsValid());
 
-    routerId = GetRouterId(rlocTlv.GetRloc16());
+    routerId = RouterIdFromRloc16(rlocTlv.GetRloc16());
     router   = mRouterTable.GetRouter(routerId);
 
     VerifyOrExit(router != NULL && router->GetExtAddress() == macAddr64Tlv.GetMacAddr());

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1528,9 +1528,11 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
     {
         Router &router = *iter.GetRouter();
 
-        otLogInfoMle("    %04x -> %04x, cost:%d %d, lqin:%d, lqout:%d", router.GetRloc16(),
-                     GetRloc16(router.GetNextHop()), router.GetCost(), mRouterTable.GetLinkCost(router),
-                     router.GetLinkInfo().GetLinkQuality(), router.GetLinkQualityOut());
+        otLogInfoMle("    %04x -> %04x, cost:%d %d, lqin:%d, lqout:%d, link:%s", router.GetRloc16(),
+                     (router.GetNextHop() == kInvalidRouterId) ? 0xffff : GetRloc16(router.GetNextHop()),
+                     router.GetCost(), mRouterTable.GetLinkCost(router), router.GetLinkInfo().GetLinkQuality(),
+                     router.GetLinkQualityOut(),
+                     router.GetRloc16() == GetRloc16() ? "device" : (router.IsStateValid() ? "yes" : "no"));
     }
 
 #else

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -716,7 +716,7 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Serv
             case NetworkDataTlv::kTypeServer:
             {
                 server = static_cast<ServerTlv *>(cur);
-                server->SetServer16(Mle::Mle::GetServiceAlocFromId(aService.GetServiceID()));
+                server->SetServer16(Mle::Mle::ServiceAlocFromId(aService.GetServiceID()));
                 break;
             }
 

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -261,7 +261,7 @@ otError NetworkDiagnostic::AppendChildTable(Message &aMessage)
         entry.SetReserved(0);
         entry.SetTimeout(timeout + 4);
 
-        entry.SetChildId(Mle::Mle::GetChildId(child.GetRloc16()));
+        entry.SetChildId(Mle::Mle::ChildIdFromRloc16(child.GetRloc16()));
         entry.SetMode(child.GetDeviceMode());
 
         SuccessOrExit(error = aMessage.Append(&entry, sizeof(ChildTableEntry)));

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -184,7 +184,7 @@ void RouterTable::UpdateAllocation(void)
             if (router.GetRouterId() != routerId)
             {
                 router.Clear();
-                router.SetRloc16(Mle::Mle::GetRloc16(routerId));
+                router.SetRloc16(Mle::Mle::Rloc16FromRouterId(routerId));
                 router.SetNextHop(Mle::kInvalidRouterId);
             }
         }
@@ -267,7 +267,7 @@ exit:
 otError RouterTable::Release(uint8_t aRouterId)
 {
     otError  error  = OT_ERROR_NONE;
-    uint16_t rloc16 = Mle::Mle::GetRloc16(aRouterId);
+    uint16_t rloc16 = Mle::Mle::Rloc16FromRouterId(aRouterId);
 
     assert(aRouterId <= Mle::kMaxRouterId);
 
@@ -383,7 +383,7 @@ exit:
 const Router *RouterTable::GetRouter(uint8_t aRouterId) const
 {
     const Router *router = NULL;
-    uint16_t      rloc16 = Mle::Mle::GetRloc16(aRouterId);
+    uint16_t      rloc16 = Mle::Mle::Rloc16FromRouterId(aRouterId);
 
     for (router = GetFirstEntry(); router != NULL; router = GetNextEntry(router))
     {
@@ -433,7 +433,7 @@ otError RouterTable::GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo
 
     memset(&aRouterInfo, 0, sizeof(aRouterInfo));
     aRouterInfo.mRouterId        = routerId;
-    aRouterInfo.mRloc16          = Mle::Mle::GetRloc16(routerId);
+    aRouterInfo.mRloc16          = Mle::Mle::Rloc16FromRouterId(routerId);
     aRouterInfo.mExtAddress      = router->GetExtAddress();
     aRouterInfo.mAllocated       = true;
     aRouterInfo.mNextHop         = router->GetNextHop();

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -424,7 +424,7 @@ otError RouterTable::GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo
     else
     {
         VerifyOrExit(Mle::Mle::IsActiveRouter(aRouterId), error = OT_ERROR_INVALID_ARGS);
-        routerId = Mle::Mle::GetRouterId(aRouterId);
+        routerId = Mle::Mle::RouterIdFromRloc16(aRouterId);
         VerifyOrExit(routerId <= Mle::kMaxRouterId, error = OT_ERROR_INVALID_ARGS);
     }
 


### PR DESCRIPTION
This PR contains a group of smaller changes/enhancements mainly in `Mle`, adding/updating log  messages and renaming the static methods which convert from one simple type/value to another:

- [mle] log rlco16 changes 

- [mle] update route table log message 
This commit updates the route table log message to include if link
is established with router or not (router is a neighbor). Also the
`0xffff` is printed as next hop if it is invalid and we indicate
if the entry is for the device itself.

- [mle-router] use routerId as variable name 

- [mle] rename static method to Rloc16FromRouterId() from GetRloc16() 
This commit renames the static `Mle` method which derives RLOC16
from a given Router ID to `Rloc16FromRouterId()` from `GetRloc16()`.
This helps distinguish this method from other `GetRloc16()` methods.

- [mle] rename static method to RouterIdFromRloc16() from GetRouterId() 

- [mle] rename static methods converting between service ALOC and Id 

- [mle] rename static method to ChildIdFromRloc16() from GetChildId() 

- [mesh-forwarder] use Mle::RouterIdMatch() helper method 

- [address-resolver] rename static method to InvalidationReasonToString 
