### PR TITLE
[github-action] fix coverage uploading for expects

### DIFF
--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -73,19 +73,19 @@ jobs:
         ./script/test cert_suite tests/scripts/thread-cert/v1_2_*
     - name: Keep-1-2-only
       run: |
-        ./script/test tar 1.1
-        ./script/test tar 1.2-bbr
+        ./script/test tar simulation 1.1
+        ./script/test tar simulation 1.2-bbr
     - name: Codecov
       uses: codecov/codecov-action@v1
     - name: Keep-1-2-bbr-only
       run: |
-        ./script/test tar 1.2
-        ./script/test untar 1.2-bbr
+        ./script/test tar simulation 1.2
+        ./script/test untar simulation 1.2-bbr
     - name: Codecov
       uses: codecov/codecov-action@v1
     - name: Keep-1-1-only
       run: |
-        ./script/test tar 1.2-bbr
-        ./script/test untar 1.1
+        ./script/test tar simulation 1.2-bbr
+        ./script/test untar simulation 1.1
     - name: Codecov
       uses: codecov/codecov-action@v1

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -219,6 +219,15 @@ jobs:
     - name: Run RCP Mode
       run: |
         OT_OPTIONS=-DOT_READLINE=OFF VIRTUAL_TIME=0 NODE_MODE=rcp ./script/test clean build expect
+    - name: Keep POSIX Only
+      run: |
+        ./script/test tar simulation 1.1
+    - name: Codecov
+      uses: codecov/codecov-action@v1
+    - name: Keep Simulation Only
+      run: |
+        ./script/test tar posix 1.1
+        ./script/test untar simulation 1.1
     - name: Codecov
       uses: codecov/codecov-action@v1
     - name: Run TUN Mode
@@ -231,6 +240,15 @@ jobs:
         sudo systemctl restart dnsmasq
         host ipv6.google.com ::1
         OT_OPTIONS=-DOT_READLINE=OFF OT_NATIVE_IP=1 VIRTUAL_TIME=0 NODE_MODE=rcp ./script/test clean build expect
+    - name: Keep POSIX Only
+      run: |
+        ./script/test tar simulation 1.1
+    - name: Codecov
+      uses: codecov/codecov-action@v1
+    - name: Keep Simulation Only
+      run: |
+        ./script/test tar posix 1.1
+        ./script/test untar simulation 1.1
     - name: Codecov
       uses: codecov/codecov-action@v1
 

--- a/script/test
+++ b/script/test
@@ -334,7 +334,7 @@ do_package()
 
 do_tar()
 {
-    local target_name="openthread-simulation-$1"
+    local target_name="openthread-$1-$2"
     local build_dir="${OT_BUILDDIR}/cmake"
     tar -cf "${target_name}.tar" -C "${build_dir}" "${target_name}"
     mv "${target_name}.tar" "${build_dir}/"
@@ -343,7 +343,7 @@ do_tar()
 
 do_untar()
 {
-    local target_name="openthread-simulation-$1"
+    local target_name="openthread-$1-$2"
     local build_dir="${OT_BUILDDIR}/cmake"
     tar -xf "${build_dir}/${target_name}.tar" -C "${build_dir}"
     rm "${build_dir:?}/${target_name}.tar"
@@ -437,11 +437,11 @@ main()
                 ;;
             tar)
                 shift
-                do_tar "$1"
+                do_tar "$@"
                 ;;
             untar)
                 shift
-                do_untar "$1"
+                do_untar "$@"
                 ;;
         esac
         shift


### PR DESCRIPTION
This PR changes the coverage data uploading for `expects` job so that it only uploads data for one build at a time, to make coverage more stable. Applies the same strategy of https://github.com/openthread/openthread/pull/5375 to this job.