### PR TITLE
[tasklet] change Post() to return void

### DIFF
--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -179,7 +179,7 @@ otError CoapSecure::Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessage
     otError error;
 
     SuccessOrExit(error = mTransmitQueue.Enqueue(aMessage));
-    IgnoreError(mTransmitTask.Post());
+    mTransmitTask.Post();
 
 exit:
     return error;
@@ -236,7 +236,7 @@ void CoapSecure::HandleTransmit(void)
 
     if (mTransmitQueue.GetHead() != NULL)
     {
-        IgnoreError(mTransmitTask.Post());
+        mTransmitTask.Post();
     }
 
     SuccessOrExit(error = mDtls.Send(*message, message->GetLength()));

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -124,7 +124,7 @@ void Notifier::Signal(otChangedFlags aFlags)
 {
     mFlagsToSignal |= aFlags;
     mSignaledFlags |= aFlags;
-    IgnoreError(mTask.Post());
+    mTask.Post();
 }
 
 void Notifier::SignalIfFirst(otChangedFlags aFlags)

--- a/src/core/common/tasklet.cpp
+++ b/src/core/common/tasklet.cpp
@@ -49,15 +49,12 @@ Tasklet::Tasklet(Instance &aInstance, Handler aHandler, void *aOwner)
 {
 }
 
-otError Tasklet::Post(void)
+void Tasklet::Post(void)
 {
-    otError error = OT_ERROR_NONE;
-
-    VerifyOrExit(!IsPosted(), error = OT_ERROR_ALREADY);
-    Get<TaskletScheduler>().PostTasklet(*this);
-
-exit:
-    return error;
+    if (!IsPosted())
+    {
+        Get<TaskletScheduler>().PostTasklet(*this);
+    }
 }
 
 TaskletScheduler::TaskletScheduler(void)

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -86,8 +86,10 @@ public:
     /**
      * This method puts the tasklet on the tasklet scheduler run queue.
      *
+     * If the tasklet is already posted, no change is made and run queue stays as before.
+     *
      */
-    otError Post(void);
+    void Post(void);
 
     /**
      * This method indicates whether the tasklet is posted or not.

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -392,7 +392,7 @@ void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
         {
             mTimer.Stop();
             FinishOperation();
-            IgnoreError(mOperationTask.Post());
+            mOperationTask.Post();
         }
 
 #if OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
@@ -697,7 +697,7 @@ void Mac::StartOperation(Operation aOperation)
 
     if (mOperation == kOperationIdle)
     {
-        IgnoreError(mOperationTask.Post());
+        mOperationTask.Post();
     }
 }
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -449,7 +449,7 @@ exit:
 void Ip6::EnqueueDatagram(Message &aMessage)
 {
     IgnoreError(mSendQueue.Enqueue(aMessage));
-    IgnoreError(mSendQueueTask.Post());
+    mSendQueueTask.Post();
 }
 
 otError Ip6::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aIpProto)

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -940,7 +940,7 @@ exit:
 
     if (mEnabled)
     {
-        IgnoreError(mScheduleTransmissionTask.Post());
+        mScheduleTransmissionTask.Post();
     }
 }
 
@@ -974,7 +974,7 @@ void MeshForwarder::HandleDiscoverTimer(void)
 
 exit:
     mSendBusy = false;
-    IgnoreError(mScheduleTransmissionTask.Post());
+    mScheduleTransmissionTask.Post();
 }
 
 void MeshForwarder::HandleDiscoverComplete(void)

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -136,7 +136,7 @@ otError MeshForwarder::SendMessage(Message &aMessage)
         break;
     }
 
-    IgnoreError(mScheduleTransmissionTask.Post());
+    mScheduleTransmissionTask.Post();
 
 exit:
     return error;
@@ -178,7 +178,7 @@ void MeshForwarder::HandleResolved(const Ip6::Address &aEid, otError aError)
 
     if (enqueuedMessage)
     {
-        IgnoreError(mScheduleTransmissionTask.Post());
+        mScheduleTransmissionTask.Post();
     }
 }
 

--- a/src/core/thread/mesh_forwarder_mtd.cpp
+++ b/src/core/thread/mesh_forwarder_mtd.cpp
@@ -46,7 +46,7 @@ otError MeshForwarder::SendMessage(Message &aMessage)
     aMessage.SetDatagramTag(0);
 
     SuccessOrExit(error = mSendQueue.Enqueue(aMessage));
-    IgnoreError(mScheduleTransmissionTask.Post());
+    mScheduleTransmissionTask.Post();
 
 exit:
     return error;

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -285,7 +285,7 @@ NcpBase::NcpBase(Instance *aInstance)
 #endif
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
     mChangedPropsSet.AddLastStatus(SPINEL_STATUS_RESET_UNKNOWN);
-    IgnoreError(mUpdateChangedPropsTask.Post());
+    mUpdateChangedPropsTask.Post();
 
 #if OPENTHREAD_ENABLE_VENDOR_EXTENSION
     aInstance->Get<Extension::ExtensionBase>().SignalNcpInit(*this);
@@ -499,7 +499,7 @@ exit:
     if (error == OT_ERROR_NO_BUFS)
     {
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_NOMEM);
-        IgnoreError(mUpdateChangedPropsTask.Post());
+        mUpdateChangedPropsTask.Post();
     }
 
     return error;
@@ -643,7 +643,7 @@ exit:
     if (error == OT_ERROR_NO_BUFS)
     {
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_NOMEM);
-        IgnoreError(mUpdateChangedPropsTask.Post());
+        mUpdateChangedPropsTask.Post();
     }
 }
 
@@ -1188,7 +1188,7 @@ otError NcpBase::CommandHandler_RESET(uint8_t aHeader)
     if (error != OT_ERROR_NONE)
     {
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_RESET_UNKNOWN);
-        IgnoreError(mUpdateChangedPropsTask.Post());
+        mUpdateChangedPropsTask.Post();
     }
 
     sNcpInstance = NULL;

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -179,7 +179,7 @@ exit:
         }
 
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_NOMEM);
-        IgnoreError(mUpdateChangedPropsTask.Post());
+        mUpdateChangedPropsTask.Post();
     }
 }
 
@@ -680,7 +680,7 @@ exit:
     if (error != OT_ERROR_NONE)
     {
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_NOMEM);
-        IgnoreError(mUpdateChangedPropsTask.Post());
+        mUpdateChangedPropsTask.Post();
     }
 }
 
@@ -723,7 +723,7 @@ exit:
     if (error != OT_ERROR_NONE)
     {
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_NOMEM);
-        IgnoreError(mUpdateChangedPropsTask.Post());
+        mUpdateChangedPropsTask.Post();
     }
 }
 

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -2064,7 +2064,7 @@ void NcpBase::HandleJamStateChange(bool aJamState)
     OT_UNUSED_VARIABLE(aJamState);
 
     mChangedPropsSet.AddProperty(SPINEL_PROP_JAM_DETECTED);
-    IgnoreError(mUpdateChangedPropsTask.Post());
+    mUpdateChangedPropsTask.Post();
 }
 
 #endif // OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
@@ -3152,7 +3152,7 @@ void NcpBase::HandleDidReceiveNewLegacyUlaPrefix(const uint8_t *aUlaPrefix)
 {
     memcpy(mLegacyUlaPrefix, aUlaPrefix, OT_NCP_LEGACY_ULA_PREFIX_LENGTH);
     mChangedPropsSet.AddProperty(SPINEL_PROP_NEST_LEGACY_ULA_PREFIX);
-    IgnoreError(mUpdateChangedPropsTask.Post());
+    mUpdateChangedPropsTask.Post();
 }
 
 void NcpBase::HandleLegacyNodeDidJoin(const otExtAddress *aExtAddr)
@@ -3160,7 +3160,7 @@ void NcpBase::HandleLegacyNodeDidJoin(const otExtAddress *aExtAddr)
     mLegacyNodeDidJoin    = true;
     mLegacyLastJoinedNode = *aExtAddr;
     mChangedPropsSet.AddProperty(SPINEL_PROP_NEST_LEGACY_LAST_NODE_JOINED);
-    IgnoreError(mUpdateChangedPropsTask.Post());
+    mUpdateChangedPropsTask.Post();
 }
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_NEST_LEGACY_ULA_PREFIX>(void)
@@ -3246,7 +3246,7 @@ void NcpBase::HandleTimeSyncUpdate(void *aContext)
 void NcpBase::HandleTimeSyncUpdate(void)
 {
     mChangedPropsSet.AddProperty(SPINEL_PROP_THREAD_NETWORK_TIME);
-    IgnoreError(mUpdateChangedPropsTask.Post());
+    mUpdateChangedPropsTask.Post();
 }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
@@ -3304,7 +3304,7 @@ void NcpBase::HandleActiveScanResult(otActiveScanResult *aResult)
         // We are finished with the scan, send an unsolicited
         // scan state update.
         mChangedPropsSet.AddProperty(SPINEL_PROP_MAC_SCAN_STATE);
-        IgnoreError(mUpdateChangedPropsTask.Post());
+        mUpdateChangedPropsTask.Post();
     }
 
 exit:
@@ -3315,7 +3315,7 @@ exit:
         // an async `LAST_STATUS(NOMEM)` when buffer space becomes
         // available.
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_NOMEM);
-        IgnoreError(mUpdateChangedPropsTask.Post());
+        mUpdateChangedPropsTask.Post();
     }
 }
 
@@ -3341,7 +3341,7 @@ void NcpBase::HandleEnergyScanResult(otEnergyScanResult *aResult)
         // We are finished with the scan, send an unsolicited
         // scan state update.
         mChangedPropsSet.AddProperty(SPINEL_PROP_MAC_SCAN_STATE);
-        IgnoreError(mUpdateChangedPropsTask.Post());
+        mUpdateChangedPropsTask.Post();
     }
 
 exit:
@@ -3349,7 +3349,7 @@ exit:
     if (error != OT_ERROR_NONE)
     {
         mChangedPropsSet.AddLastStatus(SPINEL_STATUS_NOMEM);
-        IgnoreError(mUpdateChangedPropsTask.Post());
+        mUpdateChangedPropsTask.Post();
     }
 }
 
@@ -3380,7 +3380,7 @@ void NcpBase::HandleJoinerCallback(otError aError)
         break;
     }
 
-    IgnoreError(mUpdateChangedPropsTask.Post());
+    mUpdateChangedPropsTask.Post();
 }
 #endif
 
@@ -3630,7 +3630,7 @@ void NcpBase::HandleStateChanged(otChangedFlags aFlags, void *aContext)
     NcpBase *ncp = static_cast<NcpBase *>(aContext);
 
     ncp->mThreadChangedFlags |= aFlags;
-    IgnoreError(ncp->mUpdateChangedPropsTask.Post());
+    ncp->mUpdateChangedPropsTask.Post();
 }
 
 void NcpBase::ProcessThreadChangedFlags(void)

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -116,7 +116,7 @@ void NcpUart::HandleFrameAddedToNcpBuffer(void)
 {
     if (mUartBuffer.IsEmpty())
     {
-        IgnoreError(mUartSendTask.Post());
+        mUartSendTask.Post();
     }
 }
 
@@ -226,8 +226,7 @@ extern "C" void otPlatUartSendDone(void)
 void NcpUart::HandleUartSendDone(void)
 {
     mUartBuffer.Clear();
-
-    IgnoreError(mUartSendTask.Post());
+    mUartSendTask.Post();
 }
 
 extern "C" void otPlatUartReceived(const uint8_t *aBuf, uint16_t aBufLength)


### PR DESCRIPTION
This commit changes the `Tasklet::Post()` method to return `void`
instead of `otError`. This helps simplify its use. The error indicated
whether the tasklet was already posted and was always ignored
(required `IgnoreError()` when posting tasklets). `IsPosted()` method
can be used to determine this when/if needed.