### PR TITLE
[radio-spinel] simplify 'Request()'

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -818,8 +818,8 @@ private:
     spinel_tid_t GetNextTid(void);
     void         FreeTid(spinel_tid_t tid) { mCmdTidsInUse &= ~(1 << tid); }
 
-    otError RequestV(bool aWait, uint32_t aCommand, spinel_prop_key_t aKey, const char *aFormat, va_list aArgs);
-    otError Request(bool aWait, uint32_t aCommand, spinel_prop_key_t aKey, const char *aFormat, ...);
+    otError RequestV(uint32_t aCommand, spinel_prop_key_t aKey, const char *aFormat, va_list aArgs);
+    otError Request(uint32_t aCommand, spinel_prop_key_t aKey, const char *aFormat, ...);
     otError RequestWithPropertyFormat(const char *      aPropertyFormat,
                                       uint32_t          aCommand,
                                       spinel_prop_key_t aKey,

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -1675,16 +1675,15 @@ exit:
 }
 
 template <typename InterfaceType, typename ProcessContextType>
-otError RadioSpinel<InterfaceType, ProcessContextType>::RequestV(bool              aWait,
-                                                                 uint32_t          command,
+otError RadioSpinel<InterfaceType, ProcessContextType>::RequestV(uint32_t          command,
                                                                  spinel_prop_key_t aKey,
                                                                  const char *      aFormat,
                                                                  va_list           aArgs)
 {
     otError      error = OT_ERROR_NONE;
-    spinel_tid_t tid   = (aWait ? GetNextTid() : 0);
+    spinel_tid_t tid   = GetNextTid();
 
-    VerifyOrExit(!aWait || tid > 0, error = OT_ERROR_BUSY);
+    VerifyOrExit(tid > 0, error = OT_ERROR_BUSY);
 
     error = SendCommand(command, aKey, tid, aFormat, aArgs);
     SuccessOrExit(error);
@@ -1696,7 +1695,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::RequestV(bool           
         VerifyOrExit(mTxRadioTid == 0, error = OT_ERROR_BUSY);
         mTxRadioTid = tid;
     }
-    else if (aWait)
+    else
     {
         mWaitingKey = aKey;
         mWaitingTid = tid;
@@ -1708,15 +1707,14 @@ exit:
 }
 
 template <typename InterfaceType, typename ProcessContextType>
-otError RadioSpinel<InterfaceType, ProcessContextType>::Request(bool              aWait,
-                                                                uint32_t          aCommand,
+otError RadioSpinel<InterfaceType, ProcessContextType>::Request(uint32_t          aCommand,
                                                                 spinel_prop_key_t aKey,
                                                                 const char *      aFormat,
                                                                 ...)
 {
     va_list args;
     va_start(args, aFormat);
-    otError status = RequestV(aWait, aCommand, aKey, aFormat, args);
+    otError status = RequestV(aCommand, aKey, aFormat, args);
     va_end(args);
     return status;
 }
@@ -1748,7 +1746,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::RequestWithPropertyForma
     otError error;
 
     mPropertyFormat = aPropertyFormat;
-    error           = RequestV(true, aCommand, aKey, aFormat, aArgs);
+    error           = RequestV(aCommand, aKey, aFormat, aArgs);
     mPropertyFormat = nullptr;
 
     return error;
@@ -1764,7 +1762,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::RequestWithExpectedComma
     otError error;
 
     mExpectedCommand = aExpectedCommand;
-    error            = RequestV(true, aCommand, aKey, aFormat, aArgs);
+    error            = RequestV(aCommand, aKey, aFormat, aArgs);
     mExpectedCommand = SPINEL_CMD_NOOP;
 
     return error;
@@ -1837,7 +1835,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::Transmit(otRadioFrame &a
     // `otPlatRadioTxStarted()` is triggered immediately for now, which may be earlier than real started time.
     otPlatRadioTxStarted(mInstance, mTransmitFrame);
 
-    error = Request(true, SPINEL_CMD_PROP_VALUE_SET, SPINEL_PROP_STREAM_RAW,
+    error = Request(SPINEL_CMD_PROP_VALUE_SET, SPINEL_PROP_STREAM_RAW,
                     SPINEL_DATATYPE_DATA_WLEN_S                               // Frame data
                         SPINEL_DATATYPE_UINT8_S                               // Channel
                             SPINEL_DATATYPE_UINT8_S                           // MaxCsmaBackoffs


### PR DESCRIPTION
This commit removes the unused `aWait` parameter from `Request()`
and `RequestV()` methods.