### PR TITLE
[settings] zero out any trailing bytes in buffer

### DIFF
--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -143,6 +143,7 @@ otError Settings::ReadNetworkInfo(NetworkInfo &aNetworkInfo) const
 {
     otError error;
 
+    aNetworkInfo.Init();
     SuccessOrExit(error = ReadFixedSize(kKeyNetworkInfo, &aNetworkInfo, sizeof(NetworkInfo)));
     LogNetworkInfo("Read", aNetworkInfo);
 
@@ -186,6 +187,7 @@ otError Settings::ReadParentInfo(ParentInfo &aParentInfo) const
 {
     otError error;
 
+    aParentInfo.Init();
     SuccessOrExit(error = ReadFixedSize(kKeyParentInfo, &aParentInfo, sizeof(ParentInfo)));
     LogParentInfo("Read", aParentInfo);
 
@@ -291,6 +293,7 @@ void Settings::ChildInfoIterator::Read(void)
     uint16_t size = sizeof(ChildInfo);
     otError  error;
 
+    mChildInfo.Init();
     SuccessOrExit(error = otPlatSettingsGet(&GetInstance(), kKeyChildInfo, mIndex,
                                             reinterpret_cast<uint8_t *>(&mChildInfo), &size));
     VerifyOrExit(size >= sizeof(ChildInfo), error = OT_ERROR_NOT_FOUND);

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -584,7 +584,9 @@ public:
      */
     otError ReadSlaacIidSecretKey(Utils::Slaac::IidSecretKey &aKey)
     {
-        return ReadFixedSize(kKeySlaacIidSecretKey, &aKey, sizeof(Utils::Slaac::IidSecretKey));
+        uint16_t length = sizeof(aKey);
+
+        return Read(kKeySlaacIidSecretKey, &aKey, length);
     }
 
     /**
@@ -703,8 +705,7 @@ public:
     };
 
 private:
-    otError ReadFixedSize(Key aKey, void *aBuffer, uint16_t aExpectedSize) const;
-    otError Read(Key aKey, void *aBuffer, uint16_t aMaxBufferSize, uint16_t &aReadSize) const;
+    otError Read(Key aKey, void *aBuffer, uint16_t &aSize) const;
     otError Save(Key aKey, const void *aValue, uint16_t aSize);
     otError Add(Key aKey, const void *aValue, uint16_t aSize);
     otError Delete(Key aKey);

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -92,7 +92,7 @@ public:
          * This method clears the struct object (setting all the fields to zero).
          *
          */
-        void Clear(void) { memset(this, 0, sizeof(*this)); }
+        void Init(void) { memset(this, 0, sizeof(*this)); }
 
         /**
          * This method returns the Thread role.
@@ -271,7 +271,7 @@ public:
          * This method clears the struct object (setting all the fields to zero).
          *
          */
-        void Clear(void) { memset(this, 0, sizeof(*this)); }
+        void Init(void) { memset(this, 0, sizeof(*this)); }
 
         /**
          * This method returns the extended address.
@@ -305,7 +305,7 @@ public:
          * This method clears the struct object (setting all the fields to zero).
          *
          */
-        void Clear(void) { memset(this, 0, sizeof(*this)); }
+        void Init(void) { memset(this, 0, sizeof(*this)); }
 
         /**
          * This method returns the extended address.

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -55,7 +55,7 @@ public:
     enum
     {
         kMaxSize      = 256, ///< Maximum size of MeshCoP Dataset (bytes)
-        kMaxValueSize = 16,  /// < Maximum size of each Dataset TLV value (bytes)
+        kMaxValueSize = 16,  ///< Maximum size of each Dataset TLV value (bytes)
     };
 
     /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -446,7 +446,7 @@ otError Mle::Store(void)
     otError               error = OT_ERROR_NONE;
     Settings::NetworkInfo networkInfo;
 
-    networkInfo.Clear();
+    networkInfo.Init();
 
     if (IsAttached())
     {
@@ -464,7 +464,7 @@ otError Mle::Store(void)
         {
             Settings::ParentInfo parentInfo;
 
-            parentInfo.Clear();
+            parentInfo.Init();
             parentInfo.SetExtAddress(mParent.GetExtAddress());
 
             SuccessOrExit(error = Get<Settings>().SaveParentInfo(parentInfo));

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3617,7 +3617,7 @@ otError MleRouter::StoreChild(const Child &aChild)
 
     IgnoreReturnValue(RemoveStoredChild(aChild.GetRloc16()));
 
-    childInfo.Clear();
+    childInfo.Init();
     childInfo.SetExtAddress(aChild.GetExtAddress());
     childInfo.SetTimeout(aChild.GetTimeout());
     childInfo.SetRloc16(aChild.GetRloc16());


### PR DESCRIPTION
If the setting value read from non-volatile is smaller than the
expected size, make sure to zero out the remainder of the buffer to
ensure that the additional fields are initialized.