### PR TITLE
[mle] add helper 'ReadFrameCounters()' to read Link/MLE Frame Counters

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1045,6 +1045,24 @@ protected:
     otError AppendLinkFrameCounter(Message &aMessage);
 
     /**
+     * This method reads Link and MLE Frame Counters from a message.
+     *
+     * Link Frame Counter TLV must be present in the message and its value is read into @p aLinkFrameCounter. If MLE
+     * Frame Counter TLV is present in the message, its value is read into @p aMleFrameCounter. If the MLE Frame
+     * Counter TLV is not present in the message, then @p aMleFrameCounter is set to same value as @p aLinkFrameCounter.
+     *
+     * @param[in]  aMesssage           A reference to the message to read from.
+     * @param[out] aLinkFrameCounter   A reference to an `uint32_t` to output the Link Frame Counter.
+     * @param[out] aMleFrameCounter    A reference to an `uint32_t` to output the MLE Frame Counter.
+     *
+     * @retval OT_ERROR_NONE       Successfully read the counters.
+     * @retval OT_ERROR_NOT_FOUND  Link Frame Counter TLV was not found in the message.
+     * @retval OT_ERROR_PARSE      TLVs are not well-formed.
+     *
+     */
+    otError ReadFrameCounters(const Message &aMessage, uint32_t &aLinkFrameCounter, uint32_t &aMleFrameCounter) const;
+
+    /**
      * This method appends an MLE Frame Counter TLV to a message.
      *
      * @param[in]  aMessage  A reference to the message.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -838,20 +838,8 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
     SuccessOrExit(error = Tlv::Find<VersionTlv>(aMessage, version));
     VerifyOrExit(version >= OT_THREAD_VERSION_1_1, error = OT_ERROR_PARSE);
 
-    // Link-Layer Frame Counter
-    SuccessOrExit(error = Tlv::Find<LinkFrameCounterTlv>(aMessage, linkFrameCounter));
-
-    // MLE Frame Counter
-    switch (Tlv::Find<MleFrameCounterTlv>(aMessage, mleFrameCounter))
-    {
-    case OT_ERROR_NONE:
-        break;
-    case OT_ERROR_NOT_FOUND:
-        mleFrameCounter = linkFrameCounter;
-        break;
-    default:
-        ExitNow(error = OT_ERROR_PARSE);
-    }
+    // Link and MLE Frame Counters
+    SuccessOrExit(error = ReadFrameCounters(aMessage, linkFrameCounter, mleFrameCounter));
 
     // Link Margin
     switch (Tlv::Find<LinkMarginTlv>(aMessage, linkMargin))
@@ -2220,20 +2208,8 @@ void MleRouter::HandleChildIdRequest(const Message &         aMessage,
     Get<MeshForwarder>().RemoveMessages(*child, Message::kSubTypeMleChildUpdateRequest);
     Get<MeshForwarder>().RemoveMessages(*child, Message::kSubTypeMleDataResponse);
 
-    // Link-Layer Frame Counter
-    SuccessOrExit(error = Tlv::Find<LinkFrameCounterTlv>(aMessage, linkFrameCounter));
-
-    // MLE Frame Counter
-    switch (Tlv::Find<MleFrameCounterTlv>(aMessage, mleFrameCounter))
-    {
-    case OT_ERROR_NONE:
-        break;
-    case OT_ERROR_NOT_FOUND:
-        mleFrameCounter = linkFrameCounter;
-        break;
-    default:
-        ExitNow(error = OT_ERROR_PARSE);
-    }
+    // Link-Layer and MLE Frame Counters
+    SuccessOrExit(error = ReadFrameCounters(aMessage, linkFrameCounter, mleFrameCounter));
 
     // Mode
     SuccessOrExit(error = Tlv::Find<ModeTlv>(aMessage, modeBitmask));


### PR DESCRIPTION
This commits adds a common helper method to read Link and/or MLE Frame
Counters from a message. The Link Frame Counter TLV is expected to be
present in the message. The MLE Frame Counter TLV, however, is optional
and when not present the Link Frame Counter is also used as MLE Frame
Counter value.