### PR TITLE
[posix] fix inconsistent function definitions issue

### DIFF
--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -337,7 +337,11 @@ exit:
 #endif
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-otError otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *aOutput, size_t aOutputMaxLen)
+otError otPlatDiagProcess(otInstance *aInstance,
+                          uint8_t     aArgsLength,
+                          char *      aArgs[],
+                          char *      aOutput,
+                          size_t      aOutputMaxLen)
 {
     // deliver the platform specific diags commands to radio only ncp.
     OT_UNUSED_VARIABLE(aInstance);
@@ -345,9 +349,9 @@ otError otPlatDiagProcess(otInstance *aInstance, int argc, char *argv[], char *a
     char *cur                                              = cmd;
     char *end                                              = cmd + sizeof(cmd);
 
-    for (int index = 0; index < argc; index++)
+    for (int index = 0; index < aArgsLength; index++)
     {
-        cur += snprintf(cur, static_cast<size_t>(end - cur), "%s ", argv[index]);
+        cur += snprintf(cur, static_cast<size_t>(end - cur), "%s ", aArgs[index]);
     }
 
     return sRadioSpinel.PlatDiagProcess(cmd, aOutput, aOutputMaxLen);

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -349,7 +349,7 @@ otError otPlatDiagProcess(otInstance *aInstance,
     char *cur                                              = cmd;
     char *end                                              = cmd + sizeof(cmd);
 
-    for (int index = 0; index < aArgsLength; index++)
+    for (uint8_t index = 0; index < aArgsLength; index++)
     {
         cur += snprintf(cur, static_cast<size_t>(end - cur), "%s ", aArgs[index]);
     }


### PR DESCRIPTION
The arguments of the function `otPlatDiagProcess` in posix radio drivers different from 
the one defined in the `diag.h`. It causes the diag module uses the weak definition of
the function `otPlatDiagProcess`. Then all platform defined diag commands are not
available. This PR fixes this issue.