### PR TITLE
[tests] fix tun-realm-local-multicast.exp

### DIFF
--- a/tests/scripts/expect/tun-realm-local-multicast.exp
+++ b/tests/scripts/expect/tun-realm-local-multicast.exp
@@ -66,6 +66,7 @@ send "thread start\n"
 expect "Done"
 
 wait_for "state" "router"
+sleep 3
 
 spawn_node 3 cli
 
@@ -85,6 +86,7 @@ send "thread start\n"
 expect "Done"
 
 wait_for "state" "router"
+sleep 4
 
 set extaddr3 [get_extaddr]
 
@@ -113,7 +115,6 @@ wait_for "state" "child"
 set mleid4 [get_mleid]
 
 switch_node 1
-sleep 10
 
 send "ping ${mleid4}\n"
 expect "Done"


### PR DESCRIPTION
This commit introduces short wait time per new router
to allow link/route establishment.