### PR TITLE
[spinel] fix missing prototype warning

### DIFF
--- a/src/lib/spinel/spinel.c
+++ b/src/lib/spinel/spinel.c
@@ -1158,7 +1158,7 @@ struct spinel_cstr
         (uint32_t) PREFIX##VALUE, #VALUE \
     }
 
-const char *spinel_to_cstr(const struct spinel_cstr *table, uint32_t val)
+static const char *spinel_to_cstr(const struct spinel_cstr *table, uint32_t val)
 {
     int i;
 


### PR DESCRIPTION
This function was defined without any declaration before it, causing build error when compiled with `-Werror=missing-prototypes`.