### PR TITLE
[meshcop-tlvs] remove "using ot::Encoding::Reverse32"

### DIFF
--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -55,7 +55,6 @@
 namespace ot {
 namespace MeshCoP {
 
-using ot::Encoding::Reverse32;
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;
 
@@ -1352,7 +1351,7 @@ public:
      * @returns The Channel Mask value.
      *
      */
-    uint32_t GetMask(void) const { return Reverse32(HostSwap32(mMask)); }
+    uint32_t GetMask(void) const { return Encoding::Reverse32(HostSwap32(mMask)); }
 
     /**
      * This method sets the Channel Mask value.
@@ -1360,7 +1359,7 @@ public:
      * @param[in]  aMask  The Channel Mask value.
      *
      */
-    void SetMask(uint32_t aMask) { mMask = HostSwap32(Reverse32(aMask)); }
+    void SetMask(uint32_t aMask) { mMask = HostSwap32(Encoding::Reverse32(aMask)); }
 
 private:
     uint32_t mMask;


### PR DESCRIPTION
---

Background for this change: This is more of convenience change.  Different builds of `clang-format` (version 6.0.0) behave slightly differently when sorting the `using` list.  This PR removes the `using ot::Encoding::Reverse32` to help address this. 

I notice the difference between  `clang-format version 6.0.0  (tag/google/stable/2017-11-14)`(on Mac OS X) vs. `tags/RELEASE_600/final` on other machines.