### PR TITLE
[style] simplify build paths

### DIFF
--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -64,12 +64,12 @@ jobs:
         make -f src/posix/Makefile-posix
     - name: Run
       run: |
-        VERBOSE=1 OT_CLI_PATH="$(pwd)/$(ls output/posix/*/bin/ot-cli) -v" RADIO_DEVICE="$(pwd)/$(ls output/*/bin/ot-rcp)" make -f src/posix/Makefile-posix check
+        VERBOSE=1 OT_CLI_PATH="$PWD/output/posix/bin/ot-cli -v" RADIO_DEVICE="$PWD/output/simulation/bin/ot-rcp" make -f src/posix/Makefile-posix check
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
         name: posix-cli-thread-cert
-        path: build/posix/x86_64-unknown-linux-gnu/tests/scripts/thread-cert
+        path: build/posix/tests/scripts/thread-cert
     - name: Keep Simulation Only
       run: |
         tar -cf build/posix.tar -C build/ posix/
@@ -83,7 +83,7 @@ jobs:
         path: tmp/coverage.info
     - name: Keep POSIX Only
       run: |
-        rm -rf build/x86_64-unknown-linux-gnu/
+        rm -rf build/simulation/
         tar -xf build/posix.tar -C build/
     - name: Generate Coverage
       run: |
@@ -118,12 +118,12 @@ jobs:
         make -f src/posix/Makefile-posix
     - name: Run
       run: |
-        VERBOSE=1 OT_NCP_PATH="$(pwd)/$(ls output/posix/*/bin/ot-ncp)" RADIO_DEVICE="$(pwd)/$(ls output/*/bin/ot-rcp)" make -f src/posix/Makefile-posix check
+        VERBOSE=1 OT_NCP_PATH="$PWD/output/posix/bin/ot-ncp" RADIO_DEVICE="$PWD/output/simulation/bin/ot-rcp" make -f src/posix/Makefile-posix check
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
         name: posix-ncp-thread-cert
-        path: build/posix/x86_64-unknown-linux-gnu/tests/scripts/thread-cert
+        path: build/posix/tests/scripts/thread-cert
     - name: Keep Simulation Only
       run: |
         tar -cf build/posix.tar -C build/ posix/
@@ -137,7 +137,7 @@ jobs:
         path: tmp/coverage.info
     - name: Keep POSIX Only
       run: |
-        rm -rf build/x86_64-unknown-linux-gnu/
+        rm -rf build/simulation/
         tar -xf build/posix.tar -C build/
     - name: Generate Coverage
       run: |
@@ -177,7 +177,7 @@ jobs:
         path: tmp/coverage.info
     - name: Keep POSIX Only
       run: |
-        rm -rf build/x86_64-unknown-linux-gnu/
+        rm -rf build/simulation/
         tar -xf build/posix.tar -C build/
     - name: Generate Coverage
       run: |
@@ -225,7 +225,7 @@ jobs:
         path: tmp/coverage.info
     - name: Keep POSIX Only
       run: |
-        rm -rf build/x86_64-unknown-linux-gnu/
+        rm -rf build/simulation/
         tar -xf build/posix.tar -C build/
     - name: Generate Coverage
       run: |
@@ -274,7 +274,7 @@ jobs:
         path: tmp/coverage.info
     - name: Keep POSIX Only
       run: |
-        rm -rf build/x86_64-unknown-linux-gnu/
+        rm -rf build/simulation/
         tar -xf build/posix.tar -C build/
     - name: Generate Coverage
       run: |

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -89,7 +89,7 @@ jobs:
         ./bootstrap
     - name: Run OTNS Tests
       env:
-        OTNS_COMMIT: "2d57478d9e748d09cad65cf5374942e9d96719ed" # just for CI
+        OTNS_COMMIT: "2d57478d9e748d09cad65cf5374942e9d96719ed" # openthread/ot-ns#112
       run: |
         export OT_DIR=$PWD
         mkdir -p /tmp/otns

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -183,7 +183,7 @@ jobs:
       if: ${{ failure() }}
       with:
         name: cli-ftd-thread-cert
-        path: build/x86_64-unknown-linux-gnu/tests/scripts/thread-cert
+        path: build/simulation/tests/scripts/thread-cert
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc
@@ -224,7 +224,7 @@ jobs:
       if: ${{ failure() }}
       with:
         name: cli-mtd-thread-cert
-        path: build/x86_64-unknown-linux-gnu/tests/scripts/thread-cert
+        path: build/simulation/tests/scripts/thread-cert
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc
@@ -261,7 +261,7 @@ jobs:
       if: ${{ failure() }}
       with:
         name: cli-time-sync-thread-cert
-        path: build/x86_64-unknown-linux-gnu/tests/scripts/thread-cert
+        path: build/simulation/tests/scripts/thread-cert
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc
@@ -408,7 +408,7 @@ jobs:
       if: ${{ failure() }}
       with:
         name: multiple-instance-thread-cert
-        path: build/x86_64-unknown-linux-gnu/tests/scripts/thread-cert
+        path: build/simulation/tests/scripts/thread-cert
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc
@@ -447,7 +447,7 @@ jobs:
       if: ${{ failure() }}
       with:
         name: ncp-gcc-m32-thread-cert
-        path: build/x86_64-unknown-linux-gnu/tests/scripts/thread-cert
+        path: build/simulation/tests/scripts/thread-cert
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc
@@ -485,7 +485,7 @@ jobs:
       if: ${{ failure() }}
       with:
         name: cli-clang-thread-cert
-        path: build/x86_64-unknown-linux-gnu/tests/scripts/thread-cert
+        path: build/simulation/tests/scripts/thread-cert
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage llvm

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -89,7 +89,7 @@ jobs:
         ./bootstrap
     - name: Run OTNS Tests
       env:
-        OTNS_COMMIT: "632503d7ccbadcbdc49c6245eafc2425c80bbf04" # Sep 29, 2020
+        OTNS_COMMIT: "2d57478d9e748d09cad65cf5374942e9d96719ed" # just for CI
       run: |
         export OT_DIR=$PWD
         mkdir -p /tmp/otns

--- a/examples/Makefile-simulation
+++ b/examples/Makefile-simulation
@@ -152,7 +152,7 @@ ResultPath                      = output
 TopResultDir                    = $(ResultPath)
 AbsTopResultDir                 = $(PWD)/$(TopResultDir)
 
-TargetTuple                     = $(shell ${AbsTopSourceDir}/third_party/nlbuild-autotools/repo/third_party/autoconf/config.guess | sed -e 's/[[:digit:].]*$$//g')
+TargetTuple                     = simulation
 
 ifndef BuildJobs
 BuildJobs := $(shell getconf _NPROCESSORS_ONLN)

--- a/script/check-ncp-rcp-migrate
+++ b/script/check-ncp-rcp-migrate
@@ -61,7 +61,7 @@ check()
     MASTER_KEY="0123456789abcdef0123456789abcdef"
 
     echo "Step 1. Start NCP platform and form a PAN..."
-    RADIO_NCP_CMD="$(pwd)/$(ls output/*linux*/bin/ot-cli-ftd)"
+    RADIO_NCP_CMD="$PWD/output/simulation/bin/ot-cli-ftd"
 
     expect <<EOF
 spawn ${RADIO_NCP_CMD} 1
@@ -92,13 +92,13 @@ expect eof
 EOF
 
     echo "Step 2. Start retrieving dataset from Radio..."
-    RADIO_NCP_PATH="$(pwd)/$(ls output/*linux*/bin/ot-ncp-ftd)"
-    "$(pwd)/$(ls output/posix/*linux*/bin/ot-ncp)" -n --radio-version "spinel+hdlc+forkpty://${RADIO_NCP_PATH}?forkpty-arg=1&ncp-dataset=1"
+    RADIO_NCP_PATH="$PWD/output/simulation/bin/ot-ncp-ftd"
+    "$PWD/output/posix/bin/ot-ncp" -n --radio-version "spinel+hdlc+forkpty://${RADIO_NCP_PATH}?forkpty-arg=1&ncp-dataset=1"
 
     echo "Step 3. Start posix app and check whether PAN dataset is the same..."
-    RADIO_RCP_PATH="$(pwd)/$(ls output/*linux*/bin/ot-rcp)"
+    RADIO_RCP_PATH="$PWD/output/simulation/bin/ot-rcp"
 
-    OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli) spinel+hdlc+forkpty://${RADIO_RCP_PATH}?forkpty-arg=1"
+    OT_CLI_CMD="$PWD/output/posix/bin/ot-cli spinel+hdlc+forkpty://${RADIO_RCP_PATH}?forkpty-arg=1"
 
     expect <<EOF
 spawn ${OT_CLI_CMD}
@@ -126,7 +126,7 @@ expect eof
 EOF
 
     echo "Step 4. Start posix app and check whether it can get radio firmware version..."
-    RADIO_VERSION="$("$(pwd)/$(ls output/posix/*linux*/bin/ot-cli)" -n --radio-version "spinel+hdlc+forkpty://${RADIO_RCP_PATH}?forkpty-arg=1&ncp-dataset=1")" || true
+    RADIO_VERSION="$("$PWD/output/posix/bin/ot-cli" -n --radio-version "spinel+hdlc+forkpty://${RADIO_RCP_PATH}?forkpty-arg=1&ncp-dataset=1")" || true
     echo "${RADIO_VERSION}"
     test -n "{RADIO_VERSION}"
 }

--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -75,7 +75,7 @@ check()
     echo 'RADIO_PTY' "$RADIO_PTY"
     echo 'CORE_PTY' "$CORE_PTY"
 
-    RADIO_NCP_PATH="$(pwd)/$(ls output/*linux*/bin/ot-rcp)"
+    RADIO_NCP_PATH="$PWD/output/simulation/bin/ot-rcp"
 
     # shellcheck disable=SC2094
     $RADIO_NCP_PATH 1 >"$RADIO_PTY" <"$RADIO_PTY" &
@@ -86,9 +86,9 @@ check()
     RADIO_URL="spinel+hdlc+uart://${CORE_PTY}?max-power-table=11,12,13,14,15,16,17,18,19,20,21,22,23,24,25,26"
 
     if [[ ${DAEMON} == 1 ]]; then
-        sudo "$(pwd)/$(ls output/posix/*linux*/bin/ot-daemon)" -I "${VALID_NETIF_NAME}" "${RADIO_URL}" &
+        sudo "$PWD/output/posix/bin/ot-daemon" -I "${VALID_NETIF_NAME}" "${RADIO_URL}" &
         sleep 1
-        OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-ctl)"
+        OT_CLI_CMD="$PWD/output/posix/bin/ot-ctl"
         sudo "${OT_CLI_CMD}" panid 0xface | grep 'Done' || die 'failed to set panid with ot-ctl'
 
         # verify this reset and factoryreset end immediately
@@ -97,7 +97,7 @@ check()
         sleep 2
         sudo "${OT_CLI_CMD}" factoryreset
     else
-        OT_CLI="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli)"
+        OT_CLI="$PWD/output/posix/bin/ot-cli"
         sudo "${OT_CLI}" -I "${VALID_NETIF_NAME}" -n "${RADIO_URL}"
 
         # Cover setting a too long(max is 15 characters) network interface name.
@@ -105,7 +105,7 @@ check()
         readonly INVALID_NETIF_NAME="wan0123456789123"
         sudo "${OT_CLI}" -I "${INVALID_NETIF_NAME}" -n "${RADIO_URL}" || test $? = 2
 
-        OT_CLI_CMD="$(pwd)/$(ls output/posix/*linux*/bin/ot-cli) ${RADIO_URL}"
+        OT_CLI_CMD="$PWD/output/posix/bin/ot-cli ${RADIO_URL}"
     fi
 
     sudo expect <<EOF | tee "${OT_OUTPUT}" &

--- a/script/test
+++ b/script/test
@@ -73,13 +73,13 @@ build_simulation()
         options+=("${ot_extra_options[@]}")
     fi
 
-    OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/cmake/openthread-simulation-${version}" "${OT_SRCDIR}"/script/cmake-build simulation "${options[@]}"
+    OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/openthread-simulation-${version}" "${OT_SRCDIR}"/script/cmake-build simulation "${options[@]}"
 
     if [[ ${version} == "1.2" ]]; then
 
         options+=("-DOT_BACKBONE_ROUTER=ON")
 
-        OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/cmake/openthread-simulation-${version}-bbr" "${OT_SRCDIR}"/script/cmake-build simulation "${options[@]}"
+        OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/openthread-simulation-${version}-bbr" "${OT_SRCDIR}"/script/cmake-build simulation "${options[@]}"
 
     fi
 }
@@ -106,13 +106,13 @@ build_posix()
         options+=("${ot_extra_options[@]}")
     fi
 
-    OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/cmake/openthread-posix-${version}" "${OT_SRCDIR}"/script/cmake-build posix "${options[@]}"
+    OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/openthread-posix-${version}" "${OT_SRCDIR}"/script/cmake-build posix "${options[@]}"
 
     if [[ ${version} == "1.2" ]]; then
 
         options+=("-DOT_BACKBONE_ROUTER=ON")
 
-        OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/cmake/openthread-posix-${version}-bbr" "${OT_SRCDIR}"/script/cmake-build posix "${options[@]}"
+        OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/openthread-posix-${version}-bbr" "${OT_SRCDIR}"/script/cmake-build posix "${options[@]}"
     fi
 }
 
@@ -144,7 +144,7 @@ do_clean()
 do_unit_version()
 {
     local version=$1
-    local builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${version}"
+    local builddir="${OT_BUILDDIR}/openthread-simulation-${version}"
 
     if [[ ! -d ${builddir} ]]; then
         echo "Cannot find build directory: ${builddir}"
@@ -168,7 +168,7 @@ do_unit()
 
 do_cert()
 {
-    export top_builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}"
+    export top_builddir="${OT_BUILDDIR}/openthread-simulation-${THREAD_VERSION}"
 
     case "${OT_NODE_TYPE}" in
         rcp | rcp-cli | cli)
@@ -180,9 +180,9 @@ do_cert()
     esac
 
     if [[ ${THREAD_VERSION} == "1.2" ]]; then
-        export top_builddir_1_2_bbr="${OT_BUILDDIR}/cmake/openthread-simulation-1.2-bbr"
+        export top_builddir_1_2_bbr="${OT_BUILDDIR}/openthread-simulation-1.2-bbr"
         if [[ ${INTER_OP} == "1" ]]; then
-            export top_builddir_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1"
+            export top_builddir_1_1="${OT_BUILDDIR}/openthread-simulation-1.1"
         fi
     fi
 
@@ -192,12 +192,12 @@ do_cert()
 
 do_cert_suite()
 {
-    export top_builddir="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}"
+    export top_builddir="${OT_BUILDDIR}/openthread-simulation-${THREAD_VERSION}"
 
     if [[ ${THREAD_VERSION} == "1.2" ]]; then
-        export top_builddir_1_2_bbr="${OT_BUILDDIR}/cmake/openthread-simulation-1.2-bbr"
+        export top_builddir_1_2_bbr="${OT_BUILDDIR}/openthread-simulation-1.2-bbr"
         if [[ ${INTER_OP} == "1" ]]; then
-            export top_builddir_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1"
+            export top_builddir_1_1="${OT_BUILDDIR}/openthread-simulation-1.1"
         fi
     fi
 
@@ -372,15 +372,15 @@ do_package()
         options+=("${ot_extra_options[@]}")
     fi
 
-    builddir="${OT_BUILDDIR}/cmake/openthread-sim"
+    builddir="${OT_BUILDDIR}/openthread-sim"
     OT_CMAKE_NINJA_TARGET="package" OT_CMAKE_BUILD_DIR="${builddir}" "${OT_SRCDIR}"/script/cmake-build simulation "${options[@]}"
     ls "${builddir}"/openthread-simulation-*.deb
 
-    builddir="${OT_BUILDDIR}/cmake/openthread-host"
+    builddir="${OT_BUILDDIR}/openthread-host"
     OT_CMAKE_NINJA_TARGET="package" OT_CMAKE_BUILD_DIR="${builddir}" "${OT_SRCDIR}"/script/cmake-build posix "${options[@]}"
     ls "${builddir}"/openthread-standalone-*.deb
 
-    builddir="${OT_BUILDDIR}/cmake/openthread-daemon"
+    builddir="${OT_BUILDDIR}/openthread-daemon"
     OT_CMAKE_NINJA_TARGET="package" OT_CMAKE_BUILD_DIR="${builddir}" "${OT_SRCDIR}"/script/cmake-build posix -DOT_DAEMON=ON -DOT_PLATFORM_NETIF=ON -DOT_PLATFORM_UDP=ON "${options[@]}"
     ls "${builddir}"/openthread-daemon-*.deb
 }
@@ -388,7 +388,7 @@ do_package()
 do_tar()
 {
     local target_name="openthread-$1-$2"
-    local build_dir="${OT_BUILDDIR}/cmake"
+    local build_dir="${OT_BUILDDIR}"
     tar -cf "${target_name}.tar" -C "${build_dir}" "${target_name}"
     mv "${target_name}.tar" "${build_dir}/"
     rm -rf "${build_dir:?}/${target_name}"
@@ -397,7 +397,7 @@ do_tar()
 do_untar()
 {
     local target_name="openthread-$1-$2"
-    local build_dir="${OT_BUILDDIR}/cmake"
+    local build_dir="${OT_BUILDDIR}"
     tar -xf "${build_dir}/${target_name}.tar" -C "${build_dir}"
     rm "${build_dir:?}/${target_name}.tar"
 }
@@ -452,21 +452,21 @@ envsetup()
     export THREAD_VERSION
 
     if [[ ${OT_NODE_TYPE} == rcp* ]]; then
-        export RADIO_DEVICE="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}/examples/apps/ncp/ot-rcp"
-        export OT_CLI_PATH="${OT_BUILDDIR}/cmake/openthread-posix-${THREAD_VERSION}/src/posix/ot-cli"
-        export OT_NCP_PATH="${OT_BUILDDIR}/cmake/openthread-posix-${THREAD_VERSION}/src/posix/ot-ncp"
+        export RADIO_DEVICE="${OT_BUILDDIR}/openthread-simulation-${THREAD_VERSION}/examples/apps/ncp/ot-rcp"
+        export OT_CLI_PATH="${OT_BUILDDIR}/openthread-posix-${THREAD_VERSION}/src/posix/ot-cli"
+        export OT_NCP_PATH="${OT_BUILDDIR}/openthread-posix-${THREAD_VERSION}/src/posix/ot-ncp"
 
         if [[ ${THREAD_VERSION} == "1.2" ]]; then
-            export RADIO_DEVICE_1_1="${OT_BUILDDIR}/cmake/openthread-simulation-1.1/examples/apps/ncp/ot-rcp"
-            export OT_CLI_PATH_1_1="${OT_BUILDDIR}/cmake/openthread-posix-1.1/src/posix/ot-cli"
-            export OT_NCP_PATH_1_1="${OT_BUILDDIR}/cmake/openthread-posix-1.1/src/posix/ot-ncp"
-            export OT_CLI_PATH_1_2_BBR="${OT_BUILDDIR}/cmake/openthread-posix-1.2-bbr/src/posix/ot-cli"
-            export OT_NCP_PATH_1_2_BBR="${OT_BUILDDIR}/cmake/openthread-posix-1.2-bbr/src/posix/ot-ncp"
+            export RADIO_DEVICE_1_1="${OT_BUILDDIR}/openthread-simulation-1.1/examples/apps/ncp/ot-rcp"
+            export OT_CLI_PATH_1_1="${OT_BUILDDIR}/openthread-posix-1.1/src/posix/ot-cli"
+            export OT_NCP_PATH_1_1="${OT_BUILDDIR}/openthread-posix-1.1/src/posix/ot-ncp"
+            export OT_CLI_PATH_1_2_BBR="${OT_BUILDDIR}/openthread-posix-1.2-bbr/src/posix/ot-cli"
+            export OT_NCP_PATH_1_2_BBR="${OT_BUILDDIR}/openthread-posix-1.2-bbr/src/posix/ot-ncp"
         fi
     fi
 
-    export OT_SIMULATION_APPS="${OT_BUILDDIR}/cmake/openthread-simulation-${THREAD_VERSION}/examples/apps"
-    export OT_POSIX_APPS="${OT_BUILDDIR}/cmake/openthread-posix-${THREAD_VERSION}/src/posix"
+    export OT_SIMULATION_APPS="${OT_BUILDDIR}/openthread-simulation-${THREAD_VERSION}/examples/apps"
+    export OT_POSIX_APPS="${OT_BUILDDIR}/openthread-posix-${THREAD_VERSION}/src/posix"
 
     if [[ ! ${VIRTUAL_TIME+x} ]]; then
         # All expect tests only works in real time mode.

--- a/src/posix/Makefile-posix
+++ b/src/posix/Makefile-posix
@@ -158,15 +158,15 @@ MKDIR_P                        := mkdir -p
 RM_F                           := rm -f
 
 BuildJobs                      ?= 10
-BuildPath                       = build/posix
+BuildPath                       = build
 TopBuildDir                     = $(BuildPath)
 AbsTopBuildDir                  = $(PWD)/$(TopBuildDir)
 
-ResultPath                      = output/posix
+ResultPath                      = output
 TopResultDir                    = $(ResultPath)
 AbsTopResultDir                 = $(PWD)/$(TopResultDir)
 
-TargetTuple                     = $(shell ${AbsTopSourceDir}/third_party/nlbuild-autotools/repo/third_party/autoconf/config.guess | sed -e 's/[[:digit:].]*$$//g')
+TargetTuple                     = posix
 
 ifndef BuildJobs
 BuildJobs := $(shell getconf _NPROCESSORS_ONLN)

--- a/src/posix/README.md
+++ b/src/posix/README.md
@@ -89,7 +89,7 @@ python cc2538-bsl/cc2538-bsl.py -b 460800 -e -w -v -p /dev/ttyUSB0 ot-rcp.bin
 ### With Simulation
 
 ```sh
-sudo wpantund -s 'system:./output/posix/bin/ot-ncp spinel+hdlc+forkpty://output/x86_64-unknown-linux-gnu/bin/ot-rcp?forkpty-arg=1'
+sudo wpantund -s 'system:./output/posix/bin/ot-ncp spinel+hdlc+forkpty://output/simulation/bin/ot-rcp?forkpty-arg=1'
 ```
 
 ### With Real Device
@@ -109,7 +109,7 @@ OpenThread Posix Daemon mode uses a unix socket as input and output, so that Ope
 # build daemon mode core stack for POSIX
 make -f src/posix/Makefile-posix DAEMON=1
 # Daemon with simulation
-./output/posix/bin/ot-daemon 'spinel+hdlc+forkpty://output/x86_64-unknown-linux-gnu/bin/ot-rcp?forkpty-arg=1'
+./output/posix/bin/ot-daemon 'spinel+hdlc+forkpty://output/simulation/bin/ot-rcp?forkpty-arg=1'
 # Daemon with real device
 ./output/posix/bin/ot-daemon 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=115200'
 # Built-in controller

--- a/src/posix/README.md
+++ b/src/posix/README.md
@@ -33,7 +33,7 @@ make -f examples/Makefile-xxxx
 
 ```sh
 make -f examples/Makefile-simulation
-./output/posix/x86_64-unknown-linux-gnu/bin/ot-cli 'spinel+hdlc+forkpty://output/x86_64-unknown-linux-gnu/bin/ot-rcp?forkpty-arg=1'
+./output/posix/bin/ot-cli 'spinel+hdlc+forkpty://output/simulation/bin/ot-rcp?forkpty-arg=1'
 ```
 
 ### With Real Device
@@ -58,7 +58,7 @@ expect "Probe configured successfully."
 exit
 EOF
 
-./output/posix/x86_64-unknown-linux-gnu/bin/ot-cli 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=115200'
+./output/posix/bin/ot-cli 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=115200'
 ```
 
 - USB=1
@@ -69,7 +69,7 @@ make -f examples/Makefile-nrf52840 USB=1
 arm-none-eabi-objcopy -O ihex output/nrf52840/bin/ot-rcp ot-rcp.hex
 nrfjprog -f nrf52 --chiperase --reset --program ot-rcp.hex
 # plug the CDC serial USB port
-./output/posix/x86_64-unknown-linux-gnu/bin/ot-cli 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=115200'
+./output/posix/bin/ot-cli 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=115200'
 ```
 
 #### CC2538
@@ -79,7 +79,7 @@ make -f examples/Makefile-cc2538
 arm-none-eabi-objcopy -O binary output/cc2538/bin/ot-rcp ot-rcp.bin
 # see https://github.com/JelmerT/cc2538-bsl
 python cc2538-bsl/cc2538-bsl.py -b 460800 -e -w -v -p /dev/ttyUSB0 ot-rcp.bin
-./output/posix/x86_64-unknown-linux-gnu/bin/ot-cli 'spinel+hdlc+uart:///dev/ttyUSB0?uart-baudrate=115200'
+./output/posix/bin/ot-cli 'spinel+hdlc+uart:///dev/ttyUSB0?uart-baudrate=115200'
 ```
 
 ## Wpantund Support
@@ -89,16 +89,16 @@ python cc2538-bsl/cc2538-bsl.py -b 460800 -e -w -v -p /dev/ttyUSB0 ot-rcp.bin
 ### With Simulation
 
 ```sh
-sudo wpantund -s 'system:./output/posix/x86_64-unknown-linux-gnu/bin/ot-ncp spinel+hdlc+forkpty://output/x86_64-unknown-linux-gnu/bin/ot-rcp?forkpty-arg=1'
+sudo wpantund -s 'system:./output/posix/bin/ot-ncp spinel+hdlc+forkpty://output/x86_64-unknown-linux-gnu/bin/ot-rcp?forkpty-arg=1'
 ```
 
 ### With Real Device
 
 ```sh
 # nRF52840
-sudo wpantund -s 'system:./output/posix/x86_64-unknown-linux-gnu/bin/ot-ncp spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=115200'
+sudo wpantund -s 'system:./output/posix/bin/ot-ncp spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=115200'
 # CC2538
-sudo wpantund -s 'system:./output/posix/x86_64-unknown-linux-gnu/bin/ot-ncp spinel+hdlc+uart:///dev/ttyUSB0?uart-baudrate=115200'
+sudo wpantund -s 'system:./output/posix/bin/ot-ncp spinel+hdlc+uart:///dev/ttyUSB0?uart-baudrate=115200'
 ```
 
 ## Daemon Mode Support
@@ -109,9 +109,9 @@ OpenThread Posix Daemon mode uses a unix socket as input and output, so that Ope
 # build daemon mode core stack for POSIX
 make -f src/posix/Makefile-posix DAEMON=1
 # Daemon with simulation
-./output/posix/x86_64-unknown-linux-gnu/bin/ot-daemon 'spinel+hdlc+forkpty://output/x86_64-unknown-linux-gnu/bin/ot-rcp?forkpty-arg=1'
+./output/posix/bin/ot-daemon 'spinel+hdlc+forkpty://output/x86_64-unknown-linux-gnu/bin/ot-rcp?forkpty-arg=1'
 # Daemon with real device
-./output/posix/x86_64-unknown-linux-gnu/bin/ot-daemon 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=115200'
+./output/posix/bin/ot-daemon 'spinel+hdlc+uart:///dev/ttyACM0?uart-baudrate=115200'
 # Built-in controller
-./output/posix/x86_64-unknown-linux-gnu/bin/ot-ctl
+./output/posix/bin/ot-ctl
 ```


### PR DESCRIPTION
This commit simplifies the build paths:

* remove cmake prefix from `script/test`
* use fixed name for simulation and posix platforms just like others

Depends-On: openthread/ot-ns#112