### PR TITLE
Fixed bootloop when more than 255 ChildInfo entries are stored

### DIFF
--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -763,7 +763,7 @@ public:
         void Read(void);
 
         ChildInfo mChildInfo;
-        uint8_t   mIndex;
+        uint16_t  mIndex;
         bool      mIsDone;
     };
 


### PR DESCRIPTION
The device was resetting just after bootup, while calling otInstanceInitSingle(). During investigation we found that there are 270 ChildInfo entries in openthread settings stored on flash. In MleRouter::RestoreChildren() there is an iteration over all ChildInfo items. This iterator uses mIndex which is uint8_t and in our case its value wraps causing infinite loop. Changing mIndex to uint16_t fixes this issue.