### PR TITLE
[posix] fix otPlatAlarmMicroGetNow to use scaled time

### DIFF
--- a/src/posix/platform/alarm.cpp
+++ b/src/posix/platform/alarm.cpp
@@ -98,7 +98,7 @@ void otPlatAlarmMilliStop(otInstance *aInstance)
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 uint32_t otPlatAlarmMicroGetNow(void)
 {
-    return (uint32_t)(platformAlarmGetNow());
+    return static_cast<uint32_t>(platformAlarmGetNow());
 }
 
 void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)

--- a/src/posix/platform/alarm.cpp
+++ b/src/posix/platform/alarm.cpp
@@ -98,7 +98,7 @@ void otPlatAlarmMilliStop(otInstance *aInstance)
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 uint32_t otPlatAlarmMicroGetNow(void)
 {
-    return (uint32_t)(otPlatTimeGet());
+    return (uint32_t)(platformAlarmGetNow());
 }
 
 void otPlatAlarmMicroStartAt(otInstance *aInstance, uint32_t aT0, uint32_t aDt)


### PR DESCRIPTION
This makes it consistent with MilliGetNow() conterpart