### PR TITLE
[posix] fix options dependency

### DIFF
--- a/src/posix/console_cli.cpp
+++ b/src/posix/console_cli.cpp
@@ -28,6 +28,8 @@
 
 #include "console_cli.h"
 
+#if OPENTHREAD_CONFIG_CLI_TRANSPORT == OT_CLI_TRANSPORT_CONSOLE
+
 #include <openthread/config.h>
 
 #include <assert.h>
@@ -129,3 +131,5 @@ void otxConsoleProcess(const otSysMainloopContext *aMainloop)
 }
 
 #endif // HAVE_LIBEDIT || HAVE_LIBREADLINE
+
+#endif // OPENTHREAD_CONFIG_CLI_TRANSPORT == OT_CLI_TRANSPORT_CONSOLE

--- a/src/posix/console_cli.h
+++ b/src/posix/console_cli.h
@@ -35,6 +35,24 @@
 
 #include <openthread/openthread-system.h>
 
+#include "cli/cli_config.h"
+
+#ifndef HAVE_LIBEDIT
+#define HAVE_LIBEDIT 0
+#endif
+
+#ifndef HAVE_LIBREADLINE
+#define HAVE_LIBREADLINE 0
+#endif
+
+#if OPENTHREAD_CONFIG_CLI_TRANSPORT == OT_CLI_TRANSPORT_CONSOLE
+#define OPENTHREAD_USE_CONSOLE 1
+#if !(HAVE_LIBEDIT || HAVE_LIBREADLINE) || OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
+#error \
+    "When OPENTHREAD_CONFIG_CLI_TRANSPORT=OT_CLI_TRANSPORT_CONSOLE, HAVE_LIBEDIT or HAVE_LIBREADLINE MUST be defined and OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE MUST be 0"
+#endif
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -66,12 +66,8 @@
 #elif OPENTHREAD_POSIX_APP_TYPE == OT_POSIX_APP_TYPE_CLI
 #include <openthread/cli.h>
 
-#include "cli/cli_config.h"
-#if (HAVE_LIBEDIT || HAVE_LIBREADLINE) && !OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE && \
-    (OPENTHREAD_CONFIG_CLI_TRANSPORT == OT_CLI_TRANSPORT_CONSOLE)
-#define OPENTHREAD_USE_CONSOLE 1
 #include "console_cli.h"
-#endif
+#include "cli/cli_config.h"
 #else
 #error "Unknown posix app type!"
 #endif


### PR DESCRIPTION
This PR fixes the problem #5520 

The root cause of #5520 turned out to be the absence of LIBREADLINE in the environment. However the error I got is confusing and doesn't indicate that because the options dependencies are not good. I think the options' dependency and relationship here should be:
1. When `DEAMON=0`(ot-cli, ot-ncp will be built and ot-cli depends on console), `CLI_TRANSPORT=CONSOLE` MUST be used. And otherwise (`DEAMON=1`), `CLI_TRANSPORT=UART`MUST be used. **So when users build posix, they don't need to consider the option `CLI_TRANSPORT`.**  It's reasonable to add the evaluation for `CLI_TRANSPORT` in `Makefile-posix`.
2. When `CLI_TRANSPORT=CONSOLE`, `(HAVE_LIBEDIT || HAVE_LIBREADLINE)` MUST be defined and `DAEMON=0` MUST be satisfied. I think `(HAVE_LIBEDIT || HAVE_LIBREADLINE)` is a result of `CLI_TRANSPORT` instead of the reason. The reason for `CLI_TRANSPORT` should be `DEAMON`.

Now I set `CLI_TRANSPORT` option based on `DAEMON` and make `(HAVE_LIBEDIT || HAVE_LIBREADLINE)` as a check for `CLI_TRANSPORT=CONSOLE`.

Going back to issue #5520, if READLINE lib is not found, in this implementation, there will be an error indicating that it's not found.

Resolves #5520
