### PR TITLE
[code-utils] enhance 'VerifyOrExit' to make action optional

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -344,7 +344,7 @@ otError Interpreter::ProcessBackboneRouterMgmtMlr(uint8_t aArgsLength, char **aA
 {
     otError error = OT_ERROR_INVALID_COMMAND;
 
-    VerifyOrExit(aArgsLength >= 1, OT_NOOP);
+    VerifyOrExit(aArgsLength >= 1);
 
     if (!strcmp(aArgs[0], "listener"))
     {
@@ -1528,7 +1528,7 @@ otError Interpreter::ProcessFake(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_INVALID_COMMAND;
 
-    VerifyOrExit(aArgsLength >= 1, OT_NOOP);
+    VerifyOrExit(aArgsLength >= 1);
 
     if (strcmp(aArgs[0], "/a/an") == 0)
     {
@@ -1943,7 +1943,7 @@ otError Interpreter::ProcessLinkMetrics(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_INVALID_COMMAND;
 
-    VerifyOrExit(aArgsLength >= 1, OT_NOOP);
+    VerifyOrExit(aArgsLength >= 1);
 
     if (strcmp(aArgs[0], "query") == 0)
     {
@@ -1961,7 +1961,7 @@ otError Interpreter::ProcessLinkMetricsQuery(uint8_t aArgsLength, char *aArgs[])
     otLinkMetrics linkMetrics;
     long          seriesId = 0;
 
-    VerifyOrExit(aArgsLength >= 2, OT_NOOP);
+    VerifyOrExit(aArgsLength >= 2);
 
     SuccessOrExit(error = ParseAsIp6Address(aArgs[0], address));
 
@@ -1969,7 +1969,7 @@ otError Interpreter::ProcessLinkMetricsQuery(uint8_t aArgsLength, char *aArgs[])
 
     if (strcmp(aArgs[1], "single") == 0)
     {
-        VerifyOrExit(aArgsLength == 3, OT_NOOP);
+        VerifyOrExit(aArgsLength == 3);
         for (char *arg = aArgs[2]; *arg != '\0'; arg++)
         {
             switch (*arg)
@@ -2592,8 +2592,8 @@ void Interpreter::HandleIcmpReceive(otMessage *          aMessage,
     uint32_t timestamp = 0;
     uint16_t dataSize;
 
-    VerifyOrExit(aIcmpHeader->mType == OT_ICMP6_TYPE_ECHO_REPLY, OT_NOOP);
-    VerifyOrExit((mPingIdentifier != 0) && (mPingIdentifier == HostSwap16(aIcmpHeader->mData.m16[0])), OT_NOOP);
+    VerifyOrExit(aIcmpHeader->mType == OT_ICMP6_TYPE_ECHO_REPLY);
+    VerifyOrExit((mPingIdentifier != 0) && (mPingIdentifier == HostSwap16(aIcmpHeader->mData.m16[0])));
 
     dataSize = otMessageGetLength(aMessage) - otMessageGetOffset(aMessage);
     OutputFormat("%u bytes from ", dataSize + static_cast<uint16_t>(sizeof(otIcmp6Header)));
@@ -2702,7 +2702,7 @@ void Interpreter::SendPing(void)
     messageInfo.mAllowZeroHopLimit = mPingAllowZeroHopLimit;
 
     message = otIp6NewMessage(mInstance, nullptr);
-    VerifyOrExit(message != nullptr, OT_NOOP);
+    VerifyOrExit(message != nullptr);
 
     SuccessOrExit(otMessageAppend(message, &timestamp, sizeof(timestamp)));
     SuccessOrExit(otMessageSetLength(message, mPingLength));
@@ -3922,7 +3922,7 @@ otError Interpreter::ProcessMacFilterAddress(uint8_t aArgsLength, char *aArgs[])
             SuccessOrExit(error = ParseAsHexString(aArgs[1], extAddr.m8));
             error = otLinkFilterAddAddress(mInstance, &extAddr);
 
-            VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY, OT_NOOP);
+            VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY);
 
             if (aArgsLength > 2)
             {
@@ -4130,7 +4130,7 @@ otError Interpreter::ProcessMacSend(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_INVALID_ARGS;
 
-    VerifyOrExit(aArgsLength == 1, OT_NOOP);
+    VerifyOrExit(aArgsLength == 1);
 
     if (strcmp(aArgs[0], "datarequest") == 0)
     {
@@ -4170,7 +4170,7 @@ void Interpreter::ProcessLine(char *aBuf, uint16_t aBufLength)
     uint8_t        aArgsLength = 0;
     const Command *command;
 
-    VerifyOrExit(aBuf != nullptr && StringLength(aBuf, aBufLength + 1) <= aBufLength, OT_NOOP);
+    VerifyOrExit(aBuf != nullptr && StringLength(aBuf, aBufLength + 1) <= aBufLength);
 
     VerifyOrExit(Utils::CmdLineParser::ParseCmd(aBuf, aArgsLength, aArgs, kMaxArgs) == OT_ERROR_NONE,
                  OutputLine("Error: too many args (max %d)", kMaxArgs));
@@ -4630,7 +4630,7 @@ extern "C" void otCliPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, cons
     OT_UNUSED_VARIABLE(aLogLevel);
     OT_UNUSED_VARIABLE(aLogRegion);
 
-    VerifyOrExit(Interpreter::IsInitialized(), OT_NOOP);
+    VerifyOrExit(Interpreter::IsInitialized());
 
     Interpreter::GetInterpreter().OutputFormatV(aFormat, aArgs);
     Interpreter::GetInterpreter().OutputLine("");

--- a/src/cli/cli_commissioner.cpp
+++ b/src/cli/cli_commissioner.cpp
@@ -425,7 +425,7 @@ otError Commissioner::Process(uint8_t aArgsLength, char *aArgs[])
     VerifyOrExit(aArgsLength != 0, IgnoreError(ProcessHelp(0, nullptr)));
 
     command = Utils::LookupTable::Find(aArgs[0], sCommands);
-    VerifyOrExit(command != nullptr, OT_NOOP);
+    VerifyOrExit(command != nullptr);
 
     error = (this->*command->mHandler)(aArgsLength, aArgs);
 

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -169,7 +169,7 @@ otError Dataset::Process(uint8_t aArgsLength, char *aArgs[])
     }
 
     command = Utils::LookupTable::Find(aArgs[0], sCommands);
-    VerifyOrExit(command != nullptr, OT_NOOP);
+    VerifyOrExit(command != nullptr);
 
     error = (this->*command->mHandler)(aArgsLength - 1, aArgs + 1);
 

--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -143,7 +143,7 @@ otError Joiner::Process(uint8_t aArgsLength, char *aArgs[])
     VerifyOrExit(aArgsLength != 0, IgnoreError(ProcessHelp(0, nullptr)));
 
     command = Utils::LookupTable::Find(aArgs[0], sCommands);
-    VerifyOrExit(command != nullptr, OT_NOOP);
+    VerifyOrExit(command != nullptr);
 
     error = (this->*command->mHandler)(aArgsLength, aArgs);
 

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -206,7 +206,7 @@ otError NetworkData::ProcessSteeringData(uint8_t aArgsLength, char *aArgs[])
     otExtAddress      addr;
     otJoinerDiscerner discerner;
 
-    VerifyOrExit((aArgsLength > 1) && (strcmp(aArgs[0], "check") == 0), OT_NOOP);
+    VerifyOrExit((aArgsLength > 1) && (strcmp(aArgs[0], "check") == 0));
 
     discerner.mLength = 0;
 
@@ -319,7 +319,7 @@ otError NetworkData::Process(uint8_t aArgsLength, char *aArgs[])
     VerifyOrExit(aArgsLength != 0, IgnoreError(ProcessHelp(0, nullptr)));
 
     command = Utils::LookupTable::Find(aArgs[0], sCommands);
-    VerifyOrExit(command != nullptr, OT_NOOP);
+    VerifyOrExit(command != nullptr);
 
     error = (this->*command->mHandler)(aArgsLength - 1, aArgs + 1);
 

--- a/src/cli/cli_uart.cpp
+++ b/src/cli/cli_uart.cpp
@@ -293,7 +293,7 @@ int Uart::Output(const char *aBuf, uint16_t aBufLength)
 
 void Uart::Send(void)
 {
-    VerifyOrExit(mSendLength == 0, OT_NOOP);
+    VerifyOrExit(mSendLength == 0);
 
     if (mTxLength > kTxBufferSize - mTxHead)
     {

--- a/src/core/api/tasklet_api.cpp
+++ b/src/core/api/tasklet_api.cpp
@@ -46,7 +46,7 @@ void otTaskletsProcess(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(otInstanceIsInitialized(aInstance), OT_NOOP);
+    VerifyOrExit(otInstanceIsInitialized(aInstance));
     instance.Get<TaskletScheduler>().ProcessQueuedTasklets();
 
 exit:
@@ -58,7 +58,7 @@ bool otTaskletsArePending(otInstance *aInstance)
     bool      retval   = false;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(otInstanceIsInitialized(aInstance), OT_NOOP);
+    VerifyOrExit(otInstanceIsInitialized(aInstance));
     retval = instance.Get<TaskletScheduler>().AreTaskletsPending();
 
 exit:

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -81,7 +81,7 @@ Local::Local(Instance &aInstance)
 
 void Local::SetEnabled(bool aEnable)
 {
-    VerifyOrExit(aEnable == (mState == OT_BACKBONE_ROUTER_STATE_DISABLED), OT_NOOP);
+    VerifyOrExit(aEnable == (mState == OT_BACKBONE_ROUTER_STATE_DISABLED));
 
     if (aEnable)
     {
@@ -104,7 +104,7 @@ exit:
 
 void Local::Reset(void)
 {
-    VerifyOrExit(mState != OT_BACKBONE_ROUTER_STATE_DISABLED, OT_NOOP);
+    VerifyOrExit(mState != OT_BACKBONE_ROUTER_STATE_DISABLED);
 
     if (RemoveService() == OT_ERROR_NONE)
     {
@@ -183,14 +183,13 @@ otError Local::AddService(bool aForce)
     uint8_t                               serviceData = NetworkData::ServiceTlv::kServiceDataBackboneRouter;
     NetworkData::BackboneRouterServerData serverData;
 
-    VerifyOrExit(mState != OT_BACKBONE_ROUTER_STATE_DISABLED && Get<Mle::Mle>().IsAttached(), OT_NOOP);
+    VerifyOrExit(mState != OT_BACKBONE_ROUTER_STATE_DISABLED && Get<Mle::Mle>().IsAttached());
 
     VerifyOrExit(aForce /* if register by force */ ||
-                     !Get<BackboneRouter::Leader>().HasPrimary() /* if no available Backbone Router service */ ||
-                     Get<BackboneRouter::Leader>().GetServer16() == Get<Mle::MleRouter>().GetRloc16()
+                 !Get<BackboneRouter::Leader>().HasPrimary() /* if no available Backbone Router service */ ||
+                 Get<BackboneRouter::Leader>().GetServer16() == Get<Mle::MleRouter>().GetRloc16()
                  /* If the device itself should be BBR. */
-                 ,
-                 OT_NOOP);
+    );
 
     serverData.SetSequenceNumber(mSequenceNumber);
     serverData.SetReregistrationDelay(mReregistrationDelay);
@@ -224,7 +223,7 @@ exit:
 
 void Local::SetState(BackboneRouterState aState)
 {
-    VerifyOrExit(mState != aState, OT_NOOP);
+    VerifyOrExit(mState != aState);
 
     if (mState == OT_BACKBONE_ROUTER_STATE_DISABLED)
     {
@@ -260,7 +259,7 @@ void Local::HandleBackboneRouterPrimaryUpdate(Leader::State aState, const Backbo
 {
     OT_UNUSED_VARIABLE(aState);
 
-    VerifyOrExit(mState != OT_BACKBONE_ROUTER_STATE_DISABLED && Get<Mle::MleRouter>().IsAttached(), OT_NOOP);
+    VerifyOrExit(mState != OT_BACKBONE_ROUTER_STATE_DISABLED && Get<Mle::MleRouter>().IsAttached());
 
     // Wait some jitter before trying to Register.
     if (aConfig.mServer16 == Mac::kShortAddrInvalid)
@@ -350,7 +349,7 @@ void Local::SetDomainPrefix(const NetworkData::OnMeshPrefixConfig &aConfig)
 
 void Local::ApplyMeshLocalPrefix(void)
 {
-    VerifyOrExit(IsEnabled(), OT_NOOP);
+    VerifyOrExit(IsEnabled());
 
     Get<ThreadNetif>().UnsubscribeMulticast(mAllNetworkBackboneRouters);
     mAllNetworkBackboneRouters.GetAddress().SetMulticastNetworkPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -474,13 +474,13 @@ bool Manager::ShouldForwardDuaToBackbone(const Ip6::Address &aAddress)
     Mac::ShortAddress rloc16;
     otError           error;
 
-    VerifyOrExit(Get<Local>().IsPrimary(), OT_NOOP);
-    VerifyOrExit(Get<Leader>().IsDomainUnicast(aAddress), OT_NOOP);
+    VerifyOrExit(Get<Local>().IsPrimary());
+    VerifyOrExit(Get<Leader>().IsDomainUnicast(aAddress));
 
-    VerifyOrExit(!mNdProxyTable.IsRegistered(aAddress.GetIid()), OT_NOOP);
+    VerifyOrExit(!mNdProxyTable.IsRegistered(aAddress.GetIid()));
 
     error = Get<AddressResolver>().Resolve(aAddress, rloc16, /* aAllowAddressQuery */ false);
-    VerifyOrExit(error != OT_ERROR_NONE || rloc16 == Get<Mle::MleRouter>().GetRloc16(), OT_NOOP);
+    VerifyOrExit(error != OT_ERROR_NONE || rloc16 == Get<Mle::MleRouter>().GetRloc16());
 
     // TODO: check if the DUA is an address of any Child?
     forwardToBackbone = true;

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -117,7 +117,7 @@ Message *CoapBase::NewMessage(const Message::Settings &aSettings)
 {
     Message *message = nullptr;
 
-    VerifyOrExit((message = static_cast<Message *>(Get<Ip6::Udp>().NewMessage(0, aSettings))) != nullptr, OT_NOOP);
+    VerifyOrExit((message = static_cast<Message *>(Get<Ip6::Udp>().NewMessage(0, aSettings))) != nullptr);
     message->SetOffset(0);
 
 exit:
@@ -561,7 +561,7 @@ void CoapBase::ProcessReceivedResponse(Message &aMessage, const Ip6::MessageInfo
 #endif
 
     request = FindRelatedRequest(aMessage, aMessageInfo, metadata);
-    VerifyOrExit(request != nullptr, OT_NOOP);
+    VerifyOrExit(request != nullptr);
 
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
     if (metadata.mObserve && request->IsRequest())
@@ -811,11 +811,11 @@ void ResponsesQueue::EnqueueResponse(Message &               aMessage,
     metadata.mDequeueTime = TimerMilli::GetNow() + aTxParameters.CalculateExchangeLifetime();
     metadata.mMessageInfo = aMessageInfo;
 
-    VerifyOrExit(FindMatchedResponse(aMessage, aMessageInfo) == nullptr, OT_NOOP);
+    VerifyOrExit(FindMatchedResponse(aMessage, aMessageInfo) == nullptr);
 
     UpdateQueue();
 
-    VerifyOrExit((responseCopy = aMessage.Clone()) != nullptr, OT_NOOP);
+    VerifyOrExit((responseCopy = aMessage.Clone()) != nullptr);
 
     VerifyOrExit(metadata.AppendTo(*responseCopy) == OT_ERROR_NONE, responseCopy->Free());
 
@@ -924,7 +924,7 @@ static uint32_t Multiply(uint32_t aValueA, uint32_t aValueB)
 {
     uint32_t result = 0;
 
-    VerifyOrExit(aValueA, OT_NOOP);
+    VerifyOrExit(aValueA);
 
     result = aValueA * aValueB;
     result = (result / aValueA == aValueB) ? result : 0;
@@ -993,7 +993,7 @@ otError Coap::Start(uint16_t aPort, otNetifIdentifier aNetifIdentifier)
     otError error        = OT_ERROR_NONE;
     bool    socketOpened = false;
 
-    VerifyOrExit(!mSocket.IsBound(), OT_NOOP);
+    VerifyOrExit(!mSocket.IsBound());
 
     SuccessOrExit(error = mSocket.Open(&Coap::HandleUdpReceive, this));
     socketOpened = true;
@@ -1014,7 +1014,7 @@ otError Coap::Stop(void)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mSocket.IsBound(), OT_NOOP);
+    VerifyOrExit(mSocket.IsBound());
 
     SuccessOrExit(error = mSocket.Close());
     ClearRequestsAndResponses();

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -364,7 +364,7 @@ Message *Message::Clone(uint16_t aLength) const
 {
     Message *message = static_cast<Message *>(ot::Message::Clone(aLength));
 
-    VerifyOrExit(message != nullptr, OT_NOOP);
+    VerifyOrExit(message != nullptr);
 
     message->GetHelpData() = GetHelpData();
 
@@ -501,7 +501,7 @@ otError Option::Iterator::Advance(void)
     uint16_t optionDelta;
     uint16_t optionLength;
 
-    VerifyOrExit(!IsDone(), OT_NOOP);
+    VerifyOrExit(!IsDone());
 
     error = Read(sizeof(uint8_t), &headerByte);
 
@@ -596,7 +596,7 @@ otError Option::Iterator::ReadExtendedOptionField(uint16_t &aValue)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aValue >= Message::kOption1ByteExtension, OT_NOOP);
+    VerifyOrExit(aValue >= Message::kOption1ByteExtension);
 
     if (aValue == Message::kOption1ByteExtension)
     {

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -171,8 +171,7 @@ void CoapSecure::HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength)
 {
     ot::Message *message = nullptr;
 
-    VerifyOrExit((message = Get<MessagePool>().New(Message::kTypeIp6, Message::GetHelpDataReserved())) != nullptr,
-                 OT_NOOP);
+    VerifyOrExit((message = Get<MessagePool>().New(Message::kTypeIp6, Message::GetHelpDataReserved())) != nullptr);
     SuccessOrExit(message->AppendBytes(aBuf, aLength));
 
     CoapBase::Receive(*message, mDtls.GetMessageInfo());
@@ -191,7 +190,7 @@ void CoapSecure::HandleTransmit(void)
     otError      error   = OT_ERROR_NONE;
     ot::Message *message = mTransmitQueue.GetHead();
 
-    VerifyOrExit(message != nullptr, OT_NOOP);
+    VerifyOrExit(message != nullptr);
     mTransmitQueue.Dequeue(*message);
 
     if (mTransmitQueue.GetHead() != nullptr)

--- a/src/core/common/code_utils.hpp
+++ b/src/core/common/code_utils.hpp
@@ -38,6 +38,8 @@
 
 #include <openthread/error.h>
 
+#include "common/arg_macros.hpp"
+
 /**
  * This macro calculates the number of elements in an array.
  *
@@ -109,25 +111,19 @@
     } while (false)
 
 /**
- * Use this macro in conjunction with `VerifyOrExit()` when no action is specified.
- *
- */
-#define OT_NOOP
-
-/**
  * This macro checks for the specified condition, which is expected to commonly be true, and both executes @a ... and
  * branches to the local label 'exit' if the condition is false.
  *
  * @param[in]  aCondition  A Boolean expression to be evaluated.
- * @param[in]  aAction     An expression or block to execute when the assertion fails.
+ * @param[in]  aAction     An optional expression or block to execute when the assertion fails.
  *
  */
-#define VerifyOrExit(aCondition, aAction) \
+#define VerifyOrExit(...)                 \
     do                                    \
     {                                     \
-        if (!(aCondition))                \
+        if (!(OT_FIRST_ARG(__VA_ARGS__))) \
         {                                 \
-            aAction;                      \
+            OT_SECOND_ARG(__VA_ARGS__);   \
             goto exit;                    \
         }                                 \
     } while (false)

--- a/src/core/common/extension_example.cpp
+++ b/src/core/common/extension_example.cpp
@@ -68,7 +68,7 @@ ExtensionBase &ExtensionBase::Init(Instance &aInstance)
 {
     ExtensionBase *ext = reinterpret_cast<ExtensionBase *>(&sExtensionRaw);
 
-    VerifyOrExit(!ext->mIsInitialized, OT_NOOP);
+    VerifyOrExit(!ext->mIsInitialized);
 
     ext = new (&sExtensionRaw) Extension(aInstance);
 

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -121,7 +121,7 @@ Instance &Instance::InitSingle(void)
 {
     Instance *instance = &Get();
 
-    VerifyOrExit(!instance->mIsInitialized, OT_NOOP);
+    VerifyOrExit(!instance->mIsInitialized);
 
     instance = new (&gInstanceRaw) Instance();
 
@@ -144,12 +144,12 @@ Instance *Instance::Init(void *aBuffer, size_t *aBufferSize)
 {
     Instance *instance = nullptr;
 
-    VerifyOrExit(aBufferSize != nullptr, OT_NOOP);
+    VerifyOrExit(aBufferSize != nullptr);
 
     // Make sure the input buffer is big enough
     VerifyOrExit(sizeof(Instance) <= *aBufferSize, *aBufferSize = sizeof(Instance));
 
-    VerifyOrExit(aBuffer != nullptr, OT_NOOP);
+    VerifyOrExit(aBuffer != nullptr);
 
     instance = new (aBuffer) Instance();
 
@@ -185,7 +185,7 @@ void Instance::AfterInit(void)
 
 void Instance::Finalize(void)
 {
-    VerifyOrExit(mIsInitialized, OT_NOOP);
+    VerifyOrExit(mIsInitialized);
 
     mIsInitialized = false;
 

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -60,7 +60,7 @@ Message *MessagePool::New(Message::Type aType, uint16_t aReserveHeader, Message:
     otError  error = OT_ERROR_NONE;
     Message *message;
 
-    VerifyOrExit((message = static_cast<Message *>(NewBuffer(aPriority))) != nullptr, OT_NOOP);
+    VerifyOrExit((message = static_cast<Message *>(NewBuffer(aPriority))) != nullptr);
 
     memset(message, 0, sizeof(*message));
     message->SetMessagePool(this);
@@ -113,7 +113,7 @@ Buffer *MessagePool::NewBuffer(Message::Priority aPriority)
 #else
 
     buffer = mBufferPool.Allocate();
-    VerifyOrExit(buffer != nullptr, OT_NOOP);
+    VerifyOrExit(buffer != nullptr);
 
     mNumFreeBuffers--;
     buffer->SetNextBuffer(nullptr);
@@ -343,7 +343,7 @@ otError Message::SetPriority(Priority aPriority)
     VerifyOrExit(priority < kNumPriorities, error = OT_ERROR_INVALID_ARGS);
 
     VerifyOrExit(IsInAQueue(), GetMetadata().mPriority = priority);
-    VerifyOrExit(GetMetadata().mPriority != priority, OT_NOOP);
+    VerifyOrExit(GetMetadata().mPriority != priority);
 
     if (GetMetadata().mInPriorityQ)
     {

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -58,7 +58,7 @@ otError Notifier::RegisterCallback(otStateChangedCallback aCallback, void *aCont
     otError           error          = OT_ERROR_NONE;
     ExternalCallback *unusedCallback = nullptr;
 
-    VerifyOrExit(aCallback != nullptr, OT_NOOP);
+    VerifyOrExit(aCallback != nullptr);
 
     for (ExternalCallback &callback : mExternalCallbacks)
     {
@@ -86,7 +86,7 @@ exit:
 
 void Notifier::RemoveCallback(otStateChangedCallback aCallback, void *aContext)
 {
-    VerifyOrExit(aCallback != nullptr, OT_NOOP);
+    VerifyOrExit(aCallback != nullptr);
 
     for (ExternalCallback &callback : mExternalCallbacks)
     {
@@ -125,7 +125,7 @@ void Notifier::EmitEvents(void)
 {
     Events events;
 
-    VerifyOrExit(!mEventsToSignal.IsEmpty(), OT_NOOP);
+    VerifyOrExit(!mEventsToSignal.IsEmpty());
 
     // Note that the callbacks may signal new events, so we create a
     // copy of `mEventsToSignal` and then clear it.
@@ -207,7 +207,7 @@ void Notifier::LogEvents(Events aEvents) const
 
     for (uint8_t bit = 0; bit < sizeof(Events::Flags) * CHAR_BIT; bit++)
     {
-        VerifyOrExit(flags != 0, OT_NOOP);
+        VerifyOrExit(flags != 0);
 
         if (flags & (1 << bit))
         {

--- a/src/core/common/random_manager.cpp
+++ b/src/core/common/random_manager.cpp
@@ -63,7 +63,7 @@ RandomManager::RandomManager(void)
 
     OT_ASSERT(sInitCount < 0xffff);
 
-    VerifyOrExit(sInitCount == 0, OT_NOOP);
+    VerifyOrExit(sInitCount == 0);
 
 #if !OPENTHREAD_RADIO
     sEntropy.Init();
@@ -87,7 +87,7 @@ RandomManager::~RandomManager(void)
     OT_ASSERT(sInitCount > 0);
 
     sInitCount--;
-    VerifyOrExit(sInitCount == 0, OT_NOOP);
+    VerifyOrExit(sInitCount == 0);
 
 #if !OPENTHREAD_RADIO
     sCtrDrbg.Deinit();
@@ -175,7 +175,7 @@ int RandomManager::Entropy::HandleMbedtlsEntropyPoll(void *         aData,
     SuccessOrExit(otPlatEntropyGet(reinterpret_cast<uint8_t *>(aOutput), static_cast<uint16_t>(aInLen)));
     rval = 0;
 
-    VerifyOrExit(aOutLen != nullptr, OT_NOOP);
+    VerifyOrExit(aOutLen != nullptr);
     *aOutLen = aInLen;
 
 exit:

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -126,7 +126,7 @@ void TimerScheduler::Add(Timer &aTimer, const AlarmApi &aAlarmApi)
 
 void TimerScheduler::Remove(Timer &aTimer, const AlarmApi &aAlarmApi)
 {
-    VerifyOrExit(aTimer.IsRunning(), OT_NOOP);
+    VerifyOrExit(aTimer.IsRunning());
 
     if (mTimerList.GetHead() == &aTimer)
     {
@@ -188,7 +188,7 @@ extern "C" void otPlatAlarmMilliFired(otInstance *aInstance)
 {
     Instance *instance = static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(otInstanceIsInitialized(aInstance), OT_NOOP);
+    VerifyOrExit(otInstanceIsInitialized(aInstance));
     instance->Get<TimerMilliScheduler>().ProcessTimers();
 
 exit:
@@ -224,7 +224,7 @@ extern "C" void otPlatAlarmMicroFired(otInstance *aInstance)
 {
     Instance *instance = static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(otInstanceIsInitialized(aInstance), OT_NOOP);
+    VerifyOrExit(otInstanceIsInitialized(aInstance));
     instance->Get<TimerMicroScheduler>().ProcessTimers();
 
 exit:

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -119,7 +119,7 @@ otError Tlv::Find(const Message &aMessage, uint8_t aType, uint16_t *aOffset, uin
     Tlv      tlv;
     uint32_t size;
 
-    VerifyOrExit(offset <= remainingLen, OT_NOOP);
+    VerifyOrExit(offset <= remainingLen);
     remainingLen -= offset;
 
     while (true)
@@ -136,11 +136,11 @@ otError Tlv::Find(const Message &aMessage, uint8_t aType, uint16_t *aOffset, uin
 
             SuccessOrExit(aMessage.Read(offset, extTlv));
 
-            VerifyOrExit(extTlv.GetLength() <= (remainingLen - sizeof(ExtendedTlv)), OT_NOOP);
+            VerifyOrExit(extTlv.GetLength() <= (remainingLen - sizeof(ExtendedTlv)));
             size = extTlv.GetSize();
         }
 
-        VerifyOrExit(size <= remainingLen, OT_NOOP);
+        VerifyOrExit(size <= remainingLen);
 
         if (tlv.GetType() == aType)
         {
@@ -295,7 +295,7 @@ otError Tlv::AppendTlv(Message &aMessage, uint8_t aType, const void *aValue, uin
     tlv.SetLength(aLength);
     SuccessOrExit(error = aMessage.Append(tlv));
 
-    VerifyOrExit(aLength > 0, OT_NOOP);
+    VerifyOrExit(aLength > 0);
     error = aMessage.AppendBytes(aValue, aLength);
 
 exit:

--- a/src/core/common/trickle_timer.cpp
+++ b/src/core/common/trickle_timer.cpp
@@ -90,7 +90,7 @@ void TrickleTimer::IndicateInconsistent(void)
 {
     // If interval is equal to minimum when an "inconsistent" event
     // is received, do nothing.
-    VerifyOrExit(mIsRunning && (mInterval != mIntervalMin), OT_NOOP);
+    VerifyOrExit(mIsRunning && (mInterval != mIntervalMin));
 
     mInterval = mIntervalMin;
     StartNewInterval();

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -488,7 +488,7 @@ void Diags::TransmitDone(otError aError)
         }
     }
 
-    VerifyOrExit(!mRepeatActive, OT_NOOP);
+    VerifyOrExit(!mRepeatActive);
     TransmitPacket();
 
 exit:

--- a/src/core/mac/channel_mask.cpp
+++ b/src/core/mac/channel_mask.cpp
@@ -78,7 +78,7 @@ uint8_t ChannelMask::ChooseRandomChannel(void) const
     uint8_t channel = kChannelIteratorFirst;
     uint8_t randomIndex;
 
-    VerifyOrExit(!IsEmpty(), OT_NOOP);
+    VerifyOrExit(!IsEmpty());
 
     randomIndex = Random::NonCrypto::GetUint8InRange(0, GetNumberOfChannels());
 

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -129,12 +129,12 @@ void DataPollHandler::HandleDataPoll(Mac::RxFrame &aFrame)
     Child *      child;
     uint16_t     indirectMsgCount;
 
-    VerifyOrExit(aFrame.GetSecurityEnabled(), OT_NOOP);
-    VerifyOrExit(!Get<Mle::MleRouter>().IsDetached(), OT_NOOP);
+    VerifyOrExit(aFrame.GetSecurityEnabled());
+    VerifyOrExit(!Get<Mle::MleRouter>().IsDetached());
 
     SuccessOrExit(aFrame.GetSrcAddr(macSource));
     child = Get<ChildTable>().FindChild(macSource, Child::kInStateValidOrRestoring);
-    VerifyOrExit(child != nullptr, OT_NOOP);
+    VerifyOrExit(child != nullptr);
 
     child->SetLastHeard(TimerMilli::GetNow());
     child->ResetLinkFailures();
@@ -203,7 +203,7 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, otError aError
 {
     Child *child = mIndirectTxChild;
 
-    VerifyOrExit(child != nullptr, OT_NOOP);
+    VerifyOrExit(child != nullptr);
 
     mIndirectTxChild = nullptr;
     HandleSentFrame(aFrame, aError, *child);

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -71,7 +71,7 @@ const Neighbor &DataPollSender::GetParent(void) const
 
 void DataPollSender::StartPolling(void)
 {
-    VerifyOrExit(!mEnabled, OT_NOOP);
+    VerifyOrExit(!mEnabled);
 
     OT_ASSERT(!Get<Mle::MleRouter>().IsRxOnWhenIdle());
 
@@ -203,7 +203,7 @@ void DataPollSender::HandlePollSent(Mac::TxFrame &aFrame, otError aError)
     Mac::Address macDest;
     bool         shouldRecalculatePollPeriod = false;
 
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
 
     if (!aFrame.IsEmpty())
     {
@@ -287,7 +287,7 @@ void DataPollSender::HandlePollTimeout(void)
     // a data poll indicated that a frame was pending, but no frame
     // was received after timeout interval.
 
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
 
     mPollTimeoutCounter++;
 
@@ -308,7 +308,7 @@ exit:
 
 void DataPollSender::ProcessFrame(const Mac::RxFrame &aFrame)
 {
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
 
     mPollTimeoutCounter = 0;
 
@@ -380,15 +380,15 @@ void DataPollSender::SendFastPolls(uint8_t aNumFastPolls)
 
 void DataPollSender::StopFastPolls(void)
 {
-    VerifyOrExit(mFastPollsUsers != 0, OT_NOOP);
+    VerifyOrExit(mFastPollsUsers != 0);
 
     // If `mFastPollsUsers` hits the max, let it be cleared
     // from `HandlePollSent()` (after all fast polls are sent).
-    VerifyOrExit(mFastPollsUsers < kMaxFastPollsUsers, OT_NOOP);
+    VerifyOrExit(mFastPollsUsers < kMaxFastPollsUsers);
 
     mFastPollsUsers--;
 
-    VerifyOrExit(mFastPollsUsers == 0, OT_NOOP);
+    VerifyOrExit(mFastPollsUsers == 0);
 
     mRemainingFastPolls = 0;
     ScheduleNextPoll(kRecalculatePollPeriod);

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -308,7 +308,7 @@ void Mac::PerformActiveScan(void)
 
 void Mac::ReportActiveScanResult(const RxFrame *aBeaconFrame)
 {
-    VerifyOrExit(mActiveScanHandler != nullptr, OT_NOOP);
+    VerifyOrExit(mActiveScanHandler != nullptr);
 
     if (aBeaconFrame == nullptr)
     {
@@ -365,7 +365,7 @@ void Mac::ReportEnergyScanResult(int8_t aRssi)
 {
     EnergyScanResult result;
 
-    VerifyOrExit((mEnergyScanHandler != nullptr) && (aRssi != kInvalidRssiValue), OT_NOOP);
+    VerifyOrExit((mEnergyScanHandler != nullptr) && (aRssi != kInvalidRssiValue));
 
     result.mChannel = mScanChannel;
     result.mMaxRssi = aRssi;
@@ -384,7 +384,7 @@ void Mac::EnergyScanDone(int8_t aEnergyScanMaxRssi)
 
 void Mac::SetRxOnWhenIdle(bool aRxOnWhenIdle)
 {
-    VerifyOrExit(mRxOnWhenIdle != aRxOnWhenIdle, OT_NOOP);
+    VerifyOrExit(mRxOnWhenIdle != aRxOnWhenIdle);
 
     mRxOnWhenIdle = aRxOnWhenIdle;
 
@@ -430,7 +430,7 @@ otError Mac::SetPanChannel(uint8_t aChannel)
 
     mCcaSuccessRateTracker.Reset();
 
-    VerifyOrExit(!mUsingTemporaryChannel, OT_NOOP);
+    VerifyOrExit(!mUsingTemporaryChannel);
 
     mRadioChannel = mPanChannel;
 
@@ -551,8 +551,8 @@ void Mac::SetExtendedPanId(const ExtendedPanId &aExtendedPanId)
 
 void Mac::RequestDirectFrameTransmission(void)
 {
-    VerifyOrExit(IsEnabled(), OT_NOOP);
-    VerifyOrExit(!mPendingTransmitDataDirect && (mOperation != kOperationTransmitDataDirect), OT_NOOP);
+    VerifyOrExit(IsEnabled());
+    VerifyOrExit(!mPendingTransmitDataDirect && (mOperation != kOperationTransmitDataDirect));
 
     StartOperation(kOperationTransmitDataDirect);
 
@@ -563,8 +563,8 @@ exit:
 #if OPENTHREAD_FTD
 void Mac::RequestIndirectFrameTransmission(void)
 {
-    VerifyOrExit(IsEnabled(), OT_NOOP);
-    VerifyOrExit(!mPendingTransmitDataIndirect && (mOperation != kOperationTransmitDataIndirect), OT_NOOP);
+    VerifyOrExit(IsEnabled());
+    VerifyOrExit(!mPendingTransmitDataIndirect && (mOperation != kOperationTransmitDataIndirect));
 
     StartOperation(kOperationTransmitDataIndirect);
 
@@ -575,7 +575,7 @@ exit:
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
 void Mac::RequestCslFrameTransmission(uint32_t aDelay)
 {
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
 
     mCslTxFireTime = mTimer.GetNow() + aDelay;
 
@@ -627,7 +627,7 @@ void Mac::UpdateIdleMode(void)
 {
     bool shouldSleep = !mRxOnWhenIdle && !mPromiscuous;
 
-    VerifyOrExit(mOperation == kOperationIdle, OT_NOOP);
+    VerifyOrExit(mOperation == kOperationIdle);
 
     if (!mRxOnWhenIdle)
     {
@@ -751,7 +751,7 @@ void Mac::HandleOperationTask(Tasklet &aTasklet)
 
 void Mac::PerformNextOperation(void)
 {
-    VerifyOrExit(mOperation == kOperationIdle, OT_NOOP);
+    VerifyOrExit(mOperation == kOperationIdle);
 
     if (!IsEnabled())
     {
@@ -983,7 +983,7 @@ bool Mac::ShouldSendBeacon(void) const
 {
     bool shouldSend = false;
 
-    VerifyOrExit(IsEnabled(), OT_NOOP);
+    VerifyOrExit(IsEnabled());
 
     shouldSend = IsBeaconEnabled();
 
@@ -1020,7 +1020,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
     uint8_t           keyIdMode;
     const ExtAddress *extAddress = nullptr;
 
-    VerifyOrExit(aFrame.GetSecurityEnabled(), OT_NOOP);
+    VerifyOrExit(aFrame.GetSecurityEnabled());
 
     IgnoreError(aFrame.GetKeyIdMode(keyIdMode));
 
@@ -1063,12 +1063,12 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     // Transmit security will be processed after time IE content is updated.
-    VerifyOrExit(aFrame.GetTimeIeOffset() == 0, OT_NOOP);
+    VerifyOrExit(aFrame.GetTimeIeOffset() == 0);
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     // Transmit security will be processed after time IE content is updated.
-    VerifyOrExit(aFrame.mInfo.mTxInfo.mCslPresent == 0, OT_NOOP);
+    VerifyOrExit(aFrame.mInfo.mTxInfo.mCslPresent == 0);
 #endif
 
     aFrame.ProcessTransmitAesCcm(*extAddress);
@@ -1241,7 +1241,7 @@ void Mac::RecordFrameTransmitStatus(const TxFrame &aFrame,
     Address   dstAddr;
     Neighbor *neighbor;
 
-    VerifyOrExit(!aFrame.IsEmpty(), OT_NOOP);
+    VerifyOrExit(!aFrame.IsEmpty());
 
     IgnoreError(aFrame.GetDstAddr(dstAddr));
     neighbor = Get<NeighborTable>().FindNeighbor(dstAddr);
@@ -1554,7 +1554,7 @@ otError Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Ne
     VerifyOrExit(aFrame.GetSecurityEnabled(), error = OT_ERROR_NONE);
 
     IgnoreError(aFrame.GetSecurityLevel(securityLevel));
-    VerifyOrExit(securityLevel == Frame::kSecEncMic32, OT_NOOP);
+    VerifyOrExit(securityLevel == Frame::kSecEncMic32);
 
     IgnoreError(aFrame.GetFrameCounter(frameCounter));
     otLogDebgMac("Rx security - frame counter %u", frameCounter);
@@ -1569,7 +1569,7 @@ otError Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Ne
         break;
 
     case Frame::kKeyIdMode1:
-        VerifyOrExit(aNeighbor != nullptr, OT_NOOP);
+        VerifyOrExit(aNeighbor != nullptr);
 
         IgnoreError(aFrame.GetKeyId(keyid));
         keyid--;
@@ -1601,14 +1601,14 @@ otError Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Ne
 
         if (aNeighbor->IsStateValid())
         {
-            VerifyOrExit(keySequence >= aNeighbor->GetKeySequence(), OT_NOOP);
+            VerifyOrExit(keySequence >= aNeighbor->GetKeySequence());
 
             if (keySequence == aNeighbor->GetKeySequence())
             {
                 // If frame counter is one off, then frame is a duplicate.
                 VerifyOrExit((frameCounter + 1) != aNeighbor->GetLinkFrameCounter(), error = OT_ERROR_DUPLICATED);
 
-                VerifyOrExit(frameCounter >= aNeighbor->GetLinkFrameCounter(), OT_NOOP);
+                VerifyOrExit(frameCounter >= aNeighbor->GetLinkFrameCounter());
             }
         }
 
@@ -1672,10 +1672,10 @@ otError Mac::ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame)
     const Key * macKey;
 
     VerifyOrExit(aAckFrame.GetSecurityEnabled(), error = OT_ERROR_NONE);
-    VerifyOrExit(aAckFrame.IsVersion2015(), OT_NOOP);
+    VerifyOrExit(aAckFrame.IsVersion2015());
 
     IgnoreError(aAckFrame.GetSecurityLevel(securityLevel));
-    VerifyOrExit(securityLevel == Frame::kSecEncMic32, OT_NOOP);
+    VerifyOrExit(securityLevel == Frame::kSecEncMic32);
 
     IgnoreError(aAckFrame.GetKeyIdMode(keyIdMode));
     VerifyOrExit(keyIdMode == Frame::kKeyIdMode1, error = OT_ERROR_NONE);
@@ -1683,7 +1683,7 @@ otError Mac::ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame)
     IgnoreError(aTxFrame.GetKeyId(txKeyId));
     IgnoreError(aAckFrame.GetKeyId(ackKeyId));
 
-    VerifyOrExit(txKeyId == ackKeyId, OT_NOOP);
+    VerifyOrExit(txKeyId == ackKeyId);
 
     IgnoreError(aAckFrame.GetFrameCounter(frameCounter));
     otLogDebgMac("Rx security - Ack frame counter %u", frameCounter);
@@ -1710,7 +1710,7 @@ otError Mac::ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame)
         srcAddr.SetExtended(neighbor->GetExtAddress());
     }
 
-    VerifyOrExit(srcAddr.IsExtended() && neighbor != nullptr, OT_NOOP);
+    VerifyOrExit(srcAddr.IsExtended() && neighbor != nullptr);
 
     ackKeyId--;
 
@@ -1733,7 +1733,7 @@ otError Mac::ProcessEnhAckSecurity(TxFrame &aTxFrame, RxFrame &aAckFrame)
 
     if (neighbor->IsStateValid())
     {
-        VerifyOrExit(frameCounter >= neighbor->GetLinkAckFrameCounter(), OT_NOOP);
+        VerifyOrExit(frameCounter >= neighbor->GetLinkAckFrameCounter());
     }
 
     error = aAckFrame.ProcessReceiveAesCcm(srcAddr.GetExtended(), *macKey);
@@ -1878,7 +1878,7 @@ void Mac::HandleReceivedFrame(RxFrame *aFrame, otError aError)
         // so the duplicate frame will not be passed to next
         // layer (`MeshForwarder`).
 
-        VerifyOrExit(mOperation == kOperationWaitingForData, OT_NOOP);
+        VerifyOrExit(mOperation == kOperationWaitingForData);
 
         // Fall through
 
@@ -2273,7 +2273,7 @@ uint8_t Mac::GetTimeIeOffset(const Frame &aFrame)
     const uint8_t *cur    = nullptr;
 
     cur = reinterpret_cast<const uint8_t *>(aFrame.GetTimeIe());
-    VerifyOrExit(cur != nullptr, OT_NOOP);
+    VerifyOrExit(cur != nullptr);
 
     cur += sizeof(VendorIeHeader);
     offset = static_cast<uint8_t>(cur - base);
@@ -2286,7 +2286,7 @@ exit:
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 void Mac::SetCslChannel(uint8_t aChannel)
 {
-    VerifyOrExit(GetCslChannel() != aChannel, OT_NOOP);
+    VerifyOrExit(GetCslChannel() != aChannel);
 
     mSubMac.SetCslChannel(aChannel);
     mSubMac.SetCslChannelSpecified(aChannel != 0 ? true : false);
@@ -2314,7 +2314,7 @@ void Mac::SetCslPeriod(uint16_t aPeriod)
 
 void Mac::SetCslTimeout(uint32_t aTimeout)
 {
-    VerifyOrExit(GetCslTimeout() != aTimeout, OT_NOOP);
+    VerifyOrExit(GetCslTimeout() != aTimeout);
 
     mSubMac.SetCslTimeout(aTimeout);
 
@@ -2342,7 +2342,7 @@ void Mac::ProcessCsl(const RxFrame &aFrame, const Address &aSrcAddr)
     Child *        child = Get<ChildTable>().FindChild(aSrcAddr, Child::kInStateAnyExceptInvalid);
     const CslIe *  csl;
 
-    VerifyOrExit(cur != nullptr && child != nullptr && aFrame.GetSecurityEnabled(), OT_NOOP);
+    VerifyOrExit(cur != nullptr && child != nullptr && aFrame.GetSecurityEnabled());
 
     csl = reinterpret_cast<const CslIe *>(cur + sizeof(HeaderIe));
 
@@ -2373,7 +2373,7 @@ otError Mac::AppendHeaderIe(bool aIsTimeSync, TxFrame &aFrame) const
     otError      error   = OT_ERROR_NONE;
     uint8_t      ieCount = 0;
 
-    VerifyOrExit(aFrame.IsVersion2015() && aFrame.IsIePresent(), OT_NOOP);
+    VerifyOrExit(aFrame.IsVersion2015() && aFrame.IsIePresent());
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     if (aIsTimeSync)

--- a/src/core/mac/mac_filter.cpp
+++ b/src/core/mac/mac_filter.cpp
@@ -162,7 +162,7 @@ void Filter::RemoveRssIn(const ExtAddress &aExtAddress)
 {
     FilterEntry *entry = FindEntry(aExtAddress);
 
-    VerifyOrExit(entry != nullptr, OT_NOOP);
+    VerifyOrExit(entry != nullptr);
 
     entry->mRssIn = kFixedRssDisabled;
 

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -556,7 +556,7 @@ otError Frame::GetKeyId(uint8_t &aKeyId) const
     uint8_t keySourceLength;
     uint8_t index = FindSecurityHeaderIndex();
 
-    VerifyOrExit(index != kInvalidIndex, OT_NOOP);
+    VerifyOrExit(index != kInvalidIndex);
 
     keySourceLength = GetKeySourceLength(mPsdu[index] & kKeyIdModeMask);
 
@@ -608,7 +608,7 @@ bool Frame::IsDataRequestCommand(void) const
     bool    isDataRequest = false;
     uint8_t commandId;
 
-    VerifyOrExit(GetType() == kFcfFrameMacCmd, OT_NOOP);
+    VerifyOrExit(GetType() == kFcfFrameMacCmd);
     SuccessOrExit(GetCommandId(commandId));
     isDataRequest = (commandId == kMacCmdDataRequest);
 
@@ -626,7 +626,7 @@ uint8_t Frame::GetFooterLength(void) const
     uint8_t footerLength = static_cast<uint8_t>(GetFcsSize());
     uint8_t index        = FindSecurityHeaderIndex();
 
-    VerifyOrExit(index != kInvalidIndex, OT_NOOP);
+    VerifyOrExit(index != kInvalidIndex);
     footerLength += CalculateMicSize(mPsdu[index]);
 
 exit:
@@ -682,7 +682,7 @@ uint8_t Frame::SkipSecurityHeaderIndex(void) const
 {
     uint8_t index = SkipAddrFieldIndex();
 
-    VerifyOrExit(index != kInvalidIndex, OT_NOOP);
+    VerifyOrExit(index != kInvalidIndex);
 
     if (GetSecurityEnabled())
     {
@@ -811,7 +811,7 @@ uint8_t Frame::FindPayloadIndex(void) const
 
     uint16_t index = SkipSecurityHeaderIndex();
 
-    VerifyOrExit(index != kInvalidIndex, OT_NOOP);
+    VerifyOrExit(index != kInvalidIndex);
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
     if (IsIePresent())
@@ -914,7 +914,7 @@ const uint8_t *Frame::GetHeaderIe(uint8_t aIeId) const
     // `FindPayloadIndex()` verifies that Header IE(s) in frame (if present)
     // are well-formed.
 
-    VerifyOrExit((index != kInvalidIndex) && (payloadIndex != kInvalidIndex), OT_NOOP);
+    VerifyOrExit((index != kInvalidIndex) && (payloadIndex != kInvalidIndex));
 
     while (index <= payloadIndex)
     {
@@ -940,7 +940,7 @@ void Frame::SetCslIe(uint16_t aCslPeriod, uint16_t aCslPhase)
     uint8_t *cur = GetHeaderIe(Frame::kHeaderIeCsl);
     CslIe *  csl;
 
-    VerifyOrExit(cur != nullptr, OT_NOOP);
+    VerifyOrExit(cur != nullptr);
 
     csl = reinterpret_cast<CslIe *>(cur + sizeof(HeaderIe));
     csl->SetPeriod(aCslPeriod);
@@ -957,7 +957,7 @@ const TimeIe *Frame::GetTimeIe(void) const
     const uint8_t *cur    = nullptr;
 
     cur = GetHeaderIe(kHeaderIeVendor);
-    VerifyOrExit(cur != nullptr, OT_NOOP);
+    VerifyOrExit(cur != nullptr);
 
     cur += sizeof(HeaderIe);
 
@@ -1002,7 +1002,7 @@ void TxFrame::ProcessTransmitAesCcm(const ExtAddress &aExtAddress)
     uint8_t        tagLength;
     Crypto::AesCcm aesCcm;
 
-    VerifyOrExit(GetSecurityEnabled(), OT_NOOP);
+    VerifyOrExit(GetSecurityEnabled());
 
     SuccessOrExit(GetSecurityLevel(securityLevel));
     SuccessOrExit(GetFrameCounter(frameCounter));
@@ -1191,7 +1191,7 @@ otError RxFrame::ProcessReceiveAesCcm(const ExtAddress &aExtAddress, const Key &
     aesCcm.Finalize(tag);
 
 #ifndef FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION
-    VerifyOrExit(memcmp(tag, GetFooter(), tagLength) == 0, OT_NOOP);
+    VerifyOrExit(memcmp(tag, GetFooter(), tagLength) == 0);
 #endif
 
     error = OT_ERROR_NONE;

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -154,7 +154,7 @@ otError SubMac::Enable(void)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mState == kStateDisabled, OT_NOOP);
+    VerifyOrExit(mState == kStateDisabled);
 
     SuccessOrExit(error = Get<Radio>().Enable());
     SuccessOrExit(error = Get<Radio>().Sleep());
@@ -312,12 +312,12 @@ void SubMac::ProcessTransmitSecurity(void)
     const ExtAddress *extAddress = nullptr;
     uint8_t           keyIdMode;
 
-    VerifyOrExit(ShouldHandleTransmitSecurity(), OT_NOOP);
-    VerifyOrExit(mTransmitFrame.GetSecurityEnabled(), OT_NOOP);
-    VerifyOrExit(!mTransmitFrame.IsSecurityProcessed(), OT_NOOP);
+    VerifyOrExit(ShouldHandleTransmitSecurity());
+    VerifyOrExit(mTransmitFrame.GetSecurityEnabled());
+    VerifyOrExit(!mTransmitFrame.IsSecurityProcessed());
 
     SuccessOrExit(mTransmitFrame.GetKeyIdMode(keyIdMode));
-    VerifyOrExit(keyIdMode == Frame::kKeyIdMode1, OT_NOOP);
+    VerifyOrExit(keyIdMode == Frame::kKeyIdMode1);
 
     mTransmitFrame.SetAesKey(GetCurrentMacKey());
 
@@ -334,7 +334,7 @@ void SubMac::ProcessTransmitSecurity(void)
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     // Transmit security will be processed after time IE content is updated.
-    VerifyOrExit(mTransmitFrame.GetTimeIeOffset() == 0, OT_NOOP);
+    VerifyOrExit(mTransmitFrame.GetTimeIeOffset() == 0);
 #endif
 
     mTransmitFrame.ProcessTransmitAesCcm(*extAddress);
@@ -418,9 +418,9 @@ void SubMac::BeginTransmit(void)
     OT_UNUSED_VARIABLE(error);
 
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-    VerifyOrExit(mState == kStateCsmaBackoff || mState == kStateCslTransmit, OT_NOOP);
+    VerifyOrExit(mState == kStateCsmaBackoff || mState == kStateCslTransmit);
 #else
-    VerifyOrExit(mState == kStateCsmaBackoff, OT_NOOP);
+    VerifyOrExit(mState == kStateCsmaBackoff);
 #endif
 
     mTransmitFrame.SetCsmaCaEnabled(mTransmitFrame.mInfo.mTxInfo.mPeriod == 0);
@@ -538,7 +538,7 @@ void SubMac::UpdateFrameCounterOnTxDone(const TxFrame &aFrame)
 
     OT_UNUSED_VARIABLE(allowError);
 
-    VerifyOrExit(!ShouldHandleTransmitSecurity() && aFrame.GetSecurityEnabled(), OT_NOOP);
+    VerifyOrExit(!ShouldHandleTransmitSecurity() && aFrame.GetSecurityEnabled());
 
     // In an FTD/MTD build, if/when link-raw is enabled, the `TxFrame`
     // is prepared and given by user and may not necessarily follow 15.4
@@ -554,7 +554,7 @@ void SubMac::UpdateFrameCounterOnTxDone(const TxFrame &aFrame)
 #endif
 
     VerifyOrExit(aFrame.GetKeyIdMode(keyIdMode) == OT_ERROR_NONE, OT_ASSERT(allowError));
-    VerifyOrExit(keyIdMode == Frame::kKeyIdMode1, OT_NOOP);
+    VerifyOrExit(keyIdMode == Frame::kKeyIdMode1);
 
     VerifyOrExit(aFrame.GetFrameCounter(frameCounter) == OT_ERROR_NONE, OT_ASSERT(allowError));
     UpdateFrameCounter(frameCounter);
@@ -694,7 +694,7 @@ bool SubMac::ShouldHandleTransmitSecurity(void) const
     VerifyOrExit(!RadioSupportsTransmitSecurity(), swTxSecurity = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NOOP);
+    VerifyOrExit(Get<LinkRaw>().IsEnabled());
 #endif
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE || OPENTHREAD_RADIO
@@ -712,7 +712,7 @@ bool SubMac::ShouldHandleCsmaBackOff(void) const
     VerifyOrExit(!RadioSupportsCsmaBackoff(), swCsma = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NOOP);
+    VerifyOrExit(Get<LinkRaw>().IsEnabled());
 #endif
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE || OPENTHREAD_RADIO
@@ -730,7 +730,7 @@ bool SubMac::ShouldHandleAckTimeout(void) const
     VerifyOrExit(!RadioSupportsAckTimeout(), swAckTimeout = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NOOP);
+    VerifyOrExit(Get<LinkRaw>().IsEnabled());
 #endif
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE || OPENTHREAD_RADIO
@@ -748,7 +748,7 @@ bool SubMac::ShouldHandleRetries(void) const
     VerifyOrExit(!RadioSupportsRetries(), swRetries = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NOOP);
+    VerifyOrExit(Get<LinkRaw>().IsEnabled());
 #endif
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE || OPENTHREAD_RADIO
@@ -766,7 +766,7 @@ bool SubMac::ShouldHandleEnergyScan(void) const
     VerifyOrExit(!RadioSupportsEnergyScan(), swEnergyScan = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NOOP);
+    VerifyOrExit(Get<LinkRaw>().IsEnabled());
 #endif
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE || OPENTHREAD_RADIO
@@ -784,7 +784,7 @@ bool SubMac::ShouldHandleTransmitTargetTime(void) const
     VerifyOrExit(!RadioSupportsTransmitTiming(), swTxDelay = false);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-    VerifyOrExit(Get<LinkRaw>().IsEnabled(), OT_NOOP);
+    VerifyOrExit(Get<LinkRaw>().IsEnabled());
 #endif
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE || OPENTHREAD_RADIO
@@ -827,7 +827,7 @@ void SubMac::SetMacKey(uint8_t    aKeyIdMode,
         break;
     }
 
-    VerifyOrExit(!ShouldHandleTransmitSecurity(), OT_NOOP);
+    VerifyOrExit(!ShouldHandleTransmitSecurity());
 
     Get<Radio>().SetMacKey(aKeyIdMode, aKeyId, aPrevKey, aCurrKey, aNextKey);
 
@@ -846,7 +846,7 @@ void SubMac::SetFrameCounter(uint32_t aFrameCounter)
 {
     mFrameCounter = aFrameCounter;
 
-    VerifyOrExit(!ShouldHandleTransmitSecurity(), OT_NOOP);
+    VerifyOrExit(!ShouldHandleTransmitSecurity());
 
     Get<Radio>().SetMacFrameCounter(aFrameCounter);
 
@@ -932,7 +932,7 @@ void SubMac::SetCslChannel(uint8_t aChannel)
 
 void SubMac::SetCslPeriod(uint16_t aPeriod)
 {
-    VerifyOrExit(mCslPeriod != aPeriod, OT_NOOP);
+    VerifyOrExit(mCslPeriod != aPeriod);
 
     mCslPeriod = aPeriod;
 

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -343,10 +343,10 @@ BorderAgent::BorderAgent(Instance &aInstance)
 
 void BorderAgent::HandleNotifierEvents(Events aEvents)
 {
-    VerifyOrExit(aEvents.ContainsAny(kEventThreadRoleChanged | kEventCommissionerStateChanged), OT_NOOP);
+    VerifyOrExit(aEvents.ContainsAny(kEventThreadRoleChanged | kEventCommissionerStateChanged));
 
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-    VerifyOrExit(Get<MeshCoP::Commissioner>().IsDisabled(), OT_NOOP);
+    VerifyOrExit(Get<MeshCoP::Commissioner>().IsDisabled());
 #endif
 
     if (Get<Mle::MleRouter>().IsAttached())
@@ -503,7 +503,7 @@ void BorderAgent::HandleRelayTransmit(const Coap::Message &aMessage)
     Ip6::MessageInfo messageInfo;
     uint16_t         offset = 0;
 
-    VerifyOrExit(aMessage.IsNonConfirmablePostRequest(), OT_NOOP);
+    VerifyOrExit(aMessage.IsNonConfirmablePostRequest());
 
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kJoinerRouterLocator, joinerRouterRloc));
 
@@ -696,7 +696,7 @@ void BorderAgent::SetState(otBorderAgentState aState)
 
 void BorderAgent::ApplyMeshLocalPrefix(void)
 {
-    VerifyOrExit(mState == OT_BORDER_AGENT_STATE_ACTIVE, OT_NOOP);
+    VerifyOrExit(mState == OT_BORDER_AGENT_STATE_ACTIVE);
 
     if (Get<ThreadNetif>().HasUnicastAddress(mCommissionerAloc))
     {

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -112,7 +112,7 @@ void Commissioner::SignalJoinerEvent(JoinerEvent aEvent, const Joiner *aJoiner) 
     Mac::ExtAddress joinerId;
     bool            noJoinerId = false;
 
-    VerifyOrExit((mJoinerCallback != nullptr) && (aJoiner != nullptr), OT_NOOP);
+    VerifyOrExit((mJoinerCallback != nullptr) && (aJoiner != nullptr));
 
     aJoiner->CopyToJoinerInfo(joinerInfo);
 
@@ -306,7 +306,7 @@ otError Commissioner::Start(otCommissionerStateCallback  aStateCallback,
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
     error = Get<MeshCoP::BorderAgent>().Stop();
-    VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY, OT_NOOP);
+    VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY);
 #endif
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().Start(SendRelayTransmit, this));
@@ -733,7 +733,7 @@ void Commissioner::HandleMgmtCommissionerGetResponse(Coap::Message *         aMe
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == Coap::kCodeChanged, OT_NOOP);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == Coap::kCodeChanged);
     otLogInfoMeshCoP("received MGMT_COMMISSIONER_GET response");
 
 exit:
@@ -814,7 +814,7 @@ void Commissioner::HandleMgmtCommissionerSetResponse(Coap::Message *         aMe
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == Coap::kCodeChanged, OT_NOOP);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == Coap::kCodeChanged);
     otLogInfoMeshCoP("received MGMT_COMMISSIONER_SET response");
 
 exit:
@@ -871,7 +871,7 @@ void Commissioner::HandleLeaderPetitionResponse(Coap::Message *         aMessage
     uint8_t state;
     bool    retransmit = false;
 
-    VerifyOrExit(mState != kStateActive, OT_NOOP);
+    VerifyOrExit(mState != kStateActive);
     VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == Coap::kCodeChanged,
                  retransmit = (mState == kStatePetition));
 
@@ -965,7 +965,7 @@ void Commissioner::HandleLeaderKeepAliveResponse(Coap::Message *         aMessag
 
     uint8_t state;
 
-    VerifyOrExit(mState == kStateActive, OT_NOOP);
+    VerifyOrExit(mState == kStateActive);
     VerifyOrExit(aResult == OT_ERROR_NONE && aMessage->GetCode() == Coap::kCodeChanged,
                  IgnoreError(Stop(/* aResign */ false)));
 
@@ -1000,7 +1000,7 @@ void Commissioner::HandleRelayReceive(Coap::Message &aMessage, const Ip6::Messag
 
     VerifyOrExit(mState == kStateActive, error = OT_ERROR_INVALID_STATE);
 
-    VerifyOrExit(aMessage.IsNonConfirmablePostRequest(), OT_NOOP);
+    VerifyOrExit(aMessage.IsNonConfirmablePostRequest());
 
     SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kJoinerUdpPort, joinerPort));
     SuccessOrExit(error = Tlv::FindTlv(aMessage, Tlv::kJoinerIid, &joinerIid, sizeof(joinerIid)));
@@ -1018,7 +1018,7 @@ void Commissioner::HandleRelayReceive(Coap::Message &aMessage, const Ip6::Messag
         mJoinerIid.ConvertToExtAddress(receivedId);
 
         joiner = FindBestMatchingJoinerEntry(receivedId);
-        VerifyOrExit(joiner != nullptr, OT_NOOP);
+        VerifyOrExit(joiner != nullptr);
 
         Get<Coap::CoapSecure>().SetPsk(joiner->mPskd);
         mActiveJoiner = joiner;
@@ -1028,7 +1028,7 @@ void Commissioner::HandleRelayReceive(Coap::Message &aMessage, const Ip6::Messag
     }
     else
     {
-        VerifyOrExit(mJoinerIid == joinerIid, OT_NOOP);
+        VerifyOrExit(mJoinerIid == joinerIid);
     }
 
     mJoinerPort = joinerPort;
@@ -1057,7 +1057,7 @@ void Commissioner::HandleDatasetChanged(void *aContext, otMessage *aMessage, con
 
 void Commissioner::HandleDatasetChanged(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    VerifyOrExit(aMessage.IsConfirmablePostRequest(), OT_NOOP);
+    VerifyOrExit(aMessage.IsConfirmablePostRequest());
 
     otLogInfoMeshCoP("received dataset changed");
 
@@ -1131,7 +1131,7 @@ void Commissioner::SendJoinFinalizeResponse(const Coap::Message &aRequest, State
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
 
-    VerifyOrExit(message->GetLength() <= sizeof(buf), OT_NOOP);
+    VerifyOrExit(message->GetLength() <= sizeof(buf));
     message->ReadBytes(message->GetOffset(), buf, message->GetLength() - message->GetOffset());
     otDumpCertMeshCoP("[THCI] direction=send | type=JOIN_FIN.rsp |", buf, message->GetLength() - message->GetOffset());
 #endif
@@ -1206,7 +1206,7 @@ exit:
 
 void Commissioner::ApplyMeshLocalPrefix(void)
 {
-    VerifyOrExit(mState == kStateActive, OT_NOOP);
+    VerifyOrExit(mState == kStateActive);
 
     Get<ThreadNetif>().RemoveUnicastAddress(mCommissionerAloc);
     mCommissionerAloc.GetAddress().SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -292,13 +292,13 @@ const Timestamp *Dataset::GetTimestamp(void) const
     if (mType == kActive)
     {
         const ActiveTimestampTlv *tlv = GetTlv<ActiveTimestampTlv>();
-        VerifyOrExit(tlv != nullptr, OT_NOOP);
+        VerifyOrExit(tlv != nullptr);
         timestamp = static_cast<const Timestamp *>(tlv);
     }
     else
     {
         const PendingTimestampTlv *tlv = GetTlv<PendingTimestampTlv>();
-        VerifyOrExit(tlv != nullptr, OT_NOOP);
+        VerifyOrExit(tlv != nullptr);
         timestamp = static_cast<const Timestamp *>(tlv);
     }
 
@@ -382,7 +382,7 @@ void Dataset::RemoveTlv(Tlv::Type aType)
 {
     Tlv *tlv;
 
-    VerifyOrExit((tlv = GetTlv(aType)) != nullptr, OT_NOOP);
+    VerifyOrExit((tlv = GetTlv(aType)) != nullptr);
     RemoveTlv(tlv);
 
 exit:
@@ -395,7 +395,7 @@ otError Dataset::AppendMleDatasetTlv(Message &aMessage) const
     Mle::Tlv       tlv;
     Mle::Tlv::Type type;
 
-    VerifyOrExit(mLength > 0, OT_NOOP);
+    VerifyOrExit(mLength > 0);
 
     type = (mType == kActive ? Mle::Tlv::kActiveDataset : Mle::Tlv::kPendingDataset);
 

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -106,7 +106,7 @@ otError DatasetLocal::Read(Dataset &aDataset) const
     else
     {
         delayTimer = aDataset.GetTlv<DelayTimerTlv>();
-        VerifyOrExit(delayTimer, OT_NOOP);
+        VerifyOrExit(delayTimer);
 
         elapsed = TimerMilli::GetNow() - mUpdateTime;
 

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -237,7 +237,7 @@ otError DatasetManager::GetChannelMask(Mac::ChannelMask &aChannelMask) const
 
     channelMaskTlv = dataset.GetTlv<ChannelMaskTlv>();
     VerifyOrExit(channelMaskTlv != nullptr, error = OT_ERROR_NOT_FOUND);
-    VerifyOrExit((mask = channelMaskTlv->GetChannelMask()) != 0, OT_NOOP);
+    VerifyOrExit((mask = channelMaskTlv->GetChannelMask()) != 0);
 
     aChannelMask.SetMask(mask & Get<Mac::Mac>().GetSupportedChannelMask().GetMask());
 
@@ -360,7 +360,7 @@ void DatasetManager::HandleGet(const Coap::Message &aMessage, const Ip6::Message
     }
 
     // MGMT_PENDING_GET.rsp must include Delay Timer TLV (Thread 1.1.1 Section 8.7.5.4)
-    VerifyOrExit(length > 0 && strcmp(mUriGet, UriPath::kPendingGet) == 0, OT_NOOP);
+    VerifyOrExit(length > 0 && strcmp(mUriGet, UriPath::kPendingGet) == 0);
 
     for (uint8_t i = 0; i < length; i++)
     {

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -92,18 +92,18 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
     channel.SetLength(0);
     pendingTimestamp.SetLength(0);
 
-    VerifyOrExit(Get<Mle::MleRouter>().IsLeader(), OT_NOOP);
+    VerifyOrExit(Get<Mle::MleRouter>().IsLeader());
 
     // verify that TLV data size is less than maximum TLV value size
     while (offset < aMessage.GetLength())
     {
         SuccessOrExit(aMessage.Read(offset, tlv));
-        VerifyOrExit(tlv.GetLength() <= Dataset::kMaxValueSize, OT_NOOP);
+        VerifyOrExit(tlv.GetLength() <= Dataset::kMaxValueSize);
         offset += sizeof(tlv) + tlv.GetLength();
     }
 
     // verify that does not overflow dataset buffer
-    VerifyOrExit((offset - aMessage.GetOffset()) <= Dataset::kMaxSize, OT_NOOP);
+    VerifyOrExit((offset - aMessage.GetOffset()) <= Dataset::kMaxSize);
 
     type = (strcmp(mUriSet, UriPath::kActiveSet) == 0 ? Tlv::kActiveTimestamp : Tlv::kPendingTimestamp);
 
@@ -112,23 +112,23 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
         ExitNow();
     }
 
-    VerifyOrExit(activeTimestamp.IsValid(), OT_NOOP);
+    VerifyOrExit(activeTimestamp.IsValid());
 
     if (Tlv::FindTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == OT_ERROR_NONE)
     {
-        VerifyOrExit(pendingTimestamp.IsValid(), OT_NOOP);
+        VerifyOrExit(pendingTimestamp.IsValid());
     }
 
     // verify the request includes a timestamp that is ahead of the locally stored value
     timestamp = (type == Tlv::kActiveTimestamp) ? static_cast<Timestamp *>(&activeTimestamp)
                                                 : static_cast<Timestamp *>(&pendingTimestamp);
 
-    VerifyOrExit(mLocal.Compare(timestamp) > 0, OT_NOOP);
+    VerifyOrExit(mLocal.Compare(timestamp) > 0);
 
     // check channel
     if (Tlv::FindTlv(aMessage, Tlv::kChannel, sizeof(channel), channel) == OT_ERROR_NONE)
     {
-        VerifyOrExit(channel.IsValid(), OT_NOOP);
+        VerifyOrExit(channel.IsValid());
 
         if (channel.GetChannel() != Get<Mac::Mac>().GetPanChannel())
         {
@@ -167,7 +167,7 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
         // no change to master key, active timestamp must be ahead
         const Timestamp *localActiveTimestamp = Get<ActiveDataset>().GetTimestamp();
 
-        VerifyOrExit(localActiveTimestamp == nullptr || localActiveTimestamp->Compare(activeTimestamp) > 0, OT_NOOP);
+        VerifyOrExit(localActiveTimestamp == nullptr || localActiveTimestamp->Compare(activeTimestamp) > 0);
     }
 
     // check commissioner session id
@@ -180,11 +180,11 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
         localId = static_cast<const CommissionerSessionIdTlv *>(
             Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kCommissionerSessionId));
 
-        VerifyOrExit(localId != nullptr && localId->GetCommissionerSessionId() == sessionId, OT_NOOP);
+        VerifyOrExit(localId != nullptr && localId->GetCommissionerSessionId() == sessionId);
     }
 
     // verify an MGMT_ACTIVE_SET.req from a Commissioner does not affect connectivity
-    VerifyOrExit(!isUpdateFromCommissioner || type == Tlv::kPendingTimestamp || !doesAffectConnectivity, OT_NOOP);
+    VerifyOrExit(!isUpdateFromCommissioner || type == Tlv::kPendingTimestamp || !doesAffectConnectivity);
 
     if (isUpdateFromCommissioner)
     {
@@ -251,7 +251,7 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
 
         localSessionId = static_cast<const CommissionerSessionIdTlv *>(
             Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kCommissionerSessionId));
-        VerifyOrExit(localSessionId != nullptr, OT_NOOP);
+        VerifyOrExit(localSessionId != nullptr);
 
         SuccessOrExit(
             Get<Mle::MleRouter>().GetCommissionerAloc(destination, localSessionId->GetCommissionerSessionId()));
@@ -510,7 +510,7 @@ void PendingDataset::ApplyActiveDataset(const Timestamp &aTimestamp, Coap::Messa
     uint16_t offset = aMessage.GetOffset();
     Dataset  dataset(mLocal.GetType());
 
-    VerifyOrExit(Get<Mle::MleRouter>().IsAttached(), OT_NOOP);
+    VerifyOrExit(Get<Mle::MleRouter>().IsAttached());
 
     while (offset < aMessage.GetLength())
     {

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -191,8 +191,7 @@ void Dtls::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageI
     default:
         // Once DTLS session is started, communicate only with a peer.
         VerifyOrExit((mMessageInfo.GetPeerAddr() == aMessageInfo.GetPeerAddr()) &&
-                         (mMessageInfo.GetPeerPort() == aMessageInfo.GetPeerPort()),
-                     OT_NOOP);
+                     (mMessageInfo.GetPeerPort() == aMessageInfo.GetPeerPort()));
         break;
     }
 
@@ -261,7 +260,7 @@ otError Dtls::Setup(bool aClient)
 
     rval = mbedtls_ssl_config_defaults(&mConf, aClient ? MBEDTLS_SSL_IS_CLIENT : MBEDTLS_SSL_IS_SERVER,
                                        MBEDTLS_SSL_TRANSPORT_DATAGRAM, MBEDTLS_SSL_PRESET_DEFAULT);
-    VerifyOrExit(rval == 0, OT_NOOP);
+    VerifyOrExit(rval == 0);
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
     if (mVerifyPeerCertificate && mCipherSuites[0] == MBEDTLS_TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8)
@@ -297,14 +296,14 @@ otError Dtls::Setup(bool aClient)
     if (!aClient)
     {
         rval = mbedtls_ssl_cookie_setup(&mCookieCtx, mbedtls_ctr_drbg_random, Random::Crypto::MbedTlsContextGet());
-        VerifyOrExit(rval == 0, OT_NOOP);
+        VerifyOrExit(rval == 0);
 
         mbedtls_ssl_conf_dtls_cookies(&mConf, mbedtls_ssl_cookie_write, mbedtls_ssl_cookie_check, &mCookieCtx);
     }
 #endif
 
     rval = mbedtls_ssl_setup(&mSsl, &mConf);
-    VerifyOrExit(rval == 0, OT_NOOP);
+    VerifyOrExit(rval == 0);
 
     mbedtls_ssl_set_bio(&mSsl, this, &Dtls::HandleMbedtlsTransmit, HandleMbedtlsReceive, nullptr);
     mbedtls_ssl_set_timer_cb(&mSsl, this, &Dtls::HandleMbedtlsSetTimer, HandleMbedtlsGetTimer);
@@ -319,7 +318,7 @@ otError Dtls::Setup(bool aClient)
         rval = SetApplicationCoapSecureKeys();
     }
 #endif
-    VerifyOrExit(rval == 0, OT_NOOP);
+    VerifyOrExit(rval == 0);
 
     mReceiveMessage = nullptr;
     mMessageSubType = Message::kSubTypeNone;
@@ -363,7 +362,7 @@ int Dtls::SetApplicationCoapSecureKeys(void)
         {
             rval = mbedtls_x509_crt_parse(&mCaChain, static_cast<const unsigned char *>(mCaChainSrc),
                                           static_cast<size_t>(mCaChainLength));
-            VerifyOrExit(rval == 0, OT_NOOP);
+            VerifyOrExit(rval == 0);
             mbedtls_ssl_conf_ca_chain(&mConf, &mCaChain, nullptr);
         }
 
@@ -371,12 +370,12 @@ int Dtls::SetApplicationCoapSecureKeys(void)
         {
             rval = mbedtls_x509_crt_parse(&mOwnCert, static_cast<const unsigned char *>(mOwnCertSrc),
                                           static_cast<size_t>(mOwnCertLength));
-            VerifyOrExit(rval == 0, OT_NOOP);
+            VerifyOrExit(rval == 0);
             rval = mbedtls_pk_parse_key(&mPrivateKey, static_cast<const unsigned char *>(mPrivateKeySrc),
                                         static_cast<size_t>(mPrivateKeyLength), nullptr, 0);
-            VerifyOrExit(rval == 0, OT_NOOP);
+            VerifyOrExit(rval == 0);
             rval = mbedtls_ssl_conf_own_cert(&mConf, &mOwnCert, &mPrivateKey);
-            VerifyOrExit(rval == 0, OT_NOOP);
+            VerifyOrExit(rval == 0);
         }
 #endif
         break;
@@ -385,7 +384,7 @@ int Dtls::SetApplicationCoapSecureKeys(void)
 #ifdef MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
         rval = mbedtls_ssl_conf_psk(&mConf, static_cast<const unsigned char *>(mPreSharedKey), mPreSharedKeyLength,
                                     static_cast<const unsigned char *>(mPreSharedKeyIdentity), mPreSharedKeyIdLength);
-        VerifyOrExit(rval == 0, OT_NOOP);
+        VerifyOrExit(rval == 0);
 #endif
         break;
 
@@ -417,7 +416,7 @@ void Dtls::Close(void)
 
 void Dtls::Disconnect(void)
 {
-    VerifyOrExit(mState == kStateConnecting || mState == kStateConnected, OT_NOOP);
+    VerifyOrExit(mState == kStateConnecting || mState == kStateConnected);
 
     mbedtls_ssl_close_notify(&mSsl);
     mState = kStateCloseNotify;

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -120,14 +120,14 @@ void EnergyScanClient::HandleReport(Coap::Message &aMessage, const Ip6::MessageI
         uint8_t                list[OPENTHREAD_CONFIG_TMF_ENERGY_SCAN_MAX_RESULTS];
     } OT_TOOL_PACKED_END energyList;
 
-    VerifyOrExit(aMessage.IsConfirmablePostRequest(), OT_NOOP);
+    VerifyOrExit(aMessage.IsConfirmablePostRequest());
 
     otLogInfoMeshCoP("received energy scan report");
 
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NOOP);
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
 
     SuccessOrExit(MeshCoP::Tlv::FindTlv(aMessage, MeshCoP::Tlv::kEnergyList, sizeof(energyList), energyList.tlv));
-    VerifyOrExit(energyList.tlv.IsValid(), OT_NOOP);
+    VerifyOrExit(energyList.tlv.IsValid());
 
     if (mCallback != nullptr)
     {

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -103,7 +103,7 @@ otError Joiner::ClearDiscerner(void)
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(mState == kStateIdle, error = OT_ERROR_INVALID_STATE);
-    VerifyOrExit(!mDiscerner.IsEmpty(), OT_NOOP);
+    VerifyOrExit(!mDiscerner.IsEmpty());
 
     mDiscerner.Clear();
     SetIdFromIeeeEui64();
@@ -274,7 +274,7 @@ void Joiner::HandleDiscoverResult(Mle::DiscoverScanner::ScanResult *aResult, voi
 
 void Joiner::HandleDiscoverResult(Mle::DiscoverScanner::ScanResult *aResult)
 {
-    VerifyOrExit(mState == kStateDiscover, OT_NOOP);
+    VerifyOrExit(mState == kStateDiscover);
 
     if (aResult != nullptr)
     {
@@ -319,7 +319,7 @@ void Joiner::SaveDiscoveredJoinerRouter(const Mle::DiscoverScanner::ScanResult &
         }
     }
 
-    VerifyOrExit(entry < end, OT_NOOP);
+    VerifyOrExit(entry < end);
 
     // Shift elements in array to make room for the new one.
     memmove(entry + 1, entry,
@@ -404,7 +404,7 @@ void Joiner::HandleSecureCoapClientConnect(bool aConnected, void *aContext)
 
 void Joiner::HandleSecureCoapClientConnect(bool aConnected)
 {
-    VerifyOrExit(mState == kStateConnect, OT_NOOP);
+    VerifyOrExit(mState == kStateConnect);
 
     if (aConnected)
     {
@@ -489,7 +489,7 @@ exit:
 
 void Joiner::FreeJoinerFinalizeMessage(void)
 {
-    VerifyOrExit(mState == kStateIdle && mFinalizeMessage != nullptr, OT_NOOP);
+    VerifyOrExit(mState == kStateIdle && mFinalizeMessage != nullptr);
 
     mFinalizeMessage->Free();
     mFinalizeMessage = nullptr;
@@ -533,8 +533,7 @@ void Joiner::HandleJoinerFinalizeResponse(Coap::Message &         aMessage,
     uint8_t state;
 
     VerifyOrExit(mState == kStateConnected && aResult == OT_ERROR_NONE && aMessage.IsAck() &&
-                     aMessage.GetCode() == Coap::kCodeChanged,
-                 OT_NOOP);
+                 aMessage.GetCode() == Coap::kCodeChanged);
 
     SuccessOrExit(Tlv::FindUint8Tlv(aMessage, Tlv::kState, state));
 
@@ -686,7 +685,7 @@ void Joiner::LogCertMessage(const char *aText, const Coap::Message &aMessage) co
 {
     uint8_t buf[OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE];
 
-    VerifyOrExit(aMessage.GetLength() <= sizeof(buf), OT_NOOP);
+    VerifyOrExit(aMessage.GetLength() <= sizeof(buf));
     aMessage.ReadBytes(aMessage.GetOffset(), buf, aMessage.GetLength() - aMessage.GetOffset());
 
     otDumpCertMeshCoP(aText, buf, aMessage.GetLength() - aMessage.GetOffset());

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -74,13 +74,13 @@ void JoinerRouter::HandleNotifierEvents(Events aEvents)
 
 void JoinerRouter::Start(void)
 {
-    VerifyOrExit(Get<Mle::MleRouter>().IsFullThreadDevice(), OT_NOOP);
+    VerifyOrExit(Get<Mle::MleRouter>().IsFullThreadDevice());
 
     if (Get<NetworkData::Leader>().IsJoiningEnabled())
     {
         uint16_t port = GetJoinerUdpPort();
 
-        VerifyOrExit(!mSocket.IsBound(), OT_NOOP);
+        VerifyOrExit(!mSocket.IsBound());
 
         IgnoreError(mSocket.Open(&JoinerRouter::HandleUdpReceive, this));
         IgnoreError(mSocket.Bind(port));
@@ -89,7 +89,7 @@ void JoinerRouter::Start(void)
     }
     else
     {
-        VerifyOrExit(mSocket.IsBound(), OT_NOOP);
+        VerifyOrExit(mSocket.IsBound());
 
         IgnoreError(Get<Ip6::Filter>().RemoveUnsecurePort(mSocket.GetSockName().mPort));
 
@@ -109,7 +109,7 @@ uint16_t JoinerRouter::GetJoinerUdpPort(void)
 
     joinerUdpPort = static_cast<const JoinerUdpPortTlv *>(
         Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kJoinerUdpPort));
-    VerifyOrExit(joinerUdpPort != nullptr, OT_NOOP);
+    VerifyOrExit(joinerUdpPort != nullptr);
 
     rval = joinerUdpPort->GetUdpPort();
 
@@ -265,8 +265,8 @@ void JoinerRouter::SendDelayedJoinerEntrust(void)
     JoinerEntrustMetadata metadata;
     Message *             message = mDelayedJoinEnts.GetHead();
 
-    VerifyOrExit(message != nullptr, OT_NOOP);
-    VerifyOrExit(!mTimer.IsRunning(), OT_NOOP);
+    VerifyOrExit(message != nullptr);
+    VerifyOrExit(!mTimer.IsRunning());
 
     metadata.ReadFrom(*message);
 
@@ -413,9 +413,9 @@ void JoinerRouter::HandleJoinerEntrustResponse(Coap::Message *         aMessage,
 
     SendDelayedJoinerEntrust();
 
-    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage != nullptr, OT_NOOP);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage != nullptr);
 
-    VerifyOrExit(aMessage->GetCode() == Coap::kCodeChanged, OT_NOOP);
+    VerifyOrExit(aMessage->GetCode() == Coap::kCodeChanged);
 
     otLogInfoMeshCoP("Receive joiner entrust response");
     otLogCertMeshCoP("[THCI] direction=recv | type=JOIN_ENT.rsp");

--- a/src/core/meshcop/meshcop.cpp
+++ b/src/core/meshcop/meshcop.cpp
@@ -85,14 +85,14 @@ bool JoinerPskd::IsPskdValid(const char *aPskString)
     bool     valid      = false;
     uint16_t pskdLength = StringLength(aPskString, kMaxLength + 1);
 
-    VerifyOrExit(pskdLength >= kMinLength && pskdLength <= kMaxLength, OT_NOOP);
+    VerifyOrExit(pskdLength >= kMinLength && pskdLength <= kMaxLength);
 
     for (uint16_t i = 0; i < pskdLength; i++)
     {
         char c = aPskString[i];
 
-        VerifyOrExit(isdigit(c) || isupper(c), OT_NOOP);
-        VerifyOrExit(c != 'I' && c != 'O' && c != 'Q' && c != 'Z', OT_NOOP);
+        VerifyOrExit(isdigit(c) || isupper(c));
+        VerifyOrExit(c != 'I' && c != 'O' && c != 'Q' && c != 'Z');
     }
 
     valid = true;

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -80,15 +80,14 @@ void Leader::HandlePetition(Coap::Message &aMessage, const Ip6::MessageInfo &aMe
 
     otLogInfoMeshCoP("received petition");
 
-    VerifyOrExit(Get<Mle::MleRouter>().IsRoutingLocator(aMessageInfo.GetPeerAddr()), OT_NOOP);
+    VerifyOrExit(Get<Mle::MleRouter>().IsRoutingLocator(aMessageInfo.GetPeerAddr()));
     SuccessOrExit(Tlv::FindTlv(aMessage, Tlv::kCommissionerId, sizeof(commissionerId), commissionerId));
 
     if (mTimer.IsRunning())
     {
         VerifyOrExit((commissionerId.GetCommissionerIdLength() == mCommissionerId.GetCommissionerIdLength()) &&
-                         (!strncmp(commissionerId.GetCommissionerId(), mCommissionerId.GetCommissionerId(),
-                                   commissionerId.GetCommissionerIdLength())),
-                     OT_NOOP);
+                     (!strncmp(commissionerId.GetCommissionerId(), mCommissionerId.GetCommissionerId(),
+                               commissionerId.GetCommissionerIdLength())));
 
         ResignCommissioner();
     }
@@ -272,7 +271,7 @@ void Leader::HandleTimer(Timer &aTimer)
 
 void Leader::HandleTimer(void)
 {
-    VerifyOrExit(Get<Mle::MleRouter>().IsLeader(), OT_NOOP);
+    VerifyOrExit(Get<Mle::MleRouter>().IsLeader());
 
     ResignCommissioner();
 

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -139,10 +139,10 @@ bool ChannelTlv::IsValid(void) const
 {
     bool ret = false;
 
-    VerifyOrExit(GetLength() == sizeof(*this) - sizeof(Tlv), OT_NOOP);
-    VerifyOrExit(mChannelPage <= OT_RADIO_CHANNEL_PAGE_MAX, OT_NOOP);
-    VerifyOrExit((1U << mChannelPage) & Radio::kSupportedChannelPages, OT_NOOP);
-    VerifyOrExit(Radio::kChannelMin <= GetChannel() && GetChannel() <= Radio::kChannelMax, OT_NOOP);
+    VerifyOrExit(GetLength() == sizeof(*this) - sizeof(Tlv));
+    VerifyOrExit(mChannelPage <= OT_RADIO_CHANNEL_PAGE_MAX);
+    VerifyOrExit((1U << mChannelPage) & Radio::kSupportedChannelPages);
+    VerifyOrExit(Radio::kChannelMin <= GetChannel() && GetChannel() <= Radio::kChannelMax);
     ret = true;
 
 exit:
@@ -175,7 +175,7 @@ const ChannelMaskEntryBase *ChannelMaskBaseTlv::GetFirstEntry(void) const
 {
     const ChannelMaskEntryBase *entry = nullptr;
 
-    VerifyOrExit(GetLength() >= sizeof(ChannelMaskEntryBase), OT_NOOP);
+    VerifyOrExit(GetLength() >= sizeof(ChannelMaskEntryBase));
 
     entry = reinterpret_cast<const ChannelMaskEntryBase *>(GetValue());
     VerifyOrExit(GetLength() >= entry->GetEntrySize(), entry = nullptr);
@@ -233,7 +233,7 @@ uint32_t ChannelMaskTlv::GetChannelMask(void) const
 
     for (; cur < end; cur = static_cast<const ChannelMaskEntry *>(cur->GetNext()))
     {
-        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end, OT_NOOP);
+        VerifyOrExit((cur + 1) <= end && cur->GetNext() <= end);
 
 #if OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT
         if (cur->GetChannelPage() == OT_RADIO_CHANNEL_PAGE_2)
@@ -268,7 +268,7 @@ uint32_t ChannelMaskTlv::GetChannelMask(const Message &aMessage)
         ChannelMaskEntry entry;
 
         IgnoreError(aMessage.Read(offset, entry));
-        VerifyOrExit(offset + entry.GetEntrySize() <= end, OT_NOOP);
+        VerifyOrExit(offset + entry.GetEntrySize() <= end);
 
         switch (entry.GetChannelPage())
         {

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -110,13 +110,13 @@ void PanIdQueryClient::HandleConflict(Coap::Message &aMessage, const Ip6::Messag
     Ip6::MessageInfo responseInfo(aMessageInfo);
     uint32_t         mask;
 
-    VerifyOrExit(aMessage.IsConfirmablePostRequest(), OT_NOOP);
+    VerifyOrExit(aMessage.IsConfirmablePostRequest());
 
     otLogInfoMeshCoP("received panid conflict");
 
     SuccessOrExit(Tlv::FindUint16Tlv(aMessage, MeshCoP::Tlv::kPanId, panId));
 
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NOOP);
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
 
     if (mCallback != nullptr)
     {

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -165,7 +165,7 @@ void Client::UpdateAddresses(void)
 
 void Client::Start(void)
 {
-    VerifyOrExit(!mSocket.IsBound(), OT_NOOP);
+    VerifyOrExit(!mSocket.IsBound());
 
     IgnoreError(mSocket.Open(&Client::HandleUdpReceive, this));
     IgnoreError(mSocket.Bind(kDhcpClientPort));
@@ -186,8 +186,7 @@ bool Client::ProcessNextIdentityAssociation(void)
     bool rval = false;
 
     // not interrupt in-progress solicit
-    VerifyOrExit(mIdentityAssociationCurrent == nullptr || mIdentityAssociationCurrent->mStatus != kIaStatusSoliciting,
-                 OT_NOOP);
+    VerifyOrExit(mIdentityAssociationCurrent == nullptr || mIdentityAssociationCurrent->mStatus != kIaStatusSoliciting);
 
     mTrickleTimer.Stop();
 
@@ -432,18 +431,18 @@ void Client::ProcessReply(Message &aMessage)
     }
 
     // Server Identifier
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionServerIdentifier)) > 0, OT_NOOP);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionServerIdentifier)) > 0);
     SuccessOrExit(ProcessServerIdentifier(aMessage, optionOffset));
 
     // Client Identifier
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionClientIdentifier)) > 0, OT_NOOP);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionClientIdentifier)) > 0);
     SuccessOrExit(ProcessClientIdentifier(aMessage, optionOffset));
 
     // Rapid Commit
-    VerifyOrExit(FindOption(aMessage, offset, length, kOptionRapidCommit) > 0, OT_NOOP);
+    VerifyOrExit(FindOption(aMessage, offset, length, kOptionRapidCommit) > 0);
 
     // IA_NA
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionIaNa)) > 0, OT_NOOP);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionIaNa)) > 0);
     SuccessOrExit(ProcessIaNa(aMessage, optionOffset));
 
     HandleTrickleTimer();

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -187,7 +187,7 @@ void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
     aMessage.MoveOffset(sizeof(header));
 
     // discard if not solicit type
-    VerifyOrExit((header.GetType() == kTypeSolicit), OT_NOOP);
+    VerifyOrExit((header.GetType() == kTypeSolicit));
 
     ProcessSolicit(aMessage, aMessageInfo.GetPeerAddr(), header.GetTransactionId());
 
@@ -204,14 +204,14 @@ void Server::ProcessSolicit(Message &aMessage, const Ip6::Address &aDst, const T
     uint16_t         length = aMessage.GetLength() - aMessage.GetOffset();
 
     // Client Identifier (discard if not present)
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionClientIdentifier)) > 0, OT_NOOP);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionClientIdentifier)) > 0);
     SuccessOrExit(ProcessClientIdentifier(aMessage, optionOffset, clientIdentifier));
 
     // Server Identifier (assuming Rapid Commit, discard if present)
-    VerifyOrExit(FindOption(aMessage, offset, length, kOptionServerIdentifier) == 0, OT_NOOP);
+    VerifyOrExit(FindOption(aMessage, offset, length, kOptionServerIdentifier) == 0);
 
     // Rapid Commit (assuming Rapid Commit, discard if not present)
-    VerifyOrExit(FindOption(aMessage, offset, length, kOptionRapidCommit) > 0, OT_NOOP);
+    VerifyOrExit(FindOption(aMessage, offset, length, kOptionRapidCommit) > 0);
 
     // Elapsed Time if present
     if ((optionOffset = FindOption(aMessage, offset, length, kOptionElapsedTime)) > 0)
@@ -220,7 +220,7 @@ void Server::ProcessSolicit(Message &aMessage, const Ip6::Address &aDst, const T
     }
 
     // IA_NA (discard if not present)
-    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionIaNa)) > 0, OT_NOOP);
+    VerifyOrExit((optionOffset = FindOption(aMessage, offset, length, kOptionIaNa)) > 0);
     SuccessOrExit(ProcessIaNa(aMessage, optionOffset, iana));
 
     SuccessOrExit(SendReply(aDst, aTransactionId, clientIdentifier, iana));
@@ -292,7 +292,7 @@ otError Server::ProcessIaNa(Message &aMessage, uint16_t aOffset, IaNa &aIaNa)
 
     while (length > 0)
     {
-        VerifyOrExit((optionOffset = FindOption(aMessage, aOffset, length, kOptionIaAddress)) > 0, OT_NOOP);
+        VerifyOrExit((optionOffset = FindOption(aMessage, aOffset, length, kOptionIaAddress)) > 0);
         SuccessOrExit(error = ProcessIaAddress(aMessage, optionOffset));
 
         length -= ((optionOffset - aOffset) + sizeof(IaAddress));

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -146,7 +146,7 @@ Message *Client::NewMessage(const Header &aHeader)
 {
     Message *message = nullptr;
 
-    VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != nullptr, OT_NOOP);
+    VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != nullptr);
     IgnoreError(message->Prepend(aHeader));
     message->SetOffset(0);
 
@@ -439,13 +439,12 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
 
     SuccessOrExit(aMessage.Read(aMessage.GetOffset(), responseHeader));
     VerifyOrExit(responseHeader.GetType() == Header::kTypeResponse && responseHeader.GetQuestionCount() == 1 &&
-                     !responseHeader.IsTruncationFlagSet(),
-                 OT_NOOP);
+                 !responseHeader.IsTruncationFlagSet());
 
     aMessage.MoveOffset(sizeof(responseHeader));
     offset = aMessage.GetOffset();
 
-    VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != nullptr, OT_NOOP);
+    VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != nullptr);
 
     VerifyOrExit(responseHeader.GetResponseCode() == Header::kResponseSuccess, error = OT_ERROR_FAILED);
 

--- a/src/core/net/icmp6.cpp
+++ b/src/core/net/icmp6.cpp
@@ -103,7 +103,7 @@ otError Icmp::SendError(Header::Type       aType,
     if (ip6Header.GetNextHeader() == kProtoIcmp6)
     {
         SuccessOrExit(aMessage.Read(sizeof(ip6Header), icmp6Header));
-        VerifyOrExit(!icmp6Header.IsError(), OT_NOOP);
+        VerifyOrExit(!icmp6Header.IsError());
     }
 
     messageInfoLocal = aMessageInfo;
@@ -184,7 +184,7 @@ otError Icmp::HandleEchoRequest(Message &aRequestMessage, const MessageInfo &aMe
     uint16_t    payloadLength;
 
     // always handle Echo Request destined for RLOC or ALOC
-    VerifyOrExit(ShouldHandleEchoRequest(aMessageInfo) || aMessageInfo.GetSockAddr().GetIid().IsLocator(), OT_NOOP);
+    VerifyOrExit(ShouldHandleEchoRequest(aMessageInfo) || aMessageInfo.GetSockAddr().GetIid().IsLocator());
 
     otLogInfoIcmp("Received Echo Request");
 

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -78,7 +78,7 @@ Message *Ip6::NewMessage(const uint8_t *aData, uint16_t aDataLength, const Messa
 {
     Message *message = Get<MessagePool>().New(Message::kTypeIp6, 0, aSettings);
 
-    VerifyOrExit(message != nullptr, OT_NOOP);
+    VerifyOrExit(message != nullptr);
 
     if (message->AppendBytes(aData, aDataLength) != OT_ERROR_NONE)
     {
@@ -239,8 +239,7 @@ otError Ip6::InsertMplOption(Message &aMessage, Header &aHeader, MessageInfo &aM
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aHeader.GetDestination().IsMulticast() &&
-                     aHeader.GetDestination().GetScope() >= Address::kRealmLocalScope,
-                 OT_NOOP);
+                 aHeader.GetDestination().GetScope() >= Address::kRealmLocalScope);
 
     if (aHeader.GetDestination().IsRealmLocalMulticast())
     {
@@ -329,7 +328,7 @@ otError Ip6::RemoveMplOption(Message &aMessage)
     offset = 0;
     IgnoreError(aMessage.Read(offset, ip6Header));
     offset += sizeof(ip6Header);
-    VerifyOrExit(ip6Header.GetNextHeader() == kProtoHopOpts, OT_NOOP);
+    VerifyOrExit(ip6Header.GetNextHeader() == kProtoHopOpts);
 
     IgnoreError(aMessage.Read(offset, hbh));
     endOffset = offset + (hbh.GetLength() + 1) * 8;
@@ -1220,7 +1219,7 @@ start:
 
         if (aNetif != nullptr)
         {
-            VerifyOrExit(mForwardingEnabled, OT_NOOP);
+            VerifyOrExit(mForwardingEnabled);
             header.SetHopLimit(header.GetHopLimit() - 1);
         }
 

--- a/src/core/net/ip6_filter.cpp
+++ b/src/core/net/ip6_filter.cpp
@@ -71,7 +71,7 @@ bool Filter::Accept(Message &aMessage) const
     SuccessOrExit(aMessage.Read(0, ip6));
 
     // Allow only link-local unicast or multicast
-    VerifyOrExit(ip6.GetDestination().IsLinkLocal() || ip6.GetDestination().IsLinkLocalMulticast(), OT_NOOP);
+    VerifyOrExit(ip6.GetDestination().IsLinkLocal() || ip6.GetDestination().IsLinkLocalMulticast());
 
     switch (ip6.GetNextHeader())
     {

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -309,7 +309,7 @@ void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSeque
     uint8_t interval = kDataMessageInterval;
 #endif
 
-    VerifyOrExit(GetTimerExpirations() > 0, OT_NOOP);
+    VerifyOrExit(GetTimerExpirations() > 0);
     VerifyOrExit((messageCopy = aMessage.Clone()) != nullptr, error = OT_ERROR_NO_BUFS);
 
     if (!aIsOutbound)

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -128,7 +128,7 @@ void Netif::SubscribeAllNodesMulticast(void)
     NetifMulticastAddress &linkLocalAllNodesAddress =
         static_cast<NetifMulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
 
-    VerifyOrExit(!mMulticastAddresses.Contains(linkLocalAllNodesAddress), OT_NOOP);
+    VerifyOrExit(!mMulticastAddresses.Contains(linkLocalAllNodesAddress));
 
     // Append the fixed chain of three multicast addresses to the
     // tail of the list:
@@ -148,7 +148,7 @@ void Netif::SubscribeAllNodesMulticast(void)
 
     Get<Notifier>().Signal(kEventIp6MulticastSubscribed);
 
-    VerifyOrExit(mAddressCallback != nullptr, OT_NOOP);
+    VerifyOrExit(mAddressCallback != nullptr);
 
     for (const NetifMulticastAddress *entry = &linkLocalAllNodesAddress; entry; entry = entry->GetNext())
     {
@@ -198,7 +198,7 @@ void Netif::UnsubscribeAllNodesMulticast(void)
 
     Get<Notifier>().Signal(kEventIp6MulticastUnsubscribed);
 
-    VerifyOrExit(mAddressCallback != nullptr, OT_NOOP);
+    VerifyOrExit(mAddressCallback != nullptr);
 
     for (const NetifMulticastAddress *entry = &linkLocalAllNodesAddress; entry; entry = entry->GetNext())
     {
@@ -245,7 +245,7 @@ void Netif::SubscribeAllRoutersMulticast(void)
     // `RealmLocalAllRouters` then all five addresses are on
     // the list already.
 
-    VerifyOrExit(prev != &realmLocalAllRoutersAddress, OT_NOOP);
+    VerifyOrExit(prev != &realmLocalAllRoutersAddress);
 
     if (prev == nullptr)
     {
@@ -258,7 +258,7 @@ void Netif::SubscribeAllRoutersMulticast(void)
 
     Get<Notifier>().Signal(kEventIp6MulticastSubscribed);
 
-    VerifyOrExit(mAddressCallback != nullptr, OT_NOOP);
+    VerifyOrExit(mAddressCallback != nullptr);
 
     for (const NetifMulticastAddress *entry = &linkLocalAllRoutersAddress; entry != &linkLocalAllNodesAddress;
          entry                              = entry->GetNext())
@@ -304,7 +304,7 @@ void Netif::UnsubscribeAllRoutersMulticast(void)
 
     Get<Notifier>().Signal(kEventIp6MulticastUnsubscribed);
 
-    VerifyOrExit(mAddressCallback != nullptr, OT_NOOP);
+    VerifyOrExit(mAddressCallback != nullptr);
 
     for (const NetifMulticastAddress *entry = &linkLocalAllRoutersAddress; entry != &linkLocalAllNodesAddress;
          entry                              = entry->GetNext())
@@ -330,7 +330,7 @@ void Netif::SubscribeMulticast(NetifMulticastAddress &aAddress)
 
     Get<Notifier>().Signal(kEventIp6MulticastSubscribed);
 
-    VerifyOrExit(mAddressCallback != nullptr, OT_NOOP);
+    VerifyOrExit(mAddressCallback != nullptr);
 
     {
         AddressInfo addressInfo(aAddress);
@@ -349,7 +349,7 @@ void Netif::UnsubscribeMulticast(const NetifMulticastAddress &aAddress)
 
     Get<Notifier>().Signal(kEventIp6MulticastUnsubscribed);
 
-    VerifyOrExit(mAddressCallback != nullptr, OT_NOOP);
+    VerifyOrExit(mAddressCallback != nullptr);
     {
         AddressInfo addressInfo(aAddress);
 
@@ -442,7 +442,7 @@ void Netif::AddUnicastAddress(NetifUnicastAddress &aAddress)
 
     Get<Notifier>().Signal(aAddress.mRloc ? kEventThreadRlocAdded : kEventIp6AddressAdded);
 
-    VerifyOrExit(mAddressCallback != nullptr, OT_NOOP);
+    VerifyOrExit(mAddressCallback != nullptr);
 
     {
         AddressInfo addressInfo(aAddress, GetInstance());
@@ -461,7 +461,7 @@ void Netif::RemoveUnicastAddress(const NetifUnicastAddress &aAddress)
 
     Get<Notifier>().Signal(aAddress.mRloc ? kEventThreadRlocRemoved : kEventIp6AddressRemoved);
 
-    VerifyOrExit(mAddressCallback != nullptr, OT_NOOP);
+    VerifyOrExit(mAddressCallback != nullptr);
     {
         AddressInfo addressInfo(aAddress, GetInstance());
 

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -177,7 +177,7 @@ Message *Client::NewMessage(const Header &aHeader)
 {
     Message *message = nullptr;
 
-    VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != nullptr, OT_NOOP);
+    VerifyOrExit((message = mSocket.NewMessage(sizeof(aHeader))) != nullptr);
     IgnoreError(message->Prepend(aHeader));
     message->SetOffset(0);
 
@@ -350,7 +350,7 @@ void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessag
 
     SuccessOrExit(aMessage.Read(aMessage.GetOffset(), responseHeader));
 
-    VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != nullptr, OT_NOOP);
+    VerifyOrExit((message = FindRelatedQuery(responseHeader, queryMetadata)) != nullptr);
 
     // Check if response came from the server.
     VerifyOrExit(responseHeader.GetMode() == Header::kModeServer, error = OT_ERROR_FAILED);

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -51,20 +51,18 @@ bool Udp::SocketHandle::Matches(const MessageInfo &aMessageInfo) const
 {
     bool matches = false;
 
-    VerifyOrExit(GetSockName().mPort == aMessageInfo.GetSockPort(), OT_NOOP);
+    VerifyOrExit(GetSockName().mPort == aMessageInfo.GetSockPort());
 
     VerifyOrExit(aMessageInfo.GetSockAddr().IsMulticast() || GetSockName().GetAddress().IsUnspecified() ||
-                     GetSockName().GetAddress() == aMessageInfo.GetSockAddr(),
-                 OT_NOOP);
+                 GetSockName().GetAddress() == aMessageInfo.GetSockAddr());
 
     // Verify source if connected socket
     if (GetPeerName().mPort != 0)
     {
-        VerifyOrExit(GetPeerName().mPort == aMessageInfo.GetPeerPort(), OT_NOOP);
+        VerifyOrExit(GetPeerName().mPort == aMessageInfo.GetPeerPort());
 
         VerifyOrExit(GetPeerName().GetAddress().IsUnspecified() ||
-                         GetPeerName().GetAddress() == aMessageInfo.GetPeerAddr(),
-                     OT_NOOP);
+                     GetPeerName().GetAddress() == aMessageInfo.GetPeerAddr());
     }
 
     matches = true;
@@ -451,12 +449,12 @@ otError Udp::HandleMessage(Message &aMessage, MessageInfo &aMessageInfo)
     aMessageInfo.mSockPort = udpHeader.GetDestinationPort();
 
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
-    VerifyOrExit(IsMlePort(aMessageInfo.mSockPort), OT_NOOP);
+    VerifyOrExit(IsMlePort(aMessageInfo.mSockPort));
 #endif
 
     for (Receiver *receiver = mReceivers.GetHead(); receiver; receiver = receiver->GetNext())
     {
-        VerifyOrExit(!receiver->HandleMessage(aMessage, aMessageInfo), OT_NOOP);
+        VerifyOrExit(!receiver->HandleMessage(aMessage, aMessageInfo));
     }
 
     HandlePayload(aMessage, aMessageInfo);
@@ -491,7 +489,7 @@ void Udp::HandlePayload(Message &aMessage, MessageInfo &aMessageInfo)
     socket = mSockets.FindMatching(aMessageInfo, prev);
 #endif
 
-    VerifyOrExit(socket != nullptr, OT_NOOP);
+    VerifyOrExit(socket != nullptr);
 
     aMessage.RemoveHeader(aMessage.GetOffset());
     OT_ASSERT(aMessage.GetOffset() == 0);

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -142,7 +142,7 @@ otError AddressResolver::GetNextCacheEntry(EntryInfo &aInfo, Iterator &aIterator
         aInfo.mCanEvict       = true;
         aInfo.mValidLastTrans = entry->IsLastTransactionTimeValid();
 
-        VerifyOrExit(entry->IsLastTransactionTimeValid(), OT_NOOP);
+        VerifyOrExit(entry->IsLastTransactionTimeValid());
 
         aInfo.mLastTransTime = entry->GetLastTransactionTime();
         static_cast<Ip6::Address &>(aInfo.mMeshLocalEid).SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
@@ -226,7 +226,7 @@ AddressResolver::CacheEntry *AddressResolver::FindCacheEntry(const Ip6::Address 
     {
         aList = list;
         entry = aList->FindMatching(aEid, aPrevEntry);
-        VerifyOrExit(entry == nullptr, OT_NOOP);
+        VerifyOrExit(entry == nullptr);
     }
 
 exit:
@@ -245,7 +245,7 @@ void AddressResolver::Remove(const Ip6::Address &aEid, Reason aReason)
     CacheEntryList *list;
 
     entry = FindCacheEntry(aEid, list, prev);
-    VerifyOrExit(entry != nullptr, OT_NOOP);
+    VerifyOrExit(entry != nullptr);
 
     RemoveCacheEntry(*entry, *list, prev, aReason);
     mCacheEntryPool.Free(*entry);
@@ -272,7 +272,7 @@ AddressResolver::CacheEntry *AddressResolver::NewCacheEntry(bool aSnoopedEntry)
     // evicted till timeout).
 
     newEntry = mCacheEntryPool.Allocate();
-    VerifyOrExit(newEntry == nullptr, OT_NOOP);
+    VerifyOrExit(newEntry == nullptr);
 
     for (CacheEntryList *list : lists)
     {
@@ -312,7 +312,7 @@ AddressResolver::CacheEntry *AddressResolver::NewCacheEntry(bool aSnoopedEntry)
             // snooped entries that are in timeout mode and cannot be
             // evicted by `kMaxNonEvictableSnoopedEntries`.
 
-            VerifyOrExit(numNonEvictable < kMaxNonEvictableSnoopedEntries, OT_NOOP);
+            VerifyOrExit(numNonEvictable < kMaxNonEvictableSnoopedEntries);
         }
     }
 
@@ -347,7 +347,7 @@ otError AddressResolver::UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAd
 
     if ((list == &mCachedList) || (list == &mSnoopedList))
     {
-        VerifyOrExit(entry->GetRloc16() != aRloc16, OT_NOOP);
+        VerifyOrExit(entry->GetRloc16() != aRloc16);
         entry->SetRloc16(aRloc16);
     }
     else
@@ -377,7 +377,7 @@ void AddressResolver::AddSnoopedCacheEntry(const Ip6::Address &aEid, Mac::ShortA
     CacheEntry *entry;
 
     entry = NewCacheEntry(/* aSnoopedEntry */ true);
-    VerifyOrExit(entry != nullptr, OT_NOOP);
+    VerifyOrExit(entry != nullptr);
 
     for (CacheEntry *snooped = mSnoopedList.GetHead(); snooped != nullptr; snooped = snooped->GetNext())
     {
@@ -569,7 +569,7 @@ void AddressResolver::HandleAddressNotification(Coap::Message &aMessage, const I
     CacheEntry *             entry;
     CacheEntry *             prev;
 
-    VerifyOrExit(aMessage.IsConfirmablePostRequest(), OT_NOOP);
+    VerifyOrExit(aMessage.IsConfirmablePostRequest());
 
     SuccessOrExit(Tlv::FindTlv(aMessage, ThreadTlv::kTarget, &target, sizeof(target)));
     SuccessOrExit(Tlv::FindTlv(aMessage, ThreadTlv::kMeshLocalEid, &meshLocalIid, sizeof(meshLocalIid)));
@@ -590,7 +590,7 @@ void AddressResolver::HandleAddressNotification(Coap::Message &aMessage, const I
                  aMessageInfo.GetPeerAddr().GetIid().GetLocator(), target.ToString().AsCString(), rloc16);
 
     entry = FindCacheEntry(target, list, prev);
-    VerifyOrExit(entry != nullptr, OT_NOOP);
+    VerifyOrExit(entry != nullptr);
 
     if (list == &mCachedList)
     {
@@ -603,7 +603,7 @@ void AddressResolver::HandleAddressNotification(Coap::Message &aMessage, const I
 
             VerifyOrExit(entry->GetMeshLocalIid() == meshLocalIid, SendAddressError(target, meshLocalIid, nullptr));
 
-            VerifyOrExit(lastTransactionTime < entry->GetLastTransactionTime(), OT_NOOP);
+            VerifyOrExit(lastTransactionTime < entry->GetLastTransactionTime());
         }
     }
 
@@ -761,7 +761,7 @@ void AddressResolver::HandleAddressQuery(Coap::Message &aMessage, const Ip6::Mes
     Ip6::Address target;
     uint32_t     lastTransactionTime;
 
-    VerifyOrExit(aMessage.IsNonConfirmablePostRequest(), OT_NOOP);
+    VerifyOrExit(aMessage.IsNonConfirmablePostRequest());
 
     SuccessOrExit(Tlv::FindTlv(aMessage, ThreadTlv::kTarget, &target, sizeof(target)));
 
@@ -932,8 +932,8 @@ void AddressResolver::HandleIcmpReceive(Message &                aMessage,
 
     Ip6::Header ip6Header;
 
-    VerifyOrExit(aIcmpHeader.GetType() == Ip6::Icmp::Header::kTypeDstUnreach, OT_NOOP);
-    VerifyOrExit(aIcmpHeader.GetCode() == Ip6::Icmp::Header::kCodeDstUnreachNoRoute, OT_NOOP);
+    VerifyOrExit(aIcmpHeader.GetType() == Ip6::Icmp::Header::kTypeDstUnreach);
+    VerifyOrExit(aIcmpHeader.GetCode() == Ip6::Icmp::Header::kCodeDstUnreachNoRoute);
     SuccessOrExit(aMessage.Read(aMessage.GetOffset(), ip6Header));
 
     Remove(ip6Header.GetDestination(), kReasonReceivedIcmpDstUnreachNoRoute);

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -72,8 +72,8 @@ void AnnounceBeginServer::HandleRequest(Coap::Message &aMessage, const Ip6::Mess
     uint16_t         period;
     Ip6::MessageInfo responseInfo(aMessageInfo);
 
-    VerifyOrExit(aMessage.IsPostRequest(), OT_NOOP);
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NOOP);
+    VerifyOrExit(aMessage.IsPostRequest());
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
 
     SuccessOrExit(Tlv::FindUint8Tlv(aMessage, MeshCoP::Tlv::kCount, count));
     SuccessOrExit(Tlv::FindUint16Tlv(aMessage, MeshCoP::Tlv::kPeriod, period));

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -59,11 +59,11 @@ AnnounceSenderBase::AnnounceSenderBase(Instance &aInstance, Timer::Handler aHand
 
 void AnnounceSenderBase::SendAnnounce(Mac::ChannelMask aChannelMask, uint8_t aCount, uint32_t aPeriod, uint16_t aJitter)
 {
-    VerifyOrExit(aPeriod != 0, OT_NOOP);
-    VerifyOrExit(aJitter < aPeriod, OT_NOOP);
+    VerifyOrExit(aPeriod != 0);
+    VerifyOrExit(aJitter < aPeriod);
 
     aChannelMask.Intersect(Get<Mac::Mac>().GetSupportedChannelMask());
-    VerifyOrExit(!aChannelMask.IsEmpty(), OT_NOOP);
+    VerifyOrExit(!aChannelMask.IsEmpty());
 
     mChannelMask = aChannelMask;
     mCount       = aCount;
@@ -91,7 +91,7 @@ void AnnounceSenderBase::HandleTimer(void)
         if (mCount != 0)
         {
             mCount--;
-            VerifyOrExit(mCount != 0, OT_NOOP);
+            VerifyOrExit(mCount != 0);
         }
 
         mChannel = Mac::ChannelMask::kChannelIteratorFirst;
@@ -160,7 +160,7 @@ void AnnounceSender::CheckState(void)
         period = kMinTxPeriod;
     }
 
-    VerifyOrExit(!IsRunning() || (period != GetPeriod()) || (GetChannelMask() != channelMask), OT_NOOP);
+    VerifyOrExit(!IsRunning() || (period != GetPeriod()) || (GetChannelMask() != channelMask));
 
     SendAnnounce(channelMask, 0, period, kMaxJitter);
 

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -61,7 +61,7 @@ void ChildTable::Iterator::Reset(void)
 
 void ChildTable::Iterator::Advance(void)
 {
-    VerifyOrExit(mChild != nullptr, OT_NOOP);
+    VerifyOrExit(mChild != nullptr);
 
     do
     {
@@ -96,7 +96,7 @@ Child *ChildTable::GetChildAtIndex(uint16_t aChildIndex)
 {
     Child *child = nullptr;
 
-    VerifyOrExit(aChildIndex < mMaxChildrenAllowed, OT_NOOP);
+    VerifyOrExit(aChildIndex < mMaxChildrenAllowed);
     child = &mChildren[aChildIndex];
 
 exit:
@@ -107,7 +107,7 @@ Child *ChildTable::GetNewChild(void)
 {
     Child *child = FindChild(Child::AddressMatcher(Child::kInStateInvalid));
 
-    VerifyOrExit(child != nullptr, OT_NOOP);
+    VerifyOrExit(child != nullptr);
     child->Clear();
 
 exit:

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -213,7 +213,7 @@ void CslTxScheduler::HandleSentFrame(const Mac::TxFrame &aFrame, otError aError)
 {
     Child *child = mCslTxChild;
 
-    VerifyOrExit(child != nullptr, OT_NOOP); // The result is no longer interested by upper layer
+    VerifyOrExit(child != nullptr); // The result is no longer interested by upper layer
 
     mCslTxChild   = nullptr;
     mCslTxMessage = nullptr;

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -264,7 +264,7 @@ void DiscoverScanner::HandleTimer(Timer &aTimer)
 
 void DiscoverScanner::HandleTimer(void)
 {
-    VerifyOrExit(mState == kStateScanning, OT_NOOP);
+    VerifyOrExit(mState == kStateScanning);
 
     // Move to next scan channel and resume message transmissions on
     // `MeshForwarder` so that the queued MLE Discovery Request message
@@ -356,7 +356,7 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
 
                 if (mEnableFiltering)
                 {
-                    VerifyOrExit(steeringData.Contains(mFilterIndexes), OT_NOOP);
+                    VerifyOrExit(steeringData.Contains(mFilterIndexes));
                 }
 
                 didCheckSteeringData = true;
@@ -374,7 +374,7 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
         offset += sizeof(meshcopTlv) + meshcopTlv.GetLength();
     }
 
-    VerifyOrExit(!mEnableFiltering || didCheckSteeringData, OT_NOOP);
+    VerifyOrExit(!mEnableFiltering || didCheckSteeringData);
 
     if (mHandler)
     {

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -108,7 +108,7 @@ void DuaManager::HandleDomainPrefixUpdate(BackboneRouter::Leader::DomainPrefixSt
     {
     case BackboneRouter::Leader::kDomainPrefixUnchanged:
         // In case removed for some reason e.g. the kDuaInvalid response from PBBR forcely
-        VerifyOrExit(!Get<ThreadNetif>().HasUnicastAddress(GetDomainUnicastAddress()), OT_NOOP);
+        VerifyOrExit(!Get<ThreadNetif>().HasUnicastAddress(GetDomainUnicastAddress()));
 
         // fall through
     case BackboneRouter::Leader::kDomainPrefixRefreshed:
@@ -171,7 +171,7 @@ otError DuaManager::SetFixedDuaInterfaceIdentifier(const Ip6::InterfaceIdentifie
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(!aIid.IsReserved(), error = OT_ERROR_INVALID_ARGS);
-    VerifyOrExit(mFixedDuaInterfaceIdentifier.IsUnspecified() || mFixedDuaInterfaceIdentifier != aIid, OT_NOOP);
+    VerifyOrExit(mFixedDuaInterfaceIdentifier.IsUnspecified() || mFixedDuaInterfaceIdentifier != aIid);
 
     mFixedDuaInterfaceIdentifier = aIid;
     otLogInfoDua("Set DUA IID: %s", mFixedDuaInterfaceIdentifier.ToString().AsCString());
@@ -190,7 +190,7 @@ exit:
 void DuaManager::ClearFixedDuaInterfaceIdentifier(void)
 {
     // Nothing to clear.
-    VerifyOrExit(IsFixedDuaInterfaceIdentifierSet(), OT_NOOP);
+    VerifyOrExit(IsFixedDuaInterfaceIdentifierSet());
 
     if (GetDomainUnicastAddress().GetIid() == mFixedDuaInterfaceIdentifier &&
         Get<ThreadNetif>().HasUnicastAddress(GetDomainUnicastAddress()))
@@ -276,7 +276,7 @@ void DuaManager::UpdateReregistrationDelay(void)
     uint16_t               delay = 0;
     otBackboneRouterConfig config;
 
-    VerifyOrExit(Get<BackboneRouter::Leader>().GetConfig(config) == OT_ERROR_NONE, OT_NOOP);
+    VerifyOrExit(Get<BackboneRouter::Leader>().GetConfig(config) == OT_ERROR_NONE);
 
     delay = config.mReregistrationDelay > 1 ? Random::NonCrypto::GetUint16InRange(1, config.mReregistrationDelay) : 1;
 

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -75,13 +75,13 @@ void EnergyScanServer::HandleRequest(Coap::Message &aMessage, const Ip6::Message
     Ip6::MessageInfo responseInfo(aMessageInfo);
     uint32_t         mask;
 
-    VerifyOrExit(aMessage.IsPostRequest(), OT_NOOP);
+    VerifyOrExit(aMessage.IsPostRequest());
 
     SuccessOrExit(Tlv::FindUint8Tlv(aMessage, MeshCoP::Tlv::kCount, count));
     SuccessOrExit(Tlv::FindUint16Tlv(aMessage, MeshCoP::Tlv::kPeriod, period));
     SuccessOrExit(Tlv::FindUint16Tlv(aMessage, MeshCoP::Tlv::kScanDuration, scanDuration));
 
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NOOP);
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
 
     mChannelMask        = mask;
     mChannelMaskCurrent = mChannelMask;
@@ -111,7 +111,7 @@ void EnergyScanServer::HandleTimer(Timer &aTimer)
 
 void EnergyScanServer::HandleTimer(void)
 {
-    VerifyOrExit(mActive, OT_NOOP);
+    VerifyOrExit(mActive);
 
     if (mCount)
     {
@@ -135,11 +135,11 @@ void EnergyScanServer::HandleScanResult(Mac::EnergyScanResult *aResult, void *aC
 
 void EnergyScanServer::HandleScanResult(Mac::EnergyScanResult *aResult)
 {
-    VerifyOrExit(mActive, OT_NOOP);
+    VerifyOrExit(mActive);
 
     if (aResult)
     {
-        VerifyOrExit(mScanResultsLength < OPENTHREAD_CONFIG_TMF_ENERGY_SCAN_MAX_RESULTS, OT_NOOP);
+        VerifyOrExit(mScanResultsLength < OPENTHREAD_CONFIG_TMF_ENERGY_SCAN_MAX_RESULTS);
         mScanResults[mScanResultsLength++] = aResult->mMaxRssi;
     }
     else

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -73,7 +73,7 @@ IndirectSender::IndirectSender(Instance &aInstance)
 
 void IndirectSender::Stop(void)
 {
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
 
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateAnyExceptInvalid))
     {
@@ -97,7 +97,7 @@ void IndirectSender::AddMessageForSleepyChild(Message &aMessage, Child &aChild)
     OT_ASSERT(!aChild.IsRxOnWhenIdle());
 
     childIndex = Get<ChildTable>().GetChildIndex(aChild);
-    VerifyOrExit(!aMessage.GetChildMask(childIndex), OT_NOOP);
+    VerifyOrExit(!aMessage.GetChildMask(childIndex));
 
     aMessage.SetChildMask(childIndex);
     mSourceMatchController.IncrementMessageCount(aChild);
@@ -139,7 +139,7 @@ void IndirectSender::ClearAllMessagesForSleepyChild(Child &aChild)
     Message *message;
     Message *nextMessage;
 
-    VerifyOrExit(aChild.GetIndirectMessageCount() > 0, OT_NOOP);
+    VerifyOrExit(aChild.GetIndirectMessageCount() > 0);
 
     for (message = Get<MeshForwarder>().mSendQueue.GetHead(); message; message = nextMessage)
     {
@@ -173,7 +173,7 @@ exit:
 
 void IndirectSender::SetChildUseShortAddress(Child &aChild, bool aUseShortAddress)
 {
-    VerifyOrExit(aChild.IsIndirectSourceMatchShort() != aUseShortAddress, OT_NOOP);
+    VerifyOrExit(aChild.IsIndirectSourceMatchShort() != aUseShortAddress);
 
     mSourceMatchController.SetSrcMatchAsShort(aChild, aUseShortAddress);
 
@@ -270,11 +270,11 @@ void IndirectSender::RequestMessageUpdate(Child &aChild)
         ExitNow();
     }
 
-    VerifyOrExit(!aChild.IsWaitingForMessageUpdate(), OT_NOOP);
+    VerifyOrExit(!aChild.IsWaitingForMessageUpdate());
 
     newMessage = FindIndirectMessage(aChild);
 
-    VerifyOrExit(curMessage != newMessage, OT_NOOP);
+    VerifyOrExit(curMessage != newMessage);
 
     if (curMessage == nullptr)
     {
@@ -291,7 +291,7 @@ void IndirectSender::RequestMessageUpdate(Child &aChild)
     // fragment. If a next fragment frame for message is already
     // prepared, we wait for the entire message to be delivered.
 
-    VerifyOrExit(aChild.GetIndirectFragmentOffset() == 0, OT_NOOP);
+    VerifyOrExit(aChild.GetIndirectFragmentOffset() == 0);
 
     aChild.SetWaitingForMessageUpdate(true);
     mDataPollHandler.RequestFrameChange(DataPollHandler::kReplaceFrame, aChild);
@@ -305,7 +305,7 @@ exit:
 
 void IndirectSender::HandleFrameChangeDone(Child &aChild)
 {
-    VerifyOrExit(aChild.IsWaitingForMessageUpdate(), OT_NOOP);
+    VerifyOrExit(aChild.IsWaitingForMessageUpdate());
     UpdateIndirectMessage(aChild);
 
 exit:
@@ -427,7 +427,7 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
     Message *message    = aChild.GetIndirectMessage();
     uint16_t nextOffset = aContext.mMessageNextOffset;
 
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
 
     switch (aError)
     {

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -184,7 +184,7 @@ void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
         if (mKeySwitchGuardEnabled)
         {
             // Check if the guard timer has expired if key rotation is requested.
-            VerifyOrExit(mHoursSinceKeyRotation >= mKeySwitchGuardTime, OT_NOOP);
+            VerifyOrExit(mHoursSinceKeyRotation >= mKeySwitchGuardTime);
             StartKeyRotationTimer();
         }
 

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -176,7 +176,7 @@ void LinkMetrics::HandleLinkMetricsReport(const Message &     aMessage,
     Tlv                    tlv;
     LinkMetricsTypeIdFlags typeIdFlags;
 
-    VerifyOrExit(mLinkMetricsReportCallback != nullptr, OT_NOOP);
+    VerifyOrExit(mLinkMetricsReportCallback != nullptr);
 
     memset(&metricsValues, 0, sizeof(metricsValues));
 
@@ -185,9 +185,9 @@ void LinkMetrics::HandleLinkMetricsReport(const Message &     aMessage,
     while (pos < endPos)
     {
         SuccessOrExit(aMessage.Read(pos, tlv));
-        VerifyOrExit(tlv.GetType() == kLinkMetricsReportSub, OT_NOOP);
+        VerifyOrExit(tlv.GetType() == kLinkMetricsReportSub);
         pos += sizeof(Tlv);
-        VerifyOrExit(pos + tlv.GetLength() <= endPos, OT_NOOP);
+        VerifyOrExit(pos + tlv.GetLength() <= endPos);
 
         IgnoreError(aMessage.Read(pos, typeIdFlags));
 

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -114,7 +114,7 @@ RssAverager::InfoString RssAverager::ToString(void) const
 {
     InfoString string;
 
-    VerifyOrExit(mCount != 0, OT_NOOP);
+    VerifyOrExit(mCount != 0);
     IgnoreError(string.Set("%d.%s", -(mAverage >> kPrecisionBitShift), kDigitsString[mAverage & kPrecisionBitMask]));
 
 exit:
@@ -154,7 +154,7 @@ void LinkQualityInfo::AddRss(int8_t aRss)
 {
     uint8_t oldLinkQuality = kNoLinkQuality;
 
-    VerifyOrExit(aRss != OT_RADIO_RSSI_INVALID, OT_NOOP);
+    VerifyOrExit(aRss != OT_RADIO_RSSI_INVALID);
 
     mLastRss = aRss;
 

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -672,12 +672,12 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     uint8_t              nextHeader;
     uint8_t *            bytes;
 
-    VerifyOrExit(cur + 2 <= end, OT_NOOP);
+    VerifyOrExit(cur + 2 <= end);
     hcCtl = ReadUint16(cur);
     cur += 2;
 
     // check Dispatch bits
-    VerifyOrExit((hcCtl & kHcDispatchMask) == kHcDispatch, OT_NOOP);
+    VerifyOrExit((hcCtl & kHcDispatchMask) == kHcDispatch);
 
     // Context Identifier
     srcContext.mPrefix.SetLength(0);
@@ -685,7 +685,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
 
     if ((hcCtl & kHcContextId) != 0)
     {
-        VerifyOrExit(cur < end, OT_NOOP);
+        VerifyOrExit(cur < end);
 
         if (networkData.GetContext(cur[0] >> 4, srcContext) != OT_ERROR_NONE)
         {
@@ -711,7 +711,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     // Traffic Class and Flow Label
     if ((hcCtl & kHcTrafficFlowMask) != kHcTrafficFlow)
     {
-        VerifyOrExit(cur < end, OT_NOOP);
+        VerifyOrExit(cur < end);
 
         bytes = reinterpret_cast<uint8_t *>(&aIp6Header);
         bytes[1] |= (cur[0] & 0xc0) >> 2;
@@ -725,7 +725,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
 
         if ((hcCtl & kHcFlowLabel) == 0)
         {
-            VerifyOrExit(cur + 3 <= end, OT_NOOP);
+            VerifyOrExit(cur + 3 <= end);
             bytes[1] |= cur[0] & 0x0f;
             bytes[2] |= cur[1];
             bytes[3] |= cur[2];
@@ -736,7 +736,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     // Next Header
     if ((hcCtl & kHcNextHeader) == 0)
     {
-        VerifyOrExit(cur < end, OT_NOOP);
+        VerifyOrExit(cur < end);
         aIp6Header.SetNextHeader(cur[0]);
         cur++;
         aCompressedNextHeader = false;
@@ -762,7 +762,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         break;
 
     default:
-        VerifyOrExit(cur < end, OT_NOOP);
+        VerifyOrExit(cur < end);
         aIp6Header.SetHopLimit(cur[0]);
         cur++;
         break;
@@ -774,7 +774,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
     case kHcSrcAddrMode0:
         if ((hcCtl & kHcSrcAddrContext) == 0)
         {
-            VerifyOrExit(cur + sizeof(Ip6::Address) <= end, OT_NOOP);
+            VerifyOrExit(cur + sizeof(Ip6::Address) <= end);
             memcpy(&aIp6Header.GetSource(), cur, sizeof(aIp6Header.GetSource()));
             cur += sizeof(Ip6::Address);
         }
@@ -782,13 +782,13 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         break;
 
     case kHcSrcAddrMode1:
-        VerifyOrExit(cur + Ip6::InterfaceIdentifier::kSize <= end, OT_NOOP);
+        VerifyOrExit(cur + Ip6::InterfaceIdentifier::kSize <= end);
         aIp6Header.GetSource().GetIid().SetBytes(cur);
         cur += Ip6::InterfaceIdentifier::kSize;
         break;
 
     case kHcSrcAddrMode2:
-        VerifyOrExit(cur + 2 <= end, OT_NOOP);
+        VerifyOrExit(cur + 2 <= end);
         aIp6Header.GetSource().mFields.m8[11] = 0xff;
         aIp6Header.GetSource().mFields.m8[12] = 0xfe;
         memcpy(aIp6Header.GetSource().mFields.m8 + 14, cur, 2);
@@ -808,7 +808,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         }
         else
         {
-            VerifyOrExit(srcContextValid, OT_NOOP);
+            VerifyOrExit(srcContextValid);
             CopyContext(srcContext, aIp6Header.GetSource());
         }
     }
@@ -820,20 +820,20 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         switch (hcCtl & kHcDstAddrModeMask)
         {
         case kHcDstAddrMode0:
-            VerifyOrExit((hcCtl & kHcDstAddrContext) == 0, OT_NOOP);
-            VerifyOrExit(cur + sizeof(Ip6::Address) <= end, OT_NOOP);
+            VerifyOrExit((hcCtl & kHcDstAddrContext) == 0);
+            VerifyOrExit(cur + sizeof(Ip6::Address) <= end);
             memcpy(&aIp6Header.GetDestination(), cur, sizeof(aIp6Header.GetDestination()));
             cur += sizeof(Ip6::Address);
             break;
 
         case kHcDstAddrMode1:
-            VerifyOrExit(cur + Ip6::InterfaceIdentifier::kSize <= end, OT_NOOP);
+            VerifyOrExit(cur + Ip6::InterfaceIdentifier::kSize <= end);
             aIp6Header.GetDestination().GetIid().SetBytes(cur);
             cur += Ip6::InterfaceIdentifier::kSize;
             break;
 
         case kHcDstAddrMode2:
-            VerifyOrExit(cur + 2 <= end, OT_NOOP);
+            VerifyOrExit(cur + 2 <= end);
             aIp6Header.GetDestination().mFields.m8[11] = 0xff;
             aIp6Header.GetDestination().mFields.m8[12] = 0xfe;
             memcpy(aIp6Header.GetDestination().mFields.m8 + 14, cur, 2);
@@ -854,7 +854,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
         }
         else
         {
-            VerifyOrExit(dstContextValid, OT_NOOP);
+            VerifyOrExit(dstContextValid);
             CopyContext(dstContext, aIp6Header.GetDestination());
         }
     }
@@ -869,27 +869,27 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
             switch (hcCtl & kHcDstAddrModeMask)
             {
             case kHcDstAddrMode0:
-                VerifyOrExit(cur + sizeof(Ip6::Address) <= end, OT_NOOP);
+                VerifyOrExit(cur + sizeof(Ip6::Address) <= end);
                 memcpy(aIp6Header.GetDestination().mFields.m8, cur, sizeof(Ip6::Address));
                 cur += sizeof(Ip6::Address);
                 break;
 
             case kHcDstAddrMode1:
-                VerifyOrExit(cur + 6 <= end, OT_NOOP);
+                VerifyOrExit(cur + 6 <= end);
                 aIp6Header.GetDestination().mFields.m8[1] = cur[0];
                 memcpy(aIp6Header.GetDestination().mFields.m8 + 11, cur + 1, 5);
                 cur += 6;
                 break;
 
             case kHcDstAddrMode2:
-                VerifyOrExit(cur + 4 <= end, OT_NOOP);
+                VerifyOrExit(cur + 4 <= end);
                 aIp6Header.GetDestination().mFields.m8[1] = cur[0];
                 memcpy(aIp6Header.GetDestination().mFields.m8 + 13, cur + 1, 3);
                 cur += 4;
                 break;
 
             case kHcDstAddrMode3:
-                VerifyOrExit(cur < end, OT_NOOP);
+                VerifyOrExit(cur < end);
                 aIp6Header.GetDestination().mFields.m8[1]  = 0x02;
                 aIp6Header.GetDestination().mFields.m8[15] = cur[0];
                 cur++;
@@ -901,8 +901,8 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
             switch (hcCtl & kHcDstAddrModeMask)
             {
             case 0:
-                VerifyOrExit(cur + 6 <= end, OT_NOOP);
-                VerifyOrExit(dstContextValid, OT_NOOP);
+                VerifyOrExit(cur + 6 <= end);
+                VerifyOrExit(dstContextValid);
                 aIp6Header.GetDestination().mFields.m8[1] = cur[0];
                 aIp6Header.GetDestination().mFields.m8[2] = cur[1];
                 aIp6Header.GetDestination().mFields.m8[3] = dstContext.mPrefix.GetLength();
@@ -919,7 +919,7 @@ int Lowpan::DecompressBaseHeader(Ip6::Header &       aIp6Header,
 
     if ((hcCtl & kHcNextHeader) != 0)
     {
-        VerifyOrExit(cur < end, OT_NOOP);
+        VerifyOrExit(cur < end);
         SuccessOrExit(DispatchToNextHeader(cur[0], nextHeader));
         aIp6Header.SetNextHeader(nextHeader);
     }
@@ -943,30 +943,30 @@ int Lowpan::DecompressExtensionHeader(Message &aMessage, const uint8_t *aBuf, ui
     Ip6::OptionPad1 optionPad1;
     Ip6::OptionPadN optionPadN;
 
-    VerifyOrExit(cur < end, OT_NOOP);
+    VerifyOrExit(cur < end);
     cur++;
 
     // next header
     if (ctl & kExtHdrNextHeader)
     {
-        VerifyOrExit(cur < end, OT_NOOP);
+        VerifyOrExit(cur < end);
 
         len = cur[0];
         cur++;
 
-        VerifyOrExit(cur + len <= end, OT_NOOP);
+        VerifyOrExit(cur + len <= end);
         SuccessOrExit(DispatchToNextHeader(cur[len], nextHeader));
         hdr[0] = static_cast<uint8_t>(nextHeader);
     }
     else
     {
-        VerifyOrExit(cur + 2 <= end, OT_NOOP);
+        VerifyOrExit(cur + 2 <= end);
 
         hdr[0] = cur[0];
         len    = cur[1];
         cur += 2;
 
-        VerifyOrExit(cur + len <= end, OT_NOOP);
+        VerifyOrExit(cur + len <= end);
     }
 
     // length
@@ -1014,11 +1014,11 @@ int Lowpan::DecompressUdpHeader(Ip6::Udp::Header &aUdpHeader, const uint8_t *aBu
     const uint8_t *end   = aBuf + aBufLength;
     uint8_t        udpCtl;
 
-    VerifyOrExit(cur < end, OT_NOOP);
+    VerifyOrExit(cur < end);
     udpCtl = cur[0];
     cur++;
 
-    VerifyOrExit((udpCtl & kUdpDispatchMask) == kUdpDispatch, OT_NOOP);
+    VerifyOrExit((udpCtl & kUdpDispatchMask) == kUdpDispatch);
 
     memset(&aUdpHeader, 0, sizeof(aUdpHeader));
 
@@ -1026,28 +1026,28 @@ int Lowpan::DecompressUdpHeader(Ip6::Udp::Header &aUdpHeader, const uint8_t *aBu
     switch (udpCtl & kUdpPortMask)
     {
     case 0:
-        VerifyOrExit(cur + 4 <= end, OT_NOOP);
+        VerifyOrExit(cur + 4 <= end);
         aUdpHeader.SetSourcePort(ReadUint16(cur));
         aUdpHeader.SetDestinationPort(ReadUint16(cur + 2));
         cur += 4;
         break;
 
     case 1:
-        VerifyOrExit(cur + 3 <= end, OT_NOOP);
+        VerifyOrExit(cur + 3 <= end);
         aUdpHeader.SetSourcePort(ReadUint16(cur));
         aUdpHeader.SetDestinationPort(0xf000 | cur[2]);
         cur += 3;
         break;
 
     case 2:
-        VerifyOrExit(cur + 3 <= end, OT_NOOP);
+        VerifyOrExit(cur + 3 <= end);
         aUdpHeader.SetSourcePort(0xf000 | cur[0]);
         aUdpHeader.SetDestinationPort(ReadUint16(cur + 1));
         cur += 3;
         break;
 
     case 3:
-        VerifyOrExit(cur < end, OT_NOOP);
+        VerifyOrExit(cur < end);
         aUdpHeader.SetSourcePort(0xf0b0 | (cur[0] >> 4));
         aUdpHeader.SetDestinationPort(0xf0b0 | (cur[0] & 0xf));
         cur++;
@@ -1061,7 +1061,7 @@ int Lowpan::DecompressUdpHeader(Ip6::Udp::Header &aUdpHeader, const uint8_t *aBu
     }
     else
     {
-        VerifyOrExit(cur + 2 <= end, OT_NOOP);
+        VerifyOrExit(cur + 2 <= end);
         aUdpHeader.SetChecksum(ReadUint16(cur));
         cur += 2;
     }
@@ -1078,7 +1078,7 @@ int Lowpan::DecompressUdpHeader(Message &aMessage, const uint8_t *aBuf, uint16_t
     int              headerLen = -1;
 
     headerLen = DecompressUdpHeader(udpHeader, aBuf, aBufLength);
-    VerifyOrExit(headerLen >= 0, OT_NOOP);
+    VerifyOrExit(headerLen >= 0);
 
     // length
     if (aDatagramLength == 0)
@@ -1114,9 +1114,8 @@ int Lowpan::Decompress(Message &           aMessage,
     uint16_t       compressedLength = 0;
     uint16_t       currentOffset    = aMessage.GetOffset();
 
-    VerifyOrExit(remaining >= 2, OT_NOOP);
-    VerifyOrExit((rval = DecompressBaseHeader(ip6Header, compressed, aMacSource, aMacDest, cur, remaining)) >= 0,
-                 OT_NOOP);
+    VerifyOrExit(remaining >= 2);
+    VerifyOrExit((rval = DecompressBaseHeader(ip6Header, compressed, aMacSource, aMacDest, cur, remaining)) >= 0);
 
     cur += rval;
     remaining -= rval;
@@ -1126,7 +1125,7 @@ int Lowpan::Decompress(Message &           aMessage,
 
     while (compressed)
     {
-        VerifyOrExit(remaining >= 1, OT_NOOP);
+        VerifyOrExit(remaining >= 1);
 
         if ((cur[0] & kExtHdrDispatchMask) == kExtHdrDispatch)
         {
@@ -1137,26 +1136,25 @@ int Lowpan::Decompress(Message &           aMessage,
                 cur++;
                 remaining--;
 
-                VerifyOrExit((rval = Decompress(aMessage, aMacSource, aMacDest, cur, remaining, aDatagramLength)) >= 0,
-                             OT_NOOP);
+                VerifyOrExit((rval = Decompress(aMessage, aMacSource, aMacDest, cur, remaining, aDatagramLength)) >= 0);
             }
             else
             {
                 compressed = (cur[0] & kExtHdrNextHeader) != 0;
-                VerifyOrExit((rval = DecompressExtensionHeader(aMessage, cur, remaining)) >= 0, OT_NOOP);
+                VerifyOrExit((rval = DecompressExtensionHeader(aMessage, cur, remaining)) >= 0);
             }
         }
         else if ((cur[0] & kUdpDispatchMask) == kUdpDispatch)
         {
             compressed = false;
-            VerifyOrExit((rval = DecompressUdpHeader(aMessage, cur, remaining, aDatagramLength)) >= 0, OT_NOOP);
+            VerifyOrExit((rval = DecompressUdpHeader(aMessage, cur, remaining, aDatagramLength)) >= 0);
         }
         else
         {
             ExitNow();
         }
 
-        VerifyOrExit(remaining >= rval, OT_NOOP);
+        VerifyOrExit(remaining >= rval);
         cur += rval;
         remaining -= rval;
     }
@@ -1201,17 +1199,16 @@ otError MeshHeader::ParseFrom(const uint8_t *aFrame, uint16_t aFrameLength, uint
     otError error = OT_ERROR_PARSE;
     uint8_t dispatch;
 
-    VerifyOrExit(aFrameLength >= kMinHeaderLength, OT_NOOP);
+    VerifyOrExit(aFrameLength >= kMinHeaderLength);
     dispatch = *aFrame++;
 
-    VerifyOrExit((dispatch & (kDispatchMask | kSourceShort | kDestShort)) == (kDispatch | kSourceShort | kDestShort),
-                 OT_NOOP);
+    VerifyOrExit((dispatch & (kDispatchMask | kSourceShort | kDestShort)) == (kDispatch | kSourceShort | kDestShort));
 
     mHopsLeft = (dispatch & kHopsLeftMask);
 
     if (mHopsLeft == kDeepHopsLeft)
     {
-        VerifyOrExit(aFrameLength >= kDeepHopsHeaderLength, OT_NOOP);
+        VerifyOrExit(aFrameLength >= kDeepHopsHeaderLength);
         mHopsLeft     = *aFrame++;
         aHeaderLength = kDeepHopsHeaderLength;
     }
@@ -1313,14 +1310,14 @@ otError FragmentHeader::ParseFrom(const uint8_t *aFrame, uint16_t aFrameLength, 
 {
     otError error = OT_ERROR_PARSE;
 
-    VerifyOrExit(IsFragmentHeader(aFrame, aFrameLength), OT_NOOP);
+    VerifyOrExit(IsFragmentHeader(aFrame, aFrameLength));
 
     mSize = ReadUint16(aFrame + kSizeIndex) & kSizeMask;
     mTag  = ReadUint16(aFrame + kTagIndex);
 
     if ((*aFrame & kOffsetFlag) == kOffsetFlag)
     {
-        VerifyOrExit(aFrameLength >= kSubsequentFragmentHeaderSize, OT_NOOP);
+        VerifyOrExit(aFrameLength >= kSubsequentFragmentHeaderSize);
         mOffset       = aFrame[kOffsetIndex] * 8;
         aHeaderLength = kSubsequentFragmentHeaderSize;
     }

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -120,7 +120,7 @@ void MeshForwarder::Stop(void)
 {
     Message *message;
 
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
 
     mDataPollSender.StopPolling();
     Get<TimeTicker>().UnregisterReceiver(TimeTicker::kMeshForwarder);
@@ -233,10 +233,10 @@ void MeshForwarder::ScheduleTransmissionTask(Tasklet &aTasklet)
 
 void MeshForwarder::ScheduleTransmissionTask(void)
 {
-    VerifyOrExit(!mSendBusy && !mTxPaused, OT_NOOP);
+    VerifyOrExit(!mSendBusy && !mTxPaused);
 
     mSendMessage = GetDirectTransmission();
-    VerifyOrExit(mSendMessage != nullptr, OT_NOOP);
+    VerifyOrExit(mSendMessage != nullptr);
 
     if (mSendMessage->GetOffset() == 0)
     {
@@ -812,12 +812,12 @@ Neighbor *MeshForwarder::UpdateNeighborOnSentFrame(Mac::TxFrame &aFrame, otError
 {
     Neighbor *neighbor = nullptr;
 
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
 
     neighbor = Get<NeighborTable>().FindNeighbor(aMacDest);
-    VerifyOrExit(neighbor != nullptr, OT_NOOP);
+    VerifyOrExit(neighbor != nullptr);
 
-    VerifyOrExit(aFrame.GetAckRequest(), OT_NOOP);
+    VerifyOrExit(aFrame.GetAckRequest());
 
     if (aError == OT_ERROR_NONE)
     {
@@ -826,7 +826,7 @@ Neighbor *MeshForwarder::UpdateNeighborOnSentFrame(Mac::TxFrame &aFrame, otError
     else if (aError == OT_ERROR_NO_ACK)
     {
         neighbor->IncrementLinkFailures();
-        VerifyOrExit(Mle::Mle::IsActiveRouter(neighbor->GetRloc16()), OT_NOOP);
+        VerifyOrExit(Mle::Mle::IsActiveRouter(neighbor->GetRloc16()));
 
         if (neighbor->GetLinkFailures() >= Mle::kFailedRouterTransmissions)
         {
@@ -848,7 +848,7 @@ void MeshForwarder::HandleSentFrame(Mac::TxFrame &aFrame, otError aError)
 
     mSendBusy = false;
 
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
 
     if (!aFrame.IsEmpty())
     {
@@ -856,7 +856,7 @@ void MeshForwarder::HandleSentFrame(Mac::TxFrame &aFrame, otError aError)
         neighbor = UpdateNeighborOnSentFrame(aFrame, aError, macDest);
     }
 
-    VerifyOrExit(mSendMessage != nullptr, OT_NOOP);
+    VerifyOrExit(mSendMessage != nullptr);
     OT_ASSERT(mSendMessage->GetDirectTransmission());
 
     if (aError != OT_ERROR_NONE)
@@ -1382,7 +1382,7 @@ otError MeshForwarder::ParseIp6UdpTcpHeader(const Message &aMessage,
     aDestPort   = 0;
 
     SuccessOrExit(aMessage.Read(0, aIp6Header));
-    VerifyOrExit(aIp6Header.IsVersion6(), OT_NOOP);
+    VerifyOrExit(aIp6Header.IsVersion6());
 
     switch (aIp6Header.GetNextHeader())
     {
@@ -1556,7 +1556,7 @@ void MeshForwarder::LogMessage(MessageAction       aAction,
         break;
     }
 
-    VerifyOrExit(GetInstance().GetLogLevel() >= logLevel, OT_NOOP);
+    VerifyOrExit(GetInstance().GetLogLevel() >= logLevel);
 
     switch (aMessage.GetType())
     {

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -533,15 +533,14 @@ void MeshForwarder::SendIcmpErrorIfDstUnreach(const Message &     aMessage,
     Ip6::Header ip6header;
     Child *     child;
 
-    VerifyOrExit(aMacSource.IsShort() && aMacDest.IsShort(), OT_NOOP);
+    VerifyOrExit(aMacSource.IsShort() && aMacDest.IsShort());
 
     child = Get<ChildTable>().FindChild(aMacSource.GetShort(), Child::kInStateAnyExceptInvalid);
-    VerifyOrExit((child == nullptr) || child->IsFullThreadDevice(), OT_NOOP);
+    VerifyOrExit((child == nullptr) || child->IsFullThreadDevice());
 
     IgnoreError(aMessage.Read(0, ip6header));
     VerifyOrExit(!ip6header.GetDestination().IsMulticast() &&
-                     Get<NetworkData::Leader>().IsOnMesh(ip6header.GetDestination()),
-                 OT_NOOP);
+                 Get<NetworkData::Leader>().IsOnMesh(ip6header.GetDestination()));
 
     error = Get<Mle::MleRouter>().CheckReachability(aMacDest.GetShort(), ip6header);
 
@@ -695,7 +694,7 @@ void MeshForwarder::UpdateRoutes(const uint8_t *     aFrame,
     Ip6::Header ip6Header;
     Neighbor *  neighbor;
 
-    VerifyOrExit(!aMeshDest.IsBroadcast() && aMeshSource.IsShort(), OT_NOOP);
+    VerifyOrExit(!aMeshDest.IsBroadcast() && aMeshSource.IsShort());
     SuccessOrExit(GetIp6Header(aFrame, aFrameLength, aMeshSource, aMeshDest, ip6Header));
 
     if (!ip6Header.GetSource().GetIid().IsLocator() &&
@@ -721,7 +720,7 @@ void MeshForwarder::UpdateRoutes(const uint8_t *     aFrame,
     }
 
     neighbor = Get<NeighborTable>().FindNeighbor(ip6Header.GetSource());
-    VerifyOrExit(neighbor != nullptr && !neighbor->IsFullThreadDevice(), OT_NOOP);
+    VerifyOrExit(neighbor != nullptr && !neighbor->IsFullThreadDevice());
 
     if (!Mle::Mle::RouterIdMatch(aMeshSource.GetShort(), Get<Mac::Mac>().GetShortAddress()))
     {
@@ -763,7 +762,7 @@ void MeshForwarder::UpdateFragmentPriority(Lowpan::FragmentHeader &aFragmentHead
 
     if (entry == nullptr)
     {
-        VerifyOrExit(aFragmentHeader.GetDatagramOffset() == 0, OT_NOOP);
+        VerifyOrExit(aFragmentHeader.GetDatagramOffset() == 0);
 
         mFragmentPriorityList.AllocateEntry(aSrcRloc16, aFragmentHeader.GetDatagramTag(), aPriority);
         Get<TimeTicker>().RegisterReceiver(TimeTicker::kMeshForwarder);
@@ -1022,7 +1021,7 @@ otError MeshForwarder::LogMeshFragmentHeader(MessageAction       aAction,
         otLogMac(aLogLevel, "    Frag tag:%04x, offset:%d, size:%d", fragmentHeader.GetDatagramTag(),
                  fragmentHeader.GetDatagramOffset(), fragmentHeader.GetDatagramSize());
 
-        VerifyOrExit(fragmentHeader.GetDatagramOffset() == 0, OT_NOOP);
+        VerifyOrExit(fragmentHeader.GetDatagramOffset() == 0);
     }
 
     error = OT_ERROR_NONE;
@@ -1061,7 +1060,7 @@ otError MeshForwarder::DecompressIp6UdpTcpHeader(const Message &     aMessage,
 
     headerLength = Get<Lowpan::Lowpan>().DecompressBaseHeader(aIp6Header, nextHeaderCompressed, aMeshSource, aMeshDest,
                                                               frameBuffer, frameLength);
-    VerifyOrExit(headerLength >= 0, OT_NOOP);
+    VerifyOrExit(headerLength >= 0);
 
     aOffset += headerLength;
 
@@ -1074,7 +1073,7 @@ otError MeshForwarder::DecompressIp6UdpTcpHeader(const Message &     aMessage,
         {
             frameLength  = aMessage.ReadBytes(aOffset, frameBuffer, sizeof(Ip6::Udp::Header));
             headerLength = Get<Lowpan::Lowpan>().DecompressUdpHeader(header.udp, frameBuffer, frameLength);
-            VerifyOrExit(headerLength >= 0, OT_NOOP);
+            VerifyOrExit(headerLength >= 0);
         }
         else
         {
@@ -1144,7 +1143,7 @@ void MeshForwarder::LogMeshMessage(MessageAction       aAction,
     // logged when the same Mesh Header message was received
     // and info about it was logged.
 
-    VerifyOrExit(aAction != kMessageTransmit, OT_NOOP);
+    VerifyOrExit(aAction != kMessageTransmit);
 
     LogMeshIpHeader(aMessage, offset, meshSource, meshDest, aLogLevel);
 

--- a/src/core/thread/mesh_forwarder_mtd.cpp
+++ b/src/core/thread/mesh_forwarder_mtd.cpp
@@ -54,7 +54,7 @@ otError MeshForwarder::EvictMessage(Message::Priority aPriority)
     otError  error = OT_ERROR_NOT_FOUND;
     Message *message;
 
-    VerifyOrExit((message = mSendQueue.GetTail()) != nullptr, OT_NOOP);
+    VerifyOrExit((message = mSendQueue.GetTail()) != nullptr);
 
     if (message->GetPriority() < static_cast<uint8_t>(aPriority))
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -250,7 +250,7 @@ void Mle::Stop(bool aClearNetworkDatasets)
         Get<MeshCoP::PendingDataset>().HandleDetach();
     }
 
-    VerifyOrExit(!IsDisabled(), OT_NOOP);
+    VerifyOrExit(!IsDisabled());
 
     Get<KeyManager>().Stop();
     SetStateDetached();
@@ -304,7 +304,7 @@ exit:
 
 void Mle::SetAttachState(AttachState aState)
 {
-    VerifyOrExit(aState != mAttachState, OT_NOOP);
+    VerifyOrExit(aState != mAttachState);
     otLogInfoMle("AttachState %s -> %s", AttachStateToString(mAttachState), AttachStateToString(aState));
     mAttachState = aState;
 
@@ -333,7 +333,7 @@ otError Mle::Restore(void)
     mDeviceMode.Set(networkInfo.GetDeviceMode());
 
     // force re-attach when version mismatch.
-    VerifyOrExit(networkInfo.GetVersion() == kThreadVersion, OT_NOOP);
+    VerifyOrExit(networkInfo.GetVersion() == kThreadVersion);
 
     switch (networkInfo.GetRole())
     {
@@ -473,7 +473,7 @@ otError Mle::BecomeDetached(void)
     // (i.e., waiting to start an attach attempt), there is no need to make any
     // changes.
 
-    VerifyOrExit(!IsDetached() || mAttachState != kAttachStateStart, OT_NOOP);
+    VerifyOrExit(!IsDetached() || mAttachState != kAttachStateStart);
 
     // not in reattach stage after reset
     if (mReattachState == kReattachStop)
@@ -559,7 +559,7 @@ uint32_t Mle::GetAttachStartDelay(void) const
     uint32_t delay = 1;
     uint32_t jitter;
 
-    VerifyOrExit(IsDetached(), OT_NOOP);
+    VerifyOrExit(IsDetached());
 
     if (mAttachCounter == 0)
     {
@@ -694,12 +694,11 @@ void Mle::SetStateChild(uint16_t aRloc16)
 
 void Mle::InformPreviousChannel(void)
 {
-    VerifyOrExit(mAlternatePanId != Mac::kPanIdBroadcast, OT_NOOP);
-    VerifyOrExit(IsChild() || IsRouter(), OT_NOOP);
+    VerifyOrExit(mAlternatePanId != Mac::kPanIdBroadcast);
+    VerifyOrExit(IsChild() || IsRouter());
 
 #if OPENTHREAD_FTD
-    VerifyOrExit(!IsFullThreadDevice() || IsRouter() || Get<MleRouter>().GetRouterSelectionJitterTimeout() == 0,
-                 OT_NOOP);
+    VerifyOrExit(!IsFullThreadDevice() || IsRouter() || Get<MleRouter>().GetRouterSelectionJitterTimeout() == 0);
 #endif
 
     mAlternatePanId = Mac::kPanIdBroadcast;
@@ -711,7 +710,7 @@ exit:
 
 void Mle::SetTimeout(uint32_t aTimeout)
 {
-    VerifyOrExit(mTimeout != aTimeout, OT_NOOP);
+    VerifyOrExit(mTimeout != aTimeout);
 
     if (aTimeout < kMinTimeout)
     {
@@ -737,7 +736,7 @@ otError Mle::SetDeviceMode(DeviceMode aDeviceMode)
     DeviceMode oldMode = mDeviceMode;
 
     VerifyOrExit(aDeviceMode.IsValid(), error = OT_ERROR_INVALID_ARGS);
-    VerifyOrExit(mDeviceMode != aDeviceMode, OT_NOOP);
+    VerifyOrExit(mDeviceMode != aDeviceMode);
     mDeviceMode = aDeviceMode;
 
 #if OPENTHREAD_CONFIG_OTNS_ENABLE
@@ -808,7 +807,7 @@ void Mle::SetMeshLocalPrefix(const MeshLocalPrefix &aMeshLocalPrefix)
     mLeaderAloc.GetAddress().SetPrefix(aMeshLocalPrefix);
 
     // Just keep mesh local prefix if network interface is down
-    VerifyOrExit(Get<ThreadNetif>().IsUp(), OT_NOOP);
+    VerifyOrExit(Get<ThreadNetif>().IsUp());
 
     ApplyMeshLocalPrefix();
 
@@ -821,7 +820,7 @@ void Mle::ApplyMeshLocalPrefix(void)
     mLinkLocalAllThreadNodes.GetAddress().SetMulticastNetworkPrefix(GetMeshLocalPrefix());
     mRealmLocalAllThreadNodes.GetAddress().SetMulticastNetworkPrefix(GetMeshLocalPrefix());
 
-    VerifyOrExit(!IsDisabled(), OT_NOOP);
+    VerifyOrExit(!IsDisabled());
 
     // Add the addresses back into the table.
     Get<ThreadNetif>().AddUnicastAddress(mMeshLocal64);
@@ -980,7 +979,7 @@ Message *Mle::NewMleMessage(void)
     Message::Settings settings(Message::kNoLinkSecurity, Message::kPriorityNet);
 
     message = mSocket.NewMessage(0, settings);
-    VerifyOrExit(message != nullptr, OT_NOOP);
+    VerifyOrExit(message != nullptr);
 
     message->SetSubType(Message::kSubTypeMleGeneral);
 
@@ -1227,7 +1226,7 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
     length += entry.GetLength();
 
     // Continue to append the other addresses if not `kAppendMeshLocalOnly` mode
-    VerifyOrExit(aMode != kAppendMeshLocalOnly, OT_NOOP);
+    VerifyOrExit(aMode != kAppendMeshLocalOnly);
     counter++;
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
@@ -1282,7 +1281,7 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
         length += entry.GetLength();
         counter++;
         // only continue to append if there is available entry.
-        VerifyOrExit(counter < OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER, OT_NOOP);
+        VerifyOrExit(counter < OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER);
     }
 
     // Append external multicast addresses.  For sleepy end device,
@@ -1314,7 +1313,7 @@ otError Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMod
 
             counter++;
             // only continue to append if there is available entry.
-            VerifyOrExit(counter < OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER, OT_NOOP);
+            VerifyOrExit(counter < OPENTHREAD_CONFIG_MLE_IP_ADDRS_TO_REGISTER);
         }
     }
 
@@ -1400,7 +1399,7 @@ otError Mle::AppendCslChannel(Message &aMessage)
     // in CSL Channel TLV, if CSL channel is not specified, we don't append CSL Channel TLV.
     // And on transmitter side, it would also set CSL Channel for the child to `0` if it doesn't find a CSL Channel
     // TLV.
-    VerifyOrExit(Get<Mac::Mac>().IsCslChannelSpecified(), OT_NOOP);
+    VerifyOrExit(Get<Mac::Mac>().IsCslChannelSpecified());
 
     cslChannel.Init();
     cslChannel.SetChannelPage(0);
@@ -1422,7 +1421,7 @@ otError Mle::AppendCslTimeout(Message &aMessage)
 
 void Mle::HandleNotifierEvents(Events aEvents)
 {
-    VerifyOrExit(!IsDisabled(), OT_NOOP);
+    VerifyOrExit(!IsDisabled());
 
     if (aEvents.Contains(kEventThreadRoleChanged))
     {
@@ -1538,7 +1537,7 @@ void Mle::UpdateServiceAlocs(void)
     size_t                serviceAlocsLength = OT_ARRAY_LENGTH(mServiceAlocs);
     size_t                i                  = 0;
 
-    VerifyOrExit(!IsDisabled(), OT_NOOP);
+    VerifyOrExit(!IsDisabled());
 
     // First remove all alocs which are no longer necessary, to free up space in mServiceAlocs
     for (i = 0; i < serviceAlocsLength; i++)
@@ -1729,8 +1728,7 @@ bool Mle::PrepareAnnounceState(void)
     Mac::ChannelMask channelMask;
 
     VerifyOrExit(!IsChild() && (mReattachState == kReattachStop) &&
-                     (Get<MeshCoP::ActiveDataset>().IsPartiallyComplete() || !IsFullThreadDevice()),
-                 OT_NOOP);
+                 (Get<MeshCoP::ActiveDataset>().IsPartiallyComplete() || !IsFullThreadDevice()));
 
     if (Get<MeshCoP::ActiveDataset>().GetChannelMask(channelMask) != OT_ERROR_NONE)
     {
@@ -1774,7 +1772,7 @@ uint32_t Mle::Reattach(void)
         IgnoreError(Get<MeshCoP::ActiveDataset>().Restore());
     }
 
-    VerifyOrExit(mReattachState == kReattachStop, OT_NOOP);
+    VerifyOrExit(mReattachState == kReattachStop);
 
     switch (mParentRequestMode)
     {
@@ -2176,7 +2174,7 @@ void Mle::HandleMessageTransmissionTimer(void)
         }
 
         // Keep-alive "Child Update Request" only on a non-sleepy child
-        VerifyOrExit(IsChild() && IsRxOnWhenIdle(), OT_NOOP);
+        VerifyOrExit(IsChild() && IsRxOnWhenIdle());
         break;
 
     case kChildUpdateRequestPending:
@@ -2526,7 +2524,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 
     otLogDebgMle("Receive UDP message");
 
-    VerifyOrExit(aMessageInfo.GetLinkInfo() != nullptr, OT_NOOP);
+    VerifyOrExit(aMessageInfo.GetLinkInfo() != nullptr);
     VerifyOrExit(aMessageInfo.GetHopLimit() == kMleHopLimit, error = OT_ERROR_PARSE);
 
     length = aMessage.ReadBytes(aMessage.GetOffset(), &header, sizeof(header));
@@ -2767,7 +2765,7 @@ void Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &a
         ExitNow();
 
     case kRoleChild:
-        VerifyOrExit(aNeighbor == &mParent, OT_NOOP);
+        VerifyOrExit(aNeighbor == &mParent);
 
         if ((mParent.GetRloc16() == sourceAddress) && (leaderData.GetPartitionId() != mLeaderData.GetPartitionId() ||
                                                        leaderData.GetLeaderRouterId() != GetLeaderId()))
@@ -2795,7 +2793,7 @@ void Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &a
 
     case kRoleRouter:
     case kRoleLeader:
-        VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), OT_NOOP);
+        VerifyOrExit(aNeighbor && aNeighbor->IsStateValid());
         break;
     }
 
@@ -2891,7 +2889,7 @@ otError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &a
     }
     else if (!mRetrieveNewNetworkData)
     {
-        VerifyOrExit(IsNetworkDataNewer(leaderData), OT_NOOP);
+        VerifyOrExit(IsNetworkDataNewer(leaderData));
     }
 
     // Active Timestamp
@@ -3169,26 +3167,25 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
         switch (mParentRequestMode)
         {
         case kAttachAny:
-            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId() || diff > 0, OT_NOOP);
+            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId() || diff > 0);
             break;
 
         case kAttachSame1:
         case kAttachSame2:
-            VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId(), OT_NOOP);
-            VerifyOrExit(diff > 0, OT_NOOP);
+            VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId());
+            VerifyOrExit(diff > 0);
             break;
 
         case kAttachSameDowngrade:
-            VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId(), OT_NOOP);
-            VerifyOrExit(diff >= 0, OT_NOOP);
+            VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId());
+            VerifyOrExit(diff >= 0);
             break;
 
         case kAttachBetter:
-            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId(), OT_NOOP);
+            VerifyOrExit(leaderData.GetPartitionId() != mLeaderData.GetPartitionId());
 
             VerifyOrExit(MleRouter::ComparePartitions(connectivity.GetActiveRouters() <= 1, leaderData,
-                                                      Get<MleRouter>().IsSingleton(), mLeaderData) > 0,
-                         OT_NOOP);
+                                                      Get<MleRouter>().IsSingleton(), mLeaderData) > 0);
             break;
         }
     }
@@ -3211,13 +3208,12 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
         }
 
         // only consider partitions that are the same or better
-        VerifyOrExit(compare >= 0, OT_NOOP);
+        VerifyOrExit(compare >= 0);
 #endif
 
         // only consider better parents if the partitions are the same
         VerifyOrExit(compare != 0 || IsBetterParent(sourceAddress, linkQuality, linkMargin, connectivity,
-                                                    static_cast<uint8_t>(version)),
-                     OT_NOOP);
+                                                    static_cast<uint8_t>(version)));
     }
 
     // Link Frame Counter
@@ -3240,7 +3236,7 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
     // Time Parameter
     if (Tlv::FindTlv(aMessage, Tlv::kTimeParameter, sizeof(timeParameter), timeParameter) == OT_ERROR_NONE)
     {
-        VerifyOrExit(timeParameter.IsValid(), OT_NOOP);
+        VerifyOrExit(timeParameter.IsValid());
 
         Get<TimeSync>().SetTimeSyncPeriod(timeParameter.GetTimeSyncPeriod());
         Get<TimeSync>().SetXtalThreshold(timeParameter.GetXtalThreshold());
@@ -3312,7 +3308,7 @@ void Mle::HandleChildIdResponse(const Message &         aMessage,
 
     VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), error = OT_ERROR_SECURITY);
 
-    VerifyOrExit(mAttachState == kAttachStateChildIdRequest, OT_NOOP);
+    VerifyOrExit(mAttachState == kAttachStateChildIdRequest);
 
     // Leader Data
     SuccessOrExit(error = ReadLeaderData(aMessage, leaderData));
@@ -3658,12 +3654,11 @@ void Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMessa
         // Announce message.
 
         VerifyOrExit(!IsDetached() || (Get<Mac::Mac>().GetPanChannel() != channel) ||
-                         (Get<Mac::Mac>().GetPanId() != panId),
-                     OT_NOOP);
+                     (Get<Mac::Mac>().GetPanId() != panId));
 
         if (mAttachState == kAttachStateProcessAnnounce)
         {
-            VerifyOrExit(mAlternateTimestamp < timestamp.GetSeconds(), OT_NOOP);
+            VerifyOrExit(mAlternateTimestamp < timestamp.GetSeconds());
         }
 
         mAlternateTimestamp = timestamp.GetSeconds();
@@ -3760,8 +3755,7 @@ void Mle::InformPreviousParent(void)
     Message *        message = nullptr;
     Ip6::MessageInfo messageInfo;
 
-    VerifyOrExit((mPreviousParentRloc != Mac::kShortAddrInvalid) && (mPreviousParentRloc != mParent.GetRloc16()),
-                 OT_NOOP);
+    VerifyOrExit((mPreviousParentRloc != Mac::kShortAddrInvalid) && (mPreviousParentRloc != mParent.GetRloc16()));
 
     mCounters.mParentChanges++;
 
@@ -3814,11 +3808,11 @@ void Mle::HandleParentSearchTimer(void)
 
     mParentSearchIsInBackoff = false;
 
-    VerifyOrExit(IsChild(), OT_NOOP);
+    VerifyOrExit(IsChild());
 
     parentRss = GetParent().GetLinkInfo().GetAverageRss();
     otLogInfoMle("PeriodicParentSearch: Parent RSS %d", parentRss);
-    VerifyOrExit(parentRss != OT_RADIO_RSSI_INVALID, OT_NOOP);
+    VerifyOrExit(parentRss != OT_RADIO_RSSI_INVALID);
 
     if (parentRss < kParentSearchRssThreadhold)
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -250,7 +250,7 @@ void MleRouter::HandleChildStart(AttachMode aMode)
 
     Get<ThreadNetif>().SubscribeAllRoutersMulticast();
 
-    VerifyOrExit(IsRouterIdValid(mPreviousRouterId), OT_NOOP);
+    VerifyOrExit(IsRouterIdValid(mPreviousRouterId));
 
     switch (aMode)
     {
@@ -405,7 +405,7 @@ void MleRouter::StopAdvertiseTimer(void)
 
 void MleRouter::ResetAdvertiseInterval(void)
 {
-    VerifyOrExit(IsRouterOrLeader(), OT_NOOP);
+    VerifyOrExit(IsRouterOrLeader());
 
     if (!mAdvertiseTimer.IsRunning())
     {
@@ -430,13 +430,13 @@ void MleRouter::SendAdvertisement(void)
     // Without this suppression, a device may send an MLE Advertisement before receiving the MLE Child ID Response.
     // The candidate parent then removes the attaching device because the Source Address TLV includes an RLOC16 that
     // indicates a Router role (i.e. a Child ID equal to zero).
-    VerifyOrExit(!IsAttaching(), OT_NOOP);
+    VerifyOrExit(!IsAttaching());
 
     // Suppress MLE Advertisements when transitioning to the router role.
     //
     // When trying to attach to a new partition, sending out advertisements as a REED can cause already-attached
     // children to detach.
-    VerifyOrExit(!mAddressSolicitPending, OT_NOOP);
+    VerifyOrExit(!mAddressSolicitPending);
 
     VerifyOrExit((message = NewMleMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = AppendHeader(*message, kCommandAdvertisement));
@@ -617,7 +617,7 @@ void MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInf
             }
             else
             {
-                VerifyOrExit(neighbor->GetExtAddress() == extAddr, OT_NOOP);
+                VerifyOrExit(neighbor->GetExtAddress() == extAddr);
             }
         }
 
@@ -891,7 +891,7 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
         mRouterTable.Clear();
         SuccessOrExit(error = ProcessRouteTlv(route));
         router = mRouterTable.GetRouter(routerId);
-        VerifyOrExit(router != nullptr, OT_NOOP);
+        VerifyOrExit(router != nullptr);
 
         if (mLeaderData.GetLeaderRouterId() == RouterIdFromRloc16(GetRloc16()))
         {
@@ -911,16 +911,16 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
         break;
 
     case kRoleChild:
-        VerifyOrExit(router != nullptr, OT_NOOP);
+        VerifyOrExit(router != nullptr);
         break;
 
     case kRoleRouter:
     case kRoleLeader:
-        VerifyOrExit(router != nullptr, OT_NOOP);
+        VerifyOrExit(router != nullptr);
 
         // Leader Data
         SuccessOrExit(error = ReadLeaderData(aMessage, leaderData));
-        VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId(), OT_NOOP);
+        VerifyOrExit(leaderData.GetPartitionId() == mLeaderData.GetPartitionId());
 
         if (mRetrieveNewNetworkData ||
             (static_cast<int8_t>(leaderData.GetDataVersion() - Get<NetworkData::Leader>().GetVersion()) > 0))
@@ -1028,7 +1028,7 @@ uint8_t MleRouter::GetLinkCost(uint8_t aRouterId)
     router = mRouterTable.GetRouter(aRouterId);
 
     // nullptr aRouterId indicates non-existing next hop, hence return kMaxRouteCost for it.
-    VerifyOrExit(router != nullptr, OT_NOOP);
+    VerifyOrExit(router != nullptr);
 
     rval = mRouterTable.GetLinkCost(*router);
 
@@ -1199,7 +1199,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
     }
     else if (leaderData.GetLeaderRouterId() != GetLeaderId())
     {
-        VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), OT_NOOP);
+        VerifyOrExit(aNeighbor && aNeighbor->IsStateValid());
 
         if (!IsChild())
         {
@@ -1211,7 +1211,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
         ExitNow();
     }
 
-    VerifyOrExit(IsActiveRouter(sourceAddress) && route.IsValid(), OT_NOOP);
+    VerifyOrExit(IsActiveRouter(sourceAddress) && route.IsValid());
     routerId = RouterIdFromRloc16(sourceAddress);
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
@@ -1329,7 +1329,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
         {
             // MLE Advertisement not from parent, but from some other neighboring router
             router = mRouterTable.GetRouter(routerId);
-            VerifyOrExit(router != nullptr, OT_NOOP);
+            VerifyOrExit(router != nullptr);
 
             if (IsFullThreadDevice() && !router->IsStateValid() && !router->IsStateLinkRequest() &&
                 (mRouterTable.GetActiveLinkCount() < OPENTHREAD_CONFIG_MLE_CHILD_ROUTER_LINKS))
@@ -1351,7 +1351,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
 
     case kRoleRouter:
         router = mRouterTable.GetRouter(routerId);
-        VerifyOrExit(router != nullptr, OT_NOOP);
+        VerifyOrExit(router != nullptr);
 
         // check current active router number
         routerCount = 0;
@@ -1375,7 +1375,7 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
 
     case kRoleLeader:
         router = mRouterTable.GetRouter(routerId);
-        VerifyOrExit(router != nullptr, OT_NOOP);
+        VerifyOrExit(router != nullptr);
 
         // Send unicast link request if no link to router and no unicast/multicast link request in progress
         if (!router->IsStateValid() && !router->IsStateLinkRequest() && (mChallengeTimeout == 0) &&
@@ -1414,7 +1414,7 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
     bool    changed          = false;
 
     neighbor = mRouterTable.GetRouter(aRouterId);
-    VerifyOrExit(neighbor != nullptr, OT_NOOP);
+    VerifyOrExit(neighbor != nullptr);
 
     // update link quality out to neighbor
     changed = UpdateLinkQualityOut(aRoute, *neighbor, resetAdvInterval);
@@ -1501,7 +1501,7 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
 
 #if (OPENTHREAD_CONFIG_LOG_MLE && (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO))
 
-    VerifyOrExit(changed, OT_NOOP);
+    VerifyOrExit(changed);
     otLogInfoMle("Route table updated");
 
     for (Router &router : Get<RouterTable>().Iterate())
@@ -1531,7 +1531,7 @@ bool MleRouter::UpdateLinkQualityOut(const RouteTlv &aRoute, Router &aNeighbor, 
     Router *nextHop;
 
     myRouterId = RouterIdFromRloc16(GetRloc16());
-    VerifyOrExit(aRoute.IsRouterIdSet(myRouterId), OT_NOOP);
+    VerifyOrExit(aRoute.IsRouterIdSet(myRouterId));
 
     myRouteCount = 0;
     for (uint8_t routerId = 0; routerId < myRouterId; routerId++)
@@ -1540,7 +1540,7 @@ bool MleRouter::UpdateLinkQualityOut(const RouteTlv &aRoute, Router &aNeighbor, 
     }
 
     linkQuality = aRoute.GetLinkQualityIn(myRouteCount);
-    VerifyOrExit(aNeighbor.GetLinkQualityOut() != linkQuality, OT_NOOP);
+    VerifyOrExit(aNeighbor.GetLinkQualityOut() != linkQuality);
 
     oldLinkCost = mRouterTable.GetLinkCost(aNeighbor);
 
@@ -1618,13 +1618,13 @@ void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageI
         ExitNow();
 
     case kRoleChild:
-        VerifyOrExit(ScanMaskTlv::IsEndDeviceFlagSet(scanMask), OT_NOOP);
+        VerifyOrExit(ScanMaskTlv::IsEndDeviceFlagSet(scanMask));
         VerifyOrExit(mRouterTable.GetActiveRouterCount() < kMaxRouters, error = OT_ERROR_DROP);
         break;
 
     case kRoleRouter:
     case kRoleLeader:
-        VerifyOrExit(ScanMaskTlv::IsRouterFlagSet(scanMask), OT_NOOP);
+        VerifyOrExit(ScanMaskTlv::IsRouterFlagSet(scanMask));
         break;
     }
 
@@ -2738,7 +2738,7 @@ void MleRouter::HandleNetworkDataUpdateRouter(void)
     Ip6::Address         destination;
     uint16_t             delay;
 
-    VerifyOrExit(IsRouterOrLeader(), OT_NOOP);
+    VerifyOrExit(IsRouterOrLeader());
 
     destination.SetToLinkLocalAllNodesMulticast();
 
@@ -2753,7 +2753,7 @@ exit:
 
 void MleRouter::SynchronizeChildNetworkData(void)
 {
-    VerifyOrExit(IsRouterOrLeader(), OT_NOOP);
+    VerifyOrExit(IsRouterOrLeader());
 
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
@@ -3327,7 +3327,7 @@ void MleRouter::RemoveRouterLink(Router &aRouter)
 
 void MleRouter::RemoveNeighbor(Neighbor &aNeighbor)
 {
-    VerifyOrExit(!aNeighbor.IsStateInvalid(), OT_NOOP);
+    VerifyOrExit(!aNeighbor.IsStateInvalid());
 
     if (&aNeighbor == &mParent)
     {
@@ -3395,7 +3395,7 @@ uint16_t MleRouter::GetNextHop(uint16_t aDestination)
     }
 
     router = mRouterTable.GetRouter(destinationId);
-    VerifyOrExit(router != nullptr, OT_NOOP);
+    VerifyOrExit(router != nullptr);
 
     linkCost  = GetLinkCost(destinationId);
     routeCost = GetRouteCost(aDestination);
@@ -3403,7 +3403,7 @@ uint16_t MleRouter::GetNextHop(uint16_t aDestination)
     if ((routeCost + GetLinkCost(router->GetNextHop())) < linkCost)
     {
         nextHop = mRouterTable.GetRouter(router->GetNextHop());
-        VerifyOrExit(nextHop != nullptr && !nextHop->IsStateInvalid(), OT_NOOP);
+        VerifyOrExit(nextHop != nullptr && !nextHop->IsStateInvalid());
 
         rval = Rloc16FromRouterId(router->GetNextHop());
     }
@@ -3423,7 +3423,7 @@ uint8_t MleRouter::GetCost(uint16_t aRloc16)
     Router *router   = mRouterTable.GetRouter(routerId);
     uint8_t routeCost;
 
-    VerifyOrExit(router != nullptr && mRouterTable.GetRouter(router->GetNextHop()) != nullptr, OT_NOOP);
+    VerifyOrExit(router != nullptr && mRouterTable.GetRouter(router->GetNextHop()) != nullptr);
 
     routeCost = GetRouteCost(aRloc16) + GetLinkCost(router->GetNextHop());
 
@@ -3442,7 +3442,7 @@ uint8_t MleRouter::GetRouteCost(uint16_t aRloc16) const
     const Router *router;
 
     router = mRouterTable.GetRouter(RouterIdFromRloc16(aRloc16));
-    VerifyOrExit(router != nullptr && mRouterTable.GetRouter(router->GetNextHop()) != nullptr, OT_NOOP);
+    VerifyOrExit(router != nullptr && mRouterTable.GetRouter(router->GetNextHop()) != nullptr);
 
     rval = router->GetCost();
 
@@ -3479,7 +3479,7 @@ void MleRouter::ResolveRoutingLoops(uint16_t aSourceMac, uint16_t aDestRloc16)
 
     // loop exists
     router = mRouterTable.GetRouter(RouterIdFromRloc16(aDestRloc16));
-    VerifyOrExit(router != nullptr, OT_NOOP);
+    VerifyOrExit(router != nullptr);
 
     // invalidate next hop
     router->SetNextHop(kInvalidRouterId);
@@ -3539,7 +3539,7 @@ otError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
     Ip6::MessageInfo messageInfo;
     Coap::Message *  message = nullptr;
 
-    VerifyOrExit(!mAddressSolicitPending, OT_NOOP);
+    VerifyOrExit(!mAddressSolicitPending);
 
     VerifyOrExit((message = Get<Tmf::TmfAgent>().NewPriorityMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
 
@@ -3628,9 +3628,9 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
 
     mAddressSolicitPending = false;
 
-    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage != nullptr && aMessage != nullptr, OT_NOOP);
+    VerifyOrExit(aResult == OT_ERROR_NONE && aMessage != nullptr && aMessage != nullptr);
 
-    VerifyOrExit(aMessage->GetCode() == Coap::kCodeChanged, OT_NOOP);
+    VerifyOrExit(aMessage->GetCode() == Coap::kCodeChanged);
 
     Log(kMessageReceive, kTypeAddressReply, aMessageInfo->GetPeerAddr());
 
@@ -3657,7 +3657,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
     routerId = RouterIdFromRloc16(rloc16);
 
     SuccessOrExit(ThreadTlv::FindTlv(*aMessage, ThreadTlv::kRouterMask, sizeof(routerMaskTlv), routerMaskTlv));
-    VerifyOrExit(routerMaskTlv.IsValid(), OT_NOOP);
+    VerifyOrExit(routerMaskTlv.IsValid());
 
     // assign short address
     SetRouterId(routerId);
@@ -3667,13 +3667,13 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
     mRouterTable.UpdateRouterIdSet(routerMaskTlv.GetIdSequence(), routerMaskTlv.GetAssignedRouterIdMask());
 
     router = mRouterTable.GetRouter(routerId);
-    VerifyOrExit(router != nullptr, OT_NOOP);
+    VerifyOrExit(router != nullptr);
 
     router->SetExtAddress(Get<Mac::Mac>().GetExtAddress());
     router->SetCost(0);
 
     router = mRouterTable.GetRouter(mParent.GetRouterId());
-    VerifyOrExit(router != nullptr, OT_NOOP);
+    VerifyOrExit(router != nullptr);
 
     // Keep link to the parent in order to respond to Parent Requests before new link is established.
     *router = mParent;
@@ -3740,7 +3740,7 @@ void MleRouter::HandleAddressSolicit(Coap::Message &aMessage, const Ip6::Message
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     // In a time sync enabled network, all routers' xtal accuracy must be less than the threshold.
     SuccessOrExit(Tlv::FindUint16Tlv(aMessage, Tlv::kXtalAccuracy, xtalAccuracy));
-    VerifyOrExit(xtalAccuracy <= Get<TimeSync>().GetXtalThreshold(), OT_NOOP);
+    VerifyOrExit(xtalAccuracy <= Get<TimeSync>().GetXtalThreshold());
 #endif
 
     // see if allocation already exists
@@ -3755,7 +3755,7 @@ void MleRouter::HandleAddressSolicit(Coap::Message &aMessage, const Ip6::Message
     switch (status)
     {
     case ThreadStatusTlv::kTooFewRouters:
-        VerifyOrExit(mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold, OT_NOOP);
+        VerifyOrExit(mRouterTable.GetActiveRouterCount() < mRouterUpgradeThreshold);
         break;
 
     case ThreadStatusTlv::kHaveChildIdRequest:
@@ -3854,7 +3854,7 @@ void MleRouter::HandleAddressRelease(Coap::Message &aMessage, const Ip6::Message
     uint8_t         routerId;
     Router *        router;
 
-    VerifyOrExit(aMessage.IsConfirmablePostRequest(), OT_NOOP);
+    VerifyOrExit(aMessage.IsConfirmablePostRequest());
 
     Log(kMessageReceive, kTypeAddressRelease, aMessageInfo.GetPeerAddr());
 
@@ -3865,7 +3865,7 @@ void MleRouter::HandleAddressRelease(Coap::Message &aMessage, const Ip6::Message
     routerId = RouterIdFromRloc16(rloc16);
     router   = mRouterTable.GetRouter(routerId);
 
-    VerifyOrExit((router != nullptr) && (router->GetExtAddress() == extAddress), OT_NOOP);
+    VerifyOrExit((router != nullptr) && (router->GetExtAddress() == extAddress));
 
     IgnoreError(mRouterTable.Release(routerId));
 
@@ -4276,7 +4276,7 @@ exit:
 
 void MleRouter::SetChildStateToValid(Child &aChild)
 {
-    VerifyOrExit(!aChild.IsStateValid(), OT_NOOP);
+    VerifyOrExit(!aChild.IsStateValid());
 
     aChild.SetState(Neighbor::kStateValid);
     IgnoreError(mChildTable.StoreChild(aChild));
@@ -4309,7 +4309,7 @@ bool MleRouter::HasSmallNumberOfChildren(void)
     uint16_t numChildren = 0;
     uint8_t  routerCount = mRouterTable.GetActiveRouterCount();
 
-    VerifyOrExit(routerCount > mRouterDowngradeThreshold, OT_NOOP);
+    VerifyOrExit(routerCount > mRouterDowngradeThreshold);
 
     numChildren = mChildTable.GetNumChildren(Child::kInStateValid);
 
@@ -4362,7 +4362,7 @@ void MleRouter::HandleTimeSync(const Message &aMessage, const Ip6::MessageInfo &
 {
     Log(kMessageReceive, kTypeTimeSync, aMessageInfo.GetPeerAddr());
 
-    VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), OT_NOOP);
+    VerifyOrExit(aNeighbor && aNeighbor->IsStateValid());
 
     Get<TimeSync>().HandleTimeSyncMessage(aMessage);
 

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -151,7 +151,7 @@ void MlrManager::UpdateProxiedSubscriptions(Child &             aChild,
                                             const Ip6::Address *aOldMlrRegisteredAddresses,
                                             uint16_t            aOldMlrRegisteredAddressNum)
 {
-    VerifyOrExit(aChild.IsStateValid(), OT_NOOP);
+    VerifyOrExit(aChild.IsStateValid());
 
     // Search the new multicast addresses and set its flag accordingly
     for (const Ip6::Address &address : aChild.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
@@ -194,7 +194,7 @@ void MlrManager::ScheduleSend(uint16_t aDelay)
 {
     OT_ASSERT(!mMlrPending || mSendDelay == 0);
 
-    VerifyOrExit(!mMlrPending, OT_NOOP);
+    VerifyOrExit(!mMlrPending);
 
     if (aDelay == 0)
     {

--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -101,7 +101,7 @@ Neighbor *NeighborTable::FindNeighbor(Mac::ShortAddress aShortAddress, Neighbor:
 {
     Neighbor *neighbor = nullptr;
 
-    VerifyOrExit((aShortAddress != Mac::kShortAddrBroadcast) && (aShortAddress != Mac::kShortAddrInvalid), OT_NOOP);
+    VerifyOrExit((aShortAddress != Mac::kShortAddrBroadcast) && (aShortAddress != Mac::kShortAddrInvalid));
     neighbor = FindNeighbor(Neighbor::AddressMatcher(aShortAddress, aFilter));
 
 exit:
@@ -171,7 +171,7 @@ Neighbor *NeighborTable::FindRxOnlyNeighborRouter(const Mac::Address &aMacAddres
 {
     Neighbor *neighbor = nullptr;
 
-    VerifyOrExit(Get<Mle::Mle>().IsChild(), OT_NOOP);
+    VerifyOrExit(Get<Mle::Mle>().IsChild());
     neighbor = Get<RouterTable>().GetNeighbor(aMacAddress);
 
 exit:
@@ -240,10 +240,10 @@ otError NeighborTable::GetNextNeighborInfo(otNeighborInfoIterator &aIterator, Ne
 {
     otError error = OT_ERROR_NOT_FOUND;
 
-    VerifyOrExit(aIterator == OT_NEIGHBOR_INFO_ITERATOR_INIT, OT_NOOP);
+    VerifyOrExit(aIterator == OT_NEIGHBOR_INFO_ITERATOR_INIT);
 
     aIterator++;
-    VerifyOrExit(Get<Mle::Mle>().GetParent().IsStateValid(), OT_NOOP);
+    VerifyOrExit(Get<Mle::Mle>().GetParent().IsStateValid());
 
     aNeighInfo.SetFrom(Get<Mle::Mle>().GetParent());
     aNeighInfo.mIsChild = false;

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -697,7 +697,7 @@ const PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix,
     {
         prefixTlv = FindTlv<PrefixTlv>(start, end);
 
-        VerifyOrExit(prefixTlv != nullptr, OT_NOOP);
+        VerifyOrExit(prefixTlv != nullptr);
 
         if (prefixTlv->IsEqual(aPrefix, aPrefixLength))
         {
@@ -734,7 +734,7 @@ const ServiceTlv *NetworkData::FindService(uint32_t       aEnterpriseNumber,
     {
         serviceTlv = FindTlv<ServiceTlv>(start, end);
 
-        VerifyOrExit(serviceTlv != nullptr, OT_NOOP);
+        VerifyOrExit(serviceTlv != nullptr);
 
         if ((serviceTlv->GetEnterpriseNumber() == aEnterpriseNumber) &&
             (serviceTlv->GetServiceDataLength() == aServiceDataLength) &&

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -124,7 +124,7 @@ otError LeaderBase::GetBackboneRouterPrimary(BackboneRouter::BackboneRouterConfi
         }
     }
 
-    VerifyOrExit(rvalServerTlv != nullptr, OT_NOOP);
+    VerifyOrExit(rvalServerTlv != nullptr);
 
     aConfig.mServer16            = rvalServerTlv->GetServer16();
     aConfig.mSequenceNumber      = rvalServerData->GetSequenceNumber();
@@ -499,7 +499,7 @@ const MeshCoP::Tlv *LeaderBase::GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aT
     const NetworkDataTlv *commissioningDataTlv;
 
     commissioningDataTlv = GetCommissioningData();
-    VerifyOrExit(commissioningDataTlv != nullptr, OT_NOOP);
+    VerifyOrExit(commissioningDataTlv != nullptr);
 
     rval = MeshCoP::Tlv::FindTlv(commissioningDataTlv->GetValue(), commissioningDataTlv->GetLength(), aType);
 
@@ -512,10 +512,10 @@ bool LeaderBase::IsJoiningEnabled(void) const
     const MeshCoP::Tlv *steeringData;
     bool                rval = false;
 
-    VerifyOrExit(GetCommissioningDataSubTlv(MeshCoP::Tlv::kBorderAgentLocator) != nullptr, OT_NOOP);
+    VerifyOrExit(GetCommissioningDataSubTlv(MeshCoP::Tlv::kBorderAgentLocator) != nullptr);
 
     steeringData = GetCommissioningDataSubTlv(MeshCoP::Tlv::kSteeringData);
-    VerifyOrExit(steeringData != nullptr, OT_NOOP);
+    VerifyOrExit(steeringData != nullptr);
 
     for (int i = 0; i < steeringData->GetLength(); i++)
     {
@@ -533,7 +533,7 @@ void LeaderBase::RemoveCommissioningData(void)
 {
     CommissioningDataTlv *tlv = GetCommissioningData();
 
-    VerifyOrExit(tlv != nullptr, OT_NOOP);
+    VerifyOrExit(tlv != nullptr);
     RemoveTlv(tlv);
 
 exit:

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -144,7 +144,7 @@ void Leader::HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &a
 
     otLogInfoNetData("Received network data registration");
 
-    VerifyOrExit(aMessageInfo.GetPeerAddr().GetIid().IsRoutingLocator(), OT_NOOP);
+    VerifyOrExit(aMessageInfo.GetPeerAddr().GetIid().IsRoutingLocator());
 
     switch (Tlv::FindUint16Tlv(aMessage, ThreadTlv::kRloc16, rloc16))
     {
@@ -159,7 +159,7 @@ void Leader::HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &a
 
     if (ThreadTlv::FindTlv(aMessage, ThreadTlv::kThreadNetworkData, sizeof(networkData), networkData) == OT_ERROR_NONE)
     {
-        VerifyOrExit(networkData.IsValid(), OT_NOOP);
+        VerifyOrExit(networkData.IsValid());
         RegisterNetworkData(aMessageInfo.GetPeerAddr().GetIid().GetLocator(), networkData.GetTlvs(),
                             networkData.GetLength());
     }
@@ -192,8 +192,8 @@ void Leader::HandleCommissioningSet(Coap::Message &aMessage, const Ip6::MessageI
     MeshCoP::Tlv *cur;
     MeshCoP::Tlv *end;
 
-    VerifyOrExit(length <= sizeof(tlvs), OT_NOOP);
-    VerifyOrExit(Get<Mle::MleRouter>().IsLeader(), OT_NOOP);
+    VerifyOrExit(length <= sizeof(tlvs));
+    VerifyOrExit(Get<Mle::MleRouter>().IsLeader());
 
     aMessage.ReadBytes(offset, tlvs, length);
 
@@ -206,7 +206,7 @@ void Leader::HandleCommissioningSet(Coap::Message &aMessage, const Ip6::MessageI
     {
         MeshCoP::Tlv::Type type;
 
-        VerifyOrExit(((cur + 1) <= end) && !cur->IsExtended() && (cur->GetNext() <= end), OT_NOOP);
+        VerifyOrExit(((cur + 1) <= end) && !cur->IsExtended() && (cur->GetNext() <= end));
 
         type = cur->GetType();
 
@@ -222,7 +222,7 @@ void Leader::HandleCommissioningSet(Coap::Message &aMessage, const Ip6::MessageI
         {
             MeshCoP::CommissionerSessionIdTlv *tlv = static_cast<MeshCoP::CommissionerSessionIdTlv *>(cur);
 
-            VerifyOrExit(tlv->IsValid(), OT_NOOP);
+            VerifyOrExit(tlv->IsValid());
             sessionId    = tlv->GetCommissionerSessionId();
             hasSessionId = true;
         }
@@ -235,10 +235,10 @@ void Leader::HandleCommissioningSet(Coap::Message &aMessage, const Ip6::MessageI
     }
 
     // verify whether or not commissioner session id TLV is included
-    VerifyOrExit(hasSessionId, OT_NOOP);
+    VerifyOrExit(hasSessionId);
 
     // verify whether or not MGMT_COMM_SET.req includes at least one valid TLV
-    VerifyOrExit(hasValidTlv, OT_NOOP);
+    VerifyOrExit(hasValidTlv);
 
     // Find Commissioning Data TLV
     commDataTlv = GetCommissioningData();
@@ -253,12 +253,11 @@ void Leader::HandleCommissioningSet(Coap::Message &aMessage, const Ip6::MessageI
             if (cur->GetType() == MeshCoP::Tlv::kCommissionerSessionId)
             {
                 VerifyOrExit(sessionId ==
-                                 static_cast<MeshCoP::CommissionerSessionIdTlv *>(cur)->GetCommissionerSessionId(),
-                             OT_NOOP);
+                             static_cast<MeshCoP::CommissionerSessionIdTlv *>(cur)->GetCommissionerSessionId());
             }
             else if (cur->GetType() == MeshCoP::Tlv::kBorderAgentLocator)
             {
-                VerifyOrExit(length + cur->GetSize() <= sizeof(tlvs), OT_NOOP);
+                VerifyOrExit(length + cur->GetSize() <= sizeof(tlvs));
                 memcpy(tlvs + length, reinterpret_cast<uint8_t *>(cur), cur->GetSize());
                 length += cur->GetSize();
             }
@@ -471,7 +470,7 @@ otError Leader::ValidatePrefix(const PrefixTlv &aPrefix, uint16_t aRloc16)
 
     for (const NetworkDataTlv *subCur = aPrefix.GetSubTlvs(); subCur < subEnd; subCur = subCur->GetNext())
     {
-        VerifyOrExit((subCur + 1) <= subEnd && subCur->GetNext() <= subEnd, OT_NOOP);
+        VerifyOrExit((subCur + 1) <= subEnd && subCur->GetNext() <= subEnd);
 
         switch (subCur->GetType())
         {
@@ -485,17 +484,17 @@ otError Leader::ValidatePrefix(const PrefixTlv &aPrefix, uint16_t aRloc16)
 
             if (borderRouter->IsStable())
             {
-                VerifyOrExit(!foundStableBorderRouter, OT_NOOP);
+                VerifyOrExit(!foundStableBorderRouter);
                 foundStableBorderRouter = true;
             }
             else
             {
-                VerifyOrExit(!foundTempBorderRouter, OT_NOOP);
+                VerifyOrExit(!foundTempBorderRouter);
                 foundTempBorderRouter = true;
             }
 
-            VerifyOrExit(borderRouter->GetFirstEntry() == borderRouter->GetLastEntry(), OT_NOOP);
-            VerifyOrExit(borderRouter->GetFirstEntry()->GetRloc() == aRloc16, OT_NOOP);
+            VerifyOrExit(borderRouter->GetFirstEntry() == borderRouter->GetLastEntry());
+            VerifyOrExit(borderRouter->GetFirstEntry()->GetRloc() == aRloc16);
             break;
         }
 
@@ -509,17 +508,17 @@ otError Leader::ValidatePrefix(const PrefixTlv &aPrefix, uint16_t aRloc16)
 
             if (hasRoute->IsStable())
             {
-                VerifyOrExit(!foundStableHasRoute, OT_NOOP);
+                VerifyOrExit(!foundStableHasRoute);
                 foundStableHasRoute = true;
             }
             else
             {
-                VerifyOrExit(!foundTempHasRoute, OT_NOOP);
+                VerifyOrExit(!foundTempHasRoute);
                 foundTempHasRoute = true;
             }
 
-            VerifyOrExit(hasRoute->GetFirstEntry() == hasRoute->GetLastEntry(), OT_NOOP);
-            VerifyOrExit(hasRoute->GetFirstEntry()->GetRloc() == aRloc16, OT_NOOP);
+            VerifyOrExit(hasRoute->GetFirstEntry() == hasRoute->GetLastEntry());
+            VerifyOrExit(hasRoute->GetFirstEntry()->GetRloc() == aRloc16);
             break;
         }
 
@@ -548,7 +547,7 @@ otError Leader::ValidateService(const ServiceTlv &aService, uint16_t aRloc16)
 
     for (const NetworkDataTlv *subCur = aService.GetSubTlvs(); subCur < subEnd; subCur = subCur->GetNext())
     {
-        VerifyOrExit((subCur + 1) <= subEnd && subCur->GetNext() <= subEnd, OT_NOOP);
+        VerifyOrExit((subCur + 1) <= subEnd && subCur->GetNext() <= subEnd);
 
         switch (subCur->GetType())
         {
@@ -556,10 +555,10 @@ otError Leader::ValidateService(const ServiceTlv &aService, uint16_t aRloc16)
         {
             const ServerTlv *server = static_cast<const ServerTlv *>(subCur);
 
-            VerifyOrExit(!foundServer, OT_NOOP);
+            VerifyOrExit(!foundServer);
             foundServer = true;
 
-            VerifyOrExit(server->IsValid() && server->GetServer16() == aRloc16, OT_NOOP);
+            VerifyOrExit(server->IsValid() && server->GetServer16() == aRloc16);
             break;
         }
 
@@ -591,7 +590,7 @@ bool Leader::ContainsMatchingEntry(const HasRouteTlv *aHasRoute, const HasRouteE
 
     bool contains = false;
 
-    VerifyOrExit(aHasRoute != nullptr, OT_NOOP);
+    VerifyOrExit(aHasRoute != nullptr);
 
     for (const HasRouteEntry *entry = aHasRoute->GetFirstEntry(); entry <= aHasRoute->GetLastEntry(); entry++)
     {
@@ -620,7 +619,7 @@ bool Leader::ContainsMatchingEntry(const BorderRouterTlv *aBorderRouter, const B
 
     bool contains = false;
 
-    VerifyOrExit(aBorderRouter != nullptr, OT_NOOP);
+    VerifyOrExit(aBorderRouter != nullptr);
 
     for (const BorderRouterEntry *entry = aBorderRouter->GetFirstEntry(); entry <= aBorderRouter->GetLastEntry();
          entry++)
@@ -644,7 +643,7 @@ bool Leader::ContainsMatchingServer(const ServiceTlv *aService, const ServerTlv 
     bool             contains = false;
     const ServerTlv *server;
 
-    VerifyOrExit(aService != nullptr, OT_NOOP);
+    VerifyOrExit(aService != nullptr);
 
     for (const NetworkDataTlv *start = aService->GetSubTlvs();
          (server = FindTlv<ServerTlv>(start, aService->GetNext(), aServer.IsStable())) != nullptr;
@@ -853,7 +852,7 @@ otError Leader::AddHasRoute(const HasRouteTlv &aHasRoute, PrefixTlv &aDstPrefix,
         }
     }
 
-    VerifyOrExit(!ContainsMatchingEntry(dstHasRoute, *entry), OT_NOOP);
+    VerifyOrExit(!ContainsMatchingEntry(dstHasRoute, *entry));
 
     VerifyOrExit(CanInsert(sizeof(HasRouteEntry)), error = OT_ERROR_NO_BUFS);
 
@@ -924,7 +923,7 @@ otError Leader::AddBorderRouter(const BorderRouterTlv &aBorderRouter,
     dstContext->SetCompress();
     StopContextReuseTimer(dstContext->GetContextId());
 
-    VerifyOrExit(!ContainsMatchingEntry(dstBorderRouter, *entry), OT_NOOP);
+    VerifyOrExit(!ContainsMatchingEntry(dstBorderRouter, *entry));
 
     VerifyOrExit(CanInsert(sizeof(BorderRouterEntry)), error = OT_ERROR_NO_BUFS);
 
@@ -944,7 +943,7 @@ otError Leader::AddServer(const ServerTlv &aServer, ServiceTlv &aDstService, Cha
     ServerTlv *dstServer;
     uint8_t    tlvSize = aServer.GetSize();
 
-    VerifyOrExit(!ContainsMatchingServer(&aDstService, aServer), OT_NOOP);
+    VerifyOrExit(!ContainsMatchingServer(&aDstService, aServer));
 
     VerifyOrExit(CanInsert(tlvSize), error = OT_ERROR_NO_BUFS);
 
@@ -1368,7 +1367,7 @@ otError Leader::RemoveStaleChildEntries(Coap::ResponseHandler aHandler, void *aC
     Iterator iterator = kIteratorInit;
     uint16_t rloc16;
 
-    VerifyOrExit(Get<Mle::MleRouter>().IsRouterOrLeader(), OT_NOOP);
+    VerifyOrExit(Get<Mle::MleRouter>().IsRouterOrLeader());
 
     while (GetNextServer(iterator, rloc16) == OT_ERROR_NONE)
     {

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -62,20 +62,20 @@ void Notifier::SynchronizeServerData(void)
 {
     otError error = OT_ERROR_NOT_FOUND;
 
-    VerifyOrExit(Get<Mle::MleRouter>().IsAttached() && !mWaitingForResponse, OT_NOOP);
+    VerifyOrExit(Get<Mle::MleRouter>().IsAttached() && !mWaitingForResponse);
 
-    VerifyOrExit((mNextDelay == 0) || !mTimer.IsRunning(), OT_NOOP);
+    VerifyOrExit((mNextDelay == 0) || !mTimer.IsRunning());
 
 #if OPENTHREAD_FTD
     mNextDelay = kDelayRemoveStaleChildren;
     error      = Get<Leader>().RemoveStaleChildEntries(&Notifier::HandleCoapResponse, this);
-    VerifyOrExit(error == OT_ERROR_NOT_FOUND, OT_NOOP);
+    VerifyOrExit(error == OT_ERROR_NOT_FOUND);
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     mNextDelay = kDelaySynchronizeServerData;
     error      = Get<Local>().UpdateInconsistentServerData(&Notifier::HandleCoapResponse, this);
-    VerifyOrExit(error == OT_ERROR_NOT_FOUND, OT_NOOP);
+    VerifyOrExit(error == OT_ERROR_NOT_FOUND);
 #endif
 
 exit:

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -141,8 +141,8 @@ void NetworkDiagnostic::HandleDiagnosticGetResponse(Coap::Message *         aMes
                                                     const Ip6::MessageInfo *aMessageInfo,
                                                     otError                 aResult)
 {
-    VerifyOrExit(aResult == OT_ERROR_NONE, OT_NOOP);
-    VerifyOrExit(aMessage && aMessage->GetCode() == Coap::kCodeChanged, OT_NOOP);
+    VerifyOrExit(aResult == OT_ERROR_NONE);
+    VerifyOrExit(aMessage && aMessage->GetCode() == Coap::kCodeChanged);
 
     otLogInfoNetDiag("Received diagnostic get response");
 
@@ -165,7 +165,7 @@ void NetworkDiagnostic::HandleDiagnosticGetAnswer(void *               aContext,
 
 void NetworkDiagnostic::HandleDiagnosticGetAnswer(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    VerifyOrExit(aMessage.IsConfirmablePostRequest(), OT_NOOP);
+    VerifyOrExit(aMessage.IsConfirmablePostRequest());
 
     otLogInfoNetDiag("Diagnostic get answer received");
 
@@ -236,7 +236,7 @@ otError NetworkDiagnostic::AppendChildTable(Message &aMessage)
 
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
-        VerifyOrExit(count--, OT_NOOP);
+        VerifyOrExit(count--);
 
         timeout = 0;
 
@@ -622,11 +622,11 @@ void NetworkDiagnostic::HandleDiagnosticReset(Coap::Message &aMessage, const Ip6
 
     otLogInfoNetDiag("Received diagnostic reset request");
 
-    VerifyOrExit(aMessage.IsConfirmablePostRequest(), OT_NOOP);
+    VerifyOrExit(aMessage.IsConfirmablePostRequest());
 
     SuccessOrExit(aMessage.Read(aMessage.GetOffset(), tlv));
 
-    VerifyOrExit(tlv.GetType() == NetworkDiagnosticTlv::kTypeList, OT_NOOP);
+    VerifyOrExit(tlv.GetType() == NetworkDiagnosticTlv::kTypeList);
 
     offset = aMessage.GetOffset() + sizeof(NetworkDiagnosticTlv);
 

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -68,8 +68,8 @@ void PanIdQueryServer::HandleQuery(Coap::Message &aMessage, const Ip6::MessageIn
     Ip6::MessageInfo responseInfo(aMessageInfo);
     uint32_t         mask;
 
-    VerifyOrExit(aMessage.IsPostRequest(), OT_NOOP);
-    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0, OT_NOOP);
+    VerifyOrExit(aMessage.IsPostRequest());
+    VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
 
     SuccessOrExit(Tlv::FindUint16Tlv(aMessage, MeshCoP::Tlv::kPanId, panId));
 

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -78,7 +78,7 @@ exit:
 
 const Router *RouterTable::GetNextEntry(const Router *aRouter) const
 {
-    VerifyOrExit(aRouter != nullptr, OT_NOOP);
+    VerifyOrExit(aRouter != nullptr);
     aRouter++;
     VerifyOrExit(aRouter < &mRouters[Mle::kMaxRouters], aRouter = nullptr);
     VerifyOrExit(aRouter->GetRloc16() != 0xffff, aRouter = nullptr);
@@ -211,7 +211,7 @@ Router *RouterTable::Allocate(void)
         }
     }
 
-    VerifyOrExit(mActiveRouterCount < Mle::kMaxRouters && numAvailable > 0, OT_NOOP);
+    VerifyOrExit(mActiveRouterCount < Mle::kMaxRouters && numAvailable > 0);
 
     // choose available router id at random
     freeBit = Random::NonCrypto::GetUint8InRange(0, numAvailable);
@@ -243,8 +243,7 @@ Router *RouterTable::Allocate(uint8_t aRouterId)
     Router *rval = nullptr;
 
     VerifyOrExit(aRouterId <= Mle::kMaxRouterId && mActiveRouterCount < Mle::kMaxRouters && !IsAllocated(aRouterId) &&
-                     mRouterIdReuseDelay[aRouterId] == 0,
-                 OT_NOOP);
+                 mRouterIdReuseDelay[aRouterId] == 0);
 
     mAllocatedRouterIds.Add(aRouterId);
     UpdateAllocation();
@@ -361,7 +360,7 @@ Router *RouterTable::GetNeighbor(uint16_t aRloc16)
 {
     Router *router = nullptr;
 
-    VerifyOrExit(aRloc16 != Get<Mle::MleRouter>().GetRloc16(), OT_NOOP);
+    VerifyOrExit(aRloc16 != Get<Mle::MleRouter>().GetRloc16());
     router = FindRouter(Router::AddressMatcher(aRloc16, Router::kInStateValid));
 
 exit:
@@ -384,7 +383,7 @@ const Router *RouterTable::GetRouter(uint8_t aRouterId) const
     uint16_t      rloc16;
 
     // Skip if invalid router id is passed.
-    VerifyOrExit(aRouterId < Mle::kInvalidRouterId, OT_NOOP);
+    VerifyOrExit(aRouterId < Mle::kInvalidRouterId);
 
     rloc16 = Mle::Mle::Rloc16FromRouterId(aRouterId);
     router = FindRouter(Router::AddressMatcher(rloc16, Router::kInStateAny));
@@ -453,7 +452,7 @@ uint8_t RouterTable::GetLinkCost(Router &aRouter)
 {
     uint8_t rval = Mle::kMaxRouteCost;
 
-    VerifyOrExit(aRouter.GetRloc16() != Get<Mle::MleRouter>().GetRloc16() && aRouter.IsStateValid(), OT_NOOP);
+    VerifyOrExit(aRouter.GetRloc16() != Get<Mle::MleRouter>().GetRloc16() && aRouter.IsStateValid());
 
     rval = aRouter.GetLinkInfo().GetLinkQuality();
 
@@ -473,7 +472,7 @@ void RouterTable::UpdateRouterIdSet(uint8_t aRouterIdSequence, const Mle::Router
     mRouterIdSequence            = aRouterIdSequence;
     mRouterIdSequenceLastUpdated = TimerMilli::GetNow();
 
-    VerifyOrExit(mAllocatedRouterIds != aRouterIdSet, OT_NOOP);
+    VerifyOrExit(mAllocatedRouterIds != aRouterIdSet);
 
     for (uint8_t routerId = 0; routerId <= Mle::kMaxRouterId; routerId++)
     {

--- a/src/core/thread/src_match_controller.cpp
+++ b/src/core/thread/src_match_controller.cpp
@@ -92,7 +92,7 @@ void SourceMatchController::ResetMessageCount(Child &aChild)
 
 void SourceMatchController::SetSrcMatchAsShort(Child &aChild, bool aUseShortAddress)
 {
-    VerifyOrExit(aChild.IsIndirectSourceMatchShort() != aUseShortAddress, OT_NOOP);
+    VerifyOrExit(aChild.IsIndirectSourceMatchShort() != aUseShortAddress);
 
     if (aChild.GetIndirectMessageCount() > 0)
     {

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -134,7 +134,7 @@ ThreadNetif::ThreadNetif(Instance &aInstance)
 
 void ThreadNetif::Up(void)
 {
-    VerifyOrExit(!mIsUp, OT_NOOP);
+    VerifyOrExit(!mIsUp);
 
     // Enable the MAC just in case it was disabled while the Interface was down.
     Get<Mac::Mac>().SetEnabled(true);
@@ -162,7 +162,7 @@ exit:
 
 void ThreadNetif::Down(void)
 {
-    VerifyOrExit(mIsUp, OT_NOOP);
+    VerifyOrExit(mIsUp);
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
     IgnoreError(Get<Dns::Client>().Stop());

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -80,7 +80,7 @@ void TimeSync::HandleTimeSyncMessage(const Message &aMessage)
     const int64_t origNetworkTimeOffset = mNetworkTimeOffset;
     int8_t        timeSyncSeqDelta;
 
-    VerifyOrExit(aMessage.GetTimeSyncSeq() != OT_TIME_SYNC_INVALID_SEQ, OT_NOOP);
+    VerifyOrExit(aMessage.GetTimeSyncSeq() != OT_TIME_SYNC_INVALID_SEQ);
 
     timeSyncSeqDelta = static_cast<int8_t>(aMessage.GetTimeSyncSeq() - mTimeSyncSeq);
 
@@ -161,7 +161,7 @@ void TimeSync::ProcessTimeSync(void)
 
     if (mTimeSyncRequired)
     {
-        VerifyOrExit(Get<Mle::MleRouter>().SendTimeSync() == OT_ERROR_NONE, OT_NOOP);
+        VerifyOrExit(Get<Mle::MleRouter>().SendTimeSync() == OT_ERROR_NONE);
 
         mLastTimeSyncSent = TimerMilli::GetNow();
         mTimeSyncRequired = false;

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -45,16 +45,16 @@ bool Neighbor::AddressMatcher::Matches(const Neighbor &aNeighbor) const
 {
     bool matches = false;
 
-    VerifyOrExit(aNeighbor.MatchesFilter(mStateFilter), OT_NOOP);
+    VerifyOrExit(aNeighbor.MatchesFilter(mStateFilter));
 
     if (mShortAddress != Mac::kShortAddrInvalid)
     {
-        VerifyOrExit(mShortAddress == aNeighbor.GetRloc16(), OT_NOOP);
+        VerifyOrExit(mShortAddress == aNeighbor.GetRloc16());
     }
 
     if (mExtAddress != nullptr)
     {
-        VerifyOrExit(*mExtAddress == aNeighbor.GetExtAddress(), OT_NOOP);
+        VerifyOrExit(*mExtAddress == aNeighbor.GetExtAddress());
     }
 
     matches = true;
@@ -204,7 +204,7 @@ void Child::AddressIterator::Update(void)
 
         VerifyOrExit((address != nullptr) && !address->IsUnspecified(), mIndex = kMaxIndex);
 
-        VerifyOrExit(!address->MatchesFilter(mFilter), OT_NOOP);
+        VerifyOrExit(!address->MatchesFilter(mFilter));
         mIndex++;
     }
 
@@ -293,7 +293,7 @@ otError Child::RemoveIp6Address(const Ip6::Address &aAddress)
 
     for (index = 0; index < kNumIp6Addresses; index++)
     {
-        VerifyOrExit(!mIp6Address[index].IsUnspecified(), OT_NOOP);
+        VerifyOrExit(!mIp6Address[index].IsUnspecified());
 
         if (mIp6Address[index] == aAddress)
         {
@@ -319,7 +319,7 @@ bool Child::HasIp6Address(const Ip6::Address &aAddress) const
 {
     bool retval = false;
 
-    VerifyOrExit(!aAddress.IsUnspecified(), OT_NOOP);
+    VerifyOrExit(!aAddress.IsUnspecified());
 
     if (Get<Mle::MleRouter>().IsMeshLocalAddress(aAddress))
     {
@@ -329,7 +329,7 @@ bool Child::HasIp6Address(const Ip6::Address &aAddress) const
 
     for (const Ip6::Address &ip6Address : mIp6Address)
     {
-        VerifyOrExit(!ip6Address.IsUnspecified(), OT_NOOP);
+        VerifyOrExit(!ip6Address.IsUnspecified());
 
         if (ip6Address == aAddress)
         {
@@ -348,7 +348,7 @@ const Ip6::Address *Child::GetDomainUnicastAddress(void) const
 
     for (const Ip6::Address &ip6Address : mIp6Address)
     {
-        VerifyOrExit(!ip6Address.IsUnspecified(), OT_NOOP);
+        VerifyOrExit(!ip6Address.IsUnspecified());
 
         if (Get<BackboneRouter::Leader>().IsDomainUnicast(ip6Address))
         {
@@ -371,7 +371,7 @@ bool Child::HasMlrRegisteredAddress(const Ip6::Address &aAddress) const
 {
     bool has = false;
 
-    VerifyOrExit(mMlrRegisteredMask.HasAny(), OT_NOOP);
+    VerifyOrExit(mMlrRegisteredMask.HasAny());
 
     for (const Ip6::Address &address : IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -101,9 +101,9 @@ void ChannelManager::PreparePendingDataset(void)
     otOperationalDataset dataset;
     otError              error;
 
-    VerifyOrExit(mState == kStateChangeRequested, OT_NOOP);
+    VerifyOrExit(mState == kStateChangeRequested);
 
-    VerifyOrExit(mChannel != Get<Mac::Mac>().GetPanChannel(), OT_NOOP);
+    VerifyOrExit(mChannel != Get<Mac::Mac>().GetPanChannel());
 
     if (Get<MeshCoP::PendingDataset>().Read(dataset) == OT_ERROR_NONE)
     {
@@ -253,8 +253,8 @@ void ChannelManager::HandleTimer(void)
 
 void ChannelManager::HandleNotifierEvents(Events aEvents)
 {
-    VerifyOrExit(aEvents.Contains(kEventThreadChannelChanged), OT_NOOP);
-    VerifyOrExit(mChannel == Get<Mac::Mac>().GetPanChannel(), OT_NOOP);
+    VerifyOrExit(aEvents.Contains(kEventThreadChannelChanged));
+    VerifyOrExit(mChannel == Get<Mac::Mac>().GetPanChannel());
 
     mState = kStateIdle;
     StartAutoSelectTimer();
@@ -341,7 +341,7 @@ otError ChannelManager::RequestChannelSelect(bool aSkipQualityCheck)
 
     VerifyOrExit(!Get<Mle::Mle>().IsDisabled(), error = OT_ERROR_INVALID_STATE);
 
-    VerifyOrExit(aSkipQualityCheck || ShouldAttemptChannelChange(), OT_NOOP);
+    VerifyOrExit(aSkipQualityCheck || ShouldAttemptChannelChange());
 
     SuccessOrExit(error = FindBetterChannel(newChannel, newOccupancy));
 
@@ -383,7 +383,7 @@ exit:
 
 void ChannelManager::StartAutoSelectTimer(void)
 {
-    VerifyOrExit(mState == kStateIdle, OT_NOOP);
+    VerifyOrExit(mState == kStateIdle);
 
     if (mAutoSelectEnabled)
     {

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -105,7 +105,7 @@ uint16_t ChannelMonitor::GetChannelOccupancy(uint8_t aChannel) const
 {
     uint16_t occupancy = 0;
 
-    VerifyOrExit((Radio::kChannelMin <= aChannel) && (aChannel <= Radio::kChannelMax), OT_NOOP);
+    VerifyOrExit((Radio::kChannelMin <= aChannel) && (aChannel <= Radio::kChannelMax));
     occupancy = mChannelOccupancy[aChannel - Radio::kChannelMin];
 
 exit:

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -64,7 +64,7 @@ Child *ChildSupervisor::GetDestination(const Message &aMessage) const
     Child *  child = nullptr;
     uint16_t childIndex;
 
-    VerifyOrExit(aMessage.GetType() == Message::kTypeSupervision, OT_NOOP);
+    VerifyOrExit(aMessage.GetType() == Message::kTypeSupervision);
 
     IgnoreError(aMessage.Read(0, childIndex));
     child = Get<ChildTable>().GetChildAtIndex(childIndex);
@@ -78,10 +78,10 @@ void ChildSupervisor::SendMessage(Child &aChild)
     Message *message = nullptr;
     uint16_t childIndex;
 
-    VerifyOrExit(aChild.GetIndirectMessageCount() == 0, OT_NOOP);
+    VerifyOrExit(aChild.GetIndirectMessageCount() == 0);
 
     message = Get<MessagePool>().New(Message::kTypeSupervision, sizeof(uint8_t));
-    VerifyOrExit(message != nullptr, OT_NOOP);
+    VerifyOrExit(message != nullptr);
 
     // Supervision message is an empty payload 15.4 data frame.
     // The child index is stored here in the message content to allow
@@ -184,8 +184,7 @@ void SupervisionListener::UpdateOnReceive(const Mac::Address &aSourceAddress, bo
     // If listener is enabled and device is a child and it received a secure frame from its parent, restart the timer.
 
     VerifyOrExit(mTimer.IsRunning() && aIsSecure && Get<Mle::MleRouter>().IsChild() &&
-                     (Get<NeighborTable>().FindNeighbor(aSourceAddress) == &Get<Mle::MleRouter>().GetParent()),
-                 OT_NOOP);
+                 (Get<NeighborTable>().FindNeighbor(aSourceAddress) == &Get<Mle::MleRouter>().GetParent()));
 
     RestartTimer();
 
@@ -212,7 +211,7 @@ void SupervisionListener::HandleTimer(Timer &aTimer)
 
 void SupervisionListener::HandleTimer(void)
 {
-    VerifyOrExit(Get<Mle::MleRouter>().IsChild() && !Get<MeshForwarder>().GetRxOnWhenIdle(), OT_NOOP);
+    VerifyOrExit(Get<Mle::MleRouter>().IsChild() && !Get<MeshForwarder>().GetRxOnWhenIdle());
 
     otLogWarnUtil("Supervision timeout. No frame from parent in %d sec", mTimeout);
 

--- a/src/core/utils/flash.cpp
+++ b/src/core/utils/flash.cpp
@@ -235,7 +235,7 @@ void Flash::Swap(void)
     {
         otPlatFlashRead(&GetInstance(), mSwapIndex, srcOffset, &record, sizeof(RecordHeader));
 
-        VerifyOrExit(record.IsAddBeginSet(), OT_NOOP);
+        VerifyOrExit(record.IsAddBeginSet());
 
         if (!record.IsValid() || DoesValidRecordExist(srcOffset + record.GetSize(), record.GetKey()))
         {

--- a/src/core/utils/heap.cpp
+++ b/src/core/utils/heap.cpp
@@ -66,7 +66,7 @@ void *Heap::CAlloc(size_t aCount, size_t aSize)
     Block *  curr = nullptr;
     uint16_t size = static_cast<uint16_t>(aCount * aSize);
 
-    VerifyOrExit(size, OT_NOOP);
+    VerifyOrExit(size);
 
     size += kAlignSize - 1 - kBlockRemainderSize;
     size &= ~(kAlignSize - 1);
@@ -81,7 +81,7 @@ void *Heap::CAlloc(size_t aCount, size_t aSize)
         curr = &BlockNext(*curr);
     }
 
-    VerifyOrExit(curr->IsFree(), OT_NOOP);
+    VerifyOrExit(curr->IsFree());
 
     prev->SetNext(curr->GetNext());
 

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -100,18 +100,18 @@ exit:
 
 void JamDetector::CheckState(void)
 {
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
 
     switch (Get<Mle::MleRouter>().GetRole())
     {
     case Mle::kRoleDisabled:
-        VerifyOrExit(mTimer.IsRunning(), OT_NOOP);
+        VerifyOrExit(mTimer.IsRunning());
         mTimer.Stop();
         SetJamState(false);
         break;
 
     default:
-        VerifyOrExit(!mTimer.IsRunning(), OT_NOOP);
+        VerifyOrExit(!mTimer.IsRunning());
         mCurSecondStartTime   = TimerMilli::GetNow();
         mAlwaysAboveThreshold = true;
         mHistoryBitmap        = 0;
@@ -169,7 +169,7 @@ void JamDetector::HandleTimer(void)
     int8_t rssi;
     bool   didExceedThreshold = true;
 
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
 
     rssi = Get<Radio>().GetRssi();
 

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -258,9 +258,9 @@ otError ParseAsIp6Prefix(const char *aString, otIp6Prefix &aPrefix)
     const char *prefixLengthStr;
 
     prefixLengthStr = strchr(aString, '/');
-    VerifyOrExit(prefixLengthStr != nullptr, OT_NOOP);
+    VerifyOrExit(prefixLengthStr != nullptr);
 
-    VerifyOrExit(prefixLengthStr - aString < static_cast<int32_t>(sizeof(string)), OT_NOOP);
+    VerifyOrExit(prefixLengthStr - aString < static_cast<int32_t>(sizeof(string)));
 
     memcpy(string, aString, static_cast<uint8_t>(prefixLengthStr - aString));
     string[prefixLengthStr - aString] = '\0';

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -57,7 +57,7 @@ Slaac::Slaac(Instance &aInstance)
 
 void Slaac::Enable(void)
 {
-    VerifyOrExit(!mEnabled, OT_NOOP);
+    VerifyOrExit(!mEnabled);
 
     otLogInfoUtil("SLAAC:: Enabling");
     mEnabled = true;
@@ -69,7 +69,7 @@ exit:
 
 void Slaac::Disable(void)
 {
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
 
     otLogInfoUtil("SLAAC:: Disabling");
     mEnabled = false;
@@ -81,12 +81,12 @@ exit:
 
 void Slaac::SetFilter(otIp6SlaacPrefixFilter aFilter)
 {
-    VerifyOrExit(aFilter != mFilter, OT_NOOP);
+    VerifyOrExit(aFilter != mFilter);
 
     mFilter = aFilter;
     otLogInfoUtil("SLAAC: Filter %s", (mFilter != nullptr) ? "updated" : "disabled");
 
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
     Update(kModeAdd | kModeRemove);
 
 exit:
@@ -102,7 +102,7 @@ void Slaac::HandleNotifierEvents(Events aEvents)
 {
     UpdateMode mode = kModeNone;
 
-    VerifyOrExit(mEnabled, OT_NOOP);
+    VerifyOrExit(mEnabled);
 
     if (aEvents.Contains(kEventThreadNetdataChanged))
     {
@@ -327,7 +327,7 @@ void Slaac::GetIidSecretKey(IidSecretKey &aKey) const
     otError error;
 
     error = Get<Settings>().ReadSlaacIidSecretKey(aKey);
-    VerifyOrExit(error != OT_ERROR_NONE, OT_NOOP);
+    VerifyOrExit(error != OT_ERROR_NONE);
 
     // If there is no previously saved secret key, generate
     // a random one and save it.

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -479,7 +479,7 @@ void RadioSpinel<InterfaceType, ProcessContextType>::HandleNotification(const ui
     unpacked = spinel_datatype_unpack(aFrame, aLength, "CiiD", &header, &cmd, &key, &data, &len);
     VerifyOrExit(unpacked > 0, error = OT_ERROR_PARSE);
     VerifyOrExit(SPINEL_HEADER_GET_TID(header) == 0, error = OT_ERROR_PARSE);
-    VerifyOrExit(cmd == SPINEL_CMD_PROP_VALUE_IS, OT_NOOP);
+    VerifyOrExit(cmd == SPINEL_CMD_PROP_VALUE_IS);
     HandleValueIs(key, data, static_cast<uint16_t>(len));
 
 exit:
@@ -700,7 +700,7 @@ void RadioSpinel<InterfaceType, ProcessContextType>::HandleWaitingResponse(uint3
     {
         spinel_ssize_t unpacked;
 
-        VerifyOrExit(mDiagOutput != nullptr, OT_NOOP);
+        VerifyOrExit(mDiagOutput != nullptr);
         unpacked =
             spinel_datatype_unpack_in_place(aBuffer, aLength, SPINEL_DATATYPE_UTF8_S, mDiagOutput, &mDiagOutputMaxLen);
         VerifyOrExit(unpacked > 0, mError = OT_ERROR_PARSE);
@@ -1037,7 +1037,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::SetShortAddress(uint16_t
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mShortAddress != aAddress, OT_NOOP);
+    VerifyOrExit(mShortAddress != aAddress);
     SuccessOrExit(error = Set(SPINEL_PROP_MAC_15_4_SADDR, SPINEL_DATATYPE_UINT16_S, aAddress));
     mShortAddress = aAddress;
 
@@ -1100,7 +1100,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::SetPanId(uint16_t aPanId
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(mPanId != aPanId, OT_NOOP);
+    VerifyOrExit(mPanId != aPanId);
     SuccessOrExit(error = Set(SPINEL_PROP_MAC_15_4_PANID, SPINEL_DATATYPE_UINT16_S, aPanId));
     mPanId = aPanId;
 
@@ -1570,8 +1570,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::Transmit(otRadioFrame &a
 {
     otError error = OT_ERROR_INVALID_STATE;
 
-    VerifyOrExit(mState == kStateReceive || (mState == kStateSleep && (mRadioCaps & OT_RADIO_CAPS_SLEEP_TO_TX)),
-                 OT_NOOP);
+    VerifyOrExit(mState == kStateReceive || (mState == kStateSleep && (mRadioCaps & OT_RADIO_CAPS_SLEEP_TO_TX)));
 
     mTransmitFrame = &aFrame;
 
@@ -1668,7 +1667,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::Enable(otInstance *aInst
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(!IsEnabled(), OT_NOOP);
+    VerifyOrExit(!IsEnabled());
 
     mInstance = aInstance;
 
@@ -1694,7 +1693,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::Disable(void)
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(IsEnabled(), OT_NOOP);
+    VerifyOrExit(IsEnabled());
     VerifyOrExit(mState == kStateSleep, error = OT_ERROR_INVALID_STATE);
 
     SuccessOrDie(Set(SPINEL_PROP_PHY_ENABLED, SPINEL_DATATYPE_BOOL_S, false));
@@ -1805,7 +1804,7 @@ void RadioSpinel<InterfaceType, ProcessContextType>::CalcRcpTimeOffset(void)
      *         D = T1' - ((T0 + T2)/ 2)
      */
 
-    VerifyOrExit(!mIsTimeSynced || (otPlatTimeGet() >= GetNextRadioTimeRecalcStart()), OT_NOOP);
+    VerifyOrExit(!mIsTimeSynced || (otPlatTimeGet() >= GetNextRadioTimeRecalcStart()));
     packed = spinel_datatype_pack(buffer, sizeof(buffer), SPINEL_DATATYPE_UINT64_S, remoteTimestamp);
     VerifyOrExit(packed > 0 && static_cast<size_t>(packed) <= sizeof(buffer), error = OT_ERROR_NO_BUFS);
 

--- a/src/lib/spinel/spinel_buffer.cpp
+++ b/src/lib/spinel/spinel_buffer.cpp
@@ -252,7 +252,7 @@ otError Buffer::InFrameBeginSegment(void)
     uint16_t headerFlags = kSegmentHeaderNoFlag;
 
     // Verify that segment is not yet started (i.e., head and tail are the same).
-    VerifyOrExit(mWriteSegmentHead == mWriteSegmentTail, OT_NOOP);
+    VerifyOrExit(mWriteSegmentHead == mWriteSegmentTail);
 
     // Check if this is the start of a new frame (i.e., frame start is same as segment head).
     if (mWriteFrameStart[mWriteDirection] == mWriteSegmentHead)
@@ -309,7 +309,7 @@ void Buffer::InFrameDiscard(void)
     otMessage *message;
 #endif
 
-    VerifyOrExit(mWriteDirection != kUnknown, OT_NOOP);
+    VerifyOrExit(mWriteDirection != kUnknown);
 
     // Move the write segment head and tail pointers back to frame start.
     mWriteSegmentHead = mWriteSegmentTail = mWriteFrameStart[mWriteDirection];
@@ -466,12 +466,12 @@ uint16_t Buffer::InFrameGetDistance(const WritePosition &aPosition) const
     uint16_t segmentLength;
     uint16_t offset;
 
-    VerifyOrExit(mWriteDirection != kUnknown, OT_NOOP);
-    VerifyOrExit(aPosition.mSegmentHead == mWriteSegmentHead, OT_NOOP);
+    VerifyOrExit(mWriteDirection != kUnknown);
+    VerifyOrExit(aPosition.mSegmentHead == mWriteSegmentHead);
 
     segmentLength = GetDistance(mWriteSegmentHead, mWriteSegmentTail, mWriteDirection);
     offset        = GetDistance(mWriteSegmentHead, aPosition.mPosition, mWriteDirection);
-    VerifyOrExit(offset < segmentLength, OT_NOOP);
+    VerifyOrExit(offset < segmentLength);
 
     distance = GetDistance(aPosition.mPosition, mWriteSegmentTail, mWriteDirection);
 

--- a/src/lib/url/Makefile.am
+++ b/src/lib/url/Makefile.am
@@ -33,6 +33,7 @@ noinst_LIBRARIES = libopenthread-url.a
 libopenthread_url_a_CPPFLAGS                = \
     -I$(top_srcdir)/include                   \
     -I$(top_srcdir)/src                       \
+    -I$(top_srcdir)/src/core                  \
     $(NULL)
 
 libopenthread_url_a_SOURCES                 = \
@@ -45,6 +46,7 @@ check_PROGRAMS = test-url
 test_url_CPPFLAGS                                             = \
     -I$(top_srcdir)/include                                     \
     -I$(top_srcdir)/src                                         \
+    -I$(top_srcdir)/src/core                                    \
     -DSELF_TEST                                                 \
     $(NULL)
 

--- a/src/lib/url/url.cpp
+++ b/src/lib/url/url.cpp
@@ -82,7 +82,7 @@ const char *Url::GetValue(const char *aName, const char *aLastValue) const
     }
     else
     {
-        VerifyOrExit(aLastValue > mQuery && aLastValue < mEnd, OT_NOOP);
+        VerifyOrExit(aLastValue > mQuery && aLastValue < mEnd);
         start = aLastValue + strlen(aLastValue) + 1;
     }
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -341,7 +341,7 @@ void NcpBase::HandleReceive(const uint8_t *aBuf, uint16_t aBufLength)
     // Skip if there is no header byte to read or this isn't a spinel frame.
 
     SuccessOrExit(mDecoder.ReadUint8(header));
-    VerifyOrExit((SPINEL_HEADER_FLAG & header) == SPINEL_HEADER_FLAG, OT_NOOP);
+    VerifyOrExit((SPINEL_HEADER_FLAG & header) == SPINEL_HEADER_FLAG);
 
     mRxSpinelFrameCounter++;
 
@@ -631,7 +631,7 @@ void NcpBase::Log(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aLog
     uint8_t header = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
 
     VerifyOrExit(!mDisableStreamWrite, error = OT_ERROR_INVALID_STATE);
-    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_STREAM_LOG), OT_NOOP);
+    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_STREAM_LOG));
 
     // If there is a pending queued response we do not allow any new log
     // stream writes. This is to ensure that log messages can not continue
@@ -819,7 +819,7 @@ void NcpBase::UpdateChangedProps(void)
     ProcessThreadChangedFlags();
 #endif
 
-    VerifyOrExit(!mChangedPropsSet.IsEmpty(), OT_NOOP);
+    VerifyOrExit(!mChangedPropsSet.IsEmpty());
 
     entry = mChangedPropsSet.GetSupportedEntries(numEntries);
 
@@ -849,7 +849,7 @@ void NcpBase::UpdateChangedProps(void)
         }
 
         mChangedPropsSet.RemoveEntry(index);
-        VerifyOrExit(!mChangedPropsSet.IsEmpty(), OT_NOOP);
+        VerifyOrExit(!mChangedPropsSet.IsEmpty());
     }
 
 exit:
@@ -986,7 +986,7 @@ otError NcpBase::HandleCommandPropertySet(uint8_t aHeader, spinel_prop_key_t aKe
 
         bool didHandle = HandlePropertySetForSpecialProperties(aHeader, aKey, error);
 
-        VerifyOrExit(!didHandle, OT_NOOP);
+        VerifyOrExit(!didHandle);
 
 #if OPENTHREAD_ENABLE_NCP_VENDOR_HOOK
         if (aKey >= SPINEL_PROP_VENDOR__BEGIN && aKey < SPINEL_PROP_VENDOR__END)

--- a/src/ncp/ncp_base_ftd.cpp
+++ b/src/ncp/ncp_base_ftd.cpp
@@ -86,7 +86,7 @@ exit:
 
 void NcpBase::HandleParentResponseInfo(otThreadParentResponseInfo *aInfo, void *aContext)
 {
-    VerifyOrExit(aInfo && aContext, OT_NOOP);
+    VerifyOrExit(aInfo && aContext);
 
     static_cast<NcpBase *>(aContext)->HandleParentResponseInfo(*aInfo);
 
@@ -96,7 +96,7 @@ exit:
 
 void NcpBase::HandleParentResponseInfo(const otThreadParentResponseInfo &aInfo)
 {
-    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_PARENT_RESPONSE_INFO), OT_NOOP);
+    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(SPINEL_PROP_PARENT_RESPONSE_INFO));
 
     SuccessOrExit(mEncoder.BeginFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_CMD_PROP_VALUE_IS,
                                       SPINEL_PROP_PARENT_RESPONSE_INFO));
@@ -134,7 +134,7 @@ void NcpBase::HandleNeighborTableChanged(otNeighborTableEvent aEvent, const otNe
         // Fall through
     case OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED:
         property = SPINEL_PROP_THREAD_CHILD_TABLE;
-        VerifyOrExit(!aEntry.mInfo.mChild.mIsStateRestoring, OT_NOOP);
+        VerifyOrExit(!aEntry.mInfo.mChild.mIsStateRestoring);
         break;
 
     case OT_NEIGHBOR_TABLE_EVENT_ROUTER_ADDED:
@@ -148,7 +148,7 @@ void NcpBase::HandleNeighborTableChanged(otNeighborTableEvent aEvent, const otNe
         ExitNow();
     }
 
-    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(property), OT_NOOP);
+    VerifyOrExit(!mChangedPropsSet.IsPropertyFiltered(property));
 
     SuccessOrExit(error = mEncoder.BeginFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, command, property));
 

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -1575,7 +1575,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_IPV6_ML_PREFIX>(void)
     const otMeshLocalPrefix *mlPrefix = otThreadGetMeshLocalPrefix(mInstance);
     otIp6Address             addr;
 
-    VerifyOrExit(mlPrefix != nullptr, OT_NOOP); // If `mlPrefix` is nullptr send empty response.
+    VerifyOrExit(mlPrefix != nullptr); // If `mlPrefix` is nullptr send empty response.
 
     memcpy(addr.mFields.m8, mlPrefix->m8, 8);
 
@@ -1610,7 +1610,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_IPV6_ML_ADDR>(void)
     otError             error = OT_ERROR_NONE;
     const otIp6Address *ml64  = otThreadGetMeshLocalEid(mInstance);
 
-    VerifyOrExit(ml64 != nullptr, OT_NOOP);
+    VerifyOrExit(ml64 != nullptr);
     SuccessOrExit(error = mEncoder.WriteIp6Address(*ml64));
 
 exit:
@@ -1622,7 +1622,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_IPV6_LL_ADDR>(void)
     otError             error   = OT_ERROR_NONE;
     const otIp6Address *address = otThreadGetLinkLocalIp6Address(mInstance);
 
-    VerifyOrExit(address != nullptr, OT_NOOP);
+    VerifyOrExit(address != nullptr);
     SuccessOrExit(error = mEncoder.WriteIp6Address(*address));
 
 exit:
@@ -3152,7 +3152,7 @@ void NcpBase::RegisterLegacyHandlers(const otNcpLegacyHandlers *aHandlers)
     mLegacyHandlers = aHandlers;
     bool isEnabled;
 
-    VerifyOrExit(mLegacyHandlers != nullptr, OT_NOOP);
+    VerifyOrExit(mLegacyHandlers != nullptr);
 
     isEnabled = (otThreadGetDeviceRole(mInstance) != OT_DEVICE_ROLE_DISABLED);
 
@@ -3427,7 +3427,7 @@ void NcpBase::HandleDatagramFromStack(otMessage *aMessage, void *aContext)
 
 void NcpBase::HandleDatagramFromStack(otMessage *aMessage)
 {
-    VerifyOrExit(aMessage != nullptr, OT_NOOP);
+    VerifyOrExit(aMessage != nullptr);
 
     // Do not forward frames larger than SPINEL payload size.
     VerifyOrExit(otMessageGetLength(aMessage) <= SPINEL_FRAME_MAX_COMMAND_PAYLOAD_SIZE, otMessageFree(aMessage));
@@ -3597,7 +3597,7 @@ void NcpBase::HandlePcapFrame(const otRadioFrame *aFrame, bool aIsTx)
     uint16_t flags  = 0;
     uint8_t  header = SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0;
 
-    VerifyOrExit(mPcapEnabled, OT_NOOP);
+    VerifyOrExit(mPcapEnabled);
 
     if (aIsTx)
     {
@@ -3639,7 +3639,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_PHY_PCAP_ENABLED>(voi
     bool    enabled;
 
     SuccessOrExit(error = mDecoder.ReadBool(enabled));
-    VerifyOrExit(enabled != mPcapEnabled, OT_NOOP);
+    VerifyOrExit(enabled != mPcapEnabled);
 
     mPcapEnabled = enabled;
 
@@ -3699,7 +3699,7 @@ void NcpBase::ProcessThreadChangedFlags(void)
         {OT_CHANGED_SUPPORTED_CHANNEL_MASK, SPINEL_PROP_PHY_CHAN_SUPPORTED},
     };
 
-    VerifyOrExit(mThreadChangedFlags != 0, OT_NOOP);
+    VerifyOrExit(mThreadChangedFlags != 0);
 
     // If thread role has changed, check for possible "join" error.
 
@@ -3770,7 +3770,7 @@ void NcpBase::ProcessThreadChangedFlags(void)
             }
 
             mThreadChangedFlags &= ~threadFlag;
-            VerifyOrExit(mThreadChangedFlags != 0, OT_NOOP);
+            VerifyOrExit(mThreadChangedFlags != 0);
         }
     }
 

--- a/src/ncp/ncp_spi.cpp
+++ b/src/ncp/ncp_spi.cpp
@@ -145,9 +145,8 @@ bool NcpSpi::SpiTransactionComplete(uint8_t *aOutputBuf,
     SpiFrame inputFrame(aInputBuf);
     SpiFrame sendFrame(mSendFrame);
 
-    VerifyOrExit((aTransLen >= kSpiHeaderSize) && (aInputLen >= kSpiHeaderSize) && (aOutputLen >= kSpiHeaderSize),
-                 OT_NOOP);
-    VerifyOrExit(inputFrame.IsValid() && outputFrame.IsValid(), OT_NOOP);
+    VerifyOrExit((aTransLen >= kSpiHeaderSize) && (aInputLen >= kSpiHeaderSize) && (aOutputLen >= kSpiHeaderSize));
+    VerifyOrExit(inputFrame.IsValid() && outputFrame.IsValid());
 
     transDataLen = aTransLen - kSpiHeaderSize;
 
@@ -262,7 +261,7 @@ void NcpSpi::PrepareNextSpiSendFrame(void)
     uint16_t readLength;
     SpiFrame sendFrame(mSendFrame);
 
-    VerifyOrExit(!mTxFrameBuffer.IsEmpty(), OT_NOOP);
+    VerifyOrExit(!mTxFrameBuffer.IsEmpty());
 
     if (ShouldWakeHost())
     {

--- a/src/ncp/ncp_uart.cpp
+++ b/src/ncp/ncp_uart.cpp
@@ -149,7 +149,7 @@ void NcpUart::EncodeAndSendToUart(void)
                 otPlatWakeHost();
             }
 
-            VerifyOrExit(!super_t::ShouldDeferHostSend(), OT_NOOP);
+            VerifyOrExit(!super_t::ShouldDeferHostSend());
             SuccessOrExit(mFrameEncoder.BeginFrame());
 
             IgnoreError(txFrameBuffer.OutFrameBegin());

--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -152,7 +152,7 @@ static bool ReconnectSession(void)
         VerifyOrExit(rval == -1, ok = true);
 
         // Exit immediately if the sock file is not found
-        VerifyOrExit(errno != ENOENT, OT_NOOP);
+        VerifyOrExit(errno != ENOENT);
     }
 
 exit:

--- a/src/posix/platform/alarm.cpp
+++ b/src/posix/platform/alarm.cpp
@@ -214,7 +214,7 @@ void platformAlarmUpdateTimeout(struct timeval *aTimeout)
     if (sIsMsRunning)
     {
         remaining = (int32_t)(sMsAlarm - (uint32_t)(now / US_PER_MS));
-        VerifyOrExit(remaining > 0, OT_NOOP);
+        VerifyOrExit(remaining > 0);
         remaining *= US_PER_MS;
         remaining -= (now % US_PER_MS);
     }

--- a/src/posix/platform/hdlc_interface.cpp
+++ b/src/posix/platform/hdlc_interface.cpp
@@ -177,7 +177,7 @@ HdlcInterface::~HdlcInterface(void)
 
 void HdlcInterface::Deinit(void)
 {
-    VerifyOrExit(mSockFd != -1, OT_NOOP);
+    VerifyOrExit(mSockFd != -1);
 
     VerifyOrExit(0 == close(mSockFd), perror("close RCP"));
     VerifyOrExit(-1 != wait(nullptr) || errno == ECHILD, perror("wait RCP"));
@@ -431,7 +431,7 @@ int HdlcInterface::OpenFile(const RadioUrl &aRadioUrl)
         int      stopBit  = 1;
         uint32_t baudrate = 115200;
 
-        VerifyOrExit((rval = tcgetattr(fd, &tios)) == 0, OT_NOOP);
+        VerifyOrExit((rval = tcgetattr(fd, &tios)) == 0);
 
         cfmakeraw(&tios);
 
@@ -573,7 +573,7 @@ int HdlcInterface::OpenFile(const RadioUrl &aRadioUrl)
 
         VerifyOrExit((rval = cfsetspeed(&tios, static_cast<speed_t>(speed))) == 0, perror("cfsetspeed"));
         VerifyOrExit((rval = tcsetattr(fd, TCSANOW, &tios)) == 0, perror("tcsetattr"));
-        VerifyOrExit((rval = tcflush(fd, TCIOFLUSH)) == 0, OT_NOOP);
+        VerifyOrExit((rval = tcflush(fd, TCIOFLUSH)) == 0);
     }
 
 exit:

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -443,7 +443,7 @@ static void UpdateMulticast(otInstance *aInstance, const otIp6Address &aAddress,
 
     assert(sInstance == aInstance);
 
-    VerifyOrExit(sIpFd >= 0, OT_NOOP);
+    VerifyOrExit(sIpFd >= 0);
     memcpy(&mreq.ipv6mr_multiaddr, &aAddress, sizeof(mreq.ipv6mr_multiaddr));
     mreq.ipv6mr_interface = gNetifIndex;
 
@@ -486,7 +486,7 @@ static void UpdateLink(otInstance *aInstance)
 
     assert(sInstance == aInstance);
 
-    VerifyOrExit(sIpFd >= 0, OT_NOOP);
+    VerifyOrExit(sIpFd >= 0);
     memset(&ifr, 0, sizeof(ifr));
     strncpy(ifr.ifr_name, gNetifName, sizeof(ifr.ifr_name));
     VerifyOrExit(ioctl(sIpFd, SIOCGIFFLAGS, &ifr) == 0, perror("ioctl"); error = OT_ERROR_FAILED);
@@ -550,7 +550,7 @@ static void processReceive(otMessage *aMessage, void *aContext)
     assert(sInstance == aContext);
     assert(length <= kMaxIp6Size);
 
-    VerifyOrExit(sTunFd > 0, OT_NOOP);
+    VerifyOrExit(sTunFd > 0);
 
     VerifyOrExit(otMessageRead(aMessage, 0, &packet[offset], maxLength) == length, error = OT_ERROR_NO_BUFS);
 
@@ -671,8 +671,7 @@ static void processNetifAddrEvent(otInstance *aInstance, struct nlmsghdr *aNetli
     otError             error = OT_ERROR_NONE;
     struct sockaddr_in6 addr6;
 
-    VerifyOrExit(ifaddr->ifa_index == static_cast<unsigned int>(gNetifIndex) && ifaddr->ifa_family == AF_INET6,
-                 OT_NOOP);
+    VerifyOrExit(ifaddr->ifa_index == static_cast<unsigned int>(gNetifIndex) && ifaddr->ifa_family == AF_INET6);
 
     rtaLength = IFA_PAYLOAD(aNetlinkMessage);
 
@@ -770,7 +769,7 @@ static void processNetifLinkEvent(otInstance *aInstance, struct nlmsghdr *aNetli
     struct ifinfomsg *ifinfo = reinterpret_cast<struct ifinfomsg *>(NLMSG_DATA(aNetlinkMessage));
     otError           error  = OT_ERROR_NONE;
 
-    VerifyOrExit(ifinfo->ifi_index == static_cast<int>(gNetifIndex), OT_NOOP);
+    VerifyOrExit(ifinfo->ifi_index == static_cast<int>(gNetifIndex));
     SuccessOrExit(error = otIp6SetEnabled(aInstance, ifinfo->ifi_flags & IFF_UP));
 
 exit:
@@ -827,7 +826,7 @@ static void processNetifAddrEvent(otInstance *aInstance, struct rt_msghdr *rtm)
     {
         ifam = reinterpret_cast<struct ifa_msghdr *>(rtm);
 
-        VerifyOrExit(ifam->ifam_index == static_cast<unsigned int>(gNetifIndex), OT_NOOP);
+        VerifyOrExit(ifam->ifam_index == static_cast<unsigned int>(gNetifIndex));
 
         addrbuf  = (uint8_t *)&ifam[1];
         addrmask = (unsigned int)ifam->ifam_addrs;
@@ -837,7 +836,7 @@ static void processNetifAddrEvent(otInstance *aInstance, struct rt_msghdr *rtm)
     {
         ifmam = reinterpret_cast<struct ifma_msghdr *>(rtm);
 
-        VerifyOrExit(ifmam->ifmam_index == static_cast<unsigned int>(gNetifIndex), OT_NOOP);
+        VerifyOrExit(ifmam->ifmam_index == static_cast<unsigned int>(gNetifIndex));
 
         addrbuf  = (uint8_t *)&ifmam[1];
         addrmask = (unsigned int)ifmam->ifmam_addrs;
@@ -1011,7 +1010,7 @@ static void processNetifInfoEvent(otInstance *aInstance, struct rt_msghdr *rtm)
     struct if_msghdr *ifm   = reinterpret_cast<struct if_msghdr *>(rtm);
     otError           error = OT_ERROR_NONE;
 
-    VerifyOrExit(ifm->ifm_index == static_cast<int>(gNetifIndex), OT_NOOP);
+    VerifyOrExit(ifm->ifm_index == static_cast<int>(gNetifIndex));
 
     UpdateLink(aInstance);
 
@@ -1036,7 +1035,7 @@ static void processNetlinkEvent(otInstance *aInstance)
 
     length = recv(sNetlinkFd, buffer, sizeof(buffer), 0);
 
-    VerifyOrExit(length > 0, OT_NOOP);
+    VerifyOrExit(length > 0);
 
 #if defined(__linux__)
     for (struct nlmsghdr *msg = reinterpret_cast<struct nlmsghdr *>(buffer); NLMSG_OK(msg, static_cast<size_t>(length));
@@ -1177,13 +1176,13 @@ static void processMLDEvent(otInstance *aInstance)
     char                addressString[INET6_ADDRSTRLEN + 1];
 
     bufferLen = recvfrom(sMLDMonitorFd, buffer, sizeof(buffer), 0, reinterpret_cast<sockaddr *>(&srcAddr), &addrLen);
-    VerifyOrExit(bufferLen > 0, OT_NOOP);
+    VerifyOrExit(bufferLen > 0);
 
     type = buffer[0];
-    VerifyOrExit(type == kICMPv6MLDv2Type && bufferLen >= static_cast<ssize_t>(sizeof(MLDv2Header)), OT_NOOP);
+    VerifyOrExit(type == kICMPv6MLDv2Type && bufferLen >= static_cast<ssize_t>(sizeof(MLDv2Header)));
 
     // Check whether it is sent by self
-    VerifyOrExit(getifaddrs(&ifAddrs) == 0, OT_NOOP);
+    VerifyOrExit(getifaddrs(&ifAddrs) == 0);
     for (struct ifaddrs *ifAddr = ifAddrs; ifAddr != nullptr; ifAddr = ifAddr->ifa_next)
     {
         if (ifAddr->ifa_addr != nullptr && ifAddr->ifa_addr->sa_family == AF_INET6 &&
@@ -1198,7 +1197,7 @@ static void processMLDEvent(otInstance *aInstance)
             }
         }
     }
-    VerifyOrExit(fromSelf, OT_NOOP);
+    VerifyOrExit(fromSelf);
 
     hdr    = reinterpret_cast<MLDv2Header *>(buffer);
     offset = sizeof(MLDv2Header);
@@ -1473,7 +1472,7 @@ void platformNetifUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *a
 {
     OT_UNUSED_VARIABLE(aWriteFdSet);
 
-    VerifyOrExit(gNetifIndex > 0, OT_NOOP);
+    VerifyOrExit(gNetifIndex > 0);
 
     assert(sTunFd >= 0);
     assert(sNetlinkFd >= 0);
@@ -1511,7 +1510,7 @@ exit:
 void platformNetifProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, const fd_set *aErrorFdSet)
 {
     OT_UNUSED_VARIABLE(aWriteFdSet);
-    VerifyOrExit(gNetifIndex > 0, OT_NOOP);
+    VerifyOrExit(gNetifIndex > 0);
 
     if (FD_ISSET(sTunFd, aErrorFdSet))
     {

--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -461,7 +461,7 @@ otError SpiInterface::PushPullSpi(void)
     SuccessOrExit(error = mRxFrameBuffer.SetSkipLength(kSpiFrameHeaderSize));
 
     // Check whether the remaining frame buffer has enough space to store the data to be received.
-    VerifyOrExit(mRxFrameBuffer.GetFrameMaxLength() >= spiTransferBytes + mSpiAlignAllowance, OT_NOOP);
+    VerifyOrExit(mRxFrameBuffer.GetFrameMaxLength() >= spiTransferBytes + mSpiAlignAllowance);
 
     // Point to the start of the reserved buffer.
     spiRxFrameBuffer = mRxFrameBuffer.GetFrame() - kSpiFrameHeaderSize;

--- a/src/posix/platform/uart.cpp
+++ b/src/posix/platform/uart.cpp
@@ -68,7 +68,7 @@ otError otPlatUartEnable(void)
     int                ret;
 
     // This allows implementing pseudo reset.
-    VerifyOrExit(sUartSocket == -1, OT_NOOP);
+    VerifyOrExit(sUartSocket == -1);
 
     sUartSocket = SocketWithCloseExec(AF_UNIX, SOCK_STREAM, 0, kSocketNonBlock);
 
@@ -171,7 +171,7 @@ exit:
 
 void platformUartUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, fd_set *aErrorFdSet, int *aMaxFd)
 {
-    VerifyOrExit(sEnabled, OT_NOOP);
+    VerifyOrExit(sEnabled);
 
     if (aReadFdSet != nullptr)
     {
@@ -226,11 +226,11 @@ static void InitializeSessionSocket(void)
 
     VerifyOrExit((newSessionSocket = accept(sUartSocket, nullptr, nullptr)) != -1, rval = -1);
 
-    VerifyOrExit((rval = fcntl(newSessionSocket, F_GETFD, 0)) != -1, OT_NOOP);
+    VerifyOrExit((rval = fcntl(newSessionSocket, F_GETFD, 0)) != -1);
 
     rval |= FD_CLOEXEC;
 
-    VerifyOrExit((rval = fcntl(newSessionSocket, F_SETFD, rval)) != -1, OT_NOOP);
+    VerifyOrExit((rval = fcntl(newSessionSocket, F_SETFD, rval)) != -1);
 
 #ifndef __linux__
     // some platforms (macOS, Solaris) don't have MSG_NOSIGNAL
@@ -239,7 +239,7 @@ static void InitializeSessionSocket(void)
     // to simply ignore it.
 #if defined(SO_NOSIGPIPE)
     rval = setsockopt(newSessionSocket, SOL_SOCKET, SO_NOSIGPIPE, &rval, sizeof(rval));
-    VerifyOrExit(rval != -1, OT_NOOP);
+    VerifyOrExit(rval != -1);
 #else
 #warning "no support for MSG_NOSIGNAL or SO_NOSIGPIPE"
 #endif
@@ -313,7 +313,7 @@ void platformUartProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, co
     ssize_t rval;
     int     fd;
 
-    VerifyOrExit(sEnabled, OT_NOOP);
+    VerifyOrExit(sEnabled);
 #if OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
     if (FD_ISSET(sUartSocket, aErrorFdSet))
     {
@@ -332,7 +332,7 @@ void platformUartProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, co
         otPlatUartSendDone();
     }
 
-    VerifyOrExit(sSessionSocket != -1, OT_NOOP);
+    VerifyOrExit(sSessionSocket != -1);
 
     if (FD_ISSET(sSessionSocket, aErrorFdSet))
     {
@@ -340,7 +340,7 @@ void platformUartProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, co
         sSessionSocket = -1;
     }
 
-    VerifyOrExit(sSessionSocket != -1, OT_NOOP);
+    VerifyOrExit(sSessionSocket != -1);
 
     fd = sSessionSocket;
 #else  // OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -429,7 +429,7 @@ exit:
 
 void platformUdpUpdateFdSet(otInstance *aInstance, fd_set *aReadFdSet, int *aMaxFd)
 {
-    VerifyOrExit(gNetifIndex != 0, OT_NOOP);
+    VerifyOrExit(gNetifIndex != 0);
 
     for (otUdpSocket *socket = otUdpGetSockets(aInstance); socket != nullptr; socket = socket->mNext)
     {

--- a/tests/fuzz/cli_uart_received.cpp
+++ b/tests/fuzz/cli_uart_received.cpp
@@ -50,7 +50,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     otInstance *instance = nullptr;
     uint8_t *   buf      = nullptr;
 
-    VerifyOrExit(size <= 65536, OT_NOOP);
+    VerifyOrExit(size <= 65536);
 
     FuzzerPlatformInit();
 
@@ -67,7 +67,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     otPlatUartReceived(buf, (uint16_t)size);
 
-    VerifyOrExit(!FuzzerPlatformResetWasRequested(), OT_NOOP);
+    VerifyOrExit(!FuzzerPlatformResetWasRequested());
 
     for (int i = 0; i < MAX_ITERATIONS; i++)
     {

--- a/tests/fuzz/ip6_send.cpp
+++ b/tests/fuzz/ip6_send.cpp
@@ -50,7 +50,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     otError           error    = OT_ERROR_NONE;
     otMessageSettings settings;
 
-    VerifyOrExit(size > 0, OT_NOOP);
+    VerifyOrExit(size > 0);
 
     FuzzerPlatformInit();
 
@@ -73,7 +73,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     message = nullptr;
 
-    VerifyOrExit(!FuzzerPlatformResetWasRequested(), OT_NOOP);
+    VerifyOrExit(!FuzzerPlatformResetWasRequested());
 
     for (int i = 0; i < MAX_ITERATIONS; i++)
     {

--- a/tests/fuzz/ncp_uart_received.cpp
+++ b/tests/fuzz/ncp_uart_received.cpp
@@ -50,7 +50,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     otInstance *instance = nullptr;
     uint8_t *   buf      = nullptr;
 
-    VerifyOrExit(size <= 65536, OT_NOOP);
+    VerifyOrExit(size <= 65536);
 
     FuzzerPlatformInit();
 
@@ -67,7 +67,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     otPlatUartReceived(buf, (uint16_t)size);
 
-    VerifyOrExit(!FuzzerPlatformResetWasRequested(), OT_NOOP);
+    VerifyOrExit(!FuzzerPlatformResetWasRequested());
 
     for (int i = 0; i < MAX_ITERATIONS; i++)
     {

--- a/tests/fuzz/radio_receive_done.cpp
+++ b/tests/fuzz/radio_receive_done.cpp
@@ -50,7 +50,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
     otRadioFrame frame;
     uint8_t *    buf = nullptr;
 
-    VerifyOrExit(size <= OT_RADIO_FRAME_MAX_SIZE, OT_NOOP);
+    VerifyOrExit(size <= OT_RADIO_FRAME_MAX_SIZE);
 
     FuzzerPlatformInit();
 
@@ -71,7 +71,7 @@ extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
 
     otPlatRadioReceiveDone(instance, &frame, OT_ERROR_NONE);
 
-    VerifyOrExit(!FuzzerPlatformResetWasRequested(), OT_NOOP);
+    VerifyOrExit(!FuzzerPlatformResetWasRequested());
 
     for (int i = 0; i < MAX_ITERATIONS; i++)
     {

--- a/tests/unit/test_macros.cpp
+++ b/tests/unit/test_macros.cpp
@@ -116,9 +116,59 @@ void TestMacros(void)
     VerifyOrQuit(OT_SECOND_ARG(1, 2) == 2, "OT_SECOND_ARG() failed");
 }
 
+void TestVerifyOrExitSuccessNoAction(void)
+{
+    bool reachedEnd = false;
+
+    VerifyOrExit(true);
+    reachedEnd = true;
+
+exit:
+    VerifyOrQuit(reachedEnd, "VerifyOrExit() failed");
+}
+
+void TestVerifyOrExitFailureNoAction(void)
+{
+    bool reachedEnd = false;
+
+    VerifyOrExit(false);
+    reachedEnd = true;
+
+exit:
+    VerifyOrQuit(!reachedEnd, "VerifyOrExit() failed");
+}
+
+void TestVerifyOrExitSuccessWithAction(void)
+{
+    bool didAction  = false;
+    bool reachedEnd = false;
+
+    VerifyOrExit(true, didAction = true);
+    reachedEnd = true;
+
+exit:
+    VerifyOrQuit(reachedEnd && !didAction, "VerifyOrExit() failed");
+}
+
+void TestVerifyOrExitFailureWithAction(void)
+{
+    bool didAction  = false;
+    bool reachedEnd = false;
+
+    VerifyOrExit(false, didAction = true);
+    reachedEnd = true;
+
+exit:
+    VerifyOrQuit(!reachedEnd && didAction, "VerifyOrExit() failed");
+}
+
 int main(void)
 {
     TestMacros();
+    TestVerifyOrExitSuccessNoAction();
+    TestVerifyOrExitFailureNoAction();
+    TestVerifyOrExitSuccessWithAction();
+    TestVerifyOrExitFailureWithAction();
     printf("All tests passed\n");
     return 0;
 }


### PR DESCRIPTION
This commit uses the newly added macros from `arg_macros.hpp` to
enhance `VerifyOfExit()` enabling `aAction` argument to be optional.

-----------

This PR contains the commit from https://github.com/openthread/openthread/pull/5650 adding the `arg_macros.hpp`

It also contains small fix/improvement commit related to lib-url `Makefile`:

**[lib-url] update 'Makefile' to include 'src/core' in header path search**
    
The `url.cpp` can use core header files (e.g. `common/core_utils.hpp`)
This change ensure yhe core header files should be able to see each
other (e.g., `code_utils.hpp` including `arg_macros.hpp`).