### PR TITLE
[flash] improve power failure robustness

### DIFF
--- a/src/core/utils/flash.cpp
+++ b/src/core/utils/flash.cpp
@@ -183,6 +183,8 @@ otError Flash::Add(uint16_t aKey, bool aFirst, const uint8_t *aValue, uint16_t a
     record.Init(aKey, aFirst);
     record.SetData(aValue, aValueLength);
 
+    OT_ASSERT((mSwapSize - record.GetSize()) >= kSwapMarkerSize);
+
     if ((mSwapSize - record.GetSize()) < mSwapUsed)
     {
         Swap();

--- a/src/core/utils/flash.cpp
+++ b/src/core/utils/flash.cpp
@@ -116,7 +116,7 @@ otError Flash::Get(uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueL
 {
     otError      error       = OT_ERROR_NOT_FOUND;
     uint16_t     valueLength = 0;
-    int          index       = 0;
+    int          index = 0; // This must be initalized to 0. See [Note] in Delete().
     uint32_t     offset;
     RecordHeader record;
 
@@ -255,8 +255,8 @@ exit:
 
 otError Flash::Delete(uint16_t aKey, int aIndex)
 {
-    otError      error = OT_ERROR_NOT_FOUND;
-    int          index = 0;
+    otError error = OT_ERROR_NOT_FOUND;
+    int index = 0; // This must be initalized to 0. See [Note] below.
     RecordHeader record;
 
     for (uint32_t offset = kSwapMarkerSize; offset < mSwapUsed; offset += record.GetSize())
@@ -279,6 +279,10 @@ otError Flash::Delete(uint16_t aKey, int aIndex)
             otPlatFlashWrite(&GetInstance(), mSwapIndex, offset, &record, sizeof(record));
             error = OT_ERROR_NONE;
         }
+
+        /* [Note] If the operation gets interrupted here and aIndex is 0, the next record (index == 1) will never get
+         * marked as first. However, this is not actually an issue because all the methods that iterate over the
+         * settings area initialize the index to 0, without expecting any record to be effectively marked as first. */
 
         if ((index == 1) && (aIndex == 0))
         {

--- a/src/core/utils/flash.cpp
+++ b/src/core/utils/flash.cpp
@@ -116,7 +116,7 @@ otError Flash::Get(uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueL
 {
     otError      error       = OT_ERROR_NOT_FOUND;
     uint16_t     valueLength = 0;
-    int          index = 0; // This must be initalized to 0. See [Note] in Delete().
+    int          index       = 0; // This must be initalized to 0. See [Note] in Delete().
     uint32_t     offset;
     RecordHeader record;
 
@@ -255,8 +255,8 @@ exit:
 
 otError Flash::Delete(uint16_t aKey, int aIndex)
 {
-    otError error = OT_ERROR_NOT_FOUND;
-    int index = 0; // This must be initalized to 0. See [Note] below.
+    otError      error = OT_ERROR_NOT_FOUND;
+    int          index = 0; // This must be initalized to 0. See [Note] below.
     RecordHeader record;
 
     for (uint32_t offset = kSwapMarkerSize; offset < mSwapUsed; offset += record.GetSize())

--- a/src/core/utils/flash.hpp
+++ b/src/core/utils/flash.hpp
@@ -222,6 +222,7 @@ private:
 
     otError Add(uint16_t aKey, bool aFirst, const uint8_t *aValue, uint16_t aValueLength);
     bool    DoesValidRecordExist(uint32_t aOffset, uint16_t aKey) const;
+    void    SanitizeFreeSpace(void);
     void    Swap(void);
 
     uint32_t mSwapSize;


### PR DESCRIPTION
This PR improves the flash implementation robustness to power failure. The idea is the following:

The `Init` method now checks if a record has been partially written by seeing if the `kFlagAddBegin` flag is set, but the `kFlagComplete` flag is not. In this case, `Init` stops incrementing `mSwapUsed`. The new `SanitizeFreeSpace` method checks the (supposedly) free space, to see if it is writeable. If it isn't, it triggers a `Swap`, which sanitizes the flash area.

Please see #4710 and https://github.com/openthread/openthread/pull/4552#issuecomment-592943770.

There is an additional subtle detail: the `Delete` method, when called with `aIndex = 0`, erases the records without first marking the `index = 1` record with `kFlagFirst`. If the operation is interrupted at this point, no record will have the `kFlagFirst` flag set. At first, this struck me as a possible issue, but actually it's not: all the methods that iterate over the settings area initialize `index = 0` without expecting a record with the `kFlagFirst` flag set. Maybe we could add a comment, so that this doesn't get lost during a future code refactoring, or maybe it's obvious for the casual reader (it wasn't obvious to me...).
