### PR TITLE
[dns-header] fix 'ParseName()' when header offset is non-zero

### DIFF
--- a/src/core/net/dns_headers.cpp
+++ b/src/core/net/dns_headers.cpp
@@ -205,7 +205,7 @@ otError Name::ParseName(const Message &aMessage, uint16_t &aOffset)
 
     while (true)
     {
-        error = iterator.GetNextLabel();
+        error = iterator.GetNextLabel(/* aStopOnEndOffsetSet */ true);
 
         VerifyOrExit((error == OT_ERROR_NONE) || (error == OT_ERROR_NOT_FOUND));
 
@@ -293,7 +293,7 @@ exit:
     return error;
 }
 
-otError Name::LabelIterator::GetNextLabel(void)
+otError Name::LabelIterator::GetNextLabel(bool aStopOnEndOffsetSet)
 {
     otError error;
 
@@ -338,6 +338,7 @@ otError Name::LabelIterator::GetNextLabel(void)
             if (!IsEndOffsetSet())
             {
                 mNameEndOffset = mNextLabelOffset + sizeof(uint16_t);
+                VerifyOrExit(!aStopOnEndOffsetSet);
             }
 
             mNextLabelOffset = mHeaderOffset + (HostSwap16(pointerValue) & kPointerLabelOffsetMask);

--- a/src/core/net/dns_headers.hpp
+++ b/src/core/net/dns_headers.hpp
@@ -697,7 +697,7 @@ private:
         }
 
         bool    IsEndOffsetSet(void) const { return (mNameEndOffset != kUnsetNameEndOffset); }
-        otError GetNextLabel(void);
+        otError GetNextLabel(bool aStopOnEndOffsetSet = false);
         otError ReadLabel(char *aLabelBuffer, uint8_t &aLabelLength, bool aAllowDotCharInLabel) const;
 
         const Message &mMessage;          // Message to read labels from.

--- a/tests/unit/test_dns.cpp
+++ b/tests/unit/test_dns.cpp
@@ -292,7 +292,7 @@ void TestDnsCompressedName(void)
 
     for (uint8_t index = 0; index < kHeaderOffset + kGuardBlockSize; index++)
     {
-        SuccessOrQuit(message->Append(index), "Message::Append() failed");
+        SuccessOrQuit(message->Append(0x80 + index), "Message::Append() failed");
     }
 
     name1Offset = message->GetLength();


### PR DESCRIPTION
This commit fixes an issue with `Dns::Name::ParseName()`. This method
intentionally does not get the header offset (which is used for
parsing compressed DNS names) since its implementation does not need
to read the entire name and can stop as soon as we reach the end of
the current segment of the name. This commit changes `GetNextLabel()`
method adding a new input parameter `aStopOnEndOffsetSet` to stop as
soon as `mNameEndOffset` is found and set on the `Iterator`. This new
parameter is then used by `ParseName()` ensuring that we stop
immediately when we find the end offset and do not continue reading a
next label (jumping to an incorrect offset and potentially reading a
bad label length value and reporting it as a parse error).

The unit test `test_dns` is also updated to catch and cover this
situation by populating the guard region in the start of the message
with `0x80 + index` values which are invalid label length values
(length value's first two bits must be 00 or 11).