### PR TITLE
[mle] restore operational datasets when becoming leader

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -337,6 +337,8 @@ void MleRouter::SetStateRouter(uint16_t aRloc16)
 
 void MleRouter::SetStateLeader(uint16_t aRloc16)
 {
+    IgnoreError(Get<MeshCoP::ActiveDataset>().Restore());
+    IgnoreError(Get<MeshCoP::PendingDataset>().Restore());
     SetRloc16(aRloc16);
 
     SetRole(kRoleLeader);


### PR DESCRIPTION
The leader is authoritative in the operational datasets that it
distributes. This commit ensures that a device becoming a leader
restores the operational dataset from non-volatile. This ensures that
the operational datasets that the leader attempts to distribute are
the same as in its non-volatile storage.