### PR TITLE
[tests] init joiner with different masterkey before start

### DIFF
--- a/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_01_JoinerRouter.py
@@ -51,13 +51,13 @@ class Cert_8_2_01_JoinerRouter(thread_cert.TestCase):
         },
         JOINER_ROUTER: {
             'name': 'JOINER_ROUTER',
-            'masterkey': '00112233445566778899aabbccddeeff',
+            'masterkey': 'deadbeefdeadbeefdeadbeefdeadbeef',
             'mode': 'rdn',
             'router_selection_jitter': 1
         },
         JOINER: {
             'name': 'JOINER',
-            'masterkey': '00112233445566778899aabbccddeeff',
+            'masterkey': 'deadbeefdeadbeefdeadbeefdeadbeef',
             'mode': 'rdn',
             'router_selection_jitter': 1
         },

--- a/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
+++ b/tests/scripts/thread-cert/Cert_8_2_02_JoinerRouter.py
@@ -51,13 +51,13 @@ class Cert_8_2_02_JoinerRouter(thread_cert.TestCase):
         },
         JOINER_ROUTER: {
             'name': 'JOINER_ROUTER',
-            'masterkey': '00112233445566778899aabbccddeeff',
+            'masterkey': 'deadbeefdeadbeefdeadbeefdeadbeef',
             'mode': 'rdn',
             'router_selection_jitter': 1
         },
         JOINER: {
             'name': 'JOINER',
-            'masterkey': '00112233445566778899aabbccddeeff',
+            'masterkey': 'deadbeefdeadbeefdeadbeefdeadbeef',
             'mode': 'rdn',
             'router_selection_jitter': 1
         },

--- a/tests/scripts/thread-cert/Cert_9_2_11_MasterKey.py
+++ b/tests/scripts/thread-cert/Cert_9_2_11_MasterKey.py
@@ -56,7 +56,7 @@ class Cert_9_2_11_MasterKey(thread_cert.TestCase):
                 'timestamp': 10,
                 'panid': PANID_INIT,
                 'channel': CHANNEL_INIT,
-                'master_key': '000102030405060708090a0b0c0d0e0f'
+                'master_key': KEY1
             },
             'mode': 'rdn',
             'router_selection_jitter': 1,
@@ -67,7 +67,7 @@ class Cert_9_2_11_MasterKey(thread_cert.TestCase):
                 'timestamp': 10,
                 'panid': PANID_INIT,
                 'channel': CHANNEL_INIT,
-                'master_key': '000102030405060708090a0b0c0d0e0f'
+                'master_key': KEY1
             },
             'mode': 'rdn',
             'router_selection_jitter': 1,
@@ -78,7 +78,7 @@ class Cert_9_2_11_MasterKey(thread_cert.TestCase):
                 'timestamp': 10,
                 'panid': PANID_INIT,
                 'channel': CHANNEL_INIT,
-                'master_key': '000102030405060708090a0b0c0d0e0f'
+                'master_key': KEY1
             },
             'mode': 'rdn',
             'router_selection_jitter': 1,
@@ -87,7 +87,7 @@ class Cert_9_2_11_MasterKey(thread_cert.TestCase):
         ED1: {
             'channel': CHANNEL_INIT,
             'is_mtd': True,
-            'masterkey': '000102030405060708090a0b0c0d0e0f',
+            'masterkey': KEY1,
             'mode': 'rn',
             'panid': PANID_INIT,
             'allowlist': [ROUTER1]
@@ -95,7 +95,7 @@ class Cert_9_2_11_MasterKey(thread_cert.TestCase):
         SED1: {
             'channel': CHANNEL_INIT,
             'is_mtd': True,
-            'masterkey': '000102030405060708090a0b0c0d0e0f',
+            'masterkey': KEY1,
             'mode': '-',
             'panid': PANID_INIT,
             'timeout': config.DEFAULT_CHILD_TIMEOUT,


### PR DESCRIPTION
For 8.x.x, there is validation that joiner has the same keys as the commissioner after commissioning, it should be configured with a different master key before start commissioning.