### PR TITLE
[posix] increase max log size

### DIFF
--- a/src/posix/platform/openthread-core-posix-config.h
+++ b/src/posix/platform/openthread-core-posix-config.h
@@ -116,4 +116,14 @@
 
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_LOG_MAX_SIZE
+ *
+ * The maximum log string size (number of chars).
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_LOG_MAX_SIZE
+#define OPENTHREAD_CONFIG_LOG_MAX_SIZE 1024
+#endif
+
 #endif // OPENTHREAD_CORE_POSIX_CONFIG_H_


### PR DESCRIPTION
This commit increases the `OPENTHREAD_CONFIG_LOG_MAX_SIZE` from 150 to 1024 for posix.