### PR TITLE
[posix] bind infra IF socket to specific interface

### DIFF
--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -250,6 +250,13 @@ void platformInfraIfInit(otInstance *aInstance, const char *aIfName)
         DieNow(OT_EXIT_ERROR_ERRNO);
     }
 
+#ifdef __linux__
+    rval = setsockopt(sock, SOL_SOCKET, SO_BINDTODEVICE, sInfraIfName, strlen(sInfraIfName));
+#else  // __NetBSD__ || __FreeBSD__ || __APPLE__
+    rval = setsockopt(sock, IPPROTO_IP, IP_BOUND_IF, &sInfraIfIndex, sizeof(sInfraIfIndex));
+#endif // __linux__
+    VerifyOrDie(rval == 0, OT_EXIT_ERROR_ERRNO);
+
     sInfraIfIcmp6Socket = sock;
     InitLinkLocalAddress();
 }


### PR DESCRIPTION
This is for ensuring sending ICMP6 packets on only the specified infrastructure interface.