### PR TITLE
[scripts] fix test_router_reattach

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -771,6 +771,10 @@ class Node:
         self.send_command(cmd)
         self._expect('Done')
 
+    def get_router_downgrade_threshold(self) -> int:
+        self.send_command('routerdowngradethreshold')
+        return int(self._expect_result(r'\d+'))
+
     def prefer_router_id(self, router_id):
         cmd = 'preferrouterid %d' % router_id
         self.send_command(cmd)

--- a/tests/scripts/thread-cert/test_router_reattach.py
+++ b/tests/scripts/thread-cert/test_router_reattach.py
@@ -272,7 +272,16 @@ class test_router_reattach(thread_cert.TestCase):
             self.assertEqual(self.nodes[i].get_state(), 'router')
 
         self.nodes[2].reset()
+        self.nodes[2].set_router_selection_jitter(3)
+        self.nodes[2].set_router_upgrade_threshold(32)
+        self.nodes[2].set_router_downgrade_threshold(32)
+
         self.nodes[2].start()
+        self.assertEqual(self.nodes[2].get_router_downgrade_threshold(), 32)
+        # Verify that the node restored as Router.
+        self.simulator.go(1)
+        self.assertEqual(self.nodes[2].get_state(), 'router')
+        # Verify that the node does not downgrade after Router Selection Jitter.
         self.simulator.go(5)
         self.assertEqual(self.nodes[2].get_state(), 'router')
 


### PR DESCRIPTION
Fix `test_router_attach.py` failing by a small chance. 

**Root cause: `routerdowngradethreshold` restored back to default (23) after node reset, so the test had 5/120 chance to downgrade. We should set it back to 32 before starting it.**

This PR also enhance the test for a little bit:
- Make sure the node reattached as Router within 1 second
- Make sure the node does not downgrade after Router Selection Jitter (3s)

Fixes #5447