### PR TITLE
[net-diag] invoke the callback when failed to get the response

### DIFF
--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -228,6 +228,7 @@ jobs:
       MULTIPLY: 3
       PYTHONUNBUFFERED: 1
       VERBOSE: 1
+      OTBR_COMMIT: "d18242b0af81494e3a3c996cd1b2ab3b001f247c" # Date:   Mon Oct 26 15:27:04 2020 +0800
     steps:
       - uses: actions/checkout@v2
       - name: Build OTBR Docker

--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -228,7 +228,7 @@ jobs:
       MULTIPLY: 3
       PYTHONUNBUFFERED: 1
       VERBOSE: 1
-      OTBR_COMMIT: "d18242b0af81494e3a3c996cd1b2ab3b001f247c" # Date:   Mon Oct 26 15:27:04 2020 +0800
+      OTBR_COMMIT: "3cf6ff1126dca96803252514691f40d0554046bf" # Date:   Mon Oct 26 15:27:04 2020 +0800
     steps:
       - uses: actions/checkout@v2
       - name: Build OTBR Docker

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (41)
+#define OPENTHREAD_API_VERSION (42)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/netdiag.h
+++ b/include/openthread/netdiag.h
@@ -283,13 +283,18 @@ otError otThreadGetNextDiagnosticTlv(const otMessage *      aMessage,
 /**
  * This function pointer is called when Network Diagnostic Get response is received.
  *
+ * @param[in]  aError        The error when failed to get the response.
  * @param[in]  aMessage      A pointer to the message buffer containing the received Network Diagnostic
- *                           Get response payload.
- * @param[in]  aMessageInfo  A pointer to the message info for @p aMessage.
+ *                           Get response payload. Available only when @p aError is `OT_ERROR_NONE`.
+ * @param[in]  aMessageInfo  A pointer to the message info for @p aMessage. Available only when
+ *                           @p aError is `OT_ERROR_NONE`.
  * @param[in]  aContext      A pointer to application-specific context.
  *
  */
-typedef void (*otReceiveDiagnosticGetCallback)(otMessage *aMessage, const otMessageInfo *aMessageInfo, void *aContext);
+typedef void (*otReceiveDiagnosticGetCallback)(otError              aError,
+                                               otMessage *          aMessage,
+                                               const otMessageInfo *aMessageInfo,
+                                               void *               aContext);
 
 /**
  * This function registers a callback to provide received raw Network Diagnostic Get response payload.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -4266,9 +4266,8 @@ void Interpreter::HandleDiagnosticGetResponse(otError aError, const otMessage *a
     uint16_t              length;
     otNetworkDiagTlv      diagTlv;
     otNetworkDiagIterator iterator = OT_NETWORK_DIAGNOSTIC_ITERATOR_INIT;
-    otError               error    = OT_ERROR_NONE;
 
-    SuccessOrExit(error = aError);
+    SuccessOrExit(aError);
 
     OutputFormat("DIAG_GET.rsp/ans: ");
 
@@ -4288,7 +4287,7 @@ void Interpreter::HandleDiagnosticGetResponse(otError aError, const otMessage *a
     OutputLine("");
 
     // Output Network Diagnostic TLV values in standard YAML format.
-    while ((error = otThreadGetNextDiagnosticTlv(aMessage, &iterator, &diagTlv)) == OT_ERROR_NONE)
+    while ((aError = otThreadGetNextDiagnosticTlv(aMessage, &iterator, &diagTlv)) == OT_ERROR_NONE)
     {
         uint16_t column = 0;
         switch (diagTlv.mType)
@@ -4365,13 +4364,13 @@ void Interpreter::HandleDiagnosticGetResponse(otError aError, const otMessage *a
         }
     }
 
-    if (error == OT_ERROR_NOT_FOUND)
+    if (aError == OT_ERROR_NOT_FOUND)
     {
-        error = OT_ERROR_NONE;
+        aError = OT_ERROR_NONE;
     }
 
 exit:
-    OutputResult(error);
+    OutputResult(aError);
 }
 
 void Interpreter::OutputSpaces(uint16_t aCount)

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -4249,28 +4249,35 @@ exit:
     return error;
 }
 
-void Interpreter::HandleDiagnosticGetResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo, void *aContext)
+void Interpreter::HandleDiagnosticGetResponse(otError              aError,
+                                              otMessage *          aMessage,
+                                              const otMessageInfo *aMessageInfo,
+                                              void *               aContext)
 {
     static_cast<Interpreter *>(aContext)->HandleDiagnosticGetResponse(
-        *aMessage, *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+        aError, aMessage, static_cast<const Ip6::MessageInfo *>(aMessageInfo));
 }
 
-void Interpreter::HandleDiagnosticGetResponse(const otMessage &aMessage, const Ip6::MessageInfo &)
+void Interpreter::HandleDiagnosticGetResponse(otError aError, const otMessage *aMessage, const Ip6::MessageInfo *)
 {
     uint8_t               buf[16];
     uint16_t              bytesToPrint;
     uint16_t              bytesPrinted = 0;
-    uint16_t              length       = otMessageGetLength(&aMessage) - otMessageGetOffset(&aMessage);
+    uint16_t              length;
     otNetworkDiagTlv      diagTlv;
     otNetworkDiagIterator iterator = OT_NETWORK_DIAGNOSTIC_ITERATOR_INIT;
     otError               error    = OT_ERROR_NONE;
 
+    SuccessOrExit(error = aError);
+
     OutputFormat("DIAG_GET.rsp/ans: ");
+
+    length = otMessageGetLength(aMessage) - otMessageGetOffset(aMessage);
 
     while (length > 0)
     {
         bytesToPrint = (length < sizeof(buf)) ? length : sizeof(buf);
-        otMessageRead(&aMessage, otMessageGetOffset(&aMessage) + bytesPrinted, buf, bytesToPrint);
+        otMessageRead(aMessage, otMessageGetOffset(aMessage) + bytesPrinted, buf, bytesToPrint);
 
         OutputBytes(buf, static_cast<uint8_t>(bytesToPrint));
 
@@ -4281,7 +4288,7 @@ void Interpreter::HandleDiagnosticGetResponse(const otMessage &aMessage, const I
     OutputLine("");
 
     // Output Network Diagnostic TLV values in standard YAML format.
-    while ((error = otThreadGetNextDiagnosticTlv(&aMessage, &iterator, &diagTlv)) == OT_ERROR_NONE)
+    while ((error = otThreadGetNextDiagnosticTlv(aMessage, &iterator, &diagTlv)) == OT_ERROR_NONE)
     {
         uint16_t column = 0;
         switch (diagTlv.mType)
@@ -4358,7 +4365,13 @@ void Interpreter::HandleDiagnosticGetResponse(const otMessage &aMessage, const I
         }
     }
 
-    OutputResult(error == OT_ERROR_NOT_FOUND ? OT_ERROR_NONE : error);
+    if (error == OT_ERROR_NOT_FOUND)
+    {
+        error = OT_ERROR_NONE;
+    }
+
+exit:
+    OutputResult(error);
 }
 
 void Interpreter::OutputSpaces(uint16_t aCount)

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -485,8 +485,11 @@ private:
     static void HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx, void *aContext);
 
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
-    void        HandleDiagnosticGetResponse(const otMessage &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    static void HandleDiagnosticGetResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo, void *aContext);
+    void HandleDiagnosticGetResponse(otError aError, const otMessage *aMessage, const Ip6::MessageInfo *aMessageInfo);
+    static void HandleDiagnosticGetResponse(otError              aError,
+                                            otMessage *          aMessage,
+                                            const otMessageInfo *aMessageInfo,
+                                            void *               aContext);
     void        OutputSpaces(uint16_t aCount);
     void        OutputMode(const otLinkModeConfig &aMode, uint16_t aColumn);
     void        OutputConnectivity(const otNetworkDiagConnectivity &aConnectivity, uint16_t aColumn);

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -142,7 +142,7 @@ void NetworkDiagnostic::HandleDiagnosticGetResponse(Coap::Message *         aMes
                                                     otError                 aResult)
 {
     SuccessOrExit(aResult);
-    VerifyOrExit(aMessage && aMessage->GetCode() == Coap::kCodeChanged, aResult = OT_ERROR_FAILED);
+    VerifyOrExit(aMessage->GetCode() == Coap::kCodeChanged, aResult = OT_ERROR_FAILED);
 
 exit:
     if (mReceiveDiagnosticGetCallback)

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -141,17 +141,20 @@ void NetworkDiagnostic::HandleDiagnosticGetResponse(Coap::Message *         aMes
                                                     const Ip6::MessageInfo *aMessageInfo,
                                                     otError                 aResult)
 {
-    VerifyOrExit(aResult == OT_ERROR_NONE);
-    VerifyOrExit(aMessage && aMessage->GetCode() == Coap::kCodeChanged);
+    otError error = OT_ERROR_FAILED;
 
-    otLogInfoNetDiag("Received diagnostic get response");
-
-    if (mReceiveDiagnosticGetCallback)
-    {
-        mReceiveDiagnosticGetCallback(aMessage, aMessageInfo, mReceiveDiagnosticGetCallbackContext);
-    }
+    SuccessOrExit(error = aResult);
+    VerifyOrExit(aMessage && aMessage->GetCode() == Coap::kCodeChanged, error = OT_ERROR_FAILED);
 
 exit:
+    if (mReceiveDiagnosticGetCallback)
+    {
+        mReceiveDiagnosticGetCallback(error, aMessage, aMessageInfo, mReceiveDiagnosticGetCallbackContext);
+    }
+    else
+    {
+        otLogDebgNetDiag("Received diagnostic get response, error = %s", otThreadErrorToString(error));
+    }
     return;
 }
 
@@ -171,7 +174,7 @@ void NetworkDiagnostic::HandleDiagnosticGetAnswer(Coap::Message &aMessage, const
 
     if (mReceiveDiagnosticGetCallback)
     {
-        mReceiveDiagnosticGetCallback(&aMessage, &aMessageInfo, mReceiveDiagnosticGetCallbackContext);
+        mReceiveDiagnosticGetCallback(OT_ERROR_NONE, &aMessage, &aMessageInfo, mReceiveDiagnosticGetCallbackContext);
     }
 
     SuccessOrExit(Get<Tmf::TmfAgent>().SendEmptyAck(aMessage, aMessageInfo));

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -141,19 +141,17 @@ void NetworkDiagnostic::HandleDiagnosticGetResponse(Coap::Message *         aMes
                                                     const Ip6::MessageInfo *aMessageInfo,
                                                     otError                 aResult)
 {
-    otError error = OT_ERROR_FAILED;
-
-    SuccessOrExit(error = aResult);
-    VerifyOrExit(aMessage && aMessage->GetCode() == Coap::kCodeChanged, error = OT_ERROR_FAILED);
+    SuccessOrExit(aResult);
+    VerifyOrExit(aMessage && aMessage->GetCode() == Coap::kCodeChanged, aResult = OT_ERROR_FAILED);
 
 exit:
     if (mReceiveDiagnosticGetCallback)
     {
-        mReceiveDiagnosticGetCallback(error, aMessage, aMessageInfo, mReceiveDiagnosticGetCallbackContext);
+        mReceiveDiagnosticGetCallback(aResult, aMessage, aMessageInfo, mReceiveDiagnosticGetCallbackContext);
     }
     else
     {
-        otLogDebgNetDiag("Received diagnostic get response, error = %s", otThreadErrorToString(error));
+        otLogDebgNetDiag("Received diagnostic get response, error = %s", otThreadErrorToString(aResult));
     }
     return;
 }


### PR DESCRIPTION
This PR fixes the bug that the Network Diagnostic callback is not called when we failed to get the response (e.g. the request timeouted). This results in no command output in the CLI.

Fixes https://github.com/openthread/ot-br-posix/issues/588.