### PR TITLE
[udp] bind to an interface when sending/connecting

### DIFF
--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -68,7 +68,7 @@ otError otUdpBind(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr 
     Instance &instance = *static_cast<Instance *>(aInstance);
 
     return instance.Get<Ip6::Udp>().Bind(*static_cast<Ip6::Udp::SocketHandle *>(aSocket),
-                                         *static_cast<const Ip6::SockAddr *>(aSockName));
+                                         *static_cast<const Ip6::SockAddr *>(aSockName), OT_NETIF_THREAD);
 }
 
 otError otUdpConnect(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr *aSockName)

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -451,13 +451,14 @@ public:
      *
      * @param[in]  aSocket          A reference to the socket.
      * @param[in]  aSockAddr        A reference to the socket address.
+     * @param[in]  aNetifIdentifier The network interface identifier.
      *
      * @retval kErrorNone            Successfully bound the socket.
      * @retval kErrorInvalidArgs     Unable to bind to Thread network interface with the given address.
      * @retval kErrorFailed          Failed to bind UDP Socket.
      *
      */
-    Error Bind(SocketHandle &aSocket, const SockAddr &aSockAddr);
+    Error Bind(SocketHandle &aSocket, const SockAddr &aSockAddr, otNetifIdentifier aNetifIdentifier);
 
     /**
      * This method connects a UDP socket.


### PR DESCRIPTION
A follow up of #6318 to ensure a socket is bound to an interface when no Udp::Bind is called.