### PR TITLE
[scripts] make BMLR test more reliable

### DIFF
--- a/tests/scripts/thread-cert/backbone/test_bmlr.py
+++ b/tests/scripts/thread-cert/backbone/test_bmlr.py
@@ -109,6 +109,8 @@ class BBR_5_11_01(thread_cert.TestCase):
         self.nodes[COMMISSIONER].start()
         self.wait_node_state(COMMISSIONER, 'router', 5)
 
+        self.wait_route_established(COMMISSIONER, PBBR)
+
         self.nodes[COMMISSIONER].commissioner_start()
         self.simulator.go(10)
         self.assertEqual('active', self.nodes[COMMISSIONER].commissioner_state())

--- a/tests/scripts/thread-cert/thread_cert.py
+++ b/tests/scripts/thread-cert/thread_cert.py
@@ -502,3 +502,17 @@ class TestCase(NcpSupportMixin, unittest.TestCase):
 
     def wait_node_state(self, nodeid: int, state: str, timeout: int):
         self.wait_until(lambda: self.nodes[nodeid].get_state() == state, timeout)
+
+    def wait_route_established(self, node1: int, node2: int, timeout=10):
+        node2_addr = self.nodes[node2].get_ip6_address(config.ADDRESS_TYPE.RLOC)
+
+        while timeout > 0:
+
+            if self.nodes[node1].ping(node2_addr):
+                break
+
+            self.simulator.go(1)
+            timeout -= 1
+
+        else:
+            raise Exception("Route between node %d and %d is not established" % (node1, node2))


### PR DESCRIPTION
Fixes #6299

In BMLR test, the commissioner may fail to start because the `/c/ps` COAP message failed to reach Leader due to unstable links. 
This commit makes sure the links are established before starting the commissioner. 