### PR TITLE
[github-actions] fix expects fail by chance

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -30,7 +30,10 @@
 proc wait_for {command expected} {
     set result 0
     for {set i 0} {$i < 20} {incr i} {
-        send "$command\n"
+        if {$command != ""} {
+            send "$command\n"
+        }
+
         expect {
             -re $expected {
                 set result 1

--- a/tests/scripts/expect/cli-channel.exp
+++ b/tests/scripts/expect/cli-channel.exp
@@ -30,7 +30,7 @@
 source "tests/scripts/expect/_common.exp"
 
 spawn $env(OT_COMMAND) 1
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/cli-child.exp
+++ b/tests/scripts/expect/cli-child.exp
@@ -29,7 +29,7 @@
 
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 1
+set timeout 3
 setup_nodes
 
 set spawn_id $spawn_2

--- a/tests/scripts/expect/cli-childip.exp
+++ b/tests/scripts/expect/cli-childip.exp
@@ -29,7 +29,7 @@
 
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 1
+set timeout 3
 setup_nodes
 
 set spawn_id $spawn_2

--- a/tests/scripts/expect/cli-coex.exp
+++ b/tests/scripts/expect/cli-coex.exp
@@ -30,7 +30,7 @@
 source "tests/scripts/expect/_common.exp"
 
 spawn $env(OT_COMMAND) 1
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/cli-counters.exp
+++ b/tests/scripts/expect/cli-counters.exp
@@ -28,7 +28,7 @@
 #
 
 spawn $env(OT_COMMAND) 1
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/cli-dataset.exp
+++ b/tests/scripts/expect/cli-dataset.exp
@@ -30,7 +30,7 @@
 source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 1
+set timeout 3
 setup_nodes
 
 set spawn_id $spawn_1

--- a/tests/scripts/expect/cli-extaddr.exp
+++ b/tests/scripts/expect/cli-extaddr.exp
@@ -28,7 +28,7 @@
 #
 
 spawn $env(OT_COMMAND) 1
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/cli-ipmaddr.exp
+++ b/tests/scripts/expect/cli-ipmaddr.exp
@@ -29,7 +29,7 @@
 
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 1
+set timeout 3
 setup_nodes
 
 set spawn_id $spawn_1

--- a/tests/scripts/expect/cli-log-level.exp
+++ b/tests/scripts/expect/cli-log-level.exp
@@ -28,7 +28,7 @@
 #
 
 spawn $env(OT_COMMAND) 1
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/cli-mac.exp
+++ b/tests/scripts/expect/cli-mac.exp
@@ -30,7 +30,7 @@
 source "tests/scripts/expect/_common.exp"
 
 spawn $env(OT_COMMAND) 1
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/cli-macfilter.exp
+++ b/tests/scripts/expect/cli-macfilter.exp
@@ -30,7 +30,7 @@
 source "tests/scripts/expect/_common.exp"
 
 spawn $env(OT_COMMAND) 1
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/cli-misc.exp
+++ b/tests/scripts/expect/cli-misc.exp
@@ -29,7 +29,7 @@
 
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 1
+set timeout 3
 setup_nodes
 set spawn_id $spawn_1
 

--- a/tests/scripts/expect/cli-neighbor.exp
+++ b/tests/scripts/expect/cli-neighbor.exp
@@ -29,7 +29,7 @@
 
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 1
+set timeout 3
 setup_nodes
 
 set spawn_id $spawn_2

--- a/tests/scripts/expect/cli-ping.exp
+++ b/tests/scripts/expect/cli-ping.exp
@@ -31,7 +31,7 @@ source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
 
-set timeout 1
+set timeout 3
 
 
 spawn $env(OT_COMMAND) 1

--- a/tests/scripts/expect/cli-promiscuous.exp
+++ b/tests/scripts/expect/cli-promiscuous.exp
@@ -31,7 +31,7 @@ source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
 
-set timeout 1
+set timeout 3
 
 
 spawn $env(OT_COMMAND) 1

--- a/tests/scripts/expect/cli-pskc.exp
+++ b/tests/scripts/expect/cli-pskc.exp
@@ -28,7 +28,7 @@
 #
 
 spawn $env(OT_COMMAND) 1
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/cli-router.exp
+++ b/tests/scripts/expect/cli-router.exp
@@ -30,7 +30,7 @@
 source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 1
+set timeout 3
 setup_nodes
 
 set spawn_id $spawn_1

--- a/tests/scripts/expect/cli-routereligible.exp
+++ b/tests/scripts/expect/cli-routereligible.exp
@@ -28,7 +28,7 @@
 #
 
 spawn $env(OT_COMMAND) 1
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/cli-scan-discover.exp
+++ b/tests/scripts/expect/cli-scan-discover.exp
@@ -30,7 +30,7 @@
 source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 1
+set timeout 3
 setup_nodes
 
 spawn $env(OT_COMMAND) 3

--- a/tests/scripts/expect/posix-diag-rcp.exp
+++ b/tests/scripts/expect/posix-diag-rcp.exp
@@ -28,7 +28,7 @@
 #
 
 spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=1"
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/posix-max-power-table.exp
+++ b/tests/scripts/expect/posix-max-power-table.exp
@@ -29,7 +29,7 @@
 
 # allows 11-25 and forbidden 26
 spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?max-power-table=11,12,13,14,15,16,17,18,19,20,21,22,23,24,-1,0x7f&forkpty-arg=1"
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }
@@ -43,7 +43,7 @@ send "\x04"
 expect eof
 # allows all channels by default
 spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=1"
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/posix-rcp.exp
+++ b/tests/scripts/expect/posix-rcp.exp
@@ -30,7 +30,7 @@
 source "tests/scripts/expect/_common.exp"
 
 spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=1"
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/posix-scan-tx-to-sleep.exp
+++ b/tests/scripts/expect/posix-scan-tx-to-sleep.exp
@@ -29,7 +29,7 @@
 
 source "tests/scripts/expect/_common.exp"
 
-set timeout 1
+set timeout 3
 
 spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=--sleep-to-tx 1"
 set node_1 $spawn_id

--- a/tests/scripts/expect/tun-dns-client.exp
+++ b/tests/scripts/expect/tun-dns-client.exp
@@ -30,7 +30,7 @@
 source "tests/scripts/expect/_common.exp"
 
 spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=1"
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }
@@ -44,7 +44,6 @@ expect "Done"
 wait_for "state" "leader"
 expect "Done"
 
-set timeout 2
 send "dns resolve ipv6.google.com ::1 53\n"
 expect "DNS response for ipv6.google.com"
 expect "Done"

--- a/tests/scripts/expect/tun-netif.exp
+++ b/tests/scripts/expect/tun-netif.exp
@@ -30,7 +30,7 @@
 source "tests/scripts/expect/_common.exp"
 
 spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=1"
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/tun-sntp.exp
+++ b/tests/scripts/expect/tun-sntp.exp
@@ -30,7 +30,7 @@
 source "tests/scripts/expect/_common.exp"
 
 spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=1"
-set timeout 1
+set timeout 3
 expect_after {
     timeout { exit 1 }
 }
@@ -44,7 +44,6 @@ expect "Done"
 wait_for "state" "leader"
 expect "Done"
 
-set timeout 2
 send "sntp query ::1 123\n"
 expect -re {SNTP response - Unix time: \d+ \(era: \d+\)}
 expect "Done"


### PR DESCRIPTION
This PR tries to reduce expects fails in GitHub actions:
- `wait_for` only sends command when it's not empty
- increases the default `expect` timeout from 1s to 3s.