### PR TITLE
[cli] add CLI commands for multi-radio feature

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -67,6 +67,7 @@ Done
 - [masterkey](#masterkey)
 - [mlr](#mlr-reg-ipaddr--timeout)
 - [mode](#mode)
+- [multiradio](#multiradio)
 - [neighbor](#neighbor-list)
 - [netdata](README_NETDATA.md)
 - [netstat](#netstat)
@@ -1401,6 +1402,43 @@ Done
 
 ```bash
 > mode -
+Done
+```
+
+### multiradio
+
+Get the list of supported radio links by the device.
+
+This command is always available, even when only a single radio is supported by the device.
+
+```bash
+> multiradio
+[15.4, TREL]
+Done
+```
+
+### multiradio neighbor list
+
+Get the list of neighbors and their supported radios and their preference.
+
+This command is only available when device supports more than one radio link.
+
+```bash
+> multiradio neighbor list
+ExtAddr:3a65bc38dbe4a5be, RLOC16:0xcc00, Radios:[15.4(255), TREL(255)]
+ExtAddr:17df23452ee4a4be, RLOC16:0x1300, Radios:[15.4(255)]
+Done
+```
+
+### multiradio neighbor \<ext address\>
+
+Get the radio info for specific neighbor with a given extended address.
+
+This command is only available when device supports more than one radio link.
+
+```bash
+> multiradio neighbor 3a65bc38dbe4a5be
+[15.4(255), TREL(255)]
 Done
 ```
 

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -424,6 +424,10 @@ private:
                                    uint8_t             aFailedAddressNum);
 #endif
     otError ProcessMode(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMultiRadio(uint8_t aArgsLength, char *aArgsp[]);
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+    void OutputMultiRadioInfo(const otMultiRadioNeighborInfo &aMultiRadioInfo);
+#endif
 #if OPENTHREAD_FTD
     otError ProcessNeighbor(uint8_t aArgsLength, char *aArgs[]);
 #endif
@@ -711,6 +715,7 @@ private:
         {"mlr", &Interpreter::ProcessMlr},
 #endif
         {"mode", &Interpreter::ProcessMode},
+        {"multiradio", &Interpreter::ProcessMultiRadio},
 #if OPENTHREAD_FTD
         {"neighbor", &Interpreter::ProcessNeighbor},
 #endif


### PR DESCRIPTION
This commit adds new CLI command `multiradio` to get the list of
supported radio types by device and `multiradio neighbor` sub-command
to get the radio info (supported radios and the their preference) for
specific neighbor or for all neighbors.