### PR TITLE
[settings] encode as packed little endian structs

### DIFF
--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -51,26 +51,29 @@ namespace ot {
 void SettingsBase::LogNetworkInfo(const char *aAction, const NetworkInfo &aNetworkInfo) const
 {
     otLogInfoCore("Non-volatile: %s NetworkInfo {rloc:0x%04x, extaddr:%s, role:%s, mode:0x%02x, keyseq:0x%x, ...",
-                  aAction, aNetworkInfo.mRloc16, aNetworkInfo.mExtAddress.ToString().AsCString(),
-                  Mle::Mle::RoleToString(static_cast<otDeviceRole>(aNetworkInfo.mRole)), aNetworkInfo.mDeviceMode,
-                  aNetworkInfo.mKeySequence);
+                  aAction, aNetworkInfo.GetRloc16(), aNetworkInfo.GetExtAddress().ToString().AsCString(),
+                  Mle::Mle::RoleToString(static_cast<otDeviceRole>(aNetworkInfo.GetRole())),
+                  aNetworkInfo.GetDeviceMode(), aNetworkInfo.GetKeySequence());
 
-    otLogInfoCore("Non-volatile: ... pid:0x%x, mlecntr:0x%x, maccntr:0x%x, mliid:%02x%02x%02x%02x%02x%02x%02x%02x}",
-                  aNetworkInfo.mPreviousPartitionId, aNetworkInfo.mMleFrameCounter, aNetworkInfo.mMacFrameCounter,
-                  aNetworkInfo.mMlIid[0], aNetworkInfo.mMlIid[1], aNetworkInfo.mMlIid[2], aNetworkInfo.mMlIid[3],
-                  aNetworkInfo.mMlIid[4], aNetworkInfo.mMlIid[5], aNetworkInfo.mMlIid[6], aNetworkInfo.mMlIid[7]);
+    otLogInfoCore(
+        "Non-volatile: ... pid:0x%x, mlecntr:0x%x, maccntr:0x%x, mliid:%02x%02x%02x%02x%02x%02x%02x%02x}",
+        aNetworkInfo.GetPreviousPartitionId(), aNetworkInfo.GetMleFrameCounter(), aNetworkInfo.GetMacFrameCounter(),
+        aNetworkInfo.GetMeshLocalIid()[0], aNetworkInfo.GetMeshLocalIid()[1], aNetworkInfo.GetMeshLocalIid()[2],
+        aNetworkInfo.GetMeshLocalIid()[3], aNetworkInfo.GetMeshLocalIid()[4], aNetworkInfo.GetMeshLocalIid()[5],
+        aNetworkInfo.GetMeshLocalIid()[6], aNetworkInfo.GetMeshLocalIid()[7]);
 }
 
 void SettingsBase::LogParentInfo(const char *aAction, const ParentInfo &aParentInfo) const
 {
-    otLogInfoCore("Non-volatile: %s ParentInfo {extaddr:%s}", aAction, aParentInfo.mExtAddress.ToString().AsCString());
+    otLogInfoCore("Non-volatile: %s ParentInfo {extaddr:%s}", aAction,
+                  aParentInfo.GetExtAddress().ToString().AsCString());
 }
 
 void SettingsBase::LogChildInfo(const char *aAction, const ChildInfo &aChildInfo) const
 {
     otLogInfoCore("Non-volatile: %s ChildInfo {rloc:0x%04x, extaddr:%s, timeout:%u, mode:0x%02x}", aAction,
-                  aChildInfo.mRloc16, aChildInfo.mExtAddress.ToString().AsCString(), aChildInfo.mTimeout,
-                  aChildInfo.mMode);
+                  aChildInfo.GetRloc16(), aChildInfo.GetExtAddress().ToString().AsCString(), aChildInfo.GetTimeout(),
+                  aChildInfo.GetMode());
 }
 
 #endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO)

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -83,6 +83,7 @@ public:
      * This structure represents the device's own network information for settings storage.
      *
      */
+    OT_TOOL_PACKED_BEGIN
     struct NetworkInfo
     {
         /**
@@ -100,12 +101,13 @@ public:
         uint32_t        mPreviousPartitionId;    ///< PartitionId
         Mac::ExtAddress mExtAddress;             ///< Extended Address
         uint8_t         mMlIid[OT_IP6_IID_SIZE]; ///< IID from ML-EID
-    };
+    } OT_TOOL_PACKED_END;
 
     /**
      * This structure represents the parent information for settings storage.
      *
      */
+    OT_TOOL_PACKED_BEGIN
     struct ParentInfo
     {
         /**
@@ -115,12 +117,13 @@ public:
         void Clear(void) { memset(this, 0, sizeof(*this)); }
 
         Mac::ExtAddress mExtAddress; ///< Extended Address
-    };
+    } OT_TOOL_PACKED_END;
 
     /**
      * This structure represents the child information for settings storage.
      *
      */
+    OT_TOOL_PACKED_BEGIN
     struct ChildInfo
     {
         /**
@@ -133,7 +136,7 @@ public:
         uint32_t        mTimeout;    ///< Timeout
         uint16_t        mRloc16;     ///< RLOC16
         uint8_t         mMode;       ///< The MLE device mode
-    };
+    } OT_TOOL_PACKED_END;
 
     /**
      * This enumeration defines the keys of settings.

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -36,6 +36,7 @@
 
 #include "openthread-core-config.h"
 
+#include "common/encoding.hpp"
 #include "common/locator.hpp"
 #include "mac/mac_types.hpp"
 #if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
@@ -84,14 +85,169 @@ public:
      *
      */
     OT_TOOL_PACKED_BEGIN
-    struct NetworkInfo
+    class NetworkInfo
     {
+    public:
         /**
          * This method clears the struct object (setting all the fields to zero).
          *
          */
         void Clear(void) { memset(this, 0, sizeof(*this)); }
 
+        /**
+         * This method returns the Thread role.
+         *
+         * @returns The Thread role.
+         *
+         */
+        uint8_t GetRole(void) const { return mRole; }
+
+        /**
+         * This method sets the Thread role.
+         *
+         * @param[in] aRole  The Thread Role.
+         *
+         */
+        void SetRole(uint8_t aRole) { mRole = aRole; }
+
+        /**
+         * This method returns the Thread device mode.
+         *
+         * @returns the Thread device mode.
+         *
+         */
+        uint8_t GetDeviceMode(void) const { return mDeviceMode; }
+
+        /**
+         * This method sets the Thread device mode.
+         *
+         * @param[in] aDeviceMode  The Thread device mode.
+         *
+         */
+        void SetDeviceMode(uint8_t aDeviceMode) { mDeviceMode = aDeviceMode; }
+
+        /**
+         * This method returns the RLOC16.
+         *
+         * @returns The RLOC16.
+         *
+         */
+        uint16_t GetRloc16(void) const { return Encoding::LittleEndian::HostSwap16(mRloc16); }
+
+        /**
+         * This method sets the RLOC16.
+         *
+         * @param[in] aRloc16  The RLOC16.
+         *
+         */
+        void SetRloc16(uint16_t aRloc16) { mRloc16 = Encoding::LittleEndian::HostSwap16(aRloc16); }
+
+        /**
+         * This method returns the key sequence.
+         *
+         * @returns The key sequence.
+         *
+         */
+        uint32_t GetKeySequence(void) const { return Encoding::LittleEndian::HostSwap32(mKeySequence); }
+
+        /**
+         * This method sets the key sequence.
+         *
+         * @param[in] aKeySequence  The key sequence.
+         *
+         */
+        void SetKeySequence(uint32_t aKeySequence) { mKeySequence = Encoding::LittleEndian::HostSwap32(aKeySequence); }
+
+        /**
+         * This method returns the MLE frame counter.
+         *
+         * @returns The MLE frame counter.
+         *
+         */
+        uint32_t GetMleFrameCounter(void) const { return Encoding::LittleEndian::HostSwap32(mMleFrameCounter); }
+
+        /**
+         * This method sets the MLE frame counter.
+         *
+         * @param[in] aMleFrameCounter  The MLE frame counter.
+         *
+         */
+        void SetMleFrameCounter(uint32_t aMleFrameCounter)
+        {
+            mMleFrameCounter = Encoding::LittleEndian::HostSwap32(aMleFrameCounter);
+        }
+
+        /**
+         * This method returns the MAC frame counter.
+         *
+         * @returns The MAC frame counter.
+         *
+         */
+        uint32_t GetMacFrameCounter(void) const { return Encoding::LittleEndian::HostSwap32(mMacFrameCounter); }
+
+        /**
+         * This method sets the MAC frame counter.
+         *
+         * @param[in] aMacFrameCounter  The MAC frame counter.
+         *
+         */
+        void SetMacFrameCounter(uint32_t aMacFrameCounter)
+        {
+            mMacFrameCounter = Encoding::LittleEndian::HostSwap32(aMacFrameCounter);
+        }
+
+        /**
+         * This method returns the previous partition ID.
+         *
+         * @returns The previous partition ID.
+         *
+         */
+        uint32_t GetPreviousPartitionId(void) const { return Encoding::LittleEndian::HostSwap32(mPreviousPartitionId); }
+
+        /**
+         * This method sets the previous partition id.
+         *
+         * @param[in] aPreviousPartitionId  The previous partition ID.
+         *
+         */
+        void SetPreviousPartitionId(uint32_t aPreviousPartitionId)
+        {
+            mPreviousPartitionId = Encoding::LittleEndian::HostSwap32(aPreviousPartitionId);
+        }
+
+        /**
+         * This method returns the extended address.
+         *
+         * @returns The extended address.
+         *
+         */
+        const Mac::ExtAddress &GetExtAddress(void) const { return mExtAddress; }
+
+        /**
+         * This method sets the extended address.
+         *
+         * @param[in] aExtAddress  The extended address.
+         *
+         */
+        void SetExtAddress(const Mac::ExtAddress &aExtAddress) { mExtAddress = aExtAddress; }
+
+        /**
+         * This method returns the Mesh Local Interface Identifier.
+         *
+         * @returns The Mesh Local Interface Identifier.
+         *
+         */
+        const uint8_t *GetMeshLocalIid(void) const { return mMlIid; }
+
+        /**
+         * This method sets the Mesh Local Interface Identifier.
+         *
+         * @param[in] aMeshLocalIid  The Mesh Local Interface Identifier.
+         *
+         */
+        void SetMeshLocalIid(const uint8_t *aMeshLocalIid) { memcpy(mMlIid, aMeshLocalIid, sizeof(mMlIid)); }
+
+    private:
         uint8_t         mRole;                   ///< Current Thread role.
         uint8_t         mDeviceMode;             ///< Device mode setting.
         uint16_t        mRloc16;                 ///< RLOC16
@@ -108,14 +264,32 @@ public:
      *
      */
     OT_TOOL_PACKED_BEGIN
-    struct ParentInfo
+    class ParentInfo
     {
+    public:
         /**
          * This method clears the struct object (setting all the fields to zero).
          *
          */
         void Clear(void) { memset(this, 0, sizeof(*this)); }
 
+        /**
+         * This method returns the extended address.
+         *
+         * @returns The extended address.
+         *
+         */
+        const Mac::ExtAddress &GetExtAddress(void) const { return mExtAddress; }
+
+        /**
+         * This method sets the extended address.
+         *
+         * @param[in] aExtAddress  The extended address.
+         *
+         */
+        void SetExtAddress(const Mac::ExtAddress &aExtAddress) { mExtAddress = aExtAddress; }
+
+    private:
         Mac::ExtAddress mExtAddress; ///< Extended Address
     } OT_TOOL_PACKED_END;
 
@@ -124,14 +298,80 @@ public:
      *
      */
     OT_TOOL_PACKED_BEGIN
-    struct ChildInfo
+    class ChildInfo
     {
+    public:
         /**
          * This method clears the struct object (setting all the fields to zero).
          *
          */
         void Clear(void) { memset(this, 0, sizeof(*this)); }
 
+        /**
+         * This method returns the extended address.
+         *
+         * @returns The extended address.
+         *
+         */
+        const Mac::ExtAddress &GetExtAddress(void) const { return mExtAddress; }
+
+        /**
+         * This method sets the extended address.
+         *
+         * @param[in] aExtAddress  The extended address.
+         *
+         */
+        void SetExtAddress(const Mac::ExtAddress &aExtAddress) { mExtAddress = aExtAddress; }
+
+        /**
+         * This method returns the child timeout.
+         *
+         * @returns The child timeout.
+         *
+         */
+        uint32_t GetTimeout(void) const { return Encoding::LittleEndian::HostSwap32(mTimeout); }
+
+        /**
+         * This method sets the child timeout.
+         *
+         * @param[in] aTimeout  The child timeout.
+         *
+         */
+        void SetTimeout(uint32_t aTimeout) { mTimeout = Encoding::LittleEndian::HostSwap32(aTimeout); }
+
+        /**
+         * This method returns the RLOC16.
+         *
+         * @returns The RLOC16.
+         *
+         */
+        uint16_t GetRloc16(void) const { return Encoding::LittleEndian::HostSwap16(mRloc16); }
+
+        /**
+         * This method sets the RLOC16.
+         *
+         * @param[in] aRloc16  The RLOC16.
+         *
+         */
+        void SetRloc16(uint16_t aRloc16) { mRloc16 = Encoding::LittleEndian::HostSwap16(aRloc16); }
+
+        /**
+         * This method returns the Thread device mode.
+         *
+         * @returns The Thread device mode.
+         *
+         */
+        uint8_t GetMode(void) const { return mMode; }
+
+        /**
+         * This method sets the Thread device mode.
+         *
+         * @param[in] aRloc16  The Thread device mode.
+         *
+         */
+        void SetMode(uint8_t aMode) { mMode = aMode; }
+
+    private:
         Mac::ExtAddress mExtAddress; ///< Extended Address
         uint32_t        mTimeout;    ///< Timeout
         uint16_t        mRloc16;     ///< RLOC16

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -375,12 +375,12 @@ otError Mle::Restore(void)
 
     SuccessOrExit(error = Get<Settings>().ReadNetworkInfo(networkInfo));
 
-    Get<KeyManager>().SetCurrentKeySequence(networkInfo.mKeySequence);
-    Get<KeyManager>().SetMleFrameCounter(networkInfo.mMleFrameCounter);
-    Get<KeyManager>().SetMacFrameCounter(networkInfo.mMacFrameCounter);
-    mDeviceMode.Set(networkInfo.mDeviceMode);
+    Get<KeyManager>().SetCurrentKeySequence(networkInfo.GetKeySequence());
+    Get<KeyManager>().SetMleFrameCounter(networkInfo.GetMleFrameCounter());
+    Get<KeyManager>().SetMacFrameCounter(networkInfo.GetMacFrameCounter());
+    mDeviceMode.Set(networkInfo.GetDeviceMode());
 
-    switch (networkInfo.mRole)
+    switch (networkInfo.GetRole())
     {
     case OT_DEVICE_ROLE_CHILD:
     case OT_DEVICE_ROLE_ROUTER:
@@ -391,18 +391,18 @@ otError Mle::Restore(void)
         ExitNow();
     }
 
-    Get<Mac::Mac>().SetShortAddress(networkInfo.mRloc16);
-    Get<Mac::Mac>().SetExtAddress(networkInfo.mExtAddress);
+    Get<Mac::Mac>().SetShortAddress(networkInfo.GetRloc16());
+    Get<Mac::Mac>().SetExtAddress(networkInfo.GetExtAddress());
 
-    memcpy(&mMeshLocal64.GetAddress().mFields.m8[OT_IP6_PREFIX_SIZE], networkInfo.mMlIid,
+    memcpy(&mMeshLocal64.GetAddress().mFields.m8[OT_IP6_PREFIX_SIZE], networkInfo.GetMeshLocalIid(),
            OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE);
 
-    if (networkInfo.mRloc16 == Mac::kShortAddrInvalid)
+    if (networkInfo.GetRloc16() == Mac::kShortAddrInvalid)
     {
         ExitNow();
     }
 
-    if (!IsActiveRouter(networkInfo.mRloc16))
+    if (!IsActiveRouter(networkInfo.GetRloc16()))
     {
         error = Get<Settings>().ReadParentInfo(parentInfo);
 
@@ -415,15 +415,15 @@ otError Mle::Restore(void)
             // exchange) and going through the full attach process.
 
             otLogWarnMle("Invalid settings - no saved parent info with valid end-device RLOC16 0x%04x",
-                         networkInfo.mRloc16);
+                         networkInfo.GetRloc16());
             ExitNow();
         }
 
         mParent.Clear();
-        mParent.SetExtAddress(*static_cast<Mac::ExtAddress *>(&parentInfo.mExtAddress));
+        mParent.SetExtAddress(parentInfo.GetExtAddress());
         mParent.SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                          DeviceMode::kModeFullNetworkData | DeviceMode::kModeSecureDataRequest));
-        mParent.SetRloc16(Rloc16FromRouterId(RouterIdFromRloc16(networkInfo.mRloc16)));
+        mParent.SetRloc16(Rloc16FromRouterId(RouterIdFromRloc16(networkInfo.GetRloc16())));
         mParent.SetState(Neighbor::kStateRestored);
 
 #if OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
@@ -433,7 +433,7 @@ otError Mle::Restore(void)
     else
     {
         Get<MleRouter>().SetRouterId(RouterIdFromRloc16(GetRloc16()));
-        Get<MleRouter>().SetPreviousPartitionId(networkInfo.mPreviousPartitionId);
+        Get<MleRouter>().SetPreviousPartitionId(networkInfo.GetPreviousPartitionId());
         Get<MleRouter>().RestoreChildren();
     }
 
@@ -454,18 +454,18 @@ otError Mle::Store(void)
         // avoid losing/overwriting previous information when a reboot
         // occurs after a message is sent but before attaching.
 
-        networkInfo.mRole                = mRole;
-        networkInfo.mRloc16              = GetRloc16();
-        networkInfo.mPreviousPartitionId = mLeaderData.GetPartitionId();
-        networkInfo.mExtAddress          = Get<Mac::Mac>().GetExtAddress();
-        memcpy(networkInfo.mMlIid, &mMeshLocal64.GetAddress().mFields.m8[OT_IP6_PREFIX_SIZE], OT_IP6_IID_SIZE);
+        networkInfo.SetRole(mRole);
+        networkInfo.SetRloc16(GetRloc16());
+        networkInfo.SetPreviousPartitionId(mLeaderData.GetPartitionId());
+        networkInfo.SetExtAddress(Get<Mac::Mac>().GetExtAddress());
+        networkInfo.SetMeshLocalIid(&mMeshLocal64.GetAddress().mFields.m8[OT_IP6_PREFIX_SIZE]);
 
         if (mRole == OT_DEVICE_ROLE_CHILD)
         {
             Settings::ParentInfo parentInfo;
 
             parentInfo.Clear();
-            parentInfo.mExtAddress = mParent.GetExtAddress();
+            parentInfo.SetExtAddress(mParent.GetExtAddress());
 
             SuccessOrExit(error = Get<Settings>().SaveParentInfo(parentInfo));
         }
@@ -483,15 +483,17 @@ otError Mle::Store(void)
         SuccessOrExit(Get<Settings>().ReadNetworkInfo(networkInfo));
     }
 
-    networkInfo.mKeySequence     = Get<KeyManager>().GetCurrentKeySequence();
-    networkInfo.mMleFrameCounter = Get<KeyManager>().GetMleFrameCounter() + OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD;
-    networkInfo.mMacFrameCounter = Get<KeyManager>().GetMacFrameCounter() + OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD;
-    networkInfo.mDeviceMode      = mDeviceMode.Get();
+    networkInfo.SetKeySequence(Get<KeyManager>().GetCurrentKeySequence());
+    networkInfo.SetMleFrameCounter(Get<KeyManager>().GetMleFrameCounter() +
+                                   OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD);
+    networkInfo.SetMacFrameCounter(Get<KeyManager>().GetMacFrameCounter() +
+                                   OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD);
+    networkInfo.SetDeviceMode(mDeviceMode.Get());
 
     SuccessOrExit(error = Get<Settings>().SaveNetworkInfo(networkInfo));
 
-    Get<KeyManager>().SetStoredMleFrameCounter(networkInfo.mMleFrameCounter);
-    Get<KeyManager>().SetStoredMacFrameCounter(networkInfo.mMacFrameCounter);
+    Get<KeyManager>().SetStoredMleFrameCounter(networkInfo.GetMleFrameCounter());
+    Get<KeyManager>().SetStoredMacFrameCounter(networkInfo.GetMacFrameCounter());
 
     otLogDebgMle("Store Network Information");
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3556,8 +3556,7 @@ void MleRouter::RestoreChildren(void)
         Child *                    child;
         const Settings::ChildInfo &childInfo = iter.GetChildInfo();
 
-        child = mChildTable.FindChild(*static_cast<const Mac::ExtAddress *>(&childInfo.mExtAddress),
-                                      Child::kInStateAnyExceptInvalid);
+        child = mChildTable.FindChild(childInfo.GetExtAddress(), Child::kInStateAnyExceptInvalid);
 
         if (child == NULL)
         {
@@ -3570,11 +3569,11 @@ void MleRouter::RestoreChildren(void)
 
         child->Clear();
 
-        child->SetExtAddress(*static_cast<const Mac::ExtAddress *>(&childInfo.mExtAddress));
+        child->SetExtAddress(childInfo.GetExtAddress());
         child->GetLinkInfo().Clear();
-        child->SetRloc16(childInfo.mRloc16);
-        child->SetTimeout(childInfo.mTimeout);
-        child->SetDeviceMode(DeviceMode(childInfo.mMode));
+        child->SetRloc16(childInfo.GetRloc16());
+        child->SetTimeout(childInfo.GetTimeout());
+        child->SetDeviceMode(DeviceMode(childInfo.GetMode()));
         child->SetState(Neighbor::kStateRestored);
         child->SetLastHeard(TimerMilli::GetNow());
         Get<IndirectSender>().SetChildUseShortAddress(*child, true);
@@ -3601,7 +3600,7 @@ otError MleRouter::RemoveStoredChild(uint16_t aChildRloc16)
 
     for (Settings::ChildInfoIterator iter(GetInstance()); !iter.IsDone(); iter++)
     {
-        if (iter.GetChildInfo().mRloc16 == aChildRloc16)
+        if (iter.GetChildInfo().GetRloc16() == aChildRloc16)
         {
             error = iter.Delete();
             ExitNow();
@@ -3619,10 +3618,10 @@ otError MleRouter::StoreChild(const Child &aChild)
     IgnoreReturnValue(RemoveStoredChild(aChild.GetRloc16()));
 
     childInfo.Clear();
-    childInfo.mExtAddress = aChild.GetExtAddress();
-    childInfo.mTimeout    = aChild.GetTimeout();
-    childInfo.mRloc16     = aChild.GetRloc16();
-    childInfo.mMode       = aChild.GetDeviceMode().Get();
+    childInfo.SetExtAddress(aChild.GetExtAddress());
+    childInfo.SetTimeout(aChild.GetTimeout());
+    childInfo.SetRloc16(aChild.GetRloc16());
+    childInfo.SetMode(aChild.GetDeviceMode().Get());
 
     return Get<Settings>().AddChildInfo(childInfo);
 }


### PR DESCRIPTION
The choice of little-endian was made for the following reasons:

- The existing encoding remains unchanged for settings unchanged on little-endian platforms.

- Eliminates any code overhead for little-endian platforms.

Resolves #4461 