### PR TITLE
[mesh-forwarder] include address resolving queue in message eviction

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -310,7 +310,7 @@ public:
      * @returns  A reference to the resolving queue.
      *
      */
-    const MessageQueue &GetResolvingQueue(void) const { return mResolvingQueue; }
+    const PriorityQueue &GetResolvingQueue(void) const { return mResolvingQueue; }
 #endif
 
 private:
@@ -519,7 +519,7 @@ private:
 
 #if OPENTHREAD_FTD
     FragmentPriorityEntry mFragmentEntries[kNumFragmentPriorityEntries];
-    MessageQueue          mResolvingQueue;
+    PriorityQueue         mResolvingQueue;
     IndirectSender        mIndirectSender;
 #endif
 


### PR DESCRIPTION
The existing implementation only considered the forwarding queue when
looking for a message to evict. This ignores message buffers that may
be buffered in other message queues.

This commit adds the ability to evict messages in the address resolver
queue. The lowest priority message from either the forwarding or
address resolver queue is selected for eviction.