### PR TITLE
[security] disable CC310 and use buildin mbedtls for nrf52840 in OT1.2

### DIFF
--- a/examples/Makefile-nrf52840
+++ b/examples/Makefile-nrf52840
@@ -43,7 +43,14 @@ GCCVersion                      = $(shell expr `$(CC) -dumpversion | cut -f1 -d.
 
 # Disable built-in mbedTLS by default allowing for nrf_security implementation with hardware acceleration.
 # When set to 0 built-in, software implementation would be used.
+ifeq ($(THREAD_VERSION), 1.2)
+ifeq ($(DISABLE_BUILTIN_MBEDTLS), 1)
+$(error for THREAD_VERSION>=1.2, cannot use CC310, please use DISABLE_BUILTIN_MBEDTLS=0)
+endif
+DISABLE_BUILTIN_MBEDTLS        = 0
+else
 DISABLE_BUILTIN_MBEDTLS        ?= 1
+endif
 
 ifeq ($(DISABLE_CC310), 1)
 $(error DISABLE_CC310=1 is deprecated, please use DISABLE_BUILTIN_MBEDTLS=0)


### PR DESCRIPTION
This PR fixes issue #5568.

In OT1.2, the Enh-ACK and Tx frame encryption will be done in interrupt context. However, the decryption is still done in `Mac` layer in normal context. CC310 crypto cell library does not support multi-threading. Change to use software builtin mbedtls library.