### PR TITLE
[posix] increase UART tx buffer size for posix

### DIFF
--- a/examples/platforms/nrf528xx/nrf52833/openthread-core-nrf52833-config.h
+++ b/examples/platforms/nrf528xx/nrf52833/openthread-core-nrf52833-config.h
@@ -225,7 +225,7 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_CLI_TX_BUFFER_SIZE
+ * @def OPENTHREAD_CONFIG_CLI_UART_TX_BUFFER_SIZE
  *
  *  The size of CLI message buffer in bytes
  *

--- a/examples/platforms/nrf528xx/nrf52840/openthread-core-nrf52840-config.h
+++ b/examples/platforms/nrf528xx/nrf52840/openthread-core-nrf52840-config.h
@@ -225,7 +225,7 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_CLI_TX_BUFFER_SIZE
+ * @def OPENTHREAD_CONFIG_CLI_UART_TX_BUFFER_SIZE
  *
  *  The size of CLI message buffer in bytes
  *

--- a/src/cli/cli_config.h
+++ b/src/cli/cli_config.h
@@ -56,7 +56,7 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_CLI_TX_BUFFER_SIZE
+ * @def OPENTHREAD_CONFIG_CLI_UART_TX_BUFFER_SIZE
  *
  * The size of CLI message buffer in bytes.
  *

--- a/src/posix/platform/openthread-core-posix-config.h
+++ b/src/posix/platform/openthread-core-posix-config.h
@@ -118,4 +118,14 @@
 
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_CLI_TX_BUFFER_SIZE
+ *
+ * The size of CLI message buffer in bytes.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CLI_UART_TX_BUFFER_SIZE
+#define OPENTHREAD_CONFIG_CLI_UART_TX_BUFFER_SIZE 8192
+#endif
+
 #endif // OPENTHREAD_CORE_POSIX_CONFIG_H_

--- a/src/posix/platform/openthread-core-posix-config.h
+++ b/src/posix/platform/openthread-core-posix-config.h
@@ -119,7 +119,7 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_CLI_TX_BUFFER_SIZE
+ * @def OPENTHREAD_CONFIG_CLI_UART_TX_BUFFER_SIZE
  *
  * The size of CLI message buffer in bytes.
  *


### PR DESCRIPTION
This fixes the issue for `ot-br-posix` when running command `ot-ctl` with large outputs over 1024 bytes.
In addition, I fixed the macro name in the comment.