### PR TITLE
[test] fix network name capturing in expect scripts

### DIFF
--- a/tests/scripts/expect/cli-scan-discover.exp
+++ b/tests/scripts/expect/cli-scan-discover.exp
@@ -53,7 +53,7 @@ set extpan $expect_out(1,string)
 expect "Done"
 send "networkname\n"
 expect "networkname"
-expect -re {[^\w-]([\w-]+)[^\w-]}
+expect -re {[\r\n]([^\r\n]+?)[\r\n]}
 set network $expect_out(1,string)
 expect "Done"
 send "channel\n"

--- a/tests/scripts/expect/cli-scan-discover.exp
+++ b/tests/scripts/expect/cli-scan-discover.exp
@@ -51,6 +51,7 @@ expect "extpanid"
 expect -re {([0-9a-f]{16})}
 set extpan $expect_out(1,string)
 expect "Done"
+expect "> "
 send "networkname\n"
 expect "networkname"
 expect -re {[\r\n]([^\r\n]+?)[\r\n]}

--- a/tests/scripts/expect/cli-scan-discover.exp
+++ b/tests/scripts/expect/cli-scan-discover.exp
@@ -53,7 +53,7 @@ set extpan $expect_out(1,string)
 expect "Done"
 send "networkname\n"
 expect "networkname"
-expect -re {[\r\n]([^\r\n]+?)[\r\n]}
+expect -re {[^\w-]([\w-]+)[^\w-]}
 set network $expect_out(1,string)
 expect "Done"
 send "channel\n"

--- a/tests/scripts/expect/posix-scan-tx-to-sleep.exp
+++ b/tests/scripts/expect/posix-scan-tx-to-sleep.exp
@@ -63,6 +63,7 @@ expect "extpanid"
 expect -re {([0-9a-f]{16})}
 set extpan $expect_out(1,string)
 expect "Done"
+expect "> "
 send "networkname\n"
 expect "networkname"
 expect -re {[\r\n]([^\r\n]+)[\r\n]}

--- a/tests/scripts/expect/posix-scan-tx-to-sleep.exp
+++ b/tests/scripts/expect/posix-scan-tx-to-sleep.exp
@@ -65,7 +65,7 @@ set extpan $expect_out(1,string)
 expect "Done"
 send "networkname\n"
 expect "networkname"
-expect -re {[\r\n]([^\r\n]+)[\r\n]}
+expect -re {[^\w-]([\w-]+)[^\w-]}
 set network $expect_out(1,string)
 expect "Done"
 send "channel\n"

--- a/tests/scripts/expect/posix-scan-tx-to-sleep.exp
+++ b/tests/scripts/expect/posix-scan-tx-to-sleep.exp
@@ -65,7 +65,7 @@ set extpan $expect_out(1,string)
 expect "Done"
 send "networkname\n"
 expect "networkname"
-expect -re {[^\w-]([\w-]+)[^\w-]}
+expect -re {[\r\n]([^\r\n]+)[\r\n]}
 set network $expect_out(1,string)
 expect "Done"
 send "channel\n"


### PR DESCRIPTION
This fixes some `expect` test failures caused by the scenario below:
Sometimes the command prompt `> ` can be put after the echo of the input command when inputs come too fast, because we are sending the next command as soon as we see `Done`, we don't wait for the next `> `. An example case:
```
2020-07-23T07:58:23.4151267Z > panid
2020-07-23T07:58:23.4153883Z 0x56af
2020-07-23T07:58:23.4154163Z 
2020-07-23T07:58:23.4156623Z Done
2020-07-23T07:58:23.4156952Z extpanid
2020-07-23T07:58:23.4157776Z 
2020-07-23T07:58:23.4160948Z > 3bdf955e7ddd80f3
2020-07-23T07:58:23.4161216Z 
2020-07-23T07:58:23.4164133Z Done
2020-07-23T07:58:23.4164481Z networkname
2020-07-23T07:58:23.4165323Z 
2020-07-23T07:58:23.4174275Z > OpenThread-56af
2020-07-23T07:58:23.4174801Z 
2020-07-23T07:58:23.4175875Z Done
```
This makes `> OpenThread-56af` to be captured as the network name, causing the failure. This PR adds `expect "> "` before sending the command to fix this.