### PR TITLE
[style] fix include directives

### DIFF
--- a/src/core/api/channel_manager_api.cpp
+++ b/src/core/api/channel_manager_api.cpp
@@ -32,7 +32,7 @@
  */
 
 #include "openthread-core-config.h"
-#include "openthread/channel_manager.h"
+#include <openthread/channel_manager.h>
 
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"

--- a/src/core/api/channel_monitor_api.cpp
+++ b/src/core/api/channel_monitor_api.cpp
@@ -32,7 +32,7 @@
  */
 
 #include "openthread-core-config.h"
-#include "openthread/channel_monitor.h"
+#include <openthread/channel_monitor.h>
 
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"

--- a/src/core/api/child_supervision_api.cpp
+++ b/src/core/api/child_supervision_api.cpp
@@ -32,7 +32,7 @@
  */
 
 #include "openthread-core-config.h"
-#include "openthread/child_supervision.h"
+#include <openthread/child_supervision.h>
 
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"

--- a/src/core/api/entropy_api.cpp
+++ b/src/core/api/entropy_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread entropy source management API.
  */
 
-#include "openthread/entropy.h"
+#include <openthread/entropy.h>
 
 #include "common/random_manager.hpp"
 

--- a/src/core/api/network_time_api.cpp
+++ b/src/core/api/network_time_api.cpp
@@ -35,7 +35,7 @@
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
-#include "openthread/network_time.h"
+#include <openthread/network_time.h>
 
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"

--- a/src/core/api/random_crypto_api.cpp
+++ b/src/core/api/random_crypto_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread cryptographic random number generator API.
  */
 
-#include "openthread/random_crypto.h"
+#include <openthread/random_crypto.h>
 
 #include <mbedtls/ctr_drbg.h>
 

--- a/src/core/api/random_noncrypto_api.cpp
+++ b/src/core/api/random_noncrypto_api.cpp
@@ -31,7 +31,7 @@
  *   This file implements the OpenThread software random number generator API.
  */
 
-#include "openthread/random_noncrypto.h"
+#include <openthread/random_noncrypto.h>
 
 #include "common/random.hpp"
 

--- a/src/posix/console_cli.cpp
+++ b/src/posix/console_cli.cpp
@@ -28,7 +28,7 @@
 
 #include "console_cli.h"
 
-#include "openthread/config.h"
+#include <openthread/config.h>
 
 #include <assert.h>
 #include <stdio.h>


### PR DESCRIPTION
This PR fixes some public include directives that uses `#include "xxx.h"`. It should be `#include <xxx.h>` for public headers.