### PR TITLE
[spi] add parameter to reset gpio device for spi

### DIFF
--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -162,7 +162,7 @@ static void PrintUsage(const char *aProgramName, FILE *aStream, int aExitCode)
             "                                  If not specified, `SPI` interface will fall back to polling,\n"
             "                                  which is inefficient.\n"
             "        --gpio-reset\n"
-            "                                  Just reset the GPIO device. Do not start.\n"
+            "                                  Just reset the RCP chip. Do not start.\n"
             "        --gpio-reset-dev[=gpio-device-path]\n"
             "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"
             "                                  `R̅E̅S̅` pin.\n"

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -111,6 +111,7 @@ enum
     ARG_SPI_RESET_DELAY     = 1018,
     ARG_SPI_ALIGN_ALLOWANCE = 1019,
     ARG_SPI_SMALL_PACKET    = 1020,
+    ARG_SPI_GPIO_RESET      = 1021,
 };
 
 static const struct option kOptions[] = {{"debug-level", required_argument, NULL, 'd'},
@@ -125,6 +126,7 @@ static const struct option kOptions[] = {{"debug-level", required_argument, NULL
 #if OPENTHREAD_POSIX_RCP_SPI_ENABLE
                                          {"gpio-int-dev", required_argument, NULL, ARG_SPI_GPIO_INT_DEV},
                                          {"gpio-int-line", required_argument, NULL, ARG_SPI_GPIO_INT_LINE},
+                                         {"gpio-reset", no_argument, NULL, ARG_SPI_GPIO_RESET},
                                          {"gpio-reset-dev", required_argument, NULL, ARG_SPI_GPIO_RESET_DEV},
                                          {"gpio-reset-line", required_argument, NULL, ARG_SPI_GPIO_RESET_LINE},
                                          {"spi-mode", required_argument, NULL, ARG_SPI_MODE},
@@ -159,6 +161,8 @@ static void PrintUsage(const char *aProgramName, FILE *aStream, int aExitCode)
             "                                  The offset index of `I̅N̅T̅` pin for the associated GPIO device.\n"
             "                                  If not specified, `SPI` interface will fall back to polling,\n"
             "                                  which is inefficient.\n"
+            "        --gpio-reset\n"
+            "                                  Just reset the GPIO device. Do not start.\n"
             "        --gpio-reset-dev[=gpio-device-path]\n"
             "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"
             "                                  `R̅E̅S̅` pin.\n"
@@ -249,6 +253,9 @@ static void ParseArg(int aArgCount, char *aArgVector[], PosixConfig *aConfig)
             break;
         case ARG_SPI_GPIO_INT_LINE:
             aConfig->mPlatformConfig.mSpiGpioIntLine = (uint8_t)atoi(optarg);
+            break;
+        case ARG_SPI_GPIO_RESET:
+            aConfig->mPlatformConfig.mSpiGpioReset = true;
             break;
         case ARG_SPI_GPIO_RESET_DEV:
             aConfig->mPlatformConfig.mSpiGpioResetDevice = optarg;

--- a/src/posix/platform/openthread-system.h
+++ b/src/posix/platform/openthread-system.h
@@ -114,7 +114,7 @@ typedef struct otPlatformConfig
     bool        mResetRadio;            ///< Whether to reset RCP when initializing.
     bool        mRestoreDatasetFromNcp; ///< Whether to retrieve dataset from NCP and save to file.
 
-    bool     mSpiGpioReset;       ///< Whether to reset GPIO device only.
+    bool     mSpiGpioReset;       ///< Whether to use Reset Pin to reset RCP only.
     char *   mSpiGpioIntDevice;   ///< Path to the Linux GPIO character device for the `I̅N̅T̅` pin.
     char *   mSpiGpioResetDevice; ///< Path to the Linux GPIO character device for the `R̅E̅S̅E̅T̅` pin.
     uint8_t  mSpiGpioIntLine;     ///< Line index of the `I̅N̅T̅` pin for the associated GPIO character device.

--- a/src/posix/platform/openthread-system.h
+++ b/src/posix/platform/openthread-system.h
@@ -114,6 +114,7 @@ typedef struct otPlatformConfig
     bool        mResetRadio;            ///< Whether to reset RCP when initializing.
     bool        mRestoreDatasetFromNcp; ///< Whether to retrieve dataset from NCP and save to file.
 
+    bool     mSpiGpioReset;       ///< Whether to reset GPIO device only.
     char *   mSpiGpioIntDevice;   ///< Path to the Linux GPIO character device for the `I̅N̅T̅` pin.
     char *   mSpiGpioResetDevice; ///< Path to the Linux GPIO character device for the `R̅E̅S̅E̅T̅` pin.
     uint8_t  mSpiGpioIntLine;     ///< Line index of the `I̅N̅T̅` pin for the associated GPIO character device.

--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -107,6 +107,12 @@ otError SpiInterface::Init(const otPlatformConfig &aPlatformConfig)
     // Reset RCP chip.
     TrigerReset();
 
+    // Exit if only to reset GPIO device.
+    if (aPlatformConfig.mSpiGpioReset)
+    {
+        exit(OT_EXIT_SUCCESS);
+    }
+
     // Waiting for the RCP chip starts up.
     usleep(static_cast<useconds_t>(aPlatformConfig.mSpiResetDelay) * kUsecPerMsec);
 

--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -107,7 +107,7 @@ otError SpiInterface::Init(const otPlatformConfig &aPlatformConfig)
     // Reset RCP chip.
     TrigerReset();
 
-    // Exit if only to reset GPIO device.
+    // Exit if only to reset RCP chip.
     if (aPlatformConfig.mSpiGpioReset)
     {
         exit(OT_EXIT_SUCCESS);


### PR DESCRIPTION
This PR is related to #4431 
Currently some GPIO is exported in some scripts to do the hardware reset. However, to use SPI, these GPIOs cannot be exported. So a parameter is added to the command to do the reset so that GPIOs don't need to be exported.