### PR TITLE
[posix] tolerate SIGPIPE under daemon mode

### DIFF
--- a/src/posix/platform/uart.cpp
+++ b/src/posix/platform/uart.cpp
@@ -297,7 +297,12 @@ void platformUartProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, co
 
     if ((sWriteLength > 0) && (FD_ISSET(fd, aWriteFdSet)))
     {
+#if OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
+        // Don't die on SIGPIPE
+        rval = send(fd, sWriteBuffer, sWriteLength, MSG_NOSIGNAL);
+#else
         rval = write(fd, sWriteBuffer, sWriteLength);
+#endif
 
         if (rval < 0)
         {


### PR DESCRIPTION
Chances are that the ot-ctl client exits between read error check and
write. This will lead to a SIGPIPE crash. We can ignore this signal and
check the error code instead.