### PR TITLE
[otns] emit device mode

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -778,6 +778,10 @@ otError Mle::SetDeviceMode(DeviceMode aDeviceMode)
     VerifyOrExit(mDeviceMode != aDeviceMode, OT_NOOP);
     mDeviceMode = aDeviceMode;
 
+#if OPENTHREAD_CONFIG_OTNS_ENABLE
+    Get<Utils::Otns>().EmitDeviceMode(mDeviceMode);
+#endif
+
     otLogNoteMle("Mode 0x%02x -> 0x%02x [%s]", oldMode.Get(), mDeviceMode.Get(), mDeviceMode.ToString().AsCString());
 
     IgnoreError(Store());

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -153,6 +153,12 @@ void Otns::EmitTransmit(const Mac::TxFrame &aFrame)
     }
 }
 
+void Otns::EmitDeviceMode(Mle::DeviceMode aMode)
+{
+    EmitStatus("mode=%s%s%s%s", aMode.IsRxOnWhenIdle() ? "r" : "", aMode.IsSecureDataRequest() ? "s" : "",
+               aMode.IsFullThreadDevice() ? "d" : "", aMode.IsFullNetworkData() ? "n" : "");
+}
+
 } // namespace Utils
 } // namespace ot
 

--- a/src/core/utils/otns.hpp
+++ b/src/core/utils/otns.hpp
@@ -132,6 +132,14 @@ public:
      */
     static void EmitTransmit(const Mac::TxFrame &aFrame);
 
+    /**
+     * This function emits the device mode to OTNS.
+     *
+     * @param[in] aMode The device mode.
+     *
+     */
+    static void EmitDeviceMode(Mle::DeviceMode aMode);
+
 private:
     static void EmitStatus(const char *aFmt, ...);
 


### PR DESCRIPTION
This PR allows [OTNS](https://github.com/openthread/ot-ns) to correctly visualize node mode when it changes.  