### PR TITLE
[router-table] enable use of range-based "for" loop

### DIFF
--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -122,11 +122,11 @@ otError KeyManager::SetMasterKey(const MasterKey &aKey)
 
 #if OPENTHREAD_FTD
     // reset router frame counters
-    for (RouterTable::Iterator iter(GetInstance()); !iter.IsDone(); iter++)
+    for (Router &router : Get<RouterTable>().Iterate())
     {
-        iter.GetRouter()->SetKeySequence(0);
-        iter.GetRouter()->SetLinkFrameCounter(0);
-        iter.GetRouter()->SetMleFrameCounter(0);
+        router.SetKeySequence(0);
+        router.SetLinkFrameCounter(0);
+        router.SetMleFrameCounter(0);
     }
 
     // reset child frame counters

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1541,10 +1541,8 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
     VerifyOrExit(changed, OT_NOOP);
     otLogInfoMle("Route table updated");
 
-    for (RouterTable::Iterator iter(GetInstance()); !iter.IsDone(); iter++)
+    for (Router &router : Get<RouterTable>().Iterate())
     {
-        Router &router = *iter.GetRouter();
-
         otLogInfoMle("    %04x -> %04x, cost:%d %d, lqin:%d, lqout:%d, link:%s", router.GetRloc16(),
                      (router.GetNextHop() == kInvalidRouterId) ? 0xffff : Rloc16FromRouterId(router.GetNextHop()),
                      router.GetCost(), mRouterTable.GetLinkCost(router), router.GetLinkInfo().GetLinkQuality(),
@@ -1870,9 +1868,8 @@ void MleRouter::HandleStateUpdateTimer(void)
     }
 
     // update router state
-    for (RouterTable::Iterator iter(GetInstance()); !iter.IsDone(); iter++)
+    for (Router &router : Get<RouterTable>().Iterate())
     {
-        Router & router = *iter.GetRouter();
         uint32_t age;
 
         if (router.GetRloc16() == GetRloc16())
@@ -4372,9 +4369,8 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
 
     aTlv.SetActiveRouters(mRouterTable.GetActiveRouterCount());
 
-    for (RouterTable::Iterator iter(GetInstance()); !iter.IsDone(); iter++)
+    for (Router &router : Get<RouterTable>().Iterate())
     {
-        Router &router = *iter.GetRouter();
         uint8_t linkQuality;
 
         if (router.GetRloc16() == GetRloc16())
@@ -4479,10 +4475,8 @@ void MleRouter::FillRouteTlv(RouteTlv &aTlv)
     aTlv.SetRouterIdSequence(mRouterTable.GetRouterIdSequence());
     aTlv.SetRouterIdMask(mRouterTable.GetRouterIdSet());
 
-    for (RouterTable::Iterator iter(GetInstance()); !iter.IsDone(); iter++, routerCount++)
+    for (Router &router : Get<RouterTable>().Iterate())
     {
-        Router &router = *iter.GetRouter();
-
         if (router.GetRloc16() == GetRloc16())
         {
             aTlv.SetLinkQualityIn(routerCount, 0);
@@ -4521,6 +4515,8 @@ void MleRouter::FillRouteTlv(RouteTlv &aTlv)
             aTlv.SetLinkQualityOut(routerCount, router.GetLinkQualityOut());
             aTlv.SetLinkQualityIn(routerCount, router.GetLinkInfo().GetLinkQuality());
         }
+
+        routerCount++;
     }
 
     aTlv.SetRouteDataLength(routerCount);
@@ -4551,10 +4547,8 @@ bool MleRouter::HasMinDowngradeNeighborRouters(void)
     uint8_t linkQuality;
     uint8_t routerCount = 0;
 
-    for (RouterTable::Iterator iter(GetInstance()); !iter.IsDone(); iter++)
+    for (Router &router : Get<RouterTable>().Iterate())
     {
-        Router &router = *iter.GetRouter();
-
         if (!router.IsStateValid())
         {
             continue;
@@ -4581,9 +4575,8 @@ bool MleRouter::HasOneNeighborWithComparableConnectivity(const RouteTlv &aRoute,
     bool rval = true;
 
     // process local neighbor routers
-    for (RouterTable::Iterator iter(GetInstance()); !iter.IsDone(); iter++)
+    for (Router &router : Get<RouterTable>().Iterate())
     {
-        Router &router           = *iter.GetRouter();
         uint8_t localLinkQuality = 0;
         uint8_t peerLinkQuality  = 0;
         uint8_t routerCount      = 0;

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -44,14 +44,8 @@ namespace ot {
 
 RouterTable::Iterator::Iterator(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mRouter(nullptr)
+    , mRouter(Get<RouterTable>().GetFirstEntry())
 {
-    Reset();
-}
-
-void RouterTable::Iterator::Reset(void)
-{
-    mRouter = Get<RouterTable>().GetFirstEntry();
 }
 
 void RouterTable::Iterator::Advance(void)


### PR DESCRIPTION
This commit updates `RouterTable` class to add support for using
range-based `for` loops to iterate over all routers.