### PR TITLE
[message] add helper macros to free message (on error)

### DIFF
--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -283,11 +283,7 @@ void Manager::SendMulticastListenerRegistrationResponse(const Coap::Message &   
     SuccessOrExit(error = Get<Tmf::TmfAgent>().SendMessage(*message, aMessageInfo));
 
 exit:
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     otLogInfoBbr("Sent MLR.rsp (status=%d): %s", aStatus, otThreadErrorToString(error));
 }
 
@@ -370,11 +366,7 @@ void Manager::SendDuaRegistrationResponse(const Coap::Message &      aMessage,
     SuccessOrExit(error = Get<Tmf::TmfAgent>().SendMessage(*message, aMessageInfo));
 
 exit:
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     otLogInfoBbr("Sent DUA.rsp for DUA %s, status %d %s", aTarget.ToString().AsCString(), aStatus,
                  otThreadErrorToString(error));
 }

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -279,12 +279,7 @@ otError CoapBase::SendEmptyMessage(Type aType, const Message &aRequest, const Ip
     SuccessOrExit(error = Send(*message, aMessageInfo));
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -317,12 +312,7 @@ otError CoapBase::SendHeaderResponse(Message::Code aCode, const Message &aReques
     SuccessOrExit(error = SendMessage(*message, aMessageInfo));
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -440,13 +430,7 @@ Message *CoapBase::CopyAndEnqueueMessage(const Message &aMessage, uint16_t aCopy
     mPendingRequests.Enqueue(*messageCopy);
 
 exit:
-
-    if (error != OT_ERROR_NONE && messageCopy != nullptr)
-    {
-        messageCopy->Free();
-        messageCopy = nullptr;
-    }
-
+    FreeAndNullMessageOnError(messageCopy, error);
     return messageCopy;
 }
 
@@ -481,11 +465,7 @@ exit:
     if (error != OT_ERROR_NONE)
     {
         otLogWarnCoap("Failed to send copy: %s", otThreadErrorToString(error));
-
-        if (messageCopy != nullptr)
-        {
-            messageCopy->Free();
-        }
+        FreeMessage(messageCopy);
     }
 }
 
@@ -762,10 +742,7 @@ exit:
             IgnoreError(SendNotFound(aMessage, aMessageInfo));
         }
 
-        if (cachedResponse != nullptr)
-        {
-            cachedResponse->Free();
-        }
+        FreeMessage(cachedResponse);
     }
 }
 

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -178,11 +178,7 @@ void CoapSecure::HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength)
     CoapBase::Receive(*message, mDtls.GetMessageInfo());
 
 exit:
-
-    if (message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessage(message);
 }
 
 void CoapSecure::HandleTransmit(Tasklet &aTasklet)

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -591,13 +591,7 @@ Message *Message::Clone(uint16_t aLength) const
 #endif
 
 exit:
-
-    if (error != OT_ERROR_NONE && messageCopy != nullptr)
-    {
-        messageCopy->Free();
-        messageCopy = nullptr;
-    }
-
+    FreeAndNullMessageOnError(messageCopy, error);
     return messageCopy;
 }
 

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -53,8 +53,6 @@
 
 namespace ot {
 
-class ThreadLinkInfo;
-
 /**
  * @addtogroup core-message
  *
@@ -64,6 +62,61 @@ class ThreadLinkInfo;
  * @{
  *
  */
+
+/**
+ * This macro frees a given message buffer if not nullptr.
+ *
+ * This macro and the ones that follow contain small but common code patterns used in many of the core modules. They
+ * are intentionally defined as macros instead of inline methods/functions to ensure that they are fully inlined.
+ * Note that an `inline` method/function is not necessarily always inlined by the toolchain and not inlining such
+ * small implementations can add a rather large code-size overhead.
+ *
+ * @param[in] aMessage    A pointer to a `Message` to free (can be nullptr).
+ *
+ */
+#define FreeMessage(aMessage)      \
+    do                             \
+    {                              \
+        if ((aMessage) != nullptr) \
+        {                          \
+            (aMessage)->Free();    \
+        }                          \
+    } while (false)
+
+/**
+ * This macro frees a given message buffer if a given `otError` indicates an error.
+ *
+ * The parameter @p aMessage can be nullptr in which case this macro does nothing.
+ *
+ * @param[in] aMessage    A pointer to a `Message` to free (can be nullptr).
+ * @param[in] aError      The `otError` to check.
+ *
+ */
+#define FreeMessageOnError(aMessage, aError)                        \
+    do                                                              \
+    {                                                               \
+        if (((aError) != OT_ERROR_NONE) && ((aMessage) != nullptr)) \
+        {                                                           \
+            (aMessage)->Free();                                     \
+        }                                                           \
+    } while (false)
+
+/**
+ * This macro frees a given message buffer if a given `otError` indicates an error and sets the `aMessage` to `nullptr`.
+ *
+ * @param[in] aMessage    A pointer to a `Message` to free (can be nullptr).
+ * @param[in] aError      The `otError` to check.
+ *
+ */
+#define FreeAndNullMessageOnError(aMessage, aError)                 \
+    do                                                              \
+    {                                                               \
+        if (((aError) != OT_ERROR_NONE) && ((aMessage) != nullptr)) \
+        {                                                           \
+            (aMessage)->Free();                                     \
+            (aMessage) = nullptr;                                   \
+        }                                                           \
+    } while (false)
 
 enum
 {
@@ -75,6 +128,7 @@ class Message;
 class MessagePool;
 class MessageQueue;
 class PriorityQueue;
+class ThreadLinkInfo;
 
 /**
  * This structure contains metadata about a Message.

--- a/src/core/meshcop/announce_begin_client.cpp
+++ b/src/core/meshcop/announce_begin_client.cpp
@@ -88,12 +88,7 @@ otError AnnounceBeginClient::SendRequest(uint32_t            aChannelMask,
     otLogInfoMeshCoP("sent announce begin query");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -174,11 +174,7 @@ static void SendErrorMessage(Coap::CoapSecure &aCoapSecure, ForwardContext &aFor
     SuccessOrExit(error = aCoapSecure.SendMessage(*message, aCoapSecure.GetMessageInfo()));
 
 exit:
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogError("send error CoAP message", error);
 }
 
@@ -211,11 +207,7 @@ static void SendErrorMessage(Coap::CoapSecure &   aCoapSecure,
     SuccessOrExit(error = aCoapSecure.SendMessage(*message, aCoapSecure.GetMessageInfo()));
 
 exit:
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogError("send error CoAP message", error);
 }
 
@@ -265,12 +257,10 @@ void BorderAgent::HandleCoapResponse(void *               aContext,
     SuccessOrExit(error = borderAgent.ForwardToCommissioner(*message, *response));
 
 exit:
+
     if (error != OT_ERROR_NONE)
     {
-        if (message != nullptr)
-        {
-            message->Free();
-        }
+        FreeMessage(message);
 
         otLogWarnMeshCoP("Commissioner request[%hu] failed: %s", forwardContext.GetMessageId(),
                          otThreadErrorToString(error));
@@ -401,11 +391,7 @@ void BorderAgent::HandleProxyTransmit(const Coap::Message &aMessage)
     otLogInfoMeshCoP("Proxy transmit sent");
 
 exit:
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogError("send proxy stream", error);
 }
 
@@ -449,11 +435,7 @@ bool BorderAgent::HandleUdpReceive(const Message &aMessage, const Ip6::MessageIn
     otLogInfoMeshCoP("Sent to commissioner on %s", UriPath::kProxyRx);
 
 exit:
-    if (message != nullptr && error != OT_ERROR_NONE)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogError("notify commissioner on ProxyRx (c/ur)", error);
 
     return error != OT_ERROR_DESTINATION_ADDRESS_FILTERED;
@@ -479,10 +461,7 @@ void BorderAgent::HandleRelayReceive(const Coap::Message &aMessage)
     otLogInfoMeshCoP("Sent to commissioner on %s", UriPath::kRelayRx);
 
 exit:
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 otError BorderAgent::ForwardToCommissioner(Coap::Message &aForwardMessage, const Message &aMessage)
@@ -548,14 +527,7 @@ void BorderAgent::HandleRelayTransmit(const Coap::Message &aMessage)
     otLogInfoMeshCoP("Sent to joiner router request on %s", UriPath::kRelayTx);
 
 exit:
-    if (error != OT_ERROR_NONE)
-    {
-        if (message != nullptr)
-        {
-            message->Free();
-        }
-    }
-
+    FreeMessageOnError(message, error);
     LogError("send to joiner router request RelayTx (c/tx)", error);
 }
 
@@ -617,11 +589,7 @@ exit:
             GetInstance().HeapFree(forwardContext);
         }
 
-        if (message != nullptr)
-        {
-            message->Free();
-        }
-
+        FreeMessage(message);
         SendErrorMessage(Get<Coap::CoapSecure>(), aMessage, aSeparate, error);
     }
 

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -714,12 +714,7 @@ otError Commissioner::SendMgmtCommissionerGetRequest(const uint8_t *aTlvs, uint8
     otLogInfoMeshCoP("sent MGMT_COMMISSIONER_GET.req to leader");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -800,12 +795,7 @@ otError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDatase
     otLogInfoMeshCoP("sent MGMT_COMMISSIONER_SET.req to leader");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -859,12 +849,7 @@ otError Commissioner::SendPetition(void)
     otLogInfoMeshCoP("sent petition");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -959,11 +944,7 @@ void Commissioner::SendKeepAlive(uint16_t aSessionId)
     otLogInfoMeshCoP("sent keep alive");
 
 exit:
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogError("send keep alive", error);
 }
 
@@ -1168,11 +1149,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Message &aRequest, State
     otLogInfoMeshCoP("sent joiner finalize response");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 otError Commissioner::SendRelayTransmit(void *aContext, Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -1222,12 +1199,7 @@ otError Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::MessageInf
     aMessage.Free();
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -308,12 +308,7 @@ exit:
 
     default:
         otLogWarnMeshCoP("Failed to send %s to leader: %s", mUriSet, otThreadErrorToString(error));
-
-        if (message != nullptr)
-        {
-            message->Free();
-        }
-
+        FreeMessage(message);
         break;
     }
 }
@@ -436,11 +431,7 @@ void DatasetManager::SendGetResponse(const Coap::Message &   aRequest,
     otLogInfoMeshCoP("sent dataset get response");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, const uint8_t *aTlvs, uint8_t aLength)
@@ -584,12 +575,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
     otLogInfoMeshCoP("sent dataset set request to leader");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -709,12 +695,7 @@ otError DatasetManager::SendGetRequest(const otOperationalDatasetComponents &aDa
     otLogInfoMeshCoP("sent dataset get request");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -288,11 +288,7 @@ void DatasetManager::SendSetResponse(const Coap::Message &   aRequest,
     otLogInfoMeshCoP("sent dataset set response");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 otError DatasetManager::DatasetTlv::ReadFromMessage(const Message &aMessage, uint16_t aOffset)

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -932,12 +932,7 @@ otError Dtls::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, Message::Sub
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -99,12 +99,7 @@ otError EnergyScanClient::SendQuery(uint32_t                           aChannelM
     mContext  = aContext;
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -611,11 +611,7 @@ void Joiner::SendJoinerEntrustResponse(const Coap::Message &aRequest, const Ip6:
     otLogCertMeshCoP("[THCI] direction=send | type=JOIN_ENT.rsp");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 void Joiner::HandleTimer(Timer &aTimer)

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -170,11 +170,7 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
     otLogInfoMeshCoP("Sent relay rx");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 void JoinerRouter::HandleRelayTransmit(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
@@ -224,10 +220,7 @@ void JoinerRouter::HandleRelayTransmit(Coap::Message &aMessage, const Ip6::Messa
     }
 
 exit:
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 void JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessageInfo, const Kek &aKek)
@@ -253,11 +246,7 @@ void JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessageInf
     }
 
 exit:
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogError("schedule joiner entrust", error);
 }
 
@@ -320,11 +309,7 @@ otError JoinerRouter::SendJoinerEntrust(const Ip6::MessageInfo &aMessageInfo)
     otLogCertMeshCoP("[THCI] direction=send | type=JOIN_ENT.ntf");
 
 exit:
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -407,13 +392,7 @@ Coap::Message *JoinerRouter::PrepareJoinerEntrustMessage(void)
         error = Tlv::AppendUint32Tlv(*message, Tlv::kNetworkKeySequence, Get<KeyManager>().GetCurrentKeySequence()));
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-        message = nullptr;
-    }
-
+    FreeAndNullMessageOnError(message, error);
     return message;
 }
 

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -149,12 +149,7 @@ void Leader::SendPetitionResponse(const Coap::Message &   aRequest,
     otLogInfoMeshCoP("sent petition response");
 
 exit:
-
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogError("send petition response", error);
 }
 
@@ -228,12 +223,7 @@ void Leader::SendKeepAliveResponse(const Coap::Message &   aRequest,
     otLogInfoMeshCoP("sent keep alive response");
 
 exit:
-
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogError("send keep alive response", error);
 }
 
@@ -255,12 +245,7 @@ void Leader::SendDatasetChanged(const Ip6::Address &aAddress)
     otLogInfoMeshCoP("sent dataset changed");
 
 exit:
-
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogError("send dataset changed", error);
 }
 

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -94,12 +94,7 @@ otError PanIdQueryClient::SendQuery(uint16_t                            aPanId,
     mContext  = aContext;
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -286,15 +286,10 @@ void Client::Solicit(uint16_t aRloc16)
     otLogInfoIp6("solicit");
 
 exit:
-
-    if (message != nullptr)
+    if (error != OT_ERROR_NONE)
     {
+        FreeMessage(message);
         otLogWarnIp6("Failed to send DHCPv6 Solicit: %s", otThreadErrorToString(error));
-
-        if (error != OT_ERROR_NONE)
-        {
-            message->Free();
-        }
     }
 }
 

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -349,12 +349,7 @@ otError Server::SendReply(const Ip6::Address & aDst,
     SuccessOrExit(error = mSocket.SendTo(*message, messageInfo));
 
 exit:
-
-    if (message != nullptr && error != OT_ERROR_NONE)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -131,10 +131,7 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        if (message)
-        {
-            message->Free();
-        }
+        FreeMessage(message);
 
         if (messageCopy)
         {
@@ -172,13 +169,7 @@ Message *Client::CopyAndEnqueueMessage(const Message &aMessage, const QueryMetad
     mRetransmissionTimer.FireAtIfEarlier(aQueryMetadata.mTransmissionTime);
 
 exit:
-
-    if (error != OT_ERROR_NONE && messageCopy != nullptr)
-    {
-        messageCopy->Free();
-        messageCopy = nullptr;
-    }
-
+    FreeAndNullMessageOnError(messageCopy, error);
     return messageCopy;
 }
 
@@ -217,12 +208,8 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
+        FreeMessage(messageCopy);
         otLogWarnIp6("Failed to send DNS request: %s", otThreadErrorToString(error));
-
-        if (messageCopy != nullptr)
-        {
-            messageCopy->Free();
-        }
     }
 }
 

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -127,12 +127,7 @@ otError Icmp::SendError(Header::Type       aType,
     otLogInfoIcmp("Sent ICMPv6 Error");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -227,12 +222,7 @@ otError Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMe
     otLogInfoIcmp("Sent Echo Reply (seq = %d)", icmp6Header.GetSequence());
 
 exit:
-
-    if (error != OT_ERROR_NONE && replyMessage != nullptr)
-    {
-        replyMessage->Free();
-    }
-
+    FreeMessageOnError(replyMessage, error);
     return error;
 }
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -669,11 +669,7 @@ exit:
         otLogWarnIp6("No buffer for Ip6 fragmentation");
     }
 
-    if (error != OT_ERROR_NONE && fragment != nullptr)
-    {
-        fragment->Free();
-    }
-
+    FreeMessageOnError(fragment, error);
     return error;
 }
 

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -331,11 +331,7 @@ void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSeque
     mRetransmissionTimer.FireAtIfEarlier(metadata.mTransmissionTime);
 
 exit:
-
-    if (error != OT_ERROR_NONE && messageCopy != nullptr)
-    {
-        messageCopy->Free();
-    }
+    FreeMessageOnError(messageCopy, error);
 }
 
 void Mpl::HandleRetransmissionTimer(Timer &aTimer)

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -199,13 +199,7 @@ Message *Client::CopyAndEnqueueMessage(const Message &aMessage, const QueryMetad
     mRetransmissionTimer.FireAtIfEarlier(aQueryMetadata.mTransmissionTime);
 
 exit:
-
-    if (error != OT_ERROR_NONE && messageCopy != nullptr)
-    {
-        messageCopy->Free();
-        messageCopy = nullptr;
-    }
-
+    FreeAndNullMessageOnError(messageCopy, error);
     return messageCopy;
 }
 
@@ -241,15 +235,10 @@ void Client::SendCopy(const Message &aMessage, const Ip6::MessageInfo &aMessageI
     SuccessOrExit(error = SendMessage(*messageCopy, aMessageInfo));
 
 exit:
-
     if (error != OT_ERROR_NONE)
     {
+        FreeMessage(messageCopy);
         otLogWarnIp6("Failed to send SNTP request: %s", otThreadErrorToString(error));
-
-        if (messageCopy != nullptr)
-        {
-            messageCopy->Free();
-        }
     }
 }
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -549,12 +549,7 @@ otError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
 exit:
 
     Get<TimeTicker>().RegisterReceiver(TimeTicker::kAddressResolver);
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -669,12 +664,8 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
+        FreeMessage(message);
         otLogInfoArp("Failed to send address error: %s", otThreadErrorToString(error));
-
-        if (message != nullptr)
-        {
-            message->Free();
-        }
     }
 }
 
@@ -827,11 +818,7 @@ void AddressResolver::SendAddressQueryResponse(const Ip6::Address &            a
     otLogInfoArp("Sending address notification for target %s", aTarget.ToString().AsCString());
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 void AddressResolver::HandleTimeTick(void)

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -157,12 +157,7 @@ otError DiscoverScanner::Discover(const Mac::ChannelMask &aScanChannels,
     Mle::Log(Mle::kMessageSend, Mle::kTypeDiscoveryRequest, destination);
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -507,11 +507,7 @@ exit:
         UpdateCheckDelay(Mle::kNoBufDelay);
     }
 
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     otLogInfoDua("Sent DUA.req for DUA %s: %s", dua.ToString().AsCString(), otThreadErrorToString(error));
 }
 
@@ -672,16 +668,14 @@ void DuaManager::SendAddressNotification(Ip6::Address &             aAddress,
     otLogInfoDua("Sent ADDR_NTF for child %04x DUA %s", aChild.GetRloc16(), aAddress.ToString().AsCString());
 
 exit:
+
     if (error != OT_ERROR_NONE)
     {
+        FreeMessage(message);
+
         // TODO: (DUA) (P4) may enhance to  guarantee the delivery of DUA.ntf
         otLogWarnDua("Sent ADDR_NTF for child %04x DUA %s Error %s", aChild.GetRloc16(),
                      aAddress.ToString().AsCString(), otThreadErrorToString(error));
-
-        if (message != nullptr)
-        {
-            message->Free();
-        }
     }
 }
 

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -197,14 +197,8 @@ void EnergyScanServer::SendReport(void)
     otLogInfoMeshCoP("sent scan results");
 
 exit:
-
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     MeshCoP::LogError("send scan results", error);
-
     mActive = false;
 }
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1059,11 +1059,7 @@ exit:
     {
         LogFragmentFrameDrop(error, aFrameLength, aMacSource, aMacDest, fragmentHeader,
                              aLinkInfo.IsLinkSecurityEnabled());
-
-        if (message != nullptr)
-        {
-            message->Free();
-        }
+        FreeMessage(message);
     }
 }
 
@@ -1197,11 +1193,7 @@ exit:
     else
     {
         LogLowpanHcFrameDrop(error, aFrameLength, aMacSource, aMacDest, aLinkInfo.IsLinkSecurityEnabled());
-
-        if (message != nullptr)
-        {
-            message->Free();
-        }
+        FreeMessage(message);
     }
 }
 

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -595,10 +595,7 @@ exit:
         SendDestinationUnreachable(aMeshSource.GetShort(), *message);
     }
 
-    if (message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessage(message);
 
     return error;
 }
@@ -686,11 +683,7 @@ exit:
     {
         otLogInfoMac("Dropping rx mesh frame, error:%s, len:%d, src:%s, sec:%s", otThreadErrorToString(error),
                      aFrameLength, aMacSource.ToString().AsCString(), aLinkInfo.IsLinkSecurityEnabled() ? "yes" : "no");
-
-        if (message != nullptr)
-        {
-            message->Free();
-        }
+        FreeMessage(message);
     }
 }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1951,12 +1951,7 @@ otError Mle::SendParentRequest(ParentRequestType aType)
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -2033,12 +2028,7 @@ otError Mle::SendChildIdRequest(void)
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -2073,11 +2063,7 @@ otError Mle::SendDataRequest(const Ip6::Address &aDestination,
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 
     if (IsChild() && !IsRxOnWhenIdle())
     {
@@ -2286,12 +2272,7 @@ otError Mle::SendChildUpdateRequest(void)
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -2358,12 +2339,7 @@ otError Mle::SendChildUpdateResponse(const uint8_t *aTlvs, uint8_t aNumTlvs, con
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -2415,11 +2391,7 @@ void Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Addres
     otLogInfoMle("Send Announce on channel %d", aChannel);
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 otError Mle::SendOrphanAnnounce(void)
@@ -3785,10 +3757,7 @@ exit:
     {
         otLogWarnMle("Failed to inform previous parent: %s", otThreadErrorToString(error));
 
-        if (message != nullptr)
-        {
-            message->Free();
-        }
+        FreeMessage(message);
     }
 }
 #endif // OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -465,12 +465,7 @@ void MleRouter::SendAdvertisement(void)
     Log(kMessageSend, kTypeAdvertisement, destination);
 
 exit:
-
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogSendError(kTypeAdvertisement, error);
 }
 
@@ -555,12 +550,7 @@ otError MleRouter::SendLinkRequest(Neighbor *aNeighbor)
     Log(kMessageSend, kTypeLinkRequest, destination);
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -761,12 +751,7 @@ otError MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo,
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -1968,12 +1953,7 @@ void MleRouter::SendParentResponse(Child *aChild, const Challenge &aChallenge, b
     Log(kMessageDelay, kTypeParentResponse, destination);
 
 exit:
-
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogSendError(kTypeParentResponse, error);
 }
 
@@ -2995,12 +2975,7 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
     Log(kMessageDelay, kTypeDiscoveryResponse, aDestination);
 
 exit:
-
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogProcessError(kTypeDiscoveryResponse, error);
     return error;
 }
@@ -3092,12 +3067,7 @@ otError MleRouter::SendChildIdResponse(Child &aChild)
     Log(kMessageSend, kTypeChildIdResponse, destination, aChild.GetRloc16());
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -3158,12 +3128,7 @@ otError MleRouter::SendChildUpdateRequest(Child &aChild)
     Log(kMessageSend, kTypeChildUpdateRequestOfChild, destination, aChild.GetRloc16());
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -3239,11 +3204,7 @@ void MleRouter::SendChildUpdateResponse(Child *                 aChild,
     }
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 void MleRouter::SendDataResponse(const Ip6::Address &aDestination,
@@ -3308,12 +3269,7 @@ void MleRouter::SendDataResponse(const Ip6::Address &aDestination,
     }
 
 exit:
-
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogSendError(kTypeDataResponse, error);
 }
 
@@ -3603,12 +3559,7 @@ otError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
     Log(kMessageSend, kTypeAddressSolicit, messageInfo.GetPeerAddr());
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -3636,12 +3587,7 @@ void MleRouter::SendAddressRelease(void)
     Log(kMessageSend, kTypeAddressRelease, messageInfo.GetPeerAddr());
 
 exit:
-
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     LogSendError(kTypeAddressRelease, error);
 }
 
@@ -3879,11 +3825,7 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Message &   aRequest,
     Log(kMessageSend, kTypeAddressReply, aMessageInfo.GetPeerAddr());
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 void MleRouter::HandleAddressRelease(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
@@ -4432,12 +4374,7 @@ otError MleRouter::SendTimeSync(void)
     Log(kMessageSend, kTypeTimeSync, destination);
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -439,12 +439,7 @@ otError MlrManager::SendMulticastListenerRegistrationMessage(const otIp6Address 
 
 exit:
     otLogInfoMlr("Send MLR.req: %s, addressNum=%d", otThreadErrorToString(error), aAddressNum);
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -833,12 +833,7 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16, Coap::Response
     otLogInfoNetData("Sent server data notification");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -355,11 +355,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Message &   aRequest,
     otLogInfoMeshCoP("sent commissioning dataset get response");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 void Leader::SendCommissioningSetResponse(const Coap::Message &    aRequest,
@@ -381,11 +377,7 @@ void Leader::SendCommissioningSetResponse(const Coap::Message &    aRequest,
     otLogInfoMeshCoP("sent commissioning dataset set response");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 bool Leader::RlocMatch(uint16_t aFirstRloc16, uint16_t aSecondRloc16, MatchMode aMatchMode)

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -124,12 +124,7 @@ otError NetworkDiagnostic::SendDiagnosticGet(const Ip6::Address &aDestination,
     otLogInfoNetDiag("Sent diagnostic get");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 
@@ -525,11 +520,7 @@ void NetworkDiagnostic::HandleDiagnosticGetQuery(Coap::Message &aMessage, const 
     otLogInfoNetDiag("Sent diagnostic get answer");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 void NetworkDiagnostic::HandleDiagnosticGetRequest(void *               aContext,
@@ -575,11 +566,7 @@ void NetworkDiagnostic::HandleDiagnosticGetRequest(Coap::Message &aMessage, cons
     otLogInfoNetDiag("Sent diagnostic get response");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessageOnError(message, error);
 }
 
 otError NetworkDiagnostic::SendDiagnosticReset(const Ip6::Address &aDestination,
@@ -621,12 +608,7 @@ otError NetworkDiagnostic::SendDiagnosticReset(const Ip6::Address &aDestination,
     otLogInfoNetDiag("Sent network diagnostic reset");
 
 exit:
-
-    if (error != OT_ERROR_NONE && message != nullptr)
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     return error;
 }
 

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -134,12 +134,7 @@ void PanIdQueryServer::SendConflict(void)
     otLogInfoMeshCoP("sent panid conflict");
 
 exit:
-
-    if ((error != OT_ERROR_NONE) && (message != nullptr))
-    {
-        message->Free();
-    }
-
+    FreeMessageOnError(message, error);
     MeshCoP::LogError("send panid conflict", error);
 }
 

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -97,11 +97,7 @@ void ChildSupervisor::SendMessage(Child &aChild)
     otLogInfoUtil("Sending supervision message to child 0x%04x", aChild.GetRloc16());
 
 exit:
-
-    if (message != nullptr)
-    {
-        message->Free();
-    }
+    FreeMessage(message);
 }
 
 void ChildSupervisor::UpdateOnSend(Child &aChild)


### PR DESCRIPTION
This commit adds macros `FreeMessage()`, `FreeMessageOnError(`' and
`FreeAndNullMessageOnError()` which would free a given `Message`
pointer if not `nullptr` (conditionally on an `otError`).

These macros implement small yet common code patterns used in many of
the core modules. They are intentionally defined as macros instead of
inline methods/functions to ensure that they are fully inlined. Note
that an `inline` method/function is not necessarily always inlined by
the toolchain, and not inlining such small implementations could add a
rather large code-size overhead.