### PR TITLE
[test] add rcp-ncp node type

### DIFF
--- a/script/test
+++ b/script/test
@@ -58,7 +58,7 @@ build_simulation()
     if [[ ${VIRTUAL_TIME} == 1 ]]; then
         options+=("-DOT_SIMULATION_VIRTUAL_TIME=ON")
 
-        if [[ ${OT_NODE_TYPE} == "rcp" ]]; then
+        if [[ ${OT_NODE_TYPE} == rcp* ]]; then
             options+=("-DOT_SIMULATION_VIRTUAL_TIME_UART=ON")
         fi
 
@@ -122,7 +122,7 @@ build_for_one_version()
 
     build_simulation "${version}"
 
-    if [[ ${OT_NODE_TYPE} == "rcp" ]]; then
+    if [[ ${OT_NODE_TYPE} == rcp* ]]; then
         build_posix "${version}"
     fi
 }
@@ -171,10 +171,10 @@ do_cert()
     export top_builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}"
 
     case "${OT_NODE_TYPE}" in
-        rcp | cli)
+        rcp | rcp-cli | cli)
             export NODE_TYPE=sim
             ;;
-        ncp)
+        rcp-ncp | ncp)
             export NODE_TYPE=ncp-sim
             ;;
     esac
@@ -264,7 +264,7 @@ do_expect()
 {
     local test_patterns
 
-    if [[ ${OT_NODE_TYPE} == rcp ]]; then
+    if [[ ${OT_NODE_TYPE} == rcp* ]]; then
         if [[ ${THREAD_VERSION} == "1.2" ]]; then
             test_patterns=(-name 'v1_2-*.exp')
         elif [[ ${OT_NATIVE_IP} == 1 ]]; then
@@ -312,7 +312,10 @@ print_usage()
     echo "USAGE: [ENVIRONMENTS] $0 COMMANDS
 
 ENVIRONMENTS:
-    OT_NODE_TYPE    'rcp' for POSIX/RCP, 'cli' for CLI simulation, 'ncp' for NCP simulation, The default is 'cli'.
+    OT_NODE_TYPE    'cli' for CLI simulation, 'ncp' for NCP simulation.
+                    'rcp' or 'rcp-cli' for CLI on POSIX platform.
+                    'rcp-ncp' for NCP on POSIX platform.
+                    The default is 'cli'.
     OT_NATIVE_IP    1 to enable platform UDP and netif on POSIX platform. The default is 0.
     VERBOSE         1 to build or test verbosely. The default is 0.
     VIRTUAL_TIME    1 for virtual time, otherwise real time. The default is 1.
@@ -446,7 +449,7 @@ do_upload_codecov()
 
 envsetup()
 {
-    if [[ ${OT_NODE_TYPE} == 'rcp' ]]; then
+    if [[ ${OT_NODE_TYPE} == rcp* ]]; then
         export RADIO_DEVICE="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}/examples/apps/ncp/ot-rcp"
         export OT_CLI_PATH="${OT_BUILDDIR}/cmake/openthread-posix-${THREAD_VERSION}/src/posix/ot-cli"
         export OT_NCP_PATH="${OT_BUILDDIR}/cmake/openthread-posix-${THREAD_VERSION}/src/posix/ot-ncp"

--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -65,8 +65,8 @@ proc spawn_node {id {type ""}} {
 
     send_user "\n# ${id} ${type}\n"
 
-    switch ${type} {
-        rcp {
+    switch -regexp ${type} {
+        {rcp|rcp-cli} {
             spawn $::env(OT_POSIX_APPS)/ot-cli "spinel+hdlc+uart://$::env(OT_SIMULATION_APPS)/ncp/ot-rcp?forkpty-arg=$id"
             send "routerselectionjitter 1\n"
             expect "Done"


### PR DESCRIPTION
This commit enables `script/test` to run cert tests on NCP nodes of
POSIX platform.