### PR TITLE
[otns] fix extaddr byte order

### DIFF
--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -145,10 +145,7 @@ void Otns::EmitTransmit(const Mac::TxFrame &aFrame)
     }
     else if (dst.IsExtended())
     {
-        Mac::ExtAddress revExtAddress;
-        revExtAddress.Set(dst.GetExtended().m8, Mac::ExtAddress::kReverseByteOrder);
-        EmitStatus("transmit=%d,%04x,%d,%s", channel, frameControlField, sequence,
-                   revExtAddress.ToString().AsCString());
+        EmitStatus("transmit=%d,%04x,%d,%s", channel, frameControlField, sequence, dst.ToString().AsCString());
     }
     else
     {


### PR DESCRIPTION
The extended address already has byte order reversed when calling `aFrame.GetDstAddr(dst)`. The reversal logic is therefore not needed. This PR fixes that.