### PR TITLE
[posix] fix socket issues

### DIFF
--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -178,6 +178,7 @@ exit:
 
 void Client::Stop(void)
 {
+    mTrickleTimer.Stop();
     IgnoreError(mSocket.Close());
 }
 
@@ -223,6 +224,8 @@ bool Client::HandleTrickleTimer(void)
 {
     bool rval = true;
 
+    OT_ASSERT(mSocket.IsBound());
+
     VerifyOrExit(mIdentityAssociationCurrent != nullptr, rval = false);
 
     switch (mIdentityAssociationCurrent->mStatus)
@@ -242,7 +245,6 @@ bool Client::HandleTrickleTimer(void)
 
         if (!ProcessNextIdentityAssociation())
         {
-            mTrickleTimer.Stop();
             Stop();
             rval = false;
         }

--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -182,7 +182,7 @@ bool platformInfraIfIsRunning(void)
 
     OT_ASSERT(sInfraIfIndex != 0);
 
-    sock = socket(AF_INET6, SOCK_DGRAM, IPPROTO_IP);
+    sock = SocketWithCloseExec(AF_INET6, SOCK_DGRAM, IPPROTO_IP, kSocketBlock);
     VerifyOrDie(sock != -1, OT_EXIT_ERROR_ERRNO);
 
     memset(&ifReq, 0, sizeof(ifReq));
@@ -204,7 +204,7 @@ static int CreateIcmp6Socket(void)
     const int           kHopLimit           = 255;
 
     // Initializes the ICMPv6 socket.
-    sock = socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6);
+    sock = SocketWithCloseExec(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6, kSocketBlock);
     VerifyOrDie(sock != -1, OT_EXIT_ERROR_ERRNO);
 
     // Only accept router advertisements and solicitations.
@@ -314,7 +314,7 @@ static int CreateNetLinkSocket(void)
     int                rval;
     struct sockaddr_nl addr;
 
-    sock = socket(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE);
+    sock = SocketWithCloseExec(AF_NETLINK, SOCK_DGRAM, NETLINK_ROUTE, kSocketBlock);
     VerifyOrDie(sock != -1, OT_EXIT_ERROR_ERRNO);
 
     memset(&addr, 0, sizeof(addr));

--- a/src/posix/platform/multicast_routing.cpp
+++ b/src/posix/platform/multicast_routing.cpp
@@ -171,7 +171,7 @@ void MulticastRoutingManager::InitMulticastRouterSock(void)
     struct mif6ctl      mif6ctl;
 
     // Create a Multicast Routing socket
-    mMulticastRouterSock = socket(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6);
+    mMulticastRouterSock = SocketWithCloseExec(AF_INET6, SOCK_RAW, IPPROTO_ICMPV6, kSocketBlock);
     VerifyOrDie(mMulticastRouterSock != -1, OT_EXIT_ERROR_ERRNO);
 
     // Enable Multicast Forwarding in Kernel

--- a/tests/scripts/thread-cert/border_router/test_plat_udp_accessiblity.py
+++ b/tests/scripts/thread-cert/border_router/test_plat_udp_accessiblity.py
@@ -95,7 +95,7 @@ class TestPlatUdpAccessibility(thread_cert.TestCase):
         self.nodes[server].add_prefix(DHCP6_PREFIX, 'pdros')
         self.simulator.go(3)
         self.nodes[server].register_netdata()
-        self.simulator.go(5)
+        self.simulator.go(10)
 
         # Verify DHCP6 client works
         self.assertTrue(self.nodes[client].get_addr(DHCP6_PREFIX))
@@ -112,7 +112,8 @@ class TestPlatUdpAccessibility(thread_cert.TestCase):
             self.nodes[server].add_prefix(DHCP6_PREFIX, 'pdros')
             self.simulator.go(3)
             self.nodes[server].register_netdata()
-            self.simulator.go(5)
+
+        self.simulator.go(10)
 
         # Verify DHCP6 client works after reset
         self.assertTrue(self.nodes[client].get_addr(DHCP6_PREFIX))


### PR DESCRIPTION
This commit fixes #6264 
- [x] Fix Multicast Routing failed to initialize MRT6 after reset
- [x] Fix DHCP6 client failed to stop the trickle timer

I think there sockets in other modules that need to add `CLOSE_EXEC` flag too:
- TREL over UDP6
- ND Proxy

These can be addressed in future PRs.
