### PR TITLE
[ip6-address] update and use Ip6::InterfaceIdentifier class

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (12)
+#define OPENTHREAD_API_VERSION (13)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -66,7 +66,12 @@ extern "C" {
 OT_TOOL_PACKED_BEGIN
 struct otIp6InterfaceIdentifier
 {
-    uint8_t m8[OT_IP6_IID_SIZE]; ///< The Interface Identifier of an IPv6 address.
+    union OT_TOOL_PACKED_FIELD
+    {
+        uint8_t  m8[OT_IP6_IID_SIZE];                     ///< 8-bit fields
+        uint16_t m16[OT_IP6_IID_SIZE / sizeof(uint16_t)]; ///< 16-bit fields
+        uint32_t m32[OT_IP6_IID_SIZE / sizeof(uint32_t)]; ///< 32-bit fields
+    } mFields;                                            ///< The Interface Identifier accessor fields
 } OT_TOOL_PACKED_END;
 
 /**
@@ -74,6 +79,43 @@ struct otIp6InterfaceIdentifier
  *
  */
 typedef struct otIp6InterfaceIdentifier otIp6InterfaceIdentifier;
+
+/**
+ * @struct otIp6NetworkPrefix
+ *
+ * This structure represents the Network Prefix of an IPv6 address (most significant 64 bits of the address).
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+struct otIp6NetworkPrefix
+{
+    uint8_t m8[OT_IP6_PREFIX_SIZE]; ///< The Network Prefix.
+} OT_TOOL_PACKED_END;
+
+/**
+ * This structure represents the Network Prefix of an IPv6 address (most significant 64 bits of the address).
+ *
+ */
+typedef struct otIp6NetworkPrefix otIp6NetworkPrefix;
+
+/**
+ * @struct otIp6AddressComponents
+ *
+ * This structure represents the components of an IPv6 address.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+struct otIp6AddressComponents
+{
+    otIp6NetworkPrefix       mNetworkPrefix; ///< The Network Prefix (most significant 64 bits of the address)
+    otIp6InterfaceIdentifier mIid;           ///< The Interface Identifier (least significant 64 bits of the address)
+} OT_TOOL_PACKED_END;
+
+/**
+ * This structure represents the components of an IPv6 address.
+ *
+ */
+typedef struct otIp6AddressComponents otIp6AddressComponents;
 
 /**
  * @struct otIp6Address
@@ -86,10 +128,11 @@ struct otIp6Address
 {
     union OT_TOOL_PACKED_FIELD
     {
-        uint8_t  m8[OT_IP6_ADDRESS_SIZE];                     ///< 8-bit fields
-        uint16_t m16[OT_IP6_ADDRESS_SIZE / sizeof(uint16_t)]; ///< 16-bit fields
-        uint32_t m32[OT_IP6_ADDRESS_SIZE / sizeof(uint32_t)]; ///< 32-bit fields
-    } mFields;                                                ///< IPv6 accessor fields
+        uint8_t                m8[OT_IP6_ADDRESS_SIZE];                     ///< 8-bit fields
+        uint16_t               m16[OT_IP6_ADDRESS_SIZE / sizeof(uint16_t)]; ///< 16-bit fields
+        uint32_t               m32[OT_IP6_ADDRESS_SIZE / sizeof(uint32_t)]; ///< 32-bit fields
+        otIp6AddressComponents mComponents;                                 ///< IPv6 address components
+    } mFields;                                                              ///< IPv6 accessor fields
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -627,7 +627,7 @@ void Interpreter::ProcessDua(uint8_t aArgsLength, char *aArgs[])
 
         if (iid != nullptr)
         {
-            OutputBytes(iid->m8, sizeof(otIp6InterfaceIdentifier));
+            OutputBytes(iid->mFields.m8, sizeof(otIp6InterfaceIdentifier));
             mServer->OutputFormat("\r\n");
         }
         break;
@@ -641,7 +641,7 @@ void Interpreter::ProcessDua(uint8_t aArgsLength, char *aArgs[])
         {
             otIp6InterfaceIdentifier iid;
 
-            VerifyOrExit(Hex2Bin(aArgs[1], iid.m8, sizeof(otIp6InterfaceIdentifier)) ==
+            VerifyOrExit(Hex2Bin(aArgs[1], iid.mFields.m8, sizeof(otIp6InterfaceIdentifier)) ==
                              sizeof(otIp6InterfaceIdentifier),
                          error = OT_ERROR_INVALID_ARGS);
             SuccessOrExit(error = otThreadSetFixedDuaInterfaceIdentifier(mInstance, &iid));

--- a/src/core/backbone_router/local.cpp
+++ b/src/core/backbone_router/local.cpp
@@ -67,7 +67,7 @@ Local::Local(Instance &aInstance)
     mBackboneRouterPrimaryAloc.mValid              = true;
     mBackboneRouterPrimaryAloc.mScopeOverride      = Ip6::Address::kRealmLocalScope;
     mBackboneRouterPrimaryAloc.mScopeOverrideValid = true;
-    mBackboneRouterPrimaryAloc.GetAddress().SetLocator(Mle::kAloc16BackboneRouterPrimary);
+    mBackboneRouterPrimaryAloc.GetAddress().GetIid().SetLocator(Mle::kAloc16BackboneRouterPrimary);
 
     // All Network Backbone Routers Multicast Address.
     mAllNetworkBackboneRouters.Clear();

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -500,7 +500,8 @@ Message *CoapBase::FindRelatedRequest(const Message &         aResponse,
         aMetadata.ReadFrom(*message);
 
         if (((aMetadata.mDestinationAddress == aMessageInfo.GetPeerAddr()) ||
-             aMetadata.mDestinationAddress.IsMulticast() || aMetadata.mDestinationAddress.IsIidAnycastLocator()) &&
+             aMetadata.mDestinationAddress.IsMulticast() ||
+             aMetadata.mDestinationAddress.GetIid().IsAnycastLocator()) &&
             (aMetadata.mDestinationPort == aMessageInfo.GetPeerPort()))
         {
             switch (aResponse.GetType())

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -57,12 +57,9 @@ void SettingsBase::LogNetworkInfo(const char *aAction, const NetworkInfo &aNetwo
         Mle::Mle::RoleToString(static_cast<Mle::DeviceRole>(aNetworkInfo.GetRole())), aNetworkInfo.GetDeviceMode(),
         aNetworkInfo.GetVersion(), aNetworkInfo.GetKeySequence());
 
-    otLogInfoCore(
-        "Non-volatile: ... pid:0x%x, mlecntr:0x%x, maccntr:0x%x, mliid:%02x%02x%02x%02x%02x%02x%02x%02x}",
-        aNetworkInfo.GetPreviousPartitionId(), aNetworkInfo.GetMleFrameCounter(), aNetworkInfo.GetMacFrameCounter(),
-        aNetworkInfo.GetMeshLocalIid()[0], aNetworkInfo.GetMeshLocalIid()[1], aNetworkInfo.GetMeshLocalIid()[2],
-        aNetworkInfo.GetMeshLocalIid()[3], aNetworkInfo.GetMeshLocalIid()[4], aNetworkInfo.GetMeshLocalIid()[5],
-        aNetworkInfo.GetMeshLocalIid()[6], aNetworkInfo.GetMeshLocalIid()[7]);
+    otLogInfoCore("Non-volatile: ... pid:0x%x, mlecntr:0x%x, maccntr:0x%x, mliid:%s}",
+                  aNetworkInfo.GetPreviousPartitionId(), aNetworkInfo.GetMleFrameCounter(),
+                  aNetworkInfo.GetMacFrameCounter(), aNetworkInfo.GetMeshLocalIid().ToString().AsCString());
 }
 
 void SettingsBase::LogParentInfo(const char *aAction, const ParentInfo &aParentInfo) const

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -40,6 +40,7 @@
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "mac/mac_types.hpp"
+#include "net/ip6_address.hpp"
 #include "utils/flash.hpp"
 #if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
 #include "utils/slaac_address.hpp"
@@ -338,7 +339,7 @@ public:
          * @returns The Mesh Local Interface Identifier.
          *
          */
-        const uint8_t *GetMeshLocalIid(void) const { return mMlIid; }
+        const Ip6::InterfaceIdentifier &GetMeshLocalIid(void) const { return mMlIid; }
 
         /**
          * This method sets the Mesh Local Interface Identifier.
@@ -346,7 +347,7 @@ public:
          * @param[in] aMeshLocalIid  The Mesh Local Interface Identifier.
          *
          */
-        void SetMeshLocalIid(const uint8_t *aMeshLocalIid) { memcpy(mMlIid, aMeshLocalIid, sizeof(mMlIid)); }
+        void SetMeshLocalIid(const Ip6::InterfaceIdentifier &aMeshLocalIid) { mMlIid = aMeshLocalIid; }
 
         /**
          * This method returns the Thread version.
@@ -365,16 +366,16 @@ public:
         void SetVersion(uint16_t aVersion) { mVersion = Encoding::LittleEndian::HostSwap16(aVersion); }
 
     private:
-        uint8_t         mRole;                   ///< Current Thread role.
-        uint8_t         mDeviceMode;             ///< Device mode setting.
-        uint16_t        mRloc16;                 ///< RLOC16
-        uint32_t        mKeySequence;            ///< Key Sequence
-        uint32_t        mMleFrameCounter;        ///< MLE Frame Counter
-        uint32_t        mMacFrameCounter;        ///< MAC Frame Counter
-        uint32_t        mPreviousPartitionId;    ///< PartitionId
-        Mac::ExtAddress mExtAddress;             ///< Extended Address
-        uint8_t         mMlIid[OT_IP6_IID_SIZE]; ///< IID from ML-EID
-        uint16_t        mVersion;                ///< Version
+        uint8_t                  mRole;                ///< Current Thread role.
+        uint8_t                  mDeviceMode;          ///< Device mode setting.
+        uint16_t                 mRloc16;              ///< RLOC16
+        uint32_t                 mKeySequence;         ///< Key Sequence
+        uint32_t                 mMleFrameCounter;     ///< MLE Frame Counter
+        uint32_t                 mMacFrameCounter;     ///< MAC Frame Counter
+        uint32_t                 mPreviousPartitionId; ///< PartitionId
+        Mac::ExtAddress          mExtAddress;          ///< Extended Address
+        Ip6::InterfaceIdentifier mMlIid;               ///< IID from ML-EID
+        uint16_t                 mVersion;             ///< Version
     } OT_TOOL_PACKED_END;
 
     /**

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -563,7 +563,7 @@ void BorderAgent::HandleRelayTransmit(const Coap::Message &aMessage)
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerPort(kCoapUdpPort);
     messageInfo.SetPeerAddr(Get<Mle::MleRouter>().GetMeshLocal16());
-    messageInfo.GetPeerAddr().SetLocator(joinerRouterRloc);
+    messageInfo.GetPeerAddr().GetIid().SetLocator(joinerRouterRloc);
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, messageInfo));
 

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -121,8 +121,7 @@ void Commissioner::SignalJoinerEvent(otCommissionerJoinerEvent aEvent, const Joi
     }
     else if (aJoiner == mActiveJoiner)
     {
-        joinerId.Set(mJoinerIid.m8);
-        joinerId.ToggleLocal();
+        mJoinerIid.ConvertToExtAddress(joinerId);
     }
     else
     {
@@ -1048,9 +1047,7 @@ void Commissioner::HandleRelayReceive(Coap::Message &aMessage, const Ip6::Messag
         Joiner *        joiner;
 
         mJoinerIid = joinerIid;
-
-        receivedId.Set(mJoinerIid.m8);
-        receivedId.ToggleLocal();
+        mJoinerIid.ConvertToExtAddress(receivedId);
 
         joiner = FindBestMatchingJoinerEntry(receivedId);
         VerifyOrExit(joiner != nullptr, OT_NOOP);
@@ -1230,7 +1227,7 @@ otError Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::MessageInf
     aMessage.CopyTo(0, offset, aMessage.GetLength(), *message);
 
     messageInfo.SetPeerAddr(Get<Mle::MleRouter>().GetMeshLocal16());
-    messageInfo.GetPeerAddr().SetLocator(mJoinerRloc);
+    messageInfo.GetPeerAddr().GetIid().SetLocator(mJoinerRloc);
     messageInfo.SetPeerPort(kCoapUdpPort);
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, messageInfo));

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -94,7 +94,7 @@ void Leader::HandlePetition(Coap::Message &aMessage, const Ip6::MessageInfo &aMe
     }
 
     data.mBorderAgentLocator.Init();
-    data.mBorderAgentLocator.SetBorderAgentLocator(aMessageInfo.GetPeerAddr().GetLocator());
+    data.mBorderAgentLocator.SetBorderAgentLocator(aMessageInfo.GetPeerAddr().GetIid().GetLocator());
 
     data.mCommissionerSessionId.Init();
     data.mCommissionerSessionId.SetCommissionerSessionId(++mSessionId);
@@ -194,7 +194,7 @@ void Leader::HandleKeepAlive(Coap::Message &aMessage, const Ip6::MessageInfo &aM
     }
     else
     {
-        uint16_t rloc = aMessageInfo.GetPeerAddr().GetLocator();
+        uint16_t rloc = aMessageInfo.GetPeerAddr().GetIid().GetLocator();
 
         if (borderAgentLocator->GetBorderAgentLocator() != rloc)
         {

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -469,7 +469,8 @@ otError Dhcp6Server::AddIaAddress(Message &aMessage, const Ip6::Address &aPrefix
 
     option.Init();
     option.GetAddress().SetPrefix(aPrefix.mFields.m8, OT_IP6_PREFIX_BITSIZE);
-    option.GetAddress().SetIid(*reinterpret_cast<Mac::ExtAddress *>(aClientId.GetDuidLinkLayerAddress()));
+    option.GetAddress().GetIid().SetFromExtAddress(
+        *reinterpret_cast<Mac::ExtAddress *>(aClientId.GetDuidLinkLayerAddress()));
     option.SetPreferredLifetime(OT_DHCP6_DEFAULT_PREFERRED_LIFETIME);
     option.SetValidLifetime(OT_DHCP6_DEFAULT_VALID_LIFETIME);
     SuccessOrExit(error = aMessage.Append(&option, sizeof(option)));

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -202,7 +202,7 @@ otError Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMe
     uint16_t    payloadLength;
 
     // always handle Echo Request destined for RLOC or ALOC
-    VerifyOrExit(ShouldHandleEchoRequest(aMessageInfo) || aMessageInfo.GetSockAddr().IsIidLocator(), OT_NOOP);
+    VerifyOrExit(ShouldHandleEchoRequest(aMessageInfo) || aMessageInfo.GetSockAddr().GetIid().IsLocator(), OT_NOOP);
 
     otLogInfoIcmp("Received Echo Request");
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1037,8 +1037,8 @@ otError Ip6::ProcessReceiveCallback(const Message &    aMessage,
     if (mIsReceiveIp6FilterEnabled)
     {
         // do not pass messages sent to an RLOC/ALOC, except Service Locator
-        VerifyOrExit(!aMessageInfo.GetSockAddr().IsIidLocator() ||
-                         aMessageInfo.GetSockAddr().IsIidAnycastServiceLocator(),
+        VerifyOrExit(!aMessageInfo.GetSockAddr().GetIid().IsLocator() ||
+                         aMessageInfo.GetSockAddr().GetIid().IsAnycastServiceLocator(),
                      error = OT_ERROR_NO_ROUTE);
 
         switch (aIpProto)
@@ -1374,7 +1374,7 @@ const NetifUnicastAddress *Ip6::SelectSourceAddress(MessageInfo &aMessageInfo)
         uint8_t        candidatePrefixMatched;
         uint8_t        overrideScope;
 
-        if (candidateAddr->IsIidAnycastLocator())
+        if (candidateAddr->GetIid().IsAnycastLocator())
         {
             // Don't use anycast address as source address.
             continue;
@@ -1444,7 +1444,7 @@ const NetifUnicastAddress *Ip6::SelectSourceAddress(MessageInfo &aMessageInfo)
             rvalPrefixMatched = candidatePrefixMatched;
         }
         else if ((candidatePrefixMatched == rvalPrefixMatched) &&
-                 (destination->IsIidRoutingLocator() == candidateAddr->IsIidRoutingLocator()))
+                 (destination->GetIid().IsRoutingLocator() == candidateAddr->GetIid().IsRoutingLocator()))
         {
             // Additional rule: Prefer RLOC source for RLOC destination, EID source for anything else
             rvalAddr          = addr;

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -38,6 +38,7 @@
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
+#include "common/random.hpp"
 #include "net/netif.hpp"
 
 using ot::Encoding::BigEndian::HostSwap32;
@@ -45,24 +46,114 @@ using ot::Encoding::BigEndian::HostSwap32;
 namespace ot {
 namespace Ip6 {
 
+//---------------------------------------------------------------------------------------------------------------------
+// InterfaceIdentifier methods
+
 bool InterfaceIdentifier::IsUnspecified(void) const
 {
-    return (m8[0] == 0 && m8[1] == 0 && m8[2] == 0 && m8[3] == 0 && m8[4] == 0 && m8[5] == 0 && m8[6] == 0 &&
-            m8[7] == 0);
+    return (mFields.m32[0] == 0) && (mFields.m32[1] == 0);
 }
 
 bool InterfaceIdentifier::IsReserved(void) const
 {
-    Address addr;
+    return IsSubnetRouterAnycast() || IsReservedSubnetAnycast() || IsAnycastLocator();
+}
 
-    addr.SetIid(this->m8);
-    return addr.IsIidReserved();
+bool InterfaceIdentifier::IsSubnetRouterAnycast(void) const
+{
+    return (mFields.m32[0] == 0) && (mFields.m32[1] == 0);
+}
+
+bool InterfaceIdentifier::IsReservedSubnetAnycast(void) const
+{
+    // Format of IID in a Reserved Subnet Anycast Address (RFC 2526)
+    //
+    // |      57 bits     |   7 bits   |
+    // +------------------+------------+
+    // | 1111110111...111 | anycast ID |
+    // +------------------+------------+
+
+    return (mFields.m32[0] == HostSwap32(0xfdffffff) && mFields.m16[2] == HostSwap16(0xffff) && mFields.m8[6] == 0xff &&
+            mFields.m8[7] >= 0x80);
+}
+
+void InterfaceIdentifier::GenerateRandom(void)
+{
+    otError error;
+
+    OT_UNUSED_VARIABLE(error);
+
+    error = Random::Crypto::FillBuffer(mFields.m8, kSize);
+
+    OT_ASSERT(error == OT_ERROR_NONE);
+}
+
+void InterfaceIdentifier::SetBytes(const uint8_t *aBuffer)
+{
+    memcpy(mFields.m8, aBuffer, kSize);
+}
+
+void InterfaceIdentifier::SetFromExtAddress(const Mac::ExtAddress &aExtAddress)
+{
+    Mac::ExtAddress addr;
+
+    addr = aExtAddress;
+    addr.ToggleLocal();
+    addr.CopyTo(mFields.m8);
+}
+
+void InterfaceIdentifier::ConvertToExtAddress(Mac::ExtAddress &aExtAddress) const
+{
+    aExtAddress.Set(mFields.m8);
+    aExtAddress.ToggleLocal();
+}
+
+void InterfaceIdentifier::ConvertToMacAddress(Mac::Address &aMacAddress) const
+{
+    aMacAddress.SetExtended(mFields.m8);
+    aMacAddress.GetExtended().ToggleLocal();
+}
+
+void InterfaceIdentifier::SetToLocator(uint16_t aLocator)
+{
+    // Locator IID pattern `0000:00ff:fe00:xxxx`
+    mFields.m32[0] = HostSwap32(0x000000ff);
+    mFields.m16[2] = HostSwap16(0xfe00);
+    mFields.m16[3] = HostSwap16(aLocator);
+}
+
+bool InterfaceIdentifier::IsLocator(void) const
+{
+    // Locator IID pattern 0000:00ff:fe00:xxxx
+    return (mFields.m32[0] == HostSwap32(0x000000ff) && mFields.m16[2] == HostSwap16(0xfe00));
+}
+
+bool InterfaceIdentifier::IsRoutingLocator(void) const
+{
+    return (IsLocator() && (mFields.m8[6] < kAloc16Mask) && ((mFields.m8[6] & kRloc16ReservedBitMask) == 0));
+}
+
+bool InterfaceIdentifier::IsAnycastLocator(void) const
+{
+    // Anycast locator range 0xfc00- 0xfcff (`kAloc16Mask` is 0xfc)
+    return (IsLocator() && (mFields.m8[6] == kAloc16Mask));
+}
+
+bool InterfaceIdentifier::IsAnycastServiceLocator(void) const
+{
+    uint16_t locator = GetLocator();
+
+    return (IsLocator() && (locator >= Mle::kAloc16ServiceStart) && (locator <= Mle::kAloc16ServiceEnd));
 }
 
 InterfaceIdentifier::InfoString InterfaceIdentifier::ToString(void) const
 {
-    return InfoString("%02x%02x%02x%02x%02x%02x%02x%02x", m8[0], m8[1], m8[2], m8[3], m8[4], m8[5], m8[6], m8[7]);
+    return InfoString("%02x%02x%02x%02x%02x%02x%02x%02x", mFields.m8[0], mFields.m8[1], mFields.m8[2], mFields.m8[3],
+                      mFields.m8[4], mFields.m8[5], mFields.m8[6], mFields.m8[7]);
 }
+
+//---------------------------------------------------------------------------------------------------------------------
+// Address methods
 
 bool Address::IsUnspecified(void) const
 {
@@ -83,10 +174,10 @@ void Address::SetToLinkLocalAddress(const Mac::ExtAddress &aExtAddress)
 {
     mFields.m32[0] = HostSwap32(0xfe800000);
     mFields.m32[1] = 0;
-    SetIid(aExtAddress);
+    GetIid().SetFromExtAddress(aExtAddress);
 }
 
-void Address::SetToLinkLocalAddress(const uint8_t *aIid)
+void Address::SetToLinkLocalAddress(const InterfaceIdentifier &aIid)
 {
     mFields.m32[0] = HostSwap32(0xfe800000);
     mFields.m32[1] = 0;
@@ -158,46 +249,6 @@ void Address::SetToRealmLocalAllMplForwarders(void)
     *this = GetRealmLocalAllMplForwarders();
 }
 
-bool Address::IsSubnetRouterAnycast(void) const
-{
-    return (mFields.m32[2] == 0 && mFields.m32[3] == 0);
-}
-
-bool Address::IsReservedSubnetAnycast(void) const
-{
-    return (mFields.m32[2] == HostSwap32(0xfdffffff) && mFields.m16[6] == 0xffff && mFields.m8[14] == 0xff &&
-            mFields.m8[15] >= 0x80);
-}
-
-bool Address::IsIidReserved(void) const
-{
-    return IsSubnetRouterAnycast() || IsReservedSubnetAnycast() || IsIidAnycastLocator();
-}
-
-bool Address::IsIidLocator(void) const
-{
-    // IID pattern 0000:00ff:fe00:xxxx
-    return (mFields.m32[2] == HostSwap32(0x000000ff) && mFields.m16[6] == HostSwap16(0xfe00));
-}
-
-bool Address::IsIidRoutingLocator(void) const
-{
-    return (IsIidLocator() && (mFields.m8[14] < kAloc16Mask) && ((mFields.m8[14] & kRloc16ReservedBitMask) == 0));
-}
-
-bool Address::IsIidAnycastLocator(void) const
-{
-    // Anycast locator range 0xfc00- 0xfcff (`kAloc16Max` is 0xfc)
-    return (IsIidLocator() && (mFields.m8[14] == kAloc16Mask));
-}
-
-bool Address::IsIidAnycastServiceLocator(void) const
-{
-    uint16_t locator = GetLocator();
-
-    return (IsIidLocator() && (locator >= Mle::kAloc16ServiceStart) && (locator <= Mle::kAloc16ServiceEnd));
-}
-
 void Address::SetPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength)
 {
     SetPrefix(0, aPrefix, aPrefixLength);
@@ -217,7 +268,7 @@ void Address::SetPrefix(uint8_t aOffset, const uint8_t *aPrefix, uint8_t aPrefix
         uint8_t index = aOffset + bytes;
         uint8_t mask  = ((0x80 >> (extraBits - 1)) - 1);
 
-        // `mask` has its higher (msb) `extraBits` bits as `0` and the reminaing as `1`.
+        // `mask` has its higher (msb) `extraBits` bits as `0` and the remaining as `1`.
         // Example with `extraBits` = 3:
         // ((0x80 >> 2) - 1) = (0b0010_0000 - 1) = 0b0001_1111
 
@@ -232,49 +283,10 @@ void Address::SetMulticastNetworkPrefix(const uint8_t *aPrefix, uint8_t aPrefixL
     mFields.m8[kMulticastNetworkPrefixLengthOffset] = aPrefixLength;
 }
 
-bool Address::HasIid(const uint8_t *aIid) const
-{
-    return (memcmp(mFields.m8 + kInterfaceIdentifierOffset, aIid, kInterfaceIdentifierSize) == 0);
-}
-
-void Address::SetIid(const uint8_t *aIid)
-{
-    memcpy(mFields.m8 + kInterfaceIdentifierOffset, aIid, kInterfaceIdentifierSize);
-}
-
-void Address::SetIid(const Mac::ExtAddress &aExtAddress)
-{
-    Mac::ExtAddress addr;
-
-    addr = aExtAddress;
-    addr.ToggleLocal();
-    addr.CopyTo(mFields.m8 + kInterfaceIdentifierOffset);
-}
-
-void Address::SetIidToLocator(uint16_t aLocator)
-{
-    // Locator IID pattern `0000:00ff:fe00:xxxx`
-    mFields.m32[2] = HostSwap32(0x000000ff);
-    mFields.m16[6] = HostSwap16(0xfe00);
-    mFields.m16[7] = HostSwap16(aLocator);
-}
-
 void Address::SetToLocator(const Mle::MeshLocalPrefix &aMeshLocalPrefix, uint16_t aLocator)
 {
     SetPrefix(aMeshLocalPrefix);
-    SetIidToLocator(aLocator);
-}
-
-void Address::ToExtAddress(Mac::ExtAddress &aExtAddress) const
-{
-    aExtAddress.Set(mFields.m8 + kInterfaceIdentifierOffset);
-    aExtAddress.ToggleLocal();
-}
-
-void Address::ToExtAddress(Mac::Address &aMacAddress) const
-{
-    aMacAddress.SetExtended(mFields.m8 + kInterfaceIdentifierOffset);
-    aMacAddress.GetExtended().ToggleLocal();
+    GetIid().SetToLocator(aLocator);
 }
 
 uint8_t Address::GetScope(void) const

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -575,18 +575,18 @@ void AddressResolver::HandleAddressNotification(void *aContext, otMessage *aMess
 
 void AddressResolver::HandleAddressNotification(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    Ip6::Address    target;
-    uint8_t         meshLocalIid[Ip6::Address::kInterfaceIdentifierSize];
-    uint16_t        rloc16;
-    uint32_t        lastTransactionTime;
-    CacheEntryList *list;
-    CacheEntry *    entry;
-    CacheEntry *    prev;
+    Ip6::Address             target;
+    Ip6::InterfaceIdentifier meshLocalIid;
+    uint16_t                 rloc16;
+    uint32_t                 lastTransactionTime;
+    CacheEntryList *         list;
+    CacheEntry *             entry;
+    CacheEntry *             prev;
 
     VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
     SuccessOrExit(Tlv::FindTlv(aMessage, ThreadTlv::kTarget, &target, sizeof(target)));
-    SuccessOrExit(Tlv::FindTlv(aMessage, ThreadTlv::kMeshLocalEid, meshLocalIid, sizeof(meshLocalIid)));
+    SuccessOrExit(Tlv::FindTlv(aMessage, ThreadTlv::kMeshLocalEid, &meshLocalIid, sizeof(meshLocalIid)));
     SuccessOrExit(Tlv::FindUint16Tlv(aMessage, ThreadTlv::kRloc16, rloc16));
 
     switch (Tlv::FindUint32Tlv(aMessage, ThreadTlv::kLastTransactionTime, lastTransactionTime))
@@ -600,8 +600,8 @@ void AddressResolver::HandleAddressNotification(Coap::Message &aMessage, const I
         ExitNow();
     }
 
-    otLogInfoArp("Received address notification from 0x%04x for %s to 0x%04x", aMessageInfo.GetPeerAddr().GetLocator(),
-                 target.ToString().AsCString(), rloc16);
+    otLogInfoArp("Received address notification from 0x%04x for %s to 0x%04x",
+                 aMessageInfo.GetPeerAddr().GetIid().GetLocator(), target.ToString().AsCString(), rloc16);
 
     entry = FindCacheEntry(target, list, prev);
     VerifyOrExit(entry != nullptr, OT_NOOP);
@@ -615,7 +615,7 @@ void AddressResolver::HandleAddressNotification(Coap::Message &aMessage, const I
             // by more than one device. Try to resolve the duplicate
             // address by sending an Address Error message.
 
-            VerifyOrExit(entry->HasMeshLocalIid(meshLocalIid), SendAddressError(target, meshLocalIid, nullptr));
+            VerifyOrExit(entry->GetMeshLocalIid() == meshLocalIid, SendAddressError(target, meshLocalIid, nullptr));
 
             VerifyOrExit(lastTransactionTime < entry->GetLastTransactionTime(), OT_NOOP);
         }
@@ -641,9 +641,9 @@ exit:
     return;
 }
 
-void AddressResolver::SendAddressError(const Ip6::Address &aTarget,
-                                       const uint8_t *     aMeshLocalIid,
-                                       const Ip6::Address *aDestination)
+void AddressResolver::SendAddressError(const Ip6::Address &            aTarget,
+                                       const Ip6::InterfaceIdentifier &aMeshLocalIid,
+                                       const Ip6::Address *            aDestination)
 {
     otError          error;
     Coap::Message *  message;
@@ -656,8 +656,7 @@ void AddressResolver::SendAddressError(const Ip6::Address &aTarget,
     SuccessOrExit(error = message->SetPayloadMarker());
 
     SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kTarget, &aTarget, sizeof(aTarget)));
-    SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kMeshLocalEid, aMeshLocalIid,
-                                         Ip6::Address::kInterfaceIdentifierSize));
+    SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kMeshLocalEid, &aMeshLocalIid, sizeof(aMeshLocalIid)));
 
     if (aDestination == nullptr)
     {
@@ -696,11 +695,11 @@ void AddressResolver::HandleAddressError(void *aContext, otMessage *aMessage, co
 
 void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    otError         error = OT_ERROR_NONE;
-    Ip6::Address    target;
-    uint8_t         meshLocalIid[Ip6::Address::kInterfaceIdentifierSize];
-    Mac::ExtAddress macAddr;
-    Ip6::Address    destination;
+    otError                  error = OT_ERROR_NONE;
+    Ip6::Address             target;
+    Ip6::InterfaceIdentifier meshLocalIid;
+    Mac::ExtAddress          extAddr;
+    Ip6::Address             destination;
 
     VerifyOrExit(aMessage.GetCode() == OT_COAP_CODE_POST, error = OT_ERROR_DROP);
 
@@ -715,13 +714,12 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
     }
 
     SuccessOrExit(error = Tlv::FindTlv(aMessage, ThreadTlv::kTarget, &target, sizeof(target)));
-    SuccessOrExit(error = Tlv::FindTlv(aMessage, ThreadTlv::kMeshLocalEid, meshLocalIid, sizeof(meshLocalIid)));
+    SuccessOrExit(error = Tlv::FindTlv(aMessage, ThreadTlv::kMeshLocalEid, &meshLocalIid, sizeof(meshLocalIid)));
 
     for (const Ip6::NetifUnicastAddress *address = Get<ThreadNetif>().GetUnicastAddresses(); address;
          address                                 = address->GetNext())
     {
-        if (address->GetAddress() == target &&
-            memcmp(Get<Mle::MleRouter>().GetMeshLocal64().GetIid(), meshLocalIid, sizeof(meshLocalIid)))
+        if (address->GetAddress() == target && Get<Mle::MleRouter>().GetMeshLocal64().GetIid() != meshLocalIid)
         {
             // Target EID matches address and Mesh Local EID differs
             Get<ThreadNetif>().RemoveUnicastAddress(*address);
@@ -729,8 +727,7 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
         }
     }
 
-    macAddr.Set(meshLocalIid);
-    macAddr.ToggleLocal();
+    meshLocalIid.ConvertToExtAddress(extAddr);
 
     for (ChildTable::Iterator iter(GetInstance(), Child::kInStateValid); !iter.IsDone(); iter++)
     {
@@ -741,7 +738,7 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
             continue;
         }
 
-        if (child.GetExtAddress() != macAddr)
+        if (child.GetExtAddress() != extAddr)
         {
             // Mesh Local EID differs, so check whether Target EID
             // matches a child address and if so remove it.
@@ -779,7 +776,7 @@ void AddressResolver::HandleAddressQuery(Coap::Message &aMessage, const Ip6::Mes
 
     SuccessOrExit(Tlv::FindTlv(aMessage, ThreadTlv::kTarget, &target, sizeof(target)));
 
-    otLogInfoArp("Received address query from 0x%04x for target %s", aMessageInfo.GetPeerAddr().GetLocator(),
+    otLogInfoArp("Received address query from 0x%04x for target %s", aMessageInfo.GetPeerAddr().GetIid().GetLocator(),
                  target.ToString().AsCString());
 
     if (Get<ThreadNetif>().HasUnicastAddress(target))
@@ -810,10 +807,10 @@ exit:
     return;
 }
 
-void AddressResolver::SendAddressQueryResponse(const Ip6::Address &aTarget,
-                                               const uint8_t *     aMeshLocalIid,
-                                               const uint32_t *    aLastTransactionTime,
-                                               const Ip6::Address &aDestination)
+void AddressResolver::SendAddressQueryResponse(const Ip6::Address &            aTarget,
+                                               const Ip6::InterfaceIdentifier &aMeshLocalIid,
+                                               const uint32_t *                aLastTransactionTime,
+                                               const Ip6::Address &            aDestination)
 {
     otError          error;
     Coap::Message *  message;
@@ -826,8 +823,7 @@ void AddressResolver::SendAddressQueryResponse(const Ip6::Address &aTarget,
     SuccessOrExit(error = message->SetPayloadMarker());
 
     SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kTarget, &aTarget, sizeof(aTarget)));
-    SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kMeshLocalEid, aMeshLocalIid,
-                                         Ip6::Address::kInterfaceIdentifierSize));
+    SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kMeshLocalEid, &aMeshLocalIid, sizeof(aMeshLocalIid)));
     SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, ThreadTlv::kRloc16, Get<Mle::MleRouter>().GetRloc16()));
 
     if (aLastTransactionTime != nullptr)
@@ -1074,16 +1070,6 @@ void AddressResolver::CacheEntry::SetNext(CacheEntry *aEntry)
 
 exit:
     return;
-}
-
-bool AddressResolver::CacheEntry::HasMeshLocalIid(const uint8_t *aIid) const
-{
-    return memcmp(mInfo.mCached.mMeshLocalIid, aIid, Ip6::Address::kInterfaceIdentifierSize) == 0;
-}
-
-void AddressResolver::CacheEntry::SetMeshLocalIid(const uint8_t *aIid)
-{
-    memcpy(mInfo.mCached.mMeshLocalIid, aIid, Ip6::Address::kInterfaceIdentifierSize);
 }
 
 } // namespace ot

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -200,9 +200,8 @@ private:
         Mac::ShortAddress GetRloc16(void) const { return mRloc16; }
         void              SetRloc16(Mac::ShortAddress aRloc16) { mRloc16 = aRloc16; }
 
-        const uint8_t *GetMeshLocalIid(void) const { return mInfo.mCached.mMeshLocalIid; }
-        bool           HasMeshLocalIid(const uint8_t *aIid) const;
-        void           SetMeshLocalIid(const uint8_t *aIid);
+        const Ip6::InterfaceIdentifier &GetMeshLocalIid(void) const { return mInfo.mCached.mMeshLocalIid; }
+        void SetMeshLocalIid(const Ip6::InterfaceIdentifier &aIid) { mInfo.mCached.mMeshLocalIid = aIid; }
 
         uint32_t GetLastTransactionTime(void) const { return mInfo.mCached.mLastTransactionTime; }
         void     SetLastTransactionTime(uint32_t aTime) { mInfo.mCached.mLastTransactionTime = aTime; }
@@ -236,8 +235,8 @@ private:
         {
             struct
             {
-                uint32_t mLastTransactionTime;
-                uint8_t  mMeshLocalIid[Ip6::Address::kInterfaceIdentifierSize];
+                uint32_t                 mLastTransactionTime;
+                Ip6::InterfaceIdentifier mMeshLocalIid;
             } mCached;
 
             struct
@@ -278,11 +277,13 @@ private:
     void        RemoveCacheEntry(CacheEntry &aEntry, CacheEntryList &aList, CacheEntry *aPrevEntry, Reason aReason);
 
     otError SendAddressQuery(const Ip6::Address &aEid);
-    void SendAddressError(const Ip6::Address &aTarget, const uint8_t *aMeshLocalIid, const Ip6::Address *aDestination);
-    void SendAddressQueryResponse(const Ip6::Address &aTarget,
-                                  const uint8_t *     aMeshLocalIid,
-                                  const uint32_t *    aLastTransactionTimeTlv,
-                                  const Ip6::Address &aDestination);
+    void    SendAddressError(const Ip6::Address &            aTarget,
+                             const Ip6::InterfaceIdentifier &aMeshLocalIid,
+                             const Ip6::Address *            aDestination);
+    void    SendAddressQueryResponse(const Ip6::Address &            aTarget,
+                                     const Ip6::InterfaceIdentifier &aMeshLocalIid,
+                                     const uint32_t *                aLastTransactionTimeTlv,
+                                     const Ip6::Address &            aDestination);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -279,7 +279,8 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
     result.mChannel = linkInfo->mChannel;
     result.mRssi    = linkInfo->mRss;
     result.mLqi     = linkInfo->mLqi;
-    aMessageInfo.GetPeerAddr().ToExtAddress(*static_cast<Mac::ExtAddress *>(&result.mExtAddress));
+
+    aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(static_cast<Mac::ExtAddress &>(result.mExtAddress));
 
     // Process MeshCoP TLVs
     while (offset < end)

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -147,7 +147,7 @@ void DuaManager::ClearFixedDuaInterfaceIdentifier(void)
     // Nothing to clear.
     VerifyOrExit(IsFixedDuaInterfaceIdentifierSet(), OT_NOOP);
 
-    if (GetDomainUnicastAddress().HasIid(mFixedDuaInterfaceIdentifier) &&
+    if (GetDomainUnicastAddress().GetIid() == mFixedDuaInterfaceIdentifier &&
         Get<ThreadNetif>().HasUnicastAddress(GetDomainUnicastAddress()))
     {
         Get<ThreadNetif>().RemoveUnicastAddress(mDomainUnicastAddress);

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -339,7 +339,7 @@ void MeshForwarder::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 
 void MeshForwarder::GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr)
 {
-    aIp6Addr.ToExtAddress(aMacAddr);
+    aIp6Addr.GetIid().ConvertToMacAddress(aMacAddr);
 
     if (aMacAddr.GetExtended() != Get<Mac::Mac>().GetExtAddress())
     {
@@ -355,11 +355,11 @@ void MeshForwarder::GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::
     }
     else if (Get<Mle::MleRouter>().IsRoutingLocator(aIp6Addr))
     {
-        aMacAddr.SetShort(aIp6Addr.GetLocator());
+        aMacAddr.SetShort(aIp6Addr.GetIid().GetLocator());
     }
     else
     {
-        aIp6Addr.ToExtAddress(aMacAddr);
+        aIp6Addr.GetIid().ConvertToMacAddress(aMacAddr);
     }
 }
 

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -416,13 +416,13 @@ otError MeshForwarder::UpdateIp6RouteFtd(Ip6::Header &ip6Header, Message &aMessa
     }
     else if (mle.IsRoutingLocator(ip6Header.GetDestination()))
     {
-        uint16_t rloc16 = ip6Header.GetDestination().GetLocator();
+        uint16_t rloc16 = ip6Header.GetDestination().GetIid().GetLocator();
         VerifyOrExit(mle.IsRouterIdValid(Mle::Mle::RouterIdFromRloc16(rloc16)), error = OT_ERROR_DROP);
         mMeshDest = rloc16;
     }
     else if (mle.IsAnycastLocator(ip6Header.GetDestination()))
     {
-        uint16_t aloc16 = ip6Header.GetDestination().GetLocator();
+        uint16_t aloc16 = ip6Header.GetDestination().GetIid().GetLocator();
 
         if (aloc16 == Mle::kAloc16Leader)
         {
@@ -600,7 +600,7 @@ void MeshForwarder::SendDestinationUnreachable(uint16_t aMeshSource, const Messa
     Ip6::MessageInfo messageInfo;
 
     messageInfo.GetPeerAddr() = Get<Mle::MleRouter>().GetMeshLocal16();
-    messageInfo.GetPeerAddr().SetLocator(aMeshSource);
+    messageInfo.GetPeerAddr().GetIid().SetLocator(aMeshSource);
 
     IgnoreError(Get<Ip6::Icmp>().SendError(Ip6::IcmpHeader::kTypeDstUnreach, Ip6::IcmpHeader::kCodeDstUnreachNoRoute,
                                            messageInfo, aMessage));
@@ -699,7 +699,7 @@ void MeshForwarder::UpdateRoutes(const uint8_t *     aFrame,
     VerifyOrExit(!aMeshDest.IsBroadcast() && aMeshSource.IsShort(), OT_NOOP);
     SuccessOrExit(GetIp6Header(aFrame, aFrameLength, aMeshSource, aMeshDest, ip6Header));
 
-    if (!ip6Header.GetSource().IsIidLocator() &&
+    if (!ip6Header.GetSource().GetIid().IsLocator() &&
         Get<NetworkData::Leader>().IsOnMesh(ip6Header.GetSource()) /* only for on mesh address which may require AQ */)
     {
         if (Get<AddressResolver>().UpdateCacheEntry(ip6Header.GetSource(), aMeshSource.GetShort()) ==

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -148,7 +148,7 @@ Mle::Mle(Instance &aInstance)
         mServiceAlocs[i].mValid              = true;
         mServiceAlocs[i].mScopeOverride      = Ip6::Address::kRealmLocalScope;
         mServiceAlocs[i].mScopeOverrideValid = true;
-        mServiceAlocs[i].GetAddress().SetLocator(Mac::kShortAddrInvalid);
+        mServiceAlocs[i].GetAddress().GetIid().SetLocator(Mac::kShortAddrInvalid);
     }
 
 #endif
@@ -158,8 +158,7 @@ Mle::Mle(Instance &aInstance)
 
     // mesh-local 64
     mMeshLocal64.Clear();
-    IgnoreError(Random::Crypto::FillBuffer(mMeshLocal64.GetAddress().mFields.m8 + OT_IP6_PREFIX_SIZE,
-                                           OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE));
+    mMeshLocal64.GetAddress().GetIid().GenerateRandom();
 
     mMeshLocal64.mPrefixLength       = MeshLocalPrefix::kLength;
     mMeshLocal64.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
@@ -170,7 +169,7 @@ Mle::Mle(Instance &aInstance)
 
     // mesh-local 16
     mMeshLocal16.Clear();
-    mMeshLocal16.GetAddress().SetIidToLocator(0);
+    mMeshLocal16.GetAddress().GetIid().SetToLocator(0);
     mMeshLocal16.mPrefixLength       = MeshLocalPrefix::kLength;
     mMeshLocal16.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
     mMeshLocal16.mPreferred          = true;
@@ -395,8 +394,7 @@ otError Mle::Restore(void)
     Get<Mac::Mac>().SetShortAddress(networkInfo.GetRloc16());
     Get<Mac::Mac>().SetExtAddress(networkInfo.GetExtAddress());
 
-    memcpy(&mMeshLocal64.GetAddress().mFields.m8[OT_IP6_PREFIX_SIZE], networkInfo.GetMeshLocalIid(),
-           OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE);
+    mMeshLocal64.GetAddress().SetIid(networkInfo.GetMeshLocalIid());
 
     if (networkInfo.GetRloc16() == Mac::kShortAddrInvalid)
     {
@@ -462,7 +460,7 @@ otError Mle::Store(void)
         networkInfo.SetRloc16(GetRloc16());
         networkInfo.SetPreviousPartitionId(mLeaderData.GetPartitionId());
         networkInfo.SetExtAddress(Get<Mac::Mac>().GetExtAddress());
-        networkInfo.SetMeshLocalIid(&mMeshLocal64.GetAddress().mFields.m8[OT_IP6_PREFIX_SIZE]);
+        networkInfo.SetMeshLocalIid(mMeshLocal64.GetAddress().GetIid());
         networkInfo.SetVersion(kThreadVersion);
 
         if (IsChild())
@@ -813,7 +811,7 @@ exit:
 void Mle::UpdateLinkLocalAddress(void)
 {
     Get<ThreadNetif>().RemoveUnicastAddress(mLinkLocal64);
-    mLinkLocal64.GetAddress().SetIid(Get<Mac::Mac>().GetExtAddress());
+    mLinkLocal64.GetAddress().GetIid().SetFromExtAddress(Get<Mac::Mac>().GetExtAddress());
     Get<ThreadNetif>().AddUnicastAddress(mLinkLocal64);
 
     Get<Notifier>().Signal(kEventThreadLinkLocalAddrChanged);
@@ -887,7 +885,7 @@ void Mle::ApplyMeshLocalPrefix(void)
 
     for (size_t i = 0; i < OT_ARRAY_LENGTH(mServiceAlocs); i++)
     {
-        if (mServiceAlocs[i].GetAddress().GetLocator() != Mac::kShortAddrInvalid)
+        if (mServiceAlocs[i].GetAddress().GetIid().GetLocator() != Mac::kShortAddrInvalid)
         {
             Get<ThreadNetif>().RemoveUnicastAddress(mServiceAlocs[i]);
             mServiceAlocs[i].GetAddress().SetPrefix(GetMeshLocalPrefix());
@@ -934,7 +932,7 @@ void Mle::SetRloc16(uint16_t aRloc16)
     if (aRloc16 != Mac::kShortAddrInvalid)
     {
         // mesh-local 16
-        mMeshLocal16.GetAddress().SetLocator(aRloc16);
+        mMeshLocal16.GetAddress().GetIid().SetLocator(aRloc16);
         Get<ThreadNetif>().AddUnicastAddress(mMeshLocal16);
 #if OPENTHREAD_FTD
         Get<AddressResolver>().RestartAddressQueries();
@@ -981,7 +979,7 @@ otError Mle::GetLocatorAddress(Ip6::Address &aAddress, uint16_t aLocator) const
     VerifyOrExit(GetRloc16() != Mac::kShortAddrInvalid, error = OT_ERROR_DETACHED);
 
     memcpy(&aAddress, &mMeshLocal16.GetAddress(), 14);
-    aAddress.SetLocator(aLocator);
+    aAddress.GetIid().SetLocator(aLocator);
 
 exit:
     return error;
@@ -1464,8 +1462,7 @@ void Mle::HandleNotifierEvents(Events aEvents)
         if (!Get<ThreadNetif>().HasUnicastAddress(mMeshLocal64.GetAddress()))
         {
             // Mesh Local EID was removed, choose a new one and add it back
-            IgnoreError(Random::Crypto::FillBuffer(mMeshLocal64.GetAddress().mFields.m8 + OT_IP6_PREFIX_SIZE,
-                                                   OT_IP6_ADDRESS_SIZE - OT_IP6_PREFIX_SIZE));
+            mMeshLocal64.GetAddress().GetIid().GenerateRandom();
 
             Get<ThreadNetif>().AddUnicastAddress(mMeshLocal64);
             Get<Notifier>().Signal(kEventThreadMeshLocalAddrChanged);
@@ -1564,13 +1561,13 @@ void Mle::UpdateServiceAlocs(void)
     // First remove all alocs which are no longer necessary, to free up space in mServiceAlocs
     for (i = 0; i < serviceAlocsLength; i++)
     {
-        serviceAloc = mServiceAlocs[i].GetAddress().GetLocator();
+        serviceAloc = mServiceAlocs[i].GetAddress().GetIid().GetLocator();
 
         if ((serviceAloc != Mac::kShortAddrInvalid) &&
             (!Get<NetworkData::Leader>().ContainsService(Mle::ServiceIdFromAloc(serviceAloc), rloc)))
         {
             Get<ThreadNetif>().RemoveUnicastAddress(mServiceAlocs[i]);
-            mServiceAlocs[i].GetAddress().SetLocator(Mac::kShortAddrInvalid);
+            mServiceAlocs[i].GetAddress().GetIid().SetLocator(Mac::kShortAddrInvalid);
         }
     }
 
@@ -1579,7 +1576,7 @@ void Mle::UpdateServiceAlocs(void)
     {
         for (i = 0; i < serviceAlocsLength; i++)
         {
-            serviceAloc = mServiceAlocs[i].GetAddress().GetLocator();
+            serviceAloc = mServiceAlocs[i].GetAddress().GetIid().GetLocator();
 
             if ((serviceAloc != Mac::kShortAddrInvalid) && (Mle::ServiceIdFromAloc(serviceAloc) == serviceId))
             {
@@ -1592,7 +1589,7 @@ void Mle::UpdateServiceAlocs(void)
             // Service Aloc is not there, but it should be. Lets add it into first empty space
             for (i = 0; i < serviceAlocsLength; i++)
             {
-                serviceAloc = mServiceAlocs[i].GetAddress().GetLocator();
+                serviceAloc = mServiceAlocs[i].GetAddress().GetIid().GetLocator();
 
                 if (serviceAloc == Mac::kShortAddrInvalid)
                 {
@@ -2535,7 +2532,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     uint32_t        frameCounter;
     uint8_t         messageTag[kMleSecurityTagSize];
     uint8_t         nonce[Crypto::AesCcm::kNonceSize];
-    Mac::ExtAddress macAddr;
+    Mac::ExtAddress extAddr;
     Crypto::AesCcm  aesCcm;
     uint16_t        mleOffset;
     uint8_t         buf[64];
@@ -2596,9 +2593,10 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     aMessage.Read(aMessage.GetLength() - sizeof(messageTag), sizeof(messageTag), messageTag);
     SuccessOrExit(error = aMessage.SetLength(aMessage.GetLength() - sizeof(messageTag)));
 
-    aMessageInfo.GetPeerAddr().ToExtAddress(macAddr);
+    aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
+
     frameCounter = header.GetFrameCounter();
-    Crypto::AesCcm::GenerateNonce(macAddr, frameCounter, Mac::Frame::kSecEncMic32, nonce);
+    Crypto::AesCcm::GenerateNonce(extAddr, frameCounter, Mac::Frame::kSecEncMic32, nonce);
 
     aesCcm.SetKey(*mleKey);
     aesCcm.Init(sizeof(aMessageInfo.GetPeerAddr()) + sizeof(aMessageInfo.GetSockAddr()) + header.GetHeaderLength(),
@@ -2639,18 +2637,18 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     {
     case kRoleDetached:
     case kRoleChild:
-        neighbor = GetNeighbor(macAddr);
+        neighbor = GetNeighbor(extAddr);
         break;
 
     case kRoleRouter:
     case kRoleLeader:
         if (command == Header::kCommandChildIdResponse)
         {
-            neighbor = GetNeighbor(macAddr);
+            neighbor = GetNeighbor(extAddr);
         }
         else
         {
-            neighbor = Get<MleRouter>().GetNeighbor(macAddr);
+            neighbor = Get<MleRouter>().GetNeighbor(extAddr);
         }
 
         break;
@@ -3166,7 +3164,7 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
     SuccessOrExit(error = ReadResponse(aMessage, response));
     VerifyOrExit(response == mParentRequestChallenge, error = OT_ERROR_PARSE);
 
-    aMessageInfo.GetPeerAddr().ToExtAddress(extAddress);
+    aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddress);
 
     if (IsChild() && mParent.GetExtAddress() == extAddress)
     {
@@ -3841,12 +3839,12 @@ uint16_t Mle::GetNextHop(uint16_t aDestination) const
 
 bool Mle::IsRoutingLocator(const Ip6::Address &aAddress) const
 {
-    return IsMeshLocalAddress(aAddress) && aAddress.IsIidRoutingLocator();
+    return IsMeshLocalAddress(aAddress) && aAddress.GetIid().IsRoutingLocator();
 }
 
 bool Mle::IsAnycastLocator(const Ip6::Address &aAddress) const
 {
-    return IsMeshLocalAddress(aAddress) && aAddress.IsIidAnycastLocator();
+    return IsMeshLocalAddress(aAddress) && aAddress.GetIid().IsAnycastLocator();
 }
 
 bool Mle::IsMeshLocalAddress(const Ip6::Address &aAddress) const
@@ -3887,7 +3885,7 @@ void Mle::InformPreviousParent(void)
 
     messageInfo.SetSockAddr(GetMeshLocal64());
     messageInfo.SetPeerAddr(GetMeshLocal16());
-    messageInfo.GetPeerAddr().SetLocator(mPreviousParentRloc);
+    messageInfo.GetPeerAddr().GetIid().SetLocator(mPreviousParentRloc);
 
     SuccessOrExit(error = Get<Ip6::Ip6>().SendDatagram(*message, messageInfo, Ip6::kProtoNone));
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -611,9 +611,9 @@ void MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInf
     case OT_ERROR_NONE:
         if (IsActiveRouter(sourceAddress))
         {
-            Mac::ExtAddress macAddr;
+            Mac::ExtAddress extAddr;
 
-            aMessageInfo.GetPeerAddr().ToExtAddress(macAddr);
+            aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
 
             neighbor = mRouterTable.GetRouter(RouterIdFromRloc16(sourceAddress));
             VerifyOrExit(neighbor != nullptr, error = OT_ERROR_PARSE);
@@ -623,7 +623,7 @@ void MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInf
             {
                 const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
 
-                neighbor->SetExtAddress(macAddr);
+                neighbor->SetExtAddress(extAddr);
                 neighbor->GetLinkInfo().Clear();
                 neighbor->GetLinkInfo().AddRss(linkInfo->mRss);
                 neighbor->ResetLinkFailures();
@@ -632,7 +632,7 @@ void MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInf
             }
             else
             {
-                VerifyOrExit(neighbor->GetExtAddress() == macAddr, OT_NOOP);
+                VerifyOrExit(neighbor->GetExtAddress() == extAddr, OT_NOOP);
             }
         }
 
@@ -818,7 +818,7 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
     const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
     Router *                router;
     Neighbor::State         neighborState;
-    Mac::ExtAddress         macAddr;
+    Mac::ExtAddress         extAddr;
     uint16_t                version;
     Challenge               response;
     uint16_t                sourceAddress;
@@ -987,8 +987,8 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
     }
 
     // finish link synchronization
-    aMessageInfo.GetPeerAddr().ToExtAddress(macAddr);
-    router->SetExtAddress(macAddr);
+    aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
+    router->SetExtAddress(extAddr);
     router->SetRloc16(sourceAddress);
     router->SetLinkFrameCounter(linkFrameCounter);
     router->SetMleFrameCounter(mleFrameCounter);
@@ -1174,7 +1174,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
     otError                 error    = OT_ERROR_NONE;
     const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
     uint8_t linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
-    Mac::ExtAddress macAddr;
+    Mac::ExtAddress extAddr;
     uint16_t        sourceAddress = Mac::kShortAddrInvalid;
     LeaderData      leaderData;
     RouteTlv        route;
@@ -1183,7 +1183,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
     uint8_t         routerId;
     uint8_t         routerCount;
 
-    aMessageInfo.GetPeerAddr().ToExtAddress(macAddr);
+    aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
 
     // Source Address
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
@@ -1371,7 +1371,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
             if (IsFullThreadDevice() && !router->IsStateValid() && !router->IsStateLinkRequest() &&
                 (mRouterTable.GetActiveLinkCount() < OPENTHREAD_CONFIG_MLE_CHILD_ROUTER_LINKS))
             {
-                router->SetExtAddress(macAddr);
+                router->SetExtAddress(extAddr);
                 router->GetLinkInfo().Clear();
                 router->GetLinkInfo().AddRss(linkInfo->mRss);
                 router->ResetLinkFailures();
@@ -1418,7 +1418,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
         if (!router->IsStateValid() && !router->IsStateLinkRequest() && (mChallengeTimeout == 0) &&
             (linkMargin >= OPENTHREAD_CONFIG_MLE_LINK_REQUEST_MARGIN_MIN))
         {
-            router->SetExtAddress(macAddr);
+            router->SetExtAddress(extAddr);
             router->GetLinkInfo().Clear();
             router->GetLinkInfo().AddRss(linkInfo->mRss);
             router->ResetLinkFailures();
@@ -1601,7 +1601,7 @@ void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageI
 {
     otError                 error    = OT_ERROR_NONE;
     const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
-    Mac::ExtAddress         macAddr;
+    Mac::ExtAddress         extAddr;
     uint16_t                version;
     uint8_t                 scanMask;
     Challenge               challenge;
@@ -1642,7 +1642,7 @@ void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageI
     // the network (because Leader would reject any further address solicit).
     // ==> Verified below when checking the scan mask.
 
-    aMessageInfo.GetPeerAddr().ToExtAddress(macAddr);
+    aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
 
     // Version
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kVersion, version));
@@ -1671,14 +1671,14 @@ void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageI
     // Challenge
     SuccessOrExit(error = ReadChallenge(aMessage, challenge));
 
-    child = mChildTable.FindChild(macAddr, Child::kInStateAnyExceptInvalid);
+    child = mChildTable.FindChild(extAddr, Child::kInStateAnyExceptInvalid);
 
     if (child == nullptr)
     {
         VerifyOrExit((child = mChildTable.GetNewChild()) != nullptr, OT_NOOP);
 
         // MAC Address
-        child->SetExtAddress(macAddr);
+        child->SetExtAddress(extAddr);
         child->GetLinkInfo().Clear();
         child->GetLinkInfo().AddRss(linkInfo->mRss);
         child->ResetLinkFailures();
@@ -2079,7 +2079,7 @@ otError MleRouter::UpdateChildAddresses(const Message &aMessage, uint16_t aOffse
         }
         else
         {
-            address = *entry.GetIp6Address();
+            address = entry.GetIp6Address();
         }
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
@@ -2160,7 +2160,7 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
 {
     otError                 error    = OT_ERROR_NONE;
     const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
-    Mac::ExtAddress         macAddr;
+    Mac::ExtAddress         extAddr;
     uint16_t                version;
     Challenge               response;
     uint32_t                linkFrameCounter;
@@ -2184,9 +2184,9 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     VerifyOrExit(IsAttached(), error = OT_ERROR_INVALID_STATE);
 
     // Find Child
-    aMessageInfo.GetPeerAddr().ToExtAddress(macAddr);
+    aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
 
-    child = mChildTable.FindChild(macAddr, Child::kInStateAnyExceptInvalid);
+    child = mChildTable.FindChild(extAddr, Child::kInStateAnyExceptInvalid);
     VerifyOrExit(child != nullptr, error = OT_ERROR_ALREADY);
 
     // Version
@@ -2252,7 +2252,7 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     }
 
     // Remove from router table
-    router = mRouterTable.GetRouter(macAddr);
+    router = mRouterTable.GetRouter(extAddr);
     if (router != nullptr)
     {
         // The `router` here can be invalid
@@ -2336,7 +2336,7 @@ void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
     static const uint8_t kMaxResponseTlvs = 10;
 
     otError         error = OT_ERROR_NONE;
-    Mac::ExtAddress macAddr;
+    Mac::ExtAddress extAddr;
     uint8_t         modeBitmask;
     DeviceMode      mode;
     Challenge       challenge;
@@ -2370,8 +2370,8 @@ void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
     }
 
     // Find Child
-    aMessageInfo.GetPeerAddr().ToExtAddress(macAddr);
-    child = mChildTable.FindChild(macAddr, Child::kInStateAnyExceptInvalid);
+    aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
+    child = mChildTable.FindChild(extAddr, Child::kInStateAnyExceptInvalid);
 
     tlvs[tlvslength++] = Tlv::kSourceAddress;
 
@@ -3451,15 +3451,15 @@ Neighbor *MleRouter::GetNeighbor(const Mac::Address &aAddress)
 
 Neighbor *MleRouter::GetNeighbor(const Ip6::Address &aAddress)
 {
-    Mac::Address    macAddr;
     Lowpan::Context context;
     Child *         child;
     Neighbor *      rval = nullptr;
 
     if (aAddress.IsLinkLocal())
     {
-        aAddress.ToExtAddress(macAddr);
+        Mac::Address macAddr;
 
+        aAddress.GetIid().ConvertToMacAddress(macAddr);
         ExitNow(rval = GetNeighbor(macAddr));
     }
 
@@ -3472,8 +3472,8 @@ Neighbor *MleRouter::GetNeighbor(const Ip6::Address &aAddress)
     {
         child = iter.GetChild();
 
-        if ((context.mContextId == kMeshLocalPrefixContextId) && aAddress.IsIidLocator() &&
-            (aAddress.GetLocator() == child->GetRloc16()))
+        if ((context.mContextId == kMeshLocalPrefixContextId) && aAddress.GetIid().IsLocator() &&
+            (aAddress.GetIid().GetLocator() == child->GetRloc16()))
         {
             ExitNow(rval = child);
         }
@@ -3486,9 +3486,9 @@ Neighbor *MleRouter::GetNeighbor(const Ip6::Address &aAddress)
 
     VerifyOrExit(context.mContextId == kMeshLocalPrefixContextId, rval = nullptr);
 
-    if (aAddress.IsIidLocator())
+    if (aAddress.GetIid().IsLocator())
     {
-        rval = mRouterTable.GetNeighbor(aAddress.GetLocator());
+        rval = mRouterTable.GetNeighbor(aAddress.GetIid().GetLocator());
     }
 
 exit:

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -923,28 +923,28 @@ public:
     void SetContextId(uint8_t aContextId) { mControl = kCompressed | aContextId; }
 
     /**
-     * This method returns a pointer to the IID value.
+     * This method returns the IID value.
      *
-     * @returns A pointer to the IID value.
+     * @returns The IID value.
      *
      */
-    const uint8_t *GetIid(void) const { return mIid; }
+    const Ip6::InterfaceIdentifier &GetIid(void) const { return mIid; }
 
     /**
      * This method sets the IID value.
      *
-     * @param[in]  aIid  A pointer to the IID value.
+     * @param[in]  aIid  The IID value.
      *
      */
-    void SetIid(const uint8_t *aIid) { memcpy(mIid, aIid, sizeof(mIid)); }
+    void SetIid(const Ip6::InterfaceIdentifier &aIid) { mIid = aIid; }
 
     /**
-     * This method returns a pointer to the IPv6 Address value.
+     * This method returns the IPv6 Address value.
      *
-     * @returns A pointer to the IPv6 Address value.
+     * @returns The IPv6 Address value.
      *
      */
-    const Ip6::Address *GetIp6Address(void) const { return &mIp6Address; }
+    const Ip6::Address &GetIp6Address(void) const { return mIp6Address; }
 
     /**
      * This method sets the IPv6 Address value.
@@ -964,8 +964,8 @@ private:
     uint8_t mControl;
     union
     {
-        uint8_t      mIid[Ip6::Address::kInterfaceIdentifierSize];
-        Ip6::Address mIp6Address;
+        Ip6::InterfaceIdentifier mIid;
+        Ip6::Address             mIp6Address;
     } OT_TOOL_PACKED_FIELD;
 } OT_TOOL_PACKED_END;
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -144,7 +144,7 @@ void Leader::HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &a
 
     otLogInfoNetData("Received network data registration");
 
-    VerifyOrExit(aMessageInfo.GetPeerAddr().IsIidRoutingLocator(), OT_NOOP);
+    VerifyOrExit(aMessageInfo.GetPeerAddr().GetIid().IsRoutingLocator(), OT_NOOP);
 
     switch (Tlv::FindUint16Tlv(aMessage, ThreadTlv::kRloc16, rloc16))
     {
@@ -160,7 +160,8 @@ void Leader::HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &a
     if (ThreadTlv::FindTlv(aMessage, ThreadTlv::kThreadNetworkData, sizeof(networkData), networkData) == OT_ERROR_NONE)
     {
         VerifyOrExit(networkData.IsValid(), OT_NOOP);
-        RegisterNetworkData(aMessageInfo.GetPeerAddr().GetLocator(), networkData.GetTlvs(), networkData.GetLength());
+        RegisterNetworkData(aMessageInfo.GetPeerAddr().GetIid().GetLocator(), networkData.GetTlvs(),
+                            networkData.GetLength());
     }
 
     SuccessOrExit(Get<Coap::Coap>().SendEmptyAck(aMessage, aMessageInfo));

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -884,7 +884,7 @@ public:
      * @retval FALSE  If the TLV does not appear to be well-formed.
      *
      */
-    bool IsValid(void) const { return !IsExtended() && (GetLength() % OT_IP6_ADDRESS_SIZE == 0); }
+    bool IsValid(void) const { return !IsExtended() && (GetLength() % sizeof(Ip6::Address) == 0); }
 
     /**
      * This method returns a pointer to the IPv6 address entry.

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -585,12 +585,12 @@ public:
     otError GetMeshLocalIp6Address(Ip6::Address &aAddress) const;
 
     /**
-     * This method returns a pointer to the Mesh Local Interface Identifier.
+     * This method returns the Mesh Local Interface Identifier.
      *
-     * @returns a pointer to the Mesh Local Interface Identifier.
+     * @returns The Mesh Local Interface Identifier.
      *
      */
-    const uint8_t *GetMeshLocalIid(void) const { return mMeshLocalIid; }
+    const Ip6::InterfaceIdentifier &GetMeshLocalIid(void) const { return mMeshLocalIid; }
 
     /**
      * This method gets the next IPv6 address in the list.
@@ -753,9 +753,9 @@ private:
         kNumIp6Addresses = OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD - 1,
     };
 
-    uint8_t      mNetworkDataVersion;                                   ///< Current Network Data version
-    uint8_t      mMeshLocalIid[Ip6::Address::kInterfaceIdentifierSize]; ///< IPv6 address IID for mesh-local address
-    Ip6::Address mIp6Address[kNumIp6Addresses];                         ///< Registered IPv6 addresses
+    uint8_t                  mNetworkDataVersion;           ///< Current Network Data version
+    Ip6::InterfaceIdentifier mMeshLocalIid;                 ///< IPv6 address IID for mesh-local address
+    Ip6::Address             mIp6Address[kNumIp6Addresses]; ///< Registered IPv6 addresses
 
     uint32_t mTimeout; ///< Child timeout
 

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -290,7 +290,7 @@ otError Slaac::GenerateIid(Ip6::NetifUnicastAddress &aAddress,
     Crypto::Sha256 sha256;
     uint8_t        hash[Crypto::Sha256::kHashSize];
 
-    static_assert(sizeof(hash) >= Ip6::Address::kInterfaceIdentifierSize,
+    static_assert(sizeof(hash) >= Ip6::InterfaceIdentifier::kSize,
                   "SHA-256 hash size is too small to use as IPv6 address IID");
 
     GetIidSecretKey(secretKey);
@@ -310,10 +310,10 @@ otError Slaac::GenerateIid(Ip6::NetifUnicastAddress &aAddress,
         sha256.Update(secretKey.m8, sizeof(IidSecretKey));
         sha256.Finish(hash);
 
-        aAddress.GetAddress().SetIid(&hash[0]);
+        aAddress.GetAddress().GetIid().SetBytes(&hash[0]);
 
         // If the IID is reserved, try again with a new dadCounter
-        if (aAddress.GetAddress().IsIidReserved())
+        if (aAddress.GetAddress().GetIid().IsReserved())
         {
             continue;
         }

--- a/tests/unit/test_child.cpp
+++ b/tests/unit/test_child.cpp
@@ -114,7 +114,10 @@ void TestChildIp6Address(void)
         "fd00:1234::204c:3d7c:98f6:9a1b",
     };
 
-    const uint8_t meshLocalIid[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
+    const uint8_t            meshLocalIidArray[] = {0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88};
+    Ip6::InterfaceIdentifier meshLocalIid;
+
+    meshLocalIid.SetBytes(meshLocalIidArray);
 
     sInstance = testInitInstance();
     VerifyOrQuit(sInstance != nullptr, "Null instance");


### PR DESCRIPTION
This commit updates `Ip6::InterfaceIdentifier` class adding new helper methods to it (e.g., generate random IID, or convert IID to/from a MAC Extended Address). It also updates the `Ip6::Address` methods (related to getting/setting IID) to use the `Ip6::InterfaceIdentifier` type.

The larger change in this commit is to update other core classes and modules (`Lowpan`, `Mle`, `Settings`, `AddressResolver`, `Child`, etc.) to use the `Ip6::InterfaceIdentifier`/`Ip6::Address` type and their new/changed methods.

This commit also adds a new `struct` type `otIp6AddressComponents` to the public OT API header `ip6.h`. This type represents the components of a (unicast) IPv6 address, i.e. a network prefix and an IID. The `otIp6Address` uses the new type as one of its `union` representations of an IPv6 address.