### PR TITLE
[commissioner] synchronize the state with Border Agent

### DIFF
--- a/include/openthread/commissioner.h
+++ b/include/openthread/commissioner.h
@@ -158,8 +158,9 @@ typedef void (*otCommissionerJoinerCallback)(otCommissionerJoinerEvent aEvent,
  * @param[in]  aJoinerCallback   A pointer to a function that is called with a joiner event occurs.
  * @param[in]  aCallbackContext  A pointer to application-specific context.
  *
- * @retval OT_ERROR_NONE           Successfully started the Commissioner role.
- * @retval OT_ERROR_INVALID_STATE  Commissioner is already started.
+ * @retval OT_ERROR_NONE           Successfully started the Commissioner service.
+ * @retval OT_ERROR_ALREADY        Commissioner is already started.
+ * @retval OT_ERROR_INVALID_STATE  Device is not currently attached to a network.
  *
  */
 otError otCommissionerStart(otInstance *                 aInstance,
@@ -172,8 +173,8 @@ otError otCommissionerStart(otInstance *                 aInstance,
  *
  * @param[in]  aInstance         A pointer to an OpenThread instance.
  *
- * @retval OT_ERROR_NONE           Successfully stopped the Commissioner role.
- * @retval OT_ERROR_INVALID_STATE  Commissioner is already stopped.
+ * @retval OT_ERROR_NONE     Successfully stopped the Commissioner service.
+ * @retval OT_ERROR_ALREADY  Commissioner is already stopped.
  *
  */
 otError otCommissionerStop(otInstance *aInstance);

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -150,6 +150,7 @@ enum
     OT_CHANGED_THREAD_BACKBONE_ROUTER_STATE = 1 << 25, ///< Backbone Router state changed
     OT_CHANGED_THREAD_BACKBONE_ROUTER_LOCAL = 1 << 26, ///< Local Backbone Router configuration changed
     OT_CHANGED_JOINER_STATE                 = 1 << 27, ///< Joiner state changed
+    OT_CHANGED_COMMISSIONER_STATE           = 1 << 28, ///< Commissioner state changed
 };
 
 /**

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -145,12 +145,11 @@ enum
     OT_CHANGED_SECURITY_POLICY              = 1 << 20, ///< Security Policy changed
     OT_CHANGED_CHANNEL_MANAGER_NEW_CHANNEL  = 1 << 21, ///< Channel Manager new pending Thread channel changed
     OT_CHANGED_SUPPORTED_CHANNEL_MASK       = 1 << 22, ///< Supported channel mask changed
-    OT_CHANGED_BORDER_AGENT_STATE           = 1 << 23, ///< Border agent state changed
+    OT_CHANGED_COMMISSIONER_STATE           = 1 << 23, ///< Commissioner state changed
     OT_CHANGED_THREAD_NETIF_STATE           = 1 << 24, ///< Thread network interface state changed
     OT_CHANGED_THREAD_BACKBONE_ROUTER_STATE = 1 << 25, ///< Backbone Router state changed
     OT_CHANGED_THREAD_BACKBONE_ROUTER_LOCAL = 1 << 26, ///< Local Backbone Router configuration changed
     OT_CHANGED_JOINER_STATE                 = 1 << 27, ///< Joiner state changed
-    OT_CHANGED_COMMISSIONER_STATE           = 1 << 28, ///< Commissioner state changed
 };
 
 /**

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -50,9 +50,6 @@ otError otCommissionerStart(otInstance *                 aInstance,
 
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    SuccessOrExit(error = instance.Get<MeshCoP::BorderAgent>().Stop());
-#endif
     SuccessOrExit(error =
                       instance.Get<MeshCoP::Commissioner>().Start(aStateCallback, aJoinerCallback, aCallbackContext));
 exit:
@@ -65,9 +62,6 @@ otError otCommissionerStop(otInstance *aInstance)
     Instance &instance = *static_cast<Instance *>(aInstance);
 
     SuccessOrExit(error = instance.Get<MeshCoP::Commissioner>().Stop(/* aResign */ true));
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    SuccessOrExit(error = instance.Get<MeshCoP::BorderAgent>().Start());
-#endif
 
 exit:
     return error;

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -308,16 +308,12 @@ const char *Notifier::FlagToString(otChangedFlags aFlag) const
         retval = "ChanMask";
         break;
 
-    case OT_CHANGED_BORDER_AGENT_STATE:
-        retval = "BorderAgentState";
+    case OT_CHANGED_COMMISSIONER_STATE:
+        retval = "CommissionerState";
         break;
 
     case OT_CHANGED_THREAD_NETIF_STATE:
         retval = "NetifState";
-        break;
-
-    case OT_CHANGED_COMMISSIONER_STATE:
-        retval = "CommissionerState";
         break;
 
     default:

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -316,6 +316,10 @@ const char *Notifier::FlagToString(otChangedFlags aFlag) const
         retval = "NetifState";
         break;
 
+    case OT_CHANGED_COMMISSIONER_STATE:
+        retval = "CommissionerState";
+        break;
+
     default:
         break;
     }

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -367,7 +367,11 @@ void BorderAgent::HandleStateChanged(Notifier::Callback &aCallback, otChangedFla
 
 void BorderAgent::HandleStateChanged(otChangedFlags aFlags)
 {
-    VerifyOrExit((aFlags & OT_CHANGED_THREAD_ROLE) != 0);
+    VerifyOrExit((aFlags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_COMMISSIONER_STATE)) != 0);
+
+#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
+    VerifyOrExit(Get<MeshCoP::Commissioner>().IsDisabled());
+#endif
 
     if (Get<Mle::MleRouter>().IsAttached())
     {

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -743,7 +743,6 @@ void BorderAgent::SetState(otBorderAgentState aState)
     if (mState != aState)
     {
         mState = aState;
-        Get<Notifier>().Signal(OT_CHANGED_BORDER_AGENT_STATE);
     }
 }
 

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -350,6 +350,7 @@ BorderAgent::BorderAgent(Instance &aInstance)
     , mUdpReceiver(BorderAgent::HandleUdpReceive, this)
     , mTimer(aInstance, HandleTimeout, this)
     , mState(OT_BORDER_AGENT_STATE_STOPPED)
+    , mNotifierCallback(aInstance, &BorderAgent::HandleStateChanged, this)
 {
     mCommissionerAloc.Clear();
     mCommissionerAloc.mPrefixLength       = 64;
@@ -357,6 +358,28 @@ BorderAgent::BorderAgent(Instance &aInstance)
     mCommissionerAloc.mValid              = true;
     mCommissionerAloc.mScopeOverride      = Ip6::Address::kRealmLocalScope;
     mCommissionerAloc.mScopeOverrideValid = true;
+}
+
+void BorderAgent::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
+{
+    aCallback.GetOwner<BorderAgent>().HandleStateChanged(aFlags);
+}
+
+void BorderAgent::HandleStateChanged(otChangedFlags aFlags)
+{
+    VerifyOrExit((aFlags & OT_CHANGED_THREAD_ROLE) != 0);
+
+    if (Get<Mle::MleRouter>().IsAttached())
+    {
+        Start();
+    }
+    else
+    {
+        Stop();
+    }
+
+exit:
+    return;
 }
 
 void BorderAgent::HandleProxyTransmit(const Coap::Message &aMessage)

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -40,6 +40,7 @@
 
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
+#include "common/notifier.hpp"
 #include "net/udp6.hpp"
 
 namespace ot {
@@ -63,7 +64,7 @@ public:
      * This method starts the Border Agent service.
      *
      * @retval OT_ERROR_NONE    Successfully started the Border Agent service.
-     * @retval OT_ERROR_ALREADY Already started.
+     * @retval OT_ERROR_ALREADY Border Agent is already started.
      *
      */
     otError Start(void);
@@ -71,7 +72,8 @@ public:
     /**
      * This method stops the Border Agent service.
      *
-     * @retval OT_ERROR_NONE  Successfully stopped the Border Agent service.
+     * @retval OT_ERROR_NONE    Successfully stopped the Border Agent service.
+     * @retval OT_ERROR_ALREADY Border Agent is already stopped.
      *
      */
     otError Stop(void);
@@ -85,6 +87,9 @@ public:
     otBorderAgentState GetState(void) const { return mState; }
 
 private:
+    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
+    void        HandleStateChanged(otChangedFlags aFlags);
+
     static void HandleConnected(bool aConnected, void *aContext)
     {
         static_cast<BorderAgent *>(aContext)->HandleConnected(aConnected);
@@ -151,6 +156,8 @@ private:
 
     TimerMilli         mTimer;
     otBorderAgentState mState;
+
+    Notifier::Callback mNotifierCallback;
 };
 
 } // namespace MeshCoP

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -74,7 +74,8 @@ public:
      * @param[in]  aCallbackContext  A pointer to application-specific context.
      *
      * @retval OT_ERROR_NONE           Successfully started the Commissioner service.
-     * @retval OT_ERROR_INVALID_STATE  Commissioner is already started.
+     * @retval OT_ERROR_ALREADY        Commissioner is already started.
+     * @retval OT_ERROR_INVALID_STATE  Device is not currently attached to a network.
      *
      */
     otError Start(otCommissionerStateCallback  aStateCallback,
@@ -86,8 +87,8 @@ public:
      *
      * @param[in]  aResign      Whether send LEAD_KA.req to resign as Commissioner
      *
-     * @retval OT_ERROR_NONE           Successfully stopped the Commissioner service.
-     * @retval OT_ERROR_INVALID_STATE  Commissioner is already stopped.
+     * @retval OT_ERROR_NONE     Successfully stopped the Commissioner service.
+     * @retval OT_ERROR_ALREADY  Commissioner is already stopped.
      *
      */
     otError Stop(bool aResign);
@@ -171,6 +172,14 @@ public:
      *
      */
     bool IsActive(void) const { return mState == OT_COMMISSIONER_STATE_ACTIVE; }
+
+    /**
+     * This method indicates whether or not the Commissioner role is disabled.
+     *
+     * @returns TRUE if the Commissioner role is disabled, FALSE otherwise.
+     *
+     */
+    bool IsDisabled(void) const { return mState == OT_COMMISSIONER_STATE_DISABLED; }
 
     /**
      * This function returns the Commissioner State.

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -130,7 +130,7 @@ otError Joiner::Start(const char *     aPskd,
 exit:
     if (error != OT_ERROR_NONE)
     {
-        otLogInfoMeshCoP("Error %s while starting joiner", otThreadErrorToString(error));
+        otLogWarnMeshCoP("Failed to start joiner: %s", otThreadErrorToString(error));
         FreeJoinerFinalizeMessage();
     }
 
@@ -351,7 +351,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        otLogInfoMeshCoP("Error %s while joiner trying to connect", otThreadErrorToString(error));
+        otLogWarnMeshCoP("Failed to start secure joiner connection: %s", otThreadErrorToString(error));
     }
 
     return error;
@@ -553,7 +553,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        otLogWarnMeshCoP("Error %s while processing joiner entrust", otThreadErrorToString(error));
+        otLogWarnMeshCoP("Failed to process joiner entrust: %s", otThreadErrorToString(error));
     }
 }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -374,17 +374,6 @@ void Mle::SetRole(DeviceRole aRole)
         mParent.SetState(Neighbor::kStateInvalid);
     }
 
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    if (IsAttached())
-    {
-        SuccessOrExit(Get<MeshCoP::BorderAgent>().Start());
-    }
-    else
-    {
-        SuccessOrExit(Get<MeshCoP::BorderAgent>().Stop());
-    }
-#endif
-
 exit:
     OT_UNUSED_VARIABLE(oldRole);
 }


### PR DESCRIPTION
This PR fixes the bug found during the Commissioning procedure when i wasn't able to turn on native commissioner even though the actual state was `Disabled`.

----------------

In case both Commissioner and Border Agent are compiled in, there is a chance that Commissioner will change the state without user intervention e.g. from `Active` to `Disabled` (due to some network issue e.g. Keep Alives are lost) without calling the OpenThread API.

If that happens, it may not be possible to turn on/off the commissioner again. There are a couple of possible problems but just to give perspective:

- Border Agent may return `OT_ERROR_ALREADY` which prevents to call the `otCommisionerStart` API https://github.com/openthread/openthread/blob/master/src/core/api/commissioner_api.cpp#L54
- If the Commissioner state changes to `Disabled` in the background, the Border Agent may keep be turned off. 
- In case `otCommissionerStop` API is called, the Border Agent may not be started, due to the `OT_ERROR_INVALID_STATE` error.

---------------------

This PR introduces a few improvements:

To make architectural more cleaner:
- Move the Border Agent state handling from `Mle` to Border Agent module (by using notifier).
- Remove connection between Border Agent and Commissioner in the `commissioner_api.cpp`.
- Return `OT_ERROR_ALREADY` instead of `OT_ERROR_INVALID_STATE` when applicable in Commissioner API.

To fix the above problem:
- Ensure Border Agent is stopped before starting the commissioner, and properly handle `OT_ERROR_ALREADY` error.
- Inform the Border Agent module about the change of the commissioner state (by introducing new notifier entry).