### PR TITLE
[travis] move package check into lint stage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,10 +49,6 @@ stages:
 
 jobs:
   include:
-    - env: BUILD_TARGET="package-check" VERBOSE=1
-      os: linux
-      compiler: gcc
-      script: script/test package
     - env: BUILD_TARGET="v1.2" VERBOSE=1 VIRTUAL_TIME=1 THREAD_VERSION=1.2
       os: linux
       compiler: gcc
@@ -215,6 +211,10 @@ jobs:
           packages:
             - clang-format-6.0
       script: .travis/check-pretty
+    - name: "Package Check"
+      os: linux
+      compiler: gcc
+      script: pip3 install -U cmake && script/test package
     - env:
       name: "Size Report"
       os: linux

--- a/script/test
+++ b/script/test
@@ -113,10 +113,6 @@ EXAMPLES:
 }
 
 do_package() {
-    if ! cmake --version | grep -q '(?<=cmake version \(\d+.+d)'; then
-        pip3 install -U cmake
-    fi
-
     local builddir="${OT_BUILDDIR}/cmake/openthread-sim"
     (mkdir -p "${builddir}" \
         && cd "${builddir}" \

--- a/script/test
+++ b/script/test
@@ -113,6 +113,10 @@ EXAMPLES:
 }
 
 do_package() {
+    if ! cmake --version | grep -q '(?<=cmake version \(\d+.+d)'; then
+        pip3 install -U cmake
+    fi
+
     local builddir="${OT_BUILDDIR}/cmake/openthread-sim"
     (mkdir -p "${builddir}" \
         && cd "${builddir}" \


### PR DESCRIPTION
This PR moves the package check into the first stage so that if there
are any cmake build errors jobs in stage 2 will be skipped.