### PR TITLE
[address-resolver] ensure prev pointer stays valid on entry removal

### DIFF
--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -315,6 +315,8 @@ private:
 
     const char *ListToString(const CacheEntryList *aList) const;
 
+    static AddressResolver::CacheEntry *GetEntryAfter(CacheEntry *aPrev, CacheEntryList &aList);
+
     Coap::Resource mAddressError;
     Coap::Resource mAddressQuery;
     Coap::Resource mAddressNotification;


### PR DESCRIPTION
This commit simplifies the model for iterating through a linked
list by using a `prev` pointer as the iterator variable. This helps
fix an issue with the `prev` pointer not staying  valid when entry
is removed from the list during iteration.