### PR TITLE
[cli] return OT_ERROR_INVALID_ARGS for invalid arguments

### DIFF
--- a/examples/platforms/nrf528xx/src/diag.c
+++ b/examples/platforms/nrf528xx/src/diag.c
@@ -396,7 +396,7 @@ const struct PlatformDiagCommand sCommands[] = {
 
 otError otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
 {
-    otError error = OT_ERROR_NOT_IMPLEMENTED;
+    otError error = OT_ERROR_INVALID_COMMAND;
     size_t  i;
 
     for (i = 0; i < otARRAY_LENGTH(sCommands); i++)

--- a/include/openthread/error.h
+++ b/include/openthread/error.h
@@ -88,7 +88,7 @@ typedef enum otError
     OT_ERROR_BUSY = 5,
 
     /**
-     * Failed to parse message or arguments.
+     * Failed to parse message.
      */
     OT_ERROR_PARSE = 6,
 
@@ -222,6 +222,11 @@ typedef enum otError
      * The link margin was too low.
      */
     OT_ERROR_LINK_MARGIN_LOW = 34,
+
+    /**
+     * Input (CLI) command is invalid.
+     */
+    OT_ERROR_INVALID_COMMAND = 35,
 
     /**
      * The number of defined errors.

--- a/include/openthread/platform/diag.h
+++ b/include/openthread/platform/diag.h
@@ -67,7 +67,7 @@ extern "C" {
  *
  * @retval  OT_ERROR_INVALID_ARGS       The command is supported but invalid arguments provided.
  * @retval  OT_ERROR_NONE               The command is successfully process.
- * @retval  OT_ERROR_NOT_IMPLEMENTED    The command is not supported.
+ * @retval  OT_ERROR_INVALID_COMMAND    The command is not valid or not supported.
  *
  */
 otError otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen);

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1015,7 +1015,7 @@ void Interpreter::ProcessDiscover(int argc, char *argv[])
 
     if (argc > 0)
     {
-        SuccessOrExit(error = ParseLong(argv[0], value) == OT_ERROR_NONE);
+        SuccessOrExit(error = ParseLong(argv[0], value));
         VerifyOrExit((0 <= value) && (value < static_cast<long>(sizeof(scanChannels) * CHAR_BIT)),
                      error = OT_ERROR_INVALID_ARGS);
         scanChannels = 1 << value;

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2602,6 +2602,7 @@ otError Interpreter::ProcessRouteRemove(int argc, char *argv[])
 
     {
         unsigned long length;
+
         SuccessOrExit(error = ParseUnsignedLong(prefixLengthStr, length));
         prefix.mLength = static_cast<uint8_t>(length);
     }

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1122,7 +1122,6 @@ void Interpreter::ProcessEidCache(int argc, char *argv[])
 {
     OT_UNUSED_VARIABLE(argc);
     OT_UNUSED_VARIABLE(argv);
-    otError error = OT_ERROR_NONE;
 
     otEidCacheEntry entry;
 
@@ -1140,7 +1139,7 @@ void Interpreter::ProcessEidCache(int argc, char *argv[])
     }
 
 exit:
-    AppendResult(error);
+    AppendResult(OT_ERROR_NONE);
 }
 #endif // OPENTHREAD_FTD
 
@@ -2387,7 +2386,6 @@ otError Interpreter::ProcessPrefixList(void)
 {
     otNetworkDataIterator iterator = OT_NETWORK_DATA_ITERATOR_INIT;
     otBorderRouterConfig  config;
-    otError               error;
 
     while (otBorderRouterGetNextOnMeshPrefix(mInstance, &iterator, &config) == OT_ERROR_NONE)
     {
@@ -2447,7 +2445,7 @@ otError Interpreter::ProcessPrefixList(void)
         }
     }
 
-    return error;
+    return OT_ERROR_NONE;
 }
 
 void Interpreter::ProcessPrefix(int argc, char *argv[])
@@ -2617,7 +2615,6 @@ otError Interpreter::ProcessRouteList(void)
 {
     otNetworkDataIterator iterator = OT_NETWORK_DATA_ITERATOR_INIT;
     otExternalRouteConfig config;
-    otError               error;
 
     while (otBorderRouterGetNextRoute(mInstance, &iterator, &config) == OT_ERROR_NONE)
     {
@@ -2647,7 +2644,7 @@ otError Interpreter::ProcessRouteList(void)
         }
     }
 
-    return error;
+    return OT_ERROR_NONE;
 }
 
 void Interpreter::ProcessRoute(int argc, char *argv[])

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2281,6 +2281,7 @@ otError Interpreter::ProcessPrefixAdd(int argc, char *argv[])
 
     {
         unsigned long length;
+
         SuccessOrExit(error = ParseUnsignedLong(prefixLengthStr, length));
         config.mPrefix.mLength = static_cast<uint8_t>(length);
     }
@@ -2372,6 +2373,7 @@ otError Interpreter::ProcessPrefixRemove(int argc, char *argv[])
 
     {
         unsigned long length;
+
         SuccessOrExit(error = ParseUnsignedLong(prefixLengthStr, length));
         prefix.mLength = static_cast<uint8_t>(length);
     }

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1128,7 +1128,7 @@ void Interpreter::ProcessEidCache(int argc, char *argv[])
 
     for (uint8_t i = 0;; i++)
     {
-        SuccessOrExit(error = otThreadGetEidCacheEntry(mInstance, i, &entry));
+        SuccessOrExit(otThreadGetEidCacheEntry(mInstance, i, &entry));
 
         if (!entry.mValid)
         {
@@ -2389,7 +2389,7 @@ otError Interpreter::ProcessPrefixList(void)
     otBorderRouterConfig  config;
     otError               error;
 
-    while ((error = otBorderRouterGetNextOnMeshPrefix(mInstance, &iterator, &config)) == OT_ERROR_NONE)
+    while (otBorderRouterGetNextOnMeshPrefix(mInstance, &iterator, &config) == OT_ERROR_NONE)
     {
         mServer->OutputFormat("%x:%x:%x:%x::/%d ", HostSwap16(config.mPrefix.mPrefix.mFields.m16[0]),
                               HostSwap16(config.mPrefix.mPrefix.mFields.m16[1]),
@@ -2619,7 +2619,7 @@ otError Interpreter::ProcessRouteList(void)
     otExternalRouteConfig config;
     otError               error;
 
-    while ((error = otBorderRouterGetNextRoute(mInstance, &iterator, &config)) == OT_ERROR_NONE)
+    while (otBorderRouterGetNextRoute(mInstance, &iterator, &config) == OT_ERROR_NONE)
     {
         mServer->OutputFormat("%x:%x:%x:%x::/%d ", HostSwap16(config.mPrefix.mPrefix.mFields.m16[0]),
                               HostSwap16(config.mPrefix.mPrefix.mFields.m16[1]),

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1015,7 +1015,7 @@ void Interpreter::ProcessDiscover(int argc, char *argv[])
 
     if (argc > 0)
     {
-        VerifyOrExit(ParseLong(argv[0], value) == OT_ERROR_NONE, error = OT_ERROR_INVALID_ARGS);
+        SuccessOrExit(error = ParseLong(argv[0], value) == OT_ERROR_NONE);
         VerifyOrExit((0 <= value) && (value < static_cast<long>(sizeof(scanChannels) * CHAR_BIT)),
                      error = OT_ERROR_INVALID_ARGS);
         scanChannels = 1 << value;

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2543,6 +2543,7 @@ otError Interpreter::ProcessRouteAdd(int argc, char *argv[])
 
     {
         unsigned long length;
+
         SuccessOrExit(error = ParseUnsignedLong(prefixLengthStr, length));
         config.mPrefix.mLength = static_cast<uint8_t>(length);
     }

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1078,7 +1078,7 @@ void Interpreter::ProcessDns(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_ARGS);
+        ExitNow(error = OT_ERROR_INVALID_COMMAND);
     }
 
 exit:
@@ -1122,12 +1122,13 @@ void Interpreter::ProcessEidCache(int argc, char *argv[])
 {
     OT_UNUSED_VARIABLE(argc);
     OT_UNUSED_VARIABLE(argv);
+    otError error = OT_ERROR_NONE;
 
     otEidCacheEntry entry;
 
     for (uint8_t i = 0;; i++)
     {
-        SuccessOrExit(otThreadGetEidCacheEntry(mInstance, i, &entry));
+        SuccessOrExit(error = otThreadGetEidCacheEntry(mInstance, i, &entry));
 
         if (!entry.mValid)
         {
@@ -1139,7 +1140,7 @@ void Interpreter::ProcessEidCache(int argc, char *argv[])
     }
 
 exit:
-    AppendResult(OT_ERROR_NONE);
+    AppendResult(error);
 }
 #endif // OPENTHREAD_FTD
 
@@ -1343,7 +1344,7 @@ void Interpreter::ProcessIpAddr(int argc, char *argv[])
         }
         else
         {
-            ExitNow(error = OT_ERROR_INVALID_ARGS);
+            ExitNow(error = OT_ERROR_INVALID_COMMAND);
         }
     }
 
@@ -1442,7 +1443,7 @@ void Interpreter::ProcessIpMulticastAddr(int argc, char *argv[])
         }
         else
         {
-            ExitNow(error = OT_ERROR_INVALID_ARGS);
+            ExitNow(error = OT_ERROR_INVALID_COMMAND);
         }
     }
 
@@ -1797,7 +1798,7 @@ void Interpreter::ProcessService(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_ARGS);
+        ExitNow(error = OT_ERROR_INVALID_COMMAND);
     }
 
 exit:
@@ -2386,8 +2387,9 @@ otError Interpreter::ProcessPrefixList(void)
 {
     otNetworkDataIterator iterator = OT_NETWORK_DATA_ITERATOR_INIT;
     otBorderRouterConfig  config;
+    otError               error;
 
-    while (otBorderRouterGetNextOnMeshPrefix(mInstance, &iterator, &config) == OT_ERROR_NONE)
+    while ((error = otBorderRouterGetNextOnMeshPrefix(mInstance, &iterator, &config)) == OT_ERROR_NONE)
     {
         mServer->OutputFormat("%x:%x:%x:%x::/%d ", HostSwap16(config.mPrefix.mPrefix.mFields.m16[0]),
                               HostSwap16(config.mPrefix.mPrefix.mFields.m16[1]),
@@ -2445,7 +2447,7 @@ otError Interpreter::ProcessPrefixList(void)
         }
     }
 
-    return OT_ERROR_NONE;
+    return error;
 }
 
 void Interpreter::ProcessPrefix(int argc, char *argv[])
@@ -2466,7 +2468,7 @@ void Interpreter::ProcessPrefix(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_ARGS);
+        ExitNow(error = OT_ERROR_INVALID_COMMAND);
     }
 
 exit:
@@ -2615,8 +2617,9 @@ otError Interpreter::ProcessRouteList(void)
 {
     otNetworkDataIterator iterator = OT_NETWORK_DATA_ITERATOR_INIT;
     otExternalRouteConfig config;
+    otError               error;
 
-    while (otBorderRouterGetNextRoute(mInstance, &iterator, &config) == OT_ERROR_NONE)
+    while ((error = otBorderRouterGetNextRoute(mInstance, &iterator, &config)) == OT_ERROR_NONE)
     {
         mServer->OutputFormat("%x:%x:%x:%x::/%d ", HostSwap16(config.mPrefix.mPrefix.mFields.m16[0]),
                               HostSwap16(config.mPrefix.mPrefix.mFields.m16[1]),
@@ -2644,7 +2647,7 @@ otError Interpreter::ProcessRouteList(void)
         }
     }
 
-    return OT_ERROR_NONE;
+    return error;
 }
 
 void Interpreter::ProcessRoute(int argc, char *argv[])
@@ -2665,7 +2668,7 @@ void Interpreter::ProcessRoute(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_ARGS);
+        ExitNow(error = OT_ERROR_INVALID_COMMAND);
     }
 
 exit:
@@ -3019,7 +3022,7 @@ void Interpreter::ProcessSntp(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_ARGS);
+        ExitNow(error = OT_ERROR_INVALID_COMMAND);
     }
 
 exit:
@@ -3145,7 +3148,7 @@ void Interpreter::ProcessThread(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_ARGS);
+        ExitNow(error = OT_ERROR_INVALID_COMMAND);
     }
 
 exit:
@@ -3263,7 +3266,7 @@ void Interpreter::ProcessMacFilter(int argc, char *argv[])
         }
         else
         {
-            error = OT_ERROR_INVALID_ARGS;
+            error = OT_ERROR_INVALID_COMMAND;
         }
     }
 
@@ -3418,7 +3421,7 @@ otError Interpreter::ProcessMacFilterAddress(int argc, char *argv[])
         }
         else
         {
-            error = OT_ERROR_INVALID_ARGS;
+            error = OT_ERROR_INVALID_COMMAND;
         }
     }
 
@@ -3525,7 +3528,7 @@ otError Interpreter::ProcessMacFilterRss(int argc, char *argv[])
         }
         else
         {
-            error = OT_ERROR_INVALID_ARGS;
+            error = OT_ERROR_INVALID_COMMAND;
         }
     }
 
@@ -3547,7 +3550,7 @@ void Interpreter::ProcessMac(int argc, char *argv[])
     }
     else
     {
-        error = OT_ERROR_INVALID_ARGS;
+        error = OT_ERROR_INVALID_COMMAND;
     }
 
 exit:
@@ -3708,7 +3711,7 @@ void Interpreter::ProcessNetworkDiagnostic(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_ARGS);
+        ExitNow(error = OT_ERROR_INVALID_COMMAND);
     }
 
 exit:

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -127,7 +127,7 @@ public:
      * @param[out]  aLong    A reference to where the parsed long is placed.
      *
      * @retval OT_ERROR_NONE          Successfully parsed the ASCII string.
-     * @retval OT_ERROR_INVALID_ARGS  @p aString is an invalid long integer.
+     * @retval OT_ERROR_INVALID_ARGS  @p aString is not a valid long integer.
      *
      */
     static otError ParseLong(char *aString, long &aLong);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -139,7 +139,7 @@ public:
      * @param[out]  aUnsignedLong    A reference to where the parsed unsigned long is placed.
      *
      * @retval OT_ERROR_NONE          Successfully parsed the ASCII string.
-     * @retval OT_ERROR_INVALID_ARGS  @p aString is an invalid unsigned long integer.
+     * @retval OT_ERROR_INVALID_ARGS  @p aString is not a valid unsigned long integer.
      *
      */
     static otError ParseUnsignedLong(char *aString, unsigned long &aUnsignedLong);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -153,8 +153,7 @@ public:
      * @param[in]   aAllowTruncate  TRUE if @p aBinLength may be less than what is required
      *                              to convert @p aHex to binary representation, FALSE otherwise.
      *
-     * @returns -1         Indicates @p aHex is a invalid hex string.
-     * @returns Otherwise  The number of bytes in the binary representation.
+     * @returns  The number of bytes in the binary representation, or -1 if @p aHex is not a valid hex string
      *
      */
     static int Hex2Bin(const char *aHex, uint8_t *aBin, uint16_t aBinLength, bool aAllowTruncate = false);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -126,8 +126,8 @@ public:
      * @param[in]   aString  A pointer to the ASCII string.
      * @param[out]  aLong    A reference to where the parsed long is placed.
      *
-     * @retval OT_ERROR_NONE   Successfully parsed the ASCII string.
-     * @retval OT_ERROR_PARSE  Could not parse the ASCII string.
+     * @retval OT_ERROR_NONE          Successfully parsed the ASCII string.
+     * @retval OT_ERROR_INVALID_ARGS  @p aString is an invalid long integer.
      *
      */
     static otError ParseLong(char *aString, long &aLong);
@@ -138,8 +138,8 @@ public:
      * @param[in]   aString          A pointer to the ASCII string.
      * @param[out]  aUnsignedLong    A reference to where the parsed unsigned long is placed.
      *
-     * @retval OT_ERROR_NONE   Successfully parsed the ASCII string.
-     * @retval OT_ERROR_PARSE  Could not parse the ASCII string.
+     * @retval OT_ERROR_NONE          Successfully parsed the ASCII string.
+     * @retval OT_ERROR_INVALID_ARGS  @p aString is an invalid unsigned long integer.
      *
      */
     static otError ParseUnsignedLong(char *aString, unsigned long &aUnsignedLong);
@@ -153,8 +153,9 @@ public:
      * @param[in]   aAllowTruncate  TRUE if @p aBinLength may be less than what is required
      *                              to convert @p aHex to binary representation, FALSE otherwise.
      *
+     * @returns -1         Indicates @p aHex is a invalid hex string.
+     * @returns Otherwise  The number of bytes in the binary representation.
      *
-     * @returns The number of bytes in the binary representation.
      */
     static int Hex2Bin(const char *aHex, uint8_t *aBin, uint16_t aBinLength, bool aAllowTruncate = false);
 

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -512,7 +512,7 @@ exit:
 
 otError Coap::Process(int argc, char *argv[])
 {
-    otError error = OT_ERROR_PARSE;
+    otError error = OT_ERROR_INVALID_COMMAND;
 
     if (argc < 1)
     {

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -220,7 +220,7 @@ otError CoapSecure::ProcessRequest(int argc, char *argv[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_PARSE);
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
     }
 
     // Destination IPv6 address
@@ -389,7 +389,7 @@ otError CoapSecure::ProcessX509(int argc, char *argv[])
 
 otError CoapSecure::Process(int argc, char *argv[])
 {
-    otError error = OT_ERROR_PARSE;
+    otError error = OT_ERROR_INVALID_COMMAND;
 
     if (argc < 1)
     {

--- a/src/cli/cli_commissioner.cpp
+++ b/src/cli/cli_commissioner.cpp
@@ -126,7 +126,8 @@ otError Commissioner::ProcessJoiner(int argc, char *argv[])
     }
     else
     {
-        VerifyOrExit(Interpreter::Hex2Bin(argv[2], addr.m8, sizeof(addr)) == sizeof(addr), error = OT_ERROR_PARSE);
+        VerifyOrExit(Interpreter::Hex2Bin(argv[2], addr.m8, sizeof(addr)) == sizeof(addr),
+                     error = OT_ERROR_INVALID_ARGS);
         addrPtr = &addr;
     }
 
@@ -191,7 +192,7 @@ otError Commissioner::ProcessMgmtGet(int argc, char *argv[])
             VerifyOrExit(static_cast<size_t>(value) <= (sizeof(tlvs) - static_cast<size_t>(length)),
                          error = OT_ERROR_NO_BUFS);
             VerifyOrExit(Interpreter::Hex2Bin(argv[index], tlvs + length, static_cast<uint16_t>(value)) >= 0,
-                         error = OT_ERROR_PARSE);
+                         error = OT_ERROR_INVALID_ARGS);
             length += value;
         }
         else
@@ -244,7 +245,7 @@ otError Commissioner::ProcessMgmtSet(int argc, char *argv[])
             VerifyOrExit(static_cast<size_t>(length) <= OT_STEERING_DATA_MAX_LENGTH, error = OT_ERROR_NO_BUFS);
             VerifyOrExit(Interpreter::Hex2Bin(argv[index], dataset.mSteeringData.m8, static_cast<uint16_t>(length)) >=
                              0,
-                         error = OT_ERROR_PARSE);
+                         error = OT_ERROR_INVALID_ARGS);
             dataset.mSteeringData.mLength = static_cast<uint8_t>(length);
             length                        = 0;
         }
@@ -261,7 +262,7 @@ otError Commissioner::ProcessMgmtSet(int argc, char *argv[])
             length = static_cast<int>((strlen(argv[index]) + 1) / 2);
             VerifyOrExit(static_cast<size_t>(length) <= sizeof(tlvs), error = OT_ERROR_NO_BUFS);
             VerifyOrExit(Interpreter::Hex2Bin(argv[index], tlvs, static_cast<uint16_t>(length)) >= 0,
-                         error = OT_ERROR_PARSE);
+                         error = OT_ERROR_INVALID_ARGS);
         }
         else
         {
@@ -387,7 +388,7 @@ otError Commissioner::ProcessStop(int argc, char *argv[])
 
 otError Commissioner::Process(int argc, char *argv[])
 {
-    otError error = OT_ERROR_INVALID_ARGS;
+    otError error = OT_ERROR_INVALID_COMMAND;
 
     if (argc < 1)
     {

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -184,7 +184,7 @@ otError Dataset::Print(otOperationalDataset &aDataset)
 
 otError Dataset::Process(int argc, char *argv[])
 {
-    otError error = OT_ERROR_PARSE;
+    otError error = OT_ERROR_INVALID_COMMAND;
 
     if (argc == 0)
     {
@@ -370,7 +370,7 @@ otError Dataset::ProcessExtPanId(int argc, char *argv[])
     uint8_t extPanId[OT_EXT_PAN_ID_SIZE];
 
     VerifyOrExit(argc > 0, error = OT_ERROR_INVALID_ARGS);
-    VerifyOrExit(Interpreter::Hex2Bin(argv[0], extPanId, sizeof(extPanId)) >= 0, error = OT_ERROR_PARSE);
+    VerifyOrExit(Interpreter::Hex2Bin(argv[0], extPanId, sizeof(extPanId)) >= 0, error = OT_ERROR_INVALID_ARGS);
 
     memcpy(sDataset.mExtendedPanId.m8, extPanId, sizeof(sDataset.mExtendedPanId));
     sDataset.mComponents.mIsExtendedPanIdPresent = true;
@@ -385,7 +385,8 @@ otError Dataset::ProcessMasterKey(int argc, char *argv[])
     uint8_t key[OT_MASTER_KEY_SIZE];
 
     VerifyOrExit(argc > 0, error = OT_ERROR_INVALID_ARGS);
-    VerifyOrExit((Interpreter::Hex2Bin(argv[0], key, sizeof(key))) == OT_MASTER_KEY_SIZE, error = OT_ERROR_PARSE);
+    VerifyOrExit((Interpreter::Hex2Bin(argv[0], key, sizeof(key))) == OT_MASTER_KEY_SIZE,
+                 error = OT_ERROR_INVALID_ARGS);
 
     memcpy(sDataset.mMasterKey.m8, key, sizeof(sDataset.mMasterKey));
     sDataset.mComponents.mIsMasterKeyPresent = true;
@@ -415,7 +416,7 @@ otError Dataset::ProcessNetworkName(int argc, char *argv[])
     size_t  length;
 
     VerifyOrExit(argc > 0, error = OT_ERROR_INVALID_ARGS);
-    VerifyOrExit((length = strlen(argv[0])) <= OT_NETWORK_NAME_MAX_SIZE, error = OT_ERROR_PARSE);
+    VerifyOrExit((length = strlen(argv[0])) <= OT_NETWORK_NAME_MAX_SIZE, error = OT_ERROR_INVALID_ARGS);
 
     memset(&sDataset.mNetworkName, 0, sizeof(sDataset.mNetworkName));
     memcpy(sDataset.mNetworkName.m8, argv[0], length);
@@ -488,7 +489,7 @@ otError Dataset::ProcessMgmtSetCommand(int argc, char *argv[])
             dataset.mComponents.mIsMasterKeyPresent = true;
             VerifyOrExit((length = Interpreter::Hex2Bin(argv[index], dataset.mMasterKey.m8,
                                                         sizeof(dataset.mMasterKey.m8))) == OT_MASTER_KEY_SIZE,
-                         error = OT_ERROR_PARSE);
+                         error = OT_ERROR_INVALID_ARGS);
             length = 0;
         }
         else if (strcmp(argv[index], "networkname") == 0)
@@ -496,7 +497,7 @@ otError Dataset::ProcessMgmtSetCommand(int argc, char *argv[])
             VerifyOrExit(++index < argc, error = OT_ERROR_INVALID_ARGS);
             dataset.mComponents.mIsNetworkNamePresent = true;
             VerifyOrExit((length = static_cast<int>(strlen(argv[index]))) <= OT_NETWORK_NAME_MAX_SIZE,
-                         error = OT_ERROR_PARSE);
+                         error = OT_ERROR_INVALID_ARGS);
             memset(&dataset.mNetworkName, 0, sizeof(sDataset.mNetworkName));
             memcpy(dataset.mNetworkName.m8, argv[index], static_cast<size_t>(length));
             length = 0;
@@ -507,7 +508,7 @@ otError Dataset::ProcessMgmtSetCommand(int argc, char *argv[])
             dataset.mComponents.mIsExtendedPanIdPresent = true;
             VerifyOrExit(
                 Interpreter::Hex2Bin(argv[index], dataset.mExtendedPanId.m8, sizeof(dataset.mExtendedPanId.m8)) >= 0,
-                error = OT_ERROR_PARSE);
+                error = OT_ERROR_INVALID_ARGS);
         }
         else if (strcmp(argv[index], "localprefix") == 0)
         {
@@ -550,7 +551,7 @@ otError Dataset::ProcessMgmtSetCommand(int argc, char *argv[])
             length = static_cast<int>((strlen(argv[index]) + 1) / 2);
             VerifyOrExit(static_cast<size_t>(length) <= sizeof(tlvs), error = OT_ERROR_NO_BUFS);
             VerifyOrExit(Interpreter::Hex2Bin(argv[index], tlvs, static_cast<uint16_t>(length)) >= 0,
-                         error = OT_ERROR_PARSE);
+                         error = OT_ERROR_INVALID_ARGS);
         }
         else
         {
@@ -638,7 +639,7 @@ otError Dataset::ProcessMgmtGetCommand(int argc, char *argv[])
             VerifyOrExit(static_cast<size_t>(value) <= (sizeof(tlvs) - static_cast<size_t>(length)),
                          error = OT_ERROR_NO_BUFS);
             VerifyOrExit(Interpreter::Hex2Bin(argv[index], tlvs + length, static_cast<uint16_t>(value)) >= 0,
-                         error = OT_ERROR_PARSE);
+                         error = OT_ERROR_INVALID_ARGS);
             length += value;
         }
         else if (strcmp(argv[index], "address") == 0)
@@ -683,7 +684,7 @@ otError Dataset::ProcessPskc(int argc, char *argv[])
     length = static_cast<uint16_t>((strlen(argv[0]) + 1) / 2);
     VerifyOrExit(length <= OT_PSKC_MAX_SIZE, error = OT_ERROR_NO_BUFS);
     VerifyOrExit(Interpreter::Hex2Bin(argv[0], sDataset.mPskc.m8 + OT_PSKC_MAX_SIZE - length, length) == length,
-                 error = OT_ERROR_PARSE);
+                 error = OT_ERROR_INVALID_ARGS);
 
     sDataset.mComponents.mIsPskcPresent = true;
 
@@ -729,7 +730,7 @@ otError Dataset::ProcessSecurityPolicy(int argc, char *argv[])
                 break;
 
             default:
-                ExitNow(error = OT_ERROR_PARSE);
+                ExitNow(error = OT_ERROR_INVALID_ARGS);
             }
         }
     }

--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -107,7 +107,7 @@ otError Joiner::ProcessStop(int argc, char *argv[])
 
 otError Joiner::Process(int argc, char *argv[])
 {
-    otError error = OT_ERROR_INVALID_ARGS;
+    otError error = OT_ERROR_INVALID_COMMAND;
 
     if (argc < 1)
     {

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -260,7 +260,7 @@ exit:
 
 otError UdpExample::Process(int argc, char *argv[])
 {
-    otError error = OT_ERROR_PARSE;
+    otError error = OT_ERROR_INVALID_COMMAND;
 
     if (argc < 1)
     {

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -192,6 +192,7 @@ static const char *const sThreadErrorStrings[OT_NUM_ERRORS] = {
     "NonLowpanDataFrame",         // OT_ERROR_NOT_LOWPAN_DATA_FRAME = 32
     "ReservedError33",            // otError 33 is reserved
     "LinkMarginLow",              // OT_ERROR_LINK_MARGIN_LOW = 34
+    "InvalidCommand",             // OT_ERROR_INVALID_COMMAND = 35
 };
 
 const char *otThreadErrorToString(otError aError)

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -54,7 +54,7 @@ otError otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *a
     OT_UNUSED_VARIABLE(aOutput);
     OT_UNUSED_VARIABLE(aOutputMaxLen);
 
-    return OT_ERROR_NOT_IMPLEMENTED;
+    return OT_ERROR_INVALID_COMMAND;
 }
 
 namespace ot {
@@ -574,7 +574,7 @@ otError Diags::ProcessCmd(int aArgCount, char *aArgVector[], char *aOutput, size
 
 exit:
     // Add more platform specific diagnostics features here.
-    if (error == OT_ERROR_NOT_IMPLEMENTED && aArgCount > 1)
+    if (error == OT_ERROR_INVALID_COMMAND && aArgCount > 1)
     {
         snprintf(aOutput, aOutputMaxLen, "diag feature '%s' is not supported\r\n", aArgVector[0]);
     }

--- a/tests/fuzz/fuzzer_platform.cpp
+++ b/tests/fuzz/fuzzer_platform.cpp
@@ -520,7 +520,7 @@ otError otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *a
     OT_UNUSED_VARIABLE(aOutput);
     OT_UNUSED_VARIABLE(aOutputMaxLen);
 
-    return OT_ERROR_INVALID_ARGS;
+    return OT_ERROR_INVALID_COMMAND;
 }
 
 void otPlatDiagModeSet(bool aMode)


### PR DESCRIPTION
This PR addresses https://github.com/openthread/openthread/issues/4611 with three changes:
1. Remove argument parsing failure from semantic of `OT_ERROR_PARSE`.
2. Add `OT_ERROR_INVALID_COMMAND` to indicate invalid CLI command error.
3. return `OT_ERROR_INVALID_ARGS` for invalid CLI arguments.