### PR TITLE
[diag] check state before entering diagnostic mode

### DIFF
--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -288,6 +288,8 @@ otError Diags::ProcessStart(uint8_t aArgsLength, char *aArgs[], char *aOutput, s
 
     otError error = OT_ERROR_NONE;
 
+    VerifyOrExit(!Get<ThreadNetif>().IsUp(), error = OT_ERROR_INVALID_STATE);
+
     otPlatDiagChannelSet(mChannel);
     otPlatDiagTxPowerSet(mTxPower);
 

--- a/tests/scripts/expect/cli-misc.exp
+++ b/tests/scripts/expect/cli-misc.exp
@@ -164,4 +164,7 @@ expect "0:0:0:0::/64 s low"
 send "route remove ::/64\n"
 expect "Done"
 
+send "diag start\n"
+expect ": InvalidState"
+
 dispose_all


### PR DESCRIPTION
This commit restrict diagnostic mode only when network stack is not up,
which prevents some issues caused by switching to diag mode after the
device was attached. For example, timers may not be triggered properly
after returnning from diagnostic mode.