### PR TITLE
[nrf528xx] fix SPI issue

### DIFF
--- a/examples/platforms/nrf528xx/src/transport/spi-slave.c
+++ b/examples/platforms/nrf528xx/src/transport/spi-slave.c
@@ -78,7 +78,8 @@ static void spisEventHandler(nrfx_spis_evt_t const *aEvent, void *aContext)
         nrf_gpio_pin_set(SPIS_PIN_HOST_IRQ);
 
         // Execute application callback.
-        if (sCompleteCallback(sContext, sOutputBuf, sOutputBufLen, sInputBuf, sInputBufLen, aEvent->rx_amount))
+        if (sCompleteCallback(sContext, aEvent->tx_buffer, aEvent->tx_buffer_size, aEvent->rx_buffer,
+                              aEvent->rx_buffer_size, aEvent->rx_amount))
         {
             // Further processing is required.
             sFurtherProcessingFlag = true;
@@ -196,7 +197,14 @@ otError otPlatSpiSlavePrepareTransaction(uint8_t *aOutputBuf,
     sRequestTransactionFlag = aRequestTransactionFlag;
 
     error = nrfx_spis_buffers_set(&sSpiSlaveInstance, sOutputBuf, sOutputBufLen, sInputBuf, sInputBufLen);
-    assert(error == NRFX_SUCCESS);
+    if (error == NRFX_ERROR_INVALID_STATE)
+    {
+        result = OT_ERROR_BUSY;
+    }
+    else
+    {
+        assert(error == NRFX_SUCCESS);
+    }
 
 exit:
     return result;

--- a/third_party/NordicSemiconductor/nrfx/drivers/include/nrfx_spis.h
+++ b/third_party/NordicSemiconductor/nrfx/drivers/include/nrfx_spis.h
@@ -102,9 +102,13 @@ typedef enum
 /** @brief SPI slave driver event structure. */
 typedef struct
 {
-    nrfx_spis_evt_type_t evt_type;  //!< Type of the event.
-    size_t               rx_amount; //!< Number of bytes received in the last transaction. This parameter is only valid for @ref NRFX_SPIS_XFER_DONE events.
-    size_t               tx_amount; //!< Number of bytes transmitted in the last transaction. This parameter is only valid for @ref NRFX_SPIS_XFER_DONE events.
+    nrfx_spis_evt_type_t evt_type;       //!< Type of the event.
+    uint8_t *            tx_buffer;      //!< SPI slave TX buffer.
+    uint8_t *            rx_buffer;      //!< SPI slave RX buffer.
+    size_t               tx_buffer_size; //!< SPI slave TX buffer size in bytes.
+    size_t               rx_buffer_size; //!< SPI slave RX buffer size in bytes.
+    size_t               rx_amount;      //!< Number of bytes received in the last transaction. This parameter is only valid for @ref NRFX_SPIS_XFER_DONE events.
+    size_t               tx_amount;      //!< Number of bytes transmitted in the last transaction. This parameter is only valid for @ref NRFX_SPIS_XFER_DONE events.
 } nrfx_spis_evt_t;
 
 /** @brief The default configuration of the SPI slave instance. */

--- a/third_party/NordicSemiconductor/nrfx/drivers/src/nrfx_spis.c
+++ b/third_party/NordicSemiconductor/nrfx/drivers/src/nrfx_spis.c
@@ -335,6 +335,8 @@ static void spis_state_entry_action_execute(NRF_SPIS_Type * p_spis,
 
         case SPIS_XFER_COMPLETED:
             event.evt_type  = NRFX_SPIS_XFER_DONE;
+            nrf_spis_tx_buffer_get(p_spis, &event.tx_buffer, &event.tx_buffer_size);
+            nrf_spis_rx_buffer_get(p_spis, &event.rx_buffer, &event.rx_buffer_size);
             event.rx_amount = nrf_spis_rx_amount_get(p_spis);
             event.tx_amount = nrf_spis_tx_amount_get(p_spis);
             NRFX_LOG_INFO("Transfer rx_len:%d.", event.rx_amount);
@@ -428,8 +430,41 @@ static void spis_irq_handler(NRF_SPIS_Type * p_spis, spis_cb_t * p_cb)
 {
     // @note: as multiple events can be pending for processing, the correct event processing order
     // is as follows:
-    // - SPI semaphore acquired event.
     // - SPI transaction complete event.
+    // - SPI semaphore acquired event.
+
+    // Check for SPI transaction complete event.
+    if (nrf_spis_event_check(p_spis, NRF_SPIS_EVENT_END))
+    {
+        nrfx_spis_evt_t event;
+        nrf_spis_event_clear(p_spis, NRF_SPIS_EVENT_END);
+        NRFX_LOG_DEBUG("SPIS: Event: %s.", EVT_TO_STR(NRF_SPIS_EVENT_END));
+
+        switch (p_cb->spi_state)
+        {
+            case SPIS_BUFFER_RESOURCE_CONFIGURED:
+                spis_state_change(p_spis, p_cb, SPIS_XFER_COMPLETED);
+                break;
+
+            case SPIS_BUFFER_RESOURCE_REQUESTED:
+                event.evt_type  = NRFX_SPIS_XFER_DONE;
+                nrf_spis_tx_buffer_get(p_spis, &event.tx_buffer, &event.tx_buffer_size);
+                nrf_spis_rx_buffer_get(p_spis, &event.rx_buffer, &event.rx_buffer_size);
+                event.rx_amount = nrf_spis_rx_amount_get(p_spis);
+                event.tx_amount = nrf_spis_tx_amount_get(p_spis);
+                NRFX_LOG_INFO("Transfer rx_len:%d.", event.rx_amount);
+                NRFX_LOG_DEBUG("Rx data:");
+                NRFX_LOG_HEXDUMP_DEBUG((uint8_t const *)p_cb->rx_buffer,
+                                       event.rx_amount * sizeof(p_cb->rx_buffer[0]));
+                NRFX_ASSERT(p_cb->handler != NULL);
+                p_cb->handler(&event, p_cb->p_context);
+                break;
+
+            default:
+                // No implementation required.
+                break;
+        }
+    }
 
     // Check for SPI semaphore acquired event.
     if (nrf_spis_event_check(p_spis, NRF_SPIS_EVENT_ACQUIRED))
@@ -446,24 +481,6 @@ static void spis_irq_handler(NRF_SPIS_Type * p_spis, spis_cb_t * p_cb)
                 nrf_spis_task_trigger(p_spis, NRF_SPIS_TASK_RELEASE);
 
                 spis_state_change(p_spis, p_cb, SPIS_BUFFER_RESOURCE_CONFIGURED);
-                break;
-
-            default:
-                // No implementation required.
-                break;
-        }
-    }
-
-    // Check for SPI transaction complete event.
-    if (nrf_spis_event_check(p_spis, NRF_SPIS_EVENT_END))
-    {
-        nrf_spis_event_clear(p_spis, NRF_SPIS_EVENT_END);
-        NRFX_LOG_DEBUG("SPIS: Event: %s.", EVT_TO_STR(NRF_SPIS_EVENT_END));
-
-        switch (p_cb->spi_state)
-        {
-            case SPIS_BUFFER_RESOURCE_CONFIGURED:
-                spis_state_change(p_spis, p_cb, SPIS_XFER_COMPLETED);
                 break;
 
             default:

--- a/third_party/NordicSemiconductor/nrfx/drivers/src/nrfx_spis.c
+++ b/third_party/NordicSemiconductor/nrfx/drivers/src/nrfx_spis.c
@@ -335,8 +335,8 @@ static void spis_state_entry_action_execute(NRF_SPIS_Type * p_spis,
 
         case SPIS_XFER_COMPLETED:
             event.evt_type  = NRFX_SPIS_XFER_DONE;
-            nrf_spis_tx_buffer_get(p_spis, &event.tx_buffer, &event.tx_buffer_size);
-            nrf_spis_rx_buffer_get(p_spis, &event.rx_buffer, &event.rx_buffer_size);
+            event.tx_buffer = nrf_spis_tx_buffer_get(p_spis, &event.tx_buffer_size);
+            event.rx_buffer = nrf_spis_rx_buffer_get(p_spis, &event.rx_buffer_size);
             event.rx_amount = nrf_spis_rx_amount_get(p_spis);
             event.tx_amount = nrf_spis_tx_amount_get(p_spis);
             NRFX_LOG_INFO("Transfer rx_len:%d.", event.rx_amount);
@@ -448,14 +448,14 @@ static void spis_irq_handler(NRF_SPIS_Type * p_spis, spis_cb_t * p_cb)
 
             case SPIS_BUFFER_RESOURCE_REQUESTED:
                 event.evt_type  = NRFX_SPIS_XFER_DONE;
-                nrf_spis_tx_buffer_get(p_spis, &event.tx_buffer, &event.tx_buffer_size);
-                nrf_spis_rx_buffer_get(p_spis, &event.rx_buffer, &event.rx_buffer_size);
+                event.tx_buffer = nrf_spis_tx_buffer_get(p_spis, &event.tx_buffer_size);
+                event.rx_buffer = nrf_spis_rx_buffer_get(p_spis, &event.rx_buffer_size);
                 event.rx_amount = nrf_spis_rx_amount_get(p_spis);
                 event.tx_amount = nrf_spis_tx_amount_get(p_spis);
                 NRFX_LOG_INFO("Transfer rx_len:%d.", event.rx_amount);
                 NRFX_LOG_DEBUG("Rx data:");
-                NRFX_LOG_HEXDUMP_DEBUG((uint8_t const *)p_cb->rx_buffer,
-                                       event.rx_amount * sizeof(p_cb->rx_buffer[0]));
+                NRFX_LOG_HEXDUMP_DEBUG((uint8_t const *)event.rx_buffer,
+                                       event.rx_amount * sizeof(event.rx_buffer[0]));
                 NRFX_ASSERT(p_cb->handler != NULL);
                 p_cb->handler(&event, p_cb->p_context);
                 break;

--- a/third_party/NordicSemiconductor/nrfx/drivers/src/nrfx_spis.c
+++ b/third_party/NordicSemiconductor/nrfx/drivers/src/nrfx_spis.c
@@ -341,8 +341,8 @@ static void spis_state_entry_action_execute(NRF_SPIS_Type * p_spis,
             event.tx_amount = nrf_spis_tx_amount_get(p_spis);
             NRFX_LOG_INFO("Transfer rx_len:%d.", event.rx_amount);
             NRFX_LOG_DEBUG("Rx data:");
-            NRFX_LOG_HEXDUMP_DEBUG((uint8_t const *)p_cb->rx_buffer,
-                                   event.rx_amount * sizeof(p_cb->rx_buffer[0]));
+            NRFX_LOG_HEXDUMP_DEBUG((uint8_t const *)event.rx_buffer,
+                                   event.rx_amount * sizeof(event.rx_buffer[0]));
             NRFX_ASSERT(p_cb->handler != NULL);
             p_cb->handler(&event, p_cb->p_context);
             break;

--- a/third_party/NordicSemiconductor/nrfx/hal/nrf_spis.h
+++ b/third_party/NordicSemiconductor/nrfx/hal/nrf_spis.h
@@ -572,7 +572,7 @@ __STATIC_INLINE uint8_t * nrf_spis_tx_buffer_get(NRF_SPIS_Type * p_reg,
 {
 #if defined (NRF51)
     *p_length = p_reg->MAXTX;
-    return (uint8_t *)p_reg->TXDPTR
+    return (uint8_t *)p_reg->TXDPTR;
 #else
     *p_length = p_reg->TXD.MAXCNT;
     return (uint8_t *)p_reg->TXD.PTR;

--- a/third_party/NordicSemiconductor/nrfx/hal/nrf_spis.h
+++ b/third_party/NordicSemiconductor/nrfx/hal/nrf_spis.h
@@ -334,24 +334,24 @@ __STATIC_INLINE void nrf_spis_rx_buffer_set(NRF_SPIS_Type * p_reg,
 /**
  * @brief Function for getting the transmit buffer.
  *
- * @param[in]  p_reg    Pointer to the structure of registers of the peripheral.
- * @param[out] length   Pointer to the maximum number of data bytes in transmit buffer.
+ * @param[in]  p_reg      Pointer to the structure of registers of the peripheral.
+ * @param[out] p_length   Pointer to the maximum number of data bytes in transmit buffer.
  *
  * @returns The transmit buffer pointer.
  */
 __STATIC_INLINE uint8_t * nrf_spis_tx_buffer_get(NRF_SPIS_Type * p_reg,
-                                            size_t *             length);
+                                            size_t *             p_length);
 
 /**
  * @brief Function for getting the receive buffer.
  *
- * @param[in]  p_reg    Pointer to the structure of registers of the peripheral.
- * @param[out] length   Pointer to the maximum number of data bytes in receive buffer.
+ * @param[in]  p_reg      Pointer to the structure of registers of the peripheral.
+ * @param[out] p_length   Pointer to the maximum number of data bytes in receive buffer.
  *
  * @returns The receive buffer pointer.
  */
 __STATIC_INLINE uint8_t * nrf_spis_rx_buffer_get(NRF_SPIS_Type * p_reg,
-                                                 size_t *        length);
+                                                 size_t *        p_length);
 
 /**
  * @brief Function for getting the number of bytes transmitted
@@ -568,25 +568,25 @@ __STATIC_INLINE void nrf_spis_rx_buffer_set(NRF_SPIS_Type * p_reg,
 }
 
 __STATIC_INLINE uint8_t * nrf_spis_tx_buffer_get(NRF_SPIS_Type * p_reg,
-                                                 size_t *        length)
+                                                 size_t *        p_length)
 {
 #if defined (NRF51)
-    *length   = p_reg->MAXTX;
+    *p_length = p_reg->MAXTX;
     return (uint8_t *)p_reg->TXDPTR
 #else
-    *length   = p_reg->TXD.MAXCNT;
+    *p_length = p_reg->TXD.MAXCNT;
     return (uint8_t *)p_reg->TXD.PTR;
 #endif
 }
 
 __STATIC_INLINE uint8_t * nrf_spis_rx_buffer_get(NRF_SPIS_Type * p_reg,
-                                                 size_t *        length)
+                                                 size_t *        p_length)
 {
 #if defined (NRF51)
-    *length   = p_reg->MAXRX;
+    *p_length = p_reg->MAXRX;
     return (uint8_t *)p_reg->RXDPTR;
 #else
-    *length   = p_reg->RXD.MAXCNT;
+    *p_length = p_reg->RXD.MAXCNT;
     return (uint8_t *)p_reg->RXD.PTR;
 #endif
 }

--- a/third_party/NordicSemiconductor/nrfx/hal/nrf_spis.h
+++ b/third_party/NordicSemiconductor/nrfx/hal/nrf_spis.h
@@ -332,6 +332,28 @@ __STATIC_INLINE void nrf_spis_rx_buffer_set(NRF_SPIS_Type * p_reg,
                                             size_t          length);
 
 /**
+ * @brief Function for getting the transmit buffer.
+ *
+ * @param[in]  p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[out] p_buffer Pointer to the transmit buffer pointer.
+ * @param[out] length   Pointer to the maximum number of data bytes in transmit buffer.
+ */
+__STATIC_INLINE void nrf_spis_tx_buffer_get(NRF_SPIS_Type * p_reg,
+                                            uint8_t      ** p_buffer,
+                                            size_t *        length);
+
+/**
+ * @brief Function for getting the receive buffer.
+ *
+ * @param[in]  p_reg    Pointer to the structure of registers of the peripheral.
+ * @param[out] p_buffer Pointer to the receive buffer pointer.
+ * @param[out] length   Pointer to the maximum number of data bytes in receive buffer.
+ */
+__STATIC_INLINE void nrf_spis_rx_buffer_get(NRF_SPIS_Type * p_reg,
+                                            uint8_t **      p_buffer,
+                                            size_t *        length);
+
+/**
  * @brief Function for getting the number of bytes transmitted
  *        in the last granted transaction.
  *
@@ -542,6 +564,32 @@ __STATIC_INLINE void nrf_spis_rx_buffer_set(NRF_SPIS_Type * p_reg,
 #else
     p_reg->RXD.PTR    = (uint32_t)p_buffer;
     p_reg->RXD.MAXCNT = length;
+#endif
+}
+
+__STATIC_INLINE void nrf_spis_tx_buffer_get(NRF_SPIS_Type * p_reg,
+                                            uint8_t      ** p_buffer,
+                                            size_t *        length)
+{
+#if defined (NRF51)
+    *p_buffer = (uint8_t *)p_reg->TXDPTR
+    *length   = p_reg->MAXTX;
+#else
+    *p_buffer = (uint8_t *)p_reg->TXD.PTR;
+    *length   = p_reg->TXD.MAXCNT;
+#endif
+}
+
+__STATIC_INLINE void nrf_spis_rx_buffer_get(NRF_SPIS_Type * p_reg,
+                                            uint8_t **      p_buffer,
+                                            size_t *        length)
+{
+#if defined (NRF51)
+    *p_buffer = (uint8_t *)p_reg->RXDPTR;
+    *length   = p_reg->MAXRX;
+#else
+    *p_buffer = (uint8_t *)p_reg->RXD.PTR;
+    *length   = p_reg->RXD.MAXCNT;
 #endif
 }
 

--- a/third_party/NordicSemiconductor/nrfx/hal/nrf_spis.h
+++ b/third_party/NordicSemiconductor/nrfx/hal/nrf_spis.h
@@ -340,7 +340,7 @@ __STATIC_INLINE void nrf_spis_rx_buffer_set(NRF_SPIS_Type * p_reg,
  * @returns The transmit buffer pointer.
  */
 __STATIC_INLINE uint8_t * nrf_spis_tx_buffer_get(NRF_SPIS_Type * p_reg,
-                                            size_t *             p_length);
+                                                 size_t *        p_length);
 
 /**
  * @brief Function for getting the receive buffer.

--- a/third_party/NordicSemiconductor/nrfx/hal/nrf_spis.h
+++ b/third_party/NordicSemiconductor/nrfx/hal/nrf_spis.h
@@ -335,23 +335,23 @@ __STATIC_INLINE void nrf_spis_rx_buffer_set(NRF_SPIS_Type * p_reg,
  * @brief Function for getting the transmit buffer.
  *
  * @param[in]  p_reg    Pointer to the structure of registers of the peripheral.
- * @param[out] p_buffer Pointer to the transmit buffer pointer.
  * @param[out] length   Pointer to the maximum number of data bytes in transmit buffer.
+ *
+ * @returns The transmit buffer pointer.
  */
-__STATIC_INLINE void nrf_spis_tx_buffer_get(NRF_SPIS_Type * p_reg,
-                                            uint8_t      ** p_buffer,
-                                            size_t *        length);
+__STATIC_INLINE uint8_t * nrf_spis_tx_buffer_get(NRF_SPIS_Type * p_reg,
+                                            size_t *             length);
 
 /**
  * @brief Function for getting the receive buffer.
  *
  * @param[in]  p_reg    Pointer to the structure of registers of the peripheral.
- * @param[out] p_buffer Pointer to the receive buffer pointer.
  * @param[out] length   Pointer to the maximum number of data bytes in receive buffer.
+ *
+ * @returns The receive buffer pointer.
  */
-__STATIC_INLINE void nrf_spis_rx_buffer_get(NRF_SPIS_Type * p_reg,
-                                            uint8_t **      p_buffer,
-                                            size_t *        length);
+__STATIC_INLINE uint8_t * nrf_spis_rx_buffer_get(NRF_SPIS_Type * p_reg,
+                                                 size_t *        length);
 
 /**
  * @brief Function for getting the number of bytes transmitted
@@ -567,29 +567,27 @@ __STATIC_INLINE void nrf_spis_rx_buffer_set(NRF_SPIS_Type * p_reg,
 #endif
 }
 
-__STATIC_INLINE void nrf_spis_tx_buffer_get(NRF_SPIS_Type * p_reg,
-                                            uint8_t      ** p_buffer,
-                                            size_t *        length)
+__STATIC_INLINE uint8_t * nrf_spis_tx_buffer_get(NRF_SPIS_Type * p_reg,
+                                                 size_t *        length)
 {
 #if defined (NRF51)
-    *p_buffer = (uint8_t *)p_reg->TXDPTR
     *length   = p_reg->MAXTX;
+    return (uint8_t *)p_reg->TXDPTR
 #else
-    *p_buffer = (uint8_t *)p_reg->TXD.PTR;
     *length   = p_reg->TXD.MAXCNT;
+    return (uint8_t *)p_reg->TXD.PTR;
 #endif
 }
 
-__STATIC_INLINE void nrf_spis_rx_buffer_get(NRF_SPIS_Type * p_reg,
-                                            uint8_t **      p_buffer,
-                                            size_t *        length)
+__STATIC_INLINE uint8_t * nrf_spis_rx_buffer_get(NRF_SPIS_Type * p_reg,
+                                                 size_t *        length)
 {
 #if defined (NRF51)
-    *p_buffer = (uint8_t *)p_reg->RXDPTR;
     *length   = p_reg->MAXRX;
+    return (uint8_t *)p_reg->RXDPTR;
 #else
-    *p_buffer = (uint8_t *)p_reg->RXD.PTR;
     *length   = p_reg->RXD.MAXCNT;
+    return (uint8_t *)p_reg->RXD.PTR;
 #endif
 }
 


### PR DESCRIPTION
When the SPI is transmitting a frame, the ncp_spi sets the SPI to
transmit the second frame.  After the current frame is transmitted,
the SPI generates the END and ACQUIRED event at the same time. The
SPI driver processes the ACQUIRED event first and then the END event.
The ACQUIRED event notifies the up layer to set the SPI GPIO interrupt
pin. The END event notifies the up layer that the transmission has
completed. Because the SPI tx/rx buffer variables in the `spi_slave.c`
has been updated to the second frame buffer. The ncp_spi thinks that
the second frame has been transmitted in the END event. Then the second
frame is lost.

This CL processes the END event first then ACQUIRED event. To avoid
the cached frame buffer variables are passed to the ncp_spi, the SPI
driver gets the frame buffers directly from the SPI buffer registers.