### PR TITLE
[netif] add helper methods to init 'NetifUnicastAddress'

### DIFF
--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -59,14 +59,7 @@ Local::Local(Instance &aInstance)
     mDomainPrefixConfig.GetPrefix().SetLength(0);
 
     // Primary Backbone Router Aloc
-    mBackboneRouterPrimaryAloc.Clear();
-
-    mBackboneRouterPrimaryAloc.mPrefixLength       = Mle::MeshLocalPrefix::kLength;
-    mBackboneRouterPrimaryAloc.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
-    mBackboneRouterPrimaryAloc.mPreferred          = true;
-    mBackboneRouterPrimaryAloc.mValid              = true;
-    mBackboneRouterPrimaryAloc.mScopeOverride      = Ip6::Address::kRealmLocalScope;
-    mBackboneRouterPrimaryAloc.mScopeOverrideValid = true;
+    mBackboneRouterPrimaryAloc.InitAsThreadOriginRealmLocalScope();
     mBackboneRouterPrimaryAloc.GetAddress().GetIid().SetLocator(Mle::kAloc16BackboneRouterPrimary);
 
     // All Network Backbone Routers Multicast Address.

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -352,13 +352,7 @@ BorderAgent::BorderAgent(Instance &aInstance)
     , mTimer(aInstance, HandleTimeout, this)
     , mState(OT_BORDER_AGENT_STATE_STOPPED)
 {
-    mCommissionerAloc.Clear();
-    mCommissionerAloc.mPrefixLength       = 64;
-    mCommissionerAloc.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
-    mCommissionerAloc.mPreferred          = true;
-    mCommissionerAloc.mValid              = true;
-    mCommissionerAloc.mScopeOverride      = Ip6::Address::kRealmLocalScope;
-    mCommissionerAloc.mScopeOverrideValid = true;
+    mCommissionerAloc.InitAsThreadOriginRealmLocalScope();
 }
 
 void BorderAgent::HandleNotifierEvents(Events aEvents)

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -165,11 +165,8 @@ private:
         {
             mPrefix = aPrefix;
 
+            mAloc.InitAsThreadOrigin();
             mAloc.GetAddress().SetToAnycastLocator(aMeshLocalPrefix, (Ip6::Address::kAloc16Mask << 8) + aContextId);
-            mAloc.mPrefixLength  = OT_IP6_PREFIX_BITSIZE;
-            mAloc.mAddressOrigin = OT_ADDRESS_ORIGIN_THREAD;
-            mAloc.mPreferred     = true;
-            mAloc.mValid         = true;
         }
 
     private:

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -495,5 +495,37 @@ bool Netif::IsUnicastAddressExternal(const NetifUnicastAddress &aAddress) const
     return mExtUnicastAddressPool.IsPoolEntry(aAddress);
 }
 
+void NetifUnicastAddress::InitAsThreadOrigin(void)
+{
+    Clear();
+    mPrefixLength  = NetworkPrefix::kLength;
+    mAddressOrigin = OT_ADDRESS_ORIGIN_THREAD;
+    mPreferred     = true;
+    mValid         = true;
+}
+
+void NetifUnicastAddress::InitAsThreadOriginRealmLocalScope(void)
+{
+    InitAsThreadOrigin();
+    SetScopeOverride(Address::kRealmLocalScope);
+}
+
+void NetifUnicastAddress::InitAsThreadOriginGlobalScope(void)
+{
+    Clear();
+    mAddressOrigin = OT_ADDRESS_ORIGIN_THREAD;
+    mValid         = true;
+    SetScopeOverride(Address::kGlobalScope);
+}
+
+void NetifUnicastAddress::InitAsSlaacOrigin(uint8_t aPrefixLength, bool aPreferred)
+{
+    Clear();
+    mPrefixLength  = aPrefixLength;
+    mAddressOrigin = OT_ADDRESS_ORIGIN_SLAAC;
+    mPreferred     = aPreferred;
+    mValid         = true;
+}
+
 } // namespace Ip6
 } // namespace ot

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -76,6 +76,37 @@ class NetifUnicastAddress : public otNetifAddress,
 
 public:
     /**
+     * This method clears and initializes the unicast address as a preferred, valid, thread-origin address with 64-bit
+     * prefix length.
+     *
+     */
+    void InitAsThreadOrigin(void);
+
+    /**
+     * This method clears and initializes the unicast address as a preferred, valid, thread-origin, realm-local scope
+     * (overridden) address with 64-bit prefix length.
+     *
+     */
+    void InitAsThreadOriginRealmLocalScope(void);
+
+    /**
+     * This method clears and initializes the unicast address as a valid (but not preferred), thread-origin, global
+     * scope address.
+     *
+     */
+    void InitAsThreadOriginGlobalScope(void);
+
+    /**
+     * This method clears and initializes the unicast address as a valid, SLAAC-origin address with a given preferred
+     * flag and a given prefix length.
+     *
+     * @param[in] aPrefixLength    The prefix length (in bits).
+     * @param[in] aPreferred       The preferred flag.
+     *
+     */
+    void InitAsSlaacOrigin(uint8_t aPrefixLength, bool aPreferred);
+
+    /**
      * This method returns the unicast address.
      *
      * @returns The unicast address.
@@ -122,6 +153,18 @@ public:
     uint8_t GetScope(void) const
     {
         return mScopeOverrideValid ? static_cast<uint8_t>(mScopeOverride) : GetAddress().GetScope();
+    }
+
+    /**
+     * This method sets the IPv6 scope override value.
+     *
+     * @param[in]  aScope  The IPv6 scope value.
+     *
+     */
+    void SetScopeOverride(uint8_t aScope)
+    {
+        mScopeOverride      = aScope;
+        mScopeOverrideValid = true;
     }
 
 private:

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -68,13 +68,7 @@ DuaManager::DuaManager(Instance &aInstance)
     mDelay.mValue = 0;
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
-    mDomainUnicastAddress.Clear();
-    mDomainUnicastAddress.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
-    mDomainUnicastAddress.mPreferred          = false;
-    mDomainUnicastAddress.mValid              = true;
-    mDomainUnicastAddress.mScopeOverride      = Ip6::Address::kGlobalScope;
-    mDomainUnicastAddress.mScopeOverrideValid = true;
-
+    mDomainUnicastAddress.InitAsThreadOriginGlobalScope();
     mFixedDuaInterfaceIdentifier.Clear();
 #endif
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -120,78 +120,37 @@ Mle::Mle(Instance &aInstance)
     mParentCandidate.Clear();
     ResetCounters();
 
-    // link-local 64
-    mLinkLocal64.Clear();
+    mLinkLocal64.InitAsThreadOrigin();
     mLinkLocal64.GetAddress().SetToLinkLocalAddress(Get<Mac::Mac>().GetExtAddress());
-    mLinkLocal64.mPrefixLength  = 64;
-    mLinkLocal64.mAddressOrigin = OT_ADDRESS_ORIGIN_THREAD;
-    mLinkLocal64.mPreferred     = true;
-    mLinkLocal64.mValid         = true;
 
-    // Leader Aloc
-    mLeaderAloc.Clear();
-    mLeaderAloc.mPrefixLength       = MeshLocalPrefix::kLength;
-    mLeaderAloc.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
-    mLeaderAloc.mPreferred          = true;
-    mLeaderAloc.mValid              = true;
-    mLeaderAloc.mScopeOverride      = Ip6::Address::kRealmLocalScope;
-    mLeaderAloc.mScopeOverrideValid = true;
+    mLeaderAloc.InitAsThreadOriginRealmLocalScope();
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-
-    // Service Alocs
     for (Ip6::NetifUnicastAddress &serviceAloc : mServiceAlocs)
     {
-        serviceAloc.Clear();
-        serviceAloc.mPrefixLength       = MeshLocalPrefix::kLength;
-        serviceAloc.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
-        serviceAloc.mPreferred          = true;
-        serviceAloc.mValid              = true;
-        serviceAloc.mScopeOverride      = Ip6::Address::kRealmLocalScope;
-        serviceAloc.mScopeOverrideValid = true;
+        serviceAloc.InitAsThreadOriginRealmLocalScope();
         serviceAloc.GetAddress().GetIid().SetLocator(Mac::kShortAddrInvalid);
     }
-
 #endif
 
-    // initialize Mesh Local Prefix
     meshLocalPrefix.SetFromExtendedPanId(Get<Mac::Mac>().GetExtendedPanId());
 
-    // mesh-local 64
-    mMeshLocal64.Clear();
+    mMeshLocal64.InitAsThreadOriginRealmLocalScope();
     mMeshLocal64.GetAddress().GetIid().GenerateRandom();
 
-    mMeshLocal64.mPrefixLength       = MeshLocalPrefix::kLength;
-    mMeshLocal64.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
-    mMeshLocal64.mPreferred          = true;
-    mMeshLocal64.mValid              = true;
-    mMeshLocal64.mScopeOverride      = Ip6::Address::kRealmLocalScope;
-    mMeshLocal64.mScopeOverrideValid = true;
-
-    // mesh-local 16
-    mMeshLocal16.Clear();
+    mMeshLocal16.InitAsThreadOriginRealmLocalScope();
     mMeshLocal16.GetAddress().GetIid().SetToLocator(0);
-    mMeshLocal16.mPrefixLength       = MeshLocalPrefix::kLength;
-    mMeshLocal16.mAddressOrigin      = OT_ADDRESS_ORIGIN_THREAD;
-    mMeshLocal16.mPreferred          = true;
-    mMeshLocal16.mValid              = true;
-    mMeshLocal16.mScopeOverride      = Ip6::Address::kRealmLocalScope;
-    mMeshLocal16.mScopeOverrideValid = true;
-    mMeshLocal16.mRloc               = true;
+    mMeshLocal16.mRloc = true;
 
     // Store RLOC address reference in MPL module.
     Get<Ip6::Mpl>().SetMatchingAddress(mMeshLocal16.GetAddress());
 
-    // link-local all thread nodes
     mLinkLocalAllThreadNodes.Clear();
     mLinkLocalAllThreadNodes.GetAddress().mFields.m16[0] = HostSwap16(0xff32);
-    mLinkLocalAllThreadNodes.GetAddress().mFields.m16[6] = HostSwap16(0x0000);
     mLinkLocalAllThreadNodes.GetAddress().mFields.m16[7] = HostSwap16(0x0001);
 
-    // realm-local all thread nodes
     mRealmLocalAllThreadNodes.Clear();
     mRealmLocalAllThreadNodes.GetAddress().mFields.m16[0] = HostSwap16(0xff33);
-    mRealmLocalAllThreadNodes.GetAddress().mFields.m16[6] = HostSwap16(0x0000);
     mRealmLocalAllThreadNodes.GetAddress().mFields.m16[7] = HostSwap16(0x0001);
 
     SetMeshLocalPrefix(meshLocalPrefix);

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -229,13 +229,8 @@ void Slaac::Update(UpdateMode aMode)
                         continue;
                     }
 
-                    slaacAddr.Clear();
+                    slaacAddr.InitAsSlaacOrigin(config.mOnMesh ? prefix.mLength : 128, config.mPreferred);
                     slaacAddr.GetAddress().SetPrefix(prefix);
-
-                    slaacAddr.mPrefixLength  = config.mOnMesh ? prefix.mLength : 128;
-                    slaacAddr.mAddressOrigin = OT_ADDRESS_ORIGIN_SLAAC;
-                    slaacAddr.mPreferred     = config.mPreferred;
-                    slaacAddr.mValid         = true;
 
                     IgnoreError(GenerateIid(slaacAddr));
 


### PR DESCRIPTION
This commit adds a group of `Init` methods in `NetifUnciastAddress`
for common initializations of a unicast address with different
parameters (origin, scope, prefix length, and preferred/valid flags).