### PR TITLE
[network-data] only send ADDR_QRY.qry for on-mesh prefixes

### DIFF
--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -260,12 +260,25 @@ bool LeaderBase::IsOnMesh(const Ip6::Address &aAddress) const
 
     while ((prefix = FindNextMatchingPrefix(aAddress, prefix)) != nullptr)
     {
-        if (FindBorderRouter(*prefix) == nullptr)
+        // check both stable and temporary Border Router TLVs
+        for (int i = 0; i < 2; i++)
         {
-            continue;
-        }
+            const BorderRouterTlv *borderRouter = FindBorderRouter(*prefix, /* aStable */ (i == 0));
 
-        ExitNow(rval = true);
+            if (borderRouter == nullptr)
+            {
+                continue;
+            }
+
+            for (const BorderRouterEntry *entry = borderRouter->GetFirstEntry(); entry <= borderRouter->GetLastEntry();
+                 entry                          = entry->GetNext())
+            {
+                if (entry->IsOnMesh())
+                {
+                    ExitNow(rval = true);
+                }
+            }
+        }
     }
 
 exit:

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -138,6 +138,14 @@ exit:
     return;
 }
 
+bool Slaac::DoesConfigMatchNetifAddr(const NetworkData::OnMeshPrefixConfig &aConfig,
+                                     const Ip6::NetifUnicastAddress &       aAddr)
+{
+    return (((aConfig.mOnMesh && (aAddr.mPrefixLength == aConfig.mPrefix.mLength)) ||
+             (!aConfig.mOnMesh && (aAddr.mPrefixLength == 128))) &&
+            (aAddr.GetAddress().PrefixMatch(aConfig.mPrefix.mPrefix) >= aConfig.mPrefix.mLength));
+}
+
 void Slaac::Update(UpdateMode aMode)
 {
     NetworkData::Iterator           iterator;
@@ -165,16 +173,13 @@ void Slaac::Update(UpdateMode aMode)
 
                 while (Get<NetworkData::Leader>().GetNextOnMeshPrefix(iterator, config) == OT_ERROR_NONE)
                 {
-                    otIp6Prefix &prefix = config.mPrefix;
-
                     if (config.mDp)
                     {
                         // Skip domain prefix which is processed in MLE.
                         continue;
                     }
 
-                    if (config.mSlaac && !ShouldFilter(prefix) && (prefix.mLength == slaacAddr->mPrefixLength) &&
-                        (slaacAddr->GetAddress().PrefixMatch(prefix.mPrefix) >= prefix.mLength))
+                    if (config.mSlaac && !ShouldFilter(config.mPrefix) && DoesConfigMatchNetifAddr(config, *slaacAddr))
                     {
                         found = true;
                         break;
@@ -212,8 +217,7 @@ void Slaac::Update(UpdateMode aMode)
             for (const Ip6::NetifUnicastAddress *netifAddr = Get<ThreadNetif>().GetUnicastAddresses();
                  netifAddr != nullptr; netifAddr           = netifAddr->GetNext())
             {
-                if ((netifAddr->mPrefixLength == prefix.mLength) &&
-                    (netifAddr->GetAddress().PrefixMatch(prefix.mPrefix) >= prefix.mLength))
+                if (DoesConfigMatchNetifAddr(config, *netifAddr))
                 {
                     found = true;
                     break;
@@ -234,7 +238,7 @@ void Slaac::Update(UpdateMode aMode)
                     slaacAddr->Clear();
                     memcpy(&slaacAddr->mAddress, &prefix.mPrefix, BitVectorBytes(prefix.mLength));
 
-                    slaacAddr->mPrefixLength  = prefix.mLength;
+                    slaacAddr->mPrefixLength  = config.mOnMesh ? prefix.mLength : 128;
                     slaacAddr->mAddressOrigin = OT_ADDRESS_ORIGIN_SLAAC;
                     slaacAddr->mPreferred     = config.mPreferred;
                     slaacAddr->mValid         = true;

--- a/src/core/utils/slaac_address.hpp
+++ b/src/core/utils/slaac_address.hpp
@@ -39,6 +39,7 @@
 #include "common/locator.hpp"
 #include "common/notifier.hpp"
 #include "net/netif.hpp"
+#include "thread/network_data.hpp"
 
 namespace ot {
 namespace Utils {
@@ -163,6 +164,8 @@ private:
     void        GetIidSecretKey(IidSecretKey &aKey) const;
     static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
+    static bool DoesConfigMatchNetifAddr(const NetworkData::OnMeshPrefixConfig &aConfig,
+                                         const Ip6::NetifUnicastAddress &       aAddr);
 
     bool                     mEnabled;
     otIp6SlaacPrefixFilter   mFilter;

--- a/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
+++ b/tests/scripts/thread-cert/Cert_5_6_05_NetworkDataRegisterAfterAttachRouter.py
@@ -109,7 +109,7 @@ class Cert_5_6_5_NetworkDataRegisterAfterAttachRouter(thread_cert.TestCase):
             if addr[0:3] == '200':
                 self.assertTrue(self.nodes[LEADER].ping(addr))
 
-        self.nodes[ROUTER].add_prefix('2001:2:0:3::/64', 'pacs')
+        self.nodes[ROUTER].add_prefix('2001:2:0:3::/64', 'paos')
         self.nodes[ROUTER].register_netdata()
 
         # Set lowpan context of sniffer

--- a/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
+++ b/tests/scripts/thread-cert/Cert_5_6_06_NetworkDataExpiration.py
@@ -109,7 +109,7 @@ class Cert_5_6_6_NetworkDataExpiration(thread_cert.TestCase):
             if addr[0:3] == '200':
                 self.assertTrue(self.nodes[LEADER].ping(addr))
 
-        self.nodes[ROUTER].add_prefix('2001:2:0:3::/64', 'pacs')
+        self.nodes[ROUTER].add_prefix('2001:2:0:3::/64', 'paos')
         self.nodes[ROUTER].register_netdata()
 
         # Set lowpan context of sniffer

--- a/tests/scripts/thread-cert/test_on_mesh_prefix.py
+++ b/tests/scripts/thread-cert/test_on_mesh_prefix.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import unittest
+
+import config
+import thread_cert
+
+LEADER = 1
+ROUTER = 2
+ED1 = 3
+SED1 = 4
+
+MTDS = [ED1, SED1]
+
+
+class Test_OnMeshPrefix(thread_cert.TestCase):
+    TOPOLOGY = {
+        LEADER: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'whitelist': [ROUTER]
+        },
+        ROUTER: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_selection_jitter': 1,
+            'whitelist': [LEADER, ED1, SED1]
+        },
+        ED1: {
+            'is_mtd': True,
+            'mode': 'rsn',
+            'panid': 0xface,
+            'whitelist': [ROUTER]
+        },
+        SED1: {
+            'is_mtd': True,
+            'mode': 's',
+            'panid': 0xface,
+            'timeout': config.DEFAULT_CHILD_TIMEOUT,
+            'whitelist': [ROUTER]
+        },
+    }
+
+    def test(self):
+        self.nodes[LEADER].start()
+        self.simulator.go(4)
+        self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+
+        self.nodes[ROUTER].start()
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[ROUTER].get_state(), 'router')
+
+        self.nodes[ED1].start()
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[ED1].get_state(), 'child')
+
+        self.nodes[SED1].start()
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[SED1].get_state(), 'child')
+
+        self.nodes[ROUTER].add_prefix('2001:2:0:1::/64', 'paros')
+        self.nodes[ROUTER].add_prefix('2001:2:0:2::/64', 'paro')
+        self.nodes[ROUTER].register_netdata()
+
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(1, '2001:2:0:1::/64')
+        self.simulator.set_lowpan_context(2, '2001:2:0:2::/64')
+
+        self.simulator.go(10)
+
+        addrs = self.nodes[ED1].get_addrs()
+        self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))
+        self.assertTrue(any('2001:2:0:2' in addr[0:10] for addr in addrs))
+        for addr in addrs:
+            if addr[0:3] == '200':
+                self.assertTrue(self.nodes[LEADER].ping(addr))
+
+        addrs = self.nodes[SED1].get_addrs()
+        self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))
+        self.assertFalse(any('2001:2:0:2' in addr[0:10] for addr in addrs))
+        for addr in addrs:
+            if addr[0:3] == '200':
+                self.assertTrue(self.nodes[LEADER].ping(addr))
+
+        self.nodes[ROUTER].add_prefix('2002:2:0:3::/64', 'pars')
+        self.nodes[ROUTER].register_netdata()
+
+        # Set lowpan context of sniffer
+        self.simulator.set_lowpan_context(3, '2002:2:0:3::/64')
+
+        self.simulator.go(10)
+
+        addrs = self.nodes[ED1].get_addrs()
+        self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))
+        self.assertTrue(any('2001:2:0:2' in addr[0:10] for addr in addrs))
+        self.assertTrue(any('2002:2:0:3' in addr[0:10] for addr in addrs))
+        for addr in addrs:
+            if addr[0:4] == '2001':
+                self.assertTrue(self.nodes[LEADER].ping(addr))
+            elif addr[0:4] == '2002':
+                self.assertFalse(self.nodes[LEADER].ping(addr))
+
+        addrs = self.nodes[SED1].get_addrs()
+        self.assertTrue(any('2001:2:0:1' in addr[0:10] for addr in addrs))
+        self.assertFalse(any('2001:2:0:2' in addr[0:10] for addr in addrs))
+        self.assertTrue(any('2002:2:0:3' in addr[0:10] for addr in addrs))
+        for addr in addrs:
+            if addr[0:4] == '2001':
+                self.assertTrue(self.nodes[LEADER].ping(addr))
+            elif addr[0:4] == '2002':
+                self.assertFalse(self.nodes[LEADER].ping(addr))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR includes the following fixes.

- fix `NetworkData::Leader::IsOnMesh()` to check on-mesh flags.

- fix tests to specify on-mesh flag in prefix 3.

- fix SLAAC to set prefix length to /128 when prefix is not on mesh.

Resolves #5112 