### PR TITLE
[udp] bind to Thread interface by default

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1666,8 +1666,7 @@ Error Coap::Start(uint16_t aPort, otNetifIdentifier aNetifIdentifier)
     SuccessOrExit(error = mSocket.Open(&Coap::HandleUdpReceive, this));
     socketOpened = true;
 
-    SuccessOrExit(error = mSocket.BindToNetif(aNetifIdentifier));
-    SuccessOrExit(error = mSocket.Bind(aPort));
+    SuccessOrExit(error = mSocket.Bind(aPort, aNetifIdentifier));
 
 exit:
     if (error != kErrorNone && socketOpened)

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -215,7 +215,7 @@ Error Dtls::Bind(uint16_t aPort)
     VerifyOrExit(mState == kStateOpen, error = kErrorInvalidState);
     VerifyOrExit(mTransportCallback == nullptr, error = kErrorAlready);
 
-    SuccessOrExit(error = mSocket.Bind(aPort));
+    SuccessOrExit(error = mSocket.Bind(aPort, OT_NETIF_UNSPECIFIED));
 
 exit:
     return error;

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -66,7 +66,7 @@ Error Server::Start(void)
     VerifyOrExit(!IsRunning());
 
     SuccessOrExit(error = mSocket.Open(&Server::HandleUdpReceive, this));
-    SuccessOrExit(error = mSocket.Bind(kPort));
+    SuccessOrExit(error = mSocket.Bind(kPort, OT_NETIF_UNSPECIFIED));
 
 exit:
     otLogInfoDns("[server] started: %s", ErrorToString(error));

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -424,7 +424,7 @@ void Server::Start(void)
     VerifyOrExit(!IsRunning());
 
     SuccessOrExit(error = mSocket.Open(HandleUdpReceive, this));
-    SuccessOrExit(error = mSocket.Bind(0));
+    SuccessOrExit(error = mSocket.Bind(0, OT_NETIF_UNSPECIFIED));
 
     SuccessOrExit(error = PublishServerData());
 

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -174,36 +174,27 @@ public:
         /**
          * This method binds the UDP socket.
          *
-         * @param[in]  aSockAddr    A reference to the socket address.
+         * @param[in]  aSockAddr            A reference to the socket address.
+         * @param[in]  aNetifIdentifier     The network interface identifier.
          *
          * @retval kErrorNone            Successfully bound the socket.
          * @retval kErrorInvalidArgs     Unable to bind to Thread network interface with the given address.
          * @retval kErrorFailed          Failed to bind UDP Socket.
          *
          */
-        Error Bind(const SockAddr &aSockAddr);
-
-        /**
-         * This method binds the UDP socket to a specified network interface.
-         *
-         * @param[in]  aNetifIdentifier     The network interface identifier.
-         *
-         * @retval kErrorNone    Successfully bound to the network interface.
-         * @retval kErrorFailed  Failed to bind to the network interface.
-         *
-         */
-        Error BindToNetif(otNetifIdentifier aNetifIdentifier);
+        Error Bind(const SockAddr &aSockAddr, otNetifIdentifier aNetifIdentifier = OT_NETIF_THREAD);
 
         /**
          * This method binds the UDP socket.
          *
-         * @param[in]  aPort        A port number.
+         * @param[in]  aPort                A port number.
+         * @param[in]  aNetifIdentifier     The network interface identifier.
          *
          * @retval kErrorNone            Successfully bound the socket.
          * @retval kErrorFailed          Failed to bind UDP Socket.
          *
          */
-        Error Bind(uint16_t aPort);
+        Error Bind(uint16_t aPort, otNetifIdentifier aNetifIdentifier = OT_NETIF_THREAD);
 
         /**
          * This method binds the UDP socket.
@@ -467,15 +458,6 @@ public:
      *
      */
     Error Bind(SocketHandle &aSocket, const SockAddr &aSockAddr);
-
-    /**
-     * This method binds a UDP socket to the Network interface.
-     *
-     * @param[in]  aSocket           A reference to the socket.
-     * @param[in]  aNetifIdentifier  The network interface identifier.
-     *
-     */
-    void BindToNetif(SocketHandle &aSocket, otNetifIdentifier aNetifIdentifier);
 
     /**
      * This method connects a UDP socket.


### PR DESCRIPTION
Bind to Thread network by default so that UDP sockets in CLI can send multicast packets through Thread network interface.