### PR TITLE
[scripts] fix test_route_table.py fails by chance

### DIFF
--- a/tests/scripts/thread-cert/test_route_table.py
+++ b/tests/scripts/thread-cert/test_route_table.py
@@ -69,9 +69,11 @@ class TestRouteTable(thread_cert.TestCase):
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         self.nodes[ROUTER1].start()
-        self.nodes[ROUTER2].start()
         self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
+
+        self.nodes[ROUTER2].start()
+        self.simulator.go(5)
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'router')
 
         self.simulator.go(100)


### PR DESCRIPTION
Observed that `test_route_table.py` (introduced by #5558) might fail by chance. 
Verified that this PR fixes this isue. 