### PR TITLE
[dua] fix debg output

### DIFF
--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -336,8 +336,12 @@ void DuaManager::HandleTimeTick(void)
 {
     bool attempt = false;
 
+#if OPENTHREAD_CONFIG_DUA_ENABLE
     otLogDebgDua("regdelay %d, reregdelay %d, checkdelay %d", mDelay.mFields.mRegistrationDelay,
                  mDelay.mFields.mReregistrationDelay, mDelay.mFields.mCheckDelay);
+#else
+    otLogDebgDua("reregdelay %d, checkdelay %d", mDelay.mFields.mReregistrationDelay, mDelay.mFields.mCheckDelay);
+#endif
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     if (mDuaState != kNotExist && TimerMilli::GetNow() > mLastRegistrationTime + Mle::kDuaDadPeriod)


### PR DESCRIPTION
`mRegistrationDelay` only exists when `OPENTHREAD_CONFIG_DUA_ENABLE` is set. If `OPENTHREAD_CONFIG_DUA_ENABLE` is not set and log level is DEBUG, there would be an error.