### PR TITLE
[low-power] fix csl simulation

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -356,8 +356,8 @@ void SubMac::StartCsmaBackoff(void)
 
         if (ShouldHandleTransmitTargetTime())
         {
-            if (otPlatRadioGetNow(&GetInstance()) <
-                mTransmitFrame.mInfo.mTxInfo.mTxDelayBaseTime + mTransmitFrame.mInfo.mTxInfo.mTxDelay)
+            if (Time(static_cast<uint32_t>(otPlatRadioGetNow(&GetInstance()))) <
+                Time(mTransmitFrame.mInfo.mTxInfo.mTxDelayBaseTime) + mTransmitFrame.mInfo.mTxInfo.mTxDelay)
             {
                 mTimer.StartAt(Time(mTransmitFrame.mInfo.mTxInfo.mTxDelayBaseTime),
                                mTransmitFrame.mInfo.mTxInfo.mTxDelay);


### PR DESCRIPTION
This PR fixes #5783.

The cause is that, on nRF platform, `otPlatRadioGetNow` always gets the LSB part of an `uint64_t` time. However, on simulation platform, this is not the case. So in
```
            if (otPlatRadioGetNow(&GetInstance()) <
                mTransmitFrame.mInfo.mTxInfo.mTxDelayBaseTime + mTransmitFrame.mInfo.mTxInfo.mTxDelay)
```
we don't get the result expected. `otPlatRadioGetNow(&GetInstance())` is a very big number on simulation platform, and `mTxDelayBaseTime` is the LSB part of the rx time.