### PR TITLE
[nrf528xx] add `OT_UNUSED_VARIABLE` to avoid compiler warning

### DIFF
--- a/examples/platforms/nrf528xx/src/transport/transport.c
+++ b/examples/platforms/nrf528xx/src/transport/transport.c
@@ -31,6 +31,7 @@
  *   This file implements the nrf5 platform transport initialization functions.
  *
  */
+#include <openthread/platform/toolchain.h>
 
 #include "platform-nrf5-transport.h"
 
@@ -50,6 +51,7 @@ void nrf5TransportInit(bool aPseudoReset)
 #endif
 
 #if (SPIS_AS_SERIAL_TRANSPORT == 1)
+    OT_UNUSED_VARIABLE(aPseudoReset);
     nrf5SpiSlaveInit();
 #endif
 }
@@ -64,6 +66,7 @@ void nrf5TransportDeinit(bool aPseudoReset)
 #endif
 
 #if (SPIS_AS_SERIAL_TRANSPORT == 1)
+    OT_UNUSED_VARIABLE(aPseudoReset);
     nrf5SpiSlaveDeinit();
 #endif
 }

--- a/examples/platforms/nrf528xx/src/transport/transport.c
+++ b/examples/platforms/nrf528xx/src/transport/transport.c
@@ -31,6 +31,7 @@
  *   This file implements the nrf5 platform transport initialization functions.
  *
  */
+
 #include <openthread/platform/toolchain.h>
 
 #include "platform-nrf5-transport.h"


### PR DESCRIPTION
When the macro `SPIS_AS_SERIAL_TRANSPORT` is enabled,
`UART_AS_SERIAL_TRANSPORT` and `USB_CDC_AS_SERIAL_TRANSPORT`
are disabled, no one uses the argument `aPseudoReset`. The compiler generates a warning.