### PR TITLE
[cmake] avoid unnecessary rebuilds

### DIFF
--- a/third_party/mbedtls/CMakeLists.txt
+++ b/third_party/mbedtls/CMakeLists.txt
@@ -26,7 +26,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-set(OT_MBEDTLS_DEFAULT_CONFIG_FILE \"${CMAKE_CURRENT_BINARY_DIR}/openthread-mbedtls-config.h\")
+set(OT_MBEDTLS_DEFAULT_CONFIG_FILE \"openthread-mbedtls-config.h\")
 
 set(OT_MBEDTLS_CONFIG_FILE "" CACHE STRING "The mbedTLS config file")
 
@@ -45,8 +45,8 @@ find_program(SED_EXE sed)
 add_subdirectory(repo)
 
 if(UNIFDEFALL_EXE AND SED_EXE AND UNIFDEF_VERSION VERSION_GREATER_EQUAL 2.10)
-    add_custom_target(openthread-mbedtls-config
-        ${UNIFDEFALL_EXE}
+    add_custom_command(OUTPUT openthread-mbedtls-config.h
+        COMMAND ${UNIFDEFALL_EXE}
             "'-D$<JOIN:$<TARGET_PROPERTY:ot-config,INTERFACE_COMPILE_DEFINITIONS>,';'-D>'"
             "-I$<JOIN:$<TARGET_PROPERTY:ot-config,INTERFACE_INCLUDE_DIRECTORIES>,;-I>"
             "-I$<JOIN:${OT_PUBLIC_INCLUDES},;-I>"
@@ -54,14 +54,22 @@ if(UNIFDEFALL_EXE AND SED_EXE AND UNIFDEF_VERSION VERSION_GREATER_EQUAL 2.10)
             "${CMAKE_CURRENT_SOURCE_DIR}/mbedtls-config.h" |
             ${SED_EXE} '/openthread-core-config\.h/d' >
             openthread-mbedtls-config.h
+        MAIN_DEPENDENCY mbedtls-config.h
         COMMAND_EXPAND_LISTS
     )
+
+    add_custom_target(openthread-mbedtls-config
+        DEPENDS openthread-mbedtls-config.h)
+
+    add_dependencies(ot-config openthread-mbedtls-config)
     add_dependencies(mbedtls openthread-mbedtls-config)
     add_dependencies(mbedx509 openthread-mbedtls-config)
     add_dependencies(mbedcrypto openthread-mbedtls-config)
 else()
     configure_file(mbedtls-config.h openthread-mbedtls-config.h COPYONLY)
 endif()
+
+target_include_directories(ot-config INTERFACE ${CMAKE_CURRENT_BINARY_DIR})
 
 target_compile_definitions(mbedtls
     PUBLIC


### PR DESCRIPTION
This commit avoid unnecessary rebuilds. The issue is caused by the
openthread-mbedtls-config target added by add_custom_target will always
be run, so the generated openthread-mbedtls-config.h is always
re-generated. This commit changes to use add_custom_command to generate
the header file.

Test:
```bash
./script/test clean build
# the next command should cause no files rebuilt
./script/test build
touch third_party/mbedtls/mbedtls-config.h
# the next command should cause all targets depends on mbedtls rebuilt
./script/test build
```