### PR TITLE
[test] add various CLI command tests

### DIFF
--- a/tests/scripts/expect/cli-counters.exp
+++ b/tests/scripts/expect/cli-counters.exp
@@ -1,0 +1,53 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+spawn $env(OT_COMMAND) 1
+set timeout 1
+expect_after {
+    timeout { exit 1 }
+}
+
+send "counters\n"
+expect "mac"
+expect "mle"
+expect "Done"
+send "counters mac\n"
+expect "Done"
+send "counters mle\n"
+expect "Done"
+send "counters mac reset\n"
+expect "Done"
+send "counters mle reset\n"
+expect "Done"
+send "counters mac 1\n"
+expect "Error 7: InvalidArgs"
+send "counters mle 1\n"
+expect "Error 7: InvalidArgs"
+send "counters other\n"
+expect "Error 7: InvalidArgs"

--- a/tests/scripts/expect/cli-misc.exp
+++ b/tests/scripts/expect/cli-misc.exp
@@ -1,0 +1,106 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+spawn $env(OT_COMMAND) 1
+set timeout 1
+expect_after {
+    timeout { exit 1 }
+}
+
+send "help\n"
+expect "Done"
+
+send "bufferinfo\n"
+expect "Done"
+
+send "netdatashow\n"
+expect "Done"
+
+send "parent\n"
+expect "Done"
+
+send "delaytimermin 1\n"
+expect "Done"
+send "delaytimermin\n"
+expect "1"
+expect "Done"
+send "delaytimermin 1 2\n"
+send "counters mac 1\n"
+expect "Error 7: InvalidArgs"
+
+send "ifconfig\n"
+expect "down"
+expect "Done"
+send "ifconfig up\n"
+expect "Done"
+send "ifconfig\n"
+expect "up"
+expect "Done"
+
+send "ipaddr add ::\n"
+expect "Done"
+send "ipaddr del ::\n"
+expect "Done"
+
+send "leaderweight 1\n"
+expect "Done"
+send "leaderweight\n"
+expect "1"
+expect "Done"
+
+send "mode rsdn\n"
+expect "Done"
+send "mode\n"
+expect -re "(?=.*r)(?=.*s)(?=.*d)(?=.*n)"
+
+send "parent\n"
+expect "Done"
+
+send "singleton\n"
+expect -re "true|false"
+expect "Done"
+
+send "state\n"
+expect "disabled"
+expect "Done"
+
+send "txpower -10\n"
+expect "Done"
+send "txpower\n"
+expect -- "-10 dBm"
+expect "Done"
+
+send "thread version\n"
+expect "Done"
+
+send "joinerport 10001\n"
+expect "Done"
+send "joinerport\n"
+expect "10001"
+expect "Done"

--- a/tests/scripts/expect/cli-routereligible.exp
+++ b/tests/scripts/expect/cli-routereligible.exp
@@ -1,0 +1,54 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+spawn $env(OT_COMMAND) 1
+set timeout 1
+expect_after {
+    timeout { exit 1 }
+}
+
+send "routereligible disable\n"
+expect "Done"
+send "routereligible\n"
+expect "Disabled"
+expect "Done"
+send "routereligible enable\n"
+expect "Done"
+send "routereligible\n"
+expect "Enabled"
+expect "Done"
+send "routereligible something_invalid\n"
+expect "Error 7: InvalidArgs"
+send "mode rs\n"
+expect "Done"
+send "routereligible\n"
+expect "Disabled"
+expect "Done"
+send "routereligible enable\n"
+expect "Error 27: NotCapable"


### PR DESCRIPTION
This adds `expect` tests for many CLI commands. Some simple commands are placed in `cli-misc.exp`.