### PR TITLE
[ip6] use ALOC source address

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -462,8 +462,7 @@ otError Ip6::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t 
         header.SetHopLimit(static_cast<uint8_t>(kDefaultHopLimit));
     }
 
-    if (aMessageInfo.GetSockAddr().IsUnspecified() || aMessageInfo.GetSockAddr().IsMulticast() ||
-        Get<Mle::Mle>().IsAnycastLocator(aMessageInfo.GetSockAddr()))
+    if (aMessageInfo.GetSockAddr().IsUnspecified() || aMessageInfo.GetSockAddr().IsMulticast())
     {
         const NetifUnicastAddress *source = SelectSourceAddress(aMessageInfo);
 

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -374,15 +374,6 @@ otError Udp::SendTo(SocketHandle &aSocket, Message &aMessage, const MessageInfo 
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
     if (ShouldUsePlatformUdp(aSocket))
     {
-        // Replace anycast address with a valid unicast address since response messages typically copy the peer address
-        if (Get<Mle::Mle>().IsAnycastLocator(messageInfoLocal.GetSockAddr()))
-        {
-            const NetifUnicastAddress *netifAddr = Get<Ip6>().SelectSourceAddress(messageInfoLocal);
-
-            VerifyOrExit(netifAddr != nullptr, error = OT_ERROR_INVALID_ARGS);
-            messageInfoLocal.SetSockAddr(netifAddr->GetAddress());
-        }
-
         SuccessOrExit(error = otPlatUdpSend(&aSocket, &aMessage, &messageInfoLocal));
     }
     else

--- a/tests/scripts/thread-cert/Cert_8_3_01_CommissionerPetition.py
+++ b/tests/scripts/thread-cert/Cert_8_3_01_CommissionerPetition.py
@@ -119,7 +119,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
         #             Commissioner ID TLV
         pv.verify_attached('COMMISSIONER', 'LEADER')
         _pkt = pkts.last()
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _leader_pet_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_wpan_dst16(LEADER_RLOC16).\
             filter_coap_request(LEAD_PET_URI).\
             filter(lambda p: {
@@ -143,7 +143,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
         #             - Leader Data TLV
         #             - Network Data TLV
         #             - Source Address TLV
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_leader_pet_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(LEAD_PET_URI).\
             filter(lambda p: {
                               NM_STATE_TLV,
@@ -182,7 +182,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
         #         CoAP Payload
         #             State TLV (value = Accept)
         #             Commissioner Session ID TLV
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _leader_ka_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(LEAD_KA_URI).\
             filter(lambda p: {
@@ -198,7 +198,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
         #             2.04 Changed
         #         CoAP Payload
         #             State TLV (value = Accept)
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_leader_ka_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(LEAD_KA_URI).\
             filter(lambda p: {
                               NM_STATE_TLV
@@ -214,7 +214,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
         #         CoAP Payload
         #             Commissioner Session ID TLV
         #             Steering Data TLV
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_set_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p: {
@@ -237,7 +237,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
         #             - Leader Data TLV
         #             - Network Data TLV
         #             - Source Address TLV
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_set_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p: {
                               NM_STATE_TLV
@@ -276,7 +276,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
         #         CoAP Payload
         #             State TLV (value = Reject)
         #             Commissioner Session ID TLV
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _leader_ka_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(LEAD_KA_URI).\
             filter(lambda p: {
@@ -300,7 +300,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
         #             - Leader Data TLV
         #             - Network Data TLV
         #             - Source Address TLV
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_leader_ka_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(LEAD_KA_URI).\
             filter(lambda p: {
                               NM_STATE_TLV
@@ -334,7 +334,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
         #              CON POST coap://<L>:MM/c/lp
         #          CoAP Payload
         #              Commissioner ID TLV
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _leader_pet_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(LEAD_PET_URI).\
             filter(lambda p: {
@@ -352,7 +352,7 @@ class Cert_8_3_01_CommissionerPetition(thread_cert.TestCase):
         #              Commissioner ID TLV
         #              Commissioner Session ID TLV (contains higher Session ID number
         #              than in Step 9)
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_leader_pet_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(LEAD_PET_URI).\
             filter(lambda p: {
                               NM_STATE_TLV,

--- a/tests/scripts/thread-cert/Cert_9_2_01_MGMTCommissionerGet.py
+++ b/tests/scripts/thread-cert/Cert_9_2_01_MGMTCommissionerGet.py
@@ -56,6 +56,7 @@ LEADER = 2
 
 class Cert_9_2_01_MGMTCommissionerGet(thread_cert.TestCase):
     SUPPORT_NCP = False
+    USE_MESSAGE_FACTORY = True
 
     TOPOLOGY = {
         COMMISSIONER: {
@@ -82,7 +83,6 @@ class Cert_9_2_01_MGMTCommissionerGet(thread_cert.TestCase):
         self.nodes[COMMISSIONER].start()
         self.simulator.go(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'router')
-        self.simulator.get_messages_sent_by(LEADER)
 
         self.collect_leader_aloc(LEADER)
         self.collect_rlocs()
@@ -143,7 +143,7 @@ class Cert_9_2_01_MGMTCommissionerGet(thread_cert.TestCase):
         #             Border Agent Locator TLV
         #             Commissioner Session ID TLV
         #             Steering Data TLV
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_COMMISSIONER_GET_URI).\
             filter(lambda p: {
                               NM_COMMISSIONER_SESSION_ID_TLV,
@@ -163,7 +163,7 @@ class Cert_9_2_01_MGMTCommissionerGet(thread_cert.TestCase):
         #         CoAP Payload
         #             Commissioner Session ID TLV
         #             Steering Data TLV
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_get_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_COMMISSIONER_GET_URI).\
             filter(lambda p: {
@@ -181,7 +181,7 @@ class Cert_9_2_01_MGMTCommissionerGet(thread_cert.TestCase):
         #         Encoded values for the requested Commissioner Dataset parameters
         #             Commissioner Session ID TLV
         #             Steering Data TLV
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_get_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_COMMISSIONER_GET_URI).\
             filter(lambda p: {
                               NM_COMMISSIONER_SESSION_ID_TLV,
@@ -199,7 +199,7 @@ class Cert_9_2_01_MGMTCommissionerGet(thread_cert.TestCase):
         #         CoAP Payload
         #             Commissioner Session ID TLV
         #             PAN ID TLV
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_get_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_COMMISSIONER_GET_URI).\
             filter(lambda p: {
@@ -217,7 +217,7 @@ class Cert_9_2_01_MGMTCommissionerGet(thread_cert.TestCase):
         #         Encoded values for the requested Commissioner Dataset parameters
         #             Commissioner Session ID TLV
         #             (PAN ID TLV in Get TLV is ignored)
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_get_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_COMMISSIONER_GET_URI).\
             filter(lambda p: {
                               NM_COMMISSIONER_SESSION_ID_TLV
@@ -234,7 +234,7 @@ class Cert_9_2_01_MGMTCommissionerGet(thread_cert.TestCase):
         #         CoAP Payload
         #             Border Agent Locator TLV
         #             Network Name TLV
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_get_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_COMMISSIONER_GET_URI).\
             filter(lambda p: {
@@ -252,7 +252,7 @@ class Cert_9_2_01_MGMTCommissionerGet(thread_cert.TestCase):
         #         Encoded values for the requested Commissioner Dataset parameters
         #             Border Agent Locator TLV
         #             (Network Name TLV in Get TLV is ignored)
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_get_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_COMMISSIONER_GET_URI).\
             filter(lambda p: {
                               NM_BORDER_AGENT_LOCATOR_TLV

--- a/tests/scripts/thread-cert/Cert_9_2_02_MGMTCommissionerSet.py
+++ b/tests/scripts/thread-cert/Cert_9_2_02_MGMTCommissionerSet.py
@@ -152,7 +152,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
         #         CoAP Payload
         #             (missing Commissioner Session ID TLV)
         #             Steering Data TLV (0xFF)
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_set_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p:
@@ -167,7 +167,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
         #             2.04 Changed
         #         CoAP Payload
         #             State TLV (value = Reject)
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_set_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p:
                    [NM_STATE_TLV] == p.coap.tlv.type and\
@@ -182,7 +182,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
         #         CoAP Payload
         #             Commissioner Session ID TLV
         #             Steering Data TLV (0xFF)
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_set_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p: {
@@ -199,7 +199,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
         #             2.04 Changed
         #         CoAP Payload
         #             State TLV (value = Accept)
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_set_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p:
                    [NM_STATE_TLV] == p.coap.tlv.type and\
@@ -241,7 +241,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
         #         CoAP Payload
         #             Commissioner Session ID TLV
         #             Border Agent Locator TLV (0x0400) (not allowed TLV)
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_set_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p: {
@@ -258,7 +258,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
         #             2.04 Changed
         #         CoAP Payload
         #             State TLV (value = Reject)
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_set_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p:
                    [NM_STATE_TLV] == p.coap.tlv.type and\
@@ -274,7 +274,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
         #             Commissioner Session ID TLV
         #             Steering Data TLV (0xFF)
         #             Border Agent Locator TLV (0x0400) (not allowed TLV)
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_set_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p: {
@@ -293,7 +293,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
         #             2.04 Changed
         #         CoAP Payload
         #             State TLV (value = Reject)
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_set_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p:
                    [NM_STATE_TLV] == p.coap.tlv.type and\
@@ -308,7 +308,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
         #         CoAP Payload
         #             Commissioner Session ID TLV (0xFFFF) (invalid value)
         #             Steering Data TLV (0xFF)
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_set_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p: {
@@ -326,7 +326,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
         #             2.04 Changed
         #         CoAP Payload
         #             State TLV (value = Reject)
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_set_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p:
                    [NM_STATE_TLV] == p.coap.tlv.type and\
@@ -342,7 +342,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
         #             Commissioner Session ID TLV
         #             Steering Data TLV (0xFF)
         #             Channel TLV (not allowed TLV)
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_set_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p: {
@@ -360,7 +360,7 @@ class Cert_9_2_02_MGMTCommissionerSet(thread_cert.TestCase):
         #             2.04 Changed
         #         CoAP Payload
         #             State TLV (value = Accept)
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_set_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_COMMISSIONER_SET_URI).\
             filter(lambda p:
                    [NM_STATE_TLV] == p.coap.tlv.type and\

--- a/tests/scripts/thread-cert/Cert_9_2_03_ActiveDatasetGet.py
+++ b/tests/scripts/thread-cert/Cert_9_2_03_ActiveDatasetGet.py
@@ -57,6 +57,7 @@ LEADER = 2
 
 class Cert_9_2_03_ActiveDatasetGet(thread_cert.TestCase):
     SUPPORT_NCP = False
+    USE_MESSAGE_FACTORY = False
 
     TOPOLOGY = {
         COMMISSIONER: {
@@ -83,7 +84,6 @@ class Cert_9_2_03_ActiveDatasetGet(thread_cert.TestCase):
         self.nodes[COMMISSIONER].start()
         self.simulator.go(5)
         self.assertEqual(self.nodes[COMMISSIONER].get_state(), 'router')
-        self.simulator.get_messages_sent_by(LEADER)
 
         self.collect_rlocs()
         self.collect_rloc16s()
@@ -152,7 +152,7 @@ class Cert_9_2_03_ActiveDatasetGet(thread_cert.TestCase):
         #             PAN ID TLV
         #             PSKc TLV
         #             Security Policy TLV
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_ACTIVE_GET_URI).\
             filter(lambda p: {
                               NM_ACTIVE_TIMESTAMP_TLV,

--- a/tests/scripts/thread-cert/Cert_9_2_19_PendingDatasetGet.py
+++ b/tests/scripts/thread-cert/Cert_9_2_19_PendingDatasetGet.py
@@ -131,7 +131,7 @@ class Cert_9_2_19_PendingDatasetGet(thread_cert.TestCase):
         #             CON POST coap://<L>:MM/c/pg
         #         CoAP Payload
         #             <empty> - get all Active Operational Dataset parameters
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_get_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_PENDING_GET_URI).\
             filter(lambda p: p.coap.tlv.type is nullField).\
@@ -143,7 +143,7 @@ class Cert_9_2_19_PendingDatasetGet(thread_cert.TestCase):
         #             2.04 Changed
         #         CoAP Payload
         #             <empty> - (no Pending Operational Dataset)
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_get_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_PENDING_GET_URI).\
             filter(lambda p: p.coap.tlv.type is nullField).\
             must_next()
@@ -158,7 +158,7 @@ class Cert_9_2_19_PendingDatasetGet(thread_cert.TestCase):
         #             Delay Timer TLV: 1 minute
         #             Pending Timestamp TLV: 30s
         #             PAN ID TLV: 0xAFCE (new value)
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_pending_set_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_PENDING_SET_URI).\
             filter(lambda p: {
@@ -179,7 +179,7 @@ class Cert_9_2_19_PendingDatasetGet(thread_cert.TestCase):
         #             2.04 Changed
         #         CoAP Payload
         #             State TLV (value = Accept (01))
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_pending_set_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_PENDING_SET_URI).\
             filter(lambda p:
                    p.thread_meshcop.tlv.state == 1
@@ -192,7 +192,7 @@ class Cert_9_2_19_PendingDatasetGet(thread_cert.TestCase):
         #             CON POST coap://<L>:MM/c/pg
         #         CoAP Payload
         #             <empty> - get all Active Operational Dataset parameters
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_pending_get_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_PENDING_GET_URI).\
             filter(lambda p: p.coap.tlv.type is nullField).\
@@ -216,7 +216,7 @@ class Cert_9_2_19_PendingDatasetGet(thread_cert.TestCase):
         #             Pending Timestamp TLV
         #             PSKc TLV
         #             Security Policy TLV
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_pending_get_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_PENDING_GET_URI).\
             filter(lambda p: {
                               NM_ACTIVE_TIMESTAMP_TLV,
@@ -241,7 +241,7 @@ class Cert_9_2_19_PendingDatasetGet(thread_cert.TestCase):
         #             CON POST coap://<L>:MM/c/pg
         #         CoAP Payload
         #             PAN ID TLV
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_pending_get_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_PENDING_GET_URI).\
             filter(lambda p: {
@@ -257,7 +257,7 @@ class Cert_9_2_19_PendingDatasetGet(thread_cert.TestCase):
         #         CoAP Payload
         #             PAN ID TLV
         #             Delay Timer TLV
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_pending_get_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_PENDING_GET_URI).\
             filter(lambda p: {
                               NM_DELAY_TIMER_TLV,
@@ -274,7 +274,7 @@ class Cert_9_2_19_PendingDatasetGet(thread_cert.TestCase):
         #             CON POST coap://<L>:MM/c/pg
         #         CoAP Payload
         #             <empty> - get all Active Operational Dataset parameters
-        pkts.filter_wpan_src64(COMMISSIONER).\
+        _mgmt_pending_get_pkt = pkts.filter_wpan_src64(COMMISSIONER).\
             filter_ipv6_2dsts(LEADER_ALOC, LEADER_RLOC).\
             filter_coap_request(MGMT_PENDING_GET_URI).\
             filter(lambda p: p.coap.tlv.type is nullField).\
@@ -286,7 +286,7 @@ class Cert_9_2_19_PendingDatasetGet(thread_cert.TestCase):
         #             2.04 Changed
         #         CoAP Payload
         #             <empty> - (no Pending Operational Dataset)
-        pkts.filter_ipv6_src_dst(LEADER_RLOC, COMMISSIONER_RLOC).\
+        pkts.filter_ipv6_src_dst(_mgmt_pending_get_pkt.ipv6.dst, COMMISSIONER_RLOC).\
             filter_coap_ack(MGMT_PENDING_GET_URI).\
             filter(lambda p: p.thread_meshcop.tlv.type is nullField).\
            must_next()


### PR DESCRIPTION
#5632 convert ALOC source addresses to RLOCs.

This commit revert this feature.

**Background:**
[CoAP](https://tools.ietf.org/html/rfc7252#section-5.3.2) requires that the source address of a response must match the destination addresses of the request. So, if a device sends a TMF request using ALOC as destination address, the TMF response **SHOULD** use the ALOC as source address. Otherwise, CoAP implementations (beside OpenThread) may fail to match the request and response. 