### PR TITLE
[posix] add platform udp send retry

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -671,7 +671,7 @@ static void processNetifAddrEvent(otInstance *aInstance, struct nlmsghdr *aNetli
         }
 
         default:
-            otLogWarnPlat("unexpected address type (%d).", (int)rta->rta_type);
+            otLogDebgPlat("unexpected address type (%d).", static_cast<int>(rta->rta_type));
             break;
         }
     }

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -101,4 +101,14 @@
 #define OPENTHREAD_POSIX_CONFIG_MAX_POWER_TABLE_ENABLE 0
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_UDP_SEND_RETRY
+ *
+ * Number of times the stack will retry to send udp packets via kernel.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_UDP_SEND_RETRY
+#define OPENTHREAD_CONFIG_UDP_SEND_RETRY 5
+#endif
+
 #endif // OPENTHREAD_PLATFORM_CONFIG_H_

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -155,17 +155,17 @@ static otError transmitPacket(int aFd, uint8_t *aPayload, uint16_t aLength, cons
     for (size_t i = 0; i < OPENTHREAD_CONFIG_UDP_SEND_RETRY; i++)
     {
         rval = sendmsg(aFd, &msg, 0);
-        if (rval > 0 || errno != EINVAL)
+        if (rval != -1 || errno != EINVAL)
         {
             break;
         }
-        otLogWarnPlat("sendmsg(), retry: %s", strerror(errno));
+        otLogWarnPlat("sendmsg(): %s", strerror(errno));
         sleep(0);
     }
-    VerifyOrExit(rval > 0, perror("sendmsg"));
+    VerifyOrExit(rval != -1, perror("sendmsg"));
 
 exit:
-    return rval > 0 ? OT_ERROR_NONE : OT_ERROR_FAILED;
+    return rval != -1 ? OT_ERROR_NONE : OT_ERROR_FAILED;
 }
 
 static otError receivePacket(int aFd, uint8_t *aPayload, uint16_t &aLength, otMessageInfo &aMessageInfo)

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -152,8 +152,16 @@ static otError transmitPacket(int aFd, uint8_t *aPayload, uint16_t aLength, cons
 #else
     msg.msg_controllen = controlLength;
 #endif
-
-    rval = sendmsg(aFd, &msg, 0);
+    for (size_t i = 0; i < OPENTHREAD_CONFIG_UDP_SEND_RETRY; i++)
+    {
+        rval = sendmsg(aFd, &msg, 0);
+        if (rval > 0 || errno != EINVAL)
+        {
+            break;
+        }
+        otLogWarnPlat("sendmsg(), retry: %s", strerror(errno));
+        sleep(0);
+    }
     VerifyOrExit(rval > 0, perror("sendmsg"));
 
 exit:


### PR DESCRIPTION
The kernel will report EINVAL when we've just added/removed addresses
on the interface. Add retry to be tolerate.