### PR TITLE
[error] disable error checking enforcement for old versions of clang

### DIFF
--- a/include/openthread/platform/toolchain.h
+++ b/include/openthread/platform/toolchain.h
@@ -75,7 +75,7 @@ extern "C" {
  *       '-Wno-unused-result' compiler option.
  *
  */
-#if defined(__clang__)
+#if defined(__clang__) && (__clang_major__ >= 4 || (__clang_major__ >= 3 && __clang_minor__ >= 9))
 #define OT_MUST_USE_RESULT __attribute__((warn_unused_result))
 #else
 #define OT_MUST_USE_RESULT


### PR DESCRIPTION
With clang older than 3.9, the `warn_unused_result` feature works only with functions and classes, not enums. This disables it if the clang version is too old.