### PR TITLE
[build] add SPINEL_ENCRYPTER_LIBS option to common switches

### DIFF
--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -283,6 +283,10 @@ ifeq ($(OTNS),1)
 COMMONCFLAGS += -DOPENTHREAD_CONFIG_OTNS_ENABLE=1
 endif
 
+ifneq ($(SPINEL_ENCRYPTER_LIBS),)
+configure_OPTIONS              += --with-ncp-spinel-encrypter-libs=$(SPINEL_ENCRYPTER_LIBS)
+endif
+
 ifeq ($(FULL_LOGS),1)
 # HINT: Add more here, or comment out ones you do not need/want
 LOG_FLAGS += -DOPENTHREAD_CONFIG_LOG_LEVEL=OT_LOG_LEVEL_DEBG


### PR DESCRIPTION
This option allows to pass Spinel Encrypter library to predefined Makefiles for different platforms.

Example usage:
```
make -f examples/Makefile-nrf52840 SPINEL_ENCRYPTER_LIBS=my_encrypter_lib.a
```