### PR TITLE
[cert] capitalize python class constants

### DIFF
--- a/tests/scripts/thread-cert/Cert_5_1_01_RouterAttach.py
+++ b/tests/scripts/thread-cert/Cert_5_1_01_RouterAttach.py
@@ -38,7 +38,7 @@ ROUTER = 2
 
 
 class Cert_5_1_01_RouterAttach(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
@@ -42,7 +42,7 @@ MTDS = [ED, SED]
 
 
 class Cert_5_1_02_ChildAddressTimeout(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_1_03_RouterAddressReallocation.py
+++ b/tests/scripts/thread-cert/Cert_5_1_03_RouterAddressReallocation.py
@@ -39,7 +39,7 @@ ROUTER2 = 3
 
 
 class Cert_5_1_03_RouterAddressReallocation(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_1_04_RouterAddressReallocation.py
+++ b/tests/scripts/thread-cert/Cert_5_1_04_RouterAddressReallocation.py
@@ -39,7 +39,7 @@ ROUTER2 = 3
 
 
 class Cert_5_1_04_RouterAddressReallocation(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
+++ b/tests/scripts/thread-cert/Cert_5_1_05_RouterAddressTimeout.py
@@ -38,7 +38,7 @@ ROUTER1 = 2
 
 
 class Cert_5_1_05_RouterAddressTimeout(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
+++ b/tests/scripts/thread-cert/Cert_5_1_06_RemoveRouterId.py
@@ -39,7 +39,7 @@ ROUTER1 = 2
 
 
 class Cert_5_1_06_RemoveRouterId(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
+++ b/tests/scripts/thread-cert/Cert_5_1_07_MaxChildCount.py
@@ -38,7 +38,7 @@ SED1 = 7
 
 
 class Cert_5_1_07_MaxChildCount(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_1_08_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_5_1_08_RouterAttachConnectivity.py
@@ -41,7 +41,7 @@ ROUTER4 = 5
 
 
 class Cert_5_1_08_RouterAttachConnectivity(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_1_09_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_5_1_09_REEDAttachConnectivity.py
@@ -41,7 +41,7 @@ ROUTER2 = 5
 
 
 class Cert_5_1_09_REEDAttachConnectivity(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_1_10_RouterAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_1_10_RouterAttachLinkQuality.py
@@ -39,7 +39,7 @@ ROUTER3 = 4
 
 
 class Cert_5_1_10_RouterAttachLinkQuality(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_1_11_REEDAttachLinkQuality.py
@@ -39,7 +39,7 @@ ROUTER1 = 4
 
 
 class Cert_5_1_11_REEDAttachLinkQuality(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_1_12_NewRouterNeighborSync.py
+++ b/tests/scripts/thread-cert/Cert_5_1_12_NewRouterNeighborSync.py
@@ -38,7 +38,7 @@ ROUTER2 = 3
 
 
 class Cert_5_1_12_NewRouterSync(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_1_13_RouterReset.py
+++ b/tests/scripts/thread-cert/Cert_5_1_13_RouterReset.py
@@ -37,7 +37,7 @@ ROUTER = 2
 
 
 class Cert_5_1_13_RouterReset(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_2_01_REEDAttach.py
+++ b/tests/scripts/thread-cert/Cert_5_2_01_REEDAttach.py
@@ -41,7 +41,7 @@ MED1 = 4
 
 
 class Cert_5_2_01_REEDAttach(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_2_03_LeaderReject2Hops.py
+++ b/tests/scripts/thread-cert/Cert_5_2_03_LeaderReject2Hops.py
@@ -40,7 +40,7 @@ ROUTER_32 = 33
 
 
 class Cert_5_2_3_LeaderReject2Hops(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         DUT_LEADER: {
             'mode':
                 'rsdn',

--- a/tests/scripts/thread-cert/Cert_5_2_04_REEDUpgrade.py
+++ b/tests/scripts/thread-cert/Cert_5_2_04_REEDUpgrade.py
@@ -45,7 +45,7 @@ ROUTER_SELECTION_JITTER = 1
 
 
 class Cert_5_2_4_REEDUpgrade(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode':
                 'rsdn',

--- a/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_2_05_AddressQuery.py
@@ -42,7 +42,7 @@ ROUTER_SELECTION_JITTER = 1
 
 
 class Cert_5_2_5_AddressQuery(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode':
                 'rsdn',

--- a/tests/scripts/thread-cert/Cert_5_2_06_RouterDowngrade.py
+++ b/tests/scripts/thread-cert/Cert_5_2_06_RouterDowngrade.py
@@ -41,7 +41,7 @@ ROUTER24 = 24
 
 
 class Cert_5_2_06_RouterDowngrade(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_2_07_REEDSynchronization.py
+++ b/tests/scripts/thread-cert/Cert_5_2_07_REEDSynchronization.py
@@ -43,7 +43,7 @@ MLE_MIN_LINKS = 3
 
 
 class Cert_5_2_7_REEDSynchronization(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_3_01_LinkLocal.py
+++ b/tests/scripts/thread-cert/Cert_5_3_01_LinkLocal.py
@@ -37,7 +37,7 @@ DUT_ROUTER1 = 2
 
 
 class Cert_5_3_1_LinkLocal(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface

--- a/tests/scripts/thread-cert/Cert_5_3_02_RealmLocal.py
+++ b/tests/scripts/thread-cert/Cert_5_3_02_RealmLocal.py
@@ -39,7 +39,7 @@ SED1 = 4
 
 
 class Cert_5_3_2_RealmLocal(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
@@ -42,7 +42,7 @@ MED1_TIMEOUT = 3
 
 
 class Cert_5_3_3_AddressQuery(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_3_04_AddressMapCache.py
+++ b/tests/scripts/thread-cert/Cert_5_3_04_AddressMapCache.py
@@ -45,7 +45,7 @@ MTDS = [SED1, ED1, ED2, ED3, ED4]
 
 
 class Cert_5_3_4_AddressMapCache(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_3_05_RoutingLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_5_3_05_RoutingLinkQuality.py
@@ -40,7 +40,7 @@ ROUTER3 = 4
 
 
 class Cert_5_3_5_RoutingLinkQuality(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_3_06_RouterIdMask.py
+++ b/tests/scripts/thread-cert/Cert_5_3_06_RouterIdMask.py
@@ -40,7 +40,7 @@ ROUTER2 = 3
 
 
 class Cert_5_3_6_RouterIdMask(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         DUT_LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_3_06b_RouterIdMask.py
+++ b/tests/scripts/thread-cert/Cert_5_3_06b_RouterIdMask.py
@@ -37,7 +37,7 @@ ROUTER2 = 3
 
 
 class Cert_5_3_6_RouterIdMask(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
+++ b/tests/scripts/thread-cert/Cert_5_3_07_DuplicateAddress.py
@@ -45,7 +45,7 @@ MTDS = [MED1, SED1, MED3]
 
 
 class Cert_5_3_7_DuplicateAddress(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         DUT_LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_3_08_ChildAddressSet.py
+++ b/tests/scripts/thread-cert/Cert_5_3_08_ChildAddressSet.py
@@ -44,7 +44,7 @@ MTDS = [MED1, MED2]
 
 
 class Cert_5_3_8_ChildAddressSet(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         DUT_LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_3_09_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_09_AddressQuery.py
@@ -43,7 +43,7 @@ SED1 = 5
 
 
 class Cert_5_3_09_AddressQuery(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
@@ -45,7 +45,7 @@ MED1 = 5
 class Cert_5_3_10_AddressQuery(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_10_AddressQuery.py
@@ -43,7 +43,7 @@ MED1 = 5
 
 
 class Cert_5_3_10_AddressQuery(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         LEADER: {

--- a/tests/scripts/thread-cert/Cert_5_3_11_AddressQueryTimeoutIntervals.py
+++ b/tests/scripts/thread-cert/Cert_5_3_11_AddressQueryTimeoutIntervals.py
@@ -39,7 +39,7 @@ MED1 = 3
 
 
 class Cert_5_3_11_AddressQueryTimeoutIntervals(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_5_01_LeaderReboot.py
+++ b/tests/scripts/thread-cert/Cert_5_5_01_LeaderReboot.py
@@ -40,7 +40,7 @@ DUT_ROUTER1 = 2
 
 
 class Cert_5_5_1_LeaderReboot(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         DUT_LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
+++ b/tests/scripts/thread-cert/Cert_5_5_02_LeaderReboot.py
@@ -37,7 +37,7 @@ ED = 3
 
 
 class Cert_5_5_2_LeaderReboot(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
+++ b/tests/scripts/thread-cert/Cert_5_5_03_SplitMergeChildren.py
@@ -42,7 +42,7 @@ MTDS = [ED1, ED2, ED3]
 
 
 class Cert_5_5_3_SplitMergeChildren(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
+++ b/tests/scripts/thread-cert/Cert_5_5_04_SplitMergeRouters.py
@@ -39,7 +39,7 @@ ROUTER4 = 5
 
 
 class Cert_5_5_4_SplitMergeRouters(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_5_05_SplitMergeREED.py
+++ b/tests/scripts/thread-cert/Cert_5_5_05_SplitMergeREED.py
@@ -40,7 +40,7 @@ REED1 = 17
 
 
 class Cert_5_5_5_SplitMergeREED(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode':
                 'rsdn',

--- a/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
+++ b/tests/scripts/thread-cert/Cert_5_5_07_SplitMergeThreeWay.py
@@ -38,7 +38,7 @@ ROUTER3 = 4
 
 
 class Cert_5_5_7_SplitMergeThreeWay(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER1: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_5_08_SplitRoutersLostLeader.py
@@ -39,7 +39,7 @@ ED1 = 5
 
 
 class Cert_5_5_8_SplitRoutersLostLeader(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER1: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_01_NetworkDataRegisterBeforeAttachLeader.py
@@ -41,7 +41,7 @@ MTDS = [ED1, SED1]
 
 
 class Cert_5_6_1_NetworkDataLeaderAsBr(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_02_NetworkDataRegisterBeforeAttachRouter.py
@@ -41,7 +41,7 @@ MTDS = [ED1, SED1]
 
 
 class Cert_5_6_2_NetworkDataRouterAsBr(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
+++ b/tests/scripts/thread-cert/Cert_5_6_03_NetworkDataRegisterAfterAttachLeader.py
@@ -41,7 +41,7 @@ MTDS = [ED1, SED1]
 
 
 class Cert_5_6_3_NetworkDataRegisterAfterAttachLeader(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_04_NetworkDataRegisterAfterAttachRouter.py
@@ -41,7 +41,7 @@ MTDS = [ED1, SED1]
 
 
 class Cert_5_6_4_NetworkDataRegisterAfterAttachRouter(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
@@ -41,7 +41,7 @@ MTDS = [ED1, SED1]
 
 
 class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
+++ b/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
@@ -41,7 +41,7 @@ MTDS = [ED1, SED1]
 
 
 class Cert_5_6_6_NetworkDataExpiration(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
+++ b/tests/scripts/thread-cert/Cert_5_6_07_NetworkDataRequestREED.py
@@ -37,7 +37,7 @@ REED = 3
 
 
 class Cert_5_6_7_NetworkDataRequestREED(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
+++ b/tests/scripts/thread-cert/Cert_5_6_08_ContextManagement.py
@@ -37,7 +37,7 @@ ED = 3
 
 
 class Cert_5_6_8_ContextManagement(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'context_reuse_delay': 10,
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
+++ b/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
@@ -42,7 +42,7 @@ MTDS = [ED, SED]
 
 
 class Cert_5_6_9_NetworkDataForwarding(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_5_7_01_CoapDiagCommands_A.py
+++ b/tests/scripts/thread-cert/Cert_5_7_01_CoapDiagCommands_A.py
@@ -48,7 +48,7 @@ MTDS = [MED1, SED1]
 
 
 class Cert_5_7_01_CoapDiagCommands_A(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         LEADER: {

--- a/tests/scripts/thread-cert/Cert_5_7_01_CoapDiagCommands_A.py
+++ b/tests/scripts/thread-cert/Cert_5_7_01_CoapDiagCommands_A.py
@@ -50,7 +50,7 @@ MTDS = [MED1, SED1]
 class Cert_5_7_01_CoapDiagCommands_A(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'whitelist': [ROUTER1],
         },

--- a/tests/scripts/thread-cert/Cert_5_8_01_KeySynchronization.py
+++ b/tests/scripts/thread-cert/Cert_5_8_01_KeySynchronization.py
@@ -36,7 +36,7 @@ ED = 2
 
 
 class Cert_5_8_1_KeySynchronization(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'key_switch_guardtime': 0,
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_5_8_02_KeyIncrement.py
@@ -36,7 +36,7 @@ ROUTER = 2
 
 
 class Cert_5_8_2_KeyIncrement(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'key_switch_guardtime': 0,
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_5_8_03_KeyIncrementRollOver.py
@@ -36,7 +36,7 @@ ROUTER = 2
 
 
 class Cert_5_8_3_KeyIncrementRollOver(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'key_sequence_counter': 127,
             'key_switch_guardtime': 0,

--- a/tests/scripts/thread-cert/Cert_6_1_01_RouterAttach.py
+++ b/tests/scripts/thread-cert/Cert_6_1_01_RouterAttach.py
@@ -37,7 +37,7 @@ ED = 2
 
 
 class Cert_6_1_1_RouterAttach(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach_MED.py
+++ b/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach_MED.py
@@ -43,7 +43,7 @@ MED = 3
 
 
 class Cert_6_1_2_REEDAttach_MED(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach_SED.py
+++ b/tests/scripts/thread-cert/Cert_6_1_02_REEDAttach_SED.py
@@ -44,7 +44,7 @@ SED = 3
 
 
 class Cert_6_1_2_REEDAttach_SED(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_03_RouterAttachConnectivity.py
@@ -40,7 +40,7 @@ ED = 5
 
 
 class Cert_6_1_3_RouterAttachConnectivity(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
+++ b/tests/scripts/thread-cert/Cert_6_1_04_REEDAttachConnectivity.py
@@ -39,7 +39,7 @@ ED = 5
 
 
 class Cert_6_1_4_REEDAttachConnectivity(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
+++ b/tests/scripts/thread-cert/Cert_6_1_05_RouterAttachLinkQuality.py
@@ -38,7 +38,7 @@ ED = 4
 
 
 class Cert_6_1_5_RouterAttachLinkQuality(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality_ED.py
+++ b/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality_ED.py
@@ -39,7 +39,7 @@ ED = 4
 
 
 class Cert_6_1_6_REEDAttachLinkQuality_ED(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality_SED.py
+++ b/tests/scripts/thread-cert/Cert_6_1_06_REEDAttachLinkQuality_SED.py
@@ -40,7 +40,7 @@ SED = 4
 
 
 class Cert_6_1_6_REEDAttachLinkQuality_SED(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_1_07_EDSynchronization.py
+++ b/tests/scripts/thread-cert/Cert_6_1_07_EDSynchronization.py
@@ -39,7 +39,7 @@ ROUTER3 = 5
 
 
 class Cert_6_1_7_EDSynchronization(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_01_NewPartition.py
@@ -37,7 +37,7 @@ ED = 3
 
 
 class Cert_6_2_1_NewPartition(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
+++ b/tests/scripts/thread-cert/Cert_6_2_02_NewPartition.py
@@ -38,7 +38,7 @@ ED = 4
 
 
 class Cert_6_2_2_NewPartition(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_3_01_OrphanReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_3_01_OrphanReattach.py
@@ -37,7 +37,7 @@ ED = 3
 
 
 class Cert_6_3_1_OrphanReattach(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
+++ b/tests/scripts/thread-cert/Cert_6_3_02_NetworkDataUpdate.py
@@ -36,7 +36,7 @@ ED = 2
 
 
 class Cert_6_3_2_NetworkDataUpdate(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_4_01_LinkLocal.py
+++ b/tests/scripts/thread-cert/Cert_6_4_01_LinkLocal.py
@@ -36,7 +36,7 @@ ED = 2
 
 
 class Cert_6_4_1_LinkLocal(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
+++ b/tests/scripts/thread-cert/Cert_6_4_02_RealmLocal.py
@@ -37,7 +37,7 @@ ED = 3
 
 
 class Cert_5_3_2_RealmLocal(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_5_01_ChildResetSynchronize.py
+++ b/tests/scripts/thread-cert/Cert_6_5_01_ChildResetSynchronize.py
@@ -37,7 +37,7 @@ ED = 2
 
 
 class Cert_6_5_1_ChildResetSynchronize(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
+++ b/tests/scripts/thread-cert/Cert_6_5_02_ChildResetReattach.py
@@ -36,7 +36,7 @@ ED = 2
 
 
 class Cert_6_5_2_ChildResetReattach(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
+++ b/tests/scripts/thread-cert/Cert_6_6_01_KeyIncrement.py
@@ -36,7 +36,7 @@ ED = 2
 
 
 class Cert_6_6_1_KeyIncrement(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'key_switch_guardtime': 0,
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
+++ b/tests/scripts/thread-cert/Cert_6_6_02_KeyIncrementRollOver.py
@@ -36,7 +36,7 @@ ED = 2
 
 
 class Cert_6_6_2_KeyIncrement1(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'key_sequence_counter': 127,
             'key_switch_guardtime': 0,

--- a/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_01_BorderRouterAsLeader.py
@@ -51,7 +51,7 @@ MTDS = [SED1, MED1]
 
 
 class Cert_7_1_1_BorderRouterAsLeader(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_02_BorderRouterAsRouter.py
@@ -41,7 +41,7 @@ MTDS = [ED2, SED2]
 
 
 class Cert_7_1_2_BorderRouterAsRouter(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
+++ b/tests/scripts/thread-cert/Cert_7_1_03_BorderRouterAsLeader.py
@@ -51,7 +51,7 @@ MTDS = [SED1, MED1]
 
 
 class Cert_7_1_3_BorderRouterAsLeader(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_04_BorderRouterAsRouter.py
@@ -41,7 +41,7 @@ MTDS = [SED2, ED2]
 
 
 class Cert_7_1_4_BorderRouterAsRouter(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
+++ b/tests/scripts/thread-cert/Cert_7_1_05_BorderRouterAsRouter.py
@@ -41,7 +41,7 @@ MTDS = [ED2, SED2]
 
 
 class Cert_7_1_5_BorderRouterAsRouter(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
@@ -41,7 +41,7 @@ JOINER = 2
 
 
 class Cert_8_1_01_Commissioning(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
@@ -43,7 +43,7 @@ JOINER = 2
 class Cert_8_1_01_Commissioning(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'masterkey': '00112233445566778899aabbccddeeff',
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
@@ -38,7 +38,7 @@ JOINER = 2
 class Cert_8_1_02_Commissioning(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'masterkey': 'deadbeefdeadbeefdeadbeefdeadbeef',
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_02_Commissioning.py
@@ -36,7 +36,7 @@ JOINER = 2
 
 
 class Cert_8_1_02_Commissioning(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
@@ -39,7 +39,7 @@ JOINER = 3
 class Cert_8_2_01_JoinerRouter(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'masterkey': 'deadbeefdeadbeefdeadbeefdeadbeef',
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
@@ -37,7 +37,7 @@ JOINER = 3
 
 
 class Cert_8_2_01_JoinerRouter(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
@@ -37,7 +37,7 @@ JOINER = 3
 
 
 class Cert_8_2_02_JoinerRouter(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
@@ -39,7 +39,7 @@ JOINER = 3
 class Cert_8_2_02_JoinerRouter(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'masterkey': 'deadbeefdeadbeefdeadbeefdeadbeef',
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/Cert_9_2_02_MGMTCommissionerSet.py
+++ b/tests/scripts/thread-cert/Cert_9_2_02_MGMTCommissionerSet.py
@@ -40,7 +40,7 @@ LEADER = 2
 
 
 class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_9_2_02_MGMTCommissionerSet.py
+++ b/tests/scripts/thread-cert/Cert_9_2_02_MGMTCommissionerSet.py
@@ -42,7 +42,7 @@ LEADER = 2
 class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_9_2_04_ActiveDataset.py
+++ b/tests/scripts/thread-cert/Cert_9_2_04_ActiveDataset.py
@@ -38,7 +38,7 @@ LEADER = 2
 class Cert_9_2_04_ActiveDataset(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'active_dataset': {
                 'timestamp': 10,

--- a/tests/scripts/thread-cert/Cert_9_2_04_ActiveDataset.py
+++ b/tests/scripts/thread-cert/Cert_9_2_04_ActiveDataset.py
@@ -36,7 +36,7 @@ LEADER = 2
 
 
 class Cert_9_2_04_ActiveDataset(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_9_2_07_DelayTimer.py
+++ b/tests/scripts/thread-cert/Cert_9_2_07_DelayTimer.py
@@ -47,7 +47,7 @@ COMMISSIONER_PENDING_PANID = 0xafce
 
 
 class Cert_9_2_7_DelayTimer(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_9_2_07_DelayTimer.py
+++ b/tests/scripts/thread-cert/Cert_9_2_07_DelayTimer.py
@@ -49,7 +49,7 @@ COMMISSIONER_PENDING_PANID = 0xafce
 class Cert_9_2_7_DelayTimer(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'active_dataset': {
                 'timestamp': LEADER_ACTIVE_TIMESTAMP

--- a/tests/scripts/thread-cert/Cert_9_2_08_PersistentDatasets.py
+++ b/tests/scripts/thread-cert/Cert_9_2_08_PersistentDatasets.py
@@ -51,7 +51,7 @@ MTDS = [ED, SED]
 class Cert_9_2_8_PersistentDatasets(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'active_dataset': {
                 'timestamp': LEADER_ACTIVE_TIMESTAMP,

--- a/tests/scripts/thread-cert/Cert_9_2_08_PersistentDatasets.py
+++ b/tests/scripts/thread-cert/Cert_9_2_08_PersistentDatasets.py
@@ -49,7 +49,7 @@ MTDS = [ED, SED]
 
 
 class Cert_9_2_8_PersistentDatasets(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_9_2_09_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_09_PendingPartition.py
@@ -46,7 +46,7 @@ ROUTER2 = 4
 class Cert_9_2_09_PendingPartition(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'active_dataset': {
                 'timestamp': 10,

--- a/tests/scripts/thread-cert/Cert_9_2_09_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_09_PendingPartition.py
@@ -44,7 +44,7 @@ ROUTER2 = 4
 
 
 class Cert_9_2_09_PendingPartition(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_9_2_10_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_10_PendingPartition.py
@@ -50,7 +50,7 @@ MTDS = [ED1, SED1]
 class Cert_9_2_10_PendingPartition(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'active_dataset': {
                 'timestamp': 15,

--- a/tests/scripts/thread-cert/Cert_9_2_10_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_10_PendingPartition.py
@@ -48,7 +48,7 @@ MTDS = [ED1, SED1]
 
 
 class Cert_9_2_10_PendingPartition(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_9_2_11_MasterKey.py
+++ b/tests/scripts/thread-cert/Cert_9_2_11_MasterKey.py
@@ -50,7 +50,7 @@ MTDS = [ED1, SED1]
 class Cert_9_2_11_MasterKey(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'active_dataset': {
                 'timestamp': 10,

--- a/tests/scripts/thread-cert/Cert_9_2_11_MasterKey.py
+++ b/tests/scripts/thread-cert/Cert_9_2_11_MasterKey.py
@@ -48,7 +48,7 @@ MTDS = [ED1, SED1]
 
 
 class Cert_9_2_11_MasterKey(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_9_2_12_Announce.py
+++ b/tests/scripts/thread-cert/Cert_9_2_12_Announce.py
@@ -47,7 +47,7 @@ DATASET2_PANID = 0xafce
 
 
 class Cert_9_2_12_Announce(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         LEADER1: {

--- a/tests/scripts/thread-cert/Cert_9_2_12_Announce.py
+++ b/tests/scripts/thread-cert/Cert_9_2_12_Announce.py
@@ -49,7 +49,7 @@ DATASET2_PANID = 0xafce
 class Cert_9_2_12_Announce(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         LEADER1: {
             'active_dataset': {
                 'timestamp': DATASET1_TIMESTAMP,

--- a/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
@@ -38,7 +38,7 @@ ED1 = 4
 
 
 class Cert_9_2_13_EnergyScan(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_13_EnergyScan.py
@@ -40,7 +40,7 @@ ED1 = 4
 class Cert_9_2_13_EnergyScan(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
+++ b/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
@@ -38,7 +38,7 @@ LEADER2 = 4
 
 
 class Cert_9_2_14_PanIdQuery(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
+++ b/tests/scripts/thread-cert/Cert_9_2_14_PanIdQuery.py
@@ -40,7 +40,7 @@ LEADER2 = 4
 class Cert_9_2_14_PanIdQuery(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/Cert_9_2_15_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_15_PendingPartition.py
@@ -43,7 +43,7 @@ ROUTER2 = 4
 
 
 class Cert_9_2_15_PendingPartition(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_9_2_15_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_15_PendingPartition.py
@@ -45,7 +45,7 @@ ROUTER2 = 4
 class Cert_9_2_15_PendingPartition(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'active_dataset': {
                 'timestamp': 15,

--- a/tests/scripts/thread-cert/Cert_9_2_16_ActivePendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_16_ActivePendingPartition.py
@@ -46,7 +46,7 @@ ROUTER2 = 4
 class Cert_9_2_16_ActivePendingPartition(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'active_dataset': {
                 'timestamp': 1,

--- a/tests/scripts/thread-cert/Cert_9_2_16_ActivePendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_16_ActivePendingPartition.py
@@ -44,7 +44,7 @@ ROUTER2 = 4
 
 
 class Cert_9_2_16_ActivePendingPartition(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
@@ -45,7 +45,7 @@ ED1 = 3
 class Cert_9_2_17_Orphan(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         LEADER1: {
             'active_dataset': {
                 'timestamp': 10,

--- a/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
@@ -43,7 +43,7 @@ ED1 = 3
 
 
 class Cert_9_2_17_Orphan(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         LEADER1: {

--- a/tests/scripts/thread-cert/Cert_9_2_18_RollBackActiveTimestamp.py
+++ b/tests/scripts/thread-cert/Cert_9_2_18_RollBackActiveTimestamp.py
@@ -51,7 +51,7 @@ MTDS = [ED1, SED1]
 class Cert_9_2_18_RollBackActiveTimestamp(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         COMMISSIONER: {
             'active_dataset': {
                 'timestamp': 1,

--- a/tests/scripts/thread-cert/Cert_9_2_18_RollBackActiveTimestamp.py
+++ b/tests/scripts/thread-cert/Cert_9_2_18_RollBackActiveTimestamp.py
@@ -49,7 +49,7 @@ MTDS = [ED1, SED1]
 
 
 class Cert_9_2_18_RollBackActiveTimestamp(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         COMMISSIONER: {

--- a/tests/scripts/thread-cert/Test_Cli.py
+++ b/tests/scripts/thread-cert/Test_Cli.py
@@ -35,7 +35,7 @@ LEADER = 1
 
 
 class Cert_Cli(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {},
     }
 

--- a/tests/scripts/thread-cert/Test_MacScan.py
+++ b/tests/scripts/thread-cert/Test_MacScan.py
@@ -37,7 +37,7 @@ ROUTER = 2
 
 
 class Test_MacScan(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'channel': 12,
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/test_coap_observe.py
+++ b/tests/scripts/thread-cert/test_coap_observe.py
@@ -44,7 +44,7 @@ class TestCoapObserve(thread_cert.TestCase):
 
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/test_coap_observe.py
+++ b/tests/scripts/thread-cert/test_coap_observe.py
@@ -42,7 +42,7 @@ class TestCoapObserve(thread_cert.TestCase):
     Test suite for CoAP Observations (RFC7641).
     """
 
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         LEADER: {

--- a/tests/scripts/thread-cert/test_coaps.py
+++ b/tests/scripts/thread-cert/test_coaps.py
@@ -39,7 +39,7 @@ ROUTER = 2
 class TestCoaps(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/test_coaps.py
+++ b/tests/scripts/thread-cert/test_coaps.py
@@ -37,7 +37,7 @@ ROUTER = 2
 
 
 class TestCoaps(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         LEADER: {

--- a/tests/scripts/thread-cert/test_diag.py
+++ b/tests/scripts/thread-cert/test_diag.py
@@ -36,7 +36,7 @@ import thread_cert
 class TestDiag(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {1: None}
+    TOPOLOGY = {1: None}
 
     def test(self):
         node = self.nodes[1]

--- a/tests/scripts/thread-cert/test_diag.py
+++ b/tests/scripts/thread-cert/test_diag.py
@@ -34,7 +34,7 @@ import thread_cert
 
 
 class TestDiag(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {1: None}
 

--- a/tests/scripts/thread-cert/test_ipv6_fragmentation.py
+++ b/tests/scripts/thread-cert/test_ipv6_fragmentation.py
@@ -38,7 +38,7 @@ ROUTER = 2
 
 
 class TestIPv6Fragmentation(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         LEADER: {

--- a/tests/scripts/thread-cert/test_ipv6_fragmentation.py
+++ b/tests/scripts/thread-cert/test_ipv6_fragmentation.py
@@ -40,7 +40,7 @@ ROUTER = 2
 class TestIPv6Fragmentation(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xcafe,

--- a/tests/scripts/thread-cert/test_ipv6_source_selection.py
+++ b/tests/scripts/thread-cert/test_ipv6_source_selection.py
@@ -39,7 +39,7 @@ ROUTER = 2
 class TestIPv6SourceSelection(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xcafe,

--- a/tests/scripts/thread-cert/test_ipv6_source_selection.py
+++ b/tests/scripts/thread-cert/test_ipv6_source_selection.py
@@ -37,7 +37,7 @@ ROUTER = 2
 
 
 class TestIPv6SourceSelection(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         LEADER: {

--- a/tests/scripts/thread-cert/test_reed_address_solicit_rejected.py
+++ b/tests/scripts/thread-cert/test_reed_address_solicit_rejected.py
@@ -49,7 +49,7 @@ SRV_0_SERVER_DATA = 'bar'
 class TestREEDAddressSolicitRejected(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface

--- a/tests/scripts/thread-cert/test_reed_address_solicit_rejected.py
+++ b/tests/scripts/thread-cert/test_reed_address_solicit_rejected.py
@@ -47,7 +47,7 @@ SRV_0_SERVER_DATA = 'bar'
 
 
 class TestREEDAddressSolicitRejected(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         LEADER: {

--- a/tests/scripts/thread-cert/test_reset.py
+++ b/tests/scripts/thread-cert/test_reset.py
@@ -37,7 +37,7 @@ SED = 4
 
 
 class TestReset(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/test_route_table.py
+++ b/tests/scripts/thread-cert/test_route_table.py
@@ -41,7 +41,7 @@ ROUTER2 = 3
 
 
 class TestRouteTable(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',
             'panid': 0xface,

--- a/tests/scripts/thread-cert/test_service.py
+++ b/tests/scripts/thread-cert/test_service.py
@@ -51,7 +51,7 @@ SRV_1_SERVER_DATA = 'qux'
 class Test_Service(thread_cert.TestCase):
     support_ncp = False
 
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'channel': 12,
             'mode': 'rsdn',

--- a/tests/scripts/thread-cert/test_service.py
+++ b/tests/scripts/thread-cert/test_service.py
@@ -49,7 +49,7 @@ SRV_1_SERVER_DATA = 'qux'
 
 
 class Test_Service(thread_cert.TestCase):
-    support_ncp = False
+    SUPPORT_NCP = False
 
     TOPOLOGY = {
         LEADER: {

--- a/tests/scripts/thread-cert/thread_cert.py
+++ b/tests/scripts/thread-cert/thread_cert.py
@@ -71,6 +71,8 @@ class TestCase(NcpSupportMixin, unittest.TestCase):
     The `topology` member of sub-class is used to create test topology.
     """
 
+    TOPOLOGY = None
+
     def setUp(self):
         """Create simulator, nodes and apply configurations.
         """
@@ -80,7 +82,7 @@ class TestCase(NcpSupportMixin, unittest.TestCase):
         self.nodes = {}
 
         initial_topology = {}
-        for i, params in self.topology.items():
+        for i, params in self.TOPOLOGY.items():
             if params:
                 params = dict(DEFAULT_PARAMS, **params)
             else:

--- a/tests/scripts/thread-cert/thread_cert.py
+++ b/tests/scripts/thread-cert/thread_cert.py
@@ -55,10 +55,10 @@ class NcpSupportMixin():
     """ The mixin to check whether a test case supports NCP.
     """
 
-    support_ncp = True
+    SUPPORT_NCP = True
 
     def __init__(self, *args, **kwargs):
-        if os.getenv('NODE_TYPE', 'sim') == 'ncp-sim' and not self.support_ncp:
+        if os.getenv('NODE_TYPE', 'sim') == 'ncp-sim' and not self.SUPPORT_NCP:
             # 77 means skip this test case in automake tests
             sys.exit(77)
 

--- a/tests/scripts/thread-cert/v1_2_router_5_1_1.py
+++ b/tests/scripts/thread-cert/v1_2_router_5_1_1.py
@@ -38,7 +38,7 @@ ROUTER_1 = 2
 
 
 class Router_5_1_01(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'version': '1.2'
         },

--- a/tests/scripts/thread-cert/v1_2_test_backbone_router_service.py
+++ b/tests/scripts/thread-cert/v1_2_test_backbone_router_service.py
@@ -70,7 +70,7 @@ BBR_REGISTRATION_JITTER = 5
 
 
 class TestBackboneRouterService(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER_1_1: {
             'version': '1.1',
             'whitelist': [BBR_1, BBR_2],

--- a/tests/scripts/thread-cert/v1_2_test_domain_unicast_address.py
+++ b/tests/scripts/thread-cert/v1_2_test_domain_unicast_address.py
@@ -100,7 +100,7 @@ TEST_PREFIX3 = '2001:0:0:3::/64'
 
 
 class TestDomainUnicastAddress(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         BBR_1: {
             'version': '1.2',
             'whitelist': [ROUTER_1_1, ROUTER_1_2],

--- a/tests/scripts/thread-cert/v1_2_test_enhanced_frame_pending.py
+++ b/tests/scripts/thread-cert/v1_2_test_enhanced_frame_pending.py
@@ -59,7 +59,7 @@ DEFAULT_POLL_PERIOD = CHILD_TIMEOUT - 4
 
 
 class SED_EnhancedFramePending(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'version': '1.2'
         },

--- a/tests/scripts/thread-cert/v1_2_test_enhanced_keep_alive.py
+++ b/tests/scripts/thread-cert/v1_2_test_enhanced_keep_alive.py
@@ -45,7 +45,7 @@ USER_POLL_PERIOD = CHILD_TIMEOUT // 3
 
 
 class SED_EnhancedKeepAlive(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER: {
             'version': '1.2'
         },

--- a/tests/scripts/thread-cert/v1_2_test_multicast_registration.py
+++ b/tests/scripts/thread-cert/v1_2_test_multicast_registration.py
@@ -95,7 +95,7 @@ MED_1_2 --- LEADER_1_2 --- MED_1_1
 
 
 class TestMulticastRegistration(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER_1_2: {
             'version': '1.2',
             'whitelist': [MED_1_2, SED_1_2, MED_1_1, SED_1_1, ROUTER_1_1],

--- a/tests/scripts/thread-cert/v1_2_test_parent_selection.py
+++ b/tests/scripts/thread-cert/v1_2_test_parent_selection.py
@@ -69,7 +69,7 @@ MED_1_2 = 7
 
 
 class TestParentSelection(thread_cert.TestCase):
-    topology = {
+    TOPOLOGY = {
         LEADER_1_2: {
             'version': '1.2',
             'whitelist': [REED_1_2, ROUTER_1_2, REED_1_1, ROUTER_1_1, MED_1_1],


### PR DESCRIPTION
According to [PEP8](https://www.python.org/dev/peps/pep-0008/#constants), constants should be written in all capital letters. 

This PR capitalize these constants:
- thread_cert.TestCase.topology
- thread_cert.TestCase.support_ncp
