### PR TITLE
[efr32] radio: increase FIFO size to allow handling of heavy traffic

### DIFF
--- a/examples/platforms/efr32/src/radio.c
+++ b/examples/platforms/efr32/src/radio.c
@@ -113,7 +113,7 @@ static otRadioState  sState        = OT_RADIO_STATE_DISABLED;
 enum
 {
     ACKED_WITH_FP_MATCH_LENGTH = 1 + IEEE802154_MAX_MHR_LENGTH, // PHR and MHR
-    ACKED_WITH_FP_SLOTS = 16, // maximum number of Data Request packets in the RX FIFO. Length should be a power of 2.
+    ACKED_WITH_FP_SLOTS = 32, // maximum number of Data Request packets in the RX FIFO. Length should be a power of 2.
 };
 
 typedef struct efr32AckedWithFP


### PR DESCRIPTION
This PR increases the FIFO size used for storing the handles of the data request packets that were ACKed with the frame pending bit set. This is a temporary "fix" for #5689; the actual reason for the assert is being investigated by Silabs.

The logic behind the original implementation is here: #4484.