### PR TITLE
[udp6] adding new flavors of Bind() and Connect() in Socket

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1020,12 +1020,10 @@ Coap::Coap(Instance &aInstance)
 
 otError Coap::Start(uint16_t aPort)
 {
-    otError       error;
-    Ip6::SockAddr sockaddr;
+    otError error;
 
-    sockaddr.mPort = aPort;
     SuccessOrExit(error = mSocket.Open(&Coap::HandleUdpReceive, this));
-    VerifyOrExit((error = mSocket.Bind(sockaddr)) == OT_ERROR_NONE, IgnoreError(mSocket.Close()));
+    VerifyOrExit((error = mSocket.Bind(aPort)) == OT_ERROR_NONE, IgnoreError(mSocket.Close()));
 
 exit:
     return error;

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -172,12 +172,7 @@ void Dtls::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageI
         ExitNow();
 
     case MeshCoP::Dtls::kStateOpen:
-    {
-        Ip6::SockAddr sockAddr;
-
-        sockAddr.mAddress = aMessageInfo.GetPeerAddr();
-        sockAddr.mPort    = aMessageInfo.GetPeerPort();
-        IgnoreError(mSocket.Connect(sockAddr));
+        IgnoreError(mSocket.Connect(Ip6::SockAddr(aMessageInfo.GetPeerAddr(), aMessageInfo.GetPeerPort())));
 
         mMessageInfo.SetPeerAddr(aMessageInfo.GetPeerAddr());
         mMessageInfo.SetPeerPort(aMessageInfo.GetPeerPort());
@@ -192,7 +187,6 @@ void Dtls::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageI
 
         SuccessOrExit(Setup(false));
         break;
-    }
 
     default:
         // Once DTLS session is started, communicate only with a peer.
@@ -217,14 +211,12 @@ exit:
 
 otError Dtls::Bind(uint16_t aPort)
 {
-    otError       error;
-    Ip6::SockAddr sockaddr;
+    otError error;
 
     VerifyOrExit(mState == kStateOpen, error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(mTransportCallback == nullptr, error = OT_ERROR_ALREADY);
 
-    sockaddr.mPort = aPort;
-    SuccessOrExit(error = mSocket.Bind(sockaddr));
+    SuccessOrExit(error = mSocket.Bind(aPort));
 
 exit:
     return error;
@@ -432,7 +424,7 @@ void Dtls::Disconnect(void)
     mTimer.Start(kGuardTimeNewConnectionMilli);
 
     mMessageInfo.Clear();
-    IgnoreError(mSocket.Connect(Ip6::SockAddr()));
+    IgnoreError(mSocket.Connect());
 
     FreeMbedtls();
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -379,7 +379,7 @@ exit:
 otError Joiner::Connect(JoinerRouter &aRouter)
 {
     otError       error = OT_ERROR_NOT_FOUND;
-    Ip6::SockAddr sockaddr;
+    Ip6::SockAddr sockAddr(aRouter.mJoinerUdpPort);
 
     otLogInfoMeshCoP("Joiner connecting to %s, pan:0x%04x, chan:%d", aRouter.mExtAddr.ToString().AsCString(),
                      aRouter.mPanId, aRouter.mChannel);
@@ -388,10 +388,9 @@ otError Joiner::Connect(JoinerRouter &aRouter)
     SuccessOrExit(error = Get<Mac::Mac>().SetPanChannel(aRouter.mChannel));
     SuccessOrExit(error = Get<Ip6::Filter>().AddUnsecurePort(kJoinerUdpPort));
 
-    sockaddr.GetAddress().SetToLinkLocalAddress(aRouter.mExtAddr);
-    sockaddr.mPort = aRouter.mJoinerUdpPort;
+    sockAddr.GetAddress().SetToLinkLocalAddress(aRouter.mExtAddr);
 
-    SuccessOrExit(error = Get<Coap::CoapSecure>().Connect(sockaddr, Joiner::HandleSecureCoapClientConnect, this));
+    SuccessOrExit(error = Get<Coap::CoapSecure>().Connect(sockAddr, Joiner::HandleSecureCoapClientConnect, this));
 
     SetState(OT_JOINER_STATE_CONNECT);
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -84,15 +84,13 @@ void JoinerRouter::Start(void)
 
     if (Get<NetworkData::Leader>().IsJoiningEnabled())
     {
-        Ip6::SockAddr sockaddr;
+        uint16_t port = GetJoinerUdpPort();
 
         VerifyOrExit(!mSocket.IsBound(), OT_NOOP);
 
-        sockaddr.mPort = GetJoinerUdpPort();
-
         IgnoreError(mSocket.Open(&JoinerRouter::HandleUdpReceive, this));
-        IgnoreError(mSocket.Bind(sockaddr));
-        IgnoreError(Get<Ip6::Filter>().AddUnsecurePort(sockaddr.mPort));
+        IgnoreError(mSocket.Bind(port));
+        IgnoreError(Get<Ip6::Filter>().AddUnsecurePort(port));
         otLogInfoMeshCoP("Joiner Router: start");
     }
     else

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -165,13 +165,10 @@ void Client::UpdateAddresses(void)
 
 void Client::Start(void)
 {
-    Ip6::SockAddr sockaddr;
-
     VerifyOrExit(!mSocket.IsBound(), OT_NOOP);
 
-    sockaddr.mPort = kDhcpClientPort;
     IgnoreError(mSocket.Open(&Client::HandleUdpReceive, this));
-    IgnoreError(mSocket.Bind(sockaddr));
+    IgnoreError(mSocket.Bind(kDhcpClientPort));
 
     ProcessNextIdentityAssociation();
 

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -132,11 +132,8 @@ otError Server::UpdateService(void)
 
 void Server::Start(void)
 {
-    Ip6::SockAddr sockaddr;
-
-    sockaddr.mPort = kDhcpServerPort;
     IgnoreError(mSocket.Open(&Server::HandleUdpReceive, this));
-    IgnoreError(mSocket.Bind(sockaddr));
+    IgnoreError(mSocket.Bind(kDhcpServerPort));
 }
 
 void Server::Stop(void)

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -81,11 +81,10 @@ Client::Client(Instance &aInstance)
 
 otError Client::Start(void)
 {
-    otError       error;
-    Ip6::SockAddr addr;
+    otError error;
 
     SuccessOrExit(error = mSocket.Open(&Client::HandleUdpReceive, this));
-    SuccessOrExit(error = mSocket.Bind(addr));
+    SuccessOrExit(error = mSocket.Bind());
 
 exit:
     return error;

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -98,11 +98,10 @@ Client::Client(Instance &aInstance)
 
 otError Client::Start(void)
 {
-    otError       error;
-    Ip6::SockAddr addr;
+    otError error;
 
     SuccessOrExit(error = mSocket.Open(&Client::HandleUdpReceive, this));
-    SuccessOrExit(error = mSocket.Bind(addr));
+    SuccessOrExit(error = mSocket.Bind());
 
 exit:
     return error;

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -209,10 +209,35 @@ class SockAddr : public otSockAddr, public Clearable<SockAddr>
 {
 public:
     /**
-     * This constructor initializes the object.
+     * This constructor initializes the socket address (all fields are set to zero).
      *
      */
     SockAddr(void) { Clear(); }
+
+    /**
+     * This constructor initializes the socket address with a given port number.
+     *
+     * @param[in] aPort   A port number.
+     *
+     */
+    explicit SockAddr(uint16_t aPort)
+    {
+        mPort = aPort;
+        GetAddress().Clear();
+    }
+
+    /**
+     * This constructor initializes the socket address with a given address and port number.
+     *
+     * @param[in] aAddress  An IPv6 address.
+     * @param[in] aPort     A port number.
+     *
+     */
+    SockAddr(const Address &aAddress, uint16_t aPort)
+    {
+        mAddress = aAddress;
+        mPort    = aPort;
+    }
 
     /**
      * This method returns a reference to the IPv6 address.

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -95,9 +95,19 @@ otError Udp::Socket::Bind(const SockAddr &aSockAddr)
     return Get<Udp>().Bind(*this, aSockAddr);
 }
 
+otError Udp::Socket::Bind(uint16_t aPort)
+{
+    return Bind(SockAddr(aPort));
+}
+
 otError Udp::Socket::Connect(const SockAddr &aSockAddr)
 {
     return Get<Udp>().Connect(*this, aSockAddr);
+}
+
+otError Udp::Socket::Connect(uint16_t aPort)
+{
+    return Bind(SockAddr(aPort));
 }
 
 otError Udp::Socket::Close(void)

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -176,6 +176,26 @@ public:
         otError Bind(const SockAddr &aSockAddr);
 
         /**
+         * This method binds the UDP socket.
+         *
+         * @param[in] aPort  A port number.
+         *
+         * @retval OT_ERROR_NONE    Successfully bound the socket.
+         * @retval OT_ERROR_FAILED  Failed to bind UDP Socket.
+         *
+         */
+        otError Bind(uint16_t aPort);
+
+        /**
+         * This method binds the UDP socket.
+         *
+         * @retval OT_ERROR_NONE    Successfully bound the socket.
+         * @retval OT_ERROR_FAILED  Failed to bind UDP Socket.
+         *
+         */
+        otError Bind(void) { return Bind(0); }
+
+        /**
          * This method connects the UDP socket.
          *
          * @param[in]  aSockAddr  A reference to the socket address.
@@ -185,6 +205,26 @@ public:
          *
          */
         otError Connect(const SockAddr &aSockAddr);
+
+        /**
+         * This method connects the UDP socket.
+         *
+         * @param[in]  aPort        A port number.
+         *
+         * @retval OT_ERROR_NONE    Successfully connected the socket.
+         * @retval OT_ERROR_FAILED  Failed to connect UDP Socket.
+         *
+         */
+        otError Connect(uint16_t aPort);
+
+        /**
+         * This method connects the UDP socket.
+         *
+         * @retval OT_ERROR_NONE    Successfully connected the socket.
+         * @retval OT_ERROR_FAILED  Failed to connect UDP Socket.
+         *
+         */
+        otError Connect(void) { return Connect(0); }
 
         /**
          * This method closes the UDP socket.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -202,13 +202,11 @@ Mle::Mle(Instance &aInstance)
 
 otError Mle::Enable(void)
 {
-    otError       error = OT_ERROR_NONE;
-    Ip6::SockAddr sockaddr;
+    otError error = OT_ERROR_NONE;
 
     UpdateLinkLocalAddress();
-    sockaddr.mPort = kUdpPort;
     SuccessOrExit(error = mSocket.Open(&Mle::HandleUdpReceive, this));
-    SuccessOrExit(error = mSocket.Bind(sockaddr));
+    SuccessOrExit(error = mSocket.Bind(kUdpPort));
 
 #if OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE
     StartParentSearchTimer();


### PR DESCRIPTION
This commit adds new flavors of methods `Bind()` and `Connect()` in
`Udp6::Socket` allowing user to only specify a port number or provide
no input (address and/or port are determined by the UDP module itself
when not provided). The new methods help simplify `Socket` use in
different modules. This commit also enhances `SockAddr` class adding
new constructors to allow a `SockAddr` instance to be initialized with
a given port number or a given IPv6 address and port number.