### PR TITLE
[cli] return error from 'Process{Cmd}()' methods, adding 'OT_ERROR_PENDING'

### DIFF
--- a/include/openthread/cli.h
+++ b/include/openthread/cli.h
@@ -109,6 +109,7 @@ void otCliUartInit(otInstance *aInstance);
  *
  * @param[in]  aUserCommands  A pointer to an array with user commands.
  * @param[in]  aLength        @p aUserCommands length.
+ *
  */
 void otCliSetUserCommands(const otCliCommand *aUserCommands, uint8_t aLength);
 
@@ -117,6 +118,7 @@ void otCliSetUserCommands(const otCliCommand *aUserCommands, uint8_t aLength);
  *
  * @param[in]  aBytes   A pointer to data which should be printed.
  * @param[in]  aLength  @p aBytes length.
+ *
  */
 void otCliOutputBytes(const uint8_t *aBytes, uint8_t aLength);
 
@@ -125,6 +127,7 @@ void otCliOutputBytes(const uint8_t *aBytes, uint8_t aLength);
  *
  * @param[in]  aFmt   A pointer to the format string.
  * @param[in]  ...    A matching list of arguments.
+ *
  */
 void otCliOutputFormat(const char *aFmt, ...);
 
@@ -133,13 +136,17 @@ void otCliOutputFormat(const char *aFmt, ...);
  *
  * @param[in]  aString  A pointer to the string, which may not be null-terminated.
  * @param[in]  aLength  Number of bytes.
+ *
  */
 void otCliOutput(const char *aString, uint16_t aLength);
 
 /**
  * Write error code to the CLI console
  *
+ * If the @p aError is `OT_ERROR_PENDING` nothing will be outputted.
+ *
  * @param[in]  aError Error code value.
+ *
  */
 void otCliAppendResult(otError aError);
 
@@ -150,6 +157,7 @@ void otCliAppendResult(otError aError);
  * @param[in]  aLogRegion  The log region.
  * @param[in]  aFormat     A pointer to the format string.
  * @param[in]  aArgs       va_list matching aFormat.
+ *
  */
 void otCliPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, va_list aArgs);
 

--- a/include/openthread/error.h
+++ b/include/openthread/error.h
@@ -229,6 +229,12 @@ typedef enum OT_MUST_USE_RESULT otError
     OT_ERROR_INVALID_COMMAND = 35,
 
     /**
+     * Special error code used to indicate success/error status is pending and not yet known.
+     *
+     */
+    OT_ERROR_PENDING = 36,
+
+    /**
      * The number of defined errors.
      */
     OT_NUM_ERRORS,

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (28)
+#define OPENTHREAD_API_VERSION (29)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -217,12 +217,16 @@ exit:
 
 void Interpreter::OutputResult(otError aError)
 {
-    if (aError == OT_ERROR_NONE)
+    switch (aError)
     {
+    case OT_ERROR_NONE:
         OutputLine("Done");
-    }
-    else
-    {
+        break;
+
+    case OT_ERROR_PENDING:
+        break;
+
+    default:
         OutputLine("Error %d: %s", aError, otThreadErrorToString(aError));
     }
 }
@@ -327,7 +331,7 @@ exit:
     return error;
 }
 
-void Interpreter::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -344,11 +348,11 @@ void Interpreter::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
         OutputLine("%s", mUserCommands[i].mName);
     }
 
-    OutputResult(OT_ERROR_NONE);
+    return OT_ERROR_NONE;
 }
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-void Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
     otError                error = OT_ERROR_INVALID_COMMAND;
@@ -412,7 +416,7 @@ void Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[])
 
 exit:
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    OutputResult(error);
+    return error;
 }
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
@@ -585,7 +589,7 @@ exit:
 }
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
 
-void Interpreter::ProcessDomainName(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDomainName(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -600,11 +604,11 @@ void Interpreter::ProcessDomainName(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
-void Interpreter::ProcessDua(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDua(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -644,13 +648,13 @@ void Interpreter::ProcessDua(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif // OPENTHREAD_CONFIG_DUA_ENABLE
 
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
-void Interpreter::ProcessBufferInfo(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessBufferInfo(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -671,10 +675,10 @@ void Interpreter::ProcessBufferInfo(uint8_t aArgsLength, char *aArgs[])
     OutputLine("coap secure: %d %d", bufferInfo.mCoapSecureMessages, bufferInfo.mCoapSecureBuffers);
     OutputLine("application coap: %d %d", bufferInfo.mApplicationCoapMessages, bufferInfo.mApplicationCoapBuffers);
 
-    OutputResult(OT_ERROR_NONE);
+    return OT_ERROR_NONE;
 }
 
-void Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -816,11 +820,11 @@ void Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
 {
     otError     error = OT_ERROR_NONE;
     otChildInfo childInfo;
@@ -925,10 +929,10 @@ void Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
     OutputLine("RSSI: %d", childInfo.mAverageRssi);
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessChildIp(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessChildIp(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
     otError error = OT_ERROR_NONE;
@@ -986,10 +990,10 @@ void Interpreter::ProcessChildIp(uint8_t aArgsLength, char *aArgs[])
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 exit:
 #endif
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessChildMax(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessChildMax(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -1005,11 +1009,11 @@ void Interpreter::ProcessChildMax(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif // OPENTHREAD_FTD
 
-void Interpreter::ProcessChildTimeout(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessChildTimeout(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -1025,29 +1029,25 @@ void Interpreter::ProcessChildTimeout(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
-void Interpreter::ProcessCoap(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessCoap(uint8_t aArgsLength, char *aArgs[])
 {
-    otError error;
-    error = mCoap.Process(aArgsLength, aArgs);
-    OutputResult(error);
+    return mCoap.Process(aArgsLength, aArgs);
 }
 #endif
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-void Interpreter::ProcessCoapSecure(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessCoapSecure(uint8_t aArgsLength, char *aArgs[])
 {
-    otError error;
-    error = mCoapSecure.Process(aArgsLength, aArgs);
-    OutputResult(error);
+    return mCoapSecure.Process(aArgsLength, aArgs);
 }
 #endif
 
 #if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
-void Interpreter::ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1097,12 +1097,12 @@ void Interpreter::ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif // OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessContextIdReuseDelay(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessContextIdReuseDelay(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -1118,11 +1118,11 @@ void Interpreter::ProcessContextIdReuseDelay(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif
 
-void Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1209,11 +1209,11 @@ void Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-void Interpreter::ProcessCsl(uint8_t aArgsLength, char *argv[])
+otError Interpreter::ProcessCsl(uint8_t aArgsLength, char *argv[])
 {
     otError error = OT_ERROR_INVALID_ARGS;
 
@@ -1246,12 +1246,12 @@ void Interpreter::ProcessCsl(uint8_t aArgsLength, char *argv[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessDelayTimerMin(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDelayTimerMin(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1271,11 +1271,11 @@ void Interpreter::ProcessDelayTimerMin(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif
 
-void Interpreter::ProcessDiscover(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDiscover(uint8_t aArgsLength, char *aArgs[])
 {
     otError  error        = OT_ERROR_NONE;
     uint32_t scanChannels = 0;
@@ -1294,15 +1294,14 @@ void Interpreter::ProcessDiscover(uint8_t aArgsLength, char *aArgs[])
     OutputLine("| J | Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |");
     OutputLine("+---+------------------+------------------+------+------------------+----+-----+-----+");
 
+    error = OT_ERROR_PENDING;
+
 exit:
-    if (error != OT_ERROR_NONE)
-    {
-        OutputResult(error);
-    }
+    return error;
 }
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
-void Interpreter::ProcessDns(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDns(uint8_t aArgsLength, char *aArgs[])
 {
     otError          error = OT_ERROR_NONE;
     long             port  = OT_DNS_DEFAULT_SERVER_PORT;
@@ -1349,11 +1348,10 @@ void Interpreter::ProcessDns(uint8_t aArgsLength, char *aArgs[])
         ExitNow(error = OT_ERROR_INVALID_COMMAND);
     }
 
+    error = OT_ERROR_PENDING;
+
 exit:
-    if (error != OT_ERROR_NONE)
-    {
-        OutputResult(error);
-    }
+    return error;
 }
 
 void Interpreter::HandleDnsResponse(void *              aContext,
@@ -1386,7 +1384,7 @@ void Interpreter::HandleDnsResponse(const char *aHostname, const Ip6::Address *a
 #endif
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessEidCache(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessEidCache(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -1405,11 +1403,11 @@ void Interpreter::ProcessEidCache(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(OT_ERROR_NONE);
+    return OT_ERROR_NONE;
 }
 #endif
 
-void Interpreter::ProcessEui64(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessEui64(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
 
@@ -1423,10 +1421,10 @@ void Interpreter::ProcessEui64(uint8_t aArgsLength, char *aArgs[])
     OutputLine("");
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessExtAddress(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessExtAddress(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1448,20 +1446,22 @@ void Interpreter::ProcessExtAddress(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 #if OPENTHREAD_POSIX
-void Interpreter::ProcessExit(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessExit(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
     exit(EXIT_SUCCESS);
+
+    return OT_ERROR_NONE;
 }
 #endif
 
-void Interpreter::ProcessLog(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessLog(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1500,10 +1500,10 @@ void Interpreter::ProcessLog(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessExtPanId(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessExtPanId(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1524,18 +1524,20 @@ void Interpreter::ProcessExtPanId(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessFactoryReset(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessFactoryReset(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
     otInstanceFactoryReset(mInstance);
+
+    return OT_ERROR_NONE;
 }
 
-void Interpreter::ProcessIfconfig(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessIfconfig(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1564,7 +1566,7 @@ void Interpreter::ProcessIfconfig(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 otError Interpreter::ProcessIpAddrAdd(uint8_t aArgsLength, char *aArgs[])
@@ -1599,7 +1601,7 @@ exit:
     return error;
 }
 
-void Interpreter::ProcessIpAddr(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessIpAddr(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1645,7 +1647,7 @@ void Interpreter::ProcessIpAddr(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 otError Interpreter::ProcessIpMulticastAddrAdd(uint8_t aArgsLength, char *aArgs[])
@@ -1711,7 +1713,7 @@ exit:
     return error;
 }
 
-void Interpreter::ProcessIpMulticastAddr(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessIpMulticastAddr(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1744,10 +1746,10 @@ void Interpreter::ProcessIpMulticastAddr(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessKeySequence(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessKeySequence(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -1784,10 +1786,10 @@ void Interpreter::ProcessKeySequence(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessLeaderData(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessLeaderData(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -1804,11 +1806,11 @@ void Interpreter::ProcessLeaderData(uint8_t aArgsLength, char *aArgs[])
     OutputLine("Leader Router ID: %d", leaderData.mLeaderRouterId);
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessLeaderPartitionId(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessLeaderPartitionId(uint8_t aArgsLength, char *aArgs[])
 {
     otError       error = OT_ERROR_NONE;
     unsigned long value;
@@ -1824,10 +1826,10 @@ void Interpreter::ProcessLeaderPartitionId(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessLeaderWeight(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessLeaderWeight(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -1843,12 +1845,12 @@ void Interpreter::ProcessLeaderWeight(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif // OPENTHREAD_FTD
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessPskc(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPskc(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1886,11 +1888,11 @@ void Interpreter::ProcessPskc(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif
 
-void Interpreter::ProcessMasterKey(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMasterKey(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1914,28 +1916,31 @@ void Interpreter::ProcessMasterKey(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
 
-void Interpreter::ProcessMlr(uint8_t aArgsLength, char **aArgs)
+otError Interpreter::ProcessMlr(uint8_t aArgsLength, char **aArgs)
 {
-    if (aArgsLength == 0)
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_COMMAND);
+
+    if (!strcmp(aArgs[0], "reg"))
     {
-        OutputResult(OT_ERROR_INVALID_COMMAND);
-    }
-    else if (!strcmp(aArgs[0], "reg"))
-    {
-        ProcessMlrReg(aArgsLength - 1, aArgs + 1);
+        error = ProcessMlrReg(aArgsLength - 1, aArgs + 1);
     }
     else
     {
-        OutputResult(OT_ERROR_INVALID_COMMAND);
+        error = OT_ERROR_INVALID_COMMAND;
     }
+
+exit:
+    return error;
 }
 
-void Interpreter::ProcessMlrReg(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMlrReg(uint8_t aArgsLength, char *aArgs[])
 {
     otError      error = OT_ERROR_NONE;
     otIp6Address addresses[kIPv6AddressesNumMax];
@@ -1965,14 +1970,14 @@ void Interpreter::ProcessMlrReg(uint8_t aArgsLength, char *aArgs[])
         timeout = static_cast<uint32_t>(value);
     }
 
-    error = otIp6RegisterMulticastListeners(mInstance, addresses, i, i == aArgsLength - 1 ? &timeout : nullptr,
-                                            Interpreter::HandleMlrRegResult, this);
+    SuccessOrExit(error = otIp6RegisterMulticastListeners(mInstance, addresses, i,
+                                                          i == aArgsLength - 1 ? &timeout : nullptr,
+                                                          Interpreter::HandleMlrRegResult, this));
+
+    error = OT_ERROR_PENDING;
 
 exit:
-    if (error != OT_ERROR_NONE)
-    {
-        OutputResult(error);
-    }
+    return error;
 }
 
 void Interpreter::HandleMlrRegResult(void *              aContext,
@@ -2005,7 +2010,7 @@ void Interpreter::HandleMlrRegResult(otError             aError,
 
 #endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
 
-void Interpreter::ProcessMode(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMode(uint8_t aArgsLength, char *aArgs[])
 {
     otError          error = OT_ERROR_NONE;
     otLinkModeConfig linkMode;
@@ -2069,11 +2074,11 @@ void Interpreter::ProcessMode(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessNeighbor(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNeighbor(uint8_t aArgsLength, char *aArgs[])
 {
     otError                error = OT_ERROR_NONE;
     otNeighborInfo         neighborInfo;
@@ -2128,12 +2133,12 @@ void Interpreter::ProcessNeighbor(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
-void Interpreter::ProcessNetif(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetif(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -2147,11 +2152,11 @@ void Interpreter::ProcessNetif(uint8_t aArgsLength, char *aArgs[])
     OutputLine("%s:%u", netif ? netif : "(null)", netifidx);
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif
 
-void Interpreter::ProcessNetstat(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetstat(uint8_t aArgsLength, char *aArgs[])
 {
     otUdpSocket *socket = otUdpGetSockets(mInstance);
 
@@ -2185,7 +2190,7 @@ void Interpreter::ProcessNetstat(uint8_t aArgsLength, char *aArgs[])
         socket = socket->mNext;
     }
 
-    OutputResult(OT_ERROR_NONE);
+    return OT_ERROR_NONE;
 }
 
 int Interpreter::OutputSocketAddress(const otSockAddr &aAddress)
@@ -2227,7 +2232,7 @@ otError Interpreter::ProcessServiceList(void)
     return OT_ERROR_NONE;
 }
 
-void Interpreter::ProcessService(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessService(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -2278,19 +2283,17 @@ void Interpreter::ProcessService(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif
 
-void Interpreter::ProcessNetworkData(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetworkData(uint8_t aArgsLength, char *aArgs[])
 {
-    otError error;
-    error = mNetworkData.Process(aArgsLength, aArgs);
-    OutputResult(error);
+    return mNetworkData.Process(aArgsLength, aArgs);
 }
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessNetworkIdTimeout(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetworkIdTimeout(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -2306,11 +2309,11 @@ void Interpreter::ProcessNetworkIdTimeout(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif
 
-void Interpreter::ProcessNetworkName(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetworkName(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -2325,11 +2328,11 @@ void Interpreter::ProcessNetworkName(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-void Interpreter::ProcessNetworkTime(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetworkTime(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -2378,11 +2381,11 @@ void Interpreter::ProcessNetworkTime(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
-void Interpreter::ProcessPanId(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPanId(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -2398,10 +2401,10 @@ void Interpreter::ProcessPanId(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessParent(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessParent(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -2425,11 +2428,11 @@ void Interpreter::ProcessParent(uint8_t aArgsLength, char *aArgs[])
     OutputLine("Age: %d", parentInfo.mAge);
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessParentPriority(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessParentPriority(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -2445,7 +2448,7 @@ void Interpreter::ProcessParentPriority(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif
 
@@ -2488,7 +2491,7 @@ exit:
     return;
 }
 
-void Interpreter::ProcessPing(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPing(uint8_t aArgsLength, char *aArgs[])
 {
     otError  error = OT_ERROR_NONE;
     uint8_t  index = 1;
@@ -2559,7 +2562,7 @@ void Interpreter::ProcessPing(uint8_t aArgsLength, char *aArgs[])
     SendPing();
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 void Interpreter::HandlePingTimer(Timer &aTimer)
@@ -2602,7 +2605,7 @@ exit:
     }
 }
 
-void Interpreter::ProcessPollPeriod(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPollPeriod(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -2618,10 +2621,10 @@ void Interpreter::ProcessPollPeriod(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessPromiscuous(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPromiscuous(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -2655,7 +2658,7 @@ void Interpreter::ProcessPromiscuous(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 void Interpreter::HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx, void *aContext)
@@ -2890,7 +2893,7 @@ exit:
     return OT_ERROR_NONE;
 }
 
-void Interpreter::ProcessPrefix(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPrefix(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -2912,12 +2915,12 @@ void Interpreter::ProcessPrefix(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessPreferRouterId(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPreferRouterId(uint8_t aArgsLength, char *aArgs[])
 {
     otError       error = OT_ERROR_NONE;
     unsigned long value;
@@ -2927,11 +2930,11 @@ void Interpreter::ProcessPreferRouterId(uint8_t aArgsLength, char *aArgs[])
     error = otThreadSetPreferredRouterId(mInstance, static_cast<uint8_t>(value));
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif
 
-void Interpreter::ProcessRcp(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRcp(uint8_t aArgsLength, char *aArgs[])
 {
     otError     error   = OT_ERROR_NONE;
     const char *version = otPlatRadioGetVersionString(mInstance);
@@ -2949,11 +2952,11 @@ void Interpreter::ProcessRcp(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessReleaseRouterId(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessReleaseRouterId(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -2964,25 +2967,28 @@ void Interpreter::ProcessReleaseRouterId(uint8_t aArgsLength, char *aArgs[])
     SuccessOrExit(error = otThreadReleaseRouterId(mInstance, static_cast<uint8_t>(value)));
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif
 
-void Interpreter::ProcessReset(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessReset(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
     otInstanceReset(mInstance);
+
+    return OT_ERROR_NONE;
 }
 
-void Interpreter::ProcessRloc16(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRloc16(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
     OutputLine("%04x", otThreadGetRloc16(mInstance));
-    OutputResult(OT_ERROR_NONE);
+
+    return OT_ERROR_NONE;
 }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
@@ -3091,7 +3097,7 @@ otError Interpreter::ProcessRouteList(void)
     return OT_ERROR_NONE;
 }
 
-void Interpreter::ProcessRoute(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRoute(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3113,12 +3119,12 @@ void Interpreter::ProcessRoute(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessRouter(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRouter(uint8_t aArgsLength, char *aArgs[])
 {
     otError      error = OT_ERROR_NONE;
     otRouterInfo routerInfo;
@@ -3206,10 +3212,10 @@ void Interpreter::ProcessRouter(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessRouterDowngradeThreshold(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRouterDowngradeThreshold(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -3225,10 +3231,10 @@ void Interpreter::ProcessRouterDowngradeThreshold(uint8_t aArgsLength, char *aAr
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessRouterEligible(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRouterEligible(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3257,10 +3263,10 @@ void Interpreter::ProcessRouterEligible(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessRouterSelectionJitter(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRouterSelectionJitter(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -3277,10 +3283,10 @@ void Interpreter::ProcessRouterSelectionJitter(uint8_t aArgsLength, char *aArgs[
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessRouterUpgradeThreshold(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRouterUpgradeThreshold(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -3296,11 +3302,11 @@ void Interpreter::ProcessRouterUpgradeThreshold(uint8_t aArgsLength, char *aArgs
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif // OPENTHREAD_FTD
 
-void Interpreter::ProcessScan(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessScan(uint8_t aArgsLength, char *aArgs[])
 {
     otError  error        = OT_ERROR_NONE;
     uint32_t scanChannels = 0;
@@ -3344,11 +3350,10 @@ void Interpreter::ProcessScan(uint8_t aArgsLength, char *aArgs[])
                                                &Interpreter::HandleActiveScanResult, this));
     }
 
+    error = OT_ERROR_PENDING;
+
 exit:
-    if (error != OT_ERROR_NONE)
-    {
-        OutputResult(error);
-    }
+    return error;
 }
 
 void Interpreter::HandleActiveScanResult(otActiveScanResult *aResult, void *aContext)
@@ -3401,12 +3406,10 @@ exit:
     return;
 }
 
-void Interpreter::ProcessSingleton(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessSingleton(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
-
-    otError error = OT_ERROR_NONE;
 
     if (otThreadIsSingleton(mInstance))
     {
@@ -3417,11 +3420,11 @@ void Interpreter::ProcessSingleton(uint8_t aArgsLength, char *aArgs[])
         OutputLine("false");
     }
 
-    OutputResult(error);
+    return OT_ERROR_NONE;
 }
 
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
-void Interpreter::ProcessSntp(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessSntp(uint8_t aArgsLength, char *aArgs[])
 {
     otError          error = OT_ERROR_NONE;
     long             port  = OT_SNTP_DEFAULT_SERVER_PORT;
@@ -3462,11 +3465,10 @@ void Interpreter::ProcessSntp(uint8_t aArgsLength, char *aArgs[])
         ExitNow(error = OT_ERROR_INVALID_COMMAND);
     }
 
+    error = OT_ERROR_PENDING;
+
 exit:
-    if (error != OT_ERROR_NONE)
-    {
-        OutputResult(error);
-    }
+    return error;
 }
 
 void Interpreter::HandleSntpResponse(void *aContext, uint64_t aTime, otError aResult)
@@ -3494,7 +3496,7 @@ void Interpreter::HandleSntpResponse(uint64_t aTime, otError aResult)
 }
 #endif
 
-void Interpreter::ProcessState(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessState(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3557,10 +3559,10 @@ void Interpreter::ProcessState(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessThread(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessThread(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -3587,17 +3589,15 @@ void Interpreter::ProcessThread(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessDataset(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDataset(uint8_t aArgsLength, char *aArgs[])
 {
-    otError error;
-    error = mDataset.Process(aArgsLength, aArgs);
-    OutputResult(error);
+    return mDataset.Process(aArgsLength, aArgs);
 }
 
-void Interpreter::ProcessTxPower(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessTxPower(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3617,17 +3617,15 @@ void Interpreter::ProcessTxPower(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessUdp(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessUdp(uint8_t aArgsLength, char *aArgs[])
 {
-    otError error;
-    error = mUdp.Process(aArgsLength, aArgs);
-    OutputResult(error);
+    return mUdp.Process(aArgsLength, aArgs);
 }
 
-void Interpreter::ProcessUnsecurePort(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessUnsecurePort(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3682,43 +3680,36 @@ void Interpreter::ProcessUnsecurePort(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
-void Interpreter::ProcessVersion(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessVersion(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
     const char *version = otGetVersionString();
     OutputLine("%s", static_cast<const char *>(version));
-    OutputResult(OT_ERROR_NONE);
+
+    return OT_ERROR_NONE;
 }
 
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-
-void Interpreter::ProcessCommissioner(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessCommissioner(uint8_t aArgsLength, char *aArgs[])
 {
-    otError error;
-    error = mCommissioner.Process(aArgsLength, aArgs);
-    OutputResult(error);
+    return mCommissioner.Process(aArgsLength, aArgs);
 }
-
 #endif
 
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
-
-void Interpreter::ProcessJoiner(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessJoiner(uint8_t aArgsLength, char *aArgs[])
 {
-    otError error;
-    error = mJoiner.Process(aArgsLength, aArgs);
-    OutputResult(error);
+    return mJoiner.Process(aArgsLength, aArgs);
 }
-
 #endif
 
 #if OPENTHREAD_FTD
-void Interpreter::ProcessJoinerPort(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessJoinerPort(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
     long    value;
@@ -3734,12 +3725,12 @@ void Interpreter::ProcessJoinerPort(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
-void Interpreter::ProcessMacFilter(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMacFilter(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3763,7 +3754,7 @@ void Interpreter::ProcessMacFilter(uint8_t aArgsLength, char *aArgs[])
         }
     }
 
-    OutputResult(error);
+    return error;
 }
 
 void Interpreter::PrintMacFilter(void)
@@ -4028,7 +4019,7 @@ exit:
 
 #endif // OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
 
-void Interpreter::ProcessMac(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMac(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -4044,7 +4035,7 @@ void Interpreter::ProcessMac(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    OutputResult(error);
+    return error;
 }
 
 otError Interpreter::ProcessMacRetries(uint8_t aArgsLength, char *aArgs[])
@@ -4097,7 +4088,7 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-void Interpreter::ProcessDiag(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDiag(uint8_t aArgsLength, char *aArgs[])
 {
     otError error;
     char    output[OPENTHREAD_CONFIG_DIAG_OUTPUT_BUFFER_SIZE];
@@ -4108,7 +4099,8 @@ void Interpreter::ProcessDiag(uint8_t aArgsLength, char *aArgs[])
 
     error = otDiagProcessCmd(mInstance, aArgsLength, aArgs, output, sizeof(output) - 1);
     Output(output, static_cast<uint16_t>(strlen(output)));
-    OutputResult(error);
+
+    return error;
 }
 #endif
 
@@ -4165,7 +4157,7 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength)
 
     if (command != nullptr)
     {
-        (this->*command->mCommand)(aArgsLength - 1, &aArgs[1]);
+        OutputResult((this->*command->mCommand)(aArgsLength - 1, &aArgs[1]));
         ExitNow();
     }
 
@@ -4186,7 +4178,7 @@ exit:
 }
 
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
-void Interpreter::ProcessNetworkDiagnostic(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetworkDiagnostic(uint8_t aArgsLength, char *aArgs[])
 {
     otError             error = OT_ERROR_NONE;
     struct otIp6Address address;
@@ -4211,23 +4203,19 @@ void Interpreter::ProcessNetworkDiagnostic(uint8_t aArgsLength, char *aArgs[])
     if (strcmp(aArgs[0], "get") == 0)
     {
         IgnoreError(otThreadSendDiagnosticGet(mInstance, &address, tlvTypes, count));
-        ExitNow();
+        ExitNow(error = OT_ERROR_PENDING);
     }
     else if (strcmp(aArgs[0], "reset") == 0)
     {
         IgnoreError(otThreadSendDiagnosticReset(mInstance, &address, tlvTypes, count));
-        OutputResult(OT_ERROR_NONE);
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_COMMAND);
+        error = OT_ERROR_INVALID_COMMAND;
     }
 
 exit:
-    if (error != OT_ERROR_NONE)
-    {
-        OutputResult(error);
-    }
+    return error;
 }
 
 void Interpreter::HandleDiagnosticGetResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo, void *aContext)

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -236,6 +236,8 @@ public:
     /**
      * This method delivers a success or error message the client.
      *
+     * If the @p aError is `OT_ERROR_PENDING` nothing will be outputted.
+     *
      * @param[in]  aError  The error code.
      *
      */
@@ -270,17 +272,17 @@ private:
     struct Command
     {
         const char *mName;
-        void (Interpreter::*mCommand)(uint8_t aArgsLength, char *aArgs[]);
+        otError (Interpreter::*mCommand)(uint8_t aArgsLength, char *aArgs[]);
     };
 
     const Command *FindCommand(const char *aName) const;
     otError        ParsePingInterval(const char *aString, uint32_t &aInterval);
     static otError ParseJoinerDiscerner(char *aString, otJoinerDiscerner &aJoinerDiscerner);
-    void           ProcessHelp(uint8_t aArgsLength, char *aArgs[]);
-    void           ProcessBufferInfo(uint8_t aArgsLength, char *aArgs[]);
-    void           ProcessChannel(uint8_t aArgsLength, char *aArgs[]);
+    otError        ProcessHelp(uint8_t aArgsLength, char *aArgs[]);
+    otError        ProcessBufferInfo(uint8_t aArgsLength, char *aArgs[]);
+    otError        ProcessChannel(uint8_t aArgsLength, char *aArgs[]);
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-    void ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[]);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     otError ProcessBackboneRouterLocal(uint8_t aArgsLength, char *aArgs[]);
@@ -290,84 +292,84 @@ private:
 #endif
 #endif
 
-    void ProcessDomainName(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDomainName(uint8_t aArgsLength, char *aArgs[]);
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
-    void ProcessDua(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDua(uint8_t aArgsLength, char *aArgs[]);
 #endif
 
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
 #if OPENTHREAD_FTD
-    void ProcessChild(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessChildIp(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessChildMax(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessChild(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessChildIp(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessChildMax(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessChildTimeout(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessChildTimeout(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
-    void ProcessCoap(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessCoap(uint8_t aArgsLength, char *aArgs[]);
 #endif
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-    void ProcessCoapSecure(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessCoapSecure(uint8_t aArgsLength, char *aArgs[]);
 #endif
 #if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
-    void ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[]);
 #endif
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-    void ProcessCommissioner(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessCommissioner(uint8_t aArgsLength, char *aArgs[]);
 #endif
 #if OPENTHREAD_FTD
-    void ProcessContextIdReuseDelay(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessContextIdReuseDelay(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessCounters(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessCsl(uint8_t aArgsLength, char *argv[]);
+    otError ProcessCounters(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessCsl(uint8_t aArgsLength, char *argv[]);
 #if OPENTHREAD_FTD
-    void ProcessDelayTimerMin(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDelayTimerMin(uint8_t aArgsLength, char *aArgs[]);
 #endif
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-    void ProcessDiag(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDiag(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessDiscover(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDiscover(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
-    void ProcessDns(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDns(uint8_t aArgsLength, char *aArgs[]);
 #endif
 #if OPENTHREAD_FTD
-    void ProcessEidCache(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessEidCache(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessEui64(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessEui64(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_POSIX
-    void ProcessExit(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessExit(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void    ProcessLog(uint8_t aArgsLength, char *aArgs[]);
-    void    ProcessExtAddress(uint8_t aArgsLength, char *aArgs[]);
-    void    ProcessExtPanId(uint8_t aArgsLength, char *aArgs[]);
-    void    ProcessFactoryReset(uint8_t aArgsLength, char *aArgs[]);
-    void    ProcessIfconfig(uint8_t aArgsLength, char *aArgs[]);
-    void    ProcessIpAddr(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessLog(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessExtAddress(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessExtPanId(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessFactoryReset(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessIfconfig(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessIpAddr(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessIpAddrAdd(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessIpAddrDel(uint8_t aArgsLength, char *aArgs[]);
-    void    ProcessIpMulticastAddr(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessIpMulticastAddr(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessIpMulticastAddrAdd(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessIpMulticastAddrDel(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessMulticastPromiscuous(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
-    void ProcessJoiner(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessJoiner(uint8_t aArgsLength, char *aArgs[]);
 #endif
 #if OPENTHREAD_FTD
-    void ProcessJoinerPort(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessJoinerPort(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessKeySequence(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessLeaderData(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessKeySequence(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessLeaderData(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_FTD
-    void ProcessLeaderPartitionId(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessLeaderWeight(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessLeaderPartitionId(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessLeaderWeight(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessMasterKey(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMasterKey(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
-    void ProcessMlr(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMlr(uint8_t aArgsLength, char *aArgs[]);
 
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-    void ProcessMlrReg(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMlrReg(uint8_t aArgsLength, char *aArgs[]);
 
     static void HandleMlrRegResult(void *              aContext,
                                    otError             aError,
@@ -380,102 +382,102 @@ private:
                                    uint8_t             aFailedAddressNum);
 #endif
 #endif
-    void ProcessMode(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMode(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_FTD
-    void ProcessNeighbor(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNeighbor(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessNetworkData(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessNetworkDataPrefix(void);
-    void ProcessNetworkDataRoute(void);
-    void ProcessNetworkDataService(void);
-    void OutputPrefix(const otBorderRouterConfig &aConfig);
-    void OutputRoute(const otExternalRouteConfig &aConfig);
-    void OutputService(const otServiceConfig &aConfig);
+    otError ProcessNetworkData(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNetworkDataPrefix(void);
+    otError ProcessNetworkDataRoute(void);
+    otError ProcessNetworkDataService(void);
+    void    OutputPrefix(const otBorderRouterConfig &aConfig);
+    void    OutputRoute(const otExternalRouteConfig &aConfig);
+    void    OutputService(const otServiceConfig &aConfig);
 
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
-    void ProcessNetif(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNetif(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessNetstat(uint8_t aArgsLength, char *aArgs[]);
-    int  OutputSocketAddress(const otSockAddr &aAddress);
+    otError ProcessNetstat(uint8_t aArgsLength, char *aArgs[]);
+    int     OutputSocketAddress(const otSockAddr &aAddress);
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    void    ProcessService(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessService(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessServiceList(void);
 #endif
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
-    void ProcessNetworkDiagnostic(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNetworkDiagnostic(uint8_t aArgsLength, char *aArgs[]);
 #endif
 #if OPENTHREAD_FTD
-    void ProcessNetworkIdTimeout(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNetworkIdTimeout(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessNetworkName(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNetworkName(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    void ProcessNetworkTime(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNetworkTime(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessPanId(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessParent(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessPanId(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessParent(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_FTD
-    void ProcessParentPriority(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessParentPriority(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessPing(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessPollPeriod(uint8_t aArgsLength, char *aArgs[]);
-    void SignalPingRequest(const Ip6::Address &aPeerAddress,
-                           uint16_t            aPingLength,
-                           uint32_t            aTimestamp,
-                           uint8_t             aHopLimit);
-    void SignalPingReply(const Ip6::Address &aPeerAddress,
-                         uint16_t            aPingLength,
-                         uint32_t            aTimestamp,
-                         uint8_t             aHopLimit);
+    otError ProcessPing(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessPollPeriod(uint8_t aArgsLength, char *aArgs[]);
+    void    SignalPingRequest(const Ip6::Address &aPeerAddress,
+                              uint16_t            aPingLength,
+                              uint32_t            aTimestamp,
+                              uint8_t             aHopLimit);
+    void    SignalPingReply(const Ip6::Address &aPeerAddress,
+                            uint16_t            aPingLength,
+                            uint32_t            aTimestamp,
+                            uint8_t             aHopLimit);
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
-    void    ProcessPrefix(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessPrefix(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessPrefixAdd(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessPrefixRemove(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessPrefixList(void);
 #endif
-    void ProcessPromiscuous(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessPromiscuous(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_FTD
-    void ProcessPreferRouterId(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessPskc(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessPreferRouterId(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessPskc(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessRcp(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessRcp(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_FTD
-    void ProcessReleaseRouterId(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessReleaseRouterId(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessReset(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessReset(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
-    void    ProcessRoute(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessRoute(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessRouteAdd(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessRouteRemove(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessRouteList(void);
 #endif
 #if OPENTHREAD_FTD
-    void ProcessRouter(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessRouterDowngradeThreshold(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessRouterEligible(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessRouterSelectionJitter(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessRouterUpgradeThreshold(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessRouter(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessRouterDowngradeThreshold(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessRouterEligible(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessRouterSelectionJitter(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessRouterUpgradeThreshold(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessRloc16(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessScan(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessSingleton(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessRloc16(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessScan(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessSingleton(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
-    void ProcessSntp(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessSntp(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void ProcessState(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessThread(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessDataset(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessTxPower(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessUdp(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessUnsecurePort(uint8_t aArgsLength, char *aArgs[]);
-    void ProcessVersion(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessState(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessThread(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDataset(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessTxPower(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessUdp(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessUnsecurePort(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessVersion(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
-    void    ProcessMacFilter(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMacFilter(uint8_t aArgsLength, char *aArgs[]);
     void    PrintMacFilter(void);
     otError ProcessMacFilterAddress(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessMacFilterRss(uint8_t aArgsLength, char *aArgs[]);
 #endif
-    void    ProcessMac(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMac(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessMacRetries(uint8_t aArgsLength, char *aArgs[]);
 
     static void HandleIcmpReceive(void *               aContext,

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -192,6 +192,7 @@ static const char *const sThreadErrorStrings[OT_NUM_ERRORS] = {
     "ReservedError33",            // otError 33 is reserved
     "LinkMarginLow",              // OT_ERROR_LINK_MARGIN_LOW = 34
     "InvalidCommand",             // OT_ERROR_INVALID_COMMAND = 35
+    "Pending",                    // OT_ERROR_PENDING = 36
 };
 
 const char *otThreadErrorToString(otError aError)


### PR DESCRIPTION
This commit changes the CLI `Process{Cmd}()` handler methods to return
an `otError` (instead of outputting the result). This helps harmonize
the `Process{Cmd}()` handlers in different CLI modules. It also
enables the result of CLI command to be outputted from `ProcessLine()`
after the command is looked up in the table and the corresponding
`Process{Cmd}()` handler is invoked.

This commit also adds a new error code `OT_ERROR_PENDING`. This
special error code indicates the success or error status of an
operation is not yet known and is pending. This is then used by some
of the CLI `Process{Cmd}()` methods which perform an async operation,
e.g., `ProcessDiscover()` returns `OT_ERROR_PENDING` if the discover
scan starts successfully, and later the final result is outputted from
scan callback. The `OutputResult(aError)` method is changed to output
nothing if the error is `OT_ERROR_PENDING`.