### PR TITLE
[logging] fix typo for otDumpNote definition

### DIFF
--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -1206,7 +1206,7 @@ extern "C" {
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
 #define otDumpNote(aRegion, aId, aBuf, aLength) otDump(OT_LOG_LEVEL_NOTE, aRegion, aId, aBuf, aLength)
 #else
-#define otDumpInfo(aRegion, aId, aBuf, aLength)
+#define otDumpNote(aRegion, aId, aBuf, aLength)
 #endif
 
 /**


### PR DESCRIPTION
otDumpNote definition looks like it was copy/pasted from otDumpInfo and hasn't been compiled with the appropriate compile options and an actual call to otDumpNote.