### PR TITLE
[coap] allow max URI path length

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -666,7 +666,7 @@ exit:
 
 void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    char             uriPath[Resource::kMaxReceivedUriPath];
+    char             uriPath[Resource::kMaxReceivedUriPath + 1];
     char *           curUriPath     = uriPath;
     Message *        cachedResponse = nullptr;
     otError          error          = OT_ERROR_NOT_FOUND;
@@ -704,7 +704,7 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
             *curUriPath++ = '/';
         }
 
-        VerifyOrExit(curUriPath + optionLength < OT_ARRAY_END(uriPath), OT_NOOP);
+        VerifyOrExit(curUriPath + optionLength < OT_ARRAY_END(uriPath), error = OT_ERROR_PARSE);
 
         IgnoreError(iterator.ReadOptionValue(curUriPath));
         curUriPath += optionLength;


### PR DESCRIPTION
This PR:
- allow max URI path length of 32
- change error to `OT_ERROR_PARSE` (used to be `OT_ERROR_NOT_FOUND`)