### PR TITLE
[continuous-integration] use apt-get instead of apt

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt remove -y clang-6.0 libclang-common-6.0-dev libclang1-6.0 libllvm6.0
-        sudo apt autoremove
-        sudo apt --no-install-recommends install -y clang-tools clang-format-6.0 shellcheck
+        sudo apt-get update
+        sudo apt-get remove -y clang-6.0 libclang-common-6.0-dev libclang1-6.0 libllvm6.0
+        sudo apt-get autoremove
+        sudo apt-get --no-install-recommends install -y clang-tools clang-format-6.0 shellcheck
         python3 -m pip install yapf==0.29.0
         sudo snap install shfmt
     - name: Check
@@ -75,8 +75,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y ninja-build libreadline-dev libncurses-dev
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y ninja-build libreadline-dev libncurses-dev
     - name: Package
       run: |
         script/test package
@@ -87,10 +87,10 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt remove -y clang-6.0 libclang-common-6.0-dev libclang1-6.0 libllvm6.0
-        sudo apt autoremove
-        sudo apt --no-install-recommends install -y clang-tools
+        sudo apt-get update
+        sudo apt-get remove -y clang-6.0 libclang-common-6.0-dev libclang1-6.0 libllvm6.0
+        sudo apt-get autoremove
+        sudo apt-get --no-install-recommends install -y clang-tools
     - name: Run
       run: |
         script/check-scan-build
@@ -121,8 +121,8 @@ jobs:
     - name: Bootstrap
       run: |
         cd /tmp
-        sudo apt update
-        sudo apt --no-install-recommends install -y lib32z1 ninja-build
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y lib32z1 ninja-build
         wget ${{ matrix.gcc_download_url }} -O gcc-arm.tar.bz2
         tar xjf gcc-arm.tar.bz2
 
@@ -146,8 +146,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y gcc-${{ matrix.gcc_ver }} g++-${{ matrix.gcc_ver }} ninja-build libreadline-dev libncurses-dev
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y gcc-${{ matrix.gcc_ver }} g++-${{ matrix.gcc_ver }} ninja-build libreadline-dev libncurses-dev
     - name: Build
       run: |
         script/check-simulation-build
@@ -170,9 +170,9 @@ jobs:
       - name: Bootstrap
         run: |
           sudo dpkg --add-architecture i386
-          sudo apt update
-          sudo apt --no-install-recommends install -y clang-${{ matrix.clang_ver }} clang++-${{ matrix.clang_ver }} g++-multilib ninja-build
-          sudo apt --no-install-recommends install -y libreadline-dev:i386 libncurses-dev:i386
+          sudo apt-get update
+          sudo apt-get --no-install-recommends install -y clang-${{ matrix.clang_ver }} clang++-${{ matrix.clang_ver }} g++-multilib ninja-build
+          sudo apt-get --no-install-recommends install -y libreadline-dev:i386 libncurses-dev:i386
       - name: Build
         run: |
           script/check-posix-build
@@ -183,8 +183,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y ninja-build
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y ninja-build
         cd /tmp
         wget -O gn.zip https://chrome-infra-packages.appspot.com/dl/gn/gn/linux-amd64/+/latest
         unzip -o gn.zip

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -51,8 +51,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y llvm-runtime
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y llvm-runtime
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Run
       run: |
@@ -78,8 +78,8 @@ jobs:
         go-version: '1.13'
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y g++-multilib
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y g++-multilib
         ./bootstrap
     - name: Run OTNS Tests
       run: |
@@ -103,8 +103,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y g++-multilib
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y g++-multilib
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
       run: |
@@ -130,8 +130,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y g++-multilib
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y g++-multilib
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
       run: |
@@ -157,8 +157,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y g++-multilib
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y g++-multilib
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
       run: |
@@ -176,7 +176,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        OT_OPTIONS=-DOT_READLINE=OFF sudo apt --no-install-recommends install -y expect ninja-build
+        OT_OPTIONS=-DOT_READLINE=OFF sudo apt-get --no-install-recommends install -y expect ninja-build
     - name: Run
       run: |
         VIRTUAL_TIME=0 ./script/test build expect
@@ -225,8 +225,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y g++-multilib python3-setuptools
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y g++-multilib python3-setuptools
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
         sudo python3 -m pip install git+https://github.com/openthread/pyspinel
     - name: Build
@@ -252,8 +252,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y libreadline6-dev
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y libreadline6-dev
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
       run: |
@@ -280,8 +280,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y libreadline6-dev python3-setuptools
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y libreadline6-dev python3-setuptools
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
         sudo python3 -m pip install git+https://github.com/openthread/pyspinel
     - name: Build
@@ -303,8 +303,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y expect
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y expect
     - name: Build
       run: |
         ./bootstrap
@@ -323,8 +323,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-         sudo apt --no-install-recommends install -y socat expect
+        sudo apt-get update
+         sudo apt-get --no-install-recommends install -y socat expect
          cd /tmp
          wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
          tar xvf bsd-licensed.tar.gz
@@ -352,8 +352,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-         sudo apt --no-install-recommends install -y socat expect
+        sudo apt-get update
+         sudo apt-get --no-install-recommends install -y socat expect
          cd /tmp
          wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
          tar xvf bsd-licensed.tar.gz
@@ -392,8 +392,8 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y g++-multilib ninja-build
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y g++-multilib ninja-build
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
       run: |

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -324,15 +324,15 @@ jobs:
     - name: Bootstrap
       run: |
         sudo apt-get update
-         sudo apt-get --no-install-recommends install -y socat expect
-         cd /tmp
-         wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
-         tar xvf bsd-licensed.tar.gz
-         cd libcoap-bsd-licensed
-         ./autogen.sh
-         ./configure --prefix= --exec-prefix=/usr --with-boost=internal --disable-tests --disable-documentation
-         make -j2
-         sudo make install
+        sudo apt-get --no-install-recommends install -y socat expect
+        cd /tmp
+        wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
+        tar xvf bsd-licensed.tar.gz
+        cd libcoap-bsd-licensed
+        ./autogen.sh
+        ./configure --prefix= --exec-prefix=/usr --with-boost=internal --disable-tests --disable-documentation
+        make -j2
+        sudo make install
     - name: Build
       run: |
         ./bootstrap
@@ -353,15 +353,15 @@ jobs:
     - name: Bootstrap
       run: |
         sudo apt-get update
-         sudo apt-get --no-install-recommends install -y socat expect
-         cd /tmp
-         wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
-         tar xvf bsd-licensed.tar.gz
-         cd libcoap-bsd-licensed
-         ./autogen.sh
-         ./configure --prefix= --exec-prefix=/usr --with-boost=internal --disable-tests --disable-documentation
-         make -j2
-         sudo make install
+        sudo apt-get --no-install-recommends install -y socat expect
+        cd /tmp
+        wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
+        tar xvf bsd-licensed.tar.gz
+        cd libcoap-bsd-licensed
+        ./autogen.sh
+        ./configure --prefix= --exec-prefix=/usr --with-boost=internal --disable-tests --disable-documentation
+        make -j2
+        sudo make install
     - name: Build
       run: |
         ./bootstrap

--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -48,13 +48,13 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y dbus libdbus-1-dev
-        sudo apt --no-install-recommends install -y autoconf-archive
-        sudo apt --no-install-recommends install -y bsdtar
-        sudo apt --no-install-recommends install -y libtool
-        sudo apt --no-install-recommends install -y libglib2.0-dev
-        sudo apt --no-install-recommends install -y libboost-dev libboost-signals-dev
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y dbus libdbus-1-dev
+        sudo apt-get --no-install-recommends install -y autoconf-archive
+        sudo apt-get --no-install-recommends install -y bsdtar
+        sudo apt-get --no-install-recommends install -y libtool
+        sudo apt-get --no-install-recommends install -y libglib2.0-dev
+        sudo apt-get --no-install-recommends install -y libboost-dev libboost-signals-dev
 
         git clone --depth=1 --branch=master https://github.com/openthread/wpantund.git
         cd wpantund
@@ -77,13 +77,13 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt update
-        sudo apt --no-install-recommends install -y dbus libdbus-1-dev
-        sudo apt --no-install-recommends install -y autoconf-archive
-        sudo apt --no-install-recommends install -y bsdtar
-        sudo apt --no-install-recommends install -y libtool
-        sudo apt --no-install-recommends install -y libglib2.0-dev
-        sudo apt --no-install-recommends install -y libboost-dev libboost-signals-dev
+        sudo apt-get update
+        sudo apt-get --no-install-recommends install -y dbus libdbus-1-dev
+        sudo apt-get --no-install-recommends install -y autoconf-archive
+        sudo apt-get --no-install-recommends install -y bsdtar
+        sudo apt-get --no-install-recommends install -y libtool
+        sudo apt-get --no-install-recommends install -y libglib2.0-dev
+        sudo apt-get --no-install-recommends install -y libboost-dev libboost-signals-dev
 
         git clone --depth=1 --branch=master https://github.com/openthread/wpantund.git
         cd wpantund

--- a/etc/docker/arm32v7_ubuntu_wpantund/Dockerfile
+++ b/etc/docker/arm32v7_ubuntu_wpantund/Dockerfile
@@ -5,7 +5,6 @@ LABEL maintainer="Marcin K Szczodrak"
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
-RUN apt-get --no-install-recommends install -y apt-utils
 RUN apt-get --no-install-recommends install -y build-essential git make autoconf autoconf-archive \
     automake dbus libtool gcc g++ libreadline-dev libdbus-1-dev libboost-dev
 

--- a/etc/docker/x86_ubuntu_wpantund/Dockerfile
+++ b/etc/docker/x86_ubuntu_wpantund/Dockerfile
@@ -5,7 +5,6 @@ LABEL maintainer="Marcin K Szczodrak"
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update
-RUN apt-get --no-install-recommends install -y apt-utils
 RUN apt-get --no-install-recommends install -y build-essential git make autoconf autoconf-archive \
     automake dbus libtool gcc g++ libreadline-dev libdbus-1-dev libboost-dev
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -35,7 +35,7 @@ set -e
 
 install_packages_apt()
 {
-    # apt update and install dependencies
+    # apt-get update and install dependencies
     sudo apt-get update
     sudo apt-get --no-install-recommends install -y automake g++ libtool lsb-release make cmake ninja-build
 


### PR DESCRIPTION
This commit change apt to apt-get for the WARNING in build logs:

```
WARNING: apt does not have a stable CLI interface. Use with caution in
scripts.
```