### PR TITLE
[k32w] rtos uart fixes

### DIFF
--- a/examples/platforms/k32w/jn5189/Makefile.am
+++ b/examples/platforms/k32w/jn5189/Makefile.am
@@ -66,6 +66,7 @@ LIB_FLAGS                                                                       
     -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/XCVR/DK6/Build/Include                   \
     -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/XCVR/DK6                                 \
     -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/Common                                   \
+    -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/SerialManager/Source                     \
     -Wno-unknown-pragmas                                                                                             \
     -Wno-sign-compare                                                                                                \
     -Wno-unused-function                                                                                             \

--- a/examples/platforms/k32w/jn5189/Makefile.am
+++ b/examples/platforms/k32w/jn5189/Makefile.am
@@ -67,6 +67,7 @@ LIB_FLAGS                                                                       
     -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/XCVR/DK6                                 \
     -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/Common                                   \
     -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/SerialManager/Source                     \
+    -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/TimersManager/Source/                    \
     -Wno-unknown-pragmas                                                                                             \
     -Wno-sign-compare                                                                                                \
     -Wno-unused-function                                                                                             \

--- a/examples/platforms/k32w/jn5189/Makefile.am
+++ b/examples/platforms/k32w/jn5189/Makefile.am
@@ -46,7 +46,6 @@ LIB_FLAGS                                                                       
     -DCPU_JN518X_REV=2                                                                                               \
     -DJENNIC_CHIP_FAMILY_JN518x                                                                                      \
     -DJENNIC_CHIP_FAMILY_NAME=_JN518x                                                                                \
-    -DUSE_RTOS=0                                                                                                     \
     -DgPWR_LDOMEM_0_9V_PD=0                                                                                          \
     -DNO_SYSCORECLK_UPD=0                                                                                            \
     -I$(top_srcdir)/include                                                                                          \

--- a/examples/platforms/k32w/jn5189/Makefile.am
+++ b/examples/platforms/k32w/jn5189/Makefile.am
@@ -67,7 +67,7 @@ LIB_FLAGS                                                                       
     -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/XCVR/DK6                                 \
     -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/Common                                   \
     -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/SerialManager/Source                     \
-    -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/TimersManager/Source/                    \
+    -I$(top_srcdir)/third_party/nxp/JN5189DK6/middleware/wireless/framework/TimersManager/Source                     \
     -Wno-unknown-pragmas                                                                                             \
     -Wno-sign-compare                                                                                                \
     -Wno-unused-function                                                                                             \

--- a/examples/platforms/k32w/k32w061/Makefile.am
+++ b/examples/platforms/k32w/k32w061/Makefile.am
@@ -48,7 +48,6 @@ LIB_FLAGS                                                                       
     -DCPU_JN518X_REV=2                                                                                                 \
     -DJENNIC_CHIP_FAMILY_JN518x                                                                                        \
     -DJENNIC_CHIP_FAMILY_NAME=_JN518x                                                                                  \
-    -DUSE_RTOS=0                                                                                                       \
     -DgPWR_LDOMEM_0_9V_PD=0                                                                                            \
     -DNO_SYSCORECLK_UPD=0                                                                                              \
     -I$(top_srcdir)/include                                                                                            \

--- a/examples/platforms/k32w/k32w061/Makefile.am
+++ b/examples/platforms/k32w/k32w061/Makefile.am
@@ -67,6 +67,7 @@ LIB_FLAGS                                                                       
     -I$(top_srcdir)/third_party/nxp/K32W061DK6/middleware/wireless/framework/XCVR/DK6/Build/Include                    \
     -I$(top_srcdir)/third_party/nxp/K32W061DK6/middleware/wireless/framework/XCVR/DK6                                  \
     -I$(top_srcdir)/third_party/nxp/K32W061DK6/middleware/wireless/framework/Common/                                   \
+    -I$(top_srcdir)/third_party/nxp/K32W061DK6/middleware/wireless/framework/SerialManager/Source                      \
     -I$(top_srcdir)/third_party/nxp/K32W061DK6/boards/k32w061dk6/wireless_examples/openthread/enablement               \
     -Wno-unknown-pragmas                                                                                               \
     -Wno-sign-compare                                                                                                  \

--- a/examples/platforms/k32w/k32w061/Makefile.am
+++ b/examples/platforms/k32w/k32w061/Makefile.am
@@ -68,6 +68,7 @@ LIB_FLAGS                                                                       
     -I$(top_srcdir)/third_party/nxp/K32W061DK6/middleware/wireless/framework/XCVR/DK6                                  \
     -I$(top_srcdir)/third_party/nxp/K32W061DK6/middleware/wireless/framework/Common/                                   \
     -I$(top_srcdir)/third_party/nxp/K32W061DK6/middleware/wireless/framework/SerialManager/Source                      \
+    -I$(top_srcdir)/third_party/nxp/K32W061DK6/middleware/wireless/framework/TimersManager/Source                      \
     -I$(top_srcdir)/third_party/nxp/K32W061DK6/boards/k32w061dk6/wireless_examples/openthread/enablement               \
     -Wno-unknown-pragmas                                                                                               \
     -Wno-sign-compare                                                                                                  \

--- a/examples/platforms/k32w/src/alarm.c
+++ b/examples/platforms/k32w/src/alarm.c
@@ -217,7 +217,6 @@ void CTIMER0_IRQHandler(void)
     sEventFired = true;
 
 #if USE_RTOS
-    /* TODO: do we need to make this call on each alarm interrupt? */
     otSysEventSignalPending();
 #endif
 }
@@ -228,7 +227,6 @@ void WAKE_UP_TIMER0_DriverIRQHandler()
     WTIMER_StartTimer(WTIMER_TIMER0_ID, TIMER0_MAX_COUNT_VALUE);
 
 #if USE_RTOS
-    /* TODO: do we need to make this call on each alarm interrupt? */
     otSysEventSignalPending();
 #endif
 }
@@ -246,7 +244,6 @@ void WAKE_UP_TIMER1_DriverIRQHandler()
     }
 
 #if USE_RTOS
-    /* TODO: do we need to make this call on each alarm interrupt? */
     otSysEventSignalPending();
 #endif
 }

--- a/examples/platforms/k32w/src/alarm.c
+++ b/examples/platforms/k32w/src/alarm.c
@@ -35,16 +35,14 @@
 /* Openthread configuration */
 #include OPENTHREAD_PROJECT_CORE_CONFIG_FILE
 
+#include "TMR_Adapter.h"
 #include "fsl_clock.h"
 #include "fsl_ctimer.h"
 #include "fsl_device_registers.h"
 #include "fsl_wtimer.h"
+#include "openthread-system.h"
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
-
-#if USE_RTOS
-#include "openthread-system.h"
-#endif
 
 #define ALARM_USE_CTIMER 0
 #define ALARM_USE_WTIMER 1
@@ -99,6 +97,9 @@ void K32WAlarmInit(void)
     /* Wake timer 1 is 28 bits long and is used for alarm events, including waking up the MCU
        from sleep */
     WTIMER_EnableInterrupts(WTIMER_TIMER1_ID);
+
+    NVIC_SetPriority(WAKE_UP_TIMER0_IRQn, gStackTimer_IsrPrio_c >> (8 - __NVIC_PRIO_BITS));
+    NVIC_SetPriority(WAKE_UP_TIMER1_IRQn, gStackTimer_IsrPrio_c >> (8 - __NVIC_PRIO_BITS));
 
     /* Start wake timer 0 counter for timestamp - the counter counts down to 0 so a simple
        substracion from TIMER0_MAX_COUNT_VALUE will give us the timestamp */

--- a/examples/platforms/k32w/src/alarm.c
+++ b/examples/platforms/k32w/src/alarm.c
@@ -42,6 +42,10 @@
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
 
+#if USE_RTOS
+#include "openthread-system.h"
+#endif
+
 #define ALARM_USE_CTIMER 0
 #define ALARM_USE_WTIMER 1
 
@@ -211,12 +215,22 @@ void CTIMER0_IRQHandler(void)
     uint32_t flags = CTIMER_GetStatusFlags(CTIMER0);
     CTIMER_ClearStatusFlags(CTIMER0, flags);
     sEventFired = true;
+
+#if USE_RTOS
+    /* TODO: do we need to make this call on each alarm interrupt? */
+    otSysEventSignalPending();
+#endif
 }
 #else
 void WAKE_UP_TIMER0_DriverIRQHandler()
 {
     WTIMER_ClearStatusFlags(WTIMER_TIMER0_ID);
     WTIMER_StartTimer(WTIMER_TIMER0_ID, TIMER0_MAX_COUNT_VALUE);
+
+#if USE_RTOS
+    /* TODO: do we need to make this call on each alarm interrupt? */
+    otSysEventSignalPending();
+#endif
 }
 void WAKE_UP_TIMER1_DriverIRQHandler()
 {
@@ -230,5 +244,10 @@ void WAKE_UP_TIMER1_DriverIRQHandler()
     {
         sEventFired = true;
     }
+
+#if USE_RTOS
+    /* TODO: do we need to make this call on each alarm interrupt? */
+    otSysEventSignalPending();
+#endif
 }
 #endif

--- a/examples/platforms/k32w/src/radio.c
+++ b/examples/platforms/k32w/src/radio.c
@@ -827,7 +827,6 @@ static void K32WISR(uint32_t u32IntBitmap)
     }
 
 #if USE_RTOS
-    /* TODO: do we need to make this call on each Radio interrupt */
     otSysEventSignalPending();
 #endif
 }

--- a/examples/platforms/k32w/src/radio.c
+++ b/examples/platforms/k32w/src/radio.c
@@ -49,6 +49,10 @@
 #include <openthread/platform/diag.h>
 #include <openthread/platform/radio.h>
 
+#if USE_RTOS
+#include "openthread-system.h"
+#endif
+
 extern void BOARD_LedDongleToggle(void);
 
 /* Defines */
@@ -821,6 +825,11 @@ static void K32WISR(uint32_t u32IntBitmap)
     default:
         break;
     }
+
+#if USE_RTOS
+    /* TODO: do we need to make this call on each Radio interrupt */
+    otSysEventSignalPending();
+#endif
 }
 /**
  * Process the MAC Header of the latest received packet

--- a/examples/platforms/k32w/src/system.c
+++ b/examples/platforms/k32w/src/system.c
@@ -82,7 +82,7 @@ void otSysProcessDrivers(otInstance *aInstance)
     K32WAlarmProcess(aInstance);
 }
 
-void otSysEventSignalPending(void)
+WEAK void otSysEventSignalPending(void)
 {
-    /* TODO */
+    /* Intentionally left empty */
 }

--- a/examples/platforms/k32w/src/uart.c
+++ b/examples/platforms/k32w/src/uart.c
@@ -272,7 +272,6 @@ static void USART0_IRQHandler(USART_Type *base, usart_handle_t *handle)
         }
 
 #if USE_RTOS
-        /* TODO: do we need to make this call on each USART interrupt */
         otSysEventSignalPending();
 #endif
     }

--- a/examples/platforms/k32w/src/uart.c
+++ b/examples/platforms/k32w/src/uart.c
@@ -175,7 +175,6 @@ otError otPlatUartFlush(void)
  * @param[in] aBuf             Pointer to the character buffer
  * @param[in] len              Length of the character buffer
  */
-
 void K32WWriteBlocking(const uint8_t *aBuf, uint32_t len)
 {
     otEXPECT(sIsUartInitialized && sUartHandle.txState != UART_BUSY);

--- a/third_party/nxp/JN5189DK6/middleware/wireless/framework/Common/EmbeddedTypes.h
+++ b/third_party/nxp/JN5189DK6/middleware/wireless/framework/Common/EmbeddedTypes.h
@@ -1,0 +1,277 @@
+/*! *********************************************************************************
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* Copyright 2016-2017 NXP
+* All rights reserved.
+*
+* \file
+*
+* SPDX-License-Identifier: BSD-3-Clause
+********************************************************************************** */
+
+#ifndef _EMBEDDEDTYPES_H_
+#define _EMBEDDEDTYPES_H_
+
+
+/************************************************************************************
+*
+*       INCLUDES
+*
+************************************************************************************/
+
+#include <stdint.h>
+#if defined (__IAR_SYSTEMS_ICC__)
+#include "cmsis_iccarm.h"
+#endif
+/************************************************************************************
+*
+*       TYPE DEFINITIONS
+*
+************************************************************************************/
+
+/* boolean types */
+typedef uint8_t   bool_t;
+
+typedef uint8_t   index_t;
+
+/* TRUE/FALSE definition*/
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+/* null pointer definition*/
+#ifndef NULL
+#define NULL (( void * )( 0x0UL ))
+#endif
+
+#if defined(__GNUC__)
+#define PACKED_STRUCT struct __attribute__ ((__packed__))
+#define PACKED_UNION  union __attribute__ ((__packed__))
+#elif defined(__IAR_SYSTEMS_ICC__)
+#define PACKED_STRUCT __packed struct
+#define PACKED_UNION __packed union
+#elif defined(__CC_ARM)
+#define PACKED_STRUCT struct __attribute__((packed))
+#define PACKED_UNION union __attribute__((packed))
+#else
+#warning No definition for PACKED_STRUCT and PACKED_UNION!
+#endif
+
+typedef unsigned char uintn8_t;
+typedef unsigned long uintn32_t;
+
+typedef unsigned char uchar_t;
+
+#if !defined(MIN)
+#define MIN(a,b)                    (((a) < (b))?(a):(b))
+#endif
+
+#if !defined(MAX)
+#define MAX(a,b)                    (((a) > (b))?(a):(b))
+#endif
+
+/* Compute the number of elements of an array */
+#define NumberOfElements(x) (sizeof(x)/sizeof((x)[0]))
+
+/* Compute the size of a string initialized with quotation marks */
+#define SizeOfString(string) (sizeof(string) - 1)
+
+#define GetRelAddr(strct, member) ((uint32_t)&(((strct*)(void *)0)->member))
+#define GetSizeOfMember(strct, member) sizeof(((strct*)(void *)0)->member)
+
+/* Type definitions for link configuration of instantiable layers  */
+#define gInvalidInstanceId_c (instanceId_t)(-1)
+typedef uint32_t instanceId_t;
+
+/* Bit shift definitions */
+#define BIT0              0x01U
+#define BIT1              0x02U
+#define BIT2              0x04U
+#define BIT3              0x08U
+#define BIT4              0x10U
+#define BIT5              0x20U
+#define BIT6              0x40U
+#define BIT7              0x80U
+#define BIT8             0x100U
+#define BIT9             0x200U
+#define BIT10            0x400U
+#define BIT11            0x800U
+#define BIT12           0x1000U
+#define BIT13           0x2000U
+#define BIT14           0x4000U
+#define BIT15           0x8000U
+#define BIT16          0x10000U
+#define BIT17          0x20000U
+#define BIT18          0x40000U
+#define BIT19          0x80000U
+#define BIT20         0x100000U
+#define BIT21         0x200000U
+#define BIT22         0x400000U
+#define BIT23         0x800000U
+#define BIT24        0x1000000U
+#define BIT25        0x2000000U
+#define BIT26        0x4000000U
+#define BIT27        0x8000000U
+#define BIT28       0x10000000U
+#define BIT29       0x20000000U
+#define BIT30       0x40000000U
+#define BIT31       0x80000000U
+
+/* Shift definitions */
+#define SHIFT0      (0U)
+#define SHIFT1      (1U)
+#define SHIFT2      (2U)
+#define SHIFT3      (3U)
+#define SHIFT4      (4U)
+#define SHIFT5      (5U)
+#define SHIFT6      (6U)
+#define SHIFT7      (7U)
+#define SHIFT8      (8U)
+#define SHIFT9      (9U)
+#define SHIFT10     (10U)
+#define SHIFT11     (11U)
+#define SHIFT12     (12U)
+#define SHIFT13     (13U)
+#define SHIFT14     (14U)
+#define SHIFT15     (15U)
+#define SHIFT16     (16U)
+#define SHIFT17     (17U)
+#define SHIFT18     (18U)
+#define SHIFT19     (19U)
+#define SHIFT20     (20U)
+#define SHIFT21     (21U)
+#define SHIFT22     (22U)
+#define SHIFT23     (23U)
+#define SHIFT24     (24U)
+#define SHIFT25     (25U)
+#define SHIFT26     (26U)
+#define SHIFT27     (27U)
+#define SHIFT28     (28U)
+#define SHIFT29     (29U)
+#define SHIFT30     (30U)
+#define SHIFT31     (31U)
+
+#define SHIFT32     (32U)
+#define SHIFT33     (33U)
+#define SHIFT34     (34U)
+#define SHIFT35     (35U)
+#define SHIFT36     (36U)
+#define SHIFT37     (37U)
+#define SHIFT38     (38U)
+#define SHIFT39     (39U)
+#define SHIFT40     (40U)
+#define SHIFT41     (41U)
+#define SHIFT42     (42U)
+#define SHIFT43     (43U)
+#define SHIFT44     (44U)
+#define SHIFT45     (45U)
+#define SHIFT46     (46U)
+#define SHIFT47     (47U)
+#define SHIFT48     (48U)
+#define SHIFT49     (49U)
+#define SHIFT50     (50U)
+#define SHIFT51     (51U)
+#define SHIFT52     (52U)
+#define SHIFT53     (53U)
+#define SHIFT54     (54U)
+#define SHIFT55     (55U)
+#define SHIFT56     (56U)
+#define SHIFT57     (57U)
+#define SHIFT58     (58U)
+#define SHIFT59     (59U)
+#define SHIFT60     (60U)
+#define SHIFT61     (61U)
+#define SHIFT62     (62U)
+#define SHIFT63     (63U)
+
+#define NOT_USED(x) ((x)=(x))
+
+/*============================================================================
+                         FUNCTION PROTOTYPES
+=============================================================================*/
+
+
+/*!
+ * CLZ implementation : count leading zeroes from MSB
+ */
+#ifdef __GNUC__
+#define HAL_CLZ(x) __builtin_clz(x)
+#define HAL_CTZ(x) __builtin_ctz(x)
+#elif defined (__IAR_SYSTEMS_ICC__)
+#define HAL_CLZ(x) __CLZ(x)
+
+inline uint32_t __hal_ctz(uint32_t x)
+{
+    unsigned int res;
+    x = __RBIT(x);
+    res = __CLZ(x);
+    return res;
+}
+#define HAL_CTZ(x) __hal_ctz(x)
+
+#else
+#define HAL_CLZ(x) HAL_CLZ_UNDEFINED(x)
+#define HAL_CTZ(x) HAL_CTZ_UNDEFINED(x)
+#endif
+
+
+
+/*!
+ ****************************************************************************************
+ * @brief
+ * HAL_BSR Bit Scan Reverse ( find MSB bit set in a bit field )
+ * HAL_BSF Bit Scan Forward ( find LSB bit set in a bit field )
+ * HAL_FFS Find LSB bit position + 1 per standard ffs definition
+ *
+ ****************************************************************************************
+ */
+#define HAL_BSR(x) (31 - HAL_CLZ(x))
+#define HAL_BSF(x) HAL_CTZ(x)
+#define HAL_FFS(x) (HAL_CTZ(x) + 1)
+/*!
+ ****************************************************************************************
+ * @brief
+ * HAL_REV16 swap bytes in a 16 bit word : useful for htons/ntohs and all enddianness conversions
+ * HAL_REV32 swap bytes in a 32 bit word : useful for htonl/ntohl and all enddianness conversions
+ * HAL_RBIT bit mirror / reverse of 32 bit word
+ ****************************************************************************************
+ */
+#ifdef __GNUC__
+#define HAL_REV16(x) __builtin_bswap16(x)
+#define HAL_REV32(x)  __builtin_bswap32(x)
+static inline uint32_t __hal_revb(uint32_t x)
+{
+    unsigned int res;
+    __asm volatile ("rbit    %0, %1  \n\t"
+                    : "=r" (res)
+                    : "r" (x));
+    return res;
+}
+
+#define HAL_RBIT(x) __hal_revb(x)
+
+#elif defined (__IAR_SYSTEMS_ICC__)
+#define HAL_REV16(x) __REV16(x)
+#define HAL_RBIT(x)  __RBIT(x)
+#define HAL_REV32(x) HAL_REV32_UNDEFINED(x)
+
+
+#endif
+
+
+
+
+#define HAL_HTONS(_x_)  HAL_REV16((_x_))
+#define HAL_NTOHS(_x_)  HAL_REV16((_x_))
+
+#define HAL_HTONL(_x_)  HAL_REV32((_x_))
+#define HAL_NTOHL(_x_)  HAL_REV32((_x_))
+
+#define HAL_BSWAP16(_x_) HAL_REV16((_x_))
+#define HAL_BSWAP32(_x_) HAL_REV32((_x_))
+
+
+#endif /* _EMBEDDEDTYPES_H_ */

--- a/third_party/nxp/JN5189DK6/middleware/wireless/framework/SerialManager/Source/UART_Serial_Adapter.h
+++ b/third_party/nxp/JN5189DK6/middleware/wireless/framework/SerialManager/Source/UART_Serial_Adapter.h
@@ -1,0 +1,98 @@
+/*! *********************************************************************************
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* Copyright 2016-2017 NXP
+* All rights reserved.
+*
+* \file
+*
+* SPDX-License-Identifier: BSD-3-Clause
+********************************************************************************** */
+
+#ifndef __UART_ADAPTER_H__
+#define __UART_ADAPTER_H__
+
+/*! *********************************************************************************
+*************************************************************************************
+* Public macros
+*************************************************************************************
+********************************************************************************** */
+#ifndef gUartIsrPrio_c
+#define gUartIsrPrio_c (0x40)
+#endif
+
+
+/*! *********************************************************************************
+*************************************************************************************
+* Public type definitions
+*************************************************************************************
+********************************************************************************** */
+typedef struct uartState_tag uartState_t;
+
+typedef void (*uartCallback_t)(uartState_t* state);
+
+struct uartState_tag {
+    uartCallback_t txCb;
+    uartCallback_t rxCb;
+    uint32_t txCbParam;
+    uint32_t rxCbParam;
+    uint8_t *pTxData;
+    uint8_t *pRxData;
+    volatile uint32_t txSize;
+    volatile uint32_t rxSize;
+};
+
+enum uartStatus_tag {
+    gUartSuccess_c,
+    gUartInvalidParameter_c,
+    gUartBusy_c
+};
+
+/*! *********************************************************************************
+*************************************************************************************
+* Public functions
+*************************************************************************************
+********************************************************************************** */
+uint32_t UART_Initialize(uint32_t instance, uartState_t *pState);
+uint32_t UART_SetBaudrate(uint32_t instance, uint32_t baudrate);
+uint32_t UART_SendData(uint32_t instance, uint8_t* pData, uint32_t size);
+uint32_t UART_ReceiveData(uint32_t instance, uint8_t* pData, uint32_t size);
+uint32_t UART_InstallRxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t UART_InstallTxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t UART_IsTxActive(uint32_t instance);
+uint32_t UART_EnableLowPowerWakeup(uint32_t instance);
+uint32_t UART_DisableLowPowerWakeup(uint32_t instance);
+uint32_t UART_IsWakeupSource(uint32_t instance);
+
+uint32_t LPUART_Initialize(uint32_t instance, uartState_t *pState);
+uint32_t LPUART_SetBaudrate(uint32_t instance, uint32_t baudrate);
+uint32_t LPUART_SendData(uint32_t instance, uint8_t* pData, uint32_t size);
+uint32_t LPUART_ReceiveData(uint32_t instance, uint8_t* pData, uint32_t size);
+uint32_t LPUART_InstallRxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t LPUART_InstallTxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t LPUART_IsTxActive(uint32_t instance);
+uint32_t LPUART_EnableLowPowerWakeup(uint32_t instance);
+uint32_t LPUART_DisableLowPowerWakeup(uint32_t instance);
+uint32_t LPUART_IsWakeupSource(uint32_t instance);
+
+uint32_t LPSCI_Initialize(uint32_t instance, uartState_t *pState);
+uint32_t LPSCI_SetBaudrate(uint32_t instance, uint32_t baudrate);
+uint32_t LPSCI_SendData(uint32_t instance, uint8_t* pData, uint32_t size);
+uint32_t LPSCI_ReceiveData(uint32_t instance, uint8_t* pData, uint32_t size);
+uint32_t LPSCI_InstallRxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t LPSCI_InstallTxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t LPSCI_IsTxActive(uint32_t instance);
+uint32_t LPSCI_EnableLowPowerWakeup(uint32_t instance);
+uint32_t LPSCI_DisableLowPowerWakeup(uint32_t instance);
+uint32_t LPSCI_IsWakeupSource(uint32_t instance);
+
+uint32_t USART_Initialize(uint32_t instance, uartState_t *pState);
+uint32_t USART_SetBaudrate(uint32_t instance, uint32_t baudrate);
+uint32_t USART_SendData(uint32_t instance, uint8_t *pData, uint32_t size);
+uint32_t USART_ReceiveData(uint32_t instance, uint8_t *pData, uint32_t size);
+uint32_t USART_InstallRxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t USART_InstallTxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t USART_IsTxActive(uint32_t instance);
+uint32_t USART_EnableLowPowerWakeup(uint32_t instance);
+uint32_t USART_DisableLowPowerWakeup(uint32_t instance);
+uint32_t USART_IsWakeupSource(uint32_t instance);
+#endif /* __UART_ADAPTER_H__ */

--- a/third_party/nxp/JN5189DK6/middleware/wireless/framework/TimersManager/Source/TMR_Adapter.h
+++ b/third_party/nxp/JN5189DK6/middleware/wireless/framework/TimersManager/Source/TMR_Adapter.h
@@ -1,0 +1,151 @@
+/*! *********************************************************************************
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* Copyright 2016-2017 NXP
+* All rights reserved.
+*
+* \file
+*
+* TMR export interface file for ARM CORTEX processor
+*
+* SPDX-License-Identifier: BSD-3-Clause
+********************************************************************************** */
+
+#ifndef _TMR_ADAPTER_H_
+#define _TMR_ADAPTER_H_
+
+
+/************************************************************************************
+*************************************************************************************
+* Include
+*************************************************************************************
+***********************************************************************************/
+#include "EmbeddedTypes.h"
+#include "fsl_device_registers.h"
+#include "board.h"
+
+
+
+/************************************************************************************
+*************************************************************************************
+* Public macros
+*************************************************************************************
+************************************************************************************/
+#ifdef CPU_JN518X
+#if gTimestamp_Enabled_d || gTimerMgrLowPowerTimers
+/* */
+#ifndef gTimerMgrUseCtimer_c
+#define gTimerMgrUseCtimer_c	        (0)
+#endif
+#ifndef gTimerMgrUseLpcRtc_c
+#define gTimerMgrUseLpcRtc_c	        (1)
+#endif
+#else
+#ifndef gTimerMgrUseCtimer_c
+#define gTimerMgrUseCtimer_c	        (1)
+#endif
+#ifndef gTimerMgrUseLpcRtc_c
+#define gTimerMgrUseLpcRtc_c	        (0)
+#endif
+#endif
+#endif
+
+
+/* Defines which timer resource can be used */
+#if (defined (FSL_FEATURE_SOC_CTIMER_COUNT) && (FSL_FEATURE_SOC_CTIMER_COUNT > 0))
+#ifndef gTimerMgrUseCtimer_c
+#define gTimerMgrUseCtimer_c	(1)
+#endif
+#endif
+
+#if(defined (FSL_FEATURE_SOC_LPC_RTC_COUNT) && (FSL_FEATURE_SOC_LPC_RTC_COUNT > 0))
+#ifndef gTimerMgrUseLpcRtc_c
+#define gTimerMgrUseLpcRtc_c	(1)
+#endif
+#endif
+
+#if(defined (FSL_FEATURE_RTC_HAS_FRC) && (FSL_FEATURE_RTC_HAS_FRC > 0))
+#ifndef gTimerMgrUseRtcFrc_c
+#define gTimerMgrUseRtcFrc_c	(1)
+#endif
+#endif
+
+#if(defined (FSL_FEATURE_SOC_FTM_COUNT) && (FSL_FEATURE_SOC_FTM_COUNT > 0))
+#ifndef gTimerMgrUseFtm_c
+#define gTimerMgrUseFtm_c       (1)
+#endif
+#endif
+
+
+
+#ifndef gStackTimerInstance_c
+#define gStackTimerInstance_c  0
+#endif
+
+#ifndef gStackTimerChannel_c
+#define gStackTimerChannel_c   0
+#endif
+
+#ifndef gLptmrInstance_c
+#define gLptmrInstance_c       0
+#endif
+
+#ifndef gTmrRtcInstance_c
+#define gTmrRtcInstance_c      0
+#endif
+
+#ifndef gTmrPitInstance_c
+#define gTmrPitInstance_c      0
+#endif
+
+#define gStackTimer_IsrPrio_c (0x80)
+
+#if gTimerMgrUseLpcRtc_c
+#define gStackTimerMaxCountValue_c  0xffff
+#else
+#define gStackTimerMaxCountValue_c  0xffffffff
+#endif
+/************************************************************************************
+*************************************************************************************
+* Public types
+*************************************************************************************
+************************************************************************************/
+typedef struct _tmr_adapter_pwm_param_type
+{
+    uint32_t frequency;
+    uint32_t initValue;
+}tmr_adapter_pwm_param_t;
+
+
+/*
+ * \brief   Platofrm specific timer ticks type definition
+ */
+#if FSL_FEATURE_SOC_CTIMER_COUNT || FSL_FEATURE_RTC_HAS_FRC
+    typedef uint32_t tmrTimerTicks_t;
+#else
+    typedef uint16_t tmrTimerTicks_t;
+#endif
+/************************************************************************************
+*************************************************************************************
+* Public prototypes
+*************************************************************************************
+************************************************************************************/
+void StackTimer_Init(void (*cb)(void));
+int  StackTimer_ReInit(void (*cb)(void));
+void StackTimer_Enable(void);
+void StackTimer_Disable(void);
+uint32_t StackTimer_ClearIntFlag(void);
+uint32_t StackTimer_GetInputFrequency(void);
+uint32_t StackTimer_GetCounterValue(void);
+void StackTimer_SetOffsetTicks(uint32_t offset);
+
+#ifndef ENABLE_RAM_VECTOR_TABLE
+void StackTimer_ISR_withParam(uint32_t param);
+#endif
+
+void PWM_Init(uint8_t instance);
+void PWM_SetChnCountVal(uint8_t instance, uint8_t channel, tmrTimerTicks_t val);
+tmrTimerTicks_t PWM_GetChnCountVal(uint8_t instance, uint8_t channel);
+#if !defined(FSL_FEATURE_SOC_CTIMER_COUNT) || (FSL_FEATURE_SOC_CTIMER_COUNT == 0)
+void PWM_StartEdgeAlignedLowTrue(uint8_t instance, tmr_adapter_pwm_param_t *param, uint8_t channel);
+#endif
+#endif /* _TMR_ADAPTER_H_ */

--- a/third_party/nxp/K32W061DK6/devices/K32W061/mcuxpresso/startup_k32w061.c
+++ b/third_party/nxp/K32W061DK6/devices/K32W061/mcuxpresso/startup_k32w061.c
@@ -149,6 +149,8 @@ WEAK void PVTVF1_AMBER_IRQHandler(void);
 WEAK void PVTVF1_RED_IRQHandler(void);
 WEAK void BLE_WAKE_UP_TIMER_IRQHandler(void);
 WEAK void SHA_IRQHandler(void);
+WEAK void vMMAC_IntHandlerBbc(void);
+WEAK void vMMAC_IntHandlerPhy(void);
 
 //*****************************************************************************
 // Forward declaration of the driver IRQ handlers. These are aliased
@@ -842,17 +844,34 @@ WEAK void BLE_LL_ALL_IRQHandler(void)
 
 WEAK void ZIGBEE_MAC_IRQHandler(void)
 {
-    ZIGBEE_MAC_DriverIRQHandler();
+    if (vMMAC_IntHandlerBbc)
+    {
+        vMMAC_IntHandlerBbc();
+    }
+    else if (ZIGBEE_MAC_IRQHandler)
+    {
+        ZIGBEE_MAC_IRQHandler();
+    }
+    else
+    {
+        IntDefaultHandler();
+    }
 }
 
 WEAK void ZIGBEE_MODEM_IRQHandler(void)
 {
-    ZIGBEE_MODEM_DriverIRQHandler();
-}
-
-WEAK void RFP_TMU_IRQHandler(void)
-{
-    RFP_TMU_DriverIRQHandler();
+    if (vMMAC_IntHandlerPhy)
+    {
+        vMMAC_IntHandlerPhy();
+    }
+    else if (ZIGBEE_MODEM_IRQHandler)
+    {
+        ZIGBEE_MODEM_IRQHandler();
+    }
+    else
+    {
+        IntDefaultHandler();
+    }
 }
 
 WEAK void RFP_AGC_IRQHandler(void)

--- a/third_party/nxp/K32W061DK6/middleware/wireless/framework/Common/EmbeddedTypes.h
+++ b/third_party/nxp/K32W061DK6/middleware/wireless/framework/Common/EmbeddedTypes.h
@@ -1,0 +1,277 @@
+/*! *********************************************************************************
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* Copyright 2016-2017 NXP
+* All rights reserved.
+*
+* \file
+*
+* SPDX-License-Identifier: BSD-3-Clause
+********************************************************************************** */
+
+#ifndef _EMBEDDEDTYPES_H_
+#define _EMBEDDEDTYPES_H_
+
+
+/************************************************************************************
+*
+*       INCLUDES
+*
+************************************************************************************/
+
+#include <stdint.h>
+#if defined (__IAR_SYSTEMS_ICC__)
+#include "cmsis_iccarm.h"
+#endif
+/************************************************************************************
+*
+*       TYPE DEFINITIONS
+*
+************************************************************************************/
+
+/* boolean types */
+typedef uint8_t   bool_t;
+
+typedef uint8_t   index_t;
+
+/* TRUE/FALSE definition*/
+#ifndef TRUE
+#define TRUE 1
+#endif
+
+#ifndef FALSE
+#define FALSE 0
+#endif
+
+/* null pointer definition*/
+#ifndef NULL
+#define NULL (( void * )( 0x0UL ))
+#endif
+
+#if defined(__GNUC__)
+#define PACKED_STRUCT struct __attribute__ ((__packed__))
+#define PACKED_UNION  union __attribute__ ((__packed__))
+#elif defined(__IAR_SYSTEMS_ICC__)
+#define PACKED_STRUCT __packed struct
+#define PACKED_UNION __packed union
+#elif defined(__CC_ARM)
+#define PACKED_STRUCT struct __attribute__((packed))
+#define PACKED_UNION union __attribute__((packed))
+#else
+#warning No definition for PACKED_STRUCT and PACKED_UNION!
+#endif
+
+typedef unsigned char uintn8_t;
+typedef unsigned long uintn32_t;
+
+typedef unsigned char uchar_t;
+
+#if !defined(MIN)
+#define MIN(a,b)                    (((a) < (b))?(a):(b))
+#endif
+
+#if !defined(MAX)
+#define MAX(a,b)                    (((a) > (b))?(a):(b))
+#endif
+
+/* Compute the number of elements of an array */
+#define NumberOfElements(x) (sizeof(x)/sizeof((x)[0]))
+
+/* Compute the size of a string initialized with quotation marks */
+#define SizeOfString(string) (sizeof(string) - 1)
+
+#define GetRelAddr(strct, member) ((uint32_t)&(((strct*)(void *)0)->member))
+#define GetSizeOfMember(strct, member) sizeof(((strct*)(void *)0)->member)
+
+/* Type definitions for link configuration of instantiable layers  */
+#define gInvalidInstanceId_c (instanceId_t)(-1)
+typedef uint32_t instanceId_t;
+
+/* Bit shift definitions */
+#define BIT0              0x01U
+#define BIT1              0x02U
+#define BIT2              0x04U
+#define BIT3              0x08U
+#define BIT4              0x10U
+#define BIT5              0x20U
+#define BIT6              0x40U
+#define BIT7              0x80U
+#define BIT8             0x100U
+#define BIT9             0x200U
+#define BIT10            0x400U
+#define BIT11            0x800U
+#define BIT12           0x1000U
+#define BIT13           0x2000U
+#define BIT14           0x4000U
+#define BIT15           0x8000U
+#define BIT16          0x10000U
+#define BIT17          0x20000U
+#define BIT18          0x40000U
+#define BIT19          0x80000U
+#define BIT20         0x100000U
+#define BIT21         0x200000U
+#define BIT22         0x400000U
+#define BIT23         0x800000U
+#define BIT24        0x1000000U
+#define BIT25        0x2000000U
+#define BIT26        0x4000000U
+#define BIT27        0x8000000U
+#define BIT28       0x10000000U
+#define BIT29       0x20000000U
+#define BIT30       0x40000000U
+#define BIT31       0x80000000U
+
+/* Shift definitions */
+#define SHIFT0      (0U)
+#define SHIFT1      (1U)
+#define SHIFT2      (2U)
+#define SHIFT3      (3U)
+#define SHIFT4      (4U)
+#define SHIFT5      (5U)
+#define SHIFT6      (6U)
+#define SHIFT7      (7U)
+#define SHIFT8      (8U)
+#define SHIFT9      (9U)
+#define SHIFT10     (10U)
+#define SHIFT11     (11U)
+#define SHIFT12     (12U)
+#define SHIFT13     (13U)
+#define SHIFT14     (14U)
+#define SHIFT15     (15U)
+#define SHIFT16     (16U)
+#define SHIFT17     (17U)
+#define SHIFT18     (18U)
+#define SHIFT19     (19U)
+#define SHIFT20     (20U)
+#define SHIFT21     (21U)
+#define SHIFT22     (22U)
+#define SHIFT23     (23U)
+#define SHIFT24     (24U)
+#define SHIFT25     (25U)
+#define SHIFT26     (26U)
+#define SHIFT27     (27U)
+#define SHIFT28     (28U)
+#define SHIFT29     (29U)
+#define SHIFT30     (30U)
+#define SHIFT31     (31U)
+
+#define SHIFT32     (32U)
+#define SHIFT33     (33U)
+#define SHIFT34     (34U)
+#define SHIFT35     (35U)
+#define SHIFT36     (36U)
+#define SHIFT37     (37U)
+#define SHIFT38     (38U)
+#define SHIFT39     (39U)
+#define SHIFT40     (40U)
+#define SHIFT41     (41U)
+#define SHIFT42     (42U)
+#define SHIFT43     (43U)
+#define SHIFT44     (44U)
+#define SHIFT45     (45U)
+#define SHIFT46     (46U)
+#define SHIFT47     (47U)
+#define SHIFT48     (48U)
+#define SHIFT49     (49U)
+#define SHIFT50     (50U)
+#define SHIFT51     (51U)
+#define SHIFT52     (52U)
+#define SHIFT53     (53U)
+#define SHIFT54     (54U)
+#define SHIFT55     (55U)
+#define SHIFT56     (56U)
+#define SHIFT57     (57U)
+#define SHIFT58     (58U)
+#define SHIFT59     (59U)
+#define SHIFT60     (60U)
+#define SHIFT61     (61U)
+#define SHIFT62     (62U)
+#define SHIFT63     (63U)
+
+#define NOT_USED(x) ((x)=(x))
+
+/*============================================================================
+                         FUNCTION PROTOTYPES
+=============================================================================*/
+
+
+/*!
+ * CLZ implementation : count leading zeroes from MSB
+ */
+#ifdef __GNUC__
+#define HAL_CLZ(x) __builtin_clz(x)
+#define HAL_CTZ(x) __builtin_ctz(x)
+#elif defined (__IAR_SYSTEMS_ICC__)
+#define HAL_CLZ(x) __CLZ(x)
+
+inline uint32_t __hal_ctz(uint32_t x)
+{
+    unsigned int res;
+    x = __RBIT(x);
+    res = __CLZ(x);
+    return res;
+}
+#define HAL_CTZ(x) __hal_ctz(x)
+
+#else
+#define HAL_CLZ(x) HAL_CLZ_UNDEFINED(x)
+#define HAL_CTZ(x) HAL_CTZ_UNDEFINED(x)
+#endif
+
+
+
+/*!
+ ****************************************************************************************
+ * @brief
+ * HAL_BSR Bit Scan Reverse ( find MSB bit set in a bit field )
+ * HAL_BSF Bit Scan Forward ( find LSB bit set in a bit field )
+ * HAL_FFS Find LSB bit position + 1 per standard ffs definition
+ *
+ ****************************************************************************************
+ */
+#define HAL_BSR(x) (31 - HAL_CLZ(x))
+#define HAL_BSF(x) HAL_CTZ(x)
+#define HAL_FFS(x) (HAL_CTZ(x) + 1)
+/*!
+ ****************************************************************************************
+ * @brief
+ * HAL_REV16 swap bytes in a 16 bit word : useful for htons/ntohs and all enddianness conversions
+ * HAL_REV32 swap bytes in a 32 bit word : useful for htonl/ntohl and all enddianness conversions
+ * HAL_RBIT bit mirror / reverse of 32 bit word
+ ****************************************************************************************
+ */
+#ifdef __GNUC__
+#define HAL_REV16(x) __builtin_bswap16(x)
+#define HAL_REV32(x)  __builtin_bswap32(x)
+static inline uint32_t __hal_revb(uint32_t x)
+{
+    unsigned int res;
+    __asm volatile ("rbit    %0, %1  \n\t"
+                    : "=r" (res)
+                    : "r" (x));
+    return res;
+}
+
+#define HAL_RBIT(x) __hal_revb(x)
+
+#elif defined (__IAR_SYSTEMS_ICC__)
+#define HAL_REV16(x) __REV16(x)
+#define HAL_RBIT(x)  __RBIT(x)
+#define HAL_REV32(x) HAL_REV32_UNDEFINED(x)
+
+
+#endif
+
+
+
+
+#define HAL_HTONS(_x_)  HAL_REV16((_x_))
+#define HAL_NTOHS(_x_)  HAL_REV16((_x_))
+
+#define HAL_HTONL(_x_)  HAL_REV32((_x_))
+#define HAL_NTOHL(_x_)  HAL_REV32((_x_))
+
+#define HAL_BSWAP16(_x_) HAL_REV16((_x_))
+#define HAL_BSWAP32(_x_) HAL_REV32((_x_))
+
+
+#endif /* _EMBEDDEDTYPES_H_ */

--- a/third_party/nxp/K32W061DK6/middleware/wireless/framework/SerialManager/Source/UART_Serial_Adapter.h
+++ b/third_party/nxp/K32W061DK6/middleware/wireless/framework/SerialManager/Source/UART_Serial_Adapter.h
@@ -1,0 +1,98 @@
+/*! *********************************************************************************
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* Copyright 2016-2017 NXP
+* All rights reserved.
+*
+* \file
+*
+* SPDX-License-Identifier: BSD-3-Clause
+********************************************************************************** */
+
+#ifndef __UART_ADAPTER_H__
+#define __UART_ADAPTER_H__
+
+/*! *********************************************************************************
+*************************************************************************************
+* Public macros
+*************************************************************************************
+********************************************************************************** */
+#ifndef gUartIsrPrio_c
+#define gUartIsrPrio_c (0x40)
+#endif
+
+
+/*! *********************************************************************************
+*************************************************************************************
+* Public type definitions
+*************************************************************************************
+********************************************************************************** */
+typedef struct uartState_tag uartState_t;
+
+typedef void (*uartCallback_t)(uartState_t* state);
+
+struct uartState_tag {
+    uartCallback_t txCb;
+    uartCallback_t rxCb;
+    uint32_t txCbParam;
+    uint32_t rxCbParam;
+    uint8_t *pTxData;
+    uint8_t *pRxData;
+    volatile uint32_t txSize;
+    volatile uint32_t rxSize;
+};
+
+enum uartStatus_tag {
+    gUartSuccess_c,
+    gUartInvalidParameter_c,
+    gUartBusy_c
+};
+
+/*! *********************************************************************************
+*************************************************************************************
+* Public functions
+*************************************************************************************
+********************************************************************************** */
+uint32_t UART_Initialize(uint32_t instance, uartState_t *pState);
+uint32_t UART_SetBaudrate(uint32_t instance, uint32_t baudrate);
+uint32_t UART_SendData(uint32_t instance, uint8_t* pData, uint32_t size);
+uint32_t UART_ReceiveData(uint32_t instance, uint8_t* pData, uint32_t size);
+uint32_t UART_InstallRxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t UART_InstallTxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t UART_IsTxActive(uint32_t instance);
+uint32_t UART_EnableLowPowerWakeup(uint32_t instance);
+uint32_t UART_DisableLowPowerWakeup(uint32_t instance);
+uint32_t UART_IsWakeupSource(uint32_t instance);
+
+uint32_t LPUART_Initialize(uint32_t instance, uartState_t *pState);
+uint32_t LPUART_SetBaudrate(uint32_t instance, uint32_t baudrate);
+uint32_t LPUART_SendData(uint32_t instance, uint8_t* pData, uint32_t size);
+uint32_t LPUART_ReceiveData(uint32_t instance, uint8_t* pData, uint32_t size);
+uint32_t LPUART_InstallRxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t LPUART_InstallTxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t LPUART_IsTxActive(uint32_t instance);
+uint32_t LPUART_EnableLowPowerWakeup(uint32_t instance);
+uint32_t LPUART_DisableLowPowerWakeup(uint32_t instance);
+uint32_t LPUART_IsWakeupSource(uint32_t instance);
+
+uint32_t LPSCI_Initialize(uint32_t instance, uartState_t *pState);
+uint32_t LPSCI_SetBaudrate(uint32_t instance, uint32_t baudrate);
+uint32_t LPSCI_SendData(uint32_t instance, uint8_t* pData, uint32_t size);
+uint32_t LPSCI_ReceiveData(uint32_t instance, uint8_t* pData, uint32_t size);
+uint32_t LPSCI_InstallRxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t LPSCI_InstallTxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t LPSCI_IsTxActive(uint32_t instance);
+uint32_t LPSCI_EnableLowPowerWakeup(uint32_t instance);
+uint32_t LPSCI_DisableLowPowerWakeup(uint32_t instance);
+uint32_t LPSCI_IsWakeupSource(uint32_t instance);
+
+uint32_t USART_Initialize(uint32_t instance, uartState_t *pState);
+uint32_t USART_SetBaudrate(uint32_t instance, uint32_t baudrate);
+uint32_t USART_SendData(uint32_t instance, uint8_t *pData, uint32_t size);
+uint32_t USART_ReceiveData(uint32_t instance, uint8_t *pData, uint32_t size);
+uint32_t USART_InstallRxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t USART_InstallTxCalback(uint32_t instance, uartCallback_t cb, uint32_t cbParam);
+uint32_t USART_IsTxActive(uint32_t instance);
+uint32_t USART_EnableLowPowerWakeup(uint32_t instance);
+uint32_t USART_DisableLowPowerWakeup(uint32_t instance);
+uint32_t USART_IsWakeupSource(uint32_t instance);
+#endif /* __UART_ADAPTER_H__ */

--- a/third_party/nxp/K32W061DK6/middleware/wireless/framework/TimersManager/Source/TMR_Adapter.h
+++ b/third_party/nxp/K32W061DK6/middleware/wireless/framework/TimersManager/Source/TMR_Adapter.h
@@ -1,0 +1,151 @@
+/*! *********************************************************************************
+* Copyright (c) 2015, Freescale Semiconductor, Inc.
+* Copyright 2016-2017 NXP
+* All rights reserved.
+*
+* \file
+*
+* TMR export interface file for ARM CORTEX processor
+*
+* SPDX-License-Identifier: BSD-3-Clause
+********************************************************************************** */
+
+#ifndef _TMR_ADAPTER_H_
+#define _TMR_ADAPTER_H_
+
+
+/************************************************************************************
+*************************************************************************************
+* Include
+*************************************************************************************
+***********************************************************************************/
+#include "EmbeddedTypes.h"
+#include "fsl_device_registers.h"
+#include "board.h"
+
+
+
+/************************************************************************************
+*************************************************************************************
+* Public macros
+*************************************************************************************
+************************************************************************************/
+#ifdef CPU_JN518X
+#if gTimestamp_Enabled_d || gTimerMgrLowPowerTimers
+/* */
+#ifndef gTimerMgrUseCtimer_c
+#define gTimerMgrUseCtimer_c	        (0)
+#endif
+#ifndef gTimerMgrUseLpcRtc_c
+#define gTimerMgrUseLpcRtc_c	        (1)
+#endif
+#else
+#ifndef gTimerMgrUseCtimer_c
+#define gTimerMgrUseCtimer_c	        (1)
+#endif
+#ifndef gTimerMgrUseLpcRtc_c
+#define gTimerMgrUseLpcRtc_c	        (0)
+#endif
+#endif
+#endif
+
+
+/* Defines which timer resource can be used */
+#if (defined (FSL_FEATURE_SOC_CTIMER_COUNT) && (FSL_FEATURE_SOC_CTIMER_COUNT > 0))
+#ifndef gTimerMgrUseCtimer_c
+#define gTimerMgrUseCtimer_c	(1)
+#endif
+#endif
+
+#if(defined (FSL_FEATURE_SOC_LPC_RTC_COUNT) && (FSL_FEATURE_SOC_LPC_RTC_COUNT > 0))
+#ifndef gTimerMgrUseLpcRtc_c
+#define gTimerMgrUseLpcRtc_c	(1)
+#endif
+#endif
+
+#if(defined (FSL_FEATURE_RTC_HAS_FRC) && (FSL_FEATURE_RTC_HAS_FRC > 0))
+#ifndef gTimerMgrUseRtcFrc_c
+#define gTimerMgrUseRtcFrc_c	(1)
+#endif
+#endif
+
+#if(defined (FSL_FEATURE_SOC_FTM_COUNT) && (FSL_FEATURE_SOC_FTM_COUNT > 0))
+#ifndef gTimerMgrUseFtm_c
+#define gTimerMgrUseFtm_c       (1)
+#endif
+#endif
+
+
+
+#ifndef gStackTimerInstance_c
+#define gStackTimerInstance_c  0
+#endif
+
+#ifndef gStackTimerChannel_c
+#define gStackTimerChannel_c   0
+#endif
+
+#ifndef gLptmrInstance_c
+#define gLptmrInstance_c       0
+#endif
+
+#ifndef gTmrRtcInstance_c
+#define gTmrRtcInstance_c      0
+#endif
+
+#ifndef gTmrPitInstance_c
+#define gTmrPitInstance_c      0
+#endif
+
+#define gStackTimer_IsrPrio_c (0x80)
+
+#if gTimerMgrUseLpcRtc_c
+#define gStackTimerMaxCountValue_c  0xffff
+#else
+#define gStackTimerMaxCountValue_c  0xffffffff
+#endif
+/************************************************************************************
+*************************************************************************************
+* Public types
+*************************************************************************************
+************************************************************************************/
+typedef struct _tmr_adapter_pwm_param_type
+{
+    uint32_t frequency;
+    uint32_t initValue;
+}tmr_adapter_pwm_param_t;
+
+
+/*
+ * \brief   Platofrm specific timer ticks type definition
+ */
+#if FSL_FEATURE_SOC_CTIMER_COUNT || FSL_FEATURE_RTC_HAS_FRC
+    typedef uint32_t tmrTimerTicks_t;
+#else
+    typedef uint16_t tmrTimerTicks_t;
+#endif
+/************************************************************************************
+*************************************************************************************
+* Public prototypes
+*************************************************************************************
+************************************************************************************/
+void StackTimer_Init(void (*cb)(void));
+int  StackTimer_ReInit(void (*cb)(void));
+void StackTimer_Enable(void);
+void StackTimer_Disable(void);
+uint32_t StackTimer_ClearIntFlag(void);
+uint32_t StackTimer_GetInputFrequency(void);
+uint32_t StackTimer_GetCounterValue(void);
+void StackTimer_SetOffsetTicks(uint32_t offset);
+
+#ifndef ENABLE_RAM_VECTOR_TABLE
+void StackTimer_ISR_withParam(uint32_t param);
+#endif
+
+void PWM_Init(uint8_t instance);
+void PWM_SetChnCountVal(uint8_t instance, uint8_t channel, tmrTimerTicks_t val);
+tmrTimerTicks_t PWM_GetChnCountVal(uint8_t instance, uint8_t channel);
+#if !defined(FSL_FEATURE_SOC_CTIMER_COUNT) || (FSL_FEATURE_SOC_CTIMER_COUNT == 0)
+void PWM_StartEdgeAlignedLowTrue(uint8_t instance, tmr_adapter_pwm_param_t *param, uint8_t channel);
+#endif
+#endif /* _TMR_ADAPTER_H_ */


### PR DESCRIPTION
This PR adds fixes which are needed for running Project CHIP on K32W.

Fixes are related to UART handling, radio interrupts and Free RTOS support.