### PR TITLE
[mesh-forwarder] add new class 'ThreadLinkInfo'

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -655,6 +655,17 @@ bool Message::IsChildPending(void) const
     return GetMetadata().mChildMask.HasAny();
 }
 
+void Message::SetLinkInfo(const ThreadLinkInfo &aLinkInfo)
+{
+    SetLinkSecurityEnabled(aLinkInfo.mLinkSecurity);
+    SetPanId(aLinkInfo.mPanId);
+    AddRss(aLinkInfo.mRss);
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    SetTimeSyncSeq(aLinkInfo.mTimeSyncSeq);
+    SetNetworkTimeOffset(aLinkInfo.mNetworkTimeOffset);
+#endif
+}
+
 uint16_t Message::UpdateChecksum(uint16_t aChecksum, uint16_t aValue)
 {
     uint16_t result = aChecksum + aValue;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -53,6 +53,8 @@
 
 namespace ot {
 
+class ThreadLinkInfo;
+
 /**
  * @addtogroup core-message
  *
@@ -797,6 +799,14 @@ public:
      *
      */
     const RssAverager &GetRssAverager(void) const { return GetMetadata().mRssAverager; }
+
+    /**
+     * This method sets the message's link info properties (PAN ID, link security, RSS) from a given `ThreadLinkInfo`.
+     *
+     * @param[in] aLinkInfo   The `ThreadLinkInfo` instance from which to set message's related properties.
+     *
+     */
+    void SetLinkInfo(const ThreadLinkInfo &aLinkInfo);
 
     /**
      * This static method updates a checksum.

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -40,6 +40,9 @@
 #include "net/ip6_address.hpp"
 
 namespace ot {
+
+class ThreadLinkInfo;
+
 namespace Ip6 {
 
 /**
@@ -159,20 +162,28 @@ public:
     void SetHopLimit(uint8_t aHopLimit) { mHopLimit = aHopLimit; }
 
     /**
-     * This method returns a pointer to the Link Info.
+     * This method returns a pointer to the link-specific information object.
      *
-     * @returns A pointer to the Link Info.
+     * @returns A pointer to the link-specific information object.
      *
      */
     const void *GetLinkInfo(void) const { return mLinkInfo; }
 
     /**
-     * This method sets the pointer to the Link Info.
+     * This method sets the pointer to the link-specific information object.
      *
-     * @param[in]  aLinkInfo  A pointer to the Link Info.
+     * @param[in]  aLinkInfo  A pointer to the link-specific information object.
      *
      */
     void SetLinkInfo(const void *aLinkInfo) { mLinkInfo = aLinkInfo; }
+
+    /**
+     * This method returns a pointer to the link-specific information as a `ThreadLinkInfo`.
+     *
+     * @returns A pointer to to the link-specific information object as `ThreadLinkInfo`.
+     *
+     */
+    const ThreadLinkInfo *GetThreadLinkInfo(void) const { return reinterpret_cast<const ThreadLinkInfo *>(mLinkInfo); }
 
     /**
      * This method indicates whether peer is via the host interface.

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -292,7 +292,7 @@ exit:
 void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const
 {
     otError                       error    = OT_ERROR_NONE;
-    const otThreadLinkInfo *      linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
+    const ThreadLinkInfo *        linkInfo = aMessageInfo.GetThreadLinkInfo();
     Tlv                           tlv;
     MeshCoP::Tlv                  meshcopTlv;
     MeshCoP::DiscoveryResponseTlv discoveryResponse;

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -65,6 +65,81 @@ class DiscoverScanner;
  */
 
 /**
+ * This class represents link-specific information for messages received from the Thread radio.
+ *
+ */
+class ThreadLinkInfo : public otThreadLinkInfo, public Clearable<ThreadLinkInfo>
+{
+public:
+    /**
+     * This method returns the IEEE 802.15.4 Source PAN ID.
+     *
+     * @returns The IEEE 802.15.4 Source PAN ID.
+     *
+     */
+    Mac::PanId GetPanId(void) const { return mPanId; }
+
+    /**
+     * This method returns the IEEE 802.15.4 Channel.
+     *
+     * @returns The IEEE 802.15.4 Channel.
+     *
+     */
+    uint8_t GetChannel(void) const { return mChannel; }
+
+    /**
+     * This method indicates whether or not link security is enabled.
+     *
+     * @retval TRUE   If link security is enabled.
+     * @retval FALSE  If link security is not enabled.
+     *
+     */
+    bool IsLinkSecurityEnabled(void) const { return mLinkSecurity; }
+
+    /**
+     * This method returns the Received Signal Strength (RSS) in dBm.
+     *
+     * @returns The Received Signal Strength (RSS) in dBm.
+     *
+     */
+    int8_t GetRss(void) const { return mRss; }
+
+    /**
+     * This method returns the frame/radio Link Quality Indicator (LQI) value.
+     *
+     * @returns The Link Quality Indicator value.
+     *
+     */
+    uint8_t GetLqi(void) const { return mLqi; }
+
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    /**
+     * This method returns the Time Sync Sequence.
+     *
+     * @returns The Time Sync Sequence.
+     *
+     */
+    uint8_t GetTimeSyncSeq(void) const { return mTimeSyncSeq; }
+
+    /**
+     * This method returns the time offset to the Thread network time (in microseconds).
+     *
+     * @returns The time offset to the Thread network time (in microseconds).
+     *
+     */
+    int64_t GetNetworkTimeOffset(void) const { return mNetworkTimeOffset; }
+#endif
+
+    /**
+     * This method sets the `ThreadLinkInfo` from a given received frame.
+     *
+     * @param[in] aFrame  A received frame.
+     *
+     */
+    void SetFrom(const Mac::RxFrame &aFrame);
+};
+
+/**
  * This class implements mesh forwarding within Thread.
  *
  */
@@ -310,20 +385,20 @@ private:
     void     GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
     void     GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
     Message *GetDirectTransmission(void);
-    void     HandleMesh(uint8_t *               aFrame,
-                        uint16_t                aFrameLength,
-                        const Mac::Address &    aMacSource,
-                        const otThreadLinkInfo &aLinkInfo);
-    void     HandleFragment(const uint8_t *         aFrame,
-                            uint16_t                aFrameLength,
-                            const Mac::Address &    aMacSource,
-                            const Mac::Address &    aMacDest,
-                            const otThreadLinkInfo &aLinkInfo);
-    void     HandleLowpanHC(const uint8_t *         aFrame,
-                            uint16_t                aFrameLength,
-                            const Mac::Address &    aMacSource,
-                            const Mac::Address &    aMacDest,
-                            const otThreadLinkInfo &aLinkInfo);
+    void     HandleMesh(uint8_t *             aFrame,
+                        uint16_t              aFrameLength,
+                        const Mac::Address &  aMacSource,
+                        const ThreadLinkInfo &aLinkInfo);
+    void     HandleFragment(const uint8_t *       aFrame,
+                            uint16_t              aFrameLength,
+                            const Mac::Address &  aMacSource,
+                            const Mac::Address &  aMacDest,
+                            const ThreadLinkInfo &aLinkInfo);
+    void     HandleLowpanHC(const uint8_t *       aFrame,
+                            uint16_t              aFrameLength,
+                            const Mac::Address &  aMacSource,
+                            const Mac::Address &  aMacDest,
+                            const ThreadLinkInfo &aLinkInfo);
     uint16_t PrepareDataFrame(Mac::TxFrame &      aFrame,
                               Message &           aMessage,
                               const Mac::Address &aMacSource,
@@ -342,7 +417,7 @@ private:
                                    uint16_t                aFragmentLength,
                                    uint16_t                aSrcRloc16,
                                    Message::Priority       aPriority);
-    otError HandleDatagram(Message &aMessage, const otThreadLinkInfo &aLinkInfo, const Mac::Address &aMacSource);
+    otError HandleDatagram(Message &aMessage, const ThreadLinkInfo &aLinkInfo, const Mac::Address &aMacSource);
     void    ClearReassemblyList(void);
     void    RemoveMessage(Message &aMessage);
     void    HandleDiscoverComplete(void);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3052,19 +3052,19 @@ exit:
 
 void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, uint32_t aKeySequence)
 {
-    otError                 error    = OT_ERROR_NONE;
-    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
-    Challenge               response;
-    uint16_t                version;
-    uint16_t                sourceAddress;
-    LeaderData              leaderData;
-    uint8_t                 linkMarginFromTlv;
-    uint8_t                 linkMargin;
-    uint8_t                 linkQuality;
-    ConnectivityTlv         connectivity;
-    uint32_t                linkFrameCounter;
-    uint32_t                mleFrameCounter;
-    Mac::ExtAddress         extAddress;
+    otError               error    = OT_ERROR_NONE;
+    const ThreadLinkInfo *linkInfo = aMessageInfo.GetThreadLinkInfo();
+    Challenge             response;
+    uint16_t              version;
+    uint16_t              sourceAddress;
+    LeaderData            leaderData;
+    uint8_t               linkMarginFromTlv;
+    uint8_t               linkMargin;
+    uint8_t               linkQuality;
+    ConnectivityTlv       connectivity;
+    uint32_t              linkFrameCounter;
+    uint32_t              mleFrameCounter;
+    Mac::ExtAddress       extAddress;
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     TimeParameterTlv timeParameter;
 #endif
@@ -3095,7 +3095,7 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
     // Link Margin
     SuccessOrExit(error = Tlv::FindUint8Tlv(aMessage, Tlv::kLinkMargin, linkMarginFromTlv));
 
-    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->GetRss());
 
     if (linkMargin > linkMarginFromTlv)
     {
@@ -3115,7 +3115,7 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
 
         parentinfo.mExtAddr      = extAddress;
         parentinfo.mRloc16       = sourceAddress;
-        parentinfo.mRssi         = linkInfo->mRss;
+        parentinfo.mRssi         = linkInfo->GetRss();
         parentinfo.mPriority     = connectivity.GetParentPriority();
         parentinfo.mLinkQuality3 = connectivity.GetLinkQuality3();
         parentinfo.mLinkQuality2 = connectivity.GetLinkQuality2();
@@ -3231,7 +3231,7 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
     mParentCandidate.SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                               DeviceMode::kModeFullNetworkData | DeviceMode::kModeSecureDataRequest));
     mParentCandidate.GetLinkInfo().Clear();
-    mParentCandidate.GetLinkInfo().AddRss(linkInfo->mRss);
+    mParentCandidate.GetLinkInfo().AddRss(linkInfo->GetRss());
     mParentCandidate.ResetLinkFailures();
     mParentCandidate.SetLinkQualityOut(LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMarginFromTlv));
     mParentCandidate.SetState(Neighbor::kStateParentResponse);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -622,11 +622,9 @@ void MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInf
 
             if (!neighbor->IsStateValid())
             {
-                const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
-
                 neighbor->SetExtAddress(extAddr);
                 neighbor->GetLinkInfo().Clear();
-                neighbor->GetLinkInfo().AddRss(linkInfo->mRss);
+                neighbor->GetLinkInfo().AddRss(aMessageInfo.GetThreadLinkInfo()->GetRss());
                 neighbor->ResetLinkFailures();
                 neighbor->SetLastHeard(TimerMilli::GetNow());
                 neighbor->SetState(Neighbor::kStateLinkRequest);
@@ -691,12 +689,11 @@ otError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo,
                                   const RequestedTlvs &   aRequestedTlvs,
                                   const Challenge &       aChallenge)
 {
-    otError                 error        = OT_ERROR_NONE;
-    const otThreadLinkInfo *linkInfo     = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
-    static const uint8_t    routerTlvs[] = {Tlv::kLinkMargin};
-    Message *               message;
-    Header::Command         command;
-    uint8_t                 linkMargin;
+    otError              error        = OT_ERROR_NONE;
+    static const uint8_t routerTlvs[] = {Tlv::kLinkMargin};
+    Message *            message;
+    Header::Command      command;
+    uint8_t              linkMargin;
 
     command = (aNeighbor == nullptr || aNeighbor->IsStateValid()) ? Header::kCommandLinkAccept
                                                                   : Header::kCommandLinkAcceptAndRequest;
@@ -710,7 +707,8 @@ otError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo,
     SuccessOrExit(error = AppendMleFrameCounter(*message));
 
     // always append a link margin, regardless of whether or not it was requested
-    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(),
+                                                         aMessageInfo.GetThreadLinkInfo()->GetRss());
 
     SuccessOrExit(error = AppendLinkMargin(*message, linkMargin));
 
@@ -815,21 +813,20 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
 {
     static const uint8_t dataRequestTlvs[] = {Tlv::kNetworkData};
 
-    otError                 error    = OT_ERROR_NONE;
-    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
-    Router *                router;
-    Neighbor::State         neighborState;
-    Mac::ExtAddress         extAddr;
-    uint16_t                version;
-    Challenge               response;
-    uint16_t                sourceAddress;
-    uint32_t                linkFrameCounter;
-    uint32_t                mleFrameCounter;
-    uint8_t                 routerId;
-    uint16_t                address16;
-    RouteTlv                route;
-    LeaderData              leaderData;
-    uint8_t                 linkMargin;
+    otError         error = OT_ERROR_NONE;
+    Router *        router;
+    Neighbor::State neighborState;
+    Mac::ExtAddress extAddr;
+    uint16_t        version;
+    Challenge       response;
+    uint16_t        sourceAddress;
+    uint32_t        linkFrameCounter;
+    uint32_t        mleFrameCounter;
+    uint8_t         routerId;
+    uint16_t        address16;
+    RouteTlv        route;
+    LeaderData      leaderData;
+    uint8_t         linkMargin;
 
     // Source Address
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
@@ -997,7 +994,7 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
     router->SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                      DeviceMode::kModeFullNetworkData));
     router->GetLinkInfo().Clear();
-    router->GetLinkInfo().AddRss(linkInfo->mRss);
+    router->GetLinkInfo().AddRss(aMessageInfo.GetThreadLinkInfo()->GetRss());
     router->SetLinkQualityOut(LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMargin));
     router->ResetLinkFailures();
     router->SetState(Neighbor::kStateValid);
@@ -1172,9 +1169,9 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
                                        const Ip6::MessageInfo &aMessageInfo,
                                        Neighbor *              aNeighbor)
 {
-    otError                 error    = OT_ERROR_NONE;
-    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
-    uint8_t linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->mRss);
+    otError               error    = OT_ERROR_NONE;
+    const ThreadLinkInfo *linkInfo = aMessageInfo.GetThreadLinkInfo();
+    uint8_t linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->GetRss());
     Mac::ExtAddress extAddr;
     uint16_t        sourceAddress = Mac::kShortAddrInvalid;
     LeaderData      leaderData;
@@ -1374,7 +1371,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
             {
                 router->SetExtAddress(extAddr);
                 router->GetLinkInfo().Clear();
-                router->GetLinkInfo().AddRss(linkInfo->mRss);
+                router->GetLinkInfo().AddRss(linkInfo->GetRss());
                 router->ResetLinkFailures();
                 router->SetLastHeard(TimerMilli::GetNow());
                 router->SetState(Neighbor::kStateLinkRequest);
@@ -1421,7 +1418,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
         {
             router->SetExtAddress(extAddr);
             router->GetLinkInfo().Clear();
-            router->GetLinkInfo().AddRss(linkInfo->mRss);
+            router->GetLinkInfo().AddRss(linkInfo->GetRss());
             router->ResetLinkFailures();
             router->SetLastHeard(TimerMilli::GetNow());
             router->SetState(Neighbor::kStateLinkRequest);
@@ -1598,14 +1595,13 @@ exit:
 
 void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    otError                 error    = OT_ERROR_NONE;
-    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
-    Mac::ExtAddress         extAddr;
-    uint16_t                version;
-    uint8_t                 scanMask;
-    Challenge               challenge;
-    Router *                leader;
-    Child *                 child;
+    otError         error = OT_ERROR_NONE;
+    Mac::ExtAddress extAddr;
+    uint16_t        version;
+    uint8_t         scanMask;
+    Challenge       challenge;
+    Router *        leader;
+    Child *         child;
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     TimeRequestTlv timeRequest;
 #endif
@@ -1679,7 +1675,7 @@ void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageI
         // MAC Address
         child->SetExtAddress(extAddr);
         child->GetLinkInfo().Clear();
-        child->GetLinkInfo().AddRss(linkInfo->mRss);
+        child->GetLinkInfo().AddRss(aMessageInfo.GetThreadLinkInfo()->GetRss());
         child->ResetLinkFailures();
         child->SetState(Neighbor::kStateParentRequest);
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
@@ -2226,23 +2222,22 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
                                      const Ip6::MessageInfo &aMessageInfo,
                                      uint32_t                aKeySequence)
 {
-    otError                 error    = OT_ERROR_NONE;
-    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
-    Mac::ExtAddress         extAddr;
-    uint16_t                version;
-    Challenge               response;
-    uint32_t                linkFrameCounter;
-    uint32_t                mleFrameCounter;
-    uint8_t                 modeBitmask;
-    DeviceMode              mode;
-    uint32_t                timeout;
-    RequestedTlvs           requestedTlvs;
-    ActiveTimestampTlv      activeTimestamp;
-    PendingTimestampTlv     pendingTimestamp;
-    Child *                 child;
-    Router *                router;
-    uint8_t                 numTlvs;
-    uint16_t                addressRegistrationOffset = 0;
+    otError             error = OT_ERROR_NONE;
+    Mac::ExtAddress     extAddr;
+    uint16_t            version;
+    Challenge           response;
+    uint32_t            linkFrameCounter;
+    uint32_t            mleFrameCounter;
+    uint8_t             modeBitmask;
+    DeviceMode          mode;
+    uint32_t            timeout;
+    RequestedTlvs       requestedTlvs;
+    ActiveTimestampTlv  activeTimestamp;
+    PendingTimestampTlv pendingTimestamp;
+    Child *             child;
+    Router *            router;
+    uint8_t             numTlvs;
+    uint16_t            addressRegistrationOffset = 0;
 
     LogMleMessage("Receive Child ID Request", aMessageInfo.GetPeerAddr());
 
@@ -2342,7 +2337,7 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     child->SetKeySequence(aKeySequence);
     child->SetDeviceMode(mode);
     child->SetVersion(static_cast<uint8_t>(version));
-    child->GetLinkInfo().AddRss(linkInfo->mRss);
+    child->GetLinkInfo().AddRss(aMessageInfo.GetThreadLinkInfo()->GetRss());
     child->SetTimeout(timeout);
 
     if (mode.IsFullNetworkData())
@@ -2573,17 +2568,16 @@ void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
                                           uint32_t                aKeySequence,
                                           Neighbor *              aNeighbor)
 {
-    otError                 error    = OT_ERROR_NONE;
-    const otThreadLinkInfo *linkInfo = static_cast<const otThreadLinkInfo *>(aMessageInfo.GetLinkInfo());
-    uint16_t                sourceAddress;
-    uint32_t                timeout;
-    Challenge               response;
-    uint8_t                 status;
-    uint32_t                linkFrameCounter;
-    uint32_t                mleFrameCounter;
-    LeaderData              leaderData;
-    Child *                 child;
-    uint16_t                addressRegistrationOffset = 0;
+    otError    error = OT_ERROR_NONE;
+    uint16_t   sourceAddress;
+    uint32_t   timeout;
+    Challenge  response;
+    uint8_t    status;
+    uint32_t   linkFrameCounter;
+    uint32_t   mleFrameCounter;
+    LeaderData leaderData;
+    Child *    child;
+    uint16_t   addressRegistrationOffset = 0;
 
     if ((aNeighbor == nullptr) || IsActiveRouter(aNeighbor->GetRloc16()))
     {
@@ -2704,7 +2698,7 @@ void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
     SetChildStateToValid(*child);
     child->SetLastHeard(TimerMilli::GetNow());
     child->SetKeySequence(aKeySequence);
-    child->GetLinkInfo().AddRss(linkInfo->mRss);
+    child->GetLinkInfo().AddRss(aMessageInfo.GetThreadLinkInfo()->GetRss());
 
 exit:
 


### PR DESCRIPTION
The `ThreadLinkInfo` mirrors the `otThreadLinkInfo` definition.
It is mostly used in `MeshForwarder` and `Mle` class. Here are
some related helper methods:
- New helper methods in `Ip6::MessageInfo` to get and set the
  link info as `ThreadLinkInfo`.
- Helper method `ThreadLinkInfo::SetFrom()` allows it to be set
  from a given `Mac::RxFrame`.
- Helper method `Message::SetLinkInfo()` allows message link info
  related fields (in message metadata) to be set/updated from a
  given `ThreadLinkInfo`.