### PR TITLE
[diag] clear output in case no output given

### DIFF
--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -535,7 +535,7 @@ exit:
     switch (error)
     {
     case OT_ERROR_NONE:
-
+        aOutput[0] = '\0'; // In case there is no output.
         IgnoreError(ProcessCmd(argCount, &aArgsector[0], aOutput, aOutputMaxLen));
         break;
 


### PR DESCRIPTION
The `stop` command doesn't write anything to the output buffer.