### PR TITLE
[posix] handle prefixes in the router advertisement

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -155,7 +155,7 @@ jobs:
     - name: Bootstrap
       run: |
         sudo apt-get update
-        sudo apt-get --no-install-recommends install -y socat expect
+        sudo apt-get --no-install-recommends install -y socat expect radvd
         cd /tmp
         wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
         tar xvf bsd-licensed.tar.gz

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -126,7 +126,7 @@ jobs:
     - name: Bootstrap
       run: |
         sudo apt-get update
-        sudo apt-get --no-install-recommends install -y socat expect
+        sudo apt-get --no-install-recommends install -y socat expect radvd
         cd /tmp
         wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
         tar xvf bsd-licensed.tar.gz

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,5 @@ third_party/nlbuild-autotools/repo/third_party/autoconf/m4/ltsugar.m4
 third_party/nlbuild-autotools/repo/third_party/autoconf/m4/ltversion.m4
 third_party/nlbuild-autotools/repo/third_party/autoconf/m4/lt~obsolete.m4
 third_party/nlbuild-autotools/repo/third_party/autoconf/missing
+tests/scripts/misc/radvd_dhcp.conf
+tests/scripts/misc/radvd_slaac.conf

--- a/Android.mk
+++ b/Android.mk
@@ -283,6 +283,7 @@ LOCAL_SRC_FILES                                          := \
     src/posix/platform/logging.cpp                          \
     src/posix/platform/misc.cpp                             \
     src/posix/platform/netif.cpp                            \
+    src/posix/platform/ra_listener.cpp                      \
     src/posix/platform/radio.cpp                            \
     src/posix/platform/radio_url.cpp                        \
     src/posix/platform/settings.cpp                         \

--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -42,8 +42,9 @@ at_exit()
 
     sudo killall expect || true
     killall ot-ctl || true
-    killall ot-daemon || true
+    sudo killall ot-daemon || true
     killall socat || true
+    sudo killall radvd || true
 
     exit $EXIT_CODE
 }
@@ -51,7 +52,7 @@ at_exit()
 build()
 {
     make -f examples/Makefile-simulation
-    make -f src/posix/Makefile-posix PLATFORM_NETIF=1 PLATFORM_UDP=1 UDP_FORWARD=0 MAX_POWER_TABLE=1
+    make -f src/posix/Makefile-posix BORDER_ROUTER=1 PLATFORM_NETIF=1 PLATFORM_UDP=1 UDP_FORWARD=0 MAX_POWER_TABLE=1
 }
 
 check()
@@ -149,6 +150,16 @@ EOF
         sudo PATH="$(dirname "${OT_CLI_CMD}"):${PATH}" \
             python3 "$PWD/tests/scripts/misc/test_multicast_join.py" "${NETIF_INDEX}" \
             || die 'multicast group join failed'
+        sed "s/WPAN/${VALID_NETIF_NAME}/" tests/scripts/misc/radvd_slaac.conf.in >tests/scripts/misc/radvd_slaac.conf
+        sed "s/WPAN/${VALID_NETIF_NAME}/" tests/scripts/misc/radvd_dhcp.conf.in >tests/scripts/misc/radvd_dhcp.conf
+        sudo radvd -C "$PWD/tests/scripts/misc/radvd_slaac.conf"
+        sleep 3
+        sudo ${OT_CLI_CMD} prefix | grep '2001:db8:1:2::/64 ao med'
+        sudo killall radvd || true
+        sudo radvd -C "$PWD/tests/scripts/misc/radvd_dhcp.conf"
+        sleep 3
+        sudo ${OT_CLI_CMD} prefix | grep '2001:db8:1:2::/64 do med'
+        sudo killall radvd || true
     fi
 
     LEADER_ALOC=fdde:ad00:beef::ff:fe00:fc00

--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -154,11 +154,11 @@ EOF
         sed "s/WPAN/${VALID_NETIF_NAME}/" tests/scripts/misc/radvd_dhcp.conf.in >tests/scripts/misc/radvd_dhcp.conf
         sudo radvd -C "$PWD/tests/scripts/misc/radvd_slaac.conf"
         sleep 3
-        sudo ${OT_CLI_CMD} prefix | grep '2001:db8:1:2::/64 ao med'
+        sudo "${OT_CLI_CMD}" prefix | grep '2001:db8:1:2::/64 ao med'
         sudo killall radvd || true
         sudo radvd -C "$PWD/tests/scripts/misc/radvd_dhcp.conf"
         sleep 3
-        sudo ${OT_CLI_CMD} prefix | grep '2001:db8:1:2::/64 do med'
+        sudo "${OT_CLI_CMD}" prefix | grep '2001:db8:1:2::/64 do med'
         sudo killall radvd || true
     fi
 

--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -154,12 +154,16 @@ EOF
         sed "s/WPAN/${VALID_NETIF_NAME}/" tests/scripts/misc/radvd_dhcp.conf.in >tests/scripts/misc/radvd_dhcp.conf
         sudo radvd -C "$PWD/tests/scripts/misc/radvd_slaac.conf"
         sleep 3
-        sudo "${OT_CLI_CMD}" prefix | grep '2001:db8:1:2::/64 ao med'
+        sudo "${OT_CLI_CMD}" prefix | grep '2001:db8:1:2::/64 pao med'
         sudo killall radvd || true
         sudo radvd -C "$PWD/tests/scripts/misc/radvd_dhcp.conf"
         sleep 3
-        sudo "${OT_CLI_CMD}" prefix | grep '2001:db8:1:2::/64 do med'
+        sudo "${OT_CLI_CMD}" prefix | grep '2001:db8:1:2::/64 pdo med'
         sudo killall radvd || true
+        sleep 10
+        sudo "${OT_CLI_CMD}" prefix | grep '2001:db8:1:2::/64 do med'
+        sleep 10
+        sudo "${OT_CLI_CMD}" prefix | grep -L '2001:db8:1:2::'
     fi
 
     LEADER_ALOC=fdde:ad00:beef::ff:fe00:fc00

--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -160,10 +160,15 @@ EOF
         sleep 3
         sudo "${OT_CLI_CMD}" prefix | grep '2001:db8:1:2::/64 pdo med'
         sudo killall radvd || true
-        sleep 10
+        sleep 15
+        sudo "${OT_CLI_CMD}" prefix
         sudo "${OT_CLI_CMD}" prefix | grep '2001:db8:1:2::/64 do med'
-        sleep 10
-        sudo "${OT_CLI_CMD}" prefix | grep -L '2001:db8:1:2::'
+        sleep 15
+        FINAL_PREFIX=$(sudo "${OT_CLI_CMD}" prefix) 
+        echo "${FINAL_PREFIX}"
+        if [[ "${FINAL_PREFIX}" == *"2001"* ]]; then
+            exit 1
+        fi
     fi
 
     LEADER_ALOC=fdde:ad00:beef::ff:fe00:fc00

--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(openthread-posix
     logging.cpp
     misc.cpp
     netif.cpp
+    ra_listener.cpp
     radio.cpp
     radio_url.cpp
     settings.cpp

--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -49,6 +49,7 @@ libopenthread_posix_a_SOURCES             = \
     logging.cpp                             \
     misc.cpp                                \
     netif.cpp                               \
+    ra_listener.cpp                         \
     radio.cpp                               \
     radio_url.cpp                           \
     settings.cpp                            \
@@ -63,6 +64,7 @@ noinst_HEADERS                            = \
     hdlc_interface.hpp                      \
     openthread-posix-config.h               \
     platform-posix.h                        \
+    ra_listener.hpp                         \
     radio_url.hpp                           \
     $(NULL)
 

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -257,23 +257,18 @@ void platformNetifInit(otInstance *aInstance, const char *aInterfaceName);
 /**
  * This function updates the file descriptor sets with file descriptors used by platform netif module.
  *
- * @param[inout]  aReadFdSet    A pointer to the read file descriptors.
- * @param[inout]  aWriteFdSet   A pointer to the write file descriptors.
- * @param[inout]  aErrorFdSet   A pointer to the error file descriptors.
- * @param[inout]  aMaxFd        A pointer to the max file descriptor.
+ * @param[inout]  aContext      A pointer to the mainloop context.
  *
  */
-void platformNetifUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *aErrorFdSet, int *aMaxFd);
+void platformNetifUpdateFdSet(otSysMainloopContext *aContext);
 
 /**
  * This function performs platform netif processing.
  *
- * @param[in]   aReadFdSet      A pointer to the read file descriptors.
- * @param[in]   aWriteFdSet     A pointer to the write file descriptors.
- * @param[in]   aErrorFdSet     A pointer to the error file descriptors.
+ * @param[in]  aContext     A pointer to the mainloop context.
  *
  */
-void platformNetifProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, const fd_set *aErrorFdSet);
+void platformNetifProcess(const otSysMainloopContext *aContext);
 
 /**
  * This function initialize virtual time simulation.

--- a/src/posix/platform/ra_listener.cpp
+++ b/src/posix/platform/ra_listener.cpp
@@ -1,0 +1,216 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the router advertisement listener.
+ */
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
+
+#include "ra_listener.hpp"
+
+#include <arpa/inet.h>
+#include <unistd.h>
+
+#include <openthread/border_router.h>
+#include <openthread/ip6.h>
+
+#include "platform-posix.h"
+#include "common/code_utils.hpp"
+
+// ff02::01
+static const otIp6Address kRaMulticastAddress = {
+    {{0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}}};
+
+namespace ot {
+namespace Posix {
+
+enum
+{
+    kICMPv6RaType     = 134,
+    kOptionPrefixType = 3,
+};
+
+OT_TOOL_PACKED_BEGIN
+struct RaPrefixInformation
+{
+    uint8_t      mPrefixLength;
+    uint8_t      _rsv0 : 6;
+    uint8_t      mAutoConfiguration : 1;
+    uint8_t      mOnLink : 1;
+    uint32_t     mValidLifetime;
+    uint32_t     mPreferredLifetime;
+    uint32_t     _rsv1;
+    otIp6Address mPrefix;
+} OT_TOOL_PACKED_END;
+
+OT_TOOL_PACKED_BEGIN
+struct RaOptionHeader
+{
+    uint8_t mType;
+    uint8_t mLength;
+};
+
+OT_TOOL_PACKED_BEGIN
+struct RaOption
+{
+    RaOptionHeader      mHeader;
+    RaPrefixInformation mPrefixInformation;
+
+} OT_TOOL_PACKED_END;
+
+OT_TOOL_PACKED_BEGIN
+struct RaHeader
+{
+    uint8_t  mType;
+    uint8_t  mCode;
+    uint16_t mChecksum;
+    uint8_t  mHopLimit;
+    uint8_t  _rsv : 6;
+    uint8_t  mOtherConfiguration : 1;
+    uint8_t  mMananged : 1;
+    uint16_t mRouterLifetime;
+    uint32_t mReachableTime;
+    uint32_t mRetransTimer;
+} OT_TOOL_PACKED_END;
+
+RaListener::RaListener(void)
+    : mRaFd(0)
+{
+}
+
+otError RaListener::Init(unsigned int aInterfaceIndex)
+{
+    otError          error = OT_ERROR_NONE;
+    struct ipv6_mreq mreq6;
+
+    mRaFd                  = SocketWithCloseExec(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6, kSocketNonBlock);
+    mreq6.ipv6mr_interface = aInterfaceIndex;
+    memcpy(&mreq6.ipv6mr_multiaddr, kRaMulticastAddress.mFields.m8, sizeof(kRaMulticastAddress.mFields.m8));
+    VerifyOrExit(setsockopt(mRaFd, IPPROTO_IPV6, IPV6_JOIN_GROUP, &mreq6, sizeof(mreq6)) == 0, error = OT_ERROR_FAILED);
+
+exit:
+    otLogInfoPlat("RaListener::Init error=%s", otThreadErrorToString(error));
+    return error;
+}
+
+void RaListener::DeInit(void)
+{
+    if (mRaFd != 0)
+    {
+        close(mRaFd);
+        mRaFd = 0;
+    }
+}
+
+void RaListener::UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd)
+{
+    (void)aWriteFdSet;
+
+    FD_SET(mRaFd, &aReadFdSet);
+    FD_SET(mRaFd, &aErrorFdSet);
+
+    aMaxFd = (mRaFd > aMaxFd) ? mRaFd : aMaxFd;
+}
+
+otError RaListener::ProcessEvent(otInstance *  aInstance,
+                                 const fd_set &aReadFdSet,
+                                 const fd_set &aWriteFdSet,
+                                 const fd_set &aErrorFdSet)
+{
+    (void)aWriteFdSet;
+
+    const size_t kMaxRaEvent = 8192;
+    uint8_t      buffer[kMaxRaEvent];
+    ssize_t      bufferLen;
+    otError      error = OT_ERROR_NONE;
+    RaHeader *   header;
+    uint8_t *    current;
+
+    VerifyOrExit(FD_ISSET(mRaFd, &aReadFdSet), OT_NOOP);
+    VerifyOrExit(!FD_ISSET(mRaFd, &aErrorFdSet), error = OT_ERROR_FAILED);
+
+    bufferLen = recv(mRaFd, buffer, sizeof(buffer), 0);
+    VerifyOrExit(bufferLen > 0, OT_NOOP);
+    header  = reinterpret_cast<RaHeader *>(&buffer);
+    current = &buffer[0];
+    VerifyOrExit(static_cast<size_t>(bufferLen) >= sizeof(RaHeader), OT_NOOP);
+    VerifyOrExit(header->mType == kICMPv6RaType, OT_NOOP);
+    bufferLen -= sizeof(RaHeader);
+    current += sizeof(RaHeader);
+    while (bufferLen > 0)
+    {
+        RaOption *option = reinterpret_cast<RaOption *>(current);
+        size_t    optionSize;
+
+        VerifyOrExit(static_cast<size_t>(bufferLen) >= sizeof(RaOptionHeader), OT_NOOP);
+        optionSize = option->mHeader.mLength * 8; // Length in octaves
+        VerifyOrExit(static_cast<size_t>(bufferLen) >= optionSize, OT_NOOP);
+
+        if (option->mHeader.mType == kOptionPrefixType)
+        {
+            otBorderRouterConfig config;
+
+            VerifyOrExit(optionSize == sizeof(RaOptionHeader) + sizeof(RaPrefixInformation), OT_NOOP);
+            memset(&config, 0, sizeof(otBorderRouterConfig));
+            config.mSlaac          = option->mPrefixInformation.mAutoConfiguration;
+            config.mDhcp           = header->mMananged;
+            config.mPrefix.mLength = option->mPrefixInformation.mPrefixLength;
+            config.mConfigure      = header->mOtherConfiguration;
+            config.mOnMesh         = true; // Propogate this prefix to the network
+            memcpy(&config.mPrefix.mPrefix, &option->mPrefixInformation.mPrefix, sizeof(config.mPrefix.mPrefix));
+
+            VerifyOrExit(otBorderRouterAddOnMeshPrefix(aInstance, &config) == OT_ERROR_NONE, OT_NOOP);
+            VerifyOrExit(otBorderRouterRegister(aInstance) == OT_ERROR_NONE, OT_NOOP);
+            {
+                char addressString[INET6_ADDRSTRLEN + 1];
+
+                inet_ntop(AF_INET6, &config.mPrefix.mPrefix, addressString, sizeof(addressString));
+                otLogInfoPlat("Added Prefix %s(%d) slaac: %d, dhcp: %d, configure: %d", addressString,
+                              config.mPrefix.mLength, config.mSlaac, config.mDhcp, config.mConfigure);
+            }
+        }
+
+        bufferLen -= optionSize;
+        current += optionSize;
+    }
+
+exit:
+    return error;
+}
+
+RaListener::~RaListener()
+{
+    DeInit();
+}
+
+} // namespace Posix
+} // namespace ot
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE

--- a/src/posix/platform/ra_listener.cpp
+++ b/src/posix/platform/ra_listener.cpp
@@ -31,8 +31,6 @@
  *   This file implements the router advertisement listener.
  */
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
-
 #include "ra_listener.hpp"
 
 #include <arpa/inet.h>
@@ -44,6 +42,7 @@
 #include "platform-posix.h"
 #include "common/code_utils.hpp"
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 // ff02::01
 static const otIp6Address kRaMulticastAddress = {
     {{0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x01}}};

--- a/src/posix/platform/ra_listener.hpp
+++ b/src/posix/platform/ra_listener.hpp
@@ -53,8 +53,8 @@ namespace Posix {
 
 struct RouterEntry
 {
-    time_t               mPreferTimePoint;
-    time_t               mValidTimePoint;
+    uint32_t             mPreferTimePoint;
+    uint32_t             mValidTimePoint;
     otBorderRouterConfig mConfig;
     bool                 mOccupied = false;
 };
@@ -117,7 +117,7 @@ private:
 
     otError      UpdateRouterEntries(otInstance *aInstance);
     RouterEntry &EliminateEntry(void);
-    RouterEntry &GetAvailableRouterEntry(void);
+    RouterEntry &GetAvailableRouterEntry(const otIp6Address &aPrefix, uint8_t aLength);
 
     RouterEntry mRouterEntries[OPENTHREAD_POSIX_CONFIG_MAX_ROUTER_ENTRIES_COUNT];
 

--- a/src/posix/platform/ra_listener.hpp
+++ b/src/posix/platform/ra_listener.hpp
@@ -1,0 +1,119 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file contains the interface for router advertisement listener.
+ */
+
+#ifndef OPENTHREAD_POSIX_RA_LISTENER_HPP_
+#define OPENTHREAD_POSIX_RA_LISTENER_HPP_
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
+
+#include <sys/types.h>
+
+#include <openthread/error.h>
+#include <openthread/instance.h>
+
+namespace ot {
+namespace Posix {
+
+class RaListener
+{
+public:
+    /**
+     * This constructor is the same as the default constructor.
+     *
+     * Will not open the file descriptor, call @ref Init for initializing
+     *
+     */
+    RaListener(void);
+
+    /**
+     * This method initializes the listener.
+     *
+     * @param[in] aInterfaceIndex   The interface to listen on for router advertisement packets.
+     *
+     */
+    otError Init(unsigned int aInterfaceIndex);
+
+    /**
+     * This method deinitializes the listener.
+     *
+     * Will close the underlying file descriptor.
+     *
+     */
+    void DeInit(void);
+
+    /**
+     * This method updates the file descriptor sets with file descriptor used by the listener.
+     *
+     * @param[inout]  aReadFdSet   A reference to the read file descriptors.
+     * @param[inout]  aWriteFdSet  A reference to the write file descriptors.
+     * @param[inout]  aErrorFdSet  A reference to the error file descriptors.
+     * @param[inout]  aMaxFd       A reference to the max file descriptor.
+     * @param[inout]  aTimeout     A reference to the timeout.
+     *
+     */
+    void UpdateFdSet(fd_set &aReadFdSet, fd_set &aWriteFdSet, fd_set &aErrorFdSet, int &aMaxFd);
+
+    /**
+     * This method performs the I/O event processing.
+     *
+     * @param[in]   aInstance      The OpenThread instance object.
+     * @param[in]  aReadFdSet      A reference to the read file descriptors.
+     * @param[in]  aWriteFdSet     A reference to the write file descriptors.
+     * @param[in]  aErrorFdSet     A reference to the error file descriptors.
+     *
+     */
+    otError ProcessEvent(otInstance *  aInstance,
+                         const fd_set &aReadFdSet,
+                         const fd_set &aWriteFdSet,
+                         const fd_set &aErrorFdSet);
+
+    /**
+     * This destructor deinitializes the listener.
+     *
+     * Will close the underlying file descriptor if @ref DeInit is not explicitly closed.
+     *
+     */
+    ~RaListener(void);
+
+private:
+    RaListener(const RaListener &);
+    RaListener &operator=(const RaListener &);
+
+    int mRaFd;
+};
+
+} // namespace Posix
+} // namespace ot
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
+#endif // OPENTHREAD_POSIX_RA_LISTENER_HPP_

--- a/src/posix/platform/ra_listener.hpp
+++ b/src/posix/platform/ra_listener.hpp
@@ -36,7 +36,7 @@
 
 #include <sys/select.h>
 
-#include <openthread/config.h>
+#include <core/openthread-core-config.h>
 #include <openthread/error.h>
 #include <openthread/instance.h>
 

--- a/src/posix/platform/ra_listener.hpp
+++ b/src/posix/platform/ra_listener.hpp
@@ -34,12 +34,13 @@
 #ifndef OPENTHREAD_POSIX_RA_LISTENER_HPP_
 #define OPENTHREAD_POSIX_RA_LISTENER_HPP_
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
+#include <sys/select.h>
 
-#include <sys/types.h>
-
+#include <openthread/config.h>
 #include <openthread/error.h>
 #include <openthread/instance.h>
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
 namespace ot {
 namespace Posix {

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -127,8 +127,7 @@ void otSysMainloopUpdate(otInstance *aInstance, otSysMainloopContext *aMainloop)
     platformUdpUpdateFdSet(aInstance, &aMainloop->mReadFdSet, &aMainloop->mMaxFd);
 #endif
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
-    platformNetifUpdateFdSet(&aMainloop->mReadFdSet, &aMainloop->mWriteFdSet, &aMainloop->mErrorFdSet,
-                             &aMainloop->mMaxFd);
+    platformNetifUpdateFdSet(aMainloop);
 #endif
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
     virtualTimeUpdateFdSet(&aMainloop->mReadFdSet, &aMainloop->mWriteFdSet, &aMainloop->mErrorFdSet, &aMainloop->mMaxFd,
@@ -197,7 +196,7 @@ void otSysMainloopProcess(otInstance *aInstance, const otSysMainloopContext *aMa
     platformUartProcess(&aMainloop->mReadFdSet, &aMainloop->mWriteFdSet, &aMainloop->mErrorFdSet);
     platformAlarmProcess(aInstance);
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
-    platformNetifProcess(&aMainloop->mReadFdSet, &aMainloop->mWriteFdSet, &aMainloop->mErrorFdSet);
+    platformNetifProcess(aMainloop);
 #endif
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
     platformUdpProcess(aInstance, &aMainloop->mReadFdSet);

--- a/tests/scripts/misc/radvd_dhcp.conf.in
+++ b/tests/scripts/misc/radvd_dhcp.conf.in
@@ -6,6 +6,8 @@ interface WPAN {
         prefix 2001:db8:1:2::/64 { 
                 AdvOnLink on; 
                 AdvAutonomous off; 
+                AdvValidLifetime 20;
+                AdvPreferredLifetime 10;
         };
 };
 

--- a/tests/scripts/misc/radvd_dhcp.conf.in
+++ b/tests/scripts/misc/radvd_dhcp.conf.in
@@ -1,0 +1,12 @@
+interface WPAN { 
+        AdvSendAdvert on;
+        MinRtrAdvInterval 3; 
+        MaxRtrAdvInterval 10;
+        AdvManagedFlag on;
+        prefix 2001:db8:1:2::/64 { 
+                AdvOnLink on; 
+                AdvAutonomous off; 
+                AdvRouterAddr off; 
+        };
+};
+

--- a/tests/scripts/misc/radvd_dhcp.conf.in
+++ b/tests/scripts/misc/radvd_dhcp.conf.in
@@ -6,7 +6,6 @@ interface WPAN {
         prefix 2001:db8:1:2::/64 { 
                 AdvOnLink on; 
                 AdvAutonomous off; 
-                AdvRouterAddr off; 
         };
 };
 

--- a/tests/scripts/misc/radvd_slaac.conf.in
+++ b/tests/scripts/misc/radvd_slaac.conf.in
@@ -6,7 +6,6 @@ interface WPAN {
         prefix 2001:db8:1:2::/64 { 
                 AdvOnLink on; 
                 AdvAutonomous on; 
-                AdvRouterAddr on; 
         };
 };
 

--- a/tests/scripts/misc/radvd_slaac.conf.in
+++ b/tests/scripts/misc/radvd_slaac.conf.in
@@ -1,0 +1,12 @@
+interface WPAN { 
+        AdvSendAdvert on;
+        MinRtrAdvInterval 3; 
+        MaxRtrAdvInterval 10;
+        AdvManagedFlag off;
+        prefix 2001:db8:1:2::/64 { 
+                AdvOnLink on; 
+                AdvAutonomous on; 
+                AdvRouterAddr on; 
+        };
+};
+

--- a/tests/scripts/misc/radvd_slaac.conf.in
+++ b/tests/scripts/misc/radvd_slaac.conf.in
@@ -6,6 +6,8 @@ interface WPAN {
         prefix 2001:db8:1:2::/64 { 
                 AdvOnLink on; 
                 AdvAutonomous on; 
+                AdvValidLifetime 20;
+                AdvPreferredLifetime 10;
         };
 };
 


### PR DESCRIPTION
This change allows users to handle router advertisement from DHCP agent to the Thread network, enabling ISP SLAAC and DHCPv6_PD configuration.

In `wpantund`, we will add a prefix for any external addresses on the interface and ask users to statically config whether to treat the prefix as SLAAC or DHCP. This change can be viewed as an enhancement to the previous approach.

Fixes https://github.com/openthread/ot-br-posix/issues/470.