### PR TITLE
[meshcop] support get/set operational dataset via raw TLVs

### DIFF
--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -352,12 +352,38 @@ otError otDatasetGetActiveTlvs(otInstance *aInstance, otOperationalDatasetTlvs *
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aDataset  A pointer to the Active Operational Dataset.
  *
- * @retval OT_ERROR_NONE          Successfully set the Active Operational Dataset.
- * @retval OT_ERROR_NO_BUFS       Insufficient buffer space to set the Active Operational Dataset.
- * @retval OT_ERROR_INVALID_ARGS  @p aDataset was NULL.
+ * @retval OT_ERROR_NONE             Successfully set the Active Operational Dataset.
+ * @retval OT_ERROR_NO_BUFS          Insufficient buffer space to set the Active Operational Dataset.
+ * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
  *
  */
 otError otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aDataset);
+
+/**
+ * This function sets the Active Operational Dataset.
+ *
+ * If the dataset does not include an Active Timestamp, the dataset is only partially complete.
+ *
+ * If Thread is enabled on a device that has a partially complete Active Dataset, the device will attempt to attach to
+ * an existing Thread network using any existing information in the dataset. Only the Thread Master Key is needed to
+ * attach to a network.
+ *
+ * If channel is not included in the dataset, the device will send MLE Announce messages across different channels to
+ * find neighbors on other channels.
+ *
+ * If the device successfully attaches to a Thread network, the device will then retrieve the full Active Dataset from
+ * its Parent. Note that a router-capable device will not transition to the Router or Leader roles until it has a
+ * complete Active Dataset.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ * @param[in]  aDataset  A pointer to the Active Operational Dataset.
+ *
+ * @retval OT_ERROR_NONE             Successfully set the Active Operational Dataset.
+ * @retval OT_ERROR_NO_BUFS          Insufficient buffer space to set the Active Operational Dataset.
+ * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
+ *
+ */
+otError otDatasetSetActiveTlvs(otInstance *aInstance, const otOperationalDatasetTlvs *aDataset);
 
 /**
  * This function gets the Pending Operational Dataset.
@@ -389,12 +415,25 @@ otError otDatasetGetPendingTlvs(otInstance *aInstance, otOperationalDatasetTlvs 
  * @param[in]  aInstance A pointer to an OpenThread instance.
  * @param[in]  aDataset  A pointer to the Pending Operational Dataset.
  *
- * @retval OT_ERROR_NONE          Successfully set the Pending Operational Dataset.
- * @retval OT_ERROR_NO_BUFS       Insufficient buffer space to set the Pending Operational Dataset.
- * @retval OT_ERROR_INVALID_ARGS  @p aDataset was NULL.
+ * @retval OT_ERROR_NONE             Successfully set the Pending Operational Dataset.
+ * @retval OT_ERROR_NO_BUFS          Insufficient buffer space to set the Pending Operational Dataset.
+ * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
  *
  */
 otError otDatasetSetPending(otInstance *aInstance, const otOperationalDataset *aDataset);
+
+/**
+ * This function sets the Pending Operational Dataset.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ * @param[in]  aDataset  A pointer to the Pending Operational Dataset.
+ *
+ * @retval OT_ERROR_NONE             Successfully set the Pending Operational Dataset.
+ * @retval OT_ERROR_NO_BUFS          Insufficient buffer space to set the Pending Operational Dataset.
+ * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
+ *
+ */
+otError otDatasetSetPendingTlvs(otInstance *aInstance, const otOperationalDatasetTlvs *aDataset);
 
 /**
  * This function sends MGMT_ACTIVE_GET.

--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -235,6 +235,24 @@ typedef struct otOperationalDataset
 } otOperationalDataset;
 
 /**
+ * Maximum length of Operational Dataset in bytes.
+ *
+ */
+#define OT_OPERATIONAL_DATASET_MAX_LENGTH 254
+
+/**
+ * This structure represents an Active or Pending Operational Dataset.
+ *
+ * The Operational Dataset is TLV encoded as specified by Thread.
+ *
+ */
+typedef struct otOperationalDatasetTlvs
+{
+    uint8_t mTlvs[OT_OPERATIONAL_DATASET_MAX_LENGTH]; ///< Operational Dataset TLVs.
+    uint8_t mLength;                                  ///< Size of Operational Dataset in bytes.
+} otOperationalDatasetTlvs;
+
+/**
  * This enumeration represents meshcop TLV types.
  *
  */
@@ -298,10 +316,22 @@ bool otDatasetIsCommissioned(otInstance *aInstance);
  * @param[out]  aDataset  A pointer to where the Active Operational Dataset will be placed.
  *
  * @retval OT_ERROR_NONE          Successfully retrieved the Active Operational Dataset.
- * @retval OT_ERROR_INVALID_ARGS  @p aDataset was NULL.
+ * @retval OT_ERROR_NOT_FOUND     No corresponding value in the setting store.
  *
  */
 otError otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset);
+
+/**
+ * This function gets the Active Operational Dataset.
+ *
+ * @param[in]   aInstance A pointer to an OpenThread instance.
+ * @param[out]  aDataset  A pointer to where the Active Operational Dataset will be placed.
+ *
+ * @retval OT_ERROR_NONE          Successfully retrieved the Active Operational Dataset.
+ * @retval OT_ERROR_NOT_FOUND     No corresponding value in the setting store.
+ *
+ */
+otError otDatasetGetActiveTlvs(otInstance *aInstance, otOperationalDatasetTlvs *aDataset);
 
 /**
  * This function sets the Active Operational Dataset.
@@ -336,10 +366,22 @@ otError otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aD
  * @param[out]  aDataset  A pointer to where the Pending Operational Dataset will be placed.
  *
  * @retval OT_ERROR_NONE          Successfully retrieved the Pending Operational Dataset.
- * @retval OT_ERROR_INVALID_ARGS  @p aDataset was NULL.
+ * @retval OT_ERROR_NOT_FOUND     No corresponding value in the setting store.
  *
  */
 otError otDatasetGetPending(otInstance *aInstance, otOperationalDataset *aDataset);
+
+/**
+ * This function gets the Pending Operational Dataset.
+ *
+ * @param[in]   aInstance A pointer to an OpenThread instance.
+ * @param[out]  aDataset  A pointer to where the Pending Operational Dataset will be placed.
+ *
+ * @retval OT_ERROR_NONE          Successfully retrieved the Pending Operational Dataset.
+ * @retval OT_ERROR_NOT_FOUND     No corresponding value in the setting store.
+ *
+ */
+otError otDatasetGetPendingTlvs(otInstance *aInstance, otOperationalDatasetTlvs *aDataset);
 
 /**
  * This function sets the Pending Operational Dataset.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (3)
+#define OPENTHREAD_API_VERSION (4)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README_DATASET.md
+++ b/src/cli/README_DATASET.md
@@ -421,3 +421,21 @@ Set security policy.
 > dataset securitypolicy 672 onrcb
 Done
 ```
+
+### set
+
+Usage: `dataset set <active|pending> <dataset>`
+
+Set the Active Operational Dataset using hex-encoded TLVs.
+
+```bash
+dataset set active 0e080000000000010000000300001035060004001fffe002084eb74ab03c56e6d00708fdc7fe165c83a67805108e2104f183e698da87e96efc1e45aa51030f4f70656e5468726561642d383631310102861104108d6273023d82c841eff0e68db86f35740c030000ff
+Done
+```
+
+Set the Pending Operational Dataset using hex-encoded TLVs.
+
+```bash
+dataset set pending 0e080000000000010000000300001035060004001fffe002084eb74ab03c56e6d00708fdc7fe165c83a67805108e2104f183e698da87e96efc1e45aa51030f4f70656e5468726561642d383631310102861104108d6273023d82c841eff0e68db86f35740c030000ff
+Done
+```

--- a/src/cli/README_DATASET.md
+++ b/src/cli/README_DATASET.md
@@ -165,9 +165,9 @@ Done
 
 ### active
 
-Usage: `dataset active`
+Usage: `dataset active [binary]`
 
-Print Active Operational Dataset.
+Print Active Operational Dataset in human-readable form.
 
 ```bash
 > dataset active
@@ -181,6 +181,14 @@ Network Name: OpenThread-8f28
 PAN ID: 0x8f28
 PSKc: c23a76e98f1a6483639b1ac1271e2e27
 Security Policy: 0, onrcb
+Done
+```
+
+Print Active Operational Dataset as hex-encoded TLVs.
+
+```bash
+> dataset active binary
+0e080000000000010000000300001035060004001fffe002084eb74ab03c56e6d00708fdc7fe165c83a67805108e2104f183e698da87e96efc1e45aa51030f4f70656e5468726561642d383631310102861104108d6273023d82c841eff0e68db86f35740c030000ff
 Done
 ```
 
@@ -344,9 +352,9 @@ Done
 
 ### pending
 
-Usage: `dataset pending`
+Usage: `dataset pending [binary]`
 
-Print Pending Operational Dataset.
+Print Pending Operational Dataset in human-readable form.
 
 ```bash
 > dataset pending
@@ -362,6 +370,14 @@ Network Name: OpenThread-8f28
 PAN ID: 0x8f28
 PSKc: c23a76e98f1a6483639b1ac1271e2e27
 Security Policy: 0, onrcb
+Done
+```
+
+Print Pending Operational Dataset as hex-encoded TLVs.
+
+```bash
+> dataset pending binary
+0e080000000000010000000300001035060004001fffe002084eb74ab03c56e6d00708fdc7fe165c83a67805108e2104f183e698da87e96efc1e45aa51030f4f70656e5468726561642d383631310102861104108d6273023d82c841eff0e68db86f35740c030000ff
 Done
 ```
 

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -248,14 +248,29 @@ exit:
 
 otError Dataset::ProcessActive(uint8_t aArgsLength, char *aArgs[])
 {
-    OT_UNUSED_VARIABLE(aArgsLength);
-    OT_UNUSED_VARIABLE(aArgs);
+    otError error;
 
-    otOperationalDataset dataset;
-    otError              error;
+    if (aArgsLength == 0)
+    {
+        otOperationalDataset dataset;
 
-    SuccessOrExit(error = otDatasetGetActive(mInterpreter.mInstance, &dataset));
-    error = Print(dataset);
+        SuccessOrExit(error = otDatasetGetActive(mInterpreter.mInstance, &dataset));
+        error = Print(dataset);
+    }
+    else if ((aArgsLength == 1) && (strcmp(aArgs[0], "binary") == 0))
+    {
+        otOperationalDatasetTlvs dataset;
+
+        VerifyOrExit(strlen(aArgs[0]) <= OT_OPERATIONAL_DATASET_MAX_LENGTH * 2, error = OT_ERROR_NO_BUFS);
+
+        SuccessOrExit(error = otDatasetGetActiveTlvs(mInterpreter.mInstance, &dataset));
+        mInterpreter.OutputBytes(dataset.mTlvs, dataset.mLength);
+        mInterpreter.mServer->OutputFormat("\r\n");
+    }
+    else
+    {
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
+    }
 
 exit:
     return error;
@@ -263,14 +278,29 @@ exit:
 
 otError Dataset::ProcessPending(uint8_t aArgsLength, char *aArgs[])
 {
-    OT_UNUSED_VARIABLE(aArgsLength);
-    OT_UNUSED_VARIABLE(aArgs);
+    otError error;
 
-    otOperationalDataset dataset;
-    otError              error;
+    if (aArgsLength == 0)
+    {
+        otOperationalDataset dataset;
 
-    SuccessOrExit(error = otDatasetGetPending(mInterpreter.mInstance, &dataset));
-    error = Print(dataset);
+        SuccessOrExit(error = otDatasetGetPending(mInterpreter.mInstance, &dataset));
+        error = Print(dataset);
+    }
+    else if ((aArgsLength == 1) && (strcmp(aArgs[0], "binary") == 0))
+    {
+        otOperationalDatasetTlvs dataset;
+
+        VerifyOrExit(strlen(aArgs[0]) <= OT_OPERATIONAL_DATASET_MAX_LENGTH * 2, error = OT_ERROR_NO_BUFS);
+
+        SuccessOrExit(error = otDatasetGetPendingTlvs(mInterpreter.mInstance, &dataset));
+        mInterpreter.OutputBytes(dataset.mTlvs, dataset.mLength);
+        mInterpreter.mServer->OutputFormat("\r\n");
+    }
+    else
+    {
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
+    }
 
 exit:
     return error;

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -66,6 +66,7 @@ const Dataset::Command Dataset::sCommands[] = {
     {"pendingtimestamp", &Dataset::ProcessPendingTimestamp},
     {"pskc", &Dataset::ProcessPskc},
     {"securitypolicy", &Dataset::ProcessSecurityPolicy},
+    {"set", &Dataset::ProcessSet},
 };
 
 otOperationalDataset Dataset::sDataset;
@@ -785,6 +786,32 @@ otError Dataset::ProcessSecurityPolicy(uint8_t aArgsLength, char *aArgs[])
     }
 
     sDataset.mComponents.mIsSecurityPolicyPresent = true;
+
+exit:
+    return error;
+}
+
+otError Dataset::ProcessSet(uint8_t aArgsLength, char *aArgs[])
+{
+    otError                  error = OT_ERROR_NONE;
+    otOperationalDatasetTlvs dataset;
+
+    VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
+
+    if (strcmp(aArgs[0], "active") == 0)
+    {
+        dataset.mLength = static_cast<uint8_t>(Interpreter::Hex2Bin(aArgs[1], dataset.mTlvs, sizeof(dataset.mTlvs)));
+        SuccessOrExit(error = otDatasetSetActiveTlvs(mInterpreter.mInstance, &dataset));
+    }
+    else if (strcmp(aArgs[0], "pending") == 0)
+    {
+        dataset.mLength = static_cast<uint8_t>(Interpreter::Hex2Bin(aArgs[1], dataset.mTlvs, sizeof(dataset.mTlvs)));
+        SuccessOrExit(error = otDatasetSetPendingTlvs(mInterpreter.mInstance, &dataset));
+    }
+    else
+    {
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
+    }
 
 exit:
     return error;

--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -96,6 +96,7 @@ private:
     otError ProcessMgmtGetCommand(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessPskc(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessSecurityPolicy(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessSet(uint8_t aArgsLength, char *aArgs[]);
 
     Interpreter &mInterpreter;
 

--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -66,6 +66,15 @@ otError otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset
     return instance.Get<MeshCoP::ActiveDataset>().Read(*aDataset);
 }
 
+otError otDatasetGetActiveTlvs(otInstance *aInstance, otOperationalDatasetTlvs *aDataset)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    OT_ASSERT(aDataset != NULL);
+
+    return instance.Get<MeshCoP::ActiveDataset>().Read(*aDataset);
+}
+
 otError otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aDataset)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
@@ -76,6 +85,15 @@ otError otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aD
 }
 
 otError otDatasetGetPending(otInstance *aInstance, otOperationalDataset *aDataset)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    OT_ASSERT(aDataset != NULL);
+
+    return instance.Get<MeshCoP::PendingDataset>().Read(*aDataset);
+}
+
+otError otDatasetGetPendingTlvs(otInstance *aInstance, otOperationalDatasetTlvs *aDataset)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 

--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -84,6 +84,15 @@ otError otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aD
     return instance.Get<MeshCoP::ActiveDataset>().Save(*aDataset);
 }
 
+otError otDatasetSetActiveTlvs(otInstance *aInstance, const otOperationalDatasetTlvs *aDataset)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    OT_ASSERT(aDataset != NULL);
+
+    return instance.Get<MeshCoP::ActiveDataset>().Save(*aDataset);
+}
+
 otError otDatasetGetPending(otInstance *aInstance, otOperationalDataset *aDataset)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
@@ -103,6 +112,15 @@ otError otDatasetGetPendingTlvs(otInstance *aInstance, otOperationalDatasetTlvs 
 }
 
 otError otDatasetSetPending(otInstance *aInstance, const otOperationalDataset *aDataset)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    OT_ASSERT(aDataset != NULL);
+
+    return instance.Get<MeshCoP::PendingDataset>().Save(*aDataset);
+}
+
+otError otDatasetSetPendingTlvs(otInstance *aInstance, const otOperationalDatasetTlvs *aDataset)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -170,6 +170,12 @@ void Dataset::ConvertTo(otOperationalDataset &aDataset) const
     }
 }
 
+void Dataset::ConvertTo(otOperationalDatasetTlvs &aDataset) const
+{
+    memcpy(aDataset.mTlvs, mTlvs, mLength);
+    aDataset.mLength = static_cast<uint8_t>(mLength);
+}
+
 void Dataset::Set(const Dataset &aDataset)
 {
     memcpy(mTlvs, aDataset.mTlvs, aDataset.mLength);

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -190,6 +190,12 @@ void Dataset::Set(const Dataset &aDataset)
     mUpdateTime = aDataset.GetUpdateTime();
 }
 
+void Dataset::SetFrom(const otOperationalDatasetTlvs &aDataset)
+{
+    mLength = aDataset.mLength;
+    memcpy(mTlvs, aDataset.mTlvs, mLength);
+}
+
 otError Dataset::SetFrom(const otOperationalDataset &aDataset)
 {
     otError error = OT_ERROR_NONE;

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -293,6 +293,14 @@ public:
     otError SetFrom(const otOperationalDataset &aDataset);
 
     /**
+     * This method sets the Dataset using @p aDataset.
+     *
+     * @param[in]  aDataset  The input Dataset as otOperationalDatasetTlvs.
+     *
+     */
+    void SetFrom(const otOperationalDatasetTlvs &aDataset);
+
+    /**
      * This method removes a TLV from the Dataset.
      *
      * @param[in] aType The type of a specific TLV.

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -58,9 +58,9 @@ class Dataset
 public:
     enum
     {
-        kMaxSize      = 256, ///< Maximum size of MeshCoP Dataset (bytes)
-        kMaxValueSize = 16,  ///< Maximum size of each Dataset TLV value (bytes)
-        kMaxGetTypes  = 64,  ///< Maximum number of types in MGMT_GET.req
+        kMaxSize      = OT_OPERATIONAL_DATASET_MAX_LENGTH, ///< Maximum size of MeshCoP Dataset (bytes)
+        kMaxValueSize = 16,                                ///< Maximum size of each Dataset TLV value (bytes)
+        kMaxGetTypes  = 64,                                ///< Maximum number of types in MGMT_GET.req
     };
 
     /**
@@ -160,6 +160,14 @@ public:
      *
      */
     void ConvertTo(otOperationalDataset &aDataset) const;
+
+    /**
+     * This method converts the TLV representation to structure representation.
+     *
+     * @param[out] aDataset  A reference to `otOperationalDatasetTlvs` to output the Dataset.
+     *
+     */
+    void ConvertTo(otOperationalDatasetTlvs &aDataset) const;
 
     /**
      * This method returns the Dataset size in bytes.

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -156,17 +156,23 @@ exit:
 
 otError DatasetLocal::Save(const otOperationalDataset &aDataset)
 {
-    otError error = OT_ERROR_NONE;
+    otError error;
     Dataset dataset(mType);
 
-    error = dataset.SetFrom(aDataset);
-    SuccessOrExit(error);
-
-    error = Save(dataset);
-    SuccessOrExit(error);
+    SuccessOrExit(error = dataset.SetFrom(aDataset));
+    SuccessOrExit(error = Save(dataset));
 
 exit:
     return error;
+}
+
+otError DatasetLocal::Save(const otOperationalDatasetTlvs &aDataset)
+{
+    Dataset dataset(mType);
+
+    dataset.SetFrom(aDataset);
+
+    return Save(dataset);
 }
 
 otError DatasetLocal::Save(const Dataset &aDataset)

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -133,9 +133,21 @@ otError DatasetLocal::Read(otOperationalDataset &aDataset) const
 
     memset(&aDataset, 0, sizeof(aDataset));
 
-    error = Read(dataset);
-    SuccessOrExit(error);
+    SuccessOrExit(error = Read(dataset));
+    dataset.ConvertTo(aDataset);
 
+exit:
+    return error;
+}
+
+otError DatasetLocal::Read(otOperationalDatasetTlvs &aDataset) const
+{
+    Dataset dataset(mType);
+    otError error;
+
+    memset(&aDataset, 0, sizeof(aDataset));
+
+    SuccessOrExit(error = Read(dataset));
     dataset.ConvertTo(aDataset);
 
 exit:

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -125,6 +125,17 @@ public:
     otError Read(otOperationalDataset &aDataset) const;
 
     /**
+     * This method retrieves the dataset from non-volatile memory.
+     *
+     * @param[out]  aDataset  Where to place the dataset.
+     *
+     * @retval OT_ERROR_NONE       Successfully retrieved the dataset.
+     * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
+     *
+     */
+    otError Read(otOperationalDatasetTlvs &aDataset) const;
+
+    /**
      * This method returns the local time this dataset was last updated or restored.
      *
      * @returns The local time this dataset was last updated or restored.

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -146,7 +146,8 @@ public:
     /**
      * This method stores the dataset into non-volatile memory.
      *
-     * @retval OT_ERROR_NONE  Successfully stored the dataset.
+     * @retval OT_ERROR_NONE              Successfully saved the dataset.
+     * @retval OT_ERROR_NOT_IMPLEMENTED   The platform does not implement settings functionality.
      *
      */
     otError Save(const otOperationalDataset &aDataset);
@@ -154,7 +155,17 @@ public:
     /**
      * This method stores the dataset into non-volatile memory.
      *
-     * @retval OT_ERROR_NONE  Successfully stored the dataset.
+     * @retval OT_ERROR_NONE              Successfully saved the dataset.
+     * @retval OT_ERROR_NOT_IMPLEMENTED   The platform does not implement settings functionality.
+     *
+     */
+    otError Save(const otOperationalDatasetTlvs &aDataset);
+
+    /**
+     * This method stores the dataset into non-volatile memory.
+     *
+     * @retval OT_ERROR_NONE              Successfully saved the dataset.
+     * @retval OT_ERROR_NOT_IMPLEMENTED   The platform does not implement settings functionality.
      *
      */
     otError Save(const Dataset &aDataset);

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -178,10 +178,28 @@ exit:
 
 otError DatasetManager::Save(const otOperationalDataset &aDataset)
 {
-    otError error = OT_ERROR_NONE;
+    otError error;
 
     SuccessOrExit(error = mLocal.Save(aDataset));
+    HandleDatasetUpdated();
 
+exit:
+    return error;
+}
+
+otError DatasetManager::Save(const otOperationalDatasetTlvs &aDataset)
+{
+    otError error;
+
+    SuccessOrExit(error = mLocal.Save(aDataset));
+    HandleDatasetUpdated();
+
+exit:
+    return error;
+}
+
+void DatasetManager::HandleDatasetUpdated(void)
+{
     switch (Get<Mle::MleRouter>().GetRole())
     {
     case Mle::kRoleDisabled:
@@ -205,9 +223,6 @@ otError DatasetManager::Save(const otOperationalDataset &aDataset)
     default:
         break;
     }
-
-exit:
-    return error;
 }
 
 otError DatasetManager::GetChannelMask(Mac::ChannelMask &aChannelMask) const
@@ -782,7 +797,18 @@ void PendingDataset::ClearNetwork(void)
 
 otError PendingDataset::Save(const otOperationalDataset &aDataset)
 {
-    otError error = OT_ERROR_NONE;
+    otError error;
+
+    SuccessOrExit(error = DatasetManager::Save(aDataset));
+    StartDelayTimer();
+
+exit:
+    return error;
+}
+
+otError PendingDataset::Save(const otOperationalDatasetTlvs &aDataset)
+{
+    otError error;
 
     SuccessOrExit(error = DatasetManager::Save(aDataset));
     StartDelayTimer();

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -240,8 +240,22 @@ protected:
      *
      * @param[in]  aDataset  The Operational Dataset.
      *
+     * @retval OT_ERROR_NONE             Successfully saved the dataset.
+     * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
+     *
      */
     otError Save(const otOperationalDataset &aDataset);
+
+    /**
+     * This method saves the Operational Dataset in non-volatile memory.
+     *
+     * @param[in]  aDataset  The Operational Dataset.
+     *
+     * @retval OT_ERROR_NONE             Successfully saved the dataset.
+     * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
+     *
+     */
+    otError Save(const otOperationalDatasetTlvs &aDataset);
 
     /**
      * This method sets the Operational Dataset for the partition.
@@ -295,6 +309,7 @@ private:
                                    otError              aError);
     void        HandleCoapResponse(void);
 
+    void HandleDatasetUpdated(void);
     void SendSet(void);
     void SendGetResponse(const Coap::Message &   aRequest,
                          const Ip6::MessageInfo &aMessageInfo,
@@ -402,8 +417,22 @@ public:
      *
      * @param[in]  aDataset  The Operational Dataset.
      *
+     * @retval OT_ERROR_NONE             Successfully saved the dataset.
+     * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
+     *
      */
     otError Save(const otOperationalDataset &aDataset) { return DatasetManager::Save(aDataset); }
+
+    /**
+     * This method sets the Operational Dataset in non-volatile memory.
+     *
+     * @param[in]  aDataset  The Operational Dataset.
+     *
+     * @retval OT_ERROR_NONE             Successfully saved the dataset.
+     * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
+     *
+     */
+    otError Save(const otOperationalDatasetTlvs &aDataset) { return DatasetManager::Save(aDataset); }
 
 #if OPENTHREAD_FTD
 
@@ -494,8 +523,24 @@ public:
      *
      * @param[in]  aDataset  The Operational Dataset.
      *
+     * @retval OT_ERROR_NONE             Successfully saved the dataset.
+     * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
+     *
      */
     otError Save(const otOperationalDataset &aDataset);
+
+    /**
+     * This method saves the Operational Dataset in non-volatile memory.
+     *
+     * This method also starts the Delay Timer.
+     *
+     * @param[in]  aDataset  The Operational Dataset.
+     *
+     * @retval OT_ERROR_NONE             Successfully saved the dataset.
+     * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
+     *
+     */
+    otError Save(const otOperationalDatasetTlvs &aDataset);
 
     /**
      * This method sets the Operational Dataset for the partition.

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -104,6 +104,17 @@ public:
     otError Read(otOperationalDataset &aDataset) const { return mLocal.Read(aDataset); }
 
     /**
+     * This method retrieves the dataset from non-volatile memory.
+     *
+     * @param[out]  aDataset  Where to place the dataset.
+     *
+     * @retval OT_ERROR_NONE       Successfully retrieved the dataset.
+     * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
+     *
+     */
+    otError Read(otOperationalDatasetTlvs &aDataset) const { return mLocal.Read(aDataset); }
+
+    /**
      * This method retrieves the channel mask from local dataset.
      *
      * @param[out]  aChannelMask  A reference to the channel mask.


### PR DESCRIPTION
**Problem**
Thread stores and distributes Active and Pending Operational Datasets as opaque binary objects. To support forward compatibility with newer Thread versions, Thread devices must store and propagate TLVs even when they are unknown. The existing dataset API only allows getting/setting dataset values that are defined.

**Solution**
Introduce new APIs (and associated CLI commands) that allow getting/setting Active/Pending Operational Datasets via binary-encoded TLVs. This allows higher layers to copy Operational Datasets from one device to another without losing any information.

Example CLIs:

Print Active Operational Dataset as hex-encoded TLVs.

```bash
> dataset active binary
0e080000000000010000000300001035060004001fffe002084eb74ab03c56e6d00708fdc7fe165c83a67805108e2104f183e698da87e96efc1e45aa51030f4f70656e5468726561642d383631310102861104108d6273023d82c841eff0e68db86f35740c030000ff
Done
```

Set the Active Operational Dataset using hex-encoded TLVs.

```bash
> dataset set active 0e080000000000010000000300001035060004001fffe002084eb74ab03c56e6d00708fdc7fe165c83a67805108e2104f183e698da87e96efc1e45aa51030f4f70656e5468726561642d383631310102861104108d6273023d82c841eff0e68db86f35740c030000ff
Done
```

Resolves #5028 