### PR TITLE
[dhcp6] misc enhancements

### DIFF
--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -647,14 +647,14 @@ template <> inline NetworkDiagnostic::NetworkDiagnostic &Instance::Get(void)
 #endif
 
 #if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
-template <> inline Dhcp6::Dhcp6Client &Instance::Get(void)
+template <> inline Dhcp6::Client &Instance::Get(void)
 {
     return mThreadNetif.mDhcp6Client;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
-template <> inline Dhcp6::Dhcp6Server &Instance::Get(void)
+template <> inline Dhcp6::Server &Instance::Get(void)
 {
     return mThreadNetif.mDhcp6Server;
 }

--- a/src/core/net/dhcp6.hpp
+++ b/src/core/net/dhcp6.hpp
@@ -36,7 +36,11 @@
 
 #include "openthread-core-config.h"
 
+#include "common/clearable.hpp"
+#include "common/equatable.hpp"
 #include "common/message.hpp"
+#include "common/random.hpp"
+#include "mac/mac_types.hpp"
 #include "net/udp6.hpp"
 
 namespace ot {
@@ -61,21 +65,20 @@ using ot::Encoding::BigEndian::HostSwap32;
  */
 enum
 {
-    kDhcpClientPort          = 546,
-    kDhcpServerPort          = 547,
-    kTransactionIdSize       = 3,
-    kLinkLayerAddressLen     = 8,
-    kHardwareTypeEui64       = 27,
-    kHardwareTypeEthernet    = 1,
-    kLinkLayerAddressPlusLen = 6,
+
+    kDhcpClientPort       = 546,
+    kDhcpServerPort       = 547,
+    kHardwareTypeEui64    = 27,
+    kHardwareTypeEthernet = 1,
 };
 
 /**
  * DHCPv6 Message Types
  *
  */
-typedef enum Type
+enum Type : uint8_t
 {
+    kTypeNone               = 0,
     kTypeSolicit            = 1,
     kTypeAdvertise          = 2,
     kTypeRequest            = 3,
@@ -91,33 +94,49 @@ typedef enum Type
     kTypeRelayReply         = 13,
     kTypeLeaseQuery         = 14,
     kTypeLeaseQueryReply    = 15,
-} Type;
+};
+
+/**
+ * This class represents a DHCP6 transaction identifier.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class TransactionId : public Equatable<TransactionId>, public Clearable<TransactionId>
+{
+public:
+    enum : uint16_t
+    {
+        kSize = 3, // Transaction Id size (in bytes).
+    };
+
+    /**
+     * This method generates a cryptographically secure random sequence to populate the transaction identifier.
+     *
+     * @retval OT_ERROR_NONE     Successfully generated a random transaction identifier.
+     * @retval OT_ERROR_FAILED   Failed to generate random sequence.
+     *
+     */
+    otError GenerateRandom(void) { return Random::Crypto::FillBuffer(m8, kSize); }
+
+private:
+    uint8_t m8[kSize];
+} OT_TOOL_PACKED_END;
 
 /**
  * This class implements DHCPv6 header.
  *
  */
 OT_TOOL_PACKED_BEGIN
-class Dhcp6Header
+class Header : public Clearable<Header>
 {
 public:
-    /**
-     * This method initializes the DHCPv6 header to all zeros.
-     *
-     */
-    void Init(void)
-    {
-        mType             = 0;
-        mTransactionId[0] = 0;
-    }
-
     /**
      * This method returns the DHCPv6 message type.
      *
      * @returns The DHCPv6 message type.
      *
      */
-    Type GetType(void) const { return static_cast<Type>(mType); }
+    Type GetType(void) const { return mType; }
 
     /**
      * This method sets the DHCPv6 message type.
@@ -125,34 +144,34 @@ public:
      * @param[in]  aType  The DHCPv6 message type.
      *
      */
-    void SetType(Type aType) { mType = static_cast<uint8_t>(aType); }
+    void SetType(Type aType) { mType = aType; }
 
     /**
-     * This method returns the DHCPv6 message transaction id.
+     * This method returns the DHCPv6 message transaction identifier.
      *
-     * @returns A pointer of DHCPv6 message transaction id.
+     * @returns The DHCPv6 message transaction identifier.
      *
      */
-    uint8_t *GetTransactionId(void) { return mTransactionId; }
+    const TransactionId &GetTransactionId(void) const { return mTransactionId; }
 
     /**
-     * This method sets the DHCPv6 message transaction id.
+     * This method sets the DHCPv6 message transaction identifier.
      *
-     * @param[in]  aBuf  The DHCPv6 message transaction id.
+     * @param[in]  aTransactionId  The DHCPv6 message transaction identifier.
      *
      */
-    void SetTransactionId(uint8_t *aBuf) { memcpy(mTransactionId, aBuf, kTransactionIdSize); }
+    void SetTransactionId(const TransactionId &aTransactionId) { mTransactionId = aTransactionId; }
 
 private:
-    uint8_t mType;                              ///< Type
-    uint8_t mTransactionId[kTransactionIdSize]; ///< Transaction Id
+    Type          mType;
+    TransactionId mTransactionId;
 } OT_TOOL_PACKED_END;
 
 /**
- * DHCPv6 Option Codes
+ * DHCPv6 Option Codes.
  *
  */
-typedef enum Code
+enum Code : uint8_t
 {
     kOptionClientIdentifier          = 1,
     kOptionServerIdentifier          = 2,
@@ -176,14 +195,14 @@ typedef enum Code
     kOptionLeaseQuery                = 44,
     kOptionClientData                = 45,
     kOptionClientLastTransactionTime = 46,
-} Code;
+};
 
 /**
  * This class implements DHCPv6 option.
  *
  */
 OT_TOOL_PACKED_BEGIN
-class Dhcp6Option
+class Option
 {
 public:
     /**
@@ -213,7 +232,7 @@ public:
     void SetCode(Code aCode) { mCode = HostSwap16(static_cast<uint16_t>(aCode)); }
 
     /**
-     * This method returns the Length of DHCPv6 option.
+     * This method returns the length of DHCPv6 option.
      *
      * @returns The length of DHCPv6 option.
      *
@@ -229,23 +248,23 @@ public:
     void SetLength(uint16_t aLength) { mLength = HostSwap16(aLength); }
 
 private:
-    uint16_t mCode;   ///< Code
-    uint16_t mLength; ///< Length
+    uint16_t mCode;
+    uint16_t mLength;
 } OT_TOOL_PACKED_END;
 
 /**
- * Duid Type
+ * DHCP6 Unique Identifier (DUID) Type.
  *
  */
-typedef enum DuidType
+enum DuidType : uint16_t
 {
-    kDuidLLT = 1,
-    kDuidEN  = 2,
-    kDuidLL  = 3,
-} DuidType;
+    kDuidLinkLayerAddressPlusTime = 1, ///< Link-layer address plus time (DUID-LLT).
+    kDuidEnterpriseNumber         = 2, ///< Vendor-assigned unique ID based on Enterprise Number (DUID-EN).
+    kDuidLinkLayerAddress         = 3, ///< Link-layer address (DUID-LL).
+};
 
 OT_TOOL_PACKED_BEGIN
-class ClientIdentifier : public Dhcp6Option
+class ClientIdentifier : public Option
 {
 public:
     /**
@@ -255,7 +274,7 @@ public:
     void Init(void)
     {
         SetCode(kOptionClientIdentifier);
-        SetLength(sizeof(*this) - sizeof(Dhcp6Option));
+        SetLength(sizeof(*this) - sizeof(Option));
     }
 
     /**
@@ -293,10 +312,10 @@ public:
     /**
      * This method returns the client LinkLayerAddress.
      *
-     * @returns A pointer to the client LinkLayerAddress.
+     * @returns The link-layer address.
      *
      */
-    uint8_t *GetDuidLinkLayerAddress(void) { return mDuidLinkLayerAddress; }
+    const Mac::ExtAddress &GetDuidLinkLayerAddress(void) const { return mDuidLinkLayerAddress; }
 
     /**
      * This method sets the client LinkLayerAddress.
@@ -306,17 +325,17 @@ public:
      */
     void SetDuidLinkLayerAddress(const Mac::ExtAddress &aDuidLinkLayerAddress)
     {
-        memcpy(mDuidLinkLayerAddress, &aDuidLinkLayerAddress, sizeof(Mac::ExtAddress));
+        mDuidLinkLayerAddress = aDuidLinkLayerAddress;
     }
 
 private:
-    uint16_t mDuidType;                                   ///< Duid Type
-    uint16_t mDuidHardwareType;                           ///< Duid HardwareType
-    uint8_t  mDuidLinkLayerAddress[kLinkLayerAddressLen]; ///< Duid LinkLayerAddress
+    uint16_t        mDuidType;
+    uint16_t        mDuidHardwareType;
+    Mac::ExtAddress mDuidLinkLayerAddress;
 } OT_TOOL_PACKED_END;
 
 OT_TOOL_PACKED_BEGIN
-class ServerIdentifier : public Dhcp6Option
+class ServerIdentifier : public Option
 {
 public:
     /**
@@ -326,7 +345,7 @@ public:
     void Init(void)
     {
         SetCode(kOptionServerIdentifier);
-        SetLength(sizeof(*this) - sizeof(Dhcp6Option));
+        SetLength(sizeof(*this) - sizeof(Option));
     }
 
     /**
@@ -364,10 +383,10 @@ public:
     /**
      * This method returns the server LinkLayerAddress.
      *
-     * @returns A pointer to the server LinkLayerAddress.
+     * @returns The link-layer address.
      *
      */
-    uint8_t *GetDuidLinkLayerAddress(void) { return mDuidLinkLayerAddress; }
+    const Mac::ExtAddress &GetDuidLinkLayerAddress(void) const { return mDuidLinkLayerAddress; }
 
     /**
      * This method sets the server LinkLayerAddress.
@@ -377,19 +396,29 @@ public:
      */
     void SetDuidLinkLayerAddress(const Mac::ExtAddress &aDuidLinkLayerAddress)
     {
-        memcpy(mDuidLinkLayerAddress, &aDuidLinkLayerAddress, sizeof(Mac::ExtAddress));
+        mDuidLinkLayerAddress = aDuidLinkLayerAddress;
     }
 
 private:
-    uint16_t mDuidType;                                   ///< Duid Type
-    uint16_t mDuidHardwareType;                           ///< Duid HardwareType
-    uint8_t  mDuidLinkLayerAddress[kLinkLayerAddressLen]; ///< Duid LinkLayerAddress
+    uint16_t        mDuidType;
+    uint16_t        mDuidHardwareType;
+    Mac::ExtAddress mDuidLinkLayerAddress;
 } OT_TOOL_PACKED_END;
 
+/**
+ * This type represents an Identity Association for Non-temporary Address DHCPv6 option.
+ *
+ */
 OT_TOOL_PACKED_BEGIN
-class IaNa : public Dhcp6Option
+class IaNa : public Option
 {
 public:
+    enum : uint32_t
+    {
+        kDefaultT1 = 0xffffffffU, ///< Default T1 value.
+        kDefaultT2 = 0xffffffffU, ///< Default T2 value.
+    };
+
     /**
      * This method initializes the DHCPv6 Option.
      *
@@ -397,7 +426,7 @@ public:
     void Init(void)
     {
         SetCode(kOptionIaNa);
-        SetLength(sizeof(*this) - sizeof(Dhcp6Option));
+        SetLength(sizeof(*this) - sizeof(Option));
     }
 
     /**
@@ -449,15 +478,25 @@ public:
     void SetT2(uint32_t aT2) { mT2 = HostSwap32(aT2); }
 
 private:
-    uint32_t mIaid; ///< IAID
-    uint32_t mT1;   ///< T1
-    uint32_t mT2;   ///< T2
+    uint32_t mIaid;
+    uint32_t mT1;
+    uint32_t mT2;
 } OT_TOOL_PACKED_END;
 
+/**
+ * This type represents an Identity Association Address DHCPv6 option.
+ *
+ */
 OT_TOOL_PACKED_BEGIN
-class IaAddress : public Dhcp6Option
+class IaAddress : public Option
 {
 public:
+    enum : uint32_t
+    {
+        kDefaultPreferredLifetime = 0xffffffffU, ///< Default preferred lifetime.
+        kDefaultValidLiftetime    = 0xffffffffU, ///< Default valid lifetime.
+    };
+
     /**
      * This method initializes the DHCPv6 Option.
      *
@@ -465,16 +504,24 @@ public:
     void Init(void)
     {
         SetCode(kOptionIaAddress);
-        SetLength(sizeof(*this) - sizeof(Dhcp6Option));
+        SetLength(sizeof(*this) - sizeof(Option));
     }
 
     /**
-     * This method returns the pointer to the IPv6 address.
+     * This method returns a reference to the IPv6 address.
      *
-     * @returns A pointer to the IPv6 address.
+     * @returns A reference to the IPv6 address.
      *
      */
     Ip6::Address &GetAddress(void) { return mAddress; }
+
+    /**
+     * This method returns a reference to the IPv6 address.
+     *
+     * @returns A reference to the IPv6 address.
+     *
+     */
+    const Ip6::Address &GetAddress(void) const { return mAddress; }
 
     /**
      * This method sets the IPv6 address.
@@ -482,7 +529,7 @@ public:
      * @param[in]  aAddress  The reference to the IPv6 address to set.
      *
      */
-    void SetAddress(otIp6Address &aAddress) { memcpy(mAddress.mFields.m8, aAddress.mFields.m8, sizeof(otIp6Address)); }
+    void SetAddress(const Ip6::Address &aAddress) { mAddress = aAddress; }
 
     /**
      * This method returns the preferred lifetime of the IPv6 address.
@@ -517,13 +564,17 @@ public:
     void SetValidLifetime(uint32_t aValidLifetime) { mValidLifetime = HostSwap32(aValidLifetime); }
 
 private:
-    Ip6::Address mAddress;           ///< IPv6 address
-    uint32_t     mPreferredLifetime; ///< Preferred Lifetime
-    uint32_t     mValidLifetime;     ///< Valid Lifetime
+    Ip6::Address mAddress;
+    uint32_t     mPreferredLifetime;
+    uint32_t     mValidLifetime;
 } OT_TOOL_PACKED_END;
 
+/**
+ * This type represents an Elapsed Time DHCPv6 option.
+ *
+ */
 OT_TOOL_PACKED_BEGIN
-class ElapsedTime : public Dhcp6Option
+class ElapsedTime : public Option
 {
 public:
     /**
@@ -533,7 +584,7 @@ public:
     void Init(void)
     {
         SetCode(kOptionElapsedTime);
-        SetLength(sizeof(*this) - sizeof(Dhcp6Option));
+        SetLength(sizeof(*this) - sizeof(Option));
     }
 
     /**
@@ -553,14 +604,14 @@ public:
     void SetElapsedTime(uint16_t aElapsedTime) { mElapsedTime = HostSwap16(aElapsedTime); }
 
 private:
-    uint16_t mElapsedTime; ///< Elapsed time
+    uint16_t mElapsedTime;
 } OT_TOOL_PACKED_END;
 
 /**
- * Status Code
+ * Status Code.
  *
  */
-typedef enum Status
+enum Status : uint16_t
 {
     kStatusSuccess      = 0,
     kStatusUnspecFail   = 1,
@@ -572,10 +623,14 @@ typedef enum Status
     kMalformedQuery     = 8,
     kNotConfigured      = 9,
     kNotAllowed         = 10,
-} Status;
+};
 
+/**
+ * This type represents an Status Code DHCPv6 option.
+ *
+ */
 OT_TOOL_PACKED_BEGIN
-class StatusCode : public Dhcp6Option
+class StatusCode : public Option
 {
 public:
     /**
@@ -585,7 +640,7 @@ public:
     void Init(void)
     {
         SetCode(kOptionStatusCode);
-        SetLength(sizeof(*this) - sizeof(Dhcp6Option));
+        SetLength(sizeof(*this) - sizeof(Option));
     }
 
     /**
@@ -605,11 +660,15 @@ public:
     void SetStatusCode(Status aStatus) { mStatus = HostSwap16(static_cast<uint16_t>(aStatus)); }
 
 private:
-    uint16_t mStatus; ///< Status Code
+    uint16_t mStatus;
 } OT_TOOL_PACKED_END;
 
+/**
+ * This type represents an Rapid Commit DHCPv6 option.
+ *
+ */
 OT_TOOL_PACKED_BEGIN
-class RapidCommit : public Dhcp6Option
+class RapidCommit : public Option
 {
 public:
     /**
@@ -619,7 +678,7 @@ public:
     void Init(void)
     {
         SetCode(kOptionRapidCommit);
-        SetLength(sizeof(*this) - sizeof(Dhcp6Option));
+        SetLength(sizeof(*this) - sizeof(Option));
     }
 } OT_TOOL_PACKED_END;
 

--- a/src/core/net/dhcp6.hpp
+++ b/src/core/net/dhcp6.hpp
@@ -171,7 +171,7 @@ private:
  * DHCPv6 Option Codes.
  *
  */
-enum Code : uint8_t
+enum Code : uint16_t
 {
     kOptionClientIdentifier          = 1,
     kOptionServerIdentifier          = 2,

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -38,37 +38,32 @@
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 #include "common/logging.hpp"
-#include "common/random.hpp"
 #include "mac/mac.hpp"
 #include "net/dhcp6.hpp"
 #include "thread/thread_netif.hpp"
 
 #if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
 
-using ot::Encoding::BigEndian::HostSwap16;
-
 namespace ot {
-
 namespace Dhcp6 {
 
-Dhcp6Client::Dhcp6Client(Instance &aInstance)
+Client::Client(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mSocket(aInstance)
-    , mTrickleTimer(aInstance, Dhcp6Client::HandleTrickleTimer, nullptr, this)
+    , mTrickleTimer(aInstance, Client::HandleTrickleTimer, nullptr, this)
     , mStartTime(0)
     , mIdentityAssociationCurrent(nullptr)
 {
     memset(mIdentityAssociations, 0, sizeof(mIdentityAssociations));
 }
 
-bool Dhcp6Client::MatchNetifAddressWithPrefix(const Ip6::NetifUnicastAddress &aNetifAddress,
-                                              const otIp6Prefix &             aIp6Prefix)
+bool Client::MatchNetifAddressWithPrefix(const Ip6::NetifUnicastAddress &aNetifAddress, const otIp6Prefix &aIp6Prefix)
 {
     return (aIp6Prefix.mLength == aNetifAddress.mPrefixLength) &&
            (aNetifAddress.GetAddress().PrefixMatch(aIp6Prefix.mPrefix) >= aIp6Prefix.mLength);
 }
 
-void Dhcp6Client::UpdateAddresses(void)
+void Client::UpdateAddresses(void)
 {
     bool                            found          = false;
     bool                            doesAgentExist = false;
@@ -169,14 +164,14 @@ void Dhcp6Client::UpdateAddresses(void)
     }
 }
 
-void Dhcp6Client::Start(void)
+void Client::Start(void)
 {
     Ip6::SockAddr sockaddr;
 
     VerifyOrExit(!mSocket.IsBound(), OT_NOOP);
 
     sockaddr.mPort = kDhcpClientPort;
-    IgnoreError(mSocket.Open(&Dhcp6Client::HandleUdpReceive, this));
+    IgnoreError(mSocket.Open(&Client::HandleUdpReceive, this));
     IgnoreError(mSocket.Bind(sockaddr));
 
     ProcessNextIdentityAssociation();
@@ -185,12 +180,12 @@ exit:
     return;
 }
 
-void Dhcp6Client::Stop(void)
+void Client::Stop(void)
 {
     IgnoreError(mSocket.Close());
 }
 
-bool Dhcp6Client::ProcessNextIdentityAssociation()
+bool Client::ProcessNextIdentityAssociation(void)
 {
     bool rval = false;
 
@@ -208,7 +203,7 @@ bool Dhcp6Client::ProcessNextIdentityAssociation()
         }
 
         // new transaction id
-        IgnoreError(Random::Crypto::FillBuffer(mTransactionId, kTransactionIdSize));
+        IgnoreError(mTransactionId.GenerateRandom());
 
         mIdentityAssociationCurrent = &idAssociation;
 
@@ -224,12 +219,12 @@ exit:
     return rval;
 }
 
-bool Dhcp6Client::HandleTrickleTimer(TrickleTimer &aTrickleTimer)
+bool Client::HandleTrickleTimer(TrickleTimer &aTrickleTimer)
 {
-    return aTrickleTimer.GetOwner<Dhcp6Client>().HandleTrickleTimer();
+    return aTrickleTimer.GetOwner<Client>().HandleTrickleTimer();
 }
 
-bool Dhcp6Client::HandleTrickleTimer(void)
+bool Client::HandleTrickleTimer(void)
 {
     bool rval = true;
 
@@ -267,7 +262,7 @@ exit:
     return rval;
 }
 
-void Dhcp6Client::Solicit(uint16_t aRloc16)
+void Client::Solicit(uint16_t aRloc16)
 {
     otError          error = OT_ERROR_NONE;
     Message *        message;
@@ -307,17 +302,17 @@ exit:
     }
 }
 
-otError Dhcp6Client::AppendHeader(Message &aMessage)
+otError Client::AppendHeader(Message &aMessage)
 {
-    Dhcp6Header header;
+    Header header;
 
-    header.Init();
+    header.Clear();
     header.SetType(kTypeSolicit);
     header.SetTransactionId(mTransactionId);
     return aMessage.Append(&header, sizeof(header));
 }
 
-otError Dhcp6Client::AppendElapsedTime(Message &aMessage)
+otError Client::AppendElapsedTime(Message &aMessage)
 {
     ElapsedTime option;
 
@@ -326,7 +321,7 @@ otError Dhcp6Client::AppendElapsedTime(Message &aMessage)
     return aMessage.Append(&option, sizeof(option));
 }
 
-otError Dhcp6Client::AppendClientIdentifier(Message &aMessage)
+otError Client::AppendClientIdentifier(Message &aMessage)
 {
     ClientIdentifier option;
     Mac::ExtAddress  eui64;
@@ -334,14 +329,14 @@ otError Dhcp6Client::AppendClientIdentifier(Message &aMessage)
     Get<Radio>().GetIeeeEui64(eui64);
 
     option.Init();
-    option.SetDuidType(kDuidLL);
+    option.SetDuidType(kDuidLinkLayerAddress);
     option.SetDuidHardwareType(kHardwareTypeEui64);
     option.SetDuidLinkLayerAddress(eui64);
 
     return aMessage.Append(&option, sizeof(option));
 }
 
-otError Dhcp6Client::AppendIaNa(Message &aMessage, uint16_t aRloc16)
+otError Client::AppendIaNa(Message &aMessage, uint16_t aRloc16)
 {
     otError  error  = OT_ERROR_NONE;
     uint8_t  count  = 0;
@@ -364,7 +359,7 @@ otError Dhcp6Client::AppendIaNa(Message &aMessage, uint16_t aRloc16)
     }
 
     // compute the right length
-    length = sizeof(IaNa) + sizeof(IaAddress) * count - sizeof(Dhcp6Option);
+    length = sizeof(IaNa) + sizeof(IaAddress) * count - sizeof(Option);
 
     option.Init();
     option.SetLength(length);
@@ -377,7 +372,7 @@ exit:
     return error;
 }
 
-otError Dhcp6Client::AppendIaAddress(Message &aMessage, uint16_t aRloc16)
+otError Client::AppendIaAddress(Message &aMessage, uint16_t aRloc16)
 {
     otError   error = OT_ERROR_NONE;
     IaAddress option;
@@ -391,7 +386,7 @@ otError Dhcp6Client::AppendIaAddress(Message &aMessage, uint16_t aRloc16)
         if ((idAssociation.mStatus == kIaStatusSolicit || idAssociation.mStatus == kIaStatusSoliciting) &&
             (idAssociation.mPrefixAgentRloc == aRloc16))
         {
-            option.SetAddress(idAssociation.mNetifAddress.mAddress);
+            option.SetAddress(idAssociation.mNetifAddress.GetAddress());
             option.SetPreferredLifetime(0);
             option.SetValidLifetime(0);
             SuccessOrExit(error = aMessage.Append(&option, sizeof(option)));
@@ -402,7 +397,7 @@ exit:
     return error;
 }
 
-otError Dhcp6Client::AppendRapidCommit(Message &aMessage)
+otError Client::AppendRapidCommit(Message &aMessage)
 {
     RapidCommit option;
 
@@ -410,22 +405,22 @@ otError Dhcp6Client::AppendRapidCommit(Message &aMessage)
     return aMessage.Append(&option, sizeof(option));
 }
 
-void Dhcp6Client::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+void Client::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    Dhcp6Client *obj = static_cast<Dhcp6Client *>(aContext);
-    obj->HandleUdpReceive(*static_cast<Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Client *>(aContext)->HandleUdpReceive(*static_cast<Message *>(aMessage),
+                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
-void Dhcp6Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    Dhcp6Header header;
+    Header header;
 
     VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(header), &header) == sizeof(header), OT_NOOP);
     aMessage.MoveOffset(sizeof(header));
 
-    if ((header.GetType() == kTypeReply) && (!memcmp(header.GetTransactionId(), mTransactionId, kTransactionIdSize)))
+    if ((header.GetType() == kTypeReply) && (header.GetTransactionId() == mTransactionId))
     {
         ProcessReply(aMessage);
     }
@@ -434,7 +429,7 @@ exit:
     return;
 }
 
-void Dhcp6Client::ProcessReply(Message &aMessage)
+void Client::ProcessReply(Message &aMessage)
 {
     uint16_t offset = aMessage.GetOffset();
     uint16_t length = aMessage.GetLength() - aMessage.GetOffset();
@@ -466,17 +461,18 @@ exit:
     return;
 }
 
-uint16_t Dhcp6Client::FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLength, Dhcp6::Code aCode)
+uint16_t Client::FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLength, Dhcp6::Code aCode)
 {
     uint16_t end  = aOffset + aLength;
     uint16_t rval = 0;
 
     while (aOffset <= end)
     {
-        Dhcp6Option option;
+        Option option;
+
         VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option), OT_NOOP);
 
-        if (option.GetCode() == (aCode))
+        if (option.GetCode() == aCode)
         {
             ExitNow(rval = aOffset);
         }
@@ -488,21 +484,23 @@ exit:
     return rval;
 }
 
-otError Dhcp6Client::ProcessServerIdentifier(Message &aMessage, uint16_t aOffset)
+otError Client::ProcessServerIdentifier(Message &aMessage, uint16_t aOffset)
 {
     otError          error = OT_ERROR_NONE;
     ServerIdentifier option;
 
     VerifyOrExit((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)), OT_NOOP);
-    VerifyOrExit(((option.GetDuidType() == kDuidLLT) && (option.GetDuidHardwareType() == kHardwareTypeEthernet)) ||
-                     ((option.GetLength() == (sizeof(option) - sizeof(Dhcp6Option))) &&
-                      (option.GetDuidType() == kDuidLL) && (option.GetDuidHardwareType() == kHardwareTypeEui64)),
+    VerifyOrExit(((option.GetDuidType() == kDuidLinkLayerAddressPlusTime) &&
+                  (option.GetDuidHardwareType() == kHardwareTypeEthernet)) ||
+                     ((option.GetLength() == (sizeof(option) - sizeof(Option))) &&
+                      (option.GetDuidType() == kDuidLinkLayerAddress) &&
+                      (option.GetDuidHardwareType() == kHardwareTypeEui64)),
                  error = OT_ERROR_PARSE);
 exit:
     return error;
 }
 
-otError Dhcp6Client::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset)
+otError Client::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset)
 {
     otError          error = OT_ERROR_NONE;
     ClientIdentifier option;
@@ -510,16 +508,17 @@ otError Dhcp6Client::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset
 
     Get<Radio>().GetIeeeEui64(eui64);
 
-    VerifyOrExit((((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
-                   (option.GetLength() == (sizeof(option) - sizeof(Dhcp6Option))) &&
-                   (option.GetDuidType() == kDuidLL) && (option.GetDuidHardwareType() == kHardwareTypeEui64)) &&
-                  (!memcmp(option.GetDuidLinkLayerAddress(), eui64.m8, sizeof(Mac::ExtAddress)))),
-                 error = OT_ERROR_PARSE);
+    VerifyOrExit(
+        (((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
+          (option.GetLength() == (sizeof(option) - sizeof(Option))) &&
+          (option.GetDuidType() == kDuidLinkLayerAddress) && (option.GetDuidHardwareType() == kHardwareTypeEui64)) &&
+         (option.GetDuidLinkLayerAddress() == eui64)),
+        error = OT_ERROR_PARSE);
 exit:
     return error;
 }
 
-otError Dhcp6Client::ProcessIaNa(Message &aMessage, uint16_t aOffset)
+otError Client::ProcessIaNa(Message &aMessage, uint16_t aOffset)
 {
     otError  error = OT_ERROR_NONE;
     IaNa     option;
@@ -529,7 +528,7 @@ otError Dhcp6Client::ProcessIaNa(Message &aMessage, uint16_t aOffset)
     VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option), error = OT_ERROR_PARSE);
 
     aOffset += sizeof(option);
-    length = option.GetLength() - (sizeof(option) - sizeof(Dhcp6Option));
+    length = option.GetLength() - (sizeof(option) - sizeof(Option));
 
     VerifyOrExit(length <= aMessage.GetLength() - aOffset, error = OT_ERROR_PARSE);
 
@@ -555,13 +554,13 @@ exit:
     return error;
 }
 
-otError Dhcp6Client::ProcessStatusCode(Message &aMessage, uint16_t aOffset)
+otError Client::ProcessStatusCode(Message &aMessage, uint16_t aOffset)
 {
     otError    error = OT_ERROR_NONE;
     StatusCode option;
 
     VerifyOrExit(((aMessage.Read(aOffset, sizeof(option), &option) >= sizeof(option)) &&
-                  (option.GetLength() >= (sizeof(option) - sizeof(Dhcp6Option))) &&
+                  (option.GetLength() >= (sizeof(option) - sizeof(Option))) &&
                   (option.GetStatusCode() == kStatusSuccess)),
                  error = OT_ERROR_PARSE);
 
@@ -569,13 +568,13 @@ exit:
     return error;
 }
 
-otError Dhcp6Client::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
+otError Client::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
 {
     otError   error = OT_ERROR_NONE;
     IaAddress option;
 
     VerifyOrExit(((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
-                  (option.GetLength() == (sizeof(option) - sizeof(Dhcp6Option)))),
+                  (option.GetLength() == (sizeof(option) - sizeof(Option)))),
                  error = OT_ERROR_PARSE);
 
     for (IdentityAssociation &idAssociation : mIdentityAssociations)

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -61,45 +61,10 @@ namespace Dhcp6 {
  */
 
 /**
- * Some constants
- *
- */
-enum
-{
-    kTrickleTimerImin = 1,
-    kTrickleTimerImax = 120,
-};
-
-/**
- * Status of IdentityAssociation
- *
- */
-enum IaStatus
-{
-    kIaStatusInvalid,
-    kIaStatusSolicit,
-    kIaStatusSoliciting,
-    kIaStatusSolicitReplied,
-};
-
-/**
- * This class implements IdentityAssociation.
- *
- */
-struct IdentityAssociation
-{
-    Ip6::NetifUnicastAddress mNetifAddress;      ///< the NetifAddress
-    uint32_t                 mPreferredLifetime; ///< The preferred lifetime.
-    uint32_t                 mValidLifetime;     ///< The valid lifetime.
-    uint16_t                 mPrefixAgentRloc;   ///< Rloc of Prefix Agent
-    uint8_t                  mStatus;            ///< Status of IdentityAssociation
-};
-
-/**
  * This class implements DHCPv6 Client.
  *
  */
-class Dhcp6Client : public InstanceLocator
+class Client : public InstanceLocator
 {
 public:
     /**
@@ -108,7 +73,7 @@ public:
      * @param[in]  aInstance     A reference to the OpenThread instance.
      *
      */
-    explicit Dhcp6Client(Instance &aInstance);
+    explicit Client(Instance &aInstance);
 
     /**
      * This method update addresses that shall be automatically created using DHCP.
@@ -118,6 +83,29 @@ public:
     void UpdateAddresses(void);
 
 private:
+    enum
+    {
+        kTrickleTimerImin = 1,
+        kTrickleTimerImax = 120,
+    };
+
+    enum IaStatus : uint8_t
+    {
+        kIaStatusInvalid,
+        kIaStatusSolicit,
+        kIaStatusSoliciting,
+        kIaStatusSolicitReplied,
+    };
+
+    struct IdentityAssociation
+    {
+        Ip6::NetifUnicastAddress mNetifAddress;
+        uint32_t                 mPreferredLifetime;
+        uint32_t                 mValidLifetime;
+        uint16_t                 mPrefixAgentRloc;
+        IaStatus                 mStatus;
+    };
+
     void Start(void);
     void Stop(void);
 
@@ -155,8 +143,8 @@ private:
 
     TrickleTimer mTrickleTimer;
 
-    uint8_t   mTransactionId[kTransactionIdSize];
-    TimeMilli mStartTime;
+    TransactionId mTransactionId;
+    TimeMilli     mStartTime;
 
     IdentityAssociation  mIdentityAssociations[OPENTHREAD_CONFIG_DHCP6_CLIENT_NUM_PREFIXES];
     IdentityAssociation *mIdentityAssociationCurrent;

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -46,7 +46,7 @@
 namespace ot {
 namespace Dhcp6 {
 
-Dhcp6Server::Dhcp6Server(Instance &aInstance)
+Server::Server(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mSocket(aInstance)
     , mPrefixAgentsCount(0)
@@ -55,7 +55,7 @@ Dhcp6Server::Dhcp6Server(Instance &aInstance)
     memset(mPrefixAgents, 0, sizeof(mPrefixAgents));
 }
 
-otError Dhcp6Server::UpdateService(void)
+otError Server::UpdateService(void)
 {
     otError                         error  = OT_ERROR_NONE;
     uint16_t                        rloc16 = Get<Mle::MleRouter>().GetRloc16();
@@ -130,21 +130,21 @@ otError Dhcp6Server::UpdateService(void)
     return error;
 }
 
-void Dhcp6Server::Start(void)
+void Server::Start(void)
 {
     Ip6::SockAddr sockaddr;
 
     sockaddr.mPort = kDhcpServerPort;
-    IgnoreError(mSocket.Open(&Dhcp6Server::HandleUdpReceive, this));
+    IgnoreError(mSocket.Open(&Server::HandleUdpReceive, this));
     IgnoreError(mSocket.Bind(sockaddr));
 }
 
-void Dhcp6Server::Stop(void)
+void Server::Stop(void)
 {
     IgnoreError(mSocket.Close());
 }
 
-void Dhcp6Server::AddPrefixAgent(const otIp6Prefix &aIp6Prefix, const Lowpan::Context &aContext)
+void Server::AddPrefixAgent(const otIp6Prefix &aIp6Prefix, const Lowpan::Context &aContext)
 {
     otError      error    = OT_ERROR_NONE;
     PrefixAgent *newEntry = nullptr;
@@ -176,16 +176,15 @@ exit:
     }
 }
 
-void Dhcp6Server::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+void Server::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    Dhcp6Server *obj = static_cast<Dhcp6Server *>(aContext);
-    obj->HandleUdpReceive(*static_cast<Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Server *>(aContext)->HandleUdpReceive(*static_cast<Message *>(aMessage),
+                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
-void Dhcp6Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    Dhcp6Header  header;
-    otIp6Address dst = aMessageInfo.mPeerAddr;
+    Header header;
 
     VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(header), &header) == sizeof(header), OT_NOOP);
     aMessage.MoveOffset(sizeof(header));
@@ -193,13 +192,13 @@ void Dhcp6Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aM
     // discard if not solicit type
     VerifyOrExit((header.GetType() == kTypeSolicit), OT_NOOP);
 
-    ProcessSolicit(aMessage, dst, header.GetTransactionId());
+    ProcessSolicit(aMessage, aMessageInfo.GetPeerAddr(), header.GetTransactionId());
 
 exit:
     return;
 }
 
-void Dhcp6Server::ProcessSolicit(Message &aMessage, otIp6Address &aDst, uint8_t *aTransactionId)
+void Server::ProcessSolicit(Message &aMessage, const Ip6::Address &aDst, const TransactionId &aTransactionId)
 {
     IaNa             iana;
     ClientIdentifier clientIdentifier;
@@ -233,14 +232,14 @@ exit:
     return;
 }
 
-uint16_t Dhcp6Server::FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLength, Code aCode)
+uint16_t Server::FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLength, Code aCode)
 {
     uint16_t end  = aOffset + aLength;
     uint16_t rval = 0;
 
     while (aOffset <= end)
     {
-        Dhcp6Option option;
+        Option option;
         VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option), OT_NOOP);
 
         if (option.GetCode() == aCode)
@@ -254,31 +253,32 @@ uint16_t Dhcp6Server::FindOption(Message &aMessage, uint16_t aOffset, uint16_t a
 exit:
     return rval;
 }
-otError Dhcp6Server::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset, ClientIdentifier &aClientId)
+otError Server::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset, ClientIdentifier &aClientId)
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(((aMessage.Read(aOffset, sizeof(aClientId), &aClientId) == sizeof(aClientId)) &&
-                  (aClientId.GetLength() == (sizeof(aClientId) - sizeof(Dhcp6Option))) &&
-                  (aClientId.GetDuidType() == kDuidLL) && (aClientId.GetDuidHardwareType() == kHardwareTypeEui64)),
+                  (aClientId.GetLength() == (sizeof(aClientId) - sizeof(Option))) &&
+                  (aClientId.GetDuidType() == kDuidLinkLayerAddress) &&
+                  (aClientId.GetDuidHardwareType() == kHardwareTypeEui64)),
                  error = OT_ERROR_PARSE);
 exit:
     return error;
 }
 
-otError Dhcp6Server::ProcessElapsedTime(Message &aMessage, uint16_t aOffset)
+otError Server::ProcessElapsedTime(Message &aMessage, uint16_t aOffset)
 {
     otError     error = OT_ERROR_NONE;
     ElapsedTime option;
 
     VerifyOrExit(((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
-                  (option.GetLength() == ((sizeof(option) - sizeof(Dhcp6Option))))),
+                  (option.GetLength() == ((sizeof(option) - sizeof(Option))))),
                  error = OT_ERROR_PARSE);
 exit:
     return error;
 }
 
-otError Dhcp6Server::ProcessIaNa(Message &aMessage, uint16_t aOffset, IaNa &aIaNa)
+otError Server::ProcessIaNa(Message &aMessage, uint16_t aOffset, IaNa &aIaNa)
 {
     otError  error = OT_ERROR_NONE;
     uint16_t optionOffset;
@@ -287,7 +287,7 @@ otError Dhcp6Server::ProcessIaNa(Message &aMessage, uint16_t aOffset, IaNa &aIaN
     VerifyOrExit((aMessage.Read(aOffset, sizeof(aIaNa), &aIaNa) == sizeof(aIaNa)), error = OT_ERROR_PARSE);
 
     aOffset += sizeof(aIaNa);
-    length = aIaNa.GetLength() + sizeof(Dhcp6Option) - sizeof(IaNa);
+    length = aIaNa.GetLength() + sizeof(Option) - sizeof(IaNa);
 
     VerifyOrExit(length <= aMessage.GetLength() - aOffset, error = OT_ERROR_PARSE);
 
@@ -306,17 +306,17 @@ exit:
     return error;
 }
 
-otError Dhcp6Server::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
+otError Server::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
 {
     otError   error = OT_ERROR_NONE;
     IaAddress option;
 
     VerifyOrExit(((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
-                  option.GetLength() == (sizeof(option) - sizeof(Dhcp6Option))),
+                  option.GetLength() == (sizeof(option) - sizeof(Option))),
                  error = OT_ERROR_PARSE);
 
     // mask matching prefix
-    for (size_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
+    for (uint16_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
     {
         if (mPrefixAgents[i].IsValid() && mPrefixAgents[i].IsPrefixMatch(option.GetAddress()))
         {
@@ -329,7 +329,10 @@ exit:
     return error;
 }
 
-otError Dhcp6Server::SendReply(otIp6Address &aDst, uint8_t *aTransactionId, ClientIdentifier &aClientId, IaNa &aIaNa)
+otError Server::SendReply(const Ip6::Address & aDst,
+                          const TransactionId &aTransactionId,
+                          ClientIdentifier &   aClientId,
+                          IaNa &               aIaNa)
 {
     otError          error = OT_ERROR_NONE;
     Ip6::MessageInfo messageInfo;
@@ -344,8 +347,8 @@ otError Dhcp6Server::SendReply(otIp6Address &aDst, uint8_t *aTransactionId, Clie
     SuccessOrExit(error = AppendIaAddress(*message, aClientId));
     SuccessOrExit(error = AppendRapidCommit(*message));
 
-    memcpy(messageInfo.GetPeerAddr().mFields.m8, &aDst, sizeof(otIp6Address));
-    messageInfo.mPeerPort = kDhcpClientPort;
+    messageInfo.SetPeerAddr(aDst);
+    messageInfo.SetPeerPort(kDhcpClientPort);
     SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));
 
 exit:
@@ -358,22 +361,22 @@ exit:
     return error;
 }
 
-otError Dhcp6Server::AppendHeader(Message &aMessage, uint8_t *aTransactionId)
+otError Server::AppendHeader(Message &aMessage, const TransactionId &aTransactionId)
 {
-    Dhcp6Header header;
+    Header header;
 
-    header.Init();
+    header.Clear();
     header.SetType(kTypeReply);
     header.SetTransactionId(aTransactionId);
     return aMessage.Append(&header, sizeof(header));
 }
 
-otError Dhcp6Server::AppendClientIdentifier(Message &aMessage, ClientIdentifier &aClientId)
+otError Server::AppendClientIdentifier(Message &aMessage, ClientIdentifier &aClientId)
 {
     return aMessage.Append(&aClientId, sizeof(aClientId));
 }
 
-otError Dhcp6Server::AppendServerIdentifier(Message &aMessage)
+otError Server::AppendServerIdentifier(Message &aMessage)
 {
     otError          error = OT_ERROR_NONE;
     ServerIdentifier option;
@@ -382,7 +385,7 @@ otError Dhcp6Server::AppendServerIdentifier(Message &aMessage)
     Get<Radio>().GetIeeeEui64(eui64);
 
     option.Init();
-    option.SetDuidType(kDuidLL);
+    option.SetDuidType(kDuidLinkLayerAddress);
     option.SetDuidHardwareType(kHardwareTypeEui64);
     option.SetDuidLinkLayerAddress(eui64);
     SuccessOrExit(error = aMessage.Append(&option, sizeof(option)));
@@ -391,16 +394,16 @@ exit:
     return error;
 }
 
-otError Dhcp6Server::AppendIaNa(Message &aMessage, IaNa &aIaNa)
+otError Server::AppendIaNa(Message &aMessage, IaNa &aIaNa)
 {
     otError  error  = OT_ERROR_NONE;
     uint16_t length = 0;
 
     if (mPrefixAgentsMask)
     {
-        for (size_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
+        for (uint16_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
         {
-            if ((mPrefixAgentsMask & (1 << i)))
+            if (mPrefixAgentsMask & (1 << i))
             {
                 length += sizeof(IaAddress);
             }
@@ -411,18 +414,18 @@ otError Dhcp6Server::AppendIaNa(Message &aMessage, IaNa &aIaNa)
         length += sizeof(IaAddress) * mPrefixAgentsCount;
     }
 
-    length += sizeof(IaNa) + sizeof(StatusCode) - sizeof(Dhcp6Option);
+    length += sizeof(IaNa) + sizeof(StatusCode) - sizeof(Option);
 
     aIaNa.SetLength(length);
-    aIaNa.SetT1(OT_DHCP6_DEFAULT_IA_NA_T1);
-    aIaNa.SetT2(OT_DHCP6_DEFAULT_IA_NA_T2);
+    aIaNa.SetT1(IaNa::kDefaultT1);
+    aIaNa.SetT2(IaNa::kDefaultT2);
     SuccessOrExit(error = aMessage.Append(&aIaNa, sizeof(IaNa)));
 
 exit:
     return error;
 }
 
-otError Dhcp6Server::AppendStatusCode(Message &aMessage, Status aStatusCode)
+otError Server::AppendStatusCode(Message &aMessage, Status aStatusCode)
 {
     StatusCode option;
 
@@ -431,14 +434,14 @@ otError Dhcp6Server::AppendStatusCode(Message &aMessage, Status aStatusCode)
     return aMessage.Append(&option, sizeof(option));
 }
 
-otError Dhcp6Server::AppendIaAddress(Message &aMessage, ClientIdentifier &aClientId)
+otError Server::AppendIaAddress(Message &aMessage, ClientIdentifier &aClientId)
 {
     otError error = OT_ERROR_NONE;
 
     if (mPrefixAgentsMask)
     {
         // if specified, only apply specified prefixes
-        for (size_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
+        for (uint16_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
         {
             if (mPrefixAgentsMask & (1 << i))
             {
@@ -462,24 +465,23 @@ exit:
     return error;
 }
 
-otError Dhcp6Server::AddIaAddress(Message &aMessage, const Ip6::Address &aPrefix, ClientIdentifier &aClientId)
+otError Server::AddIaAddress(Message &aMessage, const Ip6::Address &aPrefix, ClientIdentifier &aClientId)
 {
     otError   error = OT_ERROR_NONE;
     IaAddress option;
 
     option.Init();
     option.GetAddress().SetPrefix(aPrefix.mFields.m8, OT_IP6_PREFIX_BITSIZE);
-    option.GetAddress().GetIid().SetFromExtAddress(
-        *reinterpret_cast<Mac::ExtAddress *>(aClientId.GetDuidLinkLayerAddress()));
-    option.SetPreferredLifetime(OT_DHCP6_DEFAULT_PREFERRED_LIFETIME);
-    option.SetValidLifetime(OT_DHCP6_DEFAULT_VALID_LIFETIME);
+    option.GetAddress().GetIid().SetFromExtAddress(aClientId.GetDuidLinkLayerAddress());
+    option.SetPreferredLifetime(IaAddress::kDefaultPreferredLifetime);
+    option.SetValidLifetime(IaAddress::kDefaultValidLiftetime);
     SuccessOrExit(error = aMessage.Append(&option, sizeof(option)));
 
 exit:
     return error;
 }
 
-otError Dhcp6Server::AppendRapidCommit(Message &aMessage)
+otError Server::AppendRapidCommit(Message &aMessage)
 {
     RapidCommit option;
 
@@ -487,7 +489,7 @@ otError Dhcp6Server::AppendRapidCommit(Message &aMessage)
     return aMessage.Append(&option, sizeof(option));
 }
 
-void Dhcp6Server::ApplyMeshLocalPrefix(void)
+void Server::ApplyMeshLocalPrefix(void)
 {
     for (PrefixAgent &prefixAgent : mPrefixAgents)
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -886,7 +886,7 @@ void Mle::ApplyMeshLocalPrefix(void)
 #endif
 
 #if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
-    Get<Dhcp6::Dhcp6Server>().ApplyMeshLocalPrefix();
+    Get<Dhcp6::Server>().ApplyMeshLocalPrefix();
 #endif
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
@@ -1513,11 +1513,11 @@ void Mle::HandleNotifierEvents(Events aEvents)
 #endif
 
 #if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
-        IgnoreError(Get<Dhcp6::Dhcp6Server>().UpdateService());
+        IgnoreError(Get<Dhcp6::Server>().UpdateService());
 #endif // OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
 
 #if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
-        Get<Dhcp6::Dhcp6Client>().UpdateAddresses();
+        Get<Dhcp6::Client>().UpdateAddresses();
 #endif // OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
     }
 

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -194,10 +194,10 @@ private:
 
     Coap::Coap mCoap;
 #if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
-    Dhcp6::Dhcp6Client mDhcp6Client;
+    Dhcp6::Client mDhcp6Client;
 #endif // OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
 #if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
-    Dhcp6::Dhcp6Server mDhcp6Server;
+    Dhcp6::Server mDhcp6Server;
 #endif // OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
 #if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
     Utils::Slaac mSlaac;


### PR DESCRIPTION
This commit contains a bunch of smaller changes and enhancements
in dhcp6 modules:
- Add and use `TransactionId` class.
- Rename header to `Dhcp6::Header` and update `Dhcp6::Type`.
- Rename server/client to `Dhcp6::Server` and `Dhcp6::Client`.
- Rename/update `DuidType` constants.
- Use `Mac::ExtAddress` as link address in `Server/ClinetIndentifer`.
- Use `Ip6::Address` instead of `otIp6Address`.
- Add `enum` constants for default values (remove `#define`)
- Define `IdentityAssociation` as nested type of `Client`.
- Update documentation.
- ~~Use `BitVector` for `mPrefixAgentsMask`.~~ _(removed due to impact on code size)._
