### PR TITLE
[cli] style fixes and smaller enhancements

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -35,41 +35,30 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include "mac/channel_mask.hpp"
-#include "utils/parse_cmdline.hpp"
 
+#include <openthread/diag.h>
 #include <openthread/icmp6.h>
 #include <openthread/link.h>
+#include <openthread/logging.h>
 #include <openthread/ncp.h>
 #include <openthread/thread.h>
+#include <openthread/platform/uart.h>
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 #include <openthread/network_time.h>
 #endif
-
 #if OPENTHREAD_FTD
 #include <openthread/dataset_ftd.h>
 #include <openthread/thread_ftd.h>
 #endif
-
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 #include <openthread/border_router.h>
 #endif
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 #include <openthread/server.h>
 #endif
-
-#include <openthread/diag.h>
-#include <openthread/icmp6.h>
-#include <openthread/logging.h>
-#include <openthread/platform/uart.h>
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
 #include <openthread/platform/misc.h>
 #endif
-
-#include "common/new.hpp"
-#include "net/ip6.hpp"
-#include "utils/otns.hpp"
-
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 #include <openthread/backbone_router.h>
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
@@ -79,23 +68,23 @@
 #include <openthread/link_metrics.h>
 #endif
 #endif
-
-#include "cli_dataset.hpp"
-
 #if OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
 #include <openthread/channel_manager.h>
 #endif
-
 #if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
 #include <openthread/channel_monitor.h>
 #endif
-
 #if (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_DEBUG_UART) && OPENTHREAD_POSIX
 #include <openthread/platform/debug_uart.h>
 #endif
 
 #include "common/encoding.hpp"
+#include "common/new.hpp"
 #include "common/string.hpp"
+#include "mac/channel_mask.hpp"
+#include "net/ip6.hpp"
+#include "utils/otns.hpp"
+#include "utils/parse_cmdline.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;
@@ -343,12 +332,12 @@ otError Interpreter::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        OutputLine("%s", command.mName);
+        OutputLine(command.mName);
     }
 
     for (uint8_t i = 0; i < mUserCommandsLength; i++)
     {
-        OutputLine("%s", mUserCommands[i].mName);
+        OutputLine(mUserCommands[i].mName);
     }
 
     return OT_ERROR_NONE;
@@ -427,9 +416,6 @@ exit:
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 otError Interpreter::ProcessBackboneRouterMgmtMlr(uint8_t aArgsLength, char **aArgs)
 {
-    OT_UNUSED_VARIABLE(aArgsLength);
-    OT_UNUSED_VARIABLE(aArgs);
-
     otError error = OT_ERROR_INVALID_COMMAND;
 
     VerifyOrExit(aArgsLength >= 1, OT_NOOP);
@@ -448,9 +434,9 @@ otError Interpreter::ProcessBackboneRouterMgmtMlr(uint8_t aArgsLength, char **aA
         }
         else if (!strcmp(aArgs[1], "add"))
         {
-            struct otIp6Address address;
-            unsigned long       value;
-            uint32_t            timeout = 0;
+            otIp6Address  address;
+            unsigned long value;
+            uint32_t      timeout = 0;
 
             VerifyOrExit(aArgsLength == 3 || aArgsLength == 4, error = OT_ERROR_INVALID_ARGS);
 
@@ -598,8 +584,7 @@ otError Interpreter::ProcessDomainName(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        const char *domainName = otThreadGetDomainName(mInstance);
-        OutputLine("%s", static_cast<const char *>(domainName));
+        OutputLine(otThreadGetDomainName(mInstance));
     }
     else
     {
@@ -769,7 +754,7 @@ otError Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
             ExitNow(error = OT_ERROR_INVALID_ARGS);
         }
     }
-#endif
+#endif // OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
 #if OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
     else if (strcmp(aArgs[0], "manager") == 0)
     {
@@ -838,7 +823,7 @@ otError Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
             ExitNow(error = OT_ERROR_INVALID_ARGS);
         }
     }
-#endif
+#endif // OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
     else
     {
         SuccessOrExit(error = ParseLong(aArgs[0], value));
@@ -960,7 +945,6 @@ exit:
 
 otError Interpreter::ProcessChildIp(uint8_t aArgsLength, char *aArgs[])
 {
-    OT_UNUSED_VARIABLE(aArgs);
     otError error = OT_ERROR_NONE;
 
     if (aArgsLength == 0)
@@ -1079,7 +1063,7 @@ otError Interpreter::ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputLine("%s", otPlatRadioIsCoexEnabled(mInstance) ? "Enabled" : "Disabled");
+        OutputLine(otPlatRadioIsCoexEnabled(mInstance) ? "Enabled" : "Disabled");
     }
     else if (strcmp(aArgs[0], "enable") == 0)
     {
@@ -1407,7 +1391,7 @@ void Interpreter::HandleDnsResponse(const char *aHostname, const Ip6::Address *a
 
     mResolvingInProgress = false;
 }
-#endif
+#endif // OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
 
 #if OPENTHREAD_FTD
 otError Interpreter::ProcessEidCache(uint8_t aArgsLength, char *aArgs[])
@@ -1642,8 +1626,8 @@ exit:
 
 otError Interpreter::ProcessIpAddrDel(uint8_t aArgsLength, char *aArgs[])
 {
-    otError             error;
-    struct otIp6Address address;
+    otError      error;
+    otIp6Address address;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
@@ -1705,8 +1689,8 @@ exit:
 
 otError Interpreter::ProcessIpMulticastAddrAdd(uint8_t aArgsLength, char *aArgs[])
 {
-    otError             error;
-    struct otIp6Address address;
+    otError      error;
+    otIp6Address address;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
@@ -1719,8 +1703,8 @@ exit:
 
 otError Interpreter::ProcessIpMulticastAddrDel(uint8_t aArgsLength, char *aArgs[])
 {
-    otError             error;
-    struct otIp6Address address;
+    otError      error;
+    otIp6Address address;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
@@ -2046,7 +2030,7 @@ otError Interpreter::ProcessPskc(uint8_t aArgsLength, char *aArgs[])
 exit:
     return error;
 }
-#endif
+#endif // OPENTHREAD_FTD
 
 otError Interpreter::ProcessMasterKey(uint8_t aArgsLength, char *aArgs[])
 {
@@ -2291,7 +2275,7 @@ otError Interpreter::ProcessNeighbor(uint8_t aArgsLength, char *aArgs[])
 exit:
     return error;
 }
-#endif
+#endif // OPENTHREAD_FTD
 
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
 otError Interpreter::ProcessNetif(uint8_t aArgsLength, char *aArgs[])
@@ -2432,7 +2416,7 @@ otError Interpreter::ProcessService(uint8_t aArgsLength, char *aArgs[])
 exit:
     return error;
 }
-#endif
+#endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
 otError Interpreter::ProcessNetworkData(uint8_t aArgsLength, char *aArgs[])
 {
@@ -2466,8 +2450,7 @@ otError Interpreter::ProcessNetworkName(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        const char *networkName = otThreadGetNetworkName(mInstance);
-        OutputLine("%s", static_cast<const char *>(networkName));
+        OutputLine(otThreadGetNetworkName(mInstance));
     }
     else
     {
@@ -2983,12 +2966,10 @@ exit:
 
 otError Interpreter::ProcessPrefixRemove(uint8_t aArgsLength, char *aArgs[])
 {
-    OT_UNUSED_VARIABLE(aArgsLength);
-
-    otError            error = OT_ERROR_NONE;
-    struct otIp6Prefix prefix;
-    uint8_t            argcur = 0;
-    char *             prefixLengthStr;
+    otError     error = OT_ERROR_NONE;
+    otIp6Prefix prefix;
+    uint8_t     argcur = 0;
+    char *      prefixLengthStr;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
@@ -3091,7 +3072,7 @@ otError Interpreter::ProcessRcp(uint8_t aArgsLength, char *aArgs[])
 
     if (strcmp(aArgs[0], "version") == 0)
     {
-        OutputLine("%s", version);
+        OutputLine(version);
     }
     else
     {
@@ -3200,12 +3181,12 @@ exit:
 
 otError Interpreter::ProcessRouteRemove(uint8_t aArgsLength, char *aArgs[])
 {
-    otError            error = OT_ERROR_NONE;
-    struct otIp6Prefix prefix;
-    uint8_t            argcur = 0;
-    char *             prefixLengthStr;
+    otError     error = OT_ERROR_NONE;
+    otIp6Prefix prefix;
+    uint8_t     argcur = 0;
+    char *      prefixLengthStr;
 
-    memset(&prefix, 0, sizeof(struct otIp6Prefix));
+    memset(&prefix, 0, sizeof(otIp6Prefix));
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
@@ -3641,7 +3622,7 @@ void Interpreter::HandleSntpResponse(uint64_t aTime, otError aResult)
 
     OutputResult(OT_ERROR_NONE);
 }
-#endif
+#endif // OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
 
 otError Interpreter::ProcessState(uint8_t aArgsLength, char *aArgs[])
 {
@@ -3711,9 +3692,6 @@ exit:
 
 otError Interpreter::ProcessThread(uint8_t aArgsLength, char *aArgs[])
 {
-    OT_UNUSED_VARIABLE(aArgsLength);
-    OT_UNUSED_VARIABLE(aArgs);
-
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
@@ -3836,7 +3814,7 @@ otError Interpreter::ProcessVersion(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        OutputLine("%s", otGetVersionString());
+        OutputLine(otGetVersionString());
         ExitNow();
     }
 
@@ -4339,11 +4317,11 @@ exit:
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
 otError Interpreter::ProcessNetworkDiagnostic(uint8_t aArgsLength, char *aArgs[])
 {
-    otError             error = OT_ERROR_NONE;
-    struct otIp6Address address;
-    uint8_t             tlvTypes[OT_NETWORK_DIAGNOSTIC_TYPELIST_MAX_ENTRIES];
-    uint8_t             count     = 0;
-    uint8_t             argsIndex = 0;
+    otError      error = OT_ERROR_NONE;
+    otIp6Address address;
+    uint8_t      tlvTypes[OT_NETWORK_DIAGNOSTIC_TYPELIST_MAX_ENTRIES];
+    uint8_t      count     = 0;
+    uint8_t      argsIndex = 0;
 
     // Include operation, address and type tlv list.
     VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -41,7 +41,9 @@
 #include <stdarg.h>
 
 #include <openthread/cli.h>
+#include <openthread/dns.h>
 #include <openthread/ip6.h>
+#include <openthread/sntp.h>
 #include <openthread/udp.h>
 
 #include "cli/cli_commissioner.hpp"
@@ -49,20 +51,14 @@
 #include "cli/cli_joiner.hpp"
 #include "cli/cli_network_data.hpp"
 #include "cli/cli_udp.hpp"
-
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
 #include "cli/cli_coap.hpp"
 #endif
-
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
 #include "cli/cli_coap_secure.hpp"
 #endif
-
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
-
-#include <openthread/dns.h>
-#include <openthread/sntp.h>
 #include "common/timer.hpp"
 #include "net/icmp6.hpp"
 

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -43,7 +43,7 @@
 namespace ot {
 namespace Cli {
 
-const struct Coap::Command Coap::sCommands[] = {
+const Coap::Command Coap::sCommands[] = {
     {"help", &Coap::ProcessHelp},
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
     {"cancel", &Coap::ProcessCancel},
@@ -174,7 +174,7 @@ otError Coap::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        mInterpreter.OutputLine("%s", command.mName);
+        mInterpreter.OutputLine(command.mName);
     }
 
     return OT_ERROR_NONE;
@@ -197,7 +197,7 @@ otError Coap::ProcessResource(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        mInterpreter.OutputLine("%s", mResource.mUriPath);
+        mInterpreter.OutputLine(mResource.mUriPath != nullptr ? mResource.mUriPath : "");
     }
 
 exit:
@@ -251,7 +251,7 @@ otError Coap::ProcessSet(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        mInterpreter.OutputLine("%s", mResourceContent);
+        mInterpreter.OutputLine(mResourceContent);
     }
 
 exit:

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -45,7 +45,7 @@
 namespace ot {
 namespace Cli {
 
-const struct CoapSecure::Command CoapSecure::sCommands[] = {
+const CoapSecure::Command CoapSecure::sCommands[] = {
     {"help", &CoapSecure::ProcessHelp},      {"connect", &CoapSecure::ProcessConnect},
     {"delete", &CoapSecure::ProcessRequest}, {"disconnect", &CoapSecure::ProcessDisconnect},
     {"get", &CoapSecure::ProcessRequest},    {"post", &CoapSecure::ProcessRequest},
@@ -107,7 +107,7 @@ otError CoapSecure::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        mInterpreter.OutputLine("%s", command.mName);
+        mInterpreter.OutputLine(command.mName);
     }
 
     return OT_ERROR_NONE;
@@ -130,7 +130,7 @@ otError CoapSecure::ProcessResource(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        mInterpreter.OutputLine("%s", mResource.mUriPath);
+        mInterpreter.OutputLine(mResource.mUriPath != nullptr ? mResource.mUriPath : "");
     }
 
 exit:
@@ -149,7 +149,7 @@ otError CoapSecure::ProcessSet(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        mInterpreter.OutputLine("%s", mResourceContent);
+        mInterpreter.OutputLine(mResourceContent);
     }
 
 exit:

--- a/src/cli/cli_commissioner.cpp
+++ b/src/cli/cli_commissioner.cpp
@@ -40,7 +40,7 @@
 namespace ot {
 namespace Cli {
 
-const struct Commissioner::Command Commissioner::sCommands[] = {
+const Commissioner::Command Commissioner::sCommands[] = {
     {"help", &Commissioner::ProcessHelp},           {"announce", &Commissioner::ProcessAnnounce},
     {"energy", &Commissioner::ProcessEnergy},       {"joiner", &Commissioner::ProcessJoiner},
     {"mgmtget", &Commissioner::ProcessMgmtGet},     {"mgmtset", &Commissioner::ProcessMgmtSet},
@@ -56,7 +56,7 @@ otError Commissioner::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        mInterpreter.OutputLine("%s", command.mName);
+        mInterpreter.OutputLine(command.mName);
     }
 
     return OT_ERROR_NONE;
@@ -429,7 +429,7 @@ otError Commissioner::ProcessState(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    mInterpreter.OutputLine("%s", StateToString(otCommissionerGetState(mInterpreter.mInstance)));
+    mInterpreter.OutputLine(StateToString(otCommissionerGetState(mInterpreter.mInstance)));
 
     return OT_ERROR_NONE;
 }

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -210,7 +210,7 @@ otError Dataset::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        mInterpreter.OutputLine("%s", command.mName);
+        mInterpreter.OutputLine(command.mName);
     }
 
     return OT_ERROR_NONE;

--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -42,7 +42,7 @@
 namespace ot {
 namespace Cli {
 
-const struct Joiner::Command Joiner::sCommands[] = {
+const Joiner::Command Joiner::sCommands[] = {
     {"discerner", &Joiner::ProcessDiscerner}, {"help", &Joiner::ProcessHelp}, {"id", &Joiner::ProcessId},
     {"start", &Joiner::ProcessStart},         {"stop", &Joiner::ProcessStop},
 };
@@ -91,7 +91,7 @@ otError Joiner::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        mInterpreter.OutputLine("%s", command.mName);
+        mInterpreter.OutputLine(command.mName);
     }
 
     return OT_ERROR_NONE;

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -44,7 +44,7 @@ using ot::Encoding::BigEndian::HostSwap16;
 namespace ot {
 namespace Cli {
 
-const struct NetworkData::Command NetworkData::sCommands[] = {
+const NetworkData::Command NetworkData::sCommands[] = {
     {"help", &NetworkData::ProcessHelp},
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     {"register", &NetworkData::ProcessRegister},
@@ -180,7 +180,7 @@ otError NetworkData::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        mInterpreter.OutputLine("%s", command.mName);
+        mInterpreter.OutputLine(command.mName);
     }
 
     return OT_ERROR_NONE;

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -46,6 +46,9 @@
 #include <openthread/cli.h>
 #include <openthread/platform/logging.h>
 #include <openthread/platform/uart.h>
+#if OPENTHREAD_CONFIG_ENABLE_DEBUG_UART
+#include <openthread/platform/debug_uart.h>
+#endif
 
 #include "cli/cli.hpp"
 #include "common/code_utils.hpp"
@@ -53,10 +56,6 @@
 #include "common/logging.hpp"
 #include "common/new.hpp"
 #include "common/tasklet.hpp"
-
-#if OPENTHREAD_CONFIG_ENABLE_DEBUG_UART
-#include <openthread/platform/debug_uart.h>
-#endif
 
 #ifdef OT_CLI_UART_LOCK_HDR_FILE
 

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -44,13 +44,13 @@ using ot::Encoding::BigEndian::HostSwap16;
 namespace ot {
 namespace Cli {
 
-const struct UdpExample::Command UdpExample::sCommands[] = {{"help", &UdpExample::ProcessHelp},
-                                                            {"bind", &UdpExample::ProcessBind},
-                                                            {"close", &UdpExample::ProcessClose},
-                                                            {"connect", &UdpExample::ProcessConnect},
-                                                            {"linksecurity", &UdpExample::ProcessLinkSecurity},
-                                                            {"open", &UdpExample::ProcessOpen},
-                                                            {"send", &UdpExample::ProcessSend}};
+const UdpExample::Command UdpExample::sCommands[] = {{"help", &UdpExample::ProcessHelp},
+                                                     {"bind", &UdpExample::ProcessBind},
+                                                     {"close", &UdpExample::ProcessClose},
+                                                     {"connect", &UdpExample::ProcessConnect},
+                                                     {"linksecurity", &UdpExample::ProcessLinkSecurity},
+                                                     {"open", &UdpExample::ProcessOpen},
+                                                     {"send", &UdpExample::ProcessSend}};
 
 UdpExample::UdpExample(Interpreter &aInterpreter)
     : mInterpreter(aInterpreter)
@@ -66,7 +66,7 @@ otError UdpExample::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 
     for (const Command &command : sCommands)
     {
-        mInterpreter.OutputLine("%s", command.mName);
+        mInterpreter.OutputLine(command.mName);
     }
 
     return OT_ERROR_NONE;
@@ -241,7 +241,7 @@ otError UdpExample::ProcessLinkSecurity(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        mInterpreter.OutputLine("%s", mLinkSecurityEnabled ? "Enabled" : "Disabled");
+        mInterpreter.OutputLine(mLinkSecurityEnabled ? "Enabled" : "Disabled");
     }
     else if (strcmp(aArgs[0], "enable") == 0)
     {
@@ -317,8 +317,8 @@ void UdpExample::HandleUdpReceive(void *aContext, otMessage *aMessage, const otM
 
 void UdpExample::HandleUdpReceive(otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    uint8_t buf[1500];
-    int     length;
+    char buf[1500];
+    int  length;
 
     mInterpreter.OutputFormat("%d bytes from ", otMessageGetLength(aMessage) - otMessageGetOffset(aMessage));
     mInterpreter.OutputIp6Address(aMessageInfo->mPeerAddr);
@@ -327,7 +327,7 @@ void UdpExample::HandleUdpReceive(otMessage *aMessage, const otMessageInfo *aMes
     length      = otMessageRead(aMessage, otMessageGetOffset(aMessage), buf, sizeof(buf) - 1);
     buf[length] = '\0';
 
-    mInterpreter.OutputLine("%s", buf);
+    mInterpreter.OutputLine(buf);
 }
 
 } // namespace Cli


### PR DESCRIPTION
This commit contains a group of style fixes and smaller enhancements
in CLI modules:
- Remove unnecessary use of `struct` when declaring variable.
- Remove use of single `"%s"` in `Output` methods.
- Fix order of `#include` headers.
- Remove unnecessary use of `OT_UNUSED_VARIABLE`.
- Remove unnecessary temp variables and casts.
- Add comments to `#endif` directives than are more than  than 20
  lines away from the corresponding `#if` they are associated with.