### PR TITLE
[srp-server] bind SRP Server to Thread netif

### DIFF
--- a/src/core/config/srp_server.h
+++ b/src/core/config/srp_server.h
@@ -46,6 +46,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT
+ *
+ * Specifies the SRP Server UDP port.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT
+#define OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT 0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_SRP_SERVER_SERVICE_NUMBER
  *
  * Specifies the Thread Network Data Service number for SRP Server.

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -424,7 +424,7 @@ void Server::Start(void)
     VerifyOrExit(!IsRunning());
 
     SuccessOrExit(error = mSocket.Open(HandleUdpReceive, this));
-    SuccessOrExit(error = mSocket.Bind(0, OT_NETIF_UNSPECIFIED));
+    SuccessOrExit(error = mSocket.Bind(kUdpPort, OT_NETIF_THREAD));
 
     SuccessOrExit(error = PublishServerData());
 

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -73,6 +73,11 @@ class Server : public InstanceLocator, private NonCopyable
     friend class ot::Notifier;
 
 public:
+    enum : uint16_t
+    {
+        kUdpPort = OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT, ///< The SRP Server UDP listening port.
+    };
+
     class Host;
     class Service;
 

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -909,7 +909,7 @@ class NodeImpl:
                 return service
 
     def get_srp_server_port(self):
-        """Returns the dynamic SRP server UDP port by parsing
+        """Returns the SRP server UDP port by parsing
            the SRP Server Data in Network Data.
         """
 

--- a/tests/scripts/thread-cert/test_srp_auto_start_mode.py
+++ b/tests/scripts/thread-cert/test_srp_auto_start_mode.py
@@ -109,7 +109,7 @@ class SrpAutoStartMode(thread_cert.TestCase):
         self.simulator.go(2)
 
         self.assertEqual(client.srp_client_get_state(), 'Enabled')
-        self.assertEqual(client.srp_client_get_server_port(), client.get_srp_server_port())
+        self.assertTrue(server1.has_ipaddr(client.srp_client_get_server_address()))
 
         #
         # 2. Disable server1 and check client is stopped/disabled.
@@ -126,7 +126,7 @@ class SrpAutoStartMode(thread_cert.TestCase):
         server2.srp_server_set_enabled(True)
         self.simulator.go(5)
         self.assertEqual(client.srp_client_get_state(), 'Enabled')
-        prev_port = client.srp_client_get_server_port()
+        server2_address = client.srp_client_get_server_address()
 
         #
         # 4. Enable both servers and check client stays with server2.
@@ -135,7 +135,7 @@ class SrpAutoStartMode(thread_cert.TestCase):
         server1.srp_server_set_enabled(True)
         self.simulator.go(2)
         self.assertEqual(client.srp_client_get_state(), 'Enabled')
-        self.assertEqual(client.srp_client_get_server_port(), prev_port)
+        self.assertEqual(client.srp_client_get_server_address(), server2_address)
 
         #
         # 5. Disable server2 and check client switches to server1.
@@ -144,7 +144,7 @@ class SrpAutoStartMode(thread_cert.TestCase):
         server2.srp_server_set_enabled(False)
         self.simulator.go(5)
         self.assertEqual(client.srp_client_get_state(), 'Enabled')
-        self.assertNotEqual(client.srp_client_get_server_port(), prev_port)
+        self.assertNotEqual(client.srp_client_get_server_address(), server2_address)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR binds SRP Server to Thread netif.

We also add a configuration option for the SRP server UDP port to allow using a specific/static port.

See also discussions at https://github.com/openthread/openthread/pull/6318#discussion_r598065071.