### PR TITLE
[continuous-integration] remove `git clean` in scripts

### DIFF
--- a/script/check-arm-build-cmake
+++ b/script/check-arm-build-cmake
@@ -29,14 +29,16 @@
 
 set -euxo pipefail
 
+readonly OT_SRCDIR="$(pwd)"
+readonly OT_BUILDDIR="$OT_SRCDIR/build"
+
 readonly OT_COMMON_OPTIONS=(
     "-DOT_COMPILE_WARNING_AS_ERROR=ON"
 )
 
 reset_source()
 {
-    git checkout -- .
-    git clean -xfd
+    rm -rf "$OT_BUILDDIR"
 }
 
 build_cc1352()
@@ -56,11 +58,11 @@ build_cc1352()
     )
 
     reset_source
-    mkdir build
-    cd build
+    mkdir -p "$OT_BUILDDIR"
+    cd "$OT_BUILDDIR"
     cmake -GNinja "${options[@]}" ..
     ninja
-    cd ..
+    cd "$OT_SRCDIR"
 }
 
 build_cc2538()
@@ -73,11 +75,11 @@ build_cc2538()
     )
 
     reset_source
-    mkdir build
-    cd build
+    mkdir -p "$OT_BUILDDIR"
+    cd "$OT_BUILDDIR"
     cmake -GNinja "${options[@]}" ..
     ninja
-    cd ..
+    cd "$OT_SRCDIR"
 }
 
 build_cc2650()
@@ -91,11 +93,11 @@ build_cc2650()
     )
 
     reset_source
-    mkdir build
-    cd build
+    mkdir -p "$OT_BUILDDIR"
+    cd "$OT_BUILDDIR"
     cmake -GNinja "${options[@]}" ..
     ninja ot-cli-mtd ot-ncp-mtd
-    cd ..
+    cd "$OT_SRCDIR"
 }
 
 build_cc2652()
@@ -115,11 +117,11 @@ build_cc2652()
     )
 
     reset_source
-    mkdir build
-    cd build
+    mkdir -p "$OT_BUILDDIR"
+    cd "$OT_BUILDDIR"
     cmake -GNinja "${options[@]}" ..
     ninja
-    cd ..
+    cd "$OT_SRCDIR"
 }
 
 build_kw41z()
@@ -139,11 +141,11 @@ build_kw41z()
     )
 
     reset_source
-    mkdir build
-    cd build
+    mkdir -p "$OT_BUILDDIR"
+    cd "$OT_BUILDDIR"
     cmake -GNinja "${options[@]}" ..
     ninja
-    cd ..
+    cd "$OT_SRCDIR"
 }
 
 build_qpg6095()
@@ -163,11 +165,11 @@ build_qpg6095()
     )
 
     reset_source
-    mkdir build
-    cd build
+    mkdir -p "$OT_BUILDDIR"
+    cd "$OT_BUILDDIR"
     cmake -GNinja "${options[@]}" ..
     ninja
-    cd ..
+    cd "$OT_SRCDIR"
 }
 
 build_samr21()
@@ -190,11 +192,11 @@ build_samr21()
     wget http://ww1.microchip.com/downloads/en/DeviceDoc/asf-standalone-archive-3.45.0.85.zip || die
     unzip -qq asf-standalone-archive-3.45.0.85.zip || die
     mv xdk-asf-3.45.0 third_party/microchip/asf || die
-    mkdir build
-    cd build
+    mkdir -p "$OT_BUILDDIR"
+    cd "$OT_BUILDDIR"
     cmake -GNinja "${options[@]}" ..
     ninja
-    cd ..
+    cd "$OT_SRCDIR"
 }
 
 main()

--- a/script/check-posix-build-cmake
+++ b/script/check-posix-build-cmake
@@ -29,13 +29,12 @@
 
 set -euxo pipefail
 
-readonly OT_BUILDDIR="$(pwd)/build"
 readonly OT_SRCDIR="$(pwd)"
+readonly OT_BUILDDIR="$OT_SRCDIR/build"
 
 reset_source()
 {
-    git checkout -- .
-    git clean -xfd
+    rm -rf "$OT_BUILDDIR"
 }
 
 build()

--- a/script/check-simulation-build-cmake
+++ b/script/check-simulation-build-cmake
@@ -29,6 +29,9 @@
 
 set -euxo pipefail
 
+readonly OT_SRCDIR="$(pwd)"
+readonly OT_BUILDDIR="$OT_SRCDIR/build"
+
 readonly OT_COMMON_OPTIONS=(
     "-DOT_COMPILE_WARNING_AS_ERROR=on"
     "-DOT_PLATFORM=simulation"
@@ -36,8 +39,7 @@ readonly OT_COMMON_OPTIONS=(
 
 reset_source()
 {
-    git checkout -- .
-    git clean -xfd
+    rm -rf "$OT_BUILDDIR"
 }
 
 build_all_features()
@@ -71,21 +73,20 @@ build_all_features()
 
     reset_source
 
-    git checkout -- .
-    git clean -xfd
-    mkdir build && cd build
+    mkdir -p "$OT_BUILDDIR"
+    cd "$OT_BUILDDIR"
     cmake -GNinja "${options[@]}" ..
     ninja
-    cd ..
+    cd "$OT_SRCDIR"
 }
 
 build_toranj()
 {
     reset_source
-    ./tests/toranj/build.sh cmake
+    top_builddir="$OT_BUILDDIR" ./tests/toranj/build.sh cmake
 
     reset_source
-    ./tests/toranj/build.sh cmake-posix
+    top_builddir="$OT_BUILDDIR" ./tests/toranj/build.sh cmake-posix
 }
 
 main()

--- a/tests/toranj/build.sh
+++ b/tests/toranj/build.sh
@@ -150,8 +150,10 @@ case ${build_config} in
         echo "===================================================================================================="
         echo "Building OpenThread (NCP/CLI for FTD/MTD/RCP mode) with simulation platform using cmake"
         echo "===================================================================================================="
+        cd "${top_builddir}" || die "cd failed"
         cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=on \
-            -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h . || die
+            -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
+            "${top_srcdir}" || die
         ninja || die
         ;;
 
@@ -159,8 +161,10 @@ case ${build_config} in
         echo "===================================================================================================="
         echo "Building OpenThread POSIX host platform using cmake"
         echo "===================================================================================================="
+        cd "${top_builddir}" || die "cd failed"
         cmake -GNinja -DOT_PLATFORM=posix -DOT_COMPILE_WARNING_AS_ERROR=on \
-            -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-posix.h . || die
+            -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-posix.h \
+            "${top_srcdir}" || die
         ninja || die
         ;;
 


### PR DESCRIPTION
This removes the use of `git clean` in scripts to prevent accidental loss of work.