### PR TITLE
[cli] allow to escape separators

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -5,6 +5,27 @@ command line interface. Use the CLI to play with OpenThread, which
 can also be used with additional application code. The
 OpenThread test scripts use the CLI to execute test cases.
 
+## Separator and escaping characters
+
+The whitespace character (`' '`) is used to delimitate the command name
+and the different arguments, toghether with tab (`'\t'`) and new line
+characters (`'\r'`, `'\n'`).
+
+Some arguments might require to accept whitespaces on them. For those
+cases the backslash character (`'\'`) can be used to escape whitespace
+or the backslash itself.
+
+Example:
+
+```bash
+> networkname Test\ Network
+Done
+> networkname
+Test Network
+Done
+>
+```
+
 ## OpenThread Command List
 
 * [bufferinfo](#bufferinfo)
@@ -718,7 +739,7 @@ Done
 
 ### logfilename \<filename\>
 
-- Note: POSIX Platform Only, ie: `OPENTHREAD_EXAMPLES_POSIX`
+- Note: Simulation Only, ie: `OPENTHREAD_EXAMPLES_SIMULATION`
 - Requires `OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_DEBUG_UART`
 
 Specifies filename to capture otPlatLog() messages, useful when

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -7,12 +7,12 @@ OpenThread test scripts use the CLI to execute test cases.
 
 ## Separator and escaping characters
 
-The whitespace character (`' '`) is used to delimitate the command name
+The whitespace character (`' '`) is used to delimit the command name
 and the different arguments, together with tab (`'\t'`) and new line
 characters (`'\r'`, `'\n'`).
 
 Some arguments might require to accept whitespaces on them. For those
-cases the backslash character (`'\'`) can be used to escape whitespace
+cases the backslash character (`'\'`) can be used to escape separators
 or the backslash itself.
 
 Example:

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -8,7 +8,7 @@ OpenThread test scripts use the CLI to execute test cases.
 ## Separator and escaping characters
 
 The whitespace character (`' '`) is used to delimitate the command name
-and the different arguments, toghether with tab (`'\t'`) and new line
+and the different arguments, together with tab (`'\t'`) and new line
 characters (`'\r'`, `'\n'`).
 
 Some arguments might require to accept whitespaces on them. For those

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -45,6 +45,11 @@ static bool IsSpaceOrNewLine(char aChar)
     return (aChar == ' ') || (aChar == '\t') || (aChar == '\r') || (aChar == '\n');
 }
 
+static bool IsEscapable(char aChar)
+{
+    return (aChar == ' ') || (aChar == '\\');
+}
+
 otError CmdLineParser::ParseCmd(char *aString, uint8_t &aArgc, char *aArgv[], uint8_t aArgcMax)
 {
     otError error = OT_ERROR_NONE;
@@ -54,14 +59,15 @@ otError CmdLineParser::ParseCmd(char *aString, uint8_t &aArgc, char *aArgv[], ui
 
     for (cmd = aString; *cmd; cmd++)
     {
-        if ((*cmd == '\\') && (*(cmd + 1) == ' '))
+        if ((*cmd == '\\') && IsEscapable(*(cmd + 1)))
         {
-            strcpy(cmd, cmd + 1);
+            memmove(cmd, cmd + 1, strlen(cmd));
         }
         else if (IsSpaceOrNewLine(*cmd))
         {
             *cmd = '\0';
         }
+
         if ((*cmd != '\0') && ((aArgc == 0) || (*(cmd - 1) == '\0')))
         {
             VerifyOrExit(aArgc < aArgcMax, error = OT_ERROR_INVALID_ARGS);

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -31,6 +31,8 @@
  *   This file implements the command line parser.
  */
 
+#include <string.h>
+
 #include "parse_cmdline.hpp"
 
 #include "common/code_utils.hpp"
@@ -50,21 +52,17 @@ otError CmdLineParser::ParseCmd(char *aString, uint8_t &aArgc, char *aArgv[], ui
 
     aArgc = 0;
 
-    for (cmd = aString; IsSpaceOrNewLine(*cmd) && *cmd; cmd++)
-        ;
-
-    if (*cmd)
+    for (cmd = aString; *cmd; cmd++)
     {
-        aArgv[aArgc++] = cmd++; // the first argument
-    }
-
-    for (; *cmd; cmd++)
-    {
-        if (IsSpaceOrNewLine(*cmd))
+        if ((*cmd == '\\') && (*(cmd + 1) == ' '))
+        {
+            strcpy(cmd, cmd + 1);
+        }
+        else if (IsSpaceOrNewLine(*cmd))
         {
             *cmd = '\0';
         }
-        else if (*(cmd - 1) == '\0')
+        if ((*cmd != '\0') && ((aArgc == 0) || (*(cmd - 1) == '\0')))
         {
             VerifyOrExit(aArgc < aArgcMax, error = OT_ERROR_INVALID_ARGS);
             aArgv[aArgc++] = cmd;

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -47,7 +47,7 @@ static bool IsSpaceOrNewLine(char aChar)
 
 static bool IsEscapable(char aChar)
 {
-    return (aChar == ' ') || (aChar == '\\');
+    return IsSpaceOrNewLine(aChar) || (aChar == '\\');
 }
 
 otError CmdLineParser::ParseCmd(char *aString, uint8_t &aArgc, char *aArgv[], uint8_t aArgcMax)

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -61,6 +61,7 @@ otError CmdLineParser::ParseCmd(char *aString, uint8_t &aArgc, char *aArgv[], ui
     {
         if ((*cmd == '\\') && IsEscapable(*(cmd + 1)))
         {
+            // include the null terminator: strlen(cmd) = strlen(cmd + 1) + 1
             memmove(cmd, cmd + 1, strlen(cmd));
         }
         else if (IsSpaceOrNewLine(*cmd))

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -40,14 +40,14 @@
 namespace ot {
 namespace Utils {
 
-static bool IsSpaceOrNewLine(char aChar)
+static bool IsSeparator(char aChar)
 {
     return (aChar == ' ') || (aChar == '\t') || (aChar == '\r') || (aChar == '\n');
 }
 
 static bool IsEscapable(char aChar)
 {
-    return IsSpaceOrNewLine(aChar) || (aChar == '\\');
+    return IsSeparator(aChar) || (aChar == '\\');
 }
 
 otError CmdLineParser::ParseCmd(char *aString, uint8_t &aArgc, char *aArgv[], uint8_t aArgcMax)
@@ -64,7 +64,7 @@ otError CmdLineParser::ParseCmd(char *aString, uint8_t &aArgc, char *aArgv[], ui
             // include the null terminator: strlen(cmd) = strlen(cmd + 1) + 1
             memmove(cmd, cmd + 1, strlen(cmd));
         }
-        else if (IsSpaceOrNewLine(*cmd))
+        else if (IsSeparator(*cmd))
         {
             *cmd = '\0';
         }

--- a/src/core/utils/parse_cmdline.hpp
+++ b/src/core/utils/parse_cmdline.hpp
@@ -60,7 +60,8 @@ public:
      * This function parses the command line.
      *
      * Note: this method may change the input @p aString, it will put a '\0' by the end of each argument,
-     *       and @p aArgv will point to the arguments in the input @p aString.
+     *       and @p aArgv will point to the arguments in the input @p aString. Backslash ('\') can be used
+     *       to escape spaces (' ') and the backslash itself.
      *
      * @param[in]   aString   A NULL-terminated input string.
      * @param[out]  aArgc     The argument counter of the command line.

--- a/src/core/utils/parse_cmdline.hpp
+++ b/src/core/utils/parse_cmdline.hpp
@@ -61,7 +61,7 @@ public:
      *
      * Note: this method may change the input @p aString, it will put a '\0' by the end of each argument,
      *       and @p aArgv will point to the arguments in the input @p aString. Backslash ('\') can be used
-     *       to escape spaces (' ') and the backslash itself.
+     *       to escape separators (' ', '\t', '\r', '\n') and the backslash itself.
      *
      * @param[in]   aString   A NULL-terminated input string.
      * @param[out]  aArgc     The argument counter of the command line.

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -455,7 +455,7 @@ class Node:
         Returns:
             [str]: The modified string with escaped characters.
         """
-        escapable_chars = ['\\', ' ', '\t', '\r', '\n']
+        escapable_chars = '\\ \t\r\n'
         for char in escapable_chars:
             string = string.replace(char, '\\%s' % char)
         return string

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -446,6 +446,20 @@ class Node:
         self.send_command(cmd)
         self._expect('Done')
 
+    def _escape_escapable(self, string):
+        """Escape CLI escapable characters in the given string.
+
+        Args:
+            string (str): UTF-8 input string.
+
+        Returns:
+            [str]: The modified string with escaped characters.
+        """
+        escapable_chars = ['\\', ' ', '\t', '\r', '\n']
+        for char in escapable_chars:
+            string = string.replace(char, '\\%s' % char)
+        return string
+
     def get_network_name(self):
         self.send_command('networkname')
         while True:
@@ -457,7 +471,7 @@ class Node:
         return network_name
 
     def set_network_name(self, network_name):
-        cmd = 'networkname %s' % network_name
+        cmd = 'networkname %s' % self._escape_escapable(network_name)
         self.send_command(cmd)
         self._expect('Done')
 
@@ -969,7 +983,7 @@ class Node:
             cmd += 'localprefix %s ' % mesh_local
 
         if network_name is not None:
-            cmd += 'networkname %s ' % network_name
+            cmd += 'networkname %s ' % self._escape_escapable(network_name)
 
         if binary is not None:
             cmd += 'binary %s ' % binary
@@ -1011,7 +1025,7 @@ class Node:
             cmd += 'localprefix %s ' % mesh_local
 
         if network_name is not None:
-            cmd += 'networkname %s ' % network_name
+            cmd += 'networkname %s ' % self._escape_escapable(network_name)
 
         self.send_command(cmd)
         self._expect('Done')

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -637,7 +637,7 @@ class OpenThread(IThci):
         """
         escapable_chars = ['\\', ' ', '\t', '\r', '\n']
         for char in escapable_chars:
-            string = string.replace(char, '\ %s' % char)
+            string = string.replace(char, '\\%s' % char)
         return string
 
     def _connect(self):

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -635,7 +635,7 @@ class OpenThread(IThci):
         Returns:
             [str]: The modified string with escaped characters.
         """
-        escapable_chars = ['\\', ' ', '\t', '\r', '\n']
+        escapable_chars = '\\ \t\r\n'
         for char in escapable_chars:
             string = string.replace(char, '\\%s' % char)
         return string

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -626,7 +626,7 @@ class OpenThread(IThci):
         print('%s call getCommissionerSessionId' % self.port)
         return self.__sendCommand('commissioner sessionid')[0]
 
-    def __escape_escapable(self, string):
+    def __escapeEscapable(self, string):
         """Escape CLI escapable characters in the given string.
 
         Args:
@@ -702,7 +702,7 @@ class OpenThread(IThci):
         """
         print('%s call setNetworkName' % self.port)
         print(networkName)
-        networkName = self.__escape_escapable(networkName)
+        networkName = self.__escapeEscapable(networkName)
         try:
             cmd = 'networkname %s' % networkName
             datasetCmd = 'dataset networkname %s' % networkName
@@ -2408,7 +2408,7 @@ class OpenThread(IThci):
 
             if sNetworkName is not None:
                 cmd += ' networkname '
-                cmd += self.__escape_escapable(str(sNetworkName))
+                cmd += self.__escapeEscapable(str(sNetworkName))
 
             if xChannel is not None:
                 cmd += ' channel '
@@ -2609,7 +2609,7 @@ class OpenThread(IThci):
 
             if sNetworkName is not None:
                 cmd += ' networkname '
-                cmd += self.__escape_escapable(str(sNetworkName))
+                cmd += self.__escapeEscapable(str(sNetworkName))
 
             if xCommissionerSessionId is not None:
                 cmd += ' binary '

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -626,6 +626,20 @@ class OpenThread(IThci):
         print('%s call getCommissionerSessionId' % self.port)
         return self.__sendCommand('commissioner sessionid')[0]
 
+    def __escape_escapable(self, string):
+        """Escape CLI escapable characters in the given string.
+
+        Args:
+            string (str): UTF-8 input string.
+
+        Returns:
+            [str]: The modified string with escaped characters.
+        """
+        escapable_chars = ['\\', ' ', '\t', '\r', '\n']
+        for char in escapable_chars:
+            string = string.replace(char, '\ %s' % char)
+        return string
+
     def _connect(self):
         print('My port is %s' % self.port)
         if self.port.startswith('COM'):
@@ -688,6 +702,7 @@ class OpenThread(IThci):
         """
         print('%s call setNetworkName' % self.port)
         print(networkName)
+        networkName = self.__escape_escapable(networkName)
         try:
             cmd = 'networkname %s' % networkName
             datasetCmd = 'dataset networkname %s' % networkName
@@ -2393,7 +2408,7 @@ class OpenThread(IThci):
 
             if sNetworkName is not None:
                 cmd += ' networkname '
-                cmd += str(sNetworkName)
+                cmd += self.__escape_escapable(str(sNetworkName))
 
             if xChannel is not None:
                 cmd += ' channel '
@@ -2594,7 +2609,7 @@ class OpenThread(IThci):
 
             if sNetworkName is not None:
                 cmd += ' networkname '
-                cmd += str(sNetworkName)
+                cmd += self.__escape_escapable(str(sNetworkName))
 
             if xCommissionerSessionId is not None:
                 cmd += ' binary '


### PR DESCRIPTION
Fixing #4598

Now it's allowed to escape the space character `' '` using backslash `'\'`.

For instance:
```
> networkname Test\ Network                                                     
Done                                                                            
> networkname                                                                   
Test Network                                                                    
Done                                                                            
>
```