### PR TITLE
[dua] delay registration for DUA newly added

### DIFF
--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -407,6 +407,7 @@ void Manager::HandleDuaRegistration(const Coap::Message &aMessage, const Ip6::Me
 #endif
 
     VerifyOrExit(isPrimary, status = ThreadStatusTlv::kDuaNotPrimary);
+    VerifyOrExit(Get<BackboneRouter::Leader>().HasDomainPrefix(), status = ThreadStatusTlv::kDuaGeneralFailure);
     VerifyOrExit(Get<BackboneRouter::Leader>().IsDomainUnicast(target), status = ThreadStatusTlv::kDuaInvalid);
 
     hasLastTransactionTime = (Tlv::Find<ThreadLastTransactionTimeTlv>(aMessage, lastTransactionTime) == OT_ERROR_NONE);

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -329,7 +329,7 @@ void DuaManager::HandleNotifierEvents(Events aEvents)
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     if (aEvents.ContainsAny(kEventIp6AddressAdded))
     {
-        UpdateRegistrationDelay(1);
+        UpdateRegistrationDelay(kNewDuaRegistrationDelay);
     }
 #endif
 }

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -326,10 +326,12 @@ void DuaManager::HandleNotifierEvents(Events aEvents)
 #endif
     }
 
+#if OPENTHREAD_CONFIG_DUA_ENABLE
     if (aEvents.ContainsAny(kEventIp6AddressAdded))
     {
-        mRegistrationTask.Post();
+        UpdateRegistrationDelay(1);
     }
+#endif
 }
 
 void DuaManager::HandleBackboneRouterPrimaryUpdate(BackboneRouter::Leader::State               aState,

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -170,6 +170,7 @@ private:
     enum
     {
         kNewRouterRegistrationDelay = 3, ///< Delay (in seconds) for waiting link establishment for a new Router.
+        kNewDuaRegistrationDelay    = 1, ///< Delay (in seconds) for newly added DUA.
     };
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE


### PR DESCRIPTION
**Background:**

```
     PBBR
   /      \
ROUTER---LEADER
```

In the tests of #5910 , we found that it's possible that a Router, in a topology like above, could send DUA.req so quickly after receiving `Data Response` from Leader that the PBBR is not able to process the same `Data Response` message and update the network data accordingly. Consequently, PBBR sends DUA.rsp with `kDuaInvalid` status because it can't find a valid Domain Prefix in the Network Data. 

This commit help resolve this issue with two fixes:
- Node to delay for up to 1000ms before sending DUA.req when domain prefix addresses is generated
- PBBR to respond with `kDuaGeneralFailure` to allow the node to re-register the same DUA again.