### PR TITLE
[dtls] small enhancements

### DIFF
--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -173,7 +173,7 @@ otError CoapSecure::SendMessage(Message &aMessage, ResponseHandler aHandler, voi
 
     VerifyOrExit(IsConnected(), error = OT_ERROR_INVALID_STATE);
 
-    error = CoapBase::SendMessage(aMessage, mDtls.GetPeerAddress(), aHandler, aContext);
+    error = CoapBase::SendMessage(aMessage, mDtls.GetMessageInfo(), aHandler, aContext);
 
 exit:
     return error;
@@ -223,7 +223,7 @@ void CoapSecure::HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength)
                  OT_NOOP);
     SuccessOrExit(message->Append(aBuf, aLength));
 
-    CoapBase::Receive(*message, mDtls.GetPeerAddress());
+    CoapBase::Receive(*message, mDtls.GetMessageInfo());
 
 exit:
 

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -313,7 +313,7 @@ public:
      * @return DTLS session's message info.
      *
      */
-    const Ip6::MessageInfo &GetPeerAddress(void) const { return mDtls.GetPeerAddress(); }
+    const Ip6::MessageInfo &GetMessageInfo(void) const { return mDtls.GetMessageInfo(); }
 
 private:
     static otError Send(CoapBase &aCoapBase, ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -169,7 +169,7 @@ static void SendErrorMessage(Coap::CoapSecure &aCoapSecure, ForwardContext &aFor
 
     VerifyOrExit((message = NewMeshCoPMessage(aCoapSecure)) != nullptr, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = aForwardContext.ToHeader(*message, CoapCodeFromError(aError)));
-    SuccessOrExit(error = aCoapSecure.SendMessage(*message, aCoapSecure.GetPeerAddress()));
+    SuccessOrExit(error = aCoapSecure.SendMessage(*message, aCoapSecure.GetMessageInfo()));
 
 exit:
     if (error != OT_ERROR_NONE)
@@ -209,7 +209,7 @@ static void SendErrorMessage(Coap::CoapSecure &   aCoapSecure,
 
     SuccessOrExit(error = message->SetToken(aRequest.GetToken(), aRequest.GetTokenLength()));
 
-    SuccessOrExit(error = aCoapSecure.SendMessage(*message, aCoapSecure.GetPeerAddress()));
+    SuccessOrExit(error = aCoapSecure.SendMessage(*message, aCoapSecure.GetMessageInfo()));
 
 exit:
     if (error != OT_ERROR_NONE)
@@ -463,7 +463,7 @@ bool BorderAgent::HandleUdpReceive(const Message &aMessage, const Ip6::MessageIn
     SuccessOrExit(error =
                       Tlv::AppendTlv(*message, Tlv::kIPv6Address, &aMessageInfo.GetPeerAddr(), sizeof(Ip6::Address)));
 
-    SuccessOrExit(error = Get<Coap::CoapSecure>().SendMessage(*message, Get<Coap::CoapSecure>().GetPeerAddress()));
+    SuccessOrExit(error = Get<Coap::CoapSecure>().SendMessage(*message, Get<Coap::CoapSecure>().GetMessageInfo()));
 
     otLogInfoMeshCoP("Sent to commissioner on %s", OT_URI_PATH_PROXY_RX);
 
@@ -513,7 +513,7 @@ otError BorderAgent::ForwardToCommissioner(Coap::Message &aForwardMessage, const
     aMessage.CopyTo(aMessage.GetOffset(), offset, aMessage.GetLength() - aMessage.GetOffset(), aForwardMessage);
 
     SuccessOrExit(error =
-                      Get<Coap::CoapSecure>().SendMessage(aForwardMessage, Get<Coap::CoapSecure>().GetPeerAddress()));
+                      Get<Coap::CoapSecure>().SendMessage(aForwardMessage, Get<Coap::CoapSecure>().GetMessageInfo()));
 
     otLogInfoMeshCoP("Sent to commissioner");
 

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -332,7 +332,7 @@ public:
      * @return DTLS session's message info.
      *
      */
-    const Ip6::MessageInfo &GetPeerAddress(void) const { return mPeerAddress; }
+    const Ip6::MessageInfo &GetMessageInfo(void) const { return mMessageInfo; }
 
     void HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
@@ -460,7 +460,7 @@ private:
     ReceiveHandler   mReceiveHandler;
     void *           mContext;
 
-    Ip6::MessageInfo mPeerAddress;
+    Ip6::MessageInfo mMessageInfo;
     Ip6::Udp::Socket mSocket;
 
     TransportCallback mTransportCallback;

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -53,14 +53,14 @@ namespace Ip6 {
  * This class implements message information for an IPv6 message.
  *
  */
-class MessageInfo : public otMessageInfo
+class MessageInfo : public otMessageInfo, public Clearable<MessageInfo>
 {
 public:
     /**
      * This constructor initializes the object.
      *
      */
-    MessageInfo(void) { memset(this, 0, sizeof(*this)); }
+    MessageInfo(void) { Clear(); }
 
     /**
      * This method returns a reference to the local socket address.


### PR DESCRIPTION
This commit contains few small enhancements in `Dtls`:

- It renames the `GetPeerAddress()` to `GetMessageInof()` (to indicate
  that it returns `Ip6::MessageInfo` and not just peer socket address).
  (it also renames the variable to `mMessageInfo` from `mPeerAddress`).

- Declares `Ip6::MessageInfo` to be `Clearable` and uses the `Clear()
  method instead of `new` operator to clear the `mMessageInfo`.

- Uses helper methods to set the peer socket address (remove `memcpy`).