### PR TITLE
[otns] implement `otPlatOtnsStatus` for posix

### DIFF
--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -212,4 +212,4 @@ void otPlatOtnsStatus(const char *aStatus)
     otLogOtns("[OTNS] %s", aStatus);
 }
 
-#endif // OPENTHREAD_CONFIG_OTNS_ENABLE
+#endif

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -40,6 +40,7 @@
 #include <openthread-core-config.h>
 #include <openthread/tasklet.h>
 #include <openthread/platform/alarm-milli.h>
+#include <openthread/platform/otns.h>
 #include <openthread/platform/radio.h>
 #include <openthread/platform/uart.h>
 
@@ -203,3 +204,12 @@ void otSysMainloopProcess(otInstance *aInstance, const otSysMainloopContext *aMa
     platformUdpProcess(aInstance, &aMainloop->mReadFdSet);
 #endif
 }
+
+#if OPENTHREAD_CONFIG_OTNS_ENABLE
+
+void otPlatOtnsStatus(const char *aStatus)
+{
+    otLogOtns("[OTNS] %s", aStatus);
+}
+
+#endif // OPENTHREAD_CONFIG_OTNS_ENABLE


### PR DESCRIPTION
This PR generates `[OTNS]` logs:
```
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] extaddr=7ac54b174025345b
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] rloc16=65534
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] rloc16=30720
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] extaddr=46ce26bba9f0b764
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] transmit=11,d849,128,ffff
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] transmit=11,d849,129,ffff
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] rloc16=30720
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] role=1
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] transmit=11,d841,130,ffff
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] transmit=11,d859,131,ffff
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] transmit=11,d849,132,ffff
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] rloc16=65534
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] transmit=11,d841,133,ffff
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] transmit=11,d841,134,ffff
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] rloc16=30720
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] role=4
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] parid=6efcbdc3
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] transmit=11,d841,135,ffff
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] transmit=11,d859,136,ffff
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] transmit=11,d849,137,ffff
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] transmit=11,d841,138,ffff
./cmake-build-debug/src/posix/ot-daemon[13954]: [NONE][OTNS] transmit=11,d841,139,ffff
```

**This is required by `Silk+OTNS Integration` to work with `ot-daemon`.**