### PR TITLE
[build] add option to build 1.2 alone

### DIFF
--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -50,6 +50,7 @@ jobs:
       COVERAGE: 1
       THREAD_VERSION: 1.2
       VIRTUAL_TIME: 1
+      INTER_OP: 1
       CC: ${{ matrix.compiler.c }}
       CXX: ${{ matrix.compiler.cxx }}
     strategy:

--- a/script/test
+++ b/script/test
@@ -43,6 +43,7 @@ readonly NODE_MODE="${NODE_MODE:-standalone}"
 readonly NODE_TYPE="${NODE_TYPE:-sim}"
 readonly OT_NATIVE_IP="${OT_NATIVE_IP:-0}"
 readonly THREAD_VERSION="${THREAD_VERSION:-1.1}"
+readonly INTER_OP="${INTER_OP:-0}"
 readonly VERBOSE="${VERBOSE:-0}"
 
 build_simulation()
@@ -115,21 +116,23 @@ build_posix()
     fi
 }
 
-do_build()
+build_for_one_version()
 {
-    build_simulation "${THREAD_VERSION}"
+    local version="$1"
+
+    build_simulation "${version}"
 
     if [[ ${NODE_MODE} == "rcp" ]]; then
-        build_posix "${THREAD_VERSION}"
+        build_posix "${version}"
     fi
+}
 
-    # Extra 1.1 build for 1.2 tests
-    if [[ ${THREAD_VERSION} == "1.2" ]]; then
-        build_simulation 1.1
+do_build()
+{
+    build_for_one_version "${THREAD_VERSION}"
 
-        if [[ ${NODE_MODE} == "rcp" ]]; then
-            build_posix 1.1
-        fi
+    if [[ ${THREAD_VERSION} == "1.2" && ${INTER_OP} == "1" ]]; then
+        build_for_one_version 1.1
     fi
 }
 
@@ -155,8 +158,10 @@ do_cert()
     export top_builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}"
 
     if [[ ${THREAD_VERSION} == "1.2" ]]; then
-        export top_builddir_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1"
         export top_builddir_1_2_bbr="${OT_BUILDDIR}/cmake/openthread-simulation-1.2-bbr"
+        if [[ ${INTER_OP} == "1" ]]; then
+            export top_builddir_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1"
+        fi
     fi
 
     [[ ! -d tmp ]] || rm -rvf tmp
@@ -168,8 +173,10 @@ do_cert_suite()
     export top_builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}"
 
     if [[ ${THREAD_VERSION} == "1.2" ]]; then
-        export top_builddir_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1"
         export top_builddir_1_2_bbr="${OT_BUILDDIR}/cmake/openthread-simulation-1.2-bbr"
+        if [[ ${INTER_OP} == "1" ]]; then
+            export top_builddir_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1"
+        fi
     fi
 
     local pass_count=0
@@ -269,6 +276,7 @@ ENVIRONMENTS:
     VERBOSE         1 to build or test verbosely. The default is 0.
     VIRTUAL_TIME    1 for virtual time, otherwise real time. The default is 1.
     THREAD_VERSION  1.1 for Thread 1.1 stack, 1.2 for Thread 1.2 stack. The default is 1.1.
+    INTER_OP        1 to build 1.1 together. Only works when THREAD_VERSION is 1.2.
 
 COMMANDS:
     clean           Clean built files to prepare for new build.
@@ -296,9 +304,10 @@ EXAMPLES:
     VIRTUAL_TIME=0 $0 clean build cert tests/scripts/thread-cert/Cert_5_1_01_RouterAttach.py
     VIRTUAL_TIME=0 $0 cert tests/scripts/thread-cert/Cert_5_1_02_ChildAddressTimeout.py
 
-    # Test Thread 1.2 with real time
-    THREAD_VERSION=1.2 VIRTUAL_TIME=0 $0 clean build cert tests/scripts/thread-cert/v1_2_router_5_1_1.py
-    THREAD_VERSION=1.2 VIRTUAL_TIME=0 $0 clean build cert_suite tests/scripts/thread-cert/v1_2_*
+    # Test Thread 1.2 with real time, use 'INTER_OP=1' when the case needs both versions.
+    THREAD_VERSION=1.2 VIRTUAL_TIME=0 $0 clean build cert tests/scripts/thread-cert/v1_2_test_enhanced_keep_alive.py
+    THREAD_VERSION=1.2 INTER_OP=1 VIRTUAL_TIME=0 $0 clean build cert tests/scripts/thread-cert/v1_2_router_5_1_1.py
+    THREAD_VERSION=1.2 INTER_OP=1 VIRTUAL_TIME=0 $0 clean build cert_suite tests/scripts/thread-cert/v1_2_*
 
     # Run a single expect test
     $0 clean build expect tests/scripts/expect/cli-log-level.exp

--- a/script/test
+++ b/script/test
@@ -276,7 +276,7 @@ ENVIRONMENTS:
     VERBOSE         1 to build or test verbosely. The default is 0.
     VIRTUAL_TIME    1 for virtual time, otherwise real time. The default is 1.
     THREAD_VERSION  1.1 for Thread 1.1 stack, 1.2 for Thread 1.2 stack. The default is 1.1.
-    INTER_OP        1 to build 1.1 together. Only works when THREAD_VERSION is 1.2.
+    INTER_OP        1 to build 1.1 together. Only works when THREAD_VERSION is 1.2. The default is 0.
 
 COMMANDS:
     clean           Clean built files to prepare for new build.


### PR DESCRIPTION
Currently `script/test` can only build 1.2 together with 1.1. This PR add supports to build 1.2 alone. And when `THREAD_VERSION=1.2` and `INTER_OP=1` are both set, both versions would be built. Sometimes we only want to build 1.2. This would save some time for us.