### PR TITLE
[continuous-integration] add code coverage threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,10 +4,7 @@ coverage:
       default:
         target: auto
         threshold: 1%
-    patch:
-      default:
-        target: 85%
-        threshold: 0%
+    patch: off
 
 ignore:
   - "tests/*"

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,7 +1,13 @@
 coverage:
   status:
-    project: off
-    patch: off
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 85%
+        threshold: 0%
 
 ignore:
   - "tests/*"


### PR DESCRIPTION
This adds 2 coverage checks to pull requests:
1. The overall coverage must not drop more than 1% against the parent commit.
1. ~~The diff coverage must be at least 85%.~~