### PR TITLE
[tests]  add build test for OT_ASSERT=OFF

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -30,7 +30,7 @@ option(OT_APP_CLI "enable CLI app" ON)
 option(OT_APP_NCP "enable NCP app" ON)
 option(OT_APP_RCP "enable RCP app" ON)
 
-option(OT_ASSERT "enable OT_ASSERT" ON)
+option(OT_ASSERT "enable assert function OT_ASSERT()" ON)
 if(OT_ASSERT)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_ASSERT_ENABLE=1")
 else()

--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -30,6 +30,13 @@ option(OT_APP_CLI "enable CLI app" ON)
 option(OT_APP_NCP "enable NCP app" ON)
 option(OT_APP_RCP "enable RCP app" ON)
 
+option(OT_ASSERT "enable OT_ASSERT" ON)
+if(OT_ASSERT)
+    target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_ASSERT_ENABLE=1")
+else()
+    target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_ASSERT_ENABLE=0")
+endif()
+
 option(OT_BACKBONE_ROUTER "enable backbone router functionality")
 if(OT_BACKBONE_ROUTER)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE=1")

--- a/script/check-simulation-build-cmake
+++ b/script/check-simulation-build-cmake
@@ -42,6 +42,8 @@ build_all_features()
     "$(dirname "$0")"/cmake-build simulation
     reset_source
     "$(dirname "$0")"/cmake-build simulation -DOT_OTNS=ON -DOT_SIMULATION_VIRTUAL_TIME=ON
+    reset_source
+    "$(dirname "$0")"/cmake-build simulation -DOT_OTNS=ON -DOT_SIMULATION_VIRTUAL_TIME=ON -DOT_ASSERT=OFF
 }
 
 build_toranj()

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -1184,7 +1184,7 @@ otError TxFrame::GenerateEnhAck(const RxFrame &aFrame, bool aIsFramePending, con
     // Set frame length
     footerLength = GetFooterLength();
     OT_ASSERT(footerLength != kInvalidIndex);
-    mLength = SkipSecurityHeaderIndex() + aIeLength + GetFooterLength();
+    mLength = SkipSecurityHeaderIndex() + aIeLength + footerLength;
 
 exit:
     return error;

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -79,6 +79,7 @@ void Otns::EmitStatus(const char *aFmt, ...)
     va_start(ap, aFmt);
 
     n = vsnprintf(statusStr, sizeof(statusStr), aFmt, ap);
+    OT_UNUSED_VARIABLE(n);
     OT_ASSERT(n >= 0);
 
     va_end(ap);


### PR DESCRIPTION
This PR adds a build test without OT_ASSERT to catch compile issues. 

- [x] Add cmake option: `OT_ASSERT=ON`
- [x] Add build test with OT_ASSERT=OFF
- [x] Fixes 2 compile errors.