### PR TITLE
[cmake] add log output option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,14 +103,16 @@ set(OT_LOG_OUTPUT_VALUES
 if(OT_REFERENCE_DEVICE AND NOT OT_PLATFORM STREQUAL "posix")
     set(OT_LOG_OUTPUT "APP" CACHE STRING "Set log output to application for reference device")
 else()
-    set(OT_LOG_OUTPUT "PLATFORM_DEFINED" CACHE STRING "Where the log output goes to")
+    set(OT_LOG_OUTPUT "" CACHE STRING "Where log output goes to")
 endif()
 set_property(CACHE OT_LOG_OUTPUT PROPERTY STRINGS ${OT_LOG_OUTPUT_VALUES})
-if(NOT OT_LOG_OUTPUT IN_LIST OT_LOG_OUTPUT_VALUES)
-    message(FATAL_ERROR "Log output unknown: ${OT_LOG_OUTPUT}")
+if(OT_LOG_OUTPUT)
+    if(NOT OT_LOG_OUTPUT IN_LIST OT_LOG_OUTPUT_VALUES)
+        message(FATAL_ERROR "Log output unknown: ${OT_LOG_OUTPUT}")
+    endif()
+    list(APPEND OT_PRIVATE_DEFINES "OPENTHREAD_CONFIG_LOG_OUTPUT=OPENTHREAD_CONFIG_LOG_OUTPUT_${OT_LOG_OUTPUT}")
+    message(STATUS "Log output: ${OT_LOG_OUTPUT}")
 endif()
-message(STATUS "Log output: ${OT_LOG_OUTPUT}")
-list(APPEND OT_PRIVATE_DEFINES "OPENTHREAD_CONFIG_LOG_OUTPUT=OPENTHREAD_CONFIG_LOG_OUTPUT_${OT_LOG_OUTPUT}")
 
 # OT_CONFIG allows users to specify the path to OpenThread project core
 # config header file. The default value of this parameter is empty string.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,6 +93,25 @@ if(NOT OT_PLATFORM IN_LIST OT_EXAMPLE_PLATFORMS)
     endif()
 endif()
 
+set(OT_LOG_OUTPUT_VALUES
+    "APP"
+    "DEBUG_UART"
+    "NCP_SPINEL"
+    "NONE"
+    "PLATFORM_DEFINED"
+)
+if(OT_REFERENCE_DEVICE AND NOT OT_PLATFORM STREQUAL "posix")
+    set(OT_LOG_OUTPUT "APP" CACHE STRING "Set log output to application for reference device")
+else()
+    set(OT_LOG_OUTPUT "PLATFORM_DEFINED" CACHE STRING "Where the log output goes to")
+endif()
+set_property(CACHE OT_LOG_OUTPUT PROPERTY STRINGS ${OT_LOG_OUTPUT_VALUES})
+if(NOT OT_LOG_OUTPUT IN_LIST OT_LOG_OUTPUT_VALUES)
+    message(FATAL_ERROR "Log output unknown: ${OT_LOG_OUTPUT}")
+endif()
+message(STATUS "Log output: ${OT_LOG_OUTPUT}")
+list(APPEND OT_PRIVATE_DEFINES "OPENTHREAD_CONFIG_LOG_OUTPUT=OPENTHREAD_CONFIG_LOG_OUTPUT_${OT_LOG_OUTPUT}")
+
 # OT_CONFIG allows users to specify the path to OpenThread project core
 # config header file. The default value of this parameter is empty string.
 # When not specified by user (value is ""), a platform cmake file may
@@ -135,3 +154,5 @@ if(OT_PLATFORM STREQUAL "simulation")
     enable_testing()
     add_subdirectory(tests)
 endif()
+
+message(STATUS "Definitions: ${OT_PRIVATE_DEFINES}")

--- a/examples/apps/cli/CMakeLists.txt
+++ b/examples/apps/cli/CMakeLists.txt
@@ -44,6 +44,9 @@ set(COMMON_INCLUDES
 target_include_directories(ot-cli-ftd PRIVATE ${COMMON_INCLUDES})
 target_include_directories(ot-cli-mtd PRIVATE ${COMMON_INCLUDES})
 
+target_compile_definitions(ot-cli-ftd PRIVATE ${OT_PRIVATE_DEFINES})
+target_compile_definitions(ot-cli-mtd PRIVATE ${OT_PRIVATE_DEFINES})
+
 target_link_libraries(ot-cli-ftd
     openthread-cli-ftd
     ${OT_PLATFORM_LIB}

--- a/examples/apps/ncp/CMakeLists.txt
+++ b/examples/apps/ncp/CMakeLists.txt
@@ -49,6 +49,10 @@ target_include_directories(ot-ncp-ftd PRIVATE ${COMMON_INCLUDES})
 target_include_directories(ot-ncp-mtd PRIVATE ${COMMON_INCLUDES})
 target_include_directories(ot-rcp PRIVATE ${COMMON_INCLUDES})
 
+target_compile_definitions(ot-ncp-ftd PRIVATE ${OT_PRIVATE_DEFINES})
+target_compile_definitions(ot-ncp-mtd PRIVATE ${OT_PRIVATE_DEFINES})
+target_compile_definitions(ot-rcp PRIVATE ${OT_PRIVATE_DEFINES})
+
 target_link_libraries(ot-ncp-ftd
     openthread-ncp-ftd
     ${OT_PLATFORM_LIB}


### PR DESCRIPTION
This is required for running commissioning related tests for the
commissioning messages are retrieved from logs.