### PR TITLE
[scripts] remove 1.2-bbr build from script/test

### DIFF
--- a/script/test
+++ b/script/test
@@ -65,7 +65,7 @@ build_simulation()
     fi
 
     if [[ ${version} == "1.2" ]]; then
-        options+=("-DOT_CSL_RECEIVER=ON")
+        options+=("-DOT_CSL_RECEIVER=ON" "-DOT_BACKBONE_ROUTER=ON")
     fi
 
     if [[ ${ot_extra_options[*]+x} ]]; then
@@ -73,14 +73,6 @@ build_simulation()
     fi
 
     OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/cmake/openthread-simulation-${version}" "${OT_SRCDIR}"/script/cmake-build simulation "${options[@]}"
-
-    if [[ ${version} == "1.2" ]]; then
-
-        options+=("-DOT_BACKBONE_ROUTER=ON")
-
-        OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/cmake/openthread-simulation-${version}-bbr" "${OT_SRCDIR}"/script/cmake-build simulation "${options[@]}"
-
-    fi
 }
 
 build_posix()
@@ -91,6 +83,7 @@ build_posix()
     if [[ ${version} == "1.2" ]]; then
         options+=("-DOT_DUA=ON")
         options+=("-DOT_MLR=ON")
+        options+=("-DOT_BACKBONE_ROUTER=ON")
     fi
 
     if [[ ${VIRTUAL_TIME} == 1 ]]; then
@@ -106,13 +99,6 @@ build_posix()
     fi
 
     OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/cmake/openthread-posix-${version}" "${OT_SRCDIR}"/script/cmake-build posix "${options[@]}"
-
-    if [[ ${version} == "1.2" ]]; then
-
-        options+=("-DOT_BACKBONE_ROUTER=ON")
-
-        OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/cmake/openthread-posix-${version}-bbr" "${OT_SRCDIR}"/script/cmake-build posix "${options[@]}"
-    fi
 }
 
 do_build()
@@ -156,7 +142,6 @@ do_cert()
 
     if [[ ${THREAD_VERSION} == "1.2" ]]; then
         export top_builddir_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1"
-        export top_builddir_1_2_bbr="${OT_BUILDDIR}/cmake/openthread-simulation-1.2-bbr"
     fi
 
     [[ ! -d tmp ]] || rm -rvf tmp
@@ -169,7 +154,6 @@ do_cert_suite()
 
     if [[ ${THREAD_VERSION} == "1.2" ]]; then
         export top_builddir_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1"
-        export top_builddir_1_2_bbr="${OT_BUILDDIR}/cmake/openthread-simulation-1.2-bbr"
     fi
 
     local pass_count=0
@@ -360,8 +344,6 @@ envsetup()
             export RADIO_DEVICE_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1/examples/apps/ncp/ot-rcp"
             export OT_CLI_PATH_1_1="${OT_BUILDDIR}/cmake/openthread-posix-1.1/src/posix/ot-cli"
             export OT_NCP_PATH_1_1="${OT_BUILDDIR}/cmake/openthread-posix-1.1/src/posix/ot-ncp"
-            export OT_CLI_PATH_1_2_BBR="${OT_BUILDDIR}/cmake/openthread-posix-1.2-bbr/src/posix/ot-cli"
-            export OT_NCP_PATH_1_2_BBR="${OT_BUILDDIR}/cmake/openthread-posix-1.2-bbr/src/posix/ot-ncp"
         fi
     fi
 

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -86,22 +86,12 @@ class Node:
 
         # If Thread version of node matches the testing environment version.
         if self.version == self.env_version:
-            # Load Thread 1.2 BBR device when testing Thread 1.2 scenarios
-            # which requires device with Backbone functionality.
-            if self.version == '1.2' and self.is_bbr:
-                if 'OT_CLI_PATH_1_2_BBR' in os.environ:
-                    cmd = os.environ['OT_CLI_PATH_1_2_BBR']
-                elif 'top_builddir_1_2_bbr' in os.environ:
-                    srcdir = os.environ['top_builddir_1_2_bbr']
-                    cmd = '%s/examples/apps/cli/ot-cli-%s' % (srcdir, mode)
-
             # Load Thread device of the testing environment version (may be 1.1 or 1.2)
-            else:
-                if 'OT_CLI_PATH' in os.environ:
-                    cmd = os.environ['OT_CLI_PATH']
-                elif 'top_builddir' in os.environ:
-                    srcdir = os.environ['top_builddir']
-                    cmd = '%s/examples/apps/cli/ot-cli-%s' % (srcdir, mode)
+            if 'OT_CLI_PATH' in os.environ:
+                cmd = os.environ['OT_CLI_PATH']
+            elif 'top_builddir' in os.environ:
+                srcdir = os.environ['top_builddir']
+                cmd = '%s/examples/apps/cli/ot-cli-%s' % (srcdir, mode)
 
             if 'RADIO_DEVICE' in os.environ:
                 cmd += ' --real-time-signal=+1 -v spinel+hdlc+uart://%s?forkpty-arg=%d' % (os.environ['RADIO_DEVICE'],
@@ -152,36 +142,19 @@ class Node:
             else:
                 args = ''
 
-            # Load Thread 1.2 BBR device when testing Thread 1.2 scenarios
-            # which requires device with Backbone functionality.
-            if self.version == '1.2' and self.is_bbr:
-                if 'OT_NCP_PATH_1_2_BBR' in os.environ:
-                    cmd = 'spinel-cli.py -p "%s%s" -n' % (
-                        os.environ['OT_NCP_PATH_1_2_BBR'],
-                        args,
-                    )
-                elif 'top_builddir_1_2_bbr' in os.environ:
-                    srcdir = os.environ['top_builddir_1_2_bbr']
-                    cmd = '%s/examples/apps/ncp/ot-ncp-%s' % (srcdir, mode)
-                    cmd = 'spinel-cli.py -p "%s%s" -n' % (
-                        cmd,
-                        args,
-                    )
-
             # Load Thread device of the testing environment version (may be 1.1 or 1.2).
-            else:
-                if 'OT_NCP_PATH' in os.environ:
-                    cmd = 'spinel-cli.py -p "%s%s" -n' % (
-                        os.environ['OT_NCP_PATH'],
-                        args,
-                    )
-                elif 'top_builddir' in os.environ:
-                    srcdir = os.environ['top_builddir']
-                    cmd = '%s/examples/apps/ncp/ot-ncp-%s' % (srcdir, mode)
-                    cmd = 'spinel-cli.py -p "%s%s" -n' % (
-                        cmd,
-                        args,
-                    )
+            if 'OT_NCP_PATH' in os.environ:
+                cmd = 'spinel-cli.py -p "%s%s" -n' % (
+                    os.environ['OT_NCP_PATH'],
+                    args,
+                )
+            elif 'top_builddir' in os.environ:
+                srcdir = os.environ['top_builddir']
+                cmd = '%s/examples/apps/ncp/ot-ncp-%s' % (srcdir, mode)
+                cmd = 'spinel-cli.py -p "%s%s" -n' % (
+                    cmd,
+                    args,
+                )
 
         # Load Thread 1.1 node when testing Thread 1.2 scenarios for interoperability.
         elif self.version == '1.1':


### PR DESCRIPTION
This PR simplifies 1.2 builds by removing 1.2-bbr builds from `script/test`. 
With this PR, `script/test` always build one Thread 1.2 version with `BACKBONE_ROUTER` feature. 
**Non-BBR devices simple do not issue `bbr enable` command.**