### PR TITLE
[tests] fix external commissioner building options

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -221,6 +221,8 @@ jobs:
               -DCMAKE_CXX_STANDARD_REQUIRED=ON  \
               -DCMAKE_BUILD_TYPE=Release        \
               -DCMAKE_INSTALL_PREFIX=/usr/local \
+              -DOT_COMM_COVERAGE=ON             \
+              -DOT_COMM_CCM=OFF                 \
               -S . -B build
         cmake --build build
         sudo cmake --install build


### PR DESCRIPTION
This PR aligns the external commissioner buliding options with OT commissioner.

Fixes test failures revealed in https://github.com/openthread/openthread/pull/5317/checks?check_run_id=934695903.
