### PR TITLE
[locator] adding InstanceLocatorInit (providing default constructor)

### DIFF
--- a/src/core/common/locator.hpp
+++ b/src/core/common/locator.hpp
@@ -71,6 +71,8 @@ extern uint64_t gInstanceRaw[];
  */
 class InstanceLocator
 {
+    friend class InstanceLocatorInit;
+
 public:
     /**
      * This method returns a reference to the parent OpenThread Instance.
@@ -79,7 +81,7 @@ public:
      *
      */
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
-    Instance &GetInstance(void) const { return mInstance; }
+    Instance &GetInstance(void) const { return *mInstance; }
 #else
     Instance &GetInstance(void) const { return *reinterpret_cast<Instance *>(&gInstanceRaw); }
 #endif
@@ -101,21 +103,62 @@ protected:
     /**
      * This constructor initializes the object.
      *
-     * @param[in]  aInstance  A pointer to the otInstance.
+     * @param[in]  aInstance  A reference to the OpenThread Instance.
      *
      */
     explicit InstanceLocator(Instance &aInstance)
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
-        : mInstance(aInstance)
+        : mInstance(&aInstance)
 #endif
     {
         OT_UNUSED_VARIABLE(aInstance);
     }
 
-#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
 private:
-    Instance &mInstance;
+    InstanceLocator(void) {}
+
+#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+    Instance *mInstance;
 #endif
+};
+
+/**
+ * This class implements a locator for an OpenThread Instance object.
+ *
+ * The `InstanceLocatorInit` is similar to `InstanceLoator` but provides a default constructor (instead of a
+ * parameterized one) and allows an inheriting class to initialize the object (set the OpenThread Instance) post
+ * constructor call using the `Init()` method. This class is intended for types that require a default constructor and
+ * cannot use a parameterized one. (e.g., `Neighbor`/`Child`/`Router` classes which are used as a C array element type
+ * in`ChildTable`/`RouterTable`).
+ *
+ * The inheriting class from `InstanceLocatorInit` should ensure that object is properly initialized after the object
+ * is created and more importantly that it is re-initialized when/if it is cleared or reset.
+ *
+ */
+class InstanceLocatorInit : public InstanceLocator
+{
+protected:
+    /**
+     * This is the default constructor for the `InstanceLocatorInit` object.
+     *
+     */
+    InstanceLocatorInit(void)
+        : InstanceLocator()
+    {
+    }
+
+    /**
+     * This method (re)initializes the object and sets the OpenThread Instance.
+     *
+     * @param[in] aInstance  A reference to the OpenThread Instance.
+     */
+    void Init(Instance &aInstance)
+    {
+#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+        mInstance = &aInstance;
+#endif
+        OT_UNUSED_VARIABLE(aInstance);
+    }
 };
 
 /**

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1181,7 +1181,7 @@ void Mac::RecordFrameTransmitStatus(const TxFrame &aFrame,
 
     if ((aError == OT_ERROR_NONE) && ackRequested && (aAckFrame != NULL) && (neighbor != NULL))
     {
-        neighbor->GetLinkInfo().AddRss(GetNoiseFloor(), aAckFrame->GetRssi());
+        neighbor->GetLinkInfo().AddRss(aAckFrame->GetRssi());
     }
 
     // Update MAC counters.
@@ -1648,7 +1648,7 @@ void Mac::HandleReceivedFrame(RxFrame *aFrame, otError aError)
 
     if (neighbor != NULL)
     {
-        neighbor->GetLinkInfo().AddRss(GetNoiseFloor(), aFrame->GetRssi());
+        neighbor->GetLinkInfo().AddRss(aFrame->GetRssi());
 
         if (aFrame->GetSecurityEnabled())
         {
@@ -1876,11 +1876,6 @@ void Mac::ResetRetrySuccessHistogram()
     memset(&mRetryHistogram, 0, sizeof(mRetryHistogram));
 }
 #endif // OPENTHREAD_CONFIG_MAC_RETRY_SUCCESS_HISTOGRAM_ENABLE
-
-int8_t Mac::GetNoiseFloor(void)
-{
-    return Get<Radio>().GetReceiveSensitivity();
-}
 
 // LCOV_EXCL_START
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -609,7 +609,7 @@ public:
      * @returns The noise floor value in dBm.
      *
      */
-    int8_t GetNoiseFloor(void);
+    int8_t GetNoiseFloor(void) { return mSubMac.GetNoiseFloor(); }
 
     /**
      * This method returns the current CCA (Clear Channel Assessment) failure rate.

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -388,6 +388,11 @@ int8_t SubMac::GetRssi(void) const
     return Get<Radio>().GetRssi();
 }
 
+int8_t SubMac::GetNoiseFloor(void)
+{
+    return Get<Radio>().GetReceiveSensitivity();
+}
+
 otError SubMac::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration)
 {
     otError error = OT_ERROR_NONE;

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -339,6 +339,14 @@ public:
      */
     otError EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration);
 
+    /**
+     * This method returns the noise floor value (currently use the radio receive sensitivity value).
+     *
+     * @returns The noise floor value in dBm.
+     *
+     */
+    int8_t GetNoiseFloor(void);
+
 private:
     enum
     {

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -681,7 +681,7 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
             // Mesh Local EID differs, so check whether Target EID
             // matches a child address and if so remove it.
 
-            if (child.RemoveIp6Address(GetInstance(), targetTlv.GetTarget()) == OT_ERROR_NONE)
+            if (child.RemoveIp6Address(targetTlv.GetTarget()) == OT_ERROR_NONE)
             {
                 destination.Clear();
                 destination.mFields.m16[0] = HostSwap16(0xfe80);
@@ -742,7 +742,7 @@ void AddressResolver::HandleAddressQuery(Coap::Message &aMessage, const Ip6::Mes
             continue;
         }
 
-        if (child.HasIp6Address(GetInstance(), targetTlv.GetTarget()))
+        if (child.HasIp6Address(targetTlv.GetTarget()))
         {
             mlIidTlv.SetIid(child.GetExtAddress());
             lastTransactionTimeTlv.SetTime(TimerMilli::GetNow() - child.GetLastHeard());

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -102,7 +102,11 @@ ChildTable::ChildTable(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mMaxChildrenAllowed(kMaxChildren)
 {
-    Clear();
+    for (Child *child = &mChildren[0]; child < OT_ARRAY_END(mChildren); child++)
+    {
+        child->Init(aInstance);
+        child->Clear();
+    }
 }
 
 void ChildTable::Clear(void)

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -150,7 +150,7 @@ void LinkQualityInfo::Clear(void)
     mMessageErrorRate.Reset();
 }
 
-void LinkQualityInfo::AddRss(int8_t aNoiseFloor, int8_t aRss)
+void LinkQualityInfo::AddRss(int8_t aRss)
 {
     uint8_t oldLinkQuality = kNoLinkQuality;
 
@@ -165,10 +165,15 @@ void LinkQualityInfo::AddRss(int8_t aNoiseFloor, int8_t aRss)
 
     SuccessOrExit(mRssAverager.Add(aRss));
 
-    SetLinkQuality(CalculateLinkQuality(GetLinkMargin(aNoiseFloor), oldLinkQuality));
+    SetLinkQuality(CalculateLinkQuality(GetLinkMargin(), oldLinkQuality));
 
 exit:
     return;
+}
+
+uint8_t LinkQualityInfo::GetLinkMargin(void) const
+{
+    return ConvertRssToLinkMargin(Get<Mac::SubMac>().GetNoiseFloor(), GetAverageRss());
 }
 
 LinkQualityInfo::InfoString LinkQualityInfo::ToInfoString(void) const

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -37,6 +37,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
+#include "common/locator-getters.hpp"
 
 namespace ot {
 

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/platform/radio.h>
 
+#include "common/locator.hpp"
 #include "common/string.hpp"
 
 namespace ot {
@@ -215,7 +216,7 @@ private:
  * strength (RSS), last RSS, link margin, and link quality.
  *
  */
-class LinkQualityInfo
+class LinkQualityInfo : public InstanceLocatorInit
 {
 public:
     enum
@@ -228,6 +229,14 @@ public:
      *
      */
     typedef String<kInfoStringSize> InfoString;
+
+    /**
+     * This method initializes the `LinkQualityInfo` object.
+     *
+     * @param[in] aInstance  A reference to the OpenThread instance.
+     *
+     */
+    void Init(Instance &aInstance) { InstanceLocatorInit::Init(aInstance); }
 
     /**
      * This method clears the all the data in the object.

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -247,11 +247,10 @@ public:
     /**
      * This method adds a new received signal strength (RSS) value to the average.
      *
-     * @param[in] aNoiseFloor  The noise floor value (in dBm).
      * @param[in] aRss         A new received signal strength value (in dBm) to be added to the average.
      *
      */
-    void AddRss(int8_t aNoiseFloor, int8_t aRss);
+    void AddRss(int8_t aRss);
 
     /**
      * This method returns the current average received signal strength value.
@@ -282,12 +281,10 @@ public:
      * This method returns the link margin. The link margin is calculated using the link's current average received
      * signal strength (RSS) and average noise floor.
      *
-     * @param[in]  aNoiseFloor  The noise floor value (in dBm).
-     *
      * @returns Link margin derived from average received signal strength and average noise floor.
      *
      */
-    uint8_t GetLinkMargin(int8_t aNoiseFloor) const { return ConvertRssToLinkMargin(aNoiseFloor, GetAverageRss()); }
+    uint8_t GetLinkMargin(void) const;
 
     /**
      * Returns the current one-way link quality value. The link quality value is a number 0-3.
@@ -299,8 +296,6 @@ public:
      * In order to ensure that a link margin near the boundary of two different link quality values does not cause
      * frequent changes, a hysteresis of 2 dB is applied when determining the link quality. For example, the average
      * link margin must be at least 12 dB to change a quality 1 link to a quality 2 link.
-     *
-     * @param[in]  aNoiseFloor  The noise floor value (in dBm).
      *
      * @returns The current link quality value (value 0-3 as per Thread specification).
      *

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -114,6 +114,9 @@ Mle::Mle(Instance &aInstance)
 {
     otMeshLocalPrefix meshLocalPrefix;
 
+    mParent.Init(aInstance);
+    mParentCandidate.Init(aInstance);
+
     mLeaderData.Clear();
     mParentLeaderData.Clear();
     mParent.Clear();

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3328,7 +3328,7 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
     mParentCandidate.SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                               DeviceMode::kModeFullNetworkData | DeviceMode::kModeSecureDataRequest));
     mParentCandidate.GetLinkInfo().Clear();
-    mParentCandidate.GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+    mParentCandidate.GetLinkInfo().AddRss(linkInfo->mRss);
     mParentCandidate.ResetLinkFailures();
     mParentCandidate.SetLinkQualityOut(LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMarginTlv.GetLinkMargin()));
     mParentCandidate.SetState(Neighbor::kStateParentResponse);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2021,7 +2021,7 @@ otError MleRouter::UpdateChildAddresses(const Message &aMessage, uint16_t aOffse
         // We try to accept/add as many IPv6 addresses as possible.
         // "Child ID/Update Response" will indicate the accepted
         // addresses.
-        error = aChild.AddIp6Address(GetInstance(), address);
+        error = aChild.AddIp6Address(address);
 
         if (error == OT_ERROR_NONE)
         {
@@ -2057,7 +2057,7 @@ otError MleRouter::UpdateChildAddresses(const Message &aMessage, uint16_t aOffse
                 continue;
             }
 
-            IgnoreReturnValue(iter.GetChild()->RemoveIp6Address(GetInstance(), address));
+            IgnoreReturnValue(iter.GetChild()->RemoveIp6Address(address));
         }
 
         // Clear EID-to-RLOC cache for the unicast address registered by the child.
@@ -3356,7 +3356,7 @@ Neighbor *MleRouter::GetNeighbor(const Ip6::Address &aAddress)
             ExitNow(rval = child);
         }
 
-        if (child->HasIp6Address(GetInstance(), aAddress))
+        if (child->HasIp6Address(aAddress))
         {
             ExitNow(rval = child);
         }
@@ -3539,7 +3539,7 @@ otError MleRouter::GetChildNextIp6Address(uint16_t                   aChildIndex
     VerifyOrExit(child != NULL, error = OT_ERROR_INVALID_ARGS);
     VerifyOrExit(child->IsStateValidOrRestoring(), error = OT_ERROR_INVALID_ARGS);
 
-    error = child->GetNextIp6Address(GetInstance(), aIterator, aAddress);
+    error = child->GetNextIp6Address(aIterator, aAddress);
 
 exit:
     return error;
@@ -4351,7 +4351,7 @@ otError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
     tlv.SetType(Tlv::kAddressRegistration);
     SuccessOrExit(error = aMessage.Append(&tlv, sizeof(tlv)));
 
-    while (aChild.GetNextIp6Address(GetInstance(), iterator, address) == OT_ERROR_NONE)
+    while (aChild.GetNextIp6Address(iterator, address) == OT_ERROR_NONE)
     {
         if (address.IsMulticast() || Get<NetworkData::Leader>().GetContext(address, context) != OT_ERROR_NONE)
         {
@@ -4704,8 +4704,7 @@ exit:
 
 bool MleRouter::IsSleepyChildSubscribed(const Ip6::Address &aAddress, Child &aChild)
 {
-    return aChild.IsStateValidOrRestoring() && !aChild.IsRxOnWhenIdle() &&
-           aChild.HasIp6Address(GetInstance(), aAddress);
+    return aChild.IsStateValidOrRestoring() && !aChild.IsRxOnWhenIdle() && aChild.HasIp6Address(aAddress);
 }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -615,7 +615,7 @@ otError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::Message
 
                 neighbor->SetExtAddress(macAddr);
                 neighbor->GetLinkInfo().Clear();
-                neighbor->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+                neighbor->GetLinkInfo().AddRss(linkInfo->mRss);
                 neighbor->ResetLinkFailures();
                 neighbor->SetLastHeard(TimerMilli::GetNow());
                 neighbor->SetState(Neighbor::kStateLinkRequest);
@@ -981,7 +981,7 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
     router->SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                      DeviceMode::kModeFullNetworkData));
     router->GetLinkInfo().Clear();
-    router->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+    router->GetLinkInfo().AddRss(linkInfo->mRss);
     router->SetLinkQualityOut(LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMargin.GetLinkMargin()));
     router->ResetLinkFailures();
     router->SetState(Neighbor::kStateValid);
@@ -1356,7 +1356,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
             {
                 router->SetExtAddress(macAddr);
                 router->GetLinkInfo().Clear();
-                router->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+                router->GetLinkInfo().AddRss(linkInfo->mRss);
                 router->ResetLinkFailures();
                 router->SetLastHeard(TimerMilli::GetNow());
                 router->SetState(Neighbor::kStateLinkRequest);
@@ -1403,7 +1403,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
         {
             router->SetExtAddress(macAddr);
             router->GetLinkInfo().Clear();
-            router->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+            router->GetLinkInfo().AddRss(linkInfo->mRss);
             router->ResetLinkFailures();
             router->SetLastHeard(TimerMilli::GetNow());
             router->SetState(Neighbor::kStateLinkRequest);
@@ -1660,7 +1660,7 @@ otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::Messa
         // MAC Address
         child->SetExtAddress(macAddr);
         child->GetLinkInfo().Clear();
-        child->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+        child->GetLinkInfo().AddRss(linkInfo->mRss);
         child->ResetLinkFailures();
         child->SetState(Neighbor::kStateParentRequest);
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
@@ -1937,7 +1937,7 @@ void MleRouter::SendParentResponse(Child *aChild, const ChallengeTlv &aChallenge
     aChild->GenerateChallenge();
 
     SuccessOrExit(error = AppendChallenge(*message, aChild->GetChallenge(), aChild->GetChallengeSize()));
-    error = AppendLinkMargin(*message, aChild->GetLinkInfo().GetLinkMargin(Get<Mac::Mac>().GetNoiseFloor()));
+    error = AppendLinkMargin(*message, aChild->GetLinkInfo().GetLinkMargin());
     SuccessOrExit(error);
 
     SuccessOrExit(error = AppendConnectivity(*message));
@@ -2194,7 +2194,7 @@ otError MleRouter::HandleChildIdRequest(const Message &         aMessage,
     child->SetMleFrameCounter(mleFrameCounter.GetFrameCounter());
     child->SetKeySequence(aKeySequence);
     child->SetDeviceMode(mode.GetMode());
-    child->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+    child->GetLinkInfo().AddRss(linkInfo->mRss);
     child->SetTimeout(timeout.GetTimeout());
 
     if (mode.GetMode().IsFullNetworkData())
@@ -2515,7 +2515,7 @@ otError MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
     SetChildStateToValid(*child);
     child->SetLastHeard(TimerMilli::GetNow());
     child->SetKeySequence(aKeySequence);
-    child->GetLinkInfo().AddRss(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+    child->GetLinkInfo().AddRss(linkInfo->mRss);
 
 exit:
 

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -65,6 +65,11 @@ RouterTable::RouterTable(Instance &aInstance)
     , mRouterIdSequence(Random::NonCrypto::GetUint8())
     , mActiveRouterCount(0)
 {
+    for (uint8_t index = 0; index < Mle::kMaxRouters; index++)
+    {
+        mRouters[index].Init(aInstance);
+    }
+
     Clear();
 }
 

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -44,6 +44,7 @@ namespace ot {
 void Neighbor::Init(Instance &aInstance)
 {
     InstanceLocatorInit::Init(aInstance);
+    mLinkInfo.Init(aInstance);
     SetState(kStateInvalid);
 }
 

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -145,14 +145,13 @@ exit:
     return retval;
 }
 
-otError Child::GetMeshLocalIp6Address(Instance &aInstance, Ip6::Address &aAddress) const
+otError Child::GetMeshLocalIp6Address(Ip6::Address &aAddress) const
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(!IsAllZero(mMeshLocalIid, sizeof(mMeshLocalIid)), error = OT_ERROR_NOT_FOUND);
 
-    memcpy(aAddress.mFields.m8, aInstance.Get<Mle::MleRouter>().GetMeshLocalPrefix().m8,
-           Ip6::Address::kMeshLocalPrefixSize);
+    memcpy(aAddress.mFields.m8, Get<Mle::MleRouter>().GetMeshLocalPrefix().m8, Ip6::Address::kMeshLocalPrefixSize);
 
     aAddress.SetIid(mMeshLocalIid);
 
@@ -160,7 +159,7 @@ exit:
     return error;
 }
 
-otError Child::GetNextIp6Address(Instance &aInstance, Ip6AddressIterator &aIterator, Ip6::Address &aAddress) const
+otError Child::GetNextIp6Address(Ip6AddressIterator &aIterator, Ip6::Address &aAddress) const
 {
     otError                   error = OT_ERROR_NONE;
     otChildIp6AddressIterator index;
@@ -170,7 +169,7 @@ otError Child::GetNextIp6Address(Instance &aInstance, Ip6AddressIterator &aItera
     if (aIterator.Get() == 0)
     {
         aIterator.Increment();
-        VerifyOrExit(GetMeshLocalIp6Address(aInstance, aAddress) == OT_ERROR_NOT_FOUND);
+        VerifyOrExit(GetMeshLocalIp6Address(aAddress) == OT_ERROR_NOT_FOUND);
     }
 
     index = aIterator.Get() - 1;
@@ -185,13 +184,13 @@ exit:
     return error;
 }
 
-otError Child::AddIp6Address(Instance &aInstance, const Ip6::Address &aAddress)
+otError Child::AddIp6Address(const Ip6::Address &aAddress)
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(!aAddress.IsUnspecified(), error = OT_ERROR_INVALID_ARGS);
 
-    if (aInstance.Get<Mle::MleRouter>().IsMeshLocalAddress(aAddress))
+    if (Get<Mle::MleRouter>().IsMeshLocalAddress(aAddress))
     {
         VerifyOrExit(IsAllZero(mMeshLocalIid, sizeof(mMeshLocalIid)), error = OT_ERROR_ALREADY);
         memcpy(mMeshLocalIid, aAddress.GetIid(), Ip6::Address::kInterfaceIdentifierSize);
@@ -215,14 +214,14 @@ exit:
     return error;
 }
 
-otError Child::RemoveIp6Address(Instance &aInstance, const Ip6::Address &aAddress)
+otError Child::RemoveIp6Address(const Ip6::Address &aAddress)
 {
     otError  error = OT_ERROR_NOT_FOUND;
     uint16_t index;
 
     VerifyOrExit(!aAddress.IsUnspecified(), error = OT_ERROR_INVALID_ARGS);
 
-    if (aInstance.Get<Mle::MleRouter>().IsMeshLocalAddress(aAddress))
+    if (Get<Mle::MleRouter>().IsMeshLocalAddress(aAddress))
     {
         if (memcmp(aAddress.GetIid(), mMeshLocalIid, Ip6::Address::kInterfaceIdentifierSize) == 0)
         {
@@ -257,13 +256,13 @@ exit:
     return error;
 }
 
-bool Child::HasIp6Address(Instance &aInstance, const Ip6::Address &aAddress) const
+bool Child::HasIp6Address(const Ip6::Address &aAddress) const
 {
     bool retval = false;
 
     VerifyOrExit(!aAddress.IsUnspecified());
 
-    if (aInstance.Get<Mle::MleRouter>().IsMeshLocalAddress(aAddress))
+    if (Get<Mle::MleRouter>().IsMeshLocalAddress(aAddress))
     {
         retval = (memcmp(aAddress.GetIid(), mMeshLocalIid, Ip6::Address::kInterfaceIdentifierSize) == 0);
         ExitNow();

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -41,6 +41,12 @@
 
 namespace ot {
 
+void Neighbor::Init(Instance &aInstance)
+{
+    InstanceLocatorInit::Init(aInstance);
+    SetState(kStateInvalid);
+}
+
 bool Neighbor::IsStateValidOrAttaching(void) const
 {
     bool rval = false;
@@ -105,8 +111,10 @@ void Neighbor::GenerateChallenge(void)
 
 void Child::Clear(void)
 {
+    Instance &instance = GetInstance();
+
     memset(reinterpret_cast<void *>(this), 0, sizeof(Child));
-    SetState(kStateInvalid);
+    Init(instance);
 }
 
 void Child::ClearIp6Addresses(void)
@@ -282,8 +290,10 @@ void Child::GenerateChallenge(void)
 
 void Router::Clear(void)
 {
+    Instance &instance = GetInstance();
+
     memset(reinterpret_cast<void *>(this), 0, sizeof(Router));
-    SetState(kStateInvalid);
+    Init(instance);
 }
 
 } // namespace ot

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -542,19 +542,17 @@ public:
     /**
      * This method gets the mesh-local IPv6 address.
      *
-     * @param[in]    aInstance           A reference to the OpenThread instance.
      * @param[out]   aAddress            A reference to an IPv6 address to provide address (if any).
      *
      * @retval       OT_ERROR_NONE       Successfully found the mesh-local address and updated @p aAddress.
      * @retval       OT_ERROR_NOT_FOUND  No mesh-local IPv6 address in the IPv6 address list.
      *
      */
-    otError GetMeshLocalIp6Address(Instance &aInstance, Ip6::Address &aAddress) const;
+    otError GetMeshLocalIp6Address(Ip6::Address &aAddress) const;
 
     /**
      * This method gets the next IPv6 address in the list.
      *
-     * @param[in]    aInstance           A reference to the OpenThread instance.
      * @param[inout] aIterator           A reference to an IPv6 address iterator.
      * @param[out]   aAddress            A reference to an IPv6 address to provide the next address (if any).
      *
@@ -562,12 +560,11 @@ public:
      * @retval       OT_ERROR_NOT_FOUND  No subsequent IPv6 address exists in the IPv6 address list.
      *
      */
-    otError GetNextIp6Address(Instance &aInstance, Ip6AddressIterator &aIterator, Ip6::Address &aAddress) const;
+    otError GetNextIp6Address(Ip6AddressIterator &aIterator, Ip6::Address &aAddress) const;
 
     /**
      * This method adds an IPv6 address to the list.
      *
-     * @param[in]  aInstance          A reference to the OpenThread instance.
      * @param[in]  aAddress           A reference to IPv6 address to be added.
      *
      * @retval OT_ERROR_NONE          Successfully added the new address.
@@ -576,12 +573,11 @@ public:
      * @retval OT_ERROR_INVALID_ARGS  Address is invalid (it is the Unspecified Address).
      *
      */
-    otError AddIp6Address(Instance &aInstance, const Ip6::Address &aAddress);
+    otError AddIp6Address(const Ip6::Address &aAddress);
 
     /**
      * This method removes an IPv6 address from the list.
      *
-     * @param[in]  aInstance              A reference to the OpenThread instance.
      * @param[in]  aAddress               A reference to IPv6 address to be removed.
      *
      * @retval OT_ERROR_NONE              Successfully removed the address.
@@ -589,19 +585,18 @@ public:
      * @retval OT_ERROR_INVALID_ARGS      Address is invalid (it is the Unspecified Address).
      *
      */
-    otError RemoveIp6Address(Instance &aInstance, const Ip6::Address &aAddress);
+    otError RemoveIp6Address(const Ip6::Address &aAddress);
 
     /**
      * This method indicates whether an IPv6 address is in the list of IPv6 addresses of the child.
      *
-     * @param[in]  aInstance  A reference to the OpenThread instance.
      * @param[in]  aAddress   A reference to IPv6 address.
      *
      * @retval TRUE           The address exists on the list.
      * @retval FALSE          Address was not found in the list.
      *
      */
-    bool HasIp6Address(Instance &aInstance, const Ip6::Address &aAddress) const;
+    bool HasIp6Address(const Ip6::Address &aAddress) const;
 
     /**
      * This method gets the child timeout.

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/thread_ftd.h>
 
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/random.hpp"
 #include "common/timer.hpp"
@@ -50,13 +51,11 @@
 
 namespace ot {
 
-class Instance;
-
 /**
  * This class represents a Thread neighbor.
  *
  */
-class Neighbor
+class Neighbor : public InstanceLocatorInit
 {
 public:
     /**
@@ -420,6 +419,15 @@ public:
     void SetTimeSyncEnabled(bool aEnabled) { mTimeSyncEnabled = aEnabled; }
 #endif
 
+protected:
+    /**
+     * This method initializes the `Neighbor` object.
+     *
+     * @param[in] aInstance  A reference to OpenThread instance.
+     *
+     */
+    void Init(Instance &aInstance);
+
 private:
     Mac::ExtAddress mMacAddr;   ///< The IEEE 802.15.4 Extended Address
     TimeMilli       mLastHeard; ///< Time when last heard.
@@ -510,6 +518,14 @@ public:
 
         otChildIp6AddressIterator mIndex;
     };
+
+    /**
+     * This method initializes the `Child` object.
+     *
+     * @param[in] aInstance  A reference to OpenThread instance.
+     *
+     */
+    void Init(Instance &aInstance) { Neighbor::Init(aInstance); }
 
     /**
      * This method clears the child entry.
@@ -726,6 +742,14 @@ private:
 class Router : public Neighbor
 {
 public:
+    /**
+     * This method initializes the `Router` object.
+     *
+     * @param[in] aInstance  A reference to OpenThread instance.
+     *
+     */
+    void Init(Instance &aInstance) { Neighbor::Init(aInstance); }
+
     /**
      * This method clears the router entry.
      *

--- a/tests/unit/test_child.cpp
+++ b/tests/unit/test_child.cpp
@@ -90,8 +90,7 @@ void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, co
 
         if (sInstance->Get<Mle::MleRouter>().IsMeshLocalAddress(aAddressList[index]))
         {
-            SuccessOrQuit(aChild.GetMeshLocalIp6Address(address),
-                          "Child::GetMeshLocalIp6Address() failed\n");
+            SuccessOrQuit(aChild.GetMeshLocalIp6Address(address), "Child::GetMeshLocalIp6Address() failed\n");
             VerifyOrQuit(address == aAddressList[index], "GetMeshLocalIp6Address() did not return expected address");
             hasMeshLocal = true;
         }

--- a/tests/unit/test_child.cpp
+++ b/tests/unit/test_child.cpp
@@ -120,6 +120,8 @@ void TestChildIp6Address(void)
     sInstance = testInitInstance();
     VerifyOrQuit(sInstance != NULL, "Null instance");
 
+    child.Init(*sInstance);
+
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
     printf("\nConverting IPv6 addresses from string");

--- a/tests/unit/test_child.cpp
+++ b/tests/unit/test_child.cpp
@@ -54,7 +54,7 @@ void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, co
 
     for (uint8_t index = 0; index < aAddressListLength; index++)
     {
-        VerifyOrQuit(aChild.HasIp6Address(*sInstance, aAddressList[index]), "HasIp6Address() failed");
+        VerifyOrQuit(aChild.HasIp6Address(aAddressList[index]), "HasIp6Address() failed");
     }
 
     memset(addressObserved, 0, sizeof(addressObserved));
@@ -67,7 +67,7 @@ void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, co
         }
     }
 
-    while (aChild.GetNextIp6Address(*sInstance, iterator, address) == OT_ERROR_NONE)
+    while (aChild.GetNextIp6Address(iterator, address) == OT_ERROR_NONE)
     {
         bool addressIsInList = false;
 
@@ -90,7 +90,7 @@ void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, co
 
         if (sInstance->Get<Mle::MleRouter>().IsMeshLocalAddress(aAddressList[index]))
         {
-            SuccessOrQuit(aChild.GetMeshLocalIp6Address(*sInstance, address),
+            SuccessOrQuit(aChild.GetMeshLocalIp6Address(address),
                           "Child::GetMeshLocalIp6Address() failed\n");
             VerifyOrQuit(address == aAddressList[index], "GetMeshLocalIp6Address() did not return expected address");
             hasMeshLocal = true;
@@ -99,7 +99,7 @@ void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, co
 
     if (!hasMeshLocal)
     {
-        VerifyOrQuit(aChild.GetMeshLocalIp6Address(*sInstance, address) == OT_ERROR_NOT_FOUND,
+        VerifyOrQuit(aChild.GetMeshLocalIp6Address(address) == OT_ERROR_NOT_FOUND,
                      "Child::GetMeshLocalIp6Address() returned an address not in the expected list");
     }
 }
@@ -154,7 +154,7 @@ void TestChildIp6Address(void)
 
     for (uint8_t index = 0; index < numAddresses; index++)
     {
-        SuccessOrQuit(child.AddIp6Address(*sInstance, addresses[index]), "AddIp6Address() failed");
+        SuccessOrQuit(child.AddIp6Address(addresses[index]), "AddIp6Address() failed");
         VerifyChildIp6Addresses(child, 1, &addresses[index]);
 
         child.ClearIp6Addresses();
@@ -168,7 +168,7 @@ void TestChildIp6Address(void)
 
     for (uint8_t index = 0; index < numAddresses; index++)
     {
-        SuccessOrQuit(child.AddIp6Address(*sInstance, addresses[index]), "AddIp6Address() failed");
+        SuccessOrQuit(child.AddIp6Address(addresses[index]), "AddIp6Address() failed");
         VerifyChildIp6Addresses(child, index + 1, addresses);
     }
 
@@ -179,7 +179,7 @@ void TestChildIp6Address(void)
 
     for (uint8_t index = 0; index < numAddresses; index++)
     {
-        VerifyOrQuit(child.AddIp6Address(*sInstance, addresses[index]) == OT_ERROR_ALREADY,
+        VerifyOrQuit(child.AddIp6Address(addresses[index]) == OT_ERROR_ALREADY,
                      "AddIp6Address() did not fail when adding same address");
         VerifyChildIp6Addresses(child, numAddresses, addresses);
     }
@@ -191,10 +191,10 @@ void TestChildIp6Address(void)
 
     for (uint8_t index = 0; index < numAddresses; index++)
     {
-        SuccessOrQuit(child.RemoveIp6Address(*sInstance, addresses[index]), "RemoveIp6Address() failed");
+        SuccessOrQuit(child.RemoveIp6Address(addresses[index]), "RemoveIp6Address() failed");
         VerifyChildIp6Addresses(child, numAddresses - 1 - index, &addresses[index + 1]);
 
-        VerifyOrQuit(child.RemoveIp6Address(*sInstance, addresses[index]) == OT_ERROR_NOT_FOUND,
+        VerifyOrQuit(child.RemoveIp6Address(addresses[index]) == OT_ERROR_NOT_FOUND,
                      "RemoveIp6Address() did not fail when removing an address not on the list");
     }
 
@@ -206,15 +206,15 @@ void TestChildIp6Address(void)
 
     for (uint8_t index = 0; index < numAddresses; index++)
     {
-        SuccessOrQuit(child.AddIp6Address(*sInstance, addresses[index]), "AddIp6Address() failed");
+        SuccessOrQuit(child.AddIp6Address(addresses[index]), "AddIp6Address() failed");
     }
 
     for (uint8_t index = numAddresses - 1; index > 0; index--)
     {
-        SuccessOrQuit(child.RemoveIp6Address(*sInstance, addresses[index]), "RemoveIp6Address() failed");
+        SuccessOrQuit(child.RemoveIp6Address(addresses[index]), "RemoveIp6Address() failed");
         VerifyChildIp6Addresses(child, index, &addresses[0]);
 
-        VerifyOrQuit(child.RemoveIp6Address(*sInstance, addresses[index]) == OT_ERROR_NOT_FOUND,
+        VerifyOrQuit(child.RemoveIp6Address(addresses[index]) == OT_ERROR_NOT_FOUND,
                      "RemoveIp6Address() did not fail when removing an address not on the list");
     }
 
@@ -229,12 +229,12 @@ void TestChildIp6Address(void)
 
         for (uint8_t index = 0; index < numAddresses; index++)
         {
-            SuccessOrQuit(child.AddIp6Address(*sInstance, addresses[index]), "AddIp6Address() failed");
+            SuccessOrQuit(child.AddIp6Address(addresses[index]), "AddIp6Address() failed");
         }
 
-        SuccessOrQuit(child.RemoveIp6Address(*sInstance, addresses[indexToRemove]), "RemoveIp6Address() failed");
+        SuccessOrQuit(child.RemoveIp6Address(addresses[indexToRemove]), "RemoveIp6Address() failed");
 
-        VerifyOrQuit(child.RemoveIp6Address(*sInstance, addresses[indexToRemove]) == OT_ERROR_NOT_FOUND,
+        VerifyOrQuit(child.RemoveIp6Address(addresses[indexToRemove]) == OT_ERROR_NOT_FOUND,
                      "RemoveIp6Address() did not fail when removing an address not on the list");
 
         {

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -34,6 +34,8 @@
 
 namespace ot {
 
+static ot::Instance *sInstance;
+
 enum
 {
     kMaxRssValue = 0,
@@ -88,6 +90,10 @@ void TestLinkQualityData(RssTestData aRssData)
     LinkQualityInfo linkInfo;
     int8_t          rss, ave, min, max;
     size_t          i;
+
+    sInstance = testInitInstance();
+    VerifyOrQuit(sInstance != NULL, "Null instance");
+    linkInfo.Init(*sInstance);
 
     printf("- - - - - - - - - - - - - - - - - -\n");
     linkInfo.Clear();

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -105,7 +105,7 @@ void TestLinkQualityData(RssTestData aRssData)
         rss = aRssData.mRssList[i];
         min = MIN_RSS(rss, min);
         max = MAX_RSS(rss, max);
-        linkInfo.AddRss(sNoiseFloor, rss);
+        linkInfo.AddRss(rss);
         VerifyOrQuit(linkInfo.GetLastRss() == rss, "TestLinkQualityInfo failed - GetLastRss() is incorrect");
         ave = linkInfo.GetAverageRss();
         VerifyOrQuit(ave >= min, "TestLinkQualityInfo failed - GetAverageRss() is smaller than min value.");

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -392,7 +392,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
-    return 0;
+    return -100;
 }
 //
 // Random


### PR DESCRIPTION
This PR contains a group of related commits:

**[locator] adding InstanceLocatorInit**

This commit adds a new class `InstanceLocatorInit` which is
similar to `InstanceLoator` but provides a default  constructor
(instead of a parameterized one) and allows an inheriting class to
initialize the object (set the OpenThread Instance) post constructor
call using the `Init()` method. This class is intended for types that
require a default constructor and cannot use a parameterized one. An
example of such a class is one that is used as type of a C array
element (e.g., `Neighbor`/`Child`/`Router` classes which are used as
array in `ChildTable`/`RouterTable`). The inheriting class from
`InstanceLocatorInit` should ensure that object is properly
initialized after the object is created and more importantly that it
is re-initialized when/if it is ever cleared or reset.

**[topology] have Neighbor/Child/Router inherit from InstanceLocatorInit**

This commit changes the `Neighbor` class (and therefore its sub-classes
`Child` and `Router`) to inherit from `InstanceLoatorInit`. It adds
`Init()` method to them as well and ensures that they are initialized
before use from `ChildTable`, `RouterTable` and `Mle` classes.

**[child] remove instance parameter from Ip6Address related methods**

Remove the now unnecessary `aInstance` parameter in `Child` methods
(since `Child` is now itself an `InstanceLocator`).

**[link-quality] have LinkQualityInfo inherit from IntsanceLocatorInit**

**[link-quality] remove aNoiseFloor param from LinkQualityInfo methods**
