### PR TITLE
[address-resolver] TimeSinceLastTransaction should be in seconds

### DIFF
--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -42,6 +42,7 @@
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 #include "common/logging.hpp"
+#include "common/time.hpp"
 #include "mac/mac_types.hpp"
 #include "thread/mesh_forwarder.hpp"
 #include "thread/mle_router.hpp"
@@ -787,7 +788,7 @@ void AddressResolver::HandleAddressQuery(Coap::Message &aMessage, const Ip6::Mes
 
         if (child.HasIp6Address(target))
         {
-            lastTransactionTime = TimerMilli::GetNow() - child.GetLastHeard();
+            lastTransactionTime = Time::MsecToSec(TimerMilli::GetNow() - child.GetLastHeard());
             SendAddressQueryResponse(target, child.GetMeshLocalIid(), &lastTransactionTime, aMessageInfo.GetPeerAddr());
             ExitNow();
         }

--- a/tests/toranj/test-039-address-cache-table-snoop.py
+++ b/tests/toranj/test-039-address-cache-table-snoop.py
@@ -322,7 +322,9 @@ for index in range(NUM_ADDRESSES):
            str(NUM_ADDRESSES - index - 1))
     verify(cache_table[index].rloc16 == r3_rloc)
     verify(cache_table[index].state == wpan.ADDRESS_CACHE_ENTRY_STATE_CACHED)
-    verify(cache_table[index].last_trans > 0)
+    # SED's keep-alive period (`POLL_PERIOD`) is 200ms, `last_trans` should always be 0 as it is
+    # the number of seconds since a keep-alive was last received from the child.
+    verify(cache_table[index].last_trans == 0)
 
 # Send again to r2. This should cause the related cache entries to be moved to top of the list:
 


### PR DESCRIPTION
Thread Specification 5.4.2.4
> The Time Since Last Transaction TLV contains the number of seconds since a keep-alive message (as defined in Section 4.6.3 Timing Out Children in Chapter 4, Mesh Link Establishment) was last received from the Child.