### PR TITLE
[tests] initialize _initialized

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -48,6 +48,7 @@ class Node:
         self.verbose = int(float(os.getenv('VERBOSE', 0)))
         self.node_type = os.getenv('NODE_TYPE', 'sim')
         self.env_version = os.getenv('THREAD_VERSION', '1.1')
+        self._initialized = False
 
         if version is not None:
             self.version = version


### PR DESCRIPTION
This PR initializes `_initialized` of `Node` before doing initialization. Otherwise, we will have an `AttributeError` in desctructor when initialization failed:
```text
Exception ignored in: <function Node.__del__ at 0x7fd3a90b6560>
Traceback (most recent call last):
  File "/usr/local/google/home/wgtdkp/openthread/tests/scripts/thread-cert/node.py", line 187, in __del__
    self.destroy()
  File "/usr/local/google/home/wgtdkp/openthread/tests/scripts/thread-cert/node.py", line 190, in destroy
    if not self._initialized:
AttributeError: 'Node' object has no attribute '_initialized'
```