### PR TITLE
[equatable] 'Unequatable' class adding overload of operator `!=`

### DIFF
--- a/src/core/common/equatable.hpp
+++ b/src/core/common/equatable.hpp
@@ -41,6 +41,32 @@
 namespace ot {
 
 /**
+ * This template class defines an overload of operator `!=`.
+ *
+ * The `!=` implementation uses an existing `==` overload provided by the `Type` class.
+ *
+ * Users of this class should follow CRTP-style inheritance, i.e., the `Type` class itself should publicly inherit
+ * from `Unequatable<Type>`.
+ *
+ */
+template <typename Type> class Unequatable
+{
+public:
+    /**
+     * This method overloads operator `!=` to evaluate whether or not two instances of `Type` are equal.
+     *
+     * This is implemented in terms of an existing `==` overload provided by `Type` class itself.
+     *
+     * @param[in]  aOther  The other `Type` instance to compare with.
+     *
+     * @retval TRUE   If the two `Type` instances are not equal.
+     * @retval FALSE  If the two `Type` instances are equal.
+     *
+     */
+    bool operator!=(const Type &aOther) const { return !(*static_cast<const Type *>(this) == aOther); }
+};
+
+/**
  * This template class defines overloads of operators `==` and `!=`.
  *
  * The `==` implementation simply compares all the bytes of two `Type` instances to be equal (using `memcmp()`).
@@ -49,7 +75,7 @@ namespace ot {
  * from `Equatable<Type>`.
  *
  */
-template <class Type> class Equatable
+template <typename Type> class Equatable : public Unequatable<Type>
 {
 public:
     /**
@@ -62,17 +88,6 @@ public:
      *
      */
     bool operator==(const Type &aOther) const { return memcmp(this, &aOther, sizeof(Type)) == 0; }
-
-    /**
-     * This method overloads operator `!=` to evaluate whether or not two instances of `Type` are equal.
-     *
-     * @param[in]  aOther  The other `Type` instance to compare with.
-     *
-     * @retval TRUE   If the two `Type` instances are not equal.
-     * @retval FALSE  If the two `Type` instances are equal.
-     *
-     */
-    bool operator!=(const Type &aOther) const { return !(*this == aOther); }
 };
 
 } // namespace ot

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -870,7 +870,7 @@ public:
      * This class defines an iterator to access all Child Info entries in the settings.
      *
      */
-    class ChildInfoIterator : public SettingsBase
+    class ChildInfoIterator : public SettingsBase, public Unequatable<ChildInfoIterator>
     {
         friend class ChildInfoIteratorBuilder;
 
@@ -954,17 +954,6 @@ public:
         {
             return (mIsDone && aOther.mIsDone) || (!mIsDone && !aOther.mIsDone && (mIndex == aOther.mIndex));
         }
-
-        /**
-         * This method overloads operator `!=` to evaluate whether or not two iterator instances are unequal.
-         *
-         * @param[in]  aOther  The other iterator to compare with.
-         *
-         * @retval TRUE   If the two iterator objects are unequal.
-         * @retval FALSE  If the two iterator objects are not unequal.
-         *
-         */
-        bool operator!=(const ChildInfoIterator &aOther) const { return !(*this == aOther); }
 
     private:
         enum IteratorType

--- a/src/core/common/time.hpp
+++ b/src/core/common/time.hpp
@@ -39,6 +39,8 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "common/equatable.hpp"
+
 namespace ot {
 
 /**
@@ -55,7 +57,7 @@ namespace ot {
  * This class represents a time instance.
  *
  */
-class Time
+class Time : public Unequatable<Time>
 {
 public:
     /**
@@ -155,17 +157,6 @@ public:
      *
      */
     bool operator==(const Time &aOther) const { return mValue == aOther.mValue; }
-
-    /**
-     * This method indicates whether two `Time` instance are not equal.
-     *
-     * @param[in]   aOther   A `Time` instance to compare with.
-     *
-     * @retval TRUE    The two `Time` instances are not equal.
-     * @retval FALSE   The two `Time` instances are equal.
-     *
-     */
-    bool operator!=(const Time &aOther) const { return !(*this == aOther); }
 
     /**
      * This method indicates whether this `Time` instance is strictly before another one.

--- a/src/core/mac/channel_mask.hpp
+++ b/src/core/mac/channel_mask.hpp
@@ -39,6 +39,7 @@
 #include <limits.h>
 #include <openthread/platform/radio.h>
 
+#include "common/equatable.hpp"
 #include "common/string.hpp"
 #include "radio/radio.hpp"
 
@@ -61,7 +62,7 @@ namespace Mac {
  * It is a wrapper class around a `uint32_t` bit vector representing a set of channels.
  *
  */
-class ChannelMask
+class ChannelMask : public Unequatable<ChannelMask>
 {
 public:
     enum
@@ -224,16 +225,6 @@ public:
      *
      */
     bool operator==(const ChannelMask &aAnother) const { return (mMask == aAnother.mMask); }
-
-    /**
-     * This method overloads `!=` operator to indicate whether two masks are different.
-     *
-     * @param[in] aAnother     A reference to another mask to compare with the current one.
-     *
-     * @returns TRUE if the two masks are different, FALSE otherwise.
-     *
-     */
-    bool operator!=(const ChannelMask &aAnother) const { return !(*this == aAnother); }
 
     /**
      * This method converts the channel mask into a human-readable string.

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -45,6 +45,7 @@
 
 #include "coap/coap.hpp"
 #include "common/clearable.hpp"
+#include "common/equatable.hpp"
 #include "common/message.hpp"
 #include "common/string.hpp"
 #include "mac/mac_types.hpp"
@@ -65,7 +66,7 @@ enum
  * This type represents a Joiner PSKd.
  *
  */
-class JoinerPskd : public otJoinerPskd, public Clearable<JoinerPskd>
+class JoinerPskd : public otJoinerPskd, public Clearable<JoinerPskd>, public Unequatable<JoinerPskd>
 {
 public:
     enum
@@ -129,17 +130,6 @@ public:
     bool operator==(const JoinerPskd &aOther) const;
 
     /**
-     * This method overloads operator `!=` to evaluate whether or not two PSKds are unequal.
-     *
-     * @param[in]  aOther  The other PSKd to compare with.
-     *
-     * @retval TRUE   If the two are not equal.
-     * @retval FALSE  If the two are equal.
-     *
-     */
-    bool operator!=(const JoinerPskd &aOther) const { return !(*this == aOther); }
-
-    /**
      * This static method indicates whether a given PSKd string if well-formed and valid.
      *
      * @param[in] aPskdString  A pointer to a PSKd string array.
@@ -156,7 +146,7 @@ public:
  * This type represents a Joiner Discerner.
  *
  */
-class JoinerDiscerner : public otJoinerDiscerner
+class JoinerDiscerner : public otJoinerDiscerner, public Unequatable<JoinerDiscerner>
 {
     friend class SteeringData;
 
@@ -240,17 +230,6 @@ public:
      *
      */
     bool operator==(const JoinerDiscerner &aOther) const;
-
-    /**
-     * This method overloads operator `!=` to evaluate whether or not two Joiner Discerner instances are equal.
-     *
-     * @param[in]  aOther  The other Joiner Discerner to compare with.
-     *
-     * @retval TRUE   If the two are not equal.
-     * @retval FALSE  If the two are equal.
-     *
-     */
-    bool operator!=(const JoinerDiscerner &aOther) const { return !(*this == aOther); }
 
     /**
      * This method converts the Joiner Discerner to a string.

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -87,7 +87,7 @@ public:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class Prefix : public otIp6Prefix, public Clearable<Prefix>
+class Prefix : public otIp6Prefix, public Clearable<Prefix>, public Unequatable<Prefix>
 {
 public:
     enum : uint8_t
@@ -221,17 +221,6 @@ public:
         return (mLength == aOther.mLength) &&
                (MatchLength(GetBytes(), aOther.GetBytes(), GetBytesSize()) >= GetLength());
     }
-
-    /**
-     * This method overloads operator `==` to evaluate whether or not two prefixes are unequal.
-     *
-     * @param[in]  aOther  The other prefix to compare with.
-     *
-     * @retval TRUE   If the two prefixes are unequal.
-     * @retval FALSE  If the two prefixes are not unequal.
-     *
-     */
-    bool operator!=(const Prefix &aOther) const { return !(*this == aOther); }
 
     /**
      * This method overloads operator `<` to compare two prefixes.

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/clearable.hpp"
+#include "common/equatable.hpp"
 #include "net/ip6_address.hpp"
 
 namespace ot {
@@ -233,7 +234,7 @@ public:
  * This class implements a socket address.
  *
  */
-class SockAddr : public otSockAddr, public Clearable<SockAddr>
+class SockAddr : public otSockAddr, public Clearable<SockAddr>, public Unequatable<SockAddr>
 {
 public:
     enum : uint16_t
@@ -324,17 +325,6 @@ public:
     {
         return (GetPort() == aOther.GetPort()) && (GetAddress() == aOther.GetAddress());
     }
-
-    /**
-     * This method overloads operator `!=` to evaluate whether or not two `SockAddr` instances are unequal.
-     *
-     * @param[in]  aOther  The other `SockAddr` instance to compare with.
-     *
-     * @retval TRUE   If the two `SockAddr` instances are not equal.
-     * @retval FALSE  If the two `SockAddr` instances are equal.
-     *
-     */
-    bool operator!=(const SockAddr &aOther) const { return !(*this == aOther); }
 
     /**
      * This method converts the socket address to a string.

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -180,7 +180,7 @@ private:
  * This type represents a Service configuration.
  *
  */
-class ServiceConfig : public otServiceConfig, public Clearable<ServiceConfig>
+class ServiceConfig : public otServiceConfig, public Clearable<ServiceConfig>, public Unequatable<ServiceConfig>
 {
     friend class NetworkData;
 
@@ -189,7 +189,7 @@ public:
      * This class represents a Server configuration.
      *
      */
-    class ServerConfig : public otServerConfig
+    class ServerConfig : public otServerConfig, public Unequatable<ServerConfig>
     {
         friend class ServiceConfig;
 
@@ -204,17 +204,6 @@ public:
          *
          */
         bool operator==(const ServerConfig &aOther) const;
-
-        /**
-         * This method overloads operator `!=` to evaluate whether or not two `ServerConfig` instances are unequal.
-         *
-         * @param[in]  aOther  The other `ServerConfig` instance to compare with.
-         *
-         * @retval TRUE   If the two `ServerConfig` instances are unequal.
-         * @retval FALSE  If the two `ServerConfig` instances are not unequal.
-         *
-         */
-        bool operator!=(const ServerConfig &aOther) const { return !(*this == aOther); }
 
     private:
         void SetFrom(const ServerTlv &aServerTlv);
@@ -246,17 +235,6 @@ public:
      *
      */
     bool operator==(const ServiceConfig &aOther) const;
-
-    /**
-     * This method overloads operator `!=` to evaluate whether or not two `ServiceConfig` instances are unequal.
-     *
-     * @param[in]  aOther  The other `ServiceConfig` instance to compare with.
-     *
-     * @retval TRUE   If the two `ServiceConfig` instances are unequal.
-     * @retval FALSE  If the two `ServiceConfig` instances are not unequal.
-     *
-     */
-    bool operator!=(const ServiceConfig &aOther) const { return !(*this == aOther); }
 
 private:
     void SetFrom(const ServiceTlv &aServiceTlv, const ServerTlv &aServerTlv);

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -39,6 +39,7 @@
 #include <openthread/thread_ftd.h>
 
 #include "common/clearable.hpp"
+#include "common/equatable.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
@@ -854,7 +855,7 @@ public:
      * This class defines an iterator used to go through IPv6 address entries of a child.
      *
      */
-    class AddressIterator
+    class AddressIterator : public Unequatable<AddressIterator>
     {
         friend class AddressIteratorBuilder;
 
@@ -968,19 +969,6 @@ public:
          *
          */
         bool operator==(const AddressIterator &aOther) const { return (mIndex == aOther.mIndex); }
-
-        /**
-         * This method overloads operator `!=` to evaluate whether or not two `Iterator` instances are unequal.
-         *
-         * This method MUST be used when the two iterators are associated with the same `Child` entry.
-         *
-         * @param[in]  aOther  The other `Iterator` to compare with.
-         *
-         * @retval TRUE   If the two `Iterator` objects are unequal.
-         * @retval FALSE  If the two `Iterator` objects are not unequal.
-         *
-         */
-        bool operator!=(const AddressIterator &aOther) const { return !(*this == aOther); }
 
     private:
         enum IteratorType : uint8_t


### PR DESCRIPTION
This commit adds `Unequatable<Type>` class which adds an overload of
operator `!=` using an existing `==` overload provided by the `Type`
class. The `Unequatable` should follow CRTP-style inheritance, i.e.,
the `Type` class should publicly inherit from `Unequatable<Type>`.
This provides a solution to avoid repeating the simple implementation
of `operator!=()` overload in different classes.