### PR TITLE
[low-power] add receive timing capability to CSL receiver

### DIFF
--- a/examples/platforms/nrf528xx/nrf52811/openthread-core-nrf52811-config.h
+++ b/examples/platforms/nrf528xx/nrf52811/openthread-core-nrf52811-config.h
@@ -161,6 +161,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE
+ *
+ * Define to 1 to enable software reception target time logic.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE
+#define OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
  *
  * Define to 1 if you want to support microsecond timer in platform.
@@ -224,6 +234,27 @@
  */
 #ifndef RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM
 #define RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM 0
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD
+ *
+ * Reception scheduling and ramp up time needed for the CSL receiver to be ready, in units of microseconds.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD
+#define OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD 2000
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_CSL_MIN_RECEIVE_ON
+ *
+ * The minimum CSL receive window (in microseconds) required to receive an IEEE 802.15.4 frame.
+ * - Frame preamble: 6*2 symbols + margin
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CSL_MIN_RECEIVE_ON
+#define OPENTHREAD_CONFIG_CSL_MIN_RECEIVE_ON 12 * 16
 #endif
 
 /*

--- a/examples/platforms/nrf528xx/nrf52833/openthread-core-nrf52833-config.h
+++ b/examples/platforms/nrf528xx/nrf52833/openthread-core-nrf52833-config.h
@@ -183,6 +183,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE
+ *
+ * Define to 1 to enable software reception target time logic.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE
+#define OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
  *
  * Define to 1 if you want to support microsecond timer in platform.
@@ -276,6 +286,27 @@
  */
 #ifndef RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM
 #define RADIO_CONFIG_SRC_MATCH_EXT_ENTRY_NUM 0
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD
+ *
+ * Reception scheduling and ramp up time needed for the CSL receiver to be ready, in units of microseconds.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD
+#define OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD 2000
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_CSL_MIN_RECEIVE_ON
+ *
+ * The minimum CSL receive window (in microseconds) required to receive an IEEE 802.15.4 frame.
+ * - Frame preamble: 6*2 symbols + margin
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CSL_MIN_RECEIVE_ON
+#define OPENTHREAD_CONFIG_CSL_MIN_RECEIVE_ON 12 * 16
 #endif
 
 /*

--- a/examples/platforms/nrf528xx/nrf52840/openthread-core-nrf52840-config.h
+++ b/examples/platforms/nrf528xx/nrf52840/openthread-core-nrf52840-config.h
@@ -183,6 +183,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE
+ *
+ * Define to 1 to enable software reception target time logic.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE
+#define OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
  *
  * Define to 1 if you want to support microsecond timer in platform.
@@ -285,14 +295,13 @@
  *
  */
 #ifndef OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD
-#define OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD 800
+#define OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD 2000
 #endif
 
 /**
  * @def OPENTHREAD_CONFIG_CSL_MIN_RECEIVE_ON
  *
- * The total duration, in units of microseconds, required for the CSL receiver to fully receive and acknowledge a frame
- * of maximum possible length.
+ * The minimum CSL receive window (in microseconds) required to receive an IEEE 802.15.4 frame.
  * - Frame preamble: 6*2 symbols + margin
  *
  */

--- a/include/openthread/crypto.h
+++ b/include/openthread/crypto.h
@@ -129,7 +129,7 @@ void otCryptoAesCcm(const uint8_t *aKey,
  * @param[out]    aOutput            An output buffer where ECDSA sign should be stored.
  * @param[inout]  aOutputLength      The length of the @p aOutput buffer.
  * @param[in]     aInputHash         An input hash.
- * @param[in]     aInputHashLength   The length of the @p aClaims buffer.
+ * @param[in]     aInputHashLength   The length of the @p aInputHash buffer.
  * @param[in]     aPrivateKey        A private key in PEM format.
  * @param[in]     aPrivateKeyLength  The length of the @p aPrivateKey buffer.
  *

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (104)
+#define OPENTHREAD_API_VERSION (105)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -127,6 +127,7 @@ enum
     OT_RADIO_CAPS_SLEEP_TO_TX      = 1 << 4, ///< Radio supports direct transition from sleep to TX with CSMA.
     OT_RADIO_CAPS_TRANSMIT_SEC     = 1 << 5, ///< Radio supports tx security.
     OT_RADIO_CAPS_TRANSMIT_TIMING  = 1 << 6, ///< Radio supports tx at specific time.
+    OT_RADIO_CAPS_RECEIVE_TIMING   = 1 << 7, ///< Radio supports rx at specific time.
 };
 
 #define OT_PANID_BROADCAST 0xffff ///< IEEE 802.15.4 Broadcast PAN ID
@@ -679,6 +680,18 @@ otError otPlatRadioSleep(otInstance *aInstance);
  *
  */
 otError otPlatRadioReceive(otInstance *aInstance, uint8_t aChannel);
+
+/**
+ * Schedule a radio reception window at a specific time and duration.
+ *
+ * @param[in]  aChannel   The radio channel on which to receive.
+ * @param[in]  aStart     The receive window start time, in microseconds.
+ * @param[in]  aDuration  The receive window duration, in microseconds
+ *
+ * @retval OT_ERROR_NONE    Successfully scheduled receive window.
+ * @retval OT_ERROR_FAILED  The receive window could not be scheduled.
+ */
+otError otPlatRadioReceiveAt(otInstance *aInstance, uint8_t aChannel, uint32_t aStart, uint32_t aDuration);
 
 /**
  * The radio driver calls this method to notify OpenThread of a received frame.

--- a/src/core/config/mac.h
+++ b/src/core/config/mac.h
@@ -316,6 +316,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE
+ *
+ * Define to 1 to enable software reception target time logic.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE
+#define OPENTHREAD_CONFIG_MAC_SOFTWARE_RX_TIMING_ENABLE 0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_MAC_SOFTWARE_ENERGY_SCAN_ENABLE
  *
  * Define to 1 to enable software energy scanning logic.
@@ -399,8 +409,7 @@
 /**
  * @def OPENTHREAD_CONFIG_CSL_MIN_RECEIVE_ON
  *
- * The total duration, in units of microseconds, required for the CSL receiver to fully receive and acknowledge a frame
- * of maximum possible length.
+ * The minimum CSL receive window (in microseconds) required to receive an IEEE 802.15.4 frame.
  * - Maximum frame size with preamble: 6*2+127*2 symbols
  * - AIFS: 12 symbols
  * - Maximum ACK size with preamble: 6*2+33*2 symbols

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -572,6 +572,7 @@ private:
     bool RadioSupportsAckTimeout(void) const { return ((mRadioCaps & OT_RADIO_CAPS_ACK_TIMEOUT) != 0); }
     bool RadioSupportsEnergyScan(void) const { return ((mRadioCaps & OT_RADIO_CAPS_ENERGY_SCAN) != 0); }
     bool RadioSupportsTransmitTiming(void) const { return ((mRadioCaps & OT_RADIO_CAPS_TRANSMIT_TIMING) != 0); }
+    bool RadioSupportsReceiveTiming(void) const { return ((mRadioCaps & OT_RADIO_CAPS_RECEIVE_TIMING) != 0); }
 
     bool ShouldHandleTransmitSecurity(void) const;
     bool ShouldHandleCsmaBackOff(void) const;

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -413,6 +413,19 @@ public:
      */
     void UpdateCslSampleTime(uint32_t aCslSampleTime);
 
+    /**
+     * This method schedules a radio reception window at a specific time and duration.
+     *
+     * @param[in]  aChannel   The radio channel on which to receive.
+     * @param[in]  aStart     The receive window start time, in microseconds.
+     * @param[in]  aDuration  The receive window duration, in microseconds.
+     *
+     * @retval kErrorNone    Successfully scheduled receive window.
+     * @retval kErrorFailed  The receive window could not be scheduled.
+     *
+     */
+    Error ReceiveAt(uint8_t aChannel, uint32_t aStart, uint32_t aDuration);
+
     /** This method enables CSL sampling in radio.
      *
      * @param[in]  aCslPeriod    CSL period, 0 for disabling CSL.
@@ -741,6 +754,11 @@ inline void Radio::UpdateCslSampleTime(uint32_t aCslSampleTime)
     otPlatRadioUpdateCslSampleTime(GetInstancePtr(), aCslSampleTime);
 }
 
+inline Error Radio::ReceiveAt(uint8_t aChannel, uint32_t aStart, uint32_t aDuration)
+{
+    return otPlatRadioReceiveAt(GetInstancePtr(), aChannel, aStart, aDuration);
+}
+
 inline Error Radio::EnableCsl(uint32_t aCslPeriod, const otExtAddress *aExtAddr)
 {
     return otPlatRadioEnableCsl(GetInstancePtr(), aCslPeriod, aExtAddr);
@@ -892,6 +910,11 @@ inline Error Radio::Receive(uint8_t)
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 inline void Radio::UpdateCslSampleTime(uint32_t)
 {
+}
+
+inline Error Radio::ReceiveAt(uint8_t, uint32_t, uint32_t)
+{
+    return kErrorNone;
 }
 
 inline Error Radio::EnableCsl(uint32_t, const otExtAddress *)

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -289,3 +289,13 @@ OT_TOOL_WEAK Error otPlatRadioGetRegion(otInstance *aInstance, uint16_t *aRegion
 
     return kErrorNotImplemented;
 }
+
+OT_TOOL_WEAK Error otPlatRadioReceiveAt(otInstance *aInstance, uint8_t aChannel, uint32_t aStart, uint32_t aDuration)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aChannel);
+    OT_UNUSED_VARIABLE(aStart);
+    OT_UNUSED_VARIABLE(aDuration);
+
+    return kErrorNotImplemented;
+}

--- a/src/posix/platform/radio.cpp
+++ b/src/posix/platform/radio.cpp
@@ -579,3 +579,12 @@ otError otPlatRadioGetRegion(otInstance *aInstance, uint16_t *aRegionCode)
     OT_UNUSED_VARIABLE(aInstance);
     return sRadioSpinel.GetRadioRegion(aRegionCode);
 }
+
+otError otPlatRadioReceiveAt(otInstance *aInstance, uint8_t aChannel, uint32_t aStart, uint32_t aDuration)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aChannel);
+    OT_UNUSED_VARIABLE(aStart);
+    OT_UNUSED_VARIABLE(aDuration);
+    return OT_ERROR_NOT_IMPLEMENTED;
+}


### PR DESCRIPTION
This PR uses the receive timing capability from the radio to schedule CSL receive operations with a higher precision, allowing for shorter receive windows.

`mCslTimer` is set up to be triggered `OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD` before the start of the receive window.

Depends on:
- [x]  https://github.com/openthread/openthread/pull/6311 [low-power] adaptative CSL window duration