### PR TITLE
[build] remove unneeded-internal-declaration warning on Fuchsia

### DIFF
--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -80,7 +80,7 @@ using ot::Spinel::Decoder;
 namespace ot {
 namespace Spinel {
 
-static otError SpinelStatusToOtError(spinel_status_t aError)
+static inline otError SpinelStatusToOtError(spinel_status_t aError)
 {
     otError ret;
 
@@ -154,7 +154,7 @@ static otError SpinelStatusToOtError(spinel_status_t aError)
     return ret;
 }
 
-static void LogIfFail(const char *aText, otError aError)
+static inline void LogIfFail(const char *aText, otError aError)
 {
     OT_UNUSED_VARIABLE(aText);
     OT_UNUSED_VARIABLE(aError);


### PR DESCRIPTION
By inlining static functions defined in the header file.

Since this increases the function size of functions which use the definition, an alternative is to define these functions as function templates with unused template parameters. This ensures that functions are created only in the files where they are used. Please let me know if I should do that instead.