### PR TITLE
[pretty] fix yapf version to 0.29.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,7 +51,7 @@ jobs:
         sudo apt autoremove
         sudo apt --no-install-recommends install -y clang-tools clang-format-6.0
         clang-format-6.0 --version
-        python3 -m pip install yapf
+        python3 -m pip install yapf==0.29.0
     - name: Check
       run: |
         script/make-pretty check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -108,7 +108,7 @@ This will open up a text editor where you can specify which commits to squash.
 
 #### Coding Conventions and Style
 
-OpenThread uses and enforces the [OpenThread Coding Conventions and Style](STYLE_GUIDE.md) on all code, except for code located in [third_party](third_party).  Use `script/make-pretty` and `script/make-pretty check` to automatically reformat code and check for code-style compliance, respectively.  OpenThread currently requires [clang-format v6.0.0](http://releases.llvm.org/download.html#6.0.0) for C/C++ and [yapf](https://github.com/google/yapf) for Python.
+OpenThread uses and enforces the [OpenThread Coding Conventions and Style](STYLE_GUIDE.md) on all code, except for code located in [third_party](third_party).  Use `script/make-pretty` and `script/make-pretty check` to automatically reformat code and check for code-style compliance, respectively.  OpenThread currently requires [clang-format v6.0.0](http://releases.llvm.org/download.html#6.0.0) for C/C++ and [yapf v0.29.0](https://github.com/google/yapf) for Python.
 
 As part of the cleanup process, you should also run `script/make-pretty check` to ensure that your code passes the baseline code style checks.
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -116,7 +116,7 @@
 
 - OpenThread uses `script/make-pretty` to reformat code and enforce code format and style.  `script/make-pretty check` build target is included in OpenThread's continuous integration and must pass before a pull request is merged.
 
-- `script/make-pretty` requires [clang-format v6.0.0](http://releases.llvm.org/download.html#6.0.0) for C/C++ and [yapf](https://github.com/google/yapf) for Python.
+- `script/make-pretty` requires [clang-format v6.0.0](http://releases.llvm.org/download.html#6.0.0) for C/C++ and [yapf v0.29.0](https://github.com/google/yapf) for Python.
 
 ### File Names
 - File names should match the names and types of what is described in the file.  If a file contains many declarations and definitions, the author should choose the one that predominantly describes or that makes the most sense.

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -54,7 +54,7 @@ install_packages_apt()
     sudo apt-get --no-install-recommends install -y clang-format-6.0
 
     # add yapf for pretty
-    python3 -m pip install yapf || echo 'Failed to install python code formatter yapf. Install it manually if you need.'
+    python3 -m pip install yapf==0.29.0 || echo 'Failed to install python code formatter yapf. Install it manually if you need.'
 
     # add mdv for local size report
     python3 -m pip install mdv || echo 'Failed to install markdown render. Install it manually if you need.'


### PR DESCRIPTION
v0.30.0 (released on 2020-04-23) introduces formatting changes that
are not compatible with v0.29.0.