### PR TITLE
[joiner] use random extended address for discovery request

### DIFF
--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -96,15 +96,15 @@ otError Joiner::Start(const char *     aPskd,
                       void *           aContext)
 {
     otError         error;
-    Mac::ExtAddress extAddress;
+    Mac::ExtAddress randomAddress;
 
     otLogInfoMeshCoP("Joiner starting");
 
     VerifyOrExit(mState == OT_JOINER_STATE_IDLE, error = OT_ERROR_BUSY);
 
     // Use random-generated extended address.
-    extAddress.GenerateRandom();
-    Get<Mac::Mac>().SetExtAddress(extAddress);
+    randomAddress.GenerateRandom();
+    Get<Mac::Mac>().SetExtAddress(randomAddress);
     Get<Mle::MleRouter>().UpdateLinkLocalAddress();
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().Start(kJoinerUdpPort));

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -96,15 +96,15 @@ otError Joiner::Start(const char *     aPskd,
                       void *           aContext)
 {
     otError         error;
-    Mac::ExtAddress joinerId;
+    Mac::ExtAddress extAddress;
 
     otLogInfoMeshCoP("Joiner starting");
 
     VerifyOrExit(mState == OT_JOINER_STATE_IDLE, error = OT_ERROR_BUSY);
 
-    // Use extended address based on factory-assigned IEEE EUI-64
-    GetJoinerId(joinerId);
-    Get<Mac::Mac>().SetExtAddress(joinerId);
+    // Use random-generated extended address.
+    extAddress.GenerateRandom();
+    Get<Mac::Mac>().SetExtAddress(extAddress);
     Get<Mle::MleRouter>().UpdateLinkLocalAddress();
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().Start(kJoinerUdpPort));
@@ -222,6 +222,8 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult, void *aContext)
 
 void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
 {
+    Mac::ExtAddress joinerId;
+
     VerifyOrExit(mState == OT_JOINER_STATE_DISCOVER, OT_NOOP);
 
     if (aResult != NULL)
@@ -230,6 +232,11 @@ void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
     }
     else
     {
+        // Use extended address based on factory-assigned IEEE EUI-64
+        GetJoinerId(joinerId);
+        Get<Mac::Mac>().SetExtAddress(joinerId);
+        Get<Mle::MleRouter>().UpdateLinkLocalAddress();
+
         mJoinerRouterIndex = 0;
         TryNextJoinerRouter(OT_ERROR_NONE);
     }


### PR DESCRIPTION
This PR fixes the bug that OpenThread uses hash of EUI64 (joiner ID) as the source address of Discovery Request messages. Thread specification requires the source address to be random value:

> Discovery Request messages MUST have the Source Address in the IEEE 802.15.4 header
set to an extended (64-bit) random generated value.

(section 8.4.4.1.1.1 of Thread 1.1 specification).

While for subsequent messages, the joiner should use hash of EUI64 (joiner ID) value:

> When the Thread device is configured to obtain Thread Network security credentials using Thread
Commissioning as specified in Chapter 8, Mesh Commissioning Protocol, the specific value
provided by the device to the MAC sub-layer to represent the aExtendedAddress prior to obtaining
the network security credentials MUST be the first 64 bits of the result of computing SHA-256 over
the universally administered IEEE EUI-64 value that has been factory assigned to the Thread
interface instead of the actual IEEE EUI-64 value.

(table 3-2 of Thread 1.1 specification).

related JIRA issue: [Discovery request should have MAC source address set to 64-bit hash of IEEE EUI64](https://threadgroup.atlassian.net/browse/SPEC-927?atlOrigin=eyJpIjoiYTkwMzg4NGFkMGY4NDQ1Y2IzZTQ3ZmE1ZWQ2ZTQ0ZmYiLCJwIjoiaiJ9).