### PR TITLE
[mle] simplify how parent candidate is cleared

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -637,7 +637,7 @@ otError Mle::BecomeChild(AttachMode aMode)
         }
     }
 
-    ResetParentCandidate();
+    mParentCandidate.Clear();
     SetAttachState(kAttachStateStart);
     mParentRequestMode = aMode;
 
@@ -1765,7 +1765,7 @@ void Mle::HandleAttachTimer(void)
 
     case kAttachStateChildIdRequest:
         SetAttachState(kAttachStateIdle);
-        ResetParentCandidate();
+        mParentCandidate.Clear();
         delay = Reattach();
         break;
     }
@@ -3145,11 +3145,6 @@ exit:
     return rval;
 }
 
-void Mle::ResetParentCandidate(void)
-{
-    mParentCandidate.Clear();
-}
-
 otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, uint32_t aKeySequence)
 {
     otError                 error    = OT_ERROR_NONE;
@@ -3459,7 +3454,7 @@ otError Mle::HandleChildIdResponse(const Message &         aMessage,
     }
 
     mParent = mParentCandidate;
-    ResetParentCandidate();
+    mParentCandidate.Clear();
 
     mParent.SetRloc16(sourceAddress.GetRloc16());
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1722,7 +1722,6 @@ private:
 
     bool IsBetterParent(uint16_t aRloc16, uint8_t aLinkQuality, uint8_t aLinkMargin, ConnectivityTlv &aConnectivityTlv);
     bool IsNetworkDataNewer(const LeaderDataTlv &aLeaderData);
-    void ResetParentCandidate(void);
 
     otError GetAlocAddress(Ip6::Address &aAddress, uint16_t aAloc16) const;
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE


### PR DESCRIPTION
This commit inlines and removes `ResetParentCandidate()` method.