### PR TITLE
[github-actions] update binaries path in upload action

### DIFF
--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -88,7 +88,7 @@ jobs:
       with:
         name: core-thread-1-2-${{ matrix.compiler.c }}-${{ matrix.arch }}
         path: |
-          ./build/cmake/openthread-simulation-1.2/examples/apps/cli/ot-cli-*
+          ./build/openthread-simulation-1.2/examples/apps/cli/ot-cli-*
           ./ot-core-dump/*
           ./so-lib/*
     - name: Keep-1-2-only
@@ -172,8 +172,8 @@ jobs:
       with:
         name: core-packet-verification-low-power
         path: |
-          ./build/cmake/openthread-simulation-1.2/examples/apps/cli/ot-cli-*
-          ./build/cmake/openthread-simulation-1.1/examples/apps/cli/ot-cli-*
+          ./build/openthread-simulation-1.2/examples/apps/cli/ot-cli-*
+          ./build/openthread-simulation-1.1/examples/apps/cli/ot-cli-*
           ./ot-core-dump/*
           ./so-lib/*
     - name: Keep-1-2-only


### PR DESCRIPTION
#5888 updates the build path for binaries. I just found there were no binaries uploaded in artifacts of action where crash happened. This PR updates the path correspondingly in upload actions.

I will work on something which doesn't use hard-coding. Currently let's just keep it as it is.