### PR TITLE
[build] update `toranj` build script to skip over empty "" args

### DIFF
--- a/tests/toranj/build.sh
+++ b/tests/toranj/build.sh
@@ -74,6 +74,9 @@ while [ $# -ge 2 ]; do
             tests=yes
             shift
             ;;
+        "")
+            shift
+            ;;
         *)
             echo "Error: Unknown option \"$1\""
             display_usage


### PR DESCRIPTION
This commit updates `toranj/build.sh` script to skip over empty ""
arguments at the start. This addresses an issue introduced in commit
531cb3484 (PR #6421) where the `start.sh` adds an empty arg when
invoking `build.sh` when coverage is not enabled.