### PR TITLE
[compiler] avoid use of compiler extensions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,7 +51,7 @@ if(CMAKE_COMPILER_IS_GNUCC OR CMAKE_C_COMPILER_ID MATCHES "(Apple)?[Cc]lang")
 
     set(OT_CFLAGS
         $<$<COMPILE_LANGUAGE:C>:${OT_CFLAGS} -Wall -Wextra -Wshadow -pedantic-errors>
-        $<$<COMPILE_LANGUAGE:CXX>:${OT_CFLAGS} -Wall -Wextra -Wshadow -Wno-c++14-compat -fno-exceptions>
+        $<$<COMPILE_LANGUAGE:CXX>:${OT_CFLAGS} -Wall -Wextra -Wshadow -Wno-c++14-compat -fno-exceptions -pedantic-errors>
     )
 endif()
 

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -33,7 +33,7 @@ set_target_properties(
     openthread-cli-ftd openthread-cli-mtd
     PROPERTIES
         C_STANDARD 99
-        CXX_STANDARD 98
+        CXX_STANDARD 11
 )
 
 target_compile_definitions(openthread-cli-ftd PRIVATE

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2229,8 +2229,8 @@ void Interpreter::HandleIcmpReceive(otMessage *          aMessage,
     uint32_t timestamp = 0;
     uint16_t dataSize;
 
-    VerifyOrExit(aIcmpHeader->mType == OT_ICMP6_TYPE_ECHO_REPLY);
-    VerifyOrExit((mPingIdentifier != 0) && (mPingIdentifier == HostSwap16(aIcmpHeader->mData.m16[0])));
+    VerifyOrExit(aIcmpHeader->mType == OT_ICMP6_TYPE_ECHO_REPLY, OT_NOOP);
+    VerifyOrExit((mPingIdentifier != 0) && (mPingIdentifier == HostSwap16(aIcmpHeader->mData.m16[0])), OT_NOOP);
 
     dataSize = otMessageGetLength(aMessage) - otMessageGetOffset(aMessage);
     mServer->OutputFormat("%u bytes from ", dataSize + static_cast<uint16_t>(sizeof(otIcmp6Header)));
@@ -2344,7 +2344,7 @@ void Interpreter::SendPing(void)
     messageInfo.mAllowZeroHopLimit = mPingAllowZeroHopLimit;
 
     message = otIp6NewMessage(mInstance, NULL);
-    VerifyOrExit(message != NULL);
+    VerifyOrExit(message != NULL, OT_NOOP);
 
     SuccessOrExit(otMessageAppend(message, &timestamp, sizeof(timestamp)));
     SuccessOrExit(otMessageSetLength(message, mPingLength));
@@ -3672,7 +3672,7 @@ otError Interpreter::ProcessMacFilterAddress(uint8_t aArgsLength, char *aArgs[])
 
             error = otLinkFilterAddAddress(mInstance, &extAddr);
 
-            VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY);
+            VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY, OT_NOOP);
 
             if (aArgsLength > 2)
             {
@@ -3906,7 +3906,7 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength, Server &aServer)
 
     mServer = &aServer;
 
-    VerifyOrExit(aBuf != NULL && StringLength(aBuf, aBufLength + 1) <= aBufLength);
+    VerifyOrExit(aBuf != NULL && StringLength(aBuf, aBufLength + 1) <= aBufLength, OT_NOOP);
 
     VerifyOrExit(Utils::CmdLineParser::ParseCmd(aBuf, aArgsLength, aArgs, kMaxArgs) == OT_ERROR_NONE,
                  mServer->OutputFormat("Error: too many args (max %d)\r\n", kMaxArgs));
@@ -4344,7 +4344,7 @@ extern "C" void otCliPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, cons
     OT_UNUSED_VARIABLE(aLogLevel);
     OT_UNUSED_VARIABLE(aLogRegion);
 
-    VerifyOrExit(Server::sServer != NULL);
+    VerifyOrExit(Server::sServer != NULL, OT_NOOP);
 
     Server::sServer->OutputFormatV(aFormat, aArgs);
     Server::sServer->OutputFormat("\r\n");

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -294,7 +294,7 @@ int Uart::Output(const char *aBuf, uint16_t aBufLength)
 
 void Uart::Send(void)
 {
-    VerifyOrExit(mSendLength == 0);
+    VerifyOrExit(mSendLength == 0, OT_NOOP);
 
     if (mTxLength > kTxBufferSize - mTxHead)
     {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -34,7 +34,7 @@ set_target_properties(
     openthread-ftd openthread-mtd openthread-radio
     PROPERTIES
         C_STANDARD 99
-        CXX_STANDARD 98
+        CXX_STANDARD 11
 )
 
 target_compile_definitions(openthread-ftd PRIVATE

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -191,7 +191,7 @@ otMessage *otIp6NewMessageFromBuffer(otInstance *             aInstance,
     Instance &instance = *static_cast<Instance *>(aInstance);
     Message * message;
 
-    VerifyOrExit((message = instance.Get<Ip6::Ip6>().NewMessage(aData, aDataLength, aSettings)) != NULL);
+    VerifyOrExit((message = instance.Get<Ip6::Ip6>().NewMessage(aData, aDataLength, aSettings)) != NULL, OT_NOOP);
 
 exit:
     return message;

--- a/src/core/api/tasklet_api.cpp
+++ b/src/core/api/tasklet_api.cpp
@@ -46,7 +46,7 @@ void otTaskletsProcess(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(otInstanceIsInitialized(aInstance));
+    VerifyOrExit(otInstanceIsInitialized(aInstance), OT_NOOP);
     instance.Get<TaskletScheduler>().ProcessQueuedTasklets();
 
 exit:
@@ -58,7 +58,7 @@ bool otTaskletsArePending(otInstance *aInstance)
     bool      retval   = false;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(otInstanceIsInitialized(aInstance));
+    VerifyOrExit(otInstanceIsInitialized(aInstance), OT_NOOP);
     retval = instance.Get<TaskletScheduler>().AreTaskletsPending();
 
 exit:

--- a/src/core/backbone_router/local.cpp
+++ b/src/core/backbone_router/local.cpp
@@ -61,7 +61,7 @@ Local::Local(Instance &aInstance)
 
 void Local::SetEnabled(bool aEnable)
 {
-    VerifyOrExit(aEnable == (mState == OT_BACKBONE_ROUTER_STATE_DISABLED));
+    VerifyOrExit(aEnable == (mState == OT_BACKBONE_ROUTER_STATE_DISABLED), OT_NOOP);
 
     if (aEnable)
     {
@@ -84,7 +84,7 @@ exit:
 
 void Local::Reset(void)
 {
-    VerifyOrExit(mState != OT_BACKBONE_ROUTER_STATE_DISABLED);
+    VerifyOrExit(mState != OT_BACKBONE_ROUTER_STATE_DISABLED, OT_NOOP);
 
     if (RemoveService() == OT_ERROR_NONE)
     {
@@ -151,13 +151,14 @@ otError Local::AddService(bool aForce)
     uint8_t                               serviceData = NetworkData::ServiceTlv::kServiceDataBackboneRouter;
     NetworkData::BackboneRouterServerData serverData;
 
-    VerifyOrExit(mState != OT_BACKBONE_ROUTER_STATE_DISABLED && Get<Mle::Mle>().IsAttached());
+    VerifyOrExit(mState != OT_BACKBONE_ROUTER_STATE_DISABLED && Get<Mle::Mle>().IsAttached(), OT_NOOP);
 
     VerifyOrExit(aForce /* if register by force */ ||
-                 !Get<BackboneRouter::Leader>().HasPrimary() /* if no available Backbone Router service */ ||
-                 Get<BackboneRouter::Leader>().GetServer16() == Get<Mle::MleRouter>().GetRloc16()
+                     !Get<BackboneRouter::Leader>().HasPrimary() /* if no available Backbone Router service */ ||
+                     Get<BackboneRouter::Leader>().GetServer16() == Get<Mle::MleRouter>().GetRloc16()
                  /* If the device itself should be BBR. */
-    );
+                 ,
+                 OT_NOOP);
 
     serverData.SetSequenceNumber(mSequenceNumber);
     serverData.SetReregistrationDelay(mReregistrationDelay);
@@ -191,7 +192,7 @@ exit:
 
 void Local::SetState(BackboneRouterState aState)
 {
-    VerifyOrExit(mState != aState);
+    VerifyOrExit(mState != aState, OT_NOOP);
 
     mState = aState;
     Get<Notifier>().Signal(OT_CHANGED_THREAD_BACKBONE_ROUTER_STATE);
@@ -204,7 +205,7 @@ void Local::UpdateBackboneRouterPrimary(Leader::State aState, const BackboneRout
 {
     OT_UNUSED_VARIABLE(aState);
 
-    VerifyOrExit(mState != OT_BACKBONE_ROUTER_STATE_DISABLED && Get<Mle::MleRouter>().IsAttached());
+    VerifyOrExit(mState != OT_BACKBONE_ROUTER_STATE_DISABLED && Get<Mle::MleRouter>().IsAttached(), OT_NOOP);
 
     // Wait some jitter before trying to Register.
     if (aConfig.mServer16 == Mac::kShortAddrInvalid)

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -117,7 +117,7 @@ Message *CoapBase::NewMessage(const otMessageSettings *aSettings)
 {
     Message *message = NULL;
 
-    VerifyOrExit((message = static_cast<Message *>(Get<Ip6::Udp>().NewMessage(0, aSettings))) != NULL);
+    VerifyOrExit((message = static_cast<Message *>(Get<Ip6::Udp>().NewMessage(0, aSettings))) != NULL, OT_NOOP);
     message->SetOffset(0);
 
 exit:
@@ -560,7 +560,7 @@ void CoapBase::ProcessReceivedResponse(Message &aMessage, const Ip6::MessageInfo
 #endif
 
     request = FindRelatedRequest(aMessage, aMessageInfo, metadata);
-    VerifyOrExit(request != NULL);
+    VerifyOrExit(request != NULL, OT_NOOP);
 
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
     if (metadata.mObserve && request->IsRequest())
@@ -721,7 +721,7 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
                 *curUriPath++ = '/';
             }
 
-            VerifyOrExit(option->mLength < sizeof(uriPath) - static_cast<size_t>(curUriPath + 1 - uriPath));
+            VerifyOrExit(option->mLength < sizeof(uriPath) - static_cast<size_t>(curUriPath + 1 - uriPath), OT_NOOP);
 
             iterator.GetOptionValue(curUriPath);
             curUriPath += option->mLength;
@@ -837,11 +837,11 @@ void ResponsesQueue::EnqueueResponse(Message &               aMessage,
     metadata.mDequeueTime = TimerMilli::GetNow() + aTxParameters.CalculateExchangeLifetime();
     metadata.mMessageInfo = aMessageInfo;
 
-    VerifyOrExit(FindMatchedResponse(aMessage, aMessageInfo) == NULL);
+    VerifyOrExit(FindMatchedResponse(aMessage, aMessageInfo) == NULL, OT_NOOP);
 
     UpdateQueue();
 
-    VerifyOrExit((responseCopy = aMessage.Clone()) != NULL);
+    VerifyOrExit((responseCopy = aMessage.Clone()) != NULL, OT_NOOP);
 
     VerifyOrExit(metadata.AppendTo(*responseCopy) == OT_ERROR_NONE, responseCopy->Free());
 
@@ -950,7 +950,7 @@ static uint32_t Multiply(uint32_t aValueA, uint32_t aValueB)
 {
     uint32_t result = 0;
 
-    VerifyOrExit(aValueA);
+    VerifyOrExit(aValueA, OT_NOOP);
 
     result = aValueA * aValueB;
     result = (result / aValueA == aValueB) ? result : 0;

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -304,7 +304,7 @@ Message *Message::Clone(uint16_t aLength) const
 {
     Message *message = static_cast<Message *>(ot::Message::Clone(aLength));
 
-    VerifyOrExit(message != NULL);
+    VerifyOrExit(message != NULL, OT_NOOP);
 
     memcpy(&message->GetHelpData(), &GetHelpData(), sizeof(GetHelpData()));
 

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -207,7 +207,8 @@ void CoapSecure::HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength)
 {
     ot::Message *message = NULL;
 
-    VerifyOrExit((message = Get<MessagePool>().New(Message::kTypeIp6, Message::GetHelpDataReserved())) != NULL);
+    VerifyOrExit((message = Get<MessagePool>().New(Message::kTypeIp6, Message::GetHelpDataReserved())) != NULL,
+                 OT_NOOP);
     SuccessOrExit(message->Append(aBuf, aLength));
 
     CoapBase::Receive(*message, mDtls.GetPeerAddress());
@@ -230,7 +231,7 @@ void CoapSecure::HandleTransmit(void)
     otError      error   = OT_ERROR_NONE;
     ot::Message *message = mTransmitQueue.GetHead();
 
-    VerifyOrExit(message != NULL);
+    VerifyOrExit(message != NULL, OT_NOOP);
     mTransmitQueue.Dequeue(*message);
 
     if (mTransmitQueue.GetHead() != NULL)

--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -99,21 +99,27 @@
     } while (false)
 
 /**
+ * Use this macro in conjunction with `VerifyOrExit()` when no action is specified.
+ *
+ */
+#define OT_NOOP
+
+/**
  * This macro checks for the specified condition, which is expected to commonly be true, and both executes @a ... and
  * branches to the local label 'exit' if the condition is false.
  *
  * @param[in]  aCondition  A Boolean expression to be evaluated.
- * @param[in]  ...         An expression or block to execute when the assertion fails.
+ * @param[in]  aAction     An expression or block to execute when the assertion fails.
  *
  */
-#define VerifyOrExit(aCondition, ...) \
-    do                                \
-    {                                 \
-        if (!(aCondition))            \
-        {                             \
-            __VA_ARGS__;              \
-            goto exit;                \
-        }                             \
+#define VerifyOrExit(aCondition, aAction) \
+    do                                    \
+    {                                     \
+        if (!(aCondition))                \
+        {                                 \
+            aAction;                      \
+            goto exit;                    \
+        }                                 \
     } while (false)
 
 /**

--- a/src/core/common/extension_example.cpp
+++ b/src/core/common/extension_example.cpp
@@ -68,7 +68,7 @@ ExtensionBase &ExtensionBase::Init(Instance &aInstance)
 {
     ExtensionBase *ext = reinterpret_cast<ExtensionBase *>(&sExtensionRaw);
 
-    VerifyOrExit(!ext->mIsInitialized);
+    VerifyOrExit(!ext->mIsInitialized, OT_NOOP);
 
     ext = new (&sExtensionRaw) Extension(aInstance);
 

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -120,7 +120,7 @@ Instance &Instance::InitSingle(void)
 {
     Instance *instance = &Get();
 
-    VerifyOrExit(!instance->mIsInitialized);
+    VerifyOrExit(!instance->mIsInitialized, OT_NOOP);
 
     instance = new (&gInstanceRaw) Instance();
 
@@ -184,7 +184,7 @@ void Instance::AfterInit(void)
 
 void Instance::Finalize(void)
 {
-    VerifyOrExit(mIsInitialized);
+    VerifyOrExit(mIsInitialized, OT_NOOP);
 
     mIsInitialized = false;
 

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -44,8 +44,7 @@
 #error OPENTHREAD_CONFIG_ENABLE_DEBUG_UART_LOG requires OPENTHREAD_CONFIG_ENABLE_DEBUG_UART
 #endif
 
-#define otLogDump(aFormat, ...) \
-    _otDynamicLog(aLogLevel, aLogRegion, aFormat OPENTHREAD_CONFIG_LOG_SUFFIX, ##__VA_ARGS__)
+#define otLogDump(aFormat, ...) _otDynamicLog(aLogLevel, aLogRegion, aFormat OPENTHREAD_CONFIG_LOG_SUFFIX, __VA_ARGS__)
 
 #ifdef __cplusplus
 extern "C" {

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -116,15 +116,13 @@ extern "C" {
  * Logging at log level critical.
  *
  * @param[in]  aRegion   The log region.
- * @param[in]  aFormat   A pointer to the format string.
  * @param[in]  ...       Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_CRIT
-#define otLogCrit(aRegion, aFormat, ...) \
-    _otLogFormatter(OT_LOG_LEVEL_CRIT, aRegion, _OT_LEVEL_CRIT_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCrit(aRegion, ...) _otLogFormatter(OT_LOG_LEVEL_CRIT, aRegion, _OT_LEVEL_CRIT_PREFIX __VA_ARGS__, NULL)
 #else
-#define otLogCrit(aRegion, aFormat, ...)
+#define otLogCrit(aRegion, ...)
 #endif
 
 /**
@@ -133,15 +131,13 @@ extern "C" {
  * Logging at log level warning.
  *
  * @param[in]  aRegion   The log region.
- * @param[in]  aFormat   A pointer to the format string.
  * @param[in]  ...       Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
-#define otLogWarn(aRegion, aFormat, ...) \
-    _otLogFormatter(OT_LOG_LEVEL_WARN, aRegion, _OT_LEVEL_WARN_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogWarn(aRegion, ...) _otLogFormatter(OT_LOG_LEVEL_WARN, aRegion, _OT_LEVEL_WARN_PREFIX __VA_ARGS__, NULL)
 #else
-#define otLogWarn(aRegion, aFormat, ...)
+#define otLogWarn(aRegion, ...)
 #endif
 
 /**
@@ -150,15 +146,13 @@ extern "C" {
  * Logging at log level note
  *
  * @param[in]  aRegion   The log region.
- * @param[in]  aFormat   A pointer to the format string.
  * @param[in]  ...       Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
-#define otLogNote(aRegion, aFormat, ...) \
-    _otLogFormatter(OT_LOG_LEVEL_NOTE, aRegion, _OT_LEVEL_NOTE_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogNote(aRegion, ...) _otLogFormatter(OT_LOG_LEVEL_NOTE, aRegion, _OT_LEVEL_NOTE_PREFIX __VA_ARGS__, NULL)
 #else
-#define otLogNote(aRegion, aFormat, ...)
+#define otLogNote(aRegion, ...)
 #endif
 
 /**
@@ -167,15 +161,13 @@ extern "C" {
  * Logging at log level info.
  *
  * @param[in]  aRegion   The log region.
- * @param[in]  aFormat   A pointer to the format string.
  * @param[in]  ...       Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
-#define otLogInfo(aRegion, aFormat, ...) \
-    _otLogFormatter(OT_LOG_LEVEL_INFO, aRegion, _OT_LEVEL_INFO_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogInfo(aRegion, ...) _otLogFormatter(OT_LOG_LEVEL_INFO, aRegion, _OT_LEVEL_INFO_PREFIX __VA_ARGS__, NULL)
 #else
-#define otLogInfo(aRegion, aFormat, ...)
+#define otLogInfo(aRegion, ...)
 #endif
 
 /**
@@ -184,15 +176,13 @@ extern "C" {
  * Logging at log level debug.
  *
  * @param[in]  aRegion   The log region.
- * @param[in]  aFormat   A pointer to the format string.
  * @param[in]  ...       Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
-#define otLogDebg(aRegion, aFormat, ...) \
-    _otLogFormatter(OT_LOG_LEVEL_DEBG, aRegion, _OT_LEVEL_DEBG_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogDebg(aRegion, ...) _otLogFormatter(OT_LOG_LEVEL_DEBG, aRegion, _OT_LEVEL_DEBG_PREFIX __VA_ARGS__, NULL)
 #else
-#define otLogDebg(aRegion, aFormat, ...)
+#define otLogDebg(aRegion, ...)
 #endif
 
 /**
@@ -200,8 +190,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the API region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -210,8 +199,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the API region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -220,8 +208,7 @@ extern "C" {
  *
  * This method generates a log with level note for the API region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -230,8 +217,7 @@ extern "C" {
  *
  * This method generates a log with level info for the API region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -240,22 +226,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the API region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_API == 1
-#define otLogCritApi(aFormat, ...) otLogCrit(OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnApi(aFormat, ...) otLogWarn(OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteApi(aFormat, ...) otLogNote(OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoApi(aFormat, ...) otLogInfo(OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgApi(aFormat, ...) otLogDebg(OT_LOG_REGION_API, _OT_REGION_API_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritApi(...) otLogCrit(OT_LOG_REGION_API, _OT_REGION_API_PREFIX __VA_ARGS__)
+#define otLogWarnApi(...) otLogWarn(OT_LOG_REGION_API, _OT_REGION_API_PREFIX __VA_ARGS__)
+#define otLogNoteApi(...) otLogNote(OT_LOG_REGION_API, _OT_REGION_API_PREFIX __VA_ARGS__)
+#define otLogInfoApi(...) otLogInfo(OT_LOG_REGION_API, _OT_REGION_API_PREFIX __VA_ARGS__)
+#define otLogDebgApi(...) otLogDebg(OT_LOG_REGION_API, _OT_REGION_API_PREFIX __VA_ARGS__)
 #else
-#define otLogCritApi(aFormat, ...)
-#define otLogWarnApi(aFormat, ...)
-#define otLogNoteApi(aFormat, ...)
-#define otLogInfoApi(aFormat, ...)
-#define otLogDebgApi(aFormat, ...)
+#define otLogCritApi(...)
+#define otLogWarnApi(...)
+#define otLogNoteApi(...)
+#define otLogInfoApi(...)
+#define otLogDebgApi(...)
 #endif
 
 /**
@@ -263,8 +248,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  *
  */
@@ -274,8 +258,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -284,8 +267,7 @@ extern "C" {
  *
  * This method generates a log with level note for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -294,8 +276,7 @@ extern "C" {
  *
  * This method generates a log with level info for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -304,42 +285,35 @@ extern "C" {
  *
  * This method generates a log with level debug for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MLE == 1
-#define otLogCritMeshCoP(aFormat, ...) \
-    otLogCrit(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnMeshCoP(aFormat, ...) \
-    otLogWarn(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteMeshCoP(aFormat, ...) \
-    otLogNote(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoMeshCoP(aFormat, ...) \
-    otLogInfo(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgMeshCoP(aFormat, ...) \
-    otLogDebg(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritMeshCoP(...) otLogCrit(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX __VA_ARGS__)
+#define otLogWarnMeshCoP(...) otLogWarn(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX __VA_ARGS__)
+#define otLogNoteMeshCoP(...) otLogNote(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX __VA_ARGS__)
+#define otLogInfoMeshCoP(...) otLogInfo(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX __VA_ARGS__)
+#define otLogDebgMeshCoP(...) otLogDebg(OT_LOG_REGION_MESH_COP, _OT_REGION_MESH_COP_PREFIX __VA_ARGS__)
 #else
-#define otLogCritMeshCoP(aFormat, ...)
-#define otLogWarnMeshCoP(aFormat, ...)
-#define otLogNoteMeshCoP(aFormat, ...)
-#define otLogInfoMeshCoP(aFormat, ...)
-#define otLogDebgMeshCoP(aFormat, ...)
+#define otLogCritMeshCoP(...)
+#define otLogWarnMeshCoP(...)
+#define otLogNoteMeshCoP(...)
+#define otLogInfoMeshCoP(...)
+#define otLogDebgMeshCoP(...)
 #endif
 
-#define otLogCritMbedTls(aFormat, ...) otLogCritMeshCoP(aFormat, ##__VA_ARGS__)
-#define otLogWarnMbedTls(aFormat, ...) otLogWarnMeshCoP(aFormat, ##__VA_ARGS__)
-#define otLogNoteMbedTls(aFormat, ...) otLogNoteMeshCoP(aFormat, ##__VA_ARGS__)
-#define otLogInfoMbedTls(aFormat, ...) otLogInfoMeshCoP(aFormat, ##__VA_ARGS__)
-#define otLogDebgMbedTls(aFormat, ...) otLogDebgMeshCoP(aFormat, ##__VA_ARGS__)
+#define otLogCritMbedTls(...) otLogCritMeshCoP(__VA_ARGS__)
+#define otLogWarnMbedTls(...) otLogWarnMeshCoP(__VA_ARGS__)
+#define otLogNoteMbedTls(...) otLogNoteMeshCoP(__VA_ARGS__)
+#define otLogInfoMbedTls(...) otLogInfoMeshCoP(__VA_ARGS__)
+#define otLogDebgMbedTls(...) otLogDebgMeshCoP(__VA_ARGS__)
 
 /**
  * @def otLogCritMle
  *
  * This method generates a log with level critical for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -348,8 +322,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -358,8 +331,7 @@ extern "C" {
  *
  * This method generates a log with level note for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -368,8 +340,7 @@ extern "C" {
  *
  * This method generates a log with level info for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -378,23 +349,22 @@ extern "C" {
  *
  * This method generates a log with level debug for the MLE region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MLE == 1
-#define otLogCritMle(aFormat, ...) otLogCrit(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnMle(aFormat, ...) otLogWarn(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteMle(aFormat, ...) otLogNote(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoMle(aFormat, ...) otLogInfo(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgMle(aFormat, ...) otLogDebg(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritMle(...) otLogCrit(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX __VA_ARGS__)
+#define otLogWarnMle(...) otLogWarn(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX __VA_ARGS__)
+#define otLogNoteMle(...) otLogNote(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX __VA_ARGS__)
+#define otLogInfoMle(...) otLogInfo(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX __VA_ARGS__)
+#define otLogDebgMle(...) otLogDebg(OT_LOG_REGION_MLE, _OT_REGION_MLE_PREFIX __VA_ARGS__)
 #else
-#define otLogCritMle(aFormat, ...)
-#define otLogWarnMle(aFormat, ...)
-#define otLogNoteMle(aFormat, ...)
-#define otLogInfoMle(aFormat, ...)
-#define otLogDebgMle(aFormat, ...)
+#define otLogCritMle(...)
+#define otLogWarnMle(...)
+#define otLogNoteMle(...)
+#define otLogInfoMle(...)
+#define otLogDebgMle(...)
 #endif
 
 /**
@@ -402,8 +372,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -412,8 +381,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -422,8 +390,7 @@ extern "C" {
  *
  * This method generates a log with level note for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -432,8 +399,7 @@ extern "C" {
  *
  * This method generates a log with level info for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -442,22 +408,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the EID-to-RLOC mapping region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ARP == 1
-#define otLogCritArp(aFormat, ...) otLogCrit(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnArp(aFormat, ...) otLogWarn(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteArp(aFormat, ...) otLogNote(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoArp(aFormat, ...) otLogInfo(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgArp(aFormat, ...) otLogDebg(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritArp(...) otLogCrit(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX __VA_ARGS__)
+#define otLogWarnArp(...) otLogWarn(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX __VA_ARGS__)
+#define otLogNoteArp(...) otLogNote(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX __VA_ARGS__)
+#define otLogInfoArp(...) otLogInfo(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX __VA_ARGS__)
+#define otLogDebgArp(...) otLogDebg(OT_LOG_REGION_ARP, _OT_REGION_ARP_PREFIX __VA_ARGS__)
 #else
-#define otLogCritArp(aFormat, ...)
-#define otLogWarnArp(aFormat, ...)
-#define otLogNoteArp(aFormat, ...)
-#define otLogInfoArp(aFormat, ...)
-#define otLogDebgArp(aFormat, ...)
+#define otLogCritArp(...)
+#define otLogWarnArp(...)
+#define otLogNoteArp(...)
+#define otLogInfoArp(...)
+#define otLogDebgArp(...)
 #endif
 
 /**
@@ -465,8 +430,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the Backbone Router (BBR) region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -475,8 +439,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the Backbone Router (BBR) region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -485,8 +448,7 @@ extern "C" {
  *
  * This method generates a log with level note for the Backbone Router (BBR) region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -495,8 +457,7 @@ extern "C" {
  *
  * This method generates a log with level info for the Backbone Router (BBR) region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -505,22 +466,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the Backbone Router (BBR) region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_BBR == 1
-#define otLogCritBbr(aFormat, ...) otLogCrit(OT_LOG_REGION_BBR, _OT_REGION_BBR_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnBbr(aFormat, ...) otLogWarn(OT_LOG_REGION_BBR, _OT_REGION_BBR_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteBbr(aFormat, ...) otLogNote(OT_LOG_REGION_BBR, _OT_REGION_BBR_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoBbr(aFormat, ...) otLogInfo(OT_LOG_REGION_BBR, _OT_REGION_BBR_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgBbr(aFormat, ...) otLogDebg(OT_LOG_REGION_BBR, _OT_REGION_BBR_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritBbr(...) otLogCrit(OT_LOG_REGION_BBR, _OT_REGION_BBR_PREFIX aFormat __VA_ARGS__)
+#define otLogWarnBbr(...) otLogWarn(OT_LOG_REGION_BBR, _OT_REGION_BBR_PREFIX aFormat __VA_ARGS__)
+#define otLogNoteBbr(...) otLogNote(OT_LOG_REGION_BBR, _OT_REGION_BBR_PREFIX aFormat __VA_ARGS__)
+#define otLogInfoBbr(...) otLogInfo(OT_LOG_REGION_BBR, _OT_REGION_BBR_PREFIX aFormat __VA_ARGS__)
+#define otLogDebgBbr(...) otLogDebg(OT_LOG_REGION_BBR, _OT_REGION_BBR_PREFIX aFormat __VA_ARGS__)
 #else
-#define otLogCritBbr(aFormat, ...)
-#define otLogWarnBbr(aFormat, ...)
-#define otLogNoteBbr(aFormat, ...)
-#define otLogInfoBbr(aFormat, ...)
-#define otLogDebgBbr(aFormat, ...)
+#define otLogCritBbr(...)
+#define otLogWarnBbr(...)
+#define otLogNoteBbr(...)
+#define otLogInfoBbr(...)
+#define otLogDebgBbr(...)
 #endif
 
 /**
@@ -528,8 +488,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the Network Data region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -538,8 +497,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the Network Data region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -548,8 +506,7 @@ extern "C" {
  *
  * This method generates a log with level note for the Network Data region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -558,8 +515,7 @@ extern "C" {
  *
  * This method generates a log with level info for the Network Data region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -568,27 +524,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the Network Data region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_NETDATA == 1
-#define otLogCritNetData(aFormat, ...) \
-    otLogCrit(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnNetData(aFormat, ...) \
-    otLogWarn(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteNetData(aFormat, ...) \
-    otLogNote(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoNetData(aFormat, ...) \
-    otLogInfo(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgNetData(aFormat, ...) \
-    otLogDebg(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritNetData(...) otLogCrit(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX __VA_ARGS__)
+#define otLogWarnNetData(...) otLogWarn(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX __VA_ARGS__)
+#define otLogNoteNetData(...) otLogNote(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX __VA_ARGS__)
+#define otLogInfoNetData(...) otLogInfo(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX __VA_ARGS__)
+#define otLogDebgNetData(...) otLogDebg(OT_LOG_REGION_NET_DATA, _OT_REGION_NET_DATA_PREFIX __VA_ARGS__)
 #else
-#define otLogCritNetData(aFormat, ...)
-#define otLogWarnNetData(aFormat, ...)
-#define otLogNoteNetData(aFormat, ...)
-#define otLogInfoNetData(aFormat, ...)
-#define otLogDebgNetData(aFormat, ...)
+#define otLogCritNetData(...)
+#define otLogWarnNetData(...)
+#define otLogNoteNetData(...)
+#define otLogInfoNetData(...)
+#define otLogDebgNetData(...)
 #endif
 
 /**
@@ -596,8 +546,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the ICMPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -606,8 +555,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the ICMPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -616,8 +564,7 @@ extern "C" {
  *
  * This method generates a log with level note for the ICMPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -626,8 +573,7 @@ extern "C" {
  *
  * This method generates a log with level info for the ICMPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -636,22 +582,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the ICMPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_ICMP == 1
-#define otLogCritIcmp(aFormat, ...) otLogCrit(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnIcmp(aFormat, ...) otLogWarn(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteIcmp(aFormat, ...) otLogNote(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoIcmp(aFormat, ...) otLogInfo(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgIcmp(aFormat, ...) otLogDebg(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritIcmp(...) otLogCrit(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX __VA_ARGS__)
+#define otLogWarnIcmp(...) otLogWarn(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX __VA_ARGS__)
+#define otLogNoteIcmp(...) otLogNote(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX __VA_ARGS__)
+#define otLogInfoIcmp(...) otLogInfo(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX __VA_ARGS__)
+#define otLogDebgIcmp(...) otLogDebg(OT_LOG_REGION_ICMP, _OT_REGION_ICMP_PREFIX __VA_ARGS__)
 #else
-#define otLogCritIcmp(aFormat, ...)
-#define otLogWarnIcmp(aFormat, ...)
-#define otLogNoteIcmp(aFormat, ...)
-#define otLogInfoIcmp(aFormat, ...)
-#define otLogDebgIcmp(aFormat, ...)
+#define otLogCritIcmp(...)
+#define otLogWarnIcmp(...)
+#define otLogNoteIcmp(...)
+#define otLogInfoIcmp(...)
+#define otLogDebgIcmp(...)
 #endif
 
 /**
@@ -659,8 +604,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the IPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -669,8 +613,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the IPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -679,8 +622,7 @@ extern "C" {
  *
  * This method generates a log with level note for the IPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -689,8 +631,7 @@ extern "C" {
  *
  * This method generates a log with level info for the IPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -699,22 +640,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the IPv6 region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_IP6 == 1
-#define otLogCritIp6(aFormat, ...) otLogCrit(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnIp6(aFormat, ...) otLogWarn(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteIp6(aFormat, ...) otLogNote(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoIp6(aFormat, ...) otLogInfo(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgIp6(aFormat, ...) otLogDebg(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritIp6(...) otLogCrit(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX __VA_ARGS__)
+#define otLogWarnIp6(...) otLogWarn(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX __VA_ARGS__)
+#define otLogNoteIp6(...) otLogNote(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX __VA_ARGS__)
+#define otLogInfoIp6(...) otLogInfo(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX __VA_ARGS__)
+#define otLogDebgIp6(...) otLogDebg(OT_LOG_REGION_IP6, _OT_REGION_IP6_PREFIX __VA_ARGS__)
 #else
-#define otLogCritIp6(aFormat, ...)
-#define otLogWarnIp6(aFormat, ...)
-#define otLogNoteIp6(aFormat, ...)
-#define otLogInfoIp6(aFormat, ...)
-#define otLogDebgIp6(aFormat, ...)
+#define otLogCritIp6(...)
+#define otLogWarnIp6(...)
+#define otLogNoteIp6(...)
+#define otLogInfoIp6(...)
+#define otLogDebgIp6(...)
 #endif
 
 /**
@@ -722,8 +662,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the MAC region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -732,8 +671,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the MAC region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -742,8 +680,7 @@ extern "C" {
  *
  * This method generates a log with level note for the MAC region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -752,8 +689,7 @@ extern "C" {
  *
  * This method generates a log with level info for the MAC region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -762,8 +698,7 @@ extern "C" {
  *
  * This method generates a log with level debug for the MAC region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -772,34 +707,34 @@ extern "C" {
  *
  * This method generates a log with a given log level for the MAC region.
  *
- * @param[in]  aLogLevel    A log level.
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  aLogLevel  A log level.
+ * @param[in]  aFormat    A pointer to the format string.
+ * @param[in]  ...        Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MAC == 1
-#define otLogCritMac(aFormat, ...) otLogCrit(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnMac(aFormat, ...) otLogWarn(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteMac(aFormat, ...) otLogNote(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoMac(aFormat, ...) otLogInfo(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgMac(aFormat, ...) otLogDebg(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritMac(...) otLogCrit(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX __VA_ARGS__)
+#define otLogWarnMac(...) otLogWarn(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX __VA_ARGS__)
+#define otLogNoteMac(...) otLogNote(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX __VA_ARGS__)
+#define otLogInfoMac(...) otLogInfo(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX __VA_ARGS__)
+#define otLogDebgMac(...) otLogDebg(OT_LOG_REGION_MAC, _OT_REGION_MAC_PREFIX __VA_ARGS__)
 #define otLogMac(aLogLevel, aFormat, ...)                                                     \
     do                                                                                        \
     {                                                                                         \
         if (otLoggingGetLevel() >= aLogLevel)                                                 \
         {                                                                                     \
             _otLogFormatter(aLogLevel, OT_LOG_REGION_MAC, "%s" _OT_REGION_MAC_PREFIX aFormat, \
-                            otLogLevelToPrefixString(aLogLevel), ##__VA_ARGS__);              \
+                            otLogLevelToPrefixString(aLogLevel), __VA_ARGS__);                \
         }                                                                                     \
     } while (false)
 
 #else
-#define otLogCritMac(aFormat, ...)
-#define otLogWarnMac(aFormat, ...)
-#define otLogNoteMac(aFormat, ...)
-#define otLogInfoMac(aFormat, ...)
-#define otLogDebgMac(aFormat, ...)
-#define otLogMac(aLogLevel, aFormat, ...)
+#define otLogCritMac(...)
+#define otLogWarnMac(...)
+#define otLogNoteMac(...)
+#define otLogInfoMac(...)
+#define otLogDebgMac(...)
+#define otLogMac(aLogLevel, ...)
 #endif
 
 /**
@@ -807,8 +742,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the Core region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -817,8 +751,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the Core region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -827,8 +760,7 @@ extern "C" {
  *
  * This method generates a log with level note for the Core region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -837,8 +769,7 @@ extern "C" {
  *
  * This method generates a log with level info for the Core region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -847,21 +778,20 @@ extern "C" {
  *
  * This method generates a log with level debug for the Core region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_CORE == 1
-#define otLogCritCore(aFormat, ...) otLogCrit(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnCore(aFormat, ...) otLogWarn(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteCore(aFormat, ...) otLogNote(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoCore(aFormat, ...) otLogInfo(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgCore(aFormat, ...) otLogDebg(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritCore(...) otLogCrit(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX __VA_ARGS__)
+#define otLogWarnCore(...) otLogWarn(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX __VA_ARGS__)
+#define otLogNoteCore(...) otLogNote(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX __VA_ARGS__)
+#define otLogInfoCore(...) otLogInfo(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX __VA_ARGS__)
+#define otLogDebgCore(...) otLogDebg(OT_LOG_REGION_CORE, _OT_REGION_CORE_PREFIX __VA_ARGS__)
 #else
-#define otLogCritCore(aFormat, ...)
-#define otLogWarnCore(aFormat, ...)
-#define otLogInfoCore(aFormat, ...)
-#define otLogDebgCore(aFormat, ...)
+#define otLogCritCore(...)
+#define otLogWarnCore(...)
+#define otLogInfoCore(...)
+#define otLogDebgCore(...)
 #endif
 
 /**
@@ -869,8 +799,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the memory region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -879,8 +808,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the memory region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -889,8 +817,7 @@ extern "C" {
  *
  * This method generates a log with level note for the memory region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -899,8 +826,7 @@ extern "C" {
  *
  * This method generates a log with level info for the memory region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -909,22 +835,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the memory region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_MEM == 1
-#define otLogCritMem(aFormat, ...) otLogCrit(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnMem(aFormat, ...) otLogWarn(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteMem(aFormat, ...) otLogNote(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoMem(aFormat, ...) otLogInfo(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgMem(aFormat, ...) otLogDebg(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritMem(...) otLogCrit(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX __VA_ARGS__)
+#define otLogWarnMem(...) otLogWarn(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX __VA_ARGS__)
+#define otLogNoteMem(...) otLogNote(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX __VA_ARGS__)
+#define otLogInfoMem(...) otLogInfo(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX __VA_ARGS__)
+#define otLogDebgMem(...) otLogDebg(OT_LOG_REGION_MEM, _OT_REGION_MEM_PREFIX __VA_ARGS__)
 #else
-#define otLogCritMem(aFormat, ...)
-#define otLogWarnMem(aFormat, ...)
-#define otLogNoteMem(aFormat, ...)
-#define otLogInfoMem(aFormat, ...)
-#define otLogDebgMem(aFormat, ...)
+#define otLogCritMem(...)
+#define otLogWarnMem(...)
+#define otLogNoteMem(...)
+#define otLogInfoMem(...)
+#define otLogDebgMem(...)
 #endif
 
 /**
@@ -932,8 +857,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the Util region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -942,8 +866,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the Util region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -952,8 +875,7 @@ extern "C" {
  *
  * This method generates a log with level note for the Util region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -962,8 +884,7 @@ extern "C" {
  *
  * This method generates a log with level info for the Util region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -972,22 +893,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the Util region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_UTIL == 1
-#define otLogCritUtil(aFormat, ...) otLogCrit(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnUtil(aFormat, ...) otLogWarn(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteUtil(aFormat, ...) otLogNote(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoUtil(aFormat, ...) otLogInfo(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgUtil(aFormat, ...) otLogDebg(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritUtil(...) otLogCrit(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX __VA_ARGS__)
+#define otLogWarnUtil(...) otLogWarn(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX __VA_ARGS__)
+#define otLogNoteUtil(...) otLogNote(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX __VA_ARGS__)
+#define otLogInfoUtil(...) otLogInfo(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX __VA_ARGS__)
+#define otLogDebgUtil(...) otLogDebg(OT_LOG_REGION_UTIL, _OT_REGION_UTIL_PREFIX __VA_ARGS__)
 #else
-#define otLogCritUtil(aFormat, ...)
-#define otLogWarnUtil(aFormat, ...)
-#define otLogNoteUtil(aFormat, ...)
-#define otLogInfoUtil(aFormat, ...)
-#define otLogDebgUtil(aFormat, ...)
+#define otLogCritUtil(...)
+#define otLogWarnUtil(...)
+#define otLogNoteUtil(...)
+#define otLogInfoUtil(...)
+#define otLogDebgUtil(...)
 #endif
 
 /**
@@ -995,8 +915,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the NETDIAG region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1005,8 +924,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the NETDIAG region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1015,8 +933,7 @@ extern "C" {
  *
  * This method generates a log with level note for the NETDIAG region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1025,8 +942,7 @@ extern "C" {
  *
  * This method generates a log with level info for the NETDIAG region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1035,27 +951,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the NETDIAG region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_NETDIAG == 1
-#define otLogCritNetDiag(aFormat, ...) \
-    otLogCrit(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnNetDiag(aFormat, ...) \
-    otLogWarn(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteNetDiag(aFormat, ...) \
-    otLogNote(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoNetDiag(aFormat, ...) \
-    otLogInfo(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgNetDiag(aFormat, ...) \
-    otLogDebg(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritNetDiag(...) otLogCrit(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX __VA_ARGS__)
+#define otLogWarnNetDiag(...) otLogWarn(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX __VA_ARGS__)
+#define otLogNoteNetDiag(...) otLogNote(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX __VA_ARGS__)
+#define otLogInfoNetDiag(...) otLogInfo(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX __VA_ARGS__)
+#define otLogDebgNetDiag(...) otLogDebg(OT_LOG_REGION_NET_DIAG, _OT_REGION_NET_DIAG_PREFIX __VA_ARGS__)
 #else
-#define otLogCritNetDiag(aFormat, ...)
-#define otLogWarnNetDiag(aFormat, ...)
-#define otLogNoteNetDiag(aFormat, ...)
-#define otLogInfoNetDiag(aFormat, ...)
-#define otLogDebgNetDiag(aFormat, ...)
+#define otLogCritNetDiag(...)
+#define otLogWarnNetDiag(...)
+#define otLogNoteNetDiag(...)
+#define otLogInfoNetDiag(...)
+#define otLogDebgNetDiag(...)
 #endif
 
 /**
@@ -1063,16 +973,14 @@ extern "C" {
  *
  * This method generates a log with level none for the certification test.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  *
  */
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-#define otLogCertMeshCoP(aFormat, ...) \
-    _otLogFormatter(OT_LOG_LEVEL_NONE, OT_LOG_REGION_MESH_COP, aFormat, ##__VA_ARGS__)
+#define otLogCertMeshCoP(...) _otLogFormatter(OT_LOG_LEVEL_NONE, OT_LOG_REGION_MESH_COP, __VA_ARGS__, NULL)
 #else
-#define otLogCertMeshCoP(aFormat, ...)
+#define otLogCertMeshCoP(...)
 #endif
 
 /**
@@ -1080,8 +988,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the CLI region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1090,8 +997,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the CLI region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1100,8 +1006,7 @@ extern "C" {
  *
  * This method generates a log with level note for the CLI region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1110,8 +1015,7 @@ extern "C" {
  *
  * This method generates a log with level info for the CLI region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1120,23 +1024,22 @@ extern "C" {
  *
  * This method generates a log with level debug for the CLI region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_CLI == 1
 
-#define otLogCritCli(aFormat, ...) otLogCrit(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnCli(aFormat, ...) otLogWarn(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteCli(aFormat, ...) otLogNote(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoCli(aFormat, ...) otLogInfo(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgCli(aFormat, ...) otLogDebg(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritCli(...) otLogCrit(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX __VA_ARGS__)
+#define otLogWarnCli(...) otLogWarn(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX __VA_ARGS__)
+#define otLogNoteCli(...) otLogNote(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX __VA_ARGS__)
+#define otLogInfoCli(...) otLogInfo(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX __VA_ARGS__)
+#define otLogDebgCli(...) otLogDebg(OT_LOG_REGION_CLI, _OT_REGION_CLI_PREFIX __VA_ARGS__)
 #else
-#define otLogCritCli(aFormat, ...)
-#define otLogWarnCli(aFormat, ...)
-#define otLogNoteCli(aFormat, ...)
-#define otLogInfoCli(aFormat, ...)
-#define otLogDebgCli(aFormat, ...)
+#define otLogCritCli(...)
+#define otLogWarnCli(...)
+#define otLogNoteCli(...)
+#define otLogInfoCli(...)
+#define otLogDebgCli(...)
 #endif
 
 /**
@@ -1144,8 +1047,7 @@ extern "C" {
  *
  * This method generates a log with level critical for the CoAP region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1154,8 +1056,7 @@ extern "C" {
  *
  * This method generates a log with level warning for the CoAP region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1164,8 +1065,7 @@ extern "C" {
  *
  * This method generates a log with level note for the CoAP region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1174,8 +1074,7 @@ extern "C" {
  *
  * This method generates a log with level info for the CoAP region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 
@@ -1184,22 +1083,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the CoAP region.
  *
- * @param[in]  aFormat      A pointer to the format string.
- * @param[in]  ...          Arguments for the format specification.
+ * @param[in]  ...  Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_COAP == 1
-#define otLogCritCoap(aFormat, ...) otLogCrit(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnCoap(aFormat, ...) otLogWarn(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNoteCoap(aFormat, ...) otLogNote(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoCoap(aFormat, ...) otLogInfo(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgCoap(aFormat, ...) otLogDebg(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritCoap(...) otLogCrit(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX __VA_ARGS__)
+#define otLogWarnCoap(...) otLogWarn(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX __VA_ARGS__)
+#define otLogNoteCoap(...) otLogNote(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX __VA_ARGS__)
+#define otLogInfoCoap(...) otLogInfo(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX __VA_ARGS__)
+#define otLogDebgCoap(...) otLogDebg(OT_LOG_REGION_COAP, _OT_REGION_COAP_PREFIX __VA_ARGS__)
 #else
-#define otLogCritCoap(aFormat, ...)
-#define otLogWarnCoap(aFormat, ...)
-#define otLogNoteCoap(aFormat, ...)
-#define otLogInfoCoap(aFormat, ...)
-#define otLogDebgCoap(aFormat, ...)
+#define otLogCritCoap(...)
+#define otLogWarnCoap(...)
+#define otLogNoteCoap(...)
+#define otLogInfoCoap(...)
+#define otLogDebgCoap(...)
 #endif
 
 /**
@@ -1207,7 +1105,6 @@ extern "C" {
  *
  * This method generates a log with level critical for the Platform region.
  *
- * @param[in]  aFormat   A pointer to the format string.
  * @param[in]  ...       Arguments for the format specification.
  *
  */
@@ -1217,7 +1114,6 @@ extern "C" {
  *
  * This method generates a log with level warning for the Platform region.
  *
- * @param[in]  aFormat   A pointer to the format string.
  * @param[in]  ...       Arguments for the format specification.
  *
  */
@@ -1227,7 +1123,6 @@ extern "C" {
  *
  * This method generates a log with level note for the Platform region.
  *
- * @param[in]  aFormat   A pointer to the format string.
  * @param[in]  ...       Arguments for the format specification.
  *
  */
@@ -1237,7 +1132,6 @@ extern "C" {
  *
  * This method generates a log with level info for the Platform region.
  *
- * @param[in]  aFormat   A pointer to the format string.
  * @param[in]  ...       Arguments for the format specification.
  *
  */
@@ -1247,22 +1141,21 @@ extern "C" {
  *
  * This method generates a log with level debug for the Platform region.
  *
- * @param[in]  aFormat   A pointer to the format string.
  * @param[in]  ...       Arguments for the format specification.
  *
  */
 #if OPENTHREAD_CONFIG_LOG_PLATFORM == 1
-#define otLogCritPlat(aFormat, ...) otLogCrit(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogWarnPlat(aFormat, ...) otLogWarn(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogNotePlat(aFormat, ...) otLogNote(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogInfoPlat(aFormat, ...) otLogInfo(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
-#define otLogDebgPlat(aFormat, ...) otLogDebg(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX aFormat, ##__VA_ARGS__)
+#define otLogCritPlat(...) otLogCrit(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX __VA_ARGS__)
+#define otLogWarnPlat(...) otLogWarn(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX __VA_ARGS__)
+#define otLogNotePlat(...) otLogNote(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX __VA_ARGS__)
+#define otLogInfoPlat(...) otLogInfo(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX __VA_ARGS__)
+#define otLogDebgPlat(...) otLogDebg(OT_LOG_REGION_PLATFORM, _OT_REGION_PLATFORM_PREFIX __VA_ARGS__)
 #else
-#define otLogCritPlat(aFormat, ...)
-#define otLogWarnPlat(aFormat, ...)
-#define otLogNotePlat(aFormat, ...)
-#define otLogInfoPlat(aFormat, ...)
-#define otLogDebgPlat(aFormat, ...)
+#define otLogCritPlat(...)
+#define otLogWarnPlat(...)
+#define otLogNotePlat(...)
+#define otLogInfoPlat(...)
+#define otLogDebgPlat(...)
 #endif
 
 /**
@@ -1999,23 +1892,23 @@ const char *otLogLevelToPrefixString(otLogLevel aLogLevel);
  * Local/private macro to format the log message
  */
 #define _otLogFormatter(aLogLevel, aRegion, aFormat, ...) \
-    _otDynamicLog(aLogLevel, aRegion, aFormat OPENTHREAD_CONFIG_LOG_SUFFIX, ##__VA_ARGS__)
+    _otDynamicLog(aLogLevel, aRegion, aFormat OPENTHREAD_CONFIG_LOG_SUFFIX, __VA_ARGS__)
 
 #if OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE == 1
 
 /**
  * Local/private macro to dynamically filter log level.
  */
-#define _otDynamicLog(aLogLevel, aRegion, aFormat, ...)             \
-    do                                                              \
-    {                                                               \
-        if (otLoggingGetLevel() >= aLogLevel)                       \
-            _otPlatLog(aLogLevel, aRegion, aFormat, ##__VA_ARGS__); \
+#define _otDynamicLog(aLogLevel, aRegion, ...)           \
+    do                                                   \
+    {                                                    \
+        if (otLoggingGetLevel() >= aLogLevel)            \
+            _otPlatLog(aLogLevel, aRegion, __VA_ARGS__); \
     } while (false)
 
 #else // OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE
 
-#define _otDynamicLog(aLogLevel, aRegion, aFormat, ...) _otPlatLog(aLogLevel, aRegion, aFormat, ##__VA_ARGS__)
+#define _otDynamicLog(aLogLevel, aRegion, ...) _otPlatLog(aLogLevel, aRegion, __VA_ARGS__)
 
 #endif // OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE
 
@@ -2024,8 +1917,7 @@ const char *otLogLevelToPrefixString(otLogLevel aLogLevel);
  * function/macro to be used for logging in OpenThread. By default it is set to `otPlatLog()`.
  *
  */
-#define _otPlatLog(aLogLevel, aRegion, aFormat, ...) \
-    OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION(aLogLevel, aRegion, aFormat, ##__VA_ARGS__)
+#define _otPlatLog(aLogLevel, aRegion, ...) OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION(aLogLevel, aRegion, __VA_ARGS__)
 
 #ifdef __cplusplus
 }

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -65,10 +65,10 @@ MessagePool::MessagePool(Instance &aInstance)
 
 Message *MessagePool::New(uint8_t aType, uint16_t aReserveHeader, uint8_t aPriority)
 {
-    otError  error   = OT_ERROR_NONE;
-    Message *message = NULL;
+    otError  error = OT_ERROR_NONE;
+    Message *message;
 
-    VerifyOrExit((message = static_cast<Message *>(NewBuffer(aPriority))) != NULL);
+    VerifyOrExit((message = static_cast<Message *>(NewBuffer(aPriority))) != NULL, OT_NOOP);
 
     memset(message, 0, sizeof(*message));
     message->SetMessagePool(this);
@@ -367,7 +367,7 @@ otError Message::SetPriority(uint8_t aPriority)
     VerifyOrExit(aPriority < kNumPriorities, error = OT_ERROR_INVALID_ARGS);
 
     VerifyOrExit(IsInAQueue(), mBuffer.mHead.mInfo.mPriority = aPriority);
-    VerifyOrExit(mBuffer.mHead.mInfo.mPriority != aPriority);
+    VerifyOrExit(mBuffer.mHead.mInfo.mPriority != aPriority, OT_NOOP);
 
     if (mBuffer.mHead.mInfo.mInPriorityQ)
     {

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -73,7 +73,7 @@ otError Notifier::RegisterCallback(otStateChangedCallback aCallback, void *aCont
     otError           error          = OT_ERROR_NONE;
     ExternalCallback *unusedCallback = NULL;
 
-    VerifyOrExit(aCallback != NULL);
+    VerifyOrExit(aCallback != NULL, OT_NOOP);
 
     for (unsigned int i = 0; i < kMaxExternalHandlers; i++)
     {
@@ -103,7 +103,7 @@ exit:
 
 void Notifier::RemoveCallback(otStateChangedCallback aCallback, void *aContext)
 {
-    VerifyOrExit(aCallback != NULL);
+    VerifyOrExit(aCallback != NULL, OT_NOOP);
 
     for (unsigned int i = 0; i < kMaxExternalHandlers; i++)
     {
@@ -144,7 +144,7 @@ void Notifier::HandleStateChanged(void)
 {
     otChangedFlags flags = mFlagsToSignal;
 
-    VerifyOrExit(flags != 0);
+    VerifyOrExit(flags != 0, OT_NOOP);
 
     mFlagsToSignal = 0;
 
@@ -182,7 +182,7 @@ void Notifier::LogChangedFlags(otChangedFlags aFlags) const
 
     for (uint8_t bit = 0; bit < sizeof(otChangedFlags) * CHAR_BIT; bit++)
     {
-        VerifyOrExit(flags != 0);
+        VerifyOrExit(flags != 0, OT_NOOP);
 
         if (flags & (1 << bit))
         {

--- a/src/core/common/random_manager.cpp
+++ b/src/core/common/random_manager.cpp
@@ -63,7 +63,7 @@ RandomManager::RandomManager(void)
 
     OT_ASSERT(sInitCount < 0xffff);
 
-    VerifyOrExit(sInitCount == 0);
+    VerifyOrExit(sInitCount == 0, OT_NOOP);
 
 #if !OPENTHREAD_RADIO
     sEntropy.Init();
@@ -87,7 +87,7 @@ RandomManager::~RandomManager(void)
     OT_ASSERT(sInitCount > 0);
 
     sInitCount--;
-    VerifyOrExit(sInitCount == 0);
+    VerifyOrExit(sInitCount == 0, OT_NOOP);
 
 #if !OPENTHREAD_RADIO
     sCtrDrbg.Deinit();
@@ -175,7 +175,7 @@ int RandomManager::Entropy::HandleMbedtlsEntropyPoll(void *         aData,
     SuccessOrExit(otPlatEntropyGet(reinterpret_cast<uint8_t *>(aOutput), static_cast<uint16_t>(aInLen)));
     rval = 0;
 
-    VerifyOrExit(aOutLen != NULL);
+    VerifyOrExit(aOutLen != NULL, OT_NOOP);
     *aOutLen = aInLen;
 
 exit:

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -126,7 +126,7 @@ void TimerScheduler::Add(Timer &aTimer, const AlarmApi &aAlarmApi)
 
 void TimerScheduler::Remove(Timer &aTimer, const AlarmApi &aAlarmApi)
 {
-    VerifyOrExit(aTimer.IsRunning());
+    VerifyOrExit(aTimer.IsRunning(), OT_NOOP);
 
     if (mTimerList.GetHead() == &aTimer)
     {
@@ -188,7 +188,7 @@ extern "C" void otPlatAlarmMilliFired(otInstance *aInstance)
 {
     Instance *instance = static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(otInstanceIsInitialized(aInstance));
+    VerifyOrExit(otInstanceIsInitialized(aInstance), OT_NOOP);
     instance->Get<TimerMilliScheduler>().ProcessTimers();
 
 exit:
@@ -224,7 +224,7 @@ extern "C" void otPlatAlarmMicroFired(otInstance *aInstance)
 {
     Instance *instance = static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(otInstanceIsInitialized(aInstance));
+    VerifyOrExit(otInstanceIsInitialized(aInstance), OT_NOOP);
     instance->Get<TimerMicroScheduler>().ProcessTimers();
 
 exit:

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -120,12 +120,12 @@ otError Tlv::Find(const Message &aMessage, uint8_t aType, uint16_t *aOffset, uin
     Tlv      tlv;
     uint32_t size;
 
-    VerifyOrExit(offset <= remainingLen);
+    VerifyOrExit(offset <= remainingLen, OT_NOOP);
     remainingLen -= offset;
 
     while (true)
     {
-        VerifyOrExit(sizeof(Tlv) <= remainingLen);
+        VerifyOrExit(sizeof(Tlv) <= remainingLen, OT_NOOP);
         aMessage.Read(offset, sizeof(Tlv), &tlv);
 
         if (tlv.mLength != kExtendedLength)
@@ -136,14 +136,14 @@ otError Tlv::Find(const Message &aMessage, uint8_t aType, uint16_t *aOffset, uin
         {
             ExtendedTlv extTlv;
 
-            VerifyOrExit(sizeof(ExtendedTlv) <= remainingLen);
+            VerifyOrExit(sizeof(ExtendedTlv) <= remainingLen, OT_NOOP);
             aMessage.Read(offset, sizeof(ExtendedTlv), &extTlv);
 
-            VerifyOrExit(extTlv.GetLength() <= (remainingLen - sizeof(ExtendedTlv)));
+            VerifyOrExit(extTlv.GetLength() <= (remainingLen - sizeof(ExtendedTlv)), OT_NOOP);
             size = extTlv.GetSize();
         }
 
-        VerifyOrExit(size <= remainingLen);
+        VerifyOrExit(size <= remainingLen, OT_NOOP);
 
         if (tlv.GetType() == aType)
         {
@@ -268,7 +268,7 @@ otError Tlv::AppendTlv(Message &aMessage, uint8_t aType, const uint8_t *aValue, 
     tlv.SetLength(aLength);
     SuccessOrExit(error = aMessage.Append(&tlv, sizeof(tlv)));
 
-    VerifyOrExit(aLength > 0);
+    VerifyOrExit(aLength > 0, OT_NOOP);
     error = aMessage.Append(aValue, aLength);
 
 exit:

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -95,7 +95,7 @@ void TrickleTimer::IndicateInconsistent(void)
 {
     // If interval is equal to minimum when an "inconsistent" event
     // is received, do nothing.
-    VerifyOrExit(mIsRunning && (mInterval != mIntervalMin));
+    VerifyOrExit(mIsRunning && (mInterval != mIntervalMin), OT_NOOP);
 
     mInterval = mIntervalMin;
     StartNewInterval();

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -488,7 +488,7 @@ void Diags::TransmitDone(otError aError)
         }
     }
 
-    VerifyOrExit(!mRepeatActive);
+    VerifyOrExit(!mRepeatActive, OT_NOOP);
     TransmitPacket();
 
 exit:

--- a/src/core/mac/channel_mask.cpp
+++ b/src/core/mac/channel_mask.cpp
@@ -78,7 +78,7 @@ uint8_t ChannelMask::ChooseRandomChannel(void) const
     uint8_t channel = kChannelIteratorFirst;
     uint8_t randomIndex;
 
-    VerifyOrExit(!IsEmpty());
+    VerifyOrExit(!IsEmpty(), OT_NOOP);
 
     randomIndex = Random::NonCrypto::GetUint8InRange(0, GetNumberOfChannels());
 

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -130,12 +130,12 @@ void DataPollHandler::HandleDataPoll(Mac::RxFrame &aFrame)
     Child *      child;
     uint16_t     indirectMsgCount;
 
-    VerifyOrExit(aFrame.GetSecurityEnabled());
-    VerifyOrExit(!Get<Mle::MleRouter>().IsDetached());
+    VerifyOrExit(aFrame.GetSecurityEnabled(), OT_NOOP);
+    VerifyOrExit(!Get<Mle::MleRouter>().IsDetached(), OT_NOOP);
 
     SuccessOrExit(aFrame.GetSrcAddr(macSource));
     child = Get<ChildTable>().FindChild(macSource, Child::kInStateValidOrRestoring);
-    VerifyOrExit(child != NULL);
+    VerifyOrExit(child != NULL, OT_NOOP);
 
     child->SetLastHeard(TimerMilli::GetNow());
     child->ResetLinkFailures();
@@ -204,7 +204,7 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, otError aError
 {
     Child *child = mIndirectTxChild;
 
-    VerifyOrExit(child != NULL);
+    VerifyOrExit(child != NULL, OT_NOOP);
 
     mIndirectTxChild = NULL;
     HandleSentFrame(aFrame, aError, *child);

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -204,7 +204,7 @@ void DataPollSender::HandlePollSent(Mac::TxFrame &aFrame, otError aError)
     Mac::Address macDest;
     bool         shouldRecalculatePollPeriod = false;
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NOOP);
 
     if (!aFrame.IsEmpty())
     {
@@ -288,7 +288,7 @@ void DataPollSender::HandlePollTimeout(void)
     // a data poll indicated that a frame was pending, but no frame
     // was received after timeout interval.
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NOOP);
 
     mPollTimeoutCounter++;
 
@@ -309,7 +309,7 @@ exit:
 
 void DataPollSender::ProcessFrame(const Mac::RxFrame &aFrame)
 {
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NOOP);
 
     mPollTimeoutCounter = 0;
 
@@ -383,11 +383,11 @@ otError DataPollSender::StopFastPolls(void)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mFastPollsUsers != 0);
+    VerifyOrExit(mFastPollsUsers != 0, OT_NOOP);
 
     // If `mFastPollsUsers` hits the max, let it be cleared
     // from `HandlePollSent()` (after all fast polls are sent).
-    VerifyOrExit(mFastPollsUsers < kMaxFastPollsUsers);
+    VerifyOrExit(mFastPollsUsers < kMaxFastPollsUsers, OT_NOOP);
 
     mFastPollsUsers--;
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -295,7 +295,7 @@ void Mac::PerformActiveScan(void)
 
 void Mac::ReportActiveScanResult(const RxFrame *aBeaconFrame)
 {
-    VerifyOrExit(mActiveScanHandler != NULL);
+    VerifyOrExit(mActiveScanHandler != NULL, OT_NOOP);
 
     if (aBeaconFrame == NULL)
     {
@@ -352,7 +352,7 @@ void Mac::ReportEnergyScanResult(int8_t aRssi)
 {
     EnergyScanResult result;
 
-    VerifyOrExit((mEnergyScanHandler != NULL) && (aRssi != kInvalidRssiValue));
+    VerifyOrExit((mEnergyScanHandler != NULL) && (aRssi != kInvalidRssiValue), OT_NOOP);
 
     result.mChannel = mScanChannel;
     result.mMaxRssi = aRssi;
@@ -371,7 +371,7 @@ void Mac::EnergyScanDone(int8_t aEnergyScanMaxRssi)
 
 void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 {
-    VerifyOrExit(mRxOnWhenIdle != aRxOnWhenIdle);
+    VerifyOrExit(mRxOnWhenIdle != aRxOnWhenIdle, OT_NOOP);
 
     mRxOnWhenIdle = aRxOnWhenIdle;
 
@@ -417,7 +417,7 @@ otError Mac::SetPanChannel(uint8_t aChannel)
 
     mCcaSuccessRateTracker.Reset();
 
-    VerifyOrExit(!mUsingTemporaryChannel);
+    VerifyOrExit(!mUsingTemporaryChannel, OT_NOOP);
 
     mRadioChannel = mPanChannel;
 
@@ -605,7 +605,7 @@ void Mac::UpdateIdleMode(void)
 {
     bool shouldSleep = !mRxOnWhenIdle && !mPromiscuous;
 
-    VerifyOrExit(mOperation == kOperationIdle);
+    VerifyOrExit(mOperation == kOperationIdle, OT_NOOP);
 
 #if OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
     if (mShouldDelaySleep)
@@ -707,7 +707,7 @@ void Mac::HandleOperationTask(Tasklet &aTasklet)
 
 void Mac::PerformNextOperation(void)
 {
-    VerifyOrExit(mOperation == kOperationIdle);
+    VerifyOrExit(mOperation == kOperationIdle, OT_NOOP);
 
     if (!mEnabled)
     {
@@ -917,7 +917,7 @@ bool Mac::ShouldSendBeacon(void) const
 {
     bool shouldSend = false;
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NOOP);
 
     shouldSend = IsBeaconEnabled();
 
@@ -954,7 +954,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame, bool aProcessAesCcm)
     uint8_t           keyIdMode;
     const ExtAddress *extAddress = NULL;
 
-    VerifyOrExit(aFrame.GetSecurityEnabled());
+    VerifyOrExit(aFrame.GetSecurityEnabled(), OT_NOOP);
 
     aFrame.GetKeyIdMode(keyIdMode);
 
@@ -1166,7 +1166,7 @@ void Mac::RecordFrameTransmitStatus(const TxFrame &aFrame,
     Address   dstAddr;
     Neighbor *neighbor;
 
-    VerifyOrExit(!aFrame.IsEmpty());
+    VerifyOrExit(!aFrame.IsEmpty(), OT_NOOP);
 
     aFrame.GetDstAddr(dstAddr);
     neighbor = Get<Mle::MleRouter>().GetNeighbor(dstAddr);
@@ -1454,12 +1454,12 @@ otError Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Ne
     {
     case Frame::kKeyIdMode0:
         macKey = keyManager.GetKek().GetKey();
-        VerifyOrExit(macKey != NULL);
+        VerifyOrExit(macKey != NULL, OT_NOOP);
         extAddress = &aSrcAddr.GetExtended();
         break;
 
     case Frame::kKeyIdMode1:
-        VerifyOrExit(aNeighbor != NULL);
+        VerifyOrExit(aNeighbor != NULL, OT_NOOP);
 
         aFrame.GetKeyId(keyid);
         keyid--;
@@ -1491,14 +1491,14 @@ otError Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Ne
 
         if (aNeighbor->IsStateValid())
         {
-            VerifyOrExit(keySequence >= aNeighbor->GetKeySequence());
+            VerifyOrExit(keySequence >= aNeighbor->GetKeySequence(), OT_NOOP);
 
             if (keySequence == aNeighbor->GetKeySequence())
             {
                 // If frame counter is one off, then frame is a duplicate.
                 VerifyOrExit((frameCounter + 1) != aNeighbor->GetLinkFrameCounter(), error = OT_ERROR_DUPLICATED);
 
-                VerifyOrExit(frameCounter >= aNeighbor->GetLinkFrameCounter());
+                VerifyOrExit(frameCounter >= aNeighbor->GetLinkFrameCounter(), OT_NOOP);
             }
         }
 
@@ -1534,7 +1534,7 @@ otError Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Ne
     aesCcm.Finalize(tag, &tagLength);
 
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    VerifyOrExit(memcmp(tag, aFrame.GetFooter(), tagLength) == 0);
+    VerifyOrExit(memcmp(tag, aFrame.GetFooter(), tagLength) == 0, OT_NOOP);
 #endif
 
     if ((keyIdMode == Frame::kKeyIdMode1) && aNeighbor->IsStateValid())
@@ -1681,7 +1681,7 @@ void Mac::HandleReceivedFrame(RxFrame *aFrame, otError aError)
         // so the duplicate frame will not be passed to next
         // layer (`MeshForwarder`).
 
-        VerifyOrExit(mOperation == kOperationWaitingForData);
+        VerifyOrExit(mOperation == kOperationWaitingForData, OT_NOOP);
 
         // Fall through
 
@@ -2054,7 +2054,7 @@ uint8_t Mac::GetTimeIeOffset(const Frame &aFrame)
     const uint8_t *cur    = NULL;
 
     cur = reinterpret_cast<const uint8_t *>(aFrame.GetTimeIe());
-    VerifyOrExit(cur != NULL);
+    VerifyOrExit(cur != NULL, OT_NOOP);
 
     cur += sizeof(VendorIeHeader);
     offset = static_cast<uint8_t>(cur - base);

--- a/src/core/mac/mac_filter.cpp
+++ b/src/core/mac/mac_filter.cpp
@@ -75,7 +75,7 @@ Filter::FilterEntry *Filter::FindAvailableEntry(void)
 
     for (entry = &mFilterEntries[0]; entry < OT_ARRAY_END(mFilterEntries); entry++)
     {
-        VerifyOrExit(entry->IsInUse());
+        VerifyOrExit(entry->IsInUse(), OT_NOOP);
     }
 
     entry = NULL;

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -609,7 +609,7 @@ otError Frame::GetKeyId(uint8_t &aKeyId) const
     uint8_t        index = FindSecurityHeaderIndex();
     const uint8_t *buf   = GetPsdu() + index;
 
-    VerifyOrExit(index != kInvalidIndex);
+    VerifyOrExit(index != kInvalidIndex, OT_NOOP);
 
     keySourceLength = GetKeySourceLength(buf[0] & kKeyIdModeMask);
 
@@ -667,7 +667,7 @@ bool Frame::IsDataRequestCommand(void) const
     bool    isDataRequest = false;
     uint8_t commandId     = 0;
 
-    VerifyOrExit(GetType() == kFcfFrameMacCmd);
+    VerifyOrExit(GetType() == kFcfFrameMacCmd, OT_NOOP);
     SuccessOrExit(GetCommandId(commandId));
     isDataRequest = (commandId == kMacCmdDataRequest);
 
@@ -685,7 +685,7 @@ uint8_t Frame::GetFooterLength(void) const
     uint8_t footerLength = 0;
     uint8_t index        = FindSecurityHeaderIndex();
 
-    VerifyOrExit(index != kInvalidIndex);
+    VerifyOrExit(index != kInvalidIndex, OT_NOOP);
 
     switch ((GetPsdu() + index)[0] & kSecLevelMask)
     {
@@ -829,7 +829,7 @@ uint8_t Frame::FindPayloadIndex(void) const
     const uint8_t *footer = GetFooter();
 #endif
 
-    VerifyOrExit(index != kInvalidIndex);
+    VerifyOrExit(index != kInvalidIndex, OT_NOOP);
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
     cur = GetPsdu() + index;
@@ -928,7 +928,7 @@ const uint8_t *Frame::GetHeaderIe(uint8_t aIeId) const
     const uint8_t *cur     = NULL;
     const uint8_t *payload = GetPayload();
 
-    VerifyOrExit(index != kInvalidIndex);
+    VerifyOrExit(index != kInvalidIndex, OT_NOOP);
 
     cur = GetPsdu() + index;
 
@@ -969,7 +969,7 @@ const TimeIe *Frame::GetTimeIe(void) const
                                                    (VendorIeHeader::kVendorOuiNest >> 16) & 0xff};
 
     cur = GetHeaderIe(kHeaderIeVendor);
-    VerifyOrExit(cur != NULL);
+    VerifyOrExit(cur != NULL, OT_NOOP);
 
     cur += sizeof(HeaderIe);
 
@@ -1015,7 +1015,7 @@ void TxFrame::ProcessTransmitAesCcm(const ExtAddress &aExtAddress)
     Crypto::AesCcm aesCcm;
     otError        error;
 
-    VerifyOrExit(GetSecurityEnabled());
+    VerifyOrExit(GetSecurityEnabled(), OT_NOOP);
 
     SuccessOrExit(error = GetSecurityLevel(securityLevel));
     SuccessOrExit(error = GetFrameCounter(frameCounter));

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -130,7 +130,7 @@ otError SubMac::Enable(void)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mState == kStateDisabled);
+    VerifyOrExit(mState == kStateDisabled, OT_NOOP);
 
     SuccessOrExit(error = Get<Radio>().Enable());
     SuccessOrExit(error = Get<Radio>().Sleep());
@@ -264,7 +264,7 @@ void SubMac::BeginTransmit(void)
 
     OT_UNUSED_VARIABLE(error);
 
-    VerifyOrExit(mState == kStateCsmaBackoff);
+    VerifyOrExit(mState == kStateCsmaBackoff, OT_NOOP);
 
     mTransmitFrame.SetCsmaCaEnabled(true);
 
@@ -491,7 +491,7 @@ bool SubMac::ShouldHandleCsmaBackOff(void) const
     VerifyOrExit(!RadioSupportsCsmaBackoff(), swCsma = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-    VerifyOrExit(Get<LinkRaw>().IsEnabled());
+    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NOOP);
 #endif
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE || OPENTHREAD_RADIO
@@ -509,7 +509,7 @@ bool SubMac::ShouldHandleAckTimeout(void) const
     VerifyOrExit(!RadioSupportsAckTimeout(), swAckTimeout = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-    VerifyOrExit(Get<LinkRaw>().IsEnabled());
+    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NOOP);
 #endif
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE || OPENTHREAD_RADIO
@@ -527,7 +527,7 @@ bool SubMac::ShouldHandleRetries(void) const
     VerifyOrExit(!RadioSupportsRetries(), swRetries = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-    VerifyOrExit(Get<LinkRaw>().IsEnabled());
+    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NOOP);
 #endif
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE || OPENTHREAD_RADIO
@@ -545,7 +545,7 @@ bool SubMac::ShouldHandleEnergyScan(void) const
     VerifyOrExit(!RadioSupportsEnergyScan(), swEnergyScan = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-    VerifyOrExit(Get<LinkRaw>().IsEnabled());
+    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NOOP);
 #endif
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE || OPENTHREAD_RADIO

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -367,10 +367,10 @@ void BorderAgent::HandleStateChanged(Notifier::Callback &aCallback, otChangedFla
 
 void BorderAgent::HandleStateChanged(otChangedFlags aFlags)
 {
-    VerifyOrExit((aFlags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_COMMISSIONER_STATE)) != 0);
+    VerifyOrExit((aFlags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_COMMISSIONER_STATE)) != 0, OT_NOOP);
 
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-    VerifyOrExit(Get<MeshCoP::Commissioner>().IsDisabled());
+    VerifyOrExit(Get<MeshCoP::Commissioner>().IsDisabled(), OT_NOOP);
 #endif
 
     if (Get<Mle::MleRouter>().IsAttached())
@@ -544,7 +544,7 @@ void BorderAgent::HandleRelayTransmit(const Coap::Message &aMessage)
     Ip6::MessageInfo messageInfo;
     uint16_t         offset = 0;
 
-    VerifyOrExit(aMessage.IsNonConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.IsNonConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
     SuccessOrExit(error = Tlv::ReadUint16Tlv(aMessage, Tlv::kJoinerRouterLocator, joinerRouterRloc));
 

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -155,7 +155,7 @@ otError Commissioner::Start(otCommissionerStateCallback  aStateCallback,
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
     error = Get<MeshCoP::BorderAgent>().Stop();
-    VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY);
+    VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY, OT_NOOP);
 #endif
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().Start(SendRelayTransmit, this));
@@ -573,7 +573,7 @@ void Commissioner::HandleMgmtCommissionerGetResponse(Coap::Message *         aMe
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED, OT_NOOP);
     otLogInfoMeshCoP("received MGMT_COMMISSIONER_GET response");
 
 exit:
@@ -662,7 +662,7 @@ void Commissioner::HandleMgmtCommissionerSetResponse(Coap::Message *         aMe
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED, OT_NOOP);
     otLogInfoMeshCoP("received MGMT_COMMISSIONER_SET response");
 
 exit:
@@ -724,7 +724,7 @@ void Commissioner::HandleLeaderPetitionResponse(Coap::Message *         aMessage
     uint8_t state;
     bool    retransmit = false;
 
-    VerifyOrExit(mState != OT_COMMISSIONER_STATE_ACTIVE);
+    VerifyOrExit(mState != OT_COMMISSIONER_STATE_ACTIVE, OT_NOOP);
     VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED,
                  retransmit = (mState == OT_COMMISSIONER_STATE_PETITION));
 
@@ -824,7 +824,7 @@ void Commissioner::HandleLeaderKeepAliveResponse(Coap::Message *         aMessag
 
     uint8_t state;
 
-    VerifyOrExit(mState == OT_COMMISSIONER_STATE_ACTIVE);
+    VerifyOrExit(mState == OT_COMMISSIONER_STATE_ACTIVE, OT_NOOP);
     VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == OT_COAP_CODE_CHANGED, Stop(/* aResign */ false));
 
     otLogInfoMeshCoP("received Leader keep-alive response");
@@ -861,7 +861,7 @@ void Commissioner::HandleRelayReceive(Coap::Message &aMessage, const Ip6::Messag
 
     VerifyOrExit(mState == OT_COMMISSIONER_STATE_ACTIVE, error = OT_ERROR_INVALID_STATE);
 
-    VerifyOrExit(aMessage.IsNonConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.IsNonConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
     SuccessOrExit(error = Tlv::ReadUint16Tlv(aMessage, Tlv::kJoinerUdpPort, joinerPort));
     SuccessOrExit(error = Tlv::ReadTlv(aMessage, Tlv::kJoinerIid, joinerIid, sizeof(joinerIid)));
@@ -906,7 +906,7 @@ void Commissioner::HandleRelayReceive(Coap::Message &aMessage, const Ip6::Messag
         enableJoiner = (memcmp(mJoinerIid, joinerIid, sizeof(mJoinerIid)) == 0);
     }
 
-    VerifyOrExit(enableJoiner);
+    VerifyOrExit(enableJoiner, OT_NOOP);
 
     mJoinerPort = joinerPort;
     mJoinerRloc = joinerRloc;
@@ -936,7 +936,7 @@ void Commissioner::HandleDatasetChanged(void *aContext, otMessage *aMessage, con
 
 void Commissioner::HandleDatasetChanged(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
     otLogInfoMeshCoP("received dataset changed");
 
@@ -1011,7 +1011,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Message &aRequest, State
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
 
-    VerifyOrExit(message->GetLength() <= sizeof(buf));
+    VerifyOrExit(message->GetLength() <= sizeof(buf), OT_NOOP);
     message->Read(message->GetOffset(), message->GetLength() - message->GetOffset(), buf);
     otDumpCertMeshCoP("[THCI] direction=send | type=JOIN_FIN.rsp |", buf, message->GetLength() - message->GetOffset());
 #endif

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -368,13 +368,13 @@ const Timestamp *Dataset::GetTimestamp(void) const
     if (mType == Tlv::kActiveTimestamp)
     {
         const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(Get(mType));
-        VerifyOrExit(tlv != NULL);
+        VerifyOrExit(tlv != NULL, OT_NOOP);
         timestamp = static_cast<const Timestamp *>(tlv);
     }
     else
     {
         const PendingTimestampTlv *tlv = static_cast<const PendingTimestampTlv *>(Get(mType));
-        VerifyOrExit(tlv != NULL);
+        VerifyOrExit(tlv != NULL, OT_NOOP);
         timestamp = static_cast<const Timestamp *>(tlv);
     }
 
@@ -446,7 +446,7 @@ void Dataset::Remove(Tlv::Type aType)
 {
     Tlv *tlv;
 
-    VerifyOrExit((tlv = Get(aType)) != NULL);
+    VerifyOrExit((tlv = Get(aType)) != NULL, OT_NOOP);
     Remove(reinterpret_cast<uint8_t *>(tlv), sizeof(Tlv) + tlv->GetLength());
 
 exit:
@@ -461,7 +461,7 @@ otError Dataset::AppendMleDatasetTlv(Message &aMessage) const
     const Tlv *    cur = reinterpret_cast<const Tlv *>(mTlvs);
     const Tlv *    end = reinterpret_cast<const Tlv *>(mTlvs + mLength);
 
-    VerifyOrExit(mLength > 0);
+    VerifyOrExit(mLength > 0, OT_NOOP);
 
     type = (mType == Tlv::kActiveTimestamp ? Mle::Tlv::kActiveDataset : Mle::Tlv::kPendingDataset);
 

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -106,7 +106,7 @@ otError DatasetLocal::Read(Dataset &aDataset) const
     else
     {
         delayTimer = static_cast<DelayTimerTlv *>(aDataset.Get(Tlv::kDelayTimer));
-        VerifyOrExit(delayTimer);
+        VerifyOrExit(delayTimer, OT_NOOP);
 
         elapsed = TimerMilli::GetNow() - mUpdateTime;
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -220,7 +220,7 @@ otError DatasetManager::GetChannelMask(Mac::ChannelMask &aChannelMask) const
 
     channelMaskTlv = static_cast<const MeshCoP::ChannelMaskTlv *>(dataset.Get(MeshCoP::Tlv::kChannelMask));
     VerifyOrExit(channelMaskTlv != NULL, error = OT_ERROR_NOT_FOUND);
-    VerifyOrExit((mask = channelMaskTlv->GetChannelMask()) != 0);
+    VerifyOrExit((mask = channelMaskTlv->GetChannelMask()) != 0, OT_NOOP);
 
     aChannelMask.SetMask(mask & Get<Mac::Mac>().GetSupportedChannelMask().GetMask());
 
@@ -232,9 +232,9 @@ exit:
 
 void DatasetManager::HandleTimer(void)
 {
-    VerifyOrExit(Get<Mle::MleRouter>().IsAttached());
+    VerifyOrExit(Get<Mle::MleRouter>().IsAttached(), OT_NOOP);
 
-    VerifyOrExit(mLocal.Compare(GetTimestamp()) < 0);
+    VerifyOrExit(mLocal.Compare(GetTimestamp()) < 0, OT_NOOP);
 
     if (mLocal.GetType() == Tlv::kActiveTimestamp)
     {
@@ -319,7 +319,7 @@ void DatasetManager::HandleGet(const Coap::Message &aMessage, const Ip6::Message
     }
 
     // MGMT_PENDING_GET.rsp must include Delay Timer TLV (Thread 1.1.1 Section 8.7.5.4)
-    VerifyOrExit(length > 0 && strcmp(mUriGet, OT_URI_PATH_PENDING_GET) == 0);
+    VerifyOrExit(length > 0 && strcmp(mUriGet, OT_URI_PATH_PENDING_GET) == 0, OT_NOOP);
 
     for (uint8_t i = 0; i < length; i++)
     {

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -194,7 +194,8 @@ void Dtls::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageI
     default:
         // Once DTLS session is started, communicate only with a peer.
         VerifyOrExit((mPeerAddress.GetPeerAddr() == aMessageInfo.GetPeerAddr()) &&
-                     (mPeerAddress.GetPeerPort() == aMessageInfo.GetPeerPort()));
+                         (mPeerAddress.GetPeerPort() == aMessageInfo.GetPeerPort()),
+                     OT_NOOP);
         break;
     }
 
@@ -265,7 +266,7 @@ otError Dtls::Setup(bool aClient)
 
     rval = mbedtls_ssl_config_defaults(&mConf, aClient ? MBEDTLS_SSL_IS_CLIENT : MBEDTLS_SSL_IS_SERVER,
                                        MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_PRESET_DEFAULT);
-    VerifyOrExit(rval == 0);
+    VerifyOrExit(rval == 0, OT_NOOP);
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
     if (mVerifyPeerCertificate && mCipherSuites[0] == MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8)
@@ -294,14 +295,14 @@ otError Dtls::Setup(bool aClient)
     if (!aClient)
     {
         rval = mbedtls_ssl_cookie_setup(&mCookieCtx, mbedtls_ctr_drbg_random, Random::Crypto::MbedTlsContextGet());
-        VerifyOrExit(rval == 0);
+        VerifyOrExit(rval == 0, OT_NOOP);
 
         mbedtls_ssl_conf_dtls_cookies(&mConf, mbedtls_ssl_cookie_write, mbedtls_ssl_cookie_check, &mCookieCtx);
     }
 #endif
 
     rval = mbedtls_ssl_setup(&mSsl, &mConf);
-    VerifyOrExit(rval == 0);
+    VerifyOrExit(rval == 0, OT_NOOP);
 
     mbedtls_ssl_set_bio(&mSsl, this, &Dtls::HandleMbedtlsTransmit, HandleMbedtlsReceive, NULL);
     mbedtls_ssl_set_timer_cb(&mSsl, this, &Dtls::HandleMbedtlsSetTimer, HandleMbedtlsGetTimer);
@@ -316,7 +317,7 @@ otError Dtls::Setup(bool aClient)
         rval = SetApplicationCoapSecureKeys();
     }
 #endif // OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-    VerifyOrExit(rval == 0);
+    VerifyOrExit(rval == 0, OT_NOOP);
 
     mReceiveMessage = NULL;
     mMessageSubType = Message::kSubTypeNone;
@@ -360,7 +361,7 @@ int Dtls::SetApplicationCoapSecureKeys(void)
         {
             rval = mbedtls_x509_crt_parse(&mCaChain, static_cast<const unsigned char *>(mCaChainSrc),
                                           static_cast<size_t>(mCaChainLength));
-            VerifyOrExit(rval == 0);
+            VerifyOrExit(rval == 0, OT_NOOP);
             mbedtls_ssl_conf_ca_chain(&mConf, &mCaChain, NULL);
         }
 
@@ -368,12 +369,12 @@ int Dtls::SetApplicationCoapSecureKeys(void)
         {
             rval = mbedtls_x509_crt_parse(&mOwnCert, static_cast<const unsigned char *>(mOwnCertSrc),
                                           static_cast<size_t>(mOwnCertLength));
-            VerifyOrExit(rval == 0);
+            VerifyOrExit(rval == 0, OT_NOOP);
             rval = mbedtls_pk_parse_key(&mPrivateKey, static_cast<const unsigned char *>(mPrivateKeySrc),
                                         static_cast<size_t>(mPrivateKeyLength), NULL, 0);
-            VerifyOrExit(rval == 0);
+            VerifyOrExit(rval == 0, OT_NOOP);
             rval = mbedtls_ssl_conf_own_cert(&mConf, &mOwnCert, &mPrivateKey);
-            VerifyOrExit(rval == 0);
+            VerifyOrExit(rval == 0, OT_NOOP);
         }
 #endif // MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
         break;
@@ -382,7 +383,7 @@ int Dtls::SetApplicationCoapSecureKeys(void)
 #ifdef MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
         rval = mbedtls_ssl_conf_psk(&mConf, static_cast<const unsigned char *>(mPreSharedKey), mPreSharedKeyLength,
                                     static_cast<const unsigned char *>(mPreSharedKeyIdentity), mPreSharedKeyIdLength);
-        VerifyOrExit(rval == 0);
+        VerifyOrExit(rval == 0, OT_NOOP);
 #endif // MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
         break;
 
@@ -419,7 +420,7 @@ void Dtls::Close(void)
 
 void Dtls::Disconnect(void)
 {
-    VerifyOrExit(mState == kStateConnecting || mState == kStateConnected);
+    VerifyOrExit(mState == kStateConnecting || mState == kStateConnected, OT_NOOP);
 
     mbedtls_ssl_close_notify(&mSsl);
     mState = kStateCloseNotify;

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -127,14 +127,14 @@ void EnergyScanClient::HandleReport(Coap::Message &aMessage, const Ip6::MessageI
         uint8_t                list[OPENTHREAD_CONFIG_TMF_ENERGY_SCAN_MAX_RESULTS];
     } OT_TOOL_PACKED_END energyList;
 
-    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
     otLogInfoMeshCoP("received energy scan report");
 
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NOOP);
 
     SuccessOrExit(MeshCoP::Tlv::GetTlv(aMessage, MeshCoP::Tlv::kEnergyList, sizeof(energyList), energyList.tlv));
-    VerifyOrExit(energyList.tlv.IsValid());
+    VerifyOrExit(energyList.tlv.IsValid(), OT_NOOP);
 
     if (mCallback != NULL)
     {

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -222,7 +222,7 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult, void *aContext)
 
 void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
 {
-    VerifyOrExit(mState == OT_JOINER_STATE_DISCOVER);
+    VerifyOrExit(mState == OT_JOINER_STATE_DISCOVER, OT_NOOP);
 
     if (aResult != NULL)
     {
@@ -272,7 +272,7 @@ void Joiner::SaveDiscoveredJoinerRouter(const otActiveScanResult &aResult)
         }
     }
 
-    VerifyOrExit(entry < end);
+    VerifyOrExit(entry < end, OT_NOOP);
 
     // Shift elements in array to make room for the new one.
     memmove(entry + 1, entry,
@@ -364,7 +364,7 @@ void Joiner::HandleSecureCoapClientConnect(bool aConnected, void *aContext)
 
 void Joiner::HandleSecureCoapClientConnect(bool aConnected)
 {
-    VerifyOrExit(mState == OT_JOINER_STATE_CONNECT);
+    VerifyOrExit(mState == OT_JOINER_STATE_CONNECT, OT_NOOP);
 
     if (aConnected)
     {
@@ -449,7 +449,7 @@ exit:
 
 void Joiner::FreeJoinerFinalizeMessage(void)
 {
-    VerifyOrExit(mState == OT_JOINER_STATE_IDLE && mFinalizeMessage != NULL);
+    VerifyOrExit(mState == OT_JOINER_STATE_IDLE && mFinalizeMessage != NULL, OT_NOOP);
 
     mFinalizeMessage->Free();
     mFinalizeMessage = NULL;
@@ -493,7 +493,8 @@ void Joiner::HandleJoinerFinalizeResponse(Coap::Message &         aMessage,
     uint8_t state;
 
     VerifyOrExit(mState == OT_JOINER_STATE_CONNECTED && aResult == OT_ERROR_NONE && aMessage.IsAck() &&
-                 aMessage.GetCode() == OT_COAP_CODE_CHANGED);
+                     aMessage.GetCode() == OT_COAP_CODE_CHANGED,
+                 OT_NOOP);
 
     SuccessOrExit(Tlv::ReadUint8Tlv(aMessage, Tlv::kState, state));
 
@@ -655,7 +656,7 @@ void Joiner::LogCertMessage(const char *aText, const Coap::Message &aMessage) co
 {
     uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
 
-    VerifyOrExit(aMessage.GetLength() <= sizeof(buf));
+    VerifyOrExit(aMessage.GetLength() <= sizeof(buf), OT_NOOP);
     aMessage.Read(aMessage.GetOffset(), aMessage.GetLength() - aMessage.GetOffset(), buf);
 
     otDumpCertMeshCoP(aText, buf, aMessage.GetLength() - aMessage.GetOffset());

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -73,14 +73,14 @@ void JoinerRouter::HandleStateChanged(Notifier::Callback &aCallback, otChangedFl
 
 void JoinerRouter::HandleStateChanged(otChangedFlags aFlags)
 {
-    VerifyOrExit(Get<Mle::MleRouter>().IsFullThreadDevice());
-    VerifyOrExit(aFlags & OT_CHANGED_THREAD_NETDATA);
+    VerifyOrExit(Get<Mle::MleRouter>().IsFullThreadDevice(), OT_NOOP);
+    VerifyOrExit(aFlags & OT_CHANGED_THREAD_NETDATA, OT_NOOP);
 
     if (Get<NetworkData::Leader>().IsJoiningEnabled())
     {
         Ip6::SockAddr sockaddr;
 
-        VerifyOrExit(!mSocket.IsBound());
+        VerifyOrExit(!mSocket.IsBound(), OT_NOOP);
 
         sockaddr.mPort = GetJoinerUdpPort();
 
@@ -91,7 +91,7 @@ void JoinerRouter::HandleStateChanged(otChangedFlags aFlags)
     }
     else
     {
-        VerifyOrExit(mSocket.IsBound());
+        VerifyOrExit(mSocket.IsBound(), OT_NOOP);
 
         Get<Ip6::Filter>().RemoveUnsecurePort(mSocket.GetSockName().mPort);
 
@@ -111,7 +111,7 @@ uint16_t JoinerRouter::GetJoinerUdpPort(void)
 
     joinerUdpPort = static_cast<const JoinerUdpPortTlv *>(
         Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kJoinerUdpPort));
-    VerifyOrExit(joinerUdpPort != NULL);
+    VerifyOrExit(joinerUdpPort != NULL, OT_NOOP);
 
     rval = joinerUdpPort->GetUdpPort();
 
@@ -280,8 +280,8 @@ void JoinerRouter::SendDelayedJoinerEntrust(void)
     JoinerEntrustMetadata metadata;
     Message *             message = mDelayedJoinEnts.GetHead();
 
-    VerifyOrExit(message != NULL);
-    VerifyOrExit(!mTimer.IsRunning());
+    VerifyOrExit(message != NULL, OT_NOOP);
+    VerifyOrExit(!mTimer.IsRunning(), OT_NOOP);
 
     metadata.ReadFrom(*message);
 
@@ -289,7 +289,7 @@ void JoinerRouter::SendDelayedJoinerEntrust(void)
     // change (i.e., retransmission). Otherweise, we wait for Joiner
     // Entrust Response before handling any other pending delayed
     // Jointer Entrust message.
-    VerifyOrExit(!mExpectJoinEntRsp || (Get<KeyManager>().GetKek() == metadata.mKek));
+    VerifyOrExit(!mExpectJoinEntRsp || (Get<KeyManager>().GetKek() == metadata.mKek), OT_NOOP);
 
     if (TimerMilli::GetNow() < metadata.mSendTime)
     {
@@ -447,9 +447,9 @@ void JoinerRouter::HandleJoinerEntrustResponse(Coap::Message *         aMessage,
     mExpectJoinEntRsp = false;
     SendDelayedJoinerEntrust();
 
-    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage != NULL);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage != NULL, OT_NOOP);
 
-    VerifyOrExit(aMessage->GetCode() == OT_COAP_CODE_CHANGED);
+    VerifyOrExit(aMessage->GetCode() == OT_COAP_CODE_CHANGED, OT_NOOP);
 
     otLogInfoMeshCoP("Receive joiner entrust response");
     otLogCertMeshCoP("[THCI] direction=recv | type=JOIN_ENT.rsp");

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -80,14 +80,15 @@ void Leader::HandlePetition(Coap::Message &aMessage, const Ip6::MessageInfo &aMe
 
     otLogInfoMeshCoP("received petition");
 
-    VerifyOrExit(Get<Mle::MleRouter>().IsRoutingLocator(aMessageInfo.GetPeerAddr()));
+    VerifyOrExit(Get<Mle::MleRouter>().IsRoutingLocator(aMessageInfo.GetPeerAddr()), OT_NOOP);
     SuccessOrExit(Tlv::GetTlv(aMessage, Tlv::kCommissionerId, sizeof(commissionerId), commissionerId));
 
     if (mTimer.IsRunning())
     {
         VerifyOrExit((commissionerId.GetCommissionerIdLength() == mCommissionerId.GetCommissionerIdLength()) &&
-                     (!strncmp(commissionerId.GetCommissionerId(), mCommissionerId.GetCommissionerId(),
-                               commissionerId.GetCommissionerIdLength())));
+                         (!strncmp(commissionerId.GetCommissionerId(), mCommissionerId.GetCommissionerId(),
+                                   commissionerId.GetCommissionerIdLength())),
+                     OT_NOOP);
 
         ResignCommissioner();
     }
@@ -286,7 +287,7 @@ void Leader::HandleTimer(Timer &aTimer)
 
 void Leader::HandleTimer(void)
 {
-    VerifyOrExit(Get<Mle::MleRouter>().IsLeader());
+    VerifyOrExit(Get<Mle::MleRouter>().IsLeader(), OT_NOOP);
 
     ResignCommissioner();
 

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -139,10 +139,10 @@ bool ChannelTlv::IsValid(void) const
 {
     bool ret = false;
 
-    VerifyOrExit(GetLength() == sizeof(*this) - sizeof(Tlv));
-    VerifyOrExit(mChannelPage <= OT_RADIO_CHANNEL_PAGE_MAX);
-    VerifyOrExit((1U << mChannelPage) & Radio::kSupportedChannelPages);
-    VerifyOrExit(Radio::kChannelMin <= GetChannel() && GetChannel() <= Radio::kChannelMax);
+    VerifyOrExit(GetLength() == sizeof(*this) - sizeof(Tlv), OT_NOOP);
+    VerifyOrExit(mChannelPage <= OT_RADIO_CHANNEL_PAGE_MAX, OT_NOOP);
+    VerifyOrExit((1U << mChannelPage) & Radio::kSupportedChannelPages, OT_NOOP);
+    VerifyOrExit(Radio::kChannelMin <= GetChannel() && GetChannel() <= Radio::kChannelMax, OT_NOOP);
     ret = true;
 
 exit:
@@ -175,7 +175,7 @@ const ChannelMaskEntryBase *ChannelMaskBaseTlv::GetFirstEntry(void) const
 {
     const ChannelMaskEntryBase *entry = NULL;
 
-    VerifyOrExit(GetLength() >= sizeof(ChannelMaskEntryBase));
+    VerifyOrExit(GetLength() >= sizeof(ChannelMaskEntryBase), OT_NOOP);
 
     entry = reinterpret_cast<const ChannelMaskEntryBase *>(GetValue());
     VerifyOrExit(GetLength() >= entry->GetEntrySize(), entry = NULL);
@@ -233,7 +233,7 @@ uint32_t ChannelMaskTlv::GetChannelMask(void) const
 
     for (; cur < end; cur = static_cast<const ChannelMaskEntry *>(cur->GetNext()))
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
+        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, OT_NOOP);
 
 #if OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
         if (cur->GetChannelPage() == OT_RADIO_CHANNEL_PAGE_2)
@@ -268,7 +268,7 @@ uint32_t ChannelMaskTlv::GetChannelMask(const Message &aMessage)
         ChannelMaskEntry entry;
 
         aMessage.Read(offset, sizeof(ChannelMaskEntryBase), &entry);
-        VerifyOrExit(offset + entry.GetEntrySize() <= end);
+        VerifyOrExit(offset + entry.GetEntrySize() <= end, OT_NOOP);
 
         switch (entry.GetChannelPage())
         {

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -117,13 +117,13 @@ void PanIdQueryClient::HandleConflict(Coap::Message &aMessage, const Ip6::Messag
     Ip6::MessageInfo responseInfo(aMessageInfo);
     uint32_t         mask;
 
-    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
     otLogInfoMeshCoP("received panid conflict");
 
     SuccessOrExit(Tlv::ReadUint16Tlv(aMessage, MeshCoP::Tlv::kPanId, panId));
 
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NOOP);
 
     if (mCallback != NULL)
     {

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -189,7 +189,8 @@ bool Dhcp6Client::ProcessNextIdentityAssociation()
     bool rval = false;
 
     // not interrupt in-progress solicit
-    VerifyOrExit(mIdentityAssociationCurrent == NULL || mIdentityAssociationCurrent->mStatus != kIaStatusSoliciting);
+    VerifyOrExit(mIdentityAssociationCurrent == NULL || mIdentityAssociationCurrent->mStatus != kIaStatusSoliciting,
+                 OT_NOOP);
 
     mTrickleTimer.Stop();
 
@@ -418,7 +419,7 @@ void Dhcp6Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aM
 
     Dhcp6Header header;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(header), &header) == sizeof(header));
+    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(header), &header) == sizeof(header), OT_NOOP);
     aMessage.MoveOffset(sizeof(header));
 
     if ((header.GetType() == kTypeReply) && (!memcmp(header.GetTransactionId(), mTransactionId, kTransactionIdSize)))
@@ -442,18 +443,18 @@ void Dhcp6Client::ProcessReply(Message &aMessage)
     }
 
     // Server Identifier
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionServerIdentifier)) > 0);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionServerIdentifier)) > 0, OT_NOOP);
     SuccessOrExit(ProcessServerIdentifier(aMessage, optionOffset));
 
     // Client Identifier
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionClientIdentifier)) > 0);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionClientIdentifier)) > 0, OT_NOOP);
     SuccessOrExit(ProcessClientIdentifier(aMessage, optionOffset));
 
     // Rapid Commit
-    VerifyOrExit(FindOption(aMessage, offset, length, kOptionRapidCommit) > 0);
+    VerifyOrExit(FindOption(aMessage, offset, length, kOptionRapidCommit) > 0, OT_NOOP);
 
     // IA_NA
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionIaNa)) > 0);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionIaNa)) > 0, OT_NOOP);
     SuccessOrExit(ProcessIaNa(aMessage, optionOffset));
 
     HandleTrickleTimer();
@@ -470,7 +471,7 @@ uint16_t Dhcp6Client::FindOption(Message &aMessage, uint16_t aOffset, uint16_t a
     while (aOffset <= end)
     {
         Dhcp6Option option;
-        VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option));
+        VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option), OT_NOOP);
 
         if (option.GetCode() == (aCode))
         {
@@ -489,7 +490,7 @@ otError Dhcp6Client::ProcessServerIdentifier(Message &aMessage, uint16_t aOffset
     otError          error = OT_ERROR_NONE;
     ServerIdentifier option;
 
-    VerifyOrExit((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)));
+    VerifyOrExit((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)), OT_NOOP);
     VerifyOrExit(((option.GetDuidType() == kDuidLLT) && (option.GetDuidHardwareType() == kHardwareTypeEthernet)) ||
                      ((option.GetLength() == (sizeof(option) - sizeof(Dhcp6Option))) &&
                       (option.GetDuidType() == kDuidLL) && (option.GetDuidHardwareType() == kHardwareTypeEui64)),

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -183,11 +183,11 @@ void Dhcp6Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aM
     Dhcp6Header  header;
     otIp6Address dst = aMessageInfo.mPeerAddr;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(header), &header) == sizeof(header));
+    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(header), &header) == sizeof(header), OT_NOOP);
     aMessage.MoveOffset(sizeof(header));
 
     // discard if not solicit type
-    VerifyOrExit((header.GetType() == kTypeSolicit));
+    VerifyOrExit((header.GetType() == kTypeSolicit), OT_NOOP);
 
     ProcessSolicit(aMessage, dst, header.GetTransactionId());
 
@@ -204,14 +204,14 @@ void Dhcp6Server::ProcessSolicit(Message &aMessage, otIp6Address &aDst, uint8_t 
     uint16_t         length = aMessage.GetLength() - aMessage.GetOffset();
 
     // Client Identifier (discard if not present)
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionClientIdentifier)) > 0);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionClientIdentifier)) > 0, OT_NOOP);
     SuccessOrExit(ProcessClientIdentifier(aMessage, optionOffset, clientIdentifier));
 
     // Server Identifier (assuming Rapid Commit, discard if present)
-    VerifyOrExit(FindOption(aMessage, offset, length, kOptionServerIdentifier) == 0);
+    VerifyOrExit(FindOption(aMessage, offset, length, kOptionServerIdentifier) == 0, OT_NOOP);
 
     // Rapid Commit (assuming Rapid Commit, discard if not present)
-    VerifyOrExit(FindOption(aMessage, offset, length, kOptionRapidCommit) > 0);
+    VerifyOrExit(FindOption(aMessage, offset, length, kOptionRapidCommit) > 0, OT_NOOP);
 
     // Elapsed Time if present
     if ((optionOffset = FindOption(aMessage, offset, length, kOptionElapsedTime)) > 0)
@@ -220,7 +220,7 @@ void Dhcp6Server::ProcessSolicit(Message &aMessage, otIp6Address &aDst, uint8_t 
     }
 
     // IA_NA (discard if not present)
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionIaNa)) > 0);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionIaNa)) > 0, OT_NOOP);
     SuccessOrExit(ProcessIaNa(aMessage, optionOffset, iana));
 
     SuccessOrExit(SendReply(aDst, aTransactionId, clientIdentifier, iana));
@@ -237,7 +237,7 @@ uint16_t Dhcp6Server::FindOption(Message &aMessage, uint16_t aOffset, uint16_t a
     while (aOffset <= end)
     {
         Dhcp6Option option;
-        VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option));
+        VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option), OT_NOOP);
 
         if (option.GetCode() == aCode)
         {
@@ -291,7 +291,7 @@ otError Dhcp6Server::ProcessIaNa(Message &aMessage, uint16_t aOffset, IaNa &aIaN
 
     while (length > 0)
     {
-        VerifyOrExit((optionOffset = FindOption(aMessage, aOffset, length, kOptionIaAddress)) > 0);
+        VerifyOrExit((optionOffset = FindOption(aMessage, aOffset, length, kOptionIaAddress)) > 0, OT_NOOP);
         SuccessOrExit(error = ProcessIaAddress(aMessage, optionOffset));
 
         length -= ((optionOffset - aOffset) + sizeof(IaAddress));

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -171,7 +171,7 @@ Message *Client::NewMessage(const Header &aHeader)
 {
     Message *message = NULL;
 
-    VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != NULL);
+    VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != NULL, OT_NOOP);
     message->Prepend(&aHeader, sizeof(aHeader));
     message->SetOffset(0);
 
@@ -469,15 +469,16 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
     Message *          message = NULL;
     uint16_t           offset;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(responseHeader), &responseHeader) ==
-                 sizeof(responseHeader));
+    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(responseHeader), &responseHeader) == sizeof(responseHeader),
+                 OT_NOOP);
     VerifyOrExit(responseHeader.GetType() == Header::kTypeResponse && responseHeader.GetQuestionCount() == 1 &&
-                 !responseHeader.IsTruncationFlagSet());
+                     !responseHeader.IsTruncationFlagSet(),
+                 OT_NOOP);
 
     aMessage.MoveOffset(sizeof(responseHeader));
     offset = aMessage.GetOffset();
 
-    VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != NULL);
+    VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != NULL, OT_NOOP);
 
     VerifyOrExit(responseHeader.GetResponseCode() == Header::kResponseSuccess, error = OT_ERROR_FAILED);
 

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -104,10 +104,10 @@ otError Icmp::SendError(IcmpHeader::Type   aType,
 
     if (ip6Header.GetNextHeader() == kProtoIcmp6)
     {
-        VerifyOrExit(aMessage.GetLength() >= (sizeof(ip6Header) + sizeof(icmp6Header)));
+        VerifyOrExit(aMessage.GetLength() >= (sizeof(ip6Header) + sizeof(icmp6Header)), OT_NOOP);
 
         aMessage.Read(sizeof(ip6Header), sizeof(icmp6Header), &icmp6Header);
-        VerifyOrExit(!icmp6Header.IsError());
+        VerifyOrExit(!icmp6Header.IsError(), OT_NOOP);
     }
 
     messageInfoLocal = aMessageInfo;
@@ -202,7 +202,8 @@ otError Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMe
 
     // always handle Echo Request destined for RLOC or ALOC
     VerifyOrExit(ShouldHandleEchoRequest(aMessageInfo) || aMessageInfo.GetSockAddr().IsRoutingLocator() ||
-                 aMessageInfo.GetSockAddr().IsAnycastRoutingLocator());
+                     aMessageInfo.GetSockAddr().IsAnycastRoutingLocator(),
+                 OT_NOOP);
 
     otLogInfoIcmp("Received Echo Request");
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -86,7 +86,7 @@ Message *Ip6::NewMessage(const uint8_t *aData, uint16_t aDataLength, const otMes
 
     SuccessOrExit(GetDatagramPriority(aData, aDataLength, priority));
     settings.mPriority = static_cast<otMessagePriority>(priority);
-    VerifyOrExit((message = Get<MessagePool>().New(Message::kTypeIp6, 0, &settings)) != NULL);
+    VerifyOrExit((message = Get<MessagePool>().New(Message::kTypeIp6, 0, &settings)) != NULL, OT_NOOP);
 
     if (message->Append(aData, aDataLength) != OT_ERROR_NONE)
     {
@@ -254,7 +254,8 @@ otError Ip6::InsertMplOption(Message &aMessage, Header &aHeader, MessageInfo &aM
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aHeader.GetDestination().IsMulticast() &&
-                 aHeader.GetDestination().GetScope() >= Address::kRealmLocalScope);
+                     aHeader.GetDestination().GetScope() >= Address::kRealmLocalScope,
+                 OT_NOOP);
 
     if (aHeader.GetDestination().IsRealmLocalMulticast())
     {
@@ -343,7 +344,7 @@ otError Ip6::RemoveMplOption(Message &aMessage)
     offset = 0;
     aMessage.Read(offset, sizeof(ip6Header), &ip6Header);
     offset += sizeof(ip6Header);
-    VerifyOrExit(ip6Header.GetNextHeader() == kProtoHopOpts);
+    VerifyOrExit(ip6Header.GetNextHeader() == kProtoHopOpts, OT_NOOP);
 
     aMessage.Read(offset, sizeof(hbh), &hbh);
     endOffset = offset + (hbh.GetLength() + 1) * 8;

--- a/src/core/net/ip6_filter.cpp
+++ b/src/core/net/ip6_filter.cpp
@@ -68,16 +68,16 @@ bool Filter::Accept(Message &aMessage) const
     }
 
     // Read IPv6 header
-    VerifyOrExit(sizeof(ip6) == aMessage.Read(0, sizeof(ip6), &ip6));
+    VerifyOrExit(sizeof(ip6) == aMessage.Read(0, sizeof(ip6), &ip6), OT_NOOP);
 
     // Allow only link-local unicast or multicast
-    VerifyOrExit(ip6.GetDestination().IsLinkLocal() || ip6.GetDestination().IsLinkLocalMulticast());
+    VerifyOrExit(ip6.GetDestination().IsLinkLocal() || ip6.GetDestination().IsLinkLocalMulticast(), OT_NOOP);
 
     switch (ip6.GetNextHeader())
     {
     case kProtoUdp:
         // Read the UDP header and get the dst port
-        VerifyOrExit(sizeof(udp) == aMessage.Read(sizeof(ip6), sizeof(udp), &udp));
+        VerifyOrExit(sizeof(udp) == aMessage.Read(sizeof(ip6), sizeof(udp), &udp), OT_NOOP);
 
         dstport = udp.GetDestinationPort();
 
@@ -96,7 +96,7 @@ bool Filter::Accept(Message &aMessage) const
 
     case kProtoTcp:
         // Read the TCP header and get the dst port
-        VerifyOrExit(sizeof(tcp) == aMessage.Read(sizeof(ip6), sizeof(tcp), &tcp));
+        VerifyOrExit(sizeof(tcp) == aMessage.Read(sizeof(ip6), sizeof(tcp), &tcp), OT_NOOP);
 
         dstport = tcp.GetDestinationPort();
 

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -309,7 +309,7 @@ void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSeque
     uint8_t interval = kDataMessageInterval;
 #endif
 
-    VerifyOrExit(GetTimerExpirations() > 0);
+    VerifyOrExit(GetTimerExpirations() > 0, OT_NOOP);
     VerifyOrExit((messageCopy = aMessage.Clone()) != NULL, error = OT_ERROR_NO_BUFS);
 
     if (!aIsOutbound)

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -143,7 +143,7 @@ otError Netif::SubscribeAllNodesMulticast(void)
 
     Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_SUBSCRIBED);
 
-    VerifyOrExit(mAddressCallback != NULL);
+    VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
 
     for (const NetifMulticastAddress *entry = &linkLocalAllNodesAddress; entry; entry = entry->GetNext())
     {
@@ -191,7 +191,7 @@ otError Netif::UnsubscribeAllNodesMulticast(void)
 
     Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED);
 
-    VerifyOrExit(mAddressCallback != NULL);
+    VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
 
     for (const NetifMulticastAddress *entry = &linkLocalAllNodesAddress; entry; entry = entry->GetNext())
     {
@@ -247,7 +247,7 @@ otError Netif::SubscribeAllRoutersMulticast(void)
 
     Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_SUBSCRIBED);
 
-    VerifyOrExit(mAddressCallback != NULL);
+    VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
 
     for (const NetifMulticastAddress *entry = &linkLocalAllRoutersAddress; entry != &linkLocalAllNodesAddress;
          entry                              = entry->GetNext())
@@ -291,7 +291,7 @@ otError Netif::UnsubscribeAllRoutersMulticast(void)
 
     Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED);
 
-    VerifyOrExit(mAddressCallback != NULL);
+    VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
 
     for (const NetifMulticastAddress *entry = &linkLocalAllRoutersAddress; entry != &linkLocalAllNodesAddress;
          entry                              = entry->GetNext())
@@ -311,7 +311,7 @@ otError Netif::SubscribeMulticast(NetifMulticastAddress &aAddress)
 
     Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_SUBSCRIBED);
 
-    VerifyOrExit(mAddressCallback != NULL);
+    VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
     mAddressCallback(&aAddress.mAddress, kMulticastPrefixLength, /* IsAdded */ true, mAddressCallbackContext);
 
 exit:
@@ -326,7 +326,7 @@ otError Netif::UnsubscribeMulticast(const NetifMulticastAddress &aAddress)
 
     Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED);
 
-    VerifyOrExit(mAddressCallback != NULL);
+    VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
     mAddressCallback(&aAddress.mAddress, kMulticastPrefixLength, /* IsAdded */ false, mAddressCallbackContext);
 
 exit:
@@ -338,7 +338,7 @@ otError Netif::GetNextExternalMulticast(uint8_t &aIterator, Address &aAddress) c
     otError error = OT_ERROR_NOT_FOUND;
     size_t  num   = OT_ARRAY_LENGTH(mExtMulticastAddresses);
 
-    VerifyOrExit(aIterator < num);
+    VerifyOrExit(aIterator < num, OT_NOOP);
 
     for (uint8_t i = aIterator; i < num; i++)
     {
@@ -447,7 +447,7 @@ otError Netif::AddUnicastAddress(NetifUnicastAddress &aAddress)
 
     Get<Notifier>().Signal(aAddress.mRloc ? OT_CHANGED_THREAD_RLOC_ADDED : OT_CHANGED_IP6_ADDRESS_ADDED);
 
-    VerifyOrExit(mAddressCallback != NULL);
+    VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
     mAddressCallback(&aAddress.mAddress, aAddress.mPrefixLength, /* IsAdded */ true, mAddressCallbackContext);
 
 exit:
@@ -462,7 +462,7 @@ otError Netif::RemoveUnicastAddress(const NetifUnicastAddress &aAddress)
 
     Get<Notifier>().Signal(aAddress.mRloc ? OT_CHANGED_THREAD_RLOC_REMOVED : OT_CHANGED_IP6_ADDRESS_REMOVED);
 
-    VerifyOrExit(mAddressCallback != NULL);
+    VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
     mAddressCallback(&aAddress.mAddress, aAddress.mPrefixLength, /* IsAdded */ false, mAddressCallbackContext);
 
 exit:

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -177,7 +177,7 @@ Message *Client::NewMessage(const Header &aHeader)
 {
     Message *message = NULL;
 
-    VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != NULL);
+    VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != NULL, OT_NOOP);
     message->Prepend(&aHeader, sizeof(aHeader));
     message->SetOffset(0);
 
@@ -356,10 +356,10 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
     Message *     message  = NULL;
     uint64_t      unixTime = 0;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(responseHeader), &responseHeader) ==
-                 sizeof(responseHeader));
+    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(responseHeader), &responseHeader) == sizeof(responseHeader),
+                 OT_NOOP);
 
-    VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != NULL);
+    VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != NULL, OT_NOOP);
 
     // Check if response came from the server.
     VerifyOrExit(responseHeader.GetMode() == Header::kModeServer, error = OT_ERROR_FAILED);

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -325,12 +325,12 @@ otError Udp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
     aMessageInfo.mSockPort = udpHeader.GetDestinationPort();
 
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
-    VerifyOrExit(IsMle(GetInstance(), aMessageInfo.mSockPort));
+    VerifyOrExit(IsMle(GetInstance(), aMessageInfo.mSockPort), OT_NOOP);
 #endif
 
     for (UdpReceiver *receiver = mReceivers.GetHead(); receiver; receiver = receiver->GetNext())
     {
-        VerifyOrExit(!receiver->HandleMessage(aMessage, aMessageInfo));
+        VerifyOrExit(!receiver->HandleMessage(aMessage, aMessageInfo), OT_NOOP);
     }
 
     HandlePayload(aMessage, aMessageInfo);

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -149,7 +149,7 @@ otError AddressResolver::GetNextCacheEntry(EntryInfo &aInfo, Iterator &aIterator
         aInfo.mCanEvict       = true;
         aInfo.mValidLastTrans = entry->IsLastTransactionTimeValid();
 
-        VerifyOrExit(entry->IsLastTransactionTimeValid());
+        VerifyOrExit(entry->IsLastTransactionTimeValid(), OT_NOOP);
 
         aInfo.mLastTransTime = entry->GetLastTransactionTime();
         static_cast<Ip6::Address &>(aInfo.mMeshLocalEid).SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
@@ -252,7 +252,7 @@ AddressResolver::CacheEntry *AddressResolver::FindCacheEntry(const Ip6::Address 
     {
         aList = lists[index];
         entry = FindCacheEntryInList(*aList, aEid, aPrevEntry);
-        VerifyOrExit(entry == NULL);
+        VerifyOrExit(entry == NULL, OT_NOOP);
     }
 
 exit:
@@ -271,7 +271,7 @@ void AddressResolver::Remove(const Ip6::Address &aEid, Reason aReason)
     CacheEntryList *list;
 
     entry = FindCacheEntry(aEid, list, prev);
-    VerifyOrExit(entry != NULL);
+    VerifyOrExit(entry != NULL, OT_NOOP);
 
     RemoveCacheEntry(*entry, *list, prev, aReason);
     mUnusedList.Push(*entry);
@@ -298,7 +298,7 @@ AddressResolver::CacheEntry *AddressResolver::NewCacheEntry(bool aSnoopedEntry)
     // evicted till timeout).
 
     newEntry = mUnusedList.Pop();
-    VerifyOrExit(newEntry == NULL);
+    VerifyOrExit(newEntry == NULL, OT_NOOP);
 
     for (uint8_t index = 0; index < OT_ARRAY_LENGTH(lists); index++)
     {
@@ -339,7 +339,7 @@ AddressResolver::CacheEntry *AddressResolver::NewCacheEntry(bool aSnoopedEntry)
             // snooped entries that are in timeout mode and cannot be
             // evicted by `kMaxNonEvictableSnoopedEntries`.
 
-            VerifyOrExit(numNonEvictable < kMaxNonEvictableSnoopedEntries);
+            VerifyOrExit(numNonEvictable < kMaxNonEvictableSnoopedEntries, OT_NOOP);
         }
     }
 
@@ -374,7 +374,7 @@ otError AddressResolver::UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAd
 
     if ((list == &mCachedList) || (list == &mSnoopedList))
     {
-        VerifyOrExit(entry->GetRloc16() != aRloc16);
+        VerifyOrExit(entry->GetRloc16() != aRloc16, OT_NOOP);
         entry->SetRloc16(aRloc16);
     }
     else
@@ -602,7 +602,7 @@ void AddressResolver::HandleAddressNotification(Coap::Message &aMessage, const I
     CacheEntry *    entry;
     CacheEntry *    prev;
 
-    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
     SuccessOrExit(Tlv::ReadTlv(aMessage, ThreadTlv::kTarget, &target, sizeof(target)));
     SuccessOrExit(Tlv::ReadTlv(aMessage, ThreadTlv::kMeshLocalEid, meshLocalIid, sizeof(meshLocalIid)));
@@ -623,7 +623,7 @@ void AddressResolver::HandleAddressNotification(Coap::Message &aMessage, const I
                  target.ToString().AsCString(), rloc16);
 
     entry = FindCacheEntry(target, list, prev);
-    VerifyOrExit(entry != NULL);
+    VerifyOrExit(entry != NULL, OT_NOOP);
 
     if (list == &mCachedList)
     {
@@ -636,7 +636,7 @@ void AddressResolver::HandleAddressNotification(Coap::Message &aMessage, const I
 
             VerifyOrExit(entry->HasMeshLocalIid(meshLocalIid), SendAddressError(target, meshLocalIid, NULL));
 
-            VerifyOrExit(lastTransactionTime < entry->GetLastTransactionTime());
+            VerifyOrExit(lastTransactionTime < entry->GetLastTransactionTime(), OT_NOOP);
         }
     }
 
@@ -791,7 +791,7 @@ void AddressResolver::HandleAddressQuery(Coap::Message &aMessage, const Ip6::Mes
     Ip6::Address target;
     uint32_t     lastTransactionTime;
 
-    VerifyOrExit(aMessage.IsNonConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.IsNonConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
     SuccessOrExit(Tlv::ReadTlv(aMessage, ThreadTlv::kTarget, &target, sizeof(target)));
 
@@ -979,9 +979,9 @@ void AddressResolver::HandleIcmpReceive(Message &               aMessage,
 
     Ip6::Header ip6Header;
 
-    VerifyOrExit(aIcmpHeader.GetType() == Ip6::IcmpHeader::kTypeDstUnreach);
-    VerifyOrExit(aIcmpHeader.GetCode() == Ip6::IcmpHeader::kCodeDstUnreachNoRoute);
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(ip6Header), &ip6Header) == sizeof(ip6Header));
+    VerifyOrExit(aIcmpHeader.GetType() == Ip6::IcmpHeader::kTypeDstUnreach, OT_NOOP);
+    VerifyOrExit(aIcmpHeader.GetCode() == Ip6::IcmpHeader::kCodeDstUnreachNoRoute, OT_NOOP);
+    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(ip6Header), &ip6Header) == sizeof(ip6Header), OT_NOOP);
 
     Remove(ip6Header.GetDestination(), kReasonReceivedIcmpDstUnreachNoRoute);
 

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -77,8 +77,8 @@ void AnnounceBeginServer::HandleRequest(Coap::Message &aMessage, const Ip6::Mess
     uint16_t         period;
     Ip6::MessageInfo responseInfo(aMessageInfo);
 
-    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST);
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
+    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NOOP);
 
     SuccessOrExit(Tlv::ReadUint8Tlv(aMessage, MeshCoP::Tlv::kCount, count));
     SuccessOrExit(Tlv::ReadUint16Tlv(aMessage, MeshCoP::Tlv::kPeriod, period));

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -93,7 +93,7 @@ void AnnounceSenderBase::HandleTimer(void)
         if (mCount != 0)
         {
             mCount--;
-            VerifyOrExit(mCount != 0);
+            VerifyOrExit(mCount != 0, OT_NOOP);
         }
 
         mChannel = Mac::ChannelMask::kChannelIteratorFirst;
@@ -163,7 +163,7 @@ void AnnounceSender::CheckState(void)
         period = kMinTxPeriod;
     }
 
-    VerifyOrExit(!IsRunning() || (period != GetPeriod()) || (GetChannelMask() != channelMask));
+    VerifyOrExit(!IsRunning() || (period != GetPeriod()) || (GetChannelMask() != channelMask), OT_NOOP);
 
     SendAnnounce(channelMask, 0, period, kMaxJitter);
 

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -80,7 +80,7 @@ void ChildTable::Iterator::Advance(void)
     Child *     listStart  = &childTable.mChildren[0];
     Child *     listEnd    = &childTable.mChildren[childTable.mMaxChildrenAllowed];
 
-    VerifyOrExit(mChild != NULL);
+    VerifyOrExit(mChild != NULL, OT_NOOP);
 
     do
     {
@@ -121,7 +121,7 @@ Child *ChildTable::GetChildAtIndex(uint16_t aChildIndex)
 {
     Child *child = NULL;
 
-    VerifyOrExit(aChildIndex < mMaxChildrenAllowed);
+    VerifyOrExit(aChildIndex < mMaxChildrenAllowed, OT_NOOP);
     child = &mChildren[aChildIndex];
 
 exit:

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -76,13 +76,13 @@ void EnergyScanServer::HandleRequest(Coap::Message &aMessage, const Ip6::Message
     Ip6::MessageInfo responseInfo(aMessageInfo);
     uint32_t         mask;
 
-    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
     SuccessOrExit(Tlv::ReadUint8Tlv(aMessage, MeshCoP::Tlv::kCount, count));
     SuccessOrExit(Tlv::ReadUint16Tlv(aMessage, MeshCoP::Tlv::kPeriod, period));
     SuccessOrExit(Tlv::ReadUint16Tlv(aMessage, MeshCoP::Tlv::kScanDuration, scanDuration));
 
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NOOP);
 
     mChannelMask        = mask;
     mChannelMaskCurrent = mChannelMask;
@@ -112,7 +112,7 @@ void EnergyScanServer::HandleTimer(Timer &aTimer)
 
 void EnergyScanServer::HandleTimer(void)
 {
-    VerifyOrExit(mActive);
+    VerifyOrExit(mActive, OT_NOOP);
 
     if (mCount)
     {
@@ -136,11 +136,11 @@ void EnergyScanServer::HandleScanResult(Mac::EnergyScanResult *aResult, void *aC
 
 void EnergyScanServer::HandleScanResult(Mac::EnergyScanResult *aResult)
 {
-    VerifyOrExit(mActive);
+    VerifyOrExit(mActive, OT_NOOP);
 
     if (aResult)
     {
-        VerifyOrExit(mScanResultsLength < OPENTHREAD_CONFIG_TMF_ENERGY_SCAN_MAX_RESULTS);
+        VerifyOrExit(mScanResultsLength < OPENTHREAD_CONFIG_TMF_ENERGY_SCAN_MAX_RESULTS, OT_NOOP);
         mScanResults[mScanResultsLength++] = aResult->mMaxRssi;
     }
     else

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -70,7 +70,7 @@ IndirectSender::IndirectSender(Instance &aInstance)
 
 void IndirectSender::Stop(void)
 {
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NOOP);
 
     for (ChildTable::Iterator iter(GetInstance(), Child::kInStateAnyExceptInvalid); !iter.IsDone(); iter++)
     {
@@ -124,7 +124,7 @@ void IndirectSender::ClearAllMessagesForSleepyChild(Child &aChild)
     Message *message;
     Message *nextMessage;
 
-    VerifyOrExit(aChild.GetIndirectMessageCount() > 0);
+    VerifyOrExit(aChild.GetIndirectMessageCount() > 0, OT_NOOP);
 
     for (message = Get<MeshForwarder>().mSendQueue.GetHead(); message; message = nextMessage)
     {
@@ -155,7 +155,7 @@ exit:
 
 void IndirectSender::SetChildUseShortAddress(Child &aChild, bool aUseShortAddress)
 {
-    VerifyOrExit(aChild.IsIndirectSourceMatchShort() != aUseShortAddress);
+    VerifyOrExit(aChild.IsIndirectSourceMatchShort() != aUseShortAddress, OT_NOOP);
 
     mSourceMatchController.SetSrcMatchAsShort(aChild, aUseShortAddress);
 
@@ -260,11 +260,11 @@ void IndirectSender::RequestMessageUpdate(Child &aChild)
         ExitNow();
     }
 
-    VerifyOrExit(!aChild.IsWaitingForMessageUpdate());
+    VerifyOrExit(!aChild.IsWaitingForMessageUpdate(), OT_NOOP);
 
     newMessage = FindIndirectMessage(aChild);
 
-    VerifyOrExit(curMessage != newMessage);
+    VerifyOrExit(curMessage != newMessage, OT_NOOP);
 
     if (curMessage == NULL)
     {
@@ -281,7 +281,7 @@ void IndirectSender::RequestMessageUpdate(Child &aChild)
     // fragment. If a next fragment frame for message is already
     // prepared, we wait for the entire message to be delivered.
 
-    VerifyOrExit(aChild.GetIndirectFragmentOffset() == 0);
+    VerifyOrExit(aChild.GetIndirectFragmentOffset() == 0, OT_NOOP);
 
     aChild.SetWaitingForMessageUpdate(true);
     mDataPollHandler.RequestFrameChange(DataPollHandler::kReplaceFrame, aChild);
@@ -292,7 +292,7 @@ exit:
 
 void IndirectSender::HandleFrameChangeDone(Child &aChild)
 {
-    VerifyOrExit(aChild.IsWaitingForMessageUpdate());
+    VerifyOrExit(aChild.IsWaitingForMessageUpdate(), OT_NOOP);
     UpdateIndirectMessage(aChild);
 
 exit:
@@ -439,7 +439,7 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
     Message *message    = aChild.GetIndirectMessage();
     uint16_t nextOffset = aContext.mMessageNextOffset;
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NOOP);
 
     switch (aError)
     {

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -169,7 +169,7 @@ void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
         if (mKeySwitchGuardEnabled)
         {
             // Check if the guard timer has expired if key rotation is requested.
-            VerifyOrExit(mHoursSinceKeyRotation >= mKeySwitchGuardTime);
+            VerifyOrExit(mHoursSinceKeyRotation >= mKeySwitchGuardTime, OT_NOOP);
             StartKeyRotationTimer();
         }
 

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -133,7 +133,7 @@ RssAverager::InfoString RssAverager::ToString(void) const
 {
     InfoString string;
 
-    VerifyOrExit(mCount != 0);
+    VerifyOrExit(mCount != 0, OT_NOOP);
     string.Set("%d.%s", -(mAverage >> kPrecisionBitShift), kDigitsString[mAverage & kPrecisionBitMask]);
 
 exit:
@@ -154,7 +154,7 @@ void LinkQualityInfo::AddRss(int8_t aRss)
 {
     uint8_t oldLinkQuality = kNoLinkQuality;
 
-    VerifyOrExit(aRss != OT_RADIO_RSSI_INVALID);
+    VerifyOrExit(aRss != OT_RADIO_RSSI_INVALID, OT_NOOP);
 
     mLastRss = aRss;
 

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -678,12 +678,12 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     uint8_t              nextHeader;
     uint8_t *            bytes;
 
-    VerifyOrExit(cur + 2 <= end);
+    VerifyOrExit(cur + 2 <= end, OT_NOOP);
     hcCtl = ReadUint16(cur);
     cur += 2;
 
     // check Dispatch bits
-    VerifyOrExit((hcCtl & kHcDispatchMask) == kHcDispatch);
+    VerifyOrExit((hcCtl & kHcDispatchMask) == kHcDispatch, OT_NOOP);
 
     // Context Identifier
     srcContext.mPrefixLength = 0;
@@ -691,7 +691,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
 
     if ((hcCtl & kHcContextId) != 0)
     {
-        VerifyOrExit(cur < end);
+        VerifyOrExit(cur < end, OT_NOOP);
 
         if (networkData.GetContext(cur[0] >> 4, srcContext) != OT_ERROR_NONE)
         {
@@ -717,7 +717,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     // Traffic Class and Flow Label
     if ((hcCtl & kHcTrafficFlowMask) != kHcTrafficFlow)
     {
-        VerifyOrExit(cur < end);
+        VerifyOrExit(cur < end, OT_NOOP);
 
         bytes = reinterpret_cast<uint8_t *>(&aIp6Header);
         bytes[1] |= (cur[0] & 0xc0) >> 2;
@@ -731,7 +731,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
 
         if ((hcCtl & kHcFlowLabel) == 0)
         {
-            VerifyOrExit(cur + 3 <= end);
+            VerifyOrExit(cur + 3 <= end, OT_NOOP);
             bytes[1] |= cur[0] & 0x0f;
             bytes[2] |= cur[1];
             bytes[3] |= cur[2];
@@ -742,7 +742,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     // Next Header
     if ((hcCtl & kHcNextHeader) == 0)
     {
-        VerifyOrExit(cur < end);
+        VerifyOrExit(cur < end, OT_NOOP);
         aIp6Header.SetNextHeader(cur[0]);
         cur++;
         aCompressedNextHeader = false;
@@ -768,7 +768,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         break;
 
     default:
-        VerifyOrExit(cur < end);
+        VerifyOrExit(cur < end, OT_NOOP);
         aIp6Header.SetHopLimit(cur[0]);
         cur++;
         break;
@@ -780,7 +780,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     case kHcSrcAddrMode0:
         if ((hcCtl & kHcSrcAddrContext) == 0)
         {
-            VerifyOrExit(cur + sizeof(Ip6::Address) <= end);
+            VerifyOrExit(cur + sizeof(Ip6::Address) <= end, OT_NOOP);
             memcpy(&aIp6Header.GetSource(), cur, sizeof(aIp6Header.GetSource()));
             cur += sizeof(Ip6::Address);
         }
@@ -788,13 +788,13 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         break;
 
     case kHcSrcAddrMode1:
-        VerifyOrExit(cur + Ip6::Address::kInterfaceIdentifierSize <= end);
+        VerifyOrExit(cur + Ip6::Address::kInterfaceIdentifierSize <= end, OT_NOOP);
         aIp6Header.GetSource().SetIid(cur);
         cur += Ip6::Address::kInterfaceIdentifierSize;
         break;
 
     case kHcSrcAddrMode2:
-        VerifyOrExit(cur + 2 <= end);
+        VerifyOrExit(cur + 2 <= end, OT_NOOP);
         aIp6Header.GetSource().mFields.m8[11] = 0xff;
         aIp6Header.GetSource().mFields.m8[12] = 0xfe;
         memcpy(aIp6Header.GetSource().mFields.m8 + 14, cur, 2);
@@ -814,7 +814,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         }
         else
         {
-            VerifyOrExit(srcContextValid);
+            VerifyOrExit(srcContextValid, OT_NOOP);
             CopyContext(srcContext, aIp6Header.GetSource());
         }
     }
@@ -826,20 +826,20 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         switch (hcCtl & kHcDstAddrModeMask)
         {
         case kHcDstAddrMode0:
-            VerifyOrExit((hcCtl & kHcDstAddrContext) == 0);
-            VerifyOrExit(cur + sizeof(Ip6::Address) <= end);
+            VerifyOrExit((hcCtl & kHcDstAddrContext) == 0, OT_NOOP);
+            VerifyOrExit(cur + sizeof(Ip6::Address) <= end, OT_NOOP);
             memcpy(&aIp6Header.GetDestination(), cur, sizeof(aIp6Header.GetDestination()));
             cur += sizeof(Ip6::Address);
             break;
 
         case kHcDstAddrMode1:
-            VerifyOrExit(cur + Ip6::Address::kInterfaceIdentifierSize <= end);
+            VerifyOrExit(cur + Ip6::Address::kInterfaceIdentifierSize <= end, OT_NOOP);
             aIp6Header.GetDestination().SetIid(cur);
             cur += Ip6::Address::kInterfaceIdentifierSize;
             break;
 
         case kHcDstAddrMode2:
-            VerifyOrExit(cur + 2 <= end);
+            VerifyOrExit(cur + 2 <= end, OT_NOOP);
             aIp6Header.GetDestination().mFields.m8[11] = 0xff;
             aIp6Header.GetDestination().mFields.m8[12] = 0xfe;
             memcpy(aIp6Header.GetDestination().mFields.m8 + 14, cur, 2);
@@ -860,7 +860,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         }
         else
         {
-            VerifyOrExit(dstContextValid);
+            VerifyOrExit(dstContextValid, OT_NOOP);
             CopyContext(dstContext, aIp6Header.GetDestination());
         }
     }
@@ -875,27 +875,27 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
             switch (hcCtl & kHcDstAddrModeMask)
             {
             case kHcDstAddrMode0:
-                VerifyOrExit(cur + sizeof(Ip6::Address) <= end);
+                VerifyOrExit(cur + sizeof(Ip6::Address) <= end, OT_NOOP);
                 memcpy(aIp6Header.GetDestination().mFields.m8, cur, sizeof(Ip6::Address));
                 cur += sizeof(Ip6::Address);
                 break;
 
             case kHcDstAddrMode1:
-                VerifyOrExit(cur + 6 <= end);
+                VerifyOrExit(cur + 6 <= end, OT_NOOP);
                 aIp6Header.GetDestination().mFields.m8[1] = cur[0];
                 memcpy(aIp6Header.GetDestination().mFields.m8 + 11, cur + 1, 5);
                 cur += 6;
                 break;
 
             case kHcDstAddrMode2:
-                VerifyOrExit(cur + 4 <= end);
+                VerifyOrExit(cur + 4 <= end, OT_NOOP);
                 aIp6Header.GetDestination().mFields.m8[1] = cur[0];
                 memcpy(aIp6Header.GetDestination().mFields.m8 + 13, cur + 1, 3);
                 cur += 4;
                 break;
 
             case kHcDstAddrMode3:
-                VerifyOrExit(cur < end);
+                VerifyOrExit(cur < end, OT_NOOP);
                 aIp6Header.GetDestination().mFields.m8[1]  = 0x02;
                 aIp6Header.GetDestination().mFields.m8[15] = cur[0];
                 cur++;
@@ -907,8 +907,8 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
             switch (hcCtl & kHcDstAddrModeMask)
             {
             case 0:
-                VerifyOrExit(cur + 6 <= end);
-                VerifyOrExit(dstContextValid);
+                VerifyOrExit(cur + 6 <= end, OT_NOOP);
+                VerifyOrExit(dstContextValid, OT_NOOP);
                 aIp6Header.GetDestination().mFields.m8[1] = cur[0];
                 aIp6Header.GetDestination().mFields.m8[2] = cur[1];
                 aIp6Header.GetDestination().mFields.m8[3] = dstContext.mPrefixLength;
@@ -925,7 +925,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
 
     if ((hcCtl & kHcNextHeader) != 0)
     {
-        VerifyOrExit(cur < end);
+        VerifyOrExit(cur < end, OT_NOOP);
         SuccessOrExit(DispatchToNextHeader(cur[0], nextHeader));
         aIp6Header.SetNextHeader(nextHeader);
     }
@@ -949,30 +949,30 @@ int Lowpan::DecompressExtensionHeader(Message &aMessage, const uint8_t *aBuf, ui
     Ip6::OptionPad1 optionPad1;
     Ip6::OptionPadN optionPadN;
 
-    VerifyOrExit(cur < end);
+    VerifyOrExit(cur < end, OT_NOOP);
     cur++;
 
     // next header
     if (ctl & kExtHdrNextHeader)
     {
-        VerifyOrExit(cur < end);
+        VerifyOrExit(cur < end, OT_NOOP);
 
         len = cur[0];
         cur++;
 
-        VerifyOrExit(cur + len <= end);
+        VerifyOrExit(cur + len <= end, OT_NOOP);
         SuccessOrExit(DispatchToNextHeader(cur[len], nextHeader));
         hdr[0] = static_cast<uint8_t>(nextHeader);
     }
     else
     {
-        VerifyOrExit(cur + 2 <= end);
+        VerifyOrExit(cur + 2 <= end, OT_NOOP);
 
         hdr[0] = cur[0];
         len    = cur[1];
         cur += 2;
 
-        VerifyOrExit(cur + len <= end);
+        VerifyOrExit(cur + len <= end, OT_NOOP);
     }
 
     // length
@@ -1020,11 +1020,11 @@ int Lowpan::DecompressUdpHeader(Ip6::UdpHeader &aUdpHeader, const uint8_t *aBuf,
     const uint8_t *end   = aBuf + aBufLength;
     uint8_t        udpCtl;
 
-    VerifyOrExit(cur < end);
+    VerifyOrExit(cur < end, OT_NOOP);
     udpCtl = cur[0];
     cur++;
 
-    VerifyOrExit((udpCtl & kUdpDispatchMask) == kUdpDispatch);
+    VerifyOrExit((udpCtl & kUdpDispatchMask) == kUdpDispatch, OT_NOOP);
 
     memset(&aUdpHeader, 0, sizeof(aUdpHeader));
 
@@ -1032,28 +1032,28 @@ int Lowpan::DecompressUdpHeader(Ip6::UdpHeader &aUdpHeader, const uint8_t *aBuf,
     switch (udpCtl & kUdpPortMask)
     {
     case 0:
-        VerifyOrExit(cur + 4 <= end);
+        VerifyOrExit(cur + 4 <= end, OT_NOOP);
         aUdpHeader.SetSourcePort(ReadUint16(cur));
         aUdpHeader.SetDestinationPort(ReadUint16(cur + 2));
         cur += 4;
         break;
 
     case 1:
-        VerifyOrExit(cur + 3 <= end);
+        VerifyOrExit(cur + 3 <= end, OT_NOOP);
         aUdpHeader.SetSourcePort(ReadUint16(cur));
         aUdpHeader.SetDestinationPort(0xf000 | cur[2]);
         cur += 3;
         break;
 
     case 2:
-        VerifyOrExit(cur + 3 <= end);
+        VerifyOrExit(cur + 3 <= end, OT_NOOP);
         aUdpHeader.SetSourcePort(0xf000 | cur[0]);
         aUdpHeader.SetDestinationPort(ReadUint16(cur + 1));
         cur += 3;
         break;
 
     case 3:
-        VerifyOrExit(cur < end);
+        VerifyOrExit(cur < end, OT_NOOP);
         aUdpHeader.SetSourcePort(0xf0b0 | (cur[0] >> 4));
         aUdpHeader.SetDestinationPort(0xf0b0 | (cur[0] & 0xf));
         cur++;
@@ -1067,7 +1067,7 @@ int Lowpan::DecompressUdpHeader(Ip6::UdpHeader &aUdpHeader, const uint8_t *aBuf,
     }
     else
     {
-        VerifyOrExit(cur + 2 <= end);
+        VerifyOrExit(cur + 2 <= end, OT_NOOP);
         aUdpHeader.SetChecksum(ReadUint16(cur));
         cur += 2;
     }
@@ -1084,7 +1084,7 @@ int Lowpan::DecompressUdpHeader(Message &aMessage, const uint8_t *aBuf, uint16_t
     int            headerLen = -1;
 
     headerLen = DecompressUdpHeader(udpHeader, aBuf, aBufLength);
-    VerifyOrExit(headerLen >= 0);
+    VerifyOrExit(headerLen >= 0, OT_NOOP);
 
     // length
     if (aDatagramLength == 0)
@@ -1120,8 +1120,9 @@ int Lowpan::Decompress(Message &           aMessage,
     uint16_t       compressedLength = 0;
     uint16_t       currentOffset    = aMessage.GetOffset();
 
-    VerifyOrExit(remaining >= 2);
-    VerifyOrExit((rval = DecompressBaseHeader(ip6Header, compressed, aMacSource, aMacDest, cur, remaining)) >= 0);
+    VerifyOrExit(remaining >= 2, OT_NOOP);
+    VerifyOrExit((rval = DecompressBaseHeader(ip6Header, compressed, aMacSource, aMacDest, cur, remaining)) >= 0,
+                 OT_NOOP);
 
     cur += rval;
     remaining -= rval;
@@ -1131,7 +1132,7 @@ int Lowpan::Decompress(Message &           aMessage,
 
     while (compressed)
     {
-        VerifyOrExit(remaining >= 1);
+        VerifyOrExit(remaining >= 1, OT_NOOP);
 
         if ((cur[0] & kExtHdrDispatchMask) == kExtHdrDispatch)
         {
@@ -1142,25 +1143,26 @@ int Lowpan::Decompress(Message &           aMessage,
                 cur++;
                 remaining--;
 
-                VerifyOrExit((rval = Decompress(aMessage, aMacSource, aMacDest, cur, remaining, aDatagramLength)) >= 0);
+                VerifyOrExit((rval = Decompress(aMessage, aMacSource, aMacDest, cur, remaining, aDatagramLength)) >= 0,
+                             OT_NOOP);
             }
             else
             {
                 compressed = (cur[0] & kExtHdrNextHeader) != 0;
-                VerifyOrExit((rval = DecompressExtensionHeader(aMessage, cur, remaining)) >= 0);
+                VerifyOrExit((rval = DecompressExtensionHeader(aMessage, cur, remaining)) >= 0, OT_NOOP);
             }
         }
         else if ((cur[0] & kUdpDispatchMask) == kUdpDispatch)
         {
             compressed = false;
-            VerifyOrExit((rval = DecompressUdpHeader(aMessage, cur, remaining, aDatagramLength)) >= 0);
+            VerifyOrExit((rval = DecompressUdpHeader(aMessage, cur, remaining, aDatagramLength)) >= 0, OT_NOOP);
         }
         else
         {
             ExitNow();
         }
 
-        VerifyOrExit(remaining >= rval);
+        VerifyOrExit(remaining >= rval, OT_NOOP);
         cur += rval;
         remaining -= rval;
     }
@@ -1205,16 +1207,17 @@ otError MeshHeader::ParseFrom(const uint8_t *aFrame, uint16_t aFrameLength, uint
     otError error = OT_ERROR_PARSE;
     uint8_t dispatch;
 
-    VerifyOrExit(aFrameLength >= kMinHeaderLength);
+    VerifyOrExit(aFrameLength >= kMinHeaderLength, OT_NOOP);
     dispatch = *aFrame++;
 
-    VerifyOrExit((dispatch & (kDispatchMask | kSourceShort | kDestShort)) == (kDispatch | kSourceShort | kDestShort));
+    VerifyOrExit((dispatch & (kDispatchMask | kSourceShort | kDestShort)) == (kDispatch | kSourceShort | kDestShort),
+                 OT_NOOP);
 
     mHopsLeft = (dispatch & kHopsLeftMask);
 
     if (mHopsLeft == kDeepHopsLeft)
     {
-        VerifyOrExit(aFrameLength >= kDeepHopsHeaderLength);
+        VerifyOrExit(aFrameLength >= kDeepHopsHeaderLength, OT_NOOP);
         mHopsLeft     = *aFrame++;
         aHeaderLength = kDeepHopsHeaderLength;
     }
@@ -1316,14 +1319,14 @@ otError FragmentHeader::ParseFrom(const uint8_t *aFrame, uint16_t aFrameLength, 
 {
     otError error = OT_ERROR_PARSE;
 
-    VerifyOrExit(IsFragmentHeader(aFrame, aFrameLength));
+    VerifyOrExit(IsFragmentHeader(aFrame, aFrameLength), OT_NOOP);
 
     mSize = ReadUint16(aFrame + kSizeIndex) & kSizeMask;
     mTag  = ReadUint16(aFrame + kTagIndex);
 
     if ((*aFrame & kOffsetFlag) == kOffsetFlag)
     {
-        VerifyOrExit(aFrameLength >= kSubsequentFragmentHeaderSize);
+        VerifyOrExit(aFrameLength >= kSubsequentFragmentHeaderSize, OT_NOOP);
         mOffset       = aFrame[kOffsetIndex] * 8;
         aHeaderLength = kSubsequentFragmentHeaderSize;
     }

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -666,7 +666,7 @@ void MeshForwarder::UpdateRoutes(const uint8_t *     aFrame,
     Ip6::Header ip6Header;
     Neighbor *  neighbor;
 
-    VerifyOrExit(!aMeshDest.IsBroadcast() && aMeshSource.IsShort());
+    VerifyOrExit(!aMeshDest.IsBroadcast() && aMeshSource.IsShort(), OT_NOOP);
     SuccessOrExit(GetIp6Header(aFrame, aFrameLength, aMeshSource, aMeshDest, ip6Header));
 
     if (!ip6Header.GetSource().IsRoutingLocator() && !ip6Header.GetSource().IsAnycastRoutingLocator() &&
@@ -692,7 +692,7 @@ void MeshForwarder::UpdateRoutes(const uint8_t *     aFrame,
     }
 
     neighbor = Get<Mle::MleRouter>().GetNeighbor(ip6Header.GetSource());
-    VerifyOrExit(neighbor != NULL && !neighbor->IsFullThreadDevice());
+    VerifyOrExit(neighbor != NULL && !neighbor->IsFullThreadDevice(), OT_NOOP);
 
     if (!Mle::Mle::RouterIdMatch(aMeshSource.GetShort(), Get<Mac::Mac>().GetShortAddress()))
     {
@@ -732,7 +732,7 @@ void MeshForwarder::UpdateFragmentPriority(Lowpan::FragmentHeader &aFragmentHead
 
     if (aFragmentHeader.GetDatagramOffset() == 0)
     {
-        VerifyOrExit((entry = GetUnusedFragmentPriorityEntry()) != NULL);
+        VerifyOrExit((entry = GetUnusedFragmentPriorityEntry()) != NULL, OT_NOOP);
 
         entry->SetDatagramTag(aFragmentHeader.GetDatagramTag());
         entry->SetSrcRloc16(aSrcRloc16);
@@ -746,7 +746,8 @@ void MeshForwarder::UpdateFragmentPriority(Lowpan::FragmentHeader &aFragmentHead
     }
     else
     {
-        VerifyOrExit((entry = FindFragmentPriorityEntry(aFragmentHeader.GetDatagramTag(), aSrcRloc16)) != NULL);
+        VerifyOrExit((entry = FindFragmentPriorityEntry(aFragmentHeader.GetDatagramTag(), aSrcRloc16)) != NULL,
+                     OT_NOOP);
 
         entry->SetLifetime(kReassemblyTimeout);
 
@@ -995,7 +996,7 @@ otError MeshForwarder::LogMeshFragmentHeader(MessageAction       aAction,
         otLogMac(aLogLevel, "    Frag tag:%04x, offset:%d, size:%d", fragmentHeader.GetDatagramTag(),
                  fragmentHeader.GetDatagramOffset(), fragmentHeader.GetDatagramSize());
 
-        VerifyOrExit(fragmentHeader.GetDatagramOffset() == 0);
+        VerifyOrExit(fragmentHeader.GetDatagramOffset() == 0, OT_NOOP);
     }
 
     error = OT_ERROR_NONE;
@@ -1034,7 +1035,7 @@ otError MeshForwarder::DecompressIp6UdpTcpHeader(const Message &     aMessage,
 
     headerLength = Get<Lowpan::Lowpan>().DecompressBaseHeader(aIp6Header, nextHeaderCompressed, aMeshSource, aMeshDest,
                                                               frameBuffer, frameLength);
-    VerifyOrExit(headerLength >= 0);
+    VerifyOrExit(headerLength >= 0, OT_NOOP);
 
     aOffset += headerLength;
 
@@ -1047,11 +1048,12 @@ otError MeshForwarder::DecompressIp6UdpTcpHeader(const Message &     aMessage,
         {
             frameLength  = aMessage.Read(aOffset, sizeof(Ip6::UdpHeader), frameBuffer);
             headerLength = Get<Lowpan::Lowpan>().DecompressUdpHeader(header.udp, frameBuffer, frameLength);
-            VerifyOrExit(headerLength >= 0);
+            VerifyOrExit(headerLength >= 0, OT_NOOP);
         }
         else
         {
-            VerifyOrExit(sizeof(Ip6::UdpHeader) == aMessage.Read(aOffset, sizeof(Ip6::UdpHeader), &header.udp));
+            VerifyOrExit(sizeof(Ip6::UdpHeader) == aMessage.Read(aOffset, sizeof(Ip6::UdpHeader), &header.udp),
+                         OT_NOOP);
         }
 
         aChecksum   = header.udp.GetChecksum();
@@ -1060,7 +1062,7 @@ otError MeshForwarder::DecompressIp6UdpTcpHeader(const Message &     aMessage,
         break;
 
     case Ip6::kProtoTcp:
-        VerifyOrExit(sizeof(Ip6::TcpHeader) == aMessage.Read(aOffset, sizeof(Ip6::TcpHeader), &header.tcp));
+        VerifyOrExit(sizeof(Ip6::TcpHeader) == aMessage.Read(aOffset, sizeof(Ip6::TcpHeader), &header.tcp), OT_NOOP);
         aChecksum   = header.tcp.GetChecksum();
         aSourcePort = header.tcp.GetSourcePort();
         aDestPort   = header.tcp.GetDestinationPort();
@@ -1117,7 +1119,7 @@ void MeshForwarder::LogMeshMessage(MessageAction       aAction,
     // logged when the same Mesh Header message was received
     // and info about it was logged.
 
-    VerifyOrExit(aAction != kMessageTransmit);
+    VerifyOrExit(aAction != kMessageTransmit, OT_NOOP);
 
     LogMeshIpHeader(aMessage, offset, meshSource, meshDest, aLogLevel);
 

--- a/src/core/thread/mesh_forwarder_mtd.cpp
+++ b/src/core/thread/mesh_forwarder_mtd.cpp
@@ -57,7 +57,7 @@ otError MeshForwarder::EvictMessage(uint8_t aPriority)
     otError  error = OT_ERROR_NOT_FOUND;
     Message *message;
 
-    VerifyOrExit((message = mSendQueue.GetTail()) != NULL);
+    VerifyOrExit((message = mSendQueue.GetTail()) != NULL, OT_NOOP);
 
     if (message->GetPriority() < aPriority)
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -329,7 +329,7 @@ void Mle::Stop(bool aClearNetworkDatasets)
         Get<MeshCoP::PendingDataset>().HandleDetach();
     }
 
-    VerifyOrExit(!IsDisabled());
+    VerifyOrExit(!IsDisabled(), OT_NOOP);
 
     Get<KeyManager>().Stop();
     SetStateDetached();
@@ -383,7 +383,7 @@ exit:
 
 void Mle::SetAttachState(AttachState aState)
 {
-    VerifyOrExit(aState != mAttachState);
+    VerifyOrExit(aState != mAttachState, OT_NOOP);
     otLogInfoMle("AttachState %s -> %s", AttachStateToString(mAttachState), AttachStateToString(aState));
     mAttachState = aState;
 
@@ -408,7 +408,7 @@ otError Mle::Restore(void)
     mDeviceMode.Set(networkInfo.GetDeviceMode());
 
     // force re-attach when version mismatch.
-    VerifyOrExit(networkInfo.GetVersion() == kThreadVersion);
+    VerifyOrExit(networkInfo.GetVersion() == kThreadVersion, OT_NOOP);
 
     switch (networkInfo.GetRole())
     {
@@ -633,7 +633,7 @@ otError Mle::BecomeDetached(void)
     // (i.e., waiting to start an attach attempt), there is no need to make any
     // changes.
 
-    VerifyOrExit(!IsDetached() || mAttachState != kAttachStateStart);
+    VerifyOrExit(!IsDetached() || mAttachState != kAttachStateStart, OT_NOOP);
 
     // not in reattach stage after reset
     if (mReattachState == kReattachStop)
@@ -719,7 +719,7 @@ uint32_t Mle::GetAttachStartDelay(void) const
     uint32_t delay = 1;
     uint32_t jitter;
 
-    VerifyOrExit(IsDetached());
+    VerifyOrExit(IsDetached(), OT_NOOP);
 
     if (mAttachCounter == 0)
     {
@@ -846,11 +846,12 @@ void Mle::SetStateChild(uint16_t aRloc16)
 
 void Mle::InformPreviousChannel(void)
 {
-    VerifyOrExit(mAlternatePanId != Mac::kPanIdBroadcast);
-    VerifyOrExit(IsChild() || IsRouter());
+    VerifyOrExit(mAlternatePanId != Mac::kPanIdBroadcast, OT_NOOP);
+    VerifyOrExit(IsChild() || IsRouter(), OT_NOOP);
 
 #if OPENTHREAD_FTD
-    VerifyOrExit(!IsFullThreadDevice() || IsRouter() || Get<MleRouter>().GetRouterSelectionJitterTimeout() == 0);
+    VerifyOrExit(!IsFullThreadDevice() || IsRouter() || Get<MleRouter>().GetRouterSelectionJitterTimeout() == 0,
+                 OT_NOOP);
 #endif
 
     mAlternatePanId = Mac::kPanIdBroadcast;
@@ -862,7 +863,7 @@ exit:
 
 void Mle::SetTimeout(uint32_t aTimeout)
 {
-    VerifyOrExit(mTimeout != aTimeout);
+    VerifyOrExit(mTimeout != aTimeout, OT_NOOP);
 
     if (aTimeout < kMinTimeout)
     {
@@ -888,7 +889,7 @@ otError Mle::SetDeviceMode(DeviceMode aDeviceMode)
     DeviceMode oldMode = mDeviceMode;
 
     VerifyOrExit(aDeviceMode.IsValid(), error = OT_ERROR_INVALID_ARGS);
-    VerifyOrExit(mDeviceMode != aDeviceMode);
+    VerifyOrExit(mDeviceMode != aDeviceMode, OT_NOOP);
     mDeviceMode = aDeviceMode;
 
     otLogNoteMle("Mode 0x%02x -> 0x%02x [%s]", oldMode.Get(), mDeviceMode.Get(), mDeviceMode.ToString().AsCString());
@@ -971,7 +972,7 @@ void Mle::SetMeshLocalPrefix(const MeshLocalPrefix &aMeshLocalPrefix)
 #endif
 
     // Just keep mesh local prefix if network interface is down
-    VerifyOrExit(Get<ThreadNetif>().IsUp());
+    VerifyOrExit(Get<ThreadNetif>().IsUp(), OT_NOOP);
 
     ApplyMeshLocalPrefix();
 
@@ -984,7 +985,7 @@ void Mle::ApplyMeshLocalPrefix(void)
     mLinkLocalAllThreadNodes.GetAddress().SetMulticastNetworkPrefix(GetMeshLocalPrefix());
     mRealmLocalAllThreadNodes.GetAddress().SetMulticastNetworkPrefix(GetMeshLocalPrefix());
 
-    VerifyOrExit(!IsDisabled());
+    VerifyOrExit(!IsDisabled(), OT_NOOP);
 
     // Add the addresses back into the table.
     Get<ThreadNetif>().AddUnicastAddress(mMeshLocal64);
@@ -1167,7 +1168,7 @@ Message *Mle::NewMleMessage(void)
     otMessageSettings settings = {false, static_cast<otMessagePriority>(kMleMessagePriority)};
 
     message = mSocket.NewMessage(0, &settings);
-    VerifyOrExit(message != NULL);
+    VerifyOrExit(message != NULL, OT_NOOP);
 
     message->SetSubType(Message::kSubTypeMleGeneral);
 
@@ -1414,7 +1415,7 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
     length += entry.GetLength();
 
     // Continue to append the other addresses if not `kAppendMeshLocalOnly` mode
-    VerifyOrExit(aMode != kAppendMeshLocalOnly);
+    VerifyOrExit(aMode != kAppendMeshLocalOnly, OT_NOOP);
     counter++;
 
     for (const Ip6::NetifUnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr; addr = addr->GetNext())
@@ -1442,7 +1443,7 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
         length += entry.GetLength();
         counter++;
         // only continue to append if there is available entry.
-        VerifyOrExit(counter < OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER);
+        VerifyOrExit(counter < OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER, OT_NOOP);
     }
 
     // For sleepy end device, register external multicast addresses to the parent for indirect transmission
@@ -1461,7 +1462,7 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
 
             counter++;
             // only continue to append if there is available entry.
-            VerifyOrExit(counter < OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER);
+            VerifyOrExit(counter < OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER, OT_NOOP);
         }
     }
 
@@ -1544,7 +1545,7 @@ void Mle::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlag
 
 void Mle::HandleStateChanged(otChangedFlags aFlags)
 {
-    VerifyOrExit(!IsDisabled());
+    VerifyOrExit(!IsDisabled(), OT_NOOP);
 
     if (aFlags & OT_CHANGED_THREAD_ROLE)
     {
@@ -1680,7 +1681,7 @@ void Mle::UpdateServiceAlocs(void)
     NetworkData::Iterator serviceIterator    = NetworkData::kIteratorInit;
     int                   serviceAlocsLength = OT_ARRAY_LENGTH(mServiceAlocs);
 
-    VerifyOrExit(!IsDisabled());
+    VerifyOrExit(!IsDisabled(), OT_NOOP);
 
     // First remove all alocs which are no longer necessary, to free up space in mServiceAlocs
     for (i = 0; i < serviceAlocsLength; i++)
@@ -1871,7 +1872,8 @@ bool Mle::PrepareAnnounceState(void)
     Mac::ChannelMask channelMask;
 
     VerifyOrExit(!IsChild() && (mReattachState == kReattachStop) &&
-                 (Get<MeshCoP::ActiveDataset>().IsPartiallyComplete() || !IsFullThreadDevice()));
+                     (Get<MeshCoP::ActiveDataset>().IsPartiallyComplete() || !IsFullThreadDevice()),
+                 OT_NOOP);
 
     if (Get<MeshCoP::ActiveDataset>().GetChannelMask(channelMask) != OT_ERROR_NONE)
     {
@@ -1915,7 +1917,7 @@ uint32_t Mle::Reattach(void)
         Get<MeshCoP::ActiveDataset>().Restore();
     }
 
-    VerifyOrExit(mReattachState == kReattachStop);
+    VerifyOrExit(mReattachState == kReattachStop, OT_NOOP);
 
     switch (mParentRequestMode)
     {
@@ -2319,7 +2321,7 @@ void Mle::HandleMessageTransmissionTimer(void)
         }
 
         // Keep-alive "Child Update Request" only on a non-sleepy child
-        VerifyOrExit(IsChild() && IsRxOnWhenIdle());
+        VerifyOrExit(IsChild() && IsRxOnWhenIdle(), OT_NOOP);
         break;
 
     case kChildUpdateRequestPending:
@@ -2680,7 +2682,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 
     otLogDebgMle("Receive UDP message");
 
-    VerifyOrExit(aMessageInfo.GetLinkInfo() != NULL);
+    VerifyOrExit(aMessageInfo.GetLinkInfo() != NULL, OT_NOOP);
     VerifyOrExit(aMessageInfo.GetHopLimit() == kMleHopLimit, error = OT_ERROR_PARSE);
 
     length = aMessage.Read(aMessage.GetOffset(), sizeof(header), &header);
@@ -2950,7 +2952,7 @@ otError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo
         ExitNow();
 
     case kRoleChild:
-        VerifyOrExit(aNeighbor == &mParent);
+        VerifyOrExit(aNeighbor == &mParent, OT_NOOP);
 
         if ((mParent.GetRloc16() == sourceAddress) && (leaderData.GetPartitionId() != mLeaderData.GetPartitionId() ||
                                                        leaderData.GetLeaderRouterId() != GetLeaderId()))
@@ -2978,7 +2980,7 @@ otError Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo
 
     case kRoleRouter:
     case kRoleLeader:
-        VerifyOrExit(aNeighbor && aNeighbor->IsStateValid());
+        VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), OT_NOOP);
         break;
     }
 
@@ -3076,7 +3078,7 @@ otError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &a
     }
     else if (!mRetrieveNewNetworkData)
     {
-        VerifyOrExit(IsNetworkDataNewer(leaderData));
+        VerifyOrExit(IsNetworkDataNewer(leaderData), OT_NOOP);
     }
 
     // Active Timestamp
@@ -3345,25 +3347,26 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
         switch (mParentRequestMode)
         {
         case kAttachAny:
-            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId() || diff > 0);
+            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId() || diff > 0, OT_NOOP);
             break;
 
         case kAttachSame1:
         case kAttachSame2:
-            VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId());
-            VerifyOrExit(diff > 0);
+            VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId(), OT_NOOP);
+            VerifyOrExit(diff > 0, OT_NOOP);
             break;
 
         case kAttachSameDowngrade:
-            VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId());
-            VerifyOrExit(diff >= 0);
+            VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId(), OT_NOOP);
+            VerifyOrExit(diff >= 0, OT_NOOP);
             break;
 
         case kAttachBetter:
-            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId());
+            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId(), OT_NOOP);
 
             VerifyOrExit(MleRouter::ComparePartitions(connectivity.GetActiveRouters() <= 1, leaderData,
-                                                      Get<MleRouter>().IsSingleton(), mLeaderData) > 0);
+                                                      Get<MleRouter>().IsSingleton(), mLeaderData) > 0,
+                         OT_NOOP);
             break;
         }
     }
@@ -3386,12 +3389,13 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
         }
 
         // only consider partitions that are the same or better
-        VerifyOrExit(compare >= 0);
+        VerifyOrExit(compare >= 0, OT_NOOP);
 #endif
 
         // only consider better parents if the partitions are the same
         VerifyOrExit(compare != 0 || IsBetterParent(sourceAddress, linkQuality, linkMargin, connectivity,
-                                                    static_cast<uint8_t>(version)));
+                                                    static_cast<uint8_t>(version)),
+                     OT_NOOP);
     }
 
     // Link Frame Counter
@@ -3414,7 +3418,7 @@ otError Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInf
     // Time Parameter
     if (Tlv::GetTlv(aMessage, Tlv::kTimeParameter, sizeof(timeParameter), timeParameter) == OT_ERROR_NONE)
     {
-        VerifyOrExit(timeParameter.IsValid());
+        VerifyOrExit(timeParameter.IsValid(), OT_NOOP);
 
         Get<TimeSync>().SetTimeSyncPeriod(timeParameter.GetTimeSyncPeriod());
         Get<TimeSync>().SetXtalThreshold(timeParameter.GetXtalThreshold());
@@ -3491,7 +3495,7 @@ otError Mle::HandleChildIdResponse(const Message &         aMessage,
 
     VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), error = OT_ERROR_SECURITY);
 
-    VerifyOrExit(mAttachState == kAttachStateChildIdRequest);
+    VerifyOrExit(mAttachState == kAttachStateChildIdRequest, OT_NOOP);
 
     // Leader Data
     SuccessOrExit(error = ReadLeaderData(aMessage, leaderData));
@@ -3851,11 +3855,12 @@ otError Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMe
         // Announce message.
 
         VerifyOrExit(!IsDetached() || (Get<Mac::Mac>().GetPanChannel() != channel) ||
-                     (Get<Mac::Mac>().GetPanId() != panId));
+                         (Get<Mac::Mac>().GetPanId() != panId),
+                     OT_NOOP);
 
         if (mAttachState == kAttachStateProcessAnnounce)
         {
-            VerifyOrExit(mAlternateTimestamp < timestamp.GetSeconds());
+            VerifyOrExit(mAlternateTimestamp < timestamp.GetSeconds(), OT_NOOP);
         }
 
         mAlternateTimestamp = timestamp.GetSeconds();
@@ -3980,7 +3985,8 @@ otError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Message
             if (mDiscoverEnableFiltering)
             {
                 VerifyOrExit((steeringData.GetBit(mDiscoverCcittIndex % steeringData.GetNumBits()) &&
-                              steeringData.GetBit(mDiscoverAnsiIndex % steeringData.GetNumBits())));
+                              steeringData.GetBit(mDiscoverAnsiIndex % steeringData.GetNumBits())),
+                             OT_NOOP);
             }
 
             didCheckSteeringData         = true;
@@ -4002,7 +4008,7 @@ otError Mle::HandleDiscoveryResponse(const Message &aMessage, const Ip6::Message
         offset += sizeof(meshcopTlv) + meshcopTlv.GetLength();
     }
 
-    VerifyOrExit(!mDiscoverEnableFiltering || didCheckSteeringData);
+    VerifyOrExit(!mDiscoverEnableFiltering || didCheckSteeringData, OT_NOOP);
 
     mDiscoverHandler(&result, mDiscoverContext);
 
@@ -4116,7 +4122,8 @@ otError Mle::InformPreviousParent(void)
     Message *        message = NULL;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit((mPreviousParentRloc != Mac::kShortAddrInvalid) && (mPreviousParentRloc != mParent.GetRloc16()));
+    VerifyOrExit((mPreviousParentRloc != Mac::kShortAddrInvalid) && (mPreviousParentRloc != mParent.GetRloc16()),
+                 OT_NOOP);
 
     mCounters.mParentChanges++;
 
@@ -4174,11 +4181,11 @@ void Mle::HandleParentSearchTimer(void)
 
     mParentSearchIsInBackoff = false;
 
-    VerifyOrExit(IsChild());
+    VerifyOrExit(IsChild(), OT_NOOP);
 
     parentRss = GetParent().GetLinkInfo().GetAverageRss();
     otLogInfoMle("PeriodicParentSearch: Parent RSS %d", parentRss);
-    VerifyOrExit(parentRss != OT_RADIO_RSSI_INVALID);
+    VerifyOrExit(parentRss != OT_RADIO_RSSI_INVALID, OT_NOOP);
 
     if (parentRss < kParentSearchRssThreadhold)
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -398,7 +398,7 @@ void MleRouter::StopAdvertiseTimer(void)
 
 void MleRouter::ResetAdvertiseInterval(void)
 {
-    VerifyOrExit(IsRouterOrLeader());
+    VerifyOrExit(IsRouterOrLeader(), OT_NOOP);
 
     if (!mAdvertiseTimer.IsRunning())
     {
@@ -423,13 +423,13 @@ otError MleRouter::SendAdvertisement(void)
     // Without this suppression, a device may send an MLE Advertisement before receiving the MLE Child ID Response.
     // The candidate parent then removes the attaching device because the Source Address TLV includes an RLOC16 that
     // indicates a Router role (i.e. a Child ID equal to zero).
-    VerifyOrExit(!IsAttaching());
+    VerifyOrExit(!IsAttaching(), OT_NOOP);
 
     // Suppress MLE Advertisements when transitioning to the router role.
     //
     // When trying to attach to a new partition, sending out advertisements as a REED can cause already-attached
     // children to detach.
-    VerifyOrExit(!mAddressSolicitPending);
+    VerifyOrExit(!mAddressSolicitPending, OT_NOOP);
 
     VerifyOrExit((message = NewMleMessage()) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, Header::kCommandAdvertisement));
@@ -625,7 +625,7 @@ otError MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::Message
             }
             else
             {
-                VerifyOrExit(neighbor->GetExtAddress() == macAddr);
+                VerifyOrExit(neighbor->GetExtAddress() == macAddr, OT_NOOP);
             }
         }
 
@@ -922,7 +922,7 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
         mRouterTable.Clear();
         SuccessOrExit(error = ProcessRouteTlv(route));
         router = mRouterTable.GetRouter(routerId);
-        VerifyOrExit(router != NULL);
+        VerifyOrExit(router != NULL, OT_NOOP);
 
         if (mLeaderData.GetLeaderRouterId() == RouterIdFromRloc16(GetRloc16()))
         {
@@ -942,16 +942,16 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
         break;
 
     case kRoleChild:
-        VerifyOrExit(router != NULL);
+        VerifyOrExit(router != NULL, OT_NOOP);
         break;
 
     case kRoleRouter:
     case kRoleLeader:
-        VerifyOrExit(router != NULL);
+        VerifyOrExit(router != NULL, OT_NOOP);
 
         // Leader Data
         SuccessOrExit(error = ReadLeaderData(aMessage, leaderData));
-        VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId());
+        VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId(), OT_NOOP);
 
         if (mRetrieveNewNetworkData ||
             (static_cast<int8_t>(leaderData.GetDataVersion() - Get<NetworkData::Leader>().GetVersion()) > 0))
@@ -1055,7 +1055,7 @@ uint8_t MleRouter::GetLinkCost(uint8_t aRouterId)
     router = mRouterTable.GetRouter(aRouterId);
 
     // NULL aRouterId indicates non-existing next hop, hence return kMaxRouteCost for it.
-    VerifyOrExit(router != NULL);
+    VerifyOrExit(router != NULL, OT_NOOP);
 
     rval = mRouterTable.GetLinkCost(*router);
 
@@ -1226,7 +1226,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
     }
     else if (leaderData.GetLeaderRouterId() != GetLeaderId())
     {
-        VerifyOrExit(aNeighbor && aNeighbor->IsStateValid());
+        VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), OT_NOOP);
 
         if (!IsChild())
         {
@@ -1238,7 +1238,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
         ExitNow();
     }
 
-    VerifyOrExit(IsActiveRouter(sourceAddress) && route.IsValid());
+    VerifyOrExit(IsActiveRouter(sourceAddress) && route.IsValid(), OT_NOOP);
     routerId = RouterIdFromRloc16(sourceAddress);
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
@@ -1352,7 +1352,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
         {
             // MLE Advertisement not from parent, but from some other neighboring router
             router = mRouterTable.GetRouter(routerId);
-            VerifyOrExit(router != NULL);
+            VerifyOrExit(router != NULL, OT_NOOP);
 
             if (IsFullThreadDevice() && !router->IsStateValid() && !router->IsStateLinkRequest() &&
                 (mRouterTable.GetActiveLinkCount() < OPENTHREAD_CONFIG_MLE_CHILD_ROUTER_LINKS))
@@ -1374,7 +1374,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
 
     case kRoleRouter:
         router = mRouterTable.GetRouter(routerId);
-        VerifyOrExit(router != NULL);
+        VerifyOrExit(router != NULL, OT_NOOP);
 
         // check current active router number
         routerCount = 0;
@@ -1398,7 +1398,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
 
     case kRoleLeader:
         router = mRouterTable.GetRouter(routerId);
-        VerifyOrExit(router != NULL);
+        VerifyOrExit(router != NULL, OT_NOOP);
 
         // Send unicast link request if no link to router and no unicast/multicast link request in progress
         if (!router->IsStateValid() && !router->IsStateLinkRequest() && (mChallengeTimeout == 0) &&
@@ -1437,7 +1437,7 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
     bool    changed          = false;
 
     neighbor = mRouterTable.GetRouter(aRouterId);
-    VerifyOrExit(neighbor != NULL);
+    VerifyOrExit(neighbor != NULL, OT_NOOP);
 
     // update link quality out to neighbor
     changed = UpdateLinkQualityOut(aRoute, *neighbor, resetAdvInterval);
@@ -1524,7 +1524,7 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
 
 #if (OPENTHREAD_CONFIG_LOG_MLE && (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO))
 
-    VerifyOrExit(changed);
+    VerifyOrExit(changed, OT_NOOP);
     otLogInfoMle("Route table updated");
 
     for (RouterTable::Iterator iter(GetInstance()); !iter.IsDone(); iter++)
@@ -1556,7 +1556,7 @@ bool MleRouter::UpdateLinkQualityOut(const RouteTlv &aRoute, Router &aNeighbor, 
     Router *nextHop;
 
     myRouterId = RouterIdFromRloc16(GetRloc16());
-    VerifyOrExit(aRoute.IsRouterIdSet(myRouterId));
+    VerifyOrExit(aRoute.IsRouterIdSet(myRouterId), OT_NOOP);
 
     myRouteCount = 0;
     for (uint8_t routerId = 0; routerId < myRouterId; routerId++)
@@ -1565,7 +1565,7 @@ bool MleRouter::UpdateLinkQualityOut(const RouteTlv &aRoute, Router &aNeighbor, 
     }
 
     linkQuality = aRoute.GetLinkQualityIn(myRouteCount);
-    VerifyOrExit(aNeighbor.GetLinkQualityOut() != linkQuality);
+    VerifyOrExit(aNeighbor.GetLinkQualityOut() != linkQuality, OT_NOOP);
 
     oldLinkCost = mRouterTable.GetLinkCost(aNeighbor);
 
@@ -1640,12 +1640,12 @@ otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::Messa
         ExitNow();
 
     case kRoleChild:
-        VerifyOrExit(ScanMaskTlv::IsEndDeviceFlagSet(scanMask));
+        VerifyOrExit(ScanMaskTlv::IsEndDeviceFlagSet(scanMask), OT_NOOP);
         break;
 
     case kRoleRouter:
     case kRoleLeader:
-        VerifyOrExit(ScanMaskTlv::IsRouterFlagSet(scanMask));
+        VerifyOrExit(ScanMaskTlv::IsRouterFlagSet(scanMask), OT_NOOP);
         break;
     }
 
@@ -1656,7 +1656,7 @@ otError MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::Messa
 
     if (child == NULL)
     {
-        VerifyOrExit((child = mChildTable.GetNewChild()) != NULL);
+        VerifyOrExit((child = mChildTable.GetNewChild()) != NULL, OT_NOOP);
 
         // MAC Address
         child->SetExtAddress(macAddr);
@@ -1707,7 +1707,7 @@ void MleRouter::HandleStateUpdateTimer(void)
 {
     bool routerStateUpdate = false;
 
-    VerifyOrExit(IsFullThreadDevice());
+    VerifyOrExit(IsFullThreadDevice(), OT_NOOP);
 
     mStateUpdateTimer.Start(kStateUpdatePeriod);
 
@@ -2703,7 +2703,7 @@ void MleRouter::HandleNetworkDataUpdateRouter(void)
     Ip6::Address         destination;
     uint16_t             delay;
 
-    VerifyOrExit(IsRouterOrLeader());
+    VerifyOrExit(IsRouterOrLeader(), OT_NOOP);
 
     destination.SetToLinkLocalAllNodesMulticast();
 
@@ -2718,7 +2718,7 @@ exit:
 
 void MleRouter::SynchronizeChildNetworkData(void)
 {
-    VerifyOrExit(IsRouterOrLeader());
+    VerifyOrExit(IsRouterOrLeader(), OT_NOOP);
 
     for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValid); !iter.IsDone(); iter++)
     {
@@ -2828,7 +2828,7 @@ otError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Me
                 else // if steering data is not set out of band, fall back to network data
 #endif               // OPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE
                 {
-                    VerifyOrExit(Get<NetworkData::Leader>().IsJoiningEnabled());
+                    VerifyOrExit(Get<NetworkData::Leader>().IsJoiningEnabled(), OT_NOOP);
                 }
             }
 
@@ -2837,7 +2837,7 @@ otError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Me
         case MeshCoP::Tlv::kExtendedPanId:
             aMessage.Read(offset, sizeof(extPanId), &extPanId);
             VerifyOrExit(extPanId.IsValid(), error = OT_ERROR_PARSE);
-            VerifyOrExit(Get<Mac::Mac>().GetExtendedPanId() != extPanId.GetExtendedPanId());
+            VerifyOrExit(Get<Mac::Mac>().GetExtendedPanId() != extPanId.GetExtendedPanId(), OT_NOOP);
 
             break;
 
@@ -3370,7 +3370,7 @@ Neighbor *MleRouter::GetNeighbor(uint16_t aAddress)
     case kRoleRouter:
     case kRoleLeader:
         rval = mChildTable.FindChild(aAddress, Child::kInStateValidOrRestoring);
-        VerifyOrExit(rval == NULL);
+        VerifyOrExit(rval == NULL, OT_NOOP);
 
         rval = mRouterTable.GetNeighbor(aAddress);
         break;
@@ -3397,7 +3397,7 @@ Neighbor *MleRouter::GetNeighbor(const Mac::ExtAddress &aAddress)
     case kRoleRouter:
     case kRoleLeader:
         rval = mChildTable.FindChild(aAddress, Child::kInStateValidOrRestoring);
-        VerifyOrExit(rval == NULL);
+        VerifyOrExit(rval == NULL, OT_NOOP);
 
         rval = mRouterTable.GetNeighbor(aAddress);
 
@@ -3532,7 +3532,7 @@ uint16_t MleRouter::GetNextHop(uint16_t aDestination)
     }
 
     router = mRouterTable.GetRouter(destinationId);
-    VerifyOrExit(router != NULL);
+    VerifyOrExit(router != NULL, OT_NOOP);
 
     linkCost  = GetLinkCost(destinationId);
     routeCost = GetRouteCost(aDestination);
@@ -3540,7 +3540,7 @@ uint16_t MleRouter::GetNextHop(uint16_t aDestination)
     if ((routeCost + GetLinkCost(router->GetNextHop())) < linkCost)
     {
         nextHop = mRouterTable.GetRouter(router->GetNextHop());
-        VerifyOrExit(nextHop != NULL && !nextHop->IsStateInvalid());
+        VerifyOrExit(nextHop != NULL && !nextHop->IsStateInvalid(), OT_NOOP);
 
         rval = Rloc16FromRouterId(router->GetNextHop());
     }
@@ -3560,7 +3560,7 @@ uint8_t MleRouter::GetCost(uint16_t aRloc16)
     Router *router   = mRouterTable.GetRouter(routerId);
     uint8_t routeCost;
 
-    VerifyOrExit(router != NULL && mRouterTable.GetRouter(router->GetNextHop()) != NULL);
+    VerifyOrExit(router != NULL && mRouterTable.GetRouter(router->GetNextHop()) != NULL, OT_NOOP);
 
     routeCost = GetRouteCost(aRloc16) + GetLinkCost(router->GetNextHop());
 
@@ -3579,7 +3579,7 @@ uint8_t MleRouter::GetRouteCost(uint16_t aRloc16) const
     const Router *router;
 
     router = mRouterTable.GetRouter(RouterIdFromRloc16(aRloc16));
-    VerifyOrExit(router != NULL && mRouterTable.GetRouter(router->GetNextHop()) != NULL);
+    VerifyOrExit(router != NULL && mRouterTable.GetRouter(router->GetNextHop()) != NULL, OT_NOOP);
 
     rval = router->GetCost();
 
@@ -3875,7 +3875,7 @@ void MleRouter::ResolveRoutingLoops(uint16_t aSourceMac, uint16_t aDestRloc16)
 
     // loop exists
     router = mRouterTable.GetRouter(RouterIdFromRloc16(aDestRloc16));
-    VerifyOrExit(router != NULL);
+    VerifyOrExit(router != NULL, OT_NOOP);
 
     // invalidate next hop
     router->SetNextHop(kInvalidRouterId);
@@ -3935,7 +3935,7 @@ otError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
     Ip6::MessageInfo messageInfo;
     Coap::Message *  message = NULL;
 
-    VerifyOrExit(!mAddressSolicitPending);
+    VerifyOrExit(!mAddressSolicitPending, OT_NOOP);
 
     VerifyOrExit((message = Get<Coap::Coap>().NewMessage()) != NULL, error = OT_ERROR_NO_BUFS);
 
@@ -4034,9 +4034,9 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
 
     mAddressSolicitPending = false;
 
-    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage != NULL && aMessage != NULL);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage != NULL && aMessage != NULL, OT_NOOP);
 
-    VerifyOrExit(aMessage->GetCode() == OT_COAP_CODE_CHANGED);
+    VerifyOrExit(aMessage->GetCode() == OT_COAP_CODE_CHANGED, OT_NOOP);
 
     LogMleMessage("Receive Address Reply", aMessageInfo->GetPeerAddr());
 
@@ -4061,7 +4061,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
     routerId = RouterIdFromRloc16(rloc16);
 
     SuccessOrExit(ThreadTlv::GetTlv(*aMessage, ThreadTlv::kRouterMask, sizeof(routerMaskTlv), routerMaskTlv));
-    VerifyOrExit(routerMaskTlv.IsValid());
+    VerifyOrExit(routerMaskTlv.IsValid(), OT_NOOP);
 
     // assign short address
     SetRouterId(routerId);
@@ -4071,13 +4071,13 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
     mRouterTable.UpdateRouterIdSet(routerMaskTlv.GetIdSequence(), routerMaskTlv.GetAssignedRouterIdMask());
 
     router = mRouterTable.GetRouter(routerId);
-    VerifyOrExit(router != NULL);
+    VerifyOrExit(router != NULL, OT_NOOP);
 
     router->SetExtAddress(Get<Mac::Mac>().GetExtAddress());
     router->SetCost(0);
 
     router = mRouterTable.GetRouter(mParent.GetRouterId());
-    VerifyOrExit(router != NULL);
+    VerifyOrExit(router != NULL, OT_NOOP);
 
     // Keep link to the parent in order to respond to Parent Requests before new link is established.
     *router = mParent;
@@ -4138,7 +4138,7 @@ void MleRouter::HandleAddressSolicit(Coap::Message &aMessage, const Ip6::Message
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     // In a time sync enabled network, all routers' xtal accuracy must be less than the threshold.
     SuccessOrExit(Tlv::ReadUint16Tlv(aMessage, Tlv::kXtalAccuracy, xtalAccuracy));
-    VerifyOrExit(xtalAccuracy <= Get<TimeSync>().GetXtalThreshold());
+    VerifyOrExit(xtalAccuracy <= Get<TimeSync>().GetXtalThreshold(), OT_NOOP);
 #endif
 
     // see if allocation already exists
@@ -4153,7 +4153,7 @@ void MleRouter::HandleAddressSolicit(Coap::Message &aMessage, const Ip6::Message
     switch (status)
     {
     case ThreadStatusTlv::kTooFewRouters:
-        VerifyOrExit(mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold);
+        VerifyOrExit(mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold, OT_NOOP);
         break;
 
     case ThreadStatusTlv::kHaveChildIdRequest:
@@ -4256,7 +4256,7 @@ void MleRouter::HandleAddressRelease(Coap::Message &aMessage, const Ip6::Message
     uint8_t         routerId;
     Router *        router;
 
-    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
     LogMleMessage("Receive Address Release", aMessageInfo.GetPeerAddr());
 
@@ -4267,7 +4267,7 @@ void MleRouter::HandleAddressRelease(Coap::Message &aMessage, const Ip6::Message
     routerId = RouterIdFromRloc16(rloc16);
     router   = mRouterTable.GetRouter(routerId);
 
-    VerifyOrExit((router != NULL) && (router->GetExtAddress() == extAddress));
+    VerifyOrExit((router != NULL) && (router->GetExtAddress() == extAddress), OT_NOOP);
 
     mRouterTable.Release(routerId);
 
@@ -4637,7 +4637,7 @@ exit:
 
 void MleRouter::SetChildStateToValid(Child &aChild)
 {
-    VerifyOrExit(!aChild.IsStateValid());
+    VerifyOrExit(!aChild.IsStateValid(), OT_NOOP);
 
     aChild.SetState(Neighbor::kStateValid);
     StoreChild(aChild);
@@ -4665,7 +4665,7 @@ bool MleRouter::HasSmallNumberOfChildren(void)
     uint16_t numChildren = 0;
     uint8_t  routerCount = mRouterTable.GetActiveRouterCount();
 
-    VerifyOrExit(routerCount > mRouterDowngradeThreshold);
+    VerifyOrExit(routerCount > mRouterDowngradeThreshold, OT_NOOP);
 
     numChildren = mChildTable.GetNumChildren(Child::kInStateValid);
 
@@ -4795,7 +4795,7 @@ void MleRouter::HandleTimeSync(const Message &aMessage, const Ip6::MessageInfo &
 {
     LogMleMessage("Receive Time Sync", aMessageInfo.GetPeerAddr());
 
-    VerifyOrExit(aNeighbor && aNeighbor->IsStateValid());
+    VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), OT_NOOP);
 
     Get<TimeSync>().HandleTimeSyncMessage(aMessage);
 

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -669,7 +669,7 @@ const PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix,
     {
         prefixTlv = FindTlv<PrefixTlv>(start, end);
 
-        VerifyOrExit(prefixTlv != NULL);
+        VerifyOrExit(prefixTlv != NULL, OT_NOOP);
 
         if (prefixTlv->GetPrefixLength() == aPrefixLength &&
             PrefixMatch(prefixTlv->GetPrefix(), aPrefix, aPrefixLength) >= aPrefixLength)
@@ -719,7 +719,7 @@ const ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,
     {
         serviceTlv = FindTlv<ServiceTlv>(start, end);
 
-        VerifyOrExit(serviceTlv != NULL);
+        VerifyOrExit(serviceTlv != NULL, OT_NOOP);
 
         if ((serviceTlv->GetEnterpriseNumber() == aEnterpriseNumber) &&
             (serviceTlv->GetServiceDataLength() == aServiceDataLength) &&

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -124,7 +124,7 @@ otError LeaderBase::GetBackboneRouterPrimary(BackboneRouter::BackboneRouterConfi
         }
     }
 
-    VerifyOrExit(rvalServerTlv != NULL);
+    VerifyOrExit(rvalServerTlv != NULL, OT_NOOP);
 
     aConfig.mServer16            = rvalServerTlv->GetServer16();
     aConfig.mSequenceNumber      = rvalServerData->GetSequenceNumber();
@@ -489,7 +489,7 @@ const MeshCoP::Tlv *LeaderBase::GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aT
     const MeshCoP::Tlv *  end;
 
     commissioningDataTlv = GetCommissioningData();
-    VerifyOrExit(commissioningDataTlv != NULL);
+    VerifyOrExit(commissioningDataTlv != NULL, OT_NOOP);
 
     cur = reinterpret_cast<const MeshCoP::Tlv *>(commissioningDataTlv->GetValue());
     end = reinterpret_cast<const MeshCoP::Tlv *>(commissioningDataTlv->GetValue() + commissioningDataTlv->GetLength());
@@ -511,10 +511,10 @@ bool LeaderBase::IsJoiningEnabled(void) const
     const MeshCoP::Tlv *steeringData;
     bool                rval = false;
 
-    VerifyOrExit(GetCommissioningDataSubTlv(MeshCoP::Tlv::kBorderAgentLocator) != NULL);
+    VerifyOrExit(GetCommissioningDataSubTlv(MeshCoP::Tlv::kBorderAgentLocator) != NULL, OT_NOOP);
 
     steeringData = GetCommissioningDataSubTlv(MeshCoP::Tlv::kSteeringData);
-    VerifyOrExit(steeringData != NULL);
+    VerifyOrExit(steeringData != NULL, OT_NOOP);
 
     for (int i = 0; i < steeringData->GetLength(); i++)
     {

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -63,20 +63,20 @@ void Notifier::SynchronizeServerData(void)
 {
     otError error = OT_ERROR_NOT_FOUND;
 
-    VerifyOrExit(Get<Mle::MleRouter>().IsAttached() && !mWaitingForResponse);
+    VerifyOrExit(Get<Mle::MleRouter>().IsAttached() && !mWaitingForResponse, OT_NOOP);
 
-    VerifyOrExit((mNextDelay == 0) || !mTimer.IsRunning());
+    VerifyOrExit((mNextDelay == 0) || !mTimer.IsRunning(), OT_NOOP);
 
 #if OPENTHREAD_FTD
     mNextDelay = kDelayRemoveStaleChildren;
     error      = Get<Leader>().RemoveStaleChildEntries(&Notifier::HandleCoapResponse, this);
-    VerifyOrExit(error == OT_ERROR_NOT_FOUND);
+    VerifyOrExit(error == OT_ERROR_NOT_FOUND, OT_NOOP);
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     mNextDelay = kDelaySynchronizeServerData;
     error      = Get<Local>().UpdateInconsistentServerData(&Notifier::HandleCoapResponse, this);
-    VerifyOrExit(error == OT_ERROR_NOT_FOUND);
+    VerifyOrExit(error == OT_ERROR_NOT_FOUND, OT_NOOP);
 #endif
 
 exit:

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -153,8 +153,8 @@ void NetworkDiagnostic::HandleDiagnosticGetResponse(Coap::Message *         aMes
                                                     const Ip6::MessageInfo *aMessageInfo,
                                                     otError                 aResult)
 {
-    VerifyOrExit(aResult == OT_ERROR_NONE);
-    VerifyOrExit(aMessage && aMessage->GetCode() == OT_COAP_CODE_CHANGED);
+    VerifyOrExit(aResult == OT_ERROR_NONE, OT_NOOP);
+    VerifyOrExit(aMessage && aMessage->GetCode() == OT_COAP_CODE_CHANGED, OT_NOOP);
 
     otLogInfoNetDiag("Received diagnostic get response");
 
@@ -177,7 +177,7 @@ void NetworkDiagnostic::HandleDiagnosticGetAnswer(void *               aContext,
 
 void NetworkDiagnostic::HandleDiagnosticGetAnswer(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
     otLogInfoNetDiag("Diagnostic get answer received");
 
@@ -248,7 +248,7 @@ otError NetworkDiagnostic::AppendChildTable(Message &aMessage)
 
     for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValid); !iter.IsDone(); iter++)
     {
-        VerifyOrExit(count--);
+        VerifyOrExit(count--, OT_NOOP);
 
         Child &child = *iter.GetChild();
 
@@ -685,18 +685,19 @@ void NetworkDiagnostic::HandleDiagnosticReset(Coap::Message &aMessage, const Ip6
 
     otLogInfoNetDiag("Received diagnostic reset request");
 
-    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST);
+    VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
     VerifyOrExit((aMessage.Read(aMessage.GetOffset(), sizeof(NetworkDiagnosticTlv), &networkDiagnosticTlv) ==
-                  sizeof(NetworkDiagnosticTlv)));
+                  sizeof(NetworkDiagnosticTlv)),
+                 OT_NOOP);
 
-    VerifyOrExit(networkDiagnosticTlv.GetType() == NetworkDiagnosticTlv::kTypeList);
+    VerifyOrExit(networkDiagnosticTlv.GetType() == NetworkDiagnosticTlv::kTypeList, OT_NOOP);
 
     offset = aMessage.GetOffset() + sizeof(NetworkDiagnosticTlv);
 
     for (uint8_t i = 0; i < networkDiagnosticTlv.GetLength(); i++)
     {
-        VerifyOrExit(aMessage.Read(offset, sizeof(type), &type) == sizeof(type));
+        VerifyOrExit(aMessage.Read(offset, sizeof(type), &type) == sizeof(type), OT_NOOP);
 
         switch (type)
         {
@@ -814,8 +815,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             ExtMacAddressTlv extMacAddr;
 
             tlvTotalLength = sizeof(extMacAddr);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &extMacAddr) == tlvTotalLength);
-            VerifyOrExit(extMacAddr.IsValid());
+            VerifyOrExit(message.Read(offset, tlvTotalLength, &extMacAddr) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(extMacAddr.IsValid(), OT_NOOP);
 
             aNetworkDiagTlv.mData.mExtAddress = *extMacAddr.GetMacAddr();
             ExitNow(error = OT_ERROR_NONE);
@@ -827,8 +828,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             Address16Tlv addr16;
 
             tlvTotalLength = sizeof(addr16);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &addr16) == tlvTotalLength);
-            VerifyOrExit(addr16.IsValid());
+            VerifyOrExit(message.Read(offset, tlvTotalLength, &addr16) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(addr16.IsValid(), OT_NOOP);
 
             aNetworkDiagTlv.mData.mAddr16 = addr16.GetRloc16();
             ExitNow(error = OT_ERROR_NONE);
@@ -840,8 +841,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             ModeTlv linkMode;
 
             tlvTotalLength = sizeof(linkMode);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &linkMode) == tlvTotalLength);
-            VerifyOrExit(linkMode.IsValid());
+            VerifyOrExit(message.Read(offset, tlvTotalLength, &linkMode) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(linkMode.IsValid(), OT_NOOP);
 
             ParseMode(linkMode.GetMode(), aNetworkDiagTlv.mData.mMode);
             ExitNow(error = OT_ERROR_NONE);
@@ -853,8 +854,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             TimeoutTlv timeout;
 
             tlvTotalLength = sizeof(timeout);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &timeout) == tlvTotalLength);
-            VerifyOrExit(timeout.IsValid());
+            VerifyOrExit(message.Read(offset, tlvTotalLength, &timeout) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(timeout.IsValid(), OT_NOOP);
 
             aNetworkDiagTlv.mData.mTimeout = timeout.GetTimeout();
             ExitNow(error = OT_ERROR_NONE);
@@ -866,8 +867,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             ConnectivityTlv connectivity;
 
             tlvTotalLength = sizeof(connectivity);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &connectivity) == tlvTotalLength);
-            VerifyOrExit(connectivity.IsValid());
+            VerifyOrExit(message.Read(offset, tlvTotalLength, &connectivity) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(connectivity.IsValid(), OT_NOOP);
 
             ParseConnectivity(connectivity, aNetworkDiagTlv.mData.mConnectivity);
             ExitNow(error = OT_ERROR_NONE);
@@ -879,9 +880,9 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             RouteTlv route;
 
             tlvTotalLength = sizeof(tlv) + tlv.GetLength();
-            VerifyOrExit(tlvTotalLength <= sizeof(route));
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &route) == tlvTotalLength);
-            VerifyOrExit(route.IsValid());
+            VerifyOrExit(tlvTotalLength <= sizeof(route), OT_NOOP);
+            VerifyOrExit(message.Read(offset, tlvTotalLength, &route) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(route.IsValid(), OT_NOOP);
 
             ParseRoute(route, aNetworkDiagTlv.mData.mRoute);
             ExitNow(error = OT_ERROR_NONE);
@@ -893,8 +894,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             LeaderDataTlv leaderData;
 
             tlvTotalLength = sizeof(leaderData);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &leaderData) == tlvTotalLength);
-            VerifyOrExit(leaderData.IsValid());
+            VerifyOrExit(message.Read(offset, tlvTotalLength, &leaderData) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(leaderData.IsValid(), OT_NOOP);
 
             ParseLeaderData(leaderData, aNetworkDiagTlv.mData.mLeaderData);
             ExitNow(error = OT_ERROR_NONE);
@@ -906,10 +907,10 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             NetworkDataTlv networkData;
 
             tlvTotalLength = sizeof(tlv) + tlv.GetLength();
-            VerifyOrExit(tlvTotalLength <= sizeof(networkData));
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &networkData) == tlvTotalLength);
-            VerifyOrExit(networkData.IsValid());
-            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mNetworkData.m8) >= networkData.GetLength());
+            VerifyOrExit(tlvTotalLength <= sizeof(networkData), OT_NOOP);
+            VerifyOrExit(message.Read(offset, tlvTotalLength, &networkData) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(networkData.IsValid(), OT_NOOP);
+            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mNetworkData.m8) >= networkData.GetLength(), OT_NOOP);
 
             memcpy(aNetworkDiagTlv.mData.mNetworkData.m8, networkData.GetNetworkData(), networkData.GetLength());
             aNetworkDiagTlv.mData.mNetworkData.mCount = networkData.GetLength();
@@ -921,10 +922,11 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
         {
             Ip6AddressListTlv &ip6AddrList = static_cast<Ip6AddressListTlv &>(tlv);
 
-            VerifyOrExit(ip6AddrList.IsValid());
-            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mIp6AddrList.mList) >= ip6AddrList.GetLength());
+            VerifyOrExit(ip6AddrList.IsValid(), OT_NOOP);
+            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mIp6AddrList.mList) >= ip6AddrList.GetLength(), OT_NOOP);
             VerifyOrExit(message.Read(offset + sizeof(ip6AddrList), ip6AddrList.GetLength(),
-                                      aNetworkDiagTlv.mData.mIp6AddrList.mList) == ip6AddrList.GetLength());
+                                      aNetworkDiagTlv.mData.mIp6AddrList.mList) == ip6AddrList.GetLength(),
+                         OT_NOOP);
 
             aNetworkDiagTlv.mData.mIp6AddrList.mCount = ip6AddrList.GetLength() / OT_IP6_ADDRESS_SIZE;
             ExitNow(error = OT_ERROR_NONE);
@@ -936,8 +938,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             MacCountersTlv macCounters;
 
             tlvTotalLength = sizeof(MacCountersTlv);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &macCounters) == tlvTotalLength);
-            VerifyOrExit(macCounters.IsValid());
+            VerifyOrExit(message.Read(offset, tlvTotalLength, &macCounters) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(macCounters.IsValid(), OT_NOOP);
 
             ParseMacCounters(macCounters, aNetworkDiagTlv.mData.mMacCounters);
             ExitNow(error = OT_ERROR_NONE);
@@ -949,8 +951,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             BatteryLevelTlv batteryLevel;
 
             tlvTotalLength = sizeof(BatteryLevelTlv);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &batteryLevel) == tlvTotalLength);
-            VerifyOrExit(batteryLevel.IsValid());
+            VerifyOrExit(message.Read(offset, tlvTotalLength, &batteryLevel) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(batteryLevel.IsValid(), OT_NOOP);
 
             aNetworkDiagTlv.mData.mBatteryLevel = batteryLevel.GetBatteryLevel();
             ExitNow(error = OT_ERROR_NONE);
@@ -962,8 +964,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             SupplyVoltageTlv supplyVoltage;
 
             tlvTotalLength = sizeof(SupplyVoltageTlv);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &supplyVoltage) == tlvTotalLength);
-            VerifyOrExit(supplyVoltage.IsValid());
+            VerifyOrExit(message.Read(offset, tlvTotalLength, &supplyVoltage) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(supplyVoltage.IsValid(), OT_NOOP);
 
             aNetworkDiagTlv.mData.mSupplyVoltage = supplyVoltage.GetSupplyVoltage();
             ExitNow(error = OT_ERROR_NONE);
@@ -974,13 +976,14 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
         {
             ChildTableTlv &childTable = static_cast<ChildTableTlv &>(tlv);
 
-            VerifyOrExit(childTable.IsValid());
-            VerifyOrExit(childTable.GetNumEntries() <= OT_ARRAY_LENGTH(aNetworkDiagTlv.mData.mChildTable.mTable));
+            VerifyOrExit(childTable.IsValid(), OT_NOOP);
+            VerifyOrExit(childTable.GetNumEntries() <= OT_ARRAY_LENGTH(aNetworkDiagTlv.mData.mChildTable.mTable),
+                         OT_NOOP);
 
             for (uint8_t i = 0; i < childTable.GetNumEntries(); ++i)
             {
                 ChildTableEntry childEntry;
-                VerifyOrExit(childTable.ReadEntry(childEntry, message, offset, i) == OT_ERROR_NONE);
+                VerifyOrExit(childTable.ReadEntry(childEntry, message, offset, i) == OT_ERROR_NONE, OT_NOOP);
                 ParseChildEntry(childEntry, aNetworkDiagTlv.mData.mChildTable.mTable[i]);
             }
             aNetworkDiagTlv.mData.mChildTable.mCount = childTable.GetNumEntries();
@@ -990,9 +993,10 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
 
         case NetworkDiagnosticTlv::kChannelPages:
         {
-            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mChannelPages.m8) >= tlv.GetLength());
+            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mChannelPages.m8) >= tlv.GetLength(), OT_NOOP);
             VerifyOrExit(message.Read(offset + sizeof(tlv), tlv.GetLength(), aNetworkDiagTlv.mData.mChannelPages.m8) ==
-                         tlv.GetLength());
+                             tlv.GetLength(),
+                         OT_NOOP);
 
             aNetworkDiagTlv.mData.mChannelPages.mCount = tlv.GetLength();
             ExitNow(error = OT_ERROR_NONE);
@@ -1004,8 +1008,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             MaxChildTimeoutTlv maxChildTimeout;
 
             tlvTotalLength = sizeof(maxChildTimeout);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &maxChildTimeout) == tlvTotalLength);
-            VerifyOrExit(maxChildTimeout.IsValid());
+            VerifyOrExit(message.Read(offset, tlvTotalLength, &maxChildTimeout) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(maxChildTimeout.IsValid(), OT_NOOP);
 
             aNetworkDiagTlv.mData.mMaxChildTimeout = maxChildTimeout.GetTimeout();
             ExitNow(error = OT_ERROR_NONE);

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -68,8 +68,8 @@ void PanIdQueryServer::HandleQuery(Coap::Message &aMessage, const Ip6::MessageIn
     Ip6::MessageInfo responseInfo(aMessageInfo);
     uint32_t         mask;
 
-    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST);
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
+    VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NOOP);
 
     SuccessOrExit(Tlv::ReadUint16Tlv(aMessage, MeshCoP::Tlv::kPanId, panId));
 

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -84,7 +84,7 @@ exit:
 
 const Router *RouterTable::GetNextEntry(const Router *aRouter) const
 {
-    VerifyOrExit(aRouter != NULL);
+    VerifyOrExit(aRouter != NULL, OT_NOOP);
     aRouter++;
     VerifyOrExit(aRouter < &mRouters[Mle::kMaxRouters], aRouter = NULL);
     VerifyOrExit(aRouter->GetRloc16() != 0xffff, aRouter = NULL);
@@ -219,7 +219,7 @@ Router *RouterTable::Allocate(void)
         }
     }
 
-    VerifyOrExit(mActiveRouterCount < Mle::kMaxRouters && numAvailable > 0);
+    VerifyOrExit(mActiveRouterCount < Mle::kMaxRouters && numAvailable > 0, OT_NOOP);
 
     // choose available router id at random
     freeBit = Random::NonCrypto::GetUint8InRange(0, numAvailable);
@@ -251,7 +251,8 @@ Router *RouterTable::Allocate(uint8_t aRouterId)
     Router *rval = NULL;
 
     VerifyOrExit(aRouterId <= Mle::kMaxRouterId && mActiveRouterCount < Mle::kMaxRouters && !IsAllocated(aRouterId) &&
-                 mRouterIdReuseDelay[aRouterId] == 0);
+                     mRouterIdReuseDelay[aRouterId] == 0,
+                 OT_NOOP);
 
     mAllocatedRouterIds.Add(aRouterId);
     UpdateAllocation();
@@ -353,7 +354,7 @@ Router *RouterTable::GetNeighbor(uint16_t aRloc16)
 {
     Router *router = NULL;
 
-    VerifyOrExit(aRloc16 != Get<Mle::MleRouter>().GetRloc16());
+    VerifyOrExit(aRloc16 != Get<Mle::MleRouter>().GetRloc16(), OT_NOOP);
 
     for (router = GetFirstEntry(); router != NULL; router = GetNextEntry(router))
     {
@@ -371,7 +372,7 @@ Router *RouterTable::GetNeighbor(const Mac::ExtAddress &aExtAddress)
 {
     Router *router = NULL;
 
-    VerifyOrExit(aExtAddress != Get<Mac::Mac>().GetExtAddress());
+    VerifyOrExit(aExtAddress != Get<Mac::Mac>().GetExtAddress(), OT_NOOP);
 
     for (router = GetFirstEntry(); router != NULL; router = GetNextEntry(router))
     {
@@ -391,7 +392,7 @@ const Router *RouterTable::GetRouter(uint8_t aRouterId) const
     uint16_t      rloc16;
 
     // Skip if invalid router id is passed.
-    VerifyOrExit(aRouterId < Mle::kInvalidRouterId);
+    VerifyOrExit(aRouterId < Mle::kInvalidRouterId, OT_NOOP);
 
     rloc16 = Mle::Mle::Rloc16FromRouterId(aRouterId);
 
@@ -487,7 +488,7 @@ uint8_t RouterTable::GetLinkCost(Router &aRouter)
 {
     uint8_t rval = Mle::kMaxRouteCost;
 
-    VerifyOrExit(aRouter.GetRloc16() != Get<Mle::MleRouter>().GetRloc16() && aRouter.IsStateValid());
+    VerifyOrExit(aRouter.GetRloc16() != Get<Mle::MleRouter>().GetRloc16() && aRouter.IsStateValid(), OT_NOOP);
 
     rval = aRouter.GetLinkInfo().GetLinkQuality();
 
@@ -507,7 +508,7 @@ void RouterTable::UpdateRouterIdSet(uint8_t aRouterIdSequence, const Mle::Router
     mRouterIdSequence            = aRouterIdSequence;
     mRouterIdSequenceLastUpdated = TimerMilli::GetNow();
 
-    VerifyOrExit(mAllocatedRouterIds != aRouterIdSet);
+    VerifyOrExit(mAllocatedRouterIds != aRouterIdSet, OT_NOOP);
 
     for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
     {

--- a/src/core/thread/src_match_controller.cpp
+++ b/src/core/thread/src_match_controller.cpp
@@ -92,7 +92,7 @@ void SourceMatchController::ResetMessageCount(Child &aChild)
 
 void SourceMatchController::SetSrcMatchAsShort(Child &aChild, bool aUseShortAddress)
 {
-    VerifyOrExit(aChild.IsIndirectSourceMatchShort() != aUseShortAddress);
+    VerifyOrExit(aChild.IsIndirectSourceMatchShort() != aUseShortAddress, OT_NOOP);
 
     if (aChild.GetIndirectMessageCount() > 0)
     {

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -123,7 +123,7 @@ ThreadNetif::ThreadNetif(Instance &aInstance)
 
 void ThreadNetif::Up(void)
 {
-    VerifyOrExit(!mIsUp);
+    VerifyOrExit(!mIsUp, OT_NOOP);
 
     // Enable the MAC just in case it was disabled while the Interface was down.
     Get<Mac::Mac>().SetEnabled(true);
@@ -151,7 +151,7 @@ exit:
 
 void ThreadNetif::Down(void)
 {
-    VerifyOrExit(mIsUp);
+    VerifyOrExit(mIsUp, OT_NOOP);
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
     Get<Dns::Client>().Stop();

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -81,7 +81,7 @@ void TimeSync::HandleTimeSyncMessage(const Message &aMessage)
     const int64_t origNetworkTimeOffset = mNetworkTimeOffset;
     int8_t        timeSyncSeqDelta;
 
-    VerifyOrExit(aMessage.GetTimeSyncSeq() != OT_TIME_SYNC_INVALID_SEQ);
+    VerifyOrExit(aMessage.GetTimeSyncSeq() != OT_TIME_SYNC_INVALID_SEQ, OT_NOOP);
 
     timeSyncSeqDelta = static_cast<int8_t>(aMessage.GetTimeSyncSeq() - mTimeSyncSeq);
 
@@ -162,7 +162,7 @@ void TimeSync::ProcessTimeSync(void)
 
     if (mTimeSyncRequired)
     {
-        VerifyOrExit(Get<Mle::MleRouter>().SendTimeSync() == OT_ERROR_NONE);
+        VerifyOrExit(Get<Mle::MleRouter>().SendTimeSync() == OT_ERROR_NONE, OT_NOOP);
 
         mLastTimeSyncSent = TimerMilli::GetNow();
         mTimeSyncRequired = false;

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -169,7 +169,7 @@ otError Child::GetNextIp6Address(Ip6AddressIterator &aIterator, Ip6::Address &aA
     if (aIterator.Get() == 0)
     {
         aIterator.Increment();
-        VerifyOrExit(GetMeshLocalIp6Address(aAddress) == OT_ERROR_NOT_FOUND);
+        VerifyOrExit(GetMeshLocalIp6Address(aAddress) == OT_ERROR_NOT_FOUND, OT_NOOP);
     }
 
     index = aIterator.Get() - 1;
@@ -234,7 +234,7 @@ otError Child::RemoveIp6Address(const Ip6::Address &aAddress)
 
     for (index = 0; index < kNumIp6Addresses; index++)
     {
-        VerifyOrExit(!mIp6Address[index].IsUnspecified());
+        VerifyOrExit(!mIp6Address[index].IsUnspecified(), OT_NOOP);
 
         if (mIp6Address[index] == aAddress)
         {
@@ -260,7 +260,7 @@ bool Child::HasIp6Address(const Ip6::Address &aAddress) const
 {
     bool retval = false;
 
-    VerifyOrExit(!aAddress.IsUnspecified());
+    VerifyOrExit(!aAddress.IsUnspecified(), OT_NOOP);
 
     if (Get<Mle::MleRouter>().IsMeshLocalAddress(aAddress))
     {
@@ -270,7 +270,7 @@ bool Child::HasIp6Address(const Ip6::Address &aAddress) const
 
     for (uint16_t index = 0; index < kNumIp6Addresses; index++)
     {
-        VerifyOrExit(!mIp6Address[index].IsUnspecified());
+        VerifyOrExit(!mIp6Address[index].IsUnspecified(), OT_NOOP);
 
         if (mIp6Address[index] == aAddress)
         {

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -102,9 +102,9 @@ void ChannelManager::PreparePendingDataset(void)
     otOperationalDataset dataset;
     otError              error;
 
-    VerifyOrExit(mState == kStateChangeRequested);
+    VerifyOrExit(mState == kStateChangeRequested, OT_NOOP);
 
-    VerifyOrExit(mChannel != Get<Mac::Mac>().GetPanChannel());
+    VerifyOrExit(mChannel != Get<Mac::Mac>().GetPanChannel(), OT_NOOP);
 
     if (Get<MeshCoP::PendingDataset>().Read(dataset) == OT_ERROR_NONE)
     {
@@ -259,8 +259,8 @@ void ChannelManager::HandleStateChanged(Notifier::Callback &aCallback, otChanged
 
 void ChannelManager::HandleStateChanged(otChangedFlags aChangedFlags)
 {
-    VerifyOrExit((aChangedFlags & OT_CHANGED_THREAD_CHANNEL) != 0);
-    VerifyOrExit(mChannel == Get<Mac::Mac>().GetPanChannel());
+    VerifyOrExit((aChangedFlags & OT_CHANGED_THREAD_CHANNEL) != 0, OT_NOOP);
+    VerifyOrExit(mChannel == Get<Mac::Mac>().GetPanChannel(), OT_NOOP);
 
     mState = kStateIdle;
     StartAutoSelectTimer();
@@ -347,7 +347,7 @@ otError ChannelManager::RequestChannelSelect(bool aSkipQualityCheck)
 
     VerifyOrExit(!Get<Mle::Mle>().IsDisabled(), error = OT_ERROR_INVALID_STATE);
 
-    VerifyOrExit(aSkipQualityCheck || ShouldAttemptChannelChange());
+    VerifyOrExit(aSkipQualityCheck || ShouldAttemptChannelChange(), OT_NOOP);
 
     SuccessOrExit(error = FindBetterChannel(newChannel, newOccupancy));
 
@@ -389,7 +389,7 @@ exit:
 
 void ChannelManager::StartAutoSelectTimer(void)
 {
-    VerifyOrExit(mState == kStateIdle);
+    VerifyOrExit(mState == kStateIdle, OT_NOOP);
 
     if (mAutoSelectEnabled)
     {

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -105,7 +105,7 @@ uint16_t ChannelMonitor::GetChannelOccupancy(uint8_t aChannel) const
 {
     uint16_t occupancy = 0;
 
-    VerifyOrExit((Radio::kChannelMin <= aChannel) && (aChannel <= Radio::kChannelMax));
+    VerifyOrExit((Radio::kChannelMin <= aChannel) && (aChannel <= Radio::kChannelMax), OT_NOOP);
     occupancy = mChannelOccupancy[aChannel - Radio::kChannelMin];
 
 exit:

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -66,7 +66,7 @@ Child *ChildSupervisor::GetDestination(const Message &aMessage) const
     Child *  child = NULL;
     uint16_t childIndex;
 
-    VerifyOrExit(aMessage.GetType() == Message::kTypeSupervision);
+    VerifyOrExit(aMessage.GetType() == Message::kTypeSupervision, OT_NOOP);
 
     aMessage.Read(0, sizeof(childIndex), &childIndex);
     child = Get<ChildTable>().GetChildAtIndex(childIndex);
@@ -80,10 +80,10 @@ void ChildSupervisor::SendMessage(Child &aChild)
     Message *message = NULL;
     uint16_t childIndex;
 
-    VerifyOrExit(aChild.GetIndirectMessageCount() == 0);
+    VerifyOrExit(aChild.GetIndirectMessageCount() == 0, OT_NOOP);
 
     message = Get<MessagePool>().New(Message::kTypeSupervision, sizeof(uint8_t));
-    VerifyOrExit(message != NULL);
+    VerifyOrExit(message != NULL, OT_NOOP);
 
     // Supervision message is an empty payload 15.4 data frame.
     // The child index is stored here in the message content to allow
@@ -118,7 +118,7 @@ void ChildSupervisor::HandleTimer(Timer &aTimer)
 
 void ChildSupervisor::HandleTimer(void)
 {
-    VerifyOrExit(mSupervisionInterval != 0);
+    VerifyOrExit(mSupervisionInterval != 0, OT_NOOP);
 
     for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValid); !iter.IsDone(); iter++)
     {
@@ -209,7 +209,8 @@ void SupervisionListener::UpdateOnReceive(const Mac::Address &aSourceAddress, bo
     // If listener is enabled and device is a child and it received a secure frame from its parent, restart the timer.
 
     VerifyOrExit(mTimer.IsRunning() && aIsSecure && Get<Mle::MleRouter>().IsChild() &&
-                 (Get<Mle::MleRouter>().GetNeighbor(aSourceAddress) == &Get<Mle::MleRouter>().GetParent()));
+                     (Get<Mle::MleRouter>().GetNeighbor(aSourceAddress) == &Get<Mle::MleRouter>().GetParent()),
+                 OT_NOOP);
 
     RestartTimer();
 
@@ -236,7 +237,7 @@ void SupervisionListener::HandleTimer(Timer &aTimer)
 
 void SupervisionListener::HandleTimer(void)
 {
-    VerifyOrExit(Get<Mle::MleRouter>().IsChild() && !Get<MeshForwarder>().GetRxOnWhenIdle());
+    VerifyOrExit(Get<Mle::MleRouter>().IsChild() && !Get<MeshForwarder>().GetRxOnWhenIdle(), OT_NOOP);
 
     otLogWarnUtil("Supervision timeout. No frame from parent in %d sec", mTimeout);
 

--- a/src/core/utils/flash.cpp
+++ b/src/core/utils/flash.cpp
@@ -233,7 +233,7 @@ void Flash::Swap(void)
     {
         otPlatFlashRead(&GetInstance(), mSwapIndex, srcOffset, &record, sizeof(RecordHeader));
 
-        VerifyOrExit(record.IsAddBeginSet());
+        VerifyOrExit(record.IsAddBeginSet(), OT_NOOP);
 
         if (!record.IsValid() || DoesValidRecordExist(srcOffset + record.GetSize(), record.GetKey()))
         {

--- a/src/core/utils/heap.cpp
+++ b/src/core/utils/heap.cpp
@@ -66,7 +66,7 @@ void *Heap::CAlloc(size_t aCount, size_t aSize)
     Block *  curr = NULL;
     uint16_t size = static_cast<uint16_t>(aCount * aSize);
 
-    VerifyOrExit(size);
+    VerifyOrExit(size, OT_NOOP);
 
     size += kAlignSize - 1 - kBlockRemainderSize;
     size &= ~(kAlignSize - 1);
@@ -81,7 +81,7 @@ void *Heap::CAlloc(size_t aCount, size_t aSize)
         curr = &BlockNext(*curr);
     }
 
-    VerifyOrExit(curr->IsFree());
+    VerifyOrExit(curr->IsFree(), OT_NOOP);
 
     prev->SetNext(curr->GetNext());
 

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -101,18 +101,18 @@ exit:
 
 void JamDetector::CheckState(void)
 {
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NOOP);
 
     switch (Get<Mle::MleRouter>().GetRole())
     {
     case Mle::kRoleDisabled:
-        VerifyOrExit(mTimer.IsRunning());
+        VerifyOrExit(mTimer.IsRunning(), OT_NOOP);
         mTimer.Stop();
         SetJamState(false);
         break;
 
     default:
-        VerifyOrExit(!mTimer.IsRunning());
+        VerifyOrExit(!mTimer.IsRunning(), OT_NOOP);
         mCurSecondStartTime   = TimerMilli::GetNow();
         mAlwaysAboveThreshold = true;
         mHistoryBitmap        = 0;
@@ -170,7 +170,7 @@ void JamDetector::HandleTimer(void)
     int8_t rssi;
     bool   didExceedThreshold = true;
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NOOP);
 
     rssi = Get<Radio>().GetRssi();
 

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -58,7 +58,7 @@ Slaac::Slaac(Instance &aInstance)
 
 void Slaac::Enable(void)
 {
-    VerifyOrExit(!mEnabled);
+    VerifyOrExit(!mEnabled, OT_NOOP);
 
     otLogInfoUtil("SLAAC:: Enabling");
     mEnabled = true;
@@ -70,7 +70,7 @@ exit:
 
 void Slaac::Disable(void)
 {
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NOOP);
 
     otLogInfoUtil("SLAAC:: Disabling");
     mEnabled = false;
@@ -82,12 +82,12 @@ exit:
 
 void Slaac::SetFilter(otIp6SlaacPrefixFilter aFilter)
 {
-    VerifyOrExit(aFilter != mFilter);
+    VerifyOrExit(aFilter != mFilter, OT_NOOP);
 
     mFilter = aFilter;
     otLogInfoUtil("SLAAC: Filter %s", (mFilter != NULL) ? "updated" : "disabled");
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NOOP);
     Update(kModeAdd | kModeRemove);
 
 exit:
@@ -108,7 +108,7 @@ void Slaac::HandleStateChanged(otChangedFlags aFlags)
 {
     UpdateMode mode = kModeNone;
 
-    VerifyOrExit(mEnabled);
+    VerifyOrExit(mEnabled, OT_NOOP);
 
     if (aFlags & OT_CHANGED_THREAD_NETDATA)
     {
@@ -294,7 +294,7 @@ void Slaac::GenerateIid(Ip6::NetifUnicastAddress &aAddress) const
         // Exit and return the address if the IID is not reserved,
         // otherwise, try again with a new dadCounter
 
-        VerifyOrExit(aAddress.GetAddress().IsIidReserved());
+        VerifyOrExit(aAddress.GetAddress().IsIidReserved(), OT_NOOP);
     }
 
     otLogWarnUtil("SLAAC: Failed to generate a non-reserved IID after %d attempts", dadCounter);
@@ -310,7 +310,7 @@ void Slaac::GetIidSecretKey(IidSecretKey &aKey) const
     otError error;
 
     error = Get<Settings>().ReadSlaacIidSecretKey(aKey);
-    VerifyOrExit(error != OT_ERROR_NONE);
+    VerifyOrExit(error != OT_ERROR_NONE, OT_NOOP);
 
     // If there is no previously saved secret key, generate
     // a random one and save it.

--- a/src/lib/hdlc/CMakeLists.txt
+++ b/src/lib/hdlc/CMakeLists.txt
@@ -30,6 +30,13 @@ add_library(openthread-hdlc
     hdlc.cpp
 )
 
+set_target_properties(
+    openthread-hdlc
+    PROPERTIES
+        C_STANDARD 99
+        CXX_STANDARD 11
+)
+
 target_include_directories(openthread-hdlc
     PUBLIC
         ${OT_PUBLIC_INCLUDES}

--- a/src/lib/spinel/CMakeLists.txt
+++ b/src/lib/spinel/CMakeLists.txt
@@ -29,6 +29,13 @@
 add_library(openthread-spinel-ncp)
 add_library(openthread-spinel-rcp)
 
+set_target_properties(
+    openthread-spinel-ncp openthread-spinel-rcp
+    PROPERTIES
+        C_STANDARD 99
+        CXX_STANDARD 11
+)
+
 target_compile_definitions(openthread-spinel-ncp PRIVATE
     ${OT_PRIVATE_DEFINES}
     OPENTHREAD_FTD=1

--- a/src/lib/spinel/spinel_buffer.cpp
+++ b/src/lib/spinel/spinel_buffer.cpp
@@ -252,7 +252,7 @@ otError Buffer::InFrameBeginSegment(void)
     uint16_t headerFlags = kSegmentHeaderNoFlag;
 
     // Verify that segment is not yet started (i.e., head and tail are the same).
-    VerifyOrExit(mWriteSegmentHead == mWriteSegmentTail);
+    VerifyOrExit(mWriteSegmentHead == mWriteSegmentTail, OT_NOOP);
 
     // Check if this is the start of a new frame (i.e., frame start is same as segment head).
     if (mWriteFrameStart[mWriteDirection] == mWriteSegmentHead)
@@ -309,7 +309,7 @@ void Buffer::InFrameDiscard(void)
     otMessage *message;
 #endif
 
-    VerifyOrExit(mWriteDirection != kUnknown);
+    VerifyOrExit(mWriteDirection != kUnknown, OT_NOOP);
 
     // Move the write segment head and tail pointers back to frame start.
     mWriteSegmentHead = mWriteSegmentTail = mWriteFrameStart[mWriteDirection];
@@ -466,12 +466,12 @@ uint16_t Buffer::InFrameGetDistance(const WritePosition &aPosition) const
     uint16_t segmentLength;
     uint16_t offset;
 
-    VerifyOrExit(mWriteDirection != kUnknown);
-    VerifyOrExit(aPosition.mSegmentHead == mWriteSegmentHead);
+    VerifyOrExit(mWriteDirection != kUnknown, OT_NOOP);
+    VerifyOrExit(aPosition.mSegmentHead == mWriteSegmentHead, OT_NOOP);
 
     segmentLength = GetDistance(mWriteSegmentHead, mWriteSegmentTail, mWriteDirection);
     offset        = GetDistance(mWriteSegmentHead, aPosition.mPosition, mWriteDirection);
-    VerifyOrExit(offset < segmentLength);
+    VerifyOrExit(offset < segmentLength, OT_NOOP);
 
     distance = GetDistance(aPosition.mPosition, mWriteSegmentTail, mWriteDirection);
 

--- a/src/ncp/CMakeLists.txt
+++ b/src/ncp/CMakeLists.txt
@@ -32,10 +32,10 @@ add_library(openthread-rcp)
 
 # We depend on C++11 to validate that NCP handlers are sorted.
 set_target_properties(
-    openthread-ncp-mtd openthread-rcp
+    openthread-ncp-ftd openthread-ncp-mtd openthread-rcp
     PROPERTIES
         C_STANDARD 99
-        CXX_STANDARD 98
+        CXX_STANDARD 11
 )
 
 target_compile_definitions(openthread-ncp-ftd PRIVATE

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -341,7 +341,7 @@ void NcpBase::HandleReceive(const uint8_t *aBuf, uint16_t aBufLength)
     // Skip if there is no header byte to read or this isn't a spinel frame.
 
     SuccessOrExit(mDecoder.ReadUint8(header));
-    VerifyOrExit((SPINEL_HEADER_FLAG & header) == SPINEL_HEADER_FLAG);
+    VerifyOrExit((SPINEL_HEADER_FLAG & header) == SPINEL_HEADER_FLAG, OT_NOOP);
 
     mRxSpinelFrameCounter++;
 
@@ -623,7 +623,7 @@ void NcpBase::Log(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aLog
     uint8_t header = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
 
     VerifyOrExit(!mDisableStreamWrite, error = OT_ERROR_INVALID_STATE);
-    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_STREAM_LOG));
+    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_STREAM_LOG), OT_NOOP);
 
     // If there is a pending queued response we do not allow any new log
     // stream writes. This is to ensure that log messages can not continue
@@ -811,7 +811,7 @@ void NcpBase::UpdateChangedProps(void)
     ProcessThreadChangedFlags();
 #endif
 
-    VerifyOrExit(!mChangedPropsSet.IsEmpty());
+    VerifyOrExit(!mChangedPropsSet.IsEmpty(), OT_NOOP);
 
     entry = mChangedPropsSet.GetSupportedEntries(numEntries);
 
@@ -841,7 +841,7 @@ void NcpBase::UpdateChangedProps(void)
         }
 
         mChangedPropsSet.RemoveEntry(index);
-        VerifyOrExit(!mChangedPropsSet.IsEmpty());
+        VerifyOrExit(!mChangedPropsSet.IsEmpty(), OT_NOOP);
     }
 
 exit:
@@ -978,7 +978,7 @@ otError NcpBase::HandleCommandPropertySet(uint8_t aHeader, spinel_prop_key_t aKe
 
         bool didHandle = HandlePropertySetForSpecialProperties(aHeader, aKey, error);
 
-        VerifyOrExit(!didHandle);
+        VerifyOrExit(!didHandle, OT_NOOP);
 
 #if OPENTHREAD_ENABLE_NCP_VENDOR_HOOK
         if (aKey >= SPINEL_PROP_VENDOR__BEGIN && aKey < SPINEL_PROP_VENDOR__END)

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -86,7 +86,7 @@ exit:
 
 void NcpBase::HandleParentResponseInfo(otThreadParentResponseInfo *aInfo, void *aContext)
 {
-    VerifyOrExit(aInfo && aContext);
+    VerifyOrExit(aInfo && aContext, OT_NOOP);
 
     static_cast<NcpBase *>(aContext)->HandleParentResponseInfo(*aInfo);
 
@@ -96,7 +96,7 @@ exit:
 
 void NcpBase::HandleParentResponseInfo(const otThreadParentResponseInfo &aInfo)
 {
-    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_PARENT_RESPONSE_INFO));
+    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_PARENT_RESPONSE_INFO), OT_NOOP);
 
     SuccessOrExit(mEncoder.BeginFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_CMD_PROP_VALUE_IS,
                                       SPINEL_PROP_PARENT_RESPONSE_INFO));
@@ -134,7 +134,7 @@ void NcpBase::HandleNeighborTableChanged(otNeighborTableEvent aEvent, const otNe
         // Fall through
     case OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED:
         property = SPINEL_PROP_THREAD_CHILD_TABLE;
-        VerifyOrExit(!aEntry.mInfo.mChild.mIsStateRestoring);
+        VerifyOrExit(!aEntry.mInfo.mChild.mIsStateRestoring, OT_NOOP);
         break;
 
     case OT_NEIGHBOR_TABLE_EVENT_ROUTER_ADDED:
@@ -148,7 +148,7 @@ void NcpBase::HandleNeighborTableChanged(otNeighborTableEvent aEvent, const otNe
         ExitNow();
     }
 
-    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(property));
+    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(property), OT_NOOP);
 
     SuccessOrExit(error = mEncoder.BeginFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, command, property));
 

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -1539,7 +1539,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_IPV6_ML_PREFIX>(void)
     const otMeshLocalPrefix *mlPrefix = otThreadGetMeshLocalPrefix(mInstance);
     otIp6Address             addr;
 
-    VerifyOrExit(mlPrefix != NULL); // If `mlPrefix` is NULL send empty response.
+    VerifyOrExit(mlPrefix != NULL, OT_NOOP); // If `mlPrefix` is NULL send empty response.
 
     memcpy(addr.mFields.m8, mlPrefix->m8, 8);
 
@@ -1574,7 +1574,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_IPV6_ML_ADDR>(void)
     otError             error = OT_ERROR_NONE;
     const otIp6Address *ml64  = otThreadGetMeshLocalEid(mInstance);
 
-    VerifyOrExit(ml64 != NULL);
+    VerifyOrExit(ml64 != NULL, OT_NOOP);
     SuccessOrExit(error = mEncoder.WriteIp6Address(*ml64));
 
 exit:
@@ -1586,7 +1586,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_IPV6_LL_ADDR>(void)
     otError             error   = OT_ERROR_NONE;
     const otIp6Address *address = otThreadGetLinkLocalIp6Address(mInstance);
 
-    VerifyOrExit(address != NULL);
+    VerifyOrExit(address != NULL, OT_NOOP);
     SuccessOrExit(error = mEncoder.WriteIp6Address(*address));
 
 exit:
@@ -3119,7 +3119,7 @@ void NcpBase::RegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers)
     mLegacyHandlers = aHandlers;
     bool isEnabled;
 
-    VerifyOrExit(mLegacyHandlers != NULL);
+    VerifyOrExit(mLegacyHandlers != NULL, OT_NOOP);
 
     isEnabled = (otThreadGetDeviceRole(mInstance) != OT_DEVICE_ROLE_DISABLED);
 
@@ -3394,7 +3394,7 @@ void NcpBase::HandleDatagramFromStack(otMessage *aMessage, void *aContext)
 
 void NcpBase::HandleDatagramFromStack(otMessage *aMessage)
 {
-    VerifyOrExit(aMessage != NULL);
+    VerifyOrExit(aMessage != NULL, OT_NOOP);
 
     SuccessOrExit(otMessageQueueEnqueue(&mMessageQueue, aMessage));
 
@@ -3561,7 +3561,7 @@ void NcpBase::HandlePcapFrame(const otRadioFrame *aFrame, bool aIsTx)
     uint16_t flags  = 0;
     uint8_t  header = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
 
-    VerifyOrExit(mPcapEnabled);
+    VerifyOrExit(mPcapEnabled, OT_NOOP);
 
     if (aIsTx)
     {
@@ -3603,7 +3603,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_PHY_PCAP_ENABLED>(voi
     bool    enabled;
 
     SuccessOrExit(error = mDecoder.ReadBool(enabled));
-    VerifyOrExit(enabled != mPcapEnabled);
+    VerifyOrExit(enabled != mPcapEnabled, OT_NOOP);
 
     mPcapEnabled = enabled;
 
@@ -3663,7 +3663,7 @@ void NcpBase::ProcessThreadChangedFlags(void)
         {OT_CHANGED_SUPPORTED_CHANNEL_MASK, SPINEL_PROP_PHY_CHAN_SUPPORTED},
     };
 
-    VerifyOrExit(mThreadChangedFlags != 0);
+    VerifyOrExit(mThreadChangedFlags != 0, OT_NOOP);
 
     // If thread role has changed, check for possible "join" error.
 
@@ -3734,7 +3734,7 @@ void NcpBase::ProcessThreadChangedFlags(void)
             }
 
             mThreadChangedFlags &= ~threadFlag;
-            VerifyOrExit(mThreadChangedFlags != 0);
+            VerifyOrExit(mThreadChangedFlags != 0, OT_NOOP);
         }
     }
 

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -144,8 +144,9 @@ bool NcpSpi::SpiTransactionComplete(uint8_t *aOutputBuf,
     SpiFrame inputFrame(aInputBuf);
     SpiFrame sendFrame(mSendFrame);
 
-    VerifyOrExit((aTransLen >= kSpiHeaderSize) && (aInputLen >= kSpiHeaderSize) && (aOutputLen >= kSpiHeaderSize));
-    VerifyOrExit(inputFrame.IsValid() && outputFrame.IsValid());
+    VerifyOrExit((aTransLen >= kSpiHeaderSize) && (aInputLen >= kSpiHeaderSize) && (aOutputLen >= kSpiHeaderSize),
+                 OT_NOOP);
+    VerifyOrExit(inputFrame.IsValid() && outputFrame.IsValid(), OT_NOOP);
 
     transDataLen = aTransLen - kSpiHeaderSize;
 
@@ -259,7 +260,7 @@ void NcpSpi::PrepareNextSpiSendFrame(void)
     uint16_t readLength;
     SpiFrame sendFrame(mSendFrame);
 
-    VerifyOrExit(!mTxFrameBuffer.IsEmpty());
+    VerifyOrExit(!mTxFrameBuffer.IsEmpty(), OT_NOOP);
 
     if (ShouldWakeHost())
     {

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -150,7 +150,7 @@ void NcpUart::EncodeAndSendToUart(void)
                 otPlatWakeHost();
             }
 
-            VerifyOrExit(!super_t::ShouldDeferHostSend());
+            VerifyOrExit(!super_t::ShouldDeferHostSend(), OT_NOOP);
             SuccessOrExit(mFrameEncoder.BeginFrame());
 
             txFrameBuffer.OutFrameBegin();

--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -176,17 +176,17 @@ static void SendBlockingCommand(int aArgc, char *aArgv[])
 
     for (int i = 0; i < aArgc; i++)
     {
-        VerifyOrExit(DoWrite(sSessionFd, aArgv[i], strlen(aArgv[i])));
-        VerifyOrExit(DoWrite(sSessionFd, " ", 1));
+        VerifyOrExit(DoWrite(sSessionFd, aArgv[i], strlen(aArgv[i])), OT_NOOP);
+        VerifyOrExit(DoWrite(sSessionFd, " ", 1), OT_NOOP);
     }
-    VerifyOrExit(DoWrite(sSessionFd, "\n", 1));
+    VerifyOrExit(DoWrite(sSessionFd, "\n", 1), OT_NOOP);
 
     while (true)
     {
         ssize_t rval = read(sSessionFd, buffer, sizeof(buffer));
 
-        VerifyOrExit(rval >= 0);
-        VerifyOrExit(DoWrite(STDOUT_FILENO, buffer, static_cast<size_t>(rval)));
+        VerifyOrExit(rval >= 0, OT_NOOP);
+        VerifyOrExit(DoWrite(STDOUT_FILENO, buffer, static_cast<size_t>(rval)), OT_NOOP);
         for (ssize_t i = 0; i < rval; i++)
         {
             if (FindDone(&doneState, buffer[i]) || FindError(&errorState, buffer[i]))

--- a/src/posix/daemon.cmake
+++ b/src/posix/daemon.cmake
@@ -30,6 +30,13 @@ add_executable(ot-daemon
     main.c
 )
 
+set_target_properties(
+    ot-daemon
+    PROPERTIES
+        C_STANDARD 99
+        CXX_STANDARD 11
+)
+
 target_include_directories(ot-daemon PRIVATE ${COMMON_INCLUDES})
 
 target_compile_definitions(ot-daemon PRIVATE
@@ -51,6 +58,13 @@ target_link_libraries(ot-daemon PRIVATE
 
 add_executable(ot-ctl
     client.cpp
+)
+
+set_target_properties(
+    ot-ctl
+    PROPERTIES
+        C_STANDARD 99
+        CXX_STANDARD 11
 )
 
 target_compile_definitions(ot-ctl PRIVATE

--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -68,6 +68,13 @@ add_library(openthread-posix
     virtual_time.cpp
 )
 
+set_target_properties(
+    openthread-posix
+    PROPERTIES
+        C_STANDARD 99
+        CXX_STANDARD 11
+)
+
 target_link_libraries(openthread-posix PUBLIC
     util
 )

--- a/src/posix/platform/alarm.cpp
+++ b/src/posix/platform/alarm.cpp
@@ -127,7 +127,7 @@ void platformAlarmUpdateTimeout(struct timeval *aTimeout)
     if (sIsMsRunning)
     {
         remaining = (int32_t)(sMsAlarm - (uint32_t)(now / US_PER_MS));
-        VerifyOrExit(remaining > 0);
+        VerifyOrExit(remaining > 0, OT_NOOP);
         remaining *= US_PER_MS;
         remaining -= (now % US_PER_MS);
     }

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -169,7 +169,7 @@ HdlcInterface::~HdlcInterface(void)
 
 void HdlcInterface::Deinit(void)
 {
-    VerifyOrExit(mSockFd != -1);
+    VerifyOrExit(mSockFd != -1, OT_NOOP);
 
     VerifyOrExit(0 == close(mSockFd), perror("close RCP"));
     VerifyOrExit(-1 != wait(NULL) || errno == ECHILD, perror("wait RCP"));
@@ -419,7 +419,7 @@ int HdlcInterface::OpenFile(const char *aFile, const char *aConfig)
         char parity = 'N';
         char flow   = 'N';
 
-        VerifyOrExit((rval = tcgetattr(fd, &tios)) == 0);
+        VerifyOrExit((rval = tcgetattr(fd, &tios)) == 0, OT_NOOP);
 
         cfmakeraw(&tios);
 
@@ -562,7 +562,7 @@ int HdlcInterface::OpenFile(const char *aFile, const char *aConfig)
 
         VerifyOrExit((rval = cfsetspeed(&tios, static_cast<speed_t>(speed))) == 0, perror("cfsetspeed"));
         VerifyOrExit((rval = tcsetattr(fd, TCSANOW, &tios)) == 0, perror("tcsetattr"));
-        VerifyOrExit((rval = tcflush(fd, TCIOFLUSH)) == 0);
+        VerifyOrExit((rval = tcflush(fd, TCIOFLUSH)) == 0, OT_NOOP);
     }
 
 exit:

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -107,7 +107,6 @@ struct MLDv2Record
     uint8_t         mAuxDataLen;
     uint16_t        mNumSources;
     struct in6_addr mMulticastAddress;
-    struct in6_addr mSourceAddresses[];
 } OT_TOOL_PACKED_END;
 
 enum

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -160,7 +160,7 @@ static void UpdateMulticast(otInstance *aInstance, const otIp6Address &aAddress,
 
     assert(sInstance == aInstance);
 
-    VerifyOrExit(sIpFd > 0);
+    VerifyOrExit(sIpFd > 0, OT_NOOP);
     memcpy(&mreq.ipv6mr_multiaddr, &aAddress, sizeof(mreq.ipv6mr_multiaddr));
     mreq.ipv6mr_interface = sTunIndex;
 
@@ -181,7 +181,7 @@ static void UpdateLink(otInstance *aInstance)
 
     assert(sInstance == aInstance);
 
-    VerifyOrExit(sIpFd > 0);
+    VerifyOrExit(sIpFd > 0, OT_NOOP);
     memset(&ifr, 0, sizeof(ifr));
     strncpy(ifr.ifr_name, sTunName, sizeof(ifr.ifr_name));
     VerifyOrExit(ioctl(sIpFd, SIOCGIFFLAGS, &ifr) == 0, perror("ioctl"); error = OT_ERROR_FAILED);
@@ -236,7 +236,7 @@ static void processReceive(otMessage *aMessage, void *aContext)
 
     assert(sInstance == aContext);
 
-    VerifyOrExit(sTunFd > 0);
+    VerifyOrExit(sTunFd > 0, OT_NOOP);
 
     VerifyOrExit(otMessageRead(aMessage, 0, packet, sizeof(packet)) == length, error = OT_ERROR_NO_BUFS);
 
@@ -297,7 +297,7 @@ static void processNetifAddrEvent(otInstance *aInstance, struct nlmsghdr *aNetli
     size_t            rtaLength;
     otError           error = OT_ERROR_NONE;
 
-    VerifyOrExit(ifaddr->ifa_index == static_cast<unsigned int>(sTunIndex) && ifaddr->ifa_family == AF_INET6);
+    VerifyOrExit(ifaddr->ifa_index == static_cast<unsigned int>(sTunIndex) && ifaddr->ifa_family == AF_INET6, OT_NOOP);
 
     rtaLength = IFA_PAYLOAD(aNetlinkMessage);
 
@@ -367,7 +367,7 @@ static void processNetifLinkEvent(otInstance *aInstance, struct nlmsghdr *aNetli
     struct ifinfomsg *ifinfo = reinterpret_cast<struct ifinfomsg *>(NLMSG_DATA(aNetlinkMessage));
     otError           error  = OT_ERROR_NONE;
 
-    VerifyOrExit(ifinfo->ifi_index == static_cast<int>(sTunIndex));
+    VerifyOrExit(ifinfo->ifi_index == static_cast<int>(sTunIndex), OT_NOOP);
     SuccessOrExit(error = otIp6SetEnabled(aInstance, ifinfo->ifi_flags & IFF_UP));
 
 exit:
@@ -389,7 +389,7 @@ static void processNetifEvent(otInstance *aInstance)
 
     length = recv(sNetlinkFd, buffer, sizeof(buffer), 0);
 
-    VerifyOrExit(length > 0);
+    VerifyOrExit(length > 0, OT_NOOP);
 
     for (struct nlmsghdr *msg = reinterpret_cast<struct nlmsghdr *>(buffer); NLMSG_OK(msg, length);
          msg                  = NLMSG_NEXT(msg, length))
@@ -472,13 +472,13 @@ static void processMLDEvent(otInstance *aInstance)
     struct ifaddrs *    ifAddrs = NULL;
 
     bufferLen = recvfrom(sMLDMonitorFd, buffer, sizeof(buffer), 0, reinterpret_cast<sockaddr *>(&srcAddr), &addrLen);
-    VerifyOrExit(bufferLen > 0);
+    VerifyOrExit(bufferLen > 0, OT_NOOP);
 
     type = buffer[0];
-    VerifyOrExit(type == kICMPv6MLDv2Type && bufferLen >= static_cast<ssize_t>(sizeof(MLDv2Header)));
+    VerifyOrExit(type == kICMPv6MLDv2Type && bufferLen >= static_cast<ssize_t>(sizeof(MLDv2Header)), OT_NOOP);
 
     // Check whether it is sent by self
-    VerifyOrExit(getifaddrs(&ifAddrs) == 0);
+    VerifyOrExit(getifaddrs(&ifAddrs) == 0, OT_NOOP);
     for (struct ifaddrs *ifAddr = ifAddrs; ifAddr != NULL; ifAddr = ifAddr->ifa_next)
     {
         if (ifAddr->ifa_addr != NULL && ifAddr->ifa_addr->sa_family == AF_INET6 &&
@@ -493,7 +493,7 @@ static void processMLDEvent(otInstance *aInstance)
             }
         }
     }
-    VerifyOrExit(fromSelf);
+    VerifyOrExit(fromSelf, OT_NOOP);
 
     hdr    = reinterpret_cast<MLDv2Header *>(buffer);
     offset = sizeof(MLDv2Header);
@@ -616,7 +616,7 @@ void platformNetifUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *a
 {
     OT_UNUSED_VARIABLE(aWriteFdSet);
 
-    VerifyOrExit(sTunIndex > 0);
+    VerifyOrExit(sTunIndex > 0, OT_NOOP);
 
     assert(sTunFd > 0);
     assert(sNetlinkFd > 0);
@@ -650,7 +650,7 @@ exit:
 void platformNetifProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, const fd_set *aErrorFdSet)
 {
     OT_UNUSED_VARIABLE(aWriteFdSet);
-    VerifyOrExit(sTunIndex > 0);
+    VerifyOrExit(sTunIndex > 0, OT_NOOP);
 
     if (FD_ISSET(sTunFd, aErrorFdSet))
     {

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -448,7 +448,7 @@ void RadioSpinel::HandleNotification(const uint8_t *aFrame, uint16_t aLength)
     unpacked = spinel_datatype_unpack(aFrame, aLength, "CiiD", &header, &cmd, &key, &data, &len);
     VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
     VerifyOrExit(SPINEL_HEADER_GET_TID(header) == 0, error = OT_ERROR_PARSE);
-    VerifyOrExit(cmd == SPINEL_CMD_PROP_VALUE_IS);
+    VerifyOrExit(cmd == SPINEL_CMD_PROP_VALUE_IS, OT_NOOP);
     HandleValueIs(key, data, static_cast<uint16_t>(len));
 
 exit:
@@ -666,7 +666,7 @@ void RadioSpinel::HandleWaitingResponse(uint32_t          aCommand,
     {
         spinel_ssize_t unpacked;
 
-        VerifyOrExit(mDiagOutput != NULL);
+        VerifyOrExit(mDiagOutput != NULL, OT_NOOP);
         unpacked =
             spinel_datatype_unpack_in_place(aBuffer, aLength, SPINEL_DATATYPE_UTF8_S, mDiagOutput, &mDiagOutputMaxLen);
         VerifyOrExit(unpacked > 0, mError = OT_ERROR_PARSE);
@@ -996,7 +996,7 @@ otError RadioSpinel::SetShortAddress(uint16_t aAddress)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mShortAddress != aAddress);
+    VerifyOrExit(mShortAddress != aAddress, OT_NOOP);
     SuccessOrExit(error = sRadioSpinel.Set(SPINEL_PROP_MAC_15_4_SADDR, SPINEL_DATATYPE_UINT16_S, aAddress));
     mShortAddress = aAddress;
 
@@ -1024,7 +1024,7 @@ otError RadioSpinel::SetPanId(uint16_t aPanId)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mPanId != aPanId);
+    VerifyOrExit(mPanId != aPanId, OT_NOOP);
     SuccessOrExit(error = Set(SPINEL_PROP_MAC_15_4_PANID, SPINEL_DATATYPE_UINT16_S, aPanId));
     mPanId = aPanId;
 
@@ -1339,7 +1339,7 @@ otError RadioSpinel::RequestV(bool aWait, uint32_t command, spinel_prop_key_t aK
     VerifyOrExit(!aWait || tid > 0, error = OT_ERROR_BUSY);
 
     error = SendCommand(command, aKey, tid, aFormat, aArgs);
-    VerifyOrExit(error == OT_ERROR_NONE);
+    SuccessOrExit(error);
 
     if (aKey == SPINEL_PROP_STREAM_RAW)
     {
@@ -1419,7 +1419,7 @@ otError RadioSpinel::Transmit(otRadioFrame &aFrame)
 {
     otError error = OT_ERROR_INVALID_STATE;
 
-    VerifyOrExit(mState == kStateReceive);
+    VerifyOrExit(mState == kStateReceive, OT_NOOP);
 
     mTransmitFrame = &aFrame;
 
@@ -1456,14 +1456,14 @@ otError RadioSpinel::Receive(uint8_t aChannel)
     if (mChannel != aChannel)
     {
         error = Set(SPINEL_PROP_PHY_CHAN, SPINEL_DATATYPE_UINT8_S, aChannel);
-        VerifyOrExit(error == OT_ERROR_NONE);
+        SuccessOrExit(error);
         mChannel = aChannel;
     }
 
     if (mState == kStateSleep)
     {
         error = Set(SPINEL_PROP_MAC_RAW_STREAM_ENABLED, SPINEL_DATATYPE_BOOL_S, true);
-        VerifyOrExit(error == OT_ERROR_NONE);
+        SuccessOrExit(error);
     }
 
     if (mTxRadioTid != 0)
@@ -1486,7 +1486,7 @@ otError RadioSpinel::Sleep(void)
     {
     case kStateReceive:
         error = sRadioSpinel.Set(SPINEL_PROP_MAC_RAW_STREAM_ENABLED, SPINEL_DATATYPE_BOOL_S, false);
-        VerifyOrExit(error == OT_ERROR_NONE);
+        SuccessOrExit(error);
 
         mState = kStateSleep;
         break;
@@ -1507,7 +1507,7 @@ otError RadioSpinel::Enable(otInstance *aInstance)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(!IsEnabled());
+    VerifyOrExit(!IsEnabled(), OT_NOOP);
 
     mInstance = aInstance;
 
@@ -1532,7 +1532,7 @@ otError RadioSpinel::Disable(void)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(IsEnabled());
+    VerifyOrExit(IsEnabled(), OT_NOOP);
     VerifyOrExit(mState == kStateSleep, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrDie(sRadioSpinel.Set(SPINEL_PROP_PHY_ENABLED, SPINEL_DATATYPE_BOOL_S, false));

--- a/src/posix/platform/uart.cpp
+++ b/src/posix/platform/uart.cpp
@@ -67,7 +67,7 @@ otError otPlatUartEnable(void)
     int                ret;
 
     // This allows implementing pseudo reset.
-    VerifyOrExit(sUartSocket == -1);
+    VerifyOrExit(sUartSocket == -1, OT_NOOP);
 
     sUartSocket = SocketWithCloseExec(AF_UNIX, SOCK_STREAM, 0);
 
@@ -169,7 +169,7 @@ otError otPlatUartFlush(void)
 
 void platformUartUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *aErrorFdSet, int *aMaxFd)
 {
-    VerifyOrExit(sEnabled);
+    VerifyOrExit(sEnabled, OT_NOOP);
 
     if (aReadFdSet != NULL)
     {
@@ -221,7 +221,7 @@ void platformUartProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, co
     ssize_t rval;
     int     fd;
 
-    VerifyOrExit(sEnabled);
+    VerifyOrExit(sEnabled, OT_NOOP);
 #if OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
     if (FD_ISSET(sUartSocket, aErrorFdSet))
     {
@@ -240,7 +240,7 @@ void platformUartProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, co
         otPlatUartSendDone();
     }
 
-    VerifyOrExit(sSessionSocket != -1);
+    VerifyOrExit(sSessionSocket != -1, OT_NOOP);
 
     if (FD_ISSET(sSessionSocket, aErrorFdSet))
     {
@@ -248,7 +248,7 @@ void platformUartProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, co
         sSessionSocket = -1;
     }
 
-    VerifyOrExit(sSessionSocket != -1);
+    VerifyOrExit(sSessionSocket != -1, OT_NOOP);
 
     fd = sSessionSocket;
 #else  // OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
@@ -311,7 +311,7 @@ void platformUartProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, co
 #endif
         }
 
-        VerifyOrExit(rval > 0);
+        VerifyOrExit(rval > 0, OT_NOOP);
 
         sWriteBuffer += (uint16_t)rval;
         sWriteLength -= (uint16_t)rval;

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -362,7 +362,7 @@ exit:
 
 void platformUdpUpdateFdSet(otInstance *aInstance, fd_set *aReadFdSet, int *aMaxFd)
 {
-    VerifyOrExit(sPlatNetifIndex != 0);
+    VerifyOrExit(sPlatNetifIndex != 0, OT_NOOP);
 
     for (otUdpSocket *socket = otUdpGetSockets(aInstance); socket != NULL; socket = socket->mNext)
     {
@@ -405,7 +405,7 @@ void platformUdpProcess(otInstance *aInstance, const fd_set *aReadFdSet)
 {
     otMessageSettings msgSettings = {false, OT_MESSAGE_PRIORITY_NORMAL};
 
-    VerifyOrExit(sPlatNetifIndex != 0);
+    VerifyOrExit(sPlatNetifIndex != 0, OT_NOOP);
 
     for (otUdpSocket *socket = otUdpGetSockets(aInstance); socket != NULL; socket = socket->mNext)
     {

--- a/src/posix/standalone.cmake
+++ b/src/posix/standalone.cmake
@@ -31,6 +31,13 @@ add_executable(ot-cli
     $<$<BOOL:${READLINE}>:console_cli.cpp>
 )
 
+set_target_properties(
+    ot-cli
+    PROPERTIES
+        C_STANDARD 99
+        CXX_STANDARD 11
+)
+
 target_include_directories(ot-cli PRIVATE ${COMMON_INCLUDES})
 
 target_compile_definitions(ot-cli PRIVATE
@@ -54,6 +61,13 @@ target_link_libraries(ot-cli
 
 add_executable(ot-ncp
     main.c
+)
+
+set_target_properties(
+    ot-ncp
+    PROPERTIES
+        C_STANDARD 99
+        CXX_STANDARD 11
 )
 
 target_include_directories(ot-ncp PRIVATE ${COMMON_INCLUDES})

--- a/tests/fuzz/cli_uart_received.cpp
+++ b/tests/fuzz/cli_uart_received.cpp
@@ -50,7 +50,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     otInstance *instance = NULL;
     uint8_t *   buf      = NULL;
 
-    VerifyOrExit(size <= 65536);
+    VerifyOrExit(size <= 65536, OT_NOOP);
 
     FuzzerPlatformInit();
 
@@ -67,7 +67,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     otPlatUartReceived(buf, (uint16_t)size);
 
-    VerifyOrExit(!FuzzerPlatformResetWasRequested());
+    VerifyOrExit(!FuzzerPlatformResetWasRequested(), OT_NOOP);
 
     for (int i = 0; i < MAX_ITERATIONS; i++)
     {

--- a/tests/fuzz/ip6_send.cpp
+++ b/tests/fuzz/ip6_send.cpp
@@ -50,7 +50,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     otError           error    = OT_ERROR_NONE;
     otMessageSettings settings;
 
-    VerifyOrExit(size > 0);
+    VerifyOrExit(size > 0, OT_NOOP);
 
     FuzzerPlatformInit();
 
@@ -73,7 +73,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     message = NULL;
 
-    VerifyOrExit(!FuzzerPlatformResetWasRequested());
+    VerifyOrExit(!FuzzerPlatformResetWasRequested(), OT_NOOP);
 
     for (int i = 0; i < MAX_ITERATIONS; i++)
     {

--- a/tests/fuzz/ncp_uart_received.cpp
+++ b/tests/fuzz/ncp_uart_received.cpp
@@ -50,7 +50,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     otInstance *instance = NULL;
     uint8_t *   buf      = NULL;
 
-    VerifyOrExit(size <= 65536);
+    VerifyOrExit(size <= 65536, OT_NOOP);
 
     FuzzerPlatformInit();
 
@@ -67,7 +67,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     otPlatUartReceived(buf, (uint16_t)size);
 
-    VerifyOrExit(!FuzzerPlatformResetWasRequested());
+    VerifyOrExit(!FuzzerPlatformResetWasRequested(), OT_NOOP);
 
     for (int i = 0; i < MAX_ITERATIONS; i++)
     {

--- a/tests/fuzz/radio_receive_done.cpp
+++ b/tests/fuzz/radio_receive_done.cpp
@@ -50,7 +50,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     otRadioFrame frame;
     uint8_t *    buf = NULL;
 
-    VerifyOrExit(size <= OT_RADIO_FRAME_MAX_SIZE);
+    VerifyOrExit(size <= OT_RADIO_FRAME_MAX_SIZE, OT_NOOP);
 
     FuzzerPlatformInit();
 
@@ -71,7 +71,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     otPlatRadioReceiveDone(instance, &frame, OT_ERROR_NONE);
 
-    VerifyOrExit(!FuzzerPlatformResetWasRequested());
+    VerifyOrExit(!FuzzerPlatformResetWasRequested(), OT_NOOP);
 
     for (int i = 0; i < MAX_ITERATIONS; i++)
     {


### PR DESCRIPTION
- avoid use of GNU extension `##__VA_ARGS__`
- avoid use of zero variadic macro arguments
- avoid use of flexible array members
- enforce above by adding pedantic-errors flag to cmake build files
- use C++11 in cmake only because code still includes some C++11 features