### PR TITLE
[time-ticker] adding 'TimeTicker' class

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -191,6 +191,7 @@ LOCAL_SRC_FILES                                          := \
     src/core/common/settings.cpp                            \
     src/core/common/string.cpp                              \
     src/core/common/tasklet.cpp                             \
+    src/core/common/time_ticker.cpp                         \
     src/core/common/timer.cpp                               \
     src/core/common/tlvs.cpp                                \
     src/core/common/trickle_timer.cpp                       \

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -364,6 +364,8 @@ openthread_core_files = [
   "common/tasklet.cpp",
   "common/tasklet.hpp",
   "common/time.hpp",
+  "common/time_ticker.cpp",
+  "common/time_ticker.hpp",
   "common/timer.cpp",
   "common/timer.hpp",
   "common/tlvs.cpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -117,6 +117,7 @@ set(COMMON_SOURCES
     common/settings.cpp
     common/string.cpp
     common/tasklet.cpp
+    common/time_ticker.cpp
     common/timer.cpp
     common/tlvs.cpp
     common/trickle_timer.cpp

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -159,6 +159,7 @@ SOURCES_COMMON                             = \
     common/settings.cpp                      \
     common/string.cpp                        \
     common/tasklet.cpp                       \
+    common/time_ticker.cpp                   \
     common/timer.cpp                         \
     common/tlvs.cpp                          \
     common/trickle_timer.cpp                 \
@@ -349,6 +350,7 @@ HEADERS_COMMON                             = \
     common/string.hpp                        \
     common/tasklet.hpp                       \
     common/time.hpp                          \
+    common/time_ticker.hpp                   \
     common/timer.hpp                         \
     common/tlvs.hpp                          \
     common/trickle_timer.hpp                 \

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -74,6 +74,7 @@ Instance::Instance(void)
     , mRadio(*this)
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
     , mNotifier(*this)
+    , mTimeTicker(*this)
     , mSettings(*this)
     , mSettingsDriver(*this)
     , mMessagePool(*this)

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -49,6 +49,7 @@
 #include "common/non_copyable.hpp"
 #include "common/random_manager.hpp"
 #include "common/tasklet.hpp"
+#include "common/time_ticker.hpp"
 #include "common/timer.hpp"
 #include "diags/factory_diags.hpp"
 #include "radio/radio.hpp"
@@ -343,10 +344,11 @@ private:
     Radio mRadio;
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
-    // Notifier, Settings, and MessagePool are initialized  before
-    // other member variables since other classes/objects from their
-    // constructor may use them.
+    // Notifier, TimeTicker, Settings, and MessagePool are initialized
+    // before other member variables since other classes/objects from
+    // their constructor may use them.
     Notifier       mNotifier;
+    TimeTicker     mTimeTicker;
     Settings       mSettings;
     SettingsDriver mSettingsDriver;
     MessagePool    mMessagePool;
@@ -411,6 +413,11 @@ template <> inline Radio::Callbacks &Instance::Get(void)
 template <> inline Notifier &Instance::Get(void)
 {
     return mNotifier;
+}
+
+template <> inline TimeTicker &Instance::Get(void)
+{
+    return mTimeTicker;
 }
 
 template <> inline Settings &Instance::Get(void)

--- a/src/core/common/time_ticker.cpp
+++ b/src/core/common/time_ticker.cpp
@@ -1,0 +1,127 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements a time ticker.
+ */
+
+#include "time_ticker.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/debug.hpp"
+#include "common/instance.hpp"
+#include "common/locator-getters.hpp"
+#include "common/random.hpp"
+#include "thread/mle_router.hpp"
+
+namespace ot {
+
+TimeTicker::TimeTicker(Instance &aInstance)
+    : InstanceLocator(aInstance)
+    , mReceivers(0)
+    , mTimer(aInstance, HandleTimer, this)
+{
+}
+
+void TimeTicker::RegisterReceiver(Receiver aReceiver)
+{
+    mReceivers |= Mask(aReceiver);
+
+    if (!mTimer.IsRunning())
+    {
+        mTimer.Start(Random::NonCrypto::GetUint32InRange(0, kTickInterval + 1));
+    }
+}
+
+void TimeTicker::UnregisterReceiver(Receiver aReceiver)
+{
+    mReceivers &= ~Mask(aReceiver);
+
+    if (mReceivers == 0)
+    {
+        mTimer.Stop();
+    }
+}
+
+void TimeTicker::HandleTimer(Timer &aTimer)
+{
+    aTimer.GetOwner<TimeTicker>().HandleTimer();
+}
+
+void TimeTicker::HandleTimer(void)
+{
+    mTimer.FireAt(mTimer.GetFireTime() + Random::NonCrypto::AddJitter(kTickInterval, kRestartJitter));
+
+    if (mReceivers & Mask(kMeshForwarder))
+    {
+        Get<MeshForwarder>().HandleTimeTick();
+    }
+
+#if OPENTHREAD_FTD
+    if (mReceivers & Mask(kMleRouter))
+    {
+        Get<Mle::MleRouter>().HandleTimeTick();
+    }
+
+    if (mReceivers & Mask(kAddressResolver))
+    {
+        Get<AddressResolver>().HandleTimeTick();
+    }
+
+#if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
+    if (mReceivers & Mask(kChildSupervisor))
+    {
+        Get<Utils::ChildSupervisor>().HandleTimeTick();
+    }
+#endif
+#endif // OPENTHREAD_FTD
+
+#if OPENTHREAD_CONFIG_IP6_FRAGMENTATION_ENABLE
+    if (mReceivers & Mask(kIp6FragmentReassembler))
+    {
+        Get<Ip6::Ip6>().HandleTimeTick();
+    }
+#endif
+
+#if OPENTHREAD_CONFIG_DUA_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE
+    if (mReceivers & Mask(kDuaManager))
+    {
+        Get<DuaManager>().HandleTimeTick();
+    }
+#endif
+
+#if OPENTHREAD_CONFIG_MLR_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+    if (mReceivers & Mask(kMlrManager))
+    {
+        Get<MlrManager>().HandleTimeTick();
+    }
+#endif
+}
+
+} // namespace ot

--- a/src/core/common/time_ticker.hpp
+++ b/src/core/common/time_ticker.hpp
@@ -1,0 +1,131 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for a time ticker.
+ */
+
+#ifndef TIME_TICKER_HPP_
+#define TIME_TICKER_HPP_
+
+#include "openthread-core-config.h"
+
+#include <limits.h>
+
+#include "common/locator.hpp"
+#include "common/non_copyable.hpp"
+#include "common/time.hpp"
+#include "common/timer.hpp"
+
+namespace ot {
+
+/**
+ * This class represents a time ticker.
+ *
+ * The time ticker emits periodic ticks (with 1 second period interval) to a set of registered tick receiver modules.
+ * The tick receivers (OpenThread objects) are identified by the `Receiver` enumeration. The receiver objects
+ * must provide `HandleTimeTick()` method which would be invoked by `TimeTicker` periodically.
+ *
+ */
+class TimeTicker : public InstanceLocator, private NonCopyable
+{
+public:
+    /**
+     * This enumeration represents time tick receivers.
+     *
+     * This enumeration contains the list of all OpenThread modules that can be registered as time tick receivers.
+     *
+     */
+    enum Receiver : uint8_t
+    {
+        kMeshForwarder,          ///< `MeshForwarder`
+        kMleRouter,              ///< `Mle::MleRouter`
+        kAddressResolver,        ///< `AddressResolver`
+        kChildSupervisor,        ///< `Utils::ChildSupervisor`
+        kIp6FragmentReassembler, ///< `Ip6::Ip6` (handling of fragmented messages)
+        kDuaManager,             ///< `DuaManager`
+        kMlrManager,             ///< `MlrManager`
+
+        kNumReceievrs, ///< Number of receivers.
+    };
+
+    /**
+     * This constructor initializes the `TimeTicker` instance.
+     *
+     */
+    TimeTicker(Instance &aInstance);
+
+    /**
+     * This method registers a receiver with `TimeTicker` to receive periodic ticks.
+     *
+     * @param[in] aReceiver   A tick receiver identifier.
+     *
+     */
+    void RegisterReceiver(Receiver aReceiver);
+
+    /**
+     * This method unregisters a receiver with `TimeTicker` to receive periodic ticks.
+     *
+     * @param[in] aReceiver   A tick receiver identifier.
+     *
+     */
+    void UnregisterReceiver(Receiver aReceiver);
+
+    /**
+     * This method indicates whether a receiver is registered with `TimeTicker` to receive periodic ticks.
+     *
+     * @param[in] aReceiver   A tick receiver identifier.
+     *
+     * @retval TRUE   If @p aReceiver is registered with `TimeTicker`.
+     * @retval FALSE  If @p aReceiver is not registered with `TimeTicker`.
+     *
+     */
+    bool IsReceiverRegistered(Receiver aReceiver) const { return (mReceivers & Mask(aReceiver)) != 0; }
+
+private:
+    enum : uint32_t
+    {
+        kTickInterval  = 1000, // in msec.
+        kRestartJitter = 4,    // in msec, jitter added when restarting the timer [-4,+4] ms.
+    };
+
+    constexpr static uint32_t Mask(Receiver aReceiver) { return static_cast<uint32_t>(1U) << aReceiver; }
+
+    static void HandleTimer(Timer &aTimer);
+    void        HandleTimer(void);
+
+    uint32_t   mReceivers;
+    TimerMilli mTimer;
+
+    static_assert(kNumReceievrs < sizeof(mReceivers) * CHAR_BIT, "Too many `Receiver`s - does not fit in a bit mask");
+};
+
+} // namespace ot
+
+#endif // TIMER_HPP_

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -45,6 +45,7 @@
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
+#include "common/time_ticker.hpp"
 #include "common/timer.hpp"
 #include "net/icmp6.hpp"
 #include "net/ip6_address.hpp"
@@ -102,6 +103,7 @@ using ot::Encoding::BigEndian::HostSwap32;
 class Ip6 : public InstanceLocator, private NonCopyable
 {
     friend class ot::Instance;
+    friend class ot::TimeTicker;
     friend class Mpl;
 
 public:
@@ -361,11 +363,10 @@ private:
     otError FragmentDatagram(Message &aMessage, uint8_t aIpProto);
     otError HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMessageInfo, bool aFromNcpHost);
 #if OPENTHREAD_CONFIG_IP6_FRAGMENTATION_ENABLE
-    void        CleanupFragmentationBuffer(void);
-    void        HandleUpdateTimer(void);
-    void        UpdateReassemblyList(void);
-    void        SendIcmpError(Message &aMessage, Icmp::Header::Type aIcmpType, Icmp::Header::Code aIcmpCode);
-    static void HandleTimer(Timer &aTimer);
+    void CleanupFragmentationBuffer(void);
+    void HandleTimeTick(void);
+    void UpdateReassemblyList(void);
+    void SendIcmpError(Message &aMessage, Icmp::Header::Type aIcmpType, Icmp::Header::Code aIcmpCode);
 #endif
     otError AddMplOption(Message &aMessage, Header &aHeader);
     otError AddTunneledMplOption(Message &aMessage, Header &aHeader, MessageInfo &aMessageInfo);
@@ -389,7 +390,6 @@ private:
     Mpl  mMpl;
 
 #if OPENTHREAD_CONFIG_IP6_FRAGMENTATION_ENABLE
-    TimerMilli   mTimer;
     MessageQueue mReassemblyList;
 #endif
 };

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -39,6 +39,7 @@
 #include "coap/coap.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
+#include "common/time_ticker.hpp"
 #include "common/timer.hpp"
 #include "mac/mac.hpp"
 #include "net/icmp6.hpp"
@@ -62,6 +63,8 @@ namespace ot {
  */
 class AddressResolver : public InstanceLocator
 {
+    friend class TimeTicker;
+
 public:
     /**
      * This type represents an iterator used for iterating through the EID cache table entries.
@@ -180,7 +183,6 @@ private:
         kAddressQueryInitialRetryDelay = OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_INITIAL_RETRY_DELAY, // in seconds
         kAddressQueryMaxRetryDelay     = OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_MAX_RETRY_DELAY,     // in seconds
         kSnoopBlockEvictionTimeout     = OPENTHREAD_CONFIG_TMF_SNOOP_CACHE_ENTRY_TIMEOUT,         // in seconds
-        kStateUpdatePeriod             = 1000u,                                                   // in milliseconds
         kIteratorListIndex             = 0,
         kIteratorEntryIndex            = 1,
     };
@@ -307,8 +309,7 @@ private:
                                   const Ip6::MessageInfo & aMessageInfo,
                                   const Ip6::Icmp::Header &aIcmpHeader);
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimeTick(void);
 
     void LogCacheEntryChange(EntryChange       aChange,
                              Reason            aReason,
@@ -330,7 +331,6 @@ private:
     CacheEntryList mQueryRetryList;
 
     Ip6::Icmp::Handler mIcmpHandler;
-    TimerMilli         mTimer;
 };
 
 /**

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -45,6 +45,7 @@
 #include "common/notifier.hpp"
 #include "common/tasklet.hpp"
 #include "common/time.hpp"
+#include "common/time_ticker.hpp"
 #include "common/timer.hpp"
 #include "net/netif.hpp"
 #include "thread/thread_tlvs.hpp"
@@ -73,6 +74,7 @@ namespace ot {
 class DuaManager : public InstanceLocator
 {
     friend class ot::Notifier;
+    friend class ot::TimeTicker;
 
 public:
     /**
@@ -160,8 +162,7 @@ public:
 private:
     enum
     {
-        kNewRouterRegistrationDelay = 5,    ///< Delay (in seconds) for waiting link establishment for a new Router.
-        kStateUpdatePeriod          = 1000, ///< 1000ms period  (i.e. 1s)
+        kNewRouterRegistrationDelay = 5, ///< Delay (in seconds) for waiting link establishment for a new Router.
     };
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
@@ -179,13 +180,11 @@ private:
 
     void HandleNotifierEvents(Events aEvents);
 
-    static void HandleTimer(Timer &aTimer) { aTimer.GetOwner<DuaManager>().HandleTimer(); }
-
-    void HandleTimer(void);
+    void HandleTimeTick(void);
 
     static void HandleRegistrationTask(Tasklet &aTasklet) { aTasklet.GetOwner<DuaManager>().PerformNextRegistration(); }
 
-    void ScheduleTimer(void);
+    void UpdateTimeTickerRegistration(void);
 
     static void HandleDuaResponse(void *               aContext,
                                   otMessage *          aMessage,
@@ -211,7 +210,6 @@ private:
     void UpdateReregistrationDelay(void);
     void UpdateCheckDelay(uint8_t aDelay);
 
-    TimerMilli     mTimer;
     Tasklet        mRegistrationTask;
     Coap::Resource mDuaNotification;
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -41,6 +41,7 @@
 #include "common/logging.hpp"
 #include "common/message.hpp"
 #include "common/random.hpp"
+#include "common/time_ticker.hpp"
 #include "net/ip6.hpp"
 #include "net/ip6_filter.hpp"
 #include "net/netif.hpp"
@@ -79,7 +80,6 @@ void ThreadLinkInfo::SetFrom(const Mac::RxFrame &aFrame)
 
 MeshForwarder::MeshForwarder(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mUpdateTimer(aInstance, MeshForwarder::HandleUpdateTimer, this)
     , mMessageNextOffset(0)
     , mSendMessage(nullptr)
     , mMeshSource()
@@ -123,7 +123,7 @@ void MeshForwarder::Stop(void)
     VerifyOrExit(mEnabled, OT_NOOP);
 
     mDataPollSender.StopPolling();
-    mUpdateTimer.Stop();
+    Get<TimeTicker>().UnregisterReceiver(TimeTicker::kMeshForwarder);
     Get<Mle::DiscoverScanner>().Stop();
 
     while ((message = mSendQueue.GetHead()) != nullptr)
@@ -1009,10 +1009,7 @@ void MeshForwarder::HandleFragment(const uint8_t *       aFrame,
 
         mReassemblyList.Enqueue(*message);
 
-        if (!mUpdateTimer.IsRunning())
-        {
-            mUpdateTimer.Start(kStateUpdatePeriod);
-        }
+        Get<TimeTicker>().RegisterReceiver(TimeTicker::kMeshForwarder);
     }
     else // Received frame is a "next fragment".
     {
@@ -1091,22 +1088,19 @@ void MeshForwarder::ClearReassemblyList(void)
     }
 }
 
-void MeshForwarder::HandleUpdateTimer(Timer &aTimer)
+void MeshForwarder::HandleTimeTick(void)
 {
-    aTimer.GetOwner<MeshForwarder>().HandleUpdateTimer();
-}
-
-void MeshForwarder::HandleUpdateTimer(void)
-{
-    bool shouldRun = false;
+    bool contineRxingTicks = false;
 
 #if OPENTHREAD_FTD
-    shouldRun = mFragmentPriorityList.UpdateOnTimeTick();
+    contineRxingTicks = mFragmentPriorityList.UpdateOnTimeTick();
 #endif
 
-    if (UpdateReassemblyList() || shouldRun)
+    contineRxingTicks = UpdateReassemblyList() || contineRxingTicks;
+
+    if (!contineRxingTicks)
     {
-        mUpdateTimer.Start(kStateUpdatePeriod);
+        Get<TimeTicker>().UnregisterReceiver(TimeTicker::kMeshForwarder);
     }
 }
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -39,6 +39,7 @@
 #include "common/clearable.hpp"
 #include "common/locator.hpp"
 #include "common/tasklet.hpp"
+#include "common/time_ticker.hpp"
 #include "mac/channel_mask.hpp"
 #include "mac/data_poll_sender.hpp"
 #include "mac/mac.hpp"
@@ -150,6 +151,7 @@ class MeshForwarder : public InstanceLocator
     friend class DataPollSender;
     friend class IndirectSender;
     friend class Mle::DiscoverScanner;
+    friend class TimeTicker;
 
 public:
     /**
@@ -297,11 +299,6 @@ private:
         kReassemblyTimeout = OPENTHREAD_CONFIG_6LOWPAN_REASSEMBLY_TIMEOUT, // Reassembly timeout (in seconds).
     };
 
-    enum : uint32_t
-    {
-        kStateUpdatePeriod = 1000, // State update period in milliseconds.
-    };
-
     enum MessageAction ///< Defines the action parameter in `LogMessageInfo()` method.
     {
         kMessageReceive,         ///< Indicates that the message was received.
@@ -427,8 +424,7 @@ private:
     Neighbor *UpdateNeighborOnSentFrame(Mac::TxFrame &aFrame, otError aError, const Mac::Address &aMacDest);
     void      HandleSentFrame(Mac::TxFrame &aFrame, otError aError);
 
-    static void HandleUpdateTimer(Timer &aTimer);
-    void        HandleUpdateTimer(void);
+    void        HandleTimeTick(void);
     static void ScheduleTransmissionTask(Tasklet &aTasklet);
     void        ScheduleTransmissionTask(void);
 
@@ -512,8 +508,6 @@ private:
                        otError             aError,
                        otLogLevel          aLogLevel);
 #endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE) && (OPENTHREAD_CONFIG_LOG_MAC == 1)
-
-    TimerMilli mUpdateTimer;
 
     PriorityQueue mSendQueue;
     MessageQueue  mReassemblyList;

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -741,7 +741,7 @@ exit:
 
 bool MeshForwarder::FragmentPriorityList::UpdateOnTimeTick(void)
 {
-    bool shouldRun = false;
+    bool contineRxingTicks = false;
 
     for (Entry &entry : mEntries)
     {
@@ -751,12 +751,12 @@ bool MeshForwarder::FragmentPriorityList::UpdateOnTimeTick(void)
 
             if (!entry.IsExpired())
             {
-                shouldRun = true;
+                contineRxingTicks = true;
             }
         }
     }
 
-    return shouldRun;
+    return contineRxingTicks;
 }
 
 void MeshForwarder::UpdateFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader,
@@ -772,15 +772,8 @@ void MeshForwarder::UpdateFragmentPriority(Lowpan::FragmentHeader &aFragmentHead
     {
         VerifyOrExit(aFragmentHeader.GetDatagramOffset() == 0, OT_NOOP);
 
-        entry = mFragmentPriorityList.AllocateEntry(aSrcRloc16, aFragmentHeader.GetDatagramTag(), aPriority);
-
-        VerifyOrExit(entry != nullptr, OT_NOOP);
-
-        if (!mUpdateTimer.IsRunning())
-        {
-            mUpdateTimer.Start(kStateUpdatePeriod);
-        }
-
+        mFragmentPriorityList.AllocateEntry(aSrcRloc16, aFragmentHeader.GetDatagramTag(), aPriority);
+        Get<TimeTicker>().RegisterReceiver(TimeTicker::kMeshForwarder);
         ExitNow();
     }
 

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -40,6 +40,7 @@
 
 #include "coap/coap.hpp"
 #include "coap/coap_message.hpp"
+#include "common/time_ticker.hpp"
 #include "common/timer.hpp"
 #include "common/trickle_timer.hpp"
 #include "mac/mac_types.hpp"
@@ -75,6 +76,7 @@ class MleRouter : public Mle
 {
     friend class Mle;
     friend class ot::Instance;
+    friend class ot::TimeTicker;
 
 public:
     /**
@@ -647,11 +649,9 @@ private:
 
     static bool HandleAdvertiseTimer(TrickleTimer &aTimer);
     bool        HandleAdvertiseTimer(void);
-    static void HandleStateUpdateTimer(Timer &aTimer);
-    void        HandleStateUpdateTimer(void);
+    void        HandleTimeTick(void);
 
     TrickleTimer mAdvertiseTimer;
-    TimerMilli   mStateUpdateTimer;
 
     Coap::Resource mAddressSolicit;
     Coap::Resource mAddressRelease;

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -42,6 +42,7 @@
 #include "coap/coap_message.hpp"
 #include "common/locator.hpp"
 #include "common/notifier.hpp"
+#include "common/time_ticker.hpp"
 #include "common/timer.hpp"
 #include "net/netif.hpp"
 #include "thread/thread_tlvs.hpp"
@@ -70,6 +71,7 @@ namespace ot {
 class MlrManager : public InstanceLocator
 {
     friend class ot::Notifier;
+    friend class ot::TimeTicker;
 
 public:
     /**
@@ -106,11 +108,6 @@ public:
 #endif
 
 private:
-    enum
-    {
-        kTimerInterval = 1000,
-    };
-
     void HandleNotifierEvents(Events aEvents);
 
     void SendMulticastListenerRegistration(void);
@@ -158,19 +155,16 @@ private:
                                    const Ip6::Address &aAddress);
 
     void ScheduleSend(uint16_t aDelay);
-    void ResetTimer(void);
+    void UpdateTimeTickerRegistration(void);
     void UpdateReregistrationDelay(bool aRereg);
     void Reregister(void);
-
-    static void HandleTimer(Timer &aTimer) { aTimer.GetOwner<MlrManager>().HandleTimer(); }
-    void        HandleTimer(void);
+    void HandleTimeTick(void);
 
     void LogMulticastAddresses(void);
 
-    TimerMilli mTimer;
-    uint32_t   mReregistrationDelay;
-    uint16_t   mSendDelay;
-    bool       mMlrPending : 1;
+    uint32_t mReregistrationDelay;
+    uint16_t mSendDelay;
+    bool     mMlrPending : 1;
 };
 
 } // namespace ot

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -498,7 +498,7 @@ exit:
     return;
 }
 
-void RouterTable::ProcessTimerTick(void)
+void RouterTable::HandleTimeTick(void)
 {
     Mle::MleRouter &mle = Get<Mle::MleRouter>();
 

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -398,7 +398,7 @@ public:
      * This method updates the router table and must be called with a one second period.
      *
      */
-    void ProcessTimerTick(void);
+    void HandleTimeTick(void);
 
     /**
      * This method enables range-based `for` loop iteration over all Router entries in the Router table.

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -42,6 +42,7 @@
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/notifier.hpp"
+#include "common/time_ticker.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_types.hpp"
 #include "thread/topology.hpp"
@@ -91,6 +92,7 @@ namespace Utils {
 class ChildSupervisor : public InstanceLocator
 {
     friend class ot::Notifier;
+    friend class ot::TimeTicker;
 
 public:
     /**
@@ -159,14 +161,12 @@ private:
         kOneSecond                  = 1000,                                         // One second interval (in ms).
     };
 
-    void        SendMessage(Child &aChild);
-    void        CheckState(void);
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
-    void        HandleNotifierEvents(Events aEvents);
+    void SendMessage(Child &aChild);
+    void CheckState(void);
+    void HandleTimeTick(void);
+    void HandleNotifierEvents(Events aEvents);
 
-    uint16_t   mSupervisionInterval;
-    TimerMilli mTimer;
+    uint16_t mSupervisionInterval;
 };
 
 #else // #if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE && OPENTHREAD_FTD


### PR DESCRIPTION
This commit adds `TimeTicker` class which emits periodic ticks (with
one second period interval) to a set of registered tick receiver
modules. The `TimeTicker` would invoke `HandleTimeTick()` method
periodically on the registered receiver objects.

The `TimeTicker` model helps simplify the implementation of many
modules (such as `MeshForwarder`, `MleRoutuer`, `AddressResolver`,
`Ip6`, `DuaManager`, etc) which require periodic update/check of some
state (avoid each class using its own timer).