### PR TITLE
[ip6-address] add `SetFromTranslatedIp4Address()` for NAT64

### DIFF
--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -45,6 +45,7 @@
 #include "common/equatable.hpp"
 #include "common/string.hpp"
 #include "mac/mac_types.hpp"
+#include "net/ip4_address.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 
@@ -879,6 +880,19 @@ public:
      *
      */
     bool MatchesFilter(TypeFilter aFilter) const;
+
+    /**
+     * This method sets the IPv6 address by performing NAT64 address translation from a given IPv4 address as specified
+     * in RFC 6052.
+     *
+     * The NAT64 @p aPrefix MUST have one of the following lengths: 32, 40, 48, 56, 64, or 96, otherwise the behavior
+     * of this method is undefined.
+     *
+     * @param[in] aPrefix      The prefix to use for IPv4/IPv6 translation.
+     * @param[in] aIp4Address  The IPv4 address to translate to IPv6.
+     *
+     */
+    void SetFromTranslatedIp4Address(const Prefix &aPrefix, const Ip4::Address &aIp4Address);
 
     /**
      * This method converts an IPv6 address string to binary.


### PR DESCRIPTION
This commit adds `Ip6::Address::SetFromTranslatedIp4Address()` method
performing NAT64 address translation from an IPv4 address and a NAT64
prefix to construct a corresponding IPv6 address as specified in RFC
6052. This commit also updates the unit test `test_ip6_address.cpp` to
cover the behavior of the newly added method.
