### PR TITLE
[dns] match DNS name with specific domain

### DIFF
--- a/src/core/net/dns_headers.cpp
+++ b/src/core/net/dns_headers.cpp
@@ -545,15 +545,24 @@ bool Name::IsSubDomainOf(const char *aName, const char *aDomain)
     uint16_t nameLength   = StringLength(aName, kMaxLength);
     uint16_t domainLength = StringLength(aDomain, kMaxLength);
 
-    VerifyOrExit(nameLength >= domainLength && domainLength >= 1);
+    if (nameLength > 0 && aName[nameLength - 1] == kLabelSeperatorChar)
+    {
+        --nameLength;
+    }
 
+    if (domainLength > 0 && aDomain[domainLength - 1] == kLabelSeperatorChar)
+    {
+        --domainLength;
+    }
+
+    VerifyOrExit(nameLength >= domainLength);
     aName += nameLength - domainLength;
-    VerifyOrExit(memcmp(aName, aDomain, domainLength) == 0);
 
     if (nameLength > domainLength)
     {
         VerifyOrExit(aName[-1] == kLabelSeperatorChar);
     }
+    VerifyOrExit(memcmp(aName, aDomain, domainLength) == 0);
 
     match = true;
 

--- a/src/core/net/dns_headers.cpp
+++ b/src/core/net/dns_headers.cpp
@@ -539,6 +539,28 @@ bool Name::LabelIterator::CompareLabel(const LabelIterator &aOtherIterator) cons
                                  mLabelLength);
 }
 
+bool Name::IsSubDomainOf(const char *aName, const char *aDomain)
+{
+    bool     match        = false;
+    uint16_t nameLength   = StringLength(aName, kMaxLength);
+    uint16_t domainLength = StringLength(aDomain, kMaxLength);
+
+    VerifyOrExit(nameLength >= domainLength && domainLength >= 1);
+
+    aName += nameLength - domainLength;
+    VerifyOrExit(memcmp(aName, aDomain, domainLength) == 0);
+
+    if (nameLength > domainLength)
+    {
+        VerifyOrExit(aName[-1] == kLabelSeperatorChar);
+    }
+
+    match = true;
+
+exit:
+    return match;
+}
+
 otError ResourceRecord::ParseRecords(const Message &aMessage, uint16_t &aOffset, uint16_t aNumRecords)
 {
     otError error = OT_ERROR_NONE;

--- a/src/core/net/dns_headers.hpp
+++ b/src/core/net/dns_headers.hpp
@@ -888,6 +888,17 @@ public:
      */
     static otError CompareName(const Message &aMessage, uint16_t &aOffset, const Name &aName);
 
+    /**
+     * This static method tests if a DNS name is a sub-domain of a given domain.
+     *
+     * @param[in]  aName    The dot-separated name.
+     * @param[in]  aDomain  THe dot-separated domain.
+     *
+     * @returns  TRUE if the name is a sub-domain of @p aDomain, FALSE if is not.
+     *
+     */
+    static bool IsSubDomainOf(const char *aName, const char *aDomain);
+
 private:
     enum : char
     {

--- a/src/core/net/dns_headers.hpp
+++ b/src/core/net/dns_headers.hpp
@@ -891,8 +891,10 @@ public:
     /**
      * This static method tests if a DNS name is a sub-domain of a given domain.
      *
+     * Both @p aName and @p aDomain can end without dot ('.').
+     *
      * @param[in]  aName    The dot-separated name.
-     * @param[in]  aDomain  THe dot-separated domain.
+     * @param[in]  aDomain  The dot-separated domain.
      *
      * @returns  TRUE if the name is a sub-domain of @p aDomain, FALSE if is not.
      *

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -362,7 +362,8 @@ public:
         void     DeleteResourcesButRetainName(void);
         void     CopyResourcesFrom(const Host &aHost);
         Service *FindService(const char *aFullName);
-        otError  AddIp6Address(const Ip6::Address &aIp6Address);
+        const Service *FindService(const char *aFullName) const;
+        otError        AddIp6Address(const Ip6::Address &aIp6Address);
 
         char *       mFullName;
         Ip6::Address mAddresses[kMaxAddressesNum];
@@ -553,45 +554,45 @@ private:
                                  const Message &          aMessage,
                                  const Dns::UpdateHeader &aDnsHeader,
                                  const Dns::Zone &        aZone,
-                                 uint16_t &               aOffset);
+                                 uint16_t &               aOffset) const;
     otError ProcessAdditionalSection(Host *                   aHost,
                                      const Message &          aMessage,
                                      const Dns::UpdateHeader &aDnsHeader,
-                                     uint16_t &               aOffset);
+                                     uint16_t &               aOffset) const;
     otError VerifySignature(const Dns::Ecdsa256KeyRecord &aKey,
                             const Message &               aMessage,
                             Dns::UpdateHeader             aDnsHeader,
                             uint16_t                      aSigOffset,
                             uint16_t                      aSigRdataOffset,
                             uint16_t                      aSigRdataLength,
-                            const char *                  aSignerName);
+                            const char *                  aSignerName) const;
+    otError ProcessZoneSection(const Message &          aMessage,
+                               const Dns::UpdateHeader &aDnsHeader,
+                               uint16_t &               aOffset,
+                               Dns::Zone &              aZone) const;
+    otError ProcessHostDescriptionInstruction(Host &                   aHost,
+                                              const Message &          aMessage,
+                                              const Dns::UpdateHeader &aDnsHeader,
+                                              const Dns::Zone &        aZone,
+                                              uint16_t                 aOffset) const;
+    otError ProcessServiceDiscoveryInstructions(Host &                   aHost,
+                                                const Message &          aMessage,
+                                                const Dns::UpdateHeader &aDnsHeader,
+                                                const Dns::Zone &        aZone,
+                                                uint16_t                 aOffset) const;
+    otError ProcessServiceDescriptionInstructions(Host &                   aHost,
+                                                  const Message &          aMessage,
+                                                  const Dns::UpdateHeader &aDnsHeader,
+                                                  const Dns::Zone &        aZone,
+                                                  uint16_t &               aOffset) const;
 
-    static otError ProcessZoneSection(const Message &          aMessage,
-                                      const Dns::UpdateHeader &aDnsHeader,
-                                      uint16_t &               aOffset,
-                                      Dns::Zone &              aZone);
-    static otError ProcessHostDescriptionInstruction(Host &                   aHost,
-                                                     const Message &          aMessage,
-                                                     const Dns::UpdateHeader &aDnsHeader,
-                                                     const Dns::Zone &        aZone,
-                                                     uint16_t                 aOffset);
-    static otError ProcessServiceDiscoveryInstructions(Host &                   aHost,
-                                                       const Message &          aMessage,
-                                                       const Dns::UpdateHeader &aDnsHeader,
-                                                       const Dns::Zone &        aZone,
-                                                       uint16_t                 aOffset);
-    static otError ProcessServiceDescriptionInstructions(Host &                   aHost,
-                                                         const Message &          aMessage,
-                                                         const Dns::UpdateHeader &aDnsHeader,
-                                                         const Dns::Zone &        aZone,
-                                                         uint16_t &               aOffset);
     static bool    IsValidDeleteAllRecord(const Dns::ResourceRecord &aRecord);
+    const Service *FindService(const char *aFullName) const;
 
     void        HandleUpdate(const Dns::UpdateHeader &aDnsHeader, Host *aHost, const Ip6::MessageInfo &aMessageInfo);
     void        AddHost(Host *aHost);
     void        RemoveAndFreeHost(Host *aHost);
-    Service *   FindService(const char *aFullName);
-    bool        HasNameConflictsWith(Host &aHost);
+    bool        HasNameConflictsWith(Host &aHost) const;
     void        SendResponse(const Dns::UpdateHeader &   aHeader,
                              Dns::UpdateHeader::Response aResponseCode,
                              const Ip6::MessageInfo &    aMessageInfo);

--- a/tests/unit/test_dns.cpp
+++ b/tests/unit/test_dns.cpp
@@ -146,6 +146,31 @@ void TestDnsName(void)
     message->SetOffset(0);
 
     printf("----------------------------------------------------------------\n");
+    printf("Verify domain name match:\n");
+
+    {
+        const char *name;
+        const char *domain;
+
+        name   = "my-service._ipps._tcp.local.";
+        domain = "local.";
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(name, domain), "Name::IsSubDomainOf() failed");
+
+        name   = "my-service._ipps._tcp.default.service.arpa.";
+        domain = "default.service.arpa.";
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(name, domain), "Name::IsSubDomainOf() failed");
+
+        name   = "my-service._ipps._tcp.default.service.arpa.";
+        domain = "service.arpa.";
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(name, domain), "Name::IsSubDomainOf() failed");
+
+        // Verify it doesn't match a portion of a label.
+        name   = "my-service._ipps._tcp.default.service.arpa.";
+        domain = "vice.arpa.";
+        VerifyOrQuit(!Dns::Name::IsSubDomainOf(name, domain), "Name::IsSubDomainOf() succeed");
+    }
+
+    printf("----------------------------------------------------------------\n");
     printf("Append names, check encoded bytes, parse name and read labels:\n");
 
     for (const TestName &test : kTestNames)

--- a/tests/unit/test_dns.cpp
+++ b/tests/unit/test_dns.cpp
@@ -149,25 +149,37 @@ void TestDnsName(void)
     printf("Verify domain name match:\n");
 
     {
-        const char *name;
+        const char *subDomain;
         const char *domain;
 
-        name   = "my-service._ipps._tcp.local.";
-        domain = "local.";
-        VerifyOrQuit(Dns::Name::IsSubDomainOf(name, domain), "Name::IsSubDomainOf() failed");
+        subDomain = "my-service._ipps._tcp.local.";
+        domain    = "local.";
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() failed");
 
-        name   = "my-service._ipps._tcp.default.service.arpa.";
-        domain = "default.service.arpa.";
-        VerifyOrQuit(Dns::Name::IsSubDomainOf(name, domain), "Name::IsSubDomainOf() failed");
+        subDomain = "my-service._ipps._tcp.local";
+        domain    = "local.";
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() failed");
 
-        name   = "my-service._ipps._tcp.default.service.arpa.";
-        domain = "service.arpa.";
-        VerifyOrQuit(Dns::Name::IsSubDomainOf(name, domain), "Name::IsSubDomainOf() failed");
+        subDomain = "my-service._ipps._tcp.local.";
+        domain    = "local";
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() failed");
+
+        subDomain = "my-service._ipps._tcp.local";
+        domain    = "local";
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() failed");
+
+        subDomain = "my-service._ipps._tcp.default.service.arpa.";
+        domain    = "default.service.arpa.";
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() failed");
+
+        subDomain = "my-service._ipps._tcp.default.service.arpa.";
+        domain    = "service.arpa.";
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() failed");
 
         // Verify it doesn't match a portion of a label.
-        name   = "my-service._ipps._tcp.default.service.arpa.";
-        domain = "vice.arpa.";
-        VerifyOrQuit(!Dns::Name::IsSubDomainOf(name, domain), "Name::IsSubDomainOf() succeed");
+        subDomain = "my-service._ipps._tcp.default.service.arpa.";
+        domain    = "vice.arpa.";
+        VerifyOrQuit(!Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() succeed");
     }
 
     printf("----------------------------------------------------------------\n");


### PR DESCRIPTION
This PR includes two small commits:

The first commit adds a new method `Dns::Name::IsSubDomainOf` that matches a DNS name with given domain.
This is useful for SRP and DNS-SD server to verify if a RR is in our authorized domain.

The second commit adds domain checks for names in a SRP update to the SRP server.