### PR TITLE
[otns] fix compile issue when log region CORE is enabled

### DIFF
--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -38,6 +38,7 @@
 
 #include "common/debug.hpp"
 #include "common/locator-getters.hpp"
+#include "common/logging.hpp"
 
 namespace ot {
 namespace Utils {


### PR DESCRIPTION
This commit fixes an compile issue in otns.cpp when log region `CORE` is enabled. 