### PR TITLE
[harness-automation] fix browser stuck in navigating to url

### DIFF
--- a/tools/harness-automation/autothreadharness/harness_case.py
+++ b/tools/harness-automation/autothreadharness/harness_case.py
@@ -316,8 +316,8 @@ class HarnessCase(unittest.TestCase):
             browser = webdriver.Chrome(chrome_options=chrome_options)
             browser.set_page_load_timeout(20)
             browser.implicitly_wait(1)
-            browser.maximize_window()
             browser.get(settings.HARNESS_URL)
+            browser.maximize_window()
             self._browser = browser
             if not wait_until(lambda: 'Thread' in browser.title, 30):
                 self.assertIn('Thread', browser.title)


### PR DESCRIPTION
1. found setting browser window size before navigating to url may cause the browser stuck and get timeout exception:
File "autothreadharness\harness_case.py", line 323, in _init_browser
    browser.get(settings.HARNESS_URL)
  File "C:\Python27\lib\site-packages\selenium\webdriver\remote\webdriver.py", line 248, in get
    self.execute(Command.GET, {'url': url})
  File "C:\Python27\lib\site-packages\selenium\webdriver\remote\webdriver.py", line 236, in execute
    self.error_handler.check_response(response)
  File "C:\Python27\lib\site-packages\selenium\webdriver\remote\errorhandler.py", line 192, in check_response
    raise exception_class(message, screen, stacktrace)
TimeoutException: Message: timeout: Timed out receiving message from renderer: -0.005

related bug: https://github.com/mozilla/geckodriver/issues/1014

2. exchanging the order to navigate to url before setting browser window size will improve effectively