### PR TITLE
[script] fix output when no arguments are specified

### DIFF
--- a/script/test
+++ b/script/test
@@ -471,8 +471,7 @@ main()
                 ;;
             *)
                 echo
-                echo -e "${COLOR_FAIL}Unknown command${COLOR_NONE}: '$1'"
-                exit 1
+                echo -e "${COLOR_FAIL}Warning:${COLOR_NONE} Ignoring: '$1'"
                 ;;
         esac
         shift

--- a/script/test
+++ b/script/test
@@ -423,7 +423,7 @@ main()
 {
     envsetup "$@"
 
-    if [[ -z $1 ]]; then
+    if [[ -z ${1:-} ]]; then
         print_usage 1
     fi
 
@@ -468,6 +468,11 @@ main()
             untar)
                 shift
                 do_untar "$@"
+                ;;
+            *)
+                echo
+                echo -e "${COLOR_FAIL}Unknown command${COLOR_NONE}: '$1'"
+                exit 1
                 ;;
         esac
         shift


### PR DESCRIPTION
When no arguments are provided to `script/test`, the script prints `$1: unbound variable` and exits without printing the usage information. This is due to the `set -u` at the top. 

This PR has a small fix so that a newbie like me is presented with the usage information. Also, it prints an error when it detect an unknown command.

Please note that the arguments to the commands themselves are not validated.

Thanks!