### PR TITLE
[message] add new flavors of Read/Write/Append/Prepend methods

### DIFF
--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -98,19 +98,19 @@ int8_t otMessageGetRss(const otMessage *aMessage)
 otError otMessageAppend(otMessage *aMessage, const void *aBuf, uint16_t aLength)
 {
     Message &message = *static_cast<Message *>(aMessage);
-    return message.Append(aBuf, aLength);
+    return message.AppendBytes(aBuf, aLength);
 }
 
 uint16_t otMessageRead(const otMessage *aMessage, uint16_t aOffset, void *aBuf, uint16_t aLength)
 {
     const Message &message = *static_cast<const Message *>(aMessage);
-    return message.Read(aOffset, aLength, aBuf);
+    return message.ReadBytes(aOffset, aBuf, aLength);
 }
 
 int otMessageWrite(otMessage *aMessage, uint16_t aOffset, const void *aBuf, uint16_t aLength)
 {
     Message &message = *static_cast<Message *>(aMessage);
-    message.Write(aOffset, aLength, aBuf);
+    message.WriteBytes(aOffset, aBuf, aLength);
 
     return aLength;
 }

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -204,7 +204,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
 
     for (uint16_t offset = 0; offset < addressesLength; offset += sizeof(Ip6::Address))
     {
-        IgnoreReturnValue(aMessage.Read(addressesOffset + offset, sizeof(Ip6::Address), &address));
+        IgnoreError(aMessage.Read(addressesOffset + offset, address));
 
         if (timeout == 0)
         {
@@ -282,11 +282,11 @@ void Manager::SendMulticastListenerRegistrationResponse(const Coap::Message &   
 
         addressesTlv.Init();
         addressesTlv.SetLength(sizeof(Ip6::Address) * aFailedAddressNum);
-        SuccessOrExit(error = message->Append(&addressesTlv, sizeof(addressesTlv)));
+        SuccessOrExit(error = message->Append(addressesTlv));
 
         for (uint8_t i = 0; i < aFailedAddressNum; i++)
         {
-            SuccessOrExit(error = message->Append(aFailedAddresses + i, sizeof(Ip6::Address)));
+            SuccessOrExit(error = message->Append(aFailedAddresses[i]));
         }
     }
 
@@ -316,8 +316,8 @@ void Manager::SendBackboneMulticastListenerRegistration(const Ip6::Address *aAdd
 
     addressesTlv.Init();
     addressesTlv.SetLength(sizeof(Ip6::Address) * aAddressNum);
-    SuccessOrExit(error = message->Append(&addressesTlv, sizeof(addressesTlv)));
-    SuccessOrExit(error = message->Append(aAddresses, sizeof(Ip6::Address) * aAddressNum));
+    SuccessOrExit(error = message->Append(addressesTlv));
+    SuccessOrExit(error = message->AppendBytes(aAddresses, sizeof(Ip6::Address) * aAddressNum));
 
     SuccessOrExit(error = ThreadTlv::AppendUint32Tlv(*message, ThreadTlv::kTimeout, aTimeout));
 

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -750,12 +750,12 @@ void CoapBase::Metadata::ReadFrom(const Message &aMessage)
     uint16_t length = aMessage.GetLength();
 
     OT_ASSERT(length >= sizeof(*this));
-    aMessage.Read(length - sizeof(*this), sizeof(*this), this);
+    IgnoreError(aMessage.Read(length - sizeof(*this), *this));
 }
 
 void CoapBase::Metadata::UpdateIn(Message &aMessage) const
 {
-    aMessage.Write(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
+    aMessage.Write(aMessage.GetLength() - sizeof(*this), *this);
 }
 
 ResponsesQueue::ResponsesQueue(Instance &aInstance)
@@ -919,7 +919,7 @@ void ResponsesQueue::ResponseMetadata::ReadFrom(const Message &aMessage)
     uint16_t length = aMessage.GetLength();
 
     OT_ASSERT(length >= sizeof(*this));
-    aMessage.Read(length - sizeof(*this), sizeof(*this), this);
+    IgnoreError(aMessage.Read(length - sizeof(*this), *this));
 }
 
 /// Return product of @p aValueA and @p aValueB if no overflow otherwise 0.

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -247,7 +247,7 @@ private:
 
     struct ResponseMetadata
     {
-        otError AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
+        otError AppendTo(Message &aMessage) const { return aMessage.Append(*this); }
         void    ReadFrom(const Message &aMessage);
 
         TimeMilli        mDequeueTime;
@@ -533,7 +533,7 @@ protected:
 private:
     struct Metadata
     {
-        otError AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
+        otError AppendTo(Message &aMessage) const { return aMessage.Append(*this); }
         void    ReadFrom(const Message &aMessage);
         void    UpdateIn(Message &aMessage) const;
 

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -109,7 +109,7 @@ bool Message::IsNonConfirmablePostRequest(void) const
 
 void Message::Finish(void)
 {
-    Write(0, GetOptionStart(), &GetHelpData().mHeader);
+    WriteBytes(0, &GetHelpData().mHeader, GetOptionStart());
 }
 
 uint8_t Message::WriteExtendedOptionField(uint16_t aValue, uint8_t *&aBuffer)
@@ -176,8 +176,8 @@ otError Message::AppendOption(uint16_t aNumber, uint16_t aLength, const void *aV
     VerifyOrExit(static_cast<uint32_t>(GetLength()) + headerLength + aLength < kMaxHeaderLength,
                  error = OT_ERROR_NO_BUFS);
 
-    SuccessOrExit(error = Append(header, headerLength));
-    SuccessOrExit(error = Append(aValue, aLength));
+    SuccessOrExit(error = AppendBytes(header, headerLength));
+    SuccessOrExit(error = AppendBytes(aValue, aLength));
 
     GetHelpData().mOptionLast = aNumber;
 
@@ -251,7 +251,7 @@ otError Message::SetPayloadMarker(void)
     uint8_t marker = kPayloadMarker;
 
     VerifyOrExit(GetLength() < kMaxHeaderLength, error = OT_ERROR_NO_BUFS);
-    SuccessOrExit(error = Append(&marker, sizeof(marker)));
+    SuccessOrExit(error = Append(marker));
     GetHelpData().mHeaderLength = GetLength();
 
     // Set offset to the start of payload.
@@ -273,7 +273,7 @@ otError Message::ParseHeader(void)
     GetHelpData().Clear();
 
     GetHelpData().mHeaderOffset = GetOffset();
-    Read(GetHelpData().mHeaderOffset, sizeof(GetHelpData().mHeader), &GetHelpData().mHeader);
+    IgnoreError(Read(GetHelpData().mHeaderOffset, GetHelpData().mHeader));
 
     VerifyOrExit(GetTokenLength() <= kMaxTokenLength, error = OT_ERROR_PARSE);
 
@@ -518,7 +518,7 @@ otError Option::Iterator::ReadOptionValue(void *aValue) const
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(!IsDone(), error = OT_ERROR_NOT_FOUND);
-    GetMessage().Read(mNextOptionOffset - mOption.mLength, mOption.mLength, aValue);
+    GetMessage().ReadBytes(mNextOptionOffset - mOption.mLength, aValue, mOption.mLength);
 
 exit:
     return error;
@@ -554,7 +554,7 @@ otError Option::Iterator::Read(uint16_t aLength, void *aBuffer)
 
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(GetMessage().Read(mNextOptionOffset, aLength, aBuffer) == aLength, error = OT_ERROR_PARSE);
+    VerifyOrExit(GetMessage().ReadBytes(mNextOptionOffset, aBuffer, aLength) == aLength, error = OT_ERROR_PARSE);
     mNextOptionOffset += aLength;
 
 exit:

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -554,7 +554,7 @@ otError Option::Iterator::Read(uint16_t aLength, void *aBuffer)
 
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(GetMessage().ReadBytes(mNextOptionOffset, aBuffer, aLength) == aLength, error = OT_ERROR_PARSE);
+    SuccessOrExit(error = GetMessage().Read(mNextOptionOffset, aBuffer, aLength));
     mNextOptionOffset += aLength;
 
 exit:

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -173,7 +173,7 @@ void CoapSecure::HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength)
 
     VerifyOrExit((message = Get<MessagePool>().New(Message::kTypeIp6, Message::GetHelpDataReserved())) != nullptr,
                  OT_NOOP);
-    SuccessOrExit(message->Append(aBuf, aLength));
+    SuccessOrExit(message->AppendBytes(aBuf, aLength));
 
     CoapBase::Receive(*message, mDtls.GetMessageInfo());
 

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -362,19 +362,19 @@ exit:
     return error;
 }
 
-otError Message::Append(const void *aBuf, uint16_t aLength)
+otError Message::AppendBytes(const void *aBuf, uint16_t aLength)
 {
     otError  error     = OT_ERROR_NONE;
     uint16_t oldLength = GetLength();
 
     SuccessOrExit(error = SetLength(GetLength() + aLength));
-    Write(oldLength, aLength, aBuf);
+    WriteBytes(oldLength, aBuf, aLength);
 
 exit:
     return error;
 }
 
-otError Message::Prepend(const void *aBuf, uint16_t aLength)
+otError Message::PrependBytes(const void *aBuf, uint16_t aLength)
 {
     otError error     = OT_ERROR_NONE;
     Buffer *newBuffer = nullptr;
@@ -402,7 +402,7 @@ otError Message::Prepend(const void *aBuf, uint16_t aLength)
 
     if (aBuf != nullptr)
     {
-        Write(0, aLength, aBuf);
+        WriteBytes(0, aBuf, aLength);
     }
 
 exit:
@@ -510,7 +510,7 @@ exit:
     return;
 }
 
-uint16_t Message::Read(uint16_t aOffset, uint16_t aLength, void *aBuf) const
+uint16_t Message::ReadBytes(uint16_t aOffset, void *aBuf, uint16_t aLength) const
 {
     uint8_t *bufPtr = reinterpret_cast<uint8_t *>(aBuf);
     Chunk    chunk;
@@ -527,7 +527,12 @@ uint16_t Message::Read(uint16_t aOffset, uint16_t aLength, void *aBuf) const
     return static_cast<uint16_t>(bufPtr - reinterpret_cast<uint8_t *>(aBuf));
 }
 
-void Message::Write(uint16_t aOffset, uint16_t aLength, const void *aBuf)
+otError Message::Read(uint16_t aOffset, void *aBuf, uint16_t aLength) const
+{
+    return (ReadBytes(aOffset, aBuf, aLength) == aLength) ? OT_ERROR_NONE : OT_ERROR_PARSE;
+}
+
+void Message::WriteBytes(uint16_t aOffset, const void *aBuf, uint16_t aLength)
 {
     const uint8_t *bufPtr = reinterpret_cast<const uint8_t *>(aBuf);
     WritableChunk  chunk;
@@ -560,7 +565,7 @@ uint16_t Message::CopyTo(uint16_t aSourceOffset, uint16_t aDestinationOffset, ui
 
     while (chunk.GetLength() > 0)
     {
-        aMessage.Write(aDestinationOffset, chunk.GetLength(), chunk.GetData());
+        aMessage.WriteBytes(aDestinationOffset, chunk.GetData(), chunk.GetLength());
         aDestinationOffset += chunk.GetLength();
         bytesCopied += chunk.GetLength();
         GetNextChunk(aLength, chunk);

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -633,9 +633,25 @@ public:
     uint16_t ReadBytes(uint16_t aOffset, void *aBuf, uint16_t aLength) const;
 
     /**
+     * This method reads a given number of bytes from the message.
+     *
+     * If there are fewer bytes available in the message than the requested read length, the available bytes will be
+     * read and copied into @p aBuf. In this case `OT_ERROR_PARSE` will be returned.
+     *
+     * @param[in]  aOffset  Byte offset within the message to begin reading.
+     * @param[out] aBuf     A pointer to a data buffer to copy the read bytes into.
+     * @param[in]  aLength  Number of bytes to read.
+     *
+     * @retval OT_ERROR_NONE     @p aLength bytes were successfully read from message.
+     * @retval OT_ERROR_PARSE    Not enough bytes remaining in message to read the entire object.
+     *
+     */
+    otError Read(uint16_t aOffset, void *aBuf, uint16_t aLength) const;
+
+    /**
      * This method reads an object from the message.
      *
-     * If there are less bytes available in the message than the requested object size, the available bytes will be
+     * If there are fewer bytes available in the message than the requested object size, the available bytes will be
      * read and copied into @p aObject (@p aObject will be read partially). In this case `OT_ERROR_PARSE` will
      * be returned.
      *
@@ -1193,8 +1209,6 @@ private:
     {
         const_cast<const Message *>(this)->GetNextChunk(aLength, static_cast<Chunk &>(aChunk));
     }
-
-    otError Read(uint16_t aOffset, void *aBuf, uint16_t aLength) const;
 };
 
 /**

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -553,14 +553,32 @@ public:
      *
      * On success, this method grows the message by @p aLength bytes.
      *
-     * @param[in]  aBuf     A pointer to a data buffer.
+     * @param[in]  aBuf     A pointer to a data buffer (can be `nullptr` to grow message without writing bytes).
      * @param[in]  aLength  The number of bytes to prepend.
      *
      * @retval OT_ERROR_NONE     Successfully prepended the bytes.
      * @retval OT_ERROR_NO_BUFS  Not enough reserved bytes in the message.
      *
      */
-    otError Prepend(const void *aBuf, uint16_t aLength);
+    otError PrependBytes(const void *aBuf, uint16_t aLength);
+
+    /**
+     * This method prepends an object to the front of the message.
+     *
+     * On success, this method grows the message by the size of the object.
+     *
+     * @tparam    ObjectType   The object type to prepend to the message.
+     *
+     * @param[in] aObject      A reference to the object to prepend to the message.
+     *
+     * @retval OT_ERROR_NONE     Successfully prepended the object.
+     * @retval OT_ERROR_NO_BUFS  Not enough reserved bytes in the message.
+     *
+     */
+    template <typename ObjectType> otError Prepend(const ObjectType &aObject)
+    {
+        return PrependBytes(&aObject, sizeof(ObjectType));
+    }
 
     /**
      * This method removes header bytes from the message.
@@ -575,26 +593,65 @@ public:
      *
      * On success, this method grows the message by @p aLength bytes.
      *
-     * @param[in]  aBuf     A pointer to a data buffer.
+     * @param[in]  aBuf     A pointer to a data buffer (MUST not be `nullptr`).
      * @param[in]  aLength  The number of bytes to append.
      *
      * @retval OT_ERROR_NONE     Successfully appended the bytes.
      * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
      *
      */
-    otError Append(const void *aBuf, uint16_t aLength);
+    otError AppendBytes(const void *aBuf, uint16_t aLength);
+
+    /**
+     * This method appends an object to the end of the message.
+     *
+     * On success, this method grows the message by the size of the appended object
+     *
+     * @tparam    ObjectType   The object type to append to the message.
+     *
+     * @param[in] aObject      A reference to the object to append to the message.
+     *
+     * @retval OT_ERROR_NONE     Successfully appended the object.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
+     *
+     */
+    template <typename ObjectType> otError Append(const ObjectType &aObject)
+    {
+        return AppendBytes(&aObject, sizeof(ObjectType));
+    }
 
     /**
      * This method reads bytes from the message.
      *
      * @param[in]  aOffset  Byte offset within the message to begin reading.
+     * @param[out] aBuf     A pointer to a data buffer to copy the read bytes into.
      * @param[in]  aLength  Number of bytes to read.
-     * @param[in]  aBuf     A pointer to a data buffer.
      *
      * @returns The number of bytes read.
      *
      */
-    uint16_t Read(uint16_t aOffset, uint16_t aLength, void *aBuf) const;
+    uint16_t ReadBytes(uint16_t aOffset, void *aBuf, uint16_t aLength) const;
+
+    /**
+     * This method reads an object from the message.
+     *
+     * If there are less bytes available in the message than the requested object size, the available bytes will be
+     * read and copied into @p aObject (@p aObject will be read partially). In this case `OT_ERROR_PARSE` will
+     * be returned.
+     *
+     * @tparam     ObjectType   The object type to read from the message.
+     *
+     * @param[in]  aOffset      Byte offset within the message to begin reading.
+     * @param[out] aObject      A reference to the object to read into.
+     *
+     * @retval OT_ERROR_NONE     Object @p aObject was successfully read from message.
+     * @retval OT_ERROR_PARSE    Not enough bytes remaining in message to read the entire object.
+     *
+     */
+    template <typename ObjectType> otError Read(uint16_t aOffset, ObjectType &aObject) const
+    {
+        return Read(aOffset, &aObject, sizeof(ObjectType));
+    }
 
     /**
      * This method writes bytes to the message.
@@ -603,11 +660,28 @@ public:
      * existing message buffer (from the given offset @p aOffset up to the message's length).
      *
      * @param[in]  aOffset  Byte offset within the message to begin writing.
-     * @param[in]  aLength  Number of bytes to write.
      * @param[in]  aBuf     A pointer to a data buffer.
+     * @param[in]  aLength  Number of bytes to write.
      *
      */
-    void Write(uint16_t aOffset, uint16_t aLength, const void *aBuf);
+    void WriteBytes(uint16_t aOffset, const void *aBuf, uint16_t aLength);
+
+    /**
+     * This methods writes an object to the message.
+     *
+     * This method will not resize the message. The entire given object (all its bytes) MUST fit within the existing
+     * message buffer (from the given offset @p aOffset up to the message's length).
+     *
+     * @tparam     ObjectType   The object type to write to the message.
+     *
+     * @param[in]  aOffset      Byte offset within the message to begin writing.
+     * @param[in]  aObject      A reference to the object to write.
+     *
+     */
+    template <typename ObjectType> void Write(uint16_t aOffset, const ObjectType &aObject)
+    {
+        WriteBytes(aOffset, &aObject, sizeof(ObjectType));
+    }
 
     /**
      * This method copies bytes from one message to another.
@@ -1119,6 +1193,8 @@ private:
     {
         const_cast<const Message *>(this)->GetNextChunk(aLength, static_cast<Chunk &>(aChunk));
     }
+
+    otError Read(uint16_t aOffset, void *aBuf, uint16_t aLength) const;
 };
 
 /**

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -373,7 +373,7 @@ void BorderAgent::HandleProxyTransmit(const Coap::Message &aMessage)
         UdpEncapsulationTlv tlv;
 
         SuccessOrExit(error = Tlv::FindTlvOffset(aMessage, Tlv::kUdpEncapsulation, offset));
-        VerifyOrExit(aMessage.Read(offset, sizeof(tlv), &tlv) == sizeof(tlv), error = OT_ERROR_PARSE);
+        SuccessOrExit(error = aMessage.Read(offset, tlv));
 
         VerifyOrExit((message = Get<Ip6::Udp>().NewMessage(0)) != nullptr, error = OT_ERROR_NO_BUFS);
         SuccessOrExit(error = message->SetLength(tlv.GetUdpLength()));
@@ -420,7 +420,7 @@ bool BorderAgent::HandleUdpReceive(const Message &aMessage, const Ip6::MessageIn
         tlv.SetSourcePort(aMessageInfo.GetPeerPort());
         tlv.SetDestinationPort(aMessageInfo.GetSockPort());
         tlv.SetUdpLength(udpLength);
-        SuccessOrExit(error = message->Append(&tlv, sizeof(tlv)));
+        SuccessOrExit(error = message->Append(tlv));
 
         offset = message->GetLength();
         SuccessOrExit(error = message->SetLength(offset + udpLength));

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -701,8 +701,8 @@ otError Commissioner::SendMgmtCommissionerGetRequest(const uint8_t *aTlvs, uint8
     {
         tlv.SetType(MeshCoP::Tlv::kGet);
         tlv.SetLength(aLength);
-        SuccessOrExit(error = message->Append(&tlv, sizeof(tlv)));
-        SuccessOrExit(error = message->Append(aTlvs, aLength));
+        SuccessOrExit(error = message->Append(tlv));
+        SuccessOrExit(error = message->AppendBytes(aTlvs, aLength));
     }
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
@@ -777,7 +777,7 @@ otError Commissioner::SendMgmtCommissionerSetRequest(const otCommissioningDatase
 
     if (aLength > 0)
     {
-        SuccessOrExit(error = message->Append(aTlvs, aLength));
+        SuccessOrExit(error = message->AppendBytes(aTlvs, aLength));
     }
 
     if (message->GetLength() == message->GetOffset())
@@ -1100,7 +1100,7 @@ void Commissioner::HandleJoinerFinalize(Coap::Message &aMessage, const Ip6::Mess
     {
         uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
 
-        aMessage.Read(aMessage.GetOffset(), aMessage.GetLength() - aMessage.GetOffset(), buf);
+        aMessage.ReadBytes(aMessage.GetOffset(), buf, aMessage.GetLength() - aMessage.GetOffset());
         otDumpCertMeshCoP("[THCI] direction=recv | type=JOIN_FIN.req |", buf,
                           aMessage.GetLength() - aMessage.GetOffset());
     }
@@ -1132,7 +1132,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Message &aRequest, State
     uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
 
     VerifyOrExit(message->GetLength() <= sizeof(buf), OT_NOOP);
-    message->Read(message->GetOffset(), message->GetLength() - message->GetOffset(), buf);
+    message->ReadBytes(message->GetOffset(), buf, message->GetLength() - message->GetOffset());
     otDumpCertMeshCoP("[THCI] direction=send | type=JOIN_FIN.rsp |", buf, message->GetLength() - message->GetOffset());
 #endif
 
@@ -1185,7 +1185,7 @@ otError Commissioner::SendRelayTransmit(Message &aMessage, const Ip6::MessageInf
 
     tlv.SetType(Tlv::kJoinerDtlsEncapsulation);
     tlv.SetLength(aMessage.GetLength());
-    SuccessOrExit(error = message->Append(&tlv, sizeof(tlv)));
+    SuccessOrExit(error = message->Append(tlv));
     offset = message->GetLength();
     SuccessOrExit(error = message->SetLength(offset + aMessage.GetLength()));
     aMessage.CopyTo(0, offset, aMessage.GetLength(), *message);

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -366,12 +366,13 @@ otError Dataset::SetUint32Tlv(Tlv::Type aType, uint32_t aValue)
 
 otError Dataset::Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength)
 {
-    otError error = OT_ERROR_NONE;
+    otError error = OT_ERROR_INVALID_ARGS;
 
-    VerifyOrExit(aLength == aMessage.ReadBytes(aOffset, mTlvs, aLength), error = OT_ERROR_INVALID_ARGS);
+    SuccessOrExit(aMessage.Read(aOffset, mTlvs, aLength));
     mLength = aLength;
 
     mUpdateTime = TimerMilli::GetNow();
+    error       = OT_ERROR_NONE;
 
 exit:
     return error;

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -368,7 +368,7 @@ otError Dataset::Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aLength == aMessage.Read(aOffset, aLength, mTlvs), error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aLength == aMessage.ReadBytes(aOffset, mTlvs, aLength), error = OT_ERROR_INVALID_ARGS);
     mLength = aLength;
 
     mUpdateTime = TimerMilli::GetNow();
@@ -400,7 +400,7 @@ otError Dataset::AppendMleDatasetTlv(Message &aMessage) const
 
     tlv.SetType(type);
     tlv.SetLength(static_cast<uint8_t>(mLength) - sizeof(Tlv) - sizeof(Timestamp));
-    SuccessOrExit(error = aMessage.Append(&tlv, sizeof(Tlv)));
+    SuccessOrExit(error = aMessage.Append(tlv));
 
     for (const Tlv *cur = GetTlvsStart(); cur < GetTlvsEnd(); cur = cur->GetNext())
     {

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -284,7 +284,7 @@ void DatasetManager::SendSet(void)
     SuccessOrExit(error = message->SetPayloadMarker());
 
     IgnoreError(mLocal.Read(dataset));
-    SuccessOrExit(error = message->Append(dataset.GetBytes(), dataset.GetSize()));
+    SuccessOrExit(error = message->AppendBytes(dataset.GetBytes(), dataset.GetSize()));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     IgnoreError(Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr()));
@@ -340,7 +340,7 @@ void DatasetManager::HandleGet(const Coap::Message &aMessage, const Ip6::Message
 
     while (offset < aMessage.GetLength())
     {
-        aMessage.Read(offset, sizeof(tlv), &tlv);
+        IgnoreError(aMessage.Read(offset, tlv));
 
         if (tlv.GetType() == Tlv::kGet)
         {
@@ -352,7 +352,7 @@ void DatasetManager::HandleGet(const Coap::Message &aMessage, const Ip6::Message
                 length = sizeof(tlvs) - 1;
             }
 
-            aMessage.Read(offset + sizeof(Tlv), length, tlvs);
+            aMessage.ReadBytes(offset + sizeof(Tlv), tlvs, length);
             break;
         }
 
@@ -558,7 +558,7 @@ otError DatasetManager::SendSetRequest(const otOperationalDataset &aDataset, con
 
     if (aLength > 0)
     {
-        SuccessOrExit(error = message->Append(aTlvs, aLength));
+        SuccessOrExit(error = message->AppendBytes(aTlvs, aLength));
     }
 
     if (message->GetLength() == message->GetOffset())
@@ -666,16 +666,16 @@ otError DatasetManager::SendGetRequest(const otOperationalDatasetComponents &aDa
     {
         tlv.SetType(Tlv::kGet);
         tlv.SetLength(aLength + length);
-        SuccessOrExit(error = message->Append(&tlv, sizeof(tlv)));
+        SuccessOrExit(error = message->Append(tlv));
 
         if (length > 0)
         {
-            SuccessOrExit(error = message->Append(datasetTlvs, length));
+            SuccessOrExit(error = message->AppendBytes(datasetTlvs, length));
         }
 
         if (aLength > 0)
         {
-            SuccessOrExit(error = message->Append(aTlvTypes, aLength));
+            SuccessOrExit(error = message->AppendBytes(aTlvTypes, aLength));
         }
     }
 

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -295,9 +295,9 @@ otError DatasetManager::DatasetTlv::ReadFromMessage(const Message &aMessage, uin
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aMessage.ReadBytes(aOffset, this, sizeof(Tlv)) == sizeof(Tlv), error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aOffset, this, sizeof(Tlv)));
     VerifyOrExit(GetLength() <= kMaxValueSize, error = OT_ERROR_PARSE);
-    VerifyOrExit(aMessage.ReadBytes(aOffset + sizeof(Tlv), mValue, GetLength()) == GetLength(), error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aOffset + sizeof(Tlv), mValue, GetLength()));
     VerifyOrExit(Tlv::IsValid(*this), error = OT_ERROR_PARSE);
 
 exit:

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -97,7 +97,7 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
     // verify that TLV data size is less than maximum TLV value size
     while (offset < aMessage.GetLength())
     {
-        aMessage.Read(offset, sizeof(tlv), &tlv);
+        SuccessOrExit(aMessage.Read(offset, tlv));
         VerifyOrExit(tlv.GetLength() <= Dataset::kMaxValueSize, OT_NOOP);
         offset += sizeof(tlv) + tlv.GetLength();
     }
@@ -295,9 +295,9 @@ otError DatasetManager::DatasetTlv::ReadFromMessage(const Message &aMessage, uin
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aMessage.Read(aOffset, sizeof(Tlv), this) == sizeof(Tlv), error = OT_ERROR_PARSE);
+    VerifyOrExit(aMessage.ReadBytes(aOffset, this, sizeof(Tlv)) == sizeof(Tlv), error = OT_ERROR_PARSE);
     VerifyOrExit(GetLength() <= kMaxValueSize, error = OT_ERROR_PARSE);
-    VerifyOrExit(aMessage.Read(aOffset + sizeof(Tlv), GetLength(), mValue) == GetLength(), error = OT_ERROR_PARSE);
+    VerifyOrExit(aMessage.ReadBytes(aOffset + sizeof(Tlv), mValue, GetLength()) == GetLength(), error = OT_ERROR_PARSE);
     VerifyOrExit(Tlv::IsValid(*this), error = OT_ERROR_PARSE);
 
 exit:

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -539,7 +539,7 @@ otError Dtls::Send(Message &aMessage, uint16_t aLength)
         mMessageSubType = aMessage.GetSubType();
     }
 
-    aMessage.Read(0, aLength, buffer);
+    aMessage.ReadBytes(0, buffer, aLength);
 
     SuccessOrExit(error = Crypto::MbedTls::MapError(mbedtls_ssl_write(&mSsl, buffer, aLength)));
 
@@ -631,7 +631,7 @@ int Dtls::HandleMbedtlsReceive(unsigned char *aBuf, size_t aLength)
         aLength = static_cast<size_t>(rval);
     }
 
-    rval = mReceiveMessage->Read(mReceiveMessage->GetOffset(), static_cast<uint16_t>(aLength), aBuf);
+    rval = mReceiveMessage->ReadBytes(mReceiveMessage->GetOffset(), aBuf, static_cast<uint16_t>(aLength));
     mReceiveMessage->MoveOffset(rval);
 
 exit:
@@ -914,7 +914,7 @@ otError Dtls::HandleDtlsSend(const uint8_t *aBuf, uint16_t aLength, Message::Sub
     message->SetSubType(aMessageSubType);
     message->SetLinkSecurityEnabled(mLayerTwoSecurity);
 
-    SuccessOrExit(error = message->Append(aBuf, aLength));
+    SuccessOrExit(error = message->AppendBytes(aBuf, aLength));
 
     // Set message sub type in case Joiner Finalize Response is appended to the message.
     if (aMessageSubType != Message::kSubTypeNone)

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -687,7 +687,7 @@ void Joiner::LogCertMessage(const char *aText, const Coap::Message &aMessage) co
     uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
 
     VerifyOrExit(aMessage.GetLength() <= sizeof(buf), OT_NOOP);
-    aMessage.Read(aMessage.GetOffset(), aMessage.GetLength() - aMessage.GetOffset(), buf);
+    aMessage.ReadBytes(aMessage.GetOffset(), buf, aMessage.GetLength() - aMessage.GetOffset());
 
     otDumpCertMeshCoP(aText, buf, aMessage.GetLength() - aMessage.GetOffset());
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -155,7 +155,7 @@ void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &a
 
     tlv.SetType(Tlv::kJoinerDtlsEncapsulation);
     tlv.SetLength(aMessage.GetLength() - aMessage.GetOffset());
-    SuccessOrExit(error = message->Append(&tlv, sizeof(tlv)));
+    SuccessOrExit(error = message->Append(tlv));
     offset = message->GetLength();
     SuccessOrExit(error = message->SetLength(offset + tlv.GetLength()));
     aMessage.CopyTo(aMessage.GetOffset(), offset, tlv.GetLength(), *message);
@@ -429,7 +429,7 @@ void JoinerRouter::JoinerEntrustMetadata::ReadFrom(const Message &aMessage)
     uint16_t length = aMessage.GetLength();
 
     OT_ASSERT(length >= sizeof(*this));
-    aMessage.Read(length - sizeof(*this), sizeof(*this), this);
+    IgnoreError(aMessage.Read(length - sizeof(*this), *this));
 }
 
 } // namespace MeshCoP

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -88,7 +88,7 @@ private:
 
     struct JoinerEntrustMetadata
     {
-        otError AppendTo(Message &aMessage) { return aMessage.Append(this, sizeof(*this)); }
+        otError AppendTo(Message &aMessage) { return aMessage.Append(*this); }
         void    ReadFrom(const Message &aMessage);
 
         Ip6::MessageInfo mMessageInfo; // Message info of the message to send.

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -267,21 +267,21 @@ uint32_t ChannelMaskTlv::GetChannelMask(const Message &aMessage)
     {
         ChannelMaskEntry entry;
 
-        aMessage.Read(offset, sizeof(ChannelMaskEntryBase), &entry);
+        IgnoreError(aMessage.Read(offset, entry));
         VerifyOrExit(offset + entry.GetEntrySize() <= end, OT_NOOP);
 
         switch (entry.GetChannelPage())
         {
 #if OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT
         case OT_RADIO_CHANNEL_PAGE_0:
-            aMessage.Read(offset, sizeof(entry), &entry);
+            IgnoreError(aMessage.Read(offset, entry));
             mask |= entry.GetMask() & OT_RADIO_2P4GHZ_OQPSK_CHANNEL_MASK;
             break;
 #endif
 
 #if OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
         case OT_RADIO_CHANNEL_PAGE_2:
-            aMessage.Read(offset, sizeof(entry), &entry);
+            IgnoreError(aMessage.Read(offset, entry));
             mask |= entry.GetMask() & OT_RADIO_915MHZ_OQPSK_CHANNEL_MASK;
             break;
 #endif

--- a/src/core/net/checksum.cpp
+++ b/src/core/net/checksum.cpp
@@ -85,7 +85,7 @@ void Checksum::WriteToMessage(uint16_t aOffset, Message &aMessage) const
 
     checksum = Encoding::BigEndian::HostSwap16(checksum);
 
-    aMessage.Write(aOffset, sizeof(checksum), &checksum);
+    aMessage.Write(aOffset, checksum);
 }
 
 void Checksum::Calculate(const Ip6::Address &aSource,

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -300,7 +300,7 @@ otError Client::AppendHeader(Message &aMessage)
     header.Clear();
     header.SetType(kTypeSolicit);
     header.SetTransactionId(mTransactionId);
-    return aMessage.Append(&header, sizeof(header));
+    return aMessage.Append(header);
 }
 
 otError Client::AppendElapsedTime(Message &aMessage)
@@ -309,7 +309,7 @@ otError Client::AppendElapsedTime(Message &aMessage)
 
     option.Init();
     option.SetElapsedTime(static_cast<uint16_t>(Time::MsecToSec(TimerMilli::GetNow() - mStartTime)));
-    return aMessage.Append(&option, sizeof(option));
+    return aMessage.Append(option);
 }
 
 otError Client::AppendClientIdentifier(Message &aMessage)
@@ -324,7 +324,7 @@ otError Client::AppendClientIdentifier(Message &aMessage)
     option.SetDuidHardwareType(kHardwareTypeEui64);
     option.SetDuidLinkLayerAddress(eui64);
 
-    return aMessage.Append(&option, sizeof(option));
+    return aMessage.Append(option);
 }
 
 otError Client::AppendIaNa(Message &aMessage, uint16_t aRloc16)
@@ -357,7 +357,7 @@ otError Client::AppendIaNa(Message &aMessage, uint16_t aRloc16)
     option.SetIaid(0);
     option.SetT1(0);
     option.SetT2(0);
-    SuccessOrExit(error = aMessage.Append(&option, sizeof(IaNa)));
+    SuccessOrExit(error = aMessage.Append(option));
 
 exit:
     return error;
@@ -380,7 +380,7 @@ otError Client::AppendIaAddress(Message &aMessage, uint16_t aRloc16)
             option.SetAddress(idAssociation.mNetifAddress.GetAddress());
             option.SetPreferredLifetime(0);
             option.SetValidLifetime(0);
-            SuccessOrExit(error = aMessage.Append(&option, sizeof(option)));
+            SuccessOrExit(error = aMessage.Append(option));
         }
     }
 
@@ -393,7 +393,7 @@ otError Client::AppendRapidCommit(Message &aMessage)
     RapidCommit option;
 
     option.Init();
-    return aMessage.Append(&option, sizeof(option));
+    return aMessage.Append(option);
 }
 
 void Client::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
@@ -408,7 +408,7 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
 
     Header header;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(header), &header) == sizeof(header), OT_NOOP);
+    SuccessOrExit(aMessage.Read(aMessage.GetOffset(), header));
     aMessage.MoveOffset(sizeof(header));
 
     if ((header.GetType() == kTypeReply) && (header.GetTransactionId() == mTransactionId))
@@ -462,7 +462,7 @@ uint16_t Client::FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLengt
     {
         Option option;
 
-        VerifyOrExit(aMessage.Read(static_cast<uint16_t>(offset), sizeof(option), &option) == sizeof(option), OT_NOOP);
+        SuccessOrExit(aMessage.Read(static_cast<uint16_t>(offset), option));
 
         if (option.GetCode() == aCode)
         {
@@ -481,7 +481,7 @@ otError Client::ProcessServerIdentifier(Message &aMessage, uint16_t aOffset)
     otError          error = OT_ERROR_NONE;
     ServerIdentifier option;
 
-    VerifyOrExit((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)), OT_NOOP);
+    SuccessOrExit(aMessage.Read(aOffset, option));
     VerifyOrExit(((option.GetDuidType() == kDuidLinkLayerAddressPlusTime) &&
                   (option.GetDuidHardwareType() == kHardwareTypeEthernet)) ||
                      ((option.GetLength() == (sizeof(option) - sizeof(Option))) &&
@@ -500,11 +500,10 @@ otError Client::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset)
 
     Get<Radio>().GetIeeeEui64(eui64);
 
+    SuccessOrExit(error = aMessage.Read(aOffset, option));
     VerifyOrExit(
-        (((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
-          (option.GetLength() == (sizeof(option) - sizeof(Option))) &&
-          (option.GetDuidType() == kDuidLinkLayerAddress) && (option.GetDuidHardwareType() == kHardwareTypeEui64)) &&
-         (option.GetDuidLinkLayerAddress() == eui64)),
+        (option.GetLength() == (sizeof(option) - sizeof(Option))) && (option.GetDuidType() == kDuidLinkLayerAddress) &&
+            (option.GetDuidHardwareType() == kHardwareTypeEui64) && (option.GetDuidLinkLayerAddress() == eui64),
         error = OT_ERROR_PARSE);
 exit:
     return error;
@@ -517,7 +516,7 @@ otError Client::ProcessIaNa(Message &aMessage, uint16_t aOffset)
     uint16_t optionOffset;
     uint16_t length;
 
-    VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option), error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aOffset, option));
 
     aOffset += sizeof(option);
     length = option.GetLength() - (sizeof(option) - sizeof(Option));
@@ -551,9 +550,8 @@ otError Client::ProcessStatusCode(Message &aMessage, uint16_t aOffset)
     otError    error = OT_ERROR_NONE;
     StatusCode option;
 
-    VerifyOrExit(((aMessage.Read(aOffset, sizeof(option), &option) >= sizeof(option)) &&
-                  (option.GetLength() >= (sizeof(option) - sizeof(Option))) &&
-                  (option.GetStatusCode() == kStatusSuccess)),
+    SuccessOrExit(error = aMessage.Read(aOffset, option));
+    VerifyOrExit((option.GetLength() >= sizeof(option) - sizeof(Option)) && (option.GetStatusCode() == kStatusSuccess),
                  error = OT_ERROR_PARSE);
 
 exit:
@@ -565,9 +563,8 @@ otError Client::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
     otError   error = OT_ERROR_NONE;
     IaAddress option;
 
-    VerifyOrExit(((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
-                  (option.GetLength() == (sizeof(option) - sizeof(Option)))),
-                 error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aOffset, option));
+    VerifyOrExit(option.GetLength() == sizeof(option) - sizeof(Option), error = OT_ERROR_PARSE);
 
     for (IdentityAssociation &idAssociation : mIdentityAssociations)
     {

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -183,7 +183,7 @@ void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
 {
     Header header;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(header), &header) == sizeof(header), OT_NOOP);
+    SuccessOrExit(aMessage.Read(aMessage.GetOffset(), header));
     aMessage.MoveOffset(sizeof(header));
 
     // discard if not solicit type
@@ -237,7 +237,8 @@ uint16_t Server::FindOption(Message &aMessage, uint16_t aOffset, uint16_t aLengt
     while (aOffset <= end)
     {
         Option option;
-        VerifyOrExit(aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option), OT_NOOP);
+
+        SuccessOrExit(aMessage.Read(aOffset, option));
 
         if (option.GetCode() == aCode)
         {
@@ -254,10 +255,10 @@ otError Server::ProcessClientIdentifier(Message &aMessage, uint16_t aOffset, Cli
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(((aMessage.Read(aOffset, sizeof(aClientId), &aClientId) == sizeof(aClientId)) &&
-                  (aClientId.GetLength() == (sizeof(aClientId) - sizeof(Option))) &&
-                  (aClientId.GetDuidType() == kDuidLinkLayerAddress) &&
-                  (aClientId.GetDuidHardwareType() == kHardwareTypeEui64)),
+    SuccessOrExit(error = aMessage.Read(aOffset, aClientId));
+    VerifyOrExit((aClientId.GetLength() == sizeof(aClientId) - sizeof(Option)) &&
+                     (aClientId.GetDuidType() == kDuidLinkLayerAddress) &&
+                     (aClientId.GetDuidHardwareType() == kHardwareTypeEui64),
                  error = OT_ERROR_PARSE);
 exit:
     return error;
@@ -268,9 +269,8 @@ otError Server::ProcessElapsedTime(Message &aMessage, uint16_t aOffset)
     otError     error = OT_ERROR_NONE;
     ElapsedTime option;
 
-    VerifyOrExit(((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
-                  (option.GetLength() == ((sizeof(option) - sizeof(Option))))),
-                 error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aOffset, option));
+    VerifyOrExit(option.GetLength() == sizeof(option) - sizeof(Option), error = OT_ERROR_PARSE);
 exit:
     return error;
 }
@@ -281,7 +281,7 @@ otError Server::ProcessIaNa(Message &aMessage, uint16_t aOffset, IaNa &aIaNa)
     uint16_t optionOffset;
     uint16_t length;
 
-    VerifyOrExit((aMessage.Read(aOffset, sizeof(aIaNa), &aIaNa) == sizeof(aIaNa)), error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aOffset, aIaNa));
 
     aOffset += sizeof(aIaNa);
     length = aIaNa.GetLength() + sizeof(Option) - sizeof(IaNa);
@@ -308,9 +308,8 @@ otError Server::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
     otError   error = OT_ERROR_NONE;
     IaAddress option;
 
-    VerifyOrExit(((aMessage.Read(aOffset, sizeof(option), &option) == sizeof(option)) &&
-                  option.GetLength() == (sizeof(option) - sizeof(Option))),
-                 error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aOffset, option));
+    VerifyOrExit(option.GetLength() == sizeof(option) - sizeof(Option), error = OT_ERROR_PARSE);
 
     // mask matching prefix
     for (uint16_t i = 0; i < OT_ARRAY_LENGTH(mPrefixAgents); i++)
@@ -360,12 +359,12 @@ otError Server::AppendHeader(Message &aMessage, const TransactionId &aTransactio
     header.Clear();
     header.SetType(kTypeReply);
     header.SetTransactionId(aTransactionId);
-    return aMessage.Append(&header, sizeof(header));
+    return aMessage.Append(header);
 }
 
 otError Server::AppendClientIdentifier(Message &aMessage, ClientIdentifier &aClientId)
 {
-    return aMessage.Append(&aClientId, sizeof(aClientId));
+    return aMessage.Append(aClientId);
 }
 
 otError Server::AppendServerIdentifier(Message &aMessage)
@@ -380,7 +379,7 @@ otError Server::AppendServerIdentifier(Message &aMessage)
     option.SetDuidType(kDuidLinkLayerAddress);
     option.SetDuidHardwareType(kHardwareTypeEui64);
     option.SetDuidLinkLayerAddress(eui64);
-    SuccessOrExit(error = aMessage.Append(&option, sizeof(option)));
+    SuccessOrExit(error = aMessage.Append(option));
 
 exit:
     return error;
@@ -411,7 +410,7 @@ otError Server::AppendIaNa(Message &aMessage, IaNa &aIaNa)
     aIaNa.SetLength(length);
     aIaNa.SetT1(IaNa::kDefaultT1);
     aIaNa.SetT2(IaNa::kDefaultT2);
-    SuccessOrExit(error = aMessage.Append(&aIaNa, sizeof(IaNa)));
+    SuccessOrExit(error = aMessage.Append(aIaNa));
 
 exit:
     return error;
@@ -423,7 +422,7 @@ otError Server::AppendStatusCode(Message &aMessage, Status aStatusCode)
 
     option.Init();
     option.SetStatusCode(aStatusCode);
-    return aMessage.Append(&option, sizeof(option));
+    return aMessage.Append(option);
 }
 
 otError Server::AppendIaAddress(Message &aMessage, ClientIdentifier &aClientId)
@@ -467,7 +466,7 @@ otError Server::AddIaAddress(Message &aMessage, const Ip6::Address &aPrefix, Cli
     option.GetAddress().GetIid().SetFromExtAddress(aClientId.GetDuidLinkLayerAddress());
     option.SetPreferredLifetime(IaAddress::kDefaultPreferredLifetime);
     option.SetValidLifetime(IaAddress::kDefaultValidLiftetime);
-    SuccessOrExit(error = aMessage.Append(&option, sizeof(option)));
+    SuccessOrExit(error = aMessage.Append(option));
 
 exit:
     return error;
@@ -478,7 +477,7 @@ otError Server::AppendRapidCommit(Message &aMessage)
     RapidCommit option;
 
     option.Init();
-    return aMessage.Append(&option, sizeof(option));
+    return aMessage.Append(option);
 }
 
 void Server::ApplyMeshLocalPrefix(void)

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -269,7 +269,7 @@ otError Client::CompareQuestions(Message &aMessageResponse, Message &aMessageQue
         VerifyOrExit((read = aMessageQuery.ReadBytes(offset, bufQuery,
                                                      length < sizeof(bufQuery) ? length : sizeof(bufQuery))) > 0,
                      error = OT_ERROR_PARSE);
-        VerifyOrExit(aMessageResponse.ReadBytes(aOffset, bufResponse, read) == read, error = OT_ERROR_PARSE);
+        SuccessOrExit(error = aMessageResponse.Read(aOffset, bufResponse, read));
 
         VerifyOrExit(memcmp(bufResponse, bufQuery, read) == 0, error = OT_ERROR_NOT_FOUND);
 

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -147,7 +147,7 @@ Message *Client::NewMessage(const Header &aHeader)
     Message *message = nullptr;
 
     VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != nullptr, OT_NOOP);
-    IgnoreError(message->Prepend(&aHeader, sizeof(aHeader)));
+    IgnoreError(message->Prepend(aHeader));
     message->SetOffset(0);
 
 exit:
@@ -226,8 +226,8 @@ otError Client::AppendCompressedHostname(Message &aMessage, const char *aHostnam
         if (aHostname[index] == kLabelSeparator || aHostname[index] == kLabelTerminator)
         {
             VerifyOrExit(labelSize > 0, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = aMessage.Append(&labelSize, 1));
-            SuccessOrExit(error = aMessage.Append(&aHostname[labelPosition], labelSize));
+            SuccessOrExit(error = aMessage.Append(labelSize));
+            SuccessOrExit(error = aMessage.AppendBytes(&aHostname[labelPosition], labelSize));
 
             labelPosition += labelSize + 1;
             labelSize = 0;
@@ -247,7 +247,7 @@ otError Client::AppendCompressedHostname(Message &aMessage, const char *aHostnam
 
     // Add termination character at the end.
     labelSize = kLabelTerminator;
-    SuccessOrExit(error = aMessage.Append(&labelSize, 1));
+    SuccessOrExit(error = aMessage.Append(labelSize));
 
 exit:
     return error;
@@ -266,10 +266,10 @@ otError Client::CompareQuestions(Message &aMessageResponse, Message &aMessageQue
 
     while (length > 0)
     {
-        VerifyOrExit(
-            (read = aMessageQuery.Read(offset, length < sizeof(bufQuery) ? length : sizeof(bufQuery), bufQuery)) > 0,
-            error = OT_ERROR_PARSE);
-        VerifyOrExit(aMessageResponse.Read(aOffset, read, bufResponse) == read, error = OT_ERROR_PARSE);
+        VerifyOrExit((read = aMessageQuery.ReadBytes(offset, bufQuery,
+                                                     length < sizeof(bufQuery) ? length : sizeof(bufQuery))) > 0,
+                     error = OT_ERROR_PARSE);
+        VerifyOrExit(aMessageResponse.ReadBytes(aOffset, bufResponse, read) == read, error = OT_ERROR_PARSE);
 
         VerifyOrExit(memcmp(bufResponse, bufQuery, read) == 0, error = OT_ERROR_NOT_FOUND);
 
@@ -293,7 +293,7 @@ otError Client::SkipHostname(Message &aMessage, uint16_t &aOffset)
 
     while (length > 0)
     {
-        VerifyOrExit((read = aMessage.Read(offset, sizeof(buf), buf)) > 0, error = OT_ERROR_PARSE);
+        VerifyOrExit((read = aMessage.ReadBytes(offset, buf, sizeof(buf))) > 0, error = OT_ERROR_PARSE);
 
         index = 0;
 
@@ -330,10 +330,10 @@ Message *Client::FindRelatedQuery(const Header &aResponseHeader, QueryMetadata &
     while (message != nullptr)
     {
         // Partially read DNS header to obtain message ID only.
-        uint16_t count = message->Read(message->GetOffset(), sizeof(messageId), &messageId);
+        otError error = message->Read(message->GetOffset(), messageId);
 
-        OT_UNUSED_VARIABLE(count);
-        OT_ASSERT(count == sizeof(messageId));
+        OT_UNUSED_VARIABLE(error);
+        OT_ASSERT(error == OT_ERROR_NONE);
 
         if (HostSwap16(messageId) == aResponseHeader.GetMessageId())
         {
@@ -437,8 +437,7 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
     Message *          message = nullptr;
     uint16_t           offset;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(responseHeader), &responseHeader) == sizeof(responseHeader),
-                 OT_NOOP);
+    SuccessOrExit(aMessage.Read(aMessage.GetOffset(), responseHeader));
     VerifyOrExit(responseHeader.GetType() == Header::kTypeResponse && responseHeader.GetQuestionCount() == 1 &&
                      !responseHeader.IsTruncationFlagSet(),
                  OT_NOOP);
@@ -460,7 +459,7 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
 
         SuccessOrExit(error = SkipHostname(aMessage, offset));
 
-        VerifyOrExit(aMessage.Read(offset, sizeof(record), &record) == sizeof(record), error = OT_ERROR_PARSE);
+        SuccessOrExit(error = aMessage.Read(offset, record));
 
         if ((record.GetType() == ResourceRecordAaaa::kType) && (record.GetClass() == ResourceRecordAaaa::kClass))
         {
@@ -487,12 +486,12 @@ void Client::QueryMetadata::ReadFrom(const Message &aMessage)
     uint16_t length = aMessage.GetLength();
 
     OT_ASSERT(length >= sizeof(*this));
-    aMessage.Read(length - sizeof(*this), sizeof(*this), this);
+    IgnoreError(aMessage.Read(length - sizeof(*this), *this));
 }
 
 void Client::QueryMetadata::UpdateIn(Message &aMessage) const
 {
-    aMessage.Write(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
+    aMessage.Write(aMessage.GetLength() - sizeof(*this), *this);
 }
 
 } // namespace Dns

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -123,7 +123,7 @@ private:
 
     struct QueryMetadata
     {
-        otError AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
+        otError AppendTo(Message &aMessage) const { return aMessage.Append(*this); }
         void    ReadFrom(const Message &aMessage);
         void    UpdateIn(Message &aMessage) const;
 

--- a/src/core/net/dns_headers.hpp
+++ b/src/core/net/dns_headers.hpp
@@ -576,7 +576,7 @@ public:
      * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
      *
      */
-    otError AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
+    otError AppendTo(Message &aMessage) const { return aMessage.Append(*this); }
 };
 
 /**

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -80,7 +80,7 @@ Message *Ip6::NewMessage(const uint8_t *aData, uint16_t aDataLength, const Messa
 
     VerifyOrExit(message != nullptr, OT_NOOP);
 
-    if (message->Append(aData, aDataLength) != OT_ERROR_NONE)
+    if (message->AppendBytes(aData, aDataLength) != OT_ERROR_NONE)
     {
         message->Free();
         message = nullptr;
@@ -195,11 +195,11 @@ otError Ip6::AddMplOption(Message &aMessage, Header &aHeader)
     if ((mplOption.GetTotalLength() + sizeof(hbhHeader)) % 8)
     {
         padOption.Init(2);
-        SuccessOrExit(error = aMessage.Prepend(&padOption, padOption.GetTotalLength()));
+        SuccessOrExit(error = aMessage.PrependBytes(&padOption, padOption.GetTotalLength()));
     }
 
-    SuccessOrExit(error = aMessage.Prepend(&mplOption, mplOption.GetTotalLength()));
-    SuccessOrExit(error = aMessage.Prepend(&hbhHeader, sizeof(hbhHeader)));
+    SuccessOrExit(error = aMessage.PrependBytes(&mplOption, mplOption.GetTotalLength()));
+    SuccessOrExit(error = aMessage.Prepend(hbhHeader));
     aHeader.SetPayloadLength(aHeader.GetPayloadLength() + sizeof(hbhHeader) + sizeof(mplOption));
     aHeader.SetNextHeader(kProtoHopOpts);
 
@@ -228,7 +228,7 @@ otError Ip6::AddTunneledMplOption(Message &aMessage, Header &aHeader, MessageInf
     tunnelHeader.SetSource(source->GetAddress());
 
     SuccessOrExit(error = AddMplOption(aMessage, tunnelHeader));
-    SuccessOrExit(error = aMessage.Prepend(&tunnelHeader, sizeof(tunnelHeader)));
+    SuccessOrExit(error = aMessage.Prepend(tunnelHeader));
 
 exit:
     return error;
@@ -253,29 +253,29 @@ otError Ip6::InsertMplOption(Message &aMessage, Header &aHeader, MessageInfo &aM
             OptionMpl      mplOption;
 
             // read existing hop-by-hop option header
-            aMessage.Read(0, sizeof(hbh), &hbh);
+            IgnoreError(aMessage.Read(0, hbh));
             hbhLength = (hbh.GetLength() + 1) * 8;
 
             VerifyOrExit(hbhLength <= aHeader.GetPayloadLength(), error = OT_ERROR_PARSE);
 
             // increase existing hop-by-hop option header length by 8 bytes
             hbh.SetLength(hbh.GetLength() + 1);
-            aMessage.Write(0, sizeof(hbh), &hbh);
+            aMessage.Write(0, hbh);
 
             // make space for MPL Option + padding by shifting hop-by-hop option header
-            SuccessOrExit(error = aMessage.Prepend(nullptr, 8));
+            SuccessOrExit(error = aMessage.PrependBytes(nullptr, 8));
             aMessage.CopyTo(8, 0, hbhLength, aMessage);
 
             // insert MPL Option
             mMpl.InitOption(mplOption, aHeader.GetSource());
-            aMessage.Write(hbhLength, mplOption.GetTotalLength(), &mplOption);
+            aMessage.WriteBytes(hbhLength, &mplOption, mplOption.GetTotalLength());
 
             // insert Pad Option (if needed)
             if (mplOption.GetTotalLength() % 8)
             {
                 OptionPadN padOption;
                 padOption.Init(8 - (mplOption.GetTotalLength() % 8));
-                aMessage.Write(hbhLength + mplOption.GetTotalLength(), padOption.GetTotalLength(), &padOption);
+                aMessage.WriteBytes(hbhLength + mplOption.GetTotalLength(), &padOption, padOption.GetTotalLength());
             }
 
             // increase IPv6 Payload Length
@@ -286,7 +286,7 @@ otError Ip6::InsertMplOption(Message &aMessage, Header &aHeader, MessageInfo &aM
             SuccessOrExit(error = AddMplOption(aMessage, aHeader));
         }
 
-        SuccessOrExit(error = aMessage.Prepend(&aHeader, sizeof(aHeader)));
+        SuccessOrExit(error = aMessage.Prepend(aHeader));
     }
     else
     {
@@ -327,11 +327,11 @@ otError Ip6::RemoveMplOption(Message &aMessage)
     bool           remove    = false;
 
     offset = 0;
-    aMessage.Read(offset, sizeof(ip6Header), &ip6Header);
+    IgnoreError(aMessage.Read(offset, ip6Header));
     offset += sizeof(ip6Header);
     VerifyOrExit(ip6Header.GetNextHeader() == kProtoHopOpts, OT_NOOP);
 
-    aMessage.Read(offset, sizeof(hbh), &hbh);
+    IgnoreError(aMessage.Read(offset, hbh));
     endOffset = offset + (hbh.GetLength() + 1) * 8;
     VerifyOrExit(aMessage.GetLength() >= endOffset, error = OT_ERROR_PARSE);
 
@@ -341,7 +341,7 @@ otError Ip6::RemoveMplOption(Message &aMessage)
     {
         OptionHeader option;
 
-        aMessage.Read(offset, sizeof(option), &option);
+        IgnoreError(aMessage.Read(offset, option));
 
         switch (option.GetType())
         {
@@ -396,8 +396,8 @@ otError Ip6::RemoveMplOption(Message &aMessage)
 
         while (offset >= sizeof(buf))
         {
-            aMessage.Read(offset - sizeof(buf), sizeof(buf), buf);
-            aMessage.Write(offset, sizeof(buf), buf);
+            IgnoreError(aMessage.Read(offset - sizeof(buf), buf));
+            aMessage.Write(offset, buf);
             offset -= sizeof(buf);
         }
 
@@ -412,11 +412,11 @@ otError Ip6::RemoveMplOption(Message &aMessage)
         {
             // update HBH header length
             hbh.SetLength(hbh.GetLength() - 1);
-            aMessage.Write(sizeof(ip6Header), sizeof(hbh), &hbh);
+            aMessage.Write(sizeof(ip6Header), hbh);
         }
 
         ip6Header.SetPayloadLength(ip6Header.GetPayloadLength() - sizeof(buf));
-        aMessage.Write(0, sizeof(ip6Header), &ip6Header);
+        aMessage.Write(0, ip6Header);
     }
     else if (mplOffset != 0)
     {
@@ -424,7 +424,7 @@ otError Ip6::RemoveMplOption(Message &aMessage)
         OptionPadN padOption;
 
         padOption.Init(sizeof(OptionHeader) + mplLength);
-        aMessage.Write(mplOffset, padOption.GetTotalLength(), &padOption);
+        aMessage.WriteBytes(mplOffset, &padOption, padOption.GetTotalLength());
     }
 
 exit:
@@ -476,7 +476,7 @@ otError Ip6::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t 
         SuccessOrExit(error = AddMplOption(aMessage, header));
     }
 
-    SuccessOrExit(error = aMessage.Prepend(&header, sizeof(header)));
+    SuccessOrExit(error = aMessage.Prepend(header));
 
     Checksum::UpdateMessageChecksum(aMessage, header.GetSource(), header.GetDestination(), aIpProto);
 
@@ -539,8 +539,7 @@ otError Ip6::HandleOptions(Message &aMessage, Header &aHeader, bool &aForward)
     OptionHeader   optionHeader;
     uint16_t       endOffset;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(hbhHeader), &hbhHeader) == sizeof(hbhHeader),
-                 error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), hbhHeader));
     endOffset = aMessage.GetOffset() + (hbhHeader.GetLength() + 1) * 8;
 
     VerifyOrExit(endOffset <= aMessage.GetLength(), error = OT_ERROR_PARSE);
@@ -549,8 +548,7 @@ otError Ip6::HandleOptions(Message &aMessage, Header &aHeader, bool &aForward)
 
     while (aMessage.GetOffset() < endOffset)
     {
-        VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(optionHeader), &optionHeader) == sizeof(optionHeader),
-                     error = OT_ERROR_PARSE);
+        SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), optionHeader));
 
         if (optionHeader.GetType() == OptionPad1::kType)
         {
@@ -610,7 +608,7 @@ otError Ip6::FragmentDatagram(Message &aMessage, uint8_t aIpProto)
         FragmentHeader::MakeDivisibleByEight(kMinimalMtu - aMessage.GetOffset() - sizeof(fragmentHeader));
     uint16_t payloadLeft = aMessage.GetLength() - aMessage.GetOffset();
 
-    VerifyOrExit(aMessage.Read(0, sizeof(header), &header) == sizeof(header), error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(0, header));
     header.SetNextHeader(kProtoFragment);
 
     fragmentHeader.Init();
@@ -642,10 +640,10 @@ otError Ip6::FragmentDatagram(Message &aMessage, uint8_t aIpProto)
         SuccessOrExit(error = fragment->SetLength(aMessage.GetOffset() + sizeof(fragmentHeader) + payloadFragment));
 
         header.SetPayloadLength(payloadFragment + sizeof(fragmentHeader));
-        fragment->Write(0, sizeof(header), &header);
+        fragment->Write(0, header);
 
         fragment->SetOffset(aMessage.GetOffset());
-        fragment->Write(aMessage.GetOffset(), sizeof(fragmentHeader), &fragmentHeader);
+        fragment->Write(aMessage.GetOffset(), fragmentHeader);
 
         VerifyOrExit(aMessage.CopyTo(aMessage.GetOffset() + FragmentHeader::FragmentOffsetToBytes(offset),
                                      aMessage.GetOffset() + sizeof(fragmentHeader), payloadFragment,
@@ -686,10 +684,8 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
 
     OT_UNUSED_VARIABLE(assertValue);
 
-    VerifyOrExit(aMessage.Read(0, sizeof(header), &header) == sizeof(header), error = OT_ERROR_PARSE);
-
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(fragmentHeader), &fragmentHeader) == sizeof(fragmentHeader),
-                 error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(0, header));
+    SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), fragmentHeader));
 
     if (fragmentHeader.GetOffset() == 0 && !fragmentHeader.IsMoreFlagSet())
     {
@@ -700,8 +696,7 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
 
     for (message = mReassemblyList.GetHead(); message; message = message->GetNext())
     {
-        VerifyOrExit(message->Read(0, sizeof(headerBuffer), &headerBuffer) == sizeof(headerBuffer),
-                     error = OT_ERROR_PARSE);
+        SuccessOrExit(error = message->Read(0, headerBuffer));
 
         if (message->GetDatagramTag() == fragmentHeader.GetIdentification() &&
             headerBuffer.GetSource() == header.GetSource() && headerBuffer.GetDestination() == header.GetDestination())
@@ -760,10 +755,10 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
         message->SetOffset(aMessage.GetOffset() + offset + payloadFragment);
 
         // creates the header for the reassembled ipv6 package
-        VerifyOrExit(aMessage.Read(0, sizeof(header), &header) == sizeof(header), error = OT_ERROR_PARSE);
+        SuccessOrExit(error = aMessage.Read(0, header));
         header.SetPayloadLength(message->GetLength() - sizeof(header));
         header.SetNextHeader(fragmentHeader.GetNextHeader());
-        message->Write(0, sizeof(header), &header);
+        message->Write(0, header);
 
         otLogDebgIp6("Reassembly complete.");
 
@@ -842,7 +837,7 @@ void Ip6::SendIcmpError(Message &aMessage, Icmp::Header::Type aIcmpType, Icmp::H
     Header      header;
     MessageInfo messageInfo;
 
-    VerifyOrExit(aMessage.Read(0, sizeof(header), &header) == sizeof(header), error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(0, header));
 
     messageInfo.SetPeerAddr(header.GetSource());
     messageInfo.SetSockAddr(header.GetDestination());
@@ -878,8 +873,7 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
     otError        error = OT_ERROR_NONE;
     FragmentHeader fragmentHeader;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(fragmentHeader), &fragmentHeader) == sizeof(fragmentHeader),
-                 error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), fragmentHeader));
 
     VerifyOrExit(fragmentHeader.GetOffset() == 0 && !fragmentHeader.IsMoreFlagSet(), error = OT_ERROR_DROP);
 
@@ -904,8 +898,7 @@ otError Ip6::HandleExtensionHeaders(Message &    aMessage,
 
     while (aReceive || aNextHeader == kProtoHopOpts)
     {
-        VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(extHeader), &extHeader) == sizeof(extHeader),
-                     error = OT_ERROR_PARSE);
+        SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), extHeader));
 
         switch (aNextHeader)
         {
@@ -995,7 +988,7 @@ otError Ip6::ProcessReceiveCallback(Message &          aMessage,
             if (mIcmp.ShouldHandleEchoRequest(aMessageInfo))
             {
                 Icmp::Header icmp;
-                aMessage.Read(aMessage.GetOffset(), sizeof(icmp), &icmp);
+                IgnoreError(aMessage.Read(aMessage.GetOffset(), icmp));
 
                 // do not pass ICMP Echo Request messages
                 VerifyOrExit(icmp.GetType() != Icmp::Header::kTypeEchoRequest, error = OT_ERROR_DROP);
@@ -1008,7 +1001,7 @@ otError Ip6::ProcessReceiveCallback(Message &          aMessage,
             Udp::Header udp;
             uint16_t    destPort;
 
-            aMessage.Read(aMessage.GetOffset(), sizeof(udp), &udp);
+            IgnoreError(aMessage.Read(aMessage.GetOffset(), udp));
 
             destPort = udp.GetDestinationPort();
 
@@ -1192,9 +1185,7 @@ start:
             uint16_t dstPort;
 
             // TCP/UDP shares header uint16_t srcPort, uint16_t dstPort
-            VerifyOrExit(aMessage.Read(aMessage.GetOffset() + sizeof(uint16_t), sizeof(dstPort), &dstPort) ==
-                             sizeof(dstPort),
-                         error = OT_ERROR_PARSE);
+            SuccessOrExit(error = aMessage.Read(aMessage.GetOffset() + sizeof(uint16_t), dstPort));
             dstPort = HostSwap16(dstPort);
             if (aMessage.IsLinkSecurityEnabled() && Get<ot::Ip6::Filter>().IsUnsecurePort(dstPort))
             {
@@ -1232,7 +1223,7 @@ start:
         VerifyOrExit(header.GetHopLimit() > 0, error = OT_ERROR_DROP);
 
         hopLimit = header.GetHopLimit();
-        aMessage.Write(Header::kHopLimitFieldOffset, sizeof(hopLimit), &hopLimit);
+        aMessage.Write(Header::kHopLimitFieldOffset, hopLimit);
 
 #if OPENTHREAD_CONFIG_UNSECURE_TRAFFIC_MANAGED_BY_STACK_ENABLE
         // check whether source port is an unsecure port
@@ -1240,8 +1231,7 @@ start:
         {
             uint16_t sourcePort;
 
-            VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(sourcePort), &sourcePort) == sizeof(sourcePort),
-                         error = OT_ERROR_PARSE);
+            SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), sourcePort));
             sourcePort = HostSwap16(sourcePort);
             if (Get<ot::Ip6::Filter>().IsUnsecurePort(sourcePort))
             {

--- a/src/core/net/ip6_filter.cpp
+++ b/src/core/net/ip6_filter.cpp
@@ -68,7 +68,7 @@ bool Filter::Accept(Message &aMessage) const
     }
 
     // Read IPv6 header
-    VerifyOrExit(sizeof(ip6) == aMessage.Read(0, sizeof(ip6), &ip6), OT_NOOP);
+    SuccessOrExit(aMessage.Read(0, ip6));
 
     // Allow only link-local unicast or multicast
     VerifyOrExit(ip6.GetDestination().IsLinkLocal() || ip6.GetDestination().IsLinkLocalMulticast(), OT_NOOP);
@@ -77,7 +77,7 @@ bool Filter::Accept(Message &aMessage) const
     {
     case kProtoUdp:
         // Read the UDP header and get the dst port
-        VerifyOrExit(sizeof(udp) == aMessage.Read(sizeof(ip6), sizeof(udp), &udp), OT_NOOP);
+        SuccessOrExit(aMessage.Read(sizeof(ip6), udp));
 
         dstport = udp.GetDestinationPort();
 
@@ -96,7 +96,7 @@ bool Filter::Accept(Message &aMessage) const
 
     case kProtoTcp:
         // Read the TCP header and get the dst port
-        VerifyOrExit(sizeof(tcp) == aMessage.Read(sizeof(ip6), sizeof(tcp), &tcp), OT_NOOP);
+        SuccessOrExit(aMessage.Read(sizeof(ip6), tcp));
 
         dstport = tcp.GetDestinationPort();
 

--- a/src/core/net/ip6_headers.cpp
+++ b/src/core/net/ip6_headers.cpp
@@ -42,8 +42,7 @@ otError Header::Init(const Message &aMessage)
 {
     otError error = OT_ERROR_NONE;
 
-    // check aMessage length
-    VerifyOrExit(aMessage.Read(0, sizeof(*this), this) == sizeof(*this), error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(0, *this));
 
     VerifyOrExit(IsValid(), error = OT_ERROR_PARSE);
     VerifyOrExit((sizeof(*this) + GetPayloadLength()) == aMessage.GetLength(), error = OT_ERROR_PARSE);

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -82,7 +82,7 @@ otError Mpl::ProcessOption(Message &aMessage, const Address &aAddress, bool aIsO
     otError   error;
     OptionMpl option;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(option), &option) >= OptionMpl::kMinLength &&
+    VerifyOrExit(aMessage.ReadBytes(aMessage.GetOffset(), &option, sizeof(option)) >= OptionMpl::kMinLength &&
                      (option.GetSeedIdLength() == OptionMpl::kSeedIdLength0 ||
                       option.GetSeedIdLength() == OptionMpl::kSeedIdLength2),
                  error = OT_ERROR_PARSE);
@@ -314,9 +314,9 @@ void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSeque
 
     if (!aIsOutbound)
     {
-        aMessage.Read(Header::kHopLimitFieldOffset, sizeof(hopLimit), &hopLimit);
+        IgnoreError(aMessage.Read(Header::kHopLimitFieldOffset, hopLimit));
         VerifyOrExit(hopLimit-- > 1, error = OT_ERROR_DROP);
-        messageCopy->Write(Header::kHopLimitFieldOffset, sizeof(hopLimit), &hopLimit);
+        messageCopy->Write(Header::kHopLimitFieldOffset, hopLimit);
     }
 
     metadata.mSeedId            = aSeedId;
@@ -421,7 +421,7 @@ void Mpl::Metadata::ReadFrom(const Message &aMessage)
     uint16_t length = aMessage.GetLength();
 
     OT_ASSERT(length >= sizeof(*this));
-    aMessage.Read(length - sizeof(*this), sizeof(*this), this);
+    IgnoreError(aMessage.Read(length - sizeof(*this), *this));
 }
 
 void Mpl::Metadata::RemoveFrom(Message &aMessage) const
@@ -434,7 +434,7 @@ void Mpl::Metadata::RemoveFrom(Message &aMessage) const
 
 void Mpl::Metadata::UpdateIn(Message &aMessage) const
 {
-    aMessage.Write(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
+    aMessage.Write(aMessage.GetLength() - sizeof(*this), *this);
 }
 
 void Mpl::Metadata::GenerateNextTransmissionTime(TimeMilli aCurrentTime, uint8_t aInterval)

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -304,7 +304,7 @@ private:
 #if OPENTHREAD_FTD
     struct Metadata
     {
-        otError AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
+        otError AppendTo(Message &aMessage) const { return aMessage.Append(*this); }
         void    ReadFrom(const Message &aMessage);
         void    RemoveFrom(Message &aMessage) const;
         void    UpdateIn(Message &aMessage) const;

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -1,3 +1,4 @@
+
 /*
  *  Copyright (c) 2018, The OpenThread Authors.
  *  All rights reserved.
@@ -177,7 +178,7 @@ Message *Client::NewMessage(const Header &aHeader)
     Message *message = nullptr;
 
     VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != nullptr, OT_NOOP);
-    IgnoreError(message->Prepend(&aHeader, sizeof(aHeader)));
+    IgnoreError(message->Prepend(aHeader));
     message->SetOffset(0);
 
 exit:
@@ -347,8 +348,7 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
     Message *     message  = nullptr;
     uint64_t      unixTime = 0;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(responseHeader), &responseHeader) == sizeof(responseHeader),
-                 OT_NOOP);
+    SuccessOrExit(aMessage.Read(aMessage.GetOffset(), responseHeader));
 
     VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != nullptr, OT_NOOP);
 

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -444,7 +444,7 @@ public:
      * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
      *
      */
-    otError AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
+    otError AppendTo(Message &aMessage) const { return aMessage.Append(*this); }
 
     /**
      * This method reads request data from the message.
@@ -454,9 +454,10 @@ public:
      */
     void ReadFrom(const Message &aMessage)
     {
-        uint16_t length = aMessage.Read(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
-        OT_ASSERT(length == sizeof(*this));
-        OT_UNUSED_VARIABLE(length);
+        otError error = aMessage.Read(aMessage.GetLength() - sizeof(*this), *this);
+
+        OT_ASSERT(error == OT_ERROR_NONE);
+        OT_UNUSED_VARIABLE(error);
     }
 
     /**
@@ -465,10 +466,7 @@ public:
      * @param[in]  aMessage  A reference to the message.
      *
      */
-    void UpdateIn(Message &aMessage) const
-    {
-        aMessage.Write(aMessage.GetLength() - sizeof(*this), sizeof(*this), this);
-    }
+    void UpdateIn(Message &aMessage) const { aMessage.Write(aMessage.GetLength() - sizeof(*this), *this); }
 
 private:
     uint32_t              mTransmitTimestamp;   ///< Time at the client when the request departed for the server.

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -416,7 +416,7 @@ otError Udp::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t 
         udpHeader.SetLength(sizeof(udpHeader) + aMessage.GetLength());
         udpHeader.SetChecksum(0);
 
-        SuccessOrExit(error = aMessage.Prepend(&udpHeader, sizeof(udpHeader)));
+        SuccessOrExit(error = aMessage.Prepend(udpHeader));
         aMessage.SetOffset(0);
 
         error = Get<Ip6>().SendDatagram(aMessage, aMessageInfo, aIpProto);
@@ -431,8 +431,7 @@ otError Udp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
     otError error = OT_ERROR_NONE;
     Header  udpHeader;
 
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(udpHeader), &udpHeader) == sizeof(udpHeader),
-                 error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), udpHeader));
 
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
     SuccessOrExit(error = Checksum::VerifyMessageChecksum(aMessage, aMessageInfo, kProtoUdp));

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -934,7 +934,7 @@ void AddressResolver::HandleIcmpReceive(Message &                aMessage,
 
     VerifyOrExit(aIcmpHeader.GetType() == Ip6::Icmp::Header::kTypeDstUnreach, OT_NOOP);
     VerifyOrExit(aIcmpHeader.GetCode() == Ip6::Icmp::Header::kCodeDstUnreachNoRoute, OT_NOOP);
-    VerifyOrExit(aMessage.Read(aMessage.GetOffset(), sizeof(ip6Header), &ip6Header) == sizeof(ip6Header), OT_NOOP);
+    SuccessOrExit(aMessage.Read(aMessage.GetOffset(), ip6Header));
 
     Remove(ip6Header.GetDestination(), kReasonReceivedIcmpDstUnreachNoRoute);
 

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -127,7 +127,7 @@ otError DiscoverScanner::Discover(const Mac::ChannelMask &aScanChannels,
     tlv.SetLength(
         static_cast<uint8_t>(discoveryRequest.GetSize() + ((mAdvDataLength != 0) ? joinerAdvertisement.GetSize() : 0)));
 
-    SuccessOrExit(error = message->Append(&tlv, sizeof(tlv)));
+    SuccessOrExit(error = message->Append(tlv));
     SuccessOrExit(error = discoveryRequest.AppendTo(*message));
 
     if (mAdvDataLength != 0)
@@ -303,7 +303,7 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
 
     // Find MLE Discovery TLV
     VerifyOrExit(Tlv::FindTlvOffset(aMessage, Tlv::kDiscovery, offset) == OT_ERROR_NONE, error = OT_ERROR_PARSE);
-    aMessage.Read(offset, sizeof(tlv), &tlv);
+    IgnoreError(aMessage.Read(offset, tlv));
 
     offset += sizeof(tlv);
     end = offset + tlv.GetLength();
@@ -319,12 +319,12 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
     // Process MeshCoP TLVs
     while (offset < end)
     {
-        aMessage.Read(offset, sizeof(meshcopTlv), &meshcopTlv);
+        IgnoreError(aMessage.Read(offset, meshcopTlv));
 
         switch (meshcopTlv.GetType())
         {
         case MeshCoP::Tlv::kDiscoveryResponse:
-            aMessage.Read(offset, sizeof(discoveryResponse), &discoveryResponse);
+            IgnoreError(aMessage.Read(offset, discoveryResponse));
             VerifyOrExit(discoveryResponse.IsValid(), error = OT_ERROR_PARSE);
             result.mVersion  = discoveryResponse.GetVersion();
             result.mIsNative = discoveryResponse.IsNativeCommissioner();
@@ -335,7 +335,7 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
             break;
 
         case MeshCoP::Tlv::kNetworkName:
-            aMessage.Read(offset, sizeof(networkName), &networkName);
+            IgnoreError(aMessage.Read(offset, networkName));
             IgnoreError(static_cast<Mac::NetworkName &>(result.mNetworkName).Set(networkName.GetNetworkName()));
             break;
 

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -186,8 +186,8 @@ void EnergyScanServer::SendReport(void)
 
     energyList.Init();
     energyList.SetLength(mScanResultsLength);
-    SuccessOrExit(error = message->Append(&energyList, sizeof(energyList)));
-    SuccessOrExit(error = message->Append(mScanResults, mScanResultsLength));
+    SuccessOrExit(error = message->Append(energyList));
+    SuccessOrExit(error = message->AppendBytes(mScanResults, mScanResultsLength));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerAddr(mCommissioner);

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -381,7 +381,7 @@ uint16_t IndirectSender::PrepareDataFrame(Mac::TxFrame &aFrame, Child &aChild, M
 
     // Determine the MAC source and destination addresses.
 
-    aMessage.Read(0, sizeof(ip6Header), &ip6Header);
+    IgnoreError(aMessage.Read(0, ip6Header));
 
     Get<MeshForwarder>().GetMacSourceAddress(ip6Header.GetSource(), macSource);
 

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -200,7 +200,7 @@ public:
 
         VerifyOrExit(CanWrite(aLength), error = OT_ERROR_NO_BUFS);
 
-        rval = aMessage.Read(aMessage.GetOffset(), aLength, mWritePointer);
+        rval = aMessage.ReadBytes(aMessage.GetOffset(), mWritePointer, aLength);
         OT_ASSERT(rval == aLength);
 
         mWritePointer += aLength;

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -60,7 +60,7 @@ otError MeshForwarder::SendMessage(Message &aMessage)
     {
         Ip6::Header ip6Header;
 
-        aMessage.Read(0, sizeof(ip6Header), &ip6Header);
+        IgnoreError(aMessage.Read(0, ip6Header));
 
         if (ip6Header.GetDestination().IsMulticast())
         {
@@ -150,7 +150,7 @@ void MeshForwarder::HandleResolved(const Ip6::Address &aEid, otError aError)
             continue;
         }
 
-        cur->Read(Ip6::Header::kDestinationFieldOffset, sizeof(ip6Dst), &ip6Dst);
+        IgnoreError(cur->Read(Ip6::Header::kDestinationFieldOffset, ip6Dst));
 
         if (ip6Dst == aEid)
         {
@@ -265,7 +265,7 @@ void MeshForwarder::RemoveMessages(Child &aChild, Message::SubType aSubType)
             {
                 Ip6::Header ip6header;
 
-                IgnoreReturnValue(message->Read(0, sizeof(ip6header), &ip6header));
+                IgnoreError(message->Read(0, ip6header));
 
                 if (&aChild == static_cast<Child *>(Get<NeighborTable>().FindNeighbor(ip6header.GetDestination())))
                 {
@@ -318,7 +318,7 @@ void MeshForwarder::RemoveDataResponseMessages(void)
             continue;
         }
 
-        message->Read(0, sizeof(ip6Header), &ip6Header);
+        IgnoreError(message->Read(0, ip6Header));
 
         if (!(ip6Header.GetDestination().IsMulticast()))
         {
@@ -370,7 +370,7 @@ void MeshForwarder::SendMesh(Message &aMessage, Mac::TxFrame &aFrame)
 
     // write payload
     OT_ASSERT(aMessage.GetLength() <= aFrame.GetMaxPayloadLength());
-    aMessage.Read(0, aMessage.GetLength(), aFrame.GetPayload());
+    aMessage.ReadBytes(0, aFrame.GetPayload(), aMessage.GetLength());
     aFrame.SetPayloadLength(aMessage.GetLength());
 
     mMessageNextOffset = aMessage.GetLength();
@@ -538,7 +538,7 @@ void MeshForwarder::SendIcmpErrorIfDstUnreach(const Message &     aMessage,
     child = Get<ChildTable>().FindChild(aMacSource.GetShort(), Child::kInStateAnyExceptInvalid);
     VerifyOrExit((child == nullptr) || child->IsFullThreadDevice(), OT_NOOP);
 
-    aMessage.Read(0, sizeof(ip6header), &ip6header);
+    IgnoreError(aMessage.Read(0, ip6header));
     VerifyOrExit(!ip6header.GetDestination().IsMulticast() &&
                      Get<NetworkData::Leader>().IsOnMesh(ip6header.GetDestination()),
                  OT_NOOP);
@@ -581,7 +581,7 @@ otError MeshForwarder::CheckReachability(const uint8_t *     aFrame,
     error = FrameToMessage(aFrame, aFrameLength, datagramSize, aMeshSource, aMeshDest, message);
     SuccessOrExit(error);
 
-    message->Read(0, sizeof(ip6Header), &ip6Header);
+    IgnoreError(message->Read(0, ip6Header));
     error = Get<Mle::MleRouter>().CheckReachability(aMeshDest.GetShort(), ip6Header);
 
 exit:
@@ -669,7 +669,7 @@ void MeshForwarder::HandleMesh(uint8_t *             aFrame,
 
         SuccessOrExit(error = message->SetLength(meshHeader.GetHeaderLength() + aFrameLength));
         offset += meshHeader.WriteTo(*message, offset);
-        message->Write(offset, aFrameLength, aFrame);
+        message->WriteBytes(offset, aFrame, aFrameLength);
         message->SetLinkInfo(aLinkInfo);
 
         LogMessage(kMessageReceive, *message, &aMacSource, OT_ERROR_NONE);
@@ -1057,7 +1057,7 @@ otError MeshForwarder::DecompressIp6UdpTcpHeader(const Message &     aMessage,
 
     // Read and decompress the IPv6 header
 
-    frameLength = aMessage.Read(aOffset, sizeof(frameBuffer), frameBuffer);
+    frameLength = aMessage.ReadBytes(aOffset, frameBuffer, sizeof(frameBuffer));
 
     headerLength = Get<Lowpan::Lowpan>().DecompressBaseHeader(aIp6Header, nextHeaderCompressed, aMeshSource, aMeshDest,
                                                               frameBuffer, frameLength);
@@ -1072,14 +1072,13 @@ otError MeshForwarder::DecompressIp6UdpTcpHeader(const Message &     aMessage,
     case Ip6::kProtoUdp:
         if (nextHeaderCompressed)
         {
-            frameLength  = aMessage.Read(aOffset, sizeof(Ip6::Udp::Header), frameBuffer);
+            frameLength  = aMessage.ReadBytes(aOffset, frameBuffer, sizeof(Ip6::Udp::Header));
             headerLength = Get<Lowpan::Lowpan>().DecompressUdpHeader(header.udp, frameBuffer, frameLength);
             VerifyOrExit(headerLength >= 0, OT_NOOP);
         }
         else
         {
-            VerifyOrExit(sizeof(Ip6::Udp::Header) == aMessage.Read(aOffset, sizeof(Ip6::Udp::Header), &header.udp),
-                         OT_NOOP);
+            SuccessOrExit(aMessage.Read(aOffset, header.udp));
         }
 
         aChecksum   = header.udp.GetChecksum();
@@ -1088,8 +1087,7 @@ otError MeshForwarder::DecompressIp6UdpTcpHeader(const Message &     aMessage,
         break;
 
     case Ip6::kProtoTcp:
-        VerifyOrExit(sizeof(Ip6::Tcp::Header) == aMessage.Read(aOffset, sizeof(Ip6::Tcp::Header), &header.tcp),
-                     OT_NOOP);
+        SuccessOrExit(aMessage.Read(aOffset, header.tcp));
         aChecksum   = header.tcp.GetChecksum();
         aSourcePort = header.tcp.GetSourcePort();
         aDestPort   = header.tcp.GetDestinationPort();

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1542,7 +1542,7 @@ private:
 
     struct DelayedResponseMetadata
     {
-        otError AppendTo(Message &aMessage) const { return aMessage.Append(this, sizeof(*this)); }
+        otError AppendTo(Message &aMessage) const { return aMessage.Append(*this); }
         void    ReadFrom(const Message &aMessage);
         void    RemoveFrom(Message &aMessage) const;
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2044,11 +2044,11 @@ otError MleRouter::UpdateChildAddresses(const Message &aMessage, uint16_t aOffse
         uint8_t len;
 
         // read out the control field
-        VerifyOrExit(aMessage.ReadBytes(offset, &entry, sizeof(uint8_t)) == sizeof(uint8_t), error = OT_ERROR_PARSE);
+        SuccessOrExit(error = aMessage.Read(offset, &entry, sizeof(uint8_t)));
 
         len = entry.GetLength();
 
-        VerifyOrExit(aMessage.ReadBytes(offset, &entry, len) == len, error = OT_ERROR_PARSE);
+        SuccessOrExit(error = aMessage.Read(offset, &entry, len));
 
         offset += len;
         registeredCount++;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2007,7 +2007,7 @@ otError MleRouter::UpdateChildAddresses(const Message &aMessage, uint16_t aOffse
     uint16_t     oldMlrRegisteredAddressNum = 0;
 #endif
 
-    VerifyOrExit(aMessage.Read(aOffset, sizeof(tlv), &tlv) == sizeof(tlv), error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aOffset, tlv));
     VerifyOrExit(tlv.GetLength() <= (aMessage.GetLength() - aOffset - sizeof(tlv)), error = OT_ERROR_PARSE);
 
     offset = aOffset + sizeof(tlv);
@@ -2044,11 +2044,11 @@ otError MleRouter::UpdateChildAddresses(const Message &aMessage, uint16_t aOffse
         uint8_t len;
 
         // read out the control field
-        VerifyOrExit(aMessage.Read(offset, 1, &entry) == 1, error = OT_ERROR_PARSE);
+        VerifyOrExit(aMessage.ReadBytes(offset, &entry, sizeof(uint8_t)) == sizeof(uint8_t), error = OT_ERROR_PARSE);
 
         len = entry.GetLength();
 
-        VerifyOrExit(aMessage.Read(offset, len, &entry) == len, error = OT_ERROR_PARSE);
+        VerifyOrExit(aMessage.ReadBytes(offset, &entry, len) == len, error = OT_ERROR_PARSE);
 
         offset += len;
         registeredCount++;
@@ -2829,19 +2829,19 @@ void MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Messa
 
     // find MLE Discovery TLV
     VerifyOrExit(Tlv::FindTlvOffset(aMessage, Tlv::kDiscovery, offset) == OT_ERROR_NONE, error = OT_ERROR_PARSE);
-    aMessage.Read(offset, sizeof(tlv), &tlv);
+    IgnoreError(aMessage.Read(offset, tlv));
 
     offset += sizeof(tlv);
     end = offset + sizeof(tlv) + tlv.GetLength();
 
     while (offset < end)
     {
-        aMessage.Read(offset, sizeof(meshcopTlv), &meshcopTlv);
+        IgnoreError(aMessage.Read(offset, meshcopTlv));
 
         switch (meshcopTlv.GetType())
         {
         case MeshCoP::Tlv::kDiscoveryRequest:
-            aMessage.Read(offset, sizeof(discoveryRequest), &discoveryRequest);
+            IgnoreError(aMessage.Read(offset, discoveryRequest));
             VerifyOrExit(discoveryRequest.IsValid(), error = OT_ERROR_PARSE);
 
             break;
@@ -2909,7 +2909,7 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
 
     // Discovery TLV
     tlv.SetType(Tlv::kDiscovery);
-    SuccessOrExit(error = message->Append(&tlv, sizeof(tlv)));
+    SuccessOrExit(error = message->Append(tlv));
 
     startOffset = message->GetLength();
 
@@ -2966,7 +2966,7 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
                                                Get<MeshCoP::JoinerRouter>().GetJoinerUdpPort()));
 
     tlv.SetLength(static_cast<uint8_t>(message->GetLength() - startOffset));
-    message->Write(startOffset - sizeof(tlv), sizeof(tlv), &tlv);
+    message->Write(startOffset - sizeof(tlv), tlv);
 
     delay = Random::NonCrypto::GetUint16InRange(0, kDiscoveryMaxJitter + 1);
 
@@ -4020,7 +4020,7 @@ otError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
     uint16_t                 startOffset = aMessage.GetLength();
 
     tlv.SetType(Tlv::kAddressRegistration);
-    SuccessOrExit(error = aMessage.Append(&tlv, sizeof(tlv)));
+    SuccessOrExit(error = aMessage.Append(tlv));
 
     for (const Ip6::Address &address : aChild.IterateIp6Addresses())
     {
@@ -4041,12 +4041,12 @@ otError MleRouter::AppendChildAddresses(Message &aMessage, Child &aChild)
             continue;
         }
 
-        SuccessOrExit(error = aMessage.Append(&entry, entry.GetLength()));
+        SuccessOrExit(error = aMessage.AppendBytes(&entry, entry.GetLength()));
         length += entry.GetLength();
     }
 
     tlv.SetLength(length);
-    aMessage.Write(startOffset, sizeof(tlv), &tlv);
+    aMessage.Write(startOffset, tlv);
 
 exit:
     return error;

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -401,8 +401,8 @@ otError MlrManager::SendMulticastListenerRegistrationMessage(const otIp6Address 
 
     addressesTlv.Init();
     addressesTlv.SetLength(sizeof(Ip6::Address) * aAddressNum);
-    SuccessOrExit(error = message->Append(&addressesTlv, sizeof(addressesTlv)));
-    SuccessOrExit(error = message->Append(aAddresses, sizeof(Ip6::Address) * aAddressNum));
+    SuccessOrExit(error = message->Append(addressesTlv));
+    SuccessOrExit(error = message->AppendBytes(aAddresses, sizeof(Ip6::Address) * aAddressNum));
 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
     if (Get<MeshCoP::Commissioner>().IsActive())
@@ -515,8 +515,7 @@ otError MlrManager::ParseMulticastListenerRegistrationResponse(otError        aR
 
         for (uint16_t offset = 0; offset < addressesLength; offset += sizeof(Ip6::Address))
         {
-            IgnoreReturnValue(
-                aMessage->Read(addressesOffset + offset, sizeof(Ip6::Address), &aFailedAddresses[aFailedAddressNum]));
+            IgnoreError(aMessage->Read(addressesOffset + offset, aFailedAddresses[aFailedAddressNum]));
             aFailedAddressNum++;
         }
     }

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -816,8 +816,8 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16, Coap::Response
         ThreadTlv tlv;
         tlv.SetType(ThreadTlv::kThreadNetworkData);
         tlv.SetLength(mLength);
-        SuccessOrExit(error = message->Append(&tlv, sizeof(tlv)));
-        SuccessOrExit(error = message->Append(mTlvs, mLength));
+        SuccessOrExit(error = message->Append(tlv));
+        SuccessOrExit(error = message->AppendBytes(mTlvs, mLength));
     }
 
     if (aRloc16 != Mac::kShortAddrInvalid)

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -432,10 +432,9 @@ otError LeaderBase::SetNetworkData(uint8_t        aVersion,
     Mle::Tlv tlv;
     uint16_t length;
 
-    length = aMessage.Read(aMessageOffset, sizeof(tlv), &tlv);
-    VerifyOrExit(length == sizeof(tlv), error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aMessageOffset, tlv));
 
-    length = aMessage.Read(aMessageOffset + sizeof(tlv), tlv.GetLength(), mTlvs);
+    length = aMessage.ReadBytes(aMessageOffset + sizeof(tlv), mTlvs, tlv.GetLength());
     VerifyOrExit(length == tlv.GetLength(), error = OT_ERROR_PARSE);
 
     mLength        = tlv.GetLength();

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -195,7 +195,7 @@ void Leader::HandleCommissioningSet(Coap::Message &aMessage, const Ip6::MessageI
     VerifyOrExit(length <= sizeof(tlvs), OT_NOOP);
     VerifyOrExit(Get<Mle::MleRouter>().IsLeader(), OT_NOOP);
 
-    aMessage.Read(offset, length, tlvs);
+    aMessage.ReadBytes(offset, tlvs, length);
 
     // Session Id and Border Router Locator MUST NOT be set, but accept including unexpected or
     // unknown TLV as long as there is at least one valid TLV.
@@ -322,7 +322,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Message &   aRequest,
 
     if (aLength == 0)
     {
-        SuccessOrExit(error = message->Append(data, length));
+        SuccessOrExit(error = message->AppendBytes(data, length));
     }
     else
     {
@@ -330,7 +330,7 @@ void Leader::SendCommissioningGetResponse(const Coap::Message &   aRequest,
         {
             uint8_t type;
 
-            aRequest.Read(aRequest.GetOffset() + index, sizeof(type), &type);
+            IgnoreError(aRequest.Read(aRequest.GetOffset() + index, type));
 
             for (MeshCoP::Tlv *cur                                          = reinterpret_cast<MeshCoP::Tlv *>(data);
                  cur < reinterpret_cast<MeshCoP::Tlv *>(data + length); cur = cur->GetNext())

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -780,7 +780,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
 
             tlvTotalLength = sizeof(tlv) + tlv.GetLength();
             VerifyOrExit(tlvTotalLength <= sizeof(route), error = OT_ERROR_PARSE);
-            VerifyOrExit(aMessage.ReadBytes(offset, &route, tlvTotalLength) == tlvTotalLength, error = OT_ERROR_PARSE);
+            SuccessOrExit(error = aMessage.Read(offset, &route, tlvTotalLength));
             VerifyOrExit(route.IsValid(), error = OT_ERROR_PARSE);
 
             ParseRoute(route, aNetworkDiagTlv.mData.mRoute);
@@ -804,8 +804,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
 
             tlvTotalLength = sizeof(tlv) + tlv.GetLength();
             VerifyOrExit(tlvTotalLength <= sizeof(networkData), error = OT_ERROR_PARSE);
-            VerifyOrExit(aMessage.ReadBytes(offset, &networkData, tlvTotalLength) == tlvTotalLength,
-                         error = OT_ERROR_PARSE);
+            SuccessOrExit(error = aMessage.Read(offset, &networkData, tlvTotalLength));
             VerifyOrExit(networkData.IsValid(), error = OT_ERROR_PARSE);
             VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mNetworkData.m8) >= networkData.GetLength(),
                          error = OT_ERROR_PARSE);
@@ -822,10 +821,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             VerifyOrExit(ip6AddrList.IsValid(), error = OT_ERROR_PARSE);
             VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mIp6AddrList.mList) >= ip6AddrList.GetLength(),
                          error = OT_ERROR_PARSE);
-            VerifyOrExit(aMessage.ReadBytes(offset + sizeof(ip6AddrList), aNetworkDiagTlv.mData.mIp6AddrList.mList,
-                                            ip6AddrList.GetLength()) == ip6AddrList.GetLength(),
-                         error = OT_ERROR_PARSE);
-
+            SuccessOrExit(error = aMessage.Read(offset + sizeof(ip6AddrList), aNetworkDiagTlv.mData.mIp6AddrList.mList,
+                                                ip6AddrList.GetLength()));
             aNetworkDiagTlv.mData.mIp6AddrList.mCount = ip6AddrList.GetLength() / OT_IP6_ADDRESS_SIZE;
             break;
         }
@@ -871,10 +868,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
         case NetworkDiagnosticTlv::kChannelPages:
         {
             VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mChannelPages.m8) >= tlv.GetLength(), error = OT_ERROR_PARSE);
-            VerifyOrExit(aMessage.ReadBytes(offset + sizeof(tlv), aNetworkDiagTlv.mData.mChannelPages.m8,
-                                            tlv.GetLength()) == tlv.GetLength(),
-                         error = OT_ERROR_PARSE);
-
+            SuccessOrExit(
+                error = aMessage.Read(offset + sizeof(tlv), aNetworkDiagTlv.mData.mChannelPages.m8, tlv.GetLength()));
             aNetworkDiagTlv.mData.mChannelPages.mCount = tlv.GetLength();
             break;
         }

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -196,11 +196,11 @@ otError NetworkDiagnostic::AppendIp6AddressList(Message &aMessage)
     }
 
     tlv.SetLength(count * sizeof(Ip6::Address));
-    SuccessOrExit(error = aMessage.Append(&tlv, sizeof(tlv)));
+    SuccessOrExit(error = aMessage.Append(tlv));
 
     for (const Ip6::NetifUnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr; addr = addr->GetNext())
     {
-        SuccessOrExit(error = aMessage.Append(&addr->GetAddress(), sizeof(Ip6::Address)));
+        SuccessOrExit(error = aMessage.Append(addr->GetAddress()));
     }
 
 exit:
@@ -232,7 +232,7 @@ otError NetworkDiagnostic::AppendChildTable(Message &aMessage)
 
     tlv.SetLength(static_cast<uint8_t>(count * sizeof(ChildTableEntry)));
 
-    SuccessOrExit(error = aMessage.Append(&tlv, sizeof(ChildTableTlv)));
+    SuccessOrExit(error = aMessage.Append(tlv));
 
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
@@ -251,7 +251,7 @@ otError NetworkDiagnostic::AppendChildTable(Message &aMessage)
         entry.SetChildId(Mle::Mle::ChildIdFromRloc16(child.GetRloc16()));
         entry.SetMode(child.GetDeviceMode());
 
-        SuccessOrExit(error = aMessage.Append(&entry, sizeof(ChildTableEntry)));
+        SuccessOrExit(error = aMessage.Append(entry));
     }
 
 exit:
@@ -290,7 +290,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(const Message &       aRequest,
 
     for (uint32_t i = 0; i < aNetworkDiagnosticTlv.GetLength(); i++)
     {
-        VerifyOrExit(aRequest.Read(offset, sizeof(type), &type) == sizeof(type), error = OT_ERROR_PARSE);
+        SuccessOrExit(error = aRequest.Read(offset, type));
 
         otLogInfoNetDiag("Type %d", type);
 
@@ -471,9 +471,7 @@ void NetworkDiagnostic::HandleDiagnosticGetQuery(Coap::Message &aMessage, const 
 
     otLogInfoNetDiag("Received diagnostic get query");
 
-    VerifyOrExit((aMessage.Read(aMessage.GetOffset(), sizeof(NetworkDiagnosticTlv), &networkDiagnosticTlv) ==
-                  sizeof(NetworkDiagnosticTlv)),
-                 error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), networkDiagnosticTlv));
 
     VerifyOrExit(networkDiagnosticTlv.GetType() == NetworkDiagnosticTlv::kTypeList, error = OT_ERROR_PARSE);
 
@@ -542,9 +540,7 @@ void NetworkDiagnostic::HandleDiagnosticGetRequest(Coap::Message &aMessage, cons
 
     otLogInfoNetDiag("Received diagnostic get request");
 
-    VerifyOrExit((aMessage.Read(aMessage.GetOffset(), sizeof(NetworkDiagnosticTlv), &networkDiagnosticTlv) ==
-                  sizeof(NetworkDiagnosticTlv)),
-                 error = OT_ERROR_PARSE);
+    SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), networkDiagnosticTlv));
 
     VerifyOrExit(networkDiagnosticTlv.GetType() == NetworkDiagnosticTlv::kTypeList, error = OT_ERROR_PARSE);
 
@@ -628,7 +624,7 @@ void NetworkDiagnostic::HandleDiagnosticReset(Coap::Message &aMessage, const Ip6
 
     VerifyOrExit(aMessage.IsConfirmablePostRequest(), OT_NOOP);
 
-    VerifyOrExit((aMessage.Read(aMessage.GetOffset(), sizeof(tlv), &tlv) == sizeof(tlv)), OT_NOOP);
+    SuccessOrExit(aMessage.Read(aMessage.GetOffset(), tlv));
 
     VerifyOrExit(tlv.GetType() == NetworkDiagnosticTlv::kTypeList, OT_NOOP);
 
@@ -636,7 +632,7 @@ void NetworkDiagnostic::HandleDiagnosticReset(Coap::Message &aMessage, const Ip6
 
     for (uint8_t i = 0; i < tlv.GetLength(); i++)
     {
-        VerifyOrExit(aMessage.Read(offset + i, sizeof(type), &type) == sizeof(type), OT_NOOP);
+        SuccessOrExit(aMessage.Read(offset + i, type));
 
         switch (type)
         {
@@ -741,7 +737,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
     {
         uint16_t tlvTotalLength;
 
-        VerifyOrExit(aMessage.Read(offset, sizeof(tlv), &tlv) == sizeof(tlv), error = OT_ERROR_NOT_FOUND);
+        VerifyOrExit(aMessage.Read(offset, tlv) == OT_ERROR_NONE, error = OT_ERROR_NOT_FOUND);
 
         switch (tlv.GetType())
         {
@@ -771,9 +767,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
         {
             ConnectivityTlv connectivity;
 
-            tlvTotalLength = sizeof(connectivity);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &connectivity) == tlvTotalLength,
-                         error = OT_ERROR_PARSE);
+            SuccessOrExit(error = aMessage.Read(offset, connectivity));
             VerifyOrExit(connectivity.IsValid(), error = OT_ERROR_PARSE);
 
             ParseConnectivity(connectivity, aNetworkDiagTlv.mData.mConnectivity);
@@ -786,7 +780,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
 
             tlvTotalLength = sizeof(tlv) + tlv.GetLength();
             VerifyOrExit(tlvTotalLength <= sizeof(route), error = OT_ERROR_PARSE);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &route) == tlvTotalLength, error = OT_ERROR_PARSE);
+            VerifyOrExit(aMessage.ReadBytes(offset, &route, tlvTotalLength) == tlvTotalLength, error = OT_ERROR_PARSE);
             VerifyOrExit(route.IsValid(), error = OT_ERROR_PARSE);
 
             ParseRoute(route, aNetworkDiagTlv.mData.mRoute);
@@ -797,8 +791,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
         {
             LeaderDataTlv leaderData;
 
-            tlvTotalLength = sizeof(leaderData);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &leaderData) == tlvTotalLength, error = OT_ERROR_PARSE);
+            SuccessOrExit(error = aMessage.Read(offset, leaderData));
             VerifyOrExit(leaderData.IsValid(), error = OT_ERROR_PARSE);
 
             ParseLeaderData(leaderData, aNetworkDiagTlv.mData.mLeaderData);
@@ -811,7 +804,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
 
             tlvTotalLength = sizeof(tlv) + tlv.GetLength();
             VerifyOrExit(tlvTotalLength <= sizeof(networkData), error = OT_ERROR_PARSE);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &networkData) == tlvTotalLength, error = OT_ERROR_PARSE);
+            VerifyOrExit(aMessage.ReadBytes(offset, &networkData, tlvTotalLength) == tlvTotalLength,
+                         error = OT_ERROR_PARSE);
             VerifyOrExit(networkData.IsValid(), error = OT_ERROR_PARSE);
             VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mNetworkData.m8) >= networkData.GetLength(),
                          error = OT_ERROR_PARSE);
@@ -828,8 +822,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             VerifyOrExit(ip6AddrList.IsValid(), error = OT_ERROR_PARSE);
             VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mIp6AddrList.mList) >= ip6AddrList.GetLength(),
                          error = OT_ERROR_PARSE);
-            VerifyOrExit(aMessage.Read(offset + sizeof(ip6AddrList), ip6AddrList.GetLength(),
-                                       aNetworkDiagTlv.mData.mIp6AddrList.mList) == ip6AddrList.GetLength(),
+            VerifyOrExit(aMessage.ReadBytes(offset + sizeof(ip6AddrList), aNetworkDiagTlv.mData.mIp6AddrList.mList,
+                                            ip6AddrList.GetLength()) == ip6AddrList.GetLength(),
                          error = OT_ERROR_PARSE);
 
             aNetworkDiagTlv.mData.mIp6AddrList.mCount = ip6AddrList.GetLength() / OT_IP6_ADDRESS_SIZE;
@@ -840,8 +834,7 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
         {
             MacCountersTlv macCounters;
 
-            tlvTotalLength = sizeof(MacCountersTlv);
-            VerifyOrExit(aMessage.Read(offset, tlvTotalLength, &macCounters) == tlvTotalLength, error = OT_ERROR_PARSE);
+            SuccessOrExit(error = aMessage.Read(offset, macCounters));
             VerifyOrExit(macCounters.IsValid(), error = OT_ERROR_PARSE);
 
             ParseMacCounters(macCounters, aNetworkDiagTlv.mData.mMacCounters);
@@ -878,8 +871,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
         case NetworkDiagnosticTlv::kChannelPages:
         {
             VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mChannelPages.m8) >= tlv.GetLength(), error = OT_ERROR_PARSE);
-            VerifyOrExit(aMessage.Read(offset + sizeof(tlv), tlv.GetLength(), aNetworkDiagTlv.mData.mChannelPages.m8) ==
-                             tlv.GetLength(),
+            VerifyOrExit(aMessage.ReadBytes(offset + sizeof(tlv), aNetworkDiagTlv.mData.mChannelPages.m8,
+                                            tlv.GetLength()) == tlv.GetLength(),
                          error = OT_ERROR_PARSE);
 
             aNetworkDiagTlv.mData.mChannelPages.mCount = tlv.GetLength();

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -1075,9 +1075,9 @@ public:
      */
     otError ReadEntry(ChildTableEntry &aEntry, const Message &aMessage, uint16_t aOffset, uint8_t aIndex) const
     {
-        return (aIndex < GetNumEntries() &&
-                aMessage.Read(aOffset + sizeof(ChildTableTlv) + (aIndex * sizeof(ChildTableEntry)),
-                              sizeof(ChildTableEntry), &aEntry) == sizeof(ChildTableEntry))
+        return ((aIndex < GetNumEntries()) &&
+                (aMessage.Read(aOffset + sizeof(ChildTableTlv) + (aIndex * sizeof(ChildTableEntry)), aEntry) ==
+                 OT_ERROR_NONE))
                    ? OT_ERROR_NONE
                    : OT_ERROR_INVALID_ARGS;
     }

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -66,7 +66,7 @@ Child *ChildSupervisor::GetDestination(const Message &aMessage) const
 
     VerifyOrExit(aMessage.GetType() == Message::kTypeSupervision, OT_NOOP);
 
-    aMessage.Read(0, sizeof(childIndex), &childIndex);
+    IgnoreError(aMessage.Read(0, childIndex));
     child = Get<ChildTable>().GetChildAtIndex(childIndex);
 
 exit:
@@ -89,7 +89,7 @@ void ChildSupervisor::SendMessage(Child &aChild)
     // `ChildSupervisor::GetDestination(message)`.
 
     childIndex = Get<ChildTable>().GetChildIndex(aChild);
-    SuccessOrExit(message->Append(&childIndex, sizeof(childIndex)));
+    SuccessOrExit(message->Append(childIndex));
 
     SuccessOrExit(Get<ThreadNetif>().SendMessage(*message));
     message = nullptr;

--- a/tests/unit/test_checksum.cpp
+++ b/tests/unit/test_checksum.cpp
@@ -107,8 +107,8 @@ uint16_t CalculateChecksum(const Ip6::Address &aSource,
     data.mPseudoHeader.mProtocol      = Encoding::BigEndian::HostSwap32(aIpProto);
     data.mPseudoHeader.mPayloadLength = Encoding::BigEndian::HostSwap32(payloadLength);
 
-    VerifyOrQuit(aMessage.Read(aMessage.GetOffset(), payloadLength, data.mPayload) == payloadLength,
-                 "Message::Read() failed");
+    VerifyOrQuit(aMessage.ReadBytes(aMessage.GetOffset(), data.mPayload, payloadLength) == payloadLength,
+                 "Message::ReadBytes() failed");
 
     return CalculateChecksum(&data, sizeof(PseudoHeader) + payloadLength);
 }
@@ -123,13 +123,13 @@ void CorruptMessage(Message &aMessage)
 
     byteOffset = Random::NonCrypto::GetUint16InRange(0, aMessage.GetLength());
 
-    VerifyOrQuit(aMessage.Read(byteOffset, sizeof(uint8_t), &byte) == sizeof(uint8_t), "Read failed");
+    SuccessOrQuit(aMessage.Read(byteOffset, byte), "Read failed");
 
     bitOffset = Random::NonCrypto::GetUint8InRange(0, CHAR_BIT);
 
     byte ^= (1 << bitOffset);
 
-    aMessage.Write(byteOffset, sizeof(uint8_t), &byte);
+    aMessage.Write(byteOffset, byte);
 }
 
 void TestUdpMessageChecksum(void)
@@ -160,7 +160,7 @@ void TestUdpMessageChecksum(void)
 
         Random::NonCrypto::FillBuffer(reinterpret_cast<uint8_t *>(&udpHeader), sizeof(udpHeader));
         udpHeader.SetChecksum(0);
-        message->Write(0, sizeof(udpHeader), &udpHeader);
+        message->Write(0, udpHeader);
 
         if (size > sizeof(udpHeader))
         {
@@ -168,7 +168,7 @@ void TestUdpMessageChecksum(void)
             uint16_t payloadSize = size - sizeof(udpHeader);
 
             Random::NonCrypto::FillBuffer(buffer, payloadSize);
-            message->Write(sizeof(udpHeader), payloadSize, &buffer[0]);
+            message->WriteBytes(sizeof(udpHeader), &buffer[0], payloadSize);
         }
 
         SuccessOrQuit(messageInfo.GetSockAddr().FromString(kSourceAddress), "FromString() failed");
@@ -179,8 +179,7 @@ void TestUdpMessageChecksum(void)
 
         Checksum::UpdateMessageChecksum(*message, messageInfo.GetSockAddr(), messageInfo.GetPeerAddr(), Ip6::kProtoUdp);
 
-        VerifyOrQuit(message->Read(message->GetOffset(), sizeof(udpHeader), &udpHeader) == sizeof(udpHeader),
-                     "Message::Read() failed");
+        SuccessOrQuit(message->Read(message->GetOffset(), udpHeader), "Message::Read() failed");
         VerifyOrQuit(udpHeader.GetChecksum() != 0, "Failed to update checksum");
 
         // Verify that the calculated UDP checksum is valid.
@@ -234,7 +233,7 @@ void TestIcmp6MessageChecksum(void)
 
         Random::NonCrypto::FillBuffer(reinterpret_cast<uint8_t *>(&icmp6Header), sizeof(icmp6Header));
         icmp6Header.SetChecksum(0);
-        message->Write(0, sizeof(icmp6Header), &icmp6Header);
+        message->Write(0, icmp6Header);
 
         if (size > sizeof(icmp6Header))
         {
@@ -242,7 +241,7 @@ void TestIcmp6MessageChecksum(void)
             uint16_t payloadSize = size - sizeof(icmp6Header);
 
             Random::NonCrypto::FillBuffer(buffer, payloadSize);
-            message->Write(sizeof(icmp6Header), payloadSize, &buffer[0]);
+            message->WriteBytes(sizeof(icmp6Header), &buffer[0], payloadSize);
         }
 
         SuccessOrQuit(messageInfo.GetSockAddr().FromString(kSourceAddress), "FromString() failed");
@@ -254,8 +253,7 @@ void TestIcmp6MessageChecksum(void)
         Checksum::UpdateMessageChecksum(*message, messageInfo.GetSockAddr(), messageInfo.GetPeerAddr(),
                                         Ip6::kProtoIcmp6);
 
-        VerifyOrQuit(message->Read(message->GetOffset(), sizeof(icmp6Header), &icmp6Header) == sizeof(icmp6Header),
-                     "Message::Read() failed");
+        SuccessOrQuit(message->Read(message->GetOffset(), icmp6Header), "Message::Read() failed");
         VerifyOrQuit(icmp6Header.GetChecksum() != 0, "Failed to update checksum");
 
         // Verify that the calculated ICMP6 checksum is valid.

--- a/tests/unit/test_checksum.cpp
+++ b/tests/unit/test_checksum.cpp
@@ -107,8 +107,7 @@ uint16_t CalculateChecksum(const Ip6::Address &aSource,
     data.mPseudoHeader.mProtocol      = Encoding::BigEndian::HostSwap32(aIpProto);
     data.mPseudoHeader.mPayloadLength = Encoding::BigEndian::HostSwap32(payloadLength);
 
-    VerifyOrQuit(aMessage.ReadBytes(aMessage.GetOffset(), data.mPayload, payloadLength) == payloadLength,
-                 "Message::ReadBytes() failed");
+    SuccessOrQuit(aMessage.Read(aMessage.GetOffset(), data.mPayload, payloadLength), "Message::Read() failed");
 
     return CalculateChecksum(&data, sizeof(PseudoHeader) + payloadLength);
 }

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -65,7 +65,7 @@ void TestMessage(void)
     VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr, "Message::New failed");
     SuccessOrQuit(message->SetLength(kMaxSize), "Message::SetLength failed");
     message->WriteBytes(0, writeBuffer, kMaxSize);
-    VerifyOrQuit(message->ReadBytes(0, readBuffer, kMaxSize) == kMaxSize, "Message::Read failed");
+    SuccessOrQuit(message->Read(0, readBuffer, kMaxSize), "Message::Read failed");
     VerifyOrQuit(memcmp(writeBuffer, readBuffer, kMaxSize) == 0, "Message compare failed");
     VerifyOrQuit(message->GetLength() == kMaxSize, "Message::GetLength failed");
 
@@ -80,11 +80,11 @@ void TestMessage(void)
 
             message->WriteBytes(offset, &writeBuffer[offset], length);
 
-            VerifyOrQuit(message->ReadBytes(0, readBuffer, kMaxSize) == kMaxSize, "Message::Read failed");
+            SuccessOrQuit(message->Read(0, readBuffer, kMaxSize), "Message::Read failed");
             VerifyOrQuit(memcmp(writeBuffer, readBuffer, kMaxSize) == 0, "Message compare failed");
 
             memset(readBuffer, 0, sizeof(readBuffer));
-            VerifyOrQuit(message->ReadBytes(offset, readBuffer, length) == length, "Message::Read failed");
+            SuccessOrQuit(message->Read(offset, readBuffer, length), "Message::Read failed");
             VerifyOrQuit(memcmp(readBuffer, &writeBuffer[offset], length) == 0, "Message compare failed");
             VerifyOrQuit(memcmp(&readBuffer[length], zeroBuffer, kMaxSize - length) == 0, "Message read after length");
         }
@@ -132,7 +132,7 @@ void TestMessage(void)
                     VerifyOrQuit(bytesCopied == kMaxSize - srcOffset, "CopyTo() failed");
                 }
 
-                VerifyOrQuit(message2->ReadBytes(0, readBuffer, kMaxSize) == kMaxSize, "Message::Read failed");
+                SuccessOrQuit(message2->Read(0, readBuffer, kMaxSize), "Message::Read failed");
 
                 VerifyOrQuit(memcmp(&readBuffer[0], zeroBuffer, dstOffset) == 0, "read before length");
                 VerifyOrQuit(memcmp(&readBuffer[dstOffset], &writeBuffer[srcOffset], bytesCopied) == 0,
@@ -155,7 +155,7 @@ void TestMessage(void)
         bytesCopied = message->CopyTo(srcOffset, 0, kMaxSize, *message);
         VerifyOrQuit(bytesCopied == kMaxSize - srcOffset, "CopyTo() failed");
 
-        VerifyOrQuit(message->ReadBytes(0, readBuffer, kMaxSize) == kMaxSize, "Message::Read failed");
+        SuccessOrQuit(message->Read(0, readBuffer, kMaxSize), "Message::Read failed");
 
         VerifyOrQuit(memcmp(&readBuffer[0], &writeBuffer[srcOffset], bytesCopied) == 0,
                      "CopyTo() changed before srcOffset");

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -64,8 +64,8 @@ void TestMessage(void)
 
     VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr, "Message::New failed");
     SuccessOrQuit(message->SetLength(kMaxSize), "Message::SetLength failed");
-    message->Write(0, kMaxSize, writeBuffer);
-    VerifyOrQuit(message->Read(0, kMaxSize, readBuffer) == kMaxSize, "Message::Read failed");
+    message->WriteBytes(0, writeBuffer, kMaxSize);
+    VerifyOrQuit(message->ReadBytes(0, readBuffer, kMaxSize) == kMaxSize, "Message::Read failed");
     VerifyOrQuit(memcmp(writeBuffer, readBuffer, kMaxSize) == 0, "Message compare failed");
     VerifyOrQuit(message->GetLength() == kMaxSize, "Message::GetLength failed");
 
@@ -78,26 +78,26 @@ void TestMessage(void)
                 writeBuffer[offset + i]++;
             }
 
-            message->Write(offset, length, &writeBuffer[offset]);
+            message->WriteBytes(offset, &writeBuffer[offset], length);
 
-            VerifyOrQuit(message->Read(0, kMaxSize, readBuffer) == kMaxSize, "Message::Read failed");
+            VerifyOrQuit(message->ReadBytes(0, readBuffer, kMaxSize) == kMaxSize, "Message::Read failed");
             VerifyOrQuit(memcmp(writeBuffer, readBuffer, kMaxSize) == 0, "Message compare failed");
 
             memset(readBuffer, 0, sizeof(readBuffer));
-            VerifyOrQuit(message->Read(offset, length, readBuffer) == length, "Message::Read failed");
+            VerifyOrQuit(message->ReadBytes(offset, readBuffer, length) == length, "Message::Read failed");
             VerifyOrQuit(memcmp(readBuffer, &writeBuffer[offset], length) == 0, "Message compare failed");
             VerifyOrQuit(memcmp(&readBuffer[length], zeroBuffer, kMaxSize - length) == 0, "Message read after length");
         }
 
-        // Verify `Read()` behavior when requested read length goes beyond available bytes in the message.
+        // Verify `ReadBytes()` behavior when requested read length goes beyond available bytes in the message.
 
         for (uint16_t length = kMaxSize - offset + 1; length <= kMaxSize + 1; length++)
         {
             uint16_t readLength;
 
             memset(readBuffer, 0, sizeof(readBuffer));
-            readLength = message->Read(offset, length, readBuffer);
-            VerifyOrQuit(readLength <= length, "Message::Read() returned longer length");
+            readLength = message->ReadBytes(offset, readBuffer, length);
+            VerifyOrQuit(readLength <= length, "Message::ReadBytes() returned longer length");
             VerifyOrQuit(readLength == kMaxSize - offset, "Message::Read failed");
             VerifyOrQuit(memcmp(readBuffer, &writeBuffer[offset], readLength) == 0, "Message compare failed");
             VerifyOrQuit(memcmp(&readBuffer[readLength], zeroBuffer, kMaxSize - readLength) == 0, "read after length");
@@ -119,7 +119,7 @@ void TestMessage(void)
             {
                 uint16_t bytesCopied;
 
-                message2->Write(0, kMaxSize, zeroBuffer);
+                message2->WriteBytes(0, zeroBuffer, kMaxSize);
 
                 bytesCopied = message->CopyTo(srcOffset, dstOffset, length, *message2);
 
@@ -132,7 +132,7 @@ void TestMessage(void)
                     VerifyOrQuit(bytesCopied == kMaxSize - srcOffset, "CopyTo() failed");
                 }
 
-                VerifyOrQuit(message2->Read(0, kMaxSize, readBuffer) == kMaxSize, "Message::Read failed");
+                VerifyOrQuit(message2->ReadBytes(0, readBuffer, kMaxSize) == kMaxSize, "Message::Read failed");
 
                 VerifyOrQuit(memcmp(&readBuffer[0], zeroBuffer, dstOffset) == 0, "read before length");
                 VerifyOrQuit(memcmp(&readBuffer[dstOffset], &writeBuffer[srcOffset], bytesCopied) == 0,
@@ -150,12 +150,12 @@ void TestMessage(void)
     {
         uint16_t bytesCopied;
 
-        message->Write(0, kMaxSize, writeBuffer);
+        message->WriteBytes(0, writeBuffer, kMaxSize);
 
         bytesCopied = message->CopyTo(srcOffset, 0, kMaxSize, *message);
         VerifyOrQuit(bytesCopied == kMaxSize - srcOffset, "CopyTo() failed");
 
-        VerifyOrQuit(message->Read(0, kMaxSize, readBuffer) == kMaxSize, "Message::Read failed");
+        VerifyOrQuit(message->ReadBytes(0, readBuffer, kMaxSize) == kMaxSize, "Message::Read failed");
 
         VerifyOrQuit(memcmp(&readBuffer[0], &writeBuffer[srcOffset], bytesCopied) == 0,
                      "CopyTo() changed before srcOffset");

--- a/tests/unit/test_spinel_buffer.cpp
+++ b/tests/unit/test_spinel_buffer.cpp
@@ -179,7 +179,7 @@ void WriteTestFrame1(Spinel::Buffer &aNcpBuffer, Spinel::Buffer::Priority aPrior
     message = sMessagePool->New(Message::kTypeIp6, 0);
     VerifyOrQuit(message != nullptr, "Null Message");
     SuccessOrQuit(message->SetLength(sizeof(sMottoText)), "Could not set the length of message.");
-    message->Write(0, sizeof(sMottoText), sMottoText);
+    message->Write(0, sMottoText);
 
     oldContext = sContext;
     aNcpBuffer.InFrameBegin(aPriority);
@@ -223,12 +223,12 @@ void WriteTestFrame2(Spinel::Buffer &aNcpBuffer, Spinel::Buffer::Priority aPrior
     message1 = sMessagePool->New(Message::kTypeIp6, 0);
     VerifyOrQuit(message1 != nullptr, "Null Message");
     SuccessOrQuit(message1->SetLength(sizeof(sMysteryText)), "Could not set the length of message.");
-    message1->Write(0, sizeof(sMysteryText), sMysteryText);
+    message1->Write(0, sMysteryText);
 
     message2 = sMessagePool->New(Message::kTypeIp6, 0);
     VerifyOrQuit(message2 != nullptr, "Null Message");
     SuccessOrQuit(message2->SetLength(sizeof(sHelloText)), "Could not set the length of message.");
-    message2->Write(0, sizeof(sHelloText), sHelloText);
+    message2->Write(0, sHelloText);
 
     aNcpBuffer.InFrameBegin(aPriority);
     SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(message1), "InFrameFeedMessage() failed.");
@@ -529,7 +529,7 @@ void TestBuffer(void)
         message = sMessagePool->New(Message::kTypeIp6, 0);
         VerifyOrQuit(message != nullptr, "Null Message");
         SuccessOrQuit(message->SetLength(sizeof(sMysteryText)), "Could not set the length of message.");
-        message->Write(0, sizeof(sMysteryText), sMysteryText);
+        message->Write(0, sMysteryText);
 
         SuccessOrQuit(ncpBuffer.InFrameFeedMessage(message), "InFrameFeedMessage() failed.");
 
@@ -734,7 +734,7 @@ void TestBuffer(void)
     message = sMessagePool->New(Message::kTypeIp6, 0);
     VerifyOrQuit(message != nullptr, "Null Message");
     SuccessOrQuit(message->SetLength(sizeof(sMysteryText)), "Could not set the length of message.");
-    message->Write(0, sizeof(sMysteryText), sMysteryText);
+    message->Write(0, sMysteryText);
     VerifyOrQuit(ncpBuffer.InFrameFeedMessage(message) == OT_ERROR_INVALID_STATE, "Incorrect error status");
     message->Free();
     VerifyOrQuit(ncpBuffer.InFrameEnd() == OT_ERROR_INVALID_STATE, "Incorrect error status");


### PR DESCRIPTION
This commit adds new helper methods in `Message` class. It adds new
template methods to allow an object (of any type) to be read from or
written/appended/prepended to the message. The `Read<ObjectType>()`
method returns a parse `otError` if there are not enough bytes
remaining in the message to read the entire object.

The template methods are used in other core modules which help
simplify the code (there is no need to specify the template type since
it can be deduced by the complier from the passed-in argument). Also
since the template methods directly use the `sizeof` the object type,
they help reduce the chance of incorrect use (using incorrect
read/write length when calling the method).

This commit also updates and renames the methods which read/write raw
bytes from/to the message to `ReadBytes()`/`WriteBytes()`. The order
of parameters in these methods are changed to follow the common
pattern used by other modules and the OT public APIs (i.e., the
pointer to the buffer is given first, followed by its length).