### PR TITLE
[coap] reduce code size by avoiding using 64bit division

### DIFF
--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -785,7 +785,7 @@ otMessage *otCoapNewMessage(otInstance *aInstance, const otMessageSettings *aSet
  * @param[in]  aTxParameters    A pointer to transmission parameters for this request. Use NULL for defaults.
  *                              Otherwise, parameters given must meet the following conditions:
  *                              1. mMaxRetransmit is no more than OT_COAP_MAX_RETRANSMIT.
- *                              2. mAckRandomFactorNumerator / mAckRandomFactorDenominator must not below 1.0.
+ *                              2. mAckRandomFactorNumerator / mAckRandomFactorDenominator must not be below 1.0.
  *                              3. The calculated exchange life time must not overflow uint32_t.
  *
  * @retval OT_ERROR_INVALID_ARGS    @p aTxParameters is invalid.

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -62,6 +62,8 @@ extern "C" {
 
 #define OT_COAP_MAX_RETRANSMIT 30 ///< Max retransmit supported by OpenThread.
 
+#define OT_COAP_MIN_ACK_TIMEOUT 1000 ///< Minimal ACK timeout in milliseconds supported by OpenThread.
+
 /**
  * CoAP Type values.
  *

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -780,8 +780,9 @@ otMessage *otCoapNewMessage(otInstance *aInstance, const otMessageSettings *aSet
  * @param[in]  aContext         A pointer to arbitrary context information. May be NULL if not used.
  * @param[in]  aTxParameters    A pointer to transmission parameters for this request. Use NULL for defaults.
  *
- * @retval OT_ERROR_NONE    Successfully sent CoAP message.
- * @retval OT_ERROR_NO_BUFS Failed to allocate retransmission data.
+ * @retval OT_ERROR_INVALID_ARGS    @p aTxParameters is invalid.
+ * @retval OT_ERROR_NONE            Successfully sent CoAP message.
+ * @retval OT_ERROR_NO_BUFS         Failed to allocate retransmission data.
  *
  */
 otError otCoapSendRequestWithParameters(otInstance *              aInstance,

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -60,6 +60,8 @@ extern "C" {
 
 #define OT_COAP_MAX_TOKEN_LENGTH 8 ///< Max token length as specified (RFC 7252).
 
+#define OT_COAP_MAX_RETRANSMIT 30 ///< Max retransmit supported by OpenThread.
+
 /**
  * CoAP Type values.
  *
@@ -779,6 +781,10 @@ otMessage *otCoapNewMessage(otInstance *aInstance, const otMessageSettings *aSet
  * @param[in]  aHandler         A function pointer that shall be called on response reception or timeout.
  * @param[in]  aContext         A pointer to arbitrary context information. May be NULL if not used.
  * @param[in]  aTxParameters    A pointer to transmission parameters for this request. Use NULL for defaults.
+ *                              Otherwise, parameters given must meet the following conditions:
+ *                              1. mMaxRetransmit is no more than OT_COAP_MAX_RETRANSMIT.
+ *                              2. mAckRandomFactorNumerator / mAckRandomFactorDenominator must not below 1.0.
+ *                              3. The calculated exchange life time must not overflow uint32_t.
  *
  * @retval OT_ERROR_INVALID_ARGS    @p aTxParameters is invalid.
  * @retval OT_ERROR_NONE            Successfully sent CoAP message.

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -218,20 +218,17 @@ otError otCoapSendRequestWithParameters(otInstance *              aInstance,
                                         void *                    aContext,
                                         const otCoapTxParameters *aTxParameters)
 {
-    otError            error;
-    Instance &         instance = *static_cast<Instance *>(aInstance);
-    Coap::TxParameters txParameters;
+    otError   error;
+    Instance &instance = *static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(aTxParameters == NULL ||
-                     (aTxParameters->mAckRandomFactorNumerator >= aTxParameters->mAckRandomFactorDenominator &&
-                      ((aTxParameters->mAckTimeout * ((1ULL << aTxParameters->aMaxRetx + 1) - 1) /
-                        aTxParameters->mAckRandomFactorDenominator * aTxParameters->mAckRandomFactorNumerator) >>
-                       32) == 0),
-                 error = OT_ERROR_INVALID_ARGS);
+    if (aTxParameters != NULL)
+    {
+        VerifyOrExit(Coap::TxParameters::Validate(*aTxParameters), error = OT_ERROR_INVALID_ARGS);
+    }
 
     error = instance.GetApplicationCoap().SendMessage(*static_cast<Coap::Message *>(aMessage),
                                                       *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-                                                      txParameters, aHandler, aContext);
+                                                      Coap::TxParameters::From(aTxParameters), aHandler, aContext);
 
 exit:
     return error;

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -218,11 +218,23 @@ otError otCoapSendRequestWithParameters(otInstance *              aInstance,
                                         void *                    aContext,
                                         const otCoapTxParameters *aTxParameters)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    otError            error;
+    Instance &         instance = *static_cast<Instance *>(aInstance);
+    Coap::TxParameters txParameters;
 
-    return instance.GetApplicationCoap().SendMessage(*static_cast<Coap::Message *>(aMessage),
-                                                     *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-                                                     Coap::TxParameters::From(aTxParameters), aHandler, aContext);
+    VerifyOrExit(aTxParameters == NULL ||
+                     (aTxParameters->mAckRandomFactorNumerator >= aTxParameters->mAckRandomFactorDenominator &&
+                      ((aTxParameters->mAckTimeout * ((1ULL << aTxParameters->aMaxRetx + 1) - 1) /
+                        aTxParameters->mAckRandomFactorDenominator * aTxParameters->mAckRandomFactorNumerator) >>
+                       32) == 0),
+                 error = OT_ERROR_INVALID_ARGS);
+
+    error = instance.GetApplicationCoap().SendMessage(*static_cast<Coap::Message *>(aMessage),
+                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
+                                                      txParameters, aHandler, aContext);
+
+exit:
+    return error;
 }
 
 otError otCoapStart(otInstance *aInstance, uint16_t aPort)

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -218,17 +218,18 @@ otError otCoapSendRequestWithParameters(otInstance *              aInstance,
                                         void *                    aContext,
                                         const otCoapTxParameters *aTxParameters)
 {
-    otError   error;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    otError                   error;
+    Instance &                instance     = *static_cast<Instance *>(aInstance);
+    const Coap::TxParameters &txParameters = Coap::TxParameters::From(aTxParameters);
 
     if (aTxParameters != NULL)
     {
-        VerifyOrExit(Coap::TxParameters::Validate(*aTxParameters), error = OT_ERROR_INVALID_ARGS);
+        VerifyOrExit(txParameters.IsValid(), error = OT_ERROR_INVALID_ARGS);
     }
 
     error = instance.GetApplicationCoap().SendMessage(*static_cast<Coap::Message *>(aMessage),
                                                       *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-                                                      Coap::TxParameters::From(aTxParameters), aHandler, aContext);
+                                                      txParameters, aHandler, aContext);
 
 exit:
     return error;

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -970,20 +970,20 @@ static uint32_t Multiply(uint32_t aValueA, uint32_t aValueB)
     return (result / aValueA == aValueB) ? result : 0;
 }
 
-bool TxParameters::Validate(const otCoapTxParameters &aTxParameters)
+bool TxParameters::IsValid(void) const
 {
     bool rval = false;
 
-    if (aTxParameters.mAckRandomFactorNumerator >= aTxParameters.mAckRandomFactorDenominator &&
-        aTxParameters.mAckTimeout >= OT_COAP_MIN_ACK_TIMEOUT && aTxParameters.mMaxRetransmit <= OT_COAP_MAX_RETRANSMIT)
+    if (mAckRandomFactorNumerator >= mAckRandomFactorDenominator && mAckTimeout >= OT_COAP_MIN_ACK_TIMEOUT &&
+        mMaxRetransmit <= OT_COAP_MAX_RETRANSMIT)
     {
         // Calulate exchange lifetime step by step and verify no overflow.
-        uint32_t tmp = Multiply(aTxParameters.mAckTimeout, (1U << (aTxParameters.mMaxRetransmit + 1)) - 1);
+        uint32_t tmp = Multiply(mAckTimeout, (1U << (mMaxRetransmit + 1)) - 1);
 
-        tmp /= aTxParameters.mAckRandomFactorDenominator;
-        tmp = Multiply(tmp, aTxParameters.mAckRandomFactorNumerator);
+        tmp /= mAckRandomFactorDenominator;
+        tmp = Multiply(tmp, mAckRandomFactorNumerator);
 
-        rval = (tmp != 0 && (tmp + aTxParameters.mAckTimeout + 2 * kDefaultMaxLatency) > tmp);
+        rval = (tmp != 0 && (tmp + mAckTimeout + 2 * kDefaultMaxLatency) > tmp);
     }
 
     return rval;

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -981,7 +981,7 @@ bool TxParameters::Validate(const otCoapTxParameters &aTxParameters)
         uint32_t tmp = Multiply(aTxParameters.mAckTimeout, (1U << (aTxParameters.mMaxRetransmit + 1)) - 1);
 
         tmp /= aTxParameters.mAckRandomFactorDenominator;
-        tmp = Multiple(tmp, aTxParameters.mAckRandomFactorNumerator);
+        tmp = Multiply(tmp, aTxParameters.mAckRandomFactorNumerator);
 
         rval = (tmp != 0 && (tmp + aTxParameters.mAckTimeout + 2 * kDefaultMaxLatency) > tmp);
     }

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -979,15 +979,10 @@ uint32_t TxParameters::CalculateMaxTransmitWait(void) const
     return CalculateSpan(mMaxRetransmit + 1);
 }
 
-uint32_t TxParameters::CalculateSpan(uint32_t aMaxRetx) const
+uint32_t TxParameters::CalculateSpan(uint8_t aMaxRetx) const
 {
-#if OPENTHREAD_CONFIG_COAP_API_ENABLE
-    return static_cast<uint32_t>(mAckTimeout * ((1ULL << aMaxRetx) - 1) * mAckRandomFactorNumerator /
-                                 mAckRandomFactorDenominator);
-#else
-    return static_cast<uint32_t>(mAckTimeout * ((1UL << aMaxRetx) - 1) * mAckRandomFactorNumerator /
-                                 mAckRandomFactorDenominator);
-#endif
+    return static_cast<uint32_t>(mAckTimeout * ((1UL << aMaxRetx) - 1) / mAckRandomFactorDenominator *
+                                 mAckRandomFactorNumerator);
 }
 
 const otCoapTxParameters TxParameters::kDefaultTxParameters = {

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -985,10 +985,6 @@ bool TxParameters::Validate(const otCoapTxParameters &aTxParameters)
 
         rval = (tmp != 0 && (tmp + aTxParameters.mAckTimeout + 2 * kDefaultMaxLatency) > tmp);
     }
-    else
-    {
-        rval = false;
-    }
 
     return rval;
 }

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -963,7 +963,7 @@ uint32_t ResponsesQueue::ResponseMetadata::GetRemainingTime(void) const
 }
 
 /// Return product of @p aValueA and @p aValueB if no overflow otherwise 0.
-static uint32_t Multiple(uint32_t aValueA, uint32_t aValueB)
+static uint32_t Multiply(uint32_t aValueA, uint32_t aValueB)
 {
     uint32_t result = aValueA * aValueB;
 

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -981,8 +981,13 @@ uint32_t TxParameters::CalculateMaxTransmitWait(void) const
 
 uint32_t TxParameters::CalculateSpan(uint32_t aMaxRetx) const
 {
+#if OPENTHREAD_CONFIG_COAP_API_ENABLE
     return static_cast<uint32_t>(mAckTimeout * ((1ULL << aMaxRetx) - 1) * mAckRandomFactorNumerator /
                                  mAckRandomFactorDenominator);
+#else
+    return static_cast<uint32_t>(mAckTimeout * ((1UL << aMaxRetx) - 1) * mAckRandomFactorNumerator /
+                                 mAckRandomFactorDenominator);
+#endif
 }
 
 const otCoapTxParameters TxParameters::kDefaultTxParameters = {

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -975,10 +975,10 @@ bool TxParameters::Validate(const otCoapTxParameters &aTxParameters)
     bool rval = false;
 
     if (aTxParameters.mAckRandomFactorNumerator >= aTxParameters.mAckRandomFactorDenominator &&
-        aTxParameters.mMaxRetransmit <= OT_COAP_MAX_RETRANSMIT)
+        aTxParameters.mAckTimeout >= OT_COAP_MIN_ACK_TIMEOUT && aTxParameters.mMaxRetransmit <= OT_COAP_MAX_RETRANSMIT)
     {
         // Calulate exchange lifetime step by step and verify no overflow.
-        uint32_t tmp = Multiple(aTxParameters.mAckTimeout, ((1U << (aTxParameters.mMaxRetransmit + 1)) - 1));
+        uint32_t tmp = Multiple(aTxParameters.mAckTimeout, (1U << (aTxParameters.mMaxRetransmit + 1)) - 1);
 
         tmp /= aTxParameters.mAckRandomFactorDenominator;
         tmp = Multiple(tmp, aTxParameters.mAckRandomFactorNumerator);

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -972,7 +972,7 @@ static uint32_t Multiple(uint32_t aValueA, uint32_t aValueB)
 
 bool TxParameters::Validate(const otCoapTxParameters &aTxParameters)
 {
-    bool rval;
+    bool rval = false;
 
     if (aTxParameters.mAckRandomFactorNumerator >= aTxParameters.mAckRandomFactorDenominator &&
         aTxParameters.mMaxRetransmit <= OT_COAP_MAX_RETRANSMIT)

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -978,7 +978,7 @@ bool TxParameters::Validate(const otCoapTxParameters &aTxParameters)
         aTxParameters.mAckTimeout >= OT_COAP_MIN_ACK_TIMEOUT && aTxParameters.mMaxRetransmit <= OT_COAP_MAX_RETRANSMIT)
     {
         // Calulate exchange lifetime step by step and verify no overflow.
-        uint32_t tmp = Multiple(aTxParameters.mAckTimeout, (1U << (aTxParameters.mMaxRetransmit + 1)) - 1);
+        uint32_t tmp = Multiply(aTxParameters.mAckTimeout, (1U << (aTxParameters.mMaxRetransmit + 1)) - 1);
 
         tmp /= aTxParameters.mAckRandomFactorDenominator;
         tmp = Multiple(tmp, aTxParameters.mAckRandomFactorNumerator);

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -123,7 +123,7 @@ public:
 private:
     enum
     {
-        kDefaultAckTimeout                 = 2000,
+        kDefaultAckTimeout                 = 2000, // in millisecond
         kDefaultAckRandomFactorNumerator   = 3,
         kDefaultAckRandomFactorDenominator = 2,
         kDefaultMaxRetransmit              = 4,

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -103,14 +103,12 @@ public:
     }
 
     /**
-     * This static method validates whether the CoAP transmission parameters are valid.
-     *
-     * @param[in]   aTxParameters   Transmission parameters.
+     * This method validates whether the CoAP transmission parameters are valid.
      *
      * @returns Whether the parameters are valid.
      *
      */
-    static bool Validate(const otCoapTxParameters &aTxParameters);
+    bool IsValid(void) const;
 
     /**
      * This static method returns default CoAP tx parameters.

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -103,6 +103,16 @@ public:
     }
 
     /**
+     * This static method validates whether the CoAP transmission parameters are valid.
+     *
+     * @param[in]   aTxParameters   Transmission parameters.
+     *
+     * @returns Whether the parameters are valid.
+     *
+     */
+    static bool Validate(const otCoapTxParameters &aTxParameters);
+
+    /**
      * This static method returns default CoAP tx parameters.
      *
      * @returns The default tx parameters.
@@ -113,10 +123,10 @@ public:
 private:
     enum
     {
-        kDefaultAckTimeout                 = OPENTHREAD_CONFIG_COAP_ACK_TIMEOUT_MILLIS,
-        kDefaultAckRandomFactorNumerator   = OPENTHREAD_CONFIG_COAP_ACK_RANDOM_FACTOR_NUMERATOR,
-        kDefaultAckRandomFactorDenominator = OPENTHREAD_CONFIG_COAP_ACK_RANDOM_FACTOR_DENOMINATOR,
-        kDefaultMaxRetransmit              = OPENTHREAD_CONFIG_COAP_MAX_RETRANSMIT,
+        kDefaultAckTimeout                 = 2000,
+        kDefaultAckRandomFactorNumerator   = 3,
+        kDefaultAckRandomFactorDenominator = 2,
+        kDefaultMaxRetransmit              = 4,
         kDefaultMaxLatency                 = 100000, // in millisecond
     };
 

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -123,7 +123,7 @@ private:
     uint32_t CalculateInitialRetransmissionTimeout(void) const;
     uint32_t CalculateExchangeLifetime(void) const;
     uint32_t CalculateMaxTransmitWait(void) const;
-    uint32_t CalculateSpan(uint32_t aMaxRetx) const;
+    uint32_t CalculateSpan(uint8_t aMaxRetx) const;
 
     static const otCoapTxParameters kDefaultTxParameters;
 };

--- a/src/core/config/coap.h
+++ b/src/core/config/coap.h
@@ -36,49 +36,6 @@
 #define CONFIG_COAP_H_
 
 /**
- * @def OPENTHREAD_CONFIG_COAP_ACK_TIMEOUT_MILLIS
- *
- * Minimum spacing before first retransmission when ACK is not received, in milliseconds (RFC7252 default value
- * is 2000).
- *
- */
-#ifndef OPENTHREAD_CONFIG_COAP_ACK_TIMEOUT_MILLIS
-#define OPENTHREAD_CONFIG_COAP_ACK_TIMEOUT_MILLIS 2000
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_COAP_ACK_RANDOM_FACTOR_NUMERATOR
- *
- * Numerator of ACK_RANDOM_FACTOR used to calculate maximum spacing before first retransmission when
- * ACK is not received (RFC7252 default value of ACK_RANDOM_FACTOR is 1.5, must not be decreased below 1).
- *
- */
-#ifndef OPENTHREAD_CONFIG_COAP_ACK_RANDOM_FACTOR_NUMERATOR
-#define OPENTHREAD_CONFIG_COAP_ACK_RANDOM_FACTOR_NUMERATOR 3
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_COAP_ACK_RANDOM_FACTOR_DENOMINATOR
- *
- * Denominator of ACK_RANDOM_FACTOR used to calculate maximum spacing before first retransmission when
- * ACK is not received (RFC7252 default value of ACK_RANDOM_FACTOR is 1.5, must not be decreased below 1).
- *
- */
-#ifndef OPENTHREAD_CONFIG_COAP_ACK_RANDOM_FACTOR_DENOMINATOR
-#define OPENTHREAD_CONFIG_COAP_ACK_RANDOM_FACTOR_DENOMINATOR 2
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_COAP_MAX_RETRANSMIT
- *
- * Maximum number of retransmissions for CoAP Confirmable messages (RFC7252 default value is 4).
- *
- */
-#ifndef OPENTHREAD_CONFIG_COAP_MAX_RETRANSMIT
-#define OPENTHREAD_CONFIG_COAP_MAX_RETRANSMIT 4
-#endif
-
-/**
  * @def OPENTHREAD_CONFIG_COAP_SERVER_MAX_CACHED_RESPONSES
  *
  * Maximum number of cached responses for CoAP Confirmable messages.


### PR DESCRIPTION
* Removed OpenThread's default CoAP configuration macro, because they are fixed values by Thread spec.
* Use 32bit multiple only to detect overflow of application CoAP transmission parameters.
* Added documentation describing conditions of valid CoAP transmission parameters.
