### PR TITLE
[ip6-address] methods to set address to common multicast addresses

### DIFF
--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -277,8 +277,7 @@ otError Dhcp6Client::Solicit(uint16_t aRloc16)
     SuccessOrExit(error = AppendRapidCommit(*message));
 
 #if OPENTHREAD_ENABLE_DHCP6_MULTICAST_SOLICIT
-    messageInfo.GetPeerAddr().mFields.m16[0] = HostSwap16(0xff03);
-    messageInfo.GetPeerAddr().mFields.m16[7] = HostSwap16(0x0002);
+    messageInfo.GetPeerAddr().SetToRealmLocalAllRoutersMulticast();
 #else
     messageInfo.GetPeerAddr().SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
     messageInfo.GetPeerAddr().mFields.m16[4] = HostSwap16(0x0000);

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -230,9 +230,7 @@ otError Ip6::AddTunneledMplOption(Message &aMessage, Header &aHeader, MessageInf
     MessageInfo                messageInfo(aMessageInfo);
 
     // Use IP-in-IP encapsulation (RFC2473) and ALL_MPL_FORWARDERS address.
-    messageInfo.GetPeerAddr().Clear();
-    messageInfo.GetPeerAddr().mFields.m16[0] = HostSwap16(0xff03);
-    messageInfo.GetPeerAddr().mFields.m16[7] = HostSwap16(0x00fc);
+    messageInfo.GetPeerAddr().SetToRealmLocalAllMplForwarders();
 
     tunnelHeader.Init();
     tunnelHeader.SetHopLimit(static_cast<uint8_t>(kDefaultHopLimit));

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -38,6 +38,7 @@
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
+#include "net/netif.hpp"
 
 using ot::Encoding::BigEndian::HostSwap32;
 
@@ -71,14 +72,22 @@ bool Address::IsLinkLocalMulticast(void) const
 
 bool Address::IsLinkLocalAllNodesMulticast(void) const
 {
-    return (mFields.m32[0] == HostSwap32(0xff020000) && mFields.m32[1] == 0 && mFields.m32[2] == 0 &&
-            mFields.m32[3] == HostSwap32(0x01));
+    return (*this == GetLinkLocalAllNodesMulticast());
+}
+
+void Address::SetToLinkLocalAllNodesMulticast(void)
+{
+    *this = GetLinkLocalAllNodesMulticast();
 }
 
 bool Address::IsLinkLocalAllRoutersMulticast(void) const
 {
-    return (mFields.m32[0] == HostSwap32(0xff020000) && mFields.m32[1] == 0 && mFields.m32[2] == 0 &&
-            mFields.m32[3] == HostSwap32(0x02));
+    return (*this == GetLinkLocalAllRoutersMulticast());
+}
+
+void Address::SetToLinkLocalAllRoutersMulticast(void)
+{
+    *this = GetLinkLocalAllRoutersMulticast();
 }
 
 bool Address::IsRealmLocalMulticast(void) const
@@ -93,20 +102,32 @@ bool Address::IsMulticastLargerThanRealmLocal(void) const
 
 bool Address::IsRealmLocalAllNodesMulticast(void) const
 {
-    return (mFields.m32[0] == HostSwap32(0xff030000) && mFields.m32[1] == 0 && mFields.m32[2] == 0 &&
-            mFields.m32[3] == HostSwap32(0x01));
+    return (*this == GetRealmLocalAllNodesMulticast());
+}
+
+void Address::SetToRealmLocalAllNodesMulticast(void)
+{
+    *this = GetRealmLocalAllNodesMulticast();
 }
 
 bool Address::IsRealmLocalAllRoutersMulticast(void) const
 {
-    return (mFields.m32[0] == HostSwap32(0xff030000) && mFields.m32[1] == 0 && mFields.m32[2] == 0 &&
-            mFields.m32[3] == HostSwap32(0x02));
+    return (*this == GetRealmLocalAllRoutersMulticast());
+}
+
+void Address::SetToRealmLocalAllRoutersMulticast(void)
+{
+    *this = GetRealmLocalAllRoutersMulticast();
 }
 
 bool Address::IsRealmLocalAllMplForwarders(void) const
 {
-    return (mFields.m32[0] == HostSwap32(0xff030000) && mFields.m32[1] == 0 && mFields.m32[2] == 0 &&
-            mFields.m32[3] == HostSwap32(0xfc));
+    return (*this == GetRealmLocalAllMplForwarders());
+}
+
+void Address::SetToRealmLocalAllMplForwarders(void)
+{
+    *this = GetRealmLocalAllMplForwarders();
 }
 
 bool Address::IsRoutingLocator(void) const
@@ -403,6 +424,31 @@ Address::InfoString Address::ToString(void) const
     return InfoString("%x:%x:%x:%x:%x:%x:%x:%x", HostSwap16(mFields.m16[0]), HostSwap16(mFields.m16[1]),
                       HostSwap16(mFields.m16[2]), HostSwap16(mFields.m16[3]), HostSwap16(mFields.m16[4]),
                       HostSwap16(mFields.m16[5]), HostSwap16(mFields.m16[6]), HostSwap16(mFields.m16[7]));
+}
+
+const Address &Address::GetLinkLocalAllNodesMulticast(void)
+{
+    return static_cast<const Address &>(Netif::kLinkLocalAllNodesMulticastAddress.mAddress);
+}
+
+const Address &Address::GetLinkLocalAllRoutersMulticast(void)
+{
+    return static_cast<const Address &>(Netif::kLinkLocalAllRoutersMulticastAddress.mAddress);
+}
+
+const Address &Address::GetRealmLocalAllNodesMulticast(void)
+{
+    return static_cast<const Address &>(Netif::kRealmLocalAllNodesMulticastAddress.mAddress);
+}
+
+const Address &Address::GetRealmLocalAllRoutersMulticast(void)
+{
+    return static_cast<const Address &>(Netif::kRealmLocalAllRoutersMulticastAddress.mAddress);
+}
+
+const Address &Address::GetRealmLocalAllMplForwarders(void)
+{
+    return static_cast<const Address &>(Netif::kRealmLocalAllMplForwardersMulticastAddress.mAddress);
 }
 
 } // namespace Ip6

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -156,7 +156,7 @@ public:
     bool IsLinkLocalMulticast(void) const;
 
     /**
-     * This method indicates whether or not the IPv6 address is a link-local all nodes multicast address.
+     * This method indicates whether or not the IPv6 address is a link-local all nodes multicast address (ff02::01).
      *
      * @retval TRUE   If the IPv6 address is a link-local all nodes multicast address.
      * @retval FALSE  If the IPv6 address is not a link-local all nodes multicast address.
@@ -165,13 +165,25 @@ public:
     bool IsLinkLocalAllNodesMulticast(void) const;
 
     /**
-     * This method indicates whether or not the IPv6 address is a link-local all routers multicast address.
+     * This method sets the IPv6 address to the link-local all nodes multicast address (ff02::01).
+     *
+     */
+    void SetToLinkLocalAllNodesMulticast(void);
+
+    /**
+     * This method indicates whether or not the IPv6 address is a link-local all routers multicast address (ff02::02).
      *
      * @retval TRUE   If the IPv6 address is a link-local all routers multicast address.
      * @retval FALSE  If the IPv6 address is not a link-local all routers multicast address.
      *
      */
     bool IsLinkLocalAllRoutersMulticast(void) const;
+
+    /**
+     * This method sets the IPv6 address to the link-local all routers multicast address (ff02::02).
+     *
+     */
+    void SetToLinkLocalAllRoutersMulticast(void);
 
     /**
      * This method indicates whether or not the IPv6 address is a realm-local multicast address.
@@ -183,7 +195,7 @@ public:
     bool IsRealmLocalMulticast(void) const;
 
     /**
-     * This method indicates whether or not the IPv6 address is a realm-local all nodes multicast address.
+     * This method indicates whether or not the IPv6 address is a realm-local all nodes multicast address (ff03::01).
      *
      * @retval TRUE   If the IPv6 address is a realm-local all nodes multicast address.
      * @retval FALSE  If the IPv6 address is not a realm-local all nodes multicast address.
@@ -192,7 +204,13 @@ public:
     bool IsRealmLocalAllNodesMulticast(void) const;
 
     /**
-     * This method indicates whether or not the IPv6 address is a realm-local all routers multicast address.
+     * This method sets the IPv6 address to the realm-local all nodes multicast address (ff03::01)
+     *
+     */
+    void SetToRealmLocalAllNodesMulticast(void);
+
+    /**
+     * This method indicates whether or not the IPv6 address is a realm-local all routers multicast address (ff03::02).
      *
      * @retval TRUE   If the IPv6 address is a realm-local all routers multicast address.
      * @retval FALSE  If the IPv6 address is not a realm-local all routers multicast address.
@@ -201,13 +219,25 @@ public:
     bool IsRealmLocalAllRoutersMulticast(void) const;
 
     /**
-     * This method indicates whether or not the IPv6 address is a realm-local all MPL forwarders address.
+     * This method sets the IPv6 address to the realm-local all routers multicast address (ff03::02).
+     *
+     */
+    void SetToRealmLocalAllRoutersMulticast(void);
+
+    /**
+     * This method indicates whether or not the IPv6 address is a realm-local all MPL forwarders address (ff03::fc).
      *
      * @retval TRUE   If the IPv6 address is a realm-local all MPL forwarders address.
      * @retval FALSE  If the IPv6 address is not a realm-local all MPL forwarders address.
      *
      */
     bool IsRealmLocalAllMplForwarders(void) const;
+
+    /**
+     * This method sets the the IPv6 address to the realm-local all MPL forwarders address (ff03::fc).
+     *
+     */
+    void SetToRealmLocalAllMplForwarders(void);
 
     /**
      * This method indicates whether or not the IPv6 address is multicast larger than realm local.
@@ -454,6 +484,12 @@ public:
 
 private:
     void SetPrefix(uint8_t aOffset, const uint8_t *aPrefix, uint8_t aPrefixLength);
+
+    static const Address &GetLinkLocalAllNodesMulticast(void);
+    static const Address &GetLinkLocalAllRoutersMulticast(void);
+    static const Address &GetRealmLocalAllNodesMulticast(void);
+    static const Address &GetRealmLocalAllRoutersMulticast(void);
+    static const Address &GetRealmLocalAllMplForwarders(void);
 
     enum
     {

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -172,6 +172,7 @@ private:
 class Netif : public InstanceLocator, public LinkedListEntry<Netif>
 {
     friend class Ip6;
+    friend class Address;
 
 public:
     /**

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -562,8 +562,8 @@ otError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
 
     SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kTarget, aEid.mFields.m8, sizeof(aEid)));
 
-    messageInfo.GetPeerAddr().mFields.m16[0] = HostSwap16(0xff03);
-    messageInfo.GetPeerAddr().mFields.m16[7] = HostSwap16(0x0002);
+    messageInfo.GetPeerAddr().SetToRealmLocalAllRoutersMulticast();
+
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerPort(kCoapUdpPort);
 
@@ -680,8 +680,7 @@ otError AddressResolver::SendAddressError(const Ip6::Address &aTarget,
 
     if (aDestination == NULL)
     {
-        messageInfo.GetPeerAddr().mFields.m16[0] = HostSwap16(0xff03);
-        messageInfo.GetPeerAddr().mFields.m16[7] = HostSwap16(0x0002);
+        messageInfo.GetPeerAddr().SetToRealmLocalAllRoutersMulticast();
     }
     else
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -595,9 +595,8 @@ otError Mle::Discover(const Mac::ChannelMask &aScanChannels,
     tlv.SetLength(static_cast<uint8_t>(message->GetLength() - startOffset));
     message->Write(startOffset - sizeof(tlv), sizeof(tlv), &tlv);
 
-    destination.Clear();
-    destination.mFields.m16[0] = HostSwap16(0xff02);
-    destination.mFields.m16[7] = HostSwap16(0x0002);
+    destination.SetToLinkLocalAllRoutersMulticast();
+
     SuccessOrExit(error = SendMessage(*message, destination));
 
     mDiscoverInProgress = true;
@@ -2075,9 +2074,7 @@ otError Mle::SendParentRequest(ParentRequestType aType)
     SuccessOrExit(error = AppendTimeRequest(*message));
 #endif
 
-    destination.Clear();
-    destination.mFields.m16[0] = HostSwap16(0xff02);
-    destination.mFields.m16[7] = HostSwap16(0x0002);
+    destination.SetToLinkLocalAllRoutersMulticast();
     SuccessOrExit(error = SendMessage(*message, destination));
 
     switch (aType)
@@ -2501,9 +2498,7 @@ otError Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce)
 {
     Ip6::Address destination;
 
-    destination.Clear();
-    destination.mFields.m16[0] = HostSwap16(0xff02);
-    destination.mFields.m16[7] = HostSwap16(0x0001);
+    destination.SetToLinkLocalAllNodesMulticast();
 
     return SendAnnounce(aChannel, aOrphanAnnounce, destination);
 }

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -452,9 +452,7 @@ otError MleRouter::SendAdvertisement(void)
         break;
     }
 
-    destination.Clear();
-    destination.mFields.m16[0] = HostSwap16(0xff02);
-    destination.mFields.m16[7] = HostSwap16(0x0001);
+    destination.SetToLinkLocalAllNodesMulticast();
     SuccessOrExit(error = SendMessage(*message, destination));
 
     LogMleMessage("Send Advertisement", destination);
@@ -2707,9 +2705,7 @@ void MleRouter::HandleNetworkDataUpdateRouter(void)
 
     VerifyOrExit(IsRouterOrLeader());
 
-    destination.Clear();
-    destination.mFields.m16[0] = HostSwap16(0xff02);
-    destination.mFields.m16[7] = HostSwap16(0x0001);
+    destination.SetToLinkLocalAllNodesMulticast();
 
     delay = IsLeader() ? 0 : Random::NonCrypto::GetUint16InRange(0, kUnsolicitedDataResponseJitter);
     SendDataResponse(destination, tlvs, sizeof(tlvs), delay);
@@ -4818,9 +4814,7 @@ otError MleRouter::SendTimeSync(void)
 
     message->SetTimeSync(true);
 
-    destination.Clear();
-    destination.mFields.m16[0] = HostSwap16(0xff02);
-    destination.mFields.m16[7] = HostSwap16(0x0001);
+    destination.SetToLinkLocalAllNodesMulticast();
     SuccessOrExit(error = SendMessage(*message, destination));
 
     LogMleMessage("Send Time Sync", destination);


### PR DESCRIPTION
This commit adds methods to set an `Ip6::Address` to common multicast
addresses, link-local all-nodes/all-routers, realm-local all-nodes/
all-routers, or realm-local all MPL forwarders. The implementation
uses the constant addresses defined in `Netif` class.