### PR TITLE
[coap] ensure Thread control messages are prioritized

### DIFF
--- a/include/openthread/icmp6.h
+++ b/include/openthread/icmp6.h
@@ -58,11 +58,12 @@ extern "C" {
  */
 typedef enum otIcmp6Type
 {
-    OT_ICMP6_TYPE_DST_UNREACH   = 1,   ///< Destination Unreachable
-    OT_ICMP6_TYPE_PACKET_TO_BIG = 2,   ///< Packet To Big
-    OT_ICMP6_TYPE_TIME_EXCEEDED = 3,   ///< Time Exceeded
-    OT_ICMP6_TYPE_ECHO_REQUEST  = 128, ///< Echo Request
-    OT_ICMP6_TYPE_ECHO_REPLY    = 129, ///< Echo Reply
+    OT_ICMP6_TYPE_DST_UNREACH       = 1,   ///< Destination Unreachable
+    OT_ICMP6_TYPE_PACKET_TO_BIG     = 2,   ///< Packet To Big
+    OT_ICMP6_TYPE_TIME_EXCEEDED     = 3,   ///< Time Exceeded
+    OT_ICMP6_TYPE_PARAMETER_PROBLEM = 4,   ///< Parameter Problem
+    OT_ICMP6_TYPE_ECHO_REQUEST      = 128, ///< Echo Request
+    OT_ICMP6_TYPE_ECHO_REPLY        = 129, ///< Echo Reply
 } otIcmp6Type;
 
 /**

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -340,6 +340,18 @@ public:
     Message *NewMessage(const otMessageSettings *aSettings = NULL);
 
     /**
+     * This method creates a new message with a CoAP header that has Network Control priority level.
+     *
+     * @returns A pointer to the message or NULL if failed to allocate message.
+     *
+     */
+    Message *NewPriorityMessage(void)
+    {
+        otMessageSettings settings = {true, static_cast<otMessagePriority>(Message::kPriorityNet)};
+        return NewMessage(&settings);
+    }
+
+    /**
      * This method sends a CoAP message with custom transmission parameters.
      *
      * If a response for a request is expected, respective function and context information should be provided.

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -92,11 +92,12 @@ otError Icmp::SendError(IcmpHeader::Type   aType,
                         const MessageInfo &aMessageInfo,
                         const Message &    aMessage)
 {
-    otError     error = OT_ERROR_NONE;
-    MessageInfo messageInfoLocal;
-    Message *   message = NULL;
-    IcmpHeader  icmp6Header;
-    Header      ip6Header;
+    otError           error = OT_ERROR_NONE;
+    MessageInfo       messageInfoLocal;
+    Message *         message = NULL;
+    IcmpHeader        icmp6Header;
+    Header            ip6Header;
+    otMessageSettings settings = {true, static_cast<otMessagePriority>(Message::kPriorityNet)};
 
     VerifyOrExit(aMessage.GetLength() >= sizeof(ip6Header), error = OT_ERROR_INVALID_ARGS);
 
@@ -112,7 +113,7 @@ otError Icmp::SendError(IcmpHeader::Type   aType,
 
     messageInfoLocal = aMessageInfo;
 
-    VerifyOrExit((message = Get<Ip6>().NewMessage(0)) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = Get<Ip6>().NewMessage(0, &settings)) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = message->SetLength(sizeof(icmp6Header) + sizeof(ip6Header)));
 
     message->Write(sizeof(icmp6Header), sizeof(ip6Header), &ip6Header);

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -84,11 +84,12 @@ public:
      */
     enum Type
     {
-        kTypeDstUnreach   = OT_ICMP6_TYPE_DST_UNREACH,   ///< Destination Unreachable
-        kTypePacketToBig  = OT_ICMP6_TYPE_PACKET_TO_BIG, ///< Packet To Big
-        kTypeTimeExceeded = OT_ICMP6_TYPE_TIME_EXCEEDED, ///< Time Exceeded
-        kTypeEchoRequest  = OT_ICMP6_TYPE_ECHO_REQUEST,  ///< Echo Request
-        kTypeEchoReply    = OT_ICMP6_TYPE_ECHO_REPLY,    ///< Echo Reply
+        kTypeDstUnreach       = OT_ICMP6_TYPE_DST_UNREACH,       ///< Destination Unreachable
+        kTypePacketToBig      = OT_ICMP6_TYPE_PACKET_TO_BIG,     ///< Packet To Big
+        kTypeTimeExceeded     = OT_ICMP6_TYPE_TIME_EXCEEDED,     ///< Time Exceeded
+        kTypeParameterProblem = OT_ICMP6_TYPE_PARAMETER_PROBLEM, ///< Parameter Problem
+        kTypeEchoRequest      = OT_ICMP6_TYPE_ECHO_REQUEST,      ///< Echo Request
+        kTypeEchoReply        = OT_ICMP6_TYPE_ECHO_REPLY,        ///< Echo Reply
     };
 
     /**

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -553,7 +553,7 @@ otError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
     Coap::Message *  message;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit((message = Get<Coap::Coap>().NewMessage()) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = Get<Coap::Coap>().NewPriorityMessage()) != NULL, error = OT_ERROR_NO_BUFS);
 
     message->Init(OT_COAP_TYPE_NON_CONFIRMABLE, OT_COAP_CODE_POST);
     SuccessOrExit(error = message->AppendUriPathOptions(OT_URI_PATH_ADDRESS_QUERY));
@@ -837,7 +837,7 @@ void AddressResolver::SendAddressQueryResponse(const Ip6::Address &aTarget,
     Coap::Message *  message;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit((message = Get<Coap::Coap>().NewMessage()) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = Get<Coap::Coap>().NewPriorityMessage()) != NULL, error = OT_ERROR_NO_BUFS);
 
     message->Init(OT_COAP_TYPE_CONFIRMABLE, OT_COAP_CODE_POST);
     SuccessOrExit(error = message->AppendUriPathOptions(OT_URI_PATH_ADDRESS_NOTIFY));

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1349,19 +1349,35 @@ otError MeshForwarder::GetFramePriority(const uint8_t *     aFrame,
                                         const Mac::Address &aMacDest,
                                         uint8_t &           aPriority)
 {
-    otError        error = OT_ERROR_NONE;
-    Ip6::Header    ip6Header;
-    Ip6::UdpHeader udpHeader;
-    uint8_t        headerLength;
-    bool           nextHeaderCompressed;
+    otError         error = OT_ERROR_NONE;
+    Ip6::Header     ip6Header;
+    Ip6::UdpHeader  udpHeader;
+    Ip6::IcmpHeader icmpHeader;
+    uint8_t         headerLength;
+    bool            nextHeaderCompressed;
 
     SuccessOrExit(error = DecompressIp6Header(aFrame, aFrameLength, aMacSource, aMacDest, ip6Header, headerLength,
                                               nextHeaderCompressed));
     aPriority = Ip6::Ip6::DscpToPriority(ip6Header.GetDscp());
-    VerifyOrExit(ip6Header.GetNextHeader() == Ip6::kProtoUdp, OT_NOOP);
 
     aFrame += headerLength;
     aFrameLength -= headerLength;
+
+    if (ip6Header.GetNextHeader() == Ip6::kProtoIcmp6 && aFrameLength)
+    {
+        // Just check the first byte which is an ICMPv6 type.
+        memcpy(&icmpHeader, aFrame, sizeof(icmpHeader.mType));
+
+        // Only ICMPv6 error messages are prioritized.
+        if (icmpHeader.IsError())
+        {
+            aPriority = Message::kPriorityNet;
+        }
+
+        ExitNow();
+    }
+
+    VerifyOrExit(ip6Header.GetNextHeader() == Ip6::kProtoUdp, OT_NOOP);
 
     if (nextHeaderCompressed)
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3919,7 +3919,7 @@ otError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
 
     VerifyOrExit(!mAddressSolicitPending, OT_NOOP);
 
-    VerifyOrExit((message = Get<Coap::Coap>().NewMessage()) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = Get<Coap::Coap>().NewPriorityMessage()) != NULL, error = OT_ERROR_NO_BUFS);
 
     SuccessOrExit(error = message->Init(OT_COAP_TYPE_CONFIRMABLE, OT_COAP_CODE_POST, OT_URI_PATH_ADDRESS_SOLICIT));
     SuccessOrExit(error = message->SetPayloadMarker());
@@ -4204,7 +4204,7 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Message &   aRequest,
     ThreadRouterMaskTlv routerMaskTlv;
     Coap::Message *     message;
 
-    VerifyOrExit((message = Get<Coap::Coap>().NewMessage()) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = Get<Coap::Coap>().NewPriorityMessage()) != NULL, error = OT_ERROR_NO_BUFS);
 
     SuccessOrExit(error = message->SetDefaultResponseHeader(aRequest));
     SuccessOrExit(error = message->SetPayloadMarker());


### PR DESCRIPTION
According to the Thread Conformance document, we should implement the following requirement:

> All Thread Devices MUST prioritize Thread control messages over other messages.
> Thread control messages include:
> - MLE messages
> - Address Solicit Request and Address Solicit Response messages
> - Address Query and Address Notification messages
> - ICMPv6 Error messages, including ICMPv6 Destination Unreachable

OpenThread currently does not meet three last bullets.
