### PR TITLE
[cli] fix compile warning

### DIFF
--- a/src/cli/cli_config.h
+++ b/src/cli/cli_config.h
@@ -37,8 +37,6 @@
 
 #include "openthread-core-config.h"
 
-#include <openthread/config.h>
-
 /**
  * @def OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH
  *

--- a/src/cli/cli_config.h
+++ b/src/cli/cli_config.h
@@ -35,6 +35,8 @@
 #ifndef CONFIG_CLI_H_
 #define CONFIG_CLI_H_
 
+#include "openthread-core-config.h"
+
 #include <openthread/config.h>
 
 /**

--- a/src/cli/cli_console.hpp
+++ b/src/cli/cli_console.hpp
@@ -34,8 +34,9 @@
 #ifndef CLI_CONSOLE_HPP_
 #define CLI_CONSOLE_HPP_
 
-#include "cli_config.h"
 #include "openthread-core-config.h"
+
+#include "cli_config.h"
 
 #include <openthread/cli.h>
 

--- a/src/cli/cli_console.hpp
+++ b/src/cli/cli_console.hpp
@@ -34,8 +34,6 @@
 #ifndef CLI_CONSOLE_HPP_
 #define CLI_CONSOLE_HPP_
 
-#include "openthread-core-config.h"
-
 #include "cli_config.h"
 
 #include <openthread/cli.h>


### PR DESCRIPTION
Fix compile warning: "OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE"
is not defined, evaluates to 0 [-Wundef]