### PR TITLE
[toranj] add new test-case covering joiner-router behavior

### DIFF
--- a/tests/toranj/start.sh
+++ b/tests/toranj/start.sh
@@ -143,6 +143,7 @@ run test-039-address-cache-table-snoop.py
 run test-040-network-data-stable-full.py
 run test-041-lowpan-fragmentation.py
 run test-042-meshcop-joiner-discerner.py
+run test-043-meshcop-joiner-router.py
 run test-100-mcu-power-state.py
 run test-600-channel-manager-properties.py
 run test-601-channel-manager-channel-change.py

--- a/tests/toranj/test-043-meshcop-joiner-router.py
+++ b/tests/toranj/test-043-meshcop-joiner-router.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+
+import wpan
+from wpan import verify
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test description: Test MeshCop Joiner, Commissioner and Joiner-router behavior
+#
+# This test covers Thread commissioning with a commissioner, a joiner-router and
+# joiner device.
+
+test_name = __file__[:-3] if __file__.endswith('.py') else __file__
+print('-' * 120)
+print('Starting \'{}\''.format(test_name))
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Creating `wpan.Nodes` instances
+
+speedup = 4
+wpan.Node.set_time_speedup_factor(speedup)
+
+r1 = wpan.Node()
+r2 = wpan.Node()
+c2 = wpan.Node()
+joiner = wpan.Node()
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Init all nodes
+
+wpan.Node.init_all_nodes()
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Build network topology
+#
+#       r1 ---------- r2
+#   (commissioner)   (joiner-router)
+#                     |
+#                     |
+#                     joiner
+
+r1.form('jr-meshcop')
+
+r1.allowlist_node(r2)
+r2.join_node(r1, wpan.JOIN_TYPE_ROUTER)
+
+c2.join_node(r2, wpan.JOIN_TYPE_END_DEVICE)
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test implementation
+
+WAIT_TIME = 2  # seconds
+
+verify(r2.get(wpan.WPAN_NODE_TYPE) == wpan.NODE_TYPE_ROUTER)
+
+PSKd = '123456'
+
+joiner_hw_addr = joiner.get(wpan.WPAN_HW_ADDRESS)[1:-1]  # Remove the `[]`
+
+# Start the commissioner and add joiner hw address along with PSKd
+r1.commissioner_start()
+r1.commissioner_add_joiner(joiner_hw_addr, PSKd)
+
+# Start Joiner
+joiner.joiner_join(PSKd)
+
+# Verify that Joiner succeeded
+verify(joiner.get(wpan.WPAN_STATE) == wpan.STATE_COMMISSIONED)
+
+joiner.joiner_attach()
+
+
+def joiner_is_associated():
+    verify(joiner.is_associated())
+
+
+wpan.verify_within(joiner_is_associated, WAIT_TIME)
+
+# -----------------------------------------------------------------------------------------------------------------------
+# Test finished
+
+wpan.Node.finalize_all_nodes()
+
+print('\'{}\' passed.'.format(test_name))


### PR DESCRIPTION
This commit adds a new test-case in `toranj` to cover MeshCoP and
joiner-router behavior.