### PR TITLE
[mle] declare 'Header' as a private nested type of 'Mle'

### DIFF
--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -107,7 +107,7 @@ otError DiscoverScanner::Discover(const Mac::ChannelMask &aScanChannels,
     VerifyOrExit((message = Get<Mle>().NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
     message->SetSubType(Message::kSubTypeMleDiscoverRequest);
     message->SetPanId(aPanId);
-    SuccessOrExit(error = Get<Mle>().AppendHeader(*message, Header::kCommandDiscoveryRequest));
+    SuccessOrExit(error = Get<Mle>().AppendHeader(*message, Mle::kCommandDiscoveryRequest));
 
     // Prepare sub-TLV MeshCoP Discovery Request.
     discoveryRequest.Init();

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -988,14 +988,14 @@ exit:
     return message;
 }
 
-otError Mle::AppendHeader(Message &aMessage, Header::Command aCommand)
+otError Mle::AppendHeader(Message &aMessage, Command aCommand)
 {
     otError error = OT_ERROR_NONE;
     Header  header;
 
     header.Init();
 
-    if (aCommand == Header::kCommandDiscoveryRequest || aCommand == Header::kCommandDiscoveryResponse)
+    if (aCommand == kCommandDiscoveryRequest || aCommand == kCommandDiscoveryResponse)
     {
         header.SetSecuritySuite(Header::kNoSecurity);
     }
@@ -1923,7 +1923,7 @@ otError Mle::SendParentRequest(ParentRequestType aType)
     }
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandParentRequest));
+    SuccessOrExit(error = AppendHeader(*message, kCommandParentRequest));
     SuccessOrExit(error = AppendMode(*message, mDeviceMode));
     SuccessOrExit(error = AppendChallenge(*message, mParentRequestChallenge));
     SuccessOrExit(error = AppendScanMask(*message, scanMask));
@@ -1993,7 +1993,7 @@ otError Mle::SendChildIdRequest(void)
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
     message->SetSubType(Message::kSubTypeMleChildIdRequest);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildIdRequest));
+    SuccessOrExit(error = AppendHeader(*message, kCommandChildIdRequest));
     SuccessOrExit(error = AppendResponse(*message, mParentCandidateChallenge));
     SuccessOrExit(error = AppendLinkFrameCounter(*message));
     SuccessOrExit(error = AppendMleFrameCounter(*message));
@@ -2052,7 +2052,7 @@ otError Mle::SendDataRequest(const Ip6::Address &aDestination,
     Message *message;
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandDataRequest));
+    SuccessOrExit(error = AppendHeader(*message, kCommandDataRequest));
     SuccessOrExit(error = AppendTlvRequest(*message, aTlvs, aTlvsLength));
     SuccessOrExit(error = AppendActiveTimestamp(*message));
     SuccessOrExit(error = AppendPendingTimestamp(*message));
@@ -2231,7 +2231,7 @@ otError Mle::SendChildUpdateRequest(void)
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
     message->SetSubType(Message::kSubTypeMleChildUpdateRequest);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildUpdateRequest));
+    SuccessOrExit(error = AppendHeader(*message, kCommandChildUpdateRequest));
     SuccessOrExit(error = AppendMode(*message, mDeviceMode));
 
     switch (mRole)
@@ -2304,7 +2304,7 @@ otError Mle::SendChildUpdateResponse(const uint8_t *aTlvs, uint8_t aNumTlvs, con
     bool         checkAddress = false;
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildUpdateResponse));
+    SuccessOrExit(error = AppendHeader(*message, kCommandChildUpdateResponse));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
 
@@ -2389,7 +2389,7 @@ void Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Addres
     message->SetLinkSecurityEnabled(true);
     message->SetSubType(Message::kSubTypeMleAnnounce);
     message->SetChannel(aChannel);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandAnnounce));
+    SuccessOrExit(error = AppendHeader(*message, kCommandAnnounce));
 
     channel.Init();
     channel.SetChannel(Get<Mac::Mac>().GetPanChannel());
@@ -2558,12 +2558,12 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
         switch (header.GetCommand())
         {
 #if OPENTHREAD_FTD
-        case Header::kCommandDiscoveryRequest:
+        case kCommandDiscoveryRequest:
             Get<MleRouter>().HandleDiscoveryRequest(aMessage, aMessageInfo);
             break;
 #endif
 
-        case Header::kCommandDiscoveryResponse:
+        case kCommandDiscoveryResponse:
             Get<DiscoverScanner>().HandleDiscoveryResponse(aMessage, aMessageInfo);
             break;
 
@@ -2635,8 +2635,8 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     aMessage.Read(aMessage.GetOffset(), sizeof(command), &command);
     aMessage.MoveOffset(sizeof(command));
 
-    neighbor = (command == Header::kCommandChildIdResponse) ? mNeighborTable.FindParent(extAddr)
-                                                            : mNeighborTable.FindNeighbor(extAddr);
+    neighbor = (command == kCommandChildIdResponse) ? mNeighborTable.FindParent(extAddr)
+                                                    : mNeighborTable.FindNeighbor(extAddr);
 
     if (neighbor != nullptr && neighbor->IsStateValid())
     {
@@ -2656,27 +2656,27 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 
     switch (command)
     {
-    case Header::kCommandAdvertisement:
+    case kCommandAdvertisement:
         HandleAdvertisement(aMessage, aMessageInfo, neighbor);
         break;
 
-    case Header::kCommandDataResponse:
+    case kCommandDataResponse:
         HandleDataResponse(aMessage, aMessageInfo, neighbor);
         break;
 
-    case Header::kCommandParentResponse:
+    case kCommandParentResponse:
         HandleParentResponse(aMessage, aMessageInfo, keySequence);
         break;
 
-    case Header::kCommandChildIdResponse:
+    case kCommandChildIdResponse:
         HandleChildIdResponse(aMessage, aMessageInfo, neighbor);
         break;
 
-    case Header::kCommandAnnounce:
+    case kCommandAnnounce:
         HandleAnnounce(aMessage, aMessageInfo);
         break;
 
-    case Header::kCommandChildUpdateRequest:
+    case kCommandChildUpdateRequest:
 #if OPENTHREAD_FTD
         if (IsRouterOrLeader())
         {
@@ -2690,7 +2690,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 
         break;
 
-    case Header::kCommandChildUpdateResponse:
+    case kCommandChildUpdateResponse:
 #if OPENTHREAD_FTD
         if (IsRouterOrLeader())
         {
@@ -2705,32 +2705,32 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
         break;
 
 #if OPENTHREAD_FTD
-    case Header::kCommandLinkRequest:
+    case kCommandLinkRequest:
         Get<MleRouter>().HandleLinkRequest(aMessage, aMessageInfo, neighbor);
         break;
 
-    case Header::kCommandLinkAccept:
+    case kCommandLinkAccept:
         Get<MleRouter>().HandleLinkAccept(aMessage, aMessageInfo, keySequence, neighbor);
         break;
 
-    case Header::kCommandLinkAcceptAndRequest:
+    case kCommandLinkAcceptAndRequest:
         Get<MleRouter>().HandleLinkAcceptAndRequest(aMessage, aMessageInfo, keySequence, neighbor);
         break;
 
-    case Header::kCommandDataRequest:
+    case kCommandDataRequest:
         Get<MleRouter>().HandleDataRequest(aMessage, aMessageInfo, neighbor);
         break;
 
-    case Header::kCommandParentRequest:
+    case kCommandParentRequest:
         Get<MleRouter>().HandleParentRequest(aMessage, aMessageInfo);
         break;
 
-    case Header::kCommandChildIdRequest:
+    case kCommandChildIdRequest:
         Get<MleRouter>().HandleChildIdRequest(aMessage, aMessageInfo, keySequence);
         break;
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    case Header::kCommandTimeSync:
+    case kCommandTimeSync:
         Get<MleRouter>().HandleTimeSync(aMessage, aMessageInfo, neighbor);
         break;
 #endif

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -85,224 +85,6 @@ namespace Mle {
  */
 
 /**
- * This class implements MLE Header generation and parsing.
- *
- */
-OT_TOOL_PACKED_BEGIN
-class Header
-{
-public:
-    /**
-     * MLE Command Types.
-     *
-     */
-    enum Command
-    {
-        kCommandLinkRequest          = 0,  ///< Link Request
-        kCommandLinkAccept           = 1,  ///< Link Accept
-        kCommandLinkAcceptAndRequest = 2,  ///< Link Accept and Reject
-        kCommandLinkReject           = 3,  ///< Link Reject
-        kCommandAdvertisement        = 4,  ///< Advertisement
-        kCommandUpdate               = 5,  ///< Update
-        kCommandUpdateRequest        = 6,  ///< Update Request
-        kCommandDataRequest          = 7,  ///< Data Request
-        kCommandDataResponse         = 8,  ///< Data Response
-        kCommandParentRequest        = 9,  ///< Parent Request
-        kCommandParentResponse       = 10, ///< Parent Response
-        kCommandChildIdRequest       = 11, ///< Child ID Request
-        kCommandChildIdResponse      = 12, ///< Child ID Response
-        kCommandChildUpdateRequest   = 13, ///< Child Update Request
-        kCommandChildUpdateResponse  = 14, ///< Child Update Response
-        kCommandAnnounce             = 15, ///< Announce
-        kCommandDiscoveryRequest     = 16, ///< Discovery Request
-        kCommandDiscoveryResponse    = 17, ///< Discovery Response
-        kCommandTimeSync             = 99, ///< Time Sync (applicable when OPENTHREAD_CONFIG_TIME_SYNC_ENABLE enabled)
-    };
-
-    /**
-     * MLE Security Suite
-     *
-     */
-    enum SecuritySuite
-    {
-        k154Security = 0,   ///< IEEE 802.15.4-2006 security.
-        kNoSecurity  = 255, ///< No security enabled.
-    };
-
-    /**
-     * This method initializes the MLE header.
-     *
-     */
-    void Init(void)
-    {
-        mSecuritySuite   = k154Security;
-        mSecurityControl = Mac::Frame::kSecEncMic32;
-    }
-
-    /**
-     * This method indicates whether or not the TLV appears to be well-formed.
-     *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     *
-     */
-    bool IsValid(void) const
-    {
-        return (mSecuritySuite == kNoSecurity) ||
-               (mSecuritySuite == k154Security &&
-                mSecurityControl == (Mac::Frame::kKeyIdMode2 | Mac::Frame::kSecEncMic32));
-    }
-
-    /**
-     * This method returns the MLE header and Command Type length.
-     *
-     * @returns The MLE header and Command Type length.
-     *
-     */
-    uint8_t GetLength(void) const
-    {
-        return sizeof(mSecuritySuite) + sizeof(mCommand) +
-               ((mSecuritySuite == k154Security)
-                    ? sizeof(mSecurityControl) + sizeof(mFrameCounter) + sizeof(mKeySource) + sizeof(mKeyIndex)
-                    : 0);
-    }
-
-    /**
-     * This method returns the Security Suite value.
-     *
-     * @returns The Security Suite value.
-     *
-     */
-    SecuritySuite GetSecuritySuite(void) const { return static_cast<SecuritySuite>(mSecuritySuite); }
-
-    /**
-     * This method sets the Security Suite value.
-     *
-     * @param[in]  aSecuritySuite  The Security Suite value.
-     *
-     */
-    void SetSecuritySuite(SecuritySuite aSecuritySuite) { mSecuritySuite = static_cast<uint8_t>(aSecuritySuite); }
-
-    /**
-     * This method returns the MLE header length (excluding the Command Type).
-     *
-     * @returns The MLE header length (excluding the Command Type).
-     *
-     */
-    uint8_t GetHeaderLength(void) const
-    {
-        return sizeof(mSecurityControl) + sizeof(mFrameCounter) + sizeof(mKeySource) + sizeof(mKeyIndex);
-    }
-
-    /**
-     * This method returns a pointer to first byte of the MLE header.
-     *
-     * @returns A pointer to the first byte of the MLE header.
-     *
-     */
-    const uint8_t *GetBytes(void) const { return reinterpret_cast<const uint8_t *>(&mSecuritySuite); }
-
-    /**
-     * This method returns the Security Control value.
-     *
-     * @returns The Security Control value.
-     *
-     */
-    uint8_t GetSecurityControl(void) const { return mSecurityControl; }
-
-    /**
-     * This method indicates whether or not the Key ID Mode is set to 2.
-     *
-     * @retval TRUE   If the Key ID Mode is set to 2.
-     * @retval FALSE  If the Key ID Mode is not set to 2.
-     *
-     */
-    bool IsKeyIdMode2(void) const { return (mSecurityControl & Mac::Frame::kKeyIdModeMask) == Mac::Frame::kKeyIdMode2; }
-
-    /**
-     * This method sets the Key ID Mode to 2.
-     *
-     */
-    void SetKeyIdMode2(void)
-    {
-        mSecurityControl = (mSecurityControl & ~Mac::Frame::kKeyIdModeMask) | Mac::Frame::kKeyIdMode2;
-    }
-
-    /**
-     * This method returns the Key ID value.
-     *
-     * @returns The Key ID value.
-     *
-     */
-    uint32_t GetKeyId(void) const { return Encoding::BigEndian::HostSwap32(mKeySource); }
-
-    /**
-     * This method sets the Key ID value.
-     *
-     * @param[in]  aKeySequence  The Key ID value.
-     *
-     */
-    void SetKeyId(uint32_t aKeySequence)
-    {
-        mKeySource = Encoding::BigEndian::HostSwap32(aKeySequence);
-        mKeyIndex  = (aKeySequence & 0x7f) + 1;
-    }
-
-    /**
-     * This method returns the Frame Counter value.
-     *
-     * @returns The Frame Counter value.
-     *
-     */
-    uint32_t GetFrameCounter(void) const { return Encoding::LittleEndian::HostSwap32(mFrameCounter); }
-
-    /**
-     * This method sets the Frame Counter value.
-     *
-     * @param[in]  aFrameCounter  The Frame Counter value.
-     *
-     */
-    void SetFrameCounter(uint32_t aFrameCounter) { mFrameCounter = Encoding::LittleEndian::HostSwap32(aFrameCounter); }
-
-    /**
-     * This method returns the Command Type value.
-     *
-     * @returns The Command Type value.
-     *
-     */
-    Command GetCommand(void) const
-    {
-        return static_cast<Command>((mSecuritySuite == kNoSecurity) ? mSecurityControl : mCommand);
-    }
-
-    /**
-     * This method sets the Command Type value.
-     *
-     * @param[in]  aCommand  The Command Type value.
-     *
-     */
-    void SetCommand(Command aCommand)
-    {
-        if (mSecuritySuite == kNoSecurity)
-        {
-            mSecurityControl = static_cast<uint8_t>(aCommand);
-        }
-        else
-        {
-            mCommand = static_cast<uint8_t>(aCommand);
-        }
-    }
-
-private:
-    uint8_t  mSecuritySuite;
-    uint8_t  mSecurityControl;
-    uint32_t mFrameCounter;
-    uint32_t mKeySource;
-    uint8_t  mKeyIndex;
-    uint8_t  mCommand;
-} OT_TOOL_PACKED_END;
-
-/**
  * This class implements MLE functionality required by the Thread EndDevices, Router, and Leader roles.
  *
  */
@@ -935,6 +717,33 @@ public:
 
 protected:
     /**
+     * MLE Command Types.
+     *
+     */
+    enum Command : uint8_t
+    {
+        kCommandLinkRequest          = 0,  ///< Link Request
+        kCommandLinkAccept           = 1,  ///< Link Accept
+        kCommandLinkAcceptAndRequest = 2,  ///< Link Accept and Reject
+        kCommandLinkReject           = 3,  ///< Link Reject
+        kCommandAdvertisement        = 4,  ///< Advertisement
+        kCommandUpdate               = 5,  ///< Update
+        kCommandUpdateRequest        = 6,  ///< Update Request
+        kCommandDataRequest          = 7,  ///< Data Request
+        kCommandDataResponse         = 8,  ///< Data Response
+        kCommandParentRequest        = 9,  ///< Parent Request
+        kCommandParentResponse       = 10, ///< Parent Response
+        kCommandChildIdRequest       = 11, ///< Child ID Request
+        kCommandChildIdResponse      = 12, ///< Child ID Response
+        kCommandChildUpdateRequest   = 13, ///< Child Update Request
+        kCommandChildUpdateResponse  = 14, ///< Child Update Response
+        kCommandAnnounce             = 15, ///< Announce
+        kCommandDiscoveryRequest     = 16, ///< Discovery Request
+        kCommandDiscoveryResponse    = 17, ///< Discovery Response
+        kCommandTimeSync             = 99, ///< Time Sync (applicable when OPENTHREAD_CONFIG_TIME_SYNC_ENABLE enabled)
+    };
+
+    /**
      * States during attach (when searching for a parent).
      *
      */
@@ -1065,7 +874,7 @@ protected:
      * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the header.
      *
      */
-    otError AppendHeader(Message &aMessage, Header::Command aCommand);
+    otError AppendHeader(Message &aMessage, Command aCommand);
 
     /**
      * This method appends a Source Address TLV to a message.
@@ -1685,6 +1494,98 @@ private:
         Ip6::Address mDestination; // IPv6 address of the message destination.
         TimeMilli    mSendTime;    // Time when the message shall be sent.
     };
+
+    OT_TOOL_PACKED_BEGIN
+    class Header
+    {
+    public:
+        enum SecuritySuite
+        {
+            k154Security = 0,
+            kNoSecurity  = 255,
+        };
+
+        void Init(void)
+        {
+            mSecuritySuite   = k154Security;
+            mSecurityControl = Mac::Frame::kSecEncMic32;
+        }
+
+        bool IsValid(void) const
+        {
+            return (mSecuritySuite == kNoSecurity) ||
+                   (mSecuritySuite == k154Security &&
+                    mSecurityControl == (Mac::Frame::kKeyIdMode2 | Mac::Frame::kSecEncMic32));
+        }
+
+        uint8_t GetLength(void) const
+        {
+            return sizeof(mSecuritySuite) + sizeof(mCommand) +
+                   ((mSecuritySuite == k154Security)
+                        ? sizeof(mSecurityControl) + sizeof(mFrameCounter) + sizeof(mKeySource) + sizeof(mKeyIndex)
+                        : 0);
+        }
+
+        SecuritySuite GetSecuritySuite(void) const { return static_cast<SecuritySuite>(mSecuritySuite); }
+        void SetSecuritySuite(SecuritySuite aSecuritySuite) { mSecuritySuite = static_cast<uint8_t>(aSecuritySuite); }
+
+        uint8_t GetHeaderLength(void) const
+        {
+            return sizeof(mSecurityControl) + sizeof(mFrameCounter) + sizeof(mKeySource) + sizeof(mKeyIndex);
+        }
+
+        const uint8_t *GetBytes(void) const { return reinterpret_cast<const uint8_t *>(&mSecuritySuite); }
+        uint8_t        GetSecurityControl(void) const { return mSecurityControl; }
+
+        bool IsKeyIdMode2(void) const
+        {
+            return (mSecurityControl & Mac::Frame::kKeyIdModeMask) == Mac::Frame::kKeyIdMode2;
+        }
+
+        void SetKeyIdMode2(void)
+        {
+            mSecurityControl = (mSecurityControl & ~Mac::Frame::kKeyIdModeMask) | Mac::Frame::kKeyIdMode2;
+        }
+
+        uint32_t GetKeyId(void) const { return Encoding::BigEndian::HostSwap32(mKeySource); }
+
+        void SetKeyId(uint32_t aKeySequence)
+        {
+            mKeySource = Encoding::BigEndian::HostSwap32(aKeySequence);
+            mKeyIndex  = (aKeySequence & 0x7f) + 1;
+        }
+
+        uint32_t GetFrameCounter(void) const { return Encoding::LittleEndian::HostSwap32(mFrameCounter); }
+        void     SetFrameCounter(uint32_t aFrameCounter)
+        {
+            mFrameCounter = Encoding::LittleEndian::HostSwap32(aFrameCounter);
+        }
+
+        Command GetCommand(void) const
+        {
+            return static_cast<Command>((mSecuritySuite == kNoSecurity) ? mSecurityControl : mCommand);
+        }
+
+        void SetCommand(Command aCommand)
+        {
+            if (mSecuritySuite == kNoSecurity)
+            {
+                mSecurityControl = static_cast<uint8_t>(aCommand);
+            }
+            else
+            {
+                mCommand = static_cast<uint8_t>(aCommand);
+            }
+        }
+
+    private:
+        uint8_t  mSecuritySuite;
+        uint8_t  mSecurityControl;
+        uint32_t mFrameCounter;
+        uint32_t mKeySource;
+        uint8_t  mKeyIndex;
+        uint8_t  mCommand;
+    } OT_TOOL_PACKED_END;
 
     void        HandleNotifierEvents(Events aEvents);
     static void HandleAttachTimer(Timer &aTimer);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -439,7 +439,7 @@ void MleRouter::SendAdvertisement(void)
     VerifyOrExit(!mAddressSolicitPending, OT_NOOP);
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandAdvertisement));
+    SuccessOrExit(error = AppendHeader(*message, kCommandAdvertisement));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
 
@@ -486,7 +486,7 @@ otError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
     destination.Clear();
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandLinkRequest));
+    SuccessOrExit(error = AppendHeader(*message, kCommandLinkRequest));
     SuccessOrExit(error = AppendVersion(*message));
 
     switch (mRole)
@@ -684,11 +684,10 @@ otError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo,
     otError              error        = OT_ERROR_NONE;
     static const uint8_t routerTlvs[] = {Tlv::kLinkMargin};
     Message *            message;
-    Header::Command      command;
+    Command              command;
     uint8_t              linkMargin;
 
-    command = (aNeighbor == nullptr || aNeighbor->IsStateValid()) ? Header::kCommandLinkAccept
-                                                                  : Header::kCommandLinkAcceptAndRequest;
+    command = (aNeighbor == nullptr || aNeighbor->IsStateValid()) ? kCommandLinkAccept : kCommandLinkAcceptAndRequest;
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, command));
@@ -1937,7 +1936,7 @@ void MleRouter::SendParentResponse(Child *aChild, const Challenge &aChallenge, b
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
     message->SetDirectTransmission();
 
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandParentResponse));
+    SuccessOrExit(error = AppendHeader(*message, kCommandParentResponse));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
     SuccessOrExit(error = AppendLinkFrameCounter(*message));
@@ -2931,7 +2930,7 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
     message->SetSubType(Message::kSubTypeMleDiscoverResponse);
     message->SetPanId(aPanId);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandDiscoveryResponse));
+    SuccessOrExit(error = AppendHeader(*message, kCommandDiscoveryResponse));
 
     // Discovery TLV
     tlv.SetType(Tlv::kDiscovery);
@@ -3018,7 +3017,7 @@ otError MleRouter::SendChildIdResponse(Child &aChild)
     Message *    message;
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildIdResponse));
+    SuccessOrExit(error = AppendHeader(*message, kCommandChildIdResponse));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
     SuccessOrExit(error = AppendActiveTimestamp(*message));
@@ -3138,7 +3137,7 @@ otError MleRouter::SendChildUpdateRequest(Child &aChild)
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
     message->SetSubType(Message::kSubTypeMleChildUpdateRequest);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildUpdateRequest));
+    SuccessOrExit(error = AppendHeader(*message, kCommandChildUpdateRequest));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
     SuccessOrExit(error = AppendNetworkData(*message, !aChild.IsFullNetworkData()));
@@ -3183,7 +3182,7 @@ void MleRouter::SendChildUpdateResponse(Child *                 aChild,
     Message *message;
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandChildUpdateResponse));
+    SuccessOrExit(error = AppendHeader(*message, kCommandChildUpdateResponse));
 
     for (int i = 0; i < aTlvsLength; i++)
     {
@@ -3270,7 +3269,7 @@ void MleRouter::SendDataResponse(const Ip6::Address &aDestination,
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
     message->SetSubType(Message::kSubTypeMleDataResponse);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandDataResponse));
+    SuccessOrExit(error = AppendHeader(*message, kCommandDataResponse));
     SuccessOrExit(error = AppendSourceAddress(*message));
     SuccessOrExit(error = AppendLeaderData(*message));
     SuccessOrExit(error = AppendActiveTimestamp(*message));
@@ -4428,7 +4427,7 @@ otError MleRouter::SendTimeSync(void)
     Message *    message = nullptr;
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
-    SuccessOrExit(error = AppendHeader(*message, Header::kCommandTimeSync));
+    SuccessOrExit(error = AppendHeader(*message, kCommandTimeSync));
 
     message->SetTimeSync(true);
 


### PR DESCRIPTION
This commit declares MLE `Header` as a `private` nested type of `Mle`
class. It also  moves the `Command` enumeration definition into the
`Mle` class (from `Header`).