### PR TITLE
[scripts] enhance cert_suite to run multiple tests concurrently

### DIFF
--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -271,7 +271,7 @@ jobs:
       run: |
         export CI_ENV="$(bash <(curl -s https://codecov.io/env)) -e GITHUB_ACTIONS -e COVERAGE"
         echo "CI_ENV=${CI_ENV}"
-        sudo -E ./script/test cert_bbr ./tests/scripts/thread-cert/backbone/*.py || (sudo chmod a+r *.log *.json *.pcap && false)
+        sudo -E ./script/test cert_suite ./tests/scripts/thread-cert/backbone/*.py || (sudo chmod a+r *.log *.json *.pcap && false)
     - uses: actions/upload-artifact@v2
       with:
         name: cov-thread-1-2-backbone-docker

--- a/script/test
+++ b/script/test
@@ -201,61 +201,11 @@ do_cert_suite()
         fi
     fi
 
-    local pass_count=0
-    local fail_count=0
-
-    [[ ! -f fail.log ]] || rm fail.log
-
-    for test_case in "$@"; do
-        rm -rf tmp || sudo rm -rf tmp
-        if TEST_NAME="$(basename "${test_case}" .py)" "${test_case}" &>test.log; then
-            echo -e "${COLOR_PASS}PASS${COLOR_NONE} ${test_case}"
-            pass_count=$((pass_count + 1))
-        else
-            echo -e "${COLOR_FAIL}FAIL${COLOR_NONE} ${test_case}"
-            fail_count=$((fail_count + 1))
-            {
-                echo "=============================="
-                echo "!!! FAIL:${test_case}"
-                echo "=============================="
-                cat test.log
-            } >>fail.log
-        fi
-    done
-
-    echo "=================================="
-    echo "         Test Summary"
-    echo "=================================="
-    echo "# TOTAL: $((pass_count + fail_count))"
-    echo "# PASS: ${pass_count}"
-    echo "# FAIL: ${fail_count}"
-
-    if [[ ${fail_count} -gt 0 ]]; then
-        tr -dc '[:print:]\r\n\t' <fail.log
-        exit 1
-    else
-        exit 0
-    fi
-}
-
-do_cert_bbr()
-{
-    if [[ ${THREAD_VERSION} != "1.2" ]]; then
-        echo "cert_bbr only work with THREAD_VERSION=1.2!"
-        exit 1
-    fi
-
-    if [[ ${VIRTUAL_TIME} != "0" ]]; then
-        echo "cert_bbr only work with VIRTUAL_TIME=0!"
-        exit 1
-    fi
-
-    export top_builddir="${OT_BUILDDIR}/cmake/openthread-simulation-1.2"
-    export top_builddir_1_2_bbr="${OT_BUILDDIR}/cmake/openthread-simulation-1.2-bbr"
-    export top_builddir_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1"
     export PYTHONPATH=tests/scripts/thread-cert
+    export VIRTUAL_TIME
 
-    python3 tests/scripts/thread-cert/run_bbr_tests.py --multiply "${MULTIPLY:-1}" "$@"
+    python3 tests/scripts/thread-cert/run_cert_suite.py --multiply "${MULTIPLY:-1}" "$@"
+    exit 0
 }
 
 do_get_thread_wireshark()
@@ -553,10 +503,6 @@ main()
             cert_suite)
                 shift
                 do_cert_suite "$@"
-                ;;
-            cert_bbr)
-                shift
-                do_cert_bbr "$@"
                 ;;
             get_thread_wireshark)
                 do_get_thread_wireshark

--- a/tests/scripts/thread-cert/run_cert_suite.py
+++ b/tests/scripts/thread-cert/run_cert_suite.py
@@ -158,7 +158,7 @@ def run_tests(scripts: List[str], multiply: int = 1):
             color = _COLOR_PASS if script_fail_count[script] == 0 else _COLOR_FAIL
             print(f'{color}PASS {script_succ_count[script]} FAIL {script_fail_count[script]}{_COLOR_NONE} {script}')
 
-    def succ_callback(port_offset, script):
+    def pass_callback(port_offset, script):
         port_offset_pool.release(port_offset)
 
         script_succ_count[script] += 1
@@ -170,7 +170,7 @@ def run_tests(scripts: List[str], multiply: int = 1):
         port_offset = port_offset_pool.allocate()
         pool.apply_async(
             run_cert, [port_offset, script],
-            callback=lambda ret, port_offset=port_offset, script=script: succ_callback(port_offset, script),
+            callback=lambda ret, port_offset=port_offset, script=script: pass_callback(port_offset, script),
             error_callback=lambda err, port_offset=port_offset, script=script: error_callback(
                 port_offset, script, err))
 


### PR DESCRIPTION
This PR enhances `script/test cert_suite` command to run multiple tests concurrently to reduce execution time. 

**Before this PR:**
```bash
~/src/openthread$ time ./script/test cert_suite ./tests/scripts/thread-cert/Cert_*.py
...
real    0m57.071s
```

**Using this PR:**
```bash
~/src/openthread$ time ./script/test cert_suite ./tests/scripts/thread-cert/Cert_*.py
...
real    0m9.720s
```

The `packet-verification` job's test execution time is reduced from [35m](https://github.com/openthread/openthread/pull/5563/checks?check_run_id=1171620975) to [12m](https://github.com/openthread/openthread/pull/5586/checks?check_run_id=1175646305).

This PR also allows running Backbone CI tests with `script/test cert_suite`. 