### PR TITLE
[otns] allow virtual time UART

### DIFF
--- a/examples/platforms/simulation/platform-config.h
+++ b/examples/platforms/simulation/platform-config.h
@@ -92,8 +92,4 @@
 #error "OTNS requires virtual time simulations"
 #endif
 
-#if OPENTHREAD_SIMULATION_VIRTUAL_TIME_UART
-#error "OTNS does not support virtual time UART"
-#endif
-
 #endif // OPENTHREAD_CONFIG_OTNS_ENABLE


### PR DESCRIPTION
This PR allows use to build `OTNS=1` with or without `VIRTUAL_TIME_UART`.

Later I will enhance OTNS to support both virtual time UART and non virtual time UART. 