### PR TITLE
[low-power] encapsulate method to update header IE

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -763,6 +763,15 @@ uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aOffset, uint16_t 
     return aChecksum;
 }
 
+bool Message::IsTimeSync(void) const
+{
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    return GetMetadata().mTimeSync;
+#else
+    return false;
+#endif
+}
+
 void Message::SetMessageQueue(MessageQueue *aMessageQueue)
 {
     GetMetadata().mQueue.mMessage = aMessageQueue;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -856,6 +856,7 @@ public:
 
     /**
      * This method indicates whether or not the message is also used for time sync purpose.
+     *
      * When OPENTHREAD_CONFIG_TIME_SYNC_ENABLE is 0, this method always return false.
      *
      * @retval TRUE   If the message is also used for time sync purpose.

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -854,16 +854,17 @@ public:
         return (GetMetadata().mInPriorityQ) ? GetMetadata().mQueue.mPriority : NULL;
     }
 
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     /**
      * This method indicates whether or not the message is also used for time sync purpose.
+     * When OPENTHREAD_CONFIG_TIME_SYNC_ENABLE is 0, this method always return false.
      *
      * @retval TRUE   If the message is also used for time sync purpose.
      * @retval FALSE  If the message is not used for time sync purpose.
      *
      */
-    bool IsTimeSync(void) const { return GetMetadata().mTimeSync; }
+    bool IsTimeSync(void) const;
 
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     /**
      * This method sets whether or not the message is also used for time sync purpose.
      *

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -832,8 +832,8 @@ otError Mac::PrepareDataRequest(TxFrame &aFrame)
     SuccessOrExit(error = Get<DataPollSender>().GetPollDestinationAddress(dst));
     VerifyOrExit(!dst.IsNone(), error = OT_ERROR_ABORT);
 
-    fcf = Frame::kFcfFrameMacCmd | Frame::kFcfPanidCompression | Frame::kFcfFrameVersion2006 | Frame::kFcfAckRequest |
-          Frame::kFcfSecurityEnabled;
+    fcf = Frame::kFcfFrameMacCmd | Frame::kFcfPanidCompression | Frame::kFcfAckRequest | Frame::kFcfSecurityEnabled;
+    UpdateFrameControlField(NULL, fcf);
 
     if (dst.IsExtended())
     {
@@ -2060,6 +2060,70 @@ exit:
     return offset;
 }
 #endif
+
+#if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
+otError Mac::AppendHeaderIe(Message *aMessage, TxFrame &aFrame) const
+{
+    OT_UNUSED_VARIABLE(aMessage);
+
+    const size_t kMaxNumHeaderIe = 3; // TimeSync + Csl + Termination2
+    HeaderIe     ieList[kMaxNumHeaderIe];
+    otError      error   = OT_ERROR_NONE;
+    uint8_t      ieCount = 0;
+
+    VerifyOrExit(aFrame.IsVersion2015() && aFrame.IsIePresent(), OT_NOOP);
+
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    if (aMessage != NULL && aMessage->IsTimeSync())
+    {
+        ieList[ieCount].Init();
+        ieList[ieCount].SetId(Frame::kHeaderIeVendor);
+        ieList[ieCount].SetLength(sizeof(TimeIe));
+        ieCount++;
+    }
+#endif
+
+    if (ieCount > 0)
+    {
+        ieList[ieCount].Init();
+        ieList[ieCount].SetId(Frame::kHeaderIeTermination2);
+        ieList[ieCount].SetLength(0);
+
+        SuccessOrExit(error = aFrame.AppendHeaderIe(ieList, ++ieCount));
+    }
+
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    if (aMessage != NULL && aMessage->IsTimeSync())
+    {
+        uint8_t *cur = aFrame.GetHeaderIe(Frame::kHeaderIeVendor);
+        TimeIe * ie  = reinterpret_cast<TimeIe *>(cur + sizeof(HeaderIe));
+
+        ie->Init();
+    }
+#endif
+
+exit:
+    return error;
+}
+#endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
+
+void Mac::UpdateFrameControlField(Message *aMessage, uint16_t &aFcf) const
+{
+    OT_UNUSED_VARIABLE(aMessage);
+
+#if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    if (aMessage != NULL && aMessage->IsTimeSync())
+    {
+        aFcf |= Frame::kFcfFrameVersion2015 | Frame::kFcfIePresent;
+    }
+    else
+#endif
+#endif
+    {
+        aFcf |= Frame::kFcfFrameVersion2006;
+    }
+}
 
 } // namespace Mac
 } // namespace ot

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -833,7 +833,7 @@ otError Mac::PrepareDataRequest(TxFrame &aFrame)
     VerifyOrExit(!dst.IsNone(), error = OT_ERROR_ABORT);
 
     fcf = Frame::kFcfFrameMacCmd | Frame::kFcfPanidCompression | Frame::kFcfAckRequest | Frame::kFcfSecurityEnabled;
-    UpdateFrameControlField(false, fcf);
+    UpdateFrameControlField(/* aIsTimeSync */ false, fcf);
 
     if (dst.IsExtended())
     {

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2062,7 +2062,7 @@ exit:
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
-otError Mac::AppendHeaderIe(bool aIsTimeSync, TxFrame &aFrame) const
+otError Mac::AppendHeaderIe(bool aIsTimeSync, TxFrame &aFrame)
 {
     OT_UNUSED_VARIABLE(aIsTimeSync);
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -833,7 +833,7 @@ otError Mac::PrepareDataRequest(TxFrame &aFrame)
     VerifyOrExit(!dst.IsNone(), error = OT_ERROR_ABORT);
 
     fcf = Frame::kFcfFrameMacCmd | Frame::kFcfPanidCompression | Frame::kFcfAckRequest | Frame::kFcfSecurityEnabled;
-    UpdateFrameControlField(NULL, fcf);
+    UpdateFrameControlField(false, fcf);
 
     if (dst.IsExtended())
     {
@@ -2062,9 +2062,9 @@ exit:
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
-otError Mac::AppendHeaderIe(Message *aMessage, TxFrame &aFrame) const
+otError Mac::AppendHeaderIe(bool aIsTimeSync, TxFrame &aFrame) const
 {
-    OT_UNUSED_VARIABLE(aMessage);
+    OT_UNUSED_VARIABLE(aIsTimeSync);
 
     const size_t kMaxNumHeaderIe = 3; // TimeSync + Csl + Termination2
     HeaderIe     ieList[kMaxNumHeaderIe];
@@ -2074,7 +2074,7 @@ otError Mac::AppendHeaderIe(Message *aMessage, TxFrame &aFrame) const
     VerifyOrExit(aFrame.IsVersion2015() && aFrame.IsIePresent(), OT_NOOP);
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    if (aMessage != NULL && aMessage->IsTimeSync())
+    if (aIsTimeSync)
     {
         ieList[ieCount].Init();
         ieList[ieCount].SetId(Frame::kHeaderIeVendor);
@@ -2093,7 +2093,7 @@ otError Mac::AppendHeaderIe(Message *aMessage, TxFrame &aFrame) const
     }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    if (aMessage != NULL && aMessage->IsTimeSync())
+    if (aIsTimeSync)
     {
         uint8_t *cur = aFrame.GetHeaderIe(Frame::kHeaderIeVendor);
         TimeIe * ie  = reinterpret_cast<TimeIe *>(cur + sizeof(HeaderIe));
@@ -2107,13 +2107,13 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
 
-void Mac::UpdateFrameControlField(Message *aMessage, uint16_t &aFcf)
+void Mac::UpdateFrameControlField(bool aIsTimeSync, uint16_t &aFcf)
 {
-    OT_UNUSED_VARIABLE(aMessage);
+    OT_UNUSED_VARIABLE(aIsTimeSync);
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    if (aMessage != NULL && aMessage->IsTimeSync())
+    if (aIsTimeSync)
     {
         aFcf |= Frame::kFcfFrameVersion2015 | Frame::kFcfIePresent;
     }

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2107,7 +2107,7 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
 
-void Mac::UpdateFrameControlField(Message *aMessage, uint16_t &aFcf) const
+void Mac::UpdateFrameControlField(Message *aMessage, uint16_t &aFcf)
 {
     OT_UNUSED_VARIABLE(aMessage);
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -669,14 +669,14 @@ public:
      * This method appends header IEs to a TX-frame according to its
      * frame control field and if time sync is enabled.
      *
-     * @param[in]      aMessage   A pointer to the message to send, could be `NULL`.
-     * @param[in,out]  aFrame     A reference to the TX-frame to which the IEs will be appended.
+     * @param[in]      aIsTimeSync  A boolean indicates if time sync is being used.
+     * @param[in,out]  aFrame       A reference to the TX-frame to which the IEs will be appended.
      *
      * @retval OT_ERROR_NONE    If append header IEs successfully.
      * @retval OT_ERROR_FAILED  If cannot find header IE position in the frame.
      *
      */
-    otError AppendHeaderIe(Message *aMessage, TxFrame &aFrame) const;
+    otError AppendHeaderIe(bool aIsTimeSync, TxFrame &aFrame) const;
 #endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
 
     /**
@@ -685,11 +685,11 @@ public:
      * header IE is present in this frame, the version should be set to 2015.
      * Otherwise, the version would be set to 2006.
      *
-     * @param[in]   aMessage   A pointer to the message to send, could be `NULL`.
-     * @param[out]  aFcf       A reference to the frame control field to set.
+     * @param[in]   aIsTimeSync  A boolean indicates if time sync is being used.
+     * @param[out]  aFcf         A reference to the frame control field to set.
      *
      */
-    static void UpdateFrameControlField(Message *aMessage, uint16_t &aFcf);
+    static void UpdateFrameControlField(bool aIsTimeSync, uint16_t &aFcf);
 
 private:
     enum

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -689,7 +689,7 @@ public:
      * @param[out]  aFcf       A reference to the frame control field to set.
      *
      */
-    void UpdateFrameControlField(Message *aMessage, uint16_t &aFcf) const;
+    static void UpdateFrameControlField(Message *aMessage, uint16_t &aFcf);
 
 private:
     enum

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -40,6 +40,7 @@
 #include <openthread/platform/time.h>
 
 #include "common/locator.hpp"
+#include "common/message.hpp"
 #include "common/tasklet.hpp"
 #include "common/timer.hpp"
 #include "mac/channel_mask.hpp"
@@ -662,6 +663,33 @@ public:
      *
      */
     bool IsEnabled(void) const { return mEnabled; }
+
+#if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
+    /**
+     * This method appends header IEs to a TX-frame according to its
+     * frame control field and if time sync is enabled.
+     *
+     * @param[in]      aMessage   A pointer to the message to send, could be `NULL`.
+     * @param[in,out]  aFrame     A reference to the TX-frame to which the IEs will be appended.
+     *
+     * @retval OT_ERROR_NONE    If append header IEs successfully.
+     * @retval OT_ERROR_FAILED  If cannot find header IE position in the frame.
+     *
+     */
+    otError AppendHeaderIe(Message *aMessage, TxFrame &aFrame) const;
+#endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
+
+    /**
+     * This method updates frame version. If the frame would contain header IEs,
+     * IE present field would be set. If this is a csl transmission frame or
+     * header IE is present in this frame, the version should be set to 2015.
+     * Otherwise, the version would be set to 2006.
+     *
+     * @param[in]   aMessage   A pointer to the message to send, could be `NULL`.
+     * @param[out]  aFcf       A reference to the frame control field to set.
+     *
+     */
+    void UpdateFrameControlField(Message *aMessage, uint16_t &aFcf) const;
 
 private:
     enum

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -676,10 +676,10 @@ public:
      *
      */
     otError AppendHeaderIe(bool aIsTimeSync, TxFrame &aFrame) const;
-#endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
+#endif
 
     /**
-     * This method updates frame version. If the frame would contain header IEs,
+     * This method updates frame control field. If the frame would contain header IEs,
      * IE present field would be set. If this is a csl transmission frame or
      * header IE is present in this frame, the version should be set to 2015.
      * Otherwise, the version would be set to 2006.

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -40,7 +40,6 @@
 #include <openthread/platform/time.h>
 
 #include "common/locator.hpp"
-#include "common/message.hpp"
 #include "common/tasklet.hpp"
 #include "common/timer.hpp"
 #include "mac/channel_mask.hpp"

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -671,18 +671,19 @@ public:
      * @param[in]      aIsTimeSync  A boolean indicates if time sync is being used.
      * @param[in,out]  aFrame       A reference to the TX-frame to which the IEs will be appended.
      *
-     * @retval OT_ERROR_NONE    If append header IEs successfully.
-     * @retval OT_ERROR_FAILED  If cannot find header IE position in the frame.
+     * @retval OT_ERROR_NONE       If append header IEs successfully.
+     * @retval OT_ERROR_NOT_FOUND  If cannot find header IE position in the frame.
      *
      */
-    otError AppendHeaderIe(bool aIsTimeSync, TxFrame &aFrame) const;
+    static otError AppendHeaderIe(bool aIsTimeSync, TxFrame &aFrame);
 #endif
 
     /**
-     * This method updates frame control field. If the frame would contain header IEs,
-     * IE present field would be set. If this is a csl transmission frame or
-     * header IE is present in this frame, the version should be set to 2015.
-     * Otherwise, the version would be set to 2006.
+     * This method updates frame control field.
+     *
+     * If the frame would contain header IEs, IE present field would be set.
+     * If this is a csl transmission frame or header IE is present in this frame,
+     * the version should be set to 2015. Otherwise, the version would be set to 2006.
      *
      * @param[in]   aIsTimeSync  A boolean indicates if time sync is being used.
      * @param[out]  aFcf         A reference to the frame control field to set.

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -918,7 +918,7 @@ otError Frame::AppendHeaderIe(HeaderIe *aIeList, uint8_t aIeCount)
     uint8_t *cur;
     uint8_t *base;
 
-    VerifyOrExit(index != kInvalidIndex, error = OT_ERROR_FAILED);
+    VerifyOrExit(index != kInvalidIndex, error = OT_ERROR_NOT_FOUND);
     cur  = GetPsdu() + index;
     base = cur;
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -517,18 +517,13 @@ uint16_t MeshForwarder::PrepareDataFrame(Mac::TxFrame &      aFrame,
     uint16_t dstpan;
     uint8_t  secCtl;
     uint16_t nextOffset;
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    bool timeSync = aMessage.IsTimeSync();
-#else
-    bool timeSync = false;
-#endif
 
 start:
 
     // Initialize MAC header
     fcf = Mac::Frame::kFcfFrameData;
 
-    Get<Mac::Mac>().UpdateFrameControlField(timeSync, fcf);
+    Get<Mac::Mac>().UpdateFrameControlField(aMessage.IsTimeSync(), fcf);
 
     fcf |= (aMacDest.IsShort()) ? Mac::Frame::kFcfDstAddrShort : Mac::Frame::kFcfDstAddrExt;
     fcf |= (aMacSource.IsShort()) ? Mac::Frame::kFcfSrcAddrShort : Mac::Frame::kFcfSrcAddrExt;
@@ -610,7 +605,7 @@ start:
     aFrame.SetSrcAddr(aMacSource);
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
-    IgnoreError(Get<Mac::Mac>().AppendHeaderIe(timeSync, aFrame));
+    IgnoreError(Get<Mac::Mac>().AppendHeaderIe(aMessage.IsTimeSync(), aFrame));
 #endif
 
     payload = aFrame.GetPayload();

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -523,16 +523,7 @@ start:
     // Initialize MAC header
     fcf = Mac::Frame::kFcfFrameData;
 
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    if (aMessage.IsTimeSync())
-    {
-        fcf |= Mac::Frame::kFcfFrameVersion2015 | Mac::Frame::kFcfIePresent;
-    }
-    else
-#endif
-    {
-        fcf |= Mac::Frame::kFcfFrameVersion2006;
-    }
+    Get<Mac::Mac>().UpdateFrameControlField(&aMessage, fcf);
 
     fcf |= (aMacDest.IsShort()) ? Mac::Frame::kFcfDstAddrShort : Mac::Frame::kFcfDstAddrExt;
     fcf |= (aMacSource.IsShort()) ? Mac::Frame::kFcfSrcAddrShort : Mac::Frame::kFcfSrcAddrExt;
@@ -613,26 +604,8 @@ start:
     aFrame.SetDstAddr(aMacDest);
     aFrame.SetSrcAddr(aMacSource);
 
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    if (aMessage.IsTimeSync())
-    {
-        Mac::TimeIe * ie;
-        uint8_t *     cur = NULL;
-        Mac::HeaderIe ieList[2];
-
-        ieList[0].Init();
-        ieList[0].SetId(Mac::Frame::kHeaderIeVendor);
-        ieList[0].SetLength(sizeof(Mac::TimeIe));
-        ieList[1].Init();
-        ieList[1].SetId(Mac::Frame::kHeaderIeTermination2);
-        ieList[1].SetLength(0);
-        IgnoreError(aFrame.AppendHeaderIe(ieList, 2));
-
-        cur = aFrame.GetHeaderIe(Mac::Frame::kHeaderIeVendor);
-        ie  = reinterpret_cast<Mac::TimeIe *>(cur + sizeof(Mac::HeaderIe));
-        ie->Init();
-    }
-
+#if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
+    IgnoreError(Get<Mac::Mac>().AppendHeaderIe(&aMessage, aFrame));
 #endif
 
     payload = aFrame.GetPayload();

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -517,13 +517,18 @@ uint16_t MeshForwarder::PrepareDataFrame(Mac::TxFrame &      aFrame,
     uint16_t dstpan;
     uint8_t  secCtl;
     uint16_t nextOffset;
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    bool timeSync = aMessage.IsTimeSync();
+#else
+    bool timeSync = false;
+#endif
 
 start:
 
     // Initialize MAC header
     fcf = Mac::Frame::kFcfFrameData;
 
-    Get<Mac::Mac>().UpdateFrameControlField(&aMessage, fcf);
+    Get<Mac::Mac>().UpdateFrameControlField(timeSync, fcf);
 
     fcf |= (aMacDest.IsShort()) ? Mac::Frame::kFcfDstAddrShort : Mac::Frame::kFcfDstAddrExt;
     fcf |= (aMacSource.IsShort()) ? Mac::Frame::kFcfSrcAddrShort : Mac::Frame::kFcfSrcAddrExt;
@@ -605,7 +610,7 @@ start:
     aFrame.SetSrcAddr(aMacSource);
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
-    IgnoreError(Get<Mac::Mac>().AppendHeaderIe(&aMessage, aFrame));
+    IgnoreError(Get<Mac::Mac>().AppendHeaderIe(timeSync, aFrame));
 #endif
 
     payload = aFrame.GetPayload();

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -349,16 +349,11 @@ void MeshForwarder::RemoveDataResponseMessages(void)
 void MeshForwarder::SendMesh(Message &aMessage, Mac::TxFrame &aFrame)
 {
     uint16_t fcf;
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    bool timeSync = aMessage.IsTimeSync();
-#else
-    bool timeSync = false;
-#endif
 
     // initialize MAC header
     fcf = Mac::Frame::kFcfFrameData | Mac::Frame::kFcfPanidCompression | Mac::Frame::kFcfDstAddrShort |
           Mac::Frame::kFcfSrcAddrShort | Mac::Frame::kFcfAckRequest | Mac::Frame::kFcfSecurityEnabled;
-    Get<Mac::Mac>().UpdateFrameControlField(timeSync, fcf);
+    Get<Mac::Mac>().UpdateFrameControlField(aMessage.IsTimeSync(), fcf);
 
     aFrame.InitMacHeader(fcf, Mac::Frame::kKeyIdMode1 | Mac::Frame::kSecEncMic32);
     aFrame.SetDstPanId(Get<Mac::Mac>().GetPanId());

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -351,9 +351,9 @@ void MeshForwarder::SendMesh(Message &aMessage, Mac::TxFrame &aFrame)
     uint16_t fcf;
 
     // initialize MAC header
-    fcf = Mac::Frame::kFcfFrameData | Mac::Frame::kFcfPanidCompression | Mac::Frame::kFcfFrameVersion2006 |
-          Mac::Frame::kFcfDstAddrShort | Mac::Frame::kFcfSrcAddrShort | Mac::Frame::kFcfAckRequest |
-          Mac::Frame::kFcfSecurityEnabled;
+    fcf = Mac::Frame::kFcfFrameData | Mac::Frame::kFcfPanidCompression | Mac::Frame::kFcfDstAddrShort |
+          Mac::Frame::kFcfSrcAddrShort | Mac::Frame::kFcfAckRequest | Mac::Frame::kFcfSecurityEnabled;
+    Get<Mac::Mac>().UpdateFrameControlField(&aMessage, fcf);
 
     aFrame.InitMacHeader(fcf, Mac::Frame::kKeyIdMode1 | Mac::Frame::kSecEncMic32);
     aFrame.SetDstPanId(Get<Mac::Mac>().GetPanId());

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -349,11 +349,16 @@ void MeshForwarder::RemoveDataResponseMessages(void)
 void MeshForwarder::SendMesh(Message &aMessage, Mac::TxFrame &aFrame)
 {
     uint16_t fcf;
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    bool timeSync = aMessage.IsTimeSync();
+#else
+    bool timeSync = false;
+#endif
 
     // initialize MAC header
     fcf = Mac::Frame::kFcfFrameData | Mac::Frame::kFcfPanidCompression | Mac::Frame::kFcfDstAddrShort |
           Mac::Frame::kFcfSrcAddrShort | Mac::Frame::kFcfAckRequest | Mac::Frame::kFcfSecurityEnabled;
-    Get<Mac::Mac>().UpdateFrameControlField(&aMessage, fcf);
+    Get<Mac::Mac>().UpdateFrameControlField(timeSync, fcf);
 
     aFrame.InitMacHeader(fcf, Mac::Frame::kKeyIdMode1 | Mac::Frame::kSecEncMic32);
     aFrame.SetDstPanId(Get<Mac::Mac>().GetPanId());


### PR DESCRIPTION
OpenThread now have **TIME_SYNC** IE. And the presence of IE would also effect the frame version and IE present field. This PR encapsulate the process to update these things so that it could be easily extended to support other IEs that would be introduced later.