### PR TITLE
[ip6] skip copying message from 'ProcessReceiveCallback()'

### DIFF
--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -288,6 +288,28 @@ public:
     };
 
     /**
+     * This enumeration represents the message ownership model when a `Message` instance is passed to a method/function.
+     *
+     */
+    enum Ownership : uint8_t
+    {
+        /**
+         * This value indicates that the method/function receiving a `Message` instance should take custody of the
+         * message (e.g., the method should `Free()` the message if no longer needed).
+         *
+         */
+        kTakeCustody,
+
+        /**
+         * This value indicates that the method/function receiving a `Message` instance does not own the message (e.g.,
+         * it should not `Free()` or `Enqueue()` it in a queue). The receiving method/function should create a
+         * copy/clone of the message to keep (if/when needed).
+         *
+         */
+        kCopyToUse,
+    };
+
+    /**
      * This class represents settings used for creating a new message.
      *
      */

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -950,7 +950,7 @@ otError Ip6::HandleExtensionHeaders(Message &    aMessage,
 
         case kProtoFragment:
             // Always forward IPv6 fragments to the Host.
-            IgnoreError(ProcessReceiveCallback(aMessage, aMessageInfo, aNextHeader, aFromNcpHost));
+            IgnoreError(ProcessReceiveCallback(aMessage, aMessageInfo, aNextHeader, aFromNcpHost, Message::kCopyToUse));
 
             SuccessOrExit(error = HandleFragment(aMessage, aNetif, aMessageInfo, aFromNcpHost));
             break;
@@ -1002,13 +1002,14 @@ otError Ip6::HandlePayload(Message &aMessage, MessageInfo &aMessageInfo, uint8_t
     return error;
 }
 
-otError Ip6::ProcessReceiveCallback(const Message &    aMessage,
+otError Ip6::ProcessReceiveCallback(Message &          aMessage,
                                     const MessageInfo &aMessageInfo,
                                     uint8_t            aIpProto,
-                                    bool               aFromNcpHost)
+                                    bool               aFromNcpHost,
+                                    Message::Ownership aMessageOwnership)
 {
-    otError  error = OT_ERROR_NONE;
-    Message *messageCopy;
+    otError  error   = OT_ERROR_NONE;
+    Message *message = &aMessage;
 
     VerifyOrExit(!aFromNcpHost, error = OT_ERROR_NO_ROUTE);
     VerifyOrExit(mReceiveIp6DatagramCallback != nullptr, error = OT_ERROR_NO_ROUTE);
@@ -1074,19 +1075,33 @@ otError Ip6::ProcessReceiveCallback(const Message &    aMessage,
         }
     }
 
-    // make a copy of the datagram to pass to host
-    messageCopy = aMessage.Clone();
-
-    if (messageCopy == nullptr)
+    switch (aMessageOwnership)
     {
-        otLogWarnIp6("Failed to pass up message (len: %d) to host - out of message buffer.", aMessage.GetLength());
-        ExitNow(error = OT_ERROR_NO_BUFS);
+    case Message::kTakeCustody:
+        break;
+
+    case Message::kCopyToUse:
+        message = aMessage.Clone();
+
+        if (message == nullptr)
+        {
+            otLogWarnIp6("No buff to clone msg (len: %d) to pass to host", aMessage.GetLength());
+            ExitNow(error = OT_ERROR_NO_BUFS);
+        }
+
+        break;
     }
 
-    IgnoreError(RemoveMplOption(*messageCopy));
-    mReceiveIp6DatagramCallback(messageCopy, mReceiveIp6DatagramCallbackContext);
+    IgnoreError(RemoveMplOption(*message));
+    mReceiveIp6DatagramCallback(message, mReceiveIp6DatagramCallbackContext);
 
 exit:
+
+    if ((error != OT_ERROR_NONE) && (aMessageOwnership == Message::kTakeCustody))
+    {
+        aMessage.Free();
+    }
+
     return error;
 }
 
@@ -1129,12 +1144,14 @@ otError Ip6::HandleDatagram(Message &aMessage, Netif *aNetif, const void *aLinkM
     bool        receive;
     bool        forward;
     bool        multicastPromiscuous;
+    bool        shouldFreeMessage;
     uint8_t     nextHeader;
 
 start:
     receive              = false;
     forward              = false;
     multicastPromiscuous = false;
+    shouldFreeMessage    = true;
 
     SuccessOrExit(error = header.Init(aMessage));
 
@@ -1221,13 +1238,13 @@ start:
         }
 #endif
 
-        IgnoreError(ProcessReceiveCallback(aMessage, messageInfo, nextHeader, aFromNcpHost));
+        IgnoreError(ProcessReceiveCallback(aMessage, messageInfo, nextHeader, aFromNcpHost, Message::kCopyToUse));
 
         SuccessOrExit(error = HandlePayload(aMessage, messageInfo, nextHeader));
     }
     else if (multicastPromiscuous)
     {
-        IgnoreError(ProcessReceiveCallback(aMessage, messageInfo, nextHeader, aFromNcpHost));
+        IgnoreError(ProcessReceiveCallback(aMessage, messageInfo, nextHeader, aFromNcpHost, Message::kCopyToUse));
     }
 
     if (forward)
@@ -1237,17 +1254,13 @@ start:
         if (!ShouldForwardToThread(messageInfo))
         {
             // try passing to host
-            SuccessOrExit(error = ProcessReceiveCallback(aMessage, messageInfo, nextHeader, aFromNcpHost));
-
-            // the caller transfers custody in the success case, so free the aMessage here
-            aMessage.Free();
-
-            ExitNow();
+            error = ProcessReceiveCallback(aMessage, messageInfo, nextHeader, aFromNcpHost, Message::kTakeCustody);
+            ExitNow(shouldFreeMessage = false);
         }
 
         if (aNetif != nullptr)
         {
-            VerifyOrExit(mForwardingEnabled, forward = false);
+            VerifyOrExit(mForwardingEnabled, OT_NOOP);
             header.SetHopLimit(header.GetHopLimit() - 1);
         }
 
@@ -1273,12 +1286,14 @@ start:
         }
 #endif
 
+        // `SendMessage()` takes custody of message in the success case
         SuccessOrExit(error = Get<ThreadNetif>().SendMessage(aMessage));
+        shouldFreeMessage = false;
     }
 
 exit:
 
-    if (error != OT_ERROR_NONE || !forward)
+    if (shouldFreeMessage)
     {
         aMessage.Free();
     }

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -348,10 +348,11 @@ private:
     static uint16_t UpdateChecksum(uint16_t aChecksum, const Address &aAddress);
 
     void    EnqueueDatagram(Message &aMessage);
-    otError ProcessReceiveCallback(const Message &    aMessage,
+    otError ProcessReceiveCallback(Message &          aMessage,
                                    const MessageInfo &aMessageInfo,
                                    uint8_t            aIpProto,
-                                   bool               aFromNcpHost);
+                                   bool               aFromNcpHost,
+                                   Message::Ownership aMessageOwnership);
     otError HandleExtensionHeaders(Message &    aMessage,
                                    Netif *      aNetif,
                                    MessageInfo &aMessageInfo,


### PR DESCRIPTION
This commit adds a new parameter to `Ip6::ProcessReceiveCallback()`
allowing caller to indicate whether the method can take custody of the
passed-in message or whether it needs to make a copy of it (to use in
receive callback). This is indicated by a new `enum` definition
`Message::Ownership`. In case of `kTakeCustody` value, the caller
transfers custody of message to the called method (i.e. the method can
`Enqueue()` the message and would need to `Free()` the message when no
longer needed).

The `Ip6::HandleDatagram()` uses this to avoid copying the message in
cases where it is not needed (e.g. for a message that is passed to
host through callback but does not need to be processed by Thread
core).