### PR TITLE
[mle] set router's Thread version in Link Accept handler

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -948,6 +948,7 @@ otError MleRouter::HandleLinkAccept(const Message &         aMessage,
     router->SetLinkAckFrameCounter(linkFrameCounter);
     router->SetMleFrameCounter(mleFrameCounter);
     router->SetLastHeard(TimerMilli::GetNow());
+    router->SetVersion(static_cast<uint8_t>(version));
     router->SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                      DeviceMode::kModeFullNetworkData));
     router->GetLinkInfo().Clear();


### PR DESCRIPTION
Issue:
Information regarding a neighbor's Thread version is lost.

Context:
This problem can be observed during playing with Link Metrics - few methods check whenever chosen neighbor supports Thread 1.2. This information is preserved when a child is promoted to the router role, but after the reset and Link Request - Link Accept sequence it is not stored in the neighbor table.