### PR TITLE
[crypto] misc enhancements in AesCcm and other crypto modules

### DIFF
--- a/src/core/api/crypto_api.cpp
+++ b/src/core/api/crypto_api.cpp
@@ -72,13 +72,12 @@ void otCryptoAesCcm(const uint8_t *aKey,
                     bool           aEncrypt,
                     void *         aTag)
 {
-    AesCcm  aesCcm;
-    uint8_t tagLength;
+    AesCcm aesCcm;
 
     OT_ASSERT((aKey != NULL) && (aNonce != NULL) && (aPlainText != NULL) && (aCipherText != NULL) && (aTag != NULL));
 
     aesCcm.SetKey(aKey, aKeyLength);
-    SuccessOrExit(aesCcm.Init(aHeaderLength, aLength, aTagLength, aNonce, aNonceLength));
+    aesCcm.Init(aHeaderLength, aLength, aTagLength, aNonce, aNonceLength);
 
     if (aHeaderLength != 0)
     {
@@ -86,13 +85,8 @@ void otCryptoAesCcm(const uint8_t *aKey,
         aesCcm.Header(aHeader, aHeaderLength);
     }
 
-    aesCcm.Payload(aPlainText, aCipherText, aLength, aEncrypt);
-    aesCcm.Finalize(aTag, &tagLength);
-
-    OT_ASSERT(aTagLength == tagLength);
-
-exit:
-    return;
+    aesCcm.Payload(aPlainText, aCipherText, aLength, aEncrypt ? AesCcm::kEncrypt : AesCcm::kDecrypt);
+    aesCcm.Finalize(aTag);
 }
 
 #if OPENTHREAD_CONFIG_ECDSA_ENABLE

--- a/src/core/api/crypto_api.cpp
+++ b/src/core/api/crypto_api.cpp
@@ -98,7 +98,7 @@ otError otCryptoEcdsaSign(uint8_t *      aOutput,
                           const uint8_t *aPrivateKey,
                           uint16_t       aPrivateKeyLength)
 {
-    return Ecdsa::Sign(aOutput, aOutputLength, aInputHash, aInputHashLength, aPrivateKey, aPrivateKeyLength);
+    return Ecdsa::Sign(aOutput, *aOutputLength, aInputHash, aInputHashLength, aPrivateKey, aPrivateKeyLength);
 }
 
 #endif // OPENTHREAD_CONFIG_ECDSA_ENABLE

--- a/src/core/crypto/aes_ccm.cpp
+++ b/src/core/crypto/aes_ccm.cpp
@@ -33,6 +33,8 @@
 
 #include "aes_ccm.hpp"
 
+#include <limits.h>
+
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
@@ -42,7 +44,7 @@ namespace Crypto {
 
 void AesCcm::SetKey(const uint8_t *aKey, uint16_t aKeyLength)
 {
-    mEcb.SetKey(aKey, 8 * aKeyLength);
+    mEcb.SetKey(aKey, CHAR_BIT * aKeyLength);
 }
 
 void AesCcm::SetKey(const Mac::Key &aMacKey)
@@ -50,30 +52,20 @@ void AesCcm::SetKey(const Mac::Key &aMacKey)
     SetKey(aMacKey.GetKey(), Mac::Key::kSize);
 }
 
-otError AesCcm::Init(uint32_t    aHeaderLength,
-                     uint32_t    aPlainTextLength,
-                     uint8_t     aTagLength,
-                     const void *aNonce,
-                     uint8_t     aNonceLength)
+void AesCcm::Init(uint32_t    aHeaderLength,
+                  uint32_t    aPlainTextLength,
+                  uint8_t     aTagLength,
+                  const void *aNonce,
+                  uint8_t     aNonceLength)
 {
     const uint8_t *nonceBytes  = reinterpret_cast<const uint8_t *>(aNonce);
-    otError        error       = OT_ERROR_NONE;
     uint8_t        blockLength = 0;
     uint32_t       len;
     uint8_t        L;
     uint8_t        i;
 
-    // aTagLength must be even
-    aTagLength &= ~1;
-
-    if (aTagLength > sizeof(mBlock))
-    {
-        aTagLength = sizeof(mBlock);
-    }
-    else if (aTagLength < kTagLengthMin)
-    {
-        ExitNow(error = OT_ERROR_INVALID_ARGS);
-    }
+    // Tag length must be even and within [kMinTagLength, kMaxTagLength]
+    OT_ASSERT(((aTagLength & 0x1) == 0) && (kMinTagLength <= aTagLength) && (aTagLength <= kMaxTagLength));
 
     L = 0;
 
@@ -111,10 +103,7 @@ otError AesCcm::Init(uint32_t    aHeaderLength,
                  static_cast<uint8_t>(L - 1));
 
     // write nonce
-    for (i = 0; i < aNonceLength; i++)
-    {
-        mBlock[1 + i] = nonceBytes[i];
-    }
+    memcpy(&mBlock[1], nonceBytes, aNonceLength);
 
     // write len
     len = aPlainTextLength;
@@ -150,16 +139,8 @@ otError AesCcm::Init(uint32_t    aHeaderLength,
 
     // init counter
     mCtr[0] = L - 1;
-
-    for (i = 0; i < aNonceLength; i++)
-    {
-        mCtr[1 + i] = nonceBytes[i];
-    }
-
-    for (i = i + 1; i < sizeof(mCtr); i++)
-    {
-        mCtr[i] = 0;
-    }
+    memcpy(&mCtr[1], nonceBytes, aNonceLength);
+    memset(&mCtr[aNonceLength + 1], 0, sizeof(mCtr) - aNonceLength - 1);
 
     mNonceLength     = aNonceLength;
     mHeaderLength    = aHeaderLength;
@@ -169,9 +150,6 @@ otError AesCcm::Init(uint32_t    aHeaderLength,
     mBlockLength     = blockLength;
     mCtrLength       = sizeof(mCtrPad);
     mTagLength       = aTagLength;
-
-exit:
-    return error;
 }
 
 void AesCcm::Header(const void *aHeader, uint32_t aHeaderLength)
@@ -206,7 +184,7 @@ void AesCcm::Header(const void *aHeader, uint32_t aHeaderLength)
     }
 }
 
-void AesCcm::Payload(void *aPlainText, void *aCipherText, uint32_t aLength, bool aEncrypt)
+void AesCcm::Payload(void *aPlainText, void *aCipherText, uint32_t aLength, Mode aMode)
 {
     uint8_t *plaintextBytes  = reinterpret_cast<uint8_t *>(aPlainText);
     uint8_t *ciphertextBytes = reinterpret_cast<uint8_t *>(aCipherText);
@@ -230,7 +208,7 @@ void AesCcm::Payload(void *aPlainText, void *aCipherText, uint32_t aLength, bool
             mCtrLength = 0;
         }
 
-        if (aEncrypt)
+        if (aMode == kEncrypt)
         {
             byte               = plaintextBytes[i];
             ciphertextBytes[i] = byte ^ mCtrPad[mCtrLength++];
@@ -260,32 +238,21 @@ void AesCcm::Payload(void *aPlainText, void *aCipherText, uint32_t aLength, bool
         }
 
         // reset counter
-        for (uint8_t i = mNonceLength + 1; i < sizeof(mCtr); i++)
-        {
-            mCtr[i] = 0;
-        }
+        memset(&mCtr[mNonceLength + 1], 0, sizeof(mCtr) - mNonceLength - 1);
     }
 }
 
-void AesCcm::Finalize(void *aTag, uint8_t *aTagLength)
+void AesCcm::Finalize(void *aTag)
 {
     uint8_t *tagBytes = reinterpret_cast<uint8_t *>(aTag);
 
     OT_ASSERT(mPlainTextCur == mPlainTextLength);
 
-    if (mTagLength > 0)
-    {
-        mEcb.Encrypt(mCtr, mCtrPad);
+    mEcb.Encrypt(mCtr, mCtrPad);
 
-        for (int i = 0; i < mTagLength; i++)
-        {
-            tagBytes[i] = mBlock[i] ^ mCtrPad[i];
-        }
-    }
-
-    if (aTagLength)
+    for (int i = 0; i < mTagLength; i++)
     {
-        *aTagLength = mTagLength;
+        tagBytes[i] = mBlock[i] ^ mCtrPad[i];
     }
 }
 

--- a/src/core/crypto/aes_ccm.hpp
+++ b/src/core/crypto/aes_ccm.hpp
@@ -62,7 +62,19 @@ class AesCcm
 public:
     enum
     {
-        kNonceSize = 13, ///< Size of IEEE 802.15.4 Nonce (bytes).
+        kMinTagLength = 4,                  ///< Minimum tag length (in bytes).
+        kMaxTagLength = AesEcb::kBlockSize, ///< Maximum tag length (in bytes).
+        kNonceSize    = 13,                 ///< Size of IEEE 802.15.4 Nonce (in bytes).
+    };
+
+    /**
+     * This enumeration type represent the encryption vs decryption mode.
+     *
+     */
+    enum Mode
+    {
+        kEncrypt, // Encryption mode.
+        kDecrypt, // Decryption mode.
     };
 
     /**
@@ -87,19 +99,16 @@ public:
      *
      * @param[in]  aHeaderLength     Length of header in bytes.
      * @param[in]  aPlainTextLength  Length of plaintext in bytes.
-     * @param[in]  aTagLength        Length of tag in bytes.
+     * @param[in]  aTagLength        Length of tag in bytes (must be even and in `[kMinTagLength, kMaxTagLength]`).
      * @param[in]  aNonce            A pointer to the nonce.
      * @param[in]  aNonceLength      Length of nonce in bytes.
      *
-     * @retval OT_ERROR_NONE          Initialization was successful.
-     * @retval OT_ERROR_INVALID_ARGS  Initialization failed.
-     *
      */
-    otError Init(uint32_t    aHeaderLength,
-                 uint32_t    aPlainTextLength,
-                 uint8_t     aTagLength,
-                 const void *aNonce,
-                 uint8_t     aNonceLength);
+    void Init(uint32_t    aHeaderLength,
+              uint32_t    aPlainTextLength,
+              uint8_t     aTagLength,
+              const void *aNonce,
+              uint8_t     aNonceLength);
 
     /**
      * This method processes the header.
@@ -116,19 +125,26 @@ public:
      * @param[inout]  aPlainText   A pointer to the plaintext.
      * @param[inout]  aCipherText  A pointer to the ciphertext.
      * @param[in]     aLength      Payload length in bytes.
-     * @param[in]     aEncrypt     TRUE on encrypt and FALSE on decrypt.
+     * @param[in]     aMode        Mode to indicate whether to encrypt (`kEncrypt`) or decrypt (`kDecrypt`).
      *
      */
-    void Payload(void *aPlainText, void *aCipherText, uint32_t aLength, bool aEncrypt);
+    void Payload(void *aPlainText, void *aCipherText, uint32_t aLength, Mode aMode);
+
+    /**
+     * This method returns the tag length in bytes.
+     *
+     * @returns The tag length in bytes.
+     *
+     */
+    uint8_t GetTagLength(void) const { return mTagLength; }
 
     /**
      * This method generates the tag.
      *
-     * @param[out]  aTag        A pointer to the tag.
-     * @param[out]  aTagLength  Length of the tag in bytes.
+     * @param[out]  aTag        A pointer to the tag (must have `GetTagLength()` bytes).
      *
      */
-    void Finalize(void *aTag, uint8_t *aTagLength);
+    void Finalize(void *aTag);
 
     /**
      * This static method generates IEEE 802.15.4 nonce byte sequence.
@@ -145,22 +161,17 @@ public:
                               uint8_t *              aNonce);
 
 private:
-    enum
-    {
-        kTagLengthMin = 4,
-    };
-
     AesEcb   mEcb;
     uint8_t  mBlock[AesEcb::kBlockSize];
     uint8_t  mCtr[AesEcb::kBlockSize];
     uint8_t  mCtrPad[AesEcb::kBlockSize];
-    uint8_t  mNonceLength;
     uint32_t mHeaderLength;
     uint32_t mHeaderCur;
     uint32_t mPlainTextLength;
     uint32_t mPlainTextCur;
     uint16_t mBlockLength;
     uint16_t mCtrLength;
+    uint8_t  mNonceLength;
     uint8_t  mTagLength;
 };
 

--- a/src/core/crypto/aes_ecb.cpp
+++ b/src/core/crypto/aes_ecb.cpp
@@ -36,7 +36,7 @@
 namespace ot {
 namespace Crypto {
 
-AesEcb::AesEcb()
+AesEcb::AesEcb(void)
 {
     mbedtls_aes_init(&mContext);
 }
@@ -51,7 +51,7 @@ void AesEcb::Encrypt(const uint8_t aInput[kBlockSize], uint8_t aOutput[kBlockSiz
     mbedtls_aes_crypt_ecb(&mContext, MBEDTLS_AES_ENCRYPT, aInput, aOutput);
 }
 
-AesEcb::~AesEcb()
+AesEcb::~AesEcb(void)
 {
     mbedtls_aes_free(&mContext);
 }

--- a/src/core/crypto/aes_ecb.hpp
+++ b/src/core/crypto/aes_ecb.hpp
@@ -64,19 +64,19 @@ public:
      * Constructor to initialize the mbedtls_aes_context.
      *
      */
-    AesEcb();
+    AesEcb(void);
 
     /**
      * Destructor to free the mbedtls_aes_context.
      *
      */
-    ~AesEcb();
+    ~AesEcb(void);
 
     /**
      * This method sets the key.
      *
      * @param[in]  aKey        A pointer to the key.
-     * @param[in]  aKeyLength  The key length in bytes.
+     * @param[in]  aKeyLength  The key length in bits.
      *
      */
     void SetKey(const uint8_t *aKey, uint16_t aKeyLength);

--- a/src/core/crypto/ecdsa.cpp
+++ b/src/core/crypto/ecdsa.cpp
@@ -47,7 +47,7 @@ namespace Crypto {
 #if OPENTHREAD_CONFIG_ECDSA_ENABLE
 
 otError Ecdsa::Sign(uint8_t *      aOutput,
-                    uint16_t *     aOutputLength,
+                    uint16_t &     aOutputLength,
                     const uint8_t *aInputHash,
                     uint16_t       aInputHashLength,
                     const uint8_t *aPrivateKey,
@@ -79,15 +79,15 @@ otError Ecdsa::Sign(uint8_t *      aOutput,
     VerifyOrExit(mbedtls_ecdsa_sign(&ctx.grp, &rMpi, &sMpi, &ctx.d, aInputHash, aInputHashLength,
                                     mbedtls_ctr_drbg_random, Random::Crypto::MbedTlsContextGet()) == 0,
                  error = OT_ERROR_FAILED);
-    VerifyOrExit(mbedtls_mpi_size(&rMpi) + mbedtls_mpi_size(&sMpi) <= *aOutputLength, error = OT_ERROR_NO_BUFS);
+    VerifyOrExit(mbedtls_mpi_size(&rMpi) + mbedtls_mpi_size(&sMpi) <= aOutputLength, error = OT_ERROR_NO_BUFS);
 
     // Concatenate the two octet sequences in the order R and then S.
     VerifyOrExit(mbedtls_mpi_write_binary(&rMpi, aOutput, mbedtls_mpi_size(&rMpi)) == 0, error = OT_ERROR_FAILED);
-    *aOutputLength = static_cast<uint16_t>(mbedtls_mpi_size(&rMpi));
+    aOutputLength = static_cast<uint16_t>(mbedtls_mpi_size(&rMpi));
 
-    VerifyOrExit(mbedtls_mpi_write_binary(&sMpi, aOutput + *aOutputLength, mbedtls_mpi_size(&sMpi)) == 0,
+    VerifyOrExit(mbedtls_mpi_write_binary(&sMpi, aOutput + aOutputLength, mbedtls_mpi_size(&sMpi)) == 0,
                  error = OT_ERROR_FAILED);
-    *aOutputLength += mbedtls_mpi_size(&sMpi);
+    aOutputLength += mbedtls_mpi_size(&sMpi);
 
 exit:
     mbedtls_mpi_free(&rMpi);

--- a/src/core/crypto/ecdsa.hpp
+++ b/src/core/crypto/ecdsa.hpp
@@ -72,6 +72,7 @@ public:
      * @retval  OT_ERROR_NO_BUFS      Output buffer is too small.
      * @retval  OT_ERROR_INVALID_ARGS Private key is not valid EC Private Key.
      * @retval  OT_ERROR_FAILED       Error during signing.
+     *
      */
     static otError Sign(uint8_t *      aOutput,
                         uint16_t *     aOutputLength,

--- a/src/core/crypto/ecdsa.hpp
+++ b/src/core/crypto/ecdsa.hpp
@@ -75,7 +75,7 @@ public:
      *
      */
     static otError Sign(uint8_t *      aOutput,
-                        uint16_t *     aOutputLength,
+                        uint16_t &     aOutputLength,
                         const uint8_t *aInputHash,
                         uint16_t       aInputHashLength,
                         const uint8_t *aPrivateKey,

--- a/src/core/crypto/hmac_sha256.cpp
+++ b/src/core/crypto/hmac_sha256.cpp
@@ -36,7 +36,7 @@
 namespace ot {
 namespace Crypto {
 
-HmacSha256::HmacSha256()
+HmacSha256::HmacSha256(void)
 {
     const mbedtls_md_info_t *mdInfo = NULL;
     mbedtls_md_init(&mContext);
@@ -44,7 +44,7 @@ HmacSha256::HmacSha256()
     mbedtls_md_setup(&mContext, mdInfo, 1);
 }
 
-HmacSha256::~HmacSha256()
+HmacSha256::~HmacSha256(void)
 {
     mbedtls_md_free(&mContext);
 }

--- a/src/core/crypto/hmac_sha256.hpp
+++ b/src/core/crypto/hmac_sha256.hpp
@@ -66,13 +66,13 @@ public:
      * Constructor for initialization of mbedtls_md_context_t.
      *
      */
-    HmacSha256();
+    HmacSha256(void);
 
     /**
      * Destructor for freeing of mbedtls_md_context_t.
      *
      */
-    ~HmacSha256();
+    ~HmacSha256(void);
 
     /**
      * This method sets the key.

--- a/src/core/crypto/mbedtls.cpp
+++ b/src/core/crypto/mbedtls.cpp
@@ -74,11 +74,11 @@ MbedTls::MbedTls(void)
 #endif // !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE && OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS_MANAGEMENT
 }
 
-otError MbedTls::MapError(int rval)
+otError MbedTls::MapError(int aMbedTlsError)
 {
     otError error = OT_ERROR_NONE;
 
-    switch (rval)
+    switch (aMbedTlsError)
     {
 #ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
     case MBEDTLS_ERR_PK_TYPE_MISMATCH:
@@ -154,7 +154,7 @@ otError MbedTls::MapError(int rval)
         break;
 
     default:
-        OT_ASSERT(rval >= 0);
+        OT_ASSERT(aMbedTlsError >= 0);
         break;
     }
 

--- a/src/core/crypto/mbedtls.hpp
+++ b/src/core/crypto/mbedtls.hpp
@@ -64,9 +64,14 @@ public:
     MbedTls(void);
 
     /**
-     * This method converts from MbedTls error to OpenThread error.
+     * This method converts an mbed TLS error to OpenThread error.
+     *
+     * @param[in] aMbedTlsError  The mbed TLS error.
+     *
+     * @returns The mapped otError.
+     *
      */
-    static otError MapError(int rval);
+    static otError MapError(int aMbedTlsError);
 };
 
 /**

--- a/src/core/crypto/sha256.cpp
+++ b/src/core/crypto/sha256.cpp
@@ -36,12 +36,12 @@
 namespace ot {
 namespace Crypto {
 
-Sha256::Sha256()
+Sha256::Sha256(void)
 {
     mbedtls_sha256_init(&mContext);
 }
 
-Sha256::~Sha256()
+Sha256::~Sha256(void)
 {
     mbedtls_sha256_free(&mContext);
 }

--- a/src/core/crypto/sha256.hpp
+++ b/src/core/crypto/sha256.hpp
@@ -66,13 +66,13 @@ public:
      * Constructor for initializing mbedtls_sha256_context.
      *
      */
-    Sha256();
+    Sha256(void);
 
     /**
      * Destructor for freeing mbedtls_sha256_context.
      *
      */
-    ~Sha256();
+    ~Sha256(void);
 
     /**
      * This method starts the SHA-256 computation.

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1518,17 +1518,17 @@ otError Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Ne
 
     aesCcm.SetKey(*macKey);
 
-    SuccessOrExit(aesCcm.Init(aFrame.GetHeaderLength(), aFrame.GetPayloadLength(), tagLength, nonce, sizeof(nonce)));
-
+    aesCcm.Init(aFrame.GetHeaderLength(), aFrame.GetPayloadLength(), tagLength, nonce, sizeof(nonce));
     aesCcm.Header(aFrame.GetHeader(), aFrame.GetHeaderLength());
+
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    aesCcm.Payload(aFrame.GetPayload(), aFrame.GetPayload(), aFrame.GetPayloadLength(), false);
+    aesCcm.Payload(aFrame.GetPayload(), aFrame.GetPayload(), aFrame.GetPayloadLength(), Crypto::AesCcm::kDecrypt);
 #else
     // For fuzz tests, execute AES but do not alter the payload
     uint8_t fuzz[OT_RADIO_FRAME_MAX_SIZE];
-    aesCcm.Payload(fuzz, aFrame.GetPayload(), aFrame.GetPayloadLength(), false);
+    aesCcm.Payload(fuzz, aFrame.GetPayload(), aFrame.GetPayloadLength(), Crypto::AesCcm::kDecrypt);
 #endif
-    aesCcm.Finalize(tag, &tagLength);
+    aesCcm.Finalize(tag);
 
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     VerifyOrExit(memcmp(tag, aFrame.GetFooter(), tagLength) == 0, OT_NOOP);

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1052,12 +1052,10 @@ void TxFrame::ProcessTransmitAesCcm(const ExtAddress &aExtAddress)
     aesCcm.SetKey(GetAesKey());
     tagLength = GetFooterLength() - Frame::kFcsSize;
 
-    error = aesCcm.Init(GetHeaderLength(), GetPayloadLength(), tagLength, nonce, sizeof(nonce));
-    OT_ASSERT(error == OT_ERROR_NONE);
-
+    aesCcm.Init(GetHeaderLength(), GetPayloadLength(), tagLength, nonce, sizeof(nonce));
     aesCcm.Header(GetHeader(), GetHeaderLength());
-    aesCcm.Payload(GetPayload(), GetPayload(), GetPayloadLength(), true);
-    aesCcm.Finalize(GetFooter(), &tagLength);
+    aesCcm.Payload(GetPayload(), GetPayload(), GetPayloadLength(), Crypto::AesCcm::kEncrypt);
+    aesCcm.Finalize(GetFooter());
 
     SetIsSecurityProcessed(true);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2520,7 +2520,7 @@ otError Mle::SendMessage(Message &aMessage, const Ip6::Address &aDestination)
     Header           header;
     uint32_t         keySequence;
     uint8_t          nonce[Crypto::AesCcm::kNonceSize];
-    uint8_t          tag[4];
+    uint8_t          tag[kMleSecurityTagSize];
     Crypto::AesCcm   aesCcm;
     uint8_t          buf[64];
     uint16_t         length;
@@ -2605,14 +2605,14 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     uint32_t        keySequence;
     const Key *     mleKey;
     uint32_t        frameCounter;
-    uint8_t         messageTag[4];
+    uint8_t         messageTag[kMleSecurityTagSize];
     uint8_t         nonce[Crypto::AesCcm::kNonceSize];
     Mac::ExtAddress macAddr;
     Crypto::AesCcm  aesCcm;
     uint16_t        mleOffset;
     uint8_t         buf[64];
     uint16_t        length;
-    uint8_t         tag[4];
+    uint8_t         tag[kMleSecurityTagSize];
     uint8_t         command;
     Neighbor *      neighbor;
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1650,7 +1650,8 @@ protected:
 private:
     enum
     {
-        kMleHopLimit = 255,
+        kMleHopLimit        = 255,
+        kMleSecurityTagSize = 4, // Security tag size in bytes.
 
         // Parameters related to "periodic parent search" feature (CONFIG_ENABLE_PERIODIC_PARENT_SEARCH).
         // All timer intervals are converted to milliseconds.

--- a/tests/unit/test_aes.cpp
+++ b/tests/unit/test_aes.cpp
@@ -68,15 +68,17 @@ void TestMacBeaconFrame(void)
     VerifyOrQuit(instance != NULL, "Null OpenThread instance");
 
     aesCcm.SetKey(key, sizeof(key));
-    SuccessOrQuit(aesCcm.Init(headerLength, payloadLength, tagLength, nonce, sizeof(nonce)), "AesCcm::Init() failed");
+    aesCcm.Init(headerLength, payloadLength, tagLength, nonce, sizeof(nonce));
     aesCcm.Header(test, headerLength);
-    aesCcm.Finalize(test + headerLength, &tagLength);
+    VerifyOrQuit(aesCcm.GetTagLength() == tagLength, "AesCcm::GetTagLength() failed");
+    aesCcm.Finalize(test + headerLength);
 
     VerifyOrQuit(memcmp(test, encrypted, sizeof(encrypted)) == 0, "TestMacBeaconFrame encrypt failed");
 
-    SuccessOrQuit(aesCcm.Init(headerLength, payloadLength, tagLength, nonce, sizeof(nonce)), "AesCcm::Init() failed");
+    aesCcm.Init(headerLength, payloadLength, tagLength, nonce, sizeof(nonce));
     aesCcm.Header(test, headerLength);
-    aesCcm.Finalize(test + headerLength, &tagLength);
+    VerifyOrQuit(aesCcm.GetTagLength() == tagLength, "AesCcm::GetTagLength() failed");
+    aesCcm.Finalize(test + headerLength);
 
     VerifyOrQuit(memcmp(test, decrypted, sizeof(decrypted)) == 0, "TestMacBeaconFrame decrypt failed");
 
@@ -119,16 +121,18 @@ void TestMacCommandFrame()
 
     ot::Crypto::AesCcm aesCcm;
     aesCcm.SetKey(key, sizeof(key));
-    SuccessOrQuit(aesCcm.Init(headerLength, payloadLength, tagLength, nonce, sizeof(nonce)), "AesCcm::Init() failed");
+    aesCcm.Init(headerLength, payloadLength, tagLength, nonce, sizeof(nonce));
     aesCcm.Header(test, headerLength);
-    aesCcm.Payload(test + headerLength, test + headerLength, payloadLength, true);
-    aesCcm.Finalize(test + headerLength + payloadLength, &tagLength);
+    aesCcm.Payload(test + headerLength, test + headerLength, payloadLength, ot::Crypto::AesCcm::kEncrypt);
+    VerifyOrQuit(aesCcm.GetTagLength() == tagLength, "AesCcm::GetTagLength() failed");
+    aesCcm.Finalize(test + headerLength + payloadLength);
     VerifyOrQuit(memcmp(test, encrypted, sizeof(encrypted)) == 0, "TestMacCommandFrame encrypt failed");
 
-    SuccessOrQuit(aesCcm.Init(headerLength, payloadLength, tagLength, nonce, sizeof(nonce)), "AesCcm::Init() failed");
+    aesCcm.Init(headerLength, payloadLength, tagLength, nonce, sizeof(nonce));
     aesCcm.Header(test, headerLength);
-    aesCcm.Payload(test + headerLength, test + headerLength, payloadLength, false);
-    aesCcm.Finalize(test + headerLength + payloadLength, &tagLength);
+    aesCcm.Payload(test + headerLength, test + headerLength, payloadLength, ot::Crypto::AesCcm::kDecrypt);
+    VerifyOrQuit(aesCcm.GetTagLength() == tagLength, "AesCcm::GetTagLength() failed");
+    aesCcm.Finalize(test + headerLength + payloadLength);
 
     VerifyOrQuit(memcmp(test, decrypted, sizeof(decrypted)) == 0, "TestMacCommandFrame decrypt failed");
 }


### PR DESCRIPTION
This PR contains a bunch of smaller changes in `Crypto` modules: 

**[aes-ccm] add Mode enum type to indicate encrypt vs decrypt mode**

This commit adds a new enumeration type `Mode` to indicate the
encryption vs decryption mode in AesCcm::Payload() method.

**[aes-ccm] add GetTagLength() method and simplify Finalize()**

**[aes-ccm] change AesCcm::Init() to assert on bad tag length input param**

Instead of returning `OT_ERROR_INVALID_ARGS` on bad input, the
`AesCcm::Init()` now asserts if the input tag length parameter is not
valid.

**[ars-ecb] fix the AesEcb::SetKey() document about key len being in bits**

**[aes-ccm] small enhancements**

- reorder AesCcm member variable to help with alignments
- use CHAR_BIT
- remove check of tag length from Finalize
- use `memcpy`/`memset` to copy/clear buffers

**[crypto] update method documentation and style**

**[ecdsa] use reference for output length instead of pointer**

**[mle] add constant kMleSecurityTagSize for MLE security tag size**
