### PR TITLE
[mac-frame] fix problems to generate enh ack

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1165,16 +1165,20 @@ otError TxFrame::GenerateEnhAck(const RxFrame &aFrame, bool aIsFramePending, con
         SetDstAddr(address);
     }
 
-    // Set security header
-    SuccessOrExit(error = aFrame.GetSecurityControlField(securityControlField));
-    SuccessOrExit(error = aFrame.GetFrameCounter(frameCounter));
-    SuccessOrExit(error = aFrame.GetKeyId(keyId));
-
     SetPsduLength(kMaxPsduSize); // At this time the length of ACK hasn't been determined, set it to
                                  // `kMaxPsduSize` to call methods that check frame length.
-    SetSecurityControlField(securityControlField);
-    SetFrameCounter(frameCounter);
-    SetKeyId(keyId);
+
+    // Set security header
+    if (aFrame.GetSecurityEnabled())
+    {
+        SuccessOrExit(error = aFrame.GetSecurityControlField(securityControlField));
+        SuccessOrExit(error = aFrame.GetFrameCounter(frameCounter));
+        SuccessOrExit(error = aFrame.GetKeyId(keyId));
+
+        SetSecurityControlField(securityControlField);
+        SetFrameCounter(frameCounter);
+        SetKeyId(keyId);
+    }
 
     // Set header IE
     if (aIeLength > 0)
@@ -1186,7 +1190,7 @@ otError TxFrame::GenerateEnhAck(const RxFrame &aFrame, bool aIsFramePending, con
     // Set frame length
     footerLength = GetFooterLength();
     OT_ASSERT(footerLength != kInvalidIndex);
-    mLength = FindHeaderIeIndex() + aIeLength + GetFooterLength();
+    mLength = SkipSecurityHeaderIndex() + aIeLength + GetFooterLength();
 
 exit:
     return error;

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -574,7 +574,7 @@ void TestMacFrameAckGeneration(void)
     uint8_t     ie_data[6] = {0x04, 0x0d, 0x21, 0x0c, 0x35, 0x0c};
     Mac::CslIe *csl;
 
-    ackFrame.GenerateEnhAck(receivedFrame, false, ie_data, sizeof(ie_data));
+    IgnoreError(ackFrame.GenerateEnhAck(receivedFrame, false, ie_data, sizeof(ie_data)));
     csl = reinterpret_cast<Mac::CslIe *>(ackFrame.GetHeaderIe(Mac::Frame::kHeaderIeCsl) + sizeof(Mac::HeaderIe));
     VerifyOrQuit(ackFrame.mLength == 23,
                  "Mac::Frame::GenerateEnhAck() failed, length incorrect\n"); // 23 is the length of the correct ack
@@ -595,9 +595,11 @@ void TestMacFrameAckGeneration(void)
     VerifyOrQuit(csl->GetPeriod() == 3125 && csl->GetPhase() == 3105,
                  "Mac::Frame::GenerateEnhAck failed, CslIe incorrect\n");
 
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     ackFrame.SetCslIe(123, 456);
     csl = reinterpret_cast<Mac::CslIe *>(ackFrame.GetHeaderIe(Mac::Frame::kHeaderIeCsl) + sizeof(Mac::HeaderIe));
     VerifyOrQuit(csl->GetPeriod() == 123 && csl->GetPhase() == 456, "Mac::Frame::SetCslIe failed, CslIe incorrect\n");
+#endif
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 }
 


### PR DESCRIPTION
This PR fixes small problems in #4884 
1. I used to assume security is always enabled in enhanced ack, however that's not always the case. So add security part only when it's required.
2. `FindHeaderIeIndex` would return `kInvalidIndex` when IE is not present. It's possible that no IE is in an enh ack, So I use `SkipSecurityHeaderIndex` instead.