### PR TITLE
[pool] introducing a generic object pool class

### DIFF
--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -336,6 +336,7 @@ HEADERS_COMMON                             = \
     common/new.hpp                           \
     common/non_copyable.hpp                  \
     common/notifier.hpp                      \
+    common/pool.hpp                          \
     common/random.hpp                        \
     common/random_manager.hpp                \
     common/settings.hpp                      \

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -46,6 +46,7 @@
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
+#include "common/pool.hpp"
 #include "mac/mac_types.hpp"
 #include "thread/link_quality.hpp"
 
@@ -1254,9 +1255,8 @@ private:
     otError ReclaimBuffers(int aNumBuffers, Message::Priority aPriority);
 
 #if OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT == 0
-    uint16_t           mNumFreeBuffers;
-    Buffer             mBuffers[kNumBuffers];
-    LinkedList<Buffer> mFreeBuffers;
+    uint16_t                  mNumFreeBuffers;
+    Pool<Buffer, kNumBuffers> mBufferPool;
 #endif
 };
 

--- a/src/core/common/pool.hpp
+++ b/src/core/common/pool.hpp
@@ -1,0 +1,185 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for a generic object pool.
+ */
+
+#ifndef POOL_HPP_
+#define POOL_HPP_
+
+#include "openthread-core-config.h"
+
+#include "common/linked_list.hpp"
+#include "common/non_copyable.hpp"
+
+namespace ot {
+
+class Instance;
+
+/**
+ * @addtogroup core-pool
+ *
+ * @brief
+ *   This module includes definitions for OpenThread object pool.
+ *
+ * @{
+ *
+ */
+
+/**
+ * This template class represents an object pool.
+ *
+ * @tparam Type         The object type. Type should provide `GetNext() and `SetNext()` so that it can be added to a
+ *                      linked list.
+ * @tparam kPoolSize    Specifies the pool size (maximum number of objects in the pool).
+ *
+ */
+template <class Type, uint16_t kPoolSize> class Pool : private NonCopyable
+{
+public:
+    /**
+     * This constructor initializes the pool.
+     *
+     */
+    Pool(void)
+        : mFreeList()
+    {
+        for (Type &entry : mPool)
+        {
+            mFreeList.Push(entry);
+        }
+    }
+
+    /**
+     * This constructor initializes the pool.
+     *
+     * This constructor version requires the `Type` class to provide method `void Init(Instance &)` to initialize
+     * each `Type` entry object. This can be realized by the `Type` class inheriting from `InstaceLocatorInit()`.
+     *
+     * @param[in] aInstance   A reference to the OpenThread instance.
+     *
+     */
+    Pool(Instance &aInstance)
+        : mFreeList()
+    {
+        for (Type &entry : mPool)
+        {
+            entry.Init(aInstance);
+            mFreeList.Push(entry);
+        }
+    }
+
+    /**
+     * This method allocates a new object from the pool.
+     *
+     * @returns A pointer to the newly allocated object, or nullptr if all entries from the pool are already allocated.
+     *
+     */
+    Type *Allocate(void) { return mFreeList.Pop(); }
+
+    /**
+     * This method frees a previously allocated object.
+     *
+     * The @p aEntry MUST be an entry from the pool previously allocated using `Allocate()` method and not yet freed.
+     * An already freed entry MUST not be freed again.
+     *
+     * @param[in]  aEntry   The pool object entry to free.
+     *
+     */
+    void Free(Type &aEntry) { mFreeList.Push(aEntry); }
+
+    /**
+     * This method returns the pool size.
+     *
+     * @returns The pool size (maximum number of objects in the pool).
+     *
+     */
+    uint16_t GetSize(void) const { return kPoolSize; }
+
+    /**
+     * This method indicates whether or not a given `Type` object is from the pool.
+     *
+     * @param[in]  aObject   A reference to a `Type` object.
+     *
+     * @retval TRUE if @p aObject is from the pool.
+     * @retval FALSE if @p aObject is not from the pool.
+     *
+     */
+    bool IsPoolEntry(const Type &aObject) const { return (&mPool[0] <= &aObject) && (&aObject < OT_ARRAY_END(mPool)); }
+
+    /**
+     * This method returns the associated index of a given entry from the pool.
+     *
+     * The @p aEntry MUST be from the pool, otherwise the behavior of this method is undefined.
+     *
+     * @param[in] aEntry  A reference to an entry from the pool.
+     *
+     * @returns The associated index of @p aEntry.
+     *
+     */
+    uint16_t GetIndexOf(const Type &aEntry) const { return static_cast<uint16_t>(&aEntry - mPool); }
+
+    /**
+     * This method retrieves a pool entry at a given index.
+     *
+     * The @p aIndex MUST be from an earlier call to `GetIndexOf()`.
+     *
+     * @param[in] aIndex  An index.
+     *
+     * @returns A reference to entry at index @p aIndex.
+     *
+     */
+    Type &GetEntryAt(uint16_t aIndex) { return mPool[aIndex]; }
+
+    /**
+     * This method retrieves a pool entry at a given index.
+     *
+     * The @p aIndex MUST be from an earlier call to `GetIndexOf()`.
+     *
+     * @param[in] aIndex  An index.
+     *
+     * @returns A reference to entry at index @p aIndex.
+     *
+     */
+    const Type &GetEntryAt(uint16_t aIndex) const { return mPool[aIndex]; }
+
+private:
+    LinkedList<Type> mFreeList;
+    Type             mPool[kPoolSize];
+};
+
+/**
+ * @}
+ *
+ */
+
+} // namespace ot
+
+#endif // POOL_HPP_

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -103,11 +103,6 @@ public:
 
 private:
     bool Matches(const Address &aAddress) const { return GetAddress() == aAddress; }
-
-    // In an unused/available entry (i.e., entry not present in a linked
-    // list), the next pointer is set to point back to the entry itself.
-    bool IsInUse(void) const { return GetNext() != this; }
-    void MarkAsNotInUse(void) { SetNext(this); }
 };
 
 /**
@@ -159,11 +154,6 @@ public:
 
 private:
     bool Matches(const Address &aAddress) const { return GetAddress() == aAddress; }
-
-    // In an unused/available entry (i.e., entry not present in a linked
-    // list), the next pointer is set to point back to the entry itself.
-    bool IsInUse(void) const { return GetNext() != this; }
-    void MarkAsNotInUse(void) { mNext = this; }
 };
 
 /**
@@ -254,10 +244,7 @@ public:
      * @retval FALSE  The address is not an external address (it is an OpenThread internal address).
      *
      */
-    bool IsUnicastAddressExternal(const NetifUnicastAddress &aAddress) const
-    {
-        return (&mExtUnicastAddresses[0] <= &aAddress) && (&aAddress < OT_ARRAY_END(mExtUnicastAddresses));
-    }
+    bool IsUnicastAddressExternal(const NetifUnicastAddress &aAddress) const;
 
     /**
      * This method adds an external (to OpenThread) unicast address to the network interface.
@@ -336,10 +323,7 @@ public:
      * @retval FALSE  The address is not an external address (it is an OpenThread internal address).
      *
      */
-    bool IsMulticastAddressExternal(const NetifMulticastAddress &aAddress) const
-    {
-        return (&mExtMulticastAddresses[0] <= &aAddress) && (&aAddress < OT_ARRAY_END(mExtMulticastAddresses));
-    }
+    bool IsMulticastAddressExternal(const NetifMulticastAddress &aAddress) const;
 
     /**
      * This method subscribes the network interface to a multicast address.
@@ -446,8 +430,8 @@ private:
     otIp6AddressCallback mAddressCallback;
     void *               mAddressCallbackContext;
 
-    NetifUnicastAddress   mExtUnicastAddresses[OPENTHREAD_CONFIG_IP6_MAX_EXT_UCAST_ADDRS];
-    NetifMulticastAddress mExtMulticastAddresses[OPENTHREAD_CONFIG_IP6_MAX_EXT_MCAST_ADDRS];
+    Pool<NetifUnicastAddress, OPENTHREAD_CONFIG_IP6_MAX_EXT_UCAST_ADDRS>   mExtUnicastAddressPool;
+    Pool<NetifMulticastAddress, OPENTHREAD_CONFIG_IP6_MAX_EXT_MCAST_ADDRS> mExtMulticastAddressPool;
 
     static const otNetifMulticastAddress kRealmLocalAllMplForwardersMulticastAddress;
     static const otNetifMulticastAddress kLinkLocalAllNodesMulticastAddress;

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -250,7 +250,8 @@ private:
         } mInfo;
     };
 
-    typedef LinkedList<CacheEntry> CacheEntryList;
+    typedef Pool<CacheEntry, kCacheEntries> CacheEntryPool;
+    typedef LinkedList<CacheEntry>          CacheEntryList;
 
     enum EntryChange
     {
@@ -270,6 +271,8 @@ private:
         kReasonEvictingForNewEntry,
         kReasonRemovingEid,
     };
+
+    CacheEntryPool &GetCacheEntryPool(void) { return mCacheEntryPool; }
 
     void        Remove(Mac::ShortAddress aRloc16, bool aMatchRouterId);
     void        Remove(const Ip6::Address &aEid, Reason aReason);
@@ -317,12 +320,11 @@ private:
     Coap::Resource mAddressQuery;
     Coap::Resource mAddressNotification;
 
-    CacheEntry     mCacheEntries[kCacheEntries];
+    CacheEntryPool mCacheEntryPool;
     CacheEntryList mCachedList;
     CacheEntryList mSnoopedList;
     CacheEntryList mQueryList;
     CacheEntryList mQueryRetryList;
-    CacheEntryList mUnusedList;
 
     Ip6::IcmpHandler mIcmpHandler;
     TimerMilli       mTimer;

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -381,6 +381,28 @@ target_link_libraries(test-network-data
 
 add_test(NAME test-network-data COMMAND test-network-data)
 
+add_executable(test-pool
+    ${COMMON_SOURCES}
+    test_pool.cpp
+)
+
+target_include_directories(test-pool
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_options(test-pool
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
+target_link_libraries(test-pool
+    PRIVATE
+        ${COMMON_LIBS}
+)
+
+add_test(NAME test-pool COMMAND test-pool)
+
 add_executable(test-priority-queue
     ${COMMON_SOURCES}
     test_priority_queue.cpp
@@ -492,7 +514,7 @@ target_link_libraries(test-timer
 add_test(NAME test-timer COMMAND test-timer)
 
 set_target_properties(
-    test-aes test-child test-child-table test-flash test-heap test-hmac-sha256 test-ip6-address test-link-quality test-linked-list test-lowpan test-mac-frame test-message test-message-queue test-netif test-network-data test-priority-queue test-pskc test-steering-data test-string test-timer
+    test-aes test-child test-child-table test-flash test-heap test-hmac-sha256 test-ip6-address test-link-quality test-linked-list test-lowpan test-mac-frame test-message test-message-queue test-netif test-network-data test-pool test-priority-queue test-pskc test-steering-data test-string test-timer
     PROPERTIES
         C_STANDARD 99
         CXX_STANDARD 11

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -121,6 +121,7 @@ check_PROGRAMS                                                     += \
     test-message-queue                                                \
     test-netif                                                        \
     test-network-data                                                 \
+    test-pool                                                         \
     test-priority-queue                                               \
     test-pskc                                                         \
     test-steering-data                                                \
@@ -216,6 +217,9 @@ test_netif_SOURCES           = $(COMMON_SOURCES) test_netif.cpp
 
 test_network_data_LDADD      = $(COMMON_LDADD)
 test_network_data_SOURCES    = $(COMMON_SOURCES) test_network_data.cpp
+
+test_pool_LDADD              = $(COMMON_LDADD)
+test_pool_SOURCES            = $(COMMON_SOURCES) test_pool.cpp
 
 test_priority_queue_LDADD    = $(COMMON_LDADD)
 test_priority_queue_SOURCES  = $(COMMON_SOURCES) test_priority_queue.cpp

--- a/tests/unit/test_pool.cpp
+++ b/tests/unit/test_pool.cpp
@@ -1,0 +1,136 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_platform.h"
+
+#include <openthread/config.h>
+
+#include "common/instance.hpp"
+#include "common/pool.hpp"
+
+#include "test_util.h"
+
+struct EntryBase
+{
+    EntryBase *mNext;
+};
+
+struct Entry : public EntryBase, ot::LinkedListEntry<Entry>
+{
+public:
+    Entry(void)
+        : mInitWithInstance(false)
+    {
+    }
+
+    void Init(ot::Instance &) { mInitWithInstance = true; }
+
+    bool IsInitializedWithInstance(void) const { return mInitWithInstance; }
+
+private:
+    bool mInitWithInstance;
+};
+
+enum : uint16_t
+{
+    kPoolSize = 11,
+};
+
+typedef ot::Pool<Entry, kPoolSize> EntryPool;
+
+static Entry sNonPoolEntry;
+
+void VerifyEntry(EntryPool &aPool, const Entry &aEntry, bool aInitWithInstance)
+{
+    uint16_t         index;
+    const EntryPool &constPool = const_cast<const EntryPool &>(aPool);
+
+    VerifyOrQuit(aPool.IsPoolEntry(aEntry), "Pool::IsPoolEntry() failed");
+    VerifyOrQuit(!aPool.IsPoolEntry(sNonPoolEntry), "Pool::IsPoolEntry() succeeded for non-pool entry");
+
+    index = aPool.GetIndexOf(aEntry);
+    VerifyOrQuit(&aPool.GetEntryAt(index) == &aEntry, "Pool::GetEntryAt() failed");
+    VerifyOrQuit(&constPool.GetEntryAt(index) == &aEntry, "Pool::GetEntryAt() failed");
+
+    VerifyOrQuit(aEntry.IsInitializedWithInstance() == aInitWithInstance, "Pool did not correctly Init() entry");
+}
+
+void TestPool(EntryPool &aPool, bool aInitWithInstance)
+{
+    Entry *entries[kPoolSize];
+
+    VerifyOrQuit(aPool.GetSize() == kPoolSize, "Pool::GetSize() failed");
+
+    for (uint16_t i = 0; i < kPoolSize; i++)
+    {
+        entries[i] = aPool.Allocate();
+        VerifyOrQuit(entries[i] != nullptr, "Pool::Allocate() failed");
+
+        VerifyEntry(aPool, *entries[i], aInitWithInstance);
+    }
+
+    for (uint16_t numEntriesToFree = 1; numEntriesToFree <= kPoolSize; numEntriesToFree++)
+    {
+        VerifyOrQuit(aPool.Allocate() == nullptr, "Pool::Allocate() did not fail when all pool entries were allocated");
+
+        for (uint16_t i = 0; i < numEntriesToFree; i++)
+        {
+            VerifyEntry(aPool, *entries[i], aInitWithInstance);
+            aPool.Free(*entries[i]);
+        }
+
+        for (uint16_t i = 0; i < numEntriesToFree; i++)
+        {
+            entries[i] = aPool.Allocate();
+            VerifyOrQuit(entries[i] != nullptr, "Pool::Allocate() failed");
+
+            VerifyEntry(aPool, *entries[i], aInitWithInstance);
+        }
+    }
+
+    VerifyOrQuit(aPool.Allocate() == nullptr, "Pool::Allocate() did not fail when all pool entries were allocated");
+}
+
+void TestPool(void)
+{
+    ot::Instance *instance = testInitInstance();
+    EntryPool     pool1;
+    EntryPool     pool2(*instance);
+
+    TestPool(pool1, /* aInitWithInstance */ false);
+    TestPool(pool2, /* aInitWithInstance */ true);
+
+    testFreeInstance(instance);
+}
+
+int main(void)
+{
+    TestPool();
+    printf("All tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
This commit adds a template `Pool<Type, kPoolSize>` class representing
an object pool. `Message`, `Netif`, and `AddressResolver` classes are
respectively updated to use `Pool` for managing their buffer pool,
external unicast/multicast address pool, and address cache pool. This
commit also adds a unit test for the `Pool` class.