### PR TITLE
[efr32] update EFR32 mbedTLS configuration to use more hardware acceleration

### DIFF
--- a/examples/platforms/efr32mg12/crypto/efr32-mbedtls-config.h
+++ b/examples/platforms/efr32mg12/crypto/efr32-mbedtls-config.h
@@ -86,7 +86,7 @@
  * See MBEDTLS_SHA256_C for more information.
  */
 #if defined(CRYPTO_COUNT) && (CRYPTO_COUNT > 0)
-//#define MBEDTLS_SHA256_ALT
+#define MBEDTLS_SHA256_ALT
 #endif
 
 #endif // EFR32_MBEDTLS_CONFIG_H

--- a/examples/platforms/efr32mg13/crypto/efr32-mbedtls-config.h
+++ b/examples/platforms/efr32mg13/crypto/efr32-mbedtls-config.h
@@ -86,7 +86,7 @@
  * See MBEDTLS_SHA256_C for more information.
  */
 #if defined(CRYPTO_COUNT) && (CRYPTO_COUNT > 0)
-//#define MBEDTLS_SHA256_ALT
+#define MBEDTLS_SHA256_ALT
 #endif
 
 #endif // EFR32_MBEDTLS_CONFIG_H

--- a/examples/platforms/efr32mg21/crypto/efr32-mbedtls-config.h
+++ b/examples/platforms/efr32mg21/crypto/efr32-mbedtls-config.h
@@ -52,52 +52,32 @@
  *
  */
 #define MBEDTLS_ENTROPY_HARDWARE_ALT
-#define MBEDTLS_SHA256_C
 
-/**
- * \def MBEDTLS_ECP_INTERNAL_ALT
- * \def ECP_SHORTWEIERSTRASS
- * \def MBEDTLS_ECP_ADD_MIXED_ALT
- * \def MBEDTLS_ECP_DOUBLE_JAC_ALT
- * \def MBEDTLS_ECP_NORMALIZE_JAC_MANY_ALT
- * \def MBEDTLS_ECP_NORMALIZE_JAC_ALT
- *
- * Enable hardware acceleration for the elliptic curve over GF(p) library.
- *
- * Module:  sl_crypto/src/crypto_ecp.c
- * Caller:  library/ecp.c
- *
- * Requires: MBEDTLS_BIGNUM_C, MBEDTLS_ECP_C and at least one
- * MBEDTLS_ECP_DP_XXX_ENABLED and (CRYPTO_COUNT > 0)
- */
-#if defined(CRYPTO_COUNT) && (CRYPTO_COUNT > 0)
-#define MBEDTLS_ECP_INTERNAL_ALT
-#define ECP_SHORTWEIERSTRASS
-#define MBEDTLS_ECP_ADD_MIXED_ALT
-#define MBEDTLS_ECP_DOUBLE_JAC_ALT
-#define MBEDTLS_ECP_NORMALIZE_JAC_MANY_ALT
-#define MBEDTLS_ECP_NORMALIZE_JAC_ALT
-#define MBEDTLS_ECP_RANDOMIZE_JAC_ALT
-#endif
+/* Turn on all hardware acceleration provided by the EFR32xG21's built-in SE */
+#define MBEDTLS_SHA1_ALT
+#define MBEDTLS_SHA1_PROCESS_ALT
+#define MBEDTLS_SHA256_ALT
+#define MBEDTLS_SHA256_PROCESS_ALT
+#define MBEDTLS_SHA512_ALT
+#define MBEDTLS_SHA512_PROCESS_ALT
 
-/**
- * \def MBEDTLS_SHA256_ALT
- *
- * Enable hardware acceleration for the SHA-224 and SHA-256 cryptographic
- * hash algorithms.
- *
- * Module:  sl_crypto/src/crypto_sha.c
- * Caller:  library/entropy.c
- *          library/mbedtls_md.c
- *          library/ssl_cli.c
- *          library/ssl_srv.c
- *          library/ssl_tls.c
- *
- * Requires: MBEDTLS_SHA256_C and (CRYPTO_COUNT > 0)
- * See MBEDTLS_SHA256_C for more information.
- */
-#if defined(CRYPTO_COUNT) && (CRYPTO_COUNT > 0)
-//#define MBEDTLS_SHA256_ALT
-#endif
+#define MBEDTLS_CCM_ALT
+#define MBEDTLS_CMAC_ALT
+
+/* Turning on ECC acceleration is dependant on not requiring curve25519 when
+ * running on EFR32xG21A devices */
+#if (defined(_SILICON_LABS_SECURITY_FEATURE) &&                                   \
+     (_SILICON_LABS_SECURITY_FEATURE == _SILICON_LABS_SECURITY_FEATURE_VAULT)) || \
+    !defined(MBEDTLS_ECP_DP_CURVE25519_ENABLED)
+#define MBEDTLS_ECDH_GEN_PUBLIC_ALT
+#define MBEDTLS_ECDSA_GENKEY_ALT
+#define MBEDTLS_ECDH_COMPUTE_SHARED_ALT
+#define MBEDTLS_ECDSA_SIGN_ALT
+#define MBEDTLS_ECDSA_VERIFY_ALT
+/* Incompatibility in header files between mbedTLS version in OT and GSDK means
+ * we can't turn on EC-JPAKE acceleration on EFR32xG21 just yet. Will be fixed
+ * for the next GSDK update */
+//#define MBEDTLS_ECJPAKE_ALT
+#endif /* EFR32xG21B or curve25519 not enabled */
 
 #endif // EFR32_MBEDTLS_CONFIG_H

--- a/third_party/silabs/Makefile.am
+++ b/third_party/silabs/Makefile.am
@@ -168,6 +168,8 @@ SILABS_COMMON_SOURCES                                                           
     gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/crypto_aes.c              \
     gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/crypto_ecp.c              \
     gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/crypto_management.c       \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/crypto_sha.c              \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/shax.c                    \
     $(NULL)
 
 SILABS_EFR32MG12_SOURCES                                                                          = \
@@ -186,9 +188,14 @@ SILABS_EFR32MG21_SOURCES                                                        
     gecko_sdk_suite/v2.7/platform/Device/SiliconLabs/EFR32MG21/Source/system_efr32mg21.c        \
     gecko_sdk_suite/v2.7/platform/Device/SiliconLabs/EFR32MG21/Source/GCC/startup_efr32mg21.c   \
     gecko_sdk_suite/v2.7/platform/emlib/src/em_se.c                                             \
-    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/se_trng.c                       \
     gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/se_aes.c                        \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/se_ccm.c                        \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/se_cmac.c                       \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/se_ecp.c                        \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/se_jpake.c                      \
     gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/se_management.c                 \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/se_sha.c                        \
+    gecko_sdk_suite/v2.7/util/third_party/mbedtls/sl_crypto/src/se_trng.c                       \
     $(NULL)
 
 libsilabs_efr32mg12_sdk_a_CPPFLAGS                                                            = \


### PR DESCRIPTION
Turns on the following:
* SHA256 acceleration on all EFR32 devices (used for SHA256, HMAC-SHA256, ECDSA and DRBG)
* ECDSA/ECDH acceleration on EFR32MG21 (used in DTLS and exposed to application through otCryptoEcdsaSign)
* AES-CCM acceleration on EFR32MG21 (used in DTLS)
* AES-CMAC acceleration on EFR32MG21 (used for PBKDF2)

Not enabled yet, needs a new GSDK release:
* end-to-end EC-JPAKE acceleration on EFR32MG21 (used in DTLS)