### PR TITLE
[backbone-router] backbone TMF enhancements

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (36)
+#define OPENTHREAD_API_VERSION (37)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/udp.h
+++ b/include/openthread/platform/udp.h
@@ -121,6 +121,40 @@ otError otPlatUdpConnect(otUdpSocket *aUdpSocket);
  */
 otError otPlatUdpSend(otUdpSocket *aUdpSocket, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
+/**
+ * This function configures the UDP socket to join a UDP multicast group.
+ *
+ * Note: only available when `OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE` is used.
+ *
+ * @param[in]   aUdpSocket          A pointer to the UDP socket.
+ * @param[in]   aNetifIdentifier    The network interface identifier.
+ * @param[in]   aAddress            The UDP multicast group address.
+ *
+ * @retval  OT_ERROR_NONE   Successfully joined the multicast group.
+ * @retval  OT_ERROR_FAILED Failed to join the multicast group.
+ *
+ */
+otError otPlatUdpJoinMulticastGroup(otUdpSocket *       aUdpSocket,
+                                    otNetifIdentifier   aNetifIdentifier,
+                                    const otIp6Address *aAddress);
+
+/**
+ * This function configures the UDP socket to leave a UDP multicast group.
+ *
+ * Note: only available when `OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE` is used.
+ *
+ * @param[in]   aUdpSocket          A pointer to the UDP socket.
+ * @param[in]   aNetifIdentifier    The network interface identifier.
+ * @param[in]   aAddress            The UDP multicast group address.
+ *
+ * @retval  OT_ERROR_NONE   Successfully left the multicast group.
+ * @retval  OT_ERROR_FAILED Failed to leave the multicast group.
+ *
+ */
+otError otPlatUdpLeaveMulticastGroup(otUdpSocket *       aUdpSocket,
+                                     otNetifIdentifier   aNetifIdentifier,
+                                     const otIp6Address *aAddress);
+
 #ifdef __cplusplus
 } // extern "C"
 #endif

--- a/src/core/backbone_router/backbone_tmf.hpp
+++ b/src/core/backbone_router/backbone_tmf.hpp
@@ -81,6 +81,22 @@ public:
      */
     bool IsBackboneTmfMessage(const Ip6::MessageInfo &aMessageInfo) const;
 
+    /**
+     * This method subscribes the Backbone TMF socket to a given Ip6 multicast group on the Backbone network.
+     *
+     * @param[in] aAddress  The Ip6 multicast group address.
+     *
+     */
+    void SubscribeMulticast(const Ip6::Address &aAddress);
+
+    /**
+     * This method unsubscribes the Backbone TMF socket from a given Ip6 multicast group on the Backbone network.
+     *
+     * @param[in] aAddress  The Ip6 multicast group address.
+     *
+     */
+    void UnsubscribeMulticast(const Ip6::Address &aAddress);
+
 private:
     static otError Filter(const ot::Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);
 };

--- a/src/core/backbone_router/bbr_local.hpp
+++ b/src/core/backbone_router/bbr_local.hpp
@@ -205,10 +205,7 @@ public:
      * @returns A reference to the All Network Backbone Routers Multicast Address.
      *
      */
-    const Ip6::Address &GetAllNetworkBackboneRoutersAddress(void) const
-    {
-        return mAllNetworkBackboneRouters.GetAddress();
-    }
+    const Ip6::Address &GetAllNetworkBackboneRoutersAddress(void) const { return mAllNetworkBackboneRouters; }
 
     /**
      * This method returns a reference to the All Domain Backbone Routers Multicast Address.
@@ -216,10 +213,7 @@ public:
      * @returns A reference to the All Domain Backbone Routers Multicast Address.
      *
      */
-    const Ip6::Address &GetAllDomainBackboneRoutersAddress(void) const
-    {
-        return mAllDomainBackboneRouters.GetAddress();
-    }
+    const Ip6::Address &GetAllDomainBackboneRoutersAddress(void) const { return mAllDomainBackboneRouters; }
 
     /**
      * This method applies the Mesh Local Prefix.
@@ -261,9 +255,9 @@ private:
 
     NetworkData::OnMeshPrefixConfig mDomainPrefixConfig;
 
-    Ip6::NetifUnicastAddress   mBackboneRouterPrimaryAloc;
-    Ip6::NetifMulticastAddress mAllNetworkBackboneRouters;
-    Ip6::NetifMulticastAddress mAllDomainBackboneRouters;
+    Ip6::NetifUnicastAddress mBackboneRouterPrimaryAloc;
+    Ip6::Address             mAllNetworkBackboneRouters;
+    Ip6::Address             mAllDomainBackboneRouters;
 };
 
 } // namespace BackboneRouter

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -324,7 +324,6 @@ void Manager::SendBackboneMulticastListenerRegistration(const Ip6::Address *aAdd
     messageInfo.SetPeerAddr(Get<BackboneRouter::Local>().GetAllNetworkBackboneRoutersAddress());
     messageInfo.SetPeerPort(BackboneRouter::kBackboneUdpPort); // TODO: Provide API for configuring Backbone COAP port.
 
-    messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetHopLimit(Mle::kDefaultBackboneHoplimit);
     messageInfo.SetIsHostInterface(true);
 

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -225,6 +225,10 @@ otError CoapBase::SendMessage(Message &               aMessage,
         metadata.mRetransmissionTimeout    = aTxParameters.CalculateInitialRetransmissionTimeout();
         metadata.mAcknowledged             = false;
         metadata.mConfirmable              = aMessage.IsConfirmable();
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+        metadata.mHopLimit        = aMessageInfo.GetHopLimit();
+        metadata.mIsHostInterface = aMessageInfo.IsHostInterface();
+#endif
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
         metadata.mObserve = observe;
 #endif
@@ -377,6 +381,10 @@ void CoapBase::HandleRetransmissionTimer(void)
                 messageInfo.SetPeerAddr(metadata.mDestinationAddress);
                 messageInfo.SetPeerPort(metadata.mDestinationPort);
                 messageInfo.SetSockAddr(metadata.mSourceAddress);
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+                messageInfo.SetHopLimit(metadata.mHopLimit);
+                messageInfo.SetIsHostInterface(metadata.mIsHostInterface);
+#endif
 
                 SendCopy(*message, messageInfo);
             }

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -540,8 +540,14 @@ private:
         TimeMilli       mNextTimerShot;            // Time when the timer should shoot for this message.
         uint32_t        mRetransmissionTimeout;    // Delay that is applied to next retransmission.
         uint8_t         mRetransmissionsRemaining; // Number of retransmissions remaining.
-        bool            mAcknowledged : 1;         // Information that request was acknowledged.
-        bool            mConfirmable : 1;          // Information that message is confirmable.
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+        uint8_t mHopLimit; // The hop limit.
+#endif
+        bool mAcknowledged : 1; // Information that request was acknowledged.
+        bool mConfirmable : 1;  // Information that message is confirmable.
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+        bool mIsHostInterface : 1; // TRUE if packets sent/received via host interface, FALSE otherwise.
+#endif
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
         bool mObserve : 1; // Information that this request involves Observations.
 #endif

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -137,6 +137,42 @@ otError Udp::Socket::SendTo(Message &aMessage, const MessageInfo &aMessageInfo)
     return Get<Udp>().SendTo(*this, aMessage, aMessageInfo);
 }
 
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+otError Udp::Socket::JoinNetifMulticastGroup(otNetifIdentifier aNetifIdentifier, const Address &aAddress)
+{
+    OT_UNUSED_VARIABLE(aNetifIdentifier);
+    OT_UNUSED_VARIABLE(aAddress);
+
+    otError error = OT_ERROR_NOT_IMPLEMENTED;
+
+    VerifyOrExit(aAddress.IsMulticast(), error = OT_ERROR_INVALID_ARGS);
+
+#if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
+    error = otPlatUdpJoinMulticastGroup(this, aNetifIdentifier, &aAddress);
+#endif
+
+exit:
+    return error;
+}
+
+otError Udp::Socket::LeaveNetifMulticastGroup(otNetifIdentifier aNetifIdentifier, const Address &aAddress)
+{
+    OT_UNUSED_VARIABLE(aNetifIdentifier);
+    OT_UNUSED_VARIABLE(aAddress);
+
+    otError error = OT_ERROR_NOT_IMPLEMENTED;
+
+    VerifyOrExit(aAddress.IsMulticast(), error = OT_ERROR_INVALID_ARGS);
+
+#if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
+    error = otPlatUdpLeaveMulticastGroup(this, aNetifIdentifier, &aAddress);
+#endif
+
+exit:
+    return error;
+}
+#endif
+
 Udp::Udp(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mEphemeralPort(kDynamicPortMin)

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -261,6 +261,32 @@ public:
          *
          */
         otError SendTo(Message &aMessage, const MessageInfo &aMessageInfo);
+
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+        /**
+         * This method configures the UDP socket to join a mutlicast group on a Host network interface.
+         *
+         * @param[in]  aNetifIdentifier     The network interface identifier.
+         * @param[in]  aAddress             The multicast group address.
+         *
+         * @retval  OT_ERROR_NONE   Successfully joined the multicast group.
+         * @retval  OT_ERROR_FAILED Failed to join the multicast group.
+         *
+         */
+        otError JoinNetifMulticastGroup(otNetifIdentifier aNetifIdentifier, const Address &aAddress);
+
+        /**
+         * This method configures the UDP socket to leave a multicast group on a Host network interface.
+         *
+         * @param[in]  aNetifIdentifier     The network interface identifier.
+         * @param[in]  aAddress             The multicast group address.
+         *
+         * @retval  OT_ERROR_NONE   Successfully left the multicast group.
+         * @retval  OT_ERROR_FAILED Failed to leave the multicast group.
+         *
+         */
+        otError LeaveNetifMulticastGroup(otNetifIdentifier aNetifIdentifier, const Address &aAddress);
+#endif
     };
 
     /**

--- a/tests/scripts/thread-cert/backbone/test_bmlr.py
+++ b/tests/scripts/thread-cert/backbone/test_bmlr.py
@@ -147,6 +147,7 @@ class BBR_5_11_01(thread_cert.TestCase):
         pkts.filter_eth_src(PBBR_ETH).filter_coap_request('/b/bmr').must_next().must_verify(f"""
             thread_meshcop.tlv.ipv6_addr == ['{MA1}']
             and thread_bl.tlv.timeout == {MLR_TIMEOUT}
+            and ipv6.src.is_link_local
         """)
 
         # Router registers MA2 with default timeout
@@ -158,6 +159,7 @@ class BBR_5_11_01(thread_cert.TestCase):
         pkts.filter_eth_src(PBBR_ETH).filter_coap_request('/b/bmr').must_next().must_verify(f"""
             thread_meshcop.tlv.ipv6_addr == ['{MA2}']
             and thread_bl.tlv.timeout == {MLR_TIMEOUT}
+            and ipv6.src.is_link_local
         """)
 
         # Commissioner registers MA3 with deafult timeout
@@ -169,6 +171,7 @@ class BBR_5_11_01(thread_cert.TestCase):
         pkts.filter_eth_src(PBBR_ETH).filter_coap_request('/b/bmr').must_next().must_verify(f"""
             thread_meshcop.tlv.ipv6_addr == ['{MA3}']
             and thread_bl.tlv.timeout == {MLR_TIMEOUT}
+            and ipv6.src.is_link_local
         """)
 
         # Commissioner registers MA4 with custom timeout
@@ -180,6 +183,7 @@ class BBR_5_11_01(thread_cert.TestCase):
         pkts.filter_eth_src(PBBR_ETH).filter_coap_request('/b/bmr').must_next().must_verify(f"""
             thread_meshcop.tlv.ipv6_addr == ['{MA4}']
             and thread_bl.tlv.timeout == {CUSTOM_MLR_TIMEOUT}
+            and ipv6.src.is_link_local
         """)
 
         # Commissioner unregisters MA5
@@ -190,6 +194,7 @@ class BBR_5_11_01(thread_cert.TestCase):
         # Verify PBBR not sends `/b/bmr` on the Backbone link for MA5.
         pkts.filter_eth_src(PBBR_ETH).filter_coap_request('/b/bmr').filter(f"""
             thread_meshcop.tlv.ipv6_addr == ['{MA5}']
+            and ipv6.src.is_link_local
         """).must_not_next()
 
 

--- a/tests/scripts/thread-cert/v1_2_test_backbone_router_service.py
+++ b/tests/scripts/thread-cert/v1_2_test_backbone_router_service.py
@@ -108,13 +108,10 @@ class TestBackboneRouterService(thread_cert.TestCase):
         WAIT_TIME = BBR_REGISTRATION_JITTER + WAIT_REDUNDANCE
         self.simulator.go(WAIT_TIME)
         self.assertEqual(self.nodes[BBR_1].get_backbone_router_state(), 'Primary')
-        assert self.nodes[BBR_1].has_ipmaddr(config.ALL_NETWORK_BBRS_ADDRESS)
-        assert not self.nodes[BBR_1].has_ipmaddr(config.ALL_DOMAIN_BBRS_ADDRESS)
 
         self.nodes[BBR_1].set_domain_prefix(config.DOMAIN_PREFIX)
         WAIT_TIME = WAIT_REDUNDANCE
         self.simulator.go(WAIT_TIME)
-        assert self.nodes[BBR_1].has_ipmaddr(config.ALL_DOMAIN_BBRS_ADDRESS)
 
         # 2) Reset BBR_1 and bring it back soon.
         # Verify that it restores Primary State with sequence number
@@ -174,9 +171,6 @@ class TestBackboneRouterService(thread_cert.TestCase):
         WAIT_TIME = BBR_REGISTRATION_JITTER + WAIT_REDUNDANCE
         self.simulator.go(WAIT_TIME)
         self.assertEqual(self.nodes[BBR_2].get_backbone_router_state(), 'Disabled')
-
-        assert not self.nodes[BBR_2].has_ipmaddr(config.ALL_NETWORK_BBRS_ADDRESS)
-        assert not self.nodes[BBR_2].has_ipmaddr(config.ALL_DOMAIN_BBRS_ADDRESS)
 
         # Enable Backbone function, it will stay at Secondary state as
         # there is Primary Backbone Router already.
@@ -241,9 +235,6 @@ class TestBackboneRouterService(thread_cert.TestCase):
         WAIT_TIME = BBR_REGISTRATION_JITTER + WAIT_REDUNDANCE
         self.simulator.go(WAIT_TIME)
         self.assertEqual(self.nodes[BBR_2].get_backbone_router_state(), 'Secondary')
-
-        assert self.nodes[BBR_1].has_ipmaddr(config.ALL_NETWORK_BBRS_ADDRESS)
-        assert self.nodes[BBR_1].has_ipmaddr(config.ALL_DOMAIN_BBRS_ADDRESS)
 
         # 6a) Check the uniqueness of DUA by comparing the one in above 4a).
         bbr2_dua2 = self.nodes[BBR_2].get_addr(config.DOMAIN_PREFIX)

--- a/tests/scripts/thread-cert/v1_2_test_domain_unicast_address.py
+++ b/tests/scripts/thread-cert/v1_2_test_domain_unicast_address.py
@@ -166,13 +166,10 @@ class TestDomainUnicastAddress(thread_cert.TestCase):
         WAIT_TIME = BBR_REGISTRATION_JITTER + WAIT_REDUNDANCE
         self.simulator.go(WAIT_TIME)
         self.assertEqual(self.nodes[BBR_1].get_backbone_router_state(), 'Primary')
-        assert self.nodes[BBR_1].has_ipmaddr(config.ALL_NETWORK_BBRS_ADDRESS)
-        assert not self.nodes[BBR_1].has_ipmaddr(config.ALL_DOMAIN_BBRS_ADDRESS)
 
         self.nodes[BBR_1].set_domain_prefix(config.DOMAIN_PREFIX, 'prosD')
         WAIT_TIME = WAIT_REDUNDANCE
         self.simulator.go(WAIT_TIME)
-        assert self.nodes[BBR_1].has_ipmaddr(config.ALL_DOMAIN_BBRS_ADDRESS)
 
         self.simulator.set_lowpan_context(context_id, config.DOMAIN_PREFIX)
         domain_prefix_cid = context_id

--- a/tests/scripts/thread-cert/v1_2_test_domain_unicast_address_registration.py
+++ b/tests/scripts/thread-cert/v1_2_test_domain_unicast_address_registration.py
@@ -190,13 +190,10 @@ class TestDomainUnicastAddressRegistration(thread_cert.TestCase):
         WAIT_TIME = BBR_REGISTRATION_JITTER + WAIT_REDUNDANCE
         self.simulator.go(WAIT_TIME)
         self.assertEqual(self.nodes[BBR_1].get_backbone_router_state(), 'Primary')
-        assert self.nodes[BBR_1].has_ipmaddr(config.ALL_NETWORK_BBRS_ADDRESS)
-        assert not self.nodes[BBR_1].has_ipmaddr(config.ALL_DOMAIN_BBRS_ADDRESS)
 
         self.nodes[BBR_1].set_domain_prefix(config.DOMAIN_PREFIX, 'prosD')
         WAIT_TIME = WAIT_REDUNDANCE
         self.simulator.go(WAIT_TIME)
-        assert self.nodes[BBR_1].has_ipmaddr(config.ALL_DOMAIN_BBRS_ADDRESS)
 
         self.simulator.set_lowpan_context(context_id, config.DOMAIN_PREFIX)
         domain_prefix_cid = context_id

--- a/tests/scripts/thread-cert/v1_2_test_dua_handle_address_error.py
+++ b/tests/scripts/thread-cert/v1_2_test_dua_handle_address_error.py
@@ -102,7 +102,6 @@ class TestDomainUnicastAddress(thread_cert.TestCase):
 
         self.nodes[BBR_1].set_domain_prefix(config.DOMAIN_PREFIX, 'prosD')
         self.simulator.go(WAIT_REDUNDANCE)
-        assert self.nodes[BBR_1].has_ipmaddr(config.ALL_DOMAIN_BBRS_ADDRESS)
 
         # 2) Bring up ROUTER_1
         self.nodes[ROUTER].start()


### PR DESCRIPTION
This PR enhances Backbone TMF:

- [x] Subscribe Backbone TMF on multicast addresses on the Backbone interface
  - [x] All Network BBRs Multicast Address
  - [x] All Domain BBRs Multicast Address
- [x] Thread Netif no longer subscribe these two addresses, because `BBR Multicast Addresses` are only defined for the Backbone Link in Thread Spec 9.4.8.1
- [x] Make sure backbone messages are using link local src addresses
  - [x] Verify src addr for `b/bmr` messages

**DAD** feature of `Thread 1.2 DUA` requires this PR to receive `Backbone Query / Answer` on the Backbone network. 