### PR TITLE
[ot-ctl] fix wrong exit in interactive mode 

### DIFF
--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -163,9 +163,12 @@ exit:
 
 int main(int argc, char *argv[])
 {
-    int  ret;
-    bool isInteractive = true;
-    bool isFinished    = false;
+    int    ret;
+    bool   isInteractive = true;
+    bool   isFinished    = false;
+    char   lineBuffer[kLineBufferSize];
+    size_t lineBufferWritePos = 0;
+    bool   isBeginOfLine      = true;
 
     VerifyOrExit(ConnectSession() != -1, perror("connect session failed"); ret = OT_EXIT_FAILURE);
 
@@ -202,11 +205,8 @@ int main(int argc, char *argv[])
     while (!isFinished)
     {
         fd_set readFdSet;
-        char   lineBuffer[kLineBufferSize];
         char   buffer[kLineBufferSize];
-        size_t lineBufferWritePos = 0;
-        bool   isBeginOfLine      = true;
-        int    maxFd              = sSessionFd;
+        int    maxFd = sSessionFd;
 
         FD_ZERO(&readFdSet);
 


### PR DESCRIPTION
This commit fixes ot-ctl exiting in interactive mode, which was introduced by #6333, which changed the scope of variables wrongly. 