### PR TITLE
[mac] verify that Security Level is correct in rx frame

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1445,6 +1445,8 @@ otError Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Ne
     VerifyOrExit(aFrame.GetSecurityEnabled(), error = OT_ERROR_NONE);
 
     aFrame.GetSecurityLevel(securityLevel);
+    VerifyOrExit(securityLevel == Frame::kSecEncMic32, OT_NOOP);
+
     aFrame.GetFrameCounter(frameCounter);
     otLogDebgMac("Rx security - frame counter %u", frameCounter);
 


### PR DESCRIPTION
This commit adds a check in `Mac::ProcessReceiveSecurity()` to verify
that the Security Level in a received frame is properly set to
`kSecEncMic32` before trying to decrypt and validate the frame. This
helps avoid performing AES-CCM when frame is invalid and also avoid
potentially reading beyond the frame length when checking MIC/footer.