### PR TITLE
[mlr] Parent send MLR.req on behalf of Children

### DIFF
--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -227,7 +227,7 @@ void Leader::UpdateBackboneRouterPrimary(void)
     Get<BackboneRouter::Local>().HandleBackboneRouterPrimaryUpdate(state, mConfig);
 #endif
 
-#if OPENTHREAD_CONFIG_MLR_ENABLE
+#if OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     Get<MlrManager>().HandleBackboneRouterPrimaryUpdate(state, mConfig);
 #endif
 }

--- a/src/core/common/bit_vector.hpp
+++ b/src/core/common/bit_vector.hpp
@@ -78,24 +78,16 @@ public:
     }
 
     /**
-     * This method sets or clears the mask of a given index.
+     * This method sets the mask of a given index.
      *
      * @param[in] aIndex  The index.
-     * @param[in] aSet    TRUE to sets the mask, or FALSE to clear the mask.
      *
      */
-    void Set(uint16_t aIndex, bool aSet = true)
+    void Set(uint16_t aIndex)
     {
         OT_ASSERT(aIndex < N);
 
-        if (aSet)
-        {
-            mMask[aIndex / 8] |= 0x80 >> (aIndex % 8);
-        }
-        else
-        {
-            mMask[aIndex / 8] &= ~(0x80 >> (aIndex % 8));
-        }
+        mMask[aIndex / 8] |= 0x80 >> (aIndex % 8);
     }
 
     /**
@@ -104,7 +96,12 @@ public:
      * @param[in] aIndex  The index.
      *
      */
-    void Clear(uint16_t aIndex) { Set(aIndex, false); }
+    void Clear(uint16_t aIndex)
+    {
+        OT_ASSERT(aIndex < N);
+
+        mMask[aIndex / 8] &= ~(0x80 >> (aIndex % 8));
+    }
 
     /**
      * This method clears all indexes.

--- a/src/core/common/bit_vector.hpp
+++ b/src/core/common/bit_vector.hpp
@@ -78,15 +78,24 @@ public:
     }
 
     /**
-     * This method sets the mask of a given index.
+     * This method sets or clears the mask of a given index.
      *
      * @param[in] aIndex  The index.
+     * @param[in] aSet    TRUE to sets the mask, or FALSE to clear the mask.
      *
      */
-    void Set(uint16_t aIndex)
+    void Set(uint16_t aIndex, bool aSet = true)
     {
         OT_ASSERT(aIndex < N);
-        mMask[aIndex / 8] |= 0x80 >> (aIndex % 8);
+
+        if (aSet)
+        {
+            mMask[aIndex / 8] |= 0x80 >> (aIndex % 8);
+        }
+        else
+        {
+            mMask[aIndex / 8] &= ~(0x80 >> (aIndex % 8));
+        }
     }
 
     /**
@@ -95,11 +104,7 @@ public:
      * @param[in] aIndex  The index.
      *
      */
-    void Clear(uint16_t aIndex)
-    {
-        OT_ASSERT(aIndex < N);
-        mMask[aIndex / 8] &= ~(0x80 >> (aIndex % 8));
-    }
+    void Clear(uint16_t aIndex) { Set(aIndex, false); }
 
     /**
      * This method clears all indexes.

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -750,7 +750,7 @@ template <> inline DuaManager &Instance::Get(void)
 }
 #endif
 
-#if OPENTHREAD_CONFIG_MLR_ENABLE
+#if OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 template <> inline MlrManager &Instance::Get(void)
 {
     return mThreadNetif.mMlrManager;

--- a/src/core/config/tmf.h
+++ b/src/core/config/tmf.h
@@ -172,4 +172,14 @@
 #define OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE 0
 #endif
 
+/**
+ *
+ * This setting configures the Multicast Listener Registration parent proxing in Thread 1.2.
+ *
+ * This is compulsory for 1.2 FTD.
+ *
+ */
+#define OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE \
+    ((OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2) && OPENTHREAD_FTD)
+
 #endif // CONFIG_TMF_H_

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2055,13 +2055,12 @@ otError MleRouter::UpdateChildAddresses(const Message &aMessage, uint16_t aOffse
     // Retrieve registered multicast addresses of the Child
     if (aChild.HasAnyMlrRegisteredAddress())
     {
-        auto childAddresses = aChild.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal);
-
-        for (auto iter = childAddresses.begin(); iter != childAddresses.end(); iter++)
+        for (const Ip6::Address &childAddress :
+             aChild.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
         {
-            if (aChild.GetAddressMlrState(iter.GetAsIndex()) == kMlrStateRegistered)
+            if (aChild.GetAddressMlrState(childAddress) == kMlrStateRegistered)
             {
-                oldMlrRegisteredAddresses[oldMlrRegisteredAddressNum++] = *iter.GetAddress();
+                oldMlrRegisteredAddresses[oldMlrRegisteredAddressNum++] = childAddress;
             }
         }
     }

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2055,6 +2055,8 @@ otError MleRouter::UpdateChildAddresses(const Message &aMessage, uint16_t aOffse
     // Retrieve registered multicast addresses of the Child
     if (aChild.HasAnyMlrRegisteredAddress())
     {
+        OT_ASSERT(aChild.IsStateValid());
+
         for (const Ip6::Address &childAddress :
              aChild.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
         {
@@ -4651,6 +4653,11 @@ void MleRouter::SetChildStateToValid(Child &aChild)
 
     aChild.SetState(Neighbor::kStateValid);
     IgnoreError(StoreChild(aChild));
+
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+    Get<MlrManager>().UpdateProxiedSubscriptions(aChild, nullptr, 0);
+#endif
+
     Signal(OT_NEIGHBOR_TABLE_EVENT_CHILD_ADDED, aChild);
 
 exit:

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -267,6 +267,8 @@ enum
 static_assert(kMlrTimeoutDefault >= kMlrTimeoutMin,
               "kMlrTimeoutDefault must be larger than or equal to kMlrTimeoutMin");
 
+static_assert(Mle::kParentAggregateDelay > 1, "kParentAggregateDelay should be larger than 1 second");
+
 #endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 
 /**

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -249,7 +249,7 @@ enum
     kServiceMaxId = 0x0f, ///< Maximal Service ID.
 };
 
-#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE || OPENTHREAD_CONFIG_MLR_ENABLE
+#if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 
 /**
  * Backbone Router / MLR constants
@@ -261,12 +261,13 @@ enum
     kMlrTimeoutDefault                = 3600, //< In seconds.
     kMlrTimeoutMin                    = 300,  //< In seconds.
     kBackboneRouterRegistrationJitter = 5,    //< In seconds.
+    kParentAggregateDelay             = 5,    //< In seconds.
 };
 
 static_assert(kMlrTimeoutDefault >= kMlrTimeoutMin,
               "kMlrTimeoutDefault must be larger than or equal to kMlrTimeoutMin");
 
-#endif // OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE || OPENTHREAD_CONFIG_MLR_ENABLE
+#endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 
 /**
  * This type represents a MLE device mode.

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -139,7 +139,7 @@ bool MlrManager::IsAddressMlrRegisteredByAnyChildExcept(const Ip6::Address &aAdd
 
     OT_ASSERT(aAddress.IsMulticastLargerThanRealmLocal());
 
-    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValidOrRestoring))
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
         if (&child != aExceptChild && child.HasMlrRegisteredAddress(aAddress))
         {
@@ -155,7 +155,7 @@ void MlrManager::UpdateProxiedSubscriptions(Child &             aChild,
                                             const Ip6::Address *aOldMlrRegisteredAddresses,
                                             uint16_t            aOldMlrRegisteredAddressNum)
 {
-    VerifyOrExit(aChild.IsStateValidOrRestoring(), OT_NOOP);
+    VerifyOrExit(aChild.IsStateValid(), OT_NOOP);
 
     // Search the new multicast addresses and set its flag accordingly
     for (const Ip6::Address &address : aChild.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
@@ -194,7 +194,7 @@ exit:
 
 void MlrManager::SetChildMulticastAddressMlrState(MlrState aFromState, MlrState aToState)
 {
-    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValidOrRestoring))
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
         for (const Ip6::Address &address : child.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
         {
@@ -274,7 +274,7 @@ void MlrManager::SendMulticastListenerRegistration(void)
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     // Append Child multicast addresses
-    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValidOrRestoring))
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
         if (addressesNum >= kIPv6AddressesNumMax)
         {
@@ -495,7 +495,7 @@ void MlrManager::LogMulticastAddresses(void)
 #endif
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
-    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValidOrRestoring))
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
         for (const Ip6::Address &address : child.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
         {

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -33,7 +33,7 @@
 
 #include "mlr_manager.hpp"
 
-#if OPENTHREAD_CONFIG_MLR_ENABLE
+#if OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
@@ -58,10 +58,12 @@ MlrManager::MlrManager(Instance &aInstance)
 
 void MlrManager::HandleNotifierEvents(Events aEvents)
 {
+#if OPENTHREAD_CONFIG_MLR_ENABLE
     if (aEvents.Contains(kEventIp6MulticastSubscribed))
     {
-        ScheduleSend(0);
+        UpdateLocalSubscriptions();
     }
+#endif
 
     if (aEvents.Contains(kEventThreadRoleChanged) && Get<Mle::MleRouter>().IsChild())
     {
@@ -80,6 +82,136 @@ void MlrManager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State
 
     UpdateReregistrationDelay(needRereg);
 }
+
+#if OPENTHREAD_CONFIG_MLR_ENABLE
+void MlrManager::UpdateLocalSubscriptions(void)
+{
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+    // Check multicast addresses are newly listened against Children
+    for (Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+    {
+        if (addr.GetAddress().IsMulticastLargerThanRealmLocal() && addr.GetMlrState() == kMlrStateToRegister &&
+            IsAddressMlrRegisteredByAnyChild(addr.GetAddress()))
+        {
+            addr.SetMlrState(kMlrStateRegistered);
+        }
+    }
+#endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+
+    ScheduleSend(0);
+}
+
+bool MlrManager::IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress)
+{
+    bool ret = false;
+
+    OT_ASSERT(aAddress.IsMulticastLargerThanRealmLocal());
+
+    for (const Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+    {
+        if (addr.GetAddress() == aAddress && addr.GetMlrState() == kMlrStateRegistered)
+        {
+            ExitNow(ret = true);
+        }
+    }
+
+exit:
+    return ret;
+}
+
+void MlrManager::SetNetifMulticastAddressMlrState(MlrState aFromState, MlrState aToState)
+{
+    for (Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+    {
+        if (addr.GetAddress().IsMulticastLargerThanRealmLocal() && addr.GetMlrState() == aFromState)
+        {
+            addr.SetMlrState(aToState);
+        }
+    }
+}
+#endif // OPENTHREAD_CONFIG_MLR_ENABLE
+
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+
+bool MlrManager::IsAddressMlrRegisteredByAnyChildExcept(const Ip6::Address &aAddress, const Child *aExceptChild)
+{
+    bool ret = false;
+
+    OT_ASSERT(aAddress.IsMulticastLargerThanRealmLocal());
+
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValidOrRestoring))
+    {
+        if (&child != aExceptChild && child.HasMlrRegisteredAddress(aAddress))
+        {
+            ExitNow(ret = true);
+        }
+    }
+
+exit:
+    return ret;
+}
+
+void MlrManager::UpdateProxiedSubscriptions(Child &             aChild,
+                                            const Ip6::Address *aOldMlrRegisteredAddresses,
+                                            uint16_t            aOldMlrRegisteredAddressNum)
+{
+    auto childAddresses = aChild.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal);
+
+    VerifyOrExit(aChild.IsStateValidOrRestoring(), OT_NOOP);
+
+    // Search the new multicast addresses and set its flag accordingly
+    for (auto iter = childAddresses.begin(); iter != childAddresses.end(); iter++)
+    {
+        bool         isMlrRegistered = false;
+        Ip6::Address address         = *iter.GetAddress();
+
+        // Check if it's a new multicast address against old addresses
+        for (size_t i = 0; i < aOldMlrRegisteredAddressNum; i++)
+        {
+            if (aOldMlrRegisteredAddresses[i] == address)
+            {
+                isMlrRegistered = true;
+                break;
+            }
+        }
+
+#if OPENTHREAD_CONFIG_MLR_ENABLE
+        // Check if it's a new multicast address against parent Netif
+        isMlrRegistered = isMlrRegistered || IsAddressMlrRegisteredByNetif(address);
+#endif
+        // Check if it's a new multicast address against other Children
+        isMlrRegistered = isMlrRegistered || IsAddressMlrRegisteredByAnyChildExcept(address, &aChild);
+
+        // Set MLR state accordingly
+        aChild.SetAddressMlrState(iter.GetAsIndex(), isMlrRegistered ? kMlrStateRegistered : kMlrStateToRegister);
+    }
+
+exit:
+    LogMulticastAddresses();
+
+    if (aChild.HasAnyMlrToRegisterAddress())
+    {
+        static_assert(Mle::kParentAggregateDelay > 1, "kParentAggregateDelay should be larger than 1 second");
+        ScheduleSend(Random::NonCrypto::GetUint16InRange(1, Mle::kParentAggregateDelay));
+    }
+}
+
+void MlrManager::SetChildMulticastAddressMlrState(MlrState aFromState, MlrState aToState)
+{
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValidOrRestoring))
+    {
+        auto addresses = child.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal);
+
+        for (auto iter = addresses.begin(); iter != addresses.end(); iter++)
+        {
+            if (child.GetAddressMlrState(iter.GetAsIndex()) == aFromState)
+            {
+                child.SetAddressMlrState(iter.GetAsIndex(), aToState);
+            }
+        }
+    }
+}
+#endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
 void MlrManager::ScheduleSend(uint16_t aDelay)
 {
@@ -121,19 +253,64 @@ void MlrManager::SendMulticastListenerRegistration(void)
     Coap::Message *  message = nullptr;
     Ip6::MessageInfo messageInfo;
     IPv6AddressesTlv addressesTlv;
-    uint8_t          num;
+    Ip6::Address     addresses[kIPv6AddressesNumMax];
+    uint8_t          addressesNum = 0;
 
     VerifyOrExit(!mMlrPending, error = OT_ERROR_BUSY);
     VerifyOrExit(mle.IsAttached(), error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(mle.IsFullThreadDevice() || mle.GetParent().IsThreadVersion1p1(), error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(Get<BackboneRouter::Leader>().HasPrimary(), error = OT_ERROR_INVALID_STATE);
 
-    num = static_cast<uint8_t>(CountNetifMulticastAddressesToRegister());
-    VerifyOrExit(num > 0, error = OT_ERROR_NOT_FOUND);
-    if (num > kIPv6AddressesNumMax)
+#if OPENTHREAD_CONFIG_MLR_ENABLE
+    // Append Netif multicast addresses
+    for (Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
     {
-        num = kIPv6AddressesNumMax;
+        if (addressesNum >= kIPv6AddressesNumMax)
+        {
+            break;
+        }
+
+        if (addr.GetAddress().IsMulticastLargerThanRealmLocal() && addr.GetMlrState() == kMlrStateToRegister)
+        {
+            AppendToUniqueAddressList(addresses, addressesNum, addr.GetAddress());
+            addr.SetMlrState(kMlrStateRegistering);
+        }
     }
+#endif
+
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+    // Append Child multicast addresses
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValidOrRestoring))
+    {
+        auto childAddresses = child.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal);
+
+        if (addressesNum >= kIPv6AddressesNumMax)
+        {
+            break;
+        }
+
+        if (!child.HasAnyMlrToRegisterAddress())
+        {
+            continue;
+        }
+
+        for (auto iter = childAddresses.begin(); iter != childAddresses.end(); iter++)
+        {
+            if (addressesNum >= kIPv6AddressesNumMax)
+            {
+                break;
+            }
+
+            if (child.GetAddressMlrState(iter.GetAsIndex()) == kMlrStateToRegister)
+            {
+                AppendToUniqueAddressList(addresses, addressesNum, *iter.GetAddress());
+                child.SetAddressMlrState(iter.GetAsIndex(), kMlrStateRegistering);
+            }
+        }
+    }
+#endif
+
+    VerifyOrExit(addressesNum > 0, error = OT_ERROR_NOT_FOUND);
 
     VerifyOrExit((message = Get<Coap::Coap>().NewMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
 
@@ -143,23 +320,9 @@ void MlrManager::SendMulticastListenerRegistration(void)
     SuccessOrExit(message->SetPayloadMarker());
 
     addressesTlv.Init();
-    addressesTlv.SetLength(sizeof(Ip6::Address) * num);
+    addressesTlv.SetLength(sizeof(Ip6::Address) * addressesNum);
     SuccessOrExit(error = message->Append(&addressesTlv, sizeof(addressesTlv)));
-
-    for (Ip6::ExternalNetifMulticastAddress &addr :
-         Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
-    {
-        if (addr.GetMlrState() == kMlrStateToRegister)
-        {
-            SuccessOrExit(error = message->Append(&addr.GetAddress(), sizeof(Ip6::Address)));
-            addr.SetMlrState(kMlrStateRegistering);
-
-            if (--num == 0)
-            {
-                break;
-            }
-        }
-    }
+    SuccessOrExit(error = message->Append(&addresses, sizeof(Ip6::Address) * addressesNum));
 
     if (!mle.IsFullThreadDevice() && mle.GetParent().IsThreadVersion1p1())
     {
@@ -196,7 +359,7 @@ exit:
             message->Free();
         }
 
-        SetNetifMulticastAddressMlrState(kMlrStateRegistering, kMlrStateToRegister);
+        SetMulticastAddressMlrState(kMlrStateRegistering, kMlrStateToRegister);
 
         if (error == OT_ERROR_NO_BUFS)
         {
@@ -225,10 +388,15 @@ void MlrManager::HandleMulticastListenerRegistrationResponse(Coap::Message *    
     SuccessOrExit(error = Tlv::FindUint8Tlv(*aMessage, ThreadTlv::kStatus, status));
 
 exit:
+    SetMulticastAddressMlrState(kMlrStateRegistering, status == ThreadStatusTlv::MlrStatus::kMlrSuccess
+                                                          ? kMlrStateRegistered
+                                                          : kMlrStateToRegister);
+    otLogInfoBbr("Receive MLR.rsp, result=%s, status=%d, error=%s", otThreadErrorToString(aResult), status,
+                 otThreadErrorToString(error));
+    LogMulticastAddresses();
 
     if (status == ThreadStatusTlv::MlrStatus::kMlrSuccess)
     {
-        SetNetifMulticastAddressMlrState(kMlrStateRegistering, kMlrStateRegistered);
         // keep sending until all multicast addresses are registered.
         ScheduleSend(0);
     }
@@ -236,8 +404,6 @@ exit:
     {
         otBackboneRouterConfig config;
         uint16_t               reregDelay;
-
-        SetNetifMulticastAddressMlrState(kMlrStateRegistering, kMlrStateToRegister);
 
         // The Device has just attempted a Multicast Listener Registration which failed, and it retries the same
         // registration with a random time delay chosen in the interval [0, Reregistration Delay].
@@ -251,9 +417,6 @@ exit:
             ScheduleSend(reregDelay);
         }
     }
-
-    otLogInfoMlr("Receive MLR.rsp, result=%s, status=%d, error=%s", otThreadErrorToString(aResult), status,
-                 otThreadErrorToString(error));
 }
 
 void MlrManager::HandleTimer(void)
@@ -273,7 +436,8 @@ void MlrManager::HandleTimer(void)
 
 void MlrManager::Reregister(void)
 {
-    SetNetifMulticastAddressMlrState(kMlrStateRegistered, kMlrStateToRegister);
+    SetMulticastAddressMlrState(kMlrStateRegistered, kMlrStateToRegister);
+
     ScheduleSend(0);
 
     // Schedule for the next renewing.
@@ -328,45 +492,55 @@ void MlrManager::UpdateReregistrationDelay(bool aRereg)
 
 void MlrManager::LogMulticastAddresses(void)
 {
-#if OPENTHREAD_CONFIG_LOG_BBR && OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
+#if OPENTHREAD_CONFIG_LOG_MLR && OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
     otLogDebgMlr("-------- Multicast Addresses --------");
 
-    for (const Ip6::ExternalNetifMulticastAddress &addr :
-         Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
+#if OPENTHREAD_CONFIG_MLR_ENABLE
+    for (const Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
     {
         MlrState state = addr.GetMlrState();
 
         otLogDebgMlr("%-32s%c", addr.GetAddress().ToString().AsCString(), "-rR"[state]);
     }
 #endif
-}
 
-uint16_t MlrManager::CountNetifMulticastAddressesToRegister(void) const
-{
-    uint16_t count = 0;
-
-    for (const Ip6::ExternalNetifMulticastAddress &addr :
-         Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValidOrRestoring))
     {
-        if (addr.GetMlrState() == kMlrStateToRegister)
+        auto childAddresses = child.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal);
+
+        for (auto iter = childAddresses.begin(); iter != childAddresses.end(); iter++)
         {
-            count++;
+            MlrState state = child.GetAddressMlrState(iter.GetAsIndex());
+
+            otLogDebgMlr("%-32s%c %04x", iter.GetAddress()->ToString().AsCString(), "-rR"[state], child.GetRloc16());
         }
     }
+#endif
 
-    return count;
+#endif // OPENTHREAD_CONFIG_LOG_MLR && OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
 }
 
-void MlrManager::SetNetifMulticastAddressMlrState(MlrState aFromState, MlrState aToState)
+void MlrManager::AppendToUniqueAddressList(Ip6::Address (&aAddresses)[kIPv6AddressesNumMax],
+                                           uint8_t &           aAddressNum,
+                                           const Ip6::Address &aAddress)
 {
-    for (Ip6::ExternalNetifMulticastAddress &addr :
-         Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+    for (uint8_t i = 0; i < aAddressNum; i++)
     {
-        if (addr.GetMlrState() == aFromState)
+        if (aAddresses[i] == aAddress)
         {
-            addr.SetMlrState(aToState);
+            ExitNow();
         }
     }
+#endif
+
+    aAddresses[aAddressNum++] = aAddress;
+
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+exit:
+#endif
+    return;
 }
 
 } // namespace ot

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -88,20 +88,20 @@ void MlrManager::UpdateLocalSubscriptions(void)
 {
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     // Check multicast addresses are newly listened against Children
-    for (Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+    for (Ip6::ExternalNetifMulticastAddress &addr :
+         Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
-        if (addr.GetAddress().IsMulticastLargerThanRealmLocal() && addr.GetMlrState() == kMlrStateToRegister &&
-            IsAddressMlrRegisteredByAnyChild(addr.GetAddress()))
+        if (addr.GetMlrState() == kMlrStateToRegister && IsAddressMlrRegisteredByAnyChild(addr.GetAddress()))
         {
             addr.SetMlrState(kMlrStateRegistered);
         }
     }
-#endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+#endif
 
     ScheduleSend(0);
 }
 
-bool MlrManager::IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress)
+bool MlrManager::IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress) const
 {
     bool ret = false;
 
@@ -121,9 +121,10 @@ exit:
 
 void MlrManager::SetNetifMulticastAddressMlrState(MlrState aFromState, MlrState aToState)
 {
-    for (Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+    for (Ip6::ExternalNetifMulticastAddress &addr :
+         Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
-        if (addr.GetAddress().IsMulticastLargerThanRealmLocal() && addr.GetMlrState() == aFromState)
+        if (addr.GetMlrState() == aFromState)
         {
             addr.SetMlrState(aToState);
         }
@@ -133,7 +134,7 @@ void MlrManager::SetNetifMulticastAddressMlrState(MlrState aFromState, MlrState 
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
-bool MlrManager::IsAddressMlrRegisteredByAnyChildExcept(const Ip6::Address &aAddress, const Child *aExceptChild)
+bool MlrManager::IsAddressMlrRegisteredByAnyChildExcept(const Ip6::Address &aAddress, const Child *aExceptChild) const
 {
     bool ret = false;
 
@@ -179,7 +180,6 @@ void MlrManager::UpdateProxiedSubscriptions(Child &             aChild,
         // Check if it's a new multicast address against other Children
         isMlrRegistered = isMlrRegistered || IsAddressMlrRegisteredByAnyChildExcept(address, &aChild);
 
-        // Set MLR state accordingly
         aChild.SetAddressMlrState(address, isMlrRegistered ? kMlrStateRegistered : kMlrStateToRegister);
     }
 
@@ -257,14 +257,15 @@ void MlrManager::SendMulticastListenerRegistration(void)
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
     // Append Netif multicast addresses
-    for (Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+    for (Ip6::ExternalNetifMulticastAddress &addr :
+         Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
         if (addressesNum >= kIPv6AddressesNumMax)
         {
             break;
         }
 
-        if (addr.GetAddress().IsMulticastLargerThanRealmLocal() && addr.GetMlrState() == kMlrStateToRegister)
+        if (addr.GetMlrState() == kMlrStateToRegister)
         {
             AppendToUniqueAddressList(addresses, addressesNum, addr.GetAddress());
             addr.SetMlrState(kMlrStateRegistering);

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -191,7 +191,6 @@ exit:
 
     if (aChild.HasAnyMlrToRegisterAddress())
     {
-        static_assert(Mle::kParentAggregateDelay > 1, "kParentAggregateDelay should be larger than 1 second");
         ScheduleSend(Random::NonCrypto::GetUint16InRange(1, Mle::kParentAggregateDelay));
     }
 }

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -36,7 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#if OPENTHREAD_CONFIG_MLR_ENABLE
+#if OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
 #include "backbone_router/bbr_leader.hpp"
 #include "coap/coap_message.hpp"
@@ -44,6 +44,8 @@
 #include "common/notifier.hpp"
 #include "common/timer.hpp"
 #include "net/netif.hpp"
+#include "thread/thread_tlvs.hpp"
+#include "thread/topology.hpp"
 
 namespace ot {
 
@@ -86,6 +88,21 @@ public:
     void HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State               aState,
                                            const BackboneRouter::BackboneRouterConfig &aConfig);
 
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+    /**
+     * This method updates the Multicast Subscription Table according to the Child information.
+     *
+     * @param[in]  aChild                       A reference to the child information.
+     * @param[in]  aOldMlrRegisteredAddresses   A pointer to an array of the Child's previously registered Ip6
+     * addresses.
+     * @param[in]  aOldMlrRegisteredAddressNum  The number of previously registered Ip6 addresses.
+     *
+     */
+    void UpdateProxiedSubscriptions(Child &             aChild,
+                                    const Ip6::Address *aOldMlrRegisteredAddresses,
+                                    uint16_t            aOldMlrRegisteredAddressNum);
+#endif
+
 private:
     enum
     {
@@ -113,8 +130,34 @@ private:
                                                      const Ip6::MessageInfo *aMessageInfo,
                                                      otError                 aResult);
 
-    uint16_t CountNetifMulticastAddressesToRegister(void) const;
-    void     SetNetifMulticastAddressMlrState(MlrState aFromState, MlrState aToState);
+#if OPENTHREAD_CONFIG_MLR_ENABLE
+    void UpdateLocalSubscriptions(void);
+    void SetNetifMulticastAddressMlrState(MlrState aFromState, MlrState aToState);
+    bool IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress);
+#endif
+
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+    void SetChildMulticastAddressMlrState(MlrState aFromState, MlrState aToState);
+    bool IsAddressMlrRegisteredByAnyChild(const Ip6::Address &aAddress)
+    {
+        return IsAddressMlrRegisteredByAnyChildExcept(aAddress, nullptr);
+    }
+    bool IsAddressMlrRegisteredByAnyChildExcept(const Ip6::Address &aAddress, const Child *aExceptChild);
+#endif
+
+    void SetMulticastAddressMlrState(MlrState aFromState, MlrState aToState)
+    {
+#if OPENTHREAD_CONFIG_MLR_ENABLE
+        SetNetifMulticastAddressMlrState(aFromState, aToState);
+#endif
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+        SetChildMulticastAddressMlrState(aFromState, aToState);
+#endif
+    }
+
+    void AppendToUniqueAddressList(Ip6::Address (&aAddresses)[kIPv6AddressesNumMax],
+                                   uint8_t &           aAddressNum,
+                                   const Ip6::Address &aAddress);
 
     void ScheduleSend(uint16_t aDelay);
     void ResetTimer(void);
@@ -134,5 +177,5 @@ private:
 
 } // namespace ot
 
-#endif // OPENTHREAD_CONFIG_MLR_ENABLE
+#endif // OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 #endif // MLR_MANAGER_HPP_

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -94,7 +94,7 @@ public:
      *
      * @param[in]  aChild                       A reference to the child information.
      * @param[in]  aOldMlrRegisteredAddresses   A pointer to an array of the Child's previously registered Ip6
-     * addresses.
+     *                                          addresses.
      * @param[in]  aOldMlrRegisteredAddressNum  The number of previously registered Ip6 addresses.
      *
      */
@@ -133,16 +133,16 @@ private:
 #if OPENTHREAD_CONFIG_MLR_ENABLE
     void UpdateLocalSubscriptions(void);
     void SetNetifMulticastAddressMlrState(MlrState aFromState, MlrState aToState);
-    bool IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress);
+    bool IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress) const;
 #endif
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     void SetChildMulticastAddressMlrState(MlrState aFromState, MlrState aToState);
-    bool IsAddressMlrRegisteredByAnyChild(const Ip6::Address &aAddress)
+    bool IsAddressMlrRegisteredByAnyChild(const Ip6::Address &aAddress) const
     {
         return IsAddressMlrRegisteredByAnyChildExcept(aAddress, nullptr);
     }
-    bool IsAddressMlrRegisteredByAnyChildExcept(const Ip6::Address &aAddress, const Child *aExceptChild);
+    bool IsAddressMlrRegisteredByAnyChildExcept(const Ip6::Address &aAddress, const Child *aExceptChild) const;
 #endif
 
     void SetMulticastAddressMlrState(MlrState aFromState, MlrState aToState)

--- a/src/core/thread/mlr_types.hpp
+++ b/src/core/thread/mlr_types.hpp
@@ -36,7 +36,7 @@
 
 #include "openthread-core-config.h"
 
-#if OPENTHREAD_CONFIG_MLR_ENABLE
+#if OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
 namespace ot {
 
@@ -51,14 +51,14 @@ namespace ot {
  * Multicast Listener Registration state for multicast addresses.
  *
  */
-typedef enum MlrState
+enum MlrState
 {
     kMlrStateToRegister,  ///< The multicast address is to be registered.
     kMlrStateRegistering, ///< The multicast address is being registered.
     kMlrStateRegistered,  ///< The multicast address is registered.
-} MlrState;
+};
 
 } // namespace ot
 
-#endif // OPENTHREAD_CONFIG_MLR_ENABLE
+#endif // OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 #endif // MLR_TYPES_HPP_

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -114,7 +114,7 @@ ThreadNetif::ThreadNetif(Instance &aInstance)
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     , mDuaManager(aInstance)
 #endif
-#if OPENTHREAD_CONFIG_MLR_ENABLE
+#if OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     , mMlrManager(aInstance)
 #endif
     , mChildSupervisor(aInstance)

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -59,7 +59,7 @@
 #include "thread/dua_manager.hpp"
 #endif
 
-#if OPENTHREAD_CONFIG_MLR_ENABLE
+#if OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 #include "thread/mlr_manager.hpp"
 #endif
 
@@ -264,7 +264,7 @@ private:
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     DuaManager mDuaManager;
 #endif
-#if OPENTHREAD_CONFIG_MLR_ENABLE
+#if OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     MlrManager mMlrManager;
 #endif
     Utils::ChildSupervisor     mChildSupervisor;

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -244,7 +244,7 @@ private:
     uint8_t mTlvs[kMaxSize];
 } OT_TOOL_PACKED_END;
 
-#if OPENTHREAD_CONFIG_MLR_ENABLE
+#if OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
 /**
  * This class implements IPv6 Addresses TLV generation and parsing.
@@ -287,7 +287,7 @@ public:
     }
 } OT_TOOL_PACKED_END;
 
-#endif // OPENTHREAD_CONFIG_MLR_ENABLE
+#endif // OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
 } // namespace ot
 

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -279,7 +279,7 @@ void Child::GenerateChallenge(void)
 }
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
-bool Child::HasMlrRegisteredAddress(const Ip6::Address &aAddress)
+bool Child::HasMlrRegisteredAddress(const Ip6::Address &aAddress) const
 {
     bool has = false;
 
@@ -297,7 +297,7 @@ exit:
     return has;
 }
 
-MlrState Child::GetAddressMlrState(const Ip6::Address &aAddress)
+MlrState Child::GetAddressMlrState(const Ip6::Address &aAddress) const
 {
     uint16_t addressIndex;
 

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -300,17 +300,14 @@ exit:
 MlrState Child::GetAddressMlrState(const Ip6::Address &aAddress)
 {
     uint16_t addressIndex;
-    bool     toRegister, registered;
 
     OT_ASSERT(&mIp6Address[0] <= &aAddress && &aAddress < OT_ARRAY_END(mIp6Address));
 
     addressIndex = static_cast<uint16_t>(&aAddress - mIp6Address);
-    toRegister   = mMlrToRegisterMask.Get(addressIndex);
-    registered   = mMlrRegisteredMask.Get(addressIndex);
 
-    OT_ASSERT(!(toRegister && registered));
-
-    return toRegister ? kMlrStateToRegister : (registered ? kMlrStateRegistered : kMlrStateRegistering);
+    return mMlrToRegisterMask.Get(addressIndex)
+               ? kMlrStateToRegister
+               : (mMlrRegisteredMask.Get(addressIndex) ? kMlrStateRegistered : kMlrStateRegistering);
 }
 
 void Child::SetAddressMlrState(const Ip6::Address &aAddress, MlrState aState)

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -318,8 +318,23 @@ void Child::SetAddressMlrState(const Ip6::Address &aAddress, MlrState aState)
 
     addressIndex = static_cast<uint16_t>(&aAddress - mIp6Address);
 
-    mMlrToRegisterMask.Set(addressIndex, aState == kMlrStateToRegister);
-    mMlrRegisteredMask.Set(addressIndex, aState == kMlrStateRegistered);
+    if (aState == kMlrStateToRegister)
+    {
+        mMlrToRegisterMask.Set(addressIndex);
+    }
+    else
+    {
+        mMlrToRegisterMask.Clear(addressIndex);
+    }
+
+    if (aState == kMlrStateRegistered)
+    {
+        mMlrRegisteredMask.Set(addressIndex);
+    }
+    else
+    {
+        mMlrRegisteredMask.Clear(addressIndex);
+    }
 }
 #endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -506,16 +506,6 @@ public:
     };
 
     /**
-     * This class represents a bit-vector of Child Ip6 address mask.
-     *
-     * An Ip6 address index is in the range [0, OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD-1].
-     *
-     * @sa Child
-     *
-     */
-    typedef BitVector<OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD> ChildIp6AddressMask;
-
-    /**
      * This class defines an iterator used to go through IPv6 address entries of a child.
      *
      */
@@ -874,23 +864,23 @@ public:
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     /**
-     * This method returns MLR state of an Ip6 address.
+     * This method returns MLR state of an Ip6 multicast address.
      *
-     * @param[in] aAddressIndex  The Ip6 address index.
+     * @param[in] aAddress  The Ip6 multicast address.
      *
-     * @returns MLR state of the Ip6 address.
+     * @returns MLR state of the Ip6 multicast address.
      *
      */
-    MlrState GetAddressMlrState(uint16_t aAddressIndex);
+    MlrState GetAddressMlrState(const Ip6::Address &aAddress);
 
     /**
-     * This method sets MLR state of an Ip6 address.
+     * This method sets MLR state of an Ip6 multicast address.
      *
-     * @param[in] aAddressIndex  The Ip6 address index.
-     * @param[in] aState         The target MLR state.
+     * @param[in] aAddress  The Ip6 multicast address.
+     * @param[in] aState    The target MLR state.
      *
      */
-    void SetAddressMlrState(uint16_t aAddressIndex, MlrState aState);
+    void SetAddressMlrState(const Ip6::Address &aAddress, MlrState aState);
 
     /**
      * This method returns if the Child has Ip6 address @p aAddress of MLR state `kMlrStateRegistered`.
@@ -931,6 +921,8 @@ private:
     {
         kNumIp6Addresses = OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD - 1,
     };
+
+    typedef BitVector<kNumIp6Addresses> ChildIp6AddressMask;
 
     class AddressIteratorBuilder
     {

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -506,6 +506,16 @@ public:
     };
 
     /**
+     * This class represents a bit-vector of Child Ip6 address mask.
+     *
+     * An Ip6 address index is in the range [0, OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD-1].
+     *
+     * @sa Child
+     *
+     */
+    typedef BitVector<OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD> ChildIp6AddressMask;
+
+    /**
      * This class defines an iterator used to go through IPv6 address entries of a child.
      *
      */
@@ -862,6 +872,56 @@ public:
 
 #endif // #if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
 
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+    /**
+     * This method returns MLR state of an Ip6 address.
+     *
+     * @param[in] aAddressIndex  The Ip6 address index.
+     *
+     * @returns MLR state of the Ip6 address.
+     *
+     */
+    MlrState GetAddressMlrState(uint16_t aAddressIndex);
+
+    /**
+     * This method sets MLR state of an Ip6 address.
+     *
+     * @param[in] aAddressIndex  The Ip6 address index.
+     * @param[in] aState         The target MLR state.
+     *
+     */
+    void SetAddressMlrState(uint16_t aAddressIndex, MlrState aState);
+
+    /**
+     * This method returns if the Child has Ip6 address @p aAddress of MLR state `kMlrStateRegistered`.
+     *
+     * @param[in] aAddress  The Ip6 address.
+     *
+     * @retval true   If the Child has Ip6 address @p aAddress of MLR state `kMlrStateRegistered`.
+     * @retval false  If the Child does not have Ip6 address @p aAddress of MLR state `kMlrStateRegistered`.
+     *
+     */
+    bool HasMlrRegisteredAddress(const Ip6::Address &aAddress);
+
+    /**
+     * This method returns if the Child has any Ip6 address of MLR state `kMlrStateRegistered`.
+     *
+     * @retval true   If the Child has any Ip6 address of MLR state `kMlrStateRegistered`.
+     * @retval false  If the Child does not have any Ip6 address of MLR state `kMlrStateRegistered`.
+     *
+     */
+    bool HasAnyMlrRegisteredAddress() { return mMlrRegisteredMask.HasAny(); }
+
+    /**
+     * This method returns if the Child has any Ip6 address of MLR state `kMlrStateToRegister`.
+     *
+     * @retval true   If the Child has any Ip6 address of MLR state `kMlrStateToRegister`.
+     * @retval false  If the Child does not have any Ip6 address of MLR state `kMlrStateToRegister`.
+     *
+     */
+    bool HasAnyMlrToRegisterAddress() { return mMlrToRegisterMask.HasAny(); }
+#endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+
 private:
 #if OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD < 2
 #error OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD should be at least set to 2.
@@ -892,6 +952,10 @@ private:
     uint8_t                  mNetworkDataVersion;           ///< Current Network Data version
     Ip6::InterfaceIdentifier mMeshLocalIid;                 ///< IPv6 address IID for mesh-local address
     Ip6::Address             mIp6Address[kNumIp6Addresses]; ///< Registered IPv6 addresses
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+    ChildIp6AddressMask mMlrToRegisterMask;
+    ChildIp6AddressMask mMlrRegisteredMask;
+#endif
 
     uint32_t mTimeout; ///< Child timeout
 

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -947,14 +947,14 @@ private:
 
     Ip6::InterfaceIdentifier mMeshLocalIid;                 ///< IPv6 address IID for mesh-local address
     Ip6::Address             mIp6Address[kNumIp6Addresses]; ///< Registered IPv6 addresses
-    uint32_t mTimeout;            ///< Child timeout
+    uint32_t                 mTimeout;                      ///< Child timeout
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     ChildIp6AddressMask mMlrToRegisterMask;
     ChildIp6AddressMask mMlrRegisteredMask;
 #endif
 
-    uint8_t  mNetworkDataVersion; ///< Current Network Data version
+    uint8_t mNetworkDataVersion; ///< Current Network Data version
 
     union
     {

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -866,15 +866,19 @@ public:
     /**
      * This method returns MLR state of an Ip6 multicast address.
      *
+     * @note The @p aAdddress reference MUST be from `IterateIp6Addresses()` or `AddressIterator`.
+     *
      * @param[in] aAddress  The Ip6 multicast address.
      *
      * @returns MLR state of the Ip6 multicast address.
      *
      */
-    MlrState GetAddressMlrState(const Ip6::Address &aAddress);
+    MlrState GetAddressMlrState(const Ip6::Address &aAddress) const;
 
     /**
      * This method sets MLR state of an Ip6 multicast address.
+     *
+     * @note The @p aAdddress reference MUST be from `IterateIp6Addresses()` or `AddressIterator`.
      *
      * @param[in] aAddress  The Ip6 multicast address.
      * @param[in] aState    The target MLR state.
@@ -891,7 +895,7 @@ public:
      * @retval false  If the Child does not have Ip6 address @p aAddress of MLR state `kMlrStateRegistered`.
      *
      */
-    bool HasMlrRegisteredAddress(const Ip6::Address &aAddress);
+    bool HasMlrRegisteredAddress(const Ip6::Address &aAddress) const;
 
     /**
      * This method returns if the Child has any Ip6 address of MLR state `kMlrStateRegistered`.
@@ -900,7 +904,7 @@ public:
      * @retval false  If the Child does not have any Ip6 address of MLR state `kMlrStateRegistered`.
      *
      */
-    bool HasAnyMlrRegisteredAddress() { return mMlrRegisteredMask.HasAny(); }
+    bool HasAnyMlrRegisteredAddress(void) const { return mMlrRegisteredMask.HasAny(); }
 
     /**
      * This method returns if the Child has any Ip6 address of MLR state `kMlrStateToRegister`.
@@ -909,7 +913,7 @@ public:
      * @retval false  If the Child does not have any Ip6 address of MLR state `kMlrStateToRegister`.
      *
      */
-    bool HasAnyMlrToRegisterAddress() { return mMlrToRegisterMask.HasAny(); }
+    bool HasAnyMlrToRegisterAddress(void) const { return mMlrToRegisterMask.HasAny(); }
 #endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 
 private:
@@ -941,15 +945,16 @@ private:
         Ip6::Address::TypeFilter mFilter;
     };
 
-    uint8_t                  mNetworkDataVersion;           ///< Current Network Data version
     Ip6::InterfaceIdentifier mMeshLocalIid;                 ///< IPv6 address IID for mesh-local address
     Ip6::Address             mIp6Address[kNumIp6Addresses]; ///< Registered IPv6 addresses
+    uint32_t mTimeout;            ///< Child timeout
+
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     ChildIp6AddressMask mMlrToRegisterMask;
     ChildIp6AddressMask mMlrRegisteredMask;
 #endif
 
-    uint32_t mTimeout; ///< Child timeout
+    uint8_t  mNetworkDataVersion; ///< Current Network Data version
 
     union
     {

--- a/tests/scripts/thread-cert/v1_2_test_multicast_listener_registration.py
+++ b/tests/scripts/thread-cert/v1_2_test_multicast_listener_registration.py
@@ -120,7 +120,7 @@ class TestMulticastListenerRegistration(thread_cert.TestCase):
     }
     """All nodes are created with default configurations"""
 
-    def test(self):
+    def _bootstrap(self):
         # starting context id
         context_id = 1
 
@@ -198,17 +198,14 @@ class TestMulticastListenerRegistration(thread_cert.TestCase):
         self.simulator.go(WAIT_ATTACH)
         self.assertEqual(self.nodes[SED_1].get_state(), 'child')
 
+    def test(self):
+        self._bootstrap()
+
         # Verify MLR.req for each device when parent is 1.2
         self.__check_mlr_ok(ROUTER_1_2, is_ftd=True)
         self.__check_mlr_ok(FED_1, is_ftd=True)
         self.__check_mlr_ok(MED_1, is_ftd=False)
         self.__check_mlr_ok(SED_1, is_ftd=False)
-
-        # Make sure Parent registers multiple MAs of MED Children in one MLR.req
-        self.__check_parent_merge_med_mlr_req([MED_1, MED_2], ROUTER_1_2)
-
-        # Make sure Parent does not send MLR.req of Child if it's already subscribed by Netif or other Children
-        self.__check_not_send_mlr_req_if_subscribed([MED_1, MED_2], ROUTER_1_2)
 
         # Switch to parent 1.1
         self.__switch_to_1_1_parent()
@@ -220,6 +217,18 @@ class TestMulticastListenerRegistration(thread_cert.TestCase):
 
         # Switch to parent 1.2
         self.__switch_to_1_2_parent()
+
+    def testParentMergeMedMlrReq(self):
+        self._bootstrap()
+
+        # Make sure Parent registers multiple MAs of MED Children in one MLR.req
+        self.__check_parent_merge_med_mlr_req([MED_1, MED_2], ROUTER_1_2)
+
+    def testNotSendMlrReqIfSubscribed(self):
+        self._bootstrap()
+
+        # Make sure Parent does not send MLR.req of Child if it's already subscribed by Netif or other Children
+        self.__check_not_send_mlr_req_if_subscribed([MED_1, MED_2], ROUTER_1_2)
 
     def __check_mlr_ok(self, id, is_ftd, is_parent_1p1=False):
         """Check if MLR works for the node"""


### PR DESCRIPTION
This PR implements parents sending `MLR.req` on behave of Children.
  - Parent sends MLR.req for Children after delaying for a random time < PARENT_AGGREGATE_DELAY (5s).
  - Update test script to check for proxied `MLR.req`
      - Parent proxy MLR.req for Children after a delay t in [0, 5]

**MLR PR List:**
- #5236 Parent send MLR.req on behave of Children **<== This PR**
- #5292 Add MulticastListenersTable on BBR 
- ~~#5248 Send MLR.req for locally Netfi MAs **MERGED**~~
- ~~#5250 Add the `MLR` log region  **MERGED**~~