### PR TITLE
[udp/tcp/icmp] simplify Header parsing, and declare related types as nested

### DIFF
--- a/src/core/api/icmp6_api.cpp
+++ b/src/core/api/icmp6_api.cpp
@@ -58,7 +58,7 @@ otError otIcmp6RegisterHandler(otInstance *aInstance, otIcmp6Handler *aHandler)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Ip6::Icmp>().RegisterHandler(*static_cast<Ip6::IcmpHandler *>(aHandler));
+    return instance.Get<Ip6::Icmp>().RegisterHandler(*static_cast<Ip6::Icmp::Handler *>(aHandler));
 }
 
 otError otIcmp6SendEchoRequest(otInstance *         aInstance,

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -51,9 +51,9 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
 
 otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext)
 {
-    otError         error;
-    Instance &      instance = *static_cast<Instance *>(aInstance);
-    Ip6::UdpSocket &socket   = *new (aSocket) Ip6::UdpSocket(instance.Get<Ip6::Udp>());
+    otError           error;
+    Instance &        instance = *static_cast<Instance *>(aInstance);
+    Ip6::Udp::Socket &socket   = *new (aSocket) Ip6::Udp::Socket(instance.Get<Ip6::Udp>());
 
     error = socket.Open(aCallback, aContext);
 
@@ -62,8 +62,8 @@ otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCal
 
 otError otUdpClose(otUdpSocket *aSocket)
 {
-    otError         error  = OT_ERROR_INVALID_STATE;
-    Ip6::UdpSocket &socket = *static_cast<Ip6::UdpSocket *>(aSocket);
+    otError           error  = OT_ERROR_INVALID_STATE;
+    Ip6::Udp::Socket &socket = *static_cast<Ip6::Udp::Socket *>(aSocket);
 
     error = socket.Close();
 
@@ -72,19 +72,19 @@ otError otUdpClose(otUdpSocket *aSocket)
 
 otError otUdpBind(otUdpSocket *aSocket, otSockAddr *aSockName)
 {
-    Ip6::UdpSocket &socket = *static_cast<Ip6::UdpSocket *>(aSocket);
+    Ip6::Udp::Socket &socket = *static_cast<Ip6::Udp::Socket *>(aSocket);
     return socket.Bind(*static_cast<const Ip6::SockAddr *>(aSockName));
 }
 
 otError otUdpConnect(otUdpSocket *aSocket, otSockAddr *aSockName)
 {
-    Ip6::UdpSocket &socket = *static_cast<Ip6::UdpSocket *>(aSocket);
+    Ip6::Udp::Socket &socket = *static_cast<Ip6::Udp::Socket *>(aSocket);
     return socket.Connect(*static_cast<const Ip6::SockAddr *>(aSockName));
 }
 
 otError otUdpSend(otUdpSocket *aSocket, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    Ip6::UdpSocket &socket = *static_cast<Ip6::UdpSocket *>(aSocket);
+    Ip6::Udp::Socket &socket = *static_cast<Ip6::Udp::Socket *>(aSocket);
     return socket.SendTo(*static_cast<Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
@@ -132,14 +132,14 @@ otError otUdpAddReceiver(otInstance *aInstance, otUdpReceiver *aUdpReceiver)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Ip6::Udp>().AddReceiver(*static_cast<Ip6::UdpReceiver *>(aUdpReceiver));
+    return instance.Get<Ip6::Udp>().AddReceiver(*static_cast<Ip6::Udp::Receiver *>(aUdpReceiver));
 }
 
 otError otUdpRemoveReceiver(otInstance *aInstance, otUdpReceiver *aUdpReceiver)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Ip6::Udp>().RemoveReceiver(*static_cast<Ip6::UdpReceiver *>(aUdpReceiver));
+    return instance.Get<Ip6::Udp>().RemoveReceiver(*static_cast<Ip6::Udp::Receiver *>(aUdpReceiver));
 }
 
 otError otUdpSendDatagram(otInstance *aInstance, otMessage *aMessage, otMessageInfo *aMessageInfo)

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -628,7 +628,7 @@ private:
     static void    HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     otError        Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    Ip6::UdpSocket mSocket;
+    Ip6::Udp::Socket mSocket;
 };
 
 } // namespace Coap

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -157,7 +157,7 @@ private:
     Coap::Resource mPendingSet;
     Coap::Resource mProxyTransmit;
 
-    Ip6::UdpReceiver         mUdpReceiver; ///< The UDP receiver to receive packets from external commissioner
+    Ip6::Udp::Receiver       mUdpReceiver; ///< The UDP receiver to receive packets from external commissioner
     Ip6::NetifUnicastAddress mCommissionerAloc;
 
     TimerMilli         mTimer;

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -456,7 +456,7 @@ private:
     void *           mContext;
 
     Ip6::MessageInfo mPeerAddress;
-    Ip6::UdpSocket   mSocket;
+    Ip6::Udp::Socket mSocket;
 
     TransportCallback mTransportCallback;
     void *            mTransportContext;

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -118,8 +118,8 @@ private:
     otError        SendJoinerEntrust(const Ip6::MessageInfo &aMessageInfo);
     Coap::Message *PrepareJoinerEntrustMessage(void);
 
-    Ip6::UdpSocket mSocket;
-    Coap::Resource mRelayTransmit;
+    Ip6::Udp::Socket mSocket;
+    Coap::Resource   mRelayTransmit;
 
     TimerMilli   mTimer;
     MessageQueue mDelayedJoinEnts;

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -151,7 +151,7 @@ private:
     static bool HandleTrickleTimer(TrickleTimer &aTrickleTimer);
     bool        HandleTrickleTimer(void);
 
-    Ip6::UdpSocket mSocket;
+    Ip6::Udp::Socket mSocket;
 
     TrickleTimer mTrickleTimer;
 

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -214,7 +214,7 @@ private:
 
     otError SendReply(otIp6Address &aDst, uint8_t *aTransactionId, ClientIdentifier &aClientId, IaNa &aIaNa);
 
-    Ip6::UdpSocket mSocket;
+    Ip6::Udp::Socket mSocket;
 
     PrefixAgent mPrefixAgents[OPENTHREAD_CONFIG_DHCP6_SERVER_NUM_PREFIXES];
     uint8_t     mPrefixAgentsCount;

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -216,7 +216,7 @@ private:
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    Ip6::UdpSocket mSocket;
+    Ip6::Udp::Socket mSocket;
 
     uint16_t     mMessageId;
     MessageQueue mPendingQueries;

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -56,10 +56,10 @@ Icmp::Icmp(Instance &aInstance)
 
 Message *Icmp::NewMessage(uint16_t aReserved)
 {
-    return Get<Ip6>().NewMessage(sizeof(IcmpHeader) + aReserved);
+    return Get<Ip6>().NewMessage(sizeof(Header) + aReserved);
 }
 
-otError Icmp::RegisterHandler(IcmpHandler &aHandler)
+otError Icmp::RegisterHandler(Handler &aHandler)
 {
     return mHandlers.Add(aHandler);
 }
@@ -68,12 +68,12 @@ otError Icmp::SendEchoRequest(Message &aMessage, const MessageInfo &aMessageInfo
 {
     otError     error = OT_ERROR_NONE;
     MessageInfo messageInfoLocal;
-    IcmpHeader  icmpHeader;
+    Header      icmpHeader;
 
     messageInfoLocal = aMessageInfo;
 
-    icmpHeader.Init();
-    icmpHeader.SetType(IcmpHeader::kTypeEchoRequest);
+    icmpHeader.Clear();
+    icmpHeader.SetType(Header::kTypeEchoRequest);
     icmpHeader.SetId(aIdentifier);
     icmpHeader.SetSequence(mEchoSequence++);
 
@@ -87,16 +87,16 @@ exit:
     return error;
 }
 
-otError Icmp::SendError(IcmpHeader::Type   aType,
-                        IcmpHeader::Code   aCode,
+otError Icmp::SendError(Header::Type       aType,
+                        Header::Code       aCode,
                         const MessageInfo &aMessageInfo,
                         const Message &    aMessage)
 {
     otError           error = OT_ERROR_NONE;
     MessageInfo       messageInfoLocal;
     Message *         message = nullptr;
-    IcmpHeader        icmp6Header;
-    Header            ip6Header;
+    Header            icmp6Header;
+    ot::Ip6::Header   ip6Header;
     Message::Settings settings(Message::kWithLinkSecurity, Message::kPriorityNet);
 
     VerifyOrExit(aMessage.GetLength() >= sizeof(ip6Header), error = OT_ERROR_INVALID_ARGS);
@@ -118,7 +118,7 @@ otError Icmp::SendError(IcmpHeader::Type   aType,
 
     message->Write(sizeof(icmp6Header), sizeof(ip6Header), &ip6Header);
 
-    icmp6Header.Init();
+    icmp6Header.Clear();
     icmp6Header.SetType(aType);
     icmp6Header.SetCode(aCode);
     message->Write(0, sizeof(icmp6Header), &icmp6Header);
@@ -139,10 +139,10 @@ exit:
 
 otError Icmp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
 {
-    otError    error = OT_ERROR_NONE;
-    uint16_t   payloadLength;
-    IcmpHeader icmp6Header;
-    uint16_t   checksum;
+    otError  error = OT_ERROR_NONE;
+    uint16_t payloadLength;
+    Header   icmp6Header;
+    uint16_t checksum;
 
     VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(icmp6Header), &icmp6Header) == sizeof(icmp6Header),
                  error = OT_ERROR_PARSE);
@@ -154,14 +154,14 @@ otError Icmp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
     checksum = aMessage.UpdateChecksum(checksum, aMessage.GetOffset(), payloadLength);
     VerifyOrExit(checksum == 0xffff, error = OT_ERROR_PARSE);
 
-    if (icmp6Header.GetType() == IcmpHeader::kTypeEchoRequest)
+    if (icmp6Header.GetType() == Header::kTypeEchoRequest)
     {
         SuccessOrExit(error = HandleEchoRequest(aMessage, aMessageInfo));
     }
 
     aMessage.MoveOffset(sizeof(icmp6Header));
 
-    for (IcmpHandler *handler = mHandlers.GetHead(); handler; handler = handler->GetNext())
+    for (Handler *handler = mHandlers.GetHead(); handler; handler = handler->GetNext())
     {
         handler->HandleReceiveMessage(aMessage, aMessageInfo, icmp6Header);
     }
@@ -196,7 +196,7 @@ bool Icmp::ShouldHandleEchoRequest(const MessageInfo &aMessageInfo)
 otError Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMessageInfo)
 {
     otError     error = OT_ERROR_NONE;
-    IcmpHeader  icmp6Header;
+    Header      icmp6Header;
     Message *   replyMessage = nullptr;
     MessageInfo replyMessageInfo;
     uint16_t    payloadLength;
@@ -206,8 +206,8 @@ otError Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMe
 
     otLogInfoIcmp("Received Echo Request");
 
-    icmp6Header.Init();
-    icmp6Header.SetType(IcmpHeader::kTypeEchoReply);
+    icmp6Header.Clear();
+    icmp6Header.SetType(Header::kTypeEchoReply);
 
     if ((replyMessage = Get<Ip6>().NewMessage(0)) == nullptr)
     {
@@ -215,11 +215,11 @@ otError Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMe
         ExitNow();
     }
 
-    payloadLength = aRequestMessage.GetLength() - aRequestMessage.GetOffset() - IcmpHeader::GetDataOffset();
-    SuccessOrExit(error = replyMessage->SetLength(IcmpHeader::GetDataOffset() + payloadLength));
+    payloadLength = aRequestMessage.GetLength() - aRequestMessage.GetOffset() - Header::kDataFieldOffset;
+    SuccessOrExit(error = replyMessage->SetLength(Header::kDataFieldOffset + payloadLength));
 
-    replyMessage->Write(0, IcmpHeader::GetDataOffset(), &icmp6Header);
-    aRequestMessage.CopyTo(aRequestMessage.GetOffset() + IcmpHeader::GetDataOffset(), IcmpHeader::GetDataOffset(),
+    replyMessage->Write(0, Header::kDataFieldOffset, &icmp6Header);
+    aRequestMessage.CopyTo(aRequestMessage.GetOffset() + Header::kDataFieldOffset, Header::kDataFieldOffset,
                            payloadLength, *replyMessage);
 
     replyMessageInfo.SetPeerAddr(aMessageInfo.GetPeerAddr());
@@ -254,7 +254,7 @@ void Icmp::UpdateChecksum(Message &aMessage, uint16_t aChecksum)
     }
 
     aChecksum = HostSwap16(aChecksum);
-    aMessage.Write(aMessage.GetOffset() + IcmpHeader::GetChecksumOffset(), sizeof(aChecksum), &aChecksum);
+    aMessage.Write(aMessage.GetOffset() + Header::kChecksumFieldOffset, sizeof(aChecksum), &aChecksum);
 }
 
 } // namespace Ip6

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -884,7 +884,7 @@ void Ip6::UpdateReassemblyList(void)
         else
         {
             otLogNoteIp6("Reassembly timeout.");
-            SendIcmpError(*message, IcmpHeader::kTypeTimeExceeded, IcmpHeader::kCodeFragmReasTimeEx);
+            SendIcmpError(*message, Icmp::Header::kTypeTimeExceeded, Icmp::Header::kCodeFragmReasTimeEx);
 
             mReassemblyList.Dequeue(*message);
             message->Free();
@@ -892,7 +892,7 @@ void Ip6::UpdateReassemblyList(void)
     }
 }
 
-void Ip6::SendIcmpError(Message &aMessage, IcmpHeader::Type aIcmpType, IcmpHeader::Code aIcmpCode)
+void Ip6::SendIcmpError(Message &aMessage, Icmp::Header::Type aIcmpType, Icmp::Header::Code aIcmpCode)
 {
     otError     error = OT_ERROR_NONE;
     Header      header;
@@ -1046,18 +1046,18 @@ otError Ip6::ProcessReceiveCallback(const Message &    aMessage,
         case kProtoIcmp6:
             if (mIcmp.ShouldHandleEchoRequest(aMessageInfo))
             {
-                IcmpHeader icmp;
+                Icmp::Header icmp;
                 aMessage.Read(aMessage.GetOffset(), sizeof(icmp), &icmp);
 
                 // do not pass ICMP Echo Request messages
-                VerifyOrExit(icmp.GetType() != IcmpHeader::kTypeEchoRequest, error = OT_ERROR_DROP);
+                VerifyOrExit(icmp.GetType() != Icmp::Header::kTypeEchoRequest, error = OT_ERROR_DROP);
             }
 
             break;
 
         case kProtoUdp:
         {
-            UdpHeader udp;
+            Udp::Header udp;
             aMessage.Read(aMessage.GetOffset(), sizeof(udp), &udp);
 
             switch (udp.GetDestinationPort())

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -372,7 +372,7 @@ private:
     void        CleanupFragmentationBuffer(void);
     void        HandleUpdateTimer(void);
     void        UpdateReassemblyList(void);
-    void        SendIcmpError(Message &aMessage, IcmpHeader::Type aIcmpType, IcmpHeader::Code aIcmpCode);
+    void        SendIcmpError(Message &aMessage, Icmp::Header::Type aIcmpType, Icmp::Header::Code aIcmpCode);
     static void HandleTimer(Timer &aTimer);
 #endif
     otError AddMplOption(Message &aMessage, Header &aHeader);

--- a/src/core/net/ip6_filter.cpp
+++ b/src/core/net/ip6_filter.cpp
@@ -55,11 +55,11 @@ Filter::Filter(void)
 
 bool Filter::Accept(Message &aMessage) const
 {
-    bool      rval = false;
-    Header    ip6;
-    UdpHeader udp;
-    TcpHeader tcp;
-    uint16_t  dstport;
+    bool        rval = false;
+    Header      ip6;
+    Udp::Header udp;
+    Tcp::Header tcp;
+    uint16_t    dstport;
 
     // Allow all received IPv6 datagrams with link security enabled
     if (aMessage.IsLinkSecurityEnabled())

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -583,7 +583,7 @@ private:
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    Ip6::UdpSocket mSocket;
+    Ip6::Udp::Socket mSocket;
 
     MessageQueue mPendingQueries;
     TimerMilli   mRetransmissionTimer;

--- a/src/core/net/tcp.hpp
+++ b/src/core/net/tcp.hpp
@@ -40,6 +40,7 @@
 
 namespace ot {
 namespace Ip6 {
+namespace Tcp {
 
 /**
  * @addtogroup core-tcp
@@ -51,25 +52,12 @@ namespace Ip6 {
  *
  */
 
-OT_TOOL_PACKED_BEGIN
-struct TcpHeaderPoD
-{
-    uint16_t mSource;
-    uint16_t mDestination;
-    uint32_t mSequenceNumber;
-    uint32_t mAckNumber;
-    uint16_t mFlags;
-    uint16_t mWindow;
-    uint16_t mChecksum;
-    uint16_t mUrgentPointer;
-} OT_TOOL_PACKED_END;
-
 /**
  * This class implements TCP header parsing.
  *
  */
 OT_TOOL_PACKED_BEGIN
-class TcpHeader : private TcpHeaderPoD
+class Header
 {
 public:
     /**
@@ -136,6 +124,16 @@ public:
      */
     uint16_t GetUrgentPointer(void) const { return HostSwap16(mUrgentPointer); }
 
+private:
+    uint16_t mSource;
+    uint16_t mDestination;
+    uint32_t mSequenceNumber;
+    uint32_t mAckNumber;
+    uint16_t mFlags;
+    uint16_t mWindow;
+    uint16_t mChecksum;
+    uint16_t mUrgentPointer;
+
 } OT_TOOL_PACKED_END;
 
 /**
@@ -143,6 +141,7 @@ public:
  *
  */
 
+} // namespace Tcp
 } // namespace Ip6
 } // namespace ot
 

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -58,179 +58,265 @@ class Udp;
  */
 
 /**
- * This class implements a UDP receiver.
- *
- */
-class UdpReceiver : public otUdpReceiver, public LinkedListEntry<UdpReceiver>
-{
-    friend class Udp;
-
-public:
-    /**
-     * This constructor initializes the object.
-     *
-     * @param[in]   aUdpHandler     A pointer to the function to handle UDP message.
-     * @param[in]   aContext        A pointer to arbitrary context information.
-     *
-     */
-    UdpReceiver(otUdpHandler aHandler, void *aContext)
-    {
-        mNext    = nullptr;
-        mHandler = aHandler;
-        mContext = aContext;
-    }
-
-private:
-    bool HandleMessage(Message &aMessage, const MessageInfo &aMessageInfo)
-    {
-        return mHandler(mContext, &aMessage, &aMessageInfo);
-    }
-};
-
-/**
- * This class implements a UDP/IPv6 socket.
- *
- */
-class UdpSocket : public otUdpSocket, public InstanceLocator, public LinkedListEntry<UdpSocket>
-{
-    friend class Udp;
-    friend class LinkedList<UdpSocket>;
-
-public:
-    /**
-     * This constructor initializes the object.
-     *
-     * @param[in]  aUdp  A reference to the UDP transport object.
-     *
-     */
-    explicit UdpSocket(Udp &aUdp);
-
-    /**
-     * This method returns a new UDP message with sufficient header space reserved.
-     *
-     * @param[in]  aReserved  The number of header bytes to reserve after the UDP header.
-     * @param[in]  aSettings  The message settings (default is used if not provided).
-     *
-     * @returns A pointer to the message or nullptr if no buffers are available.
-     *
-     */
-    Message *NewMessage(uint16_t aReserved, const Message::Settings &aSettings = Message::Settings::GetDefault());
-
-    /**
-     * This method opens the UDP socket.
-     *
-     * @param[in]  aHandler  A pointer to a function that is called when receiving UDP messages.
-     * @param[in]  aContext  A pointer to arbitrary context information.
-     *
-     * @retval OT_ERROR_NONE     Successfully opened the socket.
-     * @retval OT_ERROR_ALREADY  The socket is already open.
-     *
-     */
-    otError Open(otUdpReceive aHandler, void *aContext);
-
-    /**
-     * This method binds the UDP socket.
-     *
-     * @param[in]  aSockAddr  A reference to the socket address.
-     *
-     * @retval OT_ERROR_NONE    Successfully bound the socket.
-     * @retval OT_ERROR_FAILED  Failed to bind UDP Socket.
-     *
-     */
-    otError Bind(const SockAddr &aSockAddr);
-
-    /**
-     * This method indicates whether or not the socket is bound.
-     *
-     * @retval TRUE if the socket is bound (i.e. source port is non-zero).
-     * @retval FALSE if the socket is not bound (source port is zero).
-     *
-     */
-    bool IsBound(void) const { return mSockName.mPort != 0; }
-
-    /**
-     * This method connects the UDP socket.
-     *
-     * @param[in]  aSockAddr  A reference to the socket address.
-     *
-     * @retval OT_ERROR_NONE    Successfully connected the socket.
-     * @retval OT_ERROR_FAILED  Failed to connect UDP Socket.
-     *
-     */
-    otError Connect(const SockAddr &aSockAddr);
-
-    /**
-     * This method closes the UDP socket.
-     *
-     * @retval OT_ERROR_NONE    Successfully closed the UDP socket.
-     * @retval OT_ERROR_FAILED  Failed to close UDP Socket.
-     *
-     */
-    otError Close(void);
-
-    /**
-     * This method sends a UDP message.
-     *
-     * @param[in]  aMessage      The message to send.
-     * @param[in]  aMessageInfo  The message info associated with @p aMessage.
-     *
-     * @retval OT_ERROR_NONE          Successfully sent the UDP message.
-     * @retval OT_ERROR_INVALID_ARGS  If no peer is specified in @p aMessageInfo or by connect().
-     * @retval OT_ERROR_NO_BUFS       Insufficient available buffer to add the UDP and IPv6 headers.
-     *
-     */
-    otError SendTo(Message &aMessage, const MessageInfo &aMessageInfo);
-
-    /**
-     * This method returns the local socket address.
-     *
-     * @returns A reference to the local socket address.
-     *
-     */
-    SockAddr &GetSockName(void) { return *static_cast<SockAddr *>(&mSockName); }
-
-    /**
-     * This method returns the local socket address.
-     *
-     * @returns A reference to the local socket address.
-     *
-     */
-    const SockAddr &GetSockName(void) const { return *static_cast<const SockAddr *>(&mSockName); }
-
-    /**
-     * This method returns the peer's socket address.
-     *
-     * @returns A reference to the peer's socket address.
-     *
-     */
-    SockAddr &GetPeerName(void) { return *static_cast<SockAddr *>(&mPeerName); }
-
-    /**
-     * This method returns the peer's socket address.
-     *
-     * @returns A reference to the peer's socket address.
-     *
-     */
-    const SockAddr &GetPeerName(void) const { return *static_cast<const SockAddr *>(&mPeerName); }
-
-private:
-    bool Matches(const MessageInfo &aMessageInfo) const;
-
-    void HandleUdpReceive(Message &aMessage, const MessageInfo &aMessageInfo)
-    {
-        mHandler(mContext, &aMessage, &aMessageInfo);
-    }
-};
-
-/**
  * This class implements core UDP message handling.
  *
  */
 class Udp : public InstanceLocator
 {
-    friend class UdpSocket;
-
 public:
+    /**
+     * This class implements a UDP/IPv6 socket.
+     *
+     */
+    class Socket : public otUdpSocket, public InstanceLocator, public LinkedListEntry<Socket>
+    {
+        friend class Udp;
+        friend class LinkedList<Socket>;
+
+    public:
+        /**
+         * This constructor initializes the object.
+         *
+         * @param[in]  aUdp  A reference to the UDP transport object.
+         *
+         */
+        explicit Socket(Udp &aUdp);
+
+        /**
+         * This method returns a new UDP message with sufficient header space reserved.
+         *
+         * @param[in]  aReserved  The number of header bytes to reserve after the UDP header.
+         * @param[in]  aSettings  The message settings (default is used if not provided).
+         *
+         * @returns A pointer to the message or nullptr if no buffers are available.
+         *
+         */
+        Message *NewMessage(uint16_t aReserved, const Message::Settings &aSettings = Message::Settings::GetDefault());
+
+        /**
+         * This method opens the UDP socket.
+         *
+         * @param[in]  aHandler  A pointer to a function that is called when receiving UDP messages.
+         * @param[in]  aContext  A pointer to arbitrary context information.
+         *
+         * @retval OT_ERROR_NONE     Successfully opened the socket.
+         * @retval OT_ERROR_ALREADY  The socket is already open.
+         *
+         */
+        otError Open(otUdpReceive aHandler, void *aContext);
+
+        /**
+         * This method binds the UDP socket.
+         *
+         * @param[in]  aSockAddr  A reference to the socket address.
+         *
+         * @retval OT_ERROR_NONE    Successfully bound the socket.
+         * @retval OT_ERROR_FAILED  Failed to bind UDP Socket.
+         *
+         */
+        otError Bind(const SockAddr &aSockAddr);
+
+        /**
+         * This method indicates whether or not the socket is bound.
+         *
+         * @retval TRUE if the socket is bound (i.e. source port is non-zero).
+         * @retval FALSE if the socket is not bound (source port is zero).
+         *
+         */
+        bool IsBound(void) const { return mSockName.mPort != 0; }
+
+        /**
+         * This method connects the UDP socket.
+         *
+         * @param[in]  aSockAddr  A reference to the socket address.
+         *
+         * @retval OT_ERROR_NONE    Successfully connected the socket.
+         * @retval OT_ERROR_FAILED  Failed to connect UDP Socket.
+         *
+         */
+        otError Connect(const SockAddr &aSockAddr);
+
+        /**
+         * This method closes the UDP socket.
+         *
+         * @retval OT_ERROR_NONE    Successfully closed the UDP socket.
+         * @retval OT_ERROR_FAILED  Failed to close UDP Socket.
+         *
+         */
+        otError Close(void);
+
+        /**
+         * This method sends a UDP message.
+         *
+         * @param[in]  aMessage      The message to send.
+         * @param[in]  aMessageInfo  The message info associated with @p aMessage.
+         *
+         * @retval OT_ERROR_NONE          Successfully sent the UDP message.
+         * @retval OT_ERROR_INVALID_ARGS  If no peer is specified in @p aMessageInfo or by connect().
+         * @retval OT_ERROR_NO_BUFS       Insufficient available buffer to add the UDP and IPv6 headers.
+         *
+         */
+        otError SendTo(Message &aMessage, const MessageInfo &aMessageInfo);
+
+        /**
+         * This method returns the local socket address.
+         *
+         * @returns A reference to the local socket address.
+         *
+         */
+        SockAddr &GetSockName(void) { return *static_cast<SockAddr *>(&mSockName); }
+
+        /**
+         * This method returns the local socket address.
+         *
+         * @returns A reference to the local socket address.
+         *
+         */
+        const SockAddr &GetSockName(void) const { return *static_cast<const SockAddr *>(&mSockName); }
+
+        /**
+         * This method returns the peer's socket address.
+         *
+         * @returns A reference to the peer's socket address.
+         *
+         */
+        SockAddr &GetPeerName(void) { return *static_cast<SockAddr *>(&mPeerName); }
+
+        /**
+         * This method returns the peer's socket address.
+         *
+         * @returns A reference to the peer's socket address.
+         *
+         */
+        const SockAddr &GetPeerName(void) const { return *static_cast<const SockAddr *>(&mPeerName); }
+
+    private:
+        bool Matches(const MessageInfo &aMessageInfo) const;
+
+        void HandleUdpReceive(Message &aMessage, const MessageInfo &aMessageInfo)
+        {
+            mHandler(mContext, &aMessage, &aMessageInfo);
+        }
+    };
+
+    /**
+     * This class implements a UDP receiver.
+     *
+     */
+    class Receiver : public otUdpReceiver, public LinkedListEntry<Receiver>
+    {
+        friend class Udp;
+
+    public:
+        /**
+         * This constructor initializes the UDP receiver.
+         *
+         * @param[in]   aUdpHandler     A pointer to the function to handle UDP message.
+         * @param[in]   aContext        A pointer to arbitrary context information.
+         *
+         */
+        Receiver(otUdpHandler aHandler, void *aContext)
+        {
+            mNext    = nullptr;
+            mHandler = aHandler;
+            mContext = aContext;
+        }
+
+    private:
+        bool HandleMessage(Message &aMessage, const MessageInfo &aMessageInfo)
+        {
+            return mHandler(mContext, &aMessage, &aMessageInfo);
+        }
+    };
+
+    /**
+     * This class implements UDP header generation and parsing.
+     *
+     */
+    OT_TOOL_PACKED_BEGIN
+    class Header
+    {
+    public:
+        enum : uint8_t
+        {
+            kSourcePortFieldOffset = 0, ///< The byte offset of Source Port field in UDP header.
+            kDestPortFieldOffset   = 2, ///< The byte offset of Destination Port field in UDP header.
+            kLengthFieldOffset     = 4, ///< The byte offset of Length field in UDP header.
+            kChecksumFieldOffset   = 6, ///< The byte offset of Checksum field in UDP header.
+        };
+
+        /**
+         * This method returns the UDP Source Port.
+         *
+         * @returns The UDP Source Port.
+         *
+         */
+        uint16_t GetSourcePort(void) const { return HostSwap16(mSourcePort); }
+
+        /**
+         * This method sets the UDP Source Port.
+         *
+         * @param[in]  aPort  The UDP Source Port.
+         *
+         */
+        void SetSourcePort(uint16_t aPort) { mSourcePort = HostSwap16(aPort); }
+
+        /**
+         * This method returns the UDP Destination Port.
+         *
+         * @returns The UDP Destination Port.
+         *
+         */
+        uint16_t GetDestinationPort(void) const { return HostSwap16(mDestinationPort); }
+
+        /**
+         * This method sets the UDP Destination Port.
+         *
+         * @param[in]  aPort  The UDP Destination Port.
+         *
+         */
+        void SetDestinationPort(uint16_t aPort) { mDestinationPort = HostSwap16(aPort); }
+
+        /**
+         * This method returns the UDP Length.
+         *
+         * @returns The UDP Length.
+         *
+         */
+        uint16_t GetLength(void) const { return HostSwap16(mLength); }
+
+        /**
+         * This method sets the UDP Length.
+         *
+         * @param[in]  aLength  The UDP Length.
+         *
+         */
+        void SetLength(uint16_t aLength) { mLength = HostSwap16(aLength); }
+
+        /**
+         * This method returns the UDP Checksum.
+         *
+         * @returns The UDP Checksum.
+         *
+         */
+        uint16_t GetChecksum(void) const { return HostSwap16(mChecksum); }
+
+        /**
+         * This method sets the UDP Checksum.
+         *
+         * @param[in]  aChecksum  The UDP Checksum.
+         *
+         */
+        void SetChecksum(uint16_t aChecksum) { mChecksum = HostSwap16(aChecksum); }
+
+    private:
+        uint16_t mSourcePort;
+        uint16_t mDestinationPort;
+        uint16_t mLength;
+        uint16_t mChecksum;
+
+    } OT_TOOL_PACKED_END;
+
     /**
      * This constructor initializes the object.
      *
@@ -248,7 +334,7 @@ public:
      * @retval OT_ERROR_ALREADY The UDP receiver was already added.
      *
      */
-    otError AddReceiver(UdpReceiver &aReceiver);
+    otError AddReceiver(Receiver &aReceiver);
 
     /**
      * This method removes a UDP receiver.
@@ -259,7 +345,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND   The UDP receiver was not added.
      *
      */
-    otError RemoveReceiver(UdpReceiver &aReceiver);
+    otError RemoveReceiver(Receiver &aReceiver);
 
     /**
      * This method adds a UDP socket.
@@ -267,7 +353,7 @@ public:
      * @param[in]  aSocket  A reference to the UDP socket.
      *
      */
-    void AddSocket(UdpSocket &aSocket);
+    void AddSocket(Socket &aSocket);
 
     /**
      * This method removes a UDP socket.
@@ -275,7 +361,7 @@ public:
      * @param[in]  aSocket  A reference to the UDP socket.
      *
      */
-    void RemoveSocket(UdpSocket &aSocket);
+    void RemoveSocket(Socket &aSocket);
 
     /**
      * This method returns a new ephemeral port.
@@ -346,7 +432,7 @@ public:
      * @returns A pointer to the head of UDP Socket linked list.
      *
      */
-    UdpSocket *GetUdpSockets(void) { return mSockets.GetHead(); }
+    Socket *GetUdpSockets(void) { return mSockets.GetHead(); }
 #endif
 
 #if OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE
@@ -371,113 +457,14 @@ private:
         kDynamicPortMax = 65535, ///< Service Name and Transport Protocol Port Number Registry
     };
 
-    uint16_t                mEphemeralPort;
-    LinkedList<UdpReceiver> mReceivers;
-    LinkedList<UdpSocket>   mSockets;
+    uint16_t             mEphemeralPort;
+    LinkedList<Receiver> mReceivers;
+    LinkedList<Socket>   mSockets;
 #if OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE
     void *         mUdpForwarderContext;
     otUdpForwarder mUdpForwarder;
 #endif
 };
-
-OT_TOOL_PACKED_BEGIN
-struct UdpHeaderPoD
-{
-    uint16_t mSource;
-    uint16_t mDestination;
-    uint16_t mLength;
-    uint16_t mChecksum;
-} OT_TOOL_PACKED_END;
-
-/**
- * This class implements UDP header generation and parsing.
- *
- */
-OT_TOOL_PACKED_BEGIN
-class UdpHeader : private UdpHeaderPoD
-{
-public:
-    /**
-     * This method returns the UDP Source Port.
-     *
-     * @returns The UDP Source Port.
-     *
-     */
-    uint16_t GetSourcePort(void) const { return HostSwap16(mSource); }
-
-    /**
-     * This method sets the UDP Source Port.
-     *
-     * @param[in]  aPort  The UDP Source Port.
-     *
-     */
-    void SetSourcePort(uint16_t aPort) { mSource = HostSwap16(aPort); }
-
-    /**
-     * This method returns the UDP Destination Port.
-     *
-     * @returns The UDP Destination Port.
-     *
-     */
-    uint16_t GetDestinationPort(void) const { return HostSwap16(mDestination); }
-
-    /**
-     * This method sets the UDP Destination Port.
-     *
-     * @param[in]  aPort  The UDP Destination Port.
-     *
-     */
-    void SetDestinationPort(uint16_t aPort) { mDestination = HostSwap16(aPort); }
-
-    /**
-     * This method returns the UDP Length.
-     *
-     * @returns The UDP Length.
-     *
-     */
-    uint16_t GetLength(void) const { return HostSwap16(mLength); }
-
-    /**
-     * This method sets the UDP Length.
-     *
-     * @param[in]  aLength  The UDP Length.
-     *
-     */
-    void SetLength(uint16_t aLength) { mLength = HostSwap16(aLength); }
-
-    /**
-     * This method returns the UDP Checksum.
-     *
-     * @returns The UDP Checksum.
-     *
-     */
-    uint16_t GetChecksum(void) const { return HostSwap16(mChecksum); }
-
-    /**
-     * This method sets the UDP Checksum.
-     *
-     * @param[in]  aChecksum  The UDP Checksum.
-     *
-     */
-    void SetChecksum(uint16_t aChecksum) { mChecksum = HostSwap16(aChecksum); }
-
-    /**
-     * This static method returns the byte offset for the UDP Length.
-     *
-     * @returns The byte offset for the UDP Length.
-     *
-     */
-    static uint8_t GetLengthOffset(void) { return offsetof(UdpHeaderPoD, mLength); }
-
-    /**
-     * This static method returns the byte offset for the UDP Checksum.
-     *
-     * @returns The byte offset for the UDP Checksum.
-     *
-     */
-    static uint8_t GetChecksumOffset(void) { return offsetof(UdpHeaderPoD, mChecksum); }
-
-} OT_TOOL_PACKED_END;
 
 /**
  * @}

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -947,19 +947,19 @@ void AddressResolver::HandleIcmpReceive(void *               aContext,
 
     static_cast<AddressResolver *>(aContext)->HandleIcmpReceive(*static_cast<Message *>(aMessage),
                                                                 *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-                                                                *static_cast<const Ip6::IcmpHeader *>(aIcmpHeader));
+                                                                *static_cast<const Ip6::Icmp::Header *>(aIcmpHeader));
 }
 
-void AddressResolver::HandleIcmpReceive(Message &               aMessage,
-                                        const Ip6::MessageInfo &aMessageInfo,
-                                        const Ip6::IcmpHeader & aIcmpHeader)
+void AddressResolver::HandleIcmpReceive(Message &                aMessage,
+                                        const Ip6::MessageInfo & aMessageInfo,
+                                        const Ip6::Icmp::Header &aIcmpHeader)
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
     Ip6::Header ip6Header;
 
-    VerifyOrExit(aIcmpHeader.GetType() == Ip6::IcmpHeader::kTypeDstUnreach, OT_NOOP);
-    VerifyOrExit(aIcmpHeader.GetCode() == Ip6::IcmpHeader::kCodeDstUnreachNoRoute, OT_NOOP);
+    VerifyOrExit(aIcmpHeader.GetType() == Ip6::Icmp::Header::kTypeDstUnreach, OT_NOOP);
+    VerifyOrExit(aIcmpHeader.GetCode() == Ip6::Icmp::Header::kCodeDstUnreachNoRoute, OT_NOOP);
     VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(ip6Header), &ip6Header) == sizeof(ip6Header), OT_NOOP);
 
     Remove(ip6Header.GetDestination(), kReasonReceivedIcmpDstUnreachNoRoute);

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -299,7 +299,9 @@ private:
                                   otMessage *          aMessage,
                                   const otMessageInfo *aMessageInfo,
                                   const otIcmp6Header *aIcmpHeader);
-    void HandleIcmpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo, const Ip6::IcmpHeader &aIcmpHeader);
+    void        HandleIcmpReceive(Message &                aMessage,
+                                  const Ip6::MessageInfo & aMessageInfo,
+                                  const Ip6::Icmp::Header &aIcmpHeader);
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
@@ -324,8 +326,8 @@ private:
     CacheEntryList mQueryRetryList;
     CacheEntryList mUnusedList;
 
-    Ip6::IcmpHandler mIcmpHandler;
-    TimerMilli       mTimer;
+    Ip6::Icmp::Handler mIcmpHandler;
+    TimerMilli         mTimer;
 };
 
 /**

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -562,12 +562,12 @@ exit:
 
 otError Lowpan::CompressUdp(Message &aMessage, BufferWriter &aBuf)
 {
-    otError        error       = OT_ERROR_NONE;
-    BufferWriter   buf         = aBuf;
-    uint16_t       startOffset = aMessage.GetOffset();
-    Ip6::UdpHeader udpHeader;
-    uint16_t       source;
-    uint16_t       destination;
+    otError          error       = OT_ERROR_NONE;
+    BufferWriter     buf         = aBuf;
+    uint16_t         startOffset = aMessage.GetOffset();
+    Ip6::Udp::Header udpHeader;
+    uint16_t         source;
+    uint16_t         destination;
 
     VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(udpHeader), &udpHeader) == sizeof(udpHeader),
                  error = OT_ERROR_PARSE);
@@ -597,10 +597,11 @@ otError Lowpan::CompressUdp(Message &aMessage, BufferWriter &aBuf)
     else
     {
         SuccessOrExit(error = buf.Write(kUdpDispatch));
-        SuccessOrExit(error = buf.Write(&udpHeader, Ip6::UdpHeader::GetLengthOffset()));
+        SuccessOrExit(error = buf.Write(&udpHeader, Ip6::Udp::Header::kLengthFieldOffset));
     }
 
-    SuccessOrExit(error = buf.Write(reinterpret_cast<uint8_t *>(&udpHeader) + Ip6::UdpHeader::GetChecksumOffset(), 2));
+    SuccessOrExit(error =
+                      buf.Write(reinterpret_cast<uint8_t *>(&udpHeader) + Ip6::Udp::Header::kChecksumFieldOffset, 2));
 
     aMessage.MoveOffset(sizeof(udpHeader));
 
@@ -1010,7 +1011,7 @@ exit:
     return (error == OT_ERROR_NONE) ? static_cast<int>(cur - aBuf) : -1;
 }
 
-int Lowpan::DecompressUdpHeader(Ip6::UdpHeader &aUdpHeader, const uint8_t *aBuf, uint16_t aBufLength)
+int Lowpan::DecompressUdpHeader(Ip6::Udp::Header &aUdpHeader, const uint8_t *aBuf, uint16_t aBufLength)
 {
     otError        error = OT_ERROR_PARSE;
     const uint8_t *cur   = aBuf;
@@ -1077,8 +1078,8 @@ exit:
 
 int Lowpan::DecompressUdpHeader(Message &aMessage, const uint8_t *aBuf, uint16_t aBufLength, uint16_t aDatagramLength)
 {
-    Ip6::UdpHeader udpHeader;
-    int            headerLen = -1;
+    Ip6::Udp::Header udpHeader;
+    int              headerLen = -1;
 
     headerLen = DecompressUdpHeader(udpHeader, aBuf, aBufLength);
     VerifyOrExit(headerLen >= 0, OT_NOOP);

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -309,7 +309,7 @@ public:
      * @returns The size of the compressed header in bytes or -1 if decompression fails.
      *
      */
-    int DecompressUdpHeader(Ip6::UdpHeader &aUdpHeader, const uint8_t *aBuf, uint16_t aBufLength);
+    int DecompressUdpHeader(Ip6::Udp::Header &aUdpHeader, const uint8_t *aBuf, uint16_t aBufLength);
 
 private:
     enum

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1242,12 +1242,12 @@ otError MeshForwarder::GetFramePriority(const uint8_t *     aFrame,
                                         const Mac::Address &aMacDest,
                                         Message::Priority & aPriority)
 {
-    otError         error = OT_ERROR_NONE;
-    Ip6::Header     ip6Header;
-    Ip6::UdpHeader  udpHeader;
-    Ip6::IcmpHeader icmpHeader;
-    uint8_t         headerLength;
-    bool            nextHeaderCompressed;
+    otError           error = OT_ERROR_NONE;
+    Ip6::Header       ip6Header;
+    Ip6::Udp::Header  udpHeader;
+    Ip6::Icmp::Header icmpHeader;
+    uint8_t           headerLength;
+    bool              nextHeaderCompressed;
 
     SuccessOrExit(error = DecompressIp6Header(aFrame, aFrameLength, aMacSource, aMacDest, ip6Header, headerLength,
                                               nextHeaderCompressed));
@@ -1278,8 +1278,8 @@ otError MeshForwarder::GetFramePriority(const uint8_t *     aFrame,
     }
     else
     {
-        VerifyOrExit(aFrameLength >= sizeof(Ip6::UdpHeader), error = OT_ERROR_PARSE);
-        memcpy(&udpHeader, aFrame, sizeof(Ip6::UdpHeader));
+        VerifyOrExit(aFrameLength >= sizeof(Ip6::Udp::Header), error = OT_ERROR_PARSE);
+        memcpy(&udpHeader, aFrame, sizeof(Ip6::Udp::Header));
     }
 
     if (udpHeader.GetDestinationPort() == Mle::kUdpPort || udpHeader.GetDestinationPort() == kCoapUdpPort)
@@ -1304,8 +1304,8 @@ otError MeshForwarder::ParseIp6UdpTcpHeader(const Message &aMessage,
     otError error = OT_ERROR_PARSE;
     union
     {
-        Ip6::UdpHeader udp;
-        Ip6::TcpHeader tcp;
+        Ip6::Udp::Header udp;
+        Ip6::Tcp::Header tcp;
     } header;
 
     aChecksum   = 0;
@@ -1318,7 +1318,8 @@ otError MeshForwarder::ParseIp6UdpTcpHeader(const Message &aMessage,
     switch (aIp6Header.GetNextHeader())
     {
     case Ip6::kProtoUdp:
-        VerifyOrExit(sizeof(Ip6::UdpHeader) == aMessage.Read(sizeof(Ip6::Header), sizeof(Ip6::UdpHeader), &header.udp),
+        VerifyOrExit(sizeof(Ip6::Udp::Header) ==
+                         aMessage.Read(sizeof(Ip6::Header), sizeof(Ip6::Udp::Header), &header.udp),
                      OT_NOOP);
         aChecksum   = header.udp.GetChecksum();
         aSourcePort = header.udp.GetSourcePort();
@@ -1326,7 +1327,8 @@ otError MeshForwarder::ParseIp6UdpTcpHeader(const Message &aMessage,
         break;
 
     case Ip6::kProtoTcp:
-        VerifyOrExit(sizeof(Ip6::TcpHeader) == aMessage.Read(sizeof(Ip6::Header), sizeof(Ip6::TcpHeader), &header.tcp),
+        VerifyOrExit(sizeof(Ip6::Tcp::Header) ==
+                         aMessage.Read(sizeof(Ip6::Header), sizeof(Ip6::Tcp::Header), &header.tcp),
                      OT_NOOP);
         aChecksum   = header.tcp.GetChecksum();
         aSourcePort = header.tcp.GetSourcePort();

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -602,8 +602,8 @@ void MeshForwarder::SendDestinationUnreachable(uint16_t aMeshSource, const Messa
     messageInfo.GetPeerAddr() = Get<Mle::MleRouter>().GetMeshLocal16();
     messageInfo.GetPeerAddr().SetLocator(aMeshSource);
 
-    IgnoreError(Get<Ip6::Icmp>().SendError(Ip6::IcmpHeader::kTypeDstUnreach, Ip6::IcmpHeader::kCodeDstUnreachNoRoute,
-                                           messageInfo, aMessage));
+    IgnoreError(Get<Ip6::Icmp>().SendError(Ip6::Icmp::Header::kTypeDstUnreach,
+                                           Ip6::Icmp::Header::kCodeDstUnreachNoRoute, messageInfo, aMessage));
 }
 
 void MeshForwarder::HandleMesh(uint8_t *               aFrame,
@@ -1051,8 +1051,8 @@ otError MeshForwarder::DecompressIp6UdpTcpHeader(const Message &     aMessage,
     uint16_t frameLength;
     union
     {
-        Ip6::UdpHeader udp;
-        Ip6::TcpHeader tcp;
+        Ip6::Udp::Header udp;
+        Ip6::Tcp::Header tcp;
     } header;
 
     aChecksum   = 0;
@@ -1076,13 +1076,13 @@ otError MeshForwarder::DecompressIp6UdpTcpHeader(const Message &     aMessage,
     case Ip6::kProtoUdp:
         if (nextHeaderCompressed)
         {
-            frameLength  = aMessage.Read(aOffset, sizeof(Ip6::UdpHeader), frameBuffer);
+            frameLength  = aMessage.Read(aOffset, sizeof(Ip6::Udp::Header), frameBuffer);
             headerLength = Get<Lowpan::Lowpan>().DecompressUdpHeader(header.udp, frameBuffer, frameLength);
             VerifyOrExit(headerLength >= 0, OT_NOOP);
         }
         else
         {
-            VerifyOrExit(sizeof(Ip6::UdpHeader) == aMessage.Read(aOffset, sizeof(Ip6::UdpHeader), &header.udp),
+            VerifyOrExit(sizeof(Ip6::Udp::Header) == aMessage.Read(aOffset, sizeof(Ip6::Udp::Header), &header.udp),
                          OT_NOOP);
         }
 
@@ -1092,7 +1092,8 @@ otError MeshForwarder::DecompressIp6UdpTcpHeader(const Message &     aMessage,
         break;
 
     case Ip6::kProtoTcp:
-        VerifyOrExit(sizeof(Ip6::TcpHeader) == aMessage.Read(aOffset, sizeof(Ip6::TcpHeader), &header.tcp), OT_NOOP);
+        VerifyOrExit(sizeof(Ip6::Tcp::Header) == aMessage.Read(aOffset, sizeof(Ip6::Tcp::Header), &header.tcp),
+                     OT_NOOP);
         aChecksum   = header.tcp.GetChecksum();
         aSourcePort = header.tcp.GetSourcePort();
         aDestPort   = header.tcp.GetDestinationPort();

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1741,8 +1741,8 @@ private:
 
     Challenge mParentCandidateChallenge;
 
-    Ip6::UdpSocket mSocket;
-    uint32_t       mTimeout;
+    Ip6::Udp::Socket mSocket;
+    uint32_t         mTimeout;
 
 #if OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
     uint16_t mPreviousParentRloc;

--- a/tests/unit/test_lowpan.hpp
+++ b/tests/unit/test_lowpan.hpp
@@ -253,12 +253,12 @@ public:
      * This fields represent uncompressed IPv6 packet.
      *
      */
-    Mac::Address   mMacSource;
-    Mac::Address   mMacDestination;
-    Ip6::Header    mIpHeader;
-    Payload        mExtHeader;
-    Ip6::Header    mIpTunneledHeader;
-    Ip6::UdpHeader mUdpHeader;
+    Mac::Address     mMacSource;
+    Mac::Address     mMacDestination;
+    Ip6::Header      mIpHeader;
+    Payload          mExtHeader;
+    Ip6::Header      mIpTunneledHeader;
+    Ip6::Udp::Header mUdpHeader;
 
     /**
      * This fields represent compressed IPv6 packet.


### PR DESCRIPTION
This commit contains two main changes in `Ip6` modules: `Udp`, `Tcp`,
and `Icmp`. First, it simplifies the `Header` types defining constant
`enum` for byte offset of different fields in the header (these
replace the static methods and avoid use of `offsetof` macro). Second
change is it declare related types in each module as nested types of
the the main class (place them under the namespace of the main type).
For example `Icmp::Header`, `Udp::Socket` respectively replace
`IcmpHeader`, `UdpSocket` types.