### PR TITLE
[dtls] make the max dtls buffer length configurable

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -669,6 +669,7 @@ source_set("libopenthread_core_config") {
     "config/diag.h",
     "config/dns_client.h",
     "config/dnssd_server.h",
+    "config/dtls.h",
     "config/ip6.h",
     "config/joiner.h",
     "config/link_quality.h",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -408,6 +408,7 @@ HEADERS_COMMON                                  = \
     config/diag.h                                 \
     config/dns_client.h                           \
     config/dnssd_server.h                         \
+    config/dtls.h                                 \
     config/ip6.h                                  \
     config/joiner.h                               \
     config/link_quality.h                         \

--- a/src/core/config/dtls.h
+++ b/src/core/config/dtls.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016, The OpenThread Authors.
+ *  Copyright (c) 2021, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,67 +28,33 @@
 
 /**
  * @file
- *   This file includes compile-time configuration constants for OpenThread.
+ *   This file includes compile-time configurations for DTLS.
+ *
  */
 
-#ifndef OPENTHREAD_CORE_CONFIG_H_
-#define OPENTHREAD_CORE_CONFIG_H_
+#ifndef CONFIG_DTLS_H_
+#define CONFIG_DTLS_H_
 
-#include <openthread/config.h>
-
-#define OT_THREAD_VERSION_INVALID 0
-#define OT_THREAD_VERSION_1_1 2
-#define OT_THREAD_VERSION_1_2 3
-
-#define OPENTHREAD_CORE_CONFIG_H_IN
-
-#ifdef OPENTHREAD_PROJECT_CORE_CONFIG_FILE
-#include OPENTHREAD_PROJECT_CORE_CONFIG_FILE
-#endif
-
-#ifndef OPENTHREAD_CONFIG_THREAD_VERSION
-#define OPENTHREAD_CONFIG_THREAD_VERSION OT_THREAD_VERSION_1_1
-#endif
-
-#include "config/openthread-core-default-config.h"
-
-#include "config/announce_sender.h"
-#include "config/backbone_router.h"
 #include "config/border_router.h"
-#include "config/channel_manager.h"
-#include "config/channel_monitor.h"
-#include "config/child_supervision.h"
 #include "config/coap.h"
 #include "config/commissioner.h"
-#include "config/dataset_updater.h"
-#include "config/dhcp6_client.h"
-#include "config/dhcp6_server.h"
-#include "config/diag.h"
-#include "config/dns_client.h"
-#include "config/dnssd_server.h"
-#include "config/dtls.h"
-#include "config/ip6.h"
 #include "config/joiner.h"
-#include "config/link_quality.h"
-#include "config/link_raw.h"
-#include "config/logging.h"
-#include "config/mac.h"
-#include "config/mle.h"
-#include "config/parent_search.h"
-#include "config/platform.h"
-#include "config/radio_link.h"
-#include "config/sntp_client.h"
-#include "config/srp_client.h"
-#include "config/srp_server.h"
-#include "config/time_sync.h"
-#include "config/tmf.h"
 
-#undef OPENTHREAD_CORE_CONFIG_H_IN
-
-#include "config/openthread-core-config-check.h"
-
-#ifdef OPENTHREAD_CORE_CONFIG_PLATFORM_CHECK_FILE
-#include OPENTHREAD_CORE_CONFIG_PLATFORM_CHECK_FILE
+/**
+ * @def OPENTHREAD_CONFIG_DTLS_MAX_CONTENT_LEN
+ *
+ * The max length of the OpenThread dtls content buffer.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_DTLS_MAX_CONTENT_LEN
+#define OPENTHREAD_CONFIG_DTLS_MAX_CONTENT_LEN MBEDTLS_SSL_MAX_CONTENT_LEN
 #endif
 
-#endif // OPENTHREAD_CORE_CONFIG_H_
+#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE || OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE || \
+    OPENTHREAD_CONFIG_COMMISSIONER_ENABLE || OPENTHREAD_CONFIG_JOINER_ENABLE
+#define OPENTHREAD_CONFIG_DTLS_ENABLE 1
+#else
+#define OPENTHREAD_CONFIG_DTLS_ENABLE 0
+#endif
+
+#endif // CONFIG_DTLS_H_

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -781,7 +781,7 @@ void Dtls::HandleTimer(void)
 
 void Dtls::Process(void)
 {
-    uint8_t buf[MBEDTLS_SSL_MAX_CONTENT_LEN];
+    uint8_t buf[OPENTHREAD_CONFIG_DTLS_MAX_CONTENT_LEN];
     bool    shouldDisconnect = false;
     int     rval;
 


### PR DESCRIPTION
On systems where OpenThread share mbedtls configuration with HTTPS and
other TLS based protocols, the TLS max content length can be way larger
than what OpenThread requires. Add an OpenThread config macro to reduce stack
consumption under such circumstance.