### PR TITLE
[github-action] change the way to upload coverage report for 1_2 tests

### DIFF
--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -71,5 +71,21 @@ jobs:
       run: |
         ./script/test unit
         ./script/test cert_suite tests/scripts/thread-cert/v1_2_*
+    - name: Keep-1-2-only
+      run: |
+        ./script/test tar 1.1
+        ./script/test tar 1.2-bbr
+    - name: Codecov
+      uses: codecov/codecov-action@v1
+    - name: Keep-1-2-bbr-only
+      run: |
+        ./script/test tar 1.2
+        ./script/test untar 1.2-bbr
+    - name: Codecov
+      uses: codecov/codecov-action@v1
+    - name: Keep-1-1-only
+      run: |
+        ./script/test tar 1.2-bbr
+        ./script/test untar 1.1
     - name: Codecov
       uses: codecov/codecov-action@v1

--- a/script/test
+++ b/script/test
@@ -332,6 +332,23 @@ do_package()
     ls "${builddir}"/openthread-daemon-*.deb
 }
 
+do_tar()
+{
+    local target_name="openthread-simulation-$1"
+    local build_dir="${OT_BUILDDIR}/cmake"
+    tar -cf "${target_name}.tar" -C "${build_dir}" "${target_name}"
+    mv "${target_name}.tar" "${build_dir}/"
+    rm -rf "${build_dir:?}/${target_name}"
+}
+
+do_untar()
+{
+    local target_name="openthread-simulation-$1"
+    local build_dir="${OT_BUILDDIR}/cmake"
+    tar -xf "${build_dir}/${target_name}.tar" -C "${build_dir}"
+    rm "${build_dir:?}/${target_name}.tar"
+}
+
 envsetup()
 {
     if [[ ${NODE_MODE} == 'rcp' ]]; then
@@ -417,6 +434,14 @@ main()
             expect)
                 shift
                 do_expect "$@"
+                ;;
+            tar)
+                shift
+                do_tar "$1"
+                ;;
+            untar)
+                shift
+                do_untar "$1"
                 ;;
         esac
         shift


### PR DESCRIPTION
I found that when running `code-cov` for `thread-1-2` in our github actions, the uploaded `.gcov` report file is not correct(Some code that will surely be executed is not hit in the report). 

The possible reason is that in `thread-1-2`, we have 3 different build directories. Thus we have 3 `.gcda` and `gcno` files for one source file. And `codecov-action@v1` isn't smart enough to include all these into one `.gcov` and then upload. Though I don't know the underlying process(how does `codecov-action@v1` generate `.gcov` when there are 3 data files for one source file), I've verified that, uploading report when there's only one build directory and repeating three times for different build directories take effect.

This PR adds a function in `script/test` to tar and untar the build directory. And in the `thread-1.2` action, `codecov-action@v1` is called for 3 times. Before each call, I use tar and untar to make sure currently there's only one valid build directory.