### PR TITLE
[scripts] set FED routereligible disable

### DIFF
--- a/tests/scripts/thread-cert/Cert_5_2_04_REEDUpgrade.py
+++ b/tests/scripts/thread-cert/Cert_5_2_04_REEDUpgrade.py
@@ -150,7 +150,8 @@ class Cert_5_2_4_REEDUpgrade(thread_cert.TestCase):
         ED: {
             'mode': 'rsdn',
             'panid': 0xface,
-            'allowlist': [DUT_REED]
+            'allowlist': [DUT_REED],
+            'router_eligible': False,
         },
     }
 

--- a/tests/scripts/thread-cert/Cert_5_7_01_CoapDiagCommands_A.py
+++ b/tests/scripts/thread-cert/Cert_5_7_01_CoapDiagCommands_A.py
@@ -75,7 +75,7 @@ class Cert_5_7_01_CoapDiagCommands_A(thread_cert.TestCase):
         },
         FED1: {
             'allowlist': [ROUTER1],
-            'router_upgrade_threshold': 0
+            'router_eligible': False,
         },
     }
 

--- a/tests/scripts/thread-cert/Cert_6_1_09_EDSynchronization.py
+++ b/tests/scripts/thread-cert/Cert_6_1_09_EDSynchronization.py
@@ -58,7 +58,7 @@ class Cert_6_1_9_EDSynchronization(thread_cert.TestCase):
         ED: {
             'name': 'ED',
             'panid': 0xface,
-            'router_upgrade_threshold': 0,
+            'router_eligible': False,
             'allowlist': [LEADER]
         },
         ROUTER2: {

--- a/tests/scripts/thread-cert/v1_2_test_multicast_listener_registration.py
+++ b/tests/scripts/thread-cert/v1_2_test_multicast_listener_registration.py
@@ -118,7 +118,7 @@ class TestMulticastListenerRegistration(thread_cert.TestCase):
             'mode': 'rsdn',
             'version': '1.2',
             'allowlist': [ROUTER_1_2],
-            'router_upgrade_threshold': 0,
+            'router_eligible': False,
             'timeout': config.DEFAULT_CHILD_TIMEOUT,
         },
     }


### PR DESCRIPTION
Instead of setting [routerupgradethreshold](https://github.com/openthread/openthread/blob/master/src/cli/README.md#routerupgradethreshold) to 0, it's more correct for `FED` to turn off [routereligible](https://github.com/openthread/openthread/blob/master/src/cli/README.md#routereligible).

- [ ] WIP: support `routereligible` on NCP (spinel-cli.py)