### PR TITLE
[ip6] fix and enhance IPv6 fragmentation

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -646,8 +646,6 @@ otError Ip6::FragmentDatagram(Message &aMessage, uint8_t aIpProto)
         FragmentHeader::MakeDivisibleByEight(kMinimalMtu - aMessage.GetOffset() - sizeof(fragmentHeader));
     uint16_t payloadLeft = aMessage.GetLength() - aMessage.GetOffset();
 
-    VerifyOrExit(aMessage.GetLength() <= kMaxAssembledDatagramLength, error = OT_ERROR_NO_BUFS);
-
     VerifyOrExit(aMessage.Read(0, sizeof(header), &header) == sizeof(header), error = OT_ERROR_PARSE);
     header.SetNextHeader(kProtoFragment);
 
@@ -699,6 +697,7 @@ otError Ip6::FragmentDatagram(Message &aMessage, uint8_t aIpProto)
 
         otLogInfoIp6("Fragment %d with %d bytes sent", fragmentCnt, payloadFragment);
     }
+
     aMessage.Free();
 
 exit:
@@ -757,6 +756,15 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
     offset          = FragmentHeader::FragmentOffsetToBytes(fragmentHeader.GetOffset());
     payloadFragment = aMessage.GetLength() - aMessage.GetOffset() - sizeof(fragmentHeader);
 
+    otLogInfoIp6("Fragment with id %d received > %d bytes, offset %d", fragmentHeader.GetIdentification(),
+                 payloadFragment, offset);
+
+    if (offset + payloadFragment + aMessage.GetOffset() > kMaxAssembledDatagramLength)
+    {
+        otLogWarnIp6("Packet too large for fragment buffer");
+        ExitNow(error = OT_ERROR_NO_BUFS);
+    }
+
     if (message == NULL)
     {
         VerifyOrExit((message = NewMessage(0)) != NULL, error = OT_ERROR_NO_BUFS);
@@ -778,15 +786,6 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
         mReassemblyList.Enqueue(*message);
 
         otLogDebgIp6("start reassembly.");
-    }
-
-    otLogInfoIp6("Fragment with id %d received > %d bytes, offset %d", message->GetDatagramTag(), payloadFragment,
-                 offset);
-
-    if (offset + payloadFragment + aMessage.GetOffset() > kMaxAssembledDatagramLength)
-    {
-        otLogWarnIp6("Package too large for fragment buffer");
-        ExitNow(error = OT_ERROR_NO_BUFS);
     }
 
     // increase message buffer if necessary
@@ -833,6 +832,7 @@ exit:
         }
         otLogWarnIp6("Reassembly failed: %s", otThreadErrorToString(error));
     }
+
     if (isFragmented)
     {
         // drop all fragments, the payload is stored in the fragment buffer
@@ -970,6 +970,9 @@ otError Ip6::HandleExtensionHeaders(Message &    aMessage,
             break;
 
         case kProtoFragment:
+            // Always forward IPv6 fragments to the Host.
+            IgnoreError(ProcessReceiveCallback(aMessage, aMessageInfo, aNextHeader, aFromNcpHost));
+
             SuccessOrExit(error = HandleFragment(aMessage, aNetif, aMessageInfo, aFromNcpHost));
             break;
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -820,7 +820,7 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
 
         mReassemblyList.Dequeue(*message);
 
-        error = HandleDatagram(*message, aNetif, aMessageInfo.mLinkInfo, aFromNcpHost);
+        IgnoreError(HandleDatagram(*message, aNetif, aMessageInfo.mLinkInfo, aFromNcpHost));
     }
 
 exit:

--- a/src/lib/spinel/spinel.h
+++ b/src/lib/spinel/spinel.h
@@ -345,7 +345,29 @@
 #define SPINEL_PROTOCOL_VERSION_THREAD_MAJOR 4
 #define SPINEL_PROTOCOL_VERSION_THREAD_MINOR 3
 
+/**
+ * @def SPINEL_FRAME_MAX_SIZE
+ *
+ *  The maximum size of SPINEL frame.
+ *
+ */
 #define SPINEL_FRAME_MAX_SIZE 1300
+
+/**
+ * @def SPINEL_FRAME_MAX_COMMAND_HEADER_SIZE
+ *
+ *  The maximum size of SPINEL command header.
+ *
+ */
+#define SPINEL_FRAME_MAX_COMMAND_HEADER_SIZE 4
+
+/**
+ * @def SPINEL_FRAME_MAX_PAYLOAD_SIZE
+ *
+ *  The maximum size of SPINEL command payload.
+ *
+ */
+#define SPINEL_FRAME_MAX_COMMAND_PAYLOAD_SIZE (SPINEL_FRAME_MAX_SIZE - SPINEL_FRAME_MAX_COMMAND_HEADER_SIZE)
 
 /**
  * @def SPINEL_ENCRYPTER_EXTRA_DATA_SIZE

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -3397,6 +3397,9 @@ void NcpBase::HandleDatagramFromStack(otMessage *aMessage)
 {
     VerifyOrExit(aMessage != NULL, OT_NOOP);
 
+    // Do not forward frames larger than SPINEL payload size.
+    VerifyOrExit(otMessageGetLength(aMessage) <= SPINEL_FRAME_MAX_COMMAND_PAYLOAD_SIZE, otMessageFree(aMessage));
+
     otMessageQueueEnqueue(&mMessageQueue, aMessage);
 
     // If there is no queued spinel command response, try to write/send

--- a/tests/scripts/thread-cert/test_ipv6_fragmentation.py
+++ b/tests/scripts/thread-cert/test_ipv6_fragmentation.py
@@ -77,9 +77,6 @@ class TestIPv6Fragmentation(thread_cert.TestCase):
         self.simulator.go(5)
         self.nodes[LEADER].udp_check_rx(1831)
 
-        self.nodes[ROUTER].udp_send(1953, mleid_leader, common.UDP_TEST_PORT,
-                                    False)
-
         self.nodes[ROUTER].udp_stop()
         self.nodes[LEADER].udp_stop()
 


### PR DESCRIPTION
This PR fixes and enhances the handling of IPv6 fragmentation.

It consists of three commits:

**[ncp] ensure IPv6 packet length does not exceed maximum size of SPINEL command payload**

With the current code, it is possible that NCP tries to send IPv6 packet larger than the maximum size of SPINEL command payload. This results in the following error in the wpantund:

```
wpantund[31934]: SpinelNCPInstance-DataPump.cpp:239: Requirement Failed (mInboundFrameSize < sizeof(mInboundFrame))
```

This commit adds additional defines to spinel.h and proper checks in NCP codebase.

**[ip6] do not free the same message twice while handling IPv6 fragment**

This commit fixes the serious bug when IPv6 fragmentation is enabled. It is possible that `HandleDatagram` which is called on complete reassembly, returns the error (e.g. because ICMPv6 Echo Response can't be generated due to lack of buffers). In such case both `HandleDatagram` method and `HandleFragment` tries to free the same message which finally ends up in a crash of the system.

To reproduce it:
- Set up a network with two nodes A and B.
- Execute the following command on node A: `ping ML-EID_B 1950 1000 0.01`

**[ip6] enhance handling of IPv6 fragmentation**

This commit introduces a few enhancements:
- In NCP architecture forward the IPv6 fragments instead of the full reassembled IPv6 packet (which in the default configuration can't be forwarder due to SPINEL limitations). Without this fix the fragmentation does not work if Thread device wants to send more than MTU data through the Border Router (to the IPv6 address of NCP). 
- Use `OPENTHREAD_CONFIG_IP6_MAX_ASSEMBLED_DATAGRAM` only for the receiving path. For transmitting path, relay on the message buffers pool. This is especially important for some of the use-cases we have, and also reduce a need for regenerating OpenThread libraries.
- In case receiving IPv6 packet is bigger than supported `OPENTHREAD_CONFIG_IP6_MAX_ASSEMBLED_DATAGRAM`, exit before trying to allocate the next message buffer.
