### PR TITLE
[coap] add helper method 'Message::SetTokenFromMessage()'

### DIFF
--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -63,7 +63,7 @@ otError otCoapMessageInitResponse(otMessage *aResponse, const otMessage *aReques
     response.Init(static_cast<Coap::Type>(aType), static_cast<Coap::Code>(aCode));
     response.SetMessageId(request.GetMessageId());
 
-    return response.SetToken(request.GetToken(), request.GetTokenLength());
+    return response.SetTokenFromMessage(request);
 }
 
 otError otCoapMessageSetToken(otMessage *aMessage, const uint8_t *aToken, uint8_t aTokenLength)
@@ -73,7 +73,7 @@ otError otCoapMessageSetToken(otMessage *aMessage, const uint8_t *aToken, uint8_
 
 void otCoapMessageGenerateToken(otMessage *aMessage, uint8_t aTokenLength)
 {
-    IgnoreError(static_cast<Coap::Message *>(aMessage)->SetToken(aTokenLength));
+    IgnoreError(static_cast<Coap::Message *>(aMessage)->GenerateRandomToken(aTokenLength));
 }
 
 otError otCoapMessageAppendContentFormatOption(otMessage *aMessage, otCoapOptionContentFormat aContentFormat)

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -320,7 +320,7 @@ otError CoapBase::SendHeaderResponse(Message::Code aCode, const Message &aReques
         OT_UNREACHABLE_CODE(break);
     }
 
-    SuccessOrExit(error = message->SetToken(aRequest.GetToken(), aRequest.GetTokenLength()));
+    SuccessOrExit(error = message->SetTokenFromMessage(aRequest));
 
     SuccessOrExit(error = SendMessage(*message, aMessageInfo));
 

--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -65,7 +65,7 @@ otError Message::Init(Type aType, Code aCode, const char *aUriPath)
     otError error;
 
     Init(aType, aCode);
-    SuccessOrExit(error = SetToken(kDefaultTokenLength));
+    SuccessOrExit(error = GenerateRandomToken(kDefaultTokenLength));
     SuccessOrExit(error = AppendUriPathOptions(aUriPath));
 
 exit:
@@ -333,7 +333,7 @@ otError Message::SetToken(const uint8_t *aToken, uint8_t aTokenLength)
     return SetLength(GetHelpData().mHeaderLength);
 }
 
-otError Message::SetToken(uint8_t aTokenLength)
+otError Message::GenerateRandomToken(uint8_t aTokenLength)
 {
     uint8_t token[kMaxTokenLength];
 
@@ -342,6 +342,11 @@ otError Message::SetToken(uint8_t aTokenLength)
     IgnoreError(Random::Crypto::FillBuffer(token, aTokenLength));
 
     return SetToken(token, aTokenLength);
+}
+
+otError Message::SetTokenFromMessage(const Message &aMessage)
+{
+    return SetToken(aMessage.GetToken(), aMessage.GetTokenLength());
 }
 
 bool Message::IsTokenEqual(const Message &aMessage) const
@@ -357,7 +362,7 @@ otError Message::SetDefaultResponseHeader(const Message &aRequest)
 
     SetMessageId(aRequest.GetMessageId());
 
-    return SetToken(aRequest.GetToken(), aRequest.GetTokenLength());
+    return SetTokenFromMessage(aRequest);
 }
 
 Message *Message::Clone(uint16_t aLength) const

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -387,6 +387,17 @@ public:
     otError SetToken(const uint8_t *aToken, uint8_t aTokenLength);
 
     /**
+     * This method sets the Token value and length by copying it from another given message.
+     *
+     * @param[in] aMessage       The message to copy the Token from.
+     *
+     * @retval OT_ERROR_NONE     Successfully set the token value.
+     * @retval OT_ERROR_NO_BUFS  Insufficient message buffers available to set the token value.
+     *
+     */
+    otError SetTokenFromMessage(const Message &aMessage);
+
+    /**
      * This method sets the Token length and randomizes its value.
      *
      * @param[in]  aTokenLength  The Length of a Token to set.
@@ -395,7 +406,7 @@ public:
      * @retval OT_ERROR_NO_BUFS  Insufficient message buffers available to set the token value.
      *
      */
-    otError SetToken(uint8_t aTokenLength);
+    otError GenerateRandomToken(uint8_t aTokenLength);
 
     /**
      * This method checks if Tokens in two CoAP headers are equal.

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -202,7 +202,7 @@ static void SendErrorMessage(Coap::CoapSecure &   aCoapSecure,
         message->SetMessageId(aRequest.GetMessageId());
     }
 
-    SuccessOrExit(error = message->SetToken(aRequest.GetToken(), aRequest.GetTokenLength()));
+    SuccessOrExit(error = message->SetTokenFromMessage(aRequest));
 
     SuccessOrExit(error = aCoapSecure.SendMessage(*message, aCoapSecure.GetMessageInfo()));
 

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -395,7 +395,7 @@ otError MlrManager::SendMulticastListenerRegistrationMessage(const otIp6Address 
     VerifyOrExit((message = Get<Tmf::TmfAgent>().NewMessage()) != nullptr, error = OT_ERROR_NO_BUFS);
 
     message->InitAsConfirmablePost();
-    SuccessOrExit(message->SetToken(Coap::Message::kDefaultTokenLength));
+    SuccessOrExit(message->GenerateRandomToken(Coap::Message::kDefaultTokenLength));
     SuccessOrExit(message->AppendUriPathOptions(UriPath::kMlr));
     SuccessOrExit(message->SetPayloadMarker());
 


### PR DESCRIPTION
This commit adds a new helper method to set the token on a CoAP
`Message` by copying it from another `Message`. It also renames the
method which generates a random token of a given length to
`GenerateRandomToken()`.