### PR TITLE
[trel] initialize TREL interface in `AfterInit`

### DIFF
--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -37,6 +37,7 @@
 
 #include "common/logging.hpp"
 #include "common/new.hpp"
+#include "radio/trel_link.hpp"
 #include "utils/heap.hpp"
 
 namespace ot {
@@ -175,6 +176,10 @@ void Instance::AfterInit(void)
 
     Get<Settings>().Init();
     IgnoreError(Get<Mle::MleRouter>().Restore());
+
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+    Get<Trel::Link>().AfterInit();
+#endif
 
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 

--- a/src/core/radio/trel_interface.cpp
+++ b/src/core/radio/trel_interface.cpp
@@ -54,7 +54,7 @@ void Interface::Init(void)
 {
     Ip6::Address ip6Address;
 
-    VerifyOrExit(!mInitialized);
+    OT_ASSERT(!mInitialized);
 
     ip6Address.SetToLinkLocalAddress(Get<Mac::Mac>().GetExtAddress());
     otPlatTrelUdp6Init(&GetInstance(), &ip6Address, kUdpPort);
@@ -63,9 +63,6 @@ void Interface::Init(void)
     otPlatTrelUdp6SubscribeMulticastAddress(&GetInstance(), &ip6Address);
 
     mInitialized = true;
-
-exit:
-    return;
 }
 
 void Interface::HandleExtAddressChange(void)

--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -65,15 +65,13 @@ Link::Link(Instance &aInstance)
     mRxFrame.SetRadioType(Mac::kRadioTypeTrel);
 #endif
 
-    // `mTxTasklet` is used for initializing the interface (in addition
-    // to handling `Send()` requests). Invoking `Interface::Init()` from
-    // a tasklet ensures that it happens after the constructors for
-    // `Instance` and all its objects are done, allowing the interface
-    // to safely use any of the core object methods (e.g., get the
-    // randomly generated MAC address).
-
     mTxTasklet.Post();
     mTimer.Start(kAckWaitWindow);
+}
+
+void Link::AfterInit(void)
+{
+    mInterface.Init();
 }
 
 void Link::Enable(void)
@@ -120,11 +118,6 @@ void Link::HandleTxTasklet(Tasklet &aTasklet)
 
 void Link::HandleTxTasklet(void)
 {
-    if (!mInterface.IsInitialized())
-    {
-        mInterface.Init();
-    }
-
     BeginTransmit();
 }
 

--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -65,7 +65,6 @@ Link::Link(Instance &aInstance)
     mRxFrame.SetRadioType(Mac::kRadioTypeTrel);
 #endif
 
-    mTxTasklet.Post();
     mTimer.Start(kAckWaitWindow);
 }
 

--- a/src/core/radio/trel_link.hpp
+++ b/src/core/radio/trel_link.hpp
@@ -166,6 +166,7 @@ private:
         kStateTransmit,
     };
 
+    void AfterInit(void);
     void SetState(State aState);
     void BeginTransmit(void);
     void InvokeSendDone(Error aError) { InvokeSendDone(aError, nullptr); }


### PR DESCRIPTION
to avoid checking `mInitialized` repeatedly in TX tasklet.