### PR TITLE
[nrf528xx] enable unused-parameter warning for platform code

### DIFF
--- a/examples/platforms/nrf528xx/nrf52811/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52811/Makefile.am
@@ -64,7 +64,6 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal                                  \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/lp_timer                          \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/temperature                       \
-    -Wno-unused-parameter                                                                                    \
     $(NULL)
 
 # Only reference the SDK header files included in third_party/NordicSemiconductor
@@ -99,7 +98,6 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/drivers/include                                     \
     -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/mdk                                                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/soc                                                 \
-    -Wno-unused-parameter                                                                                    \
     $(NULL)
 endif
 

--- a/examples/platforms/nrf528xx/nrf52833/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52833/Makefile.am
@@ -66,7 +66,6 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal/softdevice                       \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/lp_timer                          \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/temperature                       \
-    -Wno-unused-parameter                                                                                    \
     $(NULL)
 
 # Only reference the SDK header files included in third_party/NordicSemiconductor
@@ -108,7 +107,6 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/soc                                                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers                                  \
     -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf52                            \
-    -Wno-unused-parameter                                                                                    \
     $(NULL)
 endif
 
@@ -144,6 +142,7 @@ SOFTDEVICE_SOURCES                                                              
 SOFTDEVICE_CPPFLAGS                                                                                        = \
     -DSOFTDEVICE_PRESENT                                                                                     \
     -DS140                                                                                                   \
+    -Wno-unused-parameter                                                                                    \
     $(NULL)
 
 PLATFORM_SOURCES                                                                                           = \

--- a/examples/platforms/nrf528xx/nrf52840/Makefile.am
+++ b/examples/platforms/nrf528xx/nrf52840/Makefile.am
@@ -66,7 +66,6 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/rsch/raal/softdevice                       \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/lp_timer                          \
     -I$(top_srcdir)/third_party/NordicSemiconductor/drivers/radio/platform/temperature                       \
-    -Wno-unused-parameter                                                                                    \
     $(NULL)
 
 # Only reference the SDK header files included in third_party/NordicSemiconductor
@@ -108,7 +107,6 @@ COMMONCPPFLAGS                                                                  
     -I$(top_srcdir)/third_party/NordicSemiconductor/nrfx/soc                                                 \
     -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers                                  \
     -I$(top_srcdir)/third_party/NordicSemiconductor/softdevice/s140/headers/nrf52                            \
-    -Wno-unused-parameter                                                                                    \
     $(NULL)
 endif
 
@@ -145,6 +143,7 @@ SOFTDEVICE_SOURCES                                                              
 SOFTDEVICE_CPPFLAGS                                                                                        = \
     -DSOFTDEVICE_PRESENT                                                                                     \
     -DS140                                                                                                   \
+    -Wno-unused-parameter                                                                                    \
     $(NULL)
 
 PLATFORM_SOURCES                                                                                           = \
@@ -154,7 +153,7 @@ PLATFORM_SOURCES                                                                
 libopenthread_nrf52840_a_CPPFLAGS                                                                          = \
     $(COMMONCPPFLAGS)                                                                                        \
     $(SINGLEPHY_CPPFLAGS)                                                                                    \
-    -DPLATFORM_OPENTHREAD_VANILLA                                                                             \
+    -DPLATFORM_OPENTHREAD_VANILLA                                                                            \
     $(NULL)
 
 libopenthread_nrf52840_a_SOURCES                                                                           = \

--- a/examples/platforms/nrf528xx/src/radio.c
+++ b/examples/platforms/nrf528xx/src/radio.c
@@ -1089,6 +1089,7 @@ void nrf_802154_transmitted_timestamp_raw(const uint8_t *aFrame,
                                           uint8_t        aLqi,
                                           uint32_t       ack_time)
 {
+    OT_UNUSED_VARIABLE(aFrame); // For ARM gcc
     assert(aFrame == sTransmitPsdu);
 
     if (aAckPsdu == NULL)
@@ -1113,6 +1114,7 @@ void nrf_802154_transmitted_timestamp_raw(const uint8_t *aFrame,
 
 void nrf_802154_transmit_failed(const uint8_t *aFrame, nrf_802154_tx_error_t error)
 {
+    OT_UNUSED_VARIABLE(aFrame); // For ARM gcc
     assert(aFrame == sTransmitPsdu);
 
     switch (error)
@@ -1265,6 +1267,8 @@ void otPlatRadioSetMacFrameCounter(otInstance *aInstance, uint32_t aMacFrameCoun
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 static void updateIeData(otInstance *aInstance, const uint8_t *aShortAddr, const uint8_t *aExtAddr)
 {
+    OT_UNUSED_VARIABLE(aInstance);
+
     int8_t  offset = 0;
     uint8_t ackIeData[OT_ACK_IE_MAX_SIZE];
 
@@ -1324,6 +1328,9 @@ otError otPlatRadioConfigureEnhAckProbing(otInstance *         aInstance,
                                           const otExtAddress * aExtAddress)
 {
     OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aLinkMetrics);
+    OT_UNUSED_VARIABLE(aShortAddress);
+    OT_UNUSED_VARIABLE(aExtAddress);
 
     return OT_ERROR_NOT_IMPLEMENTED;
 }

--- a/examples/platforms/nrf528xx/src/transport/transport.c
+++ b/examples/platforms/nrf528xx/src/transport/transport.c
@@ -40,6 +40,8 @@
 
 void nrf5TransportInit(bool aPseudoReset)
 {
+    OT_UNUSED_VARIABLE(aPseudoReset);
+
 #if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
     if (!aPseudoReset)
     {
@@ -52,13 +54,14 @@ void nrf5TransportInit(bool aPseudoReset)
 #endif
 
 #if (SPIS_AS_SERIAL_TRANSPORT == 1)
-    OT_UNUSED_VARIABLE(aPseudoReset);
     nrf5SpiSlaveInit();
 #endif
 }
 
 void nrf5TransportDeinit(bool aPseudoReset)
 {
+    OT_UNUSED_VARIABLE(aPseudoReset);
+
 #if ((UART_AS_SERIAL_TRANSPORT == 1) || (USB_CDC_AS_SERIAL_TRANSPORT == 1))
     if (!aPseudoReset)
     {
@@ -67,7 +70,6 @@ void nrf5TransportDeinit(bool aPseudoReset)
 #endif
 
 #if (SPIS_AS_SERIAL_TRANSPORT == 1)
-    OT_UNUSED_VARIABLE(aPseudoReset);
     nrf5SpiSlaveDeinit();
 #endif
 }


### PR DESCRIPTION
This PR enables `unused-parameter` warning for NRF driver code except for soft-device.

Currently this warning is disabled for all NRF driver code, which makes `OT_UNUSED_VARIABLE` in driver code useless. I found that we only need to suppress the warning for soft-device code because only that part includes some headers in `third_party/NordicSemiconductor` that have unused parameters. We'd better to make the rest part of driver code consistent with OpenThread code.