### PR TITLE
[mle] invalidate parent if not child

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -339,7 +339,8 @@ void Mle::SetRole(otDeviceRole aRole)
         break;
     }
 
-    if (mRole != OT_DEVICE_ROLE_CHILD)
+    // If the previous state is disabled, the parent can be in kStateRestored.
+    if (mRole != OT_DEVICE_ROLE_CHILD && oldRole != OT_DEVICE_ROLE_DISABLED)
     {
         mParent.SetState(Neighbor::kStateInvalid);
     }

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -339,6 +339,11 @@ void Mle::SetRole(otDeviceRole aRole)
         break;
     }
 
+    if (mRole != OT_DEVICE_ROLE_CHILD)
+    {
+        mParent.SetState(Neighbor::kStateInvalid);
+    }
+
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
     if (IsAttached())
     {


### PR DESCRIPTION
Current Thread certification needs Parent information even after the
node already become a router or leader. This PR sets parent state to
invalid to indicate information in mParent should not be used in normal
cases.