### PR TITLE
[test] print debug info when expect tests fail

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,4 @@ third_party/nlbuild-autotools/repo/third_party/autoconf/m4/ltsugar.m4
 third_party/nlbuild-autotools/repo/third_party/autoconf/m4/ltversion.m4
 third_party/nlbuild-autotools/repo/third_party/autoconf/m4/lt~obsolete.m4
 third_party/nlbuild-autotools/repo/third_party/autoconf/missing
+/tmp/

--- a/script/test
+++ b/script/test
@@ -239,6 +239,9 @@ do_expect()
             echo -e "${COLOR_FAIL}FAIL${COLOR_NONE} ${script}"
             exit "${exit_code}"
         }
+        if [[ ${VERBOSE} == 1 ]]; then
+            cat "${log_file}" >&2
+        fi
         echo -e "${COLOR_PASS}PASS${COLOR_NONE} ${script}"
     done < <(
         if [[ $# != 0 ]]; then

--- a/script/test
+++ b/script/test
@@ -219,13 +219,10 @@ do_expect()
         test_patterns=(-name 'cli-*.exp' -o -name 'simulation-*.exp')
     fi
 
-    local temp_dir
-    temp_dir=$(mktemp -d)
-    trap 'rm -r "$temp_dir"' EXIT
-
-    local log_file="${temp_dir}/log_expect"
+    local log_file="tmp/log_expect"
     while read -r script; do
         sudo rm -rf tmp
+        mkdir tmp
         {
             if [[ ${OT_NATIVE_IP} == 1 ]]; then
                 OT_COMMAND="${ot_command}" RCP_COMMAND="${rcp_command}" sudo -E expect -df "${script}" 2>"${log_file}"

--- a/script/test
+++ b/script/test
@@ -219,10 +219,12 @@ do_expect()
         test_patterns=(-name 'cli-*.exp' -o -name 'simulation-*.exp')
     fi
 
-    local temp_dir=$(mktemp -d)
+    local temp_dir
+    temp_dir=$(mktemp -d)
     trap 'rm -r "$temp_dir"' EXIT
 
-    local log_file="${temp_dir}/log_expect"
+    local log_file
+    log_file="${temp_dir}/log_expect"
     while read -r script; do
         sudo rm -rf tmp
         {

--- a/script/test
+++ b/script/test
@@ -223,8 +223,7 @@ do_expect()
     temp_dir=$(mktemp -d)
     trap 'rm -r "$temp_dir"' EXIT
 
-    local log_file
-    log_file="${temp_dir}/log_expect"
+    local log_file="${temp_dir}/log_expect"
     while read -r script; do
         sudo rm -rf tmp
         {

--- a/script/test
+++ b/script/test
@@ -219,16 +219,21 @@ do_expect()
         test_patterns=(-name 'cli-*.exp' -o -name 'simulation-*.exp')
     fi
 
+    local temp_dir=$(mktemp -d)
+    trap 'rm -r "$temp_dir"' EXIT
+
+    local log_file="${temp_dir}/log_expect"
     while read -r script; do
         sudo rm -rf tmp
         {
             if [[ ${OT_NATIVE_IP} == 1 ]]; then
-                OT_COMMAND="${ot_command}" RCP_COMMAND="${rcp_command}" sudo -E "${script}"
+                OT_COMMAND="${ot_command}" RCP_COMMAND="${rcp_command}" sudo -E expect -df "${script}" 2> "${log_file}"
             else
-                OT_COMMAND="${ot_command}" RCP_COMMAND="${rcp_command}" "${script}"
+                OT_COMMAND="${ot_command}" RCP_COMMAND="${rcp_command}" expect -df "${script}" 2> "${log_file}"
             fi
         } || {
             local exit_code=$?
+            cat "${log_file}" >&2
             echo -e "${COLOR_FAIL}FAIL${COLOR_NONE} ${script}"
             exit "${exit_code}"
         }

--- a/script/test
+++ b/script/test
@@ -227,9 +227,9 @@ do_expect()
         sudo rm -rf tmp
         {
             if [[ ${OT_NATIVE_IP} == 1 ]]; then
-                OT_COMMAND="${ot_command}" RCP_COMMAND="${rcp_command}" sudo -E expect -df "${script}" 2> "${log_file}"
+                OT_COMMAND="${ot_command}" RCP_COMMAND="${rcp_command}" sudo -E expect -df "${script}" 2>"${log_file}"
             else
-                OT_COMMAND="${ot_command}" RCP_COMMAND="${rcp_command}" expect -df "${script}" 2> "${log_file}"
+                OT_COMMAND="${ot_command}" RCP_COMMAND="${rcp_command}" expect -df "${script}" 2>"${log_file}"
             fi
         } || {
             local exit_code=$?


### PR DESCRIPTION
This stores debug logs from `expect` and prints them if a test fails to enable easier debugging.