### PR TITLE
[ip6] do not pass reassembled IPv6 packet to the host

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1027,6 +1027,9 @@ otError Ip6::ProcessReceiveCallback(const Message &    aMessage,
     VerifyOrExit(!aFromNcpHost, error = OT_ERROR_NO_ROUTE);
     VerifyOrExit(mReceiveIp6DatagramCallback != NULL, error = OT_ERROR_NO_ROUTE);
 
+    // Do not forward reassembled IPv6 packets.
+    VerifyOrExit(aMessage.GetLength() <= kMinimalMtu, error = OT_ERROR_DROP);
+
     if (mIsReceiveIp6FilterEnabled)
     {
         // do not pass messages sent to an RLOC/ALOC, except Service Locator


### PR DESCRIPTION
When Border Router is built with `OPENTHREAD_CONFIG_IP6_FRAGMENTATION_ENABLE`
flag and receives the message to its Mesh-Local EID, for a small range of IPv6
lengths, NCP may forward both IPv6 fragments and reassembled packet. This commit
ensures the latter situation does not happen.