### PR TITLE
[thread-cert] turn off OTBR NAT64 in 1.2 Backbone tests

### DIFF
--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -227,7 +227,7 @@ jobs:
       COVERAGE: 1
       MULTIPLY: 3
       PYTHONUNBUFFERED: 1
-      OTBR_COMMIT: "e05ad0ea47461bc7aa48858cf7e1d7a9c9044fed" # Sep 29, 2020
+      OTBR_COMMIT: "bf28f461fa2a8551f0a4161c04b87f7240856608" # Date:   Wed Oct 14 12:00:44 2020 +0800
     steps:
       - uses: actions/checkout@v2
       - name: Build OTBR Docker

--- a/script/test
+++ b/script/test
@@ -288,7 +288,11 @@ do_build_otbr_docker()
         rm -rf third_party/openthread/repo
         cp -r "${otdir}" third_party/openthread/repo
         rm -rf .git
-        docker build -t "${otbr_docker_image}" -f etc/docker/Dockerfile . --build-arg REFERENCE_DEVICE=1 --build-arg OT_BACKBONE_CI=1 --build-arg OTBR_OPTIONS="${otbr_options}"
+        docker build -t "${otbr_docker_image}" -f etc/docker/Dockerfile . \
+            --build-arg REFERENCE_DEVICE=1 \
+            --build-arg OT_BACKBONE_CI=1 \
+            --build-arg NAT64=0 \
+            --build-arg OTBR_OPTIONS="${otbr_options}"
     )
 
     rm -rf "${otbrdir}"


### PR DESCRIPTION
This PR fixes random fails in Thread 1.2 Backbone tests that uses OTBR Docker. 

The fails was caused by failing to start `tayga` service when there are many OTBR Dockers running. 
This PR turns off NAT64 feature of OTBR in 1.2 Backbone tests to avoid this issue since NAT64 is not useful for Backbone tests. 

Fixes https://github.com/openthread/openthread/issues/5651