### PR TITLE
[clearable] reuse clearable for some classes

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -132,7 +132,7 @@ Mac::Mac(Instance &aInstance)
 
     randomExtAddress.GenerateRandom();
 
-    mCcaSuccessRateTracker.Reset();
+    mCcaSuccessRateTracker.Clear();
     ResetCounters();
     mExtendedPanId.Clear();
 
@@ -428,7 +428,7 @@ otError Mac::SetPanChannel(uint8_t aChannel)
 
     SuccessOrExit(Get<Notifier>().Update(mPanChannel, aChannel, kEventThreadChannelChanged));
 
-    mCcaSuccessRateTracker.Reset();
+    mCcaSuccessRateTracker.Clear();
 
     VerifyOrExit(!mUsingTemporaryChannel);
 

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -54,8 +54,8 @@ void LinkMetricsSeriesInfo::Init(uint8_t              aSeriesId,
     mLinkMetrics.mLqi        = aLinkMetricsFlags.mLqi;
     mLinkMetrics.mLinkMargin = aLinkMetricsFlags.mLinkMargin;
     mLinkMetrics.mRssi       = aLinkMetricsFlags.mRssi;
-    mRssAverager.Reset();
-    mLqiAverager.Reset();
+    mRssAverager.Clear();
+    mLqiAverager.Clear();
     mPduCount = 0;
 }
 

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -58,12 +58,6 @@ void SuccessRateTracker::AddSample(bool aSuccess, uint16_t aWeight)
     mFailureRate = static_cast<uint16_t>(((oldAverage * (n - 1)) + newValue + (n / 2)) / n);
 }
 
-void RssAverager::Reset(void)
-{
-    mAverage = 0;
-    mCount   = 0;
-}
-
 otError RssAverager::Add(int8_t aRss)
 {
     otError  error = OT_ERROR_NONE;
@@ -121,12 +115,6 @@ exit:
     return string;
 }
 
-void LqiAverager::Reset(void)
-{
-    mCount   = 0;
-    mAverage = 0;
-}
-
 void LqiAverager::Add(uint8_t aLqi)
 {
     uint8_t count;
@@ -142,12 +130,12 @@ void LqiAverager::Add(uint8_t aLqi)
 
 void LinkQualityInfo::Clear(void)
 {
-    mRssAverager.Reset();
+    mRssAverager.Clear();
     SetLinkQuality(0);
     mLastRss = OT_RADIO_RSSI_INVALID;
 
-    mFrameErrorRate.Reset();
-    mMessageErrorRate.Reset();
+    mFrameErrorRate.Clear();
+    mMessageErrorRate.Clear();
 }
 
 void LinkQualityInfo::AddRss(int8_t aRss)

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/platform/radio.h>
 
+#include "common/clearable.hpp"
 #include "common/locator.hpp"
 #include "common/string.hpp"
 
@@ -59,19 +60,13 @@ namespace ot {
  * The success rate is maintained using an exponential moving IIR averaging filter with a `uint16_t` as the storage.
  *
  */
-class SuccessRateTracker
+class SuccessRateTracker : public Clearable<SuccessRateTracker>
 {
 public:
     enum
     {
         kMaxRateValue = 0xffff, ///< Indicates value corresponding to maximum (failure/success) rate of 100%.
     };
-
-    /**
-     * This method resets the tracker to its initialized state, setting success rate to 100%.
-     *
-     */
-    void Reset(void) { mFailureRate = 0; }
 
     /**
      * This method adds a sample (success or failure) to `SuccessRateTracker`.
@@ -113,7 +108,7 @@ private:
  * The average is maintained using an adaptive exponentially weighted moving filter.
  *
  */
-class RssAverager
+class RssAverager : public Clearable<RssAverager>
 {
 public:
     enum
@@ -126,12 +121,6 @@ public:
      *
      */
     typedef String<kStringSize> InfoString;
-
-    /**
-     * This method reset the averager and clears the average value.
-     *
-     */
-    void Reset(void);
 
     /**
      * This method indicates whether the averager contains an average (i.e., at least one RSS value has been added).
@@ -217,15 +206,9 @@ private:
  * It maintains the exponential moving average value of LQI.
  *
  */
-class LqiAverager
+class LqiAverager : public Clearable<LqiAverager>
 {
 public:
-    /**
-     * This method resets the averager and clears the average value.
-     *
-     */
-    void Reset(void);
-
     /**
      * This method adds a link quality indicator (LQI) value to the average.
      *

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -162,9 +162,9 @@ void TestRssAveraging(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Values after initialization/reset.
 
-    rssAverager.Reset();
+    rssAverager.Clear();
 
-    printf("\nAfter Reset: ");
+    printf("\nAfter Clear: ");
     VerifyOrQuit(rssAverager.GetAverage() == OT_RADIO_RSSI_INVALID,
                  "TestLinkQualityInfo failed - Initial value from GetAverage() is incorrect.");
     VerifyRawRssValue(rssAverager);
@@ -180,12 +180,12 @@ void TestRssAveraging(void)
     PrintOutcome(rssAverager);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    // Reset
+    // Clear
 
-    printf("Reset(): ");
-    rssAverager.Reset();
+    printf("Clear(): ");
+    rssAverager.Clear();
     VerifyOrQuit(rssAverager.GetAverage() == OT_RADIO_RSSI_INVALID,
-                 "TestLinkQualityInfo failed - GetAverage() after Reset() is incorrect.");
+                 "TestLinkQualityInfo failed - GetAverage() after Clear() is incorrect.");
     VerifyRawRssValue(rssAverager);
     PrintOutcome(rssAverager);
 
@@ -196,7 +196,7 @@ void TestRssAveraging(void)
 
     for (j = 0; j < sizeof(rssValues); j++)
     {
-        rssAverager.Reset();
+        rssAverager.Clear();
         rss = rssValues[j];
         printf("AddRss(%4d) %d times: ", rss, kNumRssAdds);
 
@@ -228,7 +228,7 @@ void TestRssAveraging(void)
             }
 
             rss2 = rssValues[k];
-            rssAverager.Reset();
+            rssAverager.Clear();
             IgnoreError(rssAverager.Add(rss));
             IgnoreError(rssAverager.Add(rss2));
             printf("AddRss(%4d), AddRss(%4d): ", rss, rss2);
@@ -256,7 +256,7 @@ void TestRssAveraging(void)
             }
 
             rss2 = rssValues[k];
-            rssAverager.Reset();
+            rssAverager.Clear();
 
             for (i = 0; i < kNumRssAdds; i++)
             {
@@ -292,7 +292,7 @@ void TestRssAveraging(void)
             }
 
             rss2 = rssValues[k];
-            rssAverager.Reset();
+            rssAverager.Clear();
 
             for (i = 0; i < kNumRssAdds; i++)
             {
@@ -323,7 +323,7 @@ void TestRssAveraging(void)
     {
         double mean;
 
-        rssAverager.Reset();
+        rssAverager.Clear();
         sum = 0;
 
         printf("\n");
@@ -391,7 +391,7 @@ void TestSuccessRateTracker(void)
 
     printf("\nTesting SuccessRateTracker\n");
 
-    rateTracker.Reset();
+    rateTracker.Clear();
 
     VerifyOrQuit(rateTracker.GetSuccessRate() == kMaxRate, "SuccessRateTracker: Initial value incorrect");
     VerifyOrQuit(rateTracker.GetFailureRate() == 0, "SuccessRateTracker: Initial value incorrect");
@@ -405,7 +405,7 @@ void TestSuccessRateTracker(void)
         VerifyOrQuit(rateTracker.GetFailureRate() == 0, "SuccessRateTracker: incorrect rate in all success case");
     }
 
-    rateTracker.Reset();
+    rateTracker.Clear();
     VerifyOrQuit(rateTracker.GetSuccessRate() == kMaxRate, "SuccessRateTracker: Rate incorrect after reset");
     VerifyOrQuit(rateTracker.GetFailureRate() == 0, "SuccessRateTracker: Rate incorrect after reset");
 
@@ -439,7 +439,7 @@ void TestSuccessRateTracker(void)
         {
             uint16_t failureCount = 0;
 
-            rateTracker.Reset();
+            rateTracker.Clear();
 
             for (sampleCount = 1; sampleCount < kMaxSamples; sampleCount++)
             {


### PR DESCRIPTION
This PR applies `Clearable` for some classes in `link_quality` to replace `Reset` method and enhance consistency.