### PR TITLE
[bootstrap] fix gcc-arm-none-eabi install

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -68,7 +68,7 @@ install_packages_apt()
         sudo apt-get --no-install-recommends install -y ca-certificates wget
         (cd /tmp \
             && wget -c https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 \
-            && tar xjf gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 -C /opt\
+            && tar xjf gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 -C /opt \
             && rm gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 \
             && sudo ln -s /opt/gcc-arm-none-eabi-9-2020-q2-update/bin/* /usr/local/bin/.)
     fi

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -68,7 +68,7 @@ install_packages_apt()
         sudo apt-get --no-install-recommends install -y ca-certificates wget
         (cd /tmp \
             && wget -c https://developer.arm.com/-/media/Files/downloads/gnu-rm/9-2020q2/gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 \
-            && tar xjf gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 \
+            && tar xjf gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 -C /opt\
             && rm gcc-arm-none-eabi-9-2020-q2-update-x86_64-linux.tar.bz2 \
             && sudo ln -s /opt/gcc-arm-none-eabi-9-2020-q2-update/bin/* /usr/local/bin/.)
     fi


### PR DESCRIPTION
Added fix to extract archive to /opt rather than current directory which is /tmp

Fixes #6080 