### PR TITLE
[posix] fix handling SPI interrupts

### DIFF
--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -691,16 +691,14 @@ otError SpiInterface::WaitForFrame(const struct timeval &aTimeout)
     }
 
     ret = select(mIntGpioValueFd + 1, &readFdSet, NULL, NULL, &timeout);
-    if (ret > 0)
-    {
-        if (FD_ISSET(mIntGpioValueFd, &readFdSet))
-        {
-            struct gpioevent_data event;
 
-            // Read event data to clear interrupt.
-            VerifyOrDie(read(mIntGpioValueFd, &event, sizeof(event)) != -1, OT_EXIT_FAILURE);
-            isDataReady = CheckInterrupt();
-        }
+    if (ret > 0 && FD_ISSET(mIntGpioValueFd, &readFdSet))
+    {
+        struct gpioevent_data event;
+
+        // Read event data to clear interrupt.
+        VerifyOrDie(read(mIntGpioValueFd, &event, sizeof(event)) != -1, OT_EXIT_FAILURE);
+        isDataReady = true;
     }
 
     if (isDataReady)


### PR DESCRIPTION
When SPI is already interrupted before select(), the wait timeout will
be set to 0, and select() will return 0 immediately if there are no new
events. As a result, cause an incorrect OT_ERROR_RESPONSE_TIMEOUT error.

This PR fixes this issue by check if data is ready before checking the
select() result.