### PR TITLE
[script] optimization debian package manager tweaks

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -42,7 +42,7 @@ cd /tmp || die
     (cd /etc/apt/sources.list.d && sudo rm -rf cassandra.list* couchdb.list* mongodb-3.4.list* rabbitmq_rabbitmq-server.list* chris-lea-redis-server.list* github_git-lfs.list* pgdg.list)
     sudo apt-get update || die
 
-    sudo apt-get install ninja-build
+    sudo apt-get --no-install-recommends install -y ninja-build
 
     pip3 install --upgrade pip
     pip3 install cmake
@@ -61,7 +61,7 @@ cd /tmp || die
     esac
 
     [ $BUILD_TARGET != android-build ] || {
-        sudo apt-get install -y bison gcc-multilib g++-multilib
+        sudo apt-get --no-install-recommends install -y bison gcc-multilib g++-multilib
         (
         cd $HOME
         wget https://dl.google.com/android/repository/android-ndk-r17c-linux-x86_64.zip
@@ -92,7 +92,7 @@ cd /tmp || die
     }
 
     [ $BUILD_TARGET != posix-app-pty ] || {
-        sudo apt-get install socat expect || die
+        sudo apt-get --no-install-recommends install -y socat expect || die
         JOBS=$(getconf _NPROCESSORS_ONLN)
         (
         LIBCOAP_TMPDIR=/tmp/libcoap
@@ -109,11 +109,11 @@ cd /tmp || die
     }
 
     [ $BUILD_TARGET != posix-app-migrate ] || {
-        sudo apt-get install expect || die
+        sudo apt-get --no-install-recommends install -y expect || die
     }
 
     [ $BUILD_TARGET != arm-gcc-4 ] || {
-        sudo apt-get install lib32z1 || die
+        sudo apt-get --no-install-recommends install -y lib32z1 || die
         wget https://launchpad.net/gcc-arm-embedded/4.9/4.9-2015-q3-update/+download/gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2 || die
         tar xjf gcc-arm-none-eabi-4_9-2015q3-20150921-linux.tar.bz2 || die
         export PATH=/tmp/gcc-arm-none-eabi-4_9-2015q3/bin:$PATH || die
@@ -121,7 +121,7 @@ cd /tmp || die
     }
 
     [ $BUILD_TARGET != arm-gcc-5 ] || {
-        sudo apt-get install lib32z1 || die
+        sudo apt-get --no-install-recommends install -y lib32z1 || die
         wget https://developer.arm.com/-/media/Files/downloads/gnu-rm/5_4-2016q3/gcc-arm-none-eabi-5_4-2016q3-20160926-linux.tar.bz2 || die
         tar xjf gcc-arm-none-eabi-5_4-2016q3-20160926-linux.tar.bz2 || die
         export PATH=/tmp/gcc-arm-none-eabi-5_4-2016q3/bin:$PATH || die
@@ -157,23 +157,23 @@ cd /tmp || die
     }
 
     [ $BUILD_TARGET != simulation-32-bit -a $BUILD_TARGET != simulation-mtd ] || {
-        sudo apt-get install g++-multilib || die
+        sudo apt-get --no-install-recommends install -y g++-multilib || die
     }
 
     [ $BUILD_TARGET != simulation-distcheck ] || {
-        sudo apt-get install llvm-runtime || die
+        sudo apt-get --no-install-recommends install -y llvm-runtime || die
     }
 
     [ $BUILD_TARGET != toranj-test-framework ] || {
         # packages for wpantund
-        sudo apt-get install dbus || die
-        sudo apt-get install gcc g++ libdbus-1-dev || die
-        sudo apt-get install autoconf-archive || die
-        sudo apt-get install bsdtar || die
-        sudo apt-get install libtool || die
-        sudo apt-get install libglib2.0-dev || die
-        sudo apt-get install libboost-dev || die
-        sudo apt-get install libboost-signals-dev || die
+        sudo apt-get --no-install-recommends install -y dbus || die
+        sudo apt-get --no-install-recommends install -y gcc g++ libdbus-1-dev || die
+        sudo apt-get --no-install-recommends install -y autoconf-archive || die
+        sudo apt-get --no-install-recommends install -y bsdtar || die
+        sudo apt-get --no-install-recommends install -y libtool || die
+        sudo apt-get --no-install-recommends install -y libglib2.0-dev || die
+        sudo apt-get --no-install-recommends install -y libboost-dev || die
+        sudo apt-get --no-install-recommends install -y libboost-signals-dev || die
 
         # clone and build wpantund
         git clone --depth=1 --branch=master https://github.com/openthread/wpantund.git

--- a/etc/docker/arm32v7_ubuntu_wpantund/Dockerfile
+++ b/etc/docker/arm32v7_ubuntu_wpantund/Dockerfile
@@ -5,8 +5,8 @@ LABEL maintainer="Marcin K Szczodrak"
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
-RUN apt-get install -y apt-utils
-RUN apt-get install -y build-essential git make autoconf autoconf-archive \
+RUN apt-get --no-install-recommends install -y apt-utils
+RUN apt-get --no-install-recommends install -y build-essential git make autoconf autoconf-archive \
     automake dbus libtool gcc g++ libreadline-dev libdbus-1-dev libboost-dev
 
 # wpantund
@@ -28,7 +28,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update
 
-RUN apt-get install -y libdbus-1-3 libreadline-dev net-tools
+RUN apt-get --no-install-recommends install -y libdbus-1-3 libreadline-dev net-tools
 
 RUN mkdir -p /dev/net && \
     mknod /dev/net/tun c 10 200 && \

--- a/etc/docker/codelab_otsim/Dockerfile
+++ b/etc/docker/codelab_otsim/Dockerfile
@@ -7,14 +7,14 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update -qq
 
 # Install packages needed for wpantund build and runtime:
-RUN apt-get install -y build-essential git make autoconf \
+RUN apt-get --no-install-recommends install -y build-essential git make autoconf \
                        autoconf-archive automake dbus libtool gcc \
                        g++ gperf flex bison texinfo ncurses-dev \
                        libexpat-dev python sed python-pip gawk \
                        libreadline6-dev libdbus-1-dev \
                        libboost-dev inetutils-ping
 
-RUN apt-get install -y --force-yes gcc-arm-none-eabi
+RUN apt-get --no-install-recommends install -y --force-yes gcc-arm-none-eabi
 RUN pip install pexpect
 
 # Install wpantund:

--- a/etc/docker/environment/Dockerfile
+++ b/etc/docker/environment/Dockerfile
@@ -4,8 +4,8 @@ FROM ubuntu:18.04
 ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get -y update
-RUN apt-get install -y git software-properties-common sudo
-RUN apt-get install -y iproute2 psmisc rsyslog
+RUN apt-get --no-install-recommends install -y git software-properties-common sudo
+RUN apt-get --no-install-recommends install -y iproute2 psmisc rsyslog
 
 # setup openthread
 WORKDIR /

--- a/etc/docker/x86_ubuntu_wpantund/Dockerfile
+++ b/etc/docker/x86_ubuntu_wpantund/Dockerfile
@@ -5,8 +5,8 @@ LABEL maintainer="Marcin K Szczodrak"
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
-RUN apt-get install -y apt-utils
-RUN apt-get install -y build-essential git make autoconf autoconf-archive \
+RUN apt-get --no-install-recommends install -y apt-utils
+RUN apt-get --no-install-recommends install -y build-essential git make autoconf autoconf-archive \
     automake dbus libtool gcc g++ libreadline-dev libdbus-1-dev libboost-dev
 
 # wpantund
@@ -28,7 +28,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 RUN apt-get update
 
-RUN apt-get install -y libdbus-1-3 libreadline7 net-tools
+RUN apt-get --no-install-recommends install -y libdbus-1-3 libreadline7 net-tools
 
 RUN mkdir -p /dev/net && \
     mknod /dev/net/tun c 10 200 && \

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -41,21 +41,21 @@ install_packages_apt()
 {
     # apt update and install dependencies
     sudo apt-get update || die
-    sudo apt-get -y install automake g++ libtool lsb-release make || die
+    sudo apt-get --no-install-recommends install -y automake g++ libtool lsb-release make || die
 
     PLATFORM=$(lsb_release -is)
 
     if [ $PLATFORM = "Raspbian" ]; then
-        sudo apt-get -y install binutils-arm-none-eabi gcc-arm-none-eabi gdb-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib || die
+        sudo apt-get --no-install-recommends install -y binutils-arm-none-eabi gcc-arm-none-eabi gdb-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib || die
     else
         # add gcc-arm-embedded ppa
         sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y || die
         sudo apt-get update || die
-        sudo apt-get -y install gcc-arm-embedded || die
+        sudo apt-get --no-install-recommends install -y gcc-arm-embedded || die
     fi
 
     # add clang-format for pretty
-    sudo apt-get -y install clang-format-6.0
+    sudo apt-get --no-install-recommends install -y clang-format-6.0
 
     # add yapf for pretty
     python3 -m pip install yapf || echo 'Failed to install python code formatter yapf. Install it manually if you need.'


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>