### PR TITLE
[backbone-router] fix otBackboneRouterMulticastListenerGetNext missing

### DIFF
--- a/include/openthread/backbone_router_ftd.h
+++ b/include/openthread/backbone_router_ftd.h
@@ -291,9 +291,6 @@ typedef struct otBackboneRouterMulticastListenerInfo
 /**
  * This function gets the next Multicast Listener info (using an iterator).
  *
- * Note: available only when `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is enabled.
- *       Only used for test and certification.
- *
  * @param[in]     aInstance    A pointer to an OpenThread instance.
  * @param[inout]  aIterator    A pointer to the iterator. On success the iterator will be updated to point to next
  *                             Multicast Listener. To get the first entry the iterator should be set to

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (51)
+#define OPENTHREAD_API_VERSION (52)
 
 /**
  * @addtogroup api-instance

--- a/src/core/api/backbone_router_ftd_api.cpp
+++ b/src/core/api/backbone_router_ftd_api.cpp
@@ -120,6 +120,18 @@ void otBackboneRouterSetMulticastListenerCallback(otInstance *                  
     instance.Get<BackboneRouter::MulticastListenersTable>().SetCallback(aCallback, aContext);
 }
 
+otError otBackboneRouterMulticastListenerGetNext(otInstance *                           aInstance,
+                                                 otChildIp6AddressIterator *            aIterator,
+                                                 otBackboneRouterMulticastListenerInfo *aListenerInfo)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    OT_ASSERT(aIterator != nullptr);
+    OT_ASSERT(aListenerInfo != nullptr);
+
+    return instance.Get<BackboneRouter::MulticastListenersTable>().GetNext(*aIterator, *aListenerInfo);
+}
+
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 void otBackboneRouterConfigNextDuaRegistrationResponse(otInstance *                    aInstance,
                                                        const otIp6InterfaceIdentifier *aMlIid,
@@ -167,18 +179,6 @@ otError otBackboneRouterMulticastListenerAdd(otInstance *aInstance, const otIp6A
 
     return instance.Get<BackboneRouter::MulticastListenersTable>().Add(static_cast<const Ip6::Address &>(*aAddress),
                                                                        TimerMilli::GetNow() + aTimeout);
-}
-
-otError otBackboneRouterMulticastListenerGetNext(otInstance *                           aInstance,
-                                                 otChildIp6AddressIterator *            aIterator,
-                                                 otBackboneRouterMulticastListenerInfo *aListenerInfo)
-{
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    OT_ASSERT(aIterator != nullptr);
-    OT_ASSERT(aListenerInfo != nullptr);
-
-    return instance.Get<BackboneRouter::MulticastListenersTable>().GetNext(*aIterator, *aListenerInfo);
 }
 #endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 

--- a/src/core/backbone_router/multicast_listeners_table.cpp
+++ b/src/core/backbone_router/multicast_listeners_table.cpp
@@ -287,8 +287,6 @@ void MulticastListenersTable::SetCallback(otBackboneRouterMulticastListenerCallb
     }
 }
 
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-
 otError MulticastListenersTable::GetNext(otBackboneRouterMulticastListenerIterator &aIterator,
                                          otBackboneRouterMulticastListenerInfo &    aListenerInfo)
 {
@@ -308,8 +306,6 @@ otError MulticastListenersTable::GetNext(otBackboneRouterMulticastListenerIterat
 exit:
     return error;
 }
-
-#endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 
 } // namespace BackboneRouter
 

--- a/src/core/backbone_router/multicast_listeners_table.hpp
+++ b/src/core/backbone_router/multicast_listeners_table.hpp
@@ -175,7 +175,6 @@ public:
      */
     void SetCallback(otBackboneRouterMulticastListenerCallback aCallback, void *aContext);
 
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     /**
      * This method gets the next Multicast Listener.
      *
@@ -188,7 +187,6 @@ public:
      */
     otError GetNext(otBackboneRouterMulticastListenerIterator &aIterator,
                     otBackboneRouterMulticastListenerInfo &    aListenerInfo);
-#endif
 
 private:
     enum


### PR DESCRIPTION
otBackboneRouterMulticastListenerGetNext is also used by non reference device code.