### PR TITLE
[scripts] output cert test log to stderr

### DIFF
--- a/tests/scripts/thread-cert/simulator.py
+++ b/tests/scripts/thread-cert/simulator.py
@@ -84,8 +84,8 @@ class BaseSimulator(object):
                     type,
                     payload,
             ) in node.read_cert_messages_in_commissioning_log():
-                if direction == b'send':
-                    msg = self._payload_parse_factory.parse(type.decode("utf-8"), io.BytesIO(payload))
+                if direction == 'send':
+                    msg = self._payload_parse_factory.parse(type, io.BytesIO(payload))
                     self.commissioning_messages[nodeid].append(msg)
 
 


### PR DESCRIPTION
This PR allows thread-cert tests to output OT log (`otLogXxx`) to stderr which is very helpful for debugging. 