### PR TITLE
[script] update 'make-pretty clang-tidy' to output warning/error only

### DIFF
--- a/script/make-pretty
+++ b/script/make-pretty
@@ -177,7 +177,7 @@ do_clang_tidy_check()
         if grep -q "warning: \|error: " output.txt; then
             echo "You must pass the clang tidy checks before submitting a pull request"
             echo ""
-            grep --color -E '^|warning: |error: ' output.txt
+            grep --color -E 'warning: |error: ' -A 5 output.txt
             exit 1
         fi
     )


### PR DESCRIPTION
This change limits the output (when clang-tidy check fails) to error
or warning messages along with next 5 lines (remove `^|`)

-----

_Background of this change:_ 
I have been looking at output in some builds where the `clang-tidy` check was failing and it was hard to find the error from output -> example: [gh-action-pretty](https://github.com/abtink/openthread/runs/1339414917?check_suite_focus=true).
I think the issue is with `^|`. Running the script locally with the change in this PR just shows the warning/error lines and few lines after (would help with fixing the issue).
