### PR TITLE
[cmd-parser] remove dependency of <limits>

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -364,6 +364,7 @@ openthread_core_files = [
   "common/non_copyable.hpp",
   "common/notifier.cpp",
   "common/notifier.hpp",
+  "common/numeric_limits.hpp",
   "common/pool.hpp",
   "common/random.hpp",
   "common/random_manager.cpp",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -356,6 +356,7 @@ HEADERS_COMMON                                  = \
     common/new.hpp                                \
     common/non_copyable.hpp                       \
     common/notifier.hpp                           \
+    common/numeric_limits.hpp                     \
     common/pool.hpp                               \
     common/random.hpp                             \
     common/random_manager.hpp                     \

--- a/src/core/common/numeric_limits.hpp
+++ b/src/core/common/numeric_limits.hpp
@@ -1,0 +1,109 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for NumericLimits class.
+ */
+
+#ifndef NUMERIC_LIMITS_HPP_
+#define NUMERIC_LIMITS_HPP_
+
+#include <stdint.h>
+
+namespace ot {
+
+/**
+ * This class template provides a way to query properties of arithmetic types.
+ *
+ * There are no members if `Type` is not a supported arithmetic type.
+ *
+ */
+template <typename Type> class NumericLimits
+{
+};
+
+template <> class NumericLimits<int8_t>
+{
+public:
+    static constexpr int8_t Min(void) { return INT8_MIN; }
+    static constexpr int8_t Max(void) { return INT8_MAX; }
+};
+
+template <> class NumericLimits<int16_t>
+{
+public:
+    static constexpr int16_t Min(void) { return INT16_MIN; }
+    static constexpr int16_t Max(void) { return INT16_MAX; }
+};
+
+template <> class NumericLimits<int32_t>
+{
+public:
+    static constexpr int32_t Min(void) { return INT32_MIN; }
+    static constexpr int32_t Max(void) { return INT32_MAX; }
+};
+
+template <> class NumericLimits<int64_t>
+{
+public:
+    static constexpr int64_t Min(void) { return INT64_MIN; }
+    static constexpr int64_t Max(void) { return INT64_MAX; }
+};
+
+template <> class NumericLimits<uint8_t>
+{
+public:
+    static constexpr uint8_t Min(void) { return 0; }
+    static constexpr uint8_t Max(void) { return UINT8_MAX; }
+};
+
+template <> class NumericLimits<uint16_t>
+{
+public:
+    static constexpr uint16_t Min(void) { return 0; }
+    static constexpr uint16_t Max(void) { return UINT16_MAX; }
+};
+
+template <> class NumericLimits<uint32_t>
+{
+public:
+    static constexpr uint32_t Min(void) { return 0; }
+    static constexpr uint32_t Max(void) { return UINT32_MAX; }
+};
+
+template <> class NumericLimits<uint64_t>
+{
+public:
+    static constexpr uint64_t Min(void) { return 0; }
+    static constexpr uint64_t Max(void) { return UINT64_MAX; }
+};
+
+} // namespace ot
+
+#endif // NUMERIC_LIMITS_HPP_

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -36,69 +36,8 @@
 #include <string.h>
 
 #include "common/code_utils.hpp"
+#include "common/numeric_limits.hpp"
 #include "net/ip6_address.hpp"
-
-namespace {
-template <typename Type> class NumericLimits
-{
-};
-
-template <> class NumericLimits<int8_t>
-{
-public:
-    static constexpr int8_t Min() { return INT8_MIN; }
-    static constexpr int8_t Max() { return INT8_MAX; }
-};
-
-template <> class NumericLimits<int16_t>
-{
-public:
-    static constexpr int16_t Min() { return INT16_MIN; }
-    static constexpr int16_t Max() { return INT16_MAX; }
-};
-
-template <> class NumericLimits<int32_t>
-{
-public:
-    static constexpr int32_t Min() { return INT32_MIN; }
-    static constexpr int32_t Max() { return INT32_MAX; }
-};
-
-template <> class NumericLimits<int64_t>
-{
-public:
-    static constexpr int64_t Min() { return INT64_MIN; }
-    static constexpr int64_t Max() { return INT64_MAX; }
-};
-
-template <> class NumericLimits<uint8_t>
-{
-public:
-    static constexpr uint8_t Min() { return 0; }
-    static constexpr uint8_t Max() { return UINT8_MAX; }
-};
-
-template <> class NumericLimits<uint16_t>
-{
-public:
-    static constexpr uint16_t Min() { return 0; }
-    static constexpr uint16_t Max() { return UINT16_MAX; }
-};
-
-template <> class NumericLimits<uint32_t>
-{
-public:
-    static constexpr uint32_t Min() { return 0; }
-    static constexpr uint32_t Max() { return UINT32_MAX; }
-};
-
-template <> class NumericLimits<uint64_t>
-{
-public:
-    static constexpr uint64_t Min() { return 0; }
-    static constexpr uint64_t Max() { return UINT64_MAX; }
-};
-} // namespace
 
 namespace ot {
 namespace Utils {

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -33,11 +33,72 @@
 
 #include "parse_cmdline.hpp"
 
-#include <limits>
 #include <string.h>
 
 #include "common/code_utils.hpp"
 #include "net/ip6_address.hpp"
+
+namespace {
+template <typename Type> class NumericLimits
+{
+};
+
+template <> class NumericLimits<int8_t>
+{
+public:
+    static constexpr int8_t Min() { return INT8_MIN; }
+    static constexpr int8_t Max() { return INT8_MAX; }
+};
+
+template <> class NumericLimits<int16_t>
+{
+public:
+    static constexpr int16_t Min() { return INT16_MIN; }
+    static constexpr int16_t Max() { return INT16_MAX; }
+};
+
+template <> class NumericLimits<int32_t>
+{
+public:
+    static constexpr int32_t Min() { return INT32_MIN; }
+    static constexpr int32_t Max() { return INT32_MAX; }
+};
+
+template <> class NumericLimits<int64_t>
+{
+public:
+    static constexpr int64_t Min() { return INT64_MIN; }
+    static constexpr int64_t Max() { return INT64_MAX; }
+};
+
+template <> class NumericLimits<uint8_t>
+{
+public:
+    static constexpr uint8_t Min() { return 0; }
+    static constexpr uint8_t Max() { return UINT8_MAX; }
+};
+
+template <> class NumericLimits<uint16_t>
+{
+public:
+    static constexpr uint16_t Min() { return 0; }
+    static constexpr uint16_t Max() { return UINT16_MAX; }
+};
+
+template <> class NumericLimits<uint32_t>
+{
+public:
+    static constexpr uint32_t Min() { return 0; }
+    static constexpr uint32_t Max() { return UINT32_MAX; }
+};
+
+template <> class NumericLimits<uint64_t>
+{
+public:
+    static constexpr uint64_t Min() { return 0; }
+    static constexpr uint64_t Max() { return UINT64_MAX; }
+};
+} // namespace
 
 namespace ot {
 namespace Utils {
@@ -121,7 +182,7 @@ template <typename UintType> otError ParseUint(const char *aString, UintType &aU
 
     SuccessOrExit(error = ParseAsUint64(aString, value));
 
-    VerifyOrExit(value <= std::numeric_limits<UintType>::max(), error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(value <= NumericLimits<UintType>::Max(), error = OT_ERROR_INVALID_ARGS);
     aUint = static_cast<UintType>(value);
 
 exit:
@@ -189,7 +250,7 @@ template <typename IntType> otError ParseInt(const char *aString, IntType &aInt)
 
     SuccessOrExit(error = ParseAsInt32(aString, value));
 
-    VerifyOrExit((std::numeric_limits<IntType>::min() <= value) && (value <= std::numeric_limits<IntType>::max()),
+    VerifyOrExit((NumericLimits<IntType>::Min() <= value) && (value <= NumericLimits<IntType>::Max()),
                  error = OT_ERROR_INVALID_ARGS);
     aInt = static_cast<IntType>(value);
 
@@ -224,9 +285,8 @@ otError ParseAsInt32(const char *aString, int32_t &aInt32)
     }
 
     SuccessOrExit(error = ParseAsUint64(aString, value));
-    VerifyOrExit(value <= (isNegavtive
-                               ? static_cast<uint64_t>(-static_cast<int64_t>(std::numeric_limits<int32_t>::min()))
-                               : static_cast<uint64_t>(std::numeric_limits<int32_t>::max())),
+    VerifyOrExit(value <= (isNegavtive ? static_cast<uint64_t>(-static_cast<int64_t>(NumericLimits<int32_t>::Min()))
+                                       : static_cast<uint64_t>(NumericLimits<int32_t>::Max())),
                  error = OT_ERROR_INVALID_ARGS);
     aInt32 = isNegavtive ? -static_cast<int32_t>(value) : static_cast<int32_t>(value);
 


### PR DESCRIPTION
We don't have C++ STL on some platforms, so this replaces it.