### PR TITLE
[codecov] only comment after a number of builds

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -9,3 +9,4 @@ ignore:
 
 comment:
   layout: "diff, flags, files"
+  after_n_builds: 15


### PR DESCRIPTION
Immature comments from Codecov bot shows big reduce in code coverage and is confusing. 
This PR prevent Codecov comment until a number of builds are finished. 

However the number of `after_n_builds` is hardcoded and has to be revised whenever we add a new `codecov/codecov-action@v1` step. 

Do you think it's better to have `after_n_builds` defined? @wgtdkp @bukepo @jwhui 