### PR TITLE
[github-actions] fix POSIX workflow coverage uploading

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -65,6 +65,18 @@ jobs:
     - name: Run
       run: |
         VERBOSE=1 OT_CLI_PATH="$(pwd)/$(ls output/posix/*/bin/ot-cli) -v" RADIO_DEVICE="$(pwd)/$(ls output/*/bin/ot-rcp)" make -f src/posix/Makefile-posix check
+    - name: Keep Simulation Only
+      run: |
+        tar -cf build/posix.tar -C build/ posix/
+        rm -rf build/posix/
+    - name: Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: true
+    - name: Keep POSIX Only
+      run: |
+        rm -rf build/x86_64-unknown-linux-gnu/
+        tar -xf build/posix.tar -C build/
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:
@@ -118,6 +130,18 @@ jobs:
     - name: Run
       run: |
         script/check-ncp-rcp-migrate check
+    - name: Keep Simulation Only
+      run: |
+        tar -cf build/posix.tar -C build/ posix/
+        rm -rf build/posix/
+    - name: Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: true
+    - name: Keep POSIX Only
+      run: |
+        rm -rf build/x86_64-unknown-linux-gnu/
+        tar -xf build/posix.tar -C build/
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:
@@ -148,6 +172,18 @@ jobs:
     - name: Run
       run: |
         script/check-posix-pty check
+    - name: Keep Simulation Only
+      run: |
+        tar -cf build/posix.tar -C build/ posix/
+        rm -rf build/posix/
+    - name: Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: true
+    - name: Keep POSIX Only
+      run: |
+        rm -rf build/x86_64-unknown-linux-gnu/
+        tar -xf build/posix.tar -C build/
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:
@@ -179,6 +215,18 @@ jobs:
     - name: Run
       run: |
         script/check-posix-pty check
+    - name: Keep Simulation Only
+      run: |
+        tar -cf build/posix.tar -C build/ posix/
+        rm -rf build/posix/
+    - name: Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: true
+    - name: Keep POSIX Only
+      run: |
+        rm -rf build/x86_64-unknown-linux-gnu/
+        tar -xf build/posix.tar -C build/
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -108,6 +108,18 @@ jobs:
     - name: Run
       run: |
         VERBOSE=1 OT_NCP_PATH="$(pwd)/$(ls output/posix/*/bin/ot-ncp)" RADIO_DEVICE="$(pwd)/$(ls output/*/bin/ot-rcp)" make -f src/posix/Makefile-posix check
+    - name: Keep Simulation Only
+      run: |
+        tar -cf build/posix.tar -C build/ posix/
+        rm -rf build/posix/
+    - name: Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        fail_ci_if_error: true
+    - name: Keep POSIX Only
+      run: |
+        rm -rf build/x86_64-unknown-linux-gnu/
+        tar -xf build/posix.tar -C build/
     - name: Codecov
       uses: codecov/codecov-action@v1
       with:


### PR DESCRIPTION
This Applies the same strategy of #5375 to the `POSIX` workflow. Uploads data for one build at a time.