### PR TITLE
[efr32] remove -Wundef for SDK sources

### DIFF
--- a/third_party/silabs/Makefile.am
+++ b/third_party/silabs/Makefile.am
@@ -58,6 +58,10 @@ override CXXFLAGS  := $(filter-out -pedantic-errors,$(CXXFLAGS))
 override CFLAGS    := $(filter-out -Wshadow,$(CFLAGS))
 override CXXFLAGS  := $(filter-out -Wshadow,$(CXXFLAGS))
 
+# Do not enable -Wundef for Silicon Labs SDK sources
+override CFLAGS    := $(filter-out -Wundef,$(CFLAGS))
+override CXXFLAGS  := $(filter-out -Wundef,$(CXXFLAGS))
+
 EFR32_BOARD_DIR = $(shell echo $(BOARD) | tr A-Z a-z)
 
 SDK_SRC_DIR = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.7


### PR DESCRIPTION
Restore the lines accidentally removed by commit 609665d0174042d6840a7d221cbc4dfd2a1f9b6f