### PR TITLE
[github-action] remove unused apt source lists

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get remove -y clang-6.0 libclang-common-6.0-dev libclang1-6.0 libllvm6.0
         sudo apt-get autoremove
         sudo apt-get --no-install-recommends install -y clang-tools clang-format-6.0 shellcheck
@@ -88,7 +88,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build libreadline-dev libncurses-dev
     - name: Package
       run: |
@@ -100,7 +100,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get remove -y clang-6.0 libclang-common-6.0-dev libclang1-6.0 libllvm6.0
         sudo apt-get autoremove
         sudo apt-get --no-install-recommends install -y clang-tools
@@ -134,7 +134,7 @@ jobs:
     - name: Bootstrap
       run: |
         cd /tmp
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y lib32z1 ninja-build
         wget ${{ matrix.gcc_download_url }} -O gcc-arm.tar.bz2
         tar xjf gcc-arm.tar.bz2
@@ -159,7 +159,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y gcc-${{ matrix.gcc_ver }} g++-${{ matrix.gcc_ver }} ninja-build libreadline-dev libncurses-dev
     - name: Build
       run: |
@@ -179,7 +179,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bootstrap
         run: |
-          sudo apt-get update
+          sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
           sudo apt-get --no-install-recommends install -y clang-${{ matrix.clang_ver }} clang++-${{ matrix.clang_ver }} ninja-build libreadline-dev libncurses-dev
       - name: Build
         run: |
@@ -203,7 +203,7 @@ jobs:
       - name: Bootstrap
         run: |
           sudo dpkg --add-architecture i386
-          sudo apt-get update
+          sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
           sudo apt-get --no-install-recommends install -y clang-${{ matrix.clang_ver }} clang++-${{ matrix.clang_ver }} g++-multilib ninja-build
           sudo apt-get --no-install-recommends install -y libreadline-dev:i386 libncurses-dev:i386
       - name: Build
@@ -217,7 +217,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y ninja-build
         cd /tmp
         wget -O gn.zip https://chrome-infra-packages.appspot.com/dl/gn/gn/linux-amd64/+/latest

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -54,7 +54,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y libreadline6-dev
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
@@ -82,7 +82,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y libreadline6-dev python3-setuptools
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
         sudo python3 -m pip install git+https://github.com/openthread/pyspinel
@@ -105,7 +105,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y expect
     - name: Build
       run: |
@@ -125,7 +125,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y socat expect
         cd /tmp
         wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
@@ -154,7 +154,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y socat expect
         cd /tmp
         wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz

--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -60,7 +60,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y g++-multilib ninja-build
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -51,7 +51,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y llvm-runtime
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Run
@@ -78,7 +78,7 @@ jobs:
         go-version: '1.13'
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y g++-multilib
         ./bootstrap
     - name: Run OTNS Tests
@@ -103,7 +103,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y g++-multilib
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
@@ -130,7 +130,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y g++-multilib
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
@@ -157,7 +157,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y g++-multilib
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
@@ -209,6 +209,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
+        sudo rm /etc/apt/sources.list.d/*
         sudo apt-get --no-install-recommends install -y ninja-build
         git clone https://github.com/openthread/ot-commissioner.git /tmp/ot-commissioner --depth 1 --branch master
     - name: Build
@@ -272,7 +273,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y g++-multilib python3-setuptools
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
         sudo python3 -m pip install git+https://github.com/openthread/pyspinel
@@ -300,7 +301,7 @@ jobs:
       - uses: actions/checkout@v2
       - name: Bootstrap
         run: |
-          sudo apt-get update
+          sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
           sudo apt-get --no-install-recommends install -y python3-setuptools
           python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
           sudo python3 -m pip install git+https://github.com/openthread/pyspinel

--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -48,7 +48,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y dbus libdbus-1-dev
         sudo apt-get --no-install-recommends install -y autoconf-archive
         sudo apt-get --no-install-recommends install -y bsdtar
@@ -77,7 +77,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y dbus libdbus-1-dev
         sudo apt-get --no-install-recommends install -y autoconf-archive
         sudo apt-get --no-install-recommends install -y bsdtar

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -38,7 +38,7 @@ install_packages_apt()
     echo 'Installing toolchain dependencies...'
 
     # apt-get update and install dependencies
-    sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+    sudo apt-get update
     sudo apt-get --no-install-recommends install -y automake g++ libtool lsb-release make cmake ninja-build shellcheck
 
     echo 'Installing GNU Arm Embedded Toolchain...'

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -38,7 +38,7 @@ install_packages_apt()
     echo 'Installing toolchain dependencies...'
 
     # apt-get update and install dependencies
-    sudo apt-get update
+    sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
     sudo apt-get --no-install-recommends install -y automake g++ libtool lsb-release make cmake ninja-build shellcheck
 
     echo 'Installing GNU Arm Embedded Toolchain...'
@@ -56,7 +56,7 @@ install_packages_apt()
     elif ! command -v arm-none-eabi-g++; then
         # add gcc-arm-embedded ppa
         sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
-        sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y gcc-arm-embedded
     fi
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -49,14 +49,14 @@ install_packages_apt()
 
     if [ "$PLATFORM" = "Raspbian" ]; then
         sudo apt-get --no-install-recommends install -y binutils-arm-none-eabi gcc-arm-none-eabi gdb-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
-    elif [ "$PLATFORM" = "Ubuntu" ] && [ "$(echo "$RELEASE >= $UBUNTU2004" | bc)" -eq 1 ]; then
+    elif [ "$PLATFORM" = "Ubuntu" ] && [[ ! $RELEASE < $UBUNTU2004 ]]; then
         echo "Ubuntu Release >= $UBUNTU2004"
         # no need to use ppa
         sudo apt-get --no-install-recommends install -y gcc-arm-none-eabi gdb-multiarch libnewlib-arm-none-eabi
     elif ! command -v arm-none-eabi-g++; then
         # add gcc-arm-embedded ppa
         sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
-        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+        sudo apt-get update
         sudo apt-get --no-install-recommends install -y gcc-arm-embedded
     fi
 


### PR DESCRIPTION
These sources break easily, removing them so that `apt-get update` doesn't fail.