### PR TITLE
[border-agent] add logging for border agent events

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -21,7 +21,7 @@ Done
 
 ## OpenThread Command List
 
-- [ba](#ba-port)
+- [ba](#ba)
 - [bbr](#bbr)
 - [br](#br)
 - [bufferinfo](#bufferinfo)
@@ -317,6 +317,10 @@ Set jitter (in seconds) for Backbone Router registration for Thread 1.2 FTD.
 Done
 ```
 
+### ba
+
+Show current Border Agent information.
+
 ### ba port
 
 Print border agent service port.
@@ -324,6 +328,16 @@ Print border agent service port.
 ```bash
 > ba port
 49152
+Done
+```
+
+### ba state
+
+Print border agent state.
+
+```bash
+> ba state
+Started
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -290,9 +290,37 @@ otError Interpreter::ProcessBorderAgent(uint8_t aArgsLength, char *aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aArgsLength == 1 && strcmp(aArgs[0], "port") == 0, error = OT_ERROR_INVALID_COMMAND);
+    VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
 
-    OutputLine("%hu", otBorderAgentGetUdpPort(mInstance));
+    if (strcmp(aArgs[0], "port") == 0)
+    {
+        OutputLine("%hu", otBorderAgentGetUdpPort(mInstance));
+    }
+    else if (strcmp(aArgs[0], "state") == 0)
+    {
+        const char *state;
+
+        switch (otBorderAgentGetState(mInstance))
+        {
+        case OT_BORDER_AGENT_STATE_STOPPED:
+            state = "Stopped";
+            break;
+        case OT_BORDER_AGENT_STATE_STARTED:
+            state = "Started";
+            break;
+        case OT_BORDER_AGENT_STATE_ACTIVE:
+            state = "Active";
+            break;
+        default:
+            state = "Unknown";
+            break;
+        }
+        OutputLine(state);
+    }
+    else
+    {
+        ExitNow(error = OT_ERROR_INVALID_COMMAND);
+    }
 
 exit:
     return error;

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -307,11 +307,11 @@ void BorderAgent::HandleNotifierEvents(Events aEvents)
 
     if (Get<Mle::MleRouter>().IsAttached())
     {
-        IgnoreError(Start());
+        Start();
     }
     else
     {
-        IgnoreError(Stop());
+        Stop();
     }
 
 exit:
@@ -579,7 +579,7 @@ uint16_t BorderAgent::GetUdpPort(void) const
     return Get<Coap::CoapSecure>().GetUdpPort();
 }
 
-Error BorderAgent::Start(void)
+void BorderAgent::Start(void)
 {
     Error             error;
     Coap::CoapSecure &coaps = Get<Coap::CoapSecure>();
@@ -606,8 +606,13 @@ Error BorderAgent::Start(void)
     mState        = kStateStarted;
     mUdpProxyPort = 0;
 
+    otLogInfoMeshCoP("Border Agent start listening on port %d", kBorderAgentUdpPort);
+
 exit:
-    return error;
+    if (error != kErrorNone)
+    {
+        otLogWarnMeshCoP("failed to start Border Agent on port %d: %s", kBorderAgentUdpPort, ErrorToString(error));
+    }
 }
 
 void BorderAgent::HandleTimeout(Timer &aTimer)
@@ -624,12 +629,11 @@ void BorderAgent::HandleTimeout(void)
     }
 }
 
-Error BorderAgent::Stop(void)
+void BorderAgent::Stop(void)
 {
-    Error             error = kErrorNone;
     Coap::CoapSecure &coaps = Get<Coap::CoapSecure>();
 
-    VerifyOrExit(mState != kStateStopped, error = kErrorAlready);
+    VerifyOrExit(mState != kStateStopped);
 
     mTimer.Stop();
 
@@ -651,8 +655,10 @@ Error BorderAgent::Stop(void)
     mState        = kStateStopped;
     mUdpProxyPort = 0;
 
+    otLogInfoMeshCoP("Border Agent stopped");
+
 exit:
-    return error;
+    return;
 }
 
 void BorderAgent::ApplyMeshLocalPrefix(void)

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -85,20 +85,14 @@ public:
     /**
      * This method starts the Border Agent service.
      *
-     * @retval kErrorNone    Successfully started the Border Agent service.
-     * @retval kErrorAlready Border Agent is already started.
-     *
      */
-    Error Start(void);
+    void Start(void);
 
     /**
      * This method stops the Border Agent service.
      *
-     * @retval kErrorNone    Successfully stopped the Border Agent service.
-     * @retval kErrorAlready Border Agent is already stopped.
-     *
      */
-    Error Stop(void);
+    void Stop(void);
 
     /**
      * This method gets the state of the Border Agent service.

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -304,8 +304,7 @@ Error Commissioner::Start(otCommissionerStateCallback  aStateCallback,
     VerifyOrExit(mState == kStateDisabled, error = kErrorAlready);
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    error = Get<MeshCoP::BorderAgent>().Stop();
-    VerifyOrExit(error == kErrorNone || error == kErrorAlready);
+    Get<MeshCoP::BorderAgent>().Stop();
 #endif
 
     SuccessOrExit(error = Get<Coap::CoapSecure>().Start(SendRelayTransmit, this));
@@ -358,6 +357,10 @@ Error Commissioner::Stop(bool aResign)
     {
         SendKeepAlive();
     }
+
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
+    Get<MeshCoP::BorderAgent>().Start();
+#endif
 
 exit:
     LogError("stop commissioner", error);

--- a/tests/scripts/expect/cli-misc.exp
+++ b/tests/scripts/expect/cli-misc.exp
@@ -170,4 +170,7 @@ expect ": InvalidState"
 send "ba port\n"
 expect "Done"
 
+send "ba state\n"
+expect "Done"
+
 dispose_all


### PR DESCRIPTION
This PR includes several small changes:
1. Add logs for Border Agent `Start` and `Stop` events to help analysis commissioning issues such as https://github.com/openthread/ot-commissioner/issues/193#issuecomment-822120350.
2. Start Border Agent when the native commissioner is stopped.
3. Add CLI command `ba state` to get current Border Agent state.