### PR TITLE
[efr32] radio: fix otPlatRadioGetTransmitPower

### DIFF
--- a/examples/platforms/efr32/src/radio.c
+++ b/examples/platforms/efr32/src/radio.c
@@ -1126,7 +1126,7 @@ otError otPlatRadioGetTransmitPower(otInstance *aInstance, int8_t *aPower)
 
     // RAIL_GetTxPowerDbm() returns power in deci-dBm (0.1dBm)
     // Divide by 10 because aPower is supposed be in units dBm
-    *aPower = RAIL_GetTxPowerDbm(gRailHandle) / 10U;
+    *aPower = RAIL_GetTxPowerDbm(gRailHandle) / 10;
 
 exit:
     return error;
@@ -1140,7 +1140,7 @@ otError otPlatRadioSetTransmitPower(otInstance *aInstance, int8_t aPower)
 
     // RAIL_SetTxPowerDbm() takes power in units of deci-dBm (0.1dBm)
     // Divide by 10 because aPower is supposed be in units dBm
-    status = RAIL_SetTxPowerDbm(gRailHandle, ((RAIL_TxPower_t)aPower) * 10U);
+    status = RAIL_SetTxPowerDbm(gRailHandle, ((RAIL_TxPower_t)aPower) * 10);
     assert(status == RAIL_STATUS_NO_ERROR);
 
     return OT_ERROR_NONE;


### PR DESCRIPTION
From PR #5701 onwards, the efr32 platform shows the following behavior:

```bash
> txpower -10
Done
>
> txpower
-113 dBm
Done
```

The bug is caused by the C promotion rules during the division of int16_t by unsigned in `otPlatRadioGetTransmitPower`. This PR fixes the issue.
