### PR TITLE
[udp6] initialize Socket variables in its constructor

### DIFF
--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -74,7 +74,7 @@ exit:
 Udp::Socket::Socket(Instance &aInstance)
     : InstanceLocator(aInstance)
 {
-    mHandle = nullptr;
+    Clear();
 }
 
 Message *Udp::Socket::NewMessage(uint16_t aReserved, const Message::Settings &aSettings)

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -39,6 +39,7 @@
 #include <openthread/udp.h>
 #include <openthread/platform/udp.h>
 
+#include "common/clearable.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
@@ -70,7 +71,7 @@ public:
      * This class implements a UDP/IPv6 socket.
      *
      */
-    class SocketHandle : public otUdpSocket, public LinkedListEntry<SocketHandle>
+    class SocketHandle : public otUdpSocket, public LinkedListEntry<SocketHandle>, public Clearable<SocketHandle>
     {
         friend class Udp;
         friend class LinkedList<SocketHandle>;


### PR DESCRIPTION
It failed to start CoAP socket due to the `mSocket.IsBound()` check ([link](https://github.com/openthread/openthread/blob/master/src/core/coap/coap.cpp#L1003)), the root cause is that the Socket variables were not initialized properly.