### PR TITLE
[tests] allow extra chars in prefix list 'wpanctl' output in toranj

### DIFF
--- a/tests/toranj/wpan.py
+++ b/tests/toranj/wpan.py
@@ -1185,7 +1185,7 @@ class OnMeshPrefix(object):
 
         m = re.match(
             r'\t"([0-9a-fA-F:]+)\s*prefix_len:(\d+)\s+origin:(\w*)\s+stable:(\w*).* \[' +
-            r'on-mesh:(\d)\s+def-route:(\d)\s+config:(\d)\s+dhcp:(\d)\s+slaac:(\d)\s+pref:(\d)\s+prio:(\w*)\]' +
+            r'on-mesh:(\d)\s+def-route:(\d)\s+config:(\d)\s+dhcp:(\d)\s+slaac:(\d)\s+pref:(\d)\s+.*prio:(\w*)\]' +
             r'\s+rloc:(0x[0-9a-fA-F]+)', text)
         verify(m is not None)
         data = m.groups()


### PR DESCRIPTION
This commit relaxes the parsing of on-mesh prefix list `wpanctl`
output in toranj `wpan.py` allowing extra chars to be present between
"pref:" and "prio:".

---

Background:
This is related to https://github.com/openthread/wpantund/pull/482 to allow this PR to pass the CI tests.