### PR TITLE
[reference-device] send fake ADDR_NTF.ntf

### DIFF
--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -836,6 +836,23 @@ typedef void (*otThreadDiscoveryRequestCallback)(const otThreadDiscoveryRequestI
 void otThreadSetDiscoveryRequestCallback(otInstance *                     aInstnace,
                                          otThreadDiscoveryRequestCallback aCallback,
                                          void *                           aContext);
+
+/**
+ * This function sends a Proactive Address Notification (ADDR_NTF.ntf) message.
+ *
+ * This function is only available when `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is enabled.
+ *
+ * @param[in]  aInstance     A pointer to an OpenThread instance.
+ * @param[in]  aDestination  The destination to send the ADDR_NTF.ntf message.
+ * @param[in]  aTarget       The target address of the ADDR_NTF.ntf message.
+ * @param[in]  aMlIid        The ML-IID of the ADDR_NTF.ntf message.
+ *
+ */
+void otThreadSendAddressNotification(otInstance *              aInstance,
+                                     otIp6Address *            aDestination,
+                                     otIp6Address *            aTarget,
+                                     otIp6InterfaceIdentifier *aMlIid);
+
 /**
  * @}
  *

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -47,6 +47,7 @@ Done
 - [extaddr](#extaddr)
 - [extpanid](#extpanid)
 - [factoryreset](#factoryreset)
+- [fake](#fake)
 - [ifconfig](#ifconfig)
 - [ipaddr](#ipaddr)
 - [ipmaddr](#ipmaddr)
@@ -805,6 +806,19 @@ Delete all stored settings, and signal a platform reset.
 
 ```bash
 > factoryreset
+```
+
+### fake
+
+Send fake Thread messages.
+
+Note: Only for certification test.
+
+#### fake /a/an \<dst-ipaddr\> \<target\> \<meshLocalIid\>
+
+```bash
+> fake /a/an fdde:ad00:beef:0:0:ff:fe00:a800 fd00:7d03:7d03:7d03:55f2:bb6a:7a43:a03b ::1111:2222:3333:4444
+Done
 ```
 
 ### ifconfig

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -817,7 +817,7 @@ Note: Only for certification test.
 #### fake /a/an \<dst-ipaddr\> \<target\> \<meshLocalIid\>
 
 ```bash
-> fake /a/an fdde:ad00:beef:0:0:ff:fe00:a800 fd00:7d03:7d03:7d03:55f2:bb6a:7a43:a03b ::1111:2222:3333:4444
+> fake /a/an fdde:ad00:beef:0:0:ff:fe00:a800 fd00:7d03:7d03:7d03:55f2:bb6a:7a43:a03b 1111222233334444
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1569,15 +1569,18 @@ otError Interpreter::ProcessFake(uint8_t aArgsLength, char *aArgs[])
 
     if (strcmp(aArgs[0], "/a/an") == 0)
     {
-        otIp6Address destination, target, mlIid;
+        otIp6Address             destination, target;
+        otIp6InterfaceIdentifier mlIid;
 
         VerifyOrExit(aArgsLength == 4, error = OT_ERROR_INVALID_ARGS);
 
         SuccessOrExit(error = otIp6AddressFromString(aArgs[1], &destination));
         SuccessOrExit(error = otIp6AddressFromString(aArgs[2], &target));
-        SuccessOrExit(error = otIp6AddressFromString(aArgs[3], &mlIid));
+        VerifyOrExit(Hex2Bin(aArgs[3], mlIid.mFields.m8, sizeof(otIp6InterfaceIdentifier)) ==
+                         sizeof(otIp6InterfaceIdentifier),
+                     error = OT_ERROR_INVALID_ARGS);
 
-        otThreadSendAddressNotification(mInstance, &destination, &target, &mlIid.mFields.mComponents.mIid);
+        otThreadSendAddressNotification(mInstance, &destination, &target, &mlIid);
     }
 exit:
     return error;

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1560,6 +1560,30 @@ otError Interpreter::ProcessFactoryReset(uint8_t aArgsLength, char *aArgs[])
     return OT_ERROR_NONE;
 }
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+otError Interpreter::ProcessFake(uint8_t aArgsLength, char *aArgs[])
+{
+    otError error = OT_ERROR_INVALID_COMMAND;
+
+    VerifyOrExit(aArgsLength >= 1, OT_NOOP);
+
+    if (strcmp(aArgs[0], "/a/an") == 0)
+    {
+        otIp6Address destination, target, mlIid;
+
+        VerifyOrExit(aArgsLength == 4, error = OT_ERROR_INVALID_ARGS);
+
+        SuccessOrExit(error = otIp6AddressFromString(aArgs[1], &destination));
+        SuccessOrExit(error = otIp6AddressFromString(aArgs[2], &target));
+        SuccessOrExit(error = otIp6AddressFromString(aArgs[3], &mlIid));
+
+        otThreadSendAddressNotification(mInstance, &destination, &target, &mlIid.mFields.mComponents.mIid);
+    }
+exit:
+    return error;
+}
+#endif
+
 otError Interpreter::ProcessIfconfig(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -346,6 +346,9 @@ private:
     otError ProcessExtAddress(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessExtPanId(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessFactoryReset(uint8_t aArgsLength, char *aArgs[]);
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    otError ProcessFake(uint8_t aArgsLength, char *aArgs[]);
+#endif
     otError ProcessIfconfig(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessIpAddr(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessIpAddrAdd(uint8_t aArgsLength, char *aArgs[]);
@@ -605,6 +608,9 @@ private:
         {"extaddr", &Interpreter::ProcessExtAddress},
         {"extpanid", &Interpreter::ProcessExtPanId},
         {"factoryreset", &Interpreter::ProcessFactoryReset},
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+        {"fake", &Interpreter::ProcessFake},
+#endif
         {"help", &Interpreter::ProcessHelp},
         {"ifconfig", &Interpreter::ProcessIfconfig},
         {"ipaddr", &Interpreter::ProcessIpAddr},

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -391,4 +391,19 @@ void otThreadSetDiscoveryRequestCallback(otInstance *                     aInsta
 
     instance.Get<Mle::MleRouter>().SetDiscoveryRequestCallback(aCallback, aContext);
 }
+
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+void otThreadSendAddressNotification(otInstance *              aInstance,
+                                     otIp6Address *            aDestination,
+                                     otIp6Address *            aTarget,
+                                     otIp6InterfaceIdentifier *aMlIid)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    instance.Get<AddressResolver>().SendAddressQueryResponse(static_cast<Ip6::Address &>(*aTarget),
+                                                             static_cast<Ip6::InterfaceIdentifier &>(*aMlIid), nullptr,
+                                                             static_cast<Ip6::Address &>(*aDestination));
+}
+#endif
+
 #endif // OPENTHREAD_FTD

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -178,7 +178,7 @@ public:
     void RestartAddressQueries(void);
 
     /**
-     * This method sends a Address Notification (ADDR_NTF.ans) message.
+     * This method sends an Address Notification (ADDR_NTF.ans) message.
      *
      * @param[in]  aTarget                  The target address of the ADDR_NTF.ans message.
      * @param[in]  aMeshLocalIid            The ML-IID of the ADDR_NTF.ans message.

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -177,6 +177,21 @@ public:
      */
     void RestartAddressQueries(void);
 
+    /**
+     * This method sends a Address Notification (ADDR_NTF.ans) message.
+     *
+     * @param[in]  aTarget                  The target address of the ADDR_NTF.ans message.
+     * @param[in]  aMeshLocalIid            The ML-IID of the ADDR_NTF.ans message.
+     * @param[in]  aLastTransactionTimeTlv  A pointer to the Last Transaction Time if the ADDR_NTF.ans message contains
+     *                                      a Last Transaction Time TLV.
+     * @param[in]  aDestination             The destination to send the ADDR_NTF.ans message.
+     *
+     */
+    void SendAddressQueryResponse(const Ip6::Address &            aTarget,
+                                  const Ip6::InterfaceIdentifier &aMeshLocalIid,
+                                  const uint32_t *                aLastTransactionTimeTlv,
+                                  const Ip6::Address &            aDestination);
+
 private:
     enum
     {
@@ -288,10 +303,6 @@ private:
     void    SendAddressError(const Ip6::Address &            aTarget,
                              const Ip6::InterfaceIdentifier &aMeshLocalIid,
                              const Ip6::Address *            aDestination);
-    void    SendAddressQueryResponse(const Ip6::Address &            aTarget,
-                                     const Ip6::InterfaceIdentifier &aMeshLocalIid,
-                                     const uint32_t *                aLastTransactionTimeTlv,
-                                     const Ip6::Address &            aDestination);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1678,6 +1678,11 @@ class Node:
 
         return router_table
 
+    def send_address_notification(self, dst: str, target: str, mliid: str):
+        cmd = f'fake /a/an {dst} {target} {mliid}'
+        self.send_command(cmd)
+        self._expect("Done")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This PR allows Reference Devices to send fake Proactive Address Notification messages. 
This PR will be used by #5516 for testing purpose.