### PR TITLE
[otns] fix simulation to use strong otPlatOtnsStatus definition

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -84,7 +84,7 @@ jobs:
     - name: Run OTNS Tests
       run: |
         git clone https://github.com/openthread/ot-ns.git --depth 1 --branch master ~/otns
-        export OTDIR=$PWD
+        export OT_DIR=$PWD
         cd ~/otns
         ./script/test py-unittests py-examples
     - name: Codecov

--- a/examples/platforms/utils/CMakeLists.txt
+++ b/examples/platforms/utils/CMakeLists.txt
@@ -30,6 +30,7 @@ add_library(openthread-platform-utils OBJECT
     debug_uart.c
     logging_rtt.c
     mac_frame.cpp
+    otns_utils.cpp
     settings_ram.c
     soft_source_match_table.c
 )

--- a/examples/platforms/utils/Makefile.am
+++ b/examples/platforms/utils/Makefile.am
@@ -44,6 +44,7 @@ libopenthread_platform_utils_a_SOURCES  = \
     logging_rtt.h                         \
     mac_frame.cpp                         \
     mac_frame.h                           \
+    otns_utils.cpp                        \
     settings.h                            \
     settings_ram.c                        \
     soft_source_match_table.c             \

--- a/examples/platforms/utils/otns_utils.cpp
+++ b/examples/platforms/utils/otns_utils.cpp
@@ -35,7 +35,7 @@
 
 /*
  * Implementation note:
- *   These are all "weak" so that a platform may if it chooses  override the instance.
+ *   These are all "weak" so that a platform may if it chooses to override the instance.
  */
 
 #if OPENTHREAD_CONFIG_OTNS_ENABLE

--- a/examples/platforms/utils/otns_utils.cpp
+++ b/examples/platforms/utils/otns_utils.cpp
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
+#include <openthread/platform/otns.h>
+#include <openthread/platform/toolchain.h>
+
+#include "common/logging.hpp"
+
+/*
+ * Implementation note:
+ *   These are all "weak" so that a platform may if it chooses  override the instance.
+ */
+
+#if OPENTHREAD_CONFIG_OTNS_ENABLE
+
+OT_TOOL_WEAK
+void otPlatOtnsStatus(const char *aStatus)
+{
+    otLogOtns("[OTNS] %s", aStatus);
+}
+
+#endif // OPENTHREAD_CONFIG_OTNS_ENABLE

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -1167,7 +1167,7 @@ extern "C" {
  * @param[in]  ...       Arguments for the format specification.
  *
  */
-#if (OPENTHREAD_MTD || OPENTHREAD_FTD) && OPENTHREAD_CONFIG_OTNS_ENABLE
+#if OPENTHREAD_CONFIG_OTNS_ENABLE
 #define otLogOtns(...) _otLogFormatter(OT_LOG_LEVEL_NONE, OT_LOG_REGION_CORE, _OT_LEVEL_NONE_PREFIX __VA_ARGS__, NULL)
 #endif
 

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -38,7 +38,6 @@
 
 #include "common/debug.hpp"
 #include "common/locator-getters.hpp"
-#include "common/logging.hpp"
 
 namespace ot {
 namespace Utils {
@@ -133,10 +132,5 @@ void Otns::EmitNeighborChange(otNeighborTableEvent aEvent, Neighbor &aNeighbor)
 
 } // namespace Utils
 } // namespace ot
-
-OT_TOOL_WEAK void otPlatOtnsStatus(const char *aStatus)
-{
-    otLogOtns("[OTNS] %s", aStatus);
-}
 
 #endif // (OPENTHREAD_MTD || OPENTHREAD_FTD) && OPENTHREAD_CONFIG_OTNS_ENABLE


### PR DESCRIPTION
This PR fixes #5170 

This PR also fixes the issue that OTNS tests failed to use openthread of the current PR, but used openthread master instead. 

@ctan-g could you verify if this fix works for Silk?