### PR TITLE
[toranj] define platform specific config headers + add travis test

### DIFF
--- a/.travis/script.sh
+++ b/.travis/script.sh
@@ -451,6 +451,14 @@ build_samr21() {
 
     git checkout -- . || die
     git clean -xfd || die
+    ./tests/toranj/build.sh cmake || die
+
+    git checkout -- . || die
+    git clean -xfd || die
+    ./tests/toranj/build.sh cmake-posix || die
+
+    git checkout -- . || die
+    git clean -xfd || die
     ./bootstrap || die
     CPPFLAGS=-DOPENTHREAD_CONFIG_LOG_LEVEL=OT_LOG_LEVEL_NONE make -f examples/Makefile-simulation || die
 

--- a/tests/toranj/build.sh
+++ b/tests/toranj/build.sh
@@ -90,8 +90,6 @@ configure_options="                \
     --enable-ncp                   \
     "
 
-cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config.h\"'
-
 if [ -n "${top_builddir}" ]; then
     top_srcdir=$(pwd)
     mkdir -p "${top_builddir}"
@@ -107,8 +105,9 @@ case ${build_config} in
         echo "==================================================================================================="
         ./bootstrap || die
         cd "${top_builddir}"
+        cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config-simulation.h\"'
         ${top_srcdir}/configure                                                         \
-            CPPFLAGS="$cppflags_config -DOPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE=1" \
+            CPPFLAGS="$cppflags_config"                                                 \
             --with-examples=simulation                                                  \
             $configure_options || die
         make -j 8 || die
@@ -120,8 +119,9 @@ case ${build_config} in
         echo "===================================================================================================="
         ./bootstrap || die
         cd "${top_builddir}"
+        cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config-simulation.h\"'
         ${top_srcdir}/configure                                                         \
-            CPPFLAGS="$cppflags_config -DOPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE=1" \
+            CPPFLAGS="$cppflags_config "                                                \
             --enable-coverage=${coverage}                                               \
             --enable-ncp                                                                \
             --enable-radio-only                                                         \
@@ -137,6 +137,7 @@ case ${build_config} in
         echo "===================================================================================================="
         ./bootstrap || die
         cd "${top_builddir}"
+        cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config-posix.h\"'
         ${top_srcdir}/configure                 \
             CPPFLAGS="$cppflags_config"         \
             --with-platform=posix               \
@@ -148,7 +149,7 @@ case ${build_config} in
         echo "===================================================================================================="
         echo "Building OpenThread (NCP/CLI for FTD/MTD/RCP mode) with simulation platform using cmake"
         echo "===================================================================================================="
-        cmake -GNinja -DOT_PLATFORM=simulation -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config.h . || die
+        cmake -GNinja -DOT_PLATFORM=simulation -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h . || die
         ninja || die
         ;;
 
@@ -156,7 +157,7 @@ case ${build_config} in
         echo "===================================================================================================="
         echo "Building OpenThread POSIX host platform using cmake"
         echo "===================================================================================================="
-        cmake -GNinja -DOT_PLATFORM=posix -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config.h . || die
+        cmake -GNinja -DOT_PLATFORM=posix -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-posix.h . || die
         ninja || die
         ;;
 

--- a/tests/toranj/openthread-core-toranj-config-posix.h
+++ b/tests/toranj/openthread-core-toranj-config-posix.h
@@ -1,0 +1,72 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OPENTHREAD_CORE_TORANJ_CONFIG_POSIX_H_
+#define OPENTHREAD_CORE_TORANJ_CONFIG_POSIX_H_
+
+/**
+ * This header file defines the OpenThread core configuration options for toranj with POSIX platform.
+ *
+ */
+
+// Include the common configuration for all platforms.
+#include "openthread-core-toranj-config.h"
+
+/**
+ * @def OPENTHREAD_CONFIG_PLATFORM_INFO
+ *
+ * The platform-specific string to insert into the OpenThread version string.
+ *
+ */
+#define OPENTHREAD_CONFIG_PLATFORM_INFO "POSIX-toranj"
+
+/**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
+ *
+ * Define to 1 to enable Border Router support.
+ *
+ */
+#define OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE 1
+
+/**
+ * @def OPENTHREAD_POSIX_CONFIG_RCP_PTY_ENABLE
+ *
+ * Define as 1 to enable PTY device support in POSIX app.
+ *
+ */
+#define OPENTHREAD_POSIX_CONFIG_RCP_PTY_ENABLE 1
+
+/**
+ * @def OPENTHREAD_POSIX_CONFIG_RCP_UART_ENABLE
+ *
+ * Define as 1 to enable UART interface to RCP.
+ *
+ */
+#define OPENTHREAD_POSIX_CONFIG_RCP_UART_ENABLE 1
+
+#endif /* OPENTHREAD_CORE_TORANJ_CONFIG_POSIX_H_ */

--- a/tests/toranj/openthread-core-toranj-config-simulation.h
+++ b/tests/toranj/openthread-core-toranj-config-simulation.h
@@ -1,0 +1,62 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OPENTHREAD_CORE_TORANJ_CONFIG_SIMULATION_H_
+#define OPENTHREAD_CORE_TORANJ_CONFIG_SIMULATION_H_
+
+/**
+ * This header file defines the OpenThread core configuration for toranj with simulation platform.
+ *
+ */
+
+// Include the common configuration for all platforms.
+#include "openthread-core-toranj-config.h"
+
+/**
+ * @def OPENTHREAD_CONFIG_PLATFORM_INFO
+ *
+ * The platform-specific string to insert into the OpenThread version string.
+ *
+ */
+#if OPENTHREAD_RADIO
+#define OPENTHREAD_CONFIG_PLATFORM_INFO "SIMULATION-RCP-toranj"
+#else
+#define OPENTHREAD_CONFIG_PLATFORM_INFO "SIMULATION-toranj"
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+ *
+ * Define to 1 to enable otPlatFlash* APIs to support non-volatile storage.
+ *
+ * When defined to 1, the platform MUST implement the otPlatFlash* APIs instead of the otPlatSettings* APIs.
+ *
+ */
+#define OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE 1
+
+#endif /* OPENTHREAD_CORE_TORANJ_CONFIG_SIMULATION_H_ */

--- a/tests/toranj/openthread-core-toranj-config.h
+++ b/tests/toranj/openthread-core-toranj-config.h
@@ -26,30 +26,17 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef OPENTHREAD_CORE_TORANJ_CONFIG_H_
-#define OPENTHREAD_CORE_TORANJ_CONFIG_H_
-
 /**
  * This header file defines the OpenThread core configuration options used in NCP build for `toranj` test framework.
  *
  */
 
-#ifndef OPENTHREAD_RADIO
-#define OPENTHREAD_RADIO 0
+#if !defined(OPENTHREAD_CORE_TORANJ_CONFIG_SIMULATION_H_) && !defined(OPENTHREAD_CORE_TORANJ_CONFIG_POSIX_H_)
+#error "This header file should only be included through the platform-specific one"
 #endif
 
-/**
- * @def OPENTHREAD_CONFIG_PLATFORM_INFO
- *
- * The platform-specific string to insert into the OpenThread version string.
- *
- */
-#if OPENTHREAD_RADIO
-#define OPENTHREAD_CONFIG_PLATFORM_INFO "SIMULATION-RCP-toranj"
-#elif OPENTHREAD_PLATFORM_POSIX
-#define OPENTHREAD_CONFIG_PLATFORM_INFO "POSIX-toranj"
-#else
-#define OPENTHREAD_CONFIG_PLATFORM_INFO "SIMULATION-toranj"
+#ifndef OPENTHREAD_RADIO
+#define OPENTHREAD_RADIO 0
 #endif
 
 /**
@@ -421,24 +408,3 @@
  */
 #define OPENTHREAD_CONFIG_SOFTWARE_CSMA_BACKOFF_ENABLE 1
 #endif // OPENTHREAD_RADIO
-
-//--------------------------------------------------------------------------------------------------------------------
-// POSIX-App configurations
-
-/**
- * @def OPENTHREAD_POSIX_CONFIG_RCP_PTY_ENABLE
- *
- * Define as 1 to enable PTY device support in POSIX app.
- *
- */
-#define OPENTHREAD_POSIX_CONFIG_RCP_PTY_ENABLE 1
-
-/**
- * @def OPENTHREAD_POSIX_CONFIG_RCP_UART_ENABLE
- *
- * Define as 1 to enable UART interface to RCP.
- *
- */
-#define OPENTHREAD_POSIX_CONFIG_RCP_UART_ENABLE 1
-
-#endif /* OPENTHREAD_CORE_TORANJ_CONFIG_H_ */


### PR DESCRIPTION
This PR contains two commits:

**[toranj] define platform specific config headers**
    
This commit adds platform specific config header for simulation and posix platforms for toranj. The common configuration definitions stay in the `openthread-core-toranj-config.h` and are shared for all platforms. The `build.sh` script is also updated to pick the correct platform-specific config header for both cmake or autoconf builds.

 **[travis] add build checks for cmake with toranj configs (for simul/posix platforms)**

----

This change should also help address issue with the `./tests/toranj/build cmake` not defining the `OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE=1`. 