### PR TITLE
[harness-automation] fix the result parsed uncorrectly using Chrome 80

### DIFF
--- a/tools/harness-automation/autothreadharness/harness_case.py
+++ b/tools/harness-automation/autothreadharness/harness_case.py
@@ -1113,7 +1113,7 @@ class HarnessCase(unittest.TestCase):
             raise
 
         # get case result
-        status = self._browser.find_element_by_class_name('title-test').text
+        status = self._browser.find_element_by_class_name('title-test').get_attribute('innerText')
         logger.info(status)
         success = 'Pass' in status
         self.assertTrue(success)


### PR DESCRIPTION
When using "status = self._browser.find_element_by_class_name('title-test').text", the variable "status" will not contain "Pass" or "Failed", so, the result always fails.
After using "get_attribute('innerText')",  the variable "status" will contain "Pass" or "Failed" as expected