### PR TITLE
[coap] remove use of `nullptr` in coap.h

### DIFF
--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -943,7 +943,8 @@ static inline otError otCoapSendRequestBlockWise(otInstance *                aIn
                                                  otCoapBlockwiseTransmitHook aTransmitHook,
                                                  otCoapBlockwiseReceiveHook  aReceiveHook)
 {
-    return otCoapSendRequestBlockWiseWithParameters(aInstance, aMessage, aMessageInfo, aHandler, aContext, nullptr,
+    // NOLINTNEXTLINE(modernize-use-nullptr)
+    return otCoapSendRequestBlockWiseWithParameters(aInstance, aMessage, aMessageInfo, aHandler, aContext, NULL,
                                                     aTransmitHook, aReceiveHook);
 }
 
@@ -1104,8 +1105,8 @@ static inline otError otCoapSendResponseBlockWise(otInstance *                aI
                                                   void *                      aContext,
                                                   otCoapBlockwiseTransmitHook aTransmitHook)
 {
-    return otCoapSendResponseBlockWiseWithParameters(aInstance, aMessage, aMessageInfo, nullptr, aContext,
-                                                     aTransmitHook);
+    // NOLINTNEXTLINE(modernize-use-nullptr)
+    return otCoapSendResponseBlockWiseWithParameters(aInstance, aMessage, aMessageInfo, NULL, aContext, aTransmitHook);
 }
 
 /**

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (70)
+#define OPENTHREAD_API_VERSION (71)
 
 /**
  * @addtogroup api-instance


### PR DESCRIPTION
Resolves #6171 