### PR TITLE
[efr32] switch to proper config #include style

### DIFF
--- a/examples/platforms/efr32mg1/flash.c
+++ b/examples/platforms/efr32mg1/flash.c
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread platform abstraction for the non-volatile storage.
  */
 
-#include "openthread-core-efr32-config.h"
+#include <openthread-core-config.h>
 #include <openthread/config.h>
 
 #if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE // Use OT NV system

--- a/examples/platforms/efr32mg1/radio.c
+++ b/examples/platforms/efr32mg1/radio.c
@@ -32,6 +32,9 @@
  *
  */
 
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
 #include <assert.h>
 
 #include "openthread-system.h"
@@ -50,7 +53,6 @@
 #include "em_core.h"
 #include "em_system.h"
 #include "hal-config.h"
-#include "openthread-core-efr32-config.h"
 #include "pa_conversions_efr32.h"
 #include "platform-band.h"
 #include "rail.h"

--- a/examples/platforms/efr32mg1/system.c
+++ b/examples/platforms/efr32mg1/system.c
@@ -32,6 +32,9 @@
  *   This file includes the platform-specific initializers.
  */
 
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
 #include <assert.h>
 #include <string.h>
 
@@ -52,7 +55,6 @@
 #include "sl_mpu.h"
 #include "sl_sleeptimer.h"
 
-#include "openthread-core-efr32-config.h"
 #include "platform-efr32.h"
 
 #if (HAL_FEM_ENABLE)

--- a/examples/platforms/efr32mg12/flash.c
+++ b/examples/platforms/efr32mg12/flash.c
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread platform abstraction for the non-volatile storage.
  */
 
-#include "openthread-core-efr32-config.h"
+#include <openthread-core-config.h>
 #include <openthread/config.h>
 
 #if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE // Use OT NV system

--- a/examples/platforms/efr32mg12/radio.c
+++ b/examples/platforms/efr32mg12/radio.c
@@ -32,6 +32,9 @@
  *
  */
 
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
 #include <assert.h>
 
 #include "openthread-system.h"
@@ -50,7 +53,6 @@
 #include "em_core.h"
 #include "em_system.h"
 #include "hal-config.h"
-#include "openthread-core-efr32-config.h"
 #include "pa_conversions_efr32.h"
 #include "platform-band.h"
 #include "rail.h"

--- a/examples/platforms/efr32mg12/system.c
+++ b/examples/platforms/efr32mg12/system.c
@@ -32,6 +32,9 @@
  *   This file includes the platform-specific initializers.
  */
 
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
 #include <assert.h>
 #include <string.h>
 
@@ -52,7 +55,6 @@
 #include "sl_mpu.h"
 #include "sl_sleeptimer.h"
 
-#include "openthread-core-efr32-config.h"
 #include "platform-efr32.h"
 
 #if (HAL_FEM_ENABLE)

--- a/examples/platforms/efr32mg13/flash.c
+++ b/examples/platforms/efr32mg13/flash.c
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread platform abstraction for the non-volatile storage.
  */
 
-#include "openthread-core-efr32-config.h"
+#include <openthread-core-config.h>
 #include <openthread/config.h>
 
 #if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE // Use OT NV system

--- a/examples/platforms/efr32mg13/radio.c
+++ b/examples/platforms/efr32mg13/radio.c
@@ -32,6 +32,9 @@
  *
  */
 
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
 #include <assert.h>
 
 #include "openthread-system.h"
@@ -50,7 +53,6 @@
 #include "em_core.h"
 #include "em_system.h"
 #include "hal-config.h"
-#include "openthread-core-efr32-config.h"
 #include "pa_conversions_efr32.h"
 #include "platform-band.h"
 #include "rail.h"

--- a/examples/platforms/efr32mg13/system.c
+++ b/examples/platforms/efr32mg13/system.c
@@ -32,6 +32,9 @@
  *   This file includes the platform-specific initializers.
  */
 
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
 #include <assert.h>
 #include <string.h>
 

--- a/examples/platforms/efr32mg21/flash.c
+++ b/examples/platforms/efr32mg21/flash.c
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread platform abstraction for the non-volatile storage.
  */
 
-#include "openthread-core-efr32-config.h"
+#include <openthread-core-config.h>
 #include <openthread/config.h>
 
 #if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE // Use OT NV system

--- a/examples/platforms/efr32mg21/radio.c
+++ b/examples/platforms/efr32mg21/radio.c
@@ -32,10 +32,12 @@
  *
  */
 
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
 #include <assert.h>
 
 #include "openthread-system.h"
-#include <openthread/config.h>
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
 #include <openthread/platform/radio.h>
@@ -49,7 +51,6 @@
 #include "em_cmu.h"
 #include "em_core.h"
 #include "em_system.h"
-#include "openthread-core-efr32-config.h"
 #include "pa_conversions_efr32.h"
 #include "platform-band.h"
 #include "rail.h"

--- a/examples/platforms/efr32mg21/system.c
+++ b/examples/platforms/efr32mg21/system.c
@@ -32,6 +32,9 @@
  *   This file includes the platform-specific initializers.
  */
 
+#include <openthread-core-config.h>
+#include <openthread/config.h>
+
 #include <assert.h>
 #include <string.h>
 
@@ -52,7 +55,6 @@
 #include "sl_mpu.h"
 #include "sl_sleeptimer.h"
 
-#include "openthread-core-efr32-config.h"
 #include "platform-efr32.h"
 
 #if (HAL_FEM_ENABLE)


### PR DESCRIPTION
Use the config specified on the command line, so that overriding this
with a project specific config doesn't cause preprocessor macro
redefinition errors.