### PR TITLE
[style] clang-tidy misc enhancements

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,6 @@ jobs:
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y clang-format-10 clang-tidy-10 shellcheck
-        sudo ln -s /usr/bin/run-clang-tidy-10.py /usr/local/bin/run-clang-tidy.py
         python3 -m pip install yapf==0.29.0
         sudo snap install shfmt
     - name: Check

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -49,7 +49,7 @@ install_packages_apt()
         sudo apt-get --no-install-recommends install -y binutils-arm-none-eabi gcc-arm-none-eabi gdb-arm-none-eabi libnewlib-arm-none-eabi libstdc++-arm-none-eabi-newlib
     elif [ "$PLATFORM" = "Ubuntu" ]; then
         sudo apt-get --no-install-recommends install -y ca-certificates wget
-        (cd /opt \
+        (cd /tmp \
             && wget -c https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 \
             && tar xjf gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 \
             && rm gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 \
@@ -60,8 +60,6 @@ install_packages_apt()
 
     # add clang-format and clang-tidy for pretty
     sudo apt-get --no-install-recommends install -y clang-format-10 clang-tidy-10
-    sudo ln -sf /usr/bin/clang-tidy-10 /usr/bin/clang-tidy
-    sudo ln -sf /usr/bin/clang-apply-replacements-10 /usr/bin/clang-apply-replacements
 
     # add yapf for pretty
     python3 -m pip install yapf==0.29.0 || echo 'WARNING: could not install yapf, which is useful if you plan to contribute python code to the OpenThread project.'

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -1,0 +1,86 @@
+#!/bin/bash
+#
+#  Copyright (c) 2020, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+CLANG_TIDY_VERSION="LLVM version 10.0"
+CLANG_APPLY_REPLACEMENTS_VERSION="clang-apply-replacements version 10.0"
+
+die()
+{
+    echo " *** ERROR: $*"
+    exit 1
+}
+
+# Search for clang-tidy-10
+if command -v clang-tidy-10 >/dev/null; then
+    clang_tidy=$(command -v clang-tidy-10)
+elif command -v clang-tidy >/dev/null; then
+    clang_tidy=$(command -v clang-tidy)
+    case "$($clang_tidy --version)" in
+        *"$CLANG_TIDY_VERSION"*) ;;
+
+        *)
+            die "$($clang_tidy --version); $CLANG_TIDY_VERSION required"
+            ;;
+    esac
+else
+    die "clang-tidy 10.0 required"
+fi
+
+# Search for clang-apply-replacements-10
+if command -v clang-apply-replacements-10 >/dev/null; then
+    clang_apply_replacements=$(command -v clang-apply-replacements-10)
+elif command -v clang-apply-replacements >/dev/null; then
+    clang_apply_replacements=$(command -v clang-apply-replacements)
+    case "$($clang_apply_replacements --version)" in
+        "$CLANG_APPLY_REPLACEMENTS_VERSION"*) ;;
+
+        *)
+            die "$($clang_apply_replacements --version); $CLANG_APPLY_REPLACEMENTS_VERSION required"
+            ;;
+    esac
+else
+    die "clang-apply-replacements 10.0 required"
+fi
+
+# Search for run-clang-tidy-10.py
+if command -v run-clang-tidy-10.py >/dev/null; then
+    run_clang_tidy=$(command -v run-clang-tidy-10.py)
+elif command -v run-clang-tidy-10 >/dev/null; then
+    run_clang_tidy=$(command -v run-clang-tidy-10)
+elif command -v run-clang-tidy.py >/dev/null; then
+    run_clang_tidy=$(command -v run-clang-tidy.py)
+elif command -v run-clang-tidy >/dev/null; then
+    run_clang_tidy=$(command -v run-clang-tidy)
+else
+    die "run-clang-tidy.py 10.0 required"
+fi
+
+$run_clang_tidy -clang-tidy-binary "$clang_tidy" -clang-apply-replacements-binary "$clang_apply_replacements" "$@" || die
+
+exit 0

--- a/script/make-pretty
+++ b/script/make-pretty
@@ -150,7 +150,7 @@ do_clang_tidy_fix()
     (mkdir -p ./build/cmake-tidy \
         && cd ./build/cmake-tidy \
         && THREAD_VERSION=1.2 cmake "${OT_CLANG_TIDY_BUILD_OPTS[@]}" ../.. \
-        && run-clang-tidy.py -header-filter='.*' -checks="${OT_CLANG_TIDY_CHECKS}" -j"$OT_BUILD_JOBS" "${OT_CLANG_TIDY_FIX_DIRS[@]}" -fix)
+        && ../../script/clang-tidy -header-filter='.*' -checks="${OT_CLANG_TIDY_CHECKS}" -j"$OT_BUILD_JOBS" "${OT_CLANG_TIDY_FIX_DIRS[@]}" -fix)
 }
 
 do_clang_tidy_check()
@@ -163,7 +163,7 @@ do_clang_tidy_check()
         mkdir -p ./build/cmake-tidy \
             && cd ./build/cmake-tidy \
             && THREAD_VERSION=1.2 cmake "${OT_CLANG_TIDY_BUILD_OPTS[@]}" ../.. \
-            && run-clang-tidy.py -header-filter='.*' -checks="${OT_CLANG_TIDY_CHECKS}" -j"$OT_BUILD_JOBS" "${OT_CLANG_TIDY_FIX_DIRS[@]}" \
+            && ../../script/clang-tidy -header-filter='.*' -checks="${OT_CLANG_TIDY_CHECKS}" -j"$OT_BUILD_JOBS" "${OT_CLANG_TIDY_FIX_DIRS[@]}" \
             | grep -v -E "third_party" >output.txt
         if grep -q "warning: \|error: " output.txt; then
             echo "You must pass the clang tidy checks before submitting a pull request"


### PR DESCRIPTION
This commit introduces misc clang-tidy enhancements:
- Avoid creating symlinks in `/usr/bin` directory
- Search for clang-tidy-10 executables
- Fix potential bootstrap fail: permission denied in /opt directory