### PR TITLE
[simulation] set key id and frame counter for retransmissions

### DIFF
--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -644,11 +644,8 @@ static otError radioProcessTransmitSecurity(otRadioFrame *aFrame)
 
     aFrame->mInfo.mTxInfo.mAesKey = key;
 
-    if (!aFrame->mInfo.mTxInfo.mIsARetx)
-    {
-        otMacFrameSetKeyId(aFrame, keyId);
-        otMacFrameSetFrameCounter(aFrame, sMacFrameCounter++);
-    }
+    otMacFrameSetKeyId(aFrame, keyId);
+    otMacFrameSetFrameCounter(aFrame, sMacFrameCounter++);
 #else
     otEXPECT(!aFrame->mInfo.mTxInfo.mIsSecurityProcessed);
 #endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2


### PR DESCRIPTION
Frame counter and key index should be set for every frame that is not yet secured.