### PR TITLE
[efr32] fix broken radio.c in EFR32MG21

### DIFF
--- a/examples/platforms/efr32mg21/radio.c
+++ b/examples/platforms/efr32mg21/radio.c
@@ -951,7 +951,7 @@ void efr32RadioProcess(otInstance *aInstance)
 {
     // We should process the received packet first. Adding it at the end of this function,
     // will delay the stack notification until the next call to efr32RadioProcess()
-    processNextRxPacket(aInstance);
+    processNextRxPacket(aInstance, sRxBandConfig->mRailHandle);
 
     if (sState == OT_RADIO_STATE_TRANSMIT && sTransmitBusy == false)
     {


### PR DESCRIPTION
`processNextRxPacket()` on the EFR32MG21 platform takes a RAIL handle as a second argument.