### PR TITLE
[network-data] adopt const for methods, parameters, and local vars

### DIFF
--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -173,11 +173,11 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
     // check commissioner session id
     if (Tlv::ReadUint16Tlv(aMessage, Tlv::kCommissionerSessionId, sessionId) == OT_ERROR_NONE)
     {
-        CommissionerSessionIdTlv *localId;
+        const CommissionerSessionIdTlv *localId;
 
         isUpdateFromCommissioner = true;
 
-        localId = static_cast<CommissionerSessionIdTlv *>(
+        localId = static_cast<const CommissionerSessionIdTlv *>(
             Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kCommissionerSessionId));
 
         VerifyOrExit(localId != NULL && localId->GetCommissionerSessionId() == sessionId);
@@ -254,10 +254,10 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
     // notify commissioner if update is from thread device
     if (!isUpdateFromCommissioner)
     {
-        CommissionerSessionIdTlv *localSessionId;
-        Ip6::Address              destination;
+        const CommissionerSessionIdTlv *localSessionId;
+        Ip6::Address                    destination;
 
-        localSessionId = static_cast<CommissionerSessionIdTlv *>(
+        localSessionId = static_cast<const CommissionerSessionIdTlv *>(
             Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kCommissionerSessionId));
         VerifyOrExit(localSessionId != NULL);
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -102,13 +102,13 @@ exit:
 
 uint16_t JoinerRouter::GetJoinerUdpPort(void)
 {
-    uint16_t          rval = OPENTHREAD_CONFIG_JOINER_UDP_PORT;
-    JoinerUdpPortTlv *joinerUdpPort;
+    uint16_t                rval = OPENTHREAD_CONFIG_JOINER_UDP_PORT;
+    const JoinerUdpPortTlv *joinerUdpPort;
 
     VerifyOrExit(!mIsJoinerPortConfigured, rval = mJoinerUdpPort);
 
-    joinerUdpPort =
-        static_cast<JoinerUdpPortTlv *>(Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kJoinerUdpPort));
+    joinerUdpPort = static_cast<const JoinerUdpPortTlv *>(
+        Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kJoinerUdpPort));
     VerifyOrExit(joinerUdpPort != NULL);
 
     rval = joinerUdpPort->GetUdpPort();

--- a/src/core/meshcop/meshcop.cpp
+++ b/src/core/meshcop/meshcop.cpp
@@ -55,10 +55,10 @@ void ComputeJoinerId(const Mac::ExtAddress &aEui64, Mac::ExtAddress &aJoinerId)
 
 otError GetBorderAgentRloc(ThreadNetif &aNetif, uint16_t &aRloc)
 {
-    otError                error = OT_ERROR_NONE;
-    BorderAgentLocatorTlv *borderAgentLocator;
+    otError                      error = OT_ERROR_NONE;
+    const BorderAgentLocatorTlv *borderAgentLocator;
 
-    borderAgentLocator = static_cast<BorderAgentLocatorTlv *>(
+    borderAgentLocator = static_cast<const BorderAgentLocatorTlv *>(
         aNetif.Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kBorderAgentLocator));
     VerifyOrExit(borderAgentLocator != NULL, error = OT_ERROR_NOT_FOUND);
 

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -815,26 +815,26 @@ exit:
 
 otError MeshForwarder::GetDestinationRlocByServiceAloc(uint16_t aServiceAloc, uint16_t &aMeshDest)
 {
-    otError                  error      = OT_ERROR_NONE;
-    uint8_t                  serviceId  = Mle::Mle::ServiceIdFromAloc(aServiceAloc);
-    NetworkData::ServiceTlv *serviceTlv = Get<NetworkData::Leader>().FindServiceById(serviceId);
+    otError                        error      = OT_ERROR_NONE;
+    uint8_t                        serviceId  = Mle::Mle::ServiceIdFromAloc(aServiceAloc);
+    const NetworkData::ServiceTlv *serviceTlv = Get<NetworkData::Leader>().FindServiceById(serviceId);
 
     if (serviceTlv != NULL)
     {
-        NetworkData::NetworkDataTlv *cur = serviceTlv->GetSubTlvs();
-        NetworkData::NetworkDataTlv *end = serviceTlv->GetNext();
-        Neighbor *                   neighbor;
-        uint16_t                     server16;
-        uint8_t                      bestCost = Mle::kMaxRouteCost;
-        uint8_t                      curCost  = 0x00;
-        uint16_t                     bestDest = Mac::kShortAddrInvalid;
+        const NetworkData::NetworkDataTlv *cur = serviceTlv->GetSubTlvs();
+        const NetworkData::NetworkDataTlv *end = serviceTlv->GetNext();
+        Neighbor *                         neighbor;
+        uint16_t                           server16;
+        uint8_t                            bestCost = Mle::kMaxRouteCost;
+        uint8_t                            curCost  = 0x00;
+        uint16_t                           bestDest = Mac::kShortAddrInvalid;
 
         while (cur < end)
         {
             switch (cur->GetType())
             {
             case NetworkData::NetworkDataTlv::kTypeServer:
-                server16 = static_cast<NetworkData::ServerTlv *>(cur)->GetServer16();
+                server16 = static_cast<const NetworkData::ServerTlv *>(cur)->GetServer16();
 
                 // Path cost
                 curCost = Get<Mle::MleRouter>().GetCost(server16);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2869,7 +2869,7 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
     Tlv                           tlv;
     MeshCoP::DiscoveryResponseTlv discoveryResponse;
     MeshCoP::NetworkNameTlv       networkName;
-    MeshCoP::Tlv *                steeringData;
+    const MeshCoP::Tlv *          steeringData;
     uint16_t                      delay;
 
     VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -59,9 +59,11 @@ void NetworkData::Clear(void)
     mLength = 0;
 }
 
-NetworkDataTlv *NetworkData::FindTlv(NetworkDataTlv *aStart, NetworkDataTlv *aEnd, NetworkDataTlv::Type aType)
+const NetworkDataTlv *NetworkData::FindTlv(const NetworkDataTlv *aStart,
+                                           const NetworkDataTlv *aEnd,
+                                           NetworkDataTlv::Type  aType)
 {
-    NetworkDataTlv *tlv;
+    const NetworkDataTlv *tlv;
 
     for (tlv = aStart; tlv < aEnd; tlv = tlv->GetNext())
     {
@@ -79,12 +81,12 @@ exit:
     return tlv;
 }
 
-NetworkDataTlv *NetworkData::FindTlv(NetworkDataTlv *     aStart,
-                                     NetworkDataTlv *     aEnd,
-                                     NetworkDataTlv::Type aType,
-                                     bool                 aStable)
+const NetworkDataTlv *NetworkData::FindTlv(const NetworkDataTlv *aStart,
+                                           const NetworkDataTlv *aEnd,
+                                           NetworkDataTlv::Type  aType,
+                                           bool                  aStable)
 {
-    NetworkDataTlv *tlv;
+    const NetworkDataTlv *tlv;
 
     for (tlv = aStart; tlv < aEnd; tlv = tlv->GetNext())
     {
@@ -102,10 +104,10 @@ exit:
     return tlv;
 }
 
-NetworkDataTlv *NetworkData::FindTlv(NetworkDataIterator &aIterator, NetworkDataTlv::Type aTlvType)
+const NetworkDataTlv *NetworkData::FindTlv(NetworkDataIterator &aIterator, NetworkDataTlv::Type aTlvType) const
 {
-    NetworkDataTlv *start = aIterator.GetTlv(mTlvs);
-    NetworkDataTlv *tlv;
+    const NetworkDataTlv *start = aIterator.GetTlv(mTlvs);
+    const NetworkDataTlv *tlv;
 
     tlv = FindTlv(start, GetTlvsEnd(), aTlvType);
     VerifyOrExit(tlv != NULL);
@@ -121,9 +123,9 @@ exit:
     return tlv;
 }
 
-void NetworkData::IterateToNextTlv(NetworkDataIterator &aIterator)
+void NetworkData::IterateToNextTlv(NetworkDataIterator &aIterator) const
 {
-    NetworkDataTlv *tlv = aIterator.GetTlv(mTlvs);
+    const NetworkDataTlv *tlv = aIterator.GetTlv(mTlvs);
 
     tlv = tlv->GetNext();
 
@@ -132,13 +134,13 @@ void NetworkData::IterateToNextTlv(NetworkDataIterator &aIterator)
     aIterator.SetEntryIndex(0);
 }
 
-NetworkDataTlv *NetworkData::FindSubTlv(NetworkDataIterator &aIterator,
-                                        NetworkDataTlv::Type aSubTlvType,
-                                        NetworkDataTlv *     aSubTlvs,
-                                        NetworkDataTlv *     aSubTlvsEnd)
+const NetworkDataTlv *NetworkData::FindSubTlv(NetworkDataIterator & aIterator,
+                                              NetworkDataTlv::Type  aSubTlvType,
+                                              const NetworkDataTlv *aSubTlvs,
+                                              const NetworkDataTlv *aSubTlvsEnd) const
 {
-    NetworkDataTlv *subStart = aIterator.GetSubTlv(aSubTlvs);
-    NetworkDataTlv *subTlv;
+    const NetworkDataTlv *subStart = aIterator.GetSubTlv(aSubTlvs);
+    const NetworkDataTlv *subTlv;
 
     subTlv = FindTlv(subStart, aSubTlvsEnd, aSubTlvType);
     VerifyOrExit(subTlv != NULL);
@@ -153,9 +155,9 @@ exit:
     return subTlv;
 }
 
-void NetworkData::IterateToNextSubTlv(NetworkDataIterator &aIterator, NetworkDataTlv *aSubTlvs)
+void NetworkData::IterateToNextSubTlv(NetworkDataIterator &aIterator, const NetworkDataTlv *aSubTlvs) const
 {
-    NetworkDataTlv *subTlv = aIterator.GetSubTlv(aSubTlvs);
+    const NetworkDataTlv *subTlv = aIterator.GetSubTlv(aSubTlvs);
 
     subTlv = subTlv->GetNext();
 
@@ -163,7 +165,7 @@ void NetworkData::IterateToNextSubTlv(NetworkDataIterator &aIterator, NetworkDat
     aIterator.SetEntryIndex(0);
 }
 
-otError NetworkData::GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength)
+otError NetworkData::GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength) const
 {
     otError error = OT_ERROR_NONE;
 
@@ -182,19 +184,19 @@ exit:
     return error;
 }
 
-otError NetworkData::GetNextOnMeshPrefix(Iterator &aIterator, OnMeshPrefixConfig &aConfig)
+otError NetworkData::GetNextOnMeshPrefix(Iterator &aIterator, OnMeshPrefixConfig &aConfig) const
 {
     return GetNextOnMeshPrefix(aIterator, Mac::kShortAddrBroadcast, aConfig);
 }
 
-otError NetworkData::GetNextOnMeshPrefix(Iterator &aIterator, uint16_t aRloc16, OnMeshPrefixConfig &aConfig)
+otError NetworkData::GetNextOnMeshPrefix(Iterator &aIterator, uint16_t aRloc16, OnMeshPrefixConfig &aConfig) const
 {
     otError             error = OT_ERROR_NOT_FOUND;
     NetworkDataIterator iterator(aIterator);
 
-    for (PrefixTlv *prefix; (prefix = FindTlv<PrefixTlv>(iterator)) != NULL; IterateToNextTlv(iterator))
+    for (const PrefixTlv *prefix; (prefix = FindTlv<PrefixTlv>(iterator)) != NULL; IterateToNextTlv(iterator))
     {
-        for (BorderRouterTlv *borderRouter;
+        for (const BorderRouterTlv *borderRouter;
              (borderRouter = FindSubTlv<BorderRouterTlv>(iterator, prefix->GetSubTlvs(), prefix->GetNext())) != NULL;
              IterateToNextSubTlv(iterator, prefix->GetSubTlvs()))
         {
@@ -202,7 +204,7 @@ otError NetworkData::GetNextOnMeshPrefix(Iterator &aIterator, uint16_t aRloc16, 
             {
                 if (aRloc16 == Mac::kShortAddrBroadcast || borderRouter->GetEntry(index)->GetRloc() == aRloc16)
                 {
-                    BorderRouterEntry *borderRouterEntry = borderRouter->GetEntry(index);
+                    const BorderRouterEntry *borderRouterEntry = borderRouter->GetEntry(index);
 
                     memset(&aConfig, 0, sizeof(aConfig));
                     memcpy(&aConfig.mPrefix.mPrefix, prefix->GetPrefix(), BitVectorBytes(prefix->GetPrefixLength()));
@@ -229,19 +231,19 @@ exit:
     return error;
 }
 
-otError NetworkData::GetNextExternalRoute(Iterator &aIterator, ExternalRouteConfig &aConfig)
+otError NetworkData::GetNextExternalRoute(Iterator &aIterator, ExternalRouteConfig &aConfig) const
 {
     return GetNextExternalRoute(aIterator, Mac::kShortAddrBroadcast, aConfig);
 }
 
-otError NetworkData::GetNextExternalRoute(Iterator &aIterator, uint16_t aRloc16, ExternalRouteConfig &aConfig)
+otError NetworkData::GetNextExternalRoute(Iterator &aIterator, uint16_t aRloc16, ExternalRouteConfig &aConfig) const
 {
     otError             error = OT_ERROR_NOT_FOUND;
     NetworkDataIterator iterator(aIterator);
 
-    for (PrefixTlv *prefix; (prefix = FindTlv<PrefixTlv>(iterator)) != NULL; IterateToNextTlv(iterator))
+    for (const PrefixTlv *prefix; (prefix = FindTlv<PrefixTlv>(iterator)) != NULL; IterateToNextTlv(iterator))
     {
-        for (HasRouteTlv *hasRoute;
+        for (const HasRouteTlv *hasRoute;
              (hasRoute = FindSubTlv<HasRouteTlv>(iterator, prefix->GetSubTlvs(), prefix->GetNext())) != NULL;
              IterateToNextSubTlv(iterator, prefix->GetSubTlvs()))
         {
@@ -249,7 +251,7 @@ otError NetworkData::GetNextExternalRoute(Iterator &aIterator, uint16_t aRloc16,
             {
                 if (aRloc16 == Mac::kShortAddrBroadcast || hasRoute->GetEntry(index)->GetRloc() == aRloc16)
                 {
-                    HasRouteEntry *hasRouteEntry = hasRoute->GetEntry(index);
+                    const HasRouteEntry *hasRouteEntry = hasRoute->GetEntry(index);
 
                     memset(&aConfig, 0, sizeof(aConfig));
                     memcpy(&aConfig.mPrefix.mPrefix, prefix->GetPrefix(), BitVectorBytes(prefix->GetPrefixLength()));
@@ -271,19 +273,19 @@ exit:
     return error;
 }
 
-otError NetworkData::GetNextService(Iterator &aIterator, ServiceConfig &aConfig)
+otError NetworkData::GetNextService(Iterator &aIterator, ServiceConfig &aConfig) const
 {
     return GetNextService(aIterator, Mac::kShortAddrBroadcast, aConfig);
 }
 
-otError NetworkData::GetNextService(Iterator &aIterator, uint16_t aRloc16, ServiceConfig &aConfig)
+otError NetworkData::GetNextService(Iterator &aIterator, uint16_t aRloc16, ServiceConfig &aConfig) const
 {
     otError             error = OT_ERROR_NOT_FOUND;
     NetworkDataIterator iterator(aIterator);
 
-    for (ServiceTlv *service; (service = FindTlv<ServiceTlv>(iterator)) != NULL; IterateToNextTlv(iterator))
+    for (const ServiceTlv *service; (service = FindTlv<ServiceTlv>(iterator)) != NULL; IterateToNextTlv(iterator))
     {
-        for (ServerTlv *server;
+        for (const ServerTlv *server;
              (server = FindSubTlv<ServerTlv>(iterator, service->GetSubTlvs(), service->GetNext())) != NULL;
              IterateToNextSubTlv(iterator, service->GetSubTlvs()))
         {
@@ -318,7 +320,7 @@ exit:
     return error;
 }
 
-otError NetworkData::GetNextServiceId(Iterator &aIterator, uint16_t aRloc16, uint8_t &aServiceId)
+otError NetworkData::GetNextServiceId(Iterator &aIterator, uint16_t aRloc16, uint8_t &aServiceId) const
 {
     otError       error;
     ServiceConfig config;
@@ -330,7 +332,7 @@ exit:
     return error;
 }
 
-bool NetworkData::ContainsOnMeshPrefixes(NetworkData &aCompare, uint16_t aRloc16)
+bool NetworkData::ContainsOnMeshPrefixes(const NetworkData &aCompare, uint16_t aRloc16) const
 {
     Iterator           outerIterator = kIteratorInit;
     OnMeshPrefixConfig outerConfig;
@@ -360,7 +362,7 @@ exit:
     return rval;
 }
 
-bool NetworkData::ContainsExternalRoutes(NetworkData &aCompare, uint16_t aRloc16)
+bool NetworkData::ContainsExternalRoutes(const NetworkData &aCompare, uint16_t aRloc16) const
 {
     Iterator            outerIterator = kIteratorInit;
     ExternalRouteConfig outerConfig;
@@ -390,7 +392,7 @@ exit:
     return rval;
 }
 
-bool NetworkData::ContainsServices(NetworkData &aCompare, uint16_t aRloc16)
+bool NetworkData::ContainsServices(const NetworkData &aCompare, uint16_t aRloc16) const
 {
     Iterator      outerIterator = kIteratorInit;
     ServiceConfig outerConfig;
@@ -426,7 +428,7 @@ exit:
     return rval;
 }
 
-bool NetworkData::ContainsService(uint8_t aServiceId, uint16_t aRloc16)
+bool NetworkData::ContainsService(uint8_t aServiceId, uint16_t aRloc16) const
 {
     Iterator iterator = kIteratorInit;
     uint8_t  serviceId;
@@ -464,7 +466,7 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength)
                 continue;
             }
 
-            otDumpDebgNetData("remove prefix done", mTlvs, mLength);
+            otDumpDebgNetData("remove prefix done", aData, aDataLength);
             break;
         }
 
@@ -479,7 +481,7 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength)
                 continue;
             }
 
-            otDumpDebgNetData("remove service done", mTlvs, mLength);
+            otDumpDebgNetData("remove service done", aData, aDataLength);
             break;
         }
 
@@ -597,41 +599,44 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Serv
     }
 }
 
-BorderRouterTlv *NetworkData::FindBorderRouter(PrefixTlv &aPrefix)
+const BorderRouterTlv *NetworkData::FindBorderRouter(const PrefixTlv &aPrefix)
 {
     return FindTlv<BorderRouterTlv>(aPrefix.GetSubTlvs(), aPrefix.GetNext());
 }
 
-BorderRouterTlv *NetworkData::FindBorderRouter(PrefixTlv &aPrefix, bool aStable)
+const BorderRouterTlv *NetworkData::FindBorderRouter(const PrefixTlv &aPrefix, bool aStable)
 {
     return FindTlv<BorderRouterTlv>(aPrefix.GetSubTlvs(), aPrefix.GetNext(), aStable);
 }
 
-HasRouteTlv *NetworkData::FindHasRoute(PrefixTlv &aPrefix)
+const HasRouteTlv *NetworkData::FindHasRoute(const PrefixTlv &aPrefix)
 {
     return FindTlv<HasRouteTlv>(aPrefix.GetSubTlvs(), aPrefix.GetNext());
 }
 
-HasRouteTlv *NetworkData::FindHasRoute(PrefixTlv &aPrefix, bool aStable)
+const HasRouteTlv *NetworkData::FindHasRoute(const PrefixTlv &aPrefix, bool aStable)
 {
     return FindTlv<HasRouteTlv>(aPrefix.GetSubTlvs(), aPrefix.GetNext(), aStable);
 }
 
-ContextTlv *NetworkData::FindContext(PrefixTlv &aPrefix)
+const ContextTlv *NetworkData::FindContext(const PrefixTlv &aPrefix)
 {
     return FindTlv<ContextTlv>(aPrefix.GetSubTlvs(), aPrefix.GetNext());
 }
 
-PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength)
+const PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength) const
 {
     return FindPrefix(aPrefix, aPrefixLength, mTlvs, mLength);
 }
 
-PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, uint8_t *aTlvs, uint8_t aTlvsLength)
+const PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix,
+                                         uint8_t        aPrefixLength,
+                                         const uint8_t *aTlvs,
+                                         uint8_t        aTlvsLength)
 {
-    NetworkDataTlv *start = reinterpret_cast<NetworkDataTlv *>(aTlvs);
-    NetworkDataTlv *end   = reinterpret_cast<NetworkDataTlv *>(aTlvs + aTlvsLength);
-    PrefixTlv *     prefixTlv;
+    const NetworkDataTlv *start = reinterpret_cast<const NetworkDataTlv *>(aTlvs);
+    const NetworkDataTlv *end   = reinterpret_cast<const NetworkDataTlv *>(aTlvs + aTlvsLength);
+    const PrefixTlv *     prefixTlv;
 
     while (start < end)
     {
@@ -666,22 +671,22 @@ int8_t NetworkData::PrefixMatch(const uint8_t *a, const uint8_t *b, uint8_t aLen
     return (matchedLength >= aLength) ? static_cast<int8_t>(matchedLength) : -1;
 }
 
-ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,
-                                     const uint8_t *aServiceData,
-                                     uint8_t        aServiceDataLength)
+const ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,
+                                           const uint8_t *aServiceData,
+                                           uint8_t        aServiceDataLength) const
 {
     return FindService(aEnterpriseNumber, aServiceData, aServiceDataLength, mTlvs, mLength);
 }
 
-ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,
-                                     const uint8_t *aServiceData,
-                                     uint8_t        aServiceDataLength,
-                                     uint8_t *      aTlvs,
-                                     uint8_t        aTlvsLength)
+const ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,
+                                           const uint8_t *aServiceData,
+                                           uint8_t        aServiceDataLength,
+                                           const uint8_t *aTlvs,
+                                           uint8_t        aTlvsLength)
 {
-    NetworkDataTlv *start = reinterpret_cast<NetworkDataTlv *>(aTlvs);
-    NetworkDataTlv *end   = reinterpret_cast<NetworkDataTlv *>(aTlvs + aTlvsLength);
-    ServiceTlv *    serviceTlv;
+    const NetworkDataTlv *start = reinterpret_cast<const NetworkDataTlv *>(aTlvs);
+    const NetworkDataTlv *end   = reinterpret_cast<const NetworkDataTlv *>(aTlvs + aTlvsLength);
+    const ServiceTlv *    serviceTlv;
 
     while (start < end)
     {
@@ -795,7 +800,7 @@ exit:
     return error;
 }
 
-otError NetworkData::GetNextServer(Iterator &aIterator, uint16_t &aRloc16)
+otError NetworkData::GetNextServer(Iterator &aIterator, uint16_t &aRloc16) const
 {
     otError             error = OT_ERROR_NONE;
     NetworkDataIterator iterator(aIterator);

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -162,7 +162,7 @@ public:
      * @retval OT_ERROR_NO_BUFS    Not enough space to fully copy Thread Network Data.
      *
      */
-    otError GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength);
+    otError GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength) const;
 
     /**
      * This method provides the next On Mesh prefix in the Thread Network Data.
@@ -174,7 +174,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  No subsequent On Mesh prefix exists in the Thread Network Data.
      *
      */
-    otError GetNextOnMeshPrefix(Iterator &aIterator, OnMeshPrefixConfig &aConfig);
+    otError GetNextOnMeshPrefix(Iterator &aIterator, OnMeshPrefixConfig &aConfig) const;
 
     /**
      * This method provides the next On Mesh prefix in the Thread Network Data for a given RLOC16.
@@ -187,7 +187,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  No subsequent On Mesh prefix exists in the Thread Network Data.
      *
      */
-    otError GetNextOnMeshPrefix(Iterator &aIterator, uint16_t aRloc16, OnMeshPrefixConfig &aConfig);
+    otError GetNextOnMeshPrefix(Iterator &aIterator, uint16_t aRloc16, OnMeshPrefixConfig &aConfig) const;
 
     /**
      * This method provides the next external route in the Thread Network Data.
@@ -199,7 +199,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  No subsequent external route exists in the Thread Network Data.
      *
      */
-    otError GetNextExternalRoute(Iterator &aIterator, ExternalRouteConfig &aConfig);
+    otError GetNextExternalRoute(Iterator &aIterator, ExternalRouteConfig &aConfig) const;
 
     /**
      * This method provides the next external route in the Thread Network Data for a given RLOC16.
@@ -212,7 +212,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  No subsequent external route exists in the Thread Network Data.
      *
      */
-    otError GetNextExternalRoute(Iterator &aIterator, uint16_t aRloc16, ExternalRouteConfig &aConfig);
+    otError GetNextExternalRoute(Iterator &aIterator, uint16_t aRloc16, ExternalRouteConfig &aConfig) const;
 
     /**
      * This method provides the next service in the Thread Network Data.
@@ -224,7 +224,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  No subsequent service exists in the Thread Network Data.
      *
      */
-    otError GetNextService(Iterator &aIterator, ServiceConfig &aConfig);
+    otError GetNextService(Iterator &aIterator, ServiceConfig &aConfig) const;
 
     /**
      * This method provides the next service in the Thread Network Data for a given RLOC16.
@@ -237,7 +237,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  No subsequent service exists in the Thread Network Data.
      *
      */
-    otError GetNextService(Iterator &aIterator, uint16_t aRloc16, ServiceConfig &aConfig);
+    otError GetNextService(Iterator &aIterator, uint16_t aRloc16, ServiceConfig &aConfig) const;
 
     /**
      * This method provides the next Service ID in the Thread Network Data for a given RLOC16.
@@ -250,7 +250,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  No subsequent service exists in the Thread Network Data.
      *
      */
-    otError GetNextServiceId(Iterator &aIterator, uint16_t aRloc16, uint8_t &aServiceId);
+    otError GetNextServiceId(Iterator &aIterator, uint16_t aRloc16, uint8_t &aServiceId) const;
 
     /**
      * This method indicates whether or not the Thread Network Data contains all of the on mesh prefix information
@@ -263,7 +263,7 @@ public:
      *          FALSE otherwise.
      *
      */
-    bool ContainsOnMeshPrefixes(NetworkData &aCompare, uint16_t aRloc16);
+    bool ContainsOnMeshPrefixes(const NetworkData &aCompare, uint16_t aRloc16) const;
 
     /**
      * This method indicates whether or not the Thread Network Data contains all of the external route information
@@ -276,7 +276,7 @@ public:
      *          FALSE otherwise.
      *
      */
-    bool ContainsExternalRoutes(NetworkData &aCompare, uint16_t aRloc16);
+    bool ContainsExternalRoutes(const NetworkData &aCompare, uint16_t aRloc16) const;
 
     /**
      * This method indicates whether or not the Thread Network Data contains all of the service information
@@ -289,7 +289,7 @@ public:
      *          FALSE otherwise.
      *
      */
-    bool ContainsServices(NetworkData &aCompare, uint16_t aRloc16);
+    bool ContainsServices(const NetworkData &aCompare, uint16_t aRloc16) const;
 
     /**
      * This method indicates whether or not the Thread Network Data contains the service with given Service ID
@@ -302,7 +302,7 @@ public:
      *          FALSE otherwise.
      *
      */
-    bool ContainsService(uint8_t aServiceId, uint16_t aRloc16);
+    bool ContainsService(uint8_t aServiceId, uint16_t aRloc16) const;
 
     /**
      * This method provides the next server RLOC16 in the Thread Network Data.
@@ -314,7 +314,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  No subsequent server exists in the Thread Network Data.
      *
      */
-    otError GetNextServer(Iterator &aIterator, uint16_t &aRloc16);
+    otError GetNextServer(Iterator &aIterator, uint16_t &aRloc16) const;
 
 protected:
     /**
@@ -326,12 +326,28 @@ protected:
     NetworkDataTlv *GetTlvsStart(void) { return reinterpret_cast<NetworkDataTlv *>(mTlvs); }
 
     /**
+     * This method returns a pointer to the start of Network Data TLV sequence.
+     *
+     * @returns A pointer to the start of Network Data TLV sequence.
+     *
+     */
+    const NetworkDataTlv *GetTlvsStart(void) const { return reinterpret_cast<const NetworkDataTlv *>(mTlvs); }
+
+    /**
      * This method returns a pointer to the end of Network Data TLV sequence.
      *
      * @returns A pointer to the end of Network Data TLV sequence.
      *
      */
     NetworkDataTlv *GetTlvsEnd(void) { return reinterpret_cast<NetworkDataTlv *>(mTlvs + mLength); }
+
+    /**
+     * This method returns a pointer to the end of Network Data TLV sequence.
+     *
+     * @returns A pointer to the end of Network Data TLV sequence.
+     *
+     */
+    const NetworkDataTlv *GetTlvsEnd(void) const { return reinterpret_cast<const NetworkDataTlv *>(mTlvs + mLength); }
 
     /**
      * This method returns a pointer to the Border Router TLV within a given Prefix TLV.
@@ -341,7 +357,20 @@ protected:
      * @returns A pointer to the Border Router TLV if one is found or NULL if no Border Router TLV exists.
      *
      */
-    BorderRouterTlv *FindBorderRouter(PrefixTlv &aPrefix);
+    static BorderRouterTlv *FindBorderRouter(PrefixTlv &aPrefix)
+    {
+        return const_cast<BorderRouterTlv *>(FindBorderRouter(const_cast<const PrefixTlv &>(aPrefix)));
+    }
+
+    /**
+     * This method returns a pointer to the Border Router TLV within a given Prefix TLV.
+     *
+     * @param[in]  aPrefix  A reference to the Prefix TLV.
+     *
+     * @returns A pointer to the Border Router TLV if one is found or NULL if no Border Router TLV exists.
+     *
+     */
+    static const BorderRouterTlv *FindBorderRouter(const PrefixTlv &aPrefix);
 
     /**
      * This method returns a pointer to the stable or non-stable Border Router TLV within a given Prefix TLV.
@@ -352,7 +381,21 @@ protected:
      * @returns A pointer to the Border Router TLV if one is found or NULL if no Border Router TLV exists.
      *
      */
-    BorderRouterTlv *FindBorderRouter(PrefixTlv &aPrefix, bool aStable);
+    static BorderRouterTlv *FindBorderRouter(PrefixTlv &aPrefix, bool aStable)
+    {
+        return const_cast<BorderRouterTlv *>(FindBorderRouter(const_cast<const PrefixTlv &>(aPrefix), aStable));
+    }
+
+    /**
+     * This method returns a pointer to the stable or non-stable Border Router TLV within a given Prefix TLV.
+     *
+     * @param[in]  aPrefix  A reference to the Prefix TLV.
+     * @param[in]  aStable  TRUE to find a stable TLV, FALSE to find a TLV not marked as stable..
+     *
+     * @returns A pointer to the Border Router TLV if one is found or NULL if no Border Router TLV exists.
+     *
+     */
+    static const BorderRouterTlv *FindBorderRouter(const PrefixTlv &aPrefix, bool aStable);
 
     /**
      * This method returns a pointer to the Has Route TLV within a given Prefix TLV.
@@ -362,7 +405,20 @@ protected:
      * @returns A pointer to the Has Route TLV if one is found or NULL if no Has Route TLV exists.
      *
      */
-    HasRouteTlv *FindHasRoute(PrefixTlv &aPrefix);
+    static HasRouteTlv *FindHasRoute(PrefixTlv &aPrefix)
+    {
+        return const_cast<HasRouteTlv *>(FindHasRoute(const_cast<const PrefixTlv &>(aPrefix)));
+    }
+
+    /**
+     * This method returns a pointer to the Has Route TLV within a given Prefix TLV.
+     *
+     * @param[in]  aPrefix  A reference to the Prefix TLV.
+     *
+     * @returns A pointer to the Has Route TLV if one is found or NULL if no Has Route TLV exists.
+     *
+     */
+    static const HasRouteTlv *FindHasRoute(const PrefixTlv &aPrefix);
 
     /**
      * This method returns a pointer to the stable or non-stable Has Route TLV within a given Prefix TLV.
@@ -373,7 +429,21 @@ protected:
      * @returns A pointer to the Has Route TLV if one is found or NULL if no Has Route TLV exists.
      *
      */
-    HasRouteTlv *FindHasRoute(PrefixTlv &aPrefix, bool aStable);
+    static HasRouteTlv *FindHasRoute(PrefixTlv &aPrefix, bool aStable)
+    {
+        return const_cast<HasRouteTlv *>(FindHasRoute(const_cast<const PrefixTlv &>(aPrefix), aStable));
+    }
+
+    /**
+     * This method returns a pointer to the stable or non-stable Has Route TLV within a given Prefix TLV.
+     *
+     * @param[in]  aPrefix  A reference to the Prefix TLV.
+     * @param[in]  aStable  TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
+     *
+     * @returns A pointer to the Has Route TLV if one is found or NULL if no Has Route TLV exists.
+     *
+     */
+    static const HasRouteTlv *FindHasRoute(const PrefixTlv &aPrefix, bool aStable);
 
     /**
      * This method returns a pointer to the Context TLV within a given Prefix TLV.
@@ -383,7 +453,20 @@ protected:
      * @returns A pointer to the Context TLV is one is found or NULL if no Context TLV exists.
      *
      */
-    ContextTlv *FindContext(PrefixTlv &aPrefix);
+    static ContextTlv *FindContext(PrefixTlv &aPrefix)
+    {
+        return const_cast<ContextTlv *>(FindContext(const_cast<const PrefixTlv &>(aPrefix)));
+    }
+
+    /**
+     * This method returns a pointer to the Context TLV within a given Prefix TLV.
+     *
+     * @param[in]  aPrefix  A reference to the Prefix TLV.
+     *
+     * @returns A pointer to the Context TLV is one is found or NULL if no Context TLV exists.
+     *
+     */
+    static const ContextTlv *FindContext(const PrefixTlv &aPrefix);
 
     /**
      * This method returns a pointer to a Prefix TLV.
@@ -394,7 +477,21 @@ protected:
      * @returns A pointer to the Prefix TLV is one is found or NULL if no matching Prefix TLV exists.
      *
      */
-    PrefixTlv *FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength);
+    PrefixTlv *FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength)
+    {
+        return const_cast<PrefixTlv *>(const_cast<const NetworkData *>(this)->FindPrefix(aPrefix, aPrefixLength));
+    }
+
+    /**
+     * This method returns a pointer to a Prefix TLV.
+     *
+     * @param[in]  aPrefix        A pointer to an IPv6 prefix.
+     * @param[in]  aPrefixLength  The prefix length pointed to by @p aPrefix.
+     *
+     * @returns A pointer to the Prefix TLV is one is found or NULL if no matching Prefix TLV exists.
+     *
+     */
+    const PrefixTlv *FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength) const;
 
     /**
      * This method returns a pointer to a Prefix TLV in a specified tlvs buffer.
@@ -407,7 +504,27 @@ protected:
      * @returns A pointer to the Prefix TLV is one is found or NULL if no matching Prefix TLV exists.
      *
      */
-    PrefixTlv *FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, uint8_t *aTlvs, uint8_t aTlvsLength);
+    static PrefixTlv *FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, uint8_t *aTlvs, uint8_t aTlvsLength)
+    {
+        return const_cast<PrefixTlv *>(
+            FindPrefix(aPrefix, aPrefixLength, const_cast<const uint8_t *>(aTlvs), aTlvsLength));
+    }
+
+    /**
+     * This method returns a pointer to a Prefix TLV in a specified tlvs buffer.
+     *
+     * @param[in]  aPrefix        A pointer to an IPv6 prefix.
+     * @param[in]  aPrefixLength  The prefix length pointed to by @p aPrefix (in bits).
+     * @param[in]  aTlvs          A pointer to a specified tlvs buffer.
+     * @param[in]  aTlvsLength    The specified tlvs buffer length pointed to by @p aTlvs.
+     *
+     * @returns A pointer to the Prefix TLV is one is found or NULL if no matching Prefix TLV exists.
+     *
+     */
+    static const PrefixTlv *FindPrefix(const uint8_t *aPrefix,
+                                       uint8_t        aPrefixLength,
+                                       const uint8_t *aTlvs,
+                                       uint8_t        aTlvsLength);
 
     /**
      * This method returns a pointer to a matching Service TLV.
@@ -419,7 +536,25 @@ protected:
      * @returns A pointer to the Service TLV is one is found or NULL if no matching Service TLV exists.
      *
      */
-    ServiceTlv *FindService(uint32_t aEnterpriseNumber, const uint8_t *aServiceData, uint8_t aServiceDataLength);
+    ServiceTlv *FindService(uint32_t aEnterpriseNumber, const uint8_t *aServiceData, uint8_t aServiceDataLength)
+    {
+        return const_cast<ServiceTlv *>(
+            const_cast<const NetworkData *>(this)->FindService(aEnterpriseNumber, aServiceData, aServiceDataLength));
+    }
+
+    /**
+     * This method returns a pointer to a matching Service TLV.
+     *
+     * @param[in]  aEnterpriseNumber  Enterprise Number.
+     * @param[in]  aServiceData       A pointer to a Service Data.
+     * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
+     *
+     * @returns A pointer to the Service TLV is one is found or NULL if no matching Service TLV exists.
+     *
+     */
+    const ServiceTlv *FindService(uint32_t       aEnterpriseNumber,
+                                  const uint8_t *aServiceData,
+                                  uint8_t        aServiceDataLength) const;
 
     /**
      * This method returns a pointer to a Service TLV in a specified tlvs buffer.
@@ -433,11 +568,33 @@ protected:
      * @returns A pointer to the Service TLV is one is found or NULL if no matching Service TLV exists.
      *
      */
-    ServiceTlv *FindService(uint32_t       aEnterpriseNumber,
-                            const uint8_t *aServiceData,
-                            uint8_t        aServiceDataLength,
-                            uint8_t *      aTlvs,
-                            uint8_t        aTlvsLength);
+    static ServiceTlv *FindService(uint32_t       aEnterpriseNumber,
+                                   const uint8_t *aServiceData,
+                                   uint8_t        aServiceDataLength,
+                                   uint8_t *      aTlvs,
+                                   uint8_t        aTlvsLength)
+    {
+        return const_cast<ServiceTlv *>(FindService(aEnterpriseNumber, aServiceData, aServiceDataLength,
+                                                    const_cast<const uint8_t *>(aTlvs), aTlvsLength));
+    }
+
+    /**
+     * This method returns a pointer to a Service TLV in a specified tlvs buffer.
+     *
+     * @param[in]  aEnterpriseNumber  Enterprise Number.
+     * @param[in]  aServiceData       A pointer to an Service Data.
+     * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
+     * @param[in]  aTlvs              A pointer to a specified tlvs buffer.
+     * @param[in]  aTlvsLength        The specified tlvs buffer length pointed to by @p aTlvs.
+     *
+     * @returns A pointer to the Service TLV is one is found or NULL if no matching Service TLV exists.
+     *
+     */
+    static const ServiceTlv *FindService(uint32_t       aEnterpriseNumber,
+                                         const uint8_t *aServiceData,
+                                         uint8_t        aServiceDataLength,
+                                         const uint8_t *aTlvs,
+                                         uint8_t        aTlvsLength);
 
     /**
      * This method grows the Network Data to append a TLV with a requested size.
@@ -487,29 +644,7 @@ protected:
      *                             resulting Network Data in bytes.
      *
      */
-    void RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength);
-
-    /**
-     * This method strips non-stable Sub-TLVs from a Prefix TLV.
-     *
-     * @param[inout]  aData        A pointer to the Network Data to modify.
-     * @param[inout]  aDataLength  On entry, the size of the Network Data in bytes.  On exit, the size of the
-     *                             resulting Network Data in bytes.
-     * @param[inout]  aPrefix      A reference to the Prefix TLV to modify.
-     *
-     */
-    void RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, PrefixTlv &aPrefix);
-
-    /**
-     * This method strips non-stable Sub-TLVs from a Service TLV.
-     *
-     * @param[inout]  aData        A pointer to the Network Data to modify.
-     * @param[inout]  aDataLength  On entry, the size of the Network Data in bytes.  On exit, the size of the
-     *                             resulting Network Data in bytes.
-     * @param[inout]  aService     A reference to the Service TLV to modify.
-     *
-     */
-    void RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, ServiceTlv &aService);
+    static void RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength);
 
     /**
      * This method computes the number of IPv6 Prefix bits that match.
@@ -521,7 +656,7 @@ protected:
      * @returns The number of matching bits.
      *
      */
-    int8_t PrefixMatch(const uint8_t *a, const uint8_t *b, uint8_t aLength);
+    static int8_t PrefixMatch(const uint8_t *a, const uint8_t *b, uint8_t aLength);
 
     /**
      * This method sends a Server Data Notification message to the Leader.
@@ -546,7 +681,25 @@ protected:
      * @returns A pointer to the TLV if found, or NULL if not found.
      *
      */
-    static NetworkDataTlv *FindTlv(NetworkDataTlv *aStart, NetworkDataTlv *aEnd, NetworkDataTlv::Type aType);
+    static NetworkDataTlv *FindTlv(NetworkDataTlv *aStart, NetworkDataTlv *aEnd, NetworkDataTlv::Type aType)
+    {
+        return const_cast<NetworkDataTlv *>(
+            FindTlv(const_cast<const NetworkDataTlv *>(aStart), const_cast<const NetworkDataTlv *>(aEnd), aType));
+    }
+
+    /**
+     * This static method searches in a given sequence of TLVs to find the first TLV with a given TLV Type.
+     *
+     * @param[in]  aStart  A pointer to the start of the sequence of TLVs to search within.
+     * @param[in]  aEnd    A pointer to the end of the sequence of TLVs.
+     * @param[in]  aType   The TLV type to find.
+     *
+     * @returns A pointer to the TLV if found, or NULL if not found.
+     *
+     */
+    static const NetworkDataTlv *FindTlv(const NetworkDataTlv *aStart,
+                                         const NetworkDataTlv *aEnd,
+                                         NetworkDataTlv::Type  aType);
 
     /**
      * This static template method searches in a given sequence of TLVs to find the first TLV with a give template
@@ -564,6 +717,21 @@ protected:
     }
 
     /**
+     * This static template method searches in a given sequence of TLVs to find the first TLV with a give template
+     * `TlvType`.
+     *
+     * @param[in]  aStart  A pointer to the start of the sequence of TLVs to search within.
+     * @param[in]  aEnd    A pointer to the end of the sequence of TLVs.
+     *
+     * @returns A pointer to the TLV if found, or NULL if not found.
+     *
+     */
+    template <typename TlvType> static const TlvType *FindTlv(const NetworkDataTlv *aStart, const NetworkDataTlv *aEnd)
+    {
+        return static_cast<const TlvType *>(FindTlv(aStart, aEnd, static_cast<NetworkDataTlv::Type>(TlvType::kType)));
+    }
+
+    /**
      * This static method searches in a given sequence of TLVs to find the first TLV with a given TLV Type and stable
      * flag.
      *
@@ -578,7 +746,28 @@ protected:
     static NetworkDataTlv *FindTlv(NetworkDataTlv *     aStart,
                                    NetworkDataTlv *     aEnd,
                                    NetworkDataTlv::Type aType,
-                                   bool                 aStable);
+                                   bool                 aStable)
+    {
+        return const_cast<NetworkDataTlv *>(FindTlv(const_cast<const NetworkDataTlv *>(aStart),
+                                                    const_cast<const NetworkDataTlv *>(aEnd), aType, aStable));
+    }
+
+    /**
+     * This static method searches in a given sequence of TLVs to find the first TLV with a given TLV Type and stable
+     * flag.
+     *
+     * @param[in]  aStart  A pointer to the start of the sequence of TLVs to search within.
+     * @param [in] aEnd    A pointer to the end of the sequence of TLVs.
+     * @param[in]  aType   The TLV type to find.
+     * @param[in]  aStable TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
+     *
+     * @returns A pointer to the TLV if found, or NULL if not found.
+     *
+     */
+    static const NetworkDataTlv *FindTlv(const NetworkDataTlv *aStart,
+                                         const NetworkDataTlv *aEnd,
+                                         NetworkDataTlv::Type  aType,
+                                         bool                  aStable);
 
     /**
      * This template static method searches in a given sequence of TLVs to find the first TLV with a given TLV Type and
@@ -594,6 +783,24 @@ protected:
     template <typename TlvType> static TlvType *FindTlv(NetworkDataTlv *aStart, NetworkDataTlv *aEnd, bool aStable)
     {
         return static_cast<TlvType *>(
+            FindTlv(aStart, aEnd, static_cast<NetworkDataTlv::Type>(TlvType::kType), aStable));
+    }
+
+    /**
+     * This template static method searches in a given sequence of TLVs to find the first TLV with a given TLV Type and
+     * stable flag.
+     *
+     * @param[in]  aStart  A pointer to the start of the sequence of TLVs to search within.
+     * @param [in] aEnd    A pointer to the end of the sequence of TLVs.
+     * @param[in]  aStable TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
+     *
+     * @returns A pointer to the TLV if found, or NULL if not found.
+     *
+     */
+    template <typename TlvType>
+    static const TlvType *FindTlv(const NetworkDataTlv *aStart, const NetworkDataTlv *aEnd, bool aStable)
+    {
+        return static_cast<const TlvType *>(
             FindTlv(aStart, aEnd, static_cast<NetworkDataTlv::Type>(TlvType::kType), aStable));
     }
 
@@ -635,14 +842,15 @@ private:
         bool IsNewEntry(void) const { return GetEntryIndex() == 0; }
         void MarkEntryAsNotNew(void) { SetEntryIndex(1); }
 
-        NetworkDataTlv *GetTlv(uint8_t *aTlvs) const
+        const NetworkDataTlv *GetTlv(const uint8_t *aTlvs) const
         {
-            return reinterpret_cast<NetworkDataTlv *>(aTlvs + GetTlvOffset());
+            return reinterpret_cast<const NetworkDataTlv *>(aTlvs + GetTlvOffset());
         }
 
-        NetworkDataTlv *GetSubTlv(NetworkDataTlv *aSubTlvs)
+        const NetworkDataTlv *GetSubTlv(const NetworkDataTlv *aSubTlvs) const
         {
-            return reinterpret_cast<NetworkDataTlv *>(reinterpret_cast<uint8_t *>(aSubTlvs) + GetSubTlvOffset());
+            return reinterpret_cast<const NetworkDataTlv *>(reinterpret_cast<const uint8_t *>(aSubTlvs) +
+                                                            GetSubTlvOffset());
         }
 
         void SaveTlvOffset(const NetworkDataTlv *aTlv, const uint8_t *aTlvs)
@@ -668,26 +876,31 @@ private:
         uint8_t *mIteratorBuffer;
     };
 
+    static void RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, PrefixTlv &aPrefix);
+    static void RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, ServiceTlv &aService);
+
     static void Remove(uint8_t *aData, uint8_t &aDataLength, uint8_t *aRemoveStart, uint8_t aRemoveLength);
     static void RemoveTlv(uint8_t *aData, uint8_t &aDataLength, NetworkDataTlv *aTlv);
 
-    NetworkDataTlv *FindTlv(NetworkDataIterator &aIterator, NetworkDataTlv::Type aTlvType);
-    void            IterateToNextTlv(NetworkDataIterator &aIterator);
-    NetworkDataTlv *FindSubTlv(NetworkDataIterator &aIterator,
-                               NetworkDataTlv::Type aSubTlvType,
-                               NetworkDataTlv *     aSubTlvs,
-                               NetworkDataTlv *     aSubTlvsEnd);
-    void            IterateToNextSubTlv(NetworkDataIterator &aIterator, NetworkDataTlv *aSubTlvs);
+    const NetworkDataTlv *FindTlv(NetworkDataIterator &aIterator, NetworkDataTlv::Type aTlvType) const;
+    void                  IterateToNextTlv(NetworkDataIterator &aIterator) const;
+    const NetworkDataTlv *FindSubTlv(NetworkDataIterator & aIterator,
+                                     NetworkDataTlv::Type  aSubTlvType,
+                                     const NetworkDataTlv *aSubTlvs,
+                                     const NetworkDataTlv *aSubTlvsEnd) const;
+    void                  IterateToNextSubTlv(NetworkDataIterator &aIterator, const NetworkDataTlv *aSubTlvs) const;
 
-    template <typename TlvType> TlvType *FindTlv(NetworkDataIterator &aIterator)
+    template <typename TlvType> const TlvType *FindTlv(NetworkDataIterator &aIterator) const
     {
-        return static_cast<TlvType *>(FindTlv(aIterator, static_cast<NetworkDataTlv::Type>(TlvType::kType)));
+        return static_cast<const TlvType *>(FindTlv(aIterator, static_cast<NetworkDataTlv::Type>(TlvType::kType)));
     }
 
     template <typename TlvType>
-    TlvType *FindSubTlv(NetworkDataIterator &aIterator, NetworkDataTlv *aSubTlvs, NetworkDataTlv *aSubTlvsEnd)
+    const TlvType *FindSubTlv(NetworkDataIterator & aIterator,
+                              const NetworkDataTlv *aSubTlvs,
+                              const NetworkDataTlv *aSubTlvsEnd) const
     {
-        return static_cast<TlvType *>(
+        return static_cast<const TlvType *>(
             FindSubTlv(aIterator, static_cast<NetworkDataTlv::Type>(TlvType::kType), aSubTlvs, aSubTlvsEnd));
     }
 

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -71,7 +71,7 @@ otError LeaderBase::GetServiceId(uint32_t       aEnterpriseNumber,
                                  const uint8_t *aServiceData,
                                  uint8_t        aServiceDataLength,
                                  bool           aServerStable,
-                                 uint8_t &      aServiceId)
+                                 uint8_t &      aServiceId) const
 {
     otError         error    = OT_ERROR_NOT_FOUND;
     Iterator        iterator = kIteratorInit;
@@ -94,20 +94,20 @@ exit:
 }
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-otError LeaderBase::GetBackboneRouterPrimary(BackboneRouter::BackboneRouterConfig &aConfig)
+otError LeaderBase::GetBackboneRouterPrimary(BackboneRouter::BackboneRouterConfig &aConfig) const
 {
     otError                         error          = OT_ERROR_NOT_FOUND;
     uint8_t                         serviceData    = ServiceTlv::kServiceDataBackboneRouter;
-    ServerTlv *                     rvalServerTlv  = NULL;
+    const ServerTlv *               rvalServerTlv  = NULL;
     const BackboneRouterServerData *rvalServerData = NULL;
-    ServiceTlv *                    serviceTlv;
-    ServerTlv *                     serverTlv;
+    const ServiceTlv *              serviceTlv;
+    const ServerTlv *               serverTlv;
 
     serviceTlv = Get<Leader>().FindService(THREAD_ENTERPRISE_NUMBER, &serviceData, sizeof(serviceData));
 
     VerifyOrExit(serviceTlv != NULL, aConfig.mServer16 = Mac::kShortAddrInvalid);
 
-    for (NetworkDataTlv *start                                                         = serviceTlv->GetSubTlvs();
+    for (const NetworkDataTlv *start                                                   = serviceTlv->GetSubTlvs();
          (serverTlv = FindTlv<ServerTlv>(start, serviceTlv->GetNext())) != NULL; start = serverTlv->GetNext())
     {
         const BackboneRouterServerData *serverData =
@@ -138,11 +138,11 @@ exit:
 }
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
-PrefixTlv *LeaderBase::FindNextMatchingPrefix(const Ip6::Address &aAddress, PrefixTlv *aPrevTlv)
+const PrefixTlv *LeaderBase::FindNextMatchingPrefix(const Ip6::Address &aAddress, const PrefixTlv *aPrevTlv) const
 {
-    PrefixTlv *prefix;
+    const PrefixTlv *prefix;
 
-    for (NetworkDataTlv *start = (aPrevTlv == NULL) ? GetTlvsStart() : aPrevTlv->GetNext();
+    for (const NetworkDataTlv *start = (aPrevTlv == NULL) ? GetTlvsStart() : aPrevTlv->GetNext();
          (prefix = FindTlv<PrefixTlv>(start, GetTlvsEnd())) != NULL; start = prefix->GetNext())
     {
         if (PrefixMatch(prefix->GetPrefix(), aAddress.mFields.m8, prefix->GetPrefixLength()) >= 0)
@@ -155,10 +155,10 @@ exit:
     return prefix;
 }
 
-otError LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context &aContext)
+otError LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context &aContext) const
 {
-    PrefixTlv * prefix = NULL;
-    ContextTlv *contextTlv;
+    const PrefixTlv * prefix = NULL;
+    const ContextTlv *contextTlv;
 
     aContext.mPrefixLength = 0;
 
@@ -191,10 +191,10 @@ otError LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context &aC
     return (aContext.mPrefixLength > 0) ? OT_ERROR_NONE : OT_ERROR_NOT_FOUND;
 }
 
-otError LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext)
+otError LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext) const
 {
-    otError    error = OT_ERROR_NOT_FOUND;
-    PrefixTlv *prefix;
+    otError          error = OT_ERROR_NOT_FOUND;
+    const PrefixTlv *prefix;
 
     if (aContextId == Mle::kMeshLocalPrefixContextId)
     {
@@ -205,10 +205,10 @@ otError LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext)
         ExitNow(error = OT_ERROR_NONE);
     }
 
-    for (NetworkDataTlv *start = GetTlvsStart(); (prefix = FindTlv<PrefixTlv>(start, GetTlvsEnd())) != NULL;
-         start                 = prefix->GetNext())
+    for (const NetworkDataTlv *start = GetTlvsStart(); (prefix = FindTlv<PrefixTlv>(start, GetTlvsEnd())) != NULL;
+         start                       = prefix->GetNext())
     {
-        ContextTlv *contextTlv = FindContext(*prefix);
+        const ContextTlv *contextTlv = FindContext(*prefix);
 
         if ((contextTlv == NULL) || (contextTlv->GetContextId() != aContextId))
         {
@@ -226,7 +226,7 @@ exit:
     return error;
 }
 
-otError LeaderBase::GetRlocByContextId(uint8_t aContextId, uint16_t &aRloc16)
+otError LeaderBase::GetRlocByContextId(uint8_t aContextId, uint16_t &aRloc16) const
 {
     otError         error = OT_ERROR_NOT_FOUND;
     Lowpan::Context lowpanContext;
@@ -251,10 +251,10 @@ exit:
     return error;
 }
 
-bool LeaderBase::IsOnMesh(const Ip6::Address &aAddress)
+bool LeaderBase::IsOnMesh(const Ip6::Address &aAddress) const
 {
-    PrefixTlv *prefix = NULL;
-    bool       rval   = false;
+    const PrefixTlv *prefix = NULL;
+    bool             rval   = false;
 
     VerifyOrExit(!Get<Mle::MleRouter>().IsMeshLocalAddress(aAddress), rval = true);
 
@@ -275,10 +275,10 @@ exit:
 otError LeaderBase::RouteLookup(const Ip6::Address &aSource,
                                 const Ip6::Address &aDestination,
                                 uint8_t *           aPrefixMatch,
-                                uint16_t *          aRloc16)
+                                uint16_t *          aRloc16) const
 {
-    otError    error  = OT_ERROR_NO_ROUTE;
-    PrefixTlv *prefix = NULL;
+    otError          error  = OT_ERROR_NO_ROUTE;
+    const PrefixTlv *prefix = NULL;
 
     while ((prefix = FindNextMatchingPrefix(aSource, prefix)) != NULL)
     {
@@ -305,18 +305,18 @@ exit:
 otError LeaderBase::ExternalRouteLookup(uint8_t             aDomainId,
                                         const Ip6::Address &aDestination,
                                         uint8_t *           aPrefixMatch,
-                                        uint16_t *          aRloc16)
+                                        uint16_t *          aRloc16) const
 {
-    otError        error = OT_ERROR_NO_ROUTE;
-    PrefixTlv *    prefix;
-    HasRouteEntry *rvalRoute = NULL;
-    uint8_t        rval_plen = 0;
+    otError              error = OT_ERROR_NO_ROUTE;
+    const PrefixTlv *    prefix;
+    const HasRouteEntry *rvalRoute = NULL;
+    uint8_t              rval_plen = 0;
 
-    for (NetworkDataTlv *start = GetTlvsStart(); (prefix = FindTlv<PrefixTlv>(start, GetTlvsEnd())) != NULL;
-         start                 = prefix->GetNext())
+    for (const NetworkDataTlv *start = GetTlvsStart(); (prefix = FindTlv<PrefixTlv>(start, GetTlvsEnd())) != NULL;
+         start                       = prefix->GetNext())
     {
-        HasRouteTlv *hasRoute;
-        int8_t       plen;
+        const HasRouteTlv *hasRoute;
+        int8_t             plen;
 
         if (prefix->GetDomainId() != aDomainId)
         {
@@ -330,11 +330,11 @@ otError LeaderBase::ExternalRouteLookup(uint8_t             aDomainId,
             continue;
         }
 
-        for (NetworkDataTlv *subStart                                                         = prefix->GetSubTlvs();
+        for (const NetworkDataTlv *subStart                                                   = prefix->GetSubTlvs();
              (hasRoute = FindTlv<HasRouteTlv>(subStart, prefix->GetNext())) != NULL; subStart = hasRoute->GetNext())
         {
-            for (HasRouteEntry *entry = hasRoute->GetFirstEntry(); entry <= hasRoute->GetLastEntry();
-                 entry                = entry->GetNext())
+            for (const HasRouteEntry *entry = hasRoute->GetFirstEntry(); entry <= hasRoute->GetLastEntry();
+                 entry                      = entry->GetNext())
             {
                 if (rvalRoute == NULL || entry->GetPreference() > rvalRoute->GetPreference() ||
                     (entry->GetPreference() == rvalRoute->GetPreference() &&
@@ -368,17 +368,17 @@ otError LeaderBase::ExternalRouteLookup(uint8_t             aDomainId,
     return error;
 }
 
-otError LeaderBase::DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16)
+otError LeaderBase::DefaultRouteLookup(const PrefixTlv &aPrefix, uint16_t *aRloc16) const
 {
-    otError            error = OT_ERROR_NO_ROUTE;
-    BorderRouterTlv *  borderRouter;
-    BorderRouterEntry *route = NULL;
+    otError                  error = OT_ERROR_NO_ROUTE;
+    const BorderRouterTlv *  borderRouter;
+    const BorderRouterEntry *route = NULL;
 
-    for (NetworkDataTlv *start                                                              = aPrefix.GetSubTlvs();
+    for (const NetworkDataTlv *start                                                        = aPrefix.GetSubTlvs();
          (borderRouter = FindTlv<BorderRouterTlv>(start, aPrefix.GetNext())) != NULL; start = borderRouter->GetNext())
     {
-        for (BorderRouterEntry *entry = borderRouter->GetFirstEntry(); entry <= borderRouter->GetLastEntry();
-             entry                    = entry->GetNext())
+        for (const BorderRouterEntry *entry = borderRouter->GetFirstEntry(); entry <= borderRouter->GetLastEntry();
+             entry                          = entry->GetNext())
         {
             if (!entry->IsDefaultRoute())
             {
@@ -476,23 +476,23 @@ exit:
     return error;
 }
 
-CommissioningDataTlv *LeaderBase::GetCommissioningData(void)
+const CommissioningDataTlv *LeaderBase::GetCommissioningData(void) const
 {
     return FindTlv<CommissioningDataTlv>(GetTlvsStart(), GetTlvsEnd());
 }
 
-MeshCoP::Tlv *LeaderBase::GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aType)
+const MeshCoP::Tlv *LeaderBase::GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aType) const
 {
-    MeshCoP::Tlv *  rval = NULL;
-    NetworkDataTlv *commissioningDataTlv;
-    MeshCoP::Tlv *  cur;
-    MeshCoP::Tlv *  end;
+    const MeshCoP::Tlv *  rval = NULL;
+    const NetworkDataTlv *commissioningDataTlv;
+    const MeshCoP::Tlv *  cur;
+    const MeshCoP::Tlv *  end;
 
     commissioningDataTlv = GetCommissioningData();
     VerifyOrExit(commissioningDataTlv != NULL);
 
-    cur = reinterpret_cast<MeshCoP::Tlv *>(commissioningDataTlv->GetValue());
-    end = reinterpret_cast<MeshCoP::Tlv *>(commissioningDataTlv->GetValue() + commissioningDataTlv->GetLength());
+    cur = reinterpret_cast<const MeshCoP::Tlv *>(commissioningDataTlv->GetValue());
+    end = reinterpret_cast<const MeshCoP::Tlv *>(commissioningDataTlv->GetValue() + commissioningDataTlv->GetLength());
 
     for (; cur < end; cur = cur->GetNext())
     {
@@ -506,10 +506,10 @@ exit:
     return rval;
 }
 
-bool LeaderBase::IsJoiningEnabled(void)
+bool LeaderBase::IsJoiningEnabled(void) const
 {
-    MeshCoP::Tlv *steeringData;
-    bool          rval = false;
+    const MeshCoP::Tlv *steeringData;
+    bool                rval = false;
 
     VerifyOrExit(GetCommissioningDataSubTlv(MeshCoP::Tlv::kBorderAgentLocator) != NULL);
 

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -109,7 +109,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  Could not find the 6LoWPAN Context information.
      *
      */
-    otError GetContext(const Ip6::Address &aAddress, Lowpan::Context &aContext);
+    otError GetContext(const Ip6::Address &aAddress, Lowpan::Context &aContext) const;
 
     /**
      * This method retrieves the 6LoWPAN Context information based on a given Context ID.
@@ -121,7 +121,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  Could not find the 6LoWPAN Context information.
      *
      */
-    otError GetContext(uint8_t aContextId, Lowpan::Context &aContext);
+    otError GetContext(uint8_t aContextId, Lowpan::Context &aContext) const;
 
     /**
      * This method indicates whether or not the given IPv6 address is on-mesh.
@@ -132,7 +132,7 @@ public:
      * @retval FALSE  If @p aAddress if not on-link.
      *
      */
-    bool IsOnMesh(const Ip6::Address &aAddress);
+    bool IsOnMesh(const Ip6::Address &aAddress) const;
 
     /**
      * This method performs a route lookup using the Network Data.
@@ -149,7 +149,7 @@ public:
     otError RouteLookup(const Ip6::Address &aSource,
                         const Ip6::Address &aDestination,
                         uint8_t *           aPrefixMatch,
-                        uint16_t *          aRloc16);
+                        uint16_t *          aRloc16) const;
 
     /**
      * This method is used by non-Leader devices to set newly received Network Data from the Leader.
@@ -187,7 +187,18 @@ public:
      * @returns A pointer to the Commissioning Data or NULL if no Commissioning Data exists.
      *
      */
-    CommissioningDataTlv *GetCommissioningData(void);
+    CommissioningDataTlv *GetCommissioningData(void)
+    {
+        return const_cast<CommissioningDataTlv *>(const_cast<const LeaderBase *>(this)->GetCommissioningData());
+    }
+
+    /**
+     * This method returns a pointer to the Commissioning Data.
+     *
+     * @returns A pointer to the Commissioning Data or NULL if no Commissioning Data exists.
+     *
+     */
+    const CommissioningDataTlv *GetCommissioningData(void) const;
 
     /**
      * This method returns a pointer to the Commissioning Data Sub-TLV.
@@ -197,7 +208,20 @@ public:
      * @returns A pointer to the Commissioning Data Sub-TLV or NULL if no Sub-TLV exists.
      *
      */
-    MeshCoP::Tlv *GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aType);
+    MeshCoP::Tlv *GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aType)
+    {
+        return const_cast<MeshCoP::Tlv *>(const_cast<const LeaderBase *>(this)->GetCommissioningDataSubTlv(aType));
+    }
+
+    /**
+     * This method returns a pointer to the Commissioning Data Sub-TLV.
+     *
+     * @param[in]  aType  The TLV type value.
+     *
+     * @returns A pointer to the Commissioning Data Sub-TLV or NULL if no Sub-TLV exists.
+     *
+     */
+    const MeshCoP::Tlv *GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aType) const;
 
     /**
      * This method indicates whether or not the Commissioning Data TLV indicates Joining is enabled.
@@ -207,7 +231,7 @@ public:
      * @returns TRUE if the Commissioning Data TLV says Joining is enabled, FALSE otherwise.
      *
      */
-    bool IsJoiningEnabled(void);
+    bool IsJoiningEnabled(void) const;
 
     /**
      * This method adds Commissioning Data to the Thread Network Data.
@@ -231,7 +255,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  The specified @p aContextId could not be found.
      *
      */
-    otError GetRlocByContextId(uint8_t aContextId, uint16_t &aRloc16);
+    otError GetRlocByContextId(uint8_t aContextId, uint16_t &aRloc16) const;
 
     /**
      * This method gets the Service ID for the specified service.
@@ -250,7 +274,7 @@ public:
                          const uint8_t *aServiceData,
                          uint8_t        aServiceDataLength,
                          bool           aServerStable,
-                         uint8_t &      aServiceId);
+                         uint8_t &      aServiceId) const;
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
     /**
@@ -262,7 +286,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  No Backbone Router Service in the Thread Network.
      *
      */
-    otError GetBackboneRouterPrimary(BackboneRouter::BackboneRouterConfig &aConfig);
+    otError GetBackboneRouterPrimary(BackboneRouter::BackboneRouterConfig &aConfig) const;
 #endif
 
 protected:
@@ -270,15 +294,15 @@ protected:
     uint8_t mVersion;
 
 private:
-    PrefixTlv *FindNextMatchingPrefix(const Ip6::Address &aAddress, PrefixTlv *aPrevTlv);
+    const PrefixTlv *FindNextMatchingPrefix(const Ip6::Address &aAddress, const PrefixTlv *aPrevTlv) const;
 
     otError RemoveCommissioningData(void);
 
     otError ExternalRouteLookup(uint8_t             aDomainId,
                                 const Ip6::Address &aDestination,
                                 uint8_t *           aPrefixMatch,
-                                uint16_t *          aRloc16);
-    otError DefaultRouteLookup(PrefixTlv &aPrefix, uint16_t *aRloc16);
+                                uint16_t *          aRloc16) const;
+    otError DefaultRouteLookup(const PrefixTlv &aPrefix, uint16_t *aRloc16) const;
 };
 
 /**

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -402,21 +402,21 @@ bool Leader::RlocMatch(uint16_t aFirstRloc16, uint16_t aSecondRloc16, MatchMode 
     return matched;
 }
 
-otError Leader::RlocLookup(uint16_t  aRloc16,
-                           bool &    aIn,
-                           bool &    aStable,
-                           uint8_t * aTlvs,
-                           uint8_t   aTlvsLength,
-                           MatchMode aMatchMode,
-                           bool      aAllowOtherEntries)
+otError Leader::RlocLookup(uint16_t       aRloc16,
+                           bool &         aIn,
+                           bool &         aStable,
+                           const uint8_t *aTlvs,
+                           uint8_t        aTlvsLength,
+                           MatchMode      aMatchMode,
+                           bool           aAllowOtherEntries)
 {
-    otError         error = OT_ERROR_NONE;
-    NetworkDataTlv *end   = reinterpret_cast<NetworkDataTlv *>(aTlvs + aTlvsLength);
+    otError               error = OT_ERROR_NONE;
+    const NetworkDataTlv *end   = reinterpret_cast<const NetworkDataTlv *>(aTlvs + aTlvsLength);
 
     aIn     = false;
     aStable = false;
 
-    for (NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(aTlvs); cur < end; cur = cur->GetNext())
+    for (const NetworkDataTlv *cur = reinterpret_cast<const NetworkDataTlv *>(aTlvs); cur < end; cur = cur->GetNext())
     {
         VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, error = OT_ERROR_PARSE);
 
@@ -424,14 +424,14 @@ otError Leader::RlocLookup(uint16_t  aRloc16,
         {
         case NetworkDataTlv::kTypePrefix:
         {
-            PrefixTlv *     prefix = static_cast<PrefixTlv *>(cur);
-            NetworkDataTlv *subEnd;
+            const PrefixTlv *     prefix = static_cast<const PrefixTlv *>(cur);
+            const NetworkDataTlv *subEnd;
 
             VerifyOrExit(prefix->IsValid(), error = OT_ERROR_PARSE);
 
             subEnd = prefix->GetNext();
 
-            for (NetworkDataTlv *subCur = prefix->GetSubTlvs(); subCur < subEnd; subCur = subCur->GetNext())
+            for (const NetworkDataTlv *subCur = prefix->GetSubTlvs(); subCur < subEnd; subCur = subCur->GetNext())
             {
                 VerifyOrExit((subCur + 1) <= subEnd && subCur->GetNext() <= subEnd, error = OT_ERROR_PARSE);
 
@@ -439,9 +439,9 @@ otError Leader::RlocLookup(uint16_t  aRloc16,
                 {
                 case NetworkDataTlv::kTypeBorderRouter:
                 {
-                    BorderRouterTlv *borderRouter = static_cast<BorderRouterTlv *>(subCur);
+                    const BorderRouterTlv *borderRouter = static_cast<const BorderRouterTlv *>(subCur);
 
-                    for (BorderRouterEntry *borderRouterEntry = borderRouter->GetFirstEntry();
+                    for (const BorderRouterEntry *borderRouterEntry = borderRouter->GetFirstEntry();
                          borderRouterEntry <= borderRouter->GetLastEntry();
                          borderRouterEntry = borderRouterEntry->GetNext())
                     {
@@ -465,9 +465,9 @@ otError Leader::RlocLookup(uint16_t  aRloc16,
 
                 case NetworkDataTlv::kTypeHasRoute:
                 {
-                    HasRouteTlv *hasRoute = static_cast<HasRouteTlv *>(subCur);
+                    const HasRouteTlv *hasRoute = static_cast<const HasRouteTlv *>(subCur);
 
-                    for (HasRouteEntry *hasRouteEntry                             = hasRoute->GetFirstEntry();
+                    for (const HasRouteEntry *hasRouteEntry                       = hasRoute->GetFirstEntry();
                          hasRouteEntry <= hasRoute->GetLastEntry(); hasRouteEntry = hasRouteEntry->GetNext())
                     {
                         if (RlocMatch(hasRouteEntry->GetRloc(), aRloc16, aMatchMode))
@@ -502,14 +502,14 @@ otError Leader::RlocLookup(uint16_t  aRloc16,
 
         case NetworkDataTlv::kTypeService:
         {
-            ServiceTlv *    service = static_cast<ServiceTlv *>(cur);
-            NetworkDataTlv *subEnd;
+            const ServiceTlv *    service = static_cast<const ServiceTlv *>(cur);
+            const NetworkDataTlv *subEnd;
 
             VerifyOrExit(service->IsValid(), error = OT_ERROR_PARSE);
 
             subEnd = service->GetNext();
 
-            for (NetworkDataTlv *subCur = service->GetSubTlvs(); subCur < subEnd; subCur = subCur->GetNext())
+            for (const NetworkDataTlv *subCur = service->GetSubTlvs(); subCur < subEnd; subCur = subCur->GetNext())
             {
                 VerifyOrExit((subCur + 1) <= subEnd && subCur->GetNext() <= subEnd, error = OT_ERROR_PARSE);
 
@@ -517,7 +517,7 @@ otError Leader::RlocLookup(uint16_t  aRloc16,
                 {
                 case NetworkDataTlv::kTypeServer:
                 {
-                    ServerTlv *server = static_cast<ServerTlv *>(subCur);
+                    const ServerTlv *server = static_cast<const ServerTlv *>(subCur);
 
                     VerifyOrExit(server->IsValid(), error = OT_ERROR_PARSE);
 
@@ -560,12 +560,15 @@ exit:
     return error;
 }
 
-bool Leader::IsStableUpdated(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvsBase, uint8_t aTlvsBaseLength)
+bool Leader::IsStableUpdated(const uint8_t *aTlvs,
+                             uint8_t        aTlvsLength,
+                             const uint8_t *aTlvsBase,
+                             uint8_t        aTlvsBaseLength)
 {
-    bool            rval = false;
-    NetworkDataTlv *end  = reinterpret_cast<NetworkDataTlv *>(aTlvs + aTlvsLength);
+    bool                  rval = false;
+    const NetworkDataTlv *end  = reinterpret_cast<const NetworkDataTlv *>(aTlvs + aTlvsLength);
 
-    for (NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(aTlvs); cur < end; cur = cur->GetNext())
+    for (const NetworkDataTlv *cur = reinterpret_cast<const NetworkDataTlv *>(aTlvs); cur < end; cur = cur->GetNext())
     {
         VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
 
@@ -573,14 +576,14 @@ bool Leader::IsStableUpdated(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvs
         {
         case NetworkDataTlv::kTypePrefix:
         {
-            PrefixTlv *      prefix       = static_cast<PrefixTlv *>(cur);
-            ContextTlv *     context      = FindContext(*prefix);
-            BorderRouterTlv *borderRouter = FindBorderRouter(*prefix, true);
-            HasRouteTlv *    hasRoute     = FindHasRoute(*prefix, true);
+            const PrefixTlv *      prefix       = static_cast<const PrefixTlv *>(cur);
+            const ContextTlv *     context      = FindContext(*prefix);
+            const BorderRouterTlv *borderRouter = FindBorderRouter(*prefix, true);
+            const HasRouteTlv *    hasRoute     = FindHasRoute(*prefix, true);
 
             if (cur->IsStable() && (!context || borderRouter))
             {
-                PrefixTlv *prefixBase =
+                const PrefixTlv *prefixBase =
                     FindPrefix(prefix->GetPrefix(), prefix->GetPrefixLength(), aTlvsBase, aTlvsBaseLength);
 
                 if (!prefixBase)
@@ -590,7 +593,7 @@ bool Leader::IsStableUpdated(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvs
 
                 if (borderRouter)
                 {
-                    BorderRouterTlv *borderRouterBase = FindBorderRouter(*prefixBase, true);
+                    const BorderRouterTlv *borderRouterBase = FindBorderRouter(*prefixBase, true);
 
                     if (!borderRouterBase || (borderRouter->GetLength() != borderRouterBase->GetLength()) ||
                         (memcmp(borderRouter, borderRouterBase, borderRouter->GetLength()) != 0))
@@ -601,7 +604,7 @@ bool Leader::IsStableUpdated(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvs
 
                 if (hasRoute)
                 {
-                    HasRouteTlv *hasRouteBase = FindHasRoute(*prefixBase, true);
+                    const HasRouteTlv *hasRouteBase = FindHasRoute(*prefixBase, true);
 
                     if (!hasRouteBase || (hasRoute->GetLength() != hasRouteBase->GetLength()) ||
                         (memcmp(hasRoute, hasRouteBase, hasRoute->GetLength()) != 0))
@@ -616,15 +619,16 @@ bool Leader::IsStableUpdated(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvs
 
         case NetworkDataTlv::kTypeService:
         {
-            ServiceTlv *service = static_cast<ServiceTlv *>(cur);
+            const ServiceTlv *service = static_cast<const ServiceTlv *>(cur);
 
             if (cur->IsStable())
             {
-                NetworkDataTlv *curInner;
-                NetworkDataTlv *endInner;
+                const NetworkDataTlv *curInner;
+                const NetworkDataTlv *endInner;
 
-                ServiceTlv *serviceBase = FindService(service->GetEnterpriseNumber(), service->GetServiceData(),
-                                                      service->GetServiceDataLength(), aTlvsBase, aTlvsBaseLength);
+                const ServiceTlv *serviceBase =
+                    FindService(service->GetEnterpriseNumber(), service->GetServiceData(),
+                                service->GetServiceDataLength(), aTlvsBase, aTlvsBaseLength);
 
                 if (!serviceBase || !serviceBase->IsStable())
                 {
@@ -644,15 +648,15 @@ bool Leader::IsStableUpdated(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvs
                         {
                         case NetworkDataTlv::kTypeServer:
                         {
-                            bool       foundInBase = false;
-                            ServerTlv *server      = static_cast<ServerTlv *>(curInner);
+                            bool             foundInBase = false;
+                            const ServerTlv *server      = static_cast<const ServerTlv *>(curInner);
 
-                            NetworkDataTlv *curServerBase = serviceBase->GetSubTlvs();
-                            NetworkDataTlv *endServerBase = serviceBase->GetNext();
+                            const NetworkDataTlv *curServerBase = serviceBase->GetSubTlvs();
+                            const NetworkDataTlv *endServerBase = serviceBase->GetNext();
 
                             while (curServerBase < endServerBase)
                             {
-                                ServerTlv *serverBase = static_cast<ServerTlv *>(curServerBase);
+                                const ServerTlv *serverBase = static_cast<const ServerTlv *>(curServerBase);
 
                                 VerifyOrExit((curServerBase + 1) <= endServerBase &&
                                              curServerBase->GetNext() <= endServerBase);
@@ -976,10 +980,10 @@ exit:
     return error;
 }
 
-ServiceTlv *Leader::FindServiceById(uint8_t aServiceId)
+const ServiceTlv *Leader::FindServiceById(uint8_t aServiceId) const
 {
-    NetworkDataTlv *start = GetTlvsStart();
-    ServiceTlv *    service;
+    const NetworkDataTlv *start = GetTlvsStart();
+    const ServiceTlv *    service;
 
     while ((service = FindTlv<ServiceTlv>(start, GetTlvsEnd())) != NULL)
     {

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -155,7 +155,7 @@ public:
      * @return Pointer to the Service TLV for given Service ID, or NULL if not present.
      *
      */
-    ServiceTlv *FindServiceById(uint8_t aServiceId);
+    const ServiceTlv *FindServiceById(uint8_t aServiceId) const;
 
     /**
      * This method sends SVR_DATA.ntf message for any stale child entries that exist in the network data.
@@ -204,15 +204,18 @@ private:
 
     static bool RlocMatch(uint16_t aFirstRloc16, uint16_t aSecondRloc16, MatchMode aMatchMode);
 
-    otError RlocLookup(uint16_t  aRloc16,
-                       bool &    aIn,
-                       bool &    aStable,
-                       uint8_t * aTlvs,
-                       uint8_t   aTlvsLength,
-                       MatchMode aMatchMode,
-                       bool      aAllowOtherEntries = true);
+    static otError RlocLookup(uint16_t       aRloc16,
+                              bool &         aIn,
+                              bool &         aStable,
+                              const uint8_t *aTlvs,
+                              uint8_t        aTlvsLength,
+                              MatchMode      aMatchMode,
+                              bool           aAllowOtherEntries = true);
 
-    bool IsStableUpdated(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aTlvsBase, uint8_t aTlvsBaseLength);
+    static bool IsStableUpdated(const uint8_t *aTlvs,
+                                uint8_t        aTlvsLength,
+                                const uint8_t *aTlvsBase,
+                                uint8_t        aTlvsBaseLength);
 
     static void HandleCommissioningSet(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleCommissioningSet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -181,13 +181,13 @@ void Local::UpdateRloc(PrefixTlv &aPrefix)
     }
 }
 
-bool Local::IsOnMeshPrefixConsistent(void)
+bool Local::IsOnMeshPrefixConsistent(void) const
 {
     return (Get<Leader>().ContainsOnMeshPrefixes(*this, Get<Mle::MleRouter>().GetRloc16()) &&
             ContainsOnMeshPrefixes(Get<Leader>(), Get<Mle::MleRouter>().GetRloc16()));
 }
 
-bool Local::IsExternalRouteConsistent(void)
+bool Local::IsExternalRouteConsistent(void) const
 {
     return (Get<Leader>().ContainsExternalRoutes(*this, Get<Mle::MleRouter>().GetRloc16()) &&
             ContainsExternalRoutes(Get<Leader>(), Get<Mle::MleRouter>().GetRloc16()));
@@ -277,7 +277,7 @@ void Local::UpdateRloc(ServiceTlv &aService)
     }
 }
 
-bool Local::IsServiceConsistent(void)
+bool Local::IsServiceConsistent(void) const
 {
     return (Get<Leader>().ContainsServices(*this, Get<Mle::MleRouter>().GetRloc16()) &&
             ContainsServices(Get<Leader>(), Get<Mle::MleRouter>().GetRloc16()));

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -186,13 +186,13 @@ private:
                       bool                 aStable);
     otError RemovePrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, NetworkDataTlv::Type aSubTlvType);
     void    UpdateRloc(PrefixTlv &aPrefix);
-    bool    IsOnMeshPrefixConsistent(void);
-    bool    IsExternalRouteConsistent(void);
+    bool    IsOnMeshPrefixConsistent(void) const;
+    bool    IsExternalRouteConsistent(void) const;
 #endif
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     void UpdateRloc(ServiceTlv &aService);
-    bool IsServiceConsistent(void);
+    bool IsServiceConsistent(void) const;
 #endif
 
     uint16_t mOldRloc;

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -138,6 +138,14 @@ public:
     uint8_t *GetValue(void) { return reinterpret_cast<uint8_t *>(this) + sizeof(NetworkDataTlv); }
 
     /**
+     * This method returns a pointer to the Value.
+     *
+     * @returns A pointer to the value.
+     *
+     */
+    const uint8_t *GetValue(void) const { return reinterpret_cast<const uint8_t *>(this) + sizeof(NetworkDataTlv); }
+
+    /**
      * This method returns a pointer to the next Network Data TLV.
      *
      * @returns A pointer to the next Network Data TLV.
@@ -146,6 +154,18 @@ public:
     NetworkDataTlv *GetNext(void)
     {
         return reinterpret_cast<NetworkDataTlv *>(reinterpret_cast<uint8_t *>(this) + sizeof(*this) + mLength);
+    }
+
+    /**
+     * This method returns a pointer to the next Network Data TLV.
+     *
+     * @returns A pointer to the next Network Data TLV.
+     *
+     */
+    const NetworkDataTlv *GetNext(void) const
+    {
+        return reinterpret_cast<const NetworkDataTlv *>(reinterpret_cast<const uint8_t *>(this) + sizeof(*this) +
+                                                        mLength);
     }
 
     /**
@@ -242,6 +262,14 @@ public:
      */
     HasRouteEntry *GetNext(void) { return (this + 1); }
 
+    /**
+     * This method returns a pointer to the next HasRouteEntry.
+     *
+     * @returns A pointer to the next HasRouteEntry.
+     *
+     */
+    const HasRouteEntry *GetNext(void) const { return (this + 1); }
+
 private:
     enum
     {
@@ -299,12 +327,33 @@ public:
     }
 
     /**
+     * This method returns a pointer to the i'th HasRoute entry.
+     *
+     * @param[in]  i  An index.
+     *
+     * @returns A pointer to the i'th HasRoute entry.
+     *
+     */
+    const HasRouteEntry *GetEntry(uint8_t i) const
+    {
+        return reinterpret_cast<const HasRouteEntry *>(GetValue() + (i * sizeof(HasRouteEntry)));
+    }
+
+    /**
      * This method returns a pointer to the first HasRouteEntry (at index 0'th).
      *
      * @returns A pointer to the first HasRouteEntry.
      *
      */
     HasRouteEntry *GetFirstEntry(void) { return reinterpret_cast<HasRouteEntry *>(GetValue()); }
+
+    /**
+     * This method returns a pointer to the first HasRouteEntry (at index 0'th).
+     *
+     * @returns A pointer to the first HasRouteEntry.
+     *
+     */
+    const HasRouteEntry *GetFirstEntry(void) const { return reinterpret_cast<const HasRouteEntry *>(GetValue()); }
 
     /**
      * This method returns a pointer to the last HasRouteEntry.
@@ -318,6 +367,20 @@ public:
     {
         return reinterpret_cast<HasRouteEntry *>(GetValue() + GetLength() - sizeof(HasRouteEntry));
     }
+
+    /**
+     * This method returns a pointer to the last HasRouteEntry.
+     *
+     * If there are no entries the pointer will be invalid but guaranteed to be before the `GetFirstEntry()` pointer.
+     *
+     * @returns A pointer to the last HasRouteEntry.
+     *
+     */
+    const HasRouteEntry *GetLastEntry(void) const
+    {
+        return reinterpret_cast<const HasRouteEntry *>(GetValue() + GetLength() - sizeof(HasRouteEntry));
+    }
+
 } OT_TOOL_PACKED_END;
 
 /**
@@ -390,6 +453,14 @@ public:
     uint8_t *GetPrefix(void) { return reinterpret_cast<uint8_t *>(this) + sizeof(*this); }
 
     /**
+     * This method returns a pointer to the Prefix.
+     *
+     * @returns A pointer to the Prefix.
+     *
+     */
+    const uint8_t *GetPrefix(void) const { return reinterpret_cast<const uint8_t *>(this) + sizeof(*this); }
+
+    /**
      * This method returns a pointer to the Sub-TLVs.
      *
      * @returns A pointer to the Sub-TLVs.
@@ -398,6 +469,17 @@ public:
     NetworkDataTlv *GetSubTlvs(void)
     {
         return reinterpret_cast<NetworkDataTlv *>(GetPrefix() + BitVectorBytes(mPrefixLength));
+    }
+
+    /**
+     * This method returns a pointer to the Sub-TLVs.
+     *
+     * @returns A pointer to the Sub-TLVs.
+     *
+     */
+    const NetworkDataTlv *GetSubTlvs(void) const
+    {
+        return reinterpret_cast<const NetworkDataTlv *>(GetPrefix() + BitVectorBytes(mPrefixLength));
     }
 
     /**
@@ -642,6 +724,14 @@ public:
      */
     BorderRouterEntry *GetNext(void) { return (this + 1); }
 
+    /**
+     * This method returns a pointer to the next BorderRouterEntry
+     *
+     * @returns A pointer to the next BorderRouterEntry.
+     *
+     */
+    const BorderRouterEntry *GetNext(void) const { return (this + 1); }
+
 private:
     uint16_t mRloc;
     uint8_t  mFlags;
@@ -694,12 +784,36 @@ public:
     }
 
     /**
+     * This method returns a pointer to the i'th Border Router entry.
+     *
+     * @param[in]  i  The index.
+     *
+     * @returns A pointer to the i'th Border Router entry.
+     *
+     */
+    const BorderRouterEntry *GetEntry(uint8_t i) const
+    {
+        return reinterpret_cast<const BorderRouterEntry *>(GetValue() + (i * sizeof(BorderRouterEntry)));
+    }
+
+    /**
      * This method returns a pointer to the first BorderRouterEntry (at index 0'th).
      *
      * @returns A pointer to the first BorderRouterEntry.
      *
      */
     BorderRouterEntry *GetFirstEntry(void) { return reinterpret_cast<BorderRouterEntry *>(GetValue()); }
+
+    /**
+     * This method returns a pointer to the first BorderRouterEntry (at index 0'th).
+     *
+     * @returns A pointer to the first BorderRouterEntry.
+     *
+     */
+    const BorderRouterEntry *GetFirstEntry(void) const
+    {
+        return reinterpret_cast<const BorderRouterEntry *>(GetValue());
+    }
 
     /**
      * This method returns a pointer to the last BorderRouterEntry.
@@ -713,6 +827,20 @@ public:
     {
         return reinterpret_cast<BorderRouterEntry *>(GetValue() + GetLength() - sizeof(BorderRouterEntry));
     }
+
+    /**
+     * This method returns a pointer to the last BorderRouterEntry.
+     *
+     * If there are no entries the pointer will be invalid but guaranteed to be before the `GetFirstEntry()` pointer.
+     *
+     * @returns A pointer to the last BorderRouterEntry.
+     *
+     */
+    const BorderRouterEntry *GetLastEntry(void) const
+    {
+        return reinterpret_cast<const BorderRouterEntry *>(GetValue() + GetLength() - sizeof(BorderRouterEntry));
+    }
+
 } OT_TOOL_PACKED_END;
 
 /**
@@ -849,7 +977,9 @@ public:
 
     /**
      * This method initializes the TLV.
+     *
      * Initial length is set to 2, to hold S_service_data_length field.
+     *
      */
     void Init(void)
     {
@@ -867,7 +997,7 @@ public:
      * @retval FALSE  If the TLV does not appear to be well-formed.
      *
      */
-    bool IsValid(void)
+    bool IsValid(void) const
     {
         uint8_t length = GetLength();
         return ((length >= (sizeof(*this) - sizeof(NetworkDataTlv))) &&
@@ -881,13 +1011,15 @@ public:
      * This method gets Service Data length.
      *
      * @returns length of the Service Data field in bytes.
+     *
      */
-    uint8_t GetServiceDataLength(void) { return *GetServiceDataLengthLocation(); }
+    uint8_t GetServiceDataLength(void) const { return *GetServiceDataLengthLocation(); }
 
     /**
      * This method sets Service Data length.
      *
-     * @param aServiceDataLength desired length of the Service Data field in bytes.
+     * @param[in] aServiceDataLength desired length of the Service Data field in bytes.
+     *
      */
     void SetServiceDataLength(uint8_t aServiceDataLength) { *GetServiceDataLengthLocation() = aServiceDataLength; }
 
@@ -895,8 +1027,17 @@ public:
      * This method returns a pointer to the Service Data.
      *
      * @returns A pointer to the Service Data.
+     *
      */
     uint8_t *GetServiceData(void) { return GetServiceDataLengthLocation() + sizeof(uint8_t); }
+
+    /**
+     * This method returns a pointer to the Service Data.
+     *
+     * @returns A pointer to the Service Data.
+     *
+     */
+    const uint8_t *GetServiceData(void) const { return GetServiceDataLengthLocation() + sizeof(uint8_t); }
 
     /**
      * This method sets Service Data to the given values.
@@ -905,6 +1046,7 @@ public:
      *
      * @param aServiceData       pointer to the service data to use
      * @param aServiceDataLength length of the provided service data in bytes
+     *
      */
     void SetServiceData(const uint8_t *aServiceData, uint8_t aServiceDataLength)
     {
@@ -917,8 +1059,9 @@ public:
      * This method returns Enterprise Number field.
      *
      * @returns Enterprise Number
+     *
      */
-    uint32_t GetEnterpriseNumber(void)
+    uint32_t GetEnterpriseNumber(void) const
     {
         if (IsThreadEnterprise())
         {
@@ -927,7 +1070,7 @@ public:
         else
         {
             // This memory access most likely will not be aligned to 4 bytes
-            return HostSwap32(*reinterpret_cast<uint32_t *>(GetEnterpriseNumberLocation()));
+            return HostSwap32(*reinterpret_cast<const uint32_t *>(GetEnterpriseNumberLocation()));
         }
     }
 
@@ -935,6 +1078,7 @@ public:
      * This method returns the T flag. It is set when Enterprise Number is equal to THREAD_ENTERPRISE_NUMBER.
      *
      * @returns Flag whether Enterprise Number is equal to THREAD_ENTERPRISE_NUMBER
+     *
      */
     bool IsThreadEnterprise(void) const { return (mTResSId & kTMask) != 0; }
 
@@ -946,6 +1090,7 @@ public:
      * memory corruption) so modification of Enterprise Number must be done before adding any content to the TLV.
      *
      * @param [in] aEnterpriseNumber Enterprise Number
+     *
      */
     void SetEnterpriseNumber(uint32_t aEnterpriseNumber)
     {
@@ -966,6 +1111,7 @@ public:
      * This method returns length of the S_enterprise_number TLV field in bytes, for given Enterprise Number.
      *
      * @returns length of the S_enterprise_number field in bytes
+     *
      */
     static uint8_t GetEnterpriseNumberFieldLength(uint32_t aEnterpriseNumber)
     {
@@ -983,6 +1129,7 @@ public:
      * This method returns Service ID. It is in range 0x00-0x0f.
      *
      * @returns Service ID
+     *
      */
     uint8_t GetServiceId(void) const { return (mTResSId & kSIdMask) >> kSIdOffset; }
 
@@ -990,6 +1137,7 @@ public:
      * This method sets Service ID.
      *
      * @param [in] aServiceId Service ID to be set. Expected range: 0x00-0x0f.
+     *
      */
     void SetServiceId(uint8_t aServiceId)
     {
@@ -1032,25 +1180,31 @@ public:
                                                   GetServiceDataLength());
     }
 
-private:
     /**
-     * This method returns pointer to where mServiceDataLength would be.
+     * This method returns a pointer to the Sub-TLVs.
      *
-     * @returns pointer to service data length location
+     * @returns A pointer to the Sub-TLVs.
+     *
      */
+    const NetworkDataTlv *GetSubTlvs(void) const
+    {
+        return reinterpret_cast<const NetworkDataTlv *>(GetServiceDataLengthLocation() + sizeof(uint8_t) +
+                                                        GetServiceDataLength());
+    }
+
+private:
     uint8_t *GetServiceDataLengthLocation(void)
     {
         return GetEnterpriseNumberLocation() + (IsThreadEnterprise() ? 0 : sizeof(uint32_t));
     }
 
-    /**
-     * This method returns pointer to where mEnterpriseNumber would be.
-     *
-     * Note: this method returns uint8_t*, not uint32_t*.
-     *
-     * @returns pointer to enterprise number location
-     */
-    uint8_t *GetEnterpriseNumberLocation(void) { return &mTResSId + sizeof(mTResSId); }
+    const uint8_t *GetServiceDataLengthLocation(void) const
+    {
+        return GetEnterpriseNumberLocation() + (IsThreadEnterprise() ? 0 : sizeof(uint32_t));
+    }
+
+    uint8_t *      GetEnterpriseNumberLocation(void) { return &mTResSId + sizeof(mTResSId); }
+    const uint8_t *GetEnterpriseNumberLocation(void) const { return &mTResSId + sizeof(mTResSId); }
 
     enum
     {
@@ -1100,6 +1254,7 @@ public:
      * This method returns the S_server_16 value.
      *
      * @returns The S_server_16 value.
+     *
      */
     uint16_t GetServer16(void) const { return HostSwap16(mServer16); }
 
@@ -1115,8 +1270,9 @@ public:
      * This method returns a pointer to the Server Data.
      *
      * @returns A pointer to the Server Data.
+     *
      */
-    const uint8_t *GetServerData(void) { return reinterpret_cast<uint8_t *>(this) + sizeof(*this); }
+    const uint8_t *GetServerData(void) const { return reinterpret_cast<const uint8_t *>(this) + sizeof(*this); }
 
     /**
      * This method sets Server Data to the given values.


### PR DESCRIPTION
This commit declares methods, input parameters, and local variables as
`const` whenever possible in `NetworkData` modules. `const` versions
of methods (returning `const` pointer) are also added, e.g.,
`NetworkDataTlv::GetNext()`, `HasRouteTlv::GetFirstEntry()`,
`NetworkData::FindTlv()`, etc. For simpler (inline) methods, the
`const` version is directly implemented but for more complex methods,
the const version is the main implementation (defined in `cpp` file)
and non-`const` version is implemented using `const_cast` conversions
from the `const` method.

This commit also declares methods not using any member variable/info
as `static` (e.g. `FindHasRoute()` or `FindContext()`). It also
declares `RemoveTemporaryData()` flavors removing internal sub-TLVs as
`private` (instead of `protected`) and fixes the logging in
`RemoveTemporaryData()` using input `aTlvs` now instead of `mTlvs`.