### PR TITLE
[nrf528xx] set key id and frame counter for retransmissions

### DIFF
--- a/examples/platforms/nrf528xx/src/radio.c
+++ b/examples/platforms/nrf528xx/src/radio.c
@@ -1222,11 +1222,8 @@ void nrf_802154_tx_started(const uint8_t *aFrame)
 
     sTransmitFrame.mInfo.mTxInfo.mAesKey = &sCurrKey;
 
-    if (!sTransmitFrame.mInfo.mTxInfo.mIsARetx)
-    {
-        otMacFrameSetKeyId(&sTransmitFrame, sKeyId);
-        otMacFrameSetFrameCounter(&sTransmitFrame, sMacFrameCounter++);
-    }
+    otMacFrameSetKeyId(&sTransmitFrame, sKeyId);
+    otMacFrameSetFrameCounter(&sTransmitFrame, sMacFrameCounter++);
 
     processSecurity = true;
 #endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2


### PR DESCRIPTION
For nRF52 platforms in order to achieve the best CSL accuracy frame security processing was moved to the nrf_802154_tx_started() radio driver callback which is called from the interrupt context when frame transmission is started by the hardware peripheral. 

There is a possibility that a requested transmission will be aborted before nrf_802154_tx_started() is called. The frame can be then retransmitted and if nrf_802154_tx_started() is called it will skip setting key index and frame counter (so they will remain unchanged with a value equal to whatever is present in RAM). 

It seems that we should always set these fields. Moreover, security is processed only once which is controlled by mTxInfo.mIsSecurityProcessed member so checking for retransmission is redundant. Thoughts?