### PR TITLE
[posix] fix ot-ctl CLI output missing

### DIFF
--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -301,6 +301,7 @@ int main(int argc, char *argv[])
                 for (ssize_t i = 0; i < rval; i++)
                 {
                     int prevPromptState = promptState;
+
                     if (FindPrompt(promptState, buffer[i]))
                     {
                         doneState  = 0;

--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -326,14 +326,10 @@ int main(int argc, char *argv[])
                     }
                 }
 
-                if (lineStart < rval)
+                if (lineStart < rval && promptState != 1)
                 {
                     assert(promptState != 0 && promptState != 2);
-                    if (promptState == -1)
-                    {
-                        VerifyOrExit(DoWrite(STDOUT_FILENO, buffer + lineStart, rval - lineStart),
-                                     ret = OT_EXIT_FAILURE);
-                    }
+                    VerifyOrExit(DoWrite(STDOUT_FILENO, buffer + lineStart, rval - lineStart), ret = OT_EXIT_FAILURE);
                 }
             }
         }

--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -40,6 +40,7 @@
 
 #define OPENTHREAD_USE_READLINE (HAVE_LIBEDIT || HAVE_LIBREADLINE)
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -55,7 +55,6 @@
 #endif
 
 #include "common/code_utils.hpp"
-#include "common/debug.hpp"
 
 #include "platform-posix.h"
 
@@ -329,7 +328,7 @@ int main(int argc, char *argv[])
 
                 if (lineStart < rval)
                 {
-                    OT_ASSERT(promptState != 0 && promptState != 2);
+                    assert(promptState != 0 && promptState != 2);
                     if (promptState == -1)
                     {
                         VerifyOrExit(DoWrite(STDOUT_FILENO, buffer + lineStart, rval - lineStart),


### PR DESCRIPTION
This PR resolves https://github.com/openthread/ot-br-posix/issues/468.

This issue occurs when ot-ctl reads the CLI output in multiple chunks in which the last line of a chunk does not ends with a '\r\n'. The last line is then dropped incorrectly. 

This PR fixes this issue:
- Output the last line (without `\r\n`) if it's not `">"` (have to drop `'>'` because we can not determine whether or not to output `'>'`)
- Output `">"` if the first char is not `' '` but the previous `promptState` is 1 (meaning `'>'` was dropped previous but should have been printed).

I think the fix is difficult to understand and in long term we should switch to a more readable implementation that just reads and processes one complete line at a time without these state transfers. Thoughts? @bukepo @gjc13 @jwhui 