### PR TITLE
[utils] settings: move to object, to be able to have multiple instances

### DIFF
--- a/examples/platforms/utils/Makefile.am
+++ b/examples/platforms/utils/Makefile.am
@@ -47,7 +47,9 @@ libopenthread_platform_utils_a_SOURCES  = \
     mac_frame.h                           \
     settings.h                            \
     settings_ram.c                        \
-    settings_flash.c                      \
+    settings_flash_api.cpp                \
+    settings_flash.cpp                    \
+    settings_flash.hpp                    \
     soft_source_match_table.c             \
     soft_source_match_table.h             \
     $(NULL)

--- a/examples/platforms/utils/settings_flash.hpp
+++ b/examples/platforms/utils/settings_flash.hpp
@@ -1,0 +1,74 @@
+/*
+ *  Copyright (c) 2016, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the OpenThread platform abstraction for non-volatile storage of settings.
+ *
+ */
+
+#include "settings.h"
+
+#if !OPENTHREAD_SETTINGS_RAM
+
+#include <openthread/error.h>
+
+class SettingsFlash
+{
+public:
+    SettingsFlash(uint32_t aConfigBaseAddress)
+        : kConfigBaseAddress(aConfigBaseAddress)
+        , mSettingsBaseAddress(0)
+        , mSettingsUsedSize(0)
+    {
+    }
+
+    void    Init();
+    otError Get(uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength);
+    otError Set(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+    otError Add(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+    otError Delete(uint16_t aKey, int aIndex);
+    void    Wipe();
+    void    Deinit();
+
+private:
+    static uint16_t getAlignLength(uint16_t length);
+    static void     setSettingsFlag(uint32_t aBase, uint32_t aFlag);
+    static void     initSettings(uint32_t aBase, uint32_t aFlag);
+
+    uint32_t swapSettingsBlock();
+    otError  addSetting(uint16_t aKey, bool aIndex0, const uint8_t *aValue, uint16_t aValueLength);
+
+    const uint32_t kConfigBaseAddress;
+    uint32_t       mSettingsBaseAddress;
+    uint32_t       mSettingsUsedSize;
+
+    static bool mFlashInitialized;
+};
+
+#endif /* OPENTHREAD_SETTINGS_RAM */

--- a/examples/platforms/utils/settings_flash_api.cpp
+++ b/examples/platforms/utils/settings_flash_api.cpp
@@ -1,0 +1,88 @@
+/*
+ *  Copyright (c) 2016, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the OpenThread platform abstraction for non-volatile storage of settings.
+ *
+ */
+
+#include "settings_flash.hpp"
+
+#if !OPENTHREAD_SETTINGS_RAM
+
+#include <openthread/platform/settings.h>
+
+static SettingsFlash sSettings(SETTINGS_CONFIG_BASE_ADDRESS);
+
+extern "C" {
+
+void otPlatSettingsInit(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    sSettings.Init();
+}
+
+void otPlatSettingsDeinit(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    sSettings.Deinit();
+}
+
+otError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sSettings.Get(aKey, aIndex, aValue, aValueLength);
+}
+
+otError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sSettings.Set(aKey, aValue, aValueLength);
+}
+
+otError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sSettings.Add(aKey, aValue, aValueLength);
+}
+
+otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    return sSettings.Delete(aKey, aIndex);
+}
+
+void otPlatSettingsWipe(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    sSettings.Wipe();
+}
+}
+
+#endif /* OPENTHREAD_SETTINGS_RAM */


### PR DESCRIPTION
This PR modifies the implementation of Flash Settings to be able to have multiple instances.

This may be useful for applications that want to store its own settings and retain the capability of wiping the OT settings area and the APP settings area independently.