### PR TITLE
[scripts] allow virtual time simulator to `go` less than 1 second

### DIFF
--- a/tests/scripts/thread-cert/simulator.py
+++ b/tests/scripts/thread-cert/simulator.py
@@ -501,7 +501,7 @@ class VirtualTime(BaseSimulator):
 
     def go(self, duration, nodeid=None):
         assert self.current_time == self._pause_time
-        duration = int(duration) * 1000000
+        duration = int(duration * 1000000)
         dbg_print('running for %d us' % duration)
         self._pause_time += duration
         if nodeid:


### PR DESCRIPTION
This commit allows virtual time simulator to `go` (simulate) for less than 1s.