### PR TITLE
[devsite] fix wrong description in Thread Primer (en)

### DIFF
--- a/doc/site/en/guides/thread-primer/index.md
+++ b/doc/site/en/guides/thread-primer/index.md
@@ -7,7 +7,7 @@
 <a href="http://threadgroup.org/">Thread<sup>®</sup></a> is an IPv6-based
 networking protocol designed for low-power Internet of Things devices in an IEEE
 802.15.4-2006 wireless mesh network, commonly called a Wireless Personal Area
-Network (WPAN). Thread is independent of other 802.15.4 mesh networking
+Network (WPAN). Thread is independent of other 802.15 mesh networking
 protocols, such a ZigBee, Z-Wave, and Bluetooth LE.
 
 Thread's primary features include:

--- a/doc/site/en/guides/thread-primer/ipv6-addressing.md
+++ b/doc/site/en/guides/thread-primer/ipv6-addressing.md
@@ -37,8 +37,8 @@ location in the network topology.
 All devices are assigned a Router ID and a Child ID. Each Router maintains a
 table of all their Children, the combination of which uniquely identifies a
 device within the topology.  For example, consider the highlighted nodes in the
-following topology, where the number on a Router (pentagon) is the Router ID,
-and the number on an End Device (circle) is the Child ID:
+following topology, where the number in a Router (pentagon) is the Router ID,
+and the number in an End Device (circle) is the Child ID:
 
 <figure>
 <a href="../images/ot-primer-rloc-topology_2x.png"><img src="../images/ot-primer-rloc-topology.png" srcset="../images/ot-primer-rloc-topology.png 1x, ../images/ot-primer-rloc-topology_2x.png 2x" border="0" width="600" alt="OT RLOC Topology" /></a>
@@ -215,12 +215,12 @@ Multicast is used to communicate information to multiple devices at once. In a
 Thread network, specific addresses are reserved for multicast use with different
 groups of devices, depending on the scope.
 
-IPv6 Address | Scope | Delivered to
----- | ---- | ----
-`ff02::1` | Link-Local | All FTDs and MEDs
-`ff02::2` | Link-Local | All FTDs
-`ff03::1` | Mesh-Local | All FTDs and MEDs
-`ff03::2` | Mesh-Local | All FTDs
+| IPv6 Address | Scope      | Delivered to      |
+| ------------ | ---------- | ----------------- |
+| `ff02::1`    | Link-Local | All FTDs and MEDs |
+| `ff02::2`    | Link-Local | All FTDs          |
+| `ff03::1`    | Mesh-Local | All FTDs and MEDs |
+| `ff03::2`    | Mesh-Local | All FTDs          |
 
 Key Point: A major difference between FTDs and MTDs are that FTDs subscribe to
 the `ff03::2` multicast address. MTDs do not.
@@ -250,14 +250,14 @@ obtain the RLOC.
 
 Thread defines the following ALOC16 values:
 
-ALOC16 | Type
----- | ----
-`0xfc00` | Leader
-`0xfc01` – `0xfc0f` | DHCPv6 Agent
-`0xfc10` – `0xfc2f` | Service
-`0xfc30` – `0xfc37` | Commissioner
-`0xfc40` – `0xfc4e` | Neighbor Discovery Agent
-`0xfc38` – `0xfc3f`<br>`0xfc4f` – `0xfcff` | Reserved
+| ALOC16                                     | Type                     |
+| ------------------------------------------ | ------------------------ |
+| `0xfc00`                                   | Leader                   |
+| `0xfc01` – `0xfc0f`                        | DHCPv6 Agent             |
+| `0xfc10` – `0xfc2f`                        | Service                  |
+| `0xfc30` – `0xfc37`                        | Commissioner             |
+| `0xfc40` – `0xfc4e`                        | Neighbor Discovery Agent |
+| `0xfc38` – `0xfc3f`<br>`0xfc4f` – `0xfcff` | Reserved                 |
 
 ## Recap
 


### PR DESCRIPTION
Fix some errors found in #5106 discussion. 

1. @Vyrastas 

> Yes you are correct. Can you change to:
"Thread is independent of other 802.15 mesh networking protocols, such a ZigBee, Z-Wave, and Bluetooth LE."

2. @librasungirl 

>  I think the text where the number on a Router (pentagon) is the Router ID, and the number on an End Device (circle) is the Child ID doesn't match the picture which demonstrates the RLOC16, but not Router ID or Child ID.
