### PR TITLE
[link-metrics] address header file loop with 'topology.h'

### DIFF
--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -39,9 +39,8 @@
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 #include "common/logging.hpp"
+#include "thread/link_metrics_tlvs.hpp"
 #include "thread/neighbor_table.hpp"
-
-#include "link_metrics_tlvs.hpp"
 
 namespace ot {
 

--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -42,19 +42,19 @@
 #error "Thread 1.2 or higher version is required for OPENTHREAD_CONFIG_MLE_LINK_METRICS_ENABLE."
 #endif
 
-#include <openthread/ip6.h>
 #include <openthread/link.h>
 
-#include "common/code_utils.hpp"
 #include "common/locator.hpp"
+#include "common/message.hpp"
 #include "common/non_copyable.hpp"
 #include "common/pool.hpp"
-
-#include "link_metrics_tlvs.hpp"
-#include "link_quality.hpp"
-#include "topology.hpp"
+#include "net/ip6_address.hpp"
+#include "thread/link_metrics_tlvs.hpp"
+#include "thread/link_quality.hpp"
 
 namespace ot {
+
+class Neighbor;
 
 /**
  * @addtogroup core-link-metrics
@@ -107,7 +107,7 @@ public:
      * @returns  The Series ID.
      *
      */
-    uint8_t GetSeriesId() const { return mSeriesId; }
+    uint8_t GetSeriesId(void) const { return mSeriesId; }
 
     /**
      * This method gets the PDU count.
@@ -115,7 +115,7 @@ public:
      * @returns  The PDU count.
      *
      */
-    uint32_t GetPduCount() const { return mPduCount; }
+    uint32_t GetPduCount(void) const { return mPduCount; }
 
     /**
      * This method gets the average LQI.
@@ -123,7 +123,7 @@ public:
      * @returns  The average LQI.
      *
      */
-    uint8_t GetAverageLqi() const { return mLqiAverager.GetAverage(); }
+    uint8_t GetAverageLqi(void) const { return mLqiAverager.GetAverage(); }
 
     /**
      * This method gets the average RSS.
@@ -131,7 +131,7 @@ public:
      * @returns  The average RSS.
      *
      */
-    int8_t GetAverageRss() const { return mRssAverager.GetAverage(); }
+    int8_t GetAverageRss(void) const { return mRssAverager.GetAverage(); }
 
     /**
      * This method aggregates the Link Metrics data of a frame into this series.

--- a/src/core/thread/link_metrics_tlvs.hpp
+++ b/src/core/thread/link_metrics_tlvs.hpp
@@ -41,8 +41,6 @@
 #include "common/message.hpp"
 #include "common/tlvs.hpp"
 
-#include "mac/mac_frame.hpp"
-
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_ENABLE
 
 namespace ot {

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -57,10 +57,6 @@
 
 namespace ot {
 
-#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_ENABLE
-class LinkMetricsSeriesInfo; ///< Forward declaration for including each other with `link_metrics.hpp`
-#endif
-
 /**
  * This class represents a Thread neighbor.
  *


### PR DESCRIPTION
This commit addresses the header file include loop between
the `link_metrics.hpp` and `topology.hpp` by forward declaring
`Neighbor` in `link_metrics` header. It also removes some of the
unnecessary header includes and contains smaller style fixes.