### PR TITLE
[script] remove 'tmp' directory for each simulation

### DIFF
--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -577,4 +577,6 @@ def create_default_simulator():
 
 
 def _clear_tmp_files():
-    os.system(f"rm -f tmp/{PORT_OFFSET}_*.flash tmp/{PORT_OFFSET}_*.data tmp/{PORT_OFFSET}_*.swap")
+    os.system(
+        f"rm -f tmp/{PORT_OFFSET}_*.flash tmp/{PORT_OFFSET}_*.data tmp/{PORT_OFFSET}_*.swap"
+    )

--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -28,7 +28,6 @@
 #
 from enum import Enum
 import os
-import shutil
 
 from tlvs_parsing import SubTlvsFactory
 import coap
@@ -106,6 +105,8 @@ VIRTUAL_TIME = int(os.getenv('VIRTUAL_TIME', 0))
 LEADER_NOTIFY_SED_BY_CHILD_UPDATE_REQUEST = True
 
 PROTOCOL_VERSION = 2
+
+PORT_OFFSET = int(os.getenv('PORT_OFFSET', '0'))
 
 
 def create_default_network_data_prefix_sub_tlvs_factories():
@@ -568,8 +569,12 @@ def create_default_thread_sniffer():
 
 
 def create_default_simulator():
-    shutil.rmtree("tmp", ignore_errors=True)
+    _clear_tmp_files()
 
     if VIRTUAL_TIME:
         return simulator.VirtualTime()
     return simulator.RealTime()
+
+
+def _clear_tmp_files():
+    os.system(f"rm -f tmp/{PORT_OFFSET}_*.flash tmp/{PORT_OFFSET}_*.data tmp/{PORT_OFFSET}_*.swap")

--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -28,6 +28,7 @@
 #
 from enum import Enum
 import os
+import shutil
 
 from tlvs_parsing import SubTlvsFactory
 import coap
@@ -567,6 +568,8 @@ def create_default_thread_sniffer():
 
 
 def create_default_simulator():
+    shutil.rmtree("tmp", ignore_errors=True)
+
     if VIRTUAL_TIME:
         return simulator.VirtualTime()
     return simulator.RealTime()


### PR DESCRIPTION
Currently we remove `tmp` directory in `script/cert` or `test-driver` before running each test case. However, there is nothing prevent us to have multiple tests in one unit tests, e.x. [test_reed_address_solicit_rejected.py](https://github.com/openthread/openthread/blob/master/tests/scripts/thread-cert/test_reed_address_solicit_rejected.py).

This PR removes `tmp` directory to give each simulation a clean start.

**[test_reed_address_solicit_rejected.py](https://github.com/openthread/openthread/blob/master/tests/scripts/thread-cert/test_reed_address_solicit_rejected.py) has a small chance to fail without this fix.**