### PR TITLE
[pretty] add support for shell scripts

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,9 +49,9 @@ jobs:
         sudo apt update
         sudo apt remove -y clang-6.0 libclang-common-6.0-dev libclang1-6.0 libllvm6.0
         sudo apt autoremove
-        sudo apt --no-install-recommends install -y clang-tools clang-format-6.0
-        clang-format-6.0 --version
+        sudo apt --no-install-recommends install -y clang-tools clang-format-6.0 shellcheck
         python3 -m pip install yapf==0.29.0
+        sudo snap install shfmt
     - name: Check
       run: |
         script/make-pretty check

--- a/bootstrap
+++ b/bootstrap
@@ -38,8 +38,8 @@ nlbuild_autotools_stem="third_party/nlbuild-autotools/repo"
 
 # Establish some key directories
 
-srcdir=`dirname ${0}`
-abs_srcdir=`pwd`
+srcdir=$(dirname ${0})
+abs_srcdir=$(pwd)
 abs_top_srcdir="${abs_srcdir}"
 
 exec ${srcdir}/${nlbuild_autotools_stem}/scripts/bootstrap -I "${abs_top_srcdir}/${nlbuild_autotools_stem}" $*

--- a/bootstrap
+++ b/bootstrap
@@ -36,10 +36,6 @@
 
 nlbuild_autotools_stem="third_party/nlbuild-autotools/repo"
 
-# Establish some key directories
+abs_srcdir=$(cd "$(dirname "${0}")" && pwd)
 
-srcdir=$(dirname ${0})
-abs_srcdir=$(pwd)
-abs_top_srcdir="${abs_srcdir}"
-
-exec ${srcdir}/${nlbuild_autotools_stem}/scripts/bootstrap -I "${abs_top_srcdir}/${nlbuild_autotools_stem}" $*
+(cd "$abs_srcdir" && exec "$abs_srcdir/$nlbuild_autotools_stem/scripts/bootstrap" -I "$abs_srcdir/$nlbuild_autotools_stem" "${@}")

--- a/etc/docker/ot_sim/add_node
+++ b/etc/docker/ot_sim/add_node
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker exec -it otsim node $1
+docker exec -it otsim node "$1"

--- a/script/check-gn-build
+++ b/script/check-gn-build
@@ -34,7 +34,8 @@
 set -e
 set -x
 
-main() {
+main()
+{
     gn gen gn-out
     ninja -C gn-out
     test -f gn-out/obj/lib-ot-core.a

--- a/script/check-ncp-rcp-migrate
+++ b/script/check-ncp-rcp-migrate
@@ -30,7 +30,8 @@
 set -e
 set -x
 
-at_exit() {
+at_exit()
+{
     EXIT_CODE=$?
 
     killall expect || true
@@ -41,12 +42,14 @@ at_exit() {
     exit $EXIT_CODE
 }
 
-build() {
+build()
+{
     make -f examples/Makefile-simulation
     make -f src/posix/Makefile-posix
 }
 
-check() {
+check()
+{
     trap at_exit INT TERM EXIT
 
     rm -rf tmp/
@@ -127,7 +130,8 @@ EOF
     test -n "{RADIO_VERSION}"
 }
 
-main() {
+main()
+{
     case "$1" in
         build)
             build

--- a/script/check-ncp-rcp-migrate
+++ b/script/check-ncp-rcp-migrate
@@ -93,7 +93,7 @@ EOF
 
     echo "Step 2. Start retrieving dataset from Radio..."
     RADIO_NCP_PATH="$(pwd)/$(ls output/*linux*/bin/ot-ncp-ftd)"
-    "$(pwd)/$(ls output/posix/*linux*/bin/ot-ncp)" -n --radio-version --ncp-dataset -- ${RADIO_NCP_PATH} 1
+    "$(pwd)/$(ls output/posix/*linux*/bin/ot-ncp)" -n --radio-version --ncp-dataset -- "${RADIO_NCP_PATH}" 1
 
     echo "Step 3. Start posix app and check whether PAN dataset is the same..."
     RADIO_RCP_PATH="$(pwd)/$(ls output/*linux*/bin/ot-rcp)"
@@ -126,8 +126,8 @@ expect eof
 EOF
 
     echo "Step 4. Start posix app and check whether it can get radio firmware version..."
-    RADIO_VERSION="$("$(pwd)/$(ls output/posix/*linux*/bin/ot-cli)" -n --radio-version --ncp-dataset -- ${RADIO_RCP_PATH} 1)" || true
-    test -n "{RADIO_VERSION}"
+    RADIO_VERSION="$("$(pwd)/$(ls output/posix/*linux*/bin/ot-cli)" -n --radio-version --ncp-dataset -- "${RADIO_RCP_PATH}" 1)" || true
+    test -n "${RADIO_VERSION}"
 }
 
 main()

--- a/script/check-posix-build-autotools
+++ b/script/check-posix-build-autotools
@@ -29,8 +29,6 @@
 
 set -euxo pipefail
 
-readonly OT_BUILD_JOBS=$(getconf _NPROCESSORS_ONLN)
-
 reset_source()
 {
     rm -rf build output tmp

--- a/script/check-posix-build-autotools
+++ b/script/check-posix-build-autotools
@@ -41,7 +41,7 @@ build()
     reset_source
     make -f src/posix/Makefile-posix
 
-    if [[ $OSTYPE != "darwin"* ]] ; then
+    if [[ $OSTYPE != "darwin"* ]]; then
         reset_source
         make -f src/posix/Makefile-posix RCP_BUS=spi
     fi

--- a/script/check-posix-build-cmake
+++ b/script/check-posix-build-cmake
@@ -90,7 +90,7 @@ main()
     reset_source
     build
 
-    if [[ $OSTYPE != "darwin"* ]] ; then
+    if [[ $OSTYPE != "darwin"* ]]; then
         reset_source
         build -DOT_POSIX_CONFIG_RCP_BUS=SPI
     fi

--- a/script/check-posix-build-cmake
+++ b/script/check-posix-build-cmake
@@ -77,12 +77,12 @@ build()
         "-DOT_FULL_LOGS=on"
     )
 
-    mkdir -p $OT_BUILDDIR
-    cd $OT_BUILDDIR
-    cmake -GNinja "${options[@]}" $OT_SRCDIR
+    mkdir -p "$OT_BUILDDIR"
+    cd "$OT_BUILDDIR"
+    cmake -GNinja "${options[@]}" "$OT_SRCDIR"
     ninja
 
-    cd $OT_SRCDIR
+    cd "$OT_SRCDIR"
 }
 
 main()

--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -32,7 +32,7 @@ set -x
 
 die()
 {
-    echo " *** ERROR: " $*
+    echo " *** ERROR: " "$*"
     exit 1
 }
 
@@ -62,7 +62,7 @@ check()
     OT_OUTPUT=/tmp/ot-output
     socat -d -d pty,raw,echo=0 pty,raw,echo=0 >/dev/null 2>$SOCAT_OUTPUT &
     while true; do
-        if test $(head -n2 $SOCAT_OUTPUT | wc -l) = 2; then
+        if test "$(head -n2 $SOCAT_OUTPUT | wc -l)" = 2; then
             RADIO_PTY=$(head -n1 $SOCAT_OUTPUT | grep -o '/dev/.\+')
             CORE_PTY=$(head -n2 $SOCAT_OUTPUT | tail -n1 | grep -o '/dev/.\+')
             break
@@ -70,11 +70,13 @@ check()
         echo 'Waiting for socat ready...'
         sleep 1
     done
-    echo 'RADIO_PTY' $DEVICE_PTY
-    echo 'CORE_PTY' $CORE_PTY
+    echo 'RADIO_PTY' "$DEVICE_PTY"
+    echo 'CORE_PTY' "$CORE_PTY"
 
     RADIO_NCP_PATH="$(pwd)/$(ls output/*linux*/bin/ot-rcp)"
-    $RADIO_NCP_PATH 1 >$RADIO_PTY <$RADIO_PTY &
+
+    # shellcheck disable=SC2094
+    $RADIO_NCP_PATH 1 >"$RADIO_PTY" <"$RADIO_PTY" &
 
     # Cover setting a valid network interface name.
     readonly VALID_NETIF_NAME="wan$(date +%H%M%S)"
@@ -84,26 +86,28 @@ check()
     )
 
     if [[ ${DAEMON} == 1 ]]; then
-        sudo "$(pwd)/$(ls output/posix/*linux*/bin/ot-daemon)" "${options[@]}" -I "${VALID_NETIF_NAME}" ${CORE_PTY} &
+        sudo "$(pwd)/$(ls output/posix/*linux*/bin/ot-daemon)" "${options[@]}" -I "${VALID_NETIF_NAME}" "${CORE_PTY}" &
         sleep 1
         OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-ctl)"
+        OT_CLI_ARG=
     else
-        OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli) "${options[@]}" ${CORE_PTY}"
+        OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli)"
+        OT_CLI_ARG="${CORE_PTY}"
     fi
 
-    sudo ${OT_CLI_CMD} -I "${VALID_NETIF_NAME}" -n
+    sudo "${OT_CLI_CMD}" "${OT_CLI_ARG}" -I "${VALID_NETIF_NAME}" -n
 
     # Cover setting a too long(max is 15 characters) network interface name.
     # Expect exit code to be 2(OT_EXIT_INVALID_ARGUMENTS).
     readonly INVALID_NETIF_NAME="wan0123456789123"
-    sudo ${OT_CLI_CMD} -I "${INVALID_NETIF_NAME}" -n || test $? = 2
+    sudo "${OT_CLI_CMD}" "${OT_CLI_ARG}" -I "${INVALID_NETIF_NAME}" -n || test $? = 2
 
     if [[ ${DAEMON} == 1 ]]; then
-        sudo ${OT_CLI_CMD} panid 0xface | grep 'Done' || die 'failed to set panid with ot-ctl'
+        sudo "${OT_CLI_CMD}" "${OT_CLI_ARG}" panid 0xface | grep 'Done' || die 'failed to set panid with ot-ctl'
     fi
 
-    sudo expect <<EOF >"${OT_OUTPUT}" &
-spawn ${OT_CLI_CMD}
+    sudo expect <<EOF | tee "${OT_OUTPUT}" &
+spawn ${OT_CLI_CMD} ${OT_CLI_ARG}
 send "panid 0xface\r\n"
 expect "Done"
 send "ifconfig up\r\n"
@@ -142,7 +146,7 @@ EOF
         sudo killall -9 expect || true
         sudo killall -9 ot-ctl || true
         NETIF_INDEX=$(ip link show "${VALID_NETIF_NAME}" | cut -f 1 -d ":" | head -n 1)
-        sudo PATH="$(dirname ${OT_CLI_CMD}):${PATH}" \
+        sudo PATH="$(dirname "${OT_CLI_CMD}"):${PATH}" \
             python3 "$PWD/tests/scripts/misc/test_multicast_join.py" "${NETIF_INDEX}" \
             || die 'multicast group join failed'
     fi
@@ -153,7 +157,11 @@ EOF
     echo "CoAP response is: ${coap_response}"
 
     # Verify CoAP response contains the extended address
-    [[ ${coap_response} == *${extaddr}* ]] && echo 'Success' || die 'failed to get extended address'
+    if [[ ${coap_response} == *${extaddr}* ]]; then
+        echo 'Success'
+    else
+        die 'failed to get extended address'
+    fi
 }
 
 main()

--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -30,12 +30,14 @@
 set -e
 set -x
 
-die() {
-	echo " *** ERROR: " $*
-	exit 1
+die()
+{
+    echo " *** ERROR: " $*
+    exit 1
 }
 
-at_exit() {
+at_exit()
+{
     EXIT_CODE=$?
 
     sudo killall expect || true
@@ -46,17 +48,19 @@ at_exit() {
     exit $EXIT_CODE
 }
 
-build() {
+build()
+{
     make -f examples/Makefile-simulation
     make -f src/posix/Makefile-posix PLATFORM_NETIF=1 PLATFORM_UDP=1 UDP_FORWARD=0 MAX_POWER_TABLE=1
 }
 
-check() {
+check()
+{
     trap at_exit INT TERM EXIT
 
     SOCAT_OUTPUT=/tmp/ot-socat
     OT_OUTPUT=/tmp/ot-output
-    socat -d -d pty,raw,echo=0 pty,raw,echo=0 > /dev/null 2> $SOCAT_OUTPUT &
+    socat -d -d pty,raw,echo=0 pty,raw,echo=0 >/dev/null 2>$SOCAT_OUTPUT &
     while true; do
         if test $(head -n2 $SOCAT_OUTPUT | wc -l) = 2; then
             RADIO_PTY=$(head -n1 $SOCAT_OUTPUT | grep -o '/dev/.\+')
@@ -70,7 +74,7 @@ check() {
     echo 'CORE_PTY' $CORE_PTY
 
     RADIO_NCP_PATH="$(pwd)/$(ls output/*linux*/bin/ot-rcp)"
-    $RADIO_NCP_PATH 1 > $RADIO_PTY < $RADIO_PTY &
+    $RADIO_NCP_PATH 1 >$RADIO_PTY <$RADIO_PTY &
 
     # Cover setting a valid network interface name.
     readonly VALID_NETIF_NAME="wan$(date +%H%M%S)"
@@ -79,7 +83,7 @@ check() {
         '--max-power-table=11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26'
     )
 
-    if [[ "${DAEMON}" = 1 ]]; then
+    if [[ ${DAEMON} == 1 ]]; then
         sudo "$(pwd)/$(ls output/posix/*linux*/bin/ot-daemon)" "${options[@]}" -I "${VALID_NETIF_NAME}" ${CORE_PTY} &
         sleep 1
         OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-ctl)"
@@ -94,11 +98,11 @@ check() {
     readonly INVALID_NETIF_NAME="wan0123456789123"
     sudo ${OT_CLI_CMD} -I "${INVALID_NETIF_NAME}" -n || test $? = 2
 
-    if [[ "${DAEMON}" = 1 ]]; then
+    if [[ ${DAEMON} == 1 ]]; then
         sudo ${OT_CLI_CMD} panid 0xface | grep 'Done' || die 'failed to set panid with ot-ctl'
     fi
 
-    sudo expect <<EOF > "${OT_OUTPUT}" &
+    sudo expect <<EOF >"${OT_OUTPUT}" &
 spawn ${OT_CLI_CMD}
 send "panid 0xface\r\n"
 expect "Done"
@@ -134,13 +138,13 @@ EOF
     extaddr=$(awk '/extaddr/{getline; print}' $OT_OUTPUT | tr -d '\r\n')
     echo "Extended address is: ${extaddr}"
 
-    if [[ "${DAEMON}" = 1 ]]; then
+    if [[ ${DAEMON} == 1 ]]; then
         sudo killall -9 expect || true
         sudo killall -9 ot-ctl || true
         NETIF_INDEX=$(ip link show "${VALID_NETIF_NAME}" | cut -f 1 -d ":" | head -n 1)
         sudo PATH="$(dirname ${OT_CLI_CMD}):${PATH}" \
-             python3 "$PWD/tests/scripts/misc/test_multicast_join.py" "${NETIF_INDEX}" \
-             || die 'multicast group join failed'
+            python3 "$PWD/tests/scripts/misc/test_multicast_join.py" "${NETIF_INDEX}" \
+            || die 'multicast group join failed'
     fi
 
     LEADER_ALOC=fdde:ad00:beef::ff:fe00:fc00
@@ -149,10 +153,11 @@ EOF
     echo "CoAP response is: ${coap_response}"
 
     # Verify CoAP response contains the extended address
-    [[ "${coap_response}" = *${extaddr}* ]] && echo 'Success' || die 'failed to get extended address'
+    [[ ${coap_response} == *${extaddr}* ]] && echo 'Success' || die 'failed to get extended address'
 }
 
-main() {
+main()
+{
     case $1 in
         build)
             build

--- a/script/check-scan-build
+++ b/script/check-scan-build
@@ -81,7 +81,7 @@ do_scan_build()
         "-DMBEDTLS_DEBUG_C"
         "-I$(pwd)/third_party/mbedtls"
         "-I$(pwd)/third_party/mbedtls/repo/include"
-        "-DMBEDTLS_CONFIG_FILE=\\\"mbedtls-config.h\\\""
+        '-DMBEDTLS_CONFIG_FILE=\"mbedtls-config.h\"'
     )
 
     configure_options=(

--- a/script/check-size
+++ b/script/check-size
@@ -64,14 +64,14 @@ markdown_size()
     local name
     name=$(basename "$1")
 
-    read -r -a size_old <<< "$(size "$1" | awk '{text+=$1} {bss+=$2} {data+=$3} {total+=$4} END {printf "%d %d %d %d", text, bss, data, total}')"
-    read -r -a size_new <<< "$(size "$2" | awk '{text+=$1} {bss+=$2} {data+=$3} {total+=$4} END {printf "%d %d %d %d", text, bss, data, total}')"
+    read -r -a size_old <<<"$(size "$1" | awk '{text+=$1} {bss+=$2} {data+=$3} {total+=$4} END {printf "%d %d %d %d", text, bss, data, total}')"
+    read -r -a size_new <<<"$(size "$2" | awk '{text+=$1} {bss+=$2} {data+=$3} {total+=$4} END {printf "%d %d %d %d", text, bss, data, total}')"
 
     local -a size_diff
 
     for i in 0 1 2 3; do
         size_diff[$i]="$((size_new["$i"] - size_old["$i"]))"
-        if [[ "${size_diff["$i"]}" != 0 ]]; then
+        if [[ ${size_diff["$i"]} != 0 ]]; then
             size_diff["$i"]=$(printf '%+d' "${size_diff["$i"]}")
         fi
     done
@@ -86,11 +86,11 @@ markdown()
     case "$1" in
         init)
             shift
-            markdown_init "$@" > "${OT_REPORT_FILE}"
+            markdown_init "$@" >"${OT_REPORT_FILE}"
             ;;
         size)
             shift
-            markdown_size "$@" >> "${OT_REPORT_FILE}"
+            markdown_size "$@" >>"${OT_REPORT_FILE}"
             ;;
         post)
             mdv "${OT_REPORT_FILE}"
@@ -152,11 +152,11 @@ size_nrf52840()
     local reporter
 
     # not on GitHub Actions or not a pull request event
-    if [[ ! "${GITHUB_ACTIONS+x}" || ! "${GITHUB_REF-}" =~ ^refs/pull/[0-9]+/merge ]]; then
+    if [[ ! ${GITHUB_ACTIONS+x} || ! ${GITHUB_REF-} =~ ^refs/pull/[0-9]+/merge ]]; then
         reporter=markdown
     else
         reporter=./size-report
-        curl -s "${SIZE_REPORT_URL}/bash" > size-report
+        curl -s "${SIZE_REPORT_URL}/bash" >size-report
         chmod a+x size-report
         export OT_SHA_NEW OT_SHA_OLD
     fi
@@ -167,16 +167,16 @@ size_nrf52840()
     "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-cli-mtd "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-cli-mtd
     "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-ncp-ftd "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-ncp-ftd
     "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-ncp-mtd "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-ncp-mtd
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-rcp     "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-rcp
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-rcp "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-rcp
 
     "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-cli-ftd.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-cli-ftd.a
     "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-cli-mtd.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-cli-mtd.a
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-ftd.a     "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-ftd.a
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-mtd.a     "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-mtd.a
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-ftd.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-ftd.a
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-mtd.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-mtd.a
     "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-ncp-ftd.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-ncp-ftd.a
     "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-ncp-mtd.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-ncp-mtd.a
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-rcp.a     "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-rcp.a
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-radio.a   "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-radio.a
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-rcp.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-rcp.a
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-radio.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-radio.a
 
     "${reporter}" post
 }
@@ -186,9 +186,9 @@ main()
     if [[ $# == 0 ]]; then
         setup
         size_nrf52840
-    elif [[ "$1" == setup ]]; then
+    elif [[ $1 == setup ]]; then
         setup
-    elif [[ "$1" == nrf52840 ]]; then
+    elif [[ $1 == nrf52840 ]]; then
         size_nrf52840
     else
         echo "USAGE: $0 [setup|nrf52840]"

--- a/script/clang-format
+++ b/script/clang-format
@@ -29,7 +29,8 @@
 
 CLANG_FORMAT_VERSION="clang-format version 6.0"
 
-die() {
+die()
+{
     echo " *** ERROR: $*"
     exit 1
 }
@@ -38,12 +39,12 @@ die() {
 # expand_aliases shell option is set using shopt.
 shopt -s expand_aliases
 
-if command -v clang-format-6.0 > /dev/null; then
+if command -v clang-format-6.0 >/dev/null; then
     alias clang-format=clang-format-6.0
-elif command -v clang-format > /dev/null; then
+elif command -v clang-format >/dev/null; then
     case "$(clang-format --version)" in
-        "$CLANG_FORMAT_VERSION"*)
-            ;;
+        "$CLANG_FORMAT_VERSION"*) ;;
+
         *)
             die "$(clang-format --version); clang-format 6.0 required"
             ;;
@@ -56,8 +57,7 @@ clang-format "$@" || die
 
 # ensure EOF newline
 REPLACE=no
-for arg
-do
+for arg; do
     case $arg in
         -i)
             REPLACE=yes
@@ -68,7 +68,7 @@ done
 file=$arg
 
 [ $REPLACE != yes ] || {
-    [ -n "$(tail -c1 "$file")" ] && echo >> "$file"
+    [ -n "$(tail -c1 "$file")" ] && echo >>"$file"
 }
 
 exit 0

--- a/script/clang-format-check
+++ b/script/clang-format-check
@@ -35,7 +35,8 @@
 
 set -euo pipefail
 
-die() {
+die()
+{
     echo " *** ERROR:  $*"
     exit 1
 }

--- a/script/make-pretty
+++ b/script/make-pretty
@@ -67,82 +67,91 @@ readonly OT_CLANG_SOURCES=('*.c' '*.cc' '*.cpp' '*.h' '*.hpp')
 readonly OT_MARKDOWN_SOURCES=('*.md')
 readonly OT_PYTHON_SOURCES=('*.py')
 
-do_clang_format() {
+do_clang_format()
+{
     echo -e '====================='
     echo -e '     format c/c++'
     echo -e '====================='
 
-    git ls-files "${OT_CLANG_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
-        xargs -n3 -P"$OT_BUILD_JOBS" script/clang-format -style=file -i -verbose
+    git ls-files "${OT_CLANG_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs -n3 -P"$OT_BUILD_JOBS" script/clang-format -style=file -i -verbose
 }
 
-do_clang_check() {
+do_clang_check()
+{
     echo -e '====================='
     echo -e '     check c/c++'
     echo -e '====================='
 
-    git ls-files "${OT_CLANG_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
-        xargs -n3 -P"$OT_BUILD_JOBS" script/clang-format-check
+    git ls-files "${OT_CLANG_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs -n3 -P"$OT_BUILD_JOBS" script/clang-format-check
 }
 
-do_markdown_format() {
+do_markdown_format()
+{
     echo -e '======================'
     echo -e '     format markdown'
     echo -e '======================'
 
-    git ls-files "${OT_MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
-        xargs -n10 -P"$OT_BUILD_JOBS" npx prettier@2.0.4 --write
+    git ls-files "${OT_MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs -n10 -P"$OT_BUILD_JOBS" npx prettier@2.0.4 --write
 }
 
-do_markdown_check() {
+do_markdown_check()
+{
     echo -e '======================'
     echo -e '     check markdown'
     echo -e '======================'
 
-    git ls-files "${OT_MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
-        xargs -n10 -P"$OT_BUILD_JOBS" npx prettier@2.0.4 --check
+    git ls-files "${OT_MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs -n10 -P"$OT_BUILD_JOBS" npx prettier@2.0.4 --check
 }
 
-do_python_format() {
+do_python_format()
+{
     echo -e '======================'
     echo -e '     format python'
     echo -e '======================'
 
-    git ls-files "${OT_PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
-        xargs -n10 -P"$OT_BUILD_JOBS" python3 -m yapf --verbose --style google -ipr
+    git ls-files "${OT_PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs -n10 -P"$OT_BUILD_JOBS" python3 -m yapf --verbose --style google -ipr
 }
 
-do_python_check() {
+do_python_check()
+{
     echo -e '====================='
     echo -e '     check python'
     echo -e '====================='
 
-    git ls-files "${OT_PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
-        xargs -n10 -P"$OT_BUILD_JOBS" python3 -m yapf --verbose --style google -dpr
+    git ls-files "${OT_PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs -n10 -P"$OT_BUILD_JOBS" python3 -m yapf --verbose --style google -dpr
 }
 
-do_shell_format() {
+do_shell_format()
+{
     echo -e '====================='
     echo -e '     format shell'
     echo -e '====================='
 
-    shfmt -f . | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
-        xargs -n10 -P"$OT_BUILD_JOBS" shfmt -i 4 -bn -ci -fn -s -w
+    shfmt -f . | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs -n10 -P"$OT_BUILD_JOBS" shfmt -i 4 -bn -ci -fn -s -w
 }
 
-do_shell_check() {
+do_shell_check()
+{
     echo -e '====================='
     echo -e '     check shell'
     echo -e '====================='
 
-    shfmt -f . | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
-        xargs -n10 -P"$OT_BUILD_JOBS" shfmt -i 4 -bn -ci -fn -s -d
+    shfmt -f . | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs -n10 -P"$OT_BUILD_JOBS" shfmt -i 4 -bn -ci -fn -s -d
 
-    shfmt -f . | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
-        xargs -n10 -P"$OT_BUILD_JOBS" shellcheck
+    shfmt -f . | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
+        | xargs -n10 -P"$OT_BUILD_JOBS" shellcheck
 }
 
-do_check() {
+do_check()
+{
     if [ $# == 0 ]; then
         do_clang_check
         do_markdown_check
@@ -163,7 +172,8 @@ do_check() {
     fi
 }
 
-main() {
+main()
+{
     if [ $# == 0 ]; then
         do_clang_format
         do_markdown_format

--- a/script/make-pretty
+++ b/script/make-pretty
@@ -30,7 +30,7 @@
 #
 # The script to check or format source code of OpenThread.
 #
-# Format c/c++, markdown, and python:
+# Format c/c++, markdown, python, and shell:
 #
 #     script/make-pretty
 #
@@ -46,11 +46,16 @@
 #
 #     script/make-pretty python
 #
+# Format shell only:
+#
+#     script/make-pretty shell
+#
 # Check only:
 #
 #     script/make-pretty check clang
 #     script/make-pretty check markdown
 #     script/make-pretty check python
+#     script/make-pretty check shell
 #
 
 set -euo pipefail
@@ -62,102 +67,121 @@ readonly OT_CLANG_SOURCES=('*.c' '*.cc' '*.cpp' '*.h' '*.hpp')
 readonly OT_MARKDOWN_SOURCES=('*.md')
 readonly OT_PYTHON_SOURCES=('*.py')
 
-do_clang_format()
-{
+do_clang_format() {
     echo -e '====================='
     echo -e '     format c/c++'
     echo -e '====================='
 
-    git ls-files "${OT_CLANG_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
-        | xargs -n3 -P"${OT_BUILD_JOBS}" script/clang-format -style=file -i -verbose
+    git ls-files "${OT_CLANG_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
+        xargs -n3 -P"$OT_BUILD_JOBS" script/clang-format -style=file -i -verbose
 }
 
-do_clang_check()
-{
+do_clang_check() {
     echo -e '====================='
     echo -e '     check c/c++'
     echo -e '====================='
 
-    git ls-files "${OT_CLANG_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
-        | xargs -n3 -P"${OT_BUILD_JOBS}" script/clang-format-check
+    git ls-files "${OT_CLANG_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
+        xargs -n3 -P"$OT_BUILD_JOBS" script/clang-format-check
 }
 
-do_markdown_format()
-{
+do_markdown_format() {
     echo -e '======================'
     echo -e '     format markdown'
     echo -e '======================'
 
-    git ls-files "${OT_MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
-        | xargs -n10 -P"${OT_BUILD_JOBS}" npx prettier@2.0.4 --write
+    git ls-files "${OT_MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
+        xargs -n10 -P"$OT_BUILD_JOBS" npx prettier@2.0.4 --write
 }
 
-do_markdown_check()
-{
+do_markdown_check() {
     echo -e '======================'
     echo -e '     check markdown'
     echo -e '======================'
 
-    git ls-files "${OT_MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
-        | xargs -n10 -P"${OT_BUILD_JOBS}" npx prettier@2.0.4 --check
+    git ls-files "${OT_MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
+        xargs -n10 -P"$OT_BUILD_JOBS" npx prettier@2.0.4 --check
 }
 
-do_python_format()
-{
+do_python_format() {
     echo -e '======================'
     echo -e '     format python'
     echo -e '======================'
 
-    git ls-files "${OT_PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
-        | xargs -n10 -P"${OT_BUILD_JOBS}" python3 -m yapf --verbose --style google -ipr
+    git ls-files "${OT_PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
+        xargs -n10 -P"$OT_BUILD_JOBS" python3 -m yapf --verbose --style google -ipr
 }
 
-do_python_check()
-{
+do_python_check() {
     echo -e '====================='
     echo -e '     check python'
     echo -e '====================='
 
-    git ls-files "${OT_PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
-        | xargs -n10 -P"${OT_BUILD_JOBS}" python3 -m yapf --verbose --style google -dpr
+    git ls-files "${OT_PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
+        xargs -n10 -P"$OT_BUILD_JOBS" python3 -m yapf --verbose --style google -dpr
 }
 
-do_check()
-{
+do_shell_format() {
+    echo -e '====================='
+    echo -e '     format shell'
+    echo -e '====================='
+
+    shfmt -f . | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
+        xargs -n10 -P"$OT_BUILD_JOBS" shfmt -i 4 -bn -ci -fn -s -w
+}
+
+do_shell_check() {
+    echo -e '====================='
+    echo -e '     check shell'
+    echo -e '====================='
+
+    shfmt -f . | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
+        xargs -n10 -P"$OT_BUILD_JOBS" shfmt -i 4 -bn -ci -fn -s -d
+
+    shfmt -f . | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" |
+        xargs -n10 -P"$OT_BUILD_JOBS" shellcheck
+}
+
+do_check() {
     if [ $# == 0 ]; then
         do_clang_check
         do_markdown_check
         do_python_check
+        do_shell_check
     elif [ "$1" == 'clang' ]; then
         do_clang_check
     elif [ "$1" == 'markdown' ]; then
         do_markdown_check
     elif [ "$1" == 'python' ]; then
         do_python_check
+    elif [ "$1" == 'shell' ]; then
+        do_shell_check
     else
-        >&2 echo "Unsupported check: $1. Supported: clang, markdown, python"
+        echo >&2 "Unsupported check: $1. Supported: clang, markdown, python, shell"
         # 128 for Invalid arguments
         exit 128
     fi
 }
 
-main()
-{
+main() {
     if [ $# == 0 ]; then
         do_clang_format
         do_markdown_format
         do_python_format
+        do_shell_format
     elif [ "$1" == 'clang' ]; then
         do_clang_format
     elif [ "$1" == 'markdown' ]; then
         do_markdown_format
     elif [ "$1" == 'python' ]; then
         do_python_format
+    elif [ "$1" == 'shell' ]; then
+        do_shell_format
     elif [ "$1" == 'check' ]; then
         shift
         do_check "$@"
     else
-        >&2 echo "Unsupported action: $1. Supported: clang, markdown, python"
+        echo >&2 "Unsupported action: $1. Supported: clang, markdown, python, shell"
         # 128 for Invalid arguments
         exit 128
     fi

--- a/script/test
+++ b/script/test
@@ -193,7 +193,7 @@ do_unit()
     local builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}"
     if [[ ! -d ${builddir} ]]; then
         echo "Cannot find build directory!"
-        exit -1
+        exit 1
     fi
 
     cd "${builddir}"
@@ -410,8 +410,8 @@ envsetup()
         export -n VERBOSE
     fi
 
-    read -r -a ot_extra_options <<<"${OT_OPTIONS-}"
-    ot_extra_options=${ot_extra_options:-()}
+    read -r -a ot_extra_options_in <<<"${OT_OPTIONS-}"
+    ot_extra_options=${ot_extra_options_in:-()}
 }
 
 main()

--- a/script/test
+++ b/script/test
@@ -77,22 +77,22 @@ build_simulation()
         "-DOT_THREAD_VERSION=${version}"
     )
 
-    if [[ "${version}" == "1.2" ]]; then
+    if [[ ${version} == "1.2" ]]; then
         options+=(
             "-DOT_DUA=ON"
         )
     fi
 
-    if [[ "${VIRTUAL_TIME}" == 1 ]]; then
+    if [[ ${VIRTUAL_TIME} == 1 ]]; then
         options+=("-DOT_SIMULATION_VIRTUAL_TIME=ON")
 
-        if [[ "${NODE_MODE}" == "rcp" ]]; then
+        if [[ ${NODE_MODE} == "rcp" ]]; then
             options+=("-DOT_SIMULATION_VIRTUAL_TIME_UART=ON")
         fi
 
     fi
 
-    if [[ "${version}" == "1.2" ]]; then
+    if [[ ${version} == "1.2" ]]; then
         options+=(
             "-DOT_CSL_RECEIVER=ON"
         )
@@ -104,12 +104,12 @@ build_simulation()
         && cmake -GNinja "${options[@]}" "${ot_extra_options[@]}" "${OT_SRCDIR}" \
         && ninja)
 
-    if [[ "${version}" == "1.2" ]]; then
+    if [[ ${version} == "1.2" ]]; then
 
         options+=(
-        "-DOT_BACKBONE_ROUTER=ON"
-        "-DOT_BORDER_ROUTER=ON"
-        "-DOT_SERVICE=ON"
+            "-DOT_BACKBONE_ROUTER=ON"
+            "-DOT_BORDER_ROUTER=ON"
+            "-DOT_SERVICE=ON"
         )
 
         local builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${version}-bbr"
@@ -133,13 +133,13 @@ build_posix()
         "-DOT_THREAD_VERSION=${version}"
     )
 
-    if [[ "${version}" == "1.2" ]]; then
+    if [[ ${version} == "1.2" ]]; then
         options+=(
             "-DOT_DUA=ON"
         )
     fi
 
-    if [[ "${VIRTUAL_TIME}" == 1 ]]; then
+    if [[ ${VIRTUAL_TIME} == 1 ]]; then
         options+=("-DOT_POSIX_VIRTUAL_TIME=ON")
     fi
 
@@ -149,12 +149,12 @@ build_posix()
         && cmake -GNinja "${options[@]}" "${ot_extra_options[@]}" "${OT_SRCDIR}" \
         && ninja)
 
-    if [[ "${version}" == "1.2" ]]; then
+    if [[ ${version} == "1.2" ]]; then
 
         options+=(
-        "-DOT_BACKBONE_ROUTER=ON"
-        "-DOT_BORDER_ROUTER=ON"
-        "-DOT_SERVICE=ON"
+            "-DOT_BACKBONE_ROUTER=ON"
+            "-DOT_BORDER_ROUTER=ON"
+            "-DOT_SERVICE=ON"
         )
 
         local builddir="${OT_BUILDDIR}/cmake/openthread-posix-${version}-bbr"
@@ -165,30 +165,33 @@ build_posix()
     fi
 }
 
-do_build() {
+do_build()
+{
     build_simulation "${THREAD_VERSION}"
 
-    if [[ "${NODE_MODE}" == "rcp" ]]; then
+    if [[ ${NODE_MODE} == "rcp" ]]; then
         build_posix "${THREAD_VERSION}"
     fi
 
     # Extra 1.1 build for 1.2 tests
-    if [[ "${THREAD_VERSION}" == "1.2" ]]; then
+    if [[ ${THREAD_VERSION} == "1.2" ]]; then
         build_simulation 1.1
 
-        if [[ "${NODE_MODE}" == "rcp" ]]; then
+        if [[ ${NODE_MODE} == "rcp" ]]; then
             build_posix 1.1
         fi
     fi
 }
 
-do_clean() {
+do_clean()
+{
     rm -rfv "${OT_BUILDDIR}"
 }
 
-do_unit() {
+do_unit()
+{
     local builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}"
-    if [[ ! -d "${builddir}" ]]; then
+    if [[ ! -d ${builddir} ]]; then
         echo "Cannot find build directory!"
         exit -1
     fi
@@ -197,10 +200,11 @@ do_unit() {
     ninja test
 }
 
-do_cert() {
+do_cert()
+{
     export top_builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}"
 
-    if [[ "${THREAD_VERSION}" == "1.2" ]]; then
+    if [[ ${THREAD_VERSION} == "1.2" ]]; then
         export top_builddir_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1"
         export top_builddir_1_2_bbr="${OT_BUILDDIR}/cmake/openthread-simulation-1.2-bbr"
     fi
@@ -209,10 +213,11 @@ do_cert() {
     PYTHONUNBUFFERED=1 "$1"
 }
 
-do_cert_suite() {
+do_cert_suite()
+{
     export top_builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}"
 
-    if [[ "${THREAD_VERSION}" == "1.2" ]]; then
+    if [[ ${THREAD_VERSION} == "1.2" ]]; then
         export top_builddir_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1"
         export top_builddir_1_2_bbr="${OT_BUILDDIR}/cmake/openthread-simulation-1.2-bbr"
     fi
@@ -224,18 +229,18 @@ do_cert_suite() {
 
     for test_case in "$@"; do
         rm -rf tmp
-        if "${test_case}" &> test.log; then
+        if "${test_case}" &>test.log; then
             echo -e "${COLOR_PASS}PASS${COLOR_NONE} ${test_case}"
-            pass_count=$(( pass_count + 1 ))
+            pass_count=$((pass_count + 1))
         else
             echo -e "${COLOR_FAIL}FAIL${COLOR_NONE} ${test_case}"
-            fail_count=$(( fail_count + 1 ))
+            fail_count=$((fail_count + 1))
             {
                 echo "=============================="
                 echo "!!! FAIL:${test_case}"
                 echo "=============================="
                 cat test.log
-            } >> fail.log
+            } >>fail.log
         fi
     done
 
@@ -246,8 +251,8 @@ do_cert_suite() {
     echo "# PASS: ${pass_count}"
     echo "# FAIL: ${fail_count}"
 
-    if [[ "${fail_count}" -gt 0 ]]; then
-        tr -dc '[:print:]\r\n\t' < fail.log
+    if [[ ${fail_count} -gt 0 ]]; then
+        tr -dc '[:print:]\r\n\t' <fail.log
         exit 1
     else
         exit 0
@@ -260,7 +265,7 @@ do_expect()
     local rcp_command=
     local test_pattern
 
-    if [[ "${NODE_MODE}" == rcp ]]; then
+    if [[ ${NODE_MODE} == rcp ]]; then
         ot_command="${OT_CLI_PATH}"
         rcp_command="${RADIO_DEVICE}"
         test_pattern='posix-*.exp'
@@ -288,7 +293,8 @@ do_expect()
     exit 0
 }
 
-print_usage() {
+print_usage()
+{
     echo "USAGE: [ENVIRONMENTS] $0 COMMANDS
 
 ENVIRONMENTS:
@@ -338,7 +344,8 @@ EXAMPLES:
     exit "$1"
 }
 
-do_package() {
+do_package()
+{
     local builddir="${OT_BUILDDIR}/cmake/openthread-sim"
     local options=(
         "-DCMAKE_BUILD_TYPE=Release"
@@ -373,19 +380,19 @@ do_package() {
     (mkdir -p "${builddir}" \
         && cd "${builddir}" \
         && cmake -GNinja -DOT_PLATFORM="posix" \
-        -DOT_DAEMON=1 -DOT_PLATFORM_NETIF=1 -DOT_PLATFORM_UDP=1 "${options[@]}" "${ot_extra_options[@]}" "${OT_SRCDIR}" \
+            -DOT_DAEMON=1 -DOT_PLATFORM_NETIF=1 -DOT_PLATFORM_UDP=1 "${options[@]}" "${ot_extra_options[@]}" "${OT_SRCDIR}" \
         && ninja package \
         && ls "${builddir}"/openthread-daemon-*.deb)
 }
 
 envsetup()
 {
-    if [[ "${NODE_MODE}" == 'rcp' ]] ; then
+    if [[ ${NODE_MODE} == 'rcp' ]]; then
         export RADIO_DEVICE="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}/examples/apps/ncp/ot-rcp"
         export OT_CLI_PATH="${OT_BUILDDIR}/cmake/openthread-posix-${THREAD_VERSION}/src/posix/ot-cli"
         export OT_NCP_PATH="${OT_BUILDDIR}/cmake/openthread-posix-${THREAD_VERSION}/src/posix/ot-ncp"
 
-        if [[ "${THREAD_VERSION}" == "1.2" ]]; then
+        if [[ ${THREAD_VERSION} == "1.2" ]]; then
             export RADIO_DEVICE_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1/examples/apps/ncp/ot-rcp"
             export OT_CLI_PATH_1_1="${OT_BUILDDIR}/cmake/openthread-posix-1.1/src/posix/ot-cli"
             export OT_NCP_PATH_1_1="${OT_BUILDDIR}/cmake/openthread-posix-1.1/src/posix/ot-ncp"
@@ -397,13 +404,13 @@ envsetup()
     export NODE_TYPE VIRTUAL_TIME
 
     # CMake always works in verbose mode if VERBOSE exists in environments.
-    if [[ "${VERBOSE}" == 1 ]]; then
+    if [[ ${VERBOSE} == 1 ]]; then
         export VERBOSE
     else
         export -n VERBOSE
     fi
 
-    read -r -a ot_extra_options <<< "${OT_OPTIONS-}"
+    read -r -a ot_extra_options <<<"${OT_OPTIONS-}"
     ot_extra_options=${ot_extra_options:-()}
 }
 
@@ -411,14 +418,14 @@ main()
 {
     envsetup
 
-    if [[ -z "$1" ]]; then
+    if [[ -z $1 ]]; then
         print_usage 1
     fi
 
-    [[ "${NODE_MODE}" == "rcp" ]] && echo "Using rcp mode" || echo "Using standalone mode"
-    [[ "${NODE_TYPE}" == "ncp-sim" ]] && echo "Using NCP node" || echo "Using CLI node"
-    [[ "${VIRTUAL_TIME}" == 1 ]] && echo "Using virtual time" || echo "Using real time"
-    [[ "${THREAD_VERSION}" == "1.2" ]] && echo "Using Thread 1.2 stack" || echo "Using Thread 1.1 stack"
+    [[ ${NODE_MODE} == "rcp" ]] && echo "Using rcp mode" || echo "Using standalone mode"
+    [[ ${NODE_TYPE} == "ncp-sim" ]] && echo "Using NCP node" || echo "Using CLI node"
+    [[ ${VIRTUAL_TIME} == 1 ]] && echo "Using virtual time" || echo "Using real time"
+    [[ ${THREAD_VERSION} == "1.2" ]] && echo "Using Thread 1.2 stack" || echo "Using Thread 1.1 stack"
 
     while [[ $# != 0 ]]; do
         case "$1" in

--- a/tests/toranj/build.sh
+++ b/tests/toranj/build.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #  Copyright (c) 2018, The OpenThread Authors.
 #  All rights reserved.
@@ -27,15 +27,12 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-cd $(dirname $0)
-cd ../..
-
 display_usage()
 {
     echo ""
     echo "Toranj Build script "
     echo ""
-    echo "Usage: $(basename $0) [options] <config>"
+    echo "Usage: $(basename "$0") [options] <config>"
     echo "    <config> can be:"
     echo "        ncp        : Build OpenThread NCP FTD mode with simulation platform"
     echo "        rcp        : Build OpenThread RCP (NCP in radio mode) with simulation platform"
@@ -51,9 +48,12 @@ display_usage()
 
 die()
 {
-    echo " *** ERROR: " $*
+    echo " *** ERROR: " "$*"
     exit 1
 }
+
+cd "$(dirname "$0")" || die "cd failed"
+cd ../.. || die "cd failed"
 
 coverage=no
 tests=no
@@ -83,13 +83,13 @@ fi
 
 build_config=$1
 
-configure_options="                \
-    --disable-docs                 \
-    --enable-tests=$tests          \
-    --enable-coverage=$coverage    \
-    --enable-ftd                   \
-    --enable-ncp                   \
-    "
+configure_options=(
+    "--disable-docs"
+    "--enable-tests=$tests"
+    "--enable-coverage=$coverage"
+    "--enable-ftd"
+    "--enable-ncp"
+)
 
 if [ -n "${top_builddir}" ]; then
     top_srcdir=$(pwd)
@@ -104,13 +104,13 @@ case ${build_config} in
         echo "==================================================================================================="
         echo "Building OpenThread NCP FTD mode with POSIX platform"
         echo "==================================================================================================="
-        ./bootstrap || die
-        cd "${top_builddir}"
+        ./bootstrap || die "bootstrap failed"
+        cd "${top_builddir}" || die "cd failed"
         cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config-simulation.h\"'
         ${top_srcdir}/configure \
             CPPFLAGS="$cppflags_config" \
             --with-examples=simulation \
-            $configure_options || die
+            "${configure_options[@]}" || die
         make -j 8 || die
         ;;
 
@@ -118,8 +118,8 @@ case ${build_config} in
         echo "===================================================================================================="
         echo "Building OpenThread RCP (NCP in radio mode) with POSIX platform"
         echo "===================================================================================================="
-        ./bootstrap || die
-        cd "${top_builddir}"
+        ./bootstrap || die "bootstrap failed"
+        cd "${top_builddir}" || die "cd failed"
         cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config-simulation.h\"'
         ${top_srcdir}/configure \
             CPPFLAGS="$cppflags_config " \
@@ -136,13 +136,13 @@ case ${build_config} in
         echo "===================================================================================================="
         echo "Building OpenThread POSIX App NCP"
         echo "===================================================================================================="
-        ./bootstrap || die
-        cd "${top_builddir}"
+        ./bootstrap || die "bootstrap failed"
+        cd "${top_builddir}" || die "cd failed"
         cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config-posix.h\"'
         ${top_srcdir}/configure \
             CPPFLAGS="$cppflags_config" \
             --with-platform=posix \
-            $configure_options || die
+            "${configure_options[@]}" || die
         make -j 8 || die
         ;;
 

--- a/tests/toranj/build.sh
+++ b/tests/toranj/build.sh
@@ -30,7 +30,8 @@
 cd $(dirname $0)
 cd ../..
 
-display_usage() {
+display_usage()
+{
     echo ""
     echo "Toranj Build script "
     echo ""
@@ -48,7 +49,8 @@ display_usage() {
     echo ""
 }
 
-die() {
+die()
+{
     echo " *** ERROR: " $*
     exit 1
 }
@@ -56,14 +58,13 @@ die() {
 coverage=no
 tests=no
 
-while [ $# -ge 2 ]
-do
+while [ $# -ge 2 ]; do
     case $1 in
-        -c|--enable-coverage)
+        -c | --enable-coverage)
             coverage=yes
             shift
             ;;
-        -t|--enable-tests)
+        -t | --enable-tests)
             tests=yes
             shift
             ;;
@@ -106,9 +107,9 @@ case ${build_config} in
         ./bootstrap || die
         cd "${top_builddir}"
         cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config-simulation.h\"'
-        ${top_srcdir}/configure                                                         \
-            CPPFLAGS="$cppflags_config"                                                 \
-            --with-examples=simulation                                                  \
+        ${top_srcdir}/configure \
+            CPPFLAGS="$cppflags_config" \
+            --with-examples=simulation \
             $configure_options || die
         make -j 8 || die
         ;;
@@ -120,27 +121,27 @@ case ${build_config} in
         ./bootstrap || die
         cd "${top_builddir}"
         cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config-simulation.h\"'
-        ${top_srcdir}/configure                                                         \
-            CPPFLAGS="$cppflags_config "                                                \
-            --enable-coverage=${coverage}                                               \
-            --enable-ncp                                                                \
-            --enable-radio-only                                                         \
-            --with-examples=simulation                                                  \
-            --disable-docs                                                              \
+        ${top_srcdir}/configure \
+            CPPFLAGS="$cppflags_config " \
+            --enable-coverage=${coverage} \
+            --enable-ncp \
+            --enable-radio-only \
+            --with-examples=simulation \
+            --disable-docs \
             --enable-tests=$tests || die
         make -j 8 || die
         ;;
 
-    posix|posix-app|posixapp)
+    posix | posix-app | posixapp)
         echo "===================================================================================================="
         echo "Building OpenThread POSIX App NCP"
         echo "===================================================================================================="
         ./bootstrap || die
         cd "${top_builddir}"
         cppflags_config='-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\"../tests/toranj/openthread-core-toranj-config-posix.h\"'
-        ${top_srcdir}/configure                 \
-            CPPFLAGS="$cppflags_config"         \
-            --with-platform=posix               \
+        ${top_srcdir}/configure \
+            CPPFLAGS="$cppflags_config" \
+            --with-platform=posix \
             $configure_options || die
         make -j 8 || die
         ;;
@@ -149,25 +150,25 @@ case ${build_config} in
         echo "===================================================================================================="
         echo "Building OpenThread (NCP/CLI for FTD/MTD/RCP mode) with simulation platform using cmake"
         echo "===================================================================================================="
-        cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=on               \
-              -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h . || die
+        cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=on \
+            -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h . || die
         ninja || die
         ;;
 
-    cmake-posix-host|cmake-posix|cmake-p)
+    cmake-posix-host | cmake-posix | cmake-p)
         echo "===================================================================================================="
         echo "Building OpenThread POSIX host platform using cmake"
         echo "===================================================================================================="
-        cmake -GNinja -DOT_PLATFORM=posix -DOT_COMPILE_WARNING_AS_ERROR=on                    \
-              -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-posix.h . || die
+        cmake -GNinja -DOT_PLATFORM=posix -DOT_COMPILE_WARNING_AS_ERROR=on \
+            -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-posix.h . || die
         ninja || die
         ;;
 
     *)
-      echo "Error: Unknown configuration \"$1\""
-      display_usage
-      exit 1
-      ;;
+        echo "Error: Unknown configuration \"$1\""
+        display_usage
+        exit 1
+        ;;
 esac
 
 exit 0

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -27,29 +27,32 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-die() {
+die()
+{
     echo " *** ERROR: " $*
     exit 1
 }
 
-cleanup() {
+cleanup()
+{
     # Clear logs and flash files
-    sudo rm tmp/*.flash tmp/*.data tmp/*.swap > /dev/null 2>&1
-    sudo rm *.log > /dev/null 2>&1
+    sudo rm tmp/*.flash tmp/*.data tmp/*.swap >/dev/null 2>&1
+    sudo rm *.log >/dev/null 2>&1
 
     # Clear any wpantund instances
-    sudo killall wpantund > /dev/null 2>&1
+    sudo killall wpantund >/dev/null 2>&1
 
     wpan_interfaces=$(ifconfig 2>/dev/null | grep -o wpan[0-9]*)
 
     for interface in $wpan_interfaces; do
-        sudo ip link delete $interface > /dev/null 2>&1
+        sudo ip link delete $interface >/dev/null 2>&1
     done
 
     sleep 0.3
 }
 
-run() {
+run()
+{
     counter=0
     while true; do
 
@@ -60,7 +63,7 @@ run() {
 
         # We allow a failed test to be retried up to 3 attempts.
         if [ "$counter" -lt 2 ]; then
-            counter=$((counter+1))
+            counter=$((counter + 1))
             echo Attempt $counter running "$1" failed. Trying again.
             cleanup
             sleep 10
@@ -82,7 +85,7 @@ else
 fi
 
 case $TORANJ_POSIX_RCP_MODEL in
-    1|yes)
+    1 | yes)
         use_posix_with_rcp=yes
         ;;
     *)

--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #  Copyright (c) 2018, The OpenThread Authors.
 #  All rights reserved.
@@ -29,7 +29,7 @@
 
 die()
 {
-    echo " *** ERROR: " $*
+    echo " *** ERROR: " "$*"
     exit 1
 }
 
@@ -37,16 +37,14 @@ cleanup()
 {
     # Clear logs and flash files
     sudo rm tmp/*.flash tmp/*.data tmp/*.swap >/dev/null 2>&1
-    sudo rm *.log >/dev/null 2>&1
+    sudo rm ./*.log >/dev/null 2>&1
 
     # Clear any wpantund instances
     sudo killall wpantund >/dev/null 2>&1
 
-    wpan_interfaces=$(ifconfig 2>/dev/null | grep -o wpan[0-9]*)
-
-    for interface in $wpan_interfaces; do
-        sudo ip link delete $interface >/dev/null 2>&1
-    done
+    while read -r interface; do
+        sudo ip link delete "$interface" >/dev/null 2>&1
+    done < <(ifconfig 2>/dev/null | grep -o "wpan[0-9]*")
 
     sleep 0.3
 }
@@ -56,7 +54,7 @@ run()
     counter=0
     while true; do
 
-        if sudo -E python $1; then
+        if sudo -E python "$1"; then
             cleanup
             return
         fi
@@ -76,7 +74,7 @@ run()
     done
 }
 
-cd $(dirname $0)
+cd "$(dirname "$0")" || die "cd failed"
 
 if [ "$COVERAGE" = 1 ]; then
     coverage_option="--enable-coverage"
@@ -94,11 +92,11 @@ case $TORANJ_POSIX_RCP_MODEL in
 esac
 
 if [ "$use_posix_with_rcp" = "no" ]; then
-    ./build.sh ${coverage_option} ncp || die
+    ./build.sh ${coverage_option} ncp || die "ncp build failed"
 
 else
-    ./build.sh ${coverage_option} rcp || die
-    ./build.sh ${coverage_option} posix || die
+    ./build.sh ${coverage_option} rcp || die "rcp build failed"
+    ./build.sh ${coverage_option} posix || die "posix build failed"
 fi
 
 cleanup

--- a/tools/gerrit/git-squash-merge.sh
+++ b/tools/gerrit/git-squash-merge.sh
@@ -27,12 +27,13 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-die() {
+die()
+{
     echo " *** ERROR: " $*
     exit 1
 }
 
-display_usage ()
+display_usage()
 {
     echo "Squash merge a given branch into the current branch"
     echo ""
@@ -53,42 +54,39 @@ display_usage ()
 SHOULD_ADD_LIST=true
 SHOULD_COMMIT=true
 
-while test $# != 0
-do
+while test $# != 0; do
     case "$1" in
-    --help|-h|-[?])
-        display_usage
-        exit 0
-        ;;
+        --help | -h | -[?])
+            display_usage
+            exit 0
+            ;;
 
-    --no-list)
-        SHOULD_ADD_LIST=false
-        ;;
-    --no-commit)
-        SHOULD_COMMIT=false
-        ;;
-    --debug) set -x ;;
-    --*) die "Unknown argument $1" ;;
-    --)
-        shift
-        break
-        ;;
-    -*) die "Unknown argument $1" ;;
-    *)
-        break
-        ;;
+        --no-list)
+            SHOULD_ADD_LIST=false
+            ;;
+        --no-commit)
+            SHOULD_COMMIT=false
+            ;;
+        --debug) set -x ;;
+        --*) die "Unknown argument $1" ;;
+        --)
+            shift
+            break
+            ;;
+        -*) die "Unknown argument $1" ;;
+        *)
+            break
+            ;;
     esac
     shift
 done
 
-if [ "$#" -eq 0 ]
-then
+if [ "$#" -eq 0 ]; then
     display_usage
     die "No branch name"
 fi
 
-if [ "$#" -gt 2 ]
-then
+if [ "$#" -gt 2 ]; then
     display_usage
     die "Extra argument"
 fi
@@ -101,8 +99,7 @@ cur_branch=$(git rev-parse --abbrev-ref HEAD)
 # Get the list of commits (diff between current and new branch)
 # Note that the list starts with older commits
 
-if ${SHOULD_ADD_LIST}
-then
+if ${SHOULD_ADD_LIST}; then
     commit_list=$(git log HEAD..$branch --oneline --decorate=no --reverse)
 else
     commit_list=""
@@ -116,7 +113,7 @@ else
     commit_msg="${commit_msg_header}${NEWLINE}${NEWLINE}$2${NEWLINE}${NEWLINE}${commit_list}"
 fi
 
-git merge --squash $branch  1> /dev/null 2> /dev/null || die "Failed to perform 'git merge -squash $branch'"
+git merge --squash $branch 1>/dev/null 2>/dev/null || die "Failed to perform 'git merge -squash $branch'"
 
 # Check if there is anything staged
 git diff --cached --quiet
@@ -125,10 +122,9 @@ if [ $? -eq 0 ]; then
     exit 0
 fi
 
-if ${SHOULD_COMMIT}
-then
+if ${SHOULD_COMMIT}; then
     # Commit the staged changes
-    git commit -m "$commit_msg" 1> /dev/null 2> /dev/null || die "git commit failed${NEWLINE}${NEWLINE}$(cat $TMP)"
+    git commit -m "$commit_msg" 1>/dev/null 2>/dev/null || die "git commit failed${NEWLINE}${NEWLINE}$(cat $TMP)"
 
     git log -1
 
@@ -136,4 +132,3 @@ then
 else
     echo "Successfully prepared squash merge of branch '$branch' into '$cur_branch' - ready to commit"
 fi
-

--- a/tools/gerrit/git-squash-merge.sh
+++ b/tools/gerrit/git-squash-merge.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 #  Copyright (c) 2018, The OpenThread Authors.
 #  All rights reserved.
@@ -29,7 +29,7 @@
 
 die()
 {
-    echo " *** ERROR: " $*
+    echo " *** ERROR: " "$*"
     exit 1
 }
 
@@ -41,7 +41,7 @@ display_usage()
     echo "By default, the changes are committed with a commit message which includes the list of all squashed commits"
     echo "(use --no-commit and --no-list options to change default behavior)."
     echo ""
-    echo "Usage: $(basename $0) [--no-list] [--no-commit] <branch> [<commit msg>]"
+    echo "Usage: $(basename "$0") [--no-list] [--no-commit] <branch> [<commit msg>]"
     echo ""
     echo "     <branch>       Specifies the name of branch to merge into current branch"
     echo "     <commit msg>   An optional parameter specifying text to add to the commit message"
@@ -69,10 +69,6 @@ while test $# != 0; do
             ;;
         --debug) set -x ;;
         --*) die "Unknown argument $1" ;;
-        --)
-            shift
-            break
-            ;;
         -*) die "Unknown argument $1" ;;
         *)
             break
@@ -100,7 +96,7 @@ cur_branch=$(git rev-parse --abbrev-ref HEAD)
 # Note that the list starts with older commits
 
 if ${SHOULD_ADD_LIST}; then
-    commit_list=$(git log HEAD..$branch --oneline --decorate=no --reverse)
+    commit_list=$(git log HEAD.."$branch" --oneline --decorate=no --reverse)
 else
     commit_list=""
 fi
@@ -113,18 +109,17 @@ else
     commit_msg="${commit_msg_header}${NEWLINE}${NEWLINE}$2${NEWLINE}${NEWLINE}${commit_list}"
 fi
 
-git merge --squash $branch 1>/dev/null 2>/dev/null || die "Failed to perform 'git merge -squash $branch'"
+git merge --squash "$branch" 1>/dev/null 2>/dev/null || die "Failed to perform 'git merge -squash $branch'"
 
 # Check if there is anything staged
-git diff --cached --quiet
-if [ $? -eq 0 ]; then
+if ! git diff --cached --quiet; then
     echo "No changes to commit when squash merging branch '$branch' into '$cur_branch'"
     exit 0
 fi
 
 if ${SHOULD_COMMIT}; then
     # Commit the staged changes
-    git commit -m "$commit_msg" 1>/dev/null 2>/dev/null || die "git commit failed${NEWLINE}${NEWLINE}$(cat $TMP)"
+    git commit -m "$commit_msg" 1>/dev/null 2>/dev/null || die "git commit failed${NEWLINE}${NEWLINE}$(cat "$TMP")"
 
     git log -1
 

--- a/tools/harness-automation/start.sh
+++ b/tools/harness-automation/start.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
-cd $(dirname $0)
-python -u -m autothreadharness.runner $@
+cd "$(dirname "$0")" || exit 1
+python -u -m autothreadharness.runner "$@"


### PR DESCRIPTION
An alternative to #4886.

This removes `shellharden` and only relies on `shfmt` and `shellcheck` - to address https://github.com/openthread/openthread/pull/4886#discussion_r415219630.

Do we prefer this PR or #4886?