### PR TITLE
[dua] save dad counter into non volatile memory

### DIFF
--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -81,7 +81,7 @@ void SettingsBase::LogChildInfo(const char *aAction, const ChildInfo &aChildInfo
 #if OPENTHREAD_CONFIG_DUA_ENABLE
 void SettingsBase::LogDadInfo(const char *aAction, const DadInfo &aDadInfo) const
 {
-    otLogInfoCore("Non-volatile: %s DadInfo {DadCounter:0x%2d}", aAction, aDadInfo.mDadCounter);
+    otLogInfoCore("Non-volatile: %s DadInfo {DadCounter:%2d}", aAction, aDadInfo.mDadCounter);
 }
 #endif
 

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -78,6 +78,13 @@ void SettingsBase::LogChildInfo(const char *aAction, const ChildInfo &aChildInfo
                   aChildInfo.GetMode(), aChildInfo.GetVersion());
 }
 
+#if OPENTHREAD_CONFIG_DUA_ENABLE
+void SettingsBase::LogDadInfo(const char *aAction, const DadInfo &aDadInfo) const
+{
+    otLogInfoCore("Non-volatile: %s DadInfo {DadCounter:0x%2d}", aAction, aDadInfo.mDadCounter);
+}
+#endif
+
 #endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO)
 
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN)
@@ -394,6 +401,54 @@ void Settings::ChildInfoIterator::Read(void)
 exit:
     mIsDone = (error != OT_ERROR_NONE);
 }
+
+#if OPENTHREAD_CONFIG_DUA_ENABLE
+otError Settings::ReadDadInfo(DadInfo &aDadInfo) const
+{
+    otError  error;
+    uint16_t length = sizeof(DadInfo);
+
+    aDadInfo.Init();
+    SuccessOrExit(error = Read(kKeyDadInfo, &aDadInfo, length));
+    LogDadInfo("Read", aDadInfo);
+
+exit:
+    return error;
+}
+
+otError Settings::SaveDadInfo(const DadInfo &aDadInfo)
+{
+    otError  error = OT_ERROR_NONE;
+    DadInfo  prevDadInfo;
+    uint16_t length = sizeof(DadInfo);
+
+    if ((Read(kKeyDadInfo, &prevDadInfo, length) == OT_ERROR_NONE) && (length == sizeof(DadInfo)) &&
+        (memcmp(&prevDadInfo, &aDadInfo, sizeof(DadInfo)) == 0))
+    {
+        LogDadInfo("Re-saved", aDadInfo);
+        ExitNow();
+    }
+
+    SuccessOrExit(error = Save(kKeyDadInfo, &aDadInfo, sizeof(DadInfo)));
+    LogDadInfo("Saved", aDadInfo);
+
+exit:
+    LogFailure(error, "saving DadInfo", false);
+    return error;
+}
+
+otError Settings::DeleteDadInfo(void)
+{
+    otError error;
+
+    SuccessOrExit(error = Delete(kKeyDadInfo));
+    otLogInfoCore("Non-volatile: Deleted DadInfo");
+
+exit:
+    LogFailure(error, "deleting DadInfo", true);
+    return error;
+}
+#endif // OPENTHREAD_CONFIG_DUA_ENABLE
 
 otError Settings::Read(Key aKey, void *aBuffer, uint16_t &aSize) const
 {

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -539,6 +539,40 @@ public:
     } OT_TOOL_PACKED_END;
 
     /**
+     * This structure represents the duplicate address detection information for settings storage.
+     *
+     */
+    OT_TOOL_PACKED_BEGIN
+    class DadInfo
+    {
+    public:
+        /**
+         * This method clears the struct object (setting all the fields to zero).
+         *
+         */
+        void Init(void) { memset(this, 0, sizeof(*this)); }
+
+        /**
+         * This method returns the Dad Counter.
+         *
+         * @returns The Dad Counter value.
+         *
+         */
+        uint8_t GetDadCounter(void) const { return mDadCounter; }
+
+        /**
+         * This method sets the Dad Counter.
+         *
+         * @param[in] aDadCounter The Dad Counter value.
+         *
+         */
+        void SetDadCounter(uint8_t aDadCounter) { mDadCounter = aDadCounter; }
+
+    private:
+        uint8_t mDadCounter; ///< Dad Counter used to resolve address conflict in Thread 1.2 DUA feature.
+    } OT_TOOL_PACKED_END;
+
+    /**
      * This enumeration defines the keys of settings.
      *
      */
@@ -551,6 +585,7 @@ public:
         kKeyChildInfo         = 0x0005, ///< Child information
         kKeyReserved          = 0x0006, ///< Reserved (previously auto-start)
         kKeySlaacIidSecretKey = 0x0007, ///< Secret key used by SLAAC module for generating semantically opaque IID
+        kKeyDadInfo           = 0x0008, ///< Duplicate Address Detection (DAD) information.
     };
 
 protected:
@@ -563,11 +598,17 @@ protected:
     void LogNetworkInfo(const char *aAction, const NetworkInfo &aNetworkInfo) const;
     void LogParentInfo(const char *aAction, const ParentInfo &aParentInfo) const;
     void LogChildInfo(const char *aAction, const ChildInfo &aChildInfo) const;
-#else
+#if OPENTHREAD_CONFIG_DUA_ENABLE
+    void LogDadInfo(const char *aAction, const DadInfo &aDadInfo) const;
+#endif // OPENTHREAD_CONFIG_DUA_ENABLE
+#else  // (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_UTIL != 0)
     void LogNetworkInfo(const char *, const NetworkInfo &) const {}
     void LogParentInfo(const char *, const ParentInfo &) const {}
     void LogChildInfo(const char *, const ChildInfo &) const {}
-#endif
+#if OPENTHREAD_CONFIG_DUA_ENABLE
+    void LogDadInfo(const char *, const DadInfo &) const {}
+#endif // OPENTHREAD_CONFIG_DUA_ENABLE
+#endif // (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_UTIL != 0)
 
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && (OPENTHREAD_CONFIG_LOG_UTIL != 0)
     void LogFailure(otError aError, const char *aAction, bool aIsDelete) const;
@@ -863,6 +904,42 @@ public:
         uint16_t  mIndex;
         bool      mIsDone;
     };
+
+#if OPENTHREAD_CONFIG_DUA_ENABLE
+
+    /**
+     * This method saves duplicate address detection information.
+     *
+     * @param[in]   aDadInfo           A reference to a `DadInfo` structure to be saved.
+     *
+     * @retval OT_ERROR_NONE              Successfully saved duplicate address detection information in settings.
+     * @retval OT_ERROR_NOT_IMPLEMENTED   The platform does not implement settings functionality.
+     *
+     */
+    otError SaveDadInfo(const DadInfo &aDadInfo);
+
+    /**
+     * This method reads duplicate address detection information.
+     *
+     * @param[out]   aDadInfo         A reference to a `DadInfo` structure to output the read content.
+     *
+     * @retval OT_ERROR_NONE              Successfully read the duplicate address detection information.
+     * @retval OT_ERROR_NOT_FOUND         No corresponding value in the setting store.
+     * @retval OT_ERROR_NOT_IMPLEMENTED   The platform does not implement settings functionality.
+     *
+     */
+    otError ReadDadInfo(DadInfo &aDadInfo) const;
+
+    /**
+     * This method deletes duplicate address detection information from settings.
+     *
+     * @retval OT_ERROR_NONE             Successfully deleted the value.
+     * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
+     *
+     */
+    otError DeleteDadInfo(void);
+
+#endif // OPENTHREAD_CONFIG_DUA_ENABLE
 
 private:
     otError Read(Key aKey, void *aBuffer, uint16_t &aSize) const;

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -600,14 +600,14 @@ protected:
     void LogChildInfo(const char *aAction, const ChildInfo &aChildInfo) const;
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     void LogDadInfo(const char *aAction, const DadInfo &aDadInfo) const;
-#endif // OPENTHREAD_CONFIG_DUA_ENABLE
+#endif
 #else  // (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_UTIL != 0)
     void LogNetworkInfo(const char *, const NetworkInfo &) const {}
     void LogParentInfo(const char *, const ParentInfo &) const {}
     void LogChildInfo(const char *, const ChildInfo &) const {}
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     void LogDadInfo(const char *, const DadInfo &) const {}
-#endif // OPENTHREAD_CONFIG_DUA_ENABLE
+#endif
 #endif // (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_UTIL != 0)
 
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && (OPENTHREAD_CONFIG_LOG_UTIL != 0)

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -601,7 +601,7 @@ protected:
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     void LogDadInfo(const char *aAction, const DadInfo &aDadInfo) const;
 #endif
-#else  // (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_UTIL != 0)
+#else // (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_UTIL != 0)
     void LogNetworkInfo(const char *, const NetworkInfo &) const {}
     void LogParentInfo(const char *, const ParentInfo &) const {}
     void LogChildInfo(const char *, const ChildInfo &) const {}

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -164,16 +164,15 @@ exit:
     return;
 }
 
-otError DuaManager::Restore(void)
+void DuaManager::Restore(void)
 {
-    otError           error;
     Settings::DadInfo dadInfo;
 
-    SuccessOrExit(error = Get<Settings>().ReadDadInfo(dadInfo));
+    SuccessOrExit(Get<Settings>().ReadDadInfo(dadInfo));
     mDadCounter = dadInfo.GetDadCounter();
 
 exit:
-    return error;
+    return;
 }
 
 otError DuaManager::Store(void)

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -124,8 +124,18 @@ public:
      */
     const Ip6::InterfaceIdentifier &GetFixedDuaInterfaceIdentifier(void) const { return mFixedDuaInterfaceIdentifier; }
 
+    /*
+     * This method restores duplicate address detection information from non-volatile memory.
+     *
+     * @retval OT_ERROR_NONE       Successfully restored the duplicatee address detection information.
+     * @retval OT_ERROR_NOT_FOUND  There is no valid Dad Counter stored in non-volatile memory.
+     *
+     */
+    otError Restore(void);
+
 private:
     otError GenerateDomainUnicastAddressIid(void);
+    otError Store(void);
 
     Ip6::InterfaceIdentifier mFixedDuaInterfaceIdentifier;
     Ip6::NetifUnicastAddress mDomainUnicastAddress;

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -127,11 +127,8 @@ public:
     /*
      * This method restores duplicate address detection information from non-volatile memory.
      *
-     * @retval OT_ERROR_NONE       Successfully restored the duplicatee address detection information.
-     * @retval OT_ERROR_NOT_FOUND  There is no valid Dad Counter stored in non-volatile memory.
-     *
      */
-    otError Restore(void);
+    void Restore(void);
 
 private:
     otError GenerateDomainUnicastAddressIid(void);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -367,7 +367,7 @@ otError Mle::Restore(void)
     IgnoreError(Get<MeshCoP::PendingDataset>().Restore());
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
-    IgnoreError(Get<DuaManager>().Restore());
+    Get<DuaManager>().Restore();
 #endif
 
     SuccessOrExit(error = Get<Settings>().ReadNetworkInfo(networkInfo));

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -366,6 +366,10 @@ otError Mle::Restore(void)
     IgnoreError(Get<MeshCoP::ActiveDataset>().Restore());
     IgnoreError(Get<MeshCoP::PendingDataset>().Restore());
 
+#if OPENTHREAD_CONFIG_DUA_ENABLE
+    IgnoreError(Get<DuaManager>().Restore());
+#endif
+
     SuccessOrExit(error = Get<Settings>().ReadNetworkInfo(networkInfo));
 
     Get<KeyManager>().SetCurrentKeySequence(networkInfo.GetKeySequence());


### PR DESCRIPTION
This PR depends on #4900 (<-- #4862 <-- #4854).

Please review the last commit which serves the purpose of storing dad counter.

Due to that DUA DAD is not submitted yet, for this PR, just manually verified the dad counter storage and consistency of DUA address generated after reset on another fork branch [librasungirl:12_dua_store_dadcounter_test_only](https://github.com/librasungirl/openthread/commits/12_dua_store_dadcounter_test_only) which introduces some test APIs to manually update (and store) the dad counter.