### PR TITLE
[nrf52811] use the default heap size to save RAM

### DIFF
--- a/examples/platforms/nrf528xx/nrf52811/openthread-core-nrf52811-config.h
+++ b/examples/platforms/nrf528xx/nrf52811/openthread-core-nrf52811-config.h
@@ -163,26 +163,6 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE
- *
- * The size of heap buffer when DTLS is enabled.
- *
- */
-#ifndef OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE
-#define OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE (4096 * sizeof(void *))
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE_NO_DTLS
- *
- * The size of heap buffer when DTLS is disabled.
- *
- */
-#ifndef OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE_NO_DTLS
-#define OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE_NO_DTLS 2048
-#endif
-
-/**
  * @def OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
  *
  * Define as 1 to enable the time synchronization service feature.


### PR DESCRIPTION
This PR resolves the issue #4861.
The nRF52811 is designed to work in RCP architecture where DTLS is
established on the host level. The nRF52811 doesn't support Joiner
or Border Agent roles. This PR enables nRF52811 to use default heap
size to save RAM.