### PR TITLE
[cli] fix crash when full logs is on

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -251,6 +251,8 @@ const struct Command Interpreter::sCommands[] = {
     {"version", &Interpreter::ProcessVersion},
 };
 
+Interpreter *Interpreter::sInterpreter = nullptr;
+
 Interpreter::Interpreter(Instance *aInstance)
     : mUserCommands(nullptr)
     , mUserCommandsLength(0)
@@ -4648,30 +4650,50 @@ int Interpreter::OutputFormatV(const char *aFormat, va_list aArguments)
 
 extern "C" void otCliSetUserCommands(const otCliCommand *aUserCommands, uint8_t aLength)
 {
+    VerifyOrExit(Interpreter::IsInitialized(), OT_NOOP);
+
     Interpreter::GetInterpreter().SetUserCommands(aUserCommands, aLength);
+exit:
+    return;
 }
 
 extern "C" void otCliOutputBytes(const uint8_t *aBytes, uint8_t aLength)
 {
+    VerifyOrExit(Interpreter::IsInitialized(), OT_NOOP);
+
     Interpreter::GetInterpreter().OutputBytes(aBytes, aLength);
+exit:
+    return;
 }
 
 extern "C" void otCliOutputFormat(const char *aFmt, ...)
 {
+    VerifyOrExit(Interpreter::IsInitialized(), OT_NOOP);
+
     va_list aAp;
     va_start(aAp, aFmt);
     Interpreter::GetInterpreter().OutputFormatV(aFmt, aAp);
     va_end(aAp);
+exit:
+    return;
 }
 
 extern "C" void otCliOutput(const char *aString, uint16_t aLength)
 {
+    VerifyOrExit(Interpreter::IsInitialized(), OT_NOOP);
+
     Interpreter::GetInterpreter().Output(aString, aLength);
+exit:
+    return;
 }
 
 extern "C" void otCliAppendResult(otError aError)
 {
+    VerifyOrExit(Interpreter::IsInitialized(), OT_NOOP);
+
     Interpreter::GetInterpreter().AppendResult(aError);
+exit:
+    return;
 }
 
 extern "C" void otCliPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aArgs)
@@ -4679,8 +4701,12 @@ extern "C" void otCliPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, cons
     OT_UNUSED_VARIABLE(aLogLevel);
     OT_UNUSED_VARIABLE(aLogRegion);
 
+    VerifyOrExit(Interpreter::IsInitialized(), OT_NOOP);
+
     Interpreter::GetInterpreter().OutputFormatV(aFormat, aArgs);
     Interpreter::GetInterpreter().OutputFormat("\r\n");
+exit:
+    return;
 }
 
 } // namespace Cli

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -4650,50 +4650,30 @@ int Interpreter::OutputFormatV(const char *aFormat, va_list aArguments)
 
 extern "C" void otCliSetUserCommands(const otCliCommand *aUserCommands, uint8_t aLength)
 {
-    VerifyOrExit(Interpreter::IsInitialized(), OT_NOOP);
-
     Interpreter::GetInterpreter().SetUserCommands(aUserCommands, aLength);
-exit:
-    return;
 }
 
 extern "C" void otCliOutputBytes(const uint8_t *aBytes, uint8_t aLength)
 {
-    VerifyOrExit(Interpreter::IsInitialized(), OT_NOOP);
-
     Interpreter::GetInterpreter().OutputBytes(aBytes, aLength);
-exit:
-    return;
 }
 
 extern "C" void otCliOutputFormat(const char *aFmt, ...)
 {
-    VerifyOrExit(Interpreter::IsInitialized(), OT_NOOP);
-
     va_list aAp;
     va_start(aAp, aFmt);
     Interpreter::GetInterpreter().OutputFormatV(aFmt, aAp);
     va_end(aAp);
-exit:
-    return;
 }
 
 extern "C" void otCliOutput(const char *aString, uint16_t aLength)
 {
-    VerifyOrExit(Interpreter::IsInitialized(), OT_NOOP);
-
     Interpreter::GetInterpreter().Output(aString, aLength);
-exit:
-    return;
 }
 
 extern "C" void otCliAppendResult(otError aError)
 {
-    VerifyOrExit(Interpreter::IsInitialized(), OT_NOOP);
-
     Interpreter::GetInterpreter().AppendResult(aError);
-exit:
-    return;
 }
 
 extern "C" void otCliPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aArgs)

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -115,7 +115,12 @@ public:
      * @returns A reference to the interpreter object.
      *
      */
-    static Interpreter &GetInterpreter(void) { return *sInterpreter; }
+    static Interpreter &GetInterpreter(void)
+    {
+        OT_ASSERT(sInterpreter != nullptr);
+
+        return *sInterpreter;
+    }
 
     /**
      * This method returns whether the interpreter is initialized.

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -115,7 +115,15 @@ public:
      * @returns A reference to the interpreter object.
      *
      */
-    static Interpreter &GetInterpreter(void);
+    static Interpreter &GetInterpreter(void) { return *sInterpreter; }
+
+    /**
+     * This method returns whether the interpreter is initialized.
+     *
+     * @returns  Whether the interpreter is initialized.
+     *
+     */
+    static bool IsInitialized(void) { return sInterpreter != nullptr; }
 
     /**
      * This method interprets a CLI command.
@@ -235,6 +243,9 @@ public:
      * @param[in]  aLength        @p aUserCommands length.
      */
     void SetUserCommands(const otCliCommand *aCommands, uint8_t aLength);
+
+protected:
+    static Interpreter *sInterpreter;
 
 private:
     enum

--- a/src/cli/cli_console.cpp
+++ b/src/cli/cli_console.cpp
@@ -69,18 +69,11 @@ extern "C" void otPlatUartSendDone(void)
 {
 }
 
-Console *Console::sConsole = nullptr;
-
-Interpreter &Interpreter::GetInterpreter(void)
-{
-    return *Console::sConsole;
-}
-
 void Console::Initialize(otInstance *aInstance, otCliConsoleOutputCallback aCallback, void *aContext)
 {
     Instance *instance = static_cast<Instance *>(aInstance);
 
-    sConsole = new (&sCliConsoleRaw) Console(instance, aCallback, aContext);
+    Interpreter::sInterpreter = new (&sCliConsoleRaw) Console(instance, aCallback, aContext);
 }
 
 Console::Console(Instance *aInstance, otCliConsoleOutputCallback aCallback, void *aContext)

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -105,17 +105,10 @@ namespace Cli {
 
 static OT_DEFINE_ALIGNED_VAR(sCliUartRaw, sizeof(Uart), uint64_t);
 
-Uart *Uart::sUart = nullptr;
-
-Interpreter &Interpreter::GetInterpreter(void)
-{
-    return *Uart::sUart;
-}
-
 void Uart::Initialize(otInstance *aInstance)
 {
-    Instance *instance = static_cast<Instance *>(aInstance);
-    sUart              = new (&sCliUartRaw) Uart(instance);
+    Instance *instance        = static_cast<Instance *>(aInstance);
+    Interpreter::sInterpreter = new (&sCliUartRaw) Uart(instance);
 }
 
 Uart::Uart(Instance *aInstance)


### PR DESCRIPTION
It is possible that log is printed before the Interpreter (UART or CONSOLE) object is created when `FULL LOGS` is enabled. In such case, OT crashes. 
This PR fixes this bug. 

This bug was introduced by #5387 