### PR TITLE
[notifier] declare 'Notifier::Receiver' constructor as protected

### DIFF
--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -53,7 +53,7 @@ namespace BackboneRouter {
  * This class implements the definitions for Backbone Router management.
  *
  */
-class Manager : public InstanceLocator, public Notifier::Receiver
+class Manager : public InstanceLocator, private Notifier::Receiver
 {
 public:
     /**

--- a/src/core/common/notifier.hpp
+++ b/src/core/common/notifier.hpp
@@ -208,7 +208,7 @@ public:
         friend class Notifier;
         friend class LinkedListEntry<Receiver>;
 
-    public:
+    protected:
         /**
          * This type defines the function reference which is invoked to notify of events (state/configuration changes)..
          *

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -49,7 +49,7 @@ class ThreadNetif;
 
 namespace MeshCoP {
 
-class BorderAgent : public InstanceLocator, public Notifier::Receiver
+class BorderAgent : public InstanceLocator, private Notifier::Receiver
 {
 public:
     /**

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -51,7 +51,7 @@ namespace ot {
 
 namespace MeshCoP {
 
-class JoinerRouter : public InstanceLocator, public Notifier::Receiver
+class JoinerRouter : public InstanceLocator, private Notifier::Receiver
 {
 public:
     /**

--- a/src/core/thread/announce_sender.hpp
+++ b/src/core/thread/announce_sender.hpp
@@ -134,7 +134,7 @@ private:
  * This class implements an AnnounceSender.
  *
  */
-class AnnounceSender : public AnnounceSenderBase, public Notifier::Receiver
+class AnnounceSender : public AnnounceSenderBase, private Notifier::Receiver
 {
 public:
     /**

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -70,7 +70,7 @@ namespace ot {
  * This class implements managing DUA.
  *
  */
-class DuaManager : public InstanceLocator, public Notifier::Receiver
+class DuaManager : public InstanceLocator, private Notifier::Receiver
 {
 public:
     /**

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -50,7 +50,7 @@ namespace ot {
  * This class implements handling Energy Scan Requests.
  *
  */
-class EnergyScanServer : public InstanceLocator, public Notifier::Receiver
+class EnergyScanServer : public InstanceLocator, private Notifier::Receiver
 {
 public:
     /**

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -305,7 +305,7 @@ private:
  * This class implements MLE functionality required by the Thread EndDevices, Router, and Leader roles.
  *
  */
-class Mle : public InstanceLocator, public Notifier::Receiver
+class Mle : public InstanceLocator, private Notifier::Receiver
 {
     friend class DiscoverScanner;
 

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -67,7 +67,7 @@ namespace ot {
  * This class implements MLR management.
  *
  */
-class MlrManager : public InstanceLocator, public Notifier::Receiver
+class MlrManager : public InstanceLocator, private Notifier::Receiver
 {
 public:
     /**

--- a/src/core/thread/network_data_notifier.hpp
+++ b/src/core/thread/network_data_notifier.hpp
@@ -49,7 +49,7 @@ namespace NetworkData {
  * This class implements the SVR_DATA.ntf transmission logic.
  *
  */
-class Notifier : public InstanceLocator, public ot::Notifier::Receiver
+class Notifier : public InstanceLocator, private ot::Notifier::Receiver
 {
 public:
     /**

--- a/src/core/thread/time_sync_service.hpp
+++ b/src/core/thread/time_sync_service.hpp
@@ -50,7 +50,7 @@ namespace ot {
  * This class implements OpenThread Time Synchronization Service.
  *
  */
-class TimeSync : public InstanceLocator, public Notifier::Receiver
+class TimeSync : public InstanceLocator, private Notifier::Receiver
 {
 public:
     /**

--- a/src/core/utils/channel_manager.hpp
+++ b/src/core/utils/channel_manager.hpp
@@ -64,7 +64,7 @@ namespace Utils {
  * This class implements the Channel Manager.
  *
  */
-class ChannelManager : public InstanceLocator, public Notifier::Receiver, private NonCopyable
+class ChannelManager : public InstanceLocator, private Notifier::Receiver, private NonCopyable
 {
 public:
     enum

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -88,7 +88,7 @@ namespace Utils {
  * This class implements a child supervisor.
  *
  */
-class ChildSupervisor : public InstanceLocator, public Notifier::Receiver
+class ChildSupervisor : public InstanceLocator, private Notifier::Receiver
 {
 public:
     /**

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -48,7 +48,7 @@ class ThreadNetif;
 
 namespace Utils {
 
-class JamDetector : public InstanceLocator, public Notifier::Receiver
+class JamDetector : public InstanceLocator, private Notifier::Receiver
 {
 public:
     /**

--- a/src/core/utils/otns.hpp
+++ b/src/core/utils/otns.hpp
@@ -56,7 +56,7 @@ namespace Utils {
  * This class implements the OTNS Stub that interacts with OTNS.
  *
  */
-class Otns : public InstanceLocator, public Notifier::Receiver, private NonCopyable
+class Otns : public InstanceLocator, private Notifier::Receiver, private NonCopyable
 {
 public:
     /**

--- a/src/core/utils/slaac_address.hpp
+++ b/src/core/utils/slaac_address.hpp
@@ -57,7 +57,7 @@ namespace Utils {
  * This class implements the SLAAC utility for Thread protocol.
  *
  */
-class Slaac : public InstanceLocator, public Notifier::Receiver
+class Slaac : public InstanceLocator, private Notifier::Receiver
 {
 public:
     enum


### PR DESCRIPTION
This commit declares the `Notifier::Receiver` constructor and
`Handler` type as `protected` (ensures `Receiver` can only be
sub-classed). It also changes the subclasses to privately inherit from
 `Notifier::Receiver` (this helps hide the `Handler` definition).