### PR TITLE
[error] force error checking

### DIFF
--- a/include/openthread/error.h
+++ b/include/openthread/error.h
@@ -55,7 +55,7 @@ extern "C" {
  * This enumeration represents error codes used throughout OpenThread.
  *
  */
-typedef enum otError
+typedef enum OT_MUST_USE_RESULT otError
 {
     /**
      * No error.

--- a/include/openthread/platform/toolchain.h
+++ b/include/openthread/platform/toolchain.h
@@ -71,6 +71,8 @@ extern "C" {
  *
  * @note This is currently only available with clang (C++17 implements it
  *       as attribute [[nodiscard]]).
+ * @note To suppress the 'unused-result' warning/error, please use the
+ *       '-Wno-unused-result' compiler option.
  *
  */
 #if defined(__clang__)

--- a/include/openthread/platform/toolchain.h
+++ b/include/openthread/platform/toolchain.h
@@ -64,6 +64,22 @@ extern "C" {
 #endif
 
 /**
+ * @def OT_MUST_USE_RESULT
+ *
+ * Compiler-specific indication that a class or enum must be used when it is
+ * the return value of a function.
+ *
+ * @note This is currently only available with clang (C++17 implements it
+ *       as attribute [[nodiscard]]).
+ *
+ */
+#if defined(__clang__)
+#define OT_MUST_USE_RESULT __attribute__((warn_unused_result))
+#else
+#define OT_MUST_USE_RESULT
+#endif
+
+/**
  * @def OT_TOOL_PACKED_BEGIN
  *
  * Compiler-specific indication that a class or struct must be byte packed.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -276,7 +276,7 @@ Interpreter::Interpreter(Instance *aInstance)
 
     mIcmpHandler.mReceiveCallback = Interpreter::HandleIcmpReceive;
     mIcmpHandler.mContext         = this;
-    otIcmp6RegisterHandler(mInstance, &mIcmpHandler);
+    IgnoreError(otIcmp6RegisterHandler(mInstance, &mIcmpHandler));
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
     memset(mResolvingHostname, 0, sizeof(mResolvingHostname));
@@ -3978,12 +3978,12 @@ void Interpreter::ProcessNetworkDiagnostic(uint8_t aArgsLength, char *aArgs[])
 
     if (strcmp(aArgs[0], "get") == 0)
     {
-        otThreadSendDiagnosticGet(mInstance, &address, tlvTypes, count);
+        IgnoreError(otThreadSendDiagnosticGet(mInstance, &address, tlvTypes, count));
         ExitNow();
     }
     else if (strcmp(aArgs[0], "reset") == 0)
     {
-        otThreadSendDiagnosticReset(mInstance, &address, tlvTypes, count);
+        IgnoreError(otThreadSendDiagnosticReset(mInstance, &address, tlvTypes, count));
         AppendResult(OT_ERROR_NONE);
     }
     else

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -516,7 +516,7 @@ otError Coap::Process(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength < 1)
     {
-        ProcessHelp(0, NULL);
+        IgnoreError(ProcessHelp(0, NULL));
         error = OT_ERROR_INVALID_ARGS;
     }
     else

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -393,7 +393,7 @@ otError CoapSecure::Process(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength < 1)
     {
-        ProcessHelp(0, NULL);
+        IgnoreError(ProcessHelp(0, NULL));
         error = OT_ERROR_INVALID_ARGS;
     }
     else

--- a/src/cli/cli_commissioner.cpp
+++ b/src/cli/cli_commissioner.cpp
@@ -392,7 +392,7 @@ otError Commissioner::Process(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength < 1)
     {
-        ProcessHelp(0, NULL);
+        IgnoreError(ProcessHelp(0, NULL));
     }
     else
     {

--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -111,7 +111,7 @@ otError Joiner::Process(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength < 1)
     {
-        ProcessHelp(0, NULL);
+        IgnoreError(ProcessHelp(0, NULL));
     }
     else
     {

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -119,7 +119,7 @@ Uart::Uart(Instance *aInstance)
     mTxLength   = 0;
     mSendLength = 0;
 
-    otPlatUartEnable();
+    IgnoreError(otPlatUartEnable());
 }
 
 extern "C" void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)
@@ -150,7 +150,7 @@ void Uart::ReceiveTask(const uint8_t *aBuf, uint16_t aBufLength)
             if (mRxLength > 0)
             {
                 mRxBuffer[mRxLength] = '\0';
-                ProcessCommand();
+                IgnoreError(ProcessCommand());
             }
 
             Output(sCommandPrompt, sizeof(sCommandPrompt));
@@ -311,7 +311,7 @@ void Uart::Send(void)
         /* duplicate the output to the debug uart */
         otPlatDebugUart_write_bytes(reinterpret_cast<uint8_t *>(mTxBuffer + mTxHead), mSendLength);
 #endif
-        otPlatUartSend(reinterpret_cast<uint8_t *>(mTxBuffer + mTxHead), mSendLength);
+        IgnoreError(otPlatUartSend(reinterpret_cast<uint8_t *>(mTxBuffer + mTxHead), mSendLength));
     }
 
 exit:

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -264,7 +264,7 @@ otError UdpExample::Process(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength < 1)
     {
-        ProcessHelp(0, NULL);
+        IgnoreError(ProcessHelp(0, NULL));
         error = OT_ERROR_INVALID_ARGS;
     }
     else

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -69,8 +69,8 @@ otError otBorderRouterAddOnMeshPrefix(otInstance *aInstance, const otBorderRoute
     if (error == OT_ERROR_NONE && aConfig->mDp)
     {
         // Restore local server data
-        instance.Get<NetworkData::Local>().RemoveOnMeshPrefix(aConfig->mPrefix.mPrefix.mFields.m8,
-                                                              aConfig->mPrefix.mLength);
+        IgnoreError(instance.Get<NetworkData::Local>().RemoveOnMeshPrefix(aConfig->mPrefix.mPrefix.mFields.m8,
+                                                                          aConfig->mPrefix.mLength));
 
         instance.Get<BackboneRouter::Local>().SetDomainPrefix(*aConfig);
     }

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -82,7 +82,7 @@ otError otCoapMessageSetToken(otMessage *aMessage, const uint8_t *aToken, uint8_
 
 void otCoapMessageGenerateToken(otMessage *aMessage, uint8_t aTokenLength)
 {
-    static_cast<Coap::Message *>(aMessage)->SetToken(aTokenLength);
+    IgnoreError(static_cast<Coap::Message *>(aMessage)->SetToken(aTokenLength));
 }
 
 otError otCoapMessageAppendContentFormatOption(otMessage *aMessage, otCoapOptionContentFormat aContentFormat)

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -250,7 +250,7 @@ void otThreadSetRouterSelectionJitter(otInstance *aInstance, uint8_t aRouterJitt
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    instance.Get<Mle::MleRouter>().SetRouterSelectionJitter(aRouterJitter);
+    IgnoreError(instance.Get<Mle::MleRouter>().SetRouterSelectionJitter(aRouterJitter));
 }
 
 otError otThreadGetChildInfoById(otInstance *aInstance, uint16_t aChildId, otChildInfo *aChildInfo)

--- a/src/core/backbone_router/leader.cpp
+++ b/src/core/backbone_router/leader.cpp
@@ -184,7 +184,7 @@ void Leader::UpdateBackboneRouterPrimary(void)
     BackboneRouterConfig config;
     State                state;
 
-    Get<NetworkData::Leader>().GetBackboneRouterPrimary(config);
+    IgnoreError(Get<NetworkData::Leader>().GetBackboneRouterPrimary(config));
 
     if (config.mServer16 != mConfig.mServer16)
     {

--- a/src/core/backbone_router/local.cpp
+++ b/src/core/backbone_router/local.cpp
@@ -93,12 +93,12 @@ void Local::SetEnabled(bool aEnable)
     {
         SetState(OT_BACKBONE_ROUTER_STATE_SECONDARY);
         AddDomainPrefixToNetworkData();
-        AddService();
+        IgnoreError(AddService());
     }
     else
     {
         RemoveDomainPrefixFromNetworkData();
-        RemoveService();
+        IgnoreError(RemoveService());
         SetState(OT_BACKBONE_ROUTER_STATE_DISABLED);
     }
 

--- a/src/core/backbone_router/local.cpp
+++ b/src/core/backbone_router/local.cpp
@@ -224,22 +224,22 @@ void Local::SetState(BackboneRouterState aState)
     {
         // Subscribe All Network Backbone Routers Multicast Address for both Secondary and Primary state.
         mAllNetworkBackboneRouters.GetAddress().SetMulticastNetworkPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-        Get<ThreadNetif>().SubscribeMulticast(mAllNetworkBackboneRouters);
+        IgnoreError(Get<ThreadNetif>().SubscribeMulticast(mAllNetworkBackboneRouters));
     }
     else if (aState == OT_BACKBONE_ROUTER_STATE_DISABLED)
     {
-        Get<ThreadNetif>().UnsubscribeMulticast(mAllNetworkBackboneRouters);
+        IgnoreError(Get<ThreadNetif>().UnsubscribeMulticast(mAllNetworkBackboneRouters));
     }
 
     if (mState == OT_BACKBONE_ROUTER_STATE_PRIMARY)
     {
-        Get<ThreadNetif>().RemoveUnicastAddress(mBackboneRouterPrimaryAloc);
+        IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mBackboneRouterPrimaryAloc));
     }
     else if (aState == OT_BACKBONE_ROUTER_STATE_PRIMARY)
     {
         // Add Primary Backbone Router Aloc for Primary Backbone Router.
         mBackboneRouterPrimaryAloc.GetAddress().SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-        Get<ThreadNetif>().AddUnicastAddress(mBackboneRouterPrimaryAloc);
+        IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mBackboneRouterPrimaryAloc));
     }
 
     mState = aState;
@@ -351,15 +351,15 @@ void Local::ApplyMeshLocalPrefix(void)
 {
     VerifyOrExit(IsEnabled(), OT_NOOP);
 
-    Get<ThreadNetif>().UnsubscribeMulticast(mAllNetworkBackboneRouters);
+    IgnoreError(Get<ThreadNetif>().UnsubscribeMulticast(mAllNetworkBackboneRouters));
     mAllNetworkBackboneRouters.GetAddress().SetMulticastNetworkPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-    Get<ThreadNetif>().SubscribeMulticast(mAllNetworkBackboneRouters);
+    IgnoreError(Get<ThreadNetif>().SubscribeMulticast(mAllNetworkBackboneRouters));
 
     if (IsPrimary())
     {
-        Get<ThreadNetif>().RemoveUnicastAddress(mBackboneRouterPrimaryAloc);
+        IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mBackboneRouterPrimaryAloc));
         mBackboneRouterPrimaryAloc.GetAddress().SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-        Get<ThreadNetif>().AddUnicastAddress(mBackboneRouterPrimaryAloc);
+        IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mBackboneRouterPrimaryAloc));
     }
 
 exit:
@@ -370,19 +370,19 @@ void Local::UpdateAllDomainBackboneRouters(Leader::DomainPrefixState aState)
 {
     if (!IsEnabled())
     {
-        Get<ThreadNetif>().UnsubscribeMulticast(mAllDomainBackboneRouters);
+        IgnoreError(Get<ThreadNetif>().UnsubscribeMulticast(mAllDomainBackboneRouters));
         ExitNow();
     }
 
     if (aState == Leader::kDomainPrefixRemoved || aState == Leader::kDomainPrefixRefreshed)
     {
-        Get<ThreadNetif>().UnsubscribeMulticast(mAllDomainBackboneRouters);
+        IgnoreError(Get<ThreadNetif>().UnsubscribeMulticast(mAllDomainBackboneRouters));
     }
 
     if (aState == Leader::kDomainPrefixAdded || aState == Leader::kDomainPrefixRefreshed)
     {
         mAllDomainBackboneRouters.GetAddress().SetMulticastNetworkPrefix(*Get<Leader>().GetDomainPrefix());
-        Get<ThreadNetif>().SubscribeMulticast(mAllDomainBackboneRouters);
+        IgnoreError(Get<ThreadNetif>().SubscribeMulticast(mAllDomainBackboneRouters));
     }
 
 exit:

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -286,7 +286,7 @@ otError Message::SetToken(uint8_t aTokenLength)
 
     OT_ASSERT(aTokenLength <= sizeof(token));
 
-    Random::Crypto::FillBuffer(token, aTokenLength);
+    IgnoreError(Random::Crypto::FillBuffer(token, aTokenLength));
 
     return SetToken(token, aTokenLength);
 }

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -47,10 +47,10 @@ void Message::Init(void)
 {
     GetHelpData().Clear();
     SetVersion(kVersion1);
-    SetOffset(0);
+    IgnoreError(SetOffset(0));
     GetHelpData().mHeaderLength = kMinHeaderLength;
 
-    SetLength(GetHelpData().mHeaderLength);
+    IgnoreError(SetLength(GetHelpData().mHeaderLength));
 }
 
 void Message::Init(Type aType, Code aCode)
@@ -235,7 +235,7 @@ otError Message::SetPayloadMarker(void)
     GetHelpData().mHeaderLength = GetLength();
 
     // Set offset to the start of payload.
-    SetOffset(GetHelpData().mHeaderLength);
+    IgnoreError(SetOffset(GetHelpData().mHeaderLength));
 
 exit:
     return error;
@@ -264,7 +264,7 @@ otError Message::ParseHeader(void)
 
     VerifyOrExit(iterator.mNextOptionOffset > 0, error = OT_ERROR_PARSE);
     GetHelpData().mHeaderLength = iterator.mNextOptionOffset - GetHelpData().mHeaderOffset;
-    MoveOffset(GetHelpData().mHeaderLength);
+    IgnoreError(MoveOffset(GetHelpData().mHeaderLength));
 
 exit:
     return error;

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -95,7 +95,7 @@ void CoapSecure::Stop(void)
 
     for (ot::Message *message = mTransmitQueue.GetHead(); message != NULL; message = message->GetNext())
     {
-        mTransmitQueue.Dequeue(*message);
+        IgnoreError(mTransmitQueue.Dequeue(*message));
         message->Free();
     }
 
@@ -179,7 +179,7 @@ otError CoapSecure::Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessage
     otError error;
 
     SuccessOrExit(error = mTransmitQueue.Enqueue(aMessage));
-    mTransmitTask.Post();
+    IgnoreError(mTransmitTask.Post());
 
 exit:
     return error;
@@ -232,11 +232,11 @@ void CoapSecure::HandleTransmit(void)
     ot::Message *message = mTransmitQueue.GetHead();
 
     VerifyOrExit(message != NULL, OT_NOOP);
-    mTransmitQueue.Dequeue(*message);
+    IgnoreError(mTransmitQueue.Dequeue(*message));
 
     if (mTransmitQueue.GetHead() != NULL)
     {
-        mTransmitTask.Post();
+        IgnoreError(mTransmitTask.Post());
     }
 
     SuccessOrExit(error = mDtls.Send(*message, message->GetLength()));

--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -38,6 +38,8 @@
 
 #include <stdbool.h>
 
+#include <openthread/error.h>
+
 #include "utils/static_assert.hpp"
 
 /**
@@ -154,5 +156,19 @@
         {                             \
         }                             \
     } while (false)
+
+/**
+ * This function ignores an error explicitly.
+ *
+ * This is primarily used to indicate the intention of developer that
+ * the error can be safely ignored or there is guaranteed to be no error.
+ *
+ * @param[in]  aError  The error to be ignored.
+ *
+ */
+static inline void IgnoreError(otError aError)
+{
+    OT_UNUSED_VARIABLE(aError);
+}
 
 #endif // CODE_UTILS_HPP_

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -173,7 +173,7 @@ void Instance::AfterInit(void)
     // Restore datasets and network information
 
     Get<Settings>().Init();
-    Get<Mle::MleRouter>().Restore();
+    IgnoreError(Get<Mle::MleRouter>().Restore());
 
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
@@ -189,9 +189,9 @@ void Instance::Finalize(void)
     mIsInitialized = false;
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
-    IgnoreReturnValue(otThreadSetEnabled(this, false));
-    IgnoreReturnValue(otIp6SetEnabled(this, false));
-    IgnoreReturnValue(otLinkSetEnabled(this, false));
+    IgnoreError(otThreadSetEnabled(this, false));
+    IgnoreError(otIp6SetEnabled(this, false));
+    IgnoreError(otLinkSetEnabled(this, false));
 
     Get<Settings>().Deinit();
 #endif

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -196,7 +196,7 @@ void Instance::Finalize(void)
     Get<Settings>().Deinit();
 #endif
 
-    Get<Mac::SubMac>().Disable();
+    IgnoreError(Get<Mac::SubMac>().Disable());
 
 #if !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
 

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -289,7 +289,7 @@ otError Message::SetLength(uint16_t aLength)
     // Correct offset in case shorter length is set.
     if (GetOffset() > aLength)
     {
-        SetOffset(aLength);
+        IgnoreError(SetOffset(aLength));
     }
 
 exit:
@@ -372,14 +372,14 @@ otError Message::SetPriority(uint8_t aPriority)
     if (mBuffer.mHead.mInfo.mInPriorityQ)
     {
         priorityQueue = mBuffer.mHead.mInfo.mQueue.mPriority;
-        priorityQueue->Dequeue(*this);
+        IgnoreError(priorityQueue->Dequeue(*this));
     }
 
     mBuffer.mHead.mInfo.mPriority = aPriority;
 
     if (priorityQueue != NULL)
     {
-        priorityQueue->Enqueue(*this);
+        IgnoreError(priorityQueue->Enqueue(*this));
     }
 
 exit:
@@ -426,7 +426,7 @@ otError Message::Prepend(const void *aBuf, uint16_t aLength)
 
     SetReserved(GetReserved() - aLength);
     mBuffer.mHead.mInfo.mLength += aLength;
-    SetOffset(GetOffset() + aLength);
+    IgnoreError(SetOffset(GetOffset() + aLength));
 
     if (aBuf != NULL)
     {
@@ -641,7 +641,7 @@ Message *Message::Clone(uint16_t aLength) const
 
     // Copy selected message information.
     offset = GetOffset() < aLength ? GetOffset() : aLength;
-    messageCopy->SetOffset(offset);
+    IgnoreError(messageCopy->SetOffset(offset));
 
     messageCopy->SetSubType(GetSubType());
     messageCopy->SetLinkSecurityEnabled(IsLinkSecurityEnabled());

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -680,7 +680,7 @@ public:
      * @param[in] aRss A new RSS value (in dBm) to be added to average.
      *
      */
-    void AddRss(int8_t aRss) { mBuffer.mHead.mInfo.mRssAverager.Add(aRss); }
+    void AddRss(int8_t aRss) { IgnoreError(mBuffer.mHead.mInfo.mRssAverager.Add(aRss)); }
 
     /**
      * This method returns the average RSS (Received Signal Strength) associated with the message.

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -124,7 +124,7 @@ void Notifier::Signal(otChangedFlags aFlags)
 {
     mFlagsToSignal |= aFlags;
     mSignaledFlags |= aFlags;
-    mTask.Post();
+    IgnoreError(mTask.Post());
 }
 
 void Notifier::SignalIfFirst(otChangedFlags aFlags)
@@ -195,7 +195,7 @@ void Notifier::LogChangedFlags(otChangedFlags aFlags) const
                 addSpace = false;
             }
 
-            string.Append("%s%s", addSpace ? " " : "", FlagToString(1 << bit));
+            IgnoreError(string.Append("%s%s", addSpace ? " " : "", FlagToString(1 << bit)));
             addSpace = true;
 
             flags ^= (1 << bit);

--- a/src/core/common/string.hpp
+++ b/src/core/common/string.hpp
@@ -124,7 +124,7 @@ public:
     {
         va_list args;
         va_start(args, aFormat);
-        Write(mBuffer, kSize, mLength, aFormat, args);
+        IgnoreError(Write(mBuffer, kSize, mLength, aFormat, args));
         va_end(args);
     }
 

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -135,7 +135,7 @@ void TimerScheduler::Remove(Timer &aTimer, const AlarmApi &aAlarmApi)
     }
     else
     {
-        mTimerList.Remove(aTimer);
+        IgnoreError(mTimerList.Remove(aTimer));
     }
 
     aTimer.SetNext(&aTimer);

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -180,7 +180,7 @@ otError Diags::ProcessChannel(uint8_t aArgsLength, char *aArgs[], char *aOutput,
         VerifyOrExit(value >= Radio::kChannelMin && value <= Radio::kChannelMax, error = OT_ERROR_INVALID_ARGS);
 
         mChannel = static_cast<uint8_t>(value);
-        Get<Radio>().Receive(mChannel);
+        IgnoreError(Get<Radio>().Receive(mChannel));
         otPlatDiagChannelSet(mChannel);
 
         snprintf(aOutput, aOutputMaxLen, "set channel to %d\r\nstatus 0x%02x\r\n", mChannel, error);
@@ -291,7 +291,7 @@ otError Diags::ProcessStart(uint8_t aArgsLength, char *aArgs[], char *aOutput, s
     otPlatDiagChannelSet(mChannel);
     otPlatDiagTxPowerSet(mTxPower);
 
-    Get<Radio>().Enable();
+    IgnoreError(Get<Radio>().Enable());
     Get<Radio>().SetPromiscuous(true);
     otPlatAlarmMilliStop(&GetInstance());
     SuccessOrExit(error = Get<Radio>().Receive(mChannel));
@@ -370,7 +370,7 @@ void Diags::TransmitPacket(void)
         mTxPacket->mPsdu[i] = i;
     }
 
-    Get<Radio>().Transmit(*static_cast<Mac::TxFrame *>(mTxPacket));
+    IgnoreError(Get<Radio>().Transmit(*static_cast<Mac::TxFrame *>(mTxPacket)));
 }
 
 otError Diags::ProcessRadio(uint8_t aArgsLength, char *aArgs[], char *aOutput, size_t aOutputMaxLen)
@@ -536,7 +536,7 @@ exit:
     {
     case OT_ERROR_NONE:
 
-        ProcessCmd(argCount, &aArgsector[0], aOutput, aOutputMaxLen);
+        IgnoreError(ProcessCmd(argCount, &aArgsector[0], aOutput, aOutputMaxLen));
         break;
 
     case OT_ERROR_NO_BUFS:

--- a/src/core/mac/channel_mask.cpp
+++ b/src/core/mac/channel_mask.cpp
@@ -100,7 +100,7 @@ ChannelMask::InfoString ChannelMask::ToString(void) const
     bool       addComma = false;
     otError    error;
 
-    string.Append("{");
+    IgnoreError(string.Append("{"));
 
     error = GetNextChannel(channel);
 
@@ -119,16 +119,16 @@ ChannelMask::InfoString ChannelMask::ToString(void) const
             rangeEnd = channel;
         }
 
-        string.Append("%s%d", addComma ? ", " : " ", rangeStart);
+        IgnoreError(string.Append("%s%d", addComma ? ", " : " ", rangeStart));
         addComma = true;
 
         if (rangeStart < rangeEnd)
         {
-            string.Append("%s%d", rangeEnd == rangeStart + 1 ? ", " : "-", rangeEnd);
+            IgnoreError(string.Append("%s%d", rangeEnd == rangeStart + 1 ? ", " : "-", rangeEnd));
         }
     }
 
-    string.Append("}");
+    IgnoreError(string.Append("}"));
 
     return string;
 }

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -157,7 +157,7 @@ void DataPollHandler::HandleDataPoll(Mac::RxFrame &aFrame)
     if (mIndirectTxChild == NULL)
     {
         mIndirectTxChild = child;
-        Get<Mac::Mac>().RequestIndirectFrameTransmission();
+        IgnoreError(Get<Mac::Mac>().RequestIndirectFrameTransmission());
     }
     else
     {
@@ -263,10 +263,10 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, otError aError
                 uint32_t frameCounter;
                 uint8_t  keyId;
 
-                aFrame.GetFrameCounter(frameCounter);
+                IgnoreError(aFrame.GetFrameCounter(frameCounter));
                 aChild.SetIndirectFrameCounter(frameCounter);
 
-                aFrame.GetKeyId(keyId);
+                IgnoreError(aFrame.GetKeyId(keyId));
                 aChild.SetIndirectKeyId(keyId);
             }
 
@@ -309,7 +309,7 @@ void DataPollHandler::ProcessPendingPolls(void)
     if (mIndirectTxChild != NULL)
     {
         mIndirectTxChild->SetDataPollPending(false);
-        Get<Mac::Mac>().RequestIndirectFrameTransmission();
+        IgnoreError(Get<Mac::Mac>().RequestIndirectFrameTransmission());
     }
 }
 

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -208,14 +208,14 @@ void DataPollSender::HandlePollSent(Mac::TxFrame &aFrame, otError aError)
 
     if (!aFrame.IsEmpty())
     {
-        aFrame.GetDstAddr(macDest);
+        IgnoreError(aFrame.GetDstAddr(macDest));
         Get<MeshForwarder>().UpdateNeighborOnSentFrame(aFrame, aError, macDest);
     }
 
     if (GetParent().IsStateInvalid())
     {
         StopPolling();
-        Get<Mle::MleRouter>().BecomeDetached();
+        IgnoreError(Get<Mle::MleRouter>().BecomeDetached());
         ExitNow();
     }
 
@@ -296,7 +296,7 @@ void DataPollSender::HandlePollTimeout(void)
 
     if (mPollTimeoutCounter < kQuickPollsAfterTimeout)
     {
-        SendDataPoll();
+        IgnoreError(SendDataPoll());
     }
     else
     {
@@ -315,7 +315,7 @@ void DataPollSender::ProcessFrame(const Mac::RxFrame &aFrame)
 
     if (aFrame.GetFramePending())
     {
-        SendDataPoll();
+        IgnoreError(SendDataPoll());
     }
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
     else if (aFrame.IsAck())
@@ -494,7 +494,7 @@ uint32_t DataPollSender::CalculatePollPeriod(void) const
 
 void DataPollSender::HandlePollTimer(Timer &aTimer)
 {
-    aTimer.GetOwner<DataPollSender>().SendDataPoll();
+    IgnoreError(aTimer.GetOwner<DataPollSender>().SendDataPoll());
 }
 
 uint32_t DataPollSender::GetDefaultPollPeriod(void) const

--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -81,7 +81,7 @@ otError LinkRaw::SetEnabled(bool aEnabled)
     }
     else
     {
-        mSubMac.Disable();
+        IgnoreError(mSubMac.Disable());
     }
 
     mEnabled = aEnabled;

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1058,22 +1058,22 @@ Frame::InfoString Frame::ToInfoString(void) const
     uint8_t    commandId, type;
     Address    src, dst;
 
-    string.Append("len:%d, seqnum:%d, type:", GetLength(), GetSequence());
+    IgnoreError(string.Append("len:%d, seqnum:%d, type:", GetLength(), GetSequence()));
 
     type = GetType();
 
     switch (type)
     {
     case kFcfFrameBeacon:
-        string.Append("Beacon");
+        IgnoreError(string.Append("Beacon"));
         break;
 
     case kFcfFrameData:
-        string.Append("Data");
+        IgnoreError(string.Append("Data"));
         break;
 
     case kFcfFrameAck:
-        string.Append("Ack");
+        IgnoreError(string.Append("Ack"));
         break;
 
     case kFcfFrameMacCmd:
@@ -1085,30 +1085,31 @@ Frame::InfoString Frame::ToInfoString(void) const
         switch (commandId)
         {
         case kMacCmdDataRequest:
-            string.Append("Cmd(DataReq)");
+            IgnoreError(string.Append("Cmd(DataReq)"));
             break;
 
         case kMacCmdBeaconRequest:
-            string.Append("Cmd(BeaconReq)");
+            IgnoreError(string.Append("Cmd(BeaconReq)"));
             break;
 
         default:
-            string.Append("Cmd(%d)", commandId);
+            IgnoreError(string.Append("Cmd(%d)", commandId));
             break;
         }
 
         break;
 
     default:
-        string.Append("%d", type);
+        IgnoreError(string.Append("%d", type));
         break;
     }
 
-    GetSrcAddr(src);
-    GetDstAddr(dst);
+    IgnoreError(GetSrcAddr(src));
+    IgnoreError(GetDstAddr(dst));
 
-    string.Append(", src:%s, dst:%s, sec:%s, ackreq:%s", src.ToString().AsCString(), dst.ToString().AsCString(),
-                  GetSecurityEnabled() ? "yes" : "no", GetAckRequest() ? "yes" : "no");
+    IgnoreError(string.Append(", src:%s, dst:%s, sec:%s, ackreq:%s", src.ToString().AsCString(),
+                              dst.ToString().AsCString(), GetSecurityEnabled() ? "yes" : "no",
+                              GetAckRequest() ? "yes" : "no"));
 
     return string;
 }
@@ -1117,7 +1118,7 @@ BeaconPayload::InfoString BeaconPayload::ToInfoString(void) const
 {
     NetworkName name;
 
-    name.Set(GetNetworkName());
+    IgnoreError(name.Set(GetNetworkName()));
 
     return InfoString("name:%s, xpanid:%s, id:%d, ver:%d, joinable:%s, native:%s", name.GetAsCString(),
                       mExtendedPanId.ToString().AsCString(), GetProtocolId(), GetProtocolVersion(),

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -57,7 +57,7 @@ PanId GenerateRandomPanId(void)
 #if !OPENTHREAD_RADIO
 void ExtAddress::GenerateRandom(void)
 {
-    Random::Crypto::FillBuffer(m8, sizeof(ExtAddress));
+    IgnoreError(Random::Crypto::FillBuffer(m8, sizeof(ExtAddress)));
     SetGroup(false);
     SetLocal(true);
 }

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -241,11 +241,11 @@ void SubMac::StartCsmaBackoff(void)
 
     if (mRxOnWhenBackoff)
     {
-        Get<Radio>().Receive(mTransmitFrame.GetChannel());
+        IgnoreError(Get<Radio>().Receive(mTransmitFrame.GetChannel()));
     }
     else
     {
-        Get<Radio>().Sleep();
+        IgnoreError(Get<Radio>().Sleep());
     }
 
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
@@ -400,7 +400,7 @@ otError SubMac::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration)
 
     if (RadioSupportsEnergyScan())
     {
-        Get<Radio>().EnergyScan(aScanChannel, aScanDuration);
+        IgnoreError(Get<Radio>().EnergyScan(aScanChannel, aScanDuration));
         SetState(kStateEnergyScan);
     }
     else if (ShouldHandleEnergyScan())
@@ -471,7 +471,7 @@ void SubMac::HandleTimer(void)
 
     case kStateTransmit:
         otLogDebgMac("Ack timer timed out");
-        Get<Radio>().Receive(mTransmitFrame.GetChannel());
+        IgnoreError(Get<Radio>().Receive(mTransmitFrame.GetChannel()));
         HandleTransmitDone(mTransmitFrame, NULL, OT_ERROR_NO_ACK);
         break;
 

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -376,11 +376,11 @@ void BorderAgent::HandleStateChanged(otChangedFlags aFlags)
 
     if (Get<Mle::MleRouter>().IsAttached())
     {
-        Start();
+        IgnoreError(Start());
     }
     else
     {
-        Stop();
+        IgnoreError(Stop());
     }
 
 exit:
@@ -754,7 +754,7 @@ void BorderAgent::ApplyMeshLocalPrefix(void)
     if (Get<ThreadNetif>().RemoveUnicastAddress(mCommissionerAloc) == OT_ERROR_NONE)
     {
         mCommissionerAloc.GetAddress().SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-        Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc);
+        IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc));
     }
 
 exit:

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -252,9 +252,10 @@ void BorderAgent::HandleCoapResponse(void *               aContext,
 
             SuccessOrExit(error = Tlv::ReadUint16Tlv(*response, Tlv::kCommissionerSessionId, sessionId));
 
-            instance.Get<Mle::MleRouter>().GetCommissionerAloc(borderAgent.mCommissionerAloc.GetAddress(), sessionId);
-            instance.Get<ThreadNetif>().AddUnicastAddress(borderAgent.mCommissionerAloc);
-            instance.Get<Ip6::Udp>().AddReceiver(borderAgent.mUdpReceiver);
+            IgnoreError(instance.Get<Mle::MleRouter>().GetCommissionerAloc(borderAgent.mCommissionerAloc.GetAddress(),
+                                                                           sessionId));
+            IgnoreError(instance.Get<ThreadNetif>().AddUnicastAddress(borderAgent.mCommissionerAloc));
+            IgnoreError(instance.Get<Ip6::Udp>().AddReceiver(borderAgent.mUdpReceiver));
         }
     }
 
@@ -289,9 +290,9 @@ void BorderAgent::HandleRequest<&BorderAgent::mCommissionerPetition>(void *     
                                                                      otMessage *          aMessage,
                                                                      const otMessageInfo *aMessageInfo)
 {
-    static_cast<BorderAgent *>(aContext)->ForwardToLeader(*static_cast<Coap::Message *>(aMessage),
-                                                          *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-                                                          OT_URI_PATH_LEADER_PETITION, true, true);
+    IgnoreError(static_cast<BorderAgent *>(aContext)->ForwardToLeader(
+        *static_cast<Coap::Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
+        OT_URI_PATH_LEADER_PETITION, true, true));
 }
 
 template <>
@@ -659,7 +660,7 @@ void BorderAgent::HandleConnected(bool aConnected)
     else
     {
         otLogInfoMeshCoP("Commissioner disconnected");
-        Get<ThreadNetif>().RemoveUnicastAddress(mCommissionerAloc);
+        IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mCommissionerAloc));
         SetState(OT_BORDER_AGENT_STATE_STARTED);
     }
 }
@@ -675,18 +676,18 @@ otError BorderAgent::Start(void)
     SuccessOrExit(error = coaps.SetPsk(Get<KeyManager>().GetPskc().m8, OT_PSKC_MAX_SIZE));
     coaps.SetConnectedCallback(HandleConnected, this);
 
-    coaps.AddResource(mActiveGet);
-    coaps.AddResource(mActiveSet);
-    coaps.AddResource(mPendingGet);
-    coaps.AddResource(mPendingSet);
-    coaps.AddResource(mCommissionerPetition);
-    coaps.AddResource(mCommissionerKeepAlive);
-    coaps.AddResource(mCommissionerSet);
-    coaps.AddResource(mCommissionerGet);
-    coaps.AddResource(mProxyTransmit);
-    coaps.AddResource(mRelayTransmit);
+    IgnoreError(coaps.AddResource(mActiveGet));
+    IgnoreError(coaps.AddResource(mActiveSet));
+    IgnoreError(coaps.AddResource(mPendingGet));
+    IgnoreError(coaps.AddResource(mPendingSet));
+    IgnoreError(coaps.AddResource(mCommissionerPetition));
+    IgnoreError(coaps.AddResource(mCommissionerKeepAlive));
+    IgnoreError(coaps.AddResource(mCommissionerSet));
+    IgnoreError(coaps.AddResource(mCommissionerGet));
+    IgnoreError(coaps.AddResource(mProxyTransmit));
+    IgnoreError(coaps.AddResource(mRelayTransmit));
 
-    Get<Coap::Coap>().AddResource(mRelayReceive);
+    IgnoreError(Get<Coap::Coap>().AddResource(mRelayReceive));
 
     SetState(OT_BORDER_AGENT_STATE_STARTED);
 

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -105,9 +105,9 @@ private:
     template <Coap::Resource BorderAgent::*aResource>
     static void HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
     {
-        static_cast<BorderAgent *>(aContext)->ForwardToLeader(
+        IgnoreError(static_cast<BorderAgent *>(aContext)->ForwardToLeader(
             *static_cast<Coap::Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-            (static_cast<BorderAgent *>(aContext)->*aResource).GetUriPath(), false, false);
+            (static_cast<BorderAgent *>(aContext)->*aResource).GetUriPath(), false, false));
     }
 
     static void HandleTimeout(Timer &aTimer);

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -1107,9 +1107,9 @@ void Commissioner::ApplyMeshLocalPrefix(void)
 {
     VerifyOrExit(mState == OT_COMMISSIONER_STATE_ACTIVE, OT_NOOP);
 
-    Get<ThreadNetif>().RemoveUnicastAddress(mCommissionerAloc);
+    IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mCommissionerAloc));
     mCommissionerAloc.GetAddress().SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-    Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc);
+    IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc));
 
 exit:
     return;

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -833,7 +833,8 @@ void Commissioner::HandleLeaderKeepAliveResponse(Coap::Message *         aMessag
     uint8_t state;
 
     VerifyOrExit(mState == OT_COMMISSIONER_STATE_ACTIVE, OT_NOOP);
-    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED, IgnoreError(Stop(/* aResign */ false)));
+    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED,
+                 IgnoreError(Stop(/* aResign */ false)));
 
     otLogInfoMeshCoP("received Leader keep-alive response");
 

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -114,9 +114,9 @@ void Commissioner::SignalJoinerEvent(otCommissionerJoinerEvent aEvent, const Mac
 
 void Commissioner::AddCoapResources(void)
 {
-    Get<Coap::Coap>().AddResource(mRelayReceive);
-    Get<Coap::Coap>().AddResource(mDatasetChanged);
-    Get<Coap::CoapSecure>().AddResource(mJoinerFinalize);
+    IgnoreError(Get<Coap::Coap>().AddResource(mRelayReceive));
+    IgnoreError(Get<Coap::Coap>().AddResource(mDatasetChanged));
+    IgnoreError(Get<Coap::CoapSecure>().AddResource(mJoinerFinalize));
 }
 
 void Commissioner::RemoveCoapResources(void)
@@ -193,7 +193,7 @@ otError Commissioner::Stop(bool aResign)
 
     if (mState == OT_COMMISSIONER_STATE_ACTIVE)
     {
-        Get<ThreadNetif>().RemoveUnicastAddress(mCommissionerAloc);
+        IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mCommissionerAloc));
         RemoveCoapResources();
         ClearJoiners();
         needResign = true;
@@ -209,7 +209,7 @@ otError Commissioner::Stop(bool aResign)
 
     if (needResign && aResign)
     {
-        SendKeepAlive();
+        IgnoreError(SendKeepAlive());
     }
 
 exit:
@@ -276,7 +276,7 @@ void Commissioner::ClearJoiners(void)
         joiner->mValid = false;
     }
 
-    SendCommissionerSet();
+    IgnoreError(SendCommissionerSet());
 }
 
 otError Commissioner::AddJoiner(const Mac::ExtAddress *aEui64, const char *aPskd, uint32_t aTimeout)
@@ -287,7 +287,7 @@ otError Commissioner::AddJoiner(const Mac::ExtAddress *aEui64, const char *aPskd
 
     VerifyOrExit(StringLength(aPskd, Dtls::kPskMaxLength + 1) <= Dtls::kPskMaxLength, error = OT_ERROR_INVALID_ARGS);
 
-    RemoveJoiner(aEui64, 0, kJoinerOpFlagNotNotifyLeader); // remove immediately
+    IgnoreError(RemoveJoiner(aEui64, 0, kJoinerOpFlagNotNotifyLeader)); // remove immediately
 
     for (Joiner *joiner = &mJoiners[0]; joiner < OT_ARRAY_END(mJoiners); joiner++)
     {
@@ -312,7 +312,7 @@ otError Commissioner::AddJoiner(const Mac::ExtAddress *aEui64, const char *aPskd
 
         UpdateJoinerExpirationTimer();
 
-        SendCommissionerSet();
+        IgnoreError(SendCommissionerSet());
 
         otLogInfoMeshCoP("Added Joiner (%s, %s)", (aEui64 != NULL) ? aEui64->ToString().AsCString() : "*", aPskd);
 
@@ -396,7 +396,7 @@ otError Commissioner::RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDela
             UpdateJoinerExpirationTimer();
             if ((aFlags & kJoinerOpFlagNotNotifyLeader) == 0)
             {
-                SendCommissionerSet();
+                IgnoreError(SendCommissionerSet());
             }
 
             otLogInfoMeshCoP("Removed Joiner (%s)", (aEui64 != NULL) ? aEui64->ToString().AsCString() : "*");
@@ -447,11 +447,11 @@ void Commissioner::HandleTimer(void)
         break;
 
     case OT_COMMISSIONER_STATE_PETITION:
-        SendPetition();
+        IgnoreError(SendPetition());
         break;
 
     case OT_COMMISSIONER_STATE_ACTIVE:
-        SendKeepAlive();
+        IgnoreError(SendKeepAlive());
         break;
     }
 }
@@ -476,7 +476,7 @@ void Commissioner::HandleJoinerExpirationTimer(void)
         if (now >= joiner->mExpirationTime)
         {
             otLogDebgMeshCoP("removing joiner due to timeout or successfully joined");
-            RemoveJoiner(&joiner->mEui64, 0); // remove immediately
+            IgnoreError(RemoveJoiner(&joiner->mEui64, 0)); // remove immediately
         }
     }
 
@@ -634,7 +634,7 @@ otError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDatase
     if (message->GetLength() == message->GetOffset())
     {
         // no payload, remove coap payload marker
-        message->SetLength(message->GetLength() - 1);
+        IgnoreError(message->SetLength(message->GetLength() - 1));
     }
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
@@ -739,7 +739,7 @@ void Commissioner::HandleLeaderPetitionResponse(Coap::Message *         aMessage
     otLogInfoMeshCoP("received Leader Petition response");
 
     SuccessOrExit(Tlv::ReadUint8Tlv(*aMessage, Tlv::kState, state));
-    VerifyOrExit(state == StateTlv::kAccept, Stop(/* aResign */ false));
+    VerifyOrExit(state == StateTlv::kAccept, IgnoreError(Stop(/* aResign */ false)));
 
     SuccessOrExit(Tlv::ReadUint16Tlv(*aMessage, Tlv::kCommissionerSessionId, mSessionId));
 
@@ -747,12 +747,12 @@ void Commissioner::HandleLeaderPetitionResponse(Coap::Message *         aMessage
     // this could happen if commissioner is stopped by API during petitioning
     if (mState == OT_COMMISSIONER_STATE_DISABLED)
     {
-        SendKeepAlive(mSessionId);
+        IgnoreError(SendKeepAlive(mSessionId));
         ExitNow();
     }
 
-    Get<Mle::MleRouter>().GetCommissionerAloc(mCommissionerAloc.GetAddress(), mSessionId);
-    Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc);
+    IgnoreError(Get<Mle::MleRouter>().GetCommissionerAloc(mCommissionerAloc.GetAddress(), mSessionId));
+    IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc));
 
     AddCoapResources();
     SetState(OT_COMMISSIONER_STATE_ACTIVE);
@@ -766,7 +766,7 @@ exit:
     {
         if (mTransmitAttempts >= kPetitionRetryCount)
         {
-            Stop(/* aResign */ false);
+            IgnoreError(Stop(/* aResign */ false));
         }
         else
         {
@@ -833,12 +833,12 @@ void Commissioner::HandleLeaderKeepAliveResponse(Coap::Message *         aMessag
     uint8_t state;
 
     VerifyOrExit(mState == OT_COMMISSIONER_STATE_ACTIVE, OT_NOOP);
-    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED, Stop(/* aResign */ false));
+    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED, IgnoreError(Stop(/* aResign */ false)));
 
     otLogInfoMeshCoP("received Leader keep-alive response");
 
     SuccessOrExit(Tlv::ReadUint8Tlv(*aMessage, Tlv::kState, state));
-    VerifyOrExit(state == StateTlv::kAccept, Stop(/* aResign */ false));
+    VerifyOrExit(state == StateTlv::kAccept, IgnoreError(Stop(/* aResign */ false)));
 
     mTimer.Start(Time::SecToMsec(kKeepAliveTimeout) / 2);
 
@@ -923,7 +923,7 @@ void Commissioner::HandleRelayReceive(Coap::Message &aMessage, const Ip6::Messag
                      mJoinerIid[2], mJoinerIid[3], mJoinerIid[4], mJoinerIid[5], mJoinerIid[6], mJoinerIid[7],
                      mJoinerRloc);
 
-    aMessage.SetOffset(offset);
+    IgnoreError(aMessage.SetOffset(offset));
     SuccessOrExit(error = aMessage.SetLength(offset + length));
 
     joinerMessageInfo.SetPeerAddr(Get<Mle::MleRouter>().GetMeshLocal64());
@@ -1007,7 +1007,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Message &aRequest, State
 
     SuccessOrExit(error = message->SetDefaultResponseHeader(aRequest));
     SuccessOrExit(error = message->SetPayloadMarker());
-    message->SetOffset(message->GetLength());
+    IgnoreError(message->SetOffset(message->GetLength()));
     message->SetSubType(Message::kSubTypeJoinerFinalizeResponse);
 
     SuccessOrExit(error = Tlv::AppendUint8Tlv(*message, Tlv::kState, static_cast<uint8_t>(aState)));
@@ -1033,7 +1033,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Message &aRequest, State
     if (!mJoiners[mJoinerIndex].mAny)
     {
         // remove after kRemoveJoinerDelay (seconds)
-        RemoveJoiner(&mJoiners[mJoinerIndex].mEui64, kRemoveJoinerDelay);
+        IgnoreError(RemoveJoiner(&mJoiners[mJoinerIndex].mEui64, kRemoveJoinerDelay));
     }
 
     otLogInfoMeshCoP("sent joiner finalize response");

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -135,8 +135,8 @@ void Dataset::ConvertTo(otOperationalDataset &aDataset) const
             break;
 
         case Tlv::kNetworkName:
-            static_cast<Mac::NetworkName &>(aDataset.mNetworkName)
-                .Set(static_cast<const NetworkNameTlv *>(cur)->GetNetworkName());
+            IgnoreError(static_cast<Mac::NetworkName &>(aDataset.mNetworkName)
+                .Set(static_cast<const NetworkNameTlv *>(cur)->GetNetworkName()));
             aDataset.mComponents.mIsNetworkNamePresent = true;
             break;
 
@@ -194,7 +194,7 @@ otError Dataset::SetFrom(const otOperationalDataset &aDataset)
         tlv.Init();
         tlv.SetSeconds(aDataset.mActiveTimestamp);
         tlv.SetTicks(0);
-        SetTlv(tlv);
+        IgnoreError(SetTlv(tlv));
     }
 
     if (aDataset.mComponents.mIsPendingTimestampPresent)
@@ -203,12 +203,12 @@ otError Dataset::SetFrom(const otOperationalDataset &aDataset)
         tlv.Init();
         tlv.SetSeconds(aDataset.mPendingTimestamp);
         tlv.SetTicks(0);
-        SetTlv(tlv);
+        IgnoreError(SetTlv(tlv));
     }
 
     if (aDataset.mComponents.mIsDelayPresent)
     {
-        SetUint32Tlv(Tlv::kDelayTimer, aDataset.mDelay);
+        IgnoreError(SetUint32Tlv(Tlv::kDelayTimer, aDataset.mDelay));
     }
 
     if (aDataset.mComponents.mIsChannelPresent)
@@ -216,7 +216,7 @@ otError Dataset::SetFrom(const otOperationalDataset &aDataset)
         ChannelTlv tlv;
         tlv.Init();
         tlv.SetChannel(aDataset.mChannel);
-        SetTlv(tlv);
+        IgnoreError(SetTlv(tlv));
     }
 
     if (aDataset.mComponents.mIsChannelMaskPresent)
@@ -224,39 +224,39 @@ otError Dataset::SetFrom(const otOperationalDataset &aDataset)
         ChannelMaskTlv tlv;
         tlv.Init();
         tlv.SetChannelMask(aDataset.mChannelMask);
-        SetTlv(tlv);
+        IgnoreError(SetTlv(tlv));
     }
 
     if (aDataset.mComponents.mIsExtendedPanIdPresent)
     {
-        SetTlv(Tlv::kExtendedPanId, &aDataset.mExtendedPanId, sizeof(Mac::ExtendedPanId));
+        IgnoreError(SetTlv(Tlv::kExtendedPanId, &aDataset.mExtendedPanId, sizeof(Mac::ExtendedPanId)));
     }
 
     if (aDataset.mComponents.mIsMeshLocalPrefixPresent)
     {
-        SetTlv(Tlv::kMeshLocalPrefix, &aDataset.mMeshLocalPrefix, sizeof(Mle::MeshLocalPrefix));
+        IgnoreError(SetTlv(Tlv::kMeshLocalPrefix, &aDataset.mMeshLocalPrefix, sizeof(Mle::MeshLocalPrefix)));
     }
 
     if (aDataset.mComponents.mIsMasterKeyPresent)
     {
-        SetTlv(Tlv::kNetworkMasterKey, &aDataset.mMasterKey, sizeof(MasterKey));
+        IgnoreError(SetTlv(Tlv::kNetworkMasterKey, &aDataset.mMasterKey, sizeof(MasterKey)));
     }
 
     if (aDataset.mComponents.mIsNetworkNamePresent)
     {
         Mac::NameData nameData = static_cast<const Mac::NetworkName &>(aDataset.mNetworkName).GetAsData();
 
-        SetTlv(Tlv::kNetworkName, nameData.GetBuffer(), nameData.GetLength());
+        IgnoreError(SetTlv(Tlv::kNetworkName, nameData.GetBuffer(), nameData.GetLength()));
     }
 
     if (aDataset.mComponents.mIsPanIdPresent)
     {
-        SetUint16Tlv(Tlv::kPanId, aDataset.mPanId);
+        IgnoreError(SetUint16Tlv(Tlv::kPanId, aDataset.mPanId));
     }
 
     if (aDataset.mComponents.mIsPskcPresent)
     {
-        SetTlv(Tlv::kPskc, &aDataset.mPskc, sizeof(Pskc));
+        IgnoreError(SetTlv(Tlv::kPskc, &aDataset.mPskc, sizeof(Pskc)));
     }
 
     if (aDataset.mComponents.mIsSecurityPolicyPresent)
@@ -265,7 +265,7 @@ otError Dataset::SetFrom(const otOperationalDataset &aDataset)
         tlv.Init();
         tlv.SetRotationTime(aDataset.mSecurityPolicy.mRotationTime);
         tlv.SetFlags(aDataset.mSecurityPolicy.mFlags);
-        SetTlv(tlv);
+        IgnoreError(SetTlv(tlv));
     }
 
     mUpdateTime = TimerMilli::GetNow();
@@ -296,7 +296,7 @@ exit:
 
 void Dataset::SetTimestamp(const Timestamp &aTimestamp)
 {
-    SetTlv((mType == kActive) ? Tlv::kActiveTimestamp : Tlv::kPendingTimestamp, &aTimestamp, sizeof(Timestamp));
+    IgnoreError(SetTlv((mType == kActive) ? Tlv::kActiveTimestamp : Tlv::kPendingTimestamp, &aTimestamp, sizeof(Timestamp)));
 }
 
 otError Dataset::SetTlv(Tlv::Type aType, const void *aValue, uint8_t aLength)
@@ -473,7 +473,7 @@ otError Dataset::ApplyConfiguration(Instance &aInstance, bool *aIsMasterKeyUpdat
             break;
 
         case Tlv::kNetworkName:
-            mac.SetNetworkName(static_cast<const NetworkNameTlv *>(cur)->GetNetworkName());
+            IgnoreError(mac.SetNetworkName(static_cast<const NetworkNameTlv *>(cur)->GetNetworkName()));
             break;
 
         case Tlv::kNetworkMasterKey:
@@ -485,7 +485,7 @@ otError Dataset::ApplyConfiguration(Instance &aInstance, bool *aIsMasterKeyUpdat
                 *aIsMasterKeyUpdated = true;
             }
 
-            keyManager.SetMasterKey(key->GetNetworkMasterKey());
+            IgnoreError(keyManager.SetMasterKey(key->GetNetworkMasterKey()));
             break;
         }
 
@@ -505,7 +505,7 @@ otError Dataset::ApplyConfiguration(Instance &aInstance, bool *aIsMasterKeyUpdat
         case Tlv::kSecurityPolicy:
         {
             const SecurityPolicyTlv *securityPolicy = static_cast<const SecurityPolicyTlv *>(cur);
-            keyManager.SetKeyRotation(securityPolicy->GetRotationTime());
+            IgnoreError(keyManager.SetKeyRotation(securityPolicy->GetRotationTime()));
             keyManager.SetSecurityPolicyFlags(securityPolicy->GetFlags());
             break;
         }

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -136,7 +136,7 @@ void Dataset::ConvertTo(otOperationalDataset &aDataset) const
 
         case Tlv::kNetworkName:
             IgnoreError(static_cast<Mac::NetworkName &>(aDataset.mNetworkName)
-                .Set(static_cast<const NetworkNameTlv *>(cur)->GetNetworkName()));
+                            .Set(static_cast<const NetworkNameTlv *>(cur)->GetNetworkName()));
             aDataset.mComponents.mIsNetworkNamePresent = true;
             break;
 
@@ -296,7 +296,8 @@ exit:
 
 void Dataset::SetTimestamp(const Timestamp &aTimestamp)
 {
-    IgnoreError(SetTlv((mType == kActive) ? Tlv::kActiveTimestamp : Tlv::kPendingTimestamp, &aTimestamp, sizeof(Timestamp)));
+    IgnoreError(
+        SetTlv((mType == kActive) ? Tlv::kActiveTimestamp : Tlv::kPendingTimestamp, &aTimestamp, sizeof(Timestamp)));
 }
 
 otError Dataset::SetTlv(Tlv::Type aType, const void *aValue, uint8_t aLength)

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -60,7 +60,7 @@ DatasetLocal::DatasetLocal(Instance &aInstance, Dataset::Type aType)
 
 void DatasetLocal::Clear(void)
 {
-    Get<Settings>().DeleteOperationalDataset(IsActive());
+    IgnoreError(Get<Settings>().DeleteOperationalDataset(IsActive()));
     mTimestamp.Init();
     mTimestampPresent = false;
     mSaved            = false;
@@ -165,7 +165,7 @@ otError DatasetLocal::Save(const Dataset &aDataset)
     if (aDataset.GetSize() == 0)
     {
         // do not propagate error back
-        Get<Settings>().DeleteOperationalDataset(IsActive());
+        IgnoreError(Get<Settings>().DeleteOperationalDataset(IsActive()));
         mSaved = false;
         otLogInfoMeshCoP("%s dataset deleted", Dataset::TypeToString(mType));
     }

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -104,7 +104,7 @@ otError DatasetManager::Restore(void)
 
     if (mLocal.GetType() == Dataset::kActive)
     {
-        dataset.ApplyConfiguration(GetInstance());
+        SuccessOrExit(error = dataset.ApplyConfiguration(GetInstance()));
     }
 
 exit:
@@ -133,7 +133,7 @@ void DatasetManager::Clear(void)
 
 void DatasetManager::HandleDetach(void)
 {
-    Restore();
+    IgnoreError(Restore());
 }
 
 otError DatasetManager::Save(const Dataset &aDataset)
@@ -160,7 +160,7 @@ otError DatasetManager::Save(const Dataset &aDataset)
 
     if (isMasterkeyUpdated || compare > 0)
     {
-        mLocal.Save(aDataset);
+        SuccessOrExit(error = mLocal.Save(aDataset));
 
 #if OPENTHREAD_FTD
         Get<NetworkData::Leader>().IncrementVersionAndStableVersion();
@@ -184,7 +184,7 @@ otError DatasetManager::Save(const otOperationalDataset &aDataset)
     switch (Get<Mle::MleRouter>().GetRole())
     {
     case Mle::kRoleDisabled:
-        Restore();
+        IgnoreError(Restore());
         break;
 
     case Mle::kRoleChild:
@@ -196,7 +196,7 @@ otError DatasetManager::Save(const otOperationalDataset &aDataset)
         break;
 
     case Mle::kRoleLeader:
-        Restore();
+        IgnoreError(Restore());
         Get<NetworkData::Leader>().IncrementVersionAndStableVersion();
         break;
 #endif
@@ -239,7 +239,7 @@ void DatasetManager::HandleTimer(void)
     if (mLocal.GetType() == Dataset::kActive)
     {
         Dataset dataset(Dataset::kPending);
-        Get<PendingDataset>().Read(dataset);
+        IgnoreError(Get<PendingDataset>().Read(dataset));
 
         const ActiveTimestampTlv *tlv                    = dataset.GetTlv<ActiveTimestampTlv>();
         const Timestamp *         pendingActiveTimestamp = static_cast<const Timestamp *>(tlv);
@@ -251,7 +251,7 @@ void DatasetManager::HandleTimer(void)
         }
     }
 
-    Register();
+    IgnoreError(Register());
     mTimer.Start(1000);
 
 exit:
@@ -270,11 +270,11 @@ otError DatasetManager::Register(void)
     SuccessOrExit(error = message->Init(OT_COAP_TYPE_CONFIRMABLE, OT_COAP_CODE_POST, mUriSet));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    mLocal.Read(dataset);
+    IgnoreError(mLocal.Read(dataset));
     SuccessOrExit(error = message->Append(dataset.GetBytes(), dataset.GetSize()));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
-    Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr());
+    IgnoreError(Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr()));
     messageInfo.SetPeerPort(kCoapUdpPort);
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, messageInfo));
 
@@ -344,7 +344,7 @@ void DatasetManager::SendGetResponse(const Coap::Message &   aRequest,
     Coap::Message *message;
     Dataset        dataset(mLocal.GetType());
 
-    mLocal.Read(dataset);
+    IgnoreError(mLocal.Read(dataset));
 
     VerifyOrExit((message = NewMeshCoPMessage(Get<Coap::Coap>())) != NULL, error = OT_ERROR_NO_BUFS);
 
@@ -382,7 +382,7 @@ void DatasetManager::SendGetResponse(const Coap::Message &   aRequest,
     if (message->GetLength() == message->GetOffset())
     {
         // no payload, remove coap payload marker
-        message->SetLength(message->GetLength() - 1);
+        IgnoreError(message->SetLength(message->GetLength() - 1));
     }
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, aMessageInfo));
@@ -527,11 +527,11 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
     if (message->GetLength() == message->GetOffset())
     {
         // no payload, remove coap payload marker
-        message->SetLength(message->GetLength() - 1);
+        IgnoreError(message->SetLength(message->GetLength() - 1));
     }
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
-    Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr());
+    IgnoreError(Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr()));
     messageInfo.SetPeerPort(kCoapUdpPort);
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, messageInfo));
 
@@ -653,7 +653,7 @@ otError DatasetManager::SendGetRequest(const otOperationalDatasetComponents &aDa
     }
     else
     {
-        Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr());
+        IgnoreError(Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr()));
     }
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
@@ -683,7 +683,7 @@ ActiveDataset::ActiveDataset(Instance &aInstance)
     , mResourceSet(OT_URI_PATH_ACTIVE_SET, &ActiveDataset::HandleSet, this)
 #endif
 {
-    Get<Coap::Coap>().AddResource(mResourceGet);
+    IgnoreError(Get<Coap::Coap>().AddResource(mResourceGet));
 }
 
 bool ActiveDataset::IsPartiallyComplete(void) const
@@ -698,7 +698,7 @@ otError ActiveDataset::Save(const Timestamp &aTimestamp, const Message &aMessage
 
     SuccessOrExit(error = dataset.Set(aMessage, aOffset, aLength));
     dataset.SetTimestamp(aTimestamp);
-    DatasetManager::Save(dataset);
+    IgnoreError(DatasetManager::Save(dataset));
 
 exit:
     return error;
@@ -732,7 +732,7 @@ PendingDataset::PendingDataset(Instance &aInstance)
     , mResourceSet(OT_URI_PATH_PENDING_SET, &PendingDataset::HandleSet, this)
 #endif
 {
-    Get<Coap::Coap>().AddResource(mResourceGet);
+    IgnoreError(Get<Coap::Coap>().AddResource(mResourceGet));
 }
 
 void PendingDataset::Clear(void)
@@ -747,7 +747,7 @@ void PendingDataset::ClearNetwork(void)
 
     mTimestamp.Init();
     mTimestampValid = false;
-    DatasetManager::Save(dataset);
+    IgnoreError(DatasetManager::Save(dataset));
 }
 
 otError PendingDataset::Save(const otOperationalDataset &aDataset)
@@ -768,7 +768,7 @@ otError PendingDataset::Save(const Timestamp &aTimestamp, const Message &aMessag
 
     SuccessOrExit(error = dataset.Set(aMessage, aOffset, aLength));
     dataset.SetTimestamp(aTimestamp);
-    DatasetManager::Save(dataset);
+    IgnoreError(DatasetManager::Save(dataset));
     StartDelayTimer();
 
 exit:
@@ -780,7 +780,7 @@ void PendingDataset::StartDelayTimer(void)
     DelayTimerTlv *delayTimer;
     Dataset        dataset(mLocal.GetType());
 
-    mLocal.Read(dataset);
+    IgnoreError(mLocal.Read(dataset));
 
     mDelayTimer.Stop();
 
@@ -809,7 +809,7 @@ void PendingDataset::HandleDelayTimer(void)
     DelayTimerTlv *delayTimer;
     Dataset        dataset(mLocal.GetType());
 
-    mLocal.Read(dataset);
+    IgnoreError(mLocal.Read(dataset));
 
     // if the Delay Timer value is larger than what our Timer implementation can handle, we have to compute
     // the remainder and wait some more.

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -104,7 +104,7 @@ otError DatasetManager::Restore(void)
 
     if (mLocal.GetType() == Dataset::kActive)
     {
-        SuccessOrExit(error = dataset.ApplyConfiguration(GetInstance()));
+        IgnoreError(dataset.ApplyConfiguration(GetInstance()));
     }
 
 exit:
@@ -160,7 +160,7 @@ otError DatasetManager::Save(const Dataset &aDataset)
 
     if (isMasterkeyUpdated || compare > 0)
     {
-        SuccessOrExit(error = mLocal.Save(aDataset));
+        IgnoreError(mLocal.Save(aDataset));
 
 #if OPENTHREAD_FTD
         Get<NetworkData::Leader>().IncrementVersionAndStableVersion();

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -361,7 +361,7 @@ public:
      * @param[in]  aDataset  The Operational Dataset.
      *
      */
-    void Save(const Dataset &aDataset) { DatasetManager::Save(aDataset); }
+    void Save(const Dataset &aDataset) { IgnoreError(DatasetManager::Save(aDataset)); }
 
     /**
      * This method sets the Operational Dataset for the partition.

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -428,7 +428,7 @@ otError ActiveDataset::GenerateLocal(void)
     {
         if (Get<KeyManager>().IsPskcSet())
         {
-            dataset.SetTlv(Tlv::kPskc, &Get<KeyManager>().GetPskc(), sizeof(Pskc));
+            IgnoreError(dataset.SetTlv(Tlv::kPskc, &Get<KeyManager>().GetPskc(), sizeof(Pskc)));
         }
         else
         {
@@ -436,7 +436,7 @@ otError ActiveDataset::GenerateLocal(void)
             Pskc pskc;
 
             SuccessOrExit(error = pskc.GenerateRandom());
-            dataset.SetTlv(Tlv::kPskc, &pskc, sizeof(Pskc));
+            IgnoreError(dataset.SetTlv(Tlv::kPskc, &pskc, sizeof(Pskc)));
         }
     }
 
@@ -527,7 +527,7 @@ void PendingDataset::ApplyActiveDataset(const Timestamp &aTimestamp, Coap::Messa
     }
 
     // add delay timer tlv
-    dataset.SetUint32Tlv(Tlv::kDelayTimer, Get<Leader>().GetDelayTimerMinimal());
+    IgnoreError(dataset.SetUint32Tlv(Tlv::kDelayTimer, Get<Leader>().GetDelayTimerMinimal()));
 
     // add pending timestamp tlv
     dataset.SetTimestamp(aTimestamp);

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -397,13 +397,14 @@ otError ActiveDataset::GenerateLocal(void)
 
     if (dataset.GetTlv<ExtendedPanIdTlv>() == NULL)
     {
-        IgnoreError(dataset.SetTlv(Tlv::kExtendedPanId, &Get<Mac::Mac>().GetExtendedPanId(), sizeof(Mac::ExtendedPanId)));
+        IgnoreError(
+            dataset.SetTlv(Tlv::kExtendedPanId, &Get<Mac::Mac>().GetExtendedPanId(), sizeof(Mac::ExtendedPanId)));
     }
 
     if (dataset.GetTlv<MeshLocalPrefixTlv>() == NULL)
     {
         IgnoreError(dataset.SetTlv(Tlv::kMeshLocalPrefix, &Get<Mle::MleRouter>().GetMeshLocalPrefix(),
-                       sizeof(Mle::MeshLocalPrefix)));
+                                   sizeof(Mle::MeshLocalPrefix)));
     }
 
     if (dataset.GetTlv<NetworkMasterKeyTlv>() == NULL)

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -61,7 +61,7 @@ otError DatasetManager::AppendMleDatasetTlv(Message &aMessage) const
 {
     Dataset dataset(mLocal.GetType());
 
-    mLocal.Read(dataset);
+    IgnoreError(mLocal.Read(dataset));
 
     return dataset.AppendMleDatasetTlv(aMessage);
 }
@@ -190,7 +190,7 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
     {
         // Thread specification allows partial dataset changes for MGMT_ACTIVE_SET.req/MGMT_PENDING_SET.req
         // from Commissioner based on existing active dataset.
-        Get<ActiveDataset>().Read(dataset);
+        IgnoreError(Get<ActiveDataset>().Read(dataset));
     }
 
     if (type == Tlv::kPendingTimestamp || !doesAffectConnectivity)
@@ -256,7 +256,7 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
         SuccessOrExit(
             Get<Mle::MleRouter>().GetCommissionerAloc(destination, localSessionId->GetCommissionerSessionId()));
 
-        Get<Leader>().SendDatasetChanged(destination);
+        IgnoreError(Get<Leader>().SendDatasetChanged(destination));
     }
 
 exit:
@@ -368,7 +368,7 @@ otError ActiveDataset::GenerateLocal(void)
     VerifyOrExit(Get<Mle::MleRouter>().IsAttached(), error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(!mLocal.IsTimestampPresent(), error = OT_ERROR_ALREADY);
 
-    mLocal.Read(dataset);
+    IgnoreError(mLocal.Read(dataset));
 
     if (dataset.GetTlv<ActiveTimestampTlv>() == NULL)
     {
@@ -376,7 +376,7 @@ otError ActiveDataset::GenerateLocal(void)
         activeTimestampTlv.Init();
         activeTimestampTlv.SetSeconds(0);
         activeTimestampTlv.SetTicks(0);
-        dataset.SetTlv(activeTimestampTlv);
+        IgnoreError(dataset.SetTlv(activeTimestampTlv));
     }
 
     if (dataset.GetTlv<ChannelTlv>() == NULL)
@@ -384,7 +384,7 @@ otError ActiveDataset::GenerateLocal(void)
         ChannelTlv tlv;
         tlv.Init();
         tlv.SetChannel(Get<Mac::Mac>().GetPanChannel());
-        dataset.SetTlv(tlv);
+        IgnoreError(dataset.SetTlv(tlv));
     }
 
     if (dataset.GetTlv<ChannelMaskTlv>() == NULL)
@@ -392,35 +392,35 @@ otError ActiveDataset::GenerateLocal(void)
         ChannelMaskTlv tlv;
         tlv.Init();
         tlv.SetChannelMask(Get<Mac::Mac>().GetSupportedChannelMask().GetMask());
-        dataset.SetTlv(tlv);
+        IgnoreError(dataset.SetTlv(tlv));
     }
 
     if (dataset.GetTlv<ExtendedPanIdTlv>() == NULL)
     {
-        dataset.SetTlv(Tlv::kExtendedPanId, &Get<Mac::Mac>().GetExtendedPanId(), sizeof(Mac::ExtendedPanId));
+        IgnoreError(dataset.SetTlv(Tlv::kExtendedPanId, &Get<Mac::Mac>().GetExtendedPanId(), sizeof(Mac::ExtendedPanId)));
     }
 
     if (dataset.GetTlv<MeshLocalPrefixTlv>() == NULL)
     {
-        dataset.SetTlv(Tlv::kMeshLocalPrefix, &Get<Mle::MleRouter>().GetMeshLocalPrefix(),
-                       sizeof(Mle::MeshLocalPrefix));
+        IgnoreError(dataset.SetTlv(Tlv::kMeshLocalPrefix, &Get<Mle::MleRouter>().GetMeshLocalPrefix(),
+                       sizeof(Mle::MeshLocalPrefix)));
     }
 
     if (dataset.GetTlv<NetworkMasterKeyTlv>() == NULL)
     {
-        dataset.SetTlv(Tlv::kNetworkMasterKey, &Get<KeyManager>().GetMasterKey(), sizeof(MasterKey));
+        IgnoreError(dataset.SetTlv(Tlv::kNetworkMasterKey, &Get<KeyManager>().GetMasterKey(), sizeof(MasterKey)));
     }
 
     if (dataset.GetTlv<NetworkNameTlv>() == NULL)
     {
         Mac::NameData nameData = Get<Mac::Mac>().GetNetworkName().GetAsData();
 
-        dataset.SetTlv(Tlv::kNetworkName, nameData.GetBuffer(), nameData.GetLength());
+        IgnoreError(dataset.SetTlv(Tlv::kNetworkName, nameData.GetBuffer(), nameData.GetLength()));
     }
 
     if (dataset.GetTlv<PanIdTlv>() == NULL)
     {
-        dataset.SetUint16Tlv(Tlv::kPanId, Get<Mac::Mac>().GetPanId());
+        IgnoreError(dataset.SetUint16Tlv(Tlv::kPanId, Get<Mac::Mac>().GetPanId()));
     }
 
     if (dataset.GetTlv<PskcTlv>() == NULL)
@@ -445,11 +445,11 @@ otError ActiveDataset::GenerateLocal(void)
         tlv.Init();
         tlv.SetRotationTime(static_cast<uint16_t>(Get<KeyManager>().GetKeyRotation()));
         tlv.SetFlags(Get<KeyManager>().GetSecurityPolicyFlags());
-        dataset.SetTlv(tlv);
+        IgnoreError(dataset.SetTlv(tlv));
     }
 
     SuccessOrExit(error = mLocal.Save(dataset));
-    Restore();
+    IgnoreError(Restore());
 
     otLogInfoMeshCoP("Generated local dataset");
 
@@ -459,8 +459,8 @@ exit:
 
 void ActiveDataset::StartLeader(void)
 {
-    GenerateLocal();
-    Get<Coap::Coap>().AddResource(mResourceSet);
+    IgnoreError(GenerateLocal());
+    IgnoreError(Get<Coap::Coap>().AddResource(mResourceSet));
 }
 
 void ActiveDataset::StopLeader(void)
@@ -477,7 +477,7 @@ void ActiveDataset::HandleSet(void *aContext, otMessage *aMessage, const otMessa
 void ActiveDataset::HandleSet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     SuccessOrExit(DatasetManager::HandleSet(aMessage, aMessageInfo));
-    ApplyConfiguration();
+    IgnoreError(ApplyConfiguration());
 
 exit:
     return;
@@ -486,7 +486,7 @@ exit:
 void PendingDataset::StartLeader(void)
 {
     StartDelayTimer();
-    Get<Coap::Coap>().AddResource(mResourceSet);
+    IgnoreError(Get<Coap::Coap>().AddResource(mResourceSet));
 }
 
 void PendingDataset::StopLeader(void)
@@ -522,7 +522,7 @@ void PendingDataset::ApplyActiveDataset(const Timestamp &aTimestamp, Coap::Messa
 
         SuccessOrExit(datasetTlv.ReadFromMessage(aMessage, offset));
         offset += static_cast<uint16_t>(datasetTlv.GetSize());
-        dataset.SetTlv(datasetTlv);
+        IgnoreError(dataset.SetTlv(datasetTlv));
     }
 
     // add delay timer tlv
@@ -530,7 +530,7 @@ void PendingDataset::ApplyActiveDataset(const Timestamp &aTimestamp, Coap::Messa
 
     // add pending timestamp tlv
     dataset.SetTimestamp(aTimestamp);
-    DatasetManager::Save(dataset);
+    IgnoreError(DatasetManager::Save(dataset));
 
     // reset delay timer
     StartDelayTimer();

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -174,7 +174,7 @@ void Dtls::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageI
 
         sockAddr.mAddress = aMessageInfo.GetPeerAddr();
         sockAddr.mPort    = aMessageInfo.GetPeerPort();
-        mSocket.Connect(sockAddr);
+        IgnoreError(mSocket.Connect(sockAddr));
 
         mPeerAddress.SetPeerAddr(aMessageInfo.GetPeerAddr());
         mPeerAddress.SetPeerPort(aMessageInfo.GetPeerPort());
@@ -202,7 +202,7 @@ void Dtls::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageI
 #ifdef MBEDTLS_SSL_SRV_C
     if (mState == MeshCoP::Dtls::kStateConnecting)
     {
-        SetClientId(mPeerAddress.GetPeerAddr().mFields.m8, sizeof(mPeerAddress.GetPeerAddr().mFields));
+        IgnoreError(SetClientId(mPeerAddress.GetPeerAddr().mFields.m8, sizeof(mPeerAddress.GetPeerAddr().mFields)));
     }
 #endif
 
@@ -414,7 +414,7 @@ void Dtls::Close(void)
     mTransportContext  = NULL;
     mTimerSet          = false;
 
-    mSocket.Close();
+    IgnoreError(mSocket.Close());
     mTimer.Stop();
 }
 
@@ -427,7 +427,7 @@ void Dtls::Disconnect(void)
     mTimer.Start(kGuardTimeNewConnectionMilli);
 
     new (&mPeerAddress) Ip6::MessageInfo();
-    mSocket.Connect(Ip6::SockAddr());
+    IgnoreError(mSocket.Connect(Ip6::SockAddr()));
 
     FreeMbedtls();
 
@@ -636,7 +636,7 @@ int Dtls::HandleMbedtlsReceive(unsigned char *aBuf, size_t aLength)
     }
 
     rval = mReceiveMessage->Read(mReceiveMessage->GetOffset(), static_cast<uint16_t>(aLength), aBuf);
-    mReceiveMessage->MoveOffset(rval);
+    IgnoreError(mReceiveMessage->MoveOffset(rval));
 
 exit:
     return rval;

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -55,7 +55,7 @@ EnergyScanClient::EnergyScanClient(Instance &aInstance)
 {
     mContext  = NULL;
     mCallback = NULL;
-    Get<Coap::Coap>().AddResource(mEnergyScan);
+    IgnoreError(Get<Coap::Coap>().AddResource(mEnergyScan));
 }
 
 otError EnergyScanClient::SendQuery(uint32_t                           aChannelMask,

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -65,7 +65,7 @@ Joiner::Joiner(Instance &aInstance)
     , mJoinerEntrust(OT_URI_PATH_JOINER_ENTRUST, &Joiner::HandleJoinerEntrust, this)
 {
     memset(mJoinerRouters, 0, sizeof(mJoinerRouters));
-    Get<Coap::Coap>().AddResource(mJoinerEntrust);
+    IgnoreError(Get<Coap::Coap>().AddResource(mJoinerEntrust));
 }
 
 void Joiner::GetJoinerId(Mac::ExtAddress &aJoinerId) const
@@ -158,7 +158,7 @@ void Joiner::Finish(otError aError)
     case OT_JOINER_STATE_ENTRUST:
     case OT_JOINER_STATE_JOINED:
         Get<Coap::CoapSecure>().Disconnect();
-        Get<Ip6::Filter>().RemoveUnsecurePort(kJoinerUdpPort);
+        IgnoreError(Get<Ip6::Filter>().RemoveUnsecurePort(kJoinerUdpPort));
         mTimer.Stop();
 
         // Fall through
@@ -405,7 +405,7 @@ otError Joiner::PrepareJoinerFinalizeMessage(const char *aProvisioningUrl,
     mFinalizeMessage->Init(OT_COAP_TYPE_CONFIRMABLE, OT_COAP_CODE_POST);
     SuccessOrExit(error = mFinalizeMessage->AppendUriPathOptions(OT_URI_PATH_JOINER_FINALIZE));
     SuccessOrExit(error = mFinalizeMessage->SetPayloadMarker());
-    mFinalizeMessage->SetOffset(mFinalizeMessage->GetLength());
+    IgnoreError(mFinalizeMessage->SetOffset(mFinalizeMessage->GetLength()));
 
     SuccessOrExit(error = Tlv::AppendUint8Tlv(*mFinalizeMessage, Tlv::kState, StateTlv::kAccept));
 
@@ -515,7 +515,7 @@ void Joiner::HandleJoinerFinalizeResponse(Coap::Message &         aMessage,
 
 exit:
     Get<Coap::CoapSecure>().Disconnect();
-    Get<Ip6::Filter>().RemoveUnsecurePort(kJoinerUdpPort);
+    IgnoreError(Get<Ip6::Filter>().RemoveUnsecurePort(kJoinerUdpPort));
 }
 
 void Joiner::HandleJoinerEntrust(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
@@ -547,7 +547,7 @@ void Joiner::HandleJoinerEntrust(Coap::Message &aMessage, const Ip6::MessageInfo
     dataset.mPanId                      = Get<Mac::Mac>().GetPanId();
     dataset.mComponents.mIsPanIdPresent = true;
 
-    Get<MeshCoP::ActiveDataset>().Save(dataset);
+    IgnoreError(Get<MeshCoP::ActiveDataset>().Save(dataset));
 
     otLogInfoMeshCoP("Joiner successful!");
 

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -60,8 +60,8 @@ Leader::Leader(Instance &aInstance)
     , mDelayTimerMinimal(DelayTimerTlv::kDelayTimerMinimal)
     , mSessionId(Random::NonCrypto::GetUint16())
 {
-    Get<Coap::Coap>().AddResource(mPetition);
-    Get<Coap::Coap>().AddResource(mKeepAlive);
+    IgnoreError(Get<Coap::Coap>().AddResource(mPetition));
+    IgnoreError(Get<Coap::Coap>().AddResource(mKeepAlive));
 }
 
 void Leader::HandlePetition(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
@@ -117,7 +117,7 @@ void Leader::HandlePetition(Coap::Message &aMessage, const Ip6::MessageInfo &aMe
     mTimer.Start(Time::SecToMsec(kTimeoutLeaderPetition));
 
 exit:
-    SendPetitionResponse(aMessage, aMessageInfo, state);
+    IgnoreError(SendPetitionResponse(aMessage, aMessageInfo, state));
 }
 
 otError Leader::SendPetitionResponse(const Coap::Message &   aRequest,
@@ -203,7 +203,7 @@ void Leader::HandleKeepAlive(Coap::Message &aMessage, const Ip6::MessageInfo &aM
         mTimer.Start(Time::SecToMsec(kTimeoutLeaderPetition));
     }
 
-    SendKeepAliveResponse(aMessage, aMessageInfo, responseState);
+    IgnoreError(SendKeepAliveResponse(aMessage, aMessageInfo, responseState));
 
 exit:
     return;
@@ -302,8 +302,8 @@ void Leader::SetEmptyCommissionerData(void)
     mCommissionerSessionId.Init();
     mCommissionerSessionId.SetCommissionerSessionId(++mSessionId);
 
-    Get<NetworkData::Leader>().SetCommissioningData(reinterpret_cast<uint8_t *>(&mCommissionerSessionId),
-                                                    sizeof(Tlv) + mCommissionerSessionId.GetLength());
+    IgnoreError(Get<NetworkData::Leader>().SetCommissioningData(reinterpret_cast<uint8_t *>(&mCommissionerSessionId),
+                                                                sizeof(Tlv) + mCommissionerSessionId.GetLength()));
 }
 
 void Leader::ResignCommissioner(void)

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -54,7 +54,7 @@ PanIdQueryClient::PanIdQueryClient(Instance &aInstance)
     , mContext(NULL)
     , mPanIdQuery(OT_URI_PATH_PANID_CONFLICT, &PanIdQueryClient::HandleConflict, this)
 {
-    Get<Coap::Coap>().AddResource(mPanIdQuery);
+    IgnoreError(Get<Coap::Coap>().AddResource(mPanIdQuery));
 }
 
 otError PanIdQueryClient::SendQuery(uint16_t                            aPanId,

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -202,7 +202,7 @@ bool Dhcp6Client::ProcessNextIdentityAssociation()
         }
 
         // new transaction id
-        Random::Crypto::FillBuffer(mTransactionId, kTransactionIdSize);
+        IgnoreError(Random::Crypto::FillBuffer(mTransactionId, kTransactionIdSize));
 
         mIdentityAssociationCurrent = &mIdentityAssociations[i];
 

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -489,9 +489,9 @@ void Dhcp6Server::ApplyMeshLocalPrefix(void)
         if (mPrefixAgents[i].IsValid())
         {
             PrefixAgent *entry = &mPrefixAgents[i];
-            Get<ThreadNetif>().RemoveUnicastAddress(entry->GetAloc());
+            IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(entry->GetAloc()));
             entry->GetAloc().GetAddress().SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-            Get<ThreadNetif>().AddUnicastAddress(entry->GetAloc());
+            IgnoreError(Get<ThreadNetif>().AddUnicastAddress(entry->GetAloc()));
         }
     }
 }

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -114,7 +114,7 @@ otError Dhcp6Server::UpdateService(void)
 
         if (error == OT_ERROR_NONE)
         {
-            AddPrefixAgent(config.mPrefix, lowpanContext);
+            IgnoreError(AddPrefixAgent(config.mPrefix, lowpanContext));
         }
     }
 
@@ -135,13 +135,13 @@ void Dhcp6Server::Start(void)
     Ip6::SockAddr sockaddr;
 
     sockaddr.mPort = kDhcpServerPort;
-    mSocket.Open(&Dhcp6Server::HandleUdpReceive, this);
-    mSocket.Bind(sockaddr);
+    IgnoreError(mSocket.Open(&Dhcp6Server::HandleUdpReceive, this));
+    IgnoreError(mSocket.Bind(sockaddr));
 }
 
 void Dhcp6Server::Stop(void)
 {
-    mSocket.Close();
+    IgnoreError(mSocket.Close());
 }
 
 otError Dhcp6Server::AddPrefixAgent(const otIp6Prefix &aIp6Prefix, const Lowpan::Context &aContext)
@@ -165,7 +165,7 @@ otError Dhcp6Server::AddPrefixAgent(const otIp6Prefix &aIp6Prefix, const Lowpan:
     VerifyOrExit(newEntry != NULL, error = OT_ERROR_NO_BUFS);
 
     newEntry->Set(aIp6Prefix, Get<Mle::MleRouter>().GetMeshLocalPrefix(), aContext.mContextId);
-    Get<ThreadNetif>().AddUnicastAddress(newEntry->GetAloc());
+    IgnoreError(Get<ThreadNetif>().AddUnicastAddress(newEntry->GetAloc()));
     mPrefixAgentsCount++;
 
 exit:
@@ -184,7 +184,7 @@ void Dhcp6Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aM
     otIp6Address dst = aMessageInfo.mPeerAddr;
 
     VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(header), &header) == sizeof(header), OT_NOOP);
-    aMessage.MoveOffset(sizeof(header));
+    IgnoreError(aMessage.MoveOffset(sizeof(header)));
 
     // discard if not solicit type
     VerifyOrExit((header.GetType() == kTypeSolicit), OT_NOOP);

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -172,8 +172,8 @@ Message *Client::NewMessage(const Header &aHeader)
     Message *message = NULL;
 
     VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != NULL, OT_NOOP);
-    message->Prepend(&aHeader, sizeof(aHeader));
-    message->SetOffset(0);
+    IgnoreError(message->Prepend(&aHeader, sizeof(aHeader)));
+    IgnoreError(message->SetOffset(0));
 
 exit:
     return message;
@@ -189,7 +189,7 @@ Message *Client::CopyAndEnqueueMessage(const Message &aMessage, const QueryMetad
 
     // Append the copy with retransmission data and add it to the queue.
     SuccessOrExit(error = aQueryMetadata.AppendTo(*messageCopy));
-    mPendingQueries.Enqueue(*messageCopy);
+    IgnoreError(mPendingQueries.Enqueue(*messageCopy));
 
     mRetransmissionTimer.FireAtIfEarlier(aQueryMetadata.mTransmissionTime);
 
@@ -206,7 +206,7 @@ exit:
 
 void Client::DequeueMessage(Message &aMessage)
 {
-    mPendingQueries.Dequeue(aMessage);
+    IgnoreError(mPendingQueries.Dequeue(aMessage));
 
     if (mRetransmissionTimer.IsRunning() && (mPendingQueries.GetHead() == NULL))
     {
@@ -435,7 +435,7 @@ void Client::HandleRetransmissionTimer(void)
             messageInfo.SetPeerPort(queryMetadata.mDestinationPort);
             messageInfo.SetSockAddr(queryMetadata.mSourceAddress);
 
-            SendCopy(*message, messageInfo);
+            IgnoreError(SendCopy(*message, messageInfo));
         }
 
         if (nextTime > queryMetadata.mTransmissionTime)
@@ -475,7 +475,7 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
                      !responseHeader.IsTruncationFlagSet(),
                  OT_NOOP);
 
-    aMessage.MoveOffset(sizeof(responseHeader));
+    IgnoreError(aMessage.MoveOffset(sizeof(responseHeader)));
     offset = aMessage.GetOffset();
 
     VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != NULL, OT_NOOP);

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -78,7 +78,7 @@ otError Icmp::SendEchoRequest(Message &aMessage, const MessageInfo &aMessageInfo
     icmpHeader.SetSequence(mEchoSequence++);
 
     SuccessOrExit(error = aMessage.Prepend(&icmpHeader, sizeof(icmpHeader)));
-    aMessage.SetOffset(0);
+    IgnoreError(aMessage.SetOffset(0));
     SuccessOrExit(error = Get<Ip6>().SendDatagram(aMessage, messageInfoLocal, kProtoIcmp6));
 
     otLogInfoIcmp("Sent echo request: (seq = %d)", icmpHeader.GetSequence());
@@ -158,7 +158,7 @@ otError Icmp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
         SuccessOrExit(error = HandleEchoRequest(aMessage, aMessageInfo));
     }
 
-    aMessage.MoveOffset(sizeof(icmp6Header));
+    IgnoreError(aMessage.MoveOffset(sizeof(icmp6Header)));
 
     for (IcmpHandler *handler = mHandlers.GetHead(); handler; handler = handler->GetNext())
     {

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -326,7 +326,7 @@ void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSeque
     metadata.GenerateNextTransmissionTime(TimerMilli::GetNow(), interval);
 
     SuccessOrExit(error = metadata.AppendTo(*messageCopy));
-    mBufferedMessageSet.Enqueue(*messageCopy);
+    IgnoreError(mBufferedMessageSet.Enqueue(*messageCopy));
 
     mRetransmissionTimer.FireAtIfEarlier(metadata.mTransmissionTime);
 
@@ -393,7 +393,7 @@ void Mpl::HandleRetransmissionTimer(void)
             }
             else
             {
-                mBufferedMessageSet.Dequeue(*message);
+                IgnoreError(mBufferedMessageSet.Dequeue(*message));
 
                 if (metadata.mTransmissionCount == GetTimerExpirations())
                 {

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -428,7 +428,7 @@ void Netif::UnsubscribeAllExternalMulticastAddresses(void)
     {
         if (entry->IsInUse())
         {
-            UnsubscribeExternalMulticast(entry->GetAddress());
+            IgnoreError(UnsubscribeExternalMulticast(entry->GetAddress()));
         }
     }
 }
@@ -543,7 +543,7 @@ void Netif::RemoveAllExternalUnicastAddresses(void)
     {
         if (entry->IsInUse())
         {
-            RemoveExternalUnicastAddress(entry->GetAddress());
+            IgnoreError(RemoveExternalUnicastAddress(entry->GetAddress()));
         }
     }
 }

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -178,8 +178,8 @@ Message *Client::NewMessage(const Header &aHeader)
     Message *message = NULL;
 
     VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != NULL, OT_NOOP);
-    message->Prepend(&aHeader, sizeof(aHeader));
-    message->SetOffset(0);
+    IgnoreError(message->Prepend(&aHeader, sizeof(aHeader)));
+    IgnoreError(message->SetOffset(0));
 
 exit:
     return message;
@@ -195,7 +195,7 @@ Message *Client::CopyAndEnqueueMessage(const Message &aMessage, const QueryMetad
 
     // Append the copy with retransmission data and add it to the queue.
     SuccessOrExit(error = aQueryMetadata.AppendTo(*messageCopy));
-    mPendingQueries.Enqueue(*messageCopy);
+    IgnoreError(mPendingQueries.Enqueue(*messageCopy));
 
     mRetransmissionTimer.FireAtIfEarlier(aQueryMetadata.mTransmissionTime);
 
@@ -212,7 +212,7 @@ exit:
 
 void Client::DequeueMessage(Message &aMessage)
 {
-    mPendingQueries.Dequeue(aMessage);
+    IgnoreError(mPendingQueries.Dequeue(aMessage));
 
     if (mRetransmissionTimer.IsRunning() && (mPendingQueries.GetHead() == NULL))
     {
@@ -325,7 +325,7 @@ void Client::HandleRetransmissionTimer(void)
             messageInfo.SetPeerPort(queryMetadata.mDestinationPort);
             messageInfo.SetSockAddr(queryMetadata.mSourceAddress);
 
-            SendCopy(*message, messageInfo);
+            IgnoreError(SendCopy(*message, messageInfo));
         }
 
         if (nextTime > queryMetadata.mTransmissionTime)

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -232,7 +232,7 @@ exit:
 
 void Udp::AddSocket(UdpSocket &aSocket)
 {
-    mSockets.Add(aSocket);
+    IgnoreError(mSockets.Add(aSocket));
 }
 
 void Udp::RemoveSocket(UdpSocket &aSocket)
@@ -288,7 +288,7 @@ otError Udp::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t 
         udpHeader.SetChecksum(0);
 
         SuccessOrExit(error = aMessage.Prepend(&udpHeader, sizeof(udpHeader)));
-        aMessage.SetOffset(0);
+        IgnoreError(aMessage.SetOffset(0));
 
         error = Get<Ip6>().SendDatagram(aMessage, aMessageInfo, aIpProto);
     }
@@ -320,7 +320,7 @@ otError Udp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
 
     VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(udpHeader), &udpHeader) == sizeof(udpHeader),
                  error = OT_ERROR_PARSE);
-    aMessage.MoveOffset(sizeof(udpHeader));
+    IgnoreError(aMessage.MoveOffset(sizeof(udpHeader)));
     aMessageInfo.mPeerPort = udpHeader.GetSourcePort();
     aMessageInfo.mSockPort = udpHeader.GetDestinationPort();
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -71,11 +71,11 @@ AddressResolver::AddressResolver(Instance &aInstance)
         mUnusedList.Push(*entry);
     }
 
-    Get<Coap::Coap>().AddResource(mAddressError);
-    Get<Coap::Coap>().AddResource(mAddressQuery);
-    Get<Coap::Coap>().AddResource(mAddressNotification);
+    IgnoreError(Get<Coap::Coap>().AddResource(mAddressError));
+    IgnoreError(Get<Coap::Coap>().AddResource(mAddressQuery));
+    IgnoreError(Get<Coap::Coap>().AddResource(mAddressNotification));
 
-    Get<Ip6::Icmp>().RegisterHandler(mIcmpHandler);
+    IgnoreError(Get<Ip6::Icmp>().RegisterHandler(mIcmpHandler));
 }
 
 void AddressResolver::Clear(void)
@@ -465,7 +465,7 @@ void AddressResolver::RestartAddressQueries(void)
 
     for (CacheEntry *entry = mQueryList.GetHead(); entry != NULL; entry = entry->GetNext())
     {
-        SendAddressQuery(entry->GetTarget());
+        IgnoreError(SendAddressQuery(entry->GetTarget()));
 
         entry->SetTimeout(kAddressQueryTimeout);
         entry->SetRetryDelay(kAddressQueryInitialRetryDelay);
@@ -634,7 +634,8 @@ void AddressResolver::HandleAddressNotification(Coap::Message &aMessage, const I
             // by more than one device. Try to resolve the duplicate
             // address by sending an Address Error message.
 
-            VerifyOrExit(entry->HasMeshLocalIid(meshLocalIid), SendAddressError(target, meshLocalIid, NULL));
+            VerifyOrExit(entry->HasMeshLocalIid(meshLocalIid),
+                         IgnoreError(SendAddressError(target, meshLocalIid, NULL)));
 
             VerifyOrExit(lastTransactionTime < entry->GetLastTransactionTime(), OT_NOOP);
         }
@@ -740,7 +741,7 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
             memcmp(Get<Mle::MleRouter>().GetMeshLocal64().GetIid(), meshLocalIid, sizeof(meshLocalIid)))
         {
             // Target EID matches address and Mesh Local EID differs
-            Get<ThreadNetif>().RemoveUnicastAddress(*address);
+            IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(*address));
             ExitNow();
         }
     }
@@ -766,7 +767,7 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
             {
                 SuccessOrExit(error = Get<Mle::Mle>().GetLocatorAddress(destination, child.GetRloc16()));
 
-                SendAddressError(target, meshLocalIid, &destination);
+                IgnoreError(SendAddressError(target, meshLocalIid, &destination));
                 ExitNow();
             }
         }

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -51,7 +51,7 @@ AnnounceBeginServer::AnnounceBeginServer(Instance &aInstance)
     : AnnounceSenderBase(aInstance, &AnnounceBeginServer::HandleTimer)
     , mAnnounceBegin(OT_URI_PATH_ANNOUNCE_BEGIN, &AnnounceBeginServer::HandleRequest, this)
 {
-    Get<Coap::Coap>().AddResource(mAnnounceBegin);
+    IgnoreError(Get<Coap::Coap>().AddResource(mAnnounceBegin));
 }
 
 otError AnnounceBeginServer::SendAnnounce(uint32_t aChannelMask)
@@ -83,7 +83,7 @@ void AnnounceBeginServer::HandleRequest(Coap::Message &aMessage, const Ip6::Mess
     SuccessOrExit(Tlv::ReadUint8Tlv(aMessage, MeshCoP::Tlv::kCount, count));
     SuccessOrExit(Tlv::ReadUint16Tlv(aMessage, MeshCoP::Tlv::kPeriod, period));
 
-    SendAnnounce(mask, count, period);
+    IgnoreError(SendAnnounce(mask, count, period));
 
     if (aMessage.IsConfirmable() && !aMessageInfo.GetSockAddr().IsMulticast())
     {

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -102,7 +102,7 @@ void AnnounceSenderBase::HandleTimer(void)
 
     OT_ASSERT(error == OT_ERROR_NONE);
 
-    Get<Mle::MleRouter>().SendAnnounce(mChannel, false);
+    IgnoreError(Get<Mle::MleRouter>().SendAnnounce(mChannel, false));
 
     mTimer.Start(Random::NonCrypto::AddJitter(mPeriod, mJitter));
 
@@ -165,7 +165,7 @@ void AnnounceSender::CheckState(void)
 
     VerifyOrExit(!IsRunning() || (period != GetPeriod()) || (GetChannelMask() != channelMask), OT_NOOP);
 
-    SendAnnounce(channelMask, 0, period, kMaxJitter);
+    IgnoreError(SendAnnounce(channelMask, 0, period, kMaxJitter));
 
     otLogInfoMle("Starting periodic MLE Announcements tx, period %u, mask %s", period,
                  channelMask.ToString().AsCString());

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -59,7 +59,7 @@ EnergyScanServer::EnergyScanServer(Instance &aInstance)
     , mNotifierCallback(aInstance, &EnergyScanServer::HandleStateChanged, this)
     , mEnergyScan(OT_URI_PATH_ENERGY_SCAN, &EnergyScanServer::HandleRequest, this)
 {
-    Get<Coap::Coap>().AddResource(mEnergyScan);
+    IgnoreError(Get<Coap::Coap>().AddResource(mEnergyScan));
 }
 
 void EnergyScanServer::HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
@@ -118,11 +118,11 @@ void EnergyScanServer::HandleTimer(void)
     {
         // grab the lowest channel to scan
         uint32_t channelMask = mChannelMaskCurrent & ~(mChannelMaskCurrent - 1);
-        Get<Mac::Mac>().EnergyScan(channelMask, mScanDuration, HandleScanResult, this);
+        IgnoreError(Get<Mac::Mac>().EnergyScan(channelMask, mScanDuration, HandleScanResult, this));
     }
     else
     {
-        SendReport();
+        IgnoreError(SendReport());
     }
 
 exit:

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -139,7 +139,7 @@ void IndirectSender::ClearAllMessagesForSleepyChild(Child &aChild)
                 Get<MeshForwarder>().mSendMessage = NULL;
             }
 
-            Get<MeshForwarder>().mSendQueue.Dequeue(*message);
+            IgnoreError(Get<MeshForwarder>().mSendQueue.Dequeue(*message));
             message->Free();
         }
     }
@@ -219,7 +219,7 @@ Message *IndirectSender::FindIndirectMessage(Child &aChild)
             {
                 message->ClearChildMask(childIndex);
                 mSourceMatchController.DecrementMessageCount(aChild);
-                Get<MeshForwarder>().mSendQueue.Dequeue(*message);
+                IgnoreError(Get<MeshForwarder>().mSendQueue.Dequeue(*message));
                 message->Free();
                 continue;
             }
@@ -377,11 +377,11 @@ uint16_t IndirectSender::PrepareDataFrame(Mac::TxFrame &aFrame, Child &aChild, M
     // Prepare the data frame from previous child's indirect offset.
 
     directTxOffset = aMessage.GetOffset();
-    aMessage.SetOffset(aChild.GetIndirectFragmentOffset());
+    IgnoreError(aMessage.SetOffset(aChild.GetIndirectFragmentOffset()));
 
     nextOffset = Get<MeshForwarder>().PrepareDataFrame(aFrame, aMessage, macSource, macDest);
 
-    aMessage.SetOffset(directTxOffset);
+    IgnoreError(aMessage.SetOffset(directTxOffset));
 
     // Set `FramePending` if there are more queued messages (excluding
     // the current one being sent out) for the child (note `> 1` check).
@@ -424,7 +424,7 @@ void IndirectSender::PrepareEmptyFrame(Mac::TxFrame &aFrame, Child &aChild, bool
     aFrame.InitMacHeader(fcf, Mac::Frame::kKeyIdMode1 | Mac::Frame::kSecEncMic32);
 
     aFrame.SetDstPanId(Get<Mac::Mac>().GetPanId());
-    aFrame.SetSrcPanId(Get<Mac::Mac>().GetPanId());
+    IgnoreError(aFrame.SetSrcPanId(Get<Mac::Mac>().GetPanId()));
     aFrame.SetDstAddr(macDest);
     aFrame.SetSrcAddr(macSource);
     aFrame.SetPayloadLength(0);
@@ -517,7 +517,7 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
 
         if (!aFrame.IsEmpty())
         {
-            aFrame.GetDstAddr(macDest);
+            IgnoreError(aFrame.GetDstAddr(macDest));
             Get<MeshForwarder>().LogMessage(MeshForwarder::kMessageTransmit, *message, &macDest, txError);
         }
 
@@ -541,7 +541,7 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
 
         if (!message->GetDirectTransmission() && !message->IsChildPending())
         {
-            Get<MeshForwarder>().mSendQueue.Dequeue(*message);
+            IgnoreError(Get<MeshForwarder>().mSendQueue.Dequeue(*message));
             message->Free();
         }
     }

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -102,7 +102,7 @@ void KeyManager::Stop(void)
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
 void KeyManager::SetPskc(const Pskc &aPskc)
 {
-    Get<Notifier>().Update(mPskc, aPskc, OT_CHANGED_PSKC);
+    IgnoreError(Get<Notifier>().Update(mPskc, aPskc, OT_CHANGED_PSKC));
     mIsPskcSet = true;
 }
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
@@ -206,7 +206,7 @@ void KeyManager::IncrementMacFrameCounter(void)
 
     if (mMacFrameCounter >= mStoredMacFrameCounter)
     {
-        Get<Mle::MleRouter>().Store();
+        IgnoreError(Get<Mle::MleRouter>().Store());
     }
 }
 
@@ -216,7 +216,7 @@ void KeyManager::IncrementMleFrameCounter(void)
 
     if (mMleFrameCounter >= mStoredMleFrameCounter)
     {
-        Get<Mle::MleRouter>().Store();
+        IgnoreError(Get<Mle::MleRouter>().Store());
     }
 }
 
@@ -246,7 +246,7 @@ exit:
 
 void KeyManager::SetSecurityPolicyFlags(uint8_t aSecurityPolicyFlags)
 {
-    Get<Notifier>().Update(mSecurityPolicyFlags, aSecurityPolicyFlags, OT_CHANGED_SECURITY_POLICY);
+    IgnoreError(Get<Notifier>().Update(mSecurityPolicyFlags, aSecurityPolicyFlags, OT_CHANGED_SECURITY_POLICY));
 }
 
 void KeyManager::StartKeyRotationTimer(void)

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -134,7 +134,7 @@ RssAverager::InfoString RssAverager::ToString(void) const
     InfoString string;
 
     VerifyOrExit(mCount != 0, OT_NOOP);
-    string.Set("%d.%s", -(mAverage >> kPrecisionBitShift), kDigitsString[mAverage & kPrecisionBitMask]);
+    IgnoreError(string.Set("%d.%s", -(mAverage >> kPrecisionBitShift), kDigitsString[mAverage & kPrecisionBitMask]));
 
 exit:
     return string;

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -102,7 +102,7 @@ otError Lowpan::CompressSourceIid(const Mac::Address &aMacAddr,
     Ip6::Address ipaddr;
     Mac::Address tmp;
 
-    ComputeIid(aMacAddr, aContext, ipaddr);
+    IgnoreError(ComputeIid(aMacAddr, aContext, ipaddr));
 
     if (memcmp(ipaddr.GetIid(), aIpAddr.GetIid(), Ip6::Address::kInterfaceIdentifierSize) == 0)
     {
@@ -111,7 +111,7 @@ otError Lowpan::CompressSourceIid(const Mac::Address &aMacAddr,
     else
     {
         tmp.SetShort(aIpAddr.GetLocator());
-        ComputeIid(tmp, aContext, ipaddr);
+        IgnoreError(ComputeIid(tmp, aContext, ipaddr));
 
         if (memcmp(ipaddr.GetIid(), aIpAddr.GetIid(), Ip6::Address::kInterfaceIdentifierSize) == 0)
         {
@@ -145,7 +145,7 @@ otError Lowpan::CompressDestinationIid(const Mac::Address &aMacAddr,
     Ip6::Address ipaddr;
     Mac::Address tmp;
 
-    ComputeIid(aMacAddr, aContext, ipaddr);
+    IgnoreError(ComputeIid(aMacAddr, aContext, ipaddr));
 
     if (memcmp(ipaddr.GetIid(), aIpAddr.GetIid(), Ip6::Address::kInterfaceIdentifierSize) == 0)
     {
@@ -154,7 +154,7 @@ otError Lowpan::CompressDestinationIid(const Mac::Address &aMacAddr,
     else
     {
         tmp.SetShort(aIpAddr.GetLocator());
-        ComputeIid(tmp, aContext, ipaddr);
+        IgnoreError(ComputeIid(tmp, aContext, ipaddr));
 
         if (memcmp(ipaddr.GetIid(), aIpAddr.GetIid(), Ip6::Address::kInterfaceIdentifierSize) == 0)
         {
@@ -284,7 +284,7 @@ otError Lowpan::Compress(Message &           aMessage,
 
     if (!srcContextValid)
     {
-        networkData.GetContext(0, srcContext);
+        IgnoreError(networkData.GetContext(0, srcContext));
     }
 
     dstContextValid =
@@ -292,7 +292,7 @@ otError Lowpan::Compress(Message &           aMessage,
 
     if (!dstContextValid)
     {
-        networkData.GetContext(0, dstContext);
+        IgnoreError(networkData.GetContext(0, dstContext));
     }
 
     // Lowpan HC Control Bits
@@ -418,7 +418,7 @@ otError Lowpan::Compress(Message &           aMessage,
 
     headerDepth++;
 
-    aMessage.MoveOffset(sizeof(ip6Header));
+    IgnoreError(aMessage.MoveOffset(sizeof(ip6Header)));
 
     nextHeader = static_cast<uint8_t>(ip6Header.GetNextHeader());
 
@@ -454,13 +454,13 @@ exit:
 
     if (error == OT_ERROR_NONE)
     {
-        IgnoreReturnValue(aBuf.Write(hcCtl >> 8));
-        IgnoreReturnValue(aBuf.Write(hcCtl & 0xff));
+        IgnoreError(aBuf.Write(hcCtl >> 8));
+        IgnoreError(aBuf.Write(hcCtl & 0xff));
         aBuf = buf;
     }
     else
     {
-        aMessage.SetOffset(startOffset);
+        IgnoreError(aMessage.SetOffset(startOffset));
     }
 
     return error;
@@ -478,7 +478,7 @@ otError Lowpan::CompressExtensionHeader(Message &aMessage, BufferWriter &aBuf, u
 
     VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(extHeader), &extHeader) == sizeof(extHeader),
                  error = OT_ERROR_PARSE);
-    aMessage.MoveOffset(sizeof(extHeader));
+    IgnoreError(aMessage.MoveOffset(sizeof(extHeader)));
 
     tmpByte = kExtHdrDispatch | kExtHdrEidHbh;
 
@@ -545,7 +545,7 @@ otError Lowpan::CompressExtensionHeader(Message &aMessage, BufferWriter &aBuf, u
 
     SuccessOrExit(error = buf.Write(static_cast<uint8_t>(len)));
     SuccessOrExit(error = buf.Write(aMessage, static_cast<uint8_t>(len)));
-    aMessage.MoveOffset(len + padLength);
+    IgnoreError(aMessage.MoveOffset(len + padLength));
 
 exit:
     if (error == OT_ERROR_NONE)
@@ -554,7 +554,7 @@ exit:
     }
     else
     {
-        aMessage.SetOffset(startOffset);
+        IgnoreError(aMessage.SetOffset(startOffset));
     }
 
     return error;
@@ -602,7 +602,7 @@ otError Lowpan::CompressUdp(Message &aMessage, BufferWriter &aBuf)
 
     SuccessOrExit(error = buf.Write(reinterpret_cast<uint8_t *>(&udpHeader) + Ip6::UdpHeader::GetChecksumOffset(), 2));
 
-    aMessage.MoveOffset(sizeof(udpHeader));
+    IgnoreError(aMessage.MoveOffset(sizeof(udpHeader)));
 
 exit:
     if (error == OT_ERROR_NONE)
@@ -611,7 +611,7 @@ exit:
     }
     else
     {
-        aMessage.SetOffset(startOffset);
+        IgnoreError(aMessage.SetOffset(startOffset));
     }
 
     return error;
@@ -704,8 +704,8 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     }
     else
     {
-        networkData.GetContext(0, srcContext);
-        networkData.GetContext(0, dstContext);
+        IgnoreError(networkData.GetContext(0, srcContext));
+        IgnoreError(networkData.GetContext(0, dstContext));
     }
 
     memset(&aIp6Header, 0, sizeof(aIp6Header));
@@ -799,7 +799,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         break;
 
     case kHcSrcAddrMode3:
-        ComputeIid(aMacSource, srcContext, aIp6Header.GetSource());
+        IgnoreError(ComputeIid(aMacSource, srcContext, aIp6Header.GetSource()));
         break;
     }
 
@@ -976,11 +976,11 @@ int Lowpan::DecompressExtensionHeader(Message &aMessage, const uint8_t *aBuf, ui
     hdr[1] = BitVectorBytes(sizeof(hdr) + len) - 1;
 
     SuccessOrExit(aMessage.Append(hdr, sizeof(hdr)));
-    aMessage.MoveOffset(sizeof(hdr));
+    IgnoreError(aMessage.MoveOffset(sizeof(hdr)));
 
     // payload
     SuccessOrExit(aMessage.Append(cur, len));
-    aMessage.MoveOffset(len);
+    IgnoreError(aMessage.MoveOffset(len));
     cur += len;
 
     // The RFC6282 says: "The trailing Pad1 or PadN option MAY be elided by the compressor.
@@ -1001,7 +1001,7 @@ int Lowpan::DecompressExtensionHeader(Message &aMessage, const uint8_t *aBuf, ui
             SuccessOrExit(aMessage.Append(&optionPadN, padLength));
         }
 
-        aMessage.MoveOffset(padLength);
+        IgnoreError(aMessage.MoveOffset(padLength));
     }
 
     error = OT_ERROR_NONE;
@@ -1094,7 +1094,7 @@ int Lowpan::DecompressUdpHeader(Message &aMessage, const uint8_t *aBuf, uint16_t
     }
 
     VerifyOrExit(aMessage.Append(&udpHeader, sizeof(udpHeader)) == OT_ERROR_NONE, headerLen = -1);
-    aMessage.MoveOffset(sizeof(udpHeader));
+    IgnoreError(aMessage.MoveOffset(sizeof(udpHeader)));
 
 exit:
     return headerLen;

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1274,7 +1274,7 @@ otError MeshForwarder::FrameToMessage(const uint8_t *     aFrame,
 
     SuccessOrExit(error = aMessage->SetLength(aMessage->GetLength() + aFrameLength));
     aMessage->Write(aMessage->GetOffset(), aFrameLength, aFrame);
-    aMessage->MoveOffset(aFrameLength);
+    IgnoreError(aMessage->MoveOffset(aFrameLength));
 
 exit:
     return error;

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -114,13 +114,13 @@ void MeshForwarder::Stop(void)
 
     while ((message = mSendQueue.GetHead()) != NULL)
     {
-        mSendQueue.Dequeue(*message);
+        IgnoreError(mSendQueue.Dequeue(*message));
         message->Free();
     }
 
     while ((message = mReassemblyList.GetHead()) != NULL)
     {
-        mReassemblyList.Dequeue(*message);
+        IgnoreError(mReassemblyList.Dequeue(*message));
         message->Free();
     }
 
@@ -148,7 +148,7 @@ void MeshForwarder::RemoveMessage(Message &aMessage)
 #if OPENTHREAD_FTD
         for (ChildTable::Iterator iter(GetInstance(), Child::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
         {
-            IgnoreReturnValue(mIndirectSender.RemoveMessageFromSleepyChild(aMessage, *iter.GetChild()));
+            IgnoreError(mIndirectSender.RemoveMessageFromSleepyChild(aMessage, *iter.GetChild()));
         }
 #endif
 
@@ -158,7 +158,7 @@ void MeshForwarder::RemoveMessage(Message &aMessage)
         }
     }
 
-    queue->Dequeue(aMessage);
+    IgnoreError(queue->Dequeue(aMessage));
     LogMessage(kMessageEvict, aMessage, NULL, OT_ERROR_NO_BUFS);
     aMessage.Free();
 }
@@ -180,7 +180,7 @@ void MeshForwarder::ScheduleTransmissionTask(void)
         mSendMessage->SetTxSuccess(true);
     }
 
-    Get<Mac::Mac>().RequestDirectFrameTransmission();
+    IgnoreError(Get<Mac::Mac>().RequestDirectFrameTransmission());
 
 exit:
     return;
@@ -260,14 +260,14 @@ Message *MeshForwarder::GetDirectTransmission(void)
 #if OPENTHREAD_FTD
 
         case OT_ERROR_ADDRESS_QUERY:
-            mSendQueue.Dequeue(*curMessage);
-            mResolvingQueue.Enqueue(*curMessage);
+            IgnoreError(mSendQueue.Dequeue(*curMessage));
+            IgnoreError(mResolvingQueue.Enqueue(*curMessage));
             continue;
 
 #endif
 
         default:
-            mSendQueue.Dequeue(*curMessage);
+            IgnoreError(mSendQueue.Dequeue(*curMessage));
             LogMessage(kMessageDrop, *curMessage, NULL, error);
             curMessage->Free();
             continue;
@@ -358,7 +358,7 @@ void MeshForwarder::SetRxOnWhenIdle(bool aRxOnWhenIdle)
     }
     else
     {
-        mDataPollSender.StartPolling();
+        IgnoreError(mDataPollSender.StartPolling());
         Get<Utils::SupervisionListener>().Start();
     }
 }
@@ -606,7 +606,7 @@ start:
 
     aFrame.InitMacHeader(fcf, secCtl);
     aFrame.SetDstPanId(dstpan);
-    aFrame.SetSrcPanId(Get<Mac::Mac>().GetPanId());
+    IgnoreError(aFrame.SetSrcPanId(Get<Mac::Mac>().GetPanId()));
     aFrame.SetDstAddr(aMacDest);
     aFrame.SetSrcAddr(aMacSource);
 
@@ -623,7 +623,7 @@ start:
         ieList[1].Init();
         ieList[1].SetId(Mac::Frame::kHeaderIeTermination2);
         ieList[1].SetLength(0);
-        aFrame.AppendHeaderIe(ieList, 2);
+        IgnoreError(aFrame.AppendHeaderIe(ieList, 2));
 
         cur = aFrame.GetHeaderIe(Mac::Frame::kHeaderIeVendor);
         ie  = reinterpret_cast<Mac::TimeIe *>(cur + sizeof(Mac::HeaderIe));
@@ -719,7 +719,7 @@ start:
             if ((!aMessage.IsLinkSecurityEnabled()) && aMessage.IsSubTypeMle())
             {
                 // Enable security and try again.
-                aMessage.SetOffset(0);
+                IgnoreError(aMessage.SetOffset(0));
                 aMessage.SetLinkSecurityEnabled(true);
                 goto start;
             }
@@ -753,7 +753,7 @@ start:
         aFrame.SetPayloadLength(headerLength + payloadLength);
 
         nextOffset = aMessage.GetOffset() + payloadLength;
-        aMessage.SetOffset(0);
+        IgnoreError(aMessage.SetOffset(0));
     }
     else
     {
@@ -839,7 +839,7 @@ void MeshForwarder::HandleSentFrame(Mac::TxFrame &aFrame, otError aError)
 
     if (!aFrame.IsEmpty())
     {
-        aFrame.GetDstAddr(macDest);
+        IgnoreError(aFrame.GetDstAddr(macDest));
         neighbor = UpdateNeighborOnSentFrame(aFrame, aError, macDest);
     }
 
@@ -865,14 +865,14 @@ void MeshForwarder::HandleSentFrame(Mac::TxFrame &aFrame, otError aError)
 
     if (mMessageNextOffset < mSendMessage->GetLength())
     {
-        mSendMessage->SetOffset(mMessageNextOffset);
+        IgnoreError(mSendMessage->SetOffset(mMessageNextOffset));
     }
     else
     {
         otError txError = aError;
 
         mSendMessage->ClearDirectTransmission();
-        mSendMessage->SetOffset(0);
+        IgnoreError(mSendMessage->SetOffset(0));
 
         if (neighbor != NULL)
         {
@@ -930,7 +930,7 @@ void MeshForwarder::HandleSentFrame(Mac::TxFrame &aFrame, otError aError)
             Get<Mle::Mle>().RequestShorterChildIdRequest();
         }
 
-        mSendQueue.Dequeue(*mSendMessage);
+        IgnoreError(mSendQueue.Dequeue(*mSendMessage));
         mSendMessage->Free();
         mSendMessage       = NULL;
         mMessageNextOffset = 0;
@@ -940,7 +940,7 @@ exit:
 
     if (mEnabled)
     {
-        mScheduleTransmissionTask.Post();
+        IgnoreError(mScheduleTransmissionTask.Post());
     }
 }
 
@@ -962,7 +962,7 @@ void MeshForwarder::HandleDiscoverTimer(void)
 {
     if (mScanChannels.GetNextChannel(mScanChannel) != OT_ERROR_NONE)
     {
-        mSendQueue.Dequeue(*mSendMessage);
+        IgnoreError(mSendQueue.Dequeue(*mSendMessage));
         mSendMessage->Free();
         mSendMessage = NULL;
 
@@ -974,7 +974,7 @@ void MeshForwarder::HandleDiscoverTimer(void)
 
 exit:
     mSendBusy = false;
-    mScheduleTransmissionTask.Post();
+    IgnoreError(mScheduleTransmissionTask.Post());
 }
 
 void MeshForwarder::HandleDiscoverComplete(void)
@@ -1005,7 +1005,7 @@ void MeshForwarder::HandleReceivedFrame(Mac::RxFrame &aFrame)
     SuccessOrExit(error = aFrame.GetSrcAddr(macSource));
     SuccessOrExit(error = aFrame.GetDstAddr(macDest));
 
-    aFrame.GetSrcPanId(linkInfo.mPanId);
+    IgnoreError(aFrame.GetSrcPanId(linkInfo.mPanId));
     linkInfo.mChannel      = aFrame.GetChannel();
     linkInfo.mRss          = aFrame.GetRssi();
     linkInfo.mLqi          = aFrame.GetLqi();
@@ -1117,7 +1117,7 @@ void MeshForwarder::HandleFragment(const uint8_t *         aFrame,
             ClearReassemblyList();
         }
 
-        mReassemblyList.Enqueue(*message);
+        IgnoreError(mReassemblyList.Enqueue(*message));
 
         if (!mUpdateTimer.IsRunning())
         {
@@ -1153,7 +1153,7 @@ void MeshForwarder::HandleFragment(const uint8_t *         aFrame,
         VerifyOrExit(message != NULL, error = OT_ERROR_DROP);
 
         message->Write(message->GetOffset(), aFrameLength, aFrame);
-        message->MoveOffset(aFrameLength);
+        IgnoreError(message->MoveOffset(aFrameLength));
         message->AddRss(aLinkInfo.mRss);
         message->SetTimeout(kReassemblyTimeout);
     }
@@ -1164,8 +1164,8 @@ exit:
     {
         if (message->GetOffset() >= message->GetLength())
         {
-            mReassemblyList.Dequeue(*message);
-            HandleDatagram(*message, aLinkInfo, aMacSource);
+            IgnoreError(mReassemblyList.Dequeue(*message));
+            IgnoreError(HandleDatagram(*message, aLinkInfo, aMacSource));
         }
     }
     else
@@ -1187,7 +1187,7 @@ void MeshForwarder::ClearReassemblyList(void)
     for (message = mReassemblyList.GetHead(); message; message = next)
     {
         next = message->GetNext();
-        mReassemblyList.Dequeue(*message);
+        IgnoreError(mReassemblyList.Dequeue(*message));
 
         LogMessage(kMessageReassemblyDrop, *message, NULL, OT_ERROR_NO_FRAME_RECEIVED);
 
@@ -1233,7 +1233,7 @@ bool MeshForwarder::UpdateReassemblyList(void)
         }
         else
         {
-            mReassemblyList.Dequeue(*message);
+            IgnoreError(mReassemblyList.Dequeue(*message));
 
             LogMessage(kMessageReassemblyDrop, *message, NULL, OT_ERROR_REASSEMBLY_TIMEOUT);
             if (message->GetType() == Message::kTypeIp6)
@@ -1314,7 +1314,7 @@ exit:
 
     if (error == OT_ERROR_NONE)
     {
-        HandleDatagram(*message, aLinkInfo, aMacSource);
+        IgnoreError(HandleDatagram(*message, aLinkInfo, aMacSource));
     }
     else
     {

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -602,8 +602,8 @@ void MeshForwarder::SendDestinationUnreachable(uint16_t aMeshSource, const Messa
     messageInfo.GetPeerAddr() = Get<Mle::MleRouter>().GetMeshLocal16();
     messageInfo.GetPeerAddr().SetLocator(aMeshSource);
 
-    IgnoreError(Get<Ip6::Icmp>().SendError(Ip6::IcmpHeader::kTypeDstUnreach, Ip6::IcmpHeader::kCodeDstUnreachNoRoute, messageInfo,
-                               aMessage));
+    IgnoreError(Get<Ip6::Icmp>().SendError(Ip6::IcmpHeader::kTypeDstUnreach, Ip6::IcmpHeader::kCodeDstUnreachNoRoute,
+                                           messageInfo, aMessage));
 }
 
 void MeshForwarder::HandleMesh(uint8_t *               aFrame,

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -602,8 +602,8 @@ void MeshForwarder::SendDestinationUnreachable(uint16_t aMeshSource, const Messa
     messageInfo.GetPeerAddr() = Get<Mle::MleRouter>().GetMeshLocal16();
     messageInfo.GetPeerAddr().SetLocator(aMeshSource);
 
-    Get<Ip6::Icmp>().SendError(Ip6::IcmpHeader::kTypeDstUnreach, Ip6::IcmpHeader::kCodeDstUnreachNoRoute, messageInfo,
-                               aMessage);
+    IgnoreError(Get<Ip6::Icmp>().SendError(Ip6::IcmpHeader::kTypeDstUnreach, Ip6::IcmpHeader::kCodeDstUnreachNoRoute, messageInfo,
+                               aMessage));
 }
 
 void MeshForwarder::HandleMesh(uint8_t *               aFrame,

--- a/src/core/thread/mesh_forwarder_mtd.cpp
+++ b/src/core/thread/mesh_forwarder_mtd.cpp
@@ -42,11 +42,11 @@ otError MeshForwarder::SendMessage(Message &aMessage)
     otError error;
 
     aMessage.SetDirectTransmission();
-    aMessage.SetOffset(0);
+    IgnoreError(aMessage.SetOffset(0));
     aMessage.SetDatagramTag(0);
 
     SuccessOrExit(error = mSendQueue.Enqueue(aMessage));
-    mScheduleTransmissionTask.Post();
+    IgnoreError(mScheduleTransmissionTask.Post());
 
 exit:
     return error;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -161,8 +161,8 @@ Mle::Mle(Instance &aInstance)
 
     // mesh-local 64
     mMeshLocal64.Clear();
-    Random::Crypto::FillBuffer(mMeshLocal64.GetAddress().mFields.m8 + OT_IP6_PREFIX_SIZE,
-                               OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE);
+    IgnoreError(Random::Crypto::FillBuffer(mMeshLocal64.GetAddress().mFields.m8 + OT_IP6_PREFIX_SIZE,
+                               OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE));
 
     mMeshLocal64.mPrefixLength       = MeshLocalPrefix::kLength;
     mMeshLocal64.mPreferred          = true;
@@ -1550,8 +1550,8 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
         if (!Get<ThreadNetif>().IsUnicastAddress(mMeshLocal64.GetAddress()))
         {
             // Mesh Local EID was removed, choose a new one and add it back
-            Random::Crypto::FillBuffer(mMeshLocal64.GetAddress().mFields.m8 + OT_IP6_PREFIX_SIZE,
-                                       OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE);
+            IgnoreError(Random::Crypto::FillBuffer(mMeshLocal64.GetAddress().mFields.m8 + OT_IP6_PREFIX_SIZE,
+                                       OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE));
 
             IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mMeshLocal64));
             Get<Notifier>().Signal(OT_CHANGED_THREAD_ML_ADDR);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -268,21 +268,21 @@ otError Mle::Start(bool aAnnounceAttach)
 
     if (aAnnounceAttach || (GetRloc16() == Mac::kShortAddrInvalid))
     {
-        BecomeChild(kAttachAny);
+        IgnoreError(BecomeChild(kAttachAny));
     }
 #if OPENTHREAD_FTD
     else if (IsActiveRouter(GetRloc16()))
     {
         if (Get<MleRouter>().BecomeRouter(ThreadStatusTlv::kTooFewRouters) != OT_ERROR_NONE)
         {
-            BecomeChild(kAttachAny);
+            IgnoreError(BecomeChild(kAttachAny));
         }
     }
 #endif
     else
     {
         mChildUpdateAttempts = 0;
-        SendChildUpdateRequest();
+        IgnoreError(SendChildUpdateRequest());
     }
 
 exit:
@@ -301,10 +301,10 @@ void Mle::Stop(bool aClearNetworkDatasets)
 
     Get<KeyManager>().Stop();
     SetStateDetached();
-    Get<ThreadNetif>().UnsubscribeMulticast(mRealmLocalAllThreadNodes);
-    Get<ThreadNetif>().UnsubscribeMulticast(mLinkLocalAllThreadNodes);
-    Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal16);
-    Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal64);
+    IgnoreError(Get<ThreadNetif>().UnsubscribeMulticast(mRealmLocalAllThreadNodes));
+    IgnoreError(Get<ThreadNetif>().UnsubscribeMulticast(mLinkLocalAllThreadNodes));
+    IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal16));
+    IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal64));
 
     SetRole(kRoleDisabled);
 
@@ -365,8 +365,8 @@ otError Mle::Restore(void)
     Settings::NetworkInfo networkInfo;
     Settings::ParentInfo  parentInfo;
 
-    Get<MeshCoP::ActiveDataset>().Restore();
-    Get<MeshCoP::PendingDataset>().Restore();
+    IgnoreError(Get<MeshCoP::ActiveDataset>().Restore());
+    IgnoreError(Get<MeshCoP::PendingDataset>().Restore());
 
     SuccessOrExit(error = Get<Settings>().ReadNetworkInfo(networkInfo));
 
@@ -616,7 +616,7 @@ otError Mle::BecomeDetached(void)
     SetStateDetached();
     mParent.SetState(Neighbor::kStateInvalid);
     SetRloc16(Mac::kShortAddrInvalid);
-    BecomeChild(kAttachAny);
+    IgnoreError(BecomeChild(kAttachAny));
 
 exit:
     return error;
@@ -747,7 +747,7 @@ void Mle::SetStateDetached(void)
 
     if (IsLeader())
     {
-        Get<ThreadNetif>().RemoveUnicastAddress(mLeaderAloc);
+        IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mLeaderAloc));
     }
 
     SetRole(kRoleDetached);
@@ -773,7 +773,7 @@ void Mle::SetStateChild(uint16_t aRloc16)
 {
     if (IsLeader())
     {
-        Get<ThreadNetif>().RemoveUnicastAddress(mLeaderAloc);
+        IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mLeaderAloc));
     }
 
     SetRloc16(aRloc16);
@@ -790,7 +790,7 @@ void Mle::SetStateChild(uint16_t aRloc16)
 #if OPENTHREAD_FTD
     if (IsFullThreadDevice())
     {
-        Get<MleRouter>().HandleChildStart(mParentRequestMode);
+        IgnoreError(Get<MleRouter>().HandleChildStart(mParentRequestMode));
     }
 #endif
 
@@ -823,7 +823,7 @@ void Mle::InformPreviousChannel(void)
 #endif
 
     mAlternatePanId = Mac::kPanIdBroadcast;
-    Get<AnnounceBeginServer>().SendAnnounce(1 << mAlternateChannel);
+    IgnoreError(Get<AnnounceBeginServer>().SendAnnounce(1 << mAlternateChannel));
 
 exit:
     return;
@@ -844,7 +844,7 @@ void Mle::SetTimeout(uint32_t aTimeout)
 
     if (IsChild())
     {
-        SendChildUpdateRequest();
+        IgnoreError(SendChildUpdateRequest());
     }
 
 exit:
@@ -862,7 +862,7 @@ otError Mle::SetDeviceMode(DeviceMode aDeviceMode)
 
     otLogNoteMle("Mode 0x%02x -> 0x%02x [%s]", oldMode.Get(), mDeviceMode.Get(), mDeviceMode.ToString().AsCString());
 
-    Store();
+    IgnoreError(Store());
 
     switch (mRole)
     {
@@ -872,19 +872,19 @@ otError Mle::SetDeviceMode(DeviceMode aDeviceMode)
     case kRoleDetached:
         mAttachCounter = 0;
         SetStateDetached();
-        BecomeChild(kAttachAny);
+        IgnoreError(BecomeChild(kAttachAny));
         break;
 
     case kRoleChild:
         SetStateChild(GetRloc16());
-        SendChildUpdateRequest();
+        IgnoreError(SendChildUpdateRequest());
         break;
 
     case kRoleRouter:
     case kRoleLeader:
         if (oldMode.IsFullThreadDevice() && !mDeviceMode.IsFullThreadDevice())
         {
-            BecomeDetached();
+            IgnoreError(BecomeDetached());
         }
 
         break;
@@ -896,9 +896,9 @@ exit:
 
 void Mle::UpdateLinkLocalAddress(void)
 {
-    Get<ThreadNetif>().RemoveUnicastAddress(mLinkLocal64);
+    IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mLinkLocal64));
     mLinkLocal64.GetAddress().SetIid(Get<Mac::Mac>().GetExtAddress());
-    Get<ThreadNetif>().AddUnicastAddress(mLinkLocal64);
+    IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mLinkLocal64));
 
     Get<Notifier>().Signal(OT_CHANGED_THREAD_LL_ADDR);
 }
@@ -909,12 +909,13 @@ void Mle::SetMeshLocalPrefix(const MeshLocalPrefix &aMeshLocalPrefix)
 
     if (Get<ThreadNetif>().IsUp())
     {
-        Get<ThreadNetif>().RemoveUnicastAddress(mLeaderAloc);
+        IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mLeaderAloc));
+
         // We must remove the old addresses before adding the new ones.
-        Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal64);
-        Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal16);
-        Get<ThreadNetif>().UnsubscribeMulticast(mLinkLocalAllThreadNodes);
-        Get<ThreadNetif>().UnsubscribeMulticast(mRealmLocalAllThreadNodes);
+        IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal64));
+        IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal16));
+        IgnoreError(Get<ThreadNetif>().UnsubscribeMulticast(mLinkLocalAllThreadNodes));
+        IgnoreError(Get<ThreadNetif>().UnsubscribeMulticast(mRealmLocalAllThreadNodes));
     }
 
     mMeshLocal64.GetAddress().SetPrefix(aMeshLocalPrefix);
@@ -938,19 +939,19 @@ void Mle::ApplyMeshLocalPrefix(void)
     VerifyOrExit(!IsDisabled(), OT_NOOP);
 
     // Add the addresses back into the table.
-    Get<ThreadNetif>().AddUnicastAddress(mMeshLocal64);
-    Get<ThreadNetif>().SubscribeMulticast(mLinkLocalAllThreadNodes);
-    Get<ThreadNetif>().SubscribeMulticast(mRealmLocalAllThreadNodes);
+    IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mMeshLocal64));
+    IgnoreError(Get<ThreadNetif>().SubscribeMulticast(mLinkLocalAllThreadNodes));
+    IgnoreError(Get<ThreadNetif>().SubscribeMulticast(mRealmLocalAllThreadNodes));
 
     if (IsAttached())
     {
-        Get<ThreadNetif>().AddUnicastAddress(mMeshLocal16);
+        IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mMeshLocal16));
     }
 
     // update Leader ALOC
     if (IsLeader())
     {
-        Get<ThreadNetif>().AddUnicastAddress(mLeaderAloc);
+        IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mLeaderAloc));
     }
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
@@ -971,9 +972,9 @@ void Mle::ApplyMeshLocalPrefix(void)
     {
         if (mServiceAlocs[i].GetAddress().GetLocator() != Mac::kShortAddrInvalid)
         {
-            Get<ThreadNetif>().RemoveUnicastAddress(mServiceAlocs[i]);
+            IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mServiceAlocs[i]));
             mServiceAlocs[i].GetAddress().SetPrefix(GetMeshLocalPrefix());
-            Get<ThreadNetif>().AddUnicastAddress(mServiceAlocs[i]);
+            IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mServiceAlocs[i]));
         }
     }
 
@@ -1008,7 +1009,7 @@ void Mle::SetRloc16(uint16_t aRloc16)
         }
     }
 
-    Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal16);
+    IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal16));
 
     Get<Mac::Mac>().SetShortAddress(aRloc16);
     Get<Ip6::Mpl>().SetSeedId(aRloc16);
@@ -1017,7 +1018,7 @@ void Mle::SetRloc16(uint16_t aRloc16)
     {
         // mesh-local 16
         mMeshLocal16.GetAddress().SetLocator(aRloc16);
-        Get<ThreadNetif>().AddUnicastAddress(mMeshLocal16);
+        IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mMeshLocal16));
 #if OPENTHREAD_FTD
         Get<AddressResolver>().RestartAddressQueries();
 #endif
@@ -1256,7 +1257,7 @@ otError Mle::AppendNetworkData(Message &aMessage, bool aStableOnly)
     VerifyOrExit(!mRetrieveNewNetworkData, error = OT_ERROR_INVALID_STATE);
 
     length = sizeof(networkData);
-    Get<NetworkData::Leader>().GetNetworkData(aStableOnly, networkData, length);
+    IgnoreError(Get<NetworkData::Leader>().GetNetworkData(aStableOnly, networkData, length));
 
     error = Tlv::AppendTlv(aMessage, Tlv::kNetworkData, networkData, length);
 
@@ -1552,7 +1553,7 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
             Random::Crypto::FillBuffer(mMeshLocal64.GetAddress().mFields.m8 + OT_IP6_PREFIX_SIZE,
                                        OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE);
 
-            Get<ThreadNetif>().AddUnicastAddress(mMeshLocal64);
+            IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mMeshLocal64));
             Get<Notifier>().Signal(OT_CHANGED_THREAD_ML_ADDR);
         }
 
@@ -1606,7 +1607,7 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
 #endif
 
 #if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
-        Get<Dhcp6::Dhcp6Server>().UpdateService();
+        IgnoreError(Get<Dhcp6::Dhcp6Server>().UpdateService());
 #endif // OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
 
 #if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
@@ -1621,7 +1622,7 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
 
         if ((aFlags & OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER) || IsAttached())
         {
-            Store();
+            IgnoreError(Store());
         }
     }
 
@@ -1654,7 +1655,7 @@ void Mle::UpdateServiceAlocs(void)
         if ((serviceAloc != Mac::kShortAddrInvalid) &&
             (!Get<NetworkData::Leader>().ContainsService(Mle::ServiceIdFromAloc(serviceAloc), rloc)))
         {
-            Get<ThreadNetif>().RemoveUnicastAddress(mServiceAlocs[i]);
+            IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(mServiceAlocs[i]));
             mServiceAlocs[i].GetAddress().SetLocator(Mac::kShortAddrInvalid);
         }
     }
@@ -1682,7 +1683,7 @@ void Mle::UpdateServiceAlocs(void)
                 if (serviceAloc == Mac::kShortAddrInvalid)
                 {
                     SuccessOrExit(GetServiceAloc(serviceId, mServiceAlocs[i].GetAddress()));
-                    Get<ThreadNetif>().AddUnicastAddress(mServiceAlocs[i]);
+                    IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mServiceAlocs[i]));
                     break;
                 }
             }
@@ -1769,14 +1770,14 @@ void Mle::HandleAttachTimer(void)
         // during reattach when losing connectivity.
         if (mParentRequestMode == kAttachSame1 || mParentRequestMode == kAttachSame2)
         {
-            SendParentRequest(kParentRequestTypeRoutersAndReeds);
+            IgnoreError(SendParentRequest(kParentRequestTypeRoutersAndReeds));
             delay = kParentRequestReedTimeout;
         }
         // initial MLE Parent Request has only R flag set in Scan Mask TLV for
         // during initial attach or downgrade process
         else
         {
-            SendParentRequest(kParentRequestTypeRouters);
+            IgnoreError(SendParentRequest(kParentRequestTypeRouters));
             delay = kParentRequestRouterTimeout;
         }
 
@@ -1784,7 +1785,7 @@ void Mle::HandleAttachTimer(void)
 
     case kAttachStateParentRequestRouter:
         SetAttachState(kAttachStateParentRequestReed);
-        SendParentRequest(kParentRequestTypeRoutersAndReeds);
+        IgnoreError(SendParentRequest(kParentRequestTypeRoutersAndReeds));
         delay = kParentRequestReedTimeout;
         break;
 
@@ -1794,7 +1795,7 @@ void Mle::HandleAttachTimer(void)
         if (shouldAnnounce)
         {
             SetAttachState(kAttachStateAnnounce);
-            SendParentRequest(kParentRequestTypeRoutersAndReeds);
+            IgnoreError(SendParentRequest(kParentRequestTypeRoutersAndReeds));
             mAnnounceChannel = Mac::ChannelMask::kChannelIteratorFirst;
             delay            = mAnnounceDelay;
             break;
@@ -1864,7 +1865,7 @@ uint32_t Mle::Reattach(void)
     {
         if (Get<MeshCoP::PendingDataset>().Restore() == OT_ERROR_NONE)
         {
-            Get<MeshCoP::PendingDataset>().ApplyConfiguration();
+            IgnoreError(Get<MeshCoP::PendingDataset>().ApplyConfiguration());
             mReattachState = kReattachPending;
             SetAttachState(kAttachStateStart);
             delay = 1 + Random::NonCrypto::GetUint32InRange(0, kAttachStartJitter);
@@ -1877,7 +1878,7 @@ uint32_t Mle::Reattach(void)
     else if (mReattachState == kReattachPending)
     {
         mReattachState = kReattachStop;
-        Get<MeshCoP::ActiveDataset>().Restore();
+        IgnoreError(Get<MeshCoP::ActiveDataset>().Restore());
     }
 
     VerifyOrExit(mReattachState == kReattachStop, OT_NOOP);
@@ -1889,10 +1890,10 @@ uint32_t Mle::Reattach(void)
         {
             if (mAlternatePanId != Mac::kPanIdBroadcast)
             {
-                Get<Mac::Mac>().SetPanChannel(mAlternateChannel);
+                IgnoreError(Get<Mac::Mac>().SetPanChannel(mAlternateChannel));
                 Get<Mac::Mac>().SetPanId(mAlternatePanId);
                 mAlternatePanId = Mac::kPanIdBroadcast;
-                BecomeDetached();
+                IgnoreError(BecomeDetached());
             }
 #if OPENTHREAD_FTD
             else if (IsFullThreadDevice() && Get<MleRouter>().BecomeLeader() == OT_ERROR_NONE)
@@ -1902,7 +1903,7 @@ uint32_t Mle::Reattach(void)
 #endif
             else
             {
-                BecomeDetached();
+                IgnoreError(BecomeDetached());
             }
         }
         else if (!IsRxOnWhenIdle())
@@ -1915,12 +1916,12 @@ uint32_t Mle::Reattach(void)
         break;
 
     case kAttachSame1:
-        BecomeChild(kAttachSame2);
+        IgnoreError(BecomeChild(kAttachSame2));
         break;
 
     case kAttachSame2:
     case kAttachSameDowngrade:
-        BecomeChild(kAttachAny);
+        IgnoreError(BecomeChild(kAttachAny));
         break;
 
     case kAttachBetter:
@@ -1959,7 +1960,7 @@ void Mle::HandleDelayedResponseTimer(void)
         }
         else
         {
-            mDelayedResponses.Dequeue(*message);
+            IgnoreError(mDelayedResponses.Dequeue(*message));
             metadata.RemoveFrom(*message);
 
             if (SendMessage(*message, metadata.mDestination) == OT_ERROR_NONE)
@@ -2000,7 +2001,7 @@ void Mle::RemoveDelayedDataResponseMessage(void)
 
         if (message->GetSubType() == Message::kSubTypeMleDataResponse)
         {
-            mDelayedResponses.Dequeue(*message);
+            IgnoreError(mDelayedResponses.Dequeue(*message));
             message->Free();
             LogMleMessage("Remove Delayed Data Response", metadata.mDestination);
 
@@ -2071,7 +2072,7 @@ void Mle::RequestShorterChildIdRequest(void)
     if (mAttachState == kAttachStateChildIdRequest)
     {
         mAddressRegistrationMode = kAppendMeshLocalOnly;
-        SendChildIdRequest();
+        IgnoreError(SendChildIdRequest());
     }
 }
 
@@ -2267,7 +2268,7 @@ void Mle::HandleMessageTransmissionTimer(void)
             static const uint8_t tlvs[] = {Tlv::kNetworkData};
             Ip6::Address         destination;
 
-            VerifyOrExit(mDataRequestAttempts < kMaxChildKeepAliveAttempts, BecomeDetached());
+            VerifyOrExit(mDataRequestAttempts < kMaxChildKeepAliveAttempts, IgnoreError(BecomeDetached()));
 
             destination.SetToLinkLocalAddress(mParent.GetExtAddress());
 
@@ -2300,7 +2301,7 @@ void Mle::HandleMessageTransmissionTimer(void)
         break;
     }
 
-    VerifyOrExit(mChildUpdateAttempts < kMaxChildKeepAliveAttempts, BecomeDetached());
+    VerifyOrExit(mChildUpdateAttempts < kMaxChildKeepAliveAttempts, IgnoreError(BecomeDetached()));
 
     if (SendChildUpdateRequest() == OT_ERROR_NONE)
     {
@@ -2320,7 +2321,7 @@ otError Mle::SendChildUpdateRequest(void)
     if (!mParent.IsStateValidOrRestoring())
     {
         otLogWarnMle("No valid parent when sending Child Update Request");
-        BecomeDetached();
+        IgnoreError(BecomeDetached());
         ExitNow();
     }
 
@@ -2441,7 +2442,7 @@ otError Mle::SendChildUpdateResponse(const uint8_t *aTlvs, uint8_t aNumTlvs, con
 
     if (checkAddress && HasUnregisteredAddress())
     {
-        SendChildUpdateRequest();
+        IgnoreError(SendChildUpdateRequest());
     }
 
 exit:
@@ -2523,7 +2524,7 @@ otError Mle::SendOrphanAnnounce(void)
 
     SuccessOrExit(error = channelMask.GetNextChannel(mAnnounceChannel));
 
-    SendAnnounce(mAnnounceChannel, true);
+    IgnoreError(SendAnnounce(mAnnounceChannel, true));
 
 exit:
     return error;
@@ -2565,14 +2566,14 @@ otError Mle::SendMessage(Message &aMessage, const Ip6::Address &aDestination)
         aesCcm.Header(&aDestination, sizeof(aDestination));
         aesCcm.Header(header.GetBytes() + 1, header.GetHeaderLength());
 
-        aMessage.SetOffset(header.GetLength() - 1);
+        IgnoreError(aMessage.SetOffset(header.GetLength() - 1));
 
         while (aMessage.GetOffset() < aMessage.GetLength())
         {
             length = aMessage.Read(aMessage.GetOffset(), sizeof(buf), buf);
             aesCcm.Payload(buf, buf, length, true);
             aMessage.Write(aMessage.GetOffset(), length, buf);
-            aMessage.MoveOffset(length);
+            IgnoreError(aMessage.MoveOffset(length));
         }
 
         tagLength = sizeof(tag);
@@ -2602,7 +2603,7 @@ otError Mle::AddDelayedResponse(Message &aMessage, const Ip6::Address &aDestinat
     metadata.mDestination = aDestination;
 
     SuccessOrExit(error = metadata.AppendTo(aMessage));
-    mDelayedResponses.Enqueue(aMessage);
+    IgnoreError(mDelayedResponses.Enqueue(aMessage));
 
     mDelayedResponseTimer.FireAtIfEarlier(metadata.mSendTime);
 
@@ -2645,18 +2646,18 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 
     if (header.GetSecuritySuite() == Header::kNoSecurity)
     {
-        aMessage.MoveOffset(header.GetLength());
+        IgnoreError(aMessage.MoveOffset(header.GetLength()));
 
         switch (header.GetCommand())
         {
 #if OPENTHREAD_FTD
         case Header::kCommandDiscoveryRequest:
-            Get<MleRouter>().HandleDiscoveryRequest(aMessage, aMessageInfo);
+            IgnoreError(Get<MleRouter>().HandleDiscoveryRequest(aMessage, aMessageInfo));
             break;
 #endif
 
         case Header::kCommandDiscoveryResponse:
-            HandleDiscoveryResponse(aMessage, aMessageInfo);
+            IgnoreError(HandleDiscoveryResponse(aMessage, aMessageInfo));
             break;
 
         default:
@@ -2682,7 +2683,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 
     VerifyOrExit(aMessage.GetOffset() + header.GetLength() + sizeof(messageTag) <= aMessage.GetLength(),
                  error = OT_ERROR_PARSE);
-    aMessage.MoveOffset(header.GetLength() - 1);
+    IgnoreError(aMessage.MoveOffset(header.GetLength() - 1));
 
     aMessage.Read(aMessage.GetLength() - sizeof(messageTag), sizeof(messageTag), messageTag);
     SuccessOrExit(error = aMessage.SetLength(aMessage.GetLength() - sizeof(messageTag)));
@@ -2710,7 +2711,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
         aMessage.Write(aMessage.GetOffset(), length, buf);
 #endif
-        aMessage.MoveOffset(length);
+        IgnoreError(aMessage.MoveOffset(length));
     }
 
     tagLength = sizeof(tag);
@@ -2724,10 +2725,10 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
         Get<KeyManager>().SetCurrentKeySequence(keySequence);
     }
 
-    aMessage.SetOffset(mleOffset);
+    IgnoreError(aMessage.SetOffset(mleOffset));
 
     aMessage.Read(aMessage.GetOffset(), sizeof(command), &command);
-    aMessage.MoveOffset(sizeof(command));
+    IgnoreError(aMessage.MoveOffset(sizeof(command)));
 
     switch (mRole)
     {
@@ -2773,35 +2774,35 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     switch (command)
     {
     case Header::kCommandAdvertisement:
-        HandleAdvertisement(aMessage, aMessageInfo, neighbor);
+        IgnoreError(HandleAdvertisement(aMessage, aMessageInfo, neighbor));
         break;
 
     case Header::kCommandDataResponse:
-        HandleDataResponse(aMessage, aMessageInfo, neighbor);
+        IgnoreError(HandleDataResponse(aMessage, aMessageInfo, neighbor));
         break;
 
     case Header::kCommandParentResponse:
-        HandleParentResponse(aMessage, aMessageInfo, keySequence);
+        IgnoreError(HandleParentResponse(aMessage, aMessageInfo, keySequence));
         break;
 
     case Header::kCommandChildIdResponse:
-        HandleChildIdResponse(aMessage, aMessageInfo, neighbor);
+        IgnoreError(HandleChildIdResponse(aMessage, aMessageInfo, neighbor));
         break;
 
     case Header::kCommandAnnounce:
-        HandleAnnounce(aMessage, aMessageInfo);
+        IgnoreError(HandleAnnounce(aMessage, aMessageInfo));
         break;
 
     case Header::kCommandChildUpdateRequest:
 #if OPENTHREAD_FTD
         if (IsRouterOrLeader())
         {
-            Get<MleRouter>().HandleChildUpdateRequest(aMessage, aMessageInfo, keySequence);
+            IgnoreError(Get<MleRouter>().HandleChildUpdateRequest(aMessage, aMessageInfo, keySequence));
         }
         else
 #endif
         {
-            HandleChildUpdateRequest(aMessage, aMessageInfo, neighbor);
+            IgnoreError(HandleChildUpdateRequest(aMessage, aMessageInfo, neighbor));
         }
 
         break;
@@ -2810,39 +2811,39 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 #if OPENTHREAD_FTD
         if (IsRouterOrLeader())
         {
-            Get<MleRouter>().HandleChildUpdateResponse(aMessage, aMessageInfo, keySequence, neighbor);
+            IgnoreError(Get<MleRouter>().HandleChildUpdateResponse(aMessage, aMessageInfo, keySequence, neighbor));
         }
         else
 #endif
         {
-            HandleChildUpdateResponse(aMessage, aMessageInfo, neighbor);
+            IgnoreError(HandleChildUpdateResponse(aMessage, aMessageInfo, neighbor));
         }
 
         break;
 
 #if OPENTHREAD_FTD
     case Header::kCommandLinkRequest:
-        Get<MleRouter>().HandleLinkRequest(aMessage, aMessageInfo, neighbor);
+        IgnoreError(Get<MleRouter>().HandleLinkRequest(aMessage, aMessageInfo, neighbor));
         break;
 
     case Header::kCommandLinkAccept:
-        Get<MleRouter>().HandleLinkAccept(aMessage, aMessageInfo, keySequence, neighbor);
+        IgnoreError(Get<MleRouter>().HandleLinkAccept(aMessage, aMessageInfo, keySequence, neighbor));
         break;
 
     case Header::kCommandLinkAcceptAndRequest:
-        Get<MleRouter>().HandleLinkAcceptAndRequest(aMessage, aMessageInfo, keySequence, neighbor);
+        IgnoreError(Get<MleRouter>().HandleLinkAcceptAndRequest(aMessage, aMessageInfo, keySequence, neighbor));
         break;
 
     case Header::kCommandDataRequest:
-        Get<MleRouter>().HandleDataRequest(aMessage, aMessageInfo, neighbor);
+        IgnoreError(Get<MleRouter>().HandleDataRequest(aMessage, aMessageInfo, neighbor));
         break;
 
     case Header::kCommandParentRequest:
-        Get<MleRouter>().HandleParentRequest(aMessage, aMessageInfo);
+        IgnoreError(Get<MleRouter>().HandleParentRequest(aMessage, aMessageInfo));
         break;
 
     case Header::kCommandChildIdRequest:
-        Get<MleRouter>().HandleChildIdRequest(aMessage, aMessageInfo, keySequence);
+        IgnoreError(Get<MleRouter>().HandleChildIdRequest(aMessage, aMessageInfo, keySequence));
         break;
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
@@ -2895,7 +2896,7 @@ otError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo
             if ((aNeighbor == &mParent) && (mParent.GetRloc16() != sourceAddress))
             {
                 // Remove stale parent.
-                BecomeDetached();
+                IgnoreError(BecomeDetached());
             }
         }
     }
@@ -2922,7 +2923,7 @@ otError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo
                 if ((Tlv::GetTlv(aMessage, Tlv::kRoute, sizeof(route), route) == OT_ERROR_NONE) && route.IsValid())
                 {
                     // Overwrite Route Data
-                    Get<MleRouter>().ProcessRouteTlv(route);
+                    IgnoreError(Get<MleRouter>().ProcessRouteTlv(route));
                 }
             }
 #endif
@@ -2942,7 +2943,7 @@ otError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo
     if (mRetrieveNewNetworkData || IsNetworkDataNewer(leaderData))
     {
         delay = Random::NonCrypto::GetUint16InRange(0, kMleMaxResponseDelay);
-        SendDataRequest(aMessageInfo.GetPeerAddr(), tlvs, sizeof(tlvs), delay);
+        IgnoreError(SendDataRequest(aMessageInfo.GetPeerAddr(), tlvs, sizeof(tlvs), delay));
     }
 
 exit:
@@ -2974,7 +2975,7 @@ otError Mle::HandleDataResponse(const Message &         aMessage,
         // running out the specified number. E.g. other component also trigger fast poll, and
         // is waiting for response; or the corner case where multiple Mle Data Request attempts
         // happened due to the retransmission mechanism.
-        IgnoreReturnValue(Get<DataPollSender>().StopFastPolls());
+        IgnoreError(Get<DataPollSender>().StopFastPolls());
     }
 
 exit:
@@ -3096,8 +3097,8 @@ otError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &a
         if (activeDatasetOffset > 0)
         {
             aMessage.Read(activeDatasetOffset, sizeof(tlv), &tlv);
-            Get<MeshCoP::ActiveDataset>().Save(activeTimestamp, aMessage, activeDatasetOffset + sizeof(tlv),
-                                               tlv.GetLength());
+            IgnoreError(Get<MeshCoP::ActiveDataset>().Save(activeTimestamp, aMessage, activeDatasetOffset + sizeof(tlv),
+                                                           tlv.GetLength()));
         }
     }
 
@@ -3107,8 +3108,8 @@ otError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &a
         if (pendingDatasetOffset > 0)
         {
             aMessage.Read(pendingDatasetOffset, sizeof(tlv), &tlv);
-            Get<MeshCoP::PendingDataset>().Save(pendingTimestamp, aMessage, pendingDatasetOffset + sizeof(tlv),
-                                                tlv.GetLength());
+            IgnoreError(Get<MeshCoP::PendingDataset>().Save(pendingTimestamp, aMessage,
+                                                            pendingDatasetOffset + sizeof(tlv), tlv.GetLength()));
         }
     }
 
@@ -3133,7 +3134,7 @@ exit:
             delay = 10;
         }
 
-        SendDataRequest(aMessageInfo.GetPeerAddr(), tlvs, sizeof(tlvs), delay);
+        IgnoreError(SendDataRequest(aMessageInfo.GetPeerAddr(), tlvs, sizeof(tlvs), delay));
     }
     else if (error == OT_ERROR_NONE)
     {
@@ -3471,7 +3472,8 @@ otError Mle::HandleChildIdResponse(const Message &         aMessage,
         if (Tlv::GetOffset(aMessage, Tlv::kActiveDataset, offset) == OT_ERROR_NONE)
         {
             aMessage.Read(offset, sizeof(tlv), &tlv);
-            Get<MeshCoP::ActiveDataset>().Save(activeTimestamp, aMessage, offset + sizeof(tlv), tlv.GetLength());
+            IgnoreError(
+                Get<MeshCoP::ActiveDataset>().Save(activeTimestamp, aMessage, offset + sizeof(tlv), tlv.GetLength()));
         }
     }
 
@@ -3490,7 +3492,8 @@ otError Mle::HandleChildIdResponse(const Message &         aMessage,
         if (Tlv::GetOffset(aMessage, Tlv::kPendingDataset, offset) == OT_ERROR_NONE)
         {
             aMessage.Read(offset, sizeof(tlv), &tlv);
-            Get<MeshCoP::PendingDataset>().Save(pendingTimestamp, aMessage, offset + sizeof(tlv), tlv.GetLength());
+            IgnoreError(
+                Get<MeshCoP::PendingDataset>().Save(pendingTimestamp, aMessage, offset + sizeof(tlv), tlv.GetLength()));
         }
     }
     else
@@ -3539,8 +3542,9 @@ otError Mle::HandleChildIdResponse(const Message &         aMessage,
 
     mParent.SetRloc16(sourceAddress);
 
-    Get<NetworkData::Leader>().SetNetworkData(leaderData.GetDataVersion(), leaderData.GetStableDataVersion(),
-                                              !IsFullNetworkData(), aMessage, networkDataOffset);
+    IgnoreError(Get<NetworkData::Leader>().SetNetworkData(leaderData.GetDataVersion(),
+                                                          leaderData.GetStableDataVersion(), !IsFullNetworkData(),
+                                                          aMessage, networkDataOffset));
 
     SetStateChild(shortAddress);
 
@@ -3593,7 +3597,7 @@ otError Mle::HandleChildUpdateRequest(const Message &         aMessage,
         switch (Tlv::ReadUint8Tlv(aMessage, Tlv::kStatus, status))
         {
         case OT_ERROR_NONE:
-            VerifyOrExit(status != StatusTlv::kError, BecomeDetached());
+            VerifyOrExit(status != StatusTlv::kError, IgnoreError(BecomeDetached()));
             break;
         case OT_ERROR_NOT_FOUND:
             break;
@@ -3603,7 +3607,7 @@ otError Mle::HandleChildUpdateRequest(const Message &         aMessage,
 
         if (mParent.GetRloc16() != sourceAddress)
         {
-            BecomeDetached();
+            IgnoreError(BecomeDetached());
             ExitNow();
         }
 
@@ -3683,7 +3687,7 @@ otError Mle::HandleChildUpdateResponse(const Message &         aMessage,
     // Status
     if (Tlv::ReadUint8Tlv(aMessage, Tlv::kStatus, status) == OT_ERROR_NONE)
     {
-        BecomeDetached();
+        IgnoreError(BecomeDetached());
         ExitNow();
     }
 
@@ -3723,7 +3727,7 @@ otError Mle::HandleChildUpdateResponse(const Message &         aMessage,
 
         if (RouterIdFromRloc16(sourceAddress) != RouterIdFromRloc16(GetRloc16()))
         {
-            BecomeDetached();
+            IgnoreError(BecomeDetached());
             ExitNow();
         }
 
@@ -3828,10 +3832,10 @@ otError Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMe
     }
     else if (localTimestamp->Compare(timestamp) < 0)
     {
-        SendAnnounce(channel, false);
+        IgnoreError(SendAnnounce(channel, false));
 
 #if OPENTHREAD_CONFIG_MLE_SEND_UNICAST_ANNOUNCE_RESPONSE
-        SendAnnounce(channel, false, aMessageInfo.GetPeerAddr());
+        IgnoreError(SendAnnounce(channel, false, aMessageInfo.GetPeerAddr()));
 #endif
     }
     else
@@ -3868,10 +3872,10 @@ void Mle::ProcessAnnounce(void)
     mAlternatePanId     = Get<Mac::Mac>().GetPanId();
     mAlternateTimestamp = 0;
 
-    Get<Mac::Mac>().SetPanChannel(newChannel);
+    IgnoreError(Get<Mac::Mac>().SetPanChannel(newChannel));
     Get<Mac::Mac>().SetPanId(newPanId);
 
-    Start(/* aAnnounceAttach */ true);
+    IgnoreError(Start(/* aAnnounceAttach */ true));
 }
 
 otError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -3930,7 +3934,7 @@ otError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Message
 
         case MeshCoP::Tlv::kNetworkName:
             aMessage.Read(offset, sizeof(networkName), &networkName);
-            static_cast<Mac::NetworkName &>(result.mNetworkName).Set(networkName.GetNetworkName());
+            IgnoreError(static_cast<Mac::NetworkName &>(result.mNetworkName).Set(networkName.GetNetworkName()));
             break;
 
         case MeshCoP::Tlv::kSteeringData:
@@ -4144,7 +4148,7 @@ void Mle::HandleParentSearchTimer(void)
         otLogInfoMle("PeriodicParentSearch: Parent RSS less than %d, searching for new parents",
                      kParentSearchRssThreadhold);
         mParentSearchIsInBackoff = true;
-        BecomeChild(kAttachAny);
+        IgnoreError(BecomeChild(kAttachAny));
     }
 
 exit:
@@ -4371,7 +4375,7 @@ void Mle::RegisterParentResponseStatsCallback(otThreadParentResponseCallback aCa
 void Mle::Challenge::GenerateRandom(void)
 {
     mLength = kMaxChallengeSize;
-    Random::Crypto::FillBuffer(mBuffer, mLength);
+    IgnoreError(Random::Crypto::FillBuffer(mBuffer, mLength));
 }
 
 bool Mle::Challenge::Matches(const uint8_t *aBuffer, uint8_t aLength) const

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -162,7 +162,7 @@ Mle::Mle(Instance &aInstance)
     // mesh-local 64
     mMeshLocal64.Clear();
     IgnoreError(Random::Crypto::FillBuffer(mMeshLocal64.GetAddress().mFields.m8 + OT_IP6_PREFIX_SIZE,
-                               OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE));
+                                           OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE));
 
     mMeshLocal64.mPrefixLength       = MeshLocalPrefix::kLength;
     mMeshLocal64.mPreferred          = true;
@@ -1551,7 +1551,7 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
         {
             // Mesh Local EID was removed, choose a new one and add it back
             IgnoreError(Random::Crypto::FillBuffer(mMeshLocal64.GetAddress().mFields.m8 + OT_IP6_PREFIX_SIZE,
-                                       OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE));
+                                                   OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE));
 
             IgnoreError(Get<ThreadNetif>().AddUnicastAddress(mMeshLocal64));
             Get<Notifier>().Signal(OT_CHANGED_THREAD_ML_ADDR);

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -887,7 +887,7 @@ public:
     uint8_t GetCost(uint16_t) { return 0; }
 
     otError RemoveNeighbor(Neighbor &) { return BecomeDetached(); }
-    otError RemoveRouterLink(Router &) { return BecomeDetached(); }
+    void    RemoveRouterLink(Router &) { IgnoreError(BecomeDetached()); }
 
     Neighbor *GetNeighbor(const Mac::ExtAddress &aAddress) { return Mle::GetNeighbor(aAddress); }
     Neighbor *GetNeighbor(const Mac::Address &aAddress) { return Mle::GetNeighbor(aAddress); }

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -810,7 +810,7 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16, Coap::Response
         SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, ThreadTlv::kRloc16, aRloc16));
     }
 
-    Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr());
+    IgnoreError(Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr()));
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerPort(kCoapUdpPort);
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, messageInfo, aHandler, aContext));

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -455,7 +455,7 @@ otError LeaderBase::SetCommissioningData(const uint8_t *aValue, uint8_t aValueLe
     otError               error = OT_ERROR_NONE;
     CommissioningDataTlv *commissioningDataTlv;
 
-    RemoveCommissioningData();
+    IgnoreError(RemoveCommissioningData());
 
     if (aValueLength > 0)
     {

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -160,7 +160,8 @@ void Leader::HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &a
     if (ThreadTlv::GetTlv(aMessage, ThreadTlv::kThreadNetworkData, sizeof(networkData), networkData) == OT_ERROR_NONE)
     {
         VerifyOrExit(networkData.IsValid(), OT_NOOP);
-        IgnoreError(RegisterNetworkData(aMessageInfo.GetPeerAddr().GetLocator(), networkData.GetTlvs(), networkData.GetLength()));
+        IgnoreError(RegisterNetworkData(aMessageInfo.GetPeerAddr().GetLocator(), networkData.GetTlvs(),
+                                        networkData.GetLength()));
     }
 
     SuccessOrExit(Get<Coap::Coap>().SendEmptyAck(aMessage, aMessageInfo));

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -76,9 +76,9 @@ void Leader::Reset(void)
 
 void Leader::Start(void)
 {
-    Get<Coap::Coap>().AddResource(mServerData);
-    Get<Coap::Coap>().AddResource(mCommissioningDataGet);
-    Get<Coap::Coap>().AddResource(mCommissioningDataSet);
+    IgnoreError(Get<Coap::Coap>().AddResource(mServerData));
+    IgnoreError(Get<Coap::Coap>().AddResource(mCommissioningDataGet));
+    IgnoreError(Get<Coap::Coap>().AddResource(mCommissioningDataSet));
 }
 
 void Leader::Stop(void)
@@ -160,7 +160,7 @@ void Leader::HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &a
     if (ThreadTlv::GetTlv(aMessage, ThreadTlv::kThreadNetworkData, sizeof(networkData), networkData) == OT_ERROR_NONE)
     {
         VerifyOrExit(networkData.IsValid(), OT_NOOP);
-        RegisterNetworkData(aMessageInfo.GetPeerAddr().GetLocator(), networkData.GetTlvs(), networkData.GetLength());
+        IgnoreError(RegisterNetworkData(aMessageInfo.GetPeerAddr().GetLocator(), networkData.GetTlvs(), networkData.GetLength()));
     }
 
     SuccessOrExit(Get<Coap::Coap>().SendEmptyAck(aMessage, aMessageInfo));
@@ -264,7 +264,7 @@ void Leader::HandleCommissioningSet(Coap::Message &aMessage, const Ip6::MessageI
         }
     }
 
-    SetCommissioningData(tlvs, static_cast<uint8_t>(length));
+    IgnoreError(SetCommissioningData(tlvs, static_cast<uint8_t>(length)));
 
     state = MeshCoP::StateTlv::kAccept;
 
@@ -288,7 +288,7 @@ void Leader::HandleCommissioningGet(Coap::Message &aMessage, const Ip6::MessageI
     uint16_t offset;
 
     SuccessOrExit(Tlv::GetValueOffset(aMessage, MeshCoP::Tlv::kGet, offset, length));
-    aMessage.SetOffset(offset);
+    IgnoreError(aMessage.SetOffset(offset));
 
 exit:
     SendCommissioningGetResponse(aMessage, length, aMessageInfo);
@@ -346,7 +346,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Message &   aRequest,
     if (message->GetLength() == message->GetOffset())
     {
         // no payload, remove coap payload marker
-        message->SetLength(message->GetLength() - 1);
+        IgnoreError(message->SetLength(message->GetLength() - 1));
     }
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, aMessageInfo));

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -147,7 +147,7 @@ otError Local::AddPrefix(const uint8_t *      aPrefix,
                      Mle::MeshLocalPrefix::kLength,
                  error = OT_ERROR_INVALID_ARGS);
 
-    RemovePrefix(aPrefix, aPrefixLength, aSubTlvType);
+    IgnoreError(RemovePrefix(aPrefix, aPrefixLength, aSubTlvType));
 
     subTlvLength = (aSubTlvType == NetworkDataTlv::kTypeBorderRouter)
                        ? sizeof(BorderRouterTlv) + sizeof(BorderRouterEntry)
@@ -254,7 +254,7 @@ otError Local::AddService(uint32_t       aEnterpriseNumber,
     uint16_t    serviceTlvSize =
         ServiceTlv::CalculateSize(aEnterpriseNumber, aServiceDataLength) + sizeof(ServerTlv) + aServerDataLength;
 
-    RemoveService(aEnterpriseNumber, aServiceData, aServiceDataLength);
+    IgnoreError(RemoveService(aEnterpriseNumber, aServiceData, aServiceDataLength));
 
     VerifyOrExit(serviceTlvSize <= kMaxSize, error = OT_ERROR_NO_BUFS);
 

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -63,10 +63,10 @@ NetworkDiagnostic::NetworkDiagnostic(Instance &aInstance)
     , mReceiveDiagnosticGetCallback(NULL)
     , mReceiveDiagnosticGetCallbackContext(NULL)
 {
-    Get<Coap::Coap>().AddResource(mDiagnosticGetRequest);
-    Get<Coap::Coap>().AddResource(mDiagnosticGetQuery);
-    Get<Coap::Coap>().AddResource(mDiagnosticGetAnswer);
-    Get<Coap::Coap>().AddResource(mDiagnosticReset);
+    IgnoreError(Get<Coap::Coap>().AddResource(mDiagnosticGetRequest));
+    IgnoreError(Get<Coap::Coap>().AddResource(mDiagnosticGetQuery));
+    IgnoreError(Get<Coap::Coap>().AddResource(mDiagnosticGetAnswer));
+    IgnoreError(Get<Coap::Coap>().AddResource(mDiagnosticReset));
 }
 
 void NetworkDiagnostic::SetReceiveDiagnosticGetCallback(otReceiveDiagnosticGetCallback aCallback,
@@ -394,7 +394,8 @@ otError NetworkDiagnostic::FillRequestedTlvs(Message &             aRequest,
             tlv.Init();
 
             length = sizeof(NetworkDataTlv) - sizeof(Tlv); // sizeof( NetworkDataTlv::mNetworkData )
-            Get<NetworkData::Leader>().GetNetworkData(/* aStableOnly */ false, tlv.GetNetworkData(), length);
+            IgnoreError(
+                Get<NetworkData::Leader>().GetNetworkData(/* aStableOnly */ false, tlv.GetNetworkData(), length));
             tlv.SetLength(length);
 
             SuccessOrExit(error = tlv.AppendTo(aResponse));
@@ -553,7 +554,7 @@ void NetworkDiagnostic::HandleDiagnosticGetQuery(Coap::Message &aMessage, const 
     if (message->GetLength() == message->GetOffset())
     {
         // Remove Payload Marker if payload is actually empty.
-        message->SetLength(message->GetLength() - 1);
+        IgnoreError(message->SetLength(message->GetLength() - 1));
     }
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, messageInfo, NULL, this));
@@ -603,7 +604,7 @@ void NetworkDiagnostic::HandleDiagnosticGetRequest(Coap::Message &aMessage, cons
     if (message->GetLength() == message->GetOffset())
     {
         // Remove Payload Marker if payload is actually empty.
-        message->SetLength(message->GetOffset() - 1);
+        IgnoreError(message->SetLength(message->GetOffset() - 1));
     }
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, messageInfo));

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -53,7 +53,7 @@ PanIdQueryServer::PanIdQueryServer(Instance &aInstance)
     , mTimer(aInstance, &PanIdQueryServer::HandleTimer, this)
     , mPanIdQuery(OT_URI_PATH_PANID_QUERY, &PanIdQueryServer::HandleQuery, this)
 {
-    Get<Coap::Coap>().AddResource(mPanIdQuery);
+    IgnoreError(Get<Coap::Coap>().AddResource(mPanIdQuery));
 }
 
 void PanIdQueryServer::HandleQuery(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
@@ -104,7 +104,7 @@ void PanIdQueryServer::HandleScanResult(Mac::ActiveScanResult *aScanResult)
     }
     else if (mChannelMask != 0)
     {
-        SendConflict();
+        IgnoreError(SendConflict());
     }
 }
 
@@ -150,7 +150,7 @@ void PanIdQueryServer::HandleTimer(Timer &aTimer)
 
 void PanIdQueryServer::HandleTimer(void)
 {
-    Get<Mac::Mac>().ActiveScan(mChannelMask, 0, HandleScanResult, this);
+    IgnoreError(Get<Mac::Mac>().ActiveScan(mChannelMask, 0, HandleScanResult, this));
     mChannelMask = 0;
 }
 

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -131,20 +131,20 @@ void ThreadNetif::Up(void)
     // Enable the MAC just in case it was disabled while the Interface was down.
     Get<Mac::Mac>().SetEnabled(true);
 #if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
-    Get<Utils::ChannelMonitor>().Start();
+    IgnoreError(Get<Utils::ChannelMonitor>().Start());
 #endif
     Get<MeshForwarder>().Start();
 
     mIsUp = true;
 
-    SubscribeAllNodesMulticast();
-    Get<Mle::MleRouter>().Enable();
-    Get<Coap::Coap>().Start(kCoapUdpPort);
+    IgnoreError(SubscribeAllNodesMulticast());
+    IgnoreError(Get<Mle::MleRouter>().Enable());
+    IgnoreError(Get<Coap::Coap>().Start(kCoapUdpPort));
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
-    Get<Dns::Client>().Start();
+    IgnoreError(Get<Dns::Client>().Start());
 #endif
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
-    Get<Sntp::Client>().Start();
+    IgnoreError(Get<Sntp::Client>().Start());
 #endif
     Get<Notifier>().Signal(OT_CHANGED_THREAD_NETIF_STATE);
 
@@ -157,25 +157,25 @@ void ThreadNetif::Down(void)
     VerifyOrExit(mIsUp, OT_NOOP);
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
-    Get<Dns::Client>().Stop();
+    IgnoreError(Get<Dns::Client>().Stop());
 #endif
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
-    Get<Sntp::Client>().Stop();
+    IgnoreError(Get<Sntp::Client>().Stop());
 #endif
 #if OPENTHREAD_CONFIG_DTLS_ENABLE
     Get<Coap::CoapSecure>().Stop();
 #endif
-    Get<Coap::Coap>().Stop();
-    Get<Mle::MleRouter>().Disable();
+    IgnoreError(Get<Coap::Coap>().Stop());
+    IgnoreError(Get<Mle::MleRouter>().Disable());
     RemoveAllExternalUnicastAddresses();
     UnsubscribeAllExternalMulticastAddresses();
-    UnsubscribeAllRoutersMulticast();
-    UnsubscribeAllNodesMulticast();
+    IgnoreError(UnsubscribeAllRoutersMulticast());
+    IgnoreError(UnsubscribeAllNodesMulticast());
 
     mIsUp = false;
     Get<MeshForwarder>().Stop();
 #if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
-    Get<Utils::ChannelMonitor>().Stop();
+    IgnoreError(Get<Utils::ChannelMonitor>().Stop());
 #endif
     Get<Notifier>().Signal(OT_CHANGED_THREAD_NETIF_STATE);
 

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -107,7 +107,8 @@ bool Neighbor::MatchesFilter(StateFilter aFilter) const
 
 void Neighbor::GenerateChallenge(void)
 {
-    Random::Crypto::FillBuffer(mValidPending.mPending.mChallenge, sizeof(mValidPending.mPending.mChallenge));
+    IgnoreError(
+        Random::Crypto::FillBuffer(mValidPending.mPending.mChallenge, sizeof(mValidPending.mPending.mChallenge)));
 }
 
 void Child::Clear(void)
@@ -284,7 +285,7 @@ exit:
 
 void Child::GenerateChallenge(void)
 {
-    Random::Crypto::FillBuffer(mAttachChallenge, sizeof(mAttachChallenge));
+    IgnoreError(Random::Crypto::FillBuffer(mAttachChallenge, sizeof(mAttachChallenge)));
 }
 
 void Router::Clear(void)

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -236,7 +236,7 @@ void ChannelManager::HandleTimer(void)
     {
     case kStateIdle:
         otLogInfoUtil("ChannelManager: Auto-triggered channel select");
-        IgnoreReturnValue(RequestChannelSelect(false));
+        IgnoreError(RequestChannelSelect(false));
         StartAutoSelectTimer();
         break;
 
@@ -409,7 +409,7 @@ void ChannelManager::SetAutoChannelSelectionEnabled(bool aEnabled)
     if (aEnabled != mAutoSelectEnabled)
     {
         mAutoSelectEnabled = aEnabled;
-        IgnoreReturnValue(RequestChannelSelect(false));
+        IgnoreError(RequestChannelSelect(false));
         StartAutoSelectTimer();
     }
 }

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -119,7 +119,8 @@ void ChannelMonitor::HandleTimer(Timer &aTimer)
 
 void ChannelMonitor::HandleTimer(void)
 {
-    Get<Mac::Mac>().EnergyScan(mScanChannelMasks[mChannelMaskIndex], 0, &ChannelMonitor::HandleEnergyScanResult, this);
+    IgnoreError(Get<Mac::Mac>().EnergyScan(mScanChannelMasks[mChannelMaskIndex], 0,
+                                           &ChannelMonitor::HandleEnergyScanResult, this));
 
     mTimer.StartAt(mTimer.GetFireTime(), Random::NonCrypto::AddJitter(kTimerInterval, kMaxJitterInterval));
 }
@@ -194,7 +195,7 @@ void ChannelMonitor::LogResults(void)
 
     for (size_t i = 0; i < kNumChannels; i++)
     {
-        logString.Append("%02x ", mChannelOccupancy[i] >> 8);
+        IgnoreError(logString.Append("%02x ", mChannelOccupancy[i] >> 8));
     }
 
     otLogInfoUtil("ChannelMonitor: %u [%s]", mSampleCount, logString.AsCString());

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -241,7 +241,7 @@ void SupervisionListener::HandleTimer(void)
 
     otLogWarnUtil("Supervision timeout. No frame from parent in %d sec", mTimeout);
 
-    Get<Mle::MleRouter>().SendChildUpdateRequest();
+    IgnoreError(Get<Mle::MleRouter>().SendChildUpdateRequest());
 
 exit:
     RestartTimer();

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -186,7 +186,7 @@ void Slaac::Update(UpdateMode aMode)
             {
                 otLogInfoUtil("SLAAC: Removing address %s", slaacAddr->GetAddress().ToString().AsCString());
 
-                Get<ThreadNetif>().RemoveUnicastAddress(*slaacAddr);
+                IgnoreError(Get<ThreadNetif>().RemoveUnicastAddress(*slaacAddr));
                 slaacAddr->mValid = false;
             }
         }
@@ -242,7 +242,7 @@ void Slaac::Update(UpdateMode aMode)
 
                     otLogInfoUtil("SLAAC: Adding address %s", slaacAddr->GetAddress().ToString().AsCString());
 
-                    Get<ThreadNetif>().AddUnicastAddress(*slaacAddr);
+                    IgnoreError(Get<ThreadNetif>().AddUnicastAddress(*slaacAddr));
 
                     added = true;
                     break;
@@ -345,7 +345,7 @@ void Slaac::GetIidSecretKey(IidSecretKey &aKey) const
         Random::Crypto::FillBuffer(aKey.m8, sizeof(IidSecretKey));
     }
 
-    Get<Settings>().SaveSlaacIidSecretKey(aKey);
+    IgnoreError(Get<Settings>().SaveSlaacIidSecretKey(aKey));
 
     otLogInfoUtil("SLAAC: Generated and saved secret key");
 

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -238,7 +238,7 @@ void Slaac::Update(UpdateMode aMode)
                     slaacAddr->mPreferred    = config.mPreferred;
                     slaacAddr->mValid        = true;
 
-                    GenerateIid(*slaacAddr);
+                    IgnoreError(GenerateIid(*slaacAddr));
 
                     otLogInfoUtil("SLAAC: Adding address %s", slaacAddr->GetAddress().ToString().AsCString());
 
@@ -342,7 +342,7 @@ void Slaac::GetIidSecretKey(IidSecretKey &aKey) const
 
     if (error != OT_ERROR_NONE)
     {
-        Random::Crypto::FillBuffer(aKey.m8, sizeof(IidSecretKey));
+        IgnoreError(Random::Crypto::FillBuffer(aKey.m8, sizeof(IidSecretKey)));
     }
 
     IgnoreError(Get<Settings>().SaveSlaacIidSecretKey(aKey));

--- a/src/lib/hdlc/hdlc.cpp
+++ b/src/lib/hdlc/hdlc.cpp
@@ -138,8 +138,8 @@ otError Encoder::Encode(uint8_t aByte)
     {
         VerifyOrExit(mWritePointer.CanWrite(2), error = OT_ERROR_NO_BUFS);
 
-        mWritePointer.WriteByte(kEscapeSequence);
-        mWritePointer.WriteByte(aByte ^ 0x20);
+        IgnoreError(mWritePointer.WriteByte(kEscapeSequence));
+        IgnoreError(mWritePointer.WriteByte(aByte ^ 0x20));
     }
     else
     {
@@ -262,7 +262,7 @@ void Decoder::Decode(const uint8_t *aData, uint16_t aLength)
                 if (mWritePointer.CanWrite(sizeof(uint8_t)))
                 {
                     mFcs = UpdateFcs(mFcs, byte);
-                    mWritePointer.WriteByte(byte);
+                    IgnoreError(mWritePointer.WriteByte(byte));
                     mDecodedLength++;
                 }
                 else
@@ -281,7 +281,7 @@ void Decoder::Decode(const uint8_t *aData, uint16_t aLength)
             {
                 byte ^= 0x20;
                 mFcs = UpdateFcs(mFcs, byte);
-                mWritePointer.WriteByte(byte);
+                IgnoreError(mWritePointer.WriteByte(byte));
                 mDecodedLength++;
                 mState = kStateSync;
             }

--- a/src/lib/hdlc/hdlc.hpp
+++ b/src/lib/hdlc/hdlc.hpp
@@ -217,7 +217,7 @@ public:
         mWritePointer    = mBuffer + kHeaderSize;
         mRemainingLength = kSize - kHeaderSize;
 
-        SetSkipLength(0);
+        IgnoreError(SetSkipLength(0));
     }
 
     /**
@@ -322,7 +322,7 @@ public:
     {
         Encoding::LittleEndian::WriteUint16(GetSkipLength() + GetLength(), mWriteFrameStart + kHeaderTotalLengthOffset);
         mWriteFrameStart = mWritePointer;
-        SetSkipLength(0);
+        IgnoreError(SetSkipLength(0));
         mWritePointer    = GetFrame();
         mRemainingLength = static_cast<uint16_t>(mBuffer + kSize - mWritePointer);
     }
@@ -334,7 +334,7 @@ public:
      */
     void DiscardFrame(void)
     {
-        SetSkipLength(0);
+        IgnoreError(SetSkipLength(0));
 
         mWritePointer    = GetFrame();
         mRemainingLength = static_cast<uint16_t>(mBuffer + kSize - mWritePointer);

--- a/src/lib/spinel/spinel_buffer.cpp
+++ b/src/lib/spinel/spinel_buffer.cpp
@@ -93,7 +93,7 @@ void Buffer::Clear(void)
 
     while ((message = otMessageQueueGetHead(&mWriteFrameMessageQueue)) != NULL)
     {
-        otMessageQueueDequeue(&mWriteFrameMessageQueue, message);
+        IgnoreError(otMessageQueueDequeue(&mWriteFrameMessageQueue, message));
 
         // Note that messages associated with current (unfinished) input frame
         // are not yet owned by the `Buffer` and therefore should not
@@ -104,7 +104,7 @@ void Buffer::Clear(void)
     {
         while ((message = otMessageQueueGetHead(&mMessageQueue[priority])) != NULL)
         {
-            otMessageQueueDequeue(&mMessageQueue[priority], message);
+            IgnoreError(otMessageQueueDequeue(&mMessageQueue[priority], message));
             otMessageFree(message);
         }
     }
@@ -317,7 +317,7 @@ void Buffer::InFrameDiscard(void)
 #if OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE
     while ((message = otMessageQueueGetHead(&mWriteFrameMessageQueue)) != NULL)
     {
-        otMessageQueueDequeue(&mWriteFrameMessageQueue, message);
+        IgnoreError(otMessageQueueDequeue(&mWriteFrameMessageQueue, message));
 
         // Note that messages associated with current (unfinished) input frame
         // being discarded, are not yet owned by the `Buffer` and
@@ -520,8 +520,8 @@ otError Buffer::InFrameEnd(void)
     // Move all the messages from the frame queue to the main queue.
     while ((message = otMessageQueueGetHead(&mWriteFrameMessageQueue)) != NULL)
     {
-        otMessageQueueDequeue(&mWriteFrameMessageQueue, message);
-        otMessageQueueEnqueue(&mMessageQueue[mWriteDirection], message);
+        IgnoreError(otMessageQueueDequeue(&mWriteFrameMessageQueue, message));
+        IgnoreError(otMessageQueueEnqueue(&mMessageQueue[mWriteDirection], message));
     }
 #endif
 
@@ -745,7 +745,7 @@ uint8_t Buffer::OutFrameReadByte(void)
             // If there is no message, move to next segment (if any).
             if (error != OT_ERROR_NONE)
             {
-                OutFramePrepareSegment();
+                IgnoreError(OutFramePrepareSegment());
             }
         }
 
@@ -766,7 +766,7 @@ uint8_t Buffer::OutFrameReadByte(void)
             // If no more bytes in the message, move to next segment (if any).
             if (error != OT_ERROR_NONE)
             {
-                OutFramePrepareSegment();
+                IgnoreError(OutFramePrepareSegment());
             }
         }
 #endif
@@ -831,7 +831,7 @@ otError Buffer::OutFrameRemove(void)
 
             if ((message = otMessageQueueGetHead(&mMessageQueue[mReadDirection])) != NULL)
             {
-                otMessageQueueDequeue(&mMessageQueue[mReadDirection], message);
+                IgnoreError(otMessageQueueDequeue(&mMessageQueue[mReadDirection], message));
                 otMessageFree(message);
             }
         }

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -2253,7 +2253,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_DEBUG_NCP_LOG_LEVEL>(
         OT_UNREACHABLE_CODE(break);
     }
 
-    otLoggingSetLevel(logLevel);
+    IgnoreError(otLoggingSetLevel(logLevel));
 
 exit:
     return error;

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -179,7 +179,7 @@ exit:
         }
 
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_NOMEM);
-        mUpdateChangedPropsTask.Post();
+        IgnoreError(mUpdateChangedPropsTask.Post());
     }
 }
 
@@ -680,7 +680,7 @@ exit:
     if (error != OT_ERROR_NONE)
     {
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_NOMEM);
-        mUpdateChangedPropsTask.Post();
+        IgnoreError(mUpdateChangedPropsTask.Post());
     }
 }
 
@@ -723,7 +723,7 @@ exit:
     if (error != OT_ERROR_NONE)
     {
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_NOMEM);
-        mUpdateChangedPropsTask.Post();
+        IgnoreError(mUpdateChangedPropsTask.Post());
     }
 }
 

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -476,9 +476,9 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_NETWORK_DATA>(
     uint8_t networkData[255];
     uint8_t networkDataLen = 255;
 
-    otBorderRouterGetNetData(mInstance,
-                             false, // Stable?
-                             networkData, &networkDataLen);
+    IgnoreError(otBorderRouterGetNetData(mInstance,
+                                         false, // Stable?
+                                         networkData, &networkDataLen));
 
     return mEncoder.WriteData(networkData, networkDataLen);
 }
@@ -488,9 +488,9 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_STABLE_NETWORK
     uint8_t networkData[255];
     uint8_t networkDataLen = 255;
 
-    otBorderRouterGetNetData(mInstance,
-                             true, // Stable?
-                             networkData, &networkDataLen);
+    IgnoreError(otBorderRouterGetNetData(mInstance,
+                                         true, // Stable?
+                                         networkData, &networkDataLen));
 
     return mEncoder.WriteData(networkData, networkDataLen);
 }
@@ -501,9 +501,9 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_LEADER_NETWORK
     uint8_t networkData[255];
     uint8_t networkDataLen = 255;
 
-    otNetDataGet(mInstance,
-                 false, // Stable?
-                 networkData, &networkDataLen);
+    IgnoreError(otNetDataGet(mInstance,
+                             false, // Stable?
+                             networkData, &networkDataLen));
 
     return mEncoder.WriteData(networkData, networkDataLen);
 }
@@ -513,9 +513,9 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_STABLE_LEADER_
     uint8_t networkData[255];
     uint8_t networkDataLen = 255;
 
-    otNetDataGet(mInstance,
-                 true, // Stable?
-                 networkData, &networkDataLen);
+    IgnoreError(otNetDataGet(mInstance,
+                             true, // Stable?
+                             networkData, &networkDataLen));
 
     return mEncoder.WriteData(networkData, networkDataLen);
 }
@@ -559,8 +559,8 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_PARENT>(void)
             int8_t averageRssi;
             int8_t lastRssi;
 
-            otThreadGetParentAverageRssi(mInstance, &averageRssi);
-            otThreadGetParentLastRssi(mInstance, &lastRssi);
+            IgnoreError(otThreadGetParentAverageRssi(mInstance, &averageRssi));
+            IgnoreError(otThreadGetParentLastRssi(mInstance, &lastRssi));
 
             SuccessOrExit(error = mEncoder.WriteEui64(parentInfo.mExtAddress));
             SuccessOrExit(error = mEncoder.WriteUint16(parentInfo.mRloc16));
@@ -662,7 +662,8 @@ exit:
         // the state of these ports, so we need to report
         // those incomplete changes via an asynchronous
         // change event.
-        WritePropertyValueIsFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_PROP_THREAD_ASSISTING_PORTS);
+        IgnoreError(
+            WritePropertyValueIsFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_PROP_THREAD_ASSISTING_PORTS));
     }
 
     return error;
@@ -691,7 +692,7 @@ exit:
 
     if (shouldRegisterWithLeader)
     {
-        otBorderRouterRegister(mInstance);
+        IgnoreError(otBorderRouterRegister(mInstance));
     }
 
     return error;
@@ -831,7 +832,7 @@ exit:
 
     if (shouldRegisterWithLeader)
     {
-        otServerRegister(mInstance);
+        IgnoreError(otServerRegister(mInstance));
     }
 
     return error;
@@ -1091,7 +1092,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_ACTIVE_DATASET
 {
     otOperationalDataset dataset;
 
-    IgnoreReturnValue(otDatasetGetActive(mInstance, &dataset));
+    IgnoreError(otDatasetGetActive(mInstance, &dataset));
     return EncodeOperationalDataset(dataset);
 }
 
@@ -1099,7 +1100,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_PENDING_DATASE
 {
     otOperationalDataset dataset;
 
-    IgnoreReturnValue(otDatasetGetPending(mInstance, &dataset));
+    IgnoreError(otDatasetGetPending(mInstance, &dataset));
     return EncodeOperationalDataset(dataset);
 }
 
@@ -2003,11 +2004,11 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_JAM_DETECT_ENABLE>(vo
 
     if (enabled)
     {
-        otJamDetectionStart(mInstance, &NcpBase::HandleJamStateChange_Jump, this);
+        IgnoreError(otJamDetectionStart(mInstance, &NcpBase::HandleJamStateChange_Jump, this));
     }
     else
     {
-        otJamDetectionStop(mInstance);
+        IgnoreError(otJamDetectionStop(mInstance));
     }
 
 exit:
@@ -2063,7 +2064,7 @@ void NcpBase::HandleJamStateChange(bool aJamState)
     OT_UNUSED_VARIABLE(aJamState);
 
     mChangedPropsSet.AddProperty(SPINEL_PROP_JAM_DETECTED);
-    mUpdateChangedPropsTask.Post();
+    IgnoreError(mUpdateChangedPropsTask.Post());
 }
 
 #endif // OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
@@ -2673,7 +2674,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        WritePropertyValueIsFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_PROP_MAC_WHITELIST);
+        IgnoreError(WritePropertyValueIsFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_PROP_MAC_WHITELIST));
     }
 
     return error;
@@ -2731,7 +2732,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        WritePropertyValueIsFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_PROP_MAC_BLACKLIST);
+        IgnoreError(WritePropertyValueIsFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_PROP_MAC_BLACKLIST));
     }
 
     return error;
@@ -2794,7 +2795,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        WritePropertyValueIsFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_PROP_MAC_FIXED_RSS);
+        IgnoreError(WritePropertyValueIsFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_PROP_MAC_FIXED_RSS));
     }
 
     return error;
@@ -3151,7 +3152,7 @@ void NcpBase::HandleDidReceiveNewLegacyUlaPrefix(const uint8_t *aUlaPrefix)
 {
     memcpy(mLegacyUlaPrefix, aUlaPrefix, OT_NCP_LEGACY_ULA_PREFIX_LENGTH);
     mChangedPropsSet.AddProperty(SPINEL_PROP_NEST_LEGACY_ULA_PREFIX);
-    mUpdateChangedPropsTask.Post();
+    IgnoreError(mUpdateChangedPropsTask.Post());
 }
 
 void NcpBase::HandleLegacyNodeDidJoin(const otExtAddress *aExtAddr)
@@ -3159,7 +3160,7 @@ void NcpBase::HandleLegacyNodeDidJoin(const otExtAddress *aExtAddr)
     mLegacyNodeDidJoin    = true;
     mLegacyLastJoinedNode = *aExtAddr;
     mChangedPropsSet.AddProperty(SPINEL_PROP_NEST_LEGACY_LAST_NODE_JOINED);
-    mUpdateChangedPropsTask.Post();
+    IgnoreError(mUpdateChangedPropsTask.Post());
 }
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_NEST_LEGACY_ULA_PREFIX>(void)
@@ -3245,7 +3246,7 @@ void NcpBase::HandleTimeSyncUpdate(void *aContext)
 void NcpBase::HandleTimeSyncUpdate(void)
 {
     mChangedPropsSet.AddProperty(SPINEL_PROP_THREAD_NETWORK_TIME);
-    mUpdateChangedPropsTask.Post();
+    IgnoreError(mUpdateChangedPropsTask.Post());
 }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
@@ -3303,7 +3304,7 @@ void NcpBase::HandleActiveScanResult(otActiveScanResult *aResult)
         // We are finished with the scan, send an unsolicited
         // scan state update.
         mChangedPropsSet.AddProperty(SPINEL_PROP_MAC_SCAN_STATE);
-        mUpdateChangedPropsTask.Post();
+        IgnoreError(mUpdateChangedPropsTask.Post());
     }
 
 exit:
@@ -3314,7 +3315,7 @@ exit:
         // an async `LAST_STATUS(NOMEM)` when buffer space becomes
         // available.
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_NOMEM);
-        mUpdateChangedPropsTask.Post();
+        IgnoreError(mUpdateChangedPropsTask.Post());
     }
 }
 
@@ -3340,7 +3341,7 @@ void NcpBase::HandleEnergyScanResult(otEnergyScanResult *aResult)
         // We are finished with the scan, send an unsolicited
         // scan state update.
         mChangedPropsSet.AddProperty(SPINEL_PROP_MAC_SCAN_STATE);
-        mUpdateChangedPropsTask.Post();
+        IgnoreError(mUpdateChangedPropsTask.Post());
     }
 
 exit:
@@ -3348,7 +3349,7 @@ exit:
     if (error != OT_ERROR_NONE)
     {
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_NOMEM);
-        mUpdateChangedPropsTask.Post();
+        IgnoreError(mUpdateChangedPropsTask.Post());
     }
 }
 
@@ -3379,7 +3380,7 @@ void NcpBase::HandleJoinerCallback(otError aError)
         break;
     }
 
-    mUpdateChangedPropsTask.Post();
+    IgnoreError(mUpdateChangedPropsTask.Post());
 }
 #endif
 
@@ -3407,7 +3408,7 @@ void NcpBase::HandleDatagramFromStack(otMessage *aMessage)
 
     if (IsResponseQueueEmpty())
     {
-        IgnoreReturnValue(SendQueuedDatagramMessages());
+        IgnoreError(SendQueuedDatagramMessages());
     }
 
 exit:
@@ -3455,13 +3456,13 @@ otError NcpBase::SendQueuedDatagramMessages(void)
         // If forming of the spinel frame fails, the message is enqueued
         // back at the front of `mMessageQueue`.
 
-        otMessageQueueDequeue(&mMessageQueue, message);
+        IgnoreError(otMessageQueueDequeue(&mMessageQueue, message));
 
         error = SendDatagramMessage(message);
 
         if (error != OT_ERROR_NONE)
         {
-            otMessageQueueEnqueueAtHead(&mMessageQueue, message);
+            IgnoreError(otMessageQueueEnqueueAtHead(&mMessageQueue, message));
         }
 
         SuccessOrExit(error);
@@ -3629,7 +3630,7 @@ void NcpBase::HandleStateChanged(otChangedFlags aFlags, void *aContext)
     NcpBase *ncp = static_cast<NcpBase *>(aContext);
 
     ncp->mThreadChangedFlags |= aFlags;
-    ncp->mUpdateChangedPropsTask.Post();
+    IgnoreError(ncp->mUpdateChangedPropsTask.Post());
 }
 
 void NcpBase::ProcessThreadChangedFlags(void)
@@ -3690,7 +3691,7 @@ void NcpBase::ProcessThreadChangedFlags(void)
             )
             {
                 mThreadChangedFlags &= ~static_cast<uint32_t>(OT_CHANGED_THREAD_PARTITION_ID);
-                otThreadSetEnabled(mInstance, false);
+                IgnoreError(otThreadSetEnabled(mInstance, false));
 
                 mChangedPropsSet.AddProperty(SPINEL_PROP_NET_STACK_UP);
                 mChangedPropsSet.AddLastStatus(SPINEL_STATUS_JOIN_FAILURE);

--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -167,7 +167,7 @@ void NcpBase::LinkRawEnergyScanDone(int8_t aEnergyScanMaxRssi)
 
     // Make sure we are back listening on the original receive channel,
     // since the energy scan could have been on a different channel.
-    otLinkRawReceive(mInstance, &NcpBase::LinkRawReceiveDone);
+    IgnoreError(otLinkRawReceive(mInstance, &NcpBase::LinkRawReceiveDone));
 
     SuccessOrExit(mEncoder.BeginFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_CMD_PROP_VALUE_IS,
                                       SPINEL_PROP_MAC_ENERGY_SCAN_RESULT));
@@ -318,7 +318,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_PHY_ENABLED>(void)
         // If we have raw stream enabled stop receiving
         if (mIsRawStreamEnabled)
         {
-            otLinkRawSleep(mInstance);
+            IgnoreError(otLinkRawSleep(mInstance));
         }
 
         error = otLinkRawSetEnable(mInstance, false);

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -97,7 +97,7 @@ NcpUart::NcpUart(Instance *aInstance)
 {
     mTxFrameBuffer.SetFrameAddedCallback(HandleFrameAddedToNcpBuffer, this);
 
-    otPlatUartEnable();
+    IgnoreError(otPlatUartEnable());
 }
 
 void NcpUart::HandleFrameAddedToNcpBuffer(void *                   aContext,
@@ -116,7 +116,7 @@ void NcpUart::HandleFrameAddedToNcpBuffer(void)
 {
     if (mUartBuffer.IsEmpty())
     {
-        mUartSendTask.Post();
+        IgnoreError(mUartSendTask.Post());
     }
 }
 
@@ -153,7 +153,7 @@ void NcpUart::EncodeAndSendToUart(void)
             VerifyOrExit(!super_t::ShouldDeferHostSend(), OT_NOOP);
             SuccessOrExit(mFrameEncoder.BeginFrame());
 
-            txFrameBuffer.OutFrameBegin();
+            IgnoreError(txFrameBuffer.OutFrameBegin());
 
             mState = kEncodingFrame;
 
@@ -170,7 +170,7 @@ void NcpUart::EncodeAndSendToUart(void)
             // call to OutFrameRemove.
             prevHostPowerState = mHostPowerStateInProgress;
 
-            txFrameBuffer.OutFrameRemove();
+            IgnoreError(txFrameBuffer.OutFrameRemove());
 
             if (prevHostPowerState && !mHostPowerStateInProgress)
             {
@@ -227,7 +227,7 @@ void NcpUart::HandleUartSendDone(void)
 {
     mUartBuffer.Clear();
 
-    mUartSendTask.Post();
+    IgnoreError(mUartSendTask.Post());
 }
 
 extern "C" void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)
@@ -287,7 +287,7 @@ void NcpUart::HandleError(otError aError, uint8_t *aBuf, uint16_t aBufLength)
     snprintf(hexbuf, sizeof(hexbuf), "Framing error %d: [", aError);
 
     // Write out the first part of our log message.
-    otNcpStreamWrite(0, reinterpret_cast<uint8_t *>(hexbuf), static_cast<int>(strlen(hexbuf)));
+    IgnoreError(otNcpStreamWrite(0, reinterpret_cast<uint8_t *>(hexbuf), static_cast<int>(strlen(hexbuf))));
 
     // The first '3' comes from the trailing "]\n\000" at the end o the string.
     // The second '3' comes from the length of two hex digits and a space.
@@ -305,7 +305,7 @@ void NcpUart::HandleError(otError aError, uint8_t *aBuf, uint16_t aBufLength)
 
     // Write out the second part of our log message.
     // We skip the first byte since it has a space in it.
-    otNcpStreamWrite(0, reinterpret_cast<uint8_t *>(hexbuf + 1), static_cast<int>(strlen(hexbuf) - 1));
+    IgnoreError(otNcpStreamWrite(0, reinterpret_cast<uint8_t *>(hexbuf + 1), static_cast<int>(strlen(hexbuf) - 1)));
 }
 
 #if OPENTHREAD_ENABLE_NCP_SPINEL_ENCRYPTER

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -74,6 +74,7 @@
 #else
 #error "Unknown posix app type!"
 #endif
+#include <common/code_utils.hpp>
 #include <lib/platform/exit_code.h>
 #include <openthread/openthread-system.h>
 
@@ -326,7 +327,7 @@ static otInstance *InitInstance(int aArgCount, char *aArgVector[])
     setlogmask(setlogmask(0) & LOG_UPTO(LOG_DEBUG));
     syslog(LOG_INFO, "Running %s", otGetVersionString());
     syslog(LOG_INFO, "Thread version: %hu", otThreadGetVersion());
-    otLoggingSetLevel(config.mLogLevel);
+    IgnoreError(otLoggingSetLevel(config.mLogLevel));
 
     instance = otSysInit(&config.mPlatformConfig);
 

--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -679,7 +679,7 @@ void SpiInterface::Process(const RadioProcessContext &aContext)
     if (mSpiTxIsReady || CheckInterrupt())
     {
         // We guard this with the above check because we don't want to overwrite any previously received frames.
-        PushPullSpi();
+        IgnoreError(PushPullSpi());
     }
 }
 
@@ -737,7 +737,7 @@ otError SpiInterface::WaitForFrame(uint64_t aTimeoutUs)
 
     if (isDataReady)
     {
-        PushPullSpi();
+        IgnoreError(PushPullSpi());
     }
     else if (ret == 0)
     {
@@ -764,7 +764,7 @@ otError SpiInterface::SendFrame(const uint8_t *aFrame, uint16_t aLength)
     mSpiTxIsReady     = true;
     mSpiTxPayloadSize = aLength;
 
-    PushPullSpi();
+    IgnoreError(PushPullSpi());
 
 exit:
     return error;

--- a/tests/fuzz/cli_uart_received.cpp
+++ b/tests/fuzz/cli_uart_received.cpp
@@ -56,10 +56,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     instance = otInstanceInitSingle();
     otCliUartInit(instance);
-    otLinkSetPanId(instance, panId);
-    otIp6SetEnabled(instance, true);
-    otThreadSetEnabled(instance, true);
-    otThreadBecomeLeader(instance);
+    IgnoreError(otLinkSetPanId(instance, panId));
+    IgnoreError(otIp6SetEnabled(instance, true));
+    IgnoreError(otThreadSetEnabled(instance, true));
+    IgnoreError(otThreadBecomeLeader(instance));
 
     buf = static_cast<uint8_t *>(malloc(size));
 

--- a/tests/fuzz/ip6_send.cpp
+++ b/tests/fuzz/ip6_send.cpp
@@ -55,10 +55,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     FuzzerPlatformInit();
 
     instance = otInstanceInitSingle();
-    otLinkSetPanId(instance, panId);
-    otIp6SetEnabled(instance, true);
-    otThreadSetEnabled(instance, true);
-    otThreadBecomeLeader(instance);
+    IgnoreError(otLinkSetPanId(instance, panId));
+    IgnoreError(otIp6SetEnabled(instance, true));
+    IgnoreError(otThreadSetEnabled(instance, true));
+    IgnoreError(otThreadBecomeLeader(instance));
 
     settings.mLinkSecurityEnabled = (data[0] & 0x1) != 0;
     settings.mPriority            = OT_MESSAGE_PRIORITY_NORMAL;

--- a/tests/fuzz/ncp_uart_received.cpp
+++ b/tests/fuzz/ncp_uart_received.cpp
@@ -56,10 +56,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     instance = otInstanceInitSingle();
     otNcpInit(instance);
-    otLinkSetPanId(instance, panId);
-    otIp6SetEnabled(instance, true);
-    otThreadSetEnabled(instance, true);
-    otThreadBecomeLeader(instance);
+    IgnoreError(otLinkSetPanId(instance, panId));
+    IgnoreError(otIp6SetEnabled(instance, true));
+    IgnoreError(otThreadSetEnabled(instance, true));
+    IgnoreError(otThreadBecomeLeader(instance));
 
     buf = static_cast<uint8_t *>(malloc(size));
 

--- a/tests/fuzz/radio_receive_done.cpp
+++ b/tests/fuzz/radio_receive_done.cpp
@@ -55,10 +55,10 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     FuzzerPlatformInit();
 
     instance = otInstanceInitSingle();
-    otLinkSetPanId(instance, panId);
-    otIp6SetEnabled(instance, true);
-    otThreadSetEnabled(instance, true);
-    otThreadBecomeLeader(instance);
+    IgnoreError(otLinkSetPanId(instance, panId));
+    IgnoreError(otIp6SetEnabled(instance, true));
+    IgnoreError(otThreadSetEnabled(instance, true));
+    IgnoreError(otThreadBecomeLeader(instance));
 
     buf = static_cast<uint8_t *>(malloc(size));
 


### PR DESCRIPTION
This PR forces error checking by applying the `warn_unused_result` attribute on the `otError` enum (See https://github.com/openthread/ot-commissioner/pull/34 for more detail).

There are hundreds cases in openthread codebase that ignore error silently. To make this PR easier to be reviewed, I made no changes to the logic but always wrap function calls with `IgnoreError` to get rid of the warning/error. One exception is that, `RemoveRouterLink` has different signature btween FTD and MTD, this PR unify it to return `void`.

**NOTE**
**This PR also changes openthread public APIs. That is, applications building atop of the openthread library will not compile (if specified -Werror) when it silently ignores the returned `otError` of any openthread public APIs** (in case the application is compiled with clang). But the application can always get rid of the `unused-return-value` warning by using `-Wno-unused-result`. @jwhui @librasungirl @bukepo @abtink  How do you think about this?
