### PR TITLE
[otci] get prefixes/routes/services in thread network data

### DIFF
--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -1016,8 +1016,8 @@ class OTCI(object):
     #
     # Network Data utilities
     #
-    def get_prefixes(self) -> List[Tuple[Ip6Prefix, str, str, Rloc16]]:
-        """Get the prefix list in the local Network Data."""
+    def get_local_prefixes(self) -> List[Tuple[Ip6Prefix, str, str, Rloc16]]:
+        """Get prefixes from local Network Data."""
         output = self.execute_command('prefix')
         return self.__parse_prefixes(output)
 
@@ -1070,11 +1070,25 @@ class OTCI(object):
             else:
                 routes_output.append(line)
 
-        print('routes_output:', routes_output, output)
         netdata['routes'] = self.__parse_routes(routes_output)
         netdata['services'] = self.__parse_services(output)
 
         return netdata
+
+    def get_prefixes(self) -> List[Tuple[Ip6Prefix, str, str, Rloc16]]:
+        """Get network prefixes from Thread Network Data."""
+        network_data = self.get_network_data()
+        return network_data['prefixes']
+
+    def get_routes(self) -> List[Tuple[str, bool, str, Rloc16]]:
+        """Get routes from Thread Network Data."""
+        network_data = self.get_network_data()
+        return network_data['routes']
+
+    def get_services(self) -> List[Tuple[int, bytes, bytes, bool, Rloc16]]:
+        """Get services from Thread Network Data"""
+        network_data = self.get_network_data()
+        return network_data['services']
 
     def __parse_services(self, output: List[str]) -> List[Tuple[int, bytes, bytes, bool, Rloc16]]:
         services = []
@@ -1101,8 +1115,8 @@ class OTCI(object):
         hexstr = self.__parse_str(self.execute_command('netdata show -x'))
         return bytes(int(hexstr[i:i + 2], 16) for i in range(0, len(hexstr), 2))
 
-    def get_routes(self) -> List[Tuple[str, bool, str, Rloc16]]:
-        """Get the external route list in the local Network Data."""
+    def get_local_routes(self) -> List[Tuple[str, bool, str, Rloc16]]:
+        """Get routes from local Network Data."""
         return self.__parse_routes(self.execute_command('route'))
 
     def __parse_routes(self, output: List[str]) -> List[Tuple[str, bool, str, Rloc16]]:

--- a/tools/otci/tests/test_otci.py
+++ b/tools/otci/tests/test_otci.py
@@ -252,10 +252,10 @@ class TestOTCI(unittest.TestCase):
         logging.info("leader data: %r", leader.get_leader_data())
         logging.info("leader neighbor list: %r", leader.get_neighbor_list())
         logging.info("leader neighbor table: %r", leader.get_neighbor_table())
-        logging.info("Leader external routes: %r", leader.get_routes())
+        logging.info("Leader external routes: %r", leader.get_local_routes())
         leader.add_route('2002::/64')
         leader.register_network_data()
-        logging.info("Leader external routes: %r", leader.get_routes())
+        logging.info("Leader external routes: %r", leader.get_local_routes())
 
         self.assertEqual(1, len(leader.get_router_list()))
         self.assertEqual(1, len(leader.get_router_table()))
@@ -272,6 +272,12 @@ class TestOTCI(unittest.TestCase):
 
         logging.info("network data: %r", leader.get_network_data())
         logging.info("network data raw: %r", leader.get_network_data_bytes())
+        self.assertEqual(leader.get_network_data()['prefixes'] == leader.get_prefixes())
+        self.assertEqual(leader.get_network_data()['routes'] == leader.get_routes())
+        self.assertEqual(leader.get_network_data()['services'] == leader.get_services())
+
+        logging.info("local prefixes: %r", leader.get_local_prefixes())
+        logging.info("local routes: %r", leader.get_local_routes())
 
         logging.info('txpower %r', leader.get_txpower())
         leader.set_txpower(-10)
@@ -491,11 +497,11 @@ class TestOTCI(unittest.TestCase):
 
         logging.info("leader neighbor list: %r", leader.get_neighbor_list())
         logging.info("leader neighbor table: %r", leader.get_neighbor_table())
-        logging.info("prefixes: %r", commissioner.get_prefixes())
+        logging.info("prefixes: %r", commissioner.get_local_prefixes())
         commissioner.add_prefix('2001::/64')
         commissioner.register_network_data()
         commissioner.wait(1)
-        logging.info("prefixes: %r", commissioner.get_prefixes())
+        logging.info("prefixes: %r", commissioner.get_local_prefixes())
 
         self.assertEqual(2, len(leader.get_router_list()))
         self.assertEqual(2, len(leader.get_router_table()))

--- a/tools/otci/tests/test_otci.py
+++ b/tools/otci/tests/test_otci.py
@@ -272,9 +272,9 @@ class TestOTCI(unittest.TestCase):
 
         logging.info("network data: %r", leader.get_network_data())
         logging.info("network data raw: %r", leader.get_network_data_bytes())
-        self.assertEqual(leader.get_network_data()['prefixes'] == leader.get_prefixes())
-        self.assertEqual(leader.get_network_data()['routes'] == leader.get_routes())
-        self.assertEqual(leader.get_network_data()['services'] == leader.get_services())
+        self.assertEqual(leader.get_network_data()['prefixes'], leader.get_prefixes())
+        self.assertEqual(leader.get_network_data()['routes'], leader.get_routes())
+        self.assertEqual(leader.get_network_data()['services'], leader.get_services())
 
         logging.info("local prefixes: %r", leader.get_local_prefixes())
         logging.info("local routes: %r", leader.get_local_routes())


### PR DESCRIPTION
This commit changes these methods to return corresponding entries from Thread Network Data rather than local network data.
- get_prefixes
- get_routes
- get_services

Added local version to retrieve entries from local network data.
- get_local_prefixes
- get_local_routes