### PR TITLE
[github-actions] use docker/setup-buildx-action@v1

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -53,7 +53,7 @@ jobs:
       with:
         submodules: true
     - name: Set up Docker Buildx
-      uses: crazy-max/ghaction-docker-buildx@v3
+      uses: docker/setup-buildx-action@v1
     - name: Prepare
       id: prepare
       run: |


### PR DESCRIPTION
Resolve annotation in docker build. 
```
This action is ARCHIVED and will not receive any updates, update your workflows to use the official Docker action docker/setup-buildx-action@v1
```