### PR TITLE
[message] misc enhancements 

### DIFF
--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -45,18 +45,9 @@ using namespace ot;
 
 otMessage *otCoapNewMessage(otInstance *aInstance, const otMessageSettings *aSettings)
 {
-    Message * message;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    if (aSettings != NULL)
-    {
-        VerifyOrExit(aSettings->mPriority <= OT_MESSAGE_PRIORITY_HIGH, message = NULL);
-    }
-
-    message = instance.GetApplicationCoap().NewMessage(aSettings);
-
-exit:
-    return message;
+    return instance.GetApplicationCoap().NewMessage(Message::Settings(aSettings));
 }
 
 void otCoapMessageInit(otMessage *aMessage, otCoapType aType, otCoapCode aCode)

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -170,17 +170,8 @@ otError otIp6Send(otInstance *aInstance, otMessage *aMessage)
 otMessage *otIp6NewMessage(otInstance *aInstance, const otMessageSettings *aSettings)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
-    Message * message;
 
-    if (aSettings != NULL)
-    {
-        VerifyOrExit(aSettings->mPriority <= OT_MESSAGE_PRIORITY_HIGH, message = NULL);
-    }
-
-    message = instance.Get<Ip6::Ip6>().NewMessage(0, aSettings);
-
-exit:
-    return message;
+    return instance.Get<Ip6::Ip6>().NewMessage(0, Message::Settings(aSettings));
 }
 
 otMessage *otIp6NewMessageFromBuffer(otInstance *             aInstance,
@@ -191,9 +182,15 @@ otMessage *otIp6NewMessageFromBuffer(otInstance *             aInstance,
     Instance &instance = *static_cast<Instance *>(aInstance);
     Message * message;
 
-    VerifyOrExit((message = instance.Get<Ip6::Ip6>().NewMessage(aData, aDataLength, aSettings)) != NULL, OT_NOOP);
+    if (aSettings != NULL)
+    {
+        message = instance.Get<Ip6::Ip6>().NewMessage(aData, aDataLength, Message::Settings(aSettings));
+    }
+    else
+    {
+        message = instance.Get<Ip6::Ip6>().NewMessage(aData, aDataLength);
+    }
 
-exit:
     return message;
 }
 

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -45,17 +45,8 @@ using namespace ot;
 otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSettings)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
-    Message * message;
 
-    if (aSettings != NULL)
-    {
-        VerifyOrExit(aSettings->mPriority <= OT_MESSAGE_PRIORITY_HIGH, message = NULL);
-    }
-
-    message = instance.Get<Ip6::Udp>().NewMessage(0, aSettings);
-
-exit:
-    return message;
+    return instance.Get<Ip6::Udp>().NewMessage(0, Message::Settings(aSettings));
 }
 
 otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext)

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -113,7 +113,7 @@ void CoapBase::SetInterceptor(Interceptor aInterceptor, void *aContext)
     mContext     = aContext;
 }
 
-Message *CoapBase::NewMessage(const otMessageSettings *aSettings)
+Message *CoapBase::NewMessage(const Message::Settings &aSettings)
 {
     Message *message = NULL;
 

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -329,15 +329,12 @@ public:
     /**
      * This method creates a new message with a CoAP header.
      *
-     * @note If @p aSettings is 'NULL', the link layer security is enabled and the message priority is set to
-     * OT_MESSAGE_PRIORITY_NORMAL by default.
-     *
-     * @param[in]  aSettings  A pointer to the message settings or NULL to set default settings.
+     * @param[in]  aSettings  The message settings.
      *
      * @returns A pointer to the message or NULL if failed to allocate message.
      *
      */
-    Message *NewMessage(const otMessageSettings *aSettings = NULL);
+    Message *NewMessage(const Message::Settings &aSettings = Message::Settings::GetDefault());
 
     /**
      * This method creates a new message with a CoAP header that has Network Control priority level.
@@ -347,8 +344,7 @@ public:
      */
     Message *NewPriorityMessage(void)
     {
-        otMessageSettings settings = {true, static_cast<otMessagePriority>(Message::kPriorityNet)};
-        return NewMessage(&settings);
+        return NewMessage(Message::Settings(Message::kWithLinkSecurity, Message::kPriorityNet));
     }
 
     /**

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -246,7 +246,7 @@ otError Message::ParseHeader(void)
     otError        error = OT_ERROR_NONE;
     OptionIterator iterator;
 
-    OT_ASSERT(mBuffer.mHead.mInfo.mReserved >=
+    OT_ASSERT(mBuffer.mHead.mMetadata.mReserved >=
               sizeof(GetHelpData()) +
                   static_cast<size_t>((reinterpret_cast<uint8_t *>(&GetHelpData()) - mBuffer.mHead.mData)));
 

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -640,7 +640,7 @@ private:
 
     const HelpData &GetHelpData(void) const
     {
-        OT_STATIC_ASSERT(sizeof(mBuffer.mHead.mInfo) + sizeof(HelpData) + kHelpDataAlignment <= sizeof(mBuffer),
+        OT_STATIC_ASSERT(sizeof(mBuffer.mHead.mMetadata) + sizeof(HelpData) + kHelpDataAlignment <= sizeof(mBuffer),
                          "Insufficient buffer size for CoAP processing!");
 
         return *static_cast<const HelpData *>(OT_ALIGN(mBuffer.mHead.mData, kHelpDataAlignment));

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -61,7 +61,7 @@ MessagePool::MessagePool(Instance &aInstance)
 #endif
 }
 
-Message *MessagePool::New(uint8_t aType, uint16_t aReserveHeader, uint8_t aPriority)
+Message *MessagePool::New(Message::Type aType, uint16_t aReserveHeader, uint8_t aPriority)
 {
     otError  error = OT_ERROR_NONE;
     Message *message;
@@ -87,7 +87,7 @@ exit:
     return message;
 }
 
-Message *MessagePool::New(uint8_t aType, uint16_t aReserveHeader, const otMessageSettings *aSettings)
+Message *MessagePool::New(Message::Type aType, uint16_t aReserveHeader, const otMessageSettings *aSettings)
 {
     Message *message;
     bool     linkSecurityEnabled;

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -87,27 +87,13 @@ exit:
     return message;
 }
 
-Message *MessagePool::New(Message::Type aType, uint16_t aReserveHeader, const otMessageSettings *aSettings)
+Message *MessagePool::New(Message::Type aType, uint16_t aReserveHeader, const Message::Settings &aSettings)
 {
-    Message *         message;
-    bool              linkSecurityEnabled;
-    Message::Priority priority;
+    Message *message = New(aType, aReserveHeader, aSettings.GetPriority());
 
-    if (aSettings == NULL)
-    {
-        linkSecurityEnabled = true;
-        priority            = Message::kPriorityNormal;
-    }
-    else
-    {
-        linkSecurityEnabled = aSettings->mLinkSecurityEnabled;
-        priority            = static_cast<Message::Priority>(aSettings->mPriority);
-    }
-
-    message = New(aType, aReserveHeader, priority);
     if (message)
     {
-        message->SetLinkSecurityEnabled(linkSecurityEnabled);
+        message->SetLinkSecurityEnabled(aSettings.IsLinkSecurityEnabled());
     }
 
     return message;
@@ -196,6 +182,20 @@ uint16_t MessagePool::GetFreeBufferCount(void) const
 #endif
 
     return rval;
+}
+
+const Message::Settings Message::Settings::kDefault(Message::kWithLinkSecurity, Message::kPriorityNormal);
+
+Message::Settings::Settings(LinkSecurityMode aSecurityMode, Priority aPriority)
+    : mLinkSecurityEnabled(aSecurityMode == kWithLinkSecurity)
+    , mPriority(aPriority)
+{
+}
+
+Message::Settings::Settings(const otMessageSettings *aSettings)
+    : mLinkSecurityEnabled((aSettings != NULL) ? aSettings->mLinkSecurityEnabled : true)
+    , mPriority((aSettings != NULL) ? static_cast<Priority>(aSettings->mPriority) : kPriorityNormal)
+{
 }
 
 otError Message::ResizeMessage(uint16_t aLength)

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -260,13 +260,16 @@ public:
         kSubTypeMleChildIdRequest      = 10, ///< MLE Child ID Request
     };
 
-    enum
+    enum Priority
     {
         kPriorityLow    = OT_MESSAGE_PRIORITY_LOW,      ///< Low priority level.
         kPriorityNormal = OT_MESSAGE_PRIORITY_NORMAL,   ///< Normal priority level.
         kPriorityHigh   = OT_MESSAGE_PRIORITY_HIGH,     ///< High priority level.
         kPriorityNet    = OT_MESSAGE_PRIORITY_HIGH + 1, ///< Network Control priority level.
+    };
 
+    enum
+    {
         kNumPriorities = 4, ///< Number of priority levels.
     };
 
@@ -379,7 +382,7 @@ public:
      * @returns The priority level associated with this message.
      *
      */
-    uint8_t GetPriority(void) const { return GetMetadata().mPriority; }
+    Priority GetPriority(void) const { return static_cast<Priority>(GetMetadata().mPriority); }
 
     /**
      * This method sets the messages priority.
@@ -392,7 +395,7 @@ public:
      * @retval OT_ERROR_INVALID_ARGS   Priority level is not invalid.
      *
      */
-    otError SetPriority(uint8_t aPriority);
+    otError SetPriority(Priority aPriority);
 
     /**
      * This method prepends bytes to the front of the message.
@@ -1050,7 +1053,7 @@ public:
      *          this priority level.
      *
      */
-    Message *GetHeadForPriority(uint8_t aPriority) const;
+    Message *GetHeadForPriority(Message::Priority aPriority) const;
 
     /**
      * This method adds a message to the queue.
@@ -1108,7 +1111,7 @@ private:
      * @returns The first non-NULL tail pointer, or NULL if all the
      *
      */
-    Message *FindFirstNonNullTail(uint8_t aStartPriorityLevel) const;
+    Message *FindFirstNonNullTail(Message::Priority aStartPriorityLevel) const;
 
 private:
     Message *mTails[Message::kNumPriorities]; ///< Tail pointers associated with different priority levels.
@@ -1132,17 +1135,16 @@ public:
     explicit MessagePool(Instance &aInstance);
 
     /**
-     * This method is used to obtain a new message. The default priority `kDefaultMessagePriority`
-     * is assigned to the message.
+     * This method is used to obtain a new message.
      *
      * @param[in]  aType           The message type.
      * @param[in]  aReserveHeader  The number of header bytes to reserve.
-     * @param[in]  aPriority       The priority level of the message.
+     * @param[in]  aPriority       The priority level of the message (default value is `Message::kPriorityNormal`).
      *
      * @returns A pointer to the message or NULL if no message buffers are available.
      *
      */
-    Message *New(Message::Type aType, uint16_t aReserveHeader, uint8_t aPriority = kDefaultMessagePriority);
+    Message *New(Message::Type aType, uint16_t aReserveHeader, Message::Priority aPriority = Message::kPriorityNormal);
 
     /**
      * This method is used to obtain a new message with specified settings.
@@ -1176,14 +1178,9 @@ public:
     uint16_t GetFreeBufferCount(void) const;
 
 private:
-    enum
-    {
-        kDefaultMessagePriority = Message::kPriorityNormal,
-    };
-
-    Buffer *NewBuffer(uint8_t aPriority);
+    Buffer *NewBuffer(Message::Priority aPriority);
     void    FreeBuffers(Buffer *aBuffer);
-    otError ReclaimBuffers(int aNumBuffers, uint8_t aPriority);
+    otError ReclaimBuffers(int aNumBuffers, Message::Priority aPriority);
 
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT == 0
     uint16_t           mNumFreeBuffers;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -274,6 +274,72 @@ public:
     };
 
     /**
+     * This enumeration represents the link security mode (used by `Settings` constructor).
+     *
+     */
+    enum LinkSecurityMode
+    {
+        kNoLinkSecurity,   ///< Link security disabled (no link security).
+        kWithLinkSecurity, ///< Link security enabled.
+    };
+
+    /**
+     * This class represents settings used for creating a new message.
+     *
+     */
+    class Settings
+    {
+    public:
+        /**
+         * This constructor initializes the Settings object.
+         *
+         * @param[in]  aSecurityMode  A link security mode.
+         * @param[in]  aPriority      A message priority.
+         *
+         */
+        Settings(LinkSecurityMode aSecurityMode, Priority aPriority);
+
+        /**
+         * This constructor initializes the `Settings` object from a given `otMessageSettings`.
+         *
+         * @param[in] aSettings  A pointer to `otMessageSettings` to covert from. If NULL default settings (link
+         *                       security enabled with `kPriorityNormal` priority) would be used.
+         *
+         */
+        Settings(const otMessageSettings *aSettings);
+
+        /**
+         * This method gets the message priority.
+         *
+         * @returns The message priority.
+         *
+         */
+        Priority GetPriority(void) const { return mPriority; }
+
+        /**
+         * This method indicates whether the link security should be enabled.
+         *
+         * @returns TRUE if link security should be enabled, FALSE otherwise.
+         *
+         */
+        bool IsLinkSecurityEnabled(void) const { return mLinkSecurityEnabled; }
+
+        /**
+         * This static method returns the default settings with link security enabled and `kPriorityNormal` priority.
+         *
+         * @returns A reference to the default settings (link security enable and `kPriorityNormal` priority).
+         *
+         */
+        static const Settings &GetDefault(void) { return kDefault; }
+
+    private:
+        static const Settings kDefault;
+
+        bool     mLinkSecurityEnabled;
+        Priority mPriority;
+    };
+
+    /**
      * This method frees this message buffer.
      *
      */
@@ -1137,29 +1203,31 @@ public:
     /**
      * This method is used to obtain a new message.
      *
+     * The link security is enabled by default on the newly obtained message.
+     *
      * @param[in]  aType           The message type.
      * @param[in]  aReserveHeader  The number of header bytes to reserve.
-     * @param[in]  aPriority       The priority level of the message (default value is `Message::kPriorityNormal`).
+     * @param[in]  aPriority       The priority level of the message.
      *
      * @returns A pointer to the message or NULL if no message buffers are available.
      *
      */
-    Message *New(Message::Type aType, uint16_t aReserveHeader, Message::Priority aPriority = Message::kPriorityNormal);
+    Message *New(Message::Type aType, uint16_t aReserveHeader, Message::Priority aPriority);
 
+public:
     /**
      * This method is used to obtain a new message with specified settings.
      *
-     * @note If @p aSettings is 'NULL', the link layer security is enabled and the message priority is set to
-     * OT_MESSAGE_PRIORITY_NORMAL by default.
-     *
      * @param[in]  aType           The message type.
      * @param[in]  aReserveHeader  The number of header bytes to reserve.
-     * @param[in]  aSettings       A pointer to the message settings or NULL to set default settings.
+     * @param[in]  aSettings       The message settings.
      *
      * @returns A pointer to the message or NULL if no message buffers are available.
      *
      */
-    Message *New(Message::Type aType, uint16_t aReserveHeader, const otMessageSettings *aSettings);
+    Message *New(Message::Type            aType,
+                 uint16_t                 aReserveHeader,
+                 const Message::Settings &aSettings = Message::Settings::GetDefault());
 
     /**
      * This method is used to free a message and return all message buffers to the buffer pool.

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -241,7 +241,11 @@ public:
         kTypeOther       = 3, ///< Other (data) message.
     };
 
-    enum
+    /**
+     * This enumeration represents the message sub-type.
+     *
+     */
+    enum SubType
     {
         kSubTypeNone                   = 0,  ///< None
         kSubTypeMleAnnounce            = 1,  ///< MLE Announce
@@ -350,7 +354,7 @@ public:
      * @returns The sub type of the message.
      *
      */
-    uint8_t GetSubType(void) const { return GetMetadata().mSubType; }
+    SubType GetSubType(void) const { return static_cast<SubType>(GetMetadata().mSubType); }
 
     /**
      * This method sets the message sub type.
@@ -358,7 +362,7 @@ public:
      * @param[in]  aSubType  The message sub type.
      *
      */
-    void SetSubType(uint8_t aSubType) { GetMetadata().mSubType = aSubType; }
+    void SetSubType(SubType aSubType) { GetMetadata().mSubType = aSubType; }
 
     /**
      * This method returns whether or not the message is of MLE subtype.

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -229,7 +229,11 @@ class Message : public Buffer
     friend class PriorityQueue;
 
 public:
-    enum
+    /**
+     * This enumeration represents the message type.
+     *
+     */
+    enum Type
     {
         kTypeIp6         = 0, ///< A full uncompressed IPv6 packet
         kType6lowpan     = 1, ///< A 6lowpan frame
@@ -330,7 +334,7 @@ public:
      * @returns The type of the message.
      *
      */
-    uint8_t GetType(void) const { return GetMetadata().mType; }
+    Type GetType(void) const { return static_cast<Type>(GetMetadata().mType); }
 
     /**
      * This method sets the message type.
@@ -338,7 +342,7 @@ public:
      * @param[in]  aType  The message type.
      *
      */
-    void SetType(uint8_t aType) { GetMetadata().mType = aType; }
+    void SetType(Type aType) { GetMetadata().mType = aType; }
 
     /**
      * This method returns the sub type of the message.
@@ -1134,7 +1138,7 @@ public:
      * @returns A pointer to the message or NULL if no message buffers are available.
      *
      */
-    Message *New(uint8_t aType, uint16_t aReserveHeader, uint8_t aPriority = kDefaultMessagePriority);
+    Message *New(Message::Type aType, uint16_t aReserveHeader, uint8_t aPriority = kDefaultMessagePriority);
 
     /**
      * This method is used to obtain a new message with specified settings.
@@ -1149,7 +1153,7 @@ public:
      * @returns A pointer to the message or NULL if no message buffers are available.
      *
      */
-    Message *New(uint8_t aType, uint16_t aReserveHeader, const otMessageSettings *aSettings);
+    Message *New(Message::Type aType, uint16_t aReserveHeader, const otMessageSettings *aSettings);
 
     /**
      * This method is used to free a message and return all message buffers to the buffer pool.

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -43,6 +43,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
+#include "common/linked_list.hpp"
 #include "common/locator.hpp"
 #include "mac/mac_types.hpp"
 #include "thread/link_quality.hpp"
@@ -121,7 +122,7 @@ struct MessageInfo
  * This class represents a Message buffer.
  *
  */
-class Buffer : public otMessage
+class Buffer : public otMessage, public LinkedListEntry<Buffer>
 {
     friend class Message;
 
@@ -132,7 +133,15 @@ public:
      * @returns A pointer to the next message buffer.
      *
      */
-    Buffer *GetNextBuffer(void) const { return static_cast<Buffer *>(mNext); }
+    Buffer *GetNextBuffer(void) { return GetNext(); }
+
+    /**
+     * This method returns a pointer to the next message buffer.
+     *
+     * @returns A pointer to the next message buffer.
+     *
+     */
+    const Buffer *GetNextBuffer(void) const { return GetNext(); }
 
     /**
      * This method sets the pointer to the next message buffer.
@@ -140,7 +149,7 @@ public:
      * @param[in] aNext  A pointer to the next buffer.
      *
      */
-    void SetNextBuffer(Buffer *aNext) { mNext = aNext; }
+    void SetNextBuffer(Buffer *aNext) { SetNext(aNext); }
 
 private:
     /**
@@ -1156,9 +1165,9 @@ private:
     otError ReclaimBuffers(int aNumBuffers, uint8_t aPriority);
 
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT == 0
-    uint16_t mNumFreeBuffers;
-    Buffer   mBuffers[kNumBuffers];
-    Buffer * mFreeBuffers;
+    uint16_t           mNumFreeBuffers;
+    Buffer             mBuffers[kNumBuffers];
+    LinkedList<Buffer> mFreeBuffers;
 #endif
 };
 

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -76,7 +76,7 @@ class PriorityQueue;
  * This structure contains metadata about a Message.
  *
  */
-struct MessageInfo
+struct MessageMetadata
 {
     Message *    mNext;        ///< A pointer to the next Message in a doubly linked list.
     Message *    mPrev;        ///< A pointer to the previous Message in a doubly linked list.
@@ -153,6 +153,22 @@ public:
 
 private:
     /**
+     * This method returns the message metadata in the first message buffer.
+     *
+     * @returns The message metadata structure.
+     *
+     */
+    MessageMetadata &GetMetadata(void) { return mBuffer.mHead.mMetadata; }
+
+    /**
+     * This method returns the message metadata in the first message buffer.
+     *
+     * @returns The message metadata structure.
+     *
+     */
+    const MessageMetadata &GetMetadata(void) const { return mBuffer.mHead.mMetadata; }
+
+    /**
      * This method returns a pointer to the first byte of data in the first message buffer.
      *
      * @returns A pointer to the first data byte.
@@ -187,7 +203,7 @@ private:
     enum
     {
         kBufferDataSize     = kBufferSize - sizeof(otMessage),
-        kHeadBufferDataSize = kBufferDataSize - sizeof(MessageInfo),
+        kHeadBufferDataSize = kBufferDataSize - sizeof(MessageMetadata),
     };
 
 protected:
@@ -195,8 +211,8 @@ protected:
     {
         struct
         {
-            MessageInfo mInfo;
-            uint8_t     mData[kHeadBufferDataSize];
+            MessageMetadata mMetadata;
+            uint8_t         mData[kHeadBufferDataSize];
         } mHead;
         uint8_t mData[kBufferDataSize];
     } mBuffer;
@@ -265,7 +281,7 @@ public:
      *
      * @returns The number of bytes in the message.
      */
-    uint16_t GetLength(void) const { return mBuffer.mHead.mInfo.mLength; }
+    uint16_t GetLength(void) const { return GetMetadata().mLength; }
 
     /**
      * This method sets the number of bytes in the message.
@@ -290,7 +306,7 @@ public:
      * @returns A byte offset within the message.
      *
      */
-    uint16_t GetOffset(void) const { return mBuffer.mHead.mInfo.mOffset; }
+    uint16_t GetOffset(void) const { return GetMetadata().mOffset; }
 
     /**
      * This method moves the byte offset within the message.
@@ -314,7 +330,7 @@ public:
      * @returns The type of the message.
      *
      */
-    uint8_t GetType(void) const { return mBuffer.mHead.mInfo.mType; }
+    uint8_t GetType(void) const { return GetMetadata().mType; }
 
     /**
      * This method sets the message type.
@@ -322,7 +338,7 @@ public:
      * @param[in]  aType  The message type.
      *
      */
-    void SetType(uint8_t aType) { mBuffer.mHead.mInfo.mType = aType; }
+    void SetType(uint8_t aType) { GetMetadata().mType = aType; }
 
     /**
      * This method returns the sub type of the message.
@@ -330,7 +346,7 @@ public:
      * @returns The sub type of the message.
      *
      */
-    uint8_t GetSubType(void) const { return mBuffer.mHead.mInfo.mSubType; }
+    uint8_t GetSubType(void) const { return GetMetadata().mSubType; }
 
     /**
      * This method sets the message sub type.
@@ -338,7 +354,7 @@ public:
      * @param[in]  aSubType  The message sub type.
      *
      */
-    void SetSubType(uint8_t aSubType) { mBuffer.mHead.mInfo.mSubType = aSubType; }
+    void SetSubType(uint8_t aSubType) { GetMetadata().mSubType = aSubType; }
 
     /**
      * This method returns whether or not the message is of MLE subtype.
@@ -355,7 +371,7 @@ public:
      * @returns The priority level associated with this message.
      *
      */
-    uint8_t GetPriority(void) const { return mBuffer.mHead.mInfo.mPriority; }
+    uint8_t GetPriority(void) const { return GetMetadata().mPriority; }
 
     /**
      * This method sets the messages priority.
@@ -476,7 +492,7 @@ public:
      * @returns The 6LoWPAN datagram tag or the IPv6 fragment identification.
      *
      */
-    uint32_t GetDatagramTag(void) const { return mBuffer.mHead.mInfo.mDatagramTag; }
+    uint32_t GetDatagramTag(void) const { return GetMetadata().mDatagramTag; }
 
     /**
      * This method sets the datagram tag used for 6LoWPAN fragmentation.
@@ -484,7 +500,7 @@ public:
      * @param[in]  aTag  The 6LoWPAN datagram tag.
      *
      */
-    void SetDatagramTag(uint32_t aTag) { mBuffer.mHead.mInfo.mDatagramTag = aTag; }
+    void SetDatagramTag(uint32_t aTag) { GetMetadata().mDatagramTag = aTag; }
 
     /**
      * This method returns whether or not the message forwarding is scheduled for the child.
@@ -530,7 +546,7 @@ public:
      * @returns The IEEE 802.15.4 Destination PAN ID.
      *
      */
-    uint16_t GetMeshDest(void) const { return mBuffer.mHead.mInfo.mMeshDest; }
+    uint16_t GetMeshDest(void) const { return GetMetadata().mMeshDest; }
 
     /**
      * This method sets the RLOC16 of the mesh destination.
@@ -540,7 +556,7 @@ public:
      * @param[in]  aMeshDest  The IEEE 802.15.4 Destination PAN ID.
      *
      */
-    void SetMeshDest(uint16_t aMeshDest) { mBuffer.mHead.mInfo.mMeshDest = aMeshDest; }
+    void SetMeshDest(uint16_t aMeshDest) { GetMetadata().mMeshDest = aMeshDest; }
 
     /**
      * This method returns the IEEE 802.15.4 Destination PAN ID.
@@ -550,7 +566,7 @@ public:
      * @returns The IEEE 802.15.4 Destination PAN ID.
      *
      */
-    uint16_t GetPanId(void) const { return mBuffer.mHead.mInfo.mPanIdChannel.mPanId; }
+    uint16_t GetPanId(void) const { return GetMetadata().mPanIdChannel.mPanId; }
 
     /**
      * This method sets the IEEE 802.15.4 Destination PAN ID.
@@ -560,7 +576,7 @@ public:
      * @param[in]  aPanId  The IEEE 802.15.4 Destination PAN ID.
      *
      */
-    void SetPanId(uint16_t aPanId) { mBuffer.mHead.mInfo.mPanIdChannel.mPanId = aPanId; }
+    void SetPanId(uint16_t aPanId) { GetMetadata().mPanIdChannel.mPanId = aPanId; }
 
     /**
      * This method returns the IEEE 802.15.4 Channel to use for transmission.
@@ -570,7 +586,7 @@ public:
      * @returns The IEEE 802.15.4 Channel to use for transmission.
      *
      */
-    uint8_t GetChannel(void) const { return mBuffer.mHead.mInfo.mPanIdChannel.mChannel; }
+    uint8_t GetChannel(void) const { return GetMetadata().mPanIdChannel.mChannel; }
 
     /**
      * This method sets the IEEE 802.15.4 Channel to use for transmission.
@@ -580,7 +596,7 @@ public:
      * @param[in]  aChannel  The IEEE 802.15.4 Channel to use for transmission.
      *
      */
-    void SetChannel(uint8_t aChannel) { mBuffer.mHead.mInfo.mPanIdChannel.mChannel = aChannel; }
+    void SetChannel(uint8_t aChannel) { GetMetadata().mPanIdChannel.mChannel = aChannel; }
 
     /**
      * This method returns the timeout used for 6LoWPAN reassembly.
@@ -588,7 +604,7 @@ public:
      * @returns The time remaining in seconds.
      *
      */
-    uint8_t GetTimeout(void) const { return mBuffer.mHead.mInfo.mTimeout; }
+    uint8_t GetTimeout(void) const { return GetMetadata().mTimeout; }
 
     /**
      * This method sets the timeout used for 6LoWPAN reassembly.
@@ -596,13 +612,13 @@ public:
      * @param[in]  aTimeout  The timeout value.
      *
      */
-    void SetTimeout(uint8_t aTimeout) { mBuffer.mHead.mInfo.mTimeout = aTimeout; }
+    void SetTimeout(uint8_t aTimeout) { GetMetadata().mTimeout = aTimeout; }
 
     /**
      * This method decrements the timeout.
      *
      */
-    void DecrementTimeout(void) { mBuffer.mHead.mInfo.mTimeout--; }
+    void DecrementTimeout(void) { GetMetadata().mTimeout--; }
 
     /**
      * This method returns whether or not message forwarding is scheduled for direct transmission.
@@ -611,19 +627,19 @@ public:
      * @retval FALSE  If message forwarding is not scheduled for direct transmission.
      *
      */
-    bool GetDirectTransmission(void) const { return mBuffer.mHead.mInfo.mDirectTx; }
+    bool GetDirectTransmission(void) const { return GetMetadata().mDirectTx; }
 
     /**
      * This method unschedules forwarding using direct transmission.
      *
      */
-    void ClearDirectTransmission(void) { mBuffer.mHead.mInfo.mDirectTx = false; }
+    void ClearDirectTransmission(void) { GetMetadata().mDirectTx = false; }
 
     /**
      * This method schedules forwarding using direct transmission.
      *
      */
-    void SetDirectTransmission(void) { mBuffer.mHead.mInfo.mDirectTx = true; }
+    void SetDirectTransmission(void) { GetMetadata().mDirectTx = true; }
 
     /**
      * This method indicates whether the direct transmission of message was successful.
@@ -632,7 +648,7 @@ public:
      * @retval FALSE  If direct transmission of message failed (at least one fragment failed).
      *
      */
-    bool GetTxSuccess(void) const { return mBuffer.mHead.mInfo.mTxSuccess; }
+    bool GetTxSuccess(void) const { return GetMetadata().mTxSuccess; }
 
     /**
      * This method sets whether the direct transmission of message was successful.
@@ -641,7 +657,7 @@ public:
      *                         fragment transmission failed).
      *
      */
-    void SetTxSuccess(bool aTxSuccess) { mBuffer.mHead.mInfo.mTxSuccess = aTxSuccess; }
+    void SetTxSuccess(bool aTxSuccess) { GetMetadata().mTxSuccess = aTxSuccess; }
 
     /**
      * This method indicates whether the message may be evicted.
@@ -650,7 +666,7 @@ public:
      * @retval FALSE  If the message may be evicted.
      *
      */
-    bool GetDoNotEvict(void) const { return mBuffer.mHead.mInfo.mDoNotEvict; }
+    bool GetDoNotEvict(void) const { return GetMetadata().mDoNotEvict; }
 
     /**
      * This method sets whether the message may be evicted.
@@ -658,7 +674,7 @@ public:
      * @param[in]  aDoNotEvict  TRUE if the message may not be evicted, FALSE otherwise.
      *
      */
-    void SetDoNotEvict(bool aDoNotEvict) { mBuffer.mHead.mInfo.mDoNotEvict = aDoNotEvict; }
+    void SetDoNotEvict(bool aDoNotEvict) { GetMetadata().mDoNotEvict = aDoNotEvict; }
 
     /**
      * This method indicates whether or not link security is enabled for the message.
@@ -667,7 +683,7 @@ public:
      * @retval FALSE  If link security is not enabled.
      *
      */
-    bool IsLinkSecurityEnabled(void) const { return mBuffer.mHead.mInfo.mLinkSecurity; }
+    bool IsLinkSecurityEnabled(void) const { return GetMetadata().mLinkSecurity; }
 
     /**
      * This method sets whether or not link security is enabled for the message.
@@ -675,7 +691,7 @@ public:
      * @param[in]  aEnabled  TRUE if link security is enabled, FALSE otherwise.
      *
      */
-    void SetLinkSecurityEnabled(bool aEnabled) { mBuffer.mHead.mInfo.mLinkSecurity = aEnabled; }
+    void SetLinkSecurityEnabled(bool aEnabled) { GetMetadata().mLinkSecurity = aEnabled; }
 
     /**
      * This method updates the average RSS (Received Signal Strength) associated with the message by adding the given
@@ -685,7 +701,7 @@ public:
      * @param[in] aRss A new RSS value (in dBm) to be added to average.
      *
      */
-    void AddRss(int8_t aRss) { IgnoreError(mBuffer.mHead.mInfo.mRssAverager.Add(aRss)); }
+    void AddRss(int8_t aRss) { IgnoreError(GetMetadata().mRssAverager.Add(aRss)); }
 
     /**
      * This method returns the average RSS (Received Signal Strength) associated with the message.
@@ -693,7 +709,7 @@ public:
      * @returns The current average RSS value (in dBm) or OT_RADIO_RSSI_INVALID if no average is available.
      *
      */
-    int8_t GetAverageRss(void) const { return mBuffer.mHead.mInfo.mRssAverager.GetAverage(); }
+    int8_t GetAverageRss(void) const { return GetMetadata().mRssAverager.GetAverage(); }
 
     /**
      * This method returns a const reference to RssAverager of the message.
@@ -701,7 +717,7 @@ public:
      * @returns A const reference to the RssAverager of the message.
      *
      */
-    const RssAverager &GetRssAverager(void) const { return mBuffer.mHead.mInfo.mRssAverager; }
+    const RssAverager &GetRssAverager(void) const { return GetMetadata().mRssAverager; }
 
     /**
      * This static method updates a checksum.
@@ -746,7 +762,7 @@ public:
      */
     MessageQueue *GetMessageQueue(void) const
     {
-        return (!mBuffer.mHead.mInfo.mInPriorityQ) ? mBuffer.mHead.mInfo.mQueue.mMessage : NULL;
+        return (!GetMetadata().mInPriorityQ) ? GetMetadata().mQueue.mMessage : NULL;
     }
 
     /**
@@ -757,7 +773,7 @@ public:
      */
     PriorityQueue *GetPriorityQueue(void) const
     {
-        return (mBuffer.mHead.mInfo.mInPriorityQ) ? mBuffer.mHead.mInfo.mQueue.mPriority : NULL;
+        return (GetMetadata().mInPriorityQ) ? GetMetadata().mQueue.mPriority : NULL;
     }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
@@ -768,7 +784,7 @@ public:
      * @retval FALSE  If the message is not used for time sync purpose.
      *
      */
-    bool IsTimeSync(void) const { return mBuffer.mHead.mInfo.mTimeSync; }
+    bool IsTimeSync(void) const { return GetMetadata().mTimeSync; }
 
     /**
      * This method sets whether or not the message is also used for time sync purpose.
@@ -776,7 +792,7 @@ public:
      * @param[in]  aEnabled  TRUE if the message is also used for time sync purpose, FALSE otherwise.
      *
      */
-    void SetTimeSync(bool aEnabled) { mBuffer.mHead.mInfo.mTimeSync = aEnabled; }
+    void SetTimeSync(bool aEnabled) { GetMetadata().mTimeSync = aEnabled; }
 
     /**
      * This method sets the offset to network time.
@@ -784,10 +800,7 @@ public:
      * @param[in]  aNetworkTimeOffset  The offset to network time.
      *
      */
-    void SetNetworkTimeOffset(int64_t aNetworkTimeOffset)
-    {
-        mBuffer.mHead.mInfo.mNetworkTimeOffset = aNetworkTimeOffset;
-    }
+    void SetNetworkTimeOffset(int64_t aNetworkTimeOffset) { GetMetadata().mNetworkTimeOffset = aNetworkTimeOffset; }
 
     /**
      * This method gets the offset to network time.
@@ -795,7 +808,7 @@ public:
      * @returns  The offset to network time.
      *
      */
-    int64_t GetNetworkTimeOffset(void) const { return mBuffer.mHead.mInfo.mNetworkTimeOffset; }
+    int64_t GetNetworkTimeOffset(void) const { return GetMetadata().mNetworkTimeOffset; }
 
     /**
      * This method sets the time sync sequence.
@@ -803,7 +816,7 @@ public:
      * @param[in]  aTimeSyncSeq  The time sync sequence.
      *
      */
-    void SetTimeSyncSeq(uint8_t aTimeSyncSeq) { mBuffer.mHead.mInfo.mTimeSyncSeq = aTimeSyncSeq; }
+    void SetTimeSyncSeq(uint8_t aTimeSyncSeq) { GetMetadata().mTimeSyncSeq = aTimeSyncSeq; }
 
     /**
      * This method gets the time sync sequence.
@@ -811,7 +824,7 @@ public:
      * @returns  The time sync sequence.
      *
      */
-    uint8_t GetTimeSyncSeq(void) const { return mBuffer.mHead.mInfo.mTimeSyncSeq; }
+    uint8_t GetTimeSyncSeq(void) const { return GetMetadata().mTimeSyncSeq; }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
 private:
@@ -821,7 +834,7 @@ private:
      * @returns A pointer to the message pool.
      *
      */
-    MessagePool *GetMessagePool(void) const { return mBuffer.mHead.mInfo.mMessagePool; }
+    MessagePool *GetMessagePool(void) const { return GetMetadata().mMessagePool; }
 
     /**
      * This method sets the message pool this message to which this message belongs.
@@ -829,7 +842,7 @@ private:
      * @param[in] aMessagePool  A pointer to the message pool
      *
      */
-    void SetMessagePool(MessagePool *aMessagePool) { mBuffer.mHead.mInfo.mMessagePool = aMessagePool; }
+    void SetMessagePool(MessagePool *aMessagePool) { GetMetadata().mMessagePool = aMessagePool; }
 
     /**
      * This method returns `true` if the message is enqueued in any queue (`MessageQueue` or `PriorityQueue`).
@@ -837,7 +850,7 @@ private:
      * @returns `true` if the message is in any queue, `false` otherwise.
      *
      */
-    bool IsInAQueue(void) const { return (mBuffer.mHead.mInfo.mQueue.mMessage != NULL); }
+    bool IsInAQueue(void) const { return (GetMetadata().mQueue.mMessage != NULL); }
 
     /**
      * This method sets the message queue information for the message.
@@ -861,7 +874,7 @@ private:
      * @returns A reference to the mNext pointer.
      *
      */
-    Message *&Next(void) { return mBuffer.mHead.mInfo.mNext; }
+    Message *&Next(void) { return GetMetadata().mNext; }
 
     /**
      * This method returns a reference to the `mNext` pointer (const pointer).
@@ -870,7 +883,7 @@ private:
      * @returns A reference to the mNext pointer.
      *
      */
-    Message *const &Next(void) const { return mBuffer.mHead.mInfo.mNext; }
+    Message *const &Next(void) const { return GetMetadata().mNext; }
 
     /**
      * This method returns a reference to the `mPrev` pointer.
@@ -878,7 +891,7 @@ private:
      * @returns A reference to the mPrev pointer.
      *
      */
-    Message *&Prev(void) { return mBuffer.mHead.mInfo.mPrev; }
+    Message *&Prev(void) { return GetMetadata().mPrev; }
 
     /**
      * This method returns the number of reserved header bytes.
@@ -886,7 +899,7 @@ private:
      * @returns The number of reserved header bytes.
      *
      */
-    uint16_t GetReserved(void) const { return mBuffer.mHead.mInfo.mReserved; }
+    uint16_t GetReserved(void) const { return GetMetadata().mReserved; }
 
     /**
      * This method sets the number of reserved header bytes.
@@ -894,7 +907,7 @@ private:
      * @param[in] aReservedHeader  The number of header bytes to reserve.
      *
      */
-    void SetReserved(uint16_t aReservedHeader) { mBuffer.mHead.mInfo.mReserved = aReservedHeader; }
+    void SetReserved(uint16_t aReservedHeader) { GetMetadata().mReserved = aReservedHeader; }
 
     /**
      * This method adds or frees message buffers to meet the requested length.

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -72,7 +72,7 @@ class MessageQueue;
 class PriorityQueue;
 
 /**
- * This structure contains metdata about a Message.
+ * This structure contains metadata about a Message.
  *
  */
 struct MessageInfo
@@ -121,7 +121,7 @@ struct MessageInfo
  * This class represents a Message buffer.
  *
  */
-class Buffer : public ::otMessage
+class Buffer : public otMessage
 {
     friend class Message;
 
@@ -132,13 +132,15 @@ public:
      * @returns A pointer to the next message buffer.
      *
      */
-    class Buffer *GetNextBuffer(void) const { return static_cast<Buffer *>(mNext); }
+    Buffer *GetNextBuffer(void) const { return static_cast<Buffer *>(mNext); }
 
     /**
      * This method sets the pointer to the next message buffer.
      *
+     * @param[in] aNext  A pointer to the next buffer.
+     *
      */
-    void SetNextBuffer(class Buffer *buf) { mNext = static_cast<otMessage *>(buf); }
+    void SetNextBuffer(Buffer *aNext) { mNext = aNext; }
 
 private:
     /**
@@ -175,8 +177,8 @@ private:
 
     enum
     {
-        kBufferDataSize     = kBufferSize - sizeof(struct otMessage),
-        kHeadBufferDataSize = kBufferDataSize - sizeof(struct MessageInfo),
+        kBufferDataSize     = kBufferSize - sizeof(otMessage),
+        kHeadBufferDataSize = kBufferDataSize - sizeof(MessageInfo),
     };
 
 protected:

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -902,7 +902,7 @@ void Dtls::HandleMbedtlsDebug(void *ctx, int level, const char *, int, const cha
     }
 }
 
-otError Dtls::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType)
+otError Dtls::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, Message::SubType aMessageSubType)
 {
     otError      error   = OT_ERROR_NONE;
     ot::Message *message = NULL;

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -367,7 +367,7 @@ public:
      * @param[in]  aMessageSubType  The default message sub-type.
      *
      */
-    void SetDefaultMessageSubType(uint8_t aMessageSubType) { mMessageDefaultSubType = aMessageSubType; }
+    void SetDefaultMessageSubType(Message::SubType aMessageSubType) { mMessageDefaultSubType = aMessageSubType; }
 
     /**
      * This method returns the DTLS session's peer address.
@@ -425,7 +425,7 @@ private:
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
     void    HandleDtlsReceive(const uint8_t *aBuf, uint16_t aLength);
-    otError HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, uint8_t aMessageSubType);
+    otError HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, Message::SubType aMessageSubType);
 
     static void HandleUdpTransmit(Tasklet &aTasklet);
     void        HandleUdpTransmit(void);
@@ -489,8 +489,8 @@ private:
     TransportCallback mTransportCallback;
     void *            mTransportContext;
 
-    uint8_t mMessageSubType;
-    uint8_t mMessageDefaultSubType;
+    Message::SubType mMessageSubType;
+    Message::SubType mMessageDefaultSubType;
 };
 
 } // namespace MeshCoP

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -195,8 +195,8 @@ void JoinerRouter::HandleRelayTransmit(Coap::Message &aMessage, const Ip6::Messa
     Kek               kek;
     uint16_t          offset;
     uint16_t          length;
-    Message *         message  = NULL;
-    otMessageSettings settings = {false, static_cast<otMessagePriority>(kMeshCoPMessagePriority)};
+    Message *         message = NULL;
+    Message::Settings settings(Message::kNoLinkSecurity, Message::kPriorityNet);
     Ip6::MessageInfo  messageInfo;
 
     VerifyOrExit(aMessage.IsNonConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, error = OT_ERROR_DROP);
@@ -208,7 +208,7 @@ void JoinerRouter::HandleRelayTransmit(Coap::Message &aMessage, const Ip6::Messa
 
     SuccessOrExit(error = Tlv::GetValueOffset(aMessage, Tlv::kJoinerDtlsEncapsulation, offset, length));
 
-    VerifyOrExit((message = mSocket.NewMessage(0, &settings)) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = mSocket.NewMessage(0, settings)) != NULL, error = OT_ERROR_NO_BUFS);
 
     SuccessOrExit(error = message->SetLength(length));
     aMessage.CopyTo(offset, 0, length, *message);

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -52,18 +52,16 @@ namespace MeshCoP {
 
 enum
 {
-    kMeshCoPMessagePriority = Message::kPriorityNet, ///< The priority for MeshCoP message
-    kBorderAgentUdpPort     = 49191,                 ///< UDP port of border agent service.
+    kBorderAgentUdpPort = 49191, ///< UDP port of border agent service.
 };
 
 /**
- * This function create Message for MeshCoP
+ * This function creates Message for MeshCoP.
  *
  */
 inline Coap::Message *NewMeshCoPMessage(Coap::CoapBase &aCoap)
 {
-    otMessageSettings settings = {true, static_cast<otMessagePriority>(kMeshCoPMessagePriority)};
-    return aCoap.NewMessage(&settings);
+    return aCoap.NewMessage(Message::Settings(Message::kWithLinkSecurity, Message::kPriorityNet));
 }
 
 /**

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -97,7 +97,7 @@ otError Icmp::SendError(IcmpHeader::Type   aType,
     Message *         message = NULL;
     IcmpHeader        icmp6Header;
     Header            ip6Header;
-    otMessageSettings settings = {true, static_cast<otMessagePriority>(Message::kPriorityNet)};
+    Message::Settings settings(Message::kWithLinkSecurity, Message::kPriorityNet);
 
     VerifyOrExit(aMessage.GetLength() >= sizeof(ip6Header), error = OT_ERROR_INVALID_ARGS);
 
@@ -113,7 +113,7 @@ otError Icmp::SendError(IcmpHeader::Type   aType,
 
     messageInfoLocal = aMessageInfo;
 
-    VerifyOrExit((message = Get<Ip6>().NewMessage(0, &settings)) != NULL, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit((message = Get<Ip6>().NewMessage(0, settings)) != NULL, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = message->SetLength(sizeof(icmp6Header) + sizeof(ip6Header)));
 
     message->Write(sizeof(icmp6Header), sizeof(ip6Header), &ip6Header);

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -77,7 +77,7 @@ Message *Ip6::NewMessage(const uint8_t *aData, uint16_t aDataLength, const otMes
 {
     otMessageSettings settings = {true, OT_MESSAGE_PRIORITY_NORMAL};
     Message *         message  = NULL;
-    uint8_t           priority;
+    Message::Priority priority;
 
     if (aSettings != NULL)
     {
@@ -98,10 +98,10 @@ exit:
     return message;
 }
 
-uint8_t Ip6::DscpToPriority(uint8_t aDscp)
+Message::Priority Ip6::DscpToPriority(uint8_t aDscp)
 {
-    uint8_t priority;
-    uint8_t cs = aDscp & kDscpCsMask;
+    Message::Priority priority;
+    uint8_t           cs = aDscp & kDscpCsMask;
 
     switch (cs)
     {
@@ -130,7 +130,7 @@ uint8_t Ip6::DscpToPriority(uint8_t aDscp)
     return priority;
 }
 
-uint8_t Ip6::PriorityToDscp(uint8_t aPriority)
+uint8_t Ip6::PriorityToDscp(Message::Priority aPriority)
 {
     uint8_t dscp = kDscpCs0;
 
@@ -141,6 +141,7 @@ uint8_t Ip6::PriorityToDscp(uint8_t aPriority)
         break;
 
     case Message::kPriorityNormal:
+    case Message::kPriorityNet:
         dscp = kDscpCs0;
         break;
 
@@ -152,7 +153,7 @@ uint8_t Ip6::PriorityToDscp(uint8_t aPriority)
     return dscp;
 }
 
-otError Ip6::GetDatagramPriority(const uint8_t *aData, uint16_t aDataLen, uint8_t &aPriority)
+otError Ip6::GetDatagramPriority(const uint8_t *aData, uint16_t aDataLen, Message::Priority &aPriority)
 {
     otError       error = OT_ERROR_NONE;
     const Header *header;

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -116,32 +116,38 @@ public:
     /**
      * This method allocates a new message buffer from the buffer pool.
      *
-     * @note If @p aSettings is 'NULL', the link layer security is enabled and the message priority is set to
-     *       OT_MESSAGE_PRIORITY_NORMAL by default.
-     *
      * @param[in]  aReserved  The number of header bytes to reserve following the IPv6 header.
-     * @param[in]  aSettings  A pointer to the message settings or NULL to set default settings.
+     * @param[in]  aSettings  The message settings.
      *
      * @returns A pointer to the message or NULL if insufficient message buffers are available.
      *
      */
-    Message *NewMessage(uint16_t aReserved, const otMessageSettings *aSettings = NULL);
+    Message *NewMessage(uint16_t aReserved, const Message::Settings &aSettings = Message::Settings::GetDefault());
 
     /**
      * This method allocates a new message buffer from the buffer pool and writes the IPv6 datagram to the message.
      *
-     * @note If @p aSettings is NULL, the link layer security is enabled and the message priority is obtained from
-     *       IPv6 message itself.
-     *       If @p aSettings is not NULL, the @p aSetting->mPriority is ignored and obtained from IPv6 message itself.
-     *
      * @param[in]  aData        A pointer to the IPv6 datagram buffer.
      * @param[in]  aDataLength  The size of the IPV6 datagram buffer pointed by @p aData.
-     * @param[in]  aSettings    A pointer to the message settings or NULL to set default settings.
+     * @param[in]  aSettings    The message settings.
      *
      * @returns A pointer to the message or NULL if malformed IPv6 header or insufficient message buffers are available.
      *
      */
-    Message *NewMessage(const uint8_t *aData, uint16_t aDataLength, const otMessageSettings *aSettings);
+    Message *NewMessage(const uint8_t *aData, uint16_t aDataLength, const Message::Settings &aSettings);
+
+    /**
+     * This method allocates a new message buffer from the buffer pool and writes the IPv6 datagram to the message.
+     *
+     * @note The link layer security is enabled and the message priority is obtained from IPv6 message itself.
+     *
+     * @param[in]  aData        A pointer to the IPv6 datagram buffer.
+     * @param[in]  aDataLength  The size of the IPV6 datagram buffer pointed by @p aData.
+     *
+     * @returns A pointer to the message or NULL if malformed IPv6 header or insufficient message buffers are available.
+     *
+     */
+    Message *NewMessage(const uint8_t *aData, uint16_t aDataLength);
 
     /**
      * This method converts the message priority level to IPv6 DSCP value.

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -151,7 +151,7 @@ public:
      * @returns The IPv6 DSCP value.
      *
      */
-    static uint8_t PriorityToDscp(uint8_t aPriority);
+    static uint8_t PriorityToDscp(Message::Priority aPriority);
 
     /**
      * This method converts the IPv6 DSCP value to message priority level.
@@ -161,7 +161,7 @@ public:
      * @returns The message priority level.
      *
      */
-    static uint8_t DscpToPriority(uint8_t aDscp);
+    static Message::Priority DscpToPriority(uint8_t aDscp);
 
     /**
      * This constructor initializes the object.
@@ -343,7 +343,7 @@ private:
     static void HandleSendQueue(Tasklet &aTasklet);
     void        HandleSendQueue(void);
 
-    static otError GetDatagramPriority(const uint8_t *aData, uint16_t aDataLen, uint8_t &aPriority);
+    static otError GetDatagramPriority(const uint8_t *aData, uint16_t aDataLen, Message::Priority &aPriority);
 
     otError ProcessReceiveCallback(const Message &    aMessage,
                                    const MessageInfo &aMessageInfo,

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -66,7 +66,7 @@ UdpSocket::UdpSocket(Udp &aUdp)
     mHandle = NULL;
 }
 
-Message *UdpSocket::NewMessage(uint16_t aReserved, const otMessageSettings *aSettings)
+Message *UdpSocket::NewMessage(uint16_t aReserved, const Message::Settings &aSettings)
 {
     return Get<Udp>().NewMessage(aReserved, aSettings);
 }
@@ -260,7 +260,7 @@ uint16_t Udp::GetEphemeralPort(void)
     return rval;
 }
 
-Message *Udp::NewMessage(uint16_t aReserved, const otMessageSettings *aSettings)
+Message *Udp::NewMessage(uint16_t aReserved, const Message::Settings &aSettings)
 {
     return Get<Ip6>().NewMessage(sizeof(UdpHeader) + aReserved, aSettings);
 }

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -107,16 +107,13 @@ public:
     /**
      * This method returns a new UDP message with sufficient header space reserved.
      *
-     * @note If @p aSettings is 'NULL', the link layer security is enabled and the message priority is set to
-     * OT_MESSAGE_PRIORITY_NORMAL by default.
-     *
      * @param[in]  aReserved  The number of header bytes to reserve after the UDP header.
-     * @param[in]  aSettings  A pointer to the message settings or NULL to set default settings.
+     * @param[in]  aSettings  The message settings (default is used if not provided).
      *
      * @returns A pointer to the message or NULL if no buffers are available.
      *
      */
-    Message *NewMessage(uint16_t aReserved, const otMessageSettings *aSettings = NULL);
+    Message *NewMessage(uint16_t aReserved, const Message::Settings &aSettings = Message::Settings::GetDefault());
 
     /**
      * This method opens the UDP socket.
@@ -273,12 +270,12 @@ public:
      * This method returns a new UDP message with sufficient header space reserved.
      *
      * @param[in]  aReserved  The number of header bytes to reserve after the UDP header.
-     * @param[in]  aPriority  The priority of the message.
+     * @param[in]  aSettings  The message settings.
      *
      * @returns A pointer to the message or NULL if no buffers are available.
      *
      */
-    Message *NewMessage(uint16_t aReserved, const otMessageSettings *aSettings = NULL);
+    Message *NewMessage(uint16_t aReserved, const Message::Settings &aSettings = Message::Settings::GetDefault());
 
     /**
      * This method sends an IPv6 datagram.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -476,11 +476,14 @@ otError MeshForwarder::HandleFrameRequest(Mac::TxFrame &aFrame)
         // there is a pending indirect supervision message in the send
         // queue for it. The message would be then converted to a
         // direct tx.
+
+        // Fall through
+#endif
+
+    default:
         mMessageNextOffset = mSendMessage->GetLength();
         error              = OT_ERROR_ABORT;
         ExitNow();
-
-#endif
     }
 
     aFrame.SetIsARetransmission(false);

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1258,9 +1258,9 @@ otError MeshForwarder::FrameToMessage(const uint8_t *     aFrame,
                                       const Mac::Address &aMacDest,
                                       Message *&          aMessage)
 {
-    otError error = OT_ERROR_NONE;
-    int     headerLength;
-    uint8_t priority;
+    otError           error = OT_ERROR_NONE;
+    int               headerLength;
+    Message::Priority priority;
 
     error = GetFramePriority(aFrame, aFrameLength, aMacSource, aMacDest, priority);
     SuccessOrExit(error);
@@ -1350,7 +1350,7 @@ otError MeshForwarder::GetFramePriority(const uint8_t *     aFrame,
                                         uint16_t            aFrameLength,
                                         const Mac::Address &aMacSource,
                                         const Mac::Address &aMacDest,
-                                        uint8_t &           aPriority)
+                                        Message::Priority & aPriority)
 {
     otError         error = OT_ERROR_NONE;
     Ip6::Header     ip6Header;

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -254,7 +254,7 @@ public:
      *                       Use Message::kSubTypeNone remove all messages for @p aChild.
      *
      */
-    void RemoveMessages(Child &aChild, uint8_t aSubType);
+    void RemoveMessages(Child &aChild, Message::SubType aSubType);
 
     /**
      * This method frees unicast/multicast MLE Data Responses from Send Message Queue if any.

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -109,7 +109,7 @@ public:
      * @returns The fragment priority value.
      *
      */
-    uint8_t GetPriority(void) const { return mPriority; }
+    Message::Priority GetPriority(void) const { return static_cast<Message::Priority>(mPriority); }
 
     /**
      * This method sets the fragment priority value.
@@ -117,7 +117,7 @@ public:
      * @param[in]  aPriority  The fragment priority value.
      *
      */
-    void SetPriority(uint8_t aPriority) { mPriority = aPriority; }
+    void SetPriority(Message::Priority aPriority) { mPriority = aPriority; }
 
     /**
      * This method returns the fragment priority entry's remaining lifetime.
@@ -271,7 +271,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND  No low priority messages available to evict.
      *
      */
-    otError EvictMessage(uint8_t aPriority);
+    otError EvictMessage(Message::Priority aPriority);
 
     /**
      * This method returns a reference to the send queue.
@@ -316,8 +316,7 @@ public:
 private:
     enum
     {
-        kStateUpdatePeriod  = 1000,                     ///< State update period in milliseconds.
-        kDefaultMsgPriority = Message::kPriorityNormal, ///< Default message priority.
+        kStateUpdatePeriod = 1000, ///< State update period in milliseconds.
 
         /**
          * The number of fragment priority entries.
@@ -402,7 +401,7 @@ private:
     void    UpdateFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader,
                                    uint16_t                aFragmentLength,
                                    uint16_t                aSrcRloc16,
-                                   uint8_t                 aPriority);
+                                   Message::Priority       aPriority);
     otError HandleDatagram(Message &aMessage, const otThreadLinkInfo &aLinkInfo, const Mac::Address &aMacSource);
     void    ClearReassemblyList(void);
     void    RemoveMessage(Message &aMessage);
@@ -424,13 +423,15 @@ private:
                              uint16_t            aFrameLength,
                              const Mac::Address &aMacSource,
                              const Mac::Address &aMacDest,
-                             uint8_t &           aPriority);
-    otError GetFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader, uint16_t aSrcRloc16, uint8_t &aPriority);
+                             Message::Priority & aPriority);
+    otError GetFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader,
+                                uint16_t                aSrcRloc16,
+                                Message::Priority &     aPriority);
     void    GetForwardFramePriority(const uint8_t *     aFrame,
                                     uint16_t            aFrameLength,
                                     const Mac::Address &aMeshSource,
                                     const Mac::Address &aMeshDest,
-                                    uint8_t &           aPriority);
+                                    Message::Priority & aPriority);
 
     FragmentPriorityEntry *FindFragmentPriorityEntry(uint16_t aTag, uint16_t aSrcRloc16);
     FragmentPriorityEntry *GetUnusedFragmentPriorityEntry(void);

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -249,7 +249,7 @@ exit:
     return error;
 }
 
-void MeshForwarder::RemoveMessages(Child &aChild, uint8_t aSubType)
+void MeshForwarder::RemoveMessages(Child &aChild, Message::SubType aSubType)
 {
     Mle::MleRouter &mle = Get<Mle::MleRouter>();
     Message *       nextMessage;

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -181,7 +181,7 @@ void MeshForwarder::HandleResolved(const Ip6::Address &aEid, otError aError)
     }
 }
 
-otError MeshForwarder::EvictMessage(uint8_t aPriority)
+otError MeshForwarder::EvictMessage(Message::Priority aPriority)
 {
     otError        error    = OT_ERROR_NOT_FOUND;
     PriorityQueue *queues[] = {&mResolvingQueue, &mSendQueue};
@@ -192,7 +192,8 @@ otError MeshForwarder::EvictMessage(uint8_t aPriority)
     {
         for (uint8_t priority = 0; priority < aPriority; priority++)
         {
-            for (Message *message = queues[index]->GetHeadForPriority(priority); message; message = message->GetNext())
+            for (Message *message = queues[index]->GetHeadForPriority(static_cast<Message::Priority>(priority));
+                 message; message = message->GetNext())
             {
                 if (message->GetPriority() != priority)
                 {
@@ -205,7 +206,7 @@ otError MeshForwarder::EvictMessage(uint8_t aPriority)
                 }
 
                 evict     = message;
-                aPriority = priority;
+                aPriority = static_cast<Message::Priority>(priority);
                 break;
             }
         }
@@ -648,8 +649,8 @@ void MeshForwarder::HandleMesh(uint8_t *               aFrame,
     }
     else if (meshHeader.GetHopsLeft() > 0)
     {
-        uint8_t  priority = kDefaultMsgPriority;
-        uint16_t offset   = 0;
+        Message::Priority priority = Message::kPriorityNormal;
+        uint16_t          offset   = 0;
 
         Get<Mle::MleRouter>().ResolveRoutingLoops(aMacSource.GetShort(), meshDest.GetShort());
 
@@ -755,7 +756,7 @@ bool MeshForwarder::UpdateFragmentLifetime(void)
 void MeshForwarder::UpdateFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader,
                                            uint16_t                aFragmentLength,
                                            uint16_t                aSrcRloc16,
-                                           uint8_t                 aPriority)
+                                           Message::Priority       aPriority)
 {
     FragmentPriorityEntry *entry;
 
@@ -828,7 +829,7 @@ exit:
 
 otError MeshForwarder::GetFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader,
                                            uint16_t                aSrcRloc16,
-                                           uint8_t &               aPriority)
+                                           Message::Priority &     aPriority)
 {
     otError                error = OT_ERROR_NONE;
     FragmentPriorityEntry *entry;
@@ -845,7 +846,7 @@ void MeshForwarder::GetForwardFramePriority(const uint8_t *     aFrame,
                                             uint16_t            aFrameLength,
                                             const Mac::Address &aMeshSource,
                                             const Mac::Address &aMeshDest,
-                                            uint8_t &           aPriority)
+                                            Message::Priority & aPriority)
 {
     otError                error      = OT_ERROR_NONE;
     bool                   isFragment = false;

--- a/src/core/thread/mesh_forwarder_mtd.cpp
+++ b/src/core/thread/mesh_forwarder_mtd.cpp
@@ -49,14 +49,14 @@ otError MeshForwarder::SendMessage(Message &aMessage)
     return OT_ERROR_NONE;
 }
 
-otError MeshForwarder::EvictMessage(uint8_t aPriority)
+otError MeshForwarder::EvictMessage(Message::Priority aPriority)
 {
     otError  error = OT_ERROR_NOT_FOUND;
     Message *message;
 
     VerifyOrExit((message = mSendQueue.GetTail()) != NULL, OT_NOOP);
 
-    if (message->GetPriority() < aPriority)
+    if (message->GetPriority() < static_cast<uint8_t>(aPriority))
     {
         RemoveMessage(*message);
         ExitNow(error = OT_ERROR_NONE);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1092,9 +1092,9 @@ const LeaderData &Mle::GetLeaderData(void)
 Message *Mle::NewMleMessage(void)
 {
     Message *         message;
-    otMessageSettings settings = {false, static_cast<otMessagePriority>(kMleMessagePriority)};
+    Message::Settings settings(Message::kNoLinkSecurity, Message::kPriorityNet);
 
-    message = mSocket.NewMessage(0, &settings);
+    message = mSocket.NewMessage(0, settings);
     VerifyOrExit(message != NULL, OT_NOOP);
 
     message->SetSubType(Message::kSubTypeMleGeneral);

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1649,8 +1649,7 @@ protected:
 private:
     enum
     {
-        kMleMessagePriority = Message::kPriorityNet,
-        kMleHopLimit        = 255,
+        kMleHopLimit = 255,
 
         // Parameters related to "periodic parent search" feature (CONFIG_ENABLE_PERIODIC_PARENT_SEARCH).
         // All timer intervals are converted to milliseconds.

--- a/tests/unit/test_priority_queue.cpp
+++ b/tests/unit/test_priority_queue.cpp
@@ -83,12 +83,13 @@ void VerifyPriorityQueueContent(ot::PriorityQueue &aPriorityQueue, int aExpected
                 {
                     // Check the `GetHeadForPriority` is NULL if there are no expected message for this priority level.
                     VerifyOrQuit(
-                        aPriorityQueue.GetHeadForPriority(static_cast<uint8_t>(curPriority)) == NULL,
+                        aPriorityQueue.GetHeadForPriority(static_cast<ot::Message::Priority>(curPriority)) == NULL,
                         "PriorityQueue::GetHeadForPriority is non-NULL when no expected msg for this priority.");
                 }
 
                 // Check the `GetHeadForPriority`.
-                VerifyOrQuit(aPriorityQueue.GetHeadForPriority(static_cast<uint8_t>(curPriority)) == msgArg,
+                VerifyOrQuit(aPriorityQueue.GetHeadForPriority(static_cast<ot::Message::Priority>(curPriority)) ==
+                                 msgArg,
                              "PriorityQueue::GetHeadForPriority failed.");
             }
 
@@ -103,7 +104,7 @@ void VerifyPriorityQueueContent(ot::PriorityQueue &aPriorityQueue, int aExpected
         // Check the `GetHeadForPriority` is NULL if there are no expected message for any remaining priority level.
         for (curPriority--; curPriority >= 0; curPriority--)
         {
-            VerifyOrQuit(aPriorityQueue.GetHeadForPriority(static_cast<uint8_t>(curPriority)) == NULL,
+            VerifyOrQuit(aPriorityQueue.GetHeadForPriority(static_cast<ot::Message::Priority>(curPriority)) == NULL,
                          "PriorityQueue::GetHeadForPriority is non-NULL when no expected msg for this priority.");
         }
     }
@@ -172,10 +173,6 @@ void TestPriorityQueue(void)
         VerifyOrQuit(msgLow[i] != NULL, "Message::New failed");
     }
 
-    // Check the failure case for `New()` for invalid argument.
-    VerifyOrQuit(messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kNumPriorities) == NULL,
-                 "Message::New() with out of range value did not fail as expected.");
-
     // Use the function "SetPriority()" to allocate messages with different priorities
     for (int i = kNumNewPriorityTestMessages; i < kNumTestMessages; i++)
     {
@@ -192,10 +189,6 @@ void TestPriorityQueue(void)
         VerifyOrQuit(msgLow[i] != NULL, "Message::New failed");
         SuccessOrQuit(msgLow[i]->SetPriority(ot::Message::kPriorityLow), "Message:SetPriority failed");
     }
-
-    // Check the failure case for `SetPriority()` for invalid argument.
-    VerifyOrQuit(msgNet[2]->SetPriority(ot::Message::kNumPriorities) == OT_ERROR_INVALID_ARGS,
-                 "Message::SetPriority() with out of range value did not fail as expected.");
 
     // Check the `GetPriority()`
     for (int i = 0; i < kNumTestMessages; i++)


### PR DESCRIPTION
This PR contains a bunch of smaller changes/enhancements in `message` modules:
- **[message] adding Message::Settings** 
    The `Message::Settings` mirrors `otMessageSettings` and is used when allocating a new `Message`.
- **[message] add Message::Priority enumeration type** 
- **[message] add Message::SubType** 
- **[message] add Message::Type** 
- **[message] add helper methods to get Message Metadata** 
    This commit renames the message metadata to `MessageMetadata` and adds helper method `Buffer::GetMetadata()` to get the metadata.
- **[message] update Buffer and MessagePool to use LinkedList methods** 
- **[message] update method decelerations, add documentation** 