### PR TITLE
[dataset-manager] simplify 'SendSetRequest()' 

### DIFF
--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -334,15 +334,16 @@ private:
                                    otError              aError);
     void        HandleCoapResponse(void);
 
-    bool IsActiveDataset(void) const { return GetType() == Dataset::kActive; }
-    bool IsPendingDataset(void) const { return GetType() == Dataset::kPending; }
-    void SignalDatasetChange(void) const;
-    void HandleDatasetUpdated(void);
-    void SendSet(void);
-    void SendGetResponse(const Coap::Message &   aRequest,
-                         const Ip6::MessageInfo &aMessageInfo,
-                         uint8_t *               aTlvs,
-                         uint8_t                 aLength) const;
+    bool    IsActiveDataset(void) const { return GetType() == Dataset::kActive; }
+    bool    IsPendingDataset(void) const { return GetType() == Dataset::kPending; }
+    void    SignalDatasetChange(void) const;
+    void    HandleDatasetUpdated(void);
+    otError AppendDatasetToMessage(const otOperationalDataset &aDataset, Message &aMessage) const;
+    void    SendSet(void);
+    void    SendGetResponse(const Coap::Message &   aRequest,
+                            const Ip6::MessageInfo &aMessageInfo,
+                            uint8_t *               aTlvs,
+                            uint8_t                 aLength) const;
 
 #if OPENTHREAD_FTD
     void SendSetResponse(const Coap::Message &aRequest, const Ip6::MessageInfo &aMessageInfo, StateTlv::State aState);


### PR DESCRIPTION
This commit simplifies `DatasetManager::SendSetRequest()` by adding a
method to `AppendDatasetToMessage()` which uses `Dataset::SetFrom()`
method to convert a given `otOperationalDataset` to a TLV sequence
before appending it to a given message. The conversion is performed in
a new method to ensure that the stack/temporary variable `Dataset` is
released before the call to process/send the prepared message.