### PR TITLE
[address-resolver] resolve several issues

### DIFF
--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -248,8 +248,8 @@ otError AddressResolver::UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAd
 
             if (mCache[i].mState != Cache::kStateCached)
             {
-                mCache[i].mRetryTimeout        = 0;
                 mCache[i].mLastTransactionTime = static_cast<uint32_t>(kLastTransactionTimeInvalid);
+                mCache[i].mRetryTimeout        = 0;
                 mCache[i].mTimeout             = 0;
                 mCache[i].mFailures            = 0;
                 mCache[i].mState               = Cache::kStateCached;
@@ -273,11 +273,13 @@ otError AddressResolver::AddCacheEntry(const Ip6::Address &aEid, Mac::ShortAddre
 
     VerifyOrExit(entry != NULL, error = OT_ERROR_NO_BUFS);
 
-    entry->mTarget   = aEid;
-    entry->mRloc16   = aRloc16;
-    entry->mTimeout  = 0;
-    entry->mFailures = 0;
-    entry->mState    = Cache::kStateCached;
+    entry->mTarget              = aEid;
+    entry->mLastTransactionTime = static_cast<uint32_t>(kLastTransactionTimeInvalid);
+    entry->mRloc16              = aRloc16;
+    entry->mRetryTimeout        = 0;
+    entry->mTimeout             = 0;
+    entry->mFailures            = 0;
+    entry->mState               = Cache::kStateCached;
 
     MarkCacheEntryAsUsed(*entry);
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -564,8 +564,7 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
     Mac::ExtAddress       macAddr;
     Ip6::Address          destination;
 
-    VerifyOrExit(aMessage.GetType() == OT_COAP_TYPE_CONFIRMABLE && aMessage.GetCode() == OT_COAP_CODE_POST,
-                 error = OT_ERROR_DROP);
+    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST, error = OT_ERROR_DROP);
 
     otLogInfoArp("Received address error notification");
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -345,8 +345,9 @@ otError AddressResolver::AddCacheEntry(const Ip6::Address &aEid, Mac::ShortAddre
     entry->mTimeout             = 0;
     entry->mFailures            = 0;
     entry->mState               = Cache::kStateCached;
-
     MoveCacheEntryBehindCached(*entry);
+
+    otLogNoteArp("Cache entry added (snoop): %s, 0x%04x", aEid.ToString().AsCString(), aRloc16);
 
 exit:
     return error;

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -210,6 +210,7 @@ private:
 
     static const char *InvalidationReasonToString(InvalidationReason aReason);
 
+    void   Init(void);
     Cache *NewCacheEntry(void);
     void   MarkCacheEntryAsUsed(Cache &aEntry);
     void   InvalidateCacheEntry(Cache &aEntry, InvalidationReason aReason);

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -212,8 +212,13 @@ private:
 
     void   Init(void);
     Cache *NewCacheEntry(void);
-    void   MarkCacheEntryAsUsed(Cache &aEntry);
-    void   InvalidateCacheEntry(Cache &aEntry, InvalidationReason aReason);
+
+    void MoveCacheEntryAt(Cache &aEntry, uint8_t aAge);
+    void MoveCacheEntryAtFront(Cache &aEntry) { MoveCacheEntryAt(aEntry, 0); }
+    void MoveCacheEntryAtBack(Cache &aEntry) { MoveCacheEntryAt(aEntry, kCacheEntries - 1); }
+    void MoveCacheEntryBehindCached(Cache &aEntry);
+
+    void InvalidateCacheEntry(Cache &aEntry, InvalidationReason aReason);
 
     otError SendAddressQuery(const Ip6::Address &aEid);
     otError SendAddressError(const ThreadTargetTlv &      aTarget,


### PR DESCRIPTION
This PR includes four individual commits associated with the address resolver module. It should resolve #4535. It's the easiest to review them one-by-one.

**[address-resolver] accept multicast Address Error Notification**

This commit enables processing of Address Error Notification sent as non-confirmable CoAP multicast message. The code change relaxes the verification of CoAP type.
_____________________________________________________

**[address-resolver] fix last transaction time of entry created by packet inspection**

For cached entries created based on snooping message, the last transaction time was incorrectly set.
_____________________________________________________

**[address-resolver] dequeue a message from resolving queue before invalidate the entry**

During code inspection, I found that in two places, a cache entry may be invalidated in the query state. That may result in a packet permanently being stuck in resolving queue in the Mesh Forwarder layer.

The fast test, to emulate erroneous behavior without this PR:

Topology: Leader <--> Router

```
Leader:
> reset

Router:
> ping Leader_ML-EID
> state leader   (emulate moving to another partition, command needs to be executed within 3 seconds)
Done
> bufferinfo
...
arp: 1 1 (stays forever)
...
```

_____________________________________________________

**[address-resolver] introduce MoveAt functionality**

This commit introduces generic MoveCacheEntryAt functionality. This also helps to address @abtink request to put cache entries which are based on snooping messages, right after cached entries.

_____________________________________________________

I run some manual and stress tests on this PR. However, I think we should have more system/unit tests for address resolver/address error functionalities. Unfortunately, I don't have the bandwidth to add them now. 