### PR TITLE
[timer] simplify 'TrickleTimer'

### DIFF
--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -36,6 +36,7 @@
 
 #include "openthread-core-config.h"
 
+#include "common/numeric_limits.hpp"
 #include "common/timer.hpp"
 
 namespace ot {
@@ -61,39 +62,38 @@ public:
      * This enumeration defines the modes of operation for the `TrickleTimer`.
      *
      */
-    enum Mode
+    enum Mode : uint8_t
     {
-        kModeNormal,     ///< Runs the normal trickle logic (as per RFC6206).
-        kModePlainTimer, ///< Runs a plain timer with random interval selected between min/max intervals.
-        kModeMPL,        ///< Runs the trickle logic modified for MPL.
+        kModeTrickle,    ///< Operate as the normal trickle logic (as per RFC 6206).
+        kModePlainTimer, ///< Operate as a plain periodic timer with random interval selected within min/max intervals.
+    };
+
+    enum : uint16_t
+    {
+        /**
+         * Special value for redundancy constant (aka `k`) to indicate infinity (when used, it disables trickle timer's
+         * suppression behavior, invoking the handler callback independent of number of "consistent" events).
+         *
+         */
+        kInfiniteRedundancyConstant = NumericLimits<uint16_t>::Max(),
     };
 
     /**
-     * This function pointer is called when the timer expires.
+     * This function pointer is called when the timer expires (i.e., transmission should happen).
      *
      * @param[in]  aTimer  A reference to the trickle timer.
      *
-     * @retval TRUE   If the trickle timer should continue running.
-     * @retval FALSE  If the trickle timer should stop running.
-     *
      */
-    typedef bool (*Handler)(TrickleTimer &aTimer);
+    typedef void (&Handler)(TrickleTimer &aTimer);
 
     /**
      * This constructor initializes a `TrickleTimer` instance.
      *
-     * @param[in]  aInstance                A reference to the OpenThread instance.
-     * @param[in]  aRedundancyConstant      The redundancy constant for the timer, also known as `k`.
-     * @param[in]  aTransmitHandler         A pointer to a function that is called when transmission should occur.
-     * @param[in]  aIntervalExpiredHandler  An optional pointer to a function that is called when the interval expires.
+     * @param[in]  aInstance   A reference to the OpenThread instance.
+     * @param[in]  aHandler    A handler which is called when transmission should occur.
      *
      */
-    TrickleTimer(Instance &aInstance,
-#ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
-                 uint32_t aRedundancyConstant,
-#endif
-                 Handler aTransmitHandler,
-                 Handler aIntervalExpiredHandler);
+    TrickleTimer(Instance &aInstance, Handler aHandler);
 
     /**
      * This method indicates whether or not the trickle timer instance is running.
@@ -102,60 +102,85 @@ public:
      * @retval FALSE  If the trickle timer is not running.
      *
      */
-    bool IsRunning(void) const { return mIsRunning; }
+    bool IsRunning(void) const { return TimerMilli::IsRunning(); }
+
+    /**
+     * This method gets the current operation mode of the trickle timer.
+     *
+     * @returns The current operation mode of the timer.
+     *
+     */
+    Mode GetMode(void) const { return mMode; }
 
     /**
      * This method starts the trickle timer.
      *
-     * @param[in]  aIntervalMin  The minimum interval for the timer in milliseconds.
-     * @param[in]  aIntervalMax  The maximum interval for the timer in milliseconds.
-     * @param[in]  aMode         The operating mode for the timer.
+     * @param[in]  aMode                The operation mode of timer (trickle or plain periodic mode).
+     * @param[in]  aIntervalMin         The minimum interval for the timer in milliseconds.
+     * @param[in]  aIntervalMax         The maximum interval for the timer in milliseconds.
+     * @param[in]  aRedundancyConstant  The redundancy constant for the timer, also known as `k`. The default value
+     *                                  is set to `kInfiniteRedundancyConstant` which disables the suppression behavior
+     *                                  (i.e., handler is always invoked independent of number of "consistent" events).
      *
      */
-    void Start(uint32_t aIntervalMin, uint32_t aIntervalMax, Mode aMode);
+    void Start(Mode     aMode,
+               uint32_t aIntervalMin,
+               uint32_t aIntervalMax,
+               uint16_t aRedundancyConstant = kInfiniteRedundancyConstant);
 
     /**
      * This method stops the trickle timer.
      *
      */
-    void Stop(void);
+    void Stop(void) { TimerMilli::Stop(); }
 
-#ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
     /**
-     * This method indicates to the trickle timer a 'consistent' state.
+     * This method indicates to the trickle timer a 'consistent' event.
+     *
+     * The 'consistent' events are used to control suppression behavior. The trickle timer keeps track of the number of
+     * 'consistent' events in each interval. The timer handler is invoked only if the number of `consistent` events
+     * received in the interval is less than the redundancy constant.
      *
      */
-    void IndicateConsistent(void) { mCounter++; }
-#endif
+    void IndicateConsistent(void);
 
     /**
-     * This method indicates to the trickle timer an 'inconsistent' state.
+     * This method indicates to the trickle timer an 'inconsistent' event.
+     *
+     * Receiving an 'inconsistent' event causes the trickle timer to reset (i.e., start with interval set to the min
+     * value) unless the current interval being used is already equal to the min interval.
      *
      */
     void IndicateInconsistent(void);
 
 private:
+    enum Phase : uint8_t
+    {
+        kBeforeRandomTime, // Trickle timer is before random time `t` in the current interval.
+        kAfterRandomTime,  // Trickle timer is after random time `t` in the current interval.
+    };
+
     void        StartNewInterval(void);
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
     void        HandleEndOfTimeInInterval(void);
     void        HandleEndOfInterval(void);
-    void        StartAt(void) {} // Shadow base class `TimerMilli` method to ensure it is hidden.
 
-#ifdef ENABLE_TRICKLE_TIMER_SUPPRESSION_SUPPORT
-    const uint32_t mRedundancyConstant; // Redundancy constant (aka 'k').
-    uint32_t       mCounter;            // A counter for number of "consistent" transmissions (aka 'c').
-#endif
+    // Shadow base class `TimerMilli` methods to ensure they are hidden.
+    void StartAt(void) {}
+    void FireAt(void) {}
+    void FireAtIfEarlier(void) {}
+    void GetFireTime(void) {}
 
-    uint32_t mIntervalMin;            // Minimum interval (aka `Imin`).
-    uint32_t mIntervalMax;            // Maximum interval (aka `Imax`).
-    uint32_t mInterval;               // Current interval (aka `I`).
-    uint32_t mTimeInInterval;         // Time in interval (aka `t`).
-    Handler  mTransmitHandler;        // Transmit handler callback.
-    Handler  mIntervalExpiredHandler; // Interval expired handler callback.
-    Mode     mMode;                   // Trickle timer mode.
-    bool     mIsRunning : 1;          // Indicates if the trickle timer is running.
-    bool     mInTransmitPhase : 1;    // Indicates if in transmit phase (before time `t` in current interval `I`).
+    uint32_t mIntervalMin;        // Minimum interval (aka `Imin`).
+    uint32_t mIntervalMax;        // Maximum interval (aka `Imax`).
+    uint32_t mInterval;           // Current interval (aka `I`).
+    uint32_t mTimeInInterval;     // Time in interval (aka `t`).
+    uint16_t mRedundancyConstant; // Redundancy constant (aka 'k').
+    uint16_t mCounter;            // A counter for number of "consistent" transmissions (aka 'c').
+    Handler  mHandler;            // Handler callback.
+    Mode     mMode;               // Trickle timer operation mode.
+    Phase    mPhase;              // Trickle timer phase (before or after time `t` in the current interval).
 };
 
 /**

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -140,8 +140,8 @@ private:
     Error    ProcessStatusCode(Message &aMessage, uint16_t aOffset);
     Error    ProcessIaAddress(Message &aMessage, uint16_t aOffset);
 
-    static bool HandleTrickleTimer(TrickleTimer &aTrickleTimer);
-    bool        HandleTrickleTimer(void);
+    static void HandleTrickleTimer(TrickleTimer &aTrickleTimer);
+    void        HandleTrickleTimer(void);
 
     Ip6::Udp::Socket mSocket;
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -528,7 +528,7 @@ Error Mle::BecomeChild(AttachMode aMode)
 #if OPENTHREAD_FTD
         if (IsFullThreadDevice())
         {
-            Get<MleRouter>().StopAdvertiseTimer();
+            Get<MleRouter>().StopAdvertiseTrickleTimer();
         }
 #endif
     }

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -599,7 +599,7 @@ private:
 #endif
 
     Error ProcessRouteTlv(const RouteTlv &aRoute);
-    void  StopAdvertiseTimer(void);
+    void  StopAdvertiseTrickleTimer(void);
     Error SendAddressSolicit(ThreadStatusTlv::Status aStatus);
     void  SendAddressRelease(void);
     void  SendAddressSolicitResponse(const Coap::Message &   aRequest,
@@ -653,11 +653,11 @@ private:
     bool HasOneNeighborWithComparableConnectivity(const RouteTlv &aRoute, uint8_t aRouterId);
     bool HasSmallNumberOfChildren(void);
 
-    static bool HandleAdvertiseTimer(TrickleTimer &aTimer);
-    bool        HandleAdvertiseTimer(void);
+    static void HandleAdvertiseTrickleTimer(TrickleTimer &aTimer);
+    void        HandleAdvertiseTrickleTimer(void);
     void        HandleTimeTick(void);
 
-    TrickleTimer mAdvertiseTimer;
+    TrickleTimer mAdvertiseTrickleTimer;
 
     Coap::Resource mAddressSolicit;
     Coap::Resource mAddressRelease;


### PR DESCRIPTION
This commit simplifies and enhances the `TrickleTimer` class. It adds
support for suppression behavior and removes unused `Mode` and unused
end of interval callback.