### PR TITLE
[ip6] forward any packet with on-mesh destination

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1470,6 +1470,11 @@ bool Ip6::IsOnLink(const Address &aAddress) const
 {
     bool rval = false;
 
+    if (Get<ThreadNetif>().IsOnMesh(aAddress))
+    {
+        ExitNow(rval = true);
+    }
+
     for (const NetifUnicastAddress *cur = Get<ThreadNetif>().GetUnicastAddresses(); cur; cur = cur->GetNext())
     {
         if (cur->GetAddress().PrefixMatch(aAddress) >= cur->mPrefixLength)

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -206,6 +206,11 @@ otError ThreadNetif::TmfFilter(const Coap::Message &aMessage, const Ip6::Message
     return static_cast<ThreadNetif *>(aContext)->IsTmfMessage(aMessageInfo) ? OT_ERROR_NONE : OT_ERROR_NOT_TMF;
 }
 
+bool ThreadNetif::IsOnMesh(const Ip6::Address &aAddress) const
+{
+    return Get<NetworkData::Leader>().IsOnMesh(aAddress);
+}
+
 bool ThreadNetif::IsTmfMessage(const Ip6::MessageInfo &aMessageInfo)
 {
     bool rval = true;

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -164,6 +164,17 @@ public:
     otError RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination, uint8_t *aPrefixMatch);
 
     /**
+     * This method indicates whether @p aAddress matches an on-mesh prefix.
+     *
+     * @param[in]  aAddress  The IPv6 address.
+     *
+     * @retval TRUE   If @p aAddress matches an on-mesh prefix.
+     * @retval FALSE  If @p aAddress does not match an on-mesh prefix.
+     *
+     */
+    bool IsOnMesh(const Ip6::Address &aAddress) const;
+
+    /**
      * This method returns whether Thread Management Framework Addressing Rules are met.
      *
      * @retval TRUE   if Thread Management Framework Addressing Rules are met.


### PR DESCRIPTION
Existing implementation only looks at addresses configured on the
network interface to determine what prefixes are on-link (on-mesh for
Thread). When the network interface does not have an assigned address
for a given on-mesh prefix, any packet with that on-mesh prefix will
not be forwarded to the Thread network.

This commit also checks the destination address against Thread's set
of on-mesh prefixes, independent of whether addresses out are assigned
out of the on-mesh prefix.

Resolves #5022