### PR TITLE
[efr32] Radio: don't abort current operation on switching to idle

### DIFF
--- a/examples/platforms/efr32mg12/Makefile.am
+++ b/examples/platforms/efr32mg12/Makefile.am
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2017, The OpenThread Authors.
+#  Copyright (c) 2020, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/Makefile.platform.am
+++ b/examples/platforms/efr32mg12/Makefile.platform.am
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2017, The OpenThread Authors.
+#  Copyright (c) 2020, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/alarm.c
+++ b/examples/platforms/efr32mg12/alarm.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/brd4161a/board_config.h
+++ b/examples/platforms/efr32mg12/brd4161a/board_config.h
@@ -36,6 +36,7 @@
 #define __BOARD_CONFIG_H__
 
 #define RADIO_CONFIG_2P4GHZ_OQPSK_SUPPORT 1   /// Dev board suppports OQPSK modulation in 2.4GHz band.
+#define RADIO_CONFIG_915MHZ_OQPSK_SUPPORT 0   /// Dev board doesn't support OQPSK modulation in 915MHz band.
 
 #ifndef RADIO_CONFIG_DEBUG_COUNTERS_SUPPORT
 #define RADIO_CONFIG_DEBUG_COUNTERS_SUPPORT 0 /// Set to 1 to enable debug counters in radio.c

--- a/examples/platforms/efr32mg12/brd4166a/board_config.h
+++ b/examples/platforms/efr32mg12/brd4166a/board_config.h
@@ -36,6 +36,7 @@
 #define __BOARD_CONFIG_H__
 
 #define RADIO_CONFIG_2P4GHZ_OQPSK_SUPPORT 1   /// Dev board suppports OQPSK modulation in 2.4GHz band.
+#define RADIO_CONFIG_915MHZ_OQPSK_SUPPORT 0   /// Dev board doesn't support OQPSK modulation in 915MHz band.
 
 #ifndef RADIO_CONFIG_DEBUG_COUNTERS_SUPPORT
 #define RADIO_CONFIG_DEBUG_COUNTERS_SUPPORT 0 /// Set to 1 to enable debug counters in radio.c

--- a/examples/platforms/efr32mg12/brd4304a/board_config.h
+++ b/examples/platforms/efr32mg12/brd4304a/board_config.h
@@ -36,6 +36,7 @@
 #define __BOARD_CONFIG_H__
 
 #define RADIO_CONFIG_2P4GHZ_OQPSK_SUPPORT 1   /// Dev board suppports OQPSK modulation in 2.4GHz band.
+#define RADIO_CONFIG_915MHZ_OQPSK_SUPPORT 0   /// Dev board doesn't support OQPSK modulation in 915MHz band.
 
 #ifndef RADIO_CONFIG_DEBUG_COUNTERS_SUPPORT
 #define RADIO_CONFIG_DEBUG_COUNTERS_SUPPORT 0 /// Set to 1 to enable debug counters in radio.c

--- a/examples/platforms/efr32mg12/crypto/efr32-mbedtls-config.h
+++ b/examples/platforms/efr32mg12/crypto/efr32-mbedtls-config.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/diag.c
+++ b/examples/platforms/efr32mg12/diag.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/entropy.c
+++ b/examples/platforms/efr32mg12/entropy.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/fem-control.c
+++ b/examples/platforms/efr32mg12/fem-control.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/flash.c
+++ b/examples/platforms/efr32mg12/flash.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/misc.c
+++ b/examples/platforms/efr32mg12/misc.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/openthread-core-efr32-config-check.h
+++ b/examples/platforms/efr32mg12/openthread-core-efr32-config-check.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/openthread-core-efr32-config.h
+++ b/examples/platforms/efr32mg12/openthread-core-efr32-config.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/platform-band.h
+++ b/examples/platforms/efr32mg12/platform-band.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2018, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/platform-efr32.h
+++ b/examples/platforms/efr32mg12/platform-efr32.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -497,7 +497,7 @@ otError otPlatRadioSleep(otInstance *aInstance)
 
     otLogInfoPlat("State=OT_RADIO_STATE_SLEEP", NULL);
 
-    RAIL_Idle(gRailHandle, RAIL_IDLE_ABORT, true); // abort packages under reception
+    RAIL_Idle(gRailHandle, RAIL_IDLE, true);
     sState = OT_RADIO_STATE_SLEEP;
 
 exit:
@@ -518,7 +518,7 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 
     if (sCurrentBandConfig != config)
     {
-        RAIL_Idle(gRailHandle, RAIL_IDLE_ABORT, true);
+        RAIL_Idle(gRailHandle, RAIL_IDLE, true);
         efr32RailConfigLoad(config);
         sCurrentBandConfig = config;
     }
@@ -566,7 +566,7 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
 
     if (sCurrentBandConfig != config)
     {
-        RAIL_Idle(gRailHandle, RAIL_IDLE_ABORT, true);
+        RAIL_Idle(gRailHandle, RAIL_IDLE, true);
         efr32RailConfigLoad(config);
         sCurrentBandConfig = config;
     }

--- a/examples/platforms/efr32mg12/sleepy-demo/Makefile.am
+++ b/examples/platforms/efr32mg12/sleepy-demo/Makefile.am
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019, The OpenThread Authors.
+#  Copyright (c) 2020, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-ftd/Makefile.am
+++ b/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-ftd/Makefile.am
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019, The OpenThread Authors.
+#  Copyright (c) 2020, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-ftd/main.c
+++ b/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-ftd/main.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-mtd/Makefile.am
+++ b/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-mtd/Makefile.am
@@ -1,5 +1,5 @@
 #
-#  Copyright (c) 2019, The OpenThread Authors.
+#  Copyright (c) 2020, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-mtd/main.c
+++ b/examples/platforms/efr32mg12/sleepy-demo/sleepy-demo-mtd/main.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/startup-gcc.c
+++ b/examples/platforms/efr32mg12/startup-gcc.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg12/system.c
+++ b/examples/platforms/efr32mg12/system.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -91,7 +91,6 @@ void otSysInit(int argc, char *argv[])
     CMU_ClockSelectSet(cmuClock_LFE, cmuSelect_LFRCO);
     CMU_ClockEnable(cmuClock_CORELE, true);
     CMU_ClockEnable(cmuClock_RTCC, true);
-
     status = sl_sleeptimer_init();
     assert(status == SL_STATUS_OK);
 

--- a/examples/platforms/efr32mg12/uart.c
+++ b/examples/platforms/efr32mg12/uart.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without

--- a/examples/platforms/efr32mg13/brd4168a/board_config.h
+++ b/examples/platforms/efr32mg13/brd4168a/board_config.h
@@ -36,6 +36,7 @@
 #define __BOARD_CONFIG_H__
 
 #define RADIO_CONFIG_2P4GHZ_OQPSK_SUPPORT 1   /// Dev board suppports OQPSK modulation in 2.4GHz band.
+#define RADIO_CONFIG_915MHZ_OQPSK_SUPPORT 0   /// Dev board doesn't support OQPSK modulation in 915MHz band.
 
 #ifndef RADIO_CONFIG_DEBUG_COUNTERS_SUPPORT
 #define RADIO_CONFIG_DEBUG_COUNTERS_SUPPORT 0 /// Set to 1 to enable debug counters in radio.c
@@ -43,6 +44,9 @@
 
 #ifndef RADIO_CONFIG_DMP_SUPPORT
 #define RADIO_CONFIG_DMP_SUPPORT 0            /// Set to 1 to enable Dynamic Multi-Protocol support in radio.c
+
+#define RADIO_CONFIG_PA_USES_DCDC 0           /// The PA(s) is(are) fed from VBAT
+
 #endif
 
 #endif // __BOARD_CONFIG_H__

--- a/examples/platforms/efr32mg13/openthread-core-efr32-config.h
+++ b/examples/platforms/efr32mg13/openthread-core-efr32-config.h
@@ -53,7 +53,7 @@
  * Define to 1 if you want to enable physical layer to support OQPSK modulation in 915MHz band.
  *
  */
-#ifdef RADIO_CONFIG_915MHZ_OQPSK_SUPPORT
+#if RADIO_CONFIG_915MHZ_OQPSK_SUPPORT
 #define OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT 1
 #else
 #define OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT 0
@@ -65,7 +65,7 @@
  * Define to 1 if you want to enable physical layer to support OQPSK modulation in 2.4GHz band.
  *
  */
-#ifdef RADIO_CONFIG_2P4GHZ_OQPSK_SUPPORT
+#if RADIO_CONFIG_2P4GHZ_OQPSK_SUPPORT
 #define OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT 1
 #else
 #define OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT 0
@@ -93,7 +93,7 @@
  * Define to 1 if you want to enable software CSMA-CA backoff logic.
  *
  */
-#define OPENTHREAD_CONFIG_SOFTWARE_CSMA_BACKOFF_ENABLE 1
+#define OPENTHREAD_CONFIG_SOFTWARE_CSMA_BACKOFF_ENABLE 0
 
 /**
  * @def OPENTHREAD_CONFIG_SOFTWARE_ENERGY_SCAN_ENABLE
@@ -101,7 +101,7 @@
  * Define to 1 if you want to enable software energy scanning logic.
  *
  */
-#define OPENTHREAD_CONFIG_SOFTWARE_ENERGY_SCAN_ENABLE 1
+#define OPENTHREAD_CONFIG_SOFTWARE_ENERGY_SCAN_ENABLE 0
 
 /**
  * @def SETTINGS_CONFIG_BASE_ADDRESS
@@ -126,22 +126,6 @@
  *
  */
 #define SETTINGS_CONFIG_PAGE_NUM 4
-
-/**
- * @def RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM
- *
- * The number of short source address table entries.
- *
- */
-#define RADIO_CONFIG_SRC_MATCH_SHORT_ENTRY_NUM 6
-
-/**
- * @def RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM
- *
- * The number of extended source address table entries.
- *
- */
-#define RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM 6
 
 /**
  * @def OPENTHREAD_CONFIG_NCP_UART_ENABLE

--- a/examples/platforms/efr32mg13/radio.c
+++ b/examples/platforms/efr32mg13/radio.c
@@ -476,7 +476,7 @@ otError otPlatRadioSleep(otInstance *aInstance)
 
     otLogInfoPlat("State=OT_RADIO_STATE_SLEEP", NULL);
 
-    RAIL_Idle(gRailHandle, RAIL_IDLE_ABORT, true); // abort packages under reception
+    RAIL_Idle(gRailHandle, RAIL_IDLE, true);
     sState = OT_RADIO_STATE_SLEEP;
 
 exit:
@@ -497,7 +497,7 @@ otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel)
 
     if (sCurrentBandConfig != config)
     {
-        RAIL_Idle(gRailHandle, RAIL_IDLE_ABORT, true);
+        RAIL_Idle(gRailHandle, RAIL_IDLE, true);
         efr32RailConfigLoad(config);
         sCurrentBandConfig = config;
     }
@@ -545,7 +545,7 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
 
     if (sCurrentBandConfig != config)
     {
-        RAIL_Idle(gRailHandle, RAIL_IDLE_ABORT, true);
+        RAIL_Idle(gRailHandle, RAIL_IDLE, true);
         efr32RailConfigLoad(config);
         sCurrentBandConfig = config;
     }


### PR DESCRIPTION
On the RAIL callback, received packets are held and passed to OT core in the event loop.

On a sleepy device, if there is nothing more to do, the OT core calls `otPlatRadioSleep` which in turn calls `RAIL_Idle(gRailHandle, RAIL_IDLE_ABORT, true)`.

If the time between `RAIL_EVENT_RX_PACKET_RECEIVED` and the call to `RAIL_Idle` is less than the turnaround + the ACK tx time, the call to `RAIL_Idle` aborts the auto-ack that was being transmitted by the radio, so there are received packets without ACK, like this:

![image](https://user-images.githubusercontent.com/17166563/74953353-55791600-53e0-11ea-9f29-7a0b4e41ff32.png)

<pre>
[0012727105] [WARN]-PLAT----: RX_ACK_RECEIVED
[0012727111] [WARN]-PLAT----: RX_PACKET_RECEIVED
[0012727112] [WARN]-PLAT----: <b>TXACK_ABORTED</b>
[0012727998] [WARN]-PLAT----: RX_ACK_RECEIVED
[0012728008] [WARN]-PLAT----: RX_ACK_RECEIVED
[0012728019] [WARN]-PLAT----: RX_PACKET_RECEIVED
[0012728020] [WARN]-PLAT----: TXACK_PACKET_SENT
[0012728030] [WARN]-PLAT----: RX_PACKET_RECEIVED
[0012728030] [WARN]-PLAT----: TXACK_PACKET_SENT
[0012728042] [WARN]-PLAT----: RX_PACKET_RECEIVED
[0012728042] [WARN]-PLAT----: TXACK_PACKET_SENT
[0012728055] [WARN]-PLAT----: RX_ACK_RECEIVED
[0012728153] [WARN]-PLAT----: RX_ACK_RECEIVED
[0012728159] [WARN]-PLAT----: RX_PACKET_RECEIVED
[0012728160] [WARN]-PLAT----: <b>TXACK_ABORTED</b>
[0012736995] [WARN]-PLAT----: RX_ACK_RECEIVED
</pre>

This PR changes that call so that `RAIL_Idle` waits for the last operation to finish. With this change, the ACK is always sent.

