### PR TITLE
[neighbor-table] move "neighbor changed callback" and signaling

### DIFF
--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -380,7 +380,7 @@ void otThreadRegisterNeighborTableCallback(otInstance *aInstance, otNeighborTabl
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    instance.Get<Mle::MleRouter>().RegisterNeighborTableChangedCallback(aCallback);
+    instance.Get<NeighborTable>().RegisterCallback(aCallback);
 }
 
 void otThreadSetDiscoveryRequestCallback(otInstance *                     aInstance,

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -477,20 +477,6 @@ public:
     otError GetMaxChildTimeout(uint32_t &aTimeout) const;
 
     /**
-     * This method register the "neighbor table changed" callback function.
-     *
-     * The provided callback (if non-nullptr) will be invoked when a child/router entry is being added/remove to/from
-     * the neighbor table. Subsequent calls to this method will overwrite the previous callback.
-     *
-     * @param[in] aCallback    A pointer to callback handler function.
-     *
-     */
-    void RegisterNeighborTableChangedCallback(otNeighborTableCallback aCallback)
-    {
-        mNeighborTableChangedCallback = aCallback;
-    }
-
-    /**
      * This function sets the callback that is called when processing an MLE Discovery Request message.
      *
      * @param[in]  aCallback A pointer to a function that is called to deliver MLE Discovery Request data.
@@ -502,15 +488,6 @@ public:
         mDiscoveryRequestCallback        = aCallback;
         mDiscoveryRequestCallbackContext = aContext;
     }
-
-    /**
-     * This method signals a "neighbor table changed" events (invoking the registered callback function).
-     *
-     * @param[in] aEvent     The event to emit (child/router added/removed).
-     * @param[in] aNeighbor  The neighbor that is being added/removed.
-     *
-     */
-    void Signal(otNeighborTableEvent aEvent, Neighbor &aNeighbor);
 
     /**
      * This method resets the MLE Advertisement Trickle timer interval.
@@ -681,8 +658,6 @@ private:
 
     ChildTable  mChildTable;
     RouterTable mRouterTable;
-
-    otNeighborTableCallback mNeighborTableChangedCallback;
 
     uint8_t   mChallengeTimeout;
     Challenge mChallenge;

--- a/src/core/thread/neighbor_table.hpp
+++ b/src/core/thread/neighbor_table.hpp
@@ -49,6 +49,30 @@ class NeighborTable : public InstanceLocator
 {
 public:
     /**
+     * This function pointer is called to notify that a child or router neighbor is being added to or removed from
+     * neighbor table.
+     *
+     * Note that this callback in invoked while the neighbor/child table is being updated and always before the related
+     * `Notifier` event.
+     *
+     */
+    typedef otNeighborTableCallback Callback;
+
+    /**
+     * This type represents a neighbor table entry info (child or router) and is used as a parameter in the neighbor
+     * table callback.
+     *
+     */
+    typedef otNeighborTableEntryInfo EntryInfo;
+
+    /**
+     * This enumeration defines the constants used in `NeighborTable::Callback` to indicate whether a child or router
+     * neighbor is being added or removed.
+     *
+     */
+    typedef otNeighborTableEvent Event;
+
+    /**
      * This constructor initializes the `NeighborTable` instance.
      *
      * @param[in]  aInstance     A reference to the OpenThread instance.
@@ -158,12 +182,36 @@ public:
      */
     otError GetNextNeighborInfo(otNeighborInfoIterator &aIterator, Neighbor::Info &aNeighInfo);
 
+    /**
+     * This method registers the "neighbor table changed" callback function.
+     *
+     * The provided callback (if non-nullptr) will be invoked when a child/router entry is being added/remove to/from
+     * the neighbor table. Subsequent calls to this method will overwrite the previous callback.
+     *
+     * @param[in] aCallback    A pointer to callback handler function.
+     *
+     */
+    void RegisterCallback(Callback aCallback) { mCallback = aCallback; }
+
+    /**
+     * This method signals a "neighbor table changed" event.
+     *
+     * This method invokes the `NeighborTable::Callback` and also signals the change through a related `Notifier` event.
+     *
+     * @param[in] aEvent     The event to emit (child/router added/removed).
+     * @param[in] aNeighbor  The neighbor that is being added/removed.
+     *
+     */
+    void Signal(Event aEvent, const Neighbor &aNeighbor);
+
 private:
     Neighbor *FindParent(const Neighbor::AddressMatcher &aMatcher);
     Neighbor *FindNeighbor(const Neighbor::AddressMatcher &aMatcher);
 #if OPENTHREAD_FTD
     Neighbor *FindChildOrRouter(const Neighbor::AddressMatcher &aMatcher);
 #endif
+
+    Callback mCallback;
 };
 
 } // namespace ot

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -100,7 +100,7 @@ void RouterTable::ClearNeighbors(void)
     {
         if (router.IsStateValid())
         {
-            Get<Mle::MleRouter>().Signal(OT_NEIGHBOR_TABLE_EVENT_ROUTER_REMOVED, router);
+            Get<NeighborTable>().Signal(OT_NEIGHBOR_TABLE_EVENT_ROUTER_REMOVED, router);
         }
 
         router.SetState(Neighbor::kStateInvalid);

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -107,7 +107,7 @@ void Otns::HandleNotifierEvents(Events aEvents)
 #endif
 }
 
-void Otns::EmitNeighborChange(otNeighborTableEvent aEvent, Neighbor &aNeighbor)
+void Otns::EmitNeighborChange(NeighborTable::Event aEvent, const Neighbor &aNeighbor)
 {
     switch (aEvent)
     {

--- a/src/core/utils/otns.hpp
+++ b/src/core/utils/otns.hpp
@@ -47,6 +47,7 @@
 #include "common/notifier.hpp"
 #include "mac/mac_types.hpp"
 #include "net/ip6_address.hpp"
+#include "thread/neighbor_table.hpp"
 #include "thread/topology.hpp"
 
 namespace ot {
@@ -123,7 +124,7 @@ public:
      * @param[in]  aNeighbor  The neighbor that is added or removed.
      *
      */
-    static void EmitNeighborChange(otNeighborTableEvent aEvent, Neighbor &aNeighbor);
+    static void EmitNeighborChange(NeighborTable::Event aEvent, const Neighbor &aNeighbor);
 
     /**
      * This function emits a transmit event to OTNS.


### PR DESCRIPTION
This commit moves the code related to `otNeighborTableCallback`
and signaling `NeighborTable::Event` to `NeighborTable` class
(from `MleRouter`).