### PR TITLE
[backbone-router] cleanup DomainPrefixState

### DIFF
--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -145,10 +145,6 @@ const char *Leader::DomainPrefixStateToString(DomainPrefixState aState)
 
     switch (aState)
     {
-    case kDomainPrefixNone:
-        logString = "None";
-        break;
-
     case kDomainPrefixAdded:
         logString = "Added";
         break;
@@ -159,10 +155,6 @@ const char *Leader::DomainPrefixStateToString(DomainPrefixState aState)
 
     case kDomainPrefixRefreshed:
         logString = "Refreshed";
-        break;
-
-    case kDomainPrefixUnchanged:
-        logString = "Unchanged";
         break;
     }
 
@@ -277,12 +269,12 @@ void Leader::UpdateDomainPrefixConfig(void)
         }
         else
         {
-            state = kDomainPrefixNone;
+            ExitNow();
         }
     }
     else if (config.GetPrefix() == mDomainPrefix)
     {
-        state = kDomainPrefixUnchanged;
+        ExitNow();
     }
     else
     {
@@ -308,6 +300,9 @@ void Leader::UpdateDomainPrefixConfig(void)
 #if OPENTHREAD_CONFIG_DUA_ENABLE || OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE
     Get<DuaManager>().HandleDomainPrefixUpdate(state);
 #endif
+
+exit:
+    return;
 }
 
 bool Leader::IsDomainUnicast(const Ip6::Address &aAddress) const

--- a/src/core/backbone_router/bbr_leader.hpp
+++ b/src/core/backbone_router/bbr_leader.hpp
@@ -72,13 +72,11 @@ public:
     };
 
     // Domain Prefix state or state change.
-    enum DomainPrefixState
+    enum DomainPrefixState : uint8_t
     {
-        kDomainPrefixNone = 0,  ///< Not available.
         kDomainPrefixAdded,     ///< Added.
         kDomainPrefixRemoved,   ///< Removed.
         kDomainPrefixRefreshed, ///< Changed.
-        kDomainPrefixUnchanged, ///< Nothing changed.
     };
 
     /**

--- a/src/core/backbone_router/ndproxy_table.cpp
+++ b/src/core/backbone_router/ndproxy_table.cpp
@@ -120,11 +120,9 @@ void NdProxyTable::Erase(NdProxy &aProxy)
 
 void NdProxyTable::HandleDomainPrefixUpdate(Leader::DomainPrefixState aState)
 {
-    if (aState == Leader::kDomainPrefixAdded || aState == Leader::kDomainPrefixRemoved ||
-        aState == Leader::kDomainPrefixRefreshed)
-    {
-        Clear();
-    }
+    OT_UNUSED_VARIABLE(aState);
+
+    Clear();
 }
 
 void NdProxyTable::Clear(void)

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -106,11 +106,6 @@ void DuaManager::HandleDomainPrefixUpdate(BackboneRouter::Leader::DomainPrefixSt
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     switch (aState)
     {
-    case BackboneRouter::Leader::kDomainPrefixUnchanged:
-        // In case removed for some reason e.g. the kDuaInvalid response from PBBR forcely
-        VerifyOrExit(!Get<ThreadNetif>().HasUnicastAddress(GetDomainUnicastAddress()));
-
-        // fall through
     case BackboneRouter::Leader::kDomainPrefixRefreshed:
     case BackboneRouter::Leader::kDomainPrefixAdded:
     {


### PR DESCRIPTION
This commit removes two Domain Prefix states that are not actually useful.
 - kDomainPrefixNone
 - kDomainPrefixUnchanged
