### PR TITLE
[cc1352,cc26xx] fix unaligned access of ext address in radio.c

### DIFF
--- a/examples/platforms/cc1352/radio.c
+++ b/examples/platforms/cc1352/radio.c
@@ -1577,7 +1577,7 @@ otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress
     OT_UNUSED_VARIABLE(aInstance);
 
     otError  error      = OT_ERROR_NONE;
-    uint64_t extAddress = *(uint64_t *)aExtAddress;
+    uint64_t extAddress = otExtAddressLoadUint64(aExtAddress);
     uint8_t  idx        = rfCoreFindExtSrcMatchIdx(&extAddress);
 
     if (idx == CC1352_SRC_MATCH_NONE)
@@ -1611,7 +1611,7 @@ otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddre
     OT_UNUSED_VARIABLE(aInstance);
 
     otError  error      = OT_ERROR_NONE;
-    uint64_t extAddress = *(uint64_t *)aExtAddress;
+    uint64_t extAddress = otExtAddressLoadUint64(aExtAddress);
     uint8_t  idx;
 
     otEXPECT_ACTION((idx = rfCoreFindExtSrcMatchIdx(&extAddress)) != CC1352_SRC_MATCH_NONE,
@@ -1812,7 +1812,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aA
     if (sState == cc1352_stateReceive)
     {
         otEXPECT(rfCoreExecuteAbortCmd() == CMDSTA_Done);
-        sReceiveCmd.localExtAddr = *((uint64_t *)(aAddress));
+        sReceiveCmd.localExtAddr = otExtAddressLoadUint64(aAddress);
         otEXPECT(rfCoreClearReceiveQueue(&sRxDataQueue) == CMDSTA_Done);
         otEXPECT(rfCoreSendReceiveCmd() == CMDSTA_Done);
         /* the interrupt from abort changed our state to sleep */
@@ -1820,7 +1820,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aA
     }
     else if (sState != cc1352_stateTransmit)
     {
-        sReceiveCmd.localExtAddr = *((uint64_t *)(aAddress));
+        sReceiveCmd.localExtAddr = otExtAddressLoadUint64(aAddress);
     }
 
 exit:

--- a/examples/platforms/cc1352/radio.c
+++ b/examples/platforms/cc1352/radio.c
@@ -37,6 +37,7 @@
 
 #include <assert.h>
 #include <utils/code_utils.h>
+#include <utils/encoding.h>
 #include <openthread/random_noncrypto.h> /* to seed the CSMA-CA funciton */
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
@@ -1577,7 +1578,7 @@ otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress
     OT_UNUSED_VARIABLE(aInstance);
 
     otError  error      = OT_ERROR_NONE;
-    uint64_t extAddress = otExtAddressLoadUint64(aExtAddress);
+    uint64_t extAddress = otEncodingReadUint64Le(aExtAddress->m8);
     uint8_t  idx        = rfCoreFindExtSrcMatchIdx(&extAddress);
 
     if (idx == CC1352_SRC_MATCH_NONE)
@@ -1611,7 +1612,7 @@ otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddre
     OT_UNUSED_VARIABLE(aInstance);
 
     otError  error      = OT_ERROR_NONE;
-    uint64_t extAddress = otExtAddressLoadUint64(aExtAddress);
+    uint64_t extAddress = otEncodingReadUint64Le(aExtAddress->m8);
     uint8_t  idx;
 
     otEXPECT_ACTION((idx = rfCoreFindExtSrcMatchIdx(&extAddress)) != CC1352_SRC_MATCH_NONE,
@@ -1812,7 +1813,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aA
     if (sState == cc1352_stateReceive)
     {
         otEXPECT(rfCoreExecuteAbortCmd() == CMDSTA_Done);
-        sReceiveCmd.localExtAddr = otExtAddressLoadUint64(aAddress);
+        sReceiveCmd.localExtAddr = otEncodingReadUint64Le(aAddress->m8);
         otEXPECT(rfCoreClearReceiveQueue(&sRxDataQueue) == CMDSTA_Done);
         otEXPECT(rfCoreSendReceiveCmd() == CMDSTA_Done);
         /* the interrupt from abort changed our state to sleep */
@@ -1820,7 +1821,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aA
     }
     else if (sState != cc1352_stateTransmit)
     {
-        sReceiveCmd.localExtAddr = otExtAddressLoadUint64(aAddress);
+        sReceiveCmd.localExtAddr = otEncodingReadUint64Le(aAddress->m8);
     }
 
 exit:

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -32,6 +32,7 @@
 #include "cc2650_radio.h"
 #include <assert.h>
 #include <utils/code_utils.h>
+#include <utils/encoding.h>
 #include <openthread/random_noncrypto.h> /* to seed the CSMA-CA funciton */
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
@@ -1528,7 +1529,7 @@ otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress
     OT_UNUSED_VARIABLE(aInstance);
 
     otError  error      = OT_ERROR_NONE;
-    uint64_t extAddress = otExtAddressLoadUint64(aExtAddress);
+    uint64_t extAddress = otEncodingReadUint64Le(aExtAddress->m8);
     uint8_t  idx        = rfCoreFindExtSrcMatchIdx(&extAddress);
 
     if (idx == CC2650_SRC_MATCH_NONE)
@@ -1562,7 +1563,7 @@ otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddre
     OT_UNUSED_VARIABLE(aInstance);
 
     otError  error      = OT_ERROR_NONE;
-    uint64_t extAddress = otExtAddressLoadUint64(aExtAddress);
+    uint64_t extAddress = otEncodingReadUint64Le(aExtAddress->m8);
     uint8_t  idx;
 
     otEXPECT_ACTION((idx = rfCoreFindExtSrcMatchIdx(&extAddress)) != CC2650_SRC_MATCH_NONE,
@@ -1761,7 +1762,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aA
     if (sState == cc2650_stateReceive)
     {
         otEXPECT(rfCoreExecuteAbortCmd() == CMDSTA_Done);
-        sReceiveCmd.localExtAddr = otExtAddressLoadUint64(aAddress);
+        sReceiveCmd.localExtAddr = otEncodingReadUint64Le(aAddress->m8);
         otEXPECT(rfCoreClearReceiveQueue(&sRxDataQueue) == CMDSTA_Done);
         otEXPECT(rfCoreSendReceiveCmd() == CMDSTA_Done);
         /* the interrupt from abort changed our state to sleep */
@@ -1769,7 +1770,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aA
     }
     else if (sState != cc2650_stateTransmit)
     {
-        sReceiveCmd.localExtAddr = otExtAddressLoadUint64(aAddress);
+        sReceiveCmd.localExtAddr = otEncodingReadUint64Le(aAddress->m8);
     }
 
 exit:

--- a/examples/platforms/cc2650/radio.c
+++ b/examples/platforms/cc2650/radio.c
@@ -1528,7 +1528,7 @@ otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress
     OT_UNUSED_VARIABLE(aInstance);
 
     otError  error      = OT_ERROR_NONE;
-    uint64_t extAddress = *(uint64_t *)aExtAddress;
+    uint64_t extAddress = otExtAddressLoadUint64(aExtAddress);
     uint8_t  idx        = rfCoreFindExtSrcMatchIdx(&extAddress);
 
     if (idx == CC2650_SRC_MATCH_NONE)
@@ -1562,7 +1562,7 @@ otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddre
     OT_UNUSED_VARIABLE(aInstance);
 
     otError  error      = OT_ERROR_NONE;
-    uint64_t extAddress = *(uint64_t *)aExtAddress;
+    uint64_t extAddress = otExtAddressLoadUint64(aExtAddress);
     uint8_t  idx;
 
     otEXPECT_ACTION((idx = rfCoreFindExtSrcMatchIdx(&extAddress)) != CC2650_SRC_MATCH_NONE,
@@ -1761,7 +1761,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aA
     if (sState == cc2650_stateReceive)
     {
         otEXPECT(rfCoreExecuteAbortCmd() == CMDSTA_Done);
-        sReceiveCmd.localExtAddr = *((uint64_t *)(aAddress));
+        sReceiveCmd.localExtAddr = otExtAddressLoadUint64(aAddress);
         otEXPECT(rfCoreClearReceiveQueue(&sRxDataQueue) == CMDSTA_Done);
         otEXPECT(rfCoreSendReceiveCmd() == CMDSTA_Done);
         /* the interrupt from abort changed our state to sleep */
@@ -1769,7 +1769,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aA
     }
     else if (sState != cc2650_stateTransmit)
     {
-        sReceiveCmd.localExtAddr = *((uint64_t *)(aAddress));
+        sReceiveCmd.localExtAddr = otExtAddressLoadUint64(aAddress);
     }
 
 exit:

--- a/examples/platforms/cc2652/radio.c
+++ b/examples/platforms/cc2652/radio.c
@@ -1558,7 +1558,7 @@ otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress
     OT_UNUSED_VARIABLE(aInstance);
 
     otError  error      = OT_ERROR_NONE;
-    uint64_t extAddress = *(uint64_t *)aExtAddress;
+    uint64_t extAddress = otExtAddressLoadUint64(aExtAddress);
     uint8_t  idx        = rfCoreFindExtSrcMatchIdx(&extAddress);
 
     if (idx == CC2652_SRC_MATCH_NONE)
@@ -1592,7 +1592,7 @@ otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddre
     OT_UNUSED_VARIABLE(aInstance);
 
     otError  error      = OT_ERROR_NONE;
-    uint64_t extAddress = *(uint64_t *)aExtAddress;
+    uint64_t extAddress = otExtAddressLoadUint64(aExtAddress);
     uint8_t  idx;
 
     otEXPECT_ACTION((idx = rfCoreFindExtSrcMatchIdx(&extAddress)) != CC2652_SRC_MATCH_NONE,
@@ -1793,7 +1793,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aA
     if (sState == cc2652_stateReceive)
     {
         otEXPECT(rfCoreExecuteAbortCmd() == CMDSTA_Done);
-        sReceiveCmd.localExtAddr = *((uint64_t *)(aAddress));
+        sReceiveCmd.localExtAddr = otExtAddressLoadUint64(aAddress);
         otEXPECT(rfCoreClearReceiveQueue(&sRxDataQueue) == CMDSTA_Done);
         otEXPECT(rfCoreSendReceiveCmd() == CMDSTA_Done);
         /* the interrupt from abort changed our state to sleep */
@@ -1801,7 +1801,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aA
     }
     else if (sState != cc2652_stateTransmit)
     {
-        sReceiveCmd.localExtAddr = *((uint64_t *)(aAddress));
+        sReceiveCmd.localExtAddr = otExtAddressLoadUint64(aAddress);
     }
 
 exit:

--- a/examples/platforms/cc2652/radio.c
+++ b/examples/platforms/cc2652/radio.c
@@ -37,6 +37,7 @@
 
 #include <assert.h>
 #include <utils/code_utils.h>
+#include <utils/encoding.h>
 #include <openthread/random_noncrypto.h> /* to seed the CSMA-CA funciton */
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
@@ -1558,7 +1559,7 @@ otError otPlatRadioAddSrcMatchExtEntry(otInstance *aInstance, const otExtAddress
     OT_UNUSED_VARIABLE(aInstance);
 
     otError  error      = OT_ERROR_NONE;
-    uint64_t extAddress = otExtAddressLoadUint64(aExtAddress);
+    uint64_t extAddress = otEncodingReadUint64Le(aExtAddress->m8);
     uint8_t  idx        = rfCoreFindExtSrcMatchIdx(&extAddress);
 
     if (idx == CC2652_SRC_MATCH_NONE)
@@ -1592,7 +1593,7 @@ otError otPlatRadioClearSrcMatchExtEntry(otInstance *aInstance, const otExtAddre
     OT_UNUSED_VARIABLE(aInstance);
 
     otError  error      = OT_ERROR_NONE;
-    uint64_t extAddress = otExtAddressLoadUint64(aExtAddress);
+    uint64_t extAddress = otEncodingReadUint64Le(aExtAddress->m8);
     uint8_t  idx;
 
     otEXPECT_ACTION((idx = rfCoreFindExtSrcMatchIdx(&extAddress)) != CC2652_SRC_MATCH_NONE,
@@ -1793,7 +1794,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aA
     if (sState == cc2652_stateReceive)
     {
         otEXPECT(rfCoreExecuteAbortCmd() == CMDSTA_Done);
-        sReceiveCmd.localExtAddr = otExtAddressLoadUint64(aAddress);
+        sReceiveCmd.localExtAddr = otEncodingReadUint64Le(aAddress->m8);
         otEXPECT(rfCoreClearReceiveQueue(&sRxDataQueue) == CMDSTA_Done);
         otEXPECT(rfCoreSendReceiveCmd() == CMDSTA_Done);
         /* the interrupt from abort changed our state to sleep */
@@ -1801,7 +1802,7 @@ void otPlatRadioSetExtendedAddress(otInstance *aInstance, const otExtAddress *aA
     }
     else if (sState != cc2652_stateTransmit)
     {
-        sReceiveCmd.localExtAddr = otExtAddressLoadUint64(aAddress);
+        sReceiveCmd.localExtAddr = otEncodingReadUint64Le(aAddress->m8);
     }
 
 exit:

--- a/examples/platforms/utils/encoding.h
+++ b/examples/platforms/utils/encoding.h
@@ -31,8 +31,8 @@
  *   This file includes macros for validating runtime conditions.
  */
 
-#ifndef ENCODING_H
-#define ENCODING_H
+#ifndef PLATFORM_UTILS_ENCODING_H
+#define PLATFORM_UTILS_ENCODING_H
 
 #include <stdint.h>
 
@@ -40,7 +40,11 @@
  * Converts a 64-bit unsigned integer stored as a little-endian byte
  * array to uint64_t.
  *
- * @parma[in]  aSource  The byte array.
+ * Allows for the array to be byte-aligned, so that loading the
+ * uint64_t value via this function avoids a processor exception due
+ * to unaligned access.
+ *
+ * @param[in]  aSource  The byte array.
  *
  * @returns The 64-bit value as a uint64_t.
  *
@@ -61,4 +65,4 @@ static inline uint64_t otEncodingReadUint64Le(const uint8_t *aSource)
     return value;
 }
 
-#endif // ENCODING_H
+#endif // PLATFORM_UTILS_ENCODING_H

--- a/examples/platforms/utils/encoding.h
+++ b/examples/platforms/utils/encoding.h
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes macros for validating runtime conditions.
+ */
+
+#ifndef ENCODING_H
+#define ENCODING_H
+
+#include <stdint.h>
+
+/**
+ * Converts a 64-bit unsigned integer stored as a little-endian byte
+ * array to uint64_t.
+ *
+ * @parma[in]  aSource  The byte array.
+ *
+ * @returns The 64-bit value as a uint64_t.
+ *
+ */
+static inline uint64_t otEncodingReadUint64Le(const uint8_t *aSource)
+{
+    uint64_t value = 0;
+
+    value |= (uint64_t)aSource[0];
+    value |= ((uint64_t)aSource[1]) << 8;
+    value |= ((uint64_t)aSource[2]) << 16;
+    value |= ((uint64_t)aSource[3]) << 24;
+    value |= ((uint64_t)aSource[4]) << 32;
+    value |= ((uint64_t)aSource[5]) << 40;
+    value |= ((uint64_t)aSource[6]) << 48;
+    value |= ((uint64_t)aSource[7]) << 56;
+
+    return value;
+}
+
+#endif // ENCODING_H

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -161,6 +161,29 @@ struct otExtAddress
 typedef struct otExtAddress otExtAddress;
 
 /**
+ * Converts an array representing an IEEE 802.15.4 Extended Address into a
+ * 64-bit value.
+ *
+ * This is necessary as the otExtAddress array is not necessary aligned for
+ * access as a 64-bit value.
+ */
+static inline uint64_t otExtAddressLoadUint64(const otExtAddress *address)
+{
+    uint64_t alignedValue = 0;
+    /* The following loads assume that the array is storing the 64-bit word
+     * in little-endian format. */
+    alignedValue |= (uint64_t)address->m8[0];
+    alignedValue |= ((uint64_t)address->m8[1]) << 8;
+    alignedValue |= ((uint64_t)address->m8[2]) << 16;
+    alignedValue |= ((uint64_t)address->m8[3]) << 24;
+    alignedValue |= ((uint64_t)address->m8[4]) << 32;
+    alignedValue |= ((uint64_t)address->m8[5]) << 40;
+    alignedValue |= ((uint64_t)address->m8[6]) << 48;
+    alignedValue |= ((uint64_t)address->m8[7]) << 56;
+    return alignedValue;
+}
+
+/**
  * This structure represents the IEEE 802.15.4 Header IE (Information Element) related information of a radio frame.
  */
 typedef struct otRadioIeInfo

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -161,29 +161,6 @@ struct otExtAddress
 typedef struct otExtAddress otExtAddress;
 
 /**
- * Converts an array representing an IEEE 802.15.4 Extended Address into a
- * 64-bit value.
- *
- * This is necessary as the otExtAddress array is not necessary aligned for
- * access as a 64-bit value.
- */
-static inline uint64_t otExtAddressLoadUint64(const otExtAddress *address)
-{
-    uint64_t alignedValue = 0;
-    /* The following loads assume that the array is storing the 64-bit word
-     * in little-endian format. */
-    alignedValue |= (uint64_t)address->m8[0];
-    alignedValue |= ((uint64_t)address->m8[1]) << 8;
-    alignedValue |= ((uint64_t)address->m8[2]) << 16;
-    alignedValue |= ((uint64_t)address->m8[3]) << 24;
-    alignedValue |= ((uint64_t)address->m8[4]) << 32;
-    alignedValue |= ((uint64_t)address->m8[5]) << 40;
-    alignedValue |= ((uint64_t)address->m8[6]) << 48;
-    alignedValue |= ((uint64_t)address->m8[7]) << 56;
-    return alignedValue;
-}
-
-/**
  * This structure represents the IEEE 802.15.4 Header IE (Information Element) related information of a radio frame.
  */
 typedef struct otRadioIeInfo


### PR DESCRIPTION
Fix compilation errors on GCC 9.2.0 due to struct and class member alignment.