### PR TITLE
[tmf] TMF not to use platform udp

### DIFF
--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -129,6 +129,12 @@ send "ipaddr\r\n"
 expect "Done"
 send "coex\r\n"
 expect "Done"
+send "coap start\r\n"
+expect "Done"
+send "coap resource TestResource\r\n"
+expect "Done"
+send "coap set TestContent\r\n"
+expect "Done"
 wait
 EOF
 
@@ -142,7 +148,7 @@ EOF
         fi
     done
 
-    netstat -an | grep -q 61631 || die 'TMF port is not available!'
+    netstat -an | grep -q 5683 || die 'Application CoAP port is not available!'
 
     extaddr=$(grep -aoE '[0-9a-z]{16}' $OT_OUTPUT)
     echo "Extended address is: ${extaddr}"
@@ -158,14 +164,14 @@ EOF
 
     LEADER_ALOC=fdde:ad00:beef::ff:fe00:fc00
     # Retrievie extended address through network diagnostic get
-    coap_response=$(echo -n '120100' | xxd -r -p | coap-client -m POST coap://[${LEADER_ALOC}]:61631/d/dg -f- | xxd -p | grep 0008)
+    coap_response=$(coap-client -B 5 -m GET coap://[${LEADER_ALOC}]:5683/TestResource)
     echo "CoAP response is: ${coap_response}"
 
     # Verify CoAP response contains the extended address
-    if [[ ${coap_response} == *${extaddr}* ]]; then
+    if [[ ${coap_response} == *TestContent* ]]; then
         echo 'Success'
     else
-        die 'Failed to get extended address'
+        die 'Failed to access application CoAP'
     fi
 }
 

--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -163,11 +163,11 @@ EOF
     fi
 
     LEADER_ALOC=fdde:ad00:beef::ff:fe00:fc00
-    # Retrievie extended address through network diagnostic get
+    # Retrievie test resource through application CoAP
     coap_response=$(coap-client -B 5 -m GET coap://[${LEADER_ALOC}]:5683/TestResource)
     echo "CoAP response is: ${coap_response}"
 
-    # Verify CoAP response contains the extended address
+    # Verify CoAP response contains the test content
     if [[ ${coap_response} == *TestContent* ]]; then
         echo 'Success'
     else

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1004,13 +1004,11 @@ otError Ip6::ProcessReceiveCallback(Message &          aMessage,
     if (mIsReceiveIp6FilterEnabled)
     {
         // do not pass messages sent to an RLOC/ALOC, except Service Locator
-#if !OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
         bool isLocator = Get<Mle::Mle>().IsMeshLocalAddress(aMessageInfo.GetSockAddr()) &&
                          aMessageInfo.GetSockAddr().GetIid().IsLocator();
 
         VerifyOrExit(!isLocator || aMessageInfo.GetSockAddr().GetIid().IsAnycastServiceLocator(),
                      error = OT_ERROR_NO_ROUTE);
-#endif
 
         switch (aIpProto)
         {
@@ -1041,13 +1039,11 @@ otError Ip6::ProcessReceiveCallback(Message &          aMessage,
                 // do not pass MLE messages
                 ExitNow(error = OT_ERROR_NO_ROUTE);
             }
-#if !OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
             else if ((destPort == Tmf::kUdpPort) && Get<Tmf::TmfAgent>().IsTmfMessage(aMessageInfo))
             {
                 // do not pass TMF messages
                 ExitNow(error = OT_ERROR_NO_ROUTE);
             }
-#endif
 
 #if OPENTHREAD_FTD
             if (destPort == Get<MeshCoP::JoinerRouter>().GetJoinerUdpPort())

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -560,17 +560,11 @@ bool Udp::ShouldUsePlatformUdp(uint16_t aPort) const
 
 bool Udp::ShouldUsePlatformUdp(const Udp::SocketHandle &aSocket) const
 {
-    uint16_t port       = aSocket.mSockName.mPort;
-    bool     usePlatUdp = false;
-
-    VerifyOrExit(!ShouldUsePlatformUdp(port), usePlatUdp = true);
-
+    return (ShouldUsePlatformUdp(aSocket.mSockName.mPort)
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    usePlatUdp = IsBackboneSocket(aSocket);
+            || IsBackboneSocket(aSocket)
 #endif
-
-exit:
-    return usePlatUdp;
+    );
 }
 #endif
 

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -597,11 +597,13 @@ private:
     void RemoveSocket(SocketHandle &aSocket);
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
     bool ShouldUsePlatformUdp(uint16_t aPort) const;
+    bool ShouldUsePlatformUdp(const SocketHandle &aSocket) const;
 #endif
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     void                SetBackboneSocket(SocketHandle &aSocket);
-    const SocketHandle *GetBackboneSockets(void);
+    const SocketHandle *GetBackboneSockets(void) const;
+    bool                IsBackboneSocket(const SocketHandle &aSocket) const;
 #endif
 
     uint16_t                 mEphemeralPort;

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -595,7 +595,9 @@ private:
 
     void AddSocket(SocketHandle &aSocket);
     void RemoveSocket(SocketHandle &aSocket);
-    bool IsMlePort(uint16_t aPort) const;
+#if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
+    bool ShouldUsePlatformUdp(uint16_t aPort) const;
+#endif
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     void                SetBackboneSocket(SocketHandle &aSocket);


### PR DESCRIPTION
This commit fixes TMF issues related to the Host tun interface.

- [x] Do not pass TMF messages to Host tun interface
  - [x] Backbone TMF (also using port 61631) keeps passing TMF messages to Host tun interface
- [x] Re-enable packet filters for ALOC/RLOC destined and TMF packets  for PLAT_NETIF and PLAT_UDP
