### PR TITLE
[tlv] add IsBoundedBy() helper method

### DIFF
--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -55,6 +55,15 @@ const uint8_t *Tlv::GetValue(void) const
     return reinterpret_cast<const uint8_t *>(this) + (IsExtended() ? sizeof(ExtendedTlv) : sizeof(Tlv));
 }
 
+bool Tlv::IsBoundedBy(const void *aEndPointer) const
+{
+    const uint8_t *cur = reinterpret_cast<const uint8_t *>(this);
+    const uint8_t *end = reinterpret_cast<const uint8_t *>(aEndPointer);
+
+    return (cur + sizeof(Tlv) <= end) && (!IsExtended() || (cur + sizeof(ExtendedTlv) <= end)) &&
+           (cur + GetSize() <= end);
+}
+
 otError Tlv::AppendTo(Message &aMessage) const
 {
     uint32_t size = GetSize();

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -164,6 +164,19 @@ public:
     }
 
     /**
+     * This method indicates whether the TLV and its Value are bounded by (i.e., `<`) a given end pointer.
+     *
+     * This method can be used independent of whether TLV is an Extended TLV or not.
+     *
+     * @param[in] aEndPointer  An end pointer to check against.
+     *
+     * @retval TRUE   The TLV is bounded by the @p aEndPointer (i.e., the end of TLV < @p aEndPointer)
+     * @retval FALSE  The TLV is not bounded by the @p aEndPointer (i.e., the end of TLV >= @p aEndPointer).
+     *
+     */
+    bool IsBoundedBy(const void *aEndPointer) const;
+
+    /**
      * This method appends a TLV to the end of the message.
      *
      * On success, this method grows the message by the size of the TLV.

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -68,7 +68,7 @@ bool Dataset::IsValid(void) const
 
     for (; cur < end; cur = cur->GetNext())
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end && Tlv::IsValid(*cur), rval = false);
+        VerifyOrExit(cur->IsBoundedBy(end) && Tlv::IsValid(*cur), rval = false);
     }
 
 exit:

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -97,7 +97,7 @@ otError NetworkData::GetNextOnMeshPrefix(Iterator &aIterator, uint16_t aRloc16, 
         NetworkDataTlv *subCur;
         NetworkDataTlv *subEnd;
 
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, error = OT_ERROR_PARSE);
+        VerifyOrExit(cur->IsBoundedBy(end), error = OT_ERROR_PARSE);
 
         if (cur->GetType() != NetworkDataTlv::kTypePrefix)
         {
@@ -173,7 +173,7 @@ otError NetworkData::GetNextExternalRoute(Iterator &aIterator, uint16_t aRloc16,
         NetworkDataTlv *subCur;
         NetworkDataTlv *subEnd;
 
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, error = OT_ERROR_PARSE);
+        VerifyOrExit(cur->IsBoundedBy(end), error = OT_ERROR_PARSE);
 
         if (cur->GetType() != NetworkDataTlv::kTypePrefix)
         {
@@ -245,7 +245,7 @@ otError NetworkData::GetNextService(Iterator &aIterator, uint16_t aRloc16, Servi
         NetworkDataTlv *subCur;
         NetworkDataTlv *subEnd;
 
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, error = OT_ERROR_PARSE);
+        VerifyOrExit(cur->IsBoundedBy(end), error = OT_ERROR_PARSE);
 
         if (cur->GetType() != NetworkDataTlv::kTypeService)
         {
@@ -319,7 +319,7 @@ otError NetworkData::GetNextServiceId(Iterator &aIterator, uint16_t aRloc16, uin
         NetworkDataTlv *subCur;
         NetworkDataTlv *subEnd;
 
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, error = OT_ERROR_PARSE);
+        VerifyOrExit(cur->IsBoundedBy(end), error = OT_ERROR_PARSE);
 
         if (cur->GetType() != NetworkDataTlv::kTypeService)
         {
@@ -477,7 +477,7 @@ bool NetworkData::ContainsService(uint8_t aServiceId, uint16_t aRloc16)
         NetworkDataTlv *subCur;
         NetworkDataTlv *subEnd;
 
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit(cur->IsBoundedBy(end));
 
         if (cur->GetType() != NetworkDataTlv::kTypeService)
         {
@@ -749,7 +749,7 @@ BorderRouterTlv *NetworkData::FindBorderRouter(PrefixTlv &aPrefix)
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit(cur->IsBoundedBy(end));
 
         if (cur->GetType() == NetworkDataTlv::kTypeBorderRouter)
         {
@@ -771,7 +771,7 @@ BorderRouterTlv *NetworkData::FindBorderRouter(PrefixTlv &aPrefix, bool aStable)
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit(cur->IsBoundedBy(end));
 
         if (cur->GetType() == NetworkDataTlv::kTypeBorderRouter && cur->IsStable() == aStable)
         {
@@ -793,7 +793,7 @@ HasRouteTlv *NetworkData::FindHasRoute(PrefixTlv &aPrefix)
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit(cur->IsBoundedBy(end));
 
         if (cur->GetType() == NetworkDataTlv::kTypeHasRoute)
         {
@@ -815,7 +815,7 @@ HasRouteTlv *NetworkData::FindHasRoute(PrefixTlv &aPrefix, bool aStable)
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit(cur->IsBoundedBy(end));
 
         if (cur->GetType() == NetworkDataTlv::kTypeHasRoute && cur->IsStable() == aStable)
         {
@@ -837,7 +837,7 @@ ContextTlv *NetworkData::FindContext(PrefixTlv &aPrefix)
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit(cur->IsBoundedBy(end));
 
         if (cur->GetType() == NetworkDataTlv::kTypeContext)
         {
@@ -864,7 +864,7 @@ PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit(cur->IsBoundedBy(end));
 
         if (cur->GetType() == NetworkDataTlv::kTypePrefix)
         {
@@ -934,7 +934,7 @@ ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit(cur->IsBoundedBy(end));
 
         if (cur->GetType() == NetworkDataTlv::kTypeService)
         {
@@ -1043,7 +1043,7 @@ otError NetworkData::GetNextServer(Iterator &aIterator, uint16_t &aRloc16)
         NetworkDataTlv *subCur;
         NetworkDataTlv *subEnd;
 
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, error = OT_ERROR_PARSE);
+        VerifyOrExit(cur->IsBoundedBy(end), error = OT_ERROR_PARSE);
 
         switch (cur->GetType())
         {

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -213,7 +213,7 @@ void Leader::HandleCommissioningSet(Coap::Message &aMessage, const Ip6::MessageI
     {
         MeshCoP::Tlv::Type type;
 
-        VerifyOrExit(((cur + 1) <= end) && !cur->IsExtended() && (cur->GetNext() <= end));
+        VerifyOrExit(cur->IsBoundedBy(end));
 
         type = cur->GetType();
 
@@ -443,7 +443,7 @@ otError Leader::RlocLookup(uint16_t  aRloc16,
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, error = OT_ERROR_PARSE);
+        VerifyOrExit(cur->IsBoundedBy(end), error = OT_ERROR_PARSE);
 
         switch (cur->GetType())
         {
@@ -596,7 +596,7 @@ bool Leader::IsStableUpdated(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvs
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit(cur->IsBoundedBy(end));
 
         switch (cur->GetType())
         {
@@ -785,7 +785,7 @@ otError Leader::AddNetworkData(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aOl
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, error = OT_ERROR_PARSE);
+        VerifyOrExit(cur->IsBoundedBy(end), error = OT_ERROR_PARSE);
 
         switch (cur->GetType())
         {
@@ -824,7 +824,7 @@ otError Leader::AddPrefix(PrefixTlv &aPrefix)
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, error = OT_ERROR_PARSE);
+        VerifyOrExit(cur->IsBoundedBy(end), error = OT_ERROR_PARSE);
 
         switch (cur->GetType())
         {
@@ -859,7 +859,7 @@ otError Leader::AddService(ServiceTlv &aService, uint8_t *aOldTlvs, uint8_t aOld
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, error = OT_ERROR_PARSE);
+        VerifyOrExit(cur->IsBoundedBy(end), error = OT_ERROR_PARSE);
 
         switch (cur->GetType())
         {
@@ -1033,7 +1033,7 @@ ServiceTlv *Leader::FindServiceById(uint8_t aServiceId)
 
     while (cur < end)
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit(cur->IsBoundedBy(end));
 
         if (cur->GetType() == NetworkDataTlv::kTypeService)
         {

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -141,6 +141,18 @@ public:
     }
 
     /**
+     * This method returns a pointer to the next Network Data TLV.
+     *
+     * @returns A pointer to the next Network Data TLV.
+     *
+     */
+    const NetworkDataTlv *GetNext(void) const
+    {
+        return reinterpret_cast<const NetworkDataTlv *>(reinterpret_cast<const uint8_t *>(this) + sizeof(*this) +
+                                                        mLength);
+    }
+
+    /**
      * This method clears the Stable bit.
      *
      */
@@ -160,6 +172,20 @@ public:
      *
      */
     void SetStable(void) { mType |= kStableMask; }
+
+    /**
+     * This method indicates whether the TLV and its Value are bounded by (i.e., `<`) a given end pointer.
+     *
+     * @param[in] aEndPointer  An end pointer to check against.
+     *
+     * @retval TRUE   The TLV is bounded by the @p aEndPointer (i.e., the end of TLV < @p aEndPointer)
+     * @retval FALSE  The TLV is not bounded by the @p aEndPointer (i.e., the end of TLV >= @p aEndPointer).
+     *
+     */
+    bool IsBoundedBy(const NetworkDataTlv *aEndPointer) const
+    {
+        return ((this + 1) <= aEndPointer) && (GetNext() <= aEndPointer);
+    }
 
 private:
     enum


### PR DESCRIPTION
The new `Tlv::IsBoundedBy()` method checks whether the entire TLV is
bounded by (i.e., `<`) a given end pointer. The implementation works
correctly independent of TLV being an Extended TLV or not. It also
ensures not to read beyond the given end pointer by first checking the
Type and Length fields are bounded by the end address before reading
the Length value.