### PR TITLE
[coap] enum type conversion to int in otCoapBlockSizeFromExponent

### DIFF
--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -112,7 +112,7 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
 
 uint16_t otCoapBlockSizeFromExponent(otCoapBlockSize aSize)
 {
-    return static_cast<uint16_t>(1 << (aSize + Coap::Message::kBlockSzxBase));
+    return static_cast<uint16_t>(1 << (static_cast<int>(aSize) + static_cast<int>(Coap::Message::kBlockSzxBase)));
 }
 
 otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize)

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -112,7 +112,7 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
 
 uint16_t otCoapBlockSizeFromExponent(otCoapBlockSize aSize)
 {
-    return static_cast<uint16_t>(1 << (static_cast<int>(aSize) + static_cast<int>(Coap::Message::kBlockSzxBase)));
+    return static_cast<uint16_t>(1 << (static_cast<uint8_t>(aSize) + static_cast<uint8_t>(Coap::Message::kBlockSzxBase)));
 }
 
 otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize)

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -112,7 +112,8 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
 
 uint16_t otCoapBlockSizeFromExponent(otCoapBlockSize aSize)
 {
-    return static_cast<uint16_t>(1 << (static_cast<uint8_t>(aSize) + static_cast<uint8_t>(Coap::Message::kBlockSzxBase)));
+    return static_cast<uint16_t>(
+        1 << (static_cast<uint8_t>(aSize) + static_cast<uint8_t>(Coap::Message::kBlockSzxBase)));
 }
 
 otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSize aSize)


### PR DESCRIPTION
There is "enumerated type mixed with another enumerated type" error during the iar compilation. This PR fixes that.