### PR TITLE
[message] change 'Write()' to be a 'void' method

### DIFF
--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -110,7 +110,9 @@ uint16_t otMessageRead(const otMessage *aMessage, uint16_t aOffset, void *aBuf, 
 int otMessageWrite(otMessage *aMessage, uint16_t aOffset, const void *aBuf, uint16_t aLength)
 {
     Message &message = *static_cast<Message *>(aMessage);
-    return message.Write(aOffset, aLength, aBuf);
+    message.Write(aOffset, aLength, aBuf);
+
+    return aLength;
 }
 
 void otMessageQueueInit(otMessageQueue *aQueue)

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -780,9 +780,9 @@ void CoapBase::Metadata::ReadFrom(const Message &aMessage)
     aMessage.Read(length - sizeof(*this), sizeof(*this), this);
 }
 
-int CoapBase::Metadata::UpdateIn(Message &aMessage) const
+void CoapBase::Metadata::UpdateIn(Message &aMessage) const
 {
-    return aMessage.Write(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
+    aMessage.Write(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
 }
 
 ResponsesQueue::ResponsesQueue(Instance &aInstance)

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -534,7 +534,7 @@ private:
     {
         otError AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
         void    ReadFrom(const Message &aMessage);
-        int     UpdateIn(Message &aMessage) const;
+        void    UpdateIn(Message &aMessage) const;
 
         Ip6::Address    mSourceAddress;            // IPv6 address of the message source.
         Ip6::Address    mDestinationAddress;       // IPv6 address of the message destination.

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -365,13 +365,9 @@ otError Message::Append(const void *aBuf, uint16_t aLength)
 {
     otError  error     = OT_ERROR_NONE;
     uint16_t oldLength = GetLength();
-    int      bytesWritten;
 
     SuccessOrExit(error = SetLength(GetLength() + aLength));
-    bytesWritten = Write(oldLength, aLength, aBuf);
-
-    OT_ASSERT(bytesWritten == (int)aLength);
-    OT_UNUSED_VARIABLE(bytesWritten);
+    Write(oldLength, aLength, aBuf);
 
 exit:
     return error;
@@ -531,7 +527,7 @@ exit:
     return static_cast<uint16_t>(bufPtr - reinterpret_cast<uint8_t *>(aBuf));
 }
 
-int Message::Write(uint16_t aOffset, uint16_t aLength, const void *aBuf)
+void Message::Write(uint16_t aOffset, uint16_t aLength, const void *aBuf)
 {
     const uint8_t *bufPtr = reinterpret_cast<const uint8_t *>(aBuf);
     WritableChunk  chunk;
@@ -546,8 +542,6 @@ int Message::Write(uint16_t aOffset, uint16_t aLength, const void *aBuf)
         bufPtr += chunk.GetLength();
         GetNextChunk(aLength, chunk);
     }
-
-    return static_cast<int>(bufPtr - reinterpret_cast<const uint8_t *>(aBuf));
 }
 
 int Message::CopyTo(uint16_t aSourceOffset, uint16_t aDestinationOffset, uint16_t aLength, Message &aMessage) const

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -519,14 +519,15 @@ public:
     /**
      * This method writes bytes to the message.
      *
+     * This method will not resize the message. The given data to write (with @p aLength bytes) MUST fit within the
+     * existing message buffer (from the given offset @p aOffset up to the message's length).
+     *
      * @param[in]  aOffset  Byte offset within the message to begin writing.
      * @param[in]  aLength  Number of bytes to write.
      * @param[in]  aBuf     A pointer to a data buffer.
      *
-     * @returns The number of bytes written.
-     *
      */
-    int Write(uint16_t aOffset, uint16_t aLength, const void *aBuf);
+    void Write(uint16_t aOffset, uint16_t aLength, const void *aBuf);
 
     /**
      * This method copies bytes from one message to another.

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -636,9 +636,6 @@ otError Ip6::FragmentDatagram(Message &aMessage, uint8_t aIpProto)
     uint16_t       fragmentCnt     = 0;
     uint16_t       payloadFragment = 0;
     uint16_t       offset          = 0;
-    int            assertValue     = 0;
-
-    OT_UNUSED_VARIABLE(assertValue);
 
     uint16_t maxPayloadFragment =
         FragmentHeader::MakeDivisibleByEight(kMinimalMtu - aMessage.GetOffset() - sizeof(fragmentHeader));
@@ -676,12 +673,10 @@ otError Ip6::FragmentDatagram(Message &aMessage, uint8_t aIpProto)
         SuccessOrExit(error = fragment->SetLength(aMessage.GetOffset() + sizeof(fragmentHeader) + payloadFragment));
 
         header.SetPayloadLength(payloadFragment + sizeof(fragmentHeader));
-        assertValue = fragment->Write(0, sizeof(header), &header);
-        OT_ASSERT(assertValue == sizeof(header));
+        fragment->Write(0, sizeof(header), &header);
 
         fragment->SetOffset(aMessage.GetOffset());
-        assertValue = fragment->Write(aMessage.GetOffset(), sizeof(fragmentHeader), &fragmentHeader);
-        OT_ASSERT(assertValue == sizeof(fragmentHeader));
+        fragment->Write(aMessage.GetOffset(), sizeof(fragmentHeader), &fragmentHeader);
 
         VerifyOrExit(aMessage.CopyTo(aMessage.GetOffset() + FragmentHeader::FragmentOffsetToBytes(offset),
                                      aMessage.GetOffset() + sizeof(fragmentHeader), payloadFragment,
@@ -803,8 +798,7 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
         VerifyOrExit(aMessage.Read(0, sizeof(header), &header) == sizeof(header), error = OT_ERROR_PARSE);
         header.SetPayloadLength(message->GetLength() - sizeof(header));
         header.SetNextHeader(fragmentHeader.GetNextHeader());
-        assertValue = message->Write(0, sizeof(header), &header);
-        OT_ASSERT(assertValue == sizeof(header));
+        message->Write(0, sizeof(header), &header);
 
         otLogDebgIp6("Reassembly complete.");
 

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -436,9 +436,9 @@ void Mpl::Metadata::RemoveFrom(Message &aMessage) const
     OT_UNUSED_VARIABLE(error);
 }
 
-int Mpl::Metadata::UpdateIn(Message &aMessage) const
+void Mpl::Metadata::UpdateIn(Message &aMessage) const
 {
-    return aMessage.Write(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
+    aMessage.Write(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
 }
 
 void Mpl::Metadata::GenerateNextTransmissionTime(TimeMilli aCurrentTime, uint8_t aInterval)

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -307,7 +307,7 @@ private:
         otError AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
         void    ReadFrom(const Message &aMessage);
         void    RemoveFrom(Message &aMessage) const;
-        int     UpdateIn(Message &aMessage) const;
+        void    UpdateIn(Message &aMessage) const;
         void    GenerateNextTransmissionTime(TimeMilli aCurrentTime, uint8_t aInterval);
 
         TimeMilli mTransmissionTime;

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -464,12 +464,10 @@ public:
      *
      * @param[in]  aMessage  A reference to the message.
      *
-     * @returns The number of bytes updated.
-     *
      */
-    int UpdateIn(Message &aMessage) const
+    void UpdateIn(Message &aMessage) const
     {
-        return aMessage.Write(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
+        aMessage.Write(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
     }
 
 private:

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -61,7 +61,7 @@ void TestMessage(void)
 
     VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr, "Message::New failed");
     SuccessOrQuit(message->SetLength(kMaxSize), "Message::SetLength failed");
-    VerifyOrQuit(message->Write(0, kMaxSize, writeBuffer) == kMaxSize, "Message::Write failed");
+    message->Write(0, kMaxSize, writeBuffer);
     VerifyOrQuit(message->Read(0, kMaxSize, readBuffer) == kMaxSize, "Message::Read failed");
     VerifyOrQuit(memcmp(writeBuffer, readBuffer, kMaxSize) == 0, "Message compare failed");
     VerifyOrQuit(message->GetLength() == kMaxSize, "Message::GetLength failed");
@@ -75,7 +75,7 @@ void TestMessage(void)
                 writeBuffer[offset + i]++;
             }
 
-            VerifyOrQuit(message->Write(offset, length, &writeBuffer[offset]) == length, "Message::Write failed");
+            message->Write(offset, length, &writeBuffer[offset]);
 
             VerifyOrQuit(message->Read(0, kMaxSize, readBuffer) == kMaxSize, "Message::Read failed");
             VerifyOrQuit(memcmp(writeBuffer, readBuffer, kMaxSize) == 0, "Message compare failed");


### PR DESCRIPTION
This commit changes `Message::Write()` to return `void` instead of
returning the number of bytes written. The `Write()` method does not
resize the message and requires that the given data can be fully
written into the message within its existing length. The `Write()`
already contains an `OT_ASSERT()` to verify this.

This commit also removes the redundant `OT_ASSERT()` checks in few
places where `Write()` method's returned value was being used.