### PR TITLE
[toranj] improve code coverage by using absolute path

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -178,11 +178,11 @@ jobs:
       os: linux
       compiler: gcc
       script: .travis/script.sh
-    - env: BUILD_TARGET="toranj-test-framework" VERBOSE=1
+    - env: BUILD_TARGET="toranj-test-framework" COVERAGE=1 VERBOSE=1
       os: linux
       compiler: gcc
       script: .travis/script.sh
-    - env: BUILD_TARGET="toranj-test-framework" VERBOSE=1 TORANJ_POSIX_APP_RCP_MODEL=1
+    - env: BUILD_TARGET="toranj-test-framework" COVERAGE=1 VERBOSE=1 TORANJ_POSIX_APP_RCP_MODEL=1
       os: linux
       compiler: gcc
       script: .travis/script.sh

--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -632,7 +632,7 @@ build_samr21() {
 }
 
 [ $BUILD_TARGET != toranj-test-framework ] || {
-    ./tests/toranj/start.sh || die
+    top_builddir=$(pwd)/build/toranj ./tests/toranj/start.sh || die
 }
 
 [ $BUILD_TARGET != osx ] || {

--- a/tests/toranj/build.sh
+++ b/tests/toranj/build.sh
@@ -91,13 +91,22 @@ configure_options="                \
 
 cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config.h\"'
 
+if [ -n "${top_builddir}" ]; then
+    top_srcdir=$(pwd)
+    mkdir -p "${top_builddir}"
+else
+    top_srcdir=.
+    top_builddir=.
+fi
+
 case ${build_config} in
     ncp)
         echo "==================================================================================================="
         echo "Building OpenThread NCP FTD mode with POSIX platform"
         echo "==================================================================================================="
         ./bootstrap || die
-        ./configure                             \
+        cd "${top_builddir}"
+        ${top_srcdir}/configure              \
             CPPFLAGS="$cppflags_config"         \
             --with-examples=posix               \
             $configure_options || die
@@ -109,7 +118,8 @@ case ${build_config} in
         echo "Building OpenThread RCP (NCP in radio mode) with POSIX platform"
         echo "===================================================================================================="
         ./bootstrap || die
-        ./configure                             \
+        cd "${top_builddir}"
+        ${top_srcdir}/configure              \
             CPPFLAGS="$cppflags_config"         \
             --enable-coverage=${coverage}       \
             --enable-ncp                        \
@@ -125,7 +135,8 @@ case ${build_config} in
         echo "Building OpenThread POSIX App NCP"
         echo "===================================================================================================="
         ./bootstrap || die
-        ./configure                             \
+        cd "${top_builddir}"
+        ${top_srcdir}/configure              \
             CPPFLAGS="$cppflags_config -DOPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE=1" \
             --enable-posix-app                  \
             $configure_options || die

--- a/tests/toranj/build.sh
+++ b/tests/toranj/build.sh
@@ -106,7 +106,7 @@ case ${build_config} in
         echo "==================================================================================================="
         ./bootstrap || die
         cd "${top_builddir}"
-        ${top_srcdir}/configure              \
+        ${top_srcdir}/configure                 \
             CPPFLAGS="$cppflags_config"         \
             --with-examples=posix               \
             $configure_options || die
@@ -119,7 +119,7 @@ case ${build_config} in
         echo "===================================================================================================="
         ./bootstrap || die
         cd "${top_builddir}"
-        ${top_srcdir}/configure              \
+        ${top_srcdir}/configure                 \
             CPPFLAGS="$cppflags_config"         \
             --enable-coverage=${coverage}       \
             --enable-ncp                        \
@@ -136,7 +136,7 @@ case ${build_config} in
         echo "===================================================================================================="
         ./bootstrap || die
         cd "${top_builddir}"
-        ${top_srcdir}/configure              \
+        ${top_srcdir}/configure                 \
             CPPFLAGS="$cppflags_config -DOPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE=1 -DOPENTHREAD_POSIX_RCP_UART_ENABLE=1" \
             --enable-posix-app                  \
             $configure_options || die

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -77,8 +77,7 @@ run() {
 
 cd $(dirname $0)
 
-# On Travis CI, the $BUILD_TARGET is defined as "toranj-test-framework".
-if [ "$BUILD_TARGET" = "toranj-test-framework" ]; then
+if [ "$COVERAGE" = 1 ]; then
     coverage_option="--enable-coverage"
 else
     coverage_option=""


### PR DESCRIPTION
Gcov sometimes cannot correctly find source files when the code is
configured with relative path. This PR enables using absolute path to
run toranj tests.