### PR TITLE
[srp-server] notify advertising proxy of host/service expiration

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_advertising_proxy.py
+++ b/tests/scripts/thread-cert/border_router/test_advertising_proxy.py
@@ -47,6 +47,8 @@ import thread_cert
 BR = 1
 ROUTER = 2
 HOST = 3
+LEASE = 10  # Seconds
+KEY_LEASE = 20  # Seconds
 
 
 class SingleHostAndService(thread_cert.TestCase):
@@ -81,6 +83,7 @@ class SingleHostAndService(thread_cert.TestCase):
         self.simulator.go(5)
 
         server.srp_server_set_enabled(True)
+        server.srp_server_set_lease_range(LEASE, LEASE, KEY_LEASE, KEY_LEASE)
         server.start()
         self.simulator.go(5)
         self.assertEqual('leader', server.get_state())
@@ -96,7 +99,7 @@ class SingleHostAndService(thread_cert.TestCase):
         client.srp_client_set_host_name('my-host')
         client.srp_client_set_host_address('2001::1')
         client.srp_client_add_service('my-service', '_ipps._tcp', 12345)
-        client.srp_client_start(server.get_addrs()[0], client.get_srp_server_port())
+        client.srp_client_enable_auto_start_mode()
         self.simulator.go(2)
 
         self.check_host_and_service(server, client, '2001::1')
@@ -141,6 +144,32 @@ class SingleHostAndService(thread_cert.TestCase):
 
         self.check_host_and_service(server, client, '2001::2')
         self.host_check_mdns_service(host, '2001::2')
+
+        #
+        # 6. Check if the service is removed by the Advertising Proxy when the SRP server is stopped.
+        #
+
+        server.srp_server_set_enabled(False)
+        self.simulator.go(2)
+
+        self.assertEqual(len(server.srp_server_get_hosts()), 0)
+        self.assertEqual(len(server.srp_server_get_services()), 0)
+        self.assertIsNone(host.discover_mdns_service('my-service', '_ipps._tcp', 'my-host'))
+
+        server.srp_server_set_enabled(True)
+        self.simulator.go(LEASE)
+
+        self.check_host_and_service(server, client, '2001::2')
+        self.host_check_mdns_service(host, '2001::2')
+
+        #
+        # 7. Check if the expired service is removed by the Advertising Proxy.
+        #
+
+        client.srp_client_stop()
+        self.simulator.go(LEASE + 2)
+
+        self.assertIsNone(host.discover_mdns_service('my-service', '_ipps._tcp', 'my-host'))
 
     def host_check_mdns_service(self, host, host_addr):
         service = host.discover_mdns_service('my-service', '_ipps._tcp', 'my-host')

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -2741,9 +2741,10 @@ class LinuxHost():
         #
         for line in self.bash(f'cat /tmp/{host_name}'):
             elements = line.split()
-            if not elements or len(elements) < 6 or not elements[4].startswith(host_name):
+            fullname = f'{host_name}.local.'
+            if fullname not in elements:
                 continue
-            addresses.append(elements[5].split('%')[0])
+            addresses.append(elements[elements.index(fullname) + 1].split('%')[0])
 
         logging.debug(f'addresses of {host_name}: {addresses}')
 


### PR DESCRIPTION
There is an issue that the SRP host or service are not deregistered by the `Advertising Proxy`
when the host or service is expired. This is because we didn't notifies the `Advertising Proxy` of
 the host/service expiration. This PR fixes this issue and adds tests for it.

Depends-On: openthread/ot-br-posix#731
