### PR TITLE
[posix] add posix system minimal init

### DIFF
--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -314,9 +314,16 @@ static otInstance *InitInstance(PosixConfig *aConfig)
     syslog(LOG_INFO, "Thread version: %hu", otThreadGetVersion());
     IgnoreError(otLoggingSetLevel(aConfig->mLogLevel));
 
-    instance = otSysInit(&aConfig->mPlatformConfig);
-
     atexit(otSysDeinit);
+
+    if (aConfig->mIsDryRun)
+    {
+        instance = otSysInitMinimal(&aConfig->mPlatformConfig);
+    }
+    else
+    {
+        instance = otSysInit(&aConfig->mPlatformConfig);
+    }
 
     if (aConfig->mPrintRadioVersion)
     {

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -93,6 +93,20 @@ typedef struct otPlatformConfig
 otInstance *otSysInit(otPlatformConfig *aPlatformConfig);
 
 /**
+ * This function performs minimal initialization of OpenThread's drivers for dry-running of the daemon process.
+ *
+ * In some cases, the daemon process is used in a `dry-run` way. For example, it's used to print the Radio firmware
+ * version and will exit after that. In these cases, the system doesn't need a full initialization. In addition, any
+ * other failure when initializing the system will break the dry-run.
+ *
+ * @param[in]  aPlatformConfig  Platform configuration structure.
+ *
+ * @returns A pointer to the OpenThread instance.
+ *
+ */
+otInstance *otSysInitMinimal(otPlatformConfig *aPlatformConfig);
+
+/**
  * This function performs all platform-specific deinitialization for OpenThread's drivers.
  *
  * @note This function is not called by the OpenThread library. Instead, the system/RTOS should call this function

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -133,6 +133,19 @@ otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
     return instance;
 }
 
+otInstance *otSysInitMinimal(otPlatformConfig *aPlatformConfig)
+{
+    otInstance *        instance = nullptr;
+    ot::Posix::RadioUrl radioUrl(aPlatformConfig->mRadioUrl);
+
+    VerifyOrDie(radioUrl.GetPath() != nullptr, OT_EXIT_INVALID_ARGUMENTS);
+    platformRadioInit(&radioUrl);
+
+    instance = otInstanceInitSingle();
+
+    return instance;
+}
+
 void otSysDeinit(void)
 {
 #if OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE


### PR DESCRIPTION
This PR solves #6344.

This PR adds a method `otSysInitMinimal` for initialization when `dry-run` option is passed. When doing dry-run, many components are not necessary to initialize. This also avoids dry-run action (like print radio version) from being broken by failure in initialization of other unrelated components.