### PR TITLE
[continuous-integration] use sudo to kill daemon

### DIFF
--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -41,9 +41,9 @@ at_exit()
     EXIT_CODE=$?
 
     sudo killall expect || true
-    killall ot-ctl || true
-    killall ot-daemon || true
-    killall socat || true
+    sudo killall ot-ctl || true
+    sudo killall ot-daemon || true
+    sudo killall socat || true
 
     exit $EXIT_CODE
 }


### PR DESCRIPTION
This makes kill commands in pty checks run with sudo. Otherwise `ot-daemon` won't be killed and has to exit by itself, which makes `posix-pty-daemon` fail sometimes.