### PR TITLE
[dnssd-server] bind to Thread network interface

### DIFF
--- a/script/test
+++ b/script/test
@@ -262,7 +262,25 @@ do_build_otbr_docker()
     echo "Building OTBR Docker ..."
     local otdir
     local otbrdir
-    local otbr_options="-DOT_DNSSD_SERVER=ON -DOT_DNS_CLIENT=ON -DOT_SRP_CLIENT=ON -DOT_SLAAC=ON -DOT_DUA=ON -DOT_MLR=ON -DOT_COVERAGE=ON -DOTBR_REST=OFF -DOTBR_WEB=OFF -DOTBR_DUA_ROUTING=ON"
+
+    # Bind DNS-SD server to unspecified interface to allow Infrastructure Hosts to dig.
+    local common_cflags="-DOPENTHREAD_CONFIG_DNSSD_SERVER_BIND_THREAD_NETIF=OT_NETIF_UNSPECIFIED"
+
+    local otbr_options=(
+        "-DOT_DNSSD_SERVER=ON"
+        "-DOT_DNS_CLIENT=ON"
+        "-DOT_SRP_CLIENT=ON"
+        "-DOT_SLAAC=ON"
+        "-DOT_DUA=ON"
+        "-DOT_MLR=ON"
+        "-DOT_COVERAGE=ON"
+        "-DOTBR_REST=OFF"
+        "-DOTBR_WEB=OFF"
+        "-DOTBR_DUA_ROUTING=ON"
+        "-DCMAKE_C_FLAGS=${common_cflags}"
+        "-DCMAKE_CXX_FLAGS=${common_cflags}"
+    )
+
     local otbr_docker_image=${OTBR_DOCKER_IMAGE:-otbr-ot12-backbone-ci}
 
     otbrdir=$(mktemp -d -t otbr_XXXXXX)
@@ -281,7 +299,7 @@ do_build_otbr_docker()
             --build-arg REFERENCE_DEVICE=1 \
             --build-arg OT_BACKBONE_CI=1 \
             --build-arg NAT64=0 \
-            --build-arg OTBR_OPTIONS="${otbr_options}"
+            --build-arg OTBR_OPTIONS="${otbr_options[*]}"
     )
 
     rm -rf "${otbrdir}"

--- a/src/core/config/dnssd_server.h
+++ b/src/core/config/dnssd_server.h
@@ -55,4 +55,15 @@
 #define OPENTHREAD_CONFIG_DNSSD_SERVER_PORT 53
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_DNSSD_SERVER_BIND_THREAD_NETIF
+ *
+ * Define the network interface for DNS-SD server to bind.
+ * Change to OT_NETIF_UNSPECIFIED to allow DNS-SD server to bind to all network interfaces.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_DNSSD_SERVER_BIND_THREAD_NETIF
+#define OPENTHREAD_CONFIG_DNSSD_SERVER_BIND_THREAD_NETIF OT_NETIF_THREAD
+#endif
+
 #endif // CONFIG_DNSSD_SERVER_H_

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -66,10 +66,17 @@ Error Server::Start(void)
     VerifyOrExit(!IsRunning());
 
     SuccessOrExit(error = mSocket.Open(&Server::HandleUdpReceive, this));
+    SuccessOrExit(error = mSocket.BindToNetif(kBindNetif));
     SuccessOrExit(error = mSocket.Bind(kPort));
 
 exit:
     otLogInfoDns("[server] started: %s", ErrorToString(error));
+
+    if (error != OT_ERROR_NONE)
+    {
+        IgnoreError(mSocket.Close());
+    }
+
     return error;
 }
 
@@ -240,6 +247,7 @@ Header::Response Server::ResolveQuestion(const char *      aName,
     OT_UNUSED_VARIABLE(aQuestion);
     OT_UNUSED_VARIABLE(aResponseHeader);
     OT_UNUSED_VARIABLE(aResponseMessage);
+    OT_UNUSED_VARIABLE(aResolveKind);
     OT_UNUSED_VARIABLE(aCompressInfo);
 
     Header::Response response = Header::kResponseNameError;

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -89,6 +89,8 @@ private:
         kProtocolLabelLength = 4,
     };
 
+    static constexpr otNetifIdentifier kBindNetif = OPENTHREAD_CONFIG_DNSSD_SERVER_BIND_THREAD_NETIF;
+
     enum : uint8_t
     {
         kResolveNone           = 0,


### PR DESCRIPTION
This commit binds the DNS-SD server to the Thread network interface to avoid potential port conflicts. 