### PR TITLE
[cmake] fix link issues of unit tests

### DIFF
--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -33,7 +33,6 @@ set(COMMON_SOURCES
 
 set(COMMON_LIBS
     openthread-ftd
-    openthread-ncp-ftd
     ot-config
     ${OT_MBEDTLS}
     util


### PR DESCRIPTION
I think `openthread-ncp-ftd` is added to unit tests' link libraries by mistake. It's not required and as it depends on `OT_PLATFORM`, it would cause `openthread-simulation` linked in unit test executables, which would lead to a redefinition as some methods are defined in `test-platform.cpp`.