### PR TITLE
[commissioner] remove duplicate MGMT_COMMISSISONER_SET.req

### DIFF
--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -348,11 +348,11 @@ exit:
     return error;
 }
 
-otError Commissioner::RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDelay, JoinerOpFlag flags)
+otError Commissioner::RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDelay, JoinerOpFlag aFlags)
 {
     otError error = OT_ERROR_NOT_FOUND;
 
-    OT_ASSERT(!(flags & kJoinerOpFlagNotNotifyLeader) || aDelay == 0);
+    OT_ASSERT(!(aFlags & kJoinerOpFlagNotNotifyLeader) || aDelay == 0);
 
     VerifyOrExit(mState == OT_COMMISSIONER_STATE_ACTIVE, error = OT_ERROR_INVALID_STATE);
 
@@ -391,7 +391,7 @@ otError Commissioner::RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDela
 
             joiner->mValid = false;
             UpdateJoinerExpirationTimer();
-            if ((flags & kJoinerOpFlagNotNotifyLeader) == 0)
+            if ((aFlags & kJoinerOpFlagNotNotifyLeader) == 0)
             {
                 SendCommissionerSet();
             }

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -284,7 +284,7 @@ otError Commissioner::AddJoiner(const Mac::ExtAddress *aEui64, const char *aPskd
 
     VerifyOrExit(StringLength(aPskd, Dtls::kPskMaxLength + 1) <= Dtls::kPskMaxLength, error = OT_ERROR_INVALID_ARGS);
 
-    RemoveJoiner(aEui64, 0, JoinerOperationFlag::kNotNotifyLeader); // remove immediately
+    RemoveJoiner(aEui64, 0, kJoinerOpFlagNotNotifyLeader); // remove immediately
 
     for (Joiner *joiner = &mJoiners[0]; joiner < OT_ARRAY_END(mJoiners); joiner++)
     {
@@ -348,11 +348,11 @@ exit:
     return error;
 }
 
-otError Commissioner::RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDelay, JoinerOperationFlag flags)
+otError Commissioner::RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDelay, JoinerOpFlag flags)
 {
     otError error = OT_ERROR_NOT_FOUND;
 
-    OT_ASSERT(!(flags & JoinerOperationFlag::kNotNotifyLeader) || aDelay == 0);
+    OT_ASSERT(!(flags & kJoinerOpFlagNotNotifyLeader) || aDelay == 0);
 
     VerifyOrExit(mState == OT_COMMISSIONER_STATE_ACTIVE, error = OT_ERROR_INVALID_STATE);
 
@@ -391,7 +391,7 @@ otError Commissioner::RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDela
 
             joiner->mValid = false;
             UpdateJoinerExpirationTimer();
-            if ((flags & JoinerOperationFlag::kNotNotifyLeader) == 0)
+            if ((flags & kJoinerOpFlagNotNotifyLeader) == 0)
             {
                 SendCommissionerSet();
             }

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -284,7 +284,7 @@ otError Commissioner::AddJoiner(const Mac::ExtAddress *aEui64, const char *aPskd
 
     VerifyOrExit(StringLength(aPskd, Dtls::kPskMaxLength + 1) <= Dtls::kPskMaxLength, error = OT_ERROR_INVALID_ARGS);
 
-    RemoveJoiner(aEui64, 0, /* aNotifyLeader */ false); // remove immediately
+    RemoveJoiner(aEui64, 0, JoinerOperationFlag::kNotNotifyLeader); // remove immediately
 
     for (Joiner *joiner = &mJoiners[0]; joiner < OT_ARRAY_END(mJoiners); joiner++)
     {
@@ -348,11 +348,11 @@ exit:
     return error;
 }
 
-otError Commissioner::RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDelay, bool aNotifyLeader)
+otError Commissioner::RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDelay, JoinerOperationFlag flags)
 {
     otError error = OT_ERROR_NOT_FOUND;
 
-    OT_ASSERT(aNotifyLeader || aDelay == 0);
+    OT_ASSERT(!(flags & JoinerOperationFlag::kNotNotifyLeader) || aDelay == 0);
 
     VerifyOrExit(mState == OT_COMMISSIONER_STATE_ACTIVE, error = OT_ERROR_INVALID_STATE);
 
@@ -391,7 +391,7 @@ otError Commissioner::RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDela
 
             joiner->mValid = false;
             UpdateJoinerExpirationTimer();
-            if (aNotifyLeader)
+            if ((flags & JoinerOperationFlag::kNotNotifyLeader) == 0)
             {
                 SendCommissionerSet();
             }

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -62,10 +62,10 @@ public:
      * Joiner operation flags.
      *
      */
-    enum JoinerOperationFlag
+    enum JoinerOpFlag
     {
-        kDefault         = 0,      ///< The default flags
-        kNotNotifyLeader = 1 << 0, ///< Do not notify Leader
+        kJoinerOpFlagDefault         = 0,      ///< The default flags
+        kJoinerOpFlagNotNotifyLeader = 1 << 0, ///< Do not notify Leader
     };
 
     /**
@@ -147,9 +147,7 @@ public:
      * @retval OT_ERROR_INVALID_STATE  Commissioner service is not started.
      *
      */
-    otError RemoveJoiner(const Mac::ExtAddress *aEui64,
-                         uint32_t               aDelay,
-                         JoinerOperationFlag    flags = JoinerOperationFlag::kDefault);
+    otError RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDelay, JoinerOpFlag flags = kJoinerOpFlagDefault);
 
     /**
      * This method gets the Provisioning URL.

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -128,15 +128,16 @@ public:
     /**
      * This method removes a Joiner entry.
      *
-     * @param[in]  aEui64          A pointer to the Joiner's IEEE EUI-64 or NULL for any Joiner.
-     * @param[in]  aDelay          The delay to remove Joiner (in seconds).
+     * @param[in]  aEui64         A pointer to the Joiner's IEEE EUI-64 or NULL for any Joiner.
+     * @param[in]  aDelay         The delay to remove Joiner (in seconds).
+     * @param[in]  aNotifyLeader  Whether or not to send MGMT_COMMISSISONER_SET.req to notify Leader.
      *
      * @retval OT_ERROR_NONE           Successfully added the Joiner.
      * @retval OT_ERROR_NOT_FOUND      The Joiner specified by @p aEui64 was not found.
      * @retval OT_ERROR_INVALID_STATE  Commissioner service is not started.
      *
      */
-    otError RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDelay);
+    otError RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDelay, bool aNotifyLeader = true);
 
     /**
      * This method gets the Provisioning URL.

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -59,6 +59,16 @@ class Commissioner : public InstanceLocator
 {
 public:
     /**
+     * Joiner operation flags.
+     *
+     */
+    enum JoinerOperationFlag
+    {
+        kDefault         = 0,      ///< The default flags
+        kNotNotifyLeader = 1 << 0, ///< Do not notify Leader
+    };
+
+    /**
      * This constructor initializes the Commissioner object.
      *
      * @param[in]  aInstance     A reference to the OpenThread instance.
@@ -137,7 +147,9 @@ public:
      * @retval OT_ERROR_INVALID_STATE  Commissioner service is not started.
      *
      */
-    otError RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDelay, bool aNotifyLeader = true);
+    otError RemoveJoiner(const Mac::ExtAddress *aEui64,
+                         uint32_t               aDelay,
+                         JoinerOperationFlag    flags = JoinerOperationFlag::kDefault);
 
     /**
      * This method gets the Provisioning URL.

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -140,14 +140,15 @@ public:
      *
      * @param[in]  aEui64         A pointer to the Joiner's IEEE EUI-64 or NULL for any Joiner.
      * @param[in]  aDelay         The delay to remove Joiner (in seconds).
-     * @param[in]  aNotifyLeader  Whether or not to send MGMT_COMMISSISONER_SET.req to notify Leader.
+     * @param[in]  aFlags         The flags for removing the Joiner.
      *
      * @retval OT_ERROR_NONE           Successfully added the Joiner.
      * @retval OT_ERROR_NOT_FOUND      The Joiner specified by @p aEui64 was not found.
      * @retval OT_ERROR_INVALID_STATE  Commissioner service is not started.
      *
+     * @sa JoinerOpFlag
      */
-    otError RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDelay, JoinerOpFlag flags = kJoinerOpFlagDefault);
+    otError RemoveJoiner(const Mac::ExtAddress *aEui64, uint32_t aDelay, JoinerOpFlag aFlags = kJoinerOpFlagDefault);
 
     /**
      * This method gets the Provisioning URL.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2836,8 +2836,7 @@ otError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Me
         case MeshCoP::Tlv::kExtendedPanId:
             aMessage.Read(offset, sizeof(extPanId), &extPanId);
             VerifyOrExit(extPanId.IsValid(), error = OT_ERROR_PARSE);
-            VerifyOrExit(Get<Mac::Mac>().GetExtendedPanId() != extPanId.GetExtendedPanId(),
-                         error = OT_ERROR_ADDRESS_FILTERED);
+            VerifyOrExit(Get<Mac::Mac>().GetExtendedPanId() != extPanId.GetExtendedPanId(), error = OT_ERROR_DROP);
 
             break;
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2827,7 +2827,7 @@ otError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Me
                 else // if steering data is not set out of band, fall back to network data
 #endif               // OPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE
                 {
-                    VerifyOrExit(Get<NetworkData::Leader>().IsJoiningEnabled(), OT_NOOP);
+                    VerifyOrExit(Get<NetworkData::Leader>().IsJoiningEnabled(), error = OT_ERROR_SECURITY);
                 }
             }
 
@@ -2836,7 +2836,8 @@ otError MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Me
         case MeshCoP::Tlv::kExtendedPanId:
             aMessage.Read(offset, sizeof(extPanId), &extPanId);
             VerifyOrExit(extPanId.IsValid(), error = OT_ERROR_PARSE);
-            VerifyOrExit(Get<Mac::Mac>().GetExtendedPanId() != extPanId.GetExtendedPanId(), OT_NOOP);
+            VerifyOrExit(Get<Mac::Mac>().GetExtendedPanId() != extPanId.GetExtendedPanId(),
+                         error = OT_ERROR_ADDRESS_FILTERED);
 
             break;
 


### PR DESCRIPTION
This PR:
1. Removes the unnecessary `MGMT_COMMISSISONER_SET.req` sent by Commissioner to Leader when a Joiner is removed only to be added back. 
2. Use proper error codes for `MleRouter::HandleDiscoveryRequest`