### PR TITLE
[instance] disable instance member copying

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -331,6 +331,7 @@ HEADERS_COMMON                             = \
     common/logging.hpp                       \
     common/message.hpp                       \
     common/new.hpp                           \
+    common/non_copyable.hpp                  \
     common/notifier.hpp                      \
     common/random.hpp                        \
     common/random_manager.hpp                \

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -38,6 +38,7 @@
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "net/ip6.hpp"
 #include "net/netif.hpp"
@@ -268,7 +269,7 @@ private:
  * This class implements the CoAP client and server.
  *
  */
-class CoapBase : public InstanceLocator
+class CoapBase : public InstanceLocator, private NonCopyable
 {
     friend class ResponsesQueue;
 

--- a/src/core/common/extension.hpp
+++ b/src/core/common/extension.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 
 #if OPENTHREAD_ENABLE_VENDOR_EXTENSION
 
@@ -65,7 +66,7 @@ namespace Extension {
  * Support for vendor extension can be enabled using `OPENTHREAD_ENABLE_VENDOR_EXTENSION` configuration option.
  *
  */
-class ExtensionBase : public InstanceLocator
+class ExtensionBase : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -46,6 +46,7 @@
 #include <openthread/platform/memory.h>
 #endif
 
+#include "common/non_copyable.hpp"
 #include "common/random_manager.hpp"
 #include "common/tasklet.hpp"
 #include "common/timer.hpp"
@@ -119,7 +120,7 @@ namespace ot {
  * This class contains all the components used by OpenThread.
  *
  */
-class Instance : public otInstance
+class Instance : public otInstance, private NonCopyable
 {
 public:
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -44,6 +44,7 @@
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "mac/mac_types.hpp"
 #include "thread/link_quality.hpp"
 
@@ -1086,7 +1087,7 @@ private:
  * This class represents a message pool
  *
  */
-class MessagePool : public InstanceLocator
+class MessagePool : public InstanceLocator, private NonCopyable
 {
     friend class Message;
     friend class MessageQueue;

--- a/src/core/common/non_copyable.hpp
+++ b/src/core/common/non_copyable.hpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016, The OpenThread Authors.
+ *  Copyright (c) 2020, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,53 +28,29 @@
 
 /**
  * @file
- *   This file includes definitions for using mbedTLS.
+ *   This file includes a common base class for disabling copying.
  */
 
-#ifndef OT_MBEDTLS_HPP_
-#define OT_MBEDTLS_HPP_
-
-#include "openthread-core-config.h"
-
-#include <openthread/instance.h>
-
-#include "common/non_copyable.hpp"
+#ifndef NON_COPYABLE_HPP_
+#define NON_COPYABLE_HPP_
 
 namespace ot {
-namespace Crypto {
 
 /**
- * @addtogroup core-security
- *
- * @{
- *
+ * This class makes any class that derives from it non-copyable. It is
+ * intended to be used as a private base class.
  */
-
-/**
- * This class implements mbedTLS memory.
- *
- */
-class MbedTls : private NonCopyable
+class NonCopyable
 {
-public:
-    /**
-     * This constructor initializes the object.
-     *
-     */
-    MbedTls(void);
+protected:
+    NonCopyable(void) {}
+    ~NonCopyable(void) {}
 
-    /**
-     * This method converts from MbedTls error to OpenThread error.
-     */
-    static otError MapError(int rval);
+private:
+    NonCopyable(const NonCopyable &);
+    NonCopyable &operator=(const NonCopyable &);
 };
 
-/**
- * @}
- *
- */
-
-} // namespace Crypto
 } // namespace ot
 
-#endif // OT_MBEDTLS_HPP_
+#endif // NON_COPYABLE_HPP_

--- a/src/core/common/notifier.hpp
+++ b/src/core/common/notifier.hpp
@@ -44,6 +44,7 @@
 
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/tasklet.hpp"
 
 namespace ot {
@@ -73,7 +74,7 @@ namespace ot {
  *   registered at the same time is specified by `OPENTHREAD_CONFIG_MAX_STATECHANGE_HANDLERS` configuration parameter.
  *
  */
-class Notifier : public InstanceLocator
+class Notifier : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/common/random_manager.hpp
+++ b/src/core/common/random_manager.hpp
@@ -44,6 +44,8 @@
 #include <mbedtls/entropy.h>
 #endif
 
+#include "common/non_copyable.hpp"
+
 #if (!defined(MBEDTLS_NO_DEFAULT_ENTROPY_SOURCES) && \
      (!defined(MBEDTLS_NO_PLATFORM_ENTROPY) || defined(MBEDTLS_HAVEGE_C) || defined(MBEDTLS_ENTROPY_HARDWARE_ALT)))
 #define OT_MBEDTLS_STRONG_DEFAULT_ENTROPY_PRESENT
@@ -55,7 +57,7 @@ namespace ot {
  * This class manages random number generator initialization/deinitialization.
  *
  */
-class RandomManager
+class RandomManager : private NonCopyable
 {
 public:
     /**

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -38,6 +38,7 @@
 
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "mac/mac_types.hpp"
 #include "utils/flash.hpp"
 #if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
@@ -50,7 +51,7 @@ namespace MeshCoP {
 class Dataset;
 }
 
-class SettingsDriver : public InstanceLocator
+class SettingsDriver : public InstanceLocator, private NonCopyable
 {
 public:
     /**
@@ -151,7 +152,7 @@ private:
  * This class provides structure definitions for different settings keys.
  *
  */
-class SettingsBase : public InstanceLocator
+class SettingsBase : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -41,6 +41,7 @@
 #include <openthread/tasklet.h>
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 
 namespace ot {
 
@@ -149,7 +150,7 @@ private:
  * This class implements the tasklet scheduler.
  *
  */
-class TaskletScheduler
+class TaskletScheduler : private NonCopyable
 {
     friend class Tasklet;
 

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -45,6 +45,7 @@
 #include "common/debug.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/tasklet.hpp"
 #include "common/time.hpp"
 
@@ -251,7 +252,7 @@ private:
  * This class implements the base timer scheduler.
  *
  */
-class TimerScheduler : public InstanceLocator
+class TimerScheduler : public InstanceLocator, private NonCopyable
 {
     friend class Timer;
 

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -41,13 +41,14 @@
 #include <openthread/platform/radio.h>
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 
 namespace ot {
 namespace FactoryDiags {
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
 
-class Diags : public InstanceLocator
+class Diags : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -39,6 +39,7 @@
 #include <openthread/link_raw.h>
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "mac/mac_frame.hpp"
 #include "mac/sub_mac.hpp"
 
@@ -51,7 +52,7 @@ namespace Mac {
  * This class defines the raw link-layer object.
  *
  */
-class LinkRaw : public InstanceLocator
+class LinkRaw : public InstanceLocator, private NonCopyable
 {
     friend class ot::Instance;
 

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -44,6 +44,7 @@
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "net/icmp6.hpp"
 #include "net/ip6_address.hpp"
@@ -98,7 +99,7 @@ using ot::Encoding::BigEndian::HostSwap32;
  * This class implements the core IPv6 message processing.
  *
  */
-class Ip6 : public InstanceLocator
+class Ip6 : public InstanceLocator, private NonCopyable
 {
     friend class ot::Instance;
 

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -39,6 +39,7 @@
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "common/tasklet.hpp"
 #include "mac/mac_types.hpp"
 #include "net/ip6_address.hpp"
@@ -169,7 +170,7 @@ private:
  * This class implements an IPv6 network interface.
  *
  */
-class Netif : public InstanceLocator, public LinkedListEntry<Netif>
+class Netif : public InstanceLocator, public LinkedListEntry<Netif>, private NonCopyable
 {
     friend class Ip6;
     friend class Address;

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -39,6 +39,7 @@
 #include <openthread/platform/radio.h>
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "mac/mac_frame.hpp"
 #include "utils/static_assert.hpp"
 
@@ -58,7 +59,7 @@ namespace ot {
  * This class represents an OpenThread radio abstraction.
  *
  */
-class Radio : public InstanceLocator
+class Radio : public InstanceLocator, private NonCopyable
 {
     friend class Instance;
 

--- a/src/core/thread/announce_sender.hpp
+++ b/src/core/thread/announce_sender.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/timer.hpp"
 #include "mac/mac.hpp"
@@ -49,7 +50,7 @@ namespace ot {
  * This class provides APIs to schedule periodic transmission of MLE Announcement messages for a given number
  * transmissions per channel.
  */
-class AnnounceSenderBase : public InstanceLocator
+class AnnounceSenderBase : public InstanceLocator, private NonCopyable
 {
 protected:
     /**

--- a/src/core/utils/channel_manager.hpp
+++ b/src/core/utils/channel_manager.hpp
@@ -39,6 +39,7 @@
 #include <openthread/platform/radio.h>
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/timer.hpp"
 #include "mac/mac.hpp"
@@ -63,7 +64,7 @@ namespace Utils {
  * This class implements the Channel Manager.
  *
  */
-class ChannelManager : public InstanceLocator
+class ChannelManager : public InstanceLocator, private NonCopyable
 {
 public:
     enum
@@ -295,7 +296,7 @@ private:
 
 #else // OPENTHREAD_FTD
 
-class ChannelManager
+class ChannelManager : private NonCopyable
 {
 public:
     explicit ChannelManager(Instance &) {}

--- a/src/core/utils/channel_monitor.hpp
+++ b/src/core/utils/channel_monitor.hpp
@@ -39,6 +39,7 @@
 #include <openthread/platform/radio.h>
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "mac/mac.hpp"
 #include "radio/radio.hpp"
@@ -70,7 +71,7 @@ namespace Utils {
  * window (referred to as "channel occupancy").
  *
  */
-class ChannelMonitor : public InstanceLocator
+class ChannelMonitor : public InstanceLocator, private NonCopyable
 {
 public:
     enum

--- a/src/core/utils/heap.hpp
+++ b/src/core/utils/heap.hpp
@@ -40,6 +40,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "common/non_copyable.hpp"
 #include "utils/static_assert.hpp"
 
 namespace ot {
@@ -175,7 +176,7 @@ private:
  *     +--------------------------------------------------------------------------+
  *
  */
-class Heap
+class Heap : private NonCopyable
 {
 public:
     /**

--- a/src/core/utils/otns.hpp
+++ b/src/core/utils/otns.hpp
@@ -43,6 +43,7 @@
 #include <openthread/platform/otns.h>
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "mac/mac_types.hpp"
 #include "net/ip6_address.hpp"
@@ -55,7 +56,7 @@ namespace Utils {
  * This class implements the OTNS Stub that interacts with OTNS.
  *
  */
-class Otns : public InstanceLocator
+class Otns : public InstanceLocator, private NonCopyable
 {
 public:
     /**


### PR DESCRIPTION
This PR makes `Instance` and its members non-copyable to prevent issues like https://github.com/openthread/openthread/pull/4970.