### PR TITLE
[ip6-address] helper methods to set Link-Local and RLOC/ALOC addresses

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -497,7 +497,7 @@ Message *CoapBase::FindRelatedRequest(const Message &         aResponse,
         aMetadata.ReadFrom(*message);
 
         if (((aMetadata.mDestinationAddress == aMessageInfo.GetPeerAddr()) ||
-             aMetadata.mDestinationAddress.IsMulticast() || aMetadata.mDestinationAddress.IsAnycastRoutingLocator()) &&
+             aMetadata.mDestinationAddress.IsMulticast() || aMetadata.mDestinationAddress.IsIidAnycastLocator()) &&
             (aMetadata.mDestinationPort == aMessageInfo.GetPeerPort()))
         {
             switch (aResponse.GetType())

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -339,8 +339,7 @@ otError Joiner::Connect(JoinerRouter &aRouter)
     SuccessOrExit(error = Get<Mac::Mac>().SetPanChannel(aRouter.mChannel));
     SuccessOrExit(error = Get<Ip6::Filter>().AddUnsecurePort(kJoinerUdpPort));
 
-    sockaddr.GetAddress().mFields.m16[0] = HostSwap16(0xfe80);
-    sockaddr.GetAddress().SetIid(aRouter.mExtAddr);
+    sockaddr.GetAddress().SetToLinkLocalAddress(aRouter.mExtAddr);
     sockaddr.mPort = aRouter.mJoinerUdpPort;
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().Connect(sockaddr, Joiner::HandleSecureCoapClientConnect, this));

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -213,8 +213,7 @@ void JoinerRouter::HandleRelayTransmit(Coap::Message &aMessage, const Ip6::Messa
     SuccessOrExit(error = message->SetLength(length));
     aMessage.CopyTo(offset, 0, length, *message);
 
-    messageInfo.mPeerAddr.mFields.m16[0] = HostSwap16(0xfe80);
-    memcpy(messageInfo.mPeerAddr.mFields.m8 + 8, joinerIid, 8);
+    messageInfo.GetPeerAddr().SetToLinkLocalAddress(joinerIid);
     messageInfo.SetPeerPort(joinerPort);
 
     SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -280,11 +280,7 @@ otError Dhcp6Client::Solicit(uint16_t aRloc16)
 #if OPENTHREAD_ENABLE_DHCP6_MULTICAST_SOLICIT
     messageInfo.GetPeerAddr().SetToRealmLocalAllRoutersMulticast();
 #else
-    messageInfo.GetPeerAddr().SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-    messageInfo.GetPeerAddr().mFields.m16[4] = HostSwap16(0x0000);
-    messageInfo.GetPeerAddr().mFields.m16[5] = HostSwap16(0x00ff);
-    messageInfo.GetPeerAddr().mFields.m16[6] = HostSwap16(0xfe00);
-    messageInfo.GetPeerAddr().SetLocator(aRloc16);
+    messageInfo.GetPeerAddr().SetToRoutingLocator(Get<Mle::MleRouter>().GetMeshLocalPrefix(), aRloc16);
 #endif
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.mPeerPort = kDhcpServerPort;

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -167,15 +167,10 @@ private:
         {
             mPrefix = aPrefix;
 
-            mAloc.GetAddress().SetPrefix(aMeshLocalPrefix);
-            mAloc.mAddress.mFields.m16[4] = HostSwap16(0x0000);
-            mAloc.mAddress.mFields.m16[5] = HostSwap16(0x00ff);
-            mAloc.mAddress.mFields.m16[6] = HostSwap16(0xfe00);
-            mAloc.mAddress.mFields.m8[14] = Ip6::Address::kAloc16Mask;
-            mAloc.mAddress.mFields.m8[15] = aContextId;
-            mAloc.mPrefixLength           = OT_IP6_PREFIX_BITSIZE;
-            mAloc.mPreferred              = true;
-            mAloc.mValid                  = true;
+            mAloc.GetAddress().SetToAnycastLocator(aMeshLocalPrefix, (Ip6::Address::kAloc16Mask << 8) + aContextId);
+            mAloc.mPrefixLength = OT_IP6_PREFIX_BITSIZE;
+            mAloc.mPreferred    = true;
+            mAloc.mValid        = true;
         }
 
     private:

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -201,9 +201,7 @@ otError Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMe
     uint16_t    payloadLength;
 
     // always handle Echo Request destined for RLOC or ALOC
-    VerifyOrExit(ShouldHandleEchoRequest(aMessageInfo) || aMessageInfo.GetSockAddr().IsRoutingLocator() ||
-                     aMessageInfo.GetSockAddr().IsAnycastRoutingLocator(),
-                 OT_NOOP);
+    VerifyOrExit(ShouldHandleEchoRequest(aMessageInfo) || aMessageInfo.GetSockAddr().IsIidLocator(), OT_NOOP);
 
     otLogInfoIcmp("Received Echo Request");
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1027,10 +1027,9 @@ otError Ip6::ProcessReceiveCallback(const Message &    aMessage,
     if (mIsReceiveIp6FilterEnabled)
     {
         // do not pass messages sent to an RLOC/ALOC, except Service Locator
-        VerifyOrExit(
-            (!aMessageInfo.GetSockAddr().IsRoutingLocator() && !aMessageInfo.GetSockAddr().IsAnycastRoutingLocator()) ||
-                aMessageInfo.GetSockAddr().IsAnycastServiceLocator(),
-            error = OT_ERROR_NO_ROUTE);
+        VerifyOrExit(!aMessageInfo.GetSockAddr().IsIidLocator() ||
+                         aMessageInfo.GetSockAddr().IsIidAnycastServiceLocator(),
+                     error = OT_ERROR_NO_ROUTE);
 
         switch (aIpProto)
         {
@@ -1365,7 +1364,7 @@ const NetifUnicastAddress *Ip6::SelectSourceAddress(MessageInfo &aMessageInfo)
         uint8_t        candidatePrefixMatched;
         uint8_t        overrideScope;
 
-        if (candidateAddr->IsAnycastRoutingLocator())
+        if (candidateAddr->IsIidAnycastLocator())
         {
             // Don't use anycast address as source address.
             continue;
@@ -1435,7 +1434,7 @@ const NetifUnicastAddress *Ip6::SelectSourceAddress(MessageInfo &aMessageInfo)
             rvalPrefixMatched = candidatePrefixMatched;
         }
         else if ((candidatePrefixMatched == rvalPrefixMatched) &&
-                 (destination->IsRoutingLocator() == candidateAddr->IsRoutingLocator()))
+                 (destination->IsIidRoutingLocator() == candidateAddr->IsIidRoutingLocator()))
         {
             // Additional rule: Prefer RLOC source for RLOC destination, EID source for anything else
             rvalAddr          = addr;

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -138,6 +138,23 @@ public:
     bool IsLinkLocal(void) const;
 
     /**
+     * This methods sets the IPv6 address to a Link-Local address with Interface Identifier generated from a given
+     * MAC Extended Address.
+     *
+     * @param[in]  aExtAddress  A MAC Extended Address (used to generate the IID).
+     *
+     */
+    void SetToLinkLocalAddress(const Mac::ExtAddress &aExtAddress);
+
+    /**
+     * This methods sets the IPv6 address to a Link-Local address with a given Interface Identifier.
+     *
+     * @param[in]  aIid   A pointer to a buffer containing the Interface Identifier.
+     *
+     */
+    void SetToLinkLocalAddress(const uint8_t *aIid);
+
+    /**
      * This method indicates whether or not the IPv6 address is multicast address.
      *
      * @retval TRUE   If the IPv6 address is a multicast address.
@@ -249,34 +266,7 @@ public:
     bool IsMulticastLargerThanRealmLocal(void) const;
 
     /**
-     * This method indicates whether or not the IPv6 address is a RLOC address.
-     *
-     * @retval TRUE   If the IPv6 address is a RLOC address.
-     * @retval FALSE  If the IPv6 address is not a RLOC address.
-     *
-     */
-    bool IsRoutingLocator(void) const;
-
-    /**
-     * This method indicates whether or not the IPv6 address is an Anycast RLOC address.
-     *
-     * @retval TRUE   If the IPv6 address is an Anycast RLOC address.
-     * @retval FALSE  If the IPv6 address is not an Anycast RLOC address.
-     *
-     */
-    bool IsAnycastRoutingLocator(void) const;
-
-    /**
-     * This method indicates whether or not the IPv6 address is an Anycast Service Locator.
-     *
-     * @retval TRUE   If the IPv6 address is an Anycast Service Locator.
-     * @retval FALSE  If the IPv6 address is not an Anycast Service Locator.
-     *
-     */
-    bool IsAnycastServiceLocator(void) const;
-
-    /**
-     * This method indicates whether or not the IPv6 address is Subnet-Router Anycast (RFC 4291),
+     * This method indicates whether or not the IPv6 address is Subnet-Router Anycast (RFC 4291).
      *
      * @retval TRUE   If the IPv6 address is a Subnet-Router Anycast address.
      * @retval FALSE  If the IPv6 address is not a Subnet-Router Anycast address.
@@ -285,7 +275,7 @@ public:
     bool IsSubnetRouterAnycast(void) const;
 
     /**
-     * This method indicates whether or not the IPv6 address is Reserved Subnet Anycast (RFC 2526),
+     * This method indicates whether or not the IPv6 address is Reserved Subnet Anycast (RFC 2526).
      *
      * @retval TRUE   If the IPv6 address is a Reserved Subnet Anycast address.
      * @retval FALSE  If the IPv6 address is not a Reserved Subnet Anycast address.
@@ -294,13 +284,62 @@ public:
     bool IsReservedSubnetAnycast(void) const;
 
     /**
-     * This method indicates whether or not the IPv6 address contains Reserved IPv6 IID (RFC 5453),
+     * This method indicates whether or not the IPv6 address contains Reserved IPv6 IID (RFC 5453).
      *
      * @retval TRUE   If the IPv6 address contains a reserved IPv6 IID.
      * @retval FALSE  If the IPv6 address does not contain a reserved IPv6 IID.
      *
      */
     bool IsIidReserved(void) const;
+
+    /**
+     * This method indicates whether or not the Interface Identifier (IID) of the IPv6 address matches the locator
+     * pattern (`0000:00ff:fe00:xxxx`).
+     *
+     * @retval TRUE   If the IPv6 address IID matches the locator pattern
+     * @retval FALSE  If the IPv6 address IID does not match the locator pattern
+     *
+     */
+    bool IsIidLocator(void) const;
+
+    /**
+     * This method indicates whether or not the IPv6 address's Interface Identifier (IID) matches a Routing Locator
+     * (RLOC).
+     *
+     * In addition to checking that the IID matches the locator pattern (`0000:00ff:fe00:xxxx`), this method also
+     * checks that the locator value is a valid RLOC16.
+     *
+     * @retval TRUE   If the IPv6 address's IID matches a RLOC address.
+     * @retval FALSE  If the IPv6 address's IID does not match a RLOC address.
+     *
+     */
+    bool IsIidRoutingLocator(void) const;
+
+    /**
+     * This method indicates whether or not the IPv6 address's Interface Identifier (IID) matches an Anycast Locator
+     * (ALOC).
+     *
+     * In addition to checking that the IID matches the locator pattern (`0000:00ff:fe00:xxxx`), this method also
+     * checks that the locator value is any valid ALOC16 (0xfc00 - 0xfcff).
+     *
+     * @retval TRUE   If the IPv6 address's IID matches a ALOC address.
+     * @retval FALSE  If the IPv6 address's IID does not match a ALOC address.
+     *
+     */
+    bool IsIidAnycastLocator(void) const;
+
+    /**
+     * This method indicates whether or not the IPv6 address's Interface Identifier (IID) matches a Service Anycast
+     * Locator (ALOC).
+     *
+     * In addition to checking that the IID matches the locator pattern (`0000:00ff:fe00:xxxx`), this method also
+     * checks that the locator value is a valid Service ALOC16 (0xfc10 – 0xfc2f).
+     *
+     * @retval TRUE   If the IPv6 address's IID matches a ALOC address.
+     * @retval FALSE  If the IPv6 address's IID does not match a ALOC address.
+     *
+     */
+    bool IsIidAnycastServiceLocator(void) const;
 
     /**
      * This method gets the IPv6 address locator.
@@ -319,6 +358,32 @@ public:
      *
      */
     void SetLocator(uint16_t aLocator) { mFields.m16[7] = HostSwap16(aLocator); }
+
+    /**
+     * This method sets the IPv6 address to a Routing Locator (RLOC) IPv6 address with a given Mesh-local prefix and
+     * RLOC16 value.
+     *
+     * @param[in]  aMeshLocalPrefix  A Mesh Local Prefix.
+     * @param[in]  aRloc16           A RLOC16 value.
+     *
+     */
+    void SetToRoutingLocator(const Mle::MeshLocalPrefix &aMeshLocalPrefix, uint16_t aRloc16)
+    {
+        SetToLocator(aMeshLocalPrefix, aRloc16);
+    }
+
+    /**
+     * This method sets the IPv6 address to a Anycast Locator (ALOC) IPv6 address with a given Mesh-local prefix and
+     * ALOC16 value.
+     *
+     * @param[in]  aMeshLocalPrefix  A Mesh Local Prefix.
+     * @param[in]  aAloc16           A ALOC16 value.
+     *
+     */
+    void SetToAnycastLocator(const Mle::MeshLocalPrefix &aMeshLocalPrefix, uint16_t aAloc16)
+    {
+        SetToLocator(aMeshLocalPrefix, aAloc16);
+    }
 
     /**
      * This method sets the IPv6 address prefix.
@@ -405,6 +470,15 @@ public:
      *
      */
     void SetIid(const Mac::ExtAddress &aExtAddress);
+
+    /**
+     * This method sets the Interface Identifier to Routing/Anycast Locator pattern `0000:00ff:fe00:xxxx` with a given
+     * locator (RLOC16 or ALOC16) value.
+     *
+     * @param[in]  aLocator    RLOC16 or ALOC16.
+     *
+     */
+    void SetIidToLocator(uint16_t aLocator);
 
     /**
      * This method converts the IPv6 Interface Identifier to an IEEE 802.15.4 Extended Address.
@@ -495,6 +569,7 @@ public:
 
 private:
     void SetPrefix(uint8_t aOffset, const uint8_t *aPrefix, uint8_t aPrefixLength);
+    void SetToLocator(const Mle::MeshLocalPrefix &aMeshLocalPrefix, uint16_t aLocator);
 
     static const Address &GetLinkLocalAllNodesMulticast(void);
     static const Address &GetLinkLocalAllRoutersMulticast(void);

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -67,10 +67,7 @@ otError Lowpan::ComputeIid(const Mac::Address &aMacAddr, const Context &aContext
     switch (aMacAddr.GetType())
     {
     case Mac::Address::kTypeShort:
-        aIpAddress.mFields.m16[4] = HostSwap16(0x0000);
-        aIpAddress.mFields.m16[5] = HostSwap16(0x00ff);
-        aIpAddress.mFields.m16[6] = HostSwap16(0xfe00);
-        aIpAddress.SetLocator(aMacAddr.GetShort());
+        aIpAddress.SetIidToLocator(aMacAddr.GetShort());
         break;
 
     case Mac::Address::kTypeExtended:

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -669,7 +669,7 @@ void MeshForwarder::UpdateRoutes(const uint8_t *     aFrame,
     VerifyOrExit(!aMeshDest.IsBroadcast() && aMeshSource.IsShort(), OT_NOOP);
     SuccessOrExit(GetIp6Header(aFrame, aFrameLength, aMeshSource, aMeshDest, ip6Header));
 
-    if (!ip6Header.GetSource().IsRoutingLocator() && !ip6Header.GetSource().IsAnycastRoutingLocator() &&
+    if (!ip6Header.GetSource().IsIidLocator() &&
         Get<NetworkData::Leader>().IsOnMesh(ip6Header.GetSource()) /* only for on mesh address which may require AQ */)
     {
         if (Get<AddressResolver>().UpdateCacheEntry(ip6Header.GetSource(), aMeshSource.GetShort()) ==

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -144,7 +144,7 @@ void Leader::HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &a
 
     otLogInfoNetData("Received network data registration");
 
-    VerifyOrExit(aMessageInfo.GetPeerAddr().IsRoutingLocator(), OT_NOOP);
+    VerifyOrExit(aMessageInfo.GetPeerAddr().IsIidRoutingLocator(), OT_NOOP);
 
     switch (Tlv::ReadUint16Tlv(aMessage, ThreadTlv::kRloc16, rloc16))
     {


### PR DESCRIPTION
This commit adds and uses a new method `SetToLinkLocalAddress()` in
`Ip6::Address` class which sets the address to a Link-Local IPv6
address with a given Interface Identifier (either given directly or
generated from a MAC Extended Address).

It also adds methods to set the address to a Routing/Anycast Locator
and updates methods checking RLOC/ALOC addresses. It adds a common
`IsIidLocator()` to check if the IID matches the `0000:00ff:fe00:xxxx`
pattern. More specific checks for RLOC or ALOC can be done by
`IsIidRoutingLocator()` or `IsIidAnycastLocator()`. The `Mle` and
other modules are updated to use the new/updated methods.