### PR TITLE
[notifier] add Event and Events and Receiver types & simplify handler

### DIFF
--- a/src/core/backbone_router/local.cpp
+++ b/src/core/backbone_router/local.cpp
@@ -121,7 +121,7 @@ void Local::Reset(void)
     {
         // Increase sequence number when changing from Primary to Secondary.
         mSequenceNumber++;
-        Get<Notifier>().Signal(OT_CHANGED_THREAD_BACKBONE_ROUTER_LOCAL);
+        Get<Notifier>().Signal(kEventThreadBackboneRouterLocalChanged);
         SetState(OT_BACKBONE_ROUTER_STATE_SECONDARY);
     }
 
@@ -160,7 +160,7 @@ void Local::SetConfig(const BackboneRouterConfig &aConfig)
 
     if (update)
     {
-        Get<Notifier>().Signal(OT_CHANGED_THREAD_BACKBONE_ROUTER_LOCAL);
+        Get<Notifier>().Signal(kEventThreadBackboneRouterLocalChanged);
 
         if (AddService() == OT_ERROR_NONE)
         {
@@ -244,7 +244,7 @@ void Local::SetState(BackboneRouterState aState)
 
     mState = aState;
 
-    Get<Notifier>().Signal(OT_CHANGED_THREAD_BACKBONE_ROUTER_STATE);
+    Get<Notifier>().Signal(kEventThreadBackboneRouterStateChanged);
 
 exit:
     return;
@@ -281,7 +281,7 @@ void Local::UpdateBackboneRouterPrimary(Leader::State aState, const BackboneRout
         mSequenceNumber      = aConfig.mSequenceNumber + 1;
         mReregistrationDelay = aConfig.mReregistrationDelay;
         mMlrTimeout          = aConfig.mMlrTimeout;
-        Get<Notifier>().Signal(OT_CHANGED_THREAD_BACKBONE_ROUTER_LOCAL);
+        Get<Notifier>().Signal(kEventThreadBackboneRouterLocalChanged);
         if (AddService(true /* Force registration to refresh and restore Primary state */) == OT_ERROR_NONE)
         {
             Get<NetworkData::Notifier>().HandleServerDataUpdated();

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -51,9 +51,9 @@ Notifier::Callback::Callback(Instance &aInstance, Handler aHandler, void *aOwner
 
 Notifier::Notifier(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mFlagsToSignal(0)
-    , mSignaledFlags(0)
-    , mTask(aInstance, &Notifier::HandleStateChanged, this)
+    , mEventsToSignal()
+    , mSignaledEvents()
+    , mTask(aInstance, &Notifier::EmitEvents, this)
     , mCallbacks()
 {
     for (unsigned int i = 0; i < kMaxExternalHandlers; i++)
@@ -120,39 +120,43 @@ exit:
     return;
 }
 
-void Notifier::Signal(otChangedFlags aFlags)
+void Notifier::Signal(Event aEvent)
 {
-    mFlagsToSignal |= aFlags;
-    mSignaledFlags |= aFlags;
+    mEventsToSignal.Add(aEvent);
+    mSignaledEvents.Add(aEvent);
     mTask.Post();
 }
 
-void Notifier::SignalIfFirst(otChangedFlags aFlags)
+void Notifier::SignalIfFirst(Event aEvent)
 {
-    if (!HasSignaled(aFlags))
+    if (!HasSignaled(aEvent))
     {
-        Signal(aFlags);
+        Signal(aEvent);
     }
 }
 
-void Notifier::HandleStateChanged(Tasklet &aTasklet)
+void Notifier::EmitEvents(Tasklet &aTasklet)
 {
-    aTasklet.GetOwner<Notifier>().HandleStateChanged();
+    aTasklet.GetOwner<Notifier>().EmitEvents();
 }
 
-void Notifier::HandleStateChanged(void)
+void Notifier::EmitEvents(void)
 {
-    otChangedFlags flags = mFlagsToSignal;
+    Events events;
 
-    VerifyOrExit(flags != 0, OT_NOOP);
+    VerifyOrExit(!mEventsToSignal.IsEmpty(), OT_NOOP);
 
-    mFlagsToSignal = 0;
+    // Note that the callbacks may signal new events, so we create a
+    // copy of `mEventsToSignal` and then clear it.
 
-    LogChangedFlags(flags);
+    events = mEventsToSignal;
+    mEventsToSignal.Clear();
+
+    LogEvents(events);
 
     for (Callback *callback = mCallbacks.GetHead(); callback != NULL; callback = callback->GetNext())
     {
-        callback->Invoke(flags);
+        callback->Invoke(events);
     }
 
     for (unsigned int i = 0; i < kMaxExternalHandlers; i++)
@@ -161,7 +165,7 @@ void Notifier::HandleStateChanged(void)
 
         if (callback.mHandler != NULL)
         {
-            callback.mHandler(flags, callback.mContext);
+            callback.mHandler(events.GetAsFlags(), callback.mContext);
         }
     }
 
@@ -173,14 +177,14 @@ exit:
 
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_CORE == 1)
 
-void Notifier::LogChangedFlags(otChangedFlags aFlags) const
+void Notifier::LogEvents(Events aEvents) const
 {
-    otChangedFlags                 flags    = aFlags;
+    Events::Flags                  flags    = aEvents.GetAsFlags();
     bool                           addSpace = false;
     bool                           didLog   = false;
     String<kFlagsStringBufferSize> string;
 
-    for (uint8_t bit = 0; bit < sizeof(otChangedFlags) * CHAR_BIT; bit++)
+    for (uint8_t bit = 0; bit < sizeof(Events::Flags) * CHAR_BIT; bit++)
     {
         VerifyOrExit(flags != 0, OT_NOOP);
 
@@ -188,14 +192,14 @@ void Notifier::LogChangedFlags(otChangedFlags aFlags) const
         {
             if (string.GetLength() >= kFlagsStringLineLimit)
             {
-                otLogInfoCore("Notifier: StateChanged (0x%08x) %s%s ...", aFlags, didLog ? "... " : "[",
+                otLogInfoCore("Notifier: StateChanged (0x%08x) %s%s ...", aEvents.GetAsFlags(), didLog ? "... " : "[",
                               string.AsCString());
                 string.Clear();
                 didLog   = true;
                 addSpace = false;
             }
 
-            IgnoreError(string.Append("%s%s", addSpace ? " " : "", FlagToString(1 << bit)));
+            IgnoreError(string.Append("%s%s", addSpace ? " " : "", EventToString(static_cast<Event>(1 << bit))));
             addSpace = true;
 
             flags ^= (1 << bit);
@@ -203,10 +207,11 @@ void Notifier::LogChangedFlags(otChangedFlags aFlags) const
     }
 
 exit:
-    otLogInfoCore("Notifier: StateChanged (0x%08x) %s%s] ", aFlags, didLog ? "... " : "[", string.AsCString());
+    otLogInfoCore("Notifier: StateChanged (0x%08x) %s%s] ", aEvents.GetAsFlags(), didLog ? "... " : "[",
+                  string.AsCString());
 }
 
-const char *Notifier::FlagToString(otChangedFlags aFlag) const
+const char *Notifier::EventToString(Event aEvent) const
 {
     const char *retval = "(unknown)";
 
@@ -214,123 +219,118 @@ const char *Notifier::FlagToString(otChangedFlags aFlag) const
     // strings from this method should have shorter length than
     // `kMaxFlagNameLength` value.
 
-    switch (aFlag)
+    switch (aEvent)
     {
-    case OT_CHANGED_IP6_ADDRESS_ADDED:
+    case kEventIp6AddressAdded:
         retval = "Ip6+";
         break;
 
-    case OT_CHANGED_IP6_ADDRESS_REMOVED:
+    case kEventIp6AddressRemoved:
         retval = "Ip6-";
         break;
 
-    case OT_CHANGED_THREAD_ROLE:
+    case kEventThreadRoleChanged:
         retval = "Role";
         break;
 
-    case OT_CHANGED_THREAD_LL_ADDR:
+    case kEventThreadLinkLocalAddrChanged:
         retval = "LLAddr";
         break;
 
-    case OT_CHANGED_THREAD_ML_ADDR:
+    case kEventThreadMeshLocalAddrChanged:
         retval = "MLAddr";
         break;
 
-    case OT_CHANGED_THREAD_RLOC_ADDED:
+    case kEventThreadRlocAdded:
         retval = "Rloc+";
         break;
 
-    case OT_CHANGED_THREAD_RLOC_REMOVED:
+    case kEventThreadRlocRemoved:
         retval = "Rloc-";
         break;
 
-    case OT_CHANGED_THREAD_PARTITION_ID:
+    case kEventThreadPartitionIdChanged:
         retval = "PartitionId";
         break;
 
-    case OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER:
+    case kEventThreadKeySeqCounterChanged:
         retval = "KeySeqCntr";
         break;
 
-    case OT_CHANGED_THREAD_NETDATA:
+    case kEventThreadNetdataChanged:
         retval = "NetData";
         break;
 
-    case OT_CHANGED_THREAD_CHILD_ADDED:
+    case kEventThreadChildAdded:
         retval = "Child+";
         break;
 
-    case OT_CHANGED_THREAD_CHILD_REMOVED:
+    case kEventThreadChildRemoved:
         retval = "Child-";
         break;
 
-    case OT_CHANGED_IP6_MULTICAST_SUBSCRIBED:
+    case kEventIp6MulticastSubscribed:
         retval = "Ip6Mult+";
         break;
 
-    case OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED:
+    case kEventIp6MulticastUnsubscribed:
         retval = "Ip6Mult-";
         break;
 
-    case OT_CHANGED_THREAD_CHANNEL:
+    case kEventThreadChannelChanged:
         retval = "Channel";
         break;
 
-    case OT_CHANGED_THREAD_PANID:
+    case kEventThreadPanIdChanged:
         retval = "PanId";
         break;
 
-    case OT_CHANGED_THREAD_NETWORK_NAME:
+    case kEventThreadNetworkNameChanged:
         retval = "NetName";
         break;
 
-    case OT_CHANGED_THREAD_EXT_PANID:
+    case kEventThreadExtPanIdChanged:
         retval = "ExtPanId";
         break;
 
-    case OT_CHANGED_MASTER_KEY:
+    case kEventMasterKeyChanged:
         retval = "MstrKey";
         break;
 
-    case OT_CHANGED_PSKC:
+    case kEventPskcChanged:
         retval = "PSKc";
         break;
 
-    case OT_CHANGED_SECURITY_POLICY:
+    case kEventSecurityPolicyChanged:
         retval = "SecPolicy";
         break;
 
-    case OT_CHANGED_CHANNEL_MANAGER_NEW_CHANNEL:
+    case kEventChannelManagerNewChannelChanged:
         retval = "CMNewChan";
         break;
 
-    case OT_CHANGED_SUPPORTED_CHANNEL_MASK:
+    case kEventSupportedChannelMaskChanged:
         retval = "ChanMask";
         break;
 
-    case OT_CHANGED_COMMISSIONER_STATE:
+    case kEventCommissionerStateChanged:
         retval = "CommissionerState";
         break;
 
-    case OT_CHANGED_THREAD_NETIF_STATE:
+    case kEventThreadNetifStateChanged:
         retval = "NetifState";
         break;
 
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    case OT_CHANGED_THREAD_BACKBONE_ROUTER_STATE:
+    case kEventThreadBackboneRouterStateChanged:
         retval = "BbrState";
         break;
 
-    case OT_CHANGED_THREAD_BACKBONE_ROUTER_LOCAL:
+    case kEventThreadBackboneRouterLocalChanged:
         retval = "BbrLocal";
         break;
-#endif
 
-    case OT_CHANGED_JOINER_STATE:
+    case kEventJoinerStateChanged:
         retval = "JoinerState";
-        break;
-
-    default:
         break;
     }
 
@@ -339,11 +339,11 @@ const char *Notifier::FlagToString(otChangedFlags aFlag) const
 
 #else // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_CORE == 1)
 
-void Notifier::LogChangedFlags(otChangedFlags) const
+void Notifier::LogEvents(Events) const
 {
 }
 
-const char *Notifier::FlagToString(otChangedFlags) const
+const char *Notifier::EventToString(Event) const
 {
     return "";
 }

--- a/src/core/common/notifier.hpp
+++ b/src/core/common/notifier.hpp
@@ -60,6 +60,128 @@ namespace ot {
  */
 
 /**
+ * This enumeration type represents events emitted from OpenThread Notifier.
+ *
+ */
+enum Event
+{
+    kEventIp6AddressAdded                  = OT_CHANGED_IP6_ADDRESS_ADDED,            ///< IPv6 address was added
+    kEventIp6AddressRemoved                = OT_CHANGED_IP6_ADDRESS_REMOVED,          ///< IPv6 address was removed
+    kEventThreadRoleChanged                = OT_CHANGED_THREAD_ROLE,                  ///< Role changed
+    kEventThreadLinkLocalAddrChanged       = OT_CHANGED_THREAD_LL_ADDR,               ///< Link-local address changed
+    kEventThreadMeshLocalAddrChanged       = OT_CHANGED_THREAD_ML_ADDR,               ///< Mesh-local address changed
+    kEventThreadRlocAdded                  = OT_CHANGED_THREAD_RLOC_ADDED,            ///< RLOC was added
+    kEventThreadRlocRemoved                = OT_CHANGED_THREAD_RLOC_REMOVED,          ///< RLOC was removed
+    kEventThreadPartitionIdChanged         = OT_CHANGED_THREAD_PARTITION_ID,          ///< Partition ID changed
+    kEventThreadKeySeqCounterChanged       = OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER,  ///< Key Sequence changed
+    kEventThreadNetdataChanged             = OT_CHANGED_THREAD_NETDATA,               ///< Network Data changed
+    kEventThreadChildAdded                 = OT_CHANGED_THREAD_CHILD_ADDED,           ///< Child was added
+    kEventThreadChildRemoved               = OT_CHANGED_THREAD_CHILD_REMOVED,         ///< Child was removed
+    kEventIp6MulticastSubscribed           = OT_CHANGED_IP6_MULTICAST_SUBSCRIBED,     ///< Multicast address added
+    kEventIp6MulticastUnsubscribed         = OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED,   ///< Multicast address removed
+    kEventThreadChannelChanged             = OT_CHANGED_THREAD_CHANNEL,               ///< Network channel changed
+    kEventThreadPanIdChanged               = OT_CHANGED_THREAD_PANID,                 ///< Network PAN ID changed
+    kEventThreadNetworkNameChanged         = OT_CHANGED_THREAD_NETWORK_NAME,          ///< Network name changed
+    kEventThreadExtPanIdChanged            = OT_CHANGED_THREAD_EXT_PANID,             ///< Extended PAN ID changed
+    kEventMasterKeyChanged                 = OT_CHANGED_MASTER_KEY,                   ///< Master Key changed
+    kEventPskcChanged                      = OT_CHANGED_PSKC,                         ///< PSKc changed
+    kEventSecurityPolicyChanged            = OT_CHANGED_SECURITY_POLICY,              ///< Security Policy changed
+    kEventChannelManagerNewChannelChanged  = OT_CHANGED_CHANNEL_MANAGER_NEW_CHANNEL,  ///< New Channel (channel-manager)
+    kEventSupportedChannelMaskChanged      = OT_CHANGED_SUPPORTED_CHANNEL_MASK,       ///< Channel mask changed
+    kEventCommissionerStateChanged         = OT_CHANGED_COMMISSIONER_STATE,           ///< Commissioner state changed
+    kEventThreadNetifStateChanged          = OT_CHANGED_THREAD_NETIF_STATE,           ///< Netif state changed
+    kEventThreadBackboneRouterStateChanged = OT_CHANGED_THREAD_BACKBONE_ROUTER_STATE, ///< Backbone Router state changed
+    kEventThreadBackboneRouterLocalChanged = OT_CHANGED_THREAD_BACKBONE_ROUTER_LOCAL, ///< Local Backbone Router changed
+    kEventJoinerStateChanged               = OT_CHANGED_JOINER_STATE,                 ///< Joiner state changed
+};
+
+/**
+ * This type represents a list of events.
+ *
+ */
+class Events
+{
+public:
+    /**
+     * This type represents a bit-field indicating a list of events (with values from `Event`)
+     *
+     */
+    typedef otChangedFlags Flags;
+
+    /**
+     * This constructor initializes the `Events` list (as empty).
+     *
+     */
+    Events(void)
+        : mEventFlags(0)
+    {
+    }
+
+    /**
+     * This method clears the `Events` list.
+     *
+     */
+    void Clear(void) { mEventFlags = 0; }
+
+    /**
+     * This method indicates whether the `Events` list contains a given event.
+     *
+     * @param[in] aEvent  The event to check.
+     *
+     * @returns TRUE if the list contains the @p aEvent, FALSE otherwise.
+     *
+     */
+    bool Contains(Event aEvent) const { return (mEventFlags & aEvent) != 0; }
+
+    /**
+     * This method indicates whether the `Events` list contains any of a given set of events.
+     *
+     * @param[in] aEvents  The events set to check (must be a collection of `Event` constants combined using `|`).
+     *
+     * @returns TRUE if the list contains any of the @p aEvents set, FALSE otherwise.
+     *
+     */
+    bool ContainsAny(Flags aEvents) const { return (mEventFlags & aEvents) != 0; }
+
+    /**
+     * This method indicates whether the `Events` list contains all of a given set of events.
+     *
+     * @param[in] aEvents  The events set to check (must be collection of `Event` constants combined using `|`).
+     *
+     * @returns TRUE if the list contains all of the @p aEvents set, FALSE otherwise.
+     *
+     */
+    bool ContainsAll(Flags aEvents) const { return (mEventFlags & aEvents) == aEvents; }
+
+    /**
+     * This method adds a given event to the `Events` list.
+     *
+     * @param[in] aEvent  The event to add.
+     *
+     */
+    void Add(Event aEvent) { mEventFlags |= aEvent; }
+
+    /**
+     * This method indicates whether the `Events` list is empty.
+     *
+     * @returns TRUE if the list is empty, FALSE otherwise.
+     *
+     */
+    bool IsEmpty(void) const { return (mEventFlags == 0); }
+
+    /**
+     * This method gets the `Events` list as bit-field `Flags` value.
+     *
+     * @returns The list as bit-field `Flags` value.
+     *
+     */
+    Flags GetAsFlags(void) const { return mEventFlags; }
+
+private:
+    Flags mEventFlags;
+};
+
+/**
  * This class implements the OpenThread Notifier.
  *
  * It can be used to register callbacks that notify of state or configuration changes within OpenThread.
@@ -88,13 +210,13 @@ public:
 
     public:
         /**
-         * This type defines the function pointer which is called to notify of state or configuration changes.
+         * This type defines the function pointer which is called to notify of events (state/configuration changes)..
          *
          * @param[in] aCallback    A reference to callback instance.
-         * @param[in] aFlags       A bit-field indicating specific state or configuration that has changed.
+         * @param[in] aEvents      The list of events.
          *
          */
-        typedef void (*Handler)(Callback &aCallback, otChangedFlags aFlags);
+        typedef void (*Handler)(Callback &aCallback, Events aEvents);
 
         /**
          * This constructor initializes a `Callback` instance and registers it with `Notifier`.
@@ -107,7 +229,7 @@ public:
         Callback(Instance &aInstance, Handler aHandler, void *aOwner);
 
     private:
-        void Invoke(otChangedFlags aFlags) { mHandler(*this, aFlags); }
+        void Invoke(const Events aEvents) { mHandler(*this, aEvents); }
 
         Handler   mHandler;
         Callback *mNext;
@@ -144,70 +266,69 @@ public:
     void RemoveCallback(otStateChangedCallback aCallback, void *aContext);
 
     /**
-     * This method schedules signaling of changed flags.
+     * This method schedules signaling of an event.
      *
-     * @param[in]  aFlags       A bit-field indicating what configuration or state has changed.
-     *
-     */
-    void Signal(otChangedFlags aFlags);
-
-    /**
-     * This method schedules signaling of changed flags only if the set of flags has not been signaled before (first
-     * time signal).
-     *
-     * @param[in]  aFlags       A bit-field indicating what configuration or state has changed.
+     * @param[in]  aEvent     The event to signal.
      *
      */
-    void SignalIfFirst(otChangedFlags aFlags);
+    void Signal(Event aEvent);
 
     /**
-     * This method indicates whether or not a changed callback is pending.
+     * This method schedules signaling of am event only if the event has not been signaled before (first time signal).
      *
-     * @returns TRUE if a state changed callback is pending, FALSE otherwise.
+     * @param[in]  aEvent     The event to signal.
      *
      */
-    bool IsPending(void) const { return (mFlagsToSignal != 0); }
+    void SignalIfFirst(Event aFlags);
 
     /**
-     * This method indicates whether or not a changed notification for a given set of flags has been signaled before.
+     * This method indicates whether or not an event signal callback is pending/scheduled.
      *
-     * @param[in]  aFlags   A bit-field containing the flag-bits to check.
-     *
-     * @retval TRUE    All flag bits in @p aFlags have been signaled before.
-     * @retval FALSE   At least one flag bit in @p aFlags has not been signaled before.
+     * @returns TRUE if a callback is pending, FALSE otherwise.
      *
      */
-    bool HasSignaled(otChangedFlags aFlags) const { return (mSignaledFlags & aFlags) == aFlags; }
+    bool IsPending(void) const { return !mEventsToSignal.IsEmpty(); }
 
     /**
-     * This template method updates a variable of a type `Type` with a new value and signals the given changed flags.
+     * This method indicates whether or not an event has been signaled before.
      *
-     * If the variable is already set to the same value, this method returns `OT_ERROR_ALREADY` and the changed flags
-     * is signaled using `SignalIfFirst()` (i.e. signal is scheduled only if the flag has not been signaled before).
+     * @param[in]  aEvent    The event to check.
+     *
+     * @retval TRUE    The event @p aEvent have been signaled before.
+     * @retval FALSE   The event @p aEvent has not been signaled before.
+     *
+     */
+    bool HasSignaled(Event aEvent) const { return mSignaledEvents.Contains(aEvent); }
+
+    /**
+     * This template method updates a variable of a type `Type` with a new value and signals the given event.
+     *
+     * If the variable is already set to the same value, this method returns `OT_ERROR_ALREADY` and the event is
+     * signaled using `SignalIfFirst()` (i.e., signal is scheduled only if event has not been signaled before).
      *
      * The template `Type` should support comparison operator `==` and assignment operator `=`.
      *
      * @param[inout] aVariable    A reference to the variable to update.
      * @param[in]    aNewValue    The new value.
-     * @param[in]    aFlags       The changed flags to signal.
+     * @param[in]    aEvent       The event to signal.
      *
-     * @retval OT_ERROR_NONE      The variable was update successfully and @p aFlags was signaled.
+     * @retval OT_ERROR_NONE      The variable was update successfully and @p aEvent was signaled.
      * @retval OT_ERROR_ALREADY   The variable was already set to the same value.
      *
      */
-    template <typename Type> otError Update(Type &aVariable, const Type &aNewValue, otChangedFlags aFlags)
+    template <typename Type> otError Update(Type &aVariable, const Type &aNewValue, Event aEvent)
     {
         otError error = OT_ERROR_NONE;
 
         if (aVariable == aNewValue)
         {
-            SignalIfFirst(aFlags);
+            SignalIfFirst(aEvent);
             error = OT_ERROR_ALREADY;
         }
         else
         {
             aVariable = aNewValue;
-            Signal(aFlags);
+            Signal(aEvent);
         }
 
         return error;
@@ -229,14 +350,14 @@ private:
     };
 
     void        RegisterCallback(Callback &aCallback);
-    static void HandleStateChanged(Tasklet &aTasklet);
-    void        HandleStateChanged(void);
+    static void EmitEvents(Tasklet &aTasklet);
+    void        EmitEvents(void);
 
-    void        LogChangedFlags(otChangedFlags aFlags) const;
-    const char *FlagToString(otChangedFlags aFlag) const;
+    void        LogEvents(Events aEvents) const;
+    const char *EventToString(Event aEvent) const;
 
-    otChangedFlags       mFlagsToSignal;
-    otChangedFlags       mSignaledFlags;
+    Events               mEventsToSignal;
+    Events               mSignaledEvents;
     Tasklet              mTask;
     LinkedList<Callback> mCallbacks;
     ExternalCallback     mExternalCallbacks[kMaxExternalHandlers];

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -415,7 +415,7 @@ otError Mac::SetPanChannel(uint8_t aChannel)
 
     VerifyOrExit(mSupportedChannelMask.ContainsChannel(aChannel), error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(Get<Notifier>().Update(mPanChannel, aChannel, OT_CHANGED_THREAD_CHANNEL));
+    SuccessOrExit(Get<Notifier>().Update(mPanChannel, aChannel, kEventThreadChannelChanged));
 
     mCcaSuccessRateTracker.Reset();
 
@@ -459,7 +459,7 @@ void Mac::SetSupportedChannelMask(const ChannelMask &aMask)
     ChannelMask newMask = aMask;
 
     newMask.Intersect(ChannelMask(Get<Radio>().GetSupportedChannelMask()));
-    IgnoreError(Get<Notifier>().Update(mSupportedChannelMask, newMask, OT_CHANGED_SUPPORTED_CHANNEL_MASK));
+    IgnoreError(Get<Notifier>().Update(mSupportedChannelMask, newMask, kEventSupportedChannelMaskChanged));
 }
 
 otError Mac::SetNetworkName(const char *aNameString)
@@ -483,13 +483,13 @@ otError Mac::SetNetworkName(const NameData &aNameData)
 
     if (error == OT_ERROR_ALREADY)
     {
-        Get<Notifier>().SignalIfFirst(OT_CHANGED_THREAD_NETWORK_NAME);
+        Get<Notifier>().SignalIfFirst(kEventThreadNetworkNameChanged);
         error = OT_ERROR_NONE;
         ExitNow();
     }
 
     SuccessOrExit(error);
-    Get<Notifier>().Signal(OT_CHANGED_THREAD_NETWORK_NAME);
+    Get<Notifier>().Signal(kEventThreadNetworkNameChanged);
 
 exit:
     return error;
@@ -526,7 +526,7 @@ otError Mac::SetDomainName(const NameData &aNameData)
 
 void Mac::SetPanId(PanId aPanId)
 {
-    SuccessOrExit(Get<Notifier>().Update(mPanId, aPanId, OT_CHANGED_THREAD_PANID));
+    SuccessOrExit(Get<Notifier>().Update(mPanId, aPanId, kEventThreadPanIdChanged));
     mSubMac.SetPanId(mPanId);
 
 exit:
@@ -535,7 +535,7 @@ exit:
 
 void Mac::SetExtendedPanId(const ExtendedPanId &aExtendedPanId)
 {
-    IgnoreError(Get<Notifier>().Update(mExtendedPanId, aExtendedPanId, OT_CHANGED_THREAD_EXT_PANID));
+    IgnoreError(Get<Notifier>().Update(mExtendedPanId, aExtendedPanId, kEventThreadExtPanIdChanged));
 }
 
 void Mac::RequestDirectFrameTransmission(void)

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -333,6 +333,7 @@ void BorderAgent::HandleRequest<&BorderAgent::mProxyTransmit>(void *            
 
 BorderAgent::BorderAgent(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , Notifier::Receiver(aInstance, BorderAgent::HandleNotifierEvents)
     , mCommissionerPetition(OT_URI_PATH_COMMISSIONER_PETITION,
                             BorderAgent::HandleRequest<&BorderAgent::mCommissionerPetition>,
                             this)
@@ -351,7 +352,6 @@ BorderAgent::BorderAgent(Instance &aInstance)
     , mUdpReceiver(BorderAgent::HandleUdpReceive, this)
     , mTimer(aInstance, HandleTimeout, this)
     , mState(OT_BORDER_AGENT_STATE_STOPPED)
-    , mNotifierCallback(aInstance, &BorderAgent::HandleNotifierEvents, this)
 {
     mCommissionerAloc.Clear();
     mCommissionerAloc.mPrefixLength       = 64;
@@ -361,9 +361,9 @@ BorderAgent::BorderAgent(Instance &aInstance)
     mCommissionerAloc.mScopeOverrideValid = true;
 }
 
-void BorderAgent::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
+void BorderAgent::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
 {
-    aCallback.GetOwner<BorderAgent>().HandleNotifierEvents(aEvents);
+    static_cast<BorderAgent &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void BorderAgent::HandleNotifierEvents(Events aEvents)

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -351,7 +351,7 @@ BorderAgent::BorderAgent(Instance &aInstance)
     , mUdpReceiver(BorderAgent::HandleUdpReceive, this)
     , mTimer(aInstance, HandleTimeout, this)
     , mState(OT_BORDER_AGENT_STATE_STOPPED)
-    , mNotifierCallback(aInstance, &BorderAgent::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &BorderAgent::HandleNotifierEvents, this)
 {
     mCommissionerAloc.Clear();
     mCommissionerAloc.mPrefixLength       = 64;
@@ -361,14 +361,14 @@ BorderAgent::BorderAgent(Instance &aInstance)
     mCommissionerAloc.mScopeOverrideValid = true;
 }
 
-void BorderAgent::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
+void BorderAgent::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
 {
-    aCallback.GetOwner<BorderAgent>().HandleStateChanged(aFlags);
+    aCallback.GetOwner<BorderAgent>().HandleNotifierEvents(aEvents);
 }
 
-void BorderAgent::HandleStateChanged(otChangedFlags aFlags)
+void BorderAgent::HandleNotifierEvents(Events aEvents)
 {
-    VerifyOrExit((aFlags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_COMMISSIONER_STATE)) != 0, OT_NOOP);
+    VerifyOrExit(aEvents.ContainsAny(kEventThreadRoleChanged | kEventCommissionerStateChanged), OT_NOOP);
 
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
     VerifyOrExit(Get<MeshCoP::Commissioner>().IsDisabled(), OT_NOOP);

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -49,7 +49,7 @@ class ThreadNetif;
 
 namespace MeshCoP {
 
-class BorderAgent : public InstanceLocator
+class BorderAgent : public InstanceLocator, public Notifier::Receiver
 {
 public:
     /**
@@ -93,7 +93,7 @@ public:
     void ApplyMeshLocalPrefix(void);
 
 private:
-    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
 
     static void HandleConnected(bool aConnected, void *aContext)
@@ -162,8 +162,6 @@ private:
 
     TimerMilli         mTimer;
     otBorderAgentState mState;
-
-    Notifier::Callback mNotifierCallback;
 };
 
 } // namespace MeshCoP

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -93,8 +93,8 @@ public:
     void ApplyMeshLocalPrefix(void);
 
 private:
-    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
-    void        HandleStateChanged(otChangedFlags aFlags);
+    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    void        HandleNotifierEvents(Events aEvents);
 
     static void HandleConnected(bool aConnected, void *aContext)
     {

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -92,7 +92,7 @@ void Commissioner::SetState(otCommissionerState aState)
     otCommissionerState oldState = mState;
     OT_UNUSED_VARIABLE(oldState);
 
-    SuccessOrExit(Get<Notifier>().Update(mState, aState, OT_CHANGED_COMMISSIONER_STATE));
+    SuccessOrExit(Get<Notifier>().Update(mState, aState, kEventCommissionerStateChanged));
 
     otLogInfoMeshCoP("CommissionerState: %s -> %s", StateToString(oldState), StateToString(aState));
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -80,7 +80,7 @@ void Joiner::SetState(otJoinerState aState)
     otJoinerState oldState = mState;
     OT_UNUSED_VARIABLE(oldState);
 
-    SuccessOrExit(Get<Notifier>().Update(mState, aState, OT_CHANGED_JOINER_STATE));
+    SuccessOrExit(Get<Notifier>().Update(mState, aState, kEventJoinerStateChanged));
 
     otLogInfoMeshCoP("JoinerState: %s -> %s", JoinerStateToString(oldState), JoinerStateToString(aState));
 exit:

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -55,10 +55,10 @@ namespace MeshCoP {
 
 JoinerRouter::JoinerRouter(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , Notifier::Receiver(aInstance, JoinerRouter::HandleNotifierEvents)
     , mSocket(aInstance.Get<Ip6::Udp>())
     , mRelayTransmit(OT_URI_PATH_RELAY_TX, &JoinerRouter::HandleRelayTransmit, this)
     , mTimer(aInstance, JoinerRouter::HandleTimer, this)
-    , mNotifierCallback(aInstance, &JoinerRouter::HandleNotifierEvents, this)
     , mJoinerUdpPort(0)
     , mIsJoinerPortConfigured(false)
     , mExpectJoinEntRsp(false)
@@ -66,9 +66,9 @@ JoinerRouter::JoinerRouter(Instance &aInstance)
     Get<Coap::Coap>().AddResource(mRelayTransmit);
 }
 
-void JoinerRouter::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
+void JoinerRouter::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
 {
-    aCallback.GetOwner<JoinerRouter>().HandleNotifierEvents(aEvents);
+    static_cast<JoinerRouter &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void JoinerRouter::HandleNotifierEvents(Events aEvents)

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -51,7 +51,7 @@ namespace ot {
 
 namespace MeshCoP {
 
-class JoinerRouter : public InstanceLocator
+class JoinerRouter : public InstanceLocator, public Notifier::Receiver
 {
 public:
     /**
@@ -94,7 +94,7 @@ private:
         Kek              mKek;         // KEK used by MAC layer to encode this message.
     };
 
-    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
@@ -123,8 +123,6 @@ private:
 
     TimerMilli   mTimer;
     MessageQueue mDelayedJoinEnts;
-
-    Notifier::Callback mNotifierCallback;
 
     uint16_t mJoinerUdpPort;
 

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -94,8 +94,8 @@ private:
         Kek              mKek;         // KEK used by MAC layer to encode this message.
     };
 
-    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
-    void        HandleStateChanged(otChangedFlags aFlags);
+    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    void        HandleNotifierEvents(Events aEvents);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
@@ -112,6 +112,7 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
+    void           Start(void);
     void           DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessageInfo, const Kek &aKek);
     void           SendDelayedJoinerEntrust(void);
     otError        SendJoinerEntrust(const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -140,7 +140,7 @@ void Netif::SubscribeAllNodesMulticast(void)
         tail->SetNext(&linkLocalAllNodesAddress);
     }
 
-    Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_SUBSCRIBED);
+    Get<Notifier>().Signal(kEventIp6MulticastSubscribed);
 
     VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
 
@@ -187,7 +187,7 @@ void Netif::UnsubscribeAllNodesMulticast(void)
         prev->SetNext(NULL);
     }
 
-    Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED);
+    Get<Notifier>().Signal(kEventIp6MulticastUnsubscribed);
 
     VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
 
@@ -244,7 +244,7 @@ void Netif::SubscribeAllRoutersMulticast(void)
         prev->SetNext(&linkLocalAllRoutersAddress);
     }
 
-    Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_SUBSCRIBED);
+    Get<Notifier>().Signal(kEventIp6MulticastSubscribed);
 
     VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
 
@@ -287,7 +287,7 @@ void Netif::UnsubscribeAllRoutersMulticast(void)
         prev->SetNext(&linkLocalAllNodesAddress);
     }
 
-    Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED);
+    Get<Notifier>().Signal(kEventIp6MulticastUnsubscribed);
 
     VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
 
@@ -305,7 +305,7 @@ void Netif::SubscribeMulticast(NetifMulticastAddress &aAddress)
 {
     SuccessOrExit(mMulticastAddresses.Add(aAddress));
 
-    Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_SUBSCRIBED);
+    Get<Notifier>().Signal(kEventIp6MulticastSubscribed);
 
     VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
     mAddressCallback(&aAddress.mAddress, kMulticastPrefixLength, /* IsAdded */ true, mAddressCallbackContext);
@@ -318,7 +318,7 @@ void Netif::UnsubscribeMulticast(const NetifMulticastAddress &aAddress)
 {
     SuccessOrExit(mMulticastAddresses.Remove(aAddress));
 
-    Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED);
+    Get<Notifier>().Signal(kEventIp6MulticastUnsubscribed);
 
     VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
     mAddressCallback(&aAddress.mAddress, kMulticastPrefixLength, /* IsAdded */ false, mAddressCallbackContext);
@@ -374,7 +374,7 @@ otError Netif::SubscribeExternalMulticast(const Address &aAddress)
         {
             entry->mAddress = aAddress;
             mMulticastAddresses.Push(*entry);
-            Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_SUBSCRIBED);
+            Get<Notifier>().Signal(kEventIp6MulticastSubscribed);
             ExitNow();
         }
     }
@@ -409,7 +409,7 @@ otError Netif::UnsubscribeExternalMulticast(const Address &aAddress)
 
     entry->MarkAsNotInUse();
 
-    Get<Notifier>().Signal(OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED);
+    Get<Notifier>().Signal(kEventIp6MulticastUnsubscribed);
 
 exit:
     return error;
@@ -437,7 +437,7 @@ void Netif::AddUnicastAddress(NetifUnicastAddress &aAddress)
 {
     SuccessOrExit(mUnicastAddresses.Add(aAddress));
 
-    Get<Notifier>().Signal(aAddress.mRloc ? OT_CHANGED_THREAD_RLOC_ADDED : OT_CHANGED_IP6_ADDRESS_ADDED);
+    Get<Notifier>().Signal(aAddress.mRloc ? kEventThreadRlocAdded : kEventIp6AddressAdded);
 
     VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
     mAddressCallback(&aAddress.mAddress, aAddress.mPrefixLength, /* IsAdded */ true, mAddressCallbackContext);
@@ -450,7 +450,7 @@ void Netif::RemoveUnicastAddress(const NetifUnicastAddress &aAddress)
 {
     SuccessOrExit(mUnicastAddresses.Remove(aAddress));
 
-    Get<Notifier>().Signal(aAddress.mRloc ? OT_CHANGED_THREAD_RLOC_REMOVED : OT_CHANGED_IP6_ADDRESS_REMOVED);
+    Get<Notifier>().Signal(aAddress.mRloc ? kEventThreadRlocRemoved : kEventIp6AddressRemoved);
 
     VerifyOrExit(mAddressCallback != NULL, OT_NOOP);
     mAddressCallback(&aAddress.mAddress, aAddress.mPrefixLength, /* IsAdded */ false, mAddressCallbackContext);
@@ -486,7 +486,7 @@ otError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress)
         {
             *entry = aAddress;
             mUnicastAddresses.Push(*entry);
-            Get<Notifier>().Signal(OT_CHANGED_IP6_ADDRESS_ADDED);
+            Get<Notifier>().Signal(kEventIp6AddressAdded);
             ExitNow();
         }
     }
@@ -521,7 +521,7 @@ otError Netif::RemoveExternalUnicastAddress(const Address &aAddress)
 
     entry->MarkAsNotInUse();
 
-    Get<Notifier>().Signal(OT_CHANGED_IP6_ADDRESS_REMOVED);
+    Get<Notifier>().Signal(kEventIp6AddressRemoved);
 
 exit:
     return error;

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -112,7 +112,7 @@ exit:
 
 AnnounceSender::AnnounceSender(Instance &aInstance)
     : AnnounceSenderBase(aInstance, AnnounceSender::HandleTimer)
-    , mNotifierCallback(aInstance, HandleStateChanged, this)
+    , mNotifierCallback(aInstance, HandleNotifierEvents, this)
 {
 }
 
@@ -175,14 +175,14 @@ void AnnounceSender::Stop(void)
     otLogInfoMle("Stopping periodic MLE Announcements tx");
 }
 
-void AnnounceSender::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
+void AnnounceSender::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
 {
-    aCallback.GetOwner<AnnounceSender>().HandleStateChanged(aFlags);
+    aCallback.GetOwner<AnnounceSender>().HandleNotifierEvents(aEvents);
 }
 
-void AnnounceSender::HandleStateChanged(otChangedFlags aFlags)
+void AnnounceSender::HandleNotifierEvents(Events aEvents)
 {
-    if ((aFlags & OT_CHANGED_THREAD_ROLE) != 0)
+    if (aEvents.Contains(kEventThreadRoleChanged))
     {
         CheckState();
     }

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -112,7 +112,7 @@ exit:
 
 AnnounceSender::AnnounceSender(Instance &aInstance)
     : AnnounceSenderBase(aInstance, AnnounceSender::HandleTimer)
-    , mNotifierCallback(aInstance, HandleNotifierEvents, this)
+    , Notifier::Receiver(aInstance, AnnounceSender::HandleNotifierEvents)
 {
 }
 
@@ -175,9 +175,9 @@ void AnnounceSender::Stop(void)
     otLogInfoMle("Stopping periodic MLE Announcements tx");
 }
 
-void AnnounceSender::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
+void AnnounceSender::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
 {
-    aCallback.GetOwner<AnnounceSender>().HandleNotifierEvents(aEvents);
+    static_cast<AnnounceSender &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void AnnounceSender::HandleNotifierEvents(Events aEvents)

--- a/src/core/thread/announce_sender.hpp
+++ b/src/core/thread/announce_sender.hpp
@@ -134,7 +134,7 @@ private:
  * This class implements an AnnounceSender.
  *
  */
-class AnnounceSender : public AnnounceSenderBase
+class AnnounceSender : public AnnounceSenderBase, public Notifier::Receiver
 {
 public:
     /**
@@ -157,10 +157,8 @@ private:
     void        CheckState(void);
     void        Stop(void);
     static void HandleTimer(Timer &aTimer);
-    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
-
-    Notifier::Callback mNotifierCallback;
 };
 
 #endif // OPENTHREAD_CONFIG_ANNOUNCE_SENDER_ENABLE

--- a/src/core/thread/announce_sender.hpp
+++ b/src/core/thread/announce_sender.hpp
@@ -157,8 +157,8 @@ private:
     void        CheckState(void);
     void        Stop(void);
     static void HandleTimer(Timer &aTimer);
-    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
-    void        HandleStateChanged(otChangedFlags aFlags);
+    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    void        HandleNotifierEvents(Events aEvents);
 
     Notifier::Callback mNotifierCallback;
 };

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -48,6 +48,7 @@ namespace ot {
 
 EnergyScanServer::EnergyScanServer(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , Notifier::Receiver(aInstance, EnergyScanServer::HandleNotifierEvents)
     , mChannelMask(0)
     , mChannelMaskCurrent(0)
     , mPeriod(0)
@@ -56,7 +57,6 @@ EnergyScanServer::EnergyScanServer(Instance &aInstance)
     , mActive(false)
     , mScanResultsLength(0)
     , mTimer(aInstance, EnergyScanServer::HandleTimer, this)
-    , mNotifierCallback(aInstance, &EnergyScanServer::HandleNotifierEvents, this)
     , mEnergyScan(OT_URI_PATH_ENERGY_SCAN, &EnergyScanServer::HandleRequest, this)
 {
     Get<Coap::Coap>().AddResource(mEnergyScan);
@@ -212,9 +212,9 @@ exit:
     mActive = false;
 }
 
-void EnergyScanServer::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
+void EnergyScanServer::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
 {
-    aCallback.GetOwner<EnergyScanServer>().HandleNotifierEvents(aEvents);
+    static_cast<EnergyScanServer &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void EnergyScanServer::HandleNotifierEvents(Events aEvents)

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -56,7 +56,7 @@ EnergyScanServer::EnergyScanServer(Instance &aInstance)
     , mActive(false)
     , mScanResultsLength(0)
     , mTimer(aInstance, EnergyScanServer::HandleTimer, this)
-    , mNotifierCallback(aInstance, &EnergyScanServer::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &EnergyScanServer::HandleNotifierEvents, this)
     , mEnergyScan(OT_URI_PATH_ENERGY_SCAN, &EnergyScanServer::HandleRequest, this)
 {
     Get<Coap::Coap>().AddResource(mEnergyScan);
@@ -212,14 +212,14 @@ exit:
     mActive = false;
 }
 
-void EnergyScanServer::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
+void EnergyScanServer::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
 {
-    aCallback.GetOwner<EnergyScanServer>().HandleStateChanged(aFlags);
+    aCallback.GetOwner<EnergyScanServer>().HandleNotifierEvents(aEvents);
 }
 
-void EnergyScanServer::HandleStateChanged(otChangedFlags aFlags)
+void EnergyScanServer::HandleNotifierEvents(Events aEvents)
 {
-    if ((aFlags & OT_CHANGED_THREAD_NETDATA) != 0 && !mActive &&
+    if (aEvents.Contains(kEventThreadNetdataChanged) && !mActive &&
         Get<NetworkData::Leader>().GetCommissioningData() == NULL)
     {
         mActive = false;

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -75,8 +75,8 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
-    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
-    void        HandleStateChanged(otChangedFlags aFlags);
+    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    void        HandleNotifierEvents(Events aEvents);
 
     void SendReport(void);
 

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -50,7 +50,7 @@ namespace ot {
  * This class implements handling Energy Scan Requests.
  *
  */
-class EnergyScanServer : public InstanceLocator
+class EnergyScanServer : public InstanceLocator, public Notifier::Receiver
 {
 public:
     /**
@@ -75,7 +75,7 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
-    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
 
     void SendReport(void);
@@ -92,8 +92,6 @@ private:
     uint8_t mScanResultsLength;
 
     TimerMilli mTimer;
-
-    Notifier::Callback mNotifierCallback;
 
     Coap::Resource mEnergyScan;
 };

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -99,7 +99,7 @@ void KeyManager::Stop(void)
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
 void KeyManager::SetPskc(const Pskc &aPskc)
 {
-    IgnoreError(Get<Notifier>().Update(mPskc, aPskc, OT_CHANGED_PSKC));
+    IgnoreError(Get<Notifier>().Update(mPskc, aPskc, kEventPskcChanged));
     mIsPskcSet = true;
 }
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
@@ -109,9 +109,8 @@ otError KeyManager::SetMasterKey(const MasterKey &aKey)
     otError error = OT_ERROR_NONE;
     Router *parent;
 
-    SuccessOrExit(
-        Get<Notifier>().Update(mMasterKey, aKey, OT_CHANGED_MASTER_KEY | OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER));
-
+    SuccessOrExit(Get<Notifier>().Update(mMasterKey, aKey, kEventMasterKeyChanged));
+    Get<Notifier>().Signal(kEventThreadKeySeqCounterChanged);
     mKeySequence = 0;
     UpdateKeyMaterial();
 
@@ -175,7 +174,7 @@ void KeyManager::UpdateKeyMaterial(void)
 
 void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
 {
-    VerifyOrExit(aKeySequence != mKeySequence, Get<Notifier>().SignalIfFirst(OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER));
+    VerifyOrExit(aKeySequence != mKeySequence, Get<Notifier>().SignalIfFirst(kEventThreadKeySeqCounterChanged));
 
     if ((aKeySequence == (mKeySequence + 1)) && mKeyRotationTimer.IsRunning())
     {
@@ -195,7 +194,7 @@ void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
     SetMacFrameCounter(0);
     mMleFrameCounter = 0;
 
-    Get<Notifier>().Signal(OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER);
+    Get<Notifier>().Signal(kEventThreadKeySeqCounterChanged);
 
 exit:
     return;
@@ -265,7 +264,7 @@ exit:
 
 void KeyManager::SetSecurityPolicyFlags(uint8_t aSecurityPolicyFlags)
 {
-    IgnoreError(Get<Notifier>().Update(mSecurityPolicyFlags, aSecurityPolicyFlags, OT_CHANGED_SECURITY_POLICY));
+    IgnoreError(Get<Notifier>().Update(mSecurityPolicyFlags, aSecurityPolicyFlags, kEventSecurityPolicyChanged));
 }
 
 void KeyManager::StartKeyRotationTimer(void)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -108,7 +108,7 @@ Mle::Mle(Instance &aInstance)
     , mAlternateChannel(0)
     , mAlternatePanId(Mac::kPanIdBroadcast)
     , mAlternateTimestamp(0)
-    , mNotifierCallback(aInstance, &Mle::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &Mle::HandleNotifierEvents, this)
     , mParentResponseCb(NULL)
     , mParentResponseCbContext(NULL)
 {
@@ -314,7 +314,7 @@ void Mle::SetRole(DeviceRole aRole)
 {
     DeviceRole oldRole = mRole;
 
-    SuccessOrExit(Get<Notifier>().Update(mRole, aRole, OT_CHANGED_THREAD_ROLE));
+    SuccessOrExit(Get<Notifier>().Update(mRole, aRole, kEventThreadRoleChanged));
 
     otLogNoteMle("Role %s -> %s", RoleToString(oldRole), RoleToString(mRole));
 
@@ -888,12 +888,13 @@ void Mle::UpdateLinkLocalAddress(void)
     mLinkLocal64.GetAddress().SetIid(Get<Mac::Mac>().GetExtAddress());
     Get<ThreadNetif>().AddUnicastAddress(mLinkLocal64);
 
-    Get<Notifier>().Signal(OT_CHANGED_THREAD_LL_ADDR);
+    Get<Notifier>().Signal(kEventThreadLinkLocalAddrChanged);
 }
 
 void Mle::SetMeshLocalPrefix(const MeshLocalPrefix &aMeshLocalPrefix)
 {
-    VerifyOrExit(GetMeshLocalPrefix() != aMeshLocalPrefix, Get<Notifier>().SignalIfFirst(OT_CHANGED_THREAD_ML_ADDR));
+    VerifyOrExit(GetMeshLocalPrefix() != aMeshLocalPrefix,
+                 Get<Notifier>().SignalIfFirst(kEventThreadMeshLocalAddrChanged));
 
     if (Get<ThreadNetif>().IsUp())
     {
@@ -974,7 +975,7 @@ void Mle::ApplyMeshLocalPrefix(void)
 
 exit:
     // Changing the prefix also causes the mesh local address to be different.
-    Get<Notifier>().Signal(OT_CHANGED_THREAD_ML_ADDR);
+    Get<Notifier>().Signal(kEventThreadMeshLocalAddrChanged);
 }
 
 uint16_t Mle::GetRloc16(void) const
@@ -1020,12 +1021,12 @@ void Mle::SetLeaderData(uint32_t aPartitionId, uint8_t aWeighting, uint8_t aLead
 #if OPENTHREAD_FTD
         Get<MleRouter>().HandlePartitionChange();
 #endif
-        Get<Notifier>().Signal(OT_CHANGED_THREAD_PARTITION_ID);
+        Get<Notifier>().Signal(kEventThreadPartitionIdChanged);
         mCounters.mPartitionIdChanges++;
     }
     else
     {
-        Get<Notifier>().SignalIfFirst(OT_CHANGED_THREAD_PARTITION_ID);
+        Get<Notifier>().SignalIfFirst(kEventThreadPartitionIdChanged);
     }
 
     mLeaderData.SetPartitionId(aPartitionId);
@@ -1495,16 +1496,16 @@ exit:
     return error;
 }
 
-void Mle::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
+void Mle::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
 {
-    aCallback.GetOwner<Mle>().HandleStateChanged(aFlags);
+    aCallback.GetOwner<Mle>().HandleNotifierEvents(aEvents);
 }
 
-void Mle::HandleStateChanged(otChangedFlags aFlags)
+void Mle::HandleNotifierEvents(Events aEvents)
 {
     VerifyOrExit(!IsDisabled(), OT_NOOP);
 
-    if (aFlags & OT_CHANGED_THREAD_ROLE)
+    if (aEvents.Contains(kEventThreadRoleChanged))
     {
         if (IsChild() && !IsFullThreadDevice() && mAddressRegistrationMode == kAppendMeshLocalOnly)
         {
@@ -1519,7 +1520,7 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
         }
     }
 
-    if ((aFlags & (OT_CHANGED_IP6_ADDRESS_ADDED | OT_CHANGED_IP6_ADDRESS_REMOVED)) != 0)
+    if (aEvents.ContainsAny(kEventIp6AddressAdded | kEventIp6AddressRemoved))
     {
         if (!Get<ThreadNetif>().IsUnicastAddress(mMeshLocal64.GetAddress()))
         {
@@ -1528,7 +1529,7 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
                                                    OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE));
 
             Get<ThreadNetif>().AddUnicastAddress(mMeshLocal64);
-            Get<Notifier>().Signal(OT_CHANGED_THREAD_ML_ADDR);
+            Get<Notifier>().Signal(kEventThreadMeshLocalAddrChanged);
         }
 
         if (IsChild() && !IsFullThreadDevice())
@@ -1538,7 +1539,7 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
         }
     }
 
-    if ((aFlags & (OT_CHANGED_IP6_MULTICAST_SUBSCRIBED | OT_CHANGED_IP6_MULTICAST_UNSUBSCRIBED)) != 0)
+    if (aEvents.ContainsAny(kEventIp6MulticastSubscribed | kEventIp6MulticastUnsubscribed))
     {
         // When multicast subscription changes, SED always notifies its parent as it depends on its
         // parent for indirect transmission. Since Thread 1.2, MED MAY also notify its parent of 1.2
@@ -1556,7 +1557,7 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
         }
     }
 
-    if ((aFlags & OT_CHANGED_THREAD_NETDATA) != 0)
+    if (aEvents.Contains(kEventThreadNetdataChanged))
     {
 #if OPENTHREAD_FTD
         if (IsFullThreadDevice())
@@ -1566,7 +1567,7 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
         else
 #endif
         {
-            if ((aFlags & OT_CHANGED_THREAD_ROLE) == 0)
+            if (!aEvents.Contains(kEventThreadRoleChanged))
             {
                 mChildUpdateRequestState = kChildUpdateRequestPending;
                 ScheduleMessageTransmissionTimer();
@@ -1589,18 +1590,18 @@ void Mle::HandleStateChanged(otChangedFlags aFlags)
 #endif // OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
     }
 
-    if (aFlags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER))
+    if (aEvents.ContainsAny(kEventThreadRoleChanged | kEventThreadKeySeqCounterChanged))
     {
         // Store the settings on a key seq change, or when role changes and device
         // is attached (i.e., skip `Store()` on role change to detached).
 
-        if ((aFlags & OT_CHANGED_THREAD_KEY_SEQUENCE_COUNTER) || IsAttached())
+        if (aEvents.Contains(kEventThreadKeySeqCounterChanged) || IsAttached())
         {
             IgnoreError(Store());
         }
     }
 
-    if (aFlags & OT_CHANGED_SECURITY_POLICY)
+    if (aEvents.Contains(kEventSecurityPolicyChanged))
     {
         Get<Ip6::Filter>().AllowNativeCommissioner(Get<KeyManager>().IsNativeCommissioningAllowed());
     }
@@ -2229,7 +2230,7 @@ void Mle::HandleMessageTransmissionTimer(void)
 {
     // The `mMessageTransmissionTimer` is used for:
     //
-    //  - Delaying OT_CHANGED notification triggered "Child Update Request" transmission (to allow aggregation),
+    //  - Delaying kEvent notification triggered "Child Update Request" transmission (to allow aggregation),
     //  - Retransmission of "Child Update Request",
     //  - Retransmission of "Data Request" on a child,
     //  - Sending periodic keep-alive "Child Update Request" messages on a non-sleepy (rx-on) child.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -62,6 +62,7 @@ namespace Mle {
 
 Mle::Mle(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , Notifier::Receiver(aInstance, Mle::HandleNotifierEvents)
     , mRetrieveNewNetworkData(false)
     , mRole(kRoleDisabled)
     , mDeviceMode(DeviceMode::kModeRxOnWhenIdle | DeviceMode::kModeSecureDataRequest)
@@ -108,7 +109,6 @@ Mle::Mle(Instance &aInstance)
     , mAlternateChannel(0)
     , mAlternatePanId(Mac::kPanIdBroadcast)
     , mAlternateTimestamp(0)
-    , mNotifierCallback(aInstance, &Mle::HandleNotifierEvents, this)
     , mParentResponseCb(NULL)
     , mParentResponseCbContext(NULL)
 {
@@ -1496,9 +1496,9 @@ exit:
     return error;
 }
 
-void Mle::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
+void Mle::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
 {
-    aCallback.GetOwner<Mle>().HandleNotifierEvents(aEvents);
+    static_cast<Mle &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void Mle::HandleNotifierEvents(Events aEvents)

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -305,7 +305,7 @@ private:
  * This class implements MLE functionality required by the Thread EndDevices, Router, and Leader roles.
  *
  */
-class Mle : public InstanceLocator
+class Mle : public InstanceLocator, public Notifier::Receiver
 {
 public:
     /**
@@ -1696,7 +1696,7 @@ private:
         TimeMilli    mSendTime;    // Time when the message shall be sent.
     };
 
-    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
     static void HandleAttachTimer(Timer &aTimer);
     void        HandleAttachTimer(void);
@@ -1822,8 +1822,6 @@ private:
     Ip6::NetifUnicastAddress   mMeshLocal16;
     Ip6::NetifMulticastAddress mLinkLocalAllThreadNodes;
     Ip6::NetifMulticastAddress mRealmLocalAllThreadNodes;
-
-    Notifier::Callback mNotifierCallback;
 
     otThreadParentResponseCallback mParentResponseCb;
     void *                         mParentResponseCbContext;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1696,8 +1696,8 @@ private:
         TimeMilli    mSendTime;    // Time when the message shall be sent.
     };
 
-    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
-    void        HandleStateChanged(otChangedFlags aFlags);
+    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    void        HandleNotifierEvents(Events aEvents);
     static void HandleAttachTimer(Timer &aTimer);
     void        HandleAttachTimer(void);
     static void HandleDelayedResponseTimer(Timer &aTimer);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -4759,11 +4759,11 @@ void MleRouter::Signal(otNeighborTableEvent aEvent, Neighbor &aNeighbor)
     switch (aEvent)
     {
     case OT_NEIGHBOR_TABLE_EVENT_CHILD_ADDED:
-        Get<Notifier>().Signal(OT_CHANGED_THREAD_CHILD_ADDED);
+        Get<Notifier>().Signal(kEventThreadChildAdded);
         break;
 
     case OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED:
-        Get<Notifier>().Signal(OT_CHANGED_THREAD_CHILD_REMOVED);
+        Get<Notifier>().Signal(kEventThreadChildRemoved);
         break;
 
     default:

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -64,7 +64,7 @@ void LeaderBase::Reset(void)
     mVersion       = Random::NonCrypto::GetUint8();
     mStableVersion = Random::NonCrypto::GetUint8();
     mLength        = 0;
-    Get<ot::Notifier>().Signal(OT_CHANGED_THREAD_NETDATA);
+    Get<ot::Notifier>().Signal(kEventThreadNetdataChanged);
 }
 
 otError LeaderBase::GetServiceId(uint32_t       aEnterpriseNumber,
@@ -444,7 +444,7 @@ otError LeaderBase::SetNetworkData(uint8_t        aVersion,
 
     otDumpDebgNetData("set network data", mTlvs, mLength);
 
-    Get<ot::Notifier>().Signal(OT_CHANGED_THREAD_NETDATA);
+    Get<ot::Notifier>().Signal(kEventThreadNetdataChanged);
 
 exit:
     return error;
@@ -470,7 +470,7 @@ otError LeaderBase::SetCommissioningData(const uint8_t *aValue, uint8_t aValueLe
     }
 
     mVersion++;
-    Get<ot::Notifier>().Signal(OT_CHANGED_THREAD_NETDATA);
+    Get<ot::Notifier>().Signal(kEventThreadNetdataChanged);
 
 exit:
     return error;

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -120,7 +120,7 @@ void Leader::IncrementVersions(bool aIncludeStable)
     }
 
     mVersion++;
-    Get<ot::Notifier>().Signal(OT_CHANGED_THREAD_NETDATA);
+    Get<ot::Notifier>().Signal(kEventThreadNetdataChanged);
 }
 
 void Leader::RemoveBorderRouter(uint16_t aRloc16, MatchMode aMatchMode)

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -46,7 +46,7 @@ namespace NetworkData {
 
 Notifier::Notifier(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mNotifierCallback(aInstance, &Notifier::HandleNotifierEvents, this)
+    , ot::Notifier::Receiver(aInstance, Notifier::HandleNotifierEvents)
     , mTimer(aInstance, Notifier::HandleTimer, this)
     , mNextDelay(0)
     , mWaitingForResponse(false)
@@ -101,9 +101,9 @@ exit:
     }
 }
 
-void Notifier::HandleNotifierEvents(ot::Notifier::Callback &aCallback, Events aEvents)
+void Notifier::HandleNotifierEvents(ot::Notifier::Receiver &aReceiver, Events aEvents)
 {
-    aCallback.GetOwner<Notifier>().HandleNotifierEvents(aEvents);
+    static_cast<Notifier &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void Notifier::HandleNotifierEvents(Events aEvents)

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -46,7 +46,7 @@ namespace NetworkData {
 
 Notifier::Notifier(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mNotifierCallback(aInstance, &Notifier::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &Notifier::HandleNotifierEvents, this)
     , mTimer(aInstance, Notifier::HandleTimer, this)
     , mNextDelay(0)
     , mWaitingForResponse(false)
@@ -101,19 +101,19 @@ exit:
     }
 }
 
-void Notifier::HandleStateChanged(ot::Notifier::Callback &aCallback, otChangedFlags aFlags)
+void Notifier::HandleNotifierEvents(ot::Notifier::Callback &aCallback, Events aEvents)
 {
-    aCallback.GetOwner<Notifier>().HandleStateChanged(aFlags);
+    aCallback.GetOwner<Notifier>().HandleNotifierEvents(aEvents);
 }
 
-void Notifier::HandleStateChanged(otChangedFlags aFlags)
+void Notifier::HandleNotifierEvents(Events aEvents)
 {
-    if (aFlags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_THREAD_CHILD_REMOVED))
+    if (aEvents.ContainsAny(kEventThreadRoleChanged | kEventThreadChildRemoved))
     {
         mNextDelay = 0;
     }
 
-    if (aFlags & (OT_CHANGED_THREAD_NETDATA | OT_CHANGED_THREAD_ROLE | OT_CHANGED_THREAD_CHILD_REMOVED))
+    if (aEvents.ContainsAny(kEventThreadNetdataChanged | kEventThreadRoleChanged | kEventThreadChildRemoved))
     {
         SynchronizeServerData();
     }

--- a/src/core/thread/network_data_notifier.hpp
+++ b/src/core/thread/network_data_notifier.hpp
@@ -49,7 +49,7 @@ namespace NetworkData {
  * This class implements the SVR_DATA.ntf transmission logic.
  *
  */
-class Notifier : public InstanceLocator
+class Notifier : public InstanceLocator, public ot::Notifier::Receiver
 {
 public:
     /**
@@ -74,7 +74,7 @@ private:
         kDelaySynchronizeServerData = 300000, ///< milliseconds
     };
 
-    static void HandleNotifierEvents(ot::Notifier::Callback &aCallback, Events aEvents);
+    static void HandleNotifierEvents(ot::Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
 
     static void HandleTimer(Timer &aTimer);
@@ -88,10 +88,9 @@ private:
 
     void SynchronizeServerData(void);
 
-    ot::Notifier::Callback mNotifierCallback;
-    TimerMilli             mTimer;
-    uint32_t               mNextDelay;
-    bool                   mWaitingForResponse;
+    TimerMilli mTimer;
+    uint32_t   mNextDelay;
+    bool       mWaitingForResponse;
 };
 
 } // namespace NetworkData

--- a/src/core/thread/network_data_notifier.hpp
+++ b/src/core/thread/network_data_notifier.hpp
@@ -74,8 +74,8 @@ private:
         kDelaySynchronizeServerData = 300000, ///< milliseconds
     };
 
-    static void HandleStateChanged(ot::Notifier::Callback &aCallback, otChangedFlags aFlags);
-    void        HandleStateChanged(otChangedFlags aFlags);
+    static void HandleNotifierEvents(ot::Notifier::Callback &aCallback, Events aEvents);
+    void        HandleNotifierEvents(Events aEvents);
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -146,7 +146,7 @@ void ThreadNetif::Up(void)
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
     IgnoreError(Get<Sntp::Client>().Start());
 #endif
-    Get<Notifier>().Signal(OT_CHANGED_THREAD_NETIF_STATE);
+    Get<Notifier>().Signal(kEventThreadNetifStateChanged);
 
 exit:
     return;
@@ -177,7 +177,7 @@ void ThreadNetif::Down(void)
 #if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
     IgnoreError(Get<Utils::ChannelMonitor>().Stop());
 #endif
-    Get<Notifier>().Signal(OT_CHANGED_THREAD_NETIF_STATE);
+    Get<Notifier>().Signal(kEventThreadNetifStateChanged);
 
 exit:
     return;

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -62,7 +62,7 @@ TimeSync::TimeSync(Instance &aInstance)
     , mNetworkTimeOffset(0)
     , mTimeSyncCallback(NULL)
     , mTimeSyncCallbackContext(NULL)
-    , mNotifierCallback(aInstance, &TimeSync::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &TimeSync::HandleNotifierEvents, this)
     , mTimer(aInstance, HandleTimeout, this)
     , mCurrentStatus(OT_NETWORK_TIME_UNSYNCHRONIZED)
 {
@@ -173,16 +173,16 @@ exit:
 }
 #endif // OPENTHREAD_FTD
 
-void TimeSync::HandleStateChanged(otChangedFlags aFlags)
+void TimeSync::HandleNotifierEvents(Events aEvents)
 {
     bool stateChanged = false;
 
-    if ((aFlags & OT_CHANGED_THREAD_ROLE) != 0)
+    if (aEvents.Contains(kEventThreadRoleChanged))
     {
         stateChanged = true;
     }
 
-    if ((aFlags & OT_CHANGED_THREAD_PARTITION_ID) != 0 && !Get<Mle::MleRouter>().IsLeader())
+    if (aEvents.Contains(kEventThreadPartitionIdChanged) && !Get<Mle::MleRouter>().IsLeader())
     {
         // Partition has changed. Accept any network time currently being seeded on the new partition
         // and don't attempt to forward the currently held network time from the previous partition.
@@ -209,9 +209,9 @@ void TimeSync::HandleTimeout(void)
     CheckAndHandleChanges(false);
 }
 
-void TimeSync::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
+void TimeSync::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
 {
-    aCallback.GetOwner<TimeSync>().HandleStateChanged(aFlags);
+    aCallback.GetOwner<TimeSync>().HandleNotifierEvents(aEvents);
 }
 
 void TimeSync::HandleTimeout(Timer &aTimer)

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -51,6 +51,7 @@ namespace ot {
 
 TimeSync::TimeSync(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , Notifier::Receiver(aInstance, TimeSync::HandleNotifierEvents)
     , mTimeSyncRequired(false)
     , mTimeSyncSeq(OT_TIME_SYNC_INVALID_SEQ)
     , mTimeSyncPeriod(OPENTHREAD_CONFIG_TIME_SYNC_PERIOD)
@@ -62,7 +63,6 @@ TimeSync::TimeSync(Instance &aInstance)
     , mNetworkTimeOffset(0)
     , mTimeSyncCallback(NULL)
     , mTimeSyncCallbackContext(NULL)
-    , mNotifierCallback(aInstance, &TimeSync::HandleNotifierEvents, this)
     , mTimer(aInstance, HandleTimeout, this)
     , mCurrentStatus(OT_NETWORK_TIME_UNSYNCHRONIZED)
 {
@@ -209,9 +209,9 @@ void TimeSync::HandleTimeout(void)
     CheckAndHandleChanges(false);
 }
 
-void TimeSync::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
+void TimeSync::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
 {
-    aCallback.GetOwner<TimeSync>().HandleNotifierEvents(aEvents);
+    static_cast<TimeSync &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void TimeSync::HandleTimeout(Timer &aTimer)

--- a/src/core/thread/time_sync_service.hpp
+++ b/src/core/thread/time_sync_service.hpp
@@ -50,7 +50,7 @@ namespace ot {
  * This class implements OpenThread Time Synchronization Service.
  *
  */
-class TimeSync : public InstanceLocator
+class TimeSync : public InstanceLocator, public Notifier::Receiver
 {
 public:
     /**
@@ -173,7 +173,7 @@ private:
      * @param[in] aFlags Flags that denote the state change events.
      *
      */
-    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
 
     /**
      * Callback to be called when timer expires.
@@ -216,7 +216,6 @@ private:
     otNetworkTimeSyncCallbackFn
                         mTimeSyncCallback; ///< The callback to be called when time sync is handled or status updated.
     void *              mTimeSyncCallbackContext; ///< The context to be passed to callback.
-    Notifier::Callback  mNotifierCallback;        ///< Callback for thread state changes.
     TimerMilli          mTimer;                   ///< Timer for checking if a resync is required.
     otNetworkTimeStatus mCurrentStatus;           ///< Current network time status.
 };

--- a/src/core/thread/time_sync_service.hpp
+++ b/src/core/thread/time_sync_service.hpp
@@ -157,7 +157,7 @@ public:
      * @param[in] aFlags Flags that denote the state change events.
      *
      */
-    void HandleStateChanged(otChangedFlags aFlags);
+    void HandleNotifierEvents(Events aEvents);
 
     /**
      * Callback to be called when timer expires.
@@ -173,7 +173,7 @@ private:
      * @param[in] aFlags Flags that denote the state change events.
      *
      */
-    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
+    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
 
     /**
      * Callback to be called when timer expires.

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -51,7 +51,7 @@ ChannelManager::ChannelManager(Instance &aInstance)
     , mSupportedChannelMask(0)
     , mFavoredChannelMask(0)
     , mActiveTimestamp(0)
-    , mNotifierCallback(aInstance, &ChannelManager::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &ChannelManager::HandleNotifierEvents, this)
     , mDelay(kMinimumDelay)
     , mChannel(0)
     , mState(kStateIdle)
@@ -77,7 +77,7 @@ void ChannelManager::RequestChannelChange(uint8_t aChannel)
 
     mTimer.Start(1 + Random::NonCrypto::GetUint32InRange(0, kRequestStartJitterInterval));
 
-    Get<Notifier>().Signal(OT_CHANGED_CHANNEL_MANAGER_NEW_CHANNEL);
+    Get<Notifier>().Signal(kEventChannelManagerNewChannelChanged);
 
 exit:
     return;
@@ -252,14 +252,14 @@ void ChannelManager::HandleTimer(void)
     }
 }
 
-void ChannelManager::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aChangedFlags)
+void ChannelManager::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
 {
-    aCallback.GetOwner<ChannelManager>().HandleStateChanged(aChangedFlags);
+    aCallback.GetOwner<ChannelManager>().HandleNotifierEvents(aEvents);
 }
 
-void ChannelManager::HandleStateChanged(otChangedFlags aChangedFlags)
+void ChannelManager::HandleNotifierEvents(Events aEvents)
 {
-    VerifyOrExit((aChangedFlags & OT_CHANGED_THREAD_CHANNEL) != 0, OT_NOOP);
+    VerifyOrExit(aEvents.Contains(kEventThreadChannelChanged), OT_NOOP);
     VerifyOrExit(mChannel == Get<Mac::Mac>().GetPanChannel(), OT_NOOP);
 
     mState = kStateIdle;

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -48,10 +48,10 @@ namespace Utils {
 
 ChannelManager::ChannelManager(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , Notifier::Receiver(aInstance, ChannelManager::HandleNotifierEvents)
     , mSupportedChannelMask(0)
     , mFavoredChannelMask(0)
     , mActiveTimestamp(0)
-    , mNotifierCallback(aInstance, &ChannelManager::HandleNotifierEvents, this)
     , mDelay(kMinimumDelay)
     , mChannel(0)
     , mState(kStateIdle)
@@ -252,9 +252,9 @@ void ChannelManager::HandleTimer(void)
     }
 }
 
-void ChannelManager::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
+void ChannelManager::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
 {
-    aCallback.GetOwner<ChannelManager>().HandleNotifierEvents(aEvents);
+    static_cast<ChannelManager &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void ChannelManager::HandleNotifierEvents(Events aEvents)

--- a/src/core/utils/channel_manager.hpp
+++ b/src/core/utils/channel_manager.hpp
@@ -64,7 +64,7 @@ namespace Utils {
  * This class implements the Channel Manager.
  *
  */
-class ChannelManager : public InstanceLocator, private NonCopyable
+class ChannelManager : public InstanceLocator, public Notifier::Receiver, private NonCopyable
 {
 public:
     enum
@@ -272,7 +272,7 @@ private:
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
     void        PreparePendingDataset(void);
     void        StartAutoSelectTimer(void);
@@ -282,16 +282,15 @@ private:
     bool    ShouldAttemptChannelChange(void);
 #endif
 
-    Mac::ChannelMask   mSupportedChannelMask;
-    Mac::ChannelMask   mFavoredChannelMask;
-    uint64_t           mActiveTimestamp;
-    Notifier::Callback mNotifierCallback;
-    uint16_t           mDelay;
-    uint8_t            mChannel;
-    State              mState;
-    TimerMilli         mTimer;
-    uint32_t           mAutoSelectInterval;
-    bool               mAutoSelectEnabled;
+    Mac::ChannelMask mSupportedChannelMask;
+    Mac::ChannelMask mFavoredChannelMask;
+    uint64_t         mActiveTimestamp;
+    uint16_t         mDelay;
+    uint8_t          mChannel;
+    State            mState;
+    TimerMilli       mTimer;
+    uint32_t         mAutoSelectInterval;
+    bool             mAutoSelectEnabled;
 };
 
 #else // OPENTHREAD_FTD

--- a/src/core/utils/channel_manager.hpp
+++ b/src/core/utils/channel_manager.hpp
@@ -92,7 +92,7 @@ public:
      *
      * A subsequent call to this method will cancel an ongoing previously requested channel change.
      *
-     * If the requested channel changes, it will trigger a `Notifier` event `OT_CHANGED_CHANNEL_MANAGER_NEW_CHANNEL`.
+     * If the requested channel changes, it will trigger a `Notifier` event `kEventChannelManagerNewChannelChanged`.
      *
      * @param[in] aChannel             The new channel for the Thread network.
      *
@@ -272,8 +272,8 @@ private:
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aChangedFlags);
-    void        HandleStateChanged(otChangedFlags aChangedFlags);
+    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    void        HandleNotifierEvents(Events aEvents);
     void        PreparePendingDataset(void);
     void        StartAutoSelectTimer(void);
 

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -49,9 +49,9 @@ namespace Utils {
 
 ChildSupervisor::ChildSupervisor(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , Notifier::Receiver(aInstance, ChildSupervisor::HandleNotifierEvents)
     , mSupervisionInterval(kDefaultSupervisionInterval)
     , mTimer(aInstance, ChildSupervisor::HandleTimer, this)
-    , mNotifierCallback(aInstance, &ChildSupervisor::HandleNotifierEvents, this)
 {
 }
 
@@ -162,9 +162,9 @@ void ChildSupervisor::CheckState(void)
     }
 }
 
-void ChildSupervisor::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
+void ChildSupervisor::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
 {
-    aCallback.GetOwner<ChildSupervisor>().HandleNotifierEvents(aEvents);
+    static_cast<ChildSupervisor &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void ChildSupervisor::HandleNotifierEvents(Events aEvents)

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -51,7 +51,7 @@ ChildSupervisor::ChildSupervisor(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mSupervisionInterval(kDefaultSupervisionInterval)
     , mTimer(aInstance, ChildSupervisor::HandleTimer, this)
-    , mNotifierCallback(aInstance, &ChildSupervisor::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &ChildSupervisor::HandleNotifierEvents, this)
 {
 }
 
@@ -162,14 +162,14 @@ void ChildSupervisor::CheckState(void)
     }
 }
 
-void ChildSupervisor::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
+void ChildSupervisor::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
 {
-    aCallback.GetOwner<ChildSupervisor>().HandleStateChanged(aFlags);
+    aCallback.GetOwner<ChildSupervisor>().HandleNotifierEvents(aEvents);
 }
 
-void ChildSupervisor::HandleStateChanged(otChangedFlags aFlags)
+void ChildSupervisor::HandleNotifierEvents(Events aEvents)
 {
-    if ((aFlags & (OT_CHANGED_THREAD_ROLE | OT_CHANGED_THREAD_CHILD_ADDED | OT_CHANGED_THREAD_CHILD_REMOVED)) != 0)
+    if (aEvents.ContainsAny(kEventThreadRoleChanged | kEventThreadChildAdded | kEventThreadChildRemoved))
     {
         CheckState();
     }

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -88,7 +88,7 @@ namespace Utils {
  * This class implements a child supervisor.
  *
  */
-class ChildSupervisor : public InstanceLocator
+class ChildSupervisor : public InstanceLocator, public Notifier::Receiver
 {
 public:
     /**
@@ -160,12 +160,11 @@ private:
     void        CheckState(void);
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
 
-    uint16_t           mSupervisionInterval;
-    TimerMilli         mTimer;
-    Notifier::Callback mNotifierCallback;
+    uint16_t   mSupervisionInterval;
+    TimerMilli mTimer;
 };
 
 #else // #if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE && OPENTHREAD_FTD

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -160,8 +160,8 @@ private:
     void        CheckState(void);
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
-    void        HandleStateChanged(otChangedFlags aFlags);
+    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    void        HandleNotifierEvents(Events aEvents);
 
     uint16_t           mSupervisionInterval;
     TimerMilli         mTimer;

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -47,9 +47,9 @@ namespace Utils {
 
 JamDetector::JamDetector(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , Notifier::Receiver(aInstance, JamDetector::HandleNotifierEvents)
     , mHandler(NULL)
     , mContext(NULL)
-    , mNotifierCallback(aInstance, HandleNotifierEvents, this)
     , mTimer(aInstance, JamDetector::HandleTimer, this)
     , mHistoryBitmap(0)
     , mCurSecondStartTime(0)
@@ -271,9 +271,9 @@ void JamDetector::SetJamState(bool aNewState)
     }
 }
 
-void JamDetector::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
+void JamDetector::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
 {
-    aCallback.GetOwner<JamDetector>().HandleNotifierEvents(aEvents);
+    static_cast<JamDetector &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void JamDetector::HandleNotifierEvents(Events aEvents)

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -49,7 +49,7 @@ JamDetector::JamDetector(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mHandler(NULL)
     , mContext(NULL)
-    , mNotifierCallback(aInstance, HandleStateChanged, this)
+    , mNotifierCallback(aInstance, HandleNotifierEvents, this)
     , mTimer(aInstance, JamDetector::HandleTimer, this)
     , mHistoryBitmap(0)
     , mCurSecondStartTime(0)
@@ -271,14 +271,14 @@ void JamDetector::SetJamState(bool aNewState)
     }
 }
 
-void JamDetector::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
+void JamDetector::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
 {
-    aCallback.GetOwner<JamDetector>().HandleStateChanged(aFlags);
+    aCallback.GetOwner<JamDetector>().HandleNotifierEvents(aEvents);
 }
 
-void JamDetector::HandleStateChanged(otChangedFlags aFlags)
+void JamDetector::HandleNotifierEvents(Events aEvents)
 {
-    if (aFlags & OT_CHANGED_THREAD_ROLE)
+    if (aEvents.Contains(kEventThreadRoleChanged))
     {
         CheckState();
     }

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -190,8 +190,8 @@ private:
     void        HandleTimer(void);
     void        UpdateHistory(bool aDidExceedThreshold);
     void        UpdateJamState(void);
-    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
-    void        HandleStateChanged(otChangedFlags aFlags);
+    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    void        HandleNotifierEvents(Events aEvents);
 
     Handler            mHandler;                  // Handler/callback to inform about jamming state
     void *             mContext;                  // Context for handler/callback

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -48,7 +48,7 @@ class ThreadNetif;
 
 namespace Utils {
 
-class JamDetector : public InstanceLocator
+class JamDetector : public InstanceLocator, public Notifier::Receiver
 {
 public:
     /**
@@ -190,22 +190,21 @@ private:
     void        HandleTimer(void);
     void        UpdateHistory(bool aDidExceedThreshold);
     void        UpdateJamState(void);
-    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
 
-    Handler            mHandler;                  // Handler/callback to inform about jamming state
-    void *             mContext;                  // Context for handler/callback
-    Notifier::Callback mNotifierCallback;         // Notifier callback
-    TimerMilli         mTimer;                    // RSSI sample timer
-    uint64_t           mHistoryBitmap;            // History bitmap, each bit correspond to 1 sec interval
-    TimeMilli          mCurSecondStartTime;       // Start time for current 1 sec interval
-    uint16_t           mSampleInterval;           // Current sample interval
-    uint8_t            mWindow : 6;               // Window (in sec) to monitor jamming
-    uint8_t            mBusyPeriod : 6;           // BusyPeriod (in sec) with mWindow to alert jamming
-    bool               mEnabled : 1;              // If jam detection is enabled
-    bool               mAlwaysAboveThreshold : 1; // State for current 1 sec interval
-    bool               mJamState : 1;             // Current jam state
-    int8_t             mRssiThreshold;            // RSSI threshold for jam detection
+    Handler    mHandler;                  // Handler/callback to inform about jamming state
+    void *     mContext;                  // Context for handler/callback
+    TimerMilli mTimer;                    // RSSI sample timer
+    uint64_t   mHistoryBitmap;            // History bitmap, each bit correspond to 1 sec interval
+    TimeMilli  mCurSecondStartTime;       // Start time for current 1 sec interval
+    uint16_t   mSampleInterval;           // Current sample interval
+    uint8_t    mWindow : 6;               // Window (in sec) to monitor jamming
+    uint8_t    mBusyPeriod : 6;           // BusyPeriod (in sec) with mWindow to alert jamming
+    bool       mEnabled : 1;              // If jam detection is enabled
+    bool       mAlwaysAboveThreshold : 1; // State for current 1 sec interval
+    bool       mJamState : 1;             // Current jam state
+    int8_t     mRssiThreshold;            // RSSI threshold for jam detection
 };
 
 /**

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -86,9 +86,9 @@ void Otns::EmitStatus(const char *aFmt, ...)
     otPlatOtnsStatus(statusStr);
 }
 
-void Otns::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
+void Otns::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
 {
-    aCallback.GetOwner<Otns>().HandleNotifierEvents(aEvents);
+    static_cast<Otns &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void Otns::HandleNotifierEvents(Events aEvents)

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -86,24 +86,24 @@ void Otns::EmitStatus(const char *aFmt, ...)
     otPlatOtnsStatus(statusStr);
 }
 
-void Otns::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
+void Otns::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
 {
-    aCallback.GetOwner<Otns>().HandleStateChanged(aFlags);
+    aCallback.GetOwner<Otns>().HandleNotifierEvents(aEvents);
 }
 
-void Otns::HandleStateChanged(otChangedFlags aFlags)
+void Otns::HandleNotifierEvents(Events aEvents)
 {
-    if ((aFlags & OT_CHANGED_THREAD_ROLE) != 0)
+    if (aEvents.Contains(kEventThreadRoleChanged))
     {
         EmitStatus("role=%d", Get<Mle::Mle>().GetRole());
     }
 
-    if ((aFlags & OT_CHANGED_THREAD_PARTITION_ID) != 0)
+    if (aEvents.Contains(kEventThreadPartitionIdChanged))
     {
         EmitStatus("parid=%x", Get<Mle::Mle>().GetLeaderData().GetPartitionId());
     }
 
-    if ((aFlags & OT_CHANGED_JOINER_STATE) != 0)
+    if (aEvents.Contains(kEventJoinerStateChanged))
     {
         EmitStatus("joiner_state=%d", Get<MeshCoP::Joiner>().GetState());
     }

--- a/src/core/utils/otns.hpp
+++ b/src/core/utils/otns.hpp
@@ -67,7 +67,7 @@ public:
      */
     explicit Otns(Instance &aInstance)
         : InstanceLocator(aInstance)
-        , mNotifierCallback(aInstance, &Otns::HandleStateChanged, this)
+        , mNotifierCallback(aInstance, &Otns::HandleNotifierEvents, this)
     {
     }
 
@@ -127,8 +127,8 @@ public:
 private:
     static void EmitStatus(const char *aFmt, ...);
 
-    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
-    void        HandleStateChanged(otChangedFlags aFlags);
+    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    void        HandleNotifierEvents(Events aEvents);
 
     Notifier::Callback mNotifierCallback;
 };

--- a/src/core/utils/otns.hpp
+++ b/src/core/utils/otns.hpp
@@ -56,7 +56,7 @@ namespace Utils {
  * This class implements the OTNS Stub that interacts with OTNS.
  *
  */
-class Otns : public InstanceLocator, private NonCopyable
+class Otns : public InstanceLocator, public Notifier::Receiver, private NonCopyable
 {
 public:
     /**
@@ -67,7 +67,7 @@ public:
      */
     explicit Otns(Instance &aInstance)
         : InstanceLocator(aInstance)
-        , mNotifierCallback(aInstance, &Otns::HandleNotifierEvents, this)
+        , Notifier::Receiver(aInstance, Otns::HandleNotifierEvents)
     {
     }
 
@@ -127,10 +127,8 @@ public:
 private:
     static void EmitStatus(const char *aFmt, ...);
 
-    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
-
-    Notifier::Callback mNotifierCallback;
 };
 
 } // namespace Utils

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -51,7 +51,7 @@ Slaac::Slaac(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mEnabled(true)
     , mFilter(NULL)
-    , mNotifierCallback(aInstance, &Slaac::HandleStateChanged, this)
+    , mNotifierCallback(aInstance, &Slaac::HandleNotifierEvents, this)
 {
     memset(mAddresses, 0, sizeof(mAddresses));
 }
@@ -99,23 +99,23 @@ bool Slaac::ShouldFilter(const otIp6Prefix &aPrefix) const
     return (mFilter != NULL) && mFilter(&GetInstance(), &aPrefix);
 }
 
-void Slaac::HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags)
+void Slaac::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
 {
-    aCallback.GetOwner<Slaac>().HandleStateChanged(aFlags);
+    aCallback.GetOwner<Slaac>().HandleNotifierEvents(aEvents);
 }
 
-void Slaac::HandleStateChanged(otChangedFlags aFlags)
+void Slaac::HandleNotifierEvents(Events aEvents)
 {
     UpdateMode mode = kModeNone;
 
     VerifyOrExit(mEnabled, OT_NOOP);
 
-    if (aFlags & OT_CHANGED_THREAD_NETDATA)
+    if (aEvents.Contains(kEventThreadNetdataChanged))
     {
         mode |= kModeAdd | kModeRemove;
     }
 
-    if (aFlags & OT_CHANGED_IP6_ADDRESS_REMOVED)
+    if (aEvents.Contains(kEventIp6AddressRemoved))
     {
         // When an IPv6 address is removed, we ensure to check if a SLAAC address
         // needs to be added (replacing the removed address).

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -49,9 +49,9 @@ namespace Utils {
 
 Slaac::Slaac(Instance &aInstance)
     : InstanceLocator(aInstance)
+    , Notifier::Receiver(aInstance, Slaac::HandleNotifierEvents)
     , mEnabled(true)
     , mFilter(NULL)
-    , mNotifierCallback(aInstance, &Slaac::HandleNotifierEvents, this)
 {
     memset(mAddresses, 0, sizeof(mAddresses));
 }
@@ -99,9 +99,9 @@ bool Slaac::ShouldFilter(const otIp6Prefix &aPrefix) const
     return (mFilter != NULL) && mFilter(&GetInstance(), &aPrefix);
 }
 
-void Slaac::HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents)
+void Slaac::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
 {
-    aCallback.GetOwner<Slaac>().HandleNotifierEvents(aEvents);
+    static_cast<Slaac &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void Slaac::HandleNotifierEvents(Events aEvents)

--- a/src/core/utils/slaac_address.hpp
+++ b/src/core/utils/slaac_address.hpp
@@ -161,8 +161,8 @@ private:
     bool        ShouldFilter(const otIp6Prefix &aPrefix) const;
     void        Update(UpdateMode aMode);
     void        GetIidSecretKey(IidSecretKey &aKey) const;
-    static void HandleStateChanged(Notifier::Callback &aCallback, otChangedFlags aFlags);
-    void        HandleStateChanged(otChangedFlags aFlags);
+    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    void        HandleNotifierEvents(Events aEvents);
 
     bool                     mEnabled;
     otIp6SlaacPrefixFilter   mFilter;

--- a/src/core/utils/slaac_address.hpp
+++ b/src/core/utils/slaac_address.hpp
@@ -56,7 +56,7 @@ namespace Utils {
  * This class implements the SLAAC utility for Thread protocol.
  *
  */
-class Slaac : public InstanceLocator
+class Slaac : public InstanceLocator, public Notifier::Receiver
 {
 public:
     enum
@@ -161,12 +161,11 @@ private:
     bool        ShouldFilter(const otIp6Prefix &aPrefix) const;
     void        Update(UpdateMode aMode);
     void        GetIidSecretKey(IidSecretKey &aKey) const;
-    static void HandleNotifierEvents(Notifier::Callback &aCallback, Events aEvents);
+    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
 
     bool                     mEnabled;
     otIp6SlaacPrefixFilter   mFilter;
-    Notifier::Callback       mNotifierCallback;
     Ip6::NetifUnicastAddress mAddresses[OPENTHREAD_CONFIG_IP6_SLAAC_NUM_ADDRESSES];
 };
 

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -260,7 +260,7 @@ otError HdlcInterface::WaitForFrame(uint64_t aTimeoutUs)
     otError        error = OT_ERROR_NONE;
     struct timeval timeout;
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
-    struct Event event;
+    struct VirtualTimeEvent event;
 
     timeout.tv_sec  = static_cast<time_t>(aTimeoutUs / US_PER_S);
     timeout.tv_usec = static_cast<suseconds_t>(aTimeoutUs % US_PER_S);

--- a/src/posix/platform/hdlc_interface.hpp
+++ b/src/posix/platform/hdlc_interface.hpp
@@ -145,7 +145,7 @@ public:
      * @param[in] aEvent   The data event.
      *
      */
-    void Process(const Event &aEvent) { Decode(aEvent.mData, aEvent.mDataLength); }
+    void Process(const VirtualTimeEvent &aEvent) { Decode(aEvent.mData, aEvent.mDataLength); }
 #endif
 
 private:

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -83,7 +83,7 @@ enum
 };
 
 OT_TOOL_PACKED_BEGIN
-struct Event
+struct VirtualTimeEvent
 {
     uint64_t mDelay;
     uint8_t  mEvent;
@@ -331,7 +331,7 @@ void virtualTimeSendRadioSpinelWriteEvent(const uint8_t *aData, uint16_t aLength
  * @param[out]  aEvent  A pointer to the event receiving the event.
  *
  */
-void virtualTimeReceiveEvent(struct Event *aEvent);
+void virtualTimeReceiveEvent(struct VirtualTimeEvent *aEvent);
 
 /**
  * This function sends sleep event through virtual time simulation.
@@ -348,7 +348,7 @@ void virtualTimeSendSleepEvent(const struct timeval *aTimeout);
  * @param[in]   aEvent      A pointer to the current event.
  *
  */
-void virtualTimeRadioSpinelProcess(otInstance *aInstance, const struct Event *aEvent);
+void virtualTimeRadioSpinelProcess(otInstance *aInstance, const struct VirtualTimeEvent *aEvent);
 
 /**
  * This function initializes platform UDP driver.

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -39,7 +39,7 @@
 #include "hdlc_interface.hpp"
 
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
-static ot::Spinel::RadioSpinel<ot::Posix::HdlcInterface, Event> sRadioSpinel;
+static ot::Spinel::RadioSpinel<ot::Posix::HdlcInterface, VirtualTimeEvent> sRadioSpinel;
 #else
 static ot::Spinel::RadioSpinel<ot::Posix::HdlcInterface, RadioProcessContext> sRadioSpinel;
 #endif // OPENTHREAD_POSIX_VIRTUAL_TIME
@@ -246,7 +246,7 @@ void platformRadioUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, int *aMax
 }
 
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
-void virtualTimeRadioSpinelProcess(otInstance *aInstance, const struct Event *aEvent)
+void virtualTimeRadioSpinelProcess(otInstance *aInstance, const struct VirtualTimeEvent *aEvent)
 {
     OT_UNUSED_VARIABLE(aInstance);
     sRadioSpinel.Process(*aEvent);

--- a/src/posix/platform/virtual_time.cpp
+++ b/src/posix/platform/virtual_time.cpp
@@ -105,7 +105,7 @@ void virtualTimeDeinit(void)
     }
 }
 
-static void virtualTimeSendEvent(struct Event *aEvent, size_t aLength)
+static void virtualTimeSendEvent(struct VirtualTimeEvent *aEvent, size_t aLength)
 {
     ssize_t            rval;
     struct sockaddr_in sockaddr;
@@ -123,11 +123,11 @@ static void virtualTimeSendEvent(struct Event *aEvent, size_t aLength)
     }
 }
 
-void virtualTimeReceiveEvent(struct Event *aEvent)
+void virtualTimeReceiveEvent(struct VirtualTimeEvent *aEvent)
 {
     ssize_t rval = recvfrom(sSockFd, aEvent, sizeof(*aEvent), 0, NULL, NULL);
 
-    if (rval < 0 || (uint16_t)rval < offsetof(struct Event, mData))
+    if (rval < 0 || (uint16_t)rval < offsetof(struct VirtualTimeEvent, mData))
     {
         DieNowWithMessage("recvfrom", (rval < 0) ? OT_EXIT_ERROR_ERRNO : OT_EXIT_FAILURE);
     }
@@ -137,18 +137,18 @@ void virtualTimeReceiveEvent(struct Event *aEvent)
 
 void virtualTimeSendSleepEvent(const struct timeval *aTimeout)
 {
-    struct Event event;
+    struct VirtualTimeEvent event;
 
     event.mDelay      = (uint64_t)aTimeout->tv_sec * kUsPerSecond + (uint64_t)aTimeout->tv_usec;
     event.mEvent      = OT_SIM_EVENT_ALARM_FIRED;
     event.mDataLength = 0;
 
-    virtualTimeSendEvent(&event, offsetof(struct Event, mData));
+    virtualTimeSendEvent(&event, offsetof(struct VirtualTimeEvent, mData));
 }
 
 void virtualTimeSendRadioSpinelWriteEvent(const uint8_t *aData, uint16_t aLength)
 {
-    struct Event event;
+    struct VirtualTimeEvent event;
 
     event.mDelay      = 0;
     event.mEvent      = OT_SIM_EVENT_RADIO_SPINEL_WRITE;
@@ -156,7 +156,7 @@ void virtualTimeSendRadioSpinelWriteEvent(const uint8_t *aData, uint16_t aLength
 
     memcpy(event.mData, aData, aLength);
 
-    virtualTimeSendEvent(&event, offsetof(struct Event, mData) + event.mDataLength);
+    virtualTimeSendEvent(&event, offsetof(struct VirtualTimeEvent, mData) + event.mDataLength);
 }
 
 void virtualTimeUpdateFdSet(fd_set *        aReadFdSet,
@@ -181,7 +181,7 @@ void virtualTimeProcess(otInstance *  aInstance,
                         const fd_set *aWriteFdSet,
                         const fd_set *aErrorFdSet)
 {
-    struct Event event;
+    struct VirtualTimeEvent event;
 
     memset(&event, 0, sizeof(event));
 


### PR DESCRIPTION
This PR contains three related commits: 

**[notifier] add Event and Events types & simplify Notifier handler**

This class adds `Event` enumeration type representing `Notifier` events (mirroring `OT_CHANGED_{EVENT}` constants). It also adds `Events` class which represents a collection of events (i.e., signaled from `Notifier` to different modules). The `Events` class provides helper methods to check if a specific event has happened (`Events::Contains()` or if any (`Events::ContainsAny()`) or all (`Events::ContainsAll()`) of a given subset of events are present in the collection.
    
This commit also renames and harmonizes the `Notifier` handler method in different core classes to use `HandleNotififerEvents()`.

**[notifier] add Notifier::Receiver**

This commit adds `Notifier::Receiver` class which is inherited by OpenThread core types/classes to register themselves as a receiver of `Notifier` events. This change helps simplify and replace the previous `Notifier` callback model.

**[posix] rename struct Event to VirtualTimeEvent**

This `struct` is defined in a C header file and therefore is not scoped in a namespae. It is being used for radio/timer simulating (virtual time mode) in POISX platform. The rename is to avoid name conflicts with OpenThread core thus allowing `ot::Event` to be defined/used.