### PR TITLE
[github-actions] add bootstrap test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,17 @@ jobs:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       if: "github.ref != 'refs/heads/master'"
 
+  bootstrap:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-20.04, macos-10.15]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Bootstrap
+        run: |
+          script/bootstrap
+
   pretty:
     runs-on: ubuntu-20.04
     steps:


### PR DESCRIPTION
This commit adds the bootstrap job in Build workflow to make sure that `script/bootstrap` works on both Ubuntu and macOS.