### PR TITLE
[neighbor-table] fix finding neighbor by Ip6 address issue

### DIFF
--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -151,7 +151,7 @@ Neighbor *NeighborTable::FindNeighbor(const Ip6::Address &aIp6Address, Neighbor:
 
     if (!macAddress.IsNone())
     {
-        neighbor = FindChildOrRouter(Neighbor::AddressMatcher(macAddress, aFilter));
+        neighbor = FindNeighbor(Neighbor::AddressMatcher(macAddress, aFilter));
         ExitNow();
     }
 


### PR DESCRIPTION
Currently, if using `FindNeighbor(const Ip6::Address &aIp6Address, Neighbor::StateFilter aFilter)` when the `aIp6Address` is the device's parent's link local address, it cannot be found. This PR fixes this issue.

This PR fixes part of #6479 