### PR TITLE
[github-actions] run packet verification for multiple times

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -102,7 +102,7 @@ jobs:
       - name: Bootstrap
         run: |
           sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
-          sudo apt-get --no-install-recommends install -y g++-multilib python3-setuptools python3-wheel
+          sudo apt-get --no-install-recommends install -y g++-multilib python3-setuptools python3-wheel ninja-build
           python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
       - name: Build
         run: |

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -106,11 +106,13 @@ jobs:
           python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
       - name: Build
         run: |
-          ./bootstrap
-          make -f examples/Makefile-simulation
+          ./script/test build
       - name: Run
         run: |
-          VERBOSE=1 make -f examples/Makefile-simulation check
+          for i in {1..10}
+          do
+            ./script/test cert_suite ./tests/scripts/thread-cert/Cert_*.py
+          done
       - name: Codecov
         uses: codecov/codecov-action@v1
 


### PR DESCRIPTION
This PR makes packet verification to run for multiple times.

Since now we are developing many packet verification scripts, this PR can help us reduce the chance of merging a verification code that could fail by chance, which is very often for packet verification code.

**Successfully ran for 10 times in 13 minutes.**