### PR TITLE
[nrf528xx] fix synchronous GetRssi functionality

### DIFF
--- a/examples/platforms/nrf528xx/src/radio.c
+++ b/examples/platforms/nrf528xx/src/radio.c
@@ -71,6 +71,8 @@
 #define FRAME_PENDING_OFFSET  1            ///< Byte containing pending bit (+1 for frame length byte).
 #define FRAME_PENDING_BIT     (1 << 4)     ///< Frame Pending bit.
 
+#define RSSI_SETTLE_TIME_US   40           ///< RSSI settle time in microseconds.
+
 #if defined(__ICCARM__)
 _Pragma("diag_suppress=Pe167")
 #endif
@@ -412,6 +414,12 @@ otRadioFrame *otPlatRadioGetTransmitBuffer(otInstance *aInstance)
 int8_t otPlatRadioGetRssi(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
+
+    // Ensure the RSSI measurement is done after RSSI settling time.
+    // This is necessary for the Channel Monitor feature which quickly switches between channels.
+    NRFX_DELAY_US(RSSI_SETTLE_TIME_US);
+
+    nrf_802154_rssi_measure_begin();
 
     return nrf_802154_rssi_last_get();
 }


### PR DESCRIPTION
This PR aligns `otPlatRadioGetRssi` implementation with the latest changes to radio driver.

Without this change, for example, Channel Monitor and Energy Scanning with duration of 0 (`energy scan 0` command) does not work.