### PR TITLE
[tests] fix wrong usage of ping timeouts

### DIFF
--- a/tests/scripts/thread-cert/v1_2_LowPower_7_1_01_SingleProbeLinkMetricsWithEnhancedAcks.py
+++ b/tests/scripts/thread-cert/v1_2_LowPower_7_1_01_SingleProbeLinkMetricsWithEnhancedAcks.py
@@ -85,7 +85,7 @@ class LowPower_7_1_01(thread_cert.TestCase):
         leader_addr = self.nodes[LEADER].get_ip6_address(ADDRESS_TYPE.LINK_LOCAL)
 
         # Step 3 - Verify connectivity by instructing each device to sending an ICMPv6 Echo Request to the DUT
-        self.assertTrue(self.nodes[SED_1].ping(leader_addr, timeout=POLL_PERIOD))
+        self.assertTrue(self.nodes[SED_1].ping(leader_addr, timeout=POLL_PERIOD / 1000))
         self.assertTrue(self.nodes[SSED_1].ping(leader_addr))
         self.simulator.go(5)
 

--- a/tests/scripts/thread-cert/v1_2_LowPower_7_2_01_ForwardTrackingSeries.py
+++ b/tests/scripts/thread-cert/v1_2_LowPower_7_2_01_ForwardTrackingSeries.py
@@ -90,8 +90,8 @@ class LowPower_7_2_01_ForwardTrackingSeries(thread_cert.TestCase):
         leader_addr = self.nodes[LEADER].get_ip6_address(ADDRESS_TYPE.LINK_LOCAL)
 
         # Step 3 - Verify connectivity by instructing each device to send an ICMPv6 Echo Request to the DUT
-        self.assertTrue(self.nodes[SED_1].ping(leader_addr, timeout=POLL_PERIOD))
-        self.assertTrue(self.nodes[SSED_1].ping(leader_addr, timeout=2 * consts.CSL_DEFAULT_PERIOD))
+        self.assertTrue(self.nodes[SED_1].ping(leader_addr, timeout=POLL_PERIOD / 1000))
+        self.assertTrue(self.nodes[SSED_1].ping(leader_addr, timeout=2 * consts.CSL_DEFAULT_PERIOD_IN_SECOND))
         self.simulator.go(5)
 
         # Step 4 - SED_1 requests a Forward Tracking Series by sending a Link Metrics Management Request


### PR DESCRIPTION
In `tests/scripts/thread-cert/node.py`, the timeout parameter of `ping()` function is in seconds. However, in some test cases they called `ping()` with a timeout in milliseconds.

I used the following command to list `ping()` usages with a specified timeout:
```
grep -rn "ping.*timeout=" tests/scripts/thread-cert/*
```