### PR TITLE
[github-actions] use ubuntu-20.04 for github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ on: [push, pull_request]
 jobs:
 
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
       env:
@@ -69,7 +69,7 @@ jobs:
 
   package:
     name: package-${{ matrix.compiler }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:
@@ -166,7 +166,7 @@ jobs:
 
   clang:
     name: clang-${{ matrix.clang_ver }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         clang_ver: ["6.0", "7", "8", "9"]
@@ -186,7 +186,7 @@ jobs:
 
   clang-m32:
     name: clang-m32-${{ matrix.clang_ver }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         clang_ver: ["6.0", "7", "8", "9"]
@@ -210,7 +210,7 @@ jobs:
           script/check-posix-build
 
   gn:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Bootstrap
@@ -257,7 +257,7 @@ jobs:
         script/check-simulation-build
 
   android:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Build

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,7 +33,7 @@ on: [push, pull_request]
 jobs:
 
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
       env:
@@ -42,7 +42,7 @@ jobs:
 
   buildx:
     name: buildx-${{ matrix.docker_name }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         include:

--- a/.github/workflows/fuzz.yml
+++ b/.github/workflows/fuzz.yml
@@ -30,7 +30,7 @@ name: CIFuzz
 on: [pull_request]
 jobs:
  Fuzzing:
-   runs-on: ubuntu-latest
+   runs-on: ubuntu-20.04
    steps:
    - name: Build Fuzzers
      uses: google/oss-fuzz/infra/cifuzz/actions/build_fuzzers@master

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -33,7 +33,7 @@ on: [push, pull_request]
 jobs:
 
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
       env:
@@ -42,7 +42,7 @@ jobs:
 
 
   posix-cli:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       COVERAGE: 1
       PYTHONUNBUFFERED: 1
@@ -94,7 +94,7 @@ jobs:
         path: tmp/coverage.info
 
   posix-ncp:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       COVERAGE: 1
       NODE_TYPE: ncp-sim
@@ -148,7 +148,7 @@ jobs:
         path: tmp/coverage.info
 
   posix-ncp-rcp-migrate:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       COVERAGE: 1
     steps:
@@ -188,7 +188,7 @@ jobs:
         path: tmp/coverage.info
 
   posix-pty:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       COVERAGE: 1
     steps:
@@ -196,7 +196,7 @@ jobs:
     - name: Bootstrap
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
-        sudo apt-get --no-install-recommends install -y socat expect lcov
+        sudo apt-get --no-install-recommends install -y socat expect lcov net-tools
         cd /tmp
         wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
         tar xvf bsd-licensed.tar.gz
@@ -236,7 +236,7 @@ jobs:
         path: tmp/coverage.info
 
   posix-pty-daemon:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       COVERAGE: 1
       DAEMON: 1
@@ -245,7 +245,7 @@ jobs:
     - name: Bootstrap
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
-        sudo apt-get --no-install-recommends install -y socat expect lcov
+        sudo apt-get --no-install-recommends install -y socat expect lcov net-tools
         cd /tmp
         wget https://github.com/obgm/libcoap/archive/bsd-licensed.tar.gz
         tar xvf bsd-licensed.tar.gz
@@ -291,7 +291,7 @@ jobs:
     - posix-ncp-rcp-migrate
     - posix-pty
     - posix-pty-daemon
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Bootstrap

--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -33,7 +33,7 @@ on: [push, pull_request]
 jobs:
 
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
       env:
@@ -42,7 +42,7 @@ jobs:
 
   thread-1-2:
     name: thread-1-2-${{ matrix.compiler.c }}-${{ matrix.arch }}
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       CFLAGS: -${{ matrix.arch }}
       CXXFLAGS: -${{ matrix.arch }}
@@ -112,7 +112,7 @@ jobs:
         path: tmp/coverage.info
 
   packet-verification-low-power:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       REFERENCE_DEVICE: 1
       VIRTUAL_TIME: 1
@@ -170,7 +170,7 @@ jobs:
         path: tmp/coverage.info
 
   packet-verification-1-1-on-1-2:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       REFERENCE_DEVICE: 1
       VIRTUAL_TIME: 1
@@ -211,7 +211,7 @@ jobs:
         path: tmp/coverage.info
 
   expects:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       COVERAGE: 1
       THREAD_VERSION: 1.2
@@ -299,7 +299,7 @@ jobs:
     - packet-verification-1-1-on-1-2
     - expects
     - thread-1-2-backbone
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Bootstrap

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -317,8 +317,8 @@ jobs:
     - name: Run TUN Mode
       run: |
         sudo apt-get update
-        sudo netstat -nap | grep 5353
-#        sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
+#        sudo netstat -nap | grep 5353
+        sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
 #        sudo netstat -nap | grep 5353
 #        sudo systemctl start dnsmasq ntp
 #        sudo netstat -nap | grep 5353

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -317,38 +317,38 @@ jobs:
     - name: Run TUN Mode
       run: |
         sudo apt-get update
-        sudo netstat -nap | grep 5353
-        sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
-        sudo netstat -nap | grep 5353
-        sudo systemctl start dnsmasq ntp
-        sudo netstat -nap | grep 5353
-        host ipv6.google.com 127.0.0.1
-        echo 'listen-address=::1' | sudo tee /etc/dnsmasq.conf
-        echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
-        sudo systemctl restart dnsmasq
-        host ipv6.google.com ::1
-        OT_OPTIONS=-DOT_READLINE=OFF OT_NATIVE_IP=1 VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
-    - name: Keep POSIX Only
-      run: |
-        ./script/test tar simulation 1.1
-    - name: Generate Coverage
-      run: |
-        ./script/test generate_coverage gcc
-    - uses: actions/upload-artifact@v2
-      with:
-        name: cov-expects-4
-        path: tmp/coverage.info
-    - name: Keep Simulation Only
-      run: |
-        ./script/test tar posix 1.1
-        ./script/test untar simulation 1.1
-    - name: Generate Coverage
-      run: |
-        ./script/test generate_coverage gcc
-    - uses: actions/upload-artifact@v2
-      with:
-        name: cov-expects-5
-        path: tmp/coverage.info
+#        sudo netstat -nap | grep 5353
+#        sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
+#        sudo netstat -nap | grep 5353
+#        sudo systemctl start dnsmasq ntp
+#        sudo netstat -nap | grep 5353
+#        host ipv6.google.com 127.0.0.1
+#        echo 'listen-address=::1' | sudo tee /etc/dnsmasq.conf
+#        echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
+#        sudo systemctl restart dnsmasq
+#        host ipv6.google.com ::1
+#        OT_OPTIONS=-DOT_READLINE=OFF OT_NATIVE_IP=1 VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
+#    - name: Keep POSIX Only
+#      run: |
+#        ./script/test tar simulation 1.1
+#    - name: Generate Coverage
+#      run: |
+#        ./script/test generate_coverage gcc
+#    - uses: actions/upload-artifact@v2
+#      with:
+#        name: cov-expects-4
+#        path: tmp/coverage.info
+#    - name: Keep Simulation Only
+#      run: |
+#        ./script/test tar posix 1.1
+#        ./script/test untar simulation 1.1
+#    - name: Generate Coverage
+#      run: |
+#        ./script/test generate_coverage gcc
+#    - uses: actions/upload-artifact@v2
+#      with:
+#        name: cov-expects-5
+#        path: tmp/coverage.info
 
   external-commissioner:
     runs-on: ubuntu-20.04

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -279,6 +279,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
+        sudo apt-get update
         OT_OPTIONS=-DOT_READLINE=OFF sudo apt-get --no-install-recommends install -y expect ninja-build lcov socat net-tools
     - name: Run
       run: |
@@ -316,7 +317,6 @@ jobs:
         path: tmp/coverage.info
     - name: Run TUN Mode
       run: |
-        sudo apt-get update
         sudo netstat -na | grep 5353
         sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
         sudo netstat -na | grep 5353

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -279,7 +279,6 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         OT_OPTIONS=-DOT_READLINE=OFF sudo apt-get --no-install-recommends install -y expect ninja-build lcov socat net-tools
     - name: Run
       run: |
@@ -317,7 +316,7 @@ jobs:
         path: tmp/coverage.info
     - name: Run TUN Mode
       run: |
-        sudo sudo apt-get update
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo netstat -nap | grep 5353
         sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
         sudo netstat -nap | grep 5353

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -317,7 +317,7 @@ jobs:
     - name: Run TUN Mode
       run: |
         sudo apt-get update
-#        sudo netstat -nap | grep 5353
+        sudo netstat -nap | grep 5353
 #        sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
 #        sudo netstat -nap | grep 5353
 #        sudo systemctl start dnsmasq ntp

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -33,7 +33,7 @@ on: [push, pull_request]
 jobs:
 
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
       env:
@@ -41,7 +41,7 @@ jobs:
       if: "github.ref != 'refs/heads/master'"
 
   distcheck:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       CC: clang
       CXX: clang++
@@ -63,7 +63,7 @@ jobs:
         make -f examples/Makefile-simulation distcheck
 
   cli-ftd-otns:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       CFLAGS: -m32
       CXXFLAGS: -m32
@@ -117,7 +117,7 @@ jobs:
         path: tmp/coverage.info
 
   packet-verification:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       REFERENCE_DEVICE: 1
       VIRTUAL_TIME: 1
@@ -157,7 +157,7 @@ jobs:
         path: tmp/coverage.info
 
   cli-ftd:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       CFLAGS: -m32
       CXXFLAGS: -m32
@@ -193,7 +193,7 @@ jobs:
         path: tmp/coverage.info
 
   cli-mtd:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
         message_use_heap: [0, 1]
@@ -234,7 +234,7 @@ jobs:
         path: tmp/coverage.info
 
   cli-time-sync:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       CFLAGS: -m32
       CXXFLAGS: -m32
@@ -271,7 +271,7 @@ jobs:
         path: tmp/coverage.info
 
   expects:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       CFLAGS: -DCLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER=1 -DOPENTHREAD_CONFIG_MLE_MAX_CHILDREN=15
       CXXFLAGS: -DCLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER=1 -DOPENTHREAD_CONFIG_MLE_MAX_CHILDREN=15
@@ -279,7 +279,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        OT_OPTIONS=-DOT_READLINE=OFF sudo apt-get --no-install-recommends install -y expect ninja-build lcov socat
+        OT_OPTIONS=-DOT_READLINE=OFF sudo apt-get --no-install-recommends install -y expect ninja-build lcov socat net-tools
     - name: Run
       run: |
         OT_OPTIONS=-DOT_TIME_SYNC=ON VIRTUAL_TIME=0 ./script/test build expect
@@ -317,7 +317,9 @@ jobs:
     - name: Run TUN Mode
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+        sudo netstat -na | grep 5353
         sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
+        sudo netstat -na | grep 5353
         sudo systemctl start dnsmasq ntp
         host ipv6.google.com 127.0.0.1
         echo 'listen-address=::1' | sudo tee /etc/dnsmasq.conf
@@ -348,7 +350,7 @@ jobs:
         path: tmp/coverage.info
 
   external-commissioner:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Bootstrap
@@ -385,7 +387,7 @@ jobs:
         path: tmp/coverage.info
 
   multiple-instance:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       COVERAGE: 1
       MULTIPLE_INSTANCE: 1
@@ -418,7 +420,7 @@ jobs:
         path: tmp/coverage.info
 
   ncp-gcc-m32:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       CFLAGS: -m32
       CXXFLAGS: -m32
@@ -457,7 +459,7 @@ jobs:
         path: tmp/coverage.info
 
   ncp-clang:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     env:
       COVERAGE: 1
       NODE_TYPE: ncp-sim
@@ -506,7 +508,7 @@ jobs:
     - multiple-instance
     - ncp-gcc-m32
     - ncp-clang
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Bootstrap

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -317,7 +317,7 @@ jobs:
         path: tmp/coverage.info
     - name: Run TUN Mode
       run: |
-        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+        sudo sudo apt-get update
         sudo netstat -nap | grep 5353
         sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
         sudo netstat -nap | grep 5353

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -316,39 +316,38 @@ jobs:
         path: tmp/coverage.info
     - name: Run TUN Mode
       run: |
-        sudo apt-get update
-#        sudo netstat -nap | grep 5353
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+        sudo netstat -na | grep 5353
         sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
-#        sudo netstat -nap | grep 5353
-#        sudo systemctl start dnsmasq ntp
-#        sudo netstat -nap | grep 5353
-#        host ipv6.google.com 127.0.0.1
-#        echo 'listen-address=::1' | sudo tee /etc/dnsmasq.conf
-#        echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
-#        sudo systemctl restart dnsmasq
-#        host ipv6.google.com ::1
-#        OT_OPTIONS=-DOT_READLINE=OFF OT_NATIVE_IP=1 VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
-#    - name: Keep POSIX Only
-#      run: |
-#        ./script/test tar simulation 1.1
-#    - name: Generate Coverage
-#      run: |
-#        ./script/test generate_coverage gcc
-#    - uses: actions/upload-artifact@v2
-#      with:
-#        name: cov-expects-4
-#        path: tmp/coverage.info
-#    - name: Keep Simulation Only
-#      run: |
-#        ./script/test tar posix 1.1
-#        ./script/test untar simulation 1.1
-#    - name: Generate Coverage
-#      run: |
-#        ./script/test generate_coverage gcc
-#    - uses: actions/upload-artifact@v2
-#      with:
-#        name: cov-expects-5
-#        path: tmp/coverage.info
+        sudo netstat -na | grep 5353
+        sudo systemctl start dnsmasq ntp
+        host ipv6.google.com 127.0.0.1
+        echo 'listen-address=::1' | sudo tee /etc/dnsmasq.conf
+        echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6
+        sudo systemctl restart dnsmasq
+        host ipv6.google.com ::1
+        OT_OPTIONS=-DOT_READLINE=OFF OT_NATIVE_IP=1 VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
+    - name: Keep POSIX Only
+      run: |
+        ./script/test tar simulation 1.1
+    - name: Generate Coverage
+      run: |
+        ./script/test generate_coverage gcc
+    - uses: actions/upload-artifact@v2
+      with:
+        name: cov-expects-4
+        path: tmp/coverage.info
+    - name: Keep Simulation Only
+      run: |
+        ./script/test tar posix 1.1
+        ./script/test untar simulation 1.1
+    - name: Generate Coverage
+      run: |
+        ./script/test generate_coverage gcc
+    - uses: actions/upload-artifact@v2
+      with:
+        name: cov-expects-5
+        path: tmp/coverage.info
 
   external-commissioner:
     runs-on: ubuntu-20.04

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -318,8 +318,11 @@ jobs:
     - name: Run TUN Mode
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+        sudo netstat -nap | grep 5353
         sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
+        sudo netstat -nap | grep 5353
         sudo systemctl start dnsmasq ntp
+        sudo netstat -nap | grep 5353
         host ipv6.google.com 127.0.0.1
         echo 'listen-address=::1' | sudo tee /etc/dnsmasq.conf
         echo 0 | sudo tee /proc/sys/net/ipv6/conf/all/disable_ipv6

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -271,7 +271,7 @@ jobs:
         path: tmp/coverage.info
 
   expects:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-18.04
     env:
       CFLAGS: -DCLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER=1 -DOPENTHREAD_CONFIG_MLE_MAX_CHILDREN=15
       CXXFLAGS: -DCLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER=1 -DOPENTHREAD_CONFIG_MLE_MAX_CHILDREN=15
@@ -279,8 +279,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        sudo apt-get update
-        OT_OPTIONS=-DOT_READLINE=OFF sudo apt-get --no-install-recommends install -y expect ninja-build lcov socat net-tools
+        OT_OPTIONS=-DOT_READLINE=OFF sudo apt-get --no-install-recommends install -y expect ninja-build lcov socat
     - name: Run
       run: |
         OT_OPTIONS=-DOT_TIME_SYNC=ON VIRTUAL_TIME=0 ./script/test build expect
@@ -317,6 +316,7 @@ jobs:
         path: tmp/coverage.info
     - name: Run TUN Mode
       run: |
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
         sudo systemctl start dnsmasq ntp
         host ipv6.google.com 127.0.0.1

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -316,7 +316,7 @@ jobs:
         path: tmp/coverage.info
     - name: Run TUN Mode
       run: |
-        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+        sudo apt-get update
         sudo netstat -nap | grep 5353
         sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
         sudo netstat -nap | grep 5353

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -317,9 +317,7 @@ jobs:
         path: tmp/coverage.info
     - name: Run TUN Mode
       run: |
-        sudo netstat -na | grep 5353
         sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
-        sudo netstat -na | grep 5353
         sudo systemctl start dnsmasq ntp
         host ipv6.google.com 127.0.0.1
         echo 'listen-address=::1' | sudo tee /etc/dnsmasq.conf

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -316,7 +316,7 @@ jobs:
         path: tmp/coverage.info
     - name: Run TUN Mode
       run: |
-        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+        sudo apt-get update
         sudo netstat -na | grep 5353
         sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
         sudo netstat -na | grep 5353

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -317,9 +317,9 @@ jobs:
     - name: Run TUN Mode
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
-        sudo netstat -na | grep 5353
+        sudo netstat -nap | grep 5353
         sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
-        sudo netstat -na | grep 5353
+        sudo netstat -nap | grep 5353
         sudo systemctl start dnsmasq ntp
         host ipv6.google.com 127.0.0.1
         echo 'listen-address=::1' | sudo tee /etc/dnsmasq.conf

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -279,6 +279,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
+        sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         OT_OPTIONS=-DOT_READLINE=OFF sudo apt-get --no-install-recommends install -y expect ninja-build lcov socat net-tools
     - name: Run
       run: |

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -317,9 +317,7 @@ jobs:
     - name: Run TUN Mode
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
-        sudo netstat -nap | grep 5353
         sudo apt-get install --no-install-recommends -y dnsmasq bind9-host ntp
-        sudo netstat -nap | grep 5353
         sudo systemctl start dnsmasq ntp
         host ipv6.google.com 127.0.0.1
         echo 'listen-address=::1' | sudo tee /etc/dnsmasq.conf

--- a/.github/workflows/size.yml
+++ b/.github/workflows/size.yml
@@ -33,7 +33,7 @@ on: [push, pull_request]
 jobs:
 
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
       env:
@@ -41,7 +41,7 @@ jobs:
       if: "github.ref != 'refs/heads/master'"
 
   size-report:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Bootstrap

--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -33,7 +33,7 @@ on: [push, pull_request]
 jobs:
 
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
       env:

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -32,7 +32,7 @@ on: [pull_request]
 
 jobs:
   cancel-previous-runs:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
     - uses: rokroskar/workflow-run-cleanup-action@master
       env:
@@ -40,7 +40,7 @@ jobs:
       if: "github.ref != 'refs/heads/master'"
 
   api-version:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     steps:
     - uses: actions/checkout@v2
     - name: Check

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -333,7 +333,7 @@ void TestRssAveraging(void)
             rss = GetRandomRss();
             IgnoreError(rssAverager.Add(rss));
             sum += rss;
-            mean = static_cast<double>(sum) / j;
+            mean = static_cast<double>(sum) / static_cast<double>(j);
             VerifyOrQuit(ABS(rssAverager.GetAverage() - mean) < 1, "Average does not match the arithmetic mean!");
             VerifyRawRssValue(rssAverager);
             printf("AddRss(%4d) sum=%-5d, mean=%-8.2f RssAverager=", rss, sum, mean);


### PR DESCRIPTION
This commit update Github Actions workflows to use `ubuntu 20.04` whenever applicable. 

- Change `ubuntu-latest` to `ubuntu-20.04` to cleanup the annotations:
```
Ubuntu-latest workflows will use Ubuntu-20.04 soon. For more details, see https://github.com/actions/virtual-environments/issues/1816
```
- Change `ubuntu-18.04` to `ubuntu-20.04` wherever `ubuntu-20.04` works.
  - Fixed a compile issue in `tests/unit/test_link_quality.cpp` on `ubuntu-20.04`
  - Can not get `Simulation/expects` work on `ubuntu 20.04` due to unknown issue. Leave for further enhancement. 