### PR TITLE
[style] harmonize feature check and header includes

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (93)
+#define OPENTHREAD_API_VERSION (94)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/udp.h
+++ b/include/openthread/platform/udp.h
@@ -35,6 +35,8 @@
 #ifndef OPENTHREAD_PLATFORM_UDP_H_
 #define OPENTHREAD_PLATFORM_UDP_H_
 
+#include <openthread/udp.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/src/core/api/backbone_router_api.cpp
+++ b/src/core/api/backbone_router_api.cpp
@@ -34,6 +34,7 @@
 #include "openthread-core-config.h"
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+
 #include <openthread/backbone_router.h>
 #include "common/instance.hpp"
 

--- a/src/core/api/backbone_router_ftd_api.cpp
+++ b/src/core/api/backbone_router_ftd_api.cpp
@@ -34,9 +34,10 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+
 #include <openthread/backbone_router_ftd.h>
 
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
 #include "common/instance.hpp"
 
 using namespace ot;

--- a/src/core/api/border_agent_api.cpp
+++ b/src/core/api/border_agent_api.cpp
@@ -33,12 +33,12 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
+
 #include <openthread/border_agent.h>
 
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
-
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
 
 using namespace ot;
 

--- a/src/core/api/channel_manager_api.cpp
+++ b/src/core/api/channel_manager_api.cpp
@@ -32,6 +32,9 @@
  */
 
 #include "openthread-core-config.h"
+
+#if OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
+
 #include <openthread/channel_manager.h>
 
 #include "common/instance.hpp"
@@ -39,8 +42,6 @@
 #include "utils/channel_manager.hpp"
 
 using namespace ot;
-
-#if OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
 
 void otChannelManagerRequestChannelChange(otInstance *aInstance, uint8_t aChannel)
 {

--- a/src/core/api/channel_monitor_api.cpp
+++ b/src/core/api/channel_monitor_api.cpp
@@ -32,14 +32,15 @@
  */
 
 #include "openthread-core-config.h"
+
+#if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
+
 #include <openthread/channel_monitor.h>
 
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 
 using namespace ot;
-
-#if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
 
 otError otChannelMonitorSetEnabled(otInstance *aInstance, bool aEnabled)
 {

--- a/src/core/api/child_supervision_api.cpp
+++ b/src/core/api/child_supervision_api.cpp
@@ -32,14 +32,15 @@
  */
 
 #include "openthread-core-config.h"
+
+#if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
+
 #include <openthread/child_supervision.h>
 
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 
 using namespace ot;
-
-#if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
 
 uint16_t otChildSupervisionGetInterval(otInstance *aInstance)
 {

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -33,13 +33,13 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_COAP_API_ENABLE
+
 #include <openthread/coap.h>
 
 #include "coap/coap_message.hpp"
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
-
-#if OPENTHREAD_CONFIG_COAP_API_ENABLE
 
 using namespace ot;
 

--- a/src/core/api/coap_secure_api.cpp
+++ b/src/core/api/coap_secure_api.cpp
@@ -33,6 +33,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
+
 #include <openthread/coap_secure.h>
 #include <openthread/ip6.h>
 
@@ -40,8 +42,6 @@
 #include "coap/coap_secure.hpp"
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
-
-#if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
 
 using namespace ot;
 

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -33,6 +33,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
+
 #include <openthread/commissioner.h>
 
 #include "common/instance.hpp"
@@ -40,7 +42,6 @@
 
 using namespace ot;
 
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
 otError otCommissionerStart(otInstance *                 aInstance,
                             otCommissionerStateCallback  aStateCallback,
                             otCommissionerJoinerCallback aJoinerCallback,

--- a/src/core/api/crypto_api.cpp
+++ b/src/core/api/crypto_api.cpp
@@ -32,6 +32,7 @@
  */
 
 #include "openthread-core-config.h"
+
 #include <openthread/crypto.h>
 #include <openthread/error.h>
 

--- a/src/core/api/dataset_updater_api.cpp
+++ b/src/core/api/dataset_updater_api.cpp
@@ -33,6 +33,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE && OPENTHREAD_FTD
+
 #include <openthread/dataset_updater.h>
 
 #include "common/instance.hpp"
@@ -40,8 +42,6 @@
 #include "meshcop/dataset_updater.hpp"
 
 using namespace ot;
-
-#if OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE && OPENTHREAD_FTD
 
 otError otDatasetUpdaterRequestUpdate(otInstance *                aInstance,
                                       const otOperationalDataset *aDataset,

--- a/src/core/api/diags_api.cpp
+++ b/src/core/api/diags_api.cpp
@@ -33,14 +33,14 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+
 #include <openthread/diag.h>
 
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 
 using namespace ot;
-
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
 
 void otDiagProcessCmdLine(otInstance *aInstance, const char *aString, char *aOutput, size_t aOutputMaxLen)
 {

--- a/src/core/api/jam_detection_api.cpp
+++ b/src/core/api/jam_detection_api.cpp
@@ -33,14 +33,14 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
+
 #include <openthread/jam_detection.h>
 
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 
 using namespace ot;
-
-#if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
 
 otError otJamDetectionSetRssiThreshold(otInstance *aInstance, int8_t aRssiThreshold)
 {

--- a/src/core/api/joiner_api.cpp
+++ b/src/core/api/joiner_api.cpp
@@ -33,6 +33,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_JOINER_ENABLE
+
 #include <openthread/joiner.h>
 
 #include "common/instance.hpp"
@@ -40,7 +42,6 @@
 
 using namespace ot;
 
-#if OPENTHREAD_CONFIG_JOINER_ENABLE
 otError otJoinerStart(otInstance *     aInstance,
                       const char *     aPskd,
                       const char *     aProvisioningUrl,

--- a/src/core/api/link_metrics_api.cpp
+++ b/src/core/api/link_metrics_api.cpp
@@ -33,14 +33,14 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_ENABLE
+
 #include <openthread/link_metrics.h>
 
 #include "common/instance.hpp"
 #include "net/ip6_address.hpp"
 
 using namespace ot;
-
-#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_ENABLE
 
 otError otLinkMetricsQuery(otInstance *                aInstance,
                            const otIp6Address *        aDestination,

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -33,6 +33,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
+
 #include <string.h>
 #include <openthread/diag.h>
 #include <openthread/thread.h>
@@ -44,8 +46,6 @@
 #include "common/locator-getters.hpp"
 #include "common/random.hpp"
 #include "mac/mac_frame.hpp"
-
-#if OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
 
 using namespace ot;
 

--- a/src/core/api/multi_radio_api.cpp
+++ b/src/core/api/multi_radio_api.cpp
@@ -33,6 +33,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+
 #include <openthread/multi_radio.h>
 
 #include "common/code_utils.hpp"
@@ -42,8 +44,6 @@
 #include "thread/radio_selector.hpp"
 
 using namespace ot;
-
-#if OPENTHREAD_CONFIG_MULTI_RADIO
 
 otError otMultiRadioGetNeighborInfo(otInstance *              aInstance,
                                     const otExtAddress *      aExtAddress,

--- a/src/core/api/netdiag_api.cpp
+++ b/src/core/api/netdiag_api.cpp
@@ -33,13 +33,13 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
+
 #include <openthread/netdiag.h>
 
 #include "common/instance.hpp"
 
 using namespace ot;
-
-#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
 
 otError otThreadGetNextDiagnosticTlv(const otMessage *      aMessage,
                                      otNetworkDiagIterator *aIterator,

--- a/src/core/api/sntp_api.cpp
+++ b/src/core/api/sntp_api.cpp
@@ -33,6 +33,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
+
 #include <openthread/sntp.h>
 
 #include "common/instance.hpp"
@@ -40,7 +42,6 @@
 
 using namespace ot;
 
-#if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
 otError otSntpClientQuery(otInstance *          aInstance,
                           const otSntpQuery *   aQuery,
                           otSntpResponseHandler aHandler,
@@ -57,4 +58,5 @@ void otSntpClientSetUnixEra(otInstance *aInstance, uint32_t aUnixEra)
 
     return instance.Get<Sntp::Client>().SetUnixEra(aUnixEra);
 }
-#endif
+
+#endif // OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE

--- a/src/core/api/srp_client_api.cpp
+++ b/src/core/api/srp_client_api.cpp
@@ -33,6 +33,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+
 #include <openthread/srp_client.h>
 
 #include "common/instance.hpp"
@@ -40,8 +42,6 @@
 #include "net/srp_client.hpp"
 
 using namespace ot;
-
-#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
 
 otError otSrpClientStart(otInstance *aInstance, const otSockAddr *aServerSockAddr)
 {

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -33,6 +33,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
+
 #include <openthread/thread.h>
 
 #include "common/debug.hpp"
@@ -42,7 +44,6 @@
 
 using namespace ot;
 
-#if OPENTHREAD_FTD || OPENTHREAD_MTD
 uint32_t otThreadGetChildTimeout(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
@@ -515,4 +516,5 @@ void otThreadRegisterParentResponseCallback(otInstance *                   aInst
 
     instance.Get<Mle::MleRouter>().RegisterParentResponseStatsCallback(aCallback, aContext);
 }
+
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD

--- a/src/core/backbone_router/backbone_tmf.hpp
+++ b/src/core/backbone_router/backbone_tmf.hpp
@@ -34,6 +34,10 @@
 #ifndef OT_CORE_THREAD_BACKBONE_TMF_HPP_
 #define OT_CORE_THREAD_BACKBONE_TMF_HPP_
 
+#include "openthread-core-config.h"
+
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+
 #include "coap/coap.hpp"
 
 namespace ot {
@@ -103,5 +107,7 @@ private:
 
 } // namespace BackboneRouter
 } // namespace ot
+
+#endif //  OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
 
 #endif //  OT_CORE_THREAD_BACKBONE_TMF_HPP_

--- a/src/core/backbone_router/bbr_leader.hpp
+++ b/src/core/backbone_router/bbr_leader.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+
 #include <openthread/backbone_router.h>
 #include <openthread/ip6.h>
 

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+
 #include <openthread/backbone_router.h>
 #include <openthread/backbone_router_ftd.h>
 

--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -28,14 +28,14 @@
 
 #include "coap_secure.hpp"
 
+#if OPENTHREAD_CONFIG_DTLS_ENABLE
+
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 #include "common/logging.hpp"
 #include "common/new.hpp"
 #include "meshcop/dtls.hpp"
 #include "thread/thread_netif.hpp"
-
-#if OPENTHREAD_CONFIG_DTLS_ENABLE
 
 /**
  * @file

--- a/src/core/coap/coap_secure.hpp
+++ b/src/core/coap/coap_secure.hpp
@@ -31,6 +31,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_DTLS_ENABLE
+
 #include "coap/coap.hpp"
 #include "meshcop/dtls.hpp"
 #include "meshcop/meshcop.hpp"
@@ -409,5 +411,7 @@ private:
 
 } // namespace Coap
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_DTLS_ENABLE
 
 #endif // COAP_SECURE_HPP_

--- a/src/core/common/extension.hpp
+++ b/src/core/common/extension.hpp
@@ -36,11 +36,11 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_ENABLE_VENDOR_EXTENSION
+
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
-
-#if OPENTHREAD_ENABLE_VENDOR_EXTENSION
 
 namespace ot {
 namespace Ncp {

--- a/src/core/crypto/ecdsa.cpp
+++ b/src/core/crypto/ecdsa.cpp
@@ -33,6 +33,8 @@
 
 #include "ecdsa.hpp"
 
+#if OPENTHREAD_CONFIG_ECDSA_ENABLE
+
 #include <string.h>
 
 #include <mbedtls/ctr_drbg.h>
@@ -47,8 +49,6 @@
 namespace ot {
 namespace Crypto {
 namespace Ecdsa {
-
-#if OPENTHREAD_CONFIG_ECDSA_ENABLE
 
 Error P256::KeyPair::Generate(void)
 {
@@ -246,8 +246,8 @@ exit:
     return error;
 }
 
-#endif // OPENTHREAD_CONFIG_ECDSA_ENABLE
-
 } // namespace Ecdsa
 } // namespace Crypto
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_ECDSA_ENABLE

--- a/src/core/crypto/ecdsa.hpp
+++ b/src/core/crypto/ecdsa.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_ECDSA_ENABLE
+
 #include <stdint.h>
 #include <stdlib.h>
 
@@ -45,8 +47,6 @@
 namespace ot {
 namespace Crypto {
 namespace Ecdsa {
-
-#if OPENTHREAD_CONFIG_ECDSA_ENABLE
 
 /**
  * @addtogroup core-security
@@ -297,10 +297,10 @@ Error Sign(uint8_t *      aOutput,
  *
  */
 
-#endif // OPENTHREAD_CONFIG_ECDSA_ENABLE
-
 } // namespace Ecdsa
 } // namespace Crypto
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_ECDSA_ENABLE
 
 #endif // ECDSA_HPP_

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -33,6 +33,8 @@
 
 #include "factory_diags.hpp"
 
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+
 #include <stdio.h>
 #include <stdlib.h>
 
@@ -64,7 +66,6 @@ otError otPlatDiagProcess(otInstance *aInstance,
 namespace ot {
 namespace FactoryDiags {
 
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
 #if OPENTHREAD_RADIO
 
 const struct Diags::Command Diags::sCommands[] = {
@@ -607,7 +608,7 @@ bool Diags::IsEnabled(void)
     return otPlatDiagModeGet();
 }
 
-#endif // OPENTHREAD_CONFIG_DIAG_ENABLE
-
 } // namespace FactoryDiags
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_DIAG_ENABLE

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_DIAG_ENABLE
+
 #include <string.h>
 
 #include <openthread/platform/radio.h>
@@ -46,8 +48,6 @@
 
 namespace ot {
 namespace FactoryDiags {
-
-#if OPENTHREAD_CONFIG_DIAG_ENABLE
 
 class Diags : public InstanceLocator, private NonCopyable
 {
@@ -169,9 +169,9 @@ private:
 #endif
 };
 
-#endif // #if OPENTHREAD_CONFIG_DIAG_ENABLE
-
 } // namespace FactoryDiags
 } // namespace ot
+
+#endif // #if OPENTHREAD_CONFIG_DIAG_ENABLE
 
 #endif // FACTORY_DIAGS_HPP_

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -31,9 +31,9 @@
  *   This file includes the implementation for handling of data polls and indirect frame transmission.
  */
 
-#if OPENTHREAD_FTD
-
 #include "data_poll_handler.hpp"
+
+#if OPENTHREAD_FTD
 
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"

--- a/src/core/mac/data_poll_handler.hpp
+++ b/src/core/mac/data_poll_handler.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD
+
 #include "common/code_utils.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
@@ -294,5 +296,7 @@ private:
  */
 
 } // namespace ot
+
+#endif // OPENTHREAD_FTD
 
 #endif // DATA_POLL_HANDLER_HPP_

--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -33,6 +33,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
+
 #include <string.h>
 #include <openthread/diag.h>
 #include <openthread/platform/diag.h>
@@ -43,8 +45,6 @@
 #include "common/logging.hpp"
 #include "common/random.hpp"
 #include "mac/mac_frame.hpp"
-
-#if OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
 
 namespace ot {
 namespace Mac {

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
+
 #include <openthread/link_raw.h>
 
 #include "common/locator.hpp"
@@ -45,8 +47,6 @@
 
 namespace ot {
 namespace Mac {
-
-#if OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
 
 /**
  * This class defines the raw link-layer object.
@@ -311,9 +311,9 @@ private:
 #endif
 };
 
-#endif // OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-
 } // namespace Mac
 } // namespace ot
+
+#endif // OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
 
 #endif // LINK_RAW_HPP_

--- a/src/core/mac/mac_filter.cpp
+++ b/src/core/mac/mac_filter.cpp
@@ -33,9 +33,9 @@
 
 #include "mac_filter.hpp"
 
-#include "common/code_utils.hpp"
-
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+
+#include "common/code_utils.hpp"
 
 namespace ot {
 namespace Mac {

--- a/src/core/mac/mac_filter.hpp
+++ b/src/core/mac/mac_filter.hpp
@@ -36,12 +36,12 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+
 #include <stdint.h>
 
 #include "common/non_copyable.hpp"
 #include "mac/mac_frame.hpp"
-
-#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
 
 namespace ot {
 namespace Mac {

--- a/src/core/meshcop/announce_begin_client.cpp
+++ b/src/core/meshcop/announce_begin_client.cpp
@@ -33,6 +33,8 @@
 
 #include "announce_begin_client.hpp"
 
+#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
+
 #include "coap/coap_message.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
@@ -43,8 +45,6 @@
 #include "meshcop/meshcop_tlvs.hpp"
 #include "thread/thread_netif.hpp"
 #include "thread/uri_paths.hpp"
-
-#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
 
 namespace ot {
 

--- a/src/core/meshcop/announce_begin_client.hpp
+++ b/src/core/meshcop/announce_begin_client.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
+
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
 #include "net/ip6_address.hpp"
@@ -76,5 +78,7 @@ public:
  */
 
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
 
 #endif // ANNOUNCE_BEGIN_CLIENT_HPP_

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -33,6 +33,8 @@
 
 #include "border_agent.hpp"
 
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
+
 #include "coap/coap_message.hpp"
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
@@ -42,8 +44,6 @@
 #include "thread/thread_netif.hpp"
 #include "thread/thread_tlvs.hpp"
 #include "thread/uri_paths.hpp"
-
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
+
 #include <openthread/border_agent.h>
 
 #include "coap/coap.hpp"
@@ -189,5 +191,7 @@ private:
 
 } // namespace MeshCoP
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
 
 #endif // BORDER_AGENT_HPP_

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -33,6 +33,8 @@
 
 #include "commissioner.hpp"
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
+
 #include <stdio.h>
 
 #include "coap/coap_message.hpp"
@@ -48,8 +50,6 @@
 #include "thread/thread_netif.hpp"
 #include "thread/thread_tlvs.hpp"
 #include "thread/uri_paths.hpp"
-
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
+
 #include <openthread/commissioner.h>
 
 #include "coap/coap.hpp"
@@ -476,5 +478,7 @@ private:
 
 } // namespace MeshCoP
 } // namespace ot
+
+#endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
 
 #endif // COMMISSIONER_HPP_

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -31,6 +31,9 @@
  *   This file implements MeshCoP Datasets manager to process commands.
  *
  */
+
+#include "meshcop/dataset_manager.hpp"
+
 #if OPENTHREAD_FTD
 
 #include <stdio.h>
@@ -46,7 +49,6 @@
 #include "common/random.hpp"
 #include "common/timer.hpp"
 #include "meshcop/dataset.hpp"
-#include "meshcop/dataset_manager.hpp"
 #include "meshcop/meshcop.hpp"
 #include "meshcop/meshcop_leader.hpp"
 #include "meshcop/meshcop_tlvs.hpp"

--- a/src/core/meshcop/dataset_updater.cpp
+++ b/src/core/meshcop/dataset_updater.cpp
@@ -34,13 +34,13 @@
 
 #include "dataset_updater.hpp"
 
+#if (OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE || OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE) && OPENTHREAD_FTD
+
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 #include "common/logging.hpp"
 #include "common/random.hpp"
-
-#if (OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE || OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE) && OPENTHREAD_FTD
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/dataset_updater.hpp
+++ b/src/core/meshcop/dataset_updater.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if (OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE || OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE) && OPENTHREAD_FTD
+
 #include <openthread/dataset_updater.h>
 
 #include "common/locator.hpp"
@@ -48,8 +50,6 @@
 
 namespace ot {
 namespace MeshCoP {
-
-#if (OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE || OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE) && OPENTHREAD_FTD
 
 /**
  * This class implements the Dataset Updater.
@@ -138,9 +138,9 @@ private:
     Message *  mDataset;
 };
 
-#endif // (OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE || OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE) && OPENTHREAD_FTD
-
 } // namespace MeshCoP
 } // namespace ot
+
+#endif // (OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE || OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE) && OPENTHREAD_FTD
 
 #endif // DATASET_UPDATER_HPP_

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -33,6 +33,8 @@
 
 #include "energy_scan_client.hpp"
 
+#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
+
 #include "coap/coap_message.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
@@ -44,8 +46,6 @@
 #include "meshcop/meshcop_tlvs.hpp"
 #include "thread/thread_netif.hpp"
 #include "thread/uri_paths.hpp"
-
-#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
 
 namespace ot {
 

--- a/src/core/meshcop/energy_scan_client.hpp
+++ b/src/core/meshcop/energy_scan_client.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
+
 #include <openthread/commissioner.h>
 
 #include "coap/coap.hpp"
@@ -96,5 +98,7 @@ private:
  */
 
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
 
 #endif // ENERGY_SCAN_CLIENT_HPP_

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -33,6 +33,8 @@
 
 #include "joiner.hpp"
 
+#if OPENTHREAD_CONFIG_JOINER_ENABLE
+
 #include <stdio.h>
 
 #include "common/code_utils.hpp"
@@ -47,8 +49,6 @@
 #include "thread/thread_netif.hpp"
 #include "thread/uri_paths.hpp"
 #include "utils/otns.hpp"
-
-#if OPENTHREAD_CONFIG_JOINER_ENABLE
 
 namespace ot {
 namespace MeshCoP {

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_JOINER_ENABLE
+
 #include <openthread/joiner.h>
 
 #include "coap/coap.hpp"
@@ -242,5 +244,7 @@ private:
 
 } // namespace MeshCoP
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_JOINER_ENABLE
 
 #endif // JOINER_HPP_

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -31,9 +31,9 @@
  *   This file implements the Joiner Router role.
  */
 
-#if OPENTHREAD_FTD
-
 #include "joiner_router.hpp"
+
+#if OPENTHREAD_FTD
 
 #include <stdio.h>
 

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD
+
 #include "coap/coap.hpp"
 #include "coap/coap_message.hpp"
 #include "common/locator.hpp"
@@ -133,5 +135,7 @@ private:
 
 } // namespace MeshCoP
 } // namespace ot
+
+#endif // OPENTHREAD_FTD
 
 #endif // JOINER_ROUTER_HPP_

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -31,9 +31,9 @@
  *   This file implements a MeshCoP Leader.
  */
 
-#if OPENTHREAD_FTD
-
 #include "meshcop_leader.hpp"
+
+#if OPENTHREAD_FTD
 
 #include <stdio.h>
 

--- a/src/core/meshcop/meshcop_leader.hpp
+++ b/src/core/meshcop/meshcop_leader.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD
+
 #include "coap/coap.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
@@ -143,5 +145,7 @@ private:
 
 } // namespace MeshCoP
 } // namespace ot
+
+#endif // OPENTHREAD_FTD
 
 #endif // MESHCOP_LEADER_HPP_

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -33,6 +33,8 @@
 
 #include "panid_query_client.hpp"
 
+#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
+
 #include "coap/coap_message.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
@@ -43,8 +45,6 @@
 #include "meshcop/meshcop_tlvs.hpp"
 #include "thread/thread_netif.hpp"
 #include "thread/uri_paths.hpp"
-
-#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
 
 namespace ot {
 

--- a/src/core/meshcop/panid_query_client.hpp
+++ b/src/core/meshcop/panid_query_client.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
+
 #include <openthread/commissioner.h>
 
 #include "coap/coap.hpp"
@@ -92,5 +94,7 @@ private:
  */
 
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
 
 #endif // PANID_QUERY_CLIENT_HPP_

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -33,6 +33,8 @@
 
 #include "dhcp6_client.hpp"
 
+#if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
+
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
@@ -41,8 +43,6 @@
 #include "mac/mac.hpp"
 #include "net/dhcp6.hpp"
 #include "thread/thread_netif.hpp"
-
-#if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
 
 namespace ot {
 namespace Dhcp6 {

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
+
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
@@ -50,8 +52,6 @@
 namespace ot {
 
 namespace Dhcp6 {
-
-#if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
 
 /**
  * @addtogroup core-dhcp6
@@ -159,6 +159,9 @@ private:
  *
  */
 
+} // namespace Dhcp6
+} // namespace ot
+
 #else // OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
 
 #if OPENTHREAD_ENABLE_DHCP6_MULTICAST_SOLICIT
@@ -166,8 +169,5 @@ private:
 #endif
 
 #endif // OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
-
-} // namespace Dhcp6
-} // namespace ot
 
 #endif // DHCP6_CLIENT_HPP_

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -33,6 +33,8 @@
 
 #include "dhcp6_server.hpp"
 
+#if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
+
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
@@ -40,8 +42,6 @@
 #include "common/logging.hpp"
 #include "thread/mle.hpp"
 #include "thread/thread_netif.hpp"
-
-#if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
 
 namespace ot {
 namespace Dhcp6 {

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
+
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "mac/mac.hpp"
@@ -46,8 +48,6 @@
 
 namespace ot {
 namespace Dhcp6 {
-
-#if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
 
 #if OPENTHREAD_ENABLE_DHCP6_MULTICAST_SOLICIT
 #error "OPENTHREAD_ENABLE_DHCP6_MULTICAST_SOLICIT requires DHCPv6 server on Border Router side to be enabled."
@@ -229,9 +229,9 @@ private:
  *
  */
 
-#endif // OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
-
 } // namespace Dhcp6
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
 
 #endif // DHCP6_SERVER_HPP_

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -28,6 +28,8 @@
 
 #include "dns_client.hpp"
 
+#if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
+
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -35,8 +37,6 @@
 #include "common/logging.hpp"
 #include "net/udp6.hpp"
 #include "thread/thread_netif.hpp"
-
-#if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
 
 /**
  * @file

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -31,6 +31,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
+
 #include <openthread/dns_client.h>
 
 #include "common/clearable.hpp"
@@ -684,5 +686,7 @@ private:
 
 } // namespace Dns
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
 
 #endif // DNS_CLIENT_HPP_

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -29,6 +29,8 @@
 
 #include "sntp_client.hpp"
 
+#if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
+
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -36,8 +38,6 @@
 #include "common/logging.hpp"
 #include "net/udp6.hpp"
 #include "thread/thread_netif.hpp"
-
-#if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
 
 /**
  * @file

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -31,6 +31,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
+
 #include <openthread/sntp.h>
 
 #include "common/message.hpp"
@@ -590,5 +592,7 @@ private:
 
 } // namespace Sntp
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
 
 #endif // SNTP_CLIENT_HPP_

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -28,6 +28,8 @@
 
 #include "srp_client.hpp"
 
+#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -37,8 +39,6 @@
 #include "common/settings.hpp"
 #include "common/string.hpp"
 #include "thread/network_data_service.hpp"
-
-#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
 
 /**
  * @file

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -31,6 +31,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+
 #include <openthread/srp_client.h>
 
 #include "common/clearable.hpp"
@@ -44,8 +46,6 @@
 #include "net/dns_types.hpp"
 #include "net/ip6.hpp"
 #include "net/udp6.hpp"
-
-#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
 
 /**
  * @file

--- a/src/core/radio/trel_interface.cpp
+++ b/src/core/radio/trel_interface.cpp
@@ -32,14 +32,14 @@
 
 #include "trel_interface.hpp"
 
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+
 #include <openthread/platform/trel-udp6.h>
 
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 #include "common/logging.hpp"
-
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 
 namespace ot {
 namespace Trel {

--- a/src/core/radio/trel_interface.hpp
+++ b/src/core/radio/trel_interface.hpp
@@ -36,12 +36,12 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+
 #include "common/locator.hpp"
 #include "mac/mac_types.hpp"
 #include "net/ip6_address.hpp"
 #include "radio/trel_packet.hpp"
-
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 
 namespace ot {
 namespace Trel {

--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -32,13 +32,13 @@
 
 #include "trel_link.hpp"
 
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 #include "common/logging.hpp"
-
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 
 namespace ot {
 namespace Trel {

--- a/src/core/radio/trel_link.hpp
+++ b/src/core/radio/trel_link.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
 #include "common/tasklet.hpp"
@@ -44,8 +46,6 @@
 #include "mac/mac_types.hpp"
 #include "radio/trel_interface.hpp"
 #include "radio/trel_packet.hpp"
-
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 
 namespace ot {
 

--- a/src/core/radio/trel_packet.cpp
+++ b/src/core/radio/trel_packet.cpp
@@ -32,13 +32,13 @@
 
 #include "trel_packet.hpp"
 
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 #include "common/logging.hpp"
-
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 
 namespace ot {
 namespace Trel {

--- a/src/core/radio/trel_packet.hpp
+++ b/src/core/radio/trel_packet.hpp
@@ -36,12 +36,12 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
 #include "common/string.hpp"
 #include "mac/mac_types.hpp"
-
-#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 
 namespace ot {
 namespace Trel {

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -31,9 +31,9 @@
  *   This file implements Thread's EID-to-RLOC mapping and caching.
  */
 
-#if OPENTHREAD_FTD
-
 #include "address_resolver.hpp"
+
+#if OPENTHREAD_FTD
 
 #include "coap/coap_message.hpp"
 #include "common/code_utils.hpp"

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD
+
 #include "coap/coap.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
@@ -362,5 +364,7 @@ private:
  */
 
 } // namespace ot
+
+#endif //  OPENTHREAD_FTD
 
 #endif // ADDRESS_RESOLVER_HPP_

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -33,13 +33,13 @@
 
 #include "child_table.hpp"
 
+#if OPENTHREAD_FTD
+
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 
 namespace ot {
-
-#if OPENTHREAD_FTD
 
 ChildTable::Iterator::Iterator(Instance &aInstance, Child::StateFilter aFilter)
     : InstanceLocator(aInstance)
@@ -330,6 +330,6 @@ bool ChildTable::HasSleepyChildWithAddress(const Ip6::Address &aIp6Address) cons
     return hasChild;
 }
 
-#endif // OPENTHREAD_FTD
-
 } // namespace ot
+
+#endif // OPENTHREAD_FTD

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -31,6 +31,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
@@ -49,8 +51,6 @@ namespace ot {
  *
  * @{
  */
-
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
 
 class Child;
 
@@ -208,13 +208,13 @@ private:
     Callbacks               mCallbacks;
 };
 
-#endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-
 /**
  * @}
  *
  */
 
 } // namespace ot
+
+#endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
 
 #endif // CSL_TX_SCHEDULER_HPP_

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -31,9 +31,9 @@
  *   This file includes definitions for handling indirect transmission.
  */
 
-#if OPENTHREAD_FTD
-
 #include "indirect_sender.hpp"
+
+#if OPENTHREAD_FTD
 
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"

--- a/src/core/thread/indirect_sender.hpp
+++ b/src/core/thread/indirect_sender.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD
+
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
@@ -236,5 +238,7 @@ private:
  */
 
 } // namespace ot
+
+#endif // OPENTHREAD_FTD
 
 #endif // INDIRECT_SENDER_HPP_

--- a/src/core/thread/link_metrics_tlvs.hpp
+++ b/src/core/thread/link_metrics_tlvs.hpp
@@ -35,13 +35,15 @@
 #ifndef LINK_METRICS_TLVS_HPP_
 #define LINK_METRICS_TLVS_HPP_
 
+#include "openthread-core-config.h"
+
+#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_ENABLE
+
 #include <openthread/link_metrics.h>
 
 #include "common/encoding.hpp"
 #include "common/message.hpp"
 #include "common/tlvs.hpp"
-
-#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_ENABLE
 
 namespace ot {
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -235,6 +235,7 @@ public:
      */
     void SetDiscoverParameters(const Mac::ChannelMask &aScanChannels);
 
+#if OPENTHREAD_FTD
     /**
      * This method frees any messages queued for an existing child.
      *
@@ -244,6 +245,7 @@ public:
      *
      */
     void RemoveMessages(Child &aChild, Message::SubType aSubType);
+#endif
 
     /**
      * This method frees unicast/multicast MLE Data Responses from Send Message Queue if any.

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -31,9 +31,9 @@
  *   This file implements FTD-specific mesh forwarding of IPv6/6LoWPAN messages.
  */
 
-#if OPENTHREAD_FTD
-
 #include "mesh_forwarder.hpp"
+
+#if OPENTHREAD_FTD
 
 #include "common/locator-getters.hpp"
 #include "common/logging.hpp"

--- a/src/core/thread/mesh_forwarder_mtd.cpp
+++ b/src/core/thread/mesh_forwarder_mtd.cpp
@@ -31,9 +31,9 @@
  *   This file implements MTD-specific mesh forwarding of IPv6/6LoWPAN messages.
  */
 
-#if OPENTHREAD_MTD
-
 #include "mesh_forwarder.hpp"
+
+#if OPENTHREAD_MTD
 
 namespace ot {
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -39,6 +39,7 @@
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
+#include "common/notifier.hpp"
 #include "common/timer.hpp"
 #include "mac/mac.hpp"
 #include "meshcop/joiner_router.hpp"

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -30,9 +30,9 @@
  *   This file implements MLE functionality required for the Thread Router and Leader roles.
  */
 
-#if OPENTHREAD_FTD
-
 #include "mle_router.hpp"
+
+#if OPENTHREAD_FTD
 
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"

--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -267,7 +267,9 @@ void NeighborTable::Signal(Event aEvent, const Neighbor &aNeighbor)
         {
         case OT_NEIGHBOR_TABLE_EVENT_CHILD_ADDED:
         case OT_NEIGHBOR_TABLE_EVENT_CHILD_REMOVED:
+#if OPENTHREAD_FTD
             static_cast<Child::Info &>(info.mInfo.mChild).SetFrom(static_cast<const Child &>(aNeighbor));
+#endif
             break;
 
         case OT_NEIGHBOR_TABLE_EVENT_ROUTER_ADDED:

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -31,9 +31,9 @@
  *   This file implements the Thread Network Data managed by the Thread Leader.
  */
 
-#if OPENTHREAD_FTD
-
 #include "network_data_leader.hpp"
+
+#if OPENTHREAD_FTD
 
 #include "coap/coap_message.hpp"
 #include "common/code_utils.hpp"

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD
+
 #include <stdint.h>
 
 #include "coap/coap.hpp"
@@ -316,5 +318,7 @@ private:
 
 } // namespace NetworkData
 } // namespace ot
+
+#endif // OPENTHREAD_FTD
 
 #endif // NETWORK_DATA_LEADER_FTD_HPP_

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -33,6 +33,8 @@
 
 #include "network_data_local.hpp"
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -41,8 +43,6 @@
 #include "mac/mac_types.hpp"
 #include "thread/mle_types.hpp"
 #include "thread/thread_netif.hpp"
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
 namespace ot {
 namespace NetworkData {

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -37,10 +37,10 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+
 #include "common/non_copyable.hpp"
 #include "thread/network_data.hpp"
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
 namespace ot {
 

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -33,6 +33,8 @@
 
 #include "network_diagnostic.hpp"
 
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
+
 #include "coap/coap_message.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
@@ -47,8 +49,6 @@
 #include "thread/thread_netif.hpp"
 #include "thread/thread_tlvs.hpp"
 #include "thread/uri_paths.hpp"
-
-#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
 
 namespace ot {
 

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
+
 #include <openthread/netdiag.h>
 
 #include "coap/coap.hpp"
@@ -162,5 +164,7 @@ private:
 } // namespace NetworkDiagnostic
 
 } // namespace ot
+
+#endif // OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
 
 #endif // NETWORK_DIAGNOSTIC_HPP_

--- a/src/core/thread/radio_selector.cpp
+++ b/src/core/thread/radio_selector.cpp
@@ -33,13 +33,13 @@
 
 #include "radio_selector.hpp"
 
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 #include "common/logging.hpp"
 #include "common/random.hpp"
-
-#if OPENTHREAD_CONFIG_MULTI_RADIO
 
 namespace ot {
 

--- a/src/core/thread/radio_selector.hpp
+++ b/src/core/thread/radio_selector.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+
 #include <openthread/multi_radio.h>
 
 #include "common/locator.hpp"
@@ -43,8 +45,6 @@
 #include "mac/mac_frame.hpp"
 #include "mac/mac_links.hpp"
 #include "mac/mac_types.hpp"
-
-#if OPENTHREAD_CONFIG_MULTI_RADIO
 
 namespace ot {
 

--- a/src/core/thread/src_match_controller.hpp
+++ b/src/core/thread/src_match_controller.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_FTD
+
 #include "common/error.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
@@ -193,5 +195,7 @@ private:
  */
 
 } // namespace ot
+
+#endif // OPENTHREAD_FTD
 
 #endif // SOURCE_MATCH_CONTROLLER_HPP_

--- a/src/core/thread/time_sync_service.hpp
+++ b/src/core/thread/time_sync_service.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+
 #include <openthread/network_time.h>
 
 #include "common/locator.hpp"

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -214,6 +214,8 @@ const char *Neighbor::StateToString(State aState)
     return static_cast<uint8_t>(aState) < OT_ARRAY_LENGTH(kStateStrings) ? kStateStrings[aState] : "Unknown";
 }
 
+#if OPENTHREAD_FTD
+
 void Child::Info::SetFrom(const Child &aChild)
 {
     Clear();
@@ -428,7 +430,7 @@ void Child::GenerateChallenge(void)
     IgnoreError(Random::Crypto::FillBuffer(mAttachChallenge, sizeof(mAttachChallenge)));
 }
 
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+#if OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
 bool Child::HasMlrRegisteredAddress(const Ip6::Address &aAddress) const
 {
     bool has = false;
@@ -471,7 +473,9 @@ void Child::SetAddressMlrState(const Ip6::Address &aAddress, MlrState aState)
     mMlrToRegisterMask.Set(addressIndex, aState == kMlrStateToRegister);
     mMlrRegisteredMask.Set(addressIndex, aState == kMlrStateRegistered);
 }
-#endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+#endif // OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
+
+#endif // OPENTHREAD_FTD
 
 void Router::Info::SetFrom(const Router &aRouter)
 {

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -811,6 +811,8 @@ private:
 #endif
 };
 
+#if OPENTHREAD_FTD
+
 /**
  * This class represents a Thread Child.
  *
@@ -818,7 +820,7 @@ private:
 class Child : public Neighbor,
               public IndirectSender::ChildInfo,
               public DataPollHandler::ChildInfo
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     ,
               public CslTxScheduler::ChildInfo
 #endif
@@ -1307,6 +1309,8 @@ private:
 
     static_assert(OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS < 8192, "mQueuedMessageCount cannot fit max required!");
 };
+
+#endif // OPENTHREAD_FTD
 
 /**
  * This class represents a Thread Router

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -34,6 +34,8 @@
 
 #include "channel_manager.hpp"
 
+#if OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
+
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
@@ -41,8 +43,6 @@
 #include "common/random.hpp"
 #include "meshcop/dataset_updater.hpp"
 #include "radio/radio.hpp"
-
-#if OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
 
 namespace ot {
 namespace Utils {

--- a/src/core/utils/channel_manager.hpp
+++ b/src/core/utils/channel_manager.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
+
 #include <openthread/platform/radio.h>
 
 #include "common/locator.hpp"
@@ -54,8 +56,6 @@ namespace Utils {
  *
  * @{
  */
-
-#if OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
 
 /**
  * This class implements the Channel Manager.
@@ -283,8 +283,6 @@ private:
     bool             mAutoSelectEnabled;
 };
 
-#endif // OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
-
 /**
  * @}
  *
@@ -292,5 +290,7 @@ private:
 
 } // namespace Utils
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
 
 #endif // CHANNEL_MANAGER_HPP_

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -33,12 +33,12 @@
 
 #include "channel_monitor.hpp"
 
+#if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
+
 #include "common/code_utils.hpp"
 #include "common/locator-getters.hpp"
 #include "common/logging.hpp"
 #include "common/random.hpp"
-
-#if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
 
 namespace ot {
 namespace Utils {
@@ -236,4 +236,4 @@ Mac::ChannelMask ChannelMonitor::FindBestChannels(const Mac::ChannelMask &aMask,
 } // namespace Utils
 } // namespace ot
 
-#endif // #if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
+#endif // OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE

--- a/src/core/utils/channel_monitor.hpp
+++ b/src/core/utils/channel_monitor.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
+
 #include <openthread/platform/radio.h>
 
 #include "common/locator.hpp"
@@ -55,8 +57,6 @@ namespace Utils {
  *
  * @{
  */
-
-#if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
 
 /**
  * This class implements the channel monitoring logic.
@@ -213,8 +213,6 @@ private:
     TimerMilli mTimer;
 };
 
-#endif // OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
-
 /**
  * @}
  *
@@ -222,5 +220,7 @@ private:
 
 } // namespace Utils
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
 
 #endif // CHANNEL_MONITOR_HPP_

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -51,6 +51,7 @@
 namespace ot {
 
 class ThreadNetif;
+class Child;
 
 namespace Utils {
 

--- a/src/core/utils/flash.cpp
+++ b/src/core/utils/flash.cpp
@@ -28,14 +28,14 @@
 
 #include "flash.hpp"
 
+#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+
 #include <stdio.h>
 
 #include <openthread/platform/flash.h>
 
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
-
-#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
 
 namespace ot {
 

--- a/src/core/utils/flash.hpp
+++ b/src/core/utils/flash.hpp
@@ -31,6 +31,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+
 #include <stdint.h>
 #include <string.h>
 
@@ -231,5 +233,7 @@ private:
 };
 
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
 
 #endif // FLASH_HPP_

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -33,14 +33,14 @@
 
 #include "jam_detector.hpp"
 
+#if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
+
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
 #include "common/logging.hpp"
 #include "common/random.hpp"
 #include "thread/thread_netif.hpp"
-
-#if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
 
 namespace ot {
 namespace Utils {

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
+
 #include <stdint.h>
 
 #include "common/locator.hpp"
@@ -216,5 +218,7 @@ private:
 
 } // namespace Utils
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
 
 #endif // JAM_DETECTOR_HPP_

--- a/src/core/utils/otns.hpp
+++ b/src/core/utils/otns.hpp
@@ -46,6 +46,7 @@
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
+#include "mac/mac_frame.hpp"
 #include "mac/mac_types.hpp"
 #include "net/ip6_address.hpp"
 #include "thread/neighbor_table.hpp"

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -33,6 +33,8 @@
 
 #include "slaac_address.hpp"
 
+#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
+
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator-getters.hpp"
@@ -41,8 +43,6 @@
 #include "common/settings.hpp"
 #include "crypto/sha256.hpp"
 #include "net/ip6_address.hpp"
-
-#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
 
 namespace ot {
 namespace Utils {

--- a/src/core/utils/slaac_address.hpp
+++ b/src/core/utils/slaac_address.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
+
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
@@ -180,5 +182,7 @@ private:
 
 } // namespace Utils
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
 
 #endif // SLAAC_ADDRESS_HPP_


### PR DESCRIPTION
This commit harmonizes how the feature config checks are done within
OT core modules. In header `.hpp` files, any related `#if` config
check is done immediately after the `"openthread-core-config.h"` is
included. This way the rest of definitions are skipped over if the
feature is not being used. In `cpp` source files the `#if` check is
done immediately after including the related header file.

----

As a side-effect, this can help shave off few seconds from a clean build time.
Some rough measurements for `cmake/ninja` build (with `toranj` config):
It went from average of ~40s to about ~36s with this change.
