### PR TITLE
Pull/k32w rtos uart fixes

### DIFF
--- a/examples/platforms/k32w/jn5189/Makefile.am
+++ b/examples/platforms/k32w/jn5189/Makefile.am
@@ -66,6 +66,7 @@ LIB_FLAGS                                                                       
     -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/XCVR/DK6/Build/Include                   \
     -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/XCVR/DK6                                 \
     -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/Common                                   \
+    -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/TimersManager/Source                     \
     -Wno-unknown-pragmas                                                                                             \
     -Wno-sign-compare                                                                                                \
     -Wno-unused-function                                                                                             \

--- a/examples/platforms/k32w/jn5189/Makefile.am
+++ b/examples/platforms/k32w/jn5189/Makefile.am
@@ -46,7 +46,6 @@ LIB_FLAGS                                                                       
     -DCPU_JN518X_REV=2                                                                                               \
     -DJENNIC_CHIP_FAMILY_JN518x                                                                                      \
     -DJENNIC_CHIP_FAMILY_NAME=_JN518x                                                                                \
-    -DUSE_RTOS=0                                                                                                     \
     -DgPWR_LDOMEM_0_9V_PD=0                                                                                          \
     -DNO_SYSCORECLK_UPD=0                                                                                            \
     -I$(top_srcdir)/include                                                                                          \

--- a/examples/platforms/k32w/k32w061/Makefile.am
+++ b/examples/platforms/k32w/k32w061/Makefile.am
@@ -48,7 +48,6 @@ LIB_FLAGS                                                                       
     -DCPU_JN518X_REV=2                                                                                                 \
     -DJENNIC_CHIP_FAMILY_JN518x                                                                                        \
     -DJENNIC_CHIP_FAMILY_NAME=_JN518x                                                                                  \
-    -DUSE_RTOS=0                                                                                                       \
     -DgPWR_LDOMEM_0_9V_PD=0                                                                                            \
     -DNO_SYSCORECLK_UPD=0                                                                                              \
     -I$(top_srcdir)/include                                                                                            \

--- a/examples/platforms/k32w/k32w061/Makefile.am
+++ b/examples/platforms/k32w/k32w061/Makefile.am
@@ -67,6 +67,7 @@ LIB_FLAGS                                                                       
     -I$(top_srcdir)/third_party/nxp/K32W061DK6/middleware/wireless/framework/XCVR/DK6/Build/Include                    \
     -I$(top_srcdir)/third_party/nxp/K32W061DK6/middleware/wireless/framework/XCVR/DK6                                  \
     -I$(top_srcdir)/third_party/nxp/K32W061DK6/middleware/wireless/framework/Common/                                   \
+    -I$(top_srcdir)/third_party/nxp/K32W061DK6/middleware/wireless/framework/TimersManager/Source                      \
     -I$(top_srcdir)/third_party/nxp/K32W061DK6/boards/k32w061dk6/wireless_examples/openthread/enablement               \
     -Wno-unknown-pragmas                                                                                               \
     -Wno-sign-compare                                                                                                  \

--- a/examples/platforms/k32w/src/alarm.c
+++ b/examples/platforms/k32w/src/alarm.c
@@ -38,13 +38,11 @@
 #include "fsl_clock.h"
 #include "fsl_ctimer.h"
 #include "fsl_device_registers.h"
+#include "TMR_Adapter.h"
 #include "fsl_wtimer.h"
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
-
-#if USE_RTOS
 #include "openthread-system.h"
-#endif
 
 #define ALARM_USE_CTIMER 0
 #define ALARM_USE_WTIMER 1
@@ -99,6 +97,9 @@ void K32WAlarmInit(void)
     /* Wake timer 1 is 28 bits long and is used for alarm events, including waking up the MCU
        from sleep */
     WTIMER_EnableInterrupts(WTIMER_TIMER1_ID);
+
+    NVIC_SetPriority(WAKE_UP_TIMER0_IRQn, gStackTimer_IsrPrio_c >> (8 - __NVIC_PRIO_BITS));
+    NVIC_SetPriority(WAKE_UP_TIMER1_IRQn, gStackTimer_IsrPrio_c >> (8 - __NVIC_PRIO_BITS));
 
     /* Start wake timer 0 counter for timestamp - the counter counts down to 0 so a simple
        substracion from TIMER0_MAX_COUNT_VALUE will give us the timestamp */

--- a/examples/platforms/k32w/src/alarm.c
+++ b/examples/platforms/k32w/src/alarm.c
@@ -217,7 +217,6 @@ void CTIMER0_IRQHandler(void)
     sEventFired = true;
 
 #if USE_RTOS
-    /* TODO: do we need to make this call on each alarm interrupt? */
     otSysEventSignalPending();
 #endif
 }
@@ -228,7 +227,6 @@ void WAKE_UP_TIMER0_DriverIRQHandler()
     WTIMER_StartTimer(WTIMER_TIMER0_ID, TIMER0_MAX_COUNT_VALUE);
 
 #if USE_RTOS
-    /* TODO: do we need to make this call on each alarm interrupt? */
     otSysEventSignalPending();
 #endif
 }
@@ -246,7 +244,6 @@ void WAKE_UP_TIMER1_DriverIRQHandler()
     }
 
 #if USE_RTOS
-    /* TODO: do we need to make this call on each alarm interrupt? */
     otSysEventSignalPending();
 #endif
 }

--- a/examples/platforms/k32w/src/alarm.c
+++ b/examples/platforms/k32w/src/alarm.c
@@ -42,6 +42,10 @@
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
 
+#if USE_RTOS
+#include "openthread-system.h"
+#endif
+
 #define ALARM_USE_CTIMER 0
 #define ALARM_USE_WTIMER 1
 
@@ -211,12 +215,22 @@ void CTIMER0_IRQHandler(void)
     uint32_t flags = CTIMER_GetStatusFlags(CTIMER0);
     CTIMER_ClearStatusFlags(CTIMER0, flags);
     sEventFired = true;
+
+#if USE_RTOS
+    /* TODO: do we need to make this call on each alarm interrupt? */
+    otSysEventSignalPending();
+#endif
 }
 #else
 void WAKE_UP_TIMER0_DriverIRQHandler()
 {
     WTIMER_ClearStatusFlags(WTIMER_TIMER0_ID);
     WTIMER_StartTimer(WTIMER_TIMER0_ID, TIMER0_MAX_COUNT_VALUE);
+
+#if USE_RTOS
+    /* TODO: do we need to make this call on each alarm interrupt? */
+    otSysEventSignalPending();
+#endif
 }
 void WAKE_UP_TIMER1_DriverIRQHandler()
 {
@@ -230,5 +244,10 @@ void WAKE_UP_TIMER1_DriverIRQHandler()
     {
         sEventFired = true;
     }
+
+#if USE_RTOS
+    /* TODO: do we need to make this call on each alarm interrupt? */
+    otSysEventSignalPending();
+#endif
 }
 #endif

--- a/examples/platforms/k32w/src/radio.c
+++ b/examples/platforms/k32w/src/radio.c
@@ -827,7 +827,6 @@ static void K32WISR(uint32_t u32IntBitmap)
     }
 
 #if USE_RTOS
-    /* TODO: do we need to make this call on each Radio interrupt */
     otSysEventSignalPending();
 #endif
 }

--- a/examples/platforms/k32w/src/radio.c
+++ b/examples/platforms/k32w/src/radio.c
@@ -49,6 +49,10 @@
 #include <openthread/platform/diag.h>
 #include <openthread/platform/radio.h>
 
+#if USE_RTOS
+#include "openthread-system.h"
+#endif
+
 extern void BOARD_LedDongleToggle(void);
 
 /* Defines */
@@ -821,6 +825,11 @@ static void K32WISR(uint32_t u32IntBitmap)
     default:
         break;
     }
+
+#if USE_RTOS
+    /* TODO: do we need to make this call on each Radio interrupt */
+    otSysEventSignalPending();
+#endif
 }
 /**
  * Process the MAC Header of the latest received packet

--- a/examples/platforms/k32w/src/system.c
+++ b/examples/platforms/k32w/src/system.c
@@ -82,7 +82,7 @@ void otSysProcessDrivers(otInstance *aInstance)
     K32WAlarmProcess(aInstance);
 }
 
-void otSysEventSignalPending(void)
+WEAK void otSysEventSignalPending(void)
 {
-    /* TODO */
+    /* Intentionally left empty */
 }

--- a/examples/platforms/k32w/src/uart.c
+++ b/examples/platforms/k32w/src/uart.c
@@ -272,7 +272,6 @@ static void USART0_IRQHandler(USART_Type *base, usart_handle_t *handle)
         }
 
 #if USE_RTOS
-        /* TODO: do we need to make this call on each USART interrupt */
         otSysEventSignalPending();
 #endif
     }

--- a/third_party/nxp/JN5189DK6/middleware/wireless/framework/TimersManager/Source/TMR_Adapter.h
+++ b/third_party/nxp/JN5189DK6/middleware/wireless/framework/TimersManager/Source/TMR_Adapter.h
@@ -1,0 +1,151 @@
+/*! *********************************************************************************
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* Copyright 2016-2017 NXP
+* All rights reserved.
+*
+* \file
+*
+* TMR export interface file for ARM CORTEX processor
+*
+* SPDX-License-Identifier: BSD-3-Clause
+********************************************************************************** */
+
+#ifndef _TMR_ADAPTER_H_
+#define _TMR_ADAPTER_H_
+
+
+/************************************************************************************
+*************************************************************************************
+* Include
+*************************************************************************************
+***********************************************************************************/
+#include "EmbeddedTypes.h"
+#include "fsl_device_registers.h"
+#include "board.h"
+
+
+
+/************************************************************************************
+*************************************************************************************
+* Public macros
+*************************************************************************************
+************************************************************************************/
+#ifdef CPU_JN518X
+#if gTimestamp_Enabled_d || gTimerMgrLowPowerTimers
+/* */
+#ifndef gTimerMgrUseCtimer_c
+#define gTimerMgrUseCtimer_c	        (0)
+#endif
+#ifndef gTimerMgrUseLpcRtc_c
+#define gTimerMgrUseLpcRtc_c	        (1)
+#endif
+#else
+#ifndef gTimerMgrUseCtimer_c
+#define gTimerMgrUseCtimer_c	        (1)
+#endif
+#ifndef gTimerMgrUseLpcRtc_c
+#define gTimerMgrUseLpcRtc_c	        (0)
+#endif
+#endif
+#endif
+
+
+/* Defines which timer resource can be used */
+#if (defined (FSL_FEATURE_SOC_CTIMER_COUNT) && (FSL_FEATURE_SOC_CTIMER_COUNT > 0))
+#ifndef gTimerMgrUseCtimer_c
+#define gTimerMgrUseCtimer_c	(1)
+#endif
+#endif
+
+#if(defined (FSL_FEATURE_SOC_LPC_RTC_COUNT) && (FSL_FEATURE_SOC_LPC_RTC_COUNT > 0))
+#ifndef gTimerMgrUseLpcRtc_c
+#define gTimerMgrUseLpcRtc_c	(1)
+#endif
+#endif
+
+#if(defined (FSL_FEATURE_RTC_HAS_FRC) && (FSL_FEATURE_RTC_HAS_FRC > 0))
+#ifndef gTimerMgrUseRtcFrc_c
+#define gTimerMgrUseRtcFrc_c	(1)
+#endif
+#endif
+
+#if(defined (FSL_FEATURE_SOC_FTM_COUNT) && (FSL_FEATURE_SOC_FTM_COUNT > 0))
+#ifndef gTimerMgrUseFtm_c
+#define gTimerMgrUseFtm_c       (1)
+#endif
+#endif
+
+
+
+#ifndef gStackTimerInstance_c
+#define gStackTimerInstance_c  0
+#endif
+
+#ifndef gStackTimerChannel_c
+#define gStackTimerChannel_c   0
+#endif
+
+#ifndef gLptmrInstance_c
+#define gLptmrInstance_c       0
+#endif
+
+#ifndef gTmrRtcInstance_c
+#define gTmrRtcInstance_c      0
+#endif
+
+#ifndef gTmrPitInstance_c
+#define gTmrPitInstance_c      0
+#endif
+
+#define gStackTimer_IsrPrio_c (0x80)
+
+#if gTimerMgrUseLpcRtc_c
+#define gStackTimerMaxCountValue_c  0xffff
+#else
+#define gStackTimerMaxCountValue_c  0xffffffff
+#endif
+/************************************************************************************
+*************************************************************************************
+* Public types
+*************************************************************************************
+************************************************************************************/
+typedef struct _tmr_adapter_pwm_param_type
+{
+    uint32_t frequency;
+    uint32_t initValue;
+}tmr_adapter_pwm_param_t;
+
+
+/*
+ * \brief   Platofrm specific timer ticks type definition
+ */
+#if FSL_FEATURE_SOC_CTIMER_COUNT || FSL_FEATURE_RTC_HAS_FRC
+    typedef uint32_t tmrTimerTicks_t;
+#else
+    typedef uint16_t tmrTimerTicks_t;
+#endif
+/************************************************************************************
+*************************************************************************************
+* Public prototypes
+*************************************************************************************
+************************************************************************************/
+void StackTimer_Init(void (*cb)(void));
+int  StackTimer_ReInit(void (*cb)(void));
+void StackTimer_Enable(void);
+void StackTimer_Disable(void);
+uint32_t StackTimer_ClearIntFlag(void);
+uint32_t StackTimer_GetInputFrequency(void);
+uint32_t StackTimer_GetCounterValue(void);
+void StackTimer_SetOffsetTicks(uint32_t offset);
+
+#ifndef ENABLE_RAM_VECTOR_TABLE
+void StackTimer_ISR_withParam(uint32_t param);
+#endif
+
+void PWM_Init(uint8_t instance);
+void PWM_SetChnCountVal(uint8_t instance, uint8_t channel, tmrTimerTicks_t val);
+tmrTimerTicks_t PWM_GetChnCountVal(uint8_t instance, uint8_t channel);
+#if !defined(FSL_FEATURE_SOC_CTIMER_COUNT) || (FSL_FEATURE_SOC_CTIMER_COUNT == 0)
+void PWM_StartEdgeAlignedLowTrue(uint8_t instance, tmr_adapter_pwm_param_t *param, uint8_t channel);
+#endif
+#endif /* _TMR_ADAPTER_H_ */

--- a/third_party/nxp/K32W061DK6/devices/K32W061/mcuxpresso/startup_k32w061.c
+++ b/third_party/nxp/K32W061DK6/devices/K32W061/mcuxpresso/startup_k32w061.c
@@ -149,6 +149,8 @@ WEAK void PVTVF1_AMBER_IRQHandler(void);
 WEAK void PVTVF1_RED_IRQHandler(void);
 WEAK void BLE_WAKE_UP_TIMER_IRQHandler(void);
 WEAK void SHA_IRQHandler(void);
+WEAK void vMMAC_IntHandlerBbc(void);
+WEAK void vMMAC_IntHandlerPhy(void);
 
 //*****************************************************************************
 // Forward declaration of the driver IRQ handlers. These are aliased
@@ -842,17 +844,34 @@ WEAK void BLE_LL_ALL_IRQHandler(void)
 
 WEAK void ZIGBEE_MAC_IRQHandler(void)
 {
-    ZIGBEE_MAC_DriverIRQHandler();
+    if (vMMAC_IntHandlerBbc)
+    {
+        vMMAC_IntHandlerBbc();
+    }
+    else if (ZIGBEE_MAC_IRQHandler)
+    {
+        ZIGBEE_MAC_IRQHandler();
+    }
+    else
+    {
+        IntDefaultHandler();
+    }
 }
 
 WEAK void ZIGBEE_MODEM_IRQHandler(void)
 {
-    ZIGBEE_MODEM_DriverIRQHandler();
-}
-
-WEAK void RFP_TMU_IRQHandler(void)
-{
-    RFP_TMU_DriverIRQHandler();
+    if (vMMAC_IntHandlerPhy)
+    {
+        vMMAC_IntHandlerPhy();
+    }
+    else if (ZIGBEE_MODEM_IRQHandler)
+    {
+        ZIGBEE_MODEM_IRQHandler();
+    }
+    else
+    {
+        IntDefaultHandler();
+    }
 }
 
 WEAK void RFP_AGC_IRQHandler(void)

--- a/third_party/nxp/K32W061DK6/middleware/wireless/framework/TimersManager/Source/TMR_Adapter.h
+++ b/third_party/nxp/K32W061DK6/middleware/wireless/framework/TimersManager/Source/TMR_Adapter.h
@@ -1,0 +1,151 @@
+/*! *********************************************************************************
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* Copyright 2016-2017 NXP
+* All rights reserved.
+*
+* \file
+*
+* TMR export interface file for ARM CORTEX processor
+*
+* SPDX-License-Identifier: BSD-3-Clause
+********************************************************************************** */
+
+#ifndef _TMR_ADAPTER_H_
+#define _TMR_ADAPTER_H_
+
+
+/************************************************************************************
+*************************************************************************************
+* Include
+*************************************************************************************
+***********************************************************************************/
+#include "EmbeddedTypes.h"
+#include "fsl_device_registers.h"
+#include "board.h"
+
+
+
+/************************************************************************************
+*************************************************************************************
+* Public macros
+*************************************************************************************
+************************************************************************************/
+#ifdef CPU_JN518X
+#if gTimestamp_Enabled_d || gTimerMgrLowPowerTimers
+/* */
+#ifndef gTimerMgrUseCtimer_c
+#define gTimerMgrUseCtimer_c	        (0)
+#endif
+#ifndef gTimerMgrUseLpcRtc_c
+#define gTimerMgrUseLpcRtc_c	        (1)
+#endif
+#else
+#ifndef gTimerMgrUseCtimer_c
+#define gTimerMgrUseCtimer_c	        (1)
+#endif
+#ifndef gTimerMgrUseLpcRtc_c
+#define gTimerMgrUseLpcRtc_c	        (0)
+#endif
+#endif
+#endif
+
+
+/* Defines which timer resource can be used */
+#if (defined (FSL_FEATURE_SOC_CTIMER_COUNT) && (FSL_FEATURE_SOC_CTIMER_COUNT > 0))
+#ifndef gTimerMgrUseCtimer_c
+#define gTimerMgrUseCtimer_c	(1)
+#endif
+#endif
+
+#if(defined (FSL_FEATURE_SOC_LPC_RTC_COUNT) && (FSL_FEATURE_SOC_LPC_RTC_COUNT > 0))
+#ifndef gTimerMgrUseLpcRtc_c
+#define gTimerMgrUseLpcRtc_c	(1)
+#endif
+#endif
+
+#if(defined (FSL_FEATURE_RTC_HAS_FRC) && (FSL_FEATURE_RTC_HAS_FRC > 0))
+#ifndef gTimerMgrUseRtcFrc_c
+#define gTimerMgrUseRtcFrc_c	(1)
+#endif
+#endif
+
+#if(defined (FSL_FEATURE_SOC_FTM_COUNT) && (FSL_FEATURE_SOC_FTM_COUNT > 0))
+#ifndef gTimerMgrUseFtm_c
+#define gTimerMgrUseFtm_c       (1)
+#endif
+#endif
+
+
+
+#ifndef gStackTimerInstance_c
+#define gStackTimerInstance_c  0
+#endif
+
+#ifndef gStackTimerChannel_c
+#define gStackTimerChannel_c   0
+#endif
+
+#ifndef gLptmrInstance_c
+#define gLptmrInstance_c       0
+#endif
+
+#ifndef gTmrRtcInstance_c
+#define gTmrRtcInstance_c      0
+#endif
+
+#ifndef gTmrPitInstance_c
+#define gTmrPitInstance_c      0
+#endif
+
+#define gStackTimer_IsrPrio_c (0x80)
+
+#if gTimerMgrUseLpcRtc_c
+#define gStackTimerMaxCountValue_c  0xffff
+#else
+#define gStackTimerMaxCountValue_c  0xffffffff
+#endif
+/************************************************************************************
+*************************************************************************************
+* Public types
+*************************************************************************************
+************************************************************************************/
+typedef struct _tmr_adapter_pwm_param_type
+{
+    uint32_t frequency;
+    uint32_t initValue;
+}tmr_adapter_pwm_param_t;
+
+
+/*
+ * \brief   Platofrm specific timer ticks type definition
+ */
+#if FSL_FEATURE_SOC_CTIMER_COUNT || FSL_FEATURE_RTC_HAS_FRC
+    typedef uint32_t tmrTimerTicks_t;
+#else
+    typedef uint16_t tmrTimerTicks_t;
+#endif
+/************************************************************************************
+*************************************************************************************
+* Public prototypes
+*************************************************************************************
+************************************************************************************/
+void StackTimer_Init(void (*cb)(void));
+int  StackTimer_ReInit(void (*cb)(void));
+void StackTimer_Enable(void);
+void StackTimer_Disable(void);
+uint32_t StackTimer_ClearIntFlag(void);
+uint32_t StackTimer_GetInputFrequency(void);
+uint32_t StackTimer_GetCounterValue(void);
+void StackTimer_SetOffsetTicks(uint32_t offset);
+
+#ifndef ENABLE_RAM_VECTOR_TABLE
+void StackTimer_ISR_withParam(uint32_t param);
+#endif
+
+void PWM_Init(uint8_t instance);
+void PWM_SetChnCountVal(uint8_t instance, uint8_t channel, tmrTimerTicks_t val);
+tmrTimerTicks_t PWM_GetChnCountVal(uint8_t instance, uint8_t channel);
+#if !defined(FSL_FEATURE_SOC_CTIMER_COUNT) || (FSL_FEATURE_SOC_CTIMER_COUNT == 0)
+void PWM_StartEdgeAlignedLowTrue(uint8_t instance, tmr_adapter_pwm_param_t *param, uint8_t channel);
+#endif
+#endif /* _TMR_ADAPTER_H_ */


### PR DESCRIPTION
This PR adds fixes which are needed for running Project CHIP on K32W.

Fixes are related to UART handling, radio interrupts and Free RTOS support.