### PR TITLE
[ip6] tiny enhancement for HandleOptions

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -533,7 +533,7 @@ void Ip6::HandleSendQueue(void)
     }
 }
 
-otError Ip6::HandleOptions(Message &aMessage, Header &aHeader, bool &aForward, bool &aReceive)
+otError Ip6::HandleOptions(Message &aMessage, Header &aHeader, bool aForward, bool &aReceive)
 {
     otError        error = OT_ERROR_NONE;
     HopByHopHeader hbhHeader;

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -356,7 +356,7 @@ private:
     otError AddTunneledMplOption(Message &aMessage, Header &aHeader, MessageInfo &aMessageInfo);
     otError InsertMplOption(Message &aMessage, Header &aHeader, MessageInfo &aMessageInfo);
     otError RemoveMplOption(Message &aMessage);
-    otError HandleOptions(Message &aMessage, Header &aHeader, bool &aForward, bool &aReceive);
+    otError HandleOptions(Message &aMessage, Header &aHeader, bool aForward, bool &aReceive);
     otError HandlePayload(Message &          aMessage,
                           MessageInfo &      aMessageInfo,
                           uint8_t            aIpProto,


### PR DESCRIPTION
As I observed, `aForward` in `Ip6::HandleOptions` is a purely 'in' parameter. We should remove the reference to clear the confusion.