### PR TITLE
[ping-sender] let ping return statistics in OTCI

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (94)
+#define OPENTHREAD_API_VERSION (95)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ping_sender.h
+++ b/include/openthread/ping_sender.h
@@ -115,10 +115,10 @@ typedef struct otPingSenderConfig
     uint16_t mSize;               ///< Data size (# of bytes) excludes IPv6/ICMPv6 header. Zero for default.
     uint16_t mCount;              ///< Number of ping messages to send. Zero to use default.
     uint32_t mInterval;           ///< Ping tx interval in milliseconds. Zero to use default.
-    uint16_t mTimeout; ///< Time in milliseconds to wait for final reply after sending final request.
-                       ///< Zero to use default.
-    uint8_t mHopLimit; ///< Hop limit (used if `mAllowZeroHopLimit` is false). Zero for default.
-    bool    mAllowZeroHopLimit; ///< Indicates whether hop limit is zero.
+    uint16_t mTimeout;            ///< Time in milliseconds to wait for final reply after sending final request.
+                                  ///< Zero to use default.
+    uint8_t mHopLimit;            ///< Hop limit (used if `mAllowZeroHopLimit` is false). Zero for default.
+    bool    mAllowZeroHopLimit;   ///< Indicates whether hop limit is zero.
 } otPingSenderConfig;
 
 /**

--- a/include/openthread/ping_sender.h
+++ b/include/openthread/ping_sender.h
@@ -115,10 +115,10 @@ typedef struct otPingSenderConfig
     uint16_t mSize;               ///< Data size (# of bytes) excludes IPv6/ICMPv6 header. Zero for default.
     uint16_t mCount;              ///< Number of ping messages to send. Zero to use default.
     uint32_t mInterval;           ///< Ping tx interval in milliseconds. Zero to use default.
-    uint16_t mTimeout;            ///< Time in milliseconds to wait for a reply after sending out the request.
-                                  ///< Zero to use default.
-    uint8_t mHopLimit;            ///< Hop limit (used if `mAllowZeroHopLimit` is false). Zero for default.
-    bool    mAllowZeroHopLimit;   ///< Indicates whether hop limit is zero.
+    uint16_t mTimeout; ///< Time in milliseconds to wait for the final echo reply after sending out the request. Zero to
+                       ///< use default.
+    uint8_t mHopLimit; ///< Hop limit (used if `mAllowZeroHopLimit` is false). Zero for default.
+    bool    mAllowZeroHopLimit; ///< Indicates whether hop limit is zero.
 } otPingSenderConfig;
 
 /**

--- a/include/openthread/ping_sender.h
+++ b/include/openthread/ping_sender.h
@@ -115,8 +115,8 @@ typedef struct otPingSenderConfig
     uint16_t mSize;               ///< Data size (# of bytes) excludes IPv6/ICMPv6 header. Zero for default.
     uint16_t mCount;              ///< Number of ping messages to send. Zero to use default.
     uint32_t mInterval;           ///< Ping tx interval in milliseconds. Zero to use default.
-    uint16_t mTimeout; ///< Time in milliseconds to wait for the final echo reply after sending out the request. Zero to
-                       ///< use default.
+    uint16_t mTimeout; ///< Time in milliseconds to wait for final reply after sending final request.
+                       ///< Zero to use default.
     uint8_t mHopLimit; ///< Hop limit (used if `mAllowZeroHopLimit` is false). Zero for default.
     bool    mAllowZeroHopLimit; ///< Indicates whether hop limit is zero.
 } otPingSenderConfig;

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1882,7 +1882,7 @@ Set the preferred Thread Leader Partition ID.
 Done
 ```
 
-### ping \<ipaddr\> [size][count] [interval][hoplimit]
+### ping \<ipaddr\> [size][count] [interval][hoplimit] [timeout]
 
 Send an ICMPv6 Echo Request.
 
@@ -1890,6 +1890,7 @@ Send an ICMPv6 Echo Request.
 - count: The number of ICMPv6 Echo Requests to be sent.
 - interval: The interval between two consecutive ICMPv6 Echo Requests in seconds. The value may have fractional form, for example `0.5`.
 - hoplimit: The hoplimit of ICMPv6 Echo Request to be sent.
+- timeout: Time in seconds to wait for the final ICMPv6 Echo Reply after sending out the request. The value may have fractional form, for example `3.5`.
 
 ```bash
 > ping fdde:ad00:beef:0:558:f56b:d688:799

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1882,7 +1882,7 @@ Set the preferred Thread Leader Partition ID.
 Done
 ```
 
-### ping \<ipaddr\> [size] [count] [interval] [hoplimit] [timeout]
+### ping \<ipaddr\> \[size\] \[count\] \[interval\] \[hoplimit\] \[timeout\]
 
 Send an ICMPv6 Echo Request.
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1882,7 +1882,7 @@ Set the preferred Thread Leader Partition ID.
 Done
 ```
 
-### ping \<ipaddr\> [size][count] [interval][hoplimit] [timeout]
+### ping \<ipaddr\> [size] [count] [interval] [hoplimit] [timeout]
 
 Send an ICMPv6 Echo Request.
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3262,11 +3262,7 @@ otError Interpreter::ProcessPing(uint8_t aArgsLength, char *aArgs[])
     {
         uint32_t timeout;
         SuccessOrExit(error = ParsePingInterval(aArgs[5], timeout));
-        if (timeout > NumericLimits<uint16_t>::Max())
-        {
-            error = OT_ERROR_INVALID_ARGS;
-            ExitNow();
-        }
+        VerifyOrExit(timeout <= NumericLimits<uint16_t>::Max(), error = OT_ERROR_INVALID_ARGS);
         config.mTimeout = static_cast<uint16_t>(timeout);
     }
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3202,7 +3202,8 @@ void Interpreter::HandlePingStatistics(const otPingSenderStatistics *aStatistics
 {
     OutputFormat("%u packets transmitted, %u packets received.", aStatistics->mSentCount, aStatistics->mReceivedCount);
 
-    if ((aStatistics->mSentCount != 0) && !aStatistics->mIsMulticast)
+    if ((aStatistics->mSentCount != 0) && !aStatistics->mIsMulticast &&
+        aStatistics->mReceivedCount <= aStatistics->mSentCount)
     {
         uint32_t packetLossRate =
             1000 * (aStatistics->mSentCount - aStatistics->mReceivedCount) / aStatistics->mSentCount;

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3217,6 +3217,7 @@ void Interpreter::HandlePingStatistics(const otPingSenderStatistics *aStatistics
     }
 
     OutputLine("");
+    OutputResult(OT_ERROR_NONE);
 }
 
 otError Interpreter::ProcessPing(uint8_t aArgsLength, char *aArgs[])
@@ -3257,7 +3258,19 @@ otError Interpreter::ProcessPing(uint8_t aArgsLength, char *aArgs[])
         config.mAllowZeroHopLimit = (config.mHopLimit == 0);
     }
 
-    VerifyOrExit(aArgsLength <= 5, error = OT_ERROR_INVALID_ARGS);
+    if (aArgsLength > 5)
+    {
+        uint32_t timeout;
+        SuccessOrExit(error = ParsePingInterval(aArgs[5], timeout));
+        if (timeout > NumericLimits<uint16_t>::Max())
+        {
+            error = OT_ERROR_INVALID_ARGS;
+            ExitNow();
+        }
+        config.mTimeout = static_cast<uint16_t>(timeout);
+    }
+
+    VerifyOrExit(aArgsLength <= 6, error = OT_ERROR_INVALID_ARGS);
 
     config.mReplyCallback      = Interpreter::HandlePingReply;
     config.mStatisticsCallback = Interpreter::HandlePingStatistics;

--- a/src/core/utils/ping_sender.cpp
+++ b/src/core/utils/ping_sender.cpp
@@ -199,7 +199,7 @@ void PingSender::HandleIcmpReceive(const Message &          aMessage,
 {
     Reply    reply;
     uint32_t timestamp;
-    bool timerWasRunning;
+    bool     timerWasRunning;
 
     VerifyOrExit(aIcmpHeader.GetType() == Ip6::Icmp::Header::kTypeEchoReply);
     VerifyOrExit(aIcmpHeader.GetId() == mIdentifier);

--- a/src/core/utils/ping_sender.cpp
+++ b/src/core/utils/ping_sender.cpp
@@ -97,7 +97,7 @@ PingSender::PingSender(Instance &aInstance)
 
 Error PingSender::Ping(const Config &aConfig)
 {
-    Error error = kErrorNone;
+    Error error = kErrorPending;
 
     VerifyOrExit(!mTimer.IsRunning(), error = kErrorBusy);
 
@@ -108,6 +108,10 @@ Error PingSender::Ping(const Config &aConfig)
 
     mStatistics.Clear();
     mStatistics.mIsMulticast = static_cast<Ip6::Address *>(&mConfig.mDestination)->IsMulticast();
+    if (mStatistics.mIsMulticast)
+    {
+        error = kErrorNone;
+    }
 
     mIdentifier++;
     SendPing();

--- a/src/core/utils/ping_sender.cpp
+++ b/src/core/utils/ping_sender.cpp
@@ -199,6 +199,7 @@ void PingSender::HandleIcmpReceive(const Message &          aMessage,
 {
     Reply    reply;
     uint32_t timestamp;
+    bool timerWasRunning;
 
     VerifyOrExit(aIcmpHeader.GetType() == Ip6::Icmp::Header::kTypeEchoReply);
     VerifyOrExit(aIcmpHeader.GetId() == mIdentifier);
@@ -221,6 +222,7 @@ void PingSender::HandleIcmpReceive(const Message &          aMessage,
 #if OPENTHREAD_CONFIG_OTNS_ENABLE
     Get<Utils::Otns>().EmitPingReply(aMessageInfo.GetPeerAddr(), reply.mSize, timestamp, reply.mHopLimit);
 #endif
+    timerWasRunning = mTimer.IsRunning();
     // Received all ping replies, no need to wait longer.
     if (!mStatistics.mIsMulticast && mConfig.mCount == 0 && aIcmpHeader.GetSequence() == mTargetEchoSequence)
     {
@@ -228,7 +230,8 @@ void PingSender::HandleIcmpReceive(const Message &          aMessage,
     }
     mConfig.InvokeReplyCallback(reply);
     // Received all ping replies, no need to wait longer.
-    if (!mStatistics.mIsMulticast && mConfig.mCount == 0 && aIcmpHeader.GetSequence() == mTargetEchoSequence)
+    if (!mStatistics.mIsMulticast && mConfig.mCount == 0 && aIcmpHeader.GetSequence() == mTargetEchoSequence &&
+        timerWasRunning)
     {
         mConfig.InvokeStatisticsCallback(mStatistics);
     }

--- a/src/core/utils/ping_sender.cpp
+++ b/src/core/utils/ping_sender.cpp
@@ -199,8 +199,8 @@ void PingSender::HandleIcmpReceive(const Message &          aMessage,
 {
     Reply    reply;
     uint32_t timestamp;
-    bool     timerWasRunning;
 
+    VerifyOrExit(mTimer.IsRunning());
     VerifyOrExit(aIcmpHeader.GetType() == Ip6::Icmp::Header::kTypeEchoReply);
     VerifyOrExit(aIcmpHeader.GetId() == mIdentifier);
 
@@ -222,7 +222,6 @@ void PingSender::HandleIcmpReceive(const Message &          aMessage,
 #if OPENTHREAD_CONFIG_OTNS_ENABLE
     Get<Utils::Otns>().EmitPingReply(aMessageInfo.GetPeerAddr(), reply.mSize, timestamp, reply.mHopLimit);
 #endif
-    timerWasRunning = mTimer.IsRunning();
     // Received all ping replies, no need to wait longer.
     if (!mStatistics.mIsMulticast && mConfig.mCount == 0 && aIcmpHeader.GetSequence() == mTargetEchoSequence)
     {
@@ -230,8 +229,7 @@ void PingSender::HandleIcmpReceive(const Message &          aMessage,
     }
     mConfig.InvokeReplyCallback(reply);
     // Received all ping replies, no need to wait longer.
-    if (!mStatistics.mIsMulticast && mConfig.mCount == 0 && aIcmpHeader.GetSequence() == mTargetEchoSequence &&
-        timerWasRunning)
+    if (!mStatistics.mIsMulticast && mConfig.mCount == 0 && aIcmpHeader.GetSequence() == mTargetEchoSequence)
     {
         mConfig.InvokeStatisticsCallback(mStatistics);
     }

--- a/src/core/utils/ping_sender.cpp
+++ b/src/core/utils/ping_sender.cpp
@@ -108,10 +108,6 @@ Error PingSender::Ping(const Config &aConfig)
 
     mStatistics.Clear();
     mStatistics.mIsMulticast = static_cast<Ip6::Address *>(&mConfig.mDestination)->IsMulticast();
-    if (mStatistics.mIsMulticast)
-    {
-        error = kErrorNone;
-    }
 
     mIdentifier++;
     SendPing();
@@ -164,7 +160,7 @@ exit:
     {
         mTimer.Start(mConfig.mInterval);
     }
-    else if (!mStatistics.mIsMulticast)
+    else
     {
         mTimer.Start(mConfig.mTimeout);
     }

--- a/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
+++ b/tests/scripts/thread-cert/Cert_5_6_09_NetworkDataForwarding.py
@@ -120,23 +120,23 @@ class Cert_5_6_9_NetworkDataForwarding(thread_cert.TestCase):
         self.nodes[ROUTER2].register_netdata()
         self.simulator.go(15)
 
-        self.assertFalse(self.nodes[SED].ping('2001:2:0:2::1'))
+        self.assertFalse(self.nodes[SED].ping('2001:2:0:2::1', timeout=10))
 
-        self.assertFalse(self.nodes[SED].ping('2007::1'))
+        self.assertFalse(self.nodes[SED].ping('2007::1', timeout=10))
 
         self.nodes[ROUTER2].remove_prefix('2001:2:0:1::/64')
         self.nodes[ROUTER2].add_prefix('2001:2:0:1::/64', 'paros', 'high')
         self.nodes[ROUTER2].register_netdata()
         self.simulator.go(15)
 
-        self.assertFalse(self.nodes[SED].ping('2007::1'))
+        self.assertFalse(self.nodes[SED].ping('2007::1', timeout=10))
 
         self.nodes[ROUTER2].remove_prefix('2001:2:0:1::/64')
         self.nodes[ROUTER2].add_prefix('2001:2:0:1::/64', 'paros', 'med')
         self.nodes[ROUTER2].register_netdata()
         self.simulator.go(15)
 
-        self.assertFalse(self.nodes[SED].ping('2007::1'))
+        self.assertFalse(self.nodes[SED].ping('2007::1', timeout=10))
 
     def verify(self, pv):
         pkts = pv.pkts

--- a/tests/scripts/thread-cert/Cert_9_2_09_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_09_PendingPartition.py
@@ -208,8 +208,8 @@ class Cert_9_2_09_PendingPartition(thread_cert.TestCase):
 
         leader_addr = self.nodes[LEADER].get_ip6_address(config.ADDRESS_TYPE.ML_EID)
         router1_addr = self.nodes[ROUTER1].get_ip6_address(config.ADDRESS_TYPE.ML_EID)
-        self.assertTrue(self.nodes[ROUTER2].ping(leader_addr))
-        self.assertTrue(self.nodes[COMMISSIONER].ping(router1_addr))
+        self.assertTrue(self.nodes[ROUTER2].ping(leader_addr, timeout=10))
+        self.assertTrue(self.nodes[COMMISSIONER].ping(router1_addr, timeout=10))
 
     def verify(self, pv):
         pkts = pv.pkts

--- a/tools/otci/otci/command_handlers.py
+++ b/tools/otci/otci/command_handlers.py
@@ -76,9 +76,7 @@ class OtCliCommandRunner(OTCommandHandler):
                                     r')')
     """regex used to filter logs"""
 
-    __ASYNC_COMMANDS = {
-        'scan', 'ping'
-    }
+    __ASYNC_COMMANDS = {'scan', 'ping'}
 
     def __init__(self, otcli: OtCliHandler, is_spinel_cli=False):
         self.__otcli: OtCliHandler = otcli

--- a/tools/otci/otci/command_handlers.py
+++ b/tools/otci/otci/command_handlers.py
@@ -77,7 +77,7 @@ class OtCliCommandRunner(OTCommandHandler):
     """regex used to filter logs"""
 
     __ASYNC_COMMANDS = {
-        'scan',
+        'scan', 'ping'
     }
 
     def __init__(self, otcli: OtCliHandler, is_spinel_cli=False):
@@ -94,7 +94,7 @@ class OtCliCommandRunner(OTCommandHandler):
     def __repr__(self):
         return repr(self.__otcli)
 
-    def execute_command(self, cmd, timeout=10) -> None:
+    def execute_command(self, cmd, timeout=10) -> List[str]:
         self.__otcli.writeline(cmd)
 
         if cmd in {'reset', 'factoryreset'}:

--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -175,8 +175,9 @@ class OTCI(object):
     # Network Operations
     #
 
-    def ping(self, ip: str, size: int = 8, count: int = 1, interval: float = 1, hoplimit: int = 64, timeout: float = 3):
-        """Send an ICMPv6 Echo Request. The default arguments are consistent with those in src/core/config/ping_sender.h.
+    def ping(self, ip: str, size: int = 8, count: int = 1, interval: float = 1, hoplimit: int = 64, timeout: float = 3) -> Dict:
+        """Send an ICMPv6 Echo Request. 
+        The default arguments are consistent with https://github.com/openthread/openthread/blob/main/src/core/utils/ping_sender.hpp.
 
         :param ip: The target IPv6 address to ping.
         :param size: The number of data bytes in the payload. Default is 8.

--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -174,9 +174,17 @@ class OTCI(object):
     #
     # Network Operations
     #
-    _PING_STATISTICS_PATTERN = re.compile(r'^(?P<transmitted>\d+) packets transmitted, (?P<received>\d+) packets received.(?: Packet loss = (?P<loss>\d+\.\d+)%.)?(?: Round-trip min/avg/max = (?P<min>\d+)/(?P<avg>\d+\.\d+)/(?P<max>\d+) ms.)?$')
+    _PING_STATISTICS_PATTERN = re.compile(
+        r'^(?P<transmitted>\d+) packets transmitted, (?P<received>\d+) packets received.(?: Packet loss = (?P<loss>\d+\.\d+)%.)?(?: Round-trip min/avg/max = (?P<min>\d+)/(?P<avg>\d+\.\d+)/(?P<max>\d+) ms.)?$'
+    )
 
-    def ping(self, ip: str, size: int = 8, count: int = 1, interval: float = 1, hoplimit: int = 64, timeout: float = 3) -> Dict:
+    def ping(self,
+        ip: str,
+        size: int = 8,
+        count: int = 1,
+        interval: float = 1,
+        hoplimit: int = 64,
+        timeout: float = 3) -> Dict:
         """Send an ICMPv6 Echo Request. 
         The default arguments are consistent with https://github.com/openthread/openthread/blob/main/src/core/utils/ping_sender.hpp.
 

--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -179,12 +179,12 @@ class OTCI(object):
     )
 
     def ping(self,
-        ip: str,
-        size: int = 8,
-        count: int = 1,
-        interval: float = 1,
-        hoplimit: int = 64,
-        timeout: float = 3) -> Dict:
+             ip: str,
+             size: int = 8,
+             count: int = 1,
+             interval: float = 1,
+             hoplimit: int = 64,
+             timeout: float = 3) -> Dict:
         """Send an ICMPv6 Echo Request. 
         The default arguments are consistent with https://github.com/openthread/openthread/blob/main/src/core/utils/ping_sender.hpp.
 

--- a/tools/otci/tests/test_otci.py
+++ b/tools/otci/tests/test_otci.py
@@ -411,9 +411,6 @@ class TestOTCI(unittest.TestCase):
             self.assertAlmostEqual(statistics['packet_loss'], 0.0, delta=1e-9)
             self.assertTrue('round_trip_time' in statistics)
             rtt = statistics['round_trip_time']
-            self.assertTrue('min' in rtt)
-            self.assertTrue('avg' in rtt)
-            self.assertTrue('max' in rtt)
             self.assertTrue(rtt['min'] - 1e-9 <= rtt['avg'] <= rtt['max'] + 1e-9)
             commissioner.wait(1)
 

--- a/tools/otci/tests/test_otci.py
+++ b/tools/otci/tests/test_otci.py
@@ -403,13 +403,9 @@ class TestOTCI(unittest.TestCase):
 
         for dst_ip in leader.get_ipaddrs():
             statistics = commissioner.ping(dst_ip, size=10, count=10, interval=2, hoplimit=3)
-            self.assertTrue('transmitted_packets' in statistics)
             self.assertEqual(statistics['transmitted_packets'], 10)
-            self.assertTrue('received_packets' in statistics)
             self.assertEqual(statistics['received_packets'], 10)
-            self.assertTrue('packet_loss' in statistics)
             self.assertAlmostEqual(statistics['packet_loss'], 0.0, delta=1e-9)
-            self.assertTrue('round_trip_time' in statistics)
             rtt = statistics['round_trip_time']
             self.assertTrue(rtt['min'] - 1e-9 <= rtt['avg'] <= rtt['max'] + 1e-9)
             commissioner.wait(1)

--- a/tools/otci/tests/test_otci.py
+++ b/tools/otci/tests/test_otci.py
@@ -402,7 +402,14 @@ class TestOTCI(unittest.TestCase):
         self.assertEqual('router', commissioner.get_state())
 
         for dst_ip in leader.get_ipaddrs():
-            commissioner.ping(dst_ip, size=10, count=1, interval=2, hoplimit=3)
+            statistics = commissioner.ping(dst_ip, size=10, count=10, interval=2, hoplimit=3)
+            self.assertTrue('transmitted_packets' in statistics)
+            self.assertTrue('received_packets' in statistics)
+            self.assertTrue('packet_loss' in statistics)
+            self.assertTrue('round_trip_time' in statistics)
+            self.assertTrue('min' in statistics['round_trip_time'])
+            self.assertTrue('avg' in statistics['round_trip_time'])
+            self.assertTrue('max' in statistics['round_trip_time'])
             commissioner.wait(1)
 
         self.assertEqual('disabled', commissioner.get_commissioiner_state())

--- a/tools/otci/tests/test_otci.py
+++ b/tools/otci/tests/test_otci.py
@@ -518,6 +518,12 @@ class TestOTCI(unittest.TestCase):
 
         self.assertFalse(leader.is_singleton())
 
+        statistics = commissioner.ping("ff02::1", size=1, count=10, interval=1, hoplimit=255)
+        self.assertEqual(statistics['transmitted_packets'], 10)
+        self.assertEqual(statistics['received_packets'], 20)
+        rtt = statistics['round_trip_time']
+        self.assertTrue(rtt['min'] - 1e-9 <= rtt['avg'] <= rtt['max'] + 1e-9)
+
         # Shutdown
         leader.thread_stop()
         logging.info("node state: %s", leader.get_state())

--- a/tools/otci/tests/test_otci.py
+++ b/tools/otci/tests/test_otci.py
@@ -404,12 +404,17 @@ class TestOTCI(unittest.TestCase):
         for dst_ip in leader.get_ipaddrs():
             statistics = commissioner.ping(dst_ip, size=10, count=10, interval=2, hoplimit=3)
             self.assertTrue('transmitted_packets' in statistics)
+            self.assertEqual(statistics['transmitted_packets'], 10)
             self.assertTrue('received_packets' in statistics)
+            self.assertEqual(statistics['received_packets'], 10)
             self.assertTrue('packet_loss' in statistics)
+            self.assertAlmostEqual(statistics['packet_loss'], 0.0, delta=1e-9)
             self.assertTrue('round_trip_time' in statistics)
-            self.assertTrue('min' in statistics['round_trip_time'])
-            self.assertTrue('avg' in statistics['round_trip_time'])
-            self.assertTrue('max' in statistics['round_trip_time'])
+            rtt = statistics['round_trip_time']
+            self.assertTrue('min' in rtt)
+            self.assertTrue('avg' in rtt)
+            self.assertTrue('max' in rtt)
+            self.assertTrue(rtt['min'] - 1e-9 <= rtt['avg'] <= rtt['max'] + 1e-9)
             commissioner.wait(1)
 
         self.assertEqual('disabled', commissioner.get_commissioiner_state())


### PR DESCRIPTION
Ping enhancements
- If it's not multicast, `ping` command in CLI will print `Done` in the end, after printing replies and statistics. The old behavior is, `ping` command prints `Done` before any replies.
- In OTCI, let `ping` function return statistics.
- Support timeout parameter in `ping` command.
- Fix a bug that the arguments are not properly passed to `ping` in `node.py`.
- Adjust timeouts in tests.