### PR TITLE
[test] move expect timeout settings to _common.exp

### DIFF
--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -29,6 +29,7 @@
 
 proc wait_for {command expected} {
     set result 0
+    set timeout 1
     for {set i 0} {$i < 20} {incr i} {
         if {$command != ""} {
             send "$command\n"
@@ -67,3 +68,5 @@ proc dispose {} {
     send "\x04"
     expect eof
 }
+
+set timeout 10

--- a/tests/scripts/expect/cli-channel.exp
+++ b/tests/scripts/expect/cli-channel.exp
@@ -30,7 +30,6 @@
 source "tests/scripts/expect/_common.exp"
 
 set spawn_id [spawn_node 1]
-set timeout 3
 
 send "ifconfig up\n"
 expect "Done"

--- a/tests/scripts/expect/cli-child.exp
+++ b/tests/scripts/expect/cli-child.exp
@@ -27,9 +27,9 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 3
 setup_nodes
 
 set spawn_id $spawn_2

--- a/tests/scripts/expect/cli-childip.exp
+++ b/tests/scripts/expect/cli-childip.exp
@@ -27,9 +27,9 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 3
 setup_nodes
 
 set spawn_id $spawn_2

--- a/tests/scripts/expect/cli-coap.exp
+++ b/tests/scripts/expect/cli-coap.exp
@@ -27,9 +27,9 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 3
 setup_nodes
 
 set spawn_id $spawn_1

--- a/tests/scripts/expect/cli-coaps.exp
+++ b/tests/scripts/expect/cli-coaps.exp
@@ -27,9 +27,9 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 3
 setup_nodes
 
 set spawn_id $spawn_1

--- a/tests/scripts/expect/cli-coex.exp
+++ b/tests/scripts/expect/cli-coex.exp
@@ -30,7 +30,6 @@
 source "tests/scripts/expect/_common.exp"
 
 set spawn_id [spawn_node 1]
-set timeout 3
 
 send "coex disable\n"
 expect "Done"

--- a/tests/scripts/expect/cli-commissioner.exp
+++ b/tests/scripts/expect/cli-commissioner.exp
@@ -27,9 +27,9 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 3
 setup_nodes
 
 set spawn_id $spawn_2

--- a/tests/scripts/expect/cli-counters.exp
+++ b/tests/scripts/expect/cli-counters.exp
@@ -30,7 +30,6 @@
 source "tests/scripts/expect/_common.exp"
 
 set spawn_id [spawn_node 1]
-set timeout 3
 
 send "counters\n"
 expect "mac"

--- a/tests/scripts/expect/cli-dataset.exp
+++ b/tests/scripts/expect/cli-dataset.exp
@@ -30,7 +30,6 @@
 source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 3
 setup_nodes
 
 set spawn_id $spawn_1

--- a/tests/scripts/expect/cli-extaddr.exp
+++ b/tests/scripts/expect/cli-extaddr.exp
@@ -30,7 +30,6 @@
 source "tests/scripts/expect/_common.exp"
 
 set spawn_id [spawn_node 1]
-set timeout 3
 
 send "extaddr 99aabbccddeeff00\n"
 expect "Done"

--- a/tests/scripts/expect/cli-ipmaddr.exp
+++ b/tests/scripts/expect/cli-ipmaddr.exp
@@ -27,9 +27,9 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 3
 setup_nodes
 
 set spawn_id $spawn_1

--- a/tests/scripts/expect/cli-log-level.exp
+++ b/tests/scripts/expect/cli-log-level.exp
@@ -30,7 +30,6 @@
 source "tests/scripts/expect/_common.exp"
 
 set spawn_id [spawn_node 1]
-set timeout 3
 
 send "log level\n"
 expect "1"

--- a/tests/scripts/expect/cli-mac.exp
+++ b/tests/scripts/expect/cli-mac.exp
@@ -30,7 +30,6 @@
 source "tests/scripts/expect/_common.exp"
 
 set spawn_id [spawn_node 1]
-set timeout 3
 
 send "mac retries direct 5\n"
 expect "Done"

--- a/tests/scripts/expect/cli-macfilter.exp
+++ b/tests/scripts/expect/cli-macfilter.exp
@@ -30,7 +30,6 @@
 source "tests/scripts/expect/_common.exp"
 
 set spawn_id [spawn_node 1]
-set timeout 3
 
 send "macfilter\n"
 expect "Address Mode: Disabled"

--- a/tests/scripts/expect/cli-misc.exp
+++ b/tests/scripts/expect/cli-misc.exp
@@ -27,9 +27,9 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 3
 setup_nodes
 set spawn_id $spawn_1
 

--- a/tests/scripts/expect/cli-neighbor.exp
+++ b/tests/scripts/expect/cli-neighbor.exp
@@ -27,9 +27,9 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 3
 setup_nodes
 
 set spawn_id $spawn_2

--- a/tests/scripts/expect/cli-ping.exp
+++ b/tests/scripts/expect/cli-ping.exp
@@ -31,9 +31,6 @@ source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
 
-set timeout 3
-
-
 set spawn_id [spawn_node 1]
 
 send "ping ::1 1 2 1 1\n"

--- a/tests/scripts/expect/cli-promiscuous.exp
+++ b/tests/scripts/expect/cli-promiscuous.exp
@@ -31,9 +31,6 @@ source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
 
-set timeout 3
-
-
 set spawn_id [spawn_node 1]
 
 send "promiscuous\n"

--- a/tests/scripts/expect/cli-pskc.exp
+++ b/tests/scripts/expect/cli-pskc.exp
@@ -30,7 +30,6 @@
 source "tests/scripts/expect/_common.exp"
 
 set spawn_id [spawn_node 1]
-set timeout 3
 
 send "pskc 00112233445566778899aabbccddeeff\n"
 expect "Done"

--- a/tests/scripts/expect/cli-router.exp
+++ b/tests/scripts/expect/cli-router.exp
@@ -30,7 +30,6 @@
 source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 3
 setup_nodes
 
 set spawn_id $spawn_1

--- a/tests/scripts/expect/cli-routereligible.exp
+++ b/tests/scripts/expect/cli-routereligible.exp
@@ -30,7 +30,6 @@
 source "tests/scripts/expect/_common.exp"
 
 set spawn_id [spawn_node 1]
-set timeout 3
 
 send "routereligible disable\n"
 expect "Done"

--- a/tests/scripts/expect/cli-scan-discover.exp
+++ b/tests/scripts/expect/cli-scan-discover.exp
@@ -30,7 +30,6 @@
 source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 3
 setup_nodes
 
 set spawn_id [spawn_node 3]

--- a/tests/scripts/expect/cli-udp.exp
+++ b/tests/scripts/expect/cli-udp.exp
@@ -27,9 +27,9 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+source "tests/scripts/expect/_common.exp"
 source "tests/scripts/expect/_multinode.exp"
 
-set timeout 3
 setup_nodes
 
 set spawn_id $spawn_2

--- a/tests/scripts/expect/posix-diag-rcp.exp
+++ b/tests/scripts/expect/posix-diag-rcp.exp
@@ -27,11 +27,10 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=1"
-set timeout 3
-expect_after {
-    timeout { exit 1 }
-}
+source "tests/scripts/expect/_common.exp"
+
+set spawn_id [spawn_node 1]
+
 send "diag rcp\n"
 expect "diagnostics mode is disabled"
 expect "Done"
@@ -54,5 +53,5 @@ expect "status 0x7"
 expect "Done"
 send "diag rcp power 10\n"
 expect "Done"
-send "\x04"
-expect eof
+
+dispose

--- a/tests/scripts/expect/posix-max-power-table.exp
+++ b/tests/scripts/expect/posix-max-power-table.exp
@@ -27,9 +27,10 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+source "tests/scripts/expect/_common.exp"
+
 # allows 11-25 and forbidden 26
 spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?max-power-table=11,12,13,14,15,16,17,18,19,20,21,22,23,24,-1,0x7f&forkpty-arg=1"
-set timeout 3
 expect_after {
     timeout { exit 1 }
 }
@@ -43,7 +44,6 @@ send "\x04"
 expect eof
 # allows all channels by default
 spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=1"
-set timeout 3
 expect_after {
     timeout { exit 1 }
 }

--- a/tests/scripts/expect/posix-rcp.exp
+++ b/tests/scripts/expect/posix-rcp.exp
@@ -29,11 +29,7 @@
 
 source "tests/scripts/expect/_common.exp"
 
-spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=1"
-set timeout 3
-expect_after {
-    timeout { exit 1 }
-}
+set spawn_id [spawn_node 1]
 
 send "rcp version\n"
 expect "Done"

--- a/tests/scripts/expect/posix-scan-tx-to-sleep.exp
+++ b/tests/scripts/expect/posix-scan-tx-to-sleep.exp
@@ -29,8 +29,6 @@
 
 source "tests/scripts/expect/_common.exp"
 
-set timeout 3
-
 spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=--sleep-to-tx 1"
 set node_1 $spawn_id
 expect_after {

--- a/tests/scripts/expect/tun-dns-client.exp
+++ b/tests/scripts/expect/tun-dns-client.exp
@@ -29,11 +29,7 @@
 
 source "tests/scripts/expect/_common.exp"
 
-spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=1"
-set timeout 3
-expect_after {
-    timeout { exit 1 }
-}
+set spawn_id [spawn_node 1]
 
 send "panid 0xface\n"
 expect "Done"

--- a/tests/scripts/expect/tun-netif.exp
+++ b/tests/scripts/expect/tun-netif.exp
@@ -29,11 +29,7 @@
 
 source "tests/scripts/expect/_common.exp"
 
-spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=1"
-set timeout 3
-expect_after {
-    timeout { exit 1 }
-}
+set spawn_id [spawn_node 1]
 
 send "netif\n"
 expect -re {[\r\n][^\r\n:]+?:\d+}

--- a/tests/scripts/expect/tun-netstat.exp
+++ b/tests/scripts/expect/tun-netstat.exp
@@ -29,7 +29,6 @@
 
 source "tests/scripts/expect/_common.exp"
 
-set timeout 3
 set spawn_id [spawn_node 1]
 
 send "ifconfig up\n"

--- a/tests/scripts/expect/tun-sntp.exp
+++ b/tests/scripts/expect/tun-sntp.exp
@@ -29,11 +29,7 @@
 
 source "tests/scripts/expect/_common.exp"
 
-spawn $env(OT_COMMAND) "spinel+hdlc+uart://$env(RCP_COMMAND)?forkpty-arg=1"
-set timeout 3
-expect_after {
-    timeout { exit 1 }
-}
+set spawn_id [spawn_node 1]
 
 send "panid 0xface\n"
 expect "Done"


### PR DESCRIPTION
This moves all settings of `timeout` to one place. Also changes the default timeout to 10 seconds, can probably solve the occasional timeout when `dataset commit active`.