### PR TITLE
[mac-frame] handle exception case for payload index of mac cmd

### DIFF
--- a/script/test
+++ b/script/test
@@ -163,7 +163,6 @@ do_unit()
 
     if [[ ${THREAD_VERSION} == "1.2" ]]; then
         do_unit_version "1.2-bbr"
-        do_unit_version "1.1"
     fi
 }
 

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -582,10 +582,9 @@ otError Frame::GetCommandId(uint8_t &aCommandId) const
 {
     otError error = OT_ERROR_NONE;
     uint8_t index = FindPayloadIndex();
-
     VerifyOrExit(index != kInvalidIndex, error = OT_ERROR_PARSE);
 
-    aCommandId = mPsdu[index - 1];
+    aCommandId = mPsdu[IsVersion2015() ? index : (index - 1)];
 
 exit:
     return error;
@@ -598,7 +597,7 @@ otError Frame::SetCommandId(uint8_t aCommandId)
 
     VerifyOrExit(index != kInvalidIndex, error = OT_ERROR_PARSE);
 
-    mPsdu[index - 1] = aCommandId;
+    mPsdu[IsVersion2015() ? index : (index - 1)] = aCommandId;
 
 exit:
     return error;
@@ -848,7 +847,7 @@ uint8_t Frame::FindPayloadIndex(void) const
     }
 #endif // OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
 
-    if ((GetFrameControlField() & kFcfFrameTypeMask) == kFcfFrameMacCmd)
+    if (!IsVersion2015() && (GetFrameControlField() & kFcfFrameTypeMask) == kFcfFrameMacCmd)
     {
         index += kCommandIdSize;
     }


### PR DESCRIPTION
In current `Mac::Frame` implementation, when the frame is a Mac command, the `CommandId` is always not included as its **private payload**, which means we won't encrypt the `CommandId`.

According to _ieee802.15.4-2015_, 9.2.1:
> f) Secure the frame. For the frames specified in Table 9-1, the Private Payload field and Open Payload field shall be set as indicated in the table. For frames not specified in Table 9-1, the Private Payload shall be set to the MAC Payload field and Open Payload field shall be empty. The procedure shall then use the Private Payload field, the Open Payload field, the macExtendedAddress, the Frame Counter field (if TSCH is not being used), the ASN (if TSCH is being used), the SecurityLevel parameter, and the secKey element of the KeyDescriptor to produce the secured frame according to the CCM* transformation process defined in 9.3.4.

Table 9-1:
<img width="763" alt="Screen Shot 2020-09-08 at 2 38 56 PM" src="https://user-images.githubusercontent.com/12945188/92441635-2477fb80-f1e1-11ea-8099-0ed01c383a2f.png">

Mac command frame format:
<img width="835" alt="Screen Shot 2020-09-08 at 2 41 30 PM" src="https://user-images.githubusercontent.com/12945188/92441853-86d0fc00-f1e1-11ea-9ed0-59f09eb97d45.png">

As I understand, these things indicate that, in most cases the Private Payload(things we need to encrypt) shall be set to the MAC Payload field(For Mac cmd, this field includes CommandId, shown in Figure 7-17) and the Open Payload shall be empty. The only 2 exception cases are listed in Table 9-1. 

So for Mac command with version >= 2, its CommandId should be included in Private Payload and should be encrypted when necessary. For Mac command with version < 2, CommandId should be in included in Open Payload and shouldn't be encrypted.

This PR fixes this problem and adds unit tests for this.