### PR TITLE
[build] change macOS bootstrapped GCC to official ARM brew tap

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -74,8 +74,8 @@ install_packages_brew()
     brew install automake libtool
 
     # add ARM toolchain
-    brew tap PX4/homebrew-px4
-    brew install gcc-arm-none-eabi
+    brew tap ArmMbed/homebrew-formulae
+    brew install arm-none-eabi-gcc
 
     # check for gcc for posix examples
     if ! which gcc; then


### PR DESCRIPTION
The current source for arm-none-eabi-gcc on MacOS is an unofficial tap from PX4, drone flight control software. Instead, openthread should be using ARM's [official toolchain tap](https://github.com/ARMmbed/homebrew-formulae).