### PR TITLE
[srp-client] adding buffer and service pool module

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -194,6 +194,7 @@ LOCAL_SRC_FILES                                          := \
     src/core/api/server_api.cpp                             \
     src/core/api/sntp_api.cpp                               \
     src/core/api/srp_client_api.cpp                         \
+    src/core/api/srp_client_buffers_api.cpp                 \
     src/core/api/srp_server_api.cpp                         \
     src/core/api/tasklet_api.cpp                            \
     src/core/api/thread_api.cpp                             \
@@ -335,6 +336,7 @@ LOCAL_SRC_FILES                                          := \
     src/core/utils/parse_cmdline.cpp                        \
     src/core/utils/ping_sender.cpp                          \
     src/core/utils/slaac_address.cpp                        \
+    src/core/utils/srp_client_buffers.cpp                   \
     src/lib/hdlc/hdlc.cpp                                   \
     src/lib/platform/exit_code.c                            \
     src/lib/spinel/spinel.c                                 \

--- a/include/Makefile.am
+++ b/include/Makefile.am
@@ -78,6 +78,7 @@ openthread_headers                      = \
     openthread/server.h                   \
     openthread/sntp.h                     \
     openthread/srp_client.h               \
+    openthread/srp_client_buffers.h       \
     openthread/srp_server.h               \
     openthread/tasklet.h                  \
     openthread/thread.h                   \

--- a/include/openthread/BUILD.gn
+++ b/include/openthread/BUILD.gn
@@ -118,6 +118,7 @@ source_set("openthread") {
     "server.h",
     "sntp.h",
     "srp_client.h",
+    "srp_client_buffers.h",
     "srp_server.h",
     "tasklet.h",
     "thread.h",

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (87)
+#define OPENTHREAD_API_VERSION (88)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/srp_client_buffers.h
+++ b/include/openthread/srp_client_buffers.h
@@ -1,0 +1,179 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief
+ *  This file defines the OpenThread SRP (Service Registration Protocol) client buffers and service pool.
+ */
+
+#ifndef OPENTHREAD_SRP_CLIENT_BUFFERS_H_
+#define OPENTHREAD_SRP_CLIENT_BUFFERS_H_
+
+#include <openthread/dns.h>
+#include <openthread/srp_client.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @addtogroup api-srp
+ *
+ * @brief
+ *   This module includes functions for SRP client buffers and service pool.
+ *
+ * @{
+ *
+ * Functions in this module are only available when feature OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE is enabled.
+ *
+ */
+
+/**
+ * This struct represents a SRP client service pool entry.
+ *
+ */
+typedef struct otSrpClientBuffersServiceEntry
+{
+    otSrpClientService mService;  ///< The SRP client service structure.
+    otDnsTxtEntry      mTxtEntry; ///< The SRP client TXT entry.
+} otSrpClientBuffersServiceEntry;
+
+/**
+ * This function gets the string buffer to use for SRP client host name.
+ *
+ * @param[in]  aInstance  A pointer to the OpenThread instance.
+ * @param[out] aSize      Pointer to a variable to return the size (number of bytes) of the string buffer (MUST NOT be
+ *                        NULL).
+ *
+ * @returns A pointer to char buffer to use for SRP client host name.
+ *
+ */
+char *otSrpClientBuffersGetHostNameString(otInstance *aInstance, uint16_t *aSize);
+
+/**
+ * This function gets the array of IPv6 address entries to use as SRP client host address list.
+ *
+ * @param[in]  aInstance     A pointer to the OpenThread instance.
+ * @param[out] aArrayLength  Pointer to a variable to return the array length i.e., number of IPv6 address entries in
+ *                           the array (MUST NOT be NULL).
+ *
+ * @returns A pointer to an array of `otIp6Address` entries (number of entries is returned in @p aArrayLength).
+ *
+ */
+otIp6Address *otSrpClientBuffersGetHostAddressesArray(otInstance *aInstance, uint8_t *aArrayLength);
+
+/**
+ * This function allocates a new service entry from the pool.
+ *
+ * The returned service entry instance will be initialized as follows:
+ *
+ *  - `mService.mName` will point to an allocated string buffer which can be retrieved using the function
+ *    `otSrpClientBuffersGetServiceEntryServiceNameString()`.
+ *  - `mService.mInstanceName` will point to an allocated string buffer which can be retrieved using the function
+ *    `otSrpClientBuffersGetServiceEntryInstanceNameString()`.
+ *  - `mService.mTxtEntries` will point to `mTxtEntry`.
+ *  - `mService.mNumTxtEntries` will be set to one.
+ *  - Other `mService` fields (port, priority, weight) are set to zero.
+ *  - `mTxtEntry.mKey` is set to NULL (value is treated as already encoded).
+ *  - `mTxtEntry.mValue` will point to an allocated buffer which can be retrieved using the function
+ *    `otSrpClientBuffersGetServiceEntryTxtBuffer()`.
+ *  - `mTxtEntry.mValueLength` is set to zero.
+ *
+ * @param[in] aInstance   A pointer to the OpenThread instance.
+ *
+ * @returns A pointer to the newly allocated service entry or NULL if not more entry available in the pool.
+ *
+ */
+otSrpClientBuffersServiceEntry *otSrpClientBuffersAllocateService(otInstance *aInstance);
+
+/**
+ * This function frees a previously allocated service entry.
+ *
+ * The @p aService MUST be previously allocated using `otSrpClientBuffersAllocateService()` and not yet freed. Otherwise
+ * the behavior of this function is undefined.
+ *
+ * @param[in] aInstance   A pointer to the OpenThread instance.
+ * @param[in] aSevice     A pointer to the service entry to free (MUST NOT be NULL).
+ *
+ */
+void otSrpClientBuffersFreeService(otInstance *aInstance, otSrpClientBuffersServiceEntry *aService);
+
+/**
+ * This function frees all previously allocated service entries.
+ *
+ * @param[in] aInstance   A pointer to the OpenThread instance.
+ *
+ */
+void otSrpClientBuffersFreeAllServices(otInstance *aInstance);
+
+/**
+ * This function gets the string buffer for service name from a service entry.
+ *
+ * @param[in]  aEntry   A pointer to a previously allocated service entry (MUST NOT be NULL).
+ * @param[out] aSize    A pointer to a variable to return the size (number of bytes) of the string buffer (MUST NOT be
+ *                      NULL).
+ *
+ * @returns A pointer to the string buffer.
+ *
+ */
+char *otSrpClientBuffersGetServiceEntryServiceNameString(otSrpClientBuffersServiceEntry *aEntry, uint16_t *aSize);
+
+/**
+ * This function gets the string buffer for service instance name from a service entry.
+ *
+ * @param[in]  aEntry   A pointer to a previously allocated service entry (MUST NOT be NULL).
+ * @param[out] aSize    A pointer to a variable to return the size (number of bytes) of the string buffer (MUST NOT be
+ *                      NULL).
+ *
+ * @returns A pointer to the string buffer.
+ *
+ */
+char *otSrpClientBuffersGetServiceEntryInstanceNameString(otSrpClientBuffersServiceEntry *aEntry, uint16_t *aSize);
+
+/**
+ * This function gets the buffer for TXT record from a service entry.
+ *
+ * @param[in]  aEntry   A pointer to a previously allocated service entry (MUST NOT be NULL).
+ * @param[out] aSize    A pointer to a variable to return the size (number of bytes) of the buffer (MUST NOT be NULL).
+ *
+ * @returns A pointer to the buffer.
+ *
+ */
+uint8_t *otSrpClientBuffersGetServiceEntryTxtBuffer(otSrpClientBuffersServiceEntry *aEntry, uint16_t *aSize);
+
+/**
+ * @}
+ *
+ */
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // OPENTHREAD_SRP_CLIENT_BUFFERS_H_

--- a/src/cli/cli_srp_client.hpp
+++ b/src/cli/cli_srp_client.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include <openthread/srp_client.h>
+#include <openthread/srp_client_buffers.h>
 
 #include "cli/cli_config.h"
 #include "utils/lookup_table.hpp"
@@ -75,23 +76,8 @@ public:
 private:
     enum : uint8_t
     {
-        kMaxServices      = OPENTHREAD_CONFIG_CLI_SRP_CLIENT_MAX_SERVICES,
-        kMaxHostAddresses = OPENTHREAD_CONFIG_CLI_SRP_CLIENT_MAX_HOST_ADDRESSES,
-        kNameSize         = 64,
-        kTxtSize          = 255,
+        kMaxHostAddresses = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRSSES,
         kIndentSize       = 4,
-    };
-
-    struct Service
-    {
-        void MarkAsNotInUse(void) { mService.mNext = &mService; }
-        bool IsInUse(void) const { return (mService.mNext != &mService); }
-
-        otSrpClientService mService;
-        otDnsTxtEntry      mTxtEntry;
-        char               mInstanceName[kNameSize];
-        char               mServiceName[kNameSize];
-        uint8_t            mTxtBuffer[kTxtSize];
     };
 
     struct Command
@@ -108,6 +94,7 @@ private:
     otError ProcessKeyLeaseInterval(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessServer(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessService(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessServiceAdd(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessStart(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessState(uint8_t aArgsLength, char *aArgs[]);
     otError ProcessStop(uint8_t aArgsLength, char *aArgs[]);
@@ -144,9 +131,6 @@ private:
 
     Interpreter &mInterpreter;
     bool         mCallbackEnabled;
-    char         mHostName[kNameSize];
-    otIp6Address mHostAddresses[kMaxHostAddresses];
-    Service      mServicePool[kMaxServices];
 };
 
 } // namespace Cli

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -330,6 +330,7 @@ openthread_core_files = [
   "api/server_api.cpp",
   "api/sntp_api.cpp",
   "api/srp_client_api.cpp",
+  "api/srp_client_buffers_api.cpp",
   "api/srp_server_api.cpp",
   "api/tasklet_api.cpp",
   "api/thread_api.cpp",
@@ -630,6 +631,8 @@ openthread_core_files = [
   "utils/ping_sender.hpp",
   "utils/slaac_address.cpp",
   "utils/slaac_address.hpp",
+  "utils/srp_client_buffers.cpp",
+  "utils/srp_client_buffers.hpp",
 ]
 
 openthread_radio_sources = [

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -70,6 +70,7 @@ set(COMMON_SOURCES
     api/server_api.cpp
     api/sntp_api.cpp
     api/srp_client_api.cpp
+    api/srp_client_buffers_api.cpp
     api/srp_server_api.cpp
     api/tasklet_api.cpp
     api/thread_api.cpp
@@ -211,6 +212,7 @@ set(COMMON_SOURCES
     utils/parse_cmdline.cpp
     utils/ping_sender.cpp
     utils/slaac_address.cpp
+    utils/srp_client_buffers.cpp
 )
 
 set(OT_VENDOR_EXTENSION "" CACHE STRING "specify a C++ source file built as part of OpenThread core library")

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -147,6 +147,7 @@ SOURCES_COMMON                                  = \
     api/server_api.cpp                            \
     api/sntp_api.cpp                              \
     api/srp_client_api.cpp                        \
+    api/srp_client_buffers_api.cpp                \
     api/srp_server_api.cpp                        \
     api/tasklet_api.cpp                           \
     api/thread_api.cpp                            \
@@ -288,6 +289,7 @@ SOURCES_COMMON                                  = \
     utils/parse_cmdline.cpp                       \
     utils/ping_sender.cpp                         \
     utils/slaac_address.cpp                       \
+    utils/srp_client_buffers.cpp                  \
     $(NULL)
 
 EXTRA_DIST                                 = \
@@ -550,6 +552,7 @@ HEADERS_COMMON                                  = \
     utils/parse_cmdline.hpp                       \
     utils/ping_sender.hpp                         \
     utils/slaac_address.hpp                       \
+    utils/srp_client_buffers.hpp                  \
     $(NULL)
 
 noinst_HEADERS                             = \

--- a/src/core/api/srp_client_buffers_api.cpp
+++ b/src/core/api/srp_client_buffers_api.cpp
@@ -1,0 +1,97 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the OpenThread SRP client buffers and service pool APIs.
+ */
+
+#include "openthread-core-config.h"
+
+#include <openthread/srp_client_buffers.h>
+
+#include "common/instance.hpp"
+#include "common/locator-getters.hpp"
+#include "utils/srp_client_buffers.hpp"
+
+using namespace ot;
+
+#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
+
+char *otSrpClientBuffersGetHostNameString(otInstance *aInstance, uint16_t *aSize)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<Utils::SrpClientBuffers>().GetHostNameString(*aSize);
+}
+
+otIp6Address *otSrpClientBuffersGetHostAddressesArray(otInstance *aInstance, uint8_t *aArrayLength)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<Utils::SrpClientBuffers>().GetHostAddressesArray(*aArrayLength);
+}
+
+otSrpClientBuffersServiceEntry *otSrpClientBuffersAllocateService(otInstance *aInstance)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<Utils::SrpClientBuffers>().AllocateService();
+}
+
+void otSrpClientBuffersFreeService(otInstance *aInstance, otSrpClientBuffersServiceEntry *aService)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    instance.Get<Utils::SrpClientBuffers>().FreeService(
+        *static_cast<Utils::SrpClientBuffers::ServiceEntry *>(aService));
+}
+
+void otSrpClientBuffersFreeAllServices(otInstance *aInstance)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    instance.Get<Utils::SrpClientBuffers>().FreeAllServices();
+}
+
+char *otSrpClientBuffersGetServiceEntryServiceNameString(otSrpClientBuffersServiceEntry *aEntry, uint16_t *aSize)
+{
+    return static_cast<Utils::SrpClientBuffers::ServiceEntry *>(aEntry)->GetServiceNameString(*aSize);
+}
+
+char *otSrpClientBuffersGetServiceEntryInstanceNameString(otSrpClientBuffersServiceEntry *aEntry, uint16_t *aSize)
+{
+    return static_cast<Utils::SrpClientBuffers::ServiceEntry *>(aEntry)->GetInstanceNameString(*aSize);
+}
+
+uint8_t *otSrpClientBuffersGetServiceEntryTxtBuffer(otSrpClientBuffersServiceEntry *aEntry, uint16_t *aSize)
+{
+    return static_cast<Utils::SrpClientBuffers::ServiceEntry *>(aEntry)->GetTxtBuffer(*aSize);
+}
+
+#endif // OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -690,6 +690,13 @@ template <> inline Srp::Client &Instance::Get(void)
 }
 #endif
 
+#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
+template <> inline Utils::SrpClientBuffers &Instance::Get(void)
+{
+    return mThreadNetif.mSrpClientBuffers;
+}
+#endif
+
 #if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
 template <> inline Dns::ServiceDiscovery::Server &Instance::Get(void)
 {

--- a/src/core/common/pool.hpp
+++ b/src/core/common/pool.hpp
@@ -116,6 +116,20 @@ public:
     void Free(Type &aEntry) { mFreeList.Push(aEntry); }
 
     /**
+     * This method frees all previously allocated objects.
+     *
+     */
+    void FreeAll(void)
+    {
+        mFreeList.Clear();
+
+        for (Type &entry : mPool)
+        {
+            mFreeList.Push(entry);
+        }
+    }
+
+    /**
      * This method returns the pool size.
      *
      * @returns The pool size (maximum number of objects in the pool).

--- a/src/core/config/srp_client.h
+++ b/src/core/config/srp_client.h
@@ -63,7 +63,7 @@
  *
  * Define the default mode (enabled or disabled) of auto-start mode.
  *
- * This config is applicable/used only when `OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE` is enabled.
+ * This config is applicable only when `OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE` is enabled.
  *
  */
 #ifndef OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_DEFAULT_MODE
@@ -217,5 +217,74 @@
 #ifndef OPENTHREAD_CONFIG_SRP_CLIENT_RETRY_INTERVAL_GROWTH_FACTOR_DENOMINATOR
 #define OPENTHREAD_CONFIG_SRP_CLIENT_RETRY_INTERVAL_GROWTH_FACTOR_DENOMINATOR 10
 #endif
+
+/**
+ * @def OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
+ *
+ * Define to 1 to enable SRP Client buffers and service pool feature.
+ *
+ */
+#define OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+
+/**
+ * @def OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_SERVICES
+ *
+ * Specifies number of service entries in the SRP client service pool.
+ *
+ * This config is applicable only when `OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE` is enabled.
+ *
+ */
+#define OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_SERVICES 2
+
+/**
+ * @def OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRSSES
+ *
+ * Specifies number of host IPv6 address entries in the SRP client buffers and service pool.
+ *
+ * This config is applicable only when `OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE` is enabled.
+ *
+ */
+#define OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRSSES 2
+
+/**
+ * @def OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_HOST_NAME_SIZE
+ *
+ * Specifies the size (number of chars) of host name string buffer in the SRP client buffers and service pool.
+ *
+ * This config is applicable only when `OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE` is enabled.
+ *
+ */
+#define OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_HOST_NAME_SIZE 64
+
+/**
+ * @def OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_SERVICE_NAME_SIZE
+ *
+ * Specifies the size (number of chars) of service name string buffer in the SRP client buffers and service pool.
+ *
+ * This config is applicable only when `OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE` is enabled.
+ *
+ */
+#define OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_SERVICE_NAME_SIZE 64
+
+/**
+ * @def OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_SERVICE_INSTANCE_NAME_SIZE
+ *
+ * Specifies the size (number of chars) of service instance name string buffer in the SRP client buffers and service
+ * pool.
+ *
+ * This config is applicable only when `OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE` is enabled.
+ *
+ */
+#define OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_SERVICE_INSTANCE_NAME_SIZE 64
+
+/**
+ * @def OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_TXT_BUFFER_SIZE
+ *
+ * Specifies the size (number of bytes) of TXT record value buffer in the SRP client buffers and service pool.
+ *
+ * This config is applicable only when `OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE` is enabled.
+ *
+ */
+#define OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_TXT_BUFFER_SIZE 64
 
 #endif // CONFIG_SRP_CLIENT_H_

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -65,6 +65,9 @@ ThreadNetif::ThreadNetif(Instance &aInstance)
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
     , mSrpClient(aInstance)
 #endif
+#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
+    , mSrpClientBuffers(aInstance)
+#endif
 #if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
     , mDnssdServer(aInstance)
 #endif

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -102,6 +102,7 @@
 #include "thread/radio_selector.hpp"
 #include "thread/time_sync_service.hpp"
 #include "utils/child_supervision.hpp"
+#include "utils/srp_client_buffers.hpp"
 
 #if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
 #include "utils/slaac_address.hpp"
@@ -206,6 +207,9 @@ private:
 #endif
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
     Srp::Client mSrpClient;
+#endif
+#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
+    Utils::SrpClientBuffers mSrpClientBuffers;
 #endif
 #if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
     Dns::ServiceDiscovery::Server mDnssdServer;

--- a/src/core/utils/srp_client_buffers.cpp
+++ b/src/core/utils/srp_client_buffers.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2019, The OpenThread Authors.
+ *  Copyright (c) 2021, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,32 +28,45 @@
 
 /**
  * @file
- *   This file includes compile-time configurations for the CLI service.
- *
+ *   This file implements the SRP client buffers and service pool.
  */
 
-#ifndef CONFIG_CLI_H_
-#define CONFIG_CLI_H_
+#include "srp_client_buffers.hpp"
 
-#include "openthread-core-config.h"
+#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
 
-#ifndef OPENTHREAD_POSIX
-#if defined(__ANDROID__) || defined(__APPLE__) || defined(__FreeBSD__) || defined(__linux__) || defined(__NetBSD__) || \
-    defined(__unix__)
-#define OPENTHREAD_POSIX 1
-#else
-#define OPENTHREAD_POSIX 0
-#endif
-#endif
+#include <string.h>
 
-/**
- * @def OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH
- *
- * The maximum size of the CLI line in bytes.
- *
- */
-#ifndef OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH
-#define OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH 384
-#endif
+#include "common/code_utils.hpp"
+#include "common/instance.hpp"
+#include "common/locator-getters.hpp"
 
-#endif // CONFIG_CLI_H_
+namespace ot {
+namespace Utils {
+
+SrpClientBuffers::SrpClientBuffers(Instance &aInstance)
+    : InstanceLocator(aInstance)
+{
+}
+
+SrpClientBuffers::ServiceEntry *SrpClientBuffers::AllocateService(void)
+{
+    ServiceEntry *entry = mServicePool.Allocate();
+
+    VerifyOrExit(entry != nullptr);
+
+    entry->Clear();
+    entry->mService.mName          = entry->mServiceName;
+    entry->mService.mInstanceName  = entry->mInstanceName;
+    entry->mService.mTxtEntries    = &entry->mTxtEntry;
+    entry->mService.mNumTxtEntries = 1;
+    entry->mTxtEntry.mValue        = entry->mTxtBuffer;
+
+exit:
+    return entry;
+}
+
+} // namespace Utils
+} // namespace ot
+
+#endif // OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE

--- a/src/core/utils/srp_client_buffers.hpp
+++ b/src/core/utils/srp_client_buffers.hpp
@@ -1,0 +1,248 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for the SRP client buffers and service pool.
+ */
+
+#ifndef SRP_CLIENT_BUFFERS_HPP_
+#define SRP_CLIENT_BUFFERS_HPP_
+
+#include "openthread-core-config.h"
+
+#include <openthread/srp_client_buffers.h>
+
+#include "common/clearable.hpp"
+#include "common/locator.hpp"
+#include "common/non_copyable.hpp"
+#include "common/pool.hpp"
+#include "net/srp_client.hpp"
+
+namespace ot {
+namespace Utils {
+
+#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
+
+#if !OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+#error "OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE requires OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE feature."
+#endif
+
+/**
+ * This class represents the SRP client buffers and service pool.
+ *
+ */
+class SrpClientBuffers : public InstanceLocator, private NonCopyable
+{
+public:
+    enum : uint16_t
+    {
+        /**
+         * Maximum number of service entries in the pool.
+         *
+         */
+        kMaxServices = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_SERVICES,
+
+        /**
+         * Max number of host address entries.
+         *
+         */
+        kMaxHostAddresses = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRSSES,
+
+        /**
+         * Size (number of char) of host name string (includes null `\0` termination char).
+         *
+         */
+        kHostNameSize = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_HOST_NAME_SIZE,
+
+        /**
+         * Size (number of char) of service name string (includes null `\0` termination char).
+         *
+         */
+        kServiceNameSize = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_SERVICE_NAME_SIZE,
+
+        /**
+         * Size (number of char) of service instance name string (includes null `\0` termination char).
+         *
+         */
+        kInstanceNameSize = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_SERVICE_INSTANCE_NAME_SIZE,
+
+        /**
+         * Size (number of bytes) of TXT record buffer.
+         *
+         */
+        kTxtBufferSize = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_TXT_BUFFER_SIZE,
+    };
+
+    /**
+     * This class represents a SRP client service entry from the pool.
+     *
+     */
+    class ServiceEntry : public otSrpClientBuffersServiceEntry, public Clearable<ServiceEntry>
+    {
+        friend class SrpClientBuffers;
+        friend class LinkedList<ServiceEntry>;
+
+    public:
+        /**
+         * This method gets the string buffer for the service name from the service entry.
+         *
+         * @param[out] aSize    Reference to a variable to return the size (number of bytes) of the string buffer.
+         *
+         * @returns A pointer to the string buffer.
+         *
+         */
+        char *GetServiceNameString(uint16_t &aSize)
+        {
+            aSize = sizeof(mServiceName);
+            return mServiceName;
+        }
+
+        /**
+         * This method gets the string buffer for the instance name from the service entry.
+         *
+         * @param[out] aSize    Reference to a variable to return the size (number of bytes) of the string buffer.
+         *
+         * @returns A pointer to the string buffer.
+         *
+         */
+        char *GetInstanceNameString(uint16_t &aSize)
+        {
+            aSize = sizeof(mInstanceName);
+            return mInstanceName;
+        }
+
+        /**
+         * This method gets the buffer for the TXT value from the service entry.
+         *
+         * @param[out] aSize    Reference to a variable to return the size (number of bytes) of the buffer.
+         *
+         * @returns A pointer to the buffer.
+         *
+         */
+        uint8_t *GetTxtBuffer(uint16_t &aSize)
+        {
+            aSize = sizeof(mTxtBuffer);
+            return mTxtBuffer;
+        }
+
+    private:
+        ServiceEntry *      GetNext(void) { return reinterpret_cast<ServiceEntry *>(mService.mNext); }
+        const ServiceEntry *GetNext(void) const { return reinterpret_cast<const ServiceEntry *>(mService.mNext); }
+        void SetNext(ServiceEntry *aEntry) { mService.mNext = reinterpret_cast<Srp::Client::Service *>(aEntry); }
+
+        char    mServiceName[kServiceNameSize];
+        char    mInstanceName[kInstanceNameSize];
+        uint8_t mTxtBuffer[kTxtBufferSize];
+    };
+
+    /**
+     * This constructor initializes the `SrpClientBuffers` object.
+     *
+     * @param[in]  aInstance  A reference to the OpenThread instance.
+     *
+     */
+    explicit SrpClientBuffers(Instance &aInstance);
+
+    /**
+     * This method gets the string buffer to use for SRP client host name.
+     *
+     * @param[out] aSize      Reference to a variable to return the size (number of bytes) of the string buffer.
+     *
+     * @returns A pointer to char buffer to use for SRP client host name.
+     *
+     */
+    char *GetHostNameString(uint16_t &aSize)
+    {
+        aSize = sizeof(mHostName);
+        return mHostName;
+    }
+
+    /**
+     * This method gets the array of IPv6 address entries to use as SRP client host address list.
+     *
+     * @param[out] aArrayLength  Reference to a variable to return the array length (number of IPv6 address entries in
+     * *                         the array).
+     *
+     * @returns A pointer to an array of `Ip6::Address` entries (number of entries is returned in @p aArrayLength).
+     *
+     */
+    Ip6::Address *GetHostAddressesArray(uint8_t &aArrayLength)
+    {
+        aArrayLength = OT_ARRAY_LENGTH(mHostAddresses);
+        return &mHostAddresses[0];
+    }
+
+    /**
+     * This method allocates a new service entry from the pool.
+     *
+     * The returned service entry instance will be initialized as follows:
+     *
+     *  - `mService.mName` points to a string buffer which can be retrieved using `GetServiceNameString()`.
+     *  - `mService.mInstanceName` points to a string buffer which can be retrieved `GetInstanceNameString()`.
+     *  - `mService.mTxtEntries` points to `mTxtEntry`.
+     *  - `mService.mNumTxtEntries` is set to one (one entry in the list).
+     *  - Other `mService` fields (port, priority, weight) are set to zero.
+     *  - `mTxtEntry.mKey` is set to `nullptr` (value is treated as already encoded data).
+     *  - `mTxtEntry.mValue` points to a buffer which can be retrieved using `GetTxtBuffer()`
+     *  - `mTxtEntry.mValueLength` is set to zero.
+     *
+     * @returns A pointer to the newly allocated service entry or `nullptr` if not more entry available in the pool.
+     *
+     */
+    ServiceEntry *AllocateService(void);
+
+    /**
+     * This method frees a previously allocated service entry.
+     *
+     * The @p aService MUST be previously allocated using `AllocateService()` and not yet freed. Otherwise the behavior
+     * of this method is undefined.
+     *
+     * @param[in] aServiceEntry     A service entry to free.
+     *
+     */
+    void FreeService(ServiceEntry &aServiceEntry) { mServicePool.Free(aServiceEntry); }
+
+    /**
+     * This method frees all previously allocated service entries.
+     *
+     */
+    void FreeAllServices(void) { mServicePool.FreeAll(); }
+
+private:
+    char                             mHostName[kHostNameSize];
+    Ip6::Address                     mHostAddresses[kMaxHostAddresses];
+    Pool<ServiceEntry, kMaxServices> mServicePool;
+};
+
+#endif // OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
+
+} // namespace Utils
+} // namespace ot
+
+#endif // SRP_CLIENT_BUFFERS_HPP_

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -248,7 +248,6 @@ NcpBase::NcpBase(Instance *aInstance)
     , mDroppedOutboundIpFrameCounter(0)
     , mDroppedInboundIpFrameCounter(0)
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
-    , mSrpClientNumHostAddresses(0)
     , mSrpClientCallbackEnabled(false)
 #endif
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD

--- a/src/ncp/ncp_base.hpp
+++ b/src/ncp/ncp_base.hpp
@@ -611,19 +611,7 @@ protected:
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
     enum : uint8_t
     {
-        kSrpClientMaxServices      = OPENTHREAD_CONFIG_NCP_SRP_CLIENT_MAX_SERVICES,
-        kSrpClientMaxHostAddresses = OPENTHREAD_CONFIG_NCP_SRP_CLIENT_MAX_HOST_ADDRESSES,
-        kSrpClientNameSize         = 64,
-    };
-
-    struct SrpClientService
-    {
-        void MarkAsNotInUse(void) { mService.mNext = &mService; }
-        bool IsInUse(void) const { return (mService.mNext != &mService); }
-
-        otSrpClientService mService;
-        char               mInstanceName[kSrpClientNameSize];
-        char               mServiceName[kSrpClientNameSize];
+        kSrpClientMaxHostAddresses = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRSSES,
     };
 
     otError EncodeSrpClientHostInfo(const otSrpClientHostInfo &aHostInfo);
@@ -639,11 +627,7 @@ protected:
                                         const otSrpClientService * aServices,
                                         const otSrpClientService * aRemovedServices);
 
-    char             mSrpClientHostName[kSrpClientNameSize];
-    SrpClientService mSrpClientServicePool[kSrpClientMaxServices];
-    otIp6Address     mSrpClientHostAddresses[kSrpClientMaxHostAddresses];
-    uint8_t          mSrpClientNumHostAddresses;
-    bool             mSrpClientCallbackEnabled;
+    bool mSrpClientCallbackEnabled;
 #endif // OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
 
 #if OPENTHREAD_CONFIG_LEGACY_ENABLE

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -63,6 +63,9 @@
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 #include "openthread/backbone_router.h"
 #endif
+#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
+#include <openthread/srp_client_buffers.h>
+#endif
 
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
@@ -3548,21 +3551,25 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_SRP_CLIENT_HOST_NAME>
 {
     otError     error;
     const char *name;
+    uint16_t    size;
+    char *      hostNameBuffer;
 
     SuccessOrExit(error = mDecoder.ReadUtf8(name));
 
-    VerifyOrExit(StringLength(name, kSrpClientNameSize) < kSrpClientNameSize, error = OT_ERROR_INVALID_ARGS);
+    hostNameBuffer = otSrpClientBuffersGetHostNameString(mInstance, &size);
+
+    VerifyOrExit(StringLength(name, size) < size, error = OT_ERROR_INVALID_ARGS);
 
     // We first make sure we can set the name, and if so
-    // we copy it to the `mSrpClientHostName` buffer and set
-    // the host name again now with the persisted buffer
+    // we copy it to the persisted buffer and set
+    // the host name again now with the persisted buffer.
     // This ensures that we do not overwrite a previous
-    // `mSrpClientHostName` when host name cannot be set.
+    // buffer with a host name that cannot be set.
 
     SuccessOrExit(error = otSrpClientSetHostName(mInstance, name));
 
-    strcpy(mSrpClientHostName, name);
-    error = otSrpClientSetHostName(mInstance, mSrpClientHostName);
+    strcpy(hostNameBuffer, name);
+    error = otSrpClientSetHostName(mInstance, hostNameBuffer);
     OT_ASSERT(error == OT_ERROR_NONE);
 
 exit:
@@ -3585,9 +3592,14 @@ exit:
 
 template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_SRP_CLIENT_HOST_ADDRESSES>(void)
 {
-    otError      error;
-    otIp6Address addresses[kSrpClientMaxHostAddresses];
-    uint8_t      numAddresses = 0;
+    otError       error;
+    otIp6Address  addresses[kSrpClientMaxHostAddresses];
+    uint8_t       numAddresses = 0;
+    otIp6Address *hostAddressArray;
+    uint8_t       hostAddressArrayLength;
+
+    hostAddressArray = otSrpClientBuffersGetHostAddressesArray(mInstance, &hostAddressArrayLength);
+    OT_ASSERT(hostAddressArrayLength <= kSrpClientMaxHostAddresses);
 
     while (!mDecoder.IsAllReadInStruct())
     {
@@ -3597,18 +3609,16 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_SRP_CLIENT_HOST_ADDRE
         numAddresses++;
     }
 
-    // We first make sure we can set the addresses, and if so
-    // we copy the address list into `mSrpClientHostAddresses`
-    // and set it again. This ensures that we do not overwrite
-    // a previous list before we know it is safe to set/change
-    // the address list.
+    // We first make sure we can set the addresses, and if so we copy
+    // the address list into `hostAddressArray` and set it again. This
+    // ensures that we do not overwrite a previous list before we know
+    // it is safe to set/change the address list.
 
     SuccessOrExit(error = otSrpClientSetHostAddresses(mInstance, addresses, numAddresses));
 
-    memcpy(mSrpClientHostAddresses, addresses, sizeof(addresses));
-    mSrpClientNumHostAddresses = numAddresses;
+    memcpy(hostAddressArray, addresses, sizeof(addresses));
 
-    error = otSrpClientSetHostAddresses(mInstance, mSrpClientHostAddresses, numAddresses);
+    error = otSrpClientSetHostAddresses(mInstance, hostAddressArray, numAddresses);
     OT_ASSERT(error == OT_ERROR_NONE);
 
 exit:
@@ -3643,69 +3653,62 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_SRP_CLIENT_SERVICES>(
 
 template <> otError NcpBase::HandlePropertyInsert<SPINEL_PROP_SRP_CLIENT_SERVICES>(void)
 {
-    otError           error = OT_ERROR_NONE;
-    SrpClientService *entry = nullptr;
-    const char *      serviceName;
-    const char *      instanceName;
+    otError                         error = OT_ERROR_NONE;
+    otSrpClientBuffersServiceEntry *entry = nullptr;
+    const char *                    serviceName;
+    const char *                    instanceName;
+    char *                          stringBuffer;
+    uint16_t                        size;
 
-    for (SrpClientService &poolEntry : mSrpClientServicePool)
-    {
-        if (!poolEntry.IsInUse())
-        {
-            entry = &poolEntry;
-            break;
-        }
-    }
-
+    entry = otSrpClientBuffersAllocateService(mInstance);
     VerifyOrExit(entry != nullptr, error = OT_ERROR_NO_BUFS);
 
+    stringBuffer = otSrpClientBuffersGetServiceEntryServiceNameString(entry, &size);
     SuccessOrExit(error = mDecoder.ReadUtf8(serviceName));
-    VerifyOrExit(StringLength(serviceName, kSrpClientNameSize) < kSrpClientNameSize, error = OT_ERROR_INVALID_ARGS);
-    strcpy(entry->mServiceName, serviceName);
-    entry->mService.mName = entry->mServiceName;
+    VerifyOrExit(StringLength(serviceName, size) < size, error = OT_ERROR_INVALID_ARGS);
+    strcpy(stringBuffer, serviceName);
 
+    stringBuffer = otSrpClientBuffersGetServiceEntryInstanceNameString(entry, &size);
     SuccessOrExit(error = mDecoder.ReadUtf8(instanceName));
-    VerifyOrExit(StringLength(instanceName, kSrpClientNameSize) < kSrpClientNameSize, error = OT_ERROR_INVALID_ARGS);
-    strcpy(entry->mInstanceName, instanceName);
-    entry->mService.mInstanceName = entry->mInstanceName;
+    VerifyOrExit(StringLength(instanceName, size) < size, error = OT_ERROR_INVALID_ARGS);
+    strcpy(stringBuffer, instanceName);
 
     SuccessOrExit(error = mDecoder.ReadUint16(entry->mService.mPort));
     SuccessOrExit(error = mDecoder.ReadUint16(entry->mService.mPriority));
     SuccessOrExit(error = mDecoder.ReadUint16(entry->mService.mWeight));
 
-    error = otSrpClientAddService(mInstance, &entry->mService);
-
-    if (error != OT_ERROR_NONE)
-    {
-        entry->MarkAsNotInUse();
-    }
+    SuccessOrExit(error = otSrpClientAddService(mInstance, &entry->mService));
+    entry = nullptr;
 
 exit:
+    if (entry != nullptr)
+    {
+        otSrpClientBuffersFreeService(mInstance, entry);
+    }
+
     return error;
 }
 
 template <> otError NcpBase::HandlePropertyRemove<SPINEL_PROP_SRP_CLIENT_SERVICES>(void)
 {
-    otError     error = OT_ERROR_NONE;
-    const char *serviceName;
-    const char *instanceName;
+    otError                   error = OT_ERROR_NONE;
+    const char *              serviceName;
+    const char *              instanceName;
+    const otSrpClientService *service;
 
     SuccessOrExit(error = mDecoder.ReadUtf8(serviceName));
     SuccessOrExit(error = mDecoder.ReadUtf8(instanceName));
 
-    for (SrpClientService &poolEntry : mSrpClientServicePool)
+    for (service = otSrpClientGetServices(mInstance); service != nullptr; service = service->mNext)
     {
-        if (!poolEntry.IsInUse() || (strcmp(serviceName, poolEntry.mServiceName) != 0) ||
-            (strcmp(instanceName, poolEntry.mInstanceName) != 0))
+        if ((strcmp(serviceName, service->mName) == 0) || (strcmp(instanceName, service->mInstanceName) == 0))
         {
-            continue;
+            break;
         }
-
-        error = otSrpClientRemoveService(mInstance, &poolEntry.mService);
-        ExitNow();
     }
 
-    error = OT_ERROR_NOT_FOUND;
+    VerifyOrExit(service != nullptr, error = OT_ERROR_NOT_FOUND);
+    error = otSrpClientRemoveService(mInstance, const_cast<otSrpClientService *>(service));
 
 exit:
     return error;
@@ -3825,13 +3828,8 @@ exit:
     {
         next = service->mNext;
 
-        for (SrpClientService &poolEntry : mSrpClientServicePool)
-        {
-            if (&poolEntry.mService == service)
-            {
-                poolEntry.MarkAsNotInUse();
-            }
-        }
+        otSrpClientBuffersFreeService(
+            mInstance, reinterpret_cast<otSrpClientBuffersServiceEntry *>(const_cast<otSrpClientService *>(service)));
     }
 }
 

--- a/src/ncp/ncp_config.h
+++ b/src/ncp/ncp_config.h
@@ -189,28 +189,4 @@
 #define OPENTHREAD_ENABLE_NCP_VENDOR_HOOK 0
 #endif
 
-/**
- * @def OPENTHREAD_CONFIG_NCP_SRP_CLIENT_MAX_SERVICES
- *
- * The maximum number of service entries supported by SRP client.
- *
- * This is only applicable when SRP client is enabled, i.e., OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE is set.
- *
- */
-#ifndef OPENTHREAD_CONFIG_NCP_SRP_CLIENT_MAX_SERVICES
-#define OPENTHREAD_CONFIG_NCP_SRP_CLIENT_MAX_SERVICES 2
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_NCP_SRP_CLIENT_MAX_HOST_ADDRESSES
- *
- * The maximum number of host IPv6 address entries supported by SRP client.
- *
- * This is only applicable when SRP client is enabled, i.e., OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE is set.
- *
- */
-#ifndef OPENTHREAD_CONFIG_NCP_SRP_CLIENT_MAX_HOST_ADDRESSES
-#define OPENTHREAD_CONFIG_NCP_SRP_CLIENT_MAX_HOST_ADDRESSES 2
-#endif
-
 #endif // CONFIG_NCP_H_


### PR DESCRIPTION
This commit adds a new module `Utils::SrpClientBuffers` which provides
string/data buffers and a pool of service entries for use for SRP
client. OpenThread SRP client implementation requires that the
service, string/data buffers passed as parameters to its API to
persist. This allows flexibility in how the SRP client can be used
(users of API can decide on how to manage the memory). The new module
provides an option to OT API user to use the buffer and service pool
to allocate/free items (e.g., service entries). The new module is
enabled by `OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE`. A set of new
configs specifies the number of service entries in the pool, number of
host address entries, and the size of different string buffers (e.g,
size of service instance string, etc).

This commit also updates CLI and NCP implementations to use the new
common service pool for SRP client commands.