### PR TITLE
[sub-mac] fix incorrect timer configuration for energy scanning

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -431,6 +431,8 @@ exit:
 
 void SubMac::SampleRssi(void)
 {
+    assert(!RadioSupportsEnergyScan());
+
     int8_t rssi = GetRssi();
 
     if (rssi != kInvalidRssiValue)
@@ -443,7 +445,11 @@ void SubMac::SampleRssi(void)
 
     if (TimerMilli::GetNow() < mEnergyScanEndTime)
     {
+#if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+        mTimer.StartAt(mTimer.GetFireTime(), kEnergyScanRssiSampleInterval * 1000UL);
+#else
         mTimer.StartAt(mTimer.GetFireTime(), kEnergyScanRssiSampleInterval);
+#endif
     }
     else
     {


### PR DESCRIPTION
This fixes the implementation of Energy Scanning in case the platform does not support it, but uses timer with microsecond resolution. This is not the case with nRF528xx but found it during code inspection.

I've verified that after removing `OT_RADIO_CAPS_ENERGY_SCAN` capability, the Energy Scan now works correctly.