### PR TITLE
[tests] skip running expected fail tests

### DIFF
--- a/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
@@ -43,6 +43,8 @@ MED1 = 5
 
 
 class Cert_5_3_10_AddressQuery(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         LEADER: {
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/Cert_5_7_01_CoapDiagCommands_A.py
+++ b/tests/scripts/thread-cert/Cert_5_7_01_CoapDiagCommands_A.py
@@ -48,6 +48,8 @@ MTDS = [MED1, SED1]
 
 
 class Cert_5_7_01_CoapDiagCommands_A(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         LEADER: {
             'whitelist': [ROUTER1],

--- a/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
@@ -41,6 +41,8 @@ JOINER = 2
 
 
 class Cert_8_1_01_Commissioning(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'masterkey': '00112233445566778899aabbccddeeff',

--- a/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
@@ -36,6 +36,8 @@ JOINER = 2
 
 
 class Cert_8_1_02_Commissioning(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'masterkey': 'deadbeefdeadbeefdeadbeefdeadbeef',

--- a/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
@@ -37,6 +37,8 @@ JOINER = 3
 
 
 class Cert_8_2_01_JoinerRouter(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'masterkey': 'deadbeefdeadbeefdeadbeefdeadbeef',

--- a/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
@@ -37,6 +37,8 @@ JOINER = 3
 
 
 class Cert_8_2_02_JoinerRouter(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'masterkey': 'deadbeefdeadbeefdeadbeefdeadbeef',

--- a/tests/scripts/thread-cert/Cert_9_2_02_MGMTCommissionerSet.py
+++ b/tests/scripts/thread-cert/Cert_9_2_02_MGMTCommissionerSet.py
@@ -40,6 +40,8 @@ LEADER = 2
 
 
 class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/Cert_9_2_04_ActiveDataset.py
+++ b/tests/scripts/thread-cert/Cert_9_2_04_ActiveDataset.py
@@ -36,6 +36,8 @@ LEADER = 2
 
 
 class Cert_9_2_04_ActiveDataset(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'active_dataset': {

--- a/tests/scripts/thread-cert/Cert_9_2_07_DelayTimer.py
+++ b/tests/scripts/thread-cert/Cert_9_2_07_DelayTimer.py
@@ -47,6 +47,8 @@ COMMISSIONER_PENDING_PANID = 0xafce
 
 
 class Cert_9_2_7_DelayTimer(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'active_dataset': {

--- a/tests/scripts/thread-cert/Cert_9_2_08_PersistentDatasets.py
+++ b/tests/scripts/thread-cert/Cert_9_2_08_PersistentDatasets.py
@@ -49,6 +49,8 @@ MTDS = [ED, SED]
 
 
 class Cert_9_2_8_PersistentDatasets(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'active_dataset': {

--- a/tests/scripts/thread-cert/Cert_9_2_09_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_09_PendingPartition.py
@@ -44,6 +44,8 @@ ROUTER2 = 4
 
 
 class Cert_9_2_09_PendingPartition(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'active_dataset': {

--- a/tests/scripts/thread-cert/Cert_9_2_10_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_10_PendingPartition.py
@@ -48,6 +48,8 @@ MTDS = [ED1, SED1]
 
 
 class Cert_9_2_10_PendingPartition(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'active_dataset': {

--- a/tests/scripts/thread-cert/Cert_9_2_11_MasterKey.py
+++ b/tests/scripts/thread-cert/Cert_9_2_11_MasterKey.py
@@ -48,6 +48,8 @@ MTDS = [ED1, SED1]
 
 
 class Cert_9_2_11_MasterKey(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'active_dataset': {

--- a/tests/scripts/thread-cert/Cert_9_2_12_Announce.py
+++ b/tests/scripts/thread-cert/Cert_9_2_12_Announce.py
@@ -47,6 +47,8 @@ DATASET2_PANID = 0xafce
 
 
 class Cert_9_2_12_Announce(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         LEADER1: {
             'active_dataset': {

--- a/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
@@ -38,6 +38,8 @@ ED1 = 4
 
 
 class Cert_9_2_13_EnergyScan(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
+++ b/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
@@ -38,6 +38,8 @@ LEADER2 = 4
 
 
 class Cert_9_2_14_PanIdQuery(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/Cert_9_2_15_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_15_PendingPartition.py
@@ -43,6 +43,8 @@ ROUTER2 = 4
 
 
 class Cert_9_2_15_PendingPartition(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'active_dataset': {

--- a/tests/scripts/thread-cert/Cert_9_2_16_ActivePendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_16_ActivePendingPartition.py
@@ -44,6 +44,8 @@ ROUTER2 = 4
 
 
 class Cert_9_2_16_ActivePendingPartition(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'active_dataset': {

--- a/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
@@ -43,6 +43,8 @@ ED1 = 3
 
 
 class Cert_9_2_17_Orphan(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         LEADER1: {
             'active_dataset': {

--- a/tests/scripts/thread-cert/Cert_9_2_18_RollBackActiveTimestamp.py
+++ b/tests/scripts/thread-cert/Cert_9_2_18_RollBackActiveTimestamp.py
@@ -49,6 +49,8 @@ MTDS = [ED1, SED1]
 
 
 class Cert_9_2_18_RollBackActiveTimestamp(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         COMMISSIONER: {
             'active_dataset': {

--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -291,36 +291,4 @@ TESTS                                                              = \
     $(check_SCRIPTS)                                                 \
     $(NULL)
 
-XFAIL_NCP_TESTS                                                    = \
-    test_coaps.py                                                    \
-    test_coap_observe.py                                             \
-    test_diag.py                                                     \
-    test_ipv6_fragmentation.py                                       \
-    test_ipv6_source_selection.py                                    \
-    test_reed_address_solicit_rejected.py                            \
-    test_service.py                                                  \
-    Cert_5_3_10_AddressQuery.py                                      \
-    Cert_5_7_01_CoapDiagCommands_A.py                                \
-    Cert_8_1_01_Commissioning.py                                     \
-    Cert_8_1_02_Commissioning.py                                     \
-    Cert_8_2_01_JoinerRouter.py                                      \
-    Cert_8_2_02_JoinerRouter.py                                      \
-    Cert_9_2_02_MGMTCommissionerSet.py                               \
-    Cert_9_2_04_ActiveDataset.py                                     \
-    Cert_9_2_07_DelayTimer.py                                        \
-    Cert_9_2_08_PersistentDatasets.py                                \
-    Cert_9_2_09_PendingPartition.py                                  \
-    Cert_9_2_10_PendingPartition.py                                  \
-    Cert_9_2_11_MasterKey.py                                         \
-    Cert_9_2_12_Announce.py                                          \
-    Cert_9_2_13_EnergyScan.py                                        \
-    Cert_9_2_14_PanIdQuery.py                                        \
-    Cert_9_2_15_PendingPartition.py                                  \
-    Cert_9_2_16_ActivePendingPartition.py                            \
-    Cert_9_2_17_Orphan.py                                            \
-    Cert_9_2_18_RollBackActiveTimestamp.py                           \
-    $(NULL)
-
-XFAIL_TESTS = $(if $(filter $(NODE_TYPE),ncp-sim),$(XFAIL_NCP_TESTS))
-
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/tests/scripts/thread-cert/test_coap_observe.py
+++ b/tests/scripts/thread-cert/test_coap_observe.py
@@ -41,6 +41,9 @@ class TestCoapObserve(thread_cert.TestCase):
     """
     Test suite for CoAP Observations (RFC7641).
     """
+
+    support_ncp = False
+
     topology = {
         LEADER: {
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/test_coaps.py
+++ b/tests/scripts/thread-cert/test_coaps.py
@@ -37,6 +37,8 @@ ROUTER = 2
 
 
 class TestCoaps(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         LEADER: {
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/test_diag.py
+++ b/tests/scripts/thread-cert/test_diag.py
@@ -34,10 +34,12 @@ import thread_cert
 
 
 class TestDiag(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {1: None}
 
     def test(self):
-        self.node = self.nodes[1]
+        node = self.nodes[1]
 
         cases = [
             ('diag\n', 'diagnostics mode is disabled\r\n'),
@@ -88,11 +90,11 @@ class TestDiag(thread_cert.TestCase):
         ]
 
         for case in cases:
-            self.node.send_command(case[0])
+            node.send_command(case[0])
             self.simulator.go(1)
             if type(self.simulator).__name__ == 'VirtualTime':
                 time.sleep(0.1)
-            self.node._expect(case[1])
+            node._expect(case[1])
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/test_ipv6_fragmentation.py
+++ b/tests/scripts/thread-cert/test_ipv6_fragmentation.py
@@ -38,6 +38,8 @@ ROUTER = 2
 
 
 class TestIPv6Fragmentation(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         LEADER: {
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/test_ipv6_source_selection.py
+++ b/tests/scripts/thread-cert/test_ipv6_source_selection.py
@@ -37,6 +37,8 @@ ROUTER = 2
 
 
 class TestIPv6SourceSelection(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         LEADER: {
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/test_reed_address_solicit_rejected.py
+++ b/tests/scripts/thread-cert/test_reed_address_solicit_rejected.py
@@ -47,6 +47,8 @@ SRV_0_SERVER_DATA = 'bar'
 
 
 class TestREEDAddressSolicitRejected(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         LEADER: {
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/test_service.py
+++ b/tests/scripts/thread-cert/test_service.py
@@ -49,6 +49,8 @@ SRV_1_SERVER_DATA = 'qux'
 
 
 class Test_Service(thread_cert.TestCase):
+    support_ncp = False
+
     topology = {
         LEADER: {
             'channel': 12,

--- a/tests/scripts/thread-cert/thread_cert.py
+++ b/tests/scripts/thread-cert/thread_cert.py
@@ -28,6 +28,7 @@
 #
 
 import os
+import sys
 import unittest
 
 import config
@@ -50,7 +51,21 @@ EXTENDED_ADDRESS_BASE = 0x166e0a0000000000
 """Extended address base to keep U/L bit 1. The value is borrowed from Thread Test Harness."""
 
 
-class TestCase(unittest.TestCase):
+class NcpSupportMixin():
+    """ The mixin to check whether a test case supports NCP.
+    """
+
+    support_ncp = True
+
+    def __init__(self, *args, **kwargs):
+        if os.getenv('NODE_TYPE', 'sim') == 'ncp-sim' and not self.support_ncp:
+            # 77 means skip this test case in automake tests
+            sys.exit(77)
+
+        super().__init__(*args, **kwargs)
+
+
+class TestCase(NcpSupportMixin, unittest.TestCase):
     """The base class for all thread certification test cases.
 
     The `topology` member of sub-class is used to create test topology.


### PR DESCRIPTION
This commit skip running expected fail tests so that it will be easier
to find real failures and saves some time.