### PR TITLE
[bootstrap] add missing newlib on Ubuntu >= 20.04

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -48,7 +48,7 @@ install_packages_apt()
     elif [ "$PLATFORM" = "Ubuntu" ] && [ "$(echo "$RELEASE >= $UBUNTU2004" | bc)" -eq 1 ]; then
         echo "Ubuntu Release >= $UBUNTU2004"
         # no need to use ppa
-        sudo apt-get --no-install-recommends install -y gcc-arm-none-eabi gdb-multiarch
+        sudo apt-get --no-install-recommends install -y gcc-arm-none-eabi gdb-multiarch libnewlib-arm-none-eabi
     elif ! command -v arm-none-eabi-g++; then
         # add gcc-arm-embedded ppa
         sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y


### PR DESCRIPTION
I tried to build some nRF52840 examples on Ubuntu 20.04, but it failed with a `stdio.h: No such file or directory` error. It turns out `libnewlib-arm-none-eabi` is required and is a recommended dep of `gcc-arm-none-eabi`, but it was obviously not installed because of the `--no-install-recommends` flag.

This PR fixes this issue.