### PR TITLE
[otns] add radio event status emission

### DIFF
--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -965,6 +965,14 @@ public:
      */
     InfoString ToInfoString(void) const;
 
+    /**
+     * This method returns the Frame Control field of the frame.
+     *
+     * @returns The Frame Control field.
+     *
+     */
+    uint16_t GetFrameControlField(void) const;
+
 protected:
     enum
     {
@@ -974,7 +982,6 @@ protected:
         kSequenceIndex = kFcfSize,
     };
 
-    uint16_t GetFrameControlField(void) const;
     uint8_t  FindDstPanIdIndex(void) const;
     uint8_t  FindDstAddrIndex(void) const;
     uint8_t  FindSrcPanIdIndex(void) const;

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -982,14 +982,14 @@ protected:
         kSequenceIndex = kFcfSize,
     };
 
-    uint8_t  FindDstPanIdIndex(void) const;
-    uint8_t  FindDstAddrIndex(void) const;
-    uint8_t  FindSrcPanIdIndex(void) const;
-    uint8_t  FindSrcAddrIndex(void) const;
-    uint8_t  SkipAddrFieldIndex(void) const;
-    uint8_t  FindSecurityHeaderIndex(void) const;
-    uint8_t  SkipSecurityHeaderIndex(void) const;
-    uint8_t  FindPayloadIndex(void) const;
+    uint8_t FindDstPanIdIndex(void) const;
+    uint8_t FindDstAddrIndex(void) const;
+    uint8_t FindSrcPanIdIndex(void) const;
+    uint8_t FindSrcAddrIndex(void) const;
+    uint8_t SkipAddrFieldIndex(void) const;
+    uint8_t FindSecurityHeaderIndex(void) const;
+    uint8_t SkipSecurityHeaderIndex(void) const;
+    uint8_t FindPayloadIndex(void) const;
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
     uint8_t FindHeaderIeIndex(void) const;
 #endif

--- a/src/core/radio/radio.cpp
+++ b/src/core/radio/radio.cpp
@@ -51,4 +51,13 @@ void Radio::SetShortAddress(Mac::ShortAddress aShortAddress)
 #endif
 }
 
+otError Radio::Transmit(Mac::TxFrame &aFrame)
+{
+#if (OPENTHREAD_MTD || OPENTHREAD_FTD) && OPENTHREAD_CONFIG_OTNS_ENABLE
+    Get<Utils::Otns>().EmitTransmit(aFrame);
+#endif
+
+    return otPlatRadioTransmit(GetInstance(), &aFrame);
+}
+
 } // namespace ot

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -428,7 +428,7 @@ public:
      * @retval OT_ERROR_INVALID_STATE The radio was not in the Receive state.
      *
      */
-    otError Transmit(Mac::TxFrame &aFrame) { return otPlatRadioTransmit(GetInstance(), &aFrame); }
+    otError Transmit(Mac::TxFrame &aFrame);
 
     /**
      * This method gets the most recent RSSI measurement.

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -136,7 +136,7 @@ void Otns::EmitTransmit(const Mac::TxFrame &aFrame)
     uint16_t     frameControlField = aFrame.GetFrameControlField();
     uint8_t      channel           = aFrame.GetChannel();
     uint8_t      sequence          = aFrame.GetSequence();
-    
+
     IgnoreError(aFrame.GetDstAddr(dst));
 
     if (dst.IsShort())

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -133,10 +133,11 @@ void Otns::EmitNeighborChange(otNeighborTableEvent aEvent, Neighbor &aNeighbor)
 void Otns::EmitTransmit(const Mac::TxFrame &aFrame)
 {
     Mac::Address dst;
+    uint16_t     frameControlField = aFrame.GetFrameControlField();
+    uint8_t      channel           = aFrame.GetChannel();
+    uint8_t      sequence          = aFrame.GetSequence();
+    
     IgnoreError(aFrame.GetDstAddr(dst));
-    uint16_t frameControlField = aFrame.GetFrameControlField();
-    uint8_t channel = aFrame.GetChannel();
-    uint8_t sequence = aFrame.GetSequence();
 
     if (dst.IsShort())
     {

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -130,6 +130,31 @@ void Otns::EmitNeighborChange(otNeighborTableEvent aEvent, Neighbor &aNeighbor)
     }
 }
 
+void Otns::EmitTransmit(const Mac::TxFrame &aFrame)
+{
+    Mac::Address dst;
+    IgnoreError(aFrame.GetDstAddr(dst));
+    uint16_t frameControlField = aFrame.GetFrameControlField();
+    uint8_t channel = aFrame.GetChannel();
+    uint8_t sequence = aFrame.GetSequence();
+
+    if (dst.IsShort())
+    {
+        EmitStatus("transmit=%d,%04x,%d,%04x", channel, frameControlField, sequence, dst.GetShort());
+    }
+    else if (dst.IsExtended())
+    {
+        Mac::ExtAddress revExtAddress;
+        revExtAddress.Set(dst.GetExtended().m8, Mac::ExtAddress::kReverseByteOrder);
+        EmitStatus("transmit=%d,%04x,%d,%s", channel, frameControlField, sequence,
+                   revExtAddress.ToString().AsCString());
+    }
+    else
+    {
+        EmitStatus("transmit=%d,%04x,%d", channel, frameControlField, sequence);
+    }
+}
+
 } // namespace Utils
 } // namespace ot
 

--- a/src/core/utils/otns.hpp
+++ b/src/core/utils/otns.hpp
@@ -124,6 +124,14 @@ public:
      */
     static void EmitNeighborChange(otNeighborTableEvent aEvent, Neighbor &aNeighbor);
 
+    /**
+     * This function emits a transmit event to OTNS.
+     *
+     * @param[in]  aFrame  The frame of the transmission.
+     *
+     */
+    static void EmitTransmit(const Mac::TxFrame &aFrame);
+
 private:
     static void EmitStatus(const char *aFmt, ...);
 


### PR DESCRIPTION
This PR adds code in base radio implementation to emit radio events to logs, when OTNS is turned on. This is for Silk-OTNS integration's message visualizations.

This PR works together with https://github.com/openthread/ot-ns/pull/42