### PR TITLE
[low-power] fix csl posix build problem

### DIFF
--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -110,7 +110,7 @@ void CslTxScheduler::Clear(void)
 void CslTxScheduler::RescheduleCslTx(void)
 {
     uint64_t radioNow     = otPlatRadioGetNow(&GetInstance());
-    uint32_t minDelayTime = TimeMicro::kMaxDuration;
+    uint32_t minDelayTime = Time::kMaxDuration;
     Child *  bestChild    = nullptr;
 
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateAnyExceptInvalid))


### PR DESCRIPTION
This PR changes `TimeMicro::kMaxDuration` to `Time::kMaxDuration` because in posix `OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE` is not set and `TimeMicro` is not defined.

And in the context, the intent is just to set the variable to a maximum value.