### PR TITLE
[logging] add newline to the end of NCP logs

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -2409,6 +2409,8 @@ extern "C" void otNcpPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, cons
             charsWritten = static_cast<int>(sizeof(logString) - 1);
         }
 
+        logString[charsWritten++] = '\n';
+
         IgnoreError(otNcpStreamWrite(0, reinterpret_cast<uint8_t *>(logString), charsWritten));
     }
 }


### PR DESCRIPTION
This PR adds `\n` to the end of NCP logs so that `wpantund` can print each log line properly. 