### PR TITLE
Avoid comparison of narrow type with wide type in loop

### DIFF
--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -570,13 +570,12 @@ otError OptionIterator::GetOptionValue(uint64_t &aValue) const
 {
     otError error = OT_ERROR_NONE;
     uint8_t value[sizeof(aValue)];
-    uint8_t pos = 0;
 
     VerifyOrExit(mOption.mLength <= sizeof(aValue), error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = GetOptionValue(value));
 
     aValue = 0;
-    for (pos = 0; pos < mOption.mLength; pos++)
+    for (uint16_t pos = 0; pos < mOption.mLength; pos++)
     {
         aValue <<= 8;
         aValue |= value[pos];

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -353,6 +353,7 @@ private:
         kExtHdrEidMask     = 0x0e,
 
         kExtHdrNextHeader = 0x01,
+        kExtHdrMaxLength  = 255,
 
         kUdpDispatch     = 0xf0,
         kUdpDispatchMask = 0xf8,

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -309,7 +309,6 @@ void Leader::SendCommissioningGetResponse(const Coap::Message &   aRequest,
 {
     otError        error = OT_ERROR_NONE;
     Coap::Message *message;
-    uint8_t        index;
     uint8_t *      data   = NULL;
     uint8_t        length = 0;
 
@@ -337,7 +336,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Message &   aRequest,
     }
     else
     {
-        for (index = 0; index < aLength; index++)
+        for (uint16_t index = 0; index < aLength; index++)
         {
             uint8_t type;
 


### PR DESCRIPTION
- [network-data] avoid comparison of narrow type with wide type in loop
- [coap] avoid comparison of narrow type with wide type in loop
- [lowpan] do not try to compress large extension headers