### PR TITLE
[build] exclude URL library where unused

### DIFF
--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -32,7 +32,10 @@ SUBDIRS                                 = \
     hdlc                                  \
     platform                              \
     spinel                                \
-    url                                   \
     $(NULL)
+
+if OPENTHREAD_PLATFORM_POSIX
+SUBDIRS                                += url
+endif
 
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/lib/url/CMakeLists.txt
+++ b/src/lib/url/CMakeLists.txt
@@ -26,7 +26,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-add_library(openthread-url
+add_library(openthread-url EXCLUDE_FROM_ALL
     url.cpp
 )
 


### PR DESCRIPTION
This sets the URL library to be included only in POSIX builds, removing unnecessary dependencies.