### PR TITLE
[cmake] use the correct define for external heap

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -132,7 +132,7 @@ endif()
 
 option(OT_EXTERNAL_HEAP "enable external heap support")
 if(OT_EXTERNAL_HEAP)
-    target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_EXTERNAL_HEAP_ENABLE=1")
+    target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE=1")
 endif()
 
 option(OT_IP6_FRAGM "enable ipv6 fragmentation support")


### PR DESCRIPTION
In options.cmake `OPENTHREAD_CONFIG_`**EXTERNAL_HEAP**`_ENABLE` is used, while
in common-switches.mk and the source code the slightly different
`OPENTHREAD_CONFIG_`**HEAP_EXTERNAL**`_ENABLE` is used.

Signed-off-by: Markus Becker <markus.becker@tridonic.com>