### PR TITLE
[build] Support building platform code without examples

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -822,20 +822,27 @@ AM_CONDITIONAL([OPENTHREAD_ENABLE_CUSTOM_LINKER_FILE], [test "${with_custom_link
 # Examples
 #
 
+AC_MSG_CHECKING([whether to build examples])
+
 AC_ARG_WITH(examples,
     [AS_HELP_STRING([--with-examples=TARGET],
-        [Specify the examples from one of: no, posix, cc1352, cc2538, cc2650, cc2652, efr32mg12, efr32mg21, gp712, kw41z, nrf52811, nrf52833, nrf52840, qpg6095, samr21 @<:@default=no@:>@.])],
+        [Build example applications for one of: posix, cc1352, cc2538, cc2650, cc2652, efr32mg12, efr32mg21,
+         gp712, kw41z, nrf52811, nrf52833, nrf52840, qpg6095, samr21 @<:@default=no@:>@.
+         Note that building example applications also builds the associated OpenThread platform libraries 
+         and any third_party libraries needed to support the examples.])],
     [
         case "${with_examples}" in
         no)
             ;;
         posix|cc1352|cc2538|cc2650|cc2652|efr32mg12|efr32mg21|gp712|kw41z|nrf52811|nrf52833|nrf52840|qpg6095|samr21)
             if test ${enable_posix_app} = "yes"; then
+                AC_MSG_RESULT(ERROR)
                 AC_MSG_ERROR([--with-examples must be no when POSIX apps are enabled by --enable-posix-app])
             fi
             ;;
         *)
-            AC_MSG_ERROR([Invalid value ${with_examples} for --with-examples])
+            AC_MSG_RESULT(ERROR)
+            AC_MSG_ERROR([Invalid value given for --with-examples: ${with_examples}])
             ;;
         esac
     ],
@@ -860,10 +867,87 @@ AM_CONDITIONAL([OPENTHREAD_EXAMPLES_SAMR21],    [test "${with_examples}" = "samr
 
 AM_COND_IF([OPENTHREAD_EXAMPLES_POSIX], CPPFLAGS="${CPPFLAGS} -DOPENTHREAD_EXAMPLES_POSIX=1", CPPFLAGS="${CPPFLAGS} -DOPENTHREAD_EXAMPLES_POSIX=0")
 
-AC_MSG_CHECKING([whether to enable examples])
-AC_MSG_RESULT(${with_examples})
-
 AM_CONDITIONAL([OPENTHREAD_EXAMPLES_NRF528XX], [test OPENTHREAD_EXAMPLES_NRF52811 || test OPENTHREAD_EXAMPLES_NRF52833 || test OPENTHREAD_EXAMPLES_NRF52840])
+
+case ${with_examples} in
+    no)
+        AC_MSG_RESULT([no])
+        ;;
+    *)
+        AC_MSG_RESULT([yes (${with_examples})])
+        ;;
+esac
+
+#
+# Platform
+#
+
+AC_MSG_CHECKING([whether to build platform libraries])
+
+AC_ARG_WITH(platform,
+    [AS_HELP_STRING([--with-platform=TARGET],
+        [Build OpenThread platform libraries for one of: posix, cc1352, cc2538, cc2650, cc2652,
+         efr32mg12, efr32mg21, gp712, kw41z, nrf52811, nrf52833, nrf52840, qpg6095, samr21 @<:@default=no@:>@.])],
+    [
+        # Make sure the given target is valid.
+        case "${with_platform}" in
+        no|posix|cc1352|cc2538|cc2650|cc2652|efr32mg12|efr32mg21|gp712|kw41z|nrf52811|nrf52833|nrf52840|qpg6095|samr21)
+            ;;
+        *)
+            AC_MSG_RESULT(ERROR)
+            AC_MSG_ERROR([Invalid value given for --with-platform: ${with_platform}])
+            ;;
+        esac
+
+        # If both --with-platform and --with-examples are specified, make sure the targets match.
+        case "${with_examples}" in
+        no)
+            ;;
+        ${with_platform})
+            ;;
+        *)
+            AC_MSG_RESULT(ERROR)
+            AC_MSG_ERROR([Invalid value given for --with-platform: The targets for --with-examples and --with-platform must match.])
+            ;;
+        esac
+
+    ],
+    [
+        # If --with-platform is NOT specified, but --with-examples is, automatically build the
+        # corresponding platform libraries. (Essentially, --with-examples implies --with-platform).
+        with_platform=${with_examples}
+    ])
+
+AM_CONDITIONAL([OPENTHREAD_ENABLE_PLATFORM], [test ${with_platform} != "no"])
+
+OPENTHREAD_ENABLE_PLATFORM=${with_platform}
+
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_POSIX],     [test "${with_platform}" = "posix"])
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_CC1352],    [test "${with_platform}" = "cc1352"])
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_CC2538],    [test "${with_platform}" = "cc2538"])
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_CC2650],    [test "${with_platform}" = "cc2650"])
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_CC2652],    [test "${with_platform}" = "cc2652"])
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_EFR32MG12], [test "${with_platform}" = "efr32mg12"])
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_EFR32MG21], [test "${with_platform}" = "efr32mg21"])
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_GP712],     [test "${with_platform}" = "gp712"])
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_KW41Z],     [test "${with_platform}" = "kw41z"])
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_NRF52811],  [test "${with_platform}" = "nrf52811"])
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_NRF52833],  [test "${with_platform}" = "nrf52833"])
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_NRF52840],  [test "${with_platform}" = "nrf52840"])
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_QPG6095],   [test "${with_platform}" = "qpg6095"])
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_SAMR21],    [test "${with_platform}" = "samr21"])
+
+AM_CONDITIONAL([OPENTHREAD_PLATFORM_NRF528XX], [test OPENTHREAD_PLATFORM_NRF52811 || test OPENTHREAD_PLATFORM_NRF52833 || test OPENTHREAD_PLATFORM_NRF52840])
+
+case ${with_platform} in
+    no)
+        AC_MSG_RESULT([no])
+        ;;
+    *)
+        AC_MSG_RESULT([yes (${with_platform})])
+        ;;
+esac
+
 #
 # Tools
 #
@@ -1086,6 +1170,7 @@ AC_MSG_NOTICE([
   OpenThread Vendor Extension Source        : ${with_vendor_extension}
   OpenThread builtin mbedtls support        : ${enable_builtin_mbedtls}
   OpenThread Examples                       : ${with_examples}
+  OpenThread Platform Libraries             : ${with_platform}
   OpenThread POSIX Application              : ${enable_posix_app}
 
 ])

--- a/examples/platforms/Makefile.am
+++ b/examples/platforms/Makefile.am
@@ -52,51 +52,51 @@ SUBDIRS                                 = \
     utils                                 \
     $(NULL)
 
-if OPENTHREAD_EXAMPLES_CC1352
+if OPENTHREAD_PLATFORM_CC1352
 SUBDIRS                                += cc1352
 endif
 
-if OPENTHREAD_EXAMPLES_CC2538
+if OPENTHREAD_PLATFORM_CC2538
 SUBDIRS                                += cc2538
 endif
 
-if OPENTHREAD_EXAMPLES_CC2650
+if OPENTHREAD_PLATFORM_CC2650
 SUBDIRS                                += cc2650
 endif
 
-if OPENTHREAD_EXAMPLES_CC2652
+if OPENTHREAD_PLATFORM_CC2652
 SUBDIRS                                += cc2652
 endif
 
-if OPENTHREAD_EXAMPLES_EFR32MG12
+if OPENTHREAD_PLATFORM_EFR32MG12
 SUBDIRS                                += efr32mg12
 endif
 
-if OPENTHREAD_EXAMPLES_EFR32MG21
+if OPENTHREAD_PLATFORM_EFR32MG21
 SUBDIRS                                += efr32mg21
 endif
 
-if OPENTHREAD_EXAMPLES_GP712
+if OPENTHREAD_PLATFORM_GP712
 SUBDIRS                                += gp712
 endif
 
-if OPENTHREAD_EXAMPLES_KW41Z
+if OPENTHREAD_PLATFORM_KW41Z
 SUBDIRS                                += kw41z
 endif
 
-if OPENTHREAD_EXAMPLES_NRF528XX
+if OPENTHREAD_PLATFORM_NRF528XX
 SUBDIRS                                += nrf528xx
 endif
 
-if OPENTHREAD_EXAMPLES_POSIX
+if OPENTHREAD_PLATFORM_POSIX
 SUBDIRS                                += posix
 endif
 
-if OPENTHREAD_EXAMPLES_QPG6095
+if OPENTHREAD_PLATFORM_QPG6095
 SUBDIRS                                += qpg6095
 endif
 
-if OPENTHREAD_EXAMPLES_SAMR21
+if OPENTHREAD_PLATFORM_SAMR21
 SUBDIRS                                += samr21
 endif
 

--- a/examples/platforms/nrf528xx/Makefile.am
+++ b/examples/platforms/nrf528xx/Makefile.am
@@ -31,15 +31,15 @@
 # created only once which leads to errors when auto-generated Makefile tries
 # to remove .Po files that were already removed
 
-if OPENTHREAD_EXAMPLES_NRF52811
+if OPENTHREAD_PLATFORM_NRF52811
 include nrf52811/Makefile.am
 endif
 
-if OPENTHREAD_EXAMPLES_NRF52833
+if OPENTHREAD_PLATFORM_NRF52833
 include nrf52833/Makefile.am
 endif
 
-if OPENTHREAD_EXAMPLES_NRF52840
+if OPENTHREAD_PLATFORM_NRF52840
 include nrf52840/Makefile.am
 endif
 

--- a/examples/platforms/nrf528xx/nrf52811/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52811/Makefile.am
@@ -49,11 +49,6 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/examples/platforms                                                                       \
     -I$(top_srcdir)/examples/platforms/nrf528xx/src                                                          \
     -I$(top_srcdir)/src/core                                                                                 \
-    -I$(top_srcdir)/third_party/NordicSemiconductor                                                          \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/cmsis                                                    \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/dependencies                                             \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/clock                                            \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/common                                           \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio                                            \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/hal                                        \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features                               \
@@ -61,6 +56,25 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features/ack_generator                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch                                       \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal                                  \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/lp_timer                          \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/temperature                       \
+    $(NULL)
+
+# Only reference the SDK header files included in third_party/NordicSemiconductor
+# when building the example applications.
+#
+# When building just the platform libraries, the caller of configure is expected
+# to provide the correct -I arguments to locate the necessary header files in an
+# external copy of the Nordic nRF5 SDK.
+#
+# Note that an exception is made for the 802.15.4 radio driver, which is always
+# built using the sources in third_party/NordicSemiconductor/drivers/radio.
+if OPENTHREAD_ENABLE_EXAMPLES
+COMMONCPPFLAGS                                                                                            += \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/cmsis                                                    \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/dependencies                                             \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/clock                                            \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/common                                           \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/power                                            \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/systick                                          \
     -I$(top_srcdir)/third_party/NordicSemiconductor/libraries/app_error                                      \
@@ -76,6 +90,7 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk                                                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/soc                                                 \
     $(NULL)
+endif
 
 PLATFORM_COMMON_SOURCES                                                                                    = \
     src/alarm.c                                                                                              \

--- a/examples/platforms/nrf528xx/nrf52811/platform-config.h
+++ b/examples/platforms/nrf528xx/nrf52811/platform-config.h
@@ -37,7 +37,7 @@
 
 #include "nrf.h"
 #include "nrf_peripherals.h"
-#include "drivers/clock/nrf_drv_clock.h"
+#include "nrf_drv_clock.h"
 #include "hal/nrf_radio.h"
 #include "hal/nrf_uart.h"
 

--- a/examples/platforms/nrf528xx/nrf52833/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52833/Makefile.am
@@ -50,11 +50,6 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/examples/platforms                                                                       \
     -I$(top_srcdir)/examples/platforms/nrf528xx/src                                                          \
     -I$(top_srcdir)/src/core                                                                                 \
-    -I$(top_srcdir)/third_party/NordicSemiconductor                                                          \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/cmsis                                                    \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/dependencies                                             \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/clock                                            \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/common                                           \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio                                            \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/fem/three_pin_gpio                         \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/hal                                        \
@@ -62,6 +57,25 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features/ack_generator                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch                                       \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal                                  \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/lp_timer                          \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/temperature                       \
+    $(NULL)
+
+# Only reference the SDK header files included in third_party/NordicSemiconductor
+# when building the example applications.
+#
+# When building just the platform libraries, the caller of configure is expected
+# to provide the correct -I arguments to locate the necessary header files in an
+# external copy of the Nordic nRF5 SDK.
+#
+# Note that an exception is made for the 802.15.4 radio driver, which is always
+# built using the sources in third_party/NordicSemiconductor/drivers/radio.
+if OPENTHREAD_ENABLE_EXAMPLES
+COMMONCPPFLAGS                                                                                            += \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/cmsis                                                    \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/dependencies                                             \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/clock                                            \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/common                                           \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/power                                            \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/systick                                          \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/usbd                                             \
@@ -84,6 +98,7 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers                                  \
     -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf52                            \
     $(NULL)
+endif
 
 PLATFORM_COMMON_SOURCES                                                                                    = \
     src/alarm.c                                                                                              \

--- a/examples/platforms/nrf528xx/nrf52833/platform-config.h
+++ b/examples/platforms/nrf528xx/nrf52833/platform-config.h
@@ -37,7 +37,7 @@
 
 #include "nrf.h"
 #include "nrf_peripherals.h"
-#include "drivers/clock/nrf_drv_clock.h"
+#include "nrf_drv_clock.h"
 #include "hal/nrf_radio.h"
 #include "hal/nrf_uart.h"
 

--- a/examples/platforms/nrf528xx/nrf52840/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52840/Makefile.am
@@ -50,11 +50,6 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/examples/platforms                                                                       \
     -I$(top_srcdir)/examples/platforms/nrf528xx/src                                                          \
     -I$(top_srcdir)/src/core                                                                                 \
-    -I$(top_srcdir)/third_party/NordicSemiconductor                                                          \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/cmsis                                                    \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/dependencies                                             \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/clock                                            \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/common                                           \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio                                            \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/fem/three_pin_gpio                         \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/hal                                        \
@@ -62,6 +57,25 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features/ack_generator                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch                                       \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal                                  \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/lp_timer                          \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/temperature                       \
+    $(NULL)
+
+# Only reference the SDK header files included in third_party/NordicSemiconductor
+# when building the example applications.
+#
+# When building just the platform libraries, the caller of configure is expected
+# to provide the correct -I arguments to locate the necessary header files in an
+# external copy of the Nordic nRF5 SDK.
+#
+# Note that an exception is made for the 802.15.4 radio driver, which is always
+# built using the sources in third_party/NordicSemiconductor/drivers/radio.
+if OPENTHREAD_ENABLE_EXAMPLES
+COMMONCPPFLAGS                                                                                            += \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/cmsis                                                    \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/dependencies                                             \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/clock                                            \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/common                                           \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/power                                            \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/systick                                          \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/usbd                                             \
@@ -84,6 +98,7 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers                                  \
     -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf52                            \
     $(NULL)
+endif
 
 PLATFORM_COMMON_SOURCES                                                                                    = \
     src/alarm.c                                                                                              \

--- a/examples/platforms/nrf528xx/nrf52840/platform-config.h
+++ b/examples/platforms/nrf528xx/nrf52840/platform-config.h
@@ -37,7 +37,7 @@
 
 #include "nrf.h"
 #include "nrf_peripherals.h"
-#include "drivers/clock/nrf_drv_clock.h"
+#include "nrf_drv_clock.h"
 #include "hal/nrf_radio.h"
 #include "hal/nrf_uart.h"
 

--- a/examples/platforms/nrf528xx/src/alarm.c
+++ b/examples/platforms/nrf528xx/src/alarm.c
@@ -49,11 +49,11 @@
 
 #include "platform-config.h"
 #include "platform-nrf5.h"
-#include "cmsis/core_cmFunc.h"
+#include "core_cmFunc.h"
 
-#include <drivers/clock/nrf_drv_clock.h>
-#include <drivers/radio/nrf_802154_utils.h>
-#include <drivers/radio/platform/lp_timer/nrf_802154_lp_timer.h>
+#include <nrf_drv_clock.h>
+#include <nrf_802154_utils.h>
+#include <nrf_802154_lp_timer.h>
 
 #include <hal/nrf_rtc.h>
 

--- a/examples/platforms/nrf528xx/src/diag.c
+++ b/examples/platforms/nrf528xx/src/diag.c
@@ -46,7 +46,7 @@
 #include <openthread/platform/toolchain.h>
 
 #include <common/logging.hpp>
-#include <drivers/radio/nrf_802154.h>
+#include <nrf_802154.h>
 #include <utils/code_utils.h>
 
 typedef enum

--- a/examples/platforms/nrf528xx/src/system.c
+++ b/examples/platforms/nrf528xx/src/system.c
@@ -40,7 +40,7 @@
 #include "openthread-system.h"
 #include "platform-fem.h"
 #include "platform-nrf5.h"
-#include <drivers/clock/nrf_drv_clock.h>
+#include <nrf_drv_clock.h>
 #include <nrf.h>
 
 #include <openthread/config.h>

--- a/examples/platforms/nrf528xx/src/temp.c
+++ b/examples/platforms/nrf528xx/src/temp.c
@@ -34,7 +34,7 @@
 #include <utils/code_utils.h>
 
 #include "platform-nrf5.h"
-#include <drivers/radio/platform/temperature/nrf_802154_temperature.h>
+#include <nrf_802154_temperature.h>
 
 #if SOFTDEVICE_PRESENT
 #include "softdevice.h"

--- a/examples/platforms/nrf528xx/src/uart.c
+++ b/examples/platforms/nrf528xx/src/uart.c
@@ -45,7 +45,7 @@
 #include "openthread-system.h"
 
 #include "platform-nrf5.h"
-#include <drivers/clock/nrf_drv_clock.h>
+#include <nrf_drv_clock.h>
 #include <hal/nrf_gpio.h>
 #include <hal/nrf_uart.h>
 

--- a/examples/platforms/nrf528xx/src/usb-cdc-uart.c
+++ b/examples/platforms/nrf528xx/src/usb-cdc-uart.c
@@ -53,12 +53,12 @@
 
 #include "platform-nrf5.h"
 
-#include "drivers/clock/nrf_drv_clock.h"
-#include "drivers/power/nrf_drv_power.h"
-#include "libraries/usb/app_usbd.h"
-#include "libraries/usb/app_usbd_serial_num.h"
-#include "libraries/usb/class/cdc/acm/app_usbd_cdc_acm.h"
-#include "libraries/usb/nrf_dfu_trigger_usb.h"
+#include "nrf_drv_clock.h"
+#include "nrf_drv_power.h"
+#include "app_usbd.h"
+#include "app_usbd_serial_num.h"
+#include "class/cdc/acm/app_usbd_cdc_acm.h"
+#include "nrf_dfu_trigger_usb.h"
 
 #if (USB_CDC_AS_SERIAL_TRANSPORT == 1)
 

--- a/third_party/Makefile.am
+++ b/third_party/Makefile.am
@@ -45,38 +45,29 @@ DIST_SUBDIRS                            = \
 
 SUBDIRS =
 
-if OPENTHREAD_EXAMPLES_EFR32MG12
+if OPENTHREAD_PLATFORM_EFR32MG12
 SUBDIRS                                += \
     silabs                                \
     jlink                                 \
     $(NULL)
 endif
 
-if OPENTHREAD_EXAMPLES_EFR32MG21
+if OPENTHREAD_PLATFORM_EFR32MG21
 SUBDIRS                                += \
     silabs                                \
     jlink                                 \
     $(NULL)
 endif
 
-if OPENTHREAD_EXAMPLES_NRF52840
+if OPENTHREAD_PLATFORM_NRF528XX
 SUBDIRS                                += \
-    jlink                                 \
     NordicSemiconductor                   \
     $(NULL)
 endif
 
-if OPENTHREAD_EXAMPLES_NRF52833
+if OPENTHREAD_EXAMPLES_NRF528XX
 SUBDIRS                                += \
     jlink                                 \
-    NordicSemiconductor                   \
-    $(NULL)
-endif
-
-if OPENTHREAD_EXAMPLES_NRF52811
-SUBDIRS                                += \
-    jlink                                 \
-    NordicSemiconductor                   \
     $(NULL)
 endif
 

--- a/third_party/NordicSemiconductor/Makefile.am
+++ b/third_party/NordicSemiconductor/Makefile.am
@@ -28,26 +28,43 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
-if OPENTHREAD_EXAMPLES_NRF52811
+
 lib_LIBRARIES                                                                                                           = \
-    libnordicsemi-nrf52811-sdk.a                                                                                          \
+    $(NULL)
+
+# Build radio drivers when building platform libraries.
+if OPENTHREAD_PLATFORM_NRF52811
+lib_LIBRARIES                                                                                                          += \
     libnordicsemi-nrf52811-radio-driver.a                                                                                 \
     $(NULL)
 endif
-
-if OPENTHREAD_EXAMPLES_NRF52840
-lib_LIBRARIES                                                                                                           = \
-    libnordicsemi-nrf52840-sdk.a                                                                                          \
+if OPENTHREAD_PLATFORM_NRF52840
+lib_LIBRARIES                                                                                                          += \
     libnordicsemi-nrf52840-radio-driver.a                                                                                 \
     libnordicsemi-nrf52840-radio-driver-softdevice.a                                                                      \
     $(NULL)
 endif
-
-if OPENTHREAD_EXAMPLES_NRF52833
-lib_LIBRARIES                                                                                                           = \
-    libnordicsemi-nrf52833-sdk.a                                                                                          \
+if OPENTHREAD_PLATFORM_NRF52833
+lib_LIBRARIES                                                                                                          += \
     libnordicsemi-nrf52833-radio-driver.a                                                                                 \
     libnordicsemi-nrf52833-radio-driver-softdevice.a                                                                      \
+    $(NULL)
+endif
+
+# Only build the SDK library when building the example applications.
+if OPENTHREAD_EXAMPLES_NRF52811
+lib_LIBRARIES                                                                                                          += \
+    libnordicsemi-nrf52811-sdk.a                                                                                          \
+    $(NULL)
+endif
+if OPENTHREAD_EXAMPLES_NRF52840
+lib_LIBRARIES                                                                                                          += \
+    libnordicsemi-nrf52840-sdk.a                                                                                          \
+    $(NULL)
+endif
+if OPENTHREAD_EXAMPLES_NRF52833
+lib_LIBRARIES                                                                                                          += \
+    libnordicsemi-nrf52833-sdk.a                                                                                          \
     $(NULL)
 endif
 
@@ -65,11 +82,6 @@ COMMONCPPFLAGS                                                                  
     -I$(srcdir)                                                                                                           \
     -I$(top_srcdir)/include                                                                                               \
     -I$(top_srcdir)/src/core                                                                                              \
-    -I$(top_srcdir)/third_party/NordicSemiconductor                                                                       \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/cmsis                                                                 \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/dependencies                                                          \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/clock                                                         \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/common                                                        \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio                                                         \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/fem                                                     \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/fem/three_pin_gpio                                      \
@@ -79,6 +91,23 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal/softdevice                                    \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features                                            \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features/ack_generator                              \
+    $(NULL)
+
+# Only reference the SDK header files included in third_party/NordicSemiconductor
+# when building the example applications.
+#
+# When building just the platform libraries, the caller of configure is expected
+# to provide the correct -I arguments to locate the necessary header files in an
+# external copy of the Nordic nRF5 SDK.
+#
+# Note that an exception is made for the 802.15.4 radio driver, which is always built
+# using the sources in third_party/NordicSemiconductor/drivers/radio.
+if OPENTHREAD_ENABLE_EXAMPLES
+COMMONCPPFLAGS                                                                                                         += \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/cmsis                                                                 \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/dependencies                                                          \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/clock                                                         \
+    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/common                                                        \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/power                                                         \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/systick                                                       \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/usbd                                                          \
@@ -101,6 +130,7 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers                                               \
     -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf52                                         \
     $(NULL)
+endif
 
 NRF52833_CPPFLAGS                                                                                                       = \
     -DNRF52833_XXAA                                                                                                       \


### PR DESCRIPTION
- [build] Added --with-platform configure option to enable building the platform libraries
without building the example applications or any supporting libraries used solely by the
examples.

- [nrf528xx] Modified the nrf528xx-specific makefiles such that Nordic SDK code located in
third_party/NordicSemiconductor is only built/referenced when building the example
applications.  When building just the platform libraries, the caller of configure is
expected to provide the correct arguments to use an external copy of the Nordic nRF5 SDK.
An exception to this is the 802.15.4 radio driver, which is always built using the sources
in third_party/NordicSemiconductor/drivers/radio.

- [nrf528xx] Made various minor edits to #include statements in the nrf528xx platform code.
This was necessary because of the difference in directory structure between the code in
third_party/NordicSemiconductor and that in the formally published Nordic nRF5 SDK.