### PR TITLE
[heap] fix external heap configuration

### DIFF
--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -51,7 +51,7 @@ void __gcov_flush();
 #define OPENTHREAD_ENABLE_COVERAGE 0
 #endif
 
-#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 void *otPlatCAlloc(size_t aNum, size_t aSize)
 {
     return calloc(aNum, aSize);

--- a/examples/apps/ncp/main.c
+++ b/examples/apps/ncp/main.c
@@ -49,7 +49,7 @@ void __gcov_flush();
 #define OPENTHREAD_ENABLE_COVERAGE 0
 #endif
 
-#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 void *otPlatCAlloc(size_t aNum, size_t aSize)
 {
     return calloc(aNum, aSize);

--- a/examples/platforms/efr32/src/system.c
+++ b/examples/platforms/efr32/src/system.c
@@ -170,9 +170,6 @@ void otSysInit(int argc, char *argv[])
 
     __disable_irq();
 
-#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-    otHeapSetCAllocFree(sl_calloc, sl_free);
-#endif
 #undef FIXED_EXCEPTION
 #define FIXED_EXCEPTION(vectorNumber, functionName, deviceIrqn, deviceIrqHandler)
 #define EXCEPTION(vectorNumber, functionName, deviceIrqn, deviceIrqHandler, priorityLevel, subpriority) \

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (67)
+#define OPENTHREAD_API_VERSION (68)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/memory.h
+++ b/include/openthread/platform/memory.h
@@ -61,7 +61,7 @@ extern "C" {
  *   memory each and returns a pointer to the allocated memory. The allocated memory is filled with bytes
  *   of value zero."
  *
- * This function is available and can ONLY be used only when support for multiple OpenThread instances is enabled.
+ * This function is required for OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE.
  *
  * @param[in] aNum   The number of blocks to allocate
  * @param[in] aSize  The size of each block to allocate
@@ -74,7 +74,7 @@ void *otPlatCAlloc(size_t aNum, size_t aSize);
 /**
  * Frees memory that was dynamically allocated.
  *
- * This function is available and can ONLY be used only when support for multiple OpenThread instances is enabled.
+ * This function is required for OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE.
  *
  * @param[in] aPtr  A pointer the memory blocks to free. The pointer may be NULL.
  */

--- a/src/core/api/heap_api.cpp
+++ b/src/core/api/heap_api.cpp
@@ -37,8 +37,6 @@
 
 #include "common/instance.hpp"
 
-#if !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE || OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-
 #if OPENTHREAD_RADIO
 
 void *otHeapCAlloc(size_t aCount, size_t aSize)
@@ -61,25 +59,14 @@ void otHeapFree(void *aPointer)
     OT_ASSERT(false);
 }
 
-#else // OPENTHREAD_RADIO
-
+#else  // OPENTHREAD_RADIO
 void *otHeapCAlloc(size_t aCount, size_t aSize)
 {
-    return ot::Instance::Get().HeapCAlloc(aCount, aSize);
+    return ot::Instance::HeapCAlloc(aCount, aSize);
 }
 
 void otHeapFree(void *aPointer)
 {
-    ot::Instance::Get().HeapFree(aPointer);
+    ot::Instance::HeapFree(aPointer);
 }
-
 #endif // OPENTHREAD_RADIO
-
-#endif // !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE || OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-
-#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE && !OPENTHREAD_RADIO
-void otHeapSetCAllocFree(otHeapCAllocFn aCAlloc, otHeapFreeFn aFree)
-{
-    ot::Instance::HeapSetCAllocFree(aCAlloc, aFree);
-}
-#endif // OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -37,6 +37,7 @@
 
 #include "common/logging.hpp"
 #include "common/new.hpp"
+#include "utils/heap.hpp"
 
 namespace ot {
 
@@ -48,15 +49,10 @@ OT_DEFINE_ALIGNED_VAR(gInstanceRaw, sizeof(Instance), uint64_t);
 #endif
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
-
-#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-
-otHeapFreeFn   ot::Instance::mFree   = nullptr;
-otHeapCAllocFn ot::Instance::mCAlloc = nullptr;
-
-#endif // OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-
-#endif // OPENTHREAD_MTD || OPENTHREAD_FTD
+#if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+Utils::Heap Instance::sHeap;
+#endif
+#endif
 
 Instance::Instance(void)
     : mTimerMilliScheduler(*this)

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -42,7 +42,7 @@
 #include <openthread/error.h>
 #include <openthread/heap.h>
 #include <openthread/platform/logging.h>
-#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 #include <openthread/platform/memory.h>
 #endif
 
@@ -60,18 +60,16 @@
 #endif
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
 #include "common/code_utils.hpp"
-#include "crypto/mbedtls.hpp"
-#include "thread/tmf.hpp"
-#if !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
-#include "utils/heap.hpp"
-#endif
 #include "common/notifier.hpp"
 #include "common/settings.hpp"
+#include "crypto/mbedtls.hpp"
 #include "meshcop/border_agent.hpp"
 #include "net/ip6.hpp"
 #include "thread/announce_sender.hpp"
 #include "thread/link_quality.hpp"
 #include "thread/thread_netif.hpp"
+#include "thread/tmf.hpp"
+#include "utils/heap.hpp"
 #if OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
 #include "utils/channel_manager.hpp"
 #endif
@@ -247,28 +245,11 @@ public:
     otError ErasePersistentInfo(void);
 
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-    void HeapFree(void *aPointer)
-    {
-        OT_ASSERT(mFree != nullptr);
-
-        mFree(aPointer);
-    }
-
-    void *HeapCAlloc(size_t aCount, size_t aSize)
-    {
-        OT_ASSERT(mCAlloc != nullptr);
-
-        return mCAlloc(aCount, aSize);
-    }
-
-    static void HeapSetCAllocFree(otHeapCAllocFn aCAlloc, otHeapFreeFn aFree)
-    {
-        mFree   = aFree;
-        mCAlloc = aCAlloc;
-    }
-#elif !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
-    void  HeapFree(void *aPointer) { mHeap.Free(aPointer); }
-    void *HeapCAlloc(size_t aCount, size_t aSize) { return mHeap.CAlloc(aCount, aSize); }
+    static void  HeapFree(void *aPointer) { otPlatFree(aPointer); }
+    static void *HeapCAlloc(size_t aCount, size_t aSize) { return otPlatCAlloc(aCount, aSize); }
+#else
+    static void  HeapFree(void *aPointer) { sHeap.Free(aPointer); }
+    static void *HeapCAlloc(size_t aCount, size_t aSize) { return sHeap.CAlloc(aCount, aSize); }
 
     /**
      * This method returns a reference to the Heap object.
@@ -276,10 +257,7 @@ public:
      * @returns A reference to the Heap object.
      *
      */
-    Utils::Heap &GetHeap(void) { return mHeap; }
-#else
-    void  HeapFree(void *aPointer) { otPlatFree(aPointer); }
-    void *HeapCAlloc(size_t aCount, size_t aSize) { return otPlatCAlloc(aCount, aSize); }
+    Utils::Heap &GetHeap(void) { return sHeap; }
 #endif // OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
@@ -338,11 +316,8 @@ private:
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
     // RandomManager is initialized before other objects. Note that it
     // requires MbedTls which itself may use Heap.
-#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-    static otHeapFreeFn   mFree;
-    static otHeapCAllocFn mCAlloc;
-#elif !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
-    Utils::Heap  mHeap;
+#if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+    static Utils::Heap sHeap;
 #endif
     Crypto::MbedTls mMbedTls;
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -111,7 +111,7 @@ Buffer *MessagePool::NewBuffer(Message::Priority aPriority)
 
     while ((
 #if OPENTHREAD_CONFIG_MESSAGE_USE_HEAP_ENABLE
-               buffer = static_cast<Buffer *>(GetInstance().HeapCAlloc(sizeof(Buffer), 1))
+               buffer = static_cast<Buffer *>(Instance::HeapCAlloc(1, sizeof(Buffer)))
 #elif OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
                buffer = static_cast<Buffer *>(otPlatMessagePoolNew(&GetInstance()))
 #else
@@ -143,7 +143,7 @@ void MessagePool::FreeBuffers(Buffer *aBuffer)
     {
         Buffer *next = aBuffer->GetNextBuffer();
 #if OPENTHREAD_CONFIG_MESSAGE_USE_HEAP_ENABLE
-        GetInstance().HeapFree(aBuffer);
+        Instance::HeapFree(aBuffer);
 #elif OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
         otPlatMessagePoolFree(&GetInstance(), aBuffer);
 #else

--- a/src/core/crypto/mbedtls.cpp
+++ b/src/core/crypto/mbedtls.cpp
@@ -49,29 +49,15 @@
 namespace ot {
 namespace Crypto {
 
-#if !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE && OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS_MANAGEMENT
-
-static void *CAlloc(size_t aCount, size_t aSize)
-{
-    return Instance::Get().HeapCAlloc(aCount, aSize);
-}
-
-static void Free(void *aPointer)
-{
-    Instance::Get().HeapFree(aPointer);
-}
-
-#endif // !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE && OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS_MANAGEMENT
-
 MbedTls::MbedTls(void)
 {
-#if !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE && OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS_MANAGEMENT
+#if OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS_MANAGEMENT
 #ifdef MBEDTLS_DEBUG_C
     // mbedTLS's debug level is almost the same as OpenThread's
     mbedtls_debug_set_threshold(OPENTHREAD_CONFIG_LOG_LEVEL);
 #endif
-    mbedtls_platform_set_calloc_free(CAlloc, Free);
-#endif // !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE && OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS_MANAGEMENT
+    mbedtls_platform_set_calloc_free(Instance::HeapCAlloc, Instance::HeapFree);
+#endif // OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS_MANAGEMENT
 }
 
 otError MbedTls::MapError(int aMbedTlsError)

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -209,7 +209,7 @@ exit:
         SendErrorMessage(aForwardContext, error);
     }
 
-    GetInstance().HeapFree(&aForwardContext);
+    Instance::HeapFree(&aForwardContext);
 }
 
 template <Coap::Resource BorderAgent::*aResource>
@@ -494,7 +494,7 @@ otError BorderAgent::ForwardToLeader(const Coap::Message &   aMessage,
         SuccessOrExit(error = Get<Coap::CoapSecure>().SendAck(aMessage, aMessageInfo));
     }
 
-    forwardContext = static_cast<ForwardContext *>(GetInstance().HeapCAlloc(1, sizeof(ForwardContext)));
+    forwardContext = static_cast<ForwardContext *>(Instance::HeapCAlloc(1, sizeof(ForwardContext)));
     VerifyOrExit(forwardContext != nullptr, error = OT_ERROR_NO_BUFS);
 
     forwardContext->Init(GetInstance(), aMessage, aPetition, aSeparate);
@@ -530,7 +530,7 @@ exit:
     {
         if (forwardContext != nullptr)
         {
-            GetInstance().HeapFree(forwardContext);
+            Instance::HeapFree(forwardContext);
         }
 
         FreeMessage(message);

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -43,7 +43,6 @@
 #include "thread/network_data_local.hpp"
 #include "thread/network_data_notifier.hpp"
 #include "thread/thread_netif.hpp"
-#include "utils/heap.hpp"
 
 namespace ot {
 namespace Srp {
@@ -95,7 +94,7 @@ Server::Server(Instance &aInstance)
 
 Server::~Server(void)
 {
-    GetInstance().HeapFree(mDomain);
+    Instance::HeapFree(mDomain);
 }
 
 void Server::SetServiceHandler(otSrpServerServiceUpdateHandler aServiceHandler, void *aServiceHandlerContext)
@@ -183,7 +182,7 @@ otError Server::SetDomain(const char *aDomain)
         appendTrailingDot = 1;
     }
 
-    buf = static_cast<char *>(GetInstance().HeapCAlloc(1, length + appendTrailingDot + 1));
+    buf = static_cast<char *>(Instance::HeapCAlloc(1, length + appendTrailingDot + 1));
     VerifyOrExit(buf != nullptr, error = OT_ERROR_NO_BUFS);
 
     strcpy(buf, aDomain);
@@ -192,13 +191,13 @@ otError Server::SetDomain(const char *aDomain)
         buf[length]     = '.';
         buf[length + 1] = '\0';
     }
-    GetInstance().HeapFree(mDomain);
+    Instance::HeapFree(mDomain);
     mDomain = buf;
 
 exit:
     if (error != OT_ERROR_NONE)
     {
-        GetInstance().HeapFree(buf);
+        Instance::HeapFree(buf);
     }
     return error;
 }
@@ -546,7 +545,7 @@ void Server::HandleDnsUpdate(Message &                aMessage,
     // Per 2.3.2 of SRP draft 6, no prerequisites should be included in a SRP update.
     VerifyOrExit(aDnsHeader.GetPrerequisiteRecordCount() == 0, error = OT_ERROR_FAILED);
 
-    host = Host::New(GetInstance());
+    host = Host::New();
     VerifyOrExit(host != nullptr, error = OT_ERROR_NO_BUFS);
     SuccessOrExit(error = ProcessUpdateSection(*host, aMessage, aDnsHeader, zone, aOffset));
 
@@ -1276,15 +1275,15 @@ void Server::HandleOutstandingUpdatesTimer(void)
     }
 }
 
-Server::Service *Server::Service::New(Instance &aInstance, const char *aFullName)
+Server::Service *Server::Service::New(const char *aFullName)
 {
     void *   buf;
     Service *service = nullptr;
 
-    buf = aInstance.HeapCAlloc(1, sizeof(Service));
+    buf = Instance::HeapCAlloc(1, sizeof(Service));
     VerifyOrExit(buf != nullptr);
 
-    service = new (buf) Service(aInstance);
+    service = new (buf) Service();
     if (service->SetFullName(aFullName) != OT_ERROR_NONE)
     {
         service->Free();
@@ -1297,14 +1296,13 @@ exit:
 
 void Server::Service::Free(void)
 {
-    GetInstance().HeapFree(mFullName);
-    GetInstance().HeapFree(mTxtData);
-    GetInstance().HeapFree(this);
+    Instance::HeapFree(mFullName);
+    Instance::HeapFree(mTxtData);
+    Instance::HeapFree(this);
 }
 
-Server::Service::Service(Instance &aInstance)
-    : InstanceLocator(aInstance)
-    , mFullName(nullptr)
+Server::Service::Service(void)
+    : mFullName(nullptr)
     , mPriority(0)
     , mWeight(0)
     , mPort(0)
@@ -1321,12 +1319,12 @@ otError Server::Service::SetFullName(const char *aFullName)
     OT_ASSERT(aFullName != nullptr);
 
     otError error    = OT_ERROR_NONE;
-    char *  nameCopy = static_cast<char *>(GetInstance().HeapCAlloc(1, strlen(aFullName) + 1));
+    char *  nameCopy = static_cast<char *>(Instance::HeapCAlloc(1, strlen(aFullName) + 1));
 
     VerifyOrExit(nameCopy != nullptr, error = OT_ERROR_NO_BUFS);
     strcpy(nameCopy, aFullName);
 
-    GetInstance().HeapFree(mFullName);
+    Instance::HeapFree(mFullName);
     mFullName = nameCopy;
 
 exit:
@@ -1356,12 +1354,12 @@ otError Server::Service::SetTxtData(const uint8_t *aTxtData, uint16_t aTxtDataLe
     otError  error = OT_ERROR_NONE;
     uint8_t *txtData;
 
-    txtData = static_cast<uint8_t *>(GetInstance().HeapCAlloc(1, aTxtDataLength));
+    txtData = static_cast<uint8_t *>(Instance::HeapCAlloc(1, aTxtDataLength));
     VerifyOrExit(txtData != nullptr, error = OT_ERROR_NO_BUFS);
 
     memcpy(txtData, aTxtData, aTxtDataLength);
 
-    GetInstance().HeapFree(mTxtData);
+    Instance::HeapFree(mTxtData);
     mTxtData   = txtData;
     mTxtLength = aTxtDataLength;
 
@@ -1377,12 +1375,12 @@ otError Server::Service::SetTxtDataFromMessage(const Message &aMessage, uint16_t
     otError  error = OT_ERROR_NONE;
     uint8_t *txtData;
 
-    txtData = static_cast<uint8_t *>(GetInstance().HeapCAlloc(1, aLength));
+    txtData = static_cast<uint8_t *>(Instance::HeapCAlloc(1, aLength));
     VerifyOrExit(txtData != nullptr, error = OT_ERROR_NO_BUFS);
     VerifyOrExit(aMessage.ReadBytes(aOffset, txtData, aLength) == aLength, error = OT_ERROR_PARSE);
     VerifyOrExit(Dns::TxtRecord::VerifyTxtData(txtData, aLength), error = OT_ERROR_PARSE);
 
-    GetInstance().HeapFree(mTxtData);
+    Instance::HeapFree(mTxtData);
     mTxtData   = txtData;
     mTxtLength = aLength;
 
@@ -1391,7 +1389,7 @@ otError Server::Service::SetTxtDataFromMessage(const Message &aMessage, uint16_t
 exit:
     if (error != OT_ERROR_NONE)
     {
-        GetInstance().HeapFree(txtData);
+        Instance::HeapFree(txtData);
     }
 
     return error;
@@ -1400,7 +1398,7 @@ exit:
 void Server::Service::ClearResources(void)
 {
     mPort = 0;
-    GetInstance().HeapFree(mTxtData);
+    Instance::HeapFree(mTxtData);
     mTxtData   = nullptr;
     mTxtLength = 0;
 }
@@ -1433,15 +1431,15 @@ bool Server::Service::Matches(const char *aFullName) const
     return (mFullName != nullptr) && (strcmp(mFullName, aFullName) == 0);
 }
 
-Server::Host *Server::Host::New(Instance &aInstance)
+Server::Host *Server::Host::New(void)
 {
     void *buf;
     Host *host = nullptr;
 
-    buf = aInstance.HeapCAlloc(1, sizeof(Host));
+    buf = Instance::HeapCAlloc(1, sizeof(Host));
     VerifyOrExit(buf != nullptr);
 
-    host = new (buf) Host(aInstance);
+    host = new (buf) Host();
 
 exit:
     return host;
@@ -1450,13 +1448,12 @@ exit:
 void Server::Host::Free(void)
 {
     RemoveAndFreeAllServices();
-    GetInstance().HeapFree(mFullName);
-    GetInstance().HeapFree(this);
+    Instance::HeapFree(mFullName);
+    Instance::HeapFree(this);
 }
 
-Server::Host::Host(Instance &aInstance)
-    : InstanceLocator(aInstance)
-    , mFullName(nullptr)
+Server::Host::Host(void)
+    : mFullName(nullptr)
     , mAddressesNum(0)
     , mNext(nullptr)
     , mLease(0)
@@ -1471,14 +1468,14 @@ otError Server::Host::SetFullName(const char *aFullName)
     OT_ASSERT(aFullName != nullptr);
 
     otError error    = OT_ERROR_NONE;
-    char *  nameCopy = static_cast<char *>(GetInstance().HeapCAlloc(1, strlen(aFullName) + 1));
+    char *  nameCopy = static_cast<char *>(Instance::HeapCAlloc(1, strlen(aFullName) + 1));
 
     VerifyOrExit(nameCopy != nullptr, error = OT_ERROR_NO_BUFS);
     strcpy(nameCopy, aFullName);
 
     if (mFullName != nullptr)
     {
-        GetInstance().HeapFree(mFullName);
+        Instance::HeapFree(mFullName);
     }
     mFullName = nameCopy;
 
@@ -1523,7 +1520,7 @@ Server::Service *Server::Host::AddService(const char *aFullName)
 
     VerifyOrExit(service == nullptr);
 
-    service = Service::New(GetInstance(), aFullName);
+    service = Service::New(aFullName);
     if (service != nullptr)
     {
         IgnoreError(mServices.Add(*service));
@@ -1641,7 +1638,7 @@ exit:
 
 void Server::UpdateMetadata::Free(void)
 {
-    GetInstance().HeapFree(this);
+    Instance::HeapFree(this);
 }
 
 Server::UpdateMetadata::UpdateMetadata(Instance &               aInstance,

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -80,7 +80,7 @@ public:
      * This class implements a server-side SRP service.
      *
      */
-    class Service : public InstanceLocator, public LinkedListEntry<Service>, private NonCopyable
+    class Service : public LinkedListEntry<Service>, private NonCopyable
     {
         friend class LinkedListEntry<Service>;
         friend class Server;
@@ -89,14 +89,13 @@ public:
         /**
          * This method creates a new Service object with given full name.
          *
-         * @param[in]  aInstance  A reference to the OpenThread instance.
          * @param[in]  aFullName  The full name of the service instance.
          *
-         * @returns  A pointer to the newly created Service object. nullptr if
+         * @returns  A pointer to the newly created Service object, nullptr if
          *           cannot allocate memory for the object.
          *
          */
-        static Service *New(Instance &aInstance, const char *aFullName);
+        static Service *New(const char *aFullName);
 
         /**
          * This method frees the Service object.
@@ -198,7 +197,7 @@ public:
         bool Matches(const char *aFullName) const;
 
     private:
-        explicit Service(Instance &aInstance);
+        explicit Service(void);
         otError SetFullName(const char *aFullName);
         otError SetTxtData(const uint8_t *aTxtData, uint16_t aTxtDataLength);
         otError SetTxtDataFromMessage(const Message &aMessage, uint16_t aOffset, uint16_t aLength);
@@ -222,22 +221,20 @@ public:
      * This class implements the Host which registers services on the SRP server.
      *
      */
-    class Host : public InstanceLocator, public LinkedListEntry<Host>, private NonCopyable
+    class Host : public LinkedListEntry<Host>, private NonCopyable
     {
         friend class LinkedListEntry<Host>;
         friend class Server;
 
     public:
         /**
-         * This method creates a new Host object with given full name.
+         * This method creates a new Host object.
          *
-         * @param[in]  aInstance  A reference to the OpenThread instance.
-         *
-         * @returns  A pointer to the newly created Host object. nullptr if
+         * @returns  A pointer to the newly created Host object, nullptr if
          *           cannot allocate memory for the object.
          *
          */
-        static Host *New(Instance &aInstance);
+        static Host *New(void);
 
         /**
          * This method Frees the Host object.
@@ -348,7 +345,7 @@ public:
             kMaxAddressesNum = OPENTHREAD_CONFIG_SRP_SERVER_MAX_ADDRESSES_NUM,
         };
 
-        explicit Host(Instance &aInstance);
+        explicit Host(void);
         otError  SetFullName(const char *aFullName);
         void     SetKey(Dns::Ecdsa256KeyRecord &aKey);
         void     SetLease(uint32_t aLease);

--- a/src/core/utils/heap.cpp
+++ b/src/core/utils/heap.cpp
@@ -34,6 +34,8 @@
 
 #include "heap.hpp"
 
+#if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+
 #include <string.h>
 
 #include "common/code_utils.hpp"
@@ -217,3 +219,5 @@ void Heap::Free(void *aPointer)
 
 } // namespace Utils
 } // namespace ot
+
+#endif // !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE

--- a/src/core/utils/heap.hpp
+++ b/src/core/utils/heap.hpp
@@ -37,6 +37,8 @@
 
 #include "openthread-core-config.h"
 
+#if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+
 #include <stddef.h>
 #include <stdint.h>
 
@@ -352,5 +354,7 @@ private:
 
 } // namespace Utils
 } // namespace ot
+
+#endif // !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 
 #endif // OT_HEAP_HPP_

--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -66,6 +66,7 @@ add_library(openthread-posix
     hdlc_interface.cpp
     infra_if.cpp
     logging.cpp
+    memory.cpp
     misc.cpp
     multicast_routing.cpp
     netif.cpp

--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -50,6 +50,7 @@ libopenthread_posix_a_SOURCES             = \
     hdlc_interface.cpp                      \
     infra_if.cpp                            \
     logging.cpp                             \
+    memory.cpp                              \
     misc.cpp                                \
     multicast_routing.cpp                   \
     netif.cpp                               \

--- a/src/posix/platform/memory.cpp
+++ b/src/posix/platform/memory.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, The OpenThread Authors.
+ *  Copyright (c) 2021, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,54 +26,21 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-/**
- * @file
- * @brief
- *  This file defines the API for setting external heap in OpenThread.
- */
+#include "openthread-posix-config.h"
+#include "platform-posix.h"
 
-#ifndef OPENTHREAD_HEAP_H_
-#define OPENTHREAD_HEAP_H_
+#include <stdlib.h>
 
-#include <openthread/instance.h>
+#include <openthread/platform/memory.h>
 
-#ifdef __cplusplus
-extern "C" {
+#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+void *otPlatCAlloc(size_t aNum, size_t aSize)
+{
+    return calloc(aNum, aSize);
+}
+
+void otPlatFree(void *aPtr)
+{
+    free(aPtr);
+}
 #endif
-
-/**
- * @addtogroup api-heap
- *
- * @brief
- *   This module includes functions that set the external OpenThread heap.
- *
- * @{
- *
- */
-
-// This is a temporary API and would be removed after moving heap to platform.
-// TODO: Remove after moving heap to platform.
-/**
- * @note This API is deprecated and use of it is discouraged.
- *
- */
-void *otHeapCAlloc(size_t aCount, size_t aSize);
-
-// This is a temporary API and would be removed after moving heap to platform.
-// TODO: Remove after moving heap to platform.
-/**
- * @note This API is deprecated and use of it is discouraged.
- *
- */
-void otHeapFree(void *aPointer);
-
-/**
- * @}
- *
- */
-
-#ifdef __cplusplus
-} // extern "C"
-#endif
-
-#endif // OPENTHREAD_HEAP_H_

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -92,10 +92,6 @@ otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
 #endif
     platformRandomInit();
 
-#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-    otHeapSetCAllocFree(calloc, free);
-#endif
-
     instance = otInstanceInitSingle();
     assert(instance != nullptr);
 

--- a/tests/unit/test_heap.cpp
+++ b/tests/unit/test_heap.cpp
@@ -38,6 +38,8 @@
 #include "test_platform.h"
 #include "test_util.h"
 
+#if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+
 /**
  * Verifies single variable allocating and freeing.
  *
@@ -171,9 +173,13 @@ void RunTimerTests(void)
     TestAllocateMultiple();
 }
 
+#endif // !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+
 int main(void)
 {
+#if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
     RunTimerTests();
     printf("All tests passed\n");
+#endif // !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
     return 0;
 }

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -94,7 +94,7 @@ bool sDiagMode = false;
 
 extern "C" {
 
-#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 void *otPlatCAlloc(size_t aNum, size_t aSize)
 {
     return calloc(aNum, aSize);

--- a/third_party/mbedtls/mbedtls-config.h
+++ b/third_party/mbedtls/mbedtls-config.h
@@ -117,7 +117,7 @@
 #define MBEDTLS_ECP_FIXED_POINT_OPTIM      0 /**< Enable fixed-point speed-up */
 #define MBEDTLS_ENTROPY_MAX_SOURCES        1 /**< Maximum number of sources supported */
 
-#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
+#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 #define MBEDTLS_PLATFORM_STD_CALLOC      otPlatCAlloc /**< Default allocator to use, can be undefined */
 #define MBEDTLS_PLATFORM_STD_FREE        otPlatFree /**< Default free to use, can be undefined */
 #else


### PR DESCRIPTION
The `Instance::HeapCAlloc()` method can not be used in constructors when `EXTERNAL_HEAP`
is enabled but works well when internal heap is used. This is because the external heap methods
are set by public `otHeapSetCAllocFree` API after the OT instance is constructed.

This PR fixes this issue by having `Instance::HeapCAlloc()` using `otPlatCAlloc` when `EXTERNAL_HEAP`
is enabled. It also fixes build issues when `MULTIPLE_INSTANCE` and `EXTERNAL_HEAP` are used together.

Replaces #6121.