### PR TITLE
[srp-server] replace SRP Host pointer with SRP service update ID

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (97)
+#define OPENTHREAD_API_VERSION (98)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/srp_server.h
+++ b/include/openthread/srp_server.h
@@ -68,6 +68,12 @@ typedef void otSrpServerHost;
 typedef void otSrpServerService;
 
 /**
+ * The ID of a SRP service update transaction on the SRP Server.
+ *
+ */
+typedef uint32_t otSrpServerServiceUpdateId;
+
+/**
  * This method returns the domain authorized to the SRP server.
  *
  * If the domain if not set by SetDomain, "default.service.arpa." will be returned.
@@ -144,11 +150,11 @@ otError otSrpServerSetLeaseRange(otInstance *aInstance,
  * if any validation fails. For example, an Advertising Proxy should advertise (or remove) the host and
  * services on a multicast-capable link and returns specific error code if any failure occurs.
  *
- * @param[in]  aHost     A pointer to the otSrpServerHost object which contains the SRP updates.
- *                       The pointer should be passed back to otSrpServerHandleServiceUpdateResult, but
- *                       the content MUST not be accessed after this method returns. The handler
- *                       should publish/un-publish the host and each service points to this host
- *                       with below rules:
+ * @param[in]  aId       The service update transaction ID. This ID must be passed back with
+ *                       `otSrpServerHandleServiceUpdateResult`.
+ * @param[in]  aHost     A pointer to the otSrpServerHost object which contains the SRP updates. The
+ *                       handler should publish/un-publish the host and each service points to this
+ *                       host with below rules:
  *                         1. If the host is not deleted (indicated by `otSrpServerHostIsDeleted`),
  *                            then it should be published or updated with mDNS. Otherwise, the host
  *                            should be un-published (remove AAAA RRs).
@@ -163,7 +169,10 @@ otError otSrpServerSetLeaseRange(otInstance *aInstance,
  * @sa otSrpServerHandleServiceUpdateResult
  *
  */
-typedef void (*otSrpServerServiceUpdateHandler)(const otSrpServerHost *aHost, uint32_t aTimeout, void *aContext);
+typedef void (*otSrpServerServiceUpdateHandler)(otSrpServerServiceUpdateId aId,
+                                                const otSrpServerHost *    aHost,
+                                                uint32_t                   aTimeout,
+                                                void *                     aContext);
 
 /**
  * This method sets the SRP service updates handler on SRP server.
@@ -185,12 +194,13 @@ void otSrpServerSetServiceUpdateHandler(otInstance *                    aInstanc
  * processing of a SRP update.
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
- * @param[in]  aHost      A pointer to the Host object which represents a SRP update.
+ * @param[in]  aId        The service update transaction ID. This should be the same ID
+ *                        provided via `otSrpServerServiceUpdateHandler`.
  * @param[in]  aError     An error to be returned to the SRP server. Use OT_ERROR_DUPLICATED
  *                        to represent DNS name conflicts.
  *
  */
-void otSrpServerHandleServiceUpdateResult(otInstance *aInstance, const otSrpServerHost *aHost, otError aError);
+void otSrpServerHandleServiceUpdateResult(otInstance *aInstance, otSrpServerServiceUpdateId aId, otError aError);
 
 /**
  * This method returns the next registered host on the SRP server.

--- a/src/core/api/srp_server_api.cpp
+++ b/src/core/api/srp_server_api.cpp
@@ -83,11 +83,11 @@ void otSrpServerSetServiceUpdateHandler(otInstance *                    aInstanc
     instance.Get<Srp::Server>().SetServiceHandler(aServiceHandler, aContext);
 }
 
-void otSrpServerHandleServiceUpdateResult(otInstance *aInstance, const otSrpServerHost *aHost, otError aError)
+void otSrpServerHandleServiceUpdateResult(otInstance *aInstance, otSrpServerServiceUpdateId aId, otError aError)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    instance.Get<Srp::Server>().HandleServiceUpdateResult(static_cast<const Srp::Server::Host *>(aHost), aError);
+    instance.Get<Srp::Server>().HandleServiceUpdateResult(aId, aError);
 }
 
 const otSrpServerHost *otSrpServerGetNextHost(otInstance *aInstance, const otSrpServerHost *aHost)


### PR DESCRIPTION
We are using the SRP Host pointer for indexing an outstanding SRP update when
the Advertising Proxy result is passed back with `otSrpServerHandleServiceUpdateResult`.
There are chances that an old, freed Host object may be matched again with a newly allocated
Host object which coincidentally has the same address with the old Host object.

This PR solves this issue by using a random generated `uint32_t` SRP service update ID for indexing
outstanding updates.

Depends-On: openthread/ot-br-posix#774