### PR TITLE
[toranj] update test-602-channel-select to add extra wait

### DIFF
--- a/tests/toranj/test-602-channel-manager-channel-select.py
+++ b/tests/toranj/test-602-channel-manager-channel-select.py
@@ -88,11 +88,23 @@ verify(
     int(node.get(wpan.WPAN_CHANNEL_MANAGER_SUPPORTED_CHANNEL_MASK), 0) ==
     all_channels_mask)
 
+WAIT_TIME = 15
+EXPECTED_SAMEPLE_COUNT = 970
+
 # Sleep for 4.5 second with speedup factor of 10,000 this is more than 12
-# hours.
+# hours. We sleep instead of immediately checking the sample counter in
+# order to not add more actions/events into simulation (specially since
+# we are running at very high speedup).
 time.sleep(4.5)
 
-verify(int(node.get(wpan.WPAN_CHANNEL_MONITOR_SAMPLE_COUNT), 0) > 970)
+
+def check_sample_count():
+    verify(
+        int(node.get(wpan.WPAN_CHANNEL_MONITOR_SAMPLE_COUNT), 0) >
+        EXPECTED_SAMEPLE_COUNT)
+
+
+wpan.verify_within(check_sample_count, WAIT_TIME)
 
 # Verify the initial value of `NEW_CHANNEL` (should be zero if there has
 # been no channel change so far).


### PR DESCRIPTION
This commit changes the `test-602-channel-manager-channel-select` to
wait for sample count to reach a limit (within a wait interval). This
should help make the test more robust (e.g., in RCP/POSIX mode) when
the simulation processing time may require more time (note that this
test is run with very high speed-up).