### PR TITLE
[mesh-forwarder] remove unused UpdateIndirectMessages() declaration

### DIFF
--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -235,12 +235,6 @@ public:
     void SetDiscoverParameters(const Mac::ChannelMask &aScanChannels);
 
     /**
-     * This method frees any indirect messages queued for children that are no longer attached.
-     *
-     */
-    void UpdateIndirectMessages(void);
-
-    /**
      * This method frees any messages queued for an existing child.
      *
      * @param[in]  aChild    A reference to the child.


### PR DESCRIPTION
This method doesn't have definition and is not used anywhere.