### PR TITLE
[socket] add 'SockAddr::ToString()'

### DIFF
--- a/Android.bp
+++ b/Android.bp
@@ -299,6 +299,7 @@ cc_library_static {
         "src/core/net/ip6_headers.cpp",
         "src/core/net/ip6_mpl.cpp",
         "src/core/net/netif.cpp",
+        "src/core/net/socket.cpp",
         "src/core/net/udp6.cpp",
         "src/core/radio/radio.cpp",
         "src/core/radio/radio_callbacks.cpp",

--- a/Android.mk
+++ b/Android.mk
@@ -264,6 +264,7 @@ LOCAL_SRC_FILES                                          := \
     src/core/net/ip6_headers.cpp                            \
     src/core/net/ip6_mpl.cpp                                \
     src/core/net/netif.cpp                                  \
+    src/core/net/socket.cpp                                 \
     src/core/net/srp_client.cpp                             \
     src/core/net/srp_server.cpp                             \
     src/core/net/udp6.cpp                                   \

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -486,6 +486,7 @@ openthread_core_files = [
   "net/netif.hpp",
   "net/sntp_client.cpp",
   "net/sntp_client.hpp",
+  "net/socket.cpp",
   "net/socket.hpp",
   "net/srp_client.cpp",
   "net/srp_client.hpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -146,6 +146,7 @@ set(COMMON_SOURCES
     net/ip6_mpl.cpp
     net/netif.cpp
     net/sntp_client.cpp
+    net/socket.cpp
     net/srp_client.cpp
     net/srp_server.cpp
     net/udp6.cpp

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -223,6 +223,7 @@ SOURCES_COMMON                                  = \
     net/ip6_mpl.cpp                               \
     net/netif.cpp                                 \
     net/sntp_client.cpp                           \
+    net/socket.cpp                                \
     net/srp_client.cpp                            \
     net/srp_server.cpp                            \
     net/udp6.cpp                                  \

--- a/src/core/net/socket.cpp
+++ b/src/core/net/socket.cpp
@@ -1,0 +1,45 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the IPv6 sockets related functionality.
+ */
+
+#include "socket.hpp"
+
+namespace ot {
+namespace Ip6 {
+
+SockAddr::InfoString SockAddr::ToString(void) const
+{
+    return InfoString("[%s]:%u", GetAddress().ToString().AsCString(), GetPort());
+}
+
+} // namespace Ip6
+} // namespace ot

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -236,18 +236,16 @@ public:
 class SockAddr : public otSockAddr, public Clearable<SockAddr>
 {
 public:
-    enum
+    enum : uint16_t
     {
-        // The socket address string length is:
-        // len('[') + len(mAddress) + len(']') + len(':') + len(mPort)
-        kIp6SocketAddressStringSize = 1 + Address::kIp6AddressStringSize + 1 + 1 + 5,
+        kInfoStringSize = 50, ///< Max chars for the info string (`ToString()`).
     };
 
     /**
      * This type defines the fixed-length `String` object returned from `ToString()`.
      *
      */
-    typedef String<kIp6SocketAddressStringSize> InfoString;
+    typedef String<kInfoStringSize> InfoString;
 
     /**
      * This constructor initializes the socket address (all fields are set to zero).
@@ -337,6 +335,16 @@ public:
      *
      */
     bool operator!=(const SockAddr &aOther) const { return !(*this == aOther); }
+
+    /**
+     * This method converts the socket address to a string.
+     *
+     * The string is formatted as "[<ipv6 address>]:<port number>".
+     *
+     * @returns An `InfoString` containing the string representation of the `SockAddr`
+     *
+     */
+    InfoString ToString(void) const;
 };
 
 /**

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -178,8 +178,7 @@ otError Client::Start(const Ip6::SockAddr &aServerSockAddr, Callback aCallback, 
     SuccessOrExit(error = mSocket.Open(Client::HandleUdpReceive, this));
     SuccessOrExit(error = mSocket.Connect(aServerSockAddr));
 
-    otLogInfoSrp("[client] Starting, server [%s]:%d", aServerSockAddr.GetAddress().ToString().AsCString(),
-                 aServerSockAddr.mPort);
+    otLogInfoSrp("[client] Starting, server %s", aServerSockAddr.ToString().AsCString());
 
     mCallback        = aCallback;
     mCallbackContext = aContext;


### PR DESCRIPTION
This commit adds `SockAddr::ToString()` which coverts a socket
address to a string formatted as `"[<ipv6 address>]:<port number>"`.