### PR TITLE
[notifier] simplify how 'Notifier' emits events to core/internal modules

### DIFF
--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -51,7 +51,6 @@ namespace BackboneRouter {
 
 Manager::Manager(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , Notifier::Receiver(aInstance, Manager::HandleNotifierEvents)
     , mMulticastListenerRegistration(OT_URI_PATH_MLR, Manager::HandleMulticastListenerRegistration, this)
     , mDuaRegistration(OT_URI_PATH_DUA_REGISTRATION_REQUEST, Manager::HandleDuaRegistration, this)
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -53,8 +53,10 @@ namespace BackboneRouter {
  * This class implements the definitions for Backbone Router management.
  *
  */
-class Manager : public InstanceLocator, public Notifier::Receiver
+class Manager : public InstanceLocator
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * This constructor initializes the Backbone Router manager.
@@ -102,11 +104,6 @@ private:
                                      const Ip6::MessageInfo &   aMessageInfo,
                                      const Ip6::Address &       aTarget,
                                      ThreadStatusTlv::DuaStatus aStatus);
-
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-    {
-        static_cast<Manager &>(aReceiver).HandleNotifierEvents(aEvents);
-    }
     void HandleNotifierEvents(Events aEvents);
 
     Coap::Resource mMulticastListenerRegistration;

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -40,30 +40,17 @@
 
 namespace ot {
 
-Notifier::Receiver::Receiver(Instance &aInstance, Handler aHandler)
-    : mHandler(aHandler)
-    , mNext(nullptr)
-{
-    aInstance.Get<Notifier>().RegisterReceiver(*this);
-}
-
 Notifier::Notifier(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mEventsToSignal()
     , mSignaledEvents()
     , mTask(aInstance, Notifier::EmitEvents, this)
-    , mReceivers()
 {
     for (ExternalCallback &callback : mExternalCallbacks)
     {
         callback.mHandler = nullptr;
         callback.mContext = nullptr;
     }
-}
-
-void Notifier::RegisterReceiver(Receiver &aReceiver)
-{
-    mReceivers.Push(aReceiver);
 }
 
 otError Notifier::RegisterCallback(otStateChangedCallback aCallback, void *aContext)
@@ -148,10 +135,49 @@ void Notifier::EmitEvents(void)
 
     LogEvents(events);
 
-    for (Receiver *receiver = mReceivers.GetHead(); receiver != nullptr; receiver = receiver->GetNext())
-    {
-        receiver->Emit(events);
-    }
+    // Emit events to core internal modules
+
+    Get<Mle::Mle>().HandleNotifierEvents(events);
+    Get<EnergyScanServer>().HandleNotifierEvents(events);
+#if OPENTHREAD_FTD
+    Get<MeshCoP::JoinerRouter>().HandleNotifierEvents(events);
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+    Get<BackboneRouter::Manager>().HandleNotifierEvents(events);
+#endif
+#if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
+    Get<Utils::ChildSupervisor>().HandleNotifierEvents(events);
+#endif
+#if OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE
+    Get<Utils::ChannelManager>().HandleNotifierEvents(events);
+#endif
+#endif // OPENTHREAD_FTD
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+    Get<NetworkData::Notifier>().HandleNotifierEvents(events);
+#endif
+#if OPENTHREAD_CONFIG_ANNOUNCE_SENDER_ENABLE
+    Get<AnnounceSender>().HandleNotifierEvents(events);
+#endif
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
+    Get<MeshCoP::BorderAgent>().HandleNotifierEvents(events);
+#endif
+#if OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+    Get<MlrManager>().HandleNotifierEvents(events);
+#endif
+#if OPENTHREAD_CONFIG_DUA_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE
+    Get<DuaManager>().HandleNotifierEvents(events);
+#endif
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    Get<TimeSync>().HandleNotifierEvents(events);
+#endif
+#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
+    Get<Utils::Slaac>().HandleNotifierEvents(events);
+#endif
+#if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
+    Get<Utils::JamDetector>().HandleNotifierEvents(events);
+#endif
+#if OPENTHREAD_CONFIG_OTNS_ENABLE
+    Get<Utils::Otns>().HandleNotifierEvents(events);
+#endif
 
     for (ExternalCallback &callback : mExternalCallbacks)
     {

--- a/src/core/common/notifier.hpp
+++ b/src/core/common/notifier.hpp
@@ -42,7 +42,6 @@
 #include <openthread/instance.h>
 #include <openthread/platform/toolchain.h>
 
-#include "common/linked_list.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/tasklet.hpp"
@@ -184,56 +183,17 @@ private:
 /**
  * This class implements the OpenThread Notifier.
  *
- * It can be used to register callbacks that notify of state or configuration changes within OpenThread.
+ * For core internal modules, `Notifier` class emits events directly to them by invoking method `HandleNotifierEvents()`
+ * on the module instance.
  *
- * Two callback models are provided:
- *
- * - A `Notifier::Receiver` class which should be inherited by OpenThread core types to register themselves as a
- *    receiver of `Notifier` events.
- *
- * - A `otStateChangedCallback` callback handler which needs to be explicitly registered with the `Notifier`. This is
- *   commonly used by external users (provided as an OpenThread public API). Max number of such callbacks that can be
- *   registered at the same time is specified by `OPENTHREAD_CONFIG_MAX_STATECHANGE_HANDLERS` configuration parameter.
+ * A `otStateChangedCallback` callback can be explicitly registered with the `Notifier`. This is mainly intended for use
+ * by external users (i.e.provided as an OpenThread public API). Max number of such callbacks that can be registered at
+ * the same time is specified by `OPENTHREAD_CONFIG_MAX_STATECHANGE_HANDLERS` configuration parameter.
  *
  */
 class Notifier : public InstanceLocator, private NonCopyable
 {
 public:
-    /**
-     * This class defines a `Notifier::Receiver` instance.
-     *
-     */
-    class Receiver : public LinkedListEntry<Receiver>
-    {
-        friend class Notifier;
-        friend class LinkedListEntry<Receiver>;
-
-    public:
-        /**
-         * This type defines the function reference which is invoked to notify of events (state/configuration changes)..
-         *
-         * @param[in] aReceiver    A reference to `Receiver` instance.
-         * @param[in] aEvents      The list of events.
-         *
-         */
-        typedef void (&Handler)(Receiver &aReceiver, Events aEvents);
-
-        /**
-         * This constructor initializes a `Receiver` instance and registers it with `Notifier`.
-         *
-         * @param[in] aInstance   A reference to OpenThread instance.
-         * @param[in] aHandler    The handler function reference.
-         *
-         */
-        Receiver(Instance &aInstance, Handler aHandler);
-
-    private:
-        void Emit(Events aEvents) { mHandler(*this, aEvents); }
-
-        Handler   mHandler;
-        Receiver *mNext;
-    };
-
     /**
      * This constructor initializes a `Notifier` instance.
      *
@@ -348,18 +308,16 @@ private:
         void *                 mContext;
     };
 
-    void        RegisterReceiver(Receiver &aReceiver);
     static void EmitEvents(Tasklet &aTasklet);
     void        EmitEvents(void);
 
     void        LogEvents(Events aEvents) const;
     const char *EventToString(Event aEvent) const;
 
-    Events               mEventsToSignal;
-    Events               mSignaledEvents;
-    Tasklet              mTask;
-    LinkedList<Receiver> mReceivers;
-    ExternalCallback     mExternalCallbacks[kMaxExternalHandlers];
+    Events           mEventsToSignal;
+    Events           mSignaledEvents;
+    Tasklet          mTask;
+    ExternalCallback mExternalCallbacks[kMaxExternalHandlers];
 };
 
 /**

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -333,7 +333,6 @@ void BorderAgent::HandleRequest<&BorderAgent::mProxyTransmit>(void *            
 
 BorderAgent::BorderAgent(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , Notifier::Receiver(aInstance, BorderAgent::HandleNotifierEvents)
     , mCommissionerPetition(OT_URI_PATH_COMMISSIONER_PETITION,
                             BorderAgent::HandleRequest<&BorderAgent::mCommissionerPetition>,
                             this)
@@ -360,11 +359,6 @@ BorderAgent::BorderAgent(Instance &aInstance)
     mCommissionerAloc.mValid              = true;
     mCommissionerAloc.mScopeOverride      = Ip6::Address::kRealmLocalScope;
     mCommissionerAloc.mScopeOverrideValid = true;
-}
-
-void BorderAgent::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-{
-    static_cast<BorderAgent &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void BorderAgent::HandleNotifierEvents(Events aEvents)

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -49,8 +49,10 @@ class ThreadNetif;
 
 namespace MeshCoP {
 
-class BorderAgent : public InstanceLocator, public Notifier::Receiver
+class BorderAgent : public InstanceLocator
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * This constructor initializes the BorderAgent object.
@@ -93,8 +95,7 @@ public:
     void ApplyMeshLocalPrefix(void);
 
 private:
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
-    void        HandleNotifierEvents(Events aEvents);
+    void HandleNotifierEvents(Events aEvents);
 
     static void HandleConnected(bool aConnected, void *aContext)
     {

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -55,7 +55,6 @@ namespace MeshCoP {
 
 JoinerRouter::JoinerRouter(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , Notifier::Receiver(aInstance, JoinerRouter::HandleNotifierEvents)
     , mSocket(aInstance)
     , mRelayTransmit(OT_URI_PATH_RELAY_TX, &JoinerRouter::HandleRelayTransmit, this)
     , mTimer(aInstance, JoinerRouter::HandleTimer, this)
@@ -63,11 +62,6 @@ JoinerRouter::JoinerRouter(Instance &aInstance)
     , mIsJoinerPortConfigured(false)
 {
     Get<Coap::Coap>().AddResource(mRelayTransmit);
-}
-
-void JoinerRouter::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-{
-    static_cast<JoinerRouter &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void JoinerRouter::HandleNotifierEvents(Events aEvents)

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -51,8 +51,10 @@ namespace ot {
 
 namespace MeshCoP {
 
-class JoinerRouter : public InstanceLocator, public Notifier::Receiver
+class JoinerRouter : public InstanceLocator
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * This constructor initializes the Joiner Router object.
@@ -94,8 +96,7 @@ private:
         Kek              mKek;         // KEK used by MAC layer to encode this message.
     };
 
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
-    void        HandleNotifierEvents(Events aEvents);
+    void HandleNotifierEvents(Events aEvents);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -112,7 +112,6 @@ exit:
 
 AnnounceSender::AnnounceSender(Instance &aInstance)
     : AnnounceSenderBase(aInstance, AnnounceSender::HandleTimer)
-    , Notifier::Receiver(aInstance, AnnounceSender::HandleNotifierEvents)
 {
 }
 
@@ -173,11 +172,6 @@ void AnnounceSender::Stop(void)
 {
     AnnounceSenderBase::Stop();
     otLogInfoMle("Stopping periodic MLE Announcements tx");
-}
-
-void AnnounceSender::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-{
-    static_cast<AnnounceSender &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void AnnounceSender::HandleNotifierEvents(Events aEvents)

--- a/src/core/thread/announce_sender.hpp
+++ b/src/core/thread/announce_sender.hpp
@@ -134,8 +134,10 @@ private:
  * This class implements an AnnounceSender.
  *
  */
-class AnnounceSender : public AnnounceSenderBase, public Notifier::Receiver
+class AnnounceSender : public AnnounceSenderBase
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * This constructor initializes the object.
@@ -157,7 +159,6 @@ private:
     void        CheckState(void);
     void        Stop(void);
     static void HandleTimer(Timer &aTimer);
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
 };
 

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -51,7 +51,6 @@ namespace ot {
 
 DuaManager::DuaManager(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , Notifier::Receiver(aInstance, DuaManager::HandleNotifierEvents)
     , mTimer(aInstance, DuaManager::HandleTimer, this)
     , mRegistrationTask(aInstance, DuaManager::HandleRegistrationTask, this)
     , mDuaNotification(OT_URI_PATH_DUA_REGISTRATION_NOTIFY, &DuaManager::HandleDuaNotification, this)

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -70,8 +70,10 @@ namespace ot {
  * This class implements managing DUA.
  *
  */
-class DuaManager : public InstanceLocator, public Notifier::Receiver
+class DuaManager : public InstanceLocator
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * This constructor initializes the object.
@@ -174,11 +176,6 @@ private:
 #if OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE
     void SendAddressNotification(Ip6::Address &aAddress, ThreadStatusTlv::DuaStatus aStatus, const Child &aChild);
 #endif
-
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-    {
-        static_cast<DuaManager &>(aReceiver).HandleNotifierEvents(aEvents);
-    }
 
     void HandleNotifierEvents(Events aEvents);
 

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -48,7 +48,6 @@ namespace ot {
 
 EnergyScanServer::EnergyScanServer(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , Notifier::Receiver(aInstance, EnergyScanServer::HandleNotifierEvents)
     , mChannelMask(0)
     , mChannelMaskCurrent(0)
     , mPeriod(0)
@@ -210,11 +209,6 @@ exit:
     }
 
     mActive = false;
-}
-
-void EnergyScanServer::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-{
-    static_cast<EnergyScanServer &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void EnergyScanServer::HandleNotifierEvents(Events aEvents)

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -50,8 +50,10 @@ namespace ot {
  * This class implements handling Energy Scan Requests.
  *
  */
-class EnergyScanServer : public InstanceLocator, public Notifier::Receiver
+class EnergyScanServer : public InstanceLocator
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * This constructor initializes the object.
@@ -75,8 +77,7 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
-    void        HandleNotifierEvents(Events aEvents);
+    void HandleNotifierEvents(Events aEvents);
 
     void SendReport(void);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -62,7 +62,6 @@ namespace Mle {
 
 Mle::Mle(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , Notifier::Receiver(aInstance, Mle::HandleNotifierEvents)
     , mRetrieveNewNetworkData(false)
     , mRole(kRoleDisabled)
     , mDeviceMode(DeviceMode::kModeRxOnWhenIdle | DeviceMode::kModeSecureDataRequest)
@@ -1424,11 +1423,6 @@ otError Mle::AppendPendingTimestamp(Message &aMessage)
 
 exit:
     return error;
-}
-
-void Mle::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-{
-    static_cast<Mle &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void Mle::HandleNotifierEvents(Events aEvents)

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -305,9 +305,10 @@ private:
  * This class implements MLE functionality required by the Thread EndDevices, Router, and Leader roles.
  *
  */
-class Mle : public InstanceLocator, public Notifier::Receiver
+class Mle : public InstanceLocator
 {
     friend class DiscoverScanner;
+    friend class ot::Notifier;
 
 public:
     /**
@@ -1663,7 +1664,6 @@ private:
         TimeMilli    mSendTime;    // Time when the message shall be sent.
     };
 
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
     static void HandleAttachTimer(Timer &aTimer);
     void        HandleAttachTimer(void);

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -48,7 +48,6 @@ namespace ot {
 
 MlrManager::MlrManager(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , Notifier::Receiver(aInstance, MlrManager::HandleNotifierEvents)
     , mTimer(aInstance, MlrManager::HandleTimer, this)
     , mReregistrationDelay(0)
     , mSendDelay(0)

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -67,8 +67,10 @@ namespace ot {
  * This class implements MLR management.
  *
  */
-class MlrManager : public InstanceLocator, public Notifier::Receiver
+class MlrManager : public InstanceLocator
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * This constructor initializes the object.
@@ -109,10 +111,6 @@ private:
         kTimerInterval = 1000,
     };
 
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-    {
-        static_cast<MlrManager &>(aReceiver).HandleNotifierEvents(aEvents);
-    }
     void HandleNotifierEvents(Events aEvents);
 
     void SendMulticastListenerRegistration(void);

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -46,7 +46,6 @@ namespace NetworkData {
 
 Notifier::Notifier(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , ot::Notifier::Receiver(aInstance, Notifier::HandleNotifierEvents)
     , mTimer(aInstance, Notifier::HandleTimer, this)
     , mNextDelay(0)
     , mWaitingForResponse(false)
@@ -99,11 +98,6 @@ exit:
         OT_ASSERT(false);
         OT_UNREACHABLE_CODE(break);
     }
-}
-
-void Notifier::HandleNotifierEvents(ot::Notifier::Receiver &aReceiver, Events aEvents)
-{
-    static_cast<Notifier &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void Notifier::HandleNotifierEvents(Events aEvents)

--- a/src/core/thread/network_data_notifier.hpp
+++ b/src/core/thread/network_data_notifier.hpp
@@ -49,8 +49,10 @@ namespace NetworkData {
  * This class implements the SVR_DATA.ntf transmission logic.
  *
  */
-class Notifier : public InstanceLocator, public ot::Notifier::Receiver
+class Notifier : public InstanceLocator
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * Constructor.
@@ -74,8 +76,7 @@ private:
         kDelaySynchronizeServerData = 300000, ///< milliseconds
     };
 
-    static void HandleNotifierEvents(ot::Notifier::Receiver &aReceiver, Events aEvents);
-    void        HandleNotifierEvents(Events aEvents);
+    void HandleNotifierEvents(Events aEvents);
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -51,7 +51,6 @@ namespace ot {
 
 TimeSync::TimeSync(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , Notifier::Receiver(aInstance, TimeSync::HandleNotifierEvents)
     , mTimeSyncRequired(false)
     , mTimeSyncSeq(OT_TIME_SYNC_INVALID_SEQ)
     , mTimeSyncPeriod(OPENTHREAD_CONFIG_TIME_SYNC_PERIOD)
@@ -207,11 +206,6 @@ void TimeSync::HandleNotifierEvents(Events aEvents)
 void TimeSync::HandleTimeout(void)
 {
     CheckAndHandleChanges(false);
-}
-
-void TimeSync::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-{
-    static_cast<TimeSync &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void TimeSync::HandleTimeout(Timer &aTimer)

--- a/src/core/thread/time_sync_service.hpp
+++ b/src/core/thread/time_sync_service.hpp
@@ -50,8 +50,10 @@ namespace ot {
  * This class implements OpenThread Time Synchronization Service.
  *
  */
-class TimeSync : public InstanceLocator, public Notifier::Receiver
+class TimeSync : public InstanceLocator
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * This constructor initializes the object.
@@ -152,14 +154,6 @@ public:
     }
 
     /**
-     * Callback to be called when thread state changes.
-     *
-     * @param[in] aFlags Flags that denote the state change events.
-     *
-     */
-    void HandleNotifierEvents(Events aEvents);
-
-    /**
      * Callback to be called when timer expires.
      *
      */
@@ -169,11 +163,10 @@ private:
     /**
      * Callback to be called when thread state changes.
      *
-     * @param[in] aCallback Callback context.
      * @param[in] aFlags Flags that denote the state change events.
      *
      */
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
+    void HandleNotifierEvents(Events aEvents);
 
     /**
      * Callback to be called when timer expires.

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -48,7 +48,6 @@ namespace Utils {
 
 ChannelManager::ChannelManager(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , Notifier::Receiver(aInstance, ChannelManager::HandleNotifierEvents)
     , mSupportedChannelMask(0)
     , mFavoredChannelMask(0)
     , mActiveTimestamp(0)
@@ -250,11 +249,6 @@ void ChannelManager::HandleTimer(void)
         PreparePendingDataset();
         break;
     }
-}
-
-void ChannelManager::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-{
-    static_cast<ChannelManager &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void ChannelManager::HandleNotifierEvents(Events aEvents)

--- a/src/core/utils/channel_manager.hpp
+++ b/src/core/utils/channel_manager.hpp
@@ -64,8 +64,10 @@ namespace Utils {
  * This class implements the Channel Manager.
  *
  */
-class ChannelManager : public InstanceLocator, public Notifier::Receiver, private NonCopyable
+class ChannelManager : public InstanceLocator, private NonCopyable
 {
+    friend class ot::Notifier;
+
 public:
     enum
     {
@@ -272,7 +274,6 @@ private:
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
     void        PreparePendingDataset(void);
     void        StartAutoSelectTimer(void);

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -49,7 +49,6 @@ namespace Utils {
 
 ChildSupervisor::ChildSupervisor(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , Notifier::Receiver(aInstance, ChildSupervisor::HandleNotifierEvents)
     , mSupervisionInterval(kDefaultSupervisionInterval)
     , mTimer(aInstance, ChildSupervisor::HandleTimer, this)
 {
@@ -158,11 +157,6 @@ void ChildSupervisor::CheckState(void)
         mTimer.Stop();
         otLogInfoUtil("Stopping Child Supervision");
     }
-}
-
-void ChildSupervisor::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-{
-    static_cast<ChildSupervisor &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void ChildSupervisor::HandleNotifierEvents(Events aEvents)

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -88,8 +88,10 @@ namespace Utils {
  * This class implements a child supervisor.
  *
  */
-class ChildSupervisor : public InstanceLocator, public Notifier::Receiver
+class ChildSupervisor : public InstanceLocator
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * This constructor initializes the object.
@@ -161,7 +163,6 @@ private:
     void        CheckState(void);
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
 
     uint16_t   mSupervisionInterval;

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -47,7 +47,6 @@ namespace Utils {
 
 JamDetector::JamDetector(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , Notifier::Receiver(aInstance, JamDetector::HandleNotifierEvents)
     , mHandler(nullptr)
     , mContext(nullptr)
     , mTimer(aInstance, JamDetector::HandleTimer, this)
@@ -269,11 +268,6 @@ void JamDetector::SetJamState(bool aNewState)
     {
         mHandler(mJamState, mContext);
     }
-}
-
-void JamDetector::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-{
-    static_cast<JamDetector &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void JamDetector::HandleNotifierEvents(Events aEvents)

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -48,8 +48,10 @@ class ThreadNetif;
 
 namespace Utils {
 
-class JamDetector : public InstanceLocator, public Notifier::Receiver
+class JamDetector : public InstanceLocator
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * This function pointer is called if jam state changes (assuming jamming detection is enabled).
@@ -190,7 +192,6 @@ private:
     void        HandleTimer(void);
     void        UpdateHistory(bool aDidExceedThreshold);
     void        UpdateJamState(void);
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
 
     Handler    mHandler;                  // Handler/callback to inform about jamming state

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -87,11 +87,6 @@ void Otns::EmitStatus(const char *aFmt, ...)
     otPlatOtnsStatus(statusStr);
 }
 
-void Otns::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-{
-    static_cast<Otns &>(aReceiver).HandleNotifierEvents(aEvents);
-}
-
 void Otns::HandleNotifierEvents(Events aEvents)
 {
     if (aEvents.Contains(kEventThreadRoleChanged))

--- a/src/core/utils/otns.hpp
+++ b/src/core/utils/otns.hpp
@@ -56,8 +56,10 @@ namespace Utils {
  * This class implements the OTNS Stub that interacts with OTNS.
  *
  */
-class Otns : public InstanceLocator, public Notifier::Receiver, private NonCopyable
+class Otns : public InstanceLocator, private NonCopyable
 {
+    friend class ot::Notifier;
+
 public:
     /**
      * This constructor initializes the object.
@@ -67,7 +69,6 @@ public:
      */
     explicit Otns(Instance &aInstance)
         : InstanceLocator(aInstance)
-        , Notifier::Receiver(aInstance, Otns::HandleNotifierEvents)
     {
     }
 
@@ -142,8 +143,6 @@ public:
 
 private:
     static void EmitStatus(const char *aFmt, ...);
-
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
 };
 

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -49,7 +49,6 @@ namespace Utils {
 
 Slaac::Slaac(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , Notifier::Receiver(aInstance, Slaac::HandleNotifierEvents)
     , mEnabled(true)
     , mFilter(nullptr)
 {
@@ -97,11 +96,6 @@ exit:
 bool Slaac::ShouldFilter(const Ip6::Prefix &aPrefix) const
 {
     return (mFilter != nullptr) && mFilter(&GetInstance(), &aPrefix);
-}
-
-void Slaac::HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents)
-{
-    static_cast<Slaac &>(aReceiver).HandleNotifierEvents(aEvents);
 }
 
 void Slaac::HandleNotifierEvents(Events aEvents)

--- a/src/core/utils/slaac_address.hpp
+++ b/src/core/utils/slaac_address.hpp
@@ -57,8 +57,10 @@ namespace Utils {
  * This class implements the SLAAC utility for Thread protocol.
  *
  */
-class Slaac : public InstanceLocator, public Notifier::Receiver
+class Slaac : public InstanceLocator
 {
+    friend class ot::Notifier;
+
 public:
     enum
     {
@@ -162,7 +164,6 @@ private:
     bool        ShouldFilter(const Ip6::Prefix &aPrefix) const;
     void        Update(UpdateMode aMode);
     void        GetIidSecretKey(IidSecretKey &aKey) const;
-    static void HandleNotifierEvents(Notifier::Receiver &aReceiver, Events aEvents);
     void        HandleNotifierEvents(Events aEvents);
     static bool DoesConfigMatchNetifAddr(const NetworkData::OnMeshPrefixConfig &aConfig,
                                          const Ip6::NetifUnicastAddress &       aAddr);


### PR DESCRIPTION
This commit changes the way the `Notifier` class emits events to other
OpenThread core/internal modules by having `Notifier` directly invoke
their callbacks, i.e., `Notifier::EmitEvents()` uses a hard-coded list
of all core modules/objects that want to receive events and it then
directly calls `HandleNotifierEvents()` on each object.

This change replaces/removes the `Notifier::Receiver` model and
simplifies the approach (reduces code-size and memory/RAM use).

For external modules (or in case the new model cannot be used by an
internal module), `Notifier` still provides the `RegisterCallback()`
model.