### PR TITLE
[mac] stop timer before starting non-idle operation

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -854,10 +854,12 @@ void Mac::PerformNextOperation(void)
         break;
 
     case kOperationActiveScan:
+        mTimer.Stop();
         PerformActiveScan();
         break;
 
     case kOperationEnergyScan:
+        mTimer.Stop();
         PerformEnergyScan();
         break;
 
@@ -871,6 +873,7 @@ void Mac::PerformNextOperation(void)
 #endif
     case kOperationTransmitPoll:
     case kOperationTransmitOutOfBandFrame:
+        mTimer.Stop();
         BeginTransmit();
         break;
 


### PR DESCRIPTION
This PR fixes issue #5802 (and probably #5774).

Luckily, I caught a failed run of the Heisenbug after the core dump uploading feature is enabled. So I analyzed the core dump:
```
GNU gdb (Ubuntu 9.2-0ubuntu1~20.04) 9.2
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<http://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from build/openthread-simulation-1.2/examples/apps/cli/ot-cli-ftd...
[New LWP 11076]
Core was generated by `/home/runner/work/openthread/openthread/build/openthread-simulation-1.2/example'.
Program terminated with signal SIGABRT, Aborted.
#0  __GI_raise (sig=sig@entry=6) at ../sysdeps/unix/sysv/linux/raise.c:50
50      ../sysdeps/unix/sysv/linux/raise.c: No such file or directory.
(gdb) 
(gdb) '
Undefined command: "".  Try "help".
(gdb) up
#1  0x00007ff86146a859 in __GI_abort () at abort.c:79
79      abort.c: No such file or directory.
(gdb) up
#2  0x00007ff86146a729 in __assert_fail_base (fmt=0x7ff861600588 "%s%s%s:%u: %s%sAssertion `%s' failed.\n%n", 
    assertion=0x561fb6767671 "false", file=0x561fb6767656 "../../src/core/mac/mac.cpp", line=1549, function=<optimized out>) at assert.c:92
92      assert.c: No such file or directory.
(gdb) up
#3  0x00007ff86147bf36 in __GI___assert_fail (assertion=0x561fb6767671 "false", file=0x561fb6767656 "../../src/core/mac/mac.cpp", 
    line=1549, function=0x561fb6767778 "void ot::Mac::Mac::HandleTimer()") at assert.c:101
101     in assert.c
(gdb) up
#4  0x0000561fb664138b in ot::Mac::Mac::HandleTimer (this=0x561fb686d478 <ot::gInstanceRaw+26968>) at ../../src/core/mac/mac.cpp:1549
1549            OT_ASSERT(false);
(gdb) p mOperation
$1 = ot::Mac::Mac::kOperationTransmitDataDirect
(gdb) p mPendingTransmitDataCsl
$2 = true
(gdb) p mRxOnWhenIdle
$3 = true
(gdb) p mCslTxFireTime
$4 = {static kMaxDuration = 4294967295, mValue = 20497}
(gdb) p mTimer
$5 = {<ot::Timer> = {<ot::InstanceLocator> = {<No data fields>}, <ot::OwnerLocator> = {<No data fields>}, <ot::LinkedListEntry<ot::Timer>> = {<No data fields>}, static kMaxDelay = 2147483647, mHandler = @0x561fb6641188, mFireTime = {static kMaxDuration = 4294967295, 
      mValue = 20497}, mNext = 0x561fb686d5a0 <ot::gInstanceRaw+27264>}, <No data fields>}
(gdb) p mPendingTransmitDataDirect
$6 = false
(gdb) 
```

So the crash is caused by the assetion in `Mac::HandleTimer`:
```
void Mac::HandleTimer(void)                                                                                                                                                                                                                                                              
{                                                                                                                                                                                                                                                                                        
    switch (mOperation)                                                                                                                                                                                                                                                                  
    {                                                                                                                                                                                                                                                                                    
    case kOperationActiveScan:                                                                                                                                                                                                                                                           
        PerformActiveScan();                                                                                                                                                                                                                                                             
        break;                                                                                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                         
    case kOperationWaitingForData:                                                                                                                                                                                                                                                       
        otLogDebgMac("Data poll timeout");                                                                                                                                                                                                                                               
        FinishOperation();
        Get<DataPollSender>().HandlePollTimeout();
        PerformNextOperation();
        break;

    case kOperationIdle:
        if (!mRxOnWhenIdle)
        {
#if OPENTHREAD_CONFIG_MAC_STAY_AWAKE_BETWEEN_FRAGMENTS
            if (mDelayingSleep)
            {
                otLogDebgMac("Sleep delay timeout expired");
                mDelayingSleep = false;
                UpdateIdleMode();
            }
#endif
        }
#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
        else if (mPendingTransmitDataCsl)
        {
            PerformNextOperation();
        }
#endif
        break;

    default:
        OT_ASSERT(false); // !!!!!!! Crashed here
        OT_UNREACHABLE_CODE(break);
    }
}
```
As shown in the gdb copying text, currently `mOperation` is `kOperationTransmitDataDirect`. And we can see that the time  for `mTimer` is the same with `mCslTxFireTime`. So the timer is started by CSL scheduling in `UpdateIdleMode`. This problem seems to be exactly the one we discussed in the initial CSL PR: https://github.com/openthread/openthread/pull/4557#issuecomment-657742939
So to prevent such cases, we need to stop the timer before staring any non-idle operations as suggested in the comment. As I see, currently it's not ensured in the code. I think it's my mistake that I missed it when submitting the initial CSL PR. 

Please have a review. @abtink @brianljt 