### PR TITLE
[toranj] update test-039 to stagger initial address queries

### DIFF
--- a/tests/toranj/openthread-core-toranj-config.h
+++ b/tests/toranj/openthread-core-toranj-config.h
@@ -112,6 +112,16 @@
 #define OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_ENTRIES 16
 
 /**
+ * @def OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_TIMEOUT
+ *
+ * The timeout value (in seconds) waiting for a address notification response after sending an address query.
+ *
+ * Default: 3 seconds
+ *
+ */
+#define OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_TIMEOUT 6
+
+/**
  * @def OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_INITIAL_RETRY_DELAY
  *
  * Initial retry delay for address query (in seconds).

--- a/tests/toranj/test-039-address-cache-table-snoop.py
+++ b/tests/toranj/test-039-address-cache-table-snoop.py
@@ -121,12 +121,16 @@ for num in range(NUM_ADDRESSES):
 # From r1 send msg to a group of addresses (not provided by any nodes in network).
 
 NUM_QUERY_ADDRS = 5
+MAX_STAGGER_INTERVAL = 2.5
 
 for num in range(NUM_QUERY_ADDRS):
     sender = r1.prepare_tx((r1_address, PORT),
                            (PREFIX + "800:" + str(num), PORT), "hi nobody!", 1)
     wpan.Node.perform_async_tx_rx()
     verify(sender.was_successful)
+    # Wait before next tx to stagger the address queries
+    # request ensuring different timeouts
+    time.sleep(MAX_STAGGER_INTERVAL / (NUM_QUERY_ADDRS * speedup))
 
 r2_rloc = int(r2.get(wpan.WPAN_THREAD_RLOC16), 16)
 c2_rloc = int(c2.get(wpan.WPAN_THREAD_RLOC16), 16)
@@ -183,7 +187,7 @@ cache_table = wpan.parse_address_cache_table_result(
 def check_cache_entry_in_retry_state_to_get_to_zero_timeout():
     cache_table = wpan.parse_address_cache_table_result(
         r1.get(wpan.WPAN_THREAD_ADDRESS_CACHE_TABLE))
-    for index in range(NUM_ADDRESSES, NUM_QUERY_ADDRS):
+    for index in range(NUM_QUERY_ADDRS):
         verify(cache_table[index].state ==
                wpan.ADDRESS_CACHE_ENTRY_STATE_RETRY_QUERY)
         verify(cache_table[index].timeout == 0)
@@ -207,7 +211,7 @@ for num in range(NUM_QUERY_ADDRS):
 def check_cache_entry_switch_to_query_state():
     cache_table = wpan.parse_address_cache_table_result(
         r1.get(wpan.WPAN_THREAD_ADDRESS_CACHE_TABLE))
-    for index in range(NUM_ADDRESSES, NUM_QUERY_ADDRS):
+    for index in range(NUM_QUERY_ADDRS):
         verify(cache_table[index].state == wpan.ADDRESS_CACHE_ENTRY_STATE_QUERY)
         verify(cache_table[index].can_evict() == True)
 


### PR DESCRIPTION
This commit changes the `test-039` to add delay between the initial
message tx to stagger the address query send times. This helps verify
the query timeout behavior.

----------

This PR also include the fix from https://github.com/openthread/openthread/pull/4789.
Without this fix the test does indeed fail.