### PR TITLE
[mle] ensure reserved bit in Mode TLV is set

### DIFF
--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -345,10 +345,7 @@ public:
      * @param[in] aMode   A mode TLV bitmask to initialize the `DeviceMode` object.
      *
      */
-    explicit DeviceMode(uint8_t aMode)
-        : mMode(aMode)
-    {
-    }
+    explicit DeviceMode(uint8_t aMode) { Set(aMode); }
 
     /**
      * This constructor initializes a `DeviceMode` object from a given mode configuration structure.


### PR DESCRIPTION
The #5560 removed a need of setting the Secure Request Bit in the Mode TLV and supposed to set this bit to 1 always on transmission.

The reserved bit is set when `DeviceMode::Set()` method is invoked. If application uses MTD library, and does not call `otThreadSetLinkMode()`, stack does not set the reserve bit at all - since it doesn't call above method (even from [constructor](https://github.com/openthread/openthread/blob/master/src/core/thread/mle_types.hpp#L348)).

This PR ensures that reserved bit is set.

Note that i found this problem when End Device continously was deattaching from the parent after Child ID Timeout, and retried attachment procedure. The issue was that End Device [dropped](https://github.com/openthread/openthread/blob/master/src/core/thread/mle.cpp#L3679) `Child Update Response` since the `Mode TLV` sent from the Child was not the same as one sent by the Parent. Basically `Child Update Request` didn't have reserved bit set, while `Child Update Response` had. 

Let me know if you think about different solution, i just aligned the implementation to one in `mle_router.cpp`.