### PR TITLE
[thread-cert] enhance case 9.2.4 to avoid reverifying coap retransmission packets

### DIFF
--- a/tests/scripts/thread-cert/Cert_9_2_04_ActiveDataset.py
+++ b/tests/scripts/thread-cert/Cert_9_2_04_ActiveDataset.py
@@ -208,14 +208,14 @@ class Cert_9_2_04_ActiveDataset(thread_cert.TestCase):
             MLE_CHILD_ID_RESPONSE).must_next()
 
         # Step 2: Commissioner sends MGMT_ACTIVE_SET.req to Leader RLOC or Anycast Locator
-        pkts.filter_wpan_src64(COMMISSIONER).filter_ipv6_2dsts(
-            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).must_next().must_verify(
-                lambda p: p.thread_meshcop.tlv.xpan_id == '000db70000000000' and p.thread_meshcop.tlv.net_name == 'GRL'
-                and p.thread_meshcop.tlv.chan_mask_mask == '001fffe0' and p.thread_meshcop.tlv.active_tstamp == 101)
+        pkts.filter_wpan_src64(COMMISSIONER).filter_ipv6_2dsts(LEADER_RLOC, LEADER_ALOC).filter_coap_request(
+            MGMT_ACTIVE_SET_URI).filter(lambda p: p.thread_meshcop.tlv.xpan_id == '000db70000000000' and p.
+                                        thread_meshcop.tlv.net_name == 'GRL' and p.thread_meshcop.tlv.chan_mask_mask ==
+                                        '001fffe0' and p.thread_meshcop.tlv.active_tstamp == 101).must_next()
 
         # Step 3: Leader MUST send MGMT_ACTIVE_SET.rsp to the Commissioner
-        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(
-            MGMT_ACTIVE_SET_URI).must_next().must_verify(lambda p: p.thread_meshcop.tlv.state == 1)
+        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(MGMT_ACTIVE_SET_URI).filter(
+            lambda p: p.thread_meshcop.tlv.state == 1).must_next()
 
         # Step 4: Commissioner sends MGMT_ACTIVE_GET.req to Leader
         pkts.filter_wpan_src64(COMMISSIONER).filter_ipv6_2dsts(
@@ -223,100 +223,98 @@ class Cert_9_2_04_ActiveDataset(thread_cert.TestCase):
 
         # Step 5: The Leader MUST send MGMT_ACTIVE_GET.rsp to the Commissioner
         pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(
-            MGMT_ACTIVE_GET_URI
-        ).must_next().must_verify(
-            lambda p: p.thread_meshcop.tlv.active_tstamp == 101 and p.thread_meshcop.tlv.xpan_id == '000db70000000000'
-            and p.thread_meshcop.tlv.net_name == 'GRL' and p.thread_meshcop.tlv.chan_mask_mask == '001fffe0')
+            MGMT_ACTIVE_GET_URI).filter(lambda p: p.thread_meshcop.tlv.active_tstamp == 101 and p.thread_meshcop.tlv.
+                                        xpan_id == '000db70000000000' and p.thread_meshcop.tlv.net_name == 'GRL' and p.
+                                        thread_meshcop.tlv.chan_mask_mask == '001fffe0').must_next()
 
         # Step 6: Commissioner sends MGMT_ACTIVE_SET.req to Leader RLOC or Anycast Locator
         pkts.filter_wpan_src64(COMMISSIONER).filter_ipv6_2dsts(
-            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).must_next().must_verify(
+            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).filter(
                 lambda p: p.thread_meshcop.tlv.active_tstamp == 102 and p.thread_meshcop.tlv.xpan_id ==
                 '000db70000000001' and p.thread_meshcop.tlv.net_name == 'threadcert' and p.thread_meshcop.tlv.
-                chan_mask_mask == '001fffe0' and p.thread_meshcop.tlv.channel == 18)
+                chan_mask_mask == '001fffe0' and p.thread_meshcop.tlv.channel == 18).must_next()
 
         # Step 7: Leader MUST send MGMT_ACTIVE_SET.rsp to the Commissioner
-        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(
-            MGMT_ACTIVE_SET_URI).must_next().must_verify(lambda p: p.thread_meshcop.tlv.state == -1)
+        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(MGMT_ACTIVE_SET_URI).filter(
+            lambda p: p.thread_meshcop.tlv.state == -1).must_next()
 
         # Step 8: Commissioner sends MGMT_ACTIVE_SET.req to Leader RLOC or Leader Anycast Locator
         pkts.filter_wpan_src64(COMMISSIONER).filter_ipv6_2dsts(
-            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).must_next().must_verify(
+            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).filter(
                 lambda p: p.thread_meshcop.tlv.active_tstamp == 103 and p.thread_meshcop.tlv.xpan_id ==
                 '000db70000000000' and p.thread_meshcop.tlv.net_name == 'UL' and p.thread_meshcop.tlv.chan_mask_mask ==
-                '001fffe0' and p.thread_meshcop.tlv.ml_prefix == 'fd000db700000000')
+                '001fffe0' and p.thread_meshcop.tlv.ml_prefix == 'fd000db700000000').must_next()
 
         # Step 9: Leader MUST send MGMT_ACTIVE_SET.rsp to the Commissioner
-        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(
-            MGMT_ACTIVE_SET_URI).must_next().must_verify(lambda p: p.thread_meshcop.tlv.state == -1)
+        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(MGMT_ACTIVE_SET_URI).filter(
+            lambda p: p.thread_meshcop.tlv.state == -1).must_next()
 
         # Step 10: Commissioner sends MGMT_ACTIVE_SET.req to Leader RLOC or Leader Anycast Locator
         pkts.filter_wpan_src64(COMMISSIONER).filter_ipv6_2dsts(
-            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).must_next().must_verify(
+            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).filter(
                 lambda p: p.thread_meshcop.tlv.active_tstamp == 104 and p.thread_meshcop.tlv.xpan_id ==
                 '000db70000000000' and p.thread_meshcop.tlv.net_name == 'GRL' and p.thread_meshcop.tlv.master_key ==
                 'ffeeddccbbaa99887766554433221100' and p.thread_meshcop.tlv.chan_mask_mask == '001fffe0' and p.
-                thread_meshcop.tlv.ml_prefix == 'fd000db700000000')
+                thread_meshcop.tlv.ml_prefix == 'fd000db700000000').must_next()
 
         # Step 11: Leader MUST send MGMT_ACTIVE_SET.rsp to the Commissioner
-        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(
-            MGMT_ACTIVE_SET_URI).must_next().must_verify(lambda p: p.thread_meshcop.tlv.state == -1)
+        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(MGMT_ACTIVE_SET_URI).filter(
+            lambda p: p.thread_meshcop.tlv.state == -1).must_next()
 
         # Step 12: Commissioner sends MGMT_ACTIVE_SET.req to Leader RLOC or Leader Anycast Locator
         pkts.filter_wpan_src64(COMMISSIONER).filter_ipv6_2dsts(
-            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).must_next().must_verify(
+            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).filter(
                 lambda p: p.thread_meshcop.tlv.active_tstamp == 105 and p.thread_meshcop.tlv.xpan_id ==
                 '000db70000000000' and p.thread_meshcop.tlv.net_name == 'UL' and p.thread_meshcop.tlv.master_key ==
                 '00112233445566778899aabbccddeeff' and p.thread_meshcop.tlv.pan_id == 0xafce and p.thread_meshcop.tlv.
-                chan_mask_mask == '001fffe0' and p.thread_meshcop.tlv.ml_prefix == 'fd000db700000000')
+                chan_mask_mask == '001fffe0' and p.thread_meshcop.tlv.ml_prefix == 'fd000db700000000').must_next()
 
         # Step 13: Leader MUST send MGMT_ACTIVE_SET.rsp to the Commissioner
-        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(
-            MGMT_ACTIVE_SET_URI).must_next().must_verify(lambda p: p.thread_meshcop.tlv.state == -1)
+        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(MGMT_ACTIVE_SET_URI).filter(
+            lambda p: p.thread_meshcop.tlv.state == -1).must_next()
 
         # Step 14: Commissioner sends MGMT_ACTIVE_SET.req to Leader RLOC or Leader Anycast Locator
         pkts.filter_wpan_src64(COMMISSIONER).filter_ipv6_2dsts(
-            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).must_next().must_verify(
+            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).filter(
                 lambda p: p.thread_meshcop.tlv.active_tstamp == 106 and p.thread_meshcop.tlv.xpan_id ==
                 '000db70000000000' and p.thread_meshcop.tlv.net_name == 'UL' and p.thread_meshcop.tlv.
-                commissioner_sess_id == 0xabcd and p.thread_meshcop.tlv.chan_mask_mask == '001fffe0')
+                commissioner_sess_id == 0xabcd and p.thread_meshcop.tlv.chan_mask_mask == '001fffe0').must_next()
 
         # Step 15: Leader MUST send MGMT_ACTIVE_SET.rsp to the Commissioner
-        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(
-            MGMT_ACTIVE_SET_URI).must_next().must_verify(lambda p: p.thread_meshcop.tlv.state == -1)
+        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(MGMT_ACTIVE_SET_URI).filter(
+            lambda p: p.thread_meshcop.tlv.state == -1).must_next()
 
         # Step 16: Commissioner sends MGMT_ACTIVE_SET.req to Leader RLOC or Leader Anycast Locator
-        pkts.filter_wpan_src64(COMMISSIONER).filter_ipv6_2dsts(
-            LEADER_RLOC, LEADER_ALOC
-        ).filter_coap_request(MGMT_ACTIVE_SET_URI).must_next().must_verify(
-            lambda p: p.thread_meshcop.tlv.active_tstamp == 101 and p.thread_meshcop.tlv.xpan_id == '000db70000000000'
-            and p.thread_meshcop.tlv.net_name == 'UL' and p.thread_meshcop.tlv.chan_mask_mask == '001fff80')
+        pkts.filter_wpan_src64(COMMISSIONER).filter_ipv6_2dsts(LEADER_RLOC, LEADER_ALOC).filter_coap_request(
+            MGMT_ACTIVE_SET_URI).filter(lambda p: p.thread_meshcop.tlv.active_tstamp == 101 and p.thread_meshcop.tlv.
+                                        xpan_id == '000db70000000000' and p.thread_meshcop.tlv.net_name == 'UL' and p.
+                                        thread_meshcop.tlv.chan_mask_mask == '001fff80').must_next()
 
         # Step 17: Leader MUST send MGMT_ACTIVE_SET.rsp to the Commissioner
-        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(
-            MGMT_ACTIVE_SET_URI).must_next().must_verify(lambda p: p.thread_meshcop.tlv.state == -1)
+        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(MGMT_ACTIVE_SET_URI).filter(
+            lambda p: p.thread_meshcop.tlv.state == -1).must_next()
 
         # Step 18: Commissioner sends MGMT_ACTIVE_SET.req to Leader RLOC or Leader Anycast Locator
         pkts.filter_wpan_src64(COMMISSIONER).filter_ipv6_2dsts(
-            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).must_next().must_verify(
+            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).filter(
                 lambda p: p.thread_meshcop.tlv.active_tstamp == 107 and p.thread_meshcop.tlv.xpan_id ==
                 '000db70000000000' and p.thread_meshcop.tlv.net_name == 'UL' and p.thread_meshcop.tlv.steering_data ==
-                [0x113320440000] and p.thread_meshcop.tlv.chan_mask_mask == '001fffe0')
+                [0x113320440000] and p.thread_meshcop.tlv.chan_mask_mask == '001fffe0').must_next()
 
         # Step 19: Leader MUST send MGMT_ACTIVE_SET.rsp to the Commissioner
-        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(
-            MGMT_ACTIVE_SET_URI).must_next().must_verify(lambda p: p.thread_meshcop.tlv.state == 1)
+        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(MGMT_ACTIVE_SET_URI).filter(
+            lambda p: p.thread_meshcop.tlv.state == 1).must_next()
 
         # Step 20: Commissioner sends MGMT_ACTIVE_SET.req to Leader RLOC or Leader Anycast Locator
         pkts.filter_wpan_src64(COMMISSIONER).filter_ipv6_2dsts(
-            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).must_next().must_verify(
+            LEADER_RLOC, LEADER_ALOC).filter_coap_request(MGMT_ACTIVE_SET_URI).filter(
                 lambda p: p.thread_meshcop.tlv.active_tstamp == 108 and p.thread_meshcop.tlv.xpan_id ==
                 '000db70000000000' and p.thread_meshcop.tlv.net_name == 'GRL' and p.thread_meshcop.tlv.unknown ==
-                'aa55' and p.thread_meshcop.tlv.chan_mask_mask == '001fffe0')
+                'aa55' and p.thread_meshcop.tlv.chan_mask_mask == '001fffe0').must_next()
 
         # Step 21: Leader MUST send MGMT_ACTIVE_SET.rsp to the Commissioner
-        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(
-            MGMT_ACTIVE_SET_URI).must_next().must_verify(lambda p: p.thread_meshcop.tlv.state == 1)
+        pkts.filter_wpan_src64(LEADER).filter_ipv6_dst(COMMISSIONER_RLOC).filter_coap_ack(MGMT_ACTIVE_SET_URI).filter(
+            lambda p: p.thread_meshcop.tlv.state == 1).must_next()
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
replace must_verify with filter to avoid possible verification of coap retransmission packets which could cause filter incorrect packets.