### PR TITLE
[cmake] move cc1352 & cc2652 libs to third-party cmake file

### DIFF
--- a/examples/platforms/cc1352/CMakeLists.txt
+++ b/examples/platforms/cc1352/CMakeLists.txt
@@ -42,7 +42,7 @@ list(APPEND OT_PRIVATE_DEFINES "MBEDTLS_USER_CONFIG_FILE=\"cc1352-mbedtls-config
 set(OT_PRIVATE_DEFINES ${OT_PRIVATE_DEFINES} PARENT_SCOPE)
 
 list(APPEND OT_PUBLIC_INCLUDES
-    "${PROJECT_SOURCE_DIR}/examples/platforms/cc1352/crypto"
+    "${CMAKE_CURRENT_SOURCE_DIR}/crypto"
     "${PROJECT_SOURCE_DIR}/third_party/ti/devices/cc13x2_cc26x2"
 )
 set(OT_PUBLIC_INCLUDES ${OT_PUBLIC_INCLUDES} PARENT_SCOPE)
@@ -68,14 +68,12 @@ add_library(openthread-cc1352
 set_property(TARGET openthread-cc1352 PROPERTY C_STANDARD 99)
 
 target_link_libraries(openthread-cc1352
+    PUBLIC
+        cc13x2-cc26x2-driver
     PRIVATE
-        "${PROJECT_SOURCE_DIR}/third_party/ti/devices/cc13x2_cc26x2/driverlib/bin/gcc/driverlib.a"
         ${OT_MBEDTLS}
 )
-target_link_options(openthread-cc1352
-    PUBLIC
-        -T${PROJECT_SOURCE_DIR}/third_party/ti/devices/cc13x2_cc26x2/linker_files/cc26x2r1f.lds
-)
+
 target_link_options(openthread-cc1352
     PUBLIC
         -Wl,--gc-sections
@@ -97,6 +95,4 @@ target_include_directories(openthread-cc1352
         ${OT_PRIVATE_INCLUDES}
         ${PROJECT_SOURCE_DIR}/src/core
         ${PROJECT_SOURCE_DIR}/examples/platforms
-        ${PROJECT_SOURCE_DIR}/third_party/mbedtls/repo/include
-        ${PROJECT_SOURCE_DIR}/third_party/mbedtls
 )

--- a/examples/platforms/cc2652/CMakeLists.txt
+++ b/examples/platforms/cc2652/CMakeLists.txt
@@ -42,7 +42,7 @@ list(APPEND OT_PRIVATE_DEFINES "MBEDTLS_USER_CONFIG_FILE=\"cc2652-mbedtls-config
 set(OT_PRIVATE_DEFINES ${OT_PRIVATE_DEFINES} PARENT_SCOPE)
 
 list(APPEND OT_PUBLIC_INCLUDES
-    "${PROJECT_SOURCE_DIR}/examples/platforms/cc2652/crypto"
+    "${CMAKE_CURRENT_SOURCE_DIR}/crypto"
     "${PROJECT_SOURCE_DIR}/third_party/ti/devices/cc13x2_cc26x2"
 )
 set(OT_PUBLIC_INCLUDES ${OT_PUBLIC_INCLUDES} PARENT_SCOPE)
@@ -68,15 +68,15 @@ add_library(openthread-cc2652
 set_property(TARGET openthread-cc2652 PROPERTY C_STANDARD 99)
 
 target_link_libraries(openthread-cc2652
+    PUBLIC
+        cc13x2-cc26x2-driver
     PRIVATE
-        "${PROJECT_SOURCE_DIR}/third_party/ti/devices/cc13x2_cc26x2/driverlib/bin/gcc/driverlib.a"
         ${OT_MBEDTLS}
 )
+
 target_link_options(openthread-cc2652
     PUBLIC
-        -T${PROJECT_SOURCE_DIR}/third_party/ti/devices/cc13x2_cc26x2/linker_files/cc26x2r1f.lds
         -Wl,--gc-sections
-        -Wl,-Map=$<TARGET_PROPERTY:NAME>.map
 )
 
 target_compile_definitions(openthread-cc2652
@@ -97,6 +97,4 @@ target_include_directories(openthread-cc2652
         ${OT_PRIVATE_INCLUDES}
         ${PROJECT_SOURCE_DIR}/src/core
         ${PROJECT_SOURCE_DIR}/examples/platforms
-        ${PROJECT_SOURCE_DIR}/third_party/mbedtls/repo/include
-        ${PROJECT_SOURCE_DIR}/third_party/mbedtls
 )

--- a/third_party/CMakeLists.txt
+++ b/third_party/CMakeLists.txt
@@ -32,7 +32,7 @@ endif()
 
 if(OT_PLATFORM STREQUAL "kw41z")
     add_subdirectory(nxp)
-elseif(OT_PLATFORM STREQUAL "cc2650")
+elseif(OT_PLATFORM MATCHES "cc*")
     add_subdirectory(ti)
 elseif(OT_PLATFORM STREQUAL "qpg6095")
     add_subdirectory(Qorvo)

--- a/third_party/ti/CMakeLists.txt
+++ b/third_party/ti/CMakeLists.txt
@@ -38,7 +38,7 @@ if(OT_PLATFORM STREQUAL "cc2650")
         INTERFACE
             -T${CMAKE_CURRENT_SOURCE_DIR}/devices/cc26x0/linker_files/cc26x0f128.lds
     )
-elseif(OT_PLATFORM MATCHES "cc(13|26)[0-9]2")
+elseif(OT_PLATFORM STREQUAL "cc1352" OR OT_PLATFORM STREQUAL "cc2652")
     add_library(cc13x2-cc26x2-driver INTERFACE)
 
     target_link_libraries(cc13x2-cc26x2-driver

--- a/third_party/ti/CMakeLists.txt
+++ b/third_party/ti/CMakeLists.txt
@@ -38,4 +38,16 @@ if(OT_PLATFORM STREQUAL "cc2650")
         INTERFACE
             -T${CMAKE_CURRENT_SOURCE_DIR}/devices/cc26x0/linker_files/cc26x0f128.lds
     )
+elseif(OT_PLATFORM MATCHES "cc(13|26)[0-9]2")
+    add_library(cc13x2-cc26x2-driver INTERFACE)
+
+    target_link_libraries(cc13x2-cc26x2-driver
+        INTERFACE
+            ${CMAKE_CURRENT_SOURCE_DIR}/devices/cc13x2_cc26x2/driverlib/bin/gcc/driverlib.a
+    )
+
+    target_link_options(cc13x2-cc26x2-driver
+        INTERFACE
+            -T${CMAKE_CURRENT_SOURCE_DIR}/devices/cc13x2_cc26x2/linker_files/cc26x2r1f.lds
+    )
 endif()


### PR DESCRIPTION
move thirdparty related in cc1352&cc2652 cmake files into their respective cmake files