### PR TITLE
[ip6] improve frame filtering

### DIFF
--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -290,6 +290,18 @@ void otUdpForwardReceive(otInstance *        aInstance,
                          uint16_t            aSockPort);
 
 /**
+ * Determines if the given UDP port is used by OpenThread, or belongs entirely to the platform
+ *
+ * @param[in]  aInstance            A pointer to an OpenThread instance.
+ * @param[in]  port                 UDP port number to verify.
+ *
+ * @retval true    The port is being used by OpenThread
+ * @retval false   The port is not used by OpenThread i.e.it belongs to the platform or is incorrect.
+ *
+ */
+bool otUdpIsPortInUse(otInstance *aInstance, uint16_t port);
+
+/**
  * @}
  *
  */

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -147,3 +147,10 @@ otError otUdpSendDatagram(otInstance *aInstance, otMessage *aMessage, otMessageI
     return instance.Get<Ip6::Udp>().SendDatagram(*static_cast<ot::Message *>(aMessage),
                                                  *static_cast<Ip6::MessageInfo *>(aMessageInfo), Ip6::kProtoUdp);
 }
+
+bool otUdpIsPortInUse(otInstance *aInstance, uint16_t port)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<Ip6::Udp>().IsPortInUse(port);
+}

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1035,7 +1035,7 @@ Error Ip6::ProcessReceiveCallback(Message &          aMessage,
             Udp::Header udp;
 
             IgnoreError(aMessage.Read(aMessage.GetOffset(), udp));
-            VerifyOrExit(Get<Udp>().ShouldUsePlatformUdp(udp.GetDestinationPort()), error = kErrorNoRoute);
+            VerifyOrExit(Get<Udp>().IsPortInUse(udp.GetDestinationPort()) == false, error = OT_ERROR_NO_ROUTE);
 
             break;
         }

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -524,6 +524,18 @@ exit:
     return;
 }
 
+bool Udp::IsPortInUse(uint16_t aPort) const
+{
+    for (const SocketHandle * socket = mSockets.GetHead(); socket != nullptr; socket=socket->GetNext())
+    {
+        if(socket->GetSockName().GetPort() == aPort)
+        {
+            return true;
+        }
+    }
+    return false;
+}
+
 bool Udp::ShouldUsePlatformUdp(uint16_t aPort) const
 {
     return (aPort != Mle::kUdpPort && aPort != Tmf::kUdpPort

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -574,6 +574,18 @@ public:
 #endif
 
     /**
+     * This method returns whether a udp port is being used by OpenThread or any of it's optional
+     * features, e.g. CoAP API.
+     *
+     * @param[in]   aPort       The udp port
+     *
+     * @retval True when port is used by the OpenThread
+     * @retval False when the port is not used by OpenThrad.
+     *
+     */
+    bool IsPortInUse(uint16_t aPort) const;
+
+    /**
      * This method returns whether a udp port belongs to the platform or the stack.
      *
      * @param[in]   aPort       The udp port


### PR DESCRIPTION
Some packets used by openthread internally were passed outside with
filters on. This fixes the issue with coap frames being passed
outside when OpenThread CoAP API is used.
Fixes "ICMPv6 Destination Unreachable (Port unreachable)" in zephyr.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>