### PR TITLE
[toranj] use msg pool (do not use heap) in toranj config

### DIFF
--- a/tests/toranj/openthread-core-toranj-config.h
+++ b/tests/toranj/openthread-core-toranj-config.h
@@ -125,7 +125,7 @@
  * Whether use heap allocator for message buffers.
  *
  */
-#define OPENTHREAD_CONFIG_MESSAGE_USE_HEAP_ENABLE 1
+#define OPENTHREAD_CONFIG_MESSAGE_USE_HEAP_ENABLE 0
 
 /**
  * @def OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_ENTRIES


### PR DESCRIPTION

-------

Background on this:
I recently rebased the multi-radio/trel branch from #4440 on master, noticed that a bunch of test-cases under multi-radio/hybrid topology [were failing](https://github.com/abtink/openthread/runs/1409330167). After investigating further discovered that it is related to the change from https://github.com/openthread/openthread/pull/5792 where we use of heap for msg pool (mainly that the number of msg buffers (derived from default heap size) is not enough for the some test-cases where we send a lot of traffic).

We can increase the heap size but I prefer to continue to use msg pool with known/configured number of msgs in `toranj` test cases (we already have `#define OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS 256` in `toranj-config` which ensures we have enough msg buffer for all test-cases).  Also using msg pool allows us to later extend and add test-cases to verify the eviction logic in OT.