### PR TITLE
[tests] add test to verify DHCP6 client works after reset

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_plat_udp_accessiblity.py
+++ b/tests/scripts/thread-cert/border_router/test_plat_udp_accessiblity.py
@@ -29,6 +29,7 @@
 import unittest
 
 import thread_cert
+import config
 
 # Test description:
 #   This test verifies UDP servers can be accessible using RLOC/ALOC/MLEID/LINK-LOCAL/OMR when PLAT_UDP is enabled.
@@ -41,8 +42,6 @@ import thread_cert
 #           |
 #        ROUTER1
 #
-
-import config
 
 BR1 = 1
 ROUTER1 = 2
@@ -86,6 +85,38 @@ class TestPlatUdpAccessibility(thread_cert.TestCase):
         self._test_srp_server(self.nodes[BR1].get_rloc(), server_port)
         for server_aloc in self.nodes[BR1].get_ip6_address(config.ADDRESS_TYPE.ALOC):
             self._test_srp_server(server_aloc, server_port)
+
+        self._testDhcp6ClientAfterReset(BR1, BR1, BR1)
+
+    def _testDhcp6ClientAfterReset(self, server, client, reset_device):
+        DHCP6_PREFIX = '2001::/64'
+
+        # Configure DHCP6 server
+        self.nodes[server].add_prefix(DHCP6_PREFIX, 'pdros')
+        self.simulator.go(3)
+        self.nodes[server].register_netdata()
+        self.simulator.go(5)
+
+        # Verify DHCP6 client works
+        self.assertTrue(self.nodes[client].get_addr(DHCP6_PREFIX))
+        self.simulator.go(3)
+
+        self.nodes[reset_device].reset()
+        self.nodes[reset_device].start()
+        self.simulator.go(5)
+        self.assertIn(self.nodes[reset_device].get_state(), ['leader', 'router'])
+        self.simulator.go(3)
+
+        if reset_device == server:
+            # Reconfigure DHCP6 server if necessary
+            self.nodes[server].add_prefix(DHCP6_PREFIX, 'pdros')
+            self.simulator.go(3)
+            self.nodes[server].register_netdata()
+            self.simulator.go(5)
+
+        # Verify DHCP6 client works after reset
+        self.assertTrue(self.nodes[client].get_addr(DHCP6_PREFIX))
+        self.simulator.go(3)
 
     def _test_srp_server(self, server_addr, server_port):
         print(f'Testing SRP server: {server_addr}:{server_port}')

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -52,6 +52,8 @@ PORT_OFFSET = int(os.getenv('PORT_OFFSET', "0"))
 
 
 class OtbrDocker:
+    RESET_DELAY = 3
+
     _socat_proc = None
     _ot_rcp_proc = None
     _docker_proc = None
@@ -306,6 +308,8 @@ class OtbrDocker:
 
 
 class OtCli:
+
+    RESET_DELAY = 0.1
 
     def __init__(self, nodeid, is_mtd=False, version=None, is_bbr=False, **kwargs):
         self.verbose = int(float(os.getenv('VERBOSE', 0)))
@@ -1786,7 +1790,7 @@ class NodeImpl:
 
     def reset(self):
         self.send_command('reset')
-        time.sleep(0.1)
+        time.sleep(self.RESET_DELAY)
 
     def set_router_selection_jitter(self, jitter):
         cmd = 'routerselectionjitter %d' % jitter


### PR DESCRIPTION
DHCP6 client (with PLAT_UDP) failed to process Reply after reset.

This commit fixes this bug and adds a test to verify.
- [x] Fix the bug in https://github.com/openthread/ot-br-posix/pull/649
- [x] Add the test that reveals the bug

Depends-On: openthread/ot-br-posix#649