### PR TITLE
[tests] use longer timeouts for simulation tests

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -130,7 +130,7 @@ class Node:
 
         print("%s" % cmd)
 
-        self.pexpect = pexpect.popen_spawn.PopenSpawn(cmd, timeout=60)
+        self.pexpect = pexpect.popen_spawn.PopenSpawn(cmd, timeout=10)
 
         # Add delay to ensure that the process is ready to receive commands.
         timeout = 0.4
@@ -211,7 +211,7 @@ class Node:
         cmd += ' %d' % nodeid
         print("%s" % cmd)
 
-        self.pexpect = pexpect.spawn(cmd, timeout=60)
+        self.pexpect = pexpect.spawn(cmd, timeout=10)
 
         # Add delay to ensure that the process is ready to receive commands.
         time.sleep(0.2)

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -130,7 +130,7 @@ class Node:
 
         print("%s" % cmd)
 
-        self.pexpect = pexpect.popen_spawn.PopenSpawn(cmd, timeout=4)
+        self.pexpect = pexpect.popen_spawn.PopenSpawn(cmd, timeout=60)
 
         # Add delay to ensure that the process is ready to receive commands.
         timeout = 0.4
@@ -211,7 +211,7 @@ class Node:
         cmd += ' %d' % nodeid
         print("%s" % cmd)
 
-        self.pexpect = pexpect.spawn(cmd, timeout=4)
+        self.pexpect = pexpect.spawn(cmd, timeout=60)
 
         # Add delay to ensure that the process is ready to receive commands.
         time.sleep(0.2)

--- a/tests/scripts/thread-cert/simulator.py
+++ b/tests/scripts/thread-cert/simulator.py
@@ -138,7 +138,7 @@ class VirtualTime(BaseSimulator):
     END_OF_TIME = 0x7FFFFFFF
     PORT_OFFSET = int(os.getenv('PORT_OFFSET', '0'))
 
-    BLOCK_TIMEOUT = 4
+    BLOCK_TIMEOUT = 60
 
     RADIO_ONLY = os.getenv('RADIO_DEVICE') is not None
     NCP_SIM = os.getenv('NODE_TYPE', 'sim') == 'ncp-sim'

--- a/tests/scripts/thread-cert/simulator.py
+++ b/tests/scripts/thread-cert/simulator.py
@@ -138,7 +138,7 @@ class VirtualTime(BaseSimulator):
     END_OF_TIME = 0x7FFFFFFF
     PORT_OFFSET = int(os.getenv('PORT_OFFSET', '0'))
 
-    BLOCK_TIMEOUT = 60
+    BLOCK_TIMEOUT = 10
 
     RADIO_ONLY = os.getenv('RADIO_DEVICE') is not None
     NCP_SIM = os.getenv('NODE_TYPE', 'sim') == 'ncp-sim'


### PR DESCRIPTION
This PR makes 1.2 simulation tests much more stable by using longer timeouts. **Applying this fix, 1.2 simulation tests have passed 20 times continuously.**

Background:
- **The 1.2 simulation tests are failing frequently recently.**
- Tests show that this issue exists even at commit ab029e (Apr 17)
- Tests show that expecting `pexpect.EOF` in `Node.destroy` might take more than 5 seconds, and the current timeout is 4s.
- Tests show that socket timeout is likely to happen after node `reset`. Making sure `reset` complete in `Node.reset` can resolve this issue, but it turned out to be very tricky to implement. 

The test results and the fact that I can never reproduce this issue locally make me think that the fails are not due to any bug introduced by any commit, but just due to performance issues of the VMs that runs GitHub actions. 
Thus, this PR uses longer timeouts to improve the stability of simulation tests. 