### PR TITLE
[srp-client] new methods to get server address, set callback

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (67)
+#define OPENTHREAD_API_VERSION (68)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/srp_client.h
+++ b/include/openthread/srp_client.h
@@ -189,19 +189,14 @@ typedef void (*otSrpClientCallback)(otError                    aError,
  *
  * @param[in] aInstance        A pointer to the OpenThread instance.
  * @param[in] aServerSockAddr  The socket address (IPv6 address and port number) of the SRP server.
- * @param[in] aCallback        The callback which is used to notify events and changes. Can be NULL if not needed.
- * @param[in] aContext         An arbitrary context used with @p aCallback.
  *
  * @retval OT_ERROR_NONE       SRP client operation started successfully or it is already running with same server
  *                             socket address and callback.
- * @retval OT_ERROR_BUSY       SRP client is busy running with a different socket address and/or callback.
+ * @retval OT_ERROR_BUSY       SRP client is busy running with a different socket address.
  * @retval OT_ERROR_FAILED     Failed to open/connect the client's UDP socket.
  *
  */
-otError otSrpClientStart(otInstance *        aInstance,
-                         const otSockAddr *  aServerSockAddr,
-                         otSrpClientCallback aCallback,
-                         void *              aContext);
+otError otSrpClientStart(otInstance *aInstance, const otSockAddr *aServerSockAddr);
 
 /**
  * This function stops the SRP client operation.
@@ -213,6 +208,42 @@ otError otSrpClientStart(otInstance *        aInstance,
  *
  */
 void otSrpClientStop(otInstance *aInstance);
+
+/**
+ * This function indicates whether the SRP client is running or not.
+ *
+ * @param[in] aInstance       A pointer to the OpenThread instance.
+ *
+ * @returns TRUE if the SRP client is running, FALSE otherwise.
+ *
+ */
+bool otSrpClientIsRunning(otInstance *aInstance);
+
+/**
+ * This function gets the socket address (IPv6 address and port number) of the SRP server which is being used by SRP
+ * client.
+ *
+ * If the client is not running, the address is unspecified (all zero) with zero port number.
+ *
+ * @param[in] aInstance       A pointer to the OpenThread instance.
+ *
+ * @returns A pointer to the SRP server's socket address (is always non-NULL).
+ *
+ */
+const otSockAddr *otSrpClientGetServerAddress(otInstance *aInstance);
+
+/**
+ * This function sets the callback to notify caller of events/changes from SRP client.
+ *
+ * The SRP client allows a single callback to be registered. So consecutive calls to this function will overwrite any
+ * previously set callback functions.
+ *
+ * @param[in] aInstance   A pointer to the OpenThread instance.
+ * @param[in] aCallback   The callback to notify of events and changes. Can be NULL if not needed.
+ * @param[in] aContext    An arbitrary context used with @p aCallback.
+ *
+ */
+void otSrpClientSetCallback(otInstance *aInstance, otSrpClientCallback aCallback, void *aContext);
 
 /**
  * This function gets the lease interval used in SRP update requests.

--- a/src/cli/README_SRP_CLIENT.md
+++ b/src/cli/README_SRP_CLIENT.md
@@ -9,6 +9,7 @@ Usage : `srp client [command] ...`
 - [host](#host)
 - [keyleaseinterval](#keyleaseinterval)
 - [leaseinterval](#leaseinterval)
+- [server](#server)
 - [service](#service)
 - [start](#start)
 - [stop](#stop)
@@ -228,6 +229,38 @@ Set the lease interval.
 
 ```bash
 > srp client leaseinterval 3600
+Done
+```
+
+### server
+
+Usage: `srp client server`
+
+Print the server socket address (IPv6 address and port number).
+
+```bash
+> srp client server
+[fd00:0:0:0:d88a:618b:384d:e760]:4724
+Done
+```
+
+### server address
+
+Print the server IPv6 address.
+
+```bash
+> srp client server address
+fd00:0:0:0:d88a:618b:384d:e760
+Done
+```
+
+### server port
+
+Print the server port number
+
+```bash
+> srp client server port
+4724
 Done
 ```
 

--- a/src/cli/cli_srp_client.hpp
+++ b/src/cli/cli_srp_client.hpp
@@ -105,6 +105,7 @@ private:
     otError ProcessHost(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessLeaseInterval(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessKeyLeaseInterval(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessServer(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessService(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessStart(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessStop(uint8_t aArgsLength, char *aArgs[]);
@@ -129,6 +130,7 @@ private:
         {"host", &SrpClient::ProcessHost},
         {"keyleaseinterval", &SrpClient::ProcessKeyLeaseInterval},
         {"leaseinterval", &SrpClient::ProcessLeaseInterval},
+        {"server", &SrpClient::ProcessServer},
         {"service", &SrpClient::ProcessService},
         {"start", &SrpClient::ProcessStart},
         {"stop", &SrpClient::ProcessStop},

--- a/src/core/api/srp_client_api.cpp
+++ b/src/core/api/srp_client_api.cpp
@@ -43,14 +43,11 @@ using namespace ot;
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
 
-otError otSrpClientStart(otInstance *        aInstance,
-                         const otSockAddr *  aServerSockAddr,
-                         otSrpClientCallback aCallback,
-                         void *              aContext)
+otError otSrpClientStart(otInstance *aInstance, const otSockAddr *aServerSockAddr)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Srp::Client>().Start(*static_cast<const Ip6::SockAddr *>(aServerSockAddr), aCallback, aContext);
+    return instance.Get<Srp::Client>().Start(*static_cast<const Ip6::SockAddr *>(aServerSockAddr));
 }
 
 void otSrpClientStop(otInstance *aInstance)
@@ -58,6 +55,27 @@ void otSrpClientStop(otInstance *aInstance)
     Instance &instance = *static_cast<Instance *>(aInstance);
 
     return instance.Get<Srp::Client>().Stop();
+}
+
+bool otSrpClientIsRunning(otInstance *aInstance)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<Srp::Client>().IsRunning();
+}
+
+const otSockAddr *otSrpClientGetServerAddress(otInstance *aInstance)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return &instance.Get<Srp::Client>().GetServerAddress();
+}
+
+void otSrpClientSetCallback(otInstance *aInstance, otSrpClientCallback aCallback, void *aContext)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    instance.Get<Srp::Client>().SetCallback(aCallback, aContext);
 }
 
 uint32_t otSrpClientGetLeaseInterval(otInstance *aInstance)

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -164,14 +164,13 @@ Client::Client(Instance &aInstance)
     static_assert(kRemoved == 7, "kRemoved value is not correct");
 }
 
-otError Client::Start(const Ip6::SockAddr &aServerSockAddr, Callback aCallback, void *aContext)
+otError Client::Start(const Ip6::SockAddr &aServerSockAddr)
 {
     otError error = OT_ERROR_NONE;
 
     if (GetState() != kStateStopped)
     {
         VerifyOrExit(aServerSockAddr == mSocket.GetPeerName(), error = OT_ERROR_BUSY);
-        VerifyOrExit((mCallback == aCallback) && (mCallbackContext == aContext), error = OT_ERROR_BUSY);
         ExitNow();
     }
 
@@ -181,8 +180,6 @@ otError Client::Start(const Ip6::SockAddr &aServerSockAddr, Callback aCallback, 
     otLogInfoSrp("[client] Starting, server [%s]:%d", aServerSockAddr.GetAddress().ToString().AsCString(),
                  aServerSockAddr.mPort);
 
-    mCallback        = aCallback;
-    mCallbackContext = aContext;
     Resume();
 
 exit:
@@ -228,6 +225,12 @@ void Client::Stop(void)
 
 exit:
     return;
+}
+
+void Client::SetCallback(Callback aCallback, void *aContext)
+{
+    mCallback        = aCallback;
+    mCallbackContext = aContext;
 }
 
 void Client::Resume(void)

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -269,16 +269,14 @@ public:
      * single SRP Update is sent containing all the info).
      *
      * @param[in] aServerSockAddr  The socket address (IPv6 address and port number) of the SRP server.
-     * @param[in] aCallback        The callback to notify of events and changes. Can be nullptr if not needed.
-     * @param[in] aContext         An arbitrary context used with @p aCallback.
      *
      * @retval OT_ERROR_NONE     SRP client operation started successfully or it is already running with same server
      *                           socket address and callback.
-     * @retval OT_ERROR_BUSY     SRP client is busy running with a different socket address and/or callback.
+     * @retval OT_ERROR_BUSY     SRP client is busy running with a different socket address.
      * @retval OT_ERROR_FAILED   Failed to open/connect the client's UDP socket.
      *
      */
-    otError Start(const Ip6::SockAddr &aServerSockAddr, Callback aCallback, void *aContext);
+    otError Start(const Ip6::SockAddr &aServerSockAddr);
 
     /**
      * This method stops the SRP client operation.
@@ -288,6 +286,37 @@ public:
      *
      */
     void Stop(void);
+
+    /**
+     * This method indicates whether the SRP client is running or not.
+     *
+     * @returns TRUE if the SRP client is running, FALSE otherwise.
+     *
+     */
+    bool IsRunning(void) const { return (mState != kStateStopped); }
+
+    /**
+     * This method gets the socket address (IPv6 address and port number) of the SRP server which is being used by SRP
+     * client.
+     *
+     * If the client is not running, the address is unspecified (all zero) with zero port number.
+     *
+     * @returns The SRP server's socket address.
+     *
+     */
+    const Ip6::SockAddr &GetServerAddress(void) const { return mSocket.GetPeerName(); }
+
+    /**
+     * This method sets the callback used to notify caller of events/changes.
+     *
+     * The SRP client allows a single callback to be registered. So consecutive calls to this method will overwrite any
+     * previously set callback functions.
+     *
+     * @param[in] aCallback        The callback to notify of events and changes. Can be nullptr if not needed.
+     * @param[in] aContext         An arbitrary context used with @p aCallback.
+     *
+     */
+    void SetCallback(Callback aCallback, void *aContext);
 
     /**
      * This method gets the lease interval used in SRP update requests.

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -285,7 +285,9 @@ NcpBase::NcpBase(Instance *aInstance)
 #endif
     otThreadRegisterParentResponseCallback(mInstance, &NcpBase::HandleParentResponseInfo, static_cast<void *>(this));
 #endif // OPENTHREAD_FTD
-
+#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+    otSrpClientSetCallback(mInstance, HandleSrpClientCallback, this);
+#endif
 #if OPENTHREAD_CONFIG_LEGACY_ENABLE
     mLegacyNodeDidJoin = false;
     mLegacyHandlers    = nullptr;

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -3239,7 +3239,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_SRP_CLIENT_START>(voi
     SuccessOrExit(error = mDecoder.ReadUint16(serverAddr.mPort));
     SuccessOrExit(error = mDecoder.ReadBool(callbackEnabled));
 
-    SuccessOrExit(error = otSrpClientStart(mInstance, &serverAddr, HandleSrpClientCallback, this));
+    SuccessOrExit(error = otSrpClientStart(mInstance, &serverAddr));
     mSrpClientCallbackEnabled = callbackEnabled;
 
 exit:


### PR DESCRIPTION
This commit adds new methods/APIs in `Srp::Client` class:
`GetServerAddress()` to get the SRP server's socket address that is
being used by the client, `IsRunning()` to check whether the SRP
client is started and running or not, and `SetCallback()` to allow
user to set the callback at any point (before/after call to
`Start()`). It also adds a new `srp client` CLI sub-command to get 
the server address and/or its port number.