### PR TITLE
[thread-cert] fix 5.3.3 random fail by small chance

### DIFF
--- a/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
+++ b/tests/scripts/thread-cert/Cert_5_3_03_AddressQuery.py
@@ -231,7 +231,7 @@ class Cert_5_3_3_AddressQuery(thread_cert.TestCase):
             must_next()
         pkts.filter_ping_reply(identifier=_pkt.icmpv6.echo.identifier).\
             filter_wpan_src64(ROUTER_3).\
-            filter_wpan_dst16(ROUTER_2_RLOC16).\
+            filter_dst16(ROUTER_2_RLOC16).\
             must_next()
         pkts.filter_ping_reply(identifier=_pkt.icmpv6.echo.identifier).\
             filter_wpan_src64(ROUTER_2).\

--- a/tests/scripts/thread-cert/pktverify/packet_filter.py
+++ b/tests/scripts/thread-cert/pktverify/packet_filter.py
@@ -472,6 +472,9 @@ class PacketFilter(object):
         assert isinstance(addr, (str, ExtAddr)), addr
         return self.filter(lambda p: p.wpan.dst64 == addr, **kwargs)
 
+    def filter_dst16(self, rloc16: int, **kwargs):
+        return self.filter(lambda p: p.lowpan.mesh.dest16 == rloc16 or p.wpan.dst16 == rloc16, **kwargs)
+
     def filter_ping_request(self, identifier=None, **kwargs):
         return self.filter(
             lambda p: p.icmpv6.is_ping_request and (identifier is None or p.icmpv6.echo.identifier == identifier),


### PR DESCRIPTION
5.3.3 pktverify fail by small chance when the ping reply is forwarded from `Router3 -> Leader -> Router2` instead of  `Router3 -> Router2`. In such case, the direct `wpan.dst16` is not Router2's RLOC16, but Leader's RLOC16. 

This commit change 5.3.3 to check for both `6lowpan mesh dst16` and `wpan.dst16` against Router2's RLOC16.