### PR TITLE
[scripts] fix test_route_table.py

### DIFF
--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -159,6 +159,7 @@ EXTRA_DIST                                                         = \
     test_network_layer.py                                            \
     test_reed_address_solicit_rejected.py                            \
     test_reset.py                                                    \
+    test_route_table.py                                              \
     test_router_reattach.py                                          \
     test_service.py                                                  \
     thread_cert.py                                                   \
@@ -205,6 +206,7 @@ check_SCRIPTS                                                      = \
     test_network_layer.py                                            \
     test_reed_address_solicit_rejected.py                            \
     test_reset.py                                                    \
+    test_route_table.py                                              \
     test_router_reattach.py                                          \
     test_service.py                                                  \
     Cert_5_1_01_RouterAttach.py                                      \

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1573,7 +1573,7 @@ class Node:
         self._expect([r'(\d+)((\s\d+)*)'])
 
         g = self.pexpect.match.groups()
-        router_list = g[0] + ' ' + g[1]
+        router_list = g[0].decode('utf8') + ' ' + g[1].decode('utf8')
         router_list = [int(x) for x in router_list.split()]
         self._expect('Done')
         return router_list
@@ -1584,7 +1584,7 @@ class Node:
 
         self._expect(r'(.*)Done')
         g = self.pexpect.match.groups()
-        output = g[0]
+        output = g[0].decode('utf8')
         lines = output.strip().split('\n')
         lines = [l.strip() for l in lines]
         router_table = {}

--- a/tests/scripts/thread-cert/test_route_table.py
+++ b/tests/scripts/thread-cert/test_route_table.py
@@ -41,6 +41,8 @@ ROUTER2 = 3
 
 
 class TestRouteTable(thread_cert.TestCase):
+    SUPPORT_NCP = False
+
     TOPOLOGY = {
         LEADER: {
             'mode': 'rsdn',


### PR DESCRIPTION
Turn out `test_route_table.py` was never tested. 
This PR fixes and adds `test_route_table.py` to the test suite. 