### PR TITLE
[joiner-adv] initial implementation of Joiner Advertisement

### DIFF
--- a/include/openthread/dataset.h
+++ b/include/openthread/dataset.h
@@ -287,6 +287,7 @@ typedef enum otMeshcopTlvType
     OT_MESHCOP_TLV_ENERGY_LIST              = 57,  ///< meshcop Energy List TLV
     OT_MESHCOP_TLV_DISCOVERYREQUEST         = 128, ///< meshcop Discovery Request TLV
     OT_MESHCOP_TLV_DISCOVERYRESPONSE        = 129, ///< meshcop Discovery Response TLV
+    OT_MESHCOP_TLV_JOINERADVERTISEMENT      = 241, ///< meshcop Joiner Advertisement TLV
 } otMeshcopTlvType;
 
 /**

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (20)
+#define OPENTHREAD_API_VERSION (21)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -274,7 +274,7 @@ bool otThreadIsDiscoverInProgress(otInstance *aInstance);
  * @param[in]  aInstance        A pointer to an OpenThread instance.
  * @param[in]  aOui             The Vendor IEEE OUI value that will be included in the Joiner Advertisement. Only the
  *                              least significant 3 bytes will be used, and the most significant byte will be ignored.
- * @param[in]  aAdvData         The AdvData that will be included in the Joiner Advertisement.
+ * @param[in]  aAdvData         A pointer to the AdvData that will be included in the Joiner Advertisement.
  * @param[in]  aAdvDataLength   The length of AdvData in bytes.
  *
  * @retval OT_ERROR_NONE         Successfully set Joiner Advertisement.

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -286,7 +286,7 @@ otError otThreadSetJoinerAdvertisement(otInstance *   aInstance,
                                        const uint8_t *aAdvData,
                                        uint8_t        aAdvDataLength);
 
-#define OT_JOINER_ADVDATA_MAX_LENGTH 64 ///<Maximum AdvData Length of Joiner Advertisement
+#define OT_JOINER_ADVDATA_MAX_LENGTH 64 ///< Maximum AdvData Length of Joiner Advertisement
 
 /**
  * Get the Thread Child Timeout used when operating in the Child role.

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -265,6 +265,28 @@ otError otThreadDiscover(otInstance *             aInstance,
 bool otThreadIsDiscoverInProgress(otInstance *aInstance);
 
 /**
+ * This method sets the Thread Joiner Advertisement when discovering Thread network.
+ *
+ * Thread Joiner Advertisement is used to allow a Joiner advertise its own application-specific information
+ * (such as Vendor ID, Product ID, Discriminator, etc.) unsolicitedly via a newly-proposed Joiner Advertisement TLV,
+ * and to make this information available to Commissioners or Commissioner Candidates without human interactions.
+ *
+ * @param[in]  aInstance        A pointer to an OpenThread instance.
+ * @param[in]  aOui             The Vendor IEEE OUI value which will be included in the Joiner Advertisement. Only the
+ *                              least significant 3 bytes will be used, and the most significant byte will be ignored.
+ * @param[in]  aAdvData         The AdvData which will be included in the Joiner Advertisement.
+ * @param[in]  aAdvDataLength   The length of AdvData
+ *
+ * @retval OT_ERROR_NONE         Successfully set Joiner Advertisement.
+ * @retval OT_ERROR_INVALID_ARGS Invalid AdvData.
+ *
+ */
+otError otThreadSetJoinerAdvertisement(otInstance *   aInstance,
+                                       uint32_t       aOui,
+                                       const uint8_t *aAdvData,
+                                       uint8_t        aAdvDataLength);
+
+/**
  * Get the Thread Child Timeout used when operating in the Child role.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -286,6 +286,8 @@ otError otThreadSetJoinerAdvertisement(otInstance *   aInstance,
                                        const uint8_t *aAdvData,
                                        uint8_t        aAdvDataLength);
 
+#define OT_JOINER_ADVDATA_MAX_LENGTH 64 ///<Maximum AdvData Length of Joiner Advertisement
+
 /**
  * Get the Thread Child Timeout used when operating in the Child role.
  *

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -267,15 +267,15 @@ bool otThreadIsDiscoverInProgress(otInstance *aInstance);
 /**
  * This method sets the Thread Joiner Advertisement when discovering Thread network.
  *
- * Thread Joiner Advertisement is used to allow a Joiner advertise its own application-specific information
- * (such as Vendor ID, Product ID, Discriminator, etc.) unsolicitedly via a newly-proposed Joiner Advertisement TLV,
- * and to make this information available to Commissioners or Commissioner Candidates without human interactions.
+ * Thread Joiner Advertisement is used to allow a Joiner to advertise its own application-specific information
+ * (such as Vendor ID, Product ID, Discriminator, etc.) via a newly-proposed Joiner Advertisement TLV,
+ * and to make this information available to Commissioners or Commissioner Candidates without human interaction.
  *
  * @param[in]  aInstance        A pointer to an OpenThread instance.
- * @param[in]  aOui             The Vendor IEEE OUI value which will be included in the Joiner Advertisement. Only the
+ * @param[in]  aOui             The Vendor IEEE OUI value that will be included in the Joiner Advertisement. Only the
  *                              least significant 3 bytes will be used, and the most significant byte will be ignored.
- * @param[in]  aAdvData         The AdvData which will be included in the Joiner Advertisement.
- * @param[in]  aAdvDataLength   The length of AdvData
+ * @param[in]  aAdvData         The AdvData that will be included in the Joiner Advertisement.
+ * @param[in]  aAdvDataLength   The length of AdvData in bytes.
  *
  * @retval OT_ERROR_NONE         Successfully set Joiner Advertisement.
  * @retval OT_ERROR_INVALID_ARGS Invalid AdvData.

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -462,6 +462,16 @@ otError otThreadDiscover(otInstance *             aInstance,
         /* aFilterIndexes (use hash of factory EUI64) */ nullptr, aCallback, aCallbackContext);
 }
 
+otError otThreadSetJoinerAdvertisement(otInstance *   aInstance,
+                                       uint32_t       aOui,
+                                       const uint8_t *aAdvData,
+                                       uint8_t        aAdvDataLength)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<Mle::DiscoverScanner>().SetJoinerAdvertisement(aOui, aAdvData, aAdvDataLength);
+}
+
 bool otThreadIsDiscoverInProgress(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -2365,7 +2365,8 @@ class JoinerAdvertisementTlv : public Tlv
 public:
     enum
     {
-        kType = kJoinerAdvertisement, ///< The TLV Type.
+        kType             = kJoinerAdvertisement,         ///< The TLV Type.
+        kAdvDataMaxLength = OT_JOINER_ADVDATA_MAX_LENGTH, ///< The Max Length of AdvData
     };
 
     /**
@@ -2436,20 +2437,15 @@ public:
      */
     void SetAdvData(const uint8_t *aAdvData, uint8_t aAdvDataLength)
     {
-        OT_ASSERT((aAdvData != nullptr) && (aAdvDataLength > 0) && (aAdvDataLength <= kMaxLength));
+        OT_ASSERT((aAdvData != nullptr) && (aAdvDataLength > 0) && (aAdvDataLength <= kAdvDataMaxLength));
 
         SetLength(aAdvDataLength + sizeof(mOui));
         memcpy(mAdvData, aAdvData, aAdvDataLength);
     }
 
 private:
-    enum
-    {
-        kMaxLength = 64,
-    };
-
     uint8_t mOui[3];
-    uint8_t mAdvData[kMaxLength];
+    uint8_t mAdvData[kAdvDataMaxLength];
 } OT_TOOL_PACKED_END;
 
 } // namespace MeshCoP

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -2432,7 +2432,8 @@ public:
     /**
      * This method sets the Adv Data value.
      *
-     * @param[in]  aAdvData  A pointer to the Adv Data value.
+     * @param[in]  aAdvData        A pointer to the AdvData value.
+     * @param[in]  aAdvDataLength  The length of AdvData in bytes.
      *
      */
     void SetAdvData(const uint8_t *aAdvData, uint8_t aAdvDataLength)

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -111,6 +111,7 @@ public:
         kEnergyList              = OT_MESHCOP_TLV_ENERGY_LIST,              ///< Energy List TLV
         kDiscoveryRequest        = OT_MESHCOP_TLV_DISCOVERYREQUEST,         ///< Discovery Request TLV
         kDiscoveryResponse       = OT_MESHCOP_TLV_DISCOVERYRESPONSE,        ///< Discovery Response TLV
+        kJoinerAdvertisement     = OT_MESHCOP_TLV_JOINERADVERTISEMENT,      ///< Joiner Advertisement TLV
     };
 
     /**
@@ -2352,6 +2353,103 @@ private:
     };
     uint8_t mFlags;
     uint8_t mReserved;
+} OT_TOOL_PACKED_END;
+
+/**
+ * This class implements Joiner Advertisement TLV generation and parsing.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class JoinerAdvertisementTlv : public Tlv
+{
+public:
+    enum
+    {
+        kType = kJoinerAdvertisement, ///< The TLV Type.
+    };
+
+    /**
+     * This method initializes the TLV.
+     *
+     */
+    void Init(void)
+    {
+        SetType(kJoinerAdvertisement);
+        SetLength(sizeof(*this) - sizeof(Tlv));
+    }
+
+    /**
+     * This method indicates whether or not the TLV appears to be well-formed.
+     *
+     * @retval TRUE   If the TLV appears to be well-formed.
+     * @retval FALSE  If the TLV does not appear to be well-formed.
+     *
+     */
+    bool IsValid(void) const { return GetLength() >= sizeof(mOui) && GetLength() <= sizeof(mOui) + sizeof(mAdvData); }
+
+    /**
+     * This method returns the Vendor OUI value.
+     *
+     * @returns The Vendor OUI value.
+     *
+     */
+    uint32_t GetOui(void) const
+    {
+        return (static_cast<uint32_t>(mOui[0]) << 16) | (static_cast<uint32_t>(mOui[1]) << 8) |
+               static_cast<uint32_t>(mOui[2]);
+    }
+
+    /**
+     * This method returns the Vendor OUI value.
+     *
+     * @param[in]  aOui The Vendor OUI value.
+     *
+     */
+    void SetOui(uint32_t aOui)
+    {
+        mOui[0] = (aOui >> 16) & 0xff;
+        mOui[1] = (aOui >> 8) & 0xff;
+        mOui[2] = aOui & 0xff;
+    }
+
+    /**
+     * This method returns the Adv Data length.
+     *
+     * @returns The AdvData length.
+     *
+     */
+    uint8_t GetAdvDataLength(void) const { return GetLength() - sizeof(mOui); }
+
+    /**
+     * This method returns the Adv Data value.
+     *
+     * @returns A pointer to the Adv Data value.
+     *
+     */
+    const uint8_t *GetAdvData(void) const { return mAdvData; }
+
+    /**
+     * This method sets the Adv Data value.
+     *
+     * @param[in]  aAdvData  A pointer to the Adv Data value.
+     *
+     */
+    void SetAdvData(const uint8_t *aAdvData, uint8_t aAdvDataLength)
+    {
+        OT_ASSERT((aAdvData != nullptr) && (aAdvDataLength > 0) && (aAdvDataLength <= kMaxLength));
+
+        SetLength(aAdvDataLength + sizeof(mOui));
+        memcpy(mAdvData, aAdvData, aAdvDataLength);
+    }
+
+private:
+    enum
+    {
+        kMaxLength = 64,
+    };
+
+    uint8_t mOui[3];
+    uint8_t mAdvData[kMaxLength];
 } OT_TOOL_PACKED_END;
 
 } // namespace MeshCoP

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -2401,7 +2401,7 @@ public:
     }
 
     /**
-     * This method returns the Vendor OUI value.
+     * This method sets the Vendor OUI value.
      *
      * @param[in]  aOui The Vendor OUI value.
      *

--- a/src/core/thread/discover_scanner.hpp
+++ b/src/core/thread/discover_scanner.hpp
@@ -134,12 +134,30 @@ public:
      */
     bool IsInProgress(void) const { return (mState != kStateIdle); }
 
+    /**
+     * This method sets Joiner Advertisement.
+     *
+     * @param[in]  aOui             The Vendor OUI for Joiner Advertisement
+     * @param[in]  aAdvData         A pointer to AdvData for Joiner Advertisement
+     * @param[in]  aAdvDataLength   The length of AdvData
+     *
+     * @retval OT_ERROR_NONE            Successfully set Joiner Advertisement.
+     * @retval OT_ERROR_INVALID_ARGS    Invalid AdvData.
+     *
+     */
+    otError SetJoinerAdvertisement(uint32_t aOui, const uint8_t *aAdvData, uint8_t aAdvDataLength);
+
 private:
     enum State
     {
         kStateIdle,
         kStateScanning,
         kStateScanDone,
+    };
+
+    enum
+    {
+        kMaxLength = 64,
     };
 
     // Methods used by `MeshForwarder`
@@ -160,9 +178,13 @@ private:
     FilterIndexes    mFilterIndexes;
     Mac::ChannelMask mScanChannels;
     State            mState;
+    uint32_t         mOui;
     uint8_t          mScanChannel;
+    uint8_t          mAdvDataLength;
+    uint8_t          mAdvData[kMaxLength];
     bool             mEnableFiltering : 1;
     bool             mShouldRestorePanId : 1;
+    bool             mHasJoinerAdvertisement : 1;
 };
 
 } // namespace Mle

--- a/src/core/thread/discover_scanner.hpp
+++ b/src/core/thread/discover_scanner.hpp
@@ -137,9 +137,9 @@ public:
     /**
      * This method sets Joiner Advertisement.
      *
-     * @param[in]  aOui             The Vendor OUI for Joiner Advertisement
-     * @param[in]  aAdvData         A pointer to AdvData for Joiner Advertisement
-     * @param[in]  aAdvDataLength   The length of AdvData
+     * @param[in]  aOui             The Vendor OUI for Joiner Advertisement.
+     * @param[in]  aAdvData         A pointer to AdvData for Joiner Advertisement.
+     * @param[in]  aAdvDataLength   The length of AdvData.
      *
      * @retval OT_ERROR_NONE            Successfully set Joiner Advertisement.
      * @retval OT_ERROR_INVALID_ARGS    Invalid AdvData.

--- a/src/core/thread/discover_scanner.hpp
+++ b/src/core/thread/discover_scanner.hpp
@@ -155,11 +155,6 @@ private:
         kStateScanDone,
     };
 
-    enum
-    {
-        kMaxLength = 64,
-    };
-
     // Methods used by `MeshForwarder`
     otError PrepareDiscoveryRequestFrame(Mac::TxFrame &aFrame);
     void    HandleDiscoveryRequestFrameTxDone(Message &aMessage);
@@ -181,10 +176,9 @@ private:
     uint32_t         mOui;
     uint8_t          mScanChannel;
     uint8_t          mAdvDataLength;
-    uint8_t          mAdvData[kMaxLength];
+    uint8_t          mAdvData[MeshCoP::JoinerAdvertisementTlv::kAdvDataMaxLength];
     bool             mEnableFiltering : 1;
     bool             mShouldRestorePanId : 1;
-    bool             mHasJoinerAdvertisement : 1;
 };
 
 } // namespace Mle


### PR DESCRIPTION
This PR implements Thread based Joiner Advertisement from Joiner side, including:

- A new MeshCop TLV: Joiner Advertisement TLV which includes IEEE OUI and the Advertisement Data 
- New APIs to set Joiner Advertisement which will be sent along with Discovery Request messages
