### PR TITLE
[cli] misc enhancements

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -366,7 +366,7 @@ exit:
     return rval;
 }
 
-void Interpreter::AppendResult(otError aError)
+void Interpreter::OutputResult(otError aError)
 {
     if (aError == OT_ERROR_NONE)
     {
@@ -493,7 +493,7 @@ void Interpreter::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
         OutputFormat("%s\r\n", mUserCommands[i].mName);
     }
 
-    AppendResult(OT_ERROR_NONE);
+    OutputResult(OT_ERROR_NONE);
 }
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
@@ -561,7 +561,7 @@ void Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[])
 
 exit:
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
@@ -749,7 +749,7 @@ void Interpreter::ProcessDomainName(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
@@ -793,7 +793,7 @@ void Interpreter::ProcessDua(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif // OPENTHREAD_CONFIG_DUA_ENABLE
 
@@ -821,7 +821,7 @@ void Interpreter::ProcessBufferInfo(uint8_t aArgsLength, char *aArgs[])
     OutputFormat("application coap: %d %d\r\n", bufferInfo.mApplicationCoapMessages,
                  bufferInfo.mApplicationCoapBuffers);
 
-    AppendResult(OT_ERROR_NONE);
+    OutputResult(OT_ERROR_NONE);
 }
 
 void Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
@@ -966,7 +966,7 @@ void Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_FTD
@@ -1075,7 +1075,7 @@ void Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
     OutputFormat("RSSI: %d\r\n", childInfo.mAverageRssi);
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessChildIp(uint8_t aArgsLength, char *aArgs[])
@@ -1136,7 +1136,7 @@ void Interpreter::ProcessChildIp(uint8_t aArgsLength, char *aArgs[])
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 exit:
 #endif
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessChildMax(uint8_t aArgsLength, char *aArgs[])
@@ -1155,7 +1155,7 @@ void Interpreter::ProcessChildMax(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif // OPENTHREAD_FTD
 
@@ -1175,7 +1175,7 @@ void Interpreter::ProcessChildTimeout(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
@@ -1184,7 +1184,7 @@ void Interpreter::ProcessCoap(uint8_t aArgsLength, char *aArgs[])
 {
     otError error;
     error = mCoap.Process(aArgsLength, aArgs);
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #endif // OPENTHREAD_CONFIG_COAP_API_ENABLE
@@ -1195,7 +1195,7 @@ void Interpreter::ProcessCoapSecure(uint8_t aArgsLength, char *aArgs[])
 {
     otError error;
     error = mCoapSecure.Process(aArgsLength, aArgs);
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #endif // OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
@@ -1251,7 +1251,7 @@ void Interpreter::ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif // OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
 
@@ -1272,7 +1272,7 @@ void Interpreter::ProcessContextIdReuseDelay(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif // OPENTHREAD_FTD
 
@@ -1363,7 +1363,7 @@ void Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
@@ -1400,7 +1400,7 @@ void Interpreter::ProcessCsl(uint8_t aArgsLength, char *argv[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
@@ -1425,7 +1425,7 @@ void Interpreter::ProcessDelayTimerMin(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif
 
@@ -1451,7 +1451,7 @@ void Interpreter::ProcessDiscover(uint8_t aArgsLength, char *aArgs[])
 exit:
     if (error != OT_ERROR_NONE)
     {
-        AppendResult(error);
+        OutputResult(error);
     }
 }
 
@@ -1506,7 +1506,7 @@ void Interpreter::ProcessDns(uint8_t aArgsLength, char *aArgs[])
 exit:
     if (error != OT_ERROR_NONE)
     {
-        AppendResult(error);
+        OutputResult(error);
     }
 }
 
@@ -1533,7 +1533,7 @@ void Interpreter::HandleDnsResponse(const char *aHostname, const Ip6::Address *a
         OutputFormat(" TTL: %d\r\n", aTtl);
     }
 
-    AppendResult(aResult);
+    OutputResult(aResult);
 
     mResolvingInProgress = false;
 }
@@ -1559,7 +1559,7 @@ void Interpreter::ProcessEidCache(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(OT_ERROR_NONE);
+    OutputResult(OT_ERROR_NONE);
 }
 #endif // OPENTHREAD_FTD
 
@@ -1577,7 +1577,7 @@ void Interpreter::ProcessEui64(uint8_t aArgsLength, char *aArgs[])
     OutputFormat("\r\n");
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessExtAddress(uint8_t aArgsLength, char *aArgs[])
@@ -1602,7 +1602,7 @@ void Interpreter::ProcessExtAddress(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_POSIX
@@ -1654,7 +1654,7 @@ void Interpreter::ProcessLog(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessExtPanId(uint8_t aArgsLength, char *aArgs[])
@@ -1678,7 +1678,7 @@ void Interpreter::ProcessExtPanId(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessFactoryReset(uint8_t aArgsLength, char *aArgs[])
@@ -1718,7 +1718,7 @@ void Interpreter::ProcessIfconfig(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 otError Interpreter::ProcessIpAddrAdd(uint8_t aArgsLength, char *aArgs[])
@@ -1799,7 +1799,7 @@ void Interpreter::ProcessIpAddr(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 otError Interpreter::ProcessIpMulticastAddrAdd(uint8_t aArgsLength, char *aArgs[])
@@ -1898,7 +1898,7 @@ void Interpreter::ProcessIpMulticastAddr(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessKeySequence(uint8_t aArgsLength, char *aArgs[])
@@ -1938,7 +1938,7 @@ void Interpreter::ProcessKeySequence(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessLeaderData(uint8_t aArgsLength, char *aArgs[])
@@ -1958,7 +1958,7 @@ void Interpreter::ProcessLeaderData(uint8_t aArgsLength, char *aArgs[])
     OutputFormat("Leader Router ID: %d\r\n", leaderData.mLeaderRouterId);
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_FTD
@@ -1978,7 +1978,7 @@ void Interpreter::ProcessLeaderPartitionId(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessLeaderWeight(uint8_t aArgsLength, char *aArgs[])
@@ -1997,7 +1997,7 @@ void Interpreter::ProcessLeaderWeight(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif // OPENTHREAD_FTD
 
@@ -2040,7 +2040,7 @@ void Interpreter::ProcessPskc(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif
 
@@ -2068,7 +2068,7 @@ void Interpreter::ProcessMasterKey(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
@@ -2077,7 +2077,7 @@ void Interpreter::ProcessMlr(uint8_t aArgsLength, char **aArgs)
 {
     if (aArgsLength == 0)
     {
-        AppendResult(OT_ERROR_INVALID_COMMAND);
+        OutputResult(OT_ERROR_INVALID_COMMAND);
     }
     else if (!strcmp(aArgs[0], "reg"))
     {
@@ -2085,7 +2085,7 @@ void Interpreter::ProcessMlr(uint8_t aArgsLength, char **aArgs)
     }
     else
     {
-        AppendResult(OT_ERROR_INVALID_COMMAND);
+        OutputResult(OT_ERROR_INVALID_COMMAND);
     }
 }
 
@@ -2125,7 +2125,7 @@ void Interpreter::ProcessMlrReg(uint8_t aArgsLength, char *aArgs[])
 exit:
     if (error != OT_ERROR_NONE)
     {
-        AppendResult(error);
+        OutputResult(error);
     }
 }
 
@@ -2154,7 +2154,7 @@ void Interpreter::HandleMlrRegResult(otError             aError,
         }
     }
 
-    AppendResult(aError);
+    OutputResult(aError);
 }
 
 #endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
@@ -2223,7 +2223,7 @@ void Interpreter::ProcessMode(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_FTD
@@ -2282,7 +2282,7 @@ void Interpreter::ProcessNeighbor(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif
 
@@ -2301,7 +2301,7 @@ void Interpreter::ProcessNetworkDataShow(uint8_t aArgsLength, char *aArgs[])
     OutputFormat("\r\n");
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
@@ -2319,7 +2319,7 @@ void Interpreter::ProcessNetif(uint8_t aArgsLength, char *aArgs[])
     OutputFormat("%s:%u\r\n", netif ? netif : "(null)", netifidx);
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif
 
@@ -2357,7 +2357,7 @@ void Interpreter::ProcessNetstat(uint8_t aArgsLength, char *aArgs[])
         socket = socket->mNext;
     }
 
-    AppendResult(OT_ERROR_NONE);
+    OutputResult(OT_ERROR_NONE);
 }
 
 int Interpreter::OutputSocketAddress(const otSockAddr &aAddress)
@@ -2435,7 +2435,7 @@ void Interpreter::ProcessService(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif
 
@@ -2478,7 +2478,7 @@ void Interpreter::ProcessNetworkData(uint8_t aArgsLength, char *aArgs[])
     error = OT_ERROR_INVALID_COMMAND;
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
@@ -2495,7 +2495,7 @@ void Interpreter::ProcessNetworkDataRegister(uint8_t aArgsLength, char *aArgs[])
 #endif
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
@@ -2516,7 +2516,7 @@ void Interpreter::ProcessNetworkIdTimeout(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif // OPENTHREAD_FTD
 
@@ -2535,7 +2535,7 @@ void Interpreter::ProcessNetworkName(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
@@ -2588,7 +2588,7 @@ void Interpreter::ProcessNetworkTime(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
@@ -2608,7 +2608,7 @@ void Interpreter::ProcessPanId(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessParent(uint8_t aArgsLength, char *aArgs[])
@@ -2635,7 +2635,7 @@ void Interpreter::ProcessParent(uint8_t aArgsLength, char *aArgs[])
     OutputFormat("Age: %d\r\n", parentInfo.mAge);
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_FTD
@@ -2655,7 +2655,7 @@ void Interpreter::ProcessParentPriority(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif
 
@@ -2769,7 +2769,7 @@ void Interpreter::ProcessPing(uint8_t aArgsLength, char *aArgs[])
     SendPing();
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::HandlePingTimer(Timer &aTimer)
@@ -2828,7 +2828,7 @@ void Interpreter::ProcessPollPeriod(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessPromiscuous(uint8_t aArgsLength, char *aArgs[])
@@ -2865,7 +2865,7 @@ void Interpreter::ProcessPromiscuous(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx, void *aContext)
@@ -3191,7 +3191,7 @@ void Interpreter::ProcessPrefix(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
@@ -3206,7 +3206,7 @@ void Interpreter::ProcessPreferRouterId(uint8_t aArgsLength, char *aArgs[])
     error = otThreadSetPreferredRouterId(mInstance, static_cast<uint8_t>(value));
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif
 
@@ -3228,7 +3228,7 @@ void Interpreter::ProcessRcp(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_FTD
@@ -3243,7 +3243,7 @@ void Interpreter::ProcessReleaseRouterId(uint8_t aArgsLength, char *aArgs[])
     SuccessOrExit(error = otThreadReleaseRouterId(mInstance, static_cast<uint8_t>(value)));
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif
 
@@ -3261,7 +3261,7 @@ void Interpreter::ProcessRloc16(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgs);
 
     OutputFormat("%04x\r\n", otThreadGetRloc16(mInstance));
-    AppendResult(OT_ERROR_NONE);
+    OutputResult(OT_ERROR_NONE);
 }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
@@ -3415,7 +3415,7 @@ void Interpreter::ProcessRoute(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
@@ -3508,7 +3508,7 @@ void Interpreter::ProcessRouter(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessRouterDowngradeThreshold(uint8_t aArgsLength, char *aArgs[])
@@ -3527,7 +3527,7 @@ void Interpreter::ProcessRouterDowngradeThreshold(uint8_t aArgsLength, char *aAr
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessRouterEligible(uint8_t aArgsLength, char *aArgs[])
@@ -3559,7 +3559,7 @@ void Interpreter::ProcessRouterEligible(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessRouterSelectionJitter(uint8_t aArgsLength, char *aArgs[])
@@ -3579,7 +3579,7 @@ void Interpreter::ProcessRouterSelectionJitter(uint8_t aArgsLength, char *aArgs[
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessRouterUpgradeThreshold(uint8_t aArgsLength, char *aArgs[])
@@ -3598,7 +3598,7 @@ void Interpreter::ProcessRouterUpgradeThreshold(uint8_t aArgsLength, char *aArgs
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif // OPENTHREAD_FTD
 
@@ -3649,7 +3649,7 @@ void Interpreter::ProcessScan(uint8_t aArgsLength, char *aArgs[])
 exit:
     if (error != OT_ERROR_NONE)
     {
-        AppendResult(error);
+        OutputResult(error);
     }
 }
 
@@ -3662,7 +3662,7 @@ void Interpreter::HandleActiveScanResult(otActiveScanResult *aResult)
 {
     if (aResult == nullptr)
     {
-        AppendResult(OT_ERROR_NONE);
+        OutputResult(OT_ERROR_NONE);
         ExitNow();
     }
 
@@ -3693,7 +3693,7 @@ void Interpreter::HandleEnergyScanResult(otEnergyScanResult *aResult)
 {
     if (aResult == nullptr)
     {
-        AppendResult(OT_ERROR_NONE);
+        OutputResult(OT_ERROR_NONE);
         ExitNow();
     }
 
@@ -3719,7 +3719,7 @@ void Interpreter::ProcessSingleton(uint8_t aArgsLength, char *aArgs[])
         OutputFormat("false\r\n");
     }
 
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
@@ -3767,7 +3767,7 @@ void Interpreter::ProcessSntp(uint8_t aArgsLength, char *aArgs[])
 exit:
     if (error != OT_ERROR_NONE)
     {
-        AppendResult(error);
+        OutputResult(error);
     }
 }
 
@@ -3792,7 +3792,7 @@ void Interpreter::HandleSntpResponse(uint64_t aTime, otError aResult)
 
     mSntpQueryingInProgress = false;
 
-    AppendResult(OT_ERROR_NONE);
+    OutputResult(OT_ERROR_NONE);
 }
 #endif
 
@@ -3861,7 +3861,7 @@ void Interpreter::ProcessState(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessThread(uint8_t aArgsLength, char *aArgs[])
@@ -3891,14 +3891,14 @@ void Interpreter::ProcessThread(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessDataset(uint8_t aArgsLength, char *aArgs[])
 {
     otError error;
     error = mDataset.Process(aArgsLength, aArgs);
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessTxPower(uint8_t aArgsLength, char *aArgs[])
@@ -3921,14 +3921,14 @@ void Interpreter::ProcessTxPower(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessUdp(uint8_t aArgsLength, char *aArgs[])
 {
     otError error;
     error = mUdp.Process(aArgsLength, aArgs);
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessUnsecurePort(uint8_t aArgsLength, char *aArgs[])
@@ -3986,7 +3986,7 @@ void Interpreter::ProcessUnsecurePort(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::ProcessVersion(uint8_t aArgsLength, char *aArgs[])
@@ -3996,7 +3996,7 @@ void Interpreter::ProcessVersion(uint8_t aArgsLength, char *aArgs[])
 
     const char *version = otGetVersionString();
     OutputFormat("%s\r\n", static_cast<const char *>(version));
-    AppendResult(OT_ERROR_NONE);
+    OutputResult(OT_ERROR_NONE);
 }
 
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
@@ -4005,7 +4005,7 @@ void Interpreter::ProcessCommissioner(uint8_t aArgsLength, char *aArgs[])
 {
     otError error;
     error = mCommissioner.Process(aArgsLength, aArgs);
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #endif
@@ -4016,7 +4016,7 @@ void Interpreter::ProcessJoiner(uint8_t aArgsLength, char *aArgs[])
 {
     otError error;
     error = mJoiner.Process(aArgsLength, aArgs);
-    AppendResult(error);
+    OutputResult(error);
 }
 
 #endif
@@ -4038,7 +4038,7 @@ void Interpreter::ProcessJoinerPort(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif
 
@@ -4067,7 +4067,7 @@ void Interpreter::ProcessMacFilter(uint8_t aArgsLength, char *aArgs[])
         }
     }
 
-    AppendResult(error);
+    OutputResult(error);
 }
 
 void Interpreter::PrintMacFilter(void)
@@ -4350,7 +4350,7 @@ void Interpreter::ProcessMac(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    AppendResult(error);
+    OutputResult(error);
 }
 
 otError Interpreter::ProcessMacRetries(uint8_t aArgsLength, char *aArgs[])
@@ -4414,7 +4414,7 @@ void Interpreter::ProcessDiag(uint8_t aArgsLength, char *aArgs[])
 
     error = otDiagProcessCmd(mInstance, aArgsLength, aArgs, output, sizeof(output) - 1);
     Output(output, static_cast<uint16_t>(strlen(output)));
-    AppendResult(error);
+    OutputResult(error);
 }
 #endif
 
@@ -4456,7 +4456,7 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength)
         }
     }
 
-    AppendResult(OT_ERROR_INVALID_COMMAND);
+    OutputResult(OT_ERROR_INVALID_COMMAND);
 
 exit:
     return;
@@ -4493,7 +4493,7 @@ void Interpreter::ProcessNetworkDiagnostic(uint8_t aArgsLength, char *aArgs[])
     else if (strcmp(aArgs[0], "reset") == 0)
     {
         IgnoreError(otThreadSendDiagnosticReset(mInstance, &address, tlvTypes, count));
-        AppendResult(OT_ERROR_NONE);
+        OutputResult(OT_ERROR_NONE);
     }
     else
     {
@@ -4503,7 +4503,7 @@ void Interpreter::ProcessNetworkDiagnostic(uint8_t aArgsLength, char *aArgs[])
 exit:
     if (error != OT_ERROR_NONE)
     {
-        AppendResult(error);
+        OutputResult(error);
     }
 }
 
@@ -4616,7 +4616,7 @@ void Interpreter::HandleDiagnosticGetResponse(const otMessage &aMessage, const I
         }
     }
 
-    AppendResult(error == OT_ERROR_NOT_FOUND ? OT_ERROR_NONE : error);
+    OutputResult(error == OT_ERROR_NOT_FOUND ? OT_ERROR_NONE : error);
 }
 
 void Interpreter::OutputSpaces(uint16_t aCount)
@@ -4874,7 +4874,7 @@ extern "C" void otCliOutput(const char *aString, uint16_t aLength)
 
 extern "C" void otCliAppendResult(otError aError)
 {
-    Interpreter::GetInterpreter().AppendResult(aError);
+    Interpreter::GetInterpreter().OutputResult(aError);
 }
 
 extern "C" void otCliPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aArgs)

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -370,11 +370,11 @@ void Interpreter::OutputResult(otError aError)
 {
     if (aError == OT_ERROR_NONE)
     {
-        OutputFormat("Done\r\n");
+        OutputLine("Done");
     }
     else
     {
-        OutputFormat("Error %d: %s\r\n", aError, otThreadErrorToString(aError));
+        OutputLine("Error %d: %s", aError, otThreadErrorToString(aError));
     }
 }
 
@@ -485,12 +485,12 @@ void Interpreter::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        OutputFormat("%s\r\n", command.mName);
+        OutputLine("%s", command.mName);
     }
 
     for (uint8_t i = 0; i < mUserCommandsLength; i++)
     {
-        OutputFormat("%s\r\n", mUserCommands[i].mName);
+        OutputLine("%s", mUserCommands[i].mName);
     }
 
     OutputResult(OT_ERROR_NONE);
@@ -507,15 +507,15 @@ void Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[])
     {
         if (otBackboneRouterGetPrimary(mInstance, &config) == OT_ERROR_NONE)
         {
-            OutputFormat("BBR Primary:\r\n");
-            OutputFormat("server16: 0x%04X\r\n", config.mServer16);
-            OutputFormat("seqno:    %d\r\n", config.mSequenceNumber);
-            OutputFormat("delay:    %d secs\r\n", config.mReregistrationDelay);
-            OutputFormat("timeout:  %d secs\r\n", config.mMlrTimeout);
+            OutputLine("BBR Primary:");
+            OutputLine("server16: 0x%04X", config.mServer16);
+            OutputLine("seqno:    %d", config.mSequenceNumber);
+            OutputLine("delay:    %d secs", config.mReregistrationDelay);
+            OutputLine("timeout:  %d secs", config.mMlrTimeout);
         }
         else
         {
-            OutputFormat("BBR Primary: None\r\n");
+            OutputLine("BBR Primary: None");
         }
 
         error = OT_ERROR_NONE;
@@ -632,7 +632,7 @@ void Interpreter::PrintMulticastListenersTable(void)
     while (otBackboneRouterMulticastListenerGetNext(mInstance, &iter, &listenerInfo) == OT_ERROR_NONE)
     {
         OutputIp6Address(listenerInfo.mAddress);
-        OutputFormat(" %u\r\n", listenerInfo.mTimeout);
+        OutputLine(" %u", listenerInfo.mTimeout);
     }
 }
 
@@ -656,7 +656,7 @@ otError Interpreter::ProcessBackboneRouterLocal(uint8_t aArgsLength, char *aArgs
     {
         if (aArgsLength == 1)
         {
-            OutputFormat("%d\r\n", otBackboneRouterGetRegistrationJitter(mInstance));
+            OutputLine("%d", otBackboneRouterGetRegistrationJitter(mInstance));
         }
         else if (aArgsLength == 2)
         {
@@ -673,13 +673,13 @@ otError Interpreter::ProcessBackboneRouterLocal(uint8_t aArgsLength, char *aArgs
         switch (otBackboneRouterGetState(mInstance))
         {
         case OT_BACKBONE_ROUTER_STATE_DISABLED:
-            OutputFormat("Disabled\r\n");
+            OutputLine("Disabled");
             break;
         case OT_BACKBONE_ROUTER_STATE_SECONDARY:
-            OutputFormat("Secondary\r\n");
+            OutputLine("Secondary");
             break;
         case OT_BACKBONE_ROUTER_STATE_PRIMARY:
-            OutputFormat("Primary\r\n");
+            OutputLine("Primary");
             break;
         }
     }
@@ -689,9 +689,9 @@ otError Interpreter::ProcessBackboneRouterLocal(uint8_t aArgsLength, char *aArgs
 
         if (aArgsLength == 1)
         {
-            OutputFormat("seqno:    %d\r\n", config.mSequenceNumber);
-            OutputFormat("delay:    %d secs\r\n", config.mReregistrationDelay);
-            OutputFormat("timeout:  %d secs\r\n", config.mMlrTimeout);
+            OutputLine("seqno:    %d", config.mSequenceNumber);
+            OutputLine("delay:    %d secs", config.mReregistrationDelay);
+            OutputLine("timeout:  %d secs", config.mMlrTimeout);
         }
         else
         {
@@ -741,7 +741,7 @@ void Interpreter::ProcessDomainName(uint8_t aArgsLength, char *aArgs[])
     if (aArgsLength == 0)
     {
         const char *domainName = otThreadGetDomainName(mInstance);
-        OutputFormat("%s\r\n", static_cast<const char *>(domainName));
+        OutputLine("%s", static_cast<const char *>(domainName));
     }
     else
     {
@@ -768,7 +768,7 @@ void Interpreter::ProcessDua(uint8_t aArgsLength, char *aArgs[])
         if (iid != nullptr)
         {
             OutputBytes(iid->mFields.m8, sizeof(otIp6InterfaceIdentifier));
-            OutputFormat("\r\n");
+            OutputLine("");
         }
         break;
     }
@@ -808,18 +808,17 @@ void Interpreter::ProcessBufferInfo(uint8_t aArgsLength, char *aArgs[])
 
     otMessageGetBufferInfo(mInstance, &bufferInfo);
 
-    OutputFormat("total: %d\r\n", bufferInfo.mTotalBuffers);
-    OutputFormat("free: %d\r\n", bufferInfo.mFreeBuffers);
-    OutputFormat("6lo send: %d %d\r\n", bufferInfo.m6loSendMessages, bufferInfo.m6loSendBuffers);
-    OutputFormat("6lo reas: %d %d\r\n", bufferInfo.m6loReassemblyMessages, bufferInfo.m6loReassemblyBuffers);
-    OutputFormat("ip6: %d %d\r\n", bufferInfo.mIp6Messages, bufferInfo.mIp6Buffers);
-    OutputFormat("mpl: %d %d\r\n", bufferInfo.mMplMessages, bufferInfo.mMplBuffers);
-    OutputFormat("mle: %d %d\r\n", bufferInfo.mMleMessages, bufferInfo.mMleBuffers);
-    OutputFormat("arp: %d %d\r\n", bufferInfo.mArpMessages, bufferInfo.mArpBuffers);
-    OutputFormat("coap: %d %d\r\n", bufferInfo.mCoapMessages, bufferInfo.mCoapBuffers);
-    OutputFormat("coap secure: %d %d\r\n", bufferInfo.mCoapSecureMessages, bufferInfo.mCoapSecureBuffers);
-    OutputFormat("application coap: %d %d\r\n", bufferInfo.mApplicationCoapMessages,
-                 bufferInfo.mApplicationCoapBuffers);
+    OutputLine("total: %d", bufferInfo.mTotalBuffers);
+    OutputLine("free: %d", bufferInfo.mFreeBuffers);
+    OutputLine("6lo send: %d %d", bufferInfo.m6loSendMessages, bufferInfo.m6loSendBuffers);
+    OutputLine("6lo reas: %d %d", bufferInfo.m6loReassemblyMessages, bufferInfo.m6loReassemblyBuffers);
+    OutputLine("ip6: %d %d", bufferInfo.mIp6Messages, bufferInfo.mIp6Buffers);
+    OutputLine("mpl: %d %d", bufferInfo.mMplMessages, bufferInfo.mMplBuffers);
+    OutputLine("mle: %d %d", bufferInfo.mMleMessages, bufferInfo.mMleBuffers);
+    OutputLine("arp: %d %d", bufferInfo.mArpMessages, bufferInfo.mArpBuffers);
+    OutputLine("coap: %d %d", bufferInfo.mCoapMessages, bufferInfo.mCoapBuffers);
+    OutputLine("coap secure: %d %d", bufferInfo.mCoapSecureMessages, bufferInfo.mCoapSecureBuffers);
+    OutputLine("application coap: %d %d", bufferInfo.mApplicationCoapMessages, bufferInfo.mApplicationCoapBuffers);
 
     OutputResult(OT_ERROR_NONE);
 }
@@ -831,33 +830,33 @@ void Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%d\r\n", otLinkGetChannel(mInstance));
+        OutputLine("%d", otLinkGetChannel(mInstance));
     }
     else if (strcmp(aArgs[0], "supported") == 0)
     {
-        OutputFormat("0x%x\r\n", otPlatRadioGetSupportedChannelMask(mInstance));
+        OutputLine("0x%x", otPlatRadioGetSupportedChannelMask(mInstance));
     }
     else if (strcmp(aArgs[0], "preferred") == 0)
     {
-        OutputFormat("0x%x\r\n", otPlatRadioGetPreferredChannelMask(mInstance));
+        OutputLine("0x%x", otPlatRadioGetPreferredChannelMask(mInstance));
     }
 #if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
     else if (strcmp(aArgs[0], "monitor") == 0)
     {
         if (aArgsLength == 1)
         {
-            OutputFormat("enabled: %d\r\n", otChannelMonitorIsEnabled(mInstance));
+            OutputLine("enabled: %d", otChannelMonitorIsEnabled(mInstance));
             if (otChannelMonitorIsEnabled(mInstance))
             {
                 uint32_t channelMask = otLinkGetSupportedChannelMask(mInstance);
                 uint8_t  channelNum  = sizeof(channelMask) * CHAR_BIT;
 
-                OutputFormat("interval: %u\r\n", otChannelMonitorGetSampleInterval(mInstance));
-                OutputFormat("threshold: %d\r\n", otChannelMonitorGetRssiThreshold(mInstance));
-                OutputFormat("window: %u\r\n", otChannelMonitorGetSampleWindow(mInstance));
-                OutputFormat("count: %u\r\n", otChannelMonitorGetSampleCount(mInstance));
+                OutputLine("interval: %u", otChannelMonitorGetSampleInterval(mInstance));
+                OutputLine("threshold: %d", otChannelMonitorGetRssiThreshold(mInstance));
+                OutputLine("window: %u", otChannelMonitorGetSampleWindow(mInstance));
+                OutputLine("count: %u", otChannelMonitorGetSampleCount(mInstance));
 
-                OutputFormat("occupancies:\r\n");
+                OutputLine("occupancies:");
                 for (uint8_t channel = 0; channel < channelNum; channel++)
                 {
                     uint32_t occupancy = 0;
@@ -871,9 +870,9 @@ void Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
 
                     OutputFormat("ch %d (0x%04x) ", channel, occupancy);
                     occupancy = (occupancy * 10000) / 0xffff;
-                    OutputFormat("%2d.%02d%% busy\r\n", occupancy / 100, occupancy % 100);
+                    OutputLine("%2d.%02d%% busy", occupancy / 100, occupancy % 100);
                 }
-                OutputFormat("\r\n");
+                OutputLine("");
             }
         }
         else if (strcmp(aArgs[1], "start") == 0)
@@ -895,18 +894,18 @@ void Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
     {
         if (aArgsLength == 1)
         {
-            OutputFormat("channel: %d\r\n", otChannelManagerGetRequestedChannel(mInstance));
-            OutputFormat("auto: %d\r\n", otChannelManagerGetAutoChannelSelectionEnabled(mInstance));
+            OutputLine("channel: %d", otChannelManagerGetRequestedChannel(mInstance));
+            OutputLine("auto: %d", otChannelManagerGetAutoChannelSelectionEnabled(mInstance));
 
             if (otChannelManagerGetAutoChannelSelectionEnabled(mInstance))
             {
                 Mac::ChannelMask supportedMask(otChannelManagerGetSupportedChannels(mInstance));
                 Mac::ChannelMask favoredMask(otChannelManagerGetFavoredChannels(mInstance));
 
-                OutputFormat("delay: %d\r\n", otChannelManagerGetDelay(mInstance));
-                OutputFormat("interval: %u\r\n", otChannelManagerGetAutoChannelSelectionInterval(mInstance));
-                OutputFormat("supported: %s\r\n", supportedMask.ToString().AsCString());
-                OutputFormat("favored: %s\r\n", supportedMask.ToString().AsCString());
+                OutputLine("delay: %d", otChannelManagerGetDelay(mInstance));
+                OutputLine("interval: %u", otChannelManagerGetAutoChannelSelectionInterval(mInstance));
+                OutputLine("supported: %s", supportedMask.ToString().AsCString());
+                OutputLine("favored: %s", supportedMask.ToString().AsCString());
             }
         }
         else if (strcmp(aArgs[1], "change") == 0)
@@ -987,8 +986,8 @@ void Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
 
         if (isTable)
         {
-            OutputFormat("| ID  | RLOC16 | Timeout    | Age        | LQ In | C_VN |R|S|D|N| Extended MAC     |\r\n");
-            OutputFormat("+-----+--------+------------+------------+-------+------+-+-+-+-+------------------+\r\n");
+            OutputLine("| ID  | RLOC16 | Timeout    | Age        | LQ In | C_VN |R|S|D|N| Extended MAC     |");
+            OutputLine("+-----+--------+------------+------------+-------+------+-+-+-+-+------------------+");
         }
 
         maxChildren = otThreadGetMaxAllowedChildren(mInstance);
@@ -1019,7 +1018,7 @@ void Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
                     OutputFormat("%02x", b);
                 }
 
-                OutputFormat(" |\r\n");
+                OutputLine(" |");
             }
             else
             {
@@ -1027,15 +1026,15 @@ void Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
             }
         }
 
-        OutputFormat("\r\n");
+        OutputLine("");
         ExitNow();
     }
 
     SuccessOrExit(error = ParseLong(aArgs[0], value));
     SuccessOrExit(error = otThreadGetChildInfoById(mInstance, static_cast<uint16_t>(value), &childInfo));
 
-    OutputFormat("Child ID: %d\r\n", childInfo.mChildId);
-    OutputFormat("Rloc: %04x\r\n", childInfo.mRloc16);
+    OutputLine("Child ID: %d", childInfo.mChildId);
+    OutputLine("Rloc: %04x", childInfo.mRloc16);
     OutputFormat("Ext Addr: ");
 
     for (uint8_t b : childInfo.mExtAddress.m8)
@@ -1043,7 +1042,7 @@ void Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
         OutputFormat("%02x", b);
     }
 
-    OutputFormat("\r\n");
+    OutputLine("");
     OutputFormat("Mode: ");
 
     if (childInfo.mRxOnWhenIdle)
@@ -1066,13 +1065,13 @@ void Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
         OutputFormat("n");
     }
 
-    OutputFormat("\r\n");
+    OutputLine("");
 
-    OutputFormat("Net Data: %d\r\n", childInfo.mNetworkDataVersion);
-    OutputFormat("Timeout: %d\r\n", childInfo.mTimeout);
-    OutputFormat("Age: %d\r\n", childInfo.mAge);
-    OutputFormat("Link Quality In: %d\r\n", childInfo.mLinkQualityIn);
-    OutputFormat("RSSI: %d\r\n", childInfo.mAverageRssi);
+    OutputLine("Net Data: %d", childInfo.mNetworkDataVersion);
+    OutputLine("Timeout: %d", childInfo.mTimeout);
+    OutputLine("Age: %d", childInfo.mAge);
+    OutputLine("Link Quality In: %d", childInfo.mLinkQualityIn);
+    OutputLine("RSSI: %d", childInfo.mAverageRssi);
 
 exit:
     OutputResult(error);
@@ -1105,7 +1104,7 @@ void Interpreter::ProcessChildIp(uint8_t aArgsLength, char *aArgs[])
             {
                 OutputFormat("%04x: ", childInfo.mRloc16);
                 OutputIp6Address(ip6Address);
-                OutputFormat("\r\n");
+                OutputLine("");
             }
         }
     }
@@ -1113,7 +1112,7 @@ void Interpreter::ProcessChildIp(uint8_t aArgsLength, char *aArgs[])
     {
         if (aArgsLength == 1)
         {
-            OutputFormat("%d\r\n", otThreadGetMaxChildIpAddresses(mInstance));
+            OutputLine("%d", otThreadGetMaxChildIpAddresses(mInstance));
         }
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
         else if (aArgsLength == 2)
@@ -1146,7 +1145,7 @@ void Interpreter::ProcessChildMax(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%d\r\n", otThreadGetMaxAllowedChildren(mInstance));
+        OutputLine("%d", otThreadGetMaxAllowedChildren(mInstance));
     }
     else
     {
@@ -1166,7 +1165,7 @@ void Interpreter::ProcessChildTimeout(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%d\r\n", otThreadGetChildTimeout(mInstance));
+        OutputLine("%d", otThreadGetChildTimeout(mInstance));
     }
     else
     {
@@ -1203,7 +1202,7 @@ void Interpreter::ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%s\r\n", otPlatRadioIsCoexEnabled(mInstance) ? "Enabled" : "Disabled");
+        OutputLine("%s", otPlatRadioIsCoexEnabled(mInstance) ? "Enabled" : "Disabled");
     }
     else if (strcmp(aArgs[0], "enable") == 0)
     {
@@ -1219,27 +1218,27 @@ void Interpreter::ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[])
 
         SuccessOrExit(error = otPlatRadioGetCoexMetrics(mInstance, &metrics));
 
-        OutputFormat("Stopped: %s\r\n", metrics.mStopped ? "true" : "false");
-        OutputFormat("Grant Glitch: %u\r\n", metrics.mNumGrantGlitch);
-        OutputFormat("Transmit metrics\r\n");
-        OutputFormat("    Request: %u\r\n", metrics.mNumTxRequest);
-        OutputFormat("    Grant Immediate: %u\r\n", metrics.mNumTxGrantImmediate);
-        OutputFormat("    Grant Wait: %u\r\n", metrics.mNumTxGrantWait);
-        OutputFormat("    Grant Wait Activated: %u\r\n", metrics.mNumTxGrantWaitActivated);
-        OutputFormat("    Grant Wait Timeout: %u\r\n", metrics.mNumTxGrantWaitTimeout);
-        OutputFormat("    Grant Deactivated During Request: %u\r\n", metrics.mNumTxGrantDeactivatedDuringRequest);
-        OutputFormat("    Delayed Grant: %u\r\n", metrics.mNumTxDelayedGrant);
-        OutputFormat("    Average Request To Grant Time: %u\r\n", metrics.mAvgTxRequestToGrantTime);
-        OutputFormat("Receive metrics\r\n");
-        OutputFormat("    Request: %u\r\n", metrics.mNumRxRequest);
-        OutputFormat("    Grant Immediate: %u\r\n", metrics.mNumRxGrantImmediate);
-        OutputFormat("    Grant Wait: %u\r\n", metrics.mNumRxGrantWait);
-        OutputFormat("    Grant Wait Activated: %u\r\n", metrics.mNumRxGrantWaitActivated);
-        OutputFormat("    Grant Wait Timeout: %u\r\n", metrics.mNumRxGrantWaitTimeout);
-        OutputFormat("    Grant Deactivated During Request: %u\r\n", metrics.mNumRxGrantDeactivatedDuringRequest);
-        OutputFormat("    Delayed Grant: %u\r\n", metrics.mNumRxDelayedGrant);
-        OutputFormat("    Average Request To Grant Time: %u\r\n", metrics.mAvgRxRequestToGrantTime);
-        OutputFormat("    Grant None: %u\r\n", metrics.mNumRxGrantNone);
+        OutputLine("Stopped: %s", metrics.mStopped ? "true" : "false");
+        OutputLine("Grant Glitch: %u", metrics.mNumGrantGlitch);
+        OutputLine("Transmit metrics");
+        OutputLine("    Request: %u", metrics.mNumTxRequest);
+        OutputLine("    Grant Immediate: %u", metrics.mNumTxGrantImmediate);
+        OutputLine("    Grant Wait: %u", metrics.mNumTxGrantWait);
+        OutputLine("    Grant Wait Activated: %u", metrics.mNumTxGrantWaitActivated);
+        OutputLine("    Grant Wait Timeout: %u", metrics.mNumTxGrantWaitTimeout);
+        OutputLine("    Grant Deactivated During Request: %u", metrics.mNumTxGrantDeactivatedDuringRequest);
+        OutputLine("    Delayed Grant: %u", metrics.mNumTxDelayedGrant);
+        OutputLine("    Average Request To Grant Time: %u", metrics.mAvgTxRequestToGrantTime);
+        OutputLine("Receive metrics");
+        OutputLine("    Request: %u", metrics.mNumRxRequest);
+        OutputLine("    Grant Immediate: %u", metrics.mNumRxGrantImmediate);
+        OutputLine("    Grant Wait: %u", metrics.mNumRxGrantWait);
+        OutputLine("    Grant Wait Activated: %u", metrics.mNumRxGrantWaitActivated);
+        OutputLine("    Grant Wait Timeout: %u", metrics.mNumRxGrantWaitTimeout);
+        OutputLine("    Grant Deactivated During Request: %u", metrics.mNumRxGrantDeactivatedDuringRequest);
+        OutputLine("    Delayed Grant: %u", metrics.mNumRxDelayedGrant);
+        OutputLine("    Average Request To Grant Time: %u", metrics.mAvgRxRequestToGrantTime);
+        OutputLine("    Grant None: %u", metrics.mNumRxGrantNone);
     }
     else
     {
@@ -1259,7 +1258,7 @@ void Interpreter::ProcessContextIdReuseDelay(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%d\r\n", otThreadGetContextIdReuseDelay(mInstance));
+        OutputLine("%d", otThreadGetContextIdReuseDelay(mInstance));
     }
     else
     {
@@ -1278,8 +1277,8 @@ void Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("mac\r\n");
-        OutputFormat("mle\r\n");
+        OutputLine("mac");
+        OutputLine("mle");
     }
     else if (strcmp(aArgs[0], "mac") == 0)
     {
@@ -1287,37 +1286,37 @@ void Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
         {
             const otMacCounters *macCounters = otLinkGetCounters(mInstance);
 
-            OutputFormat("TxTotal: %d\r\n", macCounters->mTxTotal);
-            OutputFormat("    TxUnicast: %d\r\n", macCounters->mTxUnicast);
-            OutputFormat("    TxBroadcast: %d\r\n", macCounters->mTxBroadcast);
-            OutputFormat("    TxAckRequested: %d\r\n", macCounters->mTxAckRequested);
-            OutputFormat("    TxAcked: %d\r\n", macCounters->mTxAcked);
-            OutputFormat("    TxNoAckRequested: %d\r\n", macCounters->mTxNoAckRequested);
-            OutputFormat("    TxData: %d\r\n", macCounters->mTxData);
-            OutputFormat("    TxDataPoll: %d\r\n", macCounters->mTxDataPoll);
-            OutputFormat("    TxBeacon: %d\r\n", macCounters->mTxBeacon);
-            OutputFormat("    TxBeaconRequest: %d\r\n", macCounters->mTxBeaconRequest);
-            OutputFormat("    TxOther: %d\r\n", macCounters->mTxOther);
-            OutputFormat("    TxRetry: %d\r\n", macCounters->mTxRetry);
-            OutputFormat("    TxErrCca: %d\r\n", macCounters->mTxErrCca);
-            OutputFormat("    TxErrBusyChannel: %d\r\n", macCounters->mTxErrBusyChannel);
-            OutputFormat("RxTotal: %d\r\n", macCounters->mRxTotal);
-            OutputFormat("    RxUnicast: %d\r\n", macCounters->mRxUnicast);
-            OutputFormat("    RxBroadcast: %d\r\n", macCounters->mRxBroadcast);
-            OutputFormat("    RxData: %d\r\n", macCounters->mRxData);
-            OutputFormat("    RxDataPoll: %d\r\n", macCounters->mRxDataPoll);
-            OutputFormat("    RxBeacon: %d\r\n", macCounters->mRxBeacon);
-            OutputFormat("    RxBeaconRequest: %d\r\n", macCounters->mRxBeaconRequest);
-            OutputFormat("    RxOther: %d\r\n", macCounters->mRxOther);
-            OutputFormat("    RxAddressFiltered: %d\r\n", macCounters->mRxAddressFiltered);
-            OutputFormat("    RxDestAddrFiltered: %d\r\n", macCounters->mRxDestAddrFiltered);
-            OutputFormat("    RxDuplicated: %d\r\n", macCounters->mRxDuplicated);
-            OutputFormat("    RxErrNoFrame: %d\r\n", macCounters->mRxErrNoFrame);
-            OutputFormat("    RxErrNoUnknownNeighbor: %d\r\n", macCounters->mRxErrUnknownNeighbor);
-            OutputFormat("    RxErrInvalidSrcAddr: %d\r\n", macCounters->mRxErrInvalidSrcAddr);
-            OutputFormat("    RxErrSec: %d\r\n", macCounters->mRxErrSec);
-            OutputFormat("    RxErrFcs: %d\r\n", macCounters->mRxErrFcs);
-            OutputFormat("    RxErrOther: %d\r\n", macCounters->mRxErrOther);
+            OutputLine("TxTotal: %d", macCounters->mTxTotal);
+            OutputLine("    TxUnicast: %d", macCounters->mTxUnicast);
+            OutputLine("    TxBroadcast: %d", macCounters->mTxBroadcast);
+            OutputLine("    TxAckRequested: %d", macCounters->mTxAckRequested);
+            OutputLine("    TxAcked: %d", macCounters->mTxAcked);
+            OutputLine("    TxNoAckRequested: %d", macCounters->mTxNoAckRequested);
+            OutputLine("    TxData: %d", macCounters->mTxData);
+            OutputLine("    TxDataPoll: %d", macCounters->mTxDataPoll);
+            OutputLine("    TxBeacon: %d", macCounters->mTxBeacon);
+            OutputLine("    TxBeaconRequest: %d", macCounters->mTxBeaconRequest);
+            OutputLine("    TxOther: %d", macCounters->mTxOther);
+            OutputLine("    TxRetry: %d", macCounters->mTxRetry);
+            OutputLine("    TxErrCca: %d", macCounters->mTxErrCca);
+            OutputLine("    TxErrBusyChannel: %d", macCounters->mTxErrBusyChannel);
+            OutputLine("RxTotal: %d", macCounters->mRxTotal);
+            OutputLine("    RxUnicast: %d", macCounters->mRxUnicast);
+            OutputLine("    RxBroadcast: %d", macCounters->mRxBroadcast);
+            OutputLine("    RxData: %d", macCounters->mRxData);
+            OutputLine("    RxDataPoll: %d", macCounters->mRxDataPoll);
+            OutputLine("    RxBeacon: %d", macCounters->mRxBeacon);
+            OutputLine("    RxBeaconRequest: %d", macCounters->mRxBeaconRequest);
+            OutputLine("    RxOther: %d", macCounters->mRxOther);
+            OutputLine("    RxAddressFiltered: %d", macCounters->mRxAddressFiltered);
+            OutputLine("    RxDestAddrFiltered: %d", macCounters->mRxDestAddrFiltered);
+            OutputLine("    RxDuplicated: %d", macCounters->mRxDuplicated);
+            OutputLine("    RxErrNoFrame: %d", macCounters->mRxErrNoFrame);
+            OutputLine("    RxErrNoUnknownNeighbor: %d", macCounters->mRxErrUnknownNeighbor);
+            OutputLine("    RxErrInvalidSrcAddr: %d", macCounters->mRxErrInvalidSrcAddr);
+            OutputLine("    RxErrSec: %d", macCounters->mRxErrSec);
+            OutputLine("    RxErrFcs: %d", macCounters->mRxErrFcs);
+            OutputLine("    RxErrOther: %d", macCounters->mRxErrOther);
         }
         else if ((aArgsLength == 2) && (strcmp(aArgs[1], "reset") == 0))
         {
@@ -1334,15 +1333,15 @@ void Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
         {
             const otMleCounters *mleCounters = otThreadGetMleCounters(mInstance);
 
-            OutputFormat("Role Disabled: %d\r\n", mleCounters->mDisabledRole);
-            OutputFormat("Role Detached: %d\r\n", mleCounters->mDetachedRole);
-            OutputFormat("Role Child: %d\r\n", mleCounters->mChildRole);
-            OutputFormat("Role Router: %d\r\n", mleCounters->mRouterRole);
-            OutputFormat("Role Leader: %d\r\n", mleCounters->mLeaderRole);
-            OutputFormat("Attach Attempts: %d\r\n", mleCounters->mAttachAttempts);
-            OutputFormat("Partition Id Changes: %d\r\n", mleCounters->mPartitionIdChanges);
-            OutputFormat("Better Partition Attach Attempts: %d\r\n", mleCounters->mBetterPartitionAttachAttempts);
-            OutputFormat("Parent Changes: %d\r\n", mleCounters->mParentChanges);
+            OutputLine("Role Disabled: %d", mleCounters->mDisabledRole);
+            OutputLine("Role Detached: %d", mleCounters->mDetachedRole);
+            OutputLine("Role Child: %d", mleCounters->mChildRole);
+            OutputLine("Role Router: %d", mleCounters->mRouterRole);
+            OutputLine("Role Leader: %d", mleCounters->mLeaderRole);
+            OutputLine("Attach Attempts: %d", mleCounters->mAttachAttempts);
+            OutputLine("Partition Id Changes: %d", mleCounters->mPartitionIdChanges);
+            OutputLine("Better Partition Attach Attempts: %d", mleCounters->mBetterPartitionAttachAttempts);
+            OutputLine("Parent Changes: %d", mleCounters->mParentChanges);
         }
         else if ((aArgsLength == 2) && (strcmp(aArgs[1], "reset") == 0))
         {
@@ -1369,10 +1368,10 @@ void Interpreter::ProcessCsl(uint8_t aArgsLength, char *argv[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("Channel: %u\r\n", otLinkCslGetChannel(mInstance));
-        OutputFormat("Period: %u(in units of 10 symbols), %ums\r\n", otLinkCslGetPeriod(mInstance),
-                     otLinkCslGetPeriod(mInstance) * kUsPerTenSymbols / 1000);
-        OutputFormat("Timeout: %us\r\n", otLinkCslGetTimeout(mInstance));
+        OutputLine("Channel: %u", otLinkCslGetChannel(mInstance));
+        OutputLine("Period: %u(in units of 10 symbols), %ums", otLinkCslGetPeriod(mInstance),
+                   otLinkCslGetPeriod(mInstance) * kUsPerTenSymbols / 1000);
+        OutputLine("Timeout: %us", otLinkCslGetTimeout(mInstance));
         error = OT_ERROR_NONE;
     }
     else if (aArgsLength == 2)
@@ -1407,7 +1406,7 @@ void Interpreter::ProcessDelayTimerMin(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%d\r\n", (otDatasetGetDelayTimerMinimal(mInstance) / 1000));
+        OutputLine("%d", (otDatasetGetDelayTimerMinimal(mInstance) / 1000));
     }
     else if (aArgsLength == 1)
     {
@@ -1441,8 +1440,8 @@ void Interpreter::ProcessDiscover(uint8_t aArgsLength, char *aArgs[])
 
     SuccessOrExit(error = otThreadDiscover(mInstance, scanChannels, OT_PANID_BROADCAST, false, false,
                                            &Interpreter::HandleActiveScanResult, this));
-    OutputFormat("| J | Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |\r\n");
-    OutputFormat("+---+------------------+------------------+------+------------------+----+-----+-----+\r\n");
+    OutputLine("| J | Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |");
+    OutputLine("+---+------------------+------------------+------+------------------+----+-----+-----+");
 
 exit:
     if (error != OT_ERROR_NONE)
@@ -1526,7 +1525,7 @@ void Interpreter::HandleDnsResponse(const char *aHostname, const Ip6::Address *a
         {
             OutputIp6Address(*aAddress);
         }
-        OutputFormat(" TTL: %d\r\n", aTtl);
+        OutputLine(" TTL: %d", aTtl);
     }
 
     OutputResult(aResult);
@@ -1551,7 +1550,7 @@ void Interpreter::ProcessEidCache(uint8_t aArgsLength, char *aArgs[])
         SuccessOrExit(otThreadGetNextCacheEntry(mInstance, &entry, &iterator));
 
         OutputIp6Address(entry.mTarget);
-        OutputFormat(" %04x\r\n", entry.mRloc16);
+        OutputLine(" %04x", entry.mRloc16);
     }
 
 exit:
@@ -1570,7 +1569,7 @@ void Interpreter::ProcessEui64(uint8_t aArgsLength, char *aArgs[])
 
     otLinkGetFactoryAssignedIeeeEui64(mInstance, &extAddress);
     OutputBytes(extAddress.m8, OT_EXT_ADDRESS_SIZE);
-    OutputFormat("\r\n");
+    OutputLine("");
 
 exit:
     OutputResult(error);
@@ -1584,7 +1583,7 @@ void Interpreter::ProcessExtAddress(uint8_t aArgsLength, char *aArgs[])
     {
         const uint8_t *extAddress = reinterpret_cast<const uint8_t *>(otLinkGetExtendedAddress(mInstance));
         OutputBytes(extAddress, OT_EXT_ADDRESS_SIZE);
-        OutputFormat("\r\n");
+        OutputLine("");
     }
     else
     {
@@ -1621,7 +1620,7 @@ void Interpreter::ProcessLog(uint8_t aArgsLength, char *aArgs[])
     {
         if (aArgsLength == 1)
         {
-            OutputFormat("%d\r\n", otLoggingGetLevel());
+            OutputLine("%d", otLoggingGetLevel());
         }
 #if OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE
         else if (aArgsLength == 2)
@@ -1661,7 +1660,7 @@ void Interpreter::ProcessExtPanId(uint8_t aArgsLength, char *aArgs[])
     {
         const uint8_t *extPanId = reinterpret_cast<const uint8_t *>(otThreadGetExtendedPanId(mInstance));
         OutputBytes(extPanId, OT_EXT_PAN_ID_SIZE);
-        OutputFormat("\r\n");
+        OutputLine("");
     }
     else
     {
@@ -1693,11 +1692,11 @@ void Interpreter::ProcessIfconfig(uint8_t aArgsLength, char *aArgs[])
     {
         if (otIp6IsEnabled(mInstance))
         {
-            OutputFormat("up\r\n");
+            OutputLine("up");
         }
         else
         {
-            OutputFormat("down\r\n");
+            OutputLine("down");
         }
     }
     else if (strcmp(aArgs[0], "up") == 0)
@@ -1760,7 +1759,7 @@ void Interpreter::ProcessIpAddr(uint8_t aArgsLength, char *aArgs[])
         for (const otNetifAddress *addr = unicastAddrs; addr; addr = addr->mNext)
         {
             OutputIp6Address(addr->mAddress);
-            OutputFormat("\r\n");
+            OutputLine("");
         }
     }
     else
@@ -1776,17 +1775,17 @@ void Interpreter::ProcessIpAddr(uint8_t aArgsLength, char *aArgs[])
         else if (strcmp(aArgs[0], "linklocal") == 0)
         {
             OutputIp6Address(*otThreadGetLinkLocalIp6Address(mInstance));
-            OutputFormat("\r\n");
+            OutputLine("");
         }
         else if (strcmp(aArgs[0], "rloc") == 0)
         {
             OutputIp6Address(*otThreadGetRloc(mInstance));
-            OutputFormat("\r\n");
+            OutputLine("");
         }
         else if (strcmp(aArgs[0], "mleid") == 0)
         {
             OutputIp6Address(*otThreadGetMeshLocalEid(mInstance));
-            OutputFormat("\r\n");
+            OutputLine("");
         }
         else
         {
@@ -1834,11 +1833,11 @@ otError Interpreter::ProcessMulticastPromiscuous(uint8_t aArgsLength, char *aArg
     {
         if (otIp6IsMulticastPromiscuousEnabled(mInstance))
         {
-            OutputFormat("Enabled\r\n");
+            OutputLine("Enabled");
         }
         else
         {
-            OutputFormat("Disabled\r\n");
+            OutputLine("Disabled");
         }
     }
     else
@@ -1870,7 +1869,7 @@ void Interpreter::ProcessIpMulticastAddr(uint8_t aArgsLength, char *aArgs[])
         for (const otNetifMulticastAddress *addr = otIp6GetMulticastAddresses(mInstance); addr; addr = addr->mNext)
         {
             OutputIp6Address(addr->mAddress);
-            OutputFormat("\r\n");
+            OutputLine("");
         }
     }
     else
@@ -1908,7 +1907,7 @@ void Interpreter::ProcessKeySequence(uint8_t aArgsLength, char *aArgs[])
     {
         if (aArgsLength == 1)
         {
-            OutputFormat("%d\r\n", otThreadGetKeySequenceCounter(mInstance));
+            OutputLine("%d", otThreadGetKeySequenceCounter(mInstance));
         }
         else
         {
@@ -1920,7 +1919,7 @@ void Interpreter::ProcessKeySequence(uint8_t aArgsLength, char *aArgs[])
     {
         if (aArgsLength == 1)
         {
-            OutputFormat("%d\r\n", otThreadGetKeySwitchGuardTime(mInstance));
+            OutputLine("%d", otThreadGetKeySwitchGuardTime(mInstance));
         }
         else
         {
@@ -1947,11 +1946,11 @@ void Interpreter::ProcessLeaderData(uint8_t aArgsLength, char *aArgs[])
 
     SuccessOrExit(error = otThreadGetLeaderData(mInstance, &leaderData));
 
-    OutputFormat("Partition ID: %u\r\n", leaderData.mPartitionId);
-    OutputFormat("Weighting: %d\r\n", leaderData.mWeighting);
-    OutputFormat("Data Version: %d\r\n", leaderData.mDataVersion);
-    OutputFormat("Stable Data Version: %d\r\n", leaderData.mStableDataVersion);
-    OutputFormat("Leader Router ID: %d\r\n", leaderData.mLeaderRouterId);
+    OutputLine("Partition ID: %u", leaderData.mPartitionId);
+    OutputLine("Weighting: %d", leaderData.mWeighting);
+    OutputLine("Data Version: %d", leaderData.mDataVersion);
+    OutputLine("Stable Data Version: %d", leaderData.mStableDataVersion);
+    OutputLine("Leader Router ID: %d", leaderData.mLeaderRouterId);
 
 exit:
     OutputResult(error);
@@ -1965,7 +1964,7 @@ void Interpreter::ProcessLeaderPartitionId(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%u\r\n", otThreadGetLocalLeaderPartitionId(mInstance));
+        OutputLine("%u", otThreadGetLocalLeaderPartitionId(mInstance));
     }
     else
     {
@@ -1984,7 +1983,7 @@ void Interpreter::ProcessLeaderWeight(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%d\r\n", otThreadGetLocalLeaderWeight(mInstance));
+        OutputLine("%d", otThreadGetLocalLeaderWeight(mInstance));
     }
     else
     {
@@ -2011,7 +2010,7 @@ void Interpreter::ProcessPskc(uint8_t aArgsLength, char *aArgs[])
             OutputFormat("%02x", b);
         }
 
-        OutputFormat("\r\n");
+        OutputLine("");
     }
     else
     {
@@ -2053,7 +2052,7 @@ void Interpreter::ProcessMasterKey(uint8_t aArgsLength, char *aArgs[])
             OutputFormat("%02x", key[i]);
         }
 
-        OutputFormat("\r\n");
+        OutputLine("");
     }
     else
     {
@@ -2141,12 +2140,12 @@ void Interpreter::HandleMlrRegResult(otError             aError,
 {
     if (aError == OT_ERROR_NONE)
     {
-        OutputFormat("status %d, %d failed\r\n", aMlrStatus, aFailedAddressNum);
+        OutputLine("status %d, %d failed", aMlrStatus, aFailedAddressNum);
 
         for (uint8_t i = 0; i < aFailedAddressNum; i++)
         {
             OutputIp6Address(aFailedAddresses[i]);
-            OutputFormat("\r\n");
+            OutputLine("");
         }
     }
 
@@ -2186,7 +2185,7 @@ void Interpreter::ProcessMode(uint8_t aArgsLength, char *aArgs[])
             OutputFormat("n");
         }
 
-        OutputFormat("\r\n");
+        OutputLine("");
     }
     else
     {
@@ -2238,8 +2237,8 @@ void Interpreter::ProcessNeighbor(uint8_t aArgsLength, char *aArgs[])
     {
         if (isTable)
         {
-            OutputFormat("| Role | RLOC16 | Age | Avg RSSI | Last RSSI |R|S|D|N| Extended MAC     |\r\n");
-            OutputFormat("+------+--------+-----+----------+-----------+-+-+-+-+------------------+\r\n");
+            OutputLine("| Role | RLOC16 | Age | Avg RSSI | Last RSSI |R|S|D|N| Extended MAC     |");
+            OutputLine("+------+--------+-----+----------+-----------+-+-+-+-+------------------+");
         }
 
         while (otThreadGetNextNeighborInfo(mInstance, &iterator, &neighborInfo) == OT_ERROR_NONE)
@@ -2262,7 +2261,7 @@ void Interpreter::ProcessNeighbor(uint8_t aArgsLength, char *aArgs[])
                     OutputFormat("%02x", b);
                 }
 
-                OutputFormat(" |\r\n");
+                OutputLine(" |");
             }
             else
             {
@@ -2270,7 +2269,7 @@ void Interpreter::ProcessNeighbor(uint8_t aArgsLength, char *aArgs[])
             }
         }
 
-        OutputFormat("\r\n");
+        OutputLine("");
     }
     else
     {
@@ -2294,7 +2293,7 @@ void Interpreter::ProcessNetworkDataShow(uint8_t aArgsLength, char *aArgs[])
     SuccessOrExit(error = otNetDataGet(mInstance, false, data, &len));
 
     OutputBytes(data, static_cast<uint8_t>(len));
-    OutputFormat("\r\n");
+    OutputLine("");
 
 exit:
     OutputResult(error);
@@ -2312,7 +2311,7 @@ void Interpreter::ProcessNetif(uint8_t aArgsLength, char *aArgs[])
 
     SuccessOrExit(error = otPlatGetNetif(mInstance, &netif, &netifidx));
 
-    OutputFormat("%s:%u\r\n", netif ? netif : "(null)", netifidx);
+    OutputLine("%s:%u", netif ? netif : "(null)", netifidx);
 
 exit:
     OutputResult(error);
@@ -2326,8 +2325,8 @@ void Interpreter::ProcessNetstat(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    OutputFormat("|                 Local Address                 |                  Peer Address                 |\n");
-    OutputFormat("+-----------------------------------------------+-----------------------------------------------+\n");
+    OutputLine("|                 Local Address                 |                  Peer Address                 |");
+    OutputLine("+-----------------------------------------------+-----------------------------------------------+");
 
     while (socket)
     {
@@ -2348,7 +2347,7 @@ void Interpreter::ProcessNetstat(uint8_t aArgsLength, char *aArgs[])
         {
             OutputFormat(" ");
         }
-        OutputFormat(" |\n");
+        OutputLine(" |");
 
         socket = socket->mNext;
     }
@@ -2503,7 +2502,7 @@ void Interpreter::ProcessNetworkIdTimeout(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%d\r\n", otThreadGetNetworkIdTimeout(mInstance));
+        OutputLine("%d", otThreadGetNetworkIdTimeout(mInstance));
     }
     else
     {
@@ -2523,7 +2522,7 @@ void Interpreter::ProcessNetworkName(uint8_t aArgsLength, char *aArgs[])
     if (aArgsLength == 0)
     {
         const char *networkName = otThreadGetNetworkName(mInstance);
-        OutputFormat("%s\r\n", static_cast<const char *>(networkName));
+        OutputLine("%s", static_cast<const char *>(networkName));
     }
     else
     {
@@ -2552,23 +2551,23 @@ void Interpreter::ProcessNetworkTime(uint8_t aArgsLength, char *aArgs[])
         switch (networkTimeStatus)
         {
         case OT_NETWORK_TIME_UNSYNCHRONIZED:
-            OutputFormat(" (unsynchronized)\r\n");
+            OutputLine(" (unsynchronized)");
             break;
 
         case OT_NETWORK_TIME_RESYNC_NEEDED:
-            OutputFormat(" (resync needed)\r\n");
+            OutputLine(" (resync needed)");
             break;
 
         case OT_NETWORK_TIME_SYNCHRONIZED:
-            OutputFormat(" (synchronized)\r\n");
+            OutputLine(" (synchronized)");
             break;
 
         default:
             break;
         }
 
-        OutputFormat("Time Sync Period: %ds\r\n", otNetworkTimeGetSyncPeriod(mInstance));
-        OutputFormat("XTAL Threshold:   %dppm\r\n", otNetworkTimeGetXtalThreshold(mInstance));
+        OutputLine("Time Sync Period: %ds", otNetworkTimeGetSyncPeriod(mInstance));
+        OutputLine("XTAL Threshold:   %dppm", otNetworkTimeGetXtalThreshold(mInstance));
     }
     else if (aArgsLength == 2)
     {
@@ -2595,7 +2594,7 @@ void Interpreter::ProcessPanId(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("0x%04x\r\n", otLinkGetPanId(mInstance));
+        OutputLine("0x%04x", otLinkGetPanId(mInstance));
     }
     else
     {
@@ -2623,12 +2622,12 @@ void Interpreter::ProcessParent(uint8_t aArgsLength, char *aArgs[])
         OutputFormat("%02x", b);
     }
 
-    OutputFormat("\r\n");
+    OutputLine("");
 
-    OutputFormat("Rloc: %x\r\n", parentInfo.mRloc16);
-    OutputFormat("Link Quality In: %d\r\n", parentInfo.mLinkQualityIn);
-    OutputFormat("Link Quality Out: %d\r\n", parentInfo.mLinkQualityOut);
-    OutputFormat("Age: %d\r\n", parentInfo.mAge);
+    OutputLine("Rloc: %x", parentInfo.mRloc16);
+    OutputLine("Link Quality In: %d", parentInfo.mLinkQualityIn);
+    OutputLine("Link Quality Out: %d", parentInfo.mLinkQualityOut);
+    OutputLine("Age: %d", parentInfo.mAge);
 
 exit:
     OutputResult(error);
@@ -2642,7 +2641,7 @@ void Interpreter::ProcessParentPriority(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%d\r\n", otThreadGetParentPriority(mInstance));
+        OutputLine("%d", otThreadGetParentPriority(mInstance));
     }
     else
     {
@@ -2685,7 +2684,7 @@ void Interpreter::HandleIcmpReceive(otMessage *          aMessage,
         OutputFormat(" time=%dms", TimerMilli::GetNow().GetValue() - HostSwap32(timestamp));
     }
 
-    OutputFormat("\r\n");
+    OutputLine("");
 
     SignalPingReply(static_cast<const Ip6::MessageInfo *>(aMessageInfo)->GetPeerAddr(), dataSize, HostSwap32(timestamp),
                     aMessageInfo->mHopLimit);
@@ -2815,7 +2814,7 @@ void Interpreter::ProcessPollPeriod(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%d\r\n", otLinkGetPollPeriod(mInstance));
+        OutputLine("%d", otLinkGetPollPeriod(mInstance));
     }
     else
     {
@@ -2835,11 +2834,11 @@ void Interpreter::ProcessPromiscuous(uint8_t aArgsLength, char *aArgs[])
     {
         if (otLinkIsPromiscuous(mInstance) && otPlatRadioGetPromiscuous(mInstance))
         {
-            OutputFormat("Enabled\r\n");
+            OutputLine("Enabled");
         }
         else
         {
-            OutputFormat("Disabled\r\n");
+            OutputLine("Disabled");
         }
     }
     else
@@ -2873,7 +2872,7 @@ void Interpreter::HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx)
 {
     OT_UNUSED_VARIABLE(aIsTx);
 
-    OutputFormat("\r\n");
+    OutputLine("");
 
     for (size_t i = 0; i < 44; i++)
     {
@@ -2887,7 +2886,7 @@ void Interpreter::HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx)
         OutputFormat("=");
     }
 
-    OutputFormat("\r\n");
+    OutputLine("");
 
     for (size_t i = 0; i < aFrame->mLength; i += 16)
     {
@@ -2926,7 +2925,7 @@ void Interpreter::HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx)
             }
         }
 
-        OutputFormat("|\r\n");
+        OutputLine("|");
     }
 
     for (size_t i = 0; i < 83; i++)
@@ -2934,7 +2933,7 @@ void Interpreter::HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx)
         OutputFormat("-");
     }
 
-    OutputFormat("\r\n");
+    OutputLine("");
 }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
@@ -3138,7 +3137,7 @@ void Interpreter::OutputPrefix(otBorderRouterConfig &aConfig)
         break;
     }
 
-    OutputFormat("\r\n");
+    OutputLine("");
 }
 
 otError Interpreter::ProcessPrefixList(void)
@@ -3216,7 +3215,7 @@ void Interpreter::ProcessRcp(uint8_t aArgsLength, char *aArgs[])
 
     if (strcmp(aArgs[0], "version") == 0)
     {
-        OutputFormat("%s\r\n", version);
+        OutputLine("%s", version);
     }
     else
     {
@@ -3256,7 +3255,7 @@ void Interpreter::ProcessRloc16(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    OutputFormat("%04x\r\n", otThreadGetRloc16(mInstance));
+    OutputLine("%04x", otThreadGetRloc16(mInstance));
     OutputResult(OT_ERROR_NONE);
 }
 
@@ -3373,15 +3372,15 @@ otError Interpreter::ProcessRouteList(void)
         switch (config.mPreference)
         {
         case OT_ROUTE_PREFERENCE_LOW:
-            OutputFormat(" low\r\n");
+            OutputLine(" low");
             break;
 
         case OT_ROUTE_PREFERENCE_MED:
-            OutputFormat(" med\r\n");
+            OutputLine(" med");
             break;
 
         case OT_ROUTE_PREFERENCE_HIGH:
-            OutputFormat(" high\r\n");
+            OutputLine(" high");
             break;
         }
     }
@@ -3433,8 +3432,8 @@ void Interpreter::ProcessRouter(uint8_t aArgsLength, char *aArgs[])
 
         if (isTable)
         {
-            OutputFormat("| ID | RLOC16 | Next Hop | Path Cost | LQ In | LQ Out | Age | Extended MAC     |\r\n");
-            OutputFormat("+----+--------+----------+-----------+-------+--------+-----+------------------+\r\n");
+            OutputLine("| ID | RLOC16 | Next Hop | Path Cost | LQ In | LQ Out | Age | Extended MAC     |");
+            OutputLine("+----+--------+----------+-----------+-------+--------+-----+------------------+");
         }
 
         maxRouterId = otThreadGetMaxRouterId(mInstance);
@@ -3462,7 +3461,7 @@ void Interpreter::ProcessRouter(uint8_t aArgsLength, char *aArgs[])
                     OutputFormat("%02x", b);
                 }
 
-                OutputFormat(" |\r\n");
+                OutputLine(" |");
             }
             else
             {
@@ -3470,21 +3469,21 @@ void Interpreter::ProcessRouter(uint8_t aArgsLength, char *aArgs[])
             }
         }
 
-        OutputFormat("\r\n");
+        OutputLine("");
         ExitNow();
     }
 
     SuccessOrExit(error = ParseLong(aArgs[0], value));
     SuccessOrExit(error = otThreadGetRouterInfo(mInstance, static_cast<uint16_t>(value), &routerInfo));
 
-    OutputFormat("Alloc: %d\r\n", routerInfo.mAllocated);
+    OutputLine("Alloc: %d", routerInfo.mAllocated);
 
     if (routerInfo.mAllocated)
     {
-        OutputFormat("Router ID: %d\r\n", routerInfo.mRouterId);
-        OutputFormat("Rloc: %04x\r\n", routerInfo.mRloc16);
-        OutputFormat("Next Hop: %04x\r\n", static_cast<uint16_t>(routerInfo.mNextHop) << 10);
-        OutputFormat("Link: %d\r\n", routerInfo.mLinkEstablished);
+        OutputLine("Router ID: %d", routerInfo.mRouterId);
+        OutputLine("Rloc: %04x", routerInfo.mRloc16);
+        OutputLine("Next Hop: %04x", static_cast<uint16_t>(routerInfo.mNextHop) << 10);
+        OutputLine("Link: %d", routerInfo.mLinkEstablished);
 
         if (routerInfo.mLinkEstablished)
         {
@@ -3495,11 +3494,11 @@ void Interpreter::ProcessRouter(uint8_t aArgsLength, char *aArgs[])
                 OutputFormat("%02x", b);
             }
 
-            OutputFormat("\r\n");
-            OutputFormat("Cost: %d\r\n", routerInfo.mPathCost);
-            OutputFormat("Link Quality In: %d\r\n", routerInfo.mLinkQualityIn);
-            OutputFormat("Link Quality Out: %d\r\n", routerInfo.mLinkQualityOut);
-            OutputFormat("Age: %d\r\n", routerInfo.mAge);
+            OutputLine("");
+            OutputLine("Cost: %d", routerInfo.mPathCost);
+            OutputLine("Link Quality In: %d", routerInfo.mLinkQualityIn);
+            OutputLine("Link Quality Out: %d", routerInfo.mLinkQualityOut);
+            OutputLine("Age: %d", routerInfo.mAge);
         }
     }
 
@@ -3514,7 +3513,7 @@ void Interpreter::ProcessRouterDowngradeThreshold(uint8_t aArgsLength, char *aAr
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%d\r\n", otThreadGetRouterDowngradeThreshold(mInstance));
+        OutputLine("%d", otThreadGetRouterDowngradeThreshold(mInstance));
     }
     else
     {
@@ -3534,11 +3533,11 @@ void Interpreter::ProcessRouterEligible(uint8_t aArgsLength, char *aArgs[])
     {
         if (otThreadIsRouterEligible(mInstance))
         {
-            OutputFormat("Enabled\r\n");
+            OutputLine("Enabled");
         }
         else
         {
-            OutputFormat("Disabled\r\n");
+            OutputLine("Disabled");
         }
     }
     else if (strcmp(aArgs[0], "enable") == 0)
@@ -3565,7 +3564,7 @@ void Interpreter::ProcessRouterSelectionJitter(uint8_t aArgsLength, char *aArgs[
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%d\r\n", otThreadGetRouterSelectionJitter(mInstance));
+        OutputLine("%d", otThreadGetRouterSelectionJitter(mInstance));
     }
     else
     {
@@ -3585,7 +3584,7 @@ void Interpreter::ProcessRouterUpgradeThreshold(uint8_t aArgsLength, char *aArgs
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%d\r\n", otThreadGetRouterUpgradeThreshold(mInstance));
+        OutputLine("%d", otThreadGetRouterUpgradeThreshold(mInstance));
     }
     else
     {
@@ -3629,15 +3628,15 @@ void Interpreter::ProcessScan(uint8_t aArgsLength, char *aArgs[])
 
     if (energyScan)
     {
-        OutputFormat("| Ch | RSSI |\r\n");
-        OutputFormat("+----+------+\r\n");
+        OutputLine("| Ch | RSSI |");
+        OutputLine("+----+------+");
         SuccessOrExit(error = otLinkEnergyScan(mInstance, scanChannels, scanDuration,
                                                &Interpreter::HandleEnergyScanResult, this));
     }
     else
     {
-        OutputFormat("| J | Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |\r\n");
-        OutputFormat("+---+------------------+------------------+------+------------------+----+-----+-----+\r\n");
+        OutputLine("| J | Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |");
+        OutputLine("+---+------------------+------------------+------+------------------+----+-----+-----+");
         SuccessOrExit(error = otLinkActiveScan(mInstance, scanChannels, scanDuration,
                                                &Interpreter::HandleActiveScanResult, this));
     }
@@ -3674,7 +3673,7 @@ void Interpreter::HandleActiveScanResult(otActiveScanResult *aResult)
     OutputBytes(aResult->mExtAddress.m8, OT_EXT_ADDRESS_SIZE);
     OutputFormat(" | %2d ", aResult->mChannel);
     OutputFormat("| %3d ", aResult->mRssi);
-    OutputFormat("| %3d |\r\n", aResult->mLqi);
+    OutputLine("| %3d |", aResult->mLqi);
 
 exit:
     return;
@@ -3693,7 +3692,7 @@ void Interpreter::HandleEnergyScanResult(otEnergyScanResult *aResult)
         ExitNow();
     }
 
-    OutputFormat("| %2d | %4d |\r\n", aResult->mChannel, aResult->mMaxRssi);
+    OutputLine("| %2d | %4d |", aResult->mChannel, aResult->mMaxRssi);
 
 exit:
     return;
@@ -3708,11 +3707,11 @@ void Interpreter::ProcessSingleton(uint8_t aArgsLength, char *aArgs[])
 
     if (otThreadIsSingleton(mInstance))
     {
-        OutputFormat("true\r\n");
+        OutputLine("true");
     }
     else
     {
-        OutputFormat("false\r\n");
+        OutputLine("false");
     }
 
     OutputResult(error);
@@ -3778,12 +3777,12 @@ void Interpreter::HandleSntpResponse(uint64_t aTime, otError aResult)
     {
         // Some Embedded C libraries do not support printing of 64-bit unsigned integers.
         // To simplify, unix epoch time and era number are printed separately.
-        OutputFormat("SNTP response - Unix time: %u (era: %u)\r\n", static_cast<uint32_t>(aTime),
-                     static_cast<uint32_t>(aTime >> 32));
+        OutputLine("SNTP response - Unix time: %u (era: %u)", static_cast<uint32_t>(aTime),
+                   static_cast<uint32_t>(aTime >> 32));
     }
     else
     {
-        OutputFormat("SNTP error - %s\r\n", otThreadErrorToString(aResult));
+        OutputLine("SNTP error - %s", otThreadErrorToString(aResult));
     }
 
     mSntpQueryingInProgress = false;
@@ -3801,29 +3800,29 @@ void Interpreter::ProcessState(uint8_t aArgsLength, char *aArgs[])
         switch (otThreadGetDeviceRole(mInstance))
         {
         case OT_DEVICE_ROLE_DISABLED:
-            OutputFormat("disabled\r\n");
+            OutputLine("disabled");
             break;
 
         case OT_DEVICE_ROLE_DETACHED:
-            OutputFormat("detached\r\n");
+            OutputLine("detached");
             break;
 
         case OT_DEVICE_ROLE_CHILD:
-            OutputFormat("child\r\n");
+            OutputLine("child");
             break;
 
 #if OPENTHREAD_FTD
         case OT_DEVICE_ROLE_ROUTER:
-            OutputFormat("router\r\n");
+            OutputLine("router");
             break;
 
         case OT_DEVICE_ROLE_LEADER:
-            OutputFormat("leader\r\n");
+            OutputLine("leader");
             break;
 #endif
 
         default:
-            OutputFormat("invalid state\r\n");
+            OutputLine("invalid state");
             break;
         }
     }
@@ -3877,7 +3876,7 @@ void Interpreter::ProcessThread(uint8_t aArgsLength, char *aArgs[])
     }
     else if (strcmp(aArgs[0], "version") == 0)
     {
-        OutputFormat("%u\r\n", otThreadGetVersion());
+        OutputLine("%u", otThreadGetVersion());
     }
     else
     {
@@ -3904,7 +3903,7 @@ void Interpreter::ProcessTxPower(uint8_t aArgsLength, char *aArgs[])
         int8_t power;
 
         SuccessOrExit(error = otPlatRadioGetTransmitPower(mInstance, &power));
-        OutputFormat("%d dBm\r\n", power);
+        OutputLine("%d dBm", power);
     }
     else
     {
@@ -3972,7 +3971,7 @@ void Interpreter::ProcessUnsecurePort(uint8_t aArgsLength, char *aArgs[])
             }
         }
 
-        OutputFormat("\r\n");
+        OutputLine("");
     }
     else
     {
@@ -3989,7 +3988,7 @@ void Interpreter::ProcessVersion(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgs);
 
     const char *version = otGetVersionString();
-    OutputFormat("%s\r\n", static_cast<const char *>(version));
+    OutputLine("%s", static_cast<const char *>(version));
     OutputResult(OT_ERROR_NONE);
 }
 
@@ -4023,7 +4022,7 @@ void Interpreter::ProcessJoinerPort(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputFormat("%d\r\n", otThreadGetJoinerUdpPort(mInstance));
+        OutputLine("%d", otThreadGetJoinerUdpPort(mInstance));
     }
     else
     {
@@ -4072,15 +4071,15 @@ void Interpreter::PrintMacFilter(void)
 
     if (mode == OT_MAC_FILTER_ADDRESS_MODE_DISABLED)
     {
-        OutputFormat("Address Mode: Disabled\r\n");
+        OutputLine("Address Mode: Disabled");
     }
     else if (mode == OT_MAC_FILTER_ADDRESS_MODE_ALLOWLIST)
     {
-        OutputFormat("Address Mode: Allowlist\r\n");
+        OutputLine("Address Mode: Allowlist");
     }
     else if (mode == OT_MAC_FILTER_ADDRESS_MODE_DENYLIST)
     {
-        OutputFormat("Address Mode: Denylist\r\n");
+        OutputLine("Address Mode: Denylist");
     }
 
     while (otLinkFilterGetNextAddress(mInstance, &iterator, &entry) == OT_ERROR_NONE)
@@ -4092,11 +4091,11 @@ void Interpreter::PrintMacFilter(void)
             OutputFormat(" : rss %d (lqi %d)", entry.mRssIn, otLinkConvertRssToLinkQuality(mInstance, entry.mRssIn));
         }
 
-        OutputFormat("\r\n");
+        OutputLine("");
     }
 
     iterator = OT_MAC_FILTER_ITERATOR_INIT;
-    OutputFormat("RssIn List:\r\n");
+    OutputLine("RssIn List:");
 
     while (otLinkFilterGetNextRssIn(mInstance, &iterator, &entry) == OT_ERROR_NONE)
     {
@@ -4112,14 +4111,13 @@ void Interpreter::PrintMacFilter(void)
 
         if (i == OT_EXT_ADDRESS_SIZE)
         {
-            OutputFormat("Default rss : %d (lqi %d)\r\n", entry.mRssIn,
-                         otLinkConvertRssToLinkQuality(mInstance, entry.mRssIn));
+            OutputLine("Default rss : %d (lqi %d)", entry.mRssIn,
+                       otLinkConvertRssToLinkQuality(mInstance, entry.mRssIn));
         }
         else
         {
             OutputBytes(entry.mExtAddress.m8, OT_EXT_ADDRESS_SIZE);
-            OutputFormat(" : rss %d (lqi %d)\r\n", entry.mRssIn,
-                         otLinkConvertRssToLinkQuality(mInstance, entry.mRssIn));
+            OutputLine(" : rss %d (lqi %d)", entry.mRssIn, otLinkConvertRssToLinkQuality(mInstance, entry.mRssIn));
         }
     }
 }
@@ -4137,15 +4135,15 @@ otError Interpreter::ProcessMacFilterAddress(uint8_t aArgsLength, char *aArgs[])
     {
         if (mode == OT_MAC_FILTER_ADDRESS_MODE_DISABLED)
         {
-            OutputFormat("Disabled\r\n");
+            OutputLine("Disabled");
         }
         else if (mode == OT_MAC_FILTER_ADDRESS_MODE_ALLOWLIST)
         {
-            OutputFormat("Allowlist\r\n");
+            OutputLine("Allowlist");
         }
         else if (mode == OT_MAC_FILTER_ADDRESS_MODE_DENYLIST)
         {
-            OutputFormat("Denylist\r\n");
+            OutputLine("Denylist");
         }
 
         while (otLinkFilterGetNextAddress(mInstance, &iterator, &entry) == OT_ERROR_NONE)
@@ -4158,7 +4156,7 @@ otError Interpreter::ProcessMacFilterAddress(uint8_t aArgsLength, char *aArgs[])
                              otLinkConvertRssToLinkQuality(mInstance, entry.mRssIn));
             }
 
-            OutputFormat("\r\n");
+            OutputLine("");
         }
     }
     else
@@ -4244,14 +4242,13 @@ otError Interpreter::ProcessMacFilterRss(uint8_t aArgsLength, char *aArgs[])
 
             if (i == OT_EXT_ADDRESS_SIZE)
             {
-                OutputFormat("Default rss: %d (lqi %d)\r\n", entry.mRssIn,
-                             otLinkConvertRssToLinkQuality(mInstance, entry.mRssIn));
+                OutputLine("Default rss: %d (lqi %d)", entry.mRssIn,
+                           otLinkConvertRssToLinkQuality(mInstance, entry.mRssIn));
             }
             else
             {
                 OutputBytes(entry.mExtAddress.m8, OT_EXT_ADDRESS_SIZE);
-                OutputFormat(" : rss %d (lqi %d)\r\n", entry.mRssIn,
-                             otLinkConvertRssToLinkQuality(mInstance, entry.mRssIn));
+                OutputLine(" : rss %d (lqi %d)", entry.mRssIn, otLinkConvertRssToLinkQuality(mInstance, entry.mRssIn));
             }
         }
     }
@@ -4357,7 +4354,7 @@ otError Interpreter::ProcessMacRetries(uint8_t aArgsLength, char *aArgs[])
     {
         if (aArgsLength == 1)
         {
-            OutputFormat("%d\r\n", otLinkGetMaxFrameRetriesDirect(mInstance));
+            OutputLine("%d", otLinkGetMaxFrameRetriesDirect(mInstance));
         }
         else
         {
@@ -4374,7 +4371,7 @@ otError Interpreter::ProcessMacRetries(uint8_t aArgsLength, char *aArgs[])
     {
         if (aArgsLength == 1)
         {
-            OutputFormat("%d\r\n", otLinkGetMaxFrameRetriesIndirect(mInstance));
+            OutputLine("%d", otLinkGetMaxFrameRetriesIndirect(mInstance));
         }
         else
         {
@@ -4421,14 +4418,14 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength)
     VerifyOrExit(aBuf != nullptr && StringLength(aBuf, aBufLength + 1) <= aBufLength, OT_NOOP);
 
     VerifyOrExit(Utils::CmdLineParser::ParseCmd(aBuf, aArgsLength, aArgs, kMaxArgs) == OT_ERROR_NONE,
-                 OutputFormat("Error: too many args (max %d)\r\n", kMaxArgs));
-    VerifyOrExit(aArgsLength >= 1, OutputFormat("Error: no given command.\r\n"));
+                 OutputLine("Error: too many args (max %d)", kMaxArgs));
+    VerifyOrExit(aArgsLength >= 1, OutputLine("Error: no given command."));
 
     cmd = aArgs[0];
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
     VerifyOrExit((!otDiagIsEnabled(mInstance) || (strcmp(cmd, "diag") == 0)),
-                 OutputFormat("under diagnostics mode, execute 'diag stop' before running any other commands.\r\n"));
+                 OutputLine("under diagnostics mode, execute 'diag stop' before running any other commands."));
 #endif
 
     for (const Command &command : sCommands)
@@ -4530,7 +4527,7 @@ void Interpreter::HandleDiagnosticGetResponse(const otMessage &aMessage, const I
         bytesPrinted += bytesToPrint;
     }
 
-    OutputFormat("\r\n");
+    OutputLine("");
 
     // Output Network Diagnostic TLV values in standard YAML format.
     while ((error = otThreadGetNextDiagnosticTlv(&aMessage, &iterator, &diagTlv)) == OT_ERROR_NONE)
@@ -4541,57 +4538,57 @@ void Interpreter::HandleDiagnosticGetResponse(const otMessage &aMessage, const I
         case OT_NETWORK_DIAGNOSTIC_TLV_EXT_ADDRESS:
             OutputFormat("Ext Address: '");
             OutputBytes(diagTlv.mData.mExtAddress.m8, sizeof(diagTlv.mData.mExtAddress.m8));
-            OutputFormat("'\r\n");
+            OutputLine("'");
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_SHORT_ADDRESS:
-            OutputFormat("Rloc16: 0x%04x\r\n", diagTlv.mData.mAddr16);
+            OutputLine("Rloc16: 0x%04x", diagTlv.mData.mAddr16);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_MODE:
-            OutputFormat("Mode:\r\n");
+            OutputLine("Mode:");
             OutputMode(diagTlv.mData.mMode, column + kIndentationSize);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_TIMEOUT:
-            OutputFormat("Timeout: %u\r\n", diagTlv.mData.mTimeout);
+            OutputLine("Timeout: %u", diagTlv.mData.mTimeout);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_CONNECTIVITY:
-            OutputFormat("Connectivity:\r\n");
+            OutputLine("Connectivity:");
             OutputConnectivity(diagTlv.mData.mConnectivity, column + kIndentationSize);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_ROUTE:
-            OutputFormat("Route:\r\n");
+            OutputLine("Route:");
             OutputRoute(diagTlv.mData.mRoute, column + kIndentationSize);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_LEADER_DATA:
-            OutputFormat("Leader Data:\r\n");
+            OutputLine("Leader Data:");
             OutputLeaderData(diagTlv.mData.mLeaderData, column + kIndentationSize);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_NETWORK_DATA:
             OutputFormat("Network Data: '");
             OutputBytes(diagTlv.mData.mNetworkData.m8, diagTlv.mData.mNetworkData.mCount);
-            OutputFormat("'\r\n");
+            OutputLine("'");
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_IP6_ADDR_LIST:
-            OutputFormat("IP6 Address List:\r\n");
+            OutputLine("IP6 Address List:");
             for (uint16_t i = 0; i < diagTlv.mData.mIp6AddrList.mCount; ++i)
             {
                 OutputSpaces(column + kIndentationSize);
                 OutputFormat("- ");
                 OutputIp6Address(diagTlv.mData.mIp6AddrList.mList[i]);
-                OutputFormat("\r\n");
+                OutputLine("");
             }
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_MAC_COUNTERS:
-            OutputFormat("MAC Counters:\r\n");
+            OutputLine("MAC Counters:");
             OutputNetworkDiagMacCounters(diagTlv.mData.mMacCounters, column + kIndentationSize);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_BATTERY_LEVEL:
-            OutputFormat("Battery Level: %u%%\r\n", diagTlv.mData.mBatteryLevel);
+            OutputLine("Battery Level: %u%%", diagTlv.mData.mBatteryLevel);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_SUPPLY_VOLTAGE:
-            OutputFormat("Supply Voltage: %umV\r\n", diagTlv.mData.mSupplyVoltage);
+            OutputLine("Supply Voltage: %umV", diagTlv.mData.mSupplyVoltage);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_CHILD_TABLE:
-            OutputFormat("Child Table:\r\n");
+            OutputLine("Child Table:");
             for (uint16_t i = 0; i < diagTlv.mData.mChildTable.mCount; ++i)
             {
                 OutputSpaces(column + kIndentationSize);
@@ -4602,10 +4599,10 @@ void Interpreter::HandleDiagnosticGetResponse(const otMessage &aMessage, const I
         case OT_NETWORK_DIAGNOSTIC_TLV_CHANNEL_PAGES:
             OutputFormat("Channel Pages: '");
             OutputBytes(diagTlv.mData.mChannelPages.m8, diagTlv.mData.mChannelPages.mCount);
-            OutputFormat("'\r\n");
+            OutputLine("'");
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_MAX_CHILD_TIMEOUT:
-            OutputFormat("Max Child Timeout: %u\r\n", diagTlv.mData.mMaxChildTimeout);
+            OutputLine("Max Child Timeout: %u", diagTlv.mData.mMaxChildTimeout);
             break;
         }
     }
@@ -4631,55 +4628,55 @@ void Interpreter::OutputSpaces(uint16_t aCount)
 void Interpreter::OutputMode(const otLinkModeConfig &aMode, uint16_t aColumn)
 {
     OutputSpaces(aColumn);
-    OutputFormat("RxOnWhenIdle: %d\r\n", aMode.mRxOnWhenIdle);
+    OutputLine("RxOnWhenIdle: %d", aMode.mRxOnWhenIdle);
 
     OutputSpaces(aColumn);
-    OutputFormat("SecureDataRequests: %d\r\n", aMode.mSecureDataRequests);
+    OutputLine("SecureDataRequests: %d", aMode.mSecureDataRequests);
 
     OutputSpaces(aColumn);
-    OutputFormat("DeviceType: %d\r\n", aMode.mDeviceType);
+    OutputLine("DeviceType: %d", aMode.mDeviceType);
 
     OutputSpaces(aColumn);
-    OutputFormat("NetworkData: %d\r\n", aMode.mNetworkData);
+    OutputLine("NetworkData: %d", aMode.mNetworkData);
 }
 
 void Interpreter::OutputConnectivity(const otNetworkDiagConnectivity &aConnectivity, uint16_t aColumn)
 {
     OutputSpaces(aColumn);
-    OutputFormat("ParentPriority: %d\r\n", aConnectivity.mParentPriority);
+    OutputLine("ParentPriority: %d", aConnectivity.mParentPriority);
 
     OutputSpaces(aColumn);
-    OutputFormat("LinkQuality3: %u\r\n", aConnectivity.mLinkQuality3);
+    OutputLine("LinkQuality3: %u", aConnectivity.mLinkQuality3);
 
     OutputSpaces(aColumn);
-    OutputFormat("LinkQuality2: %u\r\n", aConnectivity.mLinkQuality2);
+    OutputLine("LinkQuality2: %u", aConnectivity.mLinkQuality2);
 
     OutputSpaces(aColumn);
-    OutputFormat("LinkQuality1: %u\r\n", aConnectivity.mLinkQuality1);
+    OutputLine("LinkQuality1: %u", aConnectivity.mLinkQuality1);
 
     OutputSpaces(aColumn);
-    OutputFormat("LeaderCost: %u\r\n", aConnectivity.mLeaderCost);
+    OutputLine("LeaderCost: %u", aConnectivity.mLeaderCost);
 
     OutputSpaces(aColumn);
-    OutputFormat("IdSequence: %u\r\n", aConnectivity.mIdSequence);
+    OutputLine("IdSequence: %u", aConnectivity.mIdSequence);
 
     OutputSpaces(aColumn);
-    OutputFormat("ActiveRouters: %u\r\n", aConnectivity.mActiveRouters);
+    OutputLine("ActiveRouters: %u", aConnectivity.mActiveRouters);
 
     OutputSpaces(aColumn);
-    OutputFormat("SedBufferSize: %u\r\n", aConnectivity.mSedBufferSize);
+    OutputLine("SedBufferSize: %u", aConnectivity.mSedBufferSize);
 
     OutputSpaces(aColumn);
-    OutputFormat("SedDatagramCount: %u\r\n", aConnectivity.mSedDatagramCount);
+    OutputLine("SedDatagramCount: %u", aConnectivity.mSedDatagramCount);
 }
 
 void Interpreter::OutputRoute(const otNetworkDiagRoute &aRoute, uint16_t aColumn)
 {
     OutputSpaces(aColumn);
-    OutputFormat("IdSequence: %u\r\n", aRoute.mIdSequence);
+    OutputLine("IdSequence: %u", aRoute.mIdSequence);
 
     OutputSpaces(aColumn);
-    OutputFormat("RouteData:\r\n");
+    OutputLine("RouteData:");
 
     aColumn += kIndentationSize;
     for (uint16_t i = 0; i < aRoute.mRouteCount; ++i)
@@ -4693,75 +4690,75 @@ void Interpreter::OutputRoute(const otNetworkDiagRoute &aRoute, uint16_t aColumn
 
 void Interpreter::OutputRouteData(const otNetworkDiagRouteData &aRouteData, uint16_t aColumn)
 {
-    OutputFormat("RouteId: 0x%02x\r\n", aRouteData.mRouterId);
+    OutputLine("RouteId: 0x%02x", aRouteData.mRouterId);
 
     OutputSpaces(aColumn);
-    OutputFormat("LinkQualityOut: %u\r\n", aRouteData.mLinkQualityOut);
+    OutputLine("LinkQualityOut: %u", aRouteData.mLinkQualityOut);
 
     OutputSpaces(aColumn);
-    OutputFormat("LinkQualityIn: %u\r\n", aRouteData.mLinkQualityIn);
+    OutputLine("LinkQualityIn: %u", aRouteData.mLinkQualityIn);
 
     OutputSpaces(aColumn);
-    OutputFormat("RouteCost: %u\r\n", aRouteData.mRouteCost);
+    OutputLine("RouteCost: %u", aRouteData.mRouteCost);
 }
 
 void Interpreter::OutputLeaderData(const otLeaderData &aLeaderData, uint16_t aColumn)
 {
     OutputSpaces(aColumn);
-    OutputFormat("PartitionId: 0x%08x\r\n", aLeaderData.mPartitionId);
+    OutputLine("PartitionId: 0x%08x", aLeaderData.mPartitionId);
 
     OutputSpaces(aColumn);
-    OutputFormat("Weighting: %u\r\n", aLeaderData.mWeighting);
+    OutputLine("Weighting: %u", aLeaderData.mWeighting);
 
     OutputSpaces(aColumn);
-    OutputFormat("DataVersion: %u\r\n", aLeaderData.mDataVersion);
+    OutputLine("DataVersion: %u", aLeaderData.mDataVersion);
 
     OutputSpaces(aColumn);
-    OutputFormat("StableDataVersion: %u\r\n", aLeaderData.mStableDataVersion);
+    OutputLine("StableDataVersion: %u", aLeaderData.mStableDataVersion);
 
     OutputSpaces(aColumn);
-    OutputFormat("LeaderRouterId: 0x%02x\r\n", aLeaderData.mLeaderRouterId);
+    OutputLine("LeaderRouterId: 0x%02x", aLeaderData.mLeaderRouterId);
 }
 
 void Interpreter::OutputNetworkDiagMacCounters(const otNetworkDiagMacCounters &aMacCounters, uint16_t aColumn)
 {
     OutputSpaces(aColumn);
-    OutputFormat("IfInUnknownProtos: %u\r\n", aMacCounters.mIfInUnknownProtos);
+    OutputLine("IfInUnknownProtos: %u", aMacCounters.mIfInUnknownProtos);
 
     OutputSpaces(aColumn);
-    OutputFormat("IfInErrors: %u\r\n", aMacCounters.mIfInErrors);
+    OutputLine("IfInErrors: %u", aMacCounters.mIfInErrors);
 
     OutputSpaces(aColumn);
-    OutputFormat("IfOutErrors: %u\r\n", aMacCounters.mIfOutErrors);
+    OutputLine("IfOutErrors: %u", aMacCounters.mIfOutErrors);
 
     OutputSpaces(aColumn);
-    OutputFormat("IfInUcastPkts: %u\r\n", aMacCounters.mIfInUcastPkts);
+    OutputLine("IfInUcastPkts: %u", aMacCounters.mIfInUcastPkts);
 
     OutputSpaces(aColumn);
-    OutputFormat("IfInBroadcastPkts: %u\r\n", aMacCounters.mIfInBroadcastPkts);
+    OutputLine("IfInBroadcastPkts: %u", aMacCounters.mIfInBroadcastPkts);
 
     OutputSpaces(aColumn);
-    OutputFormat("IfInDiscards: %u\r\n", aMacCounters.mIfInDiscards);
+    OutputLine("IfInDiscards: %u", aMacCounters.mIfInDiscards);
 
     OutputSpaces(aColumn);
-    OutputFormat("IfOutUcastPkts: %u\r\n", aMacCounters.mIfOutUcastPkts);
+    OutputLine("IfOutUcastPkts: %u", aMacCounters.mIfOutUcastPkts);
 
     OutputSpaces(aColumn);
-    OutputFormat("IfOutBroadcastPkts: %u\r\n", aMacCounters.mIfOutBroadcastPkts);
+    OutputLine("IfOutBroadcastPkts: %u", aMacCounters.mIfOutBroadcastPkts);
 
     OutputSpaces(aColumn);
-    OutputFormat("IfOutDiscards: %u\r\n", aMacCounters.mIfOutDiscards);
+    OutputLine("IfOutDiscards: %u", aMacCounters.mIfOutDiscards);
 }
 
 void Interpreter::OutputChildTableEntry(const otNetworkDiagChildEntry &aChildEntry, uint16_t aColumn)
 {
-    OutputFormat("ChildId: 0x%04x\r\n", aChildEntry.mChildId);
+    OutputLine("ChildId: 0x%04x", aChildEntry.mChildId);
 
     OutputSpaces(aColumn);
-    OutputFormat("Timeout: %u\r\n", aChildEntry.mTimeout);
+    OutputLine("Timeout: %u", aChildEntry.mTimeout);
 
     OutputSpaces(aColumn);
-    OutputFormat("Mode:\r\n");
+    OutputLine("Mode:");
 
     OutputMode(aChildEntry.mMode, aColumn + kIndentationSize);
 }
@@ -4819,7 +4816,7 @@ void Interpreter::HandleDiscoveryRequest(const otThreadDiscoveryRequestInfo &aIn
 {
     OutputFormat("~ Discovery Request from ");
     OutputBytes(aInfo.mExtAddress.m8, sizeof(aInfo.mExtAddress.m8));
-    OutputFormat(": version=%u,joiner=%d\r\n", aInfo.mVersion, aInfo.mIsJoiner);
+    OutputLine(": version=%u,joiner=%d", aInfo.mVersion, aInfo.mIsJoiner);
 }
 
 int Interpreter::OutputFormat(const char *aFormat, ...)
@@ -4832,6 +4829,17 @@ int Interpreter::OutputFormat(const char *aFormat, ...)
     va_end(ap);
 
     return rval;
+}
+
+void Interpreter::OutputLine(const char *aFormat, ...)
+{
+    va_list args;
+
+    va_start(args, aFormat);
+    OutputFormatV(aFormat, args);
+    va_end(args);
+
+    OutputFormat("\r\n");
 }
 
 int Interpreter::OutputFormatV(const char *aFormat, va_list aArguments)
@@ -4879,7 +4887,7 @@ extern "C" void otCliPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, cons
     VerifyOrExit(Interpreter::IsInitialized(), OT_NOOP);
 
     Interpreter::GetInterpreter().OutputFormatV(aFormat, aArgs);
-    Interpreter::GetInterpreter().OutputFormat("\r\n");
+    Interpreter::GetInterpreter().OutputLine("");
 exit:
     return;
 }

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -102,158 +102,7 @@ namespace ot {
 
 namespace Cli {
 
-const Interpreter::Command Interpreter::sCommands[] = {
-#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-    {"bbr", &Interpreter::ProcessBackboneRouter},
-#endif
-    {"bufferinfo", &Interpreter::ProcessBufferInfo},
-    {"channel", &Interpreter::ProcessChannel},
-#if OPENTHREAD_FTD
-    {"child", &Interpreter::ProcessChild},
-    {"childip", &Interpreter::ProcessChildIp},
-    {"childmax", &Interpreter::ProcessChildMax},
-#endif
-    {"childtimeout", &Interpreter::ProcessChildTimeout},
-#if OPENTHREAD_CONFIG_COAP_API_ENABLE
-    {"coap", &Interpreter::ProcessCoap},
-#endif
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-    {"coaps", &Interpreter::ProcessCoapSecure},
-#endif
-#if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
-    {"coex", &Interpreter::ProcessCoexMetrics},
-#endif
-#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-    {"commissioner", &Interpreter::ProcessCommissioner},
-#endif
-#if OPENTHREAD_FTD
-    {"contextreusedelay", &Interpreter::ProcessContextIdReuseDelay},
-#endif
-    {"counters", &Interpreter::ProcessCounters},
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    {"csl", &Interpreter::ProcessCsl},
-#endif
-    {"dataset", &Interpreter::ProcessDataset},
-#if OPENTHREAD_FTD
-    {"delaytimermin", &Interpreter::ProcessDelayTimerMin},
-#endif
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
-    {"diag", &Interpreter::ProcessDiag},
-#endif
-    {"discover", &Interpreter::ProcessDiscover},
-#if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
-    {"dns", &Interpreter::ProcessDns},
-#endif
-#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-    {"domainname", &Interpreter::ProcessDomainName},
-#endif
-#if OPENTHREAD_CONFIG_DUA_ENABLE
-    {"dua", &Interpreter::ProcessDua},
-#endif
-#if OPENTHREAD_FTD
-    {"eidcache", &Interpreter::ProcessEidCache},
-#endif
-    {"eui64", &Interpreter::ProcessEui64},
-#if OPENTHREAD_POSIX
-    {"exit", &Interpreter::ProcessExit},
-#endif
-    {"log", &Interpreter::ProcessLog},
-    {"extaddr", &Interpreter::ProcessExtAddress},
-    {"extpanid", &Interpreter::ProcessExtPanId},
-    {"factoryreset", &Interpreter::ProcessFactoryReset},
-    {"help", &Interpreter::ProcessHelp},
-    {"ifconfig", &Interpreter::ProcessIfconfig},
-    {"ipaddr", &Interpreter::ProcessIpAddr},
-    {"ipmaddr", &Interpreter::ProcessIpMulticastAddr},
-#if OPENTHREAD_CONFIG_JOINER_ENABLE
-    {"joiner", &Interpreter::ProcessJoiner},
-#endif
-#if OPENTHREAD_FTD
-    {"joinerport", &Interpreter::ProcessJoinerPort},
-#endif
-    {"keysequence", &Interpreter::ProcessKeySequence},
-    {"leaderdata", &Interpreter::ProcessLeaderData},
-#if OPENTHREAD_FTD
-    {"leaderpartitionid", &Interpreter::ProcessLeaderPartitionId},
-    {"leaderweight", &Interpreter::ProcessLeaderWeight},
-#endif
-    {"mac", &Interpreter::ProcessMac},
-#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
-    {"macfilter", &Interpreter::ProcessMacFilter},
-#endif
-    {"masterkey", &Interpreter::ProcessMasterKey},
-#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-    {"mlr", &Interpreter::ProcessMlr},
-#endif
-    {"mode", &Interpreter::ProcessMode},
-#if OPENTHREAD_FTD
-    {"neighbor", &Interpreter::ProcessNeighbor},
-#endif
-    {"netdata", &Interpreter::ProcessNetworkData},
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    {"netdataregister", &Interpreter::ProcessNetworkDataRegister},
-#endif
-    {"netdatashow", &Interpreter::ProcessNetworkDataShow},
-#if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
-    {"netif", &Interpreter::ProcessNetif},
-#endif
-    {"netstat", &Interpreter::ProcessNetstat},
-#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
-    {"networkdiagnostic", &Interpreter::ProcessNetworkDiagnostic},
-#endif
-#if OPENTHREAD_FTD
-    {"networkidtimeout", &Interpreter::ProcessNetworkIdTimeout},
-#endif
-    {"networkname", &Interpreter::ProcessNetworkName},
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    {"networktime", &Interpreter::ProcessNetworkTime},
-#endif
-    {"panid", &Interpreter::ProcessPanId},
-    {"parent", &Interpreter::ProcessParent},
-#if OPENTHREAD_FTD
-    {"parentpriority", &Interpreter::ProcessParentPriority},
-#endif
-    {"ping", &Interpreter::ProcessPing},
-    {"pollperiod", &Interpreter::ProcessPollPeriod},
-    {"promiscuous", &Interpreter::ProcessPromiscuous},
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
-    {"prefix", &Interpreter::ProcessPrefix},
-#endif
-#if OPENTHREAD_FTD
-    {"preferrouterid", &Interpreter::ProcessPreferRouterId},
-    {"pskc", &Interpreter::ProcessPskc},
-#endif
-    {"rcp", &Interpreter::ProcessRcp},
-#if OPENTHREAD_FTD
-    {"releaserouterid", &Interpreter::ProcessReleaseRouterId},
-#endif
-    {"reset", &Interpreter::ProcessReset},
-    {"rloc16", &Interpreter::ProcessRloc16},
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
-    {"route", &Interpreter::ProcessRoute},
-#endif
-#if OPENTHREAD_FTD
-    {"router", &Interpreter::ProcessRouter},
-    {"routerdowngradethreshold", &Interpreter::ProcessRouterDowngradeThreshold},
-    {"routereligible", &Interpreter::ProcessRouterEligible},
-    {"routerselectionjitter", &Interpreter::ProcessRouterSelectionJitter},
-    {"routerupgradethreshold", &Interpreter::ProcessRouterUpgradeThreshold},
-#endif
-    {"scan", &Interpreter::ProcessScan},
-#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    {"service", &Interpreter::ProcessService},
-#endif
-    {"singleton", &Interpreter::ProcessSingleton},
-#if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
-    {"sntp", &Interpreter::ProcessSntp},
-#endif
-    {"state", &Interpreter::ProcessState},
-    {"thread", &Interpreter::ProcessThread},
-    {"txpower", &Interpreter::ProcessTxPower},
-    {"udp", &Interpreter::ProcessUdp},
-    {"unsecureport", &Interpreter::ProcessUnsecurePort},
-    {"version", &Interpreter::ProcessVersion},
-};
+constexpr Interpreter::Command Interpreter::sCommands[];
 
 Interpreter *Interpreter::sInterpreter = nullptr;
 
@@ -482,6 +331,8 @@ void Interpreter::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
+
+    static_assert(IsArraySorted(sCommands, OT_ARRAY_LENGTH(sCommands)), "Command list is not sorted");
 
     for (const Command &command : sCommands)
     {
@@ -4409,11 +4260,41 @@ void Interpreter::ProcessDiag(uint8_t aArgsLength, char *aArgs[])
 }
 #endif
 
+const Interpreter::Command *Interpreter::FindCommand(const char *aName) const
+{
+    const Command *rval  = nullptr;
+    uint16_t       left  = 0;
+    uint16_t       right = OT_ARRAY_LENGTH(sCommands);
+
+    while (left < right)
+    {
+        uint16_t middle  = (left + right) / 2;
+        int      compare = strcmp(aName, sCommands[middle].mName);
+
+        if (compare == 0)
+        {
+            rval = &sCommands[middle];
+            break;
+        }
+        else if (compare > 0)
+        {
+            left = middle + 1;
+        }
+        else
+        {
+            right = middle;
+        }
+    }
+
+    return rval;
+}
+
 void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength)
 {
-    char *  aArgs[kMaxArgs] = {nullptr};
-    char *  cmd;
-    uint8_t aArgsLength = 0;
+    char *         aArgs[kMaxArgs] = {nullptr};
+    char *         cmdName;
+    uint8_t        aArgsLength = 0;
+    const Command *command;
 
     VerifyOrExit(aBuf != nullptr && StringLength(aBuf, aBufLength + 1) <= aBufLength, OT_NOOP);
 
@@ -4421,26 +4302,25 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength)
                  OutputLine("Error: too many args (max %d)", kMaxArgs));
     VerifyOrExit(aArgsLength >= 1, OutputLine("Error: no given command."));
 
-    cmd = aArgs[0];
+    cmdName = aArgs[0];
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-    VerifyOrExit((!otDiagIsEnabled(mInstance) || (strcmp(cmd, "diag") == 0)),
+    VerifyOrExit((!otDiagIsEnabled(mInstance) || (strcmp(cmdName, "diag") == 0)),
                  OutputLine("under diagnostics mode, execute 'diag stop' before running any other commands."));
 #endif
 
-    for (const Command &command : sCommands)
+    command = FindCommand(cmdName);
+
+    if (command != nullptr)
     {
-        if (strcmp(cmd, command.mName) == 0)
-        {
-            (this->*command.mCommand)(aArgsLength - 1, &aArgs[1]);
-            ExitNow();
-        }
+        (this->*command->mCommand)(aArgsLength - 1, &aArgs[1]);
+        ExitNow();
     }
 
     // Check user defined commands if built-in command has not been found
     for (uint8_t i = 0; i < mUserCommandsLength; i++)
     {
-        if (strcmp(cmd, mUserCommands[i].mName) == 0)
+        if (strcmp(cmdName, mUserCommands[i].mName) == 0)
         {
             mUserCommands[i].mCommand(aArgsLength - 1, &aArgs[1]);
             ExitNow();

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -104,7 +104,7 @@ namespace ot {
 
 namespace Cli {
 
-const struct Command Interpreter::sCommands[] = {
+const Interpreter::Command Interpreter::sCommands[] = {
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
     {"bbr", &Interpreter::ProcessBackboneRouter},
 #endif

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -98,8 +98,6 @@
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;
 
-#define INDENT_SIZE (4)
-
 namespace ot {
 
 namespace Cli {
@@ -4564,22 +4562,22 @@ void Interpreter::HandleDiagnosticGetResponse(const otMessage &aMessage, const I
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_MODE:
             OutputFormat("Mode:\r\n");
-            OutputMode(diagTlv.mData.mMode, column + INDENT_SIZE);
+            OutputMode(diagTlv.mData.mMode, column + kIndentationSize);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_TIMEOUT:
             OutputFormat("Timeout: %u\r\n", diagTlv.mData.mTimeout);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_CONNECTIVITY:
             OutputFormat("Connectivity:\r\n");
-            OutputConnectivity(diagTlv.mData.mConnectivity, column + INDENT_SIZE);
+            OutputConnectivity(diagTlv.mData.mConnectivity, column + kIndentationSize);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_ROUTE:
             OutputFormat("Route:\r\n");
-            OutputRoute(diagTlv.mData.mRoute, column + INDENT_SIZE);
+            OutputRoute(diagTlv.mData.mRoute, column + kIndentationSize);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_LEADER_DATA:
             OutputFormat("Leader Data:\r\n");
-            OutputLeaderData(diagTlv.mData.mLeaderData, column + INDENT_SIZE);
+            OutputLeaderData(diagTlv.mData.mLeaderData, column + kIndentationSize);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_NETWORK_DATA:
             OutputFormat("Network Data: '");
@@ -4590,7 +4588,7 @@ void Interpreter::HandleDiagnosticGetResponse(const otMessage &aMessage, const I
             OutputFormat("IP6 Address List:\r\n");
             for (uint16_t i = 0; i < diagTlv.mData.mIp6AddrList.mCount; ++i)
             {
-                OutputSpaces(column + INDENT_SIZE);
+                OutputSpaces(column + kIndentationSize);
                 OutputFormat("- ");
                 OutputIp6Address(diagTlv.mData.mIp6AddrList.mList[i]);
                 OutputFormat("\r\n");
@@ -4598,7 +4596,7 @@ void Interpreter::HandleDiagnosticGetResponse(const otMessage &aMessage, const I
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_MAC_COUNTERS:
             OutputFormat("MAC Counters:\r\n");
-            OutputNetworkDiagMacCounters(diagTlv.mData.mMacCounters, column + INDENT_SIZE);
+            OutputNetworkDiagMacCounters(diagTlv.mData.mMacCounters, column + kIndentationSize);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_BATTERY_LEVEL:
             OutputFormat("Battery Level: %u%%\r\n", diagTlv.mData.mBatteryLevel);
@@ -4610,9 +4608,9 @@ void Interpreter::HandleDiagnosticGetResponse(const otMessage &aMessage, const I
             OutputFormat("Child Table:\r\n");
             for (uint16_t i = 0; i < diagTlv.mData.mChildTable.mCount; ++i)
             {
-                OutputSpaces(column + INDENT_SIZE);
+                OutputSpaces(column + kIndentationSize);
                 OutputFormat("- ");
-                OutputChildTableEntry(diagTlv.mData.mChildTable.mTable[i], column + INDENT_SIZE + 2);
+                OutputChildTableEntry(diagTlv.mData.mChildTable.mTable[i], column + kIndentationSize + 2);
             }
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_CHANNEL_PAGES:
@@ -4697,7 +4695,7 @@ void Interpreter::OutputRoute(const otNetworkDiagRoute &aRoute, uint16_t aColumn
     OutputSpaces(aColumn);
     OutputFormat("RouteData:\r\n");
 
-    aColumn += INDENT_SIZE;
+    aColumn += kIndentationSize;
     for (uint16_t i = 0; i < aRoute.mRouteCount; ++i)
     {
         OutputSpaces(aColumn);
@@ -4779,7 +4777,7 @@ void Interpreter::OutputChildTableEntry(const otNetworkDiagChildEntry &aChildEnt
     OutputSpaces(aColumn);
     OutputFormat("Mode:\r\n");
 
-    OutputMode(aChildEntry.mMode, aColumn + INDENT_SIZE);
+    OutputMode(aChildEntry.mMode, aColumn + kIndentationSize);
 }
 #endif // OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -200,7 +200,7 @@ const Interpreter::Command Interpreter::sCommands[] = {
     {"netstat", &Interpreter::ProcessNetstat},
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
     {"networkdiagnostic", &Interpreter::ProcessNetworkDiagnostic},
-#endif // OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
+#endif
 #if OPENTHREAD_FTD
     {"networkidtimeout", &Interpreter::ProcessNetworkIdTimeout},
 #endif
@@ -302,7 +302,7 @@ Interpreter::Interpreter(Instance *aInstance)
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
     memset(mResolvingHostname, 0, sizeof(mResolvingHostname));
-#endif // OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
+#endif
 }
 
 int Interpreter::Hex2Bin(const char *aHex, uint8_t *aBin, uint16_t aBinLength, bool aAllowTruncate)
@@ -1179,26 +1179,22 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
-
 void Interpreter::ProcessCoap(uint8_t aArgsLength, char *aArgs[])
 {
     otError error;
     error = mCoap.Process(aArgsLength, aArgs);
     OutputResult(error);
 }
-
-#endif // OPENTHREAD_CONFIG_COAP_API_ENABLE
+#endif
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-
 void Interpreter::ProcessCoapSecure(uint8_t aArgsLength, char *aArgs[])
 {
     otError error;
     error = mCoapSecure.Process(aArgsLength, aArgs);
     OutputResult(error);
 }
-
-#endif // OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+#endif
 
 #if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
 void Interpreter::ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[])
@@ -1274,7 +1270,7 @@ void Interpreter::ProcessContextIdReuseDelay(uint8_t aArgsLength, char *aArgs[])
 exit:
     OutputResult(error);
 }
-#endif // OPENTHREAD_FTD
+#endif
 
 void Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
 {
@@ -1561,7 +1557,7 @@ void Interpreter::ProcessEidCache(uint8_t aArgsLength, char *aArgs[])
 exit:
     OutputResult(OT_ERROR_NONE);
 }
-#endif // OPENTHREAD_FTD
+#endif
 
 void Interpreter::ProcessEui64(uint8_t aArgsLength, char *aArgs[])
 {
@@ -2497,7 +2493,7 @@ void Interpreter::ProcessNetworkDataRegister(uint8_t aArgsLength, char *aArgs[])
 exit:
     OutputResult(error);
 }
-#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+#endif
 
 #if OPENTHREAD_FTD
 void Interpreter::ProcessNetworkIdTimeout(uint8_t aArgsLength, char *aArgs[])
@@ -2518,7 +2514,7 @@ void Interpreter::ProcessNetworkIdTimeout(uint8_t aArgsLength, char *aArgs[])
 exit:
     OutputResult(error);
 }
-#endif // OPENTHREAD_FTD
+#endif
 
 void Interpreter::ProcessNetworkName(uint8_t aArgsLength, char *aArgs[])
 {
@@ -3817,7 +3813,6 @@ void Interpreter::ProcessState(uint8_t aArgsLength, char *aArgs[])
             break;
 
 #if OPENTHREAD_FTD
-
         case OT_DEVICE_ROLE_ROUTER:
             OutputFormat("router\r\n");
             break;
@@ -3825,7 +3820,7 @@ void Interpreter::ProcessState(uint8_t aArgsLength, char *aArgs[])
         case OT_DEVICE_ROLE_LEADER:
             OutputFormat("leader\r\n");
             break;
-#endif // OPENTHREAD_FTD
+#endif
 
         default:
             OutputFormat("invalid state\r\n");
@@ -3852,8 +3847,7 @@ void Interpreter::ProcessState(uint8_t aArgsLength, char *aArgs[])
         {
             SuccessOrExit(error = otThreadBecomeLeader(mInstance));
         }
-
-#endif // OPENTHREAD_FTD
+#endif
         else
         {
             ExitNow(error = OT_ERROR_INVALID_ARGS);
@@ -4908,4 +4902,4 @@ OT_TOOL_WEAK void otNcpHandleLegacyNodeDidJoin(const otExtAddress *aExtAddr)
 {
     OT_UNUSED_VARIABLE(aExtAddr);
 }
-#endif // OPENTHREAD_CONFIG_LEGACY_ENABLE
+#endif

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -243,6 +243,7 @@ protected:
 private:
     enum
     {
+        kIndentationSize  = 4,
         kMaxArgs          = 32,
         kMaxAutoAddresses = 8,
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -76,18 +76,6 @@ namespace ot {
  */
 namespace Cli {
 
-class Interpreter;
-
-/**
- * This structure represents a CLI command.
- *
- */
-struct Command
-{
-    const char *mName;                                                 ///< A pointer to the command string.
-    void (Interpreter::*mCommand)(uint8_t aArgsLength, char *aArgs[]); ///< A function pointer to process the command.
-};
-
 /**
  * This class implements the CLI interpreter.
  *
@@ -263,6 +251,12 @@ private:
         kDefaultPingCount    = 1,
 
         kMaxLineLength = OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH,
+    };
+
+    struct Command
+    {
+        const char *mName;
+        void (Interpreter::*mCommand)(uint8_t aArgsLength, char *aArgs[]);
     };
 
     otError        ParsePingInterval(const char *aString, uint32_t &aInterval);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -294,10 +294,10 @@ private:
     void ProcessChildTimeout(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
     void ProcessCoap(uint8_t aArgsLength, char *aArgs[]);
-#endif // OPENTHREAD_CONFIG_COAP_API_ENABLE
+#endif
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
     void ProcessCoapSecure(uint8_t aArgsLength, char *aArgs[]);
-#endif // OPENTHREAD_CONFIG_COAP_API_ENABLE
+#endif
 #if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
     void ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[]);
 #endif
@@ -314,7 +314,7 @@ private:
 #endif
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
     void ProcessDiag(uint8_t aArgsLength, char *aArgs[]);
-#endif // OPENTHREAD_CONFIG_DIAG_ENABLE
+#endif
     void ProcessDiscover(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
     void ProcessDns(uint8_t aArgsLength, char *aArgs[]);
@@ -387,7 +387,7 @@ private:
 #endif
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
     void ProcessNetworkDiagnostic(uint8_t aArgsLength, char *aArgs[]);
-#endif // OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
+#endif
 #if OPENTHREAD_FTD
     void ProcessNetworkIdTimeout(uint8_t aArgsLength, char *aArgs[]);
 #endif
@@ -459,7 +459,7 @@ private:
     void    PrintMacFilter(void);
     otError ProcessMacFilterAddress(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessMacFilterRss(uint8_t aArgsLength, char *aArgs[]);
-#endif // OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+#endif
     void    ProcessMac(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessMacRetries(uint8_t aArgsLength, char *aArgs[]);
 
@@ -483,7 +483,7 @@ private:
     void        OutputLeaderData(const otLeaderData &aLeaderData, uint16_t aColumn);
     void        OutputNetworkDiagMacCounters(const otNetworkDiagMacCounters &aMacCounters, uint16_t aColumn);
     void        OutputChildTableEntry(const otNetworkDiagChildEntry &aChildEntry, uint16_t aColumn);
-#endif // OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
+#endif
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
     static void HandleDnsResponse(void *              aContext,

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -166,13 +166,6 @@ public:
     static int Hex2Bin(const char *aHex, uint8_t *aBin, uint16_t aBinLength, bool aAllowTruncate = false);
 
     /**
-     * Write error code the CLI console
-     *
-     * @param[in]  aError Error code value.
-     */
-    void AppendResult(otError aError);
-
-    /**
      * This method delivers raw characters to the client.
      *
      * @param[in]  aBuf        A pointer to a buffer.
@@ -230,10 +223,19 @@ public:
     int OutputIp6Address(const otIp6Address &aAddress);
 
     /**
-     * Set a user command table.
+     * This method delivers a success or error message the client.
+     *
+     * @param[in]  aError  The error code.
+     *
+     */
+    void OutputResult(otError aError);
+
+    /**
+     * This method sets the user command table.
      *
      * @param[in]  aUserCommands  A pointer to an array with user commands.
      * @param[in]  aLength        @p aUserCommands length.
+     *
      */
     void SetUserCommands(const otCliCommand *aCommands, uint8_t aLength);
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -211,6 +211,15 @@ public:
     int OutputFormatV(const char *aFormat, va_list aArguments);
 
     /**
+     * This method delivers formatted output (to which it also appends newline `\r\n`) to the client.
+     *
+     * @param[in]  aFormat  A pointer to the format string.
+     * @param[in]  ...      A variable list of arguments to format.
+     *
+     */
+    void OutputLine(const char *aFormat, ...);
+
+    /**
      * Write an IPv6 address to the CLI console.
      *
      * @param[in]  aAddress  A reference to the IPv6 address.

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -271,6 +271,7 @@ private:
         void (Interpreter::*mCommand)(uint8_t aArgsLength, char *aArgs[]);
     };
 
+    const Command *FindCommand(const char *aName) const;
     otError        ParsePingInterval(const char *aString, uint32_t &aInterval);
     static otError ParseJoinerDiscerner(char *aString, otJoinerDiscerner &aJoinerDiscerner);
     void           ProcessHelp(uint8_t aArgsLength, char *aArgs[]);
@@ -525,18 +526,183 @@ private:
     }
     void HandleDiscoveryRequest(const otThreadDiscoveryRequestInfo &aInfo);
 
-    static const struct Command sCommands[];
-    const otCliCommand *        mUserCommands;
-    uint8_t                     mUserCommandsLength;
-    uint16_t                    mPingLength;
-    uint16_t                    mPingCount;
-    uint32_t                    mPingInterval;
-    uint8_t                     mPingHopLimit;
-    bool                        mPingAllowZeroHopLimit;
-    uint16_t                    mPingIdentifier;
-    otIp6Address                mPingDestAddress;
-    TimerMilli                  mPingTimer;
-    otIcmp6Handler              mIcmpHandler;
+    constexpr static bool AreSorted(const char *aFirst, const char *aSecond)
+    {
+        return (*aFirst < *aSecond) ? true : ((*aFirst > *aSecond) ? false : AreSorted(aFirst + 1, aSecond + 1));
+    }
+
+    constexpr static bool IsArraySorted(const Interpreter::Command *aList, uint16_t aLength)
+    {
+        return (aLength <= 1) ? true
+                              : AreSorted(aList[0].mName, aList[1].mName) && IsArraySorted(aList + 1, aLength - 1);
+    }
+
+    static constexpr Command sCommands[] = {
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+        {"bbr", &Interpreter::ProcessBackboneRouter},
+#endif
+        {"bufferinfo", &Interpreter::ProcessBufferInfo},
+        {"channel", &Interpreter::ProcessChannel},
+#if OPENTHREAD_FTD
+        {"child", &Interpreter::ProcessChild},
+        {"childip", &Interpreter::ProcessChildIp},
+        {"childmax", &Interpreter::ProcessChildMax},
+#endif
+        {"childtimeout", &Interpreter::ProcessChildTimeout},
+#if OPENTHREAD_CONFIG_COAP_API_ENABLE
+        {"coap", &Interpreter::ProcessCoap},
+#endif
+#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+        {"coaps", &Interpreter::ProcessCoapSecure},
+#endif
+#if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
+        {"coex", &Interpreter::ProcessCoexMetrics},
+#endif
+#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
+        {"commissioner", &Interpreter::ProcessCommissioner},
+#endif
+#if OPENTHREAD_FTD
+        {"contextreusedelay", &Interpreter::ProcessContextIdReuseDelay},
+#endif
+        {"counters", &Interpreter::ProcessCounters},
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+        {"csl", &Interpreter::ProcessCsl},
+#endif
+        {"dataset", &Interpreter::ProcessDataset},
+#if OPENTHREAD_FTD
+        {"delaytimermin", &Interpreter::ProcessDelayTimerMin},
+#endif
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+        {"diag", &Interpreter::ProcessDiag},
+#endif
+        {"discover", &Interpreter::ProcessDiscover},
+#if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
+        {"dns", &Interpreter::ProcessDns},
+#endif
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+        {"domainname", &Interpreter::ProcessDomainName},
+#endif
+#if OPENTHREAD_CONFIG_DUA_ENABLE
+        {"dua", &Interpreter::ProcessDua},
+#endif
+#if OPENTHREAD_FTD
+        {"eidcache", &Interpreter::ProcessEidCache},
+#endif
+        {"eui64", &Interpreter::ProcessEui64},
+#if OPENTHREAD_POSIX
+        {"exit", &Interpreter::ProcessExit},
+#endif
+        {"extaddr", &Interpreter::ProcessExtAddress},
+        {"extpanid", &Interpreter::ProcessExtPanId},
+        {"factoryreset", &Interpreter::ProcessFactoryReset},
+        {"help", &Interpreter::ProcessHelp},
+        {"ifconfig", &Interpreter::ProcessIfconfig},
+        {"ipaddr", &Interpreter::ProcessIpAddr},
+        {"ipmaddr", &Interpreter::ProcessIpMulticastAddr},
+#if OPENTHREAD_CONFIG_JOINER_ENABLE
+        {"joiner", &Interpreter::ProcessJoiner},
+#endif
+#if OPENTHREAD_FTD
+        {"joinerport", &Interpreter::ProcessJoinerPort},
+#endif
+        {"keysequence", &Interpreter::ProcessKeySequence},
+        {"leaderdata", &Interpreter::ProcessLeaderData},
+#if OPENTHREAD_FTD
+        {"leaderpartitionid", &Interpreter::ProcessLeaderPartitionId},
+        {"leaderweight", &Interpreter::ProcessLeaderWeight},
+#endif
+        {"log", &Interpreter::ProcessLog},
+        {"mac", &Interpreter::ProcessMac},
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+        {"macfilter", &Interpreter::ProcessMacFilter},
+#endif
+        {"masterkey", &Interpreter::ProcessMasterKey},
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
+        {"mlr", &Interpreter::ProcessMlr},
+#endif
+        {"mode", &Interpreter::ProcessMode},
+#if OPENTHREAD_FTD
+        {"neighbor", &Interpreter::ProcessNeighbor},
+#endif
+        {"netdata", &Interpreter::ProcessNetworkData},
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+        {"netdataregister", &Interpreter::ProcessNetworkDataRegister},
+#endif
+        {"netdatashow", &Interpreter::ProcessNetworkDataShow},
+#if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
+        {"netif", &Interpreter::ProcessNetif},
+#endif
+        {"netstat", &Interpreter::ProcessNetstat},
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
+        {"networkdiagnostic", &Interpreter::ProcessNetworkDiagnostic},
+#endif
+#if OPENTHREAD_FTD
+        {"networkidtimeout", &Interpreter::ProcessNetworkIdTimeout},
+#endif
+        {"networkname", &Interpreter::ProcessNetworkName},
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+        {"networktime", &Interpreter::ProcessNetworkTime},
+#endif
+        {"panid", &Interpreter::ProcessPanId},
+        {"parent", &Interpreter::ProcessParent},
+#if OPENTHREAD_FTD
+        {"parentpriority", &Interpreter::ProcessParentPriority},
+#endif
+        {"ping", &Interpreter::ProcessPing},
+        {"pollperiod", &Interpreter::ProcessPollPeriod},
+#if OPENTHREAD_FTD
+        {"preferrouterid", &Interpreter::ProcessPreferRouterId},
+#endif
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
+        {"prefix", &Interpreter::ProcessPrefix},
+#endif
+        {"promiscuous", &Interpreter::ProcessPromiscuous},
+#if OPENTHREAD_FTD
+        {"pskc", &Interpreter::ProcessPskc},
+#endif
+        {"rcp", &Interpreter::ProcessRcp},
+#if OPENTHREAD_FTD
+        {"releaserouterid", &Interpreter::ProcessReleaseRouterId},
+#endif
+        {"reset", &Interpreter::ProcessReset},
+        {"rloc16", &Interpreter::ProcessRloc16},
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
+        {"route", &Interpreter::ProcessRoute},
+#endif
+#if OPENTHREAD_FTD
+        {"router", &Interpreter::ProcessRouter},
+        {"routerdowngradethreshold", &Interpreter::ProcessRouterDowngradeThreshold},
+        {"routereligible", &Interpreter::ProcessRouterEligible},
+        {"routerselectionjitter", &Interpreter::ProcessRouterSelectionJitter},
+        {"routerupgradethreshold", &Interpreter::ProcessRouterUpgradeThreshold},
+#endif
+        {"scan", &Interpreter::ProcessScan},
+#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+        {"service", &Interpreter::ProcessService},
+#endif
+        {"singleton", &Interpreter::ProcessSingleton},
+#if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
+        {"sntp", &Interpreter::ProcessSntp},
+#endif
+        {"state", &Interpreter::ProcessState},
+        {"thread", &Interpreter::ProcessThread},
+        {"txpower", &Interpreter::ProcessTxPower},
+        {"udp", &Interpreter::ProcessUdp},
+        {"unsecureport", &Interpreter::ProcessUnsecurePort},
+        {"version", &Interpreter::ProcessVersion},
+    };
+
+    const otCliCommand *mUserCommands;
+    uint8_t             mUserCommandsLength;
+    uint16_t            mPingLength;
+    uint16_t            mPingCount;
+    uint32_t            mPingInterval;
+    uint8_t             mPingHopLimit;
+    bool                mPingAllowZeroHopLimit;
+    uint16_t            mPingIdentifier;
+    otIp6Address        mPingDestAddress;
+    TimerMilli          mPingTimer;
+    otIcmp6Handler      mIcmpHandler;
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
     bool mResolvingInProgress;
     char mResolvingHostname[OT_DNS_MAX_HOSTNAME_LENGTH];

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -154,7 +154,7 @@ void Coap::PrintPayload(otMessage *aMessage) const
         }
     }
 
-    mInterpreter.OutputFormat("\r\n");
+    mInterpreter.OutputLine("");
 }
 
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
@@ -174,7 +174,7 @@ otError Coap::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        mInterpreter.OutputFormat("%s\r\n", command.mName);
+        mInterpreter.OutputLine("%s", command.mName);
     }
 
     return OT_ERROR_NONE;
@@ -197,7 +197,7 @@ otError Coap::ProcessResource(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        mInterpreter.OutputFormat("%s\r\n", mResource.mUriPath);
+        mInterpreter.OutputLine("%s", mResource.mUriPath);
     }
 
 exit:
@@ -228,7 +228,7 @@ otError Coap::ProcessSet(uint8_t aArgsLength, char *aArgs[])
 
             mInterpreter.OutputFormat("sending coap notification to ");
             mInterpreter.OutputIp6Address(mSubscriberSock.mAddress);
-            mInterpreter.OutputFormat("\r\n");
+            mInterpreter.OutputLine("");
 
             notificationMessage = otCoapNewMessage(mInterpreter.mInstance, nullptr);
             VerifyOrExit(notificationMessage != nullptr, error = OT_ERROR_NO_BUFS);
@@ -251,7 +251,7 @@ otError Coap::ProcessSet(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        mInterpreter.OutputFormat("%s\r\n", mResourceContent);
+        mInterpreter.OutputLine("%s", mResourceContent);
     }
 
 exit:
@@ -341,16 +341,16 @@ otError Coap::ProcessParameters(uint8_t aArgsLength, char *aArgs[])
         }
     }
 
-    mInterpreter.OutputFormat("Transmission parameters for %s:\r\n", aArgs[1]);
+    mInterpreter.OutputLine("Transmission parameters for %s:", aArgs[1]);
     if (*defaultTxParameters)
     {
-        mInterpreter.OutputFormat("default\r\n");
+        mInterpreter.OutputLine("default");
     }
     else
     {
-        mInterpreter.OutputFormat("ACK_TIMEOUT=%u ms, ACK_RANDOM_FACTOR=%u/%u, MAX_RETRANSMIT=%u\r\n",
-                                  txParameters->mAckTimeout, txParameters->mAckRandomFactorNumerator,
-                                  txParameters->mAckRandomFactorDenominator, txParameters->mMaxRetransmit);
+        mInterpreter.OutputLine("ACK_TIMEOUT=%u ms, ACK_RANDOM_FACTOR=%u/%u, MAX_RETRANSMIT=%u",
+                                txParameters->mAckTimeout, txParameters->mAckRandomFactorNumerator,
+                                txParameters->mAckRandomFactorDenominator, txParameters->mMaxRetransmit);
     }
 
 exit:
@@ -584,7 +584,7 @@ void Coap::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo)
         break;
 
     default:
-        mInterpreter.OutputFormat("Undefined\r\n");
+        mInterpreter.OutputLine("Undefined");
         ExitNow(error = OT_ERROR_PARSE);
     }
 
@@ -610,7 +610,7 @@ void Coap::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo)
                 if (observe == 0)
                 {
                     // New subscriber
-                    mInterpreter.OutputFormat("Subscribing client\r\n");
+                    mInterpreter.OutputLine("Subscribing client");
                     mSubscriberSock.mAddress = aMessageInfo->mPeerAddr;
                     mSubscriberSock.mPort    = aMessageInfo->mPeerPort;
                     mSubscriberTokenLength   = otCoapMessageGetTokenLength(aMessage);
@@ -673,13 +673,13 @@ exit:
     {
         if (responseMessage != nullptr)
         {
-            mInterpreter.OutputFormat("coap send response error %d: %s\r\n", error, otThreadErrorToString(error));
+            mInterpreter.OutputLine("coap send response error %d: %s", error, otThreadErrorToString(error));
             otMessageFree(responseMessage);
         }
     }
     else if (responseCode >= OT_COAP_CODE_RESPONSE_MIN)
     {
-        mInterpreter.OutputFormat("coap response sent\r\n");
+        mInterpreter.OutputLine("coap response sent");
     }
 }
 
@@ -703,13 +703,13 @@ void Coap::HandleNotificationResponse(otMessage *aMessage, const otMessageInfo *
         {
             mInterpreter.OutputFormat("Received ACK in reply to notification from ");
             mInterpreter.OutputIp6Address(aMessageInfo->mPeerAddr);
-            mInterpreter.OutputFormat("\r\n");
+            mInterpreter.OutputLine("");
         }
         break;
 
     default:
-        mInterpreter.OutputFormat("coap receive notification response error %d: %s\r\n", aError,
-                                  otThreadErrorToString(aError));
+        mInterpreter.OutputLine("coap receive notification response error %d: %s", aError,
+                                otThreadErrorToString(aError));
         CancelSubscriber();
         break;
     }
@@ -725,7 +725,7 @@ void Coap::HandleResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo
 {
     if (aError != OT_ERROR_NONE)
     {
-        mInterpreter.OutputFormat("coap receive response error %d: %s\r\n", aError, otThreadErrorToString(aError));
+        mInterpreter.OutputLine("coap receive response error %d: %s", aError, otThreadErrorToString(aError));
     }
     else if ((aMessageInfo != nullptr) && (aMessage != nullptr))
     {

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -97,7 +97,7 @@ void CoapSecure::PrintPayload(otMessage *aMessage) const
         }
     }
 
-    mInterpreter.OutputFormat("\r\n");
+    mInterpreter.OutputLine("");
 }
 
 otError CoapSecure::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
@@ -107,7 +107,7 @@ otError CoapSecure::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        mInterpreter.OutputFormat("%s\r\n", command.mName);
+        mInterpreter.OutputLine("%s", command.mName);
     }
 
     return OT_ERROR_NONE;
@@ -130,7 +130,7 @@ otError CoapSecure::ProcessResource(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        mInterpreter.OutputFormat("%s\r\n", mResource.mUriPath);
+        mInterpreter.OutputLine("%s", mResource.mUriPath);
     }
 
 exit:
@@ -149,7 +149,7 @@ otError CoapSecure::ProcessSet(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        mInterpreter.OutputFormat("%s\r\n", mResourceContent);
+        mInterpreter.OutputLine("%s", mResourceContent);
     }
 
 exit:
@@ -447,11 +447,11 @@ void CoapSecure::HandleConnected(bool aConnected)
 {
     if (aConnected)
     {
-        mInterpreter.OutputFormat("coaps connected\r\n");
+        mInterpreter.OutputLine("coaps connected");
     }
     else
     {
-        mInterpreter.OutputFormat("coaps disconnected\r\n");
+        mInterpreter.OutputLine("coaps disconnected");
 
         if (mShutdownFlag)
         {
@@ -495,7 +495,7 @@ void CoapSecure::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessag
         break;
 
     default:
-        mInterpreter.OutputFormat("Undefined\r\n");
+        mInterpreter.OutputLine("Undefined");
         return;
     }
 
@@ -539,13 +539,13 @@ exit:
     {
         if (responseMessage != nullptr)
         {
-            mInterpreter.OutputFormat("coaps send response error %d: %s\r\n", error, otThreadErrorToString(error));
+            mInterpreter.OutputLine("coaps send response error %d: %s", error, otThreadErrorToString(error));
             otMessageFree(responseMessage);
         }
     }
     else if (responseCode >= OT_COAP_CODE_RESPONSE_MIN)
     {
-        mInterpreter.OutputFormat("coaps response sent\r\n");
+        mInterpreter.OutputLine("coaps response sent");
     }
 }
 
@@ -560,7 +560,7 @@ void CoapSecure::HandleResponse(otMessage *aMessage, const otMessageInfo *aMessa
 
     if (aError != OT_ERROR_NONE)
     {
-        mInterpreter.OutputFormat("coaps receive response error %d: %s\r\n", aError, otThreadErrorToString(aError));
+        mInterpreter.OutputLine("coaps receive response error %d: %s", aError, otThreadErrorToString(aError));
     }
     else
     {

--- a/src/cli/cli_commissioner.cpp
+++ b/src/cli/cli_commissioner.cpp
@@ -56,7 +56,7 @@ otError Commissioner::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        mInterpreter.OutputFormat("%s\r\n", command.mName);
+        mInterpreter.OutputLine("%s", command.mName);
     }
 
     return OT_ERROR_NONE;
@@ -329,7 +329,7 @@ otError Commissioner::ProcessSessionId(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    mInterpreter.OutputFormat("%d\r\n", otCommissionerGetSessionId(mInterpreter.mInstance));
+    mInterpreter.OutputLine("%d", otCommissionerGetSessionId(mInterpreter.mInstance));
 
     return OT_ERROR_NONE;
 }
@@ -350,7 +350,7 @@ void Commissioner::HandleStateChanged(otCommissionerState aState, void *aContext
 
 void Commissioner::HandleStateChanged(otCommissionerState aState)
 {
-    mInterpreter.OutputFormat("Commissioner: %s\r\n", StateToString(aState));
+    mInterpreter.OutputLine("Commissioner: %s", StateToString(aState));
 }
 
 const char *Commissioner::StateToString(otCommissionerState aState)
@@ -413,7 +413,7 @@ void Commissioner::HandleJoinerEvent(otCommissionerJoinerEvent aEvent,
         mInterpreter.OutputBytes(aJoinerId->m8, sizeof(*aJoinerId));
     }
 
-    mInterpreter.OutputFormat("\r\n");
+    mInterpreter.OutputLine("");
 }
 
 otError Commissioner::ProcessStop(uint8_t aArgsLength, char *aArgs[])
@@ -429,7 +429,7 @@ otError Commissioner::ProcessState(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    mInterpreter.OutputFormat("%s\r\n", StateToString(otCommissionerGetState(mInterpreter.mInstance)));
+    mInterpreter.OutputLine("%s", StateToString(otCommissionerGetState(mInterpreter.mInstance)));
 
     return OT_ERROR_NONE;
 }
@@ -474,7 +474,7 @@ void Commissioner::HandleEnergyReport(uint32_t aChannelMask, const uint8_t *aEne
         mInterpreter.OutputFormat("%d ", static_cast<int8_t>(aEnergyList[i]));
     }
 
-    mInterpreter.OutputFormat("\r\n");
+    mInterpreter.OutputLine("");
 }
 
 void Commissioner::HandlePanIdConflict(uint16_t aPanId, uint32_t aChannelMask, void *aContext)
@@ -484,7 +484,7 @@ void Commissioner::HandlePanIdConflict(uint16_t aPanId, uint32_t aChannelMask, v
 
 void Commissioner::HandlePanIdConflict(uint16_t aPanId, uint32_t aChannelMask)
 {
-    mInterpreter.OutputFormat("Conflict: %04x, %08x\r\n", aPanId, aChannelMask);
+    mInterpreter.OutputLine("Conflict: %04x, %08x", aPanId, aChannelMask);
 }
 
 } // namespace Cli

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -82,41 +82,41 @@ otError Dataset::Print(otOperationalDataset &aDataset)
 {
     if (aDataset.mComponents.mIsPendingTimestampPresent)
     {
-        mInterpreter.OutputFormat("Pending Timestamp: %lu\r\n", aDataset.mPendingTimestamp);
+        mInterpreter.OutputLine("Pending Timestamp: %lu", aDataset.mPendingTimestamp);
     }
 
     if (aDataset.mComponents.mIsActiveTimestampPresent)
     {
-        mInterpreter.OutputFormat("Active Timestamp: %lu\r\n", aDataset.mActiveTimestamp);
+        mInterpreter.OutputLine("Active Timestamp: %lu", aDataset.mActiveTimestamp);
     }
 
     if (aDataset.mComponents.mIsChannelPresent)
     {
-        mInterpreter.OutputFormat("Channel: %d\r\n", aDataset.mChannel);
+        mInterpreter.OutputLine("Channel: %d", aDataset.mChannel);
     }
 
     if (aDataset.mComponents.mIsChannelMaskPresent)
     {
-        mInterpreter.OutputFormat("Channel Mask: 0x%08x\r\n", aDataset.mChannelMask);
+        mInterpreter.OutputLine("Channel Mask: 0x%08x", aDataset.mChannelMask);
     }
 
     if (aDataset.mComponents.mIsDelayPresent)
     {
-        mInterpreter.OutputFormat("Delay: %d\r\n", aDataset.mDelay);
+        mInterpreter.OutputLine("Delay: %d", aDataset.mDelay);
     }
 
     if (aDataset.mComponents.mIsExtendedPanIdPresent)
     {
         mInterpreter.OutputFormat("Ext PAN ID: ");
         OutputBytes(aDataset.mExtendedPanId.m8, sizeof(aDataset.mExtendedPanId));
-        mInterpreter.OutputFormat("\r\n");
+        mInterpreter.OutputLine("");
     }
 
     if (aDataset.mComponents.mIsMeshLocalPrefixPresent)
     {
         const uint8_t *prefix = aDataset.mMeshLocalPrefix.m8;
-        mInterpreter.OutputFormat(
-            "Mesh Local Prefix: %x:%x:%x:%x::/64\r\n", (static_cast<uint16_t>(prefix[0]) << 8) | prefix[1],
+        mInterpreter.OutputLine(
+            "Mesh Local Prefix: %x:%x:%x:%x::/64", (static_cast<uint16_t>(prefix[0]) << 8) | prefix[1],
             (static_cast<uint16_t>(prefix[2]) << 8) | prefix[3], (static_cast<uint16_t>(prefix[4]) << 8) | prefix[5],
             (static_cast<uint16_t>(prefix[6]) << 8) | prefix[7]);
     }
@@ -125,26 +125,25 @@ otError Dataset::Print(otOperationalDataset &aDataset)
     {
         mInterpreter.OutputFormat("Master Key: ");
         OutputBytes(aDataset.mMasterKey.m8, sizeof(aDataset.mMasterKey));
-        mInterpreter.OutputFormat("\r\n");
+        mInterpreter.OutputLine("");
     }
 
     if (aDataset.mComponents.mIsNetworkNamePresent)
     {
         mInterpreter.OutputFormat("Network Name: ");
-        mInterpreter.OutputFormat("%.*s\r\n", static_cast<uint16_t>(sizeof(aDataset.mNetworkName)),
-                                  aDataset.mNetworkName.m8);
+        mInterpreter.OutputLine("%.*s", static_cast<uint16_t>(sizeof(aDataset.mNetworkName)), aDataset.mNetworkName.m8);
     }
 
     if (aDataset.mComponents.mIsPanIdPresent)
     {
-        mInterpreter.OutputFormat("PAN ID: 0x%04x\r\n", aDataset.mPanId);
+        mInterpreter.OutputLine("PAN ID: 0x%04x", aDataset.mPanId);
     }
 
     if (aDataset.mComponents.mIsPskcPresent)
     {
         mInterpreter.OutputFormat("PSKc: ");
         OutputBytes(aDataset.mPskc.m8, sizeof(aDataset.mPskc.m8));
-        mInterpreter.OutputFormat("\r\n");
+        mInterpreter.OutputLine("");
     }
 
     if (aDataset.mComponents.mIsSecurityPolicyPresent)
@@ -176,7 +175,7 @@ otError Dataset::Print(otOperationalDataset &aDataset)
             mInterpreter.OutputFormat("b");
         }
 
-        mInterpreter.OutputFormat("\r\n");
+        mInterpreter.OutputLine("");
     }
 
     return OT_ERROR_NONE;
@@ -211,7 +210,7 @@ otError Dataset::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        mInterpreter.OutputFormat("%s\r\n", command.mName);
+        mInterpreter.OutputLine("%s", command.mName);
     }
 
     return OT_ERROR_NONE;
@@ -265,7 +264,7 @@ otError Dataset::ProcessActive(uint8_t aArgsLength, char *aArgs[])
 
         SuccessOrExit(error = otDatasetGetActiveTlvs(mInterpreter.mInstance, &dataset));
         mInterpreter.OutputBytes(dataset.mTlvs, dataset.mLength);
-        mInterpreter.OutputFormat("\r\n");
+        mInterpreter.OutputLine("");
     }
     else
     {
@@ -295,7 +294,7 @@ otError Dataset::ProcessPending(uint8_t aArgsLength, char *aArgs[])
 
         SuccessOrExit(error = otDatasetGetPendingTlvs(mInterpreter.mInstance, &dataset));
         mInterpreter.OutputBytes(dataset.mTlvs, dataset.mLength);
-        mInterpreter.OutputFormat("\r\n");
+        mInterpreter.OutputLine("");
     }
     else
     {
@@ -314,7 +313,7 @@ otError Dataset::ProcessActiveTimestamp(uint8_t aArgsLength, char *aArgs[])
     {
         if (sDataset.mComponents.mIsActiveTimestampPresent)
         {
-            mInterpreter.OutputFormat("%lu\r\n", sDataset.mActiveTimestamp);
+            mInterpreter.OutputLine("%lu", sDataset.mActiveTimestamp);
         }
     }
     else
@@ -338,7 +337,7 @@ otError Dataset::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
     {
         if (sDataset.mComponents.mIsChannelPresent)
         {
-            mInterpreter.OutputFormat("%d\r\n", sDataset.mChannel);
+            mInterpreter.OutputLine("%d", sDataset.mChannel);
         }
     }
     else
@@ -362,7 +361,7 @@ otError Dataset::ProcessChannelMask(uint8_t aArgsLength, char *aArgs[])
     {
         if (sDataset.mComponents.mIsChannelMaskPresent)
         {
-            mInterpreter.OutputFormat("0x%08x\r\n", sDataset.mChannelMask);
+            mInterpreter.OutputLine("0x%08x", sDataset.mChannelMask);
         }
     }
     else
@@ -418,7 +417,7 @@ otError Dataset::ProcessDelay(uint8_t aArgsLength, char *aArgs[])
     {
         if (sDataset.mComponents.mIsDelayPresent)
         {
-            mInterpreter.OutputFormat("%d\r\n", sDataset.mDelay);
+            mInterpreter.OutputLine("%d", sDataset.mDelay);
         }
     }
     else
@@ -443,7 +442,7 @@ otError Dataset::ProcessExtPanId(uint8_t aArgsLength, char *aArgs[])
         if (sDataset.mComponents.mIsExtendedPanIdPresent)
         {
             OutputBytes(sDataset.mExtendedPanId.m8, sizeof(sDataset.mExtendedPanId));
-            mInterpreter.OutputFormat("\r\n");
+            mInterpreter.OutputLine("");
         }
     }
     else
@@ -470,7 +469,7 @@ otError Dataset::ProcessMasterKey(uint8_t aArgsLength, char *aArgs[])
         if (sDataset.mComponents.mIsMasterKeyPresent)
         {
             OutputBytes(sDataset.mMasterKey.m8, sizeof(sDataset.mMasterKey));
-            mInterpreter.OutputFormat("\r\n");
+            mInterpreter.OutputLine("");
         }
     }
     else
@@ -497,11 +496,11 @@ otError Dataset::ProcessMeshLocalPrefix(uint8_t aArgsLength, char *aArgs[])
         if (sDataset.mComponents.mIsMeshLocalPrefixPresent)
         {
             const uint8_t *prefix = sDataset.mMeshLocalPrefix.m8;
-            mInterpreter.OutputFormat("Mesh Local Prefix: %x:%x:%x:%x::/64\r\n",
-                                      (static_cast<uint16_t>(prefix[0]) << 8) | prefix[1],
-                                      (static_cast<uint16_t>(prefix[2]) << 8) | prefix[3],
-                                      (static_cast<uint16_t>(prefix[4]) << 8) | prefix[5],
-                                      (static_cast<uint16_t>(prefix[6]) << 8) | prefix[7]);
+            mInterpreter.OutputLine("Mesh Local Prefix: %x:%x:%x:%x::/64",
+                                    (static_cast<uint16_t>(prefix[0]) << 8) | prefix[1],
+                                    (static_cast<uint16_t>(prefix[2]) << 8) | prefix[3],
+                                    (static_cast<uint16_t>(prefix[4]) << 8) | prefix[5],
+                                    (static_cast<uint16_t>(prefix[6]) << 8) | prefix[7]);
         }
     }
     else
@@ -526,8 +525,8 @@ otError Dataset::ProcessNetworkName(uint8_t aArgsLength, char *aArgs[])
     {
         if (sDataset.mComponents.mIsNetworkNamePresent)
         {
-            mInterpreter.OutputFormat("%.*s\r\n", static_cast<uint16_t>(sizeof(sDataset.mNetworkName)),
-                                      sDataset.mNetworkName.m8);
+            mInterpreter.OutputLine("%.*s", static_cast<uint16_t>(sizeof(sDataset.mNetworkName)),
+                                    sDataset.mNetworkName.m8);
         }
     }
     else
@@ -553,7 +552,7 @@ otError Dataset::ProcessPanId(uint8_t aArgsLength, char *aArgs[])
     {
         if (sDataset.mComponents.mIsPanIdPresent)
         {
-            mInterpreter.OutputFormat("0x%04x\r\n", sDataset.mPanId);
+            mInterpreter.OutputLine("0x%04x", sDataset.mPanId);
         }
     }
     else
@@ -577,7 +576,7 @@ otError Dataset::ProcessPendingTimestamp(uint8_t aArgsLength, char *aArgs[])
     {
         if (sDataset.mComponents.mIsPendingTimestampPresent)
         {
-            mInterpreter.OutputFormat("%lu\r\n", sDataset.mPendingTimestamp);
+            mInterpreter.OutputLine("%lu", sDataset.mPendingTimestamp);
         }
     }
     else
@@ -823,7 +822,7 @@ otError Dataset::ProcessPskc(uint8_t aArgsLength, char *aArgs[])
         if (sDataset.mComponents.mIsPskcPresent)
         {
             OutputBytes(sDataset.mPskc.m8, sizeof(sDataset.mPskc.m8));
-            mInterpreter.OutputFormat("\r\n");
+            mInterpreter.OutputLine("");
         }
     }
     else if (aArgsLength == 1)
@@ -892,7 +891,7 @@ otError Dataset::ProcessSecurityPolicy(uint8_t aArgsLength, char *aArgs[])
                 mInterpreter.OutputFormat("b");
             }
 
-            mInterpreter.OutputFormat("\r\n");
+            mInterpreter.OutputLine("");
         }
     }
     else

--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -73,7 +73,7 @@ otError Joiner::ProcessDiscerner(uint8_t aArgsLength, char *aArgs[])
 
         VerifyOrExit(discerner != nullptr, error = OT_ERROR_NOT_FOUND);
 
-        mInterpreter.OutputFormat("0x%" PRIx64 "/%u\r\n", discerner->mValue, discerner->mLength);
+        mInterpreter.OutputLine("0x%" PRIx64 "/%u", discerner->mValue, discerner->mLength);
     }
     else
     {
@@ -91,7 +91,7 @@ otError Joiner::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        mInterpreter.OutputFormat("%s\r\n", command.mName);
+        mInterpreter.OutputLine("%s", command.mName);
     }
 
     return OT_ERROR_NONE;
@@ -107,7 +107,7 @@ otError Joiner::ProcessId(uint8_t aArgsLength, char *aArgs[])
     joinerId = otJoinerGetId(mInterpreter.mInstance);
 
     mInterpreter.OutputBytes(joinerId->m8, sizeof(otExtAddress));
-    mInterpreter.OutputFormat("\r\n");
+    mInterpreter.OutputLine("");
 
     return OT_ERROR_NONE;
 }
@@ -174,11 +174,11 @@ void Joiner::HandleCallback(otError aError)
     switch (aError)
     {
     case OT_ERROR_NONE:
-        mInterpreter.OutputFormat("Join success\r\n");
+        mInterpreter.OutputLine("Join success");
         break;
 
     default:
-        mInterpreter.OutputFormat("Join failed [%s]\r\n", otThreadErrorToString(aError));
+        mInterpreter.OutputLine("Join failed [%s]", otThreadErrorToString(aError));
         break;
     }
 }

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -66,7 +66,7 @@ otError UdpExample::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        mInterpreter.OutputFormat("%s\r\n", command.mName);
+        mInterpreter.OutputLine("%s", command.mName);
     }
 
     return OT_ERROR_NONE;
@@ -241,7 +241,7 @@ otError UdpExample::ProcessLinkSecurity(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        mInterpreter.OutputFormat("%s\r\n", mLinkSecurityEnabled ? "Enabled" : "Disabled");
+        mInterpreter.OutputLine("%s", mLinkSecurityEnabled ? "Enabled" : "Disabled");
     }
     else if (strcmp(aArgs[0], "enable") == 0)
     {
@@ -327,7 +327,7 @@ void UdpExample::HandleUdpReceive(otMessage *aMessage, const otMessageInfo *aMes
     length      = otMessageRead(aMessage, otMessageGetOffset(aMessage), buf, sizeof(buf) - 1);
     buf[length] = '\0';
 
-    mInterpreter.OutputFormat("%s\r\n", buf);
+    mInterpreter.OutputLine("%s", buf);
 }
 
 } // namespace Cli

--- a/tests/toranj/build.sh
+++ b/tests/toranj/build.sh
@@ -151,7 +151,7 @@ case ${build_config} in
         echo "Building OpenThread (NCP/CLI for FTD/MTD/RCP mode) with simulation platform using cmake"
         echo "===================================================================================================="
         cd "${top_builddir}" || die "cd failed"
-        cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=on -DOT_APP_CLI=off \
+        cmake -GNinja -DOT_PLATFORM=simulation -DOT_COMPILE_WARNING_AS_ERROR=on -DOT_APP_CLI=on \
             -DOT_CONFIG=../tests/toranj/openthread-core-toranj-config-simulation.h \
             "${top_srcdir}" || die
         ninja || die


### PR DESCRIPTION
This commit contains a group of smaller enhancements in `Cli` modules:

- Add and use `OutputLine()` helper method which outputs a formatted 
  string  line (appends newline `\r\n`).
- Use binary search when finding the command in `sCommands` array (also
  adds`static_assert` check to ensure `sCommands` array is sorted).
- Define `Command` struct as a `private` nested type.
- Use `enum` constants (replacing `#define`).
- Rename method to `OutputResult()` (from `AppendReult`) to harmonize
  with rest of a `Output{Something}()` methods.
- Remove comments at `#endif` when within 20 lines of `#if`

--------

I kept the commits separate for easier review but would suggest to squash them all before merge.