### PR TITLE
[github-actions] run Thread 1.1 cert tests for 1.2 build

### DIFF
--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -146,7 +146,7 @@ jobs:
         with:
           fail_ci_if_error: true
 
-  packet-verification-1.1-on-1.2:
+  packet-verification-1-1-on-1-2:
     runs-on: ubuntu-18.04
     env:
       REFERENCE_DEVICE: 1

--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -146,6 +146,42 @@ jobs:
         with:
           fail_ci_if_error: true
 
+  packet-verification-1.1-on-1.2:
+    runs-on: ubuntu-18.04
+    env:
+      REFERENCE_DEVICE: 1
+      VIRTUAL_TIME: 1
+      PACKET_VERIFICATION: 1
+      THREAD_VERSION: 1.2
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bootstrap
+        run: |
+          sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+          sudo apt-get --no-install-recommends install -y g++-multilib python3-setuptools python3-wheel ninja-build
+          python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
+      - name: Build
+        run: |
+          ./script/test build
+      - name: Run
+        run: |
+          for i in {1..3}
+          do
+            ./script/test cert_suite ./tests/scripts/thread-cert/Cert_*.py
+          done
+      - uses: actions/upload-artifact@v2
+        if: ${{ failure() }}
+        with:
+          name: packet-verification-1.1-on-1.2-pcaps
+          path: |
+            *.pcap
+            *.json
+      - name: Codecov
+        uses: codecov/codecov-action@v1
+        with:
+          fail_ci_if_error: true
+
+
   expects:
     runs-on: ubuntu-18.04
     env:

--- a/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
+++ b/tests/scripts/thread-cert/Cert_8_1_01_Commissioning.py
@@ -81,12 +81,15 @@ class Cert_8_1_01_Commissioning(thread_cert.TestCase):
 
         # 3 - Joiner_1
         msg = joiner_messages.next_mle_message(mle.CommandType.DISCOVERY_REQUEST)
-        command.check_discovery_request(msg)
+        command.check_discovery_request(msg, thread_version=self.nodes[JOINER].version)
         request_src_addr = msg.mac_header.src_address
 
         # 4 - Commissioner
         msg = commissioner_messages.next_mle_message(mle.CommandType.DISCOVERY_RESPONSE)
-        command.check_discovery_response(msg, request_src_addr, steering_data=CheckType.CONTAIN)
+        command.check_discovery_response(msg,
+                                         request_src_addr,
+                                         steering_data=CheckType.CONTAIN,
+                                         thread_version=self.nodes[COMMISSIONER].version)
         udp_port_set_by_commissioner = command.get_joiner_udp_port_in_discovery_response(msg)
 
         # 5.2 - Joiner_1

--- a/tests/scripts/thread-cert/command.py
+++ b/tests/scripts/thread-cert/command.py
@@ -596,16 +596,23 @@ def assert_contains_tlv(tlvs, check_type, tlv_type):
         raise ValueError("Invalid check type: {}".format(check_type))
 
 
-def check_discovery_request(command_msg):
+def check_discovery_request(command_msg, thread_version: str = None):
     """Verify a properly formatted Thread Discovery Request command message.
     """
     assert not isinstance(command_msg.mle, mle.MleMessageSecured)
     tlvs = command_msg.assertMleMessageContainsTlv(mle.ThreadDiscovery).tlvs
     request = assert_contains_tlv(tlvs, CheckType.CONTAIN, mesh_cop.DiscoveryRequest)
-    assert request.version == config.PROTOCOL_VERSION
+    assert not thread_version or thread_version in ['1.1', '1.2']
+    if thread_version == '1.1':
+        assert request.version == config.THREAD_VERSION_1_1
+    elif thread_version == '1.2':
+        assert request.version == config.THREAD_VERSION_1_2
 
 
-def check_discovery_response(command_msg, request_src_addr, steering_data=CheckType.OPTIONAL):
+def check_discovery_response(command_msg,
+                             request_src_addr,
+                             steering_data=CheckType.OPTIONAL,
+                             thread_version: str = None):
     """Verify a properly formatted Thread Discovery Response command message.
     """
     assert not isinstance(command_msg.mle, mle.MleMessageSecured)
@@ -614,7 +621,11 @@ def check_discovery_response(command_msg, request_src_addr, steering_data=CheckT
 
     tlvs = command_msg.assertMleMessageContainsTlv(mle.ThreadDiscovery).tlvs
     response = assert_contains_tlv(tlvs, CheckType.CONTAIN, mesh_cop.DiscoveryResponse)
-    assert response.version == config.PROTOCOL_VERSION
+    assert not thread_version or thread_version in ['1.1', '1.2']
+    if thread_version == '1.1':
+        assert response.version == config.THREAD_VERSION_1_1
+    elif thread_version == '1.2':
+        assert response.version == config.THREAD_VERSION_1_2
     assert_contains_tlv(tlvs, CheckType.CONTAIN, mesh_cop.ExtendedPanid)
     assert_contains_tlv(tlvs, CheckType.CONTAIN, mesh_cop.NetworkName)
     assert_contains_tlv(tlvs, steering_data, mesh_cop.SteeringData)

--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -110,7 +110,8 @@ VIRTUAL_TIME = int(os.getenv('VIRTUAL_TIME', 0))
 
 LEADER_NOTIFY_SED_BY_CHILD_UPDATE_REQUEST = True
 
-PROTOCOL_VERSION = 2
+THREAD_VERSION_1_1 = 2
+THREAD_VERSION_1_2 = 3
 
 
 def create_default_network_data_prefix_sub_tlvs_factories():

--- a/tests/scripts/thread-cert/thread_cert.py
+++ b/tests/scripts/thread-cert/thread_cert.py
@@ -46,13 +46,15 @@ if PACKET_VERIFICATION:
 
 PORT_OFFSET = int(os.getenv('PORT_OFFSET', "0"))
 
+ENV_THREAD_VERSION = os.getenv('THREAD_VERSION', '1.1')
+
 DEFAULT_PARAMS = {
     'is_mtd': False,
     'is_bbr': False,
     'mode': 'rsdn',
     'panid': 0xface,
     'allowlist': None,
-    'version': '1.1',
+    'version': ENV_THREAD_VERSION,
 }
 """Default configurations when creating nodes."""
 


### PR DESCRIPTION
This PR runs Thread 1.1 certification tests with packet verification for 1.2 build because Thread 1.2 certified devices are supposed to be able to pass **Thread 1.1 certification** first.

**Note: changes to test `TOPOLOGY`:**
- Original: nodes use version=1.1 by default
- Now: nodes use version according to ENV, except explicitly specified