### PR TITLE
[test] add expect tests for macfilter, childip, version

### DIFF
--- a/tests/scripts/expect/cli-childip.exp
+++ b/tests/scripts/expect/cli-childip.exp
@@ -31,119 +31,31 @@ source "tests/scripts/expect/_multinode.exp"
 
 set timeout 1
 setup_nodes
+
+set spawn_id $spawn_2
+send "ipaddr mleid\n"
+expect "ipaddr mleid"
+expect -re {(([0-9a-fA-F]{1,4}:){7,7}[0-9a-fA-F]{1,4})}
+set addr $expect_out(1,string)
+expect "Done"
+send "rloc16\n"
+expect "rloc16"
+expect -re {([0-9a-f]{4})}
+set rloc $expect_out(1,string)
+expect "Done"
+
 set spawn_id $spawn_1
-
-send "leaderdata\n"
-expect -re {Partition ID: \d+}
-expect -re {Weighting: \d+}
-expect -re {Data Version: \d+}
-expect -re {Stable Data Version: \d+}
-expect -re {Leader Router ID: \d+}
+send "childip\n"
+expect "$rloc: $addr"
 expect "Done"
-
-send "help\n"
+send "childip max 2\n"
 expect "Done"
-
-send "bufferinfo\n"
+send "childip max\n"
+expect "2"
 expect "Done"
-
-send "netdatashow\n"
-expect "Done"
-
-send "parent\n"
-expect "Done"
-
-send "delaytimermin 1\n"
-expect "Done"
-send "delaytimermin\n"
-expect "1"
-expect "Done"
-send "delaytimermin 1 2\n"
-send "counters mac 1\n"
+send "childip max something_invalid\n"
 expect "Error 7: InvalidArgs"
-
-send "ifconfig down\n"
-expect "Done"
-send "ifconfig\n"
-expect "down"
-expect "Done"
-send "ifconfig up\n"
-expect "Done"
-send "ifconfig\n"
-expect "up"
-expect "Done"
-
-send "ipaddr add ::\n"
-expect "Done"
-send "ipaddr del ::\n"
-expect "Done"
-
-send "leaderweight 1\n"
-expect "Done"
-send "leaderweight\n"
-expect "1"
-expect "Done"
-
-send "mode rsdn\n"
-expect "Done"
-send "mode\n"
-expect -re "(?=.*r)(?=.*s)(?=.*d)(?=.*n)"
-
-send "parent\n"
-expect "Done"
-
-send "singleton\n"
-expect -re "true|false"
-expect "Done"
-
-send "state\n"
-expect "disabled"
-expect "Done"
-
-send "txpower -10\n"
-expect "Done"
-send "txpower\n"
-expect -- "-10 dBm"
-expect "Done"
-
-send "thread version\n"
-expect "Done"
-
-send "version\n"
-expect "Done"
-
-send "joinerport 10001\n"
-expect "Done"
-send "joinerport\n"
-expect "10001"
-expect "Done"
-
-send "parentpriority 1\n"
-expect "Done"
-send "parentpriority\n"
-expect "1"
-expect "Done"
-
-send "pollperiod 100000\n"
-expect "Done"
-send "pollperiod\n"
-expect "100000"
-expect "Done"
-
-send "prefix add ::/64 low pdcrosn\n"
-expect "Done"
-send "prefix\n"
-expect "0:0:0:0::/64 pdcrosn low"
-expect "Done"
-
-send "preferrouterid 1\n"
-expect "Done"
-
-send "route add ::/64 s low\n"
-expect "Done"
-send "route\n"
-expect "0:0:0:0::/64 s low"
-send "route remove ::/64\n"
-expect "Done"
+send "childip something_invalid\n"
+expect "Error 35: InvalidCommand"
 
 dispose_nodes

--- a/tests/scripts/expect/cli-macfilter.exp
+++ b/tests/scripts/expect/cli-macfilter.exp
@@ -27,123 +27,121 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-source "tests/scripts/expect/_multinode.exp"
+source "tests/scripts/expect/_common.exp"
 
+spawn $env(OT_COMMAND) 1
 set timeout 1
-setup_nodes
-set spawn_id $spawn_1
+expect_after {
+    timeout { exit 1 }
+}
 
-send "leaderdata\n"
-expect -re {Partition ID: \d+}
-expect -re {Weighting: \d+}
-expect -re {Data Version: \d+}
-expect -re {Stable Data Version: \d+}
-expect -re {Leader Router ID: \d+}
+send "macfilter\n"
+expect "Address Mode: Disabled"
+expect "RssIn List:"
 expect "Done"
 
-send "help\n"
+send "macfilter addr add aabbccddeeff0011\n"
 expect "Done"
 
-send "bufferinfo\n"
+send "macfilter addr\n"
+expect "Disabled"
+expect "aabbccddeeff0011"
 expect "Done"
 
-send "netdatashow\n"
+send "macfilter addr whitelist\n"
 expect "Done"
 
-send "parent\n"
+send "macfilter addr\n"
+expect "Whitelist"
+expect "aabbccddeeff0011"
 expect "Done"
 
-send "delaytimermin 1\n"
-expect "Done"
-send "delaytimermin\n"
-expect "1"
-expect "Done"
-send "delaytimermin 1 2\n"
-send "counters mac 1\n"
-expect "Error 7: InvalidArgs"
-
-send "ifconfig down\n"
-expect "Done"
-send "ifconfig\n"
-expect "down"
-expect "Done"
-send "ifconfig up\n"
-expect "Done"
-send "ifconfig\n"
-expect "up"
+send "macfilter\n"
+expect "Address Mode: Whitelist"
+expect "aabbccddeeff0011"
+expect "RssIn List:"
 expect "Done"
 
-send "ipaddr add ::\n"
-expect "Done"
-send "ipaddr del ::\n"
+send "macfilter addr add 2233445566778899\n"
 expect "Done"
 
-send "leaderweight 1\n"
-expect "Done"
-send "leaderweight\n"
-expect "1"
+send "macfilter addr remove aabbccddeeff0011\n"
 expect "Done"
 
-send "mode rsdn\n"
-expect "Done"
-send "mode\n"
-expect -re "(?=.*r)(?=.*s)(?=.*d)(?=.*n)"
-
-send "parent\n"
+send "macfilter addr blacklist\n"
 expect "Done"
 
-send "singleton\n"
-expect -re "true|false"
+send "macfilter addr\n"
+expect "Blacklist"
+expect "2233445566778899"
 expect "Done"
 
-send "state\n"
-expect "disabled"
+send "macfilter\n"
+expect "Address Mode: Blacklist"
+expect "2233445566778899"
+expect "RssIn List:"
 expect "Done"
 
-send "txpower -10\n"
-expect "Done"
-send "txpower\n"
-expect -- "-10 dBm"
+send "macfilter addr clear\n"
 expect "Done"
 
-send "thread version\n"
+send "macfilter addr disable\n"
 expect "Done"
 
-send "version\n"
+send "macfilter addr\n"
+expect "Disabled"
 expect "Done"
 
-send "joinerport 10001\n"
-expect "Done"
-send "joinerport\n"
-expect "10001"
-expect "Done"
-
-send "parentpriority 1\n"
-expect "Done"
-send "parentpriority\n"
-expect "1"
+send "macfilter\n"
+expect "Address Mode: Disabled"
+expect "RssIn List:"
 expect "Done"
 
-send "pollperiod 100000\n"
-expect "Done"
-send "pollperiod\n"
-expect "100000"
+send "macfilter addr something_invalid\n"
+expect "Error 35: InvalidCommand"
+
+send "macfilter rss\n"
 expect "Done"
 
-send "prefix add ::/64 low pdcrosn\n"
-expect "Done"
-send "prefix\n"
-expect "0:0:0:0::/64 pdcrosn low"
+send "macfilter rss add-lqi * 2\n"
 expect "Done"
 
-send "preferrouterid 1\n"
+send "macfilter rss add-lqi aabbccddeeff0011 3\n"
 expect "Done"
 
-send "route add ::/64 s low\n"
-expect "Done"
-send "route\n"
-expect "0:0:0:0::/64 s low"
-send "route remove ::/64\n"
+send "macfilter rss\n"
+expect -re {aabbccddeeff0011 : rss -?\d+ \(lqi 3\)}
+expect -re {Default rss: -?\d+ \(lqi 2\)}
 expect "Done"
 
-dispose_nodes
+send "macfilter\n"
+expect "Address Mode: Disabled"
+expect "RssIn List:"
+expect -re {aabbccddeeff0011 : rss -?\d+ \(lqi 3\)}
+expect -re {Default rss : -?\d+ \(lqi 2\)}
+expect "Done"
+
+send "macfilter rss remove *\n"
+expect "Done"
+
+send "macfilter rss remove aabbccddeeff0011\n"
+expect "Done"
+
+send "macfilter rss add 2233445566778899 -70\n"
+expect "Done"
+
+send "macfilter rss add * -80\n"
+expect "Done"
+
+send "macfilter rss\n"
+expect -re {2233445566778899 : rss -70 \(lqi \d\)}
+expect -re {Default rss: -80 \(lqi \d\)}
+expect "Done"
+
+send "macfilter rss clear\n"
+expect "Done"
+
+send "macfilter rss something_invalid\n"
+expect "Error 35: InvalidCommand"
+
+dispose


### PR DESCRIPTION
This adds `expect` tests for 3 commands: `macfilter`, `childip`, and `version`