### PR TITLE
[mle] REED to handle rejected ADDR_SOL.rsp

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -4050,10 +4050,10 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
 
     SuccessOrExit(Tlv::ReadUint8Tlv(*aMessage, ThreadTlv::kStatus, status));
 
-    mAddressSolicitRejected = (status != ThreadStatusTlv::kSuccess);
-
     if (status != ThreadStatusTlv::kSuccess)
     {
+        mAddressSolicitRejected = true;
+
         if (IsRouterIdValid(mPreviousRouterId))
         {
             if (HasChildren())

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -4120,7 +4120,7 @@ exit:
     InformPreviousChannel();
 }
 
-bool MleRouter::ExpectBecomeRouterSoon(void) const
+bool MleRouter::IsExpectedToBecomeRouter(void) const
 {
     return IsRouterEligible() && !IsRouterOrLeader() &&
            (Get<RouterTable>().GetActiveRouterCount() < GetRouterUpgradeThreshold()) && !mAddressSolicitRejected;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -4834,6 +4834,13 @@ exit:
 
     return error;
 }
+
+bool MleRouter::ExpectBecomeRouterSoon(void) const
+{
+    return IsRouterEligible() && !IsRouterOrLeader() &&
+           (Get<RouterTable>().GetActiveRouterCount() < GetRouterUpgradeThreshold());
+}
+
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
 } // namespace Mle

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -4846,7 +4846,6 @@ exit:
 
     return error;
 }
-
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
 } // namespace Mle

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -320,6 +320,15 @@ public:
     void SetRouterDowngradeThreshold(uint8_t aThreshold) { mRouterDowngradeThreshold = aThreshold; }
 
     /**
+     * This method returns if the REED is expected to become Router soon.
+     *
+     * @retval TRUE   If the REED is going to become Router.
+     * @retval FALSE  Otherwise.
+     *
+     */
+    bool ExpectBecomeRouterSoon(void) const;
+
+    /**
      * This method removes a link to a neighbor.
      *
      * @param[in]  aNeighbor  A reference to the neighbor object.

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -839,6 +839,7 @@ private:
     uint32_t mFixedLeaderPartitionId; ///< only for certification testing
     bool     mRouterEligible : 1;
     bool     mAddressSolicitPending : 1;
+    bool     mAddressSolicitRejected : 1;
 
     uint8_t mRouterId;
     uint8_t mPreviousRouterId;

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -326,7 +326,7 @@ public:
      * @retval FALSE  Otherwise.
      *
      */
-    bool ExpectBecomeRouterSoon(void) const;
+    bool IsExpectedToBecomeRouter(void) const;
 
     /**
      * This method removes a link to a neighbor.

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -361,7 +361,7 @@ otError Local::UpdateInconsistentServerData(Coap::ResponseHandler aHandler, void
 #if OPENTHREAD_FTD
 
     // Don't send this Server Data Notification if the device is going to upgrade to Router
-    if (Get<Mle::MleRouter>().ExpectBecomeRouterSoon())
+    if (Get<Mle::MleRouter>().IsExpectedToBecomeRouter())
     {
         ExitNow(error = OT_ERROR_INVALID_STATE);
     }

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -361,8 +361,7 @@ otError Local::UpdateInconsistentServerData(Coap::ResponseHandler aHandler, void
 #if OPENTHREAD_FTD
 
     // Don't send this Server Data Notification if the device is going to upgrade to Router
-    if (Get<Mle::MleRouter>().IsRouterEligible() && !Get<Mle::MleRouter>().IsRouterOrLeader() &&
-        (Get<RouterTable>().GetActiveRouterCount() < Get<Mle::MleRouter>().GetRouterUpgradeThreshold()))
+    if (Get<Mle::MleRouter>().ExpectBecomeRouterSoon())
     {
         ExitNow(error = OT_ERROR_INVALID_STATE);
     }

--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -157,6 +157,7 @@ EXTRA_DIST                                                         = \
     test_service.py                                                  \
     test_network_data.py                                             \
     test_network_layer.py                                            \
+    test_reed_address_solicit_rejected.py                            \
     tlvs_parsing.py                                                  \
     $(NULL)
 
@@ -179,6 +180,7 @@ check_SCRIPTS                                                      = \
     test_service.py                                                  \
     test_network_data.py                                             \
     test_network_layer.py                                            \
+    test_reed_address_solicit_rejected.py                            \
     Cert_5_1_01_RouterAttach.py                                      \
     Cert_5_1_02_ChildAddressTimeout.py                               \
     Cert_5_1_03_RouterAddressReallocation.py                         \
@@ -290,6 +292,7 @@ XFAIL_NCP_TESTS                                                    = \
     test_diag.py                                                     \
     test_ipv6_fragmentation.py                                       \
     test_ipv6_source_selection.py                                    \
+    test_reed_address_solicit_rejected.py                            \
     test_service.py                                                  \
     Cert_5_3_10_AddressQuery.py                                      \
     Cert_8_1_01_Commissioning.py                                     \

--- a/tests/scripts/thread-cert/test_reed_address_solicit_rejected.py
+++ b/tests/scripts/thread-cert/test_reed_address_solicit_rejected.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import config
+import node
+import re
+import unittest
+
+LEADER = 1
+REED = 2
+
+SRV_0_ID = 0
+SRV_0_ENT_NUMBER = '123'
+SRV_0_SERVICE_DATA = 'foo'
+SRV_0_SERVER_DATA = 'bar'
+
+# Topology:
+# LEADER -- REED
+#
+
+
+class TestREEDAddressSolicitRejected(unittest.TestCase):
+
+    def setUp(self):
+        self.simulator = config.create_default_simulator()
+
+        self.nodes = {}
+        for i in [LEADER, REED]:
+            self.nodes[i] = node.Node(i, simulator=self.simulator)
+
+        self.nodes[LEADER].set_panid(0xface)
+        self.nodes[LEADER].set_mode('rsdn')
+
+        self.nodes[REED].set_panid(0xface)
+        self.nodes[REED].set_mode('rsdn')
+        self.nodes[REED].set_router_selection_jitter(1)
+
+    def tearDown(self):
+        for n in list(self.nodes.values()):
+            n.stop()
+            n.destroy()
+        self.simulator.stop()
+
+    def testAddressSolicitRejectedBeforeSvrData(self):
+        self.nodes[LEADER].start()
+        self.nodes[LEADER].set_router_upgrade_threshold(1)
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+
+        self.nodes[REED].start()
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[REED].get_state(), 'child')
+
+        self.nodes[REED].add_service(SRV_0_ENT_NUMBER, SRV_0_SERVICE_DATA,
+                                     SRV_0_SERVER_DATA)
+        self.nodes[REED].register_netdata()
+        self.simulator.go(2)
+
+        self.assertEqual(self.hasAloc(REED, SRV_0_ID), True)
+
+    def testAddressSolicitRejectedAfterSvrData(self):
+        self.nodes[LEADER].start()
+        self.nodes[LEADER].set_router_upgrade_threshold(1)
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+
+        self.nodes[REED].set_router_selection_jitter(120)
+        self.nodes[REED].start()
+        # set routerupgradethreshold=1 on REED so that it won't send ADDR_SOL.req
+        self.nodes[REED].set_router_upgrade_threshold(1)
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[REED].get_state(), 'child')
+
+        # restore routerupgradethreshold to 16 and add service
+        self.nodes[REED].set_router_upgrade_threshold(16)
+        self.nodes[REED].add_service(SRV_0_ENT_NUMBER, SRV_0_SERVICE_DATA,
+                                     SRV_0_SERVER_DATA)
+        self.nodes[REED].register_netdata()
+        self.simulator.go(130)
+        self.assertEqual(self.hasAloc(REED, SRV_0_ID), True)
+
+    def hasAloc(self, node_id, service_id):
+        for addr in self.nodes[node_id].get_ip6_address(
+                config.ADDRESS_TYPE.ALOC):
+            m = re.match('.*:fc(..)$', addr, re.I)
+            if m is not None:
+                if m.group(
+                        1) == str(service_id +
+                                  10):  # for service_id=3 look for '...:fc13'
+                    return True
+
+        return False
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Currently, a REED which expects to become Router soon does not send any `SVR_DATA.ntf`. 
This PR handles rejecting `ADDR_SOL.rsp` to allow REED to send `SVR_DATA.ntf` after it's rejected. 
- [x] Commit 1 wraps existing logic within `MleRouter::ExpectBecomeRouterSoon`
- [x] Commit 2 adds a test that should fail without fix
- [x] Commit 3 fixes this issue

This PR addresses #4827 .