### PR TITLE
[otns] allow build without JOINER=1

### DIFF
--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -103,10 +103,12 @@ void Otns::HandleNotifierEvents(Events aEvents)
         EmitStatus("parid=%x", Get<Mle::Mle>().GetLeaderData().GetPartitionId());
     }
 
+#if OPENTHREAD_CONFIG_JOINER_ENABLE
     if (aEvents.Contains(kEventJoinerStateChanged))
     {
         EmitStatus("joiner_state=%d", Get<MeshCoP::Joiner>().GetState());
     }
+#endif
 }
 
 void Otns::EmitNeighborChange(otNeighborTableEvent aEvent, Neighbor &aNeighbor)


### PR DESCRIPTION
This PR fixes build errors for `OTNS=1 JOINER=0`