### PR TITLE
[tests] fix tun-realm-local-multicast.exp

### DIFF
--- a/tests/scripts/expect/tun-realm-local-multicast.exp
+++ b/tests/scripts/expect/tun-realm-local-multicast.exp
@@ -113,6 +113,7 @@ wait_for "state" "child"
 set mleid4 [get_mleid]
 
 switch_node 1
+sleep 10
 
 send "ping ${mleid4}\n"
 expect "Done"


### PR DESCRIPTION
Given the linear topology in this test, this commit
introduces wait time so that the Thread Links are
synced well before ping happens.