### PR TITLE
[cli] add cli command to control child supervision

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -28,6 +28,7 @@ Done
 - [child](#child-list)
 - [childip](#childip)
 - [childmax](#childmax)
+- [childsupervision](#childsupervision-interval)
 - [childtimeout](#childtimeout)
 - [coap](README_COAP.md)
 - [coaps](README_COAPS.md)
@@ -473,6 +474,48 @@ Set the Thread maximum number of allowed children.
 
 ```bash
 > childmax 2
+Done
+```
+
+### childsupervision interval
+
+Get the Child Supervision Interval value.
+
+Child supervision feature provides a mechanism for parent to ensure that a message is sent to each sleepy child within the supervision interval. If there is no transmission to the child within the supervision interval, OpenThread enqueues and sends a supervision message (a data message with empty payload) to the child. This command can only be used with FTD devices.
+
+```bash
+> childsupervision interval
+30
+Done
+```
+
+### childsupervision interval \<interval\>
+
+Set the Child Supervision Interval value. This command can only be used with FTD devices.
+
+```bash
+> childsupervision interval 30
+Done
+```
+
+### childsupervision checktimeout
+
+Get the Child Supervision Check Timeout value.
+
+If the device is a sleepy child and it does not hear from its parent within the specified check timeout, it initiates the re-attach process (MLE Child Update Request/Response exchange with its parent).
+
+```bash
+> childsupervision checktimeout
+30
+Done
+```
+
+### childsupervision checktimeout \<timeout\>
+
+Set the Child Supervision Check Timeout value.
+
+```bash
+> childsupervision checktimeout 30
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -56,6 +56,9 @@
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 #include <openthread/server.h>
 #endif
+#if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
+#include <openthread/child_supervision.h>
+#endif
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
 #include <openthread/platform/misc.h>
 #endif
@@ -941,6 +944,58 @@ exit:
     return error;
 }
 #endif // OPENTHREAD_FTD
+
+#if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
+otError Interpreter::ProcessChildSupervision(uint8_t aArgsLength, char *aArgs[])
+{
+    otError  error = OT_ERROR_NONE;
+    uint16_t value;
+
+    VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
+
+    if (strcmp(aArgs[0], "checktimeout") == 0)
+    {
+        if (aArgsLength == 1)
+        {
+            OutputLine("%u", otChildSupervisionGetCheckTimeout(mInstance));
+        }
+        else if (aArgsLength == 2)
+        {
+            SuccessOrExit(error = ParseAsUint16(aArgs[1], value));
+            otChildSupervisionSetCheckTimeout(mInstance, value);
+        }
+        else
+        {
+            ExitNow(error = OT_ERROR_INVALID_ARGS);
+        }
+    }
+#if OPENTHREAD_FTD
+    else if (strcmp(aArgs[0], "interval") == 0)
+    {
+        if (aArgsLength == 1)
+        {
+            OutputLine("%u", otChildSupervisionGetInterval(mInstance));
+        }
+        else if (aArgsLength == 2)
+        {
+            SuccessOrExit(error = ParseAsUint16(aArgs[1], value));
+            otChildSupervisionSetInterval(mInstance, value);
+        }
+        else
+        {
+            ExitNow(error = OT_ERROR_INVALID_ARGS);
+        }
+    }
+#endif
+    else
+    {
+        ExitNow(error = OT_ERROR_INVALID_ARGS);
+    }
+
+exit:
+    return error;
+}
+#endif // OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
 
 otError Interpreter::ProcessChildTimeout(uint8_t aArgsLength, char *aArgs[])
 {

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -287,6 +287,9 @@ private:
     otError ProcessChildIp(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessChildMax(uint8_t aArgsLength, char *aArgs[]);
 #endif
+#if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
+    otError ProcessChildSupervision(uint8_t aArgsLength, char *aArgs[]);
+#endif
     otError ProcessChildTimeout(uint8_t aArgsLength, char *aArgs[]);
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
     otError ProcessCoap(uint8_t aArgsLength, char *aArgs[]);
@@ -541,6 +544,9 @@ private:
         {"child", &Interpreter::ProcessChild},
         {"childip", &Interpreter::ProcessChildIp},
         {"childmax", &Interpreter::ProcessChildMax},
+#endif
+#if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
+        {"childsupervision", &Interpreter::ProcessChildSupervision},
 #endif
         {"childtimeout", &Interpreter::ProcessChildTimeout},
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE

--- a/tests/scripts/expect/cli-child-supervision.exp
+++ b/tests/scripts/expect/cli-child-supervision.exp
@@ -28,58 +28,20 @@
 #
 
 source "tests/scripts/expect/_common.exp"
+source "tests/scripts/expect/_multinode.exp"
 
-proc setup_nodes {{childmode {r}}} {
-    # Sets up a Thread network with 2 nodes, spawn_1 as the leader and spawn_2
-    # as a child.
+setup_nodes "-"
 
-    global spawn_1
-    global spawn_2
-    global spawn_id
-    global env
+set spawn_id $spawn_1
+send "childsupervision interval 30\n"
+expect "Done"
+send "childsupervision interval\n"
+expect "Done"
 
-    set spawn_2 [spawn_node 2]
-    set psk "J01NME"
+set spawn_id $spawn_2
+send "childsupervision checktimeout 30\n"
+expect "Done"
+send "childsupervision checktimeout\n"
+expect "Done"
 
-    set spawn_id $spawn_2
-    send "eui64\n"
-    expect -re {([0-9a-f]{16})}
-    set eui64 $expect_out(1,string)
-    expect "Done"
-
-    setup_leader
-
-    set spawn_id $spawn_1
-    send "commissioner start\n"
-    expect "Done"
-    expect "Commissioner: active"
-    send "commissioner joiner add $eui64 $psk\n"
-    expect "Done"
-    wait_for "netdata steeringdata check $eui64" "Done"
-    send "channel\n"
-    expect -re {(\d+)}
-    set channel $expect_out(1,string)
-    expect "Done"
-
-    set spawn_id $spawn_2
-    send "mode $childmode\n"
-    expect "Done"
-    send "ifconfig up\n"
-    expect "Done"
-    send "joiner start $psk\n"
-    expect "Done"
-    wait_for "" "Join success"
-    send "thread start\n"
-    expect "Done"
-    wait_for "state" "child"
-    expect "Done"
-}
-
-proc dispose_nodes {} {
-    global spawn_2
-    global spawn_id
-
-    dispose_leader
-    set spawn_id $spawn_2
-    dispose
-}
+dispose_nodes


### PR DESCRIPTION
This PR adds cli command to control child supervision in order to replacing `wpanctl` with `ot-ctl` in silk.