### PR TITLE
[cmake] fix build with external mbedTLS

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -233,12 +233,14 @@ target_sources(openthread-radio PRIVATE
     utils/parse_cmdline.cpp
 )
 
-target_link_libraries(openthread-ftd
-    PUBLIC
-        mbedcrypto
-)
+if(OT_BUILTIN_MBEDTLS)
+    target_link_libraries(openthread-ftd
+        PUBLIC
+            mbedcrypto
+    )
 
-target_link_libraries(openthread-mtd
-    PUBLIC
-        mbedcrypto
-)
+    target_link_libraries(openthread-mtd
+        PUBLIC
+            mbedcrypto
+    )
+endif()


### PR DESCRIPTION
`mbedcrypto` target is only available when `OT_BUILTIN_MBEDTLS` is set,
therefore linking it unconditionally when external mbed TLS instance is
used results in a linking error.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>