### PR TITLE
[tests] fix key_id_mode handling and add exception handle

### DIFF
--- a/tests/scripts/thread-cert/mac802154.py
+++ b/tests/scripts/thread-cert/mac802154.py
@@ -42,6 +42,11 @@ from net_crypto import (
 )
 
 
+class KeyIdMode0Exception(Exception):
+    """Raised when key id mode of packet is 0. Such packet wouldn't be handled in test scripts, but it's not abnormal behavior"""
+    pass
+
+
 class DeviceDescriptors:
     """Class representing 802.15.4 Device Descriptors."""
 
@@ -377,11 +382,13 @@ class MacFrame:
         key_id_mode = (security_control & 0x18) >> 3
 
         if key_id_mode == 0:
-            key_id = data.read(9)
+            raise KeyIdMode0Exception
         elif key_id_mode == 1:
             key_id = data.read(1)
         elif key_id_mode == 2:
             key_id = data.read(5)
+        elif key_id_mode == 3:
+            key_id = data.read(9)
         else:
             pass
 

--- a/tests/scripts/thread-cert/mac802154.py
+++ b/tests/scripts/thread-cert/mac802154.py
@@ -43,7 +43,11 @@ from net_crypto import (
 
 
 class KeyIdMode0Exception(Exception):
-    """Raised when key id mode of packet is 0. Such packet wouldn't be handled in test scripts, but it's not abnormal behavior"""
+    """
+    Raised when key id mode of packet is 0.
+    Such packet wouldn't be handled in test scripts,
+    but it's not abnormal behavior.
+    """
     pass
 
 

--- a/tests/scripts/thread-cert/message.py
+++ b/tests/scripts/thread-cert/message.py
@@ -41,6 +41,10 @@ import mle
 from enum import IntEnum
 
 
+class DropPacketException(Exception):
+    pass
+
+
 class MessageType(IntEnum):
     MLE = 0
     COAP = 1
@@ -598,30 +602,38 @@ class MessageFactory:
         self._lowpan_parser.set_lowpan_context(cid, prefix)
 
     def create(self, data):
-        message = Message()
-        message.channel = struct.unpack(">B", data.read(1))
+        try:
+            message = Message()
+            message.channel = struct.unpack(">B", data.read(1))
 
-        # Parse MAC header
-        mac_frame = self._parse_mac_frame(data)
-        message.mac_header = mac_frame.header
+            # Parse MAC header
+            mac_frame = self._parse_mac_frame(data)
+            message.mac_header = mac_frame.header
 
-        if message.mac_header.frame_type != mac802154.MacHeader.FrameType.DATA:
-            return [message]
+            if message.mac_header.frame_type != mac802154.MacHeader.FrameType.DATA:
+                return [message]
 
-        message_info = common.MessageInfo()
-        message_info.source_mac_address = message.mac_header.src_address
-        message_info.destination_mac_address = message.mac_header.dest_address
+            message_info = common.MessageInfo()
+            message_info.source_mac_address = message.mac_header.src_address
+            message_info.destination_mac_address = message.mac_header.dest_address
 
-        # Create stream with 6LoWPAN datagram
-        lowpan_payload = io.BytesIO(mac_frame.payload.data)
+            # Create stream with 6LoWPAN datagram
+            lowpan_payload = io.BytesIO(mac_frame.payload.data)
 
-        ipv6_packet = self._lowpan_parser.parse(lowpan_payload, message_info)
-        if ipv6_packet is None:
-            return [message]
+            ipv6_packet = self._lowpan_parser.parse(lowpan_payload,
+                                                    message_info)
+            if ipv6_packet is None:
+                return [message]
 
-        message.ipv6_packet = ipv6_packet
+            message.ipv6_packet = ipv6_packet
 
-        if message.type == MessageType.MLE:
-            self._add_device_descriptors(message)
+            if message.type == MessageType.MLE:
+                self._add_device_descriptors(message)
 
-        return message.try_extract_dtls_messages()
+            return message.try_extract_dtls_messages()
+
+        except mac802154.KeyIdMode0Exception:
+            print(
+                'Received packet with key_id_mode = 0, cannot be handled in test scripts'
+            )
+            raise DropPacketException

--- a/tests/scripts/thread-cert/simulator.py
+++ b/tests/scripts/thread-cert/simulator.py
@@ -41,6 +41,8 @@ import mesh_cop
 import message
 import pcap
 
+from message import DropPacketException
+
 
 def dbg_print(*args):
     if False:
@@ -183,6 +185,10 @@ class VirtualTime(BaseSimulator):
             messages = self._message_factory.create(io.BytesIO(message))
             self.devices[addr]['msgs'] += messages
 
+        except DropPacketException:
+            print(
+                "Drop current packet because it cannot be handled in test scripts"
+            )
         except Exception as e:
             # Just print the exception to the console
             print("EXCEPTION: %s" % e)

--- a/tests/scripts/thread-cert/simulator.py
+++ b/tests/scripts/thread-cert/simulator.py
@@ -41,8 +41,6 @@ import mesh_cop
 import message
 import pcap
 
-from message import DropPacketException
-
 
 def dbg_print(*args):
     if False:
@@ -177,15 +175,15 @@ class VirtualTime(BaseSimulator):
         self.sock.close()
         self.sock = None
 
-    def _add_message(self, nodeid, message):
+    def _add_message(self, nodeid, message_obj):
         addr = ('127.0.0.1', self.port + nodeid)
 
         # Ignore any exceptions
         try:
-            messages = self._message_factory.create(io.BytesIO(message))
+            messages = self._message_factory.create(io.BytesIO(message_obj))
             self.devices[addr]['msgs'] += messages
 
-        except DropPacketException:
+        except message.DropPacketException:
             print(
                 "Drop current packet because it cannot be handled in test scripts"
             )

--- a/tests/scripts/thread-cert/simulator.py
+++ b/tests/scripts/thread-cert/simulator.py
@@ -185,7 +185,7 @@ class VirtualTime(BaseSimulator):
 
         except message.DropPacketException:
             print(
-                "Drop current packet because it cannot be handled in test scripts"
+                'Drop current packet because it cannot be handled in test scripts'
             )
         except Exception as e:
             # Just print the exception to the console


### PR DESCRIPTION
Sorry for my mistake in #3448 . This PR fixes `key_id_mode` handling and added exception handling when `key_id_mode` is `0`.

According to **IEEE Std 802.15.4-2015**, when Key Id Mode is `0x00`:

> Key is determined implicitly from the originator and recipient(s) of the frame, as indicated in the frame header.

So in our test scripts we cannot actually handle such packets. In case 8_1_01, as I remember, @wgtdkp checked such packets(`HandshakeType.SERVER_KEY_EXCHANGE` and `HandshakeType.CLIENT_KEY_EXCHANGE`) by other means. When we parse such packet we can simply drop them.

However if we leave `key_id_mode = 0` case unhandled, we would get some exceptions which makes people feel that something goes wrong. However dropping packets in this case is a normal behavior. So I added the handling to such exceptions.