### PR TITLE
[test] fix external commissioner coverage data uploading

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -229,6 +229,9 @@ jobs:
         cd /tmp/ot-commissioner/tests/integration
         ./bootstrap.sh
         ./run_tests.sh
+    - name: Copy Codecov Files
+      run: |
+        cp -vr /tmp/test-ot-commissioner/ot-br-posix/build/* build/
     - name: Codecov
       uses: codecov/codecov-action@v1
 


### PR DESCRIPTION
This makes the external commissioner test to copy coverage files from `otbr` to `$PWD/build` so they are uploaded correctly.
Depends on https://github.com/openthread/ot-commissioner/pull/125 which enables coverage for `otbr`.