### PR TITLE
[mle] add `mHasRestored` flag

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -86,6 +86,7 @@ Mle::Mle(Instance &aInstance)
     , mDataRequestAttempts(0)
     , mDataRequestState(kDataRequestNone)
     , mAddressRegistrationMode(kAppendAllAddresses)
+    , mHasRestored(false)
     , mParentLinkMargin(0)
     , mParentIsSingleton(false)
     , mReceivedResponseFromParent(false)
@@ -438,6 +439,9 @@ otError Mle::Restore(void)
         Get<MleRouter>().RestoreChildren();
     }
 #endif
+
+    // Sucessfully restored the network information from non-volatile settings after boot.
+    mHasRestored = true;
 
 exit:
     return error;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -915,6 +915,16 @@ public:
      */
     otError GetLocatorAddress(Ip6::Address &aAddress, uint16_t aLocator) const;
 
+    /**
+     * This method indicates whether or not the device has restored the network information from
+     * non-volatile settings after boot.
+     *
+     * @retval true  Sucessfully restored the network information.
+     * @retval false No valid network information was found.
+     *
+     */
+    bool HasRestored(void) const { return mHasRestored; }
+
 protected:
     /**
      * States during attach (when searching for a parent).
@@ -1734,6 +1744,7 @@ private:
 
     AddressRegistrationMode mAddressRegistrationMode;
 
+    bool       mHasRestored;
     uint8_t    mParentLinkMargin;
     bool       mParentIsSingleton;
     bool       mReceivedResponseFromParent;


### PR DESCRIPTION
-- edited --
This PR introduces the `mHasRestored ` flag and a common `HasRestored()` method as devices may decide to introduce some jitter/randomization to avoid the burst of traffic in cases a bunch of devices nearby resets/reboots together. One typical usage defined in Thread 1.2 Specification 5.23.4.1 is that
> In the following cases, a random time delay chosen in the interval [0, Reregistration Delay], a random time delay chosen in the interval [0, Reregistration Delay] MUST be applied before sending the DUA.req
> - The Device reregisters its DUA due to a Device reboot/restart.

