### PR TITLE
[build] make MTD and RADIO_ONLY build configurable

### DIFF
--- a/examples/Makefile-cc1352
+++ b/examples/Makefile-cc1352
@@ -44,7 +44,6 @@ BuildJobs                                                 ?= 10
 configure_OPTIONS                                          = \
     --enable-cli                                             \
     --enable-ftd                                             \
-    --enable-mtd                                             \
     --enable-ncp                                             \
     --enable-radio-only                                      \
     --with-examples=cc1352                                   \

--- a/examples/Makefile-cc2538
+++ b/examples/Makefile-cc2538
@@ -41,12 +41,12 @@ OBJCOPY                         = arm-none-eabi-objcopy
 
 BuildJobs                      ?= 10
 
+RADIO_ONLY                     ?= 1
+
 configure_OPTIONS               = \
     --enable-cli                  \
     --enable-ftd                  \
-    --enable-mtd                  \
     --enable-ncp                  \
-    --enable-radio-only           \
     --enable-linker-map           \
     --with-examples=cc2538        \
     $(NULL)

--- a/examples/Makefile-cc2650
+++ b/examples/Makefile-cc2650
@@ -41,11 +41,11 @@ OBJCOPY                         = arm-none-eabi-objcopy
 
 BuildJobs                      ?= 10
 
+RADIO_ONLY                     ?= 1
+
 configure_OPTIONS               = \
     --enable-cli                  \
-    --enable-mtd                  \
     --enable-ncp                  \
-    --enable-radio-only           \
     --enable-linker-map           \
     --with-examples=cc2650        \
     MBEDTLS_CPPFLAGS="$(CC2650_MBEDTLS_CPPFLAGS)" \

--- a/examples/Makefile-cc2652
+++ b/examples/Makefile-cc2652
@@ -41,12 +41,12 @@ OBJCOPY = arm-none-eabi-objcopy
 
 BuildJobs                                                 ?= 10
 
+RADIO_ONLY                                                ?= 1
+
 configure_OPTIONS                                          = \
     --enable-cli                                             \
     --enable-ftd                                             \
-    --enable-mtd                                             \
     --enable-ncp                                             \
-    --enable-radio-only                                      \
     --with-examples=cc2652                                   \
     MBEDTLS_CPPFLAGS="$(CC2652_MBEDTLS_CPPFLAGS)"            \
     $(NULL)

--- a/examples/Makefile-efr32mg12
+++ b/examples/Makefile-efr32mg12
@@ -44,7 +44,6 @@ BuildJobs                      ?= 10
 configure_OPTIONS               = \
     --enable-cli                  \
     --enable-ftd                  \
-    --enable-mtd                  \
     --enable-ncp                  \
     --enable-radio-only           \
     --enable-linker-map           \

--- a/examples/Makefile-efr32mg21
+++ b/examples/Makefile-efr32mg21
@@ -41,12 +41,12 @@ OBJCOPY                         = arm-none-eabi-objcopy
 
 BuildJobs                      ?= 10
 
+RADIO_ONLY                     ?= 1
+
 configure_OPTIONS               = \
     --enable-cli                  \
     --enable-ftd                  \
-    --enable-mtd                  \
     --enable-ncp                  \
-    --enable-radio-only           \
     --enable-linker-map           \
     --with-examples=efr32mg21     \
     MBEDTLS_CPPFLAGS="$(EFR32_MBEDTLS_CPPFLAGS)" \

--- a/examples/Makefile-gp712
+++ b/examples/Makefile-gp712
@@ -48,7 +48,6 @@ BuildJobs                      ?= 9
 configure_OPTIONS               = \
     --enable-cli                  \
     --enable-ftd                  \
-    --enable-mtd                  \
     --with-examples=$(PPREFIX)    \
     $(NULL)
 

--- a/examples/Makefile-kw41z
+++ b/examples/Makefile-kw41z
@@ -41,12 +41,12 @@ OBJCOPY                         = arm-none-eabi-objcopy
 
 BuildJobs                      ?= 10
 
+RADIO_ONLY                     ?= 1
+
 configure_OPTIONS               = \
     --enable-cli                  \
     --enable-ftd                  \
-    --enable-mtd                  \
     --enable-ncp                  \
-    --enable-radio-only           \
     --enable-linker-map           \
     --with-examples=kw41z         \
     $(NULL)

--- a/examples/Makefile-nrf52811
+++ b/examples/Makefile-nrf52811
@@ -42,7 +42,6 @@ OBJCOPY                         = arm-none-eabi-objcopy
 GCCVersion                      = $(shell expr `$(CC) -dumpversion | cut -f1 -d.`)
 
 configure_OPTIONS                                 = \
-    --enable-mtd                                    \
     --enable-linker-map                             \
     --with-examples=nrf52811                        \
     MBEDTLS_CPPFLAGS="$(NRF52811_MBEDTLS_CPPFLAGS)" \

--- a/examples/Makefile-nrf52833
+++ b/examples/Makefile-nrf52833
@@ -43,7 +43,6 @@ GCCVersion                      = $(shell expr `$(CC) -dumpversion | cut -f1 -d.
 
 configure_OPTIONS                                 = \
     --enable-ftd                                    \
-    --enable-mtd                                    \
     --enable-linker-map                             \
     --with-examples=nrf52833                        \
     MBEDTLS_CPPFLAGS="$(NRF52833_MBEDTLS_CPPFLAGS)" \

--- a/examples/Makefile-nrf52840
+++ b/examples/Makefile-nrf52840
@@ -51,7 +51,6 @@ endif
 
 configure_OPTIONS                                 = \
     --enable-ftd                                    \
-    --enable-mtd                                    \
     --enable-linker-map                             \
     --with-examples=nrf52840                        \
     $(NULL)

--- a/examples/Makefile-qpg6095
+++ b/examples/Makefile-qpg6095
@@ -42,12 +42,12 @@ OBJCOPY                         = arm-none-eabi-objcopy
 BuildJobs                      ?= 10
 GCCVersion                      = $(shell expr `$(CC) -dumpversion | cut -f1 -d.`)
 
+RADIO_ONLY                     ?= 1
+
 configure_OPTIONS                                 = \
     --enable-cli                                    \
     --enable-ftd                                    \
-    --enable-mtd                                    \
     --enable-ncp                                    \
-    --enable-radio-only                             \
     --enable-linker-map                             \
     --with-examples=qpg6095                         \
     MBEDTLS_CPPFLAGS="$(QPG6095_MBEDTLS_CPPFLAGS)"  \

--- a/examples/Makefile-samr21
+++ b/examples/Makefile-samr21
@@ -41,6 +41,7 @@ OBJCOPY                         = arm-none-eabi-objcopy
 
 BuildJobs                      ?= 10
 
+RADIO_ONLY                     ?= 1
 
 # Board setup
 
@@ -59,9 +60,7 @@ endif
 configure_OPTIONS               = \
     --enable-cli                  \
     --enable-ftd                  \
-    --enable-mtd                  \
     --enable-ncp                  \
-    --enable-radio-only           \
     --enable-linker-map           \
     --with-examples=samr21        \
     MBEDTLS_CPPFLAGS="$(SAMR21_MBEDTLS_CPPFLAGS)" \

--- a/examples/Makefile-simulation
+++ b/examples/Makefile-simulation
@@ -55,7 +55,9 @@ JOINER                         ?= 1
 LEGACY                         ?= 1
 LINK_RAW                       ?= 1
 MAC_FILTER                     ?= 1
+MTD                            ?= 1
 MTD_NETDIAG                    ?= 1
+RADIO_ONLY                     ?= 1
 REFERENCE_DEVICE               ?= 1
 SERVICE                        ?= 1
 SNTP_CLIENT                    ?= 1
@@ -71,9 +73,7 @@ COMMONCFLAGS                   := \
 configure_OPTIONS               = \
     --enable-cli                  \
     --enable-ftd                  \
-    --enable-mtd                  \
     --enable-ncp                  \
-    --enable-radio-only           \
     --with-examples=simulation    \
     $(NULL)
 

--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -58,8 +58,10 @@ LOG_OUTPUT          ?= APP
 endif
 LINK_RAW            ?= 0
 MAC_FILTER          ?= 0
+MTD                 ?= 1
 MTD_NETDIAG         ?= 0
 PLATFORM_UDP        ?= 0
+RADIO_ONLY          ?= 0
 REFERENCE_DEVICE    ?= 0
 SERVICE             ?= 0
 SETTINGS_RAM        ?= 0
@@ -183,12 +185,24 @@ ifeq ($(MAC_FILTER),1)
 COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_MAC_FILTER_ENABLE=1
 endif
 
+ifeq ($(MTD),1)
+configure_OPTIONS               += --enable-mtd=yes
+else
+configure_OPTIONS               += --enable-mtd=no
+endif
+
 ifeq ($(MTD_NETDIAG),1)
 COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE=1
 endif
 
 ifeq ($(PLATFORM_UDP),1)
 COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE=1
+endif
+
+ifeq ($(RADIO_ONLY),1)
+configure_OPTIONS               += --enable-radio-only=yes
+else
+configure_OPTIONS               += --enable-radio-only=no
 endif
 
 # Enable features only required for reference device during certification.


### PR DESCRIPTION
Some feature like Backbone Router in #4430 requires FTD capability, however previously FTD/MTD/RADIO_ONLY are bundled in Makefile recipe. 

This PR introduces MTD and RADIO_ONLY option to allow the flexibility to decide whether or not to build MTD/RADIO_ONLY when `make`.