### PR TITLE
[posix-host] add otPlatRadioGetState()

### DIFF
--- a/examples/platforms/posix/radio.c
+++ b/examples/platforms/posix/radio.c
@@ -826,6 +826,13 @@ int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
     return POSIX_RECEIVE_SENSITIVITY;
 }
 
+otRadioState otPlatRadioGetState(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return sState;
+}
+
 #if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
 otError otPlatRadioSetCoexEnabled(otInstance *aInstance, bool aEnabled)
 {

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -1598,6 +1598,16 @@ exit:
     return channelMask;
 }
 
+otRadioState RadioSpinel::GetState(void) const
+{
+    static const otRadioState sOtRadioStateMap[] = {
+        OT_RADIO_STATE_DISABLED, OT_RADIO_STATE_SLEEP,    OT_RADIO_STATE_RECEIVE,
+        OT_RADIO_STATE_TRANSMIT, OT_RADIO_STATE_TRANSMIT,
+    };
+
+    return sOtRadioStateMap[mState];
+}
+
 } // namespace PosixApp
 } // namespace ot
 
@@ -1962,4 +1972,10 @@ uint32_t otPlatRadioGetPreferredChannelMask(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
     return sRadioSpinel.GetRadioChannelMask(true);
+}
+
+otRadioState otPlatRadioGetState(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sRadioSpinel.GetState();
 }

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -227,6 +227,14 @@ public:
      */
     int8_t GetReceiveSensitivity(void) const { return mRxSensitivity; }
 
+    /**
+     * This method gets current state of the radio.
+     *
+     * @return  Current state of the radio.
+     *
+     */
+    otRadioState GetState(void) const;
+
 #if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
     /**
      * Enable the radio coex.


### PR DESCRIPTION
This PR implements otPlatRadioGetState() on POSIX platforms, including
simulation and posix-host app.

This is for debugging purpose.