### PR TITLE
[cmake] export compile commands

### DIFF
--- a/script/cmake-build
+++ b/script/cmake-build
@@ -181,7 +181,7 @@ build()
     mkdir -p "${builddir}"
     cd "${builddir}"
 
-    cmake -GNinja -DOT_COMPILE_WARNING_AS_ERROR=ON "$@" "${OT_SRCDIR}"
+    cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DOT_COMPILE_WARNING_AS_ERROR=ON "$@" "${OT_SRCDIR}"
 
     if [[ -n ${OT_CMAKE_NINJA_TARGET[*]} ]]; then
         ninja "${OT_CMAKE_NINJA_TARGET[@]}"


### PR DESCRIPTION
This commit adds the option CMAKE_EXPORT_COMPILE_COMMANDS=ON to export
compile commands which is helpful for editors/IDEs.