### PR TITLE
[mle] fix invalid router after ProcessRouteTlv

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -972,6 +972,9 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
             VerifyOrExit(route.IsValid(), error = OT_ERROR_PARSE);
             SuccessOrExit(error = ProcessRouteTlv(route));
             UpdateRoutes(route, routerId);
+            // need to update router after ProcessRouteTlv
+            router = mRouterTable.GetRouter(routerId);
+            OT_ASSERT(router != nullptr);
         }
 
         // update routing table


### PR DESCRIPTION
This PR fixes #4541 

**We always need to update existing `router` references after calling `ProcessRouteTlv`.**

A similar bug was fixed by #4860 