### PR TITLE
[continuous-integration] recover verbose check

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -84,7 +84,7 @@ jobs:
         make -f examples/Makefile-simulation
     - name: Run
       run: |
-        make -f examples/Makefile-simulation check
+        VERBOSE=1 make -f examples/Makefile-simulation check
     - name: Codecov
       uses: codecov/codecov-action@v1
 
@@ -111,7 +111,7 @@ jobs:
         make -f examples/Makefile-simulation
     - name: Run
       run: |
-        make -f examples/Makefile-simulation check
+        VERBOSE=1 make -f examples/Makefile-simulation check
     - name: Codecov
       uses: codecov/codecov-action@v1
 
@@ -138,7 +138,7 @@ jobs:
         make -f examples/Makefile-simulation
     - name: Run
       run: |
-        make -f examples/Makefile-simulation check
+        VERBOSE=1 make -f examples/Makefile-simulation check
     - name: Codecov
       uses: codecov/codecov-action@v1
 
@@ -163,7 +163,6 @@ jobs:
       NODE_TYPE: ncp-sim
       PYTHONUNBUFFERED: 1
       REFERENCE_DEVICE: 1
-      VERBOSE: 1
       VIRTUAL_TIME: 1
     steps:
     - uses: actions/checkout@v2
@@ -179,7 +178,7 @@ jobs:
         make -f examples/Makefile-simulation
     - name: Run
       run: |
-        make -f examples/Makefile-simulation check
+        VERBOSE=1 make -f examples/Makefile-simulation check
     - name: Codecov
       uses: codecov/codecov-action@v1
 
@@ -206,7 +205,7 @@ jobs:
         make -f src/posix/Makefile-posix
     - name: Run
       run: |
-        OT_CLI_PATH="$(pwd)/$(ls output/posix/*/bin/ot-cli) -v" RADIO_DEVICE="$(pwd)/$(ls output/*/bin/ot-rcp)" make -f src/posix/Makefile-posix check
+        VERBOSE=1 OT_CLI_PATH="$(pwd)/$(ls output/posix/*/bin/ot-cli) -v" RADIO_DEVICE="$(pwd)/$(ls output/*/bin/ot-rcp)" make -f src/posix/Makefile-posix check
     - name: Codecov
       uses: codecov/codecov-action@v1
 
@@ -218,7 +217,6 @@ jobs:
       PYTHONUNBUFFERED: 1
       READLINE: readline
       REFERENCE_DEVICE: 1
-      VERBOSE: 1
       VIRTUAL_TIME: 1
       VIRTUAL_TIME_UART: 1
     steps:
@@ -236,7 +234,7 @@ jobs:
         make -f src/posix/Makefile-posix
     - name: Run
       run: |
-        OT_NCP_PATH="$(pwd)/$(ls output/posix/*/bin/ot-ncp)" RADIO_DEVICE="$(pwd)/$(ls output/*/bin/ot-rcp)" make -f src/posix/Makefile-posix check
+        VERBOSE=1 OT_NCP_PATH="$(pwd)/$(ls output/posix/*/bin/ot-ncp)" RADIO_DEVICE="$(pwd)/$(ls output/*/bin/ot-rcp)" make -f src/posix/Makefile-posix check
     - name: Codecov
       uses: codecov/codecov-action@v1
 


### PR DESCRIPTION
The error logs of `check` will only be printed when VERBOSE=1.