### PR TITLE
[low-power] frame pending bit handling for enh-ack in simulation

### DIFF
--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -827,11 +827,15 @@ void radioTransmit(struct RadioMessage *aMessage, const struct otRadioFrame *aFr
 
 void radioSendAck(void)
 {
-    if (hasFramePending(&sReceiveFrame)
-#if OPENTHREAD_CONFIG_THREAD_VERSION < OT_THREAD_VERSION_1_2
-        && otMacFrameIsDataRequest(&sReceiveFrame)
+    if (
+#if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
+        // Determine if frame pending should be set
+        ((otMacFrameIsVersion2015(&sReceiveFrame) && otMacFrameIsCommand(&sReceiveFrame)) ||
+         otMacFrameIsData(&sReceiveFrame) || otMacFrameIsDataRequest(&sReceiveFrame))
+#else
+        otMacFrameIsDataRequest(&sReceiveFrame)
 #endif
-    )
+        && hasFramePending(&sReceiveFrame))
     {
         sReceiveFrame.mInfo.mRxInfo.mAckedWithFramePending = true;
     }

--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -827,14 +827,11 @@ void radioTransmit(struct RadioMessage *aMessage, const struct otRadioFrame *aFr
 
 void radioSendAck(void)
 {
-    if (
-#if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
-        // Determine if frame pending should be set
-        (otMacFrameIsData(&sReceiveFrame) || otMacFrameIsDataRequest(&sReceiveFrame))
-#else
-        otMacFrameIsDataRequest(&sReceiveFrame)
+    if (hasFramePending(&sReceiveFrame)
+#if OPENTHREAD_CONFIG_THREAD_VERSION < OT_THREAD_VERSION_1_2
+        && otMacFrameIsDataRequest(&sReceiveFrame)
 #endif
-        && hasFramePending(&sReceiveFrame))
+    )
     {
         sReceiveFrame.mInfo.mRxInfo.mAckedWithFramePending = true;
     }

--- a/examples/platforms/utils/mac_frame.cpp
+++ b/examples/platforms/utils/mac_frame.cpp
@@ -76,6 +76,11 @@ bool otMacFrameIsData(const otRadioFrame *aFrame)
     return static_cast<const Mac::Frame *>(aFrame)->GetType() == Mac::Frame::kFcfFrameData;
 }
 
+bool otMacFrameIsCommand(const otRadioFrame *aFrame)
+{
+    return static_cast<const Mac::Frame *>(aFrame)->GetType() == Mac::Frame::kFcfFrameMacCmd;
+}
+
 bool otMacFrameIsDataRequest(const otRadioFrame *aFrame)
 {
     return static_cast<const Mac::Frame *>(aFrame)->IsDataRequestCommand();

--- a/examples/platforms/utils/mac_frame.h
+++ b/examples/platforms/utils/mac_frame.h
@@ -91,6 +91,17 @@ bool otMacFrameIsAck(const otRadioFrame *aFrame);
 bool otMacFrameIsData(const otRadioFrame *aFrame);
 
 /**
+ * Check if @p aFrame is a Command frame.
+ *
+ * @param[in]   aFrame          A pointer to the frame.
+ *
+ * @retval  true    It is a Command frame.
+ * @retval  false   It is not a Command frame.
+ *
+ */
+bool otMacFrameIsCommand(const otRadioFrame *aFrame);
+
+/**
  * Check if @p aFrame is an Data Request Command.
  *
  * @param[in]   aFrame          A pointer to the frame. For 802.15.4-2015 and above frame,

--- a/examples/platforms/utils/mac_frame.h
+++ b/examples/platforms/utils/mac_frame.h
@@ -102,7 +102,7 @@ bool otMacFrameIsData(const otRadioFrame *aFrame);
 bool otMacFrameIsCommand(const otRadioFrame *aFrame);
 
 /**
- * Check if @p aFrame is an Data Request Command.
+ * Check if @p aFrame is a Data Request Command.
  *
  * @param[in]   aFrame          A pointer to the frame. For 802.15.4-2015 and above frame,
  *                              the frame should be already decrypted.

--- a/examples/platforms/utils/mac_frame.h
+++ b/examples/platforms/utils/mac_frame.h
@@ -93,7 +93,8 @@ bool otMacFrameIsData(const otRadioFrame *aFrame);
 /**
  * Check if @p aFrame is an Data Request Command.
  *
- * @param[in]   aFrame          A pointer to the frame.
+ * @param[in]   aFrame          A pointer to the frame. For 802.15.4-2015 and above frame,
+ *                              the frame should be already decrypted.
  *
  * @retval  true    It is a Data Request Command frame.
  * @retval  false   It is not a Data Request Command frame.

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -734,6 +734,7 @@ public:
 
     /**
      * This method indicates whether the frame is a MAC Data Request command (data poll).
+     *
      * For 802.15.4-2015 and above frame, the frame should be already decrypted.
      *
      * @returns TRUE if frame is a MAC Data Request command, FALSE otherwise.

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -733,7 +733,8 @@ public:
     otError SetCommandId(uint8_t aCommandId);
 
     /**
-     * This method indicates whether the frame is a MAC Data Request command (data poll)
+     * This method indicates whether the frame is a MAC Data Request command (data poll).
+     * For 802.15.4-2015 and above frame, the frame should be already decrypted.
      *
      * @returns TRUE if frame is a MAC Data Request command, FALSE otherwise.
      *


### PR DESCRIPTION
MAC command frame has its command ID encrypted in frame version 802.15.4-2015. Radio driver cannot decrypt this frame payload without extended address. So the frame pending bit is not correctly set in the ACK in response to data request command with version 2015. This PR adds a special handling for frame version 2015 and only checks the frame type when deciding if it needs to set the frame pending bit.