### PR TITLE
[dua] MTD prioritizes DUA in AR Tlv

### DIFF
--- a/src/core/backbone_router/leader.hpp
+++ b/src/core/backbone_router/leader.hpp
@@ -166,7 +166,7 @@ private:
 #endif
 
     BackboneRouterConfig mConfig;       ///< Primary Backbone Router information.
-    otIp6Prefix          mDomainPrefix; ///< Domain Prefix on the Thread Network.
+    otIp6Prefix          mDomainPrefix; ///< Domain Prefix in the Thread network.
 };
 
 } // namespace BackboneRouter

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -51,6 +51,7 @@ DuaManager::DuaManager(Instance &aInstance)
 {
     mDomainUnicastAddress.Clear();
     mDomainUnicastAddress.mPreferred          = true;
+    mDomainUnicastAddress.mValid              = true;
     mDomainUnicastAddress.mScopeOverride      = Ip6::Address::kGlobalScope;
     mDomainUnicastAddress.mScopeOverrideValid = true;
 }
@@ -79,7 +80,6 @@ void DuaManager::UpdateDomainUnicastAddress(BackboneRouter::Leader::DomainPrefix
 
     if (Get<Utils::Slaac>().GenerateIid(mDomainUnicastAddress, NULL, 0, &mDadCounter) == OT_ERROR_NONE)
     {
-        mDomainUnicastAddress.mValid = true;
         Get<ThreadNetif>().AddUnicastAddress(mDomainUnicastAddress);
     }
     else

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -64,6 +64,7 @@ void DuaManager::UpdateDomainUnicastAddress(BackboneRouter::Leader::DomainPrefix
         (aState == BackboneRouter::Leader::kDomainPrefixRefreshed))
     {
         Get<ThreadNetif>().RemoveUnicastAddress(mDomainUnicastAddress);
+        mDomainUnicastAddress.GetAddress().Clear();
     }
 
     VerifyOrExit((aState == BackboneRouter::Leader::kDomainPrefixAdded) ||
@@ -74,7 +75,6 @@ void DuaManager::UpdateDomainUnicastAddress(BackboneRouter::Leader::DomainPrefix
 
     OT_ASSERT(prefix != NULL);
 
-    mDomainUnicastAddress.GetAddress().Clear();
     mDomainUnicastAddress.GetAddress().SetPrefix(prefix->mPrefix.mFields.m8, prefix->mLength);
     mDomainUnicastAddress.mPrefixLength = prefix->mLength;
 
@@ -84,6 +84,7 @@ void DuaManager::UpdateDomainUnicastAddress(BackboneRouter::Leader::DomainPrefix
     }
     else
     {
+        mDomainUnicastAddress.GetAddress().Clear();
         otLogWarnCore("Failed to generate valid DUA");
     }
 

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -82,15 +82,12 @@ public:
     void UpdateDomainUnicastAddress(BackboneRouter::Leader::DomainPrefixState aState);
 
     /**
-     * This method returns a pointer to the Domain Unicast Address.
+     * This method returns a reference to the Domain Unicast Address.
      *
-     * @returns A pointer to the Domain Unicast Address or NULL if no valid Domain Unicast Address.
+     * @returns A reference to the Domain Unicast Address.
      *
      */
-    const Ip6::Address *GetDomainUnicastAddress(void) const
-    {
-        return mDomainUnicastAddress.mValid ? &mDomainUnicastAddress.GetAddress() : NULL;
-    }
+    const Ip6::Address &GetDomainUnicastAddress(void) const { return mDomainUnicastAddress.GetAddress(); }
 
 private:
     Ip6::NetifUnicastAddress mDomainUnicastAddress;

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -81,6 +81,17 @@ public:
      */
     void UpdateDomainUnicastAddress(BackboneRouter::Leader::DomainPrefixState aState);
 
+    /**
+     * This method returns a pointer to the Domain Unicast Address.
+     *
+     * @returns A pointer to the Domain Unicast Address or NULL if no valid Domain Unicast Address.
+     *
+     */
+    const Ip6::Address *GetDomainUnicastAddress(void) const
+    {
+        return mDomainUnicastAddress.mValid ? &mDomainUnicastAddress.GetAddress() : NULL;
+    }
+
 private:
     Ip6::NetifUnicastAddress mDomainUnicastAddress;
     uint8_t                  mDadCounter;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1362,17 +1362,18 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     {
-        const Ip6::Address *dua = Get<DuaManager>().GetDomainUnicastAddress();
+        // Cache Domain Unicast Address.
+        address = Get<DuaManager>().GetDomainUnicastAddress();
 
-        if (dua && Get<ThreadNetif>().IsUnicastAddress(*dua))
+        if (Get<ThreadNetif>().IsUnicastAddress(address))
         {
-            error = Get<NetworkData::Leader>().GetContext(*dua, context);
+            error = Get<NetworkData::Leader>().GetContext(address, context);
 
             OT_ASSERT(error == OT_ERROR_NONE);
 
             // Prioritize DUA, compressed entry
             entry.SetContextId(context.mContextId);
-            entry.SetIid(dua->GetIid());
+            entry.SetIid(address.GetIid());
             SuccessOrExit(error = aMessage.Append(&entry, entry.GetLength()));
             length += entry.GetLength();
             counter++;
@@ -1390,7 +1391,7 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
         // Here skips DUA which was appended already.
-        if (&addr->GetAddress() == Get<DuaManager>().GetDomainUnicastAddress())
+        if (addr->GetAddress() == address)
         {
             continue;
         }

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1361,23 +1361,21 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
     counter++;
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
+    // Cache Domain Unicast Address.
+    address = Get<DuaManager>().GetDomainUnicastAddress();
+
+    if (Get<ThreadNetif>().IsUnicastAddress(address))
     {
-        // Cache Domain Unicast Address.
-        address = Get<DuaManager>().GetDomainUnicastAddress();
+        error = Get<NetworkData::Leader>().GetContext(address, context);
 
-        if (Get<ThreadNetif>().IsUnicastAddress(address))
-        {
-            error = Get<NetworkData::Leader>().GetContext(address, context);
+        OT_ASSERT(error == OT_ERROR_NONE);
 
-            OT_ASSERT(error == OT_ERROR_NONE);
-
-            // Prioritize DUA, compressed entry
-            entry.SetContextId(context.mContextId);
-            entry.SetIid(address.GetIid());
-            SuccessOrExit(error = aMessage.Append(&entry, entry.GetLength()));
-            length += entry.GetLength();
-            counter++;
-        }
+        // Prioritize DUA, compressed entry
+        entry.SetContextId(context.mContextId);
+        entry.SetIid(address.GetIid());
+        SuccessOrExit(error = aMessage.Append(&entry, entry.GetLength()));
+        length += entry.GetLength();
+        counter++;
     }
 #endif // OPENTHREAD_CONFIG_DUA_ENABLE
 
@@ -1390,7 +1388,7 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
         }
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
-        // Here skips DUA which was appended already.
+        // Skip DUA that was already appended above.
         if (addr->GetAddress() == address)
         {
             continue;


### PR DESCRIPTION
Thread 1.2 spec requires prioritizing DUA in AR TLV to ensure DUA could be stored in the limited addresses space for Child on the parent.

This PR depends on #4854 , please only review the last commit which is the purpose of this PR.