### PR TITLE
[cmake] enable running simulation unit tests using cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,3 +127,4 @@ if(OT_PLATFORM STREQUAL "simulation")
     enable_testing()
     add_subdirectory(tests)
 endif()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -122,3 +122,8 @@ endif()
 
 add_subdirectory(src)
 add_subdirectory(third_party)
+
+if(OT_PLATFORM STREQUAL "simulation")
+    enable_testing()
+    add_subdirectory(tests)
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -127,4 +127,3 @@ if(OT_PLATFORM STREQUAL "simulation")
     enable_testing()
     add_subdirectory(tests)
 endif()
-

--- a/script/test
+++ b/script/test
@@ -168,6 +168,17 @@ do_clean() {
     rm -rfv "${OT_BUILDDIR}"
 }
 
+do_cert_unit_tests() {
+    local builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}"
+    if [[ ! -d "${builddir}" ]]; then
+        echo "Cannot find build directory!"
+        exit -1
+    fi
+
+    cd "${builddir}"
+    ninja test
+}
+
 do_cert() {
     export top_builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}"
 
@@ -380,6 +391,9 @@ main()
             cert_suite)
                 shift
                 do_cert_suite "$@"
+                ;;
+            cert_unit_tests)
+                do_cert_unit_tests
                 ;;
             help)
                 print_usage

--- a/script/test
+++ b/script/test
@@ -280,6 +280,7 @@ COMMANDS:
     build           Build project for running tests. This can be used to rebuild the project for changes.
     cert            Run a single thread-cert test. ENVIRONMENTS should be the same as those given to build or update.
     cert_suite      Run a batch of thread-cert tests and summarize the test results. Only echo logs for failing tests.
+    unit            Run all the unit tests. This should be called after simulation is built.
     expect          Run expect tests.
     help            Print this help.
 
@@ -392,7 +393,7 @@ main()
                 shift
                 do_cert_suite "$@"
                 ;;
-            unit_tests)
+            unit)
                 do_unit
                 ;;
             help)

--- a/script/test
+++ b/script/test
@@ -168,7 +168,7 @@ do_clean() {
     rm -rfv "${OT_BUILDDIR}"
 }
 
-do_cert_unit_tests() {
+do_unit() {
     local builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}"
     if [[ ! -d "${builddir}" ]]; then
         echo "Cannot find build directory!"
@@ -392,8 +392,8 @@ main()
                 shift
                 do_cert_suite "$@"
                 ;;
-            cert_unit_tests)
-                do_cert_unit_tests
+            unit_tests)
+                do_unit
                 ;;
             help)
                 print_usage

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,29 @@
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+add_subdirectory(unit)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,4 +27,3 @@
 #
 
 add_subdirectory(unit)
-

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -27,3 +27,4 @@
 #
 
 add_subdirectory(unit)
+

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -34,7 +34,7 @@ set(COMMON_SOURCES
 set(COMMON_LIBS
     openthread-ftd
     openthread-ncp-ftd
-    mbedcrypto
+    mbedtls
     util
 )
 
@@ -147,382 +147,382 @@ add_executable(test-timer
 
 target_include_directories(test-aes
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-child
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-child-table
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-flash
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-heap
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-hmac-sha256
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-ip6-address
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-link-quality
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-linked-list
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-lowpan
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-mac-frame
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-message
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-message-queue
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-netif
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-network-data
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-priority-queue
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-pskc
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-string
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_include_directories(test-timer
     PRIVATE
-    ${COMMON_INCLUDES}
+        ${COMMON_INCLUDES}
 )
 
 target_compile_definitions(test-aes
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-child
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-child-table
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-flash
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-heap
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-hmac-sha256
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-ip6-address
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-link-quality
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-linked-list
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-lowpan
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-mac-frame
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-message
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-message-queue
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-netif
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-network-data
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-priority-queue
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-pskc
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-string
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_definitions(test-timer
     PRIVATE
-    ${OT_PRIVATE_DEFINES}
+        ${OT_PRIVATE_DEFINES}
 )
 
 target_compile_options(test-aes
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-child
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-child-table
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-flash
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-heap
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-hmac-sha256
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-ip6-address
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-link-quality
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-linked-list
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-lowpan
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-mac-frame
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-message
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-message-queue
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-netif
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-network-data
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-priority-queue
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-pskc
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-string
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_compile_options(test-timer
     PRIVATE
-    ${COMMON_COMPILE_OPTIONS}
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_link_libraries(test-aes
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-child
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-child-table
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-flash
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-heap
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-hmac-sha256
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-ip6-address
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-link-quality
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-linked-list
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-lowpan
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-mac-frame
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-message
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-message-queue
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-netif
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-network-data
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-priority-queue
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-pskc
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-string
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 target_link_libraries(test-timer
     PRIVATE
-    ${COMMON_LIBS}
+        ${COMMON_LIBS}
 )
 
 add_test(NAME test-aes COMMAND test-aes)

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -55,187 +55,7 @@ add_executable(test-aes
     test_aes.cpp
 )
 
-add_executable(test-child
-    ${COMMON_SOURCES}
-    test_child.cpp
-)
-
-add_executable(test-child-table
-    ${COMMON_SOURCES}
-    test_child_table.cpp
-)
-
-add_executable(test-flash
-    ${COMMON_SOURCES}
-    test_flash.cpp
-)
-
-add_executable(test-heap
-    ${COMMON_SOURCES}
-    test_heap.cpp
-)
-
-add_executable(test-hmac-sha256
-    ${COMMON_SOURCES}
-    test_hmac_sha256.cpp
-)
-
-add_executable(test-ip6-address
-    ${COMMON_SOURCES}
-    test_ip6_address.cpp
-)
-
-add_executable(test-link-quality
-    ${COMMON_SOURCES}
-    test_link_quality.cpp
-)
-
-add_executable(test-linked-list
-    ${COMMON_SOURCES}
-    test_linked_list.cpp
-)
-
-add_executable(test-lowpan
-    ${COMMON_SOURCES}
-    test_lowpan.cpp
-)
-
-add_executable(test-mac-frame
-    ${COMMON_SOURCES}
-    test_mac_frame.cpp
-)
-
-add_executable(test-message
-    ${COMMON_SOURCES}
-    test_message.cpp
-)
-
-add_executable(test-message-queue
-    ${COMMON_SOURCES}
-    test_message_queue.cpp
-)
-
-add_executable(test-netif
-    ${COMMON_SOURCES}
-    test_netif.cpp
-)
-
-add_executable(test-network-data
-    ${COMMON_SOURCES}
-    test_network_data.cpp
-)
-
-add_executable(test-priority-queue
-    ${COMMON_SOURCES}
-    test_priority_queue.cpp
-)
-
-add_executable(test-pskc
-    ${COMMON_SOURCES}
-    test_pskc.cpp
-)
-
-add_executable(test-string
-    ${COMMON_SOURCES}
-    test_string.cpp
-)
-
-add_executable(test-timer
-    ${COMMON_SOURCES}
-    test_timer.cpp
-)
-
 target_include_directories(test-aes
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-child
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-child-table
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-flash
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-heap
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-hmac-sha256
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-ip6-address
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-link-quality
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-linked-list
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-lowpan
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-mac-frame
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-message
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-message-queue
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-netif
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-network-data
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-priority-queue
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-pskc
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-string
-    PRIVATE
-        ${COMMON_INCLUDES}
-)
-
-target_include_directories(test-timer
     PRIVATE
         ${COMMON_INCLUDES}
 )
@@ -245,187 +65,7 @@ target_compile_definitions(test-aes
         ${OT_PRIVATE_DEFINES}
 )
 
-target_compile_definitions(test-child
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-child-table
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-flash
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-heap
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-hmac-sha256
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-ip6-address
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-link-quality
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-linked-list
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-lowpan
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-mac-frame
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-message
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-message-queue
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-netif
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-network-data
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-priority-queue
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-pskc
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-string
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
-target_compile_definitions(test-timer
-    PRIVATE
-        ${OT_PRIVATE_DEFINES}
-)
-
 target_compile_options(test-aes
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-child
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-child-table
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-flash
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-heap
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-hmac-sha256
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-ip6-address
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-link-quality
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-linked-list
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-lowpan
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-mac-frame
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-message
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-message-queue
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-netif
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-network-data
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-priority-queue
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-pskc
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-string
-    PRIVATE
-        ${COMMON_COMPILE_OPTIONS}
-)
-
-target_compile_options(test-timer
     PRIVATE
         ${COMMON_COMPILE_OPTIONS}
 )
@@ -435,9 +75,53 @@ target_link_libraries(test-aes
         ${COMMON_LIBS}
 )
 
+add_test(NAME test-aes COMMAND test-aes)
+
+add_executable(test-child
+    ${COMMON_SOURCES}
+    test_child.cpp
+)
+
+target_include_directories(test-child
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-child
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-child
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
 target_link_libraries(test-child
     PRIVATE
         ${COMMON_LIBS}
+)
+
+add_test(NAME test-child COMMAND test-child)
+
+add_executable(test-child-table
+    ${COMMON_SOURCES}
+    test_child_table.cpp
+)
+
+target_include_directories(test-child-table
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-child-table
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-child-table
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_link_libraries(test-child-table
@@ -445,9 +129,53 @@ target_link_libraries(test-child-table
         ${COMMON_LIBS}
 )
 
+add_test(NAME test-child-table COMMAND test-child-table)
+
+add_executable(test-flash
+    ${COMMON_SOURCES}
+    test_flash.cpp
+)
+
+target_include_directories(test-flash
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-flash
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-flash
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
 target_link_libraries(test-flash
     PRIVATE
         ${COMMON_LIBS}
+)
+
+add_test(NAME test-flash COMMAND test-flash)
+
+add_executable(test-heap
+    ${COMMON_SOURCES}
+    test_heap.cpp
+)
+
+target_include_directories(test-heap
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-heap
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-heap
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_link_libraries(test-heap
@@ -455,9 +183,53 @@ target_link_libraries(test-heap
         ${COMMON_LIBS}
 )
 
+add_test(NAME test-heap COMMAND test-heap)
+
+add_executable(test-hmac-sha256
+    ${COMMON_SOURCES}
+    test_hmac_sha256.cpp
+)
+
+target_include_directories(test-hmac-sha256
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-hmac-sha256
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-hmac-sha256
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
 target_link_libraries(test-hmac-sha256
     PRIVATE
         ${COMMON_LIBS}
+)
+
+add_test(NAME test-hmac-sha256 COMMAND test-hmac-sha256)
+
+add_executable(test-ip6-address
+    ${COMMON_SOURCES}
+    test_ip6_address.cpp
+)
+
+target_include_directories(test-ip6-address
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-ip6-address
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-ip6-address
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_link_libraries(test-ip6-address
@@ -465,9 +237,53 @@ target_link_libraries(test-ip6-address
         ${COMMON_LIBS}
 )
 
+add_test(NAME test-ip6-address COMMAND test-ip6-address)
+
+add_executable(test-link-quality
+    ${COMMON_SOURCES}
+    test_link_quality.cpp
+)
+
+target_include_directories(test-link-quality
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-link-quality
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-link-quality
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
 target_link_libraries(test-link-quality
     PRIVATE
         ${COMMON_LIBS}
+)
+
+add_test(NAME test-link-quality COMMAND test-link-quality)
+
+add_executable(test-linked-list
+    ${COMMON_SOURCES}
+    test_linked_list.cpp
+)
+
+target_include_directories(test-linked-list
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-linked-list
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-linked-list
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_link_libraries(test-linked-list
@@ -475,9 +291,53 @@ target_link_libraries(test-linked-list
         ${COMMON_LIBS}
 )
 
+add_test(NAME test-linked-list COMMAND test-linked-list)
+
+add_executable(test-lowpan
+    ${COMMON_SOURCES}
+    test_lowpan.cpp
+)
+
+target_include_directories(test-lowpan
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-lowpan
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-lowpan
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
 target_link_libraries(test-lowpan
     PRIVATE
         ${COMMON_LIBS}
+)
+
+add_test(NAME test-lowpan COMMAND test-lowpan)
+
+add_executable(test-mac-frame
+    ${COMMON_SOURCES}
+    test_mac_frame.cpp
+)
+
+target_include_directories(test-mac-frame
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-mac-frame
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-mac-frame
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_link_libraries(test-mac-frame
@@ -485,9 +345,53 @@ target_link_libraries(test-mac-frame
         ${COMMON_LIBS}
 )
 
+add_test(NAME test-mac-frame COMMAND test-mac-frame)
+
+add_executable(test-message
+    ${COMMON_SOURCES}
+    test_message.cpp
+)
+
+target_include_directories(test-message
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-message
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-message
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
 target_link_libraries(test-message
     PRIVATE
         ${COMMON_LIBS}
+)
+
+add_test(NAME test-message COMMAND test-message)
+
+add_executable(test-message-queue
+    ${COMMON_SOURCES}
+    test_message_queue.cpp
+)
+
+target_include_directories(test-message-queue
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-message-queue
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-message-queue
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_link_libraries(test-message-queue
@@ -495,9 +399,53 @@ target_link_libraries(test-message-queue
         ${COMMON_LIBS}
 )
 
+add_test(NAME test-message-queue COMMAND test-message-queue)
+
+add_executable(test-netif
+    ${COMMON_SOURCES}
+    test_netif.cpp
+)
+
+target_include_directories(test-netif
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-netif
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-netif
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
 target_link_libraries(test-netif
     PRIVATE
         ${COMMON_LIBS}
+)
+
+add_test(NAME test-netif COMMAND test-netif)
+
+add_executable(test-network-data
+    ${COMMON_SOURCES}
+    test_network_data.cpp
+)
+
+target_include_directories(test-network-data
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-network-data
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-network-data
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_link_libraries(test-network-data
@@ -505,9 +453,53 @@ target_link_libraries(test-network-data
         ${COMMON_LIBS}
 )
 
+add_test(NAME test-network-data COMMAND test-network-data)
+
+add_executable(test-priority-queue
+    ${COMMON_SOURCES}
+    test_priority_queue.cpp
+)
+
+target_include_directories(test-priority-queue
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-priority-queue
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-priority-queue
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
 target_link_libraries(test-priority-queue
     PRIVATE
         ${COMMON_LIBS}
+)
+
+add_test(NAME test-priority-queue COMMAND test-priority-queue)
+
+add_executable(test-pskc
+    ${COMMON_SOURCES}
+    test_pskc.cpp
+)
+
+target_include_directories(test-pskc
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-pskc
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-pskc
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_link_libraries(test-pskc
@@ -515,51 +507,59 @@ target_link_libraries(test-pskc
         ${COMMON_LIBS}
 )
 
+add_test(NAME test-pskc COMMAND test-pskc)
+
+add_executable(test-string
+    ${COMMON_SOURCES}
+    test_string.cpp
+)
+
+target_include_directories(test-string
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-string
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-string
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
 target_link_libraries(test-string
     PRIVATE
         ${COMMON_LIBS}
+)
+
+add_test(NAME test-string COMMAND test-string)
+
+add_executable(test-timer
+    ${COMMON_SOURCES}
+    test_timer.cpp
+)
+
+target_include_directories(test-timer
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-timer
+    PRIVATE
+        ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-timer
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
 )
 
 target_link_libraries(test-timer
     PRIVATE
         ${COMMON_LIBS}
 )
-
-add_test(NAME test-aes COMMAND test-aes)
-
-add_test(NAME test-child COMMAND test-child)
-
-add_test(NAME test-child-table COMMAND test-child-table)
-
-add_test(NAME test-flash COMMAND test-flash)
-
-add_test(NAME test-heap COMMAND test-heap)
-
-add_test(NAME test-hmac-sha256 COMMAND test-hmac-sha256)
-
-add_test(NAME test-ip6-address COMMAND test-ip6-address)
-
-add_test(NAME test-link-quality COMMAND test-link-quality)
-
-add_test(NAME test-linked-list COMMAND test-linked-list)
-
-add_test(NAME test-lowpan COMMAND test-lowpan)
-
-add_test(NAME test-mac-frame COMMAND test-mac-frame)
-
-add_test(NAME test-message COMMAND test-message)
-
-add_test(NAME test-message-queue COMMAND test-message-queue)
-
-add_test(NAME test-netif COMMAND test-netif)
-
-add_test(NAME test-network-data COMMAND test-network-data)
-
-add_test(NAME test-priority-queue COMMAND test-priority-queue)
-
-add_test(NAME test-pskc COMMAND test-pskc)
-
-add_test(NAME test-string COMMAND test-string)
 
 add_test(NAME test-timer COMMAND test-timer)
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,0 +1,565 @@
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+set(COMMON_SOURCES
+    test_platform.cpp
+    test_util.cpp
+)
+
+set(COMMON_LIBS
+    openthread-ftd
+    openthread-ncp-ftd
+    mbedcrypto
+    util
+)
+
+set(COMMON_INCLUDES
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/src
+    ${PROJECT_SOURCE_DIR}/src/core
+    ${PROJECT_SOURCE_DIR}/examples/platforms/simulation
+)
+
+set(COMMON_COMPILE_OPTIONS
+    -DOPENTHREAD_FTD=1
+    -DOPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE=1
+)
+
+add_executable(test-aes
+    ${COMMON_SOURCES}
+    test_aes.cpp
+)
+
+add_executable(test-child
+    ${COMMON_SOURCES}
+    test_child.cpp
+)
+
+add_executable(test-child-table
+    ${COMMON_SOURCES}
+    test_child_table.cpp
+)
+
+add_executable(test-flash
+    ${COMMON_SOURCES}
+    test_flash.cpp
+)
+
+add_executable(test-heap
+    ${COMMON_SOURCES}
+    test_heap.cpp
+)
+
+add_executable(test-hmac-sha256
+    ${COMMON_SOURCES}
+    test_hmac_sha256.cpp
+)
+
+add_executable(test-ip6-address
+    ${COMMON_SOURCES}
+    test_ip6_address.cpp
+)
+
+add_executable(test-link-quality
+    ${COMMON_SOURCES}
+    test_link_quality.cpp
+)
+
+add_executable(test-linked-list
+    ${COMMON_SOURCES}
+    test_linked_list.cpp
+)
+
+add_executable(test-lowpan
+    ${COMMON_SOURCES}
+    test_lowpan.cpp
+)
+
+add_executable(test-mac-frame
+    ${COMMON_SOURCES}
+    test_mac_frame.cpp
+)
+
+add_executable(test-message
+    ${COMMON_SOURCES}
+    test_message.cpp
+)
+
+add_executable(test-message-queue
+    ${COMMON_SOURCES}
+    test_message_queue.cpp
+)
+
+add_executable(test-netif
+    ${COMMON_SOURCES}
+    test_netif.cpp
+)
+
+add_executable(test-network-data
+    ${COMMON_SOURCES}
+    test_network_data.cpp
+)
+
+add_executable(test-priority-queue
+    ${COMMON_SOURCES}
+    test_priority_queue.cpp
+)
+
+add_executable(test-pskc
+    ${COMMON_SOURCES}
+    test_pskc.cpp
+)
+
+add_executable(test-string
+    ${COMMON_SOURCES}
+    test_string.cpp
+)
+
+add_executable(test-timer
+    ${COMMON_SOURCES}
+    test_timer.cpp
+)
+
+target_include_directories(test-aes
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-child
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-child-table
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-flash
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-heap
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-hmac-sha256
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-ip6-address
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-link-quality
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-linked-list
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-lowpan
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-mac-frame
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-message
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-message-queue
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-netif
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-network-data
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-priority-queue
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-pskc
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-string
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_include_directories(test-timer
+    PRIVATE
+    ${COMMON_INCLUDES}
+)
+
+target_compile_definitions(test-aes
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-child
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-child-table
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-flash
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-heap
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-hmac-sha256
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-ip6-address
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-link-quality
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-linked-list
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-lowpan
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-mac-frame
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-message
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-message-queue
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-netif
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-network-data
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-priority-queue
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-pskc
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-string
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_definitions(test-timer
+    PRIVATE
+    ${OT_PRIVATE_DEFINES}
+)
+
+target_compile_options(test-aes
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-child
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-child-table
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-flash
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-heap
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-hmac-sha256
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-ip6-address
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-link-quality
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-linked-list
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-lowpan
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-mac-frame
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-message
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-message-queue
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-netif
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-network-data
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-priority-queue
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-pskc
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-string
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_compile_options(test-timer
+    PRIVATE
+    ${COMMON_COMPILE_OPTIONS}
+)
+
+target_link_libraries(test-aes
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-child
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-child-table
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-flash
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-heap
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-hmac-sha256
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-ip6-address
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-link-quality
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-linked-list
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-lowpan
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-mac-frame
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-message
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-message-queue
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-netif
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-network-data
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-priority-queue
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-pskc
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-string
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+target_link_libraries(test-timer
+    PRIVATE
+    ${COMMON_LIBS}
+)
+
+add_test(NAME test-aes COMMAND test-aes)
+
+add_test(NAME test-child COMMAND test-child)
+
+add_test(NAME test-child-table COMMAND test-child-table)
+
+add_test(NAME test-flash COMMAND test-flash)
+
+add_test(NAME test-heap COMMAND test-heap)
+
+add_test(NAME test-hmac-sha256 COMMAND test-hmac-sha256)
+
+add_test(NAME test-ip6-address COMMAND test-ip6-address)
+
+add_test(NAME test-link-quality COMMAND test-link-quality)
+
+add_test(NAME test-linked-list COMMAND test-linked-list)
+
+add_test(NAME test-lowpan COMMAND test-lowpan)
+
+add_test(NAME test-mac-frame COMMAND test-mac-frame)
+
+add_test(NAME test-message COMMAND test-message)
+
+add_test(NAME test-message-queue COMMAND test-message-queue)
+
+add_test(NAME test-netif COMMAND test-netif)
+
+add_test(NAME test-network-data COMMAND test-network-data)
+
+add_test(NAME test-priority-queue COMMAND test-priority-queue)
+
+add_test(NAME test-pskc COMMAND test-pskc)
+
+add_test(NAME test-string COMMAND test-string)
+
+add_test(NAME test-timer COMMAND test-timer)
+


### PR DESCRIPTION
As we're transferring to cmake, I'm trying to replace `make -f examples/Makefile-simulation check` with cmake in our github actions. 

In this PR, we would be able to run all the simulation unit tests easier with cmake:
```
./script/test clean build unit_tests
```

I plan to also add `thread-cert` tests into cmake tests later and then gradually replace the 'make check' in github actions with cmake.  