### PR TITLE
[build] add -Wcast-align to detect potential alignment issues when casting

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -233,8 +233,8 @@ AC_PROG_LIBTOOL
 #   -Wall                        CC, CXX
 #
 
-PROSPECTIVE_CFLAGS="-Wall -Wextra -Wshadow -Wundef -Werror -Wno-error=undef -std=c99 -pedantic-errors"
-PROSPECTIVE_CXXFLAGS="-Wall -Wextra -Wshadow -Wundef -Werror -Wno-error=undef -std=gnu++98 -Wno-c++14-compat -fno-exceptions"
+PROSPECTIVE_CFLAGS="-Wall -Wextra -Wshadow -Wundef -Wcast-align -Werror -Wno-error=undef -std=c99 -pedantic-errors"
+PROSPECTIVE_CXXFLAGS="-Wall -Wextra -Wshadow -Wundef -Wcast-align -Werror -Wno-error=undef -std=gnu++98 -Wno-c++14-compat -fno-exceptions"
 
 AC_CACHE_CHECK([whether $CC is Clang],
     [nl_cv_clang],

--- a/examples/platforms/cc1352/Makefile.am
+++ b/examples/platforms/cc1352/Makefile.am
@@ -28,6 +28,10 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+# Do not enable -Wcast-align for this platform
+override CFLAGS    := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS  := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 lib_LIBRARIES = libopenthread-cc1352.a
 
 libopenthread_cc1352_a_CPPFLAGS                                                         = \

--- a/examples/platforms/cc2538/Makefile.am
+++ b/examples/platforms/cc2538/Makefile.am
@@ -28,6 +28,10 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+# Do not enable -Wcast-align for this platform
+override CFLAGS    := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS  := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 lib_LIBRARIES                             = libopenthread-cc2538.a
 
 libopenthread_cc2538_a_CPPFLAGS           = \

--- a/examples/platforms/cc2650/Makefile.am
+++ b/examples/platforms/cc2650/Makefile.am
@@ -28,6 +28,10 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+# Do not enable -Wcast-align for this platform
+override CFLAGS    := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS  := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 lib_LIBRARIES                                         = libopenthread-cc2650.a
 
 libopenthread_cc2650_a_CPPFLAGS                       = \

--- a/examples/platforms/cc2652/Makefile.am
+++ b/examples/platforms/cc2652/Makefile.am
@@ -28,6 +28,10 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+# Do not enable -Wcast-align for this platform
+override CFLAGS    := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS  := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 lib_LIBRARIES = libopenthread-cc2652.a
 
 libopenthread_cc2652_a_CPPFLAGS                                                         = \

--- a/examples/platforms/gp712/Makefile.am
+++ b/examples/platforms/gp712/Makefile.am
@@ -28,6 +28,10 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+# Do not enable -Wcast-align for this platform
+override CFLAGS    := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS  := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 lib_LIBRARIES                             = libopenthread-gp712.a
 
 libopenthread_gp712_a_CPPFLAGS            = \

--- a/examples/platforms/jn5189/Makefile.am
+++ b/examples/platforms/jn5189/Makefile.am
@@ -34,12 +34,16 @@ lib_LIBRARIES                                                                   
     $(NULL)
 
 # Do not enable -pedantic-errors for jn5189 driver library
-override CFLAGS                                      := $(filter-out -pedantic-errors,$(CFLAGS))
-override CXXFLAGS                                    := $(filter-out -pedantic-errors,$(CXXFLAGS))
+override CFLAGS    := $(filter-out -pedantic-errors,$(CFLAGS))
+override CXXFLAGS  := $(filter-out -pedantic-errors,$(CXXFLAGS))
 
 # Do not enable -Wundef for jn5189 driver library
 override CFLAGS    := $(filter-out -Wundef,$(CFLAGS))
 override CXXFLAGS  := $(filter-out -Wundef,$(CXXFLAGS))
+
+# Do not enable -Wcast-align for this platform
+override CFLAGS    := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS  := $(filter-out -Wcast-align,$(CXXFLAGS))
 
 LIB_FLAGS                                                                                          = \
     -DCPU_JN518X                                                                                     \

--- a/examples/platforms/kw41z/Makefile.am
+++ b/examples/platforms/kw41z/Makefile.am
@@ -34,6 +34,10 @@ lib_LIBRARIES = libopenthread-kw41z.a
 override CFLAGS                              := $(filter-out -Wundef,$(CFLAGS))
 override CXXFLAGS                            := $(filter-out -Wundef,$(CXXFLAGS))
 
+# Do not enable -Wcast-align for this platform
+override CFLAGS                              := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS                            := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 libopenthread_kw41z_a_CPPFLAGS                                                                     = \
     -DCPU_MKW41Z512VHT4                                                                              \
     -I$(top_srcdir)/include                                                                          \

--- a/examples/platforms/nrf528xx/nrf52811/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52811/Makefile.am
@@ -42,6 +42,10 @@ override CXXFLAGS                                    := $(filter-out -pedantic-e
 override CFLAGS                                      := $(filter-out -Wundef,$(CFLAGS))
 override CXXFLAGS                                    := $(filter-out -Wundef,$(CXXFLAGS))
 
+# Do not enable -Wcast-align for nRF52811 driver library
+override CFLAGS                                      := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS                                    := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 COMMONCPPFLAGS                                                                                             = \
     -DCONFIG_GPIO_AS_PINRESET                                                                                \
     -DNRF52811_XXAA                                                                                          \

--- a/examples/platforms/nrf528xx/nrf52833/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52833/Makefile.am
@@ -43,6 +43,10 @@ override CXXFLAGS                                    := $(filter-out -pedantic-e
 override CFLAGS                                      := $(filter-out -Wundef,$(CFLAGS))
 override CXXFLAGS                                    := $(filter-out -Wundef,$(CXXFLAGS))
 
+# Do not enable -Wcast-align for nRF52833 driver library
+override CFLAGS                                      := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS                                    := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 COMMONCPPFLAGS                                                                                             = \
     -DCONFIG_GPIO_AS_PINRESET                                                                                \
     -DNRF52833_XXAA                                                                                          \

--- a/examples/platforms/nrf528xx/nrf52840/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52840/Makefile.am
@@ -43,6 +43,10 @@ override CXXFLAGS                                    := $(filter-out -pedantic-e
 override CFLAGS                                      := $(filter-out -Wundef,$(CFLAGS))
 override CXXFLAGS                                    := $(filter-out -Wundef,$(CXXFLAGS))
 
+# Do not enable -Wcast-align for nRF52840 driver library
+override CFLAGS                                      := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS                                    := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 COMMONCPPFLAGS                                                                                             = \
     -DCONFIG_GPIO_AS_PINRESET                                                                                \
     -DNRF52840_XXAA                                                                                          \

--- a/examples/platforms/qpg6095/Makefile.am
+++ b/examples/platforms/qpg6095/Makefile.am
@@ -28,6 +28,10 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+# Do not enable -Wcast-align for this platform
+override CFLAGS    := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS  := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 lib_LIBRARIES                               = libopenthread-qpg6095.a
 
 libopenthread_qpg6095_a_CPPFLAGS            = \

--- a/examples/platforms/samr21/Makefile.am
+++ b/examples/platforms/samr21/Makefile.am
@@ -37,6 +37,10 @@ override CXXFLAGS                            := $(filter-out -pedantic-errors,$(
 override CFLAGS                              := $(filter-out -Wundef,$(CFLAGS))
 override CXXFLAGS                            := $(filter-out -Wundef,$(CXXFLAGS))
 
+# Do not enable -Wcast-align for this platform
+override CFLAGS                              := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS                            := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 libopenthread_samr21_a_CPPFLAGS                                                                              = \
     -D ARM_MATH_CM0PLUS=true                                                                                   \
     -D PHY_AT86RF233                                                                                           \

--- a/examples/platforms/utils/settings_ram.c
+++ b/examples/platforms/utils/settings_ram.c
@@ -49,11 +49,12 @@
 static uint8_t  sSettingsBuf[SETTINGS_BUFFER_SIZE];
 static uint16_t sSettingsBufLength;
 
+OT_TOOL_PACKED_BEGIN
 struct settingsBlock
 {
     uint16_t key;
     uint16_t length;
-};
+} OT_TOOL_PACKED_END;
 
 // settings API
 void otPlatSettingsInit(otInstance *aInstance)

--- a/src/core/utils/heap.hpp
+++ b/src/core/utils/heap.hpp
@@ -93,7 +93,8 @@ public:
      */
     uint16_t GetNext(void) const
     {
-        return *reinterpret_cast<const uint16_t *>(reinterpret_cast<const uint8_t *>(this) + sizeof(mSize) + mSize);
+        return *reinterpret_cast<const uint16_t *>(
+            reinterpret_cast<const void *>(reinterpret_cast<const uint8_t *>(this) + sizeof(mSize) + mSize));
     }
 
     /**
@@ -106,7 +107,8 @@ public:
      */
     void SetNext(uint16_t aNext)
     {
-        *reinterpret_cast<uint16_t *>(reinterpret_cast<uint8_t *>(this) + sizeof(mSize) + mSize) = aNext;
+        *reinterpret_cast<uint16_t *>(
+            reinterpret_cast<void *>(reinterpret_cast<uint8_t *>(this) + sizeof(mSize) + mSize)) = aNext;
     }
 
     /**

--- a/third_party/NordicSemiconductor/Makefile.am
+++ b/third_party/NordicSemiconductor/Makefile.am
@@ -80,6 +80,10 @@ override CXXFLAGS := $(filter-out -pedantic-errors,$(CXXFLAGS))
 override CFLAGS   := $(filter-out -Wundef,$(CFLAGS))
 override CXXFLAGS := $(filter-out -Wundef,$(CXXFLAGS))
 
+# Do not enable -Wcast-align for Nordic Semiconductor driver library
+override CFLAGS   := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 COMMONCPPFLAGS                                                                                                          = \
     -DCONFIG_GPIO_AS_PINRESET                                                                                             \
     -DENABLE_FEM=1                                                                                                        \

--- a/third_party/jlink/Makefile.am
+++ b/third_party/jlink/Makefile.am
@@ -32,6 +32,10 @@ include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 override CFLAGS                                      := $(filter-out -Wundef,$(CFLAGS))
 override CXXFLAGS                                    := $(filter-out -Wundef,$(CXXFLAGS))
 
+# Do not enable -Wcast-align for jlink library
+override CFLAGS                                      := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS                                    := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 lib_LIBRARIES                                             = libjlinkrtt.a
 
 libjlinkrtt_a_CPPFLAGS                                    = \

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -31,6 +31,10 @@ override CXXFLAGS                            := $(filter-out -Wconversion,$(CXXF
 override CFLAGS                              := $(filter-out -pedantic-errors,$(CFLAGS))
 override CXXFLAGS                            := $(filter-out -pedantic-errors,$(CXXFLAGS))
 
+# Do not enable -Wcast-align for mbedtls
+override CFLAGS                              := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS                            := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 MBEDTLS_SRCDIR                                = $(top_srcdir)/third_party/mbedtls/repo
 
 libmbedcrypto_a_CPPFLAGS                      = \

--- a/third_party/silabs/Makefile.am
+++ b/third_party/silabs/Makefile.am
@@ -62,6 +62,10 @@ override CXXFLAGS  := $(filter-out -Wshadow,$(CXXFLAGS))
 override CFLAGS    := $(filter-out -Wundef,$(CFLAGS))
 override CXXFLAGS  := $(filter-out -Wundef,$(CXXFLAGS))
 
+# Do not enable -Wcast-align for Silicon Labs SDK sources
+override CFLAGS    := $(filter-out -Wcast-align,$(CFLAGS))
+override CXXFLAGS  := $(filter-out -Wcast-align,$(CXXFLAGS))
+
 EFR32_BOARD_DIR = $(shell echo $(BOARD) | tr A-Z a-z)
 
 SDK_SRC_DIR = $(top_srcdir)/third_party/silabs/gecko_sdk_suite/v2.7


### PR DESCRIPTION
Hi all, this PR enables the -Wcast-align warning for the OT core, and for some platforms (very few that don't issue warnings).

For background, see #4796.