### PR TITLE
[network-diagnostics] misc. enhancements/fixes

### DIFF
--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -796,11 +796,9 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
                                           Iterator &           aIterator,
                                           otNetworkDiagTlv &   aNetworkDiagTlv)
 {
-    otError              error  = OT_ERROR_PARSE;
-    uint16_t             offset = aMessage.GetOffset();
+    otError              error  = OT_ERROR_NONE;
+    uint16_t             offset = aMessage.GetOffset() + aIterator;
     NetworkDiagnosticTlv tlv;
-
-    offset += aIterator;
 
     while (true)
     {
@@ -815,12 +813,11 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             ExtMacAddressTlv extMacAddr;
 
             tlvTotalLength = sizeof(extMacAddr);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &extMacAddr) == tlvTotalLength, OT_NOOP);
-            VerifyOrExit(extMacAddr.IsValid(), OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &extMacAddr) == tlvTotalLength, error = OT_ERROR_PARSE);
+            VerifyOrExit(extMacAddr.IsValid(), error = OT_ERROR_PARSE);
 
             aNetworkDiagTlv.mData.mExtAddress = *extMacAddr.GetMacAddr();
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kAddress16:
@@ -828,12 +825,11 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             Address16Tlv addr16;
 
             tlvTotalLength = sizeof(addr16);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &addr16) == tlvTotalLength, OT_NOOP);
-            VerifyOrExit(addr16.IsValid(), OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &addr16) == tlvTotalLength, error = OT_ERROR_PARSE);
+            VerifyOrExit(addr16.IsValid(), error = OT_ERROR_PARSE);
 
             aNetworkDiagTlv.mData.mAddr16 = addr16.GetRloc16();
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kMode:
@@ -841,12 +837,11 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             ModeTlv linkMode;
 
             tlvTotalLength = sizeof(linkMode);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &linkMode) == tlvTotalLength, OT_NOOP);
-            VerifyOrExit(linkMode.IsValid(), OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &linkMode) == tlvTotalLength, error = OT_ERROR_PARSE);
+            VerifyOrExit(linkMode.IsValid(), error = OT_ERROR_PARSE);
 
             ParseMode(linkMode.GetMode(), aNetworkDiagTlv.mData.mMode);
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kTimeout:
@@ -854,12 +849,11 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             TimeoutTlv timeout;
 
             tlvTotalLength = sizeof(timeout);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &timeout) == tlvTotalLength, OT_NOOP);
-            VerifyOrExit(timeout.IsValid(), OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &timeout) == tlvTotalLength, error = OT_ERROR_PARSE);
+            VerifyOrExit(timeout.IsValid(), error = OT_ERROR_PARSE);
 
             aNetworkDiagTlv.mData.mTimeout = timeout.GetTimeout();
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kConnectivity:
@@ -867,12 +861,12 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             ConnectivityTlv connectivity;
 
             tlvTotalLength = sizeof(connectivity);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &connectivity) == tlvTotalLength, OT_NOOP);
-            VerifyOrExit(connectivity.IsValid(), OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &connectivity) == tlvTotalLength,
+                         error = OT_ERROR_PARSE);
+            VerifyOrExit(connectivity.IsValid(), error = OT_ERROR_PARSE);
 
             ParseConnectivity(connectivity, aNetworkDiagTlv.mData.mConnectivity);
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kRoute:
@@ -880,13 +874,12 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             RouteTlv route;
 
             tlvTotalLength = sizeof(tlv) + tlv.GetLength();
-            VerifyOrExit(tlvTotalLength <= sizeof(route), OT_NOOP);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &route) == tlvTotalLength, OT_NOOP);
-            VerifyOrExit(route.IsValid(), OT_NOOP);
+            VerifyOrExit(tlvTotalLength <= sizeof(route), error = OT_ERROR_PARSE);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &route) == tlvTotalLength, error = OT_ERROR_PARSE);
+            VerifyOrExit(route.IsValid(), error = OT_ERROR_PARSE);
 
             ParseRoute(route, aNetworkDiagTlv.mData.mRoute);
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kLeaderData:
@@ -894,12 +887,11 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             LeaderDataTlv leaderData;
 
             tlvTotalLength = sizeof(leaderData);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &leaderData) == tlvTotalLength, OT_NOOP);
-            VerifyOrExit(leaderData.IsValid(), OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &leaderData) == tlvTotalLength, error = OT_ERROR_PARSE);
+            VerifyOrExit(leaderData.IsValid(), error = OT_ERROR_PARSE);
 
             ParseLeaderData(leaderData, aNetworkDiagTlv.mData.mLeaderData);
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kNetworkData:
@@ -907,30 +899,30 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             NetworkDataTlv networkData;
 
             tlvTotalLength = sizeof(tlv) + tlv.GetLength();
-            VerifyOrExit(tlvTotalLength <= sizeof(networkData), OT_NOOP);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &networkData) == tlvTotalLength, OT_NOOP);
-            VerifyOrExit(networkData.IsValid(), OT_NOOP);
-            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mNetworkData.m8) >= networkData.GetLength(), OT_NOOP);
+            VerifyOrExit(tlvTotalLength <= sizeof(networkData), error = OT_ERROR_PARSE);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &networkData) == tlvTotalLength, error = OT_ERROR_PARSE);
+            VerifyOrExit(networkData.IsValid(), error = OT_ERROR_PARSE);
+            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mNetworkData.m8) >= networkData.GetLength(),
+                         error = OT_ERROR_PARSE);
 
             memcpy(aNetworkDiagTlv.mData.mNetworkData.m8, networkData.GetNetworkData(), networkData.GetLength());
             aNetworkDiagTlv.mData.mNetworkData.mCount = networkData.GetLength();
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kIp6AddressList:
         {
             Ip6AddressListTlv &ip6AddrList = static_cast<Ip6AddressListTlv &>(tlv);
 
-            VerifyOrExit(ip6AddrList.IsValid(), OT_NOOP);
-            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mIp6AddrList.mList) >= ip6AddrList.GetLength(), OT_NOOP);
+            VerifyOrExit(ip6AddrList.IsValid(), error = OT_ERROR_PARSE);
+            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mIp6AddrList.mList) >= ip6AddrList.GetLength(),
+                         error = OT_ERROR_PARSE);
             VerifyOrExit(aMessage.Read(offset + sizeof(ip6AddrList), ip6AddrList.GetLength(),
                                        aNetworkDiagTlv.mData.mIp6AddrList.mList) == ip6AddrList.GetLength(),
-                         OT_NOOP);
+                         error = OT_ERROR_PARSE);
 
             aNetworkDiagTlv.mData.mIp6AddrList.mCount = ip6AddrList.GetLength() / OT_IP6_ADDRESS_SIZE;
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kMacCounters:
@@ -938,12 +930,11 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             MacCountersTlv macCounters;
 
             tlvTotalLength = sizeof(MacCountersTlv);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &macCounters) == tlvTotalLength, OT_NOOP);
-            VerifyOrExit(macCounters.IsValid(), OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &macCounters) == tlvTotalLength, error = OT_ERROR_PARSE);
+            VerifyOrExit(macCounters.IsValid(), error = OT_ERROR_PARSE);
 
             ParseMacCounters(macCounters, aNetworkDiagTlv.mData.mMacCounters);
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kBatteryLevel:
@@ -951,12 +942,12 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             BatteryLevelTlv batteryLevel;
 
             tlvTotalLength = sizeof(BatteryLevelTlv);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &batteryLevel) == tlvTotalLength, OT_NOOP);
-            VerifyOrExit(batteryLevel.IsValid(), OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &batteryLevel) == tlvTotalLength,
+                         error = OT_ERROR_PARSE);
+            VerifyOrExit(batteryLevel.IsValid(), error = OT_ERROR_PARSE);
 
             aNetworkDiagTlv.mData.mBatteryLevel = batteryLevel.GetBatteryLevel();
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kSupplyVoltage:
@@ -964,43 +955,42 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             SupplyVoltageTlv supplyVoltage;
 
             tlvTotalLength = sizeof(SupplyVoltageTlv);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &supplyVoltage) == tlvTotalLength, OT_NOOP);
-            VerifyOrExit(supplyVoltage.IsValid(), OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &supplyVoltage) == tlvTotalLength,
+                         error = OT_ERROR_PARSE);
+            VerifyOrExit(supplyVoltage.IsValid(), error = OT_ERROR_PARSE);
 
             aNetworkDiagTlv.mData.mSupplyVoltage = supplyVoltage.GetSupplyVoltage();
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kChildTable:
         {
             ChildTableTlv &childTable = static_cast<ChildTableTlv &>(tlv);
 
-            VerifyOrExit(childTable.IsValid(), OT_NOOP);
+            VerifyOrExit(childTable.IsValid(), error = OT_ERROR_PARSE);
             VerifyOrExit(childTable.GetNumEntries() <= OT_ARRAY_LENGTH(aNetworkDiagTlv.mData.mChildTable.mTable),
-                         OT_NOOP);
+                         error = OT_ERROR_PARSE);
 
             for (uint8_t i = 0; i < childTable.GetNumEntries(); ++i)
             {
                 ChildTableEntry childEntry;
-                VerifyOrExit(childTable.ReadEntry(childEntry, aMessage, offset, i) == OT_ERROR_NONE, OT_NOOP);
+                VerifyOrExit(childTable.ReadEntry(childEntry, aMessage, offset, i) == OT_ERROR_NONE,
+                             error = OT_ERROR_PARSE);
                 ParseChildEntry(childEntry, aNetworkDiagTlv.mData.mChildTable.mTable[i]);
             }
             aNetworkDiagTlv.mData.mChildTable.mCount = childTable.GetNumEntries();
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kChannelPages:
         {
-            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mChannelPages.m8) >= tlv.GetLength(), OT_NOOP);
+            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mChannelPages.m8) >= tlv.GetLength(), error = OT_ERROR_PARSE);
             VerifyOrExit(aMessage.Read(offset + sizeof(tlv), tlv.GetLength(), aNetworkDiagTlv.mData.mChannelPages.m8) ==
                              tlv.GetLength(),
-                         OT_NOOP);
+                         error = OT_ERROR_PARSE);
 
             aNetworkDiagTlv.mData.mChannelPages.mCount = tlv.GetLength();
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
+            break;
         }
 
         case NetworkDiagnosticTlv::kMaxChildTimeout:
@@ -1008,29 +998,28 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             MaxChildTimeoutTlv maxChildTimeout;
 
             tlvTotalLength = sizeof(maxChildTimeout);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &maxChildTimeout) == tlvTotalLength, OT_NOOP);
-            VerifyOrExit(maxChildTimeout.IsValid(), OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &maxChildTimeout) == tlvTotalLength,
+                         error = OT_ERROR_PARSE);
+            VerifyOrExit(maxChildTimeout.IsValid(), error = OT_ERROR_PARSE);
 
             aNetworkDiagTlv.mData.mMaxChildTimeout = maxChildTimeout.GetTimeout();
-            ExitNow(error = OT_ERROR_NONE);
-            OT_UNREACHABLE_CODE(break);
-        }
-
-        default:
-            // Ignore unrecognized Network Diagnostic TLV silently.
             break;
         }
 
-        // The actual TLV size may exceeds tlvTotalLength.
-        offset += tlv.GetSize();
+        default:
+            // Ignore unrecognized Network Diagnostic TLV silently and
+            // continue to top of the `while(true)` loop.
+            offset += tlv.GetSize();
+            continue;
+        }
+
+        // Exit if a TLV is recognized and parsed successfully.
+        aNetworkDiagTlv.mType = tlv.GetType();
+        aIterator             = static_cast<uint16_t>(offset - aMessage.GetOffset() + tlv.GetSize());
+        ExitNow();
     }
 
 exit:
-    if (error == OT_ERROR_NONE)
-    {
-        aNetworkDiagTlv.mType = tlv.GetType();
-        aIterator             = static_cast<uint16_t>(offset - aMessage.GetOffset() + tlv.GetSize());
-    }
     return error;
 }
 

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -645,23 +645,21 @@ void NetworkDiagnostic::HandleDiagnosticReset(Coap::Message &aMessage, const Ip6
 {
     uint16_t             offset = 0;
     uint8_t              type;
-    NetworkDiagnosticTlv networkDiagnosticTlv;
+    NetworkDiagnosticTlv tlv;
 
     otLogInfoNetDiag("Received diagnostic reset request");
 
     VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
-    VerifyOrExit((aMessage.Read(aMessage.GetOffset(), sizeof(NetworkDiagnosticTlv), &networkDiagnosticTlv) ==
-                  sizeof(NetworkDiagnosticTlv)),
-                 OT_NOOP);
+    VerifyOrExit((aMessage.Read(aMessage.GetOffset(), sizeof(tlv), &tlv) == sizeof(tlv)), OT_NOOP);
 
-    VerifyOrExit(networkDiagnosticTlv.GetType() == NetworkDiagnosticTlv::kTypeList, OT_NOOP);
+    VerifyOrExit(tlv.GetType() == NetworkDiagnosticTlv::kTypeList, OT_NOOP);
 
     offset = aMessage.GetOffset() + sizeof(NetworkDiagnosticTlv);
 
-    for (uint8_t i = 0; i < networkDiagnosticTlv.GetLength(); i++)
+    for (uint8_t i = 0; i < tlv.GetLength(); i++)
     {
-        VerifyOrExit(aMessage.Read(offset, sizeof(type), &type) == sizeof(type), OT_NOOP);
+        VerifyOrExit(aMessage.Read(offset + i, sizeof(type), &type) == sizeof(type), OT_NOOP);
 
         switch (type)
         {

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -452,7 +452,8 @@ otError NetworkDiagnostic::FillRequestedTlvs(const Message &       aRequest,
 #endif
 
         default:
-            ExitNow(error = OT_ERROR_PARSE);
+            // Skip unrecognized TLV type.
+            break;
         }
 
         offset += sizeof(type);

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -792,9 +792,9 @@ static inline void ParseChildEntry(const ChildTableEntry &aChildTableTlvEntry, o
     ParseMode(aChildTableTlvEntry.GetMode(), aChildEntry.mMode);
 }
 
-otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &  aMessage,
-                                          otNetworkDiagIterator &aIterator,
-                                          otNetworkDiagTlv &     aNetworkDiagTlv)
+otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
+                                          Iterator &           aIterator,
+                                          otNetworkDiagTlv &   aNetworkDiagTlv)
 {
     otError              error  = OT_ERROR_PARSE;
     uint16_t             offset = aMessage.GetOffset();

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -792,13 +792,12 @@ static inline void ParseChildEntry(const ChildTableEntry &aChildTableTlvEntry, o
     ParseMode(aChildTableTlvEntry.GetMode(), aChildEntry.mMode);
 }
 
-otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
+otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &  aMessage,
                                           otNetworkDiagIterator &aIterator,
                                           otNetworkDiagTlv &     aNetworkDiagTlv)
 {
-    otError              error   = OT_ERROR_PARSE;
-    const Coap::Message &message = static_cast<const Coap::Message &>(aMessage);
-    uint16_t             offset  = message.GetOffset();
+    otError              error  = OT_ERROR_PARSE;
+    uint16_t             offset = aMessage.GetOffset();
     NetworkDiagnosticTlv tlv;
 
     offset += aIterator;
@@ -807,7 +806,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
     {
         uint16_t tlvTotalLength;
 
-        VerifyOrExit(message.Read(offset, sizeof(tlv), &tlv) == sizeof(tlv), error = OT_ERROR_NOT_FOUND);
+        VerifyOrExit(aMessage.Read(offset, sizeof(tlv), &tlv) == sizeof(tlv), error = OT_ERROR_NOT_FOUND);
 
         switch (tlv.GetType())
         {
@@ -816,7 +815,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             ExtMacAddressTlv extMacAddr;
 
             tlvTotalLength = sizeof(extMacAddr);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &extMacAddr) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &extMacAddr) == tlvTotalLength, OT_NOOP);
             VerifyOrExit(extMacAddr.IsValid(), OT_NOOP);
 
             aNetworkDiagTlv.mData.mExtAddress = *extMacAddr.GetMacAddr();
@@ -829,7 +828,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             Address16Tlv addr16;
 
             tlvTotalLength = sizeof(addr16);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &addr16) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &addr16) == tlvTotalLength, OT_NOOP);
             VerifyOrExit(addr16.IsValid(), OT_NOOP);
 
             aNetworkDiagTlv.mData.mAddr16 = addr16.GetRloc16();
@@ -842,7 +841,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             ModeTlv linkMode;
 
             tlvTotalLength = sizeof(linkMode);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &linkMode) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &linkMode) == tlvTotalLength, OT_NOOP);
             VerifyOrExit(linkMode.IsValid(), OT_NOOP);
 
             ParseMode(linkMode.GetMode(), aNetworkDiagTlv.mData.mMode);
@@ -855,7 +854,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             TimeoutTlv timeout;
 
             tlvTotalLength = sizeof(timeout);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &timeout) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &timeout) == tlvTotalLength, OT_NOOP);
             VerifyOrExit(timeout.IsValid(), OT_NOOP);
 
             aNetworkDiagTlv.mData.mTimeout = timeout.GetTimeout();
@@ -868,7 +867,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             ConnectivityTlv connectivity;
 
             tlvTotalLength = sizeof(connectivity);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &connectivity) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &connectivity) == tlvTotalLength, OT_NOOP);
             VerifyOrExit(connectivity.IsValid(), OT_NOOP);
 
             ParseConnectivity(connectivity, aNetworkDiagTlv.mData.mConnectivity);
@@ -882,7 +881,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
 
             tlvTotalLength = sizeof(tlv) + tlv.GetLength();
             VerifyOrExit(tlvTotalLength <= sizeof(route), OT_NOOP);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &route) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &route) == tlvTotalLength, OT_NOOP);
             VerifyOrExit(route.IsValid(), OT_NOOP);
 
             ParseRoute(route, aNetworkDiagTlv.mData.mRoute);
@@ -895,7 +894,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             LeaderDataTlv leaderData;
 
             tlvTotalLength = sizeof(leaderData);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &leaderData) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &leaderData) == tlvTotalLength, OT_NOOP);
             VerifyOrExit(leaderData.IsValid(), OT_NOOP);
 
             ParseLeaderData(leaderData, aNetworkDiagTlv.mData.mLeaderData);
@@ -909,7 +908,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
 
             tlvTotalLength = sizeof(tlv) + tlv.GetLength();
             VerifyOrExit(tlvTotalLength <= sizeof(networkData), OT_NOOP);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &networkData) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &networkData) == tlvTotalLength, OT_NOOP);
             VerifyOrExit(networkData.IsValid(), OT_NOOP);
             VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mNetworkData.m8) >= networkData.GetLength(), OT_NOOP);
 
@@ -925,8 +924,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
 
             VerifyOrExit(ip6AddrList.IsValid(), OT_NOOP);
             VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mIp6AddrList.mList) >= ip6AddrList.GetLength(), OT_NOOP);
-            VerifyOrExit(message.Read(offset + sizeof(ip6AddrList), ip6AddrList.GetLength(),
-                                      aNetworkDiagTlv.mData.mIp6AddrList.mList) == ip6AddrList.GetLength(),
+            VerifyOrExit(aMessage.Read(offset + sizeof(ip6AddrList), ip6AddrList.GetLength(),
+                                       aNetworkDiagTlv.mData.mIp6AddrList.mList) == ip6AddrList.GetLength(),
                          OT_NOOP);
 
             aNetworkDiagTlv.mData.mIp6AddrList.mCount = ip6AddrList.GetLength() / OT_IP6_ADDRESS_SIZE;
@@ -939,7 +938,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             MacCountersTlv macCounters;
 
             tlvTotalLength = sizeof(MacCountersTlv);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &macCounters) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &macCounters) == tlvTotalLength, OT_NOOP);
             VerifyOrExit(macCounters.IsValid(), OT_NOOP);
 
             ParseMacCounters(macCounters, aNetworkDiagTlv.mData.mMacCounters);
@@ -952,7 +951,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             BatteryLevelTlv batteryLevel;
 
             tlvTotalLength = sizeof(BatteryLevelTlv);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &batteryLevel) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &batteryLevel) == tlvTotalLength, OT_NOOP);
             VerifyOrExit(batteryLevel.IsValid(), OT_NOOP);
 
             aNetworkDiagTlv.mData.mBatteryLevel = batteryLevel.GetBatteryLevel();
@@ -965,7 +964,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             SupplyVoltageTlv supplyVoltage;
 
             tlvTotalLength = sizeof(SupplyVoltageTlv);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &supplyVoltage) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &supplyVoltage) == tlvTotalLength, OT_NOOP);
             VerifyOrExit(supplyVoltage.IsValid(), OT_NOOP);
 
             aNetworkDiagTlv.mData.mSupplyVoltage = supplyVoltage.GetSupplyVoltage();
@@ -984,7 +983,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             for (uint8_t i = 0; i < childTable.GetNumEntries(); ++i)
             {
                 ChildTableEntry childEntry;
-                VerifyOrExit(childTable.ReadEntry(childEntry, message, offset, i) == OT_ERROR_NONE, OT_NOOP);
+                VerifyOrExit(childTable.ReadEntry(childEntry, aMessage, offset, i) == OT_ERROR_NONE, OT_NOOP);
                 ParseChildEntry(childEntry, aNetworkDiagTlv.mData.mChildTable.mTable[i]);
             }
             aNetworkDiagTlv.mData.mChildTable.mCount = childTable.GetNumEntries();
@@ -995,7 +994,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
         case NetworkDiagnosticTlv::kChannelPages:
         {
             VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mChannelPages.m8) >= tlv.GetLength(), OT_NOOP);
-            VerifyOrExit(message.Read(offset + sizeof(tlv), tlv.GetLength(), aNetworkDiagTlv.mData.mChannelPages.m8) ==
+            VerifyOrExit(aMessage.Read(offset + sizeof(tlv), tlv.GetLength(), aNetworkDiagTlv.mData.mChannelPages.m8) ==
                              tlv.GetLength(),
                          OT_NOOP);
 
@@ -1009,7 +1008,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const otMessage &      aMessage,
             MaxChildTimeoutTlv maxChildTimeout;
 
             tlvTotalLength = sizeof(maxChildTimeout);
-            VerifyOrExit(message.Read(offset, tlvTotalLength, &maxChildTimeout) == tlvTotalLength, OT_NOOP);
+            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &maxChildTimeout) == tlvTotalLength, OT_NOOP);
             VerifyOrExit(maxChildTimeout.IsValid(), OT_NOOP);
 
             aNetworkDiagTlv.mData.mMaxChildTimeout = maxChildTimeout.GetTimeout();
@@ -1030,7 +1029,7 @@ exit:
     if (error == OT_ERROR_NONE)
     {
         aNetworkDiagTlv.mType = tlv.GetType();
-        aIterator             = static_cast<uint16_t>(offset - message.GetOffset() + tlv.GetSize());
+        aIterator             = static_cast<uint16_t>(offset - aMessage.GetOffset() + tlv.GetSize());
     }
     return error;
 }

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -100,7 +100,7 @@ public:
      */
     otError SendDiagnosticReset(const Ip6::Address &aDestination, const uint8_t aTlvTypes[], uint8_t aCount);
 
-    static otError GetNextDiagTlv(const otMessage &      aMessage,
+    static otError GetNextDiagTlv(const Coap::Message &  aMessage,
                                   otNetworkDiagIterator &aIterator,
                                   otNetworkDiagTlv &     aNetworkDiagTlv);
 

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -100,6 +100,19 @@ public:
      */
     otError SendDiagnosticReset(const Ip6::Address &aDestination, const uint8_t aTlvTypes[], uint8_t aCount);
 
+    /**
+     * This static method gets the next Network Diagnostic TLV in a given message.
+     *
+     * @param[in]     aMessage         A message.
+     * @param[inout]  aIterator        The Network Diagnostic iterator. To get the first TLV it should be set to
+     *                                 OT_NETWORK_DIAGNOSTIC_ITERATOR_INIT.
+     * @param[out]    aNetworkDiagTlv  A reference to a Network Diagnostic TLV to output the next TLV.
+     *
+     * @retval OT_ERROR_NONE       Successfully found the next Network Diagnostic TLV.
+     * @retval OT_ERROR_NOT_FOUND  No subsequent Network Diagnostic TLV exists in the message.
+     * @retval OT_ERROR_PARSE      Parsing the next Network Diagnostic failed.
+     *
+     */
     static otError GetNextDiagTlv(const Coap::Message &  aMessage,
                                   otNetworkDiagIterator &aIterator,
                                   otNetworkDiagTlv &     aNetworkDiagTlv);

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -63,6 +63,17 @@ namespace NetworkDiagnostic {
 class NetworkDiagnostic : public InstanceLocator
 {
 public:
+    enum
+    {
+        kIteratorInit = OT_NETWORK_DIAGNOSTIC_ITERATOR_INIT, ///< Initializer value for Iterator.
+    };
+
+    /**
+     * This type represents an iterator used to iterate through Network Diagnostic TLVs from `GetNextDiagTlv()`.
+     *
+     */
+    typedef otNetworkDiagIterator Iterator;
+
     /**
      * This constructor initializes the object.
      *
@@ -104,8 +115,7 @@ public:
      * This static method gets the next Network Diagnostic TLV in a given message.
      *
      * @param[in]     aMessage         A message.
-     * @param[inout]  aIterator        The Network Diagnostic iterator. To get the first TLV it should be set to
-     *                                 OT_NETWORK_DIAGNOSTIC_ITERATOR_INIT.
+     * @param[inout]  aIterator        The Network Diagnostic iterator. To get the first TLV set it to `kIteratorInit`.
      * @param[out]    aNetworkDiagTlv  A reference to a Network Diagnostic TLV to output the next TLV.
      *
      * @retval OT_ERROR_NONE       Successfully found the next Network Diagnostic TLV.
@@ -113,9 +123,9 @@ public:
      * @retval OT_ERROR_PARSE      Parsing the next Network Diagnostic failed.
      *
      */
-    static otError GetNextDiagTlv(const Coap::Message &  aMessage,
-                                  otNetworkDiagIterator &aIterator,
-                                  otNetworkDiagTlv &     aNetworkDiagTlv);
+    static otError GetNextDiagTlv(const Coap::Message &aMessage,
+                                  Iterator &           aIterator,
+                                  otNetworkDiagTlv &   aNetworkDiagTlv);
 
 private:
     otError AppendIp6AddressList(Message &aMessage);

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -131,7 +131,7 @@ private:
     otError AppendIp6AddressList(Message &aMessage);
     otError AppendChildTable(Message &aMessage);
     void    FillMacCountersTlv(MacCountersTlv &aMacCountersTlv);
-    otError FillRequestedTlvs(Message &aRequest, Message &aResponse, NetworkDiagnosticTlv &aNetworkDiagnosticTlv);
+    otError FillRequestedTlvs(const Message &aRequest, Message &aResponse, NetworkDiagnosticTlv &aNetworkDiagnosticTlv);
 
     static void HandleDiagnosticGetRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleDiagnosticGetRequest(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);


### PR DESCRIPTION
This PR contains a bunch of smaller changes in `NetworkDiagnostics` modules (the commits are separate for easier review): 

- **[network-diagnostic] fix parsing of Type List TLV in `HandleDiagnosticReset()`**
- **[network-diagnostic] skip unrecognized TLV type in `FillRequestedTlvs()`**
- **[network-diagnostic] use `Tlv` helper methods to append simple TLVs**
- **[network-diagnostic] simplify `GetNextDiagTlv()` implementation**
    
    This commit simplifies the implementation of `GetNextDiagTlv()` by
    skipping unrecognized TLVs from `default` case and jumping to top of
    the loop for a next TLV, and adding a common `ExitNow()` at the end of
    `switch()` statement to handle when a TLV is found and successfully
    parsed. This change helps remove the need for `OT_UNREACHABLE_CODE()`
    use.
- **[network-diagnostic] add `Iterator` type**
- **[network-diagnostic] add method documentation for `GetNextDiagTlv()`**
- **[network-diagnostic] update `GetNextDiagTlv()` parameter to use `Message`**

