### PR TITLE
[codecov] cover swapping flash block of settings

### DIFF
--- a/examples/platforms/cc1352/Makefile.am
+++ b/examples/platforms/cc1352/Makefile.am
@@ -77,9 +77,8 @@ PRETTY_FILES                                                                    
     $(PLATFORM_SOURCES)                                                                   \
     $(NULL)
 
-Dash = -
 libopenthread_cc1352_a_LIBADD                                                           = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am
 

--- a/examples/platforms/cc1352/Makefile.am
+++ b/examples/platforms/cc1352/Makefile.am
@@ -78,7 +78,7 @@ PRETTY_FILES                                                                    
     $(NULL)
 
 libopenthread_cc1352_a_LIBADD                                                           = \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am
 

--- a/examples/platforms/cc2538/Makefile.am
+++ b/examples/platforms/cc2538/Makefile.am
@@ -62,8 +62,7 @@ PRETTY_FILES                             = \
     $(PLATFORM_SOURCES)                    \
     $(NULL)
 
-Dash                                      = -
 libopenthread_cc2538_a_LIBADD             = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/cc2538/Makefile.am
+++ b/examples/platforms/cc2538/Makefile.am
@@ -63,6 +63,6 @@ PRETTY_FILES                             = \
     $(NULL)
 
 libopenthread_cc2538_a_LIBADD             = \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/cc2650/Makefile.am
+++ b/examples/platforms/cc2650/Makefile.am
@@ -79,6 +79,6 @@ PRETTY_FILES                                          = \
     $(NULL)
 
 libopenthread_cc2650_a_LIBADD                         = \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/cc2650/Makefile.am
+++ b/examples/platforms/cc2650/Makefile.am
@@ -78,8 +78,7 @@ PRETTY_FILES                                          = \
     $(PLATFORM_SOURCES)                                 \
     $(NULL)
 
-Dash                                                  = -
 libopenthread_cc2650_a_LIBADD                         = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/cc2652/Makefile.am
+++ b/examples/platforms/cc2652/Makefile.am
@@ -78,7 +78,7 @@ PRETTY_FILES                                                                    
     $(NULL)
 
 libopenthread_cc2652_a_LIBADD                                                           = \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am
 

--- a/examples/platforms/cc2652/Makefile.am
+++ b/examples/platforms/cc2652/Makefile.am
@@ -77,9 +77,8 @@ PRETTY_FILES                                                                    
     $(PLATFORM_SOURCES)                                                                   \
     $(NULL)
 
-Dash = -
 libopenthread_cc2652_a_LIBADD                                                           = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am
 

--- a/examples/platforms/efr32mg12/Makefile.am
+++ b/examples/platforms/efr32mg12/Makefile.am
@@ -129,8 +129,8 @@ PRETTY_FILES                                                                  = 
 
 Dash                                                                                                 = -
 libopenthread_efr32mg12_a_LIBADD                                                                     = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")             \
-    $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")
+    $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o") \
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 DIST_SUBDIRS                                                                  = \
     sleepy-demo                                                                 \

--- a/examples/platforms/efr32mg12/Makefile.am
+++ b/examples/platforms/efr32mg12/Makefile.am
@@ -130,7 +130,7 @@ PRETTY_FILES                                                                  = 
 Dash                                                                                                 = -
 libopenthread_efr32mg12_a_LIBADD                                                                     = \
     $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o") \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 DIST_SUBDIRS                                                                  = \
     sleepy-demo                                                                 \

--- a/examples/platforms/efr32mg21/Makefile.am
+++ b/examples/platforms/efr32mg21/Makefile.am
@@ -123,7 +123,7 @@ PRETTY_FILES                                                                  = 
 Dash                                                                                                 = -
 libopenthread_efr32mg21_a_LIBADD                                                                     = \
     $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o") \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 DIST_SUBDIRS                                                                  = \
     sleepy-demo                                                                 \

--- a/examples/platforms/efr32mg21/Makefile.am
+++ b/examples/platforms/efr32mg21/Makefile.am
@@ -122,8 +122,8 @@ PRETTY_FILES                                                                  = 
 
 Dash                                                                                                 = -
 libopenthread_efr32mg21_a_LIBADD                                                                     = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")             \
-    $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")
+    $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o") \
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 DIST_SUBDIRS                                                                  = \
     sleepy-demo                                                                 \

--- a/examples/platforms/gp712/Makefile.am
+++ b/examples/platforms/gp712/Makefile.am
@@ -57,9 +57,8 @@ PLATFORM_SOURCES                          = \
     uart_qorvo.h                            \
     $(NULL)
 
-Dash                                      = -
 libopenthread_gp712_a_LIBADD              = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 libopenthread_gp712_a_SOURCES             = \
     $(PLATFORM_SOURCES)                     \

--- a/examples/platforms/gp712/Makefile.am
+++ b/examples/platforms/gp712/Makefile.am
@@ -58,7 +58,7 @@ PLATFORM_SOURCES                          = \
     $(NULL)
 
 libopenthread_gp712_a_LIBADD              = \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 libopenthread_gp712_a_SOURCES             = \
     $(PLATFORM_SOURCES)                     \

--- a/examples/platforms/kw41z/Makefile.am
+++ b/examples/platforms/kw41z/Makefile.am
@@ -103,8 +103,7 @@ PRETTY_FILES                                                                    
     $(PLATFORM_SOURCES)                                                                              \
     $(NULL)
 
-Dash                                                                                               = -
 libopenthread_kw41z_a_LIBADD                                                                       = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/kw41z/Makefile.am
+++ b/examples/platforms/kw41z/Makefile.am
@@ -104,6 +104,6 @@ PRETTY_FILES                                                                    
     $(NULL)
 
 libopenthread_kw41z_a_LIBADD                                                                       = \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/nrf528xx/nrf52811/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52811/Makefile.am
@@ -127,8 +127,8 @@ libopenthread_nrf52811_sdk_a_SOURCES                                            
 Dash                                                                                                       = -
 
 libopenthread_nrf52811_a_LIBADD                                                                            = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")                   \
-    $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")
+    $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")      \
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 libopenthread_nrf52811_sdk_a_LIBADD                                                                        = \
     $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")

--- a/examples/platforms/nrf528xx/nrf52811/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52811/Makefile.am
@@ -128,7 +128,7 @@ Dash                                                                            
 
 libopenthread_nrf52811_a_LIBADD                                                                            = \
     $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")      \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 libopenthread_nrf52811_sdk_a_LIBADD                                                                        = \
     $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")

--- a/examples/platforms/nrf528xx/nrf52833/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52833/Makefile.am
@@ -154,13 +154,13 @@ libopenthread_nrf52833_softdevice_sdk_a_SOURCES                                 
 Dash                                                                                                       = -
 
 libopenthread_nrf52833_a_LIBADD                                                                            = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")                   \
-    $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")
+    $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")      \
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 libopenthread_nrf52833_sdk_a_LIBADD                                                                        = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 libopenthread_nrf52833_softdevice_sdk_a_LIBADD                                                             = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/nrf528xx/nrf52833/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52833/Makefile.am
@@ -155,12 +155,12 @@ Dash                                                                            
 
 libopenthread_nrf52833_a_LIBADD                                                                            = \
     $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")      \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 libopenthread_nrf52833_sdk_a_LIBADD                                                                        = \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 libopenthread_nrf52833_softdevice_sdk_a_LIBADD                                                             = \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/nrf528xx/nrf52840/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52840/Makefile.am
@@ -157,12 +157,12 @@ Dash                                                                            
 
 libopenthread_nrf52840_a_LIBADD                                                                            = \
     $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")      \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 libopenthread_nrf52840_sdk_a_LIBADD                                                                        = \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 libopenthread_nrf52840_softdevice_sdk_a_LIBADD                                                             = \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/nrf528xx/nrf52840/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52840/Makefile.am
@@ -157,12 +157,12 @@ Dash                                                                            
 
 libopenthread_nrf52840_a_LIBADD                                                                            = \
     $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")                   \
-    $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 libopenthread_nrf52840_sdk_a_LIBADD                                                                        = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 libopenthread_nrf52840_softdevice_sdk_a_LIBADD                                                             = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/nrf528xx/nrf52840/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52840/Makefile.am
@@ -156,7 +156,7 @@ libopenthread_nrf52840_softdevice_sdk_a_SOURCES                                 
 Dash                                                                                                       = -
 
 libopenthread_nrf52840_a_LIBADD                                                                            = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")                   \
+    $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")      \
     $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 libopenthread_nrf52840_sdk_a_LIBADD                                                                        = \

--- a/examples/platforms/posix/Makefile.am
+++ b/examples/platforms/posix/Makefile.am
@@ -63,7 +63,7 @@ PRETTY_FILES                              = \
     $(NULL)
 
 libopenthread_posix_a_LIBADD              = \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 if OPENTHREAD_BUILD_COVERAGE
 libopenthread_posix_a_CPPFLAGS           += \

--- a/examples/platforms/posix/Makefile.am
+++ b/examples/platforms/posix/Makefile.am
@@ -62,9 +62,8 @@ PRETTY_FILES                              = \
     $(PLATFORM_SOURCES)                     \
     $(NULL)
 
-Dash                                      = -
 libopenthread_posix_a_LIBADD              = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 if OPENTHREAD_BUILD_COVERAGE
 libopenthread_posix_a_CPPFLAGS           += \

--- a/examples/platforms/samr21/Makefile.am
+++ b/examples/platforms/samr21/Makefile.am
@@ -141,8 +141,7 @@ PRETTY_FILES                                                                    
     $(PLATFORM_SOURCES)                                                                                        \
     $(NULL)
 
-Dash                                                                                                         = -
 libopenthread_samr21_a_LIBADD                                                                                = \
-    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/samr21/Makefile.am
+++ b/examples/platforms/samr21/Makefile.am
@@ -142,6 +142,6 @@ PRETTY_FILES                                                                    
     $(NULL)
 
 libopenthread_samr21_a_LIBADD                                                                                = \
-    $(addprefix $(top_builddir)/examples/platforms/utils/,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a))
+    $(addprefix $(top_builddir)/examples/platforms/utils/,$(filter %.o,$(shell $(AR) t $(top_builddir)/examples/platforms/utils/libopenthread-platform-utils.a)))
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/utils/Makefile.am
+++ b/examples/platforms/utils/Makefile.am
@@ -52,4 +52,21 @@ libopenthread_platform_utils_a_SOURCES  = \
     soft_source_match_table.h             \
     $(NULL)
 
+check_PROGRAMS = test-settings-flash
+
+test_settings_flash_SOURCES = \
+    settings_flash.c          \
+    $(NULL)
+
+test_settings_flash_CPPFLAGS           = \
+    -I$(top_srcdir)/include              \
+    -I$(top_srcdir)/examples/platforms   \
+    -I$(top_srcdir)/src/core             \
+    -DSELF_TEST=1                        \
+    $(NULL)
+
+TESTS                        = \
+    test-settings-flash        \
+    $(NULL)
+
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/utils/settings_flash.c
+++ b/examples/platforms/utils/settings_flash.c
@@ -437,12 +437,42 @@ void TestSwapBlock(void)
     otPlatSettingsDeinit(NULL);
 }
 
+// This test verifies read smaller than saved length
+void TestReadSmaller(void)
+{
+    const uint16_t kTestKey = 1;
+    otError        error;
+
+    uint8_t  value[] = {1, 2, 3, 4};
+    uint16_t len     = sizeof(value) / 2;
+
+    otPlatSettingsInit(NULL);
+
+    error = otPlatSettingsSet(NULL, kTestKey, value, sizeof(value));
+    assert(error == OT_ERROR_NONE);
+
+    memset(value, 0, sizeof(value));
+
+    error = otPlatSettingsGet(NULL, kTestKey, 0, value, &len);
+    assert(error == OT_ERROR_NONE);
+
+    assert(value[0] == 1);
+    assert(value[1] == 2);
+    assert(value[2] == 0);
+    assert(value[3] == 0);
+
+    otPlatSettingsDeinit(NULL);
+}
+
 int main()
 {
     TestSwapBlock();
 
+    TestReadSmaller();
+
     return 0;
 }
+
 #endif // SELF_TEST
 
 #endif /* OPENTHREAD_SETTINGS_RAM */

--- a/examples/platforms/utils/settings_flash.c
+++ b/examples/platforms/utils/settings_flash.c
@@ -406,7 +406,7 @@ void otPlatSettingsWipe(otInstance *aInstance)
     otPlatSettingsInit(aInstance);
 }
 
-#if SELF_TEST
+#if defined(SELF_TEST) && SELF_TEST
 uint32_t gNodeId = 1;
 
 #include "posix/flash.c"


### PR DESCRIPTION
This PR adds a self test to cover swapping block functionality. Since
find will include the `.o` file generated by the unittest program, how
the platform library find objects of the utils library is also updated.