### PR TITLE
[coap] ensure correct dequeue time for entries in response queue

### DIFF
--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -252,7 +252,6 @@ private:
 
     struct ResponseMetadata
     {
-        void     Init(TimeMilli aDequeueTime, const Ip6::MessageInfo &aMessageInfo);
         otError  AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
         void     ReadFrom(const Message &aMessage);
         uint32_t GetRemainingTime(void) const;
@@ -533,15 +532,6 @@ protected:
 private:
     struct Metadata
     {
-        void Init(bool aConfirmable,
-#if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
-                  bool aObserve,
-#endif
-                  const Ip6::MessageInfo &aMessageInfo,
-                  ResponseHandler         aHandler,
-                  void *                  aContext,
-                  const TxParameters &    aTxParameters);
-
         otError AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
         void    ReadFrom(const Message &aMessage);
         int     UpdateIn(Message &aMessage) const;

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -211,12 +211,6 @@ public:
     void EnqueueResponse(Message &aMessage, const Ip6::MessageInfo &aMessageInfo, const TxParameters &aTxParameters);
 
     /**
-     * This method removes the oldest response from the cache.
-     *
-     */
-    void DequeueOldestResponse(void);
-
-    /**
      * This method removes all responses from the cache.
      *
      */
@@ -252,9 +246,8 @@ private:
 
     struct ResponseMetadata
     {
-        otError  AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
-        void     ReadFrom(const Message &aMessage);
-        uint32_t GetRemainingTime(void) const;
+        otError AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
+        void    ReadFrom(const Message &aMessage);
 
         TimeMilli        mDequeueTime;
         Ip6::MessageInfo mMessageInfo;
@@ -262,6 +255,7 @@ private:
 
     const Message *FindMatchedResponse(const Message &aRequest, const Ip6::MessageInfo &aMessageInfo) const;
     void           DequeueResponse(Message &aMessage);
+    void           UpdateQueue(void);
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);


### PR DESCRIPTION
This PR has two related commits. The main one:

**[coap] ensure correct dequeue time for entries in response queue**

This commit changes the handling of timer for CoAP response queue to ensure that correct dequeue time is used. The existing code assumed that entries in the queue would be in order of their dequeue time (due to exchange lifetime being fixed). With the addition of configurable CoAP tx parameters feature, this is no longer valid. This commit changes the code to restart the timer with the earliest dequeue time. Also when evicting a message from the queue (due to the number of entries reaching the max limit of `kMaxCachedResponses`) we now search and find the message with earliest dequeue time to remove (instead of removing the entry at the head of queue).

**[coap] directly initalize metadata before appending to message**