### PR TITLE
[codecov] disable project coverage threshold

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,10 +1,6 @@
 coverage:
   status:
-    project:
-      default:
-        target: auto
-        threshold: 1%
-        only_pulls: true
+    project: off
     patch: off
 
 ignore:


### PR DESCRIPTION
Coverage reporting by codecov.io seems unstable. For example, it is
not respecting LCOV_EXCL_START/STOP. Disable until we figure out the
issue.