### PR TITLE
[data-poll-sender] use OT_MIN and replace enum with constexpr

### DIFF
--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -200,7 +200,7 @@ uint32_t DataPollSender::GetKeepAlivePollPeriod(void) const
 
     if (mExternalPollPeriod != 0)
     {
-        UpdateIfLarger(period, mExternalPollPeriod);
+        period = OT_MIN(period, mExternalPollPeriod);
     }
 
     return period;
@@ -457,36 +457,28 @@ void DataPollSender::ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector)
     }
 }
 
-void DataPollSender::UpdateIfLarger(uint32_t &aPeriod, uint32_t aNewPeriod)
-{
-    if (aPeriod > aNewPeriod)
-    {
-        aPeriod = aNewPeriod;
-    }
-}
-
 uint32_t DataPollSender::CalculatePollPeriod(void) const
 {
     uint32_t period = GetDefaultPollPeriod();
 
     if (mAttachMode)
     {
-        UpdateIfLarger(period, kAttachDataPollPeriod);
+        period = OT_MIN(period, kAttachDataPollPeriod);
     }
 
     if (mRetxMode)
     {
-        UpdateIfLarger(period, kRetxPollPeriod);
+        period = OT_MIN(period, kRetxPollPeriod);
     }
 
     if (mRemainingFastPolls != 0)
     {
-        UpdateIfLarger(period, kFastPollPeriod);
+        period = OT_MIN(period, kFastPollPeriod);
     }
 
     if (mExternalPollPeriod != 0)
     {
-        UpdateIfLarger(period, mExternalPollPeriod);
+        period = OT_MIN(period, mExternalPollPeriod);
     }
 
     if (period == 0)

--- a/src/core/mac/data_poll_sender.hpp
+++ b/src/core/mac/data_poll_sender.hpp
@@ -262,16 +262,6 @@ public:
     uint32_t GetDefaultPollPeriod(void) const;
 
 private:
-    enum // Poll period under different conditions (in milliseconds).
-    {
-        kAttachDataPollPeriod = OPENTHREAD_CONFIG_MAC_ATTACH_DATA_POLL_PERIOD, ///< Poll period during attach.
-        kRetxPollPeriod       = OPENTHREAD_CONFIG_MAC_RETX_POLL_PERIOD,        ///< Poll retx period due to tx failure.
-        kFastPollPeriod       = 188,                                           ///< Period used for fast polls.
-        kMinPollPeriod        = OPENTHREAD_CONFIG_MAC_MINIMUM_POLL_PERIOD,     ///< Minimum allowed poll period.
-        kMaxExternalPeriod    = ((1 << 26) - 1), ///< Maximum allowed user-specified period.
-                                                 ///< i.e. (0x3FFFFF)ms, about 18.64 hours.
-    };
-
     enum
     {
         kQuickPollsAfterTimeout = 5, ///< Maximum number of quick data poll tx in case of back-to-back poll timeouts.
@@ -285,11 +275,17 @@ private:
         kRecalculatePollPeriod,
     };
 
+    // Poll period under different conditions (in milliseconds).
+    static constexpr uint32_t kAttachDataPollPeriod = OPENTHREAD_CONFIG_MAC_ATTACH_DATA_POLL_PERIOD;
+    static constexpr uint32_t kRetxPollPeriod       = OPENTHREAD_CONFIG_MAC_RETX_POLL_PERIOD;
+    static constexpr uint32_t kFastPollPeriod       = 188;
+    static constexpr uint32_t kMinPollPeriod        = OPENTHREAD_CONFIG_MAC_MINIMUM_POLL_PERIOD;
+    static constexpr uint32_t kMaxExternalPeriod    = ((1 << 26) - 1); //< ~18.6 hours.
+
     void            ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector);
     uint32_t        CalculatePollPeriod(void) const;
     const Neighbor &GetParent(void) const;
     static void     HandlePollTimer(Timer &aTimer);
-    static void     UpdateIfLarger(uint32_t &aPeriod, uint32_t aNewPeriod);
 
     TimeMilli mTimerStartTime;
     uint32_t  mPollPeriod;


### PR DESCRIPTION
This PR replaces some enum definition with constexpr since these enum
are used for comparing. The compiler would always give warnings when 
comparing enum with other non-enumeral values. With this change, we 
can directly compare the consts with other values. And this PR replaces
`UpdateIfLarger` with `OT_MIN`.