### PR TITLE
[low-power] keep configured CSL channel for child

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2540,7 +2540,7 @@ void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
         {
             child->SetCslChannel(static_cast<uint8_t>(cslChannel.GetChannel()));
         }
-        else
+        else if (child->GetCslChannel() == 0)
         {
             child->SetCslChannel(Get<Mac::Mac>().GetPanChannel());
         }


### PR DESCRIPTION
A SSED uses the Child Update Request to start CSL synchronization. If the CSL Channel TLV is not present in the message, the parent assigns the Thread Network channel as the CSL channel for this child during the attachment.

However, it may happen that a child changes its CSL channel to a different one with a Child Update Request and decides to keep using it. In a subsequent Child Update Request it could omit the CSL Channel TLV (no changes) but the parent would change its CSL channel to the Thread Network channel. This PR avoids that.