### PR TITLE
[border-agent] remove UDP receiver on commissioner disconnect

### DIFF
--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -556,6 +556,7 @@ void BorderAgent::HandleConnected(bool aConnected)
     else
     {
         otLogInfoMeshCoP("Commissioner disconnected");
+        IgnoreError(Get<Ip6::Udp>().RemoveReceiver(mUdpReceiver));
         Get<ThreadNetif>().RemoveUnicastAddress(mCommissionerAloc);
         mState = kStateStarted;
     }


### PR DESCRIPTION
Avoids the following warning:
```
/usr/sbin/ot-daemon[3059]: [WARN]-MESH-CP-: Failed to notify commissioner on ProxyRx (c/ur): DestinationAddressFiltered
```

Thanks to @gabekassel for identifying this issue.