### PR TITLE
[mac] adding otMacKey and Mac::Key

### DIFF
--- a/include/openthread/link_raw.h
+++ b/include/openthread/link_raw.h
@@ -344,12 +344,12 @@ otError otLinkRawSrcMatchClearExtEntries(otInstance *aInstance);
  * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *
  */
-otError otLinkRawSetMacKey(otInstance *   aInstance,
-                           uint8_t        aKeyIdMode,
-                           uint8_t        aKeyId,
-                           const uint8_t *aPrevKey,
-                           const uint8_t *aCurrKey,
-                           const uint8_t *aNextKey);
+otError otLinkRawSetMacKey(otInstance *    aInstance,
+                           uint8_t         aKeyIdMode,
+                           uint8_t         aKeyId,
+                           const otMacKey *aPrevKey,
+                           const otMacKey *aCurrKey,
+                           const otMacKey *aNextKey);
 
 /**
  * @}

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -161,6 +161,26 @@ struct otExtAddress
  */
 typedef struct otExtAddress otExtAddress;
 
+#define OT_MAC_KEY_SIZE 16 ///< Size of the MAC Key in bytes.
+
+/**
+ * @struct otMacKey
+ *
+ * This structure represents a MAC Key.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+struct otMacKey
+{
+    uint8_t m8[OT_MAC_KEY_SIZE]; ///< MAC Key bytes.
+} OT_TOOL_PACKED_END;
+
+/**
+ * This structure represents a MAC Key.
+ *
+ */
+typedef struct otMacKey otMacKey;
+
 /**
  * This structure represents the IEEE 802.15.4 Header IE (Information Element) related information of a radio frame.
  */
@@ -191,13 +211,13 @@ typedef struct otRadioFrame
          */
         struct
         {
-            const uint8_t *mAesKey;            ///< The key used for AES-CCM frame security.
-            otRadioIeInfo *mIeInfo;            ///< The pointer to the Header IE(s) related information.
-            uint8_t        mMaxCsmaBackoffs;   ///< Maximum number of backoffs attempts before declaring CCA failure.
-            uint8_t        mMaxFrameRetries;   ///< Maximum number of retries allowed after a transmission failure.
-            bool           mIsARetx : 1;       ///< True if this frame is a retransmission (ignored by radio driver).
-            bool           mCsmaCaEnabled : 1; ///< Set to true to enable CSMA-CA for this packet, false otherwise.
-            bool           mIsSecurityProcessed : 1; ///< True if SubMac should skip the AES processing of this frame.
+            const otMacKey *mAesKey;            ///< The key used for AES-CCM frame security.
+            otRadioIeInfo * mIeInfo;            ///< The pointer to the Header IE(s) related information.
+            uint8_t         mMaxCsmaBackoffs;   ///< Maximum number of backoffs attempts before declaring CCA failure.
+            uint8_t         mMaxFrameRetries;   ///< Maximum number of retries allowed after a transmission failure.
+            bool            mIsARetx : 1;       ///< True if this frame is a retransmission (ignored by radio driver).
+            bool            mCsmaCaEnabled : 1; ///< Set to true to enable CSMA-CA for this packet, false otherwise.
+            bool            mIsSecurityProcessed : 1; ///< True if SubMac should skip the AES processing of this frame.
         } mTxInfo;
 
         /**
@@ -443,19 +463,17 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable);
  * @param[in]   aInstance    A pointer to an OpenThread instance.
  * @param[in]   aKeyIdMode   The key ID mode.
  * @param[in]   aKeyId       Current MAC key index.
- * @param[in]   aKeySize     The key size.
  * @param[in]   aPrevKey     A pointer to the previous MAC key.
  * @param[in]   aCurrKey     A pointer to the current MAC key.
  * @param[in]   aNextKey     A pointer to the next MAC key.
  *
  */
-void otPlatRadioSetMacKey(otInstance *   aInstance,
-                          uint8_t        aKeyIdMode,
-                          uint8_t        aKeyId,
-                          uint8_t        aKeySize,
-                          const uint8_t *aPrevKey,
-                          const uint8_t *aCurrKey,
-                          const uint8_t *aNextKey);
+void otPlatRadioSetMacKey(otInstance *    aInstance,
+                          uint8_t         aKeyIdMode,
+                          uint8_t         aKeyId,
+                          const otMacKey *aPrevKey,
+                          const otMacKey *aCurrKey,
+                          const otMacKey *aNextKey);
 
 /**
  * @}

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -221,15 +221,16 @@ exit:
     return error;
 }
 
-otError otLinkRawSetMacKey(otInstance *   aInstance,
-                           uint8_t        aKeyIdMode,
-                           uint8_t        aKeyId,
-                           const uint8_t *aPrevKey,
-                           const uint8_t *aCurrKey,
-                           const uint8_t *aNextKey)
+otError otLinkRawSetMacKey(otInstance *    aInstance,
+                           uint8_t         aKeyIdMode,
+                           uint8_t         aKeyId,
+                           const otMacKey *aPrevKey,
+                           const otMacKey *aCurrKey,
+                           const otMacKey *aNextKey)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().SetMacKey(aKeyIdMode, aKeyId, aPrevKey, aCurrKey,
-                                                                             aNextKey);
+    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().SetMacKey(
+        aKeyIdMode, aKeyId, *static_cast<const Mac::Key *>(aPrevKey), *static_cast<const Mac::Key *>(aCurrKey),
+        *static_cast<const Mac::Key *>(aNextKey));
 }
 
 #if OPENTHREAD_RADIO

--- a/src/core/crypto/aes_ccm.cpp
+++ b/src/core/crypto/aes_ccm.cpp
@@ -45,6 +45,11 @@ void AesCcm::SetKey(const uint8_t *aKey, uint16_t aKeyLength)
     mEcb.SetKey(aKey, 8 * aKeyLength);
 }
 
+void AesCcm::SetKey(const Mac::Key &aMacKey)
+{
+    SetKey(aMacKey.GetKey(), Mac::Key::kSize);
+}
+
 otError AesCcm::Init(uint32_t    aHeaderLength,
                      uint32_t    aPlainTextLength,
                      uint8_t     aTagLength,

--- a/src/core/crypto/aes_ccm.hpp
+++ b/src/core/crypto/aes_ccm.hpp
@@ -75,6 +75,14 @@ public:
     void SetKey(const uint8_t *aKey, uint16_t aKeyLength);
 
     /**
+     * This method sets the key.
+     *
+     * @param[in]  aMacKey        A MAC key.
+     *
+     */
+    void SetKey(const Mac::Key &aMacKey);
+
+    /**
      * This method initializes the AES CCM computation.
      *
      * @param[in]  aHeaderLength     Length of header in bytes.

--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -205,11 +205,11 @@ void LinkRaw::InvokeEnergyScanDone(int8_t aEnergyScanMaxRssi)
     }
 }
 
-otError LinkRaw::SetMacKey(uint8_t        aKeyIdMode,
-                           uint8_t        aKeyId,
-                           const uint8_t *aPrevKey,
-                           const uint8_t *aCurrKey,
-                           const uint8_t *aNextKey)
+otError LinkRaw::SetMacKey(uint8_t    aKeyIdMode,
+                           uint8_t    aKeyId,
+                           const Key &aPrevKey,
+                           const Key &aCurrKey,
+                           const Key &aNextKey)
 {
     otError error = OT_ERROR_NONE;
 

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -256,11 +256,11 @@ public:
      * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
      *
      */
-    otError SetMacKey(uint8_t        aKeyIdMode,
-                      uint8_t        aKeyId,
-                      const uint8_t *aPrevKey,
-                      const uint8_t *aCurrKey,
-                      const uint8_t *aNextKey);
+    otError SetMacKey(uint8_t    aKeyIdMode,
+                      uint8_t    aKeyId,
+                      const Key &aPrevKey,
+                      const Key &aCurrKey,
+                      const Key &aNextKey);
 
     /**
      * This method records the status of a frame transmission attempt and is mainly used for logging failures.

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -54,8 +54,8 @@
 namespace ot {
 namespace Mac {
 
-const uint8_t Mac::sMode2Key[] = {0x78, 0x58, 0x16, 0x86, 0xfd, 0xb4, 0x58, 0x0f,
-                                  0xb0, 0x92, 0x54, 0x6a, 0xec, 0xbd, 0x15, 0x66};
+const otMacKey Mac::sMode2Key = {
+    {0x78, 0x58, 0x16, 0x86, 0xfd, 0xb4, 0x58, 0x0f, 0xb0, 0x92, 0x54, 0x6a, 0xec, 0xbd, 0x15, 0x66}};
 
 const otExtAddress Mac::sMode2ExtAddress = {
     {0x35, 0x06, 0xfe, 0xb8, 0x23, 0xd4, 0x87, 0x12},
@@ -958,7 +958,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
     switch (keyIdMode)
     {
     case Frame::kKeyIdMode0:
-        aFrame.SetAesKey(keyManager.GetKek().GetKey());
+        aFrame.SetAesKey(keyManager.GetKek());
         extAddress = &GetExtAddress();
 
         if (!aFrame.IsARetransmission())
@@ -989,7 +989,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
     case Frame::kKeyIdMode2:
     {
         const uint8_t keySource[] = {0xff, 0xff, 0xff, 0xff};
-        aFrame.SetAesKey(sMode2Key);
+        aFrame.SetAesKey(static_cast<const Key &>(sMode2Key));
         mKeyIdMode2FrameCounter++;
         aFrame.SetFrameCounter(mKeyIdMode2FrameCounter);
         aFrame.SetKeySource(keySource);
@@ -1432,7 +1432,7 @@ otError Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Ne
     uint8_t           tagLength;
     uint8_t           keyid;
     uint32_t          keySequence = 0;
-    const uint8_t *   macKey;
+    const Key *       macKey;
     const ExtAddress *extAddress;
     Crypto::AesCcm    aesCcm;
 
@@ -1449,8 +1449,7 @@ otError Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Ne
     switch (keyIdMode)
     {
     case Frame::kKeyIdMode0:
-        macKey = keyManager.GetKek().GetKey();
-        VerifyOrExit(macKey != NULL, OT_NOOP);
+        macKey     = &keyManager.GetKek();
         extAddress = &aSrcAddr.GetExtended();
         break;
 
@@ -1463,17 +1462,17 @@ otError Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Ne
         if (keyid == (keyManager.GetCurrentKeySequence() & 0x7f))
         {
             keySequence = keyManager.GetCurrentKeySequence();
-            macKey      = mSubMac.GetCurrentMacKey();
+            macKey      = &mSubMac.GetCurrentMacKey();
         }
         else if (keyid == ((keyManager.GetCurrentKeySequence() - 1) & 0x7f))
         {
             keySequence = keyManager.GetCurrentKeySequence() - 1;
-            macKey      = mSubMac.GetPreviousMacKey();
+            macKey      = &mSubMac.GetPreviousMacKey();
         }
         else if (keyid == ((keyManager.GetCurrentKeySequence() + 1) & 0x7f))
         {
             keySequence = keyManager.GetCurrentKeySequence() + 1;
-            macKey      = mSubMac.GetNextMacKey();
+            macKey      = &mSubMac.GetNextMacKey();
         }
         else
         {
@@ -1503,7 +1502,7 @@ otError Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Ne
         break;
 
     case Frame::kKeyIdMode2:
-        macKey     = sMode2Key;
+        macKey     = static_cast<const Key *>(&sMode2Key);
         extAddress = static_cast<const ExtAddress *>(&sMode2ExtAddress);
         break;
 
@@ -1515,7 +1514,7 @@ otError Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Ne
     Crypto::AesCcm::GenerateNonce(*extAddress, frameCounter, securityLevel, nonce);
     tagLength = aFrame.GetFooterLength() - Frame::kFcsSize;
 
-    aesCcm.SetKey(macKey, 16);
+    aesCcm.SetKey(*macKey);
 
     SuccessOrExit(aesCcm.Init(aFrame.GetHeaderLength(), aFrame.GetPayloadLength(), tagLength, nonce, sizeof(nonce)));
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -745,7 +745,7 @@ private:
 
     static const char *OperationToString(Operation aOperation);
 
-    static const uint8_t         sMode2Key[];
+    static const otMacKey        sMode2Key;
     static const otExtAddress    sMode2ExtAddress;
     static const otExtendedPanId sExtendedPanidInit;
     static const char            sNetworkNameInit[];

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1049,7 +1049,7 @@ void TxFrame::ProcessTransmitAesCcm(const ExtAddress &aExtAddress)
 
     Crypto::AesCcm::GenerateNonce(aExtAddress, frameCounter, securityLevel, nonce);
 
-    aesCcm.SetKey(GetAesKey(), 16);
+    aesCcm.SetKey(GetAesKey());
     tagLength = GetFooterLength() - Frame::kFcsSize;
 
     error = aesCcm.Init(GetHeaderLength(), GetPayloadLength(), tagLength, nonce, sizeof(nonce));

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -1171,7 +1171,7 @@ public:
      * @returns The pointer to the key.
      *
      */
-    const uint8_t *GetAesKey(void) const { return mInfo.mTxInfo.mAesKey; }
+    const Mac::Key &GetAesKey(void) const { return *static_cast<const Mac::Key *>(mInfo.mTxInfo.mAesKey); }
 
     /**
      * This method sets the key used for frame encryption and authentication (AES CCM).
@@ -1179,7 +1179,7 @@ public:
      * @param[in]  aAesKey  The pointer to the key.
      *
      */
-    void SetAesKey(const uint8_t *aAesKey) { mInfo.mTxInfo.mAesKey = aAesKey; }
+    void SetAesKey(const Mac::Key &aAesKey) { mInfo.mTxInfo.mAesKey = &aAesKey; }
 
     /**
      * This method copies the PSDU and all attributes from another frame.

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -443,6 +443,56 @@ private:
 };
 
 /**
+ * This class represents a MAC key.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class Key : public otMacKey
+{
+public:
+    enum
+    {
+        kSize = OT_MAC_KEY_SIZE, // Key size in bytes.
+    };
+
+    /**
+     * This method clears the key (set all bytes to zero).
+     *
+     */
+    void Clear(void) { memset(m8, 0, kSize); }
+
+    /**
+     * This method gets a pointer to the buffer containing the key.
+     *
+     * @returns A pointer to the buffer containing the key.
+     *
+     */
+    const uint8_t *GetKey(void) const { return m8; }
+
+    /**
+     * This method evaluates whether or not two keys match.
+     *
+     * @param[in]  aOtherKey  The key to compare with.
+     *
+     * @retval TRUE   If the key matches the @p aOtherKey.
+     * @retval FALSE  If the key does not match the @p aOtherKey.
+     *
+     */
+    bool operator==(const Key &aOtherKey) const { return memcmp(m8, aOtherKey.m8, kSize) == 0; }
+
+    /**
+     * This method evaluates whether or not two keys match.
+     *
+     * @param[in]  aOtherKey  The key to compare with.
+     *
+     * @retval TRUE   If the key does not match @p aOtherKey.
+     * @retval FALSE  If the key does match @p aOtherKey.
+     *
+     */
+    bool operator!=(const Key &aOtherKey) const { return !(*this == aOtherKey); }
+} OT_TOOL_PACKED_END;
+
+/**
  * This structure represents an IEEE 802.15.4 Extended PAN Identifier.
  *
  */

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -63,9 +63,9 @@ SubMac::SubMac(Instance &aInstance)
     , mTimer(aInstance, &SubMac::HandleTimer, this)
 {
     mExtAddress.Clear();
-    memset(mPrevKey, 0, sizeof(mPrevKey));
-    memset(mCurrKey, 0, sizeof(mCurrKey));
-    memset(mNextKey, 0, sizeof(mNextKey));
+    mPrevKey.Clear();
+    mCurrKey.Clear();
+    mNextKey.Clear();
 }
 
 otRadioCaps SubMac::GetCaps(void) const
@@ -244,6 +244,7 @@ void SubMac::ProcessTransmitSecurity(void)
     VerifyOrExit(keyIdMode == Frame::kKeyIdMode1, OT_NOOP);
 
     mTransmitFrame.SetAesKey(GetCurrentMacKey());
+
     if (!mTransmitFrame.IsARetransmission())
     {
         mTransmitFrame.SetKeyId(mKeyId);
@@ -623,11 +624,11 @@ void SubMac::SetState(State aState)
     }
 }
 
-void SubMac::SetMacKey(uint8_t        aKeyIdMode,
-                       uint8_t        aKeyId,
-                       const uint8_t *aPrevKey,
-                       const uint8_t *aCurrKey,
-                       const uint8_t *aNextKey)
+void SubMac::SetMacKey(uint8_t    aKeyIdMode,
+                       uint8_t    aKeyId,
+                       const Key &aPrevKey,
+                       const Key &aCurrKey,
+                       const Key &aNextKey)
 {
     switch (aKeyIdMode)
     {
@@ -635,13 +636,10 @@ void SubMac::SetMacKey(uint8_t        aKeyIdMode,
     case Frame::kKeyIdMode2:
         break;
     case Frame::kKeyIdMode1:
-        OT_ASSERT(aPrevKey != NULL && aCurrKey != NULL && aNextKey != NULL);
-
-        mKeyId = aKeyId;
-        memcpy(mPrevKey, aPrevKey, sizeof(mPrevKey));
-        memcpy(mCurrKey, aCurrKey, sizeof(mCurrKey));
-        memcpy(mNextKey, aNextKey, sizeof(mNextKey));
-
+        mKeyId   = aKeyId;
+        mPrevKey = aPrevKey;
+        mCurrKey = aCurrKey;
+        mNextKey = aNextKey;
         break;
 
     default:
@@ -651,7 +649,7 @@ void SubMac::SetMacKey(uint8_t        aKeyIdMode,
 
     VerifyOrExit(!ShouldHandleTransmitSecurity(), OT_NOOP);
 
-    Get<Radio>().SetMacKey(aKeyIdMode, aKeyId, kMacKeySize, aPrevKey, aCurrKey, aNextKey);
+    Get<Radio>().SetMacKey(aKeyIdMode, aKeyId, aPrevKey, aCurrKey, aNextKey);
 
 exit:
     return;

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -82,7 +82,6 @@ public:
     enum
     {
         kInvalidRssiValue = 127, ///< Invalid Received Signal Strength Indicator (RSSI) value.
-        kMacKeySize       = 16,  ///< MAC Key size (bytes)
     };
 
     /**
@@ -353,40 +352,36 @@ public:
      *
      * @param[in] aKeyIdMode  MAC key ID mode.
      * @param[in] aKeyId      The key ID.
-     * @param[in] aPrevKey    A pointer to the previous MAC key.
-     * @param[in] aCurrKey    A pointer to the current MAC key.
-     * @param[in] aNextKey    A pointer to the next MAC key.
+     * @param[in] aPrevKey    The previous MAC key.
+     * @param[in] aCurrKey    The current MAC key.
+     * @param[in] aNextKey    The next MAC key.
      *
      */
-    void SetMacKey(uint8_t        aKeyIdMode,
-                   uint8_t        aKeyId,
-                   const uint8_t *aPrevKey,
-                   const uint8_t *aCurrKey,
-                   const uint8_t *aNextKey);
+    void SetMacKey(uint8_t aKeyIdMode, uint8_t aKeyId, const Key &aPrevKey, const Key &aCurrKey, const Key &aNextKey);
 
     /**
-     * This method returns a pointer to the current MAC key.
+     * This method returns a reference to the current MAC key.
      *
-     * @returns A pointer to the current MAC key.
+     * @returns A reference to the current MAC key.
      *
      */
-    const uint8_t *GetCurrentMacKey(void) const { return mCurrKey; }
+    const Key &GetCurrentMacKey(void) const { return mCurrKey; }
 
     /**
-     * This method returns a pointer to the previous MAC key.
+     * This method returns a reference to the previous MAC key.
      *
-     * @returns A pointer to the previous MAC key.
+     * @returns A reference to the previous MAC key.
      *
      */
-    const uint8_t *GetPreviousMacKey(void) const { return mPrevKey; }
+    const Key &GetPreviousMacKey(void) const { return mPrevKey; }
 
     /**
-     * This method returns a pointer to the next MAC key.
+     * This method returns a reference to the next MAC key.
      *
-     * @returns A pointer to the next MAC key.
+     * @returns A reference to the next MAC key.
      *
      */
-    const uint8_t *GetNextMacKey(void) const { return mNextKey; }
+    const Key &GetNextMacKey(void) const { return mNextKey; }
 
 private:
     enum
@@ -459,9 +454,9 @@ private:
     Callbacks          mCallbacks;
     otLinkPcapCallback mPcapCallback;
     void *             mPcapCallbackContext;
-    uint8_t            mPrevKey[kMacKeySize];
-    uint8_t            mCurrKey[kMacKeySize];
-    uint8_t            mNextKey[kMacKeySize];
+    Key                mPrevKey;
+    Key                mCurrKey;
+    Key                mNextKey;
     uint8_t            mKeyId;
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
     TimerMicro mTimer;

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -252,20 +252,18 @@ public:
      *
      * @param[in] aKeyIdMode  MAC key ID mode.
      * @param[in] aKeyId      Current MAC key index.
-     * @param[in] aKeySize    MAC key size in bytes.
-     * @param[in] aPrevKey    A pointer to the previous MAC key.
-     * @param[in] aCurrKey    A pointer to the current MAC key.
-     * @param[in] aNextKey    A pointer to the next MAC key.
+     * @param[in] aPrevKey    The previous MAC key.
+     * @param[in] aCurrKey    The current MAC key.
+     * @param[in] aNextKey    The next MAC key.
      *
      */
-    void SetMacKey(uint8_t        aKeyIdMode,
-                   uint8_t        aKeyId,
-                   uint8_t        aKeySize,
-                   const uint8_t *aPrevKey,
-                   const uint8_t *aCurrKey,
-                   const uint8_t *aNextKey)
+    void SetMacKey(uint8_t         aKeyIdMode,
+                   uint8_t         aKeyId,
+                   const Mac::Key &aPrevKey,
+                   const Mac::Key &aCurrKey,
+                   const Mac::Key &aNextKey)
     {
-        otPlatRadioSetMacKey(GetInstance(), aKeyIdMode, aKeyId, aKeySize, aPrevKey, aCurrKey, aNextKey);
+        otPlatRadioSetMacKey(GetInstance(), aKeyIdMode, aKeyId, &aPrevKey, &aCurrKey, &aNextKey);
     }
 
     /**

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -125,18 +125,16 @@ OT_TOOL_WEAK otRadioState otPlatRadioGetState(otInstance *aInstance)
     return OT_RADIO_STATE_INVALID;
 }
 
-OT_TOOL_WEAK void otPlatRadioSetMacKey(otInstance *   aInstance,
-                                       uint8_t        aKeyIdMode,
-                                       uint8_t        aKeyId,
-                                       uint8_t        aKeySize,
-                                       const uint8_t *aPrevKey,
-                                       const uint8_t *aCurrKey,
-                                       const uint8_t *aNextKey)
+OT_TOOL_WEAK void otPlatRadioSetMacKey(otInstance *    aInstance,
+                                       uint8_t         aKeyIdMode,
+                                       uint8_t         aKeyId,
+                                       const otMacKey *aPrevKey,
+                                       const otMacKey *aCurrKey,
+                                       const otMacKey *aNextKey)
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aKeyIdMode);
     OT_UNUSED_VARIABLE(aKeyId);
-    OT_UNUSED_VARIABLE(aKeySize);
     OT_UNUSED_VARIABLE(aPrevKey);
     OT_UNUSED_VARIABLE(aCurrKey);
     OT_UNUSED_VARIABLE(aNextKey);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2541,7 +2541,7 @@ otError Mle::SendMessage(Message &aMessage, const Ip6::Address &aDestination)
         Crypto::AesCcm::GenerateNonce(Get<Mac::Mac>().GetExtAddress(), Get<KeyManager>().GetMleFrameCounter(),
                                       Mac::Frame::kSecEncMic32, nonce);
 
-        aesCcm.SetKey(Get<KeyManager>().GetCurrentMleKey(), 16);
+        aesCcm.SetKey(Get<KeyManager>().GetCurrentMleKey());
         error = aesCcm.Init(16 + 16 + header.GetHeaderLength(), aMessage.GetLength() - (header.GetLength() - 1),
                             sizeof(tag), nonce, sizeof(nonce));
         OT_ASSERT(error == OT_ERROR_NONE);
@@ -2606,7 +2606,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     otError         error = OT_ERROR_NONE;
     Header          header;
     uint32_t        keySequence;
-    const uint8_t * mleKey;
+    const Key *     mleKey;
     uint32_t        frameCounter;
     uint8_t         messageTag[4];
     uint8_t         nonce[Crypto::AesCcm::kNonceSize];
@@ -2658,11 +2658,11 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 
     if (keySequence == Get<KeyManager>().GetCurrentKeySequence())
     {
-        mleKey = Get<KeyManager>().GetCurrentMleKey();
+        mleKey = &Get<KeyManager>().GetCurrentMleKey();
     }
     else
     {
-        mleKey = Get<KeyManager>().GetTemporaryMleKey(keySequence);
+        mleKey = &Get<KeyManager>().GetTemporaryMleKey(keySequence);
     }
 
     VerifyOrExit(aMessage.GetOffset() + header.GetLength() + sizeof(messageTag) <= aMessage.GetLength(),
@@ -2676,7 +2676,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     frameCounter = header.GetFrameCounter();
     Crypto::AesCcm::GenerateNonce(macAddr, frameCounter, Mac::Frame::kSecEncMic32, nonce);
 
-    aesCcm.SetKey(mleKey, 16);
+    aesCcm.SetKey(*mleKey);
     SuccessOrExit(error = aesCcm.Init(sizeof(aMessageInfo.GetPeerAddr()) + sizeof(aMessageInfo.GetSockAddr()) +
                                           header.GetHeaderLength(),
                                       aMessage.GetLength() - aMessage.GetOffset(), sizeof(messageTag), nonce,

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -648,6 +648,12 @@ private:
 } OT_TOOL_PACKED_END;
 
 /**
+ * This class represents a MLE key.
+ *
+ */
+typedef Mac::Key Key;
+
+/**
  * @}
  *
  */

--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -602,22 +602,20 @@ public:
      *
      * @param[in] aKeyIdMode  The key ID mode.
      * @param[in] aKeyId      The key index.
-     * @param[in] aKeySize    The key length.
-     * @param[in] aPrevKey    The pointer to the previous MAC key.
-     * @param[in] aCurrKey    The pointer to the current MAC key.
-     * @param[in] aNextKey    The pointer to the next MAC key.
+     * @param[in] aPrevKey    The previous MAC key.
+     * @param[in] aCurrKey    The current MAC key.
+     * @param[in] aNextKey    The next MAC key.
      *
      * @retval  OT_ERROR_NONE               Succeeded.
      * @retval  OT_ERROR_BUSY               Failed due to another operation is on going.
      * @retval  OT_ERROR_RESPONSE_TIMEOUT   Failed due to no response received from the transceiver.
      *
      */
-    otError SetMacKey(uint8_t        aKeyIdMode,
-                      uint8_t        aKeyId,
-                      uint8_t        aKeySize,
-                      const uint8_t *aPrevKey,
-                      const uint8_t *aCurrKey,
-                      const uint8_t *aNextKey);
+    otError SetMacKey(uint8_t         aKeyIdMode,
+                      uint8_t         aKeyId,
+                      const otMacKey &aPrevKey,
+                      const otMacKey &aCurrKey,
+                      const otMacKey &aNextKey);
 
     /**
      * This method checks whether the spinel interface is radio-only

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -1012,19 +1012,19 @@ exit:
 }
 
 template <typename InterfaceType, typename ProcessContextType>
-otError RadioSpinel<InterfaceType, ProcessContextType>::SetMacKey(uint8_t        aKeyIdMode,
-                                                                  uint8_t        aKeyId,
-                                                                  uint8_t        aKeySize,
-                                                                  const uint8_t *aPrevKey,
-                                                                  const uint8_t *aCurrKey,
-                                                                  const uint8_t *aNextKey)
+otError RadioSpinel<InterfaceType, ProcessContextType>::SetMacKey(uint8_t         aKeyIdMode,
+                                                                  uint8_t         aKeyId,
+                                                                  const otMacKey &aPrevKey,
+                                                                  const otMacKey &aCurrKey,
+                                                                  const otMacKey &aNextKey)
 {
     otError error;
 
     SuccessOrExit(error = Set(SPINEL_PROP_RCP_MAC_KEY,
                               SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_UINT8_S SPINEL_DATATYPE_DATA_WLEN_S
                                   SPINEL_DATATYPE_DATA_WLEN_S SPINEL_DATATYPE_DATA_WLEN_S,
-                              aKeyIdMode, aKeyId, aPrevKey, aKeySize, aCurrKey, aKeySize, aNextKey, aKeySize));
+                              aKeyIdMode, aKeyId, aPrevKey.m8, sizeof(otMacKey), aCurrKey.m8, sizeof(otMacKey),
+                              aNextKey.m8, sizeof(otMacKey)));
 
 exit:
     return error;

--- a/src/ncp/ncp_base_radio.cpp
+++ b/src/ncp/ncp_base_radio.cpp
@@ -445,15 +445,17 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_RCP_MAC_KEY>(void)
     SuccessOrExit(error = mDecoder.ReadUint8(keyId));
 
     SuccessOrExit(error = mDecoder.ReadDataWithLen(prevKey, keySize));
-    VerifyOrExit(keySize == Mac::SubMac::kMacKeySize, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(keySize == sizeof(otMacKey), error = OT_ERROR_INVALID_ARGS);
 
     SuccessOrExit(error = mDecoder.ReadDataWithLen(currKey, keySize));
-    VerifyOrExit(keySize == Mac::SubMac::kMacKeySize, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(keySize == sizeof(otMacKey), error = OT_ERROR_INVALID_ARGS);
 
     SuccessOrExit(error = mDecoder.ReadDataWithLen(nextKey, keySize));
-    VerifyOrExit(keySize == Mac::SubMac::kMacKeySize, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(keySize == sizeof(otMacKey), error = OT_ERROR_INVALID_ARGS);
 
-    error = otLinkRawSetMacKey(mInstance, keyIdMode, keyId, prevKey, currKey, nextKey);
+    error =
+        otLinkRawSetMacKey(mInstance, keyIdMode, keyId, reinterpret_cast<const otMacKey *>(prevKey),
+                           reinterpret_cast<const otMacKey *>(currKey), reinterpret_cast<const otMacKey *>(nextKey));
 
 exit:
     return error;

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -475,14 +475,13 @@ otRadioState otPlatRadioGetState(otInstance *aInstance)
     return sRadioSpinel.GetState();
 }
 
-void otPlatRadioSetMacKey(otInstance *   aInstance,
-                          uint8_t        aKeyIdMode,
-                          uint8_t        aKeyId,
-                          uint8_t        aKeySize,
-                          const uint8_t *aPrevKey,
-                          const uint8_t *aCurrKey,
-                          const uint8_t *aNextKey)
+void otPlatRadioSetMacKey(otInstance *    aInstance,
+                          uint8_t         aKeyIdMode,
+                          uint8_t         aKeyId,
+                          const otMacKey *aPrevKey,
+                          const otMacKey *aCurrKey,
+                          const otMacKey *aNextKey)
 {
-    SuccessOrDie(sRadioSpinel.SetMacKey(aKeyIdMode, aKeyId, aKeySize, aPrevKey, aCurrKey, aNextKey));
+    SuccessOrDie(sRadioSpinel.SetMacKey(aKeyIdMode, aKeyId, *aPrevKey, *aCurrKey, *aNextKey));
     OT_UNUSED_VARIABLE(aInstance);
 }


### PR DESCRIPTION
This commit adds a new type `otMacKey` which represents a MAC security
key (used by AES-CCM to perform frame security) and core subclass of
this as `Mac::Key`. The same type is used as `Mle::Key`. The
`KeyManager`, `Mac`, `Mle`, and other modules are updated to use the
new `Key` types. The public OT API `otLinkRawSetMacKey` and radio
platform `otPlatRadioSetMacKey()` are also updated to use `otMacKey`.