### PR TITLE
[linked-list] add an overload for LinkedList::FindMatching for convenience

### DIFF
--- a/src/core/common/linked_list.hpp
+++ b/src/core/common/linked_list.hpp
@@ -259,9 +259,7 @@ public:
      */
     template <typename Indicator> bool ContainsMatching(const Indicator &aIndicator) const
     {
-        const Type *prev;
-
-        return FindMatching(aIndicator, prev) != nullptr;
+        return FindMatching(aIndicator) != nullptr;
     }
 
     /**
@@ -503,6 +501,46 @@ public:
     {
         return const_cast<Type *>(
             const_cast<const LinkedList *>(this)->FindMatching(aIndicator, const_cast<const Type *&>(aPrevEntry)));
+    }
+
+    /**
+     * This template method searches within the linked list to find an entry matching a given indicator.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
+     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in]  aIndicator  An indicator to match with entries in the list.
+     *
+     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     *
+     */
+    template <typename Indicator> const Type *FindMatching(const Indicator &aIndicator) const
+    {
+        const Type *prev;
+
+        return FindMatching(aIndicator, prev);
+    }
+
+    /**
+     * This template method searches within the linked list to find an entry matching a given indicator.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
+     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in]  aIndicator  An indicator to match with entries in the list.
+     *
+     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     *
+     */
+    template <typename Indicator> Type *FindMatching(const Indicator &aIndicator)
+    {
+        return const_cast<Type *>(const_cast<const LinkedList *>(this)->FindMatching(aIndicator));
     }
 
     /**

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -117,9 +117,7 @@ Netif::Netif(Instance &aInstance)
 
 bool Netif::IsMulticastSubscribed(const Address &aAddress) const
 {
-    const NetifMulticastAddress *prev;
-
-    return mMulticastAddresses.FindMatching(aAddress, prev) != nullptr;
+    return mMulticastAddresses.ContainsMatching(aAddress);
 }
 
 void Netif::SubscribeAllNodesMulticast(void)
@@ -476,11 +474,10 @@ otError Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress)
 {
     otError              error = OT_ERROR_NONE;
     NetifUnicastAddress *entry;
-    NetifUnicastAddress *prev;
 
     VerifyOrExit(!aAddress.GetAddress().IsMulticast(), error = OT_ERROR_INVALID_ARGS);
 
-    entry = mUnicastAddresses.FindMatching(aAddress.GetAddress(), prev);
+    entry = mUnicastAddresses.FindMatching(aAddress.GetAddress());
 
     if (entry != nullptr)
     {
@@ -542,9 +539,7 @@ void Netif::RemoveAllExternalUnicastAddresses(void)
 
 bool Netif::HasUnicastAddress(const Address &aAddress) const
 {
-    const NetifUnicastAddress *prev;
-
-    return mUnicastAddresses.FindMatching(aAddress, prev) != nullptr;
+    return mUnicastAddresses.ContainsMatching(aAddress);
 }
 
 bool Netif::IsUnicastAddressExternal(const NetifUnicastAddress &aAddress) const

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -174,8 +174,7 @@ void Neighbor::AggregateLinkMetrics(uint8_t aSeriesId, uint8_t aFrameType, uint8
 
 LinkMetricsSeriesInfo *Neighbor::GetForwardTrackingSeriesInfo(const uint8_t &aSeriesId)
 {
-    LinkMetricsSeriesInfo *prev;
-    return mLinkMetricsSeriesInfoList.FindMatching(aSeriesId, prev);
+    return mLinkMetricsSeriesInfoList.FindMatching(aSeriesId);
 }
 
 void Neighbor::AddForwardTrackingSeriesInfo(LinkMetricsSeriesInfo &aLinkMetricsSeriesInfo)


### PR DESCRIPTION
This PR adds an overload version for `LinkedList::FindMatching` which doesn't require `prev` as parameter. In many cases we don't need to get the previous item's pointer when finding in a list. This version would help in these cases.