### PR TITLE
[build] change underscore to dash in libmbedcrypto name

### DIFF
--- a/examples/apps/ncp/Makefile.am
+++ b/examples/apps/ncp/Makefile.am
@@ -66,7 +66,7 @@ LDADD_MBEDTLS                                                         += \
     $(NULL)
 
 LDADD_MBEDTLS_RADIO                                                   += \
-    $(top_builddir)/third_party/mbedtls/libmbedcrypto_radio.a            \
+    $(top_builddir)/third_party/mbedtls/libmbedcrypto-radio.a            \
     $(NULL)
 endif # OPENTHREAD_ENABLE_BUILTIN_MBEDTLS
 

--- a/third_party/mbedtls/Makefile.am
+++ b/third_party/mbedtls/Makefile.am
@@ -23,7 +23,7 @@ EXTRA_DIST                                    = \
 
 lib_LIBRARIES                                 = \
     libmbedcrypto.a                             \
-    libmbedcrypto_radio.a                       \
+    libmbedcrypto-radio.a                       \
     $(NULL)
 
 # Do not enable -Wconversion for mbedtls


### PR DESCRIPTION
This PR changes libmbedcrypto_radio.a to libmbedcrypto-radio.a, since every other library uses dash rather than underscore in the name.