### PR TITLE
[tests] ignore unknown TLV

### DIFF
--- a/tests/scripts/thread-cert/mesh_cop.py
+++ b/tests/scripts/thread-cert/mesh_cop.py
@@ -934,7 +934,7 @@ class MeshCopCommandFactory:
             return self._tlvs_factories[_type]
         except KeyError:
             logging.error(
-                "Could not find TLV factory. Unsupported TLV type: {}".format(
+                'Could not find TLV factory. Unsupported TLV type: {}'.format(
                     _type))
             return UnknownTlvFactory(_type)
 

--- a/tests/scripts/thread-cert/mesh_cop.py
+++ b/tests/scripts/thread-cert/mesh_cop.py
@@ -30,10 +30,12 @@
 from binascii import hexlify
 from enum import IntEnum
 import io
+import logging
 import struct
 
 from network_data import SubTlvsFactory
 import common
+from tlvs_parsing import UnknownTlvFactory
 
 
 class TlvType(IntEnum):
@@ -931,9 +933,10 @@ class MeshCopCommandFactory:
         try:
             return self._tlvs_factories[_type]
         except KeyError:
-            raise KeyError(
+            logging.error(
                 "Could not find TLV factory. Unsupported TLV type: {}".format(
                     _type))
+            return UnknownTlvFactory(_type)
 
     def _parse_tlv(self, data):
         _type = TlvType(ord(data.read(1)))

--- a/tests/scripts/thread-cert/mesh_cop.py
+++ b/tests/scripts/thread-cert/mesh_cop.py
@@ -34,8 +34,8 @@ import logging
 import struct
 
 from network_data import SubTlvsFactory
-import common
 from tlvs_parsing import UnknownTlvFactory
+import common
 
 
 class TlvType(IntEnum):

--- a/tests/scripts/thread-cert/mle.py
+++ b/tests/scripts/thread-cert/mle.py
@@ -28,6 +28,7 @@
 #
 
 import io
+import logging
 import struct
 
 from binascii import hexlify
@@ -35,6 +36,7 @@ from binascii import hexlify
 import common
 
 from enum import IntEnum
+from tlvs_parsing import UnknownTlvFactory
 
 
 class CommandType(IntEnum):
@@ -452,15 +454,13 @@ class LeaderData(object):
                 self.leader_router_id == other.leader_router_id)
 
     def __repr__(self):
-        return (
-            "LeaderData(partition_id={}, weighting={}, data_version={}, stable_data_version={},",
-            "leader_router_id={})").format(
-                self.partition_id,
-                self.weighting,
-                self.data_version,
-                self.stable_data_version,
-                self.leader_router_id,
-            )
+        return "LeaderData(partition_id={}, weighting={}, data_version={}, stable_data_version={},leader_router_id={}".format(
+            self.partition_id,
+            self.weighting,
+            self.data_version,
+            self.stable_data_version,
+            self.leader_router_id,
+        )
 
 
 class LeaderDataFactory:
@@ -1138,9 +1138,10 @@ class MleCommandFactory:
         try:
             return self._tlvs_factories[_type]
         except KeyError:
-            raise KeyError(
+            logging.error(
                 "Could not find TLV factory. Unsupported TLV type: {}".format(
                     _type))
+            return UnknownTlvFactory(_type)
 
     def _parse_tlv(self, data, message_info):
         _type = TlvType(ord(data.read(1)))

--- a/tests/scripts/thread-cert/mle.py
+++ b/tests/scripts/thread-cert/mle.py
@@ -454,7 +454,7 @@ class LeaderData(object):
                 self.leader_router_id == other.leader_router_id)
 
     def __repr__(self):
-        return "LeaderData(partition_id={}, weighting={}, data_version={}, stable_data_version={},leader_router_id={}".format(
+        return 'LeaderData(partition_id={}, weighting={}, data_version={}, stable_data_version={},leader_router_id={}'.format(
             self.partition_id,
             self.weighting,
             self.data_version,

--- a/tests/scripts/thread-cert/mle.py
+++ b/tests/scripts/thread-cert/mle.py
@@ -1139,7 +1139,7 @@ class MleCommandFactory:
             return self._tlvs_factories[_type]
         except KeyError:
             logging.error(
-                "Could not find TLV factory. Unsupported TLV type: {}".format(
+                'Could not find TLV factory. Unsupported TLV type: {}'.format(
                     _type))
             return UnknownTlvFactory(_type)
 

--- a/tests/scripts/thread-cert/tlvs_parsing.py
+++ b/tests/scripts/thread-cert/tlvs_parsing.py
@@ -27,6 +27,26 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 
 import io
+import logging
+
+
+class UnknownTlv(object):
+
+    def __init__(self, type, data):
+        self.type = type
+        self.data = data
+
+    def __repr__(self):
+        return 'UnknownTlv(%d, %s)' % (self.type, self.data)
+
+
+class UnknownTlvFactory(object):
+
+    def __init__(self, type):
+        self._type = type
+
+    def parse(self, data, message_info):
+        return UnknownTlv(self._type, data)
 
 
 class SubTlvsFactory(object):
@@ -38,8 +58,10 @@ class SubTlvsFactory(object):
         try:
             return self._sub_tlvs_factories[_type]
         except KeyError:
-            raise RuntimeError(
-                "Could not find factory. Factory type = {}.".format(_type))
+            logging.error(
+                "Could not find TLV factory. Unsupported TLV type: {}".format(
+                    _type))
+            return UnknownTlvFactory(_type)
 
     def parse(self, data, message_info):
         sub_tlvs = []

--- a/tests/scripts/thread-cert/tlvs_parsing.py
+++ b/tests/scripts/thread-cert/tlvs_parsing.py
@@ -59,7 +59,7 @@ class SubTlvsFactory(object):
             return self._sub_tlvs_factories[_type]
         except KeyError:
             logging.error(
-                "Could not find TLV factory. Unsupported TLV type: {}".format(
+                'Could not find TLV factory. Unsupported TLV type: {}'.format(
                     _type))
             return UnknownTlvFactory(_type)
 


### PR DESCRIPTION
This PR ignores unknown TLVs when parsing a message and continues to parse the rest parts of the message.

An unknown TLV can cause the simulator to drop the whole packet, which could lead to packet parsing issues. 
For example, if a `Child ID Response` message is dropped, the dissector will fail to add the Short Address and Extended Address to the Device Descriptors, causing subsequent secure packets unable to be decrypted. 

**PR #5219 requires this PR to pass tests stably.**