### PR TITLE
[ip6] add filter for packets from host

### DIFF
--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -173,6 +173,14 @@ EOF
     else
         die 'Failed to access application CoAP'
     fi
+
+    # Retrievie extended address through network diagnostic get
+    coap_response=$(echo -n '120100' | xxd -r -p | coap-client -B 5 -m POST coap://[${LEADER_ALOC}]:61631/d/dg -f-)
+
+    # Verify Tmf CoAP is blocked
+    if [[ -z ${coap_response} ]]; then
+        die 'Tmf is not blocked'
+    fi
 }
 
 main()

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -51,6 +51,13 @@
 #include "net/udp6.hpp"
 #include "thread/mle.hpp"
 
+using IcmpType = ot::Ip6::Icmp::Header::Type;
+
+static const IcmpType sForwardICMPTypes[] = {
+    IcmpType::kTypeDstUnreach,       IcmpType::kTypePacketToBig, IcmpType::kTypeTimeExceeded,
+    IcmpType::kTypeParameterProblem, IcmpType::kTypeEchoRequest, IcmpType::kTypeEchoReply,
+};
+
 namespace ot {
 namespace Ip6 {
 
@@ -1278,22 +1285,47 @@ start:
         hopLimit = header.GetHopLimit();
         aMessage.Write(Header::kHopLimitFieldOffset, hopLimit);
 
-#if OPENTHREAD_CONFIG_UNSECURE_TRAFFIC_MANAGED_BY_STACK_ENABLE
-        // check whether source port is an unsecure port
+        if (aFromNcpHost && nextHeader == kProtoIcmp6)
+        {
+            uint8_t icmpType;
+            bool    isAllowedType = false;
+
+            SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), icmpType));
+            for (IcmpType type : sForwardICMPTypes)
+            {
+                if (icmpType == type)
+                {
+                    isAllowedType = true;
+                    break;
+                }
+            }
+            VerifyOrExit(isAllowedType, error = OT_ERROR_DROP);
+        }
         if (aFromNcpHost && (nextHeader == kProtoTcp || nextHeader == kProtoUdp))
         {
-            uint16_t sourcePort;
+            uint16_t sourcePort, destPort;
 
             SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), sourcePort));
+            SuccessOrExit(error = aMessage.Read(aMessage.GetOffset() + sizeof(sourcePort), destPort));
             sourcePort = HostSwap16(sourcePort);
+            destPort   = HostSwap16(destPort);
 
+            if (nextHeader == kProtoUdp)
+            {
+                VerifyOrExit(Get<Udp>().ShouldUsePlatformUdp(destPort), error = OT_ERROR_DROP);
+            }
+
+#if OPENTHREAD_CONFIG_UNSECURE_TRAFFIC_MANAGED_BY_STACK_ENABLE
+            // check whether source port is an unsecure port
             if (Get<Filter>().IsUnsecurePort(sourcePort))
             {
                 aMessage.SetLinkSecurityEnabled(false);
                 otLogInfoIp6("Disabled link security for packet to %s", header.GetDestination().ToString().AsCString());
             }
-        }
+#else
+            OT_UNUSED_VARIABLE(sourcePort);
 #endif
+        }
 
         // `SendMessage()` takes custody of message in the success case
         SuccessOrExit(error = Get<ThreadNetif>().SendMessage(aMessage));

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -548,7 +548,6 @@ exit:
     return;
 }
 
-#if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
 bool Udp::ShouldUsePlatformUdp(uint16_t aPort) const
 {
     return (aPort != Mle::kUdpPort && aPort != Tmf::kUdpPort
@@ -558,6 +557,7 @@ bool Udp::ShouldUsePlatformUdp(uint16_t aPort) const
     );
 }
 
+#if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
 bool Udp::ShouldUsePlatformUdp(const Udp::SocketHandle &aSocket) const
 {
     return (ShouldUsePlatformUdp(aSocket.mSockName.mPort)
@@ -566,7 +566,7 @@ bool Udp::ShouldUsePlatformUdp(const Udp::SocketHandle &aSocket) const
 #endif
     );
 }
-#endif
+#endif // OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
 
 } // namespace Ip6
 } // namespace ot

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -586,6 +586,17 @@ public:
     }
 #endif
 
+    /**
+     * This method returns whether a udp port belongs to the platform or the stack.
+     *
+     * @param[in]   aPort       The udp port
+     *
+     * @retval True when the port belongs to the platform.
+     * @retval False when the port belongs to the stack.
+     *
+     */
+    bool ShouldUsePlatformUdp(uint16_t aPort) const;
+
 private:
     enum
     {
@@ -596,7 +607,6 @@ private:
     void AddSocket(SocketHandle &aSocket);
     void RemoveSocket(SocketHandle &aSocket);
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
-    bool ShouldUsePlatformUdp(uint16_t aPort) const;
     bool ShouldUsePlatformUdp(const SocketHandle &aSocket) const;
 #endif
 


### PR DESCRIPTION
This change filters out unsupported ICMP packets, Tmf and Mle udp
packets from the host.

Depends-On: https://github.com/openthread/openthread/pull/5910