### PR TITLE
[meshcop] fix premature free of finalize message

### DIFF
--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -450,13 +450,10 @@ exit:
 
 void Joiner::FreeJoinerFinalizeMessage(void)
 {
-    VerifyOrExit(mState == OT_JOINER_STATE_IDLE);
+    VerifyOrExit(mState == OT_JOINER_STATE_IDLE && mFinalizeMessage != NULL);
 
-    if (mFinalizeMessage != NULL)
-    {
-        mFinalizeMessage->Free();
-        mFinalizeMessage = NULL;
-    }
+    mFinalizeMessage->Free();
+    mFinalizeMessage = NULL;
 
 exit:
     return;

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -129,7 +129,10 @@ exit:
     if (error != OT_ERROR_NONE)
     {
         otLogInfoMeshCoP("Error %s while starting joiner", otThreadErrorToString(error));
-        FreeJoinerFinalizeMessage();
+        if (mState == OT_JOINER_STATE_IDLE)
+        {
+            FreeJoinerFinalizeMessage();
+        }
     }
 
     return error;

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -129,10 +129,7 @@ exit:
     if (error != OT_ERROR_NONE)
     {
         otLogInfoMeshCoP("Error %s while starting joiner", otThreadErrorToString(error));
-        if (mState == OT_JOINER_STATE_IDLE)
-        {
-            FreeJoinerFinalizeMessage();
-        }
+        FreeJoinerFinalizeMessage();
     }
 
     return error;
@@ -166,11 +163,11 @@ void Joiner::Finish(otError aError)
 
     case OT_JOINER_STATE_DISCOVER:
         Get<Coap::CoapSecure>().Stop();
-        FreeJoinerFinalizeMessage();
         break;
     }
 
     SetState(OT_JOINER_STATE_IDLE);
+    FreeJoinerFinalizeMessage();
 
     if (mCallback)
     {
@@ -453,11 +450,16 @@ exit:
 
 void Joiner::FreeJoinerFinalizeMessage(void)
 {
+    VerifyOrExit(mState == OT_JOINER_STATE_IDLE);
+
     if (mFinalizeMessage != NULL)
     {
         mFinalizeMessage->Free();
         mFinalizeMessage = NULL;
     }
+
+exit:
+    return;
 }
 
 void Joiner::SendJoinerFinalize(void)


### PR DESCRIPTION
This PR fix the bug that the `finalize message` will be prematurely freed if the joiner is started at the second time without waiting for the finish of the first initiation.