### PR TITLE
[posix-host] fix warnings caused by SPI arguments

### DIFF
--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -122,7 +122,6 @@ static const struct option kOptions[] = {{"debug-level", required_argument, NULL
                                          {"ncp-dataset", no_argument, NULL, ARG_RESTORE_NCP_DATASET},
                                          {"time-speed", required_argument, NULL, 's'},
                                          {"verbose", no_argument, NULL, 'v'},
-#if OPENTHREAD_POSIX_RCP_SPI_ENABLE
                                          {"gpio-int-dev", required_argument, NULL, ARG_SPI_GPIO_INT_DEV},
                                          {"gpio-int-line", required_argument, NULL, ARG_SPI_GPIO_INT_LINE},
                                          {"gpio-reset-dev", required_argument, NULL, ARG_SPI_GPIO_RESET_DEV},
@@ -133,7 +132,6 @@ static const struct option kOptions[] = {{"debug-level", required_argument, NULL
                                          {"spi-reset-delay", required_argument, NULL, ARG_SPI_RESET_DELAY},
                                          {"spi-align-allowance", required_argument, NULL, ARG_SPI_ALIGN_ALLOWANCE},
                                          {"spi-small-packet", required_argument, NULL, ARG_SPI_SMALL_PACKET},
-#endif
                                          {0, 0, 0, 0}};
 
 static void PrintUsage(const char *aProgramName, FILE *aStream, int aExitCode)
@@ -150,7 +148,6 @@ static void PrintUsage(const char *aProgramName, FILE *aStream, int aExitCode)
             "        --ncp-dataset             Retrieve and save NCP dataset to file.\n"
             "    -s  --time-speed factor       Time speed up factor.\n"
             "    -v  --verbose                 Also log to stderr.\n"
-#if OPENTHREAD_POSIX_RCP_SPI_ENABLE
             "        --gpio-int-dev[=gpio-device-path]\n"
             "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"
             "                                  `I̅N̅T̅` pin. If not specified, `SPI` interface will fall back to\n"
@@ -172,7 +169,6 @@ static void PrintUsage(const char *aProgramName, FILE *aStream, int aExitCode)
             "                                  MISO frame. Max value is 16.\n"
             "        --spi-small-packet=[n]    Specify the smallest packet we can receive in a single transaction.\n"
             "                                  (larger packets will require two transactions). Default value is 32.\n"
-#endif
             "    -h  --help                    Display this usage information.\n",
             aProgramName);
     exit(aExitCode);
@@ -243,7 +239,6 @@ static void ParseArg(int aArgCount, char *aArgVector[], PosixConfig *aConfig)
         case ARG_RESTORE_NCP_DATASET:
             aConfig->mPlatformConfig.mRestoreDatasetFromNcp = true;
             break;
-#if OPENTHREAD_POSIX_RCP_SPI_ENABLE
         case ARG_SPI_GPIO_INT_DEV:
             aConfig->mPlatformConfig.mSpiGpioIntDevice = optarg;
             break;
@@ -260,21 +255,20 @@ static void ParseArg(int aArgCount, char *aArgVector[], PosixConfig *aConfig)
             aConfig->mPlatformConfig.mSpiMode = (uint8_t)atoi(optarg);
             break;
         case ARG_SPI_SPEED:
-            aConfig->mPlatformConfig.mSpiSpeed = atoi(optarg);
+            aConfig->mPlatformConfig.mSpiSpeed = (uint32_t)atoi(optarg);
             break;
         case ARG_SPI_CS_DELAY:
-            aConfig->mPlatformConfig.mSpiCsDelay = atoi(optarg);
+            aConfig->mPlatformConfig.mSpiCsDelay = (uint16_t)atoi(optarg);
             break;
         case ARG_SPI_RESET_DELAY:
-            aConfig->mPlatformConfig.mSpiResetDelay = atoi(optarg);
+            aConfig->mPlatformConfig.mSpiResetDelay = (uint32_t)atoi(optarg);
             break;
         case ARG_SPI_ALIGN_ALLOWANCE:
-            aConfig->mPlatformConfig.mSpiAlignAllowance = atoi(optarg);
+            aConfig->mPlatformConfig.mSpiAlignAllowance = (uint8_t)atoi(optarg);
             break;
         case ARG_SPI_SMALL_PACKET:
-            aConfig->mPlatformConfig.mSpiSmallPacketSize = atoi(optarg);
+            aConfig->mPlatformConfig.mSpiSmallPacketSize = (uint8_t)atoi(optarg);
             break;
-#endif // OPENTHREAD_POSIX_RCP_SPI_ENABLE
         case '?':
             PrintUsage(aArgVector[0], stderr, OT_EXIT_INVALID_ARGUMENTS);
             break;

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -122,6 +122,7 @@ static const struct option kOptions[] = {{"debug-level", required_argument, NULL
                                          {"ncp-dataset", no_argument, NULL, ARG_RESTORE_NCP_DATASET},
                                          {"time-speed", required_argument, NULL, 's'},
                                          {"verbose", no_argument, NULL, 'v'},
+#if OPENTHREAD_POSIX_RCP_SPI_ENABLE
                                          {"gpio-int-dev", required_argument, NULL, ARG_SPI_GPIO_INT_DEV},
                                          {"gpio-int-line", required_argument, NULL, ARG_SPI_GPIO_INT_LINE},
                                          {"gpio-reset-dev", required_argument, NULL, ARG_SPI_GPIO_RESET_DEV},
@@ -132,62 +133,49 @@ static const struct option kOptions[] = {{"debug-level", required_argument, NULL
                                          {"spi-reset-delay", required_argument, NULL, ARG_SPI_RESET_DELAY},
                                          {"spi-align-allowance", required_argument, NULL, ARG_SPI_ALIGN_ALLOWANCE},
                                          {"spi-small-packet", required_argument, NULL, ARG_SPI_SMALL_PACKET},
-                                         {0, 0, 0, 0}};
-
-#if OPENTHREAD_POSIX_RCP_SPI_ENABLE
-static const char *sHelpString =
-    "Syntax:\n"
-    "    %s [Options] NodeId|Device|Command [DeviceConfig|CommandArgs]\n"
-    "Options:\n"
-    "    -I  --interface-name name     Thread network interface name.\n"
-    "    -d  --debug-level             Debug level of logging.\n"
-    "    -n  --dry-run                 Just verify if arguments is valid and radio spinel is compatible.\n"
-    "        --no-reset                Do not send Spinel reset command to RCP on initialization.\n"
-    "        --radio-version           Print radio firmware version.\n"
-    "        --ncp-dataset             Retrieve and save NCP dataset to file.\n"
-    "    -s  --time-speed factor       Time speed up factor.\n"
-    "    -v  --verbose                 Also log to stderr.\n"
-    "        --gpio-int-dev[=gpio-device-path]\n"
-    "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"
-    "                                  `I̅N̅T̅` pin. If not specified, `SPI` interface will fall back to\n"
-    "                                  polling, which is inefficient.\n"
-    "        --gpio-int-line[=line-offset]\n"
-    "                                  The offset index of `I̅N̅T̅` pin for the associated GPIO device.\n"
-    "                                  If not specified, `SPI` interface will fall back to polling,\n"
-    "                                  which is inefficient.\n"
-    "        --gpio-reset-dev[=gpio-device-path]\n"
-    "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"
-    "                                  `R̅E̅S̅` pin.\n"
-    "        --gpio-reset-line[=line-offset]"
-    "                                  The offset index of `R̅E̅S̅` pin for the associated GPIO device.\n"
-    "        --spi-mode[=mode]         Specify the SPI mode to use (0-3).\n"
-    "        --spi-speed[=hertz]       Specify the SPI speed in hertz.\n"
-    "        --spi-cs-delay[=usec]     Specify the delay after C̅S̅ assertion, in µsec.\n"
-    "        --spi-reset-delay[=ms]    Specify the delay after R̅E̅S̅E̅T̅ assertion, in milliseconds.\n"
-    "        --spi-align-allowance[=n] Specify the maximum number of 0xFF bytes to clip from start of\n"
-    "                                  MISO frame. Max value is 16.\n"
-    "        --spi-small-packet=[n]    Specify the smallest packet we can receive in a single transaction.\n"
-    "                                  (larger packets will require two transactions). Default value is 32.\n"
-    "    -h  --help                    Display this usage information.\n";
-#else
-static const char *sHelpString =
-    "Syntax:\n"
-    "    %s [Options] NodeId|Device|Command [DeviceConfig|CommandArgs]\n"
-    "Options:\n"
-    "    -I  --interface-name name     Thread network interface name.\n"
-    "    -d  --debug-level             Debug level of logging.\n"
-    "    -n  --dry-run                 Just verify if arguments is valid and radio spinel is compatible.\n"
-    "        --no-reset                Do not send Spinel reset command to RCP on initialization.\n"
-    "        --radio-version           Print radio firmware version.\n"
-    "        --ncp-dataset             Retrieve and save NCP dataset to file.\n"
-    "    -s  --time-speed factor       Time speed up factor.\n"
-    "    -v  --verbose                 Also log to stderr.\n"
-    "    -h  --help                    Display this usage information.\n";
 #endif
+                                         {0, 0, 0, 0}};
 
 static void PrintUsage(const char *aProgramName, FILE *aStream, int aExitCode)
 {
-    fprintf(aStream, sHelpString, aProgramName);
+    fprintf(aStream,
+            "Syntax:\n"
+            "    %s [Options] NodeId|Device|Command [DeviceConfig|CommandArgs]\n"
+            "Options:\n"
+            "    -d  --debug-level             Debug level of logging.\n"
+            "    -h  --help                    Display this usage information.\n"
+            "    -I  --interface-name name     Thread network interface name.\n"
+            "    -n  --dry-run                 Just verify if arguments is valid and radio spinel is compatible.\n"
+            "        --no-reset                Do not send Spinel reset command to RCP on initialization.\n"
+            "        --radio-version           Print radio firmware version.\n"
+            "        --ncp-dataset             Retrieve and save NCP dataset to file.\n"
+            "    -s  --time-speed factor       Time speed up factor.\n"
+            "    -v  --verbose                 Also log to stderr.\n",
+            aProgramName);
+#if OPENTHREAD_POSIX_RCP_SPI_ENABLE
+    fprintf(aStream,
+            "        --gpio-int-dev[=gpio-device-path]\n"
+            "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"
+            "                                  `I̅N̅T̅` pin. If not specified, `SPI` interface will fall back to\n"
+            "                                  polling, which is inefficient.\n"
+            "        --gpio-int-line[=line-offset]\n"
+            "                                  The offset index of `I̅N̅T̅` pin for the associated GPIO device.\n"
+            "                                  If not specified, `SPI` interface will fall back to polling,\n"
+            "                                  which is inefficient.\n"
+            "        --gpio-reset-dev[=gpio-device-path]\n"
+            "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"
+            "                                  `R̅E̅S̅` pin.\n"
+            "        --gpio-reset-line[=line-offset]"
+            "                                  The offset index of `R̅E̅S̅` pin for the associated GPIO device.\n"
+            "        --spi-mode[=mode]         Specify the SPI mode to use (0-3).\n"
+            "        --spi-speed[=hertz]       Specify the SPI speed in hertz.\n"
+            "        --spi-cs-delay[=usec]     Specify the delay after C̅S̅ assertion, in µsec.\n"
+            "        --spi-reset-delay[=ms]    Specify the delay after R̅E̅S̅E̅T̅ assertion, in milliseconds.\n"
+            "        --spi-align-allowance[=n] Specify the maximum number of 0xFF bytes to clip from start of\n"
+            "                                  MISO frame. Max value is 16.\n"
+            "        --spi-small-packet=[n]    Specify the smallest packet we can receive in a single transaction.\n"
+            "                                  (larger packets will require two transactions). Default value is 32.\n");
+#endif
     exit(aExitCode);
 }
 

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -134,43 +134,60 @@ static const struct option kOptions[] = {{"debug-level", required_argument, NULL
                                          {"spi-small-packet", required_argument, NULL, ARG_SPI_SMALL_PACKET},
                                          {0, 0, 0, 0}};
 
+#if OPENTHREAD_POSIX_RCP_SPI_ENABLE
+static const char *sHelpString =
+    "Syntax:\n"
+    "    %s [Options] NodeId|Device|Command [DeviceConfig|CommandArgs]\n"
+    "Options:\n"
+    "    -I  --interface-name name     Thread network interface name.\n"
+    "    -d  --debug-level             Debug level of logging.\n"
+    "    -n  --dry-run                 Just verify if arguments is valid and radio spinel is compatible.\n"
+    "        --no-reset                Do not send Spinel reset command to RCP on initialization.\n"
+    "        --radio-version           Print radio firmware version.\n"
+    "        --ncp-dataset             Retrieve and save NCP dataset to file.\n"
+    "    -s  --time-speed factor       Time speed up factor.\n"
+    "    -v  --verbose                 Also log to stderr.\n"
+    "        --gpio-int-dev[=gpio-device-path]\n"
+    "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"
+    "                                  `I̅N̅T̅` pin. If not specified, `SPI` interface will fall back to\n"
+    "                                  polling, which is inefficient.\n"
+    "        --gpio-int-line[=line-offset]\n"
+    "                                  The offset index of `I̅N̅T̅` pin for the associated GPIO device.\n"
+    "                                  If not specified, `SPI` interface will fall back to polling,\n"
+    "                                  which is inefficient.\n"
+    "        --gpio-reset-dev[=gpio-device-path]\n"
+    "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"
+    "                                  `R̅E̅S̅` pin.\n"
+    "        --gpio-reset-line[=line-offset]"
+    "                                  The offset index of `R̅E̅S̅` pin for the associated GPIO device.\n"
+    "        --spi-mode[=mode]         Specify the SPI mode to use (0-3).\n"
+    "        --spi-speed[=hertz]       Specify the SPI speed in hertz.\n"
+    "        --spi-cs-delay[=usec]     Specify the delay after C̅S̅ assertion, in µsec.\n"
+    "        --spi-reset-delay[=ms]    Specify the delay after R̅E̅S̅E̅T̅ assertion, in milliseconds.\n"
+    "        --spi-align-allowance[=n] Specify the maximum number of 0xFF bytes to clip from start of\n"
+    "                                  MISO frame. Max value is 16.\n"
+    "        --spi-small-packet=[n]    Specify the smallest packet we can receive in a single transaction.\n"
+    "                                  (larger packets will require two transactions). Default value is 32.\n"
+    "    -h  --help                    Display this usage information.\n";
+#else
+static const char *sHelpString =
+    "Syntax:\n"
+    "    %s [Options] NodeId|Device|Command [DeviceConfig|CommandArgs]\n"
+    "Options:\n"
+    "    -I  --interface-name name     Thread network interface name.\n"
+    "    -d  --debug-level             Debug level of logging.\n"
+    "    -n  --dry-run                 Just verify if arguments is valid and radio spinel is compatible.\n"
+    "        --no-reset                Do not send Spinel reset command to RCP on initialization.\n"
+    "        --radio-version           Print radio firmware version.\n"
+    "        --ncp-dataset             Retrieve and save NCP dataset to file.\n"
+    "    -s  --time-speed factor       Time speed up factor.\n"
+    "    -v  --verbose                 Also log to stderr.\n"
+    "    -h  --help                    Display this usage information.\n";
+#endif
+
 static void PrintUsage(const char *aProgramName, FILE *aStream, int aExitCode)
 {
-    fprintf(aStream,
-            "Syntax:\n"
-            "    %s [Options] NodeId|Device|Command [DeviceConfig|CommandArgs]\n"
-            "Options:\n"
-            "    -I  --interface-name name     Thread network interface name.\n"
-            "    -d  --debug-level             Debug level of logging.\n"
-            "    -n  --dry-run                 Just verify if arguments is valid and radio spinel is compatible.\n"
-            "        --no-reset                Do not send Spinel reset command to RCP on initialization.\n"
-            "        --radio-version           Print radio firmware version.\n"
-            "        --ncp-dataset             Retrieve and save NCP dataset to file.\n"
-            "    -s  --time-speed factor       Time speed up factor.\n"
-            "    -v  --verbose                 Also log to stderr.\n"
-            "        --gpio-int-dev[=gpio-device-path]\n"
-            "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"
-            "                                  `I̅N̅T̅` pin. If not specified, `SPI` interface will fall back to\n"
-            "                                  polling, which is inefficient.\n"
-            "        --gpio-int-line[=line-offset]\n"
-            "                                  The offset index of `I̅N̅T̅` pin for the associated GPIO device.\n"
-            "                                  If not specified, `SPI` interface will fall back to polling,\n"
-            "                                  which is inefficient.\n"
-            "        --gpio-reset-dev[=gpio-device-path]\n"
-            "                                  Specify a path to the Linux sysfs-exported GPIO device for the\n"
-            "                                  `R̅E̅S̅` pin.\n"
-            "        --gpio-reset-line[=line-offset]"
-            "                                  The offset index of `R̅E̅S̅` pin for the associated GPIO device.\n"
-            "        --spi-mode[=mode]         Specify the SPI mode to use (0-3).\n"
-            "        --spi-speed[=hertz]       Specify the SPI speed in hertz.\n"
-            "        --spi-cs-delay[=usec]     Specify the delay after C̅S̅ assertion, in µsec.\n"
-            "        --spi-reset-delay[=ms]    Specify the delay after R̅E̅S̅E̅T̅ assertion, in milliseconds.\n"
-            "        --spi-align-allowance[=n] Specify the maximum number of 0xFF bytes to clip from start of\n"
-            "                                  MISO frame. Max value is 16.\n"
-            "        --spi-small-packet=[n]    Specify the smallest packet we can receive in a single transaction.\n"
-            "                                  (larger packets will require two transactions). Default value is 32.\n"
-            "    -h  --help                    Display this usage information.\n",
-            aProgramName);
+    fprintf(aStream, sHelpString, aProgramName);
     exit(aExitCode);
 }
 

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -1239,7 +1239,7 @@ otError RadioSpinel::WaitResponse(void)
 {
     uint64_t end = platformGetTime() + kMaxWaitTime * US_PER_MS;
 
-    otLogInfoPlat("Wait response: tid=%u key=%u", mWaitingTid, mWaitingKey);
+    otLogDebgPlat("Wait response: tid=%u key=%u", mWaitingTid, mWaitingKey);
 
     do
     {


### PR DESCRIPTION
* signed/unsigned conversion error
* undefined behavior of embedding macros in string literal

> embedding a directive within macro arguments has undefined behavior