### PR TITLE
[network-data] enhance/simplify updating of network data on leader

### DIFF
--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -240,7 +240,7 @@ enum AlocAllocation
  * Service IDs
  *
  */
-enum ServiceId
+enum
 {
     kServiceMinId = 0x00, ///< Minimal Service ID.
     kServiceMaxId = 0x0f, ///< Maximal Service ID.

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -712,14 +712,14 @@ exit:
     return serviceTlv;
 }
 
-NetworkDataTlv *NetworkData::AppendTlv(uint8_t aTlvSize)
+NetworkDataTlv *NetworkData::AppendTlv(uint16_t aTlvSize)
 {
     NetworkDataTlv *tlv;
 
-    VerifyOrExit(mLength + aTlvSize <= kMaxSize, tlv = NULL);
+    VerifyOrExit(CanInsert(aTlvSize), tlv = NULL);
 
     tlv = GetTlvsEnd();
-    mLength += aTlvSize;
+    mLength += static_cast<uint8_t>(aTlvSize);
 
 exit:
     return tlv;
@@ -729,7 +729,7 @@ void NetworkData::Insert(void *aStart, uint8_t aLength)
 {
     uint8_t *start = reinterpret_cast<uint8_t *>(aStart);
 
-    OT_ASSERT(aLength + mLength <= sizeof(mTlvs) && mTlvs <= start && start <= mTlvs + mLength);
+    OT_ASSERT(CanInsert(aLength) && mTlvs <= start && start <= mTlvs + mLength);
     memmove(start + aLength, start, mLength - static_cast<size_t>(start - mTlvs));
     mLength += aLength;
 }

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -597,6 +597,18 @@ protected:
                                          uint8_t        aTlvsLength);
 
     /**
+     * This method indicates whether there is space in Network Data to insert/append new info and grow it by a given
+     * number of bytes.
+     *
+     * @param[in]  aSize  The number of bytes to grow the Network Data.
+     *
+     * @retval TRUE   There is space to grow Network Data by @p aSize bytes.
+     * @retval FALSE  There is no space left to grow Network Data by @p aSize bytes.
+     *
+     */
+    bool CanInsert(uint16_t aSize) const { return (mLength + aSize <= kMaxSize); }
+
+    /**
      * This method grows the Network Data to append a TLV with a requested size.
      *
      * On success, the returned TLV is not initialized (i.e., the TLV Length field is not set) but the requested
@@ -608,7 +620,7 @@ protected:
      *          Data with requested @p aTlvSize number of bytes.
      *
      */
-    NetworkDataTlv *AppendTlv(uint8_t aTlvSize);
+    NetworkDataTlv *AppendTlv(uint16_t aTlvSize);
 
     /**
      * This method inserts bytes into the Network Data.

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -171,51 +171,105 @@ public:
     otError RemoveStaleChildEntries(Coap::ResponseHandler aHandler, void *aContext);
 
 private:
+    class ChangedFlags
+    {
+    public:
+        ChangedFlags(void)
+            : mChanged(false)
+            , mStableChanged(false)
+        {
+        }
+
+        void Update(const NetworkDataTlv &aTlv)
+        {
+            mChanged       = true;
+            mStableChanged = (mStableChanged || aTlv.IsStable());
+        }
+
+        bool DidChange(void) const { return mChanged; }
+        bool DidStableChange(void) const { return mStableChanged; }
+
+    private:
+        bool mChanged;       // Any (stable or not) network data change (add/remove).
+        bool mStableChanged; // Stable network data change (add/remove).
+    };
+
+    enum UpdateStatus
+    {
+        kTlvRemoved, // TLV contained no sub TLVs and therefore is removed.
+        kTlvUpdated, // TLV stable flag is updated based on its sub TLVs.
+    };
+
     static void HandleServerData(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
-    otError RegisterNetworkData(uint16_t aRloc16, uint8_t *aTlvs, uint8_t aTlvsLength);
+    otError RegisterNetworkData(uint16_t aRloc16, const uint8_t *aTlvs, uint8_t aTlvsLength);
 
-    otError AddHasRoute(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute);
-    otError AddBorderRouter(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter);
-    otError AddNetworkData(uint8_t *aTlvs, uint8_t aTlvsLength, uint8_t *aOldTlvs, uint8_t aOldTlvsLength);
-    otError AddPrefix(PrefixTlv &aPrefix);
-    otError AddServer(ServiceTlv &aService, ServerTlv &aServer, uint8_t *aOldTlvs, uint8_t aOldTlvsLength);
-    otError AddService(ServiceTlv &aService, uint8_t *aOldTlvs, uint8_t aOldTlvsLength);
+    otError AddPrefix(const PrefixTlv &aPrefix, ChangedFlags &aChangedFlags);
+    otError AddHasRoute(const HasRouteTlv &aHasRoute, PrefixTlv &aDstPrefix, ChangedFlags &aChangedFlags);
+    otError AddBorderRouter(const BorderRouterTlv &aBorderRouter, PrefixTlv &aDstPrefix, ChangedFlags &aFlags);
+    otError AddService(const ServiceTlv &aService, ChangedFlags &aChangedFlags);
+    otError AddServer(const ServerTlv &aServer, ServiceTlv &aDstService, ChangedFlags &aChangedFlags);
 
-    int  AllocateContext(void);
-    void FreeContext(uint8_t aContextId);
-    void StartContextReuseTimer(uint8_t aContextId);
-    void StopContextReuseTimer(uint8_t aContextId);
+    otError AllocateServiceId(uint8_t &aServiceId);
+
+    otError AllocateContextId(uint8_t &aConextId);
+    void    FreeContextId(uint8_t aContextId);
+    void    StartContextReuseTimer(uint8_t aContextId);
+    void    StopContextReuseTimer(uint8_t aContextId);
 
     void RemoveContext(uint8_t aContextId);
     void RemoveContext(PrefixTlv &aPrefix, uint8_t aContextId);
 
     void RemoveCommissioningData(void);
 
-    void RemoveRloc(uint16_t aRloc16, MatchMode aMatchMode);
-    void RemoveRloc(PrefixTlv &aPrefix, uint16_t aRloc16, MatchMode aMatchMode);
-    void RemoveRloc(ServiceTlv &aService, uint16_t aRloc16, MatchMode aMatchMode);
-    void RemoveRloc(PrefixTlv &aPrefix, HasRouteTlv &aHasRoute, uint16_t aRloc16, MatchMode aMatchMode);
-    void RemoveRloc(PrefixTlv &aPrefix, BorderRouterTlv &aBorderRouter, uint16_t aRloc16, MatchMode aMatchMode);
+    void RemoveRloc(uint16_t aRloc16, MatchMode aMatchMode, ChangedFlags &aChangedFlags);
+    void RemoveRloc(uint16_t       aRloc16,
+                    MatchMode      aMatchMode,
+                    const uint8_t *aExcludeTlvs,
+                    uint8_t        aExcludeTlvsLength,
+                    ChangedFlags & aChangedFlags);
+    void RemoveRlocInPrefix(PrefixTlv &      aPrefix,
+                            uint16_t         aRloc16,
+                            MatchMode        aMatchMode,
+                            const PrefixTlv *aExcludePrefix,
+                            ChangedFlags &   aChangedFlags);
+    void RemoveRlocInService(ServiceTlv &      aService,
+                             uint16_t          aRloc16,
+                             MatchMode         aMatchMode,
+                             const ServiceTlv *aExcludeService,
+                             ChangedFlags &    aChangedFlags);
+    void RemoveRlocInHasRoute(PrefixTlv &      aPrefix,
+                              HasRouteTlv &    aHasRoute,
+                              uint16_t         aRloc16,
+                              MatchMode        aMatchMode,
+                              const PrefixTlv *aExcludePrefix,
+                              ChangedFlags &   aChangedFlags);
+    void RemoveRlocInBorderRouter(PrefixTlv &      aPrefix,
+                                  BorderRouterTlv &aBorderRouter,
+                                  uint16_t         aRloc16,
+                                  MatchMode        aMatchMode,
+                                  const PrefixTlv *aExcludePrefix,
+                                  ChangedFlags &   aChangedFlags);
 
     static bool RlocMatch(uint16_t aFirstRloc16, uint16_t aSecondRloc16, MatchMode aMatchMode);
 
-    static otError RlocLookup(uint16_t       aRloc16,
-                              bool &         aIn,
-                              bool &         aStable,
-                              const uint8_t *aTlvs,
-                              uint8_t        aTlvsLength,
-                              MatchMode      aMatchMode,
-                              bool           aAllowOtherEntries = true);
+    static otError Validate(const uint8_t *aTlvs, uint8_t aTlvsLength, uint16_t aRloc16);
+    static otError ValidatePrefix(const PrefixTlv &aPrefix, uint16_t aRloc16);
+    static otError ValidateService(const ServiceTlv &aService, uint16_t aRloc16);
 
-    static bool IsStableUpdated(const uint8_t *aTlvs,
-                                uint8_t        aTlvsLength,
-                                const uint8_t *aTlvsBase,
-                                uint8_t        aTlvsBaseLength);
+    static bool ContainsMatchingEntry(const PrefixTlv *aPrefix, bool aStable, const HasRouteEntry &aEntry);
+    static bool ContainsMatchingEntry(const HasRouteTlv *aHasRoute, const HasRouteEntry &aEntry);
+    static bool ContainsMatchingEntry(const PrefixTlv *aPrefix, bool aStable, const BorderRouterEntry &aEntry);
+    static bool ContainsMatchingEntry(const BorderRouterTlv *aBorderRouter, const BorderRouterEntry &aEntry);
+    static bool ContainsMatchingServer(const ServiceTlv *aService, const ServerTlv &aServer);
+
+    UpdateStatus UpdatePrefix(PrefixTlv &aPrefix);
+    UpdateStatus UpdateService(ServiceTlv &aService);
+    UpdateStatus UpdateTlv(NetworkDataTlv &aTlv, const NetworkDataTlv *aSubTlvs);
 
     static void HandleCommissioningSet(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleCommissioningSet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
@@ -230,6 +284,7 @@ private:
                                       const Ip6::MessageInfo & aMessageInfo,
                                       MeshCoP::StateTlv::State aState);
     void IncrementVersions(bool aIncludeStable);
+    void IncrementVersions(const ChangedFlags &aFlags);
 
     /**
      * Thread Specification Constants.

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -124,6 +124,22 @@ public:
     void SetLength(uint8_t aLength) { mLength = aLength; }
 
     /**
+     * This methods increases the Length value by a given amount.
+     *
+     * @param[in]  aIncrement  The increment amount to increase the length.
+     *
+     */
+    void IncreaseLength(uint8_t aIncrement) { mLength += aIncrement; }
+
+    /**
+     * This methods decreases the Length value by a given amount.
+     *
+     * @param[in]  aDecrement  The decrement amount to decrease the length.
+     *
+     */
+    void DecreaseLength(uint8_t aDecrement) { mLength -= aDecrement; }
+
+    /**
      * This method returns the TLV's total size (number of bytes) including Type, Length, and Value fields.
      *
      * @returns The total size include Type, Length, and Value fields.
@@ -271,6 +287,20 @@ public:
      *
      */
     const HasRouteEntry *GetNext(void) const { return (this + 1); }
+
+    /**
+     * This method indicates whether two entries fully match.
+     *
+     * @param[in]  aOtherEntry  Another entry to compare with it.
+     *
+     * @retval TRUE  The two entries are equal.
+     * @retval FALSE The two entries are not equal.
+     *
+     */
+    bool operator==(const HasRouteEntry &aOtherEntry) const
+    {
+        return (memcmp(this, &aOtherEntry, sizeof(HasRouteEntry)) == 0);
+    }
 
 private:
     enum
@@ -506,6 +536,19 @@ public:
         SetLength(sizeof(*this) - sizeof(NetworkDataTlv) + BitVectorBytes(mPrefixLength) + aLength);
     }
 
+    /**
+     * This static method calculates the total size (number of bytes) of a Prefix TLV with a given Prefix Length value.
+     *
+     * Note that the returned size does include the Type and Length fields in the TLV, but does not account for any
+     * sub TLVs of the Prefix TLV.
+     *
+     * @param[in]  aPrefixLength     A Prefix Length in bits.
+
+     * @returns    The size (number of bytes) of the Prefix TLV.
+     *
+     */
+    static uint16_t CalculateSize(uint8_t aPrefixLength) { return sizeof(PrefixTlv) + BitVectorBytes(aPrefixLength); }
+
 private:
     uint8_t mDomainId;
     uint8_t mPrefixLength;
@@ -687,6 +730,20 @@ public:
      */
     const BorderRouterEntry *GetNext(void) const { return (this + 1); }
 
+    /**
+     * This method indicates whether two entries fully match.
+     *
+     * @param[in]  aOtherEntry  Another entry to compare with it.
+     *
+     * @retval TRUE  The two entries are equal.
+     * @retval FALSE The two entries are not equal.
+     *
+     */
+    bool operator==(const BorderRouterEntry &aOtherEntry) const
+    {
+        return (memcmp(this, &aOtherEntry, sizeof(BorderRouterEntry)) == 0);
+    }
+
 private:
     uint16_t mRloc;
     uint16_t mFlags;
@@ -811,16 +868,19 @@ public:
     };
 
     /**
-     * This method initializes the TLV.
+     * This method initializes the Context TLV.
+     *
+     * @param[in]  aConextId   The Context ID value.
+     * @param[in]  aLength     The Context Length value.
      *
      */
-    void Init(void)
+    void Init(uint8_t aContextId, uint8_t aConextLength)
     {
         NetworkDataTlv::Init();
         SetType(kTypeContext);
-        SetLength(2);
-        mFlags         = 0;
-        mContextLength = 0;
+        SetLength(sizeof(ContextTlv) - sizeof(NetworkDataTlv));
+        mFlags         = ((aContextId << kContextIdOffset) & kContextIdMask);
+        mContextLength = aConextLength;
     }
 
     /**
@@ -853,31 +913,12 @@ public:
     uint8_t GetContextId(void) const { return mFlags & kContextIdMask; }
 
     /**
-     * This method sets the Context ID value.
-     *
-     * @param[in]  aContextId  The Context ID value.
-     *
-     */
-    void SetContextId(uint8_t aContextId)
-    {
-        mFlags = (mFlags & ~kContextIdMask) | ((aContextId << kContextIdOffset) & kContextIdMask);
-    }
-
-    /**
      * This method returns the Context Length value.
      *
      * @returns The Context Length value.
      *
      */
     uint8_t GetContextLength(void) const { return mContextLength; }
-
-    /**
-     * This method sets the Context Length value.
-     *
-     * @param[in]  aLength  The Context Length value.
-     *
-     */
-    void SetContextLength(uint8_t aLength) { mContextLength = aLength; }
 
 private:
     enum
@@ -1080,7 +1121,7 @@ public:
      * @returns    The size (number of bytes) of the Service TLV.
      *
      */
-    static uint16_t GetSize(uint32_t aEnterpriseNumber, uint8_t aServiceDataLength)
+    static uint16_t CalculateSize(uint32_t aEnterpriseNumber, uint8_t aServiceDataLength)
     {
         return sizeof(NetworkDataTlv) + kMinLength + aServiceDataLength +
                ((aEnterpriseNumber == kThreadEnterpriseNumber) ? 0 : sizeof(uint32_t) /* mEnterpriseNumber  */);
@@ -1133,14 +1174,20 @@ public:
     };
 
     /**
-     * This method initializes the TLV.
+     * This method initializes the Server TLV.
+     *
+     * @param[in] aServer16          The Server16 value.
+     * @param[in] aServerData        The Server Data.
+     * @param[in] aServerDataLength  Server Data length in bytes.
      *
      */
-    void Init(void)
+    void Init(uint16_t aServer16, const uint8_t *aServerData, uint8_t aServerDataLength)
     {
         NetworkDataTlv::Init();
         SetType(kTypeServer);
-        SetLength(sizeof(*this) - sizeof(NetworkDataTlv));
+        SetServer16(aServer16);
+        memcpy(reinterpret_cast<uint8_t *>(this) + sizeof(*this), aServerData, aServerDataLength);
+        SetLength(sizeof(*this) - sizeof(NetworkDataTlv) + aServerDataLength);
     }
 
     /**
@@ -1153,42 +1200,28 @@ public:
     bool IsValid(void) const { return GetLength() >= (sizeof(*this) - sizeof(NetworkDataTlv)); }
 
     /**
-     * This method returns the S_server_16 value.
+     * This method returns the Server16 value.
      *
-     * @returns The S_server_16 value.
+     * @returns The Server16 value.
      *
      */
     uint16_t GetServer16(void) const { return HostSwap16(mServer16); }
 
-    /**
-     * This method sets the S_server_16 value.
+    /*
+     * This method sets the Server16 value.
      *
-     * @param[in]  aServer16  The S_server_16 value.
+     * @param[in]  aServer16  The Server16 value.
      *
      */
     void SetServer16(uint16_t aServer16) { mServer16 = HostSwap16(aServer16); }
 
     /**
-     * This method returns a pointer to the Server Data.
+     * This method returns the Server Data.
      *
      * @returns A pointer to the Server Data.
      *
      */
     const uint8_t *GetServerData(void) const { return reinterpret_cast<const uint8_t *>(this) + sizeof(*this); }
-
-    /**
-     * This method sets Server Data to the given values.
-     *
-     * Caller must ensure that there is enough memory allocated.
-     *
-     * @param aServerData       pointer to the server data to use
-     * @param aServerDataLength length of the provided server data in bytes
-     */
-    void SetServerData(const uint8_t *aServerData, uint8_t aServerDataLength)
-    {
-        SetLength(sizeof(*this) - sizeof(NetworkDataTlv) + aServerDataLength);
-        memcpy(reinterpret_cast<uint8_t *>(this) + sizeof(*this), aServerData, aServerDataLength);
-    }
 
     /**
      * This method returns the Server Data length in bytes.
@@ -1197,6 +1230,32 @@ public:
      *
      */
     uint8_t GetServerDataLength(void) const { return GetLength() - (sizeof(*this) - sizeof(NetworkDataTlv)); }
+
+    /**
+     * This method indicates whether two Server TLVs fully match.
+     *
+     * @param[in]  aOther  Another Server TLV to compare with it.
+     *
+     * @retval TRUE  The two TLVs are equal.
+     * @retval FALSE The two TLVs are not equal.
+     *
+     */
+    bool operator==(const ServerTlv &aOther) const
+    {
+        return (GetLength() == aOther.GetLength()) && (memcmp(GetValue(), aOther.GetValue(), GetLength()) == 0);
+    }
+
+    /**
+     * This static method calculates the total size (number of bytes) of a Service TLV with a given Server Data length.
+     *
+     * Note that the returned size does include the Type and Length fields in the TLV.
+     *
+     * @param[in]  aServerDataLength    Server Data length in bytes.
+     *
+     * @returns    The size (number of bytes) of the Server TLV.
+     *
+     */
+    static uint16_t CalculateSize(uint8_t aServerDataLength) { return sizeof(ServerTlv) + aServerDataLength; }
 
 private:
     uint16_t mServer16;

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -139,6 +139,7 @@ run test-036-wpantund-host-route-management.py
 run test-037-wpantund-auto-add-route-for-on-mesh-prefix.py
 run test-038-clear-address-cache-for-sed.py
 run test-039-address-cache-table-snoop.py
+run test-040-network-data-stable-full.py
 run test-100-mcu-power-state.py
 run test-600-channel-manager-properties.py
 run test-601-channel-manager-channel-change.py

--- a/tests/toranj/test-040-network-data-stable-full.py
+++ b/tests/toranj/test-040-network-data-stable-full.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+import wpan
+from wpan import verify
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test description: Network Data update and version changes (stable only vs. full version).
+#
+# Network topology
+#
+#      leader
+#      /  |  \
+#     /   |   \
+#    /    |    \
+#   c1    c2    c3
+#
+#
+# c3 is sleepy-end node and also configured to request stable Network Data only
+#
+# Test covers the following steps:
+# - Adding/removing prefixes (stable or temporary) on c1
+# - Verifying that Network Data is updated on all nodes
+# - Ensuring correct update to version and stable version
+
+# The above steps are repeated over many different situations:
+# - Where the same prefixes are also added by other nodes
+# - Or the same prefixes are added as off-mesh routes by other nodes
+#
+
+test_name = __file__[:-3] if __file__.endswith('.py') else __file__
+print('-' * 120)
+print('Starting \'{}\''.format(test_name))
+
+
+def verify_prefix(
+    node_list,
+    prefix,
+    rloc16,
+    prefix_len=64,
+    stable=True,
+    priority='med',
+    on_mesh=False,
+    slaac=False,
+    dhcp=False,
+    configure=False,
+    default_route=False,
+    preferred=False,
+):
+    """
+    This function verifies that the `prefix` is present on all the nodes in the `node_list`. It also verifies that the
+    `prefix` is associated with the given `rloc16` (as an integer).
+    """
+    for node in node_list:
+        prefixes = wpan.parse_on_mesh_prefix_result(
+            node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))
+        for p in prefixes:
+            if (p.prefix == prefix and p.origin == "ncp" and
+                    int(p.rloc16(), 0) == rloc16):
+                verify(int(p.prefix_len) == prefix_len)
+                verify(p.is_stable() == stable)
+                verify(p.is_on_mesh() == on_mesh)
+                verify(p.is_def_route() == default_route)
+                verify(p.is_slaac() == slaac)
+                verify(p.is_dhcp() == dhcp)
+                verify(p.is_config() == configure)
+                verify(p.is_preferred() == preferred)
+                verify(p.priority == priority)
+                break
+        else:
+            raise wpan.VerifyError("Did not find prefix {} on node {}".format(
+                prefix, node))
+
+
+def verify_no_prefix(node_list, prefix, rloc16):
+    """
+    This function verifies that none of the nodes in `node_list` contains the on-mesh `prefix` associated with the
+    given `rloc16`.
+    """
+    for node in node_list:
+        prefixes = wpan.parse_on_mesh_prefix_result(
+            node.get(wpan.WPAN_THREAD_ON_MESH_PREFIXES))
+        for p in prefixes:
+            if (p.prefix == prefix and p.origin == "ncp" and
+                    int(p.rloc16(), 0) == rloc16):
+                raise wpan.VerifyError(
+                    "Did find prefix {} with rloc {} on node {}".format(
+                        prefix, hex(rloc16), node))
+
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Creating `wpan.Nodes` instances
+
+speedup = 25
+wpan.Node.set_time_speedup_factor(speedup)
+
+leader = wpan.Node()
+c1 = wpan.Node()
+c2 = wpan.Node()
+c3 = wpan.Node()
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Init all nodes
+
+wpan.Node.init_all_nodes()
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Build network topology
+#
+
+leader.form("bloodborne")  # "fear the old blood"
+
+c1.join_node(leader, wpan.JOIN_TYPE_END_DEVICE)
+c2.join_node(leader, wpan.JOIN_TYPE_END_DEVICE)
+c3.join_node(leader, wpan.JOIN_TYPE_SLEEPY_END_DEVICE)
+c3.set(wpan.WPAN_POLL_INTERVAL, '400')
+
+# Clear the "full network data" flag on c3.
+c3.set(wpan.WPAN_THREAD_DEVICE_MODE,
+       str(wpan.THREAD_MODE_FLAG_SECURE_DATA_REQUEST))
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test implementation
+
+WAIT_TIME = 15
+
+prefix1 = "fd00:1::"
+prefix2 = "fd00:2::"
+prefix3 = "fd00:3::"
+
+leader_rloc = int(leader.get(wpan.WPAN_THREAD_RLOC16), 0)
+c1_rloc = int(c1.get(wpan.WPAN_THREAD_RLOC16), 0)
+c2_rloc = int(c2.get(wpan.WPAN_THREAD_RLOC16), 0)
+no_rloc = 0xfffe
+
+
+def test_prefix_add_remove():
+    # Tests adding and removing stable and temporary prefixes on r1
+    # Verifies that all nodes in network do see the updates and that
+    # Network Data version and stable version are updated correctly.
+
+    old_version = int(leader.get(wpan.WPAN_THREAD_NETWORK_DATA_VERSION), 0)
+    old_stable_version = int(
+        leader.get(wpan.WPAN_THREAD_STABLE_NETWORK_DATA_VERSION), 0)
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    # Add a stable prefix and check all nodes see the prefix
+    c1.add_prefix(prefix1, stable=True)
+
+    def check_prefix1():
+        verify_prefix(
+            [leader, c1, c2],
+            prefix1,
+            c1_rloc,
+            stable=True,
+        )
+
+        verify_prefix(
+            [c3],
+            prefix1,
+            no_rloc,
+            stable=True,
+        )
+
+    wpan.verify_within(check_prefix1, WAIT_TIME)
+
+    new_version = int(leader.get(wpan.WPAN_THREAD_NETWORK_DATA_VERSION), 0)
+    new_stable_version = int(
+        leader.get(wpan.WPAN_THREAD_STABLE_NETWORK_DATA_VERSION), 0)
+
+    verify(new_version == ((old_version + 1) % 256))
+    verify(new_stable_version == ((old_stable_version + 1) % 256))
+
+    old_version = new_version
+    old_stable_version = new_stable_version
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    # Add prefix 2 as temp (not stable)
+
+    c1.add_prefix(prefix2, stable=False)
+
+    def check_prefix2():
+        verify_prefix(
+            [leader, c1, c2],
+            prefix2,
+            c1_rloc,
+            stable=False,
+        )
+
+    wpan.verify_within(check_prefix1, WAIT_TIME)
+    wpan.verify_within(check_prefix2, WAIT_TIME)
+
+    new_version = int(leader.get(wpan.WPAN_THREAD_NETWORK_DATA_VERSION), 0)
+    new_stable_version = int(
+        leader.get(wpan.WPAN_THREAD_STABLE_NETWORK_DATA_VERSION), 0)
+
+    verify(new_version == ((old_version + 1) % 256))
+    verify(new_stable_version == old_stable_version)
+
+    old_version = new_version
+    old_stable_version = new_stable_version
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    # Remove prefix 1
+
+    c1.remove_prefix(prefix1)
+
+    def check_no_prefix1():
+        verify_no_prefix([leader, c1, c2], prefix1, c1_rloc)
+
+    wpan.verify_within(check_no_prefix1, WAIT_TIME)
+    wpan.verify_within(check_prefix2, WAIT_TIME)
+
+    new_version = int(leader.get(wpan.WPAN_THREAD_NETWORK_DATA_VERSION), 0)
+    new_stable_version = int(
+        leader.get(wpan.WPAN_THREAD_STABLE_NETWORK_DATA_VERSION), 0)
+
+    verify(new_version == ((old_version + 1) % 256))
+    verify(new_stable_version == ((old_stable_version + 1) % 256))
+
+    old_version = new_version
+    old_stable_version = new_stable_version
+
+    # - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+    # Remove prefix 2
+
+    c1.remove_prefix(prefix2)
+
+    def check_no_prefix2():
+        verify_no_prefix([leader, c1, c2], prefix2, c1_rloc)
+
+    wpan.verify_within(check_no_prefix1, WAIT_TIME)
+    wpan.verify_within(check_no_prefix2, WAIT_TIME)
+
+    new_version = int(leader.get(wpan.WPAN_THREAD_NETWORK_DATA_VERSION), 0)
+    new_stable_version = int(
+        leader.get(wpan.WPAN_THREAD_STABLE_NETWORK_DATA_VERSION), 0)
+
+    verify(new_version == ((old_version + 1) % 256))
+    verify(new_stable_version == old_stable_version)
+
+
+# - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+# Repeat the `test_prefix_add_remove()` under different situations
+# where same prefix is added/removed by other nodes in the network
+# or added as an off-mesh route.
+
+num_routes = 0
+
+test_prefix_add_remove()
+
+leader.add_prefix(prefix1, stable=False)
+test_prefix_add_remove()
+
+leader.add_prefix(prefix2, stable=True)
+test_prefix_add_remove()
+
+leader.remove_prefix(prefix1)
+test_prefix_add_remove()
+
+leader.remove_prefix(prefix2)
+test_prefix_add_remove()
+
+leader.add_route(prefix1, stable=False)
+num_routes = num_routes + 1
+test_prefix_add_remove()
+verify(
+    len(wpan.parse_list(c2.get(wpan.WPAN_THREAD_OFF_MESH_ROUTES))) ==
+    num_routes)
+
+leader.add_route(prefix2, stable=True)
+num_routes = num_routes + 1
+test_prefix_add_remove()
+verify(
+    len(wpan.parse_list(c2.get(wpan.WPAN_THREAD_OFF_MESH_ROUTES))) ==
+    num_routes)
+
+leader.add_prefix(prefix3, stable=True)
+test_prefix_add_remove()
+verify(
+    len(wpan.parse_list(c2.get(wpan.WPAN_THREAD_OFF_MESH_ROUTES))) ==
+    num_routes)
+
+leader.remove_route(prefix2)
+num_routes = num_routes - 1
+test_prefix_add_remove()
+verify(
+    len(wpan.parse_list(c2.get(wpan.WPAN_THREAD_OFF_MESH_ROUTES))) ==
+    num_routes)
+
+leader.remove_route(prefix1)
+num_routes = num_routes - 1
+test_prefix_add_remove()
+verify(
+    len(wpan.parse_list(c2.get(wpan.WPAN_THREAD_OFF_MESH_ROUTES))) ==
+    num_routes)
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test finished
+
+wpan.Node.finalize_all_nodes()
+
+print('\'{}\' passed.'.format(test_name))

--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -560,7 +560,7 @@ class Node(object):
             'add-route ' + route_prefix +
             (' -l {}'.format(prefix_len) if prefix_len is not None else '') +
             (' -p {}'.format(priority) if priority is not None else '') +
-            ('' if stable else '-n'))
+            ('' if stable else ' -n'))
 
     def remove_route(self,
                      route_prefix,


### PR DESCRIPTION

This commit changes the model for updating Network Data on a leader.

It adds `ChangedFlags` type which is used to track whether full or stable version of Network Data gets changed as TLVs/sub-TLVs are being added or removed. This is then used to update version and stable version accordingly.

When registering new received Network Data on the leader, the new model updates the Network Data in place. First, newly added `Validate()` method is called to verify that the received Network Data contains well-formed TLVs and sub-TLVs (e.g., no duplicate Prefix/Service TLVs) and all sub-TLVs/entries match the sender's RLOC16. Then, all entries in the current Network Data associated with the sender's RLOC16 which are not present in the newly received data are removed. Afterwards, any new entry in the received Network Data is added. This approach helps simplify the code and ensures existing TLVs/sub-TLVs remain as before (e.g., no need to keep a copy of previous data to ensure same Service IDs are used when adding/removing Service TLVs).

This commit also adds `UpdatePrefix()` and `UpdateService()` methods which ensure a Prefix or Service TLV is marked correctly as stable or not depending on its sub-TLVs (e.g., if all stable sub-TLVs are removed the enclosing TLV is marked as not stable).

-----------

**[toranj] add test-case verifying Network Data update**

This commit adds a new test-case to `toranj` which verifies Network Data update and version changes (stable only vs. full version).

The test creates a simple network of a leader with 3 children where one of the children is SED and is configured to request only stable Network Data. The test covers the following:
- Adding/removing prefixes (stable or temporary) on the first child.
- Verifying that Network Data is updated on all nodes accordingly.
- Ensuring correct update to Network Data version and stable version.

The above steps are then repeated over many different situations:
- Where the same prefixes are also added by other nodes.
- Or the same prefixes are added as off-mesh routes by other nodes.
