### PR TITLE
[udp] platform UDP sending depending on the 'IsHostInterface' flag

### DIFF
--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -372,7 +372,7 @@ otError Udp::SendTo(SocketHandle &aSocket, Message &aMessage, const MessageInfo 
     messageInfoLocal.SetSockPort(aSocket.GetSockName().mPort);
 
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
-    if (ShouldUsePlatformUdp(aSocket))
+    if (ShouldUsePlatformUdp(aSocket) && messageInfoLocal.IsHostInterface())
     {
         SuccessOrExit(error = otPlatUdpSend(&aSocket, &aMessage, &messageInfoLocal));
     }


### PR DESCRIPTION
The problem with current implementation is that:
When `PLATFORM_UDP` is enabled and a custom UDP server is started with `socket.Bind(0)`, the server can receives datagrams from both host interface and Thread interface, but the responses are always sent via the platform UDP.

I think whether a UDP message should be sent via host interface or Thread interface should be determined by the `IsHostInterface` flag.