### PR TITLE
[ip6] fix conversion of enum value to uint8_t

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -76,13 +76,15 @@ Message *Ip6::NewMessage(const uint8_t *aData, uint16_t aDataLength, const otMes
 {
     otMessageSettings settings = {true, OT_MESSAGE_PRIORITY_NORMAL};
     Message *         message  = NULL;
+    uint8_t           priority;
 
     if (aSettings != NULL)
     {
         settings = *aSettings;
     }
 
-    SuccessOrExit(GetDatagramPriority(aData, aDataLength, *reinterpret_cast<uint8_t *>(&settings.mPriority)));
+    SuccessOrExit(GetDatagramPriority(aData, aDataLength, priority));
+    settings.mPriority = static_cast<otMessagePriority>(priority);
     VerifyOrExit((message = Get<MessagePool>().New(Message::kTypeIp6, 0, &settings)) != NULL);
 
     if (message->Append(aData, aDataLength) != OT_ERROR_NONE)


### PR DESCRIPTION
This commit updates how the `otMessagePriority` enumeration variable
is updated in `otMessageSettings` structure. This addresses an issue
where the enum variable was being treated as an `uint8_t` which may
not necessarily be correct (since complier can choose any integral
type which covers all the enumerator values as the underlying storage
for an unscoped enumeration type).

------

`*reinterpret_cast<uint8_t *>(&settings.mPriority)` should work ok on most platforms/toolchains. I think it would be incorrect only if the platform is big-endian and complier uses a larger integral type (than `uint8_t`) for the enum variable.  A bug but not that critical :)
