### PR TITLE
[efr32] process received packet immediately

### DIFF
--- a/examples/platforms/efr32mg1/README.md
+++ b/examples/platforms/efr32mg1/README.md
@@ -112,7 +112,7 @@ $ arm-none-eabi-objcopy -O ihex ot-cli-ftd ot-cli-ftd.ihex
 $ <path-to-simplicity-studio>/developer/adapter_packs/commander/commander
 ```
 
-In the J-Link Device drop-down list select the serial number of the device to flash. Click the Adapter Connect button. Esnure the Debug Interface drop-down list is set to SWD and click the Target Connect button. Click on the Flash icon on the left side of the window to switch to the flash page. In the Flash MCU pane enter the path of the ot-cli-ftd.s37 file or choose the file with the Browse... button. Click the Flash button located under the Browse... button.
+In the J-Link Device drop-down list select the serial number of the device to flash. Click the Adapter Connect button. Ensure the Debug Interface drop-down list is set to SWD and click the Target Connect button. Click on the Flash icon on the left side of the window to switch to the flash page. In the Flash MCU pane enter the path of the ot-cli-ftd.s37 file or choose the file with the Browse... button. Click the Flash button located under the Browse... button.
 
 ## Run the example with EFR32MG1 boards
 

--- a/examples/platforms/efr32mg1/radio.c
+++ b/examples/platforms/efr32mg1/radio.c
@@ -838,7 +838,7 @@ static void processNextRxPacket(otInstance *aInstance)
     }
     else
     {
-        // signal MAC layer for each received frame if promiscous is enabled
+        // signal MAC layer for each received frame if promiscuous is enabled
         // otherwise only signal MAC layer for non-ACK frame
         otEXPECT(sPromiscuous || (length != IEEE802154_ACK_LENGTH));
 
@@ -1059,6 +1059,10 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
 
 void efr32RadioProcess(otInstance *aInstance)
 {
+    // We should process the received packet first. Adding it at the end of this function,
+    // will delay the stack notification until the next call to efr32RadioProcess()
+    processNextRxPacket(aInstance);
+
     if (sState == OT_RADIO_STATE_TRANSMIT && sTransmitBusy == false)
     {
         if (sTransmitError != OT_ERROR_NONE)
@@ -1099,8 +1103,6 @@ void efr32RadioProcess(otInstance *aInstance)
         sRailDebugCounters.mRailEventEnergyScanCompleted++;
 #endif
     }
-
-    processNextRxPacket(aInstance);
 }
 
 otError otPlatRadioGetTransmitPower(otInstance *aInstance, int8_t *aPower)

--- a/examples/platforms/efr32mg12/README.md
+++ b/examples/platforms/efr32mg12/README.md
@@ -125,7 +125,7 @@ $ arm-none-eabi-objcopy -O ihex ot-cli-ftd ot-cli-ftd.ihex
 $ <path-to-simplicity-studio>/developer/adapter_packs/commander/commander
 ```
 
-In the J-Link Device drop-down list select the serial number of the device to flash. Click the Adapter Connect button. Esnure the Debug Interface drop-down list is set to SWD and click the Target Connect button. Click on the Flash icon on the left side of the window to switch to the flash page. In the Flash MCU pane enter the path of the ot-cli-ftd.s37 file or choose the file with the Browse... button. Click the Flash button located under the Browse... button.
+In the J-Link Device drop-down list select the serial number of the device to flash. Click the Adapter Connect button. Ensure the Debug Interface drop-down list is set to SWD and click the Target Connect button. Click on the Flash icon on the left side of the window to switch to the flash page. In the Flash MCU pane enter the path of the ot-cli-ftd.s37 file or choose the file with the Browse... button. Click the Flash button located under the Browse... button.
 
 ## Run the example with EFR32MG12 boards
 

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -1059,6 +1059,10 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
 
 void efr32RadioProcess(otInstance *aInstance)
 {
+    // We should process the received packet first. Adding it at the end of this function,
+    // will delay the stack notification until the next call to efr32RadioProcess()
+    processNextRxPacket(aInstance);
+
     if (sState == OT_RADIO_STATE_TRANSMIT && sTransmitBusy == false)
     {
         if (sTransmitError != OT_ERROR_NONE)
@@ -1099,8 +1103,6 @@ void efr32RadioProcess(otInstance *aInstance)
         sRailDebugCounters.mRailEventEnergyScanCompleted++;
 #endif
     }
-
-    processNextRxPacket(aInstance);
 }
 
 otError otPlatRadioGetTransmitPower(otInstance *aInstance, int8_t *aPower)

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -838,7 +838,7 @@ static void processNextRxPacket(otInstance *aInstance)
     }
     else
     {
-        // signal MAC layer for each received frame if promiscous is enabled
+        // signal MAC layer for each received frame if promiscuous is enabled
         // otherwise only signal MAC layer for non-ACK frame
         otEXPECT(sPromiscuous || (length != IEEE802154_ACK_LENGTH));
 

--- a/examples/platforms/efr32mg12/sleepy-demo/README.md
+++ b/examples/platforms/efr32mg12/sleepy-demo/README.md
@@ -1,6 +1,6 @@
 # EFR32MG12 Sleepy Demo Example
 
-The EFR32 Sleepy applications demonstrates Sleepy End Device behaviour using the EFR32's low power EM2 mode. The steps below will take you through the process of building and running the demo
+The EFR32 Sleepy applications demonstrates Sleepy End Device behavior using the EFR32's low power EM2 mode. The steps below will take you through the process of building and running the demo
 
 For setting up the build environment refer to [examples/platforms/efr32mg12/README.md](../README.md).
 
@@ -35,7 +35,7 @@ sleepy-demo-ftd started
 sleepy-demo-ftd changed to leader
 ```
 
-When the sleepy-demo-mtd device starts it joins the preconfigured Thread network before disabling Rx-On-Idle to become a Sleepy-End-Device.
+When the sleepy-demo-mtd device starts it joins the pre-configured Thread network before disabling Rx-On-Idle to become a Sleepy-End-Device.
 
 Use the command "child table" in the FTD console and observe the R flag of the child is 0.
 
@@ -62,9 +62,9 @@ This will toggle the state of LED0 on the MTD. If the MTD is operating as a slee
 
 ## 5. Monitoring power consumption of the MTD
 
-Open the Energy Profiler within Silicon Labs Simplicity Studio. Within the Quick Access menu select Start Energy Capture... and select the MTD device. When operating as a Sleepy End Device with no LEDs on the current should be under 20 microamps with occassional spikes during waking and polling the parent. With the LED on the MTD has a current consumption of approximately 1mA.
+Open the Energy Profiler within Silicon Labs Simplicity Studio. Within the Quick Access menu select Start Energy Capture... and select the MTD device. When operating as a Sleepy End Device with no LEDs on the current should be under 20 microamps with occasional spikes during waking and polling the parent. With the LED on the MTD has a current consumption of approximately 1mA.
 
-When operating as a Minial End Device with the Rx on Idle observe that the current is in the order of 10ma.
+When operating as a Minimal End Device with the Rx on Idle observe that the current is in the order of 10ma.
 
 With further configuration of GPIOs and peripherals it is possible to reduce the sleepy current consumption further.
 

--- a/examples/platforms/efr32mg13/README.md
+++ b/examples/platforms/efr32mg13/README.md
@@ -118,7 +118,7 @@ $ arm-none-eabi-objcopy -O ihex ot-cli-ftd ot-cli-ftd.ihex
 $ <path-to-simplicity-studio>/developer/adapter_packs/commander/commander
 ```
 
-In the J-Link Device drop-down list select the serial number of the device to flash. Click the Adapter Connect button. Esnure the Debug Interface drop-down list is set to SWD and click the Target Connect button. Click on the Flash icon on the left side of the window to switch to the flash page. In the Flash MCU pane enter the path of the ot-cli-ftd.s37 file or choose the file with the Browse... button. Click the Flash button located under the Browse... button.
+In the J-Link Device drop-down list select the serial number of the device to flash. Click the Adapter Connect button. Ensure the Debug Interface drop-down list is set to SWD and click the Target Connect button. Click on the Flash icon on the left side of the window to switch to the flash page. In the Flash MCU pane enter the path of the ot-cli-ftd.s37 file or choose the file with the Browse... button. Click the Flash button located under the Browse... button.
 
 ## Run the example with EFR32MG13 boards
 

--- a/examples/platforms/efr32mg13/radio.c
+++ b/examples/platforms/efr32mg13/radio.c
@@ -1059,6 +1059,10 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
 
 void efr32RadioProcess(otInstance *aInstance)
 {
+    // We should process the received packet first. Adding it at the end of this function,
+    // will delay the stack notification until the next call to efr32RadioProcess()
+    processNextRxPacket(aInstance);
+
     if (sState == OT_RADIO_STATE_TRANSMIT && sTransmitBusy == false)
     {
         if (sTransmitError != OT_ERROR_NONE)
@@ -1099,8 +1103,6 @@ void efr32RadioProcess(otInstance *aInstance)
         sRailDebugCounters.mRailEventEnergyScanCompleted++;
 #endif
     }
-
-    processNextRxPacket(aInstance);
 }
 
 otError otPlatRadioGetTransmitPower(otInstance *aInstance, int8_t *aPower)

--- a/examples/platforms/efr32mg13/radio.c
+++ b/examples/platforms/efr32mg13/radio.c
@@ -838,7 +838,7 @@ static void processNextRxPacket(otInstance *aInstance)
     }
     else
     {
-        // signal MAC layer for each received frame if promiscous is enabled
+        // signal MAC layer for each received frame if promiscuous is enabled
         // otherwise only signal MAC layer for non-ACK frame
         otEXPECT(sPromiscuous || (length != IEEE802154_ACK_LENGTH));
 

--- a/examples/platforms/efr32mg13/sleepy-demo/README.md
+++ b/examples/platforms/efr32mg13/sleepy-demo/README.md
@@ -1,6 +1,6 @@
 # EFR32MG13 Sleepy Demo Example
 
-The EFR32 Sleepy applications demonstrates Sleepy End Device behaviour using the EFR32's low power EM2 mode. The steps below will take you through the process of building and running the demo
+The EFR32 Sleepy applications demonstrates Sleepy End Device behavior using the EFR32's low power EM2 mode. The steps below will take you through the process of building and running the demo
 
 For setting up the build environment refer to [examples/platforms/efr32mg13/README.md](../README.md).
 
@@ -35,7 +35,7 @@ sleepy-demo-ftd started
 sleepy-demo-ftd changed to leader
 ```
 
-When the sleepy-demo-mtd device starts it joins the preconfigured Thread network before disabling Rx-On-Idle to become a Sleepy-End-Device.
+When the sleepy-demo-mtd device starts it joins the pre-configured Thread network before disabling Rx-On-Idle to become a Sleepy-End-Device.
 
 Use the command "child table" in the FTD console and observe the R flag of the child is 0.
 
@@ -62,9 +62,9 @@ This will toggle the state of LED0 on the MTD. If the MTD is operating as a slee
 
 ## 5. Monitoring power consumption of the MTD
 
-Open the Energy Profiler within Silicon Labs Simplicity Studio. Within the Quick Access menu select Start Energy Capture... and select the MTD device. When operating as a Sleepy End Device with no LEDs on the current should be under 20 microamps with occassional spikes during waking and polling the parent. With the LED on the MTD has a current consumption of approximately 1mA.
+Open the Energy Profiler within Silicon Labs Simplicity Studio. Within the Quick Access menu select Start Energy Capture... and select the MTD device. When operating as a Sleepy End Device with no LEDs on the current should be under 20 microamps with occasional spikes during waking and polling the parent. With the LED on the MTD has a current consumption of approximately 1mA.
 
-When operating as a Minial End Device with the Rx on Idle observe that the current is in the order of 10ma.
+When operating as a Minimal End Device with the Rx on Idle observe that the current is in the order of 10ma.
 
 With further configuration of GPIOs and peripherals it is possible to reduce the sleepy current consumption further.
 

--- a/examples/platforms/efr32mg21/README.md
+++ b/examples/platforms/efr32mg21/README.md
@@ -91,7 +91,7 @@ $ arm-none-eabi-objcopy -O ihex ot-cli-ftd ot-cli-ftd.hex
 $ <path-to-simplicity-studio>/developer/adapter_packs/commander/commander
 ```
 
-In the J-Link Device drop-down list select the serial number of the device to flash. Click the Adapter Connect button. Esnure the Debug Interface drop-down list is set to SWD and click the Target Connect button. Click on the Flash icon on the left side of the window to switch to the flash page. In the Flash MCU pane enter the path of the ot-cli-ftd.s37 file or choose the file with the Browse... button. Click the Flash button located under the Browse... button.
+In the J-Link Device drop-down list select the serial number of the device to flash. Click the Adapter Connect button. Ensure the Debug Interface drop-down list is set to SWD and click the Target Connect button. Click on the Flash icon on the left side of the window to switch to the flash page. In the Flash MCU pane enter the path of the ot-cli-ftd.s37 file or choose the file with the Browse... button. Click the Flash button located under the Browse... button.
 
 ## Run the example with EFR32MG21 boards
 

--- a/examples/platforms/efr32mg21/radio.c
+++ b/examples/platforms/efr32mg21/radio.c
@@ -949,6 +949,10 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
 
 void efr32RadioProcess(otInstance *aInstance)
 {
+    // We should process the received packet first. Adding it at the end of this function,
+    // will delay the stack notification until the next call to efr32RadioProcess()
+    processNextRxPacket(aInstance);
+
     if (sState == OT_RADIO_STATE_TRANSMIT && sTransmitBusy == false)
     {
         if (sTransmitError != OT_ERROR_NONE)
@@ -989,8 +993,6 @@ void efr32RadioProcess(otInstance *aInstance)
         sRailDebugCounters.mRailEventEnergyScanCompleted++;
 #endif
     }
-
-    processNextRxPacket(aInstance, sRxBandConfig->mRailHandle);
 }
 
 otError otPlatRadioGetTransmitPower(otInstance *aInstance, int8_t *aPower)

--- a/examples/platforms/efr32mg21/radio.c
+++ b/examples/platforms/efr32mg21/radio.c
@@ -756,7 +756,7 @@ static void processNextRxPacket(otInstance *aInstance, RAIL_Handle_t aRailHandle
         else
 #endif
         {
-            // signal MAC layer for each received frame if promiscous is enabled
+            // signal MAC layer for each received frame if promiscuous is enabled
             // otherwise only signal MAC layer for non-ACK frame
             if (sPromiscuous || sReceiveFrame.mLength > IEEE802154_ACK_LENGTH)
             {

--- a/examples/platforms/efr32mg21/sleepy-demo/README.md
+++ b/examples/platforms/efr32mg21/sleepy-demo/README.md
@@ -1,6 +1,6 @@
 # EFR32MG21 Sleepy Demo Example
 
-The EFR32 Sleepy applications demonstrates Sleepy End Device behaviour using the EFR32's low power EM2 mode. The steps below will take you through the process of building and running the demo
+The EFR32 Sleepy applications demonstrates Sleepy End Device behavior using the EFR32's low power EM2 mode. The steps below will take you through the process of building and running the demo
 
 For setting up the build environment refer to [examples/platforms/efr32mg21/README.md](../README.md).
 
@@ -35,7 +35,7 @@ sleepy-demo-ftd started
 sleepy-demo-ftd changed to leader
 ```
 
-When the sleepy-demo-mtd device starts it joins the preconfigured Thread network before disabling Rx-On-Idle to become a Sleepy-End-Device.
+When the sleepy-demo-mtd device starts it joins the pre-configured Thread network before disabling Rx-On-Idle to become a Sleepy-End-Device.
 
 Use the command "child table" in the FTD console and observe the R flag of the child is 0.
 
@@ -48,15 +48,15 @@ Use the command "child table" in the FTD console and observe the R flag of the c
 Done
 ```
 
-## 3. MTD behaviour on wakeup
+## 3. MTD behavior on wake-up
 
 MTD wakes up every 5 seconds and sends a multicast UDP message containing the string "mtd is awake". The FTD listens on the multicast address and will toggle LED 0 and display a message in the CLI showing "Message Received: mtd is awake".
 
 ## 4. Monitoring power consumption of the MTD
 
-Open the Energy Profiler within Silicon Labs Simplicity Studio. Within the Quick Access menu select Start Energy Capture... and select the MTD device. When operating as a Sleepy End Device with no LEDs on the current should be under 20-80 microamps with occassional spikes during waking and polling the parent. With the LED on the MTD has a current consumption of approximately 1mA.
+Open the Energy Profiler within Silicon Labs Simplicity Studio. Within the Quick Access menu select Start Energy Capture... and select the MTD device. When operating as a Sleepy End Device with no LEDs on the current should be under 20-80 microamps with occasional spikes during waking and polling the parent. With the LED on the MTD has a current consumption of approximately 1mA.
 
-When operating as a Minial End Device with the Rx on Idle observe that the current is in the order of 10ma.
+When operating as a Minimal End Device with the Rx on Idle observe that the current is in the order of 10ma.
 
 With further configuration of GPIOs and peripherals it is possible to reduce the sleepy current consumption further.
 


### PR DESCRIPTION
When analyzing the energy mode transitions for a sleepy node, running the `sleepy-demo-mtd`  app, it was observed that, the current implementation of the platform radio driver (`efr32RadioProcess()`) although correct, can be optimized by processing the next received packet (`processNextRxPacket()`) before other actions being carried out in this routine. For example, in a situation where a 802.15.4 MAC Ack needs to be processed in response to a sent packet,  adding this call towards the end of this routine then delays stack notification (that a Tx was done) until the next call to `efr32RadioProcess()`.
