### PR TITLE
[posix] fix build errors on macOS

### DIFF
--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -182,7 +182,7 @@ static bool DoWrite(int aFile, const void *aBuffer, size_t aSize)
         else
         {
             aBuffer = reinterpret_cast<const uint8_t *>(aBuffer) + rval;
-            aSize -= rval;
+            aSize -= (size_t)rval;
         }
     }
 
@@ -316,7 +316,7 @@ int main(int argc, char *argv[])
 
                     if (buffer[i] == '\r' || buffer[i] == '\n')
                     {
-                        VerifyOrExit(DoWrite(STDOUT_FILENO, buffer + lineStart, i - lineStart + 1),
+                        VerifyOrExit(DoWrite(STDOUT_FILENO, buffer + lineStart, (size_t)(i - lineStart + 1)),
                                      ret = OT_EXIT_FAILURE);
                         lineStart = i + 1;
                     }
@@ -331,7 +331,7 @@ int main(int argc, char *argv[])
                 if (lineStart < rval && promptState != 1)
                 {
                     assert(promptState != 0 && promptState != 2);
-                    VerifyOrExit(DoWrite(STDOUT_FILENO, buffer + lineStart, rval - lineStart), ret = OT_EXIT_FAILURE);
+                    VerifyOrExit(DoWrite(STDOUT_FILENO, buffer + lineStart, (size_t)(rval - lineStart)), ret = OT_EXIT_FAILURE);
                 }
             }
         }

--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -182,7 +182,7 @@ static bool DoWrite(int aFile, const void *aBuffer, size_t aSize)
         else
         {
             aBuffer = reinterpret_cast<const uint8_t *>(aBuffer) + rval;
-            aSize -= (size_t)rval;
+            aSize -= static_cast<size_t>(rval);
         }
     }
 
@@ -316,7 +316,7 @@ int main(int argc, char *argv[])
 
                     if (buffer[i] == '\r' || buffer[i] == '\n')
                     {
-                        VerifyOrExit(DoWrite(STDOUT_FILENO, buffer + lineStart, (size_t)(i - lineStart + 1)),
+                        VerifyOrExit(DoWrite(STDOUT_FILENO, buffer + lineStart, static_cast<size_t>(i - lineStart + 1)),
                                      ret = OT_EXIT_FAILURE);
                         lineStart = i + 1;
                     }
@@ -331,7 +331,8 @@ int main(int argc, char *argv[])
                 if (lineStart < rval && promptState != 1)
                 {
                     assert(promptState != 0 && promptState != 2);
-                    VerifyOrExit(DoWrite(STDOUT_FILENO, buffer + lineStart, (size_t)(rval - lineStart)), ret = OT_EXIT_FAILURE);
+                    VerifyOrExit(DoWrite(STDOUT_FILENO, buffer + lineStart, static_cast<size_t>(rval - lineStart)),
+                                 ret = OT_EXIT_FAILURE);
                 }
             }
         }


### PR DESCRIPTION
This PR fixes 3 `implicit conversion changes signedness` errors, when trying to build the posix core in daemon mode on darwin.