### PR TITLE
[tests] add "return" for dummy test platform API

### DIFF
--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -691,6 +691,12 @@ otLinkMetrics otPlatRadioGetEnhAckProbingMetrics(otInstance *aInstance, const ot
 {
     OT_UNUSED_VARIABLE(aInstance);
     OT_UNUSED_VARIABLE(aShortAddress);
+
+    otLinkMetrics metrics;
+
+    memset(&metrics, 0, sizeof(metrics));
+
+    return metrics;
 }
 #endif
 


### PR DESCRIPTION
This PR fixes build warning:
```txt
../../tests/unit/test_platform.cpp: In function ‘otLinkMetrics otPlatRadioGetEnhAckProbingMetrics(otInstance*, otShortAddress)’:
../../tests/unit/test_platform.cpp:694:1: warning: no return statement in function returning non-void [-Wreturn-type]
  694 | }
      | ^

```