### PR TITLE
[cmake-build] ensure cc2538 uses 'CMAKE_BUILD_TYPE=Release'

### DIFF
--- a/script/cmake-build
+++ b/script/cmake-build
@@ -154,7 +154,7 @@ main()
             OT_CMAKE_NINJA_TARGET=("ot-cli-mtd" "ot-ncp-mtd")
             options+=("-DCMAKE_TOOLCHAIN_FILE=examples/platforms/${platform}/arm-none-eabi.cmake" "-DCMAKE_BUILD_TYPE=Release")
             ;;
-        cc1352 | cc2652 | cc2538 | samr21 | qpg6095)
+        cc1352 | cc2538 | cc2652 | qpg6095 | samr21)
             options+=("-DCMAKE_TOOLCHAIN_FILE=examples/platforms/${platform}/arm-none-eabi.cmake" "-DCMAKE_BUILD_TYPE=Release")
             ;;
         *)

--- a/script/cmake-build
+++ b/script/cmake-build
@@ -154,7 +154,7 @@ main()
             OT_CMAKE_NINJA_TARGET=("ot-cli-mtd" "ot-ncp-mtd")
             options+=("-DCMAKE_TOOLCHAIN_FILE=examples/platforms/${platform}/arm-none-eabi.cmake" "-DCMAKE_BUILD_TYPE=Release")
             ;;
-        cc1352 | cc2652 | samr21 | qpg6095)
+        cc1352 | cc2652 | cc2538 | samr21 | qpg6095)
             options+=("-DCMAKE_TOOLCHAIN_FILE=examples/platforms/${platform}/arm-none-eabi.cmake" "-DCMAKE_BUILD_TYPE=Release")
             ;;
         *)


### PR DESCRIPTION
This change ensures the cc2538 cmake build uses the release build type
and the compile option `-Os` (optimize for size). This harmonizes the
cmake build with automake version. It also helps address an issue with
recent PRs failing on cc2538 cmake build with arm-gcc-5 due to
reaching flash size limit (without `-Os` option).