### PR TITLE
[dns-client] simplify `SendQuery()` and add comment

### DIFF
--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -564,7 +564,7 @@ Error Client::StartQuery(QueryInfo &        aInfo,
     SuccessOrExit(error = AllocateQuery(aInfo, aLabel, aName, query));
     mQueries.Enqueue(*query);
 
-    SendQuery(*query);
+    SendQuery(*query, aInfo, /* aUpdateTimer */ true);
 
 exit:
     return error;
@@ -595,15 +595,6 @@ void Client::FreeQuery(Query &aQuery)
 {
     mQueries.Dequeue(aQuery);
     aQuery.Free();
-}
-
-void Client::SendQuery(Query &aQuery)
-{
-    QueryInfo info;
-
-    info.ReadFrom(aQuery);
-
-    SendQuery(aQuery, info, /* aUpdateTimer */ true);
 }
 
 void Client::SendQuery(Query &aQuery, QueryInfo &aInfo, bool aUpdateTimer)
@@ -787,6 +778,11 @@ void Client::ProcessResponse(const Message &aMessage)
     Error     responseError;
 
     response.mMessage = &aMessage;
+
+    // We intentionally parse the response in a separate method
+    // `ParseResponse()` to free all the stack allocated variables
+    // (e.g., `QueryInfo`) used during parsing of the message before
+    // finalizing the query and invoking the user's callback.
 
     SuccessOrExit(ParseResponse(response, type, responseError));
     FinalizeQuery(response, type, responseError);

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -655,7 +655,6 @@ private:
     Error       AllocateQuery(const QueryInfo &aInfo, const char *aLabel, const char *aName, Query *&aQuery);
     void        FreeQuery(Query &aQuery);
     void        UpdateQuery(Query &aQuery, const QueryInfo &aInfo) { aQuery.Write(0, aInfo); }
-    void        SendQuery(Query &aQuery);
     void        SendQuery(Query &aQuery, QueryInfo &aInfo, bool aUpdateTimer);
     void        FinalizeQuery(Query &aQuery, Error aError);
     void        FinalizeQuery(Response &Response, QueryType aType, Error aError);


### PR DESCRIPTION
This commit contains two small changes in `Dns::Client`: simplifying
the `SendQuery()` call and adding a comment about reason for parsing
the response in a separate method.