### PR TITLE
[dataset] add new helper 'SetTlv()' with a template 'ValueType'

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -220,7 +220,7 @@ otError Dataset::SetFrom(const otOperationalDataset &aDataset)
 
     if (aDataset.mComponents.mIsDelayPresent)
     {
-        IgnoreError(SetUint32Tlv(Tlv::kDelayTimer, aDataset.mDelay));
+        IgnoreError(SetTlv(Tlv::kDelayTimer, aDataset.mDelay));
     }
 
     if (aDataset.mComponents.mIsChannelPresent)
@@ -241,17 +241,17 @@ otError Dataset::SetFrom(const otOperationalDataset &aDataset)
 
     if (aDataset.mComponents.mIsExtendedPanIdPresent)
     {
-        IgnoreError(SetTlv(Tlv::kExtendedPanId, &aDataset.mExtendedPanId, sizeof(Mac::ExtendedPanId)));
+        IgnoreError(SetTlv(Tlv::kExtendedPanId, aDataset.mExtendedPanId));
     }
 
     if (aDataset.mComponents.mIsMeshLocalPrefixPresent)
     {
-        IgnoreError(SetTlv(Tlv::kMeshLocalPrefix, &aDataset.mMeshLocalPrefix, sizeof(Mle::MeshLocalPrefix)));
+        IgnoreError(SetTlv(Tlv::kMeshLocalPrefix, aDataset.mMeshLocalPrefix));
     }
 
     if (aDataset.mComponents.mIsMasterKeyPresent)
     {
-        IgnoreError(SetTlv(Tlv::kNetworkMasterKey, &aDataset.mMasterKey, sizeof(MasterKey)));
+        IgnoreError(SetTlv(Tlv::kNetworkMasterKey, aDataset.mMasterKey));
     }
 
     if (aDataset.mComponents.mIsNetworkNamePresent)
@@ -263,12 +263,12 @@ otError Dataset::SetFrom(const otOperationalDataset &aDataset)
 
     if (aDataset.mComponents.mIsPanIdPresent)
     {
-        IgnoreError(SetUint16Tlv(Tlv::kPanId, aDataset.mPanId));
+        IgnoreError(SetTlv(Tlv::kPanId, aDataset.mPanId));
     }
 
     if (aDataset.mComponents.mIsPskcPresent)
     {
-        IgnoreError(SetTlv(Tlv::kPskc, &aDataset.mPskc, sizeof(Pskc)));
+        IgnoreError(SetTlv(Tlv::kPskc, aDataset.mPskc));
     }
 
     if (aDataset.mComponents.mIsSecurityPolicyPresent)
@@ -308,8 +308,7 @@ exit:
 
 void Dataset::SetTimestamp(const Timestamp &aTimestamp)
 {
-    IgnoreError(
-        SetTlv((mType == kActive) ? Tlv::kActiveTimestamp : Tlv::kPendingTimestamp, &aTimestamp, sizeof(Timestamp)));
+    IgnoreError(SetTlv((mType == kActive) ? Tlv::kActiveTimestamp : Tlv::kPendingTimestamp, aTimestamp));
 }
 
 otError Dataset::SetTlv(Tlv::Type aType, const void *aValue, uint8_t aLength)
@@ -348,20 +347,6 @@ exit:
 otError Dataset::SetTlv(const Tlv &aTlv)
 {
     return SetTlv(aTlv.GetType(), aTlv.GetValue(), aTlv.GetLength());
-}
-
-otError Dataset::SetUint16Tlv(Tlv::Type aType, uint16_t aValue)
-{
-    uint16_t value16 = HostSwap16(aValue);
-
-    return SetTlv(aType, &value16, sizeof(uint16_t));
-}
-
-otError Dataset::SetUint32Tlv(Tlv::Type aType, uint32_t aValue)
-{
-    uint32_t value32 = HostSwap32(aValue);
-
-    return SetTlv(aType, &value32, sizeof(uint32_t));
 }
 
 otError Dataset::Set(const Message &aMessage, uint16_t aOffset, uint8_t aLength)

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -234,28 +234,21 @@ public:
     otError SetTlv(Tlv::Type aType, const void *aValue, uint8_t aLength);
 
     /**
-     * This method sets a TLV with a given TLV Type and a `uint16_t` Value.
+     * This template method sets a TLV with a given TLV Type and Value.
+     *
+     * @tparam ValueType    The type of TLV's Value.
      *
      * @param[in] aType     The TLV Type.
-     * @param[in] aValue    The TLV value (as `uint16_t`).
+     * @param[in] aValue    The TLV Value (of type `ValueType`).
      *
      * @retval OT_ERROR_NONE     Successfully set the TLV.
      * @retval OT_ERROR_NO_BUFS  Could not set the TLV due to insufficient buffer space.
      *
      */
-    otError SetUint16Tlv(Tlv::Type aType, uint16_t aValue);
-
-    /**
-     * This method sets a TLV with a given TLV Type and a `uint32_t` Value.
-     *
-     * @param[in] aType     The TLV Type.
-     * @param[in] aValue    The TLV value (as `uint32_t`).
-     *
-     * @retval OT_ERROR_NONE     Successfully set the TLV.
-     * @retval OT_ERROR_NO_BUFS  Could not set the TLV due to insufficient buffer space.
-     *
-     */
-    otError SetUint32Tlv(Tlv::Type aType, uint32_t aValue);
+    template <typename ValueType> otError SetTlv(Tlv::Type aType, const ValueType &aValue)
+    {
+        return SetTlv(aType, &aValue, sizeof(ValueType));
+    }
 
     /**
      * This method sets the Dataset using TLVs stored in a message buffer.
@@ -391,6 +384,40 @@ private:
     uint16_t  mLength;         ///< The number of valid bytes in @var mTlvs
     Type      mType;           ///< Active or Pending
 };
+
+/**
+ * This is a template specialization of `SetTlv<ValueType>` with a `uint16_t` value type.
+ *
+ * @param[in] aType     The TLV Type.
+ * @param[in] aValue    The TLV value (as `uint16_t`).
+ *
+ * @retval OT_ERROR_NONE     Successfully set the TLV.
+ * @retval OT_ERROR_NO_BUFS  Could not set the TLV due to insufficient buffer space.
+ *
+ */
+template <> inline otError Dataset::SetTlv(Tlv::Type aType, const uint16_t &aValue)
+{
+    uint16_t value = Encoding::BigEndian::HostSwap16(aValue);
+
+    return SetTlv(aType, &value, sizeof(uint16_t));
+}
+
+/**
+ * This is a template specialization of `SetTlv<ValueType>` with a `uint32_t` value type
+ *
+ * @param[in] aType     The TLV Type.
+ * @param[in] aValue    The TLV value (as `uint32_t`).
+ *
+ * @retval OT_ERROR_NONE     Successfully set the TLV.
+ * @retval OT_ERROR_NO_BUFS  Could not set the TLV due to insufficient buffer space.
+ *
+ */
+template <> inline otError Dataset::SetTlv(Tlv::Type aType, const uint32_t &aValue)
+{
+    uint32_t value = Encoding::BigEndian::HostSwap32(aValue);
+
+    return SetTlv(aType, &value, sizeof(uint32_t));
+}
 
 } // namespace MeshCoP
 } // namespace ot

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -392,19 +392,17 @@ otError ActiveDataset::GenerateLocal(void)
 
     if (dataset.GetTlv<ExtendedPanIdTlv>() == nullptr)
     {
-        IgnoreError(
-            dataset.SetTlv(Tlv::kExtendedPanId, &Get<Mac::Mac>().GetExtendedPanId(), sizeof(Mac::ExtendedPanId)));
+        IgnoreError(dataset.SetTlv(Tlv::kExtendedPanId, Get<Mac::Mac>().GetExtendedPanId()));
     }
 
     if (dataset.GetTlv<MeshLocalPrefixTlv>() == nullptr)
     {
-        IgnoreError(dataset.SetTlv(Tlv::kMeshLocalPrefix, &Get<Mle::MleRouter>().GetMeshLocalPrefix(),
-                                   sizeof(Mle::MeshLocalPrefix)));
+        IgnoreError(dataset.SetTlv(Tlv::kMeshLocalPrefix, Get<Mle::MleRouter>().GetMeshLocalPrefix()));
     }
 
     if (dataset.GetTlv<NetworkMasterKeyTlv>() == nullptr)
     {
-        IgnoreError(dataset.SetTlv(Tlv::kNetworkMasterKey, &Get<KeyManager>().GetMasterKey(), sizeof(MasterKey)));
+        IgnoreError(dataset.SetTlv(Tlv::kNetworkMasterKey, Get<KeyManager>().GetMasterKey()));
     }
 
     if (dataset.GetTlv<NetworkNameTlv>() == nullptr)
@@ -416,14 +414,14 @@ otError ActiveDataset::GenerateLocal(void)
 
     if (dataset.GetTlv<PanIdTlv>() == nullptr)
     {
-        IgnoreError(dataset.SetUint16Tlv(Tlv::kPanId, Get<Mac::Mac>().GetPanId()));
+        IgnoreError(dataset.SetTlv(Tlv::kPanId, Get<Mac::Mac>().GetPanId()));
     }
 
     if (dataset.GetTlv<PskcTlv>() == nullptr)
     {
         if (Get<KeyManager>().IsPskcSet())
         {
-            IgnoreError(dataset.SetTlv(Tlv::kPskc, &Get<KeyManager>().GetPskc(), sizeof(Pskc)));
+            IgnoreError(dataset.SetTlv(Tlv::kPskc, Get<KeyManager>().GetPskc()));
         }
         else
         {
@@ -431,7 +429,7 @@ otError ActiveDataset::GenerateLocal(void)
             Pskc pskc;
 
             SuccessOrExit(error = pskc.GenerateRandom());
-            IgnoreError(dataset.SetTlv(Tlv::kPskc, &pskc, sizeof(Pskc)));
+            IgnoreError(dataset.SetTlv(Tlv::kPskc, pskc));
         }
     }
 
@@ -522,7 +520,7 @@ void PendingDataset::ApplyActiveDataset(const Timestamp &aTimestamp, Coap::Messa
     }
 
     // add delay timer tlv
-    IgnoreError(dataset.SetUint32Tlv(Tlv::kDelayTimer, Get<Leader>().GetDelayTimerMinimal()));
+    IgnoreError(dataset.SetTlv(Tlv::kDelayTimer, Get<Leader>().GetDelayTimerMinimal()));
 
     // add pending timestamp tlv
     dataset.SetTimestamp(aTimestamp);


### PR DESCRIPTION
This commit also adds two specializations of the `SetTlv()` for
`uint16_t` and `uint32_t` value types where the given integral value
is `BigEndian::HostSwap()`-ed before written as the TLV value (these
specializations replace `SetUint16Tlv()` and `SetUint32Tlv()`).