### PR TITLE
[mle] log handling parent request failures

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1673,7 +1673,7 @@ void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageI
 
     if (child == nullptr)
     {
-        VerifyOrExit((child = mChildTable.GetNewChild()) != nullptr, OT_NOOP);
+        VerifyOrExit((child = mChildTable.GetNewChild()) != nullptr, error = OT_ERROR_NO_BUFS);
 
         // MAC Address
         child->SetExtAddress(extAddr);
@@ -1997,6 +1997,7 @@ exit:
     if (error != OT_ERROR_NONE && message != nullptr)
     {
         message->Free();
+        otLogWarnMle("Failed to send Parent Response: %s", otThreadErrorToString(error));
     }
 }
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1994,10 +1994,14 @@ void MleRouter::SendParentResponse(Child *aChild, const Challenge &aChallenge, b
 
 exit:
 
-    if (error != OT_ERROR_NONE && message != nullptr)
+    if (error != OT_ERROR_NONE)
     {
-        message->Free();
         otLogWarnMle("Failed to send Parent Response: %s", otThreadErrorToString(error));
+
+        if (message != nullptr)
+        {
+            message->Free();
+        }
     }
 }
 


### PR DESCRIPTION
This commit adds a few logs when handling MLE Parent Request, so that when a child failed to receive a response, the logs can tell what happened.