### PR TITLE
[notifier] signal change to active/pending dataset + simplify 'Notifier::EventToString'

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (35)
+#define OPENTHREAD_API_VERSION (36)
 
 /**
  * @addtogroup api-instance
@@ -160,6 +160,8 @@ enum
     OT_CHANGED_THREAD_BACKBONE_ROUTER_STATE = 1 << 25, ///< Backbone Router state changed
     OT_CHANGED_THREAD_BACKBONE_ROUTER_LOCAL = 1 << 26, ///< Local Backbone Router configuration changed
     OT_CHANGED_JOINER_STATE                 = 1 << 27, ///< Joiner state changed
+    OT_CHANGED_ACTIVE_DATASET               = 1 << 28, ///< Active Operational Dataset changed
+    OT_CHANGED_PENDING_DATASET              = 1 << 29, ///< Pending Operational Dataset changed
 };
 
 /**

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -353,6 +353,14 @@ const char *Notifier::EventToString(Event aEvent) const
     case kEventJoinerStateChanged:
         retval = "JoinerState";
         break;
+
+    case kEventActiveDatasetChanged:
+        retval = "ActDset";
+        break;
+
+    case kEventPendingDatasetChanged:
+        retval = "PndDset";
+        break;
     }
 
     return retval;

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -239,128 +239,46 @@ const char *Notifier::EventToString(Event aEvent) const
     // To ensure no clipping of flag names in the logs, the returned
     // strings from this method should have shorter length than
     // `kMaxFlagNameLength` value.
+    static const char *kEventStrings[] = {
+        "Ip6+",              // kEventIp6AddressAdded                  (1 << 0)
+        "Ip6-",              // kEventIp6AddressRemoved                (1 << 1)
+        "Role",              // kEventThreadRoleChanged                (1 << 2)
+        "LLAddr",            // kEventThreadLinkLocalAddrChanged       (1 << 3)
+        "MLAddr",            // kEventThreadMeshLocalAddrChanged       (1 << 4)
+        "Rloc+",             // kEventThreadRlocAdded                  (1 << 5)
+        "Rloc-",             // kEventThreadRlocRemoved                (1 << 6)
+        "PartitionId",       // kEventThreadPartitionIdChanged         (1 << 7)
+        "KeySeqCntr",        // kEventThreadKeySeqCounterChanged       (1 << 8)
+        "NetData",           // kEventThreadNetdataChanged             (1 << 9)
+        "Child+",            // kEventThreadChildAdded                 (1 << 10)
+        "Child-",            // kEventThreadChildRemoved               (1 << 11)
+        "Ip6Mult+",          // kEventIp6MulticastSubscribed           (1 << 12)
+        "Ip6Mult-",          // kEventIp6MulticastUnsubscribed         (1 << 13)
+        "Channel",           // kEventThreadChannelChanged             (1 << 14)
+        "PanId",             // kEventThreadPanIdChanged               (1 << 15)
+        "NetName",           // kEventThreadNetworkNameChanged         (1 << 16)
+        "ExtPanId",          // kEventThreadExtPanIdChanged            (1 << 17)
+        "MstrKey",           // kEventMasterKeyChanged                 (1 << 18)
+        "PSKc",              // kEventPskcChanged                      (1 << 19)
+        "SecPolicy",         // kEventSecurityPolicyChanged            (1 << 20)
+        "CMNewChan",         // kEventChannelManagerNewChannelChanged  (1 << 21)
+        "ChanMask",          // kEventSupportedChannelMaskChanged      (1 << 22)
+        "CommissionerState", // kEventCommissionerStateChanged         (1 << 23)
+        "NetifState",        // kEventThreadNetifStateChanged          (1 << 24)
+        "BbrState",          // kEventThreadBackboneRouterStateChanged (1 << 25)
+        "BbrLocal",          // kEventThreadBackboneRouterLocalChanged (1 << 26)
+        "JoinerState",       // kEventJoinerStateChanged               (1 << 27)
+        "ActDset",           // kEventActiveDatasetChanged             (1 << 28)
+        "PndDset",           // kEventPendingDatasetChanged            (1 << 29)
+    };
 
-    switch (aEvent)
+    for (uint8_t index = 0; index < OT_ARRAY_LENGTH(kEventStrings); index++)
     {
-    case kEventIp6AddressAdded:
-        retval = "Ip6+";
-        break;
-
-    case kEventIp6AddressRemoved:
-        retval = "Ip6-";
-        break;
-
-    case kEventThreadRoleChanged:
-        retval = "Role";
-        break;
-
-    case kEventThreadLinkLocalAddrChanged:
-        retval = "LLAddr";
-        break;
-
-    case kEventThreadMeshLocalAddrChanged:
-        retval = "MLAddr";
-        break;
-
-    case kEventThreadRlocAdded:
-        retval = "Rloc+";
-        break;
-
-    case kEventThreadRlocRemoved:
-        retval = "Rloc-";
-        break;
-
-    case kEventThreadPartitionIdChanged:
-        retval = "PartitionId";
-        break;
-
-    case kEventThreadKeySeqCounterChanged:
-        retval = "KeySeqCntr";
-        break;
-
-    case kEventThreadNetdataChanged:
-        retval = "NetData";
-        break;
-
-    case kEventThreadChildAdded:
-        retval = "Child+";
-        break;
-
-    case kEventThreadChildRemoved:
-        retval = "Child-";
-        break;
-
-    case kEventIp6MulticastSubscribed:
-        retval = "Ip6Mult+";
-        break;
-
-    case kEventIp6MulticastUnsubscribed:
-        retval = "Ip6Mult-";
-        break;
-
-    case kEventThreadChannelChanged:
-        retval = "Channel";
-        break;
-
-    case kEventThreadPanIdChanged:
-        retval = "PanId";
-        break;
-
-    case kEventThreadNetworkNameChanged:
-        retval = "NetName";
-        break;
-
-    case kEventThreadExtPanIdChanged:
-        retval = "ExtPanId";
-        break;
-
-    case kEventMasterKeyChanged:
-        retval = "MstrKey";
-        break;
-
-    case kEventPskcChanged:
-        retval = "PSKc";
-        break;
-
-    case kEventSecurityPolicyChanged:
-        retval = "SecPolicy";
-        break;
-
-    case kEventChannelManagerNewChannelChanged:
-        retval = "CMNewChan";
-        break;
-
-    case kEventSupportedChannelMaskChanged:
-        retval = "ChanMask";
-        break;
-
-    case kEventCommissionerStateChanged:
-        retval = "CommissionerState";
-        break;
-
-    case kEventThreadNetifStateChanged:
-        retval = "NetifState";
-        break;
-
-    case kEventThreadBackboneRouterStateChanged:
-        retval = "BbrState";
-        break;
-
-    case kEventThreadBackboneRouterLocalChanged:
-        retval = "BbrLocal";
-        break;
-
-    case kEventJoinerStateChanged:
-        retval = "JoinerState";
-        break;
-
-    case kEventActiveDatasetChanged:
-        retval = "ActDset";
-        break;
-
-    case kEventPendingDatasetChanged:
-        retval = "PndDset";
-        break;
+        if (static_cast<uint32_t>(aEvent) == (1U << index))
+        {
+            retval = kEventStrings[index];
+            break;
+        }
     }
 
     return retval;

--- a/src/core/common/notifier.hpp
+++ b/src/core/common/notifier.hpp
@@ -62,7 +62,7 @@ namespace ot {
  * This enumeration type represents events emitted from OpenThread Notifier.
  *
  */
-enum Event
+enum Event : uint32_t
 {
     kEventIp6AddressAdded                  = OT_CHANGED_IP6_ADDRESS_ADDED,            ///< IPv6 address was added
     kEventIp6AddressRemoved                = OT_CHANGED_IP6_ADDRESS_REMOVED,          ///< IPv6 address was removed

--- a/src/core/common/notifier.hpp
+++ b/src/core/common/notifier.hpp
@@ -92,6 +92,8 @@ enum Event
     kEventThreadBackboneRouterStateChanged = OT_CHANGED_THREAD_BACKBONE_ROUTER_STATE, ///< Backbone Router state changed
     kEventThreadBackboneRouterLocalChanged = OT_CHANGED_THREAD_BACKBONE_ROUTER_LOCAL, ///< Local Backbone Router changed
     kEventJoinerStateChanged               = OT_CHANGED_JOINER_STATE,                 ///< Joiner state changed
+    kEventActiveDatasetChanged             = OT_CHANGED_ACTIVE_DATASET,               ///< Active Dataset changed
+    kEventPendingDatasetChanged            = OT_CHANGED_PENDING_DATASET,              ///< Pending Dataset changed
 };
 
 /**

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -336,6 +336,7 @@ private:
 
     bool IsActiveDataset(void) const { return GetType() == Dataset::kActive; }
     bool IsPendingDataset(void) const { return GetType() == Dataset::kPending; }
+    void SignalDatasetChange(void) const;
     void HandleDatasetUpdated(void);
     void SendSet(void);
     void SendGetResponse(const Coap::Message &   aRequest,


### PR DESCRIPTION
This PR contains two related commits:

**[notifier] signal change to active or pending Operational Dataset**

**[notifier] simplify 'EventToString()'**
    
This commit changes `EventToString()` to use an array instead of
`switch`. This helps with code size due to enumerator cases being
`uint32_t` bitmask values and therefore compliers may not be able to
optimize the `switch` statement as a table.
