### PR TITLE
[cmake] fix RCP cmake build to not include FTD/MTD source files

### DIFF
--- a/src/ncp/CMakeLists.txt
+++ b/src/ncp/CMakeLists.txt
@@ -77,10 +77,10 @@ set(COMMON_INCLUDES
 set(COMMON_SOURCES
     changed_props_set.cpp
     ncp_base.cpp
+    ncp_base_dispatcher.cpp
     ncp_base_ftd.cpp
     ncp_base_mtd.cpp
     ncp_base_radio.cpp
-    ncp_base_dispatcher.cpp
     ncp_spi.cpp
     ncp_uart.cpp
 )
@@ -95,8 +95,8 @@ target_sources(openthread-ncp-mtd PRIVATE ${COMMON_SOURCES})
 target_sources(openthread-rcp PRIVATE
     changed_props_set.cpp
     ncp_base.cpp
-    ncp_base_radio.cpp
     ncp_base_dispatcher.cpp
+    ncp_base_radio.cpp
     ncp_spi.cpp
     ncp_uart.cpp
 )

--- a/src/ncp/CMakeLists.txt
+++ b/src/ncp/CMakeLists.txt
@@ -91,7 +91,15 @@ target_include_directories(openthread-rcp PUBLIC ${OT_PUBLIC_INCLUDES} PRIVATE $
 
 target_sources(openthread-ncp-ftd PRIVATE ${COMMON_SOURCES})
 target_sources(openthread-ncp-mtd PRIVATE ${COMMON_SOURCES})
-target_sources(openthread-rcp PRIVATE ${COMMON_SOURCES})
+
+target_sources(openthread-rcp PRIVATE
+    changed_props_set.cpp
+    ncp_base.cpp
+    ncp_base_radio.cpp
+    ncp_base_dispatcher.cpp
+    ncp_spi.cpp
+    ncp_uart.cpp
+)
 
 target_link_libraries(openthread-ncp-ftd
     PUBLIC


### PR DESCRIPTION
---
I think this will help address https://github.com/openthread/openthread/issues/4623