### PR TITLE
[cc1352,cc26xx] include `-pedantic-errors` in platform code

### DIFF
--- a/examples/platforms/cc1352/Makefile.am
+++ b/examples/platforms/cc1352/Makefile.am
@@ -30,10 +30,6 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 lib_LIBRARIES = libopenthread-cc1352.a
 
-# Do not enable -pedantic-errors for cc13xx driverlib
-override CFLAGS   := $(filter-out -pedantic-errors,$(CFLAGS))
-override CXXFLAGS := $(filter-out -pedantic-errors,$(CXXFLAGS))
-
 libopenthread_cc1352_a_CPPFLAGS                                                         = \
     -I$(top_srcdir)/include                                                               \
     -I$(top_srcdir)/src                                                                   \

--- a/examples/platforms/cc1352/flash.c
+++ b/examples/platforms/cc1352/flash.c
@@ -214,7 +214,7 @@ void otPlatFlashWrite(otInstance *aInstance, uint8_t aSwapIndex, uint32_t aOffse
     while (written < aSize)
     {
         uint32_t       toWrite = aSize - written;
-        const uint8_t *data    = aData + written;
+        const uint8_t *data    = (uint8_t *)aData + written;
         uint32_t       fsmRet;
         bool           interruptsWereDisabled;
 

--- a/examples/platforms/cc2650/Makefile.am
+++ b/examples/platforms/cc2650/Makefile.am
@@ -30,10 +30,6 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 lib_LIBRARIES                                         = libopenthread-cc2650.a
 
-# Do not enable -pedantic-errors for cc26xx driverlib
-override CFLAGS                                      := $(filter-out -pedantic-errors,$(CFLAGS))
-override CXXFLAGS                                    := $(filter-out -pedantic-errors,$(CXXFLAGS))
-
 libopenthread_cc2650_a_CPPFLAGS                       = \
     -I$(top_srcdir)/include                             \
     -I$(top_srcdir)/src                                 \

--- a/examples/platforms/cc2652/Makefile.am
+++ b/examples/platforms/cc2652/Makefile.am
@@ -30,10 +30,6 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
 lib_LIBRARIES = libopenthread-cc2652.a
 
-# Do not enable -pedantic-errors for cc26xx driverlib
-override CFLAGS   := $(filter-out -pedantic-errors,$(CFLAGS))
-override CXXFLAGS := $(filter-out -pedantic-errors,$(CXXFLAGS))
-
 libopenthread_cc2652_a_CPPFLAGS                                                         = \
     -I$(top_srcdir)/include                                                               \
     -I$(top_srcdir)/src                                                                   \

--- a/examples/platforms/cc2652/flash.c
+++ b/examples/platforms/cc2652/flash.c
@@ -214,7 +214,7 @@ void otPlatFlashWrite(otInstance *aInstance, uint8_t aSwapIndex, uint32_t aOffse
     while (written < aSize)
     {
         uint32_t       toWrite = aSize - written;
-        const uint8_t *data    = aData + written;
+        const uint8_t *data    = (uint8_t *)aData + written;
         uint32_t       fsmRet;
         bool           interruptsWereDisabled;
 


### PR DESCRIPTION
- Also fix a pointer arithmetic issue that was flagged.