### PR TITLE
[mac-filter] misc enhancements

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (9)
+#define OPENTHREAD_API_VERSION (10)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -722,19 +722,11 @@ void otLinkSetMaxFrameRetriesIndirect(otInstance *aInstance, uint8_t aMaxFrameRe
 /**
  * This function gets the address mode of MAC filter.
  *
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
+ *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  *
  * @returns  the address mode.
- *
- * @sa otLinkFilterSetAddressMode
- * @sa otLinkFilterAddAddress
- * @sa otLinkFilterRemoveAddress
- * @sa otLinkFilterClearAddresses
- * @sa otLinkFilterGetNextAddress
- * @sa otLinkFilterAddRssIn
- * @sa otLinkFilterRemoveRssIn
- * @sa otLinkFilterClearRssIn
- * @sa otLinkFilterGetNextRssIn
  *
  */
 otMacFilterAddressMode otLinkFilterGetAddressMode(otInstance *aInstance);
@@ -742,45 +734,25 @@ otMacFilterAddressMode otLinkFilterGetAddressMode(otInstance *aInstance);
 /**
  * This function sets the address mode of MAC filter.
  *
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
+ *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  * @param[in]  aMode      The address mode to set.
  *
- * @retval OT_ERROR_NONE           Successfully set the address mode.
- * @retval OT_ERROR_INVALID_ARGS   @p aMode is not valid.
- *
- * @sa otLinkFilterGetAddressMode
- * @sa otLinkFilterAddAddress
- * @sa otLinkFilterRemoveAddress
- * @sa otLinkFilterClearAddresses
- * @sa otLinkFilterGetNextAddress
- * @sa otLinkFilterAddRssIn
- * @sa otLinkFilterRemoveRssIn
- * @sa otLinkFilterClearRssIn
- * @sa otLinkFilterGetNextRssIn
- *
  */
-otError otLinkFilterSetAddressMode(otInstance *aInstance, otMacFilterAddressMode aMode);
+void otLinkFilterSetAddressMode(otInstance *aInstance, otMacFilterAddressMode aMode);
 
 /**
  * This method adds an Extended Address to MAC filter.
  *
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
+ *
  * @param[in]  aInstance    A pointer to an OpenThread instance.
- * @param[in]  aExtAddress  A reference to the Extended Address.
+  * @param[in]  aExtAddress  A pointer to the Extended Address (MUST NOT be NULL).
  *
  * @retval OT_ERROR_NONE           Successfully added @p aExtAddress to MAC filter.
  * @retval OT_ERROR_ALREADY        If @p aExtAddress was already in MAC filter.
- * @retval OT_ERROR_INVALID_ARGS   If @p aExtAddress is NULL.
  * @retval OT_ERROR_NO_BUFS        No available entry exists.
- *
- * @sa otLinkFilterGetAddressMode
- * @sa otLinkFilterSetAddressMode
- * @sa otLinkFilterRemoveAddress
- * @sa otLinkFilterClearAddresses
- * @sa otLinkFilterGetNextAddress
- * @sa otLinkFilterAddRssIn
- * @sa otLinkFilterRemoveRssIn
- * @sa otLinkFilterClearRssIn
- * @sa otLinkFilterGetNextRssIn
  *
  */
 otError otLinkFilterAddAddress(otInstance *aInstance, const otExtAddress *aExtAddress);
@@ -788,22 +760,13 @@ otError otLinkFilterAddAddress(otInstance *aInstance, const otExtAddress *aExtAd
 /**
  * This method removes an Extended Address from MAC filter.
  *
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
+ *
  * @param[in]  aInstance    A pointer to an OpenThread instance.
- * @param[in]  aExtAddress  A reference to the Extended Address.
+ * @param[in]  aExtAddress  A pointer to the Extended Address (MUST NOT be NULL).
  *
  * @retval OT_ERROR_NONE           Successfully removed @p aExtAddress from MAC filter.
- * @retval OT_ERROR_INVALID_ARGS   If @p aExtAddress is NULL.
  * @retval OT_ERROR_NOT_FOUND      @p aExtAddress is not in MAC filter.
- *
- * @sa otLinkFilterGetAddressMode
- * @sa otLinkFilterSetAddressMode
- * @sa otLinkFilterAddAddress
- * @sa otLinkFilterClearAddresses
- * @sa otLinkFilterGetNextAddress
- * @sa otLinkFilterAddRssIn
- * @sa otLinkFilterRemoveRssIn
- * @sa otLinkFilterClearRssIn
- * @sa otLinkFilterGetNextRssIn
  *
  */
 otError otLinkFilterRemoveAddress(otInstance *aInstance, const otExtAddress *aExtAddress);
@@ -811,17 +774,9 @@ otError otLinkFilterRemoveAddress(otInstance *aInstance, const otExtAddress *aEx
 /**
  * This method clears all the Extended Addresses from MAC filter.
  *
- * @param[in]  aInstance  A pointer to an OpenThread instance.
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
  *
- * @sa otLinkFilterGetAddressMode
- * @sa otLinkFilterSetAddressMode
- * @sa otLinkFilterAddAddress
- * @sa otLinkFilterRemoveAddress
- * @sa otLinkFilterGetNextAddress
- * @sa otLinkFilterAddRssIn
- * @sa otLinkFilterRemoveRssIn
- * @sa otLinkFilterClearRssIn
- * @sa otLinkFilterGetNextRssIn
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
  *
  */
 void otLinkFilterClearAddresses(otInstance *aInstance);
@@ -829,119 +784,96 @@ void otLinkFilterClearAddresses(otInstance *aInstance);
 /**
  * This method gets an in-use address filter entry.
  *
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
+ *
  * @param[in]     aInstance  A pointer to an OpenThread instance.
  * @param[inout]  aIterator  A pointer to the MAC filter iterator context. To get the first in-use address filter entry,
- *                           it should be set to OT_MAC_FILTER_ITERATOR_INIT.
- * @param[out]    aEntry     A pointer to where the information is placed.
+ *                           it should be set to OT_MAC_FILTER_ITERATOR_INIT. MUST NOT be NULL.
+ * @param[out]    aEntry     A pointer to where the information is placed. MUST NOT be NULL.
  *
  * @retval OT_ERROR_NONE          Successfully retrieved an in-use address filter entry.
- * @retval OT_ERROR_INVALID_ARGS  If @p aIterator or @p aEntry is NULL.
  * @retval OT_ERROR_NOT_FOUND     No subsequent entry exists.
- *
- * @sa otLinkFilterGetAddressMode
- * @sa otLinkFilterSetAddressMode
- * @sa otLinkFilterAddAddress
- * @sa otLinkFilterRemoveAddress
- * @sa otLinkFilterClearAddresses
- * @sa otLinkFilterAddRssIn
- * @sa otLinkFilterRemoveRssIn
- * @sa otLinkFilterClearRssIn
- * @sa otLinkFilterGetNextRssIn
  *
  */
 otError otLinkFilterGetNextAddress(otInstance *aInstance, otMacFilterIterator *aIterator, otMacFilterEntry *aEntry);
 
 /**
- * This method sets the received signal strength (in dBm) for the messages from the Extended Address.
- * The default received signal strength for all received messages would be set if no Extended Address is specified.
+ * This method adds a fixed received signal strength (in dBm) entry for the messages from a given Extended Address in
+ * MAC Filter.
+ *
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
  *
  * @param[in]  aInstance    A pointer to an OpenThread instance.
- * @param[in]  aExtAddress  A pointer to the IEEE 802.15.4 Extended Address, or NULL to set the default received signal
- *                          strength.
- * @param[in]  aRss         The received signal strength (in dBm) to set.
+ * @param[in]  aExtAddress  A pointer to the IEEE 802.15.4 Extended Address. MUST NOT be NULL.
+ * @param[in]  aRss         A received signal strength (in dBm).
  *
- * @retval OT_ERROR_NONE           Successfully set @p aRss for @p aExtAddress or set the default @p aRss for all
- *                                 received messages if @p aExtAddress is NULL.
+ * @retval OT_ERROR_NONE           Successfully added an entry for @p aExtAddress and @p aRss.
  * @retval OT_ERROR_NO_BUFS        No available entry exists.
- *
- * @sa otLinkFilterGetAddressMode
- * @sa otLinkFilterSetAddressMode
- * @sa otLinkFilterAddAddress
- * @sa otLinkFilterRemoveAddress
- * @sa otLinkFilterClearAddresses
- * @sa otLinkFilterGetNextAddress
- * @sa otLinkFilterRemoveRssIn
- * @sa otLinkFilterClearRssIn
- * @sa otLinkFilterGetNextRssIn
  *
  */
 otError otLinkFilterAddRssIn(otInstance *aInstance, const otExtAddress *aExtAddress, int8_t aRss);
 
 /**
- * This method removes the received signal strength setting for the received messages from the Extended Address or
- * removes the default received signal strength setting if no Extended Address is specified.
+ * This method removes a MAC Filter entry for fixed received signal strength setting for a given Extended Address.
+ *
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
+ *
+ * No action is performed if there is no existing entry in Filter matching the given Extended Address.
  *
  * @param[in]  aInstance    A pointer to an OpenThread instance.
- * @param[in]  aExtAddress  A pointer to the IEEE 802.15.4 Extended Address, or NULL to reset the default received
- *                          signal strength.
- *
- * @retval OT_ERROR_NONE       Successfully removed received signal strength setting for @p aExtAddress or
- *                             removed the default received signal strength setting if @p aExtAddress is NULL.
- * @retval OT_ERROR_NOT_FOUND  @p aExtAddress is not in MAC filter if it is not NULL.
- *
- * @sa otLinkFilterGetAddressMode
- * @sa otLinkFilterSetAddressMode
- * @sa otLinkFilterAddAddress
- * @sa otLinkFilterRemoveAddress
- * @sa otLinkFilterClearAddresses
- * @sa otLinkFilterGetNextAddress
- * @sa otLinkFilterAddRssIn
- * @sa otLinkFilterClearRssIn
- * @sa otLinkFilterGetNextRssIn
+ * @param[in]  aExtAddress  A pointer to the IEEE 802.15.4 Extended Address. MUST NOT be NULL.
  *
  */
-otError otLinkFilterRemoveRssIn(otInstance *aInstance, const otExtAddress *aExtAddress);
+void otLinkFilterRemoveRssIn(otInstance *aInstance, const otExtAddress *aExtAddress);
 
 /**
- * This method clears all the received signal strength settings.
+ * This method sets the default received signal strength (in dBm) on MAC Filter.
+ *
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
+ *
+ * The default RSS value is used for all received frames from addresses for which there is no explicit RSS-IN entry
+ * in the Filter list (added using `otLinkFilterAddRssIn()`).
+ *
+ * @param[in]  aInstance    A pointer to an OpenThread instance.
+ * @param[in]  aRss         The default received signal strength (in dBm) to set.
+ *
+ */
+void otLinkFilterSetDefaultRssIn(otInstance *aInstance, int8_t aRss);
+
+/**
+ * This method clears any previously set default received signal strength (in dBm) on MAC Filter.
+ *
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
+ *
+ * @param[in]  aInstance    A pointer to an OpenThread instance.
+ *
+ */
+void otLinkFilterClearDefaultRssIn(otInstance *aInstance);
+
+/**
+ * This method clears all the received signal strength entries (including default RSS-in) on MAC Filter.
+ *
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.
  *
- * @sa otLinkFilterGetAddressMode
- * @sa otLinkFilterSetAddressMode
- * @sa otLinkFilterAddAddress
- * @sa otLinkFilterRemoveAddress
- * @sa otLinkFilterClearAddresses
- * @sa otLinkFilterGetNextAddress
- * @sa otLinkFilterAddRssIn
- * @sa otLinkFilterRemoveRssIn
- * @sa otLinkFilterGetNextRssIn
- *
  */
-void otLinkFilterClearRssIn(otInstance *aInstance);
+void otLinkFilterClearAllRssIn(otInstance *aInstance);
 
 /**
  * This method gets an in-use RssIn filter entry.
  *
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
+ *
  * @param[in]     aInstance  A pointer to an OpenThread instance.
- * @param[inout]  aIterator  A reference to the MAC filter iterator context. To get the first in-use RssIn Filter entry,
- *                           it should be set to OT_MAC_FILTER_ITERATOR_INIT.
- * @param[out]    aEntry     A reference to where the information is placed. The last entry would have the extended
+ * @param[inout]  aIterator  A pointer to the MAC filter iterator context. MUST NOT be NULL.
+ *                           To get the first entry, it should be set to OT_MAC_FILTER_ITERATOR_INIT.
+ * @param[out]    aEntry     A pointer to where the information is placed. The last entry would have the extended
  *                           address as all 0xff to indicate the default received signal strength if it was set.
+                             @p aEntry MUST NOT be NULL.
  *
- * @retval OT_ERROR_NONE          Successfully retrieved an in-use RssIn Filter entry.
- * @retval OT_ERROR_INVALID_ARGS  If @p aIterator or @p aEntry is NULL.
+ * @retval OT_ERROR_NONE          Successfully retrieved the next entry.
  * @retval OT_ERROR_NOT_FOUND     No subsequent entry exists.
- *
- * @sa otLinkFilterGetAddressMode
- * @sa otLinkFilterSetAddressMode
- * @sa otLinkFilterAddAddress
- * @sa otLinkFilterRemoveAddress
- * @sa otLinkFilterClearAddresses
- * @sa otLinkFilterGetNextAddress
- * @sa otLinkFilterAddRssIn
- * @sa otLinkFilterRemoveRssIn
- * @sa otLinkFilterClearRssIn
  *
  */
 otError otLinkFilterGetNextRssIn(otInstance *aInstance, otMacFilterIterator *aIterator, otMacFilterEntry *aEntry);

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -748,10 +748,9 @@ void otLinkFilterSetAddressMode(otInstance *aInstance, otMacFilterAddressMode aM
  * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
  *
  * @param[in]  aInstance    A pointer to an OpenThread instance.
-  * @param[in]  aExtAddress  A pointer to the Extended Address (MUST NOT be NULL).
+ * @param[in]  aExtAddress  A pointer to the Extended Address (MUST NOT be NULL).
  *
  * @retval OT_ERROR_NONE           Successfully added @p aExtAddress to MAC filter.
- * @retval OT_ERROR_ALREADY        If @p aExtAddress was already in MAC filter.
  * @retval OT_ERROR_NO_BUFS        No available entry exists.
  *
  */
@@ -762,14 +761,13 @@ otError otLinkFilterAddAddress(otInstance *aInstance, const otExtAddress *aExtAd
  *
  * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
  *
+ * No action is performed if there is no existing entry in Filter matching the given Extended Address.
+ *
  * @param[in]  aInstance    A pointer to an OpenThread instance.
  * @param[in]  aExtAddress  A pointer to the Extended Address (MUST NOT be NULL).
  *
- * @retval OT_ERROR_NONE           Successfully removed @p aExtAddress from MAC filter.
- * @retval OT_ERROR_NOT_FOUND      @p aExtAddress is not in MAC filter.
- *
  */
-otError otLinkFilterRemoveAddress(otInstance *aInstance, const otExtAddress *aExtAddress);
+void otLinkFilterRemoveAddress(otInstance *aInstance, const otExtAddress *aExtAddress);
 
 /**
  * This method clears all the Extended Addresses from MAC filter.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3791,7 +3791,7 @@ otError Interpreter::ProcessMacFilterAddress(uint8_t aArgsLength, char *aArgs[])
             VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
             VerifyOrExit(Hex2Bin(aArgs[1], extAddr.m8, OT_EXT_ADDRESS_SIZE) == OT_EXT_ADDRESS_SIZE,
                          error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = otLinkFilterRemoveAddress(mInstance, &extAddr));
+            otLinkFilterRemoveAddress(mInstance, &extAddr);
         }
         else if (strcmp(aArgs[0], "clear") == 0)
         {

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3755,17 +3755,17 @@ otError Interpreter::ProcessMacFilterAddress(uint8_t aArgsLength, char *aArgs[])
         if (strcmp(aArgs[0], "disable") == 0)
         {
             VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = otLinkFilterSetAddressMode(mInstance, OT_MAC_FILTER_ADDRESS_MODE_DISABLED));
+            otLinkFilterSetAddressMode(mInstance, OT_MAC_FILTER_ADDRESS_MODE_DISABLED);
         }
         else if (strcmp(aArgs[0], "whitelist") == 0)
         {
             VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = otLinkFilterSetAddressMode(mInstance, OT_MAC_FILTER_ADDRESS_MODE_WHITELIST));
+            otLinkFilterSetAddressMode(mInstance, OT_MAC_FILTER_ADDRESS_MODE_WHITELIST);
         }
         else if (strcmp(aArgs[0], "blacklist") == 0)
         {
             VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = otLinkFilterSetAddressMode(mInstance, OT_MAC_FILTER_ADDRESS_MODE_BLACKLIST));
+            otLinkFilterSetAddressMode(mInstance, OT_MAC_FILTER_ADDRESS_MODE_BLACKLIST);
         }
         else if (strcmp(aArgs[0], "add") == 0)
         {
@@ -3857,7 +3857,7 @@ otError Interpreter::ProcessMacFilterRss(uint8_t aArgsLength, char *aArgs[])
 
             if (strcmp(aArgs[1], "*") == 0)
             {
-                SuccessOrExit(error = otLinkFilterAddRssIn(mInstance, nullptr, rss));
+                otLinkFilterSetDefaultRssIn(mInstance, rss);
             }
             else
             {
@@ -3875,7 +3875,7 @@ otError Interpreter::ProcessMacFilterRss(uint8_t aArgsLength, char *aArgs[])
 
             if (strcmp(aArgs[1], "*") == 0)
             {
-                SuccessOrExit(error = otLinkFilterAddRssIn(mInstance, nullptr, rss));
+                otLinkFilterSetDefaultRssIn(mInstance, rss);
             }
             else
             {
@@ -3891,19 +3891,19 @@ otError Interpreter::ProcessMacFilterRss(uint8_t aArgsLength, char *aArgs[])
 
             if (strcmp(aArgs[1], "*") == 0)
             {
-                SuccessOrExit(error = otLinkFilterRemoveRssIn(mInstance, nullptr));
+                otLinkFilterClearDefaultRssIn(mInstance);
             }
             else
             {
                 VerifyOrExit(Hex2Bin(aArgs[1], extAddr.m8, OT_EXT_ADDRESS_SIZE) == OT_EXT_ADDRESS_SIZE,
                              error = OT_ERROR_INVALID_ARGS);
 
-                SuccessOrExit(error = otLinkFilterRemoveRssIn(mInstance, &extAddr));
+                otLinkFilterRemoveRssIn(mInstance, &extAddr);
             }
         }
         else if (strcmp(aArgs[0], "clear") == 0)
         {
-            otLinkFilterClearRssIn(mInstance);
+            otLinkFilterClearAllRssIn(mInstance);
         }
         else
         {

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -241,13 +241,13 @@ otError otLinkFilterAddAddress(otInstance *aInstance, const otExtAddress *aExtAd
     return instance.Get<Mac::Filter>().AddAddress(*static_cast<const Mac::ExtAddress *>(aExtAddress));
 }
 
-otError otLinkFilterRemoveAddress(otInstance *aInstance, const otExtAddress *aExtAddress)
+void otLinkFilterRemoveAddress(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
     OT_ASSERT(aExtAddress != nullptr);
 
-    return instance.Get<Mac::Filter>().RemoveAddress(*static_cast<const Mac::ExtAddress *>(aExtAddress));
+    instance.Get<Mac::Filter>().RemoveAddress(*static_cast<const Mac::ExtAddress *>(aExtAddress));
 }
 
 void otLinkFilterClearAddresses(otInstance *aInstance)

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -222,14 +222,14 @@ otMacFilterAddressMode otLinkFilterGetAddressMode(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Mac::Filter>().GetAddressMode();
+    return static_cast<otMacFilterAddressMode>(instance.Get<Mac::Filter>().GetMode());
 }
 
-otError otLinkFilterSetAddressMode(otInstance *aInstance, otMacFilterAddressMode aMode)
+void otLinkFilterSetAddressMode(otInstance *aInstance, otMacFilterAddressMode aMode)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Mac::Filter>().SetAddressMode(aMode);
+    instance.Get<Mac::Filter>().SetMode(static_cast<Mac::Filter::Mode>(aMode));
 }
 
 otError otLinkFilterAddAddress(otInstance *aInstance, const otExtAddress *aExtAddress)
@@ -270,21 +270,39 @@ otError otLinkFilterAddRssIn(otInstance *aInstance, const otExtAddress *aExtAddr
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Mac::Filter>().AddRssIn(static_cast<const Mac::ExtAddress *>(aExtAddress), aRss);
+    OT_ASSERT(aExtAddress != nullptr);
+
+    return instance.Get<Mac::Filter>().AddRssIn(*static_cast<const Mac::ExtAddress *>(aExtAddress), aRss);
 }
 
-otError otLinkFilterRemoveRssIn(otInstance *aInstance, const otExtAddress *aExtAddress)
+void otLinkFilterRemoveRssIn(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Mac::Filter>().RemoveRssIn(static_cast<const Mac::ExtAddress *>(aExtAddress));
+    OT_ASSERT(aExtAddress != nullptr);
+
+    instance.Get<Mac::Filter>().RemoveRssIn(*static_cast<const Mac::ExtAddress *>(aExtAddress));
 }
 
-void otLinkFilterClearRssIn(otInstance *aInstance)
+void otLinkFilterSetDefaultRssIn(otInstance *aInstance, int8_t aRss)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    instance.Get<Mac::Filter>().ClearRssIn();
+    instance.Get<Mac::Filter>().SetDefaultRssIn(aRss);
+}
+
+void otLinkFilterClearDefaultRssIn(otInstance *aInstance)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    instance.Get<Mac::Filter>().ClearDefaultRssIn();
+}
+
+void otLinkFilterClearAllRssIn(otInstance *aInstance)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    instance.Get<Mac::Filter>().ClearAllRssIn();
 }
 
 otError otLinkFilterGetNextRssIn(otInstance *aInstance, otMacFilterIterator *aIterator, otMacFilterEntry *aEntry)

--- a/src/core/mac/mac_filter.cpp
+++ b/src/core/mac/mac_filter.cpp
@@ -41,61 +41,46 @@ namespace ot {
 namespace Mac {
 
 Filter::Filter(void)
-    : mAddressMode(OT_MAC_FILTER_ADDRESS_MODE_DISABLED)
+    : mMode(kModeRssInOnly)
     , mDefaultRssIn(kFixedRssDisabled)
 {
-    for (FilterEntry *entry = &mFilterEntries[0]; entry < OT_ARRAY_END(mFilterEntries); entry++)
+    for (FilterEntry &entry : mFilterEntries)
     {
-        entry->mFiltered = false;
-        entry->mRssIn    = kFixedRssDisabled;
+        entry.mFiltered = false;
+        entry.mRssIn    = kFixedRssDisabled;
     }
 }
 
 Filter::FilterEntry *Filter::FindEntry(const ExtAddress &aExtAddress)
 {
-    FilterEntry *entry;
+    FilterEntry *rval = nullptr;
 
-    for (entry = &mFilterEntries[0]; entry < OT_ARRAY_END(mFilterEntries); entry++)
+    for (FilterEntry &entry : mFilterEntries)
     {
-        if (entry->IsInUse() && (aExtAddress == entry->mExtAddress))
+        if (entry.IsInUse() && (aExtAddress == entry.mExtAddress))
         {
-            ExitNow();
+            ExitNow(rval = &entry);
         }
     }
 
-    entry = nullptr;
-
 exit:
-    return entry;
+    return rval;
 }
 
 Filter::FilterEntry *Filter::FindAvailableEntry(void)
 {
-    FilterEntry *entry;
+    FilterEntry *rval = nullptr;
 
-    for (entry = &mFilterEntries[0]; entry < OT_ARRAY_END(mFilterEntries); entry++)
+    for (FilterEntry &entry : mFilterEntries)
     {
-        VerifyOrExit(entry->IsInUse(), OT_NOOP);
+        if (!entry.IsInUse())
+        {
+            ExitNow(rval = &entry);
+        }
     }
 
-    entry = nullptr;
-
 exit:
-    return entry;
-}
-
-otError Filter::SetAddressMode(otMacFilterAddressMode aMode)
-{
-    otError error = OT_ERROR_NONE;
-
-    VerifyOrExit(aMode == OT_MAC_FILTER_ADDRESS_MODE_DISABLED || aMode == OT_MAC_FILTER_ADDRESS_MODE_WHITELIST ||
-                     aMode == OT_MAC_FILTER_ADDRESS_MODE_BLACKLIST,
-                 error = OT_ERROR_INVALID_ARGS);
-
-    mAddressMode = aMode;
-
-exit:
-    return error;
+    return rval;
 }
 
 otError Filter::AddAddress(const ExtAddress &aExtAddress)
@@ -134,9 +119,9 @@ exit:
 
 void Filter::ClearAddresses(void)
 {
-    for (FilterEntry *entry = &mFilterEntries[0]; entry < OT_ARRAY_END(mFilterEntries); entry++)
+    for (FilterEntry &entry : mFilterEntries)
     {
-        entry->mFiltered = false;
+        entry.mFiltered = false;
     }
 }
 
@@ -161,22 +146,17 @@ otError Filter::GetNextAddress(Iterator &aIterator, Entry &aEntry) const
     return error;
 }
 
-otError Filter::AddRssIn(const ExtAddress *aExtAddress, int8_t aRss)
+otError Filter::AddRssIn(const ExtAddress &aExtAddress, int8_t aRss)
 {
     otError      error = OT_ERROR_NONE;
-    FilterEntry *entry;
-
-    // Set the default RssIn when aExtAddress is not given (nullptr)
-    VerifyOrExit(aExtAddress != nullptr, mDefaultRssIn = aRss);
-
-    entry = FindEntry(*aExtAddress);
+    FilterEntry *entry = FindEntry(aExtAddress);
 
     if (entry == nullptr)
     {
         entry = FindAvailableEntry();
         VerifyOrExit(entry != nullptr, error = OT_ERROR_NO_BUFS);
 
-        entry->mExtAddress = *aExtAddress;
+        entry->mExtAddress = aExtAddress;
     }
 
     entry->mRssIn = aRss;
@@ -185,27 +165,23 @@ exit:
     return error;
 }
 
-otError Filter::RemoveRssIn(const ExtAddress *aExtAddress)
+void Filter::RemoveRssIn(const ExtAddress &aExtAddress)
 {
-    otError      error = OT_ERROR_NONE;
-    FilterEntry *entry;
+    FilterEntry *entry = FindEntry(aExtAddress);
 
-    // If no aExtAddress is given, remove default RssIn
-    VerifyOrExit(aExtAddress != nullptr, mDefaultRssIn = kFixedRssDisabled);
+    VerifyOrExit(entry != nullptr, OT_NOOP);
 
-    entry = FindEntry(*aExtAddress);
-    VerifyOrExit(entry != nullptr, error = OT_ERROR_NOT_FOUND);
     entry->mRssIn = kFixedRssDisabled;
 
 exit:
-    return error;
+    return;
 }
 
-void Filter::ClearRssIn(void)
+void Filter::ClearAllRssIn(void)
 {
-    for (FilterEntry *entry = &mFilterEntries[0]; entry < OT_ARRAY_END(mFilterEntries); entry++)
+    for (FilterEntry &entry : mFilterEntries)
     {
-        entry->mRssIn = kFixedRssDisabled;
+        entry.mRssIn = kFixedRssDisabled;
     }
 
     mDefaultRssIn = kFixedRssDisabled;
@@ -246,17 +222,28 @@ otError Filter::Apply(const ExtAddress &aExtAddress, int8_t &aRss)
 {
     otError      error = OT_ERROR_NONE;
     FilterEntry *entry = FindEntry(aExtAddress);
+    bool         isInFilterList;
 
     // Use the default RssIn setting for all receiving messages first.
     aRss = mDefaultRssIn;
 
-    if (mAddressMode == OT_MAC_FILTER_ADDRESS_MODE_WHITELIST)
+    // In whitelist mode, entry must be present in the list, in
+    // blacklist mode it must not be present.
+
+    isInFilterList = (entry != nullptr) && entry->mFiltered;
+
+    switch (mMode)
     {
-        VerifyOrExit(entry != nullptr && entry->mFiltered, error = OT_ERROR_ADDRESS_FILTERED);
-    }
-    else if (mAddressMode == OT_MAC_FILTER_ADDRESS_MODE_BLACKLIST)
-    {
-        VerifyOrExit(entry == nullptr || !entry->mFiltered, error = OT_ERROR_ADDRESS_FILTERED);
+    case kModeRssInOnly:
+        break;
+
+    case kModeWhitelist:
+        VerifyOrExit(isInFilterList, error = OT_ERROR_ADDRESS_FILTERED);
+        break;
+
+    case kModeBlacklist:
+        VerifyOrExit(!isInFilterList, error = OT_ERROR_ADDRESS_FILTERED);
+        break;
     }
 
     if ((entry != nullptr) && (entry->mRssIn != kFixedRssDisabled))

--- a/src/core/mac/mac_filter.cpp
+++ b/src/core/mac/mac_filter.cpp
@@ -94,27 +94,20 @@ otError Filter::AddAddress(const ExtAddress &aExtAddress)
         entry->mExtAddress = aExtAddress;
     }
 
-    VerifyOrExit(!entry->mFiltered, error = OT_ERROR_ALREADY);
     entry->mFiltered = true;
 
 exit:
     return error;
 }
 
-otError Filter::RemoveAddress(const ExtAddress &aExtAddress)
+void Filter::RemoveAddress(const ExtAddress &aExtAddress)
 {
-    otError      error = OT_ERROR_NONE;
     FilterEntry *entry = FindEntry(aExtAddress);
 
-    if (entry == nullptr || !entry->mFiltered)
+    if (entry != nullptr)
     {
-        ExitNow(error = OT_ERROR_NOT_FOUND);
+        entry->mFiltered = false;
     }
-
-    entry->mFiltered = false;
-
-exit:
-    return error;
 }
 
 void Filter::ClearAddresses(void)

--- a/src/core/mac/mac_filter.hpp
+++ b/src/core/mac/mac_filter.hpp
@@ -77,14 +77,14 @@ public:
      * This enumeration type represents the MAC Filter mode.
      *
      */
-    enum Mode
+    enum Mode : uint8_t
     {
         kModeRssInOnly = OT_MAC_FILTER_ADDRESS_MODE_DISABLED,  ///< No address filtering. RSS-In update only.
         kModeWhitelist = OT_MAC_FILTER_ADDRESS_MODE_WHITELIST, ///< Enable whitelist address filter mode.
         kModeBlacklist = OT_MAC_FILTER_ADDRESS_MODE_BLACKLIST, ///< Enable blacklist address filter mode.
     };
 
-    enum
+    enum : int8_t
     {
         kFixedRssDisabled = OT_MAC_FILTER_FIXED_RSS_DISABLED, ///< Value to indicate no fixed RSS is set.
     };
@@ -117,7 +117,6 @@ public:
      * @param[in]  aExtAddress  A reference to the Extended Address.
      *
      * @retval OT_ERROR_NONE           Successfully added @p aExtAddress to the filter.
-     * @retval OT_ERROR_ALREADY        If @p aExtAddress was already in the Filter.
      * @retval OT_ERROR_NO_BUFS        No available entry exists.
      *
      */
@@ -126,13 +125,12 @@ public:
     /**
      * This method removes an Extended Address from the filter.
      *
-     * @param[in]  aExtAddress  A reference to the Extended Address.
+     * No action is performed if there is no existing entry in the filter list matching the given Extended Address.
      *
-     * @retval OT_ERROR_NONE           Successfully removed @p aExtAddress from the filter.
-     * @retval OT_ERROR_NOT_FOUND      @p aExtAddress is not in the filter.
+     * @param[in]  aExtAddress  A reference to the Extended Address to remove.
      *
      */
-    otError RemoveAddress(const ExtAddress &aExtAddress);
+    void RemoveAddress(const ExtAddress &aExtAddress);
 
     /**
      * This method clears all Extended Addresses from the filter.
@@ -159,7 +157,7 @@ public:
      * @param[in]  aExtAddress  An Extended Address
      * @param[in]  aRss         The received signal strength to set.
      *
-     * @retval OT_ERROR_NONE     Successfully set @p aRss for @p aExtAddress, or
+     * @retval OT_ERROR_NONE     Successfully set @p aRss for @p aExtAddress.
      * @retval OT_ERROR_NO_BUFS  No available entry exists.
      *
      */

--- a/src/core/mac/mac_filter.hpp
+++ b/src/core/mac/mac_filter.hpp
@@ -73,10 +73,20 @@ public:
      */
     typedef otMacFilterIterator Iterator;
 
+    /**
+     * This enumeration type represents the MAC Filter mode.
+     *
+     */
+    enum Mode
+    {
+        kModeRssInOnly = OT_MAC_FILTER_ADDRESS_MODE_DISABLED,  ///< No address filtering. RSS-In update only.
+        kModeWhitelist = OT_MAC_FILTER_ADDRESS_MODE_WHITELIST, ///< Enable whitelist address filter mode.
+        kModeBlacklist = OT_MAC_FILTER_ADDRESS_MODE_BLACKLIST, ///< Enable blacklist address filter mode.
+    };
+
     enum
     {
-        kMaxEntries       = OPENTHREAD_CONFIG_MAC_FILTER_SIZE, ///< The maximum number of filter entries.
-        kFixedRssDisabled = OT_MAC_FILTER_FIXED_RSS_DISABLED,  ///< Value to indicate no fixed RSS is set.
+        kFixedRssDisabled = OT_MAC_FILTER_FIXED_RSS_DISABLED, ///< Value to indicate no fixed RSS is set.
     };
 
     /**
@@ -86,23 +96,20 @@ public:
     Filter(void);
 
     /**
-     * This function gets the address mode of the filter.
+     * This method gets the MAC Filter mode.
      *
-     * @returns  the address mode.
+     * @returns  the Filter mode.
      *
      */
-    otMacFilterAddressMode GetAddressMode(void) const { return mAddressMode; }
+    Mode GetMode(void) const { return mMode; }
 
     /**
-     * This function sets the address mode of the filter.
+     * This method sets the address mode of the filter.
      *
-     * @param[in]  aMode  The address mode to set.
-     *
-     * @retval OT_ERROR_NONE           Successfully set the AddressFilter mode.
-     * @retval OT_ERROR_INVALID_ARGS   @p aMode is not valid address mode.
+     * @param[in]  aMode  The new Filter mode.
      *
      */
-    otError SetAddressMode(otMacFilterAddressMode aMode);
+    void SetMode(Mode aMode) { mMode = aMode; }
 
     /**
      * This method adds an Extended Address to filter.
@@ -147,39 +154,49 @@ public:
     otError GetNextAddress(Iterator &aIterator, Entry &aEntry) const;
 
     /**
-     * This method sets the received signal strength for the messages from the Extended Address.
-     * The default received signal strength for all received messages would be set if no Extended Address is specified.
+     * This method adds a fixed received signal strength entry for the messages from a given Extended Address.
      *
-     * @param[in]  aExtAddress  A pointer to the Extended Address, or nullptr to set the default received signal
-     * strength.
+     * @param[in]  aExtAddress  An Extended Address
      * @param[in]  aRss         The received signal strength to set.
      *
      * @retval OT_ERROR_NONE     Successfully set @p aRss for @p aExtAddress, or
-     *                           set the default @p aRss for all received messages if @p aExtAddress is nullptr.
      * @retval OT_ERROR_NO_BUFS  No available entry exists.
      *
      */
-    otError AddRssIn(const ExtAddress *aExtAddress, int8_t aRss);
+    otError AddRssIn(const ExtAddress &aExtAddress, int8_t aRss);
 
     /**
-     * This method removes the received signal strength setting for the received messages from the Extended Address,
-     * or removes the default received signal strength setting if no Extended Address is specified.
+     * This method removes a fixed received signal strength entry for a given Extended Address.
      *
-     * @param[in]  aExtAddress  A pointer to the Extended Address.
+     * No action is performed if there is no existing entry in the filter list matching the given Extended Address.
      *
-     * @retval OT_ERROR_NONE       Successfully removed the received signal strength setting for the received
-     *                             messages from @p aExtAddress or removed the default received signal strength
-     *                             setting if @p aExtAddress is nullptr.
-     * @retval OT_ERROR_NOT_FOUND  @p aExtAddress is not in the RssIn filter if it is not nullptr.
+     * @param[in]  aExtAddress   A Extended Address.
      *
      */
-    otError RemoveRssIn(const ExtAddress *aExtAddress);
+    void RemoveRssIn(const ExtAddress &aExtAddress);
 
     /**
-     * This method clears all the received signal strength settings.
+     * This method sets the default received signal strength.
+     *
+     * The default RSS value is used for all received frames from addresses for which there is no explicit RSS-IN entry
+     * in the Filter list (added using `AddRssIn()`).
+     *
+     * @param[in]  aRss  The default received signal strength to set.
      *
      */
-    void ClearRssIn(void);
+    void SetDefaultRssIn(int8_t aRss) { mDefaultRssIn = aRss; }
+
+    /**
+     * This method clears the default received signal strength.
+     *
+     */
+    void ClearDefaultRssIn(void) { mDefaultRssIn = kFixedRssDisabled; }
+
+    /**
+     * This method clears all the received signal strength settings (inlcuding the default RSS-In).
+     *
+     */
+    void ClearAllRssIn(void);
 
     /**
      * This method iterates through RssIn filter entry.
@@ -210,6 +227,11 @@ public:
     otError Apply(const ExtAddress &aExtAddress, int8_t &aRss);
 
 private:
+    enum
+    {
+        kMaxEntries = OPENTHREAD_CONFIG_MAC_FILTER_SIZE, // The maximum number of filter entries.
+    };
+
     struct FilterEntry
     {
         bool       mFiltered;   // Indicates whether or not this entry is filtered (whitelist/blacklist modes).
@@ -222,9 +244,9 @@ private:
     FilterEntry *FindAvailableEntry(void);
     FilterEntry *FindEntry(const ExtAddress &aExtAddress);
 
-    otMacFilterAddressMode mAddressMode;
-    int8_t                 mDefaultRssIn;
-    FilterEntry            mFilterEntries[kMaxEntries];
+    Mode        mMode;
+    int8_t      mDefaultRssIn;
+    FilterEntry mFilterEntries[kMaxEntries];
 };
 
 /**

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -2755,14 +2755,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_MAC_BLACKLIST>(void)
         SuccessOrExit(error = mDecoder.ReadEui64(extAddress));
         SuccessOrExit(error = mDecoder.CloseStruct());
 
-        error = otLinkFilterRemoveAddress(mInstance, extAddress);
-
-        if (error == OT_ERROR_ALREADY)
-        {
-            error = OT_ERROR_NONE;
-        }
-
-        SuccessOrExit(error);
+        otLinkFilterRemoveAddress(mInstance, extAddress);
     }
 
 exit:
@@ -3086,12 +3079,7 @@ template <> otError NcpBase::HandlePropertyRemove<SPINEL_PROP_MAC_WHITELIST>(voi
 
     SuccessOrExit(error = mDecoder.ReadEui64(extAddress));
 
-    error = otLinkFilterRemoveAddress(mInstance, extAddress);
-
-    if (error == OT_ERROR_NOT_FOUND)
-    {
-        error = OT_ERROR_NONE;
-    }
+    otLinkFilterRemoveAddress(mInstance, extAddress);
 
 exit:
     return error;
@@ -3104,12 +3092,7 @@ template <> otError NcpBase::HandlePropertyRemove<SPINEL_PROP_MAC_BLACKLIST>(voi
 
     SuccessOrExit(error = mDecoder.ReadEui64(extAddress));
 
-    error = otLinkFilterRemoveAddress(mInstance, extAddress);
-
-    if (error == OT_ERROR_NOT_FOUND)
-    {
-        error = OT_ERROR_NONE;
-    }
+    otLinkFilterRemoveAddress(mInstance, extAddress);
 
 exit:
     return error;


### PR DESCRIPTION
This commit contains some smaller enhancements in `Mac::Filter`:

- Use C++11 range-based `for` loop when iterating over filter entries
- Define `Filter:Mode` enum (mirror of `otMacFilterAddressMode`)
- Change `Filter::SetMode()` and `otLinkFilterSetAddressMode()` to
  return `void` (update its use from CLI/NCP code).
- Simplify `Filter::Apply()` implementation.
 - Add new separate public OT and internal APIs to set/clear default
    RSS-In (e.g., `SetDefaultRssIn()`/`ClearDefaultRssIn()`).
- Return no error (instead of `ALREADY`) from `Filter::AddAddress()`
   and its corresponding public `otLinkFilter` API when entry is already
   present in the list.
- Do not return `NOT_FOUND` error from `Filter::Remove{Address/RssIn}()`.
- Update public `otLinkFilter{API}` documentation.
- Update NCP and CLI code to adopt new `otLinkFilter` APIs.
