### PR TITLE
[nrf528xx] set frame counter and key idx in otPlatRadioTransmit()

### DIFF
--- a/examples/platforms/nrf528xx/src/radio.c
+++ b/examples/platforms/nrf528xx/src/radio.c
@@ -509,6 +509,12 @@ otError otPlatRadioTransmit(otInstance *aInstance, otRadioFrame *aFrame)
     }
 
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
+    if (otMacFrameIsSecurityEnabled(aFrame) && otMacFrameIsKeyIdMode1(aFrame) && !aFrame->mInfo.mTxInfo.mIsARetx)
+    {
+        otMacFrameSetKeyId(aFrame, sKeyId);
+        otMacFrameSetFrameCounter(aFrame, sMacFrameCounter++);
+    }
+
     if (aFrame->mInfo.mTxInfo.mTxDelay != 0)
     {
         if (!nrf_802154_transmit_raw_at(&aFrame->mPsdu[-1], true, aFrame->mInfo.mTxInfo.mTxDelayBaseTime,
@@ -1221,9 +1227,6 @@ void nrf_802154_tx_started(const uint8_t *aFrame)
              !sTransmitFrame.mInfo.mTxInfo.mIsSecurityProcessed);
 
     sTransmitFrame.mInfo.mTxInfo.mAesKey = &sCurrKey;
-
-    otMacFrameSetKeyId(&sTransmitFrame, sKeyId);
-    otMacFrameSetFrameCounter(&sTransmitFrame, sMacFrameCounter++);
 
     processSecurity = true;
 #endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2


### PR DESCRIPTION
This change tackles both problems resolved and introduced by https://github.com/openthread/openthread/pull/6427.

For direct transmissions, if the first frame transmission fails, e.g. due to a CCA failure then retransmissions will contain an invalid frame counter. It causes problems especially for long IP packets - the receiver drops a fragment but the transmitter will flood it with the next fragments since it is not aware that the other party dropped a fragment. We have identified that it's a root cause of the problem reported in https://github.com/openthread/openthread/issues/6337.

Previous solution (remove the check if a frame is retransmitted) may cause problems with indirect transmissions where radio frames are created from scratch and then their frame counter would be overridden. That is why the best place for setting frame counter and key index in otPlatRadioTransmit().
