### PR TITLE
[test] fix python formatting in v1_2_* tests

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -500,8 +500,7 @@ void Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[])
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
 otError Interpreter::ProcessBackboneRouterLocal(uint8_t aArgsLength, char *aArgs[])
 {
-    otError error = OT_ERROR_NONE;
-    ;
+    otError                error = OT_ERROR_NONE;
     otBackboneRouterConfig config;
     unsigned long          value;
 

--- a/tests/scripts/thread-cert/v1_2_test_backbone_router_service.py
+++ b/tests/scripts/thread-cert/v1_2_test_backbone_router_service.py
@@ -263,7 +263,7 @@ class TestBackboneRouterService(thread_cert.TestCase):
 
         # 6a) Check the uniqueness of DUA by comparing the one in above 4a).
         bbr2_dua2 = self.nodes[BBR_2].get_addr(config.DOMAIN_PREFIX)
-        assert bbr2_dua == bbr2_dua2, 'Error: Unexpected different DUA (%s v.s. %s)'.format(
+        assert bbr2_dua == bbr2_dua2, 'Error: Unexpected different DUA ({} v.s. {})'.format(
             bbr2_dua, bbr2_dua2)
 
         # 6b) Check communication via DUA

--- a/tests/scripts/thread-cert/v1_2_test_multicast_registration.py
+++ b/tests/scripts/thread-cert/v1_2_test_multicast_registration.py
@@ -170,11 +170,11 @@ class TestMulticastRegistration(thread_cert.TestCase):
                 msg, multicast_address)
 
             if in_address_registration:
-                assert is_in, 'Error: %s %s in AddressRegistrationTLV %s'.format(
-                    'Expected', multicast_address, ' not found')
+                assert is_in, 'Error: Expected {} in AddressRegistrationTLV not found'.format(
+                    multicast_address)
             else:
-                assert not is_in, 'Error: %s %s in AddressRegistrationTLV %s'.format(
-                    'Unexpected', multicast_address, '')
+                assert not is_in, 'Error: Unexpected {} in AddressRegistrationTLV'.format(
+                    multicast_address)
 
     def test(self):
 


### PR DESCRIPTION
In some test scripts,` %s` and `format()` are mix-used by mistake.