### PR TITLE
[cli] adding helper method `ParseEnableOrDisable()`

### DIFF
--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -283,6 +283,19 @@ public:
     void OutputEnabledDisabledStatus(bool aEnabled);
 
     /**
+     * This static method checks a given string against "enable" or "disable" commands.
+     *
+     * @param[in]  aString  The string to parse.
+     * @param[out] aEnable  Boolean variable to return outcome on success.
+     *                      Set to TRUE for "enable" command, and FALSE for "disable" command.
+     *
+     * @retval OT_ERROR_NONE             Successfully parsed the @p aString and updated @p aEnable.
+     * @retval OT_ERROR_INVALID_COMMAND  The @p aString is not "enable" or "disable" command.
+     *
+     */
+    static otError ParseEnableOrDisable(const char *aString, bool &aEnable);
+
+    /**
      * This method sets the user command table.
      *
      * @param[in]  aUserCommands  A pointer to an array with user commands.

--- a/src/cli/cli_srp_client.cpp
+++ b/src/cli/cli_srp_client.cpp
@@ -94,6 +94,7 @@ exit:
 otError SrpClient::ProcessAutoStart(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
+    bool    enable;
 
     if (aArgsLength == 0)
     {
@@ -103,17 +104,15 @@ otError SrpClient::ProcessAutoStart(uint8_t aArgsLength, char *aArgs[])
 
     VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "enable") == 0)
+    SuccessOrExit(error = Interpreter::ParseEnableOrDisable(aArgs[0], enable));
+
+    if (enable)
     {
         otSrpClientEnableAutoStartMode(mInterpreter.mInstance, /* aCallback */ nullptr, /* aContext */ nullptr);
     }
-    else if (strcmp(aArgs[0], "disable") == 0)
-    {
-        otSrpClientDisableAutoStartMode(mInterpreter.mInstance);
-    }
     else
     {
-        error = OT_ERROR_INVALID_COMMAND;
+        otSrpClientDisableAutoStartMode(mInterpreter.mInstance);
     }
 
 exit:
@@ -133,19 +132,7 @@ otError SrpClient::ProcessCallback(uint8_t aArgsLength, char *aArgs[])
     }
 
     VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
-
-    if (strcmp(aArgs[0], "enable") == 0)
-    {
-        mCallbackEnabled = true;
-    }
-    else if (strcmp(aArgs[0], "disable") == 0)
-    {
-        mCallbackEnabled = false;
-    }
-    else
-    {
-        error = OT_ERROR_INVALID_ARGS;
-    }
+    error = Interpreter::ParseEnableOrDisable(aArgs[0], mCallbackEnabled);
 
 exit:
     return error;
@@ -397,20 +384,7 @@ otError SrpClient::ProcessService(uint8_t aArgsLength, char *aArgs[])
         }
 
         VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
-
-        if (strcmp(aArgs[1], "enable") == 0)
-        {
-            enable = true;
-        }
-        else if (strcmp(aArgs[1], "disable") == 0)
-        {
-            enable = false;
-        }
-        else
-        {
-            ExitNow(error = OT_ERROR_INVALID_COMMAND);
-        }
-
+        SuccessOrExit(error = Interpreter::ParseEnableOrDisable(aArgs[1], enable));
         otSrpClientSetServiceKeyRecordEnabled(mInterpreter.mInstance, enable);
     }
 #endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -216,17 +216,9 @@ otError UdpExample::ProcessLinkSecurity(uint8_t aArgsLength, char *aArgs[])
     {
         mInterpreter.OutputEnabledDisabledStatus(mLinkSecurityEnabled);
     }
-    else if (strcmp(aArgs[0], "enable") == 0)
-    {
-        mLinkSecurityEnabled = true;
-    }
-    else if (strcmp(aArgs[0], "disable") == 0)
-    {
-        mLinkSecurityEnabled = false;
-    }
     else
     {
-        error = OT_ERROR_INVALID_COMMAND;
+        error = Interpreter::ParseEnableOrDisable(aArgs[0], mLinkSecurityEnabled);
     }
 
     return error;


### PR DESCRIPTION
This commit adds a helper method `Cli::ParseEnableOrDisable()` which
checks a given string against two common commands "enable" or
"disable". This method is then used in CLI modules