### PR TITLE
[thread-cert] use `OT_TREL=OFF` for OTBR docker build

### DIFF
--- a/script/test
+++ b/script/test
@@ -263,7 +263,19 @@ do_build_otbr_docker()
     echo "Building OTBR Docker ..."
     local otdir
     local otbrdir
-    local otbr_options="-DOTBR_DNSSD_DISCOVERY_PROXY=ON -DOT_DNS_CLIENT=ON -DOT_SRP_CLIENT=ON -DOT_SLAAC=ON -DOT_DUA=ON -DOT_MLR=ON -DOT_COVERAGE=ON -DOTBR_REST=OFF -DOTBR_WEB=OFF -DOTBR_DUA_ROUTING=ON"
+    local otbr_options=(
+        "-DOTBR_DNSSD_DISCOVERY_PROXY=ON"
+        "-DOT_DNS_CLIENT=ON"
+        "-DOT_SRP_CLIENT=ON"
+        "-DOT_SLAAC=ON"
+        "-DOT_DUA=ON"
+        "-DOT_MLR=ON"
+        "-DOT_COVERAGE=ON"
+        "-DOT_TREL=OFF"
+        "-DOTBR_REST=OFF"
+        "-DOTBR_WEB=OFF"
+        "-DOTBR_DUA_ROUTING=ON"
+    )
     local otbr_docker_image=${OTBR_DOCKER_IMAGE:-otbr-ot12-backbone-ci}
 
     otbrdir=$(mktemp -d -t otbr_XXXXXX)
@@ -282,7 +294,7 @@ do_build_otbr_docker()
             --build-arg REFERENCE_DEVICE=1 \
             --build-arg OT_BACKBONE_CI=1 \
             --build-arg NAT64=0 \
-            --build-arg OTBR_OPTIONS="${otbr_options}"
+            --build-arg OTBR_OPTIONS="${otbr_options[*]}"
     )
 
     rm -rf "${otbrdir}"

--- a/script/test
+++ b/script/test
@@ -264,17 +264,16 @@ do_build_otbr_docker()
     local otdir
     local otbrdir
     local otbr_options=(
-        "-DOTBR_DNSSD_DISCOVERY_PROXY=ON"
+        "-DOT_COVERAGE=ON"
         "-DOT_DNS_CLIENT=ON"
-        "-DOT_SRP_CLIENT=ON"
-        "-DOT_SLAAC=ON"
         "-DOT_DUA=ON"
         "-DOT_MLR=ON"
-        "-DOT_COVERAGE=ON"
+        "-DOT_SLAAC=ON"
+        "-DOT_SRP_CLIENT=ON"
         "-DOT_TREL=OFF"
+        "-DOTBR_DUA_ROUTING=ON"
         "-DOTBR_REST=OFF"
         "-DOTBR_WEB=OFF"
-        "-DOTBR_DUA_ROUTING=ON"
     )
     local otbr_docker_image=${OTBR_DOCKER_IMAGE:-otbr-ot12-backbone-ci}
 


### PR DESCRIPTION
Since `OT_TREL` is going to be set to `ON` in OTBR, this commit makes sure we test OTBR with TREL off.

- Also removed `-DOTBR_DNSSD_DISCOVERY_PROXY=ON` since it's now ON by default.