### PR TITLE
[efr32] fix for trng entropy API

### DIFF
--- a/examples/platforms/efr32/src/entropy.c
+++ b/examples/platforms/efr32/src/entropy.c
@@ -51,7 +51,6 @@ otError otPlatEntropyGet(uint8_t *aOutput, uint16_t aOutputLength)
         // Non-zero return values for mbedtls_hardware_poll() signify an error has occurred
         otEXPECT_ACTION(0 == mbedtls_hardware_poll(NULL, &aOutput[outputLen], remaining, &partialLen),
                         error = OT_ERROR_FAILED);
-        otEXPECT_ACTION(partialLen > 0, error = OT_ERROR_FAILED);
     }
 
 exit:


### PR DESCRIPTION
When obtaining entropy data, trng_get_random checks the status for any noise, and if so, cleans its queues and keeps the entropy accumulator of mbedtls running.

In the process, TRNG might not have any new samples available, so a zero length output is valid, and we should keep running rather than exit fatally.

Resolves #6013