### PR TITLE
[gn] include lib/platform files in build

### DIFF
--- a/src/lib/platform/BUILD.gn
+++ b/src/lib/platform/BUILD.gn
@@ -1,4 +1,4 @@
-#  Copyright (c) 2020, The OpenThread Authors.
+#  Copyright (c) 2021, The OpenThread Authors.
 #  All rights reserved.
 #
 #  Redistribution and use in source and binary forms, with or without
@@ -27,59 +27,16 @@
 
 visibility = [ "../../../*" ]
 
-declare_args() {
-  # Platform portability header for spinel.
-  spinel_platform_header = "\"spinel_platform.h\""
-}
-
-spinel_sources = [
-  "openthread-spinel-config.h",
-  "radio_spinel.hpp",
-  "radio_spinel_impl.hpp",
-  "spinel.c",
-  "spinel_buffer.cpp",
-  "spinel_buffer.hpp",
-  "spinel_decoder.cpp",
-  "spinel_decoder.hpp",
-  "spinel_encoder.cpp",
-  "spinel_encoder.hpp",
-  "spinel_platform.h",
+platform_sources = [
+  "exit_code.c",
+  "exit_code.h",
 ]
 
-config("spinel_config") {
-  defines = [ "SPINEL_PLATFORM_HEADER=${spinel_platform_header}" ]
+config("platform_config") {
   include_dirs = [ ".." ]
 }
 
-config("spinel_config_openthread_message_enable") {
-  defines = [ "OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE=1" ]
-}
-
-config("spinel_config_openthread_message_disable") {
-  defines = [ "OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE=0" ]
-}
-
-source_set("spinel-api") {
-  public = [ "spinel.h" ]
-  public_configs = [ ":spinel_config" ]
-}
-
-static_library("libopenthread-spinel-ncp") {
-  sources = spinel_sources
-  public_deps = [
-    ":spinel-api",
-    "../../core:libopenthread_core_headers",
-    "../platform:libopenthread-platform",
-  ]
-  public_configs = [ ":spinel_config_openthread_message_enable" ]
-}
-
-static_library("libopenthread-spinel-rcp") {
-  sources = spinel_sources
-  public_deps = [
-    ":spinel-api",
-    "../../core:libopenthread_core_headers",
-    "../platform:libopenthread-platform",
-  ]
-  public_configs = [ ":spinel_config_openthread_message_disable" ]
+static_library("libopenthread-platform") {
+  sources = platform_sources
+  public_configs = [ ":platform_config" ]
 }


### PR DESCRIPTION
These are needed to enable logging when building with gn.
This fixes the bug #6316.