### PR TITLE
[test] add external commissioner tests

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -221,7 +221,6 @@ jobs:
               -DCMAKE_CXX_STANDARD_REQUIRED=ON  \
               -DCMAKE_BUILD_TYPE=Release        \
               -DCMAKE_INSTALL_PREFIX=/usr/local \
-              -DOT_COMM_COVERAGE=ON             \
               -S . -B build
         cmake --build build
         sudo cmake --install build

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -227,7 +227,7 @@ jobs:
         sudo cmake --install build
     - name: Run
       run: |
-        export OPENTHREAD="$(pwd)"
+        export OT_COMM_OPENTHREAD="$(pwd)"
         cd /tmp/ot-commissioner/tests/integration
         ./bootstrap.sh
         ./run_tests.sh

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -204,7 +204,6 @@ jobs:
       uses: codecov/codecov-action@v1
 
   external-commissioner:
-    continue-on-error: true
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -211,7 +211,7 @@ jobs:
     - name: Bootstrap
       run: |
         sudo apt-get --no-install-recommends install -y ninja-build
-        git clone https://github.com/openthread/ot-commissioner.git /tmp/ot-commissioner
+        git clone https://github.com/openthread/ot-commissioner.git /tmp/ot-commissioner --depth 1 --branch master
     - name: Build
       run: |
         cd /tmp/ot-commissioner

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -203,6 +203,37 @@ jobs:
     - name: Codecov
       uses: codecov/codecov-action@v1
 
+  external-commissioner:
+    continue-on-error: true
+    runs-on: ubuntu-18.04
+    steps:
+    - uses: actions/checkout@v2
+    - name: Bootstrap
+      run: |
+        sudo apt-get --no-install-recommends install -y ninja-build
+        git clone https://github.com/openthread/ot-commissioner.git /tmp/ot-commissioner
+    - name: Build
+      run: |
+        cd /tmp/ot-commissioner
+        script/bootstrap.sh
+        cmake -GNinja                           \
+              -DCMAKE_CXX_STANDARD=11           \
+              -DCMAKE_CXX_STANDARD_REQUIRED=ON  \
+              -DCMAKE_BUILD_TYPE=Release        \
+              -DCMAKE_INSTALL_PREFIX=/usr/local \
+              -DOT_COMM_COVERAGE=ON             \
+              -S . -B build
+        cmake --build build
+        sudo cmake --install build
+    - name: Run
+      run: |
+        export OPENTHREAD="$(pwd)"
+        cd /tmp/ot-commissioner/tests/integration
+        ./bootstrap.sh
+        ./run_tests.sh
+    - name: Codecov
+      uses: codecov/codecov-action@v1
+
   multiple-instance:
     runs-on: ubuntu-18.04
     env:


### PR DESCRIPTION
This adds tests of `ot-commissioner` as part of GitHub Action workflows.
This PR depends on https://github.com/openthread/ot-commissioner/pull/123.