### PR TITLE
[github-actions] enable full logs in expect tests

### DIFF
--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -276,12 +276,12 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
-        OT_OPTIONS=-DOT_READLINE=OFF sudo apt-get --no-install-recommends install -y expect ninja-build lcov socat
+        sudo apt-get --no-install-recommends install -y expect ninja-build lcov socat
     - name: Run
       run: |
         ulimit -c unlimited
         ./script/test prepare_coredump_upload
-        OT_OPTIONS=-DOT_TIME_SYNC=ON VIRTUAL_TIME=0 ./script/test build expect
+        OT_OPTIONS='-DOT_TIME_SYNC=ON -DOT_FULL_LOGS=ON' VIRTUAL_TIME=0 ./script/test build expect
     - name: Copy Shared Libraries
       if: ${{ failure() }}
       run: |
@@ -305,20 +305,7 @@ jobs:
       run: |
         ulimit -c unlimited
         ./script/test prepare_coredump_upload
-        OT_OPTIONS=-DOT_READLINE=OFF VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
-    - name: Copy Shared Libraries
-      if: ${{ failure() }}
-      run: |
-          ./script/test copy_so_lib
-    - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
-      with:
-        name: core-expect-rcp
-        path: |
-          ./build/openthread-simulation-1.1/examples/apps/ncp/ot-rcp
-          ./build/openthread-posix-1.1/src/posix/ot-cli
-          ./ot-core-dump/*
-          ./so-lib/*
+        OT_OPTIONS='-DOT_READLINE=OFF -DOT_FULL_LOGS=ON' VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc
@@ -338,7 +325,7 @@ jobs:
         host ipv6.google.com ::1
         ulimit -c unlimited
         ./script/test prepare_coredump_upload
-        OT_OPTIONS=-DOT_READLINE=OFF OT_NATIVE_IP=1 VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
+        OT_OPTIONS='-DOT_READLINE=OFF -DOT_FULL_LOGS=ON' OT_NATIVE_IP=1 VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
     - name: Copy Shared Libraries
       if: ${{ failure() }}
       run: |
@@ -346,12 +333,17 @@ jobs:
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
-        name: core-expect-tun
+        name: core-expect-posix
         path: |
           ./build/openthread-simulation-1.1/examples/apps/ncp/ot-rcp
           ./build/openthread-posix-1.1/src/posix/ot-cli
           ./ot-core-dump/*
           ./so-lib/*
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() }}
+      with:
+        name: syslog-expect-posix
+        path: /var/log/syslog
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -305,7 +305,7 @@ jobs:
       run: |
         ulimit -c unlimited
         ./script/test prepare_coredump_upload
-        OT_OPTIONS='-DOT_READLINE=OFF -DOT_FULL_LOGS=ON' VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
+        OT_OPTIONS='-DOT_READLINE=OFF -DOT_FULL_LOGS=ON -DOT_LOG_OUTPUT=PLATFORM_DEFINED' VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc
@@ -325,7 +325,7 @@ jobs:
         host ipv6.google.com ::1
         ulimit -c unlimited
         ./script/test prepare_coredump_upload
-        OT_OPTIONS='-DOT_READLINE=OFF -DOT_FULL_LOGS=ON' OT_NATIVE_IP=1 VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
+        OT_OPTIONS='-DOT_READLINE=OFF -DOT_FULL_LOGS=ON -DOT_LOG_OUTPUT=PLATFORM_DEFINED' OT_NATIVE_IP=1 VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
     - name: Copy Shared Libraries
       if: ${{ failure() }}
       run: |

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -281,7 +281,7 @@ jobs:
       run: |
         ulimit -c unlimited
         ./script/test prepare_coredump_upload
-        OT_OPTIONS='-DOT_TIME_SYNC=ON -DOT_FULL_LOGS=ON' VIRTUAL_TIME=0 ./script/test build expect
+        OT_OPTIONS='-DOT_TIME_SYNC=ON -DOT_FULL_LOGS=ON -DOT_LOG_OUTPUT=PLATFORM_DEFINED' VIRTUAL_TIME=0 ./script/test build expect
     - name: Copy Shared Libraries
       if: ${{ failure() }}
       run: |

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -36,6 +36,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <lib/platform/exit_code.h>
 #include <openthread/diag.h>
 #include <openthread/icmp6.h>
 #include <openthread/link.h>
@@ -3907,6 +3908,7 @@ otError Interpreter::ProcessThread(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
+    DieNow(OT_EXIT_FAILURE);
     return error;
 }
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -36,7 +36,6 @@
 #include <stdio.h>
 #include <stdlib.h>
 
-#include <lib/platform/exit_code.h>
 #include <openthread/diag.h>
 #include <openthread/icmp6.h>
 #include <openthread/link.h>
@@ -3908,7 +3907,6 @@ otError Interpreter::ProcessThread(uint8_t aArgsLength, char *aArgs[])
     }
 
 exit:
-    DieNow(OT_EXIT_FAILURE);
     return error;
 }
 


### PR DESCRIPTION
Currently if OpenThread dies with something like `VerifyOrDie`, we can't get any logs from GitHub Actions, so issues like <https://github.com/openthread/openthread/issues/5928> are hard to diagnose. This enables full logs and uploads them when `expect` tests fail, making it easier to diagnose such errors.