### PR TITLE
[mle] simplify logging and add helper log methods

### DIFF
--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -154,7 +154,7 @@ otError DiscoverScanner::Discover(const Mac::ChannelMask &aScanChannels,
     mScanChannel = Mac::ChannelMask::kChannelIteratorFirst;
     mState       = (mScanChannels.GetNextChannel(mScanChannel) == OT_ERROR_NONE) ? kStateScanning : kStateScanDone;
 
-    otLogInfoMle("Send Discovery Request (%s)", destination.ToString().AsCString());
+    Mle::Log("Send Discovery Request", destination);
 
 exit:
 
@@ -302,7 +302,7 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
     uint16_t                      end;
     bool                          didCheckSteeringData = false;
 
-    otLogInfoMle("Receive Discovery Response (%s)", aMessageInfo.GetPeerAddr().ToString().AsCString());
+    Mle::Log("Receive Discovery Response", aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(mState == kStateScanning, error = OT_ERROR_DROP);
 
@@ -387,11 +387,7 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Discovery Response: %s", otThreadErrorToString(error));
-    }
+    Mle::LogProcessError("Discovery Response", error);
 }
 
 } // namespace Mle

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1853,7 +1853,7 @@ void Mle::HandleDelayedResponseTimer(void)
 
             if (SendMessage(*message, metadata.mDestination) == OT_ERROR_NONE)
             {
-                LogMleMessage("Send delayed message", metadata.mDestination);
+                Log("Send delayed message", metadata.mDestination);
 
                 // Here enters fast poll mode, as for Rx-Off-when-idle device, the enqueued msg should
                 // be Mle Data Request.
@@ -1891,7 +1891,7 @@ void Mle::RemoveDelayedDataResponseMessage(void)
         {
             mDelayedResponses.Dequeue(*message);
             message->Free();
-            LogMleMessage("Remove Delayed Data Response", metadata.mDestination);
+            Log("Remove Delayed Data Response", metadata.mDestination);
 
             // no more than one multicast MLE Data Response in Delayed Message Queue.
             break;
@@ -1937,11 +1937,11 @@ otError Mle::SendParentRequest(ParentRequestType aType)
     switch (aType)
     {
     case kParentRequestTypeRouters:
-        LogMleMessage("Send Parent Request to routers", destination);
+        Log("Send Parent Request to routers", destination);
         break;
 
     case kParentRequestTypeRoutersAndReeds:
-        LogMleMessage("Send Parent Request to routers and REEDs", destination);
+        Log("Send Parent Request to routers and REEDs", destination);
         break;
     }
 
@@ -2019,11 +2019,11 @@ otError Mle::SendChildIdRequest(void)
 
     if (mAddressRegistrationMode == kAppendMeshLocalOnly)
     {
-        LogMleMessage("Send Child ID Request - short", destination);
+        Log("Send Child ID Request - short", destination);
     }
     else
     {
-        LogMleMessage("Send Child ID Request", destination);
+        Log("Send Child ID Request", destination);
     }
 
     if (!IsRxOnWhenIdle())
@@ -2059,12 +2059,12 @@ otError Mle::SendDataRequest(const Ip6::Address &aDestination,
     if (aDelay)
     {
         SuccessOrExit(error = AddDelayedResponse(*message, aDestination, aDelay));
-        LogMleMessage("Delay Data Request", aDestination);
+        Log("Delay Data Request", aDestination);
     }
     else
     {
         SuccessOrExit(error = SendMessage(*message, aDestination));
-        LogMleMessage("Send Data Request", aDestination);
+        Log("Send Data Request", aDestination);
 
         if (!IsRxOnWhenIdle())
         {
@@ -2269,7 +2269,7 @@ otError Mle::SendChildUpdateRequest(void)
     destination.SetToLinkLocalAddress(mParent.GetExtAddress());
     SuccessOrExit(error = SendMessage(*message, destination));
 
-    LogMleMessage("Send Child Update Request to parent", destination);
+    Log("Send Child Update Request to parent", destination);
 
     if (!IsRxOnWhenIdle())
     {
@@ -2350,7 +2350,7 @@ otError Mle::SendChildUpdateResponse(const uint8_t *aTlvs, uint8_t aNumTlvs, con
     destination.SetToLinkLocalAddress(mParent.GetExtAddress());
     SuccessOrExit(error = SendMessage(*message, destination));
 
-    LogMleMessage("Send Child Update Response to parent", destination);
+    Log("Send Child Update Response to parent", destination);
 
     if (checkAddress && HasUnregisteredAddress())
     {
@@ -2740,13 +2740,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogNoteMle("Failed to process UDP: %s", otThreadErrorToString(error));
-    }
-
-    return;
+    LogProcessError("UDP", error);
 }
 
 void Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, Neighbor *aNeighbor)
@@ -2760,7 +2754,7 @@ void Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &a
     // Source Address
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
 
-    LogMleMessage("Receive Advertisement", aMessageInfo.GetPeerAddr(), sourceAddress);
+    Log("Receive Advertisement", aMessageInfo.GetPeerAddr(), sourceAddress);
 
     // Leader Data
     SuccessOrExit(error = ReadLeaderData(aMessage, leaderData));
@@ -2829,18 +2823,14 @@ void Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &a
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Advertisement: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Advertisement", error);
 }
 
 void Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, const Neighbor *aNeighbor)
 {
     otError error;
 
-    LogMleMessage("Receive Data Response", aMessageInfo.GetPeerAddr());
+    Log("Receive Data Response", aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), error = OT_ERROR_SECURITY);
 
@@ -2857,11 +2847,7 @@ void Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageInfo &aM
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Data Response: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Data Response", error);
 }
 
 bool Mle::IsNetworkDataNewer(const LeaderData &aLeaderData)
@@ -3127,7 +3113,7 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
     // Source Address
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
 
-    LogMleMessage("Receive Parent Response", aMessageInfo.GetPeerAddr(), sourceAddress);
+    Log("Receive Parent Response", aMessageInfo.GetPeerAddr(), sourceAddress);
 
     // Version
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kVersion, version));
@@ -3304,11 +3290,7 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
     mParentLinkMargin       = linkMargin;
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Parent Response: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Parent Response", error);
 }
 
 void Mle::HandleChildIdResponse(const Message &         aMessage,
@@ -3330,7 +3312,7 @@ void Mle::HandleChildIdResponse(const Message &         aMessage,
     // Source Address
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
 
-    LogMleMessage("Receive Child ID Response", aMessageInfo.GetPeerAddr(), sourceAddress);
+    Log("Receive Child ID Response", aMessageInfo.GetPeerAddr(), sourceAddress);
 
     VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), error = OT_ERROR_SECURITY);
 
@@ -3432,11 +3414,7 @@ void Mle::HandleChildIdResponse(const Message &         aMessage,
     SetStateChild(shortAddress);
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Child ID Response: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Child ID Response", error);
 }
 
 void Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, Neighbor *aNeighbor)
@@ -3453,7 +3431,7 @@ void Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageIn
     // Source Address
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
 
-    LogMleMessage("Receive Child Update Request from parent", aMessageInfo.GetPeerAddr(), sourceAddress);
+    Log("Receive Child Update Request from parent", aMessageInfo.GetPeerAddr(), sourceAddress);
 
     // Challenge
     switch (ReadChallenge(aMessage, challenge))
@@ -3523,11 +3501,7 @@ void Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageIn
     SuccessOrExit(error = SendChildUpdateResponse(tlvs, numTlvs, challenge));
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Child Update Request from parent: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Child Update Request from parent", error);
 }
 
 void Mle::HandleChildUpdateResponse(const Message &         aMessage,
@@ -3543,7 +3517,7 @@ void Mle::HandleChildUpdateResponse(const Message &         aMessage,
     uint16_t  sourceAddress;
     uint32_t  timeout;
 
-    LogMleMessage("Receive Child Update Response from parent", aMessageInfo.GetPeerAddr());
+    Log("Receive Child Update Response from parent", aMessageInfo.GetPeerAddr());
 
     switch (mRole)
     {
@@ -3651,10 +3625,8 @@ exit:
             ScheduleMessageTransmissionTimer();
         }
     }
-    else
-    {
-        otLogWarnMle("Failed to process Child Update Response: %s", otThreadErrorToString(error));
-    }
+
+    LogProcessError("Child Update Response", error);
 }
 
 void Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -3668,7 +3640,7 @@ void Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMessa
     uint8_t                   channel;
     uint16_t                  panId;
 
-    LogMleMessage("Receive Announce", aMessageInfo.GetPeerAddr());
+    Log("Receive Announce", aMessageInfo.GetPeerAddr());
 
     SuccessOrExit(error = Tlv::FindTlv(aMessage, Tlv::kChannel, sizeof(channelTlv), channelTlv));
     VerifyOrExit(channelTlv.IsValid(), error = OT_ERROR_PARSE);
@@ -3722,11 +3694,7 @@ void Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMessa
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Announce: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Announce", error);
 }
 
 void Mle::ProcessAnnounce(void)
@@ -3932,22 +3900,35 @@ void Mle::UpdateParentSearchState(void)
 }
 #endif // OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE
 
-void Mle::LogMleMessage(const char *aLogString, const Ip6::Address &aAddress) const
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
+void Mle::Log(const char *aLogString, const Ip6::Address &aAddress)
 {
-    OT_UNUSED_VARIABLE(aLogString);
-    OT_UNUSED_VARIABLE(aAddress);
-
     otLogInfoMle("%s (%s)", aLogString, aAddress.ToString().AsCString());
 }
 
-void Mle::LogMleMessage(const char *aLogString, const Ip6::Address &aAddress, uint16_t aRloc) const
+void Mle::Log(const char *aLogString, const Ip6::Address &aAddress, uint16_t aRloc)
 {
-    OT_UNUSED_VARIABLE(aLogString);
-    OT_UNUSED_VARIABLE(aAddress);
-    OT_UNUSED_VARIABLE(aRloc);
-
     otLogInfoMle("%s (%s,0x%04x)", aLogString, aAddress.ToString().AsCString(), aRloc);
 }
+#endif
+
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
+void Mle::LogProcessError(const char *aMessageString, otError aError)
+{
+    if (aError != OT_ERROR_NONE)
+    {
+        otLogWarnMle("Failed to process %s: %s", aMessageString, otThreadErrorToString(aError));
+    }
+}
+
+void Mle::LogSendError(const char *aMessageString, otError aError)
+{
+    if (aError != OT_ERROR_NONE)
+    {
+        otLogWarnMle("Failed to send %s: %s", aMessageString, otThreadErrorToString(aError));
+    }
+}
+#endif
 
 const char *Mle::RoleToString(DeviceRole aRole)
 {

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1517,24 +1517,58 @@ protected:
      */
     otError AddDelayedResponse(Message &aMessage, const Ip6::Address &aDestination, uint16_t aDelay);
 
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
     /**
-     * This method prints an MLE log message with an IPv6 address.
+     * This static method emits a log message with an IPv6 address.
      *
      * @param[in]  aLogString  The log message string.
      * @param[in]  aAddress    The IPv6 address of the peer.
      *
      */
-    void LogMleMessage(const char *aLogString, const Ip6::Address &aAddress) const;
+    static void Log(const char *aLogString, const Ip6::Address &aAddress);
 
     /**
-     * This method prints an MLE log message with an IPv6 address and RLOC16.
+     * This static method emits a log message with an IPv6 address and RLOC16.
      *
      * @param[in]  aLogString  The log message string.
      * @param[in]  aAddress    The IPv6 address of the peer.
      * @param[in]  aRloc       The RLOC16.
      *
      */
-    void LogMleMessage(const char *aLogString, const Ip6::Address &aAddress, uint16_t aRloc) const;
+    static void Log(const char *aLogString, const Ip6::Address &aAddress, uint16_t aRloc);
+#else
+    static void Log(const char *, const Ip6::Address &) {}
+    static void Log(const char *, const Ip6::Address &, uint16_t) {}
+#endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
+
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
+    /**
+     * This static method emits a log message indicating an error in processing of an MLE message.
+     *
+     * Note that log message is emitted only if there is an error, i.e., @p aError is not `OT_ERROR_NONE`. The log
+     * message will have the format "Failed to process {aMessageString} : {ErrorString}".
+     *
+     * @param[in]  aMessageString    A string representing the MLE message type.
+     * @param[in]  aError            The error in processing the MLE message.
+     *
+     */
+    static void LogProcessError(const char *aMessageString, otError aError);
+
+    /**
+     * This static method emits a log message indicating an error when sending an MLE message.
+     *
+     * Note that log message is emitted only if there is an error, i.e. @p aError is not `OT_ERROR_NONE`. The log
+     * message will have the format "Failed to send {aMessageString} : {ErrorString}".
+     *
+     * @param[in]  aMessageString    A string representing the MLE message type.
+     * @param[in]  aError            The error in sending the MLE message.
+     *
+     */
+    static void LogSendError(const char *aMessageString, otError aError);
+#else
+    static void LogProcessError(const char *, otError) {}
+    static void LogSendError(const char *, otError) {}
+#endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
 
     /**
      * This method triggers MLE Announce on previous channel after the Thread device successfully

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -462,19 +462,16 @@ void MleRouter::SendAdvertisement(void)
     destination.SetToLinkLocalAllNodesMulticast();
     SuccessOrExit(error = SendMessage(*message, destination));
 
-    LogMleMessage("Send Advertisement", destination);
+    Log("Send Advertisement", destination);
 
 exit:
 
-    if (error != OT_ERROR_NONE)
+    if ((error != OT_ERROR_NONE) && (message != nullptr))
     {
-        otLogWarnMle("Failed to send Advertisement: %s", otThreadErrorToString(error));
-
-        if (message != nullptr)
-        {
-            message->Free();
-        }
+        message->Free();
     }
+
+    LogSendError("Advertisement", error);
 }
 
 otError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
@@ -555,7 +552,7 @@ otError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
 
     SuccessOrExit(error = SendMessage(*message, destination));
 
-    LogMleMessage("Send Link Request", destination);
+    Log("Send Link Request", destination);
 
 exit:
 
@@ -580,7 +577,7 @@ void MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInf
     TimeRequestTlv timeRequest;
 #endif
 
-    LogMleMessage("Receive Link Request", aMessageInfo.GetPeerAddr());
+    Log("Receive Link Request", aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(IsRouterOrLeader(), error = OT_ERROR_INVALID_STATE);
 
@@ -676,11 +673,7 @@ void MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInf
     SuccessOrExit(error = SendLinkAccept(aMessageInfo, neighbor, requestedTlvs, challenge));
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogNoteMle("Failed to process Link Request: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Link Request", error);
 }
 
 otError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo,
@@ -759,13 +752,13 @@ otError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo,
         SuccessOrExit(error = AddDelayedResponse(*message, aMessageInfo.GetPeerAddr(),
                                                  1 + Random::NonCrypto::GetUint16InRange(0, kMaxResponseDelay)));
 
-        LogMleMessage("Delay Link Accept", aMessageInfo.GetPeerAddr());
+        Log("Delay Link Accept", aMessageInfo.GetPeerAddr());
     }
     else
     {
         SuccessOrExit(error = SendMessage(*message, aMessageInfo.GetPeerAddr()));
 
-        LogMleMessage("Send Link Accept", aMessageInfo.GetPeerAddr());
+        Log("Send Link Accept", aMessageInfo.GetPeerAddr());
     }
 
 exit:
@@ -785,10 +778,7 @@ void MleRouter::HandleLinkAccept(const Message &         aMessage,
 {
     otError error = HandleLinkAccept(aMessage, aMessageInfo, aKeySequence, aNeighbor, false);
 
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Link Accept: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Link Accept", error);
 }
 
 void MleRouter::HandleLinkAcceptAndRequest(const Message &         aMessage,
@@ -798,10 +788,7 @@ void MleRouter::HandleLinkAcceptAndRequest(const Message &         aMessage,
 {
     otError error = HandleLinkAccept(aMessage, aMessageInfo, aKeySequence, aNeighbor, true);
 
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Link Accept and Request: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Link Accept and Request", error);
 }
 
 otError MleRouter::HandleLinkAccept(const Message &         aMessage,
@@ -832,11 +819,11 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
 
     if (aRequest)
     {
-        LogMleMessage("Receive Link Accept and Request", aMessageInfo.GetPeerAddr(), sourceAddress);
+        Log("Receive Link Accept and Request", aMessageInfo.GetPeerAddr(), sourceAddress);
     }
     else
     {
-        LogMleMessage("Receive Link Accept", aMessageInfo.GetPeerAddr(), sourceAddress);
+        Log("Receive Link Accept", aMessageInfo.GetPeerAddr(), sourceAddress);
     }
 
     VerifyOrExit(IsActiveRouter(sourceAddress), error = OT_ERROR_PARSE);
@@ -1605,7 +1592,7 @@ void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageI
     TimeRequestTlv timeRequest;
 #endif
 
-    LogMleMessage("Receive Parent Request", aMessageInfo.GetPeerAddr());
+    Log("Receive Parent Request", aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(IsRouterEligible(), error = OT_ERROR_INVALID_STATE);
 
@@ -1702,11 +1689,7 @@ void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageI
     SendParentResponse(child, challenge, !ScanMaskTlv::IsEndDeviceFlagSet(scanMask));
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Parent Request: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Parent Request", error);
 }
 
 void MleRouter::HandleTimeTick(void)
@@ -1989,19 +1972,16 @@ void MleRouter::SendParentResponse(Child *aChild, const Challenge &aChallenge, b
 
     SuccessOrExit(error = AddDelayedResponse(*message, destination, delay));
 
-    LogMleMessage("Delay Parent Response", destination);
+    Log("Delay Parent Response", destination);
 
 exit:
 
-    if (error != OT_ERROR_NONE)
+    if ((error != OT_ERROR_NONE) && (message != nullptr))
     {
-        otLogWarnMle("Failed to send Parent Response: %s", otThreadErrorToString(error));
-
-        if (message != nullptr)
-        {
-            message->Free();
-        }
+        message->Free();
     }
+
+    LogSendError("Parent Response", error);
 }
 
 uint8_t MleRouter::GetMaxChildIpAddresses(void) const
@@ -2241,7 +2221,7 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     uint8_t             numTlvs;
     uint16_t            addressRegistrationOffset = 0;
 
-    LogMleMessage("Receive Child ID Request", aMessageInfo.GetPeerAddr());
+    Log("Receive Child ID Request", aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(IsRouterEligible(), error = OT_ERROR_INVALID_STATE);
 
@@ -2387,11 +2367,7 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Child ID Request: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Child ID Request", error);
 }
 
 void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
@@ -2415,7 +2391,7 @@ void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
     uint16_t        addressRegistrationOffset = 0;
     bool            childDidChange            = false;
 
-    LogMleMessage("Receive Child Update Request from child", aMessageInfo.GetPeerAddr());
+    Log("Receive Child Update Request from child", aMessageInfo.GetPeerAddr());
 
     // Mode
     SuccessOrExit(error = Tlv::FindUint8Tlv(aMessage, Tlv::kMode, modeBitmask));
@@ -2580,11 +2556,7 @@ void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
     SendChildUpdateResponse(child, aMessageInfo, tlvs, tlvslength, challenge);
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Child Update Request from child: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Child Update Request from child", error);
 }
 
 void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
@@ -2605,7 +2577,7 @@ void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
 
     if ((aNeighbor == nullptr) || IsActiveRouter(aNeighbor->GetRloc16()))
     {
-        LogMleMessage("Receive Child Update Response from unknown child", aMessageInfo.GetPeerAddr());
+        Log("Receive Child Update Response from unknown child", aMessageInfo.GetPeerAddr());
         ExitNow(error = OT_ERROR_NOT_FOUND);
     }
 
@@ -2624,7 +2596,7 @@ void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
         ExitNow(error = OT_ERROR_NONE);
     }
 
-    LogMleMessage("Receive Child Update Response from child", aMessageInfo.GetPeerAddr(), child->GetRloc16());
+    Log("Receive Child Update Response from child", aMessageInfo.GetPeerAddr(), child->GetRloc16());
 
     // Source Address
     switch (Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress))
@@ -2725,11 +2697,7 @@ void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
     child->GetLinkInfo().AddRss(aMessageInfo.GetThreadLinkInfo()->GetRss());
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Child Update Response from child: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Child Update Response from child", error);
 }
 
 void MleRouter::HandleDataRequest(const Message &         aMessage,
@@ -2743,7 +2711,7 @@ void MleRouter::HandleDataRequest(const Message &         aMessage,
     uint8_t             tlvs[4];
     uint8_t             numTlvs;
 
-    LogMleMessage("Receive Data Request", aMessageInfo.GetPeerAddr());
+    Log("Receive Data Request", aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), error = OT_ERROR_SECURITY);
 
@@ -2784,11 +2752,7 @@ void MleRouter::HandleDataRequest(const Message &         aMessage,
     SendDataResponse(aMessageInfo.GetPeerAddr(), tlvs, numTlvs, 0);
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Data Request: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Data Request", error);
 }
 
 void MleRouter::HandleNetworkDataUpdateRouter(void)
@@ -2882,7 +2846,7 @@ void MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Messa
     uint16_t                     offset;
     uint16_t                     end;
 
-    LogMleMessage("Receive Discovery Request", aMessageInfo.GetPeerAddr());
+    Log("Receive Discovery Request", aMessageInfo.GetPeerAddr());
 
     discoveryRequest.SetLength(0);
 
@@ -2951,11 +2915,7 @@ void MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Messa
     error = SendDiscoveryResponse(aMessageInfo.GetPeerAddr(), aMessage.GetPanId());
 
 exit:
-
-    if (error != OT_ERROR_NONE)
-    {
-        otLogWarnMle("Failed to process Discovery Request: %s", otThreadErrorToString(error));
-    }
+    LogProcessError("Discovery Request", error);
 }
 
 otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint16_t aPanId)
@@ -3038,20 +2998,16 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
 
     SuccessOrExit(error = AddDelayedResponse(*message, aDestination, delay));
 
-    LogMleMessage("Delay Discovery Response", aDestination);
+    Log("Delay Discovery Response", aDestination);
 
 exit:
 
-    if (error != OT_ERROR_NONE)
+    if ((error != OT_ERROR_NONE) && (message != nullptr))
     {
-        otLogWarnMle("Failed to process Discovery Response: %s", otThreadErrorToString(error));
-
-        if (message != nullptr)
-        {
-            message->Free();
-        }
+        message->Free();
     }
 
+    LogProcessError("Discovery Response", error);
     return error;
 }
 
@@ -3139,7 +3095,7 @@ otError MleRouter::SendChildIdResponse(Child &aChild)
     destination.SetToLinkLocalAddress(aChild.GetExtAddress());
     SuccessOrExit(error = SendMessage(*message, destination));
 
-    LogMleMessage("Send Child ID Response", destination, aChild.GetRloc16());
+    Log("Send Child ID Response", destination, aChild.GetRloc16());
 
 exit:
 
@@ -3205,7 +3161,7 @@ otError MleRouter::SendChildUpdateRequest(Child &aChild)
         aChild.SetState(Child::kStateChildUpdateRequest);
     }
 
-    LogMleMessage("Send Child Update Request to child", destination, aChild.GetRloc16());
+    Log("Send Child Update Request to child", destination, aChild.GetRloc16());
 
 exit:
 
@@ -3281,11 +3237,11 @@ void MleRouter::SendChildUpdateResponse(Child *                 aChild,
 
     if (aChild == nullptr)
     {
-        LogMleMessage("Send Child Update Response to child", aMessageInfo.GetPeerAddr());
+        Log("Send Child Update Response to child", aMessageInfo.GetPeerAddr());
     }
     else
     {
-        LogMleMessage("Send Child Update Response to child", aMessageInfo.GetPeerAddr(), aChild->GetRloc16());
+        Log("Send Child Update Response to child", aMessageInfo.GetPeerAddr(), aChild->GetRloc16());
     }
 
 exit:
@@ -3349,25 +3305,22 @@ void MleRouter::SendDataResponse(const Ip6::Address &aDestination,
         RemoveDelayedDataResponseMessage();
 
         SuccessOrExit(error = AddDelayedResponse(*message, aDestination, aDelay));
-        LogMleMessage("Delay Data Response", aDestination);
+        Log("Delay Data Response", aDestination);
     }
     else
     {
         SuccessOrExit(error = SendMessage(*message, aDestination));
-        LogMleMessage("Send Data Response", aDestination);
+        Log("Send Data Response", aDestination);
     }
 
 exit:
 
-    if (error != OT_ERROR_NONE)
+    if ((error != OT_ERROR_NONE) && (message != nullptr))
     {
-        otLogWarnMle("Failed to send Data Response: %s", otThreadErrorToString(error));
-
-        if (message != nullptr)
-        {
-            message->Free();
-        }
+        message->Free();
     }
+
+    LogSendError("Data Response", error);
 }
 
 bool MleRouter::IsMinimalChild(uint16_t aRloc16)
@@ -3653,7 +3606,7 @@ otError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
         error = Get<Coap::Coap>().SendMessage(*message, messageInfo, &MleRouter::HandleAddressSolicitResponse, this));
     mAddressSolicitPending = true;
 
-    LogMleMessage("Send Address Solicit", messageInfo.GetPeerAddr());
+    Log("Send Address Solicit", messageInfo.GetPeerAddr());
 
 exit:
 
@@ -3686,19 +3639,16 @@ void MleRouter::SendAddressRelease(void)
     messageInfo.SetPeerPort(kCoapUdpPort);
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, messageInfo));
 
-    LogMleMessage("Send Address Release", messageInfo.GetPeerAddr());
+    Log("Send Address Release", messageInfo.GetPeerAddr());
 
 exit:
 
-    if (error != OT_ERROR_NONE)
+    if ((error != OT_ERROR_NONE) && (message != nullptr))
     {
-        otLogWarnMle("Failed to send Address Release: %s", otThreadErrorToString(error));
-
-        if (message != nullptr)
-        {
-            message->Free();
-        }
+        message->Free();
     }
+
+    LogSendError("Address Release", error);
 }
 
 void MleRouter::HandleAddressSolicitResponse(void *               aContext,
@@ -3729,7 +3679,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
 
     VerifyOrExit(aMessage->GetCode() == OT_COAP_CODE_CHANGED, OT_NOOP);
 
-    LogMleMessage("Receive Address Reply", aMessageInfo->GetPeerAddr());
+    Log("Receive Address Reply", aMessageInfo->GetPeerAddr());
 
     SuccessOrExit(Tlv::FindUint8Tlv(*aMessage, ThreadTlv::kStatus, status));
 
@@ -3828,7 +3778,7 @@ void MleRouter::HandleAddressSolicit(Coap::Message &aMessage, const Ip6::Message
 
     VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, error = OT_ERROR_PARSE);
 
-    LogMleMessage("Receive Address Solicit", aMessageInfo.GetPeerAddr());
+    Log("Receive Address Solicit", aMessageInfo.GetPeerAddr());
 
     SuccessOrExit(error = ThreadTlv::FindTlv(aMessage, ThreadTlv::kExtMacAddress, &extAddress, sizeof(extAddress)));
 
@@ -3932,7 +3882,7 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Message &   aRequest,
 
     SuccessOrExit(error = Get<Coap::Coap>().SendMessage(*message, aMessageInfo));
 
-    LogMleMessage("Send Address Reply", aMessageInfo.GetPeerAddr());
+    Log("Send Address Reply", aMessageInfo.GetPeerAddr());
 
 exit:
 
@@ -3957,7 +3907,7 @@ void MleRouter::HandleAddressRelease(Coap::Message &aMessage, const Ip6::Message
 
     VerifyOrExit(aMessage.IsConfirmable() && aMessage.GetCode() == OT_COAP_CODE_POST, OT_NOOP);
 
-    LogMleMessage("Receive Address Release", aMessageInfo.GetPeerAddr());
+    Log("Receive Address Release", aMessageInfo.GetPeerAddr());
 
     SuccessOrExit(Tlv::FindUint16Tlv(aMessage, ThreadTlv::kRloc16, rloc16));
 
@@ -3972,7 +3922,7 @@ void MleRouter::HandleAddressRelease(Coap::Message &aMessage, const Ip6::Message
 
     SuccessOrExit(Get<Coap::Coap>().SendEmptyAck(aMessage, aMessageInfo));
 
-    LogMleMessage("Send Address Release Reply", aMessageInfo.GetPeerAddr());
+    Log("Send Address Release Reply", aMessageInfo.GetPeerAddr());
 
 exit:
     return;
@@ -4461,7 +4411,7 @@ exit:
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 void MleRouter::HandleTimeSync(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, const Neighbor *aNeighbor)
 {
-    LogMleMessage("Receive Time Sync", aMessageInfo.GetPeerAddr());
+    Log("Receive Time Sync", aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), OT_NOOP);
 
@@ -4485,7 +4435,7 @@ otError MleRouter::SendTimeSync(void)
     destination.SetToLinkLocalAllNodesMulticast();
     SuccessOrExit(error = SendMessage(*message, destination));
 
-    LogMleMessage("Send Time Sync", destination);
+    Log("Send Time Sync", destination);
 
 exit:
 


### PR DESCRIPTION
This commit simplifies the logging in `Mle` modules. It renames and
simplifies the existing MLE logging methods. They are now defined as
`static` methods and the main implementation uses `#if` guards
checking the proper log level (when logs are not enabled they are
defined as empty inline methods).

This commit also adds new helper methods to log failure of sending or
processing of an MLE message, namely `Mle::LogSendError()` and
`Mle::LogProcessError()`. These are then used to simplify logging in
many methods in `Mle` and other related modules.