### PR TITLE
[address-resolver] use RLOC dest when send `a/ae` to child

### DIFF
--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -765,7 +765,7 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
 
             if (child.RemoveIp6Address(target) == OT_ERROR_NONE)
             {
-                SuccessOrExit(error = Get<Mle::Mle>().GetRlocAddress(destination, child.GetRloc16()));
+                SuccessOrExit(error = Get<Mle::Mle>().GetLocatorAddress(destination, child.GetRloc16()));
 
                 SendAddressError(target, meshLocalIid, &destination);
                 ExitNow();

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -765,9 +765,7 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
 
             if (child.RemoveIp6Address(target) == OT_ERROR_NONE)
             {
-                destination.Clear();
-                destination.mFields.m16[0] = HostSwap16(0xfe80);
-                destination.SetIid(child.GetExtAddress());
+                SuccessOrExit(error = Get<Mle::Mle>().GetRlocAddress(destination, child.GetRloc16()));
 
                 SendAddressError(target, meshLocalIid, &destination);
                 ExitNow();

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1108,23 +1108,17 @@ exit:
     return error;
 }
 
-otError Mle::GetAlocAddress(Ip6::Address &aAddress, uint16_t aAloc16) const
+otError Mle::GetLocatorAddress(Ip6::Address &aAddress, uint16_t aLoc16) const
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(GetRloc16() != Mac::kShortAddrInvalid, error = OT_ERROR_DETACHED);
 
     memcpy(&aAddress, &mMeshLocal16.GetAddress(), 14);
-    aAddress.SetLocator(aAloc16);
+    aAddress.SetLocator(aLoc16);
 
 exit:
     return error;
-}
-
-otError Mle::GetRlocAddress(Ip6::Address &aAddress, uint16_t aRloc16) const
-{
-    // Same logic with `GetAlocAddress`
-    return GetAlocAddress(aAddress, aRloc16);
 }
 
 otError Mle::GetServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1108,14 +1108,14 @@ exit:
     return error;
 }
 
-otError Mle::GetLocatorAddress(Ip6::Address &aAddress, uint16_t aLoc16) const
+otError Mle::GetLocatorAddress(Ip6::Address &aAddress, uint16_t aLocator) const
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(GetRloc16() != Mac::kShortAddrInvalid, error = OT_ERROR_DETACHED);
 
     memcpy(&aAddress, &mMeshLocal16.GetAddress(), 14);
-    aAddress.SetLocator(aLoc16);
+    aAddress.SetLocator(aLocator);
 
 exit:
     return error;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1121,6 +1121,12 @@ exit:
     return error;
 }
 
+otError Mle::GetRlocAddress(Ip6::Address &aAddress, uint16_t aRloc16) const
+{
+    // Same logic with `GetAlocAddress`
+    return GetAlocAddress(aAddress, aRloc16);
+}
+
 otError Mle::GetServiceAloc(uint8_t aServiceId, Ip6::Address &aAddress) const
 {
     otError error = OT_ERROR_NONE;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -779,7 +779,7 @@ public:
      * @retval OT_ERROR_DETACHED  The Thread interface is not currently attached to a Thread Partition.
      *
      */
-    otError GetLeaderAloc(Ip6::Address &aAddress) const { return GetAlocAddress(aAddress, kAloc16Leader); }
+    otError GetLeaderAloc(Ip6::Address &aAddress) const { return GetLocatorAddress(aAddress, kAloc16Leader); }
 
     /**
      * This method computes the Commissioner's ALOC.
@@ -793,7 +793,7 @@ public:
      */
     otError GetCommissionerAloc(Ip6::Address &aAddress, uint16_t aSessionId) const
     {
-        return GetAlocAddress(aAddress, CommissionerAloc16FromId(aSessionId));
+        return GetLocatorAddress(aAddress, CommissionerAloc16FromId(aSessionId));
     }
 
     /**
@@ -974,16 +974,16 @@ public:
     void RequestShorterChildIdRequest(void);
 
     /**
-     * This method gets the RLOC address of a given RLOC16.
+     * This method gets the RLOC or ALOC of a given RLOC16 or ALOC16.
      *
-     * @param[out]  aAddress  A reference to the RLOC address.
-     * @param[in]   aRloc16   The RLOC16.
+     * @param[out]  aAddress  A reference to the RLOC or ALOC.
+     * @param[in]   aLoc16    RLOC16 or ALOC16.
      *
-     * @retval OT_ERROR_NONE      If got the RLOC address successfully.
+     * @retval OT_ERROR_NONE      If got the RLOC or ALOC successfully.
      * @retval OT_ERROR_DETACHED  If device is detached.
      *
      */
-    otError GetRlocAddress(Ip6::Address &aAddress, uint16_t aRloc16) const;
+    otError GetLocatorAddress(Ip6::Address &aAddress, uint16_t aLoc16) const;
 
 protected:
     /**
@@ -1768,7 +1768,6 @@ private:
                         uint8_t                aVersion);
     bool IsNetworkDataNewer(const LeaderData &aLeaderData);
 
-    otError GetAlocAddress(Ip6::Address &aAddress, uint16_t aAloc16) const;
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     /**
      * This method scans for network data from the leader and updates IP addresses assigned to this

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -977,13 +977,13 @@ public:
      * This method gets the RLOC or ALOC of a given RLOC16 or ALOC16.
      *
      * @param[out]  aAddress  A reference to the RLOC or ALOC.
-     * @param[in]   aLoc16    RLOC16 or ALOC16.
+     * @param[in]   aLocator  RLOC16 or ALOC16.
      *
      * @retval OT_ERROR_NONE      If got the RLOC or ALOC successfully.
      * @retval OT_ERROR_DETACHED  If device is detached.
      *
      */
-    otError GetLocatorAddress(Ip6::Address &aAddress, uint16_t aLoc16) const;
+    otError GetLocatorAddress(Ip6::Address &aAddress, uint16_t aLocator) const;
 
 protected:
     /**

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -973,6 +973,18 @@ public:
      */
     void RequestShorterChildIdRequest(void);
 
+    /**
+     * This method gets the RLOC address of a given RLOC16.
+     *
+     * @param[out]  aAddress  A reference to the RLOC address.
+     * @param[in]   aRloc16   The RLOC16.
+     *
+     * @retval OT_ERROR_NONE      If got the RLOC address successfully.
+     * @retval OT_ERROR_DETACHED  If device is detached.
+     *
+     */
+    otError GetRlocAddress(Ip6::Address &aAddress, uint16_t aRloc16) const;
+
 protected:
     /**
      * States during attach (when searching for a parent).


### PR DESCRIPTION
Besides, we found that the `/a/ae` COAP message with link-local destination wouldn't be processed by by child's COAP layer. 
Thoughts on why it is unreachable by link-local address? @librasungirl @jwhui 