### PR TITLE
[network-data] add check for invalid router IDs

### DIFF
--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -727,6 +727,8 @@ otError Leader::RegisterNetworkData(uint16_t aRloc16, uint8_t *aTlvs, uint8_t aT
     uint8_t oldTlvs[NetworkData::kMaxSize];
     uint8_t oldTlvsLength = NetworkData::kMaxSize;
 
+    VerifyOrExit(Get<RouterTable>().IsAllocated(Mle::Mle::RouterIdFromRloc16(aRloc16)), error = OT_ERROR_NO_ROUTE);
+
     // Verify that `aTlvs` only contains entries matching `aRloc16`.
     SuccessOrExit(error = RlocLookup(aRloc16, rlocIn, rlocStable, aTlvs, aTlvsLength, kMatchModeRloc16,
                                      /* aAllowOtherEntries */ false));


### PR DESCRIPTION
It is posisble for a leader to receive SVR_DATA.ntf messages
attempting to register with a router ID that is not valid on the
leader.

This commit does not allow registering network data with invalid
router IDs to avoid having stale network data that persists.

Addresses the issue raised by @mwilniewiec in https://github.com/openthread/openthread/issues/4472#issuecomment-584217141.