### PR TITLE
[trel-posix] disable DAD when adding unicast address on trel netif

### DIFF
--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -58,6 +58,25 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_POSIX_TREL_USE_NETLINK_SOCKET
+ *
+ * Defines whether the TREL UDP6 platform uses netlink socket to add/remove addresses on the TREL netif or `ioctl()`
+ * command.
+ *
+ * When netlink is used Duplicate Address Detection (DAD) is disabled when a new address is added on the netif.
+ *
+ * Use of netlink is enabled by default on linux-based platforms.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_POSIX_TREL_USE_NETLINK_SOCKET
+#ifdef __linux__
+#define OPENTHREAD_CONFIG_POSIX_TREL_USE_NETLINK_SOCKET 1
+#else
+#define OPENTHREAD_CONFIG_POSIX_TREL_USE_NETLINK_SOCKET 0
+#endif
+#endif
+
+/**
  * @def OPENTHREAD_POSIX_CONFIG_DAEMON_SOCKET_BASENAME
  *
  * Define socket basename used by POSIX app daemon.

--- a/tests/toranj/openthread-core-toranj-config-posix.h
+++ b/tests/toranj/openthread-core-toranj-config-posix.h
@@ -62,6 +62,21 @@
 #define OPENTHREAD_CONFIG_POSIX_APP_TREL_INTERFACE_NAME "trel"
 
 /**
+ * @def OPENTHREAD_CONFIG_POSIX_TREL_USE_NETLINK_SOCKET
+ *
+ * Defines whether the TREL UDP6 platform uses netlink socket to add/remove addresses on the TREL netif or `ioctl()`
+ * command.
+ *
+ * When netlink is used Duplicate Address Detection (DAD) is disabled when a new address is added on the netif.
+ *
+ */
+#ifdef __linux__
+#define OPENTHREAD_CONFIG_POSIX_TREL_USE_NETLINK_SOCKET 1
+#else
+#define OPENTHREAD_CONFIG_POSIX_TREL_USE_NETLINK_SOCKET 0
+#endif
+
+/**
  * @def OPENTHREAD_POSIX_CONFIG_RCP_PTY_ENABLE
  *
  * Define as 1 to enable PTY device support in POSIX app.


### PR DESCRIPTION
This commit updates the trel platform posix implementation to use
linux netlink socket (instead of `ioctl()` command) to add/remove
unicast (link-local) address on the netif used by trel . When netlink
socket is used "Duplicate Address Detection" (DAD) is explicitly
disabled when the address is added. This helps speed up the start time
of OpenThread stack when using TREL.

The `OPENTHREAD_CONFIG_POSIX_TREL_USE_NETLINK_SOCKET` option
can be used to enable/disable the use of netlink socket by trel
platform layer implementation. By default it is enabled on all
linux-based platforms (determined by `__linux__` macro being
defined).