### PR TITLE
[github-actions] fix external-commissioner test

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -210,7 +210,7 @@ jobs:
     - name: Bootstrap
       run: |
         sudo rm /etc/apt/sources.list.d/*
-        sudo apt-get --no-install-recommends install -y ninja-build
+        sudo apt-get install avahi-daemon avahi-utils -y
         git clone https://github.com/openthread/ot-commissioner.git /tmp/ot-commissioner --depth 1 --branch master
     - name: Build
       run: |
@@ -230,9 +230,6 @@ jobs:
         cd /tmp/ot-commissioner/tests/integration
         ./bootstrap.sh
         ./run_tests.sh
-    - name: Copy Codecov Files
-      run: |
-        cp -vr /tmp/test-ot-commissioner/ot-br-posix/build/* build/
     - name: Codecov
       uses: codecov/codecov-action@v1
 


### PR DESCRIPTION
- Install avahi-daemon and avahi-utils packages.
- Remove ot-br-posix dependencies.

Resolves #5278 