### PR TITLE
[network-data] avoid buffer overrun in HandleCommissioningSet()

### DIFF
--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -206,7 +206,7 @@ void Leader::HandleCommissioningSet(Coap::Message &aMessage, const Ip6::MessageI
     {
         MeshCoP::Tlv::Type type;
 
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit(((cur + 1) <= end) && !cur->IsExtended() && (cur->GetNext() <= end));
 
         type = cur->GetType();
 

--- a/tests/fuzz/fuzzer_platform.c
+++ b/tests/fuzz/fuzzer_platform.c
@@ -26,6 +26,8 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include "openthread-core-config.h"
+
 #include <string.h>
 
 #include <openthread/platform/alarm-micro.h>
@@ -152,6 +154,8 @@ otError otDiagProcessCmd(otInstance *aInstance, int aArgCount, char *aArgVector[
     OT_UNUSED_VARIABLE(aArgVector);
     OT_UNUSED_VARIABLE(aOutput);
     OT_UNUSED_VARIABLE(aOutputMaxLen);
+
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 
 void otDiagProcessCmdLine(otInstance *aInstance, const char *aString, char *aOutput, size_t aOutputMaxLen)


### PR DESCRIPTION
Reject Commissioner Dataset TLVs with extended TLV length.