### PR TITLE
[dns] update DNS/SRP client documentation to use doxygen lists

### DIFF
--- a/include/openthread/dns_client.h
+++ b/include/openthread/dns_client.h
@@ -88,21 +88,21 @@ typedef struct otDnsAddressResponse otDnsAddressResponse;
  *
  * If the server rejects the address resolution request the error code from server is mapped as follow:
  *
- *    (0)  NOERROR   Success (no error condition)                    -> OT_ERROR_NONE
- *    (1)  FORMERR   Server unable to interpret due to format error  -> OT_ERROR_PARSE
- *    (2)  SERVFAIL  Server encountered an internal failure          -> OT_ERROR_FAILED
- *    (3)  NXDOMAIN  Name that ought to exist, does not exist        -> OT_ERROR_NOT_FOUND
- *    (4)  NOTIMP    Server does not support the query type (OpCode) -> OT_ERROR_NOT_IMPLEMENTED
- *    (5)  REFUSED   Server refused for policy/security reasons      -> OT_ERROR_SECURITY
- *    (6)  YXDOMAIN  Some name that ought not to exist, does exist   -> OT_ERROR_DUPLICATED
- *    (7)  YXRRSET   Some RRset that ought not to exist, does exist  -> OT_ERROR_DUPLICATED
- *    (8)  NXRRSET   Some RRset that ought to exist, does not exist  -> OT_ERROR_NOT_FOUND
- *    (9)  NOTAUTH   Service is not authoritative for zone           -> OT_ERROR_SECURITY
- *    (10) NOTZONE   A name is not in the zone                       -> OT_ERROR_PARSE
- *    (20) BADNAME   Bad name                                        -> OT_ERROR_PARSE
- *    (21) BADALG    Bad algorithm                                   -> OT_ERROR_SECURITY
- *    (22) BADTRUN   Bad truncation                                  -> OT_ERROR_PARSE
- *    Other response codes                                           -> OT_ERROR_FAILED
+ *  - (0)  NOERROR   Success (no error condition)                    -> OT_ERROR_NONE
+ *  - (1)  FORMERR   Server unable to interpret due to format error  -> OT_ERROR_PARSE
+ *  - (2)  SERVFAIL  Server encountered an internal failure          -> OT_ERROR_FAILED
+ *  - (3)  NXDOMAIN  Name that ought to exist, does not exist        -> OT_ERROR_NOT_FOUND
+ *  - (4)  NOTIMP    Server does not support the query type (OpCode) -> OT_ERROR_NOT_IMPLEMENTED
+ *  - (5)  REFUSED   Server refused for policy/security reasons      -> OT_ERROR_SECURITY
+ *  - (6)  YXDOMAIN  Some name that ought not to exist, does exist   -> OT_ERROR_DUPLICATED
+ *  - (7)  YXRRSET   Some RRset that ought not to exist, does exist  -> OT_ERROR_DUPLICATED
+ *  - (8)  NXRRSET   Some RRset that ought to exist, does not exist  -> OT_ERROR_NOT_FOUND
+ *  - (9)  NOTAUTH   Service is not authoritative for zone           -> OT_ERROR_SECURITY
+ *  - (10) NOTZONE   A name is not in the zone                       -> OT_ERROR_PARSE
+ *  - (20) BADNAME   Bad name                                        -> OT_ERROR_PARSE
+ *  - (21) BADALG    Bad algorithm                                   -> OT_ERROR_SECURITY
+ *  - (22) BADTRUN   Bad truncation                                  -> OT_ERROR_PARSE
+ *  - Other response codes                                           -> OT_ERROR_FAILED
  *
  */
 typedef void (*otDnsAddressCallback)(otError aError, const otDnsAddressResponse *aResponse, void *aContext);
@@ -289,12 +289,12 @@ otError otDnsBrowseResponseGetServiceInstance(const otDnsBrowseResponse *aRespon
  * (note that it is a SHOULD and not a MUST requirement). This function tries to retrieve this info for a given service
  * instance when available.
  *
- * If no matching SRV record is found in @p aResponse, `OT_ERROR_NOT_FOUND` is returned.
- * If a matching SRV record is found in @p aResponse, @p aServiceInfo is updated and `OT_ERROR_NONE` is returned.
- * If no matching TXT record is found in @p aResponse, `mTxtDataSize` in @p aServiceInfo is set to zero.
- * If no matching AAAA record is found in @p aResponse, `mHostAddress is set to all zero or unspecified address.
- * If there are multiple AAAA records for the host name in @p aResponse, `mHostAddress` is set to the first one. The
- * other addresses can be retrieved using `otDnsBrowseResponseGetHostAddress()`.
+ * - If no matching SRV record is found in @p aResponse, `OT_ERROR_NOT_FOUND` is returned.
+ * - If a matching SRV record is found in @p aResponse, @p aServiceInfo is updated and `OT_ERROR_NONE` is returned.
+ * - If no matching TXT record is found in @p aResponse, `mTxtDataSize` in @p aServiceInfo is set to zero.
+ * - If no matching AAAA record is found in @p aResponse, `mHostAddress is set to all zero or unspecified address.
+ * - If there are multiple AAAA records for the host name in @p aResponse, `mHostAddress` is set to the first one. The
+ *   other addresses can be retrieved using `otDnsBrowseResponseGetHostAddress()`.
  *
  * @param[in]  aResponse          A pointer to the response.
  * @param[in]  aInstanceLabel     The service instance label (MUST NOT be NULL).
@@ -413,12 +413,12 @@ otError otDnsServiceResponseGetServiceName(const otDnsServiceResponse *aResponse
  *
  * This function MUST only be used from `otDnsServiceCallback`.
  *
- * If no matching SRV record is found in @p aResponse, `OT_ERROR_NOT_FOUND` is returned.
- * If a matching SRV record is found in @p aResponse, @p aServiceInfo is updated and `OT_ERROR_NONE` is returned.
- * If no matching TXT record is found in @p aResponse, `mTxtDataSize` in @p aServiceInfo is set to zero.
- * If no matching AAAA record is found in @p aResponse, `mHostAddress is set to all zero or unspecified address.
- * If there are multiple AAAA records for the host name in @p aResponse, `mHostAddress` is set to the first one. The
- * other addresses can be retrieved using `otDnsServiceResponseGetHostAddress()`.
+ * - If no matching SRV record is found in @p aResponse, `OT_ERROR_NOT_FOUND` is returned.
+ * - If a matching SRV record is found in @p aResponse, @p aServiceInfo is updated and `OT_ERROR_NONE` is returned.
+ * - If no matching TXT record is found in @p aResponse, `mTxtDataSize` in @p aServiceInfo is set to zero.
+ * - If no matching AAAA record is found in @p aResponse, `mHostAddress is set to all zero or unspecified address.
+ * - If there are multiple AAAA records for the host name in @p aResponse, `mHostAddress` is set to the first one. The
+ *   other addresses can be retrieved using `otDnsServiceResponseGetHostAddress()`.
  *
  * @param[in]  aResponse          A pointer to the response.
  * @param[out] aServiceInfo       A `ServiceInfo` to output the service instance information (MUST NOT be NULL).

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (71)
+#define OPENTHREAD_API_VERSION (72)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/srp_client.h
+++ b/include/openthread/srp_client.h
@@ -130,27 +130,27 @@ typedef struct otSrpClientService
  *
  * If the server rejects an SRP update request, the DNS response code (RFC 2136) is mapped to the following errors:
  *
- *    (0)  NOERROR   Success (no error condition)                    -> OT_ERROR_NONE
- *    (1)  FORMERR   Server unable to interpret due to format error  -> OT_ERROR_PARSE
- *    (2)  SERVFAIL  Server encountered an internal failure          -> OT_ERROR_FAILED
- *    (3)  NXDOMAIN  Name that ought to exist, does not exist        -> OT_ERROR_NOT_FOUND
- *    (4)  NOTIMP    Server does not support the query type (OpCode) -> OT_ERROR_NOT_IMPLEMENTED
- *    (5)  REFUSED   Server refused for policy/security reasons      -> OT_ERROR_SECURITY
- *    (6)  YXDOMAIN  Some name that ought not to exist, does exist   -> OT_ERROR_DUPLICATED
- *    (7)  YXRRSET   Some RRset that ought not to exist, does exist  -> OT_ERROR_DUPLICATED
- *    (8)  NXRRSET   Some RRset that ought to exist, does not exist  -> OT_ERROR_NOT_FOUND
- *    (9)  NOTAUTH   Service is not authoritative for zone           -> OT_ERROR_SECURITY
- *    (10) NOTZONE   A name is not in the zone                       -> OT_ERROR_PARSE
- *    (20) BADNAME   Bad name                                        -> OT_ERROR_PARSE
- *    (21) BADALG    Bad algorithm                                   -> OT_ERROR_SECURITY
- *    (22) BADTRUN   Bad truncation                                  -> OT_ERROR_PARSE
- *    Other response codes                                           -> OT_ERROR_FAILED
+ *  - (0)  NOERROR   Success (no error condition)                    -> OT_ERROR_NONE
+ *  - (1)  FORMERR   Server unable to interpret due to format error  -> OT_ERROR_PARSE
+ *  - (2)  SERVFAIL  Server encountered an internal failure          -> OT_ERROR_FAILED
+ *  - (3)  NXDOMAIN  Name that ought to exist, does not exist        -> OT_ERROR_NOT_FOUND
+ *  - (4)  NOTIMP    Server does not support the query type (OpCode) -> OT_ERROR_NOT_IMPLEMENTED
+ *  - (5)  REFUSED   Server refused for policy/security reasons      -> OT_ERROR_SECURITY
+ *  - (6)  YXDOMAIN  Some name that ought not to exist, does exist   -> OT_ERROR_DUPLICATED
+ *  - (7)  YXRRSET   Some RRset that ought not to exist, does exist  -> OT_ERROR_DUPLICATED
+ *  - (8)  NXRRSET   Some RRset that ought to exist, does not exist  -> OT_ERROR_NOT_FOUND
+ *  - (9)  NOTAUTH   Service is not authoritative for zone           -> OT_ERROR_SECURITY
+ *  - (10) NOTZONE   A name is not in the zone                       -> OT_ERROR_PARSE
+ *  - (20) BADNAME   Bad name                                        -> OT_ERROR_PARSE
+ *  - (21) BADALG    Bad algorithm                                   -> OT_ERROR_SECURITY
+ *  - (22) BADTRUN   Bad truncation                                  -> OT_ERROR_PARSE
+ *  - Other response codes                                           -> OT_ERROR_FAILED
  *
  * The following errors are also possible:
  *
- *    OT_ERROR_RESPONSE_TIMEOUT : Timed out waiting for response from server (client would continue to retry).
- *    OT_ERROR_INVALID_ARGS     : The provided service structure is invalid (e.g., bad service name or `otDnsTxtEntry`).
- *    OT_ERROR_NO_BUFS          : Insufficient buffer to prepare or send the update message.
+ *  - OT_ERROR_RESPONSE_TIMEOUT : Timed out waiting for response from server (client would continue to retry).
+ *  - OT_ERROR_INVALID_ARGS     : The provided service structure is invalid (e.g., bad service name or `otDnsTxtEntry`).
+ *  - OT_ERROR_NO_BUFS          : Insufficient buffer to prepare or send the update message.
  *
  * Note that in case of any failure, the client continues the operation, i.e. it prepares and (re)transmits the SRP
  * update message to the server, after some wait interval. The retry wait interval starts from the minimum value and

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -260,12 +260,12 @@ public:
          * enumerated (note that it is a SHOULD and not a MUST requirement). This method tries to retrieve this info
          * for a given service instance.
          *
-         * If no matching SRV record is found, `OT_ERROR_NOT_FOUND` is returned.
-         * If a matching SRV record is found, @p aServiceInfo is updated returning `OT_ERROR_NONE`.
-         * If no matching TXT record is found, `mTxtDataSize` in @p aServiceInfo is set to zero.
-         * If no matching AAAA record is found, `mHostAddress is set to all zero or unspecified address.
-         * If there are multiple AAAA records for the host name `mHostAddress` is set to the first one.
-         * The other addresses can be retrieved using `GetHostAddress()` method.
+         * - If no matching SRV record is found, `OT_ERROR_NOT_FOUND` is returned.
+         * - If a matching SRV record is found, @p aServiceInfo is updated returning `OT_ERROR_NONE`.
+         * - If no matching TXT record is found, `mTxtDataSize` in @p aServiceInfo is set to zero.
+         * - If no matching AAAA record is found, `mHostAddress is set to all zero or unspecified address.
+         * - If there are multiple AAAA records for the host name `mHostAddress` is set to the first one. The other
+         *   addresses can be retrieved using `GetHostAddress()` method.
          *
          * @param[in]  aInstanceLabel     The service instance label (MUST NOT be `nullptr`).
          * @param[out] aServiceInfo       A `ServiceInfo` to output the service instance information.
@@ -344,12 +344,12 @@ public:
          *
          * This method MUST only be used from `ServiceCallback`.
          *
-         * If no matching SRV record is found, `OT_ERROR_NOT_FOUND` is returned.
-         * If a matching SRV record is found, @p aServiceInfo is updated and `OT_ERROR_NONE` is returned.
-         * If no matching TXT record is found, `mTxtDataSize` in @p aServiceInfo is set to zero.
-         * If no matching AAAA record is found, `mHostAddress is set to all zero or unspecified address.
-         * If there are multiple AAAA records for the host name, `mHostAddress` is set to the first one.
-         * The other addresses can be retrieved using `GetHostAddress()` method.
+         * - If no matching SRV record is found, `OT_ERROR_NOT_FOUND` is returned.
+         * - If a matching SRV record is found, @p aServiceInfo is updated and `OT_ERROR_NONE` is returned.
+         * - If no matching TXT record is found, `mTxtDataSize` in @p aServiceInfo is set to zero.
+         * - If no matching AAAA record is found, `mHostAddress is set to all zero or unspecified address.
+         * - If there are multiple AAAA records for the host name, `mHostAddress` is set to the first one. The other
+         *   addresses can be retrieved using `GetHostAddress()` method.
          *
          * @param[out] aServiceInfo       A `ServiceInfo` to output the service instance information
          *


### PR DESCRIPTION
This commit updates the doxgen documentation of some of the SRP/DNS
client definitions to use list format.

----

The intention is to improve readability of the OT API docs,
e.g. https://openthread.io/reference/group/api-srp#otsrpclientcallback