### PR TITLE
[simulation] add configuration MAX_NETWORK_SIZE

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -72,6 +72,7 @@ jobs:
       REFERENCE_DEVICE: 1
       VIRTUAL_TIME: 1
       VIRTUAL_TIME_UART: 1
+      MAX_NETWORK_SIZE: 999
     steps:
     - uses: actions/checkout@v2
     - uses: actions/setup-go@v1

--- a/examples/Makefile-simulation
+++ b/examples/Makefile-simulation
@@ -103,6 +103,10 @@ ifeq ($(VIRTUAL_TIME_UART),1)
 COMMONCFLAGS                   += -DOPENTHREAD_SIMULATION_VIRTUAL_TIME_UART=1
 endif
 
+ifneq ($(MAX_NETWORK_SIZE),)
+COMMONCFLAGS                   += -DOPENTHREAD_SIMULATION_MAX_NETWORK_SIZE=$(MAX_NETWORK_SIZE)
+endif
+
 include $(dir $(abspath $(lastword $(MAKEFILE_LIST))))/common-switches.mk
 
 TopSourceDir                   := $(dir $(shell readlink $(firstword $(MAKEFILE_LIST))))..

--- a/examples/platforms/simulation/CMakeLists.txt
+++ b/examples/platforms/simulation/CMakeLists.txt
@@ -38,6 +38,11 @@ if(OT_SIMULATION_VIRTUAL_TIME_UART)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_SIMULATION_VIRTUAL_TIME_UART=1")
 endif()
 
+option(OT_SIMULATION_MAX_NETWORK_SIZE "set maximum network size (default: 33)")
+if(OT_SIMULATION_MAX_NETWORK_SIZE)
+    target_compile_definitions(ot-config INTERFACE "OPENTHREAD_SIMULATION_MAX_NETWORK_SIZE=${OT_SIMULATION_MAX_NETWORK_SIZE}")
+endif()
+
 if(NOT OT_CONFIG)
     set(OT_CONFIG "openthread-core-simulation-config.h")
     set(OT_CONFIG ${OT_CONFIG} PARENT_SCOPE)

--- a/examples/platforms/simulation/platform-config.h
+++ b/examples/platforms/simulation/platform-config.h
@@ -93,3 +93,13 @@
 #endif
 
 #endif // OPENTHREAD_CONFIG_OTNS_ENABLE
+
+/**
+ * @def OPENTHREAD_SIMULATION_MAX_NETWORK_SIZE
+ *
+ * This setting configures the maximum network size in simulation.
+ *
+ */
+#ifndef OPENTHREAD_SIMULATION_MAX_NETWORK_SIZE
+#define OPENTHREAD_SIMULATION_MAX_NETWORK_SIZE 33
+#endif

--- a/examples/platforms/simulation/platform-simulation.h
+++ b/examples/platforms/simulation/platform-simulation.h
@@ -81,11 +81,7 @@ struct Event
 
 enum
 {
-#if OPENTHREAD_CONFIG_OTNS_ENABLE
-    WELLKNOWN_NODE_ID = 1000, ///< Well-known Unique ID used by a simulated radio that supports promiscuous mode.
-#else
-    WELLKNOWN_NODE_ID = 34, ///< Well-known Unique ID used by a simulated radio that supports promiscuous mode.
-#endif
+    MAX_NETWORK_SIZE = OPENTHREAD_SIMULATION_MAX_NETWORK_SIZE,
 };
 
 /**

--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -309,7 +309,7 @@ static void initFds(void)
     }
 
     sockaddr.sin_family      = AF_INET;
-    sockaddr.sin_port        = htons((uint16_t)(9000 + sPortOffset + WELLKNOWN_NODE_ID));
+    sockaddr.sin_port        = htons((uint16_t)(9000 + sPortOffset));
     sockaddr.sin_addr.s_addr = inet_addr(OT_RADIO_GROUP);
 
     otEXPECT_ACTION(bind(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != -1, perror("bind(sRxFd)"));
@@ -344,7 +344,7 @@ void platformRadioInit(void)
             exit(EXIT_FAILURE);
         }
 
-        sPortOffset *= WELLKNOWN_NODE_ID;
+        sPortOffset *= (MAX_NETWORK_SIZE + 1);
     }
 
     initFds();
@@ -804,7 +804,7 @@ void radioTransmit(struct RadioMessage *aMessage, const struct otRadioFrame *aFr
     sockaddr.sin_family = AF_INET;
     inet_pton(AF_INET, OT_RADIO_GROUP, &sockaddr.sin_addr);
 
-    sockaddr.sin_port = htons((uint16_t)(9000 + sPortOffset + WELLKNOWN_NODE_ID));
+    sockaddr.sin_port = htons((uint16_t)(9000 + sPortOffset));
     rval =
         sendto(sTxFd, (const char *)aMessage, 1 + aFrame->mLength, 0, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
 

--- a/examples/platforms/simulation/system.c
+++ b/examples/platforms/simulation/system.c
@@ -95,7 +95,7 @@ void otSysInit(int aArgCount, char *aArgVector[])
 
     gNodeId = (uint32_t)strtol(aArgVector[argIndex], &endptr, 0);
 
-    if (*endptr != '\0' || gNodeId < 1 || gNodeId >= WELLKNOWN_NODE_ID)
+    if (*endptr != '\0' || gNodeId < 1 || gNodeId > MAX_NETWORK_SIZE)
     {
         fprintf(stderr, "Invalid NodeId: %s\n", aArgVector[argIndex]);
         exit(EXIT_FAILURE);

--- a/examples/platforms/simulation/virtual_time/platform-sim.c
+++ b/examples/platforms/simulation/virtual_time/platform-sim.c
@@ -193,7 +193,7 @@ static void socket_init(void)
             exit(EXIT_FAILURE);
         }
 
-        sPortOffset *= WELLKNOWN_NODE_ID;
+        sPortOffset *= (MAX_NETWORK_SIZE + 1);
     }
 
     sockaddr.sin_port        = htons((uint16_t)(9000 + sPortOffset + gNodeId));
@@ -237,7 +237,7 @@ void otSysInit(int argc, char *argv[])
 
     gNodeId = (uint32_t)strtol(argv[1], &endptr, 0);
 
-    if (*endptr != '\0' || gNodeId < 1 || gNodeId >= WELLKNOWN_NODE_ID)
+    if (*endptr != '\0' || gNodeId < 1 || gNodeId > MAX_NETWORK_SIZE)
     {
         fprintf(stderr, "Invalid NodeId: %s\n", argv[1]);
         exit(EXIT_FAILURE);

--- a/src/posix/platform/virtual_time.cpp
+++ b/src/posix/platform/virtual_time.cpp
@@ -44,9 +44,9 @@
 
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
 
-static const int kWellKnownNodeId = 34;      ///< Well-known ID used by a simulated radio supporting promiscuous mode.
-static const int kBasePort        = 18000;   ///< This base port for posix app simulation.
-static const int kUsPerSecond     = 1000000; ///< Number of microseconds per second.
+static const int kMaxNetworkSize = 33;      ///< Well-known ID used by a simulated radio supporting promiscuous mode.
+static const int kBasePort       = 18000;   ///< This base port for posix app simulation.
+static const int kUsPerSecond    = 1000000; ///< Number of microseconds per second.
 
 static uint64_t sNow        = 0;  ///< Time of simulation.
 static int      sSockFd     = -1; ///< Socket used to communicating with simulator.
@@ -77,7 +77,7 @@ void virtualTimeInit(uint16_t aNodeId)
             DieNowWithMessage(msg, OT_EXIT_INVALID_ARGUMENTS);
         }
 
-        sPortOffset *= kWellKnownNodeId;
+        sPortOffset *= (kMaxNetworkSize + 1);
     }
 
     sockaddr.sin_port        = htons(kBasePort + sPortOffset + aNodeId);

--- a/tests/scripts/thread-cert/simulator.py
+++ b/tests/scripts/thread-cert/simulator.py
@@ -137,7 +137,7 @@ class VirtualTime(BaseSimulator):
     EVENT_DATA = 5
 
     BASE_PORT = 9000
-    MAX_NODES = 34
+    MAX_NODES = 33
     MAX_MESSAGE = 1024
     END_OF_TIME = float('inf')
     PORT_OFFSET = int(os.getenv('PORT_OFFSET', '0'))
@@ -152,7 +152,7 @@ class VirtualTime(BaseSimulator):
         self.sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
 
         ip = '127.0.0.1'
-        self.port = self.BASE_PORT + (self.PORT_OFFSET * self.MAX_NODES)
+        self.port = self.BASE_PORT + (self.PORT_OFFSET * (self.MAX_NODES + 1))
         self.sock.bind((ip, self.port))
 
         self.devices = {}

--- a/tests/scripts/thread-cert/sniffer_transport.py
+++ b/tests/scripts/thread-cert/sniffer_transport.py
@@ -92,7 +92,7 @@ class SnifferSocketTransport(SnifferTransport):
 
     BASE_PORT = 9000
 
-    WELLKNOWN_NODE_ID = 34
+    MAX_NETWORK_SIZE = 33
 
     PORT_OFFSET = int(os.getenv('PORT_OFFSET', "0"))
 
@@ -110,12 +110,12 @@ class SnifferSocketTransport(SnifferTransport):
     def _nodeid_to_address(self, nodeid, ip_address=''):
         return (
             ip_address,
-            self.BASE_PORT + (self.PORT_OFFSET * self.WELLKNOWN_NODE_ID) + nodeid,
+            self.BASE_PORT + (self.PORT_OFFSET * (self.MAX_NETWORK_SIZE + 1)) + nodeid,
         )
 
     def _address_to_nodeid(self, address):
         _, port = address
-        return (port - self.BASE_PORT - (self.PORT_OFFSET * self.WELLKNOWN_NODE_ID))
+        return (port - self.BASE_PORT - (self.PORT_OFFSET * (self.MAX_NETWORK_SIZE + 1)))
 
     def open(self):
         if self.is_opened:
@@ -130,7 +130,7 @@ class SnifferSocketTransport(SnifferTransport):
         self._socket.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEPORT, 1)
         self._socket.setsockopt(socket.IPPROTO_IP, socket.IP_ADD_MEMBERSHIP,
                                 socket.inet_aton(self.RADIO_GROUP) + socket.inet_aton('127.0.0.1'))
-        self._socket.bind(self._nodeid_to_address(self.WELLKNOWN_NODE_ID))
+        self._socket.bind(self._nodeid_to_address(0))
 
     def close(self):
         if not self.is_opened:


### PR DESCRIPTION
Currently, the `WELLKNOWN_NODE_ID = 34` is not properly defined. 

- In virtual time simulation, `WELLKNOWN_NODE_ID` limits the number of ports each `PORT_OFFSET` can occupy. The virtual time simulator listens at the `nodeid=0` port rather than `nodeid=34` port. So, there is no such thing as wellknown node ID in virtual time simulation. 
- In real time simulation, the sniffer listens at the `nodeid=34` port. **This PR changes it to `nodeid=0` port to be consistent with other parts.** 
- In posix virtual time, the simulator listens at the `nodeid=0` port. So, there is no such thing as wellknown node ID in Posix virtual time. 

Overall, I think `WELLKNOWN_NODE_ID = 34` is not intuitive and not properly defined. Thus this PR changes it to `MAX_NETWORK_SIZE = 33` and make it (configuration `OPENTHREAD_SIMULATION_MAX_NETWORK_SIZE`) configurable in simulation by:
- Makefile configuration: `MAX_NETWORK_SIZE`
- Cmake configuration: `OT_SIMULATION_MAX_NETWORK_SIZE` 