### PR TITLE
[meshcop] fix commissioner's invalid call to SetState

### DIFF
--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -64,7 +64,7 @@ otError otCommissionerStop(otInstance *aInstance)
     otError   error;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    SuccessOrExit(error = instance.Get<MeshCoP::Commissioner>().Stop());
+    SuccessOrExit(error = instance.Get<MeshCoP::Commissioner>().Stop(/* aResign */ true));
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
     SuccessOrExit(error = instance.Get<MeshCoP::BorderAgent>().Start());
 #endif

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -730,8 +730,6 @@ void Commissioner::HandleLeaderPetitionResponse(Coap::Message *         aMessage
         ExitNow();
     }
 
-    mSessionId = sessionId.GetCommissionerSessionId();
-
     Get<Mle::MleRouter>().GetCommissionerAloc(mCommissionerAloc.GetAddress(), mSessionId);
     Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc);
 
@@ -763,11 +761,9 @@ otError Commissioner::SendKeepAlive(void)
 
 otError Commissioner::SendKeepAlive(uint16_t aSessionId)
 {
-    otError                  error   = OT_ERROR_NONE;
-    Coap::Message *          message = NULL;
-    Ip6::MessageInfo         messageInfo;
-    StateTlv                 state;
-    CommissionerSessionIdTlv sessionId;
+    otError          error   = OT_ERROR_NONE;
+    Coap::Message *  message = NULL;
+    Ip6::MessageInfo messageInfo;
 
     VerifyOrExit((message = NewMeshCoPMessage(Get<Coap::Coap>())) != NULL, error = OT_ERROR_NO_BUFS);
 
@@ -778,7 +774,7 @@ otError Commissioner::SendKeepAlive(uint16_t aSessionId)
         error = Tlv::AppendUint8Tlv(*message, Tlv::kState,
                                     (mState == OT_COMMISSIONER_STATE_ACTIVE) ? StateTlv::kAccept : StateTlv::kReject));
 
-    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, Tlv::kCommissionerSessionId, mSessionId));
+    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, Tlv::kCommissionerSessionId, aSessionId));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     SuccessOrExit(error = Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr()));

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -84,11 +84,13 @@ public:
     /**
      * This method stops the Commissioner service.
      *
+     * @param[in]  aResign      Whether send LEAD_KA.req to resign as Commissioner
+     *
      * @retval OT_ERROR_NONE           Successfully stopped the Commissioner service.
      * @retval OT_ERROR_INVALID_STATE  Commissioner is already stopped.
      *
      */
-    otError Stop(void);
+    otError Stop(bool aResign);
 
     /**
      * This method clears all Joiner entries.
@@ -320,6 +322,7 @@ private:
     otError SendCommissionerSet(void);
     otError SendPetition(void);
     otError SendKeepAlive(void);
+    otError SendKeepAlive(uint16_t aSessionId);
 
     void SetState(otCommissionerState aState);
     void SignalJoinerEvent(otCommissionerJoinerEvent aEvent, const Mac::ExtAddress &aJoinerId);


### PR DESCRIPTION
Commissioner should not call `SetState(OT_COMMISSIONER_STATE_DISABLED)` directly, rather it should call `Stop()` so that joiners and resources are cleaned up.

This PR ...
 - Fixes this issue
 - Adds argument name `/* aResign */` to Stop() calls
 - Ignores petition/keep-alive response if commissioner is not in PETITION/ACTIVE state
 - Calls `CoapSecure::Stop` when `Start` failed (suggested by @bukepo )
 - Responds to `Leader Petition Response (accept)` by sending `KeepAlive(reject)` if commissioner is in disabled state 