### PR TITLE
[mesh-forwarder] ensure mesh dst checks for dst unreach

### DIFF
--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -93,8 +93,9 @@ struct MessageInfo
     uint16_t    mOffset;      ///< A byte offset within the message.
     RssAverager mRssAverager; ///< The averager maintaining the received signal strength (RSS) average.
 
-    uint8_t mChildMask[kChildMaskBytes]; ///< A bit-vector to indicate which sleepy children need to receive this.
-    uint8_t mTimeout;                    ///< Seconds remaining before dropping the message.
+    uint8_t  mChildMask[kChildMaskBytes]; ///< A bit-vector to indicate which sleepy children need to receive this.
+    uint16_t mMeshDest;                   ///< Used for unicast non-link-local messages.
+    uint8_t  mTimeout;                    ///< Seconds remaining before dropping the message.
     union
     {
         uint16_t mPanId;   ///< Used for MLE Discover Request and Response messages.
@@ -515,6 +516,26 @@ public:
      *
      */
     bool IsChildPending(void) const;
+
+    /**
+     * This method returns the RLOC16 of the mesh destination.
+     *
+     * @note Only use this for non-link-local unicast messages.
+     *
+     * @returns The IEEE 802.15.4 Destination PAN ID.
+     *
+     */
+    uint16_t GetMeshDest(void) const { return mBuffer.mHead.mInfo.mMeshDest; }
+
+    /**
+     * This method sets the RLOC16 of the mesh destination.
+     *
+     * @note Only use this when sending non-link-local unicast messages.
+     *
+     * @param[in]  aMeshDest  The IEEE 802.15.4 Destination PAN ID.
+     *
+     */
+    void SetMeshDest(uint16_t aMeshDest) { mBuffer.mHead.mInfo.mMeshDest = aMeshDest; }
 
     /**
      * This method returns the IEEE 802.15.4 Destination PAN ID.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1102,8 +1102,11 @@ void MeshForwarder::HandleFragment(const uint8_t *         aFrame,
         message->SetNetworkTimeOffset(aLinkInfo.mNetworkTimeOffset);
 #endif
 
-        // Security Check
         VerifyOrExit(Get<Ip6::Filter>().Accept(*message), error = OT_ERROR_DROP);
+
+#if OPENTHREAD_FTD
+        SendIcmpErrorIfDstUnreach(*message, aMacSource, aMacDest);
+#endif
 
         // Allow re-assembly of only one message at a time on a SED by clearing
         // any remaining fragments in reassembly list upon receiving of a new
@@ -1301,8 +1304,11 @@ void MeshForwarder::HandleLowpanHC(const uint8_t *         aFrame,
     message->SetNetworkTimeOffset(aLinkInfo.mNetworkTimeOffset);
 #endif
 
-    // Security Check
     VerifyOrExit(Get<Ip6::Filter>().Accept(*message), error = OT_ERROR_DROP);
+
+#if OPENTHREAD_FTD
+    SendIcmpErrorIfDstUnreach(*message, aMacSource, aMacDest);
+#endif
 
 exit:
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -392,7 +392,7 @@ private:
     void    SendMesh(Message &aMessage, Mac::TxFrame &aFrame);
     void    SendDestinationUnreachable(uint16_t aMeshSource, const Message &aMessage);
     otError UpdateIp6Route(Message &aMessage);
-    otError UpdateIp6RouteFtd(Ip6::Header &ip6Header, const Message &aMessage);
+    otError UpdateIp6RouteFtd(Ip6::Header &ip6Header, Message &aMessage);
     otError UpdateMeshRoute(Message &aMessage);
     bool    UpdateReassemblyList(void);
     bool    UpdateFragmentLifetime(void);

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -336,6 +336,9 @@ private:
         kMessageEvict,           ///< Indicates that the message was evicted.
     };
 
+    void    SendIcmpErrorIfDstUnreach(const Message &     aMessage,
+                                      const Mac::Address &aMacSource,
+                                      const Mac::Address &aMacDest);
     otError CheckReachability(const uint8_t *     aFrame,
                               uint16_t            aFrameLength,
                               const Mac::Address &aMeshSource,

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -404,13 +404,17 @@ exit:
     return error;
 }
 
-otError MeshForwarder::UpdateIp6RouteFtd(Ip6::Header &ip6Header, const Message &aMessage)
+otError MeshForwarder::UpdateIp6RouteFtd(Ip6::Header &ip6Header, Message &aMessage)
 {
     Mle::MleRouter &mle   = Get<Mle::MleRouter>();
     otError         error = OT_ERROR_NONE;
     Neighbor *      neighbor;
 
-    if (mle.IsRoutingLocator(ip6Header.GetDestination()))
+    if (aMessage.GetOffset() > 0)
+    {
+        mMeshDest = aMessage.GetMeshDest();
+    }
+    else if (mle.IsRoutingLocator(ip6Header.GetDestination()))
     {
         uint16_t rloc16 = ip6Header.GetDestination().GetLocator();
         VerifyOrExit(mle.IsRouterIdValid(Mle::Mle::RouterIdFromRloc16(rloc16)), error = OT_ERROR_DROP);
@@ -485,6 +489,7 @@ otError MeshForwarder::UpdateIp6RouteFtd(Ip6::Header &ip6Header, const Message &
     mMeshSource = Get<Mac::Mac>().GetShortAddress();
 
     SuccessOrExit(error = mle.CheckReachability(mMeshDest, ip6Header));
+    aMessage.SetMeshDest(mMeshDest);
     mMacDest.SetShort(mle.GetNextHop(mMeshDest));
 
     if (mMacDest.GetShort() != mMeshDest)

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -897,6 +897,11 @@ public:
     static bool IsRouterIdValid(uint8_t aRouterId) { return aRouterId <= kMaxRouterId; }
 
     otError SendChildUpdateRequest(void) { return Mle::SendChildUpdateRequest(); }
+
+    otError CheckReachability(uint16_t aMeshDest, Ip6::Header &aIp6Header)
+    {
+        return Mle::CheckReachability(aMeshDest, aIp6Header);
+    }
 };
 
 #endif // OPENTHREAD_MTD

--- a/tests/toranj/test-021-address-cache-table.py
+++ b/tests/toranj/test-021-address-cache-table.py
@@ -226,7 +226,27 @@ recver = c2.prepare_rx(sender)
 wpan.Node.perform_async_tx_rx()
 verify(sender.was_successful and recver.was_successful)
 
-# The address cache table on r1 should still be the same as before.
+# The address cache table on r1 should have c2's address removed.
+
+addr_cache_table = wpan.parse_address_cache_table_result(
+    r1.get(wpan.WPAN_THREAD_ADDRESS_CACHE_TABLE))
+verify(len(addr_cache_table) == 1)
+
+for entry in addr_cache_table:
+    if entry.address == c3_address:
+        # Entry for c3 should still point towards c3
+        verify(entry.rloc16 == c3_rloc)
+    else:
+        raise (wpan.VerifyError("Unknown entry in the address cache table"))
+
+# Send a UDP message from r1 to c2.
+
+sender = r1.prepare_tx(r1_address, c2_address, "Hi again c2")
+recver = c2.prepare_rx(sender)
+wpan.Node.perform_async_tx_rx()
+verify(sender.was_successful and recver.was_successful)
+
+# The address cache table on r1 should have both c1 and c2.
 
 addr_cache_table = wpan.parse_address_cache_table_result(
     r1.get(wpan.WPAN_THREAD_ADDRESS_CACHE_TABLE))
@@ -234,13 +254,50 @@ verify(len(addr_cache_table) == 2)
 
 for entry in addr_cache_table:
     if entry.address == c2_address:
-        # Entry for c2 should still point towards r2
-        verify(entry.rloc16 == r2_rloc)
+        # Entry for c2 should point towards r3
+        verify(entry.rloc16 == r3_rloc)
     elif entry.address == c3_address:
         # Entry for c3 should still point towards c3
         verify(entry.rloc16 == c3_rloc)
     else:
         raise (wpan.VerifyError("Unknown entry in the address cache table"))
+
+# Force c2 to switch its parent from r3 to r2
+
+c2.set(
+    wpan.WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT,
+    str(CHILD_SUPERVISION_CHECK_TIMEOUT),
+)
+r2.set(wpan.WPAN_CHILD_SUPERVISION_INTERVAL, str(PARENT_SUPERVISION_INTERVAL))
+
+r3.un_whitelist_node(c2)
+r2.whitelist_node(c2)
+c2.whitelist_node(r2)
+
+# Wait for c2 to detach from r3 and attach to r2.
+#
+# Upon re-attach, previous parent r3 is notified and should remove c2 from
+# its child table.
+
+
+def check_c2_is_removed_from_r3_child_table():
+    child_table = wpan.parse_list(r3.get(wpan.WPAN_THREAD_CHILD_TABLE))
+    verify(len(child_table) == 1)
+
+
+wpan.verify_within(check_c2_is_removed_from_r3_child_table, REATTACH_WAIT_TIME)
+
+# Verify that both c2 is a child of r2
+
+child_table = wpan.parse_list(r2.get(wpan.WPAN_THREAD_CHILD_TABLE))
+verify(len(child_table) == 1)
+
+# New network topology
+#
+#     r1 ---- r2 ---- r3
+#     |       |       |
+#     |       |       |
+#     c1      c2(s)   c3
 
 # Send a UDP message from c2 to c1.
 # This message will be forwarded by r1 to its FED child c1.
@@ -250,7 +307,76 @@ recver = c1.prepare_rx(sender)
 wpan.Node.perform_async_tx_rx()
 verify(sender.was_successful and recver.was_successful)
 
-# r1 upon receiving and forwarding the message from c2 (through r3 now) should
+# r1 upon receiving and forwarding the message from c2 (through r2 now) should
+# update its address cache table for c2 (address cache update through snooping).
+#
+# verify that the address cache table is updated correctly.
+
+addr_cache_table = wpan.parse_address_cache_table_result(
+    r1.get(wpan.WPAN_THREAD_ADDRESS_CACHE_TABLE))
+verify(len(addr_cache_table) == 2)
+
+for entry in addr_cache_table:
+    if entry.address == c2_address:
+        # Entry for c2's address should now point to r2
+        verify(entry.rloc16 == r2_rloc)
+    elif entry.address == c3_address:
+        # Entry for c3's address should still point to c3
+        verify(entry.rloc16 == c3_rloc)
+    else:
+        raise (wpan.VerifyError("Unknown entry in the address cache table"))
+
+# Force c2 to switch its parent from r2 to r3
+
+CHILD_SUPERVISION_CHECK_TIMEOUT = 2
+PARENT_SUPERVISION_INTERVAL = 1
+
+REATTACH_WAIT_TIME = CHILD_SUPERVISION_CHECK_TIMEOUT / speedup + 6
+
+c2.set(
+    wpan.WPAN_CHILD_SUPERVISION_CHECK_TIMEOUT,
+    str(CHILD_SUPERVISION_CHECK_TIMEOUT),
+)
+r3.set(wpan.WPAN_CHILD_SUPERVISION_INTERVAL, str(PARENT_SUPERVISION_INTERVAL))
+
+r2.un_whitelist_node(c2)
+r3.whitelist_node(c2)
+c2.whitelist_node(r3)
+
+# Wait for c2 to detach from r2 and attach to r3.
+#
+# Upon re-attach, previous parent r2 is notified and should remove c2 from
+# its child table.
+
+
+def check_c2_is_removed_from_r2_child_table():
+    child_table = wpan.parse_list(r2.get(wpan.WPAN_THREAD_CHILD_TABLE))
+    verify(len(child_table) == 0)
+
+
+wpan.verify_within(check_c2_is_removed_from_r2_child_table, REATTACH_WAIT_TIME)
+
+# Verify that both c2, c3 are children of r3
+
+child_table = wpan.parse_list(r3.get(wpan.WPAN_THREAD_CHILD_TABLE))
+verify(len(child_table) == 2)
+
+# New network topology
+#
+#     r1 ---- r2 ---- r3
+#     |               /\
+#     |              /  \
+#     c1           c2(s) c3
+
+# Send a UDP message from c2 to c1.
+# This message will be forwarded by r1 to its FED child c1.
+
+sender = c2.prepare_tx(c2_address, c1_address, "Hi c1 child of r1")
+recver = c1.prepare_rx(sender)
+wpan.Node.perform_async_tx_rx()
+verify(sender.was_successful and recver.was_successful)
+
+# r1 upon receiving and forwarding the message from c2 (through r2 now) should
 # update its address cache table for c2 (address cache update through snooping).
 #
 # verify that the address cache table is updated correctly.


### PR DESCRIPTION
This PR contains the following commits:

- [mesh-forwarder] send all message fragments to the same mesh dest
    
    All fragments for a given IPv6 datagram must be sent to the same
    destination. Otherwise, there is not much point in transmitting the
    messages.

- [mesh-forwarder] ensure mesh dst checks for dst unreach
    
    An out-dated EID-to-RLOC map cache may lead a device to send an IPv6
    datagram to a device that does not have the IPv6 Destination Address
    assigned to its interface. However, the existing implementation would
    not send back an ICMPv6 Destination Unreachable message necessary to
    invalidate the originator's EID-to-RLOC cache entry.
    
    This implementation adds reachability checks on the mesh destination
    receive path to ensure that reachability checks are performed in the
    above situation.

- [toranj] update address cache table test
    
    Updated test-021-address-cache-table.py to reflect cache entry
    invalidation when sending to a neighbor that does not have the
    destination.