### PR TITLE
[coap] Fix CoAP option data type in C/C++ API

### DIFF
--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -691,8 +691,7 @@ otError otCoapOptionIteratorInit(otCoapOptionIterator *aIterator, const otMessag
  * @returns A pointer to the first matching option. If no matching option is present NULL pointer is returned.
  *
  */
-const otCoapOption *otCoapOptionIteratorGetFirstOptionMatching(otCoapOptionIterator *aIterator,
-                                                               uint16_t              aOption);
+const otCoapOption *otCoapOptionIteratorGetFirstOptionMatching(otCoapOptionIterator *aIterator, uint16_t aOption);
 
 /**
  * This function returns a pointer to the first option.
@@ -713,8 +712,7 @@ const otCoapOption *otCoapOptionIteratorGetFirstOption(otCoapOptionIterator *aIt
  * @returns A pointer to the next matching option. If no further matching option is present NULL pointer is returned.
  *
  */
-const otCoapOption *otCoapOptionIteratorGetNextOptionMatching(otCoapOptionIterator *aIterator,
-                                                              uint16_t              aOption);
+const otCoapOption *otCoapOptionIteratorGetNextOptionMatching(otCoapOptionIterator *aIterator, uint16_t aOption);
 
 /**
  * This function returns a pointer to the next option.

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -692,7 +692,7 @@ otError otCoapOptionIteratorInit(otCoapOptionIterator *aIterator, const otMessag
  *
  */
 const otCoapOption *otCoapOptionIteratorGetFirstOptionMatching(otCoapOptionIterator *aIterator,
-                                                               uint16_t      aOption);
+                                                               uint16_t              aOption);
 
 /**
  * This function returns a pointer to the first option.
@@ -714,7 +714,7 @@ const otCoapOption *otCoapOptionIteratorGetFirstOption(otCoapOptionIterator *aIt
  *
  */
 const otCoapOption *otCoapOptionIteratorGetNextOptionMatching(otCoapOptionIterator *aIterator,
-                                                              uint16_t      aOption);
+                                                              uint16_t              aOption);
 
 /**
  * This function returns a pointer to the next option.

--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -692,7 +692,7 @@ otError otCoapOptionIteratorInit(otCoapOptionIterator *aIterator, const otMessag
  *
  */
 const otCoapOption *otCoapOptionIteratorGetFirstOptionMatching(otCoapOptionIterator *aIterator,
-                                                               otCoapOptionType      aOption);
+                                                               uint16_t      aOption);
 
 /**
  * This function returns a pointer to the first option.
@@ -714,7 +714,7 @@ const otCoapOption *otCoapOptionIteratorGetFirstOption(otCoapOptionIterator *aIt
  *
  */
 const otCoapOption *otCoapOptionIteratorGetNextOptionMatching(otCoapOptionIterator *aIterator,
-                                                              otCoapOptionType      aOption);
+                                                              uint16_t      aOption);
 
 /**
  * This function returns a pointer to the next option.

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -181,7 +181,7 @@ otError otCoapOptionIteratorInit(otCoapOptionIterator *aIterator, const otMessag
 }
 
 const otCoapOption *otCoapOptionIteratorGetFirstOptionMatching(otCoapOptionIterator *aIterator,
-                                                               otCoapOptionType      aOption)
+                                                               uint16_t      aOption)
 {
     return static_cast<Coap::OptionIterator *>(aIterator)->GetFirstOptionMatching(aOption);
 }
@@ -191,7 +191,7 @@ const otCoapOption *otCoapOptionIteratorGetFirstOption(otCoapOptionIterator *aIt
     return static_cast<Coap::OptionIterator *>(aIterator)->GetFirstOption();
 }
 
-const otCoapOption *otCoapOptionIteratorGetNextOptionMatching(otCoapOptionIterator *aIterator, otCoapOptionType aOption)
+const otCoapOption *otCoapOptionIteratorGetNextOptionMatching(otCoapOptionIterator *aIterator, uint16_t aOption)
 {
     return static_cast<Coap::OptionIterator *>(aIterator)->GetNextOptionMatching(aOption);
 }

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -180,8 +180,7 @@ otError otCoapOptionIteratorInit(otCoapOptionIterator *aIterator, const otMessag
     return static_cast<Coap::OptionIterator *>(aIterator)->Init(static_cast<const Coap::Message *>(aMessage));
 }
 
-const otCoapOption *otCoapOptionIteratorGetFirstOptionMatching(otCoapOptionIterator *aIterator,
-                                                               uint16_t              aOption)
+const otCoapOption *otCoapOptionIteratorGetFirstOptionMatching(otCoapOptionIterator *aIterator, uint16_t aOption)
 {
     return static_cast<Coap::OptionIterator *>(aIterator)->GetFirstOptionMatching(aOption);
 }

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -181,7 +181,7 @@ otError otCoapOptionIteratorInit(otCoapOptionIterator *aIterator, const otMessag
 }
 
 const otCoapOption *otCoapOptionIteratorGetFirstOptionMatching(otCoapOptionIterator *aIterator,
-                                                               uint16_t      aOption)
+                                                               uint16_t              aOption)
 {
     return static_cast<Coap::OptionIterator *>(aIterator)->GetFirstOptionMatching(aOption);
 }

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -432,7 +432,7 @@ exit:
     return err;
 }
 
-const otCoapOption *OptionIterator::GetFirstOptionMatching(otCoapOptionType aOption)
+const otCoapOption *OptionIterator::GetFirstOptionMatching(uint16_t aOption)
 {
     const otCoapOption *rval = NULL;
 
@@ -466,7 +466,7 @@ const otCoapOption *OptionIterator::GetFirstOption(void)
     return option;
 }
 
-const otCoapOption *OptionIterator::GetNextOptionMatching(otCoapOptionType aOption)
+const otCoapOption *OptionIterator::GetNextOptionMatching(uint16_t aOption)
 {
     const otCoapOption *rval = NULL;
 

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -650,7 +650,7 @@ public:
      * @returns A pointer to the first matching option. If no option matching @p aOption is seen, NULL pointer is
      *          returned.
      */
-    const otCoapOption *GetFirstOptionMatching(otCoapOptionType aOption);
+    const otCoapOption *GetFirstOptionMatching(uint16_t aOption);
 
     /**
      * This method returns a pointer to the first option.
@@ -670,7 +670,7 @@ public:
      * @returns A pointer to the next matching option (relative to current iterator position). If no option matching @p
      *          aOption is seen, NULL pointer is returned.
      */
-    const otCoapOption *GetNextOptionMatching(otCoapOptionType aOption);
+    const otCoapOption *GetNextOptionMatching(uint16_t aOption);
 
     /**
      * This method returns a pointer to the next option.


### PR DESCRIPTION
Hi all! In a recent pull request (#4396) new methods have been added to parse CoAP options using an option's number. The type these new functions receive as parameter is `otCoapOptionType`, which is an enumeration found in coap.h:

```
/**
 * CoAP Option Numbers
 */
typedef enum otCoapOptionType
{
    OT_COAP_OPTION_IF_MATCH       = 1,  ///< If-Match
    OT_COAP_OPTION_URI_HOST       = 3,  ///< Uri-Host
    ...
    OT_COAP_OPTION_PROXY_SCHEME   = 39, ///< Proxy-Scheme
    OT_COAP_OPTION_SIZE1          = 60, ///< Size1
} otCoapOptionType;
```
This makes impossible to use vendor-specific options since the underlying type of the enum is implementation-defined, and in my particular case the option number gets casted to an 8 bit integer. I simply replaced the argument type in all protoypes with uint16_t. 

