### PR TITLE
[message] update 'Write()' to use 'memmove()' instead of 'memcpy()'

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -537,7 +537,7 @@ void Message::Write(uint16_t aOffset, uint16_t aLength, const void *aBuf)
 
     while (chunk.GetLength() > 0)
     {
-        memcpy(chunk.GetData(), bufPtr, chunk.GetLength());
+        memmove(chunk.GetData(), bufPtr, chunk.GetLength());
         bufPtr += chunk.GetLength();
         GetNextChunk(aLength, chunk);
     }
@@ -547,6 +547,13 @@ uint16_t Message::CopyTo(uint16_t aSourceOffset, uint16_t aDestinationOffset, ui
 {
     uint16_t bytesCopied = 0;
     Chunk    chunk;
+
+    // This implementing can potentially overwrite the data when bytes are
+    // being copied forward within the same message, i.e., source and
+    // destination messages are the same, and source offset is smaller than
+    // the destination offset. We assert not allowing such a use.
+
+    OT_ASSERT((&aMessage != this) || (aSourceOffset >= aDestinationOffset));
 
     GetFirstChunk(aSourceOffset, aLength, chunk);
 

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -532,6 +532,10 @@ public:
     /**
      * This method copies bytes from one message to another.
      *
+     * If source and destination messages are the same, `CopyTo()` can be used to perform a backward copy, but
+     * it MUST not be used to forward copy within the same message (i.e., when source and destination messages are the
+     * same and source offset is smaller than the destination offset).
+     *
      * @param[in] aSourceOffset       Byte offset within the source message to begin reading.
      * @param[in] aDestinationOffset  Byte offset within the destination message to begin writing.
      * @param[in] aLength             Number of bytes to copy.

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -144,7 +144,27 @@ void TestMessage(void)
         }
     }
 
+    // Verify `CopyTo()` with same source and destination message and a backward copy.
+
+    for (uint16_t srcOffset = 0; srcOffset < kMaxSize; srcOffset++)
+    {
+        uint16_t bytesCopied;
+
+        message->Write(0, kMaxSize, writeBuffer);
+
+        bytesCopied = message->CopyTo(srcOffset, 0, kMaxSize, *message);
+        VerifyOrQuit(bytesCopied == kMaxSize - srcOffset, "CopyTo() failed");
+
+        VerifyOrQuit(message->Read(0, kMaxSize, readBuffer) == kMaxSize, "Message::Read failed");
+
+        VerifyOrQuit(memcmp(&readBuffer[0], &writeBuffer[srcOffset], bytesCopied) == 0,
+                     "CopyTo() changed before srcOffset");
+        VerifyOrQuit(memcmp(&readBuffer[bytesCopied], &writeBuffer[bytesCopied], kMaxSize - bytesCopied) == 0,
+                     "CopyTo() write error");
+    }
+
     message->Free();
+    message2->Free();
 
     testFreeInstance(instance);
 }


### PR DESCRIPTION
This change allows `CopyTo()` method to be used to copy bytes backwards
within the same message (i.e., src and dest messages are the same and
the dest offset is before src offset). Unit test `test_message` is
updated in this commit to cover such a use.

However, the `CopyTo()` implementing  can still potentially overwrite
the data when bytes are being copied forward within the same message,
i.e., source and destination messages are the same, and source offset
is smaller than the destination offset. This commit adds an assert not
allowing such a use and updates the method documentation mentioning
this restriction.


----------

This change should address https://github.com/openthread/openthread/issues/5460 and unblock the fuzzer error on PRs.

Checking the `Message::CopyTo()` uses in the code, we seem to be copying within same 
message only from `Ip6::InsertMplOption()` and it's backward copy which should be addressed
by using `memmove` (other places we seem to copy between different source and destination 
messages which is fine). For now added an assert to restrict the `CopyTo()`'s use to forward 
copy within the same message 

I think the overlap write was an issue with the previous implementation (before https://github.com/openthread/openthread/pull/5454)  as well but it
was being masked (not detected by fuzzer) by the fact that `CopyTo()` would read content into a 
separate small 16 bytes buffer from  source message and the write them in destination.

