### PR TITLE
[cli] add helper 'Output()' methods which prepend indentation space

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1057,24 +1057,24 @@ otError Interpreter::ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[])
         OutputLine("Stopped: %s", metrics.mStopped ? "true" : "false");
         OutputLine("Grant Glitch: %u", metrics.mNumGrantGlitch);
         OutputLine("Transmit metrics");
-        OutputLine("    Request: %u", metrics.mNumTxRequest);
-        OutputLine("    Grant Immediate: %u", metrics.mNumTxGrantImmediate);
-        OutputLine("    Grant Wait: %u", metrics.mNumTxGrantWait);
-        OutputLine("    Grant Wait Activated: %u", metrics.mNumTxGrantWaitActivated);
-        OutputLine("    Grant Wait Timeout: %u", metrics.mNumTxGrantWaitTimeout);
-        OutputLine("    Grant Deactivated During Request: %u", metrics.mNumTxGrantDeactivatedDuringRequest);
-        OutputLine("    Delayed Grant: %u", metrics.mNumTxDelayedGrant);
-        OutputLine("    Average Request To Grant Time: %u", metrics.mAvgTxRequestToGrantTime);
+        OutputLine(kIndentSize, "Request: %u", metrics.mNumTxRequest);
+        OutputLine(kIndentSize, "Grant Immediate: %u", metrics.mNumTxGrantImmediate);
+        OutputLine(kIndentSize, "Grant Wait: %u", metrics.mNumTxGrantWait);
+        OutputLine(kIndentSize, "Grant Wait Activated: %u", metrics.mNumTxGrantWaitActivated);
+        OutputLine(kIndentSize, "Grant Wait Timeout: %u", metrics.mNumTxGrantWaitTimeout);
+        OutputLine(kIndentSize, "Grant Deactivated During Request: %u", metrics.mNumTxGrantDeactivatedDuringRequest);
+        OutputLine(kIndentSize, "Delayed Grant: %u", metrics.mNumTxDelayedGrant);
+        OutputLine(kIndentSize, "Average Request To Grant Time: %u", metrics.mAvgTxRequestToGrantTime);
         OutputLine("Receive metrics");
-        OutputLine("    Request: %u", metrics.mNumRxRequest);
-        OutputLine("    Grant Immediate: %u", metrics.mNumRxGrantImmediate);
-        OutputLine("    Grant Wait: %u", metrics.mNumRxGrantWait);
-        OutputLine("    Grant Wait Activated: %u", metrics.mNumRxGrantWaitActivated);
-        OutputLine("    Grant Wait Timeout: %u", metrics.mNumRxGrantWaitTimeout);
-        OutputLine("    Grant Deactivated During Request: %u", metrics.mNumRxGrantDeactivatedDuringRequest);
-        OutputLine("    Delayed Grant: %u", metrics.mNumRxDelayedGrant);
-        OutputLine("    Average Request To Grant Time: %u", metrics.mAvgRxRequestToGrantTime);
-        OutputLine("    Grant None: %u", metrics.mNumRxGrantNone);
+        OutputLine(kIndentSize, "Request: %u", metrics.mNumRxRequest);
+        OutputLine(kIndentSize, "Grant Immediate: %u", metrics.mNumRxGrantImmediate);
+        OutputLine(kIndentSize, "Grant Wait: %u", metrics.mNumRxGrantWait);
+        OutputLine(kIndentSize, "Grant Wait Activated: %u", metrics.mNumRxGrantWaitActivated);
+        OutputLine(kIndentSize, "Grant Wait Timeout: %u", metrics.mNumRxGrantWaitTimeout);
+        OutputLine(kIndentSize, "Grant Deactivated During Request: %u", metrics.mNumRxGrantDeactivatedDuringRequest);
+        OutputLine(kIndentSize, "Delayed Grant: %u", metrics.mNumRxDelayedGrant);
+        OutputLine(kIndentSize, "Average Request To Grant Time: %u", metrics.mAvgRxRequestToGrantTime);
+        OutputLine(kIndentSize, "Grant None: %u", metrics.mNumRxGrantNone);
     }
     else
     {
@@ -1124,36 +1124,36 @@ otError Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
             const otMacCounters *macCounters = otLinkGetCounters(mInstance);
 
             OutputLine("TxTotal: %d", macCounters->mTxTotal);
-            OutputLine("    TxUnicast: %d", macCounters->mTxUnicast);
-            OutputLine("    TxBroadcast: %d", macCounters->mTxBroadcast);
-            OutputLine("    TxAckRequested: %d", macCounters->mTxAckRequested);
-            OutputLine("    TxAcked: %d", macCounters->mTxAcked);
-            OutputLine("    TxNoAckRequested: %d", macCounters->mTxNoAckRequested);
-            OutputLine("    TxData: %d", macCounters->mTxData);
-            OutputLine("    TxDataPoll: %d", macCounters->mTxDataPoll);
-            OutputLine("    TxBeacon: %d", macCounters->mTxBeacon);
-            OutputLine("    TxBeaconRequest: %d", macCounters->mTxBeaconRequest);
-            OutputLine("    TxOther: %d", macCounters->mTxOther);
-            OutputLine("    TxRetry: %d", macCounters->mTxRetry);
-            OutputLine("    TxErrCca: %d", macCounters->mTxErrCca);
-            OutputLine("    TxErrBusyChannel: %d", macCounters->mTxErrBusyChannel);
+            OutputLine(kIndentSize, "TxUnicast: %d", macCounters->mTxUnicast);
+            OutputLine(kIndentSize, "TxBroadcast: %d", macCounters->mTxBroadcast);
+            OutputLine(kIndentSize, "TxAckRequested: %d", macCounters->mTxAckRequested);
+            OutputLine(kIndentSize, "TxAcked: %d", macCounters->mTxAcked);
+            OutputLine(kIndentSize, "TxNoAckRequested: %d", macCounters->mTxNoAckRequested);
+            OutputLine(kIndentSize, "TxData: %d", macCounters->mTxData);
+            OutputLine(kIndentSize, "TxDataPoll: %d", macCounters->mTxDataPoll);
+            OutputLine(kIndentSize, "TxBeacon: %d", macCounters->mTxBeacon);
+            OutputLine(kIndentSize, "TxBeaconRequest: %d", macCounters->mTxBeaconRequest);
+            OutputLine(kIndentSize, "TxOther: %d", macCounters->mTxOther);
+            OutputLine(kIndentSize, "TxRetry: %d", macCounters->mTxRetry);
+            OutputLine(kIndentSize, "TxErrCca: %d", macCounters->mTxErrCca);
+            OutputLine(kIndentSize, "TxErrBusyChannel: %d", macCounters->mTxErrBusyChannel);
             OutputLine("RxTotal: %d", macCounters->mRxTotal);
-            OutputLine("    RxUnicast: %d", macCounters->mRxUnicast);
-            OutputLine("    RxBroadcast: %d", macCounters->mRxBroadcast);
-            OutputLine("    RxData: %d", macCounters->mRxData);
-            OutputLine("    RxDataPoll: %d", macCounters->mRxDataPoll);
-            OutputLine("    RxBeacon: %d", macCounters->mRxBeacon);
-            OutputLine("    RxBeaconRequest: %d", macCounters->mRxBeaconRequest);
-            OutputLine("    RxOther: %d", macCounters->mRxOther);
-            OutputLine("    RxAddressFiltered: %d", macCounters->mRxAddressFiltered);
-            OutputLine("    RxDestAddrFiltered: %d", macCounters->mRxDestAddrFiltered);
-            OutputLine("    RxDuplicated: %d", macCounters->mRxDuplicated);
-            OutputLine("    RxErrNoFrame: %d", macCounters->mRxErrNoFrame);
-            OutputLine("    RxErrNoUnknownNeighbor: %d", macCounters->mRxErrUnknownNeighbor);
-            OutputLine("    RxErrInvalidSrcAddr: %d", macCounters->mRxErrInvalidSrcAddr);
-            OutputLine("    RxErrSec: %d", macCounters->mRxErrSec);
-            OutputLine("    RxErrFcs: %d", macCounters->mRxErrFcs);
-            OutputLine("    RxErrOther: %d", macCounters->mRxErrOther);
+            OutputLine(kIndentSize, "RxUnicast: %d", macCounters->mRxUnicast);
+            OutputLine(kIndentSize, "RxBroadcast: %d", macCounters->mRxBroadcast);
+            OutputLine(kIndentSize, "RxData: %d", macCounters->mRxData);
+            OutputLine(kIndentSize, "RxDataPoll: %d", macCounters->mRxDataPoll);
+            OutputLine(kIndentSize, "RxBeacon: %d", macCounters->mRxBeacon);
+            OutputLine(kIndentSize, "RxBeaconRequest: %d", macCounters->mRxBeaconRequest);
+            OutputLine(kIndentSize, "RxOther: %d", macCounters->mRxOther);
+            OutputLine(kIndentSize, "RxAddressFiltered: %d", macCounters->mRxAddressFiltered);
+            OutputLine(kIndentSize, "RxDestAddrFiltered: %d", macCounters->mRxDestAddrFiltered);
+            OutputLine(kIndentSize, "RxDuplicated: %d", macCounters->mRxDuplicated);
+            OutputLine(kIndentSize, "RxErrNoFrame: %d", macCounters->mRxErrNoFrame);
+            OutputLine(kIndentSize, "RxErrNoUnknownNeighbor: %d", macCounters->mRxErrUnknownNeighbor);
+            OutputLine(kIndentSize, "RxErrInvalidSrcAddr: %d", macCounters->mRxErrInvalidSrcAddr);
+            OutputLine(kIndentSize, "RxErrSec: %d", macCounters->mRxErrSec);
+            OutputLine(kIndentSize, "RxErrFcs: %d", macCounters->mRxErrFcs);
+            OutputLine(kIndentSize, "RxErrOther: %d", macCounters->mRxErrOther);
         }
         else if ((aArgsLength == 2) && (strcmp(aArgs[1], "reset") == 0))
         {
@@ -4476,7 +4476,6 @@ void Interpreter::HandleDiagnosticGetResponse(otError aError, const otMessage *a
     // Output Network Diagnostic TLV values in standard YAML format.
     while ((aError = otThreadGetNextDiagnosticTlv(aMessage, &iterator, &diagTlv)) == OT_ERROR_NONE)
     {
-        uint16_t column = 0;
         switch (diagTlv.mType)
         {
         case OT_NETWORK_DIAGNOSTIC_TLV_EXT_ADDRESS:
@@ -4489,22 +4488,22 @@ void Interpreter::HandleDiagnosticGetResponse(otError aError, const otMessage *a
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_MODE:
             OutputLine("Mode:");
-            OutputMode(diagTlv.mData.mMode, column + kIndentationSize);
+            OutputMode(kIndentSize, diagTlv.mData.mMode);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_TIMEOUT:
             OutputLine("Timeout: %u", diagTlv.mData.mTimeout);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_CONNECTIVITY:
             OutputLine("Connectivity:");
-            OutputConnectivity(diagTlv.mData.mConnectivity, column + kIndentationSize);
+            OutputConnectivity(kIndentSize, diagTlv.mData.mConnectivity);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_ROUTE:
             OutputLine("Route:");
-            OutputRoute(diagTlv.mData.mRoute, column + kIndentationSize);
+            OutputRoute(kIndentSize, diagTlv.mData.mRoute);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_LEADER_DATA:
             OutputLine("Leader Data:");
-            OutputLeaderData(diagTlv.mData.mLeaderData, column + kIndentationSize);
+            OutputLeaderData(kIndentSize, diagTlv.mData.mLeaderData);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_NETWORK_DATA:
             OutputFormat("Network Data: '");
@@ -4515,15 +4514,14 @@ void Interpreter::HandleDiagnosticGetResponse(otError aError, const otMessage *a
             OutputLine("IP6 Address List:");
             for (uint16_t i = 0; i < diagTlv.mData.mIp6AddrList.mCount; ++i)
             {
-                OutputSpaces(column + kIndentationSize);
-                OutputFormat("- ");
+                OutputFormat(kIndentSize, "- ");
                 OutputIp6Address(diagTlv.mData.mIp6AddrList.mList[i]);
                 OutputLine("");
             }
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_MAC_COUNTERS:
             OutputLine("MAC Counters:");
-            OutputNetworkDiagMacCounters(diagTlv.mData.mMacCounters, column + kIndentationSize);
+            OutputNetworkDiagMacCounters(kIndentSize, diagTlv.mData.mMacCounters);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_BATTERY_LEVEL:
             OutputLine("Battery Level: %u%%", diagTlv.mData.mBatteryLevel);
@@ -4535,9 +4533,8 @@ void Interpreter::HandleDiagnosticGetResponse(otError aError, const otMessage *a
             OutputLine("Child Table:");
             for (uint16_t i = 0; i < diagTlv.mData.mChildTable.mCount; ++i)
             {
-                OutputSpaces(column + kIndentationSize);
-                OutputFormat("- ");
-                OutputChildTableEntry(diagTlv.mData.mChildTable.mTable[i], column + kIndentationSize + 2);
+                OutputFormat(kIndentSize, "- ");
+                OutputChildTableEntry(kIndentSize + 2, diagTlv.mData.mChildTable.mTable[i]);
             }
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_CHANNEL_PAGES:
@@ -4560,154 +4557,76 @@ exit:
     OutputResult(aError);
 }
 
-void Interpreter::OutputSpaces(uint16_t aCount)
+void Interpreter::OutputMode(uint8_t aIndentSize, const otLinkModeConfig &aMode)
 {
-    static const uint16_t kSpaceStrLen = 16;
-    char                  spaceStr[kSpaceStrLen + 1];
-
-    memset(spaceStr, ' ', kSpaceStrLen);
-    spaceStr[kSpaceStrLen] = '\0';
-
-    for (uint16_t i = 0; i < aCount; i += kSpaceStrLen)
-    {
-        uint16_t idx = (i + kSpaceStrLen <= aCount) ? 0 : (i + kSpaceStrLen - aCount);
-        OutputFormat(&spaceStr[idx]);
-    }
+    OutputLine(aIndentSize, "RxOnWhenIdle: %d", aMode.mRxOnWhenIdle);
+    OutputLine(aIndentSize, "DeviceType: %d", aMode.mDeviceType);
+    OutputLine(aIndentSize, "NetworkData: %d", aMode.mNetworkData);
 }
 
-void Interpreter::OutputMode(const otLinkModeConfig &aMode, uint16_t aColumn)
+void Interpreter::OutputConnectivity(uint8_t aIndentSize, const otNetworkDiagConnectivity &aConnectivity)
 {
-    OutputSpaces(aColumn);
-    OutputLine("RxOnWhenIdle: %d", aMode.mRxOnWhenIdle);
-
-    OutputSpaces(aColumn);
-    OutputLine("DeviceType: %d", aMode.mDeviceType);
-
-    OutputSpaces(aColumn);
-    OutputLine("NetworkData: %d", aMode.mNetworkData);
+    OutputLine(aIndentSize, "ParentPriority: %d", aConnectivity.mParentPriority);
+    OutputLine(aIndentSize, "LinkQuality3: %u", aConnectivity.mLinkQuality3);
+    OutputLine(aIndentSize, "LinkQuality2: %u", aConnectivity.mLinkQuality2);
+    OutputLine(aIndentSize, "LinkQuality1: %u", aConnectivity.mLinkQuality1);
+    OutputLine(aIndentSize, "LeaderCost: %u", aConnectivity.mLeaderCost);
+    OutputLine(aIndentSize, "IdSequence: %u", aConnectivity.mIdSequence);
+    OutputLine(aIndentSize, "ActiveRouters: %u", aConnectivity.mActiveRouters);
+    OutputLine(aIndentSize, "SedBufferSize: %u", aConnectivity.mSedBufferSize);
+    OutputLine(aIndentSize, "SedDatagramCount: %u", aConnectivity.mSedDatagramCount);
 }
-
-void Interpreter::OutputConnectivity(const otNetworkDiagConnectivity &aConnectivity, uint16_t aColumn)
+void Interpreter::OutputRoute(uint8_t aIndentSize, const otNetworkDiagRoute &aRoute)
 {
-    OutputSpaces(aColumn);
-    OutputLine("ParentPriority: %d", aConnectivity.mParentPriority);
+    OutputLine(aIndentSize, "IdSequence: %u", aRoute.mIdSequence);
+    OutputLine(aIndentSize, "RouteData:");
 
-    OutputSpaces(aColumn);
-    OutputLine("LinkQuality3: %u", aConnectivity.mLinkQuality3);
-
-    OutputSpaces(aColumn);
-    OutputLine("LinkQuality2: %u", aConnectivity.mLinkQuality2);
-
-    OutputSpaces(aColumn);
-    OutputLine("LinkQuality1: %u", aConnectivity.mLinkQuality1);
-
-    OutputSpaces(aColumn);
-    OutputLine("LeaderCost: %u", aConnectivity.mLeaderCost);
-
-    OutputSpaces(aColumn);
-    OutputLine("IdSequence: %u", aConnectivity.mIdSequence);
-
-    OutputSpaces(aColumn);
-    OutputLine("ActiveRouters: %u", aConnectivity.mActiveRouters);
-
-    OutputSpaces(aColumn);
-    OutputLine("SedBufferSize: %u", aConnectivity.mSedBufferSize);
-
-    OutputSpaces(aColumn);
-    OutputLine("SedDatagramCount: %u", aConnectivity.mSedDatagramCount);
-}
-
-void Interpreter::OutputRoute(const otNetworkDiagRoute &aRoute, uint16_t aColumn)
-{
-    OutputSpaces(aColumn);
-    OutputLine("IdSequence: %u", aRoute.mIdSequence);
-
-    OutputSpaces(aColumn);
-    OutputLine("RouteData:");
-
-    aColumn += kIndentationSize;
+    aIndentSize += kIndentSize;
     for (uint16_t i = 0; i < aRoute.mRouteCount; ++i)
     {
-        OutputSpaces(aColumn);
-        OutputFormat("- ");
-
-        OutputRouteData(aRoute.mRouteData[i], aColumn + 2);
+        OutputFormat(aIndentSize, "- ");
+        OutputRouteData(aIndentSize + 2, aRoute.mRouteData[i]);
     }
 }
 
-void Interpreter::OutputRouteData(const otNetworkDiagRouteData &aRouteData, uint16_t aColumn)
+void Interpreter::OutputRouteData(uint8_t aIndentSize, const otNetworkDiagRouteData &aRouteData)
 {
     OutputLine("RouteId: 0x%02x", aRouteData.mRouterId);
 
-    OutputSpaces(aColumn);
-    OutputLine("LinkQualityOut: %u", aRouteData.mLinkQualityOut);
-
-    OutputSpaces(aColumn);
-    OutputLine("LinkQualityIn: %u", aRouteData.mLinkQualityIn);
-
-    OutputSpaces(aColumn);
-    OutputLine("RouteCost: %u", aRouteData.mRouteCost);
+    OutputLine(aIndentSize, "LinkQualityOut: %u", aRouteData.mLinkQualityOut);
+    OutputLine(aIndentSize, "LinkQualityIn: %u", aRouteData.mLinkQualityIn);
+    OutputLine(aIndentSize, "RouteCost: %u", aRouteData.mRouteCost);
 }
 
-void Interpreter::OutputLeaderData(const otLeaderData &aLeaderData, uint16_t aColumn)
+void Interpreter::OutputLeaderData(uint8_t aIndentSize, const otLeaderData &aLeaderData)
 {
-    OutputSpaces(aColumn);
-    OutputLine("PartitionId: 0x%08x", aLeaderData.mPartitionId);
-
-    OutputSpaces(aColumn);
-    OutputLine("Weighting: %u", aLeaderData.mWeighting);
-
-    OutputSpaces(aColumn);
-    OutputLine("DataVersion: %u", aLeaderData.mDataVersion);
-
-    OutputSpaces(aColumn);
-    OutputLine("StableDataVersion: %u", aLeaderData.mStableDataVersion);
-
-    OutputSpaces(aColumn);
-    OutputLine("LeaderRouterId: 0x%02x", aLeaderData.mLeaderRouterId);
+    OutputLine(aIndentSize, "PartitionId: 0x%08x", aLeaderData.mPartitionId);
+    OutputLine(aIndentSize, "Weighting: %u", aLeaderData.mWeighting);
+    OutputLine(aIndentSize, "DataVersion: %u", aLeaderData.mDataVersion);
+    OutputLine(aIndentSize, "StableDataVersion: %u", aLeaderData.mStableDataVersion);
+    OutputLine(aIndentSize, "LeaderRouterId: 0x%02x", aLeaderData.mLeaderRouterId);
 }
 
-void Interpreter::OutputNetworkDiagMacCounters(const otNetworkDiagMacCounters &aMacCounters, uint16_t aColumn)
+void Interpreter::OutputNetworkDiagMacCounters(uint8_t aIndentSize, const otNetworkDiagMacCounters &aMacCounters)
 {
-    OutputSpaces(aColumn);
-    OutputLine("IfInUnknownProtos: %u", aMacCounters.mIfInUnknownProtos);
-
-    OutputSpaces(aColumn);
-    OutputLine("IfInErrors: %u", aMacCounters.mIfInErrors);
-
-    OutputSpaces(aColumn);
-    OutputLine("IfOutErrors: %u", aMacCounters.mIfOutErrors);
-
-    OutputSpaces(aColumn);
-    OutputLine("IfInUcastPkts: %u", aMacCounters.mIfInUcastPkts);
-
-    OutputSpaces(aColumn);
-    OutputLine("IfInBroadcastPkts: %u", aMacCounters.mIfInBroadcastPkts);
-
-    OutputSpaces(aColumn);
-    OutputLine("IfInDiscards: %u", aMacCounters.mIfInDiscards);
-
-    OutputSpaces(aColumn);
-    OutputLine("IfOutUcastPkts: %u", aMacCounters.mIfOutUcastPkts);
-
-    OutputSpaces(aColumn);
-    OutputLine("IfOutBroadcastPkts: %u", aMacCounters.mIfOutBroadcastPkts);
-
-    OutputSpaces(aColumn);
-    OutputLine("IfOutDiscards: %u", aMacCounters.mIfOutDiscards);
+    OutputLine(aIndentSize, "IfInUnknownProtos: %u", aMacCounters.mIfInUnknownProtos);
+    OutputLine(aIndentSize, "IfInErrors: %u", aMacCounters.mIfInErrors);
+    OutputLine(aIndentSize, "IfOutErrors: %u", aMacCounters.mIfOutErrors);
+    OutputLine(aIndentSize, "IfInUcastPkts: %u", aMacCounters.mIfInUcastPkts);
+    OutputLine(aIndentSize, "IfInBroadcastPkts: %u", aMacCounters.mIfInBroadcastPkts);
+    OutputLine(aIndentSize, "IfInDiscards: %u", aMacCounters.mIfInDiscards);
+    OutputLine(aIndentSize, "IfOutUcastPkts: %u", aMacCounters.mIfOutUcastPkts);
+    OutputLine(aIndentSize, "IfOutBroadcastPkts: %u", aMacCounters.mIfOutBroadcastPkts);
+    OutputLine(aIndentSize, "IfOutDiscards: %u", aMacCounters.mIfOutDiscards);
 }
 
-void Interpreter::OutputChildTableEntry(const otNetworkDiagChildEntry &aChildEntry, uint16_t aColumn)
+void Interpreter::OutputChildTableEntry(uint8_t aIndentSize, const otNetworkDiagChildEntry &aChildEntry)
 {
     OutputLine("ChildId: 0x%04x", aChildEntry.mChildId);
 
-    OutputSpaces(aColumn);
-    OutputLine("Timeout: %u", aChildEntry.mTimeout);
-
-    OutputSpaces(aColumn);
-    OutputLine("Mode:");
-
-    OutputMode(aChildEntry.mMode, aColumn + kIndentationSize);
+    OutputLine(aIndentSize, "Timeout: %u", aChildEntry.mTimeout);
+    OutputLine(aIndentSize, "Mode:");
+    OutputMode(aIndentSize + kIndentSize, aChildEntry.mMode);
 }
 #endif // OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
 
@@ -4779,6 +4698,17 @@ int Interpreter::OutputFormat(const char *aFormat, ...)
     return rval;
 }
 
+void Interpreter::OutputFormat(uint8_t aIndentSize, const char *aFormat, ...)
+{
+    va_list ap;
+
+    OutputSpaces(aIndentSize);
+
+    va_start(ap, aFormat);
+    OutputFormatV(aFormat, ap);
+    va_end(ap);
+}
+
 void Interpreter::OutputLine(const char *aFormat, ...)
 {
     va_list args;
@@ -4788,6 +4718,32 @@ void Interpreter::OutputLine(const char *aFormat, ...)
     va_end(args);
 
     OutputFormat("\r\n");
+}
+
+void Interpreter::OutputLine(uint8_t aIndentSize, const char *aFormat, ...)
+{
+    va_list args;
+
+    OutputSpaces(aIndentSize);
+
+    va_start(args, aFormat);
+    OutputFormatV(aFormat, args);
+    va_end(args);
+
+    OutputFormat("\r\n");
+}
+
+void Interpreter::OutputSpaces(uint8_t aCount)
+{
+    static const char kSpaces[] = {' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' ', ' '};
+
+    while (aCount > 0)
+    {
+        uint8_t len = OT_MIN(aCount, sizeof(kSpaces));
+
+        Output(kSpaces, len);
+        aCount -= len;
+    }
 }
 
 int Interpreter::OutputFormatV(const char *aFormat, va_list aArguments)

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -186,6 +186,17 @@ public:
     int OutputFormatV(const char *aFormat, va_list aArguments);
 
     /**
+     * This method delivers formatted output (to which it prepends a given number indentation space chars) to the
+     * client.
+     *
+     * @param[in]  aIndentSize   Number of indentation space chars to prepend to the string.
+     * @param[in]  aFormat       A pointer to the format string.
+     * @param[in]  ...           A variable list of arguments to format.
+     *
+     */
+    void OutputFormat(uint8_t aIndentSize, const char *aFormat, ...);
+
+    /**
      * This method delivers formatted output (to which it also appends newline `\r\n`) to the client.
      *
      * @param[in]  aFormat  A pointer to the format string.
@@ -193,6 +204,25 @@ public:
      *
      */
     void OutputLine(const char *aFormat, ...);
+
+    /**
+     * This method delivers formatted output (to which it prepends a given number indentation space chars and appends
+     * newline `\r\n`) to the client.
+     *
+     * @param[in]  aIndentSize   Number of indentation space chars to prepend to the string.
+     * @param[in]  aFormat       A pointer to the format string.
+     * @param[in]  ...           A variable list of arguments to format.
+     *
+     */
+    void OutputLine(uint8_t aIndentSize, const char *aFormat, ...);
+
+    /**
+     * This method writes a given number of space chars to the CLI console.
+     *
+     * @param[in] aCount  Number of space chars to output.
+     *
+     */
+    void OutputSpaces(uint8_t aCount);
 
     /**
      * This method writes an Extended MAC Address to the CLI console.
@@ -240,7 +270,7 @@ protected:
 private:
     enum
     {
-        kIndentationSize  = 4,
+        kIndentSize       = 4,
         kMaxArgs          = 32,
         kMaxAutoAddresses = 8,
 
@@ -494,14 +524,14 @@ private:
                                             otMessage *          aMessage,
                                             const otMessageInfo *aMessageInfo,
                                             void *               aContext);
-    void        OutputSpaces(uint16_t aCount);
-    void        OutputMode(const otLinkModeConfig &aMode, uint16_t aColumn);
-    void        OutputConnectivity(const otNetworkDiagConnectivity &aConnectivity, uint16_t aColumn);
-    void        OutputRoute(const otNetworkDiagRoute &aRoute, uint16_t aColumn);
-    void        OutputRouteData(const otNetworkDiagRouteData &aRouteData, uint16_t aColumn);
-    void        OutputLeaderData(const otLeaderData &aLeaderData, uint16_t aColumn);
-    void        OutputNetworkDiagMacCounters(const otNetworkDiagMacCounters &aMacCounters, uint16_t aColumn);
-    void        OutputChildTableEntry(const otNetworkDiagChildEntry &aChildEntry, uint16_t aColumn);
+
+    void OutputMode(uint8_t aIndentSize, const otLinkModeConfig &aMode);
+    void OutputConnectivity(uint8_t aIndentSize, const otNetworkDiagConnectivity &aConnectivity);
+    void OutputRoute(uint8_t aIndentSize, const otNetworkDiagRoute &aRoute);
+    void OutputRouteData(uint8_t aIndentSize, const otNetworkDiagRouteData &aRouteData);
+    void OutputLeaderData(uint8_t aIndentSize, const otLeaderData &aLeaderData);
+    void OutputNetworkDiagMacCounters(uint8_t aIndentSize, const otNetworkDiagMacCounters &aMacCounters);
+    void OutputChildTableEntry(uint8_t aIndentSize, const otNetworkDiagChildEntry &aChildEntry);
 #endif
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE


### PR DESCRIPTION
This commit simplifies the CLI module by adding new flavors of helper
methods `OutputLine/Format(aIndentSize, ...)` which prepend a given
number of indentation space characters before the format string.

It also harmonizes the other `Output{Item}()` methods which output an
item with a given indentation to use `aIndentSize` as the parameter
name and as the first parameter of the method.

It also simplifies the implementation of `OutputSpaces()`.