### PR TITLE
[cli] ensure to init 'mInstance' before other member variables

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -111,7 +111,8 @@ constexpr Interpreter::Command Interpreter::sCommands[];
 Interpreter *Interpreter::sInterpreter = nullptr;
 
 Interpreter::Interpreter(Instance *aInstance)
-    : mUserCommands(nullptr)
+    : mInstance(aInstance)
+    , mUserCommands(nullptr)
     , mUserCommandsLength(0)
     , mPingLength(kDefaultPingLength)
     , mPingCount(kDefaultPingCount)
@@ -147,7 +148,6 @@ Interpreter::Interpreter(Instance *aInstance)
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
     , mSrpServer(*this)
 #endif
-    , mInstance(aInstance)
 {
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
     otThreadSetReceiveDiagnosticGetCallback(mInstance, &Interpreter::HandleDiagnosticGetResponse, this);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -775,6 +775,7 @@ private:
 
     static_assert(Utils::LookupTable::IsSorted(sCommands), "Command Table is not sorted");
 
+    Instance *          mInstance;
     const otCliCommand *mUserCommands;
     uint8_t             mUserCommandsLength;
     void *              mUserCommandsContext;
@@ -823,8 +824,6 @@ private:
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
     SrpServer mSrpServer;
 #endif
-
-    Instance *mInstance;
 };
 
 } // namespace Cli


### PR DESCRIPTION
This commit changes the order of member variables in `Cli` class
ensuring `mInstance` is initialized before other member variables.
This then allows the `mInstance` to be safely used from the
constructor of other `Cli` sub-types.