### PR TITLE
[extension] add method to receive and handle notifier events

### DIFF
--- a/src/core/common/extension.hpp
+++ b/src/core/common/extension.hpp
@@ -38,6 +38,7 @@
 
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
+#include "common/notifier.hpp"
 
 #if OPENTHREAD_ENABLE_VENDOR_EXTENSION
 
@@ -95,6 +96,14 @@ public:
      *
      */
     void SignalNcpInit(Ncp::NcpBase &aNcpInstance);
+
+    /**
+     * This method notifies the extension object of events from  OpenThread `Notifier`.
+     *
+     * @param[in] aEvents   The list of events emitted by `Notifier`.
+     *
+     */
+    void HandleNotifierEvents(Events aEvents);
 
 protected:
     /**

--- a/src/core/common/extension_example.cpp
+++ b/src/core/common/extension_example.cpp
@@ -92,5 +92,12 @@ void ExtensionBase::SignalNcpInit(Ncp::NcpBase &aNcpBase)
     OT_UNUSED_VARIABLE(aNcpBase);
 }
 
+void ExtensionBase::HandleNotifierEvents(Events aEvents)
+{
+    // TODO: Implement vendor extension code here to handle notifier events.
+
+    OT_UNUSED_VARIABLE(aEvents);
+}
+
 } // namespace Extension
 } // namespace ot

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -178,6 +178,9 @@ void Notifier::EmitEvents(void)
 #if OPENTHREAD_CONFIG_OTNS_ENABLE
     Get<Utils::Otns>().HandleNotifierEvents(events);
 #endif
+#if OPENTHREAD_ENABLE_VENDOR_EXTENSION
+    Get<Extension::ExtensionBase>().HandleNotifierEvents(events);
+#endif
 
     for (ExternalCallback &callback : mExternalCallbacks)
     {


### PR DESCRIPTION
This commit adds `ExtnesionBase` (base class of vendor `Extension`)
as one of the event receivers from `Notifier` class.