### PR TITLE
[settings] add APIs to securely store critical settings

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (68)
+#define OPENTHREAD_API_VERSION (69)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -52,6 +52,29 @@ extern "C" {
  */
 
 /**
+ * This enumeration defines the keys of settings.
+ *
+ * Note: When adding a new setings key, if the settings corresponding to the key contains security sensitive
+ *       information, the developer MUST add the key to the array `kCriticalKeys`.
+ *
+ */
+enum Key
+{
+    OT_SETTINGS_KEY_ACTIVE_DATASET  = 0x0001, ///< Active Operational Dataset
+    OT_SETTINGS_KEY_PENDING_DATASET = 0x0002, ///< Pending Operational Dataset
+    OT_SETTINGS_KEY_NETWORK_INFO    = 0x0003, ///< Thread network information
+    OT_SETTINGS_KEY_PARENT_INFO     = 0x0004, ///< Parent information
+    OT_SETTINGS_KEY_CHILD_INFO      = 0x0005, ///< Child information
+    OT_SETTINGS_KEY_RESERVED        = 0x0006, ///< Reserved (previously auto-start)
+    OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY =
+        0x0007,                              ///< Secret key used by SLAAC module for generating semantically opaque IID
+    OT_SETTINGS_KEY_DAD_INFO       = 0x0008, ///< Duplicate Address Detection (DAD) information.
+    OT_SETTINGS_KEY_OMR_PREFIX     = 0x0009, ///< Off-mesh routable (OMR) prefix.
+    OT_SETTINGS_KEY_ON_LINK_PREFIX = 0x000a, ///< On-link prefix for infrastructure link.
+    OT_SETTINGS_KEY_SRP_ECDSA_KEY  = 0x000b, ///< SRP client ECDSA public/private key pair.
+};
+
+/**
  * Performs any initialization for the settings subsystem, if necessary.
  *
  * @param[in]  aInstance The OpenThread instance structure.
@@ -68,13 +91,13 @@ void otPlatSettingsInit(otInstance *aInstance);
 void otPlatSettingsDeinit(otInstance *aInstance);
 
 /**
- * This function sets the critical keys that should be stored in a secure area.
+ * This function sets the critical keys that should be stored in the secure area.
  *
- * Note that the memory pointed by @p aKeys will never be released by the caller.
+ * Note that the memory pointed by @p aKeys MUST not be released before @p aInstance is destroyed.
  *
  * @param[in]  aInstance    The OpenThread instance structure.
- * @param[in]  aKeys        A pointer to the value of the critical keys.
- * @param[in]  aKeysLength  The length of the keys pointed to by @p akeys.
+ * @param[in]  aKeys        A pointer to an array containing the list of critical keys.
+ * @param[in]  aKeysLength  The number of entries in the @p aKeys array.
  *
  */
 void otPlatSettingsSetCriticalKeys(otInstance *aInstance, const uint16_t *aKeys, uint16_t aKeysLength);

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -67,6 +67,18 @@ void otPlatSettingsInit(otInstance *aInstance);
  */
 void otPlatSettingsDeinit(otInstance *aInstance);
 
+/**
+ * This function sets the critical keys that should be stored in a secure area.
+ *
+ * Note that the memory pointed by @p aKeys will never be released by the caller.
+ *
+ * @param[in]  aInstance    The OpenThread instance structure.
+ * @param[in]  aKeys        A pointer to the value of the critical keys.
+ * @param[in]  aKeysLength  The length of the keys pointed to by @p akeys.
+ *
+ */
+void otPlatSettingsSetCriticalKeys(otInstance *aInstance, const uint16_t *aKeys, uint16_t aKeysLength);
+
 /// Fetches the value of a setting
 /** This function fetches the value of the setting identified
  *  by aKey and write it to the memory pointed to by aValue.

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -60,14 +60,14 @@ extern "C" {
  */
 enum
 {
-    OT_SETTINGS_KEY_ACTIVE_DATASET  = 0x0001, ///< Active Operational Dataset
-    OT_SETTINGS_KEY_PENDING_DATASET = 0x0002, ///< Pending Operational Dataset
-    OT_SETTINGS_KEY_NETWORK_INFO    = 0x0003, ///< Thread network information
-    OT_SETTINGS_KEY_PARENT_INFO     = 0x0004, ///< Parent information
-    OT_SETTINGS_KEY_CHILD_INFO      = 0x0005, ///< Child information
-    OT_SETTINGS_KEY_RESERVED        = 0x0006, ///< Reserved (previously auto-start)
+    OT_SETTINGS_KEY_ACTIVE_DATASET  = 0x0001, ///< Active Operational Dataset.
+    OT_SETTINGS_KEY_PENDING_DATASET = 0x0002, ///< Pending Operational Dataset.
+    OT_SETTINGS_KEY_NETWORK_INFO    = 0x0003, ///< Thread network information.
+    OT_SETTINGS_KEY_PARENT_INFO     = 0x0004, ///< Parent information.
+    OT_SETTINGS_KEY_CHILD_INFO      = 0x0005, ///< Child information.
+    OT_SETTINGS_KEY_RESERVED        = 0x0006, ///< Reserved (previously auto-start).
     OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY =
-        0x0007,                              ///< Secret key used by SLAAC module for generating semantically opaque IID
+        0x0007, ///< Secret key used by SLAAC module for generating semantically opaque IID.
     OT_SETTINGS_KEY_DAD_INFO       = 0x0008, ///< Duplicate Address Detection (DAD) information.
     OT_SETTINGS_KEY_OMR_PREFIX     = 0x0009, ///< Off-mesh routable (OMR) prefix.
     OT_SETTINGS_KEY_ON_LINK_PREFIX = 0x000a, ///< On-link prefix for infrastructure link.

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -60,18 +60,17 @@ extern "C" {
  */
 enum
 {
-    OT_SETTINGS_KEY_ACTIVE_DATASET  = 0x0001, ///< Active Operational Dataset.
-    OT_SETTINGS_KEY_PENDING_DATASET = 0x0002, ///< Pending Operational Dataset.
-    OT_SETTINGS_KEY_NETWORK_INFO    = 0x0003, ///< Thread network information.
-    OT_SETTINGS_KEY_PARENT_INFO     = 0x0004, ///< Parent information.
-    OT_SETTINGS_KEY_CHILD_INFO      = 0x0005, ///< Child information.
-    OT_SETTINGS_KEY_RESERVED        = 0x0006, ///< Reserved (previously auto-start).
-    OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY =
-        0x0007, ///< Secret key used by SLAAC module for generating semantically opaque IID.
-    OT_SETTINGS_KEY_DAD_INFO       = 0x0008, ///< Duplicate Address Detection (DAD) information.
-    OT_SETTINGS_KEY_OMR_PREFIX     = 0x0009, ///< Off-mesh routable (OMR) prefix.
-    OT_SETTINGS_KEY_ON_LINK_PREFIX = 0x000a, ///< On-link prefix for infrastructure link.
-    OT_SETTINGS_KEY_SRP_ECDSA_KEY  = 0x000b, ///< SRP client ECDSA public/private key pair.
+    OT_SETTINGS_KEY_ACTIVE_DATASET       = 0x0001, ///< Active Operational Dataset.
+    OT_SETTINGS_KEY_PENDING_DATASET      = 0x0002, ///< Pending Operational Dataset.
+    OT_SETTINGS_KEY_NETWORK_INFO         = 0x0003, ///< Thread network information.
+    OT_SETTINGS_KEY_PARENT_INFO          = 0x0004, ///< Parent information.
+    OT_SETTINGS_KEY_CHILD_INFO           = 0x0005, ///< Child information.
+    OT_SETTINGS_KEY_RESERVED             = 0x0006, ///< Reserved (previously auto-start).
+    OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY = 0x0007, ///< SLAAC key to generate semantically opaque IID.
+    OT_SETTINGS_KEY_DAD_INFO             = 0x0008, ///< Duplicate Address Detection (DAD) information.
+    OT_SETTINGS_KEY_OMR_PREFIX           = 0x0009, ///< Off-mesh routable (OMR) prefix.
+    OT_SETTINGS_KEY_ON_LINK_PREFIX       = 0x000a, ///< On-link prefix for infrastructure link.
+    OT_SETTINGS_KEY_SRP_ECDSA_KEY        = 0x000b, ///< SRP client ECDSA public/private key pair.
 };
 
 /**

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -58,7 +58,7 @@ extern "C" {
  *       information, the developer MUST add the key to the array `kCriticalKeys`.
  *
  */
-enum Key
+enum
 {
     OT_SETTINGS_KEY_ACTIVE_DATASET  = 0x0001, ///< Active Operational Dataset
     OT_SETTINGS_KEY_PENDING_DATASET = 0x0002, ///< Pending Operational Dataset

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -117,6 +117,11 @@ void SettingsDriver::Init(void)
     otPlatSettingsInit(&GetInstance());
 }
 
+void SettingsDriver::SetCriticalKeys(const uint16_t *aKeys, uint16_t aKeysLength)
+{
+    otPlatSettingsSetCriticalKeys(&GetInstance(), aKeys, aKeysLength);
+}
+
 void SettingsDriver::Deinit(void)
 {
     otPlatSettingsDeinit(&GetInstance());
@@ -160,6 +165,12 @@ void SettingsDriver::Init(void)
     mFlash.Init();
 }
 
+void SettingsDriver::SetCriticalKeys(const uint16_t *aKeys, uint16_t aKeysLength)
+{
+    OT_UNUSED_VARIABLE(aKeys);
+    OT_UNUSED_VARIABLE(aKeysLength);
+}
+
 void SettingsDriver::Deinit(void)
 {
 }
@@ -194,6 +205,7 @@ void SettingsDriver::Wipe(void)
 void Settings::Init(void)
 {
     Get<SettingsDriver>().Init();
+    Get<SettingsDriver>().SetCriticalKeys(mCriticalKeys, OT_ARRAY_LENGTH(mCriticalKeys));
 }
 
 void Settings::Deinit(void)
@@ -579,3 +591,13 @@ otError Settings::Delete(Key aKey)
 }
 
 } // namespace ot
+
+//---------------------------------------------------------------------------------------------------------------------
+// Default/weak implementation of settings platform APIs
+
+OT_TOOL_WEAK void otPlatSettingsSetCriticalKeys(otInstance *aInstance, const uint16_t *aKeys, uint16_t aKeysLength)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aKeys);
+    OT_UNUSED_VARIABLE(aKeysLength);
+}

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -43,6 +43,9 @@
 #include "thread/mle.hpp"
 
 namespace ot {
+// This array contains critical keys that should be stored in the secure area.
+static const uint16_t kCriticalKeys[] = {OT_SETTINGS_KEY_ACTIVE_DATASET, OT_SETTINGS_KEY_PENDING_DATASET,
+                                         OT_SETTINGS_KEY_SRP_ECDSA_KEY};
 
 // LCOV_EXCL_START
 
@@ -117,14 +120,14 @@ void SettingsDriver::Init(void)
     otPlatSettingsInit(&GetInstance());
 }
 
-void SettingsDriver::SetCriticalKeys(const uint16_t *aKeys, uint16_t aKeysLength)
-{
-    otPlatSettingsSetCriticalKeys(&GetInstance(), aKeys, aKeysLength);
-}
-
 void SettingsDriver::Deinit(void)
 {
     otPlatSettingsDeinit(&GetInstance());
+}
+
+void SettingsDriver::SetCriticalKeys(const uint16_t *aKeys, uint16_t aKeysLength)
+{
+    otPlatSettingsSetCriticalKeys(&GetInstance(), aKeys, aKeysLength);
 }
 
 otError SettingsDriver::Add(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
@@ -165,14 +168,14 @@ void SettingsDriver::Init(void)
     mFlash.Init();
 }
 
+void SettingsDriver::Deinit(void)
+{
+}
+
 void SettingsDriver::SetCriticalKeys(const uint16_t *aKeys, uint16_t aKeysLength)
 {
     OT_UNUSED_VARIABLE(aKeys);
     OT_UNUSED_VARIABLE(aKeysLength);
-}
-
-void SettingsDriver::Deinit(void)
-{
 }
 
 otError SettingsDriver::Add(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
@@ -205,7 +208,7 @@ void SettingsDriver::Wipe(void)
 void Settings::Init(void)
 {
     Get<SettingsDriver>().Init();
-    Get<SettingsDriver>().SetCriticalKeys(mCriticalKeys, OT_ARRAY_LENGTH(mCriticalKeys));
+    Get<SettingsDriver>().SetCriticalKeys(kCriticalKeys, OT_ARRAY_LENGTH(kCriticalKeys));
 }
 
 void Settings::Deinit(void)
@@ -221,7 +224,8 @@ void Settings::Wipe(void)
 
 otError Settings::SaveOperationalDataset(bool aIsActive, const MeshCoP::Dataset &aDataset)
 {
-    otError error = Save(aIsActive ? kKeyActiveDataset : kKeyPendingDataset, aDataset.GetBytes(), aDataset.GetSize());
+    otError error = Save(aIsActive ? OT_SETTINGS_KEY_ACTIVE_DATASET : OT_SETTINGS_KEY_PENDING_DATASET,
+                         aDataset.GetBytes(), aDataset.GetSize());
 
     LogFailure(error, "saving OperationalDataset", false);
     return error;
@@ -232,7 +236,8 @@ otError Settings::ReadOperationalDataset(bool aIsActive, MeshCoP::Dataset &aData
     otError  error  = OT_ERROR_NONE;
     uint16_t length = MeshCoP::Dataset::kMaxSize;
 
-    SuccessOrExit(error = Read(aIsActive ? kKeyActiveDataset : kKeyPendingDataset, aDataset.GetBytes(), length));
+    SuccessOrExit(error = Read(aIsActive ? OT_SETTINGS_KEY_ACTIVE_DATASET : OT_SETTINGS_KEY_PENDING_DATASET,
+                               aDataset.GetBytes(), length));
     VerifyOrExit(length <= MeshCoP::Dataset::kMaxSize, error = OT_ERROR_NOT_FOUND);
 
     aDataset.SetSize(length);
@@ -243,7 +248,7 @@ exit:
 
 otError Settings::DeleteOperationalDataset(bool aIsActive)
 {
-    otError error = Delete(aIsActive ? kKeyActiveDataset : kKeyPendingDataset);
+    otError error = Delete(aIsActive ? OT_SETTINGS_KEY_ACTIVE_DATASET : OT_SETTINGS_KEY_PENDING_DATASET);
 
     LogFailure(error, "deleting OperationalDataset", true);
 
@@ -256,7 +261,7 @@ otError Settings::ReadNetworkInfo(NetworkInfo &aNetworkInfo) const
     uint16_t length = sizeof(NetworkInfo);
 
     aNetworkInfo.Init();
-    SuccessOrExit(error = Read(kKeyNetworkInfo, &aNetworkInfo, length));
+    SuccessOrExit(error = Read(OT_SETTINGS_KEY_NETWORK_INFO, &aNetworkInfo, length));
     LogNetworkInfo("Read", aNetworkInfo);
 
 exit:
@@ -269,14 +274,14 @@ otError Settings::SaveNetworkInfo(const NetworkInfo &aNetworkInfo)
     NetworkInfo prevNetworkInfo;
     uint16_t    length = sizeof(prevNetworkInfo);
 
-    if ((Read(kKeyNetworkInfo, &prevNetworkInfo, length) == OT_ERROR_NONE) && (length == sizeof(NetworkInfo)) &&
-        (prevNetworkInfo == aNetworkInfo))
+    if ((Read(OT_SETTINGS_KEY_NETWORK_INFO, &prevNetworkInfo, length) == OT_ERROR_NONE) &&
+        (length == sizeof(NetworkInfo)) && (prevNetworkInfo == aNetworkInfo))
     {
         LogNetworkInfo("Re-saved", aNetworkInfo);
         ExitNow();
     }
 
-    SuccessOrExit(error = Save(kKeyNetworkInfo, &aNetworkInfo, sizeof(NetworkInfo)));
+    SuccessOrExit(error = Save(OT_SETTINGS_KEY_NETWORK_INFO, &aNetworkInfo, sizeof(NetworkInfo)));
     LogNetworkInfo("Saved", aNetworkInfo);
 
 exit:
@@ -288,7 +293,7 @@ otError Settings::DeleteNetworkInfo(void)
 {
     otError error;
 
-    SuccessOrExit(error = Delete(kKeyNetworkInfo));
+    SuccessOrExit(error = Delete(OT_SETTINGS_KEY_NETWORK_INFO));
     otLogInfoCore("Non-volatile: Deleted NetworkInfo");
 
 exit:
@@ -302,7 +307,7 @@ otError Settings::ReadParentInfo(ParentInfo &aParentInfo) const
     uint16_t length = sizeof(ParentInfo);
 
     aParentInfo.Init();
-    SuccessOrExit(error = Read(kKeyParentInfo, &aParentInfo, length));
+    SuccessOrExit(error = Read(OT_SETTINGS_KEY_PARENT_INFO, &aParentInfo, length));
     LogParentInfo("Read", aParentInfo);
 
 exit:
@@ -315,14 +320,14 @@ otError Settings::SaveParentInfo(const ParentInfo &aParentInfo)
     ParentInfo prevParentInfo;
     uint16_t   length = sizeof(ParentInfo);
 
-    if ((Read(kKeyParentInfo, &prevParentInfo, length) == OT_ERROR_NONE) && (length == sizeof(ParentInfo)) &&
-        (prevParentInfo == aParentInfo))
+    if ((Read(OT_SETTINGS_KEY_PARENT_INFO, &prevParentInfo, length) == OT_ERROR_NONE) &&
+        (length == sizeof(ParentInfo)) && (prevParentInfo == aParentInfo))
     {
         LogParentInfo("Re-saved", aParentInfo);
         ExitNow();
     }
 
-    SuccessOrExit(error = Save(kKeyParentInfo, &aParentInfo, sizeof(ParentInfo)));
+    SuccessOrExit(error = Save(OT_SETTINGS_KEY_PARENT_INFO, &aParentInfo, sizeof(ParentInfo)));
     LogParentInfo("Saved", aParentInfo);
 
 exit:
@@ -334,7 +339,7 @@ otError Settings::DeleteParentInfo(void)
 {
     otError error;
 
-    SuccessOrExit(error = Delete(kKeyParentInfo));
+    SuccessOrExit(error = Delete(OT_SETTINGS_KEY_PARENT_INFO));
     otLogInfoCore("Non-volatile: Deleted ParentInfo");
 
 exit:
@@ -346,7 +351,7 @@ otError Settings::AddChildInfo(const ChildInfo &aChildInfo)
 {
     otError error;
 
-    SuccessOrExit(error = Add(kKeyChildInfo, &aChildInfo, sizeof(aChildInfo)));
+    SuccessOrExit(error = Add(OT_SETTINGS_KEY_CHILD_INFO, &aChildInfo, sizeof(aChildInfo)));
     LogChildInfo("Added", aChildInfo);
 
 exit:
@@ -358,7 +363,7 @@ otError Settings::DeleteAllChildInfo(void)
 {
     otError error;
 
-    SuccessOrExit(error = Delete(kKeyChildInfo));
+    SuccessOrExit(error = Delete(OT_SETTINGS_KEY_CHILD_INFO));
     otLogInfoCore("Non-volatile: Deleted all ChildInfo");
 
 exit:
@@ -388,7 +393,7 @@ otError Settings::ChildInfoIterator::Delete(void)
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(!mIsDone, error = OT_ERROR_INVALID_STATE);
-    SuccessOrExit(error = Get<SettingsDriver>().Delete(kKeyChildInfo, mIndex));
+    SuccessOrExit(error = Get<SettingsDriver>().Delete(OT_SETTINGS_KEY_CHILD_INFO, mIndex));
     LogChildInfo("Removed", mChildInfo);
 
 exit:
@@ -402,8 +407,8 @@ void Settings::ChildInfoIterator::Read(void)
     otError  error;
 
     mChildInfo.Init();
-    SuccessOrExit(
-        error = Get<SettingsDriver>().Get(kKeyChildInfo, mIndex, reinterpret_cast<uint8_t *>(&mChildInfo), &length));
+    SuccessOrExit(error = Get<SettingsDriver>().Get(OT_SETTINGS_KEY_CHILD_INFO, mIndex,
+                                                    reinterpret_cast<uint8_t *>(&mChildInfo), &length));
     LogChildInfo("Read", mChildInfo);
 
 exit:
@@ -417,7 +422,7 @@ otError Settings::ReadDadInfo(DadInfo &aDadInfo) const
     uint16_t length = sizeof(DadInfo);
 
     aDadInfo.Init();
-    SuccessOrExit(error = Read(kKeyDadInfo, &aDadInfo, length));
+    SuccessOrExit(error = Read(OT_SETTINGS_KEY_DAD_INFO, &aDadInfo, length));
     LogDadInfo("Read", aDadInfo);
 
 exit:
@@ -430,14 +435,14 @@ otError Settings::SaveDadInfo(const DadInfo &aDadInfo)
     DadInfo  prevDadInfo;
     uint16_t length = sizeof(DadInfo);
 
-    if ((Read(kKeyDadInfo, &prevDadInfo, length) == OT_ERROR_NONE) && (length == sizeof(DadInfo)) &&
+    if ((Read(OT_SETTINGS_KEY_DAD_INFO, &prevDadInfo, length) == OT_ERROR_NONE) && (length == sizeof(DadInfo)) &&
         (prevDadInfo == aDadInfo))
     {
         LogDadInfo("Re-saved", aDadInfo);
         ExitNow();
     }
 
-    SuccessOrExit(error = Save(kKeyDadInfo, &aDadInfo, sizeof(DadInfo)));
+    SuccessOrExit(error = Save(OT_SETTINGS_KEY_DAD_INFO, &aDadInfo, sizeof(DadInfo)));
     LogDadInfo("Saved", aDadInfo);
 
 exit:
@@ -449,7 +454,7 @@ otError Settings::DeleteDadInfo(void)
 {
     otError error;
 
-    SuccessOrExit(error = Delete(kKeyDadInfo));
+    SuccessOrExit(error = Delete(OT_SETTINGS_KEY_DAD_INFO));
     otLogInfoCore("Non-volatile: Deleted DadInfo");
 
 exit:
@@ -465,14 +470,14 @@ otError Settings::SaveOmrPrefix(const Ip6::Prefix &aOmrPrefix)
     Ip6::Prefix prevOmrPrefix;
     uint16_t    length = sizeof(prevOmrPrefix);
 
-    if ((Read(kKeyOmrPrefix, &prevOmrPrefix, length) == OT_ERROR_NONE) && (length == sizeof(prevOmrPrefix)) &&
-        (prevOmrPrefix == aOmrPrefix))
+    if ((Read(OT_SETTINGS_KEY_OMR_PREFIX, &prevOmrPrefix, length) == OT_ERROR_NONE) &&
+        (length == sizeof(prevOmrPrefix)) && (prevOmrPrefix == aOmrPrefix))
     {
         LogPrefix("Re-saved", "OMR prefix", aOmrPrefix);
         ExitNow();
     }
 
-    SuccessOrExit(error = Save(kKeyOmrPrefix, &aOmrPrefix, sizeof(aOmrPrefix)));
+    SuccessOrExit(error = Save(OT_SETTINGS_KEY_OMR_PREFIX, &aOmrPrefix, sizeof(aOmrPrefix)));
     LogPrefix("Saved", "OMR prefix", aOmrPrefix);
 
 exit:
@@ -486,7 +491,7 @@ otError Settings::ReadOmrPrefix(Ip6::Prefix &aOmrPrefix) const
     uint16_t length = sizeof(aOmrPrefix);
 
     aOmrPrefix.Clear();
-    SuccessOrExit(error = Read(kKeyOmrPrefix, &aOmrPrefix, length));
+    SuccessOrExit(error = Read(OT_SETTINGS_KEY_OMR_PREFIX, &aOmrPrefix, length));
     LogPrefix("Read", "OMR prefix", aOmrPrefix);
 
 exit:
@@ -499,14 +504,14 @@ otError Settings::SaveOnLinkPrefix(const Ip6::Prefix &aOnLinkPrefix)
     Ip6::Prefix prevOnLinkPrefix;
     uint16_t    length = sizeof(prevOnLinkPrefix);
 
-    if ((Read(kKeyOnLinkPrefix, &prevOnLinkPrefix, length) == OT_ERROR_NONE) && (length == sizeof(prevOnLinkPrefix)) &&
-        (prevOnLinkPrefix == aOnLinkPrefix))
+    if ((Read(OT_SETTINGS_KEY_ON_LINK_PREFIX, &prevOnLinkPrefix, length) == OT_ERROR_NONE) &&
+        (length == sizeof(prevOnLinkPrefix)) && (prevOnLinkPrefix == aOnLinkPrefix))
     {
         LogPrefix("Re-saved", "on-link prefix", aOnLinkPrefix);
         ExitNow();
     }
 
-    SuccessOrExit(error = Save(kKeyOnLinkPrefix, &aOnLinkPrefix, sizeof(aOnLinkPrefix)));
+    SuccessOrExit(error = Save(OT_SETTINGS_KEY_ON_LINK_PREFIX, &aOnLinkPrefix, sizeof(aOnLinkPrefix)));
     LogPrefix("Saved", "on-link prefix", aOnLinkPrefix);
 
 exit:
@@ -520,7 +525,7 @@ otError Settings::ReadOnLinkPrefix(Ip6::Prefix &aOnLinkPrefix) const
     uint16_t length = sizeof(aOnLinkPrefix);
 
     aOnLinkPrefix.Clear();
-    SuccessOrExit(error = Read(kKeyOnLinkPrefix, &aOnLinkPrefix, length));
+    SuccessOrExit(error = Read(OT_SETTINGS_KEY_ON_LINK_PREFIX, &aOnLinkPrefix, length));
     LogPrefix("Read", "on-link prefix", aOnLinkPrefix);
 
 exit:
@@ -534,7 +539,7 @@ otError Settings::SaveSrpKey(const Crypto::Ecdsa::P256::KeyPair &aKeyPair)
 {
     otError error = OT_ERROR_NONE;
 
-    SuccessOrExit(error = Save(kKeySrpEcdsaKey, aKeyPair.GetDerBytes(), aKeyPair.GetDerLength()));
+    SuccessOrExit(error = Save(OT_SETTINGS_KEY_SRP_ECDSA_KEY, aKeyPair.GetDerBytes(), aKeyPair.GetDerLength()));
     otLogInfoCore("Non-volatile: Saved SRP key");
 
 exit:
@@ -547,7 +552,7 @@ otError Settings::ReadSrpKey(Crypto::Ecdsa::P256::KeyPair &aKeyPair) const
     otError  error;
     uint16_t length = Crypto::Ecdsa::P256::KeyPair::kMaxDerSize;
 
-    SuccessOrExit(error = Read(kKeySrpEcdsaKey, aKeyPair.GetDerBytes(), length));
+    SuccessOrExit(error = Read(OT_SETTINGS_KEY_SRP_ECDSA_KEY, aKeyPair.GetDerBytes(), length));
     VerifyOrExit(length <= Crypto::Ecdsa::P256::KeyPair::kMaxDerSize, error = OT_ERROR_NOT_FOUND);
     aKeyPair.SetDerLength(static_cast<uint8_t>(length));
     otLogInfoCore("Non-volatile: Read SRP key");
@@ -560,7 +565,7 @@ otError Settings::DeleteSrpKey(void)
 {
     otError error;
 
-    SuccessOrExit(error = Delete(kKeySrpEcdsaKey));
+    SuccessOrExit(error = Delete(OT_SETTINGS_KEY_SRP_ECDSA_KEY));
     otLogInfoCore("Non-volatile: Deleted SRP key");
 
 exit:

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -44,8 +44,8 @@
 
 namespace ot {
 // This array contains critical keys that should be stored in the secure area.
-static const uint16_t kCriticalKeys[] = {OT_SETTINGS_KEY_ACTIVE_DATASET, OT_SETTINGS_KEY_PENDING_DATASET,
-                                         OT_SETTINGS_KEY_SRP_ECDSA_KEY};
+static const uint16_t kCriticalKeys[] = {SettingsBase::kKeyActiveDataset, SettingsBase::kKeyPendingDataset,
+                                         SettingsBase::kKeySrpEcdsaKey};
 
 // LCOV_EXCL_START
 
@@ -224,8 +224,7 @@ void Settings::Wipe(void)
 
 otError Settings::SaveOperationalDataset(bool aIsActive, const MeshCoP::Dataset &aDataset)
 {
-    otError error = Save(aIsActive ? OT_SETTINGS_KEY_ACTIVE_DATASET : OT_SETTINGS_KEY_PENDING_DATASET,
-                         aDataset.GetBytes(), aDataset.GetSize());
+    otError error = Save(aIsActive ? kKeyActiveDataset : kKeyPendingDataset, aDataset.GetBytes(), aDataset.GetSize());
 
     LogFailure(error, "saving OperationalDataset", false);
     return error;
@@ -236,8 +235,7 @@ otError Settings::ReadOperationalDataset(bool aIsActive, MeshCoP::Dataset &aData
     otError  error  = OT_ERROR_NONE;
     uint16_t length = MeshCoP::Dataset::kMaxSize;
 
-    SuccessOrExit(error = Read(aIsActive ? OT_SETTINGS_KEY_ACTIVE_DATASET : OT_SETTINGS_KEY_PENDING_DATASET,
-                               aDataset.GetBytes(), length));
+    SuccessOrExit(error = Read(aIsActive ? kKeyActiveDataset : kKeyPendingDataset, aDataset.GetBytes(), length));
     VerifyOrExit(length <= MeshCoP::Dataset::kMaxSize, error = OT_ERROR_NOT_FOUND);
 
     aDataset.SetSize(length);
@@ -248,7 +246,7 @@ exit:
 
 otError Settings::DeleteOperationalDataset(bool aIsActive)
 {
-    otError error = Delete(aIsActive ? OT_SETTINGS_KEY_ACTIVE_DATASET : OT_SETTINGS_KEY_PENDING_DATASET);
+    otError error = Delete(aIsActive ? kKeyActiveDataset : kKeyPendingDataset);
 
     LogFailure(error, "deleting OperationalDataset", true);
 
@@ -261,7 +259,7 @@ otError Settings::ReadNetworkInfo(NetworkInfo &aNetworkInfo) const
     uint16_t length = sizeof(NetworkInfo);
 
     aNetworkInfo.Init();
-    SuccessOrExit(error = Read(OT_SETTINGS_KEY_NETWORK_INFO, &aNetworkInfo, length));
+    SuccessOrExit(error = Read(kKeyNetworkInfo, &aNetworkInfo, length));
     LogNetworkInfo("Read", aNetworkInfo);
 
 exit:
@@ -274,14 +272,14 @@ otError Settings::SaveNetworkInfo(const NetworkInfo &aNetworkInfo)
     NetworkInfo prevNetworkInfo;
     uint16_t    length = sizeof(prevNetworkInfo);
 
-    if ((Read(OT_SETTINGS_KEY_NETWORK_INFO, &prevNetworkInfo, length) == OT_ERROR_NONE) &&
-        (length == sizeof(NetworkInfo)) && (prevNetworkInfo == aNetworkInfo))
+    if ((Read(kKeyNetworkInfo, &prevNetworkInfo, length) == OT_ERROR_NONE) && (length == sizeof(NetworkInfo)) &&
+        (prevNetworkInfo == aNetworkInfo))
     {
         LogNetworkInfo("Re-saved", aNetworkInfo);
         ExitNow();
     }
 
-    SuccessOrExit(error = Save(OT_SETTINGS_KEY_NETWORK_INFO, &aNetworkInfo, sizeof(NetworkInfo)));
+    SuccessOrExit(error = Save(kKeyNetworkInfo, &aNetworkInfo, sizeof(NetworkInfo)));
     LogNetworkInfo("Saved", aNetworkInfo);
 
 exit:
@@ -293,7 +291,7 @@ otError Settings::DeleteNetworkInfo(void)
 {
     otError error;
 
-    SuccessOrExit(error = Delete(OT_SETTINGS_KEY_NETWORK_INFO));
+    SuccessOrExit(error = Delete(kKeyNetworkInfo));
     otLogInfoCore("Non-volatile: Deleted NetworkInfo");
 
 exit:
@@ -307,7 +305,7 @@ otError Settings::ReadParentInfo(ParentInfo &aParentInfo) const
     uint16_t length = sizeof(ParentInfo);
 
     aParentInfo.Init();
-    SuccessOrExit(error = Read(OT_SETTINGS_KEY_PARENT_INFO, &aParentInfo, length));
+    SuccessOrExit(error = Read(kKeyParentInfo, &aParentInfo, length));
     LogParentInfo("Read", aParentInfo);
 
 exit:
@@ -320,14 +318,14 @@ otError Settings::SaveParentInfo(const ParentInfo &aParentInfo)
     ParentInfo prevParentInfo;
     uint16_t   length = sizeof(ParentInfo);
 
-    if ((Read(OT_SETTINGS_KEY_PARENT_INFO, &prevParentInfo, length) == OT_ERROR_NONE) &&
-        (length == sizeof(ParentInfo)) && (prevParentInfo == aParentInfo))
+    if ((Read(kKeyParentInfo, &prevParentInfo, length) == OT_ERROR_NONE) && (length == sizeof(ParentInfo)) &&
+        (prevParentInfo == aParentInfo))
     {
         LogParentInfo("Re-saved", aParentInfo);
         ExitNow();
     }
 
-    SuccessOrExit(error = Save(OT_SETTINGS_KEY_PARENT_INFO, &aParentInfo, sizeof(ParentInfo)));
+    SuccessOrExit(error = Save(kKeyParentInfo, &aParentInfo, sizeof(ParentInfo)));
     LogParentInfo("Saved", aParentInfo);
 
 exit:
@@ -339,7 +337,7 @@ otError Settings::DeleteParentInfo(void)
 {
     otError error;
 
-    SuccessOrExit(error = Delete(OT_SETTINGS_KEY_PARENT_INFO));
+    SuccessOrExit(error = Delete(kKeyParentInfo));
     otLogInfoCore("Non-volatile: Deleted ParentInfo");
 
 exit:
@@ -351,7 +349,7 @@ otError Settings::AddChildInfo(const ChildInfo &aChildInfo)
 {
     otError error;
 
-    SuccessOrExit(error = Add(OT_SETTINGS_KEY_CHILD_INFO, &aChildInfo, sizeof(aChildInfo)));
+    SuccessOrExit(error = Add(kKeyChildInfo, &aChildInfo, sizeof(aChildInfo)));
     LogChildInfo("Added", aChildInfo);
 
 exit:
@@ -363,7 +361,7 @@ otError Settings::DeleteAllChildInfo(void)
 {
     otError error;
 
-    SuccessOrExit(error = Delete(OT_SETTINGS_KEY_CHILD_INFO));
+    SuccessOrExit(error = Delete(kKeyChildInfo));
     otLogInfoCore("Non-volatile: Deleted all ChildInfo");
 
 exit:
@@ -393,7 +391,7 @@ otError Settings::ChildInfoIterator::Delete(void)
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(!mIsDone, error = OT_ERROR_INVALID_STATE);
-    SuccessOrExit(error = Get<SettingsDriver>().Delete(OT_SETTINGS_KEY_CHILD_INFO, mIndex));
+    SuccessOrExit(error = Get<SettingsDriver>().Delete(kKeyChildInfo, mIndex));
     LogChildInfo("Removed", mChildInfo);
 
 exit:
@@ -407,8 +405,8 @@ void Settings::ChildInfoIterator::Read(void)
     otError  error;
 
     mChildInfo.Init();
-    SuccessOrExit(error = Get<SettingsDriver>().Get(OT_SETTINGS_KEY_CHILD_INFO, mIndex,
-                                                    reinterpret_cast<uint8_t *>(&mChildInfo), &length));
+    SuccessOrExit(
+        error = Get<SettingsDriver>().Get(kKeyChildInfo, mIndex, reinterpret_cast<uint8_t *>(&mChildInfo), &length));
     LogChildInfo("Read", mChildInfo);
 
 exit:
@@ -422,7 +420,7 @@ otError Settings::ReadDadInfo(DadInfo &aDadInfo) const
     uint16_t length = sizeof(DadInfo);
 
     aDadInfo.Init();
-    SuccessOrExit(error = Read(OT_SETTINGS_KEY_DAD_INFO, &aDadInfo, length));
+    SuccessOrExit(error = Read(kKeyDadInfo, &aDadInfo, length));
     LogDadInfo("Read", aDadInfo);
 
 exit:
@@ -435,14 +433,14 @@ otError Settings::SaveDadInfo(const DadInfo &aDadInfo)
     DadInfo  prevDadInfo;
     uint16_t length = sizeof(DadInfo);
 
-    if ((Read(OT_SETTINGS_KEY_DAD_INFO, &prevDadInfo, length) == OT_ERROR_NONE) && (length == sizeof(DadInfo)) &&
+    if ((Read(kKeyDadInfo, &prevDadInfo, length) == OT_ERROR_NONE) && (length == sizeof(DadInfo)) &&
         (prevDadInfo == aDadInfo))
     {
         LogDadInfo("Re-saved", aDadInfo);
         ExitNow();
     }
 
-    SuccessOrExit(error = Save(OT_SETTINGS_KEY_DAD_INFO, &aDadInfo, sizeof(DadInfo)));
+    SuccessOrExit(error = Save(kKeyDadInfo, &aDadInfo, sizeof(DadInfo)));
     LogDadInfo("Saved", aDadInfo);
 
 exit:
@@ -454,7 +452,7 @@ otError Settings::DeleteDadInfo(void)
 {
     otError error;
 
-    SuccessOrExit(error = Delete(OT_SETTINGS_KEY_DAD_INFO));
+    SuccessOrExit(error = Delete(kKeyDadInfo));
     otLogInfoCore("Non-volatile: Deleted DadInfo");
 
 exit:
@@ -470,14 +468,14 @@ otError Settings::SaveOmrPrefix(const Ip6::Prefix &aOmrPrefix)
     Ip6::Prefix prevOmrPrefix;
     uint16_t    length = sizeof(prevOmrPrefix);
 
-    if ((Read(OT_SETTINGS_KEY_OMR_PREFIX, &prevOmrPrefix, length) == OT_ERROR_NONE) &&
-        (length == sizeof(prevOmrPrefix)) && (prevOmrPrefix == aOmrPrefix))
+    if ((Read(kKeyOmrPrefix, &prevOmrPrefix, length) == OT_ERROR_NONE) && (length == sizeof(prevOmrPrefix)) &&
+        (prevOmrPrefix == aOmrPrefix))
     {
         LogPrefix("Re-saved", "OMR prefix", aOmrPrefix);
         ExitNow();
     }
 
-    SuccessOrExit(error = Save(OT_SETTINGS_KEY_OMR_PREFIX, &aOmrPrefix, sizeof(aOmrPrefix)));
+    SuccessOrExit(error = Save(kKeyOmrPrefix, &aOmrPrefix, sizeof(aOmrPrefix)));
     LogPrefix("Saved", "OMR prefix", aOmrPrefix);
 
 exit:
@@ -491,7 +489,7 @@ otError Settings::ReadOmrPrefix(Ip6::Prefix &aOmrPrefix) const
     uint16_t length = sizeof(aOmrPrefix);
 
     aOmrPrefix.Clear();
-    SuccessOrExit(error = Read(OT_SETTINGS_KEY_OMR_PREFIX, &aOmrPrefix, length));
+    SuccessOrExit(error = Read(kKeyOmrPrefix, &aOmrPrefix, length));
     LogPrefix("Read", "OMR prefix", aOmrPrefix);
 
 exit:
@@ -504,14 +502,14 @@ otError Settings::SaveOnLinkPrefix(const Ip6::Prefix &aOnLinkPrefix)
     Ip6::Prefix prevOnLinkPrefix;
     uint16_t    length = sizeof(prevOnLinkPrefix);
 
-    if ((Read(OT_SETTINGS_KEY_ON_LINK_PREFIX, &prevOnLinkPrefix, length) == OT_ERROR_NONE) &&
-        (length == sizeof(prevOnLinkPrefix)) && (prevOnLinkPrefix == aOnLinkPrefix))
+    if ((Read(kKeyOnLinkPrefix, &prevOnLinkPrefix, length) == OT_ERROR_NONE) && (length == sizeof(prevOnLinkPrefix)) &&
+        (prevOnLinkPrefix == aOnLinkPrefix))
     {
         LogPrefix("Re-saved", "on-link prefix", aOnLinkPrefix);
         ExitNow();
     }
 
-    SuccessOrExit(error = Save(OT_SETTINGS_KEY_ON_LINK_PREFIX, &aOnLinkPrefix, sizeof(aOnLinkPrefix)));
+    SuccessOrExit(error = Save(kKeyOnLinkPrefix, &aOnLinkPrefix, sizeof(aOnLinkPrefix)));
     LogPrefix("Saved", "on-link prefix", aOnLinkPrefix);
 
 exit:
@@ -525,7 +523,7 @@ otError Settings::ReadOnLinkPrefix(Ip6::Prefix &aOnLinkPrefix) const
     uint16_t length = sizeof(aOnLinkPrefix);
 
     aOnLinkPrefix.Clear();
-    SuccessOrExit(error = Read(OT_SETTINGS_KEY_ON_LINK_PREFIX, &aOnLinkPrefix, length));
+    SuccessOrExit(error = Read(kKeyOnLinkPrefix, &aOnLinkPrefix, length));
     LogPrefix("Read", "on-link prefix", aOnLinkPrefix);
 
 exit:
@@ -539,7 +537,7 @@ otError Settings::SaveSrpKey(const Crypto::Ecdsa::P256::KeyPair &aKeyPair)
 {
     otError error = OT_ERROR_NONE;
 
-    SuccessOrExit(error = Save(OT_SETTINGS_KEY_SRP_ECDSA_KEY, aKeyPair.GetDerBytes(), aKeyPair.GetDerLength()));
+    SuccessOrExit(error = Save(kKeySrpEcdsaKey, aKeyPair.GetDerBytes(), aKeyPair.GetDerLength()));
     otLogInfoCore("Non-volatile: Saved SRP key");
 
 exit:
@@ -552,7 +550,7 @@ otError Settings::ReadSrpKey(Crypto::Ecdsa::P256::KeyPair &aKeyPair) const
     otError  error;
     uint16_t length = Crypto::Ecdsa::P256::KeyPair::kMaxDerSize;
 
-    SuccessOrExit(error = Read(OT_SETTINGS_KEY_SRP_ECDSA_KEY, aKeyPair.GetDerBytes(), length));
+    SuccessOrExit(error = Read(kKeySrpEcdsaKey, aKeyPair.GetDerBytes(), length));
     VerifyOrExit(length <= Crypto::Ecdsa::P256::KeyPair::kMaxDerSize, error = OT_ERROR_NOT_FOUND);
     aKeyPair.SetDerLength(static_cast<uint8_t>(length));
     otLogInfoCore("Non-volatile: Read SRP key");
@@ -565,7 +563,7 @@ otError Settings::DeleteSrpKey(void)
 {
     otError error;
 
-    SuccessOrExit(error = Delete(OT_SETTINGS_KEY_SRP_ECDSA_KEY));
+    SuccessOrExit(error = Delete(kKeySrpEcdsaKey));
     otLogInfoCore("Non-volatile: Deleted SRP key");
 
 exit:

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#include <openthread/platform/settings.h>
+
 #include "common/clearable.hpp"
 #include "common/encoding.hpp"
 #include "common/equatable.hpp"
@@ -80,8 +82,8 @@ public:
     /**
      * This method sets the critical keys that should be stored in a secure area.
      *
-     * @param[in]  aKeys        A pointer to the value of the critical keys.
-     * @param[in]  aKeysLength  The length of the keys pointed to by @p akeys.
+     * @param[in]  aKeys        A pointer to an array containing the list of critical keys.
+     * @param[in]  aKeysLength  The number of entries in the @p aKeys array.
      *
      */
     void SetCriticalKeys(const uint16_t *aKeys, uint16_t aKeysLength);
@@ -587,25 +589,6 @@ public:
         uint8_t mDadCounter; ///< Dad Counter used to resolve address conflict in Thread 1.2 DUA feature.
     } OT_TOOL_PACKED_END;
 
-    /**
-     * This enumeration defines the keys of settings.
-     *
-     */
-    enum Key
-    {
-        kKeyActiveDataset     = 0x0001, ///< Active Operational Dataset
-        kKeyPendingDataset    = 0x0002, ///< Pending Operational Dataset
-        kKeyNetworkInfo       = 0x0003, ///< Thread network information
-        kKeyParentInfo        = 0x0004, ///< Parent information
-        kKeyChildInfo         = 0x0005, ///< Child information
-        kKeyReserved          = 0x0006, ///< Reserved (previously auto-start)
-        kKeySlaacIidSecretKey = 0x0007, ///< Secret key used by SLAAC module for generating semantically opaque IID
-        kKeyDadInfo           = 0x0008, ///< Duplicate Address Detection (DAD) information.
-        kKeyOmrPrefix         = 0x0009, ///< Off-mesh routable (OMR) prefix.
-        kKeyOnLinkPrefix      = 0x000a, ///< On-link prefix for infrastructure link.
-        kKeySrpEcdsaKey       = 0x000b, ///< SRP client ECDSA public/private key pair.
-    };
-
 protected:
     explicit SettingsBase(Instance &aInstance)
         : InstanceLocator(aInstance)
@@ -796,7 +779,7 @@ public:
      */
     otError SaveSlaacIidSecretKey(const Utils::Slaac::IidSecretKey &aKey)
     {
-        return Save(kKeySlaacIidSecretKey, &aKey, sizeof(Utils::Slaac::IidSecretKey));
+        return Save(OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY, &aKey, sizeof(Utils::Slaac::IidSecretKey));
     }
 
     /**
@@ -813,7 +796,7 @@ public:
     {
         uint16_t length = sizeof(aKey);
 
-        return Read(kKeySlaacIidSecretKey, &aKey, length);
+        return Read(OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY, &aKey, length);
     }
 
     /**
@@ -823,7 +806,7 @@ public:
      * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
      *
      */
-    otError DeleteSlaacIidSecretKey(void) { return Delete(kKeySlaacIidSecretKey); }
+    otError DeleteSlaacIidSecretKey(void) { return Delete(OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY); }
 
 #endif // OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
 
@@ -1120,8 +1103,6 @@ private:
     otError Save(Key aKey, const void *aValue, uint16_t aSize);
     otError Add(Key aKey, const void *aValue, uint16_t aSize);
     otError Delete(Key aKey);
-
-    const uint16_t mCriticalKeys[3] = {kKeyActiveDataset, kKeyPendingDataset, kKeySrpEcdsaKey};
 };
 
 } // namespace ot

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -78,6 +78,15 @@ public:
     void Deinit(void);
 
     /**
+     * This method sets the critical keys that should be stored in a secure area.
+     *
+     * @param[in]  aKeys        A pointer to the value of the critical keys.
+     * @param[in]  aKeysLength  The length of the keys pointed to by @p akeys.
+     *
+     */
+    void SetCriticalKeys(const uint16_t *aKeys, uint16_t aKeysLength);
+
+    /**
      * This method adds a value to @p aKey.
      *
      * @param[in]  aKey          The key associated with the value.
@@ -1111,6 +1120,8 @@ private:
     otError Save(Key aKey, const void *aValue, uint16_t aSize);
     otError Add(Key aKey, const void *aValue, uint16_t aSize);
     otError Delete(Key aKey);
+
+    const uint16_t mCriticalKeys[3] = {kKeyActiveDataset, kKeyPendingDataset, kKeySrpEcdsaKey};
 };
 
 } // namespace ot

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -589,6 +589,25 @@ public:
         uint8_t mDadCounter; ///< Dad Counter used to resolve address conflict in Thread 1.2 DUA feature.
     } OT_TOOL_PACKED_END;
 
+    /**
+     * This enumeration defines the keys of settings.
+     *
+     */
+    enum Key
+    {
+        kKeyActiveDataset     = OT_SETTINGS_KEY_ACTIVE_DATASET,
+        kKeyPendingDataset    = OT_SETTINGS_KEY_PENDING_DATASET,
+        kKeyNetworkInfo       = OT_SETTINGS_KEY_NETWORK_INFO,
+        kKeyParentInfo        = OT_SETTINGS_KEY_PARENT_INFO,
+        kKeyChildInfo         = OT_SETTINGS_KEY_CHILD_INFO,
+        kKeyReserved          = OT_SETTINGS_KEY_RESERVED,
+        kKeySlaacIidSecretKey = OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY,
+        kKeyDadInfo           = OT_SETTINGS_KEY_DAD_INFO,
+        kKeyOmrPrefix         = OT_SETTINGS_KEY_OMR_PREFIX,
+        kKeyOnLinkPrefix      = OT_SETTINGS_KEY_ON_LINK_PREFIX,
+        kKeySrpEcdsaKey       = OT_SETTINGS_KEY_SRP_ECDSA_KEY,
+    };
+
 protected:
     explicit SettingsBase(Instance &aInstance)
         : InstanceLocator(aInstance)
@@ -779,7 +798,7 @@ public:
      */
     otError SaveSlaacIidSecretKey(const Utils::Slaac::IidSecretKey &aKey)
     {
-        return Save(OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY, &aKey, sizeof(Utils::Slaac::IidSecretKey));
+        return Save(kKeySlaacIidSecretKey, &aKey, sizeof(Utils::Slaac::IidSecretKey));
     }
 
     /**
@@ -796,7 +815,7 @@ public:
     {
         uint16_t length = sizeof(aKey);
 
-        return Read(OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY, &aKey, length);
+        return Read(kKeySlaacIidSecretKey, &aKey, length);
     }
 
     /**
@@ -806,7 +825,7 @@ public:
      * @retval OT_ERROR_NOT_IMPLEMENTED  The platform does not implement settings functionality.
      *
      */
-    otError DeleteSlaacIidSecretKey(void) { return Delete(OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY); }
+    otError DeleteSlaacIidSecretKey(void) { return Delete(kKeySlaacIidSecretKey); }
 
 #endif // OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
 

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -732,9 +732,9 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::ThreadDatasetHandler(con
     opDataset.mComponents.mIsActiveTimestampPresent = true;
 
     SuccessOrExit(error = dataset.SetFrom(static_cast<MeshCoP::Dataset::Info &>(opDataset)));
-    SuccessOrExit(error = otPlatSettingsSet(
-                      mInstance, isActive ? SettingsBase::kKeyActiveDataset : SettingsBase::kKeyPendingDataset,
-                      dataset.GetBytes(), dataset.GetSize()));
+    SuccessOrExit(error = otPlatSettingsSet(mInstance,
+                                            isActive ? OT_SETTINGS_KEY_ACTIVE_DATASET : OT_SETTINGS_KEY_PENDING_DATASET,
+                                            dataset.GetBytes(), dataset.GetSize()));
 
 exit:
     return error;

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -732,9 +732,9 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::ThreadDatasetHandler(con
     opDataset.mComponents.mIsActiveTimestampPresent = true;
 
     SuccessOrExit(error = dataset.SetFrom(static_cast<MeshCoP::Dataset::Info &>(opDataset)));
-    SuccessOrExit(error = otPlatSettingsSet(mInstance,
-                                            isActive ? OT_SETTINGS_KEY_ACTIVE_DATASET : OT_SETTINGS_KEY_PENDING_DATASET,
-                                            dataset.GetBytes(), dataset.GetSize()));
+    SuccessOrExit(error = otPlatSettingsSet(
+                      mInstance, isActive ? SettingsBase::kKeyActiveDataset : SettingsBase::kKeyPendingDataset,
+                      dataset.GetBytes(), dataset.GetSize()));
 
 exit:
     return error;

--- a/src/posix/platform/include/openthread/platform/secure_settings.h
+++ b/src/posix/platform/include/openthread/platform/secure_settings.h
@@ -57,7 +57,7 @@ extern "C" {
  * @param[in]  aInstance The OpenThread instance structure.
  *
  */
-void otPlatSecureSettingsInit(otInstance *aInstance);
+void otPosixSecureSettingsInit(otInstance *aInstance);
 
 /**
  * This function performs any de-initialization for the secure settings subsystem, if necessary.
@@ -65,7 +65,7 @@ void otPlatSecureSettingsInit(otInstance *aInstance);
  * @param[in]  aInstance The OpenThread instance structure.
  *
  */
-void otPlatSecureSettingsDeinit(otInstance *aInstance);
+void otPosixSecureSettingsDeinit(otInstance *aInstance);
 
 /**
  * This function fetches the value of the setting identified by aKey and write it to the memory pointed to by aValue.
@@ -94,11 +94,11 @@ void otPlatSecureSettingsDeinit(otInstance *aInstance);
  * @retval OT_ERROR_NOT_IMPLEMENTED  This function is not implemented on this platform.
  *
  */
-otError otPlatSecureSettingsGet(otInstance *aInstance,
-                                uint16_t    aKey,
-                                int         aIndex,
-                                uint8_t *   aValue,
-                                uint16_t *  aValueLength);
+otError otPosixSecureSettingsGet(otInstance *aInstance,
+                                 uint16_t    aKey,
+                                 int         aIndex,
+                                 uint8_t *   aValue,
+                                 uint16_t *  aValueLength);
 
 /**
  * This function sets or replaces the value of a setting identified by aKey. If there was more than one value
@@ -117,7 +117,7 @@ otError otPlatSecureSettingsGet(otInstance *aInstance,
  * @retval OT_ERROR_NO_BUFS          No space remaining to store the given setting.
  *
  */
-otError otPlatSecureSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+otError otPosixSecureSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
 
 /**
  * This function adds the value to a setting identified by aKey, without replacing any existing values.
@@ -139,7 +139,7 @@ otError otPlatSecureSettingsSet(otInstance *aInstance, uint16_t aKey, const uint
  * @retval OT_ERROR_NO_BUFS          No space remaining to store the given setting.
  *
  */
-otError otPlatSecureSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+otError otPosixSecureSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
 
 /**
  * This function deletes a specific value from the setting identified by aKey from the secure settings store.
@@ -156,7 +156,7 @@ otError otPlatSecureSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint
  * @retval OT_ERROR_NOT_IMPLEMENTED  This function is not implemented on this platform.
  *
  */
-otError otPlatSecureSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex);
+otError otPosixSecureSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex);
 
 /**
  * This function deletes all settings from the secure settings store, resetting it to its initial factory state.
@@ -164,7 +164,7 @@ otError otPlatSecureSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIn
  * @param[in] aInstance  The OpenThread instance structure.
  *
  */
-void otPlatSecureSettingsWipe(otInstance *aInstance);
+void otPosixSecureSettingsWipe(otInstance *aInstance);
 
 /**
  * @}

--- a/src/posix/platform/include/openthread/platform/secure_settings.h
+++ b/src/posix/platform/include/openthread/platform/secure_settings.h
@@ -1,0 +1,178 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief
+ *   This file includes platform abstraction for secure non-volatile storage of settings.
+ */
+
+#ifndef OPENTHREAD_POSIX_SECURE_SETTINGS_H_
+#define OPENTHREAD_POSIX_SECURE_SETTINGS_H_
+
+#include <openthread/instance.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @addtogroup plat-settings
+ *
+ * @brief
+ *   This module includes the platform abstraction for secure non-volatile storage of settings.
+ *
+ * @{
+ *
+ */
+
+/**
+ * This function performs any initialization for the secure settings subsystem, if necessary.
+ *
+ * @param[in]  aInstance The OpenThread instance structure.
+ *
+ */
+void otPlatSecureSettingsInit(otInstance *aInstance);
+
+/**
+ * This function performs any de-initialization for the secure settings subsystem, if necessary.
+ *
+ * @param[in]  aInstance The OpenThread instance structure.
+ *
+ */
+void otPlatSecureSettingsDeinit(otInstance *aInstance);
+
+/**
+ * This function fetches the value of the setting identified by aKey and write it to the memory pointed to by aValue.
+ * It then writes the length to the integer pointed to by aValueLength. The initial value of aValueLength is the
+ * maximum number of bytes to be written to aValue.
+ *
+ * This function can be used to check for the existence of a key without fetching the value by setting aValue and
+ * aValueLength to NULL. You can also check the length of the setting without fetching it by setting only aValue
+ * to NULL.
+ *
+ * Note that the underlying storage implementation is not required to maintain the order of settings with multiple
+ * values. The order of such values MAY change after ANY write operation to the store.
+ *
+ * @param[in]     aInstance     The OpenThread instance structure.
+ * @param[in]     aKey          The key associated with the requested setting.
+ * @param[in]     aIndex        The index of the specific item to get.
+ * @param[out]    aValue        A pointer to where the value of the setting should be written. May be set to NULL if
+ *                              just testing for the presence or length of a setting.
+ * @param[inout]  aValueLength  A pointer to the length of the value. When called, this pointer should point to an
+ *                              integer containing the maximum value size that can be written to aValue. At return,
+ *                              the actual length of the setting is written. This may be set to NULL if performing
+ *                              a presence check.
+ *
+ * @retval OT_ERROR_NONE             The given setting was found and fetched successfully.
+ * @retval OT_ERROR_NOT_FOUND        The given setting was not found in the setting store.
+ * @retval OT_ERROR_NOT_IMPLEMENTED  This function is not implemented on this platform.
+ *
+ */
+otError otPlatSecureSettingsGet(otInstance *aInstance,
+                                uint16_t    aKey,
+                                int         aIndex,
+                                uint8_t *   aValue,
+                                uint16_t *  aValueLength);
+
+/**
+ * This function sets or replaces the value of a setting identified by aKey. If there was more than one value
+ * previously associated with aKey, then they are all deleted and replaced with this single entry.
+ *
+ * Calling this function successfully may cause unrelated settings with multiple values to be reordered.
+ *
+ * @param[in]  aInstance     The OpenThread instance structure.
+ * @param[in]  aKey          The key associated with the setting to change.
+ * @param[in]  aValue        A pointer to where the new value of the setting should be read from. MUST NOT be NULL if
+ *                           aValueLength is non-zero.
+ * @param[in]  aValueLength  The length of the data pointed to by aValue. May be zero.
+ *
+ * @retval OT_ERROR_NONE             The given setting was changed or staged.
+ * @retval OT_ERROR_NOT_IMPLEMENTED  This function is not implemented on this platform.
+ * @retval OT_ERROR_NO_BUFS          No space remaining to store the given setting.
+ *
+ */
+otError otPlatSecureSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+
+/**
+ * This function adds the value to a setting identified by aKey, without replacing any existing values.
+ *
+ * Note that the underlying implementation is not required to maintain the order of the items associated with a
+ * specific key. The added value may be added to the end, the beginning, or even somewhere in the middle. The order
+ * of any pre-existing values may also change.
+ *
+ * Calling this function successfully may cause unrelated settings with multiple values to be reordered.
+ *
+ * @param[in]  aInstance     The OpenThread instance structure.
+ * @param[in]  aKey          The key associated with the setting to change.
+ * @param[in]  aValue        A pointer to where the new value of the setting should be read from. MUST NOT be NULL
+ *                           if aValueLength is non-zero.
+ * @param[in]  aValueLength  The length of the data pointed to by aValue. May be zero.
+ *
+ * @retval OT_ERROR_NONE             The given setting was added or staged to be added.
+ * @retval OT_ERROR_NOT_IMPLEMENTED  This function is not implemented on this platform.
+ * @retval OT_ERROR_NO_BUFS          No space remaining to store the given setting.
+ *
+ */
+otError otPlatSecureSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+
+/**
+ * This function deletes a specific value from the setting identified by aKey from the secure settings store.
+ *
+ * Note that the underlying implementation is not required to maintain the order of the items associated with a
+ * specific key.
+ *
+ * @param[in] aInstance  The OpenThread instance structure.
+ * @param[in] aKey       The key associated with the requested setting.
+ * @param[in] aIndex     The index of the value to be removed. If set to -1, all values for this aKey will be removed.
+ *
+ * @retval OT_ERROR_NONE             The given key and index was found and removed successfully.
+ * @retval OT_ERROR_NOT_FOUND        The given key or index was not found in the setting store.
+ * @retval OT_ERROR_NOT_IMPLEMENTED  This function is not implemented on this platform.
+ *
+ */
+otError otPlatSecureSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex);
+
+/**
+ * This function deletes all settings from the secure settings store, resetting it to its initial factory state.
+ *
+ * @param[in] aInstance  The OpenThread instance structure.
+ *
+ */
+void otPlatSecureSettingsWipe(otInstance *aInstance);
+
+/**
+ * @}
+ *
+ */
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // OPENTHREAD_POSIX_SECURE_SETTINGS_H_

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -140,6 +140,17 @@
 #define OPENTHREAD_POSIX_CONFIG_MAX_MULTICAST_FORWARDING_CACHE_TABLE (OPENTHREAD_CONFIG_MAX_MULTICAST_LISTENERS * 10)
 #endif
 
+/**
+ * @def OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+ *
+ * Define as 1 to enable the secure settings. When defined to 1, the platform MUST implement the otPlatSecureSetting*
+ * APIs defined in 'src/posix/platform/include/openthread/platform/secure_settings.h'.
+ *
+ */
+#ifndef OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+#define OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE 0
+#endif
+
 #ifdef __APPLE__
 
 /**

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -143,7 +143,7 @@
 /**
  * @def OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
  *
- * Define as 1 to enable the secure settings. When defined to 1, the platform MUST implement the otPlatSecureSetting*
+ * Define as 1 to enable the secure settings. When defined to 1, the platform MUST implement the otPosixSecureSetting*
  * APIs defined in 'src/posix/platform/include/openthread/platform/secure_settings.h'.
  *
  */

--- a/src/posix/platform/settings.cpp
+++ b/src/posix/platform/settings.cpp
@@ -169,7 +169,7 @@ void otPlatSettingsInit(otInstance *aInstance)
     otError error = OT_ERROR_NONE;
 
 #if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    otPlatSecureSettingsInit(aInstance);
+    otPosixSecureSettingsInit(aInstance);
 #endif
 
     {
@@ -218,7 +218,7 @@ void otPlatSettingsDeinit(otInstance *aInstance)
     OT_UNUSED_VARIABLE(aInstance);
 
 #if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    otPlatSecureSettingsDeinit(aInstance);
+    otPosixSecureSettingsDeinit(aInstance);
 #endif
 
     assert(sSettingsFd != -1);
@@ -236,7 +236,7 @@ otError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint
 #if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
     if (isCriticalKey(aKey))
     {
-        ExitNow(error = otPlatSecureSettingsGet(aInstance, aKey, aIndex, aValue, aValueLength));
+        ExitNow(error = otPosixSecureSettingsGet(aInstance, aKey, aIndex, aValue, aValueLength));
     }
 #endif
 
@@ -297,7 +297,7 @@ otError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *a
 #if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
     if (isCriticalKey(aKey))
     {
-        ExitNow(error = otPlatSecureSettingsSet(aInstance, aKey, aValue, aValueLength));
+        ExitNow(error = otPosixSecureSettingsSet(aInstance, aKey, aValue, aValueLength));
     }
 #endif
 
@@ -336,7 +336,7 @@ otError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *a
 #if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
     if (isCriticalKey(aKey))
     {
-        ExitNow(error = otPlatSecureSettingsAdd(aInstance, aKey, aValue, aValueLength));
+        ExitNow(error = otPosixSecureSettingsAdd(aInstance, aKey, aValue, aValueLength));
     }
 #endif
 
@@ -366,7 +366,7 @@ otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
 #if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
     if (isCriticalKey(aKey))
     {
-        error = otPlatSecureSettingsDelete(aInstance, aKey, aIndex);
+        error = otPosixSecureSettingsDelete(aInstance, aKey, aIndex);
     }
     else
 #endif
@@ -475,7 +475,7 @@ void otPlatSettingsWipe(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
 #if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    otPlatSecureSettingsWipe(aInstance);
+    otPosixSecureSettingsWipe(aInstance);
 #endif
 
     VerifyOrDie(0 == ftruncate(sSettingsFd, 0), OT_EXIT_ERROR_ERRNO);

--- a/src/posix/platform/settings.cpp
+++ b/src/posix/platform/settings.cpp
@@ -47,6 +47,9 @@
 #include <openthread/platform/misc.h>
 #include <openthread/platform/radio.h>
 #include <openthread/platform/settings.h>
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+#include <openthread/platform/secure_settings.h>
+#endif
 
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
@@ -56,6 +59,34 @@ static const size_t kMaxFileNameSize = sizeof(OPENTHREAD_CONFIG_POSIX_SETTINGS_P
 static int sSettingsFd = -1;
 
 static otError platformSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex, int *aSwapFd);
+
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+static const uint16_t *sKeys       = nullptr;
+static uint16_t        sKeysLength = 0;
+
+void otPlatSettingsSetCriticalKeys(otInstance *aInstance, const uint16_t *aKeys, uint16_t aKeysLength)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    sKeys       = aKeys;
+    sKeysLength = aKeysLength;
+}
+
+static bool isCriticalKey(uint16_t aKey)
+{
+    bool ret = false;
+
+    VerifyOrExit(sKeys != nullptr);
+
+    for (uint16_t i = 0; i < sKeysLength; i++)
+    {
+        VerifyOrExit(aKey != sKeys[i], ret = true);
+    }
+
+exit:
+    return ret;
+}
+#endif
 
 static void getSettingsFileName(otInstance *aInstance, char aFileName[kMaxFileNameSize], bool aSwap)
 {
@@ -137,6 +168,10 @@ void otPlatSettingsInit(otInstance *aInstance)
 {
     otError error = OT_ERROR_NONE;
 
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    otPlatSecureSettingsInit(aInstance);
+#endif
+
     {
         struct stat st;
 
@@ -182,6 +217,10 @@ void otPlatSettingsDeinit(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    otPlatSecureSettingsDeinit(aInstance);
+#endif
+
     assert(sSettingsFd != -1);
     VerifyOrDie(close(sSettingsFd) == 0, OT_EXIT_ERROR_ERRNO);
 }
@@ -193,6 +232,13 @@ otError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint
     otError     error  = OT_ERROR_NOT_FOUND;
     const off_t size   = lseek(sSettingsFd, 0, SEEK_END);
     off_t       offset = lseek(sSettingsFd, 0, SEEK_SET);
+
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    if (isCriticalKey(aKey))
+    {
+        ExitNow(error = otPlatSecureSettingsGet(aInstance, aKey, aIndex, aValue, aValueLength));
+    }
+#endif
 
     VerifyOrExit(offset == 0 && size >= 0, error = OT_ERROR_PARSE);
 
@@ -245,7 +291,15 @@ exit:
 
 otError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
 {
-    int swapFd = -1;
+    int     swapFd = -1;
+    otError error  = OT_ERROR_NONE;
+
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    if (isCriticalKey(aKey))
+    {
+        ExitNow(error = otPlatSecureSettingsSet(aInstance, aKey, aValue, aValueLength));
+    }
+#endif
 
     switch (platformSettingsDelete(aInstance, aKey, -1, &swapFd))
     {
@@ -265,15 +319,26 @@ otError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *a
 
     swapPersist(aInstance, swapFd);
 
-    return OT_ERROR_NONE;
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+exit:
+#endif
+    return error;
 }
 
 otError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    off_t size   = lseek(sSettingsFd, 0, SEEK_END);
-    int   swapFd = swapOpen(aInstance);
+    otError error  = OT_ERROR_NONE;
+    off_t   size   = lseek(sSettingsFd, 0, SEEK_END);
+    int     swapFd = swapOpen(aInstance);
+
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    if (isCriticalKey(aKey))
+    {
+        ExitNow(error = otPlatSecureSettingsAdd(aInstance, aKey, aValue, aValueLength));
+    }
+#endif
 
     if (size > 0)
     {
@@ -288,12 +353,28 @@ otError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *a
 
     swapPersist(aInstance, swapFd);
 
-    return OT_ERROR_NONE;
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+exit:
+#endif
+    return error;
 }
 
 otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
 {
-    return platformSettingsDelete(aInstance, aKey, aIndex, nullptr);
+    otError error;
+
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    if (isCriticalKey(aKey))
+    {
+        error = otPlatSecureSettingsDelete(aInstance, aKey, aIndex);
+    }
+    else
+#endif
+    {
+        error = platformSettingsDelete(aInstance, aKey, aIndex, nullptr);
+    }
+
+    return error;
 }
 
 /**
@@ -393,6 +474,10 @@ exit:
 void otPlatSettingsWipe(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    otPlatSecureSettingsWipe(aInstance);
+#endif
+
     VerifyOrDie(0 == ftruncate(sSettingsFd, 0), OT_EXIT_ERROR_ERRNO);
 }
 


### PR DESCRIPTION
All the settings are written into a local file on the posix platform. It is easy for
others to get the sensitive infomation, such as master key, from the local file.

This commit includes the following enhancement:
<1> Add API `otPlatSettingsSetCriticalKeys()` to tell the platform which keys
        should be stored in the secure area.
<2> Expose all settings keys to the header file `settings.h`, which allows
        the platform determines which settings should be processed specially.
<3> Add new posix APIs `otPlatSecureSettingsXxx` to posix platform to allow
        the vendor to implement the functions to store the critical settings to
        the secure area.