### PR TITLE
[debug] adding OT_ASSERT() macro (allow disabling asserts)

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -504,6 +504,14 @@ build_samr21() {
     ./bootstrap || die
     make -f examples/Makefile-simulation || die
 
+    export CPPFLAGS="${CPPFLAGS}                          \
+        -DOPENTHREAD_CONFIG_ASSERT_ENABLE=0"
+
+    git checkout -- . || die
+    git clean -xfd || die
+    ./bootstrap || die
+    make -f examples/Makefile-simulation || die
+
     export CPPFLAGS="                                    \
         -DOPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE=1       \
         -DOPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE=1     \

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -47,7 +47,7 @@ otError otBorderRouterGetNetData(otInstance *aInstance, bool aStable, uint8_t *a
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aData != NULL && aDataLength != NULL);
+    OT_ASSERT(aData != NULL && aDataLength != NULL);
 
     return instance.Get<NetworkData::Local>().GetNetworkData(aStable, aData, *aDataLength);
 }
@@ -57,7 +57,7 @@ otError otBorderRouterAddOnMeshPrefix(otInstance *aInstance, const otBorderRoute
     uint8_t   flags    = 0;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aConfig != NULL);
+    OT_ASSERT(aConfig != NULL);
 
     if (aConfig->mPreferred)
     {
@@ -97,7 +97,7 @@ otError otBorderRouterRemoveOnMeshPrefix(otInstance *aInstance, const otIp6Prefi
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aPrefix != NULL);
+    OT_ASSERT(aPrefix != NULL);
 
     return instance.Get<NetworkData::Local>().RemoveOnMeshPrefix(aPrefix->mPrefix.mFields.m8, aPrefix->mLength);
 }
@@ -108,7 +108,7 @@ otError otBorderRouterGetNextOnMeshPrefix(otInstance *           aInstance,
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aIterator != NULL && aConfig != NULL);
+    OT_ASSERT(aIterator != NULL && aConfig != NULL);
 
     return instance.Get<NetworkData::Local>().GetNextOnMeshPrefix(*aIterator, *aConfig);
 }
@@ -117,7 +117,7 @@ otError otBorderRouterAddRoute(otInstance *aInstance, const otExternalRouteConfi
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aConfig != NULL);
+    OT_ASSERT(aConfig != NULL);
 
     return instance.Get<NetworkData::Local>().AddHasRoutePrefix(
         aConfig->mPrefix.mPrefix.mFields.m8, aConfig->mPrefix.mLength, aConfig->mPreference, aConfig->mStable);
@@ -127,7 +127,7 @@ otError otBorderRouterRemoveRoute(otInstance *aInstance, const otIp6Prefix *aPre
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aPrefix != NULL);
+    OT_ASSERT(aPrefix != NULL);
 
     return instance.Get<NetworkData::Local>().RemoveHasRoutePrefix(aPrefix->mPrefix.mFields.m8, aPrefix->mLength);
 }
@@ -138,7 +138,7 @@ otError otBorderRouterGetNextRoute(otInstance *           aInstance,
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aIterator != NULL && aConfig != NULL);
+    OT_ASSERT(aIterator != NULL && aConfig != NULL);
 
     return instance.Get<NetworkData::Local>().GetNextExternalRoute(*aIterator, *aConfig);
 }

--- a/src/core/api/coap_secure_api.cpp
+++ b/src/core/api/coap_secure_api.cpp
@@ -61,7 +61,7 @@ void otCoapSecureSetCertificate(otInstance *   aInstance,
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aX509Cert != NULL && aX509Length != 0 && aPrivateKey != NULL && aPrivateKeyLength != 0);
+    OT_ASSERT(aX509Cert != NULL && aX509Length != 0 && aPrivateKey != NULL && aPrivateKeyLength != 0);
 
     instance.GetApplicationCoapSecure().SetCertificate(aX509Cert, aX509Length, aPrivateKey, aPrivateKeyLength);
 }
@@ -72,7 +72,7 @@ void otCoapSecureSetCaCertificateChain(otInstance *   aInstance,
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aX509CaCertificateChain != NULL && aX509CaCertChainLength != 0);
+    OT_ASSERT(aX509CaCertificateChain != NULL && aX509CaCertChainLength != 0);
 
     instance.GetApplicationCoapSecure().SetCaCertificateChain(aX509CaCertificateChain, aX509CaCertChainLength);
 }
@@ -87,7 +87,7 @@ void otCoapSecureSetPsk(otInstance *   aInstance,
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aPsk != NULL && aPskLength != 0 && aPskIdentity != NULL && aPskIdLength != 0);
+    OT_ASSERT(aPsk != NULL && aPskLength != 0 && aPskIdentity != NULL && aPskIdLength != 0);
 
     instance.GetApplicationCoapSecure().SetPreSharedKey(aPsk, aPskLength, aPskIdentity, aPskIdLength);
 }

--- a/src/core/api/crypto_api.cpp
+++ b/src/core/api/crypto_api.cpp
@@ -52,7 +52,7 @@ void otCryptoHmacSha256(const uint8_t *aKey,
 {
     HmacSha256 hmac;
 
-    assert((aKey != NULL) && (aBuf != NULL) && (aHash != NULL));
+    OT_ASSERT((aKey != NULL) && (aBuf != NULL) && (aHash != NULL));
 
     hmac.Start(aKey, aKeyLength);
     hmac.Update(aBuf, aBufLength);
@@ -75,21 +75,21 @@ void otCryptoAesCcm(const uint8_t *aKey,
     AesCcm  aesCcm;
     uint8_t tagLength;
 
-    assert((aKey != NULL) && (aNonce != NULL) && (aPlainText != NULL) && (aCipherText != NULL) && (aTag != NULL));
+    OT_ASSERT((aKey != NULL) && (aNonce != NULL) && (aPlainText != NULL) && (aCipherText != NULL) && (aTag != NULL));
 
     aesCcm.SetKey(aKey, aKeyLength);
     SuccessOrExit(aesCcm.Init(aHeaderLength, aLength, aTagLength, aNonce, aNonceLength));
 
     if (aHeaderLength != 0)
     {
-        assert(aHeader != NULL);
+        OT_ASSERT(aHeader != NULL);
         aesCcm.Header(aHeader, aHeaderLength);
     }
 
     aesCcm.Payload(aPlainText, aCipherText, aLength, aEncrypt);
     aesCcm.Finalize(aTag, &tagLength);
 
-    assert(aTagLength == tagLength);
+    OT_ASSERT(aTagLength == tagLength);
 
 exit:
     return;

--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -60,7 +60,7 @@ otError otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aDataset != NULL);
+    OT_ASSERT(aDataset != NULL);
 
     return instance.Get<MeshCoP::ActiveDataset>().Read(*aDataset);
 }
@@ -69,7 +69,7 @@ otError otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aD
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aDataset != NULL);
+    OT_ASSERT(aDataset != NULL);
 
     return instance.Get<MeshCoP::ActiveDataset>().Save(*aDataset);
 }
@@ -78,7 +78,7 @@ otError otDatasetGetPending(otInstance *aInstance, otOperationalDataset *aDatase
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aDataset != NULL);
+    OT_ASSERT(aDataset != NULL);
 
     return instance.Get<MeshCoP::PendingDataset>().Read(*aDataset);
 }
@@ -87,7 +87,7 @@ otError otDatasetSetPending(otInstance *aInstance, const otOperationalDataset *a
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aDataset != NULL);
+    OT_ASSERT(aDataset != NULL);
 
     return instance.Get<MeshCoP::PendingDataset>().Save(*aDataset);
 }

--- a/src/core/api/heap_api.cpp
+++ b/src/core/api/heap_api.cpp
@@ -47,7 +47,7 @@ void *otHeapCAlloc(size_t aCount, size_t aSize)
     OT_UNUSED_VARIABLE(aSize);
 
     // Should never get called!
-    assert(false);
+    OT_ASSERT(false);
 
     // This function is reachable when asserts are disabled
     OT_UNREACHABLE_CODE(return NULL;)
@@ -58,7 +58,7 @@ void otHeapFree(void *aPointer)
     OT_UNUSED_VARIABLE(aPointer);
 
     // Should never get called!
-    assert(false);
+    OT_ASSERT(false);
 }
 
 #else // OPENTHREAD_RADIO

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -237,7 +237,7 @@ otError otIp6AddressFromString(const char *aString, otIp6Address *aAddress)
 
 uint8_t otIp6PrefixMatch(const otIp6Address *aFirst, const otIp6Address *aSecond)
 {
-    assert(aFirst != NULL && aSecond != NULL);
+    OT_ASSERT(aFirst != NULL && aSecond != NULL);
 
     return static_cast<const Ip6::Address *>(aFirst)->PrefixMatch(*static_cast<const Ip6::Address *>(aSecond));
 }

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -116,7 +116,7 @@ otError otLinkSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExt
     otError   error    = OT_ERROR_NONE;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aExtAddress != NULL);
+    OT_ASSERT(aExtAddress != NULL);
     VerifyOrExit(instance.Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_DISABLED, error = OT_ERROR_INVALID_STATE);
 
     instance.Get<Mac::Mac>().SetExtAddress(*static_cast<const Mac::ExtAddress *>(aExtAddress));
@@ -236,7 +236,7 @@ otError otLinkFilterAddAddress(otInstance *aInstance, const otExtAddress *aExtAd
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aExtAddress != NULL);
+    OT_ASSERT(aExtAddress != NULL);
 
     return instance.Get<Mac::Filter>().AddAddress(*static_cast<const Mac::ExtAddress *>(aExtAddress));
 }
@@ -245,7 +245,7 @@ otError otLinkFilterRemoveAddress(otInstance *aInstance, const otExtAddress *aEx
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aExtAddress != NULL);
+    OT_ASSERT(aExtAddress != NULL);
 
     return instance.Get<Mac::Filter>().RemoveAddress(*static_cast<const Mac::ExtAddress *>(aExtAddress));
 }
@@ -261,7 +261,7 @@ otError otLinkFilterGetNextAddress(otInstance *aInstance, otMacFilterIterator *a
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aIterator != NULL && aEntry != NULL);
+    OT_ASSERT(aIterator != NULL && aEntry != NULL);
 
     return instance.Get<Mac::Filter>().GetNextAddress(*aIterator, *aEntry);
 }
@@ -291,7 +291,7 @@ otError otLinkFilterGetNextRssIn(otInstance *aInstance, otMacFilterIterator *aIt
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aIterator != NULL && aEntry != NULL);
+    OT_ASSERT(aIterator != NULL && aEntry != NULL);
 
     return instance.Get<Mac::Filter>().GetNextRssIn(*aIterator, *aEntry);
 }

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -44,7 +44,7 @@ otError otNetDataGet(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aData != NULL && aDataLength != NULL);
+    OT_ASSERT(aData != NULL && aDataLength != NULL);
 
     return instance.Get<NetworkData::Leader>().GetNetworkData(aStable, aData, *aDataLength);
 }

--- a/src/core/api/server_api.cpp
+++ b/src/core/api/server_api.cpp
@@ -46,7 +46,7 @@ otError otServerGetNetDataLocal(otInstance *aInstance, bool aStable, uint8_t *aD
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aData != NULL && aDataLength != NULL);
+    OT_ASSERT(aData != NULL && aDataLength != NULL);
 
     return instance.Get<NetworkData::Local>().GetNetworkData(aStable, aData, *aDataLength);
 }

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -92,7 +92,7 @@ otError otThreadGetLeaderRloc(otInstance *aInstance, otIp6Address *aLeaderRloc)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aLeaderRloc != NULL);
+    OT_ASSERT(aLeaderRloc != NULL);
 
     return instance.Get<Mle::MleRouter>().GetLeaderAddress(*static_cast<Ip6::Address *>(aLeaderRloc));
 }
@@ -126,7 +126,7 @@ otError otThreadSetMasterKey(otInstance *aInstance, const otMasterKey *aKey)
     otError   error    = OT_ERROR_NONE;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aKey != NULL);
+    OT_ASSERT(aKey != NULL);
 
     VerifyOrExit(instance.Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_DISABLED, error = OT_ERROR_INVALID_STATE);
 
@@ -249,7 +249,7 @@ otError otThreadGetNextNeighborInfo(otInstance *aInstance, otNeighborInfoIterato
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert((aInfo != NULL) && (aIterator != NULL));
+    OT_ASSERT((aInfo != NULL) && (aIterator != NULL));
 
     return instance.Get<Mle::MleRouter>().GetNextNeighborInfo(*aIterator, *aInfo);
 }
@@ -265,7 +265,7 @@ otError otThreadGetLeaderData(otInstance *aInstance, otLeaderData *aLeaderData)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aLeaderData != NULL);
+    OT_ASSERT(aLeaderData != NULL);
 
     return instance.Get<Mle::MleRouter>().GetLeaderData(*aLeaderData);
 }
@@ -304,7 +304,7 @@ otError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
     otError   error    = OT_ERROR_NONE;
     Router *  parent;
 
-    assert(aParentInfo != NULL);
+    OT_ASSERT(aParentInfo != NULL);
 
     // Reference device needs get the original parent's info even after the node state changed.
 #if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
@@ -335,7 +335,7 @@ otError otThreadGetParentAverageRssi(otInstance *aInstance, int8_t *aParentRssi)
     otError   error    = OT_ERROR_NONE;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aParentRssi != NULL);
+    OT_ASSERT(aParentRssi != NULL);
 
     *aParentRssi = instance.Get<Mle::MleRouter>().GetParent().GetLinkInfo().GetAverageRss();
 
@@ -350,7 +350,7 @@ otError otThreadGetParentLastRssi(otInstance *aInstance, int8_t *aLastRssi)
     otError   error    = OT_ERROR_NONE;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aLastRssi != NULL);
+    OT_ASSERT(aLastRssi != NULL);
 
     *aLastRssi = instance.Get<Mle::MleRouter>().GetParent().GetLinkInfo().GetLastRss();
 

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -241,7 +241,7 @@ otError otThreadGetChildInfoById(otInstance *aInstance, uint16_t aChildId, otChi
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aChildInfo != NULL);
+    OT_ASSERT(aChildInfo != NULL);
 
     return instance.Get<Mle::MleRouter>().GetChildInfoById(aChildId, *aChildInfo);
 }
@@ -250,7 +250,7 @@ otError otThreadGetChildInfoByIndex(otInstance *aInstance, uint16_t aChildIndex,
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aChildInfo != NULL);
+    OT_ASSERT(aChildInfo != NULL);
 
     return instance.Get<Mle::MleRouter>().GetChildInfoByIndex(aChildIndex, *aChildInfo);
 }
@@ -265,7 +265,7 @@ otError otThreadGetChildNextIp6Address(otInstance *               aInstance,
     Child::Ip6AddressIterator iterator;
     Ip6::Address *            address;
 
-    assert(aIterator != NULL && aAddress != NULL);
+    OT_ASSERT(aIterator != NULL && aAddress != NULL);
 
     address = static_cast<Ip6::Address *>(aAddress);
     iterator.Set(*aIterator);
@@ -295,7 +295,7 @@ otError otThreadGetRouterInfo(otInstance *aInstance, uint16_t aRouterId, otRoute
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aRouterInfo != NULL);
+    OT_ASSERT(aRouterInfo != NULL);
 
     return instance.Get<RouterTable>().GetRouterInfo(aRouterId, *aRouterInfo);
 }
@@ -304,7 +304,7 @@ otError otThreadGetEidCacheEntry(otInstance *aInstance, uint8_t aIndex, otEidCac
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    assert(aEntry != NULL);
+    OT_ASSERT(aEntry != NULL);
     return instance.Get<AddressResolver>().GetEntry(aIndex, *aEntry);
 }
 

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -114,7 +114,7 @@ void otUdpForwardReceive(otInstance *        aInstance,
     Ip6::MessageInfo messageInfo;
     Instance &       instance = *static_cast<Instance *>(aInstance);
 
-    assert(aMessage != NULL && aPeerAddr != NULL);
+    OT_ASSERT(aMessage != NULL && aPeerAddr != NULL);
 
     messageInfo.SetSockAddr(instance.Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetSockPort(aSockPort);

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -145,7 +145,7 @@ otError CoapBase::SendMessage(Message &               aMessage,
         mResponsesQueue.EnqueueResponse(aMessage, aMessageInfo, aTxParameters);
         break;
     case OT_COAP_TYPE_RESET:
-        assert(aMessage.GetCode() == OT_COAP_CODE_EMPTY);
+        OT_ASSERT(aMessage.GetCode() == OT_COAP_CODE_EMPTY);
         break;
     default:
         aMessage.SetMessageId(mMessageId++);
@@ -789,7 +789,7 @@ void CoapBase::Metadata::ReadFrom(const Message &aMessage)
 {
     uint16_t length = aMessage.GetLength();
 
-    assert(length >= sizeof(*this));
+    OT_ASSERT(length >= sizeof(*this));
     aMessage.Read(length - sizeof(*this), sizeof(*this), this);
 }
 
@@ -951,7 +951,7 @@ void ResponsesQueue::ResponseMetadata::ReadFrom(const Message &aMessage)
 {
     uint16_t length = aMessage.GetLength();
 
-    assert(length >= sizeof(*this));
+    OT_ASSERT(length >= sizeof(*this));
     aMessage.Read(length - sizeof(*this), sizeof(*this), this);
 }
 

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -246,9 +246,9 @@ otError Message::ParseHeader(void)
     otError        error = OT_ERROR_NONE;
     OptionIterator iterator;
 
-    assert(mBuffer.mHead.mInfo.mReserved >=
-           sizeof(GetHelpData()) +
-               static_cast<size_t>((reinterpret_cast<uint8_t *>(&GetHelpData()) - mBuffer.mHead.mData)));
+    OT_ASSERT(mBuffer.mHead.mInfo.mReserved >=
+              sizeof(GetHelpData()) +
+                  static_cast<size_t>((reinterpret_cast<uint8_t *>(&GetHelpData()) - mBuffer.mHead.mData)));
 
     GetHelpData().Clear();
 
@@ -284,7 +284,7 @@ otError Message::SetToken(uint8_t aTokenLength)
 {
     uint8_t token[kMaxTokenLength] = {0};
 
-    assert(aTokenLength <= sizeof(token));
+    OT_ASSERT(aTokenLength <= sizeof(token));
 
     Random::NonCrypto::FillBuffer(token, aTokenLength);
 

--- a/src/core/common/debug.hpp
+++ b/src/core/common/debug.hpp
@@ -39,9 +39,13 @@
 #include <ctype.h>
 #include <stdio.h>
 
+#if OPENTHREAD_CONFIG_ASSERT_ENABLE
+
 #if defined(OPENTHREAD_TARGET_DARWIN) || defined(OPENTHREAD_TARGET_LINUX)
 
 #include <assert.h>
+
+#define OT_ASSERT(cond) assert(cond)
 
 #elif OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
 
@@ -55,11 +59,7 @@
 #define FILE_NAME __FILE__
 #endif
 
-#ifdef assert
-#undef assert
-#endif
-
-#define assert(cond)                               \
+#define OT_ASSERT(cond)                            \
     do                                             \
     {                                              \
         if (!(cond))                               \
@@ -73,21 +73,23 @@
 
 #else
 
-#ifdef assert
-#undef assert
-#endif
-
-#define assert(cond)  \
-    do                \
-    {                 \
-        if (!(cond))  \
-        {             \
-            while (1) \
-            {         \
-            }         \
-        }             \
+#define OT_ASSERT(cond) \
+    do                  \
+    {                   \
+        if (!(cond))    \
+        {               \
+            while (1)   \
+            {           \
+            }           \
+        }               \
     } while (0)
 
-#endif
+#endif // OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
+
+#else
+
+#define OT_ASSERT(cond)
+
+#endif // OPENTHREAD_CONFIG_ASSERT_ENABLE
 
 #endif // DEBUG_HPP_

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -217,14 +217,14 @@ public:
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
     void HeapFree(void *aPointer)
     {
-        assert(mFree != NULL);
+        OT_ASSERT(mFree != NULL);
 
         mFree(aPointer);
     }
 
     void *HeapCAlloc(size_t aCount, size_t aSize)
     {
-        assert(mCAlloc != NULL);
+        OT_ASSERT(mCAlloc != NULL);
 
         return mCAlloc(aCount, aSize);
     }

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -117,7 +117,7 @@ Message *MessagePool::New(uint8_t aType, uint16_t aReserveHeader, const otMessag
 
 void MessagePool::Free(Message *aMessage)
 {
-    assert(aMessage->Next() == NULL && aMessage->Prev() == NULL);
+    OT_ASSERT(aMessage->Next() == NULL && aMessage->Prev() == NULL);
 
     FreeBuffers(static_cast<Buffer *>(aMessage));
 }
@@ -312,11 +312,11 @@ otError Message::MoveOffset(int aDelta)
 {
     otError error = OT_ERROR_NONE;
 
-    assert(GetOffset() + aDelta <= GetLength());
+    OT_ASSERT(GetOffset() + aDelta <= GetLength());
     VerifyOrExit(GetOffset() + aDelta <= GetLength(), error = OT_ERROR_INVALID_ARGS);
 
     mBuffer.mHead.mInfo.mOffset += static_cast<int16_t>(aDelta);
-    assert(mBuffer.mHead.mInfo.mOffset <= GetLength());
+    OT_ASSERT(mBuffer.mHead.mInfo.mOffset <= GetLength());
 
 exit:
     return error;
@@ -326,7 +326,7 @@ otError Message::SetOffset(uint16_t aOffset)
 {
     otError error = OT_ERROR_NONE;
 
-    assert(aOffset <= GetLength());
+    OT_ASSERT(aOffset <= GetLength());
     VerifyOrExit(aOffset <= GetLength(), error = OT_ERROR_INVALID_ARGS);
 
     mBuffer.mHead.mInfo.mOffset = aOffset;
@@ -395,7 +395,7 @@ otError Message::Append(const void *aBuf, uint16_t aLength)
     SuccessOrExit(error = SetLength(GetLength() + aLength));
     bytesWritten = Write(oldLength, aLength, aBuf);
 
-    assert(bytesWritten == (int)aLength);
+    OT_ASSERT(bytesWritten == (int)aLength);
     OT_UNUSED_VARIABLE(bytesWritten);
 
 exit:
@@ -439,7 +439,7 @@ exit:
 
 void Message::RemoveHeader(uint16_t aLength)
 {
-    assert(aLength <= mBuffer.mHead.mInfo.mLength);
+    OT_ASSERT(aLength <= mBuffer.mHead.mInfo.mLength);
 
     mBuffer.mHead.mInfo.mReserved += aLength;
     mBuffer.mHead.mInfo.mLength -= aLength;
@@ -500,7 +500,7 @@ uint16_t Message::Read(uint16_t aOffset, uint16_t aLength, void *aBuf) const
 
     while (aOffset >= kBufferDataSize)
     {
-        assert(curBuffer != NULL);
+        OT_ASSERT(curBuffer != NULL);
 
         curBuffer = curBuffer->GetNextBuffer();
         aOffset -= kBufferDataSize;
@@ -509,7 +509,7 @@ uint16_t Message::Read(uint16_t aOffset, uint16_t aLength, void *aBuf) const
     // begin copy
     while (aLength > 0)
     {
-        assert(curBuffer != NULL);
+        OT_ASSERT(curBuffer != NULL);
 
         bytesToCopy = kBufferDataSize - aOffset;
 
@@ -538,7 +538,7 @@ int Message::Write(uint16_t aOffset, uint16_t aLength, const void *aBuf)
     uint16_t bytesCopied = 0;
     uint16_t bytesToCopy;
 
-    assert(aOffset + aLength <= GetLength());
+    OT_ASSERT(aOffset + aLength <= GetLength());
 
     if (aOffset + aLength >= GetLength())
     {
@@ -575,7 +575,7 @@ int Message::Write(uint16_t aOffset, uint16_t aLength, const void *aBuf)
 
     while (aOffset >= kBufferDataSize)
     {
-        assert(curBuffer != NULL);
+        OT_ASSERT(curBuffer != NULL);
 
         curBuffer = curBuffer->GetNextBuffer();
         aOffset -= kBufferDataSize;
@@ -584,7 +584,7 @@ int Message::Write(uint16_t aOffset, uint16_t aLength, const void *aBuf)
     // begin copy
     while (aLength > 0)
     {
-        assert(curBuffer != NULL);
+        OT_ASSERT(curBuffer != NULL);
 
         bytesToCopy = kBufferDataSize - aOffset;
 
@@ -662,19 +662,19 @@ exit:
 
 bool Message::GetChildMask(uint16_t aChildIndex) const
 {
-    assert(aChildIndex < sizeof(mBuffer.mHead.mInfo.mChildMask) * 8);
+    OT_ASSERT(aChildIndex < sizeof(mBuffer.mHead.mInfo.mChildMask) * 8);
     return (mBuffer.mHead.mInfo.mChildMask[aChildIndex / 8] & (0x80 >> (aChildIndex % 8))) != 0;
 }
 
 void Message::ClearChildMask(uint16_t aChildIndex)
 {
-    assert(aChildIndex < sizeof(mBuffer.mHead.mInfo.mChildMask) * 8);
+    OT_ASSERT(aChildIndex < sizeof(mBuffer.mHead.mInfo.mChildMask) * 8);
     mBuffer.mHead.mInfo.mChildMask[aChildIndex / 8] &= ~(0x80 >> (aChildIndex % 8));
 }
 
 void Message::SetChildMask(uint16_t aChildIndex)
 {
-    assert(aChildIndex < sizeof(mBuffer.mHead.mInfo.mChildMask) * 8);
+    OT_ASSERT(aChildIndex < sizeof(mBuffer.mHead.mInfo.mChildMask) * 8);
     mBuffer.mHead.mInfo.mChildMask[aChildIndex / 8] |= 0x80 >> (aChildIndex % 8);
 }
 
@@ -718,7 +718,7 @@ uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t 
     uint16_t bytesCovered = 0;
     uint16_t bytesToCover;
 
-    assert(aOffset + aLength <= GetLength());
+    OT_ASSERT(aOffset + aLength <= GetLength());
 
     aOffset += GetReserved();
 
@@ -749,7 +749,7 @@ uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t 
 
     while (aOffset >= kBufferDataSize)
     {
-        assert(curBuffer != NULL);
+        OT_ASSERT(curBuffer != NULL);
 
         curBuffer = curBuffer->GetNextBuffer();
         aOffset -= kBufferDataSize;
@@ -758,7 +758,7 @@ uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t 
     // begin copy
     while (aLength > 0)
     {
-        assert(curBuffer != NULL);
+        OT_ASSERT(curBuffer != NULL);
 
         bytesToCover = kBufferDataSize - aOffset;
 
@@ -809,7 +809,7 @@ otError MessageQueue::Enqueue(Message &aMessage, QueuePosition aPosition)
 
     aMessage.SetMessageQueue(this);
 
-    assert((aMessage.Next() == NULL) && (aMessage.Prev() == NULL));
+    OT_ASSERT((aMessage.Next() == NULL) && (aMessage.Prev() == NULL));
 
     if (GetTail() == NULL)
     {
@@ -844,7 +844,7 @@ otError MessageQueue::Dequeue(Message &aMessage)
 
     VerifyOrExit(aMessage.GetMessageQueue() == this, error = OT_ERROR_NOT_FOUND);
 
-    assert((aMessage.Next() != NULL) && (aMessage.Prev() != NULL));
+    OT_ASSERT((aMessage.Next() != NULL) && (aMessage.Prev() != NULL));
 
     if (&aMessage == GetTail())
     {
@@ -927,7 +927,7 @@ Message *PriorityQueue::GetHeadForPriority(uint8_t aPriority) const
     {
         previousTail = FindFirstNonNullTail(PrevPriority(aPriority));
 
-        assert(previousTail != NULL);
+        OT_ASSERT(previousTail != NULL);
 
         head = previousTail->Next();
     }

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -45,7 +45,7 @@ Notifier::Callback::Callback(Instance &aInstance, Handler aHandler, void *aOwner
     , mHandler(aHandler)
     , mNext(NULL)
 {
-    assert(aHandler != NULL);
+    OT_ASSERT(aHandler != NULL);
     aInstance.Get<Notifier>().RegisterCallback(*this);
 }
 

--- a/src/core/common/random.hpp
+++ b/src/core/common/random.hpp
@@ -90,7 +90,7 @@ inline uint16_t GetUint16(void)
  */
 inline uint8_t GetUint8InRange(uint8_t aMin, uint8_t aMax)
 {
-    assert(aMax > aMin);
+    OT_ASSERT(aMax > aMin);
     return (aMin + (GetUint8() % (aMax - aMin)));
 }
 
@@ -106,7 +106,7 @@ inline uint8_t GetUint8InRange(uint8_t aMin, uint8_t aMax)
  */
 inline uint16_t GetUint16InRange(uint16_t aMin, uint16_t aMax)
 {
-    assert(aMax > aMin);
+    OT_ASSERT(aMax > aMin);
     return (aMin + (GetUint16() % (aMax - aMin)));
 }
 
@@ -123,7 +123,7 @@ inline uint16_t GetUint16InRange(uint16_t aMin, uint16_t aMax)
  */
 inline uint32_t GetUint32InRange(uint32_t aMin, uint32_t aMax)
 {
-    assert(aMax > aMin);
+    OT_ASSERT(aMax > aMin);
     return (aMin + (GetUint32() % (aMax - aMin)));
 }
 

--- a/src/core/common/random_manager.cpp
+++ b/src/core/common/random_manager.cpp
@@ -59,7 +59,9 @@ RandomManager::RandomManager(void)
     uint32_t seed;
     otError  error;
 
-    assert(sInitCount < 0xffff);
+    OT_UNUSED_VARIABLE(error);
+
+    OT_ASSERT(sInitCount < 0xffff);
 
     VerifyOrExit(sInitCount == 0);
 
@@ -68,10 +70,10 @@ RandomManager::RandomManager(void)
     sCtrDrbg.Init();
 
     error = Random::Crypto::FillBuffer(reinterpret_cast<uint8_t *>(&seed), sizeof(seed));
-    assert(error == OT_ERROR_NONE);
+    OT_ASSERT(error == OT_ERROR_NONE);
 #else
     error = otPlatEntropyGet(reinterpret_cast<uint8_t *>(&seed), sizeof(seed));
-    assert(error == OT_ERROR_NONE);
+    OT_ASSERT(error == OT_ERROR_NONE);
 #endif
 
     sPrng.Init(seed);
@@ -82,7 +84,7 @@ exit:
 
 RandomManager::~RandomManager(void)
 {
-    assert(sInitCount > 0);
+    OT_ASSERT(sInitCount > 0);
 
     sInitCount--;
     VerifyOrExit(sInitCount == 0);
@@ -98,7 +100,7 @@ exit:
 
 uint32_t RandomManager::NonCryptoGetUint32(void)
 {
-    assert(sInitCount > 0);
+    OT_ASSERT(sInitCount > 0);
 
     return sPrng.GetNext();
 }

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -75,7 +75,7 @@ void TimerMilli::Start(uint32_t aDelay)
 
 void TimerMilli::StartAt(TimeMilli aStartTime, uint32_t aDelay)
 {
-    assert(aDelay <= kMaxDelay);
+    OT_ASSERT(aDelay <= kMaxDelay);
     FireAt(aStartTime + aDelay);
 }
 
@@ -205,7 +205,7 @@ void                           TimerMicro::Start(uint32_t aDelay)
 
 void TimerMicro::StartAt(TimeMicro aStartTime, uint32_t aDelay)
 {
-    assert(aDelay <= kMaxDelay);
+    OT_ASSERT(aDelay <= kMaxDelay);
     FireAt(aStartTime + aDelay);
 }
 

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -59,7 +59,7 @@ otError Tlv::AppendTo(Message &aMessage) const
 {
     uint32_t size = GetSize();
 
-    assert(size <= UINT16_MAX);
+    OT_ASSERT(size <= UINT16_MAX);
 
     return aMessage.Append(this, static_cast<uint16_t>(size));
 }
@@ -262,7 +262,7 @@ otError Tlv::AppendTlv(Message &aMessage, uint8_t aType, const uint8_t *aValue, 
     otError error = OT_ERROR_NONE;
     Tlv     tlv;
 
-    assert(aLength <= Tlv::kBaseTlvMaxLength);
+    OT_ASSERT(aLength <= Tlv::kBaseTlvMaxLength);
 
     tlv.SetType(aType);
     tlv.SetLength(aLength);

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -61,7 +61,7 @@ TrickleTimer::TrickleTimer(Instance &aInstance,
     , mIsRunning(false)
     , mInTransmitPhase(false)
 {
-    assert(aTransmitHandler != NULL);
+    OT_ASSERT(aTransmitHandler != NULL);
 }
 
 otError TrickleTimer::Start(uint32_t aIntervalMin, uint32_t aIntervalMax, Mode aMode)

--- a/src/core/config/openthread-core-default-config.h
+++ b/src/core/config/openthread-core-default-config.h
@@ -301,6 +301,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_ASSERT_ENABLE
+ *
+ * Define as 1 to enable assert function `OT_ASSERT()` within OpenThread code and its libraries.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_ASSERT_ENABLE
+#define OPENTHREAD_CONFIG_ASSERT_ENABLE 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_ENABLE_DEBUG_UART
  *
  * Enable the "Debug Uart" platform feature.

--- a/src/core/crypto/aes_ccm.cpp
+++ b/src/core/crypto/aes_ccm.cpp
@@ -172,7 +172,7 @@ void AesCcm::Header(const void *aHeader, uint32_t aHeaderLength)
 {
     const uint8_t *headerBytes = reinterpret_cast<const uint8_t *>(aHeader);
 
-    assert(mHeaderCur + aHeaderLength <= mHeaderLength);
+    OT_ASSERT(mHeaderCur + aHeaderLength <= mHeaderLength);
 
     // process header
     for (unsigned i = 0; i < aHeaderLength; i++)
@@ -206,7 +206,7 @@ void AesCcm::Payload(void *aPlainText, void *aCipherText, uint32_t aLength, bool
     uint8_t *ciphertextBytes = reinterpret_cast<uint8_t *>(aCipherText);
     uint8_t  byte;
 
-    assert(mPlainTextCur + aLength <= mPlainTextLength);
+    OT_ASSERT(mPlainTextCur + aLength <= mPlainTextLength);
 
     for (unsigned i = 0; i < aLength; i++)
     {
@@ -265,7 +265,7 @@ void AesCcm::Finalize(void *aTag, uint8_t *aTagLength)
 {
     uint8_t *tagBytes = reinterpret_cast<uint8_t *>(aTag);
 
-    assert(mPlainTextCur == mPlainTextLength);
+    OT_ASSERT(mPlainTextCur == mPlainTextLength);
 
     if (mTagLength > 0)
     {

--- a/src/core/crypto/ecdsa.cpp
+++ b/src/core/crypto/ecdsa.cpp
@@ -71,7 +71,7 @@ otError Ecdsa::Sign(uint8_t *      aOutput,
     VerifyOrExit(mbedtls_pk_get_type(&pkCtx) == MBEDTLS_PK_ECKEY, error = OT_ERROR_INVALID_ARGS);
 
     keypair = mbedtls_pk_ec(pkCtx);
-    assert(keypair != NULL);
+    OT_ASSERT(keypair != NULL);
 
     VerifyOrExit(mbedtls_ecdsa_from_keypair(&ctx, keypair) == 0, error = OT_ERROR_FAILED);
 

--- a/src/core/crypto/mbedtls.cpp
+++ b/src/core/crypto/mbedtls.cpp
@@ -154,7 +154,7 @@ otError MbedTls::MapError(int rval)
         break;
 
     default:
-        assert(rval >= 0);
+        OT_ASSERT(rval >= 0);
         break;
     }
 

--- a/src/core/crypto/pbkdf2_cmac.cpp
+++ b/src/core/crypto/pbkdf2_cmac.cpp
@@ -60,7 +60,7 @@ void otPbkdf2Cmac(const uint8_t *aPassword,
     uint16_t     useLen       = 0;
 
     memcpy(prfInput, aSalt, aSaltLen);
-    assert(aIterationCounter % 2 == 0);
+    OT_ASSERT(aIterationCounter % 2 == 0);
     aIterationCounter /= 2;
 
     while (keyLen)

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -277,7 +277,7 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, otError aError
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -965,7 +965,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame, bool aProcessAesCcm)
     }
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 
@@ -1044,7 +1044,7 @@ void Mac::BeginTransmit(void)
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 
@@ -1265,7 +1265,7 @@ void Mac::HandleTransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, otError aError
         break;
 
     case kOperationTransmitPoll:
-        assert(aFrame.IsEmpty() || aFrame.GetAckRequest());
+        OT_ASSERT(aFrame.IsEmpty() || aFrame.GetAckRequest());
 
         if ((aError == OT_ERROR_NONE) && (aAckFrame != NULL))
         {
@@ -1341,7 +1341,7 @@ void Mac::HandleTransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, otError aError
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 
@@ -1382,7 +1382,7 @@ void Mac::HandleTimer(void)
 #endif
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 }

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -73,7 +73,7 @@ void Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
     }
 
     // Source PAN
@@ -97,7 +97,7 @@ void Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
     }
 
     // Security Header
@@ -209,7 +209,7 @@ void Frame::SetDstPanId(PanId aPanId)
 {
     uint8_t index = FindDstPanIdIndex();
 
-    assert(index != kInvalidIndex);
+    OT_ASSERT(index != kInvalidIndex);
     Encoding::LittleEndian::WriteUint16(aPanId, GetPsdu() + index);
 }
 
@@ -246,7 +246,7 @@ exit:
 
 void Frame::SetDstAddr(ShortAddress aShortAddress)
 {
-    assert((GetFrameControlField() & kFcfDstAddrMask) == kFcfDstAddrShort);
+    OT_ASSERT((GetFrameControlField() & kFcfDstAddrMask) == kFcfDstAddrShort);
     Encoding::LittleEndian::WriteUint16(aShortAddress, GetPsdu() + FindDstAddrIndex());
 }
 
@@ -254,8 +254,8 @@ void Frame::SetDstAddr(const ExtAddress &aExtAddress)
 {
     uint8_t index = FindDstAddrIndex();
 
-    assert((GetFrameControlField() & kFcfDstAddrMask) == kFcfDstAddrExt);
-    assert(index != kInvalidIndex);
+    OT_ASSERT((GetFrameControlField() & kFcfDstAddrMask) == kFcfDstAddrExt);
+    OT_ASSERT(index != kInvalidIndex);
 
     aExtAddress.CopyTo(GetPsdu() + index, ExtAddress::kReverseByteOrder);
 }
@@ -273,7 +273,7 @@ void Frame::SetDstAddr(const Address &aAddress)
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 }
@@ -416,8 +416,8 @@ void Frame::SetSrcAddr(ShortAddress aShortAddress)
 {
     uint8_t index = FindSrcAddrIndex();
 
-    assert((GetFrameControlField() & kFcfSrcAddrMask) == kFcfSrcAddrShort);
-    assert(index != kInvalidIndex);
+    OT_ASSERT((GetFrameControlField() & kFcfSrcAddrMask) == kFcfSrcAddrShort);
+    OT_ASSERT(index != kInvalidIndex);
 
     Encoding::LittleEndian::WriteUint16(aShortAddress, GetPsdu() + index);
 }
@@ -426,8 +426,8 @@ void Frame::SetSrcAddr(const ExtAddress &aExtAddress)
 {
     uint8_t index = FindSrcAddrIndex();
 
-    assert((GetFrameControlField() & kFcfSrcAddrMask) == kFcfSrcAddrExt);
-    assert(index != kInvalidIndex);
+    OT_ASSERT((GetFrameControlField() & kFcfSrcAddrMask) == kFcfSrcAddrExt);
+    OT_ASSERT(index != kInvalidIndex);
 
     aExtAddress.CopyTo(GetPsdu() + index, ExtAddress::kReverseByteOrder);
 }
@@ -445,7 +445,7 @@ void Frame::SetSrcAddr(const Address &aAddress)
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 }
@@ -540,7 +540,7 @@ void Frame::SetFrameCounter(uint32_t aFrameCounter)
 {
     uint8_t index = FindSecurityHeaderIndex();
 
-    assert(index != kInvalidIndex);
+    OT_ASSERT(index != kInvalidIndex);
 
     // Security Control
     index += kSecurityControlSize;
@@ -553,7 +553,7 @@ const uint8_t *Frame::GetKeySource(void) const
     uint8_t        index = FindSecurityHeaderIndex();
     const uint8_t *buf   = GetPsdu() + index;
 
-    assert(index != kInvalidIndex);
+    OT_ASSERT(index != kInvalidIndex);
 
     // Security Control
     buf += kSecurityControlSize + kFrameCounterSize;
@@ -593,7 +593,7 @@ void Frame::SetKeySource(const uint8_t *aKeySource)
     uint8_t  index = FindSecurityHeaderIndex();
     uint8_t *buf   = GetPsdu() + index;
 
-    assert(index != kInvalidIndex);
+    OT_ASSERT(index != kInvalidIndex);
 
     keySourceLength = GetKeySourceLength(buf[0] & kKeyIdModeMask);
 
@@ -627,7 +627,7 @@ void Frame::SetKeyId(uint8_t aKeyId)
     uint8_t  index = FindSecurityHeaderIndex();
     uint8_t *buf   = GetPsdu() + index;
 
-    assert(index != kInvalidIndex);
+    OT_ASSERT(index != kInvalidIndex);
 
     keySourceLength = GetKeySourceLength(buf[0] & kKeyIdModeMask);
 
@@ -1026,7 +1026,7 @@ void TxFrame::ProcessTransmitAesCcm(const ExtAddress &aExtAddress)
     tagLength = GetFooterLength() - Frame::kFcsSize;
 
     error = aesCcm.Init(GetHeaderLength(), GetPayloadLength(), tagLength, nonce, sizeof(nonce));
-    assert(error == OT_ERROR_NONE);
+    OT_ASSERT(error == OT_ERROR_NONE);
 
     aesCcm.Header(GetHeader(), GetHeaderLength());
     aesCcm.Payload(GetPayload(), GetPayload(), GetPayloadLength(), true);

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -137,7 +137,7 @@ otError SubMac::Enable(void)
     SetState(kStateSleep);
 
 exit:
-    assert(error == OT_ERROR_NONE);
+    OT_ASSERT(error == OT_ERROR_NONE);
     return error;
 }
 
@@ -270,6 +270,8 @@ void SubMac::BeginTransmit(void)
 {
     otError error;
 
+    OT_UNUSED_VARIABLE(error);
+
     VerifyOrExit(mState == kStateCsmaBackoff);
 
 #if OPENTHREAD_CONFIG_MAC_DISABLE_CSMA_CA_ON_LAST_ATTEMPT
@@ -284,7 +286,7 @@ void SubMac::BeginTransmit(void)
     }
 
     error = Get<Radio>().Receive(mTransmitFrame.GetChannel());
-    assert(error == OT_ERROR_NONE);
+    OT_ASSERT(error == OT_ERROR_NONE);
 
     SetState(kStateTransmit);
 
@@ -294,7 +296,7 @@ void SubMac::BeginTransmit(void)
     }
 
     error = Get<Radio>().Transmit(mTransmitFrame);
-    assert(error == OT_ERROR_NONE);
+    OT_ASSERT(error == OT_ERROR_NONE);
 
 exit:
     return;
@@ -345,7 +347,7 @@ void SubMac::HandleTransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, otError aEr
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         OT_UNREACHABLE_CODE(ExitNow());
     }
 
@@ -418,7 +420,7 @@ otError SubMac::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration)
     else if (ShouldHandleEnergyScan())
     {
         error = Get<Radio>().Receive(aScanChannel);
-        assert(error == OT_ERROR_NONE);
+        OT_ASSERT(error == OT_ERROR_NONE);
 
         SetState(kStateEnergyScan);
         mEnergyScanMaxRssi = kInvalidRssiValue;
@@ -436,7 +438,7 @@ exit:
 
 void SubMac::SampleRssi(void)
 {
-    assert(!RadioSupportsEnergyScan());
+    OT_ASSERT(!RadioSupportsEnergyScan());
 
     int8_t rssi = GetRssi();
 

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -284,7 +284,7 @@ otError Dtls::Setup(bool aClient)
     mbedtls_ssl_conf_min_version(&mConf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
     mbedtls_ssl_conf_max_version(&mConf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
 
-    assert(mCipherSuites[1] == 0);
+    OT_ASSERT(mCipherSuites[1] == 0);
     mbedtls_ssl_conf_ciphersuites(&mConf, mCipherSuites);
     mbedtls_ssl_conf_export_keys_cb(&mConf, HandleMbedtlsExportKeys, this);
     mbedtls_ssl_conf_handshake_timeout(&mConf, 8000, 60000);
@@ -457,11 +457,11 @@ void Dtls::SetCertificate(const uint8_t *aX509Certificate,
                           const uint8_t *aPrivateKey,
                           uint32_t       aPrivateKeyLength)
 {
-    assert(aX509CertLength > 0);
-    assert(aX509Certificate != NULL);
+    OT_ASSERT(aX509CertLength > 0);
+    OT_ASSERT(aX509Certificate != NULL);
 
-    assert(aPrivateKeyLength > 0);
-    assert(aPrivateKey != NULL);
+    OT_ASSERT(aPrivateKeyLength > 0);
+    OT_ASSERT(aPrivateKey != NULL);
 
     mOwnCertSrc       = aX509Certificate;
     mOwnCertLength    = aX509CertLength;
@@ -474,8 +474,8 @@ void Dtls::SetCertificate(const uint8_t *aX509Certificate,
 
 void Dtls::SetCaCertificateChain(const uint8_t *aX509CaCertificateChain, uint32_t aX509CaCertChainLength)
 {
-    assert(aX509CaCertChainLength > 0);
-    assert(aX509CaCertificateChain != NULL);
+    OT_ASSERT(aX509CaCertChainLength > 0);
+    OT_ASSERT(aX509CaCertificateChain != NULL);
 
     mCaChainSrc    = aX509CaCertificateChain;
     mCaChainLength = aX509CaCertChainLength;
@@ -487,10 +487,10 @@ void Dtls::SetCaCertificateChain(const uint8_t *aX509CaCertificateChain, uint32_
 
 void Dtls::SetPreSharedKey(const uint8_t *aPsk, uint16_t aPskLength, const uint8_t *aPskIdentity, uint16_t aPskIdLength)
 {
-    assert(aPsk != NULL);
-    assert(aPskIdentity != NULL);
-    assert(aPskLength > 0);
-    assert(aPskIdLength > 0);
+    OT_ASSERT(aPsk != NULL);
+    OT_ASSERT(aPskIdentity != NULL);
+    OT_ASSERT(aPskLength > 0);
+    OT_ASSERT(aPskIdLength > 0);
 
     mPreSharedKey         = aPsk;
     mPreSharedKeyLength   = aPskLength;
@@ -778,7 +778,7 @@ void Dtls::HandleTimer(void)
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 }

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -458,7 +458,7 @@ exit:
 
 void Joiner::SendJoinerFinalize(void)
 {
-    assert(mFinalizeMessage != NULL);
+    OT_ASSERT(mFinalizeMessage != NULL);
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     LogCertMessage("[THCI] direction=send | type=JOIN_FIN.req |", *mFinalizeMessage);
@@ -595,7 +595,7 @@ void Joiner::HandleTimer(void)
     case OT_JOINER_STATE_IDLE:
     case OT_JOINER_STATE_DISCOVER:
     case OT_JOINER_STATE_CONNECT:
-        assert(false);
+        OT_ASSERT(false);
         break;
 
     case OT_JOINER_STATE_CONNECTED:

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -462,7 +462,7 @@ void JoinerRouter::JoinerEntrustMetadata::ReadFrom(const Message &aMessage)
 {
     uint16_t length = aMessage.GetLength();
 
-    assert(length >= sizeof(*this));
+    OT_ASSERT(length >= sizeof(*this));
     aMessage.Read(length - sizeof(*this), sizeof(*this), this);
 }
 

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -199,7 +199,7 @@ void ChannelMaskTlv::SetChannelMask(uint32_t aChannelMask)
 #if OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
     if (aChannelMask & OT_RADIO_915MHZ_OQPSK_CHANNEL_MASK)
     {
-        assert(entry != NULL);
+        OT_ASSERT(entry != NULL);
         entry->Init();
         entry->SetChannelPage(OT_RADIO_CHANNEL_PAGE_2);
         entry->SetMask(aChannelMask & OT_RADIO_915MHZ_OQPSK_CHANNEL_MASK);
@@ -213,7 +213,7 @@ void ChannelMaskTlv::SetChannelMask(uint32_t aChannelMask)
 #if OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT
     if (aChannelMask & OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MASK)
     {
-        assert(entry != NULL);
+        OT_ASSERT(entry != NULL);
         entry->Init();
         entry->SetChannelPage(OT_RADIO_CHANNEL_PAGE_0);
         entry->SetMask(aChannelMask & OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MASK);

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -363,7 +363,9 @@ Message *Client::FindRelatedQuery(const Header &aResponseHeader, QueryMetadata &
     {
         // Partially read DNS header to obtain message ID only.
         uint16_t count = message->Read(message->GetOffset(), sizeof(messageId), &messageId);
-        assert(count == sizeof(messageId));
+
+        OT_UNUSED_VARIABLE(count);
+        OT_ASSERT(count == sizeof(messageId));
 
         if (HostSwap16(messageId) == aResponseHeader.GetMessageId())
         {

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -91,7 +91,7 @@ public:
     void ReadFrom(const Message &aMessage)
     {
         uint16_t length = aMessage.Read(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
-        assert(length == sizeof(*this));
+        OT_ASSERT(length == sizeof(*this));
         OT_UNUSED_VARIABLE(length);
     }
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -636,6 +636,8 @@ otError Ip6::FragmentDatagram(Message &aMessage, uint8_t aIpProto)
     uint16_t       offset          = 0;
     int            assertValue     = 0;
 
+    OT_UNUSED_VARIABLE(assertValue);
+
     uint16_t maxPayloadFragment =
         FragmentHeader::MakeDivisibleByEight(kMinimalMtu - aMessage.GetOffset() - sizeof(fragmentHeader));
     uint16_t payloadLeft = aMessage.GetLength() - aMessage.GetOffset();
@@ -675,11 +677,11 @@ otError Ip6::FragmentDatagram(Message &aMessage, uint8_t aIpProto)
 
         header.SetPayloadLength(payloadFragment + sizeof(fragmentHeader));
         assertValue = fragment->Write(0, sizeof(header), &header);
-        assert(assertValue == sizeof(header));
+        OT_ASSERT(assertValue == sizeof(header));
 
         SuccessOrExit(error = fragment->SetOffset(aMessage.GetOffset()));
         assertValue = fragment->Write(aMessage.GetOffset(), sizeof(fragmentHeader), &fragmentHeader);
-        assert(assertValue == sizeof(fragmentHeader));
+        OT_ASSERT(assertValue == sizeof(fragmentHeader));
 
         VerifyOrExit(aMessage.CopyTo(aMessage.GetOffset() + FragmentHeader::FragmentOffsetToBytes(offset),
                                      aMessage.GetOffset() + sizeof(fragmentHeader), payloadFragment,
@@ -721,6 +723,8 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
     int            assertValue     = 0;
     bool           isFragmented    = true;
 
+    OT_UNUSED_VARIABLE(assertValue);
+
     VerifyOrExit(aMessage.Read(0, sizeof(header), &header) == sizeof(header), error = OT_ERROR_PARSE);
 
     VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(fragmentHeader), &fragmentHeader) == sizeof(fragmentHeader),
@@ -760,7 +764,7 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
 
         // copying the non-fragmentable header to the fragmentation buffer
         assertValue = aMessage.CopyTo(0, 0, aMessage.GetOffset(), *message);
-        assert(assertValue == aMessage.GetOffset());
+        OT_ASSERT(assertValue == aMessage.GetOffset());
 
         if (!mTimer.IsRunning())
         {
@@ -790,7 +794,7 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
     // copy the fragment payload into the message buffer
     assertValue = aMessage.CopyTo(aMessage.GetOffset() + sizeof(fragmentHeader), aMessage.GetOffset() + offset,
                                   payloadFragment, *message);
-    assert(assertValue == static_cast<int>(payloadFragment));
+    OT_ASSERT(assertValue == static_cast<int>(payloadFragment));
 
     // check if it is the last frame
     if (!fragmentHeader.IsMoreFlagSet())
@@ -806,7 +810,7 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
         header.SetPayloadLength(message->GetLength() - sizeof(header));
         header.SetNextHeader(fragmentHeader.GetNextHeader());
         assertValue = message->Write(0, sizeof(header), &header);
-        assert(assertValue == sizeof(header));
+        OT_ASSERT(assertValue == sizeof(header));
 
         otLogDebgIp6("Reassembly complete.");
 

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -177,7 +177,7 @@ otError Mpl::UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence)
     if (evict->GetLifetime() != 0)
     {
         // no free entries available, look to evict an existing entry
-        assert(curCount != 0);
+        OT_ASSERT(curCount != 0);
 
         if (aSeedId == group->GetSeedId() && insert == NULL)
         {
@@ -210,12 +210,12 @@ otError Mpl::UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence)
 
     if (evict > insert)
     {
-        assert(insert >= mSeedSet);
+        OT_ASSERT(insert >= mSeedSet);
         memmove(insert + 1, insert, static_cast<size_t>(evict - insert) * sizeof(MplSeedEntry));
     }
     else if (evict < insert)
     {
-        assert(evict >= mSeedSet);
+        OT_ASSERT(evict >= mSeedSet);
         memmove(evict, evict + 1, static_cast<size_t>(insert - 1 - evict) * sizeof(MplSeedEntry));
         insert--;
     }

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -281,7 +281,7 @@ public:
     void ReadFrom(const Message &aMessage)
     {
         uint16_t length = aMessage.Read(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
-        assert(length == sizeof(*this));
+        OT_ASSERT(length == sizeof(*this));
         OT_UNUSED_VARIABLE(length);
     }
 
@@ -294,7 +294,7 @@ public:
     static void RemoveFrom(Message &aMessage)
     {
         otError error = aMessage.SetLength(aMessage.GetLength() - sizeof(MplBufferedMessageMetadata));
-        assert(error == OT_ERROR_NONE);
+        OT_ASSERT(error == OT_ERROR_NONE);
         OT_UNUSED_VARIABLE(error);
     }
 

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -177,8 +177,8 @@ otError Netif::UnsubscribeAllNodesMulticast(void)
     //    LinkLocalAllRouters -> RealmLocalAllRouters -> LinkLocalAll
     //         -> RealmLocalAll -> RealmLocalAllMpl.
 
-    assert(prev != static_cast<NetifMulticastAddress *>(
-                       const_cast<otNetifMulticastAddress *>(&kRealmLocalAllRoutersMulticastAddress)));
+    OT_ASSERT(prev != static_cast<NetifMulticastAddress *>(
+                          const_cast<otNetifMulticastAddress *>(&kRealmLocalAllRoutersMulticastAddress)));
 
     if (prev == NULL)
     {
@@ -204,8 +204,8 @@ exit:
 
 otError Netif::SubscribeAllRoutersMulticast(void)
 {
-    otError                error = OT_ERROR_NONE;
-    NetifMulticastAddress *prev;
+    otError                error                      = OT_ERROR_NONE;
+    NetifMulticastAddress *prev                       = NULL;
     NetifMulticastAddress &linkLocalAllRoutersAddress = static_cast<NetifMulticastAddress &>(
         const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
     NetifMulticastAddress &linkLocalAllNodesAddress =
@@ -218,7 +218,7 @@ otError Netif::SubscribeAllRoutersMulticast(void)
     // This method MUST be called after `SubscribeAllNodesMulticast()`
     // Ensure that the `LinkLocalAll` was found on the list.
 
-    assert(error == OT_ERROR_NONE);
+    OT_ASSERT(error == OT_ERROR_NONE);
 
     // The tail of multicast address linked list contains the
     // fixed addresses. We either have a chain of five addresses

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -455,7 +455,7 @@ public:
     void ReadFrom(const Message &aMessage)
     {
         uint16_t length = aMessage.Read(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
-        assert(length == sizeof(*this));
+        OT_ASSERT(length == sizeof(*this));
         OT_UNUSED_VARIABLE(length);
     }
 

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -371,7 +371,7 @@ void Udp::HandlePayload(Message &aMessage, MessageInfo &aMessageInfo)
         }
 
         aMessage.RemoveHeader(aMessage.GetOffset());
-        assert(aMessage.GetOffset() == 0);
+        OT_ASSERT(aMessage.GetOffset() == 0);
         socket->HandleUdpReceive(aMessage, aMessageInfo);
         break;
     }

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -100,7 +100,7 @@ void AnnounceSenderBase::HandleTimer(void)
         error    = mChannelMask.GetNextChannel(mChannel);
     }
 
-    assert(error == OT_ERROR_NONE);
+    OT_ASSERT(error == OT_ERROR_NONE);
 
     Get<Mle::MleRouter>().SendAnnounce(mChannel, false);
 

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -344,7 +344,7 @@ otError IndirectSender::PrepareFrameForChild(Mac::TxFrame &aFrame, FrameContext 
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 
@@ -466,7 +466,7 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -197,10 +197,12 @@ public:
         otError error = OT_ERROR_NONE;
         int     rval;
 
+        OT_UNUSED_VARIABLE(rval);
+
         VerifyOrExit(CanWrite(aLength), error = OT_ERROR_NO_BUFS);
 
         rval = aMessage.Read(aMessage.GetOffset(), aLength, mWritePointer);
-        assert(rval == aLength);
+        OT_ASSERT(rval == aLength);
 
         mWritePointer += aLength;
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -327,7 +327,7 @@ otError MeshForwarder::UpdateIp6Route(Message &aMessage)
 #if OPENTHREAD_FTD
         error = UpdateIp6RouteFtd(ip6Header);
 #else
-        assert(false);
+        OT_ASSERT(false);
 #endif
     }
 
@@ -461,7 +461,7 @@ otError MeshForwarder::HandleFrameRequest(Mac::TxFrame &aFrame)
             ExitNow();
         }
 
-        assert(aFrame.GetLength() != 7);
+        OT_ASSERT(aFrame.GetLength() != 7);
         break;
 
 #if OPENTHREAD_FTD
@@ -691,6 +691,8 @@ start:
         Mac::Address         meshSource, meshDest;
         otError              error;
 
+        OT_UNUSED_VARIABLE(error);
+
         if (aAddMeshHeader)
         {
             meshSource.SetShort(aMeshSource);
@@ -703,7 +705,7 @@ start:
         }
 
         error = Get<Lowpan::Lowpan>().Compress(aMessage, meshSource, meshDest, buffer);
-        assert(error == OT_ERROR_NONE);
+        OT_ASSERT(error == OT_ERROR_NONE);
 
         hcLength = static_cast<uint8_t>(buffer.GetWritePointer() - payload);
         headerLength += hcLength;
@@ -828,8 +830,8 @@ void MeshForwarder::HandleSentFrame(Mac::TxFrame &aFrame, otError aError)
     Neighbor *   neighbor = NULL;
     Mac::Address macDest;
 
-    assert((aError == OT_ERROR_NONE) || (aError == OT_ERROR_CHANNEL_ACCESS_FAILURE) || (aError == OT_ERROR_ABORT) ||
-           (aError == OT_ERROR_NO_ACK));
+    OT_ASSERT((aError == OT_ERROR_NONE) || (aError == OT_ERROR_CHANNEL_ACCESS_FAILURE) || (aError == OT_ERROR_ABORT) ||
+              (aError == OT_ERROR_NO_ACK));
 
     mSendBusy = false;
 
@@ -842,7 +844,7 @@ void MeshForwarder::HandleSentFrame(Mac::TxFrame &aFrame, otError aError)
     }
 
     VerifyOrExit(mSendMessage != NULL);
-    assert(mSendMessage->GetDirectTransmission());
+    OT_ASSERT(mSendMessage->GetDirectTransmission());
 
     if (aError != OT_ERROR_NONE)
     {
@@ -977,7 +979,7 @@ exit:
 
 void MeshForwarder::HandleDiscoverComplete(void)
 {
-    assert(mScanning);
+    OT_ASSERT(mScanning);
 
     Get<Mac::Mac>().ClearTemporaryChannel();
     Get<Mac::Mac>().SetPanId(mRestorePanId);

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -126,7 +126,7 @@ otError MeshForwarder::SendMessage(Message &aMessage)
     case Message::kTypeSupervision:
     {
         Child *child = Get<Utils::ChildSupervisor>().GetDestination(aMessage);
-        assert((child != NULL) && !child->IsRxOnWhenIdle());
+        OT_ASSERT((child != NULL) && !child->IsRxOnWhenIdle());
         mIndirectSender.AddMessageForSleepyChild(aMessage, *child);
         break;
     }
@@ -328,7 +328,7 @@ void MeshForwarder::SendMesh(Message &aMessage, Mac::TxFrame &aFrame)
     aFrame.SetSrcAddr(mMacSource.GetShort());
 
     // write payload
-    assert(aMessage.GetLength() <= aFrame.GetMaxPayloadLength());
+    OT_ASSERT(aMessage.GetLength() <= aFrame.GetMaxPayloadLength());
     aMessage.Read(0, aMessage.GetLength(), aFrame.GetPayload());
     aFrame.SetPayloadLength(aMessage.GetLength());
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1678,7 +1678,7 @@ void Mle::HandleAttachTimer(void)
     switch (mAttachState)
     {
     case kAttachStateIdle:
-        assert(false);
+        OT_ASSERT(false);
         break;
 
     case kAttachStateProcessAnnounce:
@@ -2296,7 +2296,7 @@ otError Mle::SendChildUpdateRequest(void)
     case OT_DEVICE_ROLE_DISABLED:
     case OT_DEVICE_ROLE_ROUTER:
     case OT_DEVICE_ROLE_LEADER:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 
@@ -2508,7 +2508,7 @@ otError Mle::SendMessage(Message &aMessage, const Ip6::Address &aDestination)
         aesCcm.SetKey(Get<KeyManager>().GetCurrentMleKey(), 16);
         error = aesCcm.Init(16 + 16 + header.GetHeaderLength(), aMessage.GetLength() - (header.GetLength() - 1),
                             sizeof(tag), nonce, sizeof(nonce));
-        assert(error == OT_ERROR_NONE);
+        OT_ASSERT(error == OT_ERROR_NONE);
 
         aesCcm.Header(&mLinkLocal64.GetAddress(), sizeof(mLinkLocal64.GetAddress()));
         aesCcm.Header(&aDestination, sizeof(aDestination));
@@ -3602,7 +3602,7 @@ otError Mle::HandleChildUpdateResponse(const Message &         aMessage,
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 
@@ -3681,7 +3681,7 @@ otError Mle::HandleChildUpdateResponse(const Message &         aMessage,
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 
@@ -3782,7 +3782,7 @@ void Mle::ProcessAnnounce(void)
     uint8_t  newChannel = mAlternateChannel;
     uint16_t newPanId   = mAlternatePanId;
 
-    assert(mAttachState == kAttachStateProcessAnnounce);
+    OT_ASSERT(mAttachState == kAttachStateProcessAnnounce);
 
     otLogNoteMle("Processing Announce - channel %d, panid 0x%02x", newChannel, newPanId);
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -407,7 +407,7 @@ public:
     void ReadFrom(const Message &aMessage)
     {
         uint16_t length = aMessage.Read(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
-        assert(length == sizeof(*this));
+        OT_ASSERT(length == sizeof(*this));
         OT_UNUSED_VARIABLE(length);
     }
 
@@ -420,7 +420,7 @@ public:
     static void RemoveFrom(Message &aMessage)
     {
         otError error = aMessage.SetLength(aMessage.GetLength() - sizeof(DelayedResponseHeader));
-        assert(error == OT_ERROR_NONE);
+        OT_ASSERT(error == OT_ERROR_NONE);
         OT_UNUSED_VARIABLE(error);
     }
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -159,7 +159,7 @@ otError MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 
@@ -189,7 +189,7 @@ otError MleRouter::BecomeLeader(void)
     SetLeaderData(partitionId, mLeaderWeight, leaderId);
 
     router = mRouterTable.Allocate(leaderId);
-    assert(router != NULL);
+    OT_ASSERT(router != NULL);
 
     SetRouterId(leaderId);
     router->SetExtAddress(Get<Mac::Mac>().GetExtAddress());
@@ -433,7 +433,7 @@ otError MleRouter::SendAdvertisement(void)
     {
     case OT_DEVICE_ROLE_DISABLED:
     case OT_DEVICE_ROLE_DETACHED:
-        assert(false);
+        OT_ASSERT(false);
         break;
 
     case OT_DEVICE_ROLE_CHILD:
@@ -480,7 +480,7 @@ otError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
     switch (mRole)
     {
     case OT_DEVICE_ROLE_DISABLED:
-        assert(false);
+        OT_ASSERT(false);
         break;
 
     case OT_DEVICE_ROLE_DETACHED:
@@ -894,7 +894,7 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
     switch (mRole)
     {
     case OT_DEVICE_ROLE_DISABLED:
-        assert(false);
+        OT_ASSERT(false);
         break;
 
     case OT_DEVICE_ROLE_DETACHED:
@@ -1611,7 +1611,7 @@ otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::Messa
 
     // 3. Its current routing path cost to the Leader is infinite.
     leader = mRouterTable.GetLeader();
-    assert(leader != NULL);
+    OT_ASSERT(leader != NULL);
 
     VerifyOrExit(mRole == OT_DEVICE_ROLE_LEADER || GetLinkCost(GetLeaderId()) < kMaxRouteCost ||
                      (mRole == OT_DEVICE_ROLE_CHILD && leader->GetCost() + 1 < kMaxRouteCost) ||
@@ -1728,7 +1728,7 @@ void MleRouter::HandleStateUpdateTimer(void)
     switch (mRole)
     {
     case OT_DEVICE_ROLE_DISABLED:
-        assert(false);
+        OT_ASSERT(false);
         break;
 
     case OT_DEVICE_ROLE_DETACHED:
@@ -1812,7 +1812,7 @@ void MleRouter::HandleStateUpdateTimer(void)
 
         case Neighbor::kStateParentResponse:
         case Neighbor::kStateLinkRequest:
-            assert(false);
+            OT_ASSERT(false);
             break;
         }
 
@@ -2227,7 +2227,7 @@ otError MleRouter::HandleChildIdRequest(const Message &         aMessage,
     {
     case OT_DEVICE_ROLE_DISABLED:
     case OT_DEVICE_ROLE_DETACHED:
-        assert(false);
+        OT_ASSERT(false);
         break;
 
     case OT_DEVICE_ROLE_CHILD:
@@ -4034,7 +4034,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
     router->SetCost(0);
 
     leader = mRouterTable.GetLeader();
-    assert(leader != NULL);
+    OT_ASSERT(leader != NULL);
 
     if (leader != router)
     {
@@ -4681,6 +4681,8 @@ void MleRouter::Signal(otNeighborTableEvent aEvent, Neighbor &aNeighbor)
         otNeighborTableEntryInfo info;
         otError                  error;
 
+        OT_UNUSED_VARIABLE(error);
+
         info.mInstance = &GetInstance();
 
         switch (aEvent)
@@ -4688,7 +4690,7 @@ void MleRouter::Signal(otNeighborTableEvent aEvent, Neighbor &aNeighbor)
         case OT_NEIGHBOR_TABLE_EVENT_CHILD_ADDED:
         case OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED:
             error = GetChildInfo(static_cast<Child &>(aNeighbor), info.mInfo.mChild);
-            assert(error == OT_ERROR_NONE);
+            OT_ASSERT(error == OT_ERROR_NONE);
             break;
 
         case OT_NEIGHBOR_TABLE_EVENT_ROUTER_ADDED:

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -64,7 +64,7 @@ otError NetworkData::GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aData
 {
     otError error = OT_ERROR_NONE;
 
-    assert(aData != NULL);
+    OT_ASSERT(aData != NULL);
     VerifyOrExit(aDataLength >= mLength, error = OT_ERROR_NO_BUFS);
 
     memcpy(aData, mTlvs, mLength);
@@ -959,14 +959,14 @@ exit:
 
 void NetworkData::Insert(uint8_t *aStart, uint8_t aLength)
 {
-    assert(aLength + mLength <= sizeof(mTlvs) && mTlvs <= aStart && aStart <= mTlvs + mLength);
+    OT_ASSERT(aLength + mLength <= sizeof(mTlvs) && mTlvs <= aStart && aStart <= mTlvs + mLength);
     memmove(aStart + aLength, aStart, mLength - static_cast<size_t>(aStart - mTlvs));
     mLength += aLength;
 }
 
 void NetworkData::Remove(uint8_t *aStart, uint8_t aLength)
 {
-    assert(aLength <= mLength && mTlvs <= aStart && (aStart - mTlvs) + aLength <= mLength);
+    OT_ASSERT(aLength <= mLength && mTlvs <= aStart && (aStart - mTlvs) + aLength <= mLength);
     memmove(aStart, aStart + aLength, mLength - (static_cast<size_t>(aStart - mTlvs) + aLength));
     mLength -= aLength;
 }

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -191,7 +191,7 @@ void Local::UpdateRloc(PrefixTlv &aPrefix)
             break;
 
         default:
-            assert(false);
+            OT_ASSERT(false);
             break;
         }
     }
@@ -300,7 +300,7 @@ void Local::UpdateRloc(ServiceTlv &aService)
             break;
 
         default:
-            assert(false);
+            OT_ASSERT(false);
             break;
         }
     }
@@ -340,7 +340,7 @@ void Local::UpdateRloc(void)
 #endif
 
         default:
-            assert(false);
+            OT_ASSERT(false);
             break;
         }
     }

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -221,8 +221,8 @@ public:
      */
     void SetPreference(int8_t aPrf)
     {
-        assert((aPrf == OT_ROUTE_PREFERENCE_LOW) || (aPrf == OT_ROUTE_PREFERENCE_MED) ||
-               (aPrf == OT_ROUTE_PREFERENCE_HIGH));
+        OT_ASSERT((aPrf == OT_ROUTE_PREFERENCE_LOW) || (aPrf == OT_ROUTE_PREFERENCE_MED) ||
+                  (aPrf == OT_ROUTE_PREFERENCE_HIGH));
         mFlags = (mFlags & ~kPreferenceMask) | ((static_cast<uint8_t>(aPrf) << kPreferenceOffset) & kPreferenceMask);
     }
 

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -235,7 +235,7 @@ Router *RouterTable::Allocate(void)
         if (freeBit == 0)
         {
             rval = Allocate(routerId);
-            assert(rval != NULL);
+            OT_ASSERT(rval != NULL);
             ExitNow();
         }
 
@@ -274,7 +274,7 @@ otError RouterTable::Release(uint8_t aRouterId)
     otError  error  = OT_ERROR_NONE;
     uint16_t rloc16 = Mle::Mle::Rloc16FromRouterId(aRouterId);
 
-    assert(aRouterId <= Mle::kMaxRouterId);
+    OT_ASSERT(aRouterId <= Mle::kMaxRouterId);
 
     VerifyOrExit(Get<Mle::MleRouter>().GetRole() == OT_DEVICE_ROLE_LEADER, error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(IsAllocated(aRouterId), error = OT_ERROR_NOT_FOUND);
@@ -526,7 +526,7 @@ void RouterTable::ProcessTlv(const Mle::RouteTlv &aTlv)
         {
             Router *router = GetRouter(routerId);
 
-            assert(router != NULL);
+            OT_ASSERT(router != NULL);
             router->SetNextHop(Mle::kInvalidRouterId);
             RemoveNeighbor(*router);
 

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -254,7 +254,7 @@ void TimeSync::CheckAndHandleChanges(bool aTimeUpdated)
         else
         {
             // Schedule a check 1 millisecond after two periods of time
-            assert(resyncNeededThresholdMs >= timeSyncLastSyncMs);
+            OT_ASSERT(resyncNeededThresholdMs >= timeSyncLastSyncMs);
             mTimer.Start(resyncNeededThresholdMs - timeSyncLastSyncMs + 1);
             otLogInfoCore("Time sync status SYNCHRONIZED");
         }

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -151,7 +151,7 @@ void ChannelMonitor::HandleEnergyScanResult(Mac::EnergyScanResult *aResult)
         uint32_t newValue     = 0;
         uint32_t weight;
 
-        assert(channelIndex < kNumChannels);
+        OT_ASSERT(channelIndex < kNumChannels);
 
         otLogDebgUtil("ChannelMonitor: channel: %d, rssi:%d", aResult->mChannel, aResult->mMaxRssi);
 

--- a/src/lib/hdlc/hdlc.hpp
+++ b/src/lib/hdlc/hdlc.hpp
@@ -365,7 +365,7 @@ public:
     {
         otError error = OT_ERROR_NONE;
 
-        assert(aFrame == NULL || (mBuffer <= aFrame && aFrame < OT_ARRAY_END(mBuffer)));
+        OT_ASSERT(aFrame == NULL || (mBuffer <= aFrame && aFrame < OT_ARRAY_END(mBuffer)));
 
         aFrame = (aFrame == NULL) ? mBuffer : aFrame + aLength;
 

--- a/src/lib/spinel/spinel_buffer.cpp
+++ b/src/lib/spinel/spinel_buffer.cpp
@@ -152,7 +152,7 @@ uint8_t *Buffer::GetUpdatedBufPtr(uint8_t *aBufPtr, uint16_t aOffset, Direction 
         break;
 
     case kUnknown:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 
@@ -195,7 +195,7 @@ uint16_t Buffer::GetDistance(const uint8_t *aStartPtr, const uint8_t *aEndPtr, D
         break;
 
     case kUnknown:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 
@@ -226,7 +226,7 @@ otError Buffer::InFrameAppend(uint8_t aByte)
     otError  error = OT_ERROR_NONE;
     uint8_t *newTail;
 
-    assert(mWriteDirection != kUnknown);
+    OT_ASSERT(mWriteDirection != kUnknown);
 
     newTail = GetUpdatedBufPtr(mWriteSegmentTail, 1, mWriteDirection);
 
@@ -844,7 +844,7 @@ otError Buffer::OutFrameRemove(void)
 
         // If this assert fails, it is a likely indicator that the internal structure of the NCP buffer has been
         // corrupted.
-        assert(numSegments <= kMaxSegments);
+        OT_ASSERT(numSegments <= kMaxSegments);
     }
 
     mReadFrameStart[mReadDirection] = bufPtr;
@@ -947,7 +947,7 @@ uint16_t Buffer::OutFrameGetLength(void)
 
         // If this assert fails, it is a likely indicator that the internal structure of the NCP buffer has been
         // corrupted.
-        assert(numSegments <= kMaxSegments);
+        OT_ASSERT(numSegments <= kMaxSegments);
     }
 
     // Remember the calculated frame length for current active frame.

--- a/src/ncp/example_vendor_hook.cpp
+++ b/src/ncp/example_vendor_hook.cpp
@@ -149,7 +149,7 @@ extern "C" void otNcpInit(otInstance *aInstance)
 
     if (ncpVendor == NULL || ncpVendor != ot::Ncp::NcpBase::GetNcpInstance())
     {
-        assert(false);
+        // assert(false);
     }
 }
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -250,7 +250,7 @@ NcpBase::NcpBase(Instance *aInstance)
     , mDidInitialUpdates(false)
     , mLogTimestampBase(0)
 {
-    assert(mInstance != NULL);
+    OT_ASSERT(mInstance != NULL);
 
     sNcpInstance = this;
 
@@ -1030,7 +1030,7 @@ otError NcpBase::HandleCommandPropertyInsertRemove(uint8_t aHeader, spinel_prop_
         break;
 
     default:
-        assert(false);
+        OT_ASSERT(false);
         break;
     }
 
@@ -2181,10 +2181,10 @@ exit:
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_DEBUG_TEST_ASSERT>(void)
 {
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    assert(false);
+    OT_ASSERT(false);
 #endif
 
-    // We only get to this point if `assert(false)`
+    // We only get to this point if `OT_ASSERT(false)`
     // does not cause an NCP reset on the platform.
     // In such a case we return `false` as the
     // property value to indicate this.

--- a/src/ncp/ncp_base_dispatcher.cpp
+++ b/src/ncp/ncp_base_dispatcher.cpp
@@ -629,7 +629,7 @@ NcpBase::PropertyHandler NcpBase::FindPropertyHandler(const HandlerEntry *aHandl
 {
     size_t l = 0;
 
-    assert(aSize > 0);
+    OT_ASSERT(aSize > 0);
 
     for (size_t r = aSize - 1; l < r;)
     {

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -2401,8 +2401,6 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_CNTR_ALL_MAC_COUNTERS
     otError              error    = OT_ERROR_NONE;
     const otMacCounters *counters = otLinkGetCounters(mInstance);
 
-    assert(counters != NULL);
-
     // Encode Tx related counters
     SuccessOrExit(error = mEncoder.OpenStruct());
     SuccessOrExit(error = mEncoder.WriteUint32(counters->mTxTotal));
@@ -2461,7 +2459,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_CNTR_MLE_COUNTERS>(vo
     otError              error    = OT_ERROR_NONE;
     const otMleCounters *counters = otThreadGetMleCounters(mInstance);
 
-    assert(counters != NULL);
+    OT_ASSERT(counters != NULL);
 
     SuccessOrExit(error = mEncoder.WriteUint16(counters->mDisabledRole));
     SuccessOrExit(error = mEncoder.WriteUint16(counters->mDetachedRole));
@@ -2489,7 +2487,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_CNTR_ALL_IP_COUNTERS>
     otError             error    = OT_ERROR_NONE;
     const otIpCounters *counters = otThreadGetIp6Counters(mInstance);
 
-    assert(counters != NULL);
+    OT_ASSERT(counters != NULL);
 
     // Encode Tx related counters
     SuccessOrExit(error = mEncoder.OpenStruct());
@@ -2519,8 +2517,8 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_CNTR_MAC_RETRY_HISTOG
     histogramDirect   = otLinkGetTxDirectRetrySuccessHistogram(mInstance, &histogramDirectEntries);
     histogramIndirect = otLinkGetTxIndirectRetrySuccessHistogram(mInstance, &histogramIndirectEntries);
 
-    assert((histogramDirectEntries == 0) || (histogramDirect != NULL));
-    assert((histogramIndirectEntries == 0) || (histogramIndirect != NULL));
+    OT_ASSERT((histogramDirectEntries == 0) || (histogramDirect != NULL));
+    OT_ASSERT((histogramIndirectEntries == 0) || (histogramIndirect != NULL));
 
     // Encode direct message retries histogram
     SuccessOrExit(error = mEncoder.OpenStruct());

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -71,7 +71,7 @@ extern "C" void otNcpInit(otInstance *aInstance)
 
     if (ncpSpi == NULL || ncpSpi != NcpBase::GetNcpInstance())
     {
-        assert(false);
+        OT_ASSERT(false);
     }
 }
 
@@ -269,14 +269,14 @@ void NcpSpi::PrepareNextSpiSendFrame(void)
     SuccessOrExit(error = mTxFrameBuffer.OutFrameBegin());
 
     frameLength = mTxFrameBuffer.OutFrameGetLength();
-    assert(frameLength <= kSpiBufferSize - kSpiHeaderSize);
+    OT_ASSERT(frameLength <= kSpiBufferSize - kSpiHeaderSize);
 
     // The "accept length" in `mSendFrame` is already updated based
     // on current state of receive. It is changed either from the
     // `SpiTransactionComplete()` callback or from `HandleRxFrame()`.
 
     readLength = mTxFrameBuffer.OutFrameRead(frameLength, sendFrame.GetData());
-    assert(readLength == frameLength);
+    OT_ASSERT(readLength == frameLength);
 
     sendFrame.SetHeaderDataLen(frameLength);
     mSendFrameLength = frameLength + kSpiHeaderSize;

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -75,7 +75,7 @@ extern "C" void otNcpInit(otInstance *aInstance)
 
     if (ncpUart == NULL || ncpUart != NcpBase::GetNcpInstance())
     {
-        assert(false);
+        OT_ASSERT(false);
     }
 }
 
@@ -208,7 +208,7 @@ exit:
     {
         if (otPlatUartSend(mUartBuffer.GetFrame(), len) != OT_ERROR_NONE)
         {
-            assert(false);
+            OT_ASSERT(false);
         }
     }
 }
@@ -334,7 +334,7 @@ otError NcpUart::Spinel::BufferEncrypterReader::OutFrameBegin(void)
 
         if (mOutputDataLength > 0)
         {
-            assert(mOutputDataLength <= sizeof(mDataBuffer));
+            OT_ASSERT(mOutputDataLength <= sizeof(mDataBuffer));
             mTxFrameBuffer.OutFrameRead(mOutputDataLength, mDataBuffer);
 
             if (!SpinelEncrypter::EncryptOutbound(mDataBuffer, sizeof(mDataBuffer), &mOutputDataLength))


### PR DESCRIPTION
This PR contains two related commits:

**[debug] adding OT_ASSERT() macro**

This commit adds a new OpenThread specific `OT_ASSERT()` macro
along with a new config OPENTHREAD_CONFIG_ASSERT_ENABLE option which
allows the assert to be enabled or disabled. This allows a release
build to consider disabling the assert reducing code size.

**[travis] add new simul platform build with asserts disabled**
