### PR TITLE
[link-raw] disable/enable MAC layer when link-raw is enabled/disabled

### DIFF
--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -72,8 +72,14 @@ otError LinkRaw::SetReceiveDone(otLinkRawReceiveDone aCallback)
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
     VerifyOrExit(!Get<ThreadNetif>().IsUp(), error = OT_ERROR_INVALID_STATE);
-#endif
 
+    // In MTD/FTD build, `Mac` has already enabled sub-mac. We ensure to
+    // disable/enable MAC layer when link-raw is being enabled/disabled to
+    // avoid any conflict in control of radio and sub-mac between `Mac` and
+    // `LinkRaw`. in RADIO build, we directly enable/disable sub-mac.
+
+    Get<Mac>().SetEnabled(aCallback == nullptr);
+#else
     if (aCallback)
     {
         SuccessOrExit(error = mSubMac.Enable());
@@ -82,6 +88,7 @@ otError LinkRaw::SetReceiveDone(otLinkRawReceiveDone aCallback)
     {
         IgnoreError(mSubMac.Disable());
     }
+#endif
 
     mReceiveDoneCallback = aCallback;
 


### PR DESCRIPTION
This commit addresses an issue with `LinkRaw` on FTD/MTD builds. In
FTD/MTD builds, we add code to disable/enable MAC layer when link-raw
is being enabled/disabled. This ensures to avoid any conflict in
control of radio and sub-mac between `Mac` and `LinkRaw`. In RADIO
build, we directly enable/disable sub-mac (note that in FTD/MTD build
then `Mac` layer would be enable sub-mac).

---------

Background on this:
This can address some edge-case  situations: For example, on FTD build/device, link-raw is enabled while in middle of other mac operation (e.g. an ongoing active scan). Without this, such a situation can lead to radio/sub-mac being potentially controlled by two modules (`LinkRaw` and `Mac`) and potential `assert` failures due to conflicting commands (e.g., both trying to send at the same time).