### PR TITLE
[codecov] only post coverage check statuses to PRs

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -4,6 +4,7 @@ coverage:
       default:
         target: auto
         threshold: 1%
+        only_pulls: true
     patch: off
 
 ignore:


### PR DESCRIPTION
This makes codecov only check the 1% threshold for PRs, not for commits on master branch. Fixes https://github.com/openthread/openthread/issues/5571.