### PR TITLE
[cli] add cli to get All Thread Nodes multicast address

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (106)
+#define OPENTHREAD_API_VERSION (107)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -467,6 +467,40 @@ otError otThreadSetMeshLocalPrefix(otInstance *aInstance, const otMeshLocalPrefi
 const otIp6Address *otThreadGetLinkLocalIp6Address(otInstance *aInstance);
 
 /**
+ * This function returns the Thread Link-Local All Thread Nodes multicast address.
+ *
+ * The address is a link-local Unicast Prefix-Based Multcast Address [RFC 3306], with:
+ *   - flgs set to 3 (P = 1 and T = 1)
+ *   - scop set to 2
+ *   - plen set to 64
+ *   - network prefix set to the Mesh Local Prefix
+ *   - group ID set to 1
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ * @returns A pointer to Thread Link-Local All Thread Nodes multicast address.
+ *
+ */
+const otIp6Address *otThreadGetLinkLocalAllThreadNodesMulticastAddress(otInstance *aInstance);
+
+/**
+ * This function returns the Thread Realm-Local All Thread Nodes multicast address.
+ *
+ * The address is a realm-local Unicast Prefix-Based Multcast Address [RFC 3306], with:
+ *   - flgs set to 3 (P = 1 and T = 1)
+ *   - scop set to 3
+ *   - plen set to 64
+ *   - network prefix set to the Mesh Local Prefix
+ *   - group ID set to 1
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ * @returns A pointer to Thread Realm-Local All Thread Nodes multicast address.
+ *
+ */
+const otIp6Address *otThreadGetRealmLocalAllThreadNodesMulticastAddress(otInstance *aInstance);
+
+/**
  * Get the Thread Network Name.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1307,6 +1307,16 @@ Unsubscribe the Thread interface to the IPv6 multicast address.
 Done
 ```
 
+### ipmaddr llatn
+
+Get the Link-Local All Thread Nodes multicast address.
+
+```
+> ipmaddr llatn
+ff32:40:fdde:ad00:beef:0:0:1
+Done
+```
+
 ### ipmaddr promiscuous
 
 Get multicast promiscuous mode.
@@ -1332,6 +1342,16 @@ Disable multicast promiscuous mode.
 
 ```bash
 > ipmaddr promiscuous disable
+Done
+```
+
+### ipmaddr rlatn
+
+Get the Realm-Local All Thread Nodes multicast address.
+
+```
+> ipmaddr rlatn
+ff33:40:fdde:ad00:beef:0:0:1
 Done
 ```
 
@@ -1992,6 +2012,16 @@ Note: The Domain Prefix flag (`D`) is only available for Thread 1.2.
 Done
 
 > prefix add fd00:7d03:7d03:7d03::/64 prosD med
+Done
+```
+
+### prefix meshlocal
+
+Get the mesh local prefix.
+
+```bash
+> prefix meshlocal
+fdde:ad00:beef:0::/64
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2091,6 +2091,16 @@ otError Interpreter::ProcessIpMulticastAddr(uint8_t aArgsLength, char *aArgs[])
         {
             SuccessOrExit(error = ProcessMulticastPromiscuous(aArgsLength - 1, aArgs + 1));
         }
+        else if (strcmp(aArgs[0], "llatn") == 0)
+        {
+            OutputIp6Address(*otThreadGetLinkLocalAllThreadNodesMulticastAddress(mInstance));
+            OutputLine("");
+        }
+        else if (strcmp(aArgs[0], "rlatn") == 0)
+        {
+            OutputIp6Address(*otThreadGetRealmLocalAllThreadNodesMulticastAddress(mInstance));
+            OutputLine("");
+        }
         else
         {
             ExitNow(error = OT_ERROR_INVALID_COMMAND);
@@ -3612,6 +3622,11 @@ otError Interpreter::ProcessPrefix(uint8_t aArgsLength, char *aArgs[])
     {
         SuccessOrExit(error = ProcessPrefixRemove(aArgsLength - 1, aArgs + 1));
     }
+    else if (strcmp(aArgs[0], "meshlocal") == 0)
+    {
+        OutputPrefix(*otThreadGetMeshLocalPrefix(mInstance));
+        OutputLine("");
+    }
     else
     {
         ExitNow(error = OT_ERROR_INVALID_COMMAND);
@@ -4874,6 +4889,12 @@ void Interpreter::ProcessLine(char *aBuf)
 
 exit:
     return;
+}
+
+void Interpreter::OutputPrefix(const otMeshLocalPrefix &aPrefix)
+{
+    OutputFormat("%x:%x:%x:%x::/64", (aPrefix.m8[0] << 8) | aPrefix.m8[1], (aPrefix.m8[2] << 8) | aPrefix.m8[3],
+                 (aPrefix.m8[4] << 8) | aPrefix.m8[5], (aPrefix.m8[6] << 8) | aPrefix.m8[7]);
 }
 
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -463,6 +463,7 @@ private:
     otError ProcessNetworkDataPrefix(void);
     otError ProcessNetworkDataRoute(void);
     otError ProcessNetworkDataService(void);
+    void    OutputPrefix(const otMeshLocalPrefix &aPrefix);
     void    OutputPrefix(const otBorderRouterConfig &aConfig);
     void    OutputRoute(const otExternalRouteConfig &aConfig);
     void    OutputService(const otServiceConfig &aConfig);

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -179,6 +179,20 @@ const otIp6Address *otThreadGetLinkLocalIp6Address(otInstance *aInstance)
     return &instance.Get<Mle::MleRouter>().GetLinkLocalAddress();
 }
 
+const otIp6Address *otThreadGetLinkLocalAllThreadNodesMulticastAddress(otInstance *aInstance)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return &instance.Get<Mle::MleRouter>().GetLinkLocalAllThreadNodesAddress();
+}
+
+const otIp6Address *otThreadGetRealmLocalAllThreadNodesMulticastAddress(otInstance *aInstance)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return &instance.Get<Mle::MleRouter>().GetRealmLocalAllThreadNodesAddress();
+}
+
 const char *otThreadGetNetworkName(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);

--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -172,6 +172,15 @@ proc get_extaddr {} {
     return $rval
 }
 
+proc get_meshlocal_prefix {} {
+    send "prefix meshlocal\n"
+    expect -re {[\r\n ](([0-9a-fA-F]{1,4}:){3}[0-9a-fA-f]{1,4})::/64(?=[\r\n>])}
+    set rval $expect_out(1,string)
+    expect_line "Done"
+
+    return $rval
+}
+
 proc get_rloc16 {} {
     send "rloc16\n"
     expect "rloc16"

--- a/tests/scripts/expect/cli-ipmaddr.exp
+++ b/tests/scripts/expect/cli-ipmaddr.exp
@@ -40,6 +40,15 @@ expect "ff0e:0:0:0:0:0:0:1"
 expect_line "Done"
 set addr [get_ipaddr mleid]
 
+set prefix [get_meshlocal_prefix]
+
+send "ipmaddr llatn\n"
+expect "ff32:40:$prefix:0:1"
+expect_line "Done"
+send "ipmaddr rlatn\n"
+expect "ff33:40:$prefix:0:1"
+expect_line "Done"
+
 switch_node 2
 send "ping ff0e::1\n"
 expect_line "Done"

--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -1468,6 +1468,14 @@ class OTCI(object):
         """Disable multicast promiscuous mode."""
         self.execute_command('ipmaddr promiscuous disable')
 
+    def get_ipmaddr_llatn(self) -> Ip6Addr:
+        """Get Link Local All Thread Nodes Multicast Address"""
+        return self.__parse_ip6addr(self.execute_command('ipmaddr llatn'))
+
+    def get_ipmaddr_rlatn(self) -> Ip6Addr:
+        """Get Realm Local All Thread Nodes Multicast Address"""
+        return self.__parse_ip6addr(self.execute_command('ipmaddr rlatn'))
+
     #
     # Backbone Router Utilities
     #

--- a/tools/otci/tests/test_otci.py
+++ b/tools/otci/tests/test_otci.py
@@ -196,6 +196,8 @@ class TestOTCI(unittest.TestCase):
         self.assertTrue(leader.get_ipaddr_rloc())
         self.assertTrue(leader.get_ipaddr_linklocal())
         self.assertTrue(leader.get_ipaddr_mleid())
+        self.assertTrue(leader.get_ipmaddr_llatn())
+        self.assertTrue(leader.get_ipmaddr_rlatn())
 
         leader.add_ipaddr('2001::1')
         leader.del_ipaddr('2001::1')


### PR DESCRIPTION
This PR adds APIs to get Link/Realm Local All Thread Nodes multicast
addresses. This PR also adds cli command to get meshlocal prefix 
alone for writing tests.