### PR TITLE
[simulation] send enh-ack for 802.15.4-2015 frames

### DIFF
--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -732,7 +732,7 @@ void radioTransmit(struct RadioMessage *aMessage, const struct otRadioFrame *aFr
 #endif // OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0
 }
 
-void radioGenerateAck(void)
+void radioSendAck(void)
 {
     if (
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
@@ -750,24 +750,24 @@ void radioGenerateAck(void)
     // Use enh-ack for 802154-2015 secured frame
     if (otMacFrameIsVersion2015(&sReceiveFrame) && otMacFrameIsSecurityEnabled(&sReceiveFrame))
     {
-        otMacFrameGenerateEnhAck(&sReceiveFrame, sReceiveFrame.mInfo.mRxInfo.mAckedWithFramePending, NULL, 0,
-                                 &sAckFrame);
+        otEXPECT(otMacFrameGenerateEnhAck(&sReceiveFrame, sReceiveFrame.mInfo.mRxInfo.mAckedWithFramePending, NULL, 0,
+                                          &sAckFrame) == OT_ERROR_NONE);
     }
     else
 #endif
     {
         otMacFrameGenerateImmAck(&sReceiveFrame, sReceiveFrame.mInfo.mRxInfo.mAckedWithFramePending, &sAckFrame);
     }
-}
-
-void radioSendAck(void)
-{
-    radioGenerateAck();
 
     sAckMessage.mChannel = sReceiveFrame.mChannel;
 
     radioComputeCrc(&sAckMessage, sAckFrame.mLength);
     radioTransmit(&sAckMessage, &sAckFrame);
+
+#if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
+exit:
+#endif
+    return;
 }
 
 void radioProcessFrame(otInstance *aInstance)

--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -747,8 +747,8 @@ void radioSendAck(void)
     }
 
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
-    // Use enh-ack for 802154-2015 secured frame
-    if (otMacFrameIsVersion2015(&sReceiveFrame) && otMacFrameIsSecurityEnabled(&sReceiveFrame))
+    // Use enh-ack for 802.15.4-2015 frames
+    if (otMacFrameIsVersion2015(&sReceiveFrame))
     {
         otEXPECT(otMacFrameGenerateEnhAck(&sReceiveFrame, sReceiveFrame.mInfo.mRxInfo.mAckedWithFramePending, NULL, 0,
                                           &sAckFrame) == OT_ERROR_NONE);

--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -746,7 +746,18 @@ void radioGenerateAck(void)
         sReceiveFrame.mInfo.mRxInfo.mAckedWithFramePending = true;
     }
 
-    otMacFrameGenerateImmAck(&sReceiveFrame, sReceiveFrame.mInfo.mRxInfo.mAckedWithFramePending, &sAckFrame);
+#if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
+    // Use enh-ack for 802154-2015 secured frame
+    if (otMacFrameIsVersion2015(&sReceiveFrame) && otMacFrameIsSecurityEnabled(&sReceiveFrame))
+    {
+        otMacFrameGenerateEnhAck(&sReceiveFrame, sReceiveFrame.mInfo.mRxInfo.mAckedWithFramePending, NULL, 0,
+                                 &sAckFrame);
+    }
+    else
+#endif
+    {
+        otMacFrameGenerateImmAck(&sReceiveFrame, sReceiveFrame.mInfo.mRxInfo.mAckedWithFramePending, &sAckFrame);
+    }
 }
 
 void radioSendAck(void)

--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -132,6 +132,11 @@ bool otMacFrameIsVersion2015(const otRadioFrame *aFrame)
     return static_cast<const Mac::Frame *>(aFrame)->IsVersion2015();
 }
 
+bool otMacFrameIsSecurityEnabled(const otRadioFrame *aFrame)
+{
+    return static_cast<const Mac::Frame *>(aFrame)->GetSecurityEnabled();
+}
+
 void otMacFrameGenerateImmAck(const otRadioFrame *aFrame, bool aIsFramePending, otRadioFrame *aAckFrame)
 {
     assert(aFrame != NULL && aAckFrame != NULL);
@@ -139,7 +144,7 @@ void otMacFrameGenerateImmAck(const otRadioFrame *aFrame, bool aIsFramePending, 
     static_cast<Mac::TxFrame *>(aAckFrame)->GenerateImmAck(*static_cast<const Mac::RxFrame *>(aFrame), aIsFramePending);
 }
 
-#if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
+#if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 otError otMacFrameGenerateEnhAck(const otRadioFrame *aFrame,
                                  bool                aIsFramePending,
                                  const uint8_t *     aIeData,
@@ -151,6 +156,7 @@ otError otMacFrameGenerateEnhAck(const otRadioFrame *aFrame,
     return static_cast<Mac::TxFrame *>(aAckFrame)->GenerateEnhAck(*static_cast<const Mac::RxFrame *>(aFrame),
                                                                   aIsFramePending, aIeData, aIeLength);
 }
+#endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 void otMacFrameSetCslIe(otRadioFrame *aFrame, uint16_t aCslPeriod, uint16_t aCslPhase)
@@ -158,4 +164,3 @@ void otMacFrameSetCslIe(otRadioFrame *aFrame, uint16_t aCslPeriod, uint16_t aCsl
     static_cast<Mac::Frame *>(aFrame)->SetCslIe(aCslPeriod, aCslPhase);
 }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-#endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT

--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -132,11 +132,6 @@ bool otMacFrameIsVersion2015(const otRadioFrame *aFrame)
     return static_cast<const Mac::Frame *>(aFrame)->IsVersion2015();
 }
 
-bool otMacFrameIsSecurityEnabled(const otRadioFrame *aFrame)
-{
-    return static_cast<const Mac::Frame *>(aFrame)->GetSecurityEnabled();
-}
-
 void otMacFrameGenerateImmAck(const otRadioFrame *aFrame, bool aIsFramePending, otRadioFrame *aAckFrame)
 {
     assert(aFrame != NULL && aAckFrame != NULL);

--- a/examples/platforms/utils/mac_frame.h
+++ b/examples/platforms/utils/mac_frame.h
@@ -162,6 +162,17 @@ uint8_t otMacFrameGetSequence(const otRadioFrame *aFrame);
 void otMacFrameProcessTransmitAesCcm(otRadioFrame *aFrame, const otExtAddress *aExtAddress);
 
 /**
+ * Tell if the security of @p aFrame is enabled.
+ *
+ * @param[in]   aFrame          A pointer to the frame.
+ *
+ * @retval  true    It is enabled.
+ * @retval  false   It is not enabled.
+ *
+ */
+bool otMacFrameIsSecurityEnabled(const otRadioFrame *aFrame);
+
+/**
  * Tell if the version of @p aFrame is 2015.
  *
  * @param[in]   aFrame          A pointer to the frame.

--- a/examples/platforms/utils/mac_frame.h
+++ b/examples/platforms/utils/mac_frame.h
@@ -162,17 +162,6 @@ uint8_t otMacFrameGetSequence(const otRadioFrame *aFrame);
 void otMacFrameProcessTransmitAesCcm(otRadioFrame *aFrame, const otExtAddress *aExtAddress);
 
 /**
- * Tell if the security of @p aFrame is enabled.
- *
- * @param[in]   aFrame          A pointer to the frame.
- *
- * @retval  true    It is enabled.
- * @retval  false   It is not enabled.
- *
- */
-bool otMacFrameIsSecurityEnabled(const otRadioFrame *aFrame);
-
-/**
  * Tell if the version of @p aFrame is 2015.
  *
  * @param[in]   aFrame          A pointer to the frame.

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1082,7 +1082,7 @@ void TxFrame::GenerateImmAck(const RxFrame &aFrame, bool aIsFramePending)
     mLength = kImmAckLength;
 }
 
-#if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
+#if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 otError TxFrame::GenerateEnhAck(const RxFrame &aFrame, bool aIsFramePending, const uint8_t *aIeData, uint8_t aIeLength)
 {
     otError error = OT_ERROR_NONE;
@@ -1193,7 +1193,7 @@ otError TxFrame::GenerateEnhAck(const RxFrame &aFrame, bool aIsFramePending, con
 exit:
     return error;
 }
-#endif
+#endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 
 // LCOV_EXCL_START
 


### PR DESCRIPTION
This commit change the simulation radio to send secured enh-ack for
secured frames. This enhances the security for real devices and improves
code coverage for testing.