### PR TITLE
[indirect-sender] no replacing transmitting supervision message

### DIFF
--- a/src/core/mac/data_poll_handler.hpp
+++ b/src/core/mac/data_poll_handler.hpp
@@ -260,6 +260,12 @@ public:
      */
     void RequestFrameChange(FrameChange aChange, Child &aChild);
 
+    /**
+     * This method returns the current indirect tx child.
+     *
+     */
+    const Child *GetIndrectTxChild(void) const { return mIndirectTxChild; }
+
 private:
     // Callbacks from MAC
     void    HandleDataPoll(Mac::RxFrame &aFrame);

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -276,6 +276,9 @@ void IndirectSender::RequestMessageUpdate(Child &aChild)
 
     VerifyOrExit(!aChild.IsWaitingForMessageUpdate(), OT_NOOP);
 
+    // Do not replace the message when it is being transmitted.
+    VerifyOrExit(Get<DataPollHandler>().GetIndrectTxChild() != &aChild, OT_NOOP);
+
     newMessage = FindIndirectMessage(aChild);
 
     VerifyOrExit(curMessage != newMessage, OT_NOOP);


### PR DESCRIPTION
If MAC layer is transmitting a supervision message, and then another
message is delivered to the child, the supervision message will be dequeue from the
mesh forwarder send queue. And the supervision message is transmitted,
the dequeue operation will fail because the message is not in the queue.