### PR TITLE
[border-router] add validation of updated on mesh prefixes

### DIFF
--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -80,18 +80,18 @@ otError otBorderRouterAddOnMeshPrefix(otInstance *aInstance, const otBorderRoute
 
     OT_ASSERT(aConfig != nullptr);
 
-    SuccessOrExit(error = instance.Get<NetworkData::Local>().AddOnMeshPrefix(*config));
+    SuccessOrExit(error = instance.Get<NetworkData::Local>().ValidateOnMeshPrefix(*config));
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    // Only try to configure Domain Prefix after the parameter is validated via above `AddOnMeshPrefix()`.
     if (aConfig->mDp)
     {
-        // Restore local server data
-        IgnoreError(instance.Get<NetworkData::Local>().RemoveOnMeshPrefix(config->GetPrefix()));
-
         instance.Get<BackboneRouter::Local>().SetDomainPrefix(*config);
     }
+    else
 #endif
+    {
+        SuccessOrExit(error = instance.Get<NetworkData::Local>().AddOnMeshPrefix(*config));
+    }
 
 exit:
     return error;

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -80,11 +80,10 @@ otError otBorderRouterAddOnMeshPrefix(otInstance *aInstance, const otBorderRoute
 
     OT_ASSERT(aConfig != nullptr);
 
-    SuccessOrExit(error = instance.Get<NetworkData::Local>().ValidateOnMeshPrefix(*config));
-
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     if (aConfig->mDp)
     {
+        SuccessOrExit(error = instance.Get<NetworkData::Local>().ValidateOnMeshPrefix(*config));
         instance.Get<BackboneRouter::Local>().SetDomainPrefix(*config);
     }
     else

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -159,7 +159,8 @@ exit:
 
 Error Local::AddHasRoutePrefix(const ExternalRouteConfig &aConfig)
 {
-    return AddPrefix(aConfig.GetPrefix(), NetworkDataTlv::kTypeHasRoute, aConfig.mPreference, 0, aConfig.mStable);
+    return AddPrefix(aConfig.GetPrefix(), NetworkDataTlv::kTypeHasRoute, aConfig.mPreference, /* aFlags */ 0,
+                     aConfig.mStable);
 }
 
 Error Local::RemoveHasRoutePrefix(const Ip6::Prefix &aPrefix)

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -117,17 +117,6 @@ public:
     Error AddHasRoutePrefix(const ExternalRouteConfig &aConfig);
 
     /**
-     * This method validates Has Route prefix for Thread Network data.
-     *
-     * @param[in]  aConfig        A reference to the external route configuration.
-     *
-     * @retval kErrorNone         Successfully verified the Has Route prefix.
-     * @retval kErrorInvalidArgs  The prefix is not a valid Has Route prefix.
-     *
-     */
-    otError ValidateHasRoutePrefix(const ExternalRouteConfig &aConfig);
-
-    /**
      * This method removes a Border Router entry from the Thread Network Data.
      *
      * @param[in]  aPrefix        The Prefix to remove.
@@ -192,17 +181,16 @@ public:
 private:
     void UpdateRloc(void);
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
-    Error        AddPrefix(const Ip6::Prefix &  aPrefix,
-                           NetworkDataTlv::Type aSubTlvType,
-                           int8_t               aPrf,
-                           uint16_t             aFlags,
-                           bool                 aStable);
-    Error        RemovePrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvType);
-    static Error ValidatePrefix(const Ip6::Prefix &aPrefix);
-    static Error ValidatePreference(int8_t aPrf);
-    void         UpdateRloc(PrefixTlv &aPrefixTlv);
-    bool         IsOnMeshPrefixConsistent(void) const;
-    bool         IsExternalRouteConsistent(void) const;
+    Error ValidatePrefixAndPreference(const Ip6::Prefix &aPrefix, int8_t aPrf);
+    Error AddPrefix(const Ip6::Prefix &  aPrefix,
+                    NetworkDataTlv::Type aSubTlvType,
+                    int8_t               aPrf,
+                    uint16_t             aFlags,
+                    bool                 aStable);
+    Error RemovePrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvType);
+    void  UpdateRloc(PrefixTlv &aPrefixTlv);
+    bool  IsOnMeshPrefixConsistent(void) const;
+    bool  IsExternalRouteConsistent(void) const;
 #endif
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -84,6 +84,17 @@ public:
     Error AddOnMeshPrefix(const OnMeshPrefixConfig &aConfig);
 
     /**
+     * This method validates on mesh prefix.
+     *
+     * @param[in]  aConfig        A reference to the on-mesh perfix configuration.
+     *
+     * @retval kErrorNone         Successfully verified the on-mesh prefix.
+     * @retval kErrorInvalidArgs  The prefix is not a valid on-mesh prefix.
+     *
+     */
+    Error ValidateOnMeshPrefix(const OnMeshPrefixConfig &aConfig);
+
+    /**
      * This method removes a Border Router entry from the Thread Network Data.
      *
      * @param[in]  aPrefix        The Prefix to remove.
@@ -104,6 +115,17 @@ public:
      *
      */
     Error AddHasRoutePrefix(const ExternalRouteConfig &aConfig);
+
+    /**
+     * This method validates Has Route prefix for Thread Network data.
+     *
+     * @param[in]  aConfig        A reference to the external route configuration.
+     *
+     * @retval kErrorNone         Successfully verified the Has Route prefix.
+     * @retval kErrorInvalidArgs  The prefix is not a valid Has Route prefix.
+     *
+     */
+    otError ValidateHasRoutePrefix(const ExternalRouteConfig &aConfig);
 
     /**
      * This method removes a Border Router entry from the Thread Network Data.
@@ -170,15 +192,17 @@ public:
 private:
     void UpdateRloc(void);
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
-    Error AddPrefix(const Ip6::Prefix &  aPrefix,
-                    NetworkDataTlv::Type aSubTlvType,
-                    int8_t               aPrf,
-                    uint16_t             aFlags,
-                    bool                 aStable);
-    Error RemovePrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvType);
-    void  UpdateRloc(PrefixTlv &aPrefixTlv);
-    bool  IsOnMeshPrefixConsistent(void) const;
-    bool  IsExternalRouteConsistent(void) const;
+    Error        AddPrefix(const Ip6::Prefix &  aPrefix,
+                           NetworkDataTlv::Type aSubTlvType,
+                           int8_t               aPrf,
+                           uint16_t             aFlags,
+                           bool                 aStable);
+    Error        RemovePrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvType);
+    static Error ValidatePrefix(const Ip6::Prefix &aPrefix);
+    static Error ValidatePreference(int8_t aPrf);
+    void         UpdateRloc(PrefixTlv &aPrefixTlv);
+    bool         IsOnMeshPrefixConsistent(void) const;
+    bool         IsExternalRouteConsistent(void) const;
 #endif
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -84,7 +84,7 @@ public:
     Error AddOnMeshPrefix(const OnMeshPrefixConfig &aConfig);
 
     /**
-     * This method validates on mesh prefix.
+     * This method validates an on-mesh prefix.
      *
      * @param[in]  aConfig        A reference to the on-mesh perfix configuration.
      *


### PR DESCRIPTION
    This commit adds validation of the on mesh prefixes.

    With this change, the domain on mesh prefix can be directly configured after successfull verification.