### PR TITLE
[network-data] add source address of SVR_DATA.ntf check

### DIFF
--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -152,6 +152,8 @@ void Leader::HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &a
 
     otLogInfoNetData("Received network data registration");
 
+    VerifyOrExit(aMessageInfo.GetPeerAddr().IsRoutingLocator());
+
     if (ThreadTlv::GetTlv(aMessage, ThreadTlv::kRloc16, sizeof(rloc16), rloc16) == OT_ERROR_NONE)
     {
         VerifyOrExit(rloc16.IsValid());


### PR DESCRIPTION
This PR makes sure that SVR_DATA.ntf messages are using RLOC source addresses according to Spec. 5.15.6.1. Otherwise `RegisterNetworkData` might be called with wrong RLOC16. 