### PR TITLE
[ip6] simplify `Ip6:Header` and misc. enhancements

### DIFF
--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -314,9 +314,9 @@ void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSeque
 
     if (!aIsOutbound)
     {
-        aMessage.Read(Header::GetHopLimitOffset(), Header::GetHopLimitSize(), &hopLimit);
+        aMessage.Read(Header::kHopLimitFieldOffset, sizeof(hopLimit), &hopLimit);
         VerifyOrExit(hopLimit-- > 1, error = OT_ERROR_DROP);
-        messageCopy->Write(Header::GetHopLimitOffset(), Header::GetHopLimitSize(), &hopLimit);
+        messageCopy->Write(Header::kHopLimitFieldOffset, sizeof(hopLimit), &hopLimit);
     }
 
     metadata.mSeedId            = aSeedId;

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -1177,7 +1177,7 @@ int Lowpan::Decompress(Message &           aMessage,
             HostSwap16(aMessage.GetOffset() - currentOffset - sizeof(Ip6::Header) + aBufLength - compressedLength);
     }
 
-    aMessage.Write(currentOffset + Ip6::Header::GetPayloadLengthOffset(), sizeof(ip6PayloadLength), &ip6PayloadLength);
+    aMessage.Write(currentOffset + Ip6::Header::kPayloadLengthFieldOffset, sizeof(ip6PayloadLength), &ip6PayloadLength);
 
     error = OT_ERROR_NONE;
 

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -150,7 +150,7 @@ void MeshForwarder::HandleResolved(const Ip6::Address &aEid, otError aError)
             continue;
         }
 
-        cur->Read(Ip6::Header::GetDestinationOffset(), sizeof(ip6Dst), &ip6Dst);
+        cur->Read(Ip6::Header::kDestinationFieldOffset, sizeof(ip6Dst), &ip6Dst);
 
         if (ip6Dst == aEid)
         {


### PR DESCRIPTION
This commit contain a list of smaller enhancements in `Ip6` modules:
- Simplify `Ip6::Header` removing the PoD definition and providing
  `enum` constants for the byte offset to different fields in the header
  (replacing/removing static methods).
- Declare some of the `Ip6` methods as `private`.
- Remove error logs (not used/applicable anymore).
- Simplify checking of `destPort` in `ProcessReceiveCallback()`.
- Specify `int` size of `enum` definitions (declare internally-used
  `enum`s a `private`).
- Add unit test `TestIp6Header()`.