### PR TITLE
[core] adding Equatable and Clearable subclasses

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -319,6 +319,7 @@ HEADERS_COMMON                             = \
     coap/coap.hpp                            \
     coap/coap_message.hpp                    \
     coap/coap_secure.hpp                     \
+    common/clearable.hpp                     \
     common/code_utils.hpp                    \
     common/crc16.hpp                         \
     common/debug.hpp                         \

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -323,6 +323,7 @@ HEADERS_COMMON                             = \
     common/crc16.hpp                         \
     common/debug.hpp                         \
     common/encoding.hpp                      \
+    common/equatable.hpp                     \
     common/extension.hpp                     \
     common/instance.hpp                      \
     common/linked_list.hpp                   \

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/coap.h>
 
+#include "common/clearable.hpp"
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
 #include "common/message.hpp"
@@ -628,10 +629,8 @@ private:
      * This structure represents a HelpData used by this CoAP message.
      *
      */
-    struct HelpData
+    struct HelpData : public Clearable<HelpData>
     {
-        void Clear(void) { memset(this, 0, sizeof(*this)); }
-
         Header   mHeader;
         uint16_t mOptionLast;
         uint16_t mHeaderOffset; ///< The byte offset for the CoAP Header

--- a/src/core/common/clearable.hpp
+++ b/src/core/common/clearable.hpp
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for Clearable class for OpenThread objects.
+ */
+
+#ifndef CLEARABLE_HPP_
+#define CLEARABLE_HPP_
+
+#include "openthread-core-config.h"
+
+#include <string.h>
+
+namespace ot {
+
+/**
+ * This template class defines a Clearable object which provides `Clear()` method.
+ *
+ * The `Clear` implementation simply sets all the bytes of a `Type` instance to zero.
+ *
+ * Users of this class should follow CRTP-style inheritance, i.e., the `Type` class itself should publicly inherit
+ * from `Clearable<Type>`.
+ *
+ */
+template <typename Type> class Clearable
+{
+public:
+    void Clear(void) { memset(reinterpret_cast<void *>(this), 0, sizeof(Type)); }
+};
+
+} // namespace ot
+
+#endif // CLEARABLE_HPP_

--- a/src/core/common/equatable.hpp
+++ b/src/core/common/equatable.hpp
@@ -1,0 +1,80 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for Equatable class for OpenThread objects.
+ */
+
+#ifndef EQUATABLE_HPP_
+#define EQUATABLE_HPP_
+
+#include "openthread-core-config.h"
+
+#include <string.h>
+
+namespace ot {
+
+/**
+ * This template class defines overloads of operators `==` and `!=`.
+ *
+ * The `==` implementation simply compares all the bytes of two `Type` instances to be equal (using `memcmp()`).
+ *
+ * Users of this class should follow CRTP-style inheritance, i.e., the `Type` class itself should publicly inherit
+ * from `Equatable<Type>`.
+ *
+ */
+template <class Type> class Equatable
+{
+public:
+    /**
+     * This method overloads operator `==` to evaluate whether or not two instances of `Type` are equal.
+     *
+     * @param[in]  aOther  The other `Type` instance to compare with.
+     *
+     * @retval TRUE   If the two `Type` instances are equal.
+     * @retval FALSE  If the two `Type` instances are not equal.
+     *
+     */
+    bool operator==(const Type &aOther) const { return memcmp(this, &aOther, sizeof(Type)) == 0; }
+
+    /**
+     * This method overloads operator `!=` to evaluate whether or not two instances of `Type` are equal.
+     *
+     * @param[in]  aOther  The other `Type` instance to compare with.
+     *
+     * @retval TRUE   If the two `Type` instances are not equal.
+     * @retval FALSE  If the two `Type` instances are equal.
+     *
+     */
+    bool operator!=(const Type &aOther) const { return !(*this == aOther); }
+};
+
+} // namespace ot
+
+#endif // EQUATABLE_HPP_

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -63,11 +63,6 @@ void ExtAddress::GenerateRandom(void)
 }
 #endif
 
-bool ExtAddress::operator==(const ExtAddress &aOther) const
-{
-    return memcmp(m8, aOther.m8, sizeof(ExtAddress)) == 0;
-}
-
 ExtAddress::InfoString ExtAddress::ToString(void) const
 {
     return InfoString("%02x%02x%02x%02x%02x%02x%02x%02x", m8[0], m8[1], m8[2], m8[3], m8[4], m8[5], m8[6], m8[7]);
@@ -95,11 +90,6 @@ Address::InfoString Address::ToString(void) const
 {
     return (mType == kTypeExtended) ? GetExtended().ToString()
                                     : (mType == kTypeNone ? InfoString("None") : InfoString("0x%04x", GetShort()));
-}
-
-bool ExtendedPanId::operator==(const ExtendedPanId &aOther) const
-{
-    return memcmp(m8, aOther.m8, sizeof(ExtendedPanId)) == 0;
 }
 
 ExtendedPanId::InfoString ExtendedPanId::ToString(void) const

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -42,6 +42,7 @@
 #include <openthread/link.h>
 #include <openthread/thread.h>
 
+#include "common/equatable.hpp"
 #include "common/string.hpp"
 
 namespace ot {
@@ -86,7 +87,7 @@ PanId GenerateRandomPanId(void);
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ExtAddress : public otExtAddress
+class ExtAddress : public otExtAddress, public Equatable<ExtAddress>
 {
 public:
     enum
@@ -220,28 +221,6 @@ public:
     {
         CopyAddress(aBuffer, m8, aByteOrder);
     }
-
-    /**
-     * This method evaluates whether or not the Extended Addresses match.
-     *
-     * @param[in]  aOther  The Extended Address to compare.
-     *
-     * @retval TRUE   If the Extended Addresses match.
-     * @retval FALSE  If the Extended Addresses do not match.
-     *
-     */
-    bool operator==(const ExtAddress &aOther) const;
-
-    /**
-     * This method evaluates whether or not the Extended Addresses match.
-     *
-     * @param[in]  aOther  The Extended Address to compare.
-     *
-     * @retval TRUE   If the Extended Addresses do not match.
-     * @retval FALSE  If the Extended Addresses match.
-     *
-     */
-    bool operator!=(const ExtAddress &aOther) const { return !(*this == aOther); }
 
     /**
      * This method converts an address to a string.
@@ -447,7 +426,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class Key : public otMacKey
+class Key : public otMacKey, public Equatable<Key>
 {
 public:
     enum
@@ -469,27 +448,6 @@ public:
      */
     const uint8_t *GetKey(void) const { return m8; }
 
-    /**
-     * This method evaluates whether or not two keys match.
-     *
-     * @param[in]  aOtherKey  The key to compare with.
-     *
-     * @retval TRUE   If the key matches the @p aOtherKey.
-     * @retval FALSE  If the key does not match the @p aOtherKey.
-     *
-     */
-    bool operator==(const Key &aOtherKey) const { return memcmp(m8, aOtherKey.m8, kSize) == 0; }
-
-    /**
-     * This method evaluates whether or not two keys match.
-     *
-     * @param[in]  aOtherKey  The key to compare with.
-     *
-     * @retval TRUE   If the key does not match @p aOtherKey.
-     * @retval FALSE  If the key does match @p aOtherKey.
-     *
-     */
-    bool operator!=(const Key &aOtherKey) const { return !(*this == aOtherKey); }
 } OT_TOOL_PACKED_END;
 
 /**
@@ -497,7 +455,7 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ExtendedPanId : public otExtendedPanId
+class ExtendedPanId : public otExtendedPanId, public Equatable<ExtendedPanId>
 {
 public:
     enum
@@ -516,28 +474,6 @@ public:
      *
      */
     void Clear(void) { memset(this, 0, sizeof(*this)); }
-
-    /**
-     * This method evaluates whether or not the Extended PAN Identifiers match.
-     *
-     * @param[in]  aOther  The Extended PAN Id to compare.
-     *
-     * @retval TRUE   If the Extended PAN Identifiers match.
-     * @retval FALSE  If the Extended PAN Identifiers do not match.
-     *
-     */
-    bool operator==(const ExtendedPanId &aOther) const;
-
-    /**
-     * This method evaluates whether or not the Extended PAN Identifiers match.
-     *
-     * @param[in]  aOther  The Extended PAN Id to compare.
-     *
-     * @retval TRUE   If the Extended Addresses do not match.
-     * @retval FALSE  If the Extended Addresses match.
-     *
-     */
-    bool operator!=(const ExtendedPanId &aOther) const { return !(*this == aOther); }
 
     /**
      * This method converts an address to a string.

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -42,6 +42,7 @@
 #include <openthread/link.h>
 #include <openthread/thread.h>
 
+#include "common/clearable.hpp"
 #include "common/equatable.hpp"
 #include "common/string.hpp"
 
@@ -87,7 +88,7 @@ PanId GenerateRandomPanId(void);
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ExtAddress : public otExtAddress, public Equatable<ExtAddress>
+class ExtAddress : public otExtAddress, public Equatable<ExtAddress>, public Clearable<ExtAddress>
 {
 public:
     enum
@@ -110,12 +111,6 @@ public:
         kNormalByteOrder,  // Copy address bytes in normal order (as provided in array buffer).
         kReverseByteOrder, // Copy address bytes in reverse byte order.
     };
-
-    /**
-     * This method clears the Extended Address (sets all bytes to zero).
-     *
-     */
-    void Clear(void) { Fill(0); }
 
     /**
      * This method fills all bytes of address with a given byte value.
@@ -426,19 +421,13 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class Key : public otMacKey, public Equatable<Key>
+class Key : public otMacKey, public Equatable<Key>, public Clearable<Key>
 {
 public:
     enum
     {
         kSize = OT_MAC_KEY_SIZE, // Key size in bytes.
     };
-
-    /**
-     * This method clears the key (set all bytes to zero).
-     *
-     */
-    void Clear(void) { memset(m8, 0, kSize); }
 
     /**
      * This method gets a pointer to the buffer containing the key.
@@ -455,7 +444,7 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ExtendedPanId : public otExtendedPanId, public Equatable<ExtendedPanId>
+class ExtendedPanId : public otExtendedPanId, public Equatable<ExtendedPanId>, public Clearable<ExtendedPanId>
 {
 public:
     enum
@@ -468,12 +457,6 @@ public:
      *
      */
     typedef String<kInfoStringSize> InfoString;
-
-    /**
-     * This method clears the Extended PAN Identifier (sets all bytes to zero).
-     *
-     */
-    void Clear(void) { memset(this, 0, sizeof(*this)); }
 
     /**
      * This method converts an address to a string.

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -320,11 +320,6 @@ uint8_t Address::PrefixMatch(const otIp6Address &aOther) const
     return PrefixMatch(mFields.m8, aOther.mFields.m8, sizeof(Address));
 }
 
-bool Address::operator==(const Address &aOther) const
-{
-    return memcmp(mFields.m8, aOther.mFields.m8, sizeof(mFields.m8)) == 0;
-}
-
 otError Address::FromString(const char *aBuf)
 {
     otError     error  = OT_ERROR_NONE;

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -45,11 +45,6 @@ using ot::Encoding::BigEndian::HostSwap32;
 namespace ot {
 namespace Ip6 {
 
-void Address::Clear(void)
-{
-    memset(mFields.m8, 0, sizeof(mFields));
-}
-
 bool Address::IsUnspecified(void) const
 {
     return (mFields.m32[0] == 0 && mFields.m32[1] == 0 && mFields.m32[2] == 0 && mFields.m32[3] == 0);

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -38,6 +38,7 @@
 
 #include <stdint.h>
 
+#include "common/clearable.hpp"
 #include "common/encoding.hpp"
 #include "common/equatable.hpp"
 #include "common/string.hpp"
@@ -61,7 +62,7 @@ namespace Ip6 {
  *
  */
 OT_TOOL_PACKED_BEGIN
-class Address : public otIp6Address, public Equatable<Address>
+class Address : public otIp6Address, public Equatable<Address>, public Clearable<Address>
 {
 public:
     /**
@@ -104,12 +105,6 @@ public:
      *
      */
     typedef String<kIp6AddressStringSize> InfoString;
-
-    /**
-     * This method clears the IPv6 address by setting it to the Unspecified Address "::".
-     *
-     */
-    void Clear(void);
 
     /**
      * This method indicates whether or not the IPv6 address is the Unspecified Address.

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -39,6 +39,7 @@
 #include <stdint.h>
 
 #include "common/encoding.hpp"
+#include "common/equatable.hpp"
 #include "common/string.hpp"
 #include "mac/mac_types.hpp"
 #include "thread/mle_types.hpp"
@@ -60,7 +61,7 @@ namespace Ip6 {
  *
  */
 OT_TOOL_PACKED_BEGIN
-class Address : public otIp6Address
+class Address : public otIp6Address, public Equatable<Address>
 {
 public:
     /**
@@ -513,28 +514,6 @@ public:
      *
      */
     uint8_t PrefixMatch(const otIp6Address &aOther) const;
-
-    /**
-     * This method evaluates whether or not the IPv6 addresses match.
-     *
-     * @param[in]  aOther  The IPv6 address to compare.
-     *
-     * @retval TRUE   If the IPv6 addresses match.
-     * @retval FALSE  If the IPv6 addresses do not match.
-     *
-     */
-    bool operator==(const Address &aOther) const;
-
-    /**
-     * This method evaluates whether or not the IPv6 addresses differ.
-     *
-     * @param[in]  aOther  The IPv6 address to compare.
-     *
-     * @retval TRUE   If the IPv6 addresses differ.
-     * @retval FALSE  If the IPv6 addresses do not differ.
-     *
-     */
-    bool operator!=(const Address &aOther) const { return !(*this == aOther); }
 
     /**
      * This method converts an IPv6 address string to binary.

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -36,6 +36,7 @@
 
 #include "openthread-core-config.h"
 
+#include "common/clearable.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
@@ -64,17 +65,13 @@ class Ip6;
  * This class implements an IPv6 network interface unicast address.
  *
  */
-class NetifUnicastAddress : public otNetifAddress, public LinkedListEntry<NetifUnicastAddress>
+class NetifUnicastAddress : public otNetifAddress,
+                            public LinkedListEntry<NetifUnicastAddress>,
+                            public Clearable<NetifUnicastAddress>
 {
     friend class Netif;
 
 public:
-    /**
-     * This method clears the object (setting all fields to zero).
-     *
-     */
-    void Clear(void) { memset(this, 0, sizeof(*this)); }
-
     /**
      * This method returns the unicast address.
      *
@@ -113,17 +110,13 @@ private:
  * This class implements an IPv6 network interface multicast address.
  *
  */
-class NetifMulticastAddress : public otNetifMulticastAddress, public LinkedListEntry<NetifMulticastAddress>
+class NetifMulticastAddress : public otNetifMulticastAddress,
+                              public LinkedListEntry<NetifMulticastAddress>,
+                              public Clearable<NetifMulticastAddress>
 {
     friend class Netif;
 
 public:
-    /**
-     * This method clears the object (setting all fields to zero).
-     *
-     */
-    void Clear(void) { memset(this, 0, sizeof(*this)); }
-
     /**
      * This method returns the multicast address.
      *

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -36,6 +36,7 @@
 
 #include "openthread-core-config.h"
 
+#include "common/clearable.hpp"
 #include "net/ip6_address.hpp"
 
 namespace ot {
@@ -204,7 +205,7 @@ public:
  * This class implements a socket address.
  *
  */
-class SockAddr : public otSockAddr
+class SockAddr : public otSockAddr, public Clearable<SockAddr>
 {
 public:
     /**
@@ -212,12 +213,6 @@ public:
      *
      */
     SockAddr(void) { Clear(); }
-
-    /**
-     * This method clears the object (sets all fields to zero).
-     *
-     */
-    void Clear(void) { memset(this, 0, sizeof(*this)); }
 
     /**
      * This method returns a reference to the IPv6 address.

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/dataset.h>
 
+#include "common/clearable.hpp"
 #include "common/equatable.hpp"
 #include "common/locator.hpp"
 #include "common/random.hpp"
@@ -73,15 +74,9 @@ class MasterKey : public otMasterKey, public Equatable<MasterKey>
  *
  */
 OT_TOOL_PACKED_BEGIN
-class Pskc : public otPskc, public Equatable<Pskc>
+class Pskc : public otPskc, public Equatable<Pskc>, public Clearable<Pskc>
 {
 public:
-    /**
-     * This method clears the PSKc (sets all bytes to zero).
-     *
-     */
-    void Clear(void) { memset(this, 0, sizeof(*this)); }
-
 #if !OPENTHREAD_RADIO
     /**
      * This method generates a cryptographically secure random sequence to populate the Thread PSKc.

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/dataset.h>
 
+#include "common/equatable.hpp"
 #include "common/locator.hpp"
 #include "common/random.hpp"
 #include "common/timer.hpp"
@@ -63,31 +64,8 @@ namespace ot {
  *
  */
 OT_TOOL_PACKED_BEGIN
-class MasterKey : public otMasterKey
+class MasterKey : public otMasterKey, public Equatable<MasterKey>
 {
-public:
-    /**
-     * This method evaluates whether or not the Thread Master Keys match.
-     *
-     * @param[in]  aOther  The Thread Master Key to compare.
-     *
-     * @retval TRUE   If the Thread Master Keys match.
-     * @retval FALSE  If the Thread Master Keys do not match.
-     *
-     */
-    bool operator==(const MasterKey &aOther) const { return memcmp(m8, aOther.m8, sizeof(MasterKey)) == 0; }
-
-    /**
-     * This method evaluates whether or not the Thread Master Keys match.
-     *
-     * @param[in]  aOther  The Thread Master Key to compare.
-     *
-     * @retval TRUE   If the Thread Master Keys do not match.
-     * @retval FALSE  If the Thread Master Keys match.
-     *
-     */
-    bool operator!=(const MasterKey &aOther) const { return !(*this == aOther); }
-
 } OT_TOOL_PACKED_END;
 
 /**
@@ -95,7 +73,7 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class Pskc : public otPskc
+class Pskc : public otPskc, public Equatable<Pskc>
 {
 public:
     /**
@@ -103,28 +81,6 @@ public:
      *
      */
     void Clear(void) { memset(this, 0, sizeof(*this)); }
-
-    /**
-     * This method evaluates whether or not the Thread PSKc values match.
-     *
-     * @param[in]  aOther  The Thread PSKc to compare.
-     *
-     * @retval TRUE   If the Thread PSKc values match.
-     * @retval FALSE  If the Thread PSKc values do not match.
-     *
-     */
-    bool operator==(const Pskc &aOther) const { return memcmp(m8, aOther.m8, sizeof(Pskc)) == 0; }
-
-    /**
-     * This method evaluates whether or not the Thread PSKc values match.
-     *
-     * @param[in]  aOther  The Thread PSKc to compare.
-     *
-     * @retval TRUE   If the Thread PSKc values do not match.
-     * @retval FALSE  If the Thread PSKc values match.
-     *
-     */
-    bool operator!=(const Pskc &aOther) const { return !(*this == aOther); }
 
 #if !OPENTHREAD_RADIO
     /**

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -43,6 +43,7 @@
 #include <openthread/thread.h>
 
 #include "common/encoding.hpp"
+#include "common/equatable.hpp"
 #include "common/string.hpp"
 #include "mac/mac_types.hpp"
 
@@ -265,7 +266,7 @@ enum
  * This type represents a MLE device mode.
  *
  */
-class DeviceMode
+class DeviceMode : public Equatable<DeviceMode>
 {
 public:
     enum
@@ -408,28 +409,6 @@ public:
     bool IsValid(void) const { return !IsFullThreadDevice() || IsRxOnWhenIdle(); }
 
     /**
-     *  This method overloads operator `==` to evaluate whether or not two device modes are equal
-     *
-     * @param[in]  aOther  The other device mode to compare with.
-     *
-     * @retval TRUE   If the device modes are equal.
-     * @retval FALSE  If the device modes are not equal.
-     *
-     */
-    bool operator==(const DeviceMode &aOther) const { return (mMode == aOther.mMode); }
-
-    /**
-     * This method overloads operator `!=` to evaluate whether or not two device modes are not equal.
-     *
-     * @param[in]  aOther  The other device mode to compare with.
-     *
-     * @retval TRUE   If the device modes are not equal.
-     * @retval FALSE  If the device modes are equal.
-     *
-     */
-    bool operator!=(const DeviceMode &aOther) const { return !(*this == aOther); }
-
-    /**
      * This method converts the device mode into a human-readable string.
      *
      * @returns An `InfoString` object representing the device mode.
@@ -446,7 +425,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class MeshLocalPrefix : public otMeshLocalPrefix
+class MeshLocalPrefix : public otMeshLocalPrefix, public Equatable<MeshLocalPrefix>
 {
 public:
     enum
@@ -454,28 +433,6 @@ public:
         kSize   = OT_MESH_LOCAL_PREFIX_SIZE,            ///< Size in bytes.
         kLength = OT_MESH_LOCAL_PREFIX_SIZE * CHAR_BIT, ///< Length of Mesh Local Prefix in bits.
     };
-
-    /**
-     * This method evaluates whether or not two Mesh Local Prefixes match.
-     *
-     * @param[in]  aOther  The Mesh Local Prefix to compare.
-     *
-     * @retval TRUE   If the Mesh Local Prefixes match.
-     * @retval FALSE  If the Mesh Local Prefixes do not match.
-     *
-     */
-    bool operator==(const MeshLocalPrefix &aOther) const { return memcmp(m8, aOther.m8, sizeof(*this)) == 0; }
-
-    /**
-     * This method evaluates whether or not two Mesh Local Prefixes match.
-     *
-     * @param[in]  aOther  The Mesh Local Prefix to compare.
-     *
-     * @retval TRUE   If the Mesh Local Prefixes do not match.
-     * @retval FALSE  If the Mesh Local Prefixes match.
-     *
-     */
-    bool operator!=(const MeshLocalPrefix &aOther) const { return !(*this == aOther); }
 
     /**
      * This method derives and sets the Mesh Local Prefix from an Extended PAN ID.
@@ -582,7 +539,7 @@ public:
 };
 
 OT_TOOL_PACKED_BEGIN
-class RouterIdSet
+class RouterIdSet : public Equatable<RouterIdSet>
 {
 public:
     /**
@@ -617,31 +574,6 @@ public:
      *
      */
     void Remove(uint8_t aRouterId) { mRouterIdSet[aRouterId / 8] &= ~(0x80 >> (aRouterId % 8)); }
-
-    /**
-     * This method returns whether or not the Router ID sets are equal.
-     *
-     * @param[in]  aOther The other Router ID Set to compare with.
-     *
-     * @retval TRUE   If the Router ID sets are equal.
-     * @retval FALSE  If the Router ID sets are not equal.
-     *
-     */
-    bool operator==(const RouterIdSet &aOther) const
-    {
-        return memcmp(mRouterIdSet, aOther.mRouterIdSet, sizeof(mRouterIdSet)) == 0;
-    }
-
-    /**
-     * This method returns whether or not the Router ID sets are not equal.
-     *
-     * @param[in]  aOther The other Router ID Set to compare with.
-     *
-     * @retval TRUE   If the Router ID sets are not equal.
-     * @retval FALSE  If the Router ID sets are equal.
-     *
-     */
-    bool operator!=(const RouterIdSet &aOther) const { return !(*this == aOther); }
 
 private:
     uint8_t mRouterIdSet[BitVectorBytes(Mle::kMaxRouterId + 1)];

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -42,6 +42,7 @@
 
 #include <openthread/thread.h>
 
+#include "common/clearable.hpp"
 #include "common/encoding.hpp"
 #include "common/equatable.hpp"
 #include "common/string.hpp"
@@ -448,15 +449,9 @@ public:
  * This class represents the Thread Leader Data.
  *
  */
-class LeaderData : public otLeaderData
+class LeaderData : public otLeaderData, public Clearable<LeaderData>
 {
 public:
-    /**
-     * This method clears the Leader Data (setting all the fields to zero).
-     *
-     */
-    void Clear(void) { memset(this, 0, sizeof(*this)); }
-
     /**
      * This method returns the Partition ID value.
      *

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -40,6 +40,7 @@
 
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
+#include "common/equatable.hpp"
 #include "net/ip6_address.hpp"
 
 namespace ot {
@@ -223,7 +224,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class HasRouteEntry
+class HasRouteEntry : public Equatable<HasRouteEntry>
 {
 public:
     /**
@@ -287,20 +288,6 @@ public:
      *
      */
     const HasRouteEntry *GetNext(void) const { return (this + 1); }
-
-    /**
-     * This method indicates whether two entries fully match.
-     *
-     * @param[in]  aOtherEntry  Another entry to compare with it.
-     *
-     * @retval TRUE  The two entries are equal.
-     * @retval FALSE The two entries are not equal.
-     *
-     */
-    bool operator==(const HasRouteEntry &aOtherEntry) const
-    {
-        return (memcmp(this, &aOtherEntry, sizeof(HasRouteEntry)) == 0);
-    }
 
 private:
     enum
@@ -559,7 +546,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class BorderRouterEntry
+class BorderRouterEntry : public Equatable<BorderRouterEntry>
 {
 public:
     enum
@@ -729,20 +716,6 @@ public:
      *
      */
     const BorderRouterEntry *GetNext(void) const { return (this + 1); }
-
-    /**
-     * This method indicates whether two entries fully match.
-     *
-     * @param[in]  aOtherEntry  Another entry to compare with it.
-     *
-     * @retval TRUE  The two entries are equal.
-     * @retval FALSE The two entries are not equal.
-     *
-     */
-    bool operator==(const BorderRouterEntry &aOtherEntry) const
-    {
-        return (memcmp(this, &aOtherEntry, sizeof(BorderRouterEntry)) == 0);
-    }
 
 private:
     uint16_t mRloc;


### PR DESCRIPTION
This PR contains two commits:

 **[core] add Equatable class providing overloads of `==` and `!=` operator**
    
 This commit adds new class `Equatable` (inherited by other types)
 providing overloads of operators `==` and `!=`. The implementation
 simply compares all the bytes of two instances of same type to be
 equal (using `memcmp`).

**[core] add Clearable class providing simple Clear() method**
    
This commit adds new class `Clearable` (inherited by other types)
providing simple implementation of `Clear()` which sets all the
instance bytes to zero (using `memset()`).
