### PR TITLE
[network-data] fix to ensure resubmit delay

### DIFF
--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -981,11 +981,9 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16)
     {
         uint32_t diff = TimerMilli::GetNow() - mLastAttempt;
 
-        if (((mType == kTypeLocal) && (diff > kDataResubmitDelay)) ||
-            ((mType == kTypeLeader) && (diff > kProxyResubmitDelay)))
-        {
-            ExitNow(error = OT_ERROR_ALREADY);
-        }
+        VerifyOrExit(((mType == kTypeLocal) && (diff > kDataResubmitDelay)) ||
+                         ((mType == kTypeLeader) && (diff > kProxyResubmitDelay)),
+                     error = OT_ERROR_ALREADY);
     }
 
     VerifyOrExit((message = Get<Coap::Coap>().NewMessage()) != NULL, error = OT_ERROR_NO_BUFS);


### PR DESCRIPTION
Fix the bug introduced in 5ebc583 when changing from `VerifyOrExit` to `if`
