### PR TITLE
[message] Fix Message::Settings::GetDefault()

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -196,9 +196,9 @@ Message::Settings::Settings(const otMessageSettings *aSettings)
 {
 }
 
-const Message::Settings& Message::Settings::GetDefault()
+const Message::Settings& Message::Settings::GetDefault(void)
 {
-    static Message::Settings kDefault(Message::kWithLinkSecurity, Message::kPriorityNormal);
+    static const Message::Settings kDefault(Message::kWithLinkSecurity, Message::kPriorityNormal);
     return kDefault;
 }
 

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -183,7 +183,6 @@ uint16_t MessagePool::GetTotalBufferCount(void) const
 #endif
 }
 
-const Message::Settings Message::Settings::kDefault(Message::kWithLinkSecurity, Message::kPriorityNormal);
 
 Message::Settings::Settings(LinkSecurityMode aSecurityMode, Priority aPriority)
     : mLinkSecurityEnabled(aSecurityMode == kWithLinkSecurity)
@@ -195,6 +194,12 @@ Message::Settings::Settings(const otMessageSettings *aSettings)
     : mLinkSecurityEnabled((aSettings != nullptr) ? aSettings->mLinkSecurityEnabled : true)
     , mPriority((aSettings != nullptr) ? static_cast<Priority>(aSettings->mPriority) : kPriorityNormal)
 {
+}
+
+const Message::Settings& Message::Settings::GetDefault()
+{
+    static Message::Settings kDefault(Message::kWithLinkSecurity, Message::kPriorityNormal);
+    return kDefault;
 }
 
 otError Message::ResizeMessage(uint16_t aLength)

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -417,11 +417,9 @@ public:
          * @returns A reference to the default settings (link security enable and `kPriorityNormal` priority).
          *
          */
-        static const Settings &GetDefault(void) { return kDefault; }
+        static const Settings &GetDefault(void);
 
     private:
-        static const Settings kDefault;
-
         bool     mLinkSecurityEnabled;
         Priority mPriority;
     };


### PR DESCRIPTION
`kDefault` was not being initialized properly and remains zero-initialized upon first-use.

![image](https://user-images.githubusercontent.com/2881693/100775502-5d370380-33d1-11eb-8563-71c96898c206.png)


This change initializes kDefault as a singleton at first-use, which fixes the issue