### PR TITLE
[channel-monitor] remove channel monitor copying

### DIFF
--- a/src/core/api/channel_monitor_api.cpp
+++ b/src/core/api/channel_monitor_api.cpp
@@ -43,7 +43,7 @@ using namespace ot;
 
 otError otChannelMonitorSetEnabled(otInstance *aInstance, bool aEnabled)
 {
-    Utils::ChannelMonitor monitor = static_cast<Instance *>(aInstance)->Get<Utils::ChannelMonitor>();
+    Utils::ChannelMonitor &monitor = static_cast<Instance *>(aInstance)->Get<Utils::ChannelMonitor>();
 
     return aEnabled ? monitor.Start() : monitor.Stop();
 }


### PR DESCRIPTION
This removes the copying of `ChannelMonitor` in
`otChannelMonitorSetEnabled`, so channel monitor enable/disable can work.