### PR TITLE
[dtls] explicitly configure ECJPAKE parameters

### DIFF
--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -56,6 +56,11 @@
 namespace ot {
 namespace MeshCoP {
 
+const mbedtls_ecp_group_id Dtls::sCurves[] = {MBEDTLS_ECP_DP_SECP256R1, MBEDTLS_ECP_DP_NONE};
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
+const int Dtls::sHashes[] = {MBEDTLS_MD_NONE};
+#endif
+
 Dtls::Dtls(Instance &aInstance, bool aLayerTwoSecurity)
     : InstanceLocator(aInstance)
     , mState(kStateClosed)
@@ -97,10 +102,6 @@ Dtls::Dtls(Instance &aInstance, bool aLayerTwoSecurity)
 #endif
 
     memset(mCipherSuites, 0, sizeof(mCipherSuites));
-    memset(mCurves, 0, sizeof(mCurves));
-#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
-    memset(mHashes, 0, sizeof(mHashes));
-#endif
     memset(mPsk, 0, sizeof(mPsk));
     memset(&mSsl, 0, sizeof(mSsl));
     memset(&mConf, 0, sizeof(mConf));
@@ -292,10 +293,9 @@ otError Dtls::Setup(bool aClient)
     mbedtls_ssl_conf_ciphersuites(&mConf, mCipherSuites);
     if (mCipherSuites[0] == MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8)
     {
-        OT_ASSERT(mCurves[1] == MBEDTLS_ECP_DP_NONE);
-        mbedtls_ssl_conf_curves(&mConf, mCurves);
+        mbedtls_ssl_conf_curves(&mConf, sCurves);
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
-        mbedtls_ssl_conf_sig_hashes(&mConf, mHashes);
+        mbedtls_ssl_conf_sig_hashes(&mConf, sHashes);
 #endif
     }
     mbedtls_ssl_conf_export_keys_cb(&mConf, HandleMbedtlsExportKeys, this);
@@ -451,11 +451,6 @@ otError Dtls::SetPsk(const uint8_t *aPsk, uint8_t aPskLength)
     mPskLength       = aPskLength;
     mCipherSuites[0] = MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8;
     mCipherSuites[1] = 0;
-    mCurves[0]       = MBEDTLS_ECP_DP_SECP256R1;
-    mCurves[1]       = MBEDTLS_ECP_DP_NONE;
-#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
-    mHashes[0] = MBEDTLS_MD_NONE;
-#endif
 
 exit:
     return error;

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -57,7 +57,7 @@ namespace ot {
 namespace MeshCoP {
 
 const mbedtls_ecp_group_id Dtls::sCurves[] = {MBEDTLS_ECP_DP_SECP256R1, MBEDTLS_ECP_DP_NONE};
-#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
+#ifdef MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED
 const int Dtls::sHashes[] = {MBEDTLS_MD_NONE};
 #endif
 

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -294,7 +294,7 @@ otError Dtls::Setup(bool aClient)
     if (mCipherSuites[0] == MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8)
     {
         mbedtls_ssl_conf_curves(&mConf, sCurves);
-#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
+#ifdef MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED
         mbedtls_ssl_conf_sig_hashes(&mConf, sHashes);
 #endif
     }

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -98,6 +98,9 @@ Dtls::Dtls(Instance &aInstance, bool aLayerTwoSecurity)
 
     memset(mCipherSuites, 0, sizeof(mCipherSuites));
     memset(mCurves, 0, sizeof(mCurves));
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
+    memset(mHashes, 0, sizeof(mHashes));
+#endif
     memset(mPsk, 0, sizeof(mPsk));
     memset(&mSsl, 0, sizeof(mSsl));
     memset(&mConf, 0, sizeof(mConf));
@@ -291,6 +294,9 @@ otError Dtls::Setup(bool aClient)
     {
         OT_ASSERT(mCurves[1] == MBEDTLS_ECP_DP_NONE);
         mbedtls_ssl_conf_curves(&mConf, mCurves);
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
+        mbedtls_ssl_conf_sig_hashes(&mConf, mHashes);
+#endif
     }
     mbedtls_ssl_conf_export_keys_cb(&mConf, HandleMbedtlsExportKeys, this);
     mbedtls_ssl_conf_handshake_timeout(&mConf, 8000, 60000);
@@ -447,6 +453,9 @@ otError Dtls::SetPsk(const uint8_t *aPsk, uint8_t aPskLength)
     mCipherSuites[1] = 0;
     mCurves[0]       = MBEDTLS_ECP_DP_SECP256R1;
     mCurves[1]       = MBEDTLS_ECP_DP_NONE;
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
+    mHashes[0] = MBEDTLS_MD_NONE;
+#endif
 
 exit:
     return error;

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -97,6 +97,7 @@ Dtls::Dtls(Instance &aInstance, bool aLayerTwoSecurity)
 #endif
 
     memset(mCipherSuites, 0, sizeof(mCipherSuites));
+    memset(mCurves, 0, sizeof(mCurves));
     memset(mPsk, 0, sizeof(mPsk));
     memset(&mSsl, 0, sizeof(mSsl));
     memset(&mConf, 0, sizeof(mConf));
@@ -286,6 +287,11 @@ otError Dtls::Setup(bool aClient)
 
     OT_ASSERT(mCipherSuites[1] == 0);
     mbedtls_ssl_conf_ciphersuites(&mConf, mCipherSuites);
+    if (mCipherSuites[0] == MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8)
+    {
+        OT_ASSERT(mCurves[1] == MBEDTLS_ECP_DP_NONE);
+        mbedtls_ssl_conf_curves(&mConf, mCurves);
+    }
     mbedtls_ssl_conf_export_keys_cb(&mConf, HandleMbedtlsExportKeys, this);
     mbedtls_ssl_conf_handshake_timeout(&mConf, 8000, 60000);
     mbedtls_ssl_conf_dbg(&mConf, HandleMbedtlsDebug, this);
@@ -439,6 +445,8 @@ otError Dtls::SetPsk(const uint8_t *aPsk, uint8_t aPskLength)
     mPskLength       = aPskLength;
     mCipherSuites[0] = MBEDTLS_TLS_ECJPAKE_WITH_AES_128_CCM_8;
     mCipherSuites[1] = 0;
+    mCurves[0]       = MBEDTLS_ECP_DP_SECP256R1;
+    mCurves[1]       = MBEDTLS_ECP_DP_NONE;
 
 exit:
     return error;

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -414,7 +414,7 @@ private:
     uint8_t mPskLength;
 
     static const mbedtls_ecp_group_id sCurves[];
-#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
+#ifdef MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED
     static const int sHashes[];
 #endif
 

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -413,6 +413,9 @@ private:
     uint8_t              mPsk[kPskMaxLength];
     uint8_t              mPskLength;
     mbedtls_ecp_group_id mCurves[2];
+#if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
+    int mHashes[1];
+#endif
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
 #ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -409,9 +409,10 @@ private:
 
     State mState;
 
-    int     mCipherSuites[2];
-    uint8_t mPsk[kPskMaxLength];
-    uint8_t mPskLength;
+    int                  mCipherSuites[2];
+    uint8_t              mPsk[kPskMaxLength];
+    uint8_t              mPskLength;
+    mbedtls_ecp_group_id mCurves[2];
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
 #ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -409,12 +409,13 @@ private:
 
     State mState;
 
-    int                  mCipherSuites[2];
-    uint8_t              mPsk[kPskMaxLength];
-    uint8_t              mPskLength;
-    mbedtls_ecp_group_id mCurves[2];
+    int     mCipherSuites[2];
+    uint8_t mPsk[kPskMaxLength];
+    uint8_t mPskLength;
+
+    static const mbedtls_ecp_group_id sCurves[];
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED)
-    int mHashes[1];
+    static const int sHashes[];
 #endif
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE


### PR DESCRIPTION
This PR uses the mbedtls API to explicitly configure DTLS to use only the `secp256r1` curve and no signature hash algorithms when using ECJPAKE cipher suite.

This fixes https://github.com/openthread/openthread/issues/5142