### PR TITLE
[network-data] fix FindTlv() to return NULL when TLV sequence is malformed

### DIFF
--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -66,7 +66,7 @@ NetworkDataTlv *NetworkData::FindTlv(NetworkDataTlv *aStart, NetworkDataTlv *aEn
 
     for (tlv = aStart; tlv < aEnd; tlv = tlv->GetNext())
     {
-        VerifyOrExit((tlv + 1) <= aEnd && tlv->GetNext() <= aEnd);
+        VerifyOrExit((tlv + 1) <= aEnd && tlv->GetNext() <= aEnd, tlv = NULL);
 
         if (tlv->GetType() == aType)
         {
@@ -89,7 +89,7 @@ NetworkDataTlv *NetworkData::FindTlv(NetworkDataTlv *     aStart,
 
     for (tlv = aStart; tlv < aEnd; tlv = tlv->GetNext())
     {
-        VerifyOrExit((tlv + 1) <= aEnd && tlv->GetNext() <= aEnd);
+        VerifyOrExit((tlv + 1) <= aEnd && tlv->GetNext() <= aEnd, tlv = NULL);
 
         if ((tlv->GetType() == aType) && (tlv->IsStable() == aStable))
         {


### PR DESCRIPTION
---
Fix as a follow up to #4743.