### PR TITLE
[simulation] remove linux specific prctl

### DIFF
--- a/examples/platforms/simulation/uart.c
+++ b/examples/platforms/simulation/uart.c
@@ -44,13 +44,6 @@
 #include "utils/code_utils.h"
 
 #if OPENTHREAD_SIMULATION_VIRTUAL_TIME_UART == 0
-#ifdef __linux__
-#include <sys/prctl.h>
-int   posix_openpt(int oflag);
-int   grantpt(int fildes);
-int   unlockpt(int fd);
-char *ptsname(int fd);
-#endif // __linux__
 
 static uint8_t        s_receive_buffer[128];
 static const uint8_t *s_write_buffer;
@@ -82,12 +75,6 @@ otError otPlatUartEnable(void)
 {
     otError        error = OT_ERROR_NONE;
     struct termios termios;
-
-#ifdef __linux__
-    // Ensure we terminate this process if the
-    // parent process dies.
-    prctl(PR_SET_PDEATHSIG, SIGHUP);
-#endif
 
     s_in_fd  = dup(STDIN_FILENO);
     s_out_fd = dup(STDOUT_FILENO);


### PR DESCRIPTION
These code hasn't been used since we remove OPENTHREAD_TARGET_DEFINES in
examples/ in 2016.