### PR TITLE
Fix Keil packed compilation error.

### DIFF
--- a/src/core/common/clearable.hpp
+++ b/src/core/common/clearable.hpp
@@ -38,6 +38,8 @@
 
 #include <string.h>
 
+#include <openthread/platform/toolchain.h>
+
 namespace ot {
 
 /**
@@ -53,7 +55,11 @@ template <typename Type> class Clearable
 {
 public:
     void Clear(void) { memset(reinterpret_cast<void *>(this), 0, sizeof(Type)); }
-};
+}
+#if defined(__CC_ARM)
+OT_TOOL_PACKED_END
+#endif
+    ;
 
 } // namespace ot
 

--- a/src/core/common/equatable.hpp
+++ b/src/core/common/equatable.hpp
@@ -38,6 +38,8 @@
 
 #include <string.h>
 
+#include <openthread/platform/toolchain.h>
+
 namespace ot {
 
 /**
@@ -73,7 +75,11 @@ public:
      *
      */
     bool operator!=(const Type &aOther) const { return !(*this == aOther); }
-};
+}
+#if defined(__CC_ARM)
+OT_TOOL_PACKED_END
+#endif
+    ;
 
 } // namespace ot
 


### PR DESCRIPTION
After the recent approach with Clearable and Equatable classes, there are some errors.
 
When building with Keil,  there are compilation errors like the example below:
`error:  #1308: Base class "ot::Equatable<ot::Mac::ExtAddress>" of __packed class "ot::Mac::ExtAddress" must be __packed
`
The error occurs if Clearable or Equatable is a base class for a packed class.
Keil requires that all base classes of a packed class have to be packed.

Below I presented ways to deal with that problem:

1. Make classes Clearable and Equatable packed.
After during so 2 types of errors in IAR compilation (Keil compilation is fixed) appear:

i) 
`no instance of overloaded function "ot::Ip6::NetifUnicastAddress::GetNext" matches the argument list and object (the object has type qualifiers that prevent a match)
            object type is: ot::Ip6::NetifUnicastAddress const __packed`

`...\src\core\net\netif.hpp(106) : Error[Pe167]: argument of type "ot::Ip6::NetifUnicastAddress __packed *" is incompatible with parameter of type "ot::Ip6::NetifUnicastAddress *"`

`...\src\core\net\netif.hpp(159) : Error[Pe513]: a value of type "ot::Ip6::NetifMulticastAddress __packed *" cannot be assigned to an entity of type "otNetifMulticastAddress const *"`

The solution is to make struct otNetifAddress and struct otNetifMulticastAddress from ip6.h packed.
Then error
 ` ...\src\ncp\ncp_base_mtd.cpp(1625): error:  #433: qualifiers dropped in binding reference of type "std::uint8_t &" to initializer of type "__packed std::uint8_t"`
 appers but it can be easily resolved by creating a local variable and passing it to `ReadUint8()`.

ii)
Several errors like that: `src\core\net\ip6_address.cpp(48) : Error[Pe147]: declaration is incompatible with "__interwork __softfp bool ot::Ip6::Address::IsUnspecified() const" (declared <SRCREF line=116 file="...\src\core\net\ip6_address.hpp">at line 116 of "...\src\core\net\ip6_address.hpp"</SRCREF>)`

I did not found a good solution to this.

2. Remove packed from all classes that inherit from Clearable or Equatable.

Doing so requires a lot of changes and I end up with two types of errors (with GCC compiler, did not check Keil or IAR):
i) 
`.../src/core/thread/network_data_tlvs.hpp:343:90: error: cast from 'uint8_t* {aka unsigned char*}' to 'ot::NetworkData::HasRouteEntry*' increases required alignment of target type [-Werror=cast-align]
         return reinterpret_cast<HasRouteEntry *>(GetValue() + (i * sizeof(HasRouteEntry)));`

Error occurs in every place where uint8_t pointer is casted to pointer of non-packed class. 
ii)
`.../src/core/thread/network_diagnostic_tlvs.hpp:695:22: error: ignoring packed attribute because of unpacked non-POD field 'ot::Mle::RouterIdSet ot::NetworkDiagnostic::RouteTlv::mRouterIdMask' [-Werror] `

A lot of changes is required to fix this, so I decided to go another way.

3. Do not make Clearable and Equatable classes packed for IAR.

This approach is implemented in this PR.