### PR TITLE
[size-report] retry multiple times

### DIFF
--- a/script/check-size
+++ b/script/check-size
@@ -156,7 +156,7 @@ size_nrf52840()
         reporter=markdown
     else
         reporter=./size-report
-        curl -s "${SIZE_REPORT_URL}/bash" >size-report
+        curl -s --retry 5 "${SIZE_REPORT_URL}/bash" >size-report
         chmod a+x size-report
         export OT_SHA_NEW OT_SHA_OLD
     fi


### PR DESCRIPTION
`size-report` failed frequently recently. 
This PR improves the stability of `size-report ` by retrying multiple times (with exponential backoffs by default).
This PR allows [Glitch](https://glitch.com/) to wake up the App if the [App went to sleep](https://glitch.com/help/restrictions/). 

We should also need to change the [bash](https://openthread-size-report.glitch.me/size-report/1354027/bash) script. @bukepo 

**It seems not working since `size-report` check failed still.**