### PR TITLE
[network-data] implement network data notifier

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -238,6 +238,7 @@ LOCAL_SRC_FILES                                          := \
     src/core/thread/network_data_leader.cpp                 \
     src/core/thread/network_data_leader_ftd.cpp             \
     src/core/thread/network_data_local.cpp                  \
+    src/core/thread/network_data_notifier.cpp               \
     src/core/thread/network_diagnostic.cpp                  \
     src/core/thread/panid_query_server.cpp                  \
     src/core/thread/router_table.cpp                        \

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -151,6 +151,7 @@ static_library("lib-ot-core") {
     "src/core/thread/network_data_leader.cpp",
     "src/core/thread/network_data_leader_ftd.cpp",
     "src/core/thread/network_data_local.cpp",
+    "src/core/thread/network_data_notifier.cpp",
     "src/core/thread/network_diagnostic.cpp",
     "src/core/thread/panid_query_server.cpp",
     "src/core/thread/router_table.cpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -191,6 +191,7 @@ set(COMMON_SOURCES
     thread/network_data_leader.cpp
     thread/network_data_leader_ftd.cpp
     thread/network_data_local.cpp
+    thread/network_data_notifier.cpp
     thread/network_diagnostic.cpp
     thread/panid_query_server.cpp
     thread/router_table.cpp

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -229,6 +229,7 @@ SOURCES_COMMON                             = \
     thread/network_data_leader.cpp           \
     thread/network_data_leader_ftd.cpp       \
     thread/network_data_local.cpp            \
+    thread/network_data_notifier.cpp         \
     thread/network_diagnostic.cpp            \
     thread/panid_query_server.cpp            \
     thread/router_table.cpp                  \
@@ -431,6 +432,7 @@ HEADERS_COMMON                             = \
     thread/network_data_leader.hpp           \
     thread/network_data_leader_ftd.hpp       \
     thread/network_data_local.hpp            \
+    thread/network_data_notifier.hpp         \
     thread/network_data_tlvs.hpp             \
     thread/network_diagnostic.hpp            \
     thread/network_diagnostic_tlvs.hpp       \

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -147,7 +147,9 @@ otError otBorderRouterRegister(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<NetworkData::Local>().SendServerDataNotification();
+    instance.Get<NetworkData::Notifier>().HandleServerDataUpdated();
+
+    return OT_ERROR_NONE;
 }
 
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE

--- a/src/core/api/server_api.cpp
+++ b/src/core/api/server_api.cpp
@@ -88,7 +88,9 @@ otError otServerRegister(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<NetworkData::Local>().SendServerDataNotification();
+    instance.Get<NetworkData::Notifier>().HandleServerDataUpdated();
+
+    return OT_ERROR_NONE;
 }
 
 #endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE

--- a/src/core/backbone_router/local.cpp
+++ b/src/core/backbone_router/local.cpp
@@ -158,7 +158,7 @@ otError Local::AddService(bool aForce)
                       reinterpret_cast<const uint8_t *>(&serverData), sizeof(serverData)));
 
     mIsServiceAdded = true;
-    Get<NetworkData::Local>().SendServerDataNotification();
+    Get<NetworkData::Notifier>().HandleServerDataUpdated();
 
     otLogInfoNetData("BBR Service added: seqno (%d), delay (%ds), timeout (%ds)", mSequenceNumber, mReregistrationDelay,
                      mMlrTimeout);
@@ -177,11 +177,7 @@ otError Local::RemoveService(void)
         error = Get<NetworkData::Local>().RemoveService(THREAD_ENTERPRISE_NUMBER, &serviceData, sizeof(serviceData)));
 
     mIsServiceAdded = false;
-
-    if (Get<Mle::MleRouter>().IsAttached())
-    {
-        Get<NetworkData::Local>().SendServerDataNotification();
-    }
+    Get<NetworkData::Notifier>().HandleServerDataUpdated();
 
 exit:
     otLogInfoNetData("Remove BBR Service %s", otThreadErrorToString(error));

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -551,6 +551,13 @@ template <> inline NetworkData::Leader &Instance::Get(void)
     return mThreadNetif.mNetworkDataLeader;
 }
 
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+template <> inline NetworkData::Notifier &Instance::Get(void)
+{
+    return mThreadNetif.mNetworkDataNotifier;
+}
+#endif
+
 template <> inline Ip6::Udp &Instance::Get(void)
 {
     return mIp6.mUdp;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -830,9 +830,6 @@ void Mle::SetStateChild(uint16_t aRloc16)
     }
 #endif
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    Get<NetworkData::Local>().ClearResubmitDelayTimer();
-#endif
     Get<Ip6::Ip6>().SetForwardingEnabled(false);
 #if OPENTHREAD_FTD
     Get<Ip6::Mpl>().SetTimerExpirations(kMplChildDataMessageTimerExpirations);
@@ -1617,11 +1614,8 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
         Get<BackboneRouter::Leader>().Update();
 #endif
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-        Get<NetworkData::Local>().SendServerDataNotification();
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
         this->UpdateServiceAlocs();
-#endif
 #endif
 
 #if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
@@ -3002,12 +2996,6 @@ otError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo
         delay = Random::NonCrypto::GetUint16InRange(0, kMleMaxResponseDelay);
         SendDataRequest(aMessageInfo.GetPeerAddr(), tlvs, sizeof(tlvs), delay);
     }
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    else
-    {
-        Get<NetworkData::Local>().SendServerDataNotification();
-    }
-#endif
 
 exit:
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2722,8 +2722,6 @@ void MleRouter::SynchronizeChildNetworkData(void)
 {
     VerifyOrExit(mRole == OT_DEVICE_ROLE_ROUTER || mRole == OT_DEVICE_ROLE_LEADER);
 
-    Get<NetworkData::Leader>().RemoveStaleChildEntries();
-
     for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValid); !iter.IsDone(); iter++)
     {
         Child & child = *iter.GetChild();
@@ -3333,7 +3331,6 @@ void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
         }
 
         Get<IndirectSender>().ClearAllMessagesForSleepyChild(static_cast<Child &>(aNeighbor));
-        Get<NetworkData::Leader>().SendServerDataNotification(aNeighbor.GetRloc16());
 
         if (aNeighbor.IsFullThreadDevice())
         {
@@ -3922,11 +3919,6 @@ otError MleRouter::CheckReachability(uint16_t aMeshSource, uint16_t aMeshDest, I
         if (mChildTable.FindChild(aMeshDest, Child::kInStateValidOrRestoring))
         {
             ExitNow();
-        }
-        else if (IsAnycastLocator(aIp6Header.GetDestination()))
-        {
-            // Proactively notify Leader of the expired child to de-register the stale service if any.
-            Get<NetworkData::Leader>().SendServerDataNotification(aMeshDest);
         }
     }
     else if (GetNextHop(aMeshDest) != Mac::kShortAddrInvalid)

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -316,12 +316,6 @@ public:
      */
     otError GetNextServer(Iterator &aIterator, uint16_t &aRloc16);
 
-    /**
-     * This method cancels the data resubmit delay timer.
-     *
-     */
-    void ClearResubmitDelayTimer(void);
-
 protected:
     /**
      * This method returns a pointer to the start of Network Data TLV sequence.
@@ -532,13 +526,15 @@ protected:
     /**
      * This method sends a Server Data Notification message to the Leader.
      *
-     * @param[in]  aRloc16  The old RLOC16 value that was previously registered.
+     * @param[in]  aRloc16   The old RLOC16 value that was previously registered.
+     * @param[in]  aHandler  A function pointer that is called when the transaction ends.
+     * @param[in]  aContext  A pointer to arbitrary context information.
      *
      * @retval OT_ERROR_NONE     Successfully enqueued the notification message.
      * @retval OT_ERROR_NO_BUFS  Insufficient message buffers to generate the notification message.
      *
      */
-    otError SendServerDataNotification(uint16_t aRloc16);
+    otError SendServerDataNotification(uint16_t aRloc16, Coap::ResponseHandler aHandler, void *aContext);
 
     /**
      * This static method searches in a given sequence of TLVs to find the first TLV with a given TLV Type.
@@ -696,7 +692,6 @@ private:
     }
 
     const Type mType;
-    TimeMilli  mLastAttempt;
 };
 
 } // namespace NetworkData

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -64,7 +64,7 @@ void LeaderBase::Reset(void)
     mVersion       = Random::NonCrypto::GetUint8();
     mStableVersion = Random::NonCrypto::GetUint8();
     mLength        = 0;
-    Get<Notifier>().Signal(OT_CHANGED_THREAD_NETDATA);
+    Get<ot::Notifier>().Signal(OT_CHANGED_THREAD_NETDATA);
 }
 
 otError LeaderBase::GetServiceId(uint32_t       aEnterpriseNumber,
@@ -444,7 +444,7 @@ otError LeaderBase::SetNetworkData(uint8_t        aVersion,
 
     otDumpDebgNetData("set network data", mTlvs, mLength);
 
-    Get<Notifier>().Signal(OT_CHANGED_THREAD_NETDATA);
+    Get<ot::Notifier>().Signal(OT_CHANGED_THREAD_NETDATA);
 
 exit:
     return error;
@@ -470,7 +470,7 @@ otError LeaderBase::SetCommissioningData(const uint8_t *aValue, uint8_t aValueLe
     }
 
     mVersion++;
-    Get<Notifier>().Signal(OT_CHANGED_THREAD_NETDATA);
+    Get<ot::Notifier>().Signal(OT_CHANGED_THREAD_NETDATA);
 
 exit:
     return error;

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -141,17 +141,6 @@ public:
     void RemoveBorderRouter(uint16_t aRloc16, MatchMode aMatchMode);
 
     /**
-     * This method sends a Server Data Notification message to the Leader indicating an invalid RLOC16.
-     *
-     * @param[in]  aRloc16  The invalid RLOC16 to notify.
-     *
-     * @retval OT_ERROR_NONE     Successfully enqueued the notification message.
-     * @retval OT_ERROR_NO_BUFS  Insufficient message buffers to generate the notification message.
-     *
-     */
-    otError SendServerDataNotification(uint16_t aRloc16);
-
-    /**
      * This method synchronizes internal 6LoWPAN Context ID Set with recently obtained Thread Network Data.
      *
      * Note that this method should be called only by the Leader once after reset.
@@ -171,8 +160,15 @@ public:
     /**
      * This method sends SVR_DATA.ntf message for any stale child entries that exist in the network data.
      *
+     * @param[in]  aHandler  A function pointer that is called when the transaction ends.
+     * @param[in]  aContext  A pointer to arbitrary context information.
+     *
+     * @retval OT_ERROR_NONE       A stale child entry was found and successfully enqueued a SVR_DATA.ntf message.
+     * @retval OT_ERROR_NO_BUFS    A stale child entry was found, but insufficient message buffers were available.
+     * @retval OT_ERROR_NOT_FOUND  No stale child entries were found.
+     *
      */
-    void RemoveStaleChildEntries(void);
+    otError RemoveStaleChildEntries(Coap::ResponseHandler aHandler, void *aContext);
 
 private:
     static void HandleServerData(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -164,11 +164,16 @@ public:
     /**
      * This method sends a Server Data Notification message to the Leader.
      *
-     * @retval OT_ERROR_NONE     Successfully enqueued the notification message.
-     * @retval OT_ERROR_NO_BUFS  Insufficient message buffers to generate the notification message.
+     * @param[in]  aHandler  A function pointer that is called when the transaction ends.
+     * @param[in]  aContext  A pointer to arbitrary context information.
+     *
+     * @retval OT_ERROR_NONE           Successfully enqueued the notification message.
+     * @retval OT_ERROR_NO_BUFS        Insufficient message buffers to generate the notification message.
+     * @retval OT_ERROR_INVALID_STATE  Device is a REED and is in the process of becoming a Router.
+     * @retval OT_ERROR_NOT_FOUND      Server Data is already consistent with network data.
      *
      */
-    otError SendServerDataNotification(void);
+    otError UpdateInconsistentServerData(Coap::ResponseHandler aHandler, void *aContext);
 
 private:
     void UpdateRloc(void);

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -1,0 +1,167 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements transmissions of SVR_DATA.ntf messages to the Leader.
+ */
+
+#include "network_data_notifier.hpp"
+
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+
+#include "common/code_utils.hpp"
+#include "common/instance.hpp"
+#include "common/locator-getters.hpp"
+#include "thread/network_data_leader.hpp"
+#include "thread/network_data_local.hpp"
+
+namespace ot {
+namespace NetworkData {
+
+Notifier::Notifier(Instance &aInstance)
+    : InstanceLocator(aInstance)
+    , mNotifierCallback(aInstance, &Notifier::HandleStateChanged, this)
+    , mTimer(aInstance, &Notifier::HandleTimer, this)
+    , mNextDelay(0)
+    , mWaitingForResponse(false)
+{
+}
+
+void Notifier::HandleServerDataUpdated(void)
+{
+    mNextDelay = 0;
+    SynchronizeServerData();
+}
+
+void Notifier::SynchronizeServerData(void)
+{
+    otError error = OT_ERROR_NOT_FOUND;
+
+    VerifyOrExit(Get<Mle::MleRouter>().IsAttached() && !mWaitingForResponse);
+
+    VerifyOrExit((mNextDelay == 0) || !mTimer.IsRunning());
+
+#if OPENTHREAD_FTD
+    mNextDelay = kDelayRemoveStaleChildren;
+    error      = Get<Leader>().RemoveStaleChildEntries(&Notifier::HandleCoapResponse, this);
+    VerifyOrExit(error == OT_ERROR_NOT_FOUND);
+#endif
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+    mNextDelay = kDelaySynchronizeServerData;
+    error      = Get<Local>().UpdateInconsistentServerData(&Notifier::HandleCoapResponse, this);
+    VerifyOrExit(error == OT_ERROR_NOT_FOUND);
+#endif
+
+exit:
+    switch (error)
+    {
+    case OT_ERROR_NONE:
+        mWaitingForResponse = true;
+        break;
+    case OT_ERROR_NO_BUFS:
+        mTimer.Start(kDelayNoBufs);
+        break;
+#if OPENTHREAD_FTD
+    case OT_ERROR_INVALID_STATE:
+        mTimer.Start(Time::SecToMsec(Get<Mle::MleRouter>().GetRouterSelectionJitterTimeout() + 1));
+        break;
+#endif
+    case OT_ERROR_NOT_FOUND:
+        break;
+    default:
+        OT_ASSERT(false);
+        break;
+    }
+}
+
+void Notifier::HandleStateChanged(ot::Notifier::Callback &aCallback, otChangedFlags aFlags)
+{
+    aCallback.GetOwner<Notifier>().HandleStateChanged(aFlags);
+}
+
+void Notifier::HandleStateChanged(otChangedFlags aFlags)
+{
+    if (aFlags & (OT_CHANGED_THREAD_ROLE | OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED))
+    {
+        mNextDelay = 0;
+    }
+
+    if (aFlags & (OT_CHANGED_THREAD_NETDATA | OT_CHANGED_THREAD_ROLE | OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED))
+    {
+        SynchronizeServerData();
+    }
+}
+
+void Notifier::HandleTimer(Timer &aTimer)
+{
+    aTimer.GetOwner<Notifier>().HandleTimer();
+}
+
+void Notifier::HandleTimer(void)
+{
+    SynchronizeServerData();
+}
+
+void Notifier::HandleCoapResponse(void *               aContext,
+                                  otMessage *          aMessage,
+                                  const otMessageInfo *aMessageInfo,
+                                  otError              aResult)
+{
+    OT_UNUSED_VARIABLE(aMessage);
+    OT_UNUSED_VARIABLE(aMessageInfo);
+
+    static_cast<Notifier *>(aContext)->HandleCoapResponse(aResult);
+}
+
+void Notifier::HandleCoapResponse(otError aResult)
+{
+    mWaitingForResponse = false;
+
+    switch (aResult)
+    {
+    case OT_ERROR_NONE:
+        mTimer.Start(mNextDelay + 1);
+        break;
+
+    case OT_ERROR_RESPONSE_TIMEOUT:
+    case OT_ERROR_ABORT:
+        SynchronizeServerData();
+        break;
+
+    default:
+        OT_ASSERT(false);
+        break;
+    }
+}
+
+} // namespace NetworkData
+} // namespace ot
+
+#endif // OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE

--- a/src/core/thread/network_data_notifier.hpp
+++ b/src/core/thread/network_data_notifier.hpp
@@ -1,0 +1,102 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for transmitting SVR_DATA.ntf messages.
+ */
+
+#ifndef NETWORK_DATA_NOTIFIER_HPP_
+#define NETWORK_DATA_NOTIFIER_HPP_
+
+#include "openthread-core-config.h"
+
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+
+#include "coap/coap.hpp"
+#include "common/message.hpp"
+#include "common/notifier.hpp"
+
+namespace ot {
+namespace NetworkData {
+
+/**
+ * This class implements the SVR_DATA.ntf transmission logic.
+ *
+ */
+class Notifier : public InstanceLocator
+{
+public:
+    /**
+     * Constructor.
+     *
+     * @param[in] aInstance  The OpenThread instance.
+     *
+     */
+    Notifier(Instance &aInstance);
+
+    /**
+     * Call this method to inform the notifier that new server data is available.
+     *
+     */
+    void HandleServerDataUpdated(void);
+
+private:
+    enum
+    {
+        kDelayNoBufs                = 1000,   ///< milliseconds
+        kDelayRemoveStaleChildren   = 5000,   ///< milliseconds
+        kDelaySynchronizeServerData = 300000, ///< milliseconds
+    };
+
+    static void HandleStateChanged(ot::Notifier::Callback &aCallback, otChangedFlags aFlags);
+    void        HandleStateChanged(otChangedFlags aFlags);
+
+    static void HandleTimer(Timer &aTimer);
+    void        HandleTimer(void);
+
+    static void HandleCoapResponse(void *               aContext,
+                                   otMessage *          aMessage,
+                                   const otMessageInfo *aMessageInfo,
+                                   otError              aResult);
+    void        HandleCoapResponse(otError aResult);
+
+    void SynchronizeServerData(void);
+
+    ot::Notifier::Callback mNotifierCallback;
+    TimerMilli             mTimer;
+    uint32_t               mNextDelay;
+    bool                   mWaitingForResponse;
+};
+
+} // namespace NetworkData
+} // namespace ot
+
+#endif // OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+
+#endif // NETWORK_DATA_NOTIFIER_HPP_

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -76,6 +76,9 @@ ThreadNetif::ThreadNetif(Instance &aInstance)
     , mNetworkDataLocal(aInstance)
 #endif
     , mNetworkDataLeader(aInstance)
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+    , mNetworkDataNotifier(aInstance)
+#endif
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
     , mNetworkDiagnostic(aInstance)
 #endif

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -76,6 +76,7 @@
 #include "thread/mle.hpp"
 #include "thread/mle_router.hpp"
 #include "thread/network_data_local.hpp"
+#include "thread/network_data_notifier.hpp"
 #include "thread/network_diagnostic.hpp"
 #include "thread/panid_query_server.hpp"
 #include "thread/time_sync_service.hpp"
@@ -197,6 +198,9 @@ private:
     NetworkData::Local mNetworkDataLocal;
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     NetworkData::Leader mNetworkDataLeader;
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+    NetworkData::Notifier mNetworkDataNotifier;
+#endif
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
     NetworkDiagnostic::NetworkDiagnostic mNetworkDiagnostic;
 #endif // OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE


### PR DESCRIPTION
This commit centralizes the timing logic for transmitting SVR_DATA.ntf
messages that are used to update network data at the leader.

This component helps ensure the following:

- At most one SVR_DATA.ntf message is outstanding at any given time.

- A timer to rety sending SVR_DATA.ntf messages if sending fails due
  to lack of memory buffers.

- A timer to rate limit SVR_DATA.ntf messages that are acknowledged
  but no corresponding change in the Thread Network Data was observed.

- Utilizes ot::Notifier to trigger logic on role, child state, and
  network data changes.