### PR TITLE
[coap] validate token length on received messages

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -438,6 +438,11 @@ void CoapBase::Receive(ot::Message &aMessage, const Ip6::MessageInfo &aMessageIn
     if (message.ParseHeader() != OT_ERROR_NONE)
     {
         otLogDebgCoap("Failed to parse CoAP header");
+
+        if (!aMessageInfo.GetSockAddr().IsMulticast() && message.IsConfirmable())
+        {
+            SendReset(message, aMessageInfo);
+        }
     }
     else if (message.IsRequest())
     {

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -255,6 +255,8 @@ otError Message::ParseHeader(void)
     GetHelpData().mHeaderOffset = GetOffset();
     Read(GetHelpData().mHeaderOffset, sizeof(GetHelpData().mHeader), &GetHelpData().mHeader);
 
+    VerifyOrExit(GetTokenLength() <= kMaxTokenLength, error = OT_ERROR_PARSE);
+
     SuccessOrExit(error = iterator.Init(this));
     for (const otCoapOption *option = iterator.GetFirstOption(); option != NULL; option = iterator.GetNextOption())
     {


### PR DESCRIPTION
Per RFC 7252:

- Treat invalid token length as a message format error.

- Rejecting a Confirmable message is effected by sending a matching
  Reset message and otherwise ignoring it.