### PR TITLE
[spinel] fix missing initializer compiler error

### DIFF
--- a/src/lib/spinel/spinel.c
+++ b/src/lib/spinel/spinel.c
@@ -1191,7 +1191,7 @@ const char *spinel_command_to_cstr(spinel_command_t command)
         {SPINEL_CMD_PROP_VALUE_MULTI_GET, "PROP_VALUE_MULTI_GET"},
         {SPINEL_CMD_PROP_VALUE_MULTI_SET, "PROP_VALUE_MULTI_SET"},
         {SPINEL_CMD_PROP_VALUES_ARE, "PROP_VALUES_ARE"},
-        {0},
+        {0, NULL},
     };
 
     return spinel_to_cstr(spinel_commands_cstr, command);
@@ -1478,7 +1478,7 @@ const char *spinel_prop_key_to_cstr(spinel_prop_key_t prop_key)
         {SPINEL_PROP_RCP_MAC_KEY, "RCP_MAC_KEY"},
         {SPINEL_PROP_DEBUG_LOG_TIMESTAMP_BASE, "DEBUG_LOG_TIMESTAMP_BASE"},
         {SPINEL_PROP_DEBUG_TREL_TEST_MODE_ENABLE, "DEBUG_TREL_TEST_MODE_ENABLE"},
-        {0},
+        {0, NULL},
     };
 
     return spinel_to_cstr(spinel_prop_cstr, prop_key);
@@ -1491,7 +1491,7 @@ const char *spinel_net_role_to_cstr(uint8_t net_role)
         {SPINEL_NET_ROLE_CHILD, "NET_ROLE_CHILD"},
         {SPINEL_NET_ROLE_ROUTER, "NET_ROLE_ROUTER"},
         {SPINEL_NET_ROLE_LEADER, "NET_ROLE_LEADER"},
-        {0},
+        {0, NULL},
     };
 
     return spinel_to_cstr(spinel_net_cstr, net_role);
@@ -1503,7 +1503,7 @@ const char *spinel_mcu_power_state_to_cstr(uint8_t mcu_power_state)
         {SPINEL_MCU_POWER_STATE_ON, "MCU_POWER_STATE_ON"},
         {SPINEL_MCU_POWER_STATE_LOW_POWER, "MCU_POWER_STATE_LOW_POWER"},
         {SPINEL_MCU_POWER_STATE_OFF, "MCU_POWER_STATE_OFF"},
-        {0},
+        {0, NULL},
     };
 
     return spinel_to_cstr(spinel_mcu_power_state_cstr, mcu_power_state);
@@ -1550,7 +1550,7 @@ const char *spinel_status_to_cstr(spinel_status_t status)
         {SPINEL_STATUS_RESET_OTHER, "RESET_OTHER"},
         {SPINEL_STATUS_RESET_UNKNOWN, "RESET_UNKNOWN"},
         {SPINEL_STATUS_RESET_WATCHDOG, "RESET_WATCHDOG"},
-        {0},
+        {0, NULL},
     };
 
     return spinel_to_cstr(spinel_status_cstr, status);
@@ -1621,7 +1621,7 @@ const char *spinel_capability_to_cstr(spinel_capability_t capability)
         {SPINEL_CAP_NEST_LEGACY_INTERFACE, "NEST_LEGACY_INTERFACE"},
         {SPINEL_CAP_NEST_LEGACY_NET_WAKE, "NEST_LEGACY_NET_WAKE"},
         {SPINEL_CAP_NEST_TRANSMIT_HOOK, "NEST_TRANSMIT_HOOK"},
-        {0},
+        {0, NULL},
     };
 
     return spinel_to_cstr(spinel_cap_cstr, capability);


### PR DESCRIPTION
The openwrt toolchain complains
```
[ 90%] Building C object third_party/openthread/repo/src/lib/spinel/CMakeFiles/openthread-spinel-rcp.dir/spinel.c.o
/usr/src/toolchain/feeds/otbr/third_party/openthread/repo/src/lib/spinel/spinel.c: In function 'spinel_prop_key_to_cstr':
/usr/src/toolchain/feeds/otbr/third_party/openthread/repo/src/lib/spinel/spinel.c:1481:9: error: missing initializer for field 'str' of 'const struct spinel_cstr' [-Werror=missing-field-initializers]
         {0},
```
The patch adds NULL for the char* argument of spinel_cstr.