### PR TITLE
[mle] further simplifications of logging in MLE

### DIFF
--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -154,7 +154,7 @@ otError DiscoverScanner::Discover(const Mac::ChannelMask &aScanChannels,
     mScanChannel = Mac::ChannelMask::kChannelIteratorFirst;
     mState       = (mScanChannels.GetNextChannel(mScanChannel) == OT_ERROR_NONE) ? kStateScanning : kStateScanDone;
 
-    Mle::Log("Send Discovery Request", destination);
+    Mle::Log(Mle::kMessageSend, Mle::kTypeDiscoveryRequest, destination);
 
 exit:
 
@@ -302,7 +302,7 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
     uint16_t                      end;
     bool                          didCheckSteeringData = false;
 
-    Mle::Log("Receive Discovery Response", aMessageInfo.GetPeerAddr());
+    Mle::Log(Mle::kMessageReceive, Mle::kTypeDiscoveryResponse, aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(mState == kStateScanning, error = OT_ERROR_DROP);
 
@@ -387,7 +387,7 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
     }
 
 exit:
-    Mle::LogProcessError("Discovery Response", error);
+    Mle::LogProcessError(Mle::kTypeDiscoveryResponse, error);
 }
 
 } // namespace Mle

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1854,7 +1854,7 @@ void Mle::HandleDelayedResponseTimer(void)
 
             if (SendMessage(*message, metadata.mDestination) == OT_ERROR_NONE)
             {
-                Log("Send delayed message", metadata.mDestination);
+                Log(kMessageSend, kTypeGenericDelayed, metadata.mDestination);
 
                 // Here enters fast poll mode, as for Rx-Off-when-idle device, the enqueued msg should
                 // be Mle Data Request.
@@ -1892,7 +1892,7 @@ void Mle::RemoveDelayedDataResponseMessage(void)
         {
             mDelayedResponses.Dequeue(*message);
             message->Free();
-            Log("Remove Delayed Data Response", metadata.mDestination);
+            Log(kMessageRemoveDelayed, kTypeDataResponse, metadata.mDestination);
 
             // no more than one multicast MLE Data Response in Delayed Message Queue.
             break;
@@ -1938,11 +1938,11 @@ otError Mle::SendParentRequest(ParentRequestType aType)
     switch (aType)
     {
     case kParentRequestTypeRouters:
-        Log("Send Parent Request to routers", destination);
+        Log(kMessageSend, kTypeParentRequestToRouters, destination);
         break;
 
     case kParentRequestTypeRoutersAndReeds:
-        Log("Send Parent Request to routers and REEDs", destination);
+        Log(kMessageSend, kTypeParentRequestToRoutersReeds, destination);
         break;
     }
 
@@ -2018,14 +2018,9 @@ otError Mle::SendChildIdRequest(void)
     destination.SetToLinkLocalAddress(mParentCandidate.GetExtAddress());
     SuccessOrExit(error = SendMessage(*message, destination));
 
-    if (mAddressRegistrationMode == kAppendMeshLocalOnly)
-    {
-        Log("Send Child ID Request - short", destination);
-    }
-    else
-    {
-        Log("Send Child ID Request", destination);
-    }
+    Log(kMessageSend,
+        (mAddressRegistrationMode == kAppendMeshLocalOnly) ? kTypeChildIdRequestShort : kTypeChildIdRequest,
+        destination);
 
     if (!IsRxOnWhenIdle())
     {
@@ -2060,12 +2055,12 @@ otError Mle::SendDataRequest(const Ip6::Address &aDestination,
     if (aDelay)
     {
         SuccessOrExit(error = AddDelayedResponse(*message, aDestination, aDelay));
-        Log("Delay Data Request", aDestination);
+        Log(kMessageDelay, kTypeDataRequest, aDestination);
     }
     else
     {
         SuccessOrExit(error = SendMessage(*message, aDestination));
-        Log("Send Data Request", aDestination);
+        Log(kMessageSend, kTypeDataRequest, aDestination);
 
         if (!IsRxOnWhenIdle())
         {
@@ -2270,7 +2265,7 @@ otError Mle::SendChildUpdateRequest(void)
     destination.SetToLinkLocalAddress(mParent.GetExtAddress());
     SuccessOrExit(error = SendMessage(*message, destination));
 
-    Log("Send Child Update Request to parent", destination);
+    Log(kMessageSend, kTypeChildUpdateRequestOfParent, destination);
 
     if (!IsRxOnWhenIdle())
     {
@@ -2351,7 +2346,7 @@ otError Mle::SendChildUpdateResponse(const uint8_t *aTlvs, uint8_t aNumTlvs, con
     destination.SetToLinkLocalAddress(mParent.GetExtAddress());
     SuccessOrExit(error = SendMessage(*message, destination));
 
-    Log("Send Child Update Response to parent", destination);
+    Log(kMessageSend, kTypeChildUpdateResponseOfParent, destination);
 
     if (checkAddress && HasUnregisteredAddress())
     {
@@ -2741,7 +2736,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
     }
 
 exit:
-    LogProcessError("UDP", error);
+    LogProcessError(kTypeGenericUdp, error);
 }
 
 void Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, Neighbor *aNeighbor)
@@ -2755,7 +2750,7 @@ void Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &a
     // Source Address
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
 
-    Log("Receive Advertisement", aMessageInfo.GetPeerAddr(), sourceAddress);
+    Log(kMessageReceive, kTypeAdvertisement, aMessageInfo.GetPeerAddr(), sourceAddress);
 
     // Leader Data
     SuccessOrExit(error = ReadLeaderData(aMessage, leaderData));
@@ -2824,14 +2819,14 @@ void Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &a
     }
 
 exit:
-    LogProcessError("Advertisement", error);
+    LogProcessError(kTypeAdvertisement, error);
 }
 
 void Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, const Neighbor *aNeighbor)
 {
     otError error;
 
-    Log("Receive Data Response", aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeDataResponse, aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), error = OT_ERROR_SECURITY);
 
@@ -2848,7 +2843,7 @@ void Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageInfo &aM
     }
 
 exit:
-    LogProcessError("Data Response", error);
+    LogProcessError(kTypeDataResponse, error);
 }
 
 bool Mle::IsNetworkDataNewer(const LeaderData &aLeaderData)
@@ -3114,7 +3109,7 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
     // Source Address
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
 
-    Log("Receive Parent Response", aMessageInfo.GetPeerAddr(), sourceAddress);
+    Log(kMessageReceive, kTypeParentResponse, aMessageInfo.GetPeerAddr(), sourceAddress);
 
     // Version
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kVersion, version));
@@ -3291,7 +3286,7 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
     mParentLinkMargin       = linkMargin;
 
 exit:
-    LogProcessError("Parent Response", error);
+    LogProcessError(kTypeParentResponse, error);
 }
 
 void Mle::HandleChildIdResponse(const Message &         aMessage,
@@ -3313,7 +3308,7 @@ void Mle::HandleChildIdResponse(const Message &         aMessage,
     // Source Address
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
 
-    Log("Receive Child ID Response", aMessageInfo.GetPeerAddr(), sourceAddress);
+    Log(kMessageReceive, kTypeChildIdResponse, aMessageInfo.GetPeerAddr(), sourceAddress);
 
     VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), error = OT_ERROR_SECURITY);
 
@@ -3415,7 +3410,7 @@ void Mle::HandleChildIdResponse(const Message &         aMessage,
     SetStateChild(shortAddress);
 
 exit:
-    LogProcessError("Child ID Response", error);
+    LogProcessError(kTypeChildIdResponse, error);
 }
 
 void Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, Neighbor *aNeighbor)
@@ -3432,7 +3427,7 @@ void Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageIn
     // Source Address
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
 
-    Log("Receive Child Update Request from parent", aMessageInfo.GetPeerAddr(), sourceAddress);
+    Log(kMessageReceive, kTypeChildUpdateRequestOfParent, aMessageInfo.GetPeerAddr(), sourceAddress);
 
     // Challenge
     switch (ReadChallenge(aMessage, challenge))
@@ -3502,7 +3497,7 @@ void Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageIn
     SuccessOrExit(error = SendChildUpdateResponse(tlvs, numTlvs, challenge));
 
 exit:
-    LogProcessError("Child Update Request from parent", error);
+    LogProcessError(kTypeChildUpdateRequestOfParent, error);
 }
 
 void Mle::HandleChildUpdateResponse(const Message &         aMessage,
@@ -3518,7 +3513,7 @@ void Mle::HandleChildUpdateResponse(const Message &         aMessage,
     uint16_t  sourceAddress;
     uint32_t  timeout;
 
-    Log("Receive Child Update Response from parent", aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeChildUpdateResponseOfParent, aMessageInfo.GetPeerAddr());
 
     switch (mRole)
     {
@@ -3627,7 +3622,7 @@ exit:
         }
     }
 
-    LogProcessError("Child Update Response", error);
+    LogProcessError(kTypeChildUpdateResponseOfParent, error);
 }
 
 void Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -3641,7 +3636,7 @@ void Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMessa
     uint8_t                   channel;
     uint16_t                  panId;
 
-    Log("Receive Announce", aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeAnnounce, aMessageInfo.GetPeerAddr());
 
     SuccessOrExit(error = Tlv::FindTlv(aMessage, Tlv::kChannel, sizeof(channelTlv), channelTlv));
     VerifyOrExit(channelTlv.IsValid(), error = OT_ERROR_PARSE);
@@ -3695,7 +3690,7 @@ void Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMessa
     }
 
 exit:
-    LogProcessError("Announce", error);
+    LogProcessError(kTypeAnnounce, error);
 }
 
 void Mle::ProcessAnnounce(void)
@@ -3902,34 +3897,205 @@ void Mle::UpdateParentSearchState(void)
 #endif // OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE
 
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
-void Mle::Log(const char *aLogString, const Ip6::Address &aAddress)
+void Mle::Log(MessageAction aAction, MessageType aType, const Ip6::Address &aAddress)
 {
-    otLogInfoMle("%s (%s)", aLogString, aAddress.ToString().AsCString());
+    Log(aAction, aType, aAddress, Mac::kShortAddrInvalid);
 }
 
-void Mle::Log(const char *aLogString, const Ip6::Address &aAddress, uint16_t aRloc)
+void Mle::Log(MessageAction aAction, MessageType aType, const Ip6::Address &aAddress, uint16_t aRloc)
 {
-    otLogInfoMle("%s (%s,0x%04x)", aLogString, aAddress.ToString().AsCString(), aRloc);
+    enum : uint8_t
+    {
+        kRlocStringSize = 17,
+    };
+
+    String<kRlocStringSize> rlocString;
+
+    if (aRloc != Mac::kShortAddrInvalid)
+    {
+        IgnoreError(rlocString.Set(",0x%04x", aRloc));
+    }
+
+    otLogInfoMle("%s %s%s (%s%s)", MessageActionToString(aAction), MessageTypeToString(aType),
+                 MessageTypeActionToSuffixString(aType, aAction), aAddress.ToString().AsCString(),
+                 rlocString.AsCString());
 }
 #endif
 
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
-void Mle::LogProcessError(const char *aMessageString, otError aError)
+void Mle::LogProcessError(MessageType aType, otError aError)
+{
+    LogError(kMessageReceive, aType, aError);
+}
+
+void Mle::LogSendError(MessageType aType, otError aError)
+{
+    LogError(kMessageSend, aType, aError);
+}
+
+void Mle::LogError(MessageAction aAction, MessageType aType, otError aError)
 {
     if (aError != OT_ERROR_NONE)
     {
-        otLogWarnMle("Failed to process %s: %s", aMessageString, otThreadErrorToString(aError));
+        otLogWarnMle("Failed to %s %s%s: %s", aAction == kMessageSend ? "send" : "process", MessageTypeToString(aType),
+                     MessageTypeActionToSuffixString(aType, aAction), otThreadErrorToString(aError));
     }
 }
 
-void Mle::LogSendError(const char *aMessageString, otError aError)
+const char *Mle::MessageActionToString(MessageAction aAction)
 {
-    if (aError != OT_ERROR_NONE)
+    const char *str = "Unknown";
+
+    switch (aAction)
     {
-        otLogWarnMle("Failed to send %s: %s", aMessageString, otThreadErrorToString(aError));
+    case kMessageSend:
+        str = "Send";
+        break;
+    case kMessageReceive:
+        str = "Receive";
+        break;
+    case kMessageDelay:
+        str = "Delay";
+        break;
+    case kMessageRemoveDelayed:
+        str = "Remove Delayed";
+        break;
     }
+
+    return str;
 }
+
+const char *Mle::MessageTypeToString(MessageType aType)
+{
+    const char *str = "Unknown";
+
+    switch (aType)
+    {
+    case kTypeAdvertisement:
+        str = "Advertisement";
+        break;
+    case kTypeAnnounce:
+        str = "Announce";
+        break;
+    case kTypeChildIdRequest:
+        str = "Child ID Request";
+        break;
+    case kTypeChildIdRequestShort:
+    case kTypeChildIdResponse:
+        str = "Child ID Response";
+        break;
+    case kTypeChildUpdateRequestOfParent:
+#if OPENTHREAD_FTD
+    case kTypeChildUpdateRequestOfChild:
 #endif
+        str = "Child Update Request";
+        break;
+    case kTypeChildUpdateResponseOfParent:
+#if OPENTHREAD_FTD
+    case kTypeChildUpdateResponseOfChild:
+    case kTypeChildUpdateResponseOfUnknownChild:
+#endif
+        str = "Child Update Response";
+        break;
+    case kTypeDataRequest:
+        str = "Data Request";
+        break;
+    case kTypeDataResponse:
+        str = "Data Response";
+        break;
+    case kTypeDiscoveryRequest:
+        str = "Discovery Request";
+        break;
+    case kTypeDiscoveryResponse:
+        str = "Discovery Response";
+        break;
+    case kTypeGenericDelayed:
+        str = "delayed message";
+        break;
+    case kTypeGenericUdp:
+        str = "UDP";
+        break;
+    case kTypeParentRequestToRouters:
+    case kTypeParentRequestToRoutersReeds:
+    case kTypeParentResponse:
+        str = "Parent Response";
+        break;
+#if OPENTHREAD_FTD
+    case kTypeAddressRelease:
+        str = "Address Release";
+        break;
+    case kTypeAddressReleaseReply:
+        str = "Address Release Reply";
+        break;
+    case kTypeAddressReply:
+        str = "Address Reply";
+        break;
+    case kTypeAddressSolicit:
+        str = "Address Solicit";
+        break;
+    case kTypeLinkAccept:
+        str = "Link Accept";
+        break;
+    case kTypeLinkAcceptAndRequest:
+        str = "Link Accept and Request";
+        break;
+    case kTypeLinkReject:
+        str = "Link Reject";
+        break;
+    case kTypeLinkRequest:
+        str = "Link Request";
+        break;
+    case kTypeParentRequest:
+        str = "Parent Request";
+        break;
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    case kTypeTimeSync:
+        str = "Time Sync";
+        break;
+#endif
+#endif // OPENTHREAD_FTD
+    }
+
+    return str;
+}
+
+const char *Mle::MessageTypeActionToSuffixString(MessageType aType, MessageAction aAction)
+{
+    const char *str = "";
+
+    switch (aType)
+    {
+    case kTypeChildIdRequestShort:
+        str = " - short";
+        break;
+    case kTypeChildUpdateRequestOfParent:
+    case kTypeChildUpdateResponseOfParent:
+        str = (aAction == kMessageReceive) ? " from parent" : " to parent";
+        break;
+
+    case kTypeParentRequestToRouters:
+        str = " to routers";
+        break;
+    case kTypeParentRequestToRoutersReeds:
+        str = " to routers and REEDs";
+        break;
+#if OPENTHREAD_FTD
+    case kTypeChildUpdateRequestOfChild:
+    case kTypeChildUpdateResponseOfChild:
+        str = (aAction == kMessageReceive) ? " from child" : " to child";
+        break;
+    case kTypeChildUpdateResponseOfUnknownChild:
+        str = (aAction == kMessageReceive) ? " from unknown child" : " to child";
+        break;
+#endif // OPENTHREAD_FTD
+    default:
+        break;
+    }
+
+    return str;
+}
+
+#endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
 
 const char *Mle::RoleToString(DeviceRole aRole)
 {

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -787,6 +787,59 @@ protected:
     };
 
     /**
+     * This enumeration represents the message actions used in `Log()` methods.
+     *
+     */
+    enum MessageAction : uint8_t
+    {
+        kMessageSend,
+        kMessageReceive,
+        kMessageDelay,
+        kMessageRemoveDelayed,
+    };
+
+    /**
+     * This enumeration represents message types used in `Log()` methods.
+     *
+     */
+    enum MessageType : uint8_t
+    {
+        kTypeAdvertisement,
+        kTypeAnnounce,
+        kTypeChildIdRequest,
+        kTypeChildIdRequestShort,
+        kTypeChildIdResponse,
+        kTypeChildUpdateRequestOfParent,
+        kTypeChildUpdateResponseOfParent,
+        kTypeDataRequest,
+        kTypeDataResponse,
+        kTypeDiscoveryRequest,
+        kTypeDiscoveryResponse,
+        kTypeGenericDelayed,
+        kTypeGenericUdp,
+        kTypeParentRequestToRouters,
+        kTypeParentRequestToRoutersReeds,
+        kTypeParentResponse,
+#if OPENTHREAD_FTD
+        kTypeAddressRelease,
+        kTypeAddressReleaseReply,
+        kTypeAddressReply,
+        kTypeAddressSolicit,
+        kTypeChildUpdateRequestOfChild,
+        kTypeChildUpdateResponseOfChild,
+        kTypeChildUpdateResponseOfUnknownChild,
+        kTypeLinkAccept,
+        kTypeLinkAcceptAndRequest,
+        kTypeLinkReject,
+        kTypeLinkRequest,
+        kTypeParentRequest,
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+        kTypeTimeSync,
+#endif
+#endif
+    };
+
+    /**
      * This type represents a Challenge (or Response) data.
      *
      */
@@ -1330,53 +1383,55 @@ protected:
     /**
      * This static method emits a log message with an IPv6 address.
      *
-     * @param[in]  aLogString  The log message string.
+     * @param[in]  aAction     The message action (send/receive/delay, etc).
+     * @param[in]  aType       The message type.
      * @param[in]  aAddress    The IPv6 address of the peer.
      *
      */
-    static void Log(const char *aLogString, const Ip6::Address &aAddress);
+    static void Log(MessageAction aAction, MessageType aType, const Ip6::Address &aAddress);
 
     /**
      * This static method emits a log message with an IPv6 address and RLOC16.
      *
-     * @param[in]  aLogString  The log message string.
+     * @param[in]  aAction     The message action (send/receive/delay, etc).
+     * @param[in]  aType       The message type.
      * @param[in]  aAddress    The IPv6 address of the peer.
      * @param[in]  aRloc       The RLOC16.
      *
      */
-    static void Log(const char *aLogString, const Ip6::Address &aAddress, uint16_t aRloc);
+    static void Log(MessageAction aAction, MessageType aType, const Ip6::Address &aAddress, uint16_t aRloc);
 #else
-    static void Log(const char *, const Ip6::Address &) {}
-    static void Log(const char *, const Ip6::Address &, uint16_t) {}
+    static void Log(MessageAction, MessageType, const Ip6::Address &) {}
+    static void Log(MessageAction, MessageType, const Ip6::Address &, uint16_t) {}
 #endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
 
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
     /**
-     * This static method emits a log message indicating an error in processing of an MLE message.
+     * This static method emits a log message indicating an error in processing of a message.
      *
      * Note that log message is emitted only if there is an error, i.e., @p aError is not `OT_ERROR_NONE`. The log
      * message will have the format "Failed to process {aMessageString} : {ErrorString}".
      *
-     * @param[in]  aMessageString    A string representing the MLE message type.
-     * @param[in]  aError            The error in processing the MLE message.
+     * @param[in]  aType      The message type.
+     * @param[in]  aError     The error in processing of the message.
      *
      */
-    static void LogProcessError(const char *aMessageString, otError aError);
+    static void LogProcessError(MessageType aType, otError aError);
 
     /**
-     * This static method emits a log message indicating an error when sending an MLE message.
+     * This static method emits a log message indicating an error when sending a message.
      *
      * Note that log message is emitted only if there is an error, i.e. @p aError is not `OT_ERROR_NONE`. The log
-     * message will have the format "Failed to send {aMessageString} : {ErrorString}".
+     * message will have the format "Failed to send {Message Type} : {ErrorString}".
      *
-     * @param[in]  aMessageString    A string representing the MLE message type.
-     * @param[in]  aError            The error in sending the MLE message.
+     * @param[in]  aType    The message type.
+     * @param[in]  aError   The error in sending the message.
      *
      */
-    static void LogSendError(const char *aMessageString, otError aError);
+    static void LogSendError(MessageType aType, otError aError);
 #else
-    static void LogProcessError(const char *, otError) {}
-    static void LogSendError(const char *, otError) {}
+    static void LogProcessError(MessageType, otError) {}
+    static void LogSendError(MessageType, otError) {}
 #endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
 
     /**
@@ -1646,6 +1701,13 @@ private:
     void        HandleParentSearchTimer(void);
     void        StartParentSearchTimer(void);
     void        UpdateParentSearchState(void);
+#endif
+
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
+    static void        LogError(MessageAction aAction, MessageType aType, otError aError);
+    static const char *MessageActionToString(MessageAction aAction);
+    static const char *MessageTypeToString(MessageType aType);
+    static const char *MessageTypeActionToSuffixString(MessageType aType, MessageAction aAction);
 #endif
 
     MessageQueue mDelayedResponses;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -462,7 +462,7 @@ void MleRouter::SendAdvertisement(void)
     destination.SetToLinkLocalAllNodesMulticast();
     SuccessOrExit(error = SendMessage(*message, destination));
 
-    Log("Send Advertisement", destination);
+    Log(kMessageSend, kTypeAdvertisement, destination);
 
 exit:
 
@@ -471,7 +471,7 @@ exit:
         message->Free();
     }
 
-    LogSendError("Advertisement", error);
+    LogSendError(kTypeAdvertisement, error);
 }
 
 otError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
@@ -552,7 +552,7 @@ otError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
 
     SuccessOrExit(error = SendMessage(*message, destination));
 
-    Log("Send Link Request", destination);
+    Log(kMessageSend, kTypeLinkRequest, destination);
 
 exit:
 
@@ -577,7 +577,7 @@ void MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInf
     TimeRequestTlv timeRequest;
 #endif
 
-    Log("Receive Link Request", aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeLinkRequest, aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(IsRouterOrLeader(), error = OT_ERROR_INVALID_STATE);
 
@@ -673,7 +673,7 @@ void MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInf
     SuccessOrExit(error = SendLinkAccept(aMessageInfo, neighbor, requestedTlvs, challenge));
 
 exit:
-    LogProcessError("Link Request", error);
+    LogProcessError(kTypeLinkRequest, error);
 }
 
 otError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo,
@@ -751,13 +751,13 @@ otError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo,
         SuccessOrExit(error = AddDelayedResponse(*message, aMessageInfo.GetPeerAddr(),
                                                  1 + Random::NonCrypto::GetUint16InRange(0, kMaxResponseDelay)));
 
-        Log("Delay Link Accept", aMessageInfo.GetPeerAddr());
+        Log(kMessageDelay, kTypeLinkAccept, aMessageInfo.GetPeerAddr());
     }
     else
     {
         SuccessOrExit(error = SendMessage(*message, aMessageInfo.GetPeerAddr()));
 
-        Log("Send Link Accept", aMessageInfo.GetPeerAddr());
+        Log(kMessageSend, kTypeLinkAccept, aMessageInfo.GetPeerAddr());
     }
 
 exit:
@@ -777,7 +777,7 @@ void MleRouter::HandleLinkAccept(const Message &         aMessage,
 {
     otError error = HandleLinkAccept(aMessage, aMessageInfo, aKeySequence, aNeighbor, false);
 
-    LogProcessError("Link Accept", error);
+    LogProcessError(kTypeLinkAccept, error);
 }
 
 void MleRouter::HandleLinkAcceptAndRequest(const Message &         aMessage,
@@ -787,7 +787,7 @@ void MleRouter::HandleLinkAcceptAndRequest(const Message &         aMessage,
 {
     otError error = HandleLinkAccept(aMessage, aMessageInfo, aKeySequence, aNeighbor, true);
 
-    LogProcessError("Link Accept and Request", error);
+    LogProcessError(kTypeLinkAcceptAndRequest, error);
 }
 
 otError MleRouter::HandleLinkAccept(const Message &         aMessage,
@@ -816,14 +816,8 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
     // Source Address
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
 
-    if (aRequest)
-    {
-        Log("Receive Link Accept and Request", aMessageInfo.GetPeerAddr(), sourceAddress);
-    }
-    else
-    {
-        Log("Receive Link Accept", aMessageInfo.GetPeerAddr(), sourceAddress);
-    }
+    Log(kMessageReceive, aRequest ? kTypeLinkAcceptAndRequest : kTypeLinkAccept, aMessageInfo.GetPeerAddr(),
+        sourceAddress);
 
     VerifyOrExit(IsActiveRouter(sourceAddress), error = OT_ERROR_PARSE);
 
@@ -1591,7 +1585,7 @@ void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageI
     TimeRequestTlv timeRequest;
 #endif
 
-    Log("Receive Parent Request", aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeParentRequest, aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(IsRouterEligible(), error = OT_ERROR_INVALID_STATE);
 
@@ -1688,7 +1682,7 @@ void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageI
     SendParentResponse(child, challenge, !ScanMaskTlv::IsEndDeviceFlagSet(scanMask));
 
 exit:
-    LogProcessError("Parent Request", error);
+    LogProcessError(kTypeParentRequest, error);
 }
 
 void MleRouter::HandleTimeTick(void)
@@ -1971,7 +1965,7 @@ void MleRouter::SendParentResponse(Child *aChild, const Challenge &aChallenge, b
 
     SuccessOrExit(error = AddDelayedResponse(*message, destination, delay));
 
-    Log("Delay Parent Response", destination);
+    Log(kMessageDelay, kTypeParentResponse, destination);
 
 exit:
 
@@ -1980,7 +1974,7 @@ exit:
         message->Free();
     }
 
-    LogSendError("Parent Response", error);
+    LogSendError(kTypeParentResponse, error);
 }
 
 uint8_t MleRouter::GetMaxChildIpAddresses(void) const
@@ -2220,7 +2214,7 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     uint8_t             numTlvs;
     uint16_t            addressRegistrationOffset = 0;
 
-    Log("Receive Child ID Request", aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeChildIdRequest, aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(IsRouterEligible(), error = OT_ERROR_INVALID_STATE);
 
@@ -2366,7 +2360,7 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     }
 
 exit:
-    LogProcessError("Child ID Request", error);
+    LogProcessError(kTypeChildIdRequest, error);
 }
 
 void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
@@ -2390,7 +2384,7 @@ void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
     uint16_t        addressRegistrationOffset = 0;
     bool            childDidChange            = false;
 
-    Log("Receive Child Update Request from child", aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeChildUpdateRequestOfChild, aMessageInfo.GetPeerAddr());
 
     // Mode
     SuccessOrExit(error = Tlv::FindUint8Tlv(aMessage, Tlv::kMode, modeBitmask));
@@ -2555,7 +2549,7 @@ void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
     SendChildUpdateResponse(child, aMessageInfo, tlvs, tlvslength, challenge);
 
 exit:
-    LogProcessError("Child Update Request from child", error);
+    LogProcessError(kTypeChildUpdateRequestOfChild, error);
 }
 
 void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
@@ -2576,7 +2570,7 @@ void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
 
     if ((aNeighbor == nullptr) || IsActiveRouter(aNeighbor->GetRloc16()))
     {
-        Log("Receive Child Update Response from unknown child", aMessageInfo.GetPeerAddr());
+        Log(kMessageReceive, kTypeChildUpdateResponseOfUnknownChild, aMessageInfo.GetPeerAddr());
         ExitNow(error = OT_ERROR_NOT_FOUND);
     }
 
@@ -2595,7 +2589,7 @@ void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
         ExitNow(error = OT_ERROR_NONE);
     }
 
-    Log("Receive Child Update Response from child", aMessageInfo.GetPeerAddr(), child->GetRloc16());
+    Log(kMessageReceive, kTypeChildUpdateResponseOfChild, aMessageInfo.GetPeerAddr(), child->GetRloc16());
 
     // Source Address
     switch (Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress))
@@ -2696,7 +2690,7 @@ void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
     child->GetLinkInfo().AddRss(aMessageInfo.GetThreadLinkInfo()->GetRss());
 
 exit:
-    LogProcessError("Child Update Response from child", error);
+    LogProcessError(kTypeChildUpdateResponseOfChild, error);
 }
 
 void MleRouter::HandleDataRequest(const Message &         aMessage,
@@ -2710,7 +2704,7 @@ void MleRouter::HandleDataRequest(const Message &         aMessage,
     uint8_t             tlvs[4];
     uint8_t             numTlvs;
 
-    Log("Receive Data Request", aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeDataRequest, aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), error = OT_ERROR_SECURITY);
 
@@ -2751,7 +2745,7 @@ void MleRouter::HandleDataRequest(const Message &         aMessage,
     SendDataResponse(aMessageInfo.GetPeerAddr(), tlvs, numTlvs, 0);
 
 exit:
-    LogProcessError("Data Request", error);
+    LogProcessError(kTypeDataRequest, error);
 }
 
 void MleRouter::HandleNetworkDataUpdateRouter(void)
@@ -2845,7 +2839,7 @@ void MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Messa
     uint16_t                     offset;
     uint16_t                     end;
 
-    Log("Receive Discovery Request", aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeDiscoveryRequest, aMessageInfo.GetPeerAddr());
 
     discoveryRequest.SetLength(0);
 
@@ -2914,7 +2908,7 @@ void MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Messa
     error = SendDiscoveryResponse(aMessageInfo.GetPeerAddr(), aMessage.GetPanId());
 
 exit:
-    LogProcessError("Discovery Request", error);
+    LogProcessError(kTypeDiscoveryRequest, error);
 }
 
 otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint16_t aPanId)
@@ -2997,7 +2991,7 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
 
     SuccessOrExit(error = AddDelayedResponse(*message, aDestination, delay));
 
-    Log("Delay Discovery Response", aDestination);
+    Log(kMessageDelay, kTypeDiscoveryResponse, aDestination);
 
 exit:
 
@@ -3006,7 +3000,7 @@ exit:
         message->Free();
     }
 
-    LogProcessError("Discovery Response", error);
+    LogProcessError(kTypeDiscoveryResponse, error);
     return error;
 }
 
@@ -3094,7 +3088,7 @@ otError MleRouter::SendChildIdResponse(Child &aChild)
     destination.SetToLinkLocalAddress(aChild.GetExtAddress());
     SuccessOrExit(error = SendMessage(*message, destination));
 
-    Log("Send Child ID Response", destination, aChild.GetRloc16());
+    Log(kMessageSend, kTypeChildIdResponse, destination, aChild.GetRloc16());
 
 exit:
 
@@ -3160,7 +3154,7 @@ otError MleRouter::SendChildUpdateRequest(Child &aChild)
         aChild.SetState(Child::kStateChildUpdateRequest);
     }
 
-    Log("Send Child Update Request to child", destination, aChild.GetRloc16());
+    Log(kMessageSend, kTypeChildUpdateRequestOfChild, destination, aChild.GetRloc16());
 
 exit:
 
@@ -3236,11 +3230,11 @@ void MleRouter::SendChildUpdateResponse(Child *                 aChild,
 
     if (aChild == nullptr)
     {
-        Log("Send Child Update Response to child", aMessageInfo.GetPeerAddr());
+        Log(kMessageSend, kTypeChildUpdateResponseOfChild, aMessageInfo.GetPeerAddr());
     }
     else
     {
-        Log("Send Child Update Response to child", aMessageInfo.GetPeerAddr(), aChild->GetRloc16());
+        Log(kMessageSend, kTypeChildUpdateResponseOfChild, aMessageInfo.GetPeerAddr(), aChild->GetRloc16());
     }
 
 exit:
@@ -3304,12 +3298,12 @@ void MleRouter::SendDataResponse(const Ip6::Address &aDestination,
         RemoveDelayedDataResponseMessage();
 
         SuccessOrExit(error = AddDelayedResponse(*message, aDestination, aDelay));
-        Log("Delay Data Response", aDestination);
+        Log(kMessageDelay, kTypeDataResponse, aDestination);
     }
     else
     {
         SuccessOrExit(error = SendMessage(*message, aDestination));
-        Log("Send Data Response", aDestination);
+        Log(kMessageSend, kTypeDataResponse, aDestination);
     }
 
 exit:
@@ -3319,7 +3313,7 @@ exit:
         message->Free();
     }
 
-    LogSendError("Data Response", error);
+    LogSendError(kTypeDataResponse, error);
 }
 
 bool MleRouter::IsMinimalChild(uint16_t aRloc16)
@@ -3605,7 +3599,7 @@ otError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
                                                            &MleRouter::HandleAddressSolicitResponse, this));
     mAddressSolicitPending = true;
 
-    Log("Send Address Solicit", messageInfo.GetPeerAddr());
+    Log(kMessageSend, kTypeAddressSolicit, messageInfo.GetPeerAddr());
 
 exit:
 
@@ -3638,7 +3632,7 @@ void MleRouter::SendAddressRelease(void)
     messageInfo.SetPeerPort(Tmf::kUdpPort);
     SuccessOrExit(error = Get<Tmf::TmfAgent>().SendMessage(*message, messageInfo));
 
-    Log("Send Address Release", messageInfo.GetPeerAddr());
+    Log(kMessageSend, kTypeAddressRelease, messageInfo.GetPeerAddr());
 
 exit:
 
@@ -3647,7 +3641,7 @@ exit:
         message->Free();
     }
 
-    LogSendError("Address Release", error);
+    LogSendError(kTypeAddressRelease, error);
 }
 
 void MleRouter::HandleAddressSolicitResponse(void *               aContext,
@@ -3678,7 +3672,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
 
     VerifyOrExit(aMessage->GetCode() == Coap::kCodeChanged, OT_NOOP);
 
-    Log("Receive Address Reply", aMessageInfo->GetPeerAddr());
+    Log(kMessageReceive, kTypeAddressReply, aMessageInfo->GetPeerAddr());
 
     SuccessOrExit(Tlv::FindUint8Tlv(*aMessage, ThreadTlv::kStatus, status));
 
@@ -3777,7 +3771,7 @@ void MleRouter::HandleAddressSolicit(Coap::Message &aMessage, const Ip6::Message
 
     VerifyOrExit(aMessage.IsConfirmablePostRequest(), error = OT_ERROR_PARSE);
 
-    Log("Receive Address Solicit", aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeAddressSolicit, aMessageInfo.GetPeerAddr());
 
     SuccessOrExit(error = ThreadTlv::FindTlv(aMessage, ThreadTlv::kExtMacAddress, &extAddress, sizeof(extAddress)));
 
@@ -3881,7 +3875,7 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Message &   aRequest,
 
     SuccessOrExit(error = Get<Tmf::TmfAgent>().SendMessage(*message, aMessageInfo));
 
-    Log("Send Address Reply", aMessageInfo.GetPeerAddr());
+    Log(kMessageSend, kTypeAddressReply, aMessageInfo.GetPeerAddr());
 
 exit:
 
@@ -3906,7 +3900,7 @@ void MleRouter::HandleAddressRelease(Coap::Message &aMessage, const Ip6::Message
 
     VerifyOrExit(aMessage.IsConfirmablePostRequest(), OT_NOOP);
 
-    Log("Receive Address Release", aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeAddressRelease, aMessageInfo.GetPeerAddr());
 
     SuccessOrExit(Tlv::FindUint16Tlv(aMessage, ThreadTlv::kRloc16, rloc16));
 
@@ -3921,7 +3915,7 @@ void MleRouter::HandleAddressRelease(Coap::Message &aMessage, const Ip6::Message
 
     SuccessOrExit(Get<Tmf::TmfAgent>().SendEmptyAck(aMessage, aMessageInfo));
 
-    Log("Send Address Release Reply", aMessageInfo.GetPeerAddr());
+    Log(kMessageSend, kTypeAddressReleaseReply, aMessageInfo.GetPeerAddr());
 
 exit:
     return;
@@ -4410,7 +4404,7 @@ exit:
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 void MleRouter::HandleTimeSync(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, const Neighbor *aNeighbor)
 {
-    Log("Receive Time Sync", aMessageInfo.GetPeerAddr());
+    Log(kMessageReceive, kTypeTimeSync, aMessageInfo.GetPeerAddr());
 
     VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), OT_NOOP);
 
@@ -4434,7 +4428,7 @@ otError MleRouter::SendTimeSync(void)
     destination.SetToLinkLocalAllNodesMulticast();
     SuccessOrExit(error = SendMessage(*message, destination));
 
-    Log("Send Time Sync", destination);
+    Log(kMessageSend, kTypeTimeSync, destination);
 
 exit:
 


### PR DESCRIPTION
This commit updates the logging in `Mle` modules by adding two
enumerations `MessageAction` and `MessageType` to indicate the action
(send, receive, delay, etc.) and the message type in the updated
`Log()` methods.