### PR TITLE
[mesh-forwarder] add helper 'RemoveMessageIfNoPendingTx()'

### DIFF
--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -109,8 +109,7 @@ void IndirectSender::AddMessageForSleepyChild(Message &aMessage, Child &aChild)
         if (supervisionMessage != nullptr)
         {
             IgnoreError(RemoveMessageFromSleepyChild(*supervisionMessage, aChild));
-            Get<MeshForwarder>().mSendQueue.Dequeue(*supervisionMessage);
-            supervisionMessage->Free();
+            Get<MeshForwarder>().RemoveMessageIfNoPendingTx(*supervisionMessage);
         }
     }
 
@@ -149,16 +148,7 @@ void IndirectSender::ClearAllMessagesForSleepyChild(Child &aChild)
 
         message->ClearChildMask(Get<ChildTable>().GetChildIndex(aChild));
 
-        if (!message->IsChildPending() && !message->GetDirectTransmission())
-        {
-            if (Get<MeshForwarder>().mSendMessage == message)
-            {
-                Get<MeshForwarder>().mSendMessage = nullptr;
-            }
-
-            Get<MeshForwarder>().mSendQueue.Dequeue(*message);
-            message->Free();
-        }
+        Get<MeshForwarder>().RemoveMessageIfNoPendingTx(*message);
     }
 
     aChild.SetIndirectMessage(nullptr);
@@ -533,11 +523,7 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
             mSourceMatchController.DecrementMessageCount(aChild);
         }
 
-        if (!message->GetDirectTransmission() && !message->IsChildPending())
-        {
-            Get<MeshForwarder>().mSendQueue.Dequeue(*message);
-            message->Free();
-        }
+        Get<MeshForwarder>().RemoveMessageIfNoPendingTx(*message);
     }
 
     UpdateIndirectMessage(aChild);

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -455,6 +455,7 @@ private:
     void          UpdateNeighborLinkFailures(Neighbor &aNeighbor, otError aError, bool aAllowNeighborRemove);
     void          HandleSentFrame(Mac::TxFrame &aFrame, otError aError);
     void          UpdateSendMessage(otError aFrameTxError, Mac::Address &aMacDest, Neighbor *aNeighbor);
+    void          RemoveMessageIfNoPendingTx(Message &aMessage);
 
     void        HandleTimeTick(void);
     static void ScheduleTransmissionTask(Tasklet &aTasklet);

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -294,16 +294,7 @@ void MeshForwarder::RemoveMessages(Child &aChild, Message::SubType aSubType)
             }
         }
 
-        if (!message->IsChildPending() && !message->GetDirectTransmission())
-        {
-            if (mSendMessage == message)
-            {
-                mSendMessage = nullptr;
-            }
-
-            mSendQueue.Dequeue(*message);
-            message->Free();
-        }
+        RemoveMessageIfNoPendingTx(*message);
     }
 }
 


### PR DESCRIPTION
This commit adds a helper method `RemoveMessageIfNoPendingTx()` in
`MeshForwarder` which removes (dequeues from `mSendQueue` and frees
 it) if there is no pending direct or indirect transmission.

 This commit also changes `UpdateSendMessage()` to exit early when
 there are remaining fragments of the message to be sent.