### PR TITLE
[srp] fix setting srp domain when external heap is enabled

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (66)
+#define OPENTHREAD_API_VERSION (67)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/srp_server.h
+++ b/include/openthread/srp_server.h
@@ -74,7 +74,8 @@ typedef void otSrpServerService;
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  *
- * @returns A pointer to the dot-joined domain string.
+ * @returns A pointer to the dot-joined domain string, or NULL if the domain is not set
+ *          and the server hasn't been started.
  *
  */
 const char *otSrpServerGetDomain(otInstance *aInstance);

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -90,7 +90,6 @@ Server::Server(Instance &aInstance)
     , mOutstandingUpdatesTimer(aInstance, HandleOutstandingUpdatesTimer, this)
     , mEnabled(false)
 {
-    IgnoreError(SetDomain(kDefaultDomain));
 }
 
 Server::~Server(void)
@@ -405,6 +404,12 @@ void Server::Start(void)
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(!IsRunning());
+
+    if (GetDomain() == nullptr)
+    {
+        SuccessOrExit(error = SetDomain(kDefaultDomain));
+        OT_ASSERT(GetDomain() != nullptr);
+    }
 
     SuccessOrExit(error = mSocket.Open(HandleUdpReceive, this));
     SuccessOrExit(error = mSocket.Bind(0));


### PR DESCRIPTION
This Problem is that the SRP server is setting the domain in constructor, but for single OT instance with external heap, the `calloc` and `free` function can not be set by `otHeapSetCAllocFree` before creating the OT instance itself.

This commit delays setting domain to when starting the server.