### PR TITLE
[coap] Add helper functions to encode coap block options

### DIFF
--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -143,6 +143,18 @@ typedef enum otCoapOptionType
     OT_COAP_OPTION_SIZE1          = 60, ///< Size1
 } otCoapOptionType;
 
+/**
+ * CoAP Block1/Block2 Types
+ */
+typedef enum otCoapBlockType
+{
+    OT_COAP_BLOCK_TYPE_1 = 1,
+    OT_COAP_BLOCK_TYPE_2 = 2,
+} otCoapBlockType;
+
+/**
+ * CoAP Block Size Exponents
+ */
 typedef enum otCoapBlockSize
 {
     OT_COAP_BLOCK_SIZE_16   = 0,

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -144,15 +144,6 @@ typedef enum otCoapOptionType
 } otCoapOptionType;
 
 /**
- * CoAP Block1/Block2 Types
- */
-typedef enum otCoapBlockType
-{
-    OT_COAP_BLOCK_TYPE_1 = 1,
-    OT_COAP_BLOCK_TYPE_2 = 2,
-} otCoapBlockType;
-
-/**
  * CoAP Block Size Exponents
  */
 typedef enum otCoapBlockSize

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -496,12 +496,22 @@ otError otCoapMessageAppendObserveOption(otMessage *aMessage, uint32_t aObserve)
 otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriPath);
 
 /**
+ * This function converts a CoAP Block option SZX field to the actual block size
+ *
+ * @param[in]     aSize     Block size exponent.
+ *
+ * @returns The actual size exponent value.
+ *
+ */
+uint16_t otCoapBlockSizeFromExponent(otCoapBlockSize aSize);
+
+/**
  * This function appends a Block2 option
  *
  * @param[inout]  aMessage  A pointer to the CoAP message.
  * @param[in]     aNum      Current block number.
  * @param[in]     aMore     Boolean to indicate more blocks are to be sent.
- * @param[in]     aSize     Maximum block size.
+ * @param[in]     aSize     Block Size Exponent.
  *
  * @retval OT_ERROR_NONE          Successfully appended the option.
  * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
@@ -516,7 +526,7 @@ otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool
  * @param[inout]  aMessage  A pointer to the CoAP message.
  * @param[in]     aNum      Current block number.
  * @param[in]     aMore     Boolean to indicate more blocks are to be sent.
- * @param[in]     aSize     Maximum block size.
+ * @param[in]     aSize     Block Size Exponent.
  *
  * @retval OT_ERROR_NONE          Successfully appended the option.
  * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -134,6 +134,8 @@ typedef enum otCoapOptionType
     OT_COAP_OPTION_URI_QUERY      = 15, ///< Uri-Query
     OT_COAP_OPTION_ACCEPT         = 17, ///< Accept
     OT_COAP_OPTION_LOCATION_QUERY = 20, ///< Location-Query
+    OT_COAP_OPTION_BLOCK2         = 23, ///< Block1 (RFC7959)
+    OT_COAP_OPTION_BLOCK1         = 27, ///< Block2 (RFC7959)
     OT_COAP_OPTION_PROXY_URI      = 35, ///< Proxy-Uri
     OT_COAP_OPTION_PROXY_SCHEME   = 39, ///< Proxy-Scheme
     OT_COAP_OPTION_SIZE1          = 60, ///< Size1

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -141,6 +141,17 @@ typedef enum otCoapOptionType
     OT_COAP_OPTION_SIZE1          = 60, ///< Size1
 } otCoapOptionType;
 
+typedef enum otCoapBlockSize
+{
+    OT_COAP_BLOCK_SIZE_16   = 0,
+    OT_COAP_BLOCK_SIZE_32   = 1,
+    OT_COAP_BLOCK_SIZE_64   = 2,
+    OT_COAP_BLOCK_SIZE_128  = 3,
+    OT_COAP_BLOCK_SIZE_256  = 4,
+    OT_COAP_BLOCK_SIZE_512  = 5,
+    OT_COAP_BLOCK_SIZE_1024 = 6,
+} otCoapBlockSize;
+
 /**
  * This structure represents a CoAP option.
  *
@@ -483,7 +494,7 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
  * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
  *
  */
-otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint16_t aSize);
+otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize);
 
 /**
  * This function appends a Block1 option
@@ -498,7 +509,7 @@ otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool
  * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
  *
  */
-otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint16_t aSize);
+otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize);
 
 /**
  * This function appends a Proxy-Uri option.

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -471,6 +471,36 @@ otError otCoapMessageAppendObserveOption(otMessage *aMessage, uint32_t aObserve)
 otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriPath);
 
 /**
+ * This function appends a Block2 option
+ *
+ * @param[inout]  aMessage  A pointer to the CoAP message.
+ * @param[in]     aNum      Current block number.
+ * @param[in]     aMore     Boolean to indicate more blocks are to be sent.
+ * @param[in]     aSize     Maximum block size.
+ *
+ * @retval OT_ERROR_NONE          Successfully appended the option.
+ * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+ * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
+ *
+ */
+otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint16_t aSize);
+
+/**
+ * This function appends a Block1 option
+ *
+ * @param[inout]  aMessage  A pointer to the CoAP message.
+ * @param[in]     aNum      Current block number.
+ * @param[in]     aMore     Boolean to indicate more blocks are to be sent.
+ * @param[in]     aSize     Maximum block size.
+ *
+ * @retval OT_ERROR_NONE          Successfully appended the option.
+ * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+ * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
+ *
+ */
+otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint16_t aSizeExponent);
+
+/**
  * This function appends a Proxy-Uri option.
  *
  * @param[inout]  aMessage  A pointer to the CoAP message.

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -134,8 +134,8 @@ typedef enum otCoapOptionType
     OT_COAP_OPTION_URI_QUERY      = 15, ///< Uri-Query
     OT_COAP_OPTION_ACCEPT         = 17, ///< Accept
     OT_COAP_OPTION_LOCATION_QUERY = 20, ///< Location-Query
-    OT_COAP_OPTION_BLOCK2         = 23, ///< Block1 (RFC7959)
-    OT_COAP_OPTION_BLOCK1         = 27, ///< Block2 (RFC7959)
+    OT_COAP_OPTION_BLOCK2         = 23, ///< Block2 (RFC7959)
+    OT_COAP_OPTION_BLOCK1         = 27, ///< Block1 (RFC7959)
     OT_COAP_OPTION_PROXY_URI      = 35, ///< Proxy-Uri
     OT_COAP_OPTION_PROXY_SCHEME   = 39, ///< Proxy-Scheme
     OT_COAP_OPTION_SIZE1          = 60, ///< Size1
@@ -498,7 +498,7 @@ otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool
  * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
  *
  */
-otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint16_t aSizeExponent);
+otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint16_t aSize);
 
 /**
  * This function appends a Proxy-Uri option.

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -90,12 +90,13 @@ typedef enum otCoapCode
     OT_COAP_CODE_PUT    = OT_COAP_CODE(0, 3), ///< Put
     OT_COAP_CODE_DELETE = OT_COAP_CODE(0, 4), ///< Delete
 
-    OT_COAP_CODE_RESPONSE_MIN = OT_COAP_CODE(2, 0), ///< 2.00
-    OT_COAP_CODE_CREATED      = OT_COAP_CODE(2, 1), ///< Created
-    OT_COAP_CODE_DELETED      = OT_COAP_CODE(2, 2), ///< Deleted
-    OT_COAP_CODE_VALID        = OT_COAP_CODE(2, 3), ///< Valid
-    OT_COAP_CODE_CHANGED      = OT_COAP_CODE(2, 4), ///< Changed
-    OT_COAP_CODE_CONTENT      = OT_COAP_CODE(2, 5), ///< Content
+    OT_COAP_CODE_RESPONSE_MIN = OT_COAP_CODE(2, 0),  ///< 2.00
+    OT_COAP_CODE_CREATED      = OT_COAP_CODE(2, 1),  ///< Created
+    OT_COAP_CODE_DELETED      = OT_COAP_CODE(2, 2),  ///< Deleted
+    OT_COAP_CODE_VALID        = OT_COAP_CODE(2, 3),  ///< Valid
+    OT_COAP_CODE_CHANGED      = OT_COAP_CODE(2, 4),  ///< Changed
+    OT_COAP_CODE_CONTENT      = OT_COAP_CODE(2, 5),  ///< Content
+    OT_COAP_CODE_CONTINUE     = OT_COAP_CODE(2, 31), ///< RFC7959 Continue
 
     OT_COAP_CODE_BAD_REQUEST         = OT_COAP_CODE(4, 0),  ///< Bad Request
     OT_COAP_CODE_UNAUTHORIZED        = OT_COAP_CODE(4, 1),  ///< Unauthorized
@@ -104,6 +105,7 @@ typedef enum otCoapCode
     OT_COAP_CODE_NOT_FOUND           = OT_COAP_CODE(4, 4),  ///< Not Found
     OT_COAP_CODE_METHOD_NOT_ALLOWED  = OT_COAP_CODE(4, 5),  ///< Method Not Allowed
     OT_COAP_CODE_NOT_ACCEPTABLE      = OT_COAP_CODE(4, 6),  ///< Not Acceptable
+    OT_COAP_CODE_REQUEST_INCOMPLETE  = OT_COAP_CODE(4, 8),  ///< RFC7959 Request Entity Incomplete
     OT_COAP_CODE_PRECONDITION_FAILED = OT_COAP_CODE(4, 12), ///< Precondition Failed
     OT_COAP_CODE_REQUEST_TOO_LARGE   = OT_COAP_CODE(4, 13), ///< Request Entity Too Large
     OT_COAP_CODE_UNSUPPORTED_FORMAT  = OT_COAP_CODE(4, 15), ///< Unsupported Content-Format

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -112,12 +112,12 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
 
 otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(2, aNum, aMore, aSize);
+    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(OT_COAP_BLOCK_TYPE_2, aNum, aMore, aSize);
 }
 
 otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(1, aNum, aMore, aSize);
+    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(OT_COAP_BLOCK_TYPE_1, aNum, aMore, aSize);
 }
 
 otError otCoapMessageAppendProxyUriOption(otMessage *aMessage, const char *aUriPath)

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -112,19 +112,17 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
 
 uint16_t otCoapBlockSizeFromExponent(otCoapBlockSize aSize)
 {
-    return 1 << (aSize + 4);
+    return static_cast<uint16_t>(1 << (aSize + 4));
 }
 
 otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(Coap::Message::OT_COAP_BLOCK_TYPE_2, aNum, aMore,
-                                                                     aSize);
+    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(Coap::Message::kBlockType2, aNum, aMore, aSize);
 }
 
 otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(Coap::Message::OT_COAP_BLOCK_TYPE_1, aNum, aMore,
-                                                                     aSize);
+    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(Coap::Message::kBlockType1, aNum, aMore, aSize);
 }
 
 otError otCoapMessageAppendProxyUriOption(otMessage *aMessage, const char *aUriPath)

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -110,6 +110,16 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
     return static_cast<Coap::Message *>(aMessage)->AppendUriPathOptions(aUriPath);
 }
 
+otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint8_t aSizeExponent)
+{
+    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(1, aNum, aMore, aSizeExponent);
+}
+
+otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint8_t aSizeExponent)
+{
+    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(2, aNum, aMore, aSizeExponent);
+}
+
 otError otCoapMessageAppendProxyUriOption(otMessage *aMessage, const char *aUriPath)
 {
     return static_cast<Coap::Message *>(aMessage)->AppendProxyUriOption(aUriPath);

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -112,12 +112,12 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
 
 otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint16_t aSize)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(1, aNum, aMore, aSize);
+    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(2, aNum, aMore, aSize);
 }
 
 otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint16_t aSize)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(2, aNum, aMore, aSize);
+    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(1, aNum, aMore, aSize);
 }
 
 otError otCoapMessageAppendProxyUriOption(otMessage *aMessage, const char *aUriPath)

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -110,14 +110,14 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
     return static_cast<Coap::Message *>(aMessage)->AppendUriPathOptions(aUriPath);
 }
 
-otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint8_t aSizeExponent)
+otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint16_t aSize)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(1, aNum, aMore, aSizeExponent);
+    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(1, aNum, aMore, aSize);
 }
 
-otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint8_t aSizeExponent)
+otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint16_t aSize)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(2, aNum, aMore, aSizeExponent);
+    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(2, aNum, aMore, aSize);
 }
 
 otError otCoapMessageAppendProxyUriOption(otMessage *aMessage, const char *aUriPath)

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -110,12 +110,12 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
     return static_cast<Coap::Message *>(aMessage)->AppendUriPathOptions(aUriPath);
 }
 
-otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint16_t aSize)
+otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
 {
     return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(2, aNum, aMore, aSize);
 }
 
-otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, uint16_t aSize)
+otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
 {
     return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(1, aNum, aMore, aSize);
 }

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -117,12 +117,14 @@ uint16_t otCoapBlockSizeFromExponent(otCoapBlockSize aSize)
 
 otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(OT_COAP_BLOCK_TYPE_2, aNum, aMore, aSize);
+    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(Coap::Message::OT_COAP_BLOCK_TYPE_2, aNum, aMore,
+                                                                     aSize);
 }
 
 otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(OT_COAP_BLOCK_TYPE_1, aNum, aMore, aSize);
+    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(Coap::Message::OT_COAP_BLOCK_TYPE_1, aNum, aMore,
+                                                                     aSize);
 }
 
 otError otCoapMessageAppendProxyUriOption(otMessage *aMessage, const char *aUriPath)

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -112,7 +112,7 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
 
 uint16_t otCoapBlockSizeFromExponent(otCoapBlockSize aSize)
 {
-    return static_cast<uint16_t>(1 << (aSize + 4));
+    return static_cast<uint16_t>(1 << (aSize + Coap::Message::kBlockSzxBase));
 }
 
 otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize)

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -110,6 +110,11 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
     return static_cast<Coap::Message *>(aMessage)->AppendUriPathOptions(aUriPath);
 }
 
+uint16_t otCoapBlockSizeFromExponent(otCoapBlockSize aSize)
+{
+    return 1 << (aSize + 4);
+}
+
 otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
 {
     return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(OT_COAP_BLOCK_TYPE_2, aNum, aMore, aSize);

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -187,7 +187,7 @@ exit:
     return error;
 }
 
-otError Message::AppendBlockOption(Message::otCoapBlockType aType, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
+otError Message::AppendBlockOption(Message::BlockType aType, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
 {
     otError  error   = OT_ERROR_NONE;
     uint32_t encoded = aSize;
@@ -197,8 +197,8 @@ otError Message::AppendBlockOption(Message::otCoapBlockType aType, uint32_t aNum
     encoded |= static_cast<uint32_t>((aMore) << 3);
     encoded |= (aNum) << 4;
 
-    VerifyOrExit(aType == OT_COAP_BLOCK_TYPE_1 || aType == OT_COAP_BLOCK_TYPE_2, error = OT_ERROR_INVALID_ARGS);
-    error = AppendUintOption((aType == 1) ? OT_COAP_OPTION_BLOCK1 : OT_COAP_OPTION_BLOCK2, encoded);
+    VerifyOrExit(aType == kBlockType1 || aType == kBlockType2, error = OT_ERROR_INVALID_ARGS);
+    error = AppendUintOption((aType == kBlockType1) ? OT_COAP_OPTION_BLOCK1 : OT_COAP_OPTION_BLOCK2, encoded);
 
 exit:
     return error;

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -192,12 +192,13 @@ otError Message::AppendBlockOption(Message::BlockType aType, uint32_t aNum, bool
     otError  error   = OT_ERROR_NONE;
     uint32_t encoded = aSize;
 
-    VerifyOrExit(aNum < 0xFFFFF, error = OT_ERROR_INVALID_ARGS);
-
-    encoded |= static_cast<uint32_t>((aMore) << 3);
-    encoded |= (aNum) << 4;
-
     VerifyOrExit(aType == kBlockType1 || aType == kBlockType2, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aSize < OT_COAP_BLOCK_SIZE_32 || aSize > OT_COAP_BLOCK_SIZE_1024, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aNum < kBlockNumMax, error = OT_ERROR_INVALID_ARGS);
+
+    encoded |= static_cast<uint32_t>(aMore << kBlockMOffset);
+    encoded |= aNum << kBlockNumOffset;
+
     error = AppendUintOption((aType == kBlockType1) ? OT_COAP_OPTION_BLOCK1 : OT_COAP_OPTION_BLOCK2, encoded);
 
 exit:

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -187,7 +187,7 @@ exit:
     return error;
 }
 
-otError Message::AppendBlockOption(otCoapBlockType aType, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
+otError Message::AppendBlockOption(Message::otCoapBlockType aType, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
 {
     otError  error   = OT_ERROR_NONE;
     uint32_t encoded = aSize;

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -187,6 +187,74 @@ exit:
     return error;
 }
 
+otError Message::AppendBlockOption(const uint8_t  aType,
+                                   const uint32_t aNum,
+                                   const bool     aMore,
+                                   const uint16_t aSizeExponent)
+{
+    otError  error   = OT_ERROR_NONE;
+    uint32_t encoded = 0;
+
+    if ((aNum > 0xFFFFF))
+    {
+        SuccessOrExit(error = OT_ERROR_INVALID_ARGS);
+    }
+
+    switch (aSizeExponent)
+    {
+    case 16:
+        encoded = 0;
+        break;
+
+    case 32:
+        encoded = 1;
+        break;
+
+    case 64:
+        encoded = 2;
+        break;
+
+    case 128:
+        encoded = 3;
+        break;
+
+    case 256:
+        encoded = 4;
+        break;
+
+    case 512:
+        encoded = 5;
+        break;
+
+    case 1024:
+        encoded = 6;
+        break;
+
+    case 2048:
+    default:
+        SuccessOrExit(OT_ERROR_INVALID_ARGS);
+    }
+
+    encoded |= (aMore) << 3;
+    encoded |= (aNum) << 4;
+
+    if (aType == 1)
+    {
+        SuccessOrExit(error = AppendUintOption(OT_COAP_OPTION_BLOCK1, encoded));
+    }
+    else if (aType == 2)
+    {
+        SuccessOrExit(error = AppendUintOption(OT_COAP_OPTION_BLOCK2, encoded));
+    }
+    else
+    {
+        SuccessOrExit(error = OT_ERROR_INVALID_ARGS);
+    }
+
+exit:
+    return error;
+}
+
 otError Message::AppendProxyUriOption(const char *aProxyUri)
 {
     return AppendStringOption(OT_COAP_OPTION_PROXY_URI, aProxyUri);

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -187,7 +187,7 @@ exit:
     return error;
 }
 
-otError Message::AppendBlockOption(uint8_t aType, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
+otError Message::AppendBlockOption(otCoapBlockType aType, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
 {
     otError  error   = OT_ERROR_NONE;
     uint32_t encoded = aSize;
@@ -197,7 +197,7 @@ otError Message::AppendBlockOption(uint8_t aType, uint32_t aNum, bool aMore, otC
     encoded |= static_cast<uint32_t>((aMore) << 3);
     encoded |= (aNum) << 4;
 
-    VerifyOrExit(aType == 1 || aType == 2, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aType == OT_COAP_BLOCK_TYPE_1 || aType == OT_COAP_BLOCK_TYPE_2, error = OT_ERROR_INVALID_ARGS);
     error = AppendUintOption((aType == 1) ? OT_COAP_OPTION_BLOCK1 : OT_COAP_OPTION_BLOCK2, encoded);
 
 exit:

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -235,7 +235,7 @@ otError Message::AppendBlockOption(const uint8_t  aType,
         SuccessOrExit(OT_ERROR_INVALID_ARGS);
     }
 
-    encoded |= (aMore) << 3;
+    encoded |= static_cast<uint32_t>((aMore) << 3);
     encoded |= (aNum) << 4;
 
     if (aType == 1)

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -192,10 +192,7 @@ otError Message::AppendBlockOption(const uint8_t aType, const uint32_t aNum, con
     otError  error   = OT_ERROR_NONE;
     uint32_t encoded = 0;
 
-    if ((aNum > 0xFFFFF))
-    {
-        SuccessOrExit(error = OT_ERROR_INVALID_ARGS);
-    }
+    VerifyOrExit(aNum < 0xFFFFF, error = OT_ERROR_INVALID_ARGS);
 
     switch (aSize)
     {
@@ -227,26 +224,15 @@ otError Message::AppendBlockOption(const uint8_t aType, const uint32_t aNum, con
         encoded = 6;
         break;
 
-    case 2048:
     default:
-        SuccessOrExit(OT_ERROR_INVALID_ARGS);
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
     }
 
     encoded |= static_cast<uint32_t>((aMore) << 3);
     encoded |= (aNum) << 4;
 
-    if (aType == 1)
-    {
-        SuccessOrExit(error = AppendUintOption(OT_COAP_OPTION_BLOCK1, encoded));
-    }
-    else if (aType == 2)
-    {
-        SuccessOrExit(error = AppendUintOption(OT_COAP_OPTION_BLOCK2, encoded));
-    }
-    else
-    {
-        SuccessOrExit(error = OT_ERROR_INVALID_ARGS);
-    }
+    VerifyOrExit(aType == 1 || aType == 2, error = OT_ERROR_INVALID_ARGS);
+    error = AppendUintOption((aType == 1) ? OT_COAP_OPTION_BLOCK1 : OT_COAP_OPTION_BLOCK2, encoded);
 
 exit:
     return error;

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -187,10 +187,7 @@ exit:
     return error;
 }
 
-otError Message::AppendBlockOption(const uint8_t  aType,
-                                   const uint32_t aNum,
-                                   const bool     aMore,
-                                   const uint16_t aSizeExponent)
+otError Message::AppendBlockOption(const uint8_t aType, const uint32_t aNum, const bool aMore, const uint16_t aSize)
 {
     otError  error   = OT_ERROR_NONE;
     uint32_t encoded = 0;
@@ -200,7 +197,7 @@ otError Message::AppendBlockOption(const uint8_t  aType,
         SuccessOrExit(error = OT_ERROR_INVALID_ARGS);
     }
 
-    switch (aSizeExponent)
+    switch (aSize)
     {
     case 16:
         encoded = 0;

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -187,46 +187,12 @@ exit:
     return error;
 }
 
-otError Message::AppendBlockOption(const uint8_t aType, const uint32_t aNum, const bool aMore, const uint16_t aSize)
+otError Message::AppendBlockOption(uint8_t aType, uint32_t aNum, bool aMore, otCoapBlockSize aSize)
 {
     otError  error   = OT_ERROR_NONE;
-    uint32_t encoded = 0;
+    uint32_t encoded = aSize;
 
     VerifyOrExit(aNum < 0xFFFFF, error = OT_ERROR_INVALID_ARGS);
-
-    switch (aSize)
-    {
-    case 16:
-        encoded = 0;
-        break;
-
-    case 32:
-        encoded = 1;
-        break;
-
-    case 64:
-        encoded = 2;
-        break;
-
-    case 128:
-        encoded = 3;
-        break;
-
-    case 256:
-        encoded = 4;
-        break;
-
-    case 512:
-        encoded = 5;
-        break;
-
-    case 1024:
-        encoded = 6;
-        break;
-
-    default:
-        ExitNow(error = OT_ERROR_INVALID_ARGS);
-    }
 
     encoded |= static_cast<uint32_t>((aMore) << 3);
     encoded |= (aNum) << 4;

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -107,6 +107,11 @@ public:
         kBlockType2 = 2,
     };
 
+    enum
+    {
+        kBlockSzxBase = 4,
+    };
+
     /**
      * This method initializes the CoAP header.
      *
@@ -570,6 +575,18 @@ private:
         kOption2ByteExtensionOffset = 269, ///< Delta/Length offset as specified (RFC 7252).
 
         kHelpDataAlignment = sizeof(uint16_t), ///< Alignment of help data.
+    };
+
+    enum
+    {
+        kBlockSzxOffset = 0,
+        kBlockMOffset   = 3,
+        kBlockNumOffset = 4,
+    };
+
+    enum
+    {
+        kBlockNumMax = 0xFFFFF,
     };
 
     /**

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -101,11 +101,11 @@ public:
      * CoAP Block1/Block2 Types
      *
      */
-    typedef enum otCoapBlockType
+    enum BlockType
     {
-        OT_COAP_BLOCK_TYPE_1 = 1,
-        OT_COAP_BLOCK_TYPE_2 = 2,
-    } otCoapBlockType;
+        kBlockType1 = 1,
+        kBlockType2 = 2,
+    };
 
     /**
      * This method initializes the CoAP header.
@@ -358,7 +358,7 @@ public:
      * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      *
      */
-    otError AppendBlockOption(otCoapBlockType aType, uint32_t aNum, bool aMore, otCoapBlockSize aSize);
+    otError AppendBlockOption(BlockType aType, uint32_t aNum, bool aMore, otCoapBlockSize aSize);
 
     /**
      * This method appends a Proxy-Uri option.

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -348,7 +348,7 @@ public:
      * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      *
      */
-    otError AppendBlockOption(uint8_t aType, uint32_t aNum, bool aMore, otCoapBlockSize aSize);
+    otError AppendBlockOption(otCoapBlockType aType, uint32_t aNum, bool aMore, otCoapBlockSize aSize);
 
     /**
      * This method appends a Proxy-Uri option.

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -98,6 +98,16 @@ public:
     typedef otCoapCode Code;
 
     /**
+     * CoAP Block1/Block2 Types
+     *
+     */
+    typedef enum otCoapBlockType
+    {
+        OT_COAP_BLOCK_TYPE_1 = 1,
+        OT_COAP_BLOCK_TYPE_2 = 2,
+    } otCoapBlockType;
+
+    /**
      * This method initializes the CoAP header.
      *
      */

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -348,7 +348,7 @@ public:
      * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      *
      */
-    otError AppendBlockOption(const uint8_t aType, const uint32_t aNum, const bool aMore, const uint16_t aSize);
+    otError AppendBlockOption(uint8_t aType, uint32_t aNum, bool aMore, otCoapBlockSize aSize);
 
     /**
      * This method appends a Proxy-Uri option.

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -336,6 +336,21 @@ public:
     otError AppendUriPathOptions(const char *aUriPath);
 
     /**
+     * This method appends a Block option
+     *
+     * @param[in]  aType              Type of block option, 1 or 2.
+     * @param[in]  aNum               Current block number.
+     * @param[in]  aMore              Boolean to indicate more blocks are to be sent.
+     * @param[in]  aSize              Maximum block size.
+     *
+     * @retval OT_ERROR_NONE          Successfully appended the option.
+     * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
+     * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
+     *
+     */
+    otError AppendBlockOption(const uint8_t aType, const uint32_t aNum, const bool aMore, const uint16_t aSize);
+
+    /**
      * This method appends a Proxy-Uri option.
      *
      * @param[in]  aProxyUri          A pointer to a NULL-terminated string.


### PR DESCRIPTION
This small feature addition is two helper functions to encode the Block1 and Block2 uint options described in RFC7959. This should help the effort in #4213 and #4247.