### PR TITLE
[posix-host] include inttypes.h in spi_interface.cpp

### DIFF
--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -39,6 +39,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <getopt.h>
+#include <inttypes.h>
 #include <signal.h>
 #include <stdint.h>
 #include <stdio.h>


### PR DESCRIPTION
On some platforms, inttypes.h is not included by other headers.