### PR TITLE
[scripts] add option to not build bbr when building 1.2

### DIFF
--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -68,7 +68,6 @@ jobs:
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
       run: |
-        ./bootstrap
         ./script/test build
     - name: Run
       run: |
@@ -111,6 +110,7 @@ jobs:
       THREAD_VERSION: 1.2
       MAC_FILTER: 1
       INTER_OP: 1
+      INTER_OP_BBR: 0
     steps:
     - uses: actions/checkout@v2
       with:

--- a/script/test
+++ b/script/test
@@ -45,6 +45,7 @@ readonly THREAD_VERSION="${THREAD_VERSION:-1.1}"
 readonly INTER_OP="${INTER_OP:-0}"
 readonly VERBOSE="${VERBOSE:-0}"
 readonly BORDER_ROUTING="${BORDER_ROUTING:-1}"
+readonly INTER_OP_BBR="${INTER_OP_BBR:-1}"
 
 readonly OT_COREDUMP_DIR="${PWD}/ot-core-dump"
 
@@ -78,7 +79,7 @@ build_simulation()
 
     OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/openthread-simulation-${version}" "${OT_SRCDIR}"/script/cmake-build simulation "${options[@]}"
 
-    if [[ ${version} == "1.2" ]]; then
+    if [[ ${version} == "1.2" && ${INTER_OP_BBR} == 1 ]]; then
 
         options+=("-DOT_BACKBONE_ROUTER=ON")
 
@@ -111,7 +112,7 @@ build_posix()
 
     OT_CMAKE_BUILD_DIR="${OT_BUILDDIR}/openthread-posix-${version}" "${OT_SRCDIR}"/script/cmake-build posix "${options[@]}"
 
-    if [[ ${version} == "1.2" ]]; then
+    if [[ ${version} == "1.2" && ${INTER_OP_BBR} == 1 ]]; then
 
         options+=("-DOT_BACKBONE_ROUTER=ON")
 
@@ -165,7 +166,7 @@ do_unit()
 {
     do_unit_version "${THREAD_VERSION}"
 
-    if [[ ${THREAD_VERSION} == "1.2" ]]; then
+    if [[ ${THREAD_VERSION} == "1.2" && ${INTER_OP_BBR} == 1 ]]; then
         do_unit_version "1.2-bbr"
     fi
 }

--- a/script/test
+++ b/script/test
@@ -328,6 +328,7 @@ ENVIRONMENTS:
     VIRTUAL_TIME    1 for virtual time, otherwise real time. The default is 1.
     THREAD_VERSION  1.1 for Thread 1.1 stack, 1.2 for Thread 1.2 stack. The default is 1.1.
     INTER_OP        1 to build 1.1 together. Only works when THREAD_VERSION is 1.2. The default is 0.
+    INTER_OP_BBR    1 to build bbr version together. Only works when THREAD_VERSION is 1.2. The default is 1.
 
 COMMANDS:
     clean           Clean built files to prepare for new build.


### PR DESCRIPTION
Currently when we build 1.2 binaries using `script/test`, we build it twice (one only with Low Power features, one only with Backbone Router feature).
As I remember,we separate it because when we implement it, we do the work individually. I think now it's not necessary to separate it anymore. We can always build one version and test all 1.2 features with it.