### PR TITLE
[mac-frame] add missing OT_TOOL_PACKED_BEGIN to Beacon class

### DIFF
--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -1131,6 +1131,7 @@ public:
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 };
 
+OT_TOOL_PACKED_BEGIN
 class Beacon
 {
 public:


### PR DESCRIPTION
----

We already have `OT_TOOL_PACKED_END` for `Beacon` class. Most toolchains define `OT_TOOL_PACKED_BEGIN` as empty so it worked fine on those.