### PR TITLE
[tlvs] new simplified model to process/append TLVs

### DIFF
--- a/src/core/common/encoding.hpp
+++ b/src/core/common/encoding.hpp
@@ -122,7 +122,36 @@ inline uint64_t HostSwap64(uint64_t v)
 #endif // LITTLE_ENDIAN
 
 /**
- * This function reads a `uint16_t` value from a given buffer assuming big-ending encoding.
+ * This template function performs host swap on a given unsigned integer value assuming big-endian encoding.
+ *
+ * @tparam  UintType   The unsigned int type.
+ *
+ * @param   aValue     The value to host swap.
+ *
+ * @returns The host swapped value.
+ *
+ */
+template <typename UintType> UintType HostSwap(UintType aValue);
+
+template <> inline uint8_t HostSwap(uint8_t aValue)
+{
+    return aValue;
+}
+template <> inline uint16_t HostSwap(uint16_t aValue)
+{
+    return HostSwap16(aValue);
+}
+template <> inline uint32_t HostSwap(uint32_t aValue)
+{
+    return HostSwap32(aValue);
+}
+template <> inline uint64_t HostSwap(uint64_t aValue)
+{
+    return HostSwap64(aValue);
+}
+
+/**
+ * This function reads a `uint16_t` value from a given buffer assuming big-endian encoding.
  *
  * @param[in] aBuffer   Pointer to buffer to read from.
  *
@@ -135,7 +164,7 @@ inline uint16_t ReadUint16(const uint8_t *aBuffer)
 }
 
 /**
- * This function reads a `uint32_t` value from a given buffer assuming big-ending encoding.
+ * This function reads a `uint32_t` value from a given buffer assuming big-endian encoding.
  *
  * @param[in] aBuffer   Pointer to buffer to read from.
  *
@@ -149,7 +178,7 @@ inline uint32_t ReadUint32(const uint8_t *aBuffer)
 }
 
 /**
- * This function reads a 24-bit integer value from a given buffer assuming big-ending encoding.
+ * This function reads a 24-bit integer value from a given buffer assuming big-endian encoding.
  *
  * @param[in] aBuffer   Pointer to buffer to read from.
  *
@@ -163,7 +192,7 @@ inline uint32_t ReadUint24(const uint8_t *aBuffer)
 }
 
 /**
- * This function reads a `uint64_t` value from a given buffer assuming big-ending encoding.
+ * This function reads a `uint64_t` value from a given buffer assuming big-endian encoding.
  *
  * @param[in] aBuffer   Pointer to buffer to read from.
  *
@@ -179,7 +208,7 @@ inline uint64_t ReadUint64(const uint8_t *aBuffer)
 }
 
 /**
- * This function writes a `uint16_t` value to a given buffer using big-ending encoding.
+ * This function writes a `uint16_t` value to a given buffer using big-endian encoding.
  *
  * @param[in]  aValue    The value to write to buffer.
  * @param[out] aBuffer   Pointer to buffer where the value will be written.
@@ -192,7 +221,7 @@ inline void WriteUint16(uint16_t aValue, uint8_t *aBuffer)
 }
 
 /**
- * This function writes a 24-bit integer value to a given buffer using big-ending encoding.
+ * This function writes a 24-bit integer value to a given buffer using big-endian encoding.
  *
  * @param[in]  aValue    The value to write to buffer.
  * @param[out] aBuffer   Pointer to buffer where the value will be written.
@@ -206,7 +235,7 @@ inline void WriteUint24(uint32_t aValue, uint8_t *aBuffer)
 }
 
 /**
- * This function writes a `uint32_t` value to a given buffer using big-ending encoding.
+ * This function writes a `uint32_t` value to a given buffer using big-endian encoding.
  *
  * @param[in]  aValue    The value to write to buffer.
  * @param[out] aBuffer   Pointer to buffer where the value will be written.
@@ -221,7 +250,7 @@ inline void WriteUint32(uint32_t aValue, uint8_t *aBuffer)
 }
 
 /**
- * This function writes a `uint64_t` value to a given buffer using big-ending encoding.
+ * This function writes a `uint64_t` value to a given buffer using big-endian encoding.
  *
  * @param[in]  aValue    The value to write to buffer.
  * @param[out] aBuffer   Pointer to buffer where the value will be written.
@@ -276,7 +305,36 @@ inline uint64_t HostSwap64(uint64_t v)
 #endif
 
 /**
- * This function reads a `uint16_t` value from a given buffer assuming little-ending encoding.
+ * This template function performs host swap on a given unsigned integer value assuming little-endian encoding.
+ *
+ * @tparam  UintType   The unsigned int type.
+ *
+ * @param   aValue     The value to host swap.
+ *
+ * @returns The host swapped value.
+ *
+ */
+template <typename UintType> UintType HostSwap(UintType aValue);
+
+template <> inline uint8_t HostSwap(uint8_t aValue)
+{
+    return aValue;
+}
+template <> inline uint16_t HostSwap(uint16_t aValue)
+{
+    return HostSwap16(aValue);
+}
+template <> inline uint32_t HostSwap(uint32_t aValue)
+{
+    return HostSwap32(aValue);
+}
+template <> inline uint64_t HostSwap(uint64_t aValue)
+{
+    return HostSwap64(aValue);
+}
+
+/**
+ * This function reads a `uint16_t` value from a given buffer assuming little-endian encoding.
  *
  * @param[in] aBuffer   Pointer to buffer to read from.
  *
@@ -289,7 +347,7 @@ inline uint16_t ReadUint16(const uint8_t *aBuffer)
 }
 
 /**
- * This function reads a 24-bit integer value from a given buffer assuming little-ending encoding.
+ * This function reads a 24-bit integer value from a given buffer assuming little-endian encoding.
  *
  * @param[in] aBuffer   Pointer to buffer to read from.
  *
@@ -303,7 +361,7 @@ inline uint32_t ReadUint24(const uint8_t *aBuffer)
 }
 
 /**
- * This function reads a `uint32_t` value from a given buffer assuming little-ending encoding.
+ * This function reads a `uint32_t` value from a given buffer assuming little-endian encoding.
  *
  * @param[in] aBuffer   Pointer to buffer to read from.
  *
@@ -317,7 +375,7 @@ inline uint32_t ReadUint32(const uint8_t *aBuffer)
 }
 
 /**
- * This function reads a `uint64_t` value from a given buffer assuming little-ending encoding.
+ * This function reads a `uint64_t` value from a given buffer assuming little-endian encoding.
  *
  * @param[in] aBuffer   Pointer to buffer to read from.
  *
@@ -333,7 +391,7 @@ inline uint64_t ReadUint64(const uint8_t *aBuffer)
 }
 
 /**
- * This function writes a `uint16_t` value to a given buffer using little-ending encoding.
+ * This function writes a `uint16_t` value to a given buffer using little-endian encoding.
  *
  * @param[in]  aValue    The value to write to buffer.
  * @param[out] aBuffer   Pointer to buffer where the value will be written.
@@ -346,7 +404,7 @@ inline void WriteUint16(uint16_t aValue, uint8_t *aBuffer)
 }
 
 /**
- * This function writes a 24-bit integer value to a given buffer using little-ending encoding.
+ * This function writes a 24-bit integer value to a given buffer using little-endian encoding.
  *
  * @param[in]  aValue   The value to write to buffer.
  * @param[out] aBuffer  Pointer to buffer where the value will be written.
@@ -360,7 +418,7 @@ inline void WriteUint24(uint32_t aValue, uint8_t *aBuffer)
 }
 
 /**
- * This function writes a `uint32_t` value to a given buffer using little-ending encoding.
+ * This function writes a `uint32_t` value to a given buffer using little-endian encoding.
  *
  * @param[in]  aValue   The value to write to buffer.
  * @param[out] aBuffer  Pointer to buffer where the value will be written.
@@ -375,7 +433,7 @@ inline void WriteUint32(uint32_t aValue, uint8_t *aBuffer)
 }
 
 /**
- * This function writes a `uint64_t` value to a given buffer using little-ending encoding.
+ * This function writes a `uint64_t` value to a given buffer using little-endian encoding.
  *
  * @param[in]  aValue   The value to write to buffer.
  * @param[out] aBuffer  Pointer to buffer where the value will be written.

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -37,9 +37,6 @@
 #include "common/debug.hpp"
 #include "common/message.hpp"
 
-using ot::Encoding::BigEndian::HostSwap16;
-using ot::Encoding::BigEndian::HostSwap32;
-
 namespace ot {
 
 uint32_t Tlv::GetSize(void) const
@@ -171,32 +168,21 @@ exit:
     return error;
 }
 
-otError Tlv::ReadUint8Tlv(const Message &aMessage, uint16_t aOffset, uint8_t &aValue)
-{
-    return ReadTlv(aMessage, aOffset, &aValue, sizeof(uint8_t));
-}
-
-otError Tlv::ReadUint16Tlv(const Message &aMessage, uint16_t aOffset, uint16_t &aValue)
+template <typename UintType> otError Tlv::ReadUintTlv(const Message &aMessage, uint16_t aOffset, UintType &aValue)
 {
     otError error;
 
-    SuccessOrExit(error = ReadTlv(aMessage, aOffset, &aValue, sizeof(uint16_t)));
-    aValue = HostSwap16(aValue);
+    SuccessOrExit(error = ReadTlv(aMessage, aOffset, &aValue, sizeof(aValue)));
+    aValue = Encoding::BigEndian::HostSwap<UintType>(aValue);
 
 exit:
     return error;
 }
 
-otError Tlv::ReadUint32Tlv(const Message &aMessage, uint16_t aOffset, uint32_t &aValue)
-{
-    otError error;
-
-    SuccessOrExit(error = ReadTlv(aMessage, aOffset, &aValue, sizeof(uint32_t)));
-    aValue = HostSwap32(aValue);
-
-exit:
-    return error;
-}
+// Explicit instantiations of `ReadUintTlv<>()`
+template otError Tlv::ReadUintTlv<uint8_t>(const Message &aMessage, uint16_t aOffset, uint8_t &aValue);
+template otError Tlv::ReadUintTlv<uint16_t>(const Message &aMessage, uint16_t aOffset, uint16_t &aValue);
+template otError Tlv::ReadUintTlv<uint32_t>(const Message &aMessage, uint16_t aOffset, uint32_t &aValue);
 
 otError Tlv::ReadTlv(const Message &aMessage, uint16_t aOffset, void *aValue, uint8_t aLength)
 {
@@ -213,41 +199,22 @@ exit:
     return error;
 }
 
-otError Tlv::FindUint8Tlv(const Message &aMessage, uint8_t aType, uint8_t &aValue)
+template <typename UintType> otError Tlv::FindUintTlv(const Message &aMessage, uint8_t aType, UintType &aValue)
 {
     otError  error = OT_ERROR_NONE;
     uint16_t offset;
 
     SuccessOrExit(error = FindTlvOffset(aMessage, aType, offset));
-    error = ReadUint8Tlv(aMessage, offset, aValue);
+    error = ReadUintTlv<UintType>(aMessage, offset, aValue);
 
 exit:
     return error;
 }
 
-otError Tlv::FindUint16Tlv(const Message &aMessage, uint8_t aType, uint16_t &aValue)
-{
-    otError  error = OT_ERROR_NONE;
-    uint16_t offset;
-
-    SuccessOrExit(error = FindTlvOffset(aMessage, aType, offset));
-    error = ReadUint16Tlv(aMessage, offset, aValue);
-
-exit:
-    return error;
-}
-
-otError Tlv::FindUint32Tlv(const Message &aMessage, uint8_t aType, uint32_t &aValue)
-{
-    otError  error = OT_ERROR_NONE;
-    uint16_t offset;
-
-    SuccessOrExit(error = FindTlvOffset(aMessage, aType, offset));
-    error = ReadUint32Tlv(aMessage, offset, aValue);
-
-exit:
-    return error;
-}
+// Explicit instantiations of `FindUintTlv<>()`
+template otError Tlv::FindUintTlv<uint8_t>(const Message &aMessage, uint8_t aType, uint8_t &aValue);
+template otError Tlv::FindUintTlv<uint16_t>(const Message &aMessage, uint8_t aType, uint16_t &aValue);
+template otError Tlv::FindUintTlv<uint32_t>(const Message &aMessage, uint8_t aType, uint32_t &aValue);
 
 otError Tlv::FindTlv(const Message &aMessage, uint8_t aType, void *aValue, uint8_t aLength)
 {
@@ -263,26 +230,17 @@ exit:
     return error;
 }
 
-otError Tlv::AppendUint8Tlv(Message &aMessage, uint8_t aType, uint8_t aValue)
+template <typename UintType> otError Tlv::AppendUintTlv(Message &aMessage, uint8_t aType, UintType aValue)
 {
-    uint8_t value8 = aValue;
+    UintType value = Encoding::BigEndian::HostSwap<UintType>(aValue);
 
-    return AppendTlv(aMessage, aType, &value8, sizeof(uint8_t));
+    return AppendTlv(aMessage, aType, &value, sizeof(UintType));
 }
 
-otError Tlv::AppendUint16Tlv(Message &aMessage, uint8_t aType, uint16_t aValue)
-{
-    uint16_t value16 = HostSwap16(aValue);
-
-    return AppendTlv(aMessage, aType, &value16, sizeof(uint16_t));
-}
-
-otError Tlv::AppendUint32Tlv(Message &aMessage, uint8_t aType, uint32_t aValue)
-{
-    uint32_t value32 = HostSwap32(aValue);
-
-    return AppendTlv(aMessage, aType, &value32, sizeof(uint32_t));
-}
+// Explicit instantiations of `AppendUintTlv<>()`
+template otError Tlv::AppendUintTlv<uint8_t>(Message &aMessage, uint8_t aType, uint8_t aValue);
+template otError Tlv::AppendUintTlv<uint16_t>(Message &aMessage, uint8_t aType, uint16_t aValue);
+template otError Tlv::AppendUintTlv<uint32_t>(Message &aMessage, uint8_t aType, uint32_t aValue);
 
 otError Tlv::AppendTlv(Message &aMessage, uint8_t aType, const void *aValue, uint8_t aLength)
 {

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -41,6 +41,7 @@
 #include <openthread/platform/toolchain.h>
 
 #include "common/encoding.hpp"
+#include "common/type_traits.hpp"
 
 namespace ot {
 
@@ -177,45 +178,6 @@ public:
     otError AppendTo(Message &aMessage) const;
 
     /**
-     * This static method reads a TLV from a message at a given offset with TLV's value as an `uint8_t`.
-     *
-     * @param[in]   aMessage  The message to read from.
-     * @param[in]   aOffset   The offset into the message pointing to the start of the TLV.
-     * @param[out]  aValue    A reference to a `uint8_t` to output the TLV's value.
-     *
-     * @retval OT_ERROR_NONE        Successfully read the TLV and updated @p aValue.
-     * @retval OT_ERROR_PARSE       The TLV was not well-formed and could not be parsed.
-     *
-     */
-    static otError ReadUint8Tlv(const Message &aMessage, uint16_t aOffset, uint8_t &aValue);
-
-    /**
-     * This static method reads a TLV from a message at a given offset with TLV's value as an `uint16_t`.
-     *
-     * @param[in]   aMessage  The message to read from.
-     * @param[in]   aOffset   The offset into the message pointing to the start of the TLV.
-     * @param[out]  aValue    A reference to a `uint16_t` to output the TLV's value.
-     *
-     * @retval OT_ERROR_NONE        Successfully read the TLV and updated @p aValue.
-     * @retval OT_ERROR_PARSE       The TLV was not well-formed and could not be parsed.
-     *
-     */
-    static otError ReadUint16Tlv(const Message &aMessage, uint16_t aOffset, uint16_t &aValue);
-
-    /**
-     * This static method reads a TLV from a message at a given offset with TLV's value as an `uint32_t`.
-     *
-     * @param[in]   aMessage  The message to read from.
-     * @param[in]   aOffset   The offset into the message pointing to the start of the TLV.
-     * @param[out]  aValue    A reference to a `uint32_t` to output the TLV's value.
-     *
-     * @retval OT_ERROR_NONE        Successfully read the TLV and updated @p aValue.
-     * @retval OT_ERROR_PARSE       The TLV was not well-formed and could not be parsed.
-     *
-     */
-    static otError ReadUint32Tlv(const Message &aMessage, uint16_t aOffset, uint32_t &aValue);
-
-    /**
      * This static method reads a TLV in a message at a given offset expecting a minimum length for the value.
      *
      * @param[in]   aMessage    The message to read from.
@@ -230,7 +192,45 @@ public:
     static otError ReadTlv(const Message &aMessage, uint16_t aOffset, void *aValue, uint8_t aMinLength);
 
     /**
-     * This static method reads the requested TLV out of @p aMessage.
+     * This static method reads a simple TLV with a single non-integral value in a message at a given offset.
+     *
+     * @tparam      SimpleTlvType   The simple TLV type to read (must be a sub-class of `SimpleTlvInfo`).
+     *
+     * @param[in]   aMessage        The message to read from.
+     * @param[in]   aOffset         The offset into the message pointing to the start of the TLV.
+     * @param[out]  aValue          A reference to the value object to output the read value.
+     *
+     * @retval OT_ERROR_NONE        Successfully read the TLV and updated the @p aValue.
+     * @retval OT_ERROR_PARSE       The TLV was not well-formed and could not be parsed.
+     *
+     */
+    template <typename SimpleTlvType>
+    static otError Read(const Message &aMessage, uint16_t aOffset, typename SimpleTlvType::ValueType &aValue)
+    {
+        return ReadTlv(aMessage, aOffset, &aValue, sizeof(aValue));
+    }
+
+    /**
+     * This static method reads a simple TLV with a single integral value in a message at a given offset.
+     *
+     * @tparam      UintTlvType     The simple TLV type to read (must be a sub-class of `SimpleTlvInfo`).
+     *
+     * @param[in]   aMessage        The message to read from.
+     * @param[in]   aOffset         The offset into the message pointing to the start of the TLV.
+     * @param[out]  aValue          A reference to an unsigned int to output the read value.
+     *
+     * @retval OT_ERROR_NONE        Successfully read the TLV and updated the @p aValue.
+     * @retval OT_ERROR_PARSE       The TLV was not well-formed and could not be parsed.
+     *
+     */
+    template <typename UintTlvType>
+    static otError Read(const Message &aMessage, uint16_t aOffset, typename UintTlvType::UintValueType &aValue)
+    {
+        return ReadUintTlv(aMessage, aOffset, aValue);
+    }
+
+    /**
+     * This static method searches for and reads a requested TLV out of a given message.
      *
      * This method can be used independent of whether the read TLV (from message) is an Extended TLV or not.
      *
@@ -244,6 +244,25 @@ public:
      *
      */
     static otError FindTlv(const Message &aMessage, uint8_t aType, uint16_t aMaxSize, Tlv &aTlv);
+
+    /**
+     * This static method searches for and reads a requested TLV out of a given message.
+     *
+     * This method can be used independent of whether the read TLV (from message) is an Extended TLV or not.
+     *
+     * @tparam      TlvType     The TlvType to search for (must be a sub-class of `Tlv`).
+     *
+     * @param[in]   aMessage    A reference to the message.
+     * @param[out]  aTlv        A reference to the TLV that will be copied to.
+     *
+     * @retval OT_ERROR_NONE       Successfully copied the TLV.
+     * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
+     *
+     */
+    template <typename TlvType> static otError FindTlv(const Message &aMessage, TlvType &aTlv)
+    {
+        return FindTlv(aMessage, TlvType::kType, sizeof(TlvType), aTlv);
+    }
 
     /**
      * This static method obtains the offset of a TLV within @p aMessage.
@@ -277,48 +296,6 @@ public:
     static otError FindTlvValueOffset(const Message &aMessage, uint8_t aType, uint16_t &aOffset, uint16_t &aLength);
 
     /**
-     * This static method searches for a TLV with a given type in a message and reads its value as an `uint8_t`.
-     *
-     * @param[in]   aMessage        A reference to the message.
-     * @param[in]   aType           The TLV type to search for.
-     * @param[out]  aValue          A reference to a `uint8_t` to output the TLV's value.
-     *
-     * @retval OT_ERROR_NONE        Successfully found the TLV and updated @p aValue.
-     * @retval OT_ERROR_NOT_FOUND   Could not find the TLV with Type @p aType.
-     * @retval OT_ERROR_PARSE       TLV was found but it was not well-formed and could not be parsed.
-     *
-     */
-    static otError FindUint8Tlv(const Message &aMessage, uint8_t aType, uint8_t &aValue);
-
-    /**
-     * This static method searches for a TLV with a given type in a message and reads its value as an `uint16_t`.
-     *
-     * @param[in]   aMessage        A reference to the message.
-     * @param[in]   aType           The TLV type to search for.
-     * @param[out]  aValue          A reference to a `uint16_t` to output the TLV's value.
-     *
-     * @retval OT_ERROR_NONE        Successfully found the TLV and updated @p aValue.
-     * @retval OT_ERROR_NOT_FOUND   Could not find the TLV with Type @p aType.
-     * @retval OT_ERROR_PARSE       TLV was found but it was not well-formed and could not be parsed.
-     *
-     */
-    static otError FindUint16Tlv(const Message &aMessage, uint8_t aType, uint16_t &aValue);
-
-    /**
-     * This static method searches for a TLV with a given type in a message and reads its value as an `uint32_t`.
-     *
-     * @param[in]   aMessage        A reference to the message.
-     * @param[in]   aType           The TLV type to search for.
-     * @param[out]  aValue          A reference to a `uint32_t` to output the TLV's value.
-     *
-     * @retval OT_ERROR_NONE        Successfully found the TLV and updated @p aValue.
-     * @retval OT_ERROR_NOT_FOUND   Could not find the TLV with Type @p aType.
-     * @retval OT_ERROR_PARSE       TLV was found but it was not well-formed and could not be parsed.
-     *
-     */
-    static otError FindUint32Tlv(const Message &aMessage, uint8_t aType, uint32_t &aValue);
-
-    /**
      * This static method searches for a TLV with a given type in a message, ensures its length is same or larger than
      * an expected minimum value, and then reads its value into a given buffer.
      *
@@ -327,6 +304,8 @@ public:
      *
      * If the TLV length is larger than @p aLength, the TLV is considered valid, but only the first @p aLength bytes
      * of the value are read and copied into the @p aValue buffer.
+     *
+     * @tparam       TlvType     The TLV type to find.
      *
      * @param[in]    aMessage    A reference to the message.
      * @param[in]    aType       The TLV type to search for.
@@ -338,60 +317,69 @@ public:
      * @retval OT_ERROR_PARSE      TLV was found but it was not well-formed and could not be parsed.
      *
      */
-    static otError FindTlv(const Message &aMessage, uint8_t aType, void *aValue, uint8_t aLength);
+    template <typename TlvType> static otError Find(const Message &aMessage, void *aValue, uint8_t aLength)
+    {
+        return FindTlv(aMessage, TlvType::kType, aValue, aLength);
+    }
 
     /**
-     * This static method appends a simple TLV with a given type and an `uint8_t` value to a message.
+     * This static method searches for a simple TLV with a single non-integral value in a message, ensures its length is
+     * same or larger than the expected `ValueType` object size, and then reads its value into a value object reference.
      *
-     * On success this method grows the message by the size of the TLV.
+     * If the TLV length is smaller than the size of @p aValue, the TLV is considered invalid. In this case, this
+     * method returns `OT_ERROR_PARSE` and the @p aValue is not updated.
      *
-     * @param[in]  aMessage      A reference to the message to append to.
-     * @param[in]  aType         The TLV type.
-     * @param[in]  aValue        The TLV value (`uint8_t`).
+     * If the TLV length is larger than the size of @p aValue, the TLV is considered valid, but the size of
+     * `ValueType` bytes are read and copied into the @p aValue.
      *
-     * @retval OT_ERROR_NONE     Successfully appended the TLV to the message.
-     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
+     * @tparam       SimpleTlvType   The simple TLV type to find (must be a sub-class of `SimpleTlvInfo`)
+     *
+     * @param[in]    aMessage        A reference to the message.
+     * @param[in]    aType           The TLV type to search for.
+     * @param[out]   aValue          A reference to the value object to output the read value.
+     *
+     * @retval OT_ERROR_NONE         The TLV was found and read successfully. @p aValue is updated.
+     * @retval OT_ERROR_NOT_FOUND    Could not find the TLV with Type @p aType.
+     * @retval OT_ERROR_PARSE        TLV was found but it was not well-formed and could not be parsed.
      *
      */
-    static otError AppendUint8Tlv(Message &aMessage, uint8_t aType, uint8_t aValue);
+    template <typename SimpleTlvType>
+    static otError Find(const Message &aMessage, typename SimpleTlvType::ValueType &aValue)
+    {
+        return FindTlv(aMessage, SimpleTlvType::kType, &aValue, sizeof(aValue));
+    }
 
     /**
-     * This static method appends a simple TLV with a given type and an `uint16_t` value to a message.
+     * This static method searches for a simple TLV with a single integral value in a message, and then reads its value
+     * into a given `uint` reference variable.
      *
-     * On success this method grows the message by the size of the TLV.
+     * If the TLV length is smaller than size of integral value, the TLV is considered invalid. In this case, this
+     * method returns `OT_ERROR_PARSE` and the @p aValue is not updated.
      *
-     * @param[in]  aMessage      A reference to the message to append to.
-     * @param[in]  aType         The TLV type.
-     * @param[in]  aValue        The TLV value (`uint16_t`).
+     * @tparam       UintTlvType     The simple TLV type to find (must be a sub-class of `UintTlvInfo`)
      *
-     * @retval OT_ERROR_NONE     Successfully appended the TLV to the message.
-     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
+     * @param[in]    aMessage        A reference to the message.
+     * @param[out]   aValue          A reference to an unsigned int value to output the TLV's value.
      *
-     */
-    static otError AppendUint16Tlv(Message &aMessage, uint8_t aType, uint16_t aValue);
-
-    /**
-     * This static method appends a (simple) TLV with a given type and an `uint32_t` value to a message.
-     *
-     * On success this method grows the message by the size of the TLV.
-     *
-     * @param[in]  aMessage      A reference to the message to append to.
-     * @param[in]  aType         The TLV type.
-     * @param[in]  aValue        The TLV value (`uint32_t`).
-     *
-     * @retval OT_ERROR_NONE     Successfully appended the TLV to the message.
-     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
+     * @retval OT_ERROR_NONE         The TLV was found and read successfully. @p aValue is updated.
+     * @retval OT_ERROR_NOT_FOUND    Could not find the TLV with Type @p aType.
+     * @retval OT_ERROR_PARSE        TLV was found but it was not well-formed and could not be parsed.
      *
      */
-    static otError AppendUint32Tlv(Message &aMessage, uint8_t aType, uint32_t aValue);
+    template <typename UintTlvType>
+    static otError Find(const Message &aMessage, typename UintTlvType::UintValueType &aValue)
+    {
+        return FindUintTlv(aMessage, UintTlvType::kType, aValue);
+    }
 
     /**
      * This static method appends a TLV with a given type and value to a message.
      *
      * On success this method grows the message by the size of the TLV.
      *
+     * @tparam     TlvType       The TLV type to append.
+     *
      * @param[in]  aMessage      A reference to the message to append to.
-     * @param[in]  aType         The TLV type.
      * @param[in]  aValue        A buffer containing the TLV value.
      * @param[in]  aLength       The value length (in bytes).
      *
@@ -399,7 +387,49 @@ public:
      * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
      *
      */
-    static otError AppendTlv(Message &aMessage, uint8_t aType, const void *aValue, uint8_t aLength);
+    template <typename TlvType> static otError Append(Message &aMessage, const void *aValue, uint8_t aLength)
+    {
+        return AppendTlv(aMessage, TlvType::kType, aValue, aLength);
+    }
+
+    /**
+     * This static method appends a simple TLV with a single (non-integral) value to a message.
+     *
+     * On success this method grows the message by the size of the TLV.
+     *
+     * @tparam     SimpleTlvType The simple TLV type to append (must be a sub-class of `SimpleTlvInfo`)
+     *
+     * @param[in]  aMessage      A reference to the message to append to.
+     * @param[in]  aValue        A reference to the object containing TLV's value.
+     *
+     * @retval OT_ERROR_NONE     Successfully appended the TLV to the message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
+     *
+     */
+    template <typename SimpleTlvType>
+    static otError Append(Message &aMessage, const typename SimpleTlvType::ValueType &aValue)
+    {
+        return AppendTlv(aMessage, SimpleTlvType::kType, &aValue, sizeof(aValue));
+    }
+
+    /**
+     * This static method appends a simple TLV with a single integral value to a message.
+     *
+     * On success this method grows the message by the size of the TLV.
+     *
+     * @tparam     UintTlvType   The simple TLV type to append (must be a sub-class of `UintTlvInfo`)
+     *
+     * @param[in]  aMessage      A reference to the message to append to.
+     * @param[in]  aValue        An unsigned int value to use as TLV's value.
+     *
+     * @retval OT_ERROR_NONE     Successfully appended the TLV to the message.
+     * @retval OT_ERROR_NO_BUFS  Insufficient available buffers to grow the message.
+     *
+     */
+    template <typename UintTlvType> static otError Append(Message &aMessage, typename UintTlvType::UintValueType aValue)
+    {
+        return AppendUintTlv(aMessage, UintTlvType::kType, aValue);
+    }
 
 protected:
     enum
@@ -431,6 +461,13 @@ private:
                         uint16_t *     aSize,
                         bool *         aIsExtendedTlv);
 
+    static otError FindTlv(const Message &aMessage, uint8_t aType, void *aValue, uint8_t aLength);
+    static otError AppendTlv(Message &aMessage, uint8_t aType, const void *aValue, uint8_t aLength);
+    template <typename UintType>
+    static otError ReadUintTlv(const Message &aMessage, uint16_t aOffset, UintType &aValue);
+    template <typename UintType> static otError FindUintTlv(const Message &aMessage, uint8_t aTyle, UintType &aValue);
+    template <typename UintType> static otError AppendUintTlv(Message &aMessage, uint8_t aType, UintType aValue);
+
     uint8_t mType;
     uint8_t mLength;
 } OT_TOOL_PACKED_END;
@@ -460,6 +497,65 @@ public:
 private:
     uint16_t mLength;
 } OT_TOOL_PACKED_END;
+
+/**
+ * This class defines constants for a TLV.
+ *
+ * @tparam kTlvTypeValue   The TLV Type value.
+ *
+ */
+template <uint8_t kTlvTypeValue> class TlvInfo
+{
+public:
+    enum : uint8_t
+    {
+        kType = kTlvTypeValue, ///< The TLV Type value.
+    };
+};
+
+/**
+ * This class defines constants and types for a simple TLV with an unsigned int value type.
+ *
+ * This class and its sub-classes are intended to be used as the template type in `Tlv::Append<UintTlvType>()`, and
+ * the related `Tlv::FindTlv()` and `Tlv::ReadTlv()`.
+ *
+ * @tparam kTlvTypeValue   The TLV Type value.
+ * @tparam UintType        The TLV Value's type (must be an unsigned int, i.e. uint8_t, uint16_t, or uint32_t).
+ *
+ */
+template <uint8_t kTlvTypeValue, typename UintType> class UintTlvInfo : public TlvInfo<kTlvTypeValue>
+{
+public:
+    static_assert(TypeTraits::IsSame<UintType, uint8_t>::kValue || TypeTraits::IsSame<UintType, uint16_t>::kValue ||
+                      TypeTraits::IsSame<UintType, uint32_t>::kValue,
+                  "UintTlv must be used used with unsigned int value type");
+
+    typedef UintType UintValueType; ///< The TLV Value unsigned int type.
+};
+
+/**
+ * This class defines constants and types for a simple TLV with a single value.
+ *
+ * This class and its sub-classes are intended to be used as the template type in `Tlv::Append<SimpleTlvType>()`,
+ * and the related `Tlv::FindTlv()` and `Tlv::ReadTlv()`.
+ *
+ * @tparam kTlvTypeValue   The TLV Type value.
+ * @tparam TlvValueType    The TLV Value's type (must not be an integral type).
+ *
+ */
+template <uint8_t kTlvTypeValue, typename TlvValueType> class SimpleTlvInfo : public TlvInfo<kTlvTypeValue>
+{
+public:
+    static_assert(!TypeTraits::IsPointer<TlvValueType>::kValue, "TlvValueType must not be a pointer");
+    static_assert(!TypeTraits::IsSame<TlvValueType, uint8_t>::kValue, "SimpleTlv must not use int value type");
+    static_assert(!TypeTraits::IsSame<TlvValueType, uint16_t>::kValue, "SimpleTlv must not use int value type");
+    static_assert(!TypeTraits::IsSame<TlvValueType, uint32_t>::kValue, "SimpleTlv must not use int value type");
+    static_assert(!TypeTraits::IsSame<TlvValueType, int8_t>::kValue, "SimpleTlv must not use int value type");
+    static_assert(!TypeTraits::IsSame<TlvValueType, int16_t>::kValue, "SimpleTlv must not use int value type");
+    static_assert(!TypeTraits::IsSame<TlvValueType, int32_t>::kValue, "SimpleTlv must not use int value type");
+
+    typedef TlvValueType ValueType; ///< The TLV Value type.
+};
 
 } // namespace ot
 

--- a/src/core/common/type_traits.hpp
+++ b/src/core/common/type_traits.hpp
@@ -86,6 +86,24 @@ template <typename Type> struct IsPointer<const volatile Type *> : TrueValue
 {
 };
 
+/**
+ * This type indicates whether or not a given template `FirstType is the same as `SecondType`.
+ *
+ * The `constexpr` expression `IsSame<FirstType, SecondType>::kValue` would be `true` when the two types are the same,
+ * otherwise it would be `false`.
+ *
+ * @tparam FirstType     The first type.
+ * @tparam SecondType    The second type.
+ *
+ */
+template <typename FirstType, typename SecondType> struct IsSame : public FalseValue
+{
+};
+
+template <typename Type> struct IsSame<Type, Type> : public TrueValue
+{
+};
+
 } // namespace TypeTraits
 } // namespace ot
 

--- a/src/core/meshcop/announce_begin_client.cpp
+++ b/src/core/meshcop/announce_begin_client.cpp
@@ -69,15 +69,15 @@ otError AnnounceBeginClient::SendRequest(uint32_t            aChannelMask,
     SuccessOrExit(error = message->InitAsPost(aAddress, UriPath::kAnnounceBegin));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, MeshCoP::Tlv::kCommissionerSessionId,
-                                               Get<MeshCoP::Commissioner>().GetSessionId()));
+    SuccessOrExit(
+        error = Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, Get<MeshCoP::Commissioner>().GetSessionId()));
 
     channelMask.Init();
     channelMask.SetChannelMask(aChannelMask);
     SuccessOrExit(error = channelMask.AppendTo(*message));
 
-    SuccessOrExit(error = Tlv::AppendUint8Tlv(*message, MeshCoP::Tlv::kCount, aCount));
-    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, MeshCoP::Tlv::kPeriod, aPeriod));
+    SuccessOrExit(error = Tlv::Append<MeshCoP::CountTlv>(*message, aCount));
+    SuccessOrExit(error = Tlv::Append<MeshCoP::PeriodTlv>(*message, aPeriod));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerAddr(aAddress);

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -487,8 +487,7 @@ otError DatasetManager::SendSetRequest(const Dataset::Info &aDatasetInfo, const 
 
         if (!hasSessionId)
         {
-            SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, Tlv::kCommissionerSessionId,
-                                                       Get<Commissioner>().GetSessionId()));
+            SuccessOrExit(error = Tlv::Append<CommissionerSessionIdTlv>(*message, Get<Commissioner>().GetSessionId()));
         }
     }
 

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -107,14 +107,14 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
 
     type = (GetType() == Dataset::kActive) ? Tlv::kActiveTimestamp : Tlv::kPendingTimestamp;
 
-    if (Tlv::FindTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) != OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, activeTimestamp) != OT_ERROR_NONE)
     {
         ExitNow();
     }
 
     VerifyOrExit(activeTimestamp.IsValid());
 
-    if (Tlv::FindTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, pendingTimestamp) == OT_ERROR_NONE)
     {
         VerifyOrExit(pendingTimestamp.IsValid());
     }
@@ -126,7 +126,7 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
     VerifyOrExit(mLocal.Compare(timestamp) > 0);
 
     // check channel
-    if (Tlv::FindTlv(aMessage, Tlv::kChannel, sizeof(channel), channel) == OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, channel) == OT_ERROR_NONE)
     {
         VerifyOrExit(channel.IsValid());
 
@@ -137,20 +137,20 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
     }
 
     // check PAN ID
-    if (Tlv::FindUint16Tlv(aMessage, Tlv::kPanId, panId) == OT_ERROR_NONE && panId != Get<Mac::Mac>().GetPanId())
+    if (Tlv::Find<PanIdTlv>(aMessage, panId) == OT_ERROR_NONE && panId != Get<Mac::Mac>().GetPanId())
     {
         doesAffectConnectivity = true;
     }
 
     // check mesh local prefix
-    if (Tlv::FindTlv(aMessage, Tlv::kMeshLocalPrefix, &meshLocalPrefix, sizeof(meshLocalPrefix)) == OT_ERROR_NONE &&
+    if (Tlv::Find<MeshLocalPrefixTlv>(aMessage, meshLocalPrefix) == OT_ERROR_NONE &&
         meshLocalPrefix != Get<Mle::MleRouter>().GetMeshLocalPrefix())
     {
         doesAffectConnectivity = true;
     }
 
     // check network master key
-    if (Tlv::FindTlv(aMessage, Tlv::kNetworkMasterKey, &masterKey, sizeof(masterKey)) == OT_ERROR_NONE)
+    if (Tlv::Find<NetworkMasterKeyTlv>(aMessage, masterKey) == OT_ERROR_NONE)
     {
         hasMasterKey = true;
 
@@ -171,7 +171,7 @@ otError DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInf
     }
 
     // check commissioner session id
-    if (Tlv::FindUint16Tlv(aMessage, Tlv::kCommissionerSessionId, sessionId) == OT_ERROR_NONE)
+    if (Tlv::Find<CommissionerSessionIdTlv>(aMessage, sessionId) == OT_ERROR_NONE)
     {
         const CommissionerSessionIdTlv *localId;
 
@@ -281,7 +281,7 @@ void DatasetManager::SendSetResponse(const Coap::Message &   aRequest,
     SuccessOrExit(error = message->SetDefaultResponseHeader(aRequest));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = Tlv::AppendUint8Tlv(*message, Tlv::kState, static_cast<uint8_t>(aState)));
+    SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));
 
     SuccessOrExit(error = Get<Tmf::TmfAgent>().SendMessage(*message, aMessageInfo));
 

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -77,16 +77,16 @@ otError EnergyScanClient::SendQuery(uint32_t                           aChannelM
     SuccessOrExit(error = message->InitAsPost(aAddress, UriPath::kEnergyScan));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, MeshCoP::Tlv::kCommissionerSessionId,
-                                               Get<MeshCoP::Commissioner>().GetSessionId()));
+    SuccessOrExit(
+        error = Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, Get<MeshCoP::Commissioner>().GetSessionId()));
 
     channelMask.Init();
     channelMask.SetChannelMask(aChannelMask);
     SuccessOrExit(error = channelMask.AppendTo(*message));
 
-    SuccessOrExit(error = Tlv::AppendUint8Tlv(*message, MeshCoP::Tlv::kCount, aCount));
-    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, MeshCoP::Tlv::kPeriod, aPeriod));
-    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, MeshCoP::Tlv::kScanDuration, aScanDuration));
+    SuccessOrExit(error = Tlv::Append<MeshCoP::CountTlv>(*message, aCount));
+    SuccessOrExit(error = Tlv::Append<MeshCoP::PeriodTlv>(*message, aPeriod));
+    SuccessOrExit(error = Tlv::Append<MeshCoP::ScanDurationTlv>(*message, aScanDuration));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerAddr(aAddress);

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -441,7 +441,7 @@ otError Joiner::PrepareJoinerFinalizeMessage(const char *aProvisioningUrl,
     SuccessOrExit(error = mFinalizeMessage->SetPayloadMarker());
     mFinalizeMessage->SetOffset(mFinalizeMessage->GetLength());
 
-    SuccessOrExit(error = Tlv::AppendUint8Tlv(*mFinalizeMessage, Tlv::kState, StateTlv::kAccept));
+    SuccessOrExit(error = Tlv::Append<StateTlv>(*mFinalizeMessage, StateTlv::kAccept));
 
     vendorNameTlv.Init();
     vendorNameTlv.SetVendorName(aVendorName);
@@ -535,7 +535,7 @@ void Joiner::HandleJoinerFinalizeResponse(Coap::Message &         aMessage,
     VerifyOrExit(mState == kStateConnected && aResult == OT_ERROR_NONE && aMessage.IsAck() &&
                  aMessage.GetCode() == Coap::kCodeChanged);
 
-    SuccessOrExit(Tlv::FindUint8Tlv(aMessage, Tlv::kState, state));
+    SuccessOrExit(Tlv::Find<StateTlv>(aMessage, state));
 
     SetState(kStateEntrust);
     mTimer.Start(kReponseTimeout);
@@ -569,8 +569,7 @@ void Joiner::HandleJoinerEntrust(Coap::Message &aMessage, const Ip6::MessageInfo
 
     datasetInfo.Clear();
 
-    SuccessOrExit(
-        error = Tlv::FindTlv(aMessage, Tlv::kNetworkMasterKey, &datasetInfo.UpdateMasterKey(), sizeof(MasterKey)));
+    SuccessOrExit(error = Tlv::Find<NetworkMasterKeyTlv>(aMessage, datasetInfo.UpdateMasterKey()));
 
     datasetInfo.SetChannel(Get<Mac::Mac>().GetPanChannel());
     datasetInfo.SetPanId(Get<Mac::Mac>().GetPanId());

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -81,7 +81,7 @@ void Leader::HandlePetition(Coap::Message &aMessage, const Ip6::MessageInfo &aMe
     otLogInfoMeshCoP("received petition");
 
     VerifyOrExit(Get<Mle::MleRouter>().IsRoutingLocator(aMessageInfo.GetPeerAddr()));
-    SuccessOrExit(Tlv::FindTlv(aMessage, Tlv::kCommissionerId, sizeof(commissionerId), commissionerId));
+    SuccessOrExit(Tlv::FindTlv(aMessage, commissionerId));
 
     if (mTimer.IsRunning())
     {
@@ -131,7 +131,7 @@ void Leader::SendPetitionResponse(const Coap::Message &   aRequest,
     SuccessOrExit(error = message->SetDefaultResponseHeader(aRequest));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = Tlv::AppendUint8Tlv(*message, Tlv::kState, static_cast<uint8_t>(aState)));
+    SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));
 
     if (mTimer.IsRunning())
     {
@@ -140,7 +140,7 @@ void Leader::SendPetitionResponse(const Coap::Message &   aRequest,
 
     if (aState == StateTlv::kAccept)
     {
-        SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, Tlv::kCommissionerSessionId, mSessionId));
+        SuccessOrExit(error = Tlv::Append<CommissionerSessionIdTlv>(*message, mSessionId));
     }
 
     SuccessOrExit(error = Get<Tmf::TmfAgent>().SendMessage(*message, aMessageInfo));
@@ -167,9 +167,9 @@ void Leader::HandleKeepAlive(Coap::Message &aMessage, const Ip6::MessageInfo &aM
 
     otLogInfoMeshCoP("received keep alive");
 
-    SuccessOrExit(Tlv::FindUint8Tlv(aMessage, Tlv::kState, state));
+    SuccessOrExit(Tlv::Find<StateTlv>(aMessage, state));
 
-    SuccessOrExit(Tlv::FindUint16Tlv(aMessage, Tlv::kCommissionerSessionId, sessionId));
+    SuccessOrExit(Tlv::Find<CommissionerSessionIdTlv>(aMessage, sessionId));
 
     borderAgentLocator = static_cast<BorderAgentLocatorTlv *>(
         Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kBorderAgentLocator));
@@ -215,7 +215,7 @@ void Leader::SendKeepAliveResponse(const Coap::Message &   aRequest,
     SuccessOrExit(error = message->SetDefaultResponseHeader(aRequest));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = Tlv::AppendUint8Tlv(*message, Tlv::kState, static_cast<uint8_t>(aState)));
+    SuccessOrExit(error = Tlv::Append<StateTlv>(*message, aState));
 
     SuccessOrExit(error = Get<Tmf::TmfAgent>().SendMessage(*message, aMessageInfo));
 

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -103,7 +103,7 @@ public:
         kVendorData              = OT_MESHCOP_TLV_VENDOR_DATA_TLV,          ///< meshcop Vendor Data TLV
         kVendorStackVersion      = OT_MESHCOP_TLV_VENDOR_STACK_VERSION_TLV, ///< meshcop Vendor Stack Version TLV
         kUdpEncapsulation        = OT_MESHCOP_TLV_UDP_ENCAPSULATION_TLV,    ///< meshcop UDP encapsulation TLV
-        kIPv6Address             = OT_MESHCOP_TLV_IPV6_ADDRESS_TLV,         ///< meshcop IPv6 address TLV
+        kIp6Address              = OT_MESHCOP_TLV_IPV6_ADDRESS_TLV,         ///< meshcop IPv6 address TLV
         kPendingTimestamp        = OT_MESHCOP_TLV_PENDINGTIMESTAMP,         ///< Pending Timestamp TLV
         kDelayTimer              = OT_MESHCOP_TLV_DELAYTIMER,               ///< Delay Timer TLV
         kChannelMask             = OT_MESHCOP_TLV_CHANNELMASK,              ///< Channel Mask TLV
@@ -166,28 +166,23 @@ public:
     }
 
     /**
-     * This static method searches for a TLV with a given type in a message, ensures its length is same or larger than
-     * an expected minimum value, and then reads its value into a given buffer.
+     * This static method reads the requested TLV out of @p aMessage.
      *
-     * If the TLV length is smaller than the minimum length @p aLength, the TLV is considered invalid. In this case,
-     * this method returns `OT_ERROR_PARSE` and the @p aValue buffer is not updated.
+     * This method can be used independent of whether the read TLV (from message) is an Extended TLV or not.
      *
-     * If the TLV length is larger than @p aLength, the TLV is considered valid, but only the first @p aLength bytes
-     * of the value are read and copied into the @p aValue buffer.
+     * @tparam      TlvType     The TlvType to search for (must be a sub-class of `Tlv`).
      *
-     * @param[in]    aMessage    A reference to the message.
-     * @param[in]    aType       The TLV type to search for.
-     * @param[out]   aValue      A buffer to output the value (must contain at least @p aLength bytes).
-     * @param[in]    aLength     The expected (minimum) length of the TLV value.
+     * @param[in]   aMessage    A reference to the message.
+     * @param[out]  aTlv        A reference to the TLV that will be copied to.
      *
-     * @retval OT_ERROR_NONE       The TLV was found and read successfully. @p aValue is updated.
+     * @retval OT_ERROR_NONE       Successfully copied the TLV.
      * @retval OT_ERROR_NOT_FOUND  Could not find the TLV with Type @p aType.
-     * @retval OT_ERROR_PARSE      TLV was found but it was not well-formed and could not be parsed.
      *
      */
-    static otError FindTlv(const Message &aMessage, Type aType, void *aValue, uint8_t aLength)
+
+    template <typename TlvType> static otError FindTlv(const Message &aMessage, TlvType &aTlv)
     {
-        return ot::Tlv::FindTlv(aMessage, aType, aValue, aLength);
+        return ot::Tlv::FindTlv(aMessage, aTlv);
     }
 
     /**
@@ -285,18 +280,61 @@ public:
 } OT_TOOL_PACKED_END;
 
 /**
+ * This class defines Commissioner UDP Port TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kCommissionerUdpPort, uint16_t> CommissionerUdpPortTlv;
+
+/**
+ * This class defines IPv6 Address TLV constants and types.
+ *
+ */
+typedef SimpleTlvInfo<Tlv::kIp6Address, Ip6::Address> Ip6AddressTlv;
+
+/**
+ * This class defines Joiner IID TLV constants and types.
+ *
+ */
+typedef SimpleTlvInfo<Tlv::kJoinerIid, Ip6::InterfaceIdentifier> JoinerIidTlv;
+
+/**
+ * This class defines Joiner Router Locator TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kJoinerRouterLocator, uint16_t> JoinerRouterLocatorTlv;
+
+/**
+ * This class defines Joiner Router KEK TLV constants and types.
+ *
+ */
+typedef SimpleTlvInfo<Tlv::kJoinerRouterKek, Kek> JoinerRouterKekTlv;
+
+/**
+ * This class defines Count TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kCount, uint8_t> CountTlv;
+
+/**
+ * This class defines Period TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kPeriod, uint16_t> PeriodTlv;
+
+/**
+ * This class defines Scan Duration TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kScanDuration, uint16_t> ScanDurationTlv;
+
+/**
  * This class implements Channel TLV generation and parsing.
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ChannelTlv : public Tlv
+class ChannelTlv : public Tlv, public TlvInfo<Tlv::kChannel>
 {
 public:
-    enum
-    {
-        kType = kChannel, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -359,14 +397,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class PanIdTlv : public Tlv
+class PanIdTlv : public Tlv, public UintTlvInfo<Tlv::kPanId, uint16_t>
 {
 public:
-    enum
-    {
-        kType = kPanId, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -411,14 +444,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ExtendedPanIdTlv : public Tlv
+class ExtendedPanIdTlv : public Tlv, public SimpleTlvInfo<Tlv::kExtendedPanId, Mac::ExtendedPanId>
 {
 public:
-    enum
-    {
-        kType = kExtendedPanId, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -463,14 +491,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class NetworkNameTlv : public Tlv
+class NetworkNameTlv : public Tlv, public TlvInfo<Tlv::kNetworkName>
 {
 public:
-    enum
-    {
-        kType = kNetworkName, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -515,14 +538,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class PskcTlv : public Tlv
+class PskcTlv : public Tlv, public SimpleTlvInfo<Tlv::kPskc, Pskc>
 {
 public:
-    enum
-    {
-        kType = kPskc, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -567,14 +585,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class NetworkMasterKeyTlv : public Tlv
+class NetworkMasterKeyTlv : public Tlv, public SimpleTlvInfo<Tlv::kNetworkMasterKey, MasterKey>
 {
 public:
-    enum
-    {
-        kType = kNetworkMasterKey, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -619,14 +632,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class NetworkKeySequenceTlv : public Tlv
+class NetworkKeySequenceTlv : public Tlv, public UintTlvInfo<Tlv::kNetworkKeySequence, uint32_t>
 {
 public:
-    enum
-    {
-        kType = kNetworkKeySequence, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -671,14 +679,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class MeshLocalPrefixTlv : public Tlv
+class MeshLocalPrefixTlv : public Tlv, public SimpleTlvInfo<Tlv::kMeshLocalPrefix, Mle::MeshLocalPrefix>
 {
 public:
-    enum
-    {
-        kType = kMeshLocalPrefix, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -733,14 +736,9 @@ class SteeringData;
  *
  */
 OT_TOOL_PACKED_BEGIN
-class SteeringDataTlv : public Tlv
+class SteeringDataTlv : public Tlv, public TlvInfo<Tlv::kSteeringData>
 {
 public:
-    enum
-    {
-        kType = kSteeringData, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -795,14 +793,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class BorderAgentLocatorTlv : public Tlv
+class BorderAgentLocatorTlv : public Tlv, public UintTlvInfo<Tlv::kBorderAgentLocator, uint16_t>
 {
 public:
-    enum
-    {
-        kType = kBorderAgentLocator, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -847,13 +840,12 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class CommissionerIdTlv : public Tlv
+class CommissionerIdTlv : public Tlv, public TlvInfo<Tlv::kCommissionerId>
 {
 public:
     enum
     {
-        kType      = kCommissionerId, ///< The TLV Type.
-        kMaxLength = 64,              ///< maximum length (bytes)
+        kMaxLength = 64, ///< maximum length (bytes)
     };
 
     /**
@@ -907,7 +899,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class CommissionerSessionIdTlv : public Tlv
+class CommissionerSessionIdTlv : public Tlv, public UintTlvInfo<Tlv::kCommissionerSessionId, uint16_t>
 {
 public:
     enum
@@ -959,14 +951,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class SecurityPolicyTlv : public Tlv
+class SecurityPolicyTlv : public Tlv, public TlvInfo<Tlv::kSecurityPolicy>
 {
 public:
-    enum
-    {
-        kType = kSecurityPolicy, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -1037,14 +1024,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ActiveTimestampTlv : public Tlv, public Timestamp
+class ActiveTimestampTlv : public Tlv, public Timestamp, public SimpleTlvInfo<Tlv::kActiveTimestamp, Timestamp>
 {
 public:
-    enum
-    {
-        kType = kActiveTimestamp, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -1071,14 +1053,9 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class StateTlv : public Tlv
+class StateTlv : public Tlv, public UintTlvInfo<Tlv::kState, uint8_t>
 {
 public:
-    enum
-    {
-        kType = kState, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -1102,7 +1079,7 @@ public:
      * State values.
      *
      */
-    enum State
+    enum State : uint8_t
     {
         kReject  = 0xff, ///< Reject (-1)
         kPending = 0,    ///< Pending
@@ -1134,14 +1111,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class JoinerUdpPortTlv : public Tlv
+class JoinerUdpPortTlv : public Tlv, public UintTlvInfo<Tlv::kJoinerUdpPort, uint16_t>
 {
 public:
-    enum
-    {
-        kType = kJoinerUdpPort, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -1186,14 +1158,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class PendingTimestampTlv : public Tlv, public Timestamp
+class PendingTimestampTlv : public Tlv, public Timestamp, public SimpleTlvInfo<Tlv::kPendingTimestamp, Timestamp>
 {
 public:
-    enum
-    {
-        kType = kPendingTimestamp, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -1220,14 +1187,9 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class DelayTimerTlv : public Tlv
+class DelayTimerTlv : public Tlv, public UintTlvInfo<Tlv::kDelayTimer, uint32_t>
 {
 public:
-    enum
-    {
-        kType = kDelayTimer, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -1450,14 +1412,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ChannelMaskBaseTlv : public Tlv
+class ChannelMaskBaseTlv : public Tlv, public TlvInfo<Tlv::kChannelMask>
 {
 public:
-    enum
-    {
-        kType = kChannelMask, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -1553,14 +1510,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class EnergyListTlv : public Tlv
+class EnergyListTlv : public Tlv, public TlvInfo<Tlv::kEnergyList>
 {
 public:
-    enum
-    {
-        kType = kEnergyList, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -1586,12 +1538,11 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ProvisioningUrlTlv : public Tlv
+class ProvisioningUrlTlv : public Tlv, public TlvInfo<Tlv::kProvisioningUrl>
 {
 public:
     enum
     {
-        kType      = kProvisioningUrl,             ///< The TLV Type.
         kMaxLength = OT_PROVISIONING_URL_MAX_SIZE, ///< Maximum number of chars in the Provisioning URL string.
     };
 
@@ -1663,14 +1614,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class VendorNameTlv : public Tlv
+class VendorNameTlv : public Tlv, public TlvInfo<Tlv::kVendorName>
 {
 public:
-    enum
-    {
-        kType = kVendorName, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -1732,14 +1678,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class VendorModelTlv : public Tlv
+class VendorModelTlv : public Tlv, public TlvInfo<Tlv::kVendorModel>
 {
 public:
-    enum
-    {
-        kType = kVendorModel, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -1801,14 +1742,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class VendorSwVersionTlv : public Tlv
+class VendorSwVersionTlv : public Tlv, public TlvInfo<Tlv::kVendorSwVersion>
 {
 public:
-    enum
-    {
-        kType = kVendorSwVersion, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -1870,14 +1806,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class VendorDataTlv : public Tlv
+class VendorDataTlv : public Tlv, public TlvInfo<Tlv::kVendorData>
 {
 public:
-    enum
-    {
-        kType = kVendorData, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -1939,14 +1870,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class VendorStackVersionTlv : public Tlv
+class VendorStackVersionTlv : public Tlv, public TlvInfo<Tlv::kVendorStackVersion>
 {
 public:
-    enum
-    {
-        kType = kVendorStackVersion, ///< The TLV Type.
-    };
-
     /**
      * Default constructor.
      *
@@ -2096,14 +2022,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class UdpEncapsulationTlv : public ExtendedTlv
+class UdpEncapsulationTlv : public ExtendedTlv, public TlvInfo<MeshCoP::Tlv::kUdpEncapsulation>
 {
 public:
-    enum
-    {
-        kType = MeshCoP::Tlv::kUdpEncapsulation, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -2181,14 +2102,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class DiscoveryRequestTlv : public Tlv
+class DiscoveryRequestTlv : public Tlv, public TlvInfo<Tlv::kDiscoveryRequest>
 {
 public:
-    enum
-    {
-        kType = kDiscoveryRequest, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -2273,14 +2189,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class DiscoveryResponseTlv : public Tlv
+class DiscoveryResponseTlv : public Tlv, public TlvInfo<Tlv::kDiscoveryResponse>
 {
 public:
-    enum
-    {
-        kType = kDiscoveryResponse, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -2365,12 +2276,11 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class JoinerAdvertisementTlv : public Tlv
+class JoinerAdvertisementTlv : public Tlv, public TlvInfo<Tlv::kJoinerAdvertisement>
 {
 public:
     enum
     {
-        kType             = kJoinerAdvertisement,         ///< The TLV Type.
         kAdvDataMaxLength = OT_JOINER_ADVDATA_MAX_LENGTH, ///< The Max Length of AdvData
     };
 

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -74,14 +74,14 @@ otError PanIdQueryClient::SendQuery(uint16_t                            aPanId,
     SuccessOrExit(error = message->InitAsPost(aAddress, UriPath::kPanIdQuery));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, MeshCoP::Tlv::kCommissionerSessionId,
-                                               Get<MeshCoP::Commissioner>().GetSessionId()));
+    SuccessOrExit(
+        error = Tlv::Append<MeshCoP::CommissionerSessionIdTlv>(*message, Get<MeshCoP::Commissioner>().GetSessionId()));
 
     channelMask.Init();
     channelMask.SetChannelMask(aChannelMask);
     SuccessOrExit(error = channelMask.AppendTo(*message));
 
-    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, MeshCoP::Tlv::kPanId, aPanId));
+    SuccessOrExit(error = Tlv::Append<MeshCoP::PanIdTlv>(*message, aPanId));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerAddr(aAddress);
@@ -114,7 +114,7 @@ void PanIdQueryClient::HandleConflict(Coap::Message &aMessage, const Ip6::Messag
 
     otLogInfoMeshCoP("received panid conflict");
 
-    SuccessOrExit(Tlv::FindUint16Tlv(aMessage, MeshCoP::Tlv::kPanId, panId));
+    SuccessOrExit(Tlv::Find<MeshCoP::PanIdTlv>(aMessage, panId));
 
     VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -533,7 +533,7 @@ otError AddressResolver::SendAddressQuery(const Ip6::Address &aEid)
     SuccessOrExit(error = message->AppendUriPathOptions(UriPath::kAddressQuery));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kTarget, &aEid, sizeof(aEid)));
+    SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, aEid));
 
     messageInfo.GetPeerAddr().SetToRealmLocalAllRoutersMulticast();
 
@@ -581,11 +581,11 @@ void AddressResolver::HandleAddressNotification(Coap::Message &aMessage, const I
 
     VerifyOrExit(aMessage.IsConfirmablePostRequest());
 
-    SuccessOrExit(Tlv::FindTlv(aMessage, ThreadTlv::kTarget, &target, sizeof(target)));
-    SuccessOrExit(Tlv::FindTlv(aMessage, ThreadTlv::kMeshLocalEid, &meshLocalIid, sizeof(meshLocalIid)));
-    SuccessOrExit(Tlv::FindUint16Tlv(aMessage, ThreadTlv::kRloc16, rloc16));
+    SuccessOrExit(Tlv::Find<ThreadTargetTlv>(aMessage, target));
+    SuccessOrExit(Tlv::Find<ThreadMeshLocalEidTlv>(aMessage, meshLocalIid));
+    SuccessOrExit(Tlv::Find<ThreadRloc16Tlv>(aMessage, rloc16));
 
-    switch (Tlv::FindUint32Tlv(aMessage, ThreadTlv::kLastTransactionTime, lastTransactionTime))
+    switch (Tlv::Find<ThreadLastTransactionTimeTlv>(aMessage, lastTransactionTime))
     {
     case OT_ERROR_NONE:
         break;
@@ -651,8 +651,8 @@ void AddressResolver::SendAddressError(const Ip6::Address &            aTarget,
     SuccessOrExit(error = message->AppendUriPathOptions(UriPath::kAddressError));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kTarget, &aTarget, sizeof(aTarget)));
-    SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kMeshLocalEid, &aMeshLocalIid, sizeof(aMeshLocalIid)));
+    SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, aTarget));
+    SuccessOrExit(error = Tlv::Append<ThreadMeshLocalEidTlv>(*message, aMeshLocalIid));
 
     if (aDestination == nullptr)
     {
@@ -705,8 +705,8 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
         }
     }
 
-    SuccessOrExit(error = Tlv::FindTlv(aMessage, ThreadTlv::kTarget, &target, sizeof(target)));
-    SuccessOrExit(error = Tlv::FindTlv(aMessage, ThreadTlv::kMeshLocalEid, &meshLocalIid, sizeof(meshLocalIid)));
+    SuccessOrExit(error = Tlv::Find<ThreadTargetTlv>(aMessage, target));
+    SuccessOrExit(error = Tlv::Find<ThreadMeshLocalEidTlv>(aMessage, meshLocalIid));
 
     for (const Ip6::NetifUnicastAddress *address = Get<ThreadNetif>().GetUnicastAddresses(); address;
          address                                 = address->GetNext())
@@ -773,7 +773,7 @@ void AddressResolver::HandleAddressQuery(Coap::Message &aMessage, const Ip6::Mes
 
     VerifyOrExit(aMessage.IsNonConfirmablePostRequest());
 
-    SuccessOrExit(Tlv::FindTlv(aMessage, ThreadTlv::kTarget, &target, sizeof(target)));
+    SuccessOrExit(Tlv::Find<ThreadTargetTlv>(aMessage, target));
 
     otLogInfoArp("Received address query from 0x%04x for target %s", aMessageInfo.GetPeerAddr().GetIid().GetLocator(),
                  target.ToString().AsCString());
@@ -830,13 +830,13 @@ void AddressResolver::SendAddressQueryResponse(const Ip6::Address &            a
     SuccessOrExit(error = message->AppendUriPathOptions(UriPath::kAddressNotify));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kTarget, &aTarget, sizeof(aTarget)));
-    SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kMeshLocalEid, &aMeshLocalIid, sizeof(aMeshLocalIid)));
-    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, ThreadTlv::kRloc16, Get<Mle::MleRouter>().GetRloc16()));
+    SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, aTarget));
+    SuccessOrExit(error = Tlv::Append<ThreadMeshLocalEidTlv>(*message, aMeshLocalIid));
+    SuccessOrExit(error = Tlv::Append<ThreadRloc16Tlv>(*message, Get<Mle::MleRouter>().GetRloc16()));
 
     if (aLastTransactionTime != nullptr)
     {
-        SuccessOrExit(error = Tlv::AppendUint32Tlv(*message, ThreadTlv::kLastTransactionTime, *aLastTransactionTime));
+        SuccessOrExit(error = Tlv::Append<ThreadLastTransactionTimeTlv>(*message, *aLastTransactionTime));
     }
 
     messageInfo.SetPeerAddr(aDestination);

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -75,8 +75,8 @@ void AnnounceBeginServer::HandleRequest(Coap::Message &aMessage, const Ip6::Mess
     VerifyOrExit(aMessage.IsPostRequest());
     VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
 
-    SuccessOrExit(Tlv::FindUint8Tlv(aMessage, MeshCoP::Tlv::kCount, count));
-    SuccessOrExit(Tlv::FindUint16Tlv(aMessage, MeshCoP::Tlv::kPeriod, period));
+    SuccessOrExit(Tlv::Find<MeshCoP::CountTlv>(aMessage, count));
+    SuccessOrExit(Tlv::Find<MeshCoP::PeriodTlv>(aMessage, period));
 
     SendAnnounce(mask, count, period);
 

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -331,7 +331,8 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
             break;
 
         case MeshCoP::Tlv::kExtendedPanId:
-            SuccessOrExit(error = Tlv::ReadTlv(aMessage, offset, &result.mExtendedPanId, sizeof(Mac::ExtendedPanId)));
+            SuccessOrExit(error = Tlv::Read<MeshCoP::ExtendedPanIdTlv>(
+                              aMessage, offset, static_cast<Mac::ExtendedPanId &>(result.mExtendedPanId)));
             break;
 
         case MeshCoP::Tlv::kNetworkName:
@@ -364,7 +365,7 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
             break;
 
         case MeshCoP::Tlv::kJoinerUdpPort:
-            SuccessOrExit(error = Tlv::ReadUint16Tlv(aMessage, offset, result.mJoinerUdpPort));
+            SuccessOrExit(error = Tlv::Read<MeshCoP::JoinerUdpPortTlv>(aMessage, offset, result.mJoinerUdpPort));
             break;
 
         default:

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -77,9 +77,9 @@ void EnergyScanServer::HandleRequest(Coap::Message &aMessage, const Ip6::Message
 
     VerifyOrExit(aMessage.IsPostRequest());
 
-    SuccessOrExit(Tlv::FindUint8Tlv(aMessage, MeshCoP::Tlv::kCount, count));
-    SuccessOrExit(Tlv::FindUint16Tlv(aMessage, MeshCoP::Tlv::kPeriod, period));
-    SuccessOrExit(Tlv::FindUint16Tlv(aMessage, MeshCoP::Tlv::kScanDuration, scanDuration));
+    SuccessOrExit(Tlv::Find<MeshCoP::CountTlv>(aMessage, count));
+    SuccessOrExit(Tlv::Find<MeshCoP::PeriodTlv>(aMessage, period));
+    SuccessOrExit(Tlv::Find<MeshCoP::ScanDurationTlv>(aMessage, scanDuration));
 
     VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
 

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -233,7 +233,7 @@ otError LinkMetrics::AppendLinkMetricsReport(Message &aMessage, const Message &a
         switch (tlv.GetType())
         {
         case kLinkMetricsQueryId:
-            SuccessOrExit(error = Tlv::ReadUint8Tlv(aRequestMessage, offset, queryId));
+            SuccessOrExit(error = Tlv::Read<LinkMetricsQueryIdTlv>(aRequestMessage, offset, queryId));
             hasQueryId = true;
             break;
 

--- a/src/core/thread/link_metrics_tlvs.hpp
+++ b/src/core/thread/link_metrics_tlvs.hpp
@@ -71,11 +71,16 @@ enum Type : uint8_t
 };
 
 /**
+ * This class defines Link Metrics Query ID TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<kLinkMetricsQueryId, uint8_t> LinkMetricsQueryIdTlv;
+
+/**
  * This class implements Link Metrics Type Id Flags generation and parsing.
  *
  */
-OT_TOOL_PACKED_BEGIN
-class LinkMetricsTypeIdFlags
+OT_TOOL_PACKED_BEGIN class LinkMetricsTypeIdFlags
 {
 public:
     /**
@@ -215,7 +220,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class LinkMetricsReportSubTlv : public Tlv
+class LinkMetricsReportSubTlv : public Tlv, public TlvInfo<kLinkMetricsReportSub>
 {
 public:
     /**
@@ -306,7 +311,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class LinkMetricsQueryOptionsTlv : public Tlv
+class LinkMetricsQueryOptionsTlv : public Tlv, public TlvInfo<kLinkMetricsQueryOptions>
 {
 public:
     /**

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1014,37 +1014,37 @@ exit:
 
 otError Mle::AppendSourceAddress(Message &aMessage) const
 {
-    return Tlv::AppendUint16Tlv(aMessage, Tlv::kSourceAddress, GetRloc16());
+    return Tlv::Append<SourceAddressTlv>(aMessage, GetRloc16());
 }
 
 otError Mle::AppendStatus(Message &aMessage, StatusTlv::Status aStatus)
 {
-    return Tlv::AppendUint8Tlv(aMessage, Tlv::kStatus, static_cast<uint8_t>(aStatus));
+    return Tlv::Append<StatusTlv>(aMessage, aStatus);
 }
 
 otError Mle::AppendMode(Message &aMessage, DeviceMode aMode)
 {
-    return Tlv::AppendUint8Tlv(aMessage, Tlv::kMode, aMode.Get());
+    return Tlv::Append<ModeTlv>(aMessage, aMode.Get());
 }
 
 otError Mle::AppendTimeout(Message &aMessage, uint32_t aTimeout)
 {
-    return Tlv::AppendUint32Tlv(aMessage, Tlv::kTimeout, aTimeout);
+    return Tlv::Append<TimeoutTlv>(aMessage, aTimeout);
 }
 
 otError Mle::AppendChallenge(Message &aMessage, const Challenge &aChallenge)
 {
-    return Tlv::AppendTlv(aMessage, Tlv::kChallenge, aChallenge.mBuffer, aChallenge.mLength);
+    return Tlv::Append<ChallengeTlv>(aMessage, aChallenge.mBuffer, aChallenge.mLength);
 }
 
 otError Mle::AppendChallenge(Message &aMessage, const uint8_t *aChallenge, uint8_t aChallengeLength)
 {
-    return Tlv::AppendTlv(aMessage, Tlv::kChallenge, aChallenge, aChallengeLength);
+    return Tlv::Append<ChallengeTlv>(aMessage, aChallenge, aChallengeLength);
 }
 
 otError Mle::AppendResponse(Message &aMessage, const Challenge &aResponse)
 {
-    return Tlv::AppendTlv(aMessage, Tlv::kResponse, aResponse.mBuffer, aResponse.mLength);
+    return Tlv::Append<ResponseTlv>(aMessage, aResponse.mBuffer, aResponse.mLength);
 }
 
 otError Mle::ReadChallengeOrResponse(const Message &aMessage, uint8_t aTlvType, Challenge &aBuffer)
@@ -1080,17 +1080,17 @@ otError Mle::ReadResponse(const Message &aMessage, Challenge &aResponse)
 
 otError Mle::AppendLinkFrameCounter(Message &aMessage)
 {
-    return Tlv::AppendUint32Tlv(aMessage, Tlv::kLinkFrameCounter, Get<KeyManager>().GetMacFrameCounter());
+    return Tlv::Append<LinkFrameCounterTlv>(aMessage, Get<KeyManager>().GetMacFrameCounter());
 }
 
 otError Mle::AppendMleFrameCounter(Message &aMessage)
 {
-    return Tlv::AppendUint32Tlv(aMessage, Tlv::kMleFrameCounter, Get<KeyManager>().GetMleFrameCounter());
+    return Tlv::Append<MleFrameCounterTlv>(aMessage, Get<KeyManager>().GetMleFrameCounter());
 }
 
 otError Mle::AppendAddress16(Message &aMessage, uint16_t aRloc16)
 {
-    return Tlv::AppendUint16Tlv(aMessage, Tlv::kAddress16, aRloc16);
+    return Tlv::Append<Address16Tlv>(aMessage, aRloc16);
 }
 
 otError Mle::AppendLeaderData(Message &aMessage)
@@ -1111,7 +1111,7 @@ otError Mle::ReadLeaderData(const Message &aMessage, LeaderData &aLeaderData)
     otError       error;
     LeaderDataTlv leaderDataTlv;
 
-    SuccessOrExit(error = Tlv::FindTlv(aMessage, Tlv::kLeaderData, sizeof(leaderDataTlv), leaderDataTlv));
+    SuccessOrExit(error = Tlv::FindTlv(aMessage, leaderDataTlv));
     VerifyOrExit(leaderDataTlv.IsValid(), error = OT_ERROR_PARSE);
     leaderDataTlv.Get(aLeaderData);
 
@@ -1130,7 +1130,7 @@ otError Mle::AppendNetworkData(Message &aMessage, bool aStableOnly)
     length = sizeof(networkData);
     IgnoreError(Get<NetworkData::Leader>().GetNetworkData(aStableOnly, networkData, length));
 
-    error = Tlv::AppendTlv(aMessage, Tlv::kNetworkData, networkData, length);
+    error = Tlv::Append<NetworkDataTlv>(aMessage, networkData, length);
 
 exit:
     return error;
@@ -1138,7 +1138,7 @@ exit:
 
 otError Mle::AppendTlvRequest(Message &aMessage, const uint8_t *aTlvs, uint8_t aTlvsLength)
 {
-    return Tlv::AppendTlv(aMessage, Tlv::kTlvRequest, aTlvs, aTlvsLength);
+    return Tlv::Append<TlvRequestTlv>(aMessage, aTlvs, aTlvsLength);
 }
 
 otError Mle::FindTlvRequest(const Message &aMessage, RequestedTlvs &aRequestedTlvs)
@@ -1163,17 +1163,17 @@ exit:
 
 otError Mle::AppendScanMask(Message &aMessage, uint8_t aScanMask)
 {
-    return Tlv::AppendUint8Tlv(aMessage, Tlv::kScanMask, aScanMask);
+    return Tlv::Append<ScanMaskTlv>(aMessage, aScanMask);
 }
 
 otError Mle::AppendLinkMargin(Message &aMessage, uint8_t aLinkMargin)
 {
-    return Tlv::AppendUint8Tlv(aMessage, Tlv::kLinkMargin, aLinkMargin);
+    return Tlv::Append<LinkMarginTlv>(aMessage, aLinkMargin);
 }
 
 otError Mle::AppendVersion(Message &aMessage)
 {
-    return Tlv::AppendUint16Tlv(aMessage, Tlv::kVersion, kThreadVersion);
+    return Tlv::Append<VersionTlv>(aMessage, kThreadVersion);
 }
 
 bool Mle::HasUnregisteredAddress(void)
@@ -1352,7 +1352,7 @@ otError Mle::AppendTimeParameter(Message &aMessage)
 
 otError Mle::AppendXtalAccuracy(Message &aMessage)
 {
-    return Tlv::AppendUint16Tlv(aMessage, Tlv::kXtalAccuracy, otPlatTimeGetXtalAccuracy());
+    return Tlv::Append<XtalAccuracyTlv>(aMessage, otPlatTimeGetXtalAccuracy());
 }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
@@ -1415,8 +1415,8 @@ exit:
 otError Mle::AppendCslTimeout(Message &aMessage)
 {
     OT_ASSERT(Get<Mac::Mac>().IsCslEnabled());
-    return Tlv::AppendUint32Tlv(aMessage, Tlv::kCslTimeout,
-                                Get<Mac::Mac>().GetCslTimeout() == 0 ? mTimeout : Get<Mac::Mac>().GetCslTimeout());
+    return Tlv::Append<CslTimeoutTlv>(aMessage, Get<Mac::Mac>().GetCslTimeout() == 0 ? mTimeout
+                                                                                     : Get<Mac::Mac>().GetCslTimeout());
 }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
@@ -2393,7 +2393,7 @@ void Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Addres
         SuccessOrExit(error = AppendActiveTimestamp(*message));
     }
 
-    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, Tlv::kPanId, Get<Mac::Mac>().GetPanId()));
+    SuccessOrExit(error = Tlv::Append<PanIdTlv>(*message, Get<Mac::Mac>().GetPanId()));
 
     SuccessOrExit(error = SendMessage(*message, aDestination));
 
@@ -2795,7 +2795,7 @@ void Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &a
     uint16_t   delay;
 
     // Source Address
-    SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
+    SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aMessage, sourceAddress));
 
     Log(kMessageReceive, kTypeAdvertisement, aMessageInfo.GetPeerAddr(), sourceAddress);
 
@@ -2839,7 +2839,7 @@ void Mle::HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &a
             {
                 RouteTlv route;
 
-                if ((Tlv::FindTlv(aMessage, Tlv::kRoute, sizeof(route), route) == OT_ERROR_NONE) && route.IsValid())
+                if ((Tlv::FindTlv(aMessage, route) == OT_ERROR_NONE) && route.IsValid())
                 {
                     // Overwrite Route Data
                     IgnoreError(Get<MleRouter>().ProcessRouteTlv(route));
@@ -2955,7 +2955,7 @@ otError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &a
     }
 
     // Active Timestamp
-    if (Tlv::FindTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, activeTimestamp) == OT_ERROR_NONE)
     {
         const MeshCoP::Timestamp *timestamp;
 
@@ -2976,7 +2976,7 @@ otError Mle::HandleLeaderData(const Message &aMessage, const Ip6::MessageInfo &a
     }
 
     // Pending Timestamp
-    if (Tlv::FindTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, pendingTimestamp) == OT_ERROR_NONE)
     {
         const MeshCoP::Timestamp *timestamp;
 
@@ -3166,12 +3166,12 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
 #endif
 
     // Source Address
-    SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
+    SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aMessage, sourceAddress));
 
     Log(kMessageReceive, kTypeParentResponse, aMessageInfo.GetPeerAddr(), sourceAddress);
 
     // Version
-    SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kVersion, version));
+    SuccessOrExit(error = Tlv::Find<VersionTlv>(aMessage, version));
     VerifyOrExit(version >= OT_THREAD_VERSION_1_1, error = OT_ERROR_PARSE);
 
     // Response
@@ -3189,7 +3189,7 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
     SuccessOrExit(error = ReadLeaderData(aMessage, leaderData));
 
     // Link Margin
-    SuccessOrExit(error = Tlv::FindUint8Tlv(aMessage, Tlv::kLinkMargin, linkMarginFromTlv));
+    SuccessOrExit(error = Tlv::Find<LinkMarginTlv>(aMessage, linkMarginFromTlv));
 
     linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->GetRss());
 
@@ -3201,7 +3201,7 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
     linkQuality = LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMargin);
 
     // Connectivity
-    SuccessOrExit(error = Tlv::FindTlv(aMessage, Tlv::kConnectivity, sizeof(connectivity), connectivity));
+    SuccessOrExit(error = Tlv::FindTlv(aMessage, connectivity));
     VerifyOrExit(connectivity.IsValid(), error = OT_ERROR_PARSE);
 
     // Share data with application, if requested.
@@ -3279,10 +3279,10 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
     }
 
     // Link Frame Counter
-    SuccessOrExit(error = Tlv::FindUint32Tlv(aMessage, Tlv::kLinkFrameCounter, linkFrameCounter));
+    SuccessOrExit(error = Tlv::Find<LinkFrameCounterTlv>(aMessage, linkFrameCounter));
 
     // Mle Frame Counter
-    switch (Tlv::FindUint32Tlv(aMessage, Tlv::kMleFrameCounter, mleFrameCounter))
+    switch (Tlv::Find<MleFrameCounterTlv>(aMessage, mleFrameCounter))
     {
     case OT_ERROR_NONE:
         break;
@@ -3296,7 +3296,7 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
     // Time Parameter
-    if (Tlv::FindTlv(aMessage, Tlv::kTimeParameter, sizeof(timeParameter), timeParameter) == OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, timeParameter) == OT_ERROR_NONE)
     {
         VerifyOrExit(timeParameter.IsValid());
 
@@ -3364,7 +3364,7 @@ void Mle::HandleChildIdResponse(const Message &         aMessage,
     uint16_t            offset;
 
     // Source Address
-    SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
+    SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aMessage, sourceAddress));
 
     Log(kMessageReceive, kTypeChildIdResponse, aMessageInfo.GetPeerAddr(), sourceAddress);
 
@@ -3376,14 +3376,14 @@ void Mle::HandleChildIdResponse(const Message &         aMessage,
     SuccessOrExit(error = ReadLeaderData(aMessage, leaderData));
 
     // ShortAddress
-    SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kAddress16, shortAddress));
+    SuccessOrExit(error = Tlv::Find<Address16Tlv>(aMessage, shortAddress));
 
     // Network Data
     error = Tlv::FindTlvOffset(aMessage, Tlv::kNetworkData, networkDataOffset);
     SuccessOrExit(error);
 
     // Active Timestamp
-    if (Tlv::FindTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, activeTimestamp) == OT_ERROR_NONE)
     {
         VerifyOrExit(activeTimestamp.IsValid(), error = OT_ERROR_PARSE);
 
@@ -3403,7 +3403,7 @@ void Mle::HandleChildIdResponse(const Message &         aMessage,
     }
 
     // Pending Timestamp
-    if (Tlv::FindTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, pendingTimestamp) == OT_ERROR_NONE)
     {
         VerifyOrExit(pendingTimestamp.IsValid(), error = OT_ERROR_PARSE);
 
@@ -3449,7 +3449,7 @@ void Mle::HandleChildIdResponse(const Message &         aMessage,
     {
         RouteTlv route;
 
-        if (Tlv::FindTlv(aMessage, Tlv::kRoute, sizeof(route), route) == OT_ERROR_NONE)
+        if (Tlv::FindTlv(aMessage, route) == OT_ERROR_NONE)
         {
             SuccessOrExit(error = Get<MleRouter>().ProcessRouteTlv(route));
         }
@@ -3483,7 +3483,7 @@ void Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageIn
     uint8_t       numTlvs                = 0;
 
     // Source Address
-    SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
+    SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aMessage, sourceAddress));
 
     Log(kMessageReceive, kTypeChildUpdateRequestOfParent, aMessageInfo.GetPeerAddr(), sourceAddress);
 
@@ -3505,7 +3505,7 @@ void Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageIn
     {
         uint8_t status;
 
-        switch (Tlv::FindUint8Tlv(aMessage, Tlv::kStatus, status))
+        switch (Tlv::Find<StatusTlv>(aMessage, status))
         {
         case OT_ERROR_NONE:
             VerifyOrExit(status != StatusTlv::kError, IgnoreError(BecomeDetached()));
@@ -3590,22 +3590,22 @@ void Mle::HandleChildUpdateResponse(const Message &         aMessage,
     }
 
     // Status
-    if (Tlv::FindUint8Tlv(aMessage, Tlv::kStatus, status) == OT_ERROR_NONE)
+    if (Tlv::Find<StatusTlv>(aMessage, status) == OT_ERROR_NONE)
     {
         IgnoreError(BecomeDetached());
         ExitNow();
     }
 
     // Mode
-    SuccessOrExit(error = Tlv::FindUint8Tlv(aMessage, Tlv::kMode, mode));
+    SuccessOrExit(error = Tlv::Find<ModeTlv>(aMessage, mode));
     VerifyOrExit(DeviceMode(mode) == mDeviceMode, error = OT_ERROR_DROP);
 
     switch (mRole)
     {
     case kRoleDetached:
-        SuccessOrExit(error = Tlv::FindUint32Tlv(aMessage, Tlv::kLinkFrameCounter, linkFrameCounter));
+        SuccessOrExit(error = Tlv::Find<LinkFrameCounterTlv>(aMessage, linkFrameCounter));
 
-        switch (Tlv::FindUint32Tlv(aMessage, Tlv::kMleFrameCounter, mleFrameCounter))
+        switch (Tlv::Find<MleFrameCounterTlv>(aMessage, mleFrameCounter))
         {
         case OT_ERROR_NONE:
             break;
@@ -3629,7 +3629,7 @@ void Mle::HandleChildUpdateResponse(const Message &         aMessage,
 
     case kRoleChild:
         // Source Address
-        SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
+        SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aMessage, sourceAddress));
 
         if (RouterIdFromRloc16(sourceAddress) != RouterIdFromRloc16(GetRloc16()))
         {
@@ -3641,7 +3641,7 @@ void Mle::HandleChildUpdateResponse(const Message &         aMessage,
         SuccessOrExit(error = HandleLeaderData(aMessage, aMessageInfo));
 
         // Timeout optional
-        switch (Tlv::FindUint32Tlv(aMessage, Tlv::kTimeout, timeout))
+        switch (Tlv::Find<TimeoutTlv>(aMessage, timeout))
         {
         case OT_ERROR_NONE:
             mTimeout = timeout;
@@ -3697,15 +3697,15 @@ void Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMessa
 
     Log(kMessageReceive, kTypeAnnounce, aMessageInfo.GetPeerAddr());
 
-    SuccessOrExit(error = Tlv::FindTlv(aMessage, Tlv::kChannel, sizeof(channelTlv), channelTlv));
+    SuccessOrExit(error = Tlv::FindTlv(aMessage, channelTlv));
     VerifyOrExit(channelTlv.IsValid(), error = OT_ERROR_PARSE);
 
     channel = static_cast<uint8_t>(channelTlv.GetChannel());
 
-    SuccessOrExit(error = Tlv::FindTlv(aMessage, Tlv::kActiveTimestamp, sizeof(timestamp), timestamp));
+    SuccessOrExit(error = Tlv::FindTlv(aMessage, timestamp));
     VerifyOrExit(timestamp.IsValid(), error = OT_ERROR_PARSE);
 
-    SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kPanId, panId));
+    SuccessOrExit(error = Tlv::Find<PanIdTlv>(aMessage, panId));
 
     localTimestamp = Get<MeshCoP::ActiveDataset>().GetTimestamp();
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -575,7 +575,7 @@ void MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInf
     SuccessOrExit(error = ReadChallenge(aMessage, challenge));
 
     // Version
-    SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kVersion, version));
+    SuccessOrExit(error = Tlv::Find<VersionTlv>(aMessage, version));
     VerifyOrExit(version >= OT_THREAD_VERSION_1_1, error = OT_ERROR_PARSE);
 
     // Leader Data
@@ -591,7 +591,7 @@ void MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInf
     }
 
     // Source Address
-    switch (Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress))
+    switch (Tlv::Find<SourceAddressTlv>(aMessage, sourceAddress))
     {
     case OT_ERROR_NONE:
         if (IsActiveRouter(sourceAddress))
@@ -647,7 +647,7 @@ void MleRouter::HandleLinkRequest(const Message &aMessage, const Ip6::MessageInf
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     if (neighbor != nullptr)
     {
-        if (Tlv::FindTlv(aMessage, Tlv::kTimeRequest, sizeof(timeRequest), timeRequest) == OT_ERROR_NONE)
+        if (Tlv::FindTlv(aMessage, timeRequest) == OT_ERROR_NONE)
         {
             neighbor->SetTimeSyncEnabled(true);
         }
@@ -797,7 +797,7 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
     uint8_t         linkMargin;
 
     // Source Address
-    SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
+    SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aMessage, sourceAddress));
 
     Log(kMessageReceive, aRequest ? kTypeLinkAcceptAndRequest : kTypeLinkAccept, aMessageInfo.GetPeerAddr(),
         sourceAddress);
@@ -835,14 +835,14 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
     }
 
     // Version
-    SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kVersion, version));
+    SuccessOrExit(error = Tlv::Find<VersionTlv>(aMessage, version));
     VerifyOrExit(version >= OT_THREAD_VERSION_1_1, error = OT_ERROR_PARSE);
 
     // Link-Layer Frame Counter
-    SuccessOrExit(error = Tlv::FindUint32Tlv(aMessage, Tlv::kLinkFrameCounter, linkFrameCounter));
+    SuccessOrExit(error = Tlv::Find<LinkFrameCounterTlv>(aMessage, linkFrameCounter));
 
     // MLE Frame Counter
-    switch (Tlv::FindUint32Tlv(aMessage, Tlv::kMleFrameCounter, mleFrameCounter))
+    switch (Tlv::Find<MleFrameCounterTlv>(aMessage, mleFrameCounter))
     {
     case OT_ERROR_NONE:
         break;
@@ -854,7 +854,7 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
     }
 
     // Link Margin
-    switch (Tlv::FindUint8Tlv(aMessage, Tlv::kLinkMargin, linkMargin))
+    switch (Tlv::Find<LinkMarginTlv>(aMessage, linkMargin))
     {
     case OT_ERROR_NONE:
         break;
@@ -876,7 +876,7 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
 
     case kRoleDetached:
         // Address16
-        SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kAddress16, address16));
+        SuccessOrExit(error = Tlv::Find<Address16Tlv>(aMessage, address16));
         VerifyOrExit(GetRloc16() == address16, error = OT_ERROR_DROP);
 
         // Leader Data
@@ -927,7 +927,7 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
         }
 
         // Route (optional)
-        if (Tlv::FindTlv(aMessage, Tlv::kRoute, sizeof(route), route) == OT_ERROR_NONE)
+        if (Tlv::FindTlv(aMessage, route) == OT_ERROR_NONE)
         {
             VerifyOrExit(route.IsValid(), error = OT_ERROR_PARSE);
             SuccessOrExit(error = ProcessRouteTlv(route));
@@ -1147,13 +1147,13 @@ otError MleRouter::HandleAdvertisement(const Message &         aMessage,
     aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
 
     // Source Address
-    SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress));
+    SuccessOrExit(error = Tlv::Find<SourceAddressTlv>(aMessage, sourceAddress));
 
     // Leader Data
     SuccessOrExit(error = ReadLeaderData(aMessage, leaderData));
 
     // Route Data (optional)
-    if (Tlv::FindTlv(aMessage, Tlv::kRoute, sizeof(route), route) == OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, route) == OT_ERROR_NONE)
     {
         VerifyOrExit(route.IsValid(), error = OT_ERROR_PARSE);
     }
@@ -1603,11 +1603,11 @@ void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageI
     aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
 
     // Version
-    SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kVersion, version));
+    SuccessOrExit(error = Tlv::Find<VersionTlv>(aMessage, version));
     VerifyOrExit(version >= OT_THREAD_VERSION_1_1, error = OT_ERROR_PARSE);
 
     // Scan Mask
-    SuccessOrExit(error = Tlv::FindUint8Tlv(aMessage, Tlv::kScanMask, scanMask));
+    SuccessOrExit(error = Tlv::Find<ScanMaskTlv>(aMessage, scanMask));
 
     switch (mRole)
     {
@@ -1642,7 +1642,7 @@ void MleRouter::HandleParentRequest(const Message &aMessage, const Ip6::MessageI
         child->ResetLinkFailures();
         child->SetState(Neighbor::kStateParentRequest);
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-        if (Tlv::FindTlv(aMessage, Tlv::kTimeRequest, sizeof(timeRequest), timeRequest) == OT_ERROR_NONE)
+        if (Tlv::FindTlv(aMessage, timeRequest) == OT_ERROR_NONE)
         {
             child->SetTimeSyncEnabled(true);
         }
@@ -2207,7 +2207,7 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     VerifyOrExit(child != nullptr, error = OT_ERROR_ALREADY);
 
     // Version
-    SuccessOrExit(error = Tlv::FindUint16Tlv(aMessage, Tlv::kVersion, version));
+    SuccessOrExit(error = Tlv::Find<VersionTlv>(aMessage, version));
     VerifyOrExit(version >= OT_THREAD_VERSION_1_1, error = OT_ERROR_PARSE);
 
     // Response
@@ -2221,10 +2221,10 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     Get<MeshForwarder>().RemoveMessages(*child, Message::kSubTypeMleDataResponse);
 
     // Link-Layer Frame Counter
-    SuccessOrExit(error = Tlv::FindUint32Tlv(aMessage, Tlv::kLinkFrameCounter, linkFrameCounter));
+    SuccessOrExit(error = Tlv::Find<LinkFrameCounterTlv>(aMessage, linkFrameCounter));
 
     // MLE Frame Counter
-    switch (Tlv::FindUint32Tlv(aMessage, Tlv::kMleFrameCounter, mleFrameCounter))
+    switch (Tlv::Find<MleFrameCounterTlv>(aMessage, mleFrameCounter))
     {
     case OT_ERROR_NONE:
         break;
@@ -2236,11 +2236,11 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     }
 
     // Mode
-    SuccessOrExit(error = Tlv::FindUint8Tlv(aMessage, Tlv::kMode, modeBitmask));
+    SuccessOrExit(error = Tlv::Find<ModeTlv>(aMessage, modeBitmask));
     mode.Set(modeBitmask);
 
     // Timeout
-    SuccessOrExit(error = Tlv::FindUint32Tlv(aMessage, Tlv::kTimeout, timeout));
+    SuccessOrExit(error = Tlv::Find<TimeoutTlv>(aMessage, timeout));
 
     // TLV Request
     SuccessOrExit(error = FindTlvRequest(aMessage, requestedTlvs));
@@ -2249,7 +2249,7 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     // Active Timestamp
     activeTimestamp.SetLength(0);
 
-    if (Tlv::FindTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, activeTimestamp) == OT_ERROR_NONE)
     {
         VerifyOrExit(activeTimestamp.IsValid(), error = OT_ERROR_PARSE);
     }
@@ -2257,7 +2257,7 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     // Pending Timestamp
     pendingTimestamp.SetLength(0);
 
-    if (Tlv::FindTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, pendingTimestamp) == OT_ERROR_NONE)
     {
         VerifyOrExit(pendingTimestamp.IsValid(), error = OT_ERROR_PARSE);
     }
@@ -2367,7 +2367,7 @@ void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
     Log(kMessageReceive, kTypeChildUpdateRequestOfChild, aMessageInfo.GetPeerAddr());
 
     // Mode
-    SuccessOrExit(error = Tlv::FindUint8Tlv(aMessage, Tlv::kMode, modeBitmask));
+    SuccessOrExit(error = Tlv::Find<ModeTlv>(aMessage, modeBitmask));
     mode.Set(modeBitmask);
 
     // Challenge
@@ -2435,7 +2435,7 @@ void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
     }
 
     // Timeout
-    switch (Tlv::FindUint32Tlv(aMessage, Tlv::kTimeout, timeout))
+    switch (Tlv::Find<TimeoutTlv>(aMessage, timeout))
     {
     case OT_ERROR_NONE:
         if (child->GetTimeout() != timeout)
@@ -2480,12 +2480,12 @@ void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
         CslChannelTlv cslChannel;
         uint32_t      cslTimeout;
 
-        if (Tlv::FindUint32Tlv(aMessage, Tlv::kCslTimeout, cslTimeout) == OT_ERROR_NONE)
+        if (Tlv::Find<CslTimeoutTlv>(aMessage, cslTimeout) == OT_ERROR_NONE)
         {
             child->SetCslTimeout(cslTimeout);
         }
 
-        if (Tlv::FindTlv(aMessage, Tlv::kCslChannel, sizeof(cslChannel), cslChannel) == OT_ERROR_NONE)
+        if (Tlv::FindTlv(aMessage, cslChannel) == OT_ERROR_NONE)
         {
             child->SetCslChannel(static_cast<uint8_t>(cslChannel.GetChannel()));
         }
@@ -2573,7 +2573,7 @@ void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
     Log(kMessageReceive, kTypeChildUpdateResponseOfChild, aMessageInfo.GetPeerAddr(), child->GetRloc16());
 
     // Source Address
-    switch (Tlv::FindUint16Tlv(aMessage, Tlv::kSourceAddress, sourceAddress))
+    switch (Tlv::Find<SourceAddressTlv>(aMessage, sourceAddress))
     {
     case OT_ERROR_NONE:
         if (child->GetRloc16() != sourceAddress)
@@ -2592,7 +2592,7 @@ void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
     }
 
     // Status
-    switch (Tlv::FindUint8Tlv(aMessage, Tlv::kStatus, status))
+    switch (Tlv::Find<ThreadStatusTlv>(aMessage, status))
     {
     case OT_ERROR_NONE:
         VerifyOrExit(status != StatusTlv::kError, RemoveNeighbor(*child));
@@ -2605,7 +2605,7 @@ void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
 
     // Link-Layer Frame Counter
 
-    switch (Tlv::FindUint32Tlv(aMessage, Tlv::kLinkFrameCounter, linkFrameCounter))
+    switch (Tlv::Find<LinkFrameCounterTlv>(aMessage, linkFrameCounter))
     {
     case OT_ERROR_NONE:
         child->SetLinkFrameCounter(linkFrameCounter);
@@ -2618,7 +2618,7 @@ void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
     }
 
     // MLE Frame Counter
-    switch (Tlv::FindUint32Tlv(aMessage, Tlv::kMleFrameCounter, mleFrameCounter))
+    switch (Tlv::Find<MleFrameCounterTlv>(aMessage, mleFrameCounter))
     {
     case OT_ERROR_NONE:
         child->SetMleFrameCounter(mleFrameCounter);
@@ -2630,7 +2630,7 @@ void MleRouter::HandleChildUpdateResponse(const Message &         aMessage,
     }
 
     // Timeout
-    switch (Tlv::FindUint32Tlv(aMessage, Tlv::kTimeout, timeout))
+    switch (Tlv::Find<TimeoutTlv>(aMessage, timeout))
     {
     case OT_ERROR_NONE:
         child->SetTimeout(timeout);
@@ -2697,7 +2697,7 @@ void MleRouter::HandleDataRequest(const Message &         aMessage,
     // Active Timestamp
     activeTimestamp.SetLength(0);
 
-    if (Tlv::FindTlv(aMessage, Tlv::kActiveTimestamp, sizeof(activeTimestamp), activeTimestamp) == OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, activeTimestamp) == OT_ERROR_NONE)
     {
         VerifyOrExit(activeTimestamp.IsValid(), error = OT_ERROR_PARSE);
     }
@@ -2705,7 +2705,7 @@ void MleRouter::HandleDataRequest(const Message &         aMessage,
     // Pending Timestamp
     pendingTimestamp.SetLength(0);
 
-    if (Tlv::FindTlv(aMessage, Tlv::kPendingTimestamp, sizeof(pendingTimestamp), pendingTimestamp) == OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, pendingTimestamp) == OT_ERROR_NONE)
     {
         VerifyOrExit(pendingTimestamp.IsValid(), error = OT_ERROR_PARSE);
     }
@@ -2848,7 +2848,7 @@ void MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Messa
             break;
 
         case MeshCoP::Tlv::kExtendedPanId:
-            SuccessOrExit(error = Tlv::ReadTlv(aMessage, offset, &extPanId, sizeof(extPanId)));
+            SuccessOrExit(error = Tlv::Read<MeshCoP::ExtendedPanIdTlv>(aMessage, offset, extPanId));
             VerifyOrExit(Get<Mac::Mac>().GetExtendedPanId() != extPanId, error = OT_ERROR_DROP);
 
             break;
@@ -2920,8 +2920,7 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
 
     if (Get<KeyManager>().IsNativeCommissioningAllowed())
     {
-        SuccessOrExit(
-            error = Tlv::AppendUint16Tlv(*message, MeshCoP::Tlv::kCommissionerUdpPort, MeshCoP::kBorderAgentUdpPort));
+        SuccessOrExit(error = Tlv::Append<MeshCoP::CommissionerUdpPortTlv>(*message, MeshCoP::kBorderAgentUdpPort));
 
         discoveryResponse.SetNativeCommissioner(true);
     }
@@ -2933,8 +2932,7 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
     SuccessOrExit(error = discoveryResponse.AppendTo(*message));
 
     // Extended PAN ID TLV
-    SuccessOrExit(error = Tlv::AppendTlv(*message, MeshCoP::Tlv::kExtendedPanId, Get<Mac::Mac>().GetExtendedPanId().m8,
-                                         sizeof(Mac::ExtendedPanId)));
+    SuccessOrExit(error = Tlv::Append<MeshCoP::ExtendedPanIdTlv>(*message, Get<Mac::Mac>().GetExtendedPanId()));
 
     // Network Name TLV
     networkName.Init();
@@ -2946,8 +2944,8 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
     // Otherwise use the one from commissioning data.
     if (!mSteeringData.IsEmpty())
     {
-        SuccessOrExit(error = Tlv::AppendTlv(*message, MeshCoP::Tlv::kSteeringData, mSteeringData.GetData(),
-                                             mSteeringData.GetLength()));
+        SuccessOrExit(error = Tlv::Append<MeshCoP::SteeringDataTlv>(*message, mSteeringData.GetData(),
+                                                                    mSteeringData.GetLength()));
     }
     else
 #endif
@@ -2962,9 +2960,8 @@ otError MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, uint1
         }
     }
 
-    // Joiner UDP Port TLV
-    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, MeshCoP::Tlv::kJoinerUdpPort,
-                                               Get<MeshCoP::JoinerRouter>().GetJoinerUdpPort()));
+    SuccessOrExit(
+        error = Tlv::Append<MeshCoP::JoinerUdpPortTlv>(*message, Get<MeshCoP::JoinerRouter>().GetJoinerUdpPort()));
 
     tlv.SetLength(static_cast<uint8_t>(message->GetLength() - startOffset));
     message->Write(startOffset - sizeof(tlv), tlv);
@@ -3549,16 +3546,14 @@ otError MleRouter::SendAddressSolicit(ThreadStatusTlv::Status aStatus)
     SuccessOrExit(error = message->InitAsConfirmablePost(UriPath::kAddressSolicit));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kExtMacAddress, Get<Mac::Mac>().GetExtAddress().m8,
-                                         sizeof(Mac::ExtAddress)));
+    SuccessOrExit(error = Tlv::Append<ThreadExtMacAddressTlv>(*message, Get<Mac::Mac>().GetExtAddress()));
 
     if (IsRouterIdValid(mPreviousRouterId))
     {
-        SuccessOrExit(error =
-                          Tlv::AppendUint16Tlv(*message, ThreadTlv::kRloc16, Rloc16FromRouterId(mPreviousRouterId)));
+        SuccessOrExit(error = Tlv::Append<ThreadRloc16Tlv>(*message, Rloc16FromRouterId(mPreviousRouterId)));
     }
 
-    SuccessOrExit(error = Tlv::AppendUint8Tlv(*message, ThreadTlv::kStatus, static_cast<uint8_t>(aStatus)));
+    SuccessOrExit(error = Tlv::Append<ThreadStatusTlv>(*message, aStatus));
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     SuccessOrExit(error = AppendXtalAccuracy(*message));
@@ -3590,10 +3585,9 @@ void MleRouter::SendAddressRelease(void)
     SuccessOrExit(error = message->InitAsConfirmablePost(UriPath::kAddressRelease));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, ThreadTlv::kRloc16, Rloc16FromRouterId(mRouterId)));
+    SuccessOrExit(error = Tlv::Append<ThreadRloc16Tlv>(*message, Rloc16FromRouterId(mRouterId)));
 
-    SuccessOrExit(error = Tlv::AppendTlv(*message, ThreadTlv::kExtMacAddress, Get<Mac::Mac>().GetExtAddress().m8,
-                                         sizeof(Mac::ExtAddress)));
+    SuccessOrExit(error = Tlv::Append<ThreadExtMacAddressTlv>(*message, Get<Mac::Mac>().GetExtAddress()));
 
     messageInfo.SetSockAddr(GetMeshLocal16());
     SuccessOrExit(error = GetLeaderAddress(messageInfo.GetPeerAddr()));
@@ -3637,7 +3631,7 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
 
     Log(kMessageReceive, kTypeAddressReply, aMessageInfo->GetPeerAddr());
 
-    SuccessOrExit(Tlv::FindUint8Tlv(*aMessage, ThreadTlv::kStatus, status));
+    SuccessOrExit(Tlv::Find<ThreadStatusTlv>(*aMessage, status));
 
     if (status != ThreadStatusTlv::kSuccess)
     {
@@ -3656,10 +3650,10 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
         ExitNow();
     }
 
-    SuccessOrExit(Tlv::FindUint16Tlv(*aMessage, ThreadTlv::kRloc16, rloc16));
+    SuccessOrExit(Tlv::Find<ThreadRloc16Tlv>(*aMessage, rloc16));
     routerId = RouterIdFromRloc16(rloc16);
 
-    SuccessOrExit(ThreadTlv::FindTlv(*aMessage, ThreadTlv::kRouterMask, sizeof(routerMaskTlv), routerMaskTlv));
+    SuccessOrExit(Tlv::FindTlv(*aMessage, routerMaskTlv));
     VerifyOrExit(routerMaskTlv.IsValid());
 
     // assign short address
@@ -3736,13 +3730,12 @@ void MleRouter::HandleAddressSolicit(Coap::Message &aMessage, const Ip6::Message
 
     Log(kMessageReceive, kTypeAddressSolicit, aMessageInfo.GetPeerAddr());
 
-    SuccessOrExit(error = ThreadTlv::FindTlv(aMessage, ThreadTlv::kExtMacAddress, &extAddress, sizeof(extAddress)));
-
-    SuccessOrExit(error = Tlv::FindUint8Tlv(aMessage, ThreadTlv::kStatus, status));
+    SuccessOrExit(error = Tlv::Find<ThreadExtMacAddressTlv>(aMessage, extAddress));
+    SuccessOrExit(error = Tlv::Find<ThreadStatusTlv>(aMessage, status));
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     // In a time sync enabled network, all routers' xtal accuracy must be less than the threshold.
-    SuccessOrExit(Tlv::FindUint16Tlv(aMessage, Tlv::kXtalAccuracy, xtalAccuracy));
+    SuccessOrExit(Tlv::Find<XtalAccuracyTlv>(aMessage, xtalAccuracy));
     VerifyOrExit(xtalAccuracy <= Get<TimeSync>().GetXtalThreshold());
 #endif
 
@@ -3770,7 +3763,7 @@ void MleRouter::HandleAddressSolicit(Coap::Message &aMessage, const Ip6::Message
         OT_UNREACHABLE_CODE(break);
     }
 
-    switch (Tlv::FindUint16Tlv(aMessage, ThreadTlv::kRloc16, rloc16))
+    switch (Tlv::Find<ThreadRloc16Tlv>(aMessage, rloc16))
     {
     case OT_ERROR_NONE:
         router = mRouterTable.Allocate(RouterIdFromRloc16(rloc16));
@@ -3821,13 +3814,12 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Message &   aRequest,
     SuccessOrExit(error = message->SetDefaultResponseHeader(aRequest));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = Tlv::AppendUint8Tlv(*message, ThreadTlv::kStatus,
-                                              aRouter == nullptr ? ThreadStatusTlv::kNoAddressAvailable
-                                                                 : ThreadStatusTlv::kSuccess));
+    SuccessOrExit(error = Tlv::Append<ThreadStatusTlv>(
+                      *message, aRouter == nullptr ? ThreadStatusTlv::kNoAddressAvailable : ThreadStatusTlv::kSuccess));
 
     if (aRouter != nullptr)
     {
-        SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, ThreadTlv::kRloc16, aRouter->GetRloc16()));
+        SuccessOrExit(error = Tlv::Append<ThreadRloc16Tlv>(*message, aRouter->GetRloc16()));
 
         routerMaskTlv.Init();
         routerMaskTlv.SetIdSequence(mRouterTable.GetRouterIdSequence());
@@ -3861,9 +3853,8 @@ void MleRouter::HandleAddressRelease(Coap::Message &aMessage, const Ip6::Message
 
     Log(kMessageReceive, kTypeAddressRelease, aMessageInfo.GetPeerAddr());
 
-    SuccessOrExit(Tlv::FindUint16Tlv(aMessage, ThreadTlv::kRloc16, rloc16));
-
-    SuccessOrExit(Tlv::FindTlv(aMessage, ThreadTlv::kExtMacAddress, &extAddress, sizeof(extAddress)));
+    SuccessOrExit(Tlv::Find<ThreadRloc16Tlv>(aMessage, rloc16));
+    SuccessOrExit(Tlv::Find<ThreadExtMacAddressTlv>(aMessage, extAddress));
 
     routerId = RouterIdFromRloc16(rloc16);
     router   = mRouterTable.GetRouter(routerId);

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -139,6 +139,96 @@ public:
 
 } OT_TOOL_PACKED_END;
 
+/**
+ * This class defines Source Address TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kSourceAddress, uint16_t> SourceAddressTlv;
+
+/**
+ * This class defines Mode TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kMode, uint8_t> ModeTlv;
+
+/**
+ * This class defines Timeout TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kTimeout, uint32_t> TimeoutTlv;
+
+/**
+ * This class defines Challenge TLV constants and types.
+ *
+ */
+typedef TlvInfo<Tlv::kChallenge> ChallengeTlv;
+
+/**
+ * This class defines Response TLV constants and types.
+ *
+ */
+typedef TlvInfo<Tlv::kResponse> ResponseTlv;
+
+/**
+ * This class defines Link Frame Counter TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kLinkFrameCounter, uint32_t> LinkFrameCounterTlv;
+
+/**
+ * This class defines MLE Frame Counter TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kMleFrameCounter, uint32_t> MleFrameCounterTlv;
+
+/**
+ * This class defines Address16 TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kAddress16, uint16_t> Address16Tlv;
+
+/**
+ * This class defines Network Data TLV constants and types.
+ *
+ */
+typedef TlvInfo<Tlv::kNetworkData> NetworkDataTlv;
+
+/**
+ * This class defines TLV Request TLV constants and types.
+ *
+ */
+typedef TlvInfo<Tlv::kTlvRequest> TlvRequestTlv;
+
+/**
+ * This class defines Link Margin TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kLinkMargin, uint8_t> LinkMarginTlv;
+
+/**
+ * This class defines Version TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kVersion, uint16_t> VersionTlv;
+
+/**
+ * This class defines PAN ID TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kPanId, uint16_t> PanIdTlv;
+
+/**
+ * This class defines CSL Timeout TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kCslTimeout, uint32_t> CslTimeoutTlv;
+
+/**
+ * This class defines XTAL Accuracy TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<Tlv::kXtalAccuracy, uint16_t> XtalAccuracyTlv;
+
 #if !OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
 
 /**
@@ -146,7 +236,7 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class RouteTlv : public Tlv
+class RouteTlv : public Tlv, public TlvInfo<Tlv::kRoute>
 {
 public:
     enum
@@ -333,7 +423,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class RouteTlv : public Tlv
+class RouteTlv : public Tlv, public TlvInfo<Tlv::kRoute>
 {
 public:
     /**
@@ -556,7 +646,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class LeaderDataTlv : public Tlv
+class LeaderDataTlv : public Tlv, public TlvInfo<Tlv::kLeaderData>
 {
 public:
     /**
@@ -620,7 +710,7 @@ private:
  * This class implements Scan Mask TLV generation and parsing.
  *
  */
-class ScanMaskTlv
+class ScanMaskTlv : public UintTlvInfo<Tlv::kScanMask, uint8_t>
 {
 public:
     enum
@@ -655,7 +745,7 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ConnectivityTlv : public Tlv
+class ConnectivityTlv : public Tlv, public TlvInfo<Tlv::kConnectivity>
 {
 public:
     /**
@@ -880,12 +970,12 @@ private:
  * This class specifies Status TLV status values.
  *
  */
-struct StatusTlv
+struct StatusTlv : public UintTlvInfo<Tlv::kStatus, uint8_t>
 {
     /**
      * Status values.
      */
-    enum Status
+    enum Status : uint8_t
     {
         kError = 1, ///< Error.
     };
@@ -991,7 +1081,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ChannelTlv : public Tlv
+class ChannelTlv : public Tlv, public TlvInfo<Tlv::kChannel>
 {
 public:
     /**
@@ -1056,7 +1146,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class TimeRequestTlv : public Tlv
+class TimeRequestTlv : public Tlv, public TlvInfo<Tlv::kTimeRequest>
 {
 public:
     /**
@@ -1084,7 +1174,7 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class TimeParameterTlv : public Tlv
+class TimeParameterTlv : public Tlv, public TlvInfo<Tlv::kTimeParameter>
 {
 public:
     /**
@@ -1150,7 +1240,9 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ActiveTimestampTlv : public Tlv, public MeshCoP::Timestamp
+class ActiveTimestampTlv : public Tlv,
+                           public MeshCoP::Timestamp,
+                           public SimpleTlvInfo<Tlv::kActiveTimestamp, MeshCoP::Timestamp>
 {
 public:
     /**
@@ -1159,7 +1251,7 @@ public:
      */
     void Init(void)
     {
-        SetType(Mle::Tlv::kActiveTimestamp);
+        SetType(Tlv::kActiveTimestamp);
         SetLength(sizeof(*this) - sizeof(Tlv));
         Timestamp::Init();
     }
@@ -1179,7 +1271,9 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class PendingTimestampTlv : public Tlv, public MeshCoP::Timestamp
+class PendingTimestampTlv : public Tlv,
+                            public MeshCoP::Timestamp,
+                            public SimpleTlvInfo<Tlv::kPendingTimestamp, MeshCoP::Timestamp>
 {
 public:
     /**
@@ -1188,7 +1282,7 @@ public:
      */
     void Init(void)
     {
-        SetType(Mle::Tlv::kPendingTimestamp);
+        SetType(Tlv::kPendingTimestamp);
         SetLength(sizeof(*this) - sizeof(Tlv));
         Timestamp::Init();
     }
@@ -1209,7 +1303,7 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class CslChannelTlv : public Tlv
+class CslChannelTlv : public Tlv, public TlvInfo<Tlv::kCslChannel>
 {
 public:
     /**

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -407,13 +407,13 @@ otError MlrManager::SendMulticastListenerRegistrationMessage(const otIp6Address 
 #if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
     if (Get<MeshCoP::Commissioner>().IsActive())
     {
-        SuccessOrExit(error = ThreadTlv::AppendUint16Tlv(*message, ThreadTlv::kCommissionerSessionId,
-                                                         Get<MeshCoP::Commissioner>().GetSessionId()));
+        SuccessOrExit(
+            error = Tlv::Append<ThreadCommissionerSessionIdTlv>(*message, Get<MeshCoP::Commissioner>().GetSessionId()));
     }
 
     if (aTimeout != nullptr)
     {
-        SuccessOrExit(error = Tlv::AppendUint32Tlv(*message, ThreadTlv::kTimeout, *aTimeout));
+        SuccessOrExit(error = Tlv::Append<ThreadTimeoutTlv>(*message, *aTimeout));
     }
 #else
     OT_ASSERT(aTimeout == nullptr);
@@ -505,7 +505,7 @@ otError MlrManager::ParseMulticastListenerRegistrationResponse(otError        aR
     VerifyOrExit(aResult == OT_ERROR_NONE && aMessage != nullptr, error = OT_ERROR_PARSE);
     VerifyOrExit(aMessage->GetCode() == Coap::kCodeChanged, error = OT_ERROR_PARSE);
 
-    SuccessOrExit(error = Tlv::FindUint8Tlv(*aMessage, ThreadTlv::kStatus, aStatus));
+    SuccessOrExit(error = Tlv::Find<ThreadStatusTlv>(*aMessage, aStatus));
 
     if (ThreadTlv::FindTlvValueOffset(*aMessage, IPv6AddressesTlv::kIPv6Addresses, addressesOffset, addressesLength) ==
         OT_ERROR_NONE)

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -822,7 +822,7 @@ otError NetworkData::SendServerDataNotification(uint16_t aRloc16, Coap::Response
 
     if (aRloc16 != Mac::kShortAddrInvalid)
     {
-        SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, ThreadTlv::kRloc16, aRloc16));
+        SuccessOrExit(error = Tlv::Append<ThreadRloc16Tlv>(*message, aRloc16));
     }
 
     IgnoreError(Get<Mle::MleRouter>().GetLeaderAloc(messageInfo.GetPeerAddr()));

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -146,7 +146,7 @@ void Leader::HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &a
 
     VerifyOrExit(aMessageInfo.GetPeerAddr().GetIid().IsRoutingLocator());
 
-    switch (Tlv::FindUint16Tlv(aMessage, ThreadTlv::kRloc16, rloc16))
+    switch (Tlv::Find<ThreadRloc16Tlv>(aMessage, rloc16))
     {
     case OT_ERROR_NONE:
         RemoveBorderRouter(rloc16, kMatchModeRloc16);
@@ -157,7 +157,7 @@ void Leader::HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &a
         ExitNow();
     }
 
-    if (ThreadTlv::FindTlv(aMessage, ThreadTlv::kThreadNetworkData, sizeof(networkData), networkData) == OT_ERROR_NONE)
+    if (Tlv::FindTlv(aMessage, networkData) == OT_ERROR_NONE)
     {
         VerifyOrExit(networkData.IsValid());
         RegisterNetworkData(aMessageInfo.GetPeerAddr().GetIid().GetLocator(), networkData.GetTlvs(),
@@ -369,7 +369,7 @@ void Leader::SendCommissioningSetResponse(const Coap::Message &    aRequest,
     SuccessOrExit(error = message->SetDefaultResponseHeader(aRequest));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    SuccessOrExit(error = Tlv::AppendUint8Tlv(*message, MeshCoP::Tlv::kState, static_cast<uint8_t>(aState)));
+    SuccessOrExit(error = Tlv::Append<MeshCoP::StateTlv>(*message, aState));
 
     SuccessOrExit(error = Get<Tmf::TmfAgent>().SendMessage(*message, aMessageInfo));
 

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -104,7 +104,7 @@ otError NetworkDiagnostic::SendDiagnosticGet(const Ip6::Address &aDestination,
 
     if (aCount > 0)
     {
-        SuccessOrExit(error = Tlv::AppendTlv(*message, NetworkDataTlv::kTypeList, aTlvTypes, aCount));
+        SuccessOrExit(error = Tlv::Append<TypeListTlv>(*message, aTlvTypes, aCount));
     }
 
     if (aDestination.IsLinkLocal() || aDestination.IsLinkLocalMulticast())
@@ -298,22 +298,21 @@ otError NetworkDiagnostic::FillRequestedTlvs(const Message &       aRequest,
         switch (type)
         {
         case NetworkDiagnosticTlv::kExtMacAddress:
-            SuccessOrExit(
-                error = Tlv::AppendTlv(aResponse, type, &Get<Mac::Mac>().GetExtAddress(), sizeof(Mac::ExtAddress)));
+            SuccessOrExit(error = Tlv::Append<ExtMacAddressTlv>(aResponse, Get<Mac::Mac>().GetExtAddress()));
             break;
 
         case NetworkDiagnosticTlv::kAddress16:
-            SuccessOrExit(error = Tlv::AppendUint16Tlv(aResponse, type, Get<Mle::MleRouter>().GetRloc16()));
+            SuccessOrExit(error = Tlv::Append<Address16Tlv>(aResponse, Get<Mle::MleRouter>().GetRloc16()));
             break;
 
         case NetworkDiagnosticTlv::kMode:
-            SuccessOrExit(error = Tlv::AppendUint8Tlv(aResponse, type, Get<Mle::MleRouter>().GetDeviceMode().Get()));
+            SuccessOrExit(error = Tlv::Append<ModeTlv>(aResponse, Get<Mle::MleRouter>().GetDeviceMode().Get()));
             break;
 
         case NetworkDiagnosticTlv::kTimeout:
             if (!Get<Mle::MleRouter>().IsRxOnWhenIdle())
             {
-                SuccessOrExit(error = Tlv::AppendUint32Tlv(aResponse, type, Get<Mle::MleRouter>().GetTimeout()));
+                SuccessOrExit(error = Tlv::Append<TimeoutTlv>(aResponse, Get<Mle::MleRouter>().GetTimeout()));
             }
 
             break;
@@ -360,7 +359,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(const Message &       aRequest,
             uint8_t length = sizeof(netData);
 
             IgnoreError(Get<NetworkData::Leader>().GetNetworkData(/* aStableOnly */ false, netData, length));
-            SuccessOrExit(error = Tlv::AppendTlv(aResponse, type, netData, length));
+            SuccessOrExit(error = Tlv::Append<NetworkDataTlv>(aResponse, netData, length));
             break;
         }
 
@@ -436,7 +435,7 @@ otError NetworkDiagnostic::FillRequestedTlvs(const Message &       aRequest,
 
             if (Get<Mle::MleRouter>().GetMaxChildTimeout(maxTimeout) == OT_ERROR_NONE)
             {
-                SuccessOrExit(error = Tlv::AppendUint32Tlv(aResponse, type, maxTimeout));
+                SuccessOrExit(error = Tlv::Append<MaxChildTimeoutTlv>(aResponse, maxTimeout));
             }
 
             break;
@@ -585,7 +584,7 @@ otError NetworkDiagnostic::SendDiagnosticReset(const Ip6::Address &aDestination,
 
     if (aCount > 0)
     {
-        SuccessOrExit(error = Tlv::AppendTlv(*message, NetworkDataTlv::kTypeList, aTlvTypes, aCount));
+        SuccessOrExit(error = Tlv::Append<TypeListTlv>(*message, aTlvTypes, aCount));
     }
 
     if (aDestination.IsLinkLocal() || aDestination.IsLinkLocalMulticast())
@@ -743,25 +742,25 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
         switch (tlv.GetType())
         {
         case NetworkDiagnosticTlv::kExtMacAddress:
-            SuccessOrExit(
-                error = Tlv::ReadTlv(aMessage, offset, &aNetworkDiagTlv.mData.mExtAddress, sizeof(Mac::ExtAddress)));
+            SuccessOrExit(error = Tlv::Read<ExtMacAddressTlv>(
+                              aMessage, offset, static_cast<Mac::ExtAddress &>(aNetworkDiagTlv.mData.mExtAddress)));
             break;
 
         case NetworkDiagnosticTlv::kAddress16:
-            SuccessOrExit(error = Tlv::ReadUint16Tlv(aMessage, offset, aNetworkDiagTlv.mData.mAddr16));
+            SuccessOrExit(error = Tlv::Read<Address16Tlv>(aMessage, offset, aNetworkDiagTlv.mData.mAddr16));
             break;
 
         case NetworkDiagnosticTlv::kMode:
         {
             uint8_t mode;
 
-            SuccessOrExit(error = Tlv::ReadUint8Tlv(aMessage, offset, mode));
+            SuccessOrExit(error = Tlv::Read<ModeTlv>(aMessage, offset, mode));
             ParseMode(Mle::DeviceMode(mode), aNetworkDiagTlv.mData.mMode);
             break;
         }
 
         case NetworkDiagnosticTlv::kTimeout:
-            SuccessOrExit(error = Tlv::ReadUint32Tlv(aMessage, offset, aNetworkDiagTlv.mData.mTimeout));
+            SuccessOrExit(error = Tlv::Read<TimeoutTlv>(aMessage, offset, aNetworkDiagTlv.mData.mTimeout));
             break;
 
         case NetworkDiagnosticTlv::kConnectivity:
@@ -840,11 +839,11 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
         }
 
         case NetworkDiagnosticTlv::kBatteryLevel:
-            SuccessOrExit(error = Tlv::ReadUint8Tlv(aMessage, offset, aNetworkDiagTlv.mData.mBatteryLevel));
+            SuccessOrExit(error = Tlv::Read<BatteryLevelTlv>(aMessage, offset, aNetworkDiagTlv.mData.mBatteryLevel));
             break;
 
         case NetworkDiagnosticTlv::kSupplyVoltage:
-            SuccessOrExit(error = Tlv::ReadUint16Tlv(aMessage, offset, aNetworkDiagTlv.mData.mSupplyVoltage));
+            SuccessOrExit(error = Tlv::Read<SupplyVoltageTlv>(aMessage, offset, aNetworkDiagTlv.mData.mSupplyVoltage));
             break;
 
         case NetworkDiagnosticTlv::kChildTable:
@@ -876,7 +875,8 @@ otError NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
         }
 
         case NetworkDiagnosticTlv::kMaxChildTimeout:
-            SuccessOrExit(error = Tlv::ReadUint32Tlv(aMessage, offset, aNetworkDiagTlv.mData.mMaxChildTimeout));
+            SuccessOrExit(error =
+                              Tlv::Read<MaxChildTimeoutTlv>(aMessage, offset, aNetworkDiagTlv.mData.mMaxChildTimeout));
             break;
 
         default:

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -119,11 +119,53 @@ public:
 } OT_TOOL_PACKED_END;
 
 /**
+ * This class defines Extended MAC Address TLV constants and types.
+ *
+ */
+typedef SimpleTlvInfo<NetworkDiagnosticTlv::kExtMacAddress, Mac::ExtAddress> ExtMacAddressTlv;
+
+/**
+ * This class defines Address16 TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<NetworkDiagnosticTlv::kAddress16, uint16_t> Address16Tlv;
+
+/**
+ * This class defines Mode TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<NetworkDiagnosticTlv::kMode, uint8_t> ModeTlv;
+
+/**
+ * This class defines Timeout TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<NetworkDiagnosticTlv::kTimeout, uint32_t> TimeoutTlv;
+
+/**
+ * This class defines Battery Level TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<NetworkDiagnosticTlv::kBatteryLevel, uint8_t> BatteryLevelTlv;
+
+/**
+ * This class defines Supply Voltage TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<NetworkDiagnosticTlv::kSupplyVoltage, uint16_t> SupplyVoltageTlv;
+
+/**
+ * This class defines Max Child Timeout TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<NetworkDiagnosticTlv::kMaxChildTimeout, uint32_t> MaxChildTimeoutTlv;
+
+/**
  * This class implements Connectivity TLV generation and parsing.
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ConnectivityTlv : public NetworkDiagnosticTlv
+class ConnectivityTlv : public NetworkDiagnosticTlv, public TlvInfo<NetworkDiagnosticTlv::kConnectivity>
 {
 public:
     /**
@@ -346,7 +388,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class RouteTlv : public NetworkDiagnosticTlv
+class RouteTlv : public NetworkDiagnosticTlv, public TlvInfo<NetworkDiagnosticTlv::kRoute>
 {
 public:
     /**
@@ -514,7 +556,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class LeaderDataTlv : public NetworkDiagnosticTlv
+class LeaderDataTlv : public NetworkDiagnosticTlv, public TlvInfo<NetworkDiagnosticTlv::kLeaderData>
 {
 public:
     /**
@@ -629,7 +671,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class NetworkDataTlv : public NetworkDiagnosticTlv
+class NetworkDataTlv : public NetworkDiagnosticTlv, public TlvInfo<NetworkDiagnosticTlv::kNetworkData>
 {
 public:
     /**
@@ -676,7 +718,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class Ip6AddressListTlv : public NetworkDiagnosticTlv
+class Ip6AddressListTlv : public NetworkDiagnosticTlv, public TlvInfo<NetworkDiagnosticTlv::kIp6AddressList>
 {
 public:
     /**
@@ -718,7 +760,7 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class MacCountersTlv : public NetworkDiagnosticTlv
+class MacCountersTlv : public NetworkDiagnosticTlv, public TlvInfo<NetworkDiagnosticTlv::kMacCounters>
 {
 public:
     /**
@@ -1020,7 +1062,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ChildTableTlv : public NetworkDiagnosticTlv
+class ChildTableTlv : public NetworkDiagnosticTlv, public TlvInfo<NetworkDiagnosticTlv::kChildTable>
 {
 public:
     /**
@@ -1089,7 +1131,7 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ChannelPagesTlv : public NetworkDiagnosticTlv
+class ChannelPagesTlv : public NetworkDiagnosticTlv, public TlvInfo<NetworkDiagnosticTlv::kChannelPages>
 {
 public:
     /**
@@ -1132,7 +1174,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class TypeListTlv : public NetworkDiagnosticTlv
+class TypeListTlv : public NetworkDiagnosticTlv, public TlvInfo<NetworkDiagnosticTlv::kTypeList>
 {
 public:
     /**

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -71,7 +71,7 @@ void PanIdQueryServer::HandleQuery(Coap::Message &aMessage, const Ip6::MessageIn
     VerifyOrExit(aMessage.IsPostRequest());
     VerifyOrExit((mask = MeshCoP::ChannelMaskTlv::GetChannelMask(aMessage)) != 0);
 
-    SuccessOrExit(Tlv::FindUint16Tlv(aMessage, MeshCoP::Tlv::kPanId, panId));
+    SuccessOrExit(Tlv::Find<MeshCoP::PanIdTlv>(aMessage, panId));
 
     mChannelMask  = mask;
     mCommissioner = aMessageInfo.GetPeerAddr();
@@ -124,7 +124,7 @@ void PanIdQueryServer::SendConflict(void)
     channelMask.SetChannelMask(mChannelMask);
     SuccessOrExit(error = channelMask.AppendTo(*message));
 
-    SuccessOrExit(error = Tlv::AppendUint16Tlv(*message, MeshCoP::Tlv::kPanId, mPanId));
+    SuccessOrExit(error = Tlv::Append<MeshCoP::PanIdTlv>(*message, mPanId));
 
     messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetPeerAddr(mCommissioner);

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -104,17 +104,65 @@ public:
 } OT_TOOL_PACKED_END;
 
 /**
- * This class defines Status TLV constants.
+ * This class defines Target TLV constants and types.
  *
  */
-class ThreadStatusTlv
+typedef SimpleTlvInfo<ThreadTlv::kTarget, Ip6::Address> ThreadTargetTlv;
+
+/**
+ * This class defines Extended MAC Address TLV constants and types.
+ *
+ */
+typedef SimpleTlvInfo<ThreadTlv::kExtMacAddress, Mac::ExtAddress> ThreadExtMacAddressTlv;
+
+/**
+ * This class defines RLOC16 TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<ThreadTlv::kRloc16, uint16_t> ThreadRloc16Tlv;
+
+/**
+ * This class defines ML-EID TLV constants and types.
+ *
+ */
+typedef SimpleTlvInfo<ThreadTlv::kMeshLocalEid, Ip6::InterfaceIdentifier> ThreadMeshLocalEidTlv;
+
+/**
+ * This class defines Time Since Last Transaction TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<ThreadTlv::kLastTransactionTime, uint32_t> ThreadLastTransactionTimeTlv;
+
+/**
+ * This class defines Timeout TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<ThreadTlv::kTimeout, uint32_t> ThreadTimeoutTlv;
+
+/**
+ * This class defines Network Name TLV constants and types.
+ *
+ */
+typedef TlvInfo<ThreadTlv::kNetworkName> ThreadNetworkNameTlv;
+
+/**
+ * This class defines Commissioner Session ID TLV constants and types.
+ *
+ */
+typedef UintTlvInfo<ThreadTlv::kCommissionerSessionId, uint16_t> ThreadCommissionerSessionIdTlv;
+
+/**
+ * This class defines Status TLV constants and types.
+ *
+ */
+class ThreadStatusTlv : public UintTlvInfo<ThreadTlv::kStatus, uint8_t>
 {
 public:
     /**
      * Status values.
      *
      */
-    enum Status
+    enum Status : uint8_t
     {
         kSuccess               = 0, ///< Success.
         kNoAddressAvailable    = 1, ///< No address available.
@@ -158,7 +206,7 @@ public:
  * This class implements Router Mask TLV generation and parsing.
  *
  */
-class ThreadRouterMaskTlv : public ThreadTlv
+class ThreadRouterMaskTlv : public ThreadTlv, public TlvInfo<ThreadTlv::kRouterMask>
 {
 public:
     /**
@@ -223,7 +271,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ThreadNetworkDataTlv : public ThreadTlv
+class ThreadNetworkDataTlv : public ThreadTlv, public TlvInfo<ThreadTlv::kThreadNetworkData>
 {
 public:
     /**
@@ -268,7 +316,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class IPv6AddressesTlv : public ThreadTlv
+class IPv6AddressesTlv : public ThreadTlv, public TlvInfo<ThreadTlv::kIPv6Addresses>
 {
 public:
     /**


### PR DESCRIPTION
This commit adds template flavors of `Append<Tlv>()`, `Find<Tlv>()`,
and `Read<Tlv>()` in the common base `Tlv` class. This helps simplify
the processing and generating of TLVs in other modules and also adds
build-time type check for the value of simple TLVs (build error when
incorrect TLV Value type is used).

All `Tlv` sub-classes now inherit from `TlvInfo<kTlvType>` which
provides a constant `kType` specifying the TLV Type value. Simple TLVs
which contain a single value also track their TLV Value type by
inheriting from either `UintTlvInfo` (when their value is an integral
(unsigned int) type) or `SimpleTlvInfo` (when their value is
non-integral).

This commit also add `IsSame<A,B>()` to `TypeTraits` to check whether
two given types are the same. It also adds template flavors of
`HostSwap<IntType>()` in `Encoding` module.

----------

#### More details:
The new model from this PR helps simplify the use of these methods. 
We go from the following:
```
Tlv::FindTlv(aMessage, Tlv::kNetworkMasterKey, &key, sizeof(key))
Tlv::FindTlv(aMessage, ThreadTlv::kMeshLocalEid, &mlIid, sizeof(mlIid)));
Tlv::FindUint16Tlv(aMessage, MeshCoP::Tlv::kPeriod, period);
Tlv::FindTlv(aMessage, ThreadTlv::kRouterMask, sizeof(routerMaskTlv), routerMaskTlv);
```
to
```
Tlv::Find<NetworkMasterKeyTlv>(aMessage, key)
Tlv::Find<ThreadMeshLocalEidTlv>(aMessage, mlIid));
Tlv::Find<MeshCoP::PeriodTlv>(aMessage, period);
Tlv::FindTlv(aMessage, routerMaskTlv);           // Read entire TLV with template type deduced
```

It also adds TLV value type checking at build-time. For example, if `NetworkMasterKeyTlv` 
is used with value type other than `MasterKey`, or `MeshCoP::PeriodTlv` with any type other 
than  `uint16_t`,  we get a compile-time error.
