### PR TITLE
[address-resolver] use linked-list and enable snooped entry timeout

### DIFF
--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -79,16 +79,45 @@ typedef struct
 typedef uint16_t otChildIp6AddressIterator; ///< Used to iterate through IPv6 addresses of a Thread Child entry.
 
 /**
+ * This enumeration defines the EID cache entry state.
+ *
+ */
+typedef enum otCacheEntryState
+{
+    OT_CACHE_ENTRY_STATE_CACHED      = 0, // Entry is cached and in-use.
+    OT_CACHE_ENTRY_STATE_SNOOPED     = 1, // Entry is created by snoop optimization (inspection of received msg).
+    OT_CACHE_ENTRY_STATE_QUERY       = 2, // Entry represents an ongoing query for the EID.
+    OT_CACHE_ENTRY_STATE_RETRY_QUERY = 3, // Entry is in retry wait mode (a prior query did not get a response).
+} otCacheEntryState;
+
+/**
  * This structure represents an EID cache entry.
  *
  */
-typedef struct otEidCacheEntry
+typedef struct otCacheEntryInfo
 {
-    otIp6Address   mTarget;    ///< Target
-    otShortAddress mRloc16;    ///< RLOC16
-    uint8_t        mAge;       ///< Age (order of use, 0 indicates most recently used entry)
-    bool           mValid : 1; ///< Indicates whether or not the cache entry is valid
-} otEidCacheEntry;
+    otIp6Address      mTarget;             ///< Target EID
+    otShortAddress    mRloc16;             ///< RLOC16
+    otCacheEntryState mState;              ///< Entry state
+    bool              mCanEvict : 1;       ///< Indicates whether the entry can be evicted.
+    bool              mValidLastTrans : 1; ///< Indicates whether last transaction time and ML-EID are valid.
+    uint32_t          mLastTransTime;      ///< Last transaction time (applicable in cached state).
+    otIp6Address      mMeshLocalEid;       ///< Mesh Local EID (applicable if entry in cached state).
+    uint16_t          mTimeout;            ///< Timeout in seconds (applicable if in snooped/query/retry-query states).
+    uint16_t          mRetryDelay;         ///< Retry delay in seconds (applicable if in query-retry state).
+} otCacheEntryInfo;
+
+/**
+ * This type represents an iterator used for iterating through the EID cache table entries.
+ *
+ * To initialize the iterator and start from the first entry in the cache table, set all its fields in the structure to
+ * zero (e.g., `memset` the iterator to zero).
+ *
+ */
+typedef struct otCacheEntryIterator
+{
+    const void *mData[2]; ///< Opaque data used by the core implementation. Should not be changed by user.
+} otCacheEntryIterator;
 
 /**
  * Get the maximum number of children currently allowed.
@@ -507,17 +536,19 @@ uint8_t otThreadGetMaxRouterId(otInstance *aInstance);
 otError otThreadGetRouterInfo(otInstance *aInstance, uint16_t aRouterId, otRouterInfo *aRouterInfo);
 
 /**
- * This function gets an EID cache entry.
+ * This function gets the next EID cache entry (using an iterator).
  *
- * @param[in]   aInstance A pointer to an OpenThread instance.
- * @param[in]   aIndex    An index into the EID cache table.
- * @param[out]  aEntry    A pointer to where the EID information is placed.
+ * @param[in]    aInstance   A pointer to an OpenThread instance.
+ * @param[out]   aEntryInfo  A pointer to where the EID cache entry information is placed.
+ * @param[inout] aIterator   A pointer to an iterator. It will be updated to point to next entry on success. To get the
+ *                           first entry, initialize the iterator by setting all its fields to zero (e.g., `memset` the
+ *                           the iterator structure to zero).
  *
- * @retval OT_ERROR_NONE          Successfully retrieved the EID cache entry.
- * @retval OT_ERROR_INVALID_ARGS  @p aIndex was out of bounds or @p aEntry was NULL.
+ * @retval OT_ERROR_NONE          Successfully populated @p aEntryInfo for next EID cache entry.
+ * @retval OT_ERROR_NOT_FOUND     No more entries in the address cache table.
  *
  */
-otError otThreadGetEidCacheEntry(otInstance *aInstance, uint8_t aIndex, otEidCacheEntry *aEntry);
+otError otThreadGetNextCacheEntry(otInstance *aInstance, otCacheEntryInfo *aEntryInfo, otCacheEntryIterator *aIterator);
 
 /**
  * Get the Thread PSKc

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1294,16 +1294,14 @@ void Interpreter::ProcessEidCache(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    otEidCacheEntry entry;
+    otCacheEntryIterator iterator;
+    otCacheEntryInfo     entry;
+
+    memset(&iterator, 0, sizeof(iterator));
 
     for (uint8_t i = 0;; i++)
     {
-        SuccessOrExit(otThreadGetEidCacheEntry(mInstance, i, &entry));
-
-        if (!entry.mValid)
-        {
-            continue;
-        }
+        SuccessOrExit(otThreadGetNextCacheEntry(mInstance, &entry, &iterator));
 
         OutputIp6Address(entry.mTarget);
         mServer->OutputFormat(" %04x\r\n", entry.mRloc16);

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -316,12 +316,13 @@ otError otThreadGetRouterInfo(otInstance *aInstance, uint16_t aRouterId, otRoute
     return instance.Get<RouterTable>().GetRouterInfo(aRouterId, *aRouterInfo);
 }
 
-otError otThreadGetEidCacheEntry(otInstance *aInstance, uint8_t aIndex, otEidCacheEntry *aEntry)
+otError otThreadGetNextCacheEntry(otInstance *aInstance, otCacheEntryInfo *aEntryInfo, otCacheEntryIterator *aIterator)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    OT_ASSERT(aEntry != NULL);
-    return instance.Get<AddressResolver>().GetEntry(aIndex, *aEntry);
+    OT_ASSERT((aIterator != NULL) && (aEntryInfo != NULL));
+
+    return instance.Get<AddressResolver>().GetNextCacheEntry(*aEntryInfo, *aIterator);
 }
 
 #if OPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE

--- a/src/core/common/linked_list.hpp
+++ b/src/core/common/linked_list.hpp
@@ -199,18 +199,28 @@ public:
      *
      * @note This method does not change the popped entry itself, i.e., the popped entry next pointer stays as before.
      *
-     * @param[in] aPrevEntry  A reference to n previous entry (the entry after this will be popped).
-
-     * @returns The entry that was popped if list is not empty, or NULL if there is no entry after the given one.
+     * @param[in] aPrevEntry  A pointer to a previous entry. If it is not NULL the entry after this will be popped,
+     *                        otherwise (if it is NULL) the entry at head of the list is popped.
+     *
+     * @returns Pointer to the entry that was popped, or NULL if there is no entry to pop.
      *
      */
-    Type *PopAfter(Type &aPrevEntry)
+    Type *PopAfter(Type *aPrevEntry)
     {
-        Type *entry = aPrevEntry.GetNext();
+        Type *entry;
 
-        if (entry != NULL)
+        if (aPrevEntry == NULL)
         {
-            aPrevEntry.SetNext(entry->GetNext());
+            entry = Pop();
+        }
+        else
+        {
+            entry = aPrevEntry->GetNext();
+
+            if (entry != NULL)
+            {
+                aPrevEntry->SetNext(entry->GetNext());
+            }
         }
 
         return entry;

--- a/src/core/config/tmf.h
+++ b/src/core/config/tmf.h
@@ -46,6 +46,31 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES
+ *
+ * The maximum number of EID-to-RLOC cache entries that can be used for "snoop optimization" where an entry is created
+ * by inspecting a received message.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES
+#define OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES 2
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_TMF_SNOOP_CACHE_ENTRY_TIMEOUT
+ *
+ * The timeout value (in seconds) blocking eviction of an address cache entry created through snoop optimization (i.e.,
+ * inspection of a received message). After the timeout expires the entry can be reclaimed again. This timeout allows
+ * a longer response delay for a received message giving more chance that a snooped entry will be used (avoiding
+ * sending Address Query when a response message is sent to same destination from which the message was received
+ * earlier).
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_TMF_SNOOP_CACHE_ENTRY_TIMEOUT
+#define OPENTHREAD_CONFIG_TMF_SNOOP_CACHE_ENTRY_TIMEOUT 3
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_TIMEOUT
  *
  * The timeout value (in seconds) waiting for a address notification response after sending an address query.

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -404,15 +404,7 @@ otError Netif::UnsubscribeExternalMulticast(const Address &aAddress)
             VerifyOrExit((entry >= &mExtMulticastAddresses[0]) && (entry < OT_ARRAY_END(mExtMulticastAddresses)),
                          error = OT_ERROR_INVALID_ARGS);
 
-            if (last)
-            {
-                mMulticastAddresses.PopAfter(*last);
-            }
-            else
-            {
-                mMulticastAddresses.Pop();
-            }
-
+            mMulticastAddresses.PopAfter(last);
             break;
         }
 
@@ -528,15 +520,7 @@ otError Netif::RemoveExternalUnicastAddress(const Address &aAddress)
             VerifyOrExit((entry >= &mExtUnicastAddresses[0]) && (entry < OT_ARRAY_END(mExtUnicastAddresses)),
                          error = OT_ERROR_INVALID_ARGS);
 
-            if (last)
-            {
-                mUnicastAddresses.PopAfter(*last);
-            }
-            else
-            {
-                mUnicastAddresses.Pop();
-            }
-
+            mUnicastAddresses.PopAfter(last);
             break;
         }
 

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -64,6 +64,18 @@ class AddressResolver : public InstanceLocator
 {
 public:
     /**
+     * This type represents an iterator used for iterating through the EID cache table entries.
+     *
+     */
+    typedef otCacheEntryIterator Iterator;
+
+    /**
+     * This type represents an EID cache entry.
+     *
+     */
+    typedef otCacheEntryInfo EntryInfo;
+
+    /**
      * This constructor initializes the object.
      *
      */
@@ -76,16 +88,18 @@ public:
     void Clear(void);
 
     /**
-     * This method gets an EID cache entry.
+     * This method gets the information about the next EID cache entry (using an iterator).
      *
-     * @param[in]   aIndex  An index into the EID cache table.
-     * @param[out]  aEntry  A reference to where the EID information is placed.
+     * @param[out]   aInfo       An `EntryInfo` where the EID cache entry information is placed.
+     * @param[inout] aIterator   An iterator. It will be updated to point to the next entry on success.
+     *                           To get the first entry, initialize the iterator by setting all its fields to zero.
+     *                           e.g., `memset` the the iterator structure to zero.
      *
-     * @retval OT_ERROR_NONE          Successfully retrieved the EID cache entry.
-     * @retval OT_ERROR_INVALID_ARGS  @p aIndex was out of bounds.
+     * @retval OT_ERROR_NONE       Successfully populated @p aInfo with the info for the next EID cache entry.
+     * @retval OT_ERROR_NOT_FOUND  No more entries in the address cache table.
      *
      */
-    otError GetEntry(uint8_t aIndex, otEidCacheEntry &aEntry) const;
+    otError GetNextCacheEntry(EntryInfo &aInfo, Iterator &aIterator) const;
 
     /**
      * This method removes the EID-to-RLOC cache entries corresponding to an RLOC16.
@@ -170,6 +184,8 @@ private:
         kAddressQueryMaxRetryDelay     = OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_MAX_RETRY_DELAY,     // in seconds
         kSnoopBlockEvictionTimeout     = OPENTHREAD_CONFIG_TMF_SNOOP_CACHE_ENTRY_TIMEOUT,         // in seconds
         kStateUpdatePeriod             = 1000u,                                                   // in milliseconds
+        kIteratorListIndex             = 0,
+        kIteratorEntryIndex            = 1,
     };
 
     class CacheEntry : public InstanceLocatorInit

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -237,8 +237,18 @@ private:
 
     typedef LinkedList<CacheEntry> CacheEntryList;
 
+    enum EntryChange
+    {
+        kEntryAdded,
+        kEntryUpdated,
+        kEntryRemoved,
+    };
+
     enum Reason
     {
+        kReasonQueryRequest,
+        kReasonSnoop,
+        kReasonReceivedNotification,
         kReasonRemovingRouterId,
         kReasonRemovingRloc16,
         kReasonReceivedIcmpDstUnreachNoRoute,
@@ -282,8 +292,12 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
-    const char *       ListToString(const CacheEntryList &aList) const;
-    static const char *ReasonToString(Reason aReason);
+    void LogCacheEntryChange(EntryChange       aChange,
+                             Reason            aReason,
+                             const CacheEntry &aEntry,
+                             CacheEntryList *  aList = NULL);
+
+    const char *ListToString(const CacheEntryList *aList) const;
 
     Coap::Resource mAddressError;
     Coap::Resource mAddressQuery;

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -613,7 +613,7 @@ void MeshForwarder::UpdateRoutes(uint8_t *           aFrame,
                 (aMeshDest.GetShort() == Get<Mac::Mac>().GetShortAddress() ||
                  Get<Mle::MleRouter>().IsMinimalChild(aMeshDest.GetShort())))
             {
-                Get<AddressResolver>().AddCacheEntry(ip6Header.GetSource(), aMeshSource.GetShort());
+                Get<AddressResolver>().AddSnoopedCacheEntry(ip6Header.GetSource(), aMeshSource.GetShort());
             }
         }
     }

--- a/src/lib/spinel/spinel.h
+++ b/src/lib/spinel/spinel.h
@@ -630,6 +630,14 @@ enum
     SPINEL_MESHCOP_COMMISSIONER_STATE_ACTIVE   = 2,
 };
 
+enum
+{
+    SPINEL_ADDRESS_CACHE_ENTRY_STATE_CACHED      = 0, // Entry is cached and in-use.
+    SPINEL_ADDRESS_CACHE_ENTRY_STATE_SNOOPED     = 1, // Entry is created by snoop optimization.
+    SPINEL_ADDRESS_CACHE_ENTRY_STATE_QUERY       = 2, // Entry represents an ongoing query for the EID.
+    SPINEL_ADDRESS_CACHE_ENTRY_STATE_RETRY_QUERY = 3, // Entry is in retry mode (a prior query did not  a response).
+};
+
 typedef struct
 {
     uint8_t bytes[8];
@@ -2646,7 +2654,7 @@ enum
     SPINEL_PROP_THREAD_NEIGHBOR_TABLE_ERROR_RATES = SPINEL_PROP_THREAD_EXT__BEGIN + 34,
 
     /// EID (Endpoint Identifier) IPv6 Address Cache Table
-    /** Format `A(t(6SC))`
+    /** Format `A(t(6SCCt(bL6)t(bSS)))
      *
      * This property provides Thread EID address cache table.
      *
@@ -2655,6 +2663,17 @@ enum
      *  `6` : Target IPv6 address
      *  `S` : RLOC16 of target
      *  `C` : Age (order of use, 0 indicates most recently used entry)
+     *  `C` : Entry state (values are defined by enumeration `SPINEL_ADDRESS_CACHE_ENTRY_STATE_*`).
+     *
+     *  `t` : Info when state is `SPINEL_ADDRESS_CACHE_ENTRY_STATE_CACHED`
+     *    `b` : Indicates whether last transaction time and ML-EID are valid.
+     *    `L` : Last transaction time
+     *    `6` : Mesh-local EID
+     *
+     *  `t` : Info when state is other than `SPINEL_ADDRESS_CACHE_ENTRY_STATE_CACHED`
+     *    `b` : Indicates whether the entry can be evicted.
+     *    `S` : Timeout in seconds
+     *    `S` : Retry delay (applicable if in query-retry state).
      *
      */
     SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE = SPINEL_PROP_THREAD_EXT__BEGIN + 35,

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -911,22 +911,20 @@ exit:
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE>(void)
 {
-    otError         error = OT_ERROR_NONE;
-    otEidCacheEntry entry;
+    otError              error = OT_ERROR_NONE;
+    otCacheEntryIterator iterator;
+    otCacheEntryInfo     entry;
+
+    memset(&iterator, 0, sizeof(iterator));
 
     for (uint8_t index = 0;; index++)
     {
-        SuccessOrExit(otThreadGetEidCacheEntry(mInstance, index, &entry));
-
-        if (!entry.mValid)
-        {
-            continue;
-        }
+        SuccessOrExit(otThreadGetNextCacheEntry(mInstance, &entry, &iterator));
 
         SuccessOrExit(error = mEncoder.OpenStruct());
         SuccessOrExit(error = mEncoder.WriteIp6Address(entry.mTarget));
         SuccessOrExit(error = mEncoder.WriteUint16(entry.mRloc16));
-        SuccessOrExit(error = mEncoder.WriteUint8(entry.mAge));
+        SuccessOrExit(error = mEncoder.WriteUint8(index));
         SuccessOrExit(error = mEncoder.CloseStruct());
     }
 

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -925,6 +925,45 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_ADDRESS_CACHE_
         SuccessOrExit(error = mEncoder.WriteIp6Address(entry.mTarget));
         SuccessOrExit(error = mEncoder.WriteUint16(entry.mRloc16));
         SuccessOrExit(error = mEncoder.WriteUint8(index));
+
+        switch (entry.mState)
+        {
+        case OT_CACHE_ENTRY_STATE_CACHED:
+            SuccessOrExit(error = mEncoder.WriteUint8(SPINEL_ADDRESS_CACHE_ENTRY_STATE_CACHED));
+            break;
+        case OT_CACHE_ENTRY_STATE_SNOOPED:
+            SuccessOrExit(error = mEncoder.WriteUint8(SPINEL_ADDRESS_CACHE_ENTRY_STATE_SNOOPED));
+            break;
+        case OT_CACHE_ENTRY_STATE_QUERY:
+            SuccessOrExit(error = mEncoder.WriteUint8(SPINEL_ADDRESS_CACHE_ENTRY_STATE_QUERY));
+            break;
+        case OT_CACHE_ENTRY_STATE_RETRY_QUERY:
+            SuccessOrExit(error = mEncoder.WriteUint8(SPINEL_ADDRESS_CACHE_ENTRY_STATE_RETRY_QUERY));
+            break;
+        }
+
+        SuccessOrExit(error = mEncoder.OpenStruct());
+
+        if (entry.mState == OT_CACHE_ENTRY_STATE_CACHED)
+        {
+            SuccessOrExit(error = mEncoder.WriteBool(entry.mValidLastTrans));
+            SuccessOrExit(error = mEncoder.WriteUint32(entry.mLastTransTime));
+            SuccessOrExit(error = mEncoder.WriteIp6Address(entry.mMeshLocalEid));
+        }
+
+        SuccessOrExit(error = mEncoder.CloseStruct());
+
+        SuccessOrExit(error = mEncoder.OpenStruct());
+
+        if (entry.mState != OT_CACHE_ENTRY_STATE_CACHED)
+        {
+            SuccessOrExit(error = mEncoder.WriteBool(entry.mCanEvict));
+            SuccessOrExit(error = mEncoder.WriteUint16(entry.mTimeout));
+            SuccessOrExit(error = mEncoder.WriteUint16(entry.mRetryDelay));
+        }
+
+        SuccessOrExit(error = mEncoder.CloseStruct());
+
         SuccessOrExit(error = mEncoder.CloseStruct());
     }
 

--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -1548,8 +1548,6 @@ class AddressCacheEntry(object):
         # separator
         dict = {item.split(':')[0]: item.split(':')[1] for item in items[3:]}
 
-        self._age = int(dict['age'], 0)
-
     @property
     def address(self):
         return self._address
@@ -1557,10 +1555,6 @@ class AddressCacheEntry(object):
     @property
     def rloc16(self):
         return self._rloc16
-
-    @property
-    def age(self):
-        return self._age
 
     def __repr__(self):
         return 'AddressCacheEntry({})'.format(self.__dict__)

--- a/tests/unit/test_linked_list.cpp
+++ b/tests/unit/test_linked_list.cpp
@@ -132,13 +132,13 @@ void TestLinkedList(void)
     list.Push(e);
     VerifyLinkedListContent(&list, &e, &c, &a, &d, &b, NULL);
 
-    VerifyOrQuit(list.PopAfter(a) == &d, "LinkedList::PopAfter() failed");
+    VerifyOrQuit(list.PopAfter(&a) == &d, "LinkedList::PopAfter() failed");
     VerifyLinkedListContent(&list, &e, &c, &a, &b, NULL);
 
-    VerifyOrQuit(list.PopAfter(b) == NULL, "LinkedList::PopAfter() failed");
+    VerifyOrQuit(list.PopAfter(&b) == NULL, "LinkedList::PopAfter() failed");
     VerifyLinkedListContent(&list, &e, &c, &a, &b, NULL);
 
-    VerifyOrQuit(list.PopAfter(e) == &c, "LinkedList::PopAfter() failed");
+    VerifyOrQuit(list.PopAfter(&e) == &c, "LinkedList::PopAfter() failed");
     VerifyLinkedListContent(&list, &e, &a, &b, NULL);
 
     list.PushAfter(c, b);
@@ -147,8 +147,15 @@ void TestLinkedList(void)
     list.PushAfter(d, a);
     VerifyLinkedListContent(&list, &e, &a, &d, &b, &c, NULL);
 
+    VerifyOrQuit(list.PopAfter(NULL) == &e, "LinkedList::PopAfter() failed");
+    VerifyLinkedListContent(&list, &a, &d, &b, &c, NULL);
+
+    VerifyOrQuit(list.PopAfter(NULL) == &a, "LinkedList::PopAfter() failed");
+    VerifyLinkedListContent(&list, &d, &b, &c, NULL);
+
     list.Clear();
     VerifyOrQuit(list.IsEmpty(), "LinkedList::IsEmpty() failed after Clear()");
+    VerifyOrQuit(list.PopAfter(NULL) == NULL, "LinkedList::PopAfter() failed");
     VerifyLinkedListContent(&list, NULL);
 }
 


### PR DESCRIPTION
This PR updates the `AddressResolver` and how cache entries are managed. This is related to Issue https://github.com/openthread/openthread/issues/4542. It contains the following related commits:

**[linked-list] change PopAfter() parameter to be a pointer**

This commit changes `LinkedList::PopAfter()` method to accept a pointer to a previous entry as a parameter. If the previous entry pointer is NULL the entry at the head of the list is popped. 

**[address-resolver] use linked-list and enable snooped entry timeout**

This commit contains multiple enhancements in `AddressResolver`:

- Cache entries are stored in different lists: Cached list (entries in use), query list (entries actively querying and waiting for address notification response), query-retry list (entries in delay wait mode due to prior query failing to get a response), and snooped list (entries discovered through received message inspection aka snoop optimization). Singly linked list is used which helps keep the entries sorted based on the order of use (whenever a cache entry is used to resolve an address, it is moved to the head of the list). This replaces and simplifies the aging model. 
- This commit updates the cache entry class definition to use `union` for member variables (like timeout or transaction time) that are tied to entry being in different lists. This help reduce the memory requirement for cache table.
- This commit also adds a new mechanism to manage snooped entries. When a new snooped entry is added, we do not allow it to be evicted for a short timeout. This allows some delay for a response message to use the entry (if entry is used it will be moved to the cached list). If a snooped entry is not used after the timeout, we allow it to be evicted. To ensure snooped entries do not overwrite other cached entries, we limit the number of snooped entries that are in timeout mode and cannot be evicted by a (build-time configurable) threshold. 

**[address-resolver] update how the cache table changes are logged**

This commit adds a new helper method `LogCacheEntryChange()` which logs any change (entry added/removed/updated) and its reason in address cache table. 

**[address-resolver] update public OT API for getting cache table**

This commit updates the public OpenThread APIs to get the address cache table. The new APIs allows to iterate through all entries (including in query or retry mode) and provides more info about the entries, e.g., current timeout, retry delay (if entry is in query/retry state), or the mesh-local EID, last transaction time (if entry is in cached state). 

**[spinel/ncp] update address cache table property to include additional info**

This commit expands the `SPINEL_PROP_THREAD_ADDRESS_CACHE_TABLE` property format to include more info about address cache table. This change keeps the definition backward compatible by not changing existing format and only adding new (optional) fields. 

**[toranj] remove unused age property when parsing cache table**

-----------------------
This PR is related to two other PRs. The change is broken due to dependency we have between new spinel property definitions in OT, wpantund changes and then the new `toranj` test-case.
- This PR (https://github.com/openthread/openthread/pull/4599) is the first one (should be merged first). 
- The wpantund PR: https://github.com/openthread/wpantund/pull/462
- The follow up OpenThread PR (which adds the test): https://github.com/openthread/openthread/pull/4600
