### PR TITLE
[common] use non-copyable for more instance-unique classes

### DIFF
--- a/src/core/backbone_router/bbr_leader.hpp
+++ b/src/core/backbone_router/bbr_leader.hpp
@@ -43,6 +43,7 @@
 #include "coap/coap.hpp"
 #include "coap/coap_message.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "net/ip6_address.hpp"
 
 namespace ot {
@@ -55,7 +56,7 @@ typedef otBackboneRouterConfig BackboneRouterConfig;
  * This class implements the basic Primary Backbone Router service operations.
  *
  */
-class Leader : public InstanceLocator
+class Leader : public InstanceLocator, private NonCopyable
 {
 public:
     // Primary Backbone Router Service state or state change.

--- a/src/core/backbone_router/bbr_local.hpp
+++ b/src/core/backbone_router/bbr_local.hpp
@@ -42,6 +42,7 @@
 
 #include "backbone_router/bbr_leader.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "net/netif.hpp"
 #include "thread/network_data.hpp"
 
@@ -53,7 +54,7 @@ namespace BackboneRouter {
  * This class implements the definitions for local Backbone Router service.
  *
  */
-class Local : public InstanceLocator
+class Local : public InstanceLocator, private NonCopyable
 {
 public:
     typedef otBackboneRouterState BackboneRouterState;

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -45,6 +45,7 @@
 #include "backbone_router/multicast_listeners_table.hpp"
 #include "backbone_router/ndproxy_table.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "net/netif.hpp"
 #include "thread/network_data.hpp"
 
@@ -56,7 +57,7 @@ namespace BackboneRouter {
  * This class implements the definitions for Backbone Router management.
  *
  */
-class Manager : public InstanceLocator
+class Manager : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
 

--- a/src/core/backbone_router/multicast_listeners_table.hpp
+++ b/src/core/backbone_router/multicast_listeners_table.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/backbone_router_ftd.h>
 
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/time.hpp"
 #include "net/ip6_address.hpp"

--- a/src/core/mac/data_poll_handler.hpp
+++ b/src/core/mac/data_poll_handler.hpp
@@ -38,6 +38,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "mac/mac.hpp"
 #include "mac/mac_frame.hpp"
@@ -60,7 +61,7 @@ class Child;
  * This class implements the data poll (mac data request command) handler.
  *
  */
-class DataPollHandler : public InstanceLocator
+class DataPollHandler : public InstanceLocator, private NonCopyable
 {
     friend class Mac::Mac;
 

--- a/src/core/mac/data_poll_sender.hpp
+++ b/src/core/mac/data_poll_sender.hpp
@@ -38,6 +38,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_frame.hpp"
 #include "thread/topology.hpp"
@@ -58,7 +59,7 @@ namespace ot {
  *
  */
 
-class DataPollSender : public InstanceLocator
+class DataPollSender : public InstanceLocator, private NonCopyable
 {
 public:
     enum

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -40,6 +40,7 @@
 #include <openthread/platform/time.h>
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/tasklet.hpp"
 #include "common/time.hpp"
 #include "common/timer.hpp"
@@ -122,7 +123,7 @@ typedef otEnergyScanResult EnergyScanResult;
  * This class implements the IEEE 802.15.4 MAC.
  *
  */
-class Mac : public InstanceLocator
+class Mac : public InstanceLocator, private NonCopyable
 {
     friend class ot::Instance;
 

--- a/src/core/mac/mac_filter.hpp
+++ b/src/core/mac/mac_filter.hpp
@@ -38,6 +38,7 @@
 
 #include <stdint.h>
 
+#include "common/non_copyable.hpp"
 #include "mac/mac_frame.hpp"
 
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
@@ -56,7 +57,7 @@ namespace Mac {
  * This class implements Mac Filter on IEEE 802.15.4 frames.
  *
  */
-class Filter
+class Filter : private NonCopyable
 {
 public:
     /**

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -39,6 +39,7 @@
 #include <openthread/link.h>
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_frame.hpp"
 #include "radio/radio.hpp"
@@ -74,7 +75,7 @@ namespace Mac {
  * addresses and PAN Id.
  *
  */
-class SubMac : public InstanceLocator
+class SubMac : public InstanceLocator, private NonCopyable
 {
     friend class Radio::Callbacks;
 

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -40,6 +40,7 @@
 
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "net/udp6.hpp"
 
@@ -49,7 +50,7 @@ class ThreadNetif;
 
 namespace MeshCoP {
 
-class BorderAgent : public InstanceLocator
+class BorderAgent : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
 

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -41,6 +41,7 @@
 #include "coap/coap.hpp"
 #include "coap/coap_secure.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_types.hpp"
 #include "meshcop/announce_begin_client.hpp"
@@ -56,7 +57,7 @@ namespace ot {
 
 namespace MeshCoP {
 
-class Commissioner : public InstanceLocator
+class Commissioner : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -39,6 +39,7 @@
 
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "mac/channel_mask.hpp"
 #include "meshcop/dataset.hpp"
@@ -359,7 +360,7 @@ private:
 #endif // OPENTHREAD_FTD
 };
 
-class ActiveDataset : public DatasetManager
+class ActiveDataset : public DatasetManager, private NonCopyable
 {
 public:
     /**
@@ -489,7 +490,7 @@ private:
 #endif
 };
 
-class PendingDataset : public DatasetManager
+class PendingDataset : public DatasetManager, private NonCopyable
 {
 public:
     /**

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -44,6 +44,7 @@
 #include "common/locator.hpp"
 #include "common/logging.hpp"
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "mac/mac_types.hpp"
 #include "meshcop/dtls.hpp"
 #include "meshcop/meshcop.hpp"
@@ -54,7 +55,7 @@ namespace ot {
 
 namespace MeshCoP {
 
-class Joiner : public InstanceLocator
+class Joiner : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -40,6 +40,7 @@
 #include "coap/coap_message.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_types.hpp"
@@ -51,7 +52,7 @@ namespace ot {
 
 namespace MeshCoP {
 
-class JoinerRouter : public InstanceLocator
+class JoinerRouter : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
 

--- a/src/core/meshcop/meshcop_leader.hpp
+++ b/src/core/meshcop/meshcop_leader.hpp
@@ -38,6 +38,7 @@
 
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
 #include "net/udp6.hpp"
@@ -61,7 +62,7 @@ public:
     SteeringDataTlv          mSteeringData;
 } OT_TOOL_PACKED_END;
 
-class Leader : public InstanceLocator
+class Leader : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -38,6 +38,7 @@
 
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "common/trickle_timer.hpp"
 #include "mac/mac.hpp"
@@ -64,7 +65,7 @@ namespace Dhcp6 {
  * This class implements DHCPv6 Client.
  *
  */
-class Client : public InstanceLocator
+class Client : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "mac/mac.hpp"
 #include "mac/mac_types.hpp"
 #include "net/dhcp6.hpp"
@@ -57,7 +58,7 @@ namespace Dhcp6 {
  *
  */
 
-class Server : public InstanceLocator
+class Server : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -34,6 +34,7 @@
 #include <openthread/dns.h>
 
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "net/dns_headers.hpp"
 #include "net/ip6.hpp"
@@ -51,7 +52,7 @@ namespace Dns {
  * This class implements DNS client.
  *
  */
-class Client
+class Client : private NonCopyable
 {
 public:
     /**

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -42,6 +42,7 @@
 #include "common/encoding.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "net/ip6_headers.hpp"
 
 namespace ot {
@@ -63,7 +64,7 @@ using ot::Encoding::BigEndian::HostSwap16;
  * This class implements ICMPv6.
  *
  */
-class Icmp : public InstanceLocator
+class Icmp : public InstanceLocator, private NonCopyable
 {
 public:
     /*

--- a/src/core/net/ip6_filter.hpp
+++ b/src/core/net/ip6_filter.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 
 namespace ot {
 namespace Ip6 {
@@ -55,7 +56,7 @@ namespace Ip6 {
  * This class implements an IPv6 datagram filter.
  *
  */
-class Filter
+class Filter : private NonCopyable
 {
 public:
     /**

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -38,6 +38,7 @@
 
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "net/ip6_headers.hpp"
 
@@ -186,7 +187,7 @@ private:
  * This class implements MPL message processing.
  *
  */
-class Mpl : public InstanceLocator
+class Mpl : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -34,6 +34,7 @@
 #include <openthread/sntp.h>
 
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "net/ip6.hpp"
 #include "net/netif.hpp"
@@ -483,7 +484,7 @@ private:
  * This class implements SNTP client.
  *
  */
-class Client
+class Client : private NonCopyable
 {
 public:
     /**

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -41,6 +41,7 @@
 
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "net/ip6_headers.hpp"
 
 namespace ot {
@@ -62,7 +63,7 @@ class Udp;
  * This class implements core UDP message handling.
  *
  */
-class Udp : public InstanceLocator
+class Udp : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -39,6 +39,7 @@
 #include "coap/coap.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/time_ticker.hpp"
 #include "common/timer.hpp"
 #include "mac/mac.hpp"
@@ -61,7 +62,7 @@ namespace ot {
  * This class implements the EID-to-RLOC mapping and caching.
  *
  */
-class AddressResolver : public InstanceLocator
+class AddressResolver : public InstanceLocator, private NonCopyable
 {
     friend class TimeTicker;
 

--- a/src/core/thread/child_table.hpp
+++ b/src/core/thread/child_table.hpp
@@ -39,6 +39,7 @@
 #if OPENTHREAD_FTD
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "thread/topology.hpp"
 
 namespace ot {
@@ -47,7 +48,7 @@ namespace ot {
  * This class represents the Thread child table.
  *
  */
-class ChildTable : public InstanceLocator
+class ChildTable : public InstanceLocator, private NonCopyable
 {
     friend class NeighborTable;
     class IteratorBuilder;

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -33,6 +33,7 @@
 
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "common/time.hpp"
 #include "mac/mac.hpp"
 #include "mac/mac_frame.hpp"
@@ -57,7 +58,7 @@ class Child;
  * This class implements CSL tx scheduling functionality.
  *
  */
-class CslTxScheduler : public InstanceLocator
+class CslTxScheduler : public InstanceLocator, private NonCopyable
 {
     friend class Mac::Mac;
     friend class IndirectSender;

--- a/src/core/thread/discover_scanner.hpp
+++ b/src/core/thread/discover_scanner.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "mac/channel_mask.hpp"
 #include "mac/mac.hpp"
@@ -54,7 +55,7 @@ namespace Mle {
  * This class implements MLE Discover Scan.
  *
  */
-class DiscoverScanner : public InstanceLocator
+class DiscoverScanner : public InstanceLocator, private NonCopyable
 {
     friend class ot::Instance;
     friend class ot::MeshForwarder;

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -42,6 +42,7 @@
 #include "coap/coap.hpp"
 #include "coap/coap_message.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/tasklet.hpp"
 #include "common/time.hpp"
@@ -71,7 +72,7 @@ namespace ot {
  * This class implements managing DUA.
  *
  */
-class DuaManager : public InstanceLocator
+class DuaManager : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
     friend class ot::TimeTicker;

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -38,6 +38,7 @@
 
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/timer.hpp"
 #include "net/ip6_address.hpp"
@@ -50,7 +51,7 @@ namespace ot {
  * This class implements handling Energy Scan Requests.
  *
  */
-class EnergyScanServer : public InstanceLocator
+class EnergyScanServer : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
 

--- a/src/core/thread/indirect_sender.hpp
+++ b/src/core/thread/indirect_sender.hpp
@@ -38,6 +38,7 @@
 
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "mac/data_poll_handler.hpp"
 #include "mac/mac_frame.hpp"
 #include "thread/csl_tx_scheduler.hpp"
@@ -62,7 +63,7 @@ class Child;
  * This class implements indirect transmission.
  *
  */
-class IndirectSender : public InstanceLocator, public IndirectSenderBase
+class IndirectSender : public InstanceLocator, public IndirectSenderBase, private NonCopyable
 {
     friend class Instance;
     friend class DataPollHandler::Callbacks;

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -43,6 +43,7 @@
 #include "common/clearable.hpp"
 #include "common/equatable.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/random.hpp"
 #include "common/timer.hpp"
 #include "crypto/hmac_sha256.hpp"
@@ -111,7 +112,7 @@ typedef Mac::Key Kek;
  * This class defines Thread Key Manager.
  *
  */
-class KeyManager : public InstanceLocator
+class KeyManager : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -42,6 +42,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 
 #include "link_metrics_tlvs.hpp"
 #include "topology.hpp"
@@ -57,7 +58,7 @@ namespace ot {
  * @{
  */
 
-class LinkMetrics : public InstanceLocator
+class LinkMetrics : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -39,6 +39,7 @@
 #include "common/debug.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "mac/mac_types.hpp"
 #include "net/ip6.hpp"
 #include "net/ip6_address.hpp"
@@ -218,7 +219,7 @@ private:
  * This class implements LOWPAN_IPHC header compression.
  *
  */
-class Lowpan : public InstanceLocator
+class Lowpan : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -38,6 +38,7 @@
 
 #include "common/clearable.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/tasklet.hpp"
 #include "common/time_ticker.hpp"
 #include "mac/channel_mask.hpp"
@@ -144,7 +145,7 @@ public:
  * This class implements mesh forwarding within Thread.
  *
  */
-class MeshForwarder : public InstanceLocator
+class MeshForwarder : public InstanceLocator, private NonCopyable
 {
     friend class Mac::Mac;
     friend class Instance;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -38,6 +38,7 @@
 
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "mac/mac.hpp"
 #include "meshcop/joiner_router.hpp"
@@ -89,7 +90,7 @@ namespace Mle {
  * This class implements MLE functionality required by the Thread EndDevices, Router, and Leader roles.
  *
  */
-class Mle : public InstanceLocator
+class Mle : public InstanceLocator, private NonCopyable
 {
     friend class DiscoverScanner;
     friend class ot::Notifier;

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -41,6 +41,7 @@
 #include "backbone_router/bbr_leader.hpp"
 #include "coap/coap_message.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/time_ticker.hpp"
 #include "common/timer.hpp"
@@ -68,7 +69,7 @@ namespace ot {
  * This class implements MLR management.
  *
  */
-class MlrManager : public InstanceLocator
+class MlrManager : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
     friend class ot::TimeTicker;

--- a/src/core/thread/neighbor_table.hpp
+++ b/src/core/thread/neighbor_table.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "thread/topology.hpp"
 
 namespace ot {
@@ -45,7 +46,7 @@ namespace ot {
  * This class represents the Thread neighbor table.
  *
  */
-class NeighborTable : public InstanceLocator
+class NeighborTable : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -39,6 +39,7 @@
 #include <stdint.h>
 
 #include "coap/coap.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "net/ip6_address.hpp"
 #include "thread/mle_router.hpp"
@@ -62,7 +63,7 @@ namespace NetworkData {
  * This class implements the Thread Network Data maintained by the Leader.
  *
  */
-class Leader : public LeaderBase
+class Leader : public LeaderBase, private NonCopyable
 {
 public:
     /**

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -37,6 +37,7 @@
 
 #include "openthread-core-config.h"
 
+#include "common/non_copyable.hpp"
 #include "thread/network_data.hpp"
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
@@ -58,7 +59,7 @@ namespace NetworkData {
  * This class implements the Thread Network Data contributed by the local device.
  *
  */
-class Local : public NetworkData
+class Local : public NetworkData, private NonCopyable
 {
 public:
     /**

--- a/src/core/thread/network_data_notifier.hpp
+++ b/src/core/thread/network_data_notifier.hpp
@@ -40,6 +40,7 @@
 
 #include "coap/coap.hpp"
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 
 namespace ot {
@@ -49,7 +50,7 @@ namespace NetworkData {
  * This class implements the SVR_DATA.ntf transmission logic.
  *
  */
-class Notifier : public InstanceLocator
+class Notifier : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
 

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -40,6 +40,7 @@
 
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "net/udp6.hpp"
 #include "thread/network_diagnostic_tlvs.hpp"
 
@@ -60,7 +61,7 @@ namespace NetworkDiagnostic {
  * This class implements the Network Diagnostic processing.
  *
  */
-class NetworkDiagnostic : public InstanceLocator
+class NetworkDiagnostic : public InstanceLocator, private NonCopyable
 {
 public:
     enum

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -38,6 +38,7 @@
 
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "mac/mac.hpp"
 #include "net/ip6_address.hpp"
@@ -49,7 +50,7 @@ namespace ot {
  * This class implements handling PANID Query Requests.
  *
  */
-class PanIdQueryServer : public InstanceLocator
+class PanIdQueryServer : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -35,6 +35,7 @@
 
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "mac/mac_types.hpp"
 #include "thread/mle_types.hpp"
 #include "thread/thread_tlvs.hpp"
@@ -42,7 +43,7 @@
 
 namespace ot {
 
-class RouterTable : public InstanceLocator
+class RouterTable : public InstanceLocator, private NonCopyable
 {
     friend class NeighborTable;
     class IteratorBuilder;

--- a/src/core/thread/src_match_controller.hpp
+++ b/src/core/thread/src_match_controller.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/error.h>
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 
 namespace ot {
 
@@ -65,7 +66,7 @@ class Child;
  * address or an extended/long address can be added to the source address match table.
  *
  */
-class SourceMatchController : public InstanceLocator
+class SourceMatchController : public InstanceLocator, private NonCopyable
 {
 public:
     /**

--- a/src/core/thread/time_sync_service.hpp
+++ b/src/core/thread/time_sync_service.hpp
@@ -41,6 +41,7 @@
 
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/timer.hpp"
 
@@ -50,7 +51,7 @@ namespace ot {
  * This class implements OpenThread Time Synchronization Service.
  *
  */
-class TimeSync : public InstanceLocator
+class TimeSync : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
 

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -41,6 +41,7 @@
 
 #include "common/locator.hpp"
 #include "common/message.hpp"
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/time_ticker.hpp"
 #include "common/timer.hpp"
@@ -89,7 +90,7 @@ namespace Utils {
  * This class implements a child supervisor.
  *
  */
-class ChildSupervisor : public InstanceLocator
+class ChildSupervisor : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
     friend class ot::TimeTicker;
@@ -191,7 +192,7 @@ public:
  * This class implements a child supervision listener.
  *
  */
-class SupervisionListener : public InstanceLocator
+class SupervisionListener : public InstanceLocator, private NonCopyable
 {
 public:
     /**
@@ -262,7 +263,7 @@ private:
 
 #else // #if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
 
-class SupervisionListener
+class SupervisionListener : private NonCopyable
 {
 public:
     SupervisionListener(otInstance &) {}

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -39,6 +39,7 @@
 #include <stdint.h>
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/timer.hpp"
 
@@ -48,7 +49,7 @@ class ThreadNetif;
 
 namespace Utils {
 
-class JamDetector : public InstanceLocator
+class JamDetector : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
 

--- a/src/core/utils/slaac_address.hpp
+++ b/src/core/utils/slaac_address.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/locator.hpp"
+#include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "net/netif.hpp"
 #include "thread/network_data.hpp"
@@ -57,7 +58,7 @@ namespace Utils {
  * This class implements the SLAAC utility for Thread protocol.
  *
  */
-class Slaac : public InstanceLocator
+class Slaac : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
 


### PR DESCRIPTION
Following #4973 , this PR applys `NonCopyable` for more classes that has unique object in an `Instance`.