### PR TITLE
[joiner-router] prepare Joiner Entrust msg after the delay

### DIFF
--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -206,6 +206,7 @@ public:
         kTypeIp6         = 0, ///< A full uncompressed IPv6 packet
         kType6lowpan     = 1, ///< A 6lowpan frame
         kTypeSupervision = 2, ///< A child supervision frame.
+        kTypeOther       = 3, ///< Other (data) message.
     };
 
     enum

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -81,7 +81,17 @@ public:
 private:
     enum
     {
-        kDelayJoinEnt = 50, ///< milliseconds
+        kJoinerEntrustTxDelay = 50, ///< milliseconds
+    };
+
+    struct JoinerEntrustMetadata
+    {
+        otError AppendTo(Message &aMessage) { return aMessage.Append(this, sizeof(*this)); }
+        void    ReadFrom(const Message &aMessage);
+
+        Ip6::MessageInfo mMessageInfo;                    // Message info of the message to send.
+        TimeMilli        mSendTime;                       // Time when the message shall be sent.
+        uint8_t          mKek[KeyManager::kMaxKeyLength]; // KEK used by MAC layer to encode this message.
     };
 
     static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
@@ -102,9 +112,10 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
-    otError DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessageInfo, const uint8_t *aKek);
-    void    SendDelayedJoinerEntrust(void);
-    otError SendJoinerEntrust(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    otError        DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessageInfo, const uint8_t *aKek);
+    void           SendDelayedJoinerEntrust(void);
+    otError        SendJoinerEntrust(const Ip6::MessageInfo &aMessageInfo);
+    Coap::Message *PrepareJoinerEntrustMessage(void);
 
     Ip6::UdpSocket mSocket;
     Coap::Resource mRelayTransmit;
@@ -118,95 +129,6 @@ private:
 
     bool mIsJoinerPortConfigured : 1;
     bool mExpectJoinEntRsp : 1;
-};
-
-/**
- * This class implements functionality required for delaying JOIN_ENT.ntf messages.
- *
- */
-class DelayedJoinEntHeader
-{
-public:
-    /**
-     * This method initializes the object with specific values.
-     *
-     * @param[in]  aSendTime     Time when the message shall be sent.
-     * @param[in]  aMessageInfo  IPv6 address of the message destination.
-     * @param[in]  aKek          A pointer to the KEK.
-     *
-     */
-    void Init(TimeMilli aSendTime, Ip6::MessageInfo &aMessageInfo, const uint8_t *aKek)
-    {
-        mSendTime    = aSendTime;
-        mMessageInfo = aMessageInfo;
-        memcpy(&mKek, aKek, sizeof(mKek));
-    }
-
-    /**
-     * This method appends delayed response header to the message.
-     *
-     * @param[in]  aMessage  A reference to the message.
-     *
-     * @retval OT_ERROR_NONE     Successfully appended the bytes.
-     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
-     *
-     */
-    otError AppendTo(Message &aMessage) { return aMessage.Append(this, sizeof(*this)); }
-
-    /**
-     * This method reads delayed response header from the message.
-     *
-     * @param[in]  aMessage  A reference to the message.
-     *
-     */
-    void ReadFrom(const Message &aMessage)
-    {
-        uint16_t length = aMessage.Read(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
-        assert(length == sizeof(*this));
-        OT_UNUSED_VARIABLE(length);
-    }
-
-    /**
-     * This method removes delayed response header from the message.
-     *
-     * @param[in]  aMessage  A reference to the message.
-     *
-     */
-    static void RemoveFrom(Message &aMessage)
-    {
-        otError error = aMessage.SetLength(aMessage.GetLength() - sizeof(DelayedJoinEntHeader));
-        assert(error == OT_ERROR_NONE);
-        OT_UNUSED_VARIABLE(error);
-    }
-
-    /**
-     * This method returns a time when the message shall be sent.
-     *
-     * @returns  A time when the message shall be sent.
-     *
-     */
-    TimeMilli GetSendTime(void) const { return mSendTime; }
-
-    /**
-     * This method returns a destination of the delayed message.
-     *
-     * @returns  A destination of the delayed message.
-     *
-     */
-    const Ip6::MessageInfo *GetMessageInfo(void) const { return &mMessageInfo; }
-
-    /**
-     * This method returns a pointer to the KEK that should be used to send the delayed message.
-     *
-     * @returns  A pointer to the KEK.
-     *
-     */
-    const uint8_t *GetKek(void) const { return mKek; }
-
-private:
-    Ip6::MessageInfo mMessageInfo;                    ///< Message info of the message to send.
-    TimeMilli        mSendTime;                       ///< Time when the message shall be sent.
-    uint8_t          mKek[KeyManager::kMaxKeyLength]; ///< KEK used by MAC layer to encode this message.
 };
 
 } // namespace MeshCoP


### PR DESCRIPTION
This PR contains two related commits: 

**[joiner-router] move JoinerEntrustMetadata as private inner type of JoinerRouter**

**[joiner-router] prepare Joiner Entrust msg after the delay**
    
 This commit changes how the tx of Joiner Entrust is delayed. Instead of preparing the message (and appending metadata to it) and enqueueing it to be sent later after a delay, this commit changes the code such that only the metadata is saved and the Joiner Entrust message itself is prepared after the delay (when it is being sent).

----
I think it would be easier to check/review the commits separately.


