### PR TITLE
[low-power] fix csl channel

### DIFF
--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -1019,7 +1019,8 @@ uint8_t otLinkCslGetChannel(otInstance *aInstance);
  * This function sets the CSL channel.
  *
  * @param[in]  aInstance      A pointer to an OpenThread instance.
- * @param[in]  aChannel       The CSL sample channel.
+ * @param[in]  aChannel       The CSL sample channel. Channel value should be `0` (Set CSL Channel unspecified) or
+ *                            within the valid range [11, 26];
  *
  * @retval OT_ERROR_NONE           Successfully set the CSL parameters.
  * @retval OT_ERROR_INVALID_ARGS   Invalid @p aChannel.

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -1020,7 +1020,7 @@ uint8_t otLinkCslGetChannel(otInstance *aInstance);
  *
  * @param[in]  aInstance      A pointer to an OpenThread instance.
  * @param[in]  aChannel       The CSL sample channel. Channel value should be `0` (Set CSL Channel unspecified) or
- *                            within the valid range [11, 26];
+ *                            within the range [1, 10] (if 915-MHz supported) and [11, 26] (if 2.4 GHz supported).
  *
  * @retval OT_ERROR_NONE           Successfully set the CSL parameters.
  * @retval OT_ERROR_INVALID_ARGS   Invalid @p aChannel.

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -493,8 +493,7 @@ otError otLinkCslSetChannel(otInstance *aInstance, uint8_t aChannel)
     otError   error    = OT_ERROR_NONE;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(aChannel == 0 || ((Radio::kChannelMin <= aChannel) && (aChannel <= Radio::kChannelMax)),
-                 error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(Radio::IsCslChannelValid(aChannel), error = OT_ERROR_INVALID_ARGS);
 
     instance.Get<Mac::Mac>().SetCslChannel(aChannel);
 

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -493,7 +493,8 @@ otError otLinkCslSetChannel(otInstance *aInstance, uint8_t aChannel)
     otError   error    = OT_ERROR_NONE;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    VerifyOrExit((Radio::kChannelMin <= aChannel) && (aChannel <= Radio::kChannelMax), error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aChannel == 0 || ((Radio::kChannelMin <= aChannel) && (aChannel <= Radio::kChannelMax)),
+                 error = OT_ERROR_INVALID_ARGS);
 
     instance.Get<Mac::Mac>().SetCslChannel(aChannel);
 

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -434,6 +434,13 @@ otError Mac::SetPanChannel(uint8_t aChannel)
 
     mRadioChannel = mPanChannel;
 
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+    if (!mSubMac.IsCslChannelSpecified())
+    {
+        mSubMac.SetCslChannel(mRadioChannel);
+    }
+#endif
+
     UpdateIdleMode();
 
 exit:
@@ -658,7 +665,7 @@ void Mac::UpdateIdleMode(void)
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
         if (IsCslEnabled())
         {
-            IgnoreError(mSubMac.CslSample());
+            IgnoreError(mSubMac.CslSample(mRadioChannel));
             ExitNow();
         }
 #endif
@@ -2269,6 +2276,7 @@ void Mac::SetCslChannel(uint8_t aChannel)
     VerifyOrExit(GetCslChannel() != aChannel, OT_NOOP);
 
     mSubMac.SetCslChannel(aChannel);
+    mSubMac.SetIsCslChannelSpecified(true);
 
     if (IsCslEnabled())
     {

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -434,13 +434,6 @@ otError Mac::SetPanChannel(uint8_t aChannel)
 
     mRadioChannel = mPanChannel;
 
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    if (!mSubMac.IsCslChannelSpecified())
-    {
-        mSubMac.SetCslChannel(mRadioChannel);
-    }
-#endif
-
     UpdateIdleMode();
 
 exit:

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2276,7 +2276,7 @@ void Mac::SetCslChannel(uint8_t aChannel)
     VerifyOrExit(GetCslChannel() != aChannel, OT_NOOP);
 
     mSubMac.SetCslChannel(aChannel);
-    mSubMac.SetIsCslChannelSpecified(true);
+    mSubMac.SetCslChannelSpecified(aChannel != 0 ? true : false);
 
     if (IsCslEnabled())
     {

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -694,6 +694,14 @@ public:
     void SetCslChannel(uint8_t aChannel);
 
     /**
+     * This method indicates if CSL channel has been explicitly specified by the upper layer.
+     *
+     * @returns If CSL channel has been specified.
+     *
+     */
+    bool IsCslChannelSpecified(void) const { return mSubMac.IsCslChannelSpecified(); }
+
+    /**
      * This method gets the CSL period.
      *
      * @returns CSL period in units of 10 symbols.

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -68,7 +68,8 @@ SubMac::SubMac(Instance &aInstance)
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     , mCslTimeout(OPENTHREAD_CONFIG_CSL_TIMEOUT)
     , mCslPeriod(0)
-    , mCslChannel(OPENTHREAD_CONFIG_DEFAULT_CHANNEL)
+    , mCslChannel(0)
+    , mIsCslChannelSpecified(false)
     , mCslState(kCslIdle)
     , mCslTimer(aInstance, SubMac::HandleCslTimer, this)
 #endif
@@ -211,9 +212,14 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-otError SubMac::CslSample(void)
+otError SubMac::CslSample(uint8_t aPanChannel)
 {
     otError error = OT_ERROR_NONE;
+
+    if (!IsCslChannelSpecified())
+    {
+        mCslChannel = aPanChannel;
+    }
 
     switch (mCslState)
     {

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -305,7 +305,7 @@ public:
      * started, `mState` will become `kStateCslSample`. But it could be doing `Sleep` or `Receive` at this moment
      * (depending on `mCslState`).
      *
-     * @param[in]  aPanChannel  The current phy channel used by the device. This param is passed for the case when CSL
+     * @param[in]  aPanChannel  The current phy channel used by the device. This param will only take effect when CSL
      *                          channel hasn't been explicitly specified.
      *
      * @retval OT_ERROR_NONE          Successfully entered CSL operation (sleep or receive according to CSL timer).
@@ -387,7 +387,7 @@ public:
     /**
      * This method sets the CSL channel.
      *
-     * @param[in]  aChannel  The CSL channel.
+     * @param[in]  aChannel  The CSL channel. `0` to set CSL Channel unspecified.
      *
      */
     void SetCslChannel(uint8_t aChannel);

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -404,7 +404,7 @@ public:
      * This method sets the flag representing if CSL channel has been specified.
      *
      */
-    void SetIsCslChannelSpecified(bool aIsSpecified) { mIsCslChannelSpecified = aIsSpecified; }
+    void SetCslChannelSpecified(bool aIsSpecified) { mIsCslChannelSpecified = aIsSpecified; }
 
     /**
      * This method gets the CSL period.
@@ -624,10 +624,10 @@ private:
     uint32_t  mCslTimeout;     ///< The CSL synchronized timeout in seconds.
     TimeMicro mCslSampleTime;  ///< The CSL sample time of the current period.
     uint16_t  mCslPeriod;      ///< The CSL sample period, in units of 10 symbols (160 microseconds).
-    uint8_t   mCslChannel : 7; ///< The actually CSL sample channel. If `mCslChannelIsSet` is 0, this should be equal to
-                               ///< the Pan channel of `Mac`.
+    uint8_t   mCslChannel : 7; ///< The actually CSL sample channel. If `mIsCslChannelSpecified` is 0, this should be
+                               ///< equal to the Pan channel of `Mac`.
     uint8_t
-        mIsCslChannelSpecified : 1; ///< Indicates that if CSL channel has been explicitly specified by the upper layer.
+        mIsCslChannelSpecified : 1; ///< Indicates whether or not the CSL channel was explicitly specified by the user.
 
     CslState mCslState;
 

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -398,7 +398,7 @@ public:
      * @returns If CSL channel has been specified.
      *
      */
-    bool IsCslChannelSpecified() const { return mIsCslChannelSpecified; }
+    bool IsCslChannelSpecified(void) const { return mIsCslChannelSpecified; }
 
     /**
      * This method sets the flag representing if CSL channel has been specified.
@@ -626,8 +626,8 @@ private:
     uint16_t  mCslPeriod;      ///< The CSL sample period, in units of 10 symbols (160 microseconds).
     uint8_t   mCslChannel : 7; ///< The actually CSL sample channel. If `mIsCslChannelSpecified` is 0, this should be
                                ///< equal to the Pan channel of `Mac`.
-    uint8_t
-        mIsCslChannelSpecified : 1; ///< Indicates whether or not the CSL channel was explicitly specified by the user.
+    uint8_t mIsCslChannelSpecified : 1; ///< Indicates whether or not the CSL channel was explicitly specified by
+                                        ///< the user.
 
     CslState mCslState;
 

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -305,12 +305,15 @@ public:
      * started, `mState` will become `kStateCslSample`. But it could be doing `Sleep` or `Receive` at this moment
      * (depending on `mCslState`).
      *
+     * @param[in]  aPanChannel  The current phy channel used by the device. This param is passed for the case when CSL
+     *                          channel hasn't been explicitly specified.
+     *
      * @retval OT_ERROR_NONE          Successfully entered CSL operation (sleep or receive according to CSL timer).
      * @retval OT_ERROR_BUSY          The radio was transmitting.
      * @retval OT_ERROR_INVALID_STATE The radio was disabled.
      *
      */
-    otError CslSample(void);
+    otError CslSample(uint8_t aPanChannel);
 #endif
 
     /**
@@ -388,6 +391,20 @@ public:
      *
      */
     void SetCslChannel(uint8_t aChannel);
+
+    /**
+     * This method indicates if CSL channel has been explicitly specified by the upper layer.
+     *
+     * @returns If CSL channel has been specified.
+     *
+     */
+    bool IsCslChannelSpecified() const { return mIsCslChannelSpecified; }
+
+    /**
+     * This method sets the flag representing if CSL channel has been specified.
+     *
+     */
+    void SetIsCslChannelSpecified(bool aIsSpecified) { mIsCslChannelSpecified = aIsSpecified; }
 
     /**
      * This method gets the CSL period.
@@ -604,10 +621,13 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    uint32_t  mCslTimeout;    ///< The CSL synchronized timeout in seconds.
-    TimeMicro mCslSampleTime; ///< The CSL sample time of the current period.
-    uint16_t  mCslPeriod;     ///< The CSL sample period, in units of 10 symbols (160 microseconds).
-    uint8_t   mCslChannel;    ///< The CSL sample channel.
+    uint32_t  mCslTimeout;     ///< The CSL synchronized timeout in seconds.
+    TimeMicro mCslSampleTime;  ///< The CSL sample time of the current period.
+    uint16_t  mCslPeriod;      ///< The CSL sample period, in units of 10 symbols (160 microseconds).
+    uint8_t   mCslChannel : 7; ///< The actually CSL sample channel. If `mCslChannelIsSet` is 0, this should be equal to
+                               ///< the Pan channel of `Mac`.
+    uint8_t
+        mIsCslChannelSpecified : 1; ///< Indicates that if CSL channel has been explicitly specified by the upper layer.
 
     CslState mCslState;
 

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -594,6 +594,18 @@ public:
      */
     uint32_t GetPreferredChannelMask(void) { return otPlatRadioGetPreferredChannelMask(GetInstance()); }
 
+    /**
+     * This method checks if a given channel is valid as a CSL channel.
+     *
+     * @retval true   The channel is valid.
+     * @retval false  The channel is invalid.
+     *
+     */
+    static bool IsCslChannelValid(uint8_t aCslChannel)
+    {
+        return (aCslChannel == 0) || ((kChannelMin <= aCslChannel) && (aCslChannel <= kChannelMax));
+    }
+
 private:
     otInstance *GetInstance(void) { return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance()); }
 

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -200,7 +200,8 @@ otError CslTxScheduler::HandleFrameRequest(Mac::TxFrame &aFrame)
         aFrame.SetIsARetransmission(false);
     }
 
-    aFrame.SetChannel(mCslTxChild->GetCslChannel());
+    aFrame.SetChannel(mCslTxChild->GetCslChannel() == 0 ? Get<Mac::Mac>().GetPanChannel()
+                                                        : mCslTxChild->GetCslChannel());
     aFrame.SetTxPhase(mCslTxChild->GetCslPhase());
     aFrame.SetTxPeriod(mCslTxChild->GetCslPeriod());
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1396,8 +1396,6 @@ otError Mle::AppendCslChannel(Message &aMessage)
     otError       error = OT_ERROR_NONE;
     CslChannelTlv cslChannel;
 
-    VerifyOrExit(Get<Mac::Mac>().IsCslChannelSpecified(), OT_NOOP);
-
     cslChannel.Init();
     cslChannel.SetChannelPage(0);
     cslChannel.SetChannel(Get<Mac::Mac>().GetCslChannel());

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1396,7 +1396,7 @@ otError Mle::AppendCslChannel(Message &aMessage)
     otError       error = OT_ERROR_NONE;
     CslChannelTlv cslChannel;
 
-    VerifyOrExit(Get<Mac::Mac>().GetPanChannel() != Get<Mac::Mac>().GetCslChannel(), OT_NOOP);
+    VerifyOrExit(Get<Mac::Mac>().IsCslChannelSpecified(), OT_NOOP);
 
     cslChannel.Init();
     cslChannel.SetChannelPage(0);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1396,6 +1396,12 @@ otError Mle::AppendCslChannel(Message &aMessage)
     otError       error = OT_ERROR_NONE;
     CslChannelTlv cslChannel;
 
+    // In current implementation, it's allowed to set CSL Channel unspecified again. As `0` is not valid for
+    // Channel value in CSL Channel TLV, if CSL channel is not specified, we don't append CSL Channel TLV.
+    // And on transmitter side, it would also set CSL Channel for the child to `0` if it doesn't find a CSL Channel
+    // TLV.
+    VerifyOrExit(Get<Mac::Mac>().IsCslChannelSpecified(), OT_NOOP);
+
     cslChannel.Init();
     cslChannel.SetChannelPage(0);
     cslChannel.SetChannel(Get<Mac::Mac>().GetCslChannel());

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1396,8 +1396,8 @@ otError Mle::AppendCslChannel(Message &aMessage)
     otError       error = OT_ERROR_NONE;
     CslChannelTlv cslChannel;
 
-    // In current implementation, it's allowed to set CSL Channel unspecified again. As `0` is not valid for
-    // Channel value in CSL Channel TLV, if CSL channel is not specified, we don't append CSL Channel TLV.
+    // In current implementation, it's allowed to set CSL Channel unspecified. As `0` is not valid for Channel value
+    // in CSL Channel TLV, if CSL channel is not specified, we don't append CSL Channel TLV.
     // And on transmitter side, it would also set CSL Channel for the child to `0` if it doesn't find a CSL Channel
     // TLV.
     VerifyOrExit(Get<Mac::Mac>().IsCslChannelSpecified(), OT_NOOP);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2509,10 +2509,6 @@ void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
         {
             child->SetCslChannel(static_cast<uint8_t>(cslChannel.GetChannel()));
         }
-        else if (child->GetCslChannel() == 0)
-        {
-            child->SetCslChannel(Get<Mac::Mac>().GetPanChannel());
-        }
     }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2509,6 +2509,11 @@ void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
         {
             child->SetCslChannel(static_cast<uint8_t>(cslChannel.GetChannel()));
         }
+        else
+        {
+            // Set CSL Channel unspecified.
+            child->SetCslChannel(0);
+        }
     }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
 

--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -229,6 +229,7 @@ def create_default_mle_tlvs_factories():
         mle.TlvType.PANID: mle.PanIdFactory(),
         mle.TlvType.ACTIVE_TIMESTAMP: mle.ActiveTimestampFactory(),
         mle.TlvType.PENDING_TIMESTAMP: mle.PendingTimestampFactory(),
+        mle.TlvType.CSL_CHANNEL: mle.CslChannelFactory(),
         mle.TlvType.CSL_SYNCHRONIZED_TIMEOUT: mle.CslSynchronizedTimeoutFactory(),
         mle.TlvType.ACTIVE_OPERATIONAL_DATASET: mle.ActiveOperationalDatasetFactory(),
         mle.TlvType.PENDING_OPERATIONAL_DATASET: mle.PendingOperationalDatasetFactory(),

--- a/tests/scripts/thread-cert/mle.py
+++ b/tests/scripts/thread-cert/mle.py
@@ -87,6 +87,7 @@ class TlvType(IntEnum):
     ACTIVE_OPERATIONAL_DATASET = 24
     PENDING_OPERATIONAL_DATASET = 25
     THREAD_DISCOVERY = 26
+    CSL_CHANNEL = 80
     CSL_SYNCHRONIZED_TIMEOUT = 85
     TIME_REQUEST = 252
     TIME_PARAMETER = 253
@@ -1046,6 +1047,20 @@ class ThreadDiscoveryFactory:
     def parse(self, data, message_info):
         tlvs = self._tlvs_factory.parse(data, message_info)
         return ThreadDiscovery(tlvs)
+
+
+class CslChannel:
+    # TODO: Not implemented yet
+
+    def __init__(self):
+        print("CslChannel is not implemented yet.")
+
+
+class CslChannelFactory:
+    # TODO: Not implemented yet
+
+    def parse(self, data, message_info):
+        return CslChannel()
 
 
 class CslSynchronizedTimeout:

--- a/tests/scripts/thread-cert/v1_2_test_csl_transmission.py
+++ b/tests/scripts/thread-cert/v1_2_test_csl_transmission.py
@@ -36,7 +36,9 @@ SSED_1 = 2
 
 CSL_PERIOD = 500 * 6.25  # 500ms
 CSL_TIMEOUT = 30  # 30s
-CSL_CHANNEL = 12
+CSL_CHANNEL = 13
+
+SECOND_CHANNEL = 12
 
 
 class SSED_CslTransmission(thread_cert.TestCase):
@@ -55,7 +57,6 @@ class SSED_CslTransmission(thread_cert.TestCase):
 
         self.nodes[SSED_1].set_csl_period(CSL_PERIOD)
         self.nodes[SSED_1].set_csl_timeout(CSL_TIMEOUT)
-        self.nodes[SSED_1].set_csl_channel(CSL_CHANNEL)
 
         self.nodes[SSED_1].get_csl_info()
 
@@ -68,6 +69,16 @@ class SSED_CslTransmission(thread_cert.TestCase):
         self.assertEqual(self.nodes[SSED_1].get_state(), 'child')
 
         print('SSED rloc:%s' % self.nodes[SSED_1].get_rloc())
+        self.assertTrue(self.nodes[LEADER].ping(self.nodes[SSED_1].get_rloc()))
+        self.simulator.go(5)
+
+        self.nodes[SSED_1].set_csl_channel(SECOND_CHANNEL)
+        self.nodes[LEADER].set_csl_channel(SECOND_CHANNEL)
+        self.assertTrue(self.nodes[LEADER].ping(self.nodes[SSED_1].get_rloc()))
+        self.simulator.go(5)
+
+        self.nodes[SSED_1].set_csl_channel(CSL_CHANNEL)
+        self.simulator.go(1)
         self.assertTrue(self.nodes[LEADER].ping(self.nodes[SSED_1].get_rloc()))
         self.simulator.go(5)
 


### PR DESCRIPTION
Current implementation is a different of spec regarding CSL channel:
> 3.2.6.3.2    CSL Channel
> A CSL Receiver MAY configure macCslChannelMask to indicate an additional channel distinct from phyCurrentChannel. The macCslChannelMask is relayed by a CSL Receiver SSED Child to a CSL Transmitter Parent Router via the CSL Channel TLV sent in the Child Update Request as described in Section 4.6, Child Link Communication in Chapter 4, Mesh Link Establishment. A CSL Transmitter Parent Router MUST be capable of storing as many CSL Channel values as supported CSL Receiver SSED children.
> If configured, CSL data transmission and reception using the additional channel operates as described in Section 6.12.2.6 in [IEEE802154-2015]. The CSL Channel for a Thread Interface operating as a CSL Receiver or as a CSL Transmitter is either:
>  • The value of phyCurrentChannel when macCSLChannelMask has value 0.
>  • The channel value selected by macCSLChannelMask when macCSLChannelMask is different from 0.

Basically, if `CSL Channel` is never specified, the actual CSL channel should always be the phy channel that the device is using. If `CSL Channel` hasn't been specified and radio channel changes, the actual CSL channel should also change. In current implementation, `CSL Channel` is by default a valid value(not specified by upper layer) and wouldn't change when radio channel changes even if it's never specified.

This PR fixes this issue. On CSL receiver, a bit is extracted from `mCslChannel` to be used as a flag `mIsCslChannelSpecified`. If it is `false`, `mCslChannel` would keep synchronized to the value of `mRadioChannel` in `Mac` and `Csl Channel TLV` wouldn't be appended in Child Update Request to its parent. On CSL transmitter, `CSL channel` info in `child` is allowed to be `0`. If it's `0`, the channel info in frame would be set using `Mac::GetPanChannel`. 