### PR TITLE
[meshcop] include logging.hpp for helper function 'LogError()'

### DIFF
--- a/src/core/meshcop/meshcop.cpp
+++ b/src/core/meshcop/meshcop.cpp
@@ -36,6 +36,7 @@
 #include "common/crc16.hpp"
 #include "common/debug.hpp"
 #include "common/locator-getters.hpp"
+#include "common/logging.hpp"
 #include "crypto/pbkdf2_cmac.h"
 #include "crypto/sha256.hpp"
 #include "mac/mac_types.hpp"


### PR DESCRIPTION
`LogError()` uses `otLogWarnMeshCoP()`, which was included by `thread/thread_netif.hpp -> meshcop/joiner.hpp -> common/logging.hpp`.
`thread_netif.hpp` includes `joiner.hpp` only if `OT_JOINER=ON`, so the build would fail if `OT_JOINER=OFF`. This PR fixes it.