### PR TITLE
[platform] fix errno undefined on some libc

### DIFF
--- a/src/lib/platform/exit_code.c
+++ b/src/lib/platform/exit_code.c
@@ -68,7 +68,11 @@ const char *otExitCodeToString(uint8_t aExitCode)
         break;
 
     case OT_EXIT_ERROR_ERRNO:
+#ifdef errno
         retval = strerror(errno);
+#else
+        retval = "ErrorNo";
+#endif
         break;
 
     default:


### PR DESCRIPTION
Similar to the errno walkaround in `src/lib/spinel/spinel.c`.

```C
#if defined(errno) && SPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR
#error "SPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR is set but errno is already defined."
#endif

// Work-around for platforms that don't implement the `errno` variable.
#if !defined(errno) && SPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR
static int spinel_errno_workaround_;
#define errno spinel_errno_workaround_
#endif // SPINEL_PLATFORM_DOESNT_IMPLEMENT_ERRNO_VAR
```