### PR TITLE
[script] script/test cert with multiple arguments

### DIFF
--- a/script/test
+++ b/script/test
@@ -192,7 +192,7 @@ do_cert()
     fi
 
     [[ ! -d tmp ]] || rm -rvf tmp
-    PYTHONUNBUFFERED=1 "$1"
+    PYTHONUNBUFFERED=1 "$@"
 }
 
 do_cert_suite()
@@ -555,11 +555,13 @@ main()
                 ;;
             cert)
                 shift
-                do_cert "$1"
+                do_cert "$@"
+                shift $#
                 ;;
             cert_suite)
                 shift
                 do_cert_suite "$@"
+                shift $#
                 ;;
             get_thread_wireshark)
                 do_get_thread_wireshark


### PR DESCRIPTION
This commit allows specifying multiple arguments for `script/test cert path/to/script.py`.

This is useful for running a selected test case when the test script contains multiple test cases. 