### PR TITLE
[build] only build unit tests when FTD is enabled

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,4 +26,6 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
+if(OT_FTD)
 add_subdirectory(unit)
+endif()


### PR DESCRIPTION
Following #5622, build unit tests only when FTD is enabled.

With #5622, we can build MTD only. However the unit tests would still be built in this case and it links the `ftd` lib, which causes a link error. This PR solves this problem.