### PR TITLE
[build] fix warning of clearing non-trivial type

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -148,7 +148,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        gcc_ver: [5, 6, 7, 8, 9]
+        gcc_ver: [5, 6, 7, 8, 9, 10]
     env:
       CC: gcc-${{ matrix.gcc_ver }}
       CXX: g++-${{ matrix.gcc_ver }}

--- a/script/cmake-build
+++ b/script/cmake-build
@@ -109,7 +109,7 @@ build()
     mkdir -p "${builddir}"
     cd "${builddir}"
 
-    cmake -GNinja "$@" "${OT_SRCDIR}"
+    cmake -GNinja -DOT_COMPILE_WARNING_AS_ERROR=ON "$@" "${OT_SRCDIR}"
 
     if [[ -n ${OT_CMAKE_NINJA_TARGET[*]} ]]; then
         ninja "${OT_CMAKE_NINJA_TARGET[@]}"

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -75,7 +75,7 @@ Commissioner::Commissioner(Instance &aInstance)
     , mJoinerCallback(nullptr)
     , mCallbackContext(nullptr)
 {
-    memset(mJoiners, 0, sizeof(mJoiners));
+    memset(reinterpret_cast<void *>(mJoiners), 0, sizeof(mJoiners));
 
     mCommissionerAloc.Clear();
     mCommissionerAloc.mPrefixLength       = 64;

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -69,7 +69,7 @@ void Leader::Reset(void)
 {
     LeaderBase::Reset();
 
-    memset(mContextLastUsed, 0, sizeof(mContextLastUsed));
+    memset(reinterpret_cast<void *>(mContextLastUsed), 0, sizeof(mContextLastUsed));
     mContextUsed         = 0;
     mContextIdReuseDelay = kContextIdReuseDelay;
 }


### PR DESCRIPTION
There is a warning with gcc/g++ 10.2.0 when clearing an object of non-trivial type with `memset`:

(build command: `cmake -GNinja -DOT_COMMISSIONER=ON .. && ninja`)

```shell
OPENTHREAD_CONFIG_THREAD_VERSION=OT_THREAD_VERSION_1_1
[65/132] Building CXX object src/core/CMakeFiles/openthread-ftd.dir/meshcop/commissioner.cpp.o
../src/core/meshcop/commissioner.cpp: In constructor ‘ot::MeshCoP::Commissioner::Commissioner(ot::Instance&)’:
../src/core/meshcop/commissioner.cpp:78:41: warning: ‘void* memset(void*, int, size_t)’ clearing an object of non-trivial type ‘struct ot::MeshCoP::Commissioner::Joiner’; use assignment or value-initialization instead [-Wclass-memaccess]
   78 |     memset(mJoiners, 0, sizeof(mJoiners));
      |                                         ^
In file included from ../src/core/meshcop/commissioner.cpp:34:
../src/core/meshcop/commissioner.hpp:347:12: note: ‘struct ot::MeshCoP::Commissioner::Joiner’ declared here
  347 |     struct Joiner
      |            ^~~~~~
[132/132] Linking CXX static library src/ncp/libopenthread-ncp-ftd.a
```

This PR fixes this issue:
1. remove the problematic `memset` usages;
2. turn on `OT_COMPILE_WARNING_AS_ERROR` for all CI builds;