### PR TITLE
[posix] set readline screen cols

### DIFF
--- a/src/posix/console_cli.cpp
+++ b/src/posix/console_cli.cpp
@@ -57,6 +57,8 @@
 
 #include <openthread/cli.h>
 
+#include "common/code_utils.hpp"
+
 #include "openthread-core-config.h"
 #include "platform-posix.h"
 
@@ -95,7 +97,10 @@ void otxConsoleInit(otInstance *aInstance)
     rl_instream           = stdin;
     rl_outstream          = stdout;
     rl_inhibit_completion = true;
-    sReadFd               = fileno(rl_instream);
+
+    rl_set_screen_size(0, OT_MAX(OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH, OPENTHREAD_CONFIG_CLI_UART_RX_BUFFER_SIZE));
+
+    sReadFd = fileno(rl_instream);
     rl_callback_handler_install(sPrompt, InputCallback);
     otCliConsoleInit(aInstance, OutputCallback, nullptr);
 }


### PR DESCRIPTION
The default screen size might be too small for CLI command input/output. 
This commit configures the screen cols to according to CLI configs.  

- [x] Verified that this fix works in #6155.