### PR TITLE
[cmake] using cmake -E echo instead of shell echo command

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,4 +194,8 @@ endif()
 
 add_subdirectory(tests)
 
-add_custom_target(print-ot-config ALL COMMAND echo -e "$<JOIN:$<TARGET_PROPERTY:ot-config,INTERFACE_COMPILE_DEFINITIONS>,\"\\n\">")
+add_custom_target(print-ot-config ALL
+                  COMMAND ${CMAKE_COMMAND}
+                  -DLIST="$<TARGET_PROPERTY:ot-config,INTERFACE_COMPILE_DEFINITIONS>"
+                  -P ${PROJECT_SOURCE_DIR}/etc/cmake/print.cmake
+)

--- a/etc/cmake/print.cmake
+++ b/etc/cmake/print.cmake
@@ -1,0 +1,42 @@
+#
+#  Copyright (c) 2021, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+
+# Purpose of this CMake script is to support printing of properties fetched
+# using a generator expression.
+#
+# Depending on the generator in use, Ninja, Makefile, other, it is not possible
+# to always ensure proper new line on all platforms when calling echo.
+# The print.cmake handles this issue by taking a CMake list and prints each item
+# in the list on a new line.
+#
+# This script can be invoked as: `cmake -DLIST="itemA;itemB;..." -P print.cmake`
+
+foreach(item ${LIST})
+  execute_process(COMMAND ${CMAKE_COMMAND} -E echo ${item})
+endforeach()


### PR DESCRIPTION
The echo command of the host system may have slight variations between
shell built-in echo and the echo command provided by the OS.

Especially the Windows OS echo command is different from practical any
other echo command.

This means that the currently used `COMMAND echo -e "<text>"` does not
work universally.

This commit introduces `etc/cmake/print.cmake` which allow to print a
CMake list where each item is printed on a new line, to get the desired
behavior on the `print-ot-config` target.

Using `cmake -E echo <text>` ensures identical behaviour across
different systems.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>