### PR TITLE
[ip6] allow anycast source

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1075,8 +1075,7 @@ otError Ip6::SendRaw(Message &aMessage)
     bool        freed = false;
 
     SuccessOrExit(error = header.Init(aMessage));
-    VerifyOrExit(!header.GetSource().IsMulticast() && !Get<Mle::Mle>().IsAnycastLocator(header.GetSource()),
-                 error = OT_ERROR_INVALID_SOURCE_ADDRESS);
+    VerifyOrExit(!header.GetSource().IsMulticast(), error = OT_ERROR_INVALID_SOURCE_ADDRESS);
 
     messageInfo.SetPeerAddr(header.GetSource());
     messageInfo.SetSockAddr(header.GetDestination());


### PR DESCRIPTION
This commit allows IPv6 anycast as source address given it is not
forbidden in standards.

This PR addresses #5698 