### PR TITLE
[cli] add 'OutputExtAddress()' helper method

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -878,12 +878,7 @@ otError Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
                 OutputFormat("|%1d", childInfo.mFullThreadDevice);
                 OutputFormat("|%1d", childInfo.mFullNetworkData);
                 OutputFormat("| ");
-
-                for (uint8_t b : childInfo.mExtAddress.m8)
-                {
-                    OutputFormat("%02x", b);
-                }
-
+                OutputExtAddress(childInfo.mExtAddress);
                 OutputLine(" |");
             }
             else
@@ -902,12 +897,7 @@ otError Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
     OutputLine("Child ID: %d", childInfo.mChildId);
     OutputLine("Rloc: %04x", childInfo.mRloc16);
     OutputFormat("Ext Addr: ");
-
-    for (uint8_t b : childInfo.mExtAddress.m8)
-    {
-        OutputFormat("%02x", b);
-    }
-
+    OutputExtAddress(childInfo.mExtAddress);
     OutputLine("");
     OutputFormat("Mode: ");
 
@@ -1998,11 +1988,7 @@ otError Interpreter::ProcessPskc(uint8_t aArgsLength, char *aArgs[])
     {
         const otPskc *pskc = otThreadGetPskc(mInstance);
 
-        for (uint8_t b : pskc->m8)
-        {
-            OutputFormat("%02x", b);
-        }
-
+        OutputBytes(pskc->m8);
         OutputLine("");
     }
     else
@@ -2038,13 +2024,7 @@ otError Interpreter::ProcessMasterKey(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength == 0)
     {
-        const uint8_t *key = reinterpret_cast<const uint8_t *>(otThreadGetMasterKey(mInstance));
-
-        for (int i = 0; i < OT_MASTER_KEY_SIZE; i++)
-        {
-            OutputFormat("%02x", key[i]);
-        }
-
+        OutputBytes(otThreadGetMasterKey(mInstance)->m8);
         OutputLine("");
     }
     else
@@ -2251,12 +2231,7 @@ otError Interpreter::ProcessNeighbor(uint8_t aArgsLength, char *aArgs[])
                 OutputFormat("|%1d", neighborInfo.mFullThreadDevice);
                 OutputFormat("|%1d", neighborInfo.mFullNetworkData);
                 OutputFormat("| ");
-
-                for (uint8_t b : neighborInfo.mExtAddress.m8)
-                {
-                    OutputFormat("%02x", b);
-                }
-
+                OutputExtAddress(neighborInfo.mExtAddress);
                 OutputLine(" |");
             }
             else
@@ -2544,14 +2519,8 @@ otError Interpreter::ProcessParent(uint8_t aArgsLength, char *aArgs[])
 
     SuccessOrExit(error = otThreadGetParentInfo(mInstance, &parentInfo));
     OutputFormat("Ext Addr: ");
-
-    for (uint8_t b : parentInfo.mExtAddress.m8)
-    {
-        OutputFormat("%02x", b);
-    }
-
+    OutputExtAddress(parentInfo.mExtAddress);
     OutputLine("");
-
     OutputLine("Rloc: %x", parentInfo.mRloc16);
     OutputLine("Link Quality In: %d", parentInfo.mLinkQualityIn);
     OutputLine("Link Quality Out: %d", parentInfo.mLinkQualityOut);
@@ -3292,12 +3261,7 @@ otError Interpreter::ProcessRouter(uint8_t aArgsLength, char *aArgs[])
                 OutputFormat("| %6d ", routerInfo.mLinkQualityOut);
                 OutputFormat("| %3d ", routerInfo.mAge);
                 OutputFormat("| ");
-
-                for (uint8_t b : routerInfo.mExtAddress.m8)
-                {
-                    OutputFormat("%02x", b);
-                }
-
+                OutputExtAddress(routerInfo.mExtAddress);
                 OutputLine(" |");
             }
             else
@@ -3325,12 +3289,7 @@ otError Interpreter::ProcessRouter(uint8_t aArgsLength, char *aArgs[])
         if (routerInfo.mLinkEstablished)
         {
             OutputFormat("Ext Addr: ");
-
-            for (uint8_t b : routerInfo.mExtAddress.m8)
-            {
-                OutputFormat("%02x", b);
-            }
-
+            OutputExtAddress(routerInfo.mExtAddress);
             OutputLine("");
             OutputLine("Cost: %d", routerInfo.mPathCost);
             OutputLine("Link Quality In: %d", routerInfo.mLinkQualityIn);
@@ -3502,11 +3461,11 @@ void Interpreter::HandleActiveScanResult(otActiveScanResult *aResult)
     OutputFormat("| %-16s ", aResult->mNetworkName.m8);
 
     OutputFormat("| ");
-    OutputBytes(aResult->mExtendedPanId.m8, OT_EXT_PAN_ID_SIZE);
+    OutputBytes(aResult->mExtendedPanId.m8);
     OutputFormat(" ");
 
     OutputFormat("| %04x | ", aResult->mPanId);
-    OutputBytes(aResult->mExtAddress.m8, OT_EXT_ADDRESS_SIZE);
+    OutputExtAddress(aResult->mExtAddress);
     OutputFormat(" | %2d ", aResult->mChannel);
     OutputFormat("| %3d ", aResult->mRssi);
     OutputLine("| %3d |", aResult->mLqi);
@@ -3915,7 +3874,7 @@ void Interpreter::PrintMacFilter(void)
 
     while (otLinkFilterGetNextAddress(mInstance, &iterator, &entry) == OT_ERROR_NONE)
     {
-        OutputBytes(entry.mExtAddress.m8, OT_EXT_ADDRESS_SIZE);
+        OutputExtAddress(entry.mExtAddress);
 
         if (entry.mRssIn != OT_MAC_FILTER_FIXED_RSS_DISABLED)
         {
@@ -3947,7 +3906,7 @@ void Interpreter::PrintMacFilter(void)
         }
         else
         {
-            OutputBytes(entry.mExtAddress.m8, OT_EXT_ADDRESS_SIZE);
+            OutputExtAddress(entry.mExtAddress);
             OutputLine(" : rss %d (lqi %d)", entry.mRssIn, otLinkConvertRssToLinkQuality(mInstance, entry.mRssIn));
         }
     }
@@ -3979,7 +3938,7 @@ otError Interpreter::ProcessMacFilterAddress(uint8_t aArgsLength, char *aArgs[])
 
         while (otLinkFilterGetNextAddress(mInstance, &iterator, &entry) == OT_ERROR_NONE)
         {
-            OutputBytes(entry.mExtAddress.m8, OT_EXT_ADDRESS_SIZE);
+            OutputExtAddress(entry.mExtAddress);
 
             if (entry.mRssIn != OT_MAC_FILTER_FIXED_RSS_DISABLED)
             {
@@ -4078,7 +4037,7 @@ otError Interpreter::ProcessMacFilterRss(uint8_t aArgsLength, char *aArgs[])
             }
             else
             {
-                OutputBytes(entry.mExtAddress.m8, OT_EXT_ADDRESS_SIZE);
+                OutputExtAddress(entry.mExtAddress);
                 OutputLine(" : rss %d (lqi %d)", entry.mRssIn, otLinkConvertRssToLinkQuality(mInstance, entry.mRssIn));
             }
         }
@@ -4394,7 +4353,7 @@ void Interpreter::HandleDiagnosticGetResponse(const otMessage &aMessage, const I
         {
         case OT_NETWORK_DIAGNOSTIC_TLV_EXT_ADDRESS:
             OutputFormat("Ext Address: '");
-            OutputBytes(diagTlv.mData.mExtAddress.m8, sizeof(diagTlv.mData.mExtAddress.m8));
+            OutputExtAddress(diagTlv.mData.mExtAddress);
             OutputLine("'");
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_SHORT_ADDRESS:
@@ -4672,7 +4631,7 @@ void Interpreter::SignalPingReply(const Ip6::Address &aPeerAddress,
 void Interpreter::HandleDiscoveryRequest(const otThreadDiscoveryRequestInfo &aInfo)
 {
     OutputFormat("~ Discovery Request from ");
-    OutputBytes(aInfo.mExtAddress.m8, sizeof(aInfo.mExtAddress.m8));
+    OutputExtAddress(aInfo.mExtAddress);
     OutputLine(": version=%u,joiner=%d", aInfo.mVersion, aInfo.mIsJoiner);
 }
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -177,12 +177,26 @@ public:
     int Output(const char *aBuf, uint16_t aBufLength);
 
     /**
-     * Write a number of bytes to the CLI console as a hex string.
+     * This method writes a number of bytes to the CLI console as a hex string.
      *
      * @param[in]  aBytes   A pointer to data which should be printed.
      * @param[in]  aLength  @p aBytes length.
+     *
      */
     void OutputBytes(const uint8_t *aBytes, uint8_t aLength);
+
+    /**
+     * This method writes a number of bytes to the CLI console as a hex string.
+     *
+     * @tparam kBytesLength   The length of @p aBytes array.
+     *
+     * @param[in]  aBytes     A array of @p kBytesLength bytes which should be printed.
+     *
+     */
+    template <uint8_t kBytesLength> void OutputBytes(const uint8_t (&aBytes)[kBytesLength])
+    {
+        OutputBytes(aBytes, kBytesLength);
+    }
 
     /**
      * This method delivers formatted output to the client.
@@ -216,6 +230,14 @@ public:
      *
      */
     void OutputLine(const char *aFormat, ...);
+
+    /**
+     * This method writes an Extended MAC Address to the CLI console.
+     *
+     * param[in] aExtAddress  The Extended MAC Address to output.
+     *
+     */
+    void OutputExtAddress(const otExtAddress &aExtAddress) { OutputBytes(aExtAddress.m8); }
 
     /**
      * Write an IPv6 address to the CLI console.

--- a/src/cli/cli_commissioner.cpp
+++ b/src/cli/cli_commissioner.cpp
@@ -410,7 +410,7 @@ void Commissioner::HandleJoinerEvent(otCommissionerJoinerEvent aEvent,
 
     if (aJoinerId != nullptr)
     {
-        mInterpreter.OutputBytes(aJoinerId->m8, sizeof(*aJoinerId));
+        mInterpreter.OutputExtAddress(*aJoinerId);
     }
 
     mInterpreter.OutputLine("");

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -70,14 +70,6 @@ const Dataset::Command Dataset::sCommands[] = {
 
 otOperationalDataset Dataset::sDataset;
 
-void Dataset::OutputBytes(const uint8_t *aBytes, uint8_t aLength)
-{
-    for (int i = 0; i < aLength; i++)
-    {
-        mInterpreter.OutputFormat("%02x", aBytes[i]);
-    }
-}
-
 otError Dataset::Print(otOperationalDataset &aDataset)
 {
     if (aDataset.mComponents.mIsPendingTimestampPresent)
@@ -108,7 +100,7 @@ otError Dataset::Print(otOperationalDataset &aDataset)
     if (aDataset.mComponents.mIsExtendedPanIdPresent)
     {
         mInterpreter.OutputFormat("Ext PAN ID: ");
-        OutputBytes(aDataset.mExtendedPanId.m8, sizeof(aDataset.mExtendedPanId));
+        mInterpreter.OutputBytes(aDataset.mExtendedPanId.m8);
         mInterpreter.OutputLine("");
     }
 
@@ -124,7 +116,7 @@ otError Dataset::Print(otOperationalDataset &aDataset)
     if (aDataset.mComponents.mIsMasterKeyPresent)
     {
         mInterpreter.OutputFormat("Master Key: ");
-        OutputBytes(aDataset.mMasterKey.m8, sizeof(aDataset.mMasterKey));
+        mInterpreter.OutputBytes(aDataset.mMasterKey.m8);
         mInterpreter.OutputLine("");
     }
 
@@ -142,7 +134,7 @@ otError Dataset::Print(otOperationalDataset &aDataset)
     if (aDataset.mComponents.mIsPskcPresent)
     {
         mInterpreter.OutputFormat("PSKc: ");
-        OutputBytes(aDataset.mPskc.m8, sizeof(aDataset.mPskc.m8));
+        mInterpreter.OutputBytes(aDataset.mPskc.m8);
         mInterpreter.OutputLine("");
     }
 
@@ -441,7 +433,7 @@ otError Dataset::ProcessExtPanId(uint8_t aArgsLength, char *aArgs[])
     {
         if (sDataset.mComponents.mIsExtendedPanIdPresent)
         {
-            OutputBytes(sDataset.mExtendedPanId.m8, sizeof(sDataset.mExtendedPanId));
+            mInterpreter.OutputBytes(sDataset.mExtendedPanId.m8);
             mInterpreter.OutputLine("");
         }
     }
@@ -468,7 +460,7 @@ otError Dataset::ProcessMasterKey(uint8_t aArgsLength, char *aArgs[])
     {
         if (sDataset.mComponents.mIsMasterKeyPresent)
         {
-            OutputBytes(sDataset.mMasterKey.m8, sizeof(sDataset.mMasterKey));
+            mInterpreter.OutputBytes(sDataset.mMasterKey.m8);
             mInterpreter.OutputLine("");
         }
     }
@@ -821,7 +813,7 @@ otError Dataset::ProcessPskc(uint8_t aArgsLength, char *aArgs[])
     {
         if (sDataset.mComponents.mIsPskcPresent)
         {
-            OutputBytes(sDataset.mPskc.m8, sizeof(sDataset.mPskc.m8));
+            mInterpreter.OutputBytes(sDataset.mPskc.m8);
             mInterpreter.OutputLine("");
         }
     }

--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -73,7 +73,6 @@ private:
         otError (Dataset::*mCommand)(uint8_t aArgsLength, char *aArgs[]);
     };
 
-    void    OutputBytes(const uint8_t *aBytes, uint8_t aLength);
     otError Print(otOperationalDataset &aDataset);
 
     otError ProcessHelp(uint8_t aArgsLength, char *aArgs[]);

--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -102,11 +102,7 @@ otError Joiner::ProcessId(uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    const otExtAddress *joinerId;
-
-    joinerId = otJoinerGetId(mInterpreter.mInstance);
-
-    mInterpreter.OutputBytes(joinerId->m8, sizeof(otExtAddress));
+    mInterpreter.OutputExtAddress(*otJoinerGetId(mInterpreter.mInstance));
     mInterpreter.OutputLine("");
 
     return OT_ERROR_NONE;


### PR DESCRIPTION
This commit also adds a template version of `OutputBytes()` which
accepts a reference array of a specific length. This helps simplify
the calls to this helper method where the array length can be
inferred. It also changes the code to use `OutputBytes()` for
outputting master key, pskc, xpanid, etc.