### PR TITLE
[cmake] make UART RAW config visible in daemon mode

### DIFF
--- a/src/posix/CMakeLists.txt
+++ b/src/posix/CMakeLists.txt
@@ -26,6 +26,10 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+target_compile_definitions(ot-config INTERFACE
+    OPENTHREAD_CONFIG_UART_CLI_RAW=1
+)
+
 set(COMMON_INCLUDES
     ${OT_PUBLIC_INCLUDES}
     ${PROJECT_SOURCE_DIR}/src

--- a/src/posix/cli.cmake
+++ b/src/posix/cli.cmake
@@ -26,10 +26,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-target_compile_definitions(ot-config INTERFACE
-    OPENTHREAD_CONFIG_UART_CLI_RAW=1
-)
-
 add_executable(ot-cli
     main.c
     $<$<BOOL:${READLINE}>:console_cli.cpp>


### PR DESCRIPTION
This fixes UART RAW mode not enabled in ot-br-posix.