### PR TITLE
[message] add method to append bytes read from another/same message

### DIFF
--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -388,6 +388,28 @@ exit:
     return error;
 }
 
+Error Message::AppendBytesFromMessage(const Message &aMessage, uint16_t aOffset, uint16_t aLength)
+{
+    Error    error       = kErrorNone;
+    uint16_t writeOffset = GetLength();
+    Chunk    chunk;
+
+    VerifyOrExit(aMessage.GetLength() >= aOffset + aLength, error = kErrorParse);
+    SuccessOrExit(error = SetLength(GetLength() + aLength));
+
+    aMessage.GetFirstChunk(aOffset, aLength, chunk);
+
+    while (chunk.GetLength() > 0)
+    {
+        WriteBytes(writeOffset, chunk.GetData(), chunk.GetLength());
+        writeOffset += chunk.GetLength();
+        aMessage.GetNextChunk(aLength, chunk);
+    }
+
+exit:
+    return error;
+}
+
 Error Message::PrependBytes(const void *aBuf, uint16_t aLength)
 {
     Error   error     = kErrorNone;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -659,6 +659,22 @@ public:
     Error AppendBytes(const void *aBuf, uint16_t aLength);
 
     /**
+     * This method appends bytes read from another or potentially the same message to the end of the current message.
+     *
+     * On success, this method grows the message by @p aLength bytes.
+     *
+     * @param[in] aMessage   The message to read the bytes from (it can be the same as the current message).
+     * @param[in] aOffset    The offset in @p aMessage to start reading the bytes from.
+     * @param[in] aLength    The number of bytes to read from @p aMessage and append.
+     *
+     * @retval kErrorNone    Successfully appended the bytes.
+     * @retval kErrorNoBufs  Insufficient available buffers to grow the message.
+     * @retval kErrorParse   Not enough bytes in @p aMessage to read @p aLength bytes from @p aOffset.
+     *
+     */
+    Error AppendBytesFromMessage(const Message &aMessage, uint16_t aOffset, uint16_t aLength);
+
+    /**
      * This method appends an object to the end of the message.
      *
      * On success, this method grows the message by the size of the appended object


### PR DESCRIPTION
This commit adds `Message::AppendBytesFromMessage()` which appends
bytes to a message read from another or potentially the same message
at a given offset. The bytes are read and copied directly (chunk by
chunk) without requiring an intermediate buffer. This commit also
updates `test_message` unit test to cover the behavior of the newly
added method (for both cases where the source and the destination
messages are the same or different).

------

Background: I think this method will be helpful in general. The immediate use for this
is to append encoded DNS names in a message e.g., from one message to another
or within the same message (will add this in a follow-up PR).