### PR TITLE
[joiner] add 'Joiner::State' enumeration (c++ style constants)

### DIFF
--- a/src/core/api/joiner_api.cpp
+++ b/src/core/api/joiner_api.cpp
@@ -68,7 +68,7 @@ otJoinerState otJoinerGetState(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<MeshCoP::Joiner>().GetState();
+    return static_cast<otJoinerState>(instance.Get<MeshCoP::Joiner>().GetState());
 }
 
 const otExtAddress *otJoinerGetId(otInstance *aInstance)

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -50,8 +50,6 @@
 
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
 
-using ot::Encoding::BigEndian::HostSwap16;
-
 namespace ot {
 namespace MeshCoP {
 
@@ -59,7 +57,7 @@ Joiner::Joiner(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mId()
     , mDiscerner()
-    , mState(OT_JOINER_STATE_IDLE)
+    , mState(kStateIdle)
     , mCallback(nullptr)
     , mContext(nullptr)
     , mJoinerRouterIndex(0)
@@ -91,7 +89,7 @@ otError Joiner::SetDiscerner(const JoinerDiscerner &aDiscerner)
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aDiscerner.IsValid(), error = OT_ERROR_INVALID_ARGS);
-    VerifyOrExit(mState == OT_JOINER_STATE_IDLE, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mState == kStateIdle, error = OT_ERROR_INVALID_STATE);
 
     mDiscerner = aDiscerner;
     mDiscerner.GenerateJoinerId(mId);
@@ -104,7 +102,7 @@ otError Joiner::ClearDiscerner(void)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mState == OT_JOINER_STATE_IDLE, error = OT_ERROR_INVALID_STATE);
+    VerifyOrExit(mState == kStateIdle, error = OT_ERROR_INVALID_STATE);
     VerifyOrExit(!mDiscerner.IsEmpty(), OT_NOOP);
 
     mDiscerner.Clear();
@@ -114,14 +112,14 @@ exit:
     return error;
 }
 
-void Joiner::SetState(otJoinerState aState)
+void Joiner::SetState(State aState)
 {
-    otJoinerState oldState = mState;
+    State oldState = mState;
     OT_UNUSED_VARIABLE(oldState);
 
     SuccessOrExit(Get<Notifier>().Update(mState, aState, kEventJoinerStateChanged));
 
-    otLogInfoMeshCoP("JoinerState: %s -> %s", JoinerStateToString(oldState), JoinerStateToString(aState));
+    otLogInfoMeshCoP("JoinerState: %s -> %s", StateToString(oldState), StateToString(aState));
 exit:
     return;
 }
@@ -142,7 +140,7 @@ otError Joiner::Start(const char *     aPskd,
 
     otLogInfoMeshCoP("Joiner starting");
 
-    VerifyOrExit(mState == OT_JOINER_STATE_IDLE, error = OT_ERROR_BUSY);
+    VerifyOrExit(mState == kStateIdle, error = OT_ERROR_BUSY);
     VerifyOrExit(Get<ThreadNetif>().IsUp() && Get<Mle::Mle>().GetRole() == Mle::kRoleDisabled,
                  error = OT_ERROR_INVALID_STATE);
 
@@ -179,7 +177,7 @@ otError Joiner::Start(const char *     aPskd,
     mCallback = aCallback;
     mContext  = aContext;
 
-    SetState(OT_JOINER_STATE_DISCOVER);
+    SetState(kStateDiscover);
 
 exit:
     if (error != OT_ERROR_NONE)
@@ -204,25 +202,25 @@ void Joiner::Finish(otError aError)
 {
     switch (mState)
     {
-    case OT_JOINER_STATE_IDLE:
+    case kStateIdle:
         ExitNow();
 
-    case OT_JOINER_STATE_CONNECT:
-    case OT_JOINER_STATE_CONNECTED:
-    case OT_JOINER_STATE_ENTRUST:
-    case OT_JOINER_STATE_JOINED:
+    case kStateConnect:
+    case kStateConnected:
+    case kStateEntrust:
+    case kStateJoined:
         Get<Coap::CoapSecure>().Disconnect();
         IgnoreError(Get<Ip6::Filter>().RemoveUnsecurePort(kJoinerUdpPort));
         mTimer.Stop();
 
         // Fall through
 
-    case OT_JOINER_STATE_DISCOVER:
+    case kStateDiscover:
         Get<Coap::CoapSecure>().Stop();
         break;
     }
 
-    SetState(OT_JOINER_STATE_IDLE);
+    SetState(kStateIdle);
     FreeJoinerFinalizeMessage();
 
     if (mCallback)
@@ -269,14 +267,14 @@ uint8_t Joiner::CalculatePriority(int8_t aRssi, bool aSteeringDataAllowsAny)
     return static_cast<uint8_t>(priority);
 }
 
-void Joiner::HandleDiscoverResult(otActiveScanResult *aResult, void *aContext)
+void Joiner::HandleDiscoverResult(Mle::DiscoverScanner::ScanResult *aResult, void *aContext)
 {
     static_cast<Joiner *>(aContext)->HandleDiscoverResult(aResult);
 }
 
-void Joiner::HandleDiscoverResult(otActiveScanResult *aResult)
+void Joiner::HandleDiscoverResult(Mle::DiscoverScanner::ScanResult *aResult)
 {
-    VerifyOrExit(mState == OT_JOINER_STATE_DISCOVER, OT_NOOP);
+    VerifyOrExit(mState == kStateDiscover, OT_NOOP);
 
     if (aResult != nullptr)
     {
@@ -295,7 +293,7 @@ exit:
     return;
 }
 
-void Joiner::SaveDiscoveredJoinerRouter(const otActiveScanResult &aResult)
+void Joiner::SaveDiscoveredJoinerRouter(const Mle::DiscoverScanner::ScanResult &aResult)
 {
     uint8_t       priority;
     bool          doesAllowAny;
@@ -392,7 +390,7 @@ otError Joiner::Connect(JoinerRouter &aRouter)
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().Connect(sockAddr, Joiner::HandleSecureCoapClientConnect, this));
 
-    SetState(OT_JOINER_STATE_CONNECT);
+    SetState(kStateConnect);
 
 exit:
 
@@ -411,11 +409,11 @@ void Joiner::HandleSecureCoapClientConnect(bool aConnected, void *aContext)
 
 void Joiner::HandleSecureCoapClientConnect(bool aConnected)
 {
-    VerifyOrExit(mState == OT_JOINER_STATE_CONNECT, OT_NOOP);
+    VerifyOrExit(mState == kStateConnect, OT_NOOP);
 
     if (aConnected)
     {
-        SetState(OT_JOINER_STATE_CONNECTED);
+        SetState(kStateConnected);
         SendJoinerFinalize();
         mTimer.Start(kReponseTimeout);
     }
@@ -496,7 +494,7 @@ exit:
 
 void Joiner::FreeJoinerFinalizeMessage(void)
 {
-    VerifyOrExit(mState == OT_JOINER_STATE_IDLE && mFinalizeMessage != nullptr, OT_NOOP);
+    VerifyOrExit(mState == kStateIdle && mFinalizeMessage != nullptr, OT_NOOP);
 
     mFinalizeMessage->Free();
     mFinalizeMessage = nullptr;
@@ -539,13 +537,13 @@ void Joiner::HandleJoinerFinalizeResponse(Coap::Message &         aMessage,
 
     uint8_t state;
 
-    VerifyOrExit(mState == OT_JOINER_STATE_CONNECTED && aResult == OT_ERROR_NONE && aMessage.IsAck() &&
+    VerifyOrExit(mState == kStateConnected && aResult == OT_ERROR_NONE && aMessage.IsAck() &&
                      aMessage.GetCode() == Coap::kCodeChanged,
                  OT_NOOP);
 
     SuccessOrExit(Tlv::FindUint8Tlv(aMessage, Tlv::kState, state));
 
-    SetState(OT_JOINER_STATE_ENTRUST);
+    SetState(kStateEntrust);
     mTimer.Start(kReponseTimeout);
 
     otLogInfoMeshCoP("Joiner received finalize response %d", state);
@@ -570,7 +568,7 @@ void Joiner::HandleJoinerEntrust(Coap::Message &aMessage, const Ip6::MessageInfo
     otError              error;
     otOperationalDataset dataset;
 
-    VerifyOrExit(mState == OT_JOINER_STATE_ENTRUST && aMessage.IsConfirmablePostRequest(), error = OT_ERROR_DROP);
+    VerifyOrExit(mState == kStateEntrust && aMessage.IsConfirmablePostRequest(), error = OT_ERROR_DROP);
 
     otLogInfoMeshCoP("Joiner received entrust");
     otLogCertMeshCoP("[THCI] direction=recv | type=JOIN_ENT.ntf");
@@ -616,7 +614,7 @@ void Joiner::SendJoinerEntrustResponse(const Coap::Message &aRequest, const Ip6:
     responseInfo.GetSockAddr().Clear();
     SuccessOrExit(error = Get<Tmf::TmfAgent>().SendMessage(*message, responseInfo));
 
-    SetState(OT_JOINER_STATE_JOINED);
+    SetState(kStateJoined);
 
     otLogInfoMeshCoP("Joiner sent entrust response");
     otLogCertMeshCoP("[THCI] direction=send | type=JOIN_ENT.rsp");
@@ -640,18 +638,18 @@ void Joiner::HandleTimer(void)
 
     switch (mState)
     {
-    case OT_JOINER_STATE_IDLE:
-    case OT_JOINER_STATE_DISCOVER:
-    case OT_JOINER_STATE_CONNECT:
+    case kStateIdle:
+    case kStateDiscover:
+    case kStateConnect:
         OT_ASSERT(false);
         OT_UNREACHABLE_CODE(break);
 
-    case OT_JOINER_STATE_CONNECTED:
-    case OT_JOINER_STATE_ENTRUST:
+    case kStateConnected:
+    case kStateEntrust:
         error = OT_ERROR_RESPONSE_TIMEOUT;
         break;
 
-    case OT_JOINER_STATE_JOINED:
+    case kStateJoined:
         Mac::ExtAddress extAddress;
 
         extAddress.GenerateRandom();
@@ -667,28 +665,28 @@ void Joiner::HandleTimer(void)
 
 // LCOV_EXCL_START
 
-const char *Joiner::JoinerStateToString(otJoinerState aState)
+const char *Joiner::StateToString(State aState)
 {
     const char *str = "Unknown";
 
     switch (aState)
     {
-    case OT_JOINER_STATE_IDLE:
+    case kStateIdle:
         str = "Idle";
         break;
-    case OT_JOINER_STATE_DISCOVER:
+    case kStateDiscover:
         str = "Discover";
         break;
-    case OT_JOINER_STATE_CONNECT:
+    case kStateConnect:
         str = "Connecting";
         break;
-    case OT_JOINER_STATE_CONNECTED:
+    case kStateConnected:
         str = "Connected";
         break;
-    case OT_JOINER_STATE_ENTRUST:
+    case kStateEntrust:
         str = "Entrust";
         break;
-    case OT_JOINER_STATE_JOINED:
+    case kStateJoined:
         str = "Joined";
         break;
     }

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -48,6 +48,7 @@
 #include "meshcop/dtls.hpp"
 #include "meshcop/meshcop.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
+#include "thread/discover_scanner.hpp"
 
 namespace ot {
 
@@ -56,6 +57,20 @@ namespace MeshCoP {
 class Joiner : public InstanceLocator
 {
 public:
+    /**
+     * This enumeration type defines the Joiner State.
+     *
+     */
+    enum State : uint8_t
+    {
+        kStateIdle      = OT_JOINER_STATE_IDLE,
+        kStateDiscover  = OT_JOINER_STATE_DISCOVER,
+        kStateConnect   = OT_JOINER_STATE_CONNECT,
+        kStateConnected = OT_JOINER_STATE_CONNECTED,
+        kStateEntrust   = OT_JOINER_STATE_ENTRUST,
+        kStateJoined    = OT_JOINER_STATE_JOINED,
+    };
+
     /**
      * This constructor initializes the Joiner object.
      *
@@ -97,12 +112,12 @@ public:
     void Stop(void);
 
     /**
-     * This function returns the Joiner State.
+     * This method gets the Joiner State.
      *
-     * @returns The Joiner state (see `otJoinerState`).
+     * @returns The Joiner state (see `State`).
      *
      */
-    otJoinerState GetState(void) const { return mState; }
+    State GetState(void) const { return mState; }
 
     /**
      * This method retrieves the Joiner ID.
@@ -166,8 +181,8 @@ private:
         uint8_t         mPriority;
     };
 
-    static void HandleDiscoverResult(otActiveScanResult *aResult, void *aContext);
-    void        HandleDiscoverResult(otActiveScanResult *aResult);
+    static void HandleDiscoverResult(Mle::DiscoverScanner::ScanResult *aResult, void *aContext);
+    void        HandleDiscoverResult(Mle::DiscoverScanner::ScanResult *aResult);
 
     static void HandleSecureCoapClientConnect(bool aConnected, void *aContext);
     void        HandleSecureCoapClientConnect(bool aConnected);
@@ -184,11 +199,11 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
-    static const char *JoinerStateToString(otJoinerState aState);
+    static const char *StateToString(State aState);
 
-    void    SetState(otJoinerState aState);
+    void    SetState(State aState);
     void    SetIdFromIeeeEui64(void);
-    void    SaveDiscoveredJoinerRouter(const otActiveScanResult &aResult);
+    void    SaveDiscoveredJoinerRouter(const Mle::DiscoverScanner::ScanResult &aResult);
     void    TryNextJoinerRouter(otError aPrevError);
     otError Connect(JoinerRouter &aRouter);
     void    Finish(otError aError);
@@ -210,7 +225,7 @@ private:
     Mac::ExtAddress mId;
     JoinerDiscerner mDiscerner;
 
-    otJoinerState mState;
+    State mState;
 
     otJoinerCallback mCallback;
     void *           mContext;


### PR DESCRIPTION
Also changes discover scan callback to use `ScanResult` as its input
parameter type.