### PR TITLE
[android] remove settings storage path from config file

### DIFF
--- a/include/openthread-config-android.h
+++ b/include/openthread-config-android.h
@@ -64,6 +64,3 @@
 
 /* OpenThread examples */
 #define OPENTHREAD_EXAMPLES none
-
-/* The settings storage path on android. */
-#define OPENTHREAD_CONFIG_POSIX_SETTINGS_PATH "/data/thread"


### PR DESCRIPTION
This commit removes settings storage path from
`include/openthread-config-android.h` to allow users define
the settings storage path on Android platform.