### PR TITLE
[otci] get router link information

### DIFF
--- a/tools/otci/otci/types.py
+++ b/tools/otci/otci/types.py
@@ -44,7 +44,7 @@ class Rloc16(int):
     """Represents a RLOC16."""
 
     def __repr__(self):
-        return hex(self)
+        return '0x%04x' % self
 
 
 class PartitionId(int):
@@ -121,6 +121,14 @@ class Ip6Prefix(ipaddress.IPv6Network):
 
 SecurityPolicy = namedtuple('SecurityPolicy', ['rotation_time', 'flags'])
 """Represents a Security Policy configuration."""
+
+
+class RouterTableEntry(dict):
+
+    @property
+    def is_link_established(self):
+        return bool(self['link'])
+
 
 if __name__ == '__main__':
     assert Ip6Addr('2001:0:0:0:0:0:0:1') == '2001::1'

--- a/tools/otci/tests/test_otci.py
+++ b/tools/otci/tests/test_otci.py
@@ -260,6 +260,7 @@ class TestOTCI(unittest.TestCase):
         self.assertEqual(1, len(leader.get_router_list()))
         self.assertEqual(1, len(leader.get_router_table()))
         logging.info("Leader router table: %r", leader.get_router_table())
+        self.assertFalse(list(leader.get_router_table().values())[0].is_link_established)
 
         logging.info('scan: %r', leader.scan())
         logging.info('scan energy: %r', leader.scan_energy())
@@ -499,6 +500,9 @@ class TestOTCI(unittest.TestCase):
 
         self.assertEqual(2, len(leader.get_router_list()))
         self.assertEqual(2, len(leader.get_router_table()))
+        logging.info('leader router table: %r', leader.get_router_table())
+        self.assertEqual({False, True},
+                         set(router.is_link_established for router in leader.get_router_table().values()))
 
         self.assertFalse(leader.is_singleton())
 


### PR DESCRIPTION
This commit adds link information to the router table (i.e. get_router_table()).

**Verified by @jpkavita that this feature works.**