### PR TITLE
[radio] use otDataset APIs instead of otPlatSettings APIs

### DIFF
--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -520,7 +520,6 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::ThreadDatasetHandler(con
     otOperationalDataset opDataset;
     bool                 isActive = ((mWaitingKey == SPINEL_PROP_THREAD_ACTIVE_DATASET) ? true : false);
     Spinel::Decoder      decoder;
-    MeshCoP::Dataset     dataset(isActive ? MeshCoP::Dataset::kActive : MeshCoP::Dataset::kPending);
 
     memset(&opDataset, 0, sizeof(otOperationalDataset));
     decoder.Init(aBuffer, aLength);
@@ -658,10 +657,14 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::ThreadDatasetHandler(con
     opDataset.mActiveTimestamp                      = 0;
     opDataset.mComponents.mIsActiveTimestampPresent = true;
 
-    SuccessOrExit(error = dataset.SetFrom(opDataset));
-    SuccessOrExit(error = otPlatSettingsSet(
-                      mInstance, isActive ? SettingsBase::kKeyActiveDataset : SettingsBase::kKeyPendingDataset,
-                      dataset.GetBytes(), dataset.GetSize()));
+    if (isActive)
+    {
+        SuccessOrExit(error = otDatasetSetActive(mInstance, &opDataset));
+    }
+    else
+    {
+        SuccessOrExit(error = otDatasetSetPending(mInstance, &opDataset));
+    }
 
 exit:
     return error;


### PR DESCRIPTION
This PR replaces use of `otPlatSettingsSet()` in `radio_spinel_impl.hpp` to equivalent `otDatasetSetActive()` and `otDatasetSetPending()`, because `otPlatSettings` APIs are not mandatory for all platforms while `otDataset` APIs are provided by openthread itself.