### PR TITLE
[address-resolver] fix ADDR_NTF.ans to use Child's Mesh Local IID

### DIFF
--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -816,13 +816,8 @@ void AddressResolver::HandleAddressQuery(Coap::Message &aMessage, const Ip6::Mes
 
         if (child.HasIp6Address(target))
         {
-            Mac::ExtAddress addr;
-
-            // Convert extended address to IID.
-            addr = child.GetExtAddress();
-            addr.ToggleLocal();
             lastTransactionTime = TimerMilli::GetNow() - child.GetLastHeard();
-            SendAddressQueryResponse(target, addr.m8, &lastTransactionTime, aMessageInfo.GetPeerAddr());
+            SendAddressQueryResponse(target, child.GetMeshLocalIid(), &lastTransactionTime, aMessageInfo.GetPeerAddr());
             ExitNow();
         }
     }

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -585,6 +585,14 @@ public:
     otError GetMeshLocalIp6Address(Ip6::Address &aAddress) const;
 
     /**
+     * This method returns a pointer to the Mesh Local Interface Identifier.
+     *
+     * @returns a pointer to the Mesh Local Interface Identifier.
+     *
+     */
+    const uint8_t *GetMeshLocalIid(void) const { return mMeshLocalIid; }
+
+    /**
      * This method gets the next IPv6 address in the list.
      *
      * @param[inout] aIterator           A reference to an IPv6 address iterator.


### PR DESCRIPTION
Thread 1.1 specification 5.4.2.4 says

> The ML-EID TLV contains the ML-EID associated with the Target EID
