### PR TITLE
[efr32] turn off specific warnings for certain mbed TLS configurations

### DIFF
--- a/examples/Makefile-efr32mg21
+++ b/examples/Makefile-efr32mg21
@@ -84,6 +84,8 @@ EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/silabs/gecko_sdk_suit
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include
 EFR32_MBEDTLS_CPPFLAGS += -I$(AbsTopSourceDir)/third_party/mbedtls/repo/include/mbedtls
+EFR32_MBEDTLS_CPPFLAGS += -Wno-unused-function
+EFR32_MBEDTLS_CPPFLAGS += -Wno-unused-parameter
 
 CONFIG_FILE_PATH = $(AbsTopSourceDir)/examples/platforms/efr32mg21/
 HAL_CONF_DIR     = $(CONFIG_FILE_PATH)/$(shell echo $(BOARD) | tr A-Z a-z)


### PR DESCRIPTION
Detected on EFR32MG21 with hardware acceleration turned on, all inside mbedTLS' library/ecdsa.c:
* Turning on ECDSA signing acceleration (MBEDTLS_ECDSA_SIGN_ALT) triggers an unused parameter on rs_ctx in mbedtls_ecdsa_write_signature_restartable
* Turning on ECDSA verification acceleration (MBEDTLS_ECDSA_VERIFY_ALT) triggers an unused parameter on rs_ctx in mbedtls_ecdsa_read_signature_restartable
* Turning on both ECDSA signing & verification acceleration (MBEDTLS_ECDSA_SIGN_ALT + MBEDTLS_ECDSA_VERIFY_ALT) triggers an unused function error on static function derive_mpi

Looking at the latest mbed TLS development branch, it seems this issue will not be resolved soon. Therefore, we're turning off unused parameter and unused function warnings when building mbedTLS for the specific platform which uses this configuration (EFR32MG21).