### PR TITLE
[size-report] add size-report for Thread 1.2

### DIFF
--- a/script/check-size
+++ b/script/check-size
@@ -98,7 +98,7 @@ markdown()
     esac
 }
 
-size_nrf52840()
+size_nrf52840_version()
 {
     local flags=(
         "BORDER_AGENT=1"
@@ -128,6 +128,18 @@ size_nrf52840()
         "UDP_FORWARD=1"
     )
 
+    local thread_version=$1
+
+    if [[ ${thread_version} == "1.2" ]]; then
+        flags+=(
+            "THREAD_VERSION=1.2"
+            "BACKBONE_ROUTER=1"
+            "DUA=1"
+            "MLR=1"
+            # "CSL_RECEIVER=1" not supported on nrf52840 yet
+        )
+    fi
+
     rm -rf "${OT_TMP_DIR}"
 
     # new commit
@@ -149,6 +161,39 @@ size_nrf52840()
         && ./bootstrap \
         && make -f examples/Makefile-nrf52840 "${flags[@]}")
 
+    # rename the generated files to be ready for size-report
+    # shellcheck disable=SC2011
+    (
+        cd "${OT_TMP_DIR}"/a/output/nrf52840/bin
+        ls | xargs -I{} mv {} {}_"${thread_version}"
+        cd "${OT_TMP_DIR}"/b/output/nrf52840/bin
+        ls | xargs -I{} mv {} {}_"${thread_version}"
+
+        cd "${OT_TMP_DIR}"/a/output/nrf52840/lib/
+        ls ./*.a | xargs -I{} mv {} {}_"${thread_version}"
+        cd "${OT_TMP_DIR}"/b/output/nrf52840/lib/
+        ls ./*.a | xargs -I{} mv {} {}_"${thread_version}"
+    )
+
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-cli-ftd_"${thread_version}" "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-cli-ftd_"${thread_version}"
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-cli-mtd_"${thread_version}" "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-cli-mtd_"${thread_version}"
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-ncp-ftd_"${thread_version}" "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-ncp-ftd_"${thread_version}"
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-ncp-mtd_"${thread_version}" "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-ncp-mtd_"${thread_version}"
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-rcp_"${thread_version}" "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-rcp_"${thread_version}"
+
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-cli-ftd.a_"${thread_version}" "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-cli-ftd.a_"${thread_version}"
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-cli-mtd.a_"${thread_version}" "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-cli-mtd.a_"${thread_version}"
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-ftd.a_"${thread_version}" "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-ftd.a_"${thread_version}"
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-mtd.a_"${thread_version}" "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-mtd.a_"${thread_version}"
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-ncp-ftd.a_"${thread_version}" "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-ncp-ftd.a_"${thread_version}"
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-ncp-mtd.a_"${thread_version}" "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-ncp-mtd.a_"${thread_version}"
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-rcp.a_"${thread_version}" "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-rcp.a_"${thread_version}"
+    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-radio.a_"${thread_version}" "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-radio.a_"${thread_version}"
+}
+
+size_nrf52840()
+{
+
     local reporter
 
     # not on GitHub Actions or not a pull request event
@@ -163,20 +208,8 @@ size_nrf52840()
 
     "${reporter}" init OpenThread
 
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-cli-ftd "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-cli-ftd
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-cli-mtd "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-cli-mtd
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-ncp-ftd "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-ncp-ftd
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-ncp-mtd "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-ncp-mtd
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/bin/ot-rcp "${OT_TMP_DIR}"/b/output/nrf52840/bin/ot-rcp
-
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-cli-ftd.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-cli-ftd.a
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-cli-mtd.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-cli-mtd.a
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-ftd.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-ftd.a
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-mtd.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-mtd.a
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-ncp-ftd.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-ncp-ftd.a
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-ncp-mtd.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-ncp-mtd.a
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-rcp.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-rcp.a
-    "${reporter}" size "${OT_TMP_DIR}"/a/output/nrf52840/lib/libopenthread-radio.a "${OT_TMP_DIR}"/b/output/nrf52840/lib/libopenthread-radio.a
+    size_nrf52840_version 1.1
+    size_nrf52840_version 1.2
 
     "${reporter}" post
 }


### PR DESCRIPTION
This PR adds size-report for Thread 1.2 features in the simplest way that **does not require any change to [openthread-size-report](https://glitch.com/edit/#!/openthread-size-report) on Glitch**. 

Size reports for both Thread 1.1 and 1.2 are posted in the same comment with 1.2 report below 1.1 report.

This PR does not fully address style related comments in #5274, which we can leave to future enhancements.

**QUESTION: should we put 1.2 report above 1.1 report instead?**