### PR TITLE
[docker] build ot-daemon/ot-ctl in codelab_otsim

### DIFF
--- a/etc/docker/codelab_otsim/Dockerfile
+++ b/etc/docker/codelab_otsim/Dockerfile
@@ -37,3 +37,6 @@ RUN cd ~/src && \
     cd openthread && \
     ./bootstrap && \
     make -f examples/Makefile-simulation
+
+# Install OpenThread Daemon and ot-ctl
+RUN make -f src/posix/Makefile-posix DAEMON=1

--- a/etc/docker/codelab_otsim/Dockerfile
+++ b/etc/docker/codelab_otsim/Dockerfile
@@ -6,37 +6,19 @@ ENV DEBIAN_FRONTEND noninteractive
 # Install dependencies:
 RUN apt-get update -qq
 
-# Install packages needed for wpantund build and runtime:
-RUN apt-get --no-install-recommends install -y build-essential git make autoconf \
-                       autoconf-archive automake dbus libtool gcc \
-                       g++ gperf flex bison texinfo ncurses-dev \
-                       libexpat-dev python sed python-pip gawk \
-                       libreadline6-dev libdbus-1-dev \
-                       libboost-dev inetutils-ping
-
-RUN apt-get --no-install-recommends install -y --force-yes gcc-arm-none-eabi
-RUN pip install pexpect
-
-# Install wpantund:
-RUN mkdir -p ~/src && \
-    cd ~/src && \
-    git clone --recursive https://github.com/openthread/wpantund.git && \
-    cd wpantund && \
-    git checkout full/master && \
-    ./configure --sysconfdir=/etc && \
-    make && make install
-
-RUN mkdir -p /dev/net && mknod /dev/net/tun c 10 200 && chmod 600 /dev/net/tun
-
-# Restart dbus
-RUN service dbus restart
+# Install packages needed for build and runtime:
+RUN apt-get --no-install-recommends install -y git sudo software-properties-common \
+    ca-certificates \
+    && update-ca-certificates
 
 # Install OpenThread
-RUN cd ~/src && \
+RUN mkdir -p ~/src && \
+    cd ~/src && \
     git clone --recursive https://github.com/openthread/openthread.git && \
     cd openthread && \
+    ./script/bootstrap && \
     ./bootstrap && \
     make -f examples/Makefile-simulation
 
 # Install OpenThread Daemon and ot-ctl
-RUN make -f src/posix/Makefile-posix DAEMON=1
+RUN cd ~/src/openthread && make -f src/posix/Makefile-posix DAEMON=1


### PR DESCRIPTION
To support the updated Docker Simulation Codelab.