### PR TITLE
[mle] clear tag only on a "Child Update Req" Rx from a detached child

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3598,6 +3598,7 @@ void Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageIn
         tlvs[numTlvs++] = Tlv::kLinkFrameCounter;
         break;
     case kErrorNotFound:
+        challenge.mLength = 0;
         break;
     default:
         ExitNow(error = kErrorParse);
@@ -3655,7 +3656,7 @@ void Mle::HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageIn
     }
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    if (aNeighbor != nullptr)
+    if ((aNeighbor != nullptr) && (challenge.mLength != 0))
     {
         aNeighbor->ClearLastRxFragmentTag();
     }

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2507,7 +2507,14 @@ void MleRouter::HandleChildUpdateRequest(const Message &         aMessage,
     }
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    child->ClearLastRxFragmentTag();
+    // We clear the fragment tag only if the "Child Update Request" is
+    // from a detached child trying to restore its link with its
+    // parent which is indicated by the presence of Challenge TLV in
+    // the message.
+    if (challenge.mLength != 0)
+    {
+        child->ClearLastRxFragmentTag();
+    }
 #endif
 
     SendChildUpdateResponse(child, aMessageInfo, tlvs, tlvslength, challenge);


### PR DESCRIPTION
This commit changes the `MleRouter::HandleChildUpdateRequest()` to
clear the "last rx fragment tag" only if the "Child Update Request" is
from a detached child trying to restore its link with its parent. This
is indicated by the presence of Challenge TLV in the received message.
The "last rx fragment tag" is used for duplicate frame detection when
`MULTI_RADIO` is enabled.