### PR TITLE
[cli] replace 'PRIx64' use

### DIFF
--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -70,7 +70,7 @@ otError Joiner::ProcessDiscerner(uint8_t aArgsLength, char *aArgs[])
 
         VerifyOrExit(discerner != nullptr, error = OT_ERROR_NOT_FOUND);
 
-        mInterpreter.OutputLine("0x%" PRIx64 "/%u", discerner->mValue, discerner->mLength);
+        mInterpreter.OutputLine("0x%llx/%u", static_cast<unsigned long long>(discerner->mValue), discerner->mLength);
     }
     else
     {


### PR DESCRIPTION
---
This should help with https://github.com/openthread/openthread/issues/5554.

In earlier projects, we faced similar problems with `PRIx64` use with some embedded toolchains. 
In general, I would suggest we try to avoid using it if/when we can.
