### PR TITLE
[radio-spinel] add option to skip RCP compatibility check during init

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -113,13 +113,14 @@ public:
     /**
      * Initialize this radio transceiver.
      *
-     * @param[in]  aResetRadio            TRUE to reset on init, FALSE to not reset on init.
-     * @param[in]  aRestoreDatasetFromNcp TRUE to restore dataset to host from non-volatile memory
-     *                                    (only used when attempts to upgrade from NCP to RCP mode),
-     *                                    FALSE otherwise.
+     * @param[in]  aResetRadio                 TRUE to reset on init, FALSE to not reset on init.
+     * @param[in]  aRestoreDatasetFromNcp      TRUE to restore dataset to host from non-volatile memory
+     *                                         (only used when attempts to upgrade from NCP to RCP mode),
+     *                                         FALSE otherwise.
+     * @param[in]  aSkipRcpCompatibilityCheck  TRUE to skip RCP compatibility check, FALSE to perform the check.
      *
      */
-    void Init(bool aResetRadio, bool aRestoreDataSetFromNcp);
+    void Init(bool aResetRadio, bool aRestoreDataSetFromNcp, bool aSkipRcpCompatibilityCheck);
 
     /**
      * Deinitialize this radio transceiver.

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -220,7 +220,9 @@ RadioSpinel<InterfaceType, ProcessContextType>::RadioSpinel(void)
 }
 
 template <typename InterfaceType, typename ProcessContextType>
-void RadioSpinel<InterfaceType, ProcessContextType>::Init(bool aResetRadio, bool aRestoreDatasetFromNcp)
+void RadioSpinel<InterfaceType, ProcessContextType>::Init(bool aResetRadio,
+                                                          bool aRestoreDatasetFromNcp,
+                                                          bool aSkipRcpCompatibilityCheck)
 {
     otError error = OT_ERROR_NONE;
     bool    supportsRcpApiVersion;
@@ -253,8 +255,11 @@ void RadioSpinel<InterfaceType, ProcessContextType>::Init(bool aResetRadio, bool
         DieNow(exitCode);
     }
 
-    SuccessOrDie(CheckRcpApiVersion(supportsRcpApiVersion));
-    SuccessOrDie(CheckRadioCapabilities());
+    if (!aSkipRcpCompatibilityCheck)
+    {
+        SuccessOrDie(CheckRcpApiVersion(supportsRcpApiVersion));
+        SuccessOrDie(CheckRadioCapabilities());
+    }
 
     mRxRadioFrame.mPsdu  = mRxPsdu;
     mTxRadioFrame.mPsdu  = mTxPsdu;

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -92,9 +92,10 @@ void otPlatRadioSetPromiscuous(otInstance *aInstance, bool aEnable)
 
 void platformRadioInit(otUrl *aRadioUrl)
 {
-    ot::Posix::RadioUrl &radioUrl       = *static_cast<ot::Posix::RadioUrl *>(aRadioUrl);
-    bool                 resetRadio     = (radioUrl.GetValue("no-reset") == nullptr);
-    bool                 restoreDataset = (radioUrl.GetValue("ncp-dataset") != nullptr);
+    ot::Posix::RadioUrl &radioUrl               = *static_cast<ot::Posix::RadioUrl *>(aRadioUrl);
+    bool                 resetRadio             = (radioUrl.GetValue("no-reset") == nullptr);
+    bool                 restoreDataset         = (radioUrl.GetValue("ncp-dataset") != nullptr);
+    bool                 skipCompatibilityCheck = (radioUrl.GetValue("skip-rcp-compatibility-check") != nullptr);
     const char *         parameterValue;
     const char *         region;
 #if OPENTHREAD_POSIX_CONFIG_MAX_POWER_TABLE_ENABLE
@@ -102,7 +103,7 @@ void platformRadioInit(otUrl *aRadioUrl)
 #endif
 
     SuccessOrDie(sRadioSpinel.GetSpinelInterface().Init(radioUrl));
-    sRadioSpinel.Init(resetRadio, restoreDataset);
+    sRadioSpinel.Init(resetRadio, restoreDataset, skipCompatibilityCheck);
 
     parameterValue = radioUrl.GetValue("fem-lnagain");
     if (parameterValue != nullptr)

--- a/src/posix/platform/radio_url.cpp
+++ b/src/posix/platform/radio_url.cpp
@@ -92,7 +92,8 @@ const char *otSysGetRadioUrlHelpString(void)
            "    cca-threshold[=dbm]           Set the radio's CCA ED threshold in dBm measured at antenna connector.\n"
            "    fem-lnagain[=dbm]             Set the Rx LNA gain in dBm of the external FEM.\n"
            "    ncp-dataset                   Retrieve dataset from ncp.\n"
-           "    no-reset                      Do not send Spinel reset command to RCP on initialization.\n";
+           "    no-reset                      Do not send Spinel reset command to RCP on initialization.\n"
+           "    skip-rcp-compatibility-check  Skip checking RCP API version and capabilities during initialization.\n";
 }
 
 namespace ot {


### PR DESCRIPTION
This commit adds new option to skip RCP API version and capability
compatibility check during initialization. The radio URL key
`skip-rcp-compatibility-check` can be used to enable this behavior.
This is only intended for situations where RCP won't be operating as a
radio (e.g., host trying to perform an RCP firmware update).

----

Resolves #6042