### PR TITLE
[posix-trel] support TREL URL

### DIFF
--- a/src/lib/url/url.cpp
+++ b/src/lib/url/url.cpp
@@ -47,6 +47,7 @@ otError Url::Init(char *aUrl)
 
     url = strstr(aUrl, "://");
     VerifyOrExit(url != nullptr, error = OT_ERROR_PARSE);
+    *url = '\0';
     url += sizeof("://") - 1;
     mPath = url;
 

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -150,7 +150,6 @@ enum
     OT_POSIX_OPT_HELP                    = 'h',
     OT_POSIX_OPT_INTERFACE_NAME          = 'I',
     OT_POSIX_OPT_TIME_SPEED              = 's',
-    OT_POSIX_OPT_TREL_INTERFACE          = 't',
     OT_POSIX_OPT_VERBOSE                 = 'v',
 
     OT_POSIX_OPT_SHORT_MAX = 128,
@@ -168,7 +167,6 @@ static const struct option kOptions[] = {
     {"radio-version", no_argument, NULL, OT_POSIX_OPT_RADIO_VERSION},
     {"real-time-signal", required_argument, NULL, OT_POSIX_OPT_REAL_TIME_SIGNAL},
     {"time-speed", required_argument, NULL, OT_POSIX_OPT_TIME_SPEED},
-    {"trel-interface", required_argument, NULL, OT_POSIX_OPT_TREL_INTERFACE},
     {"verbose", no_argument, NULL, OT_POSIX_OPT_VERBOSE},
     {0, 0, 0, 0}};
 
@@ -176,7 +174,7 @@ static void PrintUsage(const char *aProgramName, FILE *aStream, int aExitCode)
 {
     fprintf(aStream,
             "Syntax:\n"
-            "    %s [Options] RadioURL\n"
+            "    %s [Options] RadioURL [RadioURL]\n"
             "Options:\n"
             "    -B  --backbone-interface-name Backbone network interface name.\n"
             "    -d  --debug-level             Debug level of logging.\n"
@@ -185,7 +183,6 @@ static void PrintUsage(const char *aProgramName, FILE *aStream, int aExitCode)
             "    -n  --dry-run                 Just verify if arguments is valid and radio spinel is compatible.\n"
             "        --radio-version           Print radio firmware version.\n"
             "    -s  --time-speed factor       Time speed up factor.\n"
-            "    -t  --trel-interface name   Interface name for TREL platform (e.g., wlan0 netif).\n"
             "    -v  --verbose                 Also log to stderr.\n",
             aProgramName);
 #ifdef __linux__
@@ -213,7 +210,7 @@ static void ParseArg(int aArgCount, char *aArgVector[], PosixConfig *aConfig)
     while (true)
     {
         int index  = 0;
-        int option = getopt_long(aArgCount, aArgVector, "B:d:hI:t:ns:v", kOptions, &index);
+        int option = getopt_long(aArgCount, aArgVector, "B:d:hI:ns:v", kOptions, &index);
 
         if (option == -1)
         {
@@ -233,9 +230,6 @@ static void ParseArg(int aArgCount, char *aArgVector[], PosixConfig *aConfig)
             break;
         case OT_POSIX_OPT_BACKBONE_INTERFACE_NAME:
             aConfig->mPlatformConfig.mBackboneInterfaceName = optarg;
-            break;
-        case OT_POSIX_OPT_TREL_INTERFACE:
-            aConfig->mPlatformConfig.mTrelInterface = optarg;
             break;
         case OT_POSIX_OPT_DRY_RUN:
             aConfig->mIsDryRun = true;
@@ -280,11 +274,17 @@ static void ParseArg(int aArgCount, char *aArgVector[], PosixConfig *aConfig)
         }
     }
 
-    if (optind >= aArgCount)
+    for (; optind < aArgCount; optind++)
+    {
+        VerifyOrDie(aConfig->mPlatformConfig.mRadioUrlNum < OT_ARRAY_LENGTH(aConfig->mPlatformConfig.mRadioUrls),
+                    OT_EXIT_INVALID_ARGUMENTS);
+        aConfig->mPlatformConfig.mRadioUrls[aConfig->mPlatformConfig.mRadioUrlNum++] = aArgVector[optind];
+    }
+
+    if (aConfig->mPlatformConfig.mRadioUrlNum == 0)
     {
         PrintUsage(aArgVector[0], stderr, OT_EXIT_INVALID_ARGUMENTS);
     }
-    aConfig->mPlatformConfig.mRadioUrl = aArgVector[optind];
 }
 
 static void PrintRadioUrl(void *aContext, uint8_t aArgsLength, char *aArgs[])
@@ -292,8 +292,14 @@ static void PrintRadioUrl(void *aContext, uint8_t aArgsLength, char *aArgs[])
     (void)aArgsLength;
     (void)aArgs;
 
+    uint8_t i;
+
     otPlatformConfig *config = (otPlatformConfig *)aContext;
-    otCliOutputFormat("%s\r\nDone\r\n", config->mRadioUrl);
+    for (i = 0; i < config->mRadioUrlNum; i++)
+    {
+        otCliOutputFormat("%s\r\n", config->mRadioUrls[i]);
+    }
+    otCliOutputFormat("Done\r\n");
 }
 
 static otInstance *InitInstance(PosixConfig *aConfig)

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -62,7 +62,8 @@ enum
     OT_PLATFORM_CONFIG_SPI_DEFAULT_ALIGN_ALLOWANCE =
         16, ///< Default maximum number of 0xFF bytes to clip from start of MISO frame.
     OT_PLATFORM_CONFIG_SPI_DEFAULT_SMALL_PACKET_SIZE =
-        32, ///< Default smallest SPI packet size we can receive in a single transaction.
+        32,                                ///< Default smallest SPI packet size we can receive in a single transaction.
+    OT_PLATFORM_CONFIG_MAX_RADIO_URLS = 2, ///< Max number of Radio URLs.
 };
 
 /**
@@ -71,12 +72,12 @@ enum
  */
 typedef struct otPlatformConfig
 {
-    const char *mBackboneInterfaceName; ///< Backbone network interface name.
-    const char *mInterfaceName;         ///< Thread network interface name.
-    const char *mRadioUrl;              ///< Radio url.
-    int         mRealTimeSignal;        ///< The real-time signal for microsecond timer.
-    uint32_t    mSpeedUpFactor;         ///< Speed up factor.
-    const char *mTrelInterface;         ///< Interface name used by TREL radio link (can be NULL to use default).
+    const char *mBackboneInterfaceName;                        ///< Backbone network interface name.
+    const char *mInterfaceName;                                ///< Thread network interface name.
+    const char *mRadioUrls[OT_PLATFORM_CONFIG_MAX_RADIO_URLS]; ///< Radio URLs.
+    uint8_t     mRadioUrlNum;                                  ///< Number of Radio URLs.
+    int         mRealTimeSignal;                               ///< The real-time signal for microsecond timer.
+    uint32_t    mSpeedUpFactor;                                ///< Speed up factor.
 } otPlatformConfig;
 
 /**

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -67,10 +67,51 @@ static void processStateChange(otChangedFlags aFlags, void *aContext)
 }
 #endif
 
+static const char *get802154RadioUrl(otPlatformConfig *aPlatformConfig)
+{
+    const char *radioUrl = nullptr;
+
+    for (uint8_t i = 0; i < aPlatformConfig->mRadioUrlNum; i++)
+    {
+        ot::Posix::RadioUrl url(aPlatformConfig->mRadioUrls[i]);
+
+        if (strcmp(url.GetProtocol(), "trel") == 0)
+        {
+            continue;
+        }
+
+        radioUrl = aPlatformConfig->mRadioUrls[i];
+        break;
+    }
+
+    VerifyOrDie(radioUrl != nullptr, OT_EXIT_INVALID_ARGUMENTS);
+    return radioUrl;
+}
+
+#if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
+static const char *getTrelRadioUrl(otPlatformConfig *aPlatformConfig)
+{
+    const char *radioUrl = nullptr;
+
+    for (uint8_t i = 0; i < aPlatformConfig->mRadioUrlNum; i++)
+    {
+        ot::Posix::RadioUrl url(aPlatformConfig->mRadioUrls[i]);
+
+        if (strcmp(url.GetProtocol(), "trel") == 0)
+        {
+            radioUrl = aPlatformConfig->mRadioUrls[i];
+            break;
+        }
+    }
+
+    return radioUrl;
+}
+#endif
+
 otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
 {
     otInstance *        instance = nullptr;
-    ot::Posix::RadioUrl radioUrl(aPlatformConfig->mRadioUrl);
+    ot::Posix::RadioUrl radioUrl(get802154RadioUrl(aPlatformConfig));
 
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
     // The last argument must be the node id
@@ -89,7 +130,7 @@ otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
     platformAlarmInit(aPlatformConfig->mSpeedUpFactor, aPlatformConfig->mRealTimeSignal);
     platformRadioInit(&radioUrl);
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
-    platformTrelInit(aPlatformConfig->mTrelInterface);
+    platformTrelInit(getTrelRadioUrl(aPlatformConfig));
 #endif
     platformRandomInit();
 

--- a/src/posix/platform/trel_udp6.cpp
+++ b/src/posix/platform/trel_udp6.cpp
@@ -57,6 +57,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/logging.hpp"
+#include "posix/platform/radio_url.hpp"
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 
@@ -622,11 +623,13 @@ exit:
 //---------------------------------------------------------------------------------------------------------------------
 // platformTrel system
 
-void platformTrelInit(const char *aInterfaceName)
+void platformTrelInit(const char *aTrelUrl)
 {
-    if (aInterfaceName != NULL)
+    if (aTrelUrl != NULL)
     {
-        strncpy(sInterfaceName, aInterfaceName, sizeof(sInterfaceName));
+        ot::Posix::RadioUrl url(aTrelUrl);
+
+        strncpy(sInterfaceName, url.GetPath(), sizeof(sInterfaceName));
     }
     else
     {


### PR DESCRIPTION
This commit supports TREL URL (e.g. `trel://eth0`) for Posix.

Depends-On: openthread/ot-br-posix#803