### PR TITLE
[scripts] fix parsing TXT RR containing `"` 

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -304,7 +304,7 @@ class OtbrDocker:
         # Example TXT entry:
         # "xp=\\000\\013\\184\\000\\000\\000\\000\\000"
         txt = {}
-        for entry in re.findall(r'"(.*?)"', line):
+        for entry in re.findall(r'"(.*?[^\\])"', line):
             if entry == "":
                 continue
 


### PR DESCRIPTION
This commit fixes parsing dig TXT RR that contains `"`.