### PR TITLE
[topology] define 'Neighbor::Info', 'Child::Info', and 'Router::Info'

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -304,7 +304,7 @@ otError otThreadGetNextNeighborInfo(otInstance *aInstance, otNeighborInfoIterato
 
     OT_ASSERT((aInfo != nullptr) && (aIterator != nullptr));
 
-    return instance.Get<Mle::MleRouter>().GetNextNeighborInfo(*aIterator, *aInfo);
+    return instance.Get<Mle::MleRouter>().GetNextNeighborInfo(*aIterator, *static_cast<Neighbor::Info *>(aInfo));
 }
 
 otDeviceRole otThreadGetDeviceRole(otInstance *aInstance)

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -259,7 +259,7 @@ otError otThreadGetChildInfoById(otInstance *aInstance, uint16_t aChildId, otChi
 
     OT_ASSERT(aChildInfo != nullptr);
 
-    return instance.Get<Mle::MleRouter>().GetChildInfoById(aChildId, *aChildInfo);
+    return instance.Get<Mle::MleRouter>().GetChildInfoById(aChildId, *static_cast<Child::Info *>(aChildInfo));
 }
 
 otError otThreadGetChildInfoByIndex(otInstance *aInstance, uint16_t aChildIndex, otChildInfo *aChildInfo)
@@ -268,7 +268,7 @@ otError otThreadGetChildInfoByIndex(otInstance *aInstance, uint16_t aChildIndex,
 
     OT_ASSERT(aChildInfo != nullptr);
 
-    return instance.Get<Mle::MleRouter>().GetChildInfoByIndex(aChildIndex, *aChildInfo);
+    return instance.Get<Mle::MleRouter>().GetChildInfoByIndex(aChildIndex, *static_cast<Child::Info *>(aChildInfo));
 }
 
 otError otThreadGetChildNextIp6Address(otInstance *               aInstance,
@@ -319,7 +319,7 @@ otError otThreadGetRouterInfo(otInstance *aInstance, uint16_t aRouterId, otRoute
 
     OT_ASSERT(aRouterInfo != nullptr);
 
-    return instance.Get<RouterTable>().GetRouterInfo(aRouterId, *aRouterInfo);
+    return instance.Get<RouterTable>().GetRouterInfo(aRouterId, *static_cast<Router::Info *>(aRouterInfo));
 }
 
 otError otThreadGetNextCacheEntry(otInstance *aInstance, otCacheEntryInfo *aEntryInfo, otCacheEntryIterator *aIterator)

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -430,7 +430,7 @@ public:
      * @param[out]  aChildInfo  The child information.
      *
      */
-    otError GetChildInfoById(uint16_t aChildId, otChildInfo &aChildInfo);
+    otError GetChildInfoById(uint16_t aChildId, Child::Info &aChildInfo);
 
     /**
      * This method retains diagnostic information for an attached child by the internal table index.
@@ -439,7 +439,7 @@ public:
      * @param[out]  aChildInfo   The child information.
      *
      */
-    otError GetChildInfoByIndex(uint16_t aChildIndex, otChildInfo &aChildInfo);
+    otError GetChildInfoByIndex(uint16_t aChildIndex, Child::Info &aChildInfo);
 
     /**
      * This method indicates whether or not the RLOC16 is an MTD child of this device.
@@ -464,7 +464,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND     No subsequent neighbor entry exists in the table.
      *
      */
-    otError GetNextNeighborInfo(otNeighborInfoIterator &aIterator, otNeighborInfo &aNeighInfo);
+    otError GetNextNeighborInfo(otNeighborInfoIterator &aIterator, Neighbor::Info &aNeighInfo);
 
     /**
      * This method indicates whether or not the given Thread partition attributes are preferred.
@@ -706,8 +706,6 @@ private:
     otError AppendRoute(Message &aMessage);
     otError AppendActiveDataset(Message &aMessage);
     otError AppendPendingDataset(Message &aMessage);
-    otError GetChildInfo(Child &aChild, otChildInfo &aChildInfo);
-    void    GetNeighborInfo(Neighbor &aNeighbor, otNeighborInfo &aNeighInfo);
     void    RefreshStoredChildren(void);
     void    HandleDetachStart(void);
     void    HandleChildStart(AttachMode aMode);

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -415,7 +415,7 @@ Router *RouterTable::GetRouter(const Mac::ExtAddress &aExtAddress)
     return router;
 }
 
-otError RouterTable::GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo)
+otError RouterTable::GetRouterInfo(uint16_t aRouterId, Router::Info &aRouterInfo)
 {
     otError error = OT_ERROR_NONE;
     Router *router;
@@ -435,17 +435,7 @@ otError RouterTable::GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo
     router = GetRouter(routerId);
     VerifyOrExit(router != nullptr, error = OT_ERROR_NOT_FOUND);
 
-    memset(&aRouterInfo, 0, sizeof(aRouterInfo));
-    aRouterInfo.mRouterId        = routerId;
-    aRouterInfo.mRloc16          = Mle::Mle::Rloc16FromRouterId(routerId);
-    aRouterInfo.mExtAddress      = router->GetExtAddress();
-    aRouterInfo.mAllocated       = true;
-    aRouterInfo.mNextHop         = router->GetNextHop();
-    aRouterInfo.mLinkEstablished = router->IsStateValid();
-    aRouterInfo.mPathCost        = router->GetCost();
-    aRouterInfo.mLinkQualityIn   = router->GetLinkInfo().GetLinkQuality();
-    aRouterInfo.mLinkQualityOut  = router->GetLinkQualityOut();
-    aRouterInfo.mAge             = static_cast<uint8_t>(Time::MsecToSec(TimerMilli::GetNow() - router->GetLastHeard()));
+    aRouterInfo.SetFrom(*router);
 
 exit:
     return error;

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -331,7 +331,7 @@ public:
      * @retval OT_ERROR_NOT_FOUND     No router entry with the given id.
      *
      */
-    otError GetRouterInfo(uint16_t aRouterId, otRouterInfo &aRouterInfo);
+    otError GetRouterInfo(uint16_t aRouterId, Router::Info &aRouterInfo);
 
     /**
      * This method returns the Router ID Sequence.

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -41,6 +41,25 @@
 
 namespace ot {
 
+void Neighbor::Info::SetFrom(const Neighbor &aNeighbor)
+{
+    Clear();
+    mExtAddress        = aNeighbor.GetExtAddress();
+    mAge               = Time::MsecToSec(TimerMilli::GetNow() - aNeighbor.GetLastHeard());
+    mRloc16            = aNeighbor.GetRloc16();
+    mLinkFrameCounter  = aNeighbor.GetLinkFrameCounter();
+    mMleFrameCounter   = aNeighbor.GetMleFrameCounter();
+    mLinkQualityIn     = aNeighbor.GetLinkInfo().GetLinkQuality();
+    mAverageRssi       = aNeighbor.GetLinkInfo().GetAverageRss();
+    mLastRssi          = aNeighbor.GetLinkInfo().GetLastRss();
+    mFrameErrorRate    = aNeighbor.GetLinkInfo().GetFrameErrorRate();
+    mMessageErrorRate  = aNeighbor.GetLinkInfo().GetMessageErrorRate();
+    mRxOnWhenIdle      = aNeighbor.IsRxOnWhenIdle();
+    mSecureDataRequest = aNeighbor.IsSecureDataRequest();
+    mFullThreadDevice  = aNeighbor.IsFullThreadDevice();
+    mFullNetworkData   = aNeighbor.IsFullNetworkData();
+}
+
 void Neighbor::Init(Instance &aInstance)
 {
     InstanceLocatorInit::Init(aInstance);
@@ -109,6 +128,27 @@ void Neighbor::GenerateChallenge(void)
 {
     IgnoreError(
         Random::Crypto::FillBuffer(mValidPending.mPending.mChallenge, sizeof(mValidPending.mPending.mChallenge)));
+}
+
+void Child::Info::SetFrom(const Child &aChild)
+{
+    Clear();
+    mExtAddress         = aChild.GetExtAddress();
+    mTimeout            = aChild.GetTimeout();
+    mRloc16             = aChild.GetRloc16();
+    mChildId            = Mle::Mle::ChildIdFromRloc16(aChild.GetRloc16());
+    mNetworkDataVersion = aChild.GetNetworkDataVersion();
+    mAge                = Time::MsecToSec(TimerMilli::GetNow() - aChild.GetLastHeard());
+    mLinkQualityIn      = aChild.GetLinkInfo().GetLinkQuality();
+    mAverageRssi        = aChild.GetLinkInfo().GetAverageRss();
+    mLastRssi           = aChild.GetLinkInfo().GetLastRss();
+    mFrameErrorRate     = aChild.GetLinkInfo().GetFrameErrorRate();
+    mMessageErrorRate   = aChild.GetLinkInfo().GetMessageErrorRate();
+    mRxOnWhenIdle       = aChild.IsRxOnWhenIdle();
+    mSecureDataRequest  = aChild.IsSecureDataRequest();
+    mFullThreadDevice   = aChild.IsFullThreadDevice();
+    mFullNetworkData    = aChild.IsFullNetworkData();
+    mIsStateRestoring   = aChild.IsStateRestoring();
 }
 
 const Ip6::Address *Child::AddressIterator::GetAddress(void) const
@@ -342,6 +382,21 @@ void Child::SetAddressMlrState(const Ip6::Address &aAddress, MlrState aState)
     mMlrRegisteredMask.Set(addressIndex, aState == kMlrStateRegistered);
 }
 #endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+
+void Router::Info::SetFrom(const Router &aRouter)
+{
+    Clear();
+    mRloc16          = aRouter.GetRloc16();
+    mRouterId        = Mle::Mle::RouterIdFromRloc16(mRloc16);
+    mExtAddress      = aRouter.GetExtAddress();
+    mAllocated       = true;
+    mNextHop         = aRouter.GetNextHop();
+    mLinkEstablished = aRouter.IsStateValid();
+    mPathCost        = aRouter.GetCost();
+    mLinkQualityIn   = aRouter.GetLinkInfo().GetLinkQuality();
+    mLinkQualityOut  = aRouter.GetLinkQualityOut();
+    mAge             = static_cast<uint8_t>(Time::MsecToSec(TimerMilli::GetNow() - aRouter.GetLastHeard()));
+}
 
 void Router::Clear(void)
 {

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/thread_ftd.h>
 
+#include "common/clearable.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/random.hpp"
@@ -88,6 +89,22 @@ public:
         kInStateValidOrAttaching,          ///< Accept child with `IsStateValidOrAttaching()` being `true`.
         kInStateAnyExceptInvalid,          ///< Accept child in any state except `kStateInvalid`.
         kInStateAnyExceptValidOrRestoring, ///< Accept child in any state except `IsStateValidOrRestoring()`.
+    };
+
+    /**
+     * This type represents diagnostic information for a neighboring node.
+     *
+     */
+    class Info : public otNeighborInfo, public Clearable<Info>
+    {
+    public:
+        /**
+         * This method sets the `Info` instance from a given `Neighbor`.
+         *
+         * @param[in] aNeighbor   A neighbor.
+         *
+         */
+        void SetFrom(const Neighbor &aNeighbor);
     };
 
     /**
@@ -413,6 +430,14 @@ public:
     LinkQualityInfo &GetLinkInfo(void) { return mLinkInfo; }
 
     /**
+     * This method returns the LinkQualityInfo object.
+     *
+     * @returns The LinkQualityInfo object.
+     *
+     */
+    const LinkQualityInfo &GetLinkInfo(void) const { return mLinkInfo; }
+
+    /**
      * This method generates a new challenge value for MLE Link Request/Response exchanges.
      *
      */
@@ -503,6 +528,22 @@ public:
     enum
     {
         kMaxRequestTlvs = 5,
+    };
+
+    /**
+     * This class represents diagnostic information for a Thread Child.
+     *
+     */
+    class Info : public otChildInfo, public Clearable<Info>
+    {
+    public:
+        /**
+         * This method sets the `Info` instance from a given `Child`.
+         *
+         * @param[in] aChild   A neighbor.
+         *
+         */
+        void SetFrom(const Child &aChild);
     };
 
     /**
@@ -986,6 +1027,22 @@ private:
 class Router : public Neighbor
 {
 public:
+    /**
+     * This class represents diagnostic information for a Thread Router.
+     *
+     */
+    class Info : public otRouterInfo, public Clearable<Info>
+    {
+    public:
+        /**
+         * This method sets the `Info` instance from a given `Router`.
+         *
+         * @param[in] aRouter   A router.
+         *
+         */
+        void SetFrom(const Router &aRouter);
+    };
+
     /**
      * This method initializes the `Router` object.
      *


### PR DESCRIPTION
This commit adds new class definitions in `topology` to represent
neighbor/child/router info.