### PR TITLE
[neighbor-table] add 'StateFilter' parameter in 'Find' methods

### DIFF
--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -63,19 +63,19 @@ Neighbor *NeighborTable::FindParent(const Neighbor::AddressMatcher &aMatcher)
     return neighbor;
 }
 
-Neighbor *NeighborTable::FindParent(Mac::ShortAddress aShortAddress)
+Neighbor *NeighborTable::FindParent(Mac::ShortAddress aShortAddress, Neighbor::StateFilter aFilter)
 {
-    return FindParent(Neighbor::AddressMatcher(aShortAddress, Neighbor::kInStateValidOrRestoring));
+    return FindParent(Neighbor::AddressMatcher(aShortAddress, aFilter));
 }
 
-Neighbor *NeighborTable::FindParent(const Mac::ExtAddress &aExtAddress)
+Neighbor *NeighborTable::FindParent(const Mac::ExtAddress &aExtAddress, Neighbor::StateFilter aFilter)
 {
-    return FindParent(Neighbor::AddressMatcher(aExtAddress, Neighbor::kInStateValidOrRestoring));
+    return FindParent(Neighbor::AddressMatcher(aExtAddress, aFilter));
 }
 
-Neighbor *NeighborTable::FindParent(const Mac::Address &aMacAddress)
+Neighbor *NeighborTable::FindParent(const Mac::Address &aMacAddress, Neighbor::StateFilter aFilter)
 {
-    return FindParent(Neighbor::AddressMatcher(aMacAddress, Neighbor::kInStateValidOrRestoring));
+    return FindParent(Neighbor::AddressMatcher(aMacAddress, aFilter));
 }
 
 Neighbor *NeighborTable::FindNeighbor(const Neighbor::AddressMatcher &aMatcher)
@@ -97,25 +97,25 @@ Neighbor *NeighborTable::FindNeighbor(const Neighbor::AddressMatcher &aMatcher)
     return neighbor;
 }
 
-Neighbor *NeighborTable::FindNeighbor(Mac::ShortAddress aShortAddress)
+Neighbor *NeighborTable::FindNeighbor(Mac::ShortAddress aShortAddress, Neighbor::StateFilter aFilter)
 {
     Neighbor *neighbor = nullptr;
 
     VerifyOrExit((aShortAddress != Mac::kShortAddrBroadcast) && (aShortAddress != Mac::kShortAddrInvalid), OT_NOOP);
-    neighbor = FindNeighbor(Neighbor::AddressMatcher(aShortAddress, Neighbor::kInStateValidOrRestoring));
+    neighbor = FindNeighbor(Neighbor::AddressMatcher(aShortAddress, aFilter));
 
 exit:
     return neighbor;
 }
 
-Neighbor *NeighborTable::FindNeighbor(const Mac::ExtAddress &aExtAddress)
+Neighbor *NeighborTable::FindNeighbor(const Mac::ExtAddress &aExtAddress, Neighbor::StateFilter aFilter)
 {
-    return FindNeighbor(Neighbor::AddressMatcher(aExtAddress, Neighbor::kInStateValidOrRestoring));
+    return FindNeighbor(Neighbor::AddressMatcher(aExtAddress, aFilter));
 }
 
-Neighbor *NeighborTable::FindNeighbor(const Mac::Address &aMacAddress)
+Neighbor *NeighborTable::FindNeighbor(const Mac::Address &aMacAddress, Neighbor::StateFilter aFilter)
 {
-    return FindNeighbor(Neighbor::AddressMatcher(aMacAddress, Neighbor::kInStateValidOrRestoring));
+    return FindNeighbor(Neighbor::AddressMatcher(aMacAddress, aFilter));
 }
 
 #if OPENTHREAD_FTD
@@ -134,7 +134,7 @@ Neighbor *NeighborTable::FindChildOrRouter(const Neighbor::AddressMatcher &aMatc
     return neighbor;
 }
 
-Neighbor *NeighborTable::FindNeighbor(const Ip6::Address &aIp6Address)
+Neighbor *NeighborTable::FindNeighbor(const Ip6::Address &aIp6Address, Neighbor::StateFilter aFilter)
 {
     Neighbor *   neighbor = nullptr;
     Mac::Address macAddresss;
@@ -151,11 +151,11 @@ Neighbor *NeighborTable::FindNeighbor(const Ip6::Address &aIp6Address)
 
     if (!macAddresss.IsNone())
     {
-        neighbor = FindChildOrRouter(Neighbor::AddressMatcher(macAddresss, Neighbor::kInStateValidOrRestoring));
+        neighbor = FindChildOrRouter(Neighbor::AddressMatcher(macAddresss, aFilter));
         ExitNow();
     }
 
-    for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValidOrRestoring))
+    for (Child &child : Get<ChildTable>().Iterate(aFilter))
     {
         if (child.HasIp6Address(aIp6Address))
         {

--- a/src/core/thread/neighbor_table.hpp
+++ b/src/core/thread/neighbor_table.hpp
@@ -85,63 +85,75 @@ public:
      * address.
      *
      * @param[in]  aShortAddress  A short address.
+     * @param[in]  aFilter        A neighbor state filter
      *
      * @returns A pointer to the `Neighbor` corresponding to @p aShortAddress, nullptr otherwise.
      *
      */
-    Neighbor *FindParent(Mac::ShortAddress aShortAddress);
+    Neighbor *FindParent(Mac::ShortAddress     aShortAddress,
+                         Neighbor::StateFilter aFilter = Neighbor::kInStateValidOrRestoring);
 
     /**
      * This method searches in parent and parent candidate to find a `Neighbor` corresponding to a given MAC Extended
      * Address.
      *
      * @param[in]  aExtAddress   A MAC Extended Address.
+     * @param[in]  aFilter       A neighbor state filter
      *
      * @returns A pointer to the `Neighbor` corresponding to @p aExtAddress, nullptr otherwise.
      *
      */
-    Neighbor *FindParent(const Mac::ExtAddress &aExtAddress);
+    Neighbor *FindParent(const Mac::ExtAddress &aExtAddress,
+                         Neighbor::StateFilter  aFilter = Neighbor::kInStateValidOrRestoring);
 
     /**
      * This method searches among parent and parent candidate to find a `Neighbor` object corresponding to a given MAC
      * address.
      *
      * @param[in]  aMacAddress  A MAC address.
+     * @param[in]  aFilter      A neighbor state filter
      *
      * @returns A pointer to the `Neighbor` corresponding to @p aMacAddress, nullptr otherwise.
      *
      */
-    Neighbor *FindParent(const Mac::Address &aMacAddress);
+    Neighbor *FindParent(const Mac::Address &  aMacAddress,
+                         Neighbor::StateFilter aFilter = Neighbor::kInStateValidOrRestoring);
 
     /**
      * This method searches in the neighbor table to find a `Neighbor` corresponding to a given short address.
      *
      * @param[in]  aShortAddress  A short address.
+     * @param[in]  aFilter        A neighbor state filter.
      *
      * @returns A pointer to the `Neighbor` corresponding to @p aShortAddress, nullptr otherwise.
      *
      */
-    Neighbor *FindNeighbor(Mac::ShortAddress aShortAddress);
+    Neighbor *FindNeighbor(Mac::ShortAddress     aShortAddress,
+                           Neighbor::StateFilter aFilter = Neighbor::kInStateValidOrRestoring);
 
     /**
      * This method searches in the neighbor table to find a `Neighbor` corresponding to a given MAC Extended Address.
      *
      * @param[in]  aExtAddress   A MAC Extended Address.
+     * @param[in]  aFilter       A neighbor state filter.
      *
      * @returns A pointer to the `Neighbor` corresponding to @p aExtAddress, nullptr otherwise.
      *
      */
-    Neighbor *FindNeighbor(const Mac::ExtAddress &aExtAddress);
+    Neighbor *FindNeighbor(const Mac::ExtAddress &aExtAddress,
+                           Neighbor::StateFilter  aFilter = Neighbor::kInStateValidOrRestoring);
 
     /**
      * This method searches in the neighbor table to find a `Neighbor` object corresponding to a given MAC address.
      *
      * @param[in]  aMacAddress  A MAC address.
+     * @param[in]  aFilter      A neighbor state filter.
      *
      * @returns A pointer to the `Neighbor` corresponding to @p aMacAddress, nullptr otherwise.
      *
      */
-    Neighbor *FindNeighbor(const Mac::Address &aMacAddress);
+    Neighbor *FindNeighbor(const Mac::Address &  aMacAddress,
+                           Neighbor::StateFilter aFilter = Neighbor::kInStateValidOrRestoring);
 
 #if OPENTHREAD_FTD
 
@@ -149,11 +161,13 @@ public:
      * This method searches in the neighbor table to find a `Neighbor` object corresponding to a given IPv6 address.
      *
      * @param[in]  aIp6Address  An IPv6 address.
+     * @pram[in]   aFilter      A neighbor state filter.
      *
      * @returns A pointer to the `Neighbor` corresponding to @p aIp6Address, nullptr otherwise.
      *
      */
-    Neighbor *FindNeighbor(const Ip6::Address &aIp6Address);
+    Neighbor *FindNeighbor(const Ip6::Address &  aIp6Address,
+                           Neighbor::StateFilter aFilter = Neighbor::kInStateValidOrRestoring);
 
     /**
      * This method searches in the neighbor table to find a `Neighbor` for which a one-way link is maintained (as in the


### PR DESCRIPTION
---

The filtering is not currently used in any of existing code, however it adds flexibility without adding much of (code size or run-time) overhead. 

It is a functionality that is needed/used by the multi-link (TREL) PR (which earlier added it only when feature is enabled, but I think it make sense to add the filtering in general case).