### PR TITLE
[fuzz] disable exit command on fuzz target

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1662,7 +1662,7 @@ exit:
     return error;
 }
 
-#if OPENTHREAD_POSIX
+#if OPENTHREAD_POSIX && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
 otError Interpreter::ProcessExit(uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -679,7 +679,7 @@ private:
         {"eidcache", &Interpreter::ProcessEidCache},
 #endif
         {"eui64", &Interpreter::ProcessEui64},
-#if OPENTHREAD_POSIX
+#if OPENTHREAD_POSIX && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
         {"exit", &Interpreter::ProcessExit},
 #endif
         {"extaddr", &Interpreter::ProcessExtAddress},


### PR DESCRIPTION
fuzz target must not exit() or abort() on any input.