### PR TITLE
[srp] rename Advertising to ServiceUpdate

### DIFF
--- a/src/core/api/srp_server_api.cpp
+++ b/src/core/api/srp_server_api.cpp
@@ -87,7 +87,7 @@ void otSrpServerHandleServiceUpdateResult(otInstance *aInstance, const otSrpServ
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    instance.Get<Srp::Server>().HandleAdvertisingResult(static_cast<const Srp::Server::Host *>(aHost), aError);
+    instance.Get<Srp::Server>().HandleServiceUpdateResult(static_cast<const Srp::Server::Host *>(aHost), aError);
 }
 
 const otSrpServerHost *otSrpServerGetNextHost(otInstance *aInstance, const otSrpServerHost *aHost)

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -402,10 +402,10 @@ public:
      * @param[in]  aServiceHandler         A service events handler.
      * @param[in]  aServiceHandlerContext  A pointer to arbitrary context information.
      *
-     * @note  The handler SHOULD call HandleAdvertisingResult to report the result of its processing.
+     * @note  The handler SHOULD call HandleServiceUpdateResult to report the result of its processing.
      *        Otherwise, a SRP update will be considered failed.
      *
-     * @sa  HandleAdvertisingResult
+     * @sa  HandleServiceUpdateResult
      *
      */
     void SetServiceHandler(otSrpServerServiceUpdateHandler aServiceHandler, void *aServiceHandlerContext);
@@ -482,13 +482,14 @@ public:
     const Host *GetNextHost(const Host *aHost);
 
     /**
-     * This method receives the service advertising result.
+     * This method receives the service update result from service handler set by
+     * SetServiceHandler.
      *
      * @param[in]  aHost   A pointer to the Host object which contains the SRP service updates.
-     * @param[in]  aError  The service advertising result.
+     * @param[in]  aError  The service update result.
      *
      */
-    void HandleAdvertisingResult(const Host *aHost, otError aError);
+    void HandleServiceUpdateResult(const Host *aHost, otError aError);
 
 private:
     enum : uint16_t
@@ -547,10 +548,10 @@ private:
     uint32_t GrantLease(uint32_t aLease) const;
     uint32_t GrantKeyLease(uint32_t aKeyLease) const;
 
-    void    HandleSrpUpdateResult(otError                  aError,
-                                  const Dns::UpdateHeader &aDnsHeader,
-                                  Host &                   aHost,
-                                  const Ip6::MessageInfo & aMessageInfo);
+    void    CommitSrpUpdate(otError                  aError,
+                            const Dns::UpdateHeader &aDnsHeader,
+                            Host &                   aHost,
+                            const Ip6::MessageInfo & aMessageInfo);
     void    HandleDnsUpdate(Message &                aMessage,
                             const Ip6::MessageInfo & aMessageInfo,
                             const Dns::UpdateHeader &aDnsHeader,
@@ -612,12 +613,12 @@ private:
     static void HandleOutstandingUpdatesTimer(Timer &aTimer);
     void        HandleOutstandingUpdatesTimer(void);
 
-    void                  HandleAdvertisingResult(UpdateMetadata *aUpdate, otError aError);
+    void                  HandleServiceUpdateResult(UpdateMetadata *aUpdate, otError aError);
     const UpdateMetadata *FindOutstandingUpdate(const Ip6::MessageInfo &aMessageInfo, uint16_t aDnsMessageId);
 
     Ip6::Udp::Socket                mSocket;
-    otSrpServerServiceUpdateHandler mAdvertisingHandler;
-    void *                          mAdvertisingHandlerContext;
+    otSrpServerServiceUpdateHandler mServiceUpdateHandler;
+    void *                          mServiceUpdateHandlerContext;
 
     char *mDomain;
 


### PR DESCRIPTION
This PR renames `*Advertising*` to `*ServiceUpdate*` to keep consistent with public APIs.
For example, change `HandleAdveretisingResult` to `HandleServiceUpdateResult`.