### PR TITLE
[toranj] change start.sh to remove variable check to retry failed test

### DIFF
--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -58,15 +58,13 @@ run() {
             return
         fi
 
-        # On Travis, we allow a failed test to be retried up to 3 attempts.
-        if [ "$BUILD_TARGET" = "toranj-test-framework" ]; then
-            if [ "$counter" -lt 2 ]; then
-                counter=$((counter+1))
-                echo Attempt $counter running "$1" failed. Trying again.
-                cleanup
-                sleep 10
-                continue
-            fi
+        # We allow a failed test to be retried up to 3 attempts.
+        if [ "$counter" -lt 2 ]; then
+            counter=$((counter+1))
+            echo Attempt $counter running "$1" failed. Trying again.
+            cleanup
+            sleep 10
+            continue
         fi
 
         echo " *** TEST FAILED"


### PR DESCRIPTION
This commit changes the `start.sh` script to remove the check for the
environment variable (which is specific to travis) before allowing
retry of failed tests. This should help with robustness of the tests
on GitHub Actions.
