### PR TITLE
[nrf528xx] add defines needed for compilation with IAR in nrf_security

### DIFF
--- a/third_party/NordicSemiconductor/libraries/nrf_security/config/nrf-config.h
+++ b/third_party/NordicSemiconductor/libraries/nrf_security/config/nrf-config.h
@@ -55,7 +55,7 @@
  * Required by:
  *      MBEDTLS_AESNI_C
  *      MBEDTLS_PADLOCK_C
- * 
+ *
  * Comment to disable the use of assembly code.
  */
 #define MBEDTLS_HAVE_ASM
@@ -1141,7 +1141,7 @@
  *
  * Do not use the Chinese Remainder Theorem
  * for the RSA private operation.
- * 
+ *
  * Uncomment this macro to disable the use of CRT in RSA.
  *
  */
@@ -2613,7 +2613,7 @@
  * \warning   SHA-1 is considered a weak message digest and its use constitutes
  *            a security risk. If possible, we recommend avoiding dependencies
  *            on it, and considering stronger message digests instead.
- * 
+ *
  */
 #define MBEDTLS_SHA1_C
 
@@ -3198,7 +3198,8 @@ it is (2^48 - 1), our restriction is :  (int - 0xFFFF - 0xF).*/
 /*
  * Nordic added. Ensure there is a definition of mbedtls_ecp_restart_ctx
  */
-#if defined(MBEDTLS_ECP_ALT) && !defined(MBEDTLS_ECP_RESTARTABLE)
+#if defined(MBEDTLS_ECP_ALT) && !defined(MBEDTLS_ECP_RESTARTABLE) && !defined(MBEDTLS_ECP_RESTART_CTX_DECLARED)
+#define MBEDTLS_ECP_RESTART_CTX_DECLARED
 typedef void mbedtls_ecp_restart_ctx;
 #endif
 

--- a/third_party/NordicSemiconductor/libraries/nrf_security/include/mbedtls/ecp.h
+++ b/third_party/NordicSemiconductor/libraries/nrf_security/include/mbedtls/ecp.h
@@ -317,7 +317,10 @@ int mbedtls_ecp_check_budget( const mbedtls_ecp_group *grp,
 #define MBEDTLS_ECP_BUDGET( ops )   /* no-op; for compatibility */
 
 /* We want to declare restartable versions of existing functions anyway */
+#if !defined(MBEDTLS_ECP_RESTART_CTX_DECLARED)
+#define MBEDTLS_ECP_RESTART_CTX_DECLARED
 typedef void mbedtls_ecp_restart_ctx;
+#endif /* MBEDTLS_ECP_RESTART_CTX_DECLARED */
 
 #endif /* MBEDTLS_ECP_RESTARTABLE */
 


### PR DESCRIPTION
Error[Pe301]: typedef name has already been declared (with same type)