### PR TITLE
[nrf528xx] fix sleep_to_tx transition problem

### DIFF
--- a/third_party/NordicSemiconductor/drivers/radio/rsch/nrf_802154_rsch.c
+++ b/third_party/NordicSemiconductor/drivers/radio/rsch/nrf_802154_rsch.c
@@ -214,6 +214,9 @@ static inline void all_prec_update(void)
         {
             m_requested_prio = new_prio;
 
+            nrf_802154_wifi_coex_prio_request(new_prio);
+            prec_approved_prio_set(RSCH_PREC_COEX, new_prio);
+
             if (new_prio == RSCH_PRIO_IDLE)
             {
                 nrf_802154_priority_drop_hfclk_stop();
@@ -228,9 +231,6 @@ static inline void all_prec_update(void)
                 nrf_802154_clock_hfclk_start();
                 nrf_raal_continuous_mode_enter();
             }
-
-            nrf_802154_wifi_coex_prio_request(new_prio);
-            prec_approved_prio_set(RSCH_PREC_COEX, new_prio);
         }
 
         mutex_unlock(&m_req_mutex);


### PR DESCRIPTION
This PR fixes #5826.

Thanks @hubertmis for debugging and solving this problem. The cause is that in radio scheduler, after coex precondition is approved, no action is taken to notify the core. As a result, the coex precondition is not met when doing the transmission. Now we move the code before HFCLK handling so that HFCLK handling would notify the core.

As there's no recent plan for a new bug-fix release of nRF 802.15.4 driver, let's submit this change to the repo temporarily.