### PR TITLE
[efr32] Enhancements to radio driver (3/3)

### DIFF
--- a/examples/platforms/efr32mg12/brd4161a/board_config.h
+++ b/examples/platforms/efr32mg12/brd4161a/board_config.h
@@ -45,4 +45,6 @@
 #define RADIO_CONFIG_DMP_SUPPORT 0            /// Set to 1 to enable Dynamic Multi-Protocol support in radio.c
 #endif
 
+#define RADIO_CONFIG_PA_USES_DCDC 0           /// The PA(s) is(are) fed from VBAT
+
 #endif // __BOARD_CONFIG_H__

--- a/examples/platforms/efr32mg12/brd4166a/board_config.h
+++ b/examples/platforms/efr32mg12/brd4166a/board_config.h
@@ -45,4 +45,6 @@
 #define RADIO_CONFIG_DMP_SUPPORT 0            /// Set to 1 to enable Dynamic Multi-Protocol support in radio.c
 #endif
 
+#define RADIO_CONFIG_PA_USES_DCDC 1           /// The PA(s) is(are) fed from the DCDC
+
 #endif // __BOARD_CONFIG_H__

--- a/examples/platforms/efr32mg12/brd4170a/board_config.h
+++ b/examples/platforms/efr32mg12/brd4170a/board_config.h
@@ -46,4 +46,6 @@
 #define RADIO_CONFIG_DMP_SUPPORT 0            /// Set to 1 to enable Dynamic Multi-Protocol support in radio.c
 #endif
 
+#define RADIO_CONFIG_PA_USES_DCDC 0           /// The PA(s) is(are) fed from VBAT
+
 #endif // __BOARD_CONFIG_H__

--- a/examples/platforms/efr32mg12/brd4304a/board_config.h
+++ b/examples/platforms/efr32mg12/brd4304a/board_config.h
@@ -45,4 +45,6 @@
 #define RADIO_CONFIG_DMP_SUPPORT 0            /// Set to 1 to enable Dynamic Multi-Protocol support in radio.c
 #endif
 
+#define RADIO_CONFIG_PA_USES_DCDC 0           /// The PA(s) is(are) fed from VBAT
+
 #endif // __BOARD_CONFIG_H__

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -186,7 +186,11 @@ static const RAIL_IEEE802154_Config_t sRailIeee802154Config = {
     .isPanCoordinator = false,
 };
 
+#if RADIO_CONFIG_PA_USES_DCDC
+RAIL_DECLARE_TX_POWER_DCDC_CURVES(piecewiseSegments, curvesSg, curves24Hp, curves24Lp);
+#else
 RAIL_DECLARE_TX_POWER_VBAT_CURVES(piecewiseSegments, curvesSg, curves24Hp, curves24Lp);
+#endif
 
 static int8_t sTxPowerDbm = OPENTHREAD_CONFIG_DEFAULT_TRANSMIT_POWER;
 


### PR DESCRIPTION
This is the last of 3 PRs addressing the efr32mg12 radio driver.

PR# 3:

- Features:
  - Allow per-band PA configurations:
    - Supply selection (DCDC or VBAT).
    - Ramp time configuration.
    - Voltage configuration.

- Bug fixes:
  - Corrected PA supply selection for BRD4166A (is supplied from DCDC instead of VBAT). This could cause an incorrect output power setting.

@andrasbiro-silabs please review.

Thanks


