### PR TITLE
[travis] disable build checks that exist in GitHub Actions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -110,83 +110,6 @@ jobs:
       os: linux
       compiler: gcc
       script: .travis/script.sh
-    - env: BUILD_TARGET="scan-build"
-      os: linux
-      compiler: clang
-      script: .travis/script.sh
-    - env: BUILD_TARGET="arm-gcc-4"
-      os: linux
-      compiler: gcc
-      script: .travis/script.sh
-    - env: BUILD_TARGET="arm-gcc-5"
-      os: linux
-      compiler: gcc
-      script: .travis/script.sh
-    - env: BUILD_TARGET="arm-gcc-6"
-      os: linux
-      compiler: gcc
-      script: .travis/script.sh
-    - env: BUILD_TARGET="arm-gcc-7"
-      os: linux
-      compiler: gcc
-      script: .travis/script.sh
-# Disable Arm GCC 8 until slow compile bug is fixed:
-# https://github.com/openthread/openthread/issues/4053
-#    - env: BUILD_TARGET="arm-gcc-8"
-#      os: linux
-#      compiler: gcc
-#      script: .travis/script.sh
-    - env: BUILD_TARGET="arm-gcc-9"
-      os: linux
-      compiler: gcc
-      script: .travis/script.sh
-    - env: BUILD_TARGET="simulation" CC="gcc-5" CXX="g++-5"
-      os: linux
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - gcc-5
-            - g++-5
-      script: .travis/script.sh
-    - env: BUILD_TARGET="simulation" CC="gcc-6" CXX="g++-6"
-      os: linux
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - gcc-6
-            - g++-6
-      script: .travis/script.sh
-    - env: BUILD_TARGET="simulation" CC="gcc-7" CXX="g++-7"
-      os: linux
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - gcc-7
-            - g++-7
-      script: .travis/script.sh
-    - env: BUILD_TARGET="simulation" CC="gcc-8" CXX="g++-8"
-      os: linux
-      compiler: gcc
-      addons:
-        apt:
-          packages:
-            - gcc-8
-            - g++-8
-      script: .travis/script.sh
-    - env: BUILD_TARGET="simulation" CC="gcc-9" CXX="g++-9"
-      os: linux
-      compiler: gcc
-      addons:
-        apt:
-          sources:
-            - sourceline: "ppa:ubuntu-toolchain-r/test"
-          packages:
-            - gcc-9
-            - g++-9
-      script: .travis/script.sh
     - env: BUILD_TARGET="simulation-ncp-spi" VERBOSE=1
       os: linux
       compiler: gcc
@@ -199,23 +122,7 @@ jobs:
       os: linux
       compiler: gcc
       script: .travis/script.sh
-    - env: BUILD_TARGET="osx" VERBOSE=1
-      os: osx
-      language: generic
-      script: .travis/script.sh
     - stage: lint
-      name: "Pretty Check"
-      os: linux
-      addons:
-        apt:
-          packages:
-            - clang-format-6.0
-      script: python3 -m pip install yapf && script/make-pretty check
-    - name: "Package Check"
-      os: linux
-      compiler: gcc
-      script: pip3 install -U cmake && script/test package
-    - env:
       name: "Size Report"
       os: linux
       script: .travis/check-size


### PR DESCRIPTION
If/when we are comfortable with GitHub Actions, we can start disabling redundant Travis tests.