### PR TITLE
[continuous-integration] kill ot-rcp and ot-cli in pty check

### DIFF
--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -43,6 +43,8 @@ at_exit()
     sudo killall expect || true
     sudo killall ot-ctl || true
     sudo killall ot-daemon || true
+    sudo killall ot-cli || true
+    sudo killall ot-rcp || true
     sudo killall socat || true
 
     exit $EXIT_CODE


### PR DESCRIPTION
This adds kill commands to POSIX pty check, to make sure all processes are stopped before the check completes. Fixes https://github.com/openthread/openthread/issues/5648.