### PR TITLE
[network-data-notifier] fix flag for child removed notification

### DIFF
--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -108,12 +108,14 @@ void Notifier::HandleStateChanged(ot::Notifier::Callback &aCallback, otChangedFl
 
 void Notifier::HandleStateChanged(otChangedFlags aFlags)
 {
-    if (aFlags & (OT_CHANGED_THREAD_ROLE | OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED))
+    if (aFlags &
+        (static_cast<uint32_t>(OT_CHANGED_THREAD_ROLE) | static_cast<uint32_t>(OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED)))
     {
         mNextDelay = 0;
     }
 
-    if (aFlags & (OT_CHANGED_THREAD_NETDATA | OT_CHANGED_THREAD_ROLE | OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED))
+    if (aFlags & (static_cast<uint32_t>(OT_CHANGED_THREAD_NETDATA) | static_cast<uint32_t>(OT_CHANGED_THREAD_ROLE) |
+                  static_cast<uint32_t>(OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED)))
     {
         SynchronizeServerData();
     }

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -108,14 +108,12 @@ void Notifier::HandleStateChanged(ot::Notifier::Callback &aCallback, otChangedFl
 
 void Notifier::HandleStateChanged(otChangedFlags aFlags)
 {
-    if (aFlags &
-        (static_cast<uint32_t>(OT_CHANGED_THREAD_ROLE) | static_cast<uint32_t>(OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED)))
+    if (aFlags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_THREAD_CHILD_REMOVED))
     {
         mNextDelay = 0;
     }
 
-    if (aFlags & (static_cast<uint32_t>(OT_CHANGED_THREAD_NETDATA) | static_cast<uint32_t>(OT_CHANGED_THREAD_ROLE) |
-                  static_cast<uint32_t>(OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED)))
+    if (aFlags & (OT_CHANGED_THREAD_NETDATA | OT_CHANGED_THREAD_ROLE | OT_CHANGED_THREAD_CHILD_REMOVED))
     {
         SynchronizeServerData();
     }


### PR DESCRIPTION
This PR fixes IAR compilation error:
Error[Pa089]: enumerated type mixed with another enumerated type