### PR TITLE
[flash] avoid more than two writes to the same 32-bit word

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -352,6 +352,7 @@ HEADERS_COMMON                             = \
     config/diag.h                            \
     config/dns_client.h                      \
     config/ip6.h                             \
+    config/flash.h                           \
     config/joiner.h                          \
     config/link_quality.h                    \
     config/link_raw.h                        \

--- a/src/core/config/flash.h
+++ b/src/core/config/flash.h
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes compile-time configurations for the Flash API service.
+ *
+ */
+
+#ifndef CONFIG_FLASH_H_
+#define CONFIG_FLASH_H_
+
+/**
+ * @def OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+ *
+ * Define to 1 to enable otPlatFlash* APIs to support non-volatile storage.
+ *
+ * When defined to 1, the platform MUST implement the otPlatFlash* APIs instead of the otPlatSettings* APIs.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+#define OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE 0
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE_NEW_FORMAT
+ *
+ * Define to 1 to enable the new flash format. The new format guarantees that flash words are written at most twice.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE_NEW_FORMAT
+#define OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE_NEW_FORMAT 1
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE_LEGACY_FORMAT_SUPPORT
+ *
+ * Define to 1 to continue to support the old format. Only significant if
+ * OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE_NEW_FORMAT is 1.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE_LEGACY_FORMAT_SUPPORT
+#define OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE_LEGACY_FORMAT_SUPPORT 1
+#endif
+
+#endif // CONFIG_FLASH_H_

--- a/src/core/config/openthread-core-default-config.h
+++ b/src/core/config/openthread-core-default-config.h
@@ -333,18 +333,6 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
- *
- * Define to 1 to enable otPlatFlash* APIs to support non-volatile storage.
- *
- * When defined to 1, the platform MUST implement the otPlatFlash* APIs instead of the otPlatSettings* APIs.
- *
- */
-#ifndef OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
-#define OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE 0
-#endif
-
-/**
  * @def OPENTHREAD_CONFIG_FAILED_CHILD_TRANSMISSIONS
  *
  * This setting configures the number of consecutive MCPS.DATA-Confirms having Status NO_ACK

--- a/src/core/openthread-core-config.h
+++ b/src/core/openthread-core-config.h
@@ -64,6 +64,7 @@
 #include "config/dhcp6_server.h"
 #include "config/diag.h"
 #include "config/dns_client.h"
+#include "config/flash.h"
 #include "config/ip6.h"
 #include "config/joiner.h"
 #include "config/link_quality.h"

--- a/src/core/utils/flash.cpp
+++ b/src/core/utils/flash.cpp
@@ -310,12 +310,12 @@ void Flash::Record::Write(Instance &aInstance, uint8_t aSwapIndex, uint32_t aOff
 
 void Flash::RecordHeader::WriteProgressMarkers(Instance &aInstance, uint8_t aSwapIndex, uint32_t aOffset)
 {
-    otPlatFlashWrite(&aInstance, aSwapIndex, aOffset + offsetof(RecordHeader, mWord1), &mWord1, sizeof(mWord1));
+    otPlatFlashWrite(&aInstance, aSwapIndex, aOffset, &mWord1, sizeof(mWord1));
 }
 
 void Flash::RecordHeader::WriteFirstAndDeletedFlags(Instance &aInstance, uint8_t aSwapIndex, uint32_t aOffset)
 {
-    otPlatFlashWrite(&aInstance, aSwapIndex, aOffset + offsetof(RecordHeader, mWord2), &mWord2, sizeof(mWord2));
+    otPlatFlashWrite(&aInstance, aSwapIndex, aOffset + sizeof(mWord1), &mWord2, sizeof(mWord2));
 }
 
 void Flash::RecordHeader::ReadHeader(Instance &aInstance, uint8_t aSwapIndex, uint32_t aOffset)

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -175,7 +175,7 @@ test_child_table_LDADD       = $(COMMON_LDADD)
 test_child_table_SOURCES     = $(COMMON_SOURCES) test_child_table.cpp
 
 test_flash_LDADD             = $(COMMON_LDADD)
-test_flash_SOURCES           = $(COMMON_SOURCES) test_flash.cpp
+test_flash_SOURCES           = $(COMMON_SOURCES) test_flash.cpp test_flash/flash_v1.cpp
 
 test_hdlc_LDADD              = $(COMMON_LDADD)
 test_hdlc_SOURCES            = $(COMMON_SOURCES) test_hdlc.cpp

--- a/tests/unit/test_flash.cpp
+++ b/tests/unit/test_flash.cpp
@@ -182,6 +182,54 @@ void TestFlash(void)
         VerifyOrQuit(length == key, "Get() did not return expected length");
         VerifyOrQuit(memcmp(readBuffer, writeBuffer, length) == 0, "Get() did not return expected value");
     }
+
+    // Test for the mark-first elision
+
+    {
+        uint16_t length;
+
+        flash.Wipe();
+        SuccessOrQuit(flash.Add(0, writeBuffer, 1), "Add() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 2), "Add() failed");
+        SuccessOrQuit(flash.Set(0, writeBuffer, 3), "Set() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 4), "Add() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 5), "Add() failed");
+
+        SuccessOrQuit(flash.Get(0, 0, readBuffer, &length), "Get() failed");
+        SuccessOrQuit(flash.Get(0, 1, readBuffer, &length), "Get() failed");
+        SuccessOrQuit(flash.Get(0, 2, readBuffer, &length), "Get() failed");
+
+        SuccessOrQuit(flash.Delete(0, 0), "Delete() failed");
+
+        SuccessOrQuit(flash.Get(0, 0, readBuffer, &length), "Get() failed");
+        VerifyOrQuit(length == 4, "Get() did not return expected length");
+
+        SuccessOrQuit(flash.Get(0, 1, readBuffer, &length), "Get() failed");
+        VerifyOrQuit(length == 5, "Get() did not return expected length");
+
+        flash.Wipe();
+        SuccessOrQuit(flash.Add(0, writeBuffer, 1), "Add() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 2), "Add() failed");
+        SuccessOrQuit(flash.Set(0, writeBuffer, 3), "Set() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 4), "Add() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 5), "Add() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 180), "Add() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 248), "Add() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 248), "Add() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 248), "Add() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 248), "Add() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 248), "Add() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 248), "Add() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 248), "Add() failed");
+        SuccessOrQuit(flash.Delete(0, 0), "Delete() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, 6), "Add() failed");
+
+        SuccessOrQuit(flash.Get(0, 0, readBuffer, &length), "Get() failed");
+        VerifyOrQuit(length == 4, "Get() did not return expected length");
+
+        SuccessOrQuit(flash.Get(0, 1, readBuffer, &length), "Get() failed");
+        VerifyOrQuit(length == 5, "Get() did not return expected length");
+    }
 }
 
 } // namespace ot

--- a/tests/unit/test_flash/flash_v1.cpp
+++ b/tests/unit/test_flash/flash_v1.cpp
@@ -1,0 +1,307 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "flash_v1.hpp"
+
+#include <stdio.h>
+
+#include <openthread/platform/flash.h>
+
+#include "common/code_utils.hpp"
+
+namespace ot {
+
+const uint32_t ot::FlashV1::sSwapActive;
+const uint32_t ot::FlashV1::sSwapInactive;
+
+void FlashV1::Init(void)
+{
+    RecordHeader record;
+
+    otPlatFlashInit(NULL);
+
+    mSwapSize = otPlatFlashGetSwapSize(NULL);
+
+    for (mSwapIndex = 0;; mSwapIndex++)
+    {
+        uint32_t swapMarker;
+
+        if (mSwapIndex >= 2)
+        {
+            Wipe();
+            ExitNow();
+        }
+
+        otPlatFlashRead(NULL, mSwapIndex, 0, &swapMarker, sizeof(swapMarker));
+
+        if (swapMarker == sSwapActive)
+        {
+            break;
+        }
+    }
+
+    for (mSwapUsed = kSwapMarkerSize; mSwapUsed <= mSwapSize - sizeof(record); mSwapUsed += record.GetSize())
+    {
+        otPlatFlashRead(NULL, mSwapIndex, mSwapUsed, &record, sizeof(record));
+        if (!record.IsAddBeginSet())
+        {
+            break;
+        }
+
+        if (!record.IsAddCompleteSet())
+        {
+            break;
+        }
+    }
+
+    SanitizeFreeSpace();
+
+exit:
+    return;
+}
+
+void FlashV1::SanitizeFreeSpace(void)
+{
+    uint32_t temp;
+    bool     sanitizeNeeded = false;
+
+    if (mSwapUsed & 3)
+    {
+        ExitNow(sanitizeNeeded = true);
+    }
+
+    for (uint32_t offset = mSwapUsed; offset < mSwapSize; offset += sizeof(temp))
+    {
+        otPlatFlashRead(NULL, mSwapIndex, offset, &temp, sizeof(temp));
+        if (temp != ~0U)
+        {
+            ExitNow(sanitizeNeeded = true);
+        }
+    }
+
+exit:
+    if (sanitizeNeeded)
+    {
+        Swap();
+    }
+}
+
+otError FlashV1::Get(uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength) const
+{
+    otError      error       = OT_ERROR_NOT_FOUND;
+    uint16_t     valueLength = 0;
+    int          index       = 0; // This must be initalized to 0. See [Note] in Delete().
+    uint32_t     offset;
+    RecordHeader record;
+
+    for (offset = kSwapMarkerSize; offset < mSwapUsed; offset += record.GetSize())
+    {
+        otPlatFlashRead(NULL, mSwapIndex, offset, &record, sizeof(record));
+
+        if ((record.GetKey() != aKey) || !record.IsValid())
+        {
+            continue;
+        }
+
+        if (record.IsFirst())
+        {
+            index = 0;
+        }
+
+        if (index == aIndex)
+        {
+            if (aValue && aValueLength)
+            {
+                uint16_t readLength = *aValueLength;
+
+                if (readLength > record.GetLength())
+                {
+                    readLength = record.GetLength();
+                }
+
+                otPlatFlashRead(NULL, mSwapIndex, offset + sizeof(record), aValue, readLength);
+            }
+
+            valueLength = record.GetLength();
+            error       = OT_ERROR_NONE;
+        }
+
+        index++;
+    }
+
+    if (aValueLength)
+    {
+        *aValueLength = valueLength;
+    }
+
+    return error;
+}
+
+otError FlashV1::Set(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+{
+    return Add(aKey, true, aValue, aValueLength);
+}
+
+otError FlashV1::Add(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+{
+    bool first = (Get(aKey, 0, NULL, NULL) == OT_ERROR_NOT_FOUND);
+
+    return Add(aKey, first, aValue, aValueLength);
+}
+
+otError FlashV1::Add(uint16_t aKey, bool aFirst, const uint8_t *aValue, uint16_t aValueLength)
+{
+    otError error = OT_ERROR_NONE;
+    Record  record;
+
+    record.Init(aKey, aFirst);
+    record.SetData(aValue, aValueLength);
+
+    OT_ASSERT((mSwapSize - record.GetSize()) >= kSwapMarkerSize);
+
+    if ((mSwapSize - record.GetSize()) < mSwapUsed)
+    {
+        Swap();
+        VerifyOrExit((mSwapSize - record.GetSize()) >= mSwapUsed, error = OT_ERROR_NO_BUFS);
+    }
+
+    otPlatFlashWrite(NULL, mSwapIndex, mSwapUsed, &record, record.GetSize());
+
+    record.SetAddCompleteFlag();
+    otPlatFlashWrite(NULL, mSwapIndex, mSwapUsed, &record, sizeof(RecordHeader));
+
+    mSwapUsed += record.GetSize();
+
+exit:
+    return error;
+}
+
+bool FlashV1::DoesValidRecordExist(uint32_t aOffset, uint16_t aKey) const
+{
+    RecordHeader record;
+    bool         rval = false;
+
+    for (; aOffset < mSwapUsed; aOffset += record.GetSize())
+    {
+        otPlatFlashRead(NULL, mSwapIndex, aOffset, &record, sizeof(record));
+
+        if (record.IsValid() && record.IsFirst() && (record.GetKey() == aKey))
+        {
+            ExitNow(rval = true);
+        }
+    }
+
+exit:
+    return rval;
+}
+
+void FlashV1::Swap(void)
+{
+    uint8_t  dstIndex  = !mSwapIndex;
+    uint32_t dstOffset = kSwapMarkerSize;
+    Record   record;
+
+    otPlatFlashErase(NULL, dstIndex);
+
+    for (uint32_t srcOffset = kSwapMarkerSize; srcOffset < mSwapUsed; srcOffset += record.GetSize())
+    {
+        otPlatFlashRead(NULL, mSwapIndex, srcOffset, &record, sizeof(RecordHeader));
+
+        VerifyOrExit(record.IsAddBeginSet(), OT_NOOP);
+
+        if (!record.IsValid() || DoesValidRecordExist(srcOffset + record.GetSize(), record.GetKey()))
+        {
+            continue;
+        }
+
+        otPlatFlashRead(NULL, mSwapIndex, srcOffset, &record, record.GetSize());
+        otPlatFlashWrite(NULL, dstIndex, dstOffset, &record, record.GetSize());
+        dstOffset += record.GetSize();
+    }
+
+exit:
+    otPlatFlashWrite(NULL, dstIndex, 0, &sSwapActive, sizeof(sSwapActive));
+    otPlatFlashWrite(NULL, mSwapIndex, 0, &sSwapInactive, sizeof(sSwapInactive));
+
+    mSwapIndex = dstIndex;
+    mSwapUsed  = dstOffset;
+}
+
+otError FlashV1::Delete(uint16_t aKey, int aIndex)
+{
+    otError      error = OT_ERROR_NOT_FOUND;
+    int          index = 0; // This must be initalized to 0. See [Note] below.
+    RecordHeader record;
+
+    for (uint32_t offset = kSwapMarkerSize; offset < mSwapUsed; offset += record.GetSize())
+    {
+        otPlatFlashRead(NULL, mSwapIndex, offset, &record, sizeof(record));
+
+        if ((record.GetKey() != aKey) || !record.IsValid())
+        {
+            continue;
+        }
+
+        if (record.IsFirst())
+        {
+            index = 0;
+        }
+
+        if ((aIndex == index) || (aIndex == -1))
+        {
+            record.SetDeleted();
+            otPlatFlashWrite(NULL, mSwapIndex, offset, &record, sizeof(record));
+            error = OT_ERROR_NONE;
+        }
+
+        /* [Note] If the operation gets interrupted here and aIndex is 0, the next record (index == 1) will never get
+         * marked as first. However, this is not actually an issue because all the methods that iterate over the
+         * settings area initialize the index to 0, without expecting any record to be effectively marked as first. */
+
+        if ((index == 1) && (aIndex == 0))
+        {
+            record.SetFirst();
+            otPlatFlashWrite(NULL, mSwapIndex, offset, &record, sizeof(record));
+        }
+
+        index++;
+    }
+
+    return error;
+}
+
+void FlashV1::Wipe(void)
+{
+    otPlatFlashErase(NULL, 0);
+    otPlatFlashWrite(NULL, 0, 0, &sSwapActive, sizeof(sSwapActive));
+
+    mSwapIndex = 0;
+    mSwapUsed  = sizeof(sSwapActive);
+}
+
+} // namespace ot

--- a/tests/unit/test_flash/flash_v1.hpp
+++ b/tests/unit/test_flash/flash_v1.hpp
@@ -1,0 +1,231 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef FLASHV1_HPP_
+#define FLASHV1_HPP_
+
+#include "openthread-core-config.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#include <openthread/error.h>
+#include <openthread/platform/toolchain.h>
+
+#include "common/debug.hpp"
+
+namespace ot {
+
+/**
+ * This class implements the flash storage driver.
+ *
+ */
+class FlashV1
+{
+public:
+    /**
+     * Constructor.
+     *
+     */
+    FlashV1(void) {}
+
+    /**
+     * This method initializes the flash storage driver.
+     *
+     */
+    void Init(void);
+
+    /**
+     * This method fetches the value identified by @p aKey.
+     *
+     * @param[in]     aKey          The key associated with the requested value.
+     * @param[in]     aIndex        The index of the specific item to get.
+     * @param[out]    aValue        A pointer to where the value of the setting should be written.
+     *                              May be NULL if just testing for the presence or length of a key.
+     * @param[inout]  aValueLength  A pointer to the length of the value.
+     *                              When called, this should point to an integer containing the maximum bytes that
+     *                              can be written to @p aValue.
+     *                              At return, the actual length of the setting is written.
+     *                              May be NULL if performing a presence check.
+     *
+     * @retval OT_ERROR_NONE        The value was fetched successfully.
+     * @retval OT_ERROR_NOT_FOUND   The key was not found.
+     *
+     */
+    otError Get(uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength) const;
+
+    /**
+     * This method sets or replaces the value identified by @p aKey.
+     *
+     * If there was more than one value previously associated with @p aKey, then they are all deleted and replaced with
+     * this single entry.
+     *
+     * @param[in]  aKey          The key associated with the value.
+     * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
+     *                           MUST NOT be NULL if @p aValueLength is non-zero.
+     * @param[in]  aValueLength  The length of the data pointed to by @p aValue. May be zero.
+     *
+     * @retval OT_ERROR_NONE     The value was changed.
+     * @retval OT_ERROR_NO_BUFS  Not enough space to store the value.
+     *
+     */
+    otError Set(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+
+    /**
+     * This method adds a value to @p aKey.
+     *
+     * @param[in]  aKey          The key associated with the value.
+     * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
+     *                           MUST NOT be NULL if @p aValueLength is non-zero.
+     * @param[in]  aValueLength  The length of the data pointed to by @p aValue. May be zero.
+     *
+     * @retval OT_ERROR_NONE     The value was added.
+     * @retval OT_ERROR_NO_BUFS  Not enough space to store the value.
+     *
+     */
+    otError Add(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+
+    /**
+     * This method removes a value from @p aKey.
+     *
+     *
+     * @param[in] aKey    The key associated with the value.
+     * @param[in] aIndex  The index of the value to be removed.
+     *                    If set to -1, all values for @p aKey will be removed.
+     *
+     * @retval OT_ERROR_NONE       The given key and index was found and removed successfully.
+     * @retval OT_ERROR_NOT_FOUND  The given key or index was not found.
+     *
+     */
+    otError Delete(uint16_t aKey, int aIndex);
+
+    /**
+     * This method removes all values.
+     *
+     */
+    void Wipe(void);
+
+private:
+    enum
+    {
+        kSwapMarkerSize = 4, // in bytes
+    };
+
+    static const uint32_t sSwapActive   = 0xbe5cc5ee;
+    static const uint32_t sSwapInactive = 0xbe5cc5ec;
+
+    OT_TOOL_PACKED_BEGIN
+    class RecordHeader
+    {
+    public:
+        void Init(uint16_t aKey, bool aFirst)
+        {
+            mKey   = aKey;
+            mFlags = kFlagsInit & ~kFlagAddBegin;
+
+            if (aFirst)
+            {
+                mFlags &= ~kFlagFirst;
+            }
+
+            mLength   = 0;
+            mReserved = 0xffff;
+        };
+
+        uint16_t GetKey(void) const { return mKey; }
+        void     SetKey(uint16_t aKey) { mKey = aKey; }
+
+        uint16_t GetLength(void) const { return mLength; }
+        void     SetLength(uint16_t aLength) { mLength = aLength; }
+
+        uint16_t GetSize(void) const { return sizeof(*this) + ((mLength + 3) & 0xfffc); }
+
+        bool IsValid(void) const { return ((mFlags & (kFlagAddComplete | kFlagDelete)) == kFlagDelete); }
+
+        bool IsAddBeginSet(void) const { return (mFlags & kFlagAddBegin) == 0; }
+        void SetAddBeginFlag(void) { mFlags &= ~kFlagAddBegin; }
+
+        bool IsAddCompleteSet(void) const { return (mFlags & kFlagAddComplete) == 0; }
+        void SetAddCompleteFlag(void) { mFlags &= ~kFlagAddComplete; }
+
+        bool IsDeleted(void) const { return (mFlags & kFlagDelete) == 0; }
+        void SetDeleted(void) { mFlags &= ~kFlagDelete; }
+
+        bool IsFirst(void) const { return (mFlags & kFlagFirst) == 0; }
+        void SetFirst(void) { mFlags &= ~kFlagFirst; }
+
+    private:
+        enum
+        {
+            kFlagsInit       = 0xffff, ///< Flags initialize to all-ones.
+            kFlagAddBegin    = 1 << 0, ///< 0 indicates record write has started, 1 otherwise.
+            kFlagAddComplete = 1 << 1, ///< 0 indicates record write has completed, 1 otherwise.
+            kFlagDelete      = 1 << 2, ///< 0 indicates record was deleted, 1 otherwise.
+            kFlagFirst       = 1 << 3, ///< 0 indicates first record for key, 1 otherwise.
+        };
+
+        uint16_t mKey;
+        uint16_t mFlags;
+        uint16_t mLength;
+        uint16_t mReserved;
+    } OT_TOOL_PACKED_END;
+
+    OT_TOOL_PACKED_BEGIN
+    class Record : public RecordHeader
+    {
+    public:
+        const uint8_t *GetData(void) const { return mData; }
+        void           SetData(const uint8_t *aData, uint16_t aDataLength)
+        {
+            OT_ASSERT(aDataLength <= kMaxDataSize);
+            memcpy(mData, aData, aDataLength);
+            SetLength(aDataLength);
+        }
+
+    private:
+        enum
+        {
+            kMaxDataSize = 255,
+        };
+
+        uint8_t mData[kMaxDataSize];
+    } OT_TOOL_PACKED_END;
+
+    otError Add(uint16_t aKey, bool aFirst, const uint8_t *aValue, uint16_t aValueLength);
+    bool    DoesValidRecordExist(uint32_t aOffset, uint16_t aKey) const;
+    void    SanitizeFreeSpace(void);
+    void    Swap(void);
+
+    uint32_t mSwapSize;
+    uint32_t mSwapUsed;
+    uint8_t  mSwapIndex;
+};
+
+} // namespace ot
+
+#endif // FLASHV1_HPP_

--- a/tests/unit/test_platform.h
+++ b/tests/unit/test_platform.h
@@ -83,6 +83,8 @@ extern testPlatRadioReceive            g_testPlatRadioReceive;
 extern testPlatRadioTransmit           g_testPlatRadioTransmit;
 extern testPlatRadioGetTransmitBuffer  g_testPlatRadioGetTransmitBuffer;
 
+extern bool g_flashIgnoreMultipleWrites;
+
 ot::Instance *testInitInstance(void);
 void          testFreeInstance(otInstance *aInstance);
 


### PR DESCRIPTION
Hi all, this PR updates the Flash driver and associated unit tests to avoid the issues explained in #4706.

I think it would be best to review this as separate commits. The changes are:
  - 9e7e920: Update the flash driver to avoid marking with `kFlagFirst` the record with `index == 1`. This is the most "critical" commit, because it allows the use of the `mReserved` half-word for the `kFlagFirst` and `kFlagDelete` flags. Please review it carefully; it slightly changes the underlying logic for calculating index 0.
  - cdf7a2a: Update the unit test to check the maximum number of 32-bit words written between erase cycles. This is fixed to 2. See #4706.
  - d6a1a4e: Implements the new flash format, optionally keeping backward compatibility. The new format uses the `mReserved` half-word to write the `kFlagFirst` and `kFlagDeleted`, but (optionally) understands the old format. The backward compatibility is enabled by default.
  - fa6ebef: Updates the unit test to check compatibility: writing and reading with the old driver, writing and reading with the new driver, and writing with the old driver and reading with the new one.

Comments are welcome...

Thanks.

