### PR TITLE
[network-data] simplify ServiceTlv

### DIFF
--- a/src/core/backbone_router/leader.cpp
+++ b/src/core/backbone_router/leader.cpp
@@ -80,8 +80,8 @@ otError Leader::GetServiceId(uint8_t &aServiceId) const
 
     VerifyOrExit(HasPrimary(), error = OT_ERROR_NOT_FOUND);
 
-    error = Get<NetworkData::Leader>().GetServiceId(THREAD_ENTERPRISE_NUMBER, &serviceData, sizeof(serviceData), true,
-                                                    aServiceId);
+    error = Get<NetworkData::Leader>().GetServiceId(NetworkData::ServiceTlv::kThreadEnterpriseNumber, &serviceData,
+                                                    sizeof(serviceData), true, aServiceId);
 
 exit:
     return error;

--- a/src/core/backbone_router/local.cpp
+++ b/src/core/backbone_router/local.cpp
@@ -154,7 +154,7 @@ otError Local::AddService(bool aForce)
     serverData.SetMlrTimeout(mMlrTimeout);
 
     SuccessOrExit(error = Get<NetworkData::Local>().AddService(
-                      THREAD_ENTERPRISE_NUMBER, &serviceData, sizeof(serviceData), true,
+                      NetworkData::ServiceTlv::kThreadEnterpriseNumber, &serviceData, sizeof(serviceData), true,
                       reinterpret_cast<const uint8_t *>(&serverData), sizeof(serverData)));
 
     mIsServiceAdded = true;
@@ -173,8 +173,8 @@ otError Local::RemoveService(void)
     otError error       = OT_ERROR_NONE;
     uint8_t serviceData = NetworkData::ServiceTlv::kServiceDataBackboneRouter;
 
-    SuccessOrExit(
-        error = Get<NetworkData::Local>().RemoveService(THREAD_ENTERPRISE_NUMBER, &serviceData, sizeof(serviceData)));
+    SuccessOrExit(error = Get<NetworkData::Local>().RemoveService(NetworkData::ServiceTlv::kThreadEnterpriseNumber,
+                                                                  &serviceData, sizeof(serviceData)));
 
     mIsServiceAdded = false;
     Get<NetworkData::Notifier>().HandleServerDataUpdated();

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -103,7 +103,7 @@ otError LeaderBase::GetBackboneRouterPrimary(BackboneRouter::BackboneRouterConfi
     const ServiceTlv *              serviceTlv;
     const ServerTlv *               serverTlv;
 
-    serviceTlv = Get<Leader>().FindService(THREAD_ENTERPRISE_NUMBER, &serviceData, sizeof(serviceData));
+    serviceTlv = Get<Leader>().FindService(ServiceTlv::kThreadEnterpriseNumber, &serviceData, sizeof(serviceData));
 
     VerifyOrExit(serviceTlv != NULL, aConfig.mServer16 = Mac::kShortAddrInvalid);
 

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -206,22 +206,18 @@ otError Local::AddService(uint32_t       aEnterpriseNumber,
     otError     error = OT_ERROR_NONE;
     ServiceTlv *serviceTlv;
     ServerTlv * serverTlv;
-    size_t      serviceTlvLength =
-        (sizeof(ServiceTlv) - sizeof(NetworkDataTlv)) + aServiceDataLength + sizeof(uint8_t) /*mServiceDataLength*/ +
-        ServiceTlv::GetEnterpriseNumberFieldLength(aEnterpriseNumber) + aServerDataLength + sizeof(ServerTlv);
+    size_t      serviceTlvSize =
+        ServiceTlv::GetSize(aEnterpriseNumber, aServiceDataLength) + sizeof(ServerTlv) + aServerDataLength;
 
     RemoveService(aEnterpriseNumber, aServiceData, aServiceDataLength);
 
-    VerifyOrExit(serviceTlvLength + sizeof(NetworkDataTlv) <= kMaxSize, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit(serviceTlvSize <= kMaxSize, error = OT_ERROR_NO_BUFS);
 
-    serviceTlv = static_cast<ServiceTlv *>(AppendTlv(static_cast<uint8_t>(serviceTlvLength + sizeof(NetworkDataTlv))));
+    serviceTlv = static_cast<ServiceTlv *>(AppendTlv(static_cast<uint8_t>(serviceTlvSize)));
     VerifyOrExit(serviceTlv != NULL, error = OT_ERROR_NO_BUFS);
 
-    serviceTlv->Init();
-    serviceTlv->SetEnterpriseNumber(aEnterpriseNumber);
-    serviceTlv->SetServiceId(0);
-    serviceTlv->SetServiceData(aServiceData, aServiceDataLength);
-    serviceTlv->SetLength(static_cast<uint8_t>(serviceTlvLength));
+    serviceTlv->Init(/* aServiceId */ 0, aEnterpriseNumber, aServiceData, aServiceDataLength);
+    serviceTlv->SetSubTlvsLength(sizeof(ServerTlv) + aServerDataLength);
 
     serverTlv = static_cast<ServerTlv *>(serviceTlv->GetSubTlvs());
     serverTlv->Init();


### PR DESCRIPTION
This commit updates the `ServiceTlv` implementation and its use.

- Set the `ServiceTlv` fields through a new `Init()`
- Use union for managing presence of Enterprise Number field
- Add static helper `GetSize()` to get the size of a Service TLV
  with a given Enterprise number and Service Data length.
- Add `ServiceTlv::kThreadEnterpriseNumber` constant replacing the
  `THREAD_ENTERPRISE_NUMBER` definition.