### PR TITLE
[netif] enhance IterateExternalMulticastAddresses 

### DIFF
--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -214,13 +214,15 @@ public:
     public:
         /**
          * This constructor initializes an `ExternalMulticastAddressIterator` instance to start from the first external
-         * multicast address.
+         * multicast address that matches a given Ip6 address type filter.
          *
-         * @param[in] aNetif  A reference to the Netif instance.
+         * @param[in] aNetif   A reference to the Netif instance.
+         * @param[in] aFilter  The Ip6 address type filter.
          *
          */
-        explicit ExternalMulticastAddressIterator(const Netif &aNetif)
+        explicit ExternalMulticastAddressIterator(const Netif &aNetif, Address::TypeFilter aFilter)
             : mNetif(aNetif)
+            , mFilter(aFilter)
         {
             AdvanceFrom(mNetif.GetMulticastAddresses());
         }
@@ -315,7 +317,8 @@ public:
 
         void AdvanceFrom(const NetifMulticastAddress *aAddr)
         {
-            while (aAddr != nullptr && !mNetif.IsMulticastAddressExternal(*aAddr))
+            while (aAddr != nullptr &&
+                   !(mNetif.IsMulticastAddressExternal(*aAddr) && aAddr->GetAddress().MatchesFilter(mFilter)))
             {
                 aAddr = aAddr->GetNext();
             }
@@ -326,6 +329,7 @@ public:
 
         const Netif &                  mNetif;
         ExternalNetifMulticastAddress *mCurrent;
+        Address::TypeFilter            mFilter;
     };
 
     /**
@@ -563,19 +567,28 @@ public:
     void SetMulticastPromiscuous(bool aEnabled) { mMulticastPromiscuous = aEnabled; }
 
     /**
-     * This method enables range-based `for` loop iteration over all external multicast addresses on the Netif.
+     * This method enables range-based `for` loop iteration over external multicast addresses on the Netif that matches
+     * a given Ip6 address type filter.
      *
-     * This method should be used like follows:
+     * This method should be used like follows: to iterate over all external multicast addresses
      *
      *     for (Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
      *     { ... }
      *
+     * or to iterate over a subset of extern multicast addresses determined by a given address type filter
+     *
+     *     for (Ip6::ExternalNetifMulticastAddress &addr :
+     * Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal)) { ... }
+     *
+     * @param[in] aFilter  The Ip6 address type filter.
+     *
      * @returns An `ExternalMulticastAddressIteratorBuilder` instance.
      *
      */
-    ExternalMulticastAddressIteratorBuilder IterateExternalMulticastAddresses(void)
+    ExternalMulticastAddressIteratorBuilder IterateExternalMulticastAddresses(
+        Address::TypeFilter aFilter = Address::kTypeAny)
     {
-        return ExternalMulticastAddressIteratorBuilder(*this);
+        return ExternalMulticastAddressIteratorBuilder(*this, aFilter);
     }
 
     /**
@@ -613,19 +626,21 @@ private:
     class ExternalMulticastAddressIteratorBuilder
     {
     public:
-        ExternalMulticastAddressIteratorBuilder(const Netif &aNetif)
+        ExternalMulticastAddressIteratorBuilder(const Netif &aNetif, Address::TypeFilter aFilter)
             : mNetif(aNetif)
+            , mFilter(aFilter)
         {
         }
 
-        ExternalMulticastAddressIterator begin(void) { return ExternalMulticastAddressIterator(mNetif); }
+        ExternalMulticastAddressIterator begin(void) { return ExternalMulticastAddressIterator(mNetif, mFilter); }
         ExternalMulticastAddressIterator end(void)
         {
             return ExternalMulticastAddressIterator(mNetif, ExternalMulticastAddressIterator::kEndIterator);
         }
 
     private:
-        const Netif &mNetif;
+        const Netif &       mNetif;
+        Address::TypeFilter mFilter;
     };
 
     LinkedList<NetifUnicastAddress>   mUnicastAddresses;

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -220,7 +220,7 @@ public:
          * @param[in] aFilter  The Ip6 address type filter.
          *
          */
-        explicit ExternalMulticastAddressIterator(const Netif &aNetif, Address::TypeFilter aFilter)
+        explicit ExternalMulticastAddressIterator(const Netif &aNetif, Address::TypeFilter aFilter = Address::kTypeAny)
             : mNetif(aNetif)
             , mFilter(aFilter)
         {
@@ -575,7 +575,7 @@ public:
      *     for (Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
      *     { ... }
      *
-     * or to iterate over a subset of extern multicast addresses determined by a given address type filter
+     * or to iterate over a subset of external multicast addresses determined by a given address type filter
      *
      *     for (Ip6::ExternalNetifMulticastAddress &addr :
      * Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal)) { ... }

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -146,9 +146,10 @@ void MlrManager::SendMulticastListenerRegistration(void)
     addressesTlv.SetLength(sizeof(Ip6::Address) * num);
     SuccessOrExit(error = message->Append(&addressesTlv, sizeof(addressesTlv)));
 
-    for (Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+    for (Ip6::ExternalNetifMulticastAddress &addr :
+         Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
-        if (addr.GetAddress().IsMulticastLargerThanRealmLocal() && addr.GetMlrState() == kMlrStateToRegister)
+        if (addr.GetMlrState() == kMlrStateToRegister)
         {
             SuccessOrExit(error = message->Append(&addr.GetAddress(), sizeof(Ip6::Address)));
             addr.SetMlrState(kMlrStateRegistering);
@@ -330,14 +331,12 @@ void MlrManager::LogMulticastAddresses(void)
 #if OPENTHREAD_CONFIG_LOG_BBR && OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
     otLogDebgMlr("-------- Multicast Addresses --------");
 
-    for (const Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+    for (const Ip6::ExternalNetifMulticastAddress &addr :
+         Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
-        if (addr.GetAddress().IsMulticastLargerThanRealmLocal())
-        {
-            MlrState state = addr.GetMlrState();
+        MlrState state = addr.GetMlrState();
 
-            otLogDebgMlr("%-32s%c", addr.GetAddress().ToString().AsCString(), "-rR"[state]);
-        }
+        otLogDebgMlr("%-32s%c", addr.GetAddress().ToString().AsCString(), "-rR"[state]);
     }
 #endif
 }
@@ -346,9 +345,10 @@ uint16_t MlrManager::CountNetifMulticastAddressesToRegister(void) const
 {
     uint16_t count = 0;
 
-    for (const Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+    for (const Ip6::ExternalNetifMulticastAddress &addr :
+         Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
-        if (addr.GetAddress().IsMulticastLargerThanRealmLocal() && addr.GetMlrState() == kMlrStateToRegister)
+        if (addr.GetMlrState() == kMlrStateToRegister)
         {
             count++;
         }
@@ -359,9 +359,10 @@ uint16_t MlrManager::CountNetifMulticastAddressesToRegister(void) const
 
 void MlrManager::SetNetifMulticastAddressMlrState(MlrState aFromState, MlrState aToState)
 {
-    for (Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+    for (Ip6::ExternalNetifMulticastAddress &addr :
+         Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
-        if (addr.GetAddress().IsMulticastLargerThanRealmLocal() && addr.GetMlrState() == aFromState)
+        if (addr.GetMlrState() == aFromState)
         {
             addr.SetMlrState(aToState);
         }


### PR DESCRIPTION
This PR enhances `IterateExternalMulticastAddresses` to use further filter external multicast addresses.

**Should be rebased after #5269 is merged**