### PR TITLE
[docs] correct `dataset activetimestamp` example

### DIFF
--- a/src/cli/README_DATASET.md
+++ b/src/cli/README_DATASET.md
@@ -191,7 +191,7 @@ Usage: `dataset activetimestamp <timestamp>`
 Set active timestamp.
 
 ```bash
-> dataset activestamp 123456789
+> dataset activetimestamp 123456789
 Done
 ```
 


### PR DESCRIPTION
Resolves error reported by @markus-becker-tridonic-com in https://github.com/openthread/openthread/pull/4330.