### PR TITLE
[thci] fix address filter code issues

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1329,7 +1329,6 @@ class OpenThread(IThci):
             self.setMLPrefix(self.meshLocalPrefix)
             self.setPSKc(self.pskc)
             self.setActiveTimestamp(self.activetimestamp)
-            self.clearAllowList()
         except Exception as e:
             ModuleHelper.WriteIntoDebugLogger('setDefaultValue() Error: ' +
                                               str(e))

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1329,6 +1329,7 @@ class OpenThread(IThci):
             self.setMLPrefix(self.meshLocalPrefix)
             self.setPSKc(self.pskc)
             self.setActiveTimestamp(self.activetimestamp)
+            self.clearAllowList()
         except Exception as e:
             ModuleHelper.WriteIntoDebugLogger('setDefaultValue() Error: ' +
                                               str(e))

--- a/tools/harness-thci/OpenThread_WpanCtl.py
+++ b/tools/harness-thci/OpenThread_WpanCtl.py
@@ -1579,7 +1579,6 @@ class OpenThread_WpanCtl(IThci):
             self.setMLPrefix(self.meshLocalPrefix)
             self.setPSKc(self.pskc)
             self.setActiveTimestamp(self.activetimestamp)
-            self.clearAllowList()
         except Exception as e:
             ModuleHelper.WriteIntoDebugLogger('setDefaultValue() Error: ' +
                                               str(e))

--- a/tools/harness-thci/OpenThread_WpanCtl.py
+++ b/tools/harness-thci/OpenThread_WpanCtl.py
@@ -1197,7 +1197,7 @@ class OpenThread_WpanCtl(IThci):
             if self.__setAddressfilterMode('disable'):
                 # clear ops
                 for addr in self._addressfilterSet:
-                    cmd = self.wpan_cmd_prefix + 'remove MAC:Blocklist:Entries ' + addr
+                    cmd = self.wpan_cmd_prefix + 'remove MAC:Blacklist:Entries ' + addr
                     self.__sendCommand(cmd)
 
                 self._addressfilterSet.clear()

--- a/tools/harness-thci/OpenThread_WpanCtl.py
+++ b/tools/harness-thci/OpenThread_WpanCtl.py
@@ -418,11 +418,14 @@ class OpenThread_WpanCtl(IThci):
         print('call setAddressFilterMode() %s' % mode)
         try:
             if mode in ('whitelist', 'blacklist'):
-                cmd = self.wpan_cmd_prefix + 'setprop MAC:' + mode.capitalize() + ':Enabled 1'
+                cmd = self.wpan_cmd_prefix + 'setprop MAC:' + mode.capitalize(
+                ) + ':Enabled 1'
             elif mode == 'disable':
                 if self._addressfilterMode != 'disable':
-                    assert self._addressfilterMode in ('whitelist', 'blacklist'), self._addressfilterMode
-                    cmd = self.wpan_cmd_prefix + 'setprop MAC:' + self._addressfilterMode.capitalize() + ':Enabled 0'
+                    assert self._addressfilterMode in (
+                        'whitelist', 'blacklist'), self._addressfilterMode
+                    cmd = self.wpan_cmd_prefix + 'setprop MAC:' + self._addressfilterMode.capitalize(
+                    ) + ':Enabled 0'
                 else:
                     return True
             else:


### PR DESCRIPTION
This PR fixes existing issues in address filters.

- Fix misuse of address filter modes
  - `disabled` should be `disable`
  - `Whitelist` should be `whitelist`
  - `Blacklist` should be `blacklist`
- Fix errors in removing `macfilter` entries

**Impact on 1.1 certification:**
This PR does not impact 1.1 certification because only `OpenThread_WpanCtl.py` is changed. In 1.1 certification, all **golden** devices are controlled by `OpenThread.py`. `OpenThread_WpanCtl.py` is used to control OTBR DUT, and `mac filter` feature is not useful for a DUT. @librasungirl @jwhui 