### PR TITLE
[border-router] move configuration check from api to inner class

### DIFF
--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -53,16 +53,17 @@ otError otBorderRouterGetNetData(otInstance *aInstance, bool aStable, uint8_t *a
 
 otError otBorderRouterAddOnMeshPrefix(otInstance *aInstance, const otBorderRouterConfig *aConfig)
 {
-    otError                                error    = OT_ERROR_NONE;
+    otError                                error;
     Instance &                             instance = *static_cast<Instance *>(aInstance);
     const NetworkData::OnMeshPrefixConfig *config   = static_cast<const NetworkData::OnMeshPrefixConfig *>(aConfig);
 
     OT_ASSERT(aConfig != nullptr);
 
-    error = instance.Get<NetworkData::Local>().AddOnMeshPrefix(*config);
+    SuccessOrExit(error = instance.Get<NetworkData::Local>().AddOnMeshPrefix(*config));
+
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    // Only try to configure Domain Prefix after the parameter is vaidated via above `AddOnMeshPrefix()`.
-    if (error == OT_ERROR_NONE && aConfig->mDp)
+    // Only try to configure Domain Prefix after the parameter is validated via above `AddOnMeshPrefix()`.
+    if (aConfig->mDp)
     {
         // Restore local server data
         IgnoreError(instance.Get<NetworkData::Local>().RemoveOnMeshPrefix(config->GetPrefix()));

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -58,14 +58,6 @@ otError otBorderRouterAddOnMeshPrefix(otInstance *aInstance, const otBorderRoute
     const NetworkData::OnMeshPrefixConfig *config   = static_cast<const NetworkData::OnMeshPrefixConfig *>(aConfig);
 
     OT_ASSERT(aConfig != nullptr);
-    // Add Prefix validation check:
-    // Thread 1.1 Specification 5.13.2 says
-    // "A valid prefix MUST NOT allow both DHCPv6 and SLAAC for address configuration"
-    VerifyOrExit(!aConfig->mDhcp || !aConfig->mSlaac, error = OT_ERROR_INVALID_ARGS);
-    // RFC 4944 Section 6 says:
-    // An IPv6 address prefix used for stateless autoconfiguration [RFC4862]
-    // of an IEEE 802.15.4 interface MUST have a length of 64 bits.
-    VerifyOrExit(!aConfig->mSlaac || aConfig->mPrefix.mLength == OT_IP6_PREFIX_BITSIZE, error = OT_ERROR_INVALID_ARGS);
 
     error = instance.Get<NetworkData::Local>().AddOnMeshPrefix(*config);
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -62,12 +62,12 @@ otError Local::AddOnMeshPrefix(const OnMeshPrefixConfig &aConfig)
     // Add Prefix validation check:
     // Thread 1.1 Specification 5.13.2 says
     // "A valid prefix MUST NOT allow both DHCPv6 and SLAAC for address configuration"
-    VerifyOrExit(!aConfig->mDhcp || !aConfig->mSlaac, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(!aConfig.mDhcp || !aConfig.mSlaac, error = OT_ERROR_INVALID_ARGS);
 
     // RFC 4944 Section 6 says:
     // An IPv6 address prefix used for stateless autoconfiguration [RFC4862]
     // of an IEEE 802.15.4 interface MUST have a length of 64 bits.
-    VerifyOrExit(!aConfig->mSlaac || aConfig->mPrefix.mLength == OT_IP6_PREFIX_BITSIZE, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(!aConfig.mSlaac || aConfig.mPrefix.mLength == OT_IP6_PREFIX_BITSIZE, error = OT_ERROR_INVALID_ARGS);
 
     if (aConfig.mPreferred)
     {

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -56,7 +56,7 @@ Local::Local(Instance &aInstance)
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 otError Local::AddOnMeshPrefix(const OnMeshPrefixConfig &aConfig)
 {
-    otError error;
+    otError  error;
     uint16_t flags = 0;
 
     // Add Prefix validation check:
@@ -111,8 +111,8 @@ otError Local::AddOnMeshPrefix(const OnMeshPrefixConfig &aConfig)
     }
 #endif
 
-    error = AddPrefix(aConfig.GetPrefix(), NetworkDataTlv::kTypeBorderRouter, aConfig.mPreference, flags,
-                      aConfig.mStable);
+    error =
+        AddPrefix(aConfig.GetPrefix(), NetworkDataTlv::kTypeBorderRouter, aConfig.mPreference, flags, aConfig.mStable);
 
 exit:
     return error;

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -56,7 +56,18 @@ Local::Local(Instance &aInstance)
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 otError Local::AddOnMeshPrefix(const OnMeshPrefixConfig &aConfig)
 {
+    otError error;
     uint16_t flags = 0;
+
+    // Add Prefix validation check:
+    // Thread 1.1 Specification 5.13.2 says
+    // "A valid prefix MUST NOT allow both DHCPv6 and SLAAC for address configuration"
+    VerifyOrExit(!aConfig->mDhcp || !aConfig->mSlaac, error = OT_ERROR_INVALID_ARGS);
+
+    // RFC 4944 Section 6 says:
+    // An IPv6 address prefix used for stateless autoconfiguration [RFC4862]
+    // of an IEEE 802.15.4 interface MUST have a length of 64 bits.
+    VerifyOrExit(!aConfig->mSlaac || aConfig->mPrefix.mLength == OT_IP6_PREFIX_BITSIZE, error = OT_ERROR_INVALID_ARGS);
 
     if (aConfig.mPreferred)
     {
@@ -100,8 +111,11 @@ otError Local::AddOnMeshPrefix(const OnMeshPrefixConfig &aConfig)
     }
 #endif
 
-    return AddPrefix(aConfig.GetPrefix(), NetworkDataTlv::kTypeBorderRouter, aConfig.mPreference, flags,
-                     aConfig.mStable);
+    error = AddPrefix(aConfig.GetPrefix(), NetworkDataTlv::kTypeBorderRouter, aConfig.mPreference, flags,
+                      aConfig.mStable);
+
+exit:
+    return error;
 }
 
 otError Local::RemoveOnMeshPrefix(const Ip6::Prefix &aPrefix)


### PR DESCRIPTION
This PR moves the border router configuration check into NetworkData::Local.