### PR TITLE
[posix] handle dynamic infra interface status

### DIFF
--- a/include/openthread/border_router.h
+++ b/include/openthread/border_router.h
@@ -57,20 +57,30 @@ extern "C" {
  *
  * @note  This method MUST be called before any other otBorderRouting* APIs.
  *
- * @param[in]  aInstance      A pointer to an OpenThread instance.
- * @param[in]  aInfraIfIndex  The infrastructure interface index.
+ * @param[in]  aInstance                 A pointer to an OpenThread instance.
+ * @param[in]  aInfraIfIndex             The infrastructure interface index.
+ * @param[in]  aInfraIfIsRunning         A boolean that indicates whether the infrastructure
+ *                                       interface is running.
+ * @param[in]  aInfraIfLinkLocalAddress  A pointer to the IPv6 link-local address of the infrastructure
+ *                                       interface. NULL if the IPv6 link-local address is missing.
  *
- * @retval  OT_ERROR_NONE          Successfully started the Border Routing manager on given infrastructure.
- * @retval  OT_ERROR_INVALID_ARGS  The index of the infra interface is not valid.
- * @retval  OT_ERROR_FAILED        Internal failure. This is usually failed to generate random prefixes.
+ * @retval  OT_ERROR_NONE           Successfully started the Border Routing Manager on given infrastructure.
+ * @retval  OT_ERROR_INVALID_STATE  The Border Routing Manager has already been initialized.
+ * @retval  OT_ERROR_INVALID_ARGS   The index or the IPv6 link-local address of the infra interface is not valid.
+ * @retval  OT_ERROR_FAILED         Internal failure. Usually due to failure in generating random prefixes.
+ *
+ * @sa otPlatInfraIfStateChanged.
  *
  */
-otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex);
+otError otBorderRoutingInit(otInstance *        aInstance,
+                            uint32_t            aInfraIfIndex,
+                            bool                aInfraIfIsRunning,
+                            const otIp6Address *aInfraIfLinkLocalAddress);
 
 /**
  * This method enables/disables the Border Routing Manager.
  *
- * @note  The Border Routing Manager is enabled by default.
+ * @note  The Border Routing Manager is disabled by default.
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  * @param[in]  aEnabled   A boolean to enable/disable the routing manager.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (79)
+#define OPENTHREAD_API_VERSION (80)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/infra_if.h
+++ b/include/openthread/platform/infra_if.h
@@ -47,16 +47,6 @@ extern "C" {
 #endif
 
 /**
- * This method returns the IPv6 link-local address of given infrastructure interface.
- *
- * @param[in]   aInfraIfIndex  The index of the infrastructure interface.
- *
- * @returns  A pointer to the IPv6 link-local address. NULL if no valid IPv6 link-local address found.
- *
- */
-const otIp6Address *otPlatInfraIfGetLinkLocalAddress(uint32_t aInfraIfIndex);
-
-/**
  * This method sends an ICMPv6 Neighbor Discovery message on given infrastructure interface.
  *
  * See RFC 4861: https://tools.ietf.org/html/rfc4861.
@@ -99,6 +89,29 @@ extern void otPlatInfraIfRecvIcmp6Nd(otInstance *        aInstance,
                                      const otIp6Address *aSrcAddress,
                                      const uint8_t *     aBuffer,
                                      uint16_t            aBufferLength);
+
+/**
+ * The infra interface driver calls this method to notify OpenThread
+ * of the interface state changes.
+ *
+ * @param[in]  aInstance          The OpenThread instance structure.
+ * @param[in]  aInfraIfIndex      The index of the infrastructure interface.
+ * @param[in]  aIsRunning         A boolean that indicates whether the infrastructure
+ *                                interface is running.
+ * @param[in]  aLinkLocalAddress  A pointer to the IPv6 link-local address of the infrastructure
+ *                                interface. NULL if the IPv6 link-local address is lost.
+ *
+ * @retval  OT_ERROR_NONE           Successfully updated the infra interface status.
+ * @retval  OT_ERROR_INVALID_STATE  The Routing Manager is not initialized.
+ * @retval  OT_ERROR_INVALID_ARGS   The @p aInfraIfIndex doesn't match the infra interface the
+ *                                  Routing Manager are initialized with, or the @p aLinkLocalAddress
+ *                                  is not a valid IPv6 link-local address.
+ *
+ */
+extern otError otPlatInfraIfStateChanged(otInstance *        aInstance,
+                                         uint32_t            aInfraIfIndex,
+                                         bool                aIsRunning,
+                                         const otIp6Address *aLinkLocalAddress);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -44,11 +44,15 @@
 using namespace ot;
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex)
+otError otBorderRoutingInit(otInstance *        aInstance,
+                            uint32_t            aInfraIfIndex,
+                            bool                aInfraIfIsRunning,
+                            const otIp6Address *aInfraIfLinkLocalAddress)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<BorderRouter::RoutingManager>().Init(aInfraIfIndex);
+    return instance.Get<BorderRouter::RoutingManager>().Init(
+        aInfraIfIndex, aInfraIfIsRunning, static_cast<const Ip6::Address *>(aInfraIfLinkLocalAddress));
 }
 
 otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled)

--- a/src/core/border_router/infra_if_platform.cpp
+++ b/src/core/border_router/infra_if_platform.cpp
@@ -52,4 +52,16 @@ extern "C" void otPlatInfraIfRecvIcmp6Nd(otInstance *        aInstance,
     instance.Get<BorderRouter::RoutingManager>().RecvIcmp6Message(
         aInfraIfIndex, static_cast<const Ip6::Address &>(*aSrcAddress), aBuffer, aBufferLength);
 }
+
+extern "C" otError otPlatInfraIfStateChanged(otInstance *        aInstance,
+                                             uint32_t            aInfraIfIndex,
+                                             bool                aIsRunning,
+                                             const otIp6Address *aLinkLocalAddress)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<BorderRouter::RoutingManager>().HandleInfraIfStateChanged(
+        aInfraIfIndex, aIsRunning, static_cast<const Ip6::Address *>(aLinkLocalAddress));
+}
+
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -47,6 +47,7 @@
 
 #include <openthread/error.h>
 #include <openthread/instance.h>
+#include <openthread/ip6.h>
 #include <openthread/openthread-system.h>
 #include <openthread/platform/time.h>
 
@@ -505,14 +506,32 @@ extern unsigned int gBackboneNetifIndex;
  * @param[in]  aInstance  The OpenThread instance.
  * @param[in]  aIfName    The name of the infrastructure interface.
  *
+ * @returns  The index of the infrastructure interface.
+ *
  */
-void platformInfraIfInit(otInstance *aInstance, const char *aIfName);
+uint32_t platformInfraIfInit(otInstance *aInstance, const char *aIfName);
 
 /**
  * This function deinitializes the infrastructure interface.
  *
  */
 void platformInfraIfDeinit(void);
+
+/**
+ * This function tells if the infrastructure interface is running.
+ *
+ * @returns TRUE if the infrastructure interface is running, FALSE if not.
+ *
+ */
+bool platformInfraIfIsRunning(void);
+
+/**
+ * this function returns the IPv6 link-local address of the infrastructure interface.
+ *
+ * @returns  A pointer to the link-local address; NULL if no link-local address is present.
+ *
+ */
+const otIp6Address *platformInfraIfGetLinkLocalAddress(void);
 
 /**
  * This function updates the read fd set.
@@ -531,14 +550,6 @@ void platformInfraIfUpdateFdSet(fd_set &aReadFdSet, int &aMaxFd);
  *
  */
 void platformInfraIfProcess(otInstance *aInstance, const fd_set &aReadFdSet);
-
-/**
- * This function returns the index of the infrastructure interface.
- *
- * @returns  The index of the infrastructure interface. 0 indicates invalid index.
- *
- */
-uint32_t platformInfraIfGetIndex(void);
 
 #ifdef __cplusplus
 }

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -42,6 +42,7 @@
 #include <openthread/heap.h>
 #include <openthread/tasklet.h>
 #include <openthread/platform/alarm-milli.h>
+#include <openthread/platform/infra_if.h>
 #include <openthread/platform/otns.h>
 #include <openthread/platform/radio.h>
 #include <openthread/platform/uart.h>
@@ -100,8 +101,21 @@ otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    // Reuse the backbone interface name.
-    platformInfraIfInit(instance, aPlatformConfig->mBackboneInterfaceName);
+    {
+        uint32_t infraIfIndex;
+
+        // Reuse the backbone interface name.
+        if (aPlatformConfig->mBackboneInterfaceName == nullptr || strlen(aPlatformConfig->mBackboneInterfaceName) == 0)
+        {
+            DieNowWithMessage("no infra interface is specified", OT_EXIT_INVALID_ARGUMENTS);
+        }
+
+        infraIfIndex = platformInfraIfInit(instance, aPlatformConfig->mBackboneInterfaceName);
+
+        SuccessOrDie(otBorderRoutingInit(instance, infraIfIndex, platformInfraIfIsRunning(),
+                                         platformInfraIfGetLinkLocalAddress()));
+        SuccessOrDie(otBorderRoutingSetEnabled(instance, /* aEnabled */ true));
+    }
 #endif
 
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
@@ -112,10 +126,6 @@ otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
 
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE || OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     SuccessOrDie(otSetStateChangedCallback(instance, processStateChange, instance));
-#endif
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    SuccessOrDie(otBorderRoutingInit(instance, platformInfraIfGetIndex()));
 #endif
 
     return instance;

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -2592,6 +2592,18 @@ class LinuxHost():
     PING_RESPONSE_PATTERN = re.compile(r'\d+ bytes from .*:.*')
     ETH_DEV = config.BACKBONE_IFNAME
 
+    def enable_ether(self):
+        """Enable the ethernet interface.
+        """
+
+        self.bash(f'ifconfig {self.ETH_DEV} up')
+
+    def disable_ether(self):
+        """Disable the ethernet interface.
+        """
+
+        self.bash(f'ifconfig {self.ETH_DEV} down')
+
     def get_ether_addrs(self):
         output = self.bash(f'ip -6 addr list dev {self.ETH_DEV}')
 


### PR DESCRIPTION
This commit includes below changes:
1. handles dynamic infrastructure interface status changes.
The Routing Manager will be started if the infra interface status turns
to be `RUNNING` and a valid link-local address is present. Otherwise,
the Routing Manager will be stopped.
2.  changes the default  status of the Routing Manager from `enabled`
to disabled and it is initially enabled for the posix platform.
3. the posix implementation now doesn't require the presence of the
link-local address at initialization stage. In this case, the Routing Manager
will not be started before a link-local address is added to the infra interface.

TODO:
- [x] add CI tests for the new behavior.