### PR TITLE
[efr32] fix 4161a/4166a hal-config.h for upcoming v2.7 SDK patch release

### DIFF
--- a/examples/platforms/efr32mg12/brd4161a/hal-config.h
+++ b/examples/platforms/efr32mg12/brd4161a/hal-config.h
@@ -55,9 +55,9 @@
 #define BSP_CLK_HFXO_PRESENT                  (1)
 #define BSP_CLK_LFXO_INIT                      CMU_LFXOINIT_DEFAULT
 #define BSP_CLK_LFXO_CTUNE                    (0)
-#define BSP_CLK_LFXO_FREQ                     (32768)
+#define BSP_CLK_LFXO_FREQ                     (32768U)
 #define HAL_CLK_LFACLK_SOURCE                 (HAL_CLK_LFCLK_SOURCE_LFRCO)
-#define BSP_CLK_HFXO_FREQ                     (38400000)
+#define BSP_CLK_HFXO_FREQ                     (38400000UL)
 #define BSP_CLK_HFXO_CTUNE                    (338)
 #define BSP_CLK_HFXO_INIT                      CMU_HFXOINIT_DEFAULT
 #define BSP_CLK_HFXO_CTUNE_TOKEN              (0)

--- a/examples/platforms/efr32mg12/brd4166a/hal-config.h
+++ b/examples/platforms/efr32mg12/brd4166a/hal-config.h
@@ -54,11 +54,11 @@
 #define BSP_CLK_LFXO_PRESENT                  (1)
 #define BSP_CLK_HFXO_PRESENT                  (1)
 #define BSP_CLK_LFXO_INIT                      CMU_LFXOINIT_DEFAULT
-#define BSP_CLK_LFXO_CTUNE                    (0)
-#define BSP_CLK_LFXO_FREQ                     (32768)
+#define BSP_CLK_LFXO_CTUNE                    (32U)
+#define BSP_CLK_LFXO_FREQ                     (32768U)
 #define HAL_CLK_LFACLK_SOURCE                 (HAL_CLK_LFCLK_SOURCE_LFRCO)
-#define BSP_CLK_HFXO_FREQ                     (38400000)
-#define BSP_CLK_HFXO_CTUNE                    (338)
+#define BSP_CLK_HFXO_FREQ                     (38400000UL)
+#define BSP_CLK_HFXO_CTUNE                    (332)
 #define BSP_CLK_HFXO_INIT                      CMU_HFXOINIT_DEFAULT
 #define BSP_CLK_HFXO_CTUNE_TOKEN              (0)
 #define HAL_CLK_HFXO_AUTOSTART                (HAL_CLK_HFXO_AUTOSTART_NONE)


### PR DESCRIPTION
Fixes to build OpenThread with current and upcoming patch release of v2.7 SDK
