### PR TITLE
[cli] always output command result

### DIFF
--- a/examples/platforms/cc1352/diag.c
+++ b/examples/platforms/cc1352/diag.c
@@ -46,17 +46,6 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-
-    // Add more platform specific diagnostics features here.
-    if (argc > 1)
-    {
-        snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
-    }
-}
-
 void otPlatDiagModeSet(bool aMode)
 {
     sDiagMode = aMode;

--- a/examples/platforms/cc2538/diag.c
+++ b/examples/platforms/cc2538/diag.c
@@ -45,15 +45,6 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
-{
-    OT_UNUSED_VARIABLE(argc);
-    OT_UNUSED_VARIABLE(aInstance);
-
-    // Add more platform specific diagnostics features here.
-    snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
-}
-
 void otPlatDiagModeSet(bool aMode)
 {
     sDiagMode = aMode;

--- a/examples/platforms/cc2650/diag.c
+++ b/examples/platforms/cc2650/diag.c
@@ -44,17 +44,6 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-
-    // Add more platform specific diagnostics features here.
-    if (argc > 1)
-    {
-        snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
-    }
-}
-
 void otPlatDiagModeSet(bool aMode)
 {
     sDiagMode = aMode;

--- a/examples/platforms/cc2652/diag.c
+++ b/examples/platforms/cc2652/diag.c
@@ -46,17 +46,6 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-
-    // Add more platform specific diagnostics features here.
-    if (argc > 1)
-    {
-        snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
-    }
-}
-
 void otPlatDiagModeSet(bool aMode)
 {
     sDiagMode = aMode;

--- a/examples/platforms/efr32mg12/diag.c
+++ b/examples/platforms/efr32mg12/diag.c
@@ -51,15 +51,6 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(argc);
-
-    // Add more platform specific diagnostics features here.
-    snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
-}
-
 void otPlatDiagModeSet(bool aMode)
 {
     sDiagMode = aMode;

--- a/examples/platforms/efr32mg13/diag.c
+++ b/examples/platforms/efr32mg13/diag.c
@@ -51,15 +51,6 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(argc);
-
-    // Add more platform specific diagnostics features here.
-    snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
-}
-
 void otPlatDiagModeSet(bool aMode)
 {
     sDiagMode = aMode;

--- a/examples/platforms/efr32mg21/diag.c
+++ b/examples/platforms/efr32mg21/diag.c
@@ -51,15 +51,6 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(argc);
-
-    // Add more platform specific diagnostics features here.
-    snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
-}
-
 void otPlatDiagModeSet(bool aMode)
 {
     sDiagMode = aMode;

--- a/examples/platforms/gp712/diag.c
+++ b/examples/platforms/gp712/diag.c
@@ -43,15 +43,6 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(argc);
-
-    // Add more platform specific diagnostics features here.
-    snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
-}
-
 void otPlatDiagModeSet(bool aMode)
 {
     sDiagMode = aMode;

--- a/examples/platforms/kw41z/diag.c
+++ b/examples/platforms/kw41z/diag.c
@@ -49,15 +49,6 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(argc);
-
-    // Add more platform specific diagnostics features here.
-    snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
-}
-
 void otPlatDiagModeSet(bool aMode)
 {
     sDiagMode = aMode;

--- a/examples/platforms/nrf528xx/src/diag.c
+++ b/examples/platforms/nrf528xx/src/diag.c
@@ -59,7 +59,7 @@ typedef enum
 struct PlatformDiagCommand
 {
     const char *mName;
-    void (*mCommand)(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
+    otError (*mCommand)(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
 };
 
 struct PlatformDiagMessage

--- a/examples/platforms/nrf528xx/src/diag.c
+++ b/examples/platforms/nrf528xx/src/diag.c
@@ -111,7 +111,7 @@ static bool startCarrierTransmision(void)
     return nrf_802154_continuous_carrier();
 }
 
-static void processListen(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+static otError processListen(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
@@ -136,9 +136,10 @@ static void processListen(otInstance *aInstance, int argc, char *argv[], char *a
 
 exit:
     appendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
-static void processID(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+static otError processID(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
@@ -163,9 +164,10 @@ static void processID(otInstance *aInstance, int argc, char *argv[], char *aOutp
 
 exit:
     appendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
-static void processTransmit(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+static otError processTransmit(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
     otError error = OT_ERROR_NONE;
 
@@ -243,9 +245,10 @@ static void processTransmit(otInstance *aInstance, int argc, char *argv[], char 
 
 exit:
     appendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
-static void processGpio(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+static otError processGpio(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
@@ -322,9 +325,10 @@ static void processGpio(otInstance *aInstance, int argc, char *argv[], char *aOu
 
 exit:
     appendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
-static void processTemp(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+static otError processTemp(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(argv);
@@ -343,9 +347,10 @@ static void processTemp(otInstance *aInstance, int argc, char *argv[], char *aOu
 
 exit:
     appendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
-static void processCcaThreshold(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+static otError processCcaThreshold(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
@@ -377,6 +382,7 @@ static void processCcaThreshold(otInstance *aInstance, int argc, char *argv[], c
 
 exit:
     appendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
 const struct PlatformDiagCommand sCommands[] = {
@@ -388,23 +394,21 @@ const struct PlatformDiagCommand sCommands[] = {
     {"transmit", &processTransmit},
 };
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+otError otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
-    size_t i;
+    otError error = OT_ERROR_NOT_IMPLEMENTED;
+    size_t  i;
 
     for (i = 0; i < otARRAY_LENGTH(sCommands); i++)
     {
         if (strcmp(argv[0], sCommands[i].mName) == 0)
         {
-            sCommands[i].mCommand(aInstance, argc - 1, argc > 1 ? &argv[1] : NULL, aOutput, aOutputMaxLen);
+            error = sCommands[i].mCommand(aInstance, argc - 1, argc > 1 ? &argv[1] : NULL, aOutput, aOutputMaxLen);
             break;
         }
     }
 
-    if (i == otARRAY_LENGTH(sCommands))
-    {
-        snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
-    }
+    return error;
 }
 
 void otPlatDiagModeSet(bool aMode)

--- a/examples/platforms/posix/diag.c
+++ b/examples/platforms/posix/diag.c
@@ -45,15 +45,6 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(argc);
-
-    // Add more platform specific diagnostics features here.
-    snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
-}
-
 void otPlatDiagModeSet(bool aMode)
 {
     sDiagMode = aMode;

--- a/examples/platforms/qpg6095/diag.c
+++ b/examples/platforms/qpg6095/diag.c
@@ -42,14 +42,6 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
-{
-    // Add more plarform specific diagnostics features here.
-    snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
-    OT_UNUSED_VARIABLE(argc);
-    OT_UNUSED_VARIABLE(aInstance);
-}
-
 void otPlatDiagModeSet(bool aMode)
 {
     sDiagMode = aMode;

--- a/examples/platforms/samr21/diag.c
+++ b/examples/platforms/samr21/diag.c
@@ -45,15 +45,6 @@
  */
 static bool sDiagMode = false;
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(argc);
-
-    // Add more platform specific diagnostics features here.
-    snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", argv[0]);
-}
-
 void otPlatDiagModeSet(bool aMode)
 {
     sDiagMode = aMode;

--- a/include/openthread/diag.h
+++ b/include/openthread/diag.h
@@ -60,8 +60,12 @@ extern "C" {
  * @param[out]  aOutput         The diagnostics execution result.
  * @param[in]   aOutputMaxLen   The output buffer size.
  *
+ * @retval  OT_ERROR_INVALID_ARGS       The command is supported but invalid arugments provided.
+ * @retval  OT_ERROR_NONE               The command is successfully process.
+ * @retval  OT_ERROR_NOT_IMPLEMENTED    The command is not supported.
+ *
  */
-void otDiagProcessCmd(otInstance *aInstance, int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
+otError otDiagProcessCmd(otInstance *aInstance, int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
 
 /**
  * This function processes a factory diagnostics command line.

--- a/include/openthread/platform/diag.h
+++ b/include/openthread/platform/diag.h
@@ -65,8 +65,12 @@ extern "C" {
  * @param[out]  aOutput         The diagnostics execution result.
  * @param[in]   aOutputMaxLen   The output buffer size.
  *
+ * @retval  OT_ERROR_INVALID_ARGS       The command is supported but invalid arugments provided.
+ * @retval  OT_ERROR_NONE               The command is successfully process.
+ * @retval  OT_ERROR_NOT_IMPLEMENTED    The command is not supported.
+ *
  */
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
+otError otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);
 
 /**
  * This function enables/disables the factory diagnostics mode.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2901,10 +2901,11 @@ void Interpreter::ProcessScan(int argc, char *argv[])
                                                &Interpreter::HandleActiveScanResult, this));
     }
 
-    return;
-
 exit:
-    AppendResult(error);
+    if (error != OT_ERROR_NONE)
+    {
+        AppendResult(error);
+    }
 }
 
 void Interpreter::HandleActiveScanResult(otActiveScanResult *aResult, void *aContext)

--- a/src/core/api/diags_api.cpp
+++ b/src/core/api/diags_api.cpp
@@ -49,11 +49,11 @@ void otDiagProcessCmdLine(otInstance *aInstance, const char *aString, char *aOut
     instance.Get<FactoryDiags::Diags>().ProcessLine(aString, aOutput, aOutputMaxLen);
 }
 
-void otDiagProcessCmd(otInstance *aInstance, int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError otDiagProcessCmd(otInstance *aInstance, int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    instance.Get<FactoryDiags::Diags>().ProcessCmd(aArgCount, aArgVector, aOutput, aOutputMaxLen);
+    return instance.Get<FactoryDiags::Diags>().ProcessCmd(aArgCount, aArgVector, aOutput, aOutputMaxLen);
 }
 
 bool otDiagIsEnabled(otInstance *aInstance)

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -45,6 +45,18 @@
 #include "radio/radio.hpp"
 #include "utils/parse_cmdline.hpp"
 
+OT_TOOL_WEAK
+otError otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+{
+    OT_UNUSED_VARIABLE(argc);
+    OT_UNUSED_VARIABLE(argv);
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aOutput);
+    OT_UNUSED_VARIABLE(aOutputMaxLen);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
+}
+
 namespace ot {
 namespace FactoryDiags {
 
@@ -63,7 +75,7 @@ Diags::Diags(Instance &aInstance)
 {
 }
 
-void Diags::ProcessChannel(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError Diags::ProcessChannel(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -77,9 +89,10 @@ void Diags::ProcessChannel(int aArgCount, char *aArgVector[], char *aOutput, siz
 
 exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
-void Diags::ProcessPower(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError Diags::ProcessPower(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -92,9 +105,10 @@ void Diags::ProcessPower(int aArgCount, char *aArgVector[], char *aOutput, size_
 
 exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
-void Diags::ProcessStart(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError Diags::ProcessStart(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     OT_UNUSED_VARIABLE(aArgCount);
     OT_UNUSED_VARIABLE(aArgVector);
@@ -102,9 +116,11 @@ void Diags::ProcessStart(int aArgCount, char *aArgVector[], char *aOutput, size_
     OT_UNUSED_VARIABLE(aOutputMaxLen);
 
     otPlatDiagModeSet(true);
+
+    return OT_ERROR_NONE;
 }
 
-void Diags::ProcessStop(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError Diags::ProcessStop(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     OT_UNUSED_VARIABLE(aArgCount);
     OT_UNUSED_VARIABLE(aArgVector);
@@ -112,6 +128,8 @@ void Diags::ProcessStop(int aArgCount, char *aArgVector[], char *aOutput, size_t
     OT_UNUSED_VARIABLE(aOutputMaxLen);
 
     otPlatDiagModeSet(false);
+
+    return OT_ERROR_NONE;
 }
 
 extern "C" void otPlatDiagAlarmFired(otInstance *aInstance)
@@ -143,7 +161,7 @@ Diags::Diags(Instance &aInstance)
     otPlatDiagTxPowerSet(mTxPower);
 }
 
-void Diags::ProcessChannel(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError Diags::ProcessChannel(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     otError error = OT_ERROR_NONE;
 
@@ -169,9 +187,10 @@ void Diags::ProcessChannel(int aArgCount, char *aArgVector[], char *aOutput, siz
 
 exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
-void Diags::ProcessPower(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError Diags::ProcessPower(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     otError error = OT_ERROR_NONE;
 
@@ -196,9 +215,10 @@ void Diags::ProcessPower(int aArgCount, char *aArgVector[], char *aOutput, size_
 
 exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
-void Diags::ProcessRepeat(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError Diags::ProcessRepeat(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     otError error = OT_ERROR_NONE;
 
@@ -233,9 +253,10 @@ void Diags::ProcessRepeat(int aArgCount, char *aArgVector[], char *aOutput, size
 
 exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
-void Diags::ProcessSend(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError Diags::ProcessSend(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -256,9 +277,10 @@ void Diags::ProcessSend(int aArgCount, char *aArgVector[], char *aOutput, size_t
 
 exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
-void Diags::ProcessStart(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError Diags::ProcessStart(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     OT_UNUSED_VARIABLE(aArgCount);
     OT_UNUSED_VARIABLE(aArgVector);
@@ -276,9 +298,10 @@ void Diags::ProcessStart(int aArgCount, char *aArgVector[], char *aOutput, size_
 
 exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
-void Diags::ProcessStats(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError Diags::ProcessStats(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     otError error = OT_ERROR_NONE;
 
@@ -303,9 +326,10 @@ void Diags::ProcessStats(int aArgCount, char *aArgVector[], char *aOutput, size_
 
 exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
-void Diags::ProcessStop(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError Diags::ProcessStop(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     OT_UNUSED_VARIABLE(aArgCount);
     OT_UNUSED_VARIABLE(aArgVector);
@@ -329,6 +353,7 @@ void Diags::ProcessStop(int aArgCount, char *aArgVector[], char *aOutput, size_t
 
 exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
 void Diags::TransmitPacket(void)
@@ -344,7 +369,7 @@ void Diags::TransmitPacket(void)
     Get<Radio>().Transmit(*static_cast<Mac::TxFrame *>(mTxPacket));
 }
 
-void Diags::ProcessRadio(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError Diags::ProcessRadio(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     otError error = OT_ERROR_INVALID_ARGS;
 
@@ -398,6 +423,7 @@ void Diags::ProcessRadio(int aArgCount, char *aArgVector[], char *aOutput, size_
 
 exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
 }
 
 extern "C" void otPlatDiagAlarmFired(otInstance *aInstance)
@@ -523,8 +549,10 @@ exit:
     }
 }
 
-void Diags::ProcessCmd(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError Diags::ProcessCmd(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
+    otError error = OT_ERROR_NONE;
+
     if (aArgCount == 0)
     {
         snprintf(aOutput, aOutputMaxLen, "diagnostics mode is %s\r\n", otPlatDiagModeGet() ? "enabled" : "disabled");
@@ -535,17 +563,23 @@ void Diags::ProcessCmd(int aArgCount, char *aArgVector[], char *aOutput, size_t 
     {
         if (strcmp(aArgVector[0], sCommands[i].mName) == 0)
         {
-            (this->*sCommands[i].mCommand)(aArgCount - 1, (aArgCount > 1) ? &aArgVector[1] : NULL, aOutput,
-                                           aOutputMaxLen);
+            error = (this->*sCommands[i].mCommand)(aArgCount - 1, (aArgCount > 1) ? &aArgVector[1] : NULL, aOutput,
+                                                   aOutputMaxLen);
             ExitNow();
         }
     }
 
     // more platform specific features will be processed under platform layer
-    otPlatDiagProcess(&GetInstance(), aArgCount, aArgVector, aOutput, aOutputMaxLen);
+    error = otPlatDiagProcess(&GetInstance(), aArgCount, aArgVector, aOutput, aOutputMaxLen);
 
 exit:
-    return;
+    // Add more platform specific diagnostics features here.
+    if (error == OT_ERROR_NOT_IMPLEMENTED && aArgCount > 1)
+    {
+        snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", aArgVector[0]);
+    }
+
+    return error;
 }
 
 bool Diags::IsEnabled(void)

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -76,8 +76,12 @@ public:
      * @param[out]  aOutput        The diagnostics execution result.
      * @param[in]   aOutputMaxLen  The output buffer size.
      *
+     * @retval  OT_ERROR_INVALID_ARGS       The command is supported but invalid arugments provided.
+     * @retval  OT_ERROR_NONE               The command is successfully process.
+     * @retval  OT_ERROR_NOT_IMPLEMENTED    The command is not supported.
+     *
      */
-    void ProcessCmd(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
+    otError ProcessCmd(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
 
     /**
      * This method indicates whether or not the factory diagnostics mode is enabled.
@@ -119,7 +123,7 @@ private:
     struct Command
     {
         const char *mName;
-        void (Diags::*mCommand)(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
+        otError (Diags::*mCommand)(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
     };
 
     struct Stats
@@ -134,14 +138,14 @@ private:
         uint8_t  mLastLqi;
     };
 
-    void ProcessChannel(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
-    void ProcessPower(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
-    void ProcessRadio(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
-    void ProcessRepeat(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
-    void ProcessSend(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
-    void ProcessStart(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
-    void ProcessStats(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
-    void ProcessStop(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
+    otError ProcessChannel(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
+    otError ProcessPower(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
+    otError ProcessRadio(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
+    otError ProcessRepeat(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
+    otError ProcessSend(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
+    otError ProcessStart(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
+    otError ProcessStats(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
+    otError ProcessStop(int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen);
 
     void TransmitPacket(void);
 

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -1896,7 +1896,7 @@ void platformSimRadioSpinelProcess(otInstance *aInstance, const struct Event *aE
 #endif // OPENTHREAD_POSIX_VIRTUAL_TIME
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+otError otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
     // deliver the platform specific diags commands to radio only ncp.
     OT_UNUSED_VARIABLE(aInstance);
@@ -1909,7 +1909,7 @@ void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOut
         cur += snprintf(cur, static_cast<size_t>(end - cur), "%s ", argv[index]);
     }
 
-    sRadioSpinel.PlatDiagProcess(cmd, aOutput, aOutputMaxLen);
+    return sRadioSpinel.PlatDiagProcess(cmd, aOutput, aOutputMaxLen);
 }
 
 void otPlatDiagModeSet(bool aMode)

--- a/tests/fuzz/fuzzer_platform.c
+++ b/tests/fuzz/fuzzer_platform.c
@@ -145,7 +145,7 @@ bool otDiagIsEnabled(otInstance *aInstance)
     return false;
 }
 
-void otDiagProcessCmd(otInstance *aInstance, int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
+otError otDiagProcessCmd(otInstance *aInstance, int aArgCount, char *aArgVector[], char *aOutput, size_t aOutputMaxLen)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aArgCount);
@@ -447,13 +447,15 @@ otError otPlatUartFlush(void)
     return OT_ERROR_NOT_IMPLEMENTED;
 }
 
-void otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+otError otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(argc);
     OT_UNUSED_VARIABLE(argv);
     OT_UNUSED_VARIABLE(aOutput);
     OT_UNUSED_VARIABLE(aOutputMaxLen);
+
+    return OT_ERROR_INVALID_ARGS;
 }
 
 void otPlatDiagModeSet(bool aMode)

--- a/tests/scripts/thread-cert/test_diag.py
+++ b/tests/scripts/thread-cert/test_diag.py
@@ -47,8 +47,8 @@ class TestDiag(unittest.TestCase):
     def test(self):
         cases = [
             ('diag\n', 'diagnostics mode is disabled\r\n'),
-            ('diag send 10 100\n', 'failed\r\nstatus 0xd\r\n'),
-            ('diag start\n', 'start diagnostics mode\r\nstatus 0x00\r\n'),
+            ('diag send 10 100\n', 'Error 13: InvalidState\r\n'),
+            ('diag start\n', 'Done\r\n'),
             ('diag invalid test\n',
              'diag feature \'invalid\' is not supported'),
             ('diag', 'diagnostics mode is enabled\r\n'),


### PR DESCRIPTION
Always output command result, i.e. "Done" on success, error message
otherwise.

Factory commands also follow the same pattern. Their existing error
messages are not removed for backward compatibility consideration.