### PR TITLE
[github-actions] disable "Generate coverage" step in `cli-ftd-otns` CI test

### DIFF
--- a/.github/workflows/simulation-1.1.yml
+++ b/.github/workflows/simulation-1.1.yml
@@ -111,13 +111,13 @@ jobs:
         path: |
           ./output/*/bin/*.pcap
           ./output/*/bin/*.replay
-    - name: Generate Coverage
-      run: |
-        ./script/test generate_coverage gcc
-    - uses: actions/upload-artifact@v2
-      with:
-        name: cov-cli-ftd-otns
-        path: tmp/coverage.info
+#    - name: Generate Coverage
+#      run: |
+#        ./script/test generate_coverage gcc
+#    - uses: actions/upload-artifact@v2
+#      with:
+#        name: cov-cli-ftd-otns
+#        path: tmp/coverage.info
 
   packet-verification:
     runs-on: ubuntu-20.04


### PR DESCRIPTION

----

This change is temporary fix for https://github.com/openthread/openthread/issues/6520 (simply removing the "coverage" step) to unblock other PRs.