### PR TITLE
[mac] fix default Thread Domain name per v1.2.1-draft4 spec

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -70,7 +70,7 @@ const otExtendedPanId Mac::sExtendedPanidInit = {
 const char Mac::sNetworkNameInit[] = "OpenThread";
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-const char Mac::sDomainNameInit[] = "Thread";
+const char Mac::sDomainNameInit[] = "DefaultDomain";
 #endif
 
 Mac::Mac(Instance &aInstance)


### PR DESCRIPTION
Name is updated here to specified, latest name "DefaultDomain".

Some additional info:
Note that for non-CCM Thread Devices the domain name is not even available, so the code to "get" a domain name should in fact only be available for CCM Thread Devices. (They take it out of their LDevID certificate.) The "set" Domain Name should not be possible for that CCM Thread Device.

In Border Routers that are non-CCM, there should be code to both get and set the Domain Name but I would expect that to be in the ot-br-posix repo instead! 

Removing this code from 1.2 devices could save some bytes; I could create an issue for this. The "get" function could be kept in preparation for CCM devices.
