### PR TITLE
[codecov] ignore third_party code

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -5,7 +5,7 @@ coverage:
 
 ignore:
   - "tests/*"
-  - "third_party/*"
+  - "third_party/**/*"
 
 comment:
   layout: "diff, flags, files"


### PR DESCRIPTION
From https://docs.codecov.io/docs/ignoring-paths, `third_party/*` will not recursively ignore all files in `third_party`. This PR changes `.codecov.yml` to use the correct pattern `third_party/**/*`.