### PR TITLE
[ip6-address] add a type flag to addresses

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (4)
+#define OPENTHREAD_API_VERSION (5)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -116,6 +116,18 @@ struct otIp6Prefix
 typedef struct otIp6Prefix otIp6Prefix;
 
 /**
+ * IPv6 Address origins
+ *
+ */
+enum
+{
+    OT_ADDRESS_ORIGIN_THREAD = 0, ///< Thread assigned address (ALOC, RLOC, MLEID, etc)
+    OT_ADDRESS_ORIGIN_SLAAC  = 1, ///< SLAAC assigned address
+    OT_ADDRESS_ORIGIN_DHCPV6 = 2, ///< DHCPv6 assigned address
+    OT_ADDRESS_ORIGIN_MANUAL = 3, ///< Manually assigned address
+};
+
+/**
  * This structure represents an IPv6 network interface unicast address.
  *
  */
@@ -123,6 +135,7 @@ typedef struct otNetifAddress
 {
     otIp6Address           mAddress;                ///< The IPv6 unicast address.
     uint8_t                mPrefixLength;           ///< The Prefix length (in bits).
+    uint8_t                mAddressOrigin;          ///< The IPv6 address origin.
     bool                   mPreferred : 1;          ///< TRUE if the address is preferred, FALSE otherwise.
     bool                   mValid : 1;              ///< TRUE if the address is valid, FALSE otherwise.
     bool                   mScopeOverrideValid : 1; ///< TRUE if the mScopeOverride value is valid, FALSE otherwise.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1556,10 +1556,11 @@ otError Interpreter::ProcessIpAddrAdd(uint8_t aArgsLength, char *aArgs[])
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
     SuccessOrExit(error = otIp6AddressFromString(aArgs[0], &aAddress.mAddress));
-    aAddress.mPrefixLength = 64;
-    aAddress.mPreferred    = true;
-    aAddress.mValid        = true;
-    error                  = otIp6AddUnicastAddress(mInstance, &aAddress);
+    aAddress.mPrefixLength  = 64;
+    aAddress.mPreferred     = true;
+    aAddress.mValid         = true;
+    aAddress.mAddressOrigin = OT_ADDRESS_ORIGIN_MANUAL;
+    error                   = otIp6AddUnicastAddress(mInstance, &aAddress);
 
 exit:
     return error;

--- a/src/core/backbone_router/local.cpp
+++ b/src/core/backbone_router/local.cpp
@@ -62,6 +62,7 @@ Local::Local(Instance &aInstance)
     mBackboneRouterPrimaryAloc.Clear();
 
     mBackboneRouterPrimaryAloc.mPrefixLength       = Mle::MeshLocalPrefix::kLength;
+    mBackboneRouterPrimaryAloc.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
     mBackboneRouterPrimaryAloc.mPreferred          = true;
     mBackboneRouterPrimaryAloc.mValid              = true;
     mBackboneRouterPrimaryAloc.mScopeOverride      = Ip6::Address::kRealmLocalScope;

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -355,6 +355,7 @@ BorderAgent::BorderAgent(Instance &aInstance)
 {
     mCommissionerAloc.Clear();
     mCommissionerAloc.mPrefixLength       = 64;
+    mCommissionerAloc.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
     mCommissionerAloc.mPreferred          = true;
     mCommissionerAloc.mValid              = true;
     mCommissionerAloc.mScopeOverride      = Ip6::Address::kRealmLocalScope;

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -585,12 +585,13 @@ otError Dhcp6Client::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
 
         if (ia.mNetifAddress.GetAddress().PrefixMatch(option.GetAddress()) >= ia.mNetifAddress.mPrefixLength)
         {
-            mIdentityAssociations[i].mNetifAddress.mAddress   = option.GetAddress();
-            mIdentityAssociations[i].mPreferredLifetime       = option.GetPreferredLifetime();
-            mIdentityAssociations[i].mValidLifetime           = option.GetValidLifetime();
-            mIdentityAssociations[i].mNetifAddress.mPreferred = option.GetPreferredLifetime() != 0;
-            mIdentityAssociations[i].mNetifAddress.mValid     = option.GetValidLifetime() != 0;
-            mIdentityAssociations[i].mStatus                  = kIaStatusSolicitReplied;
+            mIdentityAssociations[i].mNetifAddress.mAddress       = option.GetAddress();
+            mIdentityAssociations[i].mPreferredLifetime           = option.GetPreferredLifetime();
+            mIdentityAssociations[i].mValidLifetime               = option.GetValidLifetime();
+            mIdentityAssociations[i].mNetifAddress.mAddressOrigin = OT_ADDRESS_ORIGIN_DHCPV6;
+            mIdentityAssociations[i].mNetifAddress.mPreferred     = option.GetPreferredLifetime() != 0;
+            mIdentityAssociations[i].mNetifAddress.mValid         = option.GetValidLifetime() != 0;
+            mIdentityAssociations[i].mStatus                      = kIaStatusSolicitReplied;
             Get<ThreadNetif>().AddUnicastAddress(ia.mNetifAddress);
             break;
         }

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -174,9 +174,10 @@ private:
             mPrefix = aPrefix;
 
             mAloc.GetAddress().SetToAnycastLocator(aMeshLocalPrefix, (Ip6::Address::kAloc16Mask << 8) + aContextId);
-            mAloc.mPrefixLength = OT_IP6_PREFIX_BITSIZE;
-            mAloc.mPreferred    = true;
-            mAloc.mValid        = true;
+            mAloc.mPrefixLength  = OT_IP6_PREFIX_BITSIZE;
+            mAloc.mAddressOrigin = OT_ADDRESS_ORIGIN_THREAD;
+            mAloc.mPreferred     = true;
+            mAloc.mValid         = true;
         }
 
     private:

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -471,9 +471,10 @@ otError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress)
             VerifyOrExit((entry >= &mExtUnicastAddresses[0]) && (entry < OT_ARRAY_END(mExtUnicastAddresses)),
                          error = OT_ERROR_ALREADY);
 
-            entry->mPrefixLength = aAddress.mPrefixLength;
-            entry->mPreferred    = aAddress.mPreferred;
-            entry->mValid        = aAddress.mValid;
+            entry->mPrefixLength  = aAddress.mPrefixLength;
+            entry->mAddressOrigin = aAddress.mAddressOrigin;
+            entry->mPreferred     = aAddress.mPreferred;
+            entry->mValid         = aAddress.mValid;
             ExitNow();
         }
     }

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -51,6 +51,7 @@ DuaManager::DuaManager(Instance &aInstance)
     , mDadCounter(0)
 {
     mDomainUnicastAddress.Clear();
+    mDomainUnicastAddress.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
     mDomainUnicastAddress.mPreferred          = true;
     mDomainUnicastAddress.mValid              = true;
     mDomainUnicastAddress.mScopeOverride      = Ip6::Address::kGlobalScope;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -126,13 +126,15 @@ Mle::Mle(Instance &aInstance)
     // link-local 64
     mLinkLocal64.Clear();
     mLinkLocal64.GetAddress().SetToLinkLocalAddress(Get<Mac::Mac>().GetExtAddress());
-    mLinkLocal64.mPrefixLength = 64;
-    mLinkLocal64.mPreferred    = true;
-    mLinkLocal64.mValid        = true;
+    mLinkLocal64.mPrefixLength  = 64;
+    mLinkLocal64.mAddressOrigin = OT_ADDRESS_ORIGIN_THREAD;
+    mLinkLocal64.mPreferred     = true;
+    mLinkLocal64.mValid         = true;
 
     // Leader Aloc
     mLeaderAloc.Clear();
     mLeaderAloc.mPrefixLength       = MeshLocalPrefix::kLength;
+    mLeaderAloc.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
     mLeaderAloc.mPreferred          = true;
     mLeaderAloc.mValid              = true;
     mLeaderAloc.mScopeOverride      = Ip6::Address::kRealmLocalScope;
@@ -145,6 +147,7 @@ Mle::Mle(Instance &aInstance)
     {
         mServiceAlocs[i].Clear();
         mServiceAlocs[i].mPrefixLength       = MeshLocalPrefix::kLength;
+        mServiceAlocs[i].mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
         mServiceAlocs[i].mPreferred          = true;
         mServiceAlocs[i].mValid              = true;
         mServiceAlocs[i].mScopeOverride      = Ip6::Address::kRealmLocalScope;
@@ -163,6 +166,7 @@ Mle::Mle(Instance &aInstance)
                                            OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE));
 
     mMeshLocal64.mPrefixLength       = MeshLocalPrefix::kLength;
+    mMeshLocal64.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
     mMeshLocal64.mPreferred          = true;
     mMeshLocal64.mValid              = true;
     mMeshLocal64.mScopeOverride      = Ip6::Address::kRealmLocalScope;
@@ -172,6 +176,7 @@ Mle::Mle(Instance &aInstance)
     mMeshLocal16.Clear();
     mMeshLocal16.GetAddress().SetIidToLocator(0);
     mMeshLocal16.mPrefixLength       = MeshLocalPrefix::kLength;
+    mMeshLocal16.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
     mMeshLocal16.mPreferred          = true;
     mMeshLocal16.mValid              = true;
     mMeshLocal16.mScopeOverride      = Ip6::Address::kRealmLocalScope;

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -234,9 +234,10 @@ void Slaac::Update(UpdateMode aMode)
                     slaacAddr->Clear();
                     memcpy(&slaacAddr->mAddress, &prefix.mPrefix, BitVectorBytes(prefix.mLength));
 
-                    slaacAddr->mPrefixLength = prefix.mLength;
-                    slaacAddr->mPreferred    = config.mPreferred;
-                    slaacAddr->mValid        = true;
+                    slaacAddr->mPrefixLength  = prefix.mLength;
+                    slaacAddr->mAddressOrigin = OT_ADDRESS_ORIGIN_SLAAC;
+                    slaacAddr->mPreferred     = config.mPreferred;
+                    slaacAddr->mValid         = true;
 
                     IgnoreError(GenerateIid(*slaacAddr));
 

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -1626,8 +1626,9 @@ template <> otError NcpBase::HandlePropertyInsert<SPINEL_PROP_IPV6_ADDRESS_TABLE
     SuccessOrExit(error = mDecoder.ReadUint32(preferredLifetime));
     SuccessOrExit(error = mDecoder.ReadUint32(validLifetime));
 
-    netifAddr.mPreferred = (preferredLifetime != 0);
-    netifAddr.mValid     = (validLifetime != 0);
+    netifAddr.mAddressOrigin = OT_ADDRESS_ORIGIN_MANUAL;
+    netifAddr.mPreferred     = (preferredLifetime != 0);
+    netifAddr.mValid         = (validLifetime != 0);
 
     error = otIp6AddUnicastAddress(mInstance, &netifAddr);
 


### PR DESCRIPTION
Add a type flag to addresses so that applications are able to behave
differently on the type of address.

Signed-off-by: Markus Becker <markus.becker@tridonic.com>