### PR TITLE
[netif] enhance return value of adding external addresses

### DIFF
--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -363,6 +363,8 @@ otError Netif::SubscribeExternalMulticast(const Address &aAddress)
     NetifMulticastAddress &linkLocalAllRoutersAddress = static_cast<NetifMulticastAddress &>(
         const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
 
+    VerifyOrExit(!IsMulticastSubscribed(aAddress), error = OT_ERROR_ALREADY);
+
     // Check that the address is not one of the fixed addresses:
     // LinkLocalAllRouters -> RealmLocalAllRouters -> LinkLocalAllNodes
     // -> RealmLocalAllNodes -> RealmLocalAllMpl.
@@ -371,8 +373,6 @@ otError Netif::SubscribeExternalMulticast(const Address &aAddress)
     {
         VerifyOrExit(cur->GetAddress() != aAddress, error = OT_ERROR_INVALID_ARGS);
     }
-
-    VerifyOrExit(!IsMulticastSubscribed(aAddress), error = OT_ERROR_ALREADY);
 
     for (entry = &mExtMulticastAddresses[0]; entry < OT_ARRAY_END(mExtMulticastAddresses); entry++)
     {
@@ -482,14 +482,12 @@ otError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress)
     otError              error = OT_ERROR_NONE;
     NetifUnicastAddress *entry;
 
-    VerifyOrExit(!aAddress.GetAddress().IsLinkLocal(), error = OT_ERROR_INVALID_ARGS);
-
     for (entry = mUnicastAddresses.GetHead(); entry; entry = entry->GetNext())
     {
         if (entry->GetAddress() == aAddress.GetAddress())
         {
             VerifyOrExit((entry >= &mExtUnicastAddresses[0]) && (entry < OT_ARRAY_END(mExtUnicastAddresses)),
-                         error = OT_ERROR_INVALID_ARGS);
+                         error = OT_ERROR_ALREADY);
 
             entry->mPrefixLength = aAddress.mPrefixLength;
             entry->mPreferred    = aAddress.mPreferred;
@@ -497,6 +495,8 @@ otError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress)
             ExitNow();
         }
     }
+
+    VerifyOrExit(!aAddress.GetAddress().IsLinkLocal(), error = OT_ERROR_INVALID_ARGS);
 
     for (entry = &mExtUnicastAddresses[0]; entry < OT_ARRAY_END(mExtUnicastAddresses); entry++)
     {


### PR DESCRIPTION
This commit changes the return value of subscribing a pre-defined address when it's already subscribed. Now returns OT_ERROR_ALREADY instead of OT_ERROR_INVALID_ARGS.

Resolves the return value issue in https://github.com/openthread/openthread/pull/4664