### PR TITLE
[network-data] simplify code, user helper methods

### DIFF
--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -517,17 +517,16 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Pref
                 ContextTlv *     context      = FindContext(aPrefix);
 
                 // Replace p_border_router_16
-                for (uint8_t i = 0; i < borderRouter->GetNumEntries(); i++)
+                for (BorderRouterEntry *entry = borderRouter->GetFirstEntry(); entry <= borderRouter->GetLastEntry();
+                     entry                    = entry->GetNext())
                 {
-                    BorderRouterEntry *borderRouterEntry = borderRouter->GetEntry(i);
-
-                    if ((borderRouterEntry->IsDhcp() || borderRouterEntry->IsConfigure()) && (context != NULL))
+                    if ((entry->IsDhcp() || entry->IsConfigure()) && (context != NULL))
                     {
-                        borderRouterEntry->SetRloc(0xfc00 | context->GetContextId());
+                        entry->SetRloc(0xfc00 | context->GetContextId());
                     }
                     else
                     {
-                        borderRouterEntry->SetRloc(0xfffe);
+                        entry->SetRloc(0xfffe);
                     }
                 }
 
@@ -539,9 +538,10 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Pref
                 HasRouteTlv *hasRoute = static_cast<HasRouteTlv *>(cur);
 
                 // Replace r_border_router_16
-                for (uint8_t j = 0; j < hasRoute->GetNumEntries(); j++)
+                for (HasRouteEntry *entry = hasRoute->GetFirstEntry(); entry <= hasRoute->GetLastEntry();
+                     entry                = entry->GetNext())
                 {
-                    hasRoute->GetEntry(j)->SetRloc(0xfffe);
+                    entry->SetRloc(0xfffe);
                 }
 
                 break;

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -119,7 +119,7 @@ public:
      * @returns The CONTEXT_ID_REUSE_DELAY value.
      *
      */
-    uint32_t GetContextIdReuseDelay(void) const;
+    uint32_t GetContextIdReuseDelay(void) const { return mContextIdReuseDelay; }
 
     /**
      * This method sets CONTEXT_ID_RESUSE_DELAY value.
@@ -129,7 +129,7 @@ public:
      * @param[in]  aDelay  The CONTEXT_ID_REUSE_DELAY value.
      *
      */
-    void SetContextIdReuseDelay(uint32_t aDelay);
+    void SetContextIdReuseDelay(uint32_t aDelay) { mContextIdReuseDelay = aDelay; }
 
     /**
      * This method removes Network Data entries matching with a given RLOC16.


### PR DESCRIPTION
This commit contains the following changes in `NetworkData::Leader`:

- Simplify methods `RemoveContext()`, `UpdateContextsAfterReset()`,
 `FindServiceById()`, `RemoveRloc()` to use `FindTlv` when searching
  for TLVs of a given type.
- Removes redundant checks in `RlocLookup()`.
- Uses pointer to iterate through `BoderRouterTlv` or `HasRouteTlv`
  entries.
- Move simple getter/setter methods to header file (to be inline).