### PR TITLE
[pretty] add clang-tidy to script/make-pretty

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,13 +41,14 @@ jobs:
       if: "github.ref != 'refs/heads/master'"
 
   pretty:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
-        sudo apt-get --no-install-recommends install -y clang-format-10 shellcheck
+        sudo apt-get --no-install-recommends install -y clang-format-10 clang-tidy-10 shellcheck
+        sudo ln -s /usr/bin/run-clang-tidy-10.py /usr/local/bin/run-clang-tidy.py
         python3 -m pip install yapf==0.29.0
         sudo snap install shfmt
     - name: Check
@@ -99,7 +100,6 @@ jobs:
     - name: Bootstrap
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
-        sudo apt-get remove libllvm10
         sudo apt-get --no-install-recommends install -y clang-tools-10
     - name: Run
       run: |

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -58,8 +58,10 @@ install_packages_apt()
 
     echo 'Installing pretty tools useful for code contributions...'
 
-    # add clang-format for pretty
-    sudo apt-get --no-install-recommends install -y clang-format-10
+    # add clang-format and clang-tidy for pretty
+    sudo apt-get --no-install-recommends install -y clang-format-10 clang-tidy-10
+    sudo ln -sf /usr/bin/clang-tidy-10 /usr/bin/clang-tidy
+    sudo ln -sf /usr/bin/clang-apply-replacements-10 /usr/bin/clang-apply-replacements
 
     # add yapf for pretty
     python3 -m pip install yapf==0.29.0 || echo 'WARNING: could not install yapf, which is useful if you plan to contribute python code to the OpenThread project.'

--- a/script/make-pretty
+++ b/script/make-pretty
@@ -37,6 +37,8 @@
 # Format c/c++ only:
 #
 #     script/make-pretty clang
+#     script/make-pretty clang-format
+#     script/make-pretty clang-tidy
 #
 # Format markdown only:
 #
@@ -53,6 +55,8 @@
 # Check only:
 #
 #     script/make-pretty check clang
+#     script/make-pretty check clang-format
+#     script/make-pretty check clang-tidy
 #     script/make-pretty check markdown
 #     script/make-pretty check python
 #     script/make-pretty check shell
@@ -67,31 +71,114 @@ readonly OT_CLANG_SOURCES=('*.c' '*.cc' '*.cpp' '*.h' '*.hpp')
 readonly OT_MARKDOWN_SOURCES=('*.md')
 readonly OT_PYTHON_SOURCES=('*.py')
 
+readonly OT_CLANG_TIDY_FIX_DIRS=('examples' 'include' 'src' 'tests')
+readonly OT_CLANG_TIDY_BUILD_OPTS=(
+    '-DCMAKE_EXPORT_COMPILE_COMMANDS=ON'
+    '-DOT_APP_RCP=OFF'
+    '-DOT_MTD=OFF'
+    '-DOT_RCP=OFF'
+    '-DOT_PLATFORM=simulation'
+    '-DOT_BACKBONE_ROUTER=ON'
+    '-DOT_BORDER_AGENT=ON'
+    '-DOT_BORDER_ROUTER=ON'
+    '-DOT_CHANNEL_MANAGER=ON'
+    '-DOT_CHANNEL_MONITOR=ON'
+    '-DOT_CHILD_SUPERVISION=ON'
+    '-DOT_COAP=ON'
+    '-DOT_COAP_OBSERVE=ON'
+    '-DOT_COAPS=ON'
+    '-DOT_COMMISSIONER=ON'
+    '-DOT_CSL_RECEIVER=ON'
+    '-DOT_DHCP6_CLIENT=ON'
+    '-DOT_DHCP6_SERVER=ON'
+    '-DOT_DIAGNOSTIC=ON'
+    '-DOT_DNS_CLIENT=ON'
+    '-DOT_DUA=ON'
+    '-DOT_MLR=ON'
+    '-DOT_ECDSA=ON'
+    '-DOT_IP6_FRAGM=ON'
+    '-DOT_JAM_DETECTION=ON'
+    '-DOT_JOINER=ON'
+    '-DOT_LEGACY=ON'
+    '-DOT_LINK_RAW=ON'
+    '-DOT_LINK_METRICS=ON'
+    '-DOT_MAC_FILTER=ON'
+    '-DOT_MTD_NETDIAG=ON'
+    '-DOT_REFERENCE_DEVICE=ON'
+    '-DOT_SERVICE=ON'
+    '-DOT_SLAAC=ON'
+    '-DOT_SNTP_CLIENT=ON'
+    '-DOT_THREAD_VERSION=1.2'
+    '-DOT_COVERAGE=ON'
+    '-DOT_LOG_LEVEL_DYNAMIC=ON'
+    '-DOT_COMPILE_WARNING_AS_ERROR=ON'
+)
+
+readonly OT_CLANG_TIDY_CHECKS="\
+-*,\
+readability-make-member-function-const,\
+"
+
+#performance-for-range-copy\
+
 do_clang_format()
 {
-    echo -e '====================='
-    echo -e '     format c/c++'
-    echo -e '====================='
+    echo -e '========================================'
+    echo -e '     format c/c++ (clang-format)'
+    echo -e '========================================'
 
     git ls-files "${OT_CLANG_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
         | xargs -n3 -P"$OT_BUILD_JOBS" script/clang-format -style=file -i -verbose
 }
 
-do_clang_check()
+do_clang_format_check()
 {
-    echo -e '====================='
-    echo -e '     check c/c++'
-    echo -e '====================='
+    echo -e '========================================'
+    echo -e '     check c/c++ (clang-format)'
+    echo -e '========================================'
 
     git ls-files "${OT_CLANG_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
         | xargs -n3 -P"$OT_BUILD_JOBS" script/clang-format-check
 }
 
+do_clang_tidy_fix()
+{
+    echo -e '========================================'
+    echo -e '     format c/c++ (clang-tidy)'
+    echo -e '========================================'
+
+    (mkdir -p ./build/cmake-tidy \
+        && cd ./build/cmake-tidy \
+        && THREAD_VERSION=1.2 cmake "${OT_CLANG_TIDY_BUILD_OPTS[@]}" ../.. \
+        && run-clang-tidy.py -header-filter='.*' -checks="${OT_CLANG_TIDY_CHECKS}" -j"$OT_BUILD_JOBS" "${OT_CLANG_TIDY_FIX_DIRS[@]}" -fix)
+}
+
+do_clang_tidy_check()
+{
+    echo -e '========================================'
+    echo -e '     check c/c++ (clang-tidy)'
+    echo -e '========================================'
+
+    (
+        mkdir -p ./build/cmake-tidy \
+            && cd ./build/cmake-tidy \
+            && THREAD_VERSION=1.2 cmake "${OT_CLANG_TIDY_BUILD_OPTS[@]}" ../.. \
+            && run-clang-tidy.py -header-filter='.*' -checks="${OT_CLANG_TIDY_CHECKS}" -j"$OT_BUILD_JOBS" "${OT_CLANG_TIDY_FIX_DIRS[@]}" \
+            | grep -v -E "third_party" >output.txt
+        if grep -q "warning: \|error: " output.txt; then
+            echo "You must pass the clang tidy checks before submitting a pull request"
+            echo ""
+            grep --color -E '^|warning: |error: ' output.txt
+            exit 1
+        fi
+    )
+}
+
 do_markdown_format()
 {
-    echo -e '======================'
+    echo -e '========================================'
     echo -e '     format markdown'
-    echo -e '======================'
+    echo -e '========================================'
 
     git ls-files "${OT_MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
         | xargs -n10 -P"$OT_BUILD_JOBS" npx prettier@2.0.4 --write
@@ -99,9 +186,9 @@ do_markdown_format()
 
 do_markdown_check()
 {
-    echo -e '======================'
+    echo -e '========================================'
     echo -e '     check markdown'
-    echo -e '======================'
+    echo -e '========================================'
 
     git ls-files "${OT_MARKDOWN_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
         | xargs -n10 -P"$OT_BUILD_JOBS" npx prettier@2.0.4 --check
@@ -109,9 +196,9 @@ do_markdown_check()
 
 do_python_format()
 {
-    echo -e '======================'
+    echo -e '========================================'
     echo -e '     format python'
-    echo -e '======================'
+    echo -e '========================================'
 
     git ls-files "${OT_PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
         | xargs -n10 -P"$OT_BUILD_JOBS" python3 -m yapf --verbose --style '{based_on_style: google, column_limit: 119}' -ipr
@@ -119,9 +206,9 @@ do_python_format()
 
 do_python_check()
 {
-    echo -e '====================='
+    echo -e '========================================'
     echo -e '     check python'
-    echo -e '====================='
+    echo -e '========================================'
 
     git ls-files "${OT_PYTHON_SOURCES[@]}" | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
         | xargs -n10 -P"$OT_BUILD_JOBS" python3 -m yapf --verbose --style '{based_on_style: google, column_limit: 119}' -dpr
@@ -129,9 +216,9 @@ do_python_check()
 
 do_shell_format()
 {
-    echo -e '====================='
+    echo -e '========================================'
     echo -e '     format shell'
-    echo -e '====================='
+    echo -e '========================================'
 
     git ls-files | xargs shfmt -f | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
         | xargs -n10 -P"$OT_BUILD_JOBS" shfmt -i 4 -bn -ci -fn -s -w
@@ -139,9 +226,9 @@ do_shell_format()
 
 do_shell_check()
 {
-    echo -e '====================='
+    echo -e '========================================'
     echo -e '     check shell'
-    echo -e '====================='
+    echo -e '========================================'
 
     git ls-files | xargs shfmt -f | grep -v -E "^($(echo "${OT_EXCLUDE_DIRS[@]}" | tr ' ' '|'))" \
         | xargs -n10 -P"$OT_BUILD_JOBS" shfmt -i 4 -bn -ci -fn -s -d
@@ -153,12 +240,18 @@ do_shell_check()
 do_check()
 {
     if [ $# == 0 ]; then
-        do_clang_check
+        do_clang_format_check
+        do_clang_tidy_check
         do_markdown_check
         do_python_check
         do_shell_check
     elif [ "$1" == 'clang' ]; then
-        do_clang_check
+        do_clang_format_check
+        do_clang_tidy_check
+    elif [ "$1" == 'clang-format' ]; then
+        do_clang_format_check
+    elif [ "$1" == 'clang-tidy' ]; then
+        do_clang_tidy_check
     elif [ "$1" == 'markdown' ]; then
         do_markdown_check
     elif [ "$1" == 'python' ]; then
@@ -175,12 +268,18 @@ do_check()
 main()
 {
     if [ $# == 0 ]; then
+        do_clang_tidy_fix
         do_clang_format
         do_markdown_format
         do_python_format
         do_shell_format
     elif [ "$1" == 'clang' ]; then
+        do_clang_tidy_fix
         do_clang_format
+    elif [ "$1" == 'clang-format' ]; then
+        do_clang_format
+    elif [ "$1" == 'clang-tidy' ]; then
+        do_clang_tidy_fix
     elif [ "$1" == 'markdown' ]; then
         do_markdown_format
     elif [ "$1" == 'python' ]; then

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -44,7 +44,7 @@ namespace ot {
 const TimerScheduler::AlarmApi TimerMilliScheduler::sAlarmMilliApi = {&otPlatAlarmMilliStartAt, &otPlatAlarmMilliStop,
                                                                       &otPlatAlarmMilliGetNow};
 
-bool Timer::DoesFireBefore(const Timer &aSecondTimer, Time aNow)
+bool Timer::DoesFireBefore(const Timer &aSecondTimer, Time aNow) const
 {
     bool retval;
     bool isBeforeNow = (GetFireTime() < aNow);

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -132,7 +132,7 @@ protected:
      * @retval FALSE If the fire time of this timer object is the same or after aTimer's fire time.
      *
      */
-    bool DoesFireBefore(const Timer &aSecondTimer, Time aNow);
+    bool DoesFireBefore(const Timer &aSecondTimer, Time aNow) const;
 
     void Fired(void) { mHandler(*this); }
 

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -89,7 +89,7 @@ private:
 
     struct JoinerEntrustMetadata
     {
-        otError AppendTo(Message &aMessage) { return aMessage.Append(*this); }
+        otError AppendTo(Message &aMessage) const { return aMessage.Append(*this); }
         void    ReadFrom(const Message &aMessage);
 
         Ip6::MessageInfo mMessageInfo; // Message info of the message to send.

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -106,7 +106,7 @@ public:
      * @returns The MPL Seed Id Length value.
      *
      */
-    SeedIdLength GetSeedIdLength(void) { return static_cast<SeedIdLength>(mControl & kSeedIdLengthMask); }
+    SeedIdLength GetSeedIdLength(void) const { return static_cast<SeedIdLength>(mControl & kSeedIdLengthMask); }
 
     /**
      * This method sets the MPL Seed Id Length value.

--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -151,7 +151,7 @@ void CslTxScheduler::RescheduleCslTx(void)
     mCslTxChild = bestChild;
 }
 
-uint32_t CslTxScheduler::GetNextCslTransmissionDelay(const Child &aChild, uint64_t aRadioNow)
+uint32_t CslTxScheduler::GetNextCslTransmissionDelay(const Child &aChild, uint64_t aRadioNow) const
 {
     uint32_t delay;
     uint16_t period_offset = (aRadioNow / kUsPerTenSymbols) % aChild.GetCslPeriod();

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -190,7 +190,7 @@ private:
     void InitFrameRequestAhead(void);
     void RescheduleCslTx(void);
 
-    uint32_t GetNextCslTransmissionDelay(const Child &aChild, uint64_t aRadioNow);
+    uint32_t GetNextCslTransmissionDelay(const Child &aChild, uint64_t aRadioNow) const;
 
     // Callbacks from `Mac`
     otError HandleFrameRequest(Mac::TxFrame &aFrame);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1011,7 +1011,7 @@ exit:
     return error;
 }
 
-otError Mle::AppendSourceAddress(Message &aMessage)
+otError Mle::AppendSourceAddress(Message &aMessage) const
 {
     return Tlv::AppendUint16Tlv(aMessage, Tlv::kSourceAddress, GetRloc16());
 }

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -935,7 +935,7 @@ protected:
      * @retval OT_ERROR_NO_BUFS  Insufficient buffers available to append the Source Address TLV.
      *
      */
-    otError AppendSourceAddress(Message &aMessage);
+    otError AppendSourceAddress(Message &aMessage) const;
 
     /**
      * This method appends a Mode TLV to a message.

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -963,7 +963,7 @@ exit:
     return error;
 }
 
-otError Leader::AllocateServiceId(uint8_t &aServiceId)
+otError Leader::AllocateServiceId(uint8_t &aServiceId) const
 {
     otError error = OT_ERROR_NOT_FOUND;
     uint8_t serviceId;

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -215,7 +215,7 @@ private:
     otError AddService(const ServiceTlv &aService, ChangedFlags &aChangedFlags);
     otError AddServer(const ServerTlv &aServer, ServiceTlv &aDstService, ChangedFlags &aChangedFlags);
 
-    otError AllocateServiceId(uint8_t &aServiceId);
+    otError AllocateServiceId(uint8_t &aServiceId) const;
 
     otError AllocateContextId(uint8_t &aConextId);
     void    FreeContextId(uint8_t aContextId);

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -202,7 +202,7 @@ void ChannelMonitor::LogResults(void)
 #endif
 }
 
-Mac::ChannelMask ChannelMonitor::FindBestChannels(const Mac::ChannelMask &aMask, uint16_t &aOccupancy)
+Mac::ChannelMask ChannelMonitor::FindBestChannels(const Mac::ChannelMask &aMask, uint16_t &aOccupancy) const
 {
     uint8_t          channel;
     Mac::ChannelMask bestMask;

--- a/src/core/utils/channel_monitor.hpp
+++ b/src/core/utils/channel_monitor.hpp
@@ -183,7 +183,7 @@ public:
      *             channel with the same occupancy rate value.
      *
      */
-    Mac::ChannelMask FindBestChannels(const Mac::ChannelMask &aMask, uint16_t &aOccupancy);
+    Mac::ChannelMask FindBestChannels(const Mac::ChannelMask &aMask, uint16_t &aOccupancy) const;
 
 private:
     enum


### PR DESCRIPTION
This PR introduces clang-tidy into `script/make-pretty`.

Only one clang-tidy check (readability-make-member-function-const) is enabled in this initial PR as an example.

Further checks will be enabled in future PRs.