### PR TITLE
[efr32] Use -mfpu=fpv4-sp-d16 for efr32mg1x chips

### DIFF
--- a/examples/Makefile-efr32mg1
+++ b/examples/Makefile-efr32mg1
@@ -266,10 +266,10 @@ all: stage
 #
 
 cortex-m4_target_ABI                  = cortex-m4
-cortex-m4_target_CPPFLAGS             = -mcpu=cortex-m4 -mfloat-abi=softfp -mthumb
-cortex-m4_target_CFLAGS               = -mcpu=cortex-m4 -mfloat-abi=softfp -mthumb
-cortex-m4_target_CXXFLAGS             = -mcpu=cortex-m4 -mfloat-abi=softfp -mthumb
-cortex-m4_target_LDFLAGS              = -mcpu=cortex-m4 -mfloat-abi=softfp -mthumb
+cortex-m4_target_CPPFLAGS             = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
+cortex-m4_target_CFLAGS               = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
+cortex-m4_target_CXXFLAGS             = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
+cortex-m4_target_LDFLAGS              = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
 
 # Instantiate an architecture-specific build template for each target
 # architecture.

--- a/examples/Makefile-efr32mg12
+++ b/examples/Makefile-efr32mg12
@@ -284,10 +284,10 @@ all: stage
 #
 
 cortex-m4_target_ABI                  = cortex-m4
-cortex-m4_target_CPPFLAGS             = -mcpu=cortex-m4 -mfloat-abi=softfp -mthumb
-cortex-m4_target_CFLAGS               = -mcpu=cortex-m4 -mfloat-abi=softfp -mthumb
-cortex-m4_target_CXXFLAGS             = -mcpu=cortex-m4 -mfloat-abi=softfp -mthumb
-cortex-m4_target_LDFLAGS              = -mcpu=cortex-m4 -mfloat-abi=softfp -mthumb
+cortex-m4_target_CPPFLAGS             = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
+cortex-m4_target_CFLAGS               = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
+cortex-m4_target_CXXFLAGS             = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
+cortex-m4_target_LDFLAGS              = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
 
 # Instantiate an architecture-specific build template for each target
 # architecture.

--- a/examples/Makefile-efr32mg13
+++ b/examples/Makefile-efr32mg13
@@ -270,10 +270,10 @@ all: stage
 #
 
 cortex-m4_target_ABI                  = cortex-m4
-cortex-m4_target_CPPFLAGS             = -mcpu=cortex-m4 -mfloat-abi=softfp -mthumb
-cortex-m4_target_CFLAGS               = -mcpu=cortex-m4 -mfloat-abi=softfp -mthumb
-cortex-m4_target_CXXFLAGS             = -mcpu=cortex-m4 -mfloat-abi=softfp -mthumb
-cortex-m4_target_LDFLAGS              = -mcpu=cortex-m4 -mfloat-abi=softfp -mthumb
+cortex-m4_target_CPPFLAGS             = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
+cortex-m4_target_CFLAGS               = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
+cortex-m4_target_CXXFLAGS             = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
+cortex-m4_target_LDFLAGS              = -mcpu=cortex-m4 -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb
 
 # Instantiate an architecture-specific build template for each target
 # architecture.


### PR DESCRIPTION
This fixes a bug where Series 1 chips are failing to boot when compiles with `arm-none-eabi-gcc` version 7.2.1