### PR TITLE
[cli] fix infinite loop on networkdiagnostic

### DIFF
--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -1029,7 +1029,7 @@ exit:
     if (error == OT_ERROR_NONE)
     {
         aNetworkDiagTlv.mType = tlv.GetType();
-        aIterator             = offset - message.GetOffset();
+        aIterator             = static_cast<uint16_t>(offset - message.GetOffset() + tlv.GetSize());
     }
     return error;
 }


### PR DESCRIPTION
Reproduce by issuing `networkdiagnostic get ff03::1 0 1` on one router.