### PR TITLE
[toranj] update test-012-multi-hop-traffic

### DIFF
--- a/tests/toranj/test-012-multi-hop-traffic.py
+++ b/tests/toranj/test-012-multi-hop-traffic.py
@@ -130,6 +130,26 @@ fed_children[-1].join_node(routers[-1], wpan.JOIN_TYPE_END_DEVICE)
 NUM_MSGS = 3
 MSG_LENS = [40, 100, 400, 800, 1000]
 
+# Wait till first router has either established a link or
+# has a valid "next hop" towards all other routers.
+
+ROUTER_TABLE_WAIT_TIME = 60 / speedup + 5
+INVALID_ROUTER_ID = 63
+
+r1_rloc = int(routers[0].get(wpan.WPAN_THREAD_RLOC16), 16)
+
+
+def check_r1_router_table():
+    router_table = wpan.parse_router_table_result(
+        routers[0].get(wpan.WPAN_THREAD_ROUTER_TABLE)
+    )
+    verify(len(router_table) == NUM_ROUTERS)
+    for entry in router_table:
+        verify(entry.rloc16 == r1_rloc or entry.is_link_established or entry.next_hop != INVALID_ROUTER_ID)
+
+
+wpan.verify_within(check_r1_router_table, ROUTER_TABLE_WAIT_TIME)
+
 # Send from the first router in the chain to the last one.
 
 src = routers[0].get(wpan.WPAN_IP6_MESH_LOCAL_ADDRESS)[1:-1]


### PR DESCRIPTION
This commit updates tornaj `test-012-multi-hop-traffic` to make it
more robust by waiting for entire chain topology to be discovered
(router table to be fully updated) before starting message exchange.

This should help with rare failures of this test, which happen when an
address query response is received before the "next hop" for the
destination router is discovered (through Link Advertisement
exchanges) on the first router `r1`.