### PR TITLE
[udp6] fix 'Udp::Socket::Connect(uint16_t aPort)'

### DIFF
--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -107,7 +107,7 @@ otError Udp::Socket::Connect(const SockAddr &aSockAddr)
 
 otError Udp::Socket::Connect(uint16_t aPort)
 {
-    return Bind(SockAddr(aPort));
+    return Connect(SockAddr(aPort));
 }
 
 otError Udp::Socket::Close(void)


### PR DESCRIPTION
----

This fixes an issue with new `Connect(uint16_t port)` added in #5319.
The new overload of the `Connect()` method seems to be only used from `Dtls::Disconnect()`