### PR TITLE
[mle] fix FTD unable to restore link to parent

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2839,12 +2839,6 @@ otError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &a
     {
         if (IsChild())
         {
-#if OPENTHREAD_FTD
-            // An FTD skips handling LeaderData of a different partition.
-            VerifyOrExit(!IsFullThreadDevice() || (leaderData.GetPartitionId() == mLeaderData.GetPartitionId() &&
-                                                   leaderData.GetLeaderRouterId() == GetLeaderId()),
-                         error = OT_ERROR_DROP);
-#endif
             SetLeaderData(leaderData.GetPartitionId(), leaderData.GetWeighting(), leaderData.GetLeaderRouterId());
             mRetrieveNewNetworkData = true;
         }


### PR DESCRIPTION
This PR fixes #5293 

Testing if two `OT_ASSERT(leader != nullptr);` statements can be kept since they seems correct:
- OT Build: 
  - **FTD Leader Data dropping removed**
  - **`OT_ASSERT(leader != nullptr);` statements kept**
  - kMinDowngradeNeighbors = 4
  - OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE = 1
- OTNS Stress Tests
  - [x] [Large Network Forming](https://github.com/openthread/ot-ns/blob/master/pylibs/stress_tests/large_network_forming.py) (simulated 100 days successfully)
  - [x] [MLEID Connectivity test](https://github.com/simonlingoogle/ot-ns/blob/stress-test-mleid-connectivity/pylibs/stress_tests/mleid_connectivity.py) (simulated 100 days successfully)