### PR TITLE
[coap] smaller enhancements

### DIFF
--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -206,7 +206,7 @@ otError otCoapSendRequestWithParameters(otInstance *              aInstance,
 
     return instance.GetApplicationCoap().SendMessage(*static_cast<Coap::Message *>(aMessage),
                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-                                                     Coap::CoapTxParameters::From(aTxParameters), aHandler, aContext);
+                                                     Coap::TxParameters::From(aTxParameters), aHandler, aContext);
 }
 
 otError otCoapStart(otInstance *aInstance, uint16_t aPort)
@@ -253,7 +253,7 @@ otError otCoapSendResponseWithParameters(otInstance *              aInstance,
 
     return instance.GetApplicationCoap().SendMessage(*static_cast<Coap::Message *>(aMessage),
                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-                                                     Coap::CoapTxParameters::From(aTxParameters), NULL, NULL);
+                                                     Coap::TxParameters::From(aTxParameters), NULL, NULL);
 }
 
 #endif // OPENTHREAD_CONFIG_COAP_API_ENABLE

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -48,6 +48,8 @@ namespace Coap {
 
 CoapBase::CoapBase(Instance &aInstance, Sender aSender)
     : InstanceLocator(aInstance)
+    , mPendingRequests()
+    , mMessageId(Random::NonCrypto::GetUint16())
     , mRetransmissionTimer(aInstance, &Coap::HandleRetransmissionTimer, this)
     , mResources()
     , mContext(NULL)
@@ -57,42 +59,33 @@ CoapBase::CoapBase(Instance &aInstance, Sender aSender)
     , mDefaultHandlerContext(NULL)
     , mSender(aSender)
 {
-    mMessageId = Random::NonCrypto::GetUint16();
 }
 
 void CoapBase::ClearRequestsAndResponses(void)
 {
-    Message *    message = static_cast<Message *>(mPendingRequests.GetHead());
-    Message *    messageToRemove;
-    CoapMetadata coapMetadata;
-
-    // Remove all pending messages.
-    while (message != NULL)
-    {
-        messageToRemove = message;
-        message         = static_cast<Message *>(message->GetNext());
-
-        coapMetadata.ReadFrom(*messageToRemove);
-        FinalizeCoapTransaction(*messageToRemove, coapMetadata, NULL, NULL, OT_ERROR_ABORT);
-    }
-
+    ClearRequests(NULL); // Clear requests matching any address.
     mResponsesQueue.DequeueAllResponses();
 }
 
 void CoapBase::ClearRequests(const Ip6::Address &aAddress)
 {
+    ClearRequests(&aAddress);
+}
+
+void CoapBase::ClearRequests(const Ip6::Address *aAddress)
+{
     Message *nextMessage;
 
-    // Remove pending messages with the specified source.
     for (Message *message = static_cast<Message *>(mPendingRequests.GetHead()); message != NULL; message = nextMessage)
     {
-        CoapMetadata coapMetadata;
-        nextMessage = static_cast<Message *>(message->GetNext());
-        coapMetadata.ReadFrom(*message);
+        Metadata metadata;
 
-        if (coapMetadata.mSourceAddress == aAddress)
+        nextMessage = static_cast<Message *>(message->GetNext());
+        metadata.ReadFrom(*message);
+
+        if ((aAddress == NULL) || (metadata.mSourceAddress == *aAddress))
         {
-            FinalizeCoapTransaction(*message, coapMetadata, NULL, NULL, OT_ERROR_ABORT);
+            FinalizeCoapTransaction(*message, metadata, NULL, NULL, OT_ERROR_ABORT);
         }
     }
 }
@@ -108,10 +101,16 @@ void CoapBase::RemoveResource(Resource &aResource)
     aResource.SetNext(NULL);
 }
 
-void CoapBase::SetDefaultHandler(otCoapRequestHandler aHandler, void *aContext)
+void CoapBase::SetDefaultHandler(RequestHandler aHandler, void *aContext)
 {
     mDefaultHandler        = aHandler;
     mDefaultHandlerContext = aContext;
+}
+
+void CoapBase::SetInterceptor(Interceptor aInterceptor, void *aContext)
+{
+    mInterceptor = aInterceptor;
+    mContext     = aContext;
 }
 
 Message *CoapBase::NewMessage(const otMessageSettings *aSettings)
@@ -125,10 +124,15 @@ exit:
     return message;
 }
 
+otError CoapBase::Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+{
+    return mSender(*this, aMessage, aMessageInfo);
+}
+
 otError CoapBase::SendMessage(Message &               aMessage,
                               const Ip6::MessageInfo &aMessageInfo,
-                              const CoapTxParameters &aTxParameters,
-                              otCoapResponseHandler   aHandler,
+                              const TxParameters &    aTxParameters,
+                              ResponseHandler         aHandler,
                               void *                  aContext)
 {
     otError  error;
@@ -152,21 +156,22 @@ otError CoapBase::SendMessage(Message &               aMessage,
 
     if (aMessage.IsConfirmable())
     {
-        // Create a copy of entire message and enqueue it.
         copyLength = aMessage.GetLength();
     }
     else if (aMessage.IsNonConfirmable() && (aHandler != NULL))
     {
-        // As we do not retransmit non confirmable messages, create a copy of header only, for token information.
+        // As we do not retransmit non confirmable messages, create a
+        // copy of header only, for token information.
         copyLength = aMessage.GetOptionStart();
     }
 
     if (copyLength > 0)
     {
-        CoapMetadata coapMetadata =
-            CoapMetadata(aMessage.IsConfirmable(), aMessageInfo, aHandler, aContext, aTxParameters);
-        VerifyOrExit((storedCopy = CopyAndEnqueueMessage(aMessage, copyLength, coapMetadata)) != NULL,
-                     error = OT_ERROR_NO_BUFS);
+        Metadata metadata;
+
+        metadata.Init(aMessage.IsConfirmable(), aMessageInfo, aHandler, aContext, aTxParameters);
+        storedCopy = CopyAndEnqueueMessage(aMessage, copyLength, metadata);
+        VerifyOrExit(storedCopy != NULL, error = OT_ERROR_NO_BUFS);
     }
 
     SuccessOrExit(error = Send(aMessage, aMessageInfo));
@@ -179,6 +184,36 @@ exit:
     }
 
     return error;
+}
+
+otError CoapBase::SendMessage(Message &               aMessage,
+                              const Ip6::MessageInfo &aMessageInfo,
+                              ResponseHandler         aHandler,
+                              void *                  aContext)
+{
+    return SendMessage(aMessage, aMessageInfo, TxParameters::GetDefault(), aHandler, aContext);
+}
+
+otError CoapBase::SendReset(Message &aRequest, const Ip6::MessageInfo &aMessageInfo)
+{
+    return SendEmptyMessage(OT_COAP_TYPE_RESET, aRequest, aMessageInfo);
+}
+
+otError CoapBase::SendAck(const Message &aRequest, const Ip6::MessageInfo &aMessageInfo)
+{
+    return SendEmptyMessage(OT_COAP_TYPE_ACKNOWLEDGMENT, aRequest, aMessageInfo);
+}
+
+otError CoapBase::SendEmptyAck(const Message &aRequest, const Ip6::MessageInfo &aMessageInfo)
+{
+    return (aRequest.GetType() == OT_COAP_TYPE_CONFIRMABLE
+                ? SendHeaderResponse(OT_COAP_CODE_CHANGED, aRequest, aMessageInfo)
+                : OT_ERROR_INVALID_ARGS);
+}
+
+otError CoapBase::SendNotFound(const Message &aRequest, const Ip6::MessageInfo &aMessageInfo)
+{
+    return SendHeaderResponse(OT_COAP_CODE_NOT_FOUND, aRequest, aMessageInfo);
 }
 
 otError CoapBase::SendEmptyMessage(Message::Type aType, const Message &aRequest, const Ip6::MessageInfo &aMessageInfo)
@@ -253,46 +288,45 @@ void CoapBase::HandleRetransmissionTimer(void)
 {
     TimeMilli        now      = TimerMilli::GetNow();
     TimeMilli        nextTime = now.GetDistantFuture();
-    CoapMetadata     coapMetadata;
-    Message *        message;
+    Metadata         metadata;
     Message *        nextMessage;
     Ip6::MessageInfo messageInfo;
 
-    for (message = static_cast<Message *>(mPendingRequests.GetHead()); message != NULL; message = nextMessage)
+    for (Message *message = static_cast<Message *>(mPendingRequests.GetHead()); message != NULL; message = nextMessage)
     {
         nextMessage = static_cast<Message *>(message->GetNext());
 
-        coapMetadata.ReadFrom(*message);
+        metadata.ReadFrom(*message);
 
-        if (now >= coapMetadata.mNextTimerShot)
+        if (now >= metadata.mNextTimerShot)
         {
-            if (!coapMetadata.mConfirmable || (coapMetadata.mRetransmissionsRemaining == 0))
+            if (!metadata.mConfirmable || (metadata.mRetransmissionsRemaining == 0))
             {
                 // No expected response or acknowledgment.
-                FinalizeCoapTransaction(*message, coapMetadata, NULL, NULL, OT_ERROR_RESPONSE_TIMEOUT);
+                FinalizeCoapTransaction(*message, metadata, NULL, NULL, OT_ERROR_RESPONSE_TIMEOUT);
                 continue;
             }
 
             // Increment retransmission counter and timer.
-            coapMetadata.mRetransmissionsRemaining--;
-            coapMetadata.mRetransmissionTimeout *= 2;
-            coapMetadata.mNextTimerShot = now + coapMetadata.mRetransmissionTimeout;
-            coapMetadata.UpdateIn(*message);
+            metadata.mRetransmissionsRemaining--;
+            metadata.mRetransmissionTimeout *= 2;
+            metadata.mNextTimerShot = now + metadata.mRetransmissionTimeout;
+            metadata.UpdateIn(*message);
 
             // Retransmit
-            if (!coapMetadata.mAcknowledged)
+            if (!metadata.mAcknowledged)
             {
-                messageInfo.SetPeerAddr(coapMetadata.mDestinationAddress);
-                messageInfo.SetPeerPort(coapMetadata.mDestinationPort);
-                messageInfo.SetSockAddr(coapMetadata.mSourceAddress);
+                messageInfo.SetPeerAddr(metadata.mDestinationAddress);
+                messageInfo.SetPeerPort(metadata.mDestinationPort);
+                messageInfo.SetSockAddr(metadata.mSourceAddress);
 
                 SendCopy(*message, messageInfo);
             }
         }
 
-        if (nextTime > coapMetadata.mNextTimerShot)
+        if (nextTime > metadata.mNextTimerShot)
         {
-            nextTime = coapMetadata.mNextTimerShot;
+            nextTime = metadata.mNextTimerShot;
         }
     }
 
@@ -303,34 +337,33 @@ void CoapBase::HandleRetransmissionTimer(void)
 }
 
 void CoapBase::FinalizeCoapTransaction(Message &               aRequest,
-                                       const CoapMetadata &    aCoapMetadata,
+                                       const Metadata &        aMetadata,
                                        Message *               aResponse,
                                        const Ip6::MessageInfo *aMessageInfo,
                                        otError                 aResult)
 {
     DequeueMessage(aRequest);
 
-    if (aCoapMetadata.mResponseHandler != NULL)
+    if (aMetadata.mResponseHandler != NULL)
     {
-        aCoapMetadata.mResponseHandler(aCoapMetadata.mResponseContext, aResponse, aMessageInfo, aResult);
+        aMetadata.mResponseHandler(aMetadata.mResponseContext, aResponse, aMessageInfo, aResult);
     }
 }
 
-otError CoapBase::AbortTransaction(otCoapResponseHandler aHandler, void *aContext)
+otError CoapBase::AbortTransaction(ResponseHandler aHandler, void *aContext)
 {
-    otError      error = OT_ERROR_NOT_FOUND;
-    Message *    message;
-    Message *    nextMessage;
-    CoapMetadata coapMetadata;
+    otError  error = OT_ERROR_NOT_FOUND;
+    Message *nextMessage;
+    Metadata metadata;
 
-    for (message = static_cast<Message *>(mPendingRequests.GetHead()); message != NULL; message = nextMessage)
+    for (Message *message = static_cast<Message *>(mPendingRequests.GetHead()); message != NULL; message = nextMessage)
     {
         nextMessage = static_cast<Message *>(message->GetNext());
-        coapMetadata.ReadFrom(*message);
+        metadata.ReadFrom(*message);
 
-        if (coapMetadata.mResponseHandler == aHandler && coapMetadata.mResponseContext == aContext)
+        if (metadata.mResponseHandler == aHandler && metadata.mResponseContext == aContext)
         {
-            FinalizeCoapTransaction(*message, coapMetadata, NULL, NULL, OT_ERROR_ABORT);
+            FinalizeCoapTransaction(*message, metadata, NULL, NULL, OT_ERROR_ABORT);
             error = OT_ERROR_NONE;
         }
     }
@@ -338,22 +371,17 @@ otError CoapBase::AbortTransaction(otCoapResponseHandler aHandler, void *aContex
     return error;
 }
 
-Message *CoapBase::CopyAndEnqueueMessage(const Message &     aMessage,
-                                         uint16_t            aCopyLength,
-                                         const CoapMetadata &aCoapMetadata)
+Message *CoapBase::CopyAndEnqueueMessage(const Message &aMessage, uint16_t aCopyLength, const Metadata &aMetadata)
 {
     otError  error       = OT_ERROR_NONE;
     Message *messageCopy = NULL;
 
-    // Create a message copy of requested size.
     VerifyOrExit((messageCopy = aMessage.Clone(aCopyLength)) != NULL, error = OT_ERROR_NO_BUFS);
 
-    // Append the copy with retransmission data.
-    SuccessOrExit(error = aCoapMetadata.AppendTo(*messageCopy));
+    SuccessOrExit(error = aMetadata.AppendTo(*messageCopy));
 
-    mRetransmissionTimer.FireAtIfEarlier(aCoapMetadata.mNextTimerShot);
+    mRetransmissionTimer.FireAtIfEarlier(aMetadata.mNextTimerShot);
 
-    // Enqueue the message.
     mPendingRequests.Enqueue(*messageCopy);
 
 exit:
@@ -373,11 +401,9 @@ void CoapBase::DequeueMessage(Message &aMessage)
 
     if (mRetransmissionTimer.IsRunning() && (mPendingRequests.GetHead() == NULL))
     {
-        // No more requests pending, stop the timer.
         mRetransmissionTimer.Stop();
     }
 
-    // Free the message memory.
     aMessage.Free();
 
     // No need to worry that the earliest pending message was removed -
@@ -390,10 +416,9 @@ otError CoapBase::SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMes
     Message *messageCopy = NULL;
 
     // Create a message copy for lower layers.
-    VerifyOrExit((messageCopy = aMessage.Clone(aMessage.GetLength() - sizeof(CoapMetadata))) != NULL,
-                 error = OT_ERROR_NO_BUFS);
+    messageCopy = aMessage.Clone(aMessage.GetLength() - sizeof(Metadata));
+    VerifyOrExit(messageCopy != NULL, error = OT_ERROR_NO_BUFS);
 
-    // Send the copy.
     SuccessOrExit(error = Send(*messageCopy, aMessageInfo));
 
 exit:
@@ -408,18 +433,18 @@ exit:
 
 Message *CoapBase::FindRelatedRequest(const Message &         aResponse,
                                       const Ip6::MessageInfo &aMessageInfo,
-                                      CoapMetadata &          aCoapMetadata)
+                                      Metadata &              aMetadata)
 {
-    Message *message = static_cast<Message *>(mPendingRequests.GetHead());
+    Message *message;
 
-    while (message != NULL)
+    for (message = static_cast<Message *>(mPendingRequests.GetHead()); message != NULL;
+         message = static_cast<Message *>(message->GetNext()))
     {
-        aCoapMetadata.ReadFrom(*message);
+        aMetadata.ReadFrom(*message);
 
-        if (((aCoapMetadata.mDestinationAddress == aMessageInfo.GetPeerAddr()) ||
-             aCoapMetadata.mDestinationAddress.IsMulticast() ||
-             aCoapMetadata.mDestinationAddress.IsAnycastRoutingLocator()) &&
-            (aCoapMetadata.mDestinationPort == aMessageInfo.GetPeerPort()))
+        if (((aMetadata.mDestinationAddress == aMessageInfo.GetPeerAddr()) ||
+             aMetadata.mDestinationAddress.IsMulticast() || aMetadata.mDestinationAddress.IsAnycastRoutingLocator()) &&
+            (aMetadata.mDestinationPort == aMessageInfo.GetPeerPort()))
         {
             switch (aResponse.GetType())
             {
@@ -442,8 +467,6 @@ Message *CoapBase::FindRelatedRequest(const Message &         aResponse,
                 break;
             }
         }
-
-        message = static_cast<Message *>(message->GetNext());
     }
 
 exit:
@@ -475,23 +498,19 @@ void CoapBase::Receive(ot::Message &aMessage, const Ip6::MessageInfo &aMessageIn
 
 void CoapBase::ProcessReceivedResponse(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    CoapMetadata coapMetadata;
-    Message *    request = NULL;
-    otError      error   = OT_ERROR_NONE;
+    Metadata metadata;
+    Message *request = NULL;
+    otError  error   = OT_ERROR_NONE;
 
-    request = FindRelatedRequest(aMessage, aMessageInfo, coapMetadata);
-
-    if (request == NULL)
-    {
-        ExitNow();
-    }
+    request = FindRelatedRequest(aMessage, aMessageInfo, metadata);
+    VerifyOrExit(request != NULL);
 
     switch (aMessage.GetType())
     {
     case OT_COAP_TYPE_RESET:
         if (aMessage.IsEmpty())
         {
-            FinalizeCoapTransaction(*request, coapMetadata, NULL, NULL, OT_ERROR_ABORT);
+            FinalizeCoapTransaction(*request, metadata, NULL, NULL, OT_ERROR_ABORT);
         }
 
         // Silently ignore non-empty reset messages (RFC 7252, p. 4.2).
@@ -501,14 +520,14 @@ void CoapBase::ProcessReceivedResponse(Message &aMessage, const Ip6::MessageInfo
         if (aMessage.IsEmpty())
         {
             // Empty acknowledgment.
-            if (coapMetadata.mConfirmable)
+            if (metadata.mConfirmable)
             {
-                coapMetadata.mAcknowledged = true;
-                coapMetadata.UpdateIn(*request);
+                metadata.mAcknowledged = true;
+                metadata.UpdateIn(*request);
             }
 
             // Remove the message if response is not expected, otherwise await response.
-            if (coapMetadata.mResponseHandler == NULL)
+            if (metadata.mResponseHandler == NULL)
             {
                 DequeueMessage(*request);
             }
@@ -516,7 +535,7 @@ void CoapBase::ProcessReceivedResponse(Message &aMessage, const Ip6::MessageInfo
         else if (aMessage.IsResponse() && aMessage.IsTokenEqual(*request))
         {
             // Piggybacked response.
-            FinalizeCoapTransaction(*request, coapMetadata, &aMessage, &aMessageInfo, OT_ERROR_NONE);
+            FinalizeCoapTransaction(*request, metadata, &aMessage, &aMessageInfo, OT_ERROR_NONE);
         }
 
         // Silently ignore acknowledgments carrying requests (RFC 7252, p. 4.2)
@@ -526,20 +545,20 @@ void CoapBase::ProcessReceivedResponse(Message &aMessage, const Ip6::MessageInfo
     case OT_COAP_TYPE_CONFIRMABLE:
         // Send empty ACK if it is a CON message.
         SendAck(aMessage, aMessageInfo);
-        FinalizeCoapTransaction(*request, coapMetadata, &aMessage, &aMessageInfo, OT_ERROR_NONE);
+        FinalizeCoapTransaction(*request, metadata, &aMessage, &aMessageInfo, OT_ERROR_NONE);
         break;
 
     case OT_COAP_TYPE_NON_CONFIRMABLE:
         // Separate response.
 
-        if (coapMetadata.mDestinationAddress.IsMulticast() && coapMetadata.mResponseHandler != NULL)
+        if (metadata.mDestinationAddress.IsMulticast() && metadata.mResponseHandler != NULL)
         {
             // If multicast non-confirmable request, allow multiple responses
-            coapMetadata.mResponseHandler(coapMetadata.mResponseContext, &aMessage, &aMessageInfo, OT_ERROR_NONE);
+            metadata.mResponseHandler(metadata.mResponseContext, &aMessage, &aMessageInfo, OT_ERROR_NONE);
         }
         else
         {
-            FinalizeCoapTransaction(*request, coapMetadata, &aMessage, &aMessageInfo, OT_ERROR_NONE);
+            FinalizeCoapTransaction(*request, metadata, &aMessage, &aMessageInfo, OT_ERROR_NONE);
         }
 
         break;
@@ -551,7 +570,8 @@ exit:
     {
         if (aMessage.IsConfirmable() || aMessage.IsNonConfirmable())
         {
-            // Successfully parsed a header but no matching request was found - reject the message by sending reset.
+            // Successfully parsed a header but no matching request was
+            // found - reject the message by sending reset.
             SendReset(aMessage, aMessageInfo);
         }
     }
@@ -575,8 +595,8 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
     case OT_ERROR_NONE:
         cachedResponse->Finish();
         error = Send(*cachedResponse, aMessageInfo);
+
         // fall through
-        ;
 
     case OT_ERROR_NO_BUFS:
         ExitNow();
@@ -644,11 +664,11 @@ exit:
     }
 }
 
-CoapMetadata::CoapMetadata(bool                    aConfirmable,
-                           const Ip6::MessageInfo &aMessageInfo,
-                           otCoapResponseHandler   aHandler,
-                           void *                  aContext,
-                           const CoapTxParameters &aTxParameters)
+void CoapBase::Metadata::Init(bool                    aConfirmable,
+                              const Ip6::MessageInfo &aMessageInfo,
+                              ResponseHandler         aHandler,
+                              void *                  aContext,
+                              const TxParameters &    aTxParameters)
 {
     mSourceAddress            = aMessageInfo.GetSockAddr();
     mDestinationPort          = aMessageInfo.GetPeerPort();
@@ -657,20 +677,23 @@ CoapMetadata::CoapMetadata(bool                    aConfirmable,
     mResponseContext          = aContext;
     mRetransmissionsRemaining = aTxParameters.mMaxRetransmit;
     mRetransmissionTimeout    = aTxParameters.CalculateInitialRetransmissionTimeout();
+    mAcknowledged             = false;
+    mConfirmable              = aConfirmable;
+    mNextTimerShot =
+        TimerMilli::GetNow() + (aConfirmable ? mRetransmissionTimeout : aTxParameters.CalculateMaxTransmitWait());
+}
 
-    if (aConfirmable)
-    {
-        // Set next retransmission timeout.
-        mNextTimerShot = TimerMilli::GetNow() + mRetransmissionTimeout;
-    }
-    else
-    {
-        // Set overall response timeout.
-        mNextTimerShot = TimerMilli::GetNow() + aTxParameters.CalculateMaxTransmitWait();
-    }
+void CoapBase::Metadata::ReadFrom(const Message &aMessage)
+{
+    uint16_t length = aMessage.GetLength();
 
-    mAcknowledged = false;
-    mConfirmable  = aConfirmable;
+    assert(length >= sizeof(*this));
+    aMessage.Read(length - sizeof(*this), sizeof(*this), this);
+}
+
+int CoapBase::Metadata::UpdateIn(Message &aMessage) const
+{
+    return aMessage.Write(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
 }
 
 ResponsesQueue::ResponsesQueue(Instance &aInstance)
@@ -689,7 +712,7 @@ otError ResponsesQueue::GetMatchedResponseCopy(const Message &         aRequest,
     cacheResponse = FindMatchedResponse(aRequest, aMessageInfo);
     VerifyOrExit(cacheResponse != NULL, error = OT_ERROR_NOT_FOUND);
 
-    *aResponse = cacheResponse->Clone(cacheResponse->GetLength() - sizeof(EnqueuedResponseHeader));
+    *aResponse = cacheResponse->Clone(cacheResponse->GetLength() - sizeof(ResponseMetadata));
     VerifyOrExit(*aResponse != NULL, error = OT_ERROR_NO_BUFS);
 
 exit:
@@ -698,54 +721,42 @@ exit:
 
 const Message *ResponsesQueue::FindMatchedResponse(const Message &aRequest, const Ip6::MessageInfo &aMessageInfo) const
 {
-    Message *matchedResponse = NULL;
+    Message *message;
 
-    for (Message *message = static_cast<Message *>(mQueue.GetHead()); message != NULL;
-         message          = static_cast<Message *>(message->GetNext()))
+    for (message = static_cast<Message *>(mQueue.GetHead()); message != NULL;
+         message = static_cast<Message *>(message->GetNext()))
     {
-        EnqueuedResponseHeader enqueuedResponseHeader;
-        Ip6::MessageInfo       messageInfo;
-
-        enqueuedResponseHeader.ReadFrom(*message);
-        messageInfo = enqueuedResponseHeader.GetMessageInfo();
-
-        // Check source endpoint
-        if (messageInfo.GetPeerPort() != aMessageInfo.GetPeerPort())
+        if (message->GetMessageId() == aRequest.GetMessageId())
         {
-            continue;
-        }
+            ResponseMetadata metadata;
 
-        if (messageInfo.GetPeerAddr() != aMessageInfo.GetPeerAddr())
-        {
-            continue;
-        }
+            metadata.ReadFrom(*message);
 
-        // Check Message Id
-        if (message->GetMessageId() != aRequest.GetMessageId())
-        {
-            continue;
+            if ((metadata.mMessageInfo.GetPeerPort() == aMessageInfo.GetPeerPort()) &&
+                (metadata.mMessageInfo.GetPeerAddr() == aMessageInfo.GetPeerAddr()))
+            {
+                break;
+            }
         }
-
-        ExitNow(matchedResponse = message);
     }
 
-exit:
-    return matchedResponse;
+    return message;
 }
 
 void ResponsesQueue::EnqueueResponse(Message &               aMessage,
                                      const Ip6::MessageInfo &aMessageInfo,
-                                     const CoapTxParameters &aTxParameters)
+                                     const TxParameters &    aTxParameters)
 {
-    otError                error        = OT_ERROR_NONE;
-    Message *              responseCopy = NULL;
-    uint16_t               messageCount;
-    uint16_t               bufferCount;
-    uint32_t               exchangeLifetime = aTxParameters.CalculateExchangeLifetime();
-    TimeMilli              dequeueTime      = TimerMilli::GetNow() + exchangeLifetime;
-    EnqueuedResponseHeader enqueuedResponseHeader(dequeueTime, aMessageInfo);
+    otError          error        = OT_ERROR_NONE;
+    Message *        responseCopy = NULL;
+    uint16_t         messageCount;
+    uint16_t         bufferCount;
+    uint32_t         exchangeLifetime = aTxParameters.CalculateExchangeLifetime();
+    ResponseMetadata metadata;
 
-    // return success if matched response already exists in the cache
+    metadata.Init(TimerMilli::GetNow() + exchangeLifetime, aMessageInfo);
+
+    // Return success if matched response already exists in the cache.
     VerifyOrExit(FindMatchedResponse(aMessage, aMessageInfo) == NULL);
 
     mQueue.GetInfo(messageCount, bufferCount);
@@ -757,7 +768,7 @@ void ResponsesQueue::EnqueueResponse(Message &               aMessage,
 
     VerifyOrExit((responseCopy = aMessage.Clone()) != NULL);
 
-    SuccessOrExit(error = enqueuedResponseHeader.AppendTo(*responseCopy));
+    SuccessOrExit(error = metadata.AppendTo(*responseCopy));
     mQueue.Enqueue(*responseCopy);
 
     if (!mTimer.IsRunning())
@@ -773,6 +784,12 @@ exit:
     }
 
     return;
+}
+
+void ResponsesQueue::DequeueResponse(Message &aMessage)
+{
+    mQueue.Dequeue(aMessage);
+    aMessage.Free();
 }
 
 void ResponsesQueue::DequeueOldestResponse(void)
@@ -803,59 +820,70 @@ void ResponsesQueue::HandleTimer(Timer &aTimer)
 
 void ResponsesQueue::HandleTimer(void)
 {
-    Message *              message;
-    EnqueuedResponseHeader enqueuedResponseHeader;
+    Message *        message;
+    ResponseMetadata metadata;
 
     while ((message = static_cast<Message *>(mQueue.GetHead())) != NULL)
     {
-        enqueuedResponseHeader.ReadFrom(*message);
+        metadata.ReadFrom(*message);
 
-        if (TimerMilli::GetNow() >= enqueuedResponseHeader.mDequeueTime)
+        if (TimerMilli::GetNow() >= metadata.mDequeueTime)
         {
             DequeueResponse(*message);
         }
         else
         {
-            mTimer.Start(enqueuedResponseHeader.GetRemainingTime());
+            mTimer.Start(metadata.GetRemainingTime());
             break;
         }
     }
 }
 
-uint32_t EnqueuedResponseHeader::GetRemainingTime(void) const
+void ResponsesQueue::ResponseMetadata::Init(TimeMilli aDequeueTime, const Ip6::MessageInfo &aMessageInfo)
 {
-    TimeMilli now           = TimerMilli::GetNow();
-    uint32_t  remainingTime = 0;
-
-    if (mDequeueTime > now)
-    {
-        remainingTime = mDequeueTime - now;
-    }
-
-    return remainingTime;
+    mDequeueTime = aDequeueTime;
+    mMessageInfo = aMessageInfo;
 }
 
-uint32_t CoapTxParameters::CalculateInitialRetransmissionTimeout(void) const
+void ResponsesQueue::ResponseMetadata::ReadFrom(const Message &aMessage)
+{
+    uint16_t length = aMessage.GetLength();
+
+    assert(length >= sizeof(*this));
+    aMessage.Read(length - sizeof(*this), sizeof(*this), this);
+}
+
+uint32_t ResponsesQueue::ResponseMetadata::GetRemainingTime(void) const
+{
+    TimeMilli now = TimerMilli::GetNow();
+
+    return (mDequeueTime > now) ? mDequeueTime - now : 0;
+}
+
+uint32_t TxParameters::CalculateInitialRetransmissionTimeout(void) const
 {
     return Random::NonCrypto::GetUint32InRange(
         mAckTimeout, mAckTimeout * mAckRandomFactorNumerator / mAckRandomFactorDenominator + 1);
 }
 
-uint32_t CoapTxParameters::CalculateExchangeLifetime(void) const
+uint32_t TxParameters::CalculateExchangeLifetime(void) const
 {
-    uint32_t maxTransmitSpan = static_cast<uint32_t>(mAckTimeout * ((1ULL << mMaxRetransmit) - 1) *
-                                                     mAckRandomFactorNumerator / mAckRandomFactorDenominator);
-    uint32_t processingDelay = mAckTimeout;
-    return maxTransmitSpan + 2 * kDefaultMaxLatency + processingDelay;
+    // Final `mAckTimeout` is to account for processing delay.
+    return CalculateSpan(mMaxRetransmit) + 2 * kDefaultMaxLatency + mAckTimeout;
 }
 
-uint32_t CoapTxParameters::CalculateMaxTransmitWait(void) const
+uint32_t TxParameters::CalculateMaxTransmitWait(void) const
 {
-    return static_cast<uint32_t>(mAckTimeout * ((2ULL << mMaxRetransmit) - 1) * mAckRandomFactorNumerator /
+    return CalculateSpan(mMaxRetransmit + 1);
+}
+
+uint32_t TxParameters::CalculateSpan(uint32_t aMaxRetx) const
+{
+    return static_cast<uint32_t>(mAckTimeout * ((1ULL << aMaxRetx) - 1) * mAckRandomFactorNumerator /
                                  mAckRandomFactorDenominator);
 }
 
-const otCoapTxParameters CoapTxParameters::kDefaultTxParameters = {
+const otCoapTxParameters TxParameters::kDefaultTxParameters = {
     kDefaultAckTimeout,
     kDefaultAckRandomFactorNumerator,
     kDefaultAckRandomFactorDenominator,
@@ -896,6 +924,11 @@ void Coap::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessage
 {
     static_cast<Coap *>(aContext)->Receive(*static_cast<Message *>(aMessage),
                                            *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+}
+
+otError Coap::Send(CoapBase &aCoapBase, ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+{
+    return static_cast<Coap &>(aCoapBase).Send(aMessage, aMessageInfo);
 }
 
 otError Coap::Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -152,7 +152,7 @@ void CoapSecure::SetSslAuthMode(bool aVerifyPeerCertificate)
 
 #endif // OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
 
-otError CoapSecure::SendMessage(Message &aMessage, otCoapResponseHandler aHandler, void *aContext)
+otError CoapSecure::SendMessage(Message &aMessage, ResponseHandler aHandler, void *aContext)
 {
     otError error = OT_ERROR_NONE;
 
@@ -166,7 +166,7 @@ exit:
 
 otError CoapSecure::SendMessage(Message &               aMessage,
                                 const Ip6::MessageInfo &aMessageInfo,
-                                otCoapResponseHandler   aHandler,
+                                ResponseHandler         aHandler,
                                 void *                  aContext)
 {
     return CoapBase::SendMessage(aMessage, aMessageInfo, aHandler, aContext);

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -262,7 +262,7 @@ public:
      * @retval OT_ERROR_INVALID_STATE  DTLS connection was not initialized.
      *
      */
-    otError SendMessage(Message &aMessage, otCoapResponseHandler aHandler = NULL, void *aContext = NULL);
+    otError SendMessage(Message &aMessage, ResponseHandler aHandler = NULL, void *aContext = NULL);
 
     /**
      * This method sends a CoAP message over secure DTLS connection.
@@ -283,7 +283,7 @@ public:
      */
     otError SendMessage(Message &               aMessage,
                         const Ip6::MessageInfo &aMessageInfo,
-                        otCoapResponseHandler   aHandler = NULL,
+                        ResponseHandler         aHandler = NULL,
                         void *                  aContext = NULL);
 
     /**


### PR DESCRIPTION
**Edit**: New pushed commit rebased all changes on master and squashes them into a single commit. There are some new changes as well:

This commits contains the following changes:
- Declare `Metadata` as a private inner class of `CoapBase`. Also replace constructors with `Init()` method and removes the default empty constructor (since it is not needed).
- Add `ResponseMetadata` as private inner struct in `ResposeQueue`.
- Simplify `ResponsesQueue::FindMatchedResponse()`.
- Declare `CoapBase::Sender` as a protected type.
- Use initializer list in `CoapBase` constructor.
- Use `for` loop for iterating over messages in a message queue.
- Define `ResponseHandler` and `RequestHandler` types.
- Update `TxParameters` class. Add helper method for common calculation of span window, and remove unused constant definitions.
- Move more complex method implementation from header file into `cpp` file (helps reduce code size).
- Update comments and documentations.

----------------

This PR contain a bunch of smaller changes/enhancements in `coap` module:

**[coap] declare CoapMetadata as a private inner class of CoapBase**

This commit also replaces `CoapMetadata` constructors with `Init()`
methods and removes the default empty constructor (since it is not
needed).

**[coap] add ResponseMetadata as private inner struct in ResposeQueue**

This commit renames and moves `EnqueuedResponseHeader` definition as
`ResponseMetadata` declared as a private inner `struct` in the class
`ResponseQueue`. It also removes the unnecessary constructors for this
type (replacing them with `Init()` method) and simplifies the
implementation of `GetRemainingTime()`.


**[coap] simplify ResponsesQueue::FindMatchedResponse**

**[coap] declare CoapBase::Sender as a protected type**

Note that the `Sender` type is intended for use by sub-classes of
`CoapBase` only. This commit also declares `mSender` as a `const`
to emphasis that it would not change (this may help with tool-chain
code optimization).

**[coap] use initializer list in CoapBase constructor**

**[coap] use for loop for iterating over message in the queue**

This commit also include other smaller changes in `coap.cpp`.

**[coap] simplify calculation of constants kMaxTransmitSpan and kMaxTransmitWait**

**[coap] define ResponseHandler and RequestHandler types**

**[coap] update comments**
