### PR TITLE
[type-traits] add 'IsPointer<Type>' and use it in message/dataset

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -385,6 +385,7 @@ openthread_core_files = [
   "common/tlvs.hpp",
   "common/trickle_timer.cpp",
   "common/trickle_timer.hpp",
+  "common/type_traits.hpp",
   "crypto/aes_ccm.cpp",
   "crypto/aes_ccm.hpp",
   "crypto/aes_ecb.cpp",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -369,6 +369,7 @@ HEADERS_COMMON                                  = \
     common/timer.hpp                              \
     common/tlvs.hpp                               \
     common/trickle_timer.hpp                      \
+    common/type_traits.hpp                        \
     config/announce_sender.h                      \
     config/backbone_router.h                      \
     config/border_router.h                        \

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -47,6 +47,7 @@
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/pool.hpp"
+#include "common/type_traits.hpp"
 #include "mac/mac_types.hpp"
 #include "thread/child_mask.hpp"
 #include "thread/link_quality.hpp"
@@ -578,6 +579,8 @@ public:
      */
     template <typename ObjectType> otError Prepend(const ObjectType &aObject)
     {
+        static_assert(!TypeTraits::IsPointer<ObjectType>::kValue, "ObjectType must not be a pointer");
+
         return PrependBytes(&aObject, sizeof(ObjectType));
     }
 
@@ -618,6 +621,8 @@ public:
      */
     template <typename ObjectType> otError Append(const ObjectType &aObject)
     {
+        static_assert(!TypeTraits::IsPointer<ObjectType>::kValue, "ObjectType must not be a pointer");
+
         return AppendBytes(&aObject, sizeof(ObjectType));
     }
 
@@ -667,6 +672,8 @@ public:
      */
     template <typename ObjectType> otError Read(uint16_t aOffset, ObjectType &aObject) const
     {
+        static_assert(!TypeTraits::IsPointer<ObjectType>::kValue, "ObjectType must not be a pointer");
+
         return Read(aOffset, &aObject, sizeof(ObjectType));
     }
 
@@ -697,6 +704,8 @@ public:
      */
     template <typename ObjectType> void Write(uint16_t aOffset, const ObjectType &aObject)
     {
+        static_assert(!TypeTraits::IsPointer<ObjectType>::kValue, "ObjectType must not be a pointer");
+
         WriteBytes(aOffset, &aObject, sizeof(ObjectType));
     }
 

--- a/src/core/common/type_traits.hpp
+++ b/src/core/common/type_traits.hpp
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2020, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes type traits definitions.
+ */
+
+#ifndef OT_TYPE_TRAITS_HPP_
+#define OT_TYPE_TRAITS_HPP_
+
+namespace ot {
+namespace TypeTraits {
+
+/**
+ * This type represents a true value (contains a `true` static `kValue` member variable).
+ *
+ */
+struct TrueValue
+{
+    constexpr static bool kValue = true; ///< true value.
+};
+
+/**
+ * This type represents a false value (contains a `false` static `kValue` member variable).
+ *
+ */
+struct FalseValue
+{
+    constexpr static bool kValue = false; ///< false value.
+};
+
+/**
+ * This type indicates whether or not a given template `Type` is a pointer type.
+ *
+ * The `constexpr` expression `IsPointer<Type>::kValue` would be `true` when the `Type` is a pointer, otherwise it
+ * would be `false`.
+ *
+ * @tparam Type    A type to check if is a pointer.
+ *
+ */
+template <typename Type> struct IsPointer : public FalseValue
+{
+};
+
+// Partial template specializations of the `IsPointer<Type>`
+
+template <typename Type> struct IsPointer<Type *> : public TrueValue
+{
+};
+
+template <typename Type> struct IsPointer<const Type *> : public TrueValue
+{
+};
+
+template <typename Type> struct IsPointer<volatile Type *> : public TrueValue
+{
+};
+
+template <typename Type> struct IsPointer<const volatile Type *> : TrueValue
+{
+};
+
+} // namespace TypeTraits
+} // namespace ot
+
+#endif // OT_TYPE_TRAITS_HPP_

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -42,6 +42,7 @@
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/timer.hpp"
+#include "common/type_traits.hpp"
 #include "meshcop/meshcop_tlvs.hpp"
 
 namespace ot {
@@ -247,6 +248,8 @@ public:
      */
     template <typename ValueType> otError SetTlv(Tlv::Type aType, const ValueType &aValue)
     {
+        static_assert(!TypeTraits::IsPointer<ValueType>::kValue, "ValueType must not be a pointer");
+
         return SetTlv(aType, &aValue, sizeof(ValueType));
     }
 


### PR DESCRIPTION
This commit adds a new header `common/type_traits.hpp` which provides
`IsPointer<Type>` to check whether a template `Type` is a pointer type
or not. This is then used in `Message` and `Dataset` methods where we
append/set a generic object to check (as an `static_assert`) that the
object type is not a pointer. This adds protection (causing a compile
time error) against potential incorrect use of these methods (i.e.,
passing a pointer instead of a reference to an object by mistake).

