### PR TITLE
[efr32] change sleepy-demo-mtd to start awake

### DIFF
--- a/examples/platforms/efr32/sleepy-demo/sleepy-demo-mtd/main.c
+++ b/examples/platforms/efr32/sleepy-demo/sleepy-demo-mtd/main.c
@@ -211,7 +211,7 @@ void handleNetifStateChanged(uint32_t aFlags, void *aContext)
             config.mDeviceType   = 0;
             config.mNetworkData  = 0;
             otThreadSetLinkMode(instance, config);
-            sAllowDeepSleep = true;
+            sAllowDeepSleep = false;
             break;
 
         case OT_DEVICE_ROLE_DETACHED:


### PR DESCRIPTION
This changes the sleepy-demo-mtd app's startup behavior. Prior to the change, the MTD would go to sleep immediately. Instead, the MTD will not sleep until the button is pressed