### PR TITLE
[netif] misc enhancement

### DIFF
--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -180,7 +180,7 @@ void Dtls::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageI
         mPeerAddress.SetPeerPort(aMessageInfo.GetPeerPort());
         mPeerAddress.SetIsHostInterface(aMessageInfo.IsHostInterface());
 
-        if (Get<ThreadNetif>().IsUnicastAddress(aMessageInfo.GetSockAddr()))
+        if (Get<ThreadNetif>().HasUnicastAddress(aMessageInfo.GetSockAddr()))
         {
             mPeerAddress.SetSockAddr(aMessageInfo.GetSockAddr());
         }

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1206,7 +1206,7 @@ otError Ip6::HandleDatagram(Message &aMessage, Netif *aNetif, const void *aLinkM
     }
     else
     {
-        if (Get<ThreadNetif>().IsUnicastAddress(header.GetDestination()))
+        if (Get<ThreadNetif>().HasUnicastAddress(header.GetDestination()))
         {
             receive = true;
         }

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/clearable.hpp"
+#include "common/code_utils.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
@@ -187,15 +188,18 @@ public:
     void SetAddressCallback(otIp6AddressCallback aCallback, void *aCallbackContext);
 
     /**
-     * This method returns a pointer to the list of unicast addresses.
+     * This method returns a pointer to the head of the linked list of unicast addresses.
      *
-     * @returns A pointer to the list of unicast addresses.
+     * @returns A pointer to the head of the linked list of unicast addresses.
      *
      */
     const NetifUnicastAddress *GetUnicastAddresses(void) const { return mUnicastAddresses.GetHead(); }
 
     /**
      * This method adds a unicast address to the network interface.
+     *
+     * This method is intended for addresses internal to OpenThread. The @p aAddress instance is directly added in the
+     * unicast address linked list.
      *
      * @param[in]  aAddress  A reference to the unicast address.
      *
@@ -205,21 +209,56 @@ public:
     /**
      * This method removes a unicast address from the network interface.
      *
+     * This method is intended for addresses internal to OpenThread. The @p aAddress instance is removed from the
+     * unicast address linked list.
+     *
      * @param[in]  aAddress  A reference to the unicast address.
      *
      */
     void RemoveUnicastAddress(const NetifUnicastAddress &aAddress);
 
     /**
-     * This method indicates whether a unicast address is added to the network interface.
+     * This method indicates whether or not an address is assigned to the interface.
      *
      * @param[in]  aAddress  A reference to the unicast address.
+     *
+     * @retval TRUE   If @p aAddress is assigned to the network interface,
+     * @retval FALSE  If @p aAddress is not assigned to the network interface.
+     *
+     */
+    bool HasUnicastAddress(const Address &aAddress) const;
+
+    /**
+     * This method indicates whether or not a unicast address is assigned to the network interface.
+     *
+     * @param[in]  aAddress  A reference to the unicast address.
+     *
+     * @retval TRUE   If @p aAddress is assigned to the network interface,
+     * @retval FALSE  If @p aAddress is not assigned to the network interface.
      *
      */
     bool HasUnicastAddress(const NetifUnicastAddress &aAddress) const { return mUnicastAddresses.Contains(aAddress); }
 
     /**
+     * This method indicates whether a unicast address is an external or internal address.
+     *
+     * @param[in] aAddress  A reference to the unicast address.
+     *
+     * @retval TRUE   The address is an external address.
+     * @retval FALSE  The address is not an external address (it is an OpenThread internal address).
+     *
+     */
+    bool IsUnicastAddressExternal(const NetifUnicastAddress &aAddress) const
+    {
+        return (&mExtUnicastAddresses[0] <= &aAddress) && (&aAddress < OT_ARRAY_END(mExtUnicastAddresses));
+    }
+
+    /**
      * This method adds an external (to OpenThread) unicast address to the network interface.
+     *
+     * For external address, the @p aAddress instance is not directly used (i.e., it can be temporary). It is copied
+     * into a local entry (allocated from an internal pool) before being added in the unicast address linked list.
+     * The maximum number of external addresses is specified by `OPENTHREAD_CONFIG_IP6_MAX_EXT_UCAST_ADDRS`.
      *
      * @param[in]  aAddress  A reference to the unicast address.
      *
@@ -250,16 +289,6 @@ public:
     void RemoveAllExternalUnicastAddresses(void);
 
     /**
-     * This method indicates whether or not an address is assigned to this interface.
-     *
-     * @param[in]  aAddress  A reference to the unicast address.
-     *
-     * @returns TRUE if @p aAddress is assigned to this interface, FALSE otherwise.
-     *
-     */
-    bool IsUnicastAddress(const Address &aAddress) const;
-
-    /**
      * This method indicates whether or not the network interface is subscribed to a multicast address.
      *
      * @param[in]  aAddress  The multicast address to check.
@@ -285,15 +314,32 @@ public:
     void UnsubscribeAllRoutersMulticast(void);
 
     /**
-     * This method returns a pointer to the list of multicast addresses.
+     * This method returns a pointer to the head of the linked list of multicast addresses.
      *
-     * @returns A pointer to the list of multicast addresses.
+     * @returns A pointer to the head of the linked list of multicast addresses.
      *
      */
     const NetifMulticastAddress *GetMulticastAddresses(void) const { return mMulticastAddresses.GetHead(); }
 
     /**
+     * This method indicates whether a multicast address is an external or internal address.
+     *
+     * @param[in] aAddress  A reference to the multicast address.
+     *
+     * @retval TRUE   The address is an external address.
+     * @retval FALSE  The address is not an external address (it is an OpenThread internal address).
+     *
+     */
+    bool IsMulticastAddressExternal(const NetifMulticastAddress &aAddress) const
+    {
+        return (&mExtMulticastAddresses[0] <= &aAddress) && (&aAddress < OT_ARRAY_END(mExtMulticastAddresses));
+    }
+
+    /**
      * This method subscribes the network interface to a multicast address.
+     *
+     * This method is intended for addresses internal to OpenThread. The @p aAddress instance is directly added in the
+     * multicast address linked list.
      *
      * @param[in]  aAddress  A reference to the multicast address.
      *
@@ -303,27 +349,20 @@ public:
     /**
      * This method unsubscribes the network interface to a multicast address.
      *
+     * This method is intended for addresses internal to OpenThread. The @p aAddress instance is directly removed from
+     * the multicast address linked list.
+     *
      * @param[in]  aAddress  A reference to the multicast address.
      *
      */
     void UnsubscribeMulticast(const NetifMulticastAddress &aAddress);
 
     /**
-     * This method provides the next external multicast address that the network interface subscribed.
-     * It is used to iterate through the entries of the external multicast address table.
-     *
-     * @param[inout] aIterator A reference to the iterator context. To get the first
-     *                         external multicast address, it should be set to 0.
-     * @param[out]   aAddress  A reference where to place the external multicast address.
-     *
-     * @retval OT_ERROR_NONE       Successfully found the next external multicast address.
-     * @retval OT_ERROR_NOT_FOUND  No subsequent external multicast address.
-     *
-     */
-    otError GetNextExternalMulticast(uint8_t &aIterator, Address &aAddress) const;
-
-    /**
      * This method subscribes the network interface to the external (to OpenThread) multicast address.
+     *
+     * For external address, the @p aAddress instance is not directly used (i.e., it can be temporary). It is copied
+     * into a local entry (allocated from an internal pool) before being added in the multicast address linked list.
+     * The maximum number of external addresses is specified by `OPENTHREAD_CONFIG_IP6_MAX_EXT_MCAST_ADDRS`.
      *
      * @param[in]  aAddress  A reference to the multicast address.
      *
@@ -350,6 +389,7 @@ public:
     /**
      * This method unsubscribes the network interface from all previously added external (to OpenThread) multicast
      * addresses.
+     *
      */
     void UnsubscribeAllExternalMulticastAddresses(void);
 
@@ -358,6 +398,7 @@ public:
      *
      * @retval TRUE   If the multicast promiscuous mode is enabled.
      * @retval FALSE  If the multicast promiscuous mode is disabled.
+     *
      */
     bool IsMulticastPromiscuousEnabled(void) const { return mMulticastPromiscuous; }
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -800,7 +800,7 @@ void AddressResolver::HandleAddressQuery(Coap::Message &aMessage, const Ip6::Mes
     otLogInfoArp("Received address query from 0x%04x for target %s", aMessageInfo.GetPeerAddr().GetLocator(),
                  target.ToString().AsCString());
 
-    if (Get<ThreadNetif>().IsUnicastAddress(target))
+    if (Get<ThreadNetif>().HasUnicastAddress(target))
     {
         SendAddressQueryResponse(target, Get<Mle::MleRouter>().GetMeshLocal64().GetIid(), nullptr,
                                  aMessageInfo.GetPeerAddr());

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -131,7 +131,7 @@ otError DuaManager::SetFixedDuaInterfaceIdentifier(const Ip6::InterfaceIdentifie
     mFixedDuaInterfaceIdentifier = aIid;
     otLogInfoIp6("Set DUA IID: %s", mFixedDuaInterfaceIdentifier.ToString().AsCString());
 
-    if (Get<ThreadNetif>().IsUnicastAddress(GetDomainUnicastAddress()))
+    if (Get<ThreadNetif>().HasUnicastAddress(GetDomainUnicastAddress()))
     {
         Get<ThreadNetif>().RemoveUnicastAddress(mDomainUnicastAddress);
         mDomainUnicastAddress.GetAddress().SetIid(mFixedDuaInterfaceIdentifier);
@@ -148,7 +148,7 @@ void DuaManager::ClearFixedDuaInterfaceIdentifier(void)
     VerifyOrExit(IsFixedDuaInterfaceIdentifierSet(), OT_NOOP);
 
     if (GetDomainUnicastAddress().HasIid(mFixedDuaInterfaceIdentifier) &&
-        Get<ThreadNetif>().IsUnicastAddress(GetDomainUnicastAddress()))
+        Get<ThreadNetif>().HasUnicastAddress(GetDomainUnicastAddress()))
     {
         Get<ThreadNetif>().RemoveUnicastAddress(mDomainUnicastAddress);
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3901,7 +3901,7 @@ otError MleRouter::CheckReachability(uint16_t aMeshDest, Ip6::Header &aIp6Header
     if (aMeshDest == Get<Mac::Mac>().GetShortAddress())
     {
         // mesh destination is this device
-        if (Get<ThreadNetif>().IsUnicastAddress(aIp6Header.GetDestination()))
+        if (Get<ThreadNetif>().HasUnicastAddress(aIp6Header.GetDestination()))
         {
             // IPv6 destination is this device
             ExitNow();


### PR DESCRIPTION
This commit contains some smaller enhancements in netif:

- Add method to check if unicast/multicast address is external or
  internal (e.g., `IsUnicastAddressExternal`)
- Simplify iteration over (external) multicast addresses and remove
  `GetNextExternalMulticast()`.
- Use range-based `for` loop for iteration over external address
  arrays.
- Rename `IsUnicastAddress()` to `HasUnicastAddress()`.
- Clarify method documentation specially between internal and
  external addresses (how the passed-in address parameter is used,
  i.e., copied into another entry from an address pool for external
  vs. directly used for internal addresses).