### PR TITLE
Modify posix-app cmd to support url format

### DIFF
--- a/.travis/check-ncp-rcp-migrate
+++ b/.travis/check-ncp-rcp-migrate
@@ -90,12 +90,12 @@ EOF
 
     echo "Step 2. Start retrieving dataset from Radio..."
     RADIO_NCP_PATH="$(pwd)/$(ls output/*linux*/bin/ot-ncp-ftd)"
-    "$(pwd)/$(ls output/posix/*linux*/bin/ot-ncp)" -n --radio-version --ncp-dataset -- ${RADIO_NCP_PATH} 1
+    "$(pwd)/$(ls output/posix/*linux*/bin/ot-ncp)" -n --radio-version --ncp-dataset "spinel+hdlc+forkpty://${RADIO_NCP_PATH}?arg=1"
 
     echo "Step 3. Start posix app and check whether PAN dataset is the same..."
     RADIO_RCP_PATH="$(pwd)/$(ls output/*linux*/bin/ot-rcp)"
 
-    OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli) ${RADIO_RCP_PATH} 1"
+    OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli) spinel+hdlc+forkpty://${RADIO_RCP_PATH}?arg=1"
 
     expect <<EOF
 spawn ${OT_CLI_CMD}
@@ -123,7 +123,7 @@ expect eof
 EOF
 
     echo "Step 4. Start posix app and check whether it can get radio firmware version..."
-    RADIO_VERSION="$("$(pwd)/$(ls output/posix/*linux*/bin/ot-cli)" -n --radio-version --ncp-dataset -- ${RADIO_RCP_PATH} 1)" || true
+    RADIO_VERSION="$("$(pwd)/$(ls output/posix/*linux*/bin/ot-cli)" -n --radio-version --ncp-dataset spinel+hdlc+forkpty://${RADIO_RCP_PATH}?arg=1)" || true
     test -n "{RADIO_VERSION}"
 }
 

--- a/.travis/check-posix-app-pty
+++ b/.travis/check-posix-app-pty
@@ -73,11 +73,11 @@ check() {
     $RADIO_NCP_PATH 1 > $RADIO_PTY < $RADIO_PTY &
 
     if [[ "${DAEMON}" = 1 ]]; then
-        sudo "$(pwd)/$(ls output/posix/*linux*/bin/ot-daemon)" spinel+hdlc+forkpty://${CORE_PTY} &
+        sudo "$(pwd)/$(ls output/posix/*linux*/bin/ot-daemon)" spinel+hdlc+uart://${CORE_PTY} &
         sleep 1
         OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-ctl)"
     else
-        OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli) spinel+hdlc+forkpty://${CORE_PTY}"
+        OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli) spinel+hdlc+uart://${CORE_PTY}"
     fi
 
     # Cover setting a valid network interface name.

--- a/.travis/check-posix-app-pty
+++ b/.travis/check-posix-app-pty
@@ -77,7 +77,7 @@ check() {
         sleep 1
         OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-ctl)"
     else
-        OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli)" spinel+hdlc+forkpty://${OT_NCP_PATH}?arg=${CORE_PTY}
+        OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli) spinel+hdlc+forkpty://${CORE_PTY}"
     fi
 
     # Cover setting a valid network interface name.

--- a/.travis/check-posix-app-pty
+++ b/.travis/check-posix-app-pty
@@ -73,7 +73,7 @@ check() {
     $RADIO_NCP_PATH 1 > $RADIO_PTY < $RADIO_PTY &
 
     if [[ "${DAEMON}" = 1 ]]; then
-        sudo "$(pwd)/$(ls output/posix/*linux*/bin/ot-daemon)" spinel+hdlc+forkpty://${OT_NCP_PATH}?arg=${CORE_PTY} &
+        sudo "$(pwd)/$(ls output/posix/*linux*/bin/ot-daemon)" spinel+hdlc+forkpty://${CORE_PTY} &
         sleep 1
         OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-ctl)"
     else

--- a/.travis/check-posix-app-pty
+++ b/.travis/check-posix-app-pty
@@ -73,11 +73,11 @@ check() {
     $RADIO_NCP_PATH 1 > $RADIO_PTY < $RADIO_PTY &
 
     if [[ "${DAEMON}" = 1 ]]; then
-        sudo "$(pwd)/$(ls output/posix/*linux*/bin/ot-daemon)" ${CORE_PTY} &
+        sudo "$(pwd)/$(ls output/posix/*linux*/bin/ot-daemon)" spinel+hdlc+forkpty://${OT_NCP_PATH}?arg=${CORE_PTY} &
         sleep 1
         OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-ctl)"
     else
-        OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli) ${CORE_PTY}"
+        OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli)" spinel+hdlc+forkpty://${OT_NCP_PATH}?arg=${CORE_PTY}
     fi
 
     # Cover setting a valid network interface name.

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -268,7 +268,8 @@ static void ParseArg(int aArgCount, char *aArgVector[], PosixConfig *aConfig)
         case 'n':
             aConfig->mIsDryRun = true;
             break;
-        case 's': {
+        case 's':
+        {
             char *endptr = NULL;
 
             aConfig->mPlatformConfig.mSpeedUpFactor = (uint32_t)strtol(optarg, &endptr, 0);

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -207,7 +207,7 @@ static int ParseUrl(otRadioUrl *aRadioUrl, char *url)
         }
         for (i = 0; i < cProtocol; i++)
         {
-            if (strncmp(pStart, aProtocols[i], (int)(pEnd - pStart)) == 0)
+          if (strncmp(pStart, aProtocols[i], (size_t)(pEnd - pStart)) == 0)
             {
                 aRadioUrl->mProtocols[j] = aProtocols[i];
                 j++;

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -268,7 +268,6 @@ int ParseUrl(otRadioUrl *aRadioUrl, char *url)
 static void ParseArg(int aArgCount, char *aArgVector[], PosixConfig *aConfig)
 {
     memset(aConfig, 0, sizeof(*aConfig));
-    RadioUrl aUrl;
 
     aConfig->mPlatformConfig.mSpeedUpFactor = 1;
     aConfig->mPlatformConfig.mResetRadio    = true;
@@ -300,7 +299,8 @@ static void ParseArg(int aArgCount, char *aArgVector[], PosixConfig *aConfig)
         case 'n':
             aConfig->mIsDryRun = true;
             break;
-        case 's': {
+        case 's':
+        {
             char *endptr = NULL;
 
             aConfig->mPlatformConfig.mSpeedUpFactor = (uint32_t)strtol(optarg, &endptr, 0);

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -138,23 +138,23 @@ otError HdlcInterface::Init(const otPlatformConfig &aPlatformConfig)
 
     VerifyOrExit(mSockFd == -1, error = OT_ERROR_ALREADY);
 
-    VerifyOrDie(stat(aPlatformConfig.mRadioFile, &st) == 0, OT_EXIT_INVALID_ARGUMENTS);
+    VerifyOrDie(stat(aPlatformConfig.mRadioUrl.mDevice, &st) == 0, OT_EXIT_INVALID_ARGUMENTS);
 
     if (S_ISCHR(st.st_mode))
     {
-        mSockFd = OpenFile(aPlatformConfig.mRadioFile, aPlatformConfig.mRadioConfig);
+        mSockFd = OpenFile(aPlatformConfig.mRadioUrl.mDevice, aPlatformConfig.mRadioUrl.mArgument);
         VerifyOrExit(mSockFd != -1, error = OT_ERROR_INVALID_ARGS);
     }
 #if OPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE
     else if (S_ISREG(st.st_mode))
     {
-        mSockFd = ForkPty(aPlatformConfig.mRadioFile, aPlatformConfig.mRadioConfig);
+        mSockFd = ForkPty(aPlatformConfig.mRadioUrl.mDevice, aPlatformConfig.mRadioUrl.mArgument);
         VerifyOrExit(mSockFd != -1, error = OT_ERROR_INVALID_ARGS);
     }
 #endif // OPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE
     else
     {
-        otLogCritPlat("Radio file '%s' not supported", aPlatformConfig.mRadioFile);
+        otLogCritPlat("Radio file '%s' not supported", aPlatformConfig.mRadioUrl.mDevice);
         ExitNow(error = OT_ERROR_INVALID_ARGS);
     }
 

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -197,9 +197,9 @@ private:
     static void HandleHdlcFrame(void *aContext, otError aError);
     void        HandleHdlcFrame(otError aError);
 
-    static int OpenFile(const char *aFile, const char *aConfig);
+    static int OpenFile(const otRadioUrl *aRadioUrl);
 #if OPENTHREAD_CONFIG_POSIX_APP_ENABLE_PTY_DEVICE
-    static int ForkPty(const char *aCommand, const char *aArguments);
+    static int ForkPty(const otRadioUrl *aRadioUrl);
 #endif
 
     enum

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -35,10 +35,6 @@
 #ifndef OPENTHREAD_SYSTEM_H_
 #define OPENTHREAD_SYSTEM_H_
 
-#define MAX_SUPPORT_PROTOCOL 3
-#define DEVICE_ARG_LEN 10
-#define DEVICE_FILE_LEN 50
-
 #include <setjmp.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -93,13 +89,6 @@ enum
     OT_EXIT_RADIO_SPINEL_NO_RESPONSE = 6,
 };
 
-typedef struct otRadioUrl
-{
-    const char *mProtocols[MAX_SUPPORT_PROTOCOL];
-    char        mDevice[DEVICE_FILE_LEN];
-    char        mArgument[DEVICE_ARG_LEN];
-} otRadioUrl;
-
 /**
  * This enumeration represents default parameters for the SPI interface.
  *
@@ -117,6 +106,30 @@ enum
 };
 
 /**
+ * This enumeration represents lengh definition for otRadioUrl.
+ *
+ */
+enum
+{
+    OT_PLATFORM_CONFIG_URL_MAX_PROTOCOLS   = 3,  ///< Max supported protocols like spinel+hdlc+uart
+    OT_PLATFORM_CONFIG_URL_DEVICE_FILE_LEN = 50, ///< Device file max length
+    OT_PLATFORM_CONFIG_URL_MAX_ARGS        = 10, ///< Max supported device arguments
+    OT_PLATFORM_CONFIG_URL_ARG_VALUE_LEN   = 20, ///< Device arguments max length
+};
+
+/**
+ * This structure represents radio url specific configurations.
+ *
+ */
+typedef struct otRadioUrl
+{
+    const char *mProtocols[OT_PLATFORM_CONFIG_URL_MAX_PROTOCOLS];                                 ///< URL Protols
+    char        mDevice[OT_PLATFORM_CONFIG_URL_DEVICE_FILE_LEN];                                  ///< Device file
+    const char *mArgName[OT_PLATFORM_CONFIG_URL_MAX_ARGS];                                        ///< Argument name
+    char        mArgValue[OT_PLATFORM_CONFIG_URL_MAX_ARGS][OT_PLATFORM_CONFIG_URL_ARG_VALUE_LEN]; ///< Argument value
+} otRadioUrl;
+
+/**
  * This structure represents platform specific configurations.
  *
  */
@@ -127,18 +140,7 @@ typedef struct otPlatformConfig
     const char *mInterfaceName;         ///< Thread network interface name.
     bool        mResetRadio;            ///< Whether to reset RCP when initializing.
     bool        mRestoreDatasetFromNcp; ///< Whether to retrieve dataset from NCP and save to file.
-
-    char *     mSpiGpioIntDevice;   ///< Path to the Linux GPIO character device for the `I̅N̅T̅` pin.
-    char *     mSpiGpioResetDevice; ///< Path to the Linux GPIO character device for the `R̅E̅S̅E̅T̅` pin.
-    uint8_t    mSpiGpioIntLine;     ///< Line index of the `I̅N̅T̅` pin for the associated GPIO character device.
-    uint8_t    mSpiGpioResetLine; ///< Line index of the `R̅E̅S̅E̅T̅` pin for the associated GPIO character device.
-    uint8_t    mSpiMode;          ///< SPI mode to use (0-3).
-    uint32_t   mSpiSpeed;         ///< SPI speed in hertz.
-    uint32_t   mSpiResetDelay;    ///< The delay after R̅E̅S̅E̅T̅ assertion, in miliseconds.
-    uint16_t   mSpiCsDelay;       ///< The delay after SPI C̅S̅ assertion, in µsec.
-    uint8_t    mSpiAlignAllowance;  ///< Maximum number of 0xFF bytes to clip from start of MISO frame.
-    uint8_t    mSpiSmallPacketSize; ///< Smallest SPI packet size we can receive in a single transaction.
-    otRadioUrl mRadioUrl;           ///< Parsed Radio URL struct
+    otRadioUrl  mRadioUrl;              ///< Parsed Radio URL struct
 } otPlatformConfig;
 
 /**

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -111,10 +111,10 @@ enum
  */
 enum
 {
-    OT_PLATFORM_CONFIG_URL_MAX_PROTOCOLS   = 3,  ///< Max supported protocols like spinel+hdlc+uart
-    OT_PLATFORM_CONFIG_URL_DEVICE_FILE_LEN = 50, ///< Device file max length
-    OT_PLATFORM_CONFIG_URL_MAX_ARGS        = 10, ///< Max supported device arguments
-    OT_PLATFORM_CONFIG_URL_ARG_VALUE_LEN   = 20, ///< Device arguments max length
+    OT_PLATFORM_CONFIG_URL_MAX_PROTOCOLS   = 3,   ///< Max supported protocols like spinel+hdlc+uart
+    OT_PLATFORM_CONFIG_URL_DEVICE_FILE_LEN = 100, ///< Device file max length
+    OT_PLATFORM_CONFIG_URL_MAX_ARGS        = 10,  ///< Max supported device arguments
+    OT_PLATFORM_CONFIG_URL_ARG_VALUE_LEN   = 20,  ///< Device arguments max length
 };
 
 /**

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -35,6 +35,10 @@
 #ifndef OPENTHREAD_SYSTEM_H_
 #define OPENTHREAD_SYSTEM_H_
 
+#define MAX_SUPPORT_PROTOCOL 3
+#define DEVICE_ARG_LEN 10
+#define DEVICE_FILE_LEN 50
+
 #include <setjmp.h>
 #include <stdbool.h>
 #include <stdint.h>
@@ -89,6 +93,13 @@ enum
     OT_EXIT_RADIO_SPINEL_NO_RESPONSE = 6,
 };
 
+typedef struct otRadioUrl
+{
+    const char *mProtocols[MAX_SUPPORT_PROTOCOL];
+    char        mDevice[DEVICE_FILE_LEN];
+    char        mArgument[DEVICE_ARG_LEN];
+} otRadioUrl;
+
 /**
  * This enumeration represents default parameters for the SPI interface.
  *
@@ -114,21 +125,20 @@ typedef struct otPlatformConfig
     uint64_t    mNodeId;                ///< Unique node ID.
     uint32_t    mSpeedUpFactor;         ///< Speed up factor.
     const char *mInterfaceName;         ///< Thread network interface name.
-    const char *mRadioFile;             ///< Radio file path.
-    const char *mRadioConfig;           ///< Radio configurations.
     bool        mResetRadio;            ///< Whether to reset RCP when initializing.
     bool        mRestoreDatasetFromNcp; ///< Whether to retrieve dataset from NCP and save to file.
 
-    char *   mSpiGpioIntDevice;   ///< Path to the Linux GPIO character device for the `I̅N̅T̅` pin.
-    char *   mSpiGpioResetDevice; ///< Path to the Linux GPIO character device for the `R̅E̅S̅E̅T̅` pin.
-    uint8_t  mSpiGpioIntLine;     ///< Line index of the `I̅N̅T̅` pin for the associated GPIO character device.
-    uint8_t  mSpiGpioResetLine;   ///< Line index of the `R̅E̅S̅E̅T̅` pin for the associated GPIO character device.
-    uint8_t  mSpiMode;            ///< SPI mode to use (0-3).
-    uint32_t mSpiSpeed;           ///< SPI speed in hertz.
-    uint32_t mSpiResetDelay;      ///< The delay after R̅E̅S̅E̅T̅ assertion, in miliseconds.
-    uint16_t mSpiCsDelay;         ///< The delay after SPI C̅S̅ assertion, in µsec.
-    uint8_t  mSpiAlignAllowance;  ///< Maximum number of 0xFF bytes to clip from start of MISO frame.
-    uint8_t  mSpiSmallPacketSize; ///< Smallest SPI packet size we can receive in a single transaction.
+    char *     mSpiGpioIntDevice;   ///< Path to the Linux GPIO character device for the `I̅N̅T̅` pin.
+    char *     mSpiGpioResetDevice; ///< Path to the Linux GPIO character device for the `R̅E̅S̅E̅T̅` pin.
+    uint8_t    mSpiGpioIntLine;     ///< Line index of the `I̅N̅T̅` pin for the associated GPIO character device.
+    uint8_t    mSpiGpioResetLine; ///< Line index of the `R̅E̅S̅E̅T̅` pin for the associated GPIO character device.
+    uint8_t    mSpiMode;          ///< SPI mode to use (0-3).
+    uint32_t   mSpiSpeed;         ///< SPI speed in hertz.
+    uint32_t   mSpiResetDelay;    ///< The delay after R̅E̅S̅E̅T̅ assertion, in miliseconds.
+    uint16_t   mSpiCsDelay;       ///< The delay after SPI C̅S̅ assertion, in µsec.
+    uint8_t    mSpiAlignAllowance;  ///< Maximum number of 0xFF bytes to clip from start of MISO frame.
+    uint8_t    mSpiSmallPacketSize; ///< Smallest SPI packet size we can receive in a single transaction.
+    otRadioUrl mRadioUrl;           ///< Parsed Radio URL struct
 } otPlatformConfig;
 
 /**

--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -105,7 +105,7 @@ otError SpiInterface::Init(const otPlatformConfig &aPlatformConfig)
     }
 
     InitResetPin(aPlatformConfig.mSpiGpioResetDevice, aPlatformConfig.mSpiGpioResetLine);
-    InitSpiDev(aPlatformConfig.mRadioFile, aPlatformConfig.mSpiMode, aPlatformConfig.mSpiSpeed);
+    InitSpiDev(aPlatformConfig.mRadioUrl.mDevice, aPlatformConfig.mSpiMode, aPlatformConfig.mSpiSpeed);
 
     // Reset RCP chip.
     TrigerReset();

--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -88,8 +88,8 @@ SpiInterface::SpiInterface(SpinelInterface::Callbacks &aCallback, SpinelInterfac
 
 otError SpiInterface::Init(const otPlatformConfig &aPlatformConfig)
 {
-    int               aIntDeviceIndex;
-    int               aResetDeviceIndex;
+    int               aIntDeviceIndex   = -1;
+    int               aResetDeviceIndex = -1;
     uint8_t           aSpiGpioIntLine;
     uint8_t           aSpiGpioResetLine;
     uint8_t           aSpiSpeed           = (uint8_t)OT_PLATFORM_CONFIG_SPI_DEFAULT_SPEED_HZ;
@@ -110,7 +110,7 @@ otError SpiInterface::Init(const otPlatformConfig &aPlatformConfig)
             }
             else if (!strcmp(aRadioUrl->mArgName[i], "gpio-int-line"))
             {
-                sscanf(aRadioUrl->mArgValue[i], "%c", &aSpiGpioResetLine);
+                sscanf(aRadioUrl->mArgValue[i], "%c", &aSpiGpioIntLine);
             }
             else if (!strcmp(aRadioUrl->mArgName[i], "gpio-reset-dev"))
             {
@@ -151,9 +151,20 @@ otError SpiInterface::Init(const otPlatformConfig &aPlatformConfig)
             }
         }
     }
+
+    if (aIntDeviceIndex < 0)
+    {
+        fprintf(stderr, "Must specify gpio-int-dev\n");
+        DieNow(OT_EXIT_INVALID_ARGUMENTS);
+    }
+
+    if (aResetDeviceIndex < 0)
+    {
+        fprintf(stderr, "Must specify gpio-reset-dev\n");
+        DieNow(OT_EXIT_INVALID_ARGUMENTS);
+    }
+
     VerifyOrDie(aSpiAlignAllowance <= kSpiAlignAllowanceMax, OT_EXIT_FAILURE);
-    VerifyOrDie(aIntDeviceIndex < 0, OT_EXIT_FAILURE);
-    VerifyOrDie(aResetDeviceIndex < 0, OT_EXIT_FAILURE);
 
     mSpiCsDelayUs       = aSpiCsDelay;
     mSpiSmallPacketSize = aSpiSmallPacketSize;

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -91,7 +91,8 @@ class Node:
             cmd = '%s/ot-cli-%s' % (self.version, mode)
 
         if 'RADIO_DEVICE' in os.environ:
-            cmd += ' -v spinel+hdlc+forkpty://%s?arg=' % os.environ['RADIO_DEVICE']
+            cmd += ' -v spinel+hdlc+forkpty://%s?arg=' % os.environ[
+                'RADIO_DEVICE']
             os.environ['NODE_ID'] = str(nodeid)
 
         cmd += '%d' % nodeid

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -259,7 +259,7 @@ class Node:
         print("%d: %s" % (self.nodeid, cmd))
         self.pexpect.send(cmd + '\n')
         if go:
-            self.simulator.go(1, nodeid=self.nodeid)
+            self.simulator.go(0, nodeid=self.nodeid)
         sys.stdout.flush()
 
     def get_commands(self):

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -91,8 +91,7 @@ class Node:
             cmd = '%s/ot-cli-%s' % (self.version, mode)
 
         if 'RADIO_DEVICE' in os.environ:
-            cmd += '-v spinel+hdlc+forkpty://%s?arg=' % os.environ[
-                'RADIO_DEVICE']
+            cmd += ' spinel+hdlc+forkpty://%s?arg=' % os.environ['RADIO_DEVICE']
             os.environ['NODE_ID'] = str(nodeid)
 
         cmd += '%d' % nodeid
@@ -125,7 +124,7 @@ class Node:
             )
         elif (self.version == '1.1' and self.version != self.env_version):
             if 'OT_NCP_PATH_1_1' in os.environ:
-                cmd = 'spinel-cli.py -p "%s%s" -n' % (
+                cmd = 'spinel-cli.py -p "%s" -n spinel+hdlc+forkpty://%s?arg=' % (
                     os.environ['OT_NCP_PATH_1_1'],
                     args,
                 )

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -91,7 +91,7 @@ class Node:
             cmd = '%s/ot-cli-%s' % (self.version, mode)
 
         if 'RADIO_DEVICE' in os.environ:
-          cmd += ' -v spinel+hdlc+forkpty://%s?arg=' % os.environ['RADIO_DEVICE']
+            cmd += ' -v spinel+hdlc+forkpty://%s?arg=' % os.environ['RADIO_DEVICE']
             os.environ['NODE_ID'] = str(nodeid)
 
         cmd += '%d' % nodeid

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -91,10 +91,10 @@ class Node:
             cmd = '%s/ot-cli-%s' % (self.version, mode)
 
         if 'RADIO_DEVICE' in os.environ:
-            cmd += ' -v %s' % os.environ['RADIO_DEVICE']
+          cmd += ' -v spinel+hdlc+forkpty://%s?arg=' % os.environ['RADIO_DEVICE']
             os.environ['NODE_ID'] = str(nodeid)
 
-        cmd += ' %d' % nodeid
+        cmd += '%d' % nodeid
         print("%s" % cmd)
 
         self.pexpect = pexpect.popen_spawn.PopenSpawn(cmd, timeout=4)

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -118,32 +118,34 @@ class Node:
             args = ''
 
         if 'OT_NCP_PATH' in os.environ:
-            cmd = 'spinel-cli.py -p "%s" -n spinel+hdlc+forkpty://%s?arg=' % (
+            cmd = 'spinel-cli.py -p "%s spinel+hdlc+forkpty://%s?arg=%d" -n' % (
                 os.environ['OT_NCP_PATH'],
                 args,
+                nodeid,
             )
         elif (self.version == '1.1' and self.version != self.env_version):
             if 'OT_NCP_PATH_1_1' in os.environ:
-                cmd = 'spinel-cli.py -p "%s" -n spinel+hdlc+forkpty://%s?arg=' % (
+                cmd = 'spinel-cli.py -p "%s spinel+hdlc+forkpty://%s?arg=%d" -n' % (
                     os.environ['OT_NCP_PATH_1_1'],
                     args,
+                    nodeid,
                 )
             elif ('top_builddir_1_1') in os.environ:
                 srcdir = os.environ['top_builddir_1_1']
-                cmd = '%s/examples/apps/ncp/ot-ncp-%s' % (srcdir, mode)
+                cmd = '%s/examples/apps/ncp/ot-ncp-%s ' % (srcdir, mode)
                 cmd = 'spinel-cli.py -p "%s%s" -n ' % (
                     cmd,
                     args,
                 )
         elif ('top_builddir') in os.environ:
             srcdir = os.environ['top_builddir']
-            cmd = '%s/examples/apps/ncp/ot-ncp-%s' % (srcdir, mode)
+            cmd = '%s/examples/apps/ncp/ot-ncp-%s ' % (srcdir, mode)
             cmd = 'spinel-cli.py -p "%s%s" -n ' % (
                 cmd,
                 args,
             )
         else:
-            cmd = 'spinel-cli.py -p "%s/ot-ncp-%s%s" -n ' % (
+            cmd = 'spinel-cli.py -p "%s/ot-ncp-%s %s" -n ' % (
                 self.version,
                 mode,
                 args,
@@ -152,7 +154,7 @@ class Node:
         cmd += '%d' % nodeid
         print("%s" % cmd)
 
-        self.pexpect = pexpect.spawn(cmd, timeout=4)
+        self.pexpect = pexpect.spawn(cmd, timeout=6)
 
         # Add delay to ensure that the process is ready to receive commands.
         time.sleep(0.2)

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -86,12 +86,12 @@ class Node:
                 cmd = '%s/examples/apps/cli/ot-cli-%s' % (srcdir, mode)
         elif ('top_builddir') in os.environ:
             srcdir = os.environ['top_builddir']
-            cmd = '%s/examples/apps/cli/ot-cli-%s' % (srcdir, mode)
+            cmd = '%s/examples/apps/cli/ot-cli-%s ' % (srcdir, mode)
         else:
             cmd = '%s/ot-cli-%s' % (self.version, mode)
 
         if 'RADIO_DEVICE' in os.environ:
-            cmd += ' -v spinel+hdlc+forkpty://%s?arg=' % os.environ[
+            cmd += '-v spinel+hdlc+forkpty://%s?arg=' % os.environ[
                 'RADIO_DEVICE']
             os.environ['NODE_ID'] = str(nodeid)
 
@@ -113,13 +113,13 @@ class Node:
     def __init_ncp_sim(self, nodeid, mode):
         """ Initialize an NCP simulation node. """
         if 'RADIO_DEVICE' in os.environ:
-            args = ' %s' % os.environ['RADIO_DEVICE']
+            args = '%s' % os.environ['RADIO_DEVICE']
             os.environ['NODE_ID'] = str(nodeid)
         else:
             args = ''
 
         if 'OT_NCP_PATH' in os.environ:
-            cmd = 'spinel-cli.py -p "%s%s" -n' % (
+            cmd = 'spinel-cli.py -p "%s" -n spinel+hdlc+forkpty://%s?arg=' % (
                 os.environ['OT_NCP_PATH'],
                 args,
             )
@@ -132,25 +132,25 @@ class Node:
             elif ('top_builddir_1_1') in os.environ:
                 srcdir = os.environ['top_builddir_1_1']
                 cmd = '%s/examples/apps/ncp/ot-ncp-%s' % (srcdir, mode)
-                cmd = 'spinel-cli.py -p "%s%s" -n' % (
+                cmd = 'spinel-cli.py -p "%s%s" -n ' % (
                     cmd,
                     args,
                 )
         elif ('top_builddir') in os.environ:
             srcdir = os.environ['top_builddir']
             cmd = '%s/examples/apps/ncp/ot-ncp-%s' % (srcdir, mode)
-            cmd = 'spinel-cli.py -p "%s%s" -n' % (
+            cmd = 'spinel-cli.py -p "%s%s" -n ' % (
                 cmd,
                 args,
             )
         else:
-            cmd = 'spinel-cli.py -p "%s/ot-ncp-%s%s" -n' % (
+            cmd = 'spinel-cli.py -p "%s/ot-ncp-%s%s" -n ' % (
                 self.version,
                 mode,
                 args,
             )
 
-        cmd += ' %d' % nodeid
+        cmd += '%d' % nodeid
         print("%s" % cmd)
 
         self.pexpect = pexpect.spawn(cmd, timeout=4)
@@ -259,7 +259,7 @@ class Node:
         print("%d: %s" % (self.nodeid, cmd))
         self.pexpect.send(cmd + '\n')
         if go:
-            self.simulator.go(0, nodeid=self.nodeid)
+            self.simulator.go(1, nodeid=self.nodeid)
         sys.stdout.flush()
 
     def get_commands(self):

--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -307,7 +307,7 @@ class Node(object):
 
         index = Node._cur_index
         Node._cur_index += 1
-        rcp_url = 'spinel+hdlc+forkpty://%s?arg=%d' % (_OT_RCP, index)
+        rcp_url = 'spinel+hdlc+forkpty://%s?arg=%d' % (self._OT_RCP, index)
 
         self._index = index
         self._interface_name = self._INTFC_NAME_PREFIX + str(index)

--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -307,6 +307,7 @@ class Node(object):
 
         index = Node._cur_index
         Node._cur_index += 1
+        rcp_url = 'spinel+hdlc+forkpty://%s?arg=%d' % (_OT_RCP, index)
 
         self._index = index
         self._interface_name = self._INTFC_NAME_PREFIX + str(index)
@@ -321,9 +322,8 @@ class Node(object):
             self._use_posix_app_with_rcp = False
 
         if self._use_posix_app_with_rcp:
-            ncp_socket_path = 'system:{} -s {} {} {}'.format(
-                self._OT_NCP_FTD_POSIX_APP, self._SPEED_UP_FACTOR, self._OT_RCP,
-                index)
+            ncp_socket_path = 'system:{} -s {} {}'.format(
+                self._OT_NCP_FTD_POSIX_APP, self._SPEED_UP_FACTOR, rcp_url)
         else:
             ncp_socket_path = 'system:{} {} {}'.format(self._OT_NCP_FTD, index,
                                                        self._SPEED_UP_FACTOR)


### PR DESCRIPTION
Syntax:
    output/posix/x86_64-unknown-linux-gnu/bin/ot-cli [Options] RadioURL
    RadioURL: URL of the device and method for Thread core and RCP communication.
              'protocols://device-file?arg1=value1&arg=value2'
              e.g. 'spinel+hdlc+uart:///dev/ttyUSB0?speed=115200&parity=N'
Options:
    -I  --interface-name name     Thread network interface name.
    -d  --debug-level             Debug level of logging.
    -n  --dry-run                 Just verify if arguments is valid and radio spinel is compatible.
        --no-reset                Do not send Spinel reset command to RCP on initialization.
        --radio-version           Print radio firmware version.
        --ncp-dataset             Retrieve and save NCP dataset to file.
    -s  --time-speed factor       Time speed up factor.
    -v  --verbose                 Also log to stderr.
    -h  --help                    Display this usage information.
URL Arguments:
    SPI Required:
        gpio-int-dev=gpio-device-path
                                  Specify a path to the Linux sysfs-exported GPIO device for the
                                  `I̅N̅T̅` pin. If not specified, `SPI` interface will fall back to
                                  polling, which is inefficient.
        gpio-int-line=line-offset
                                  The offset index of `I̅N̅T̅` pin for the associated GPIO device.
                                  If not specified, `SPI` interface will fall back to polling,
                                  which is inefficient.
        gpio-reset-dev=gpio-device-path
                                  Specify a path to the Linux sysfs-exported GPIO device for the
                                  `R̅E̅S̅` pin.
        gpio-reset-line=line-offset
                                  The offset index of `R̅E̅S̅` pin for the associated GPIO device.
    SPI Optional:
        mode=mode             Specify the SPI mode to use (0-3). Default value is 0
        speed=hertz           Specify the SPI speed in hertz. Default value is 1000000
        cs-delay=usec         Specify the delay after C̅S̅ assertion, in µsec. Default value 20
        reset-delay=ms        Specify the delay after R̅E̅S̅E̅T̅ assertion, in milliseconds. Default value is 0
        align-allowance=n     Specify the maximum number of 0xFF bytes to clip from start of
                                  MISO frame. Max value is 16. Default value is 16
        small-packet=n        Specify the smallest packet we can receive in a single transaction.
                                  (larger packets will require two transactions). Default value is 32.
 UART Optional:
        speed=bps             Specify the UART input and output speed in bps. Default value is 115200
        parity=N|E|O          Specify the parity option. Default value is N
        cstopb=1|2            Specify the stop bits. Default value is 1
        flow=N|H              Specify the flow control in milliseconds. Default value is N
    ForkPty:
        arg=value             Specify arguments for forkpty. Default value is arg=1