### PR TITLE
[ip6] define NetworkPrefix type

### DIFF
--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -99,23 +99,13 @@ struct otExtendedPanId
  */
 typedef struct otExtendedPanId otExtendedPanId;
 
-#define OT_MESH_LOCAL_PREFIX_SIZE 8 ///< Size of the Mesh Local Prefix (bytes)
+#define OT_MESH_LOCAL_PREFIX_SIZE OT_IP6_PREFIX_SIZE ///< Size of the Mesh Local Prefix (bytes)
 
 /**
  * This structure represents a Mesh Local Prefix.
  *
  */
-OT_TOOL_PACKED_BEGIN
-struct otMeshLocalPrefix
-{
-    uint8_t m8[OT_MESH_LOCAL_PREFIX_SIZE]; ///< Byte values
-} OT_TOOL_PACKED_END;
-
-/**
- * This structure represents a Mesh Local Prefix.
- *
- */
-typedef struct otMeshLocalPrefix otMeshLocalPrefix;
+typedef otIp6NetworkPrefix otMeshLocalPrefix;
 
 #define OT_PSKC_MAX_SIZE 16 ///< Maximum size of the PSKc (bytes)
 

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (16)
+#define OPENTHREAD_API_VERSION (17)
 
 /**
  * @addtogroup api-instance

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -322,8 +322,7 @@ otError ActiveDataset::CreateNewNetwork(otOperationalDataset &aDataset)
     SuccessOrExit(error = static_cast<Pskc &>(aDataset.mPskc).GenerateRandom());
     SuccessOrExit(error = Random::Crypto::FillBuffer(aDataset.mExtendedPanId.m8, sizeof(aDataset.mExtendedPanId)));
 
-    aDataset.mMeshLocalPrefix.m8[0] = 0xfd;
-    SuccessOrExit(error = Random::Crypto::FillBuffer(&aDataset.mMeshLocalPrefix.m8[1], OT_MESH_LOCAL_PREFIX_SIZE - 1));
+    SuccessOrExit(error = static_cast<Ip6::NetworkPrefix &>(aDataset.mMeshLocalPrefix).GenerateRandomUla());
 
     aDataset.mSecurityPolicy.mFlags = Get<KeyManager>().GetSecurityPolicyFlags();
 

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -47,6 +47,16 @@ namespace ot {
 namespace Ip6 {
 
 //---------------------------------------------------------------------------------------------------------------------
+// NetworkPrefix methods
+
+otError NetworkPrefix::GenerateRandomUla(void)
+{
+    m8[0] = 0xfd;
+
+    return Random::Crypto::FillBuffer(&m8[1], kSize - 1);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 // InterfaceIdentifier methods
 
 bool InterfaceIdentifier::IsUnspecified(void) const
@@ -252,6 +262,11 @@ void Address::SetToRealmLocalAllMplForwarders(void)
     *this = GetRealmLocalAllMplForwarders();
 }
 
+void Address::SetPrefix(const NetworkPrefix &aNetworkPrefix)
+{
+    mFields.mComponents.mNetworkPrefix = aNetworkPrefix;
+}
+
 void Address::SetPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength)
 {
     SetPrefix(0, aPrefix, aPrefixLength);
@@ -286,9 +301,9 @@ void Address::SetMulticastNetworkPrefix(const uint8_t *aPrefix, uint8_t aPrefixL
     mFields.m8[kMulticastNetworkPrefixLengthOffset] = aPrefixLength;
 }
 
-void Address::SetToLocator(const Mle::MeshLocalPrefix &aMeshLocalPrefix, uint16_t aLocator)
+void Address::SetToLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aLocator)
 {
-    SetPrefix(aMeshLocalPrefix);
+    SetPrefix(aNetworkPrefix);
     GetIid().SetToLocator(aLocator);
 }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3849,7 +3849,7 @@ bool Mle::IsAnycastLocator(const Ip6::Address &aAddress) const
 
 bool Mle::IsMeshLocalAddress(const Ip6::Address &aAddress) const
 {
-    return (memcmp(&GetMeshLocalPrefix(), &aAddress, MeshLocalPrefix::kSize) == 0);
+    return (aAddress.GetPrefix() == GetMeshLocalPrefix());
 }
 
 otError Mle::CheckReachability(uint16_t aMeshDest, Ip6::Header &aIp6Header)

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -554,7 +554,7 @@ public:
      */
     const MeshLocalPrefix &GetMeshLocalPrefix(void) const
     {
-        return reinterpret_cast<const MeshLocalPrefix &>(mMeshLocal16.GetAddress());
+        return static_cast<const MeshLocalPrefix &>(mMeshLocal16.GetAddress().GetPrefix());
     }
 
     /**

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -47,6 +47,7 @@
 #include "common/equatable.hpp"
 #include "common/string.hpp"
 #include "mac/mac_types.hpp"
+#include "net/ip6_address.hpp"
 
 namespace ot {
 namespace Mle {
@@ -430,15 +431,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class MeshLocalPrefix : public otMeshLocalPrefix, public Equatable<MeshLocalPrefix>
+class MeshLocalPrefix : public Ip6::NetworkPrefix
 {
 public:
-    enum
-    {
-        kSize   = OT_MESH_LOCAL_PREFIX_SIZE,            ///< Size in bytes.
-        kLength = OT_MESH_LOCAL_PREFIX_SIZE * CHAR_BIT, ///< Length of Mesh Local Prefix in bits.
-    };
-
     /**
      * This method derives and sets the Mesh Local Prefix from an Extended PAN ID.
      *


### PR DESCRIPTION
This commit adds `Ip6::NetworkPrefix` mirroring `otIp6NetworkPrefix`
which represents the Network Prefix (most significant 64 bits) of an
IPv6 address. Methods in `Ip6::Address` are updated to use the new
type. The `otMeshLocalPrefix` and `Mle::MeshLocalPrefix` are also
updated to use the `NetworkPrefix` type.