### PR TITLE
[test] add expect tests for `child`

### DIFF
--- a/tests/scripts/expect/cli-2-nodes.exp
+++ b/tests/scripts/expect/cli-2-nodes.exp
@@ -1,0 +1,143 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+proc wait_for {command expected} {
+    set result 0
+    for {set i 0} {$i < 20} {incr i} {
+        send "$command\n"
+        expect {
+            -re $expected {
+                set result 1
+            }
+            timeout {
+                # Do nothing
+            }
+        }
+        if {$result == 1} {
+            break
+        }
+    }
+    if {$result == 0} {
+        exit 1
+    }
+}
+
+
+# setup
+set timeout 1
+spawn $env(OT_COMMAND) 1
+set spawn_1 $spawn_id
+expect_after {
+    timeout { exit 1 }
+}
+spawn $env(OT_COMMAND) 2
+set spawn_2 $spawn_id
+expect_after {
+    timeout { exit 1 }
+}
+set psk "J01NME"
+
+set spawn_id $spawn_2
+send "eui64\n"
+expect -re {([0-9a-f]{16})}
+set eui64 $expect_out(1,string)
+expect "Done"
+
+set spawn_id $spawn_1
+send "dataset init new\n"
+expect "Done"
+send "dataset commit active\n"
+expect "Done"
+send "ifconfig up\n"
+expect "Done"
+send "thread start\n"
+expect "Done"
+wait_for "state" {leader}
+send "commissioner start\n"
+expect "Done"
+expect "Commissioner: active"
+send "commissioner joiner add $eui64 $psk\n"
+expect "Done"
+
+set spawn_id $spawn_2
+send "mode rs\n"
+expect "Done"
+send "ifconfig up\n"
+expect "Done"
+send "joiner start $psk\n"
+expect "Done"
+wait_for "" {Join success}
+send "thread start\n"
+expect "Done"
+wait_for "state" "child"
+
+
+# ping
+set spawn_id $spawn_2
+send "ipaddr\n"
+expect -re {(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4})}
+set addr $expect_out(1,string)
+
+set spawn_id $spawn_1
+send "ping $addr\n"
+expect "16 bytes from $addr: icmp_seq=1"
+send "ping $addr 20 10 0.123456 255\n"
+for {set i 2} {$i <= 11} {incr i} {
+    expect "28 bytes from $addr: icmp_seq=$i"
+}
+
+
+# child
+set spawn_id $spawn_2
+send "extaddr\n"
+expect -re {([0-9a-f]{16})}
+set extaddr $expect_out(1,string)
+expect "Done"
+
+set spawn_id $spawn_1
+send "child table\n"
+expect "$extaddr"
+expect "Done"
+send "child list\n"
+expect -re {(\d+)}
+set child_id $expect_out(1,string)
+expect "Done"
+send "child $child_id\n"
+expect "Ext Addr: $extaddr"
+expect "Done"
+
+
+# cleanup
+set spawn_id $spawn_1
+send "\x04"
+expect eof
+
+set spawn_id $spawn_2
+send "\x04"
+expect eof

--- a/tests/scripts/expect/cli-ping.exp
+++ b/tests/scripts/expect/cli-ping.exp
@@ -33,88 +33,14 @@ expect_after {
     timeout { exit 1 }
 }
 send "ping ::1 1 2 1 1\n"
-expect "Done\r\n"
+expect "Done"
 send "ping stop\n"
-expect "Done\r\n"
+expect "Done"
+send "ping ::1 1 2 0.12345 1\n"
+expect "Done"
+send "ping stop\n"
+expect "Done"
 send "ping ::1 1 2 1 1 1\n"
-expect "Error 7: InvalidArgs\r\n"
-send "\x04"
-expect eof
-
-
-proc wait_for {command expected} {
-    set result 0
-    for {set i 0} {$i < 20} {incr i} {
-        send "$command\n"
-        expect {
-            -re $expected {
-                set result 1
-            }
-            timeout {
-                # Do nothing
-            }
-        }
-        if {$result == 1} {
-            break
-        }
-    }
-    if {$result == 0} {
-        exit 1
-    }
-}
-
-spawn $env(OT_COMMAND) 1
-set spawn_1 $spawn_id
-expect_after {
-    timeout { exit 1 }
-}
-spawn $env(OT_COMMAND) 2
-set spawn_2 $spawn_id
-expect_after {
-    timeout { exit 1 }
-}
-set psk "J01NME"
-
-set spawn_id $spawn_2
-send "eui64\n"
-expect -re "(\[0-9a-f\]{16})"
-set eui64 $expect_out(1,string)
-
-set spawn_id $spawn_1
-send "dataset init new\n"
-expect "Done"
-send "dataset commit active\n"
-expect "Done"
-send "ifconfig up\n"
-expect "Done"
-send "thread start\n"
-expect "Done"
-wait_for "state" "leader"
-send "commissioner start\n"
-expect "Done"
-expect "Commissioner: active"
-send "commissioner joiner add $eui64 $psk\n"
-expect "Done"
-
-set spawn_id $spawn_2
-send "ifconfig up\n"
-expect "Done"
-send "joiner start $psk\n"
-expect "Done"
-wait_for "" "Join success"
-send "thread start\n"
-expect "Done"
-wait_for "state" "child|router"
-send "ipaddr\n"
-expect -re "((\[0-9a-fA-F\]{1,4}:){7,7}\[0-9a-fA-F\]{1,4})"
-set addr $expect_out(1,string)
-
-set spawn_id $spawn_1
-send "ping $addr\n"
-expect "16 bytes from $addr:"
-send "\x04"
-expect eof
-
-set spawn_id $spawn_2
+expect "Error 7: InvalidArgs"
 send "\x04"
 expect eof


### PR DESCRIPTION
This adds test cases for `child` command. Also moves `ping` tests with 2 nodes to `cli-2-nodes.exp`, future tests requiring 2 nodes will be placed in this file.