### PR TITLE
[border-router] add external route for on-link prefix and external OMR prefixes

### DIFF
--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -254,7 +254,7 @@ jobs:
       MULTIPLY: 1
       PYTHONUNBUFFERED: 1
       VERBOSE: 1
-      # The border routing and DUA feature can coexist, but current wireshark
+      # The Border Routing and DUA feature can coexist, but current wireshark
       # packet verification can't handle it because of the order of context ID
       # of OMR prefix and Domain prefix is not deterministic.
       BORDER_ROUTING: 0

--- a/include/openthread/border_router.h
+++ b/include/openthread/border_router.h
@@ -58,12 +58,28 @@ extern "C" {
  * @param[in]  aInstance      A pointer to an OpenThread instance.
  * @param[in]  aInfraIfIndex  The infrastructure interface index.
  *
- * @retval  OT_ERROR_NONE          Successfully started the border routing manager on given infrastructure.
+ * @retval  OT_ERROR_NONE          Successfully started the Border Routing manager on given infrastructure.
  * @retval  OT_ERROR_INVALID_ARGS  The index of the infra interface is not valid.
  * @retval  OT_ERROR_FAILED        Internal failure. This is usually failed to generate random prefixes.
  *
+ * @retval  This method MUST be called before any other otBorderRouting* APIs.
+ *
  */
 otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex);
+
+/**
+ * This method enables/disables the Border Routing Manager.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ * @param[in]  aEnabled   A boolean to enable/disable the routing manager.
+ *
+ * @retval  OT_ERROR_INVALID_STATE  The Border Routing Manager is not initialized yet.
+ * @retval  OT_ERROR_NONE           Successfully enabled the Border Routing Manager.
+ *
+ * @note  The Border Routing Manager is enabled by default.
+ *
+ */
+otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled);
 
 /**
  * This method provides a full or stable copy of the local Thread Network Data.

--- a/include/openthread/border_router.h
+++ b/include/openthread/border_router.h
@@ -55,6 +55,8 @@ extern "C" {
 /**
  * This method initializes the Border Routing Manager on given infrastructure interface.
  *
+ * @note  This method MUST be called before any other otBorderRouting* APIs.
+ *
  * @param[in]  aInstance      A pointer to an OpenThread instance.
  * @param[in]  aInfraIfIndex  The infrastructure interface index.
  *
@@ -62,21 +64,19 @@ extern "C" {
  * @retval  OT_ERROR_INVALID_ARGS  The index of the infra interface is not valid.
  * @retval  OT_ERROR_FAILED        Internal failure. This is usually failed to generate random prefixes.
  *
- * @retval  This method MUST be called before any other otBorderRouting* APIs.
- *
  */
 otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex);
 
 /**
  * This method enables/disables the Border Routing Manager.
  *
+ * @note  The Border Routing Manager is enabled by default.
+ *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  * @param[in]  aEnabled   A boolean to enable/disable the routing manager.
  *
  * @retval  OT_ERROR_INVALID_STATE  The Border Routing Manager is not initialized yet.
- * @retval  OT_ERROR_NONE           Successfully enabled the Border Routing Manager.
- *
- * @note  The Border Routing Manager is enabled by default.
+ * @retval  OT_ERROR_NONE           Successfully enabled/disabled the Border Routing Manager.
  *
  */
 otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled);

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (63)
+#define OPENTHREAD_API_VERSION (64)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/infra_if.h
+++ b/include/openthread/platform/infra_if.h
@@ -47,6 +47,16 @@ extern "C" {
 #endif
 
 /**
+ * This method returns the IPv6 link-local address of given infrastructure interface.
+ *
+ * @param[in]   aInfraIfIndex  The index of the infrastructure interface.
+ *
+ * @returns  A pointer to the IPv6 link-local address. NULL if no valid IPv6 link-local address found.
+ *
+ */
+const otIp6Address *otPlatInfraIfGetLinkLocalAddress(uint32_t aInfraIfIndex);
+
+/**
  * This method sends an ICMPv6 Neighbor Discovery message on given infrastructure interface.
  *
  * See RFC 4861: https://tools.ietf.org/html/rfc4861.
@@ -82,8 +92,6 @@ otError otPlatInfraIfSendIcmp6Nd(uint32_t            aInfraIfIndex,
  *
  * @note  Per RFC 4861, the caller should enforce that the source address MUST be a IPv6 link-local
  *        address and the IP Hop Limit MUST be 255.
- *
- * @note  ICMPv6 message received from @p aInfraIfIndex via multicast loopback should not be passed in.
  *
  */
 extern void otPlatInfraIfRecvIcmp6Nd(otInstance *        aInstance,

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -22,6 +22,7 @@ Done
 ## OpenThread Command List
 
 - [bbr](#bbr)
+- [br](#br)
 - [bufferinfo](#bufferinfo)
 - [ccathreshold](#ccathreshold)
 - [channel](#channel)
@@ -309,6 +310,20 @@ Set jitter (in seconds) for Backbone Router registration for Thread 1.2 FTD.
 
 ```bash
 > bbr jitter 10
+Done
+```
+
+### br
+
+Enbale/disable the Border Routing functionality.
+
+```bash
+> br enable
+Done
+```
+
+```bash
+> br disable
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -274,22 +274,25 @@ otError Interpreter::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 otError Interpreter::ProcessBorderRouting(uint8_t aArgsLength, char *aArgs[])
 {
-    otError error = OT_ERROR_NONE;
+    otError error  = OT_ERROR_NONE;
+    bool    enable = false;
 
     VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
 
     if (strcmp(aArgs[0], "enable") == 0)
     {
-        SuccessOrExit(error = otBorderRoutingSetEnabled(mInstance, true));
+        enable = true;
     }
     else if (strcmp(aArgs[0], "disable") == 0)
     {
-        SuccessOrExit(error = otBorderRoutingSetEnabled(mInstance, false));
+        enable = false;
     }
     else
     {
         ExitNow(error = OT_ERROR_INVALID_COMMAND);
     }
+
+    SuccessOrExit(error = otBorderRoutingSetEnabled(mInstance, enable));
 
 exit:
     return error;

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -271,6 +271,31 @@ otError Interpreter::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
     return OT_ERROR_NONE;
 }
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+otError Interpreter::ProcessBorderRouting(uint8_t aArgsLength, char *aArgs[])
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
+
+    if (strcmp(aArgs[0], "enable") == 0)
+    {
+        SuccessOrExit(error = otBorderRoutingSetEnabled(mInstance, true));
+    }
+    else if (strcmp(aArgs[0], "disable") == 0)
+    {
+        SuccessOrExit(error = otBorderRoutingSetEnabled(mInstance, false));
+    }
+    else
+    {
+        ExitNow(error = OT_ERROR_INVALID_COMMAND);
+    }
+
+exit:
+    return error;
+}
+#endif
+
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 otError Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[])
 {

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -294,6 +294,9 @@ private:
     otError ProcessCcaThreshold(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessBufferInfo(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessChannel(uint8_t aArgsLength, char *aArgs[]);
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    otError ProcessBorderRouting(uint8_t aArgsLength, char *aArgs[]);
+#endif
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
     otError ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[]);
 
@@ -597,6 +600,9 @@ private:
     static constexpr Command sCommands[] = {
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
         {"bbr", &Interpreter::ProcessBackboneRouter},
+#endif
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+        {"br", &Interpreter::ProcessBorderRouting},
 #endif
         {"bufferinfo", &Interpreter::ProcessBufferInfo},
         {"ccathreshold", &Interpreter::ProcessCcaThreshold},

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -50,6 +50,13 @@ otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex)
 
     return instance.Get<BorderRouter::RoutingManager>().Init(aInfraIfIndex);
 }
+
+otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<BorderRouter::RoutingManager>().SetEnabled(aEnabled);
+}
 #endif
 
 otError otBorderRouterGetNetData(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)

--- a/src/core/border_router/router_advertisement.hpp
+++ b/src/core/border_router/router_advertisement.hpp
@@ -104,23 +104,39 @@ public:
     Type GetType(void) const { return mType; }
 
     /**
-     * This method sets the length of the option (in bytes).
+     * This method sets the size of the option (in bytes).
      *
      * Since the option must end on their natural 64-bits boundaries,
-     * the actual length set to the option is padded to (aLength + 7) / 8 * 8.
+     * the actual length set to the option is padded to (aSize + 7) / 8 * 8.
      *
-     * @param[in]  aLength  The length of the option in unit of 1 byte.
+     * @param[in]  aSize  The size of the option in unit of 1 byte.
      *
      */
-    void SetLength(uint16_t aLength) { mLength = (aLength + kLengthUnit - 1) / kLengthUnit; }
+    void SetSize(uint16_t aSize) { mLength = (aSize + kLengthUnit - 1) / kLengthUnit; }
 
     /**
-     * This method returns the length of the option (in bytes).
+     * This method returns the size of the option (in bytes).
      *
-     * @returns  The length of the option.
+     * @returns  The size of the option in unit of 1 byte.
      *
      */
-    uint16_t GetLength(void) const { return mLength * 8; }
+    uint16_t GetSize(void) const { return mLength * kLengthUnit; }
+
+    /**
+     * This method sets the length of the option (in unit of 8 bytes).
+     *
+     * @param[in]  aLength  The length of the option in unit of 8 bytes.
+     *
+     */
+    void SetLength(uint8_t aLength) { mLength = aLength; }
+
+    /**
+     * This method returns the length of the option (in unit of 8 bytes).
+     *
+     * @returns  The length of the option in unit of 8 bytes.
+     *
+     */
+    uint16_t GetLength(void) const { return mLength; }
 
     /**
      * This helper method returns a pointer to the next valid option in the buffer.
@@ -218,7 +234,7 @@ public:
     /**
      * This method returns the prefix in this option.
      *
-     * @retval  The IPv6 prefix in this option.
+     * @returns  The IPv6 prefix in this option.
      *
      */
     Ip6::Prefix GetPrefix(void) const;
@@ -231,7 +247,7 @@ public:
      */
     bool IsValid(void) const
     {
-        return (GetLength() == sizeof(*this)) && (mPrefixLength <= OT_IP6_ADDRESS_SIZE * CHAR_BIT);
+        return (GetSize() == sizeof(*this)) && (mPrefixLength <= OT_IP6_ADDRESS_SIZE * CHAR_BIT);
     }
 
 private:
@@ -279,7 +295,7 @@ public:
     /**
      * This method returns the route preference.
      *
-     * @returns  the route preference.
+     * @returns  The route preference.
      *
      */
     otRoutePreference GetPreference(void) const;
@@ -293,7 +309,7 @@ public:
     void SetRouteLifetime(uint32_t aLifetime) { mRouteLifetime = HostSwap32(aLifetime); }
 
     /**
-     * This method returns lifetime of the route in seconds.
+     * This method returns Route Lifetime in seconds.
      *
      * @returns  The Route Lifetime in seconds.
      *
@@ -311,7 +327,7 @@ public:
     /**
      * This method returns the prefix in this option.
      *
-     * @retval  The IPv6 prefix in this option.
+     * @returns  The IPv6 prefix in this option.
      *
      */
     Ip6::Prefix GetPrefix(void) const;
@@ -329,6 +345,13 @@ private:
     {
         kPreferenceMask   = 0x18u,
         kPreferenceOffset = 3u,
+    };
+
+    enum : uint8_t
+    {
+        kPreferenceLow  = 0x03,
+        kPreferenceMed  = 0x00,
+        kPreferenceHigh = 0x01,
     };
 
     uint8_t      mPrefixLength;  // The prefix length in bits.

--- a/src/core/border_router/router_advertisement.hpp
+++ b/src/core/border_router/router_advertisement.hpp
@@ -43,6 +43,7 @@
 
 #include <stdint.h>
 
+#include <openthread/netdata.h>
 #include <openthread/platform/toolchain.h>
 
 #include "common/encoding.hpp"
@@ -215,12 +216,12 @@ public:
     void SetPrefix(const Ip6::Prefix &aPrefix);
 
     /**
-     * THis method returns the prefix in this option.
+     * This method returns the prefix in this option.
      *
-     * @param[out]  aPrefix  The prefix to output to.
+     * @retval  The IPv6 prefix in this option.
      *
      */
-    void GetPrefix(Ip6::Prefix &aPrefix) const;
+    Ip6::Prefix GetPrefix(void) const;
 
     /**
      * This method tells whether this option is valid.
@@ -268,12 +269,36 @@ public:
     RouteInfoOption(void);
 
     /**
+     * This method sets the route preference.
+     *
+     * @param[in]  aPreference  The route preference.
+     *
+     */
+    void SetPreference(otRoutePreference aPreference);
+
+    /**
+     * This method returns the route preference.
+     *
+     * @returns  the route preference.
+     *
+     */
+    otRoutePreference GetPreference(void) const;
+
+    /**
      * This method sets the lifetime of the route in seconds.
      *
      * @param[in]  aLifetime  The lifetime of the route in seconds.
      *
      */
     void SetRouteLifetime(uint32_t aLifetime) { mRouteLifetime = HostSwap32(aLifetime); }
+
+    /**
+     * This method returns lifetime of the route in seconds.
+     *
+     * @returns  The Route Lifetime in seconds.
+     *
+     */
+    uint32_t GetRouteLifetime(void) const { return HostSwap32(mRouteLifetime); }
 
     /**
      * This method sets the prefix.
@@ -284,18 +309,28 @@ public:
     void SetPrefix(const Ip6::Prefix &aPrefix);
 
     /**
+     * This method returns the prefix in this option.
+     *
+     * @retval  The IPv6 prefix in this option.
+     *
+     */
+    Ip6::Prefix GetPrefix(void) const;
+
+    /**
      * This method tells whether this option is valid.
      *
      * @returns  A boolean indicates whether this option is valid.
      *
      */
-    bool IsValid(void) const
-    {
-        return (GetLength() == kLengthUnit || GetLength() == 2 * kLengthUnit || GetLength() == 3 * kLengthUnit) &&
-               (mPrefixLength <= OT_IP6_ADDRESS_SIZE * CHAR_BIT);
-    }
+    bool IsValid(void) const;
 
 private:
+    enum : uint8_t
+    {
+        kPreferenceMask   = 0x18u,
+        kPreferenceOffset = 3u,
+    };
+
     uint8_t      mPrefixLength;  // The prefix length in bits.
     uint8_t      mReserved;      // The reserved field.
     uint32_t     mRouteLifetime; // The lifetime in seconds.

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -521,6 +521,12 @@ const Ip6::Prefix *RoutingManager::EvaluateOnLinkPrefix(void)
             otLogInfoBr("EvaluateOnLinkPrefix: there is already smaller on-link prefix %s on interface %u",
                         smallestOnLinkPrefix->ToString().AsCString(), mInfraIfIndex);
 
+            // TODO: we removes the advertised on-link prefix by setting valid lifetime for PIO.
+            // But SLAAC addresses configured by PIO prefix will not be removed immediately (
+            // https://tools.ietf.org/html/rfc4862#section-5.5.3). This leads to a situation that
+            // a WiFi device keeps using the old SLAAC address but a Thread device cannot reach to
+            // it. One solution is to delay removing external route until the SLAAC addresses are
+            // actually expired/deprecated.
             RemoveExternalRoute(*mAdvertisedOnLinkPrefix);
         }
     }

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -89,12 +89,12 @@ public:
     /**
      * This method enables/disables the Border Routing Manager.
      *
+     * @note  The Border Routing Manager is enabled by default.
+     *
      * @param[in]  aEnabled   A boolean to enable/disable the Border Routing Manager.
      *
      * @retval  OT_ERROR_INVALID_STATE  The Border Routing Manager is not initialized yet.
-     * @retval  OT_ERROR_NONE           Successfully enabled the Border Routing Manager.
-     *
-     * @note  The Border Routing Manager is enabled by default.
+     * @retval  OT_ERROR_NONE           Successfully enabled/disabled the Border Routing Manager.
      *
      */
     otError SetEnabled(bool aEnabled);
@@ -152,10 +152,8 @@ private:
         kMaxRtrSolicitations = 3, // The Maximum number of Router Solicitations before sending Router Advertisements.
     };
 
-    /**
-     * This struct represents an external prefix which is discovered on the infrastructure interface.
-     *
-     */
+    // This struct represents an external prefix which is
+    // discovered on the infrastructure interface.
     struct ExternalPrefix : public Clearable<ExternalPrefix>
     {
         Ip6::Prefix mPrefix;
@@ -171,109 +169,19 @@ private:
     otError LoadOrGenerateRandomOmrPrefix(void);
     otError LoadOrGenerateRandomOnLinkPrefix(void);
 
-    /**
-     * This method tells whether the first prefix is numerically smaller than the second one.
-     *
-     * @note  The caller must guarantee that the two prefix has the same length.
-     *
-     */
-    static bool IsPrefixSmallerThan(const Ip6::Prefix &aFirstPrefix, const Ip6::Prefix &aSecondPrefix);
-
-    static bool IsValidOmrPrefix(const Ip6::Prefix &aOmrPrefix);
-    static bool IsValidOnLinkPrefix(const Ip6::Prefix &aOnLinkPrefix);
-
-    /**
-     * This method evaluate the routing policy depends on prefix and route
-     * information on Thread Network and infra link. As a result, this
-     * method May send RA messages on infra link and publish/unpublish
-     * OMR prefix in the Thread network.
-     *
-     * @sa EvaluateOmrPrefix
-     * @sa EvaluateOnLinkPrefix
-     * @sa PublishLocalOmrPrefix
-     * @sa UnpublishLocalOmrPrefix
-     *
-     */
-    void EvaluateRoutingPolicy(void);
-
-    /**
-     * This method evaluates the OMR prefix for the Thread Network.
-     *
-     * @param[out]  aNewOmrPrefixes   An array of the new OMR prefixes should be advertised.
-     *                                MUST not be nullptr.
-     * @param[in]   aMaxOmrPrefixNum  The maximum number of OMR prefixes that @p aNewOmrPrefixes can hold.
-     *
-     * @returns  The number of the new OMR prefixes that should be advertised after this evaluation.
-     *
-     */
-    uint8_t EvaluateOmrPrefix(Ip6::Prefix *aNewOmrPrefixes, uint8_t aMaxOmrPrefixNum);
-
-    /**
-     * This method evaluates the on-link prefix for the infra link.
-     *
-     * @returns  A pointer to the new on-link prefix should be advertised.
-     *           nullptr if we should no longer advertise an on-link prefix.
-     *
-     */
     const Ip6::Prefix *EvaluateOnLinkPrefix(void);
 
-    /**
-     * This method publishes the local OMR prefix in Thread network.
-     *
-     */
+    void    EvaluateRoutingPolicy(void);
+    uint8_t EvaluateOmrPrefix(Ip6::Prefix *aNewOmrPrefixes, uint8_t aMaxOmrPrefixNum);
     otError PublishLocalOmrPrefix(void);
-
-    /**
-     * This method unpublishes the local OMR prefix.
-     *
-     */
-    void UnpublishLocalOmrPrefix(void);
-
-    /**
-     * This method adds external route for the prefix.
-     *
-     */
+    void    UnpublishLocalOmrPrefix(void);
     otError AddExternalRoute(const Ip6::Prefix &aPrefix, otRoutePreference aRoutePreference);
-
-    /**
-     * This method removes the external route added for the prefix.
-     *
-     */
-    void RemoveExternalRoute(const Ip6::Prefix &aPrefix);
-
-    /**
-     * This method starts sending Router Solicitations in random delay
-     * between 0 and kMaxRtrSolicitationDelay.
-     *
-     */
-    void StartRouterSolicitation(void);
-
-    /**
-     * This method sends Router Solicitation messages to discover on-link
-     * prefix on infra links.
-     *
-     * @sa HandleRouterAdvertisement
-     *
-     * @retval  OT_ERROR_NONE    Successfully sent the message.
-     * @retval  OT_ERROR_FAILED  Failed to send the message.
-     *
-     */
+    void    RemoveExternalRoute(const Ip6::Prefix &aPrefix);
+    void    StartRouterSolicitation(void);
     otError SendRouterSolicitation(void);
-
-    /**
-     * This method sends Router Advertisement messages to advertise on-link prefix and route for OMR prefix.
-     *
-     * @param[in]  aNewOmrPrefixes   A pointer to an array of the new OMR prefixes to be advertised.
-     *                               @p aNewOmrPrefixNum must be zero if this argument is nullptr.
-     * @param[in]  aNewOmrPrefixNum  The number of the new OMR prefixes to be advertised.
-     *                               Zero means we should stop advertising OMR prefixes.
-     * @param[in]  aOnLinkPrefix     A pointer to the new on-link prefix to be advertised.
-     *                               nullptr means we should stop advertising on-link prefix.
-     *
-     */
-    void SendRouterAdvertisement(const Ip6::Prefix *aNewOmrPrefixes,
-                                 uint8_t            aNewOmrPrefixNum,
-                                 const Ip6::Prefix *aNewOnLinkPrefix);
+    void    SendRouterAdvertisement(const Ip6::Prefix *aNewOmrPrefixes,
+                                    uint8_t            aNewOmrPrefixNum,
+                                    const Ip6::Prefix *aNewOnLinkPrefix);
 
     static void HandleRouterAdvertisementTimer(Timer &aTimer);
     void        HandleRouterAdvertisementTimer(void);
@@ -286,109 +194,48 @@ private:
 
     void HandleRouterSolicit(const Ip6::Address &aSrcAddress, const uint8_t *aBuffer, uint16_t aBufferLength);
     void HandleRouterAdvertisement(const Ip6::Address &aSrcAddress, const uint8_t *aBuffer, uint16_t aBufferLength);
-
-    /**
-     * This method updates the discovered prefix list with given Prefix Information Option.
-     *
-     * @param[in]  aPio  A reference to the Prefix Information Option.
-     *
-     * @returns  A boolean indicates whether we need to re-evaluate our routing policy.
-     *
-     */
     bool UpdateDiscoveredPrefixes(const RouterAdv::PrefixInfoOption &aPio);
-
-    /**
-     * This method updates the discovered prefix list with given Route Information Option.
-     *
-     * @param[in]  aPio  A reference to the Route Information Option.
-     *
-     * @returns  A boolean indicates whether we need to re-evaluate our routing policy.
-     *
-     */
     bool UpdateDiscoveredPrefixes(const RouterAdv::RouteInfoOption &aRio);
-
-    /**
-     * This method removes expired or specific discovered prefixes.
-     *
-     * @param[in]  aPrefix          A pointer to a specific prefix to be removed.
-     * @param[in]  aIsOnLinkPrefix  A boolean which indicates whether the prefix is an on-link prefix.
-     *
-     * @returns  The number of removed prefixes.
-     *
-     */
-    uint8_t InvalidateDiscoveredPrefixes(const Ip6::Prefix *aPrefix = nullptr, bool aIsOnLinkPrefix = true);
-
-    /**
-     * This method invalidates all discovered prefixes.
-     *
-     */
+    bool InvalidateDiscoveredPrefixes(const Ip6::Prefix *aPrefix = nullptr, bool aIsOnLinkPrefix = true);
     void InvalidateAllDiscoveredPrefixes(void);
-
-    /**
-     * This methods adds a prefix discovered in a RA message.
-     *
-     * If the same prefix already exists, only the lifetime will be updated.
-     *
-     * @param[in]  aPrefix           The prefix to be added.
-     * @param[in]  aIsOnLinkPrefix   A boolean which indicates whether the prefix is an on-link prefix.
-     * @param[in]  aLifetime         The lifetime of the prefix. In seconds.
-     * @param[in]  aRoutePreference  The preference of the route which is associated with the prefix.
-     *
-     * @returns  A boolean indicates whether a new prefix is added.
-     *
-     */
     bool AddDiscoveredPrefix(const Ip6::Prefix &aPrefix,
                              bool               aIsOnLinkPrefix,
                              uint32_t           aLifetime,
                              otRoutePreference  aRoutePreference = OT_ROUTE_PREFERENCE_MED);
 
-    static bool ContainsPrefix(const Ip6::Prefix &aPrefix, const Ip6::Prefix *aPrefixList, uint8_t aPrefixNum);
-
+    // Decides the first prefix is numerically smaller than the second one.
+    static bool     IsPrefixSmallerThan(const Ip6::Prefix &aFirstPrefix, const Ip6::Prefix &aSecondPrefix);
+    static bool     IsValidOmrPrefix(const Ip6::Prefix &aOmrPrefix);
+    static bool     IsValidOnLinkPrefix(const Ip6::Prefix &aOnLinkPrefix);
+    static bool     ContainsPrefix(const Ip6::Prefix &aPrefix, const Ip6::Prefix *aPrefixList, uint8_t aPrefixNum);
     static uint32_t GetPrefixExpireDelay(uint32_t aValidLifetime);
 
     bool     mIsRunning;
     uint32_t mInfraIfIndex;
     bool     mEnabled;
 
-    /**
-     * The OMR prefix loaded from local persistent storage or randomly generated
-     * if non is found in persistent storage.
-     *
-     */
+    // The OMR prefix loaded from local persistent storage or randomly generated
+    // if non is found in persistent storage.
     Ip6::Prefix mLocalOmrPrefix;
 
-    /**
-     * The advertised OMR prefixes. For a stable Thread network without
-     * manually configured OMR prefixes, there should be a single OMR prefix
-     * that being advertised because each BRs will converge to the smallest
-     * OMR prefix sorted by method IsPrefixSmallerThan. If manually configured
-     * OMR prefixes exist, they will also be advertised on infra link.
-     *
-     */
+    // The advertised OMR prefixes. For a stable Thread network without
+    // manually configured OMR prefixes, there should be a single OMR prefix
+    // that is being advertised because each BRs will converge to the smallest
+    // OMR prefix sorted by method IsPrefixSmallerThan. If manually configured
+    // OMR prefixes exist, they will also be advertised on infra link.
     Ip6::Prefix mAdvertisedOmrPrefixes[kMaxOmrPrefixNum];
     uint8_t     mAdvertisedOmrPrefixNum;
 
-    /**
-     * The on-link prefix loaded from local persistent storage or randomly generated
-     * if non is found in persistent storage.
-     *
-     */
+    // The on-link prefix loaded from local persistent storage or randomly generated
+    // if non is found in persistent storage.
     Ip6::Prefix mLocalOnLinkPrefix;
 
-    /**
-     * The advertised on-link prefix.
-     *
-     * Could only be nullptr or a pointer to mLocalOnLinkPrefix.
-     *
-     */
+    // Could only be nullptr or a pointer to mLocalOnLinkPrefix.
     const Ip6::Prefix *mAdvertisedOnLinkPrefix;
 
-    /**
-     * The array of prefixes discovered on the infra link. Those prefixes consist of
-     * on-link prefix(es) and OMR prefixes advertised by BRs in another Thread Network
-     * which is connected to the same infra link.
-     *
-     */
+    // The array of prefixes discovered on the infra link. Those prefixes consist of
+    // on-link prefix(es) and OMR prefixes advertised by BRs in another Thread Network
+    // which is connected to the same infra link.
     ExternalPrefix mDiscoveredPrefixes[kMaxDiscoveredPrefixNum];
     uint8_t        mDiscoveredPrefixNum;
 

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -157,6 +157,14 @@ public:
      */
     Ip6::Prefix &GetPrefix(void) { return static_cast<Ip6::Prefix &>(mPrefix); }
 
+    /**
+     * This method sets the prefix.
+     *
+     * @param[in]  aPrefix  The prefix to set to.
+     *
+     */
+    void SetPrefix(const Ip6::Prefix &aPrefix) { mPrefix = aPrefix; }
+
 private:
     void SetFrom(Instance &           aInstance,
                  const PrefixTlv &    aPrefixTlv,

--- a/tests/scripts/thread-cert/border_routing/test_multi_border_routers.py
+++ b/tests/scripts/thread-cert/border_routing/test_multi_border_routers.py
@@ -41,14 +41,15 @@ import thread_cert
 #    ----------------(eth)------------------
 #           |                  |     |
 #          BR1 (Leader) ----- BR2   HOST
-#           |
-#          ED1
+#           |                  |
+#        ROUTER1            ROUTER2
 #
 
 BR1 = 1
 ROUTER1 = 2
 BR2 = 3
-HOST = 4
+ROUTER2 = 4
+HOST = 5
 
 CHANNEL1 = 18
 
@@ -74,8 +75,15 @@ class MultiBorderRouters(thread_cert.TestCase):
         },
         BR2: {
             'name': 'BR_2',
-            'allowlist': [BR1],
+            'allowlist': [BR1, ROUTER2],
             'is_otbr': True,
+            'version': '1.2',
+            'channel': CHANNEL1,
+            'router_selection_jitter': 2,
+        },
+        ROUTER2: {
+            'name': 'Router_2',
+            'allowlist': [BR2],
             'version': '1.2',
             'channel': CHANNEL1,
             'router_selection_jitter': 2,
@@ -87,7 +95,7 @@ class MultiBorderRouters(thread_cert.TestCase):
     }
 
     def test(self):
-        self.nodes[HOST].start(start_radvd=True, prefix=config.ONLINK_PREFIX, slaac=True)
+        self.nodes[HOST].start(start_radvd=False)
         self.simulator.go(5)
 
         self.nodes[BR1].start()
@@ -102,12 +110,70 @@ class MultiBorderRouters(thread_cert.TestCase):
         self.simulator.go(5)
         self.assertEqual('router', self.nodes[BR2].get_state())
 
+        self.nodes[ROUTER2].start()
+        self.simulator.go(5)
+        self.assertEqual('router', self.nodes[ROUTER2].get_state())
+
+        #
+        # Case 1. bi-directional connectivity when there are two BRs.
+        #
+
         self.simulator.go(10)
         self.collect_ipaddrs()
 
         logging.info("BR1     addrs: %r", self.nodes[BR1].get_addrs())
         logging.info("ROUTER1 addrs: %r", self.nodes[ROUTER1].get_addrs())
         logging.info("BR2     addrs: %r", self.nodes[BR2].get_addrs())
+        logging.info("ROUTER2 addrs: %r", self.nodes[ROUTER2].get_addrs())
+        logging.info("HOST    addrs: %r", self.nodes[HOST].get_addrs())
+
+        self.assertTrue(len(self.nodes[BR1].get_prefixes()) == 1)
+        self.assertTrue(len(self.nodes[ROUTER1].get_prefixes()) == 1)
+        self.assertTrue(len(self.nodes[BR2].get_prefixes()) == 1)
+        self.assertTrue(len(self.nodes[ROUTER2].get_prefixes()) == 1)
+
+        br1_omr_prefix = self.nodes[BR1].get_prefixes()[0]
+
+        # Each BR should independently register an external route for the on-link prefix.
+        self.assertTrue(len(self.nodes[BR1].get_routes()) == 2)
+        self.assertTrue(len(self.nodes[ROUTER1].get_routes()) == 2)
+        self.assertTrue(len(self.nodes[BR2].get_routes()) == 2)
+        self.assertTrue(len(self.nodes[ROUTER2].get_routes()) == 2)
+
+        external_route = self.nodes[BR1].get_routes()[0]
+        br1_on_link_prefix = external_route.split(' ')[0]
+
+        self.assertTrue(len(self.nodes[BR1].get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)
+        self.assertTrue(len(self.nodes[ROUTER1].get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)
+        self.assertTrue(len(self.nodes[BR2].get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)
+        self.assertTrue(len(self.nodes[ROUTER2].get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)
+        self.assertTrue(len(self.nodes[HOST].get_matched_ula_addresses(br1_on_link_prefix)) == 1)
+
+        # Router1 and Router2 can ping each other inside the Thread network.
+        self.assertTrue(self.nodes[ROUTER1].ping(self.nodes[ROUTER2].get_ip6_address(config.ADDRESS_TYPE.OMR)[0]))
+        self.assertTrue(self.nodes[ROUTER2].ping(self.nodes[ROUTER1].get_ip6_address(config.ADDRESS_TYPE.OMR)[0]))
+
+        # Both Router1 and Router2 can ping to/from the Host on infra link.
+        self.assertTrue(self.nodes[ROUTER1].ping(self.nodes[HOST].get_matched_ula_addresses(br1_on_link_prefix)[0]))
+        self.assertTrue(self.nodes[HOST].ping(self.nodes[ROUTER1].get_ip6_address(config.ADDRESS_TYPE.OMR)[0],
+                                              backbone=True))
+        self.assertTrue(self.nodes[ROUTER2].ping(self.nodes[HOST].get_matched_ula_addresses(br1_on_link_prefix)[0]))
+        self.assertTrue(self.nodes[HOST].ping(self.nodes[ROUTER2].get_ip6_address(config.ADDRESS_TYPE.OMR)[0],
+                                              backbone=True))
+
+        #
+        # Case 2. Another BR continues providing Border Routing when current one is disabled.
+        #
+
+        self.nodes[BR1].disable_br()
+
+        self.simulator.go(15)
+        self.collect_ipaddrs()
+
+        logging.info("BR1     addrs: %r", self.nodes[BR1].get_addrs())
+        logging.info("ROUTER1 addrs: %r", self.nodes[ROUTER1].get_addrs())
+        logging.info("BR2     addrs: %r", self.nodes[BR2].get_addrs())
+        logging.info("ROUTER2 addrs: %r", self.nodes[ROUTER2].get_addrs())
         logging.info("HOST    addrs: %r", self.nodes[HOST].get_addrs())
 
         self.assertGreaterEqual(len(self.nodes[HOST].get_addrs()), 2)
@@ -115,23 +181,36 @@ class MultiBorderRouters(thread_cert.TestCase):
         self.assertTrue(len(self.nodes[BR1].get_prefixes()) == 1)
         self.assertTrue(len(self.nodes[ROUTER1].get_prefixes()) == 1)
         self.assertTrue(len(self.nodes[BR2].get_prefixes()) == 1)
+        self.assertTrue(len(self.nodes[ROUTER2].get_prefixes()) == 1)
+
+        br2_omr_prefix = self.nodes[BR1].get_prefixes()[0]
+        self.assertNotEqual(br1_omr_prefix, br2_omr_prefix)
+
+        # Only BR2 will register external route for the on-link prefix.
+        self.assertTrue(len(self.nodes[BR1].get_routes()) == 1)
+        self.assertTrue(len(self.nodes[ROUTER1].get_routes()) == 1)
+        self.assertTrue(len(self.nodes[BR2].get_routes()) == 1)
+        self.assertTrue(len(self.nodes[ROUTER2].get_routes()) == 1)
+
+        br2_external_route = self.nodes[BR2].get_routes()[0]
+        br2_on_link_prefix = br2_external_route.split(' ')[0]
 
         self.assertTrue(len(self.nodes[BR1].get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)
         self.assertTrue(len(self.nodes[ROUTER1].get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)
         self.assertTrue(len(self.nodes[BR2].get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)
-        self.assertTrue(len(self.nodes[HOST].get_ip6_address(config.ADDRESS_TYPE.ONLINK_ULA)) == 1)
+        self.assertTrue(len(self.nodes[ROUTER2].get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)
 
-        # Router1 and BR2 can ping each other inside the Thread network.
-        self.assertTrue(self.nodes[ROUTER1].ping(self.nodes[BR2].get_ip6_address(config.ADDRESS_TYPE.OMR)[0]))
-        self.assertTrue(self.nodes[BR2].ping(self.nodes[ROUTER1].get_ip6_address(config.ADDRESS_TYPE.OMR)[0]))
+        self.assertTrue(len(self.nodes[HOST].get_matched_ula_addresses(br2_on_link_prefix)) == 1)
 
-        # Both Router1 and BR2 can ping to/from the Host on infra link.
-        self.assertTrue(self.nodes[ROUTER1].ping(self.nodes[HOST].get_ip6_address(config.ADDRESS_TYPE.ONLINK_ULA)[0]))
-        self.assertTrue(self.nodes[HOST].ping(self.nodes[ROUTER1].get_ip6_address(config.ADDRESS_TYPE.OMR)[0],
-                                              backbone=True))
-        self.assertTrue(self.nodes[BR2].ping(self.nodes[HOST].get_ip6_address(config.ADDRESS_TYPE.ONLINK_ULA)[0]))
-        self.assertTrue(self.nodes[HOST].ping(self.nodes[BR2].get_ip6_address(config.ADDRESS_TYPE.OMR)[0],
-                                              backbone=True))
+        # Router1 and Router2 can ping each other inside the Thread network.
+        self.assertTrue(self.nodes[ROUTER1].ping(self.nodes[ROUTER2].get_ip6_address(config.ADDRESS_TYPE.OMR)[0]))
+        self.assertTrue(self.nodes[ROUTER2].ping(self.nodes[ROUTER1].get_ip6_address(config.ADDRESS_TYPE.OMR)[0]))
+
+        # Both Router1 and Router2 can ping to/from the Host on infra link.
+        for router in [ROUTER1, ROUTER2]:
+            self.assertTrue(self.nodes[router].ping(self.nodes[HOST].get_matched_ula_addresses(br2_on_link_prefix)[0]))
+            self.assertTrue(self.nodes[HOST].ping(self.nodes[router].get_ip6_address(config.ADDRESS_TYPE.OMR)[0],
+                                                  backbone=True))
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/border_routing/test_multi_thread_networks.py
+++ b/tests/scripts/thread-cert/border_routing/test_multi_thread_networks.py
@@ -40,7 +40,7 @@ import thread_cert
 #           |               |
 #          BR1             BR2
 #           |               |
-#          ED1             ED2
+#        ROUTER1         ROUTER2
 #
 #     Thread Net1       Thread Net2
 #
@@ -118,6 +118,25 @@ class MultiThreadNetworks(thread_cert.TestCase):
         self.assertTrue(len(self.nodes[ROUTER1].get_prefixes()) == 1)
         self.assertTrue(len(self.nodes[BR2].get_prefixes()) == 1)
         self.assertTrue(len(self.nodes[ROUTER2].get_prefixes()) == 1)
+
+        br1_omr_prefix = self.nodes[BR1].get_prefixes()[0]
+        br2_omr_prefix = self.nodes[BR2].get_prefixes()[0]
+
+        self.assertNotEqual(br1_omr_prefix, br2_omr_prefix)
+
+        # Each BR should independently register an external route for the on-link prefix
+        # and OMR prefix in another Thread Network.
+        self.assertTrue(len(self.nodes[BR1].get_routes()) == 2)
+        self.assertTrue(len(self.nodes[ROUTER1].get_routes()) == 2)
+        self.assertTrue(len(self.nodes[BR2].get_routes()) == 2)
+        self.assertTrue(len(self.nodes[ROUTER2].get_routes()) == 2)
+
+        br1_external_routes = self.nodes[BR1].get_routes()
+        br2_external_routes = self.nodes[BR2].get_routes()
+
+        br1_external_routes.sort()
+        br2_external_routes.sort()
+        self.assertNotEqual(br1_external_routes, br2_external_routes)
 
         self.assertTrue(len(self.nodes[ROUTER1].get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)
         self.assertTrue(len(self.nodes[ROUTER2].get_ip6_address(config.ADDRESS_TYPE.OMR)) == 1)


### PR DESCRIPTION
This PR includes the enhancement that
1. adds non-default external route for on-link prefixes.
2. add external route for OMR prefixes advertised by BRs in other Thread Networks.
3. a new API to disable/enable the Border Routing manager at run time. CLI commands are added for testing.
4. a new platform API to get the link-local address of the infra interface so that we can filter out the ICMPv6 packets from myself by the Border Routing Manager rather than the platform implementation.


enhancements that adds random delay before changing the prefixes/routes, multiple prefixes for fault tolerance and duplicate OMR prefixes detection will be added in future PRs.