### PR TITLE
[test] modularize expect scripts

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -1,0 +1,54 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+proc wait_for {command expected} {
+    set result 0
+    for {set i 0} {$i < 20} {incr i} {
+        send "$command\n"
+        expect {
+            -re $expected {
+                set result 1
+            }
+            timeout {
+                # Do nothing
+            }
+        }
+        if {$result == 1} {
+            break
+        }
+    }
+    if {$result == 0} {
+        exit 1
+    }
+}
+
+proc dispose {} {
+    send "\x04"
+    expect eof
+}

--- a/tests/scripts/expect/_multinode.exp
+++ b/tests/scripts/expect/_multinode.exp
@@ -1,0 +1,98 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+
+proc setup_nodes {} {
+    # Sets up a Thread network with 2 nodes, spawn_1 as the leader and spawn_2
+    # as a child.
+
+    global spawn_1
+    global spawn_2
+    global spawn_id
+    global env
+
+    spawn $env(OT_COMMAND) 1
+    set spawn_1 $spawn_id
+    spawn $env(OT_COMMAND) 2
+    set spawn_2 $spawn_id
+    expect_after {
+        timeout { exit 1 }
+    }
+    set psk "J01NME"
+
+    set spawn_id $spawn_2
+    send "eui64\n"
+    expect -re {([0-9a-f]{16})}
+    set eui64 $expect_out(1,string)
+    expect "Done"
+
+    set spawn_id $spawn_1
+    send "dataset init new\n"
+    expect "Done"
+    send "dataset commit active\n"
+    expect "Done"
+    send "ifconfig up\n"
+    expect "Done"
+    send "thread start\n"
+    expect "Done"
+    wait_for "state" "leader"
+    send "commissioner start\n"
+    expect "Done"
+    expect "Commissioner: active"
+    send "commissioner joiner add $eui64 $psk\n"
+    expect "Done"
+    send "channel\n"
+    expect -re {(\d+)}
+    set channel $expect_out(1,string)
+    expect "Done"
+
+    set spawn_id $spawn_2
+    send "mode rs\n"
+    expect "Done"
+    send "ifconfig up\n"
+    expect "Done"
+    send "joiner start $psk\n"
+    expect "Done"
+    wait_for "" {Join success}
+    send "thread start\n"
+    expect "Done"
+    wait_for "state" "child"
+}
+
+proc dispose_nodes {} {
+    global spawn_1
+    global spawn_2
+    global spawn_id
+
+    set spawn_id $spawn_1
+    dispose
+    set spawn_id $spawn_2
+    dispose
+}

--- a/tests/scripts/expect/cli-2-nodes.exp
+++ b/tests/scripts/expect/cli-2-nodes.exp
@@ -27,78 +27,21 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-proc wait_for {command expected} {
-    set result 0
-    for {set i 0} {$i < 20} {incr i} {
-        send "$command\n"
-        expect {
-            -re $expected {
-                set result 1
-            }
-            timeout {
-                # Do nothing
-            }
-        }
-        if {$result == 1} {
-            break
-        }
-    }
-    if {$result == 0} {
-        exit 1
-    }
-}
+source "tests/scripts/expect/_multinode.exp"
 
 
-# setup
 set timeout 1
-spawn $env(OT_COMMAND) 1
-set spawn_1 $spawn_id
-spawn $env(OT_COMMAND) 2
-set spawn_2 $spawn_id
+setup_nodes
 spawn $env(OT_COMMAND) 3
 set spawn_3 $spawn_id
-expect_after {
-    timeout { exit 1 }
-}
-set psk "J01NME"
 
-set spawn_id $spawn_2
-send "eui64\n"
-expect -re {([0-9a-f]{16})}
-set eui64 $expect_out(1,string)
-expect "Done"
 
 set spawn_id $spawn_1
-send "dataset init new\n"
-expect "Done"
-send "dataset commit active\n"
-expect "Done"
-send "ifconfig up\n"
-expect "Done"
-send "thread start\n"
-expect "Done"
-wait_for "state" {leader}
-send "commissioner start\n"
-expect "Done"
-expect "Commissioner: active"
-send "commissioner joiner add $eui64 $psk\n"
-expect "Done"
 send "channel\n"
+expect "channel"
 expect -re {(\d+)}
 set channel $expect_out(1,string)
 expect "Done"
-
-set spawn_id $spawn_2
-send "mode rs\n"
-expect "Done"
-send "ifconfig up\n"
-expect "Done"
-send "joiner start $psk\n"
-expect "Done"
-wait_for "" {Join success}
-send "thread start\n"
-expect "Done"
-wait_for "state" "child"
 
 set spawn_id $spawn_3
 send "channel $channel\n"
@@ -211,11 +154,4 @@ for {set i 11} {$i <= 26} {incr i} {
 expect "Done"
 
 
-# cleanup
-set spawn_id $spawn_1
-send "\x04"
-expect eof
-
-set spawn_id $spawn_2
-send "\x04"
-expect eof
+dispose_nodes


### PR DESCRIPTION
This puts the scripts setting up Thread networks into separate files so that they can be reused by multiple test scripts. After this we can split the tests in `cli-2-nodes.exp` into multiple files without having to repeat codes in each file.