### PR TITLE
[mle] fix MLE Router handling errors

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2993,6 +2993,9 @@ otError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &a
     uint16_t            pendingDatasetOffset = 0;
     bool                dataRequest          = false;
     Tlv                 tlv;
+    RouterIdSet         routerIdSet;
+
+    OT_UNUSED_VARIABLE(routerIdSet);
 
     // Leader Data
     SuccessOrExit(error = ReadLeaderData(aMessage, leaderData));
@@ -3004,6 +3007,16 @@ otError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &a
         {
             SetLeaderData(leaderData.GetPartitionId(), leaderData.GetWeighting(), leaderData.GetLeaderRouterId());
             mRetrieveNewNetworkData = true;
+
+#if OPENTHREAD_FTD
+            if (IsFullThreadDevice())
+            {
+                routerIdSet.Clear();
+                routerIdSet.Add(GetLeaderId());
+                routerIdSet.Add(GetParent().GetRouterId());
+                Get<RouterTable>().UpdateRouterIdSet(0, routerIdSet);
+            }
+#endif
         }
         else
         {

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1636,6 +1636,7 @@ protected:
     bool          mRetrieveNewNetworkData;   ///< Indicating new Network Data is needed if set.
     DeviceRole    mRole;                     ///< Current Thread role.
     Router        mParent;                   ///< Parent information.
+    Router        mParentCandidate;          ///< Parent candidate information.
     DeviceMode    mDeviceMode;               ///< Device mode setting.
     AttachState   mAttachState;              ///< The parent request state.
     ReattachState mReattachState;            ///< Reattach state
@@ -1781,7 +1782,6 @@ private:
     bool       mReceivedResponseFromParent;
     LeaderData mParentLeaderData;
 
-    Router    mParentCandidate;
     Challenge mParentCandidateChallenge;
 
     Ip6::UdpSocket mSocket;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1284,6 +1284,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
         if (processRouteTlv)
         {
             SuccessOrExit(error = ProcessRouteTlv(route));
+            aNeighbor = NULL; // aNeighbor is no longer valid after `ProcessRouteTlv`
         }
     }
 
@@ -2237,6 +2238,7 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     router = mRouterTable.GetRouter(macAddr);
     if (router != NULL)
     {
+        // The `router` here can be invalid
         RemoveNeighbor(*router);
     }
 
@@ -3330,6 +3332,8 @@ void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
     }
     else if (aNeighbor.IsStateValid())
     {
+        OT_ASSERT(mRouterTable.GetRouterIndex(static_cast<Router &>(aNeighbor)) < kMaxRouters);
+
         Signal(OT_NEIGHBOR_TABLE_EVENT_ROUTER_REMOVED, aNeighbor);
         mRouterTable.RemoveRouterLink(static_cast<Router &>(aNeighbor));
     }

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3300,7 +3300,7 @@ void MleRouter::RemoveRouterLink(Router &aRouter)
 
 void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
 {
-    VerifyOrExit(!aNeighbor.IsStateInvalid());
+    VerifyOrExit(!aNeighbor.IsStateInvalid(), OT_NOOP);
 
     if (&aNeighbor == &mParent || &aNeighbor == &mParentCandidate)
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1284,7 +1284,10 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
         if (processRouteTlv)
         {
             SuccessOrExit(error = ProcessRouteTlv(route));
-            aNeighbor = NULL; // aNeighbor is no longer valid after `ProcessRouteTlv`
+            if (Get<RouterTable>().GetRouterIndex(static_cast<Router &>(*aNeighbor)) < kMaxRouters)
+            {
+                aNeighbor = NULL; // aNeighbor is no longer valid after `ProcessRouteTlv`
+            }
         }
     }
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1423,7 +1423,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
     UpdateRoutes(route, routerId);
 
 exit:
-    if (sourceAddress != 0xFFFF && aNeighbor && aNeighbor->GetRloc16() != sourceAddress)
+    if (aNeighbor && aNeighbor->GetRloc16() != sourceAddress)
     {
         // Remove stale neighbors
         RemoveNeighbor(*aNeighbor);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1166,7 +1166,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
     const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
     uint8_t linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
     Mac::ExtAddress macAddr;
-    uint16_t        sourceAddress;
+    uint16_t        sourceAddress = 0xFFFF;
     LeaderData      leaderData;
     RouteTlv        route;
     uint32_t        partitionId;
@@ -1423,7 +1423,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
     UpdateRoutes(route, routerId);
 
 exit:
-    if (aNeighbor && aNeighbor->GetRloc16() != sourceAddress)
+    if (sourceAddress != 0xFFFF && aNeighbor && aNeighbor->GetRloc16() != sourceAddress)
     {
         // Remove stale neighbors
         RemoveNeighbor(*aNeighbor);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3300,6 +3300,8 @@ void MleRouter::RemoveRouterLink(Router &aRouter)
 
 void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
 {
+    VerifyOrExit(!aNeighbor.IsStateInvalid());
+
     if (&aNeighbor == &mParent || &aNeighbor == &mParentCandidate)
     {
         if (IsChild())
@@ -3334,6 +3336,9 @@ void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
 
     aNeighbor.GetLinkInfo().Clear();
     aNeighbor.SetState(Neighbor::kStateInvalid);
+
+exit:
+    return;
 }
 
 Neighbor *MleRouter::GetNeighbor(uint16_t aAddress)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1166,7 +1166,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
     const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
     uint8_t linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
     Mac::ExtAddress macAddr;
-    uint16_t        sourceAddress = 0xFFFF;
+    uint16_t        sourceAddress = Mac::kShortAddrInvalid;
     LeaderData      leaderData;
     RouteTlv        route;
     uint32_t        partitionId;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1284,7 +1284,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
         if (processRouteTlv)
         {
             SuccessOrExit(error = ProcessRouteTlv(route));
-            if (Get<RouterTable>().GetRouterIndex(static_cast<Router &>(*aNeighbor)) < kMaxRouters)
+            if (Get<RouterTable>().Contains(*aNeighbor))
             {
                 aNeighbor = NULL; // aNeighbor is no longer valid after `ProcessRouteTlv`
             }
@@ -3339,7 +3339,7 @@ void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
     }
     else if (aNeighbor.IsStateValid())
     {
-        OT_ASSERT(mRouterTable.GetRouterIndex(static_cast<Router &>(aNeighbor)) < kMaxRouters);
+        OT_ASSERT(mRouterTable.Contains(aNeighbor));
 
         Signal(OT_NEIGHBOR_TABLE_EVENT_ROUTER_REMOVED, aNeighbor);
         mRouterTable.RemoveRouterLink(static_cast<Router &>(aNeighbor));

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3304,12 +3304,16 @@ void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
 {
     VerifyOrExit(!aNeighbor.IsStateInvalid(), OT_NOOP);
 
-    if (&aNeighbor == &mParent || &aNeighbor == &mParentCandidate)
+    if (&aNeighbor == &mParent)
     {
         if (IsChild())
         {
             IgnoreError(BecomeDetached());
         }
+    }
+    else if (&aNeighbor == &mParentCandidate)
+    {
+        mParentCandidate.Clear();
     }
     else if (!IsActiveRouter(aNeighbor.GetRloc16()))
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3300,7 +3300,7 @@ void MleRouter::RemoveRouterLink(Router &aRouter)
 
 void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
 {
-    if (&aNeighbor == &mParent)
+    if (&aNeighbor == &mParent || &aNeighbor == &mParentCandidate)
     {
         if (IsChild())
         {
@@ -3309,6 +3309,8 @@ void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
     }
     else if (!IsActiveRouter(aNeighbor.GetRloc16()))
     {
+        OT_ASSERT(mChildTable.GetChildIndex(static_cast<Child &>(aNeighbor)) < kMaxChildren);
+
         if (aNeighbor.IsStateValidOrRestoring())
         {
             Signal(OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED, aNeighbor);

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -266,14 +266,18 @@ public:
     Router *GetRouter(const Mac::ExtAddress &aExtAddress);
 
     /**
-     * This method returns the router table index for a given `Router` instance.
+     * This method returns if the router table contains a given `Neighbor` instance.
      *
-     * @param[in]  aRouter  A reference to a `Router`
+     * @param[in]  aNeighbor  A reference to a `Neighbor`.
      *
-     * @returns The index corresponding to @p aRouter.
+     * @returns Whether the router table contains @p aNeighbor.
      *
      */
-    size_t GetRouterIndex(const Router &aRouter) const { return static_cast<uint16_t>(&aRouter - mRouters); }
+    bool Contains(const Neighbor &aNeighbor) const
+    {
+        return mRouters <= &static_cast<const Router &>(aNeighbor) &&
+               &static_cast<const Router &>(aNeighbor) < mRouters + Mle::kMaxRouters;
+    }
 
     /**
      * This method retains diagnostic information for a given router.

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -272,7 +272,7 @@ public:
      *
      * @retval TRUE  if @p aNeighbor is a `Router` in the router table.
      * @retval FALSE if @p aNeighbor is not a `Router` in the router table
-     *               (e.x. mParent, mParentCandidate, a `Child` of the child table).
+     *               (i.e. mParent, mParentCandidate, a `Child` of the child table).
      *
      */
     bool Contains(const Neighbor &aNeighbor) const

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -270,7 +270,9 @@ public:
      *
      * @param[in]  aNeighbor  A reference to a `Neighbor`.
      *
-     * @returns Whether the router table contains @p aNeighbor.
+     * @retval TRUE  if @p aNeighbor is a `Router` in the router table.
+     * @retval FALSE if @p aNeighbor is not a `Router` in the router table
+     *               (e.x. mParent, mParentCandidate, a `Child` of the child table).
      *
      */
     bool Contains(const Neighbor &aNeighbor) const

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -266,6 +266,16 @@ public:
     Router *GetRouter(const Mac::ExtAddress &aExtAddress);
 
     /**
+     * This method returns the router table index for a given `Router` instance.
+     *
+     * @param[in]  aRouter  A reference to a `Router`
+     *
+     * @returns The index corresponding to @p aRouter.
+     *
+     */
+    uint16_t GetRouterIndex(const Router &aRouter) const { return static_cast<uint16_t>(&aRouter - mRouters); }
+
+    /**
      * This method retains diagnostic information for a given router.
      *
      * @param[in]   aRouterId    The router ID or RLOC16 for a given router.

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -273,7 +273,7 @@ public:
      * @returns The index corresponding to @p aRouter.
      *
      */
-    uint16_t GetRouterIndex(const Router &aRouter) const { return static_cast<uint16_t>(&aRouter - mRouters); }
+    size_t GetRouterIndex(const Router &aRouter) const { return static_cast<uint16_t>(&aRouter - mRouters); }
 
     /**
      * This method retains diagnostic information for a given router.

--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -621,3 +621,4 @@ def create_default_simulator():
     if VIRTUAL_TIME:
         return simulator.VirtualTime()
     return simulator.RealTime()
+  

--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -621,4 +621,3 @@ def create_default_simulator():
     if VIRTUAL_TIME:
         return simulator.VirtualTime()
     return simulator.RealTime()
-  


### PR DESCRIPTION
This PR tries to fix the [assertion failure](https://github.com/openthread/openthread/issues/4508#issuecomment-615899675) that occurred when simulating 8x8 nodes forming one partition by [OTNS form_partition.py](https://github.com/openthread/ot-ns/blob/master/pylibs/examples/form_partition.py). 

This bug was found when trying to resolve an issue in #4508. 