### PR TITLE
[mle] work around MLE Link Accept messages that are too large

### DIFF
--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -419,7 +419,7 @@ public:
      * @param[out]  aTlv  A reference to the tlv to be filled.
      *
      */
-    void FillRouteTlv(RouteTlv &aTlv);
+    void FillRouteTlv(RouteTlv &aTlv, Neighbor *aNeighbor = nullptr);
 
     /**
      * This method generates an MLE Child Update Request message to be sent to the parent.
@@ -582,7 +582,7 @@ private:
 
     otError AppendConnectivity(Message &aMessage);
     otError AppendChildAddresses(Message &aMessage, Child &aChild);
-    otError AppendRoute(Message &aMessage);
+    otError AppendRoute(Message &aMessage, Neighbor *aNeighbor = nullptr);
     otError AppendActiveDataset(Message &aMessage);
     otError AppendPendingDataset(Message &aMessage);
     void    HandleDetachStart(void);

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -142,6 +142,16 @@ OT_TOOL_PACKED_BEGIN
 class RouteTlv : public Tlv
 {
 public:
+    enum
+    {
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+        kLinkAcceptMaxRouters = 3,
+#else
+        kLinkAcceptMaxRouters = 20,
+#endif
+        kLinkAcceptSequenceRollback = 64,
+    };
+
     /**
      * This method initializes the TLV.
      *

--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -158,6 +158,7 @@ EXTRA_DIST                                                         = \
     test_network_layer.py                                            \
     test_reed_address_solicit_rejected.py                            \
     test_reset.py                                                    \
+    test_router_reattach.py                                          \
     test_service.py                                                  \
     thread_cert.py                                                   \
     tlvs_parsing.py                                                  \
@@ -203,6 +204,7 @@ check_SCRIPTS                                                      = \
     test_network_layer.py                                            \
     test_reed_address_solicit_rejected.py                            \
     test_reset.py                                                    \
+    test_router_reattach.py                                          \
     test_service.py                                                  \
     Cert_5_1_01_RouterAttach.py                                      \
     Cert_5_1_02_ChildAddressTimeout.py                               \

--- a/tests/scripts/thread-cert/test_router_reattach.py
+++ b/tests/scripts/thread-cert/test_router_reattach.py
@@ -1,0 +1,281 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import unittest
+
+import config
+import thread_cert
+
+
+class test_router_reattach(thread_cert.TestCase):
+    TOPOLOGY = {
+        1: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        2: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        3: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        4: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        5: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        6: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        7: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        8: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        9: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        10: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        11: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        12: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        13: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        14: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        15: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        16: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        17: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        18: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        19: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        20: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        21: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        22: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        23: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        24: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        25: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        26: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        27: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        28: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        29: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        30: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        31: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+        32: {
+            'mode': 'rsdn',
+            'panid': 0xface,
+            'router_downgrade_threshold': 32,
+            'router_selection_jitter': 1,
+            'router_upgrade_threshold': 32
+        },
+    }
+
+    def test(self):
+        self.nodes[1].start()
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[1].get_state(), 'leader')
+
+        for i in range(2, 33):
+            self.nodes[i].start()
+            self.simulator.go(5)
+            self.assertEqual(self.nodes[i].get_state(), 'router')
+
+        self.nodes[2].reset()
+        self.nodes[2].start()
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[2].get_state(), 'router')
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit addresses an issue where the MLE Link Accept message may
be too large to fit within a single IEEE 802.15.4 frame. Thread
requires any MLE message transported using 6LoWPAN fragmentation to
also enable IEEE 802.15.4 MAC frame security. However, the purpose of
MLE Link Accept messages is to establish a secure link and cannot
itself be transported with IEEE 802.15.4 MAC frame security enabled.

An MLE Link Accept message may carry a Route64 TLV that has a length
dependent on the number of active routers in the network. When there
are many active routers, the Route64 TLV is large and the MLE Link
Accept message can no longer fit within a single IEEE 802.15.4
frame. The side effect is that a router coming out of reset will not
be able to diretly restore its router role and must first attach as an
end device.

This commit limits the size of a Route64 TLV when included in MLE Link
Accept messages. When the number of active routers is above a
threshold, some routers will be elided from the Route64 TLV and the
Router ID Sequence value is decremented. This allows the device coming
out of reset to restore its router role and retrieve the current
Route64 TLV in a subsequent message exchange.

Resolves #5152 