### PR TITLE
[dataset] add 'Info' and 'Components' types

### DIFF
--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -44,17 +44,9 @@ using namespace ot;
 
 bool otDatasetIsCommissioned(otInstance *aInstance)
 {
-    otOperationalDataset dataset;
-    bool                 rval = false;
+    Instance &instance = *static_cast<Instance *>(aInstance);
 
-    SuccessOrExit(otDatasetGetActive(aInstance, &dataset));
-
-    rval = ((dataset.mComponents.mIsMasterKeyPresent) && (dataset.mComponents.mIsNetworkNamePresent) &&
-            (dataset.mComponents.mIsExtendedPanIdPresent) && (dataset.mComponents.mIsPanIdPresent) &&
-            (dataset.mComponents.mIsChannelPresent));
-
-exit:
-    return rval;
+    return instance.Get<MeshCoP::ActiveDataset>().IsCommissioned();
 }
 
 otError otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset)
@@ -63,7 +55,7 @@ otError otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset
 
     OT_ASSERT(aDataset != nullptr);
 
-    return instance.Get<MeshCoP::ActiveDataset>().Read(*aDataset);
+    return instance.Get<MeshCoP::ActiveDataset>().Read(*static_cast<MeshCoP::Dataset::Info *>(aDataset));
 }
 
 otError otDatasetGetActiveTlvs(otInstance *aInstance, otOperationalDatasetTlvs *aDataset)
@@ -81,7 +73,7 @@ otError otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aD
 
     OT_ASSERT(aDataset != nullptr);
 
-    return instance.Get<MeshCoP::ActiveDataset>().Save(*aDataset);
+    return instance.Get<MeshCoP::ActiveDataset>().Save(*static_cast<const MeshCoP::Dataset::Info *>(aDataset));
 }
 
 otError otDatasetSetActiveTlvs(otInstance *aInstance, const otOperationalDatasetTlvs *aDataset)
@@ -99,7 +91,7 @@ otError otDatasetGetPending(otInstance *aInstance, otOperationalDataset *aDatase
 
     OT_ASSERT(aDataset != nullptr);
 
-    return instance.Get<MeshCoP::PendingDataset>().Read(*aDataset);
+    return instance.Get<MeshCoP::PendingDataset>().Read(*static_cast<MeshCoP::Dataset::Info *>(aDataset));
 }
 
 otError otDatasetGetPendingTlvs(otInstance *aInstance, otOperationalDatasetTlvs *aDataset)
@@ -117,7 +109,7 @@ otError otDatasetSetPending(otInstance *aInstance, const otOperationalDataset *a
 
     OT_ASSERT(aDataset != nullptr);
 
-    return instance.Get<MeshCoP::PendingDataset>().Save(*aDataset);
+    return instance.Get<MeshCoP::PendingDataset>().Save(*static_cast<const MeshCoP::Dataset::Info *>(aDataset));
 }
 
 otError otDatasetSetPendingTlvs(otInstance *aInstance, const otOperationalDatasetTlvs *aDataset)
@@ -137,7 +129,8 @@ otError otDatasetSendMgmtActiveGet(otInstance *                          aInstan
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<MeshCoP::ActiveDataset>().SendGetRequest(*aDatasetComponents, aTlvTypes, aLength, aAddress);
+    return instance.Get<MeshCoP::ActiveDataset>().SendGetRequest(
+        *static_cast<const MeshCoP::Dataset::Components *>(aDatasetComponents), aTlvTypes, aLength, aAddress);
 }
 
 otError otDatasetSendMgmtActiveSet(otInstance *                aInstance,
@@ -147,7 +140,8 @@ otError otDatasetSendMgmtActiveSet(otInstance *                aInstance,
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<MeshCoP::ActiveDataset>().SendSetRequest(*aDataset, aTlvs, aLength);
+    return instance.Get<MeshCoP::ActiveDataset>().SendSetRequest(*static_cast<const MeshCoP::Dataset::Info *>(aDataset),
+                                                                 aTlvs, aLength);
 }
 
 otError otDatasetSendMgmtPendingGet(otInstance *                          aInstance,
@@ -158,7 +152,8 @@ otError otDatasetSendMgmtPendingGet(otInstance *                          aInsta
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<MeshCoP::PendingDataset>().SendGetRequest(*aDatasetComponents, aTlvTypes, aLength, aAddress);
+    return instance.Get<MeshCoP::PendingDataset>().SendGetRequest(
+        *static_cast<const MeshCoP::Dataset::Components *>(aDatasetComponents), aTlvTypes, aLength, aAddress);
 }
 
 otError otDatasetSendMgmtPendingSet(otInstance *                aInstance,
@@ -168,7 +163,8 @@ otError otDatasetSendMgmtPendingSet(otInstance *                aInstance,
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<MeshCoP::PendingDataset>().SendSetRequest(*aDataset, aTlvs, aLength);
+    return instance.Get<MeshCoP::PendingDataset>().SendSetRequest(
+        *static_cast<const MeshCoP::Dataset::Info *>(aDataset), aTlvs, aLength);
 }
 
 #if OPENTHREAD_FTD

--- a/src/core/api/dataset_ftd_api.cpp
+++ b/src/core/api/dataset_ftd_api.cpp
@@ -46,7 +46,7 @@ otError otDatasetCreateNewNetwork(otInstance *aInstance, otOperationalDataset *a
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<MeshCoP::ActiveDataset>().CreateNewNetwork(*aDataset);
+    return instance.Get<MeshCoP::ActiveDataset>().CreateNewNetwork(*static_cast<MeshCoP::Dataset::Info *>(aDataset));
 }
 
 uint32_t otDatasetGetDelayTimerMinimal(otInstance *aInstance)

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -39,11 +39,13 @@
 
 #include <openthread/dataset.h>
 
+#include "common/clearable.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/timer.hpp"
 #include "common/type_traits.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
+#include "thread/mle_types.hpp"
 
 namespace ot {
 namespace MeshCoP {
@@ -72,6 +74,527 @@ public:
     {
         kActive,  ///< Active Dataset
         kPending, ///< Pending Dataset
+    };
+
+    /**
+     * This class represents presence of different components in Active or Pending Operational Dataset.
+     *
+     */
+    class Components : public otOperationalDatasetComponents, public Clearable<Components>
+    {
+    public:
+        /**
+         * This method indicates whether or not the Active Timestamp is present in the Dataset.
+         *
+         * @returns TRUE if Active Timestamp is present, FALSE otherwise.
+         *
+         */
+        bool IsActiveTimestampPresent(void) const { return mIsActiveTimestampPresent; }
+
+        /**
+         * This method indicates whether or not the Pending Timestamp is present in the Dataset.
+         *
+         * @returns TRUE if Pending Timestamp is present, FALSE otherwise.
+         *
+         */
+        bool IsPendingTimestampPresent(void) const { return mIsPendingTimestampPresent; }
+
+        /**
+         * This method indicates whether or not the Network Master Key is present in the Dataset.
+         *
+         * @returns TRUE if Network Master Key is present, FALSE otherwise.
+         *
+         */
+        bool IsMasterKeyPresent(void) const { return mIsMasterKeyPresent; }
+
+        /**
+         * This method indicates whether or not the Network Name is present in the Dataset.
+         *
+         * @returns TRUE if Network Name is present, FALSE otherwise.
+         *
+         */
+        bool IsNetworkNamePresent(void) const { return mIsNetworkNamePresent; }
+
+        /**
+         * This method indicates whether or not the Extended PAN ID is present in the Dataset.
+         *
+         * @returns TRUE if Extended PAN ID is present, FALSE otherwise.
+         *
+         */
+        bool IsExtendedPanIdPresent(void) const { return mIsExtendedPanIdPresent; }
+
+        /**
+         * This method indicates whether or not the Mesh Local Prefix is present in the Dataset.
+         *
+         * @returns TRUE if Mesh Local Prefix is present, FALSE otherwise.
+         *
+         */
+        bool IsMeshLocalPrefixPresent(void) const { return mIsMeshLocalPrefixPresent; }
+
+        /**
+         * This method indicates whether or not the Delay Timer is present in the Dataset.
+         *
+         * @returns TRUE if Delay Timer is present, FALSE otherwise.
+         *
+         */
+        bool IsDelayPresent(void) const { return mIsDelayPresent; }
+
+        /**
+         * This method indicates whether or not the PAN ID is present in the Dataset.
+         *
+         * @returns TRUE if PAN ID is present, FALSE otherwise.
+         *
+         */
+        bool IsPanIdPresent(void) const { return mIsPanIdPresent; }
+
+        /**
+         * This method indicates whether or not the Channel is present in the Dataset.
+         *
+         * @returns TRUE if Channel is present, FALSE otherwise.
+         *
+         */
+        bool IsChannelPresent(void) const { return mIsChannelPresent; }
+
+        /**
+         * This method indicates whether or not the PSKc is present in the Dataset.
+         *
+         * @returns TRUE if PSKc is present, FALSE otherwise.
+         *
+         */
+        bool IsPskcPresent(void) const { return mIsPskcPresent; }
+
+        /**
+         * This method indicates whether or not the Security Policy is present in the Dataset.
+         *
+         * @returns TRUE if Security Policy is present, FALSE otherwise.
+         *
+         */
+        bool IsSecurityPolicyPresent(void) const { return mIsSecurityPolicyPresent; }
+
+        /**
+         * This method indicates whether or not the Channel Mask is present in the Dataset.
+         *
+         * @returns TRUE if Channel Mask is present, FALSE otherwise.
+         *
+         */
+        bool IsChannelMaskPresent(void) const { return mIsChannelMaskPresent; }
+    };
+
+    /**
+     * This type represents the information about the fields contained an Active or Pending Operational Dataset.
+     *
+     */
+    class Info : public otOperationalDataset, public Clearable<Info>
+    {
+    public:
+        /**
+         * This method indicates whether or not the Active Timestamp is present in the Dataset.
+         *
+         * @returns TRUE if Active Timestamp is present, FALSE otherwise.
+         *
+         */
+        bool IsActiveTimestampPresent(void) const { return mComponents.mIsActiveTimestampPresent; }
+
+        /**
+         * This method gets the Active Timestamp in the Dataset.
+         *
+         * This method MUST be used when Active Timestamp component is present in the Dataset, otherwise its behavior is
+         * undefined.
+         *
+         * @returns The Active Timestamp in the Dataset.
+         *
+         */
+        uint64_t GetActiveTimestamp(void) const { return mActiveTimestamp; }
+
+        /**
+         * This method sets the Active Timestamp in the Dataset.
+         *
+         * @param[in] aTimestamp   A Timestamp value.
+         *
+         */
+        void SetActiveTimestamp(uint64_t aTimestamp)
+        {
+            mActiveTimestamp                      = aTimestamp;
+            mComponents.mIsActiveTimestampPresent = true;
+        }
+
+        /**
+         * This method indicates whether or not the Pending Timestamp is present in the Dataset.
+         *
+         * @returns TRUE if Pending Timestamp is present, FALSE otherwise.
+         *
+         */
+        bool IsPendingTimestampPresent(void) const { return mComponents.mIsPendingTimestampPresent; }
+
+        /**
+         * This method gets the Pending Timestamp in the Dataset.
+         *
+         * This method MUST be used when Pending Timestamp component is present in the Dataset, otherwise its behavior
+         * is undefined.
+         *
+         * @returns The Pending Timestamp in the Dataset.
+         *
+         */
+        uint64_t GetPendingTimestamp(void) const { return mPendingTimestamp; }
+
+        /**
+         * This method sets the Pending Timestamp in the Dataset.
+         *
+         * @param[in] aTimestamp   A Timestamp value.
+         *
+         */
+        void SetPendingTimestamp(uint64_t aTimestamp)
+        {
+            mPendingTimestamp                      = aTimestamp;
+            mComponents.mIsPendingTimestampPresent = true;
+        }
+
+        /**
+         * This method indicates whether or not the Network Master Key is present in the Dataset.
+         *
+         * @returns TRUE if Network Master Key is present, FALSE otherwise.
+         *
+         */
+        bool IsMasterKeyPresent(void) const { return mComponents.mIsMasterKeyPresent; }
+
+        /**
+         * This method gets the Network Master Key in the Dataset.
+         *
+         * This method MUST be used when Network Master Key component is present in the Dataset, otherwise its behavior
+         * is undefined.
+         *
+         * @returns The Network Master Key in the Dataset.
+         *
+         */
+        const MasterKey &GetMasterKey(void) const { return static_cast<const MasterKey &>(mMasterKey); }
+
+        /**
+         * This method sets the Network Master Key in the Dataset.
+         *
+         * @param[in] aMasterKey  A Master Key.
+         *
+         */
+        void SetMasterKey(const MasterKey &aMasterKey)
+        {
+            mMasterKey                      = aMasterKey;
+            mComponents.mIsMasterKeyPresent = true;
+        }
+
+        /**
+         * This method returns a reference to the Network Master Key in the Dataset to be updated by caller.
+         *
+         * @returns A reference to the Network Master Key in the Dataset.
+         *
+         */
+        MasterKey &UpdateMasterKey(void)
+        {
+            mComponents.mIsMasterKeyPresent = true;
+            return static_cast<MasterKey &>(mMasterKey);
+        }
+
+        /**
+         * This method indicates whether or not the Network Name is present in the Dataset.
+         *
+         * @returns TRUE if Network Name is present, FALSE otherwise.
+         *
+         */
+        bool IsNetworkNamePresent(void) const { return mComponents.mIsNetworkNamePresent; }
+
+        /**
+         * This method gets the Network Name in the Dataset.
+         *
+         * This method MUST be used when Network Name component is present in the Dataset, otherwise its behavior is
+         * undefined.
+         *
+         * @returns The Network Name in the Dataset.
+         *
+         */
+        const Mac::NetworkName &GetNetworkName(void) const
+        {
+            return static_cast<const Mac::NetworkName &>(mNetworkName);
+        }
+
+        /**
+         * This method sets the Network Name in the Dataset.
+         *
+         * @param[in] aNetworkNameData   A Network Name Data.
+         *
+         */
+        void SetNetworkName(const Mac::NameData &aNetworkNameData)
+        {
+            IgnoreError(static_cast<Mac::NetworkName &>(mNetworkName).Set(aNetworkNameData));
+            mComponents.mIsNetworkNamePresent = true;
+        }
+
+        /**
+         * This method indicates whether or not the Extended PAN ID is present in the Dataset.
+         *
+         * @returns TRUE if Extended PAN ID is present, FALSE otherwise.
+         *
+         */
+        bool IsExtendedPanIdPresent(void) const { return mComponents.mIsExtendedPanIdPresent; }
+
+        /**
+         * This method gets the Extended PAN ID in the Dataset.
+         *
+         * This method MUST be used when Extended PAN ID component is present in the Dataset, otherwise its behavior is
+         * undefined.
+         *
+         * @returns The Extended PAN ID in the Dataset.
+         *
+         */
+        const Mac::ExtendedPanId &GetExtendedPanId(void) const
+        {
+            return static_cast<const Mac::ExtendedPanId &>(mExtendedPanId);
+        }
+
+        /**
+         * This method sets the Extended PAN ID in the Dataset.
+         *
+         * @param[in] aExtendedPanId   An Extended PAN ID.
+         *
+         */
+        void SetExtendedPanId(const Mac::ExtendedPanId &aExtendedPanId)
+        {
+            mExtendedPanId                      = aExtendedPanId;
+            mComponents.mIsExtendedPanIdPresent = true;
+        }
+
+        /**
+         * This method indicates whether or not the Mesh Local Prefix is present in the Dataset.
+         *
+         * @returns TRUE if Mesh Local Prefix is present, FALSE otherwise.
+         *
+         */
+        bool IsMeshLocalPrefixPresent(void) const { return mComponents.mIsMeshLocalPrefixPresent; }
+
+        /**
+         * This method gets the Mesh Local Prefix in the Dataset.
+         *
+         * This method MUST be used when Mesh Local Prefix component is present in the Dataset, otherwise its behavior
+         * is undefined.
+         *
+         * @returns The Mesh Local Prefix in the Dataset.
+         *
+         */
+        const Mle::MeshLocalPrefix &GetMeshLocalPrefix(void) const
+        {
+            return static_cast<const Mle::MeshLocalPrefix &>(mMeshLocalPrefix);
+        }
+
+        /**
+         * This method sets the Mesh Local Prefix in the Dataset.
+         *
+         * @param[in] aMeshLocalPrefix   A Mesh Local Prefix.
+         *
+         */
+        void SetMeshLocalPrefix(const Mle::MeshLocalPrefix &aMeshLocalPrefix)
+        {
+            mMeshLocalPrefix                      = aMeshLocalPrefix;
+            mComponents.mIsMeshLocalPrefixPresent = true;
+        }
+
+        /**
+         * This method indicates whether or not the Delay Timer is present in the Dataset.
+         *
+         * @returns TRUE if Delay Timer is present, FALSE otherwise.
+         *
+         */
+        bool IsDelayPresent(void) const { return mComponents.mIsDelayPresent; }
+
+        /**
+         * This method gets the Delay Timer in the Dataset.
+         *
+         * This method MUST be used when Delay Timer component is present in the Dataset, otherwise its behavior is
+         * undefined.
+         *
+         * @returns The Delay Timer in the Dataset.
+         *
+         */
+        uint32_t GetDelay(void) const { return mDelay; }
+
+        /**
+         * This method sets the Delay Timer in the Dataset.
+         *
+         * @param[in] aDely   A Delay value.
+         *
+         */
+        void SetDelay(uint32_t aDelay)
+        {
+            mDelay                      = aDelay;
+            mComponents.mIsDelayPresent = true;
+        }
+
+        /**
+         * This method indicates whether or not the PAN ID is present in the Dataset.
+         *
+         * @returns TRUE if PAN ID is present, FALSE otherwise.
+         *
+         */
+        bool IsPanIdPresent(void) const { return mComponents.mIsPanIdPresent; }
+
+        /**
+         * This method gets the PAN ID in the Dataset.
+         *
+         * This method MUST be used when PAN ID component is present in the Dataset, otherwise its behavior is
+         * undefined.
+         *
+         * @returns The PAN ID in the Dataset.
+         *
+         */
+        Mac::PanId GetPanId(void) const { return mPanId; }
+
+        /**
+         * This method sets the PAN ID in the Dataset.
+         *
+         * @param[in] aPanId  A PAN ID.
+         *
+         */
+        void SetPanId(Mac::PanId aPanId)
+        {
+            mPanId                      = aPanId;
+            mComponents.mIsPanIdPresent = true;
+        }
+
+        /**
+         * This method indicates whether or not the Channel is present in the Dataset.
+         *
+         * @returns TRUE if Channel is present, FALSE otherwise.
+         *
+         */
+        bool IsChannelPresent(void) const { return mComponents.mIsChannelPresent; }
+
+        /**
+         * This method gets the Channel in the Dataset.
+         *
+         * This method MUST be used when Channel component is present in the Dataset, otherwise its behavior is
+         * undefined.
+         *
+         * @returns The Channel in the Dataset.
+         *
+         */
+        uint16_t GetChannel(void) const { return mChannel; }
+
+        /**
+         * This method sets the Channel in the Dataset.
+         *
+         * @param[in] aChannel  A Channel.
+         *
+         */
+        void SetChannel(uint16_t aChannel)
+        {
+            mChannel                      = aChannel;
+            mComponents.mIsChannelPresent = true;
+        }
+
+        /**
+         * This method indicates whether or not the PSKc is present in the Dataset.
+         *
+         * @returns TRUE if PSKc is present, FALSE otherwise.
+         *
+         */
+        bool IsPskcPresent(void) const { return mComponents.mIsPskcPresent; }
+
+        /**
+         * This method gets the PSKc in the Dataset.
+         *
+         * This method MUST be used when PSKc component is present in the Dataset, otherwise its behavior is undefined.
+         *
+         * @returns The PSKc in the Dataset.
+         *
+         */
+        const Pskc &GetPskc(void) const { return static_cast<const Pskc &>(mPskc); }
+
+        /**
+         * This method set the PSKc in the Dataset.
+         *
+         * @param[in] aPskc  A PSKc value.
+         *
+         */
+        void SetPskc(const Pskc &aPskc)
+        {
+            mPskc                      = aPskc;
+            mComponents.mIsPskcPresent = true;
+        }
+
+        /**
+         * This method indicates whether or not the Security Policy is present in the Dataset.
+         *
+         * @returns TRUE if Security Policy is present, FALSE otherwise.
+         *
+         */
+        bool IsSecurityPolicyPresent(void) const { return mComponents.mIsSecurityPolicyPresent; }
+
+        /**
+         * This method gets the Security Policy in the Dataset.
+         *
+         * This method MUST be used when Security Policy component is present in the Dataset, otherwise its behavior is
+         * undefined.
+         *
+         * @returns The Security Policy in the Dataset.
+         *
+         */
+        const otSecurityPolicy &GetSecurityPolicy(void) const { return mSecurityPolicy; }
+
+        /**
+         * This method sets the Security Policy in the Dataset.
+         *
+         * @param[in] aRotationTime  A value for Key Rotation (in units of hours).
+         * @param[in] aFlags         Security policy flags
+         *
+         */
+        void SetSecurityPolicy(uint16_t aRotationTime, uint8_t aFlags)
+        {
+            mSecurityPolicy.mRotationTime        = aRotationTime;
+            mSecurityPolicy.mFlags               = aFlags;
+            mComponents.mIsSecurityPolicyPresent = true;
+        }
+
+        /**
+         * This method indicates whether or not the Channel Mask is present in the Dataset.
+         *
+         * @returns TRUE if Channel Mask is present, FALSE otherwise.
+         *
+         */
+        bool IsChannelMaskPresent(void) const { return mComponents.mIsChannelMaskPresent; }
+
+        /**
+         * This method gets the Channel Mask in the Dataset.
+         *
+         * This method MUST be used when Channel Mask component is present in the Dataset, otherwise its behavior is
+         * undefined.
+         *
+         * @returns The Channel Mask in the Dataset.
+         *
+         */
+        otChannelMask GetChannelMask(void) const { return mChannelMask; }
+
+        /**
+         * This method sets the Channel Mask in the Dataset.
+         *
+         * @param[in] aChannelMask   A Channel Mask value.
+         *
+         */
+        void SetChannelMask(otChannelMask aChannelMask)
+        {
+            mChannelMask                      = aChannelMask;
+            mComponents.mIsChannelMaskPresent = true;
+        }
+
+        /**
+         * This method populates the Dataset with random fields.
+         *
+         * The Master Key, PSKc, Mesh Local Prefix, PAN ID, and Extended PAN ID are generated randomly (crypto-secure)
+         * with Network Name set to "OpenThread-%04x" with PAN ID appended as hex. The Channel is chosen randomly from
+         * radio's preferred channel mask, Channel Mask is set from radio's supported mask, and Security Policy Flags
+         * from current `KeyManager` value.
+         *
+         * @param[in] aInstance    The OpenThread instance.
+         *
+         * @retval OT_ERROR_NONE If the Dataset was generated successfully.
+         *
+         */
+        otError GenerateRandom(Instance &aInstance);
     };
 
     /**
@@ -157,10 +680,10 @@ public:
     /**
      * This method converts the TLV representation to structure representation.
      *
-     * @param[out] aDataset  A reference to `otOperationalDataset` to output the Dataset.
+     * @param[out] aDatasetInfo  A reference to `Info` object to output the Dataset.
      *
      */
-    void ConvertTo(otOperationalDataset &aDataset) const;
+    void ConvertTo(Info &aDatasetInfo) const;
 
     /**
      * This method converts the TLV representation to structure representation.
@@ -280,13 +803,13 @@ public:
     /**
      * This method sets the Dataset from a given structure representation.
      *
-     * @param[in]  aDataset  The input Dataset as otOperationalDataset.
+     * @param[in]  aDatasetInfo  The input Dataset as `Dataset::Info`.
      *
      * @retval OT_ERROR_NONE          Successfully set the Dataset.
      * @retval OT_ERROR_INVALID_ARGS  Dataset is missing Active and/or Pending Timestamp.
      *
      */
-    otError SetFrom(const otOperationalDataset &aDataset);
+    otError SetFrom(const Info &aDatasetInfo);
 
     /**
      * This method sets the Dataset using @p aDataset.

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -126,15 +126,15 @@ exit:
     return error;
 }
 
-otError DatasetLocal::Read(otOperationalDataset &aDataset) const
+otError DatasetLocal::Read(Dataset::Info &aDatasetInfo) const
 {
     Dataset dataset(mType);
     otError error;
 
-    memset(&aDataset, 0, sizeof(aDataset));
+    aDatasetInfo.Clear();
 
     SuccessOrExit(error = Read(dataset));
-    dataset.ConvertTo(aDataset);
+    dataset.ConvertTo(aDatasetInfo);
 
 exit:
     return error;
@@ -154,12 +154,12 @@ exit:
     return error;
 }
 
-otError DatasetLocal::Save(const otOperationalDataset &aDataset)
+otError DatasetLocal::Save(const Dataset::Info &aDatasetInfo)
 {
     otError error;
     Dataset dataset(mType);
 
-    SuccessOrExit(error = dataset.SetFrom(aDataset));
+    SuccessOrExit(error = dataset.SetFrom(aDatasetInfo));
     SuccessOrExit(error = Save(dataset));
 
 exit:

--- a/src/core/meshcop/dataset_local.hpp
+++ b/src/core/meshcop/dataset_local.hpp
@@ -115,13 +115,13 @@ public:
     /**
      * This method retrieves the dataset from non-volatile memory.
      *
-     * @param[out]  aDataset  Where to place the dataset.
+     * @param[out]  aDatasetInfo  Where to place the dataset as `Dataset::Info`.
      *
      * @retval OT_ERROR_NONE       Successfully retrieved the dataset.
      * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
      *
      */
-    otError Read(otOperationalDataset &aDataset) const;
+    otError Read(Dataset::Info &aDatasetInfo) const;
 
     /**
      * This method retrieves the dataset from non-volatile memory.
@@ -145,14 +145,18 @@ public:
     /**
      * This method stores the dataset into non-volatile memory.
      *
+     * @param[in] aDatasetInfo     The Dataset to save as `Dataset::Info`.
+     *
      * @retval OT_ERROR_NONE              Successfully saved the dataset.
      * @retval OT_ERROR_NOT_IMPLEMENTED   The platform does not implement settings functionality.
      *
      */
-    otError Save(const otOperationalDataset &aDataset);
+    otError Save(const Dataset::Info &aDatasetInfo);
 
     /**
      * This method stores the dataset into non-volatile memory.
+     *
+     * @param[in]  aDataset  The Dataset to save as `otOperationalDatasetTlvs`.
      *
      * @retval OT_ERROR_NONE              Successfully saved the dataset.
      * @retval OT_ERROR_NOT_IMPLEMENTED   The platform does not implement settings functionality.
@@ -162,6 +166,8 @@ public:
 
     /**
      * This method stores the dataset into non-volatile memory.
+     *
+     * @param[in]  aDataset  The Dataset to save.
      *
      * @retval OT_ERROR_NONE              Successfully saved the dataset.
      * @retval OT_ERROR_NOT_IMPLEMENTED   The platform does not implement settings functionality.

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -96,13 +96,13 @@ public:
     /**
      * This method retrieves the dataset from non-volatile memory.
      *
-     * @param[out]  aDataset  Where to place the dataset.
+     * @param[out]  aDatasetInfo  Where to place the dataset (as `Dataset::Info`).
      *
      * @retval OT_ERROR_NONE       Successfully retrieved the dataset.
      * @retval OT_ERROR_NOT_FOUND  There is no corresponding dataset stored in non-volatile memory.
      *
      */
-    otError Read(otOperationalDataset &aDataset) const { return mLocal.Read(aDataset); }
+    otError Read(Dataset::Info &aDatasetInfo) const { return mLocal.Read(aDatasetInfo); }
 
     /**
      * This method retrieves the dataset from non-volatile memory.
@@ -146,15 +146,15 @@ public:
     /**
      * This method sends a MGMT_SET request to the Leader.
      *
-     * @param[in]  aDataset  The Operational Dataset.
-     * @param[in]  aTlvs     Any additional raw TLVs to include.
-     * @param[in]  aLength   Number of bytes in @p aTlvs.
+     * @param[in]  aDatasetInfo  The Operational Dataset.
+     * @param[in]  aTlvs         Any additional raw TLVs to include.
+     * @param[in]  aLength       Number of bytes in @p aTlvs.
      *
      * @retval OT_ERROR_NONE     Successfully send the meshcop dataset command.
      * @retval OT_ERROR_NO_BUFS  Insufficient buffer space to send.
      *
      */
-    otError SendSetRequest(const otOperationalDataset &aDataset, const uint8_t *aTlvs, uint8_t aLength);
+    otError SendSetRequest(const Dataset::Info &aDatasetInfo, const uint8_t *aTlvs, uint8_t aLength);
 
     /**
      * This method sends a MGMT_GET request.
@@ -168,10 +168,10 @@ public:
      * @retval OT_ERROR_NO_BUFS  Insufficient buffer space to send.
      *
      */
-    otError SendGetRequest(const otOperationalDatasetComponents &aDatasetComponents,
-                           const uint8_t *                       aTlvTypes,
-                           uint8_t                               aLength,
-                           const otIp6Address *                  aAddress) const;
+    otError SendGetRequest(const Dataset::Components &aDatasetComponents,
+                           const uint8_t *            aTlvTypes,
+                           uint8_t                    aLength,
+                           const otIp6Address *       aAddress) const;
 #if OPENTHREAD_FTD
     /**
      * This method appends the MLE Dataset TLV but excluding MeshCoP Sub Timestamp TLV.
@@ -253,13 +253,13 @@ protected:
     /**
      * This method saves the Operational Dataset in non-volatile memory.
      *
-     * @param[in]  aDataset  The Operational Dataset.
+     * @param[in]  aDatasetInfo  The Operational Dataset as `Dataset::Info`.
      *
      * @retval OT_ERROR_NONE             Successfully saved the dataset.
      * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
      *
      */
-    otError Save(const otOperationalDataset &aDataset);
+    otError Save(const Dataset::Info &aDatasetInfo);
 
     /**
      * This method saves the Operational Dataset in non-volatile memory.
@@ -338,7 +338,7 @@ private:
     bool    IsPendingDataset(void) const { return GetType() == Dataset::kPending; }
     void    SignalDatasetChange(void) const;
     void    HandleDatasetUpdated(void);
-    otError AppendDatasetToMessage(const otOperationalDataset &aDataset, Message &aMessage) const;
+    otError AppendDatasetToMessage(const Dataset::Info &aDatasetInfo, Message &aMessage) const;
     void    SendSet(void);
     void    SendGetResponse(const Coap::Message &   aRequest,
                             const Ip6::MessageInfo &aMessageInfo,
@@ -351,7 +351,7 @@ private:
 
     enum
     {
-        kMaxDatasetTlvs = 16,   // Maximum number of TLVs in an `otOperationalDataset`.
+        kMaxDatasetTlvs = 16,   // Maximum number of TLVs in a Dataset.
         kDelayNoBufs    = 1000, // Milliseconds
     };
 
@@ -381,6 +381,15 @@ public:
      *
      */
     bool IsPartiallyComplete(void) const;
+
+    /**
+     * This method indicates whether or not a valid network is present in the Active Operational Dataset.
+     *
+     * @retval TRUE if a valid network is present in the Active Dataset.
+     * @retval FALSE if a valid network is not present in the Active Dataset.
+     *
+     */
+    bool IsCommissioned(void) const;
 
     /**
      * This method clears the Active Operational Dataset.
@@ -415,13 +424,13 @@ public:
     /**
      * This method sets the Operational Dataset in non-volatile memory.
      *
-     * @param[in]  aDataset  The Operational Dataset.
+     * @param[in]  aDatasetInfo  The Operational Dataset as `Dataset::Info`.
      *
      * @retval OT_ERROR_NONE             Successfully saved the dataset.
      * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
      *
      */
-    otError Save(const otOperationalDataset &aDataset) { return DatasetManager::Save(aDataset); }
+    otError Save(const Dataset::Info &aDatasetInfo) { return DatasetManager::Save(aDatasetInfo); }
 
     /**
      * This method sets the Operational Dataset in non-volatile memory.
@@ -439,13 +448,13 @@ public:
     /**
      * This method creates a new Operational Dataset to use when forming a new network.
      *
-     * @param[out]  aDataset  The Operational Dataset.
+     * @param[out]  aDatasetInfo  The Operational Dataset as `Dataset::Info`.
      *
      * @retval OT_ERROR_NONE    Successfully created a new Operational Dataset.
      * @retval OT_ERROR_FAILED  Failed to generate random values for new parameters.
      *
      */
-    otError CreateNewNetwork(otOperationalDataset &aDataset);
+    otError CreateNewNetwork(Dataset::Info &aDatasetInfo) { return aDatasetInfo.GenerateRandom(GetInstance()); }
 
     /**
      * This method starts the Leader functions for maintaining the Active Operational Dataset.
@@ -521,13 +530,13 @@ public:
      *
      * This method also starts the Delay Timer.
      *
-     * @param[in]  aDataset  The Operational Dataset.
+     * @param[in]  aDatasetInfo  The Operational Dataset as `Dataset::Info`.
      *
      * @retval OT_ERROR_NONE             Successfully saved the dataset.
      * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
      *
      */
-    otError Save(const otOperationalDataset &aDataset);
+    otError Save(const Dataset::Info &aDatasetInfo);
 
     /**
      * This method saves the Operational Dataset in non-volatile memory.

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -304,57 +304,6 @@ exit:
     return error;
 }
 
-otError ActiveDataset::CreateNewNetwork(otOperationalDataset &aDataset)
-{
-    otError          error             = OT_ERROR_NONE;
-    Mac::ChannelMask supportedChannels = Get<Mac::Mac>().GetSupportedChannelMask();
-    Mac::ChannelMask preferredChannels(Get<Radio>().GetPreferredChannelMask());
-
-    memset(&aDataset, 0, sizeof(aDataset));
-
-    aDataset.mActiveTimestamp = 1;
-
-    SuccessOrExit(error = static_cast<MasterKey &>(aDataset.mMasterKey).GenerateRandom());
-    SuccessOrExit(error = static_cast<Pskc &>(aDataset.mPskc).GenerateRandom());
-    SuccessOrExit(error = Random::Crypto::FillBuffer(aDataset.mExtendedPanId.m8, sizeof(aDataset.mExtendedPanId)));
-
-    SuccessOrExit(error = static_cast<Ip6::NetworkPrefix &>(aDataset.mMeshLocalPrefix).GenerateRandomUla());
-
-    aDataset.mSecurityPolicy.mFlags = Get<KeyManager>().GetSecurityPolicyFlags();
-
-    // If the preferred channel mask is not empty, select a random
-    // channel from it, otherwise choose one from the supported
-    // channel mask.
-
-    preferredChannels.Intersect(supportedChannels);
-
-    if (preferredChannels.IsEmpty())
-    {
-        preferredChannels = supportedChannels;
-    }
-
-    aDataset.mChannel     = preferredChannels.ChooseRandomChannel();
-    aDataset.mChannelMask = supportedChannels.GetMask();
-
-    aDataset.mPanId = Mac::GenerateRandomPanId();
-
-    snprintf(aDataset.mNetworkName.m8, sizeof(aDataset.mNetworkName), "OpenThread-%04x", aDataset.mPanId);
-
-    aDataset.mComponents.mIsActiveTimestampPresent = true;
-    aDataset.mComponents.mIsMasterKeyPresent       = true;
-    aDataset.mComponents.mIsNetworkNamePresent     = true;
-    aDataset.mComponents.mIsExtendedPanIdPresent   = true;
-    aDataset.mComponents.mIsMeshLocalPrefixPresent = true;
-    aDataset.mComponents.mIsPanIdPresent           = true;
-    aDataset.mComponents.mIsChannelPresent         = true;
-    aDataset.mComponents.mIsPskcPresent            = true;
-    aDataset.mComponents.mIsSecurityPolicyPresent  = true;
-    aDataset.mComponents.mIsChannelMaskPresent     = true;
-
-exit:
-    return error;
-}
-
 otError ActiveDataset::GenerateLocal(void)
 {
     otError error = OT_ERROR_NONE;

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -559,26 +559,23 @@ void Joiner::HandleJoinerEntrust(void *aContext, otMessage *aMessage, const otMe
 
 void Joiner::HandleJoinerEntrust(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    otError              error;
-    otOperationalDataset dataset;
+    otError       error;
+    Dataset::Info datasetInfo;
 
     VerifyOrExit(mState == kStateEntrust && aMessage.IsConfirmablePostRequest(), error = OT_ERROR_DROP);
 
     otLogInfoMeshCoP("Joiner received entrust");
     otLogCertMeshCoP("[THCI] direction=recv | type=JOIN_ENT.ntf");
 
-    memset(&dataset, 0, sizeof(dataset));
+    datasetInfo.Clear();
 
-    SuccessOrExit(error = Tlv::FindTlv(aMessage, Tlv::kNetworkMasterKey, &dataset.mMasterKey, sizeof(MasterKey)));
-    dataset.mComponents.mIsMasterKeyPresent = true;
+    SuccessOrExit(
+        error = Tlv::FindTlv(aMessage, Tlv::kNetworkMasterKey, &datasetInfo.UpdateMasterKey(), sizeof(MasterKey)));
 
-    dataset.mChannel                      = Get<Mac::Mac>().GetPanChannel();
-    dataset.mComponents.mIsChannelPresent = true;
+    datasetInfo.SetChannel(Get<Mac::Mac>().GetPanChannel());
+    datasetInfo.SetPanId(Get<Mac::Mac>().GetPanId());
 
-    dataset.mPanId                      = Get<Mac::Mac>().GetPanId();
-    dataset.mComponents.mIsPanIdPresent = true;
-
-    IgnoreError(Get<MeshCoP::ActiveDataset>().Save(dataset));
+    IgnoreError(Get<MeshCoP::ActiveDataset>().Save(datasetInfo));
 
     otLogInfoMeshCoP("Joiner successful!");
 

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -672,7 +672,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::ThreadDatasetHandler(con
     opDataset.mActiveTimestamp                      = 0;
     opDataset.mComponents.mIsActiveTimestampPresent = true;
 
-    SuccessOrExit(error = dataset.SetFrom(opDataset));
+    SuccessOrExit(error = dataset.SetFrom(static_cast<MeshCoP::Dataset::Info &>(opDataset)));
     SuccessOrExit(error = otPlatSettingsSet(
                       mInstance, isActive ? SettingsBase::kKeyActiveDataset : SettingsBase::kKeyPendingDataset,
                       dataset.GetBytes(), dataset.GetSize()));


### PR DESCRIPTION
This commit adds `Dataset::Info` and `Dataset::Components` types
mirroring `otOperationalDataset` & `otOperationalDatasetComponents`
definitions and providing helper methods to get/set different fields
in the dataset.

