### PR TITLE
[radio] update docs on frame counter when `RADIO_CAPS_TRANSMIT_SEC`

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (100)
+#define OPENTHREAD_API_VERSION (101)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -230,16 +230,35 @@ typedef struct otRadioFrame
          */
         struct
         {
-            const otMacKey *mAesKey;            ///< The key used for AES-CCM frame security.
-            otRadioIeInfo * mIeInfo;            ///< The pointer to the Header IE(s) related information.
-            uint32_t        mTxDelay;           ///< The delay time for this transmission (based on `mTxDelayBaseTime`).
-            uint32_t        mTxDelayBaseTime;   ///< The base time for the transmission delay.
-            uint8_t         mMaxCsmaBackoffs;   ///< Maximum number of backoffs attempts before declaring CCA failure.
-            uint8_t         mMaxFrameRetries;   ///< Maximum number of retries allowed after a transmission failure.
-            bool            mIsARetx : 1;       ///< True if this frame is a retransmission (ignored by radio driver).
-            bool            mCsmaCaEnabled : 1; ///< Set to true to enable CSMA-CA for this packet, false otherwise.
-            bool            mCslPresent : 1;    ///< Set to true if CSL header IE is present.
-            bool            mIsSecurityProcessed : 1; ///< True if SubMac should skip the AES processing of this frame.
+            const otMacKey *mAesKey;          ///< The key used for AES-CCM frame security.
+            otRadioIeInfo * mIeInfo;          ///< The pointer to the Header IE(s) related information.
+            uint32_t        mTxDelay;         ///< The delay time for this transmission (based on `mTxDelayBaseTime`).
+            uint32_t        mTxDelayBaseTime; ///< The base time for the transmission delay.
+            uint8_t         mMaxCsmaBackoffs; ///< Maximum number of backoffs attempts before declaring CCA failure.
+            uint8_t         mMaxFrameRetries; ///< Maximum number of retries allowed after a transmission failure.
+
+            /**
+             * Indicates whether the frame is a retransmission or not.
+             *
+             * If the platform layer does not provide `OT_RADIO_CAPS_TRANSMIT_SEC` capability, it can ignore this flag.
+             *
+             * If the platform provides `OT_RADIO_CAPS_TRANSMIT_SEC` capability, then platform is expected to handle tx
+             * security processing and assignment of frame counter. In this case the following behavior is expected:
+             *
+             * When `mIsARetx` is set, it indicates that OpenThread core has already set the frame counter and key id
+             * (if security is enabled) in the prepared frame. The counter is ensured to match the counter value from
+             * the previous attempts of the same frame. The platform should not assign or change the frame counter (but
+             * may still need to perform security processing depending on `mIsSecurityProcessed` flag).
+             *
+             * If `mIsARetx` is not set, then the frame counter and key id are not set in the frame by OpenThread core
+             * and it is the responsibility of the radio platform to assign them. The platform should update the frame
+             * (assign counter and key id) even if the transmission gets aborted or fails (e.g., channel access error).
+             *
+             */
+            bool mIsARetx : 1;
+            bool mCsmaCaEnabled : 1;       ///< Set to true to enable CSMA-CA for this packet, false otherwise.
+            bool mCslPresent : 1;          ///< Set to true if CSL header IE is present.
+            bool mIsSecurityProcessed : 1; ///< True if SubMac should skip the AES processing of this frame.
         } mTxInfo;
 
         /**


### PR DESCRIPTION
This commit updates documentations in `radio.h` and adds more detail
on expected behavior on assigning of the frame counter (on retx or
first attempt frame) when radio provides `OT_RADIO_CAPS_TRANSMIT_SEC`
capability (i.e., radio platform layer handles the tx security and
frame counter management).

--------

It is related to PRs https://github.com/openthread/openthread/pull/6427 and https://github.com/openthread/openthread/pull/6446.