### PR TITLE
[meshcop] do not send MGMT_*_SET.req while one is outstanding

### DIFF
--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -278,21 +278,30 @@ private:
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleUdpReceive(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    otError Register(void);
-    void    SendGetResponse(const Coap::Message &   aRequest,
-                            const Ip6::MessageInfo &aMessageInfo,
-                            uint8_t *               aTlvs,
-                            uint8_t                 aLength) const;
+    static void HandleCoapResponse(void *               aContext,
+                                   otMessage *          aMessage,
+                                   const otMessageInfo *aMessageInfo,
+                                   otError              aError);
+    void        HandleCoapResponse(void);
+
+    void SendSet(void);
+    void SendGetResponse(const Coap::Message &   aRequest,
+                         const Ip6::MessageInfo &aMessageInfo,
+                         uint8_t *               aTlvs,
+                         uint8_t                 aLength) const;
 
     enum
     {
-        kMaxDatasetTlvs = 16, // Maximum number of TLVs in an `otOperationalDataset`.
+        kMaxDatasetTlvs = 16,   // Maximum number of TLVs in an `otOperationalDataset`.
+        kDelayNoBufs    = 1000, // Milliseconds
     };
 
     TimerMilli mTimer;
 
     const char *mUriGet;
     const char *mUriSet;
+
+    bool mCoapPending : 1;
 
 #if OPENTHREAD_FTD
 public:


### PR DESCRIPTION
This commit helps ensure the following:

- At most one MGMT_ACTIVE_SET.req message is outstanding.

- At most one MGMT_PENDING_SET.req message is outstanding.