### PR TITLE
[scripts] add live capture for sniffer.py on simulation traffic

### DIFF
--- a/tests/scripts/thread-cert/pcap.py
+++ b/tests/scripts/thread-cert/pcap.py
@@ -80,6 +80,7 @@ class PcapCodec(object):
         pkt = self.encode_frame(frame, *timestamp)
         self._pcap_file.write(pkt)
         self._pcap_file.flush()
+        return pkt
 
     def __del__(self):
         self._pcap_file.close()


### PR DESCRIPTION
This PR enhances `sniffer.py` so that we can use it as a standalone sniffer for non Virtual Time simulations. 

Usage:
```bash
$ python3 sniffer.py | wireshark -k -i -
```