### PR TITLE
[low-power] remove extra csl tx after buffered message sent by indirect tx

### DIFF
--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -167,6 +167,7 @@ otError CslTxScheduler::HandleFrameRequest(Mac::TxFrame &aFrame)
 
     SuccessOrExit(error = mCallbacks.PrepareFrameForChild(aFrame, mFrameContext, *mCslTxChild));
     mCslTxMessage = mCslTxChild->GetIndirectMessage();
+    VerifyOrExit(mCslTxMessage != nullptr, error = OT_ERROR_ABORT);
 
     if (mCslTxChild->GetIndirectTxAttempts() > 0 || mCslTxChild->GetCslTxAttempts() > 0)
     {


### PR DESCRIPTION
Consider such a case:
1. The CSL transmitter has a buffered message for a CSL receiver and has scheduled that tx.
2. Before the CSL transmitter actually sends it, the receiver sends a data request.
3. The CSL transmitter immediately sends the buffered message to the receiver.
4. The scheduled time comes.

In current CSL implementation, though the buffered message has been sent through indirect tx, when the origin CSL tx time comes, it would send another 'empty frame' due to the missing of check and the implementation of `IndirectSender::PrepareFrameForChild`. This PR adds the check for this case and avoid to send the meaningless emtpy frame.