### PR TITLE
[spinel-interface] add config option to change the rx frame buffer size

### DIFF
--- a/src/core/config/platform.h
+++ b/src/core/config/platform.h
@@ -107,4 +107,15 @@
 #define OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE 0
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_PLATFORM_RADIO_SPINEL_RX_FRAME_BUFFER_SIZE
+ *
+ * Specifies the rx frame buffer size used by `SpinelInterface` in RCP host (posix) code. This is applicable/used when
+ * `RadioSpinel` platform is used.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_PLATFORM_RADIO_SPINEL_RX_FRAME_BUFFER_SIZE
+#define OPENTHREAD_CONFIG_PLATFORM_RADIO_SPINEL_RX_FRAME_BUFFER_SIZE 8192
+#endif
+
 #endif // CONFIG_PLATFORM_H_

--- a/src/lib/spinel/spinel_interface.hpp
+++ b/src/lib/spinel/spinel_interface.hpp
@@ -45,7 +45,7 @@ class SpinelInterface
 public:
     enum
     {
-        kMaxFrameSize = 2048, ///< Maximum frame size (number of bytes).
+        kMaxFrameSize = OPENTHREAD_CONFIG_PLATFORM_RADIO_SPINEL_RX_FRAME_BUFFER_SIZE, ///< Maximum buffer size.
     };
 
     /**


### PR DESCRIPTION
Adds `OPENTHREAD_CONFIG_PLATFORM_RADIO_SPINEL_RX_FRAME_BUFFER_SIZE`
config option which specifies the rx frame buffer size used by
`SpinelInterface` in RCP host (posix) code. This is applicable/used when
`RadioSpinel` platform is used.

-----

This is related to openthread/openthread#5678.