### PR TITLE
[aloc] add ApplyMeshLocalPrefix() to applicable ALOCs

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3902,7 +3902,8 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength, Server &aServer)
 {
     char *  aArgs[kMaxArgs] = {NULL};
     char *  cmd;
-    uint8_t aArgsLength = 0, i = 0;
+    uint8_t aArgsLength = 0;
+    size_t  i           = 0;
 
     mServer = &aServer;
 

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -191,7 +191,7 @@ otError Dataset::Process(uint8_t aArgsLength, char *aArgs[])
         ExitNow(error = Print(sDataset));
     }
 
-    for (unsigned int i = 0; i < OT_ARRAY_LENGTH(sCommands); i++)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(sCommands); i++)
     {
         if (strcmp(aArgs[0], sCommands[i].mName) == 0)
         {
@@ -209,7 +209,7 @@ otError Dataset::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    for (unsigned int i = 0; i < OT_ARRAY_LENGTH(sCommands); i++)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(sCommands); i++)
     {
         mInterpreter.mServer->OutputFormat("%s\r\n", sCommands[i].mName);
     }

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -60,7 +60,7 @@ otError UdpExample::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    for (unsigned int i = 0; i < OT_ARRAY_LENGTH(sCommands); i++)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(sCommands); i++)
     {
         mInterpreter.mServer->OutputFormat("%s\r\n", sCommands[i].mName);
     }

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -746,6 +746,20 @@ void BorderAgent::SetState(otBorderAgentState aState)
     }
 }
 
+void BorderAgent::ApplyMeshLocalPrefix(void)
+{
+    VerifyOrExit(mState == OT_BORDER_AGENT_STATE_ACTIVE, OT_NOOP);
+
+    if (Get<ThreadNetif>().RemoveUnicastAddress(mCommissionerAloc) == OT_ERROR_NONE)
+    {
+        mCommissionerAloc.GetAddress().SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
+        Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc);
+    }
+
+exit:
+    return;
+}
+
 } // namespace MeshCoP
 } // namespace ot
 

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -86,6 +86,12 @@ public:
      */
     otBorderAgentState GetState(void) const { return mState; }
 
+    /**
+     * This method applies the Mesh Local Prefix.
+     *
+     */
+    void ApplyMeshLocalPrefix(void);
+
 private:
     static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
     void        HandleStateChanged(otChangedFlags aFlags);

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -1094,6 +1094,18 @@ exit:
     return error;
 }
 
+void Commissioner::ApplyMeshLocalPrefix(void)
+{
+    VerifyOrExit(mState == OT_COMMISSIONER_STATE_ACTIVE, OT_NOOP);
+
+    Get<ThreadNetif>().RemoveUnicastAddress(mCommissionerAloc);
+    mCommissionerAloc.GetAddress().SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
+    Get<ThreadNetif>().AddUnicastAddress(mCommissionerAloc);
+
+exit:
+    return;
+}
+
 // LCOV_EXCL_START
 
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MLE == 1)

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -246,6 +246,12 @@ public:
      */
     PanIdQueryClient &GetPanIdQueryClient(void) { return mPanIdQuery; }
 
+    /**
+     * This method applies the Mesh Local Prefix.
+     *
+     */
+    void ApplyMeshLocalPrefix(void);
+
 private:
     enum
     {

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -76,7 +76,7 @@ void Dhcp6Client::UpdateAddresses(void)
     NetworkData::OnMeshPrefixConfig config;
 
     // remove addresses directly if prefix not valid in network data
-    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); i++)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); i++)
     {
         IdentityAssociation &ia = mIdentityAssociations[i];
 
@@ -123,7 +123,7 @@ void Dhcp6Client::UpdateAddresses(void)
 
         found = false;
 
-        for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); i++)
+        for (size_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); i++)
         {
             if (mIdentityAssociations[i].mStatus == kIaStatusInvalid)
             {
@@ -194,7 +194,7 @@ bool Dhcp6Client::ProcessNextIdentityAssociation()
 
     mTrickleTimer.Stop();
 
-    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); ++i)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); ++i)
     {
         if (mIdentityAssociations[i].mStatus != kIaStatusSolicit)
         {
@@ -341,7 +341,7 @@ otError Dhcp6Client::AppendIaNa(Message &aMessage, uint16_t aRloc16)
 
     VerifyOrExit(mIdentityAssociationCurrent != NULL, error = OT_ERROR_DROP);
 
-    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); ++i)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); ++i)
     {
         if (mIdentityAssociations[i].mStatus == kIaStatusInvalid ||
             mIdentityAssociations[i].mStatus == kIaStatusSolicitReplied)
@@ -378,7 +378,7 @@ otError Dhcp6Client::AppendIaAddress(Message &aMessage, uint16_t aRloc16)
 
     option.Init();
 
-    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); ++i)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); ++i)
     {
         if ((mIdentityAssociations[i].mStatus == kIaStatusSolicit ||
              mIdentityAssociations[i].mStatus == kIaStatusSoliciting) &&
@@ -571,7 +571,7 @@ otError Dhcp6Client::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
                   (option.GetLength() == (sizeof(option) - sizeof(Dhcp6Option)))),
                  error = OT_ERROR_PARSE);
 
-    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); ++i)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mIdentityAssociations); ++i)
     {
         IdentityAssociation &ia = mIdentityAssociations[i];
 

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -64,7 +64,7 @@ otError Dhcp6Server::UpdateService(void)
     Lowpan::Context                 lowpanContext;
 
     // remove dhcp agent aloc and prefix delegation
-    for (int i = 0; i < OPENTHREAD_CONFIG_DHCP6_SERVER_NUM_PREFIXES; i++)
+    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
     {
         bool found = false;
 
@@ -149,7 +149,7 @@ otError Dhcp6Server::AddPrefixAgent(const otIp6Prefix &aIp6Prefix, const Lowpan:
     otError      error    = OT_ERROR_NONE;
     PrefixAgent *newEntry = NULL;
 
-    for (int i = 0; i < OPENTHREAD_CONFIG_DHCP6_SERVER_NUM_PREFIXES; i++)
+    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
     {
         if (!mPrefixAgents[i].IsValid())
         {
@@ -312,7 +312,7 @@ otError Dhcp6Server::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
                  error = OT_ERROR_PARSE);
 
     // mask matching prefix
-    for (uint8_t i = 0; i < OPENTHREAD_CONFIG_DHCP6_SERVER_NUM_PREFIXES; i++)
+    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
     {
         if (mPrefixAgents[i].IsValid() && mPrefixAgents[i].IsPrefixMatch(option.GetAddress()))
         {
@@ -394,7 +394,7 @@ otError Dhcp6Server::AppendIaNa(Message &aMessage, IaNa &aIaNa)
 
     if (mPrefixAgentsMask)
     {
-        for (uint8_t i = 0; i < OPENTHREAD_CONFIG_DHCP6_SERVER_NUM_PREFIXES; i++)
+        for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
         {
             if ((mPrefixAgentsMask & (1 << i)))
             {
@@ -434,7 +434,7 @@ otError Dhcp6Server::AppendIaAddress(Message &aMessage, ClientIdentifier &aClien
     if (mPrefixAgentsMask)
     {
         // if specified, only apply specified prefixes
-        for (uint8_t i = 0; i < OPENTHREAD_CONFIG_DHCP6_SERVER_NUM_PREFIXES; i++)
+        for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
         {
             if (mPrefixAgentsMask & (1 << i))
             {
@@ -445,7 +445,7 @@ otError Dhcp6Server::AppendIaAddress(Message &aMessage, ClientIdentifier &aClien
     else
     {
         // if not specified, apply all configured prefixes
-        for (uint8_t i = 0; i < OPENTHREAD_CONFIG_DHCP6_SERVER_NUM_PREFIXES; i++)
+        for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
         {
             if (mPrefixAgents[i].IsValid())
             {
@@ -480,6 +480,20 @@ otError Dhcp6Server::AppendRapidCommit(Message &aMessage)
 
     option.Init();
     return aMessage.Append(&option, sizeof(option));
+}
+
+void Dhcp6Server::ApplyMeshLocalPrefix(void)
+{
+    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
+    {
+        if (mPrefixAgents[i].IsValid())
+        {
+            PrefixAgent *entry = &mPrefixAgents[i];
+            Get<ThreadNetif>().RemoveUnicastAddress(entry->GetAloc());
+            entry->GetAloc().GetAddress().SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
+            Get<ThreadNetif>().AddUnicastAddress(entry->GetAloc());
+        }
+    }
 }
 
 } // namespace Dhcp6

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -64,7 +64,7 @@ otError Dhcp6Server::UpdateService(void)
     Lowpan::Context                 lowpanContext;
 
     // remove dhcp agent aloc and prefix delegation
-    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
     {
         bool found = false;
 
@@ -149,7 +149,7 @@ otError Dhcp6Server::AddPrefixAgent(const otIp6Prefix &aIp6Prefix, const Lowpan:
     otError      error    = OT_ERROR_NONE;
     PrefixAgent *newEntry = NULL;
 
-    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
     {
         if (!mPrefixAgents[i].IsValid())
         {
@@ -312,7 +312,7 @@ otError Dhcp6Server::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
                  error = OT_ERROR_PARSE);
 
     // mask matching prefix
-    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
     {
         if (mPrefixAgents[i].IsValid() && mPrefixAgents[i].IsPrefixMatch(option.GetAddress()))
         {
@@ -394,7 +394,7 @@ otError Dhcp6Server::AppendIaNa(Message &aMessage, IaNa &aIaNa)
 
     if (mPrefixAgentsMask)
     {
-        for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
+        for (size_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
         {
             if ((mPrefixAgentsMask & (1 << i)))
             {
@@ -434,7 +434,7 @@ otError Dhcp6Server::AppendIaAddress(Message &aMessage, ClientIdentifier &aClien
     if (mPrefixAgentsMask)
     {
         // if specified, only apply specified prefixes
-        for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
+        for (size_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
         {
             if (mPrefixAgentsMask & (1 << i))
             {
@@ -445,7 +445,7 @@ otError Dhcp6Server::AppendIaAddress(Message &aMessage, ClientIdentifier &aClien
     else
     {
         // if not specified, apply all configured prefixes
-        for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
+        for (size_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
         {
             if (mPrefixAgents[i].IsValid())
             {
@@ -484,7 +484,7 @@ otError Dhcp6Server::AppendRapidCommit(Message &aMessage)
 
 void Dhcp6Server::ApplyMeshLocalPrefix(void)
 {
-    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
     {
         if (mPrefixAgents[i].IsValid())
         {

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -83,6 +83,12 @@ public:
      */
     otError UpdateService();
 
+    /**
+     * This method applies the Mesh Local Prefix.
+     *
+     */
+    void ApplyMeshLocalPrefix(void);
+
 private:
     class PrefixAgent
     {

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -82,7 +82,7 @@ void AddressResolver::Clear(void)
 {
     CacheEntryList *lists[] = {&mCachedList, &mSnoopedList, &mQueryList, &mQueryRetryList};
 
-    for (uint8_t index = 0; index < OT_ARRAY_LENGTH(lists); index++)
+    for (size_t index = 0; index < OT_ARRAY_LENGTH(lists); index++)
     {
         CacheEntryList *list = lists[index];
         CacheEntry *    entry;
@@ -198,7 +198,7 @@ void AddressResolver::Remove(Mac::ShortAddress aRloc16, bool aMatchRouterId)
 {
     CacheEntryList *lists[] = {&mCachedList, &mSnoopedList};
 
-    for (uint8_t index = 0; index < OT_ARRAY_LENGTH(lists); index++)
+    for (size_t index = 0; index < OT_ARRAY_LENGTH(lists); index++)
     {
         CacheEntryList *list = lists[index];
         CacheEntry *    prev = NULL;
@@ -248,7 +248,7 @@ AddressResolver::CacheEntry *AddressResolver::FindCacheEntry(const Ip6::Address 
     CacheEntry *    entry   = NULL;
     CacheEntryList *lists[] = {&mCachedList, &mSnoopedList, &mQueryList, &mQueryRetryList};
 
-    for (uint8_t index = 0; index < OT_ARRAY_LENGTH(lists); index++)
+    for (size_t index = 0; index < OT_ARRAY_LENGTH(lists); index++)
     {
         aList = lists[index];
         entry = FindCacheEntryInList(*aList, aEid, aPrevEntry);
@@ -300,7 +300,7 @@ AddressResolver::CacheEntry *AddressResolver::NewCacheEntry(bool aSnoopedEntry)
     newEntry = mUnusedList.Pop();
     VerifyOrExit(newEntry == NULL, OT_NOOP);
 
-    for (uint8_t index = 0; index < OT_ARRAY_LENGTH(lists); index++)
+    for (size_t index = 0; index < OT_ARRAY_LENGTH(lists); index++)
     {
         CacheEntryList *list = lists[index];
         CacheEntry *    prev;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -967,7 +967,7 @@ void Mle::ApplyMeshLocalPrefix(void)
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
-    for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mServiceAlocs); i++)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(mServiceAlocs); i++)
     {
         if (mServiceAlocs[i].GetAddress().GetLocator() != Mac::kShortAddrInvalid)
         {
@@ -1613,9 +1613,9 @@ void Mle::UpdateServiceAlocs(void)
     uint16_t              rloc               = GetRloc16();
     uint16_t              serviceAloc        = 0;
     uint8_t               serviceId          = 0;
-    int                   i                  = 0;
     NetworkData::Iterator serviceIterator    = NetworkData::kIteratorInit;
-    int                   serviceAlocsLength = OT_ARRAY_LENGTH(mServiceAlocs);
+    size_t                serviceAlocsLength = OT_ARRAY_LENGTH(mServiceAlocs);
+    size_t                i                  = 0;
 
     VerifyOrExit(!IsDisabled(), OT_NOOP);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -953,6 +953,18 @@ void Mle::ApplyMeshLocalPrefix(void)
         Get<ThreadNetif>().AddUnicastAddress(mLeaderAloc);
     }
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
+    Get<MeshCoP::Commissioner>().ApplyMeshLocalPrefix();
+#endif
+
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
+    Get<MeshCoP::BorderAgent>().ApplyMeshLocalPrefix();
+#endif
+
+#if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
+    Get<Dhcp6::Dhcp6Server>().ApplyMeshLocalPrefix();
+#endif
+
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
     for (uint8_t i = 0; i < OT_ARRAY_LENGTH(mServiceAlocs); i++)

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -3700,7 +3700,7 @@ void NcpBase::ProcessThreadChangedFlags(void)
 
     // Convert OT_CHANGED flags to corresponding NCP property update.
 
-    for (unsigned i = 0; i < OT_ARRAY_LENGTH(kFlags); i++)
+    for (size_t i = 0; i < OT_ARRAY_LENGTH(kFlags); i++)
     {
         uint32_t threadFlag = kFlags[i].mThreadFlag;
 


### PR DESCRIPTION
MeshLocalPrefix may change when applying Operational Dataset.
This PR applies mesh local prefix to the ALOCs which are not in `Mle` component.