### PR TITLE
[spinel] fix time narrowing conversion

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -137,6 +137,28 @@ jobs:
         script/check-simulation-build
         script/check-posix-build
 
+  clang-m32:
+    name: clang-m32-${{ matrix.clang_ver }}
+    runs-on: ubuntu-18.04
+    strategy:
+      matrix:
+        clang_ver: [9]
+    env:
+      CC: clang-${{ matrix.clang_ver }}
+      CXX: clang++-${{ matrix.clang_ver }}
+      CFLAGS: -m32 -Wconversion
+      CXXFLAGS: -m32 -Wconversion
+      LDFLAGS: -m32
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bootstrap
+        run: |
+          sudo apt update
+          sudo apt --no-install-recommends install -y clang-${{ matrix.clang_ver }} clang++-${{ matrix.clang_ver }} g++-multilib
+      - name: Build
+        run: |
+          script/check-posix-build
+
   gn:
     runs-on: ubuntu-18.04
     steps:

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -260,8 +260,8 @@ otError HdlcInterface::WaitForFrame(uint64_t aTimeoutUs)
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
     struct Event event;
 
-    timeout.tv_sec  = aTimeoutUs / US_PER_S;
-    timeout.tv_usec = aTimeoutUs % US_PER_S;
+    timeout.tv_sec  = static_cast<time_t>(aTimeoutUs / US_PER_S);
+    timeout.tv_usec = static_cast<suseconds_t>(aTimeoutUs % US_PER_S);
 
     virtualTimeSendSleepEvent(&timeout);
     virtualTimeReceiveEvent(&event);
@@ -281,8 +281,8 @@ otError HdlcInterface::WaitForFrame(uint64_t aTimeoutUs)
         break;
     }
 #else  // OPENTHREAD_POSIX_VIRTUAL_TIME
-    timeout.tv_sec = aTimeoutUs / US_PER_S;
-    timeout.tv_usec = aTimeoutUs % US_PER_S;
+    timeout.tv_sec = static_cast<time_t>(aTimeoutUs / US_PER_S);
+    timeout.tv_usec = static_cast<suseconds_t>(aTimeoutUs % US_PER_S);
 
     fd_set read_fds;
     fd_set error_fds;

--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -692,8 +692,8 @@ otError SpiInterface::WaitForFrame(uint64_t aTimeoutUs)
     int            ret;
     bool           isDataReady = false;
 
-    timeout.tv_sec  = aTimeoutUs / US_PER_S;
-    timeout.tv_usec = aTimeoutUs % US_PER_S;
+    timeout.tv_sec  = static_cast<time_t>(aTimeoutUs / US_PER_S);
+    timeout.tv_usec = static_cast<suseconds_t>(aTimeoutUs % US_PER_S);
 
     FD_ZERO(&readFdSet);
 


### PR DESCRIPTION
This makes narrowing conversions of time types explicit to fix build errors.

Also added a CI build to check for any errors like this. The new build uses clang because GCC's `-Wconversion` is too strict, making a huge number of compiling errors in our codebase.