### PR TITLE
[github-actions] fix otns test failure

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -76,10 +76,10 @@ jobs:
     - uses: actions/setup-go@v1
       with:
         go-version: '1.13'
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 3.6
       uses: actions/setup-python@v1
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.6
     - name: Bootstrap
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -76,6 +76,10 @@ jobs:
     - uses: actions/setup-go@v1
       with:
         go-version: '1.13'
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v1
+      with:
+        python-version: ${{ matrix.python-version }}
     - name: Bootstrap
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update


### PR DESCRIPTION
This PR fixes OTNS test fails reported by #5402 @jwhui 

The OTNS test of OpenThread CI is supposed to be a subset of OTNS CI tests. So, Openthread's OTNS test should never fail if the merged OTNS PRs has all passed OTNS CI.

Turnout in OTNS CI, a setup is used to further setup the Python3 env which seems to make the Python env more reliable. 
```yml
    - name: Set up Python 3.6
      uses: actions/setup-python@v1
      with:
        python-version: 3.6
```

Adding this step in the OpenThread's OTNS test job fixes the issue.