### PR TITLE
[cli] add command `uptime` to cli

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -99,6 +99,7 @@ Done
 - [thread](#thread-start)
 - [txpower](#txpower)
 - [unsecureport](#unsecureport-add-port)
+- [uptime](#uptime)
 - [version](#version)
 
 ## OpenThread Command Details
@@ -1935,6 +1936,16 @@ Print all ports from the allowed unsecured port list.
 ```bash
 > unsecureport get
 1234
+Done
+```
+
+### uptime
+
+Print how long the device has been running.
+
+```bash
+> uptime
+00:00:51 up 0 days
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -155,6 +155,8 @@ Interpreter::Interpreter(Instance *aInstance)
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
     memset(mResolvingHostname, 0, sizeof(mResolvingHostname));
 #endif
+
+    mStartTimeUs = otPlatTimeGet();
 }
 
 int Interpreter::Hex2Bin(const char *aHex, uint8_t *aBin, uint16_t aBinLength, bool aAllowTruncate)
@@ -3762,6 +3764,34 @@ otError Interpreter::ProcessTxPower(uint8_t aArgsLength, char *aArgs[])
         SuccessOrExit(error = ParseLong(aArgs[0], value));
         SuccessOrExit(error = otPlatRadioSetTransmitPower(mInstance, static_cast<int8_t>(value)));
     }
+
+exit:
+    return error;
+}
+
+otError Interpreter::ProcessUptime(uint8_t aArgsLength, char *aArgs[])
+{
+    OT_UNUSED_VARIABLE(aArgs);
+
+    otError  error = OT_ERROR_NONE;
+    uint32_t now;
+    uint32_t seconds;
+    uint32_t minutes;
+    uint32_t hours;
+    uint32_t days;
+
+    VerifyOrExit(aArgsLength == 0, error = OT_ERROR_INVALID_ARGS);
+
+    now = static_cast<uint32_t>((otPlatTimeGet() - mStartTimeUs) / 1000000);
+
+    seconds = now % 60;
+    now     = now / 60;
+    minutes = now % 60;
+    now     = now / 60;
+    hours   = now % 24;
+    days    = now / 24;
+
+    OutputLine("%02d:%02d:%02d up %d days", hours, minutes, seconds, days);
 
 exit:
     return error;

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -477,6 +477,7 @@ private:
     otError ProcessThread(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessDataset(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessTxPower(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessUptime(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessUdp(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessUnsecurePort(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessVersion(uint8_t aArgsLength, char *aArgs[]);
@@ -716,6 +717,7 @@ private:
         {"txpower", &Interpreter::ProcessTxPower},
         {"udp", &Interpreter::ProcessUdp},
         {"unsecureport", &Interpreter::ProcessUnsecurePort},
+        {"uptime", &Interpreter::ProcessUptime},
         {"version", &Interpreter::ProcessVersion},
     };
 
@@ -758,6 +760,8 @@ private:
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
     Joiner mJoiner;
 #endif
+
+    uint64_t mStartTimeUs;
 
     Instance *mInstance;
 };

--- a/tests/scripts/expect/cli-misc.exp
+++ b/tests/scripts/expect/cli-misc.exp
@@ -154,4 +154,8 @@ expect "0:0:0:0::/64 s low"
 send "route remove ::/64\n"
 expect "Done"
 
+send "uptime\n"
+expect -re {([0-9]{2}):([0-9]{2}):([0-9]{2}) up \d+ days}
+expect "Done"
+
 dispose_nodes


### PR DESCRIPTION
This PR adds a command `uptime` to print how long the device has been running.