### PR TITLE
[dns-name] allow 'Dns::Name' to be given as string or from message

### DIFF
--- a/src/core/net/dns_headers.cpp
+++ b/src/core/net/dns_headers.cpp
@@ -404,6 +404,14 @@ exit:
     return error;
 }
 
+otError Name::CompareName(const Message &aMessage, uint16_t &aOffset, const Name &aName)
+{
+    return aName.IsFromCString()
+               ? CompareName(aMessage, aOffset, aName.mString)
+               : (aName.IsFromMessage() ? CompareName(aMessage, aOffset, *aName.mMessage, aName.mOffset)
+                                        : ParseName(aMessage, aOffset));
+}
+
 otError Name::LabelIterator::GetNextLabel(void)
 {
     otError error;
@@ -549,7 +557,7 @@ exit:
     return error;
 }
 
-otError ResourceRecord::FindRecord(const Message &aMessage, uint16_t &aOffset, uint16_t &aNumRecords, const char *aName)
+otError ResourceRecord::FindRecord(const Message &aMessage, uint16_t &aOffset, uint16_t &aNumRecords, const Name &aName)
 {
     otError error;
 

--- a/tests/unit/test_dns.cpp
+++ b/tests/unit/test_dns.cpp
@@ -862,7 +862,8 @@ void TestHeaderAndResourceRecords(void)
     {
         uint16_t prevNumRecords = numRecords;
 
-        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, kServiceName), "FindRecord failed");
+        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(kServiceName)),
+                      "FindRecord failed");
         VerifyOrQuit(numRecords == prevNumRecords - 1, "Incorrect num records");
         SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, ptrRecord), "ReadRecord() failed");
         VerifyOrQuit(ptrRecord.GetTtl() == kTtl, "Read PTR is incorrect");
@@ -873,7 +874,8 @@ void TestHeaderAndResourceRecords(void)
     }
 
     VerifyOrQuit(offset == additionalSectionOffset, "offset is incorrect after answer section parse");
-    VerifyOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, kServiceName) == OT_ERROR_NOT_FOUND,
+    VerifyOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(kServiceName)) ==
+                     OT_ERROR_NOT_FOUND,
                  "FindRecord did not fail with no records");
 
     // Use `ReadRecord()` with a non-matching record type. Verify that it correct skips over the record.
@@ -883,7 +885,8 @@ void TestHeaderAndResourceRecords(void)
 
     while (numRecords > 0)
     {
-        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, kServiceName), "FindRecord failed");
+        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(kServiceName)),
+                      "FindRecord failed");
         VerifyOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, srvRecord) == OT_ERROR_NOT_FOUND,
                      "ReadRecord() did not fail with non-matching type");
     }
@@ -894,7 +897,8 @@ void TestHeaderAndResourceRecords(void)
 
     offset     = answerSectionOffset;
     numRecords = kAnswerCount;
-    VerifyOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, kInstance1Name) == OT_ERROR_NOT_FOUND,
+    VerifyOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(kInstance1Name)) ==
+                     OT_ERROR_NOT_FOUND,
                  "FindRecord did not fail with non-matching name");
     VerifyOrQuit(numRecords == 0, "Incorrect num records");
     VerifyOrQuit(offset == additionalSectionOffset, "offset is incorrect after answer section parse");
@@ -950,18 +954,21 @@ void TestHeaderAndResourceRecords(void)
         offset     = additionalSectionOffset;
         numRecords = kAdditionalCount;
 
-        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, instanceName), "FindRecord failed");
+        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(instanceName)),
+                      "FindRecord failed");
         SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, srvRecord), "ReadRecord() failed");
         SuccessOrQuit(Dns::Name::ParseName(*message, offset), "ParseName() failed");
         printf("    \"%s\" SRV %u %d %d %d %d\n", instanceName, srvRecord.GetTtl(), srvRecord.GetLength(),
                srvRecord.GetPort(), srvRecord.GetWeight(), srvRecord.GetPriority());
 
-        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, instanceName), "FindRecord failed");
+        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(instanceName)),
+                      "FindRecord failed");
         SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, txtRecord), "ReadRecord() failed");
         offset += txtRecord.GetLength();
         printf("    \"%s\" TXT %u %d\n", instanceName, txtRecord.GetTtl(), txtRecord.GetLength());
 
-        VerifyOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, instanceName) == OT_ERROR_NOT_FOUND,
+        VerifyOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(instanceName)) ==
+                         OT_ERROR_NOT_FOUND,
                      "FindRecord() did not fail with no more records");
 
         VerifyOrQuit(offset == message->GetLength(), "offset is incorrect after additional section parse");
@@ -969,7 +976,8 @@ void TestHeaderAndResourceRecords(void)
 
     offset     = additionalSectionOffset;
     numRecords = kAdditionalCount;
-    SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, kHostName), "FindRecord() failed");
+    SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(kHostName)),
+                  "FindRecord() failed");
     SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, record), "ReadRecord() failed");
     VerifyOrQuit(record.GetType() == Dns::ResourceRecord::kTypeAaaa, "Read record has incorrect type");
     offset += record.GetLength();


### PR DESCRIPTION
This commit allows `Dns::Name` instances to be created which can be
empty or specified from a string (a dot '.' separated sequence of labels) or
from a message at a given offset (i.e., name is already encoded in a
message). `CompareName` and `FindRecord()` helper methods are updated
to allow the new `Dns::Name` type to be used when comparing/searching
for a name.

--------

_Background for this_: During DNS-SD client implementation I noticed this model of having 
a common representation of a `Dns::Name` that "may be a string" or maybe "already encoded
in a message" can be very useful. I expect it to help simplify support for handling of `CNAME`
records in a received response message.