### PR TITLE
[mesh-forwarder] allow last 6LoWPAN fragment to use longer length

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -770,11 +770,11 @@ start:
         payload += fragmentHeaderLength;
         headerLength += fragmentHeaderLength;
 
-        fragmentLength = (aFrame.GetMaxPayloadLength() - headerLength) & ~0x7;
+        fragmentLength = aFrame.GetMaxPayloadLength() - headerLength;
 
         if (payloadLength > fragmentLength)
         {
-            payloadLength = fragmentLength;
+            payloadLength = (fragmentLength & ~0x7);
         }
 
         // Copy IPv6 Payload

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -140,6 +140,7 @@ run test-037-wpantund-auto-add-route-for-on-mesh-prefix.py
 run test-038-clear-address-cache-for-sed.py
 run test-039-address-cache-table-snoop.py
 run test-040-network-data-stable-full.py
+run test-041-lowpan-fragmentation.py
 run test-100-mcu-power-state.py
 run test-600-channel-manager-properties.py
 run test-601-channel-manager-channel-change.py

--- a/tests/toranj/test-041-lowpan-fragmentation.py
+++ b/tests/toranj/test-041-lowpan-fragmentation.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+import wpan
+from wpan import verify
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test description: This test verifies 6LoWPAN fragmentation code by exchanging IPv6 messages with
+# many different lengths between two nodes.
+
+test_name = __file__[:-3] if __file__.endswith('.py') else __file__
+print('-' * 120)
+print('Starting \'{}\''.format(test_name))
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Creating `wpan.Nodes` instances
+
+speedup = 4
+wpan.Node.set_time_speedup_factor(speedup)
+
+node1 = wpan.Node()
+node2 = wpan.Node()
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Init all nodes
+
+wpan.Node.init_all_nodes()
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Build network topology
+
+# Two-node network (node1 leader/router, node2 end-device)
+
+node1.form('horizon')  # "zero dawn"
+node2.join_node(node1, node_type=wpan.JOIN_TYPE_END_DEVICE)
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test implementation
+
+# Get the link local addresses
+ll1 = node1.get(wpan.WPAN_IP6_LINK_LOCAL_ADDRESS)[1:-1]
+ll2 = node2.get(wpan.WPAN_IP6_LINK_LOCAL_ADDRESS)[1:-1]
+
+PORT = 1234
+MSG_LEN_START = 100
+MSG_LEN_END = 500
+
+for msg_length in range(MSG_LEN_START, MSG_LEN_END):
+    sender = node1.prepare_tx((ll1, PORT), (ll2, PORT), msg_length)
+    recver = node2.prepare_rx(sender)
+
+    wpan.Node.perform_async_tx_rx()
+
+    verify(sender.was_successful)
+    verify(recver.was_successful)
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test finished
+
+wpan.Node.finalize_all_nodes()
+
+print('\'{}\' passed.'.format(test_name))


### PR DESCRIPTION
This commit relaxes the length check for the last 6LoWPAN fragment of
a message. The length of a 6LoWPAN fragment is truncated to be a
multiple of eight bytes (since fragment offset can only be expressed as
multiples of eight). However this requirement does not apply to the
last fragment. This change helps avoid an unnecessary extra fragment
for messages of certain length.

---------

**[toranj] add new test to verify lowpan fragmentation**

This commit adds a new test to verify 6LoWPAN fragmentation logic by
exchanging IPv6 messages with many different lengths between two
nodes.