### PR TITLE
[trel] add 'OT_TREL' CMake option & 'TREL' autoconf switch

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -302,6 +302,11 @@ if(OT_TIME_SYNC)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_TIME_SYNC_ENABLE=1")
 endif()
 
+option(OT_TREL "enable TREL radio link for Thread over Infrastructure feature")
+if (OT_TREL)
+    target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE=1")
+endif()
+
 option(OT_UDP_FORWARD "enable UDP forward support")
 if(OT_UDP_FORWARD)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE=1")

--- a/examples/README.md
+++ b/examples/README.md
@@ -61,4 +61,5 @@ This page lists the available common switches with description. Unless stated ot
 | SRP_SERVER | OT_SRP_SERVER | Enable support for SRP server. |
 | THREAD_VERSION | OT_THREAD_VERSION | Enables the chosen Thread version (1.1 (default) / 1.2). For example, set to `1.2` for Thread 1.2. |
 | TIME_SYNC | OT_TIME_SYNC | Enables the time synchronization service feature. **Note: Enabling this feature breaks conformance to the Thread Specification.** |  |
+| TREL | OT_TREL | Enables TREL radio link for Thread over Infrastructure feature. |
 | UDP_FORWARD | OT_UDP_FORWARD | Enables support for UDP forward. | Enable this switch on the Border Router device (running on the NCP design) with External Commissioning support to service Thread Commissioner packets on the NCP side. |

--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -82,6 +82,7 @@ SRP_CLIENT                ?= 0
 SRP_SERVER                ?= 0
 THREAD_VERSION            ?= 1.1
 TIME_SYNC                 ?= 0
+TREL                      ?= 0
 UDP_FORWARD               ?= 0
 RCP_RESTORATION_MAX_COUNT ?= 0
 
@@ -296,6 +297,10 @@ endif
 
 ifeq ($(TIME_SYNC),1)
 COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_TIME_SYNC_ENABLE=1 -DOPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT=1
+endif
+
+ifeq ($(TREL),1)
+COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE=1
 endif
 
 ifeq ($(UDP_FORWARD),1)


### PR DESCRIPTION
This commit adds `OT_TREL` as a CMake option and `TREL` as an autoconf
switch option to enable support for TREL radio link for Thread over
Infrastructure feature.