### PR TITLE
[ip6-address] multiple enhancements

### DIFF
--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -129,8 +129,8 @@ bool Address::IsAnycastRoutingLocator(void) const
 
 bool Address::IsAnycastServiceLocator(void) const
 {
-    return IsAnycastRoutingLocator() && (mFields.m16[7] >= HostSwap16(Mle::kAloc16ServiceStart)) &&
-           (mFields.m16[7] <= HostSwap16(Mle::kAloc16ServiceEnd));
+    return IsAnycastRoutingLocator() && (mFields.m8[15] >= (Mle::kAloc16ServiceStart & 0xff)) &&
+           (mFields.m8[15] <= (Mle::kAloc16ServiceEnd & 0xff));
 }
 
 bool Address::IsSubnetRouterAnycast(void) const

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -62,7 +62,7 @@ bool Address::IsLoopback(void) const
 
 bool Address::IsLinkLocal(void) const
 {
-    return (mFields.m8[0] == 0xfe) && ((mFields.m8[1] & 0xc0) == 0x80);
+    return (mFields.m16[0] & HostSwap16(0xffc0)) == HostSwap16(0xfe80);
 }
 
 bool Address::IsMulticast(void) const
@@ -117,15 +117,14 @@ bool Address::IsRealmLocalAllMplForwarders(void) const
 
 bool Address::IsRoutingLocator(void) const
 {
-    return (mFields.m16[4] == HostSwap16(0x0000) && mFields.m16[5] == HostSwap16(0x00ff) &&
-            mFields.m16[6] == HostSwap16(0xfe00) && mFields.m8[14] < kAloc16Mask &&
-            (mFields.m8[14] & kRloc16ReservedBitMask) == 0);
+    return (mFields.m32[2] == HostSwap32(0x000000ff) && mFields.m16[6] == HostSwap16(0xfe00) &&
+            mFields.m8[14] < kAloc16Mask && (mFields.m8[14] & kRloc16ReservedBitMask) == 0);
 }
 
 bool Address::IsAnycastRoutingLocator(void) const
 {
-    return (mFields.m16[4] == HostSwap16(0x0000) && mFields.m16[5] == HostSwap16(0x00ff) &&
-            mFields.m16[6] == HostSwap16(0xfe00) && mFields.m8[14] == kAloc16Mask);
+    return (mFields.m32[2] == HostSwap32(0x000000ff) && mFields.m16[6] == HostSwap16(0xfe00) &&
+            mFields.m8[14] == kAloc16Mask);
 }
 
 bool Address::IsAnycastServiceLocator(void) const

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -65,11 +65,6 @@ bool Address::IsLinkLocal(void) const
     return (mFields.m16[0] & HostSwap16(0xffc0)) == HostSwap16(0xfe80);
 }
 
-bool Address::IsMulticast(void) const
-{
-    return mFields.m8[0] == 0xff;
-}
-
 bool Address::IsLinkLocalMulticast(void) const
 {
     return IsMulticast() && (GetScope() == kLinkLocalScope);
@@ -147,16 +142,6 @@ bool Address::IsReservedSubnetAnycast(void) const
 bool Address::IsIidReserved(void) const
 {
     return IsSubnetRouterAnycast() || IsReservedSubnetAnycast() || IsAnycastRoutingLocator();
-}
-
-const uint8_t *Address::GetIid(void) const
-{
-    return mFields.m8 + kInterfaceIdentifierOffset;
-}
-
-uint8_t *Address::GetIid(void)
-{
-    return mFields.m8 + kInterfaceIdentifierOffset;
 }
 
 void Address::SetIid(const uint8_t *aIid)

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -127,15 +127,6 @@ public:
     bool IsLoopback(void) const;
 
     /**
-     * This method indicates whether or not the IPv6 address scope is Interface-Local.
-     *
-     * @retval TRUE   If the IPv6 address scope is Interface-Local.
-     * @retval FALSE  If the IPv6 address scope is not Interface-Local.
-     *
-     */
-    bool IsInterfaceLocal(void) const;
-
-    /**
      * This method indicates whether or not the IPv6 address scope is Link-Local.
      *
      * @retval TRUE   If the IPv6 address scope is Link-Local.

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -142,7 +142,7 @@ public:
      * @retval FALSE  If the IPv6 address scope is not a multicast address.
      *
      */
-    bool IsMulticast(void) const;
+    bool IsMulticast(void) const { return mFields.m8[0] == 0xff; }
 
     /**
      * This method indicates whether or not the IPv6 address is a link-local multicast address.
@@ -276,7 +276,7 @@ public:
      * @returns A pointer to the Interface Identifier.
      *
      */
-    const uint8_t *GetIid(void) const;
+    const uint8_t *GetIid(void) const { return mFields.m8 + kInterfaceIdentifierOffset; }
 
     /**
      * This method returns a pointer to the Interface Identifier.
@@ -284,7 +284,7 @@ public:
      * @returns A pointer to the Interface Identifier.
      *
      */
-    uint8_t *GetIid(void);
+    uint8_t *GetIid(void) { return mFields.m8 + kInterfaceIdentifierOffset; }
 
     /**
      * This method sets the Interface Identifier.


### PR DESCRIPTION
This PR contains a group of smaller commits all in `Ip6::Address`.

**[ip6-address] use larger data fields when checking against constants**

This commit changes methods in `Ip6::Address` class to use larger
fields (`m16` or `m32`) for comparing portions of address sequence
against constant values when possible.

**[ip6-address] simplify IsAnycastServiceLocator()**

This change ensures we avoid comparing values with host-swapped
constants.

**[ip6-address] remove undefined/unused method declaration**

**[ip6-address] inline very simple methods**

This commit inlines the very simple methods (containing a single
basic operation) in `Ip6::Address` class.


------------


Adding a note regarding the second commit: The original code for `IsAnycastServiceLocator()` contained:

```
   (mFields.m16[7] >= HostSwap16(Mle::kAloc16ServiceStart)) &&
   (mFields.m16[7] <= HostSwap16(Mle::kAloc16ServiceEnd)
```

with `kAloc16ServiceStart = 0xfc10` and `kAloc16ServiceEnd = 0xfc2f` and the intention to allow values within the start to end range.

Comparing a `uint16_t` with a `BigEndian::HostSwap16()` constant does not necessarily cover the same range of values. For example, if the platform is little-endian, and the bye sequence is `0x00`, `0x11`, the `uint16_t` value would be read as `0x1100` which would then be within the range of host-swapped constants, i.e. `0x10fc <= 0x1100 <= 0x2ffc` but it should not be accepted.

The behavior of the method in this case was actually fine since the `IsAnycastRoutingLocator()` already checked the `mFields.m8[14] == kAloc16Mask` (where `kAloc16Mask = 0xfc`), so not marking this as a bug. :)
