### PR TITLE
[debug] prefer user provided assert to system assert

### DIFF
--- a/src/core/common/debug.hpp
+++ b/src/core/common/debug.hpp
@@ -41,13 +41,7 @@
 
 #if OPENTHREAD_CONFIG_ASSERT_ENABLE
 
-#if defined(__APPLE__) || defined(__linux__)
-
-#include <assert.h>
-
-#define OT_ASSERT(cond) assert(cond)
-
-#elif OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
+#if OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
 
 #include "openthread/platform/misc.h"
 
@@ -70,6 +64,12 @@
             }                                      \
         }                                          \
     } while (0)
+
+#elif defined(__APPLE__) || defined(__linux__)
+
+#include <assert.h>
+
+#define OT_ASSERT(cond) assert(cond)
 
 #else // OPENTHREAD_CONFIG_PLATFORM_ASSERT_MANAGEMENT
 

--- a/src/posix/platform/misc.cpp
+++ b/src/posix/platform/misc.cpp
@@ -76,6 +76,14 @@ otError otPlatSetMcuPowerState(otInstance *aInstance, otPlatMcuPowerState aState
     return error;
 }
 
+void otPlatAssertFail(const char *aFilename, int aLineNumber)
+{
+    otLogCritPlat("assert failed at %s:%d", aFilename, aLineNumber);
+    // For debug build, use assert to genreate a core dump
+    assert(false);
+    exit(1);
+}
+
 otPlatMcuPowerState otPlatGetMcuPowerState(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);


### PR DESCRIPTION
This allows users to enable OT_ASSERT in release builds on posix systems.