### PR TITLE
[mlr] configure MLR.req response status

### DIFF
--- a/include/openthread/backbone_router_ftd.h
+++ b/include/openthread/backbone_router_ftd.h
@@ -194,6 +194,18 @@ void otBackboneRouterConfigNextDuaRegistrationResponse(otInstance *             
                                                        uint8_t                         aStatus);
 
 /**
+ * This method configures response status for next Multicast Listener Registration.
+ *
+ * Note: available only when `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is enabled.
+ *       Only used for test and certification.
+ *
+ * @param[in] aInstance  A pointer to an OpenThread instance.
+ * @param[in] aStatus    The status to respond.
+ *
+ */
+void otBackboneRouterConfigNextMulticastListenerRegistrationResponse(otInstance *aInstance, uint8_t aStatus);
+
+/**
  * Represents the Multicast Listener events.
  *
  */

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -185,6 +185,26 @@ Done
 Done
 ```
 
+### bbr mgmt mlr response \<status\>
+
+Configure the response status for the next MLR.req.
+
+Only for testing/reference device.
+
+Known status values:
+
+- 0: ST_MLR_SUCCESS
+- 2: ST_MLR_INVALID
+- 3: ST_MLR_NO_PERSISTENT
+- 4: ST_MLR_NO_RESOURCES
+- 5: ST_MLR_BBR_NOT_PRIMARY
+- 6: ST_MLR_GENERAL_FAILURE
+
+```bash
+> bbr mgmt mlr response 2
+Done
+```
+
 ### bbr state
 
 Show local Backbone state ([`Disabled`,`Primary`, `Secondary`]) for Thread 1.2 FTD.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -605,6 +605,19 @@ otError Interpreter::ProcessBackboneRouterMgmtMlr(uint8_t aArgsLength, char **aA
             error = otBackboneRouterMulticastListenerAdd(mInstance, &address, timeout);
         }
     }
+    else if (!strcmp(aArgs[0], "response"))
+    {
+        unsigned long value;
+
+        VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
+        SuccessOrExit(error = ParseUnsignedLong(aArgs[1], value));
+
+        otBackboneRouterConfigNextMulticastListenerRegistrationResponse(mInstance, static_cast<uint8_t>(value));
+    }
+    else
+    {
+        error = OT_ERROR_INVALID_COMMAND;
+    }
 
 exit:
     return error;

--- a/src/core/api/backbone_router_ftd_api.cpp
+++ b/src/core/api/backbone_router_ftd_api.cpp
@@ -131,6 +131,16 @@ void otBackboneRouterConfigNextDuaRegistrationResponse(otInstance *             
         static_cast<const Ip6::InterfaceIdentifier *>(aMlIid), aStatus);
 }
 
+void otBackboneRouterConfigNextMulticastListenerRegistrationResponse(otInstance *aInstance, uint8_t aStatus)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    OT_ASSERT(aStatus <= ThreadStatusTlv::kMlrStatusMax);
+
+    instance.Get<BackboneRouter::Manager>().ConfigNextMulticastListenerRegistratioinResponse(
+        static_cast<ThreadStatusTlv::MlrStatus>(aStatus));
+}
+
 void otBackboneRouterMulticastListenerClear(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);

--- a/src/core/api/backbone_router_ftd_api.cpp
+++ b/src/core/api/backbone_router_ftd_api.cpp
@@ -137,7 +137,7 @@ void otBackboneRouterConfigNextMulticastListenerRegistrationResponse(otInstance 
 
     OT_ASSERT(aStatus <= ThreadStatusTlv::kMlrStatusMax);
 
-    instance.Get<BackboneRouter::Manager>().ConfigNextMulticastListenerRegistratioinResponse(
+    instance.Get<BackboneRouter::Manager>().ConfigNextMulticastListenerRegistrationResponse(
         static_cast<ThreadStatusTlv::MlrStatus>(aStatus));
 }
 

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -303,7 +303,7 @@ void Manager::ConfigNextDuaRegistrationResponse(const Ip6::InterfaceIdentifier *
     mDuaResponseStatus = static_cast<ThreadStatusTlv::DuaStatus>(aStatus);
 }
 
-void Manager::ConfigNextMulticastListenerRegistratioinResponse(ThreadStatusTlv::MlrStatus aStatus)
+void Manager::ConfigNextMulticastListenerRegistrationResponse(ThreadStatusTlv::MlrStatus aStatus)
 {
     mMlrResponseIsSpecified = true;
     mMlrResponseStatus      = aStatus;

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -57,7 +57,9 @@ Manager::Manager(Instance &aInstance)
     , mTimer(aInstance, Manager::HandleTimer, this)
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     , mDuaResponseStatus(ThreadStatusTlv::kDuaSuccess)
+    , mMlrResponseStatus(ThreadStatusTlv::kMlrSuccess)
     , mDuaResponseIsSpecified(false)
+    , mMlrResponseIsSpecified(false)
 #endif
 {
 }
@@ -106,9 +108,17 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
 
     VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, error = OT_ERROR_PARSE);
 
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    // Required by Test Specification 5.10.22 DUA-TC-26, only for certification purpose
+    if (mMlrResponseIsSpecified)
+    {
+        mMlrResponseIsSpecified = false;
+        ExitNow(status = mMlrResponseStatus);
+    }
+#endif
+
     VerifyOrExit(isPrimary, status = ThreadStatusTlv::kMlrBbrNotPrimary);
 
-    // TODO: (MLR) send configured MLR response for Reference Device
     // TODO: (MLR) handle Commissioner Session TLV
     // TODO: (MLR) handle Timeout TLV
 
@@ -291,6 +301,12 @@ void Manager::ConfigNextDuaRegistrationResponse(const Ip6::InterfaceIdentifier *
     }
 
     mDuaResponseStatus = static_cast<ThreadStatusTlv::DuaStatus>(aStatus);
+}
+
+void Manager::ConfigNextMulticastListenerRegistratioinResponse(ThreadStatusTlv::MlrStatus aStatus)
+{
+    mMlrResponseIsSpecified = true;
+    mMlrResponseStatus      = aStatus;
 }
 #endif
 

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -80,6 +80,18 @@ public:
      *
      */
     void ConfigNextDuaRegistrationResponse(const Ip6::InterfaceIdentifier *aMlIid, uint8_t aStatus);
+
+    /**
+     * This method configures response status for next Multicast Listener Registration.
+     *
+     * Note: available only when `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is enabled.
+     *       Only used for test and certification.
+     *
+     * @param[in] aStatus  The status to respond.
+     *
+     */
+    void ConfigNextMulticastListenerRegistratioinResponse(ThreadStatusTlv::MlrStatus aStatus);
+
 #endif
 
     /**
@@ -135,7 +147,9 @@ private:
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     Ip6::InterfaceIdentifier   mDuaResponseTargetMlIid;
     ThreadStatusTlv::DuaStatus mDuaResponseStatus;
+    ThreadStatusTlv::MlrStatus mMlrResponseStatus;
     bool                       mDuaResponseIsSpecified : 1;
+    bool                       mMlrResponseIsSpecified : 1;
 #endif
 };
 

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -90,7 +90,7 @@ public:
      * @param[in] aStatus  The status to respond.
      *
      */
-    void ConfigNextMulticastListenerRegistratioinResponse(ThreadStatusTlv::MlrStatus aStatus);
+    void ConfigNextMulticastListenerRegistrationResponse(ThreadStatusTlv::MlrStatus aStatus);
 
 #endif
 

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -134,6 +134,7 @@ public:
         kMlrNoResources    = 4, ///< BBR resource shortage.
         kMlrBbrNotPrimary  = 5, ///< BBR is not Primary at this moment.
         kMlrGeneralFailure = 6, ///< Reason(s) for failure are not further specified.
+        kMlrStatusMax      = 6, ///< Max MLR status.
     };
 
     /**

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -40,7 +40,7 @@ import time
 import unittest
 import binascii
 
-from typing import Union
+from typing import Union, Dict
 
 
 class Node:
@@ -530,7 +530,7 @@ class Node:
         self.send_command(cmd)
         self._expect('Done')
 
-    def multicast_listener_list(self):
+    def multicast_listener_list(self) -> Dict[ipaddress.IPv6Address, int]:
         cmd = 'bbr mgmt mlr listener'
         self.send_command(cmd)
 
@@ -558,6 +558,11 @@ class Node:
         cmd = f'bbr mgmt mlr listener add {ip.compressed} {timeout}'
         self.send_command(cmd)
         self._expect(r"(Done|Error .*)")
+
+    def set_next_mlr_response(self, status: int):
+        cmd = 'bbr mgmt mlr response {}'.format(status)
+        self.send_command(cmd)
+        self._expect('Done')
 
     def set_link_quality(self, addr, lqi):
         cmd = 'macfilter rss add-lqi %s %s' % (addr, lqi)


### PR DESCRIPTION
This PR allows BBR to configure response status for MLR.req (based on #5292):

**Please only review the last commit.**

- [x] Add configure API: `otBackboneRouterConfigNextMulticastListenerRegistrationResponse`
- [x] Add CLI command: `bbr mgmt mlr response <status>`
- [x] Add related tests. 

**Only for reference Backbone Router device.**

**MLR PR List:**
- https://github.com/openthread/ot-br-posix/pull/532 add multicast forwarding for MLR Listeners
- https://github.com/openthread/openthread/pull/5346 Add Commissioner API to register Multicast Listeners 
- https://github.com/openthread/openthread/pull/5350 Configure MLR.req response status **<== This PR**
- https://github.com/openthread/openthread/pull/5388 send BMLR.ntf on Backbone link
- ~~https://github.com/openthread/openthread/pull/5292 Add MulticastListenersTable on BBR  **MERGED**~~
- ~~#5248 Send MLR.req for locally Netfi MAs **MERGED**~~
- ~~#5250 Add the `MLR` log region  **MERGED**~~
- ~~https://github.com/openthread/openthread/pull/5236 Parent send MLR.req on behave of Children **MERGED**~~