### PR TITLE
[tests] fix expecting command output

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -499,7 +499,7 @@ class NodeImpl:
         cmd_output_started = False
 
         while True:
-            self._expect(r"[^\n]+")
+            self._expect(r"[^\n]+\n")
             line = self.pexpect.match.group(0).decode('utf8').strip()
 
             if line.startswith('> '):


### PR DESCRIPTION
The `_expect_command_output(self, ...)` doesn't match exactly one line, it may returns a line in several splits. This commit fixes this issue.