### PR TITLE
[core/common] Add an option to move instance on heap

### DIFF
--- a/src/core/common/locator.hpp
+++ b/src/core/common/locator.hpp
@@ -45,7 +45,11 @@ namespace ot {
 class Instance;
 
 #if !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+#if !OPENTHREAD_CONFIG_INSTANCE_ON_HEAP
 extern uint64_t gInstanceRaw[];
+#else
+extern Instance *gInstanceRaw;
+#endif
 #endif
 
 /**
@@ -83,7 +87,11 @@ public:
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
     Instance &GetInstance(void) const { return *mInstance; }
 #else
+#if !OPENTHREAD_CONFIG_INSTANCE_ON_HEAP
     Instance &GetInstance(void) const { return *reinterpret_cast<Instance *>(&gInstanceRaw); }
+#else
+    Instance &GetInstance(void) const { return *gInstanceRaw; }
+#endif
 #endif
 
     /**

--- a/src/core/config/openthread-core-default-config.h
+++ b/src/core/config/openthread-core-default-config.h
@@ -108,6 +108,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+ *
+ * Define to 1 to move instance on heap
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_INSTANCE_ON_HEAP
+#define OPENTHREAD_CONFIG_INSTANCE_ON_HEAP 0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
  *
  * Define to 1 to enable Thread Test Harness reference device support.


### PR DESCRIPTION
There is limit data segment on some FreeRTOS platform, because the
instance is very large, we may want to move the instance from static
data segment to dynamic allocated heap.

The patch introduced an new define option:

OPENTHREAD_CONFIG_INSTANCE_ON_HEAP

When it is defined, the instance will be allocated dynamically on heap.

Signed-off-by: Zang MingJie <mingjiez@google.com>