### PR TITLE
[posix] logging enhancements to infra if

### DIFF
--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -135,11 +135,7 @@ static void InitLinkLocalAddress(void)
 {
     struct ifaddrs *ifAddrs = nullptr;
 
-    if (getifaddrs(&ifAddrs) < 0)
-    {
-        otLogCritPlat("failed to get netif addresses: %s", strerror(errno));
-        DieNow(OT_EXIT_ERROR_ERRNO);
-    }
+    VerifyOrDie(getifaddrs(&ifAddrs) != -1, OT_EXIT_ERROR_ERRNO);
 
     for (struct ifaddrs *addr = ifAddrs; addr != nullptr; addr = addr->ifa_next)
     {
@@ -191,11 +187,7 @@ void platformInfraIfInit(otInstance *aInstance, const char *aIfName)
 
     // Initializes the ICMPv6 socket.
     sock = socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6);
-    if (sock < 0)
-    {
-        otLogCritPlat("failed to open ICMPv6 socket: %s", strerror(errno));
-        DieNow(OT_EXIT_ERROR_ERRNO);
-    }
+    VerifyOrDie(sock != -1, OT_EXIT_ERROR_ERRNO);
 
     // Only accept router advertisements and router solicits.
     ICMP6_FILTER_SETBLOCKALL(&filter);
@@ -203,52 +195,28 @@ void platformInfraIfInit(otInstance *aInstance, const char *aIfName)
     ICMP6_FILTER_SETPASS(ND_ROUTER_ADVERT, &filter);
 
     rval = setsockopt(sock, IPPROTO_ICMPV6, ICMP6_FILTER, &filter, sizeof(filter));
-    if (rval < 0)
-    {
-        otLogCritPlat("Can't set ICMP6_FILTER: %s", strerror(errno));
-        DieNow(OT_EXIT_ERROR_ERRNO);
-    }
+    VerifyOrDie(rval == 0, OT_EXIT_ERROR_ERRNO);
 
     // We want a source address and interface index.
     rval = setsockopt(sock, IPPROTO_IPV6, IPV6_RECVPKTINFO, &kEnable, sizeof(kEnable));
-    if (rval < 0)
-    {
-        otLogCritPlat("Can't set IPV6_RECVPKTINFO: %s", strerror(errno));
-        DieNow(OT_EXIT_ERROR_ERRNO);
-    }
+    VerifyOrDie(rval == 0, OT_EXIT_ERROR_ERRNO);
 
 #ifdef __linux__
     rval = setsockopt(sock, IPPROTO_RAW, IPV6_CHECKSUM, &kIpv6ChecksumOffset, sizeof(kIpv6ChecksumOffset));
 #else
     rval = setsockopt(sock, IPPROTO_IPV6, IPV6_CHECKSUM, &kIpv6ChecksumOffset, sizeof(kIpv6ChecksumOffset));
 #endif
-    if (rval < 0)
-    {
-        otLogCritPlat("Can't set IPV6_CHECKSUM: %s", strerror(errno));
-        DieNow(OT_EXIT_ERROR_ERRNO);
-    }
+    VerifyOrDie(rval == 0, OT_EXIT_ERROR_ERRNO);
 
     // We need to be able to reject RAs arriving from off-link.
     rval = setsockopt(sock, IPPROTO_IPV6, IPV6_RECVHOPLIMIT, &kEnable, sizeof(kEnable));
-    if (rval < 0)
-    {
-        otLogCritPlat("Can't set IPV6_RECVHOPLIMIT: %s", strerror(errno));
-        DieNow(OT_EXIT_ERROR_ERRNO);
-    }
+    VerifyOrDie(rval == 0, OT_EXIT_ERROR_ERRNO);
 
     rval = setsockopt(sock, IPPROTO_IPV6, IPV6_UNICAST_HOPS, &kHopLimit, sizeof(kHopLimit));
-    if (rval < 0)
-    {
-        otLogCritPlat("Can't set IPV6_UNICAST_HOPS: %s", strerror(errno));
-        DieNow(OT_EXIT_ERROR_ERRNO);
-    }
+    VerifyOrDie(rval == 0, OT_EXIT_ERROR_ERRNO);
 
     rval = setsockopt(sock, IPPROTO_IPV6, IPV6_MULTICAST_HOPS, &kHopLimit, sizeof(kHopLimit));
-    if (rval < 0)
-    {
-        otLogCritPlat("Can't set IPV6_MULTICAST_HOPS: %s", strerror(errno));
-        DieNow(OT_EXIT_ERROR_ERRNO);
-    }
+    VerifyOrDie(rval == 0, OT_EXIT_ERROR_ERRNO);
 
     sInfraIfIcmp6Socket = sock;
     InitLinkLocalAddress();
@@ -278,7 +246,7 @@ exit:
 
 void platformInfraIfProcess(otInstance *aInstance, const fd_set &aReadFdSet)
 {
-    otError  error = OT_ERROR_DROP;
+    otError  error = OT_ERROR_NONE;
     uint8_t  buffer[1500];
     uint16_t bufferLength;
 
@@ -293,6 +261,7 @@ void platformInfraIfProcess(otInstance *aInstance, const fd_set &aReadFdSet)
     struct sockaddr_in6 srcAddr;
     struct in6_addr     dstAddr;
 
+    // It is not an error when there is no input data on the socket.
     VerifyOrExit(sInfraIfIcmp6Socket != -1);
     VerifyOrExit(FD_ISSET(sInfraIfIcmp6Socket, &aReadFdSet));
 
@@ -312,7 +281,7 @@ void platformInfraIfProcess(otInstance *aInstance, const fd_set &aReadFdSet)
     if (rval < 0)
     {
         otLogWarnPlat("failed to receive ICMPv6 message: %s", strerror(errno));
-        ExitNow();
+        ExitNow(error = OT_ERROR_DROP);
     }
 
     bufferLength = static_cast<uint16_t>(rval);
@@ -335,23 +304,22 @@ void platformInfraIfProcess(otInstance *aInstance, const fd_set &aReadFdSet)
         }
     }
 
-    VerifyOrExit(ifIndex == sInfraIfIndex);
+    VerifyOrExit(ifIndex == sInfraIfIndex, error = OT_ERROR_DROP);
 
     // We currently accept only RA & RS messages for the Border Router and it requires that
     // the hoplimit must be 255 and the source address must be a link-local address.
-    VerifyOrExit(hopLimit == 255 && IN6_IS_ADDR_LINKLOCAL(&srcAddr.sin6_addr));
+    VerifyOrExit(hopLimit == 255 && IN6_IS_ADDR_LINKLOCAL(&srcAddr.sin6_addr), error = OT_ERROR_DROP);
 
     // Drop multicast messages sent by ourselves.
-    VerifyOrExit(!otIp6IsAddressEqual(&sInfraIfLinkLocalAddr, reinterpret_cast<otIp6Address *>(&srcAddr.sin6_addr)));
+    VerifyOrExit(!otIp6IsAddressEqual(&sInfraIfLinkLocalAddr, reinterpret_cast<otIp6Address *>(&srcAddr.sin6_addr)),
+                 error = OT_ERROR_DROP);
     otPlatInfraIfRecvIcmp6Nd(aInstance, ifIndex, reinterpret_cast<otIp6Address *>(&srcAddr.sin6_addr), buffer,
                              bufferLength);
-
-    error = OT_ERROR_NONE;
 
 exit:
     if (error != OT_ERROR_NONE)
     {
-        otLogDebgPlat("drop ICMPv6 message");
+        otLogDebgPlat("failed to handle ICMPv6 message: %s", otThreadErrorToString(error));
     }
 }
 


### PR DESCRIPTION
This PR includes two small enhancements to the posix infra if module:
1. simplify logging of socket errors since the `VerifyOrDie` macro already prints the line number and `strerror()`.
2. suppress "drop ICMPv6 message" debug logs when there is no input data to be read on the socket.