### PR TITLE
[otns] add default implementation for otPlatOtnsStatus

### DIFF
--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -1159,6 +1159,19 @@ extern "C" {
 #endif
 
 /**
+ * @def otLogOtns
+ *
+ * This method generates a log with level none for the Core region,
+ * and is specifically for OTNS visualization use.
+ *
+ * @param[in]  ...       Arguments for the format specification.
+ *
+ */
+#if (OPENTHREAD_MTD || OPENTHREAD_FTD) && OPENTHREAD_CONFIG_OTNS_ENABLE
+#define otLogOtns(...) _otLogFormatter(OT_LOG_LEVEL_NONE, OT_LOG_REGION_CORE, _OT_LEVEL_NONE_PREFIX __VA_ARGS__, NULL)
+#endif
+
+/**
  * @def otDumpCrit
  *
  * This method generates a memory dump with log level critical.

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -136,7 +136,7 @@ void Otns::EmitNeighborChange(otNeighborTableEvent aEvent, Neighbor &aNeighbor)
 
 OT_TOOL_WEAK void otPlatOtnsStatus(const char *aStatus)
 {
-    _otLogFormatter(OT_LOG_LEVEL_NONE, OT_LOG_REGION_CORE, "[OTNS] %s", aStatus, NULL);
+    otLogOtns("[OTNS] %s", aStatus);
 }
 
 #endif // (OPENTHREAD_MTD || OPENTHREAD_FTD) && OPENTHREAD_CONFIG_OTNS_ENABLE

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -38,6 +38,7 @@
 
 #include "common/debug.hpp"
 #include "common/locator-getters.hpp"
+#include "common/logging.hpp"
 
 namespace ot {
 namespace Utils {
@@ -132,5 +133,10 @@ void Otns::EmitNeighborChange(otNeighborTableEvent aEvent, Neighbor &aNeighbor)
 
 } // namespace Utils
 } // namespace ot
+
+OT_TOOL_WEAK void otPlatOtnsStatus(const char *aStatus)
+{
+    _otLogFormatter(OT_LOG_LEVEL_NONE, OT_LOG_REGION_CORE, "[OTNS] %s", aStatus, NULL);
+}
 
 #endif // (OPENTHREAD_MTD || OPENTHREAD_FTD) && OPENTHREAD_CONFIG_OTNS_ENABLE


### PR DESCRIPTION
This PR adds a default implementation for `otPlatOtnsStatus`, which emits OTNS status messages to log, so that `OTNS=1` could be used with real devices. This is required for the Silk-OTNS integration work, as Silk will pick up these messages and reroute them to OTNS for visualization purposes.