### PR TITLE
[network-data] periodically check for stale child ids

### DIFF
--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1504,6 +1504,23 @@ void Leader::HandleTimer(void)
     }
 }
 
+void Leader::RemoveStaleChildEntries(void)
+{
+    Iterator iterator = kIteratorInit;
+    uint16_t rloc16;
+
+    while (GetNextServer(iterator, rloc16) == OT_ERROR_NONE)
+    {
+        if (!Mle::Mle::IsActiveRouter(rloc16) && Mle::Mle::RouterIdMatch(Get<Mle::MleRouter>().GetRloc16(), rloc16) &&
+            Get<ChildTable>().FindChild(rloc16, Child::kInStateValid) == NULL)
+        {
+            // In Thread 1.1 Specification 5.15.6.1, only one RLOC16 TLV entry may appear in SRV_DATA.ntf.
+            SendServerDataNotification(rloc16);
+            break;
+        }
+    }
+}
+
 } // namespace NetworkData
 } // namespace ot
 

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -168,6 +168,12 @@ public:
      */
     ServiceTlv *FindServiceById(uint8_t aServiceId);
 
+    /**
+     * This method sends SVR_DATA.ntf message for any stale child entries that exist in the network data.
+     *
+     */
+    void RemoveStaleChildEntries(void);
+
 private:
     static void HandleServerData(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);


### PR DESCRIPTION
A parent is responsible for removing stale child entries from the
network data. The existing implementation only triggered a
SVR_DATA.ntf message when new network data is received. In some cases,
the SVR_DATA.ntf message may not be sent due to rate limiting or lack
of message buffers.

This commit turns this process into a periodic check to ensure that
stale child entires are removed even if a failure in sending the
SVR_DATA.ntf occurs.