### PR TITLE
[github-actions] allow external commissioner tests to fail

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -204,6 +204,7 @@ jobs:
       uses: codecov/codecov-action@v1
 
   external-commissioner:
+    continue-on-error: true
     runs-on: ubuntu-18.04
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -209,11 +209,9 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Bootstrap
-      continue-on-error: true
       run: |
         sudo apt-get --no-install-recommends install -y ninja-build
         git clone https://github.com/openthread/ot-commissioner.git /tmp/ot-commissioner --depth 1 --branch master
-        exit 1
     - name: Build
       run: |
         cd /tmp/ot-commissioner

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -211,9 +211,9 @@ jobs:
     - name: Bootstrap
       continue-on-error: true
       run: |
-        exit 1
         sudo apt-get --no-install-recommends install -y ninja-build
         git clone https://github.com/openthread/ot-commissioner.git /tmp/ot-commissioner --depth 1 --branch master
+        exit 1
     - name: Build
       run: |
         cd /tmp/ot-commissioner

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -210,6 +210,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
+        exit 1
         sudo apt-get --no-install-recommends install -y ninja-build
         git clone https://github.com/openthread/ot-commissioner.git /tmp/ot-commissioner --depth 1 --branch master
     - name: Build

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -209,6 +209,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Bootstrap
+      continue-on-error: true
       run: |
         exit 1
         sudo apt-get --no-install-recommends install -y ninja-build


### PR DESCRIPTION
This allows the CI test `external-commissioner` to fail. It removes the dependencies of `ot-commissioner` and `ot-br-posix` so that a breaking change can be merged. Fixes https://github.com/openthread/openthread/issues/5218.