### PR TITLE
[expect] fix CLI router tests

### DIFF
--- a/tests/scripts/expect/cli-router.exp
+++ b/tests/scripts/expect/cli-router.exp
@@ -62,7 +62,7 @@ wait_for "router list" $router_id
 send "router $router_id\n"
 expect "Router ID: $router_id"
 expect "Rloc: $rloc"
-expect "Next Hop: fc00"
+expect -re {Next Hop: [0-9a-f]{4}}
 expect -re {Link: [01]}
 expect "Done"
 


### PR DESCRIPTION
The next hop here is not deterministic. This changes it to expect any 4-digit hex. Fixes <https://github.com/openthread/openthread/issues/5993>.