### PR TITLE
[nrf528xx] fix Keil compilation error in nrf_ficr.h

### DIFF
--- a/third_party/NordicSemiconductor/nrfx/hal/nrf_ficr.h
+++ b/third_party/NordicSemiconductor/nrfx/hal/nrf_ficr.h
@@ -123,16 +123,12 @@ __STATIC_INLINE uint32_t nrf_ficr_nfc_tagheader_get(NRF_FICR_Type const * p_reg,
     switch(tagheader_id) {
         case 0:
             return p_reg->NFC.TAGHEADER0;
-            break;
         case 1:
             return p_reg->NFC.TAGHEADER1;
-            break;
         case 2:
             return p_reg->NFC.TAGHEADER2;
-            break;
         case 3:
             return p_reg->NFC.TAGHEADER3;
-            break;
         default:
             return 0;
     }


### PR DESCRIPTION
Compilation error: #111-D: statement is unreachable.