### PR TITLE
[network-data] adding helper methods, simplify code

### DIFF
--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -888,31 +888,14 @@ exit:
 
 int8_t NetworkData::PrefixMatch(const uint8_t *a, const uint8_t *b, uint8_t aLength)
 {
-    int8_t  rval  = 0;
-    uint8_t bytes = BitVectorBytes(aLength);
-    uint8_t diff;
+    uint8_t matchedLength;
 
-    for (uint8_t i = 0; i < bytes; i++)
-    {
-        diff = a[i] ^ b[i];
+    // Note that he `Ip6::Address::PrefixMatch` expects the prefix
+    // length to be in bytes unit.
 
-        if (diff == 0)
-        {
-            rval += 8;
-        }
-        else
-        {
-            while ((diff & 0x80) == 0)
-            {
-                rval++;
-                diff <<= 1;
-            }
+    matchedLength = Ip6::Address::PrefixMatch(a, b, BitVectorBytes(aLength));
 
-            break;
-        }
-    }
-
-    return (rval >= aLength) ? rval : -1;
+    return (matchedLength >= aLength) ? static_cast<int8_t>(matchedLength) : -1;
 }
 
 ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -193,17 +193,12 @@ otError NetworkData::GetNextOnMeshPrefix(Iterator &aIterator, uint16_t aRloc16, 
     otError             error = OT_ERROR_NOT_FOUND;
     NetworkDataIterator iterator(aIterator);
 
-    for (NetworkDataTlv *tlv; (tlv = FindTlv(iterator, NetworkDataTlv::kTypePrefix)) != NULL;
-         IterateToNextTlv(iterator))
+    for (PrefixTlv *prefix; (prefix = FindTlv<PrefixTlv>(iterator)) != NULL; IterateToNextTlv(iterator))
     {
-        PrefixTlv *prefix = static_cast<PrefixTlv *>(tlv);
-
-        for (NetworkDataTlv *subTlv; (subTlv = FindSubTlv(iterator, NetworkDataTlv::kTypeBorderRouter,
-                                                          prefix->GetSubTlvs(), prefix->GetNext())) != NULL;
+        for (BorderRouterTlv *borderRouter;
+             (borderRouter = FindSubTlv<BorderRouterTlv>(iterator, prefix->GetSubTlvs(), prefix->GetNext())) != NULL;
              IterateToNextSubTlv(iterator, prefix->GetSubTlvs()))
         {
-            BorderRouterTlv *borderRouter = static_cast<BorderRouterTlv *>(subTlv);
-
             for (uint8_t index = iterator.GetEntryIndex(); index < borderRouter->GetNumEntries(); index++)
             {
                 if (aRloc16 == Mac::kShortAddrBroadcast || borderRouter->GetEntry(index)->GetRloc() == aRloc16)
@@ -245,17 +240,12 @@ otError NetworkData::GetNextExternalRoute(Iterator &aIterator, uint16_t aRloc16,
     otError             error = OT_ERROR_NOT_FOUND;
     NetworkDataIterator iterator(aIterator);
 
-    for (NetworkDataTlv *tlv; (tlv = FindTlv(iterator, NetworkDataTlv::kTypePrefix)) != NULL;
-         IterateToNextTlv(iterator))
+    for (PrefixTlv *prefix; (prefix = FindTlv<PrefixTlv>(iterator)) != NULL; IterateToNextTlv(iterator))
     {
-        PrefixTlv *prefix = static_cast<PrefixTlv *>(tlv);
-
-        for (NetworkDataTlv *subTlv; (subTlv = FindSubTlv(iterator, NetworkDataTlv::kTypeHasRoute, prefix->GetSubTlvs(),
-                                                          prefix->GetNext())) != NULL;
+        for (HasRouteTlv *hasRoute;
+             (hasRoute = FindSubTlv<HasRouteTlv>(iterator, prefix->GetSubTlvs(), prefix->GetNext())) != NULL;
              IterateToNextSubTlv(iterator, prefix->GetSubTlvs()))
         {
-            HasRouteTlv *hasRoute = static_cast<HasRouteTlv *>(subTlv);
-
             for (uint8_t index = iterator.GetEntryIndex(); index < hasRoute->GetNumEntries(); index++)
             {
                 if (aRloc16 == Mac::kShortAddrBroadcast || hasRoute->GetEntry(index)->GetRloc() == aRloc16)
@@ -292,17 +282,12 @@ otError NetworkData::GetNextService(Iterator &aIterator, uint16_t aRloc16, Servi
     otError             error = OT_ERROR_NOT_FOUND;
     NetworkDataIterator iterator(aIterator);
 
-    for (NetworkDataTlv *tlv; (tlv = FindTlv(iterator, NetworkDataTlv::kTypeService)) != NULL;
-         IterateToNextTlv(iterator))
+    for (ServiceTlv *service; (service = FindTlv<ServiceTlv>(iterator)) != NULL; IterateToNextTlv(iterator))
     {
-        ServiceTlv *service = static_cast<ServiceTlv *>(tlv);
-
-        for (NetworkDataTlv *subTlv; (subTlv = FindSubTlv(iterator, NetworkDataTlv::kTypeServer, service->GetSubTlvs(),
-                                                          service->GetNext())) != NULL;
+        for (ServerTlv *server;
+             (server = FindSubTlv<ServerTlv>(iterator, service->GetSubTlvs(), service->GetNext())) != NULL;
              IterateToNextSubTlv(iterator, service->GetSubTlvs()))
         {
-            ServerTlv *server = static_cast<ServerTlv *>(subTlv);
-
             if (!iterator.IsNewEntry())
             {
                 continue;
@@ -615,30 +600,27 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Serv
 
 BorderRouterTlv *NetworkData::FindBorderRouter(PrefixTlv &aPrefix)
 {
-    return static_cast<BorderRouterTlv *>(
-        FindTlv(aPrefix.GetSubTlvs(), aPrefix.GetNext(), NetworkDataTlv::kTypeBorderRouter));
+    return FindTlv<BorderRouterTlv>(aPrefix.GetSubTlvs(), aPrefix.GetNext());
 }
 
 BorderRouterTlv *NetworkData::FindBorderRouter(PrefixTlv &aPrefix, bool aStable)
 {
-    return static_cast<BorderRouterTlv *>(
-        FindTlv(aPrefix.GetSubTlvs(), aPrefix.GetNext(), NetworkDataTlv::kTypeBorderRouter, aStable));
+    return FindTlv<BorderRouterTlv>(aPrefix.GetSubTlvs(), aPrefix.GetNext(), aStable);
 }
 
 HasRouteTlv *NetworkData::FindHasRoute(PrefixTlv &aPrefix)
 {
-    return static_cast<HasRouteTlv *>(FindTlv(aPrefix.GetSubTlvs(), aPrefix.GetNext(), NetworkDataTlv::kTypeHasRoute));
+    return FindTlv<HasRouteTlv>(aPrefix.GetSubTlvs(), aPrefix.GetNext());
 }
 
 HasRouteTlv *NetworkData::FindHasRoute(PrefixTlv &aPrefix, bool aStable)
 {
-    return static_cast<HasRouteTlv *>(
-        FindTlv(aPrefix.GetSubTlvs(), aPrefix.GetNext(), NetworkDataTlv::kTypeHasRoute, aStable));
+    return FindTlv<HasRouteTlv>(aPrefix.GetSubTlvs(), aPrefix.GetNext(), aStable);
 }
 
 ContextTlv *NetworkData::FindContext(PrefixTlv &aPrefix)
 {
-    return static_cast<ContextTlv *>(FindTlv(aPrefix.GetSubTlvs(), aPrefix.GetNext(), NetworkDataTlv::kTypeContext));
+    return FindTlv<ContextTlv>(aPrefix.GetSubTlvs(), aPrefix.GetNext());
 }
 
 PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength)
@@ -654,7 +636,7 @@ PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength
 
     while (start < end)
     {
-        prefixTlv = static_cast<PrefixTlv *>(FindTlv(start, end, NetworkDataTlv::kTypePrefix));
+        prefixTlv = FindTlv<PrefixTlv>(start, end);
 
         VerifyOrExit(prefixTlv != NULL);
 
@@ -704,7 +686,7 @@ ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,
 
     while (start < end)
     {
-        serviceTlv = static_cast<ServiceTlv *>(FindTlv(start, end, NetworkDataTlv::kTypeService));
+        serviceTlv = FindTlv<ServiceTlv>(start, end);
 
         VerifyOrExit(serviceTlv != NULL);
 

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -712,7 +712,7 @@ NetworkDataTlv *NetworkData::AppendTlv(uint8_t aTlvSize)
 
     VerifyOrExit(mLength + aTlvSize <= kMaxSize, tlv = NULL);
 
-    tlv = reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength);
+    tlv = GetTlvsEnd();
     mLength += aTlvSize;
 
 exit:

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -323,7 +323,7 @@ otError NetworkData::GetNextService(Iterator &aIterator, uint16_t aRloc16, Servi
                 memcpy(&aConfig.mServerConfig.mServerData, server->GetServerData(), server->GetServerDataLength());
                 aConfig.mServerConfig.mRloc16 = server->GetServer16();
 
-                iterator.MarkEntryAsNotnew();
+                iterator.MarkEntryAsNotNew();
 
                 ExitNow(error = OT_ERROR_NONE);
             }

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -724,6 +724,19 @@ exit:
     return serviceTlv;
 }
 
+NetworkDataTlv *NetworkData::AppendTlv(uint8_t aTlvSize)
+{
+    NetworkDataTlv *tlv;
+
+    VerifyOrExit(mLength + aTlvSize <= kMaxSize, tlv = NULL);
+
+    tlv = reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength);
+    mLength += aTlvSize;
+
+exit:
+    return tlv;
+}
+
 void NetworkData::Insert(uint8_t *aStart, uint8_t aLength)
 {
     OT_ASSERT(aLength + mLength <= sizeof(mTlvs) && mTlvs <= aStart && aStart <= mTlvs + mLength);

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -737,10 +737,12 @@ exit:
     return tlv;
 }
 
-void NetworkData::Insert(uint8_t *aStart, uint8_t aLength)
+void NetworkData::Insert(void *aStart, uint8_t aLength)
 {
-    OT_ASSERT(aLength + mLength <= sizeof(mTlvs) && mTlvs <= aStart && aStart <= mTlvs + mLength);
-    memmove(aStart + aLength, aStart, mLength - static_cast<size_t>(aStart - mTlvs));
+    uint8_t *start = reinterpret_cast<uint8_t *>(aStart);
+
+    OT_ASSERT(aLength + mLength <= sizeof(mTlvs) && mTlvs <= start && start <= mTlvs + mLength);
+    memmove(start + aLength, start, mLength - static_cast<size_t>(start - mTlvs));
     mLength += aLength;
 }
 
@@ -760,9 +762,9 @@ void NetworkData::RemoveTlv(uint8_t *aData, uint8_t &aDataLength, NetworkDataTlv
     Remove(aData, aDataLength, reinterpret_cast<uint8_t *>(aTlv), aTlv->GetSize());
 }
 
-void NetworkData::Remove(uint8_t *aRemoveStart, uint8_t aRemoveLength)
+void NetworkData::Remove(void *aRemoveStart, uint8_t aRemoveLength)
 {
-    NetworkData::Remove(mTlvs, mLength, aRemoveStart, aRemoveLength);
+    NetworkData::Remove(mTlvs, mLength, reinterpret_cast<uint8_t *>(aRemoveStart), aRemoveLength);
 }
 
 void NetworkData::RemoveTlv(NetworkDataTlv *aTlv)

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -430,6 +430,20 @@ protected:
                             uint8_t        aTlvsLength);
 
     /**
+     * This method grows the Network Data to append a TLV with a requested size.
+     *
+     * On success, the returned TLV is not initialized (i.e., the TLV Length field is not set) but the requested
+     * size for it (@p aTlvSize number of bytes) is reserved in the Network Data.
+     *
+     * @param[in]  aTlvSize  The size of TLV (total number of bytes including Type, Length, and Value fields)
+     *
+     * @returns A pointer to the TLV if there is space to grow Network Data, or NULL if no space to grow the Network
+     *          Data with requested @p aTlvSize number of bytes.
+     *
+     */
+    NetworkDataTlv *AppendTlv(uint8_t aTlvSize);
+
+    /**
      * This method inserts bytes into the Network Data.
      *
      * @param[in]  aStart   A pointer to the beginning of the insertion.

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -502,6 +502,43 @@ protected:
      */
     otError SendServerDataNotification(uint16_t aRloc16);
 
+    /**
+     * This static method searches in a given sequence of TLVs to find the first TLV with a given TLV Type.
+     *
+     * @param[in]  aStart  A pointer to the start of the sequence of TLVs to search within.
+     * @param[in]  aEnd    A pointer to the end of the sequence of TLVs.
+     * @param[in]  aType   The TLV type to find.
+     *
+     * @returns A pointer to the TLV if found, or NULL if not found.
+     *
+     */
+    static NetworkDataTlv *FindTlv(NetworkDataTlv *aStart, NetworkDataTlv *aEnd, NetworkDataTlv::Type aType);
+
+    /**
+     * This static method searches in a given sequence of TLVs to find the first TLV with a given TLV Type and stable
+     * flag.
+     *
+     * @param[in]  aStart  A pointer to the start of the sequence of TLVs to search within.
+     * @param [in] aEnd    A pointer to the end of the sequence of TLVs.
+     * @param[in]  aType   The TLV type to find.
+     * @param[in]  aStable TRUE if to find a stable TLV, FALSE otherwise.
+     *
+     * @returns A pointer to the TLV if found, or NULL if not found.
+     *
+     */
+    static NetworkDataTlv *FindTlv(NetworkDataTlv *     aStart,
+                                   NetworkDataTlv *     aEnd,
+                                   NetworkDataTlv::Type aType,
+                                   bool                 aStable);
+
+    /**
+     * This method returns a pointer to the end of Network Data TLV sequence.
+     *
+     * @returns A pointer to the end of Network Data TLV sequence.
+     *
+     */
+    NetworkDataTlv *GetTlvsEnd(void) { return reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength); }
+
     uint8_t mTlvs[kMaxSize]; ///< The Network Data buffer.
     uint8_t mLength;         ///< The number of valid bytes in @var mTlvs.
 
@@ -528,6 +565,19 @@ private:
         void    SetSubTlvOffset(uint8_t aOffset) { mIteratorBuffer[kSubTlvPosition] = aOffset; }
         void    SetEntryIndex(uint8_t aIndex) { mIteratorBuffer[kEntryPosition] = aIndex; }
 
+        bool IsNewEntry(void) const { return GetEntryIndex() == 0; }
+        void MarkEntryAsNotnew(void) { SetEntryIndex(1); }
+
+        NetworkDataTlv *GetTlv(uint8_t *aTlvs) const
+        {
+            return reinterpret_cast<NetworkDataTlv *>(aTlvs + GetTlvOffset());
+        }
+
+        NetworkDataTlv *GetSubTlv(NetworkDataTlv *aSubTlvs)
+        {
+            return reinterpret_cast<NetworkDataTlv *>(reinterpret_cast<uint8_t *>(aSubTlvs) + GetSubTlvOffset());
+        }
+
         void SaveTlvOffset(const NetworkDataTlv *aTlv, const uint8_t *aTlvs)
         {
             SetTlvOffset(static_cast<uint8_t>(reinterpret_cast<const uint8_t *>(aTlv) - aTlvs));
@@ -549,6 +599,14 @@ private:
 
         uint8_t *mIteratorBuffer;
     };
+
+    NetworkDataTlv *FindTlv(NetworkDataIterator &aIterator, NetworkDataTlv::Type aTlvType);
+    void            IterateToNextTlv(NetworkDataIterator &aIterator);
+    NetworkDataTlv *FindSubTlv(NetworkDataIterator &aIterator,
+                               NetworkDataTlv::Type aSubTlvType,
+                               NetworkDataTlv *     aSubTlvs,
+                               NetworkDataTlv *     aSubTlvsEnd);
+    void            IterateToNextSubTlv(NetworkDataIterator &aIterator, NetworkDataTlv *aSubTlvs);
 
     const Type mType;
     TimeMilli  mLastAttempt;

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -575,6 +575,13 @@ private:
     class NetworkDataIterator
     {
     public:
+        enum Type
+        {
+            kTypeOnMeshPrefix  = 0,
+            kTypeExternalRoute = 1,
+            kTypeService       = 2,
+        };
+
         explicit NetworkDataIterator(Iterator &aIterator)
             : mIteratorBuffer(reinterpret_cast<uint8_t *>(&aIterator))
         {
@@ -583,9 +590,11 @@ private:
         uint8_t GetTlvOffset(void) const { return mIteratorBuffer[kTlvPosition]; }
         uint8_t GetSubTlvOffset(void) const { return mIteratorBuffer[kSubTlvPosition]; }
         uint8_t GetEntryIndex(void) const { return mIteratorBuffer[kEntryPosition]; }
+        Type    GetType(void) const { return static_cast<Type>(mIteratorBuffer[kTypePosition]); }
         void    SetTlvOffset(uint8_t aOffset) { mIteratorBuffer[kTlvPosition] = aOffset; }
         void    SetSubTlvOffset(uint8_t aOffset) { mIteratorBuffer[kSubTlvPosition] = aOffset; }
         void    SetEntryIndex(uint8_t aIndex) { mIteratorBuffer[kEntryPosition] = aIndex; }
+        void    SetType(Type aType) { mIteratorBuffer[kTypePosition] = static_cast<uint8_t>(aType); }
 
         bool IsNewEntry(void) const { return GetEntryIndex() == 0; }
         void MarkEntryAsNotnew(void) { SetEntryIndex(1); }
@@ -617,6 +626,7 @@ private:
             kTlvPosition    = 0,
             kSubTlvPosition = 1,
             kEntryPosition  = 2,
+            kTypePosition   = 3,
         };
 
         uint8_t *mIteratorBuffer;

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -337,7 +337,7 @@ protected:
      * This method returns a pointer to the stable or non-stable Border Router TLV within a given Prefix TLV.
      *
      * @param[in]  aPrefix  A reference to the Prefix TLV.
-     * @param[in]  aStable  TRUE if requesting a stable Border Router TLV, FALSE otherwise.
+     * @param[in]  aStable  TRUE to find a stable TLV, FALSE to find a TLV not marked as stable..
      *
      * @returns A pointer to the Border Router TLV if one is found or NULL if no Border Router TLV exists.
      *
@@ -358,7 +358,7 @@ protected:
      * This method returns a pointer to the stable or non-stable Has Route TLV within a given Prefix TLV.
      *
      * @param[in]  aPrefix  A reference to the Prefix TLV.
-     * @param[in]  aStable  TRUE if requesting a stable Has Route TLV, FALSE otherwise.
+     * @param[in]  aStable  TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
      *
      * @returns A pointer to the Has Route TLV if one is found or NULL if no Has Route TLV exists.
      *
@@ -543,7 +543,7 @@ protected:
      * @param[in]  aStart  A pointer to the start of the sequence of TLVs to search within.
      * @param [in] aEnd    A pointer to the end of the sequence of TLVs.
      * @param[in]  aType   The TLV type to find.
-     * @param[in]  aStable TRUE if to find a stable TLV, FALSE otherwise.
+     * @param[in]  aStable TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
      *
      * @returns A pointer to the TLV if found, or NULL if not found.
      *
@@ -597,7 +597,7 @@ private:
         void    SetType(Type aType) { mIteratorBuffer[kTypePosition] = static_cast<uint8_t>(aType); }
 
         bool IsNewEntry(void) const { return GetEntryIndex() == 0; }
-        void MarkEntryAsNotnew(void) { SetEntryIndex(1); }
+        void MarkEntryAsNotNew(void) { SetEntryIndex(1); }
 
         NetworkDataTlv *GetTlv(uint8_t *aTlvs) const
         {

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -441,11 +441,19 @@ protected:
     /**
      * This method removes bytes from the Network Data.
      *
-     * @param[in]  aStart   A pointer to the beginning of the removal.
-     * @param[in]  aLength  The number of bytes to remove.
+     * @param[in]  aRemoveStart   A pointer to the beginning of the removal.
+     * @param[in]  aRemoveLength  The number of bytes to remove.
      *
      */
-    void Remove(uint8_t *aStart, uint8_t aLength);
+    void Remove(uint8_t *aRemoveStart, uint8_t aRemoveLength);
+
+    /**
+     * This method removes a TLV from the Network Data.
+     *
+     * @param[in]  aTlv   The TLV to remove.
+     *
+     */
+    void RemoveTlv(NetworkDataTlv *aTlv);
 
     /**
      * This method strips non-stable data from the Thread Network Data.
@@ -599,6 +607,9 @@ private:
 
         uint8_t *mIteratorBuffer;
     };
+
+    static void Remove(uint8_t *aData, uint8_t &aDataLength, uint8_t *aRemoveStart, uint8_t aRemoveLength);
+    static void RemoveTlv(uint8_t *aData, uint8_t &aDataLength, NetworkDataTlv *aTlv);
 
     NetworkDataTlv *FindTlv(NetworkDataIterator &aIterator, NetworkDataTlv::Type aTlvType);
     void            IterateToNextTlv(NetworkDataIterator &aIterator);

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -324,6 +324,22 @@ public:
 
 protected:
     /**
+     * This method returns a pointer to the start of Network Data TLV sequence.
+     *
+     * @returns A pointer to the start of Network Data TLV sequence.
+     *
+     */
+    NetworkDataTlv *GetTlvsStart(void) { return reinterpret_cast<NetworkDataTlv *>(mTlvs); }
+
+    /**
+     * This method returns a pointer to the end of Network Data TLV sequence.
+     *
+     * @returns A pointer to the end of Network Data TLV sequence.
+     *
+     */
+    NetworkDataTlv *GetTlvsEnd(void) { return reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength); }
+
+    /**
      * This method returns a pointer to the Border Router TLV within a given Prefix TLV.
      *
      * @param[in]  aPrefix  A reference to the Prefix TLV.
@@ -584,14 +600,6 @@ protected:
         return static_cast<TlvType *>(
             FindTlv(aStart, aEnd, static_cast<NetworkDataTlv::Type>(TlvType::kType), aStable));
     }
-
-    /**
-     * This method returns a pointer to the end of Network Data TLV sequence.
-     *
-     * @returns A pointer to the end of Network Data TLV sequence.
-     *
-     */
-    NetworkDataTlv *GetTlvsEnd(void) { return reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength); }
 
     uint8_t mTlvs[kMaxSize]; ///< The Network Data buffer.
     uint8_t mLength;         ///< The number of valid bytes in @var mTlvs.

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -450,7 +450,7 @@ protected:
      * @param[in]  aLength  The number of bytes to insert.
      *
      */
-    void Insert(uint8_t *aStart, uint8_t aLength);
+    void Insert(void *aStart, uint8_t aLength);
 
     /**
      * This method removes bytes from the Network Data.
@@ -459,7 +459,7 @@ protected:
      * @param[in]  aRemoveLength  The number of bytes to remove.
      *
      */
-    void Remove(uint8_t *aRemoveStart, uint8_t aRemoveLength);
+    void Remove(void *aRemoveStart, uint8_t aRemoveLength);
 
     /**
      * This method removes a TLV from the Network Data.

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -537,6 +537,21 @@ protected:
     static NetworkDataTlv *FindTlv(NetworkDataTlv *aStart, NetworkDataTlv *aEnd, NetworkDataTlv::Type aType);
 
     /**
+     * This static template method searches in a given sequence of TLVs to find the first TLV with a give template
+     * `TlvType`.
+     *
+     * @param[in]  aStart  A pointer to the start of the sequence of TLVs to search within.
+     * @param[in]  aEnd    A pointer to the end of the sequence of TLVs.
+     *
+     * @returns A pointer to the TLV if found, or NULL if not found.
+     *
+     */
+    template <typename TlvType> static TlvType *FindTlv(NetworkDataTlv *aStart, NetworkDataTlv *aEnd)
+    {
+        return static_cast<TlvType *>(FindTlv(aStart, aEnd, static_cast<NetworkDataTlv::Type>(TlvType::kType)));
+    }
+
+    /**
      * This static method searches in a given sequence of TLVs to find the first TLV with a given TLV Type and stable
      * flag.
      *
@@ -552,6 +567,23 @@ protected:
                                    NetworkDataTlv *     aEnd,
                                    NetworkDataTlv::Type aType,
                                    bool                 aStable);
+
+    /**
+     * This template static method searches in a given sequence of TLVs to find the first TLV with a given TLV Type and
+     * stable flag.
+     *
+     * @param[in]  aStart  A pointer to the start of the sequence of TLVs to search within.
+     * @param [in] aEnd    A pointer to the end of the sequence of TLVs.
+     * @param[in]  aStable TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
+     *
+     * @returns A pointer to the TLV if found, or NULL if not found.
+     *
+     */
+    template <typename TlvType> static TlvType *FindTlv(NetworkDataTlv *aStart, NetworkDataTlv *aEnd, bool aStable)
+    {
+        return static_cast<TlvType *>(
+            FindTlv(aStart, aEnd, static_cast<NetworkDataTlv::Type>(TlvType::kType), aStable));
+    }
 
     /**
      * This method returns a pointer to the end of Network Data TLV sequence.
@@ -642,6 +674,18 @@ private:
                                NetworkDataTlv *     aSubTlvs,
                                NetworkDataTlv *     aSubTlvsEnd);
     void            IterateToNextSubTlv(NetworkDataIterator &aIterator, NetworkDataTlv *aSubTlvs);
+
+    template <typename TlvType> TlvType *FindTlv(NetworkDataIterator &aIterator)
+    {
+        return static_cast<TlvType *>(FindTlv(aIterator, static_cast<NetworkDataTlv::Type>(TlvType::kType)));
+    }
+
+    template <typename TlvType>
+    TlvType *FindSubTlv(NetworkDataIterator &aIterator, NetworkDataTlv *aSubTlvs, NetworkDataTlv *aSubTlvsEnd)
+    {
+        return static_cast<TlvType *>(
+            FindSubTlv(aIterator, static_cast<NetworkDataTlv::Type>(TlvType::kType), aSubTlvs, aSubTlvsEnd));
+    }
 
     const Type mType;
     TimeMilli  mLastAttempt;

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -147,7 +147,7 @@ exit:
 PrefixTlv *LeaderBase::FindNextMatchingPrefix(const Ip6::Address &aAddress, PrefixTlv *aPrevTlv)
 {
     PrefixTlv *     prefix;
-    NetworkDataTlv *start = (aPrevTlv == NULL) ? reinterpret_cast<NetworkDataTlv *>(mTlvs) : aPrevTlv->GetNext();
+    NetworkDataTlv *start = (aPrevTlv == NULL) ? GetTlvsStart() : aPrevTlv->GetNext();
 
     for (NetworkDataTlv *cur = start; cur < GetTlvsEnd(); cur = cur->GetNext())
     {
@@ -223,7 +223,7 @@ otError LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext)
         ExitNow(error = OT_ERROR_NONE);
     }
 
-    for (NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs); cur < GetTlvsEnd(); cur = cur->GetNext())
+    for (NetworkDataTlv *cur = GetTlvsStart(); cur < GetTlvsEnd(); cur = cur->GetNext())
     {
         if (cur->GetType() != NetworkDataTlv::kTypePrefix)
         {
@@ -345,7 +345,7 @@ otError LeaderBase::ExternalRouteLookup(uint8_t             aDomainId,
     NetworkDataTlv *cur;
     NetworkDataTlv *subCur;
 
-    for (cur = reinterpret_cast<NetworkDataTlv *>(mTlvs); cur < GetTlvsEnd(); cur = cur->GetNext())
+    for (cur = GetTlvsStart(); cur < GetTlvsEnd(); cur = cur->GetNext())
     {
         if (cur->GetType() != NetworkDataTlv::kTypePrefix)
         {
@@ -528,7 +528,7 @@ exit:
 
 CommissioningDataTlv *LeaderBase::GetCommissioningData(void)
 {
-    return FindTlv<CommissioningDataTlv>(reinterpret_cast<NetworkDataTlv *>(mTlvs), GetTlvsEnd());
+    return FindTlv<CommissioningDataTlv>(GetTlvsStart(), GetTlvsEnd());
 }
 
 MeshCoP::Tlv *LeaderBase::GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aType)

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -623,7 +623,7 @@ otError LeaderBase::RemoveCommissioningData(void)
     {
         if (cur->GetType() == NetworkDataTlv::kTypeCommissioningData)
         {
-            Remove(reinterpret_cast<uint8_t *>(cur), sizeof(NetworkDataTlv) + cur->GetLength());
+            RemoveTlv(cur);
             ExitNow(error = OT_ERROR_NONE);
         }
     }

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -540,23 +540,10 @@ exit:
     return error;
 }
 
-NetworkDataTlv *LeaderBase::GetCommissioningData(void)
+CommissioningDataTlv *LeaderBase::GetCommissioningData(void)
 {
-    NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
-    NetworkDataTlv *end = GetTlvsEnd();
-
-    for (; cur < end; cur = cur->GetNext())
-    {
-        if (cur->GetType() == NetworkDataTlv::kTypeCommissioningData)
-        {
-            ExitNow();
-        }
-    }
-
-    cur = NULL;
-
-exit:
-    return cur;
+    return static_cast<CommissioningDataTlv *>(
+        FindTlv(reinterpret_cast<NetworkDataTlv *>(mTlvs), GetTlvsEnd(), NetworkDataTlv::kTypeCommissioningData));
 }
 
 MeshCoP::Tlv *LeaderBase::GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aType)
@@ -608,16 +595,11 @@ exit:
 
 otError LeaderBase::RemoveCommissioningData(void)
 {
-    otError error = OT_ERROR_NOT_FOUND;
+    otError               error = OT_ERROR_NONE;
+    CommissioningDataTlv *tlv   = GetCommissioningData();
 
-    for (NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs); cur < GetTlvsEnd(); cur = cur->GetNext())
-    {
-        if (cur->GetType() == NetworkDataTlv::kTypeCommissioningData)
-        {
-            RemoveTlv(cur);
-            ExitNow(error = OT_ERROR_NONE);
-        }
-    }
+    VerifyOrExit(tlv != NULL, error = OT_ERROR_NOT_FOUND);
+    RemoveTlv(tlv);
 
 exit:
     return error;

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -524,18 +524,18 @@ exit:
 
 otError LeaderBase::SetCommissioningData(const uint8_t *aValue, uint8_t aValueLength)
 {
-    otError               error     = OT_ERROR_NONE;
-    uint8_t               remaining = kMaxSize - mLength;
+    otError               error = OT_ERROR_NONE;
     CommissioningDataTlv *commissioningDataTlv;
-
-    VerifyOrExit(sizeof(NetworkDataTlv) + aValueLength < remaining, error = OT_ERROR_NO_BUFS);
 
     RemoveCommissioningData();
 
     if (aValueLength > 0)
     {
-        commissioningDataTlv = reinterpret_cast<CommissioningDataTlv *>(mTlvs + mLength);
-        Insert(reinterpret_cast<uint8_t *>(commissioningDataTlv), sizeof(CommissioningDataTlv) + aValueLength);
+        VerifyOrExit(aValueLength <= kMaxSize - sizeof(CommissioningDataTlv), error = OT_ERROR_NO_BUFS);
+        commissioningDataTlv =
+            static_cast<CommissioningDataTlv *>(AppendTlv(sizeof(CommissioningDataTlv) + aValueLength));
+        VerifyOrExit(commissioningDataTlv != NULL, error = OT_ERROR_NO_BUFS);
+
         commissioningDataTlv->Init();
         commissioningDataTlv->SetLength(aValueLength);
         memcpy(commissioningDataTlv->GetValue(), aValue, aValueLength);

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -528,8 +528,7 @@ exit:
 
 CommissioningDataTlv *LeaderBase::GetCommissioningData(void)
 {
-    return static_cast<CommissioningDataTlv *>(
-        FindTlv(reinterpret_cast<NetworkDataTlv *>(mTlvs), GetTlvsEnd(), NetworkDataTlv::kTypeCommissioningData));
+    return FindTlv<CommissioningDataTlv>(reinterpret_cast<NetworkDataTlv *>(mTlvs), GetTlvsEnd());
 }
 
 MeshCoP::Tlv *LeaderBase::GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aType)

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -270,6 +270,8 @@ protected:
     uint8_t mVersion;
 
 private:
+    PrefixTlv *FindNextMatchingPrefix(const Ip6::Address &aAddress, PrefixTlv *aPrevTlv);
+
     otError RemoveCommissioningData(void);
 
     otError ExternalRouteLookup(uint8_t             aDomainId,

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -187,7 +187,7 @@ public:
      * @returns A pointer to the Commissioning Data or NULL if no Commissioning Data exists.
      *
      */
-    NetworkDataTlv *GetCommissioningData(void);
+    CommissioningDataTlv *GetCommissioningData(void);
 
     /**
      * This method returns a pointer to the Commissioning Data Sub-TLV.

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -908,7 +908,7 @@ otError Leader::AddHasRoute(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute)
     if (dstPrefix == NULL)
     {
         dstPrefix = reinterpret_cast<PrefixTlv *>(mTlvs + mLength);
-        Insert(reinterpret_cast<uint8_t *>(dstPrefix), sizeof(PrefixTlv) + BitVectorBytes(aPrefix.GetPrefixLength()));
+        Insert(dstPrefix, sizeof(PrefixTlv) + BitVectorBytes(aPrefix.GetPrefixLength()));
         dstPrefix->Init(aPrefix.GetDomainId(), aPrefix.GetPrefixLength(), aPrefix.GetPrefix());
     }
 
@@ -920,7 +920,7 @@ otError Leader::AddHasRoute(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute)
     if (dstHasRoute == NULL)
     {
         dstHasRoute = static_cast<HasRouteTlv *>(dstPrefix->GetNext());
-        Insert(reinterpret_cast<uint8_t *>(dstHasRoute), sizeof(HasRouteTlv));
+        Insert(dstHasRoute, sizeof(HasRouteTlv));
         dstPrefix->SetLength(dstPrefix->GetLength() + sizeof(HasRouteTlv));
         dstHasRoute->Init();
 
@@ -930,7 +930,7 @@ otError Leader::AddHasRoute(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute)
         }
     }
 
-    Insert(reinterpret_cast<uint8_t *>(dstHasRoute->GetNext()), sizeof(HasRouteEntry));
+    Insert(dstHasRoute->GetNext(), sizeof(HasRouteEntry));
     dstHasRoute->SetLength(dstHasRoute->GetLength() + sizeof(HasRouteEntry));
     dstPrefix->SetLength(dstPrefix->GetLength() + sizeof(HasRouteEntry));
     memcpy(dstHasRoute->GetEntry(dstHasRoute->GetNumEntries() - 1), aHasRoute.GetEntry(0), sizeof(HasRouteEntry));
@@ -997,7 +997,7 @@ otError Leader::AddServer(ServiceTlv &aService, ServerTlv &aServer, uint8_t *aOl
         }
 
         dstService = reinterpret_cast<ServiceTlv *>(mTlvs + mLength);
-        Insert(reinterpret_cast<uint8_t *>(dstService), serviceInsertLength);
+        Insert(dstService, serviceInsertLength);
         dstService->Init();
         dstService->SetServiceId(serviceId);
         dstService->SetEnterpriseNumber(aService.GetEnterpriseNumber());
@@ -1007,7 +1007,7 @@ otError Leader::AddServer(ServiceTlv &aService, ServerTlv &aServer, uint8_t *aOl
 
     dstServer = static_cast<ServerTlv *>(dstService->GetNext());
 
-    Insert(reinterpret_cast<uint8_t *>(dstServer), sizeof(ServerTlv) + aServer.GetServerDataLength());
+    Insert(dstServer, sizeof(ServerTlv) + aServer.GetServerDataLength());
     dstServer->Init();
     dstServer->SetServer16(aServer.GetServer16());
     dstServer->SetServerData(aServer.GetServerData(), aServer.GetServerDataLength());
@@ -1098,14 +1098,14 @@ otError Leader::AddBorderRouter(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRout
     if (dstPrefix == NULL)
     {
         dstPrefix = reinterpret_cast<PrefixTlv *>(mTlvs + mLength);
-        Insert(reinterpret_cast<uint8_t *>(dstPrefix), sizeof(PrefixTlv) + BitVectorBytes(aPrefix.GetPrefixLength()));
+        Insert(dstPrefix, sizeof(PrefixTlv) + BitVectorBytes(aPrefix.GetPrefixLength()));
         dstPrefix->Init(aPrefix.GetDomainId(), aPrefix.GetPrefixLength(), aPrefix.GetPrefix());
     }
 
     if (dstContext == NULL)
     {
         dstContext = static_cast<ContextTlv *>(dstPrefix->GetNext());
-        Insert(reinterpret_cast<uint8_t *>(dstContext), sizeof(ContextTlv));
+        Insert(dstContext, sizeof(ContextTlv));
         dstPrefix->SetLength(dstPrefix->GetLength() + sizeof(ContextTlv));
         dstContext->Init();
         dstContext->SetCompress();
@@ -1119,12 +1119,12 @@ otError Leader::AddBorderRouter(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRout
     if (dstBorderRouter == NULL)
     {
         dstBorderRouter = static_cast<BorderRouterTlv *>(dstPrefix->GetNext());
-        Insert(reinterpret_cast<uint8_t *>(dstBorderRouter), sizeof(BorderRouterTlv));
+        Insert(dstBorderRouter, sizeof(BorderRouterTlv));
         dstPrefix->SetLength(dstPrefix->GetLength() + sizeof(BorderRouterTlv));
         dstBorderRouter->Init();
     }
 
-    Insert(reinterpret_cast<uint8_t *>(dstBorderRouter->GetNext()), sizeof(BorderRouterEntry));
+    Insert(dstBorderRouter->GetNext(), sizeof(BorderRouterEntry));
     dstBorderRouter->SetLength(dstBorderRouter->GetLength() + sizeof(BorderRouterEntry));
     dstPrefix->SetLength(dstPrefix->GetLength() + sizeof(BorderRouterEntry));
     memcpy(dstBorderRouter->GetEntry(dstBorderRouter->GetNumEntries() - 1), aBorderRouter.GetEntry(0),
@@ -1286,7 +1286,7 @@ void Leader::RemoveRloc(PrefixTlv &aPrefix, uint16_t aRloc16, MatchMode aMatchMo
             if (cur->GetLength() == 0)
             {
                 aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - sizeof(HasRouteTlv));
-                Remove(reinterpret_cast<uint8_t *>(cur), sizeof(HasRouteTlv));
+                Remove(cur, sizeof(HasRouteTlv));
                 continue;
             }
 
@@ -1299,7 +1299,7 @@ void Leader::RemoveRloc(PrefixTlv &aPrefix, uint16_t aRloc16, MatchMode aMatchMo
             if (cur->GetLength() == 0)
             {
                 aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - sizeof(BorderRouterTlv));
-                Remove(reinterpret_cast<uint8_t *>(cur), sizeof(BorderRouterTlv));
+                Remove(cur, sizeof(BorderRouterTlv));
                 continue;
             }
 
@@ -1375,7 +1375,7 @@ void Leader::RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint16_t aRl
         {
             aHasRoute.SetLength(aHasRoute.GetLength() - sizeof(HasRouteEntry));
             aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - sizeof(HasRouteEntry));
-            Remove(reinterpret_cast<uint8_t *>(entry), sizeof(HasRouteEntry));
+            Remove(entry, sizeof(HasRouteEntry));
             continue;
         }
 
@@ -1393,7 +1393,7 @@ void Leader::RemoveRloc(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter, uint
         {
             aBorderRouter.SetLength(aBorderRouter.GetLength() - sizeof(BorderRouterEntry));
             aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - sizeof(BorderRouterEntry));
-            Remove(reinterpret_cast<uint8_t *>(entry), sizeof(*entry));
+            Remove(entry, sizeof(*entry));
             continue;
         }
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -904,8 +904,7 @@ otError Leader::AddHasRoute(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute)
 
     if (dstPrefix == NULL)
     {
-        dstPrefix = reinterpret_cast<PrefixTlv *>(mTlvs + mLength);
-        Insert(dstPrefix, sizeof(PrefixTlv) + BitVectorBytes(aPrefix.GetPrefixLength()));
+        dstPrefix = static_cast<PrefixTlv *>(AppendTlv(sizeof(PrefixTlv) + BitVectorBytes(aPrefix.GetPrefixLength())));
         dstPrefix->Init(aPrefix.GetDomainId(), aPrefix.GetPrefixLength(), aPrefix.GetPrefix());
     }
 
@@ -993,8 +992,8 @@ otError Leader::AddServer(ServiceTlv &aService, ServerTlv &aServer, uint8_t *aOl
             VerifyOrExit(i <= Mle::kServiceMaxId, error = OT_ERROR_NO_BUFS);
         }
 
-        dstService = reinterpret_cast<ServiceTlv *>(mTlvs + mLength);
-        Insert(dstService, serviceInsertLength);
+        dstService = static_cast<ServiceTlv *>(AppendTlv(serviceInsertLength));
+
         dstService->Init();
         dstService->SetServiceId(serviceId);
         dstService->SetEnterpriseNumber(aService.GetEnterpriseNumber());
@@ -1094,8 +1093,7 @@ otError Leader::AddBorderRouter(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRout
 
     if (dstPrefix == NULL)
     {
-        dstPrefix = reinterpret_cast<PrefixTlv *>(mTlvs + mLength);
-        Insert(dstPrefix, sizeof(PrefixTlv) + BitVectorBytes(aPrefix.GetPrefixLength()));
+        dstPrefix = static_cast<PrefixTlv *>(AppendTlv(sizeof(PrefixTlv) + BitVectorBytes(aPrefix.GetPrefixLength())));
         dstPrefix->Init(aPrefix.GetDomainId(), aPrefix.GetPrefixLength(), aPrefix.GetPrefix());
     }
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1228,7 +1228,7 @@ void Leader::RemoveRloc(uint16_t aRloc16, MatchMode aMatchMode)
 
             if (prefix->GetSubTlvsLength() == 0)
             {
-                Remove(reinterpret_cast<uint8_t *>(prefix), sizeof(NetworkDataTlv) + prefix->GetLength());
+                RemoveTlv(prefix);
                 continue;
             }
 
@@ -1243,7 +1243,7 @@ void Leader::RemoveRloc(uint16_t aRloc16, MatchMode aMatchMode)
 
             if (service->GetSubTlvsLength() == 0)
             {
-                Remove(reinterpret_cast<uint8_t *>(service), sizeof(NetworkDataTlv) + service->GetLength());
+                RemoveTlv(service);
                 continue;
             }
 
@@ -1332,7 +1332,6 @@ void Leader::RemoveRloc(ServiceTlv &aService, uint16_t aRloc16, MatchMode aMatch
     NetworkDataTlv *cur = aService.GetSubTlvs();
     NetworkDataTlv *end;
     ServerTlv *     server;
-    uint8_t         removeLength;
 
     while (1)
     {
@@ -1350,9 +1349,9 @@ void Leader::RemoveRloc(ServiceTlv &aService, uint16_t aRloc16, MatchMode aMatch
 
             if (RlocMatch(server->GetServer16(), aRloc16, aMatchMode))
             {
-                removeLength = sizeof(ServerTlv) + server->GetServerDataLength();
-                aService.SetSubTlvsLength(aService.GetSubTlvsLength() - removeLength);
-                Remove(reinterpret_cast<uint8_t *>(cur), removeLength);
+                uint8_t subTlvSize = server->GetSize();
+                RemoveTlv(server);
+                aService.SetSubTlvsLength(aService.GetSubTlvsLength() - subTlvSize);
                 continue;
             }
 
@@ -1426,7 +1425,7 @@ void Leader::RemoveContext(uint8_t aContextId)
 
             if (prefix->GetSubTlvsLength() == 0)
             {
-                Remove(reinterpret_cast<uint8_t *>(prefix), sizeof(NetworkDataTlv) + prefix->GetLength());
+                RemoveTlv(prefix);
                 continue;
             }
 
@@ -1449,7 +1448,6 @@ void Leader::RemoveContext(PrefixTlv &aPrefix, uint8_t aContextId)
     NetworkDataTlv *cur = aPrefix.GetSubTlvs();
     NetworkDataTlv *end;
     ContextTlv *    context;
-    uint8_t         length;
 
     while (1)
     {
@@ -1469,9 +1467,9 @@ void Leader::RemoveContext(PrefixTlv &aPrefix, uint8_t aContextId)
 
             if (context->GetContextId() == aContextId)
             {
-                length = sizeof(NetworkDataTlv) + context->GetLength();
-                aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - length);
-                Remove(reinterpret_cast<uint8_t *>(context), length);
+                uint8_t subTlvSize = context->GetSize();
+                RemoveTlv(context);
+                aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - subTlvSize);
                 continue;
             }
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1022,7 +1022,7 @@ exit:
 
 ServiceTlv *Leader::FindServiceById(uint8_t aServiceId)
 {
-    NetworkDataTlv *cur     = reinterpret_cast<NetworkDataTlv *>(mTlvs);
+    NetworkDataTlv *cur     = GetTlvsStart();
     NetworkDataTlv *end     = GetTlvsEnd();
     ServiceTlv *    compare = NULL;
 
@@ -1200,7 +1200,7 @@ exit:
 
 void Leader::RemoveRloc(uint16_t aRloc16, MatchMode aMatchMode)
 {
-    NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
+    NetworkDataTlv *cur = GetTlvsStart();
 
     while (cur < GetTlvsEnd())
     {
@@ -1374,7 +1374,7 @@ void Leader::RemoveRloc(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter, uint
 
 void Leader::RemoveContext(uint8_t aContextId)
 {
-    NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs);
+    NetworkDataTlv *cur = GetTlvsStart();
 
     while (cur < GetTlvsEnd())
     {
@@ -1444,7 +1444,7 @@ void Leader::UpdateContextsAfterReset(void)
     ContextTlv *contextTlv;
 
     // Iterate through Network Data and synchronize missing contexts.
-    for (NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(mTlvs); cur < GetTlvsEnd(); cur = cur->GetNext())
+    for (NetworkDataTlv *cur = GetTlvsStart(); cur < GetTlvsEnd(); cur = cur->GetNext())
     {
         if (cur->GetType() != NetworkDataTlv::kTypePrefix)
         {

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -110,7 +110,7 @@ otError Local::RemoveOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength)
 
     VerifyOrExit((tlv = FindPrefix(aPrefix, aPrefixLength)) != NULL, error = OT_ERROR_NOT_FOUND);
     VerifyOrExit(FindBorderRouter(*tlv) != NULL, error = OT_ERROR_NOT_FOUND);
-    Remove(reinterpret_cast<uint8_t *>(tlv), sizeof(NetworkDataTlv) + tlv->GetLength());
+    RemoveTlv(tlv);
     ClearResubmitDelayTimer();
 
 exit:
@@ -169,7 +169,7 @@ otError Local::RemoveHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLengt
 
     VerifyOrExit((tlv = FindPrefix(aPrefix, aPrefixLength)) != NULL, error = OT_ERROR_NOT_FOUND);
     VerifyOrExit(FindHasRoute(*tlv) != NULL, error = OT_ERROR_NOT_FOUND);
-    Remove(reinterpret_cast<uint8_t *>(tlv), sizeof(NetworkDataTlv) + tlv->GetLength());
+    RemoveTlv(tlv);
     ClearResubmitDelayTimer();
 
 exit:
@@ -272,7 +272,7 @@ otError Local::RemoveService(uint32_t aEnterpriseNumber, const uint8_t *aService
 
     VerifyOrExit((tlv = FindService(aEnterpriseNumber, aServiceData, aServiceDataLength)) != NULL,
                  error = OT_ERROR_NOT_FOUND);
-    Remove(reinterpret_cast<uint8_t *>(tlv), sizeof(NetworkDataTlv) + tlv->GetLength());
+    RemoveTlv(tlv);
     ClearResubmitDelayTimer();
 
 exit:

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -58,7 +58,7 @@ otError Local::AddOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, in
 {
     otError          error             = OT_ERROR_NONE;
     uint8_t          prefixLengthBytes = BitVectorBytes(aPrefixLength);
-    uint8_t          appendLength;
+    uint8_t          tlvSize;
     PrefixTlv *      prefixTlv;
     BorderRouterTlv *brTlv;
 
@@ -74,11 +74,10 @@ otError Local::AddOnMeshPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, in
 
     RemoveOnMeshPrefix(aPrefix, aPrefixLength);
 
-    appendLength = sizeof(PrefixTlv) + prefixLengthBytes + sizeof(BorderRouterTlv) + sizeof(BorderRouterEntry);
-    VerifyOrExit(mLength + appendLength <= sizeof(mTlvs), error = OT_ERROR_NO_BUFS);
+    tlvSize   = sizeof(PrefixTlv) + prefixLengthBytes + sizeof(BorderRouterTlv) + sizeof(BorderRouterEntry);
+    prefixTlv = static_cast<PrefixTlv *>(AppendTlv(tlvSize));
+    VerifyOrExit(prefixTlv != NULL, error = OT_ERROR_NO_BUFS);
 
-    prefixTlv = reinterpret_cast<PrefixTlv *>(mTlvs + mLength);
-    Insert(reinterpret_cast<uint8_t *>(prefixTlv), appendLength);
     prefixTlv->Init(0, aPrefixLength, aPrefix);
     prefixTlv->SetSubTlvsLength(sizeof(BorderRouterTlv) + sizeof(BorderRouterEntry));
 
@@ -124,7 +123,7 @@ otError Local::AddHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, 
     uint8_t      prefixLengthBytes = BitVectorBytes(aPrefixLength);
     PrefixTlv *  prefixTlv;
     HasRouteTlv *hasRouteTlv;
-    uint8_t      appendLength;
+    uint8_t      tlvSize;
 
     VerifyOrExit(prefixLengthBytes <= sizeof(Ip6::Address), error = OT_ERROR_INVALID_ARGS);
 
@@ -134,11 +133,10 @@ otError Local::AddHasRoutePrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, 
 
     RemoveHasRoutePrefix(aPrefix, aPrefixLength);
 
-    appendLength = sizeof(PrefixTlv) + prefixLengthBytes + sizeof(HasRouteTlv) + sizeof(HasRouteEntry);
-    VerifyOrExit(mLength + appendLength <= sizeof(mTlvs), error = OT_ERROR_NO_BUFS);
+    tlvSize   = sizeof(PrefixTlv) + prefixLengthBytes + sizeof(HasRouteTlv) + sizeof(HasRouteEntry);
+    prefixTlv = static_cast<PrefixTlv *>(AppendTlv(tlvSize));
+    VerifyOrExit(prefixTlv != NULL, error = OT_ERROR_NO_BUFS);
 
-    prefixTlv = reinterpret_cast<PrefixTlv *>(mTlvs + mLength);
-    Insert(reinterpret_cast<uint8_t *>(prefixTlv), appendLength);
     prefixTlv->Init(0, aPrefixLength, aPrefix);
     prefixTlv->SetSubTlvsLength(sizeof(HasRouteTlv) + sizeof(HasRouteEntry));
 
@@ -231,10 +229,10 @@ otError Local::AddService(uint32_t       aEnterpriseNumber,
 
     RemoveService(aEnterpriseNumber, aServiceData, aServiceDataLength);
 
-    VerifyOrExit(mLength + sizeof(NetworkDataTlv) + serviceTlvLength <= sizeof(mTlvs), error = OT_ERROR_NO_BUFS);
+    VerifyOrExit(serviceTlvLength + sizeof(NetworkDataTlv) <= kMaxSize, error = OT_ERROR_NO_BUFS);
 
-    serviceTlv = reinterpret_cast<ServiceTlv *>(mTlvs + mLength);
-    Insert(reinterpret_cast<uint8_t *>(serviceTlv), static_cast<uint8_t>(serviceTlvLength) + sizeof(NetworkDataTlv));
+    serviceTlv = static_cast<ServiceTlv *>(AppendTlv(static_cast<uint8_t>(serviceTlvLength + sizeof(NetworkDataTlv))));
+    VerifyOrExit(serviceTlv != NULL, error = OT_ERROR_NO_BUFS);
 
     serviceTlv->Init();
     serviceTlv->SetEnterpriseNumber(aEnterpriseNumber);

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -179,16 +179,18 @@ exit:
 
 void Local::UpdateRloc(PrefixTlv &aPrefix)
 {
+    uint16_t rloc16 = Get<Mle::MleRouter>().GetRloc16();
+
     for (NetworkDataTlv *cur = aPrefix.GetSubTlvs(); cur < aPrefix.GetNext(); cur = cur->GetNext())
     {
         switch (cur->GetType())
         {
         case NetworkDataTlv::kTypeHasRoute:
-            UpdateRloc(*static_cast<HasRouteTlv *>(cur));
+            static_cast<HasRouteTlv *>(cur)->GetEntry(0)->SetRloc(rloc16);
             break;
 
         case NetworkDataTlv::kTypeBorderRouter:
-            UpdateRloc(*static_cast<BorderRouterTlv *>(cur));
+            static_cast<BorderRouterTlv *>(cur)->GetEntry(0)->SetRloc(rloc16);
             break;
 
         default:
@@ -196,18 +198,6 @@ void Local::UpdateRloc(PrefixTlv &aPrefix)
             break;
         }
     }
-}
-
-void Local::UpdateRloc(HasRouteTlv &aHasRoute)
-{
-    HasRouteEntry *entry = aHasRoute.GetEntry(0);
-    entry->SetRloc(Get<Mle::MleRouter>().GetRloc16());
-}
-
-void Local::UpdateRloc(BorderRouterTlv &aBorderRouter)
-{
-    BorderRouterEntry *entry = aBorderRouter.GetEntry(0);
-    entry->SetRloc(Get<Mle::MleRouter>().GetRloc16());
 }
 
 bool Local::IsOnMeshPrefixConsistent(void)
@@ -292,12 +282,14 @@ exit:
 
 void Local::UpdateRloc(ServiceTlv &aService)
 {
+    uint16_t rloc16 = Get<Mle::MleRouter>().GetRloc16();
+
     for (NetworkDataTlv *cur = aService.GetSubTlvs(); cur < aService.GetNext(); cur = cur->GetNext())
     {
         switch (cur->GetType())
         {
         case NetworkDataTlv::kTypeServer:
-            UpdateRloc(*static_cast<ServerTlv *>(cur));
+            static_cast<ServerTlv *>(cur)->SetServer16(rloc16);
             break;
 
         default:
@@ -305,11 +297,6 @@ void Local::UpdateRloc(ServiceTlv &aService)
             break;
         }
     }
-}
-
-void Local::UpdateRloc(ServerTlv &aServer)
-{
-    aServer.SetServer16(Get<Mle::MleRouter>().GetRloc16());
 }
 
 bool Local::IsServiceConsistent(void)

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -293,8 +293,7 @@ bool Local::IsServiceConsistent(void)
 
 void Local::UpdateRloc(void)
 {
-    for (NetworkDataTlv *cur                                            = reinterpret_cast<NetworkDataTlv *>(mTlvs);
-         cur < reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength); cur = cur->GetNext())
+    for (NetworkDataTlv *cur = GetTlvsStart(); cur < GetTlvsEnd(); cur = cur->GetNext())
     {
         switch (cur->GetType())
         {

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -173,9 +173,16 @@ public:
 private:
     void UpdateRloc(void);
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
-    void UpdateRloc(PrefixTlv &aPrefix);
-    bool IsOnMeshPrefixConsistent(void);
-    bool IsExternalRouteConsistent(void);
+    otError AddPrefix(const uint8_t *      aPrefix,
+                      uint8_t              aPrefixLength,
+                      NetworkDataTlv::Type aSubTlvType,
+                      int8_t               aPrf,
+                      uint8_t              aFlags,
+                      bool                 aStable);
+    otError RemovePrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, NetworkDataTlv::Type aSubTlvType);
+    void    UpdateRloc(PrefixTlv &aPrefix);
+    bool    IsOnMeshPrefixConsistent(void);
+    bool    IsExternalRouteConsistent(void);
 #endif
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -174,15 +174,12 @@ private:
     void UpdateRloc(void);
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
     void UpdateRloc(PrefixTlv &aPrefix);
-    void UpdateRloc(HasRouteTlv &aHasRoute);
-    void UpdateRloc(BorderRouterTlv &aBorderRouter);
     bool IsOnMeshPrefixConsistent(void);
     bool IsExternalRouteConsistent(void);
 #endif
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     void UpdateRloc(ServiceTlv &aService);
-    void UpdateRloc(ServerTlv &aServer);
     bool IsServiceConsistent(void);
 #endif
 

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -261,6 +261,11 @@ OT_TOOL_PACKED_BEGIN
 class HasRouteTlv : public NetworkDataTlv
 {
 public:
+    enum
+    {
+        kType = kTypeHasRoute, ///< The TLV Type.
+    };
+
     /**
      * This method initializes the TLV.
      *
@@ -323,6 +328,11 @@ OT_TOOL_PACKED_BEGIN
 class PrefixTlv : public NetworkDataTlv
 {
 public:
+    enum
+    {
+        kType = kTypePrefix, ///< The TLV Type.
+    };
+
     /**
      * This method initializes the TLV.
      *
@@ -646,6 +656,11 @@ OT_TOOL_PACKED_BEGIN
 class BorderRouterTlv : public NetworkDataTlv
 {
 public:
+    enum
+    {
+        kType = kTypeBorderRouter, ///< The TLV Type.
+    };
+
     /**
      * This method initializes the TLV.
      *
@@ -708,6 +723,11 @@ OT_TOOL_PACKED_BEGIN
 class ContextTlv : public NetworkDataTlv
 {
 public:
+    enum
+    {
+        kType = kTypeContext, ///< The TLV Type.
+    };
+
     /**
      * This method initializes the TLV.
      *
@@ -796,6 +816,11 @@ OT_TOOL_PACKED_BEGIN
 class CommissioningDataTlv : public NetworkDataTlv
 {
 public:
+    enum
+    {
+        kType = kTypeCommissioningData, ///< The TLV Type.
+    };
+
     /**
      * This method initializes the TLV.
      *
@@ -818,7 +843,8 @@ class ServiceTlv : public NetworkDataTlv
 public:
     enum
     {
-        kServiceDataBackboneRouter = 0x01, // const THREAD_SERVICE_DATA_BBR
+        kType                      = kTypeService, ///< The TLV Type.
+        kServiceDataBackboneRouter = 0x01,         ///< const THREAD_SERVICE_DATA_BBR
     };
 
     /**
@@ -1045,6 +1071,11 @@ OT_TOOL_PACKED_BEGIN
 class ServerTlv : public NetworkDataTlv
 {
 public:
+    enum
+    {
+        kType = kTypeServer, ///< The TLV Type.
+    };
+
     /**
      * This method initializes the TLV.
      *

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -122,6 +122,14 @@ public:
     void SetLength(uint8_t aLength) { mLength = aLength; }
 
     /**
+     * This method returns the TLV's total size (number of bytes) including Type, Length, and Value fields.
+     *
+     * @returns The total size include Type, Length, and Value fields.
+     *
+     */
+    uint8_t GetSize(void) const { return sizeof(NetworkDataTlv) + mLength; }
+
+    /**
      * This method returns a pointer to the Value.
      *
      * @returns A pointer to the value.


### PR DESCRIPTION
This PR contains a bunch of improvements and changes in `NetworkData` modules.
- Add helper `FindTlv()` and templated `FindTlv<TlvType>` methods to search within a sequence of TLVs  to find a TLV with a given type (and/or stable  status) along with 
- Add methods to help with iterating over Network Data content  (`FindTlv`, `IterateToNextTlv()`, etc).
- Add `AppendTlv()` and `RemoveTlv()` helper methods to simplify adding and removing of an entire TLV from the Network Data.
- Change `PrefixMatch()` to use `Ip6::Address` method.
- Simplify and fix `RemoveTemporaryData()` (use cast to get the sub-TLV during iteration).
- Simplify `GetNextServer()` implementation to use other methods to iterate over all on-mesh prefix, external route, and service entries in Network Data. 
- Simplify the `Local::UpdateRloc()` implementation.  
- Add `Local::AddPrefix()` and `Local::RemovePrefix()` methods to share common code for adding on-mesh or external route entries.
- Add helper `GetTlvsStart()` and `GetTlvsEnd()` to get the start or end of Network Data TLV sequence.

----

_I kept the commits small and separate to help with the review._ But would suggest we squash them before merge (possible commit message): 
```
This commit contains the following changes in `NetworkData` modules:

- Add helper `FindTlv()` and template version `FindTlv<TlvType>()` 
  methods to search within a sequence of TLVs to find a TLV with a 
  given type (and/or stable  status).
- Add methods to help with iterating over Network Data content 
  (`FindTlv`, `IterateToNextTlv()`, etc).
- Add `AppendTlv()` and `RemoveTlv()` helper methods to simplify 
  adding and removing of entire TLV from Network Data.
- Change `PrefixMatch()` to use `Ip6::Address` method.
- Simplify and fix `RemoveTemporaryData()` (use cast to get the 
  sub-TLV during iteration).
- Simplify `GetNextServer()` implementation to use other methods to 
  iterate over all on-mesh prefix, external route, and service 
  entries in Network Data. 
- Simplify the `Local::UpdateRloc()` implementation.  
- Add `Local::AddPrefix()` and `Local::RemovePrefix()` methods to 
  share common code for adding on-mesh or external route entries.
- Add helper `GetTlvsStart()`/`GetTlvsEnd()` to get the start/end 
  of Network Data TLV sequence.
```