### PR TITLE
[dataset] set key rotation time in security policy on random generation

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -67,11 +67,12 @@ otError Dataset::Info::GenerateRandom(Instance &aInstance)
 
     Clear();
 
-    mActiveTimestamp       = 1;
-    mChannel               = preferredChannels.ChooseRandomChannel();
-    mChannelMask           = supportedChannels.GetMask();
-    mSecurityPolicy.mFlags = aInstance.Get<KeyManager>().GetSecurityPolicyFlags();
-    mPanId                 = Mac::GenerateRandomPanId();
+    mActiveTimestamp              = 1;
+    mChannel                      = preferredChannels.ChooseRandomChannel();
+    mChannelMask                  = supportedChannels.GetMask();
+    mSecurityPolicy.mRotationTime = KeyManager::kDefaultKeyRotationTime;
+    mSecurityPolicy.mFlags        = KeyManager::kDefaultSecurityPolicyFlags;
+    mPanId                        = Mac::GenerateRandomPanId();
 
     SuccessOrExit(error = static_cast<MasterKey &>(mMasterKey).GenerateRandom());
     SuccessOrExit(error = static_cast<Pskc &>(mPskc).GenerateRandom());

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -78,7 +78,7 @@ KeyManager::KeyManager(Instance &aInstance)
     , mKeySwitchGuardEnabled(false)
     , mKeyRotationTimer(aInstance, KeyManager::HandleKeyRotationTimer, this)
     , mKekFrameCounter(0)
-    , mSecurityPolicyFlags(0xff)
+    , mSecurityPolicyFlags(kDefaultSecurityPolicyFlags)
     , mIsPskcSet(false)
 {
     mMasterKey = static_cast<const MasterKey &>(kDefaultMasterKey);

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -115,6 +115,16 @@ typedef Mac::Key Kek;
 class KeyManager : public InstanceLocator, private NonCopyable
 {
 public:
+    enum : uint16_t
+    {
+        kDefaultKeyRotationTime = 672, ///< Default Key Rotation Time (in unit of hours).
+    };
+
+    enum : uint8_t
+    {
+        kDefaultSecurityPolicyFlags = 0xff, ///< Default Security Policy Flags.
+    };
+
     /**
      * This constructor initializes the object.
      *
@@ -448,7 +458,6 @@ private:
     enum
     {
         kMinKeyRotationTime        = 1,
-        kDefaultKeyRotationTime    = 672,
         kDefaultKeySwitchGuardTime = 624,
         kOneHourIntervalInMsec     = 3600u * 1000u,
     };


### PR DESCRIPTION
This commit updates `Dataset::Info::GenerateRandom()` to set the Key
Rotation Time in Security Policy component on the Dataset using its
default value (from `KeyManager`). This addresses the issue where the
generated Operational Dataset could potentially use zero for Key
Rotation time.

This commit also changes Security Policy Flags to use default value
from `KeyManager`.

------

_Adding a note on this_:
With existing code, if we happen to generate and use an Operation Dataset with Key Rotation Time value set to zero, while the value in Dataset may not be correct, it would not impact the value used by `KeyManager` (`Dataset::ApplyConfigruation()` uses `keyManager.SetKeyRotation()` which itself would verify the given value to be valid, otherwise it would continue to the previous value for Key Rotation Time which is the the default set from constructor).