### PR TITLE
[spinel] fix use of OT header file in spinel.c

### DIFF
--- a/src/lib/spinel/spinel.c
+++ b/src/lib/spinel/spinel.c
@@ -54,7 +54,7 @@
  */
 #include <stdio.h>
 #include <stdlib.h>
-#include "utils/wrap_string.h"
+#include <string.h>
 #endif // #ifndef SPINEL_PLATFORM_HEADER
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
`spinel.h` and `spinel.c` are soruce files that may be used by host
side drivers and therefore the souurce code itself should not use any
of OT header files. Spienl file provide `SPINEL_PLATFORM_HEADER` to
allow platform to add their own includes if they want to.

-----
The inclusion of `#include "utils/wrap_string.h"` was added from #4885 (I think by mistake). 