### PR TITLE
[github-actions] upload core dump only when crash happens

### DIFF
--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -90,12 +90,9 @@ jobs:
     - uses: actions/upload-artifact@v2
       if: ${{ failure() && env.CRASHED == '1' }}
       with:
-        name: core-packet-verification-low-power
+        name: core-packet-verification-thread-1-2
         path: |
-          ./build/openthread-simulation-1.2/examples/apps/cli/ot-cli-*
-          ./build/openthread-simulation-1.1/examples/apps/cli/ot-cli-*
           ./ot-core-dump/*
-          ./so-lib/*
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage "${{ matrix.compiler.gcov }}"
@@ -155,10 +152,7 @@ jobs:
       with:
         name: core-packet-verification-low-power
         path: |
-          ./build/openthread-simulation-1.2/examples/apps/cli/ot-cli-*
-          ./build/openthread-simulation-1.1/examples/apps/cli/ot-cli-*
           ./ot-core-dump/*
-          ./so-lib/*
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc
@@ -239,11 +233,7 @@ jobs:
       with:
         name: core-expect-1-2
         path: |
-          ./build/openthread-simulation-1.2/examples/apps/cli/ot-cli-mtd
-          ./build/openthread-simulation-1.2/examples/apps/ncp/ot-rcp
-          ./build/openthread-posix-1.2/src/posix/ot-cli
           ./ot-core-dump/*
-          ./so-lib/*
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc

--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -76,15 +76,26 @@ jobs:
         ./script/test prepare_coredump_upload
         ./script/test unit
         ./script/test cert_suite tests/scripts/thread-cert/v1_2_*
-    - name: Copy Shared Libraries
+    - name: Check Crash
       if: ${{ failure() }}
       run: |
-          ./script/test copy_so_lib
+          CRASHED=$(./script/test check_crash | tail -1)
+          [[ $CRASHED -eq "1" ]] && echo "Crashed!" || echo "Not crashed."
+          echo "CRASHED=$CRASHED" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
         name: thread-1-2-${{ matrix.compiler.c }}-${{ matrix.arch }}-pcaps
         path: "*.pcap"
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() && env.CRASHED == '1' }}
+      with:
+        name: core-packet-verification-low-power
+        path: |
+          ./build/openthread-simulation-1.2/examples/apps/cli/ot-cli-*
+          ./build/openthread-simulation-1.1/examples/apps/cli/ot-cli-*
+          ./ot-core-dump/*
+          ./so-lib/*
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage "${{ matrix.compiler.gcov }}"
@@ -126,10 +137,12 @@ jobs:
         do
           ./script/test cert_suite ./tests/scripts/thread-cert/v1_2_LowPower*.py
         done
-    - name: Copy Shared Libraries
+    - name: Check Crash
       if: ${{ failure() }}
       run: |
-          ./script/test copy_so_lib
+          CRASHED=$(./script/test check_crash | tail -1)
+          [[ $CRASHED -eq "1" ]] && echo "Crashed!" || echo "Not crashed."
+          echo "CRASHED=$CRASHED" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:
@@ -138,7 +151,7 @@ jobs:
           *.pcap
           *.json
     - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
+      if: ${{ failure() && env.CRASHED == '1' }}
       with:
         name: core-packet-verification-low-power
         path: |
@@ -215,12 +228,14 @@ jobs:
         ulimit -c unlimited
         ./script/test prepare_coredump_upload
         OT_OPTIONS=-DOT_READLINE=OFF OT_NODE_TYPE=rcp ./script/test build expect
-    - name: Copy Shared Libraries
+    - name: Check Crash
       if: ${{ failure() }}
       run: |
-          ./script/test copy_so_lib
+          CRASHED=$(./script/test check_crash | tail -1)
+          [[ $CRASHED -eq "1" ]] && echo "Crashed!" || echo "Not crashed."
+          echo "CRASHED=$CRASHED" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
+      if: ${{ failure() && env.CRASHED == '1' }}
       with:
         name: core-expect-1-2
         path: |

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -333,9 +333,9 @@ jobs:
       with:
         name: core-expect-rcp
         path: |
-          ./build/openthread-simulation-1.2/examples/apps/cli/ot-cli-mtd
-          ./build/openthread-simulation-1.2/examples/apps/ncp/ot-rcp
-          ./build/openthread-posix-1.2/src/posix/ot-cli
+          ./build/openthread-simulation-1.1/examples/apps/cli/ot-cli-mtd
+          ./build/openthread-simulation-1.1/examples/apps/ncp/ot-rcp
+          ./build/openthread-posix-1.1/src/posix/ot-cli
           ./ot-core-dump/*
           ./so-lib/*
     - name: Generate Coverage

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -296,12 +296,14 @@ jobs:
         ulimit -c unlimited
         ./script/test prepare_coredump_upload
         OT_OPTIONS='-DOT_TIME_SYNC=ON -DOT_FULL_LOGS=ON -DOT_LOG_OUTPUT=PLATFORM_DEFINED' VIRTUAL_TIME=0 ./script/test build expect
-    - name: Copy Shared Libraries
+    - name: Check Crash
       if: ${{ failure() }}
       run: |
-          ./script/test copy_so_lib
+          CRASHED=$(./script/test check_crash | tail -1)
+          [[ $CRASHED -eq "1" ]] && echo "Crashed!" || echo "Not crashed."
+          echo "CRASHED=$CRASHED" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
+      if: ${{ failure() && env.CRASHED == '1' }}
       with:
         name: core-expect-cli
         path: |
@@ -320,6 +322,22 @@ jobs:
         ulimit -c unlimited
         ./script/test prepare_coredump_upload
         OT_OPTIONS='-DOT_READLINE=OFF -DOT_FULL_LOGS=ON -DOT_LOG_OUTPUT=PLATFORM_DEFINED' VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
+    - name: Check Crash
+      if: ${{ failure() }}
+      run: |
+          CRASHED=$(./script/test check_crash | tail -1)
+          [[ $CRASHED -eq "1" ]] && echo "Crashed!" || echo "Not crashed."
+          echo "CRASHED=$CRASHED" >> $GITHUB_ENV
+    - uses: actions/upload-artifact@v2
+      if: ${{ failure() && env.CRASHED == '1' }}
+      with:
+        name: core-expect-rcp
+        path: |
+          ./build/openthread-simulation-1.2/examples/apps/cli/ot-cli-mtd
+          ./build/openthread-simulation-1.2/examples/apps/ncp/ot-rcp
+          ./build/openthread-posix-1.2/src/posix/ot-cli
+          ./ot-core-dump/*
+          ./so-lib/*
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc
@@ -340,12 +358,14 @@ jobs:
         ulimit -c unlimited
         ./script/test prepare_coredump_upload
         OT_OPTIONS='-DOT_READLINE=OFF -DOT_FULL_LOGS=ON -DOT_LOG_OUTPUT=PLATFORM_DEFINED' OT_NATIVE_IP=1 VIRTUAL_TIME=0 OT_NODE_TYPE=rcp ./script/test clean build expect
-    - name: Copy Shared Libraries
+    - name: Check Crash
       if: ${{ failure() }}
       run: |
-          ./script/test copy_so_lib
+          CRASHED=$(./script/test check_crash | tail -1)
+          [[ $CRASHED -eq "1" ]] && echo "Crashed!" || echo "Not crashed."
+          echo "CRASHED=$CRASHED" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v2
-      if: ${{ failure() }}
+      if: ${{ failure() && env.CRASHED == '1' }}
       with:
         name: core-expect-posix
         path: |

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -307,9 +307,7 @@ jobs:
       with:
         name: core-expect-cli
         path: |
-          ./build/openthread-simulation-1.1/examples/apps/cli/ot-cli-ftd
           ./ot-core-dump/*
-          ./so-lib/*
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc
@@ -333,11 +331,7 @@ jobs:
       with:
         name: core-expect-rcp
         path: |
-          ./build/openthread-simulation-1.1/examples/apps/cli/ot-cli-mtd
-          ./build/openthread-simulation-1.1/examples/apps/ncp/ot-rcp
-          ./build/openthread-posix-1.1/src/posix/ot-cli
           ./ot-core-dump/*
-          ./so-lib/*
     - name: Generate Coverage
       run: |
         ./script/test generate_coverage gcc
@@ -369,10 +363,7 @@ jobs:
       with:
         name: core-expect-posix
         path: |
-          ./build/openthread-simulation-1.1/examples/apps/ncp/ot-rcp
-          ./build/openthread-posix-1.1/src/posix/ot-cli
           ./ot-core-dump/*
-          ./so-lib/*
     - uses: actions/upload-artifact@v2
       if: ${{ failure() }}
       with:

--- a/.github/workflows/simulation.yml
+++ b/.github/workflows/simulation.yml
@@ -301,9 +301,9 @@ jobs:
       run: |
           CRASHED=$(./script/test check_crash | tail -1)
           [[ $CRASHED -eq "1" ]] && echo "Crashed!" || echo "Not crashed."
-          echo "CRASHED=$CRASHED" >> $GITHUB_ENV
+          echo "CRASHED_CLI=$CRASHED" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v2
-      if: ${{ failure() && env.CRASHED == '1' }}
+      if: ${{ failure() && env.CRASHED_CLI == '1' }}
       with:
         name: core-expect-cli
         path: |
@@ -327,9 +327,9 @@ jobs:
       run: |
           CRASHED=$(./script/test check_crash | tail -1)
           [[ $CRASHED -eq "1" ]] && echo "Crashed!" || echo "Not crashed."
-          echo "CRASHED=$CRASHED" >> $GITHUB_ENV
+          echo "CRASHED_RCP=$CRASHED" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v2
-      if: ${{ failure() && env.CRASHED == '1' }}
+      if: ${{ failure() && env.CRASHED_RCP == '1' }}
       with:
         name: core-expect-rcp
         path: |
@@ -363,9 +363,9 @@ jobs:
       run: |
           CRASHED=$(./script/test check_crash | tail -1)
           [[ $CRASHED -eq "1" ]] && echo "Crashed!" || echo "Not crashed."
-          echo "CRASHED=$CRASHED" >> $GITHUB_ENV
+          echo "CRASHED_TUN=$CRASHED" >> $GITHUB_ENV
     - uses: actions/upload-artifact@v2
-      if: ${{ failure() && env.CRASHED == '1' }}
+      if: ${{ failure() && env.CRASHED_TUN == '1' }}
       with:
         name: core-expect-posix
         path: |

--- a/script/test
+++ b/script/test
@@ -392,6 +392,7 @@ do_package()
 do_prepare_coredump_upload()
 {
     echo "$PWD/ot-core-dump/corefile-%e-%p-%t" | sudo tee /proc/sys/kernel/core_pattern
+    rm -rf ot-core-dump
     mkdir -p ot-core-dump
 }
 

--- a/script/test
+++ b/script/test
@@ -403,6 +403,13 @@ do_copy_so_lib()
     cp /lib64/ld-linux-x86-64.so.2 ./so-lib
 }
 
+do_check_crash()
+{
+    CRASHED=$([[ $(ls ./ot-core-dump 2>/dev/null) ]] && echo 1 || echo 0)
+    echo "$CRASHED"
+    [[ $CRASHED -eq "1" ]] && do_copy_so_lib
+}
+
 do_generate_coverage()
 {
     mkdir -p tmp/
@@ -554,8 +561,8 @@ main()
             prepare_coredump_upload)
                 do_prepare_coredump_upload
                 ;;
-            copy_so_lib)
-                do_copy_so_lib
+            check_crash)
+                do_check_crash
                 ;;
             generate_coverage)
                 shift

--- a/script/test
+++ b/script/test
@@ -46,6 +46,8 @@ readonly INTER_OP="${INTER_OP:-0}"
 readonly VERBOSE="${VERBOSE:-0}"
 readonly BORDER_ROUTING="${BORDER_ROUTING:-1}"
 
+readonly OT_COREDUMP_DIR="${PWD}/ot-core-dump"
+
 build_simulation()
 {
     local version="$1"
@@ -391,24 +393,47 @@ do_package()
 
 do_prepare_coredump_upload()
 {
-    echo "$PWD/ot-core-dump/corefile-%e-%p-%t" | sudo tee /proc/sys/kernel/core_pattern
-    rm -rf ot-core-dump
-    mkdir -p ot-core-dump
+    echo "$OT_COREDUMP_DIR/corefile-%e-%p-%t" | sudo tee /proc/sys/kernel/core_pattern
+    rm -rf "$OT_COREDUMP_DIR"
+    mkdir -p "$OT_COREDUMP_DIR"
 }
 
 do_copy_so_lib()
 {
-    mkdir -p so-lib
-    cp /lib/x86_64-linux-gnu/libgcc_s.so.1 ./so-lib
-    cp /lib/x86_64-linux-gnu/libc.so.6 ./so-lib
-    cp /lib64/ld-linux-x86-64.so.2 ./so-lib
+    mkdir -p "$OT_COREDUMP_DIR/so-lib"
+    cp /lib/x86_64-linux-gnu/libgcc_s.so.1 "$OT_COREDUMP_DIR/so-lib"
+    cp /lib/x86_64-linux-gnu/libc.so.6 "$OT_COREDUMP_DIR/so-lib"
+    cp /lib64/ld-linux-x86-64.so.2 "$OT_COREDUMP_DIR/so-lib"
 }
 
 do_check_crash()
 {
-    CRASHED=$([[ $(ls ./ot-core-dump 2>/dev/null) ]] && echo 1 || echo 0)
-    echo "$CRASHED"
-    [[ $CRASHED -eq "1" ]] && do_copy_so_lib
+    shopt -s nullglob
+
+    # Scan core dumps and collect binaries which crashed
+    declare -A bin_list=([dummy]='')
+    for f in "$OT_COREDUMP_DIR"/core*; do
+        bin=$(file "$f" | grep -E -o "execfn: '(.*')," | sed -r "s/execfn: '(.*)',/\1/")
+        bin_list[$bin]=''
+    done
+
+    for key in "${!bin_list[@]}"; do
+        if [ "$key" != "dummy" ]; then
+            # Add postfix for binaries to avoid conflicts caused by different Thread version
+            postfix=""
+            if [[ $key =~ openthread-(simulation|posix)-([0-9]\.[0-9]) ]]; then
+                postfix="-$(echo "$key" | sed -r "s/.*openthread-(simulation|posix)-([0-9]\.[0-9]).*/\2/")"
+            fi
+            bin_name=$(basename "$key")
+            cp "$key" "$OT_COREDUMP_DIR"/"$bin_name""$postfix"
+        fi
+    done
+
+    # echo 1 and copy so libs if crash found, echo 0 otherwise
+    [[ ${#bin_list[@]} -gt 1 ]] && (
+        echo 1
+        do_copy_so_lib
+    ) || echo 0
 }
 
 do_generate_coverage()


### PR DESCRIPTION
Currently when a test fails, the core dump uploading action would be executed. (Even when there's no core dump, the binaries and so libs would be uploaded, which is a waste.)

This PR uses env variables of github actions to only execute the uploading action when crash actually happens.