### PR TITLE
[android] add library `libcutils` for compiling ot-cli and ot-ncp

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -429,6 +429,10 @@ include $(CLEAR_VARS)
 LOCAL_MODULE := ot-cli
 LOCAL_MODULE_TAGS := eng
 
+ifneq ($(ANDROID_NDK),1)
+LOCAL_SHARED_LIBRARIES := libcutils
+endif
+
 LOCAL_C_INCLUDES                                         := \
     $(OPENTHREAD_PROJECT_INCLUDES)                          \
     $(LOCAL_PATH)/include                                   \
@@ -508,6 +512,10 @@ include $(CLEAR_VARS)
 
 LOCAL_MODULE := ot-ncp
 LOCAL_MODULE_TAGS := eng
+
+ifneq ($(ANDROID_NDK),1)
+LOCAL_SHARED_LIBRARIES := libcutils
+endif
 
 LOCAL_C_INCLUDES                                         := \
     $(OPENTHREAD_PROJECT_INCLUDES)                          \


### PR DESCRIPTION
When compiling ot-cli and ot-ncp, the Android.mk will compile
the function `property_get` in `src/core/api/instance_api.cpp`.
The function `property_get` is provided by the library `libcutils`.

GitHub Action uses Android NDK to compile Android.mk, Android NDK
only allows adding the shared library `libcutils` for the library
`ot-core`. However, Android requires to add the shared library
`libutils` for the binary `ot-cli` and `ot-ncp`. Therefore, this PR
uses the macro `ANDROID_NDK` to distinguish these two cases.