### PR TITLE
[continuous-integration] avoid coverage data loss

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -146,10 +146,16 @@ jobs:
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2
-    - name: Run
+    - name: Bootstrap
       run: |
         sudo apt --no-install-recommends install -y expect ninja-build
+    - name: Run
+      run: |
         ./script/test build expect
+    - name: Codecov
+      uses: codecov/codecov-action@v1
+    - name: Run RCP Mode
+      run: |
         VIRTUAL_TIME=0 NODE_MODE=rcp ./script/test clean build expect
     - name: Codecov
       uses: codecov/codecov-action@v1


### PR DESCRIPTION
The code coverage data generated by `./script/test build expect`
will be erased by `VIRTUAL_TIME=0 NODE_MODE=rcp ./script/test clean build expect`'s `clean` step, causing coverage less than actual value. This adds an upload step after the first run to avoid the data loss.