### PR TITLE
[thread-tlvs] rename to follow style

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2574,14 +2574,14 @@ exit:
 otError Interpreter::ProcessMlrReg(uint8_t aArgsLength, char *aArgs[])
 {
     otError      error = OT_ERROR_NONE;
-    otIp6Address addresses[kIPv6AddressesNumMax];
+    otIp6Address addresses[kIp6AddressesNumMax];
     uint32_t     timeout;
     uint8_t      i;
 
     VerifyOrExit(aArgsLength >= 1, error = OT_ERROR_INVALID_ARGS);
-    VerifyOrExit(aArgsLength <= kIPv6AddressesNumMax + 1, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aArgsLength <= kIp6AddressesNumMax + 1, error = OT_ERROR_INVALID_ARGS);
 
-    for (i = 0; i < aArgsLength && i < kIPv6AddressesNumMax; i++)
+    for (i = 0; i < aArgsLength && i < kIp6AddressesNumMax; i++)
     {
         if (ParseAsIp6Address(aArgs[i], addresses[i]) != OT_ERROR_NONE)
         {

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -162,7 +162,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
 
     uint16_t     addressesOffset, addressesLength;
     Ip6::Address address;
-    Ip6::Address addresses[kIPv6AddressesNumMax];
+    Ip6::Address addresses[kIp6AddressesNumMax];
     uint8_t      failedAddressNum  = 0;
     uint8_t      successAddressNum = 0;
     TimeMilli    expireTime;
@@ -201,11 +201,11 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
 
     processTimeoutTlv = hasCommissionerSessionIdTlv && (Tlv::Find<ThreadTimeoutTlv>(aMessage, timeout) == kErrorNone);
 
-    VerifyOrExit(Tlv::FindTlvValueOffset(aMessage, IPv6AddressesTlv::kIPv6Addresses, addressesOffset,
-                                         addressesLength) == kErrorNone,
+    VerifyOrExit(Tlv::FindTlvValueOffset(aMessage, Ip6AddressesTlv::kIp6Addresses, addressesOffset, addressesLength) ==
+                     kErrorNone,
                  error = kErrorParse);
     VerifyOrExit(addressesLength % sizeof(Ip6::Address) == 0, status = ThreadStatusTlv::kMlrGeneralFailure);
-    VerifyOrExit(addressesLength / sizeof(Ip6::Address) <= kIPv6AddressesNumMax,
+    VerifyOrExit(addressesLength / sizeof(Ip6::Address) <= kIp6AddressesNumMax,
                  status = ThreadStatusTlv::kMlrGeneralFailure);
 
     if (!processTimeoutTlv)
@@ -274,7 +274,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
             else
             {
                 // Put successfully registered addresses at the end of `addresses`.
-                addresses[kIPv6AddressesNumMax - (++successAddressNum)] = address;
+                addresses[kIp6AddressesNumMax - (++successAddressNum)] = address;
             }
         }
     }
@@ -287,7 +287,7 @@ exit:
 
     if (successAddressNum > 0)
     {
-        SendBackboneMulticastListenerRegistration(&addresses[kIPv6AddressesNumMax - successAddressNum],
+        SendBackboneMulticastListenerRegistration(&addresses[kIp6AddressesNumMax - successAddressNum],
                                                   successAddressNum, timeout);
     }
 }
@@ -310,7 +310,7 @@ void Manager::SendMulticastListenerRegistrationResponse(const Coap::Message &   
 
     if (aFailedAddressNum > 0)
     {
-        IPv6AddressesTlv addressesTlv;
+        Ip6AddressesTlv addressesTlv;
 
         addressesTlv.Init();
         addressesTlv.SetLength(sizeof(Ip6::Address) * aFailedAddressNum);
@@ -336,10 +336,10 @@ void Manager::SendBackboneMulticastListenerRegistration(const Ip6::Address *aAdd
     Error             error   = kErrorNone;
     Coap::Message *   message = nullptr;
     Ip6::MessageInfo  messageInfo;
-    IPv6AddressesTlv  addressesTlv;
+    Ip6AddressesTlv   addressesTlv;
     BackboneTmfAgent &backboneTmf = Get<BackboneRouter::BackboneTmfAgent>();
 
-    OT_ASSERT(aAddressNum >= kIPv6AddressesNumMin && aAddressNum <= kIPv6AddressesNumMax);
+    OT_ASSERT(aAddressNum >= kIp6AddressesNumMin && aAddressNum <= kIp6AddressesNumMax);
 
     VerifyOrExit((message = backboneTmf.NewMessage()) != nullptr, error = kErrorNoBufs);
 

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -227,7 +227,7 @@ void MlrManager::SendMulticastListenerRegistration(void)
 {
     Error           error;
     Mle::MleRouter &mle = Get<Mle::MleRouter>();
-    Ip6::Address    addresses[kIPv6AddressesNumMax];
+    Ip6::Address    addresses[kIp6AddressesNumMax];
     uint8_t         addressesNum = 0;
 
     VerifyOrExit(!mMlrPending, error = kErrorBusy);
@@ -240,7 +240,7 @@ void MlrManager::SendMulticastListenerRegistration(void)
     for (Ip6::ExternalNetifMulticastAddress &addr :
          Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
-        if (addressesNum >= kIPv6AddressesNumMax)
+        if (addressesNum >= kIp6AddressesNumMax)
         {
             break;
         }
@@ -257,7 +257,7 @@ void MlrManager::SendMulticastListenerRegistration(void)
     // Append Child multicast addresses
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
-        if (addressesNum >= kIPv6AddressesNumMax)
+        if (addressesNum >= kIp6AddressesNumMax)
         {
             break;
         }
@@ -269,7 +269,7 @@ void MlrManager::SendMulticastListenerRegistration(void)
 
         for (const Ip6::Address &address : child.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
         {
-            if (addressesNum >= kIPv6AddressesNumMax)
+            if (addressesNum >= kIp6AddressesNumMax)
             {
                 break;
             }
@@ -323,7 +323,7 @@ Error MlrManager::RegisterMulticastListeners(const otIp6Address *               
     Error error;
 
     VerifyOrExit(aAddresses != nullptr, error = kErrorInvalidArgs);
-    VerifyOrExit(aAddressNum > 0 && aAddressNum <= kIPv6AddressesNumMax, error = kErrorInvalidArgs);
+    VerifyOrExit(aAddressNum > 0 && aAddressNum <= kIp6AddressesNumMax, error = kErrorInvalidArgs);
     VerifyOrExit(aContext == nullptr || aCallback != nullptr, error = kErrorInvalidArgs);
     VerifyOrExit(Get<MeshCoP::Commissioner>().IsActive(), error = kErrorInvalidState);
 
@@ -358,7 +358,7 @@ void MlrManager::HandleRegisterMulticastListenersResponse(otMessage *          a
 
     uint8_t                                 status;
     Error                                   error;
-    Ip6::Address                            failedAddresses[kIPv6AddressesNumMax];
+    Ip6::Address                            failedAddresses[kIp6AddressesNumMax];
     uint8_t                                 failedAddressNum = 0;
     otIp6RegisterMulticastListenersCallback callback         = mRegisterMulticastListenersCallback;
     void *                                  context          = mRegisterMulticastListenersContext;
@@ -390,7 +390,7 @@ Error MlrManager::SendMulticastListenerRegistrationMessage(const otIp6Address * 
     Mle::MleRouter & mle     = Get<Mle::MleRouter>();
     Coap::Message *  message = nullptr;
     Ip6::MessageInfo messageInfo;
-    IPv6AddressesTlv addressesTlv;
+    Ip6AddressesTlv  addressesTlv;
 
     VerifyOrExit(Get<BackboneRouter::Leader>().HasPrimary(), error = kErrorInvalidState);
 
@@ -462,7 +462,7 @@ void MlrManager::HandleMulticastListenerRegistrationResponse(Coap::Message *    
 
     uint8_t      status;
     Error        error;
-    Ip6::Address failedAddresses[kIPv6AddressesNumMax];
+    Ip6::Address failedAddresses[kIp6AddressesNumMax];
     uint8_t      failedAddressNum = 0;
 
     error = ParseMulticastListenerRegistrationResponse(aResult, aMessage, status, failedAddresses, failedAddressNum);
@@ -509,11 +509,11 @@ Error MlrManager::ParseMulticastListenerRegistrationResponse(Error          aRes
 
     SuccessOrExit(error = Tlv::Find<ThreadStatusTlv>(*aMessage, aStatus));
 
-    if (ThreadTlv::FindTlvValueOffset(*aMessage, IPv6AddressesTlv::kIPv6Addresses, addressesOffset, addressesLength) ==
+    if (ThreadTlv::FindTlvValueOffset(*aMessage, Ip6AddressesTlv::kIp6Addresses, addressesOffset, addressesLength) ==
         kErrorNone)
     {
         VerifyOrExit(addressesLength % sizeof(Ip6::Address) == 0, error = kErrorParse);
-        VerifyOrExit(addressesLength / sizeof(Ip6::Address) <= kIPv6AddressesNumMax, error = kErrorParse);
+        VerifyOrExit(addressesLength / sizeof(Ip6::Address) <= kIp6AddressesNumMax, error = kErrorParse);
 
         for (uint16_t offset = 0; offset < addressesLength; offset += sizeof(Ip6::Address))
         {
@@ -694,7 +694,7 @@ void MlrManager::LogMulticastAddresses(void)
 #endif // OPENTHREAD_CONFIG_LOG_MLR && OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
 }
 
-void MlrManager::AppendToUniqueAddressList(Ip6::Address (&aAddresses)[kIPv6AddressesNumMax],
+void MlrManager::AppendToUniqueAddressList(Ip6::Address (&aAddresses)[kIp6AddressesNumMax],
                                            uint8_t &           aAddressNum,
                                            const Ip6::Address &aAddress)
 {

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -193,7 +193,7 @@ private:
                                              const Ip6::Address *aFailedAddresses,
                                              uint8_t             aFailedAddressNum);
 
-    void        AppendToUniqueAddressList(Ip6::Address (&aAddresses)[kIPv6AddressesNumMax],
+    void        AppendToUniqueAddressList(Ip6::Address (&aAddresses)[kIp6AddressesNumMax],
                                           uint8_t &           aAddressNum,
                                           const Ip6::Address &aAddress);
     static bool AddressListContains(const Ip6::Address *aAddressList,

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -51,8 +51,8 @@ using ot::Encoding::BigEndian::HostSwap32;
 enum
 {
     // Thread 1.2.0 5.19.13 limits the number of IPv6 addresses should be [1, 15].
-    kIPv6AddressesNumMin = 1,
-    kIPv6AddressesNumMax = 15,
+    kIp6AddressesNumMin = 1,
+    kIp6AddressesNumMax = 15,
 };
 
 /**
@@ -76,12 +76,12 @@ public:
         kStatus                = 4,  ///< Status TLV
         kLastTransactionTime   = 6,  ///< Time Since Last Transaction TLV
         kRouterMask            = 7,  ///< Router Mask TLV
-        kNDOption              = 8,  ///< ND Option TLV
-        kNDData                = 9,  ///< ND Data TLV
+        kNdOption              = 8,  ///< ND Option TLV
+        kNdData                = 9,  ///< ND Data TLV
         kThreadNetworkData     = 10, ///< Thread Network Data TLV
         kTimeout               = 11, ///< Timeout TLV
         kNetworkName           = 12, ///< Network Name TLV
-        kIPv6Addresses         = 14, ///< IPv6 Addresses TLV
+        kIp6Addresses          = 14, ///< IPv6 Addresses TLV
         kCommissionerSessionId = 15, ///< Commissioner Session ID TLV
     };
 
@@ -316,14 +316,14 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class IPv6AddressesTlv : public ThreadTlv, public TlvInfo<ThreadTlv::kIPv6Addresses>
+class Ip6AddressesTlv : public ThreadTlv, public TlvInfo<ThreadTlv::kIp6Addresses>
 {
 public:
     /**
      * This method initializes the TLV.
      *
      */
-    void Init(void) { SetType(kIPv6Addresses); }
+    void Init(void) { SetType(kIp6Addresses); }
 
     /**
      * This method indicates whether or not the TLV appears to be well-formed.
@@ -334,8 +334,8 @@ public:
      */
     bool IsValid(void) const
     {
-        return GetLength() >= sizeof(Ip6::Address) * kIPv6AddressesNumMin &&
-               GetLength() <= sizeof(Ip6::Address) * kIPv6AddressesNumMax && (GetLength() % sizeof(Ip6::Address)) == 0;
+        return GetLength() >= sizeof(Ip6::Address) * kIp6AddressesNumMin &&
+               GetLength() <= sizeof(Ip6::Address) * kIp6AddressesNumMax && (GetLength() % sizeof(Ip6::Address)) == 0;
     }
 
     /**

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -266,7 +266,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_CSL_CHANNEL>(v
 template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_MLR_REQUEST>(void)
 {
     otError      error = OT_ERROR_NONE;
-    otIp6Address addresses[kIPv6AddressesNumMax];
+    otIp6Address addresses[kIp6AddressesNumMax];
     uint8_t      addressesCount = 0U;
     bool         timeoutPresent = false;
     uint32_t     timeout;
@@ -275,7 +275,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_MLR_REQUEST>(v
 
     while (mDecoder.GetRemainingLengthInStruct())
     {
-        VerifyOrExit(addressesCount < kIPv6AddressesNumMax, error = OT_ERROR_NO_BUFS);
+        VerifyOrExit(addressesCount < kIp6AddressesNumMax, error = OT_ERROR_NO_BUFS);
         SuccessOrExit(error = mDecoder.ReadIp6Address(addresses[addressesCount]));
         ++addressesCount;
     }


### PR DESCRIPTION
This commit renames some of the definitions in `thread_tlvs.hpp`
to follow the camel-case naming style.