### PR TITLE
[posix-app] update config header file includes

### DIFF
--- a/src/ncp/hdlc.hpp
+++ b/src/ncp/hdlc.hpp
@@ -37,6 +37,7 @@
 
 #include <stdint.h>
 #include <stdlib.h>
+#include <string.h>
 
 #include <openthread/error.h>
 #include "common/code_utils.hpp"

--- a/src/posix/client.c
+++ b/src/posix/client.c
@@ -26,7 +26,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "openthread-core-config.h"
+#include "platform/openthread-posix-config.h"
 
 #include <openthread/platform/toolchain.h>
 

--- a/src/posix/console_cli.h
+++ b/src/posix/console_cli.h
@@ -29,6 +29,8 @@
 #ifndef OPENTHREAD_CONSOLE_CLI_H_
 #define OPENTHREAD_CONSOLE_CLI_H_
 
+#include "platform/openthread-posix-config.h"
+
 #include <stdint.h>
 
 #include "openthread-system.h"

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -26,6 +26,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "platform/openthread-posix-config.h"
+
 #include <openthread/config.h>
 
 #include <assert.h>

--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -58,6 +58,7 @@ libopenthread_posix_a_SOURCES             = \
     $(NULL)
 
 noinst_HEADERS                            = \
+    openthread-posix-config.h               \
     platform-posix.h                        \
     hdlc_interface.hpp                      \
     radio_spinel.hpp                        \

--- a/src/posix/platform/alarm.c
+++ b/src/posix/platform/alarm.c
@@ -26,7 +26,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "openthread-core-config.h"
+#include "openthread-posix-config.h"
 #include "platform-posix.h"
 
 #include <assert.h>

--- a/src/posix/platform/entropy.c
+++ b/src/posix/platform/entropy.c
@@ -32,9 +32,9 @@
  *
  */
 
-#include <openthread/platform/entropy.h>
+#include "openthread-posix-config.h"
 
-#include "openthread-core-config.h"
+#include <openthread/platform/entropy.h>
 
 #include <assert.h>
 #include <stdio.h>

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -31,10 +31,9 @@
  *   This file includes the implementation for the HDLC interface to radio (RCP).
  */
 
-#include "openthread-core-config.h"
-#include "platform-posix.h"
-
 #include "hdlc_interface.hpp"
+
+#include "platform-posix.h"
 
 #include <assert.h>
 #include <errno.h>

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -34,7 +34,8 @@
 #ifndef POSIX_APP_HDLC_INTERFACE_HPP_
 #define POSIX_APP_HDLC_INTERFACE_HPP_
 
-#include "platform-config.h"
+#include "openthread-posix-config.h"
+#include "platform-posix.h"
 #include "spinel_interface.hpp"
 #include "ncp/hdlc.hpp"
 

--- a/src/posix/platform/logging.c
+++ b/src/posix/platform/logging.c
@@ -26,7 +26,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "openthread-core-config.h"
+#include "openthread-posix-config.h"
 #include "platform-posix.h"
 
 #include <assert.h>

--- a/src/posix/platform/misc.c
+++ b/src/posix/platform/misc.c
@@ -26,7 +26,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "openthread-core-config.h"
+#include "openthread-posix-config.h"
 #include "platform-posix.h"
 
 #include <assert.h>

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -30,7 +30,8 @@
  * @file
  *   This file implements the platform network on Linux.
  */
-#include "openthread-core-config.h"
+
+#include "openthread-posix-config.h"
 #include "platform-posix.h"
 
 #include <arpa/inet.h>

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -67,4 +67,24 @@
 #define OPENTHREAD_POSIX_VIRTUAL_TIME 0
 #endif
 
+/**
+ * @def OPENTHREAD_POSIX_RCP_UART_ENABLE
+ *
+ * Define as 1 to enable UART interface to RCP.
+ *
+ */
+#ifndef OPENTHREAD_POSIX_RCP_UART_ENABLE
+#define OPENTHREAD_POSIX_RCP_UART_ENABLE 0
+#endif
+
+/**
+ * @def OPENTHREAD_POSIX_RCP_SPI_ENABLE
+ *
+ * Define as 1 to enable SPI interface to RCP.
+ *
+ */
+#ifndef OPENTHREAD_POSIX_RCP_SPI_ENABLE
+#define OPENTHREAD_POSIX_RCP_SPI_ENABLE 0
+#endif
+
 #endif // OPENTHREAD_PLATFORM_CONFIG_H_

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -29,6 +29,8 @@
 #ifndef OPENTHREAD_PLATFORM_CONFIG_H_
 #define OPENTHREAD_PLATFORM_CONFIG_H_
 
+#include "openthread-core-config.h"
+
 /**
  * @file
  * @brief

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -35,6 +35,8 @@
 #ifndef PLATFORM_POSIX_H_
 #define PLATFORM_POSIX_H_
 
+#include "openthread-posix-config.h"
+
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
@@ -45,7 +47,6 @@
 #include <openthread/error.h>
 #include <openthread/instance.h>
 
-#include "platform-config.h"
 #include "common/logging.hpp"
 
 /**

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -31,11 +31,10 @@
  *   This file implements the spinel based radio transceiver.
  */
 
-#include "openthread-core-config.h"
+#include "radio_spinel.hpp"
+
 #include "platform-posix.h"
 #include "ncp/spinel_decoder.hpp"
-
-#include "radio_spinel.hpp"
 
 #include <assert.h>
 #include <errno.h>

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -46,6 +46,10 @@
 #include "spi_interface.hpp"
 #endif
 
+#if !OPENTHREAD_POSIX_RCP_UART_ENABLE && !OPENTHREAD_POSIX_RCP_SPI_ENABLE
+#error "Please enable either OPENTHREAD_POSIX_RCP_UART_ENABLE or OPENTHREAD_POSIX_RCP_SPI_ENABLE."
+#endif
+
 #include "spinel_interface.hpp"
 #include "ncp/ncp_config.h"
 #include "ncp/spinel.h"

--- a/src/posix/platform/radio_spinel.hpp
+++ b/src/posix/platform/radio_spinel.hpp
@@ -34,6 +34,8 @@
 #ifndef RADIO_SPINEL_HPP_
 #define RADIO_SPINEL_HPP_
 
+#include "openthread-posix-config.h"
+
 #include <openthread/platform/radio.h>
 
 #if OPENTHREAD_POSIX_RCP_UART_ENABLE

--- a/src/posix/platform/settings.cpp
+++ b/src/posix/platform/settings.cpp
@@ -32,7 +32,7 @@
  *
  */
 
-#include "openthread-core-config.h"
+#include "openthread-posix-config.h"
 #include "platform-posix.h"
 
 #include <assert.h>

--- a/src/posix/platform/sim.c
+++ b/src/posix/platform/sim.c
@@ -32,7 +32,7 @@
  *   This file implements the posix simulation.
  */
 
-#include "openthread-core-config.h"
+#include "openthread-posix-config.h"
 #include "platform-posix.h"
 
 #include <arpa/inet.h>

--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -31,10 +31,9 @@
  *   This file includes the implementation for the SPI interface to radio (RCP).
  */
 
-#include "openthread-core-config.h"
+#include "spi_interface.hpp"
 
 #include "platform-posix.h"
-#include "spi_interface.hpp"
 
 #include <assert.h>
 #include <errno.h>

--- a/src/posix/platform/spi_interface.hpp
+++ b/src/posix/platform/spi_interface.hpp
@@ -34,6 +34,8 @@
 #ifndef POSIX_APP_SPI_INTERFACE_HPP_
 #define POSIX_APP_SPI_INTERFACE_HPP_
 
+#include "openthread-posix-config.h"
+
 #include "spinel_interface.hpp"
 #include "ncp/hdlc.hpp"
 
@@ -164,7 +166,7 @@ private:
         kSpiTxRefuseExitCount    = 100,
         kImmediateRetryCount     = 5,
         kFastRetryCount          = 15,
-        kDebugBytesPerLine       = 16, 
+        kDebugBytesPerLine       = 16,
         kGpioIntAssertState      = 0,
         kGpioResetAssertState    = 0,
     };

--- a/src/posix/platform/spinel_interface.hpp
+++ b/src/posix/platform/spinel_interface.hpp
@@ -35,6 +35,8 @@
 #ifndef POSIX_APP_SPINEL_INTERFACE_HPP_
 #define POSIX_APP_SPINEL_INTERFACE_HPP_
 
+#include "openthread-posix-config.h"
+
 #include "ncp/hdlc.hpp"
 
 namespace ot {

--- a/src/posix/platform/system.c
+++ b/src/posix/platform/system.c
@@ -32,7 +32,7 @@
  *   This file includes the platform-specific initializers.
  */
 
-#include "openthread-core-config.h"
+#include "openthread-posix-config.h"
 #include "platform-posix.h"
 
 #include <assert.h>

--- a/src/posix/platform/uart.c
+++ b/src/posix/platform/uart.c
@@ -26,7 +26,7 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "openthread-core-config.h"
+#include "openthread-posix-config.h"
 #include "platform-posix.h"
 
 #if OPENTHREAD_ENABLE_POSIX_APP_DAEMON

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -36,7 +36,7 @@
 #define __APPLE_USE_RFC_3542
 #endif
 
-#include "openthread-core-config.h"
+#include "openthread-posix-config.h"
 #include "platform-posix.h"
 
 #include <arpa/inet.h>

--- a/tests/toranj/build.sh
+++ b/tests/toranj/build.sh
@@ -137,7 +137,7 @@ case ${build_config} in
         ./bootstrap || die
         cd "${top_builddir}"
         ${top_srcdir}/configure                 \
-            CPPFLAGS="$cppflags_config -DOPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE=1 -DOPENTHREAD_POSIX_RCP_UART_ENABLE=1" \
+            CPPFLAGS="$cppflags_config"         \
             --enable-posix-app                  \
             $configure_options || die
         make -j 8 || die

--- a/tests/toranj/openthread-core-toranj-config.h
+++ b/tests/toranj/openthread-core-toranj-config.h
@@ -422,5 +422,24 @@
 #define OPENTHREAD_CONFIG_SOFTWARE_CSMA_BACKOFF_ENABLE          1
 #endif // OPENTHREAD_RADIO
 
+//--------------------------------------------------------------------------------------------------------------------
+// POSIX-App configurations
+
+/**
+ * @def OPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE
+ *
+ * Define as 1 to enable PTY device support in POSIX app.
+ *
+ */
+#define OPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE 1
+
+/**
+ * @def OPENTHREAD_POSIX_RCP_UART_ENABLE
+ *
+ * Define as 1 to enable UART interface to RCP.
+ *
+ */
+#define OPENTHREAD_POSIX_RCP_UART_ENABLE 1
+
 #endif /* OPENTHREAD_CORE_TORANJ_CONFIG_H_ */
 


### PR DESCRIPTION
This PR contains a group of (related) commits for posix-app.

**[posix-app] add missing config header file includes**    
 This commit updates how posix-app source files include the config header file to follow a similar policy as for core modules. All header files and `cpp` files that do not have a corresponding `hpp` file should include "platform-config.h" first (which itself will include the core config header). The "cpp" files which have a related "hpp" should include the related hpp file first. This way we ensure all config macro definitions are correctly included in all modules.

**[posix-app-config] add UART/SPI config macros and their default value**    
This addresses undefined macro warnings when building posix-app.

**[toranj] move posix-app config defs into header file from build script**

**[hdlc] add missing <string.h> include (for memmove())**

**[posix-app] add error if no RCP interface (SPI/UART) is enabled**