### PR TITLE
[efr32] switch NAME_WLE to NAME_WE to be CMake 3.10 compatible

### DIFF
--- a/third_party/silabs/cmake/imported_libs.cmake
+++ b/third_party/silabs/cmake/imported_libs.cmake
@@ -35,7 +35,7 @@ file(GLOB rail_libs ${librail_release_dir}/*.a)
 foreach(lib_file ${rail_libs})
 
     # Parse lib name, stripping .a extension
-    get_filename_component(lib_name ${lib_file} NAME_WLE)
+    get_filename_component(lib_name ${lib_file} NAME_WE)
     set(imported_lib_name "silabs-${lib_name}")
 
     # Add as an IMPORTED lib
@@ -58,7 +58,7 @@ file(GLOB nvm3_libs ${libnvm3_release_dir}/*.a)
 foreach(lib_file ${nvm3_libs})
 
     # Parse lib name, stripping .a extension
-    get_filename_component(lib_name ${lib_file} NAME_WLE)
+    get_filename_component(lib_name ${lib_file} NAME_WE)
     set(imported_lib_name "silabs-${lib_name}")
 
     # Add as an IMPORTED lib


### PR DESCRIPTION
NAME_WLE was [added](https://cliutils.gitlab.io/modern-cmake/chapters/intro/newcmake.html#cmake-314--file-utilities-aka-cmake-%CF%80) in CMake 3.14 and isn't available in 3.10, which is the default requirement for openthread

This switches `imported_libs.cmake` to NAME_WL, which is in 3.10