### PR TITLE
[mac-frame] ensure frame length is correctly updated from InitMacHeader()     

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -48,20 +48,21 @@ namespace Mac {
 
 void Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
 {
-    uint8_t *bytes  = GetPsdu();
-    uint8_t  length = 0;
+    uint8_t *bytes = GetPsdu();
+
+    mLength = 0;
 
     // Frame Control Field
     Encoding::LittleEndian::WriteUint16(aFcf, bytes);
-    length += kFcfSize;
+    mLength += kFcfSize;
 
     // Sequence Number
-    length += kDsnSize;
+    mLength += kDsnSize;
 
     // Destination PAN
     if (IsDstPanIdPresent(aFcf))
     {
-        length += sizeof(PanId);
+        mLength += sizeof(PanId);
     }
 
     // Destination Address
@@ -71,11 +72,11 @@ void Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
         break;
 
     case kFcfDstAddrShort:
-        length += sizeof(ShortAddress);
+        mLength += sizeof(ShortAddress);
         break;
 
     case kFcfDstAddrExt:
-        length += sizeof(ExtAddress);
+        mLength += sizeof(ExtAddress);
         break;
 
     default:
@@ -85,7 +86,7 @@ void Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
     // Source PAN
     if (IsSrcPanIdPresent(aFcf))
     {
-        length += sizeof(PanId);
+        mLength += sizeof(PanId);
     }
 
     // Source Address
@@ -95,11 +96,11 @@ void Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
         break;
 
     case kFcfSrcAddrShort:
-        length += sizeof(ShortAddress);
+        mLength += sizeof(ShortAddress);
         break;
 
     case kFcfSrcAddrExt:
-        length += sizeof(ExtAddress);
+        mLength += sizeof(ExtAddress);
         break;
 
     default:
@@ -109,29 +110,29 @@ void Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
     // Security Header
     if (aFcf & kFcfSecurityEnabled)
     {
-        bytes[length] = aSecurityControl;
+        bytes[mLength] = aSecurityControl;
 
         if (aSecurityControl & kSecLevelMask)
         {
-            length += kSecurityControlSize + kFrameCounterSize;
+            mLength += kSecurityControlSize + kFrameCounterSize;
         }
 
         switch (aSecurityControl & kKeyIdModeMask)
         {
         case kKeyIdMode0:
-            length += kKeySourceSizeMode0;
+            mLength += kKeySourceSizeMode0;
             break;
 
         case kKeyIdMode1:
-            length += kKeySourceSizeMode1 + kKeyIndexSize;
+            mLength += kKeySourceSizeMode1 + kKeyIndexSize;
             break;
 
         case kKeyIdMode2:
-            length += kKeySourceSizeMode2 + kKeyIndexSize;
+            mLength += kKeySourceSizeMode2 + kKeyIndexSize;
             break;
 
         case kKeyIdMode3:
-            length += kKeySourceSizeMode3 + kKeyIndexSize;
+            mLength += kKeySourceSizeMode3 + kKeyIndexSize;
             break;
         }
     }
@@ -139,10 +140,10 @@ void Frame::InitMacHeader(uint16_t aFcf, uint8_t aSecurityControl)
     // Command ID
     if ((aFcf & kFcfFrameTypeMask) == kFcfFrameMacCmd)
     {
-        length += kCommandIdSize;
+        mLength += kCommandIdSize;
     }
 
-    SetPsduLength(length + GetFooterLength());
+    mLength += GetFooterLength();
 }
 
 uint16_t Frame::GetFrameControlField(void) const

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -237,36 +237,37 @@ void TestMacHeader(void)
         uint16_t fcf;
         uint8_t  secCtl;
         uint8_t  headerLength;
+        uint8_t  footerLength;
     } tests[] = {
-        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrNone | Mac::Frame::kFcfSrcAddrNone, 0, 3},
-        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrNone | Mac::Frame::kFcfSrcAddrShort, 0, 7},
-        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrNone | Mac::Frame::kFcfSrcAddrExt, 0, 13},
-        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrShort | Mac::Frame::kFcfSrcAddrNone, 0, 7},
-        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrExt | Mac::Frame::kFcfSrcAddrNone, 0, 13},
-        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrShort | Mac::Frame::kFcfSrcAddrShort, 0, 11},
-        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrShort | Mac::Frame::kFcfSrcAddrExt, 0, 17},
-        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrExt | Mac::Frame::kFcfSrcAddrShort, 0, 17},
-        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrExt | Mac::Frame::kFcfSrcAddrExt, 0, 23},
+        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrNone | Mac::Frame::kFcfSrcAddrNone, 0, 3, 2},
+        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrNone | Mac::Frame::kFcfSrcAddrShort, 0, 7, 2},
+        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrNone | Mac::Frame::kFcfSrcAddrExt, 0, 13, 2},
+        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrShort | Mac::Frame::kFcfSrcAddrNone, 0, 7, 2},
+        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrExt | Mac::Frame::kFcfSrcAddrNone, 0, 13, 2},
+        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrShort | Mac::Frame::kFcfSrcAddrShort, 0, 11, 2},
+        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrShort | Mac::Frame::kFcfSrcAddrExt, 0, 17, 2},
+        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrExt | Mac::Frame::kFcfSrcAddrShort, 0, 17, 2},
+        {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrExt | Mac::Frame::kFcfSrcAddrExt, 0, 23, 2},
 
         {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrShort | Mac::Frame::kFcfSrcAddrShort |
              Mac::Frame::kFcfPanidCompression,
-         0, 9},
+         0, 9, 2},
         {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrShort | Mac::Frame::kFcfSrcAddrExt |
              Mac::Frame::kFcfPanidCompression,
-         0, 15},
+         0, 15, 2},
         {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrExt | Mac::Frame::kFcfSrcAddrShort |
              Mac::Frame::kFcfPanidCompression,
-         0, 15},
+         0, 15, 2},
         {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrExt | Mac::Frame::kFcfSrcAddrExt |
              Mac::Frame::kFcfPanidCompression,
-         0, 21},
+         0, 21, 2},
 
         {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrShort | Mac::Frame::kFcfSrcAddrShort |
              Mac::Frame::kFcfPanidCompression | Mac::Frame::kFcfSecurityEnabled,
-         Mac::Frame::kSecMic32 | Mac::Frame::kKeyIdMode1, 15},
+         Mac::Frame::kSecMic32 | Mac::Frame::kKeyIdMode1, 15, 6},
         {Mac::Frame::kFcfFrameVersion2006 | Mac::Frame::kFcfDstAddrShort | Mac::Frame::kFcfSrcAddrShort |
              Mac::Frame::kFcfPanidCompression | Mac::Frame::kFcfSecurityEnabled,
-         Mac::Frame::kSecMic32 | Mac::Frame::kKeyIdMode2, 19},
+         Mac::Frame::kSecMic32 | Mac::Frame::kKeyIdMode2, 19, 6},
     };
 
     for (unsigned i = 0; i < OT_ARRAY_LENGTH(tests); i++)
@@ -274,11 +275,14 @@ void TestMacHeader(void)
         uint8_t      psdu[Mac::Frame::kMtu];
         Mac::TxFrame frame;
 
-        frame.mPsdu = psdu;
+        frame.mPsdu   = psdu;
+        frame.mLength = 0;
 
         frame.InitMacHeader(tests[i].fcf, tests[i].secCtl);
-        printf("%d\n", frame.GetHeaderLength());
+
         VerifyOrQuit(frame.GetHeaderLength() == tests[i].headerLength, "MacHeader test failed");
+        VerifyOrQuit(frame.GetFooterLength() == tests[i].footerLength, "MacHeader test failed");
+        VerifyOrQuit(frame.GetLength() == tests[i].headerLength + tests[i].footerLength, "MacHeader test failed");
     }
 }
 


### PR DESCRIPTION
This commit directly updates the `mLength` from `InitMacHeader()` as it prepares the frame header (instead of setting it at the end). This ensures that `InitMacHeader()` can safely call other `Frame` helper methods (e.g. `GetFooterLength()` which itself does check the frame length).

[tests] update Mac::Frame unit test to check footer and frame length

--------

Background on this: This PR addresses an issue (introduced in #4826) where from `InitMacHeader()` before setting the length of frame, we would call `GetFooterLength()` which in turn calls `FindSecurityHeaderIndex()`  which would check the length from `VerifyOrExit(kFcfSize < GetLength(), index = kInvalidIndex);` (basically using the frame length uninitialized and before it is set). While it is a bug, I think it is not critial in current use of `Frame` since the length is not cleared/updated between tx frame preparations, so only the the first tx frame may be impacted.

A second commit  in this PR updates the `test_mac_frame` unit test to check footer length and frame length in addition to header length.