### PR TITLE
[indirect-sender] free and dequeue the supervision message when removed

### DIFF
--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -109,6 +109,8 @@ void IndirectSender::AddMessageForSleepyChild(Message &aMessage, Child &aChild)
         if (supervisionMessage != nullptr)
         {
             IgnoreError(RemoveMessageFromSleepyChild(*supervisionMessage, aChild));
+            Get<MeshForwarder>().mSendQueue.Dequeue(*supervisionMessage);
+            supervisionMessage->Free();
         }
     }
 


### PR DESCRIPTION
This commit fixes an issue with removal of supervision message
for child when another message is queued for the same child.
This fixes an issue added by PR #5638 (which itself addresses
an issue that if the supervision message was removed while MAC
was busy sending the message, the MAC layer would not be
notified of the removal).

----

Should address Issue https://github.com/openthread/openthread/issues/6211