### PR TITLE
[nrf528xx] fix IAR undefined order of volatile accesses error

### DIFF
--- a/examples/platforms/nrf528xx/src/transport/uart.c
+++ b/examples/platforms/nrf528xx/src/transport/uart.c
@@ -99,6 +99,7 @@ static void processReceive(void)
     // Set head position to not be changed during read procedure.
     uint16_t head = sReceiveHead;
     uint8_t *position;
+
     otEXPECT(isRxBufferEmpty() == false);
 
     // In case head roll back to the beginning of the buffer, notify about left

--- a/examples/platforms/nrf528xx/src/transport/uart.c
+++ b/examples/platforms/nrf528xx/src/transport/uart.c
@@ -87,7 +87,8 @@ static __INLINE bool isRxBufferFull()
  */
 static __INLINE bool isRxBufferEmpty()
 {
-    return (sReceiveHead == sReceiveTail);
+    uint16_t head = sReceiveHead;
+    return (head == sReceiveTail);
 }
 
 /**
@@ -97,21 +98,23 @@ static void processReceive(void)
 {
     // Set head position to not be changed during read procedure.
     uint16_t head = sReceiveHead;
-
+    uint8_t *position;
     otEXPECT(isRxBufferEmpty() == false);
 
     // In case head roll back to the beginning of the buffer, notify about left
     // bytes from the end of the buffer.
     if (head < sReceiveTail)
     {
-        otPlatUartReceived(&sReceiveBuffer[sReceiveTail], (UART_RX_BUFFER_SIZE - sReceiveTail));
+        position = &sReceiveBuffer[sReceiveTail];
+        otPlatUartReceived(position, (UART_RX_BUFFER_SIZE - sReceiveTail));
         sReceiveTail = 0;
     }
 
     // Notify about received bytes.
     if (head > sReceiveTail)
     {
-        otPlatUartReceived(&sReceiveBuffer[sReceiveTail], (head - sReceiveTail));
+        position = &sReceiveBuffer[sReceiveTail];
+        otPlatUartReceived(position, (head - sReceiveTail));
         sReceiveTail = head;
     }
 


### PR DESCRIPTION
After #4652 IAR compiles with warning: 
warning[Pa082]: undefined behavior: the order of volatile accesses is undefined in this statement