### PR TITLE
[posix] set up heap before creating OT instance

### DIFF
--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -92,12 +92,12 @@ otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
 #endif
     platformRandomInit();
 
-    instance = otInstanceInitSingle();
-    assert(instance != nullptr);
-
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
     otHeapSetCAllocFree(calloc, free);
 #endif
+
+    instance = otInstanceInitSingle();
+    assert(instance != nullptr);
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     platformBackboneInit(instance, aPlatformConfig->mBackboneInterfaceName);


### PR DESCRIPTION
This is a quick fix that allows heap usage in constructors.