### PR TITLE
[ip6] enqueue reassembly buffer immediately

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -726,7 +726,9 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
 
     if (message == nullptr)
     {
+        otLogDebgIp6("start reassembly");
         VerifyOrExit((message = NewMessage(0)) != nullptr, error = OT_ERROR_NO_BUFS);
+        mReassemblyList.Enqueue(*message);
         SuccessOrExit(error = message->SetLength(aMessage.GetOffset()));
 
         message->SetTimeout(kIp6ReassemblyTimeout);
@@ -738,10 +740,6 @@ otError Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMess
         OT_ASSERT(assertValue == aMessage.GetOffset());
 
         Get<TimeTicker>().RegisterReceiver(TimeTicker::kIp6FragmentReassembler);
-
-        mReassemblyList.Enqueue(*message);
-
-        otLogDebgIp6("start reassembly.");
     }
 
     // increase message buffer if necessary


### PR DESCRIPTION
So that `mReassemblyList.Dequeue()` is always valid on any error.