### PR TITLE
[thread-cert] set node addr64 to EXTENDED_ADDRESS_BASE + nodeid

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -45,6 +45,7 @@ import pexpect.popen_spawn
 
 import config
 import simulator
+import thread_cert
 
 PORT_OFFSET = int(os.getenv('PORT_OFFSET', "0"))
 
@@ -412,6 +413,7 @@ class NodeImpl:
         super().__init__(nodeid, **kwargs)
 
         self.set_extpanid(config.EXTENDED_PANID)
+        self.set_addr64('%016x' % (thread_cert.EXTENDED_ADDRESS_BASE + nodeid))
 
     def _expect(self, pattern, timeout=-1, *args, **kwargs):
         """ Process simulator events until expected the pattern. """
@@ -831,7 +833,10 @@ class NodeImpl:
         self.send_command('extaddr')
         return self._expect_result('[0-9a-fA-F]{16}')
 
-    def set_addr64(self, addr64):
+    def set_addr64(self, addr64: str):
+        # Make sure `addr64` is a hex string of length 16
+        assert len(addr64) == 16
+        int(addr64, 16)
         self.send_command('extaddr %s' % addr64)
         self._expect('Done')
 


### PR DESCRIPTION
This PR sets nodes' extaddrs to `0x166e0a0000000000 + nodeid`, which does not change node behavior but makes it easier for us to analyze pcaps.

Depends on https://github.com/openthread/pyspinel/pull/103. 

Please skip the commit that uses `simonlingoogle/pyspinel@fix-extaddr` for testing when merging. @jwhui 