### PR TITLE
[coap] update/simplify CoAP Options generation/processing

### DIFF
--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -169,37 +169,49 @@ const uint8_t *otCoapMessageGetToken(const otMessage *aMessage)
 
 otError otCoapOptionIteratorInit(otCoapOptionIterator *aIterator, const otMessage *aMessage)
 {
-    return static_cast<Coap::OptionIterator *>(aIterator)->Init(static_cast<const Coap::Message *>(aMessage));
+    return static_cast<Coap::Option::Iterator *>(aIterator)->Init(*static_cast<const Coap::Message *>(aMessage));
 }
 
 const otCoapOption *otCoapOptionIteratorGetFirstOptionMatching(otCoapOptionIterator *aIterator, uint16_t aOption)
 {
-    return static_cast<Coap::OptionIterator *>(aIterator)->GetFirstOptionMatching(aOption);
+    Coap::Option::Iterator &iterator = *static_cast<Coap::Option::Iterator *>(aIterator);
+
+    IgnoreError(iterator.Init(iterator.GetMessage(), aOption));
+    return iterator.GetOption();
 }
 
 const otCoapOption *otCoapOptionIteratorGetFirstOption(otCoapOptionIterator *aIterator)
 {
-    return static_cast<Coap::OptionIterator *>(aIterator)->GetFirstOption();
+    Coap::Option::Iterator &iterator = *static_cast<Coap::Option::Iterator *>(aIterator);
+
+    IgnoreError(iterator.Init(iterator.GetMessage()));
+    return iterator.GetOption();
 }
 
 const otCoapOption *otCoapOptionIteratorGetNextOptionMatching(otCoapOptionIterator *aIterator, uint16_t aOption)
 {
-    return static_cast<Coap::OptionIterator *>(aIterator)->GetNextOptionMatching(aOption);
+    Coap::Option::Iterator &iterator = *static_cast<Coap::Option::Iterator *>(aIterator);
+
+    IgnoreError(iterator.Advance(aOption));
+    return iterator.GetOption();
 }
 
 const otCoapOption *otCoapOptionIteratorGetNextOption(otCoapOptionIterator *aIterator)
 {
-    return static_cast<Coap::OptionIterator *>(aIterator)->GetNextOption();
+    Coap::Option::Iterator &iterator = *static_cast<Coap::Option::Iterator *>(aIterator);
+
+    IgnoreError(iterator.Advance());
+    return iterator.GetOption();
 }
 
 otError otCoapOptionIteratorGetOptionUintValue(otCoapOptionIterator *aIterator, uint64_t *const aValue)
 {
-    return static_cast<Coap::OptionIterator *>(aIterator)->GetOptionValue(*aValue);
+    return static_cast<Coap::Option::Iterator *>(aIterator)->ReadOptionValue(*aValue);
 }
 
 otError otCoapOptionIteratorGetOptionValue(otCoapOptionIterator *aIterator, void *aValue)
 {
-    return static_cast<Coap::OptionIterator *>(aIterator)->GetOptionValue(aValue);
+    return static_cast<Coap::Option::Iterator *>(aIterator)->ReadOptionValue(aValue);
 }
 
 otError otCoapSendRequestWithParameters(otInstance *              aInstance,

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -66,7 +66,7 @@ using ot::Encoding::BigEndian::HostSwap16;
  *
  */
 
-class OptionIterator;
+class Option;
 
 /**
  * CoAP Type values.
@@ -159,7 +159,7 @@ enum : uint16_t
  */
 class Message : public ot::Message
 {
-    friend class OptionIterator;
+    friend class Option;
 
 public:
     enum : uint8_t
@@ -404,16 +404,14 @@ public:
      * @retval FALSE  If Tokens differ in length or value.
      *
      */
-    bool IsTokenEqual(const Message &aMessage) const
-    {
-        return ((GetTokenLength() == aMessage.GetTokenLength()) &&
-                (memcmp(GetToken(), aMessage.GetToken(), GetTokenLength()) == 0));
-    }
+    bool IsTokenEqual(const Message &aMessage) const;
 
     /**
      * This method appends a CoAP option.
      *
-     * @param[in]  aOption  The CoAP Option.
+     * @param[in] aNumber   The CoAP Option number.
+     * @param[in] aLength   The CoAP Option length.
+     * @param[in] aValue    A pointer to the CoAP Option value (@p aLength bytes are used as Option value).
      *
      * @retval OT_ERROR_NONE          Successfully appended the option.
      * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
@@ -423,8 +421,7 @@ public:
     otError AppendOption(uint16_t aNumber, uint16_t aLength, const void *aValue);
 
     /**
-     * This method appends an unsigned integer CoAP option as specified in
-     * https://tools.ietf.org/html/rfc7252#section-3.2
+     * This method appends an unsigned integer CoAP option as specified in RFC-7252 section-3.2
      *
      * @param[in]  aNumber  The CoAP Option number.
      * @param[in]  aValue   The CoAP Option unsigned integer value.
@@ -458,7 +455,7 @@ public:
      * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
      * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      */
-    otError AppendObserveOption(uint32_t aObserve);
+    otError AppendObserveOption(uint32_t aObserve) { return AppendUintOption(kOptionObserve, aObserve & kObserveMask); }
 
     /**
      * This method appends a Uri-Path option.
@@ -497,7 +494,7 @@ public:
      * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      *
      */
-    otError AppendProxyUriOption(const char *aProxyUri);
+    otError AppendProxyUriOption(const char *aProxyUri) { return AppendStringOption(kOptionProxyUri, aProxyUri); }
 
     /**
      * This method appends a Content-Format option.
@@ -509,7 +506,10 @@ public:
      * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      *
      */
-    otError AppendContentFormatOption(otCoapOptionContentFormat aContentFormat);
+    otError AppendContentFormatOption(otCoapOptionContentFormat aContentFormat)
+    {
+        return AppendUintOption(kOptionContentFormat, static_cast<uint32_t>(aContentFormat));
+    }
 
     /**
      * This method appends a Max-Age option.
@@ -520,7 +520,7 @@ public:
      * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
      * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      */
-    otError AppendMaxAgeOption(uint32_t aMaxAge);
+    otError AppendMaxAgeOption(uint32_t aMaxAge) { return AppendUintOption(kOptionMaxAge, aMaxAge); }
 
     /**
      * This method appends a single Uri-Query option.
@@ -531,7 +531,7 @@ public:
      * @retval OT_ERROR_INVALID_ARGS  The option type is not equal or greater than the last option type.
      * @retval OT_ERROR_NO_BUFS       The option length exceeds the buffer size.
      */
-    otError AppendUriQueryOption(const char *aUriQuery);
+    otError AppendUriQueryOption(const char *aUriQuery) { return AppendStringOption(kOptionUriQuery, aUriQuery); }
 
     /**
      * This method adds Payload Marker indicating beginning of the payload to the CoAP header.
@@ -788,9 +788,12 @@ private:
         kOptionLengthOffset = 0,
         kOptionLengthMask   = 0xf << kOptionLengthOffset,
 
-        kMaxOptionHeaderSize  = 5,
-        kOption1ByteExtension = 13, // Indicates a 1 byte extension (RFC 7252).
-        kOption2ByteExtension = 14, // Indicates a 2 byte extension (RFC 7252).
+        kMaxOptionHeaderSize = 5,
+
+        kOption1ByteExtension = 13, // Indicates a one-byte extension.
+        kOption2ByteExtension = 14, // Indicates a two-byte extension.
+
+        kPayloadMarker = 0xff,
 
         kHelpDataAlignment = sizeof(uint16_t), ///< Alignment of help data.
     };
@@ -811,9 +814,10 @@ private:
         kBlockNumOffset = 4,
     };
 
-    enum
+    enum : uint32_t
     {
-        kBlockNumMax = 0xFFFFF,
+        kObserveMask = 0xffffff,
+        kBlockNumMax = 0xffff,
     };
 
     /**
@@ -858,6 +862,8 @@ private:
         GetHelpData().mHeader.mVersionTypeToken &= ~kTokenLengthMask;
         GetHelpData().mHeader.mVersionTypeToken |= ((aTokenLength << kTokenLengthOffset) & kTokenLengthMask);
     }
+
+    uint8_t WriteExtendedOptionField(uint16_t aValue, uint8_t *&aBuffer);
 };
 
 /**
@@ -911,88 +917,180 @@ public:
 };
 
 /**
- * This class acts as an iterator for CoAP options.
+ * This class represents a CoAP option.
  *
  */
-class OptionIterator : public ::otCoapOptionIterator
+class Option : public otCoapOption
 {
 public:
     /**
-     * Initialize the state of the iterator to iterate over the given message.
-     *
-     * @retval  OT_ERROR_NONE   Successfully initialized
-     * @retval  OT_ERROR_PARSE  Message state is inconsistent
+     * This class represents an iterator for CoAP options.
      *
      */
-    otError Init(const Message *aMessage);
+    class Iterator : public otCoapOptionIterator
+    {
+    public:
+        /**
+         * This method initializes the iterator to iterate over CoAP Options in a CoAP message.
+         *
+         * The iterator MUST be initialized before any other methods are used, otherwise its behavior is undefined.
+         *
+         * After initialization, the iterator is either updated to point to the first option, or it is marked as done
+         * (i.e., `IsDone()` returns `true`) when there is no option or if there is a parse error.
+         *
+         * @param[in] aMessage  The CoAP message.
+         *
+         * @retval OT_ERROR_NONE   Successfully initialized. Iterator is either at the first option or done.
+         * @retval OT_ERROR_PARSE  CoAP Option header in @p aMessage is not well-formed.
+         *
+         */
+        otError Init(const Message &aMessage);
+
+        /**
+         * This method initializes the iterator to iterate over CoAP Options in a CoAP message matching a given Option
+         * Number value.
+         *
+         * The iterator MUST be initialized before any other methods are used, otherwise its behavior is undefined.
+         *
+         * After initialization, the iterator is either updated to point to the first option matching the given Option
+         * Number value, or it is marked as done (i.e., `IsDone()` returns `true`) when there is no matching option or
+         * if there is a parse error.
+         *
+         * @param[in] aMessage  The CoAP message.
+         * @param[in] aNumber   The CoAP Option Number.
+         *
+         * @retval  OT_ERROR_NONE   Successfully initialized. Iterator is either at the first matching option or done.
+         * @retval  OT_ERROR_PARSE  CoAP Option header in @p aMessage is not well-formed.
+         *
+         */
+        otError Init(const Message &aMessage, uint16_t aNumber) { return InitOrAdvance(&aMessage, aNumber); }
+
+        /**
+         * This method indicates whether or not the iterator is done (i.e., has reached the end of CoAP Option Header).
+         *
+         * @retval TRUE   Iterator is done (reached end of Option header).
+         * @retval FALSE  Iterator is not done and currently pointing to a CoAP Option.
+         *
+         */
+        bool IsDone(void) const { return mOption.mLength == kIteratorDoneLength; }
+
+        /**
+         * This method indicates whether or not there was a earlier parse error (i.e., whether the iterator is valid).
+         *
+         * After a parse errors, iterator would also be marked as done.
+         *
+         * @retval TRUE   There was an earlier parse error and the iterator is not valid.
+         * @retval FALSE  There was no earlier parse error and the iterator is valid.
+         *
+         */
+        bool HasParseErrored(void) const { return mNextOptionOffset == kNextOptionOffsetParseError; }
+
+        /**
+         * This method advances the iterator to the next CoAP Option in the header.
+         *
+         * The iterator is updated to point to the next option or marked as done when there are no more options.
+         *
+         * @retval  OT_ERROR_NONE   Successfully advanced the iterator.
+         * @retval  OT_ERROR_PARSE  CoAP Option header is not well-formed.
+         *
+         */
+        otError Advance(void);
+
+        /**
+         * This method advances the iterator to the next CoAP Option in the header matching a given Option Number value.
+         *
+         * The iterator is updated to point to the next matching option or marked as done when there are no more
+         * matching options.
+         *
+         * @param[in] aNumber   The CoAP Option Number.
+         *
+         * @retval  OT_ERROR_NONE   Successfully advanced the iterator.
+         * @retval  OT_ERROR_PARSE  CoAP Option header is not well-formed.
+         *
+         */
+        otError Advance(uint16_t aNumber) { return InitOrAdvance(nullptr, aNumber); }
+
+        /**
+         * This method gets the CoAP message associated with the iterator.
+         *
+         * @returns A reference to the CoAP message.
+         *
+         */
+        const Message &GetMessage(void) const { return *static_cast<const Message *>(mMessage); }
+
+        /**
+         * This methods gets a pointer to the current CoAP Option to which the iterator is currently pointing.
+         *
+         * @returns A pointer to the current CoAP Option, or nullptr if iterator is done (or there was an earlier
+         *          parse error).
+         *
+         */
+        const Option *GetOption(void) const { return IsDone() ? nullptr : static_cast<const Option *>(&mOption); }
+
+        /**
+         * This method reads the current Option Value into a given buffer.
+         *
+         * @param[out]  aValue   The pointer to a buffer to copy the Option Value. The buffer is assumed to be
+         *                       sufficiently large (i.e. at least `GetOption()->GetLength()` bytes).
+         *
+         * @retval OT_ERROR_NONE        Successfully read and copied the Option Value into given buffer.
+         * @retval OT_ERROR_NOT_FOUND   Iterator is done (not pointing to any option).
+         *
+         */
+        otError ReadOptionValue(void *aValue) const;
+
+        /**
+         * This method read the current Option Value which is assumed to be an unsigned integer.
+         *
+         * @param[out]  aValue          A reference to `uint64_t` to output the read Option Value.
+         *
+         * @retval OT_ERROR_NONE        Successfully read the Option value.
+         * @retval OT_ERROR_NO_BUFS     Value is too long to fit in an `uint64_t`.
+         * @retval OT_ERROR_NOT_FOUND   Iterator is done (not pointing to any option).
+         *
+         */
+        otError ReadOptionValue(uint64_t &aValue) const;
+
+        /**
+         * This method gets the offset of beginning of the CoAP message payload (after the CoAP header).
+         *
+         * This method MUST be used after the iterator is done (i.e. iterated through all options).
+         *
+         * @returns The offset of beginning of the CoAP message payload
+         *
+         */
+        uint16_t GetPayloadMessageOffset(void) const { return mNextOptionOffset; }
+
+    private:
+        enum : uint16_t
+        {
+            kIteratorDoneLength         = 0xffff, // `mOption.mLength` value to indicate iterator is done.
+            kNextOptionOffsetParseError = 0,      // Special `mNextOptionOffset` value to indicate a parse error.
+        };
+
+        void MarkAsDone(void) { mOption.mLength = kIteratorDoneLength; }
+        void MarkAsParseErrored(void) { MarkAsDone(), mNextOptionOffset = kNextOptionOffsetParseError; }
+
+        otError Read(uint16_t aLength, void *aBuffer);
+        otError ReadExtendedOptionField(uint16_t &aValue);
+        otError InitOrAdvance(const Message *aMessage, uint16_t aNumber);
+    };
 
     /**
-     * This method returns a pointer to the first option matching the given option number.
+     * This method gets the CoAP Option Number.
      *
-     * The internal option pointer is advanced until matching option is seen, if no matching
-     * option is seen, the iterator will advance to the end of the options block.
+     * @returns The CoAP Option Number.
      *
-     * @param[in]   aOption         Option number to look for.
-     *
-     * @returns A pointer to the first matching option. If no option matching @p aOption is seen, nullptr pointer is
-     *          returned.
      */
-    const otCoapOption *GetFirstOptionMatching(uint16_t aOption);
+    uint16_t GetNumber(void) const { return mNumber; }
 
     /**
-     * This method returns a pointer to the first option.
+     * This method gets the CoAP Option Length (length of Option Value in bytes).
      *
-     * @returns A pointer to the first option. If no option is present nullptr pointer is returned.
-     */
-    const otCoapOption *GetFirstOption(void);
-
-    /**
-     * This method returns a pointer to the next option matching the given option number.
-     *
-     * The internal option pointer is advanced until matching option is seen, if no matching
-     * option is seen, the iterator will advance to the end of the options block.
-     *
-     * @param[in]   aOption         Option number to look for.
-     *
-     * @returns A pointer to the next matching option (relative to current iterator position). If no option matching @p
-     *          aOption is seen, nullptr pointer is returned.
-     */
-    const otCoapOption *GetNextOptionMatching(uint16_t aOption);
-
-    /**
-     * This method returns a pointer to the next option.
-     *
-     * @returns A pointer to the next option. If no more options are present nullptr pointer is returned.
-     */
-    const otCoapOption *GetNextOption(void);
-
-    /**
-     * This function fills current option value into @p aValue.  The option is assumed to be an unsigned integer.
-     *
-     * @param[out]  aValue          Buffer to store the option value.
-     *
-     * @retval  OT_ERROR_NONE       Successfully filled value.
-     * @retval  OT_ERROR_NOT_FOUND  No more options, aIterator->mNextOptionOffset is set to offset of payload.
-     * @retval  OT_ERROR_NO_BUFS    Value is too long to fit in a uint64_t.
+     * @returns The CoAP Option Length (in bytes).
      *
      */
-    otError GetOptionValue(uint64_t &aValue) const;
-
-    /**
-     * This function fills current option value into @p aValue.
-     *
-     * @param[out]  aValue          Buffer to store the option value.  This buffer is assumed to be sufficiently large
-     *                              (see @ref otCoapOption::mLength).
-     *
-     * @retval  OT_ERROR_NONE       Successfully filled value.
-     * @retval  OT_ERROR_NOT_FOUND  No more options, mNextOptionOffset is set to offset of payload.
-     *
-     */
-    otError GetOptionValue(void *aValue) const;
-
-private:
-    void           ClearOption(void) { memset(&mOption, 0, sizeof(mOption)); }
-    const Message &GetMessage(void) const { return *static_cast<const Message *>(mMessage); }
+    uint16_t GetLength(void) const { return mLength; }
 };
 
 /**


### PR DESCRIPTION
This commit simplifies the generation/processing of CoAP Options in a
CoAP message. It adds helper methods `ReadExtendedOptionField()`,
`WriteExtendedOptionField` to decode/encode extended Option Header
fields (Option Number Delta or Option Length). It simplifies
`Option::Iterator` (using `Init()`/`Advance()` to parse and iterate
through all CoAP Options in a message). Note that the public OT
`otCoap` APIs and their behavior remain as before and unchanged.