### PR TITLE
[nrf528xx] Separate transport from platform

### DIFF
--- a/examples/Makefile-nrf52811
+++ b/examples/Makefile-nrf52811
@@ -60,7 +60,6 @@ NRF52811_MBEDTLS_CPPFLAGS += -DMBEDTLS_USER_CONFIG_FILE='\"nrf52811-mbedtls-conf
 NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls
 NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include
 NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include/mbedtls
-NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/NordicSemiconductor/libraries/crypto
 NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/NordicSemiconductor/libraries/nrf_security/mbedtls_plat_config
 NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/NordicSemiconductor/nrfx/mdk
 NRF52811_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/NordicSemiconductor/cmsis

--- a/examples/Makefile-nrf52833
+++ b/examples/Makefile-nrf52833
@@ -61,7 +61,6 @@ NRF52833_MBEDTLS_CPPFLAGS += -DMBEDTLS_USER_CONFIG_FILE='\"nrf52833-mbedtls-conf
 NRF52833_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls
 NRF52833_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include
 NRF52833_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include/mbedtls
-NRF52833_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/NordicSemiconductor/libraries/crypto
 NRF52833_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/NordicSemiconductor/libraries/nrf_security/mbedtls_plat_config
 NRF52833_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/NordicSemiconductor/nrfx/mdk
 NRF52833_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/NordicSemiconductor/cmsis

--- a/examples/platforms/nrf528xx/Makefile.am
+++ b/examples/platforms/nrf528xx/Makefile.am
@@ -27,7 +27,7 @@
 #
 
 # Use automake includes since we cannot use SUBDIRS feature due to  cleanup
-# errors - few targets may use the same source file but dependency file is 
+# errors - few targets may use the same source file but dependency file is
 # created only once which leads to errors when auto-generated Makefile tries
 # to remove .Po files that were already removed
 

--- a/examples/platforms/nrf528xx/nrf52811/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52811/Makefile.am
@@ -31,6 +31,7 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 lib_LIBRARIES                                                                                              = \
     libopenthread-nrf52811.a                                                                                 \
     libopenthread-nrf52811-sdk.a                                                                             \
+    libopenthread-nrf52811-transport.a                                                                       \
     $(NULL)
 
 # Do not enable -pedantic-errors for nRF52811 driver library
@@ -49,6 +50,7 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/include                                                                                  \
     -I$(top_srcdir)/examples/platforms                                                                       \
     -I$(top_srcdir)/examples/platforms/nrf528xx/src                                                          \
+    -I$(top_srcdir)/examples/platforms/nrf528xx/src/transport                                                    \
     -I$(top_srcdir)/src/core                                                                                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio                                            \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/hal                                        \
@@ -107,10 +109,14 @@ PLATFORM_COMMON_SOURCES                                                         
     src/logging.c                                                                                            \
     src/misc.c                                                                                               \
     src/radio.c                                                                                              \
-    src/spi-slave.c                                                                                          \
     src/system.c                                                                                             \
     src/temp.c                                                                                               \
-    src/uart.c                                                                                               \
+    $(NULL)
+
+TRANSPORT_SOURCES                                                                                          = \
+    src/transport/spi-slave.c                                                                                    \
+    src/transport/uart.c                                                                                         \
+    src/transport/transport.c                                                                                    \
     $(NULL)
 
 SINGLEPHY_SOURCES                                                                                          = \
@@ -145,6 +151,14 @@ libopenthread_nrf52811_sdk_a_SOURCES                                            
     $(SINGLEPHY_SOURCES)                                                                                     \
     $(NULL)
 
+libopenthread_nrf52811_transport_a_CPPFLAGS                                                                = \
+    $(COMMONCPPFLAGS)                                                                                        \
+    $(NULL)
+
+libopenthread_nrf52811_transport_a_SOURCES                                                                 = \
+    $(TRANSPORT_SOURCES)                                                                                     \
+    $(NULL)
+
 Dash                                                                                                       = -
 
 libopenthread_nrf52811_a_LIBADD                                                                            = \
@@ -152,6 +166,9 @@ libopenthread_nrf52811_a_LIBADD                                                 
     $(shell find $(top_builddir)/third_party/jlink/SEGGER_RTT_V640/RTT $(Dash)type f $(Dash)name "*.o")
 
 libopenthread_nrf52811_sdk_a_LIBADD                                                                        = \
+    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+
+libopenthread_nrf52811_transport_a_LIBADD                                                                  = \
     $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/nrf528xx/nrf52811/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52811/Makefile.am
@@ -50,10 +50,9 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/include                                                                                  \
     -I$(top_srcdir)/examples/platforms                                                                       \
     -I$(top_srcdir)/examples/platforms/nrf528xx/src                                                          \
-    -I$(top_srcdir)/examples/platforms/nrf528xx/src/transport                                                    \
+    -I$(top_srcdir)/examples/platforms/nrf528xx/src/transport                                                \
     -I$(top_srcdir)/src/core                                                                                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio                                            \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/hal                                        \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features                               \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/fem/three_pin_gpio                         \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features/ack_generator                 \
@@ -114,9 +113,9 @@ PLATFORM_COMMON_SOURCES                                                         
     $(NULL)
 
 TRANSPORT_SOURCES                                                                                          = \
-    src/transport/spi-slave.c                                                                                    \
-    src/transport/uart.c                                                                                         \
-    src/transport/transport.c                                                                                    \
+    src/transport/spi-slave.c                                                                                \
+    src/transport/uart.c                                                                                     \
+    src/transport/transport.c                                                                                \
     $(NULL)
 
 SINGLEPHY_SOURCES                                                                                          = \

--- a/examples/platforms/nrf528xx/nrf52811/Makefile.platform.am
+++ b/examples/platforms/nrf528xx/nrf52811/Makefile.platform.am
@@ -34,6 +34,7 @@ LDADD_COMMON                                                                    
     $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52811.a                        \
     $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52811-sdk.a                \
     $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52811-radio-driver.a       \
+    $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52811-transport.a              \
     $(NULL)
 
 if OPENTHREAD_ENABLE_CUSTOM_LINKER_FILE

--- a/examples/platforms/nrf528xx/nrf52811/Makefile.platform.am
+++ b/examples/platforms/nrf528xx/nrf52811/Makefile.platform.am
@@ -32,9 +32,9 @@
 
 LDADD_COMMON                                                                                 += \
     $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52811.a                        \
+    $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52811-transport.a              \
     $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52811-sdk.a                \
     $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52811-radio-driver.a       \
-    $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52811-transport.a              \
     $(NULL)
 
 if OPENTHREAD_ENABLE_CUSTOM_LINKER_FILE

--- a/examples/platforms/nrf528xx/nrf52833/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52833/Makefile.am
@@ -32,6 +32,7 @@ lib_LIBRARIES                                                                   
     libopenthread-nrf52833.a                                                                                 \
     libopenthread-nrf52833-sdk.a                                                                             \
     libopenthread-nrf52833-softdevice-sdk.a                                                                  \
+    libopenthread-nrf52833-transport.a                                                                       \
     $(NULL)
 
 # Do not enable -pedantic-errors for nRF52833 driver library
@@ -50,6 +51,7 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/include                                                                                  \
     -I$(top_srcdir)/examples/platforms                                                                       \
     -I$(top_srcdir)/examples/platforms/nrf528xx/src                                                          \
+    -I$(top_srcdir)/examples/platforms/nrf528xx/src/transport                                                \
     -I$(top_srcdir)/src/core                                                                                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio                                            \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/fem/three_pin_gpio                         \
@@ -116,11 +118,15 @@ PLATFORM_COMMON_SOURCES                                                         
     src/logging.c                                                                                            \
     src/misc.c                                                                                               \
     src/radio.c                                                                                              \
-    src/temp.c                                                                                               \
-    src/spi-slave.c                                                                                          \
     src/system.c                                                                                             \
-    src/uart.c                                                                                               \
-    src/usb-cdc-uart.c                                                                                       \
+    src/temp.c                                                                                               \
+    $(NULL)
+
+TRANSPORT_SOURCES                                                                                          = \
+    src/transport/spi-slave.c                                                                                \
+    src/transport/uart.c                                                                                     \
+    src/transport/usb-cdc-uart.c                                                                             \
+    src/transport/transport.c                                                                                \
     $(NULL)
 
 SINGLEPHY_SOURCES                                                                                          = \
@@ -171,6 +177,14 @@ libopenthread_nrf52833_softdevice_sdk_a_SOURCES                                 
     $(SOFTDEVICE_SOURCES)                                                                                    \
     $(NULL)
 
+libopenthread_nrf52833_transport_a_CPPFLAGS                                                                = \
+    $(COMMONCPPFLAGS)                                                                                        \
+    $(NULL)
+
+libopenthread_nrf52833_transport_a_SOURCES                                                                 = \
+    $(TRANSPORT_SOURCES)                                                                                     \
+    $(NULL)
+
 Dash                                                                                                       = -
 
 libopenthread_nrf52833_a_LIBADD                                                                            = \
@@ -181,6 +195,9 @@ libopenthread_nrf52833_sdk_a_LIBADD                                             
     $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
 
 libopenthread_nrf52833_softdevice_sdk_a_LIBADD                                                             = \
+    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+
+libopenthread_nrf52833_transport_a_LIBADD                                                                  = \
     $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/nrf528xx/nrf52833/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52833/Makefile.am
@@ -55,7 +55,6 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/src/core                                                                                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio                                            \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/fem/three_pin_gpio                         \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/hal                                        \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features                               \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features/ack_generator                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch                                       \

--- a/examples/platforms/nrf528xx/nrf52833/Makefile.platform.am
+++ b/examples/platforms/nrf528xx/nrf52833/Makefile.platform.am
@@ -34,6 +34,7 @@ LDADD_COMMON                                                                    
     $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52833.a                        \
     $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52833-sdk.a                \
     $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52833-radio-driver.a       \
+    $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52833-transport.a              \
     $(NULL)
 
 if OPENTHREAD_ENABLE_CUSTOM_LINKER_FILE

--- a/examples/platforms/nrf528xx/nrf52833/Makefile.platform.am
+++ b/examples/platforms/nrf528xx/nrf52833/Makefile.platform.am
@@ -32,9 +32,9 @@
 
 LDADD_COMMON                                                                                 += \
     $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52833.a                        \
+    $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52833-transport.a              \
     $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52833-sdk.a                \
     $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52833-radio-driver.a       \
-    $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52833-transport.a              \
     $(NULL)
 
 if OPENTHREAD_ENABLE_CUSTOM_LINKER_FILE

--- a/examples/platforms/nrf528xx/nrf52840/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52840/Makefile.am
@@ -55,7 +55,6 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/src/core                                                                                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio                                            \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/fem/three_pin_gpio                         \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/hal                                        \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features                               \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/mac_features/ack_generator                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch                                       \

--- a/examples/platforms/nrf528xx/nrf52840/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52840/Makefile.am
@@ -32,6 +32,7 @@ lib_LIBRARIES                                                                   
     libopenthread-nrf52840.a                                                                                 \
     libopenthread-nrf52840-sdk.a                                                                             \
     libopenthread-nrf52840-softdevice-sdk.a                                                                  \
+    libopenthread-nrf52840-transport.a                                                                       \
     $(NULL)
 
 # Do not enable -pedantic-errors for nRF52840 driver library
@@ -50,6 +51,7 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/include                                                                                  \
     -I$(top_srcdir)/examples/platforms                                                                       \
     -I$(top_srcdir)/examples/platforms/nrf528xx/src                                                          \
+    -I$(top_srcdir)/examples/platforms/nrf528xx/src/transport                                                \
     -I$(top_srcdir)/src/core                                                                                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio                                            \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/fem/three_pin_gpio                         \
@@ -116,11 +118,15 @@ PLATFORM_COMMON_SOURCES                                                         
     src/logging.c                                                                                            \
     src/misc.c                                                                                               \
     src/radio.c                                                                                              \
-    src/spi-slave.c                                                                                          \
     src/system.c                                                                                             \
     src/temp.c                                                                                               \
-    src/uart.c                                                                                               \
-    src/usb-cdc-uart.c                                                                                       \
+    $(NULL)
+
+TRANSPORT_SOURCES                                                                                          = \
+    src/transport/spi-slave.c                                                                                \
+    src/transport/uart.c                                                                                     \
+    src/transport/usb-cdc-uart.c                                                                             \
+    src/transport/transport.c                                                                                \
     $(NULL)
 
 SINGLEPHY_SOURCES                                                                                          = \
@@ -173,6 +179,14 @@ libopenthread_nrf52840_softdevice_sdk_a_SOURCES                                 
     $(SOFTDEVICE_SOURCES)                                                                                    \
     $(NULL)
 
+libopenthread_nrf52840_transport_a_CPPFLAGS                                                                = \
+    $(COMMONCPPFLAGS)                                                                                        \
+    $(NULL)
+
+libopenthread_nrf52840_transport_a_SOURCES                                                                 = \
+    $(TRANSPORT_SOURCES)                                                                                     \
+    $(NULL)
+
 Dash                                                                                                       = -
 
 libopenthread_nrf52840_a_LIBADD                                                                            = \
@@ -183,6 +197,9 @@ libopenthread_nrf52840_sdk_a_LIBADD                                             
     $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
 
 libopenthread_nrf52840_softdevice_sdk_a_LIBADD                                                             = \
+    $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
+
+libopenthread_nrf52840_transport_a_LIBADD                                                                  = \
     $(shell find $(top_builddir)/examples/platforms/utils $(Dash)type f $(Dash)name "*.o")
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/examples/platforms/nrf528xx/nrf52840/Makefile.platform.am
+++ b/examples/platforms/nrf528xx/nrf52840/Makefile.platform.am
@@ -32,9 +32,9 @@
 
 LDADD_COMMON                                                                           += \
     $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52840.a                  \
+    $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52840-transport.a        \
     $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52840-sdk.a          \
     $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52840-radio-driver.a \
-    $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52840-transport.a        \
     $(NULL)
 
 if !OPENTHREAD_ENABLE_BUILTIN_MBEDTLS

--- a/examples/platforms/nrf528xx/nrf52840/Makefile.platform.am
+++ b/examples/platforms/nrf528xx/nrf52840/Makefile.platform.am
@@ -34,6 +34,7 @@ LDADD_COMMON                                                                    
     $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52840.a                  \
     $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52840-sdk.a          \
     $(top_builddir)/third_party/NordicSemiconductor/libnordicsemi-nrf52840-radio-driver.a \
+    $(top_builddir)/examples/platforms/nrf528xx/libopenthread-nrf52840-transport.a        \
     $(NULL)
 
 if !OPENTHREAD_ENABLE_BUILTIN_MBEDTLS

--- a/examples/platforms/nrf528xx/src/platform-nrf5-transport.h
+++ b/examples/platforms/nrf528xx/src/platform-nrf5-transport.h
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2017, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes the platform-specific transport initializers.
+ *
+ */
+
+#ifndef PLATFORM_NRF5_TRANSPORT_H_
+#define PLATFORM_NRF5_TRANSPORT_H_
+
+#include <stdbool.h>
+
+#include "platform-config.h"
+
+/**
+ * Initialization of transport.
+ *
+ */
+void nrf5TransportInit(bool pseudoReset);
+
+/**
+ * Deinitialization of transport.
+ *
+ */
+void nrf5TransportDeinit(bool pseudoReset);
+
+/**
+ * This function performs transport processing.
+ *
+ */
+void nrf5TransportProcess(void);
+
+#endif

--- a/examples/platforms/nrf528xx/src/platform-nrf5-transport.h
+++ b/examples/platforms/nrf528xx/src/platform-nrf5-transport.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2017, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -43,13 +43,13 @@
  * Initialization of transport.
  *
  */
-void nrf5TransportInit(bool pseudoReset);
+void nrf5TransportInit(bool aPseudoReset);
 
 /**
  * Deinitialization of transport.
  *
  */
-void nrf5TransportDeinit(bool pseudoReset);
+void nrf5TransportDeinit(bool aPseudoReset);
 
 /**
  * This function performs transport processing.

--- a/examples/platforms/nrf528xx/src/platform-nrf5.h
+++ b/examples/platforms/nrf528xx/src/platform-nrf5.h
@@ -41,34 +41,7 @@
 
 #include "platform-config.h"
 
-/**
- * Initialization of UART driver.
- *
- */
-void nrf5UartInit(void);
 
-/**
- * Deinitialization of UART driver.
- *
- */
-void nrf5UartDeinit(void);
-
-/**
- * Clear pending UART data.
- *
- */
-void nrf5UartClearPendingData(void);
-
-/**
- * This function performs UART driver processing.
- *
- */
-void nrf5UartProcess(void);
-
-/**
- * Initialization of Alarm driver.
- *
- */
 void nrf5AlarmInit(void);
 
 /**
@@ -118,23 +91,6 @@ void nrf5LogInit(void);
  *
  */
 void nrf5LogDeinit(void);
-
-/**
- * Initialization of SPI Slave driver.
- *
- */
-void nrf5SpiSlaveInit(void);
-
-/**
- * Deinitialization of SPI Slave driver.
- *
- */
-void nrf5SpiSlaveDeinit(void);
-
-/**
- * Function for processing SPI Slave driver.
- */
-void nrf5SpiSlaveProcess(void);
 
 /**
  * Initialization of Misc module.

--- a/examples/platforms/nrf528xx/src/platform-nrf5.h
+++ b/examples/platforms/nrf528xx/src/platform-nrf5.h
@@ -41,7 +41,6 @@
 
 #include "platform-config.h"
 
-
 void nrf5AlarmInit(void);
 
 /**

--- a/examples/platforms/nrf528xx/src/system.c
+++ b/examples/platforms/nrf528xx/src/system.c
@@ -39,8 +39,8 @@
 
 #include "openthread-system.h"
 #include "platform-fem.h"
-#include "platform-nrf5.h"
 #include "platform-nrf5-transport.h"
+#include "platform-nrf5.h"
 #include <nrf.h>
 #include <nrf_drv_clock.h>
 

--- a/examples/platforms/nrf528xx/src/system.c
+++ b/examples/platforms/nrf528xx/src/system.c
@@ -40,6 +40,7 @@
 #include "openthread-system.h"
 #include "platform-fem.h"
 #include "platform-nrf5.h"
+#include "platform-nrf5-transport.h"
 #include <nrf.h>
 #include <nrf_drv_clock.h>
 
@@ -94,23 +95,11 @@ void otSysInit(int argc, char *argv[])
     nrf5RandomInit();
     if (!gPlatformPseudoResetWasRequested)
     {
-#if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
-        nrf5UartInit();
-#endif
 #if NRF52840_XXAA
         nrf5CryptoInit();
 #endif
     }
-    else
-    {
-#if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
-        nrf5UartClearPendingData();
-#endif
-    }
-
-#if (SPIS_AS_SERIAL_TRANSPORT == 1)
-    nrf5SpiSlaveInit();
-#endif
+    nrf5TransportInit(gPlatformPseudoResetWasRequested);
     nrf5MiscInit();
     nrf5RadioInit();
     nrf5TempInit();
@@ -127,18 +116,13 @@ void otSysDeinit(void)
     nrf5TempDeinit();
     nrf5RadioDeinit();
     nrf5MiscDeinit();
-#if (SPIS_AS_SERIAL_TRANSPORT == 1)
-    nrf5SpiSlaveDeinit();
-#endif
     if (!gPlatformPseudoResetWasRequested)
     {
 #if NRF52840_XXAA
         nrf5CryptoDeinit();
 #endif
-#if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
-        nrf5UartDeinit();
-#endif
     }
+    nrf5TransportDeinit(gPlatformPseudoResetWasRequested);
     nrf5RandomDeinit();
     nrf5AlarmDeinit();
 #if (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED) || \
@@ -159,12 +143,7 @@ bool otSysPseudoResetWasRequested(void)
 void otSysProcessDrivers(otInstance *aInstance)
 {
     nrf5RadioProcess(aInstance);
-#if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
-    nrf5UartProcess();
-#endif
-#if (SPIS_AS_SERIAL_TRANSPORT == 1)
-    nrf5SpiSlaveProcess();
-#endif
+    nrf5TransportProcess();
     nrf5TempProcess();
     nrf5AlarmProcess(aInstance);
 }

--- a/examples/platforms/nrf528xx/src/transport/spi-slave.c
+++ b/examples/platforms/nrf528xx/src/transport/spi-slave.c
@@ -36,10 +36,10 @@
 #include <utils/code_utils.h>
 #include <openthread/platform/spi-slave.h>
 
+#include "platform-nrf5-transport.h"
 #include <hal/nrf_gpio.h>
 #include <nrfx.h>
 #include <nrfx_spis.h>
-#include "platform-nrf5-transport.h"
 
 #include "openthread-system.h"
 

--- a/examples/platforms/nrf528xx/src/transport/spi-slave.c
+++ b/examples/platforms/nrf528xx/src/transport/spi-slave.c
@@ -39,7 +39,7 @@
 #include <hal/nrf_gpio.h>
 #include <nrfx.h>
 #include <nrfx_spis.h>
-#include <platform-nrf5.h>
+#include "platform-nrf5-transport.h"
 
 #include "openthread-system.h"
 

--- a/examples/platforms/nrf528xx/src/transport/transport-drivers.h
+++ b/examples/platforms/nrf528xx/src/transport/transport-drivers.h
@@ -1,0 +1,79 @@
+/*
+ *  Copyright (c) 2016, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes UART/USB and SPI driver initializers.
+ *
+ */
+
+#ifndef TRANSPORT_DRIVERS_H_
+#define TRANSPORT_DRIVERS_H_
+
+/**
+ * Initialization of UART driver.
+ *
+ */
+void nrf5UartInit(void);
+
+/**
+ * Deinitialization of UART driver.
+ *
+ */
+void nrf5UartDeinit(void);
+
+/**
+ * Clear pending UART data.
+ *
+ */
+void nrf5UartClearPendingData(void);
+
+/**
+ * This function performs UART driver processing.
+ *
+ */
+void nrf5UartProcess(void);
+
+/**
+ * Initialization of SPI Slave driver.
+ *
+ */
+void nrf5SpiSlaveInit(void);
+
+/**
+ * Deinitialization of SPI Slave driver.
+ *
+ */
+void nrf5SpiSlaveDeinit(void);
+
+/**
+ * Function for processing SPI Slave driver.
+ */
+void nrf5SpiSlaveProcess(void);
+
+#endif

--- a/examples/platforms/nrf528xx/src/transport/transport.c
+++ b/examples/platforms/nrf528xx/src/transport/transport.c
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2019, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the nrf5 platform transport initialization functions.
+ *
+ */
+
+#include "platform-nrf5-transport.h"
+
+#include "transport-drivers.h"
+
+
+void nrf5TransportInit(bool pseudoReset)
+{
+#if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
+    if (!pseudoReset)
+    {
+        nrf5UartInit();
+    }
+    else
+    {
+        nrf5UartClearPendingData();
+    }
+#endif
+
+#if (SPIS_AS_SERIAL_TRANSPORT == 1)
+    nrf5SpiSlaveInit();
+#endif
+}
+
+void nrf5TransportDeinit(bool pseudoReset)
+{
+#if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
+    if (!pseudoReset)
+    {
+        nrf5UartDeinit();
+    }
+#endif
+
+#if (SPIS_AS_SERIAL_TRANSPORT == 1)
+    nrf5SpiSlaveDeinit();
+#endif
+}
+
+void nrf5TransportProcess(void)
+{
+#if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
+    nrf5UartProcess();
+#endif
+#if (SPIS_AS_SERIAL_TRANSPORT == 1)
+    nrf5SpiSlaveProcess();
+#endif
+}

--- a/examples/platforms/nrf528xx/src/transport/transport.c
+++ b/examples/platforms/nrf528xx/src/transport/transport.c
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -36,10 +36,10 @@
 
 #include "transport-drivers.h"
 
-void nrf5TransportInit(bool pseudoReset)
+void nrf5TransportInit(bool aPseudoReset)
 {
 #if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
-    if (!pseudoReset)
+    if (!aPseudoReset)
     {
         nrf5UartInit();
     }
@@ -54,10 +54,10 @@ void nrf5TransportInit(bool pseudoReset)
 #endif
 }
 
-void nrf5TransportDeinit(bool pseudoReset)
+void nrf5TransportDeinit(bool aPseudoReset)
 {
 #if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
-    if (!pseudoReset)
+    if (!aPseudoReset)
     {
         nrf5UartDeinit();
     }

--- a/examples/platforms/nrf528xx/src/transport/transport.c
+++ b/examples/platforms/nrf528xx/src/transport/transport.c
@@ -36,7 +36,6 @@
 
 #include "transport-drivers.h"
 
-
 void nrf5TransportInit(bool pseudoReset)
 {
 #if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))

--- a/examples/platforms/nrf528xx/src/transport/uart.c
+++ b/examples/platforms/nrf528xx/src/transport/uart.c
@@ -44,7 +44,7 @@
 
 #include "openthread-system.h"
 
-#include "platform-nrf5.h"
+#include "platform-nrf5-transport.h"
 #include <hal/nrf_gpio.h>
 #include <hal/nrf_uart.h>
 #include <nrf_drv_clock.h>

--- a/examples/platforms/nrf528xx/src/transport/usb-cdc-uart.c
+++ b/examples/platforms/nrf528xx/src/transport/usb-cdc-uart.c
@@ -51,7 +51,7 @@
 #include <openthread/platform/misc.h>
 #include <openthread/platform/uart.h>
 
-#include "platform-nrf5.h"
+#include "platform-nrf5-transport.h"
 
 #include "app_usbd.h"
 #include "app_usbd_serial_num.h"

--- a/third_party/NordicSemiconductor/Makefile.am
+++ b/third_party/NordicSemiconductor/Makefile.am
@@ -90,7 +90,6 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio                                                         \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/fem                                                     \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/fem/three_pin_gpio                                      \
-    -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/hal                                                     \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch                                                    \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal                                               \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal/softdevice                                    \


### PR DESCRIPTION
Transport-related functions for nrf528xx platform are moved to separated library.