### PR TITLE
[mac-frame] enhance utility functions

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -806,7 +806,7 @@ exit:
     return index;
 }
 
-uint8_t Frame::SkipAddrFieldIndex() const
+uint8_t Frame::SkipAddrFieldIndex(void) const
 {
     uint8_t  index = kFcfSize + kDsnSize; // Frame Control field and Sequence Number field
     uint16_t fcf;

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -378,9 +378,9 @@ public:
     uint16_t GetVersion(void) const { return GetFrameControlField() & kFcfFrameVersionMask; }
 
     /**
-     * This method returns if the current IEEE 802.15.4 frame object's version is 2015.
+     * This method returns if this IEEE 802.15.4 frame's version is 2015.
      *
-     * @returns TRUE if version is 2015 and false otherwise.
+     * @returns TRUE if version is 2015, FALSE otherwise.
      *
      */
     bool IsVersion2015(void) const { return IsVersion2015(GetFrameControlField()); }
@@ -454,12 +454,12 @@ public:
     void SetSequence(uint8_t aSequence) { GetPsdu()[kSequenceIndex] = aSequence; }
 
     /**
-     * This method indicates whether or not the Dst PanId is present in this frame object.
+     * This method indicates whether or not the Destination PAN ID is present.
      *
-     * @returns TRUE if the Dst PanId is present, FALSE otherwise.
+     * @returns TRUE if the Destination PAN ID is present, FALSE otherwise.
      *
      */
-    bool IsDstPanIdPresent() const { return IsDstPanIdPresent(GetFrameControlField()); }
+    bool IsDstPanIdPresent(void) const { return IsDstPanIdPresent(GetFrameControlField()); }
 
     /**
      * This method gets the Destination PAN Identifier.
@@ -486,7 +486,7 @@ public:
      * @retval TRUE if the Destination Address is present, FALSE otherwise.
      *
      */
-    bool IsDstAddrPresent() { return IsDstAddrPresent(GetFrameControlField()); }
+    bool IsDstAddrPresent() const { return IsDstAddrPresent(GetFrameControlField()); }
 
     /**
      * This method gets the Destination Address.
@@ -556,7 +556,7 @@ public:
      * @retval TRUE if the Source Address is present, FALSE otherwise.
      *
      */
-    bool IsSrcAddrPresent() { return IsSrcAddrPresent(GetFrameControlField()); }
+    bool IsSrcAddrPresent(void) const { return IsSrcAddrPresent(GetFrameControlField()); }
 
     /**
      * This method gets the Source Address.
@@ -953,7 +953,7 @@ private:
     uint8_t  FindDstAddrIndex(void) const;
     uint8_t  FindSrcPanIdIndex(void) const;
     uint8_t  FindSrcAddrIndex(void) const;
-    uint8_t  SkipAddrFieldIndex() const;
+    uint8_t  SkipAddrFieldIndex(void) const;
     uint8_t  FindSecurityHeaderIndex(void) const;
     uint8_t  SkipSecurityHeaderIndex(void) const;
     uint8_t  FindPayloadIndex(void) const;

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -378,6 +378,14 @@ public:
     uint16_t GetVersion(void) const { return GetFrameControlField() & kFcfFrameVersionMask; }
 
     /**
+     * This method returns if the IEEE 802.15.4 frame's version is 2015.
+     *
+     * @returns true if version is 2015 and false otherwise.
+     *
+     */
+    bool IsVersion2015(void) const { return (GetFrameControlField() & kFcfFrameVersionMask) == kFcfFrameVersion2015; }
+
+    /**
      * This method indicates whether or not security is enabled.
      *
      * @retval TRUE   If security is enabled.
@@ -446,6 +454,23 @@ public:
     void SetSequence(uint8_t aSequence) { GetPsdu()[kSequenceIndex] = aSequence; }
 
     /**
+     * This method indicates whether or not the Dst PanId is present.
+     *
+     * @param[in]  aFcf          The Frame Control field.
+     * @returns TRUE if the Dst PanId is present, FALSE otherwise.
+     *
+     */
+    bool IsDstPanIdPresent(uint16_t aFcf) const;
+
+    /**
+     * This method indicates whether or not the Dst PanId is present in this frame object.
+     *
+     * @returns TRUE if the Dst PanId is present, FALSE otherwise.
+     *
+     */
+    bool IsDstPanIdPresent() const { return IsDstPanIdPresent(GetFrameControlField()); }
+
+    /**
      * This method gets the Destination PAN Identifier.
      *
      * @param[out]  aPanId  The Destination PAN Identifier.
@@ -463,6 +488,24 @@ public:
      *
      */
     void SetDstPanId(PanId aPanId);
+
+    /**
+     * This method indicates whether or not the Destination Address is present.
+     *
+     * @paran[in]  aFcf  The frame control field
+     *
+     * @retval TRUE if the Destination Address is present, FALSE otherwise.
+     *
+     */
+    static bool IsDstAddrPresent(uint16_t aFcf) { return (aFcf & kFcfDstAddrMask) != kFcfDstAddrNone; }
+
+    /**
+     * This method indicates whether or not the Destination Address is present for this object.
+     *
+     * @retval TRUE if the Destination Address is present, FALSE otherwise.
+     *
+     */
+    bool IsDstAddrPresent() { return IsDstAddrPresent(GetFrameControlField()); }
 
     /**
      * This method gets the Destination Address.
@@ -527,6 +570,24 @@ public:
     otError SetSrcPanId(PanId aPanId);
 
     /**
+     * This method indicates whether or not the Source Address is present.
+     *
+     * @paran[in]  aFcf  The frame control field
+     *
+     * @retval TRUE if the Source Address is present, FALSE otherwise.
+     *
+     */
+    static bool IsSrcAddrPresent(uint16_t aFcf) { return (aFcf & kFcfSrcAddrMask) != kFcfSrcAddrNone; }
+
+    /**
+     * This method indicates whether or not the Source Address is present for this object.
+     *
+     * @retval TRUE if the Source Address is present, FALSE otherwise.
+     *
+     */
+    bool IsSrcAddrPresent() { return IsSrcAddrPresent(GetFrameControlField()); }
+
+    /**
      * This method gets the Source Address.
      *
      * @param[out]  aAddress  The Source Address.
@@ -559,6 +620,24 @@ public:
      *
      */
     void SetSrcAddr(const Address &aAddress);
+
+    /**
+     * This method gets the Security Control Field.
+     *
+     * @param[out]  aSecurityControlField  The Security Control Field.
+     *
+     * @retval OT_ERROR_NONE  Successfully retrieved the Security Level Identifier.
+     *
+     */
+    otError GetSecurityControlField(uint8_t &aSecurityControlField) const;
+
+    /**
+     * This method sets the Security Control Field.
+     *
+     * @param[in]  aSecurityControlField  The Security Control Field.
+     *
+     */
+    void SetSecurityControlField(uint8_t aSecurityControlField);
 
     /**
      * This method gets the Security Level Identifier.
@@ -902,6 +981,7 @@ private:
     uint8_t  FindDstAddrIndex(void) const;
     uint8_t  FindSrcPanIdIndex(void) const;
     uint8_t  FindSrcAddrIndex(void) const;
+    uint8_t  SkipAddrField(const uint16_t &fcf) const;
     uint8_t  FindSecurityHeaderIndex(void) const;
     uint8_t  SkipSecurityHeaderIndex(void) const;
     uint8_t  FindPayloadIndex(void) const;

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -378,12 +378,12 @@ public:
     uint16_t GetVersion(void) const { return GetFrameControlField() & kFcfFrameVersionMask; }
 
     /**
-     * This method returns if the IEEE 802.15.4 frame's version is 2015.
+     * This method returns if the current IEEE 802.15.4 frame object's version is 2015.
      *
-     * @returns true if version is 2015 and false otherwise.
+     * @returns TRUE if version is 2015 and false otherwise.
      *
      */
-    bool IsVersion2015(void) const { return (GetFrameControlField() & kFcfFrameVersionMask) == kFcfFrameVersion2015; }
+    bool IsVersion2015(void) const { return IsVersion2015(GetFrameControlField()); }
 
     /**
      * This method indicates whether or not security is enabled.
@@ -454,15 +454,6 @@ public:
     void SetSequence(uint8_t aSequence) { GetPsdu()[kSequenceIndex] = aSequence; }
 
     /**
-     * This method indicates whether or not the Dst PanId is present.
-     *
-     * @param[in]  aFcf          The Frame Control field.
-     * @returns TRUE if the Dst PanId is present, FALSE otherwise.
-     *
-     */
-    bool IsDstPanIdPresent(uint16_t aFcf) const;
-
-    /**
      * This method indicates whether or not the Dst PanId is present in this frame object.
      *
      * @returns TRUE if the Dst PanId is present, FALSE otherwise.
@@ -488,16 +479,6 @@ public:
      *
      */
     void SetDstPanId(PanId aPanId);
-
-    /**
-     * This method indicates whether or not the Destination Address is present.
-     *
-     * @paran[in]  aFcf  The frame control field
-     *
-     * @retval TRUE if the Destination Address is present, FALSE otherwise.
-     *
-     */
-    static bool IsDstAddrPresent(uint16_t aFcf) { return (aFcf & kFcfDstAddrMask) != kFcfDstAddrNone; }
 
     /**
      * This method indicates whether or not the Destination Address is present for this object.
@@ -570,16 +551,6 @@ public:
     otError SetSrcPanId(PanId aPanId);
 
     /**
-     * This method indicates whether or not the Source Address is present.
-     *
-     * @paran[in]  aFcf  The frame control field
-     *
-     * @retval TRUE if the Source Address is present, FALSE otherwise.
-     *
-     */
-    static bool IsSrcAddrPresent(uint16_t aFcf) { return (aFcf & kFcfSrcAddrMask) != kFcfSrcAddrNone; }
-
-    /**
      * This method indicates whether or not the Source Address is present for this object.
      *
      * @retval TRUE if the Source Address is present, FALSE otherwise.
@@ -626,7 +597,8 @@ public:
      *
      * @param[out]  aSecurityControlField  The Security Control Field.
      *
-     * @retval OT_ERROR_NONE  Successfully retrieved the Security Level Identifier.
+     * @retval OT_ERROR_NONE   Successfully retrieved the Security Level Identifier.
+     * @retval OT_ERROR_PARSE  Fail to find the security control field ins the frame.
      *
      */
     otError GetSecurityControlField(uint8_t &aSecurityControlField) const;
@@ -981,7 +953,7 @@ private:
     uint8_t  FindDstAddrIndex(void) const;
     uint8_t  FindSrcPanIdIndex(void) const;
     uint8_t  FindSrcAddrIndex(void) const;
-    uint8_t  SkipAddrField(const uint16_t &fcf) const;
+    uint8_t  SkipAddrFieldIndex() const;
     uint8_t  FindSecurityHeaderIndex(void) const;
     uint8_t  SkipSecurityHeaderIndex(void) const;
     uint8_t  FindPayloadIndex(void) const;
@@ -990,6 +962,11 @@ private:
 #endif
 
     static uint8_t GetKeySourceLength(uint8_t aKeyIdMode);
+
+    static bool IsDstAddrPresent(uint16_t aFcf) { return (aFcf & kFcfDstAddrMask) != kFcfDstAddrNone; }
+    static bool IsDstPanIdPresent(uint16_t aFcf);
+    static bool IsSrcAddrPresent(uint16_t aFcf) { return (aFcf & kFcfSrcAddrMask) != kFcfSrcAddrNone; }
+    static bool IsVersion2015(uint16_t aFcf) { return (aFcf & kFcfFrameVersionMask) == kFcfFrameVersion2015; }
 };
 
 /**

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -598,7 +598,7 @@ public:
      * @param[out]  aSecurityControlField  The Security Control Field.
      *
      * @retval OT_ERROR_NONE   Successfully retrieved the Security Level Identifier.
-     * @retval OT_ERROR_PARSE  Fail to find the security control field ins the frame.
+     * @retval OT_ERROR_PARSE  Failed to find the security control field in the frame.
      *
      */
     otError GetSecurityControlField(uint8_t &aSecurityControlField) const;

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -407,14 +407,18 @@ void TestMacChannelMask(void)
 
 void TestMacFrameApi(void)
 {
-    uint8_t    ack_psdu1[] = {0x02, 0x10, 0x5e, 0xd2, 0x9b};
-    uint8_t    ack_psdu2[] = {0x29, 0xee, 0x53, 0xce, 0xfa, 0x01, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x6e, 0x16, 0x05,
-                           0x00, 0x00, 0x00, 0x00, 0x0a, 0x6e, 0x16, 0x0d, 0x01, 0x00, 0x00, 0x00, 0x01};
-    otError    error;
-    Mac::Frame frame;
-    uint8_t    scf; // SecurityControlField
+    uint8_t ack_psdu1[] = {0x02, 0x10, 0x5e, 0xd2, 0x9b};
 
-    // IEEE 802.15.4 Ack, Sequence Number: 94
+    Mac::Frame frame;
+
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+    uint8_t data_psdu1[] = {0x29, 0xee, 0x53, 0xce, 0xfa, 0x01, 0x00, 0x00, 0x00, 0x00, 0x0a, 0x6e, 0x16, 0x05,
+                            0x00, 0x00, 0x00, 0x00, 0x0a, 0x6e, 0x16, 0x0d, 0x01, 0x00, 0x00, 0x00, 0x01};
+    otError error;
+    uint8_t scf; // SecurityControlField
+#endif
+
+    // Imm-Ack, Sequence Number: 94
     //   Frame Control Field: 0x1002
     //     .... .... .... .010 = Frame Type: Ack (0x2)
     //     .... .... .... 0... = Security Enabled: False
@@ -428,7 +432,8 @@ void TestMacFrameApi(void)
     //     00.. .... .... .... = Source Addressing Mode: None (0x0)
     //   Sequence Number: 94
     //   FCS: 0x9bd2 (Correct)
-    frame.mPsdu = ack_psdu1;
+    frame.mPsdu   = ack_psdu1;
+    frame.mLength = sizeof(ack_psdu1);
     VerifyOrQuit(frame.GetType() == Mac::Frame::kFcfFrameAck, "Mac::Frame::GetType() failed\n");
     VerifyOrQuit(frame.GetSecurityEnabled() == false, "Mac::Frame::GetSecurityEnabled() failed\n");
     VerifyOrQuit(frame.GetFramePending() == false, "Mac::Frame::GetFramePendIng() failed\n");
@@ -440,14 +445,17 @@ void TestMacFrameApi(void)
     VerifyOrQuit(frame.IsSrcAddrPresent() == false, "Mac::Frame::IsSrcAddrPresent failed\n");
     VerifyOrQuit(frame.GetSequence() == 94, "Mac::Frame::GetSequence failed\n");
 
-    // IEEE 802.15.4 Data
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+    // IEEE 802.15.4-2015 Data
     //   Sequence Number: 83
     //   Destination PAN: 0xface
     //   Destination: 16:6e:0a:00:00:00:00:01
     //   Extended Source: 16:6e:0a:00:00:00:00:05
     //   Auxiliary Security Header
     //     Security Control Field: 0x0d
-    frame.mPsdu = ack_psdu2;
+    frame.mPsdu   = data_psdu1;
+    frame.mLength = sizeof(data_psdu1);
+    VerifyOrQuit(frame.IsVersion2015() == true, "Mac::Frame::IsVersion2015 failed\n");
     VerifyOrQuit(frame.IsDstPanIdPresent() == true, "Mac::Frame::IsDstPanIdPresent failed\n");
     VerifyOrQuit(frame.IsDstAddrPresent() == true, "Mac::Frame::IsDstAddrPresent failed\n");
     VerifyOrQuit(frame.IsSrcAddrPresent() == true, "Mac::Frame::IsSrcAddrPresent failed\n");
@@ -456,8 +464,9 @@ void TestMacFrameApi(void)
     VerifyOrQuit(scf == 0x0d, "Mac::Frame::GetSecurityControlField value failed\n");
     frame.SetSecurityControlField(0xff);
     VerifyOrQuit((error = frame.GetSecurityControlField(scf)) == OT_ERROR_NONE,
-                 "Mac::Frame::SetSecurityControlField failed\n");
+                 "Mac::Frame::GetSecurityControlField failed\n");
     VerifyOrQuit(scf == 0xff, "Mac::Frame::SetSecurityControlField value failed\n");
+#endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 }
 
 } // namespace ot


### PR DESCRIPTION
This PR enhances some utility functions in mac frame for frame parsing and adds some basic testing. 
* Currently the mac frame parsing only doesn't include the rule for version 2015. This PR adds the parsing of dstPanId for 2015 frames.
* This PR adds some helper function dealing with Security Header so that later PR of CSL and setting security header in enhanced ACK would be easier.