### PR TITLE
[dataset] multiple enhancements (add Type, rename to GetTlv/SetTlv, etc.)

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -115,7 +115,7 @@ exit:
     return rval;
 }
 
-void Dataset::Get(otOperationalDataset &aDataset) const
+void Dataset::ConvertTo(otOperationalDataset &aDataset) const
 {
     const Tlv *cur = reinterpret_cast<const Tlv *>(mTlvs);
     const Tlv *end = reinterpret_cast<const Tlv *>(mTlvs + mLength);
@@ -253,7 +253,7 @@ void Dataset::Set(const Dataset &aDataset)
     mUpdateTime = aDataset.GetUpdateTime();
 }
 
-otError Dataset::Set(const otOperationalDataset &aDataset)
+otError Dataset::SetFrom(const otOperationalDataset &aDataset)
 {
     otError error = OT_ERROR_NONE;
 

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -75,7 +75,7 @@ exit:
     return rval;
 }
 
-Tlv *Dataset::Get(Tlv::Type aType)
+Tlv *Dataset::GetTlv(Tlv::Type aType)
 {
     Tlv *cur  = reinterpret_cast<Tlv *>(mTlvs);
     Tlv *end  = reinterpret_cast<Tlv *>(mTlvs + mLength);
@@ -95,7 +95,7 @@ exit:
     return rval;
 }
 
-const Tlv *Dataset::Get(Tlv::Type aType) const
+const Tlv *Dataset::GetTlv(Tlv::Type aType) const
 {
     const Tlv *cur  = reinterpret_cast<const Tlv *>(mTlvs);
     const Tlv *end  = reinterpret_cast<const Tlv *>(mTlvs + mLength);
@@ -263,7 +263,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         tlv.Init();
         tlv.SetSeconds(aDataset.mActiveTimestamp);
         tlv.SetTicks(0);
-        Set(tlv);
+        SetTlv(tlv);
     }
 
     if (aDataset.mComponents.mIsPendingTimestampPresent)
@@ -272,7 +272,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         tlv.Init();
         tlv.SetSeconds(aDataset.mPendingTimestamp);
         tlv.SetTicks(0);
-        Set(tlv);
+        SetTlv(tlv);
     }
 
     if (aDataset.mComponents.mIsDelayPresent)
@@ -280,7 +280,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::DelayTimerTlv tlv;
         tlv.Init();
         tlv.SetDelayTimer(aDataset.mDelay);
-        Set(tlv);
+        SetTlv(tlv);
     }
 
     if (aDataset.mComponents.mIsChannelPresent)
@@ -288,7 +288,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::ChannelTlv tlv;
         tlv.Init();
         tlv.SetChannel(aDataset.mChannel);
-        Set(tlv);
+        SetTlv(tlv);
     }
 
     if (aDataset.mComponents.mIsChannelMaskPresent)
@@ -296,7 +296,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::ChannelMaskTlv tlv;
         tlv.Init();
         tlv.SetChannelMask(aDataset.mChannelMask);
-        Set(tlv);
+        SetTlv(tlv);
     }
 
     if (aDataset.mComponents.mIsExtendedPanIdPresent)
@@ -304,7 +304,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::ExtendedPanIdTlv tlv;
         tlv.Init();
         tlv.SetExtendedPanId(static_cast<const Mac::ExtendedPanId &>(aDataset.mExtendedPanId));
-        Set(tlv);
+        SetTlv(tlv);
     }
 
     if (aDataset.mComponents.mIsMeshLocalPrefixPresent)
@@ -312,7 +312,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::MeshLocalPrefixTlv tlv;
         tlv.Init();
         tlv.SetMeshLocalPrefix(static_cast<const Mle::MeshLocalPrefix &>(aDataset.mMeshLocalPrefix));
-        Set(tlv);
+        SetTlv(tlv);
     }
 
     if (aDataset.mComponents.mIsMasterKeyPresent)
@@ -320,7 +320,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::NetworkMasterKeyTlv tlv;
         tlv.Init();
         tlv.SetNetworkMasterKey(static_cast<const MasterKey &>(aDataset.mMasterKey));
-        Set(tlv);
+        SetTlv(tlv);
     }
 
     if (aDataset.mComponents.mIsNetworkNamePresent)
@@ -328,7 +328,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::NetworkNameTlv tlv;
         tlv.Init();
         tlv.SetNetworkName(static_cast<const Mac::NetworkName &>(aDataset.mNetworkName).GetAsData());
-        Set(tlv);
+        SetTlv(tlv);
     }
 
     if (aDataset.mComponents.mIsPanIdPresent)
@@ -336,7 +336,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::PanIdTlv tlv;
         tlv.Init();
         tlv.SetPanId(aDataset.mPanId);
-        Set(tlv);
+        SetTlv(tlv);
     }
 
     if (aDataset.mComponents.mIsPskcPresent)
@@ -344,7 +344,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         MeshCoP::PskcTlv tlv;
         tlv.Init();
         tlv.SetPskc(static_cast<const Pskc &>(aDataset.mPskc));
-        Set(tlv);
+        SetTlv(tlv);
     }
 
     if (aDataset.mComponents.mIsSecurityPolicyPresent)
@@ -353,7 +353,7 @@ otError Dataset::Set(const otOperationalDataset &aDataset)
         tlv.Init();
         tlv.SetRotationTime(aDataset.mSecurityPolicy.mRotationTime);
         tlv.SetFlags(aDataset.mSecurityPolicy.mFlags);
-        Set(tlv);
+        SetTlv(tlv);
     }
 
     mUpdateTime = TimerMilli::GetNow();
@@ -367,13 +367,13 @@ const Timestamp *Dataset::GetTimestamp(void) const
 
     if (mType == kActive)
     {
-        const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(Get(Tlv::kActiveTimestamp));
+        const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(GetTlv(Tlv::kActiveTimestamp));
         VerifyOrExit(tlv != NULL, OT_NOOP);
         timestamp = static_cast<const Timestamp *>(tlv);
     }
     else
     {
-        const PendingTimestampTlv *tlv = static_cast<const PendingTimestampTlv *>(Get(Tlv::kPendingTimestamp));
+        const PendingTimestampTlv *tlv = static_cast<const PendingTimestampTlv *>(GetTlv(Tlv::kPendingTimestamp));
         VerifyOrExit(tlv != NULL, OT_NOOP);
         timestamp = static_cast<const Timestamp *>(tlv);
     }
@@ -389,22 +389,22 @@ void Dataset::SetTimestamp(const Timestamp &aTimestamp)
         ActiveTimestampTlv activeTimestamp;
         activeTimestamp.Init();
         *static_cast<Timestamp *>(&activeTimestamp) = aTimestamp;
-        Set(activeTimestamp);
+        SetTlv(activeTimestamp);
     }
     else
     {
         PendingTimestampTlv pendingTimestamp;
         pendingTimestamp.Init();
         *static_cast<Timestamp *>(&pendingTimestamp) = aTimestamp;
-        Set(pendingTimestamp);
+        SetTlv(pendingTimestamp);
     }
 }
 
-otError Dataset::Set(const Tlv &aTlv)
+otError Dataset::SetTlv(const Tlv &aTlv)
 {
     otError  error          = OT_ERROR_NONE;
     uint16_t bytesAvailable = sizeof(mTlvs) - mLength;
-    Tlv *    old            = Get(aTlv.GetType());
+    Tlv *    old            = GetTlv(aTlv.GetType());
 
     if (old != NULL)
     {
@@ -446,7 +446,7 @@ void Dataset::Remove(Tlv::Type aType)
 {
     Tlv *tlv;
 
-    VerifyOrExit((tlv = Get(aType)) != NULL, OT_NOOP);
+    VerifyOrExit((tlv = GetTlv(aType)) != NULL, OT_NOOP);
     Remove(reinterpret_cast<uint8_t *>(tlv), sizeof(Tlv) + tlv->GetLength());
 
 exit:

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -103,7 +103,7 @@ public:
      * @returns A pointer to the TLV or NULL if none is found.
      *
      */
-    Tlv *Get(Tlv::Type aType);
+    Tlv *GetTlv(Tlv::Type aType);
 
     /**
      * This method returns a pointer to the TLV with a given type.
@@ -113,7 +113,7 @@ public:
      * @returns A pointer to the TLV or NULL if none is found.
      *
      */
-    const Tlv *Get(Tlv::Type aType) const;
+    const Tlv *GetTlv(Tlv::Type aType) const;
 
     /**
      * This method returns a pointer to the byte representation of the Dataset.
@@ -188,7 +188,7 @@ public:
      * @retval OT_ERROR_NO_BUFS  Could not set the TLV due to insufficient buffer space.
      *
      */
-    otError Set(const Tlv &aTlv);
+    otError SetTlv(const Tlv &aTlv);
 
     /**
      * This method sets the Dataset using TLVs stored in a message buffer.

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -64,12 +64,22 @@ public:
     };
 
     /**
+     * This enumeration represents the Dataset type (active or pending).
+     *
+     */
+    enum Type
+    {
+        kActive,  ///< Active Dataset
+        kPending, ///< Pending Dataset
+    };
+
+    /**
      * This constructor initializes the object.
      *
      * @param[in]  aType       The type of the dataset, active or pending.
      *
      */
-    explicit Dataset(Tlv::Type aType);
+    explicit Dataset(Type aType);
 
     /**
      * This method clears the Dataset.
@@ -254,13 +264,21 @@ public:
      */
     void ConvertToActive(void);
 
+    /**
+     * This static method converts a Dataset Type to a string.
+     *
+     * @param[in]  aType   A Dataset type.
+     *
+     */
+    static const char *TypeToString(Type aType);
+
 private:
     void Remove(uint8_t *aStart, uint8_t aLength);
 
     uint8_t   mTlvs[kMaxSize]; ///< The Dataset buffer
     TimeMilli mUpdateTime;     ///< Local time last updated
     uint16_t  mLength;         ///< The number of valid bytes in @var mTlvs
-    Tlv::Type mType;           ///< Active or Pending
+    Type      mType;           ///< Active or Pending
 };
 
 } // namespace MeshCoP

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -137,7 +137,7 @@ public:
      * @param[out] aDataset  A reference to `otOperationalDataset` to output the Dataset.
      *
      */
-    void Get(otOperationalDataset &aDataset) const;
+    void ConvertTo(otOperationalDataset &aDataset) const;
 
     /**
      * This method returns the Dataset size in bytes.
@@ -215,15 +215,15 @@ public:
     void Set(const Dataset &aDataset);
 
     /**
-     * This method sets the Dataset.
+     * This method sets the Dataset from a given structure representation.
      *
-     * @param[in]  aDataset  The input Dataset.
+     * @param[in]  aDataset  The input Dataset as otOperationalDataset.
      *
      * @retval OT_ERROR_NONE          Successfully set the Dataset.
      * @retval OT_ERROR_INVALID_ARGS  Dataset is missing Active and/or Pending Timestamp.
      *
      */
-    otError Set(const otOperationalDataset &aDataset);
+    otError SetFrom(const otOperationalDataset &aDataset);
 
     /**
      * This method removes a TLV from the Dataset.

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -47,6 +47,10 @@
 namespace ot {
 namespace MeshCoP {
 
+/**
+ * This class represents MeshCop Dataset.
+ *
+ */
 class Dataset
 {
     friend class DatasetLocal;
@@ -82,7 +86,9 @@ public:
     bool IsValid(void) const;
 
     /**
-     * This method returns a pointer to the TLV.
+     * This method returns a pointer to the TLV with a given type.
+     *
+     * @param[in] aType  A TLV type.
      *
      * @returns A pointer to the TLV or NULL if none is found.
      *
@@ -90,7 +96,9 @@ public:
     Tlv *Get(Tlv::Type aType);
 
     /**
-     * This method returns a pointer to the TLV.
+     * This method returns a pointer to the TLV with a given type.
+     *
+     * @param[in] aType  The TLV type.
      *
      * @returns A pointer to the TLV or NULL if none is found.
      *
@@ -115,6 +123,8 @@ public:
 
     /**
      * This method converts the TLV representation to structure representation.
+     *
+     * @param[out] aDataset  A reference to `otOperationalDataset` to output the Dataset.
      *
      */
     void Get(otOperationalDataset &aDataset) const;
@@ -153,6 +163,8 @@ public:
 
     /**
      * This method sets the Timestamp value.
+     *
+     * @param[in] aTimestamp   A Timestamp.
      *
      */
     void SetTimestamp(const Timestamp &aTimestamp);
@@ -213,6 +225,8 @@ public:
 
     /**
      * This method appends the MLE Dataset TLV but excluding MeshCoP Sub Timestamp TLV.
+     *
+     * @param[in] aMessage       A message to append to.
      *
      * @retval OT_ERROR_NONE     Successfully append MLE Dataset TLV without MeshCoP Sub Timestamp TLV.
      * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to append the message with MLE Dataset TLV.

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -136,7 +136,7 @@ otError DatasetLocal::Read(otOperationalDataset &aDataset) const
     error = Read(dataset);
     SuccessOrExit(error);
 
-    dataset.Get(aDataset);
+    dataset.ConvertTo(aDataset);
 
 exit:
     return error;
@@ -147,7 +147,7 @@ otError DatasetLocal::Save(const otOperationalDataset &aDataset)
     otError error = OT_ERROR_NONE;
     Dataset dataset(mType);
 
-    error = dataset.Set(aDataset);
+    error = dataset.SetFrom(aDataset);
     SuccessOrExit(error);
 
     error = Save(dataset);

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -105,7 +105,7 @@ otError DatasetLocal::Read(Dataset &aDataset) const
     }
     else
     {
-        delayTimer = static_cast<DelayTimerTlv *>(aDataset.Get(Tlv::kDelayTimer));
+        delayTimer = static_cast<DelayTimerTlv *>(aDataset.GetTlv(Tlv::kDelayTimer));
         VerifyOrExit(delayTimer, OT_NOOP);
 
         elapsed = TimerMilli::GetNow() - mUpdateTime;

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -48,7 +48,7 @@
 namespace ot {
 namespace MeshCoP {
 
-DatasetLocal::DatasetLocal(Instance &aInstance, Tlv::Type aType)
+DatasetLocal::DatasetLocal(Instance &aInstance, Dataset::Type aType)
     : InstanceLocator(aInstance)
     , mUpdateTime(0)
     , mType(aType)
@@ -98,7 +98,7 @@ otError DatasetLocal::Read(Dataset &aDataset) const
     error = Get<Settings>().ReadOperationalDataset(IsActive(), aDataset);
     VerifyOrExit(error == OT_ERROR_NONE, aDataset.mLength = 0);
 
-    if (mType == Tlv::kActiveTimestamp)
+    if (mType == Dataset::kActive)
     {
         aDataset.Remove(Tlv::kPendingTimestamp);
         aDataset.Remove(Tlv::kDelayTimer);
@@ -167,13 +167,13 @@ otError DatasetLocal::Save(const Dataset &aDataset)
         // do not propagate error back
         Get<Settings>().DeleteOperationalDataset(IsActive());
         mSaved = false;
-        otLogInfoMeshCoP("%s dataset deleted", mType == Tlv::kActiveTimestamp ? "Active" : "Pending");
+        otLogInfoMeshCoP("%s dataset deleted", Dataset::TypeToString(mType));
     }
     else
     {
         SuccessOrExit(error = Get<Settings>().SaveOperationalDataset(IsActive(), aDataset));
         mSaved = true;
-        otLogInfoMeshCoP("%s dataset set", mType == Tlv::kActiveTimestamp ? "Active" : "Pending");
+        otLogInfoMeshCoP("%s dataset set", Dataset::TypeToString(mType));
     }
 
     timestamp = aDataset.GetTimestamp();

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -54,7 +54,7 @@ public:
      * @param[in]  aType      The type of the dataset, active or pending.
      *
      */
-    DatasetLocal(Instance &aInstance, Tlv::Type aType);
+    DatasetLocal(Instance &aInstance, Dataset::Type aType);
 
     /**
      * This method indicates whether this is an Active or Pending Dataset.
@@ -63,7 +63,7 @@ public:
      * @retval Tlv::kPendingTimetamp when this is a Pending Dataset.
      *
      */
-    Tlv::Type GetType(void) const { return mType; }
+    Dataset::Type GetType(void) const { return mType; }
 
     /**
      * This method clears the Dataset.
@@ -161,14 +161,14 @@ public:
     int Compare(const Timestamp *aCompare);
 
 private:
-    bool IsActive(void) const { return (mType == Tlv::kActiveTimestamp); }
+    bool IsActive(void) const { return (mType == Dataset::kActive); }
     void SetTimestamp(const Dataset &aDataset);
 
-    Timestamp mTimestamp;            ///< Active or Pending Timestamp
-    TimeMilli mUpdateTime;           ///< Local time last updated
-    Tlv::Type mType;                 ///< Active or Pending
-    bool      mTimestampPresent : 1; ///< Whether a timestamp is present
-    bool      mSaved : 1;            ///< Whether a dataset is saved in non-volatile
+    Timestamp     mTimestamp;            ///< Active or Pending Timestamp
+    TimeMilli     mUpdateTime;           ///< Local time last updated
+    Dataset::Type mType;                 ///< Active or Pending
+    bool          mTimestampPresent : 1; ///< Whether a timestamp is present
+    bool          mSaved : 1;            ///< Whether a dataset is saved in non-volatile
 };
 
 } // namespace MeshCoP

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -218,7 +218,7 @@ otError DatasetManager::GetChannelMask(Mac::ChannelMask &aChannelMask) const
 
     SuccessOrExit(error = mLocal.Read(dataset));
 
-    channelMaskTlv = static_cast<const MeshCoP::ChannelMaskTlv *>(dataset.Get(MeshCoP::Tlv::kChannelMask));
+    channelMaskTlv = static_cast<const MeshCoP::ChannelMaskTlv *>(dataset.GetTlv(MeshCoP::Tlv::kChannelMask));
     VerifyOrExit(channelMaskTlv != NULL, error = OT_ERROR_NOT_FOUND);
     VerifyOrExit((mask = channelMaskTlv->GetChannelMask()) != 0, OT_NOOP);
 
@@ -241,7 +241,7 @@ void DatasetManager::HandleTimer(void)
         Dataset dataset(Dataset::kPending);
         Get<PendingDataset>().Read(dataset);
 
-        const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(dataset.Get(Tlv::kActiveTimestamp));
+        const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(dataset.GetTlv(Tlv::kActiveTimestamp));
         const Timestamp *         pendingActiveTimestamp = static_cast<const Timestamp *>(tlv);
 
         if (pendingActiveTimestamp != NULL && mLocal.Compare(pendingActiveTimestamp) == 0)
@@ -377,7 +377,7 @@ void DatasetManager::SendGetResponse(const Coap::Message &   aRequest,
                 continue;
             }
 
-            if ((tlv = dataset.Get(static_cast<Tlv::Type>(aTlvs[index]))) != NULL)
+            if ((tlv = dataset.GetTlv(static_cast<Tlv::Type>(aTlvs[index]))) != NULL)
             {
                 SuccessOrExit(error = tlv->AppendTo(*message));
             }
@@ -790,7 +790,7 @@ void PendingDataset::StartDelayTimer(void)
 
     mDelayTimer.Stop();
 
-    if ((delayTimer = static_cast<DelayTimerTlv *>(dataset.Get(Tlv::kDelayTimer))) != NULL)
+    if ((delayTimer = static_cast<DelayTimerTlv *>(dataset.GetTlv(Tlv::kDelayTimer))) != NULL)
     {
         uint32_t delay = delayTimer->GetDelayTimer();
 
@@ -819,7 +819,7 @@ void PendingDataset::HandleDelayTimer(void)
 
     // if the Delay Timer value is larger than what our Timer implementation can handle, we have to compute
     // the remainder and wait some more.
-    if ((delayTimer = static_cast<DelayTimerTlv *>(dataset.Get(Tlv::kDelayTimer))) != NULL)
+    if ((delayTimer = static_cast<DelayTimerTlv *>(dataset.GetTlv(Tlv::kDelayTimer))) != NULL)
     {
         uint32_t elapsed = mDelayTimer.GetFireTime() - dataset.GetUpdateTime();
         uint32_t delay   = delayTimer->GetDelayTimer();

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -49,11 +49,11 @@
 namespace ot {
 namespace MeshCoP {
 
-DatasetManager::DatasetManager(Instance &      aInstance,
-                               const Tlv::Type aType,
-                               const char *    aUriGet,
-                               const char *    aUriSet,
-                               Timer::Handler  aTimerHandler)
+DatasetManager::DatasetManager(Instance &     aInstance,
+                               Dataset::Type  aType,
+                               const char *   aUriGet,
+                               const char *   aUriSet,
+                               Timer::Handler aTimerHandler)
     : InstanceLocator(aInstance)
     , mLocal(aInstance, aType)
     , mTimestampValid(false)
@@ -102,7 +102,7 @@ otError DatasetManager::Restore(void)
         mTimestampValid = true;
     }
 
-    if (mLocal.GetType() == Tlv::kActiveTimestamp)
+    if (mLocal.GetType() == Dataset::kActive)
     {
         dataset.ApplyConfiguration(GetInstance());
     }
@@ -150,7 +150,7 @@ otError DatasetManager::Save(const Dataset &aDataset)
         mTimestamp      = *timestamp;
         mTimestampValid = true;
 
-        if (mLocal.GetType() == Tlv::kActiveTimestamp)
+        if (mLocal.GetType() == Dataset::kActive)
         {
             SuccessOrExit(error = aDataset.ApplyConfiguration(GetInstance(), &isMasterkeyUpdated));
         }
@@ -236,9 +236,9 @@ void DatasetManager::HandleTimer(void)
 
     VerifyOrExit(mLocal.Compare(GetTimestamp()) < 0, OT_NOOP);
 
-    if (mLocal.GetType() == Tlv::kActiveTimestamp)
+    if (mLocal.GetType() == Dataset::kActive)
     {
-        Dataset dataset(Tlv::kPendingTimestamp);
+        Dataset dataset(Dataset::kPending);
         Get<PendingDataset>().Read(dataset);
 
         const ActiveTimestampTlv *tlv = static_cast<const ActiveTimestampTlv *>(dataset.Get(Tlv::kActiveTimestamp));
@@ -680,7 +680,7 @@ exit:
 
 ActiveDataset::ActiveDataset(Instance &aInstance)
     : DatasetManager(aInstance,
-                     Tlv::kActiveTimestamp,
+                     Dataset::kActive,
                      OT_URI_PATH_ACTIVE_GET,
                      OT_URI_PATH_ACTIVE_SET,
                      &ActiveDataset::HandleTimer)
@@ -728,7 +728,7 @@ void ActiveDataset::HandleTimer(Timer &aTimer)
 
 PendingDataset::PendingDataset(Instance &aInstance)
     : DatasetManager(aInstance,
-                     Tlv::kPendingTimestamp,
+                     Dataset::kPending,
                      OT_URI_PATH_PENDING_GET,
                      OT_URI_PATH_PENDING_SET,
                      &PendingDataset::HandleTimer)

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -134,7 +134,7 @@ public:
     /**
      * This method sends a MGMT_SET request to the Leader.
      *
-     * @param[in]  aDataset  The Operational Datset.
+     * @param[in]  aDataset  The Operational Dataset.
      * @param[in]  aTlvs     Any additional raw TLVs to include.
      * @param[in]  aLength   Number of bytes in @p aTlvs.
      *
@@ -173,7 +173,7 @@ protected:
      *
      */
     DatasetManager(Instance &          aInstance,
-                   Tlv::Type           aType,
+                   Dataset::Type       aType,
                    const char *        aUriGet,
                    const char *        aUriSet,
                    TimerMilli::Handler aTimerHandler);

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -241,13 +241,6 @@ protected:
      */
     void HandleTimer(void);
 
-    /**
-     * This method re-defines template `Get<Type>()` as the `InstanceLocator` (base class) definition is shadowed by
-     * the public `Get(dataset)` methods in this class.
-     *
-     */
-    template <typename Type> inline Type &Get(void) const { return InstanceLocator::Get<Type>(); }
-
     DatasetLocal mLocal;
     Timestamp    mTimestamp;
     bool         mTimestampValid : 1;

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -235,7 +235,7 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
                 // fall through
 
             default:
-                SuccessOrExit(dataset.Set(data.tlv));
+                SuccessOrExit(dataset.SetTlv(data.tlv));
                 break;
             }
 
@@ -367,80 +367,80 @@ otError ActiveDataset::GenerateLocal(void)
     mLocal.Read(dataset);
 
     // Active Timestamp
-    if (dataset.Get(Tlv::kActiveTimestamp) == NULL)
+    if (dataset.GetTlv(Tlv::kActiveTimestamp) == NULL)
     {
         ActiveTimestampTlv activeTimestampTlv;
         activeTimestampTlv.Init();
         activeTimestampTlv.SetSeconds(0);
         activeTimestampTlv.SetTicks(0);
-        dataset.Set(activeTimestampTlv);
+        dataset.SetTlv(activeTimestampTlv);
     }
 
     // Channel
-    if (dataset.Get(Tlv::kChannel) == NULL)
+    if (dataset.GetTlv(Tlv::kChannel) == NULL)
     {
         ChannelTlv tlv;
         tlv.Init();
         tlv.SetChannel(Get<Mac::Mac>().GetPanChannel());
-        dataset.Set(tlv);
+        dataset.SetTlv(tlv);
     }
 
     // channelMask
-    if (dataset.Get(Tlv::kChannelMask) == NULL)
+    if (dataset.GetTlv(Tlv::kChannelMask) == NULL)
     {
         ChannelMaskTlv tlv;
         tlv.Init();
         tlv.SetChannelMask(Get<Mac::Mac>().GetSupportedChannelMask().GetMask());
-        dataset.Set(tlv);
+        dataset.SetTlv(tlv);
     }
 
     // Extended PAN ID
-    if (dataset.Get(Tlv::kExtendedPanId) == NULL)
+    if (dataset.GetTlv(Tlv::kExtendedPanId) == NULL)
     {
         ExtendedPanIdTlv tlv;
         tlv.Init();
         tlv.SetExtendedPanId(Get<Mac::Mac>().GetExtendedPanId());
-        dataset.Set(tlv);
+        dataset.SetTlv(tlv);
     }
 
     // Mesh-Local Prefix
-    if (dataset.Get(Tlv::kMeshLocalPrefix) == NULL)
+    if (dataset.GetTlv(Tlv::kMeshLocalPrefix) == NULL)
     {
         MeshLocalPrefixTlv tlv;
         tlv.Init();
         tlv.SetMeshLocalPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-        dataset.Set(tlv);
+        dataset.SetTlv(tlv);
     }
 
     // Master Key
-    if (dataset.Get(Tlv::kNetworkMasterKey) == NULL)
+    if (dataset.GetTlv(Tlv::kNetworkMasterKey) == NULL)
     {
         NetworkMasterKeyTlv tlv;
         tlv.Init();
         tlv.SetNetworkMasterKey(Get<KeyManager>().GetMasterKey());
-        dataset.Set(tlv);
+        dataset.SetTlv(tlv);
     }
 
     // Network Name
-    if (dataset.Get(Tlv::kNetworkName) == NULL)
+    if (dataset.GetTlv(Tlv::kNetworkName) == NULL)
     {
         NetworkNameTlv tlv;
         tlv.Init();
         tlv.SetNetworkName(Get<Mac::Mac>().GetNetworkName().GetAsData());
-        dataset.Set(tlv);
+        dataset.SetTlv(tlv);
     }
 
     // Pan ID
-    if (dataset.Get(Tlv::kPanId) == NULL)
+    if (dataset.GetTlv(Tlv::kPanId) == NULL)
     {
         PanIdTlv tlv;
         tlv.Init();
         tlv.SetPanId(Get<Mac::Mac>().GetPanId());
-        dataset.Set(tlv);
+        dataset.SetTlv(tlv);
     }
 
     // PSKc
-    if (dataset.Get(Tlv::kPskc) == NULL)
+    if (dataset.GetTlv(Tlv::kPskc) == NULL)
     {
         PskcTlv tlv;
 
@@ -460,17 +460,17 @@ otError ActiveDataset::GenerateLocal(void)
             tlv.SetPskc(pskc);
         }
 
-        dataset.Set(tlv);
+        dataset.SetTlv(tlv);
     }
 
     // Security Policy
-    if (dataset.Get(Tlv::kSecurityPolicy) == NULL)
+    if (dataset.GetTlv(Tlv::kSecurityPolicy) == NULL)
     {
         SecurityPolicyTlv tlv;
         tlv.Init();
         tlv.SetRotationTime(static_cast<uint16_t>(Get<KeyManager>().GetKeyRotation()));
         tlv.SetFlags(Get<KeyManager>().GetSecurityPolicyFlags());
-        dataset.Set(tlv);
+        dataset.SetTlv(tlv);
     }
 
     SuccessOrExit(error = mLocal.Save(dataset));
@@ -553,14 +553,14 @@ void PendingDataset::ApplyActiveDataset(const Timestamp &aTimestamp, Coap::Messa
 
         aMessage.Read(offset, sizeof(Tlv), &data.tlv);
         aMessage.Read(offset + sizeof(Tlv), data.tlv.GetLength(), data.value);
-        dataset.Set(data.tlv);
+        dataset.SetTlv(data.tlv);
         offset += sizeof(Tlv) + data.tlv.GetLength();
     }
 
     // add delay timer tlv
     delayTimer.Init();
     delayTimer.SetDelayTimer(Get<Leader>().GetDelayTimerMinimal());
-    dataset.Set(delayTimer);
+    dataset.SetTlv(delayTimer);
 
     // add pending timestamp tlv
     dataset.SetTimestamp(aTimestamp);

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -343,7 +343,7 @@ Coap::Message *JoinerRouter::PrepareJoinerEntrustMessage(void)
 {
     otError        error;
     Coap::Message *message = NULL;
-    Dataset        dataset(MeshCoP::Tlv::kActiveTimestamp);
+    Dataset        dataset(Dataset::kActive);
 
     NetworkNameTlv networkName;
     const Tlv *    tlv;

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -370,7 +370,7 @@ Coap::Message *JoinerRouter::PrepareJoinerEntrustMessage(void)
 
     Get<ActiveDataset>().Read(dataset);
 
-    if ((tlv = dataset.Get(Tlv::kActiveTimestamp)) != NULL)
+    if ((tlv = dataset.GetTlv(Tlv::kActiveTimestamp)) != NULL)
     {
         SuccessOrExit(error = tlv->AppendTo(*message));
     }
@@ -381,7 +381,7 @@ Coap::Message *JoinerRouter::PrepareJoinerEntrustMessage(void)
         SuccessOrExit(error = activeTimestamp.AppendTo(*message));
     }
 
-    if ((tlv = dataset.Get(Tlv::kChannelMask)) != NULL)
+    if ((tlv = dataset.GetTlv(Tlv::kChannelMask)) != NULL)
     {
         SuccessOrExit(error = tlv->AppendTo(*message));
     }
@@ -392,7 +392,7 @@ Coap::Message *JoinerRouter::PrepareJoinerEntrustMessage(void)
         SuccessOrExit(error = channelMask.AppendTo(*message));
     }
 
-    if ((tlv = dataset.Get(Tlv::kPskc)) != NULL)
+    if ((tlv = dataset.GetTlv(Tlv::kPskc)) != NULL)
     {
         SuccessOrExit(error = tlv->AppendTo(*message));
     }
@@ -403,7 +403,7 @@ Coap::Message *JoinerRouter::PrepareJoinerEntrustMessage(void)
         SuccessOrExit(error = pskc.AppendTo(*message));
     }
 
-    if ((tlv = dataset.Get(Tlv::kSecurityPolicy)) != NULL)
+    if ((tlv = dataset.GetTlv(Tlv::kSecurityPolicy)) != NULL)
     {
         SuccessOrExit(error = tlv->AppendTo(*message));
     }

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -501,7 +501,7 @@ otError RadioSpinel::ThreadDatasetHandler(const uint8_t *aBuffer, uint16_t aLeng
     otOperationalDataset opDataset;
     bool                 isActive = ((mWaitingKey == SPINEL_PROP_THREAD_ACTIVE_DATASET) ? true : false);
     Spinel::Decoder      decoder;
-    MeshCoP::Dataset     dataset(isActive ? MeshCoP::Tlv::kActiveTimestamp : MeshCoP::Tlv::kPendingTimestamp);
+    MeshCoP::Dataset     dataset(isActive ? MeshCoP::Dataset::kActive : MeshCoP::Dataset::kPending);
 
     memset(&opDataset, 0, sizeof(otOperationalDataset));
     decoder.Init(aBuffer, aLength);

--- a/src/posix/platform/radio_spinel.cpp
+++ b/src/posix/platform/radio_spinel.cpp
@@ -639,7 +639,7 @@ otError RadioSpinel::ThreadDatasetHandler(const uint8_t *aBuffer, uint16_t aLeng
     opDataset.mActiveTimestamp                      = 0;
     opDataset.mComponents.mIsActiveTimestampPresent = true;
 
-    SuccessOrExit(error = dataset.Set(opDataset));
+    SuccessOrExit(error = dataset.SetFrom(opDataset));
     SuccessOrExit(error = otPlatSettingsSet(
                       mInstance, isActive ? SettingsBase::kKeyActiveDataset : SettingsBase::kKeyPendingDataset,
                       dataset.GetBytes(), dataset.GetSize()));


### PR DESCRIPTION
This commit contains multiple enhancements in `Dataset` modules. It
adds a new enumeration `Type` to specify the type of a Dataset
(active or pending). It also renames the methods that get or a set a
TLV within the dataset to `GetTlv()` and `SetTlv()`. It also renames
methods converting the TLV format to/from an `otOperationalDataset`
structure. With the renames, we can remove the re-definition of
`Get<Type>()` method (since no longer being shadowed by other
definitions). Finally this commit updates some of the method
documentation.

----

I kept the commits separate for easier review but for meting would suggest to squash them all. The first commit contains the full log message.