### PR TITLE
allow otPlatReset to be linked as part of platform library

### DIFF
--- a/include/openthread/platform/misc.h
+++ b/include/openthread/platform/misc.h
@@ -61,6 +61,11 @@ extern "C" {
  */
 void otPlatReset(otInstance *aInstance);
 
+#if OPENTHREAD_LINK_PLAT_RESET_VIA_CALLBACK
+typedef void (*otPlatResetCallbackFunction)(otInstance *aInstance);
+void otSetPlatResetCallback(otPlatResetCallbackFunction f);
+#endif
+
 /**
  * Enumeration of possible reset reason codes.
  *

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -59,6 +59,7 @@
 #include <openthread/logging.h>
 #include <openthread/tasklet.h>
 #include <openthread/thread.h>
+#include <openthread/platform/misc.h>
 #include <openthread/platform/radio.h>
 #if OPENTHREAD_POSIX_APP_TYPE == OT_POSIX_APP_TYPE_NCP
 #include <openthread/ncp.h>
@@ -334,7 +335,12 @@ void otTaskletsSignalPending(otInstance *aInstance)
     OT_UNUSED_VARIABLE(aInstance);
 }
 
-void otPlatReset(otInstance *aInstance)
+#if OPENTHREAD_LINK_PLAT_RESET_VIA_CALLBACK
+#define otPlatReset localPlatReset
+static
+#endif
+    void
+    otPlatReset(otInstance *aInstance)
 {
     otInstanceFinalize(aInstance);
     otSysDeinit();
@@ -346,6 +352,10 @@ void otPlatReset(otInstance *aInstance)
 int main(int argc, char *argv[])
 {
     otInstance *instance;
+
+#if OPENTHREAD_LINK_PLAT_RESET_VIA_CALLBACK
+    otSetPlatResetCallback(otPlatReset);
+#endif
 
 #ifdef __linux__
     // Ensure we terminate this process if the

--- a/src/posix/platform/misc.cpp
+++ b/src/posix/platform/misc.cpp
@@ -43,6 +43,22 @@
 static otPlatResetReason   sPlatResetReason   = OT_PLAT_RESET_REASON_POWER_ON;
 static otPlatMcuPowerState gPlatMcuPowerState = OT_PLAT_MCU_POWER_STATE_ON;
 
+#if OPENTHREAD_LINK_PLAT_RESET_VIA_CALLBACK
+static otPlatResetCallbackFunction otPlatResetCallback = NULL;
+
+void otSetPlatResetCallback(otPlatResetCallbackFunction f)
+{
+    otPlatResetCallback = f;
+}
+
+void otPlatReset(otInstance *aInstance)
+{
+    assert(otPlatResetCallback != NULL);
+
+    otPlatResetCallback(aInstance);
+}
+#endif
+
 otPlatResetReason otPlatGetResetReason(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);


### PR DESCRIPTION
Addresses #4769.  Provides an optional compile-time flag (OPENTHREAD_LINK_PLAT_RESET_VIA_CALLBACK).  If set, otPlatReset function will be defined in the platform layer, and a new API to set a callback into the application layer will be exposed.