### PR TITLE
[mle] mark former parent as valid after becoming router

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3988,6 +3988,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
 
     // Keep link to the parent in order to respond to Parent Requests before new link is established.
     *router = mParent;
+    router->SetState(Neighbor::kStateValid);
     router->SetNextHop(kInvalidRouterId);
     router->SetCost(0);
 


### PR DESCRIPTION
Commit a8638d7 added logic to invalidate the parent upon a role
change. However, when upgrading from child to router, the existing
implementation updates the role before copying the parent into into
the router table. As a result, a router may not have any connectivity
with the rest of the partition until after additional MLE exchanges.

This commit marks the newly created router entry as valid so that the
router retains connectivity.