### PR TITLE
[posix-host] explicitly ignore return value on write

### DIFF
--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -164,7 +164,7 @@ static void SendBlockingCommand(int aArgc, char *aArgv[])
         ssize_t rval = read(sSessionFd, buffer, sizeof(buffer));
 
         VerifyOrExit(rval >= 0);
-        write(STDOUT_FILENO, buffer, static_cast<size_t>(rval));
+        IgnoreReturnValue(write(STDOUT_FILENO, buffer, static_cast<size_t>(rval)));
         for (ssize_t i = 0; i < rval; i++)
         {
             if (FindDone(&doneState, buffer[i]) || FindError(&errorState, buffer[i]))


### PR DESCRIPTION
This PR fixes an "Ignored return value" warning by effectively marking the return value as ignored on purpose.

However, I think that the return value should be checked and dealt with. There are 2 instances where this happens:

https://github.com/openthread/openthread/blob/fbada4d21845e1d725079d8c003333c99894f20a/src/posix/client.cpp#L166-L169

https://github.com/openthread/openthread/blob/fbada4d21845e1d725079d8c003333c99894f20a/src/posix/client.cpp#L263-L267
