### PR TITLE
[ncp] remove unused code

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1214,14 +1214,6 @@ otError NcpBase::CommandHandler_RESET(uint8_t aHeader)
     IgnoreError(otIp6SetEnabled(mInstance, false));
 #endif
 
-    error = WriteLastStatusFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_STATUS_RESET_SOFTWARE);
-
-    if (error != OT_ERROR_NONE)
-    {
-        mChangedPropsSet.AddLastStatus(SPINEL_STATUS_RESET_UNKNOWN);
-        mUpdateChangedPropsTask.Post();
-    }
-
     sNcpInstance = nullptr;
 
     return error;


### PR DESCRIPTION
For the case when otInstanceReset returns during pseudo reset action
setting here SPINEL_STATUS_RESET_SOFTWARE is useless as line below
the current sNcpInstance is cleared. The new status never gets
a chance to be transmitted to the host.