### PR TITLE
[cli] simplify arg checking/parsing with new `Arg` class

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -86,19 +86,8 @@
 #include "common/new.hpp"
 #include "common/string.hpp"
 #include "mac/channel_mask.hpp"
-#include "utils/parse_cmdline.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
-
-using ot::Utils::CmdLineParser::ParseAsBool;
-using ot::Utils::CmdLineParser::ParseAsHexString;
-using ot::Utils::CmdLineParser::ParseAsInt8;
-using ot::Utils::CmdLineParser::ParseAsIp6Address;
-using ot::Utils::CmdLineParser::ParseAsIp6Prefix;
-using ot::Utils::CmdLineParser::ParseAsUint16;
-using ot::Utils::CmdLineParser::ParseAsUint32;
-using ot::Utils::CmdLineParser::ParseAsUint64;
-using ot::Utils::CmdLineParser::ParseAsUint8;
 
 namespace ot {
 namespace Cli {
@@ -181,15 +170,15 @@ int Interpreter::OutputIp6Address(const otIp6Address &aAddress)
         HostSwap16(aAddress.mFields.m16[5]), HostSwap16(aAddress.mFields.m16[6]), HostSwap16(aAddress.mFields.m16[7]));
 }
 
-otError Interpreter::ParseEnableOrDisable(const char *aString, bool &aEnable)
+otError Interpreter::ParseEnableOrDisable(const Arg &aArg, bool &aEnable)
 {
     otError error = OT_ERROR_NONE;
 
-    if (strcmp(aString, "enable") == 0)
+    if (aArg == "enable")
     {
         aEnable = true;
     }
-    else if (strcmp(aString, "disable") == 0)
+    else if (aArg == "disable")
     {
         aEnable = false;
     }
@@ -201,17 +190,17 @@ otError Interpreter::ParseEnableOrDisable(const char *aString, bool &aEnable)
     return error;
 }
 
-otError Interpreter::ParseJoinerDiscerner(char *aString, otJoinerDiscerner &aDiscerner)
+otError Interpreter::ParseJoinerDiscerner(Arg &aArg, otJoinerDiscerner &aDiscerner)
 {
     otError error     = OT_ERROR_NONE;
-    char *  separator = strstr(aString, "/");
+    char *  separator = strstr(aArg.GetCString(), "/");
 
     VerifyOrExit(separator != nullptr, error = OT_ERROR_NOT_FOUND);
 
-    SuccessOrExit(error = ParseAsUint8(separator + 1, aDiscerner.mLength));
+    SuccessOrExit(error = Utils::CmdLineParser::ParseAsUint8(separator + 1, aDiscerner.mLength));
     VerifyOrExit(aDiscerner.mLength > 0 && aDiscerner.mLength <= 64, error = OT_ERROR_INVALID_ARGS);
     *separator = '\0';
-    error      = ParseAsUint64(aString, aDiscerner.mValue);
+    error      = aArg.ParseAsUint64(aDiscerner.mValue);
 
 exit:
     return error;
@@ -219,17 +208,18 @@ exit:
 
 #if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
 
-otError Interpreter::ParsePingInterval(const char *aString, uint32_t &aInterval)
+otError Interpreter::ParsePingInterval(const Arg &aArg, uint32_t &aInterval)
 {
     otError        error    = OT_ERROR_NONE;
+    const char *   string   = aArg.GetCString();
     const uint32_t msFactor = 1000;
     uint32_t       factor   = msFactor;
 
     aInterval = 0;
 
-    while (*aString)
+    while (*string)
     {
-        if ('0' <= *aString && *aString <= '9')
+        if ('0' <= *string && *string <= '9')
         {
             // In the case of seconds, change the base of already calculated value.
             if (factor == msFactor)
@@ -237,7 +227,7 @@ otError Interpreter::ParsePingInterval(const char *aString, uint32_t &aInterval)
                 aInterval *= 10;
             }
 
-            aInterval += static_cast<uint32_t>(*aString - '0') * factor;
+            aInterval += static_cast<uint32_t>(*string - '0') * factor;
 
             // In the case of milliseconds, change the multiplier factor.
             if (factor != msFactor)
@@ -245,7 +235,7 @@ otError Interpreter::ParsePingInterval(const char *aString, uint32_t &aInterval)
                 factor /= 10;
             }
         }
-        else if (*aString == '.')
+        else if (*string == '.')
         {
             // Accept only one dot character.
             VerifyOrExit(factor == msFactor, error = OT_ERROR_INVALID_ARGS);
@@ -258,7 +248,7 @@ otError Interpreter::ParsePingInterval(const char *aString, uint32_t &aInterval)
             ExitNow(error = OT_ERROR_INVALID_ARGS);
         }
 
-        aString++;
+        string++;
     }
 
 exit:
@@ -267,7 +257,7 @@ exit:
 
 #endif // OPENTHREAD_CONFIG_PING_SENDER_ENABLE
 
-otError Interpreter::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessHelp(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -286,17 +276,17 @@ otError Interpreter::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 }
 
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-otError Interpreter::ProcessBorderAgent(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessBorderAgent(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "port") == 0)
+    if (aArgs[0] == "port")
     {
         OutputLine("%hu", otBorderAgentGetUdpPort(mInstance));
     }
-    else if (strcmp(aArgs[0], "state") == 0)
+    else if (aArgs[0] == "state")
     {
         const char *state;
 
@@ -328,7 +318,7 @@ exit:
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-otError Interpreter::ProcessBorderRouting(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessBorderRouting(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
     bool    enable;
@@ -344,7 +334,7 @@ exit:
 #endif
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-otError Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
     otError                error = OT_ERROR_INVALID_COMMAND;
@@ -371,14 +361,14 @@ otError Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[])
     else
     {
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-        if (strcmp(aArgs[0], "mgmt") == 0)
+        if (aArgs[0] == "mgmt")
         {
             if (aArgsLength < 2)
             {
                 ExitNow(error = OT_ERROR_INVALID_COMMAND);
             }
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
-            else if (strcmp(aArgs[1], "dua") == 0)
+            else if (aArgs[1] == "dua")
             {
                 uint8_t                   status;
                 otIp6InterfaceIdentifier *mlIid = nullptr;
@@ -386,11 +376,11 @@ otError Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[])
 
                 VerifyOrExit((aArgsLength == 3 || aArgsLength == 4), error = OT_ERROR_INVALID_ARGS);
 
-                SuccessOrExit(error = ParseAsUint8(aArgs[2], status));
+                SuccessOrExit(error = aArgs[2].ParseAsUint8(status));
 
                 if (aArgsLength == 4)
                 {
-                    SuccessOrExit(error = ParseAsHexString(aArgs[3], iid.mFields.m8));
+                    SuccessOrExit(error = aArgs[3].ParseAsHexString(iid.mFields.m8));
                     mlIid = &iid;
                 }
 
@@ -399,7 +389,7 @@ otError Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[])
             }
 #endif
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
-            else if (strcmp(aArgs[1], "mlr") == 0)
+            else if (aArgs[1] == "mlr")
             {
                 error = ProcessBackboneRouterMgmtMlr(aArgsLength - 2, aArgs + 2);
                 ExitNow();
@@ -418,47 +408,47 @@ exit:
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE && OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
-otError Interpreter::ProcessBackboneRouterMgmtMlr(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessBackboneRouterMgmtMlr(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_INVALID_COMMAND;
 
     VerifyOrExit(aArgsLength >= 1);
 
-    if (!strcmp(aArgs[0], "listener"))
+    if (aArgs[0] == "listener")
     {
         if (aArgsLength == 1)
         {
             PrintMulticastListenersTable();
             error = OT_ERROR_NONE;
         }
-        else if (!strcmp(aArgs[1], "clear"))
+        else if (aArgs[1] == "clear")
         {
             otBackboneRouterMulticastListenerClear(mInstance);
             error = OT_ERROR_NONE;
         }
-        else if (!strcmp(aArgs[1], "add"))
+        else if (aArgs[1] == "add")
         {
             otIp6Address address;
             uint32_t     timeout = 0;
 
             VerifyOrExit(aArgsLength == 3 || aArgsLength == 4, error = OT_ERROR_INVALID_ARGS);
 
-            SuccessOrExit(error = ParseAsIp6Address(aArgs[2], address));
+            SuccessOrExit(error = aArgs[2].ParseAsIp6Address(address));
 
             if (aArgsLength == 4)
             {
-                SuccessOrExit(error = ParseAsUint32(aArgs[3], timeout));
+                SuccessOrExit(error = aArgs[3].ParseAsUint32(timeout));
             }
 
             error = otBackboneRouterMulticastListenerAdd(mInstance, &address, timeout);
         }
     }
-    else if (!strcmp(aArgs[0], "response"))
+    else if (aArgs[0] == "response")
     {
         uint8_t status;
 
         VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
-        SuccessOrExit(error = ParseAsUint8(aArgs[1], status));
+        SuccessOrExit(error = aArgs[1].ParseAsUint8(status));
 
         otBackboneRouterConfigNextMulticastListenerRegistrationResponse(mInstance, status);
     }
@@ -485,7 +475,7 @@ void Interpreter::PrintMulticastListenersTable(void)
 
 #endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE && OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
 
-otError Interpreter::ProcessBackboneRouterLocal(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessBackboneRouterLocal(uint8_t aArgsLength, Arg aArgs[])
 {
     otError                error = OT_ERROR_NONE;
     otBackboneRouterConfig config;
@@ -495,7 +485,7 @@ otError Interpreter::ProcessBackboneRouterLocal(uint8_t aArgsLength, char *aArgs
     {
         otBackboneRouterSetEnabled(mInstance, enable);
     }
-    else if (strcmp(aArgs[0], "jitter") == 0)
+    else if (aArgs[0] == "jitter")
     {
         if (aArgsLength == 1)
         {
@@ -505,15 +495,15 @@ otError Interpreter::ProcessBackboneRouterLocal(uint8_t aArgsLength, char *aArgs
         {
             uint8_t jitter;
 
-            SuccessOrExit(error = ParseAsUint8(aArgs[1], jitter));
+            SuccessOrExit(error = aArgs[1].ParseAsUint8(jitter));
             otBackboneRouterSetRegistrationJitter(mInstance, jitter);
         }
     }
-    else if (strcmp(aArgs[0], "register") == 0)
+    else if (aArgs[0] == "register")
     {
         SuccessOrExit(error = otBackboneRouterRegister(mInstance));
     }
-    else if (strcmp(aArgs[0], "state") == 0)
+    else if (aArgs[0] == "state")
     {
         switch (otBackboneRouterGetState(mInstance))
         {
@@ -528,7 +518,7 @@ otError Interpreter::ProcessBackboneRouterLocal(uint8_t aArgsLength, char *aArgs
             break;
         }
     }
-    else if (strcmp(aArgs[0], "config") == 0)
+    else if (aArgs[0] == "config")
     {
         otBackboneRouterGetConfig(mInstance, &config);
 
@@ -545,17 +535,17 @@ otError Interpreter::ProcessBackboneRouterLocal(uint8_t aArgsLength, char *aArgs
             {
                 VerifyOrExit(argCur + 1 < aArgsLength, error = OT_ERROR_INVALID_ARGS);
 
-                if (strcmp(aArgs[argCur], "seqno") == 0)
+                if (aArgs[argCur] == "seqno")
                 {
-                    SuccessOrExit(error = ParseAsUint8(aArgs[++argCur], config.mSequenceNumber));
+                    SuccessOrExit(error = aArgs[++argCur].ParseAsUint8(config.mSequenceNumber));
                 }
-                else if (strcmp(aArgs[argCur], "delay") == 0)
+                else if (aArgs[argCur] == "delay")
                 {
-                    SuccessOrExit(error = ParseAsUint16(aArgs[++argCur], config.mReregistrationDelay));
+                    SuccessOrExit(error = aArgs[++argCur].ParseAsUint16(config.mReregistrationDelay));
                 }
-                else if (strcmp(aArgs[argCur], "timeout") == 0)
+                else if (aArgs[argCur] == "timeout")
                 {
-                    SuccessOrExit(error = ParseAsUint32(aArgs[++argCur], config.mMlrTimeout));
+                    SuccessOrExit(error = aArgs[++argCur].ParseAsUint32(config.mMlrTimeout));
                 }
                 else
                 {
@@ -576,7 +566,7 @@ exit:
 }
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
 
-otError Interpreter::ProcessDomainName(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDomainName(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -586,7 +576,7 @@ otError Interpreter::ProcessDomainName(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        SuccessOrExit(error = otThreadSetDomainName(mInstance, aArgs[0]));
+        SuccessOrExit(error = otThreadSetDomainName(mInstance, aArgs[0].GetCString()));
     }
 
 exit:
@@ -594,11 +584,11 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
-otError Interpreter::ProcessDua(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDua(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
-    VerifyOrExit(aArgsLength >= 1 && strcmp(aArgs[0], "iid") == 0, error = OT_ERROR_INVALID_COMMAND);
+    VerifyOrExit(aArgsLength >= 1 && (aArgs[0] == "iid"), error = OT_ERROR_INVALID_COMMAND);
 
     switch (aArgsLength)
     {
@@ -614,7 +604,7 @@ otError Interpreter::ProcessDua(uint8_t aArgsLength, char *aArgs[])
         break;
     }
     case 2:
-        if (strcmp(aArgs[1], "clear") == 0)
+        if (aArgs[1] == "clear")
         {
             SuccessOrExit(error = otThreadSetFixedDuaInterfaceIdentifier(mInstance, nullptr));
         }
@@ -622,7 +612,7 @@ otError Interpreter::ProcessDua(uint8_t aArgsLength, char *aArgs[])
         {
             otIp6InterfaceIdentifier iid;
 
-            SuccessOrExit(error = ParseAsHexString(aArgs[1], iid.mFields.m8));
+            SuccessOrExit(error = aArgs[1].ParseAsHexString(iid.mFields.m8));
             SuccessOrExit(error = otThreadSetFixedDuaInterfaceIdentifier(mInstance, &iid));
         }
         break;
@@ -638,7 +628,7 @@ exit:
 
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
-otError Interpreter::ProcessBufferInfo(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessBufferInfo(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -662,7 +652,7 @@ otError Interpreter::ProcessBufferInfo(uint8_t aArgsLength, char *aArgs[])
     return OT_ERROR_NONE;
 }
 
-otError Interpreter::ProcessCcaThreshold(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessCcaThreshold(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
     int8_t  cca;
@@ -674,7 +664,7 @@ otError Interpreter::ProcessCcaThreshold(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        SuccessOrExit(error = ParseAsInt8(aArgs[0], cca));
+        SuccessOrExit(error = aArgs[0].ParseAsInt8(cca));
         SuccessOrExit(error = otPlatRadioSetCcaEnergyDetectThreshold(mInstance, cca));
     }
 
@@ -682,7 +672,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessChannel(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
     uint8_t channel;
@@ -691,16 +681,16 @@ otError Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
     {
         OutputLine("%d", otLinkGetChannel(mInstance));
     }
-    else if (strcmp(aArgs[0], "supported") == 0)
+    else if (aArgs[0] == "supported")
     {
         OutputLine("0x%x", otPlatRadioGetSupportedChannelMask(mInstance));
     }
-    else if (strcmp(aArgs[0], "preferred") == 0)
+    else if (aArgs[0] == "preferred")
     {
         OutputLine("0x%x", otPlatRadioGetPreferredChannelMask(mInstance));
     }
 #if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
-    else if (strcmp(aArgs[0], "monitor") == 0)
+    else if (aArgs[0] == "monitor")
     {
         if (aArgsLength == 1)
         {
@@ -734,11 +724,11 @@ otError Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
                 OutputLine("");
             }
         }
-        else if (strcmp(aArgs[1], "start") == 0)
+        else if (aArgs[1] == "start")
         {
             error = otChannelMonitorSetEnabled(mInstance, true);
         }
-        else if (strcmp(aArgs[1], "stop") == 0)
+        else if (aArgs[1] == "stop")
         {
             error = otChannelMonitorSetEnabled(mInstance, false);
         }
@@ -749,7 +739,7 @@ otError Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
     }
 #endif // OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
 #if OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
-    else if (strcmp(aArgs[0], "manager") == 0)
+    else if (aArgs[0] == "manager")
     {
         if (aArgsLength == 1)
         {
@@ -768,68 +758,68 @@ otError Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
                 OutputLine("favored: %s", supportedMask.ToString().AsCString());
             }
         }
-        else if (strcmp(aArgs[1], "change") == 0)
+        else if (aArgs[1] == "change")
         {
             VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseAsUint8(aArgs[2], channel));
+            SuccessOrExit(error = aArgs[2].ParseAsUint8(channel));
             otChannelManagerRequestChannelChange(mInstance, channel);
         }
 #if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
-        else if (strcmp(aArgs[1], "select") == 0)
+        else if (aArgs[1] == "select")
         {
             bool enable;
 
             VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseAsBool(aArgs[2], enable));
+            SuccessOrExit(error = aArgs[2].ParseAsBool(enable));
             error = otChannelManagerRequestChannelSelect(mInstance, enable);
         }
 #endif
-        else if (strcmp(aArgs[1], "auto") == 0)
+        else if (aArgs[1] == "auto")
         {
             bool enable;
 
             VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseAsBool(aArgs[2], enable));
+            SuccessOrExit(error = aArgs[2].ParseAsBool(enable));
             otChannelManagerSetAutoChannelSelectionEnabled(mInstance, enable);
         }
-        else if (strcmp(aArgs[1], "delay") == 0)
+        else if (aArgs[1] == "delay")
         {
             uint8_t delay;
 
             VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseAsUint8(aArgs[2], delay));
+            SuccessOrExit(error = aArgs[2].ParseAsUint8(delay));
             error = otChannelManagerSetDelay(mInstance, delay);
         }
-        else if (strcmp(aArgs[1], "interval") == 0)
+        else if (aArgs[1] == "interval")
         {
             uint32_t interval;
 
             VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseAsUint32(aArgs[2], interval));
+            SuccessOrExit(error = aArgs[2].ParseAsUint32(interval));
             error = otChannelManagerSetAutoChannelSelectionInterval(mInstance, interval);
         }
-        else if (strcmp(aArgs[1], "supported") == 0)
+        else if (aArgs[1] == "supported")
         {
             uint32_t mask;
 
             VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseAsUint32(aArgs[2], mask));
+            SuccessOrExit(error = aArgs[2].ParseAsUint32(mask));
             otChannelManagerSetSupportedChannels(mInstance, mask);
         }
-        else if (strcmp(aArgs[1], "favored") == 0)
+        else if (aArgs[1] == "favored")
         {
             uint32_t mask;
 
             VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseAsUint32(aArgs[2], mask));
+            SuccessOrExit(error = aArgs[2].ParseAsUint32(mask));
             otChannelManagerSetFavoredChannels(mInstance, mask);
         }
-        else if (strcmp(aArgs[1], "threshold") == 0)
+        else if (aArgs[1] == "threshold")
         {
             uint16_t threshold;
 
             VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseAsUint16(aArgs[2], threshold));
+            SuccessOrExit(error = aArgs[2].ParseAsUint16(threshold));
             otChannelManagerSetCcaFailureRateThreshold(mInstance, threshold);
         }
         else
@@ -840,7 +830,7 @@ otError Interpreter::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
 #endif // OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
     else
     {
-        SuccessOrExit(error = ParseAsUint8(aArgs[0], channel));
+        SuccessOrExit(error = aArgs[0].ParseAsUint8(channel));
         error = otLinkSetChannel(mInstance, channel);
     }
 
@@ -849,7 +839,7 @@ exit:
 }
 
 #if OPENTHREAD_FTD
-otError Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessChild(uint8_t aArgsLength, Arg aArgs[])
 {
     otError     error = OT_ERROR_NONE;
     otChildInfo childInfo;
@@ -858,9 +848,9 @@ otError Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    isTable = (strcmp(aArgs[0], "table") == 0);
+    isTable = (aArgs[0] == "table");
 
-    if (isTable || strcmp(aArgs[0], "list") == 0)
+    if (isTable || (aArgs[0] == "list"))
     {
         uint16_t maxChildren;
 
@@ -909,7 +899,7 @@ otError Interpreter::ProcessChild(uint8_t aArgsLength, char *aArgs[])
         ExitNow();
     }
 
-    SuccessOrExit(error = ParseAsUint16(aArgs[0], childId));
+    SuccessOrExit(error = aArgs[0].ParseAsUint16(childId));
     SuccessOrExit(error = otThreadGetChildInfoById(mInstance, childId, &childInfo));
 
     OutputLine("Child ID: %d", childInfo.mChildId);
@@ -953,7 +943,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessChildIp(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessChildIp(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -983,7 +973,7 @@ otError Interpreter::ProcessChildIp(uint8_t aArgsLength, char *aArgs[])
             }
         }
     }
-    else if (strcmp(aArgs[0], "max") == 0)
+    else if (aArgs[0] == "max")
     {
         if (aArgsLength == 1)
         {
@@ -993,7 +983,7 @@ otError Interpreter::ProcessChildIp(uint8_t aArgsLength, char *aArgs[])
         else if (aArgsLength == 2)
         {
             uint8_t maxIpAddresses;
-            SuccessOrExit(error = ParseAsUint8(aArgs[1], maxIpAddresses));
+            SuccessOrExit(error = aArgs[1].ParseAsUint8(maxIpAddresses));
             SuccessOrExit(error = otThreadSetMaxChildIpAddresses(mInstance, maxIpAddresses));
         }
 #endif
@@ -1013,7 +1003,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessChildMax(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessChildMax(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1025,7 +1015,7 @@ otError Interpreter::ProcessChildMax(uint8_t aArgsLength, char *aArgs[])
     {
         uint16_t maxChildren;
 
-        SuccessOrExit(error = ParseAsUint16(aArgs[0], maxChildren));
+        SuccessOrExit(error = aArgs[0].ParseAsUint16(maxChildren));
         SuccessOrExit(error = otThreadSetMaxAllowedChildren(mInstance, maxChildren));
     }
 
@@ -1035,14 +1025,14 @@ exit:
 #endif // OPENTHREAD_FTD
 
 #if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
-otError Interpreter::ProcessChildSupervision(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessChildSupervision(uint8_t aArgsLength, Arg aArgs[])
 {
     otError  error = OT_ERROR_NONE;
     uint16_t value;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "checktimeout") == 0)
+    if (aArgs[0] == "checktimeout")
     {
         if (aArgsLength == 1)
         {
@@ -1050,7 +1040,7 @@ otError Interpreter::ProcessChildSupervision(uint8_t aArgsLength, char *aArgs[])
         }
         else if (aArgsLength == 2)
         {
-            SuccessOrExit(error = ParseAsUint16(aArgs[1], value));
+            SuccessOrExit(error = aArgs[1].ParseAsUint16(value));
             otChildSupervisionSetCheckTimeout(mInstance, value);
         }
         else
@@ -1059,7 +1049,7 @@ otError Interpreter::ProcessChildSupervision(uint8_t aArgsLength, char *aArgs[])
         }
     }
 #if OPENTHREAD_FTD
-    else if (strcmp(aArgs[0], "interval") == 0)
+    else if (aArgs[0] == "interval")
     {
         if (aArgsLength == 1)
         {
@@ -1067,7 +1057,7 @@ otError Interpreter::ProcessChildSupervision(uint8_t aArgsLength, char *aArgs[])
         }
         else if (aArgsLength == 2)
         {
-            SuccessOrExit(error = ParseAsUint16(aArgs[1], value));
+            SuccessOrExit(error = aArgs[1].ParseAsUint16(value));
             otChildSupervisionSetInterval(mInstance, value);
         }
         else
@@ -1086,7 +1076,7 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
 
-otError Interpreter::ProcessChildTimeout(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessChildTimeout(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1098,7 +1088,7 @@ otError Interpreter::ProcessChildTimeout(uint8_t aArgsLength, char *aArgs[])
     {
         uint32_t timeout;
 
-        SuccessOrExit(error = ParseAsUint32(aArgs[0], timeout));
+        SuccessOrExit(error = aArgs[0].ParseAsUint32(timeout));
         otThreadSetChildTimeout(mInstance, timeout);
     }
 
@@ -1107,21 +1097,21 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
-otError Interpreter::ProcessCoap(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessCoap(uint8_t aArgsLength, Arg aArgs[])
 {
     return mCoap.Process(aArgsLength, aArgs);
 }
 #endif
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-otError Interpreter::ProcessCoapSecure(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessCoapSecure(uint8_t aArgsLength, Arg aArgs[])
 {
     return mCoapSecure.Process(aArgsLength, aArgs);
 }
 #endif
 
 #if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
-otError Interpreter::ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessCoexMetrics(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
     bool    enable;
@@ -1134,7 +1124,7 @@ otError Interpreter::ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[])
     {
         error = otPlatRadioSetCoexEnabled(mInstance, enable);
     }
-    else if (strcmp(aArgs[0], "metrics") == 0)
+    else if (aArgs[0] == "metrics")
     {
         otRadioCoexMetrics metrics;
 
@@ -1173,7 +1163,7 @@ exit:
 #endif // OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
 
 #if OPENTHREAD_FTD
-otError Interpreter::ProcessContextIdReuseDelay(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessContextIdReuseDelay(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1185,7 +1175,7 @@ otError Interpreter::ProcessContextIdReuseDelay(uint8_t aArgsLength, char *aArgs
     {
         uint32_t delay;
 
-        SuccessOrExit(error = ParseAsUint32(aArgs[0], delay));
+        SuccessOrExit(error = aArgs[0].ParseAsUint32(delay));
         otThreadSetContextIdReuseDelay(mInstance, delay);
     }
 
@@ -1194,7 +1184,7 @@ exit:
 }
 #endif
 
-otError Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessCounters(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1203,7 +1193,7 @@ otError Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
         OutputLine("mac");
         OutputLine("mle");
     }
-    else if (strcmp(aArgs[0], "mac") == 0)
+    else if (aArgs[0] == "mac")
     {
         if (aArgsLength == 1)
         {
@@ -1241,7 +1231,7 @@ otError Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
             OutputLine(kIndentSize, "RxErrFcs: %d", macCounters->mRxErrFcs);
             OutputLine(kIndentSize, "RxErrOther: %d", macCounters->mRxErrOther);
         }
-        else if ((aArgsLength == 2) && (strcmp(aArgs[1], "reset") == 0))
+        else if ((aArgsLength == 2) && (aArgs[1] == "reset"))
         {
             otLinkResetCounters(mInstance);
         }
@@ -1250,7 +1240,7 @@ otError Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
             ExitNow(error = OT_ERROR_INVALID_ARGS);
         }
     }
-    else if (strcmp(aArgs[0], "mle") == 0)
+    else if (aArgs[0] == "mle")
     {
         if (aArgsLength == 1)
         {
@@ -1266,7 +1256,7 @@ otError Interpreter::ProcessCounters(uint8_t aArgsLength, char *aArgs[])
             OutputLine("Better Partition Attach Attempts: %d", mleCounters->mBetterPartitionAttachAttempts);
             OutputLine("Parent Changes: %d", mleCounters->mParentChanges);
         }
-        else if ((aArgsLength == 2) && (strcmp(aArgs[1], "reset") == 0))
+        else if ((aArgsLength == 2) && (aArgs[1] == "reset"))
         {
             otThreadResetMleCounters(mInstance);
         }
@@ -1285,7 +1275,7 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-otError Interpreter::ProcessCsl(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessCsl(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_INVALID_ARGS;
 
@@ -1299,25 +1289,25 @@ otError Interpreter::ProcessCsl(uint8_t aArgsLength, char *aArgs[])
     }
     else if (aArgsLength == 2)
     {
-        if (strcmp(aArgs[0], "channel") == 0)
+        if (aArgs[0] == "channel")
         {
             uint8_t channel;
 
-            SuccessOrExit(error = ParseAsUint8(aArgs[1], channel));
+            SuccessOrExit(error = aArgs[1].ParseAsUint8(channel));
             SuccessOrExit(error = otLinkCslSetChannel(mInstance, channel));
         }
-        else if (strcmp(aArgs[0], "period") == 0)
+        else if (aArgs[0] == "period")
         {
             uint16_t period;
 
-            SuccessOrExit(error = ParseAsUint16(aArgs[1], period));
+            SuccessOrExit(error = aArgs[1].ParseAsUint16(period));
             SuccessOrExit(error = otLinkCslSetPeriod(mInstance, period));
         }
-        else if (strcmp(aArgs[0], "timeout") == 0)
+        else if (aArgs[0] == "timeout")
         {
             uint32_t timeout;
 
-            SuccessOrExit(error = ParseAsUint32(aArgs[1], timeout));
+            SuccessOrExit(error = aArgs[1].ParseAsUint32(timeout));
             SuccessOrExit(error = otLinkCslSetTimeout(mInstance, timeout));
         }
     }
@@ -1328,7 +1318,7 @@ exit:
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
 #if OPENTHREAD_FTD
-otError Interpreter::ProcessDelayTimerMin(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDelayTimerMin(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1339,7 +1329,7 @@ otError Interpreter::ProcessDelayTimerMin(uint8_t aArgsLength, char *aArgs[])
     else if (aArgsLength == 1)
     {
         uint32_t delay;
-        SuccessOrExit(error = ParseAsUint32(aArgs[0], delay));
+        SuccessOrExit(error = aArgs[0].ParseAsUint32(delay));
         SuccessOrExit(error = otDatasetSetDelayTimerMinimal(mInstance, static_cast<uint32_t>(delay * 1000)));
     }
     else
@@ -1352,7 +1342,7 @@ exit:
 }
 #endif
 
-otError Interpreter::ProcessDiscover(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDiscover(uint8_t aArgsLength, Arg aArgs[])
 {
     otError  error        = OT_ERROR_NONE;
     uint32_t scanChannels = 0;
@@ -1361,7 +1351,7 @@ otError Interpreter::ProcessDiscover(uint8_t aArgsLength, char *aArgs[])
     {
         uint8_t channel;
 
-        SuccessOrExit(error = ParseAsUint8(aArgs[0], channel));
+        SuccessOrExit(error = aArgs[0].ParseAsUint8(channel));
         VerifyOrExit(channel < sizeof(scanChannels) * CHAR_BIT, error = OT_ERROR_INVALID_ARGS);
         scanChannels = 1 << channel;
     }
@@ -1422,7 +1412,7 @@ void Interpreter::OutputDnsTxtData(const uint8_t *aTxtData, uint16_t aTxtDataLen
     OutputFormat("]");
 }
 
-otError Interpreter::ProcessDns(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDns(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
 
@@ -1437,7 +1427,7 @@ otError Interpreter::ProcessDns(uint8_t aArgsLength, char *aArgs[])
         error = OT_ERROR_INVALID_ARGS;
     }
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    else if (strcmp(aArgs[0], "compression") == 0)
+    else if (aArgs[0] == "compression")
     {
         if (aArgsLength == 1)
         {
@@ -1454,7 +1444,7 @@ otError Interpreter::ProcessDns(uint8_t aArgsLength, char *aArgs[])
     }
 #endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
-    else if (strcmp(aArgs[0], "config") == 0)
+    else if (aArgs[0] == "config")
     {
         if (aArgsLength == 1)
         {
@@ -1474,25 +1464,25 @@ otError Interpreter::ProcessDns(uint8_t aArgsLength, char *aArgs[])
             otDnsClientSetDefaultConfig(mInstance, config);
         }
     }
-    else if (strcmp(aArgs[0], "resolve") == 0)
+    else if (aArgs[0] == "resolve")
     {
         SuccessOrExit(error = GetDnsConfig(aArgsLength, aArgs, config, 2));
-        SuccessOrExit(error = otDnsClientResolveAddress(mInstance, aArgs[1], &Interpreter::HandleDnsAddressResponse,
-                                                        this, config));
+        SuccessOrExit(error = otDnsClientResolveAddress(mInstance, aArgs[1].GetCString(),
+                                                        &Interpreter::HandleDnsAddressResponse, this, config));
         error = OT_ERROR_PENDING;
     }
 #if OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE
-    else if (strcmp(aArgs[0], "browse") == 0)
+    else if (aArgs[0] == "browse")
     {
         SuccessOrExit(error = GetDnsConfig(aArgsLength, aArgs, config, 2));
-        SuccessOrExit(error =
-                          otDnsClientBrowse(mInstance, aArgs[1], &Interpreter::HandleDnsBrowseResponse, this, config));
+        SuccessOrExit(error = otDnsClientBrowse(mInstance, aArgs[1].GetCString(), &Interpreter::HandleDnsBrowseResponse,
+                                                this, config));
         error = OT_ERROR_PENDING;
     }
-    else if (strcmp(aArgs[0], "service") == 0)
+    else if (aArgs[0] == "service")
     {
         SuccessOrExit(error = GetDnsConfig(aArgsLength, aArgs, config, 3));
-        SuccessOrExit(error = otDnsClientResolveService(mInstance, aArgs[1], aArgs[2],
+        SuccessOrExit(error = otDnsClientResolveService(mInstance, aArgs[1].GetCString(), aArgs[2].GetCString(),
                                                         &Interpreter::HandleDnsServiceResponse, this, config));
         error = OT_ERROR_PENDING;
     }
@@ -1509,10 +1499,7 @@ exit:
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
 
-otError Interpreter::GetDnsConfig(uint8_t            aArgsLength,
-                                  char *             aArgs[],
-                                  otDnsQueryConfig *&aConfig,
-                                  uint8_t            aStartArgsIndex)
+otError Interpreter::GetDnsConfig(uint8_t aArgsLength, Arg aArgs[], otDnsQueryConfig *&aConfig, uint8_t aStartArgsIndex)
 {
     // This method gets the optional config from given `aArgs` after the
     // `aStartArgsIndex`. The format: `[server IPv6 address] [server
@@ -1525,19 +1512,19 @@ otError Interpreter::GetDnsConfig(uint8_t            aArgsLength,
 
     VerifyOrExit(aArgsLength > aStartArgsIndex, aConfig = nullptr);
 
-    SuccessOrExit(error = ParseAsIp6Address(aArgs[aStartArgsIndex], aConfig->mServerSockAddr.mAddress));
+    SuccessOrExit(error = aArgs[aStartArgsIndex].ParseAsIp6Address(aConfig->mServerSockAddr.mAddress));
 
     VerifyOrExit(aArgsLength > aStartArgsIndex + 1);
-    SuccessOrExit(error = ParseAsUint16(aArgs[aStartArgsIndex + 1], aConfig->mServerSockAddr.mPort));
+    SuccessOrExit(error = aArgs[aStartArgsIndex + 1].ParseAsUint16(aConfig->mServerSockAddr.mPort));
 
     VerifyOrExit(aArgsLength > aStartArgsIndex + 2);
-    SuccessOrExit(error = ParseAsUint32(aArgs[aStartArgsIndex + 2], aConfig->mResponseTimeout));
+    SuccessOrExit(error = aArgs[aStartArgsIndex + 2].ParseAsUint32(aConfig->mResponseTimeout));
 
     VerifyOrExit(aArgsLength > aStartArgsIndex + 3);
-    SuccessOrExit(error = ParseAsUint8(aArgs[aStartArgsIndex + 3], aConfig->mMaxTxAttempts));
+    SuccessOrExit(error = aArgs[aStartArgsIndex + 3].ParseAsUint8(aConfig->mMaxTxAttempts));
 
     VerifyOrExit(aArgsLength > aStartArgsIndex + 4);
-    SuccessOrExit(error = ParseAsBool(aArgs[aStartArgsIndex + 4], recursionDesired));
+    SuccessOrExit(error = aArgs[aStartArgsIndex + 4].ParseAsBool(recursionDesired));
     aConfig->mRecursionFlag = recursionDesired ? OT_DNS_FLAG_RECURSION_DESIRED : OT_DNS_FLAG_NO_RECURSION;
 
 exit:
@@ -1709,7 +1696,7 @@ void Interpreter::OutputEidCacheEntry(const otCacheEntryInfo &aEntry)
     OutputLine("");
 }
 
-otError Interpreter::ProcessEidCache(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessEidCache(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -1730,7 +1717,7 @@ exit:
 }
 #endif
 
-otError Interpreter::ProcessEui64(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessEui64(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
 
@@ -1747,7 +1734,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessExtAddress(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessExtAddress(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1761,7 +1748,7 @@ otError Interpreter::ProcessExtAddress(uint8_t aArgsLength, char *aArgs[])
     {
         otExtAddress extAddress;
 
-        SuccessOrExit(error = ParseAsHexString(aArgs[0], extAddress.m8));
+        SuccessOrExit(error = aArgs[0].ParseAsHexString(extAddress.m8));
         error = otLinkSetExtendedAddress(mInstance, &extAddress);
     }
 
@@ -1770,7 +1757,7 @@ exit:
 }
 
 #if OPENTHREAD_POSIX && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
-otError Interpreter::ProcessExit(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessExit(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -1781,13 +1768,13 @@ otError Interpreter::ProcessExit(uint8_t aArgsLength, char *aArgs[])
 }
 #endif
 
-otError Interpreter::ProcessLog(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessLog(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgsLength >= 1, error = OT_ERROR_INVALID_ARGS);
 
-    if (!strcmp(aArgs[0], "level"))
+    if (aArgs[0] == "level")
     {
         if (aArgsLength == 1)
         {
@@ -1798,7 +1785,7 @@ otError Interpreter::ProcessLog(uint8_t aArgsLength, char *aArgs[])
         {
             uint8_t level;
 
-            SuccessOrExit(error = ParseAsUint8(aArgs[1], level));
+            SuccessOrExit(error = aArgs[1].ParseAsUint8(level));
             SuccessOrExit(error = otLoggingSetLevel(static_cast<otLogLevel>(level)));
         }
 #endif
@@ -1808,10 +1795,10 @@ otError Interpreter::ProcessLog(uint8_t aArgsLength, char *aArgs[])
         }
     }
 #if (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_DEBUG_UART) && OPENTHREAD_POSIX
-    else if (!strcmp(aArgs[0], "filename"))
+    else if (aArgs[0] == "filename")
     {
         VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
-        SuccessOrExit(error = otPlatDebugUart_logfile(aArgs[1]));
+        SuccessOrExit(error = otPlatDebugUart_logfile(aArgs[1].GetCString()));
     }
 #endif
     else
@@ -1823,7 +1810,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessExtPanId(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessExtPanId(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1837,7 +1824,7 @@ otError Interpreter::ProcessExtPanId(uint8_t aArgsLength, char *aArgs[])
     {
         otExtendedPanId extPanId;
 
-        SuccessOrExit(error = ParseAsHexString(aArgs[0], extPanId.m8));
+        SuccessOrExit(error = aArgs[0].ParseAsHexString(extPanId.m8));
         error = otThreadSetExtendedPanId(mInstance, &extPanId);
     }
 
@@ -1845,7 +1832,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessFactoryReset(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessFactoryReset(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -1856,26 +1843,26 @@ otError Interpreter::ProcessFactoryReset(uint8_t aArgsLength, char *aArgs[])
 }
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-otError Interpreter::ProcessFake(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessFake(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_INVALID_COMMAND;
 
     VerifyOrExit(aArgsLength >= 1);
 
-    if (strcmp(aArgs[0], "/a/an") == 0)
+    if (aArgs[0] == "/a/an")
     {
         otIp6Address             destination, target;
         otIp6InterfaceIdentifier mlIid;
 
         VerifyOrExit(aArgsLength == 4, error = OT_ERROR_INVALID_ARGS);
 
-        SuccessOrExit(error = ParseAsIp6Address(aArgs[1], destination));
-        SuccessOrExit(error = ParseAsIp6Address(aArgs[2], target));
-        SuccessOrExit(error = ParseAsHexString(aArgs[3], mlIid.mFields.m8));
+        SuccessOrExit(error = aArgs[1].ParseAsIp6Address(destination));
+        SuccessOrExit(error = aArgs[2].ParseAsIp6Address(target));
+        SuccessOrExit(error = aArgs[3].ParseAsHexString(mlIid.mFields.m8));
         otThreadSendAddressNotification(mInstance, &destination, &target, &mlIid);
     }
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
-    else if (strcmp(aArgs[0], "/b/ba") == 0)
+    else if (aArgs[0] == "/b/ba")
     {
         otIp6Address             target;
         otIp6InterfaceIdentifier mlIid;
@@ -1883,9 +1870,9 @@ otError Interpreter::ProcessFake(uint8_t aArgsLength, char *aArgs[])
 
         VerifyOrExit(aArgsLength == 4, error = OT_ERROR_INVALID_ARGS);
 
-        SuccessOrExit(error = ParseAsIp6Address(aArgs[1], target));
-        SuccessOrExit(error = ParseAsHexString(aArgs[2], mlIid.mFields.m8));
-        SuccessOrExit(error = ParseAsUint32(aArgs[3], timeSinceLastTransaction));
+        SuccessOrExit(error = aArgs[1].ParseAsIp6Address(target));
+        SuccessOrExit(error = aArgs[2].ParseAsHexString(mlIid.mFields.m8));
+        SuccessOrExit(error = aArgs[3].ParseAsUint32(timeSinceLastTransaction));
 
         error = otThreadSendProactiveBackboneNotification(mInstance, &target, &mlIid, timeSinceLastTransaction);
     }
@@ -1895,7 +1882,7 @@ exit:
 }
 #endif
 
-otError Interpreter::ProcessFem(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessFem(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1906,7 +1893,7 @@ otError Interpreter::ProcessFem(uint8_t aArgsLength, char *aArgs[])
         SuccessOrExit(error = otPlatRadioGetFemLnaGain(mInstance, &lnaGain));
         OutputLine("LNA gain %d dBm", lnaGain);
     }
-    else if (strcmp(aArgs[0], "lnagain") == 0)
+    else if (aArgs[0] == "lnagain")
     {
         if (aArgsLength == 1)
         {
@@ -1919,7 +1906,7 @@ otError Interpreter::ProcessFem(uint8_t aArgsLength, char *aArgs[])
         {
             int8_t lnaGain;
 
-            SuccessOrExit(error = ParseAsInt8(aArgs[1], lnaGain));
+            SuccessOrExit(error = aArgs[1].ParseAsInt8(lnaGain));
             SuccessOrExit(error = otPlatRadioSetFemLnaGain(mInstance, lnaGain));
         }
     }
@@ -1932,7 +1919,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessIfconfig(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessIfconfig(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -1947,11 +1934,11 @@ otError Interpreter::ProcessIfconfig(uint8_t aArgsLength, char *aArgs[])
             OutputLine("down");
         }
     }
-    else if (strcmp(aArgs[0], "up") == 0)
+    else if (aArgs[0] == "up")
     {
         SuccessOrExit(error = otIp6SetEnabled(mInstance, true));
     }
-    else if (strcmp(aArgs[0], "down") == 0)
+    else if (aArgs[0] == "down")
     {
         SuccessOrExit(error = otIp6SetEnabled(mInstance, false));
     }
@@ -1964,14 +1951,14 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessIpAddrAdd(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessIpAddrAdd(uint8_t aArgsLength, Arg aArgs[])
 {
     otError        error;
     otNetifAddress aAddress;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = ParseAsIp6Address(aArgs[0], aAddress.mAddress));
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Address(aAddress.mAddress));
     aAddress.mPrefixLength  = 64;
     aAddress.mPreferred     = true;
     aAddress.mValid         = true;
@@ -1982,21 +1969,21 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessIpAddrDel(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessIpAddrDel(uint8_t aArgsLength, Arg aArgs[])
 {
     otError      error;
     otIp6Address address;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = ParseAsIp6Address(aArgs[0], address));
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Address(address));
     error = otIp6RemoveUnicastAddress(mInstance, &address);
 
 exit:
     return error;
 }
 
-otError Interpreter::ProcessIpAddr(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessIpAddr(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -2012,25 +1999,25 @@ otError Interpreter::ProcessIpAddr(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        if (strcmp(aArgs[0], "add") == 0)
+        if (aArgs[0] == "add")
         {
             SuccessOrExit(error = ProcessIpAddrAdd(aArgsLength - 1, aArgs + 1));
         }
-        else if (strcmp(aArgs[0], "del") == 0)
+        else if (aArgs[0] == "del")
         {
             SuccessOrExit(error = ProcessIpAddrDel(aArgsLength - 1, aArgs + 1));
         }
-        else if (strcmp(aArgs[0], "linklocal") == 0)
+        else if (aArgs[0] == "linklocal")
         {
             OutputIp6Address(*otThreadGetLinkLocalIp6Address(mInstance));
             OutputLine("");
         }
-        else if (strcmp(aArgs[0], "rloc") == 0)
+        else if (aArgs[0] == "rloc")
         {
             OutputIp6Address(*otThreadGetRloc(mInstance));
             OutputLine("");
         }
-        else if (strcmp(aArgs[0], "mleid") == 0)
+        else if (aArgs[0] == "mleid")
         {
             OutputIp6Address(*otThreadGetMeshLocalEid(mInstance));
             OutputLine("");
@@ -2045,35 +2032,35 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessIpMulticastAddrAdd(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessIpMulticastAddrAdd(uint8_t aArgsLength, Arg aArgs[])
 {
     otError      error;
     otIp6Address address;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = ParseAsIp6Address(aArgs[0], address));
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Address(address));
     error = otIp6SubscribeMulticastAddress(mInstance, &address);
 
 exit:
     return error;
 }
 
-otError Interpreter::ProcessIpMulticastAddrDel(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessIpMulticastAddrDel(uint8_t aArgsLength, Arg aArgs[])
 {
     otError      error;
     otIp6Address address;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = ParseAsIp6Address(aArgs[0], address));
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Address(address));
     error = otIp6UnsubscribeMulticastAddress(mInstance, &address);
 
 exit:
     return error;
 }
 
-otError Interpreter::ProcessMulticastPromiscuous(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMulticastPromiscuous(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -2093,7 +2080,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessIpMulticastAddr(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessIpMulticastAddr(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -2107,24 +2094,24 @@ otError Interpreter::ProcessIpMulticastAddr(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        if (strcmp(aArgs[0], "add") == 0)
+        if (aArgs[0] == "add")
         {
             SuccessOrExit(error = ProcessIpMulticastAddrAdd(aArgsLength - 1, aArgs + 1));
         }
-        else if (strcmp(aArgs[0], "del") == 0)
+        else if (aArgs[0] == "del")
         {
             SuccessOrExit(error = ProcessIpMulticastAddrDel(aArgsLength - 1, aArgs + 1));
         }
-        else if (strcmp(aArgs[0], "promiscuous") == 0)
+        else if (aArgs[0] == "promiscuous")
         {
             SuccessOrExit(error = ProcessMulticastPromiscuous(aArgsLength - 1, aArgs + 1));
         }
-        else if (strcmp(aArgs[0], "llatn") == 0)
+        else if (aArgs[0] == "llatn")
         {
             OutputIp6Address(*otThreadGetLinkLocalAllThreadNodesMulticastAddress(mInstance));
             OutputLine("");
         }
-        else if (strcmp(aArgs[0], "rlatn") == 0)
+        else if (aArgs[0] == "rlatn")
         {
             OutputIp6Address(*otThreadGetRealmLocalAllThreadNodesMulticastAddress(mInstance));
             OutputLine("");
@@ -2139,13 +2126,13 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessKeySequence(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessKeySequence(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgsLength == 1 || aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "counter") == 0)
+    if (aArgs[0] == "counter")
     {
         if (aArgsLength == 1)
         {
@@ -2155,11 +2142,11 @@ otError Interpreter::ProcessKeySequence(uint8_t aArgsLength, char *aArgs[])
         {
             uint32_t counter;
 
-            SuccessOrExit(error = ParseAsUint32(aArgs[1], counter));
+            SuccessOrExit(error = aArgs[1].ParseAsUint32(counter));
             otThreadSetKeySequenceCounter(mInstance, counter);
         }
     }
-    else if (strcmp(aArgs[0], "guardtime") == 0)
+    else if (aArgs[0] == "guardtime")
     {
         if (aArgsLength == 1)
         {
@@ -2169,7 +2156,7 @@ otError Interpreter::ProcessKeySequence(uint8_t aArgsLength, char *aArgs[])
         {
             uint32_t guardTime;
 
-            SuccessOrExit(error = ParseAsUint32(aArgs[1], guardTime));
+            SuccessOrExit(error = aArgs[1].ParseAsUint32(guardTime));
             otThreadSetKeySwitchGuardTime(mInstance, guardTime);
         }
     }
@@ -2182,7 +2169,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessLeaderData(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessLeaderData(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -2203,7 +2190,7 @@ exit:
 }
 
 #if OPENTHREAD_FTD
-otError Interpreter::ProcessPartitionId(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPartitionId(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
 
@@ -2215,7 +2202,7 @@ otError Interpreter::ProcessPartitionId(uint8_t aArgsLength, char *aArgs[])
         error = OT_ERROR_NONE;
     }
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    else if (strcmp(aArgs[0], "preferred") == 0)
+    else if (aArgs[0] == "preferred")
     {
         if (aArgsLength == 1)
         {
@@ -2226,7 +2213,7 @@ otError Interpreter::ProcessPartitionId(uint8_t aArgsLength, char *aArgs[])
         {
             uint32_t partitionId;
 
-            SuccessOrExit(error = ParseAsUint32(aArgs[1], partitionId));
+            SuccessOrExit(error = aArgs[1].ParseAsUint32(partitionId));
             otThreadSetPreferredLeaderPartitionId(mInstance, partitionId);
         }
     }
@@ -2237,7 +2224,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessLeaderWeight(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessLeaderWeight(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -2249,7 +2236,7 @@ otError Interpreter::ProcessLeaderWeight(uint8_t aArgsLength, char *aArgs[])
     {
         uint8_t weight;
 
-        SuccessOrExit(error = ParseAsUint8(aArgs[0], weight));
+        SuccessOrExit(error = aArgs[0].ParseAsUint8(weight));
         otThreadSetLocalLeaderWeight(mInstance, weight);
     }
 
@@ -2389,21 +2376,21 @@ const char *Interpreter::LinkMetricsStatusToStr(uint8_t aStatus)
     return linkMetricsStatusText[strIndex];
 }
 
-otError Interpreter::ProcessLinkMetrics(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessLinkMetrics(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_INVALID_COMMAND;
 
     VerifyOrExit(aArgsLength >= 1);
 
-    if (strcmp(aArgs[0], "query") == 0)
+    if (aArgs[0] == "query")
     {
         error = ProcessLinkMetricsQuery(aArgsLength - 1, aArgs + 1);
     }
-    else if (strcmp(aArgs[0], "mgmt") == 0)
+    else if (aArgs[0] == "mgmt")
     {
         error = ProcessLinkMetricsMgmt(aArgsLength - 1, aArgs + 1);
     }
-    else if (strcmp(aArgs[0], "probe") == 0)
+    else if (aArgs[0] == "probe")
     {
         error = ProcessLinkMetricsProbe(aArgsLength - 1, aArgs + 1);
     }
@@ -2412,7 +2399,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessLinkMetricsQuery(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessLinkMetricsQuery(uint8_t aArgsLength, Arg aArgs[])
 {
     otError       error = OT_ERROR_INVALID_ARGS;
     otIp6Address  address;
@@ -2420,18 +2407,18 @@ otError Interpreter::ProcessLinkMetricsQuery(uint8_t aArgsLength, char *aArgs[])
 
     VerifyOrExit(aArgsLength == 3);
 
-    SuccessOrExit(error = ParseAsIp6Address(aArgs[0], address));
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Address(address));
 
-    if (strcmp(aArgs[1], "single") == 0)
+    if (aArgs[1] == "single")
     {
         SuccessOrExit(error = ParseLinkMetricsFlags(linkMetrics, aArgs[2]));
         error = otLinkMetricsQuery(mInstance, &address, /* aSeriesId */ 0, &linkMetrics,
                                    &Interpreter::HandleLinkMetricsReport, this);
     }
-    else if (strcmp(aArgs[1], "forward") == 0)
+    else if (aArgs[1] == "forward")
     {
         uint8_t seriesId;
-        SuccessOrExit(error = ParseAsUint8(aArgs[2], seriesId));
+        SuccessOrExit(error = aArgs[2].ParseAsUint8(seriesId));
         error = otLinkMetricsQuery(mInstance, &address, seriesId, nullptr, &Interpreter::HandleLinkMetricsReport, this);
     }
 
@@ -2439,13 +2426,13 @@ exit:
     return error;
 }
 
-otError Interpreter::ParseLinkMetricsFlags(otLinkMetrics &aLinkMetrics, char *aFlags)
+otError Interpreter::ParseLinkMetricsFlags(otLinkMetrics &aLinkMetrics, const Arg &aFlags)
 {
     otError error = OT_ERROR_NONE;
 
     memset(&aLinkMetrics, 0, sizeof(aLinkMetrics));
 
-    for (char *arg = aFlags; *arg != '\0'; arg++)
+    for (const char *arg = aFlags.GetCString(); *arg != '\0'; arg++)
     {
         switch (*arg)
         {
@@ -2474,7 +2461,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessLinkMetricsMgmt(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessLinkMetricsMgmt(uint8_t aArgsLength, Arg aArgs[])
 {
     otError                  error = OT_ERROR_INVALID_ARGS;
     otIp6Address             address;
@@ -2483,11 +2470,11 @@ otError Interpreter::ProcessLinkMetricsMgmt(uint8_t aArgsLength, char *aArgs[])
 
     VerifyOrExit(aArgsLength >= 2);
 
-    SuccessOrExit(error = ParseAsIp6Address(aArgs[0], address));
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Address(address));
 
     memset(&seriesFlags, 0, sizeof(otLinkMetricsSeriesFlags));
 
-    if (strcmp(aArgs[1], "forward") == 0)
+    if (aArgs[1] == "forward")
     {
         uint8_t       seriesId;
         otLinkMetrics linkMetrics;
@@ -2495,9 +2482,9 @@ otError Interpreter::ProcessLinkMetricsMgmt(uint8_t aArgsLength, char *aArgs[])
         VerifyOrExit(aArgsLength >= 4);
 
         memset(&linkMetrics, 0, sizeof(otLinkMetrics));
-        SuccessOrExit(error = ParseAsUint8(aArgs[2], seriesId));
+        SuccessOrExit(error = aArgs[2].ParseAsUint8(seriesId));
 
-        for (char *arg = aArgs[3]; *arg != '\0'; arg++)
+        for (const char *arg = aArgs[3].GetCString(); *arg != '\0'; arg++)
         {
             switch (*arg)
             {
@@ -2518,7 +2505,7 @@ otError Interpreter::ProcessLinkMetricsMgmt(uint8_t aArgsLength, char *aArgs[])
                 break;
 
             case 'X':
-                VerifyOrExit(arg == aArgs[3] && *(arg + 1) == '\0' && aArgsLength == 4,
+                VerifyOrExit(arg == aArgs[3].GetCString() && *(arg + 1) == '\0' && aArgsLength == 4,
                              error = OT_ERROR_INVALID_ARGS); // Ensure the flags only contain 'X'
                 clear = true;
                 break;
@@ -2538,7 +2525,7 @@ otError Interpreter::ProcessLinkMetricsMgmt(uint8_t aArgsLength, char *aArgs[])
                                                          clear ? nullptr : &linkMetrics,
                                                          &Interpreter::HandleLinkMetricsMgmtResponse, this);
     }
-    else if (strcmp(aArgs[1], "enhanced-ack") == 0)
+    else if (aArgs[1] == "enhanced-ack")
     {
         otLinkMetricsEnhAckFlags enhAckFlags;
         otLinkMetrics            linkMetrics;
@@ -2546,18 +2533,18 @@ otError Interpreter::ProcessLinkMetricsMgmt(uint8_t aArgsLength, char *aArgs[])
 
         VerifyOrExit(aArgsLength >= 3);
 
-        if (strcmp(aArgs[2], "clear") == 0)
+        if (aArgs[2] == "clear")
         {
             enhAckFlags  = OT_LINK_METRICS_ENH_ACK_CLEAR;
             pLinkMetrics = nullptr;
         }
-        else if (strcmp(aArgs[2], "register") == 0)
+        else if (aArgs[2] == "register")
         {
             enhAckFlags = OT_LINK_METRICS_ENH_ACK_REGISTER;
             VerifyOrExit(aArgsLength >= 4);
             SuccessOrExit(error = ParseLinkMetricsFlags(linkMetrics, aArgs[3]));
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-            if (aArgsLength > 4 && strcmp(aArgs[4], "r") == 0)
+            if (aArgsLength > 4 && (aArgs[4] == "r"))
             {
                 linkMetrics.mReserved = true;
             }
@@ -2577,7 +2564,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessLinkMetricsProbe(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessLinkMetricsProbe(uint8_t aArgsLength, Arg aArgs[])
 {
     otError      error = OT_ERROR_INVALID_ARGS;
     otIp6Address address;
@@ -2586,9 +2573,9 @@ otError Interpreter::ProcessLinkMetricsProbe(uint8_t aArgsLength, char *aArgs[])
 
     VerifyOrExit(aArgsLength == 3);
 
-    SuccessOrExit(error = ParseAsIp6Address(aArgs[0], address));
-    SuccessOrExit(error = ParseAsUint8(aArgs[1], seriesId));
-    SuccessOrExit(error = ParseAsUint8(aArgs[2], length));
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Address(address));
+    SuccessOrExit(error = aArgs[1].ParseAsUint8(seriesId));
+    SuccessOrExit(error = aArgs[2].ParseAsUint8(length));
 
     error = otLinkMetricsSendLinkProbe(mInstance, &address, seriesId, length);
 
@@ -2598,7 +2585,7 @@ exit:
 #endif // OPENTHREAD_CONFIG_MLE_LINK_METRICS_ENABLE
 
 #if OPENTHREAD_FTD
-otError Interpreter::ProcessPskc(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPskc(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -2615,12 +2602,13 @@ otError Interpreter::ProcessPskc(uint8_t aArgsLength, char *aArgs[])
 
         if (aArgsLength == 1)
         {
-            SuccessOrExit(error = ParseAsHexString(aArgs[0], pskc.m8));
+            SuccessOrExit(error = aArgs[0].ParseAsHexString(pskc.m8));
         }
-        else if (!strcmp(aArgs[0], "-p"))
+        else if (aArgs[0] == "-p")
         {
             SuccessOrExit(error = otDatasetGeneratePskc(
-                              aArgs[1], reinterpret_cast<const otNetworkName *>(otThreadGetNetworkName(mInstance)),
+                              aArgs[1].GetCString(),
+                              reinterpret_cast<const otNetworkName *>(otThreadGetNetworkName(mInstance)),
                               otThreadGetExtendedPanId(mInstance), &pskc));
         }
         else
@@ -2636,7 +2624,7 @@ exit:
 }
 #endif // OPENTHREAD_FTD
 
-otError Interpreter::ProcessMasterKey(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMasterKey(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -2649,7 +2637,7 @@ otError Interpreter::ProcessMasterKey(uint8_t aArgsLength, char *aArgs[])
     {
         otMasterKey key;
 
-        SuccessOrExit(error = ParseAsHexString(aArgs[0], key.m8));
+        SuccessOrExit(error = aArgs[0].ParseAsHexString(key.m8));
         SuccessOrExit(error = otThreadSetMasterKey(mInstance, &key));
     }
 
@@ -2659,13 +2647,13 @@ exit:
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
 
-otError Interpreter::ProcessMlr(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMlr(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_COMMAND);
 
-    if (!strcmp(aArgs[0], "reg"))
+    if (aArgs[0] == "reg")
     {
         error = ProcessMlrReg(aArgsLength - 1, aArgs + 1);
     }
@@ -2678,7 +2666,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessMlrReg(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMlrReg(uint8_t aArgsLength, Arg aArgs[])
 {
     otError      error = OT_ERROR_NONE;
     otIp6Address addresses[kIp6AddressesNumMax];
@@ -2690,7 +2678,7 @@ otError Interpreter::ProcessMlrReg(uint8_t aArgsLength, char *aArgs[])
 
     for (i = 0; i < aArgsLength && i < kIp6AddressesNumMax; i++)
     {
-        if (ParseAsIp6Address(aArgs[i], addresses[i]) != OT_ERROR_NONE)
+        if (aArgs[i].ParseAsIp6Address(addresses[i]) != OT_ERROR_NONE)
         {
             break;
         }
@@ -2701,7 +2689,7 @@ otError Interpreter::ProcessMlrReg(uint8_t aArgsLength, char *aArgs[])
     if (i == aArgsLength - 1)
     {
         // Parse the last argument as a timeout in seconds
-        SuccessOrExit(error = ParseAsUint32(aArgs[i], timeout));
+        SuccessOrExit(error = aArgs[i].ParseAsUint32(timeout));
     }
 
     SuccessOrExit(error = otIp6RegisterMulticastListeners(mInstance, addresses, i,
@@ -2744,7 +2732,7 @@ void Interpreter::HandleMlrRegResult(otError             aError,
 
 #endif // (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE) && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
 
-otError Interpreter::ProcessMode(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMode(uint8_t aArgsLength, Arg aArgs[])
 {
     otError          error = OT_ERROR_NONE;
     otLinkModeConfig linkMode;
@@ -2782,9 +2770,9 @@ otError Interpreter::ProcessMode(uint8_t aArgsLength, char *aArgs[])
         ExitNow();
     }
 
-    if (strcmp(aArgs[0], "-") != 0)
+    if (aArgs[0] != "-")
     {
-        for (char *arg = aArgs[0]; *arg != '\0'; arg++)
+        for (const char *arg = aArgs[0].GetCString(); *arg != '\0'; arg++)
         {
             switch (*arg)
             {
@@ -2812,7 +2800,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessMultiRadio(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMultiRadio(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -2835,13 +2823,13 @@ otError Interpreter::ProcessMultiRadio(uint8_t aArgsLength, char *aArgs[])
         OT_UNUSED_VARIABLE(isFirst);
     }
 #if OPENTHREAD_CONFIG_MULTI_RADIO
-    else if (strcmp(aArgs[0], "neighbor") == 0)
+    else if (aArgs[0] == "neighbor")
     {
         otMultiRadioNeighborInfo multiRadioInfo;
 
         VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
 
-        if (strcmp(aArgs[1], "list") == 0)
+        if (aArgs[1] == "list")
         {
             otNeighborInfoIterator iterator = OT_NEIGHBOR_INFO_ITERATOR_INIT;
             otNeighborInfo         neighInfo;
@@ -2863,7 +2851,7 @@ otError Interpreter::ProcessMultiRadio(uint8_t aArgsLength, char *aArgs[])
         {
             otExtAddress extAddress;
 
-            SuccessOrExit(error = ParseAsHexString(aArgs[1], extAddress.m8));
+            SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddress.m8));
             SuccessOrExit(error = otMultiRadioGetNeighborInfo(mInstance, &extAddress, &multiRadioInfo));
             OutputMultiRadioInfo(multiRadioInfo);
         }
@@ -2901,7 +2889,7 @@ void Interpreter::OutputMultiRadioInfo(const otMultiRadioNeighborInfo &aMultiRad
 #endif // OPENTHREAD_CONFIG_MULTI_RADIO
 
 #if OPENTHREAD_FTD
-otError Interpreter::ProcessNeighbor(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNeighbor(uint8_t aArgsLength, Arg aArgs[])
 {
     otError                error = OT_ERROR_NONE;
     otNeighborInfo         neighborInfo;
@@ -2910,9 +2898,9 @@ otError Interpreter::ProcessNeighbor(uint8_t aArgsLength, char *aArgs[])
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    isTable = (strcmp(aArgs[0], "table") == 0);
+    isTable = (aArgs[0] == "table");
 
-    if (isTable || strcmp(aArgs[0], "list") == 0)
+    if (isTable || (aArgs[0] == "list"))
     {
         if (isTable)
         {
@@ -2955,7 +2943,7 @@ exit:
 #endif // OPENTHREAD_FTD
 
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
-otError Interpreter::ProcessNetif(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetif(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -2973,7 +2961,7 @@ exit:
 }
 #endif
 
-otError Interpreter::ProcessNetstat(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetstat(uint8_t aArgsLength, Arg aArgs[])
 {
     otUdpSocket *socket = otUdpGetSockets(mInstance);
 
@@ -3049,7 +3037,7 @@ otError Interpreter::ProcessServiceList(void)
     return OT_ERROR_NONE;
 }
 
-otError Interpreter::ProcessService(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessService(uint8_t aArgsLength, Arg aArgs[])
 {
     otError         error = OT_ERROR_INVALID_COMMAND;
     otServiceConfig cfg;
@@ -3064,19 +3052,19 @@ otError Interpreter::ProcessService(uint8_t aArgsLength, char *aArgs[])
 
         VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
 
-        SuccessOrExit(error = ParseAsUint32(aArgs[1], cfg.mEnterpriseNumber));
+        SuccessOrExit(error = aArgs[1].ParseAsUint32(cfg.mEnterpriseNumber));
 
         length = sizeof(cfg.mServiceData);
-        SuccessOrExit(error = ParseAsHexString(aArgs[2], length, cfg.mServiceData));
+        SuccessOrExit(error = aArgs[2].ParseAsHexString(length, cfg.mServiceData));
         VerifyOrExit(length > 0, error = OT_ERROR_INVALID_ARGS);
         cfg.mServiceDataLength = static_cast<uint8_t>(length);
 
-        if (strcmp(aArgs[0], "add") == 0)
+        if (aArgs[0] == "add")
         {
             VerifyOrExit(aArgsLength > 3, error = OT_ERROR_INVALID_ARGS);
 
             length = sizeof(cfg.mServerConfig.mServerData);
-            SuccessOrExit(error = ParseAsHexString(aArgs[3], length, cfg.mServerConfig.mServerData));
+            SuccessOrExit(error = aArgs[3].ParseAsHexString(length, cfg.mServerConfig.mServerData));
             VerifyOrExit(length > 0, error = OT_ERROR_INVALID_ARGS);
             cfg.mServerConfig.mServerDataLength = static_cast<uint8_t>(length);
 
@@ -3084,7 +3072,7 @@ otError Interpreter::ProcessService(uint8_t aArgsLength, char *aArgs[])
 
             error = otServerAddService(mInstance, &cfg);
         }
-        else if (strcmp(aArgs[0], "remove") == 0)
+        else if (aArgs[0] == "remove")
         {
             error = otServerRemoveService(mInstance, cfg.mEnterpriseNumber, cfg.mServiceData, cfg.mServiceDataLength);
         }
@@ -3095,13 +3083,13 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
-otError Interpreter::ProcessNetworkData(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetworkData(uint8_t aArgsLength, Arg aArgs[])
 {
     return mNetworkData.Process(aArgsLength, aArgs);
 }
 
 #if OPENTHREAD_FTD
-otError Interpreter::ProcessNetworkIdTimeout(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetworkIdTimeout(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3113,7 +3101,7 @@ otError Interpreter::ProcessNetworkIdTimeout(uint8_t aArgsLength, char *aArgs[])
     {
         uint8_t timeout;
 
-        SuccessOrExit(error = ParseAsUint8(aArgs[0], timeout));
+        SuccessOrExit(error = aArgs[0].ParseAsUint8(timeout));
         otThreadSetNetworkIdTimeout(mInstance, timeout);
     }
 
@@ -3122,7 +3110,7 @@ exit:
 }
 #endif
 
-otError Interpreter::ProcessNetworkName(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetworkName(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3132,7 +3120,7 @@ otError Interpreter::ProcessNetworkName(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        SuccessOrExit(error = otThreadSetNetworkName(mInstance, aArgs[0]));
+        SuccessOrExit(error = otThreadSetNetworkName(mInstance, aArgs[0].GetCString()));
     }
 
 exit:
@@ -3140,7 +3128,7 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-otError Interpreter::ProcessNetworkTime(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetworkTime(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3179,9 +3167,8 @@ otError Interpreter::ProcessNetworkTime(uint8_t aArgsLength, char *aArgs[])
         uint16_t period;
         uint16_t xtalThreshold;
 
-        SuccessOrExit(error = ParseAsUint16(aArgs[0], period));
-        ;
-        SuccessOrExit(error = ParseAsUint16(aArgs[1], xtalThreshold));
+        SuccessOrExit(error = aArgs[0].ParseAsUint16(period));
+        SuccessOrExit(error = aArgs[1].ParseAsUint16(xtalThreshold));
         SuccessOrExit(error = otNetworkTimeSetSyncPeriod(mInstance, period));
         SuccessOrExit(error = otNetworkTimeSetXtalThreshold(mInstance, xtalThreshold));
     }
@@ -3195,7 +3182,7 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 
-otError Interpreter::ProcessPanId(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPanId(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3207,7 +3194,7 @@ otError Interpreter::ProcessPanId(uint8_t aArgsLength, char *aArgs[])
     {
         uint16_t panId;
 
-        SuccessOrExit(error = ParseAsUint16(aArgs[0], panId));
+        SuccessOrExit(error = aArgs[0].ParseAsUint16(panId));
         error = otLinkSetPanId(mInstance, panId);
     }
 
@@ -3215,7 +3202,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessParent(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessParent(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -3237,7 +3224,7 @@ exit:
 }
 
 #if OPENTHREAD_FTD
-otError Interpreter::ProcessParentPriority(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessParentPriority(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3249,7 +3236,7 @@ otError Interpreter::ProcessParentPriority(uint8_t aArgsLength, char *aArgs[])
     {
         int8_t priority;
 
-        SuccessOrExit(error = ParseAsInt8(aArgs[0], priority));
+        SuccessOrExit(error = aArgs[0].ParseAsInt8(priority));
         error = otThreadSetParentPriority(mInstance, priority);
     }
 
@@ -3300,14 +3287,14 @@ void Interpreter::HandlePingStatistics(const otPingSenderStatistics *aStatistics
     OutputResult(OT_ERROR_NONE);
 }
 
-otError Interpreter::ProcessPing(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPing(uint8_t aArgsLength, Arg aArgs[])
 {
     otError            error = OT_ERROR_NONE;
     otPingSenderConfig config;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "stop") == 0)
+    if (aArgs[0] == "stop")
     {
         otPingSenderStop(mInstance);
         ExitNow();
@@ -3317,15 +3304,16 @@ otError Interpreter::ProcessPing(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength >= 2)
     {
-        if (!strcmp(aArgs[0], "-I"))
+        if (aArgs[0] == "-I")
         {
-            SuccessOrExit(error = ParseAsIp6Address(aArgs[1], config.mSource));
+            SuccessOrExit(error = aArgs[1].ParseAsIp6Address(config.mSource));
 #if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
             {
                 bool                  valid        = false;
                 const otNetifAddress *unicastAddrs = otIp6GetUnicastAddresses(mInstance);
 
-                SuccessOrExit(error = ParseAsIp6Address(aArgs[1], config.mSource));
+                SuccessOrExit(error = aArgs[1].ParseAsIp6Address(config.mSource));
+
                 for (const otNetifAddress *addr = unicastAddrs; addr; addr = addr->mNext)
                 {
                     if (otIp6IsAddressEqual(&addr->mAddress, &config.mSource))
@@ -3334,6 +3322,7 @@ otError Interpreter::ProcessPing(uint8_t aArgsLength, char *aArgs[])
                         break;
                     }
                 }
+
                 VerifyOrExit(valid, error = OT_ERROR_INVALID_ARGS);
             }
 #endif
@@ -3342,16 +3331,16 @@ otError Interpreter::ProcessPing(uint8_t aArgsLength, char *aArgs[])
         }
     }
 
-    SuccessOrExit(error = ParseAsIp6Address(aArgs[0], config.mDestination));
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Address(config.mDestination));
 
     if (aArgsLength > 1)
     {
-        SuccessOrExit(error = ParseAsUint16(aArgs[1], config.mSize));
+        SuccessOrExit(error = aArgs[1].ParseAsUint16(config.mSize));
     }
 
     if (aArgsLength > 2)
     {
-        SuccessOrExit(error = ParseAsUint16(aArgs[2], config.mCount));
+        SuccessOrExit(error = aArgs[2].ParseAsUint16(config.mCount));
     }
 
     if (aArgsLength > 3)
@@ -3361,7 +3350,7 @@ otError Interpreter::ProcessPing(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength > 4)
     {
-        SuccessOrExit(error = ParseAsUint8(aArgs[4], config.mHopLimit));
+        SuccessOrExit(error = aArgs[4].ParseAsUint8(config.mHopLimit));
         config.mAllowZeroHopLimit = (config.mHopLimit == 0);
     }
 
@@ -3387,7 +3376,7 @@ exit:
 
 #endif // OPENTHREAD_CONFIG_PING_SENDER_ENABLE
 
-otError Interpreter::ProcessPollPeriod(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPollPeriod(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3399,7 +3388,7 @@ otError Interpreter::ProcessPollPeriod(uint8_t aArgsLength, char *aArgs[])
     {
         uint32_t pollPeriod;
 
-        SuccessOrExit(error = ParseAsUint32(aArgs[0], pollPeriod));
+        SuccessOrExit(error = aArgs[0].ParseAsUint32(pollPeriod));
         error = otLinkSetPollPeriod(mInstance, pollPeriod);
     }
 
@@ -3407,7 +3396,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessPromiscuous(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPromiscuous(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3512,7 +3501,7 @@ void Interpreter::HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx)
 }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
-otError Interpreter::ProcessPrefixAdd(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPrefixAdd(uint8_t aArgsLength, Arg aArgs[])
 {
     otError              error = OT_ERROR_NONE;
     otBorderRouterConfig config;
@@ -3522,26 +3511,26 @@ otError Interpreter::ProcessPrefixAdd(uint8_t aArgsLength, char *aArgs[])
 
     memset(&config, 0, sizeof(otBorderRouterConfig));
 
-    SuccessOrExit(error = ParseAsIp6Prefix(aArgs[argcur], config.mPrefix));
+    SuccessOrExit(error = aArgs[argcur].ParseAsIp6Prefix(config.mPrefix));
     argcur++;
 
     for (; argcur < aArgsLength; argcur++)
     {
-        if (strcmp(aArgs[argcur], "high") == 0)
+        if (aArgs[argcur] == "high")
         {
             config.mPreference = OT_ROUTE_PREFERENCE_HIGH;
         }
-        else if (strcmp(aArgs[argcur], "med") == 0)
+        else if (aArgs[argcur] == "med")
         {
             config.mPreference = OT_ROUTE_PREFERENCE_MED;
         }
-        else if (strcmp(aArgs[argcur], "low") == 0)
+        else if (aArgs[argcur] == "low")
         {
             config.mPreference = OT_ROUTE_PREFERENCE_LOW;
         }
         else
         {
-            for (char *arg = aArgs[argcur]; *arg != '\0'; arg++)
+            for (char *arg = aArgs[argcur].GetCString(); *arg != '\0'; arg++)
             {
                 switch (*arg)
                 {
@@ -3595,14 +3584,14 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessPrefixRemove(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPrefixRemove(uint8_t aArgsLength, Arg aArgs[])
 {
     otError     error = OT_ERROR_NONE;
     otIp6Prefix prefix;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = ParseAsIp6Prefix(aArgs[0], prefix));
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Prefix(prefix));
 
     error = otBorderRouterRemoveOnMeshPrefix(mInstance, &prefix);
 
@@ -3634,7 +3623,7 @@ exit:
     return OT_ERROR_NONE;
 }
 
-otError Interpreter::ProcessPrefix(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPrefix(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3642,15 +3631,15 @@ otError Interpreter::ProcessPrefix(uint8_t aArgsLength, char *aArgs[])
     {
         SuccessOrExit(error = ProcessPrefixList());
     }
-    else if (strcmp(aArgs[0], "add") == 0)
+    else if (aArgs[0] == "add")
     {
         SuccessOrExit(error = ProcessPrefixAdd(aArgsLength - 1, aArgs + 1));
     }
-    else if (strcmp(aArgs[0], "remove") == 0)
+    else if (aArgs[0] == "remove")
     {
         SuccessOrExit(error = ProcessPrefixRemove(aArgsLength - 1, aArgs + 1));
     }
-    else if (strcmp(aArgs[0], "meshlocal") == 0)
+    else if (aArgs[0] == "meshlocal")
     {
         OutputPrefix(*otThreadGetMeshLocalPrefix(mInstance));
         OutputLine("");
@@ -3666,13 +3655,13 @@ exit:
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
 #if OPENTHREAD_FTD
-otError Interpreter::ProcessPreferRouterId(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessPreferRouterId(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
     uint8_t routerId;
 
     VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
-    SuccessOrExit(error = ParseAsUint8(aArgs[0], routerId));
+    SuccessOrExit(error = aArgs[0].ParseAsUint8(routerId));
     error = otThreadSetPreferredRouterId(mInstance, routerId);
 
 exit:
@@ -3680,7 +3669,7 @@ exit:
 }
 #endif
 
-otError Interpreter::ProcessRcp(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRcp(uint8_t aArgsLength, Arg aArgs[])
 {
     otError     error   = OT_ERROR_NONE;
     const char *version = otPlatRadioGetVersionString(mInstance);
@@ -3688,7 +3677,7 @@ otError Interpreter::ProcessRcp(uint8_t aArgsLength, char *aArgs[])
     VerifyOrExit(version != otGetVersionString(), error = OT_ERROR_NOT_IMPLEMENTED);
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "version") == 0)
+    if (aArgs[0] == "version")
     {
         OutputLine("%s", version);
     }
@@ -3701,7 +3690,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessRegion(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRegion(uint8_t aArgsLength, Arg aArgs[])
 {
     otError  error = OT_ERROR_NONE;
     uint16_t regionCode;
@@ -3713,10 +3702,10 @@ otError Interpreter::ProcessRegion(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        VerifyOrExit(strlen(aArgs[0]) == 2, error = OT_ERROR_INVALID_ARGS);
+        VerifyOrExit(aArgs[0].GetLength() == 2, error = OT_ERROR_INVALID_ARGS);
 
-        regionCode =
-            static_cast<uint16_t>(static_cast<uint16_t>(aArgs[0][0]) << 8) + static_cast<uint16_t>(aArgs[0][1]);
+        regionCode = static_cast<uint16_t>(static_cast<uint16_t>(aArgs[0].GetCString()[0]) << 8) +
+                     static_cast<uint16_t>(aArgs[0].GetCString()[1]);
         error = otPlatRadioSetRegion(mInstance, regionCode);
     }
 
@@ -3725,14 +3714,14 @@ exit:
 }
 
 #if OPENTHREAD_FTD
-otError Interpreter::ProcessReleaseRouterId(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessReleaseRouterId(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
     uint8_t routerId;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = ParseAsUint8(aArgs[0], routerId));
+    SuccessOrExit(error = aArgs[0].ParseAsUint8(routerId));
     SuccessOrExit(error = otThreadReleaseRouterId(mInstance, routerId));
 
 exit:
@@ -3740,7 +3729,7 @@ exit:
 }
 #endif
 
-otError Interpreter::ProcessReset(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessReset(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -3750,7 +3739,7 @@ otError Interpreter::ProcessReset(uint8_t aArgsLength, char *aArgs[])
     return OT_ERROR_NONE;
 }
 
-otError Interpreter::ProcessRloc16(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRloc16(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -3761,7 +3750,7 @@ otError Interpreter::ProcessRloc16(uint8_t aArgsLength, char *aArgs[])
 }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
-otError Interpreter::ProcessRouteAdd(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRouteAdd(uint8_t aArgsLength, Arg aArgs[])
 {
     otError               error = OT_ERROR_NONE;
     otExternalRouteConfig config;
@@ -3771,28 +3760,28 @@ otError Interpreter::ProcessRouteAdd(uint8_t aArgsLength, char *aArgs[])
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = ParseAsIp6Prefix(aArgs[argcur], config.mPrefix));
+    SuccessOrExit(error = aArgs[argcur].ParseAsIp6Prefix(config.mPrefix));
     argcur++;
 
     for (; argcur < aArgsLength; argcur++)
     {
-        if (strcmp(aArgs[argcur], "s") == 0)
+        if (aArgs[argcur] == "s")
         {
             config.mStable = true;
         }
-        else if (strcmp(aArgs[argcur], "n") == 0)
+        else if (aArgs[argcur] == "n")
         {
             config.mNat64 = true;
         }
-        else if (strcmp(aArgs[argcur], "high") == 0)
+        else if (aArgs[argcur] == "high")
         {
             config.mPreference = OT_ROUTE_PREFERENCE_HIGH;
         }
-        else if (strcmp(aArgs[argcur], "med") == 0)
+        else if (aArgs[argcur] == "med")
         {
             config.mPreference = OT_ROUTE_PREFERENCE_MED;
         }
-        else if (strcmp(aArgs[argcur], "low") == 0)
+        else if (aArgs[argcur] == "low")
         {
             config.mPreference = OT_ROUTE_PREFERENCE_LOW;
         }
@@ -3808,14 +3797,14 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessRouteRemove(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRouteRemove(uint8_t aArgsLength, Arg aArgs[])
 {
     otError     error = OT_ERROR_NONE;
     otIp6Prefix prefix;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = ParseAsIp6Prefix(aArgs[0], prefix));
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Prefix(prefix));
 
     error = otBorderRouterRemoveRoute(mInstance, &prefix);
 
@@ -3836,7 +3825,7 @@ otError Interpreter::ProcessRouteList(void)
     return OT_ERROR_NONE;
 }
 
-otError Interpreter::ProcessRoute(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRoute(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3844,11 +3833,11 @@ otError Interpreter::ProcessRoute(uint8_t aArgsLength, char *aArgs[])
     {
         SuccessOrExit(error = ProcessRouteList());
     }
-    else if (strcmp(aArgs[0], "add") == 0)
+    else if (aArgs[0] == "add")
     {
         SuccessOrExit(error = ProcessRouteAdd(aArgsLength - 1, aArgs + 1));
     }
-    else if (strcmp(aArgs[0], "remove") == 0)
+    else if (aArgs[0] == "remove")
     {
         SuccessOrExit(error = ProcessRouteRemove(aArgsLength - 1, aArgs + 1));
     }
@@ -3863,7 +3852,7 @@ exit:
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
 #if OPENTHREAD_FTD
-otError Interpreter::ProcessRouter(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRouter(uint8_t aArgsLength, Arg aArgs[])
 {
     otError      error = OT_ERROR_NONE;
     otRouterInfo routerInfo;
@@ -3872,9 +3861,9 @@ otError Interpreter::ProcessRouter(uint8_t aArgsLength, char *aArgs[])
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    isTable = (strcmp(aArgs[0], "table") == 0);
+    isTable = (aArgs[0] == "table");
 
-    if (isTable || strcmp(aArgs[0], "list") == 0)
+    if (isTable || (aArgs[0] == "list"))
     {
         uint8_t maxRouterId;
 
@@ -3916,7 +3905,7 @@ otError Interpreter::ProcessRouter(uint8_t aArgsLength, char *aArgs[])
         ExitNow();
     }
 
-    SuccessOrExit(error = ParseAsUint16(aArgs[0], routerId));
+    SuccessOrExit(error = aArgs[0].ParseAsUint16(routerId));
     SuccessOrExit(error = otThreadGetRouterInfo(mInstance, routerId, &routerInfo));
 
     OutputLine("Alloc: %d", routerInfo.mAllocated);
@@ -3944,7 +3933,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessRouterDowngradeThreshold(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRouterDowngradeThreshold(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3956,7 +3945,7 @@ otError Interpreter::ProcessRouterDowngradeThreshold(uint8_t aArgsLength, char *
     {
         uint8_t threshold;
 
-        SuccessOrExit(error = ParseAsUint8(aArgs[0], threshold));
+        SuccessOrExit(error = aArgs[0].ParseAsUint8(threshold));
         otThreadSetRouterDowngradeThreshold(mInstance, threshold);
     }
 
@@ -3964,7 +3953,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessRouterEligible(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRouterEligible(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3984,7 +3973,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessRouterSelectionJitter(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRouterSelectionJitter(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -3996,7 +3985,7 @@ otError Interpreter::ProcessRouterSelectionJitter(uint8_t aArgsLength, char *aAr
     {
         uint8_t jitter;
 
-        SuccessOrExit(error = ParseAsUint8(aArgs[0], jitter));
+        SuccessOrExit(error = aArgs[0].ParseAsUint8(jitter));
         otThreadSetRouterSelectionJitter(mInstance, jitter);
     }
 
@@ -4004,7 +3993,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessRouterUpgradeThreshold(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessRouterUpgradeThreshold(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -4016,7 +4005,7 @@ otError Interpreter::ProcessRouterUpgradeThreshold(uint8_t aArgsLength, char *aA
     {
         uint8_t threshold;
 
-        SuccessOrExit(error = ParseAsUint8(aArgs[0], threshold));
+        SuccessOrExit(error = aArgs[0].ParseAsUint8(threshold));
         otThreadSetRouterUpgradeThreshold(mInstance, threshold);
     }
 
@@ -4025,7 +4014,7 @@ exit:
 }
 #endif // OPENTHREAD_FTD
 
-otError Interpreter::ProcessScan(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessScan(uint8_t aArgsLength, Arg aArgs[])
 {
     otError  error        = OT_ERROR_NONE;
     uint32_t scanChannels = 0;
@@ -4035,14 +4024,14 @@ otError Interpreter::ProcessScan(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength > 0)
     {
-        if (strcmp(aArgs[index], "energy") == 0)
+        if (aArgs[index] == "energy")
         {
             energyScan = true;
             index++;
 
             if (aArgsLength > 1)
             {
-                SuccessOrExit(error = ParseAsUint16(aArgs[index++], scanDuration));
+                SuccessOrExit(error = aArgs[index++].ParseAsUint16(scanDuration));
             }
         }
 
@@ -4050,7 +4039,7 @@ otError Interpreter::ProcessScan(uint8_t aArgsLength, char *aArgs[])
         {
             uint8_t channel;
 
-            SuccessOrExit(error = ParseAsUint8(aArgs[index++], channel));
+            SuccessOrExit(error = aArgs[index++].ParseAsUint8(channel));
             VerifyOrExit(channel < sizeof(scanChannels) * CHAR_BIT, error = OT_ERROR_INVALID_ARGS);
             scanChannels = 1 << channel;
         }
@@ -4127,7 +4116,7 @@ exit:
     return;
 }
 
-otError Interpreter::ProcessSingleton(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessSingleton(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -4145,7 +4134,7 @@ otError Interpreter::ProcessSingleton(uint8_t aArgsLength, char *aArgs[])
 }
 
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
-otError Interpreter::ProcessSntp(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessSntp(uint8_t aArgsLength, Arg aArgs[])
 {
     otError          error = OT_ERROR_NONE;
     uint16_t         port  = OT_SNTP_DEFAULT_SERVER_PORT;
@@ -4154,13 +4143,13 @@ otError Interpreter::ProcessSntp(uint8_t aArgsLength, char *aArgs[])
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "query") == 0)
+    if (aArgs[0] == "query")
     {
         VerifyOrExit(!mSntpQueryingInProgress, error = OT_ERROR_BUSY);
 
         if (aArgsLength > 1)
         {
-            SuccessOrExit(error = ParseAsIp6Address(aArgs[1], messageInfo.GetPeerAddr()));
+            SuccessOrExit(error = aArgs[1].ParseAsIp6Address(messageInfo.GetPeerAddr()));
         }
         else
         {
@@ -4170,7 +4159,7 @@ otError Interpreter::ProcessSntp(uint8_t aArgsLength, char *aArgs[])
 
         if (aArgsLength > 2)
         {
-            SuccessOrExit(error = ParseAsUint16(aArgs[2], port));
+            SuccessOrExit(error = aArgs[2].ParseAsUint16(port));
         }
 
         messageInfo.SetPeerPort(port);
@@ -4218,7 +4207,7 @@ void Interpreter::HandleSntpResponse(uint64_t aTime, otError aResult)
 #endif // OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE || OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
-otError Interpreter::ProcessSrp(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessSrp(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -4234,13 +4223,13 @@ otError Interpreter::ProcessSrp(uint8_t aArgsLength, char *aArgs[])
     }
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
-    if (strcmp(aArgs[0], "client") == 0)
+    if (aArgs[0] == "client")
     {
         ExitNow(error = mSrpClient.Process(aArgsLength - 1, aArgs + 1));
     }
 #endif
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
-    if (strcmp(aArgs[0], "server") == 0)
+    if (aArgs[0] == "server")
     {
         ExitNow(error = mSrpServer.Process(aArgsLength - 1, aArgs + 1));
     }
@@ -4253,7 +4242,7 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE || OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
 
-otError Interpreter::ProcessState(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessState(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -4290,21 +4279,21 @@ otError Interpreter::ProcessState(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        if (strcmp(aArgs[0], "detached") == 0)
+        if (aArgs[0] == "detached")
         {
             SuccessOrExit(error = otThreadBecomeDetached(mInstance));
         }
-        else if (strcmp(aArgs[0], "child") == 0)
+        else if (aArgs[0] == "child")
         {
             SuccessOrExit(error = otThreadBecomeChild(mInstance));
         }
 
 #if OPENTHREAD_FTD
-        else if (strcmp(aArgs[0], "router") == 0)
+        else if (aArgs[0] == "router")
         {
             SuccessOrExit(error = otThreadBecomeRouter(mInstance));
         }
-        else if (strcmp(aArgs[0], "leader") == 0)
+        else if (aArgs[0] == "leader")
         {
             SuccessOrExit(error = otThreadBecomeLeader(mInstance));
         }
@@ -4319,21 +4308,21 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessThread(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessThread(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "start") == 0)
+    if (aArgs[0] == "start")
     {
         SuccessOrExit(error = otThreadSetEnabled(mInstance, true));
     }
-    else if (strcmp(aArgs[0], "stop") == 0)
+    else if (aArgs[0] == "stop")
     {
         SuccessOrExit(error = otThreadSetEnabled(mInstance, false));
     }
-    else if (strcmp(aArgs[0], "version") == 0)
+    else if (aArgs[0] == "version")
     {
         OutputLine("%u", otThreadGetVersion());
     }
@@ -4346,12 +4335,12 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessDataset(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDataset(uint8_t aArgsLength, Arg aArgs[])
 {
     return mDataset.Process(aArgsLength, aArgs);
 }
 
-otError Interpreter::ProcessTxPower(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessTxPower(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
     int8_t  power;
@@ -4363,7 +4352,7 @@ otError Interpreter::ProcessTxPower(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        SuccessOrExit(error = ParseAsInt8(aArgs[0], power));
+        SuccessOrExit(error = aArgs[0].ParseAsInt8(power));
         SuccessOrExit(error = otPlatRadioSetTransmitPower(mInstance, power));
     }
 
@@ -4371,30 +4360,30 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessUdp(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessUdp(uint8_t aArgsLength, Arg aArgs[])
 {
     return mUdp.Process(aArgsLength, aArgs);
 }
 
-otError Interpreter::ProcessUnsecurePort(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessUnsecurePort(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgsLength >= 1, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "add") == 0)
+    if (aArgs[0] == "add")
     {
         uint16_t port;
 
         VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
-        SuccessOrExit(error = ParseAsUint16(aArgs[1], port));
+        SuccessOrExit(error = aArgs[1].ParseAsUint16(port));
         SuccessOrExit(error = otIp6AddUnsecurePort(mInstance, port));
     }
-    else if (strcmp(aArgs[0], "remove") == 0)
+    else if (aArgs[0] == "remove")
     {
         VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
 
-        if (strcmp(aArgs[1], "all") == 0)
+        if (aArgs[1] == "all")
         {
             otIp6RemoveAllUnsecurePorts(mInstance);
         }
@@ -4402,11 +4391,11 @@ otError Interpreter::ProcessUnsecurePort(uint8_t aArgsLength, char *aArgs[])
         {
             uint16_t port;
 
-            SuccessOrExit(error = ParseAsUint16(aArgs[1], port));
+            SuccessOrExit(error = aArgs[1].ParseAsUint16(port));
             SuccessOrExit(error = otIp6RemoveUnsecurePort(mInstance, port));
         }
     }
-    else if (strcmp(aArgs[0], "get") == 0)
+    else if (aArgs[0] == "get")
     {
         const uint16_t *ports;
         uint8_t         numPorts;
@@ -4432,7 +4421,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessVersion(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessVersion(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -4442,7 +4431,7 @@ otError Interpreter::ProcessVersion(uint8_t aArgsLength, char *aArgs[])
         ExitNow();
     }
 
-    if (strcmp(aArgs[0], "api") == 0)
+    if (aArgs[0] == "api")
     {
         OutputLine("%d", OPENTHREAD_API_VERSION);
     }
@@ -4456,21 +4445,21 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-otError Interpreter::ProcessCommissioner(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessCommissioner(uint8_t aArgsLength, Arg aArgs[])
 {
     return mCommissioner.Process(aArgsLength, aArgs);
 }
 #endif
 
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
-otError Interpreter::ProcessJoiner(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessJoiner(uint8_t aArgsLength, Arg aArgs[])
 {
     return mJoiner.Process(aArgsLength, aArgs);
 }
 #endif
 
 #if OPENTHREAD_FTD
-otError Interpreter::ProcessJoinerPort(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessJoinerPort(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -4482,7 +4471,7 @@ otError Interpreter::ProcessJoinerPort(uint8_t aArgsLength, char *aArgs[])
     {
         uint16_t port;
 
-        SuccessOrExit(error = ParseAsUint16(aArgs[0], port));
+        SuccessOrExit(error = aArgs[0].ParseAsUint16(port));
         error = otThreadSetJoinerUdpPort(mInstance, port);
     }
 
@@ -4492,7 +4481,7 @@ exit:
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
-otError Interpreter::ProcessMacFilter(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMacFilter(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -4502,11 +4491,11 @@ otError Interpreter::ProcessMacFilter(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        if (strcmp(aArgs[0], "addr") == 0)
+        if (aArgs[0] == "addr")
         {
             error = ProcessMacFilterAddress(aArgsLength - 1, aArgs + 1);
         }
-        else if (strcmp(aArgs[0], "rss") == 0)
+        else if (aArgs[0] == "rss")
         {
             error = ProcessMacFilterRss(aArgsLength - 1, aArgs + 1);
         }
@@ -4578,7 +4567,7 @@ void Interpreter::PrintMacFilter(void)
     }
 }
 
-otError Interpreter::ProcessMacFilterAddress(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMacFilterAddress(uint8_t aArgsLength, Arg aArgs[])
 {
     otError                error = OT_ERROR_NONE;
     otExtAddress           extAddr;
@@ -4616,25 +4605,25 @@ otError Interpreter::ProcessMacFilterAddress(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        if (strcmp(aArgs[0], "disable") == 0)
+        if (aArgs[0] == "disable")
         {
             VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
             otLinkFilterSetAddressMode(mInstance, OT_MAC_FILTER_ADDRESS_MODE_DISABLED);
         }
-        else if (strcmp(aArgs[0], "allowlist") == 0)
+        else if (aArgs[0] == "allowlist")
         {
             VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
             otLinkFilterSetAddressMode(mInstance, OT_MAC_FILTER_ADDRESS_MODE_ALLOWLIST);
         }
-        else if (strcmp(aArgs[0], "denylist") == 0)
+        else if (aArgs[0] == "denylist")
         {
             VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
             otLinkFilterSetAddressMode(mInstance, OT_MAC_FILTER_ADDRESS_MODE_DENYLIST);
         }
-        else if (strcmp(aArgs[0], "add") == 0)
+        else if (aArgs[0] == "add")
         {
             VerifyOrExit(aArgsLength >= 2, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseAsHexString(aArgs[1], extAddr.m8));
+            SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
             error = otLinkFilterAddAddress(mInstance, &extAddr);
 
             VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY);
@@ -4644,17 +4633,17 @@ otError Interpreter::ProcessMacFilterAddress(uint8_t aArgsLength, char *aArgs[])
                 int8_t rss;
 
                 VerifyOrExit(aArgsLength == 3, error = OT_ERROR_INVALID_ARGS);
-                SuccessOrExit(error = ParseAsInt8(aArgs[2], rss));
+                SuccessOrExit(error = aArgs[2].ParseAsInt8(rss));
                 SuccessOrExit(error = otLinkFilterAddRssIn(mInstance, &extAddr, rss));
             }
         }
-        else if (strcmp(aArgs[0], "remove") == 0)
+        else if (aArgs[0] == "remove")
         {
             VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseAsHexString(aArgs[1], extAddr.m8));
+            SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
             otLinkFilterRemoveAddress(mInstance, &extAddr);
         }
-        else if (strcmp(aArgs[0], "clear") == 0)
+        else if (aArgs[0] == "clear")
         {
             VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
             otLinkFilterClearAddresses(mInstance);
@@ -4669,7 +4658,7 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessMacFilterRss(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMacFilterRss(uint8_t aArgsLength, Arg aArgs[])
 {
     otError             error = OT_ERROR_NONE;
     otMacFilterEntry    entry;
@@ -4705,56 +4694,56 @@ otError Interpreter::ProcessMacFilterRss(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        if (strcmp(aArgs[0], "add-lqi") == 0)
+        if (aArgs[0] == "add-lqi")
         {
             uint8_t linkQuality;
 
             VerifyOrExit(aArgsLength == 3, error = OT_ERROR_INVALID_ARGS);
 
-            SuccessOrExit(error = ParseAsUint8(aArgs[2], linkQuality));
+            SuccessOrExit(error = aArgs[2].ParseAsUint8(linkQuality));
             VerifyOrExit(linkQuality <= 3, error = OT_ERROR_INVALID_ARGS);
             rss = otLinkConvertLinkQualityToRss(mInstance, linkQuality);
 
-            if (strcmp(aArgs[1], "*") == 0)
+            if (aArgs[1] == "*")
             {
                 otLinkFilterSetDefaultRssIn(mInstance, rss);
             }
             else
             {
-                SuccessOrExit(error = ParseAsHexString(aArgs[1], extAddr.m8));
+                SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
                 SuccessOrExit(error = otLinkFilterAddRssIn(mInstance, &extAddr, rss));
             }
         }
-        else if (strcmp(aArgs[0], "add") == 0)
+        else if (aArgs[0] == "add")
         {
             VerifyOrExit(aArgsLength == 3, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseAsInt8(aArgs[2], rss));
+            SuccessOrExit(error = aArgs[2].ParseAsInt8(rss));
 
-            if (strcmp(aArgs[1], "*") == 0)
+            if (aArgs[1] == "*")
             {
                 otLinkFilterSetDefaultRssIn(mInstance, rss);
             }
             else
             {
-                SuccessOrExit(error = ParseAsHexString(aArgs[1], extAddr.m8));
+                SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
                 SuccessOrExit(error = otLinkFilterAddRssIn(mInstance, &extAddr, rss));
             }
         }
-        else if (strcmp(aArgs[0], "remove") == 0)
+        else if (aArgs[0] == "remove")
         {
             VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
 
-            if (strcmp(aArgs[1], "*") == 0)
+            if (aArgs[1] == "*")
             {
                 otLinkFilterClearDefaultRssIn(mInstance);
             }
             else
             {
-                SuccessOrExit(error = ParseAsHexString(aArgs[1], extAddr.m8));
+                SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
                 otLinkFilterRemoveRssIn(mInstance, &extAddr);
             }
         }
-        else if (strcmp(aArgs[0], "clear") == 0)
+        else if (aArgs[0] == "clear")
         {
             otLinkFilterClearAllRssIn(mInstance);
         }
@@ -4770,18 +4759,18 @@ exit:
 
 #endif // OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
 
-otError Interpreter::ProcessMac(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMac(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "retries") == 0)
+    if (aArgs[0] == "retries")
     {
         error = ProcessMacRetries(aArgsLength - 1, aArgs + 1);
     }
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    else if (strcmp(aArgs[0], "send") == 0)
+    else if (aArgs[0] == "send")
     {
         error = ProcessMacSend(aArgsLength - 1, aArgs + 1);
     }
@@ -4795,13 +4784,13 @@ exit:
     return error;
 }
 
-otError Interpreter::ProcessMacRetries(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMacRetries(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgsLength > 0 && aArgsLength <= 2, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "direct") == 0)
+    if (aArgs[0] == "direct")
     {
         if (aArgsLength == 1)
         {
@@ -4811,12 +4800,12 @@ otError Interpreter::ProcessMacRetries(uint8_t aArgsLength, char *aArgs[])
         {
             uint8_t retries;
 
-            SuccessOrExit(error = ParseAsUint8(aArgs[1], retries));
+            SuccessOrExit(error = aArgs[1].ParseAsUint8(retries));
             otLinkSetMaxFrameRetriesDirect(mInstance, retries);
         }
     }
 #if OPENTHREAD_FTD
-    else if (strcmp(aArgs[0], "indirect") == 0)
+    else if (aArgs[0] == "indirect")
     {
         if (aArgsLength == 1)
         {
@@ -4826,7 +4815,7 @@ otError Interpreter::ProcessMacRetries(uint8_t aArgsLength, char *aArgs[])
         {
             uint8_t retries;
 
-            SuccessOrExit(error = ParseAsUint8(aArgs[1], retries));
+            SuccessOrExit(error = aArgs[1].ParseAsUint8(retries));
             otLinkSetMaxFrameRetriesIndirect(mInstance, retries);
         }
     }
@@ -4841,17 +4830,17 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-otError Interpreter::ProcessMacSend(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessMacSend(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_INVALID_ARGS;
 
     VerifyOrExit(aArgsLength == 1);
 
-    if (strcmp(aArgs[0], "datarequest") == 0)
+    if (aArgs[0] == "datarequest")
     {
         error = otLinkSendDataRequest(mInstance);
     }
-    else if (strcmp(aArgs[0], "emptydata") == 0)
+    else if (aArgs[0] == "emptydata")
     {
         error = otLinkSendEmptyData(mInstance);
     }
@@ -4862,16 +4851,20 @@ exit:
 #endif
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-otError Interpreter::ProcessDiag(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessDiag(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error;
+    char *  args[kMaxArgs];
     char    output[OPENTHREAD_CONFIG_DIAG_OUTPUT_BUFFER_SIZE];
 
     // all diagnostics related features are processed within diagnostics module
     output[0]                  = '\0';
     output[sizeof(output) - 1] = '\0';
 
-    error = otDiagProcessCmd(mInstance, aArgsLength, aArgs, output, sizeof(output) - 1);
+    Arg::CopyArgsToStringArray(aArgs, aArgsLength, args);
+
+    error = otDiagProcessCmd(mInstance, aArgsLength, args, output, sizeof(output) - 1);
+
     OutputFormat("%s", output);
 
     return error;
@@ -4880,7 +4873,7 @@ otError Interpreter::ProcessDiag(uint8_t aArgsLength, char *aArgs[])
 
 void Interpreter::ProcessLine(char *aBuf)
 {
-    char *         args[kMaxArgs] = {nullptr};
+    Arg            args[kMaxArgs];
     uint8_t        argsLength;
     const Command *command;
 
@@ -4891,11 +4884,11 @@ void Interpreter::ProcessLine(char *aBuf)
     VerifyOrExit(argsLength >= 1);
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-    VerifyOrExit((!otDiagIsEnabled(mInstance) || (strcmp(args[0], "diag") == 0)),
+    VerifyOrExit((!otDiagIsEnabled(mInstance) || (args[0] == "diag")),
                  OutputLine("under diagnostics mode, execute 'diag stop' before running any other commands."));
 #endif
 
-    command = Utils::LookupTable::Find(args[0], sCommands);
+    command = Utils::LookupTable::Find(args[0].GetCString(), sCommands);
 
     if (command != nullptr)
     {
@@ -4903,20 +4896,31 @@ void Interpreter::ProcessLine(char *aBuf)
         ExitNow();
     }
 
-    // Check user defined commands if built-in command has not been found
-    for (uint8_t i = 0; i < mUserCommandsLength; i++)
-    {
-        if (strcmp(args[0], mUserCommands[i].mName) == 0)
-        {
-            mUserCommands[i].mCommand(mUserCommandsContext, argsLength - 1, &args[1]);
-            ExitNow();
-        }
-    }
-
+    SuccessOrExit(ProcessUserCommands(argsLength, args));
     OutputResult(OT_ERROR_INVALID_COMMAND);
 
 exit:
     return;
+}
+
+otError Interpreter::ProcessUserCommands(uint8_t aArgsLength, Arg aArgs[])
+{
+    otError error = OT_ERROR_NOT_FOUND;
+
+    for (uint8_t i = 0; i < mUserCommandsLength; i++)
+    {
+        if (aArgs[0] == mUserCommands[i].mName)
+        {
+            char *args[kMaxArgs];
+
+            Arg::CopyArgsToStringArray(aArgs, aArgsLength, args);
+            mUserCommands[i].mCommand(mUserCommandsContext, aArgsLength - 1, args + 1);
+            error = OT_ERROR_NONE;
+            break;
+        }
+    }
+
+    return error;
 }
 
 void Interpreter::OutputPrefix(const otMeshLocalPrefix &aPrefix)
@@ -4926,7 +4930,7 @@ void Interpreter::OutputPrefix(const otMeshLocalPrefix &aPrefix)
 }
 
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
-otError Interpreter::ProcessNetworkDiagnostic(uint8_t aArgsLength, char *aArgs[])
+otError Interpreter::ProcessNetworkDiagnostic(uint8_t aArgsLength, Arg aArgs[])
 {
     otError      error = OT_ERROR_NONE;
     otIp6Address address;
@@ -4937,22 +4941,22 @@ otError Interpreter::ProcessNetworkDiagnostic(uint8_t aArgsLength, char *aArgs[]
     // Include operation, address and type tlv list.
     VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = ParseAsIp6Address(aArgs[1], address));
+    SuccessOrExit(error = aArgs[1].ParseAsIp6Address(address));
 
     argsIndex = 2;
 
     while (argsIndex < aArgsLength && count < sizeof(tlvTypes))
     {
-        SuccessOrExit(error = ParseAsUint8(aArgs[argsIndex++], tlvTypes[count++]));
+        SuccessOrExit(error = aArgs[argsIndex++].ParseAsUint8(tlvTypes[count++]));
     }
 
-    if (strcmp(aArgs[0], "get") == 0)
+    if (aArgs[0] == "get")
     {
         SuccessOrExit(error = otThreadSendDiagnosticGet(mInstance, &address, tlvTypes, count,
                                                         &Interpreter::HandleDiagnosticGetResponse, this));
         ExitNow(error = OT_ERROR_PENDING);
     }
-    else if (strcmp(aArgs[0], "reset") == 0)
+    else if (aArgs[0] == "reset")
     {
         IgnoreError(otThreadSendDiagnosticReset(mInstance, &address, tlvTypes, count));
     }

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -69,6 +69,7 @@
 #include "common/debug.hpp"
 #include "common/instance.hpp"
 #include "utils/lookup_table.hpp"
+#include "utils/parse_cmdline.hpp"
 
 namespace ot {
 
@@ -98,6 +99,8 @@ class Interpreter
     friend class UdpExample;
 
 public:
+    typedef Utils::CmdLineParser::Arg Arg;
+
     /**
      * Constructor
      *
@@ -283,9 +286,9 @@ public:
     void OutputEnabledDisabledStatus(bool aEnabled);
 
     /**
-     * This static method checks a given string against "enable" or "disable" commands.
+     * This static method checks a given argument string against "enable" or "disable" commands.
      *
-     * @param[in]  aString  The string to parse.
+     * @param[in]  aArgs    The argument string to parse.
      * @param[out] aEnable  Boolean variable to return outcome on success.
      *                      Set to TRUE for "enable" command, and FALSE for "disable" command.
      *
@@ -293,7 +296,7 @@ public:
      * @retval OT_ERROR_INVALID_COMMAND  The @p aString is not "enable" or "disable" command.
      *
      */
-    static otError ParseEnableOrDisable(const char *aString, bool &aEnable);
+    static otError ParseEnableOrDisable(const Arg &aArg, bool &aEnable);
 
     /**
      * This method sets the user command table.
@@ -320,126 +323,127 @@ private:
     struct Command
     {
         const char *mName;
-        otError (Interpreter::*mHandler)(uint8_t aArgsLength, char *aArgs[]);
+        otError (Interpreter::*mHandler)(uint8_t aArgsLength, Arg aArgs[]);
     };
 
 #if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
-    otError ParsePingInterval(const char *aString, uint32_t &aInterval);
+    otError ParsePingInterval(const Arg &aArg, uint32_t &aInterval);
 #endif
-    static otError ParseJoinerDiscerner(char *aString, otJoinerDiscerner &aDiscerner);
+    static otError ParseJoinerDiscerner(Arg &aArg, otJoinerDiscerner &aDiscerner);
 
-    otError ProcessHelp(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessCcaThreshold(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessBufferInfo(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessChannel(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessUserCommands(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessHelp(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessCcaThreshold(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessBufferInfo(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessChannel(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    otError ProcessBorderAgent(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessBorderAgent(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    otError ProcessBorderRouting(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessBorderRouting(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-    otError ProcessBackboneRouter(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessBackboneRouter(uint8_t aArgsLength, Arg aArgs[]);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    otError ProcessBackboneRouterLocal(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessBackboneRouterLocal(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE && OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
-    otError ProcessBackboneRouterMgmtMlr(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessBackboneRouterMgmtMlr(uint8_t aArgsLength, Arg aArgs[]);
     void    PrintMulticastListenersTable(void);
 #endif
 #endif
 
-    otError ProcessDomainName(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDomainName(uint8_t aArgsLength, Arg aArgs[]);
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
-    otError ProcessDua(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDua(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
 #if OPENTHREAD_FTD
-    otError ProcessChild(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessChildIp(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessChildMax(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessChild(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessChildIp(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessChildMax(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 #if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
-    otError ProcessChildSupervision(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessChildSupervision(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessChildTimeout(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessChildTimeout(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
-    otError ProcessCoap(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessCoap(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-    otError ProcessCoapSecure(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessCoapSecure(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 #if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
-    otError ProcessCoexMetrics(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessCoexMetrics(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-    otError ProcessCommissioner(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessCommissioner(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 #if OPENTHREAD_FTD
-    otError ProcessContextIdReuseDelay(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessContextIdReuseDelay(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessCounters(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessCsl(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessCounters(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessCsl(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_FTD
-    otError ProcessDelayTimerMin(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDelayTimerMin(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-    otError ProcessDiag(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDiag(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessDiscover(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessDns(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDiscover(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessDns(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_FTD
     void    OutputEidCacheEntry(const otCacheEntryInfo &aEntry);
-    otError ProcessEidCache(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessEidCache(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessEui64(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessEui64(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_POSIX && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
-    otError ProcessExit(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessExit(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessLog(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessExtAddress(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessExtPanId(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessFactoryReset(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessLog(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessExtAddress(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessExtPanId(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessFactoryReset(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    otError ProcessFake(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessFake(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessFem(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessIfconfig(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessIpAddr(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessIpAddrAdd(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessIpAddrDel(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessIpMulticastAddr(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessIpMulticastAddrAdd(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessIpMulticastAddrDel(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessMulticastPromiscuous(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessFem(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessIfconfig(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessIpAddr(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessIpAddrAdd(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessIpAddrDel(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessIpMulticastAddr(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessIpMulticastAddrAdd(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessIpMulticastAddrDel(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessMulticastPromiscuous(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
-    otError ProcessJoiner(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessJoiner(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 #if OPENTHREAD_FTD
-    otError ProcessJoinerPort(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessJoinerPort(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessKeySequence(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessLeaderData(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessKeySequence(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessLeaderData(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_FTD
-    otError ProcessPartitionId(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessLeaderWeight(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessPartitionId(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessLeaderWeight(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessMasterKey(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMasterKey(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_ENABLE
-    otError ProcessLinkMetrics(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessLinkMetricsQuery(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessLinkMetricsMgmt(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessLinkMetricsProbe(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessLinkMetrics(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessLinkMetricsQuery(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessLinkMetricsMgmt(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessLinkMetricsProbe(uint8_t aArgsLength, Arg aArgs[]);
 
-    otError ParseLinkMetricsFlags(otLinkMetrics &aLinkMetrics, char *aFlags);
+    otError ParseLinkMetricsFlags(otLinkMetrics &aLinkMetrics, const Arg &aFlags);
 #endif
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-    otError ProcessMlr(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMlr(uint8_t aArgsLength, Arg aArgs[]);
 
-    otError ProcessMlrReg(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMlrReg(uint8_t aArgsLength, Arg aArgs[]);
 
     static void HandleMlrRegResult(void *              aContext,
                                    otError             aError,
@@ -451,15 +455,15 @@ private:
                                    const otIp6Address *aFailedAddresses,
                                    uint8_t             aFailedAddressNum);
 #endif
-    otError ProcessMode(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessMultiRadio(uint8_t aArgsLength, char *aArgsp[]);
+    otError ProcessMode(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessMultiRadio(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     void OutputMultiRadioInfo(const otMultiRadioNeighborInfo &aMultiRadioInfo);
 #endif
 #if OPENTHREAD_FTD
-    otError ProcessNeighbor(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNeighbor(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessNetworkData(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNetworkData(uint8_t aArgsLength, Arg aArgs[]);
     otError ProcessNetworkDataPrefix(void);
     otError ProcessNetworkDataRoute(void);
     otError ProcessNetworkDataService(void);
@@ -469,89 +473,89 @@ private:
     void    OutputService(const otServiceConfig &aConfig);
 
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
-    otError ProcessNetif(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNetif(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessNetstat(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNetstat(uint8_t aArgsLength, Arg aArgs[]);
     int     OutputSocketAddress(const otSockAddr &aAddress);
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    otError ProcessService(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessService(uint8_t aArgsLength, Arg aArgs[]);
     otError ProcessServiceList(void);
 #endif
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
-    otError ProcessNetworkDiagnostic(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNetworkDiagnostic(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 #if OPENTHREAD_FTD
-    otError ProcessNetworkIdTimeout(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNetworkIdTimeout(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessNetworkName(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNetworkName(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    otError ProcessNetworkTime(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessNetworkTime(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessPanId(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessParent(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessPanId(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessParent(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_FTD
-    otError ProcessParentPriority(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessParentPriority(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 #if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
-    otError ProcessPing(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessPing(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessPollPeriod(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessPollPeriod(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
-    otError ProcessPrefix(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessPrefixAdd(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessPrefixRemove(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessPrefix(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessPrefixAdd(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessPrefixRemove(uint8_t aArgsLength, Arg aArgs[]);
     otError ProcessPrefixList(void);
 #endif
-    otError ProcessPromiscuous(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessPromiscuous(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_FTD
-    otError ProcessPreferRouterId(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessPskc(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessPreferRouterId(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessPskc(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessRcp(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessRegion(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessRcp(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessRegion(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_FTD
-    otError ProcessReleaseRouterId(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessReleaseRouterId(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessReset(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessReset(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
-    otError ProcessRoute(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessRouteAdd(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessRouteRemove(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessRoute(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessRouteAdd(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessRouteRemove(uint8_t aArgsLength, Arg aArgs[]);
     otError ProcessRouteList(void);
 #endif
 #if OPENTHREAD_FTD
-    otError ProcessRouter(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessRouterDowngradeThreshold(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessRouterEligible(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessRouterSelectionJitter(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessRouterUpgradeThreshold(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessRouter(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessRouterDowngradeThreshold(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessRouterEligible(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessRouterSelectionJitter(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessRouterUpgradeThreshold(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessRloc16(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessScan(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessSingleton(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessRloc16(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessScan(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessSingleton(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
-    otError ProcessSntp(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessSntp(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE || OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
-    otError ProcessSrp(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessSrp(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessState(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessThread(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessDataset(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessTxPower(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessUdp(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessUnsecurePort(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessVersion(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessState(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessThread(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessDataset(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessTxPower(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessUdp(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessUnsecurePort(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessVersion(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
-    otError ProcessMacFilter(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMacFilter(uint8_t aArgsLength, Arg aArgs[]);
     void    PrintMacFilter(void);
-    otError ProcessMacFilterAddress(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessMacFilterRss(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMacFilterAddress(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessMacFilterRss(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessMac(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessMacRetries(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMac(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessMacRetries(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    otError ProcessMacSend(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessMacSend(uint8_t aArgsLength, Arg aArgs[]);
 #endif
 
 #if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
@@ -581,7 +585,7 @@ private:
     void OutputDnsTxtData(const uint8_t *aTxtData, uint16_t aTxtDataLength);
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
-    otError     GetDnsConfig(uint8_t aArgsLength, char *aArgs[], otDnsQueryConfig *&aConfig, uint8_t aStartArgsIndex);
+    otError     GetDnsConfig(uint8_t aArgsLength, Arg aArgs[], otDnsQueryConfig *&aConfig, uint8_t aStartArgsIndex);
     static void HandleDnsAddressResponse(otError aError, const otDnsAddressResponse *aResponse, void *aContext);
     void        HandleDnsAddressResponse(otError aError, const otDnsAddressResponse *aResponse);
 #if OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE

--- a/src/cli/cli_coap.hpp
+++ b/src/cli/cli_coap.hpp
@@ -40,6 +40,7 @@
 
 #include "coap/coap_message.hpp"
 #include "utils/lookup_table.hpp"
+#include "utils/parse_cmdline.hpp"
 
 namespace ot {
 namespace Cli {
@@ -53,6 +54,8 @@ class Interpreter;
 class Coap
 {
 public:
+    typedef Utils::CmdLineParser::Arg Arg;
+
     /**
      * Constructor
      *
@@ -68,7 +71,7 @@ public:
      * @param[in]  aArgs        An array of command line arguments.
      *
      */
-    otError Process(uint8_t aArgsLength, char *aArgs[]);
+    otError Process(uint8_t aArgsLength, Arg aArgs[]);
 
 private:
     enum
@@ -80,7 +83,7 @@ private:
     struct Command
     {
         const char *mName;
-        otError (Coap::*mHandler)(uint8_t aArgsLength, char *aArgs[]);
+        otError (Coap::*mHandler)(uint8_t aArgsLength, Arg aArgs[]);
     };
 
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
@@ -90,16 +93,16 @@ private:
 
     void PrintPayload(otMessage *aMessage) const;
 
-    otError ProcessHelp(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessHelp(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
-    otError ProcessCancel(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessCancel(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessParameters(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessRequest(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessResource(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessSet(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessStart(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessStop(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessParameters(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessRequest(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessResource(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessSet(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessStart(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessStop(uint8_t aArgsLength, Arg aArgs[]);
 
     static void HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo);

--- a/src/cli/cli_coap_secure.hpp
+++ b/src/cli/cli_coap_secure.hpp
@@ -41,6 +41,7 @@
 #include "coap/coap_message.hpp"
 #include "coap/coap_secure.hpp"
 #include "utils/lookup_table.hpp"
+#include "utils/parse_cmdline.hpp"
 
 #ifndef CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER
 #define CLI_COAP_SECURE_USE_COAP_DEFAULT_HANDLER 0
@@ -58,6 +59,8 @@ class Interpreter;
 class CoapSecure
 {
 public:
+    typedef Utils::CmdLineParser::Arg Arg;
+
     /**
      * Constructor
      *
@@ -73,7 +76,7 @@ public:
      * @param[in]  aArgs        An array of command line arguments.
      *
      */
-    otError Process(uint8_t aArgsLength, char *aArgs[]);
+    otError Process(uint8_t aArgsLength, Arg aArgs[]);
 
 private:
     enum
@@ -87,21 +90,21 @@ private:
     struct Command
     {
         const char *mName;
-        otError (CoapSecure::*mHandler)(uint8_t aArgsLength, char *aArgs[]);
+        otError (CoapSecure::*mHandler)(uint8_t aArgsLength, Arg aArgs[]);
     };
 
     void PrintPayload(otMessage *aMessage) const;
 
-    otError ProcessHelp(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessConnect(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessDisconnect(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessPsk(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessRequest(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessResource(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessSet(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessStart(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessStop(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessX509(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessHelp(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessConnect(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessDisconnect(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessPsk(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessRequest(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessResource(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessSet(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessStart(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessStop(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessX509(uint8_t aArgsLength, Arg aArgs[]);
 
     void Stop(void);
 

--- a/src/cli/cli_commissioner.hpp
+++ b/src/cli/cli_commissioner.hpp
@@ -39,6 +39,7 @@
 #include <openthread/commissioner.h>
 
 #include "utils/lookup_table.hpp"
+#include "utils/parse_cmdline.hpp"
 
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
 
@@ -54,6 +55,8 @@ class Interpreter;
 class Commissioner
 {
 public:
+    typedef Utils::CmdLineParser::Arg Arg;
+
     /**
      * Constructor
      *
@@ -72,7 +75,7 @@ public:
      * @param[in]  aArgs        An array of command line arguments.
      *
      */
-    otError Process(uint8_t aArgsLength, char *aArgs[]);
+    otError Process(uint8_t aArgsLength, Arg aArgs[]);
 
 private:
     enum
@@ -83,21 +86,21 @@ private:
     struct Command
     {
         const char *mName;
-        otError (Commissioner::*mHandler)(uint8_t aArgsLength, char *aArgs[]);
+        otError (Commissioner::*mHandler)(uint8_t aArgsLength, Arg aArgs[]);
     };
 
-    otError ProcessHelp(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessAnnounce(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessEnergy(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessJoiner(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessMgmtGet(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessMgmtSet(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessPanId(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessProvisioningUrl(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessSessionId(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessStart(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessState(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessStop(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessHelp(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessAnnounce(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessEnergy(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessJoiner(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessMgmtGet(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessMgmtSet(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessPanId(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessProvisioningUrl(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessSessionId(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessStart(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessState(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessStop(uint8_t aArgsLength, Arg aArgs[]);
 
     static void HandleStateChanged(otCommissionerState aState, void *aContext);
     void        HandleStateChanged(otCommissionerState aState);

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -42,13 +42,6 @@
 
 #include "cli/cli.hpp"
 #include "common/string.hpp"
-#include "utils/parse_cmdline.hpp"
-
-using ot::Utils::CmdLineParser::ParseAsHexString;
-using ot::Utils::CmdLineParser::ParseAsIp6Address;
-using ot::Utils::CmdLineParser::ParseAsUint16;
-using ot::Utils::CmdLineParser::ParseAsUint32;
-using ot::Utils::CmdLineParser::ParseAsUint64;
 
 namespace ot {
 namespace Cli {
@@ -134,7 +127,7 @@ otError Dataset::Print(otOperationalDataset &aDataset)
     return OT_ERROR_NONE;
 }
 
-otError Dataset::Process(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::Process(uint8_t aArgsLength, Arg aArgs[])
 {
     otError        error = OT_ERROR_INVALID_COMMAND;
     const Command *command;
@@ -144,7 +137,7 @@ otError Dataset::Process(uint8_t aArgsLength, char *aArgs[])
         ExitNow(error = Print(sDataset));
     }
 
-    command = Utils::LookupTable::Find(aArgs[0], sCommands);
+    command = Utils::LookupTable::Find(aArgs[0].GetCString(), sCommands);
     VerifyOrExit(command != nullptr);
 
     error = (this->*command->mHandler)(aArgsLength - 1, aArgs + 1);
@@ -153,7 +146,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessHelp(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -166,22 +159,22 @@ otError Dataset::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
     return OT_ERROR_NONE;
 }
 
-otError Dataset::ProcessInit(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessInit(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "active") == 0)
+    if (aArgs[0] == "active")
     {
         SuccessOrExit(error = otDatasetGetActive(mInterpreter.mInstance, &sDataset));
     }
-    else if (strcmp(aArgs[0], "pending") == 0)
+    else if (aArgs[0] == "pending")
     {
         SuccessOrExit(error = otDatasetGetPending(mInterpreter.mInstance, &sDataset));
     }
 #if OPENTHREAD_FTD
-    else if (strcmp(aArgs[0], "new") == 0)
+    else if (aArgs[0] == "new")
     {
         SuccessOrExit(error = otDatasetCreateNewNetwork(mInterpreter.mInstance, &sDataset));
     }
@@ -195,7 +188,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessActive(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessActive(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error;
 
@@ -206,11 +199,11 @@ otError Dataset::ProcessActive(uint8_t aArgsLength, char *aArgs[])
         SuccessOrExit(error = otDatasetGetActive(mInterpreter.mInstance, &dataset));
         error = Print(dataset);
     }
-    else if ((aArgsLength == 1) && (strcmp(aArgs[0], "-x") == 0))
+    else if ((aArgsLength == 1) && (aArgs[0] == "-x"))
     {
         otOperationalDatasetTlvs dataset;
 
-        VerifyOrExit(strlen(aArgs[0]) <= OT_OPERATIONAL_DATASET_MAX_LENGTH * 2, error = OT_ERROR_NO_BUFS);
+        VerifyOrExit(aArgs[0].GetLength() <= OT_OPERATIONAL_DATASET_MAX_LENGTH * 2, error = OT_ERROR_NO_BUFS);
 
         SuccessOrExit(error = otDatasetGetActiveTlvs(mInterpreter.mInstance, &dataset));
         mInterpreter.OutputBytes(dataset.mTlvs, dataset.mLength);
@@ -225,7 +218,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessPending(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessPending(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error;
 
@@ -236,11 +229,11 @@ otError Dataset::ProcessPending(uint8_t aArgsLength, char *aArgs[])
         SuccessOrExit(error = otDatasetGetPending(mInterpreter.mInstance, &dataset));
         error = Print(dataset);
     }
-    else if ((aArgsLength == 1) && (strcmp(aArgs[0], "-x") == 0))
+    else if ((aArgsLength == 1) && (aArgs[0] == "-x"))
     {
         otOperationalDatasetTlvs dataset;
 
-        VerifyOrExit(strlen(aArgs[0]) <= OT_OPERATIONAL_DATASET_MAX_LENGTH * 2, error = OT_ERROR_NO_BUFS);
+        VerifyOrExit(aArgs[0].GetLength() <= OT_OPERATIONAL_DATASET_MAX_LENGTH * 2, error = OT_ERROR_NO_BUFS);
 
         SuccessOrExit(error = otDatasetGetPendingTlvs(mInterpreter.mInstance, &dataset));
         mInterpreter.OutputBytes(dataset.mTlvs, dataset.mLength);
@@ -255,7 +248,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessActiveTimestamp(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessActiveTimestamp(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -268,7 +261,7 @@ otError Dataset::ProcessActiveTimestamp(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        SuccessOrExit(error = ParseAsUint64(aArgs[0], sDataset.mActiveTimestamp));
+        SuccessOrExit(error = aArgs[0].ParseAsUint64(sDataset.mActiveTimestamp));
         sDataset.mComponents.mIsActiveTimestampPresent = true;
     }
 
@@ -276,7 +269,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessChannel(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -289,7 +282,7 @@ otError Dataset::ProcessChannel(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        SuccessOrExit(error = ParseAsUint16(aArgs[0], sDataset.mChannel));
+        SuccessOrExit(error = aArgs[0].ParseAsUint16(sDataset.mChannel));
         sDataset.mComponents.mIsChannelPresent = true;
     }
 
@@ -297,7 +290,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessChannelMask(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessChannelMask(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -310,7 +303,7 @@ otError Dataset::ProcessChannelMask(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        SuccessOrExit(error = ParseAsUint32(aArgs[0], sDataset.mChannelMask));
+        SuccessOrExit(error = aArgs[0].ParseAsUint32(sDataset.mChannelMask));
         sDataset.mComponents.mIsChannelMaskPresent = true;
     }
 
@@ -318,7 +311,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessClear(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessClear(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -327,17 +320,17 @@ otError Dataset::ProcessClear(uint8_t aArgsLength, char *aArgs[])
     return OT_ERROR_NONE;
 }
 
-otError Dataset::ProcessCommit(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessCommit(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
     VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "active") == 0)
+    if (aArgs[0] == "active")
     {
         SuccessOrExit(error = otDatasetSetActive(mInterpreter.mInstance, &sDataset));
     }
-    else if (strcmp(aArgs[0], "pending") == 0)
+    else if (aArgs[0] == "pending")
     {
         SuccessOrExit(error = otDatasetSetPending(mInterpreter.mInstance, &sDataset));
     }
@@ -350,7 +343,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessDelay(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessDelay(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -363,7 +356,7 @@ otError Dataset::ProcessDelay(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        SuccessOrExit(error = ParseAsUint32(aArgs[0], sDataset.mDelay));
+        SuccessOrExit(error = aArgs[0].ParseAsUint32(sDataset.mDelay));
         sDataset.mComponents.mIsDelayPresent = true;
     }
 
@@ -371,7 +364,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessExtPanId(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessExtPanId(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -385,7 +378,7 @@ otError Dataset::ProcessExtPanId(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        SuccessOrExit(error = ParseAsHexString(aArgs[0], sDataset.mExtendedPanId.m8));
+        SuccessOrExit(error = aArgs[0].ParseAsHexString(sDataset.mExtendedPanId.m8));
         sDataset.mComponents.mIsExtendedPanIdPresent = true;
     }
 
@@ -393,7 +386,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessMasterKey(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessMasterKey(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -407,7 +400,7 @@ otError Dataset::ProcessMasterKey(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        SuccessOrExit(error = ParseAsHexString(aArgs[0], sDataset.mMasterKey.m8));
+        SuccessOrExit(error = aArgs[0].ParseAsHexString(sDataset.mMasterKey.m8));
         sDataset.mComponents.mIsMasterKeyPresent = true;
     }
 
@@ -415,7 +408,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessMeshLocalPrefix(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessMeshLocalPrefix(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -435,7 +428,7 @@ otError Dataset::ProcessMeshLocalPrefix(uint8_t aArgsLength, char *aArgs[])
     {
         otIp6Address prefix;
 
-        SuccessOrExit(error = ParseAsIp6Address(aArgs[0], prefix));
+        SuccessOrExit(error = aArgs[0].ParseAsIp6Address(prefix));
 
         memcpy(sDataset.mMeshLocalPrefix.m8, prefix.mFields.m8, sizeof(sDataset.mMeshLocalPrefix.m8));
         sDataset.mComponents.mIsMeshLocalPrefixPresent = true;
@@ -445,7 +438,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessNetworkName(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessNetworkName(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -459,13 +452,13 @@ otError Dataset::ProcessNetworkName(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        size_t length;
+        uint16_t length;
 
-        VerifyOrExit((length = strlen(aArgs[0])) <= OT_NETWORK_NAME_MAX_SIZE, error = OT_ERROR_INVALID_ARGS);
-        VerifyOrExit(IsValidUtf8String(aArgs[0]), error = OT_ERROR_INVALID_ARGS);
+        VerifyOrExit((length = aArgs[0].GetLength()) <= OT_NETWORK_NAME_MAX_SIZE, error = OT_ERROR_INVALID_ARGS);
+        VerifyOrExit(IsValidUtf8String(aArgs[0].GetCString()), error = OT_ERROR_INVALID_ARGS);
 
         memset(&sDataset.mNetworkName, 0, sizeof(sDataset.mNetworkName));
-        memcpy(sDataset.mNetworkName.m8, aArgs[0], length);
+        memcpy(sDataset.mNetworkName.m8, aArgs[0].GetCString(), length);
         sDataset.mComponents.mIsNetworkNamePresent = true;
     }
 
@@ -473,7 +466,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessPanId(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessPanId(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -486,7 +479,7 @@ otError Dataset::ProcessPanId(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        SuccessOrExit(error = ParseAsUint16(aArgs[0], sDataset.mPanId));
+        SuccessOrExit(error = aArgs[0].ParseAsUint16(sDataset.mPanId));
         sDataset.mComponents.mIsPanIdPresent = true;
     }
 
@@ -494,7 +487,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessPendingTimestamp(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessPendingTimestamp(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -507,7 +500,7 @@ otError Dataset::ProcessPendingTimestamp(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        SuccessOrExit(error = ParseAsUint64(aArgs[0], sDataset.mPendingTimestamp));
+        SuccessOrExit(error = aArgs[0].ParseAsUint64(sDataset.mPendingTimestamp));
         sDataset.mComponents.mIsPendingTimestampPresent = true;
     }
 
@@ -515,7 +508,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessMgmtSetCommand(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessMgmtSetCommand(uint8_t aArgsLength, Arg aArgs[])
 {
     otError              error = OT_ERROR_NONE;
     otOperationalDataset dataset;
@@ -528,88 +521,88 @@ otError Dataset::ProcessMgmtSetCommand(uint8_t aArgsLength, char *aArgs[])
 
     for (uint8_t index = 1; index < aArgsLength; index++)
     {
-        if (strcmp(aArgs[index], "activetimestamp") == 0)
+        if (aArgs[index] == "activetimestamp")
         {
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
             dataset.mComponents.mIsActiveTimestampPresent = true;
-            SuccessOrExit(error = ParseAsUint64(aArgs[index], dataset.mActiveTimestamp));
+            SuccessOrExit(error = aArgs[index].ParseAsUint64(dataset.mActiveTimestamp));
         }
-        else if (strcmp(aArgs[index], "pendingtimestamp") == 0)
+        else if (aArgs[index] == "pendingtimestamp")
         {
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
             dataset.mComponents.mIsPendingTimestampPresent = true;
-            SuccessOrExit(error = ParseAsUint64(aArgs[index], dataset.mPendingTimestamp));
+            SuccessOrExit(error = aArgs[index].ParseAsUint64(dataset.mPendingTimestamp));
         }
-        else if (strcmp(aArgs[index], "masterkey") == 0)
+        else if (aArgs[index] == "masterkey")
         {
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
             dataset.mComponents.mIsMasterKeyPresent = true;
-            SuccessOrExit(error = ParseAsHexString(aArgs[index], dataset.mMasterKey.m8));
+            SuccessOrExit(error = aArgs[index].ParseAsHexString(dataset.mMasterKey.m8));
         }
-        else if (strcmp(aArgs[index], "networkname") == 0)
+        else if (aArgs[index] == "networkname")
         {
-            size_t length;
+            uint16_t length;
 
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
             dataset.mComponents.mIsNetworkNamePresent = true;
-            VerifyOrExit((length = strlen(aArgs[index])) <= OT_NETWORK_NAME_MAX_SIZE, error = OT_ERROR_INVALID_ARGS);
+            VerifyOrExit((length = aArgs[index].GetLength()) <= OT_NETWORK_NAME_MAX_SIZE,
+                         error = OT_ERROR_INVALID_ARGS);
             memset(&dataset.mNetworkName, 0, sizeof(sDataset.mNetworkName));
-            memcpy(dataset.mNetworkName.m8, aArgs[index], length);
+            memcpy(dataset.mNetworkName.m8, aArgs[index].GetCString(), length);
         }
-        else if (strcmp(aArgs[index], "extpanid") == 0)
+        else if (aArgs[index] == "extpanid")
         {
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
             dataset.mComponents.mIsExtendedPanIdPresent = true;
-            SuccessOrExit(error = ParseAsHexString(aArgs[index], dataset.mExtendedPanId.m8));
+            SuccessOrExit(error = aArgs[index].ParseAsHexString(dataset.mExtendedPanId.m8));
         }
-        else if (strcmp(aArgs[index], "localprefix") == 0)
+        else if (aArgs[index] == "localprefix")
         {
             otIp6Address prefix;
 
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
             dataset.mComponents.mIsMeshLocalPrefixPresent = true;
-            SuccessOrExit(error = ParseAsIp6Address(aArgs[index], prefix));
+            SuccessOrExit(error = aArgs[index].ParseAsIp6Address(prefix));
             memcpy(dataset.mMeshLocalPrefix.m8, prefix.mFields.m8, sizeof(dataset.mMeshLocalPrefix.m8));
         }
-        else if (strcmp(aArgs[index], "delaytimer") == 0)
+        else if (aArgs[index] == "delaytimer")
         {
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
             dataset.mComponents.mIsDelayPresent = true;
-            SuccessOrExit(error = ParseAsUint32(aArgs[index], dataset.mDelay));
+            SuccessOrExit(error = aArgs[index].ParseAsUint32(dataset.mDelay));
         }
-        else if (strcmp(aArgs[index], "panid") == 0)
+        else if (aArgs[index] == "panid")
         {
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
             dataset.mComponents.mIsPanIdPresent = true;
-            SuccessOrExit(error = ParseAsUint16(aArgs[index], dataset.mPanId));
+            SuccessOrExit(error = aArgs[index].ParseAsUint16(dataset.mPanId));
         }
-        else if (strcmp(aArgs[index], "channel") == 0)
+        else if (aArgs[index] == "channel")
         {
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
             dataset.mComponents.mIsChannelPresent = true;
-            SuccessOrExit(error = ParseAsUint16(aArgs[index], dataset.mChannel));
+            SuccessOrExit(error = aArgs[index].ParseAsUint16(dataset.mChannel));
         }
-        else if (strcmp(aArgs[index], "channelmask") == 0)
+        else if (aArgs[index] == "channelmask")
         {
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
             dataset.mComponents.mIsChannelMaskPresent = true;
-            SuccessOrExit(error = ParseAsUint32(aArgs[index], dataset.mChannelMask));
+            SuccessOrExit(error = aArgs[index].ParseAsUint32(dataset.mChannelMask));
         }
-        else if (strcmp(aArgs[index], "securitypolicy") == 0)
+        else if (aArgs[index] == "securitypolicy")
         {
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseSecurityPolicy(dataset.mSecurityPolicy, aArgs[index],
-                                                      index + 1 < aArgsLength ? aArgs[index + 1] : nullptr));
+            SuccessOrExit(error = ParseSecurityPolicy(dataset.mSecurityPolicy, aArgsLength - index, &aArgs[index]));
             dataset.mComponents.mIsSecurityPolicyPresent = true;
             ++index;
         }
-        else if (strcmp(aArgs[index], "-x") == 0)
+        else if (aArgs[index] == "-x")
         {
             uint16_t length;
 
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
             length = sizeof(tlvs);
-            SuccessOrExit(error = ParseAsHexString(aArgs[index], length, tlvs));
+            SuccessOrExit(error = aArgs[index].ParseAsHexString(length, tlvs));
             tlvsLength = static_cast<uint8_t>(length);
         }
         else
@@ -618,11 +611,11 @@ otError Dataset::ProcessMgmtSetCommand(uint8_t aArgsLength, char *aArgs[])
         }
     }
 
-    if (strcmp(aArgs[0], "active") == 0)
+    if (aArgs[0] == "active")
     {
         SuccessOrExit(error = otDatasetSendMgmtActiveSet(mInterpreter.mInstance, &dataset, tlvs, tlvsLength));
     }
-    else if (strcmp(aArgs[0], "pending") == 0)
+    else if (aArgs[0] == "pending")
     {
         SuccessOrExit(error = otDatasetSendMgmtPendingSet(mInterpreter.mInstance, &dataset, tlvs, tlvsLength));
     }
@@ -635,7 +628,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessMgmtGetCommand(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessMgmtGetCommand(uint8_t aArgsLength, Arg aArgs[])
 {
     otError                        error = OT_ERROR_NONE;
     otOperationalDatasetComponents datasetComponents;
@@ -650,59 +643,59 @@ otError Dataset::ProcessMgmtGetCommand(uint8_t aArgsLength, char *aArgs[])
 
     for (uint8_t index = 1; index < aArgsLength; index++)
     {
-        if (strcmp(aArgs[index], "activetimestamp") == 0)
+        if (aArgs[index] == "activetimestamp")
         {
             datasetComponents.mIsActiveTimestampPresent = true;
         }
-        else if (strcmp(aArgs[index], "pendingtimestamp") == 0)
+        else if (aArgs[index] == "pendingtimestamp")
         {
             datasetComponents.mIsPendingTimestampPresent = true;
         }
-        else if (strcmp(aArgs[index], "masterkey") == 0)
+        else if (aArgs[index] == "masterkey")
         {
             datasetComponents.mIsMasterKeyPresent = true;
         }
-        else if (strcmp(aArgs[index], "networkname") == 0)
+        else if (aArgs[index] == "networkname")
         {
             datasetComponents.mIsNetworkNamePresent = true;
         }
-        else if (strcmp(aArgs[index], "extpanid") == 0)
+        else if (aArgs[index] == "extpanid")
         {
             datasetComponents.mIsExtendedPanIdPresent = true;
         }
-        else if (strcmp(aArgs[index], "localprefix") == 0)
+        else if (aArgs[index] == "localprefix")
         {
             datasetComponents.mIsMeshLocalPrefixPresent = true;
         }
-        else if (strcmp(aArgs[index], "delaytimer") == 0)
+        else if (aArgs[index] == "delaytimer")
         {
             datasetComponents.mIsDelayPresent = true;
         }
-        else if (strcmp(aArgs[index], "panid") == 0)
+        else if (aArgs[index] == "panid")
         {
             datasetComponents.mIsPanIdPresent = true;
         }
-        else if (strcmp(aArgs[index], "channel") == 0)
+        else if (aArgs[index] == "channel")
         {
             datasetComponents.mIsChannelPresent = true;
         }
-        else if (strcmp(aArgs[index], "securitypolicy") == 0)
+        else if (aArgs[index] == "securitypolicy")
         {
             datasetComponents.mIsSecurityPolicyPresent = true;
         }
-        else if (strcmp(aArgs[index], "-x") == 0)
+        else if (aArgs[index] == "-x")
         {
             uint16_t length;
 
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
             length = sizeof(tlvs);
-            SuccessOrExit(error = ParseAsHexString(aArgs[index], length, tlvs));
+            SuccessOrExit(error = aArgs[index].ParseAsHexString(length, tlvs));
             tlvsLength = static_cast<uint8_t>(length);
         }
-        else if (strcmp(aArgs[index], "address") == 0)
+        else if (aArgs[index] == "address")
         {
             VerifyOrExit(++index < aArgsLength, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseAsIp6Address(aArgs[index], address));
+            SuccessOrExit(error = aArgs[index].ParseAsIp6Address(address));
             destAddrSpecified = true;
         }
         else
@@ -711,12 +704,12 @@ otError Dataset::ProcessMgmtGetCommand(uint8_t aArgsLength, char *aArgs[])
         }
     }
 
-    if (strcmp(aArgs[0], "active") == 0)
+    if (aArgs[0] == "active")
     {
         SuccessOrExit(error = otDatasetSendMgmtActiveGet(mInterpreter.mInstance, &datasetComponents, tlvs, tlvsLength,
                                                          destAddrSpecified ? &address : nullptr));
     }
-    else if (strcmp(aArgs[0], "pending") == 0)
+    else if (aArgs[0] == "pending")
     {
         SuccessOrExit(error = otDatasetSendMgmtPendingGet(mInterpreter.mInstance, &datasetComponents, tlvs, tlvsLength,
                                                           destAddrSpecified ? &address : nullptr));
@@ -730,7 +723,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessPskc(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessPskc(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -744,14 +737,14 @@ otError Dataset::ProcessPskc(uint8_t aArgsLength, char *aArgs[])
     }
     else if (aArgsLength == 1)
     {
-        SuccessOrExit(error = ParseAsHexString(aArgs[0], sDataset.mPskc.m8));
+        SuccessOrExit(error = aArgs[0].ParseAsHexString(sDataset.mPskc.m8));
     }
 #if OPENTHREAD_FTD
-    else if (aArgsLength == 2 && !strcmp(aArgs[0], "-p"))
+    else if (aArgsLength == 2 && (aArgs[0] == "-p"))
     {
         SuccessOrExit(
             error = otDatasetGeneratePskc(
-                aArgs[1],
+                aArgs[1].GetCString(),
                 (sDataset.mComponents.mIsNetworkNamePresent
                      ? &sDataset.mNetworkName
                      : reinterpret_cast<const otNetworkName *>(otThreadGetNetworkName(mInterpreter.mInstance))),
@@ -821,17 +814,17 @@ void Dataset::OutputSecurityPolicy(const otSecurityPolicy &aSecurityPolicy)
     }
 }
 
-Error Dataset::ParseSecurityPolicy(otSecurityPolicy &aSecurityPolicy, const char *aRotation, const char *aFlags)
+Error Dataset::ParseSecurityPolicy(otSecurityPolicy &aSecurityPolicy, uint8_t aArgsLength, Arg aArgs[])
 {
     Error            error;
     otSecurityPolicy policy;
 
     memset(&policy, 0, sizeof(policy));
-    SuccessOrExit(error = ParseAsUint16(aRotation, policy.mRotationTime));
+    SuccessOrExit(error = aArgs[0].ParseAsUint16(policy.mRotationTime));
 
-    VerifyOrExit(aFlags != nullptr);
+    VerifyOrExit(aArgsLength >= 1);
 
-    for (const char *flag = aFlags; *flag != '\0'; flag++)
+    for (const char *flag = aArgs[1].GetCString(); *flag != '\0'; flag++)
     {
         switch (*flag)
         {
@@ -884,7 +877,7 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessSecurityPolicy(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessSecurityPolicy(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -898,8 +891,7 @@ otError Dataset::ProcessSecurityPolicy(uint8_t aArgsLength, char *aArgs[])
     }
     else
     {
-        SuccessOrExit(
-            error = ParseSecurityPolicy(sDataset.mSecurityPolicy, aArgs[0], aArgsLength > 1 ? aArgs[1] : nullptr));
+        SuccessOrExit(error = ParseSecurityPolicy(sDataset.mSecurityPolicy, aArgsLength, aArgs));
         sDataset.mComponents.mIsSecurityPolicyPresent = true;
     }
 
@@ -907,18 +899,18 @@ exit:
     return error;
 }
 
-otError Dataset::ProcessSet(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessSet(uint8_t aArgsLength, Arg aArgs[])
 {
     otError                error = OT_ERROR_NONE;
     MeshCoP::Dataset::Type datasetType;
 
     VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "active") == 0)
+    if (aArgs[0] == "active")
     {
         datasetType = MeshCoP::Dataset::Type::kActive;
     }
-    else if (strcmp(aArgs[0], "pending") == 0)
+    else if (aArgs[0] == "pending")
     {
         datasetType = MeshCoP::Dataset::Type::kPending;
     }
@@ -932,7 +924,7 @@ otError Dataset::ProcessSet(uint8_t aArgsLength, char *aArgs[])
         MeshCoP::Dataset::Info datasetInfo;
         uint16_t               tlvsLength = MeshCoP::Dataset::kMaxSize;
 
-        SuccessOrExit(error = ParseAsHexString(aArgs[1], tlvsLength, dataset.GetBytes()));
+        SuccessOrExit(error = aArgs[1].ParseAsHexString(tlvsLength, dataset.GetBytes()));
         dataset.SetSize(tlvsLength);
         VerifyOrExit(dataset.IsValid(), error = OT_ERROR_INVALID_ARGS);
         dataset.ConvertTo(datasetInfo);
@@ -954,7 +946,7 @@ exit:
 
 #if OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE && OPENTHREAD_FTD
 
-otError Dataset::ProcessUpdater(uint8_t aArgsLength, char *aArgs[])
+otError Dataset::ProcessUpdater(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -964,11 +956,11 @@ otError Dataset::ProcessUpdater(uint8_t aArgsLength, char *aArgs[])
         ExitNow();
     }
 
-    if (strcmp(aArgs[0], "start") == 0)
+    if (aArgs[0] == "start")
     {
         error = otDatasetUpdaterRequestUpdate(mInterpreter.mInstance, &sDataset, &Dataset::HandleDatasetUpdater, this);
     }
-    else if (strcmp(aArgs[0], "cancel") == 0)
+    else if (aArgs[0] == "cancel")
     {
         otDatasetUpdaterCancelUpdate(mInterpreter.mInstance);
     }

--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -41,6 +41,7 @@
 #include <openthread/dataset.h>
 
 #include "utils/lookup_table.hpp"
+#include "utils/parse_cmdline.hpp"
 
 namespace ot {
 namespace Cli {
@@ -54,6 +55,8 @@ class Interpreter;
 class Dataset
 {
 public:
+    typedef Utils::CmdLineParser::Arg Arg;
+
     explicit Dataset(Interpreter &aInterpreter)
         : mInterpreter(aInterpreter)
     {
@@ -66,47 +69,47 @@ public:
      * @param[in]  aArgs        An array of command line arguments.
      *
      */
-    otError Process(uint8_t aArgsLength, char *aArgs[]);
+    otError Process(uint8_t aArgsLength, Arg aArgs[]);
 
 private:
     struct Command
     {
         const char *mName;
-        otError (Dataset::*mHandler)(uint8_t aArgsLength, char *aArgs[]);
+        otError (Dataset::*mHandler)(uint8_t aArgsLength, Arg aArgs[]);
     };
 
     otError Print(otOperationalDataset &aDataset);
 
-    otError ProcessHelp(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessActive(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessActiveTimestamp(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessChannel(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessChannelMask(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessClear(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessCommit(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessDelay(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessExtPanId(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessInit(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessMasterKey(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessMeshLocalPrefix(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessNetworkName(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessPanId(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessPending(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessPendingTimestamp(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessMgmtSetCommand(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessMgmtGetCommand(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessPskc(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessSecurityPolicy(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessSet(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessHelp(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessActive(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessActiveTimestamp(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessChannel(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessChannelMask(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessClear(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessCommit(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessDelay(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessExtPanId(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessInit(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessMasterKey(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessMeshLocalPrefix(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessNetworkName(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessPanId(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessPending(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessPendingTimestamp(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessMgmtSetCommand(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessMgmtGetCommand(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessPskc(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessSecurityPolicy(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessSet(uint8_t aArgsLength, Arg aArgs[]);
 
 #if OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE && OPENTHREAD_FTD
-    otError     ProcessUpdater(uint8_t aArgsLength, char *aArgs[]);
+    otError     ProcessUpdater(uint8_t aArgsLength, Arg aArgs[]);
     static void HandleDatasetUpdater(otError aError, void *aContext);
     void        HandleDatasetUpdater(otError aError);
 #endif
 
     void  OutputSecurityPolicy(const otSecurityPolicy &aSecurityPolicy);
-    Error ParseSecurityPolicy(otSecurityPolicy &aSecurityPolicy, const char *aRotation, const char *aFlags);
+    Error ParseSecurityPolicy(otSecurityPolicy &aSecurityPolicy, uint8_t aArgsLength, Arg aArgs[]);
 
     static constexpr Command sCommands[] = {
         {"active", &Dataset::ProcessActive},

--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -36,7 +36,6 @@
 #include <inttypes.h>
 
 #include "cli/cli.hpp"
-#include "utils/parse_cmdline.hpp"
 
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
 
@@ -45,7 +44,7 @@ namespace Cli {
 
 constexpr Joiner::Command Joiner::sCommands[];
 
-otError Joiner::ProcessDiscerner(uint8_t aArgsLength, char *aArgs[])
+otError Joiner::ProcessDiscerner(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -54,7 +53,8 @@ otError Joiner::ProcessDiscerner(uint8_t aArgsLength, char *aArgs[])
         otJoinerDiscerner discerner;
 
         memset(&discerner, 0, sizeof(discerner));
-        if (strcmp(aArgs[1], "clear") == 0)
+
+        if (aArgs[1] == "clear")
         {
             SuccessOrExit(error = otJoinerSetDiscerner(mInterpreter.mInstance, nullptr));
         }
@@ -82,7 +82,7 @@ exit:
     return error;
 }
 
-otError Joiner::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
+otError Joiner::ProcessHelp(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -95,7 +95,7 @@ otError Joiner::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
     return OT_ERROR_NONE;
 }
 
-otError Joiner::ProcessId(uint8_t aArgsLength, char *aArgs[])
+otError Joiner::ProcessId(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -106,7 +106,7 @@ otError Joiner::ProcessId(uint8_t aArgsLength, char *aArgs[])
     return OT_ERROR_NONE;
 }
 
-otError Joiner::ProcessStart(uint8_t aArgsLength, char *aArgs[])
+otError Joiner::ProcessStart(uint8_t aArgsLength, Arg aArgs[])
 {
     otError     error;
     const char *provisioningUrl = nullptr;
@@ -115,17 +115,17 @@ otError Joiner::ProcessStart(uint8_t aArgsLength, char *aArgs[])
 
     if (aArgsLength > 2)
     {
-        provisioningUrl = aArgs[2];
+        provisioningUrl = aArgs[2].GetCString();
     }
 
-    error = otJoinerStart(mInterpreter.mInstance, aArgs[1], provisioningUrl, PACKAGE_NAME,
+    error = otJoinerStart(mInterpreter.mInstance, aArgs[1].GetCString(), provisioningUrl, PACKAGE_NAME,
                           OPENTHREAD_CONFIG_PLATFORM_INFO, PACKAGE_VERSION, nullptr, &Joiner::HandleCallback, this);
 
 exit:
     return error;
 }
 
-otError Joiner::ProcessStop(uint8_t aArgsLength, char *aArgs[])
+otError Joiner::ProcessStop(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -135,14 +135,14 @@ otError Joiner::ProcessStop(uint8_t aArgsLength, char *aArgs[])
     return OT_ERROR_NONE;
 }
 
-otError Joiner::Process(uint8_t aArgsLength, char *aArgs[])
+otError Joiner::Process(uint8_t aArgsLength, Arg aArgs[])
 {
     otError        error = OT_ERROR_INVALID_COMMAND;
     const Command *command;
 
     VerifyOrExit(aArgsLength != 0, IgnoreError(ProcessHelp(0, nullptr)));
 
-    command = Utils::LookupTable::Find(aArgs[0], sCommands);
+    command = Utils::LookupTable::Find(aArgs[0].GetCString(), sCommands);
     VerifyOrExit(command != nullptr);
 
     error = (this->*command->mHandler)(aArgsLength, aArgs);

--- a/src/cli/cli_joiner.hpp
+++ b/src/cli/cli_joiner.hpp
@@ -39,6 +39,7 @@
 #include <openthread/joiner.h>
 
 #include "utils/lookup_table.hpp"
+#include "utils/parse_cmdline.hpp"
 
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
 
@@ -54,6 +55,8 @@ class Interpreter;
 class Joiner
 {
 public:
+    typedef Utils::CmdLineParser::Arg Arg;
+
     /**
      * Constructor
      *
@@ -72,20 +75,20 @@ public:
      * @param[in]  aArgs        A pointer to an array of command line arguments.
      *
      */
-    otError Process(uint8_t aArgsLength, char *aArgs[]);
+    otError Process(uint8_t aArgsLength, Arg aArgs[]);
 
 private:
     struct Command
     {
         const char *mName;
-        otError (Joiner::*mHandler)(uint8_t aArgsLength, char *aArgs[]);
+        otError (Joiner::*mHandler)(uint8_t aArgsLength, Arg aArgs[]);
     };
 
-    otError ProcessDiscerner(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessHelp(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessId(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessStart(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessStop(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDiscerner(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessHelp(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessId(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessStart(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessStop(uint8_t aArgsLength, Arg aArgs[]);
 
     static void HandleCallback(otError aError, void *aContext);
     void        HandleCallback(otError aError);

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -38,10 +38,6 @@
 
 #include "cli/cli.hpp"
 #include "common/encoding.hpp"
-#include "utils/parse_cmdline.hpp"
-
-using ot::Encoding::BigEndian::HostSwap16;
-using ot::Utils::CmdLineParser::ParseAsHexString;
 
 namespace ot {
 namespace Cli {
@@ -205,7 +201,7 @@ void NetworkData::OutputService(const otServiceConfig &aConfig)
     mInterpreter.OutputLine(" %04x", aConfig.mServerConfig.mRloc16);
 }
 
-otError NetworkData::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
+otError NetworkData::ProcessHelp(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -219,7 +215,7 @@ otError NetworkData::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
 }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-otError NetworkData::ProcessRegister(uint8_t aArgsLength, char *aArgs[])
+otError NetworkData::ProcessRegister(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -237,13 +233,13 @@ exit:
 }
 #endif
 
-otError NetworkData::ProcessSteeringData(uint8_t aArgsLength, char *aArgs[])
+otError NetworkData::ProcessSteeringData(uint8_t aArgsLength, Arg aArgs[])
 {
     otError           error = OT_ERROR_INVALID_ARGS;
     otExtAddress      addr;
     otJoinerDiscerner discerner;
 
-    VerifyOrExit((aArgsLength > 1) && (strcmp(aArgs[0], "check") == 0));
+    VerifyOrExit((aArgsLength > 1) && (aArgs[0] == "check"));
 
     discerner.mLength = 0;
 
@@ -251,7 +247,7 @@ otError NetworkData::ProcessSteeringData(uint8_t aArgsLength, char *aArgs[])
 
     if (error == OT_ERROR_NOT_FOUND)
     {
-        SuccessOrExit(error = ParseAsHexString(aArgs[1], addr.m8));
+        SuccessOrExit(error = aArgs[1].ParseAsHexString(addr.m8));
     }
     else if (error != OT_ERROR_NONE)
     {
@@ -325,7 +321,7 @@ exit:
     return error;
 }
 
-otError NetworkData::ProcessShow(uint8_t aArgsLength, char *aArgs[])
+otError NetworkData::ProcessShow(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error;
 
@@ -336,7 +332,7 @@ otError NetworkData::ProcessShow(uint8_t aArgsLength, char *aArgs[])
         OutputServices();
         error = OT_ERROR_NONE;
     }
-    else if (strcmp(aArgs[0], "-x") == 0)
+    else if (aArgs[0] == "-x")
     {
         error = OutputBinary();
     }
@@ -348,14 +344,14 @@ otError NetworkData::ProcessShow(uint8_t aArgsLength, char *aArgs[])
     return error;
 }
 
-otError NetworkData::Process(uint8_t aArgsLength, char *aArgs[])
+otError NetworkData::Process(uint8_t aArgsLength, Arg aArgs[])
 {
     otError        error = OT_ERROR_INVALID_COMMAND;
     const Command *command;
 
     VerifyOrExit(aArgsLength != 0, IgnoreError(ProcessHelp(0, nullptr)));
 
-    command = Utils::LookupTable::Find(aArgs[0], sCommands);
+    command = Utils::LookupTable::Find(aArgs[0].GetCString(), sCommands);
     VerifyOrExit(command != nullptr);
 
     error = (this->*command->mHandler)(aArgsLength - 1, aArgs + 1);

--- a/src/cli/cli_network_data.hpp
+++ b/src/cli/cli_network_data.hpp
@@ -39,6 +39,7 @@
 #include <openthread/netdata.h>
 
 #include "utils/lookup_table.hpp"
+#include "utils/parse_cmdline.hpp"
 
 namespace ot {
 namespace Cli {
@@ -52,6 +53,8 @@ class Interpreter;
 class NetworkData
 {
 public:
+    typedef Utils::CmdLineParser::Arg Arg;
+
     /**
      * Constructor
      *
@@ -67,7 +70,7 @@ public:
      * @param[in]  aArgs        An array of command line arguments.
      *
      */
-    otError Process(uint8_t aArgsLength, char *aArgs[]);
+    otError Process(uint8_t aArgsLength, Arg aArgs[]);
 
     /**
      * This method outputs the prefix config.
@@ -97,15 +100,15 @@ private:
     struct Command
     {
         const char *mName;
-        otError (NetworkData::*mHandler)(uint8_t aArgsLength, char *aArgs[]);
+        otError (NetworkData::*mHandler)(uint8_t aArgsLength, Arg aArgs[]);
     };
 
-    otError ProcessHelp(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessHelp(uint8_t aArgsLength, Arg aArgs[]);
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    otError ProcessRegister(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessRegister(uint8_t aArgsLength, Arg aArgs[]);
 #endif
-    otError ProcessShow(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessSteeringData(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessShow(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessSteeringData(uint8_t aArgsLength, Arg aArgs[]);
 
     otError OutputBinary(void);
     void    OutputPrefixes(void);

--- a/src/cli/cli_srp_client.cpp
+++ b/src/cli/cli_srp_client.cpp
@@ -38,13 +38,6 @@
 #include <string.h>
 
 #include "cli/cli.hpp"
-#include "utils/parse_cmdline.hpp"
-
-using ot::Utils::CmdLineParser::ParseAsBool;
-using ot::Utils::CmdLineParser::ParseAsHexString;
-using ot::Utils::CmdLineParser::ParseAsIp6Address;
-using ot::Utils::CmdLineParser::ParseAsUint16;
-using ot::Utils::CmdLineParser::ParseAsUint32;
 
 namespace ot {
 namespace Cli {
@@ -73,14 +66,14 @@ SrpClient::SrpClient(Interpreter &aInterpreter)
     otSrpClientSetCallback(mInterpreter.mInstance, SrpClient::HandleCallback, this);
 }
 
-otError SrpClient::Process(uint8_t aArgsLength, char *aArgs[])
+otError SrpClient::Process(uint8_t aArgsLength, Arg aArgs[])
 {
     otError        error = OT_ERROR_INVALID_COMMAND;
     const Command *command;
 
     VerifyOrExit(aArgsLength != 0, IgnoreError(ProcessHelp(0, nullptr)));
 
-    command = Utils::LookupTable::Find(aArgs[0], sCommands);
+    command = Utils::LookupTable::Find(aArgs[0].GetCString(), sCommands);
     VerifyOrExit(command != nullptr);
 
     error = (this->*command->mHandler)(aArgsLength - 1, aArgs + 1);
@@ -91,7 +84,7 @@ exit:
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
 
-otError SrpClient::ProcessAutoStart(uint8_t aArgsLength, char *aArgs[])
+otError SrpClient::ProcessAutoStart(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
     bool    enable;
@@ -121,7 +114,7 @@ exit:
 
 #endif // OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
 
-otError SrpClient::ProcessCallback(uint8_t aArgsLength, char *aArgs[])
+otError SrpClient::ProcessCallback(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -138,7 +131,7 @@ exit:
     return error;
 }
 
-otError SrpClient::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
+otError SrpClient::ProcessHelp(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -151,7 +144,7 @@ otError SrpClient::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
     return OT_ERROR_NONE;
 }
 
-otError SrpClient::ProcessHost(uint8_t aArgsLength, char *aArgs[])
+otError SrpClient::ProcessHost(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -161,7 +154,7 @@ otError SrpClient::ProcessHost(uint8_t aArgsLength, char *aArgs[])
         ExitNow();
     }
 
-    if (strcmp(aArgs[0], "name") == 0)
+    if (aArgs[0] == "name")
     {
         if (aArgsLength == 1)
         {
@@ -170,14 +163,14 @@ otError SrpClient::ProcessHost(uint8_t aArgsLength, char *aArgs[])
         }
         else
         {
-            size_t   len;
+            uint16_t len;
             uint16_t size;
             char *   hostName;
 
             VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
             hostName = otSrpClientBuffersGetHostNameString(mInterpreter.mInstance, &size);
 
-            len = strlen(aArgs[1]);
+            len = aArgs[1].GetLength();
             VerifyOrExit(len + 1 <= size, error = OT_ERROR_INVALID_ARGS);
 
             // We first make sure we can set the name, and if so
@@ -186,19 +179,19 @@ otError SrpClient::ProcessHost(uint8_t aArgsLength, char *aArgs[])
             // This ensures that we do not overwrite a previous
             // buffer with a host name that cannot be set.
 
-            SuccessOrExit(error = otSrpClientSetHostName(mInterpreter.mInstance, aArgs[1]));
-            memcpy(hostName, aArgs[1], len + 1);
+            SuccessOrExit(error = otSrpClientSetHostName(mInterpreter.mInstance, aArgs[1].GetCString()));
+            memcpy(hostName, aArgs[1].GetCString(), len + 1);
 
             IgnoreError(otSrpClientSetHostName(mInterpreter.mInstance, hostName));
         }
     }
-    else if (strcmp(aArgs[0], "state") == 0)
+    else if (aArgs[0] == "state")
     {
         VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
         mInterpreter.OutputLine("%s",
                                 otSrpClientItemStateToString(otSrpClientGetHostInfo(mInterpreter.mInstance)->mState));
     }
-    else if (strcmp(aArgs[0], "address") == 0)
+    else if (aArgs[0] == "address")
     {
         if (aArgsLength == 1)
         {
@@ -229,7 +222,7 @@ otError SrpClient::ProcessHost(uint8_t aArgsLength, char *aArgs[])
 
             for (uint8_t index = 1; index < aArgsLength; index++)
             {
-                SuccessOrExit(error = ParseAsIp6Address(aArgs[index], addresses[index - 1]));
+                SuccessOrExit(error = aArgs[index].ParseAsIp6Address(addresses[index - 1]));
             }
 
             SuccessOrExit(error = otSrpClientSetHostAddresses(mInterpreter.mInstance, addresses, numAddresses));
@@ -238,19 +231,19 @@ otError SrpClient::ProcessHost(uint8_t aArgsLength, char *aArgs[])
             IgnoreError(otSrpClientSetHostAddresses(mInterpreter.mInstance, hostAddressArray, numAddresses));
         }
     }
-    else if (strcmp(aArgs[0], "remove") == 0)
+    else if (aArgs[0] == "remove")
     {
         bool removeKeyLease = false;
 
         if (aArgsLength > 1)
         {
             VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
-            SuccessOrExit(error = ParseAsBool(aArgs[1], removeKeyLease));
+            SuccessOrExit(error = aArgs[1].ParseAsBool(removeKeyLease));
         }
 
         error = otSrpClientRemoveHostAndServices(mInterpreter.mInstance, removeKeyLease);
     }
-    else if (strcmp(aArgs[0], "clear") == 0)
+    else if (aArgs[0] == "clear")
     {
         VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
         otSrpClientClearHostAndServices(mInterpreter.mInstance);
@@ -265,7 +258,7 @@ exit:
     return error;
 }
 
-otError SrpClient::ProcessLeaseInterval(uint8_t aArgsLength, char *aArgs[])
+otError SrpClient::ProcessLeaseInterval(uint8_t aArgsLength, Arg aArgs[])
 {
     otError  error = OT_ERROR_NONE;
     uint32_t interval;
@@ -277,14 +270,14 @@ otError SrpClient::ProcessLeaseInterval(uint8_t aArgsLength, char *aArgs[])
     }
 
     VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
-    SuccessOrExit(error = ParseAsUint32(aArgs[0], interval));
+    SuccessOrExit(error = aArgs[0].ParseAsUint32(interval));
     otSrpClientSetLeaseInterval(mInterpreter.mInstance, interval);
 
 exit:
     return error;
 }
 
-otError SrpClient::ProcessKeyLeaseInterval(uint8_t aArgsLength, char *aArgs[])
+otError SrpClient::ProcessKeyLeaseInterval(uint8_t aArgsLength, Arg aArgs[])
 {
     otError  error = OT_ERROR_NONE;
     uint32_t interval;
@@ -296,14 +289,14 @@ otError SrpClient::ProcessKeyLeaseInterval(uint8_t aArgsLength, char *aArgs[])
     }
 
     VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
-    SuccessOrExit(error = ParseAsUint32(aArgs[0], interval));
+    SuccessOrExit(error = aArgs[0].ParseAsUint32(interval));
     otSrpClientSetKeyLeaseInterval(mInterpreter.mInstance, interval);
 
 exit:
     return error;
 }
 
-otError SrpClient::ProcessServer(uint8_t aArgsLength, char *aArgs[])
+otError SrpClient::ProcessServer(uint8_t aArgsLength, Arg aArgs[])
 {
     otError           error          = OT_ERROR_NONE;
     const otSockAddr *serverSockAddr = otSrpClientGetServerAddress(mInterpreter.mInstance);
@@ -318,12 +311,12 @@ otError SrpClient::ProcessServer(uint8_t aArgsLength, char *aArgs[])
 
     VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
 
-    if (strcmp(aArgs[0], "address") == 0)
+    if (aArgs[0] == "address")
     {
         mInterpreter.OutputIp6Address(serverSockAddr->mAddress);
         mInterpreter.OutputLine("");
     }
-    else if (strcmp(aArgs[0], "port") == 0)
+    else if (aArgs[0] == "port")
     {
         mInterpreter.OutputLine("%u", serverSockAddr->mPort);
     }
@@ -336,7 +329,7 @@ exit:
     return error;
 }
 
-otError SrpClient::ProcessService(uint8_t aArgsLength, char *aArgs[])
+otError SrpClient::ProcessService(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
@@ -346,11 +339,11 @@ otError SrpClient::ProcessService(uint8_t aArgsLength, char *aArgs[])
         ExitNow();
     }
 
-    if (strcmp(aArgs[0], "add") == 0)
+    if (aArgs[0] == "add")
     {
         error = ProcessServiceAdd(aArgsLength, aArgs);
     }
-    else if (strcmp(aArgs[0], "remove") == 0)
+    else if (aArgs[0] == "remove")
     {
         // `remove` <instance-name> <service-name>
 
@@ -360,7 +353,7 @@ otError SrpClient::ProcessService(uint8_t aArgsLength, char *aArgs[])
 
         for (service = otSrpClientGetServices(mInterpreter.mInstance); service != nullptr; service = service->mNext)
         {
-            if ((strcmp(aArgs[1], service->mInstanceName) == 0) && (strcmp(aArgs[2], service->mName) == 0))
+            if ((aArgs[1] == service->mInstanceName) && (aArgs[2] == service->mName))
             {
                 break;
             }
@@ -371,7 +364,7 @@ otError SrpClient::ProcessService(uint8_t aArgsLength, char *aArgs[])
         error = otSrpClientRemoveService(mInterpreter.mInstance, const_cast<otSrpClientService *>(service));
     }
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    else if (strcmp(aArgs[0], "key") == 0)
+    else if (aArgs[0] == "key")
     {
         // `key [enable/disable]`
 
@@ -397,7 +390,7 @@ exit:
     return error;
 }
 
-otError SrpClient::ProcessServiceAdd(uint8_t aArgsLength, char *aArgs[])
+otError SrpClient::ProcessServiceAdd(uint8_t aArgsLength, Arg aArgs[])
 {
     // `add` <instance-name> <service-name> <port> [priority] [weight] [txt]
 
@@ -413,21 +406,21 @@ otError SrpClient::ProcessServiceAdd(uint8_t aArgsLength, char *aArgs[])
     VerifyOrExit(entry != nullptr, error = OT_ERROR_NO_BUFS);
 
     string = otSrpClientBuffersGetServiceEntryInstanceNameString(entry, &size);
-    SuccessOrExit(error = CopyString(string, size, aArgs[1]));
+    SuccessOrExit(error = CopyString(string, size, aArgs[1].GetCString()));
 
     string = otSrpClientBuffersGetServiceEntryServiceNameString(entry, &size);
-    SuccessOrExit(error = CopyString(string, size, aArgs[2]));
+    SuccessOrExit(error = CopyString(string, size, aArgs[2].GetCString()));
 
-    SuccessOrExit(error = ParseAsUint16(aArgs[3], entry->mService.mPort));
+    SuccessOrExit(error = aArgs[3].ParseAsUint16(entry->mService.mPort));
 
     if (aArgsLength >= 5)
     {
-        SuccessOrExit(error = ParseAsUint16(aArgs[4], entry->mService.mPriority));
+        SuccessOrExit(error = aArgs[4].ParseAsUint16(entry->mService.mPriority));
     }
 
     if (aArgsLength >= 6)
     {
-        SuccessOrExit(error = ParseAsUint16(aArgs[5], entry->mService.mWeight));
+        SuccessOrExit(error = aArgs[5].ParseAsUint16(entry->mService.mWeight));
     }
 
     if (aArgsLength >= 7)
@@ -437,7 +430,7 @@ otError SrpClient::ProcessServiceAdd(uint8_t aArgsLength, char *aArgs[])
         txtBuffer                     = otSrpClientBuffersGetServiceEntryTxtBuffer(entry, &size);
         entry->mTxtEntry.mValueLength = size;
 
-        SuccessOrExit(error = ParseAsHexString(aArgs[6], entry->mTxtEntry.mValueLength, txtBuffer));
+        SuccessOrExit(error = aArgs[6].ParseAsHexString(entry->mTxtEntry.mValueLength, txtBuffer));
     }
     else
     {
@@ -501,15 +494,15 @@ void SrpClient::OutputService(uint8_t aIndentSize, const otSrpClientService &aSe
                             aService.mPort, aService.mPriority, aService.mWeight);
 }
 
-otError SrpClient::ProcessStart(uint8_t aArgsLength, char *aArgs[])
+otError SrpClient::ProcessStart(uint8_t aArgsLength, Arg aArgs[])
 {
     otError    error = OT_ERROR_NONE;
     otSockAddr serverSockAddr;
 
     VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = ParseAsIp6Address(aArgs[0], serverSockAddr.mAddress));
-    SuccessOrExit(error = ParseAsUint16(aArgs[1], serverSockAddr.mPort));
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Address(serverSockAddr.mAddress));
+    SuccessOrExit(error = aArgs[1].ParseAsUint16(serverSockAddr.mPort));
 
     error = otSrpClientStart(mInterpreter.mInstance, &serverSockAddr);
 
@@ -517,7 +510,7 @@ exit:
     return error;
 }
 
-otError SrpClient::ProcessState(uint8_t aArgsLength, char *aArgs[])
+otError SrpClient::ProcessState(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
 
@@ -531,7 +524,7 @@ exit:
     return error;
 }
 
-otError SrpClient::ProcessStop(uint8_t aArgsLength, char *aArgs[])
+otError SrpClient::ProcessStop(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
 

--- a/src/cli/cli_srp_client.hpp
+++ b/src/cli/cli_srp_client.hpp
@@ -41,6 +41,7 @@
 
 #include "cli/cli_config.h"
 #include "utils/lookup_table.hpp"
+#include "utils/parse_cmdline.hpp"
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
 
@@ -56,6 +57,8 @@ class Interpreter;
 class SrpClient
 {
 public:
+    typedef Utils::CmdLineParser::Arg Arg;
+
     /**
      * Constructor
      *
@@ -71,7 +74,7 @@ public:
      * @param[in]  aArgs        A pointer to an array of command line arguments.
      *
      */
-    otError Process(uint8_t aArgsLength, char *aArgs[]);
+    otError Process(uint8_t aArgsLength, Arg aArgs[]);
 
 private:
     enum : uint8_t
@@ -83,21 +86,21 @@ private:
     struct Command
     {
         const char *mName;
-        otError (SrpClient::*mHandler)(uint8_t aArgsLength, char *aArgs[]);
+        otError (SrpClient::*mHandler)(uint8_t aArgsLength, Arg aArgs[]);
     };
 
-    otError ProcessAutoStart(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessCallback(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessHelp(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessHost(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessLeaseInterval(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessKeyLeaseInterval(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessServer(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessService(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessServiceAdd(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessStart(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessState(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessStop(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessAutoStart(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessCallback(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessHelp(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessHost(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessLeaseInterval(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessKeyLeaseInterval(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessServer(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessService(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessServiceAdd(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessStart(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessState(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessStop(uint8_t aArgsLength, Arg aArgs[]);
 
     void OutputHostInfo(uint8_t aIndentSize, const otSrpClientHostInfo &aHostInfo);
     void OutputServiceList(uint8_t aIndentSize, const otSrpClientService *aServices);

--- a/src/cli/cli_srp_server.cpp
+++ b/src/cli/cli_srp_server.cpp
@@ -37,7 +37,6 @@
 
 #include "cli/cli.hpp"
 #include "common/string.hpp"
-#include "utils/parse_cmdline.hpp"
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
 
@@ -46,14 +45,14 @@ namespace Cli {
 
 constexpr SrpServer::Command SrpServer::sCommands[];
 
-otError SrpServer::Process(uint8_t aArgsLength, char *aArgs[])
+otError SrpServer::Process(uint8_t aArgsLength, Arg aArgs[])
 {
     otError        error = OT_ERROR_INVALID_COMMAND;
     const Command *command;
 
     VerifyOrExit(aArgsLength != 0, IgnoreError(ProcessHelp(0, nullptr)));
 
-    command = Utils::LookupTable::Find(aArgs[0], sCommands);
+    command = Utils::LookupTable::Find(aArgs[0].GetCString(), sCommands);
     VerifyOrExit(command != nullptr);
 
     error = (this->*command->mHandler)(aArgsLength, aArgs);
@@ -62,13 +61,13 @@ exit:
     return error;
 }
 
-otError SrpServer::ProcessDomain(uint8_t aArgsLength, char *aArgs[])
+otError SrpServer::ProcessDomain(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
     if (aArgsLength > 1)
     {
-        SuccessOrExit(error = otSrpServerSetDomain(mInterpreter.mInstance, aArgs[1]));
+        SuccessOrExit(error = otSrpServerSetDomain(mInterpreter.mInstance, aArgs[1].GetCString()));
     }
     else
     {
@@ -79,7 +78,7 @@ exit:
     return error;
 }
 
-otError SrpServer::ProcessEnable(uint8_t aArgsLength, char *aArgs[])
+otError SrpServer::ProcessEnable(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -89,7 +88,7 @@ otError SrpServer::ProcessEnable(uint8_t aArgsLength, char *aArgs[])
     return OT_ERROR_NONE;
 }
 
-otError SrpServer::ProcessDisable(uint8_t aArgsLength, char *aArgs[])
+otError SrpServer::ProcessDisable(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
@@ -99,7 +98,7 @@ otError SrpServer::ProcessDisable(uint8_t aArgsLength, char *aArgs[])
     return OT_ERROR_NONE;
 }
 
-otError SrpServer::ProcessLease(uint8_t aArgsLength, char *aArgs[])
+otError SrpServer::ProcessLease(uint8_t aArgsLength, Arg aArgs[])
 {
     otError  error = OT_ERROR_NONE;
     uint32_t minLease;
@@ -108,10 +107,10 @@ otError SrpServer::ProcessLease(uint8_t aArgsLength, char *aArgs[])
     uint32_t maxKeyLease;
 
     VerifyOrExit(aArgsLength == 5, error = OT_ERROR_INVALID_ARGS);
-    SuccessOrExit(error = Utils::CmdLineParser::ParseAsUint32(aArgs[1], minLease));
-    SuccessOrExit(error = Utils::CmdLineParser::ParseAsUint32(aArgs[2], maxLease));
-    SuccessOrExit(error = Utils::CmdLineParser::ParseAsUint32(aArgs[3], minKeyLease));
-    SuccessOrExit(error = Utils::CmdLineParser::ParseAsUint32(aArgs[4], maxKeyLease));
+    SuccessOrExit(error = aArgs[1].ParseAsUint32(minLease));
+    SuccessOrExit(error = aArgs[2].ParseAsUint32(maxLease));
+    SuccessOrExit(error = aArgs[3].ParseAsUint32(minKeyLease));
+    SuccessOrExit(error = aArgs[4].ParseAsUint32(maxKeyLease));
 
     error = otSrpServerSetLeaseRange(mInterpreter.mInstance, minLease, maxLease, minKeyLease, maxKeyLease);
 
@@ -119,7 +118,7 @@ exit:
     return error;
 }
 
-otError SrpServer::ProcessHost(uint8_t aArgsLength, char *aArgs[])
+otError SrpServer::ProcessHost(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
 
@@ -183,7 +182,7 @@ void SrpServer::OutputHostAddresses(const otSrpServerHost *aHost)
     mInterpreter.OutputFormat("]");
 }
 
-otError SrpServer::ProcessService(uint8_t aArgsLength, char *aArgs[])
+otError SrpServer::ProcessService(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
 
@@ -231,7 +230,7 @@ exit:
     return error;
 }
 
-otError SrpServer::ProcessHelp(uint8_t aArgsLength, char *aArgs[])
+otError SrpServer::ProcessHelp(uint8_t aArgsLength, Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);

--- a/src/cli/cli_srp_server.hpp
+++ b/src/cli/cli_srp_server.hpp
@@ -39,6 +39,7 @@
 #include <openthread/srp_server.h>
 
 #include "utils/lookup_table.hpp"
+#include "utils/parse_cmdline.hpp"
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
 
@@ -54,6 +55,8 @@ class Interpreter;
 class SrpServer
 {
 public:
+    typedef Utils::CmdLineParser::Arg Arg;
+
     /**
      * Constructor
      *
@@ -75,22 +78,22 @@ public:
      * @retval  ...            Failed to execute the CLI command.
      *
      */
-    otError Process(uint8_t aArgsLength, char *aArgs[]);
+    otError Process(uint8_t aArgsLength, Arg aArgs[]);
 
 private:
     struct Command
     {
         const char *mName;
-        otError (SrpServer::*mHandler)(uint8_t aArgsLength, char *aArgs[]);
+        otError (SrpServer::*mHandler)(uint8_t aArgsLength, Arg aArgs[]);
     };
 
-    otError ProcessDomain(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessEnable(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessDisable(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessLease(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessHost(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessService(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessHelp(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessDomain(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessEnable(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessDisable(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessLease(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessHost(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessService(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessHelp(uint8_t aArgsLength, Arg aArgs[]);
 
     void OutputHostAddresses(const otSrpServerHost *aHost);
 

--- a/src/cli/cli_udp.hpp
+++ b/src/cli/cli_udp.hpp
@@ -39,6 +39,7 @@
 #include <openthread/udp.h>
 
 #include "utils/lookup_table.hpp"
+#include "utils/parse_cmdline.hpp"
 
 namespace ot {
 namespace Cli {
@@ -52,6 +53,8 @@ class Interpreter;
 class UdpExample
 {
 public:
+    typedef Utils::CmdLineParser::Arg Arg;
+
     /**
      * Constructor
      *
@@ -67,13 +70,13 @@ public:
      * @param[in]  aArgs        An array of command line arguments.
      *
      */
-    otError Process(uint8_t aArgsLength, char *aArgs[]);
+    otError Process(uint8_t aArgsLength, Arg aArgs[]);
 
 private:
     struct Command
     {
         const char *mName;
-        otError (UdpExample::*mHandler)(uint8_t aArgsLength, char *aArgs[]);
+        otError (UdpExample::*mHandler)(uint8_t aArgsLength, Arg aArgs[]);
     };
 
     enum PayloadType
@@ -83,13 +86,13 @@ private:
         kTypeHexString = 2,
     };
 
-    otError ProcessHelp(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessBind(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessClose(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessConnect(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessOpen(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessSend(uint8_t aArgsLength, char *aArgs[]);
-    otError ProcessLinkSecurity(uint8_t aArgsLength, char *aArgs[]);
+    otError ProcessHelp(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessBind(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessClose(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessConnect(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessOpen(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessSend(uint8_t aArgsLength, Arg aArgs[]);
+    otError ProcessLinkSecurity(uint8_t aArgsLength, Arg aArgs[]);
     otError WriteCharToBuffer(otMessage *aMessage, uint16_t aMessageSize);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -515,23 +515,35 @@ Error Diags::ParseLong(char *aString, long &aLong)
     return (*endptr == '\0') ? kErrorNone : kErrorParse;
 }
 
+Error Diags::ParseCmd(char *aString, uint8_t &aArgsLength, char *aArgs[])
+{
+    Error                     error;
+    Utils::CmdLineParser::Arg args[kMaxArgs];
+
+    SuccessOrExit(error = Utils::CmdLineParser::ParseCmd(aString, aArgsLength, args, aArgsLength));
+    Utils::CmdLineParser::Arg::CopyArgsToStringArray(args, aArgsLength, aArgs);
+
+exit:
+    return error;
+}
+
 void Diags::ProcessLine(const char *aString, char *aOutput, size_t aOutputMaxLen)
 {
     enum
     {
-        kMaxArgs          = OPENTHREAD_CONFIG_DIAG_CMD_LINE_ARGS_MAX,
         kMaxCommandBuffer = OPENTHREAD_CONFIG_DIAG_CMD_LINE_BUFFER_SIZE,
     };
 
     Error   error = kErrorNone;
     char    buffer[kMaxCommandBuffer];
-    char *  aArgsector[kMaxArgs];
+    char *  args[kMaxArgs];
     uint8_t argCount = 0;
 
     VerifyOrExit(StringLength(aString, kMaxCommandBuffer) < kMaxCommandBuffer, error = kErrorNoBufs);
 
     strcpy(buffer, aString);
-    error = ot::Utils::CmdLineParser::ParseCmd(buffer, argCount, aArgsector, kMaxArgs);
+    argCount = kMaxArgs;
+    error    = ParseCmd(buffer, argCount, args);
 
 exit:
 
@@ -539,7 +551,7 @@ exit:
     {
     case kErrorNone:
         aOutput[0] = '\0'; // In case there is no output.
-        IgnoreError(ProcessCmd(argCount, &aArgsector[0], aOutput, aOutputMaxLen));
+        IgnoreError(ProcessCmd(argCount, &args[0], aOutput, aOutputMaxLen));
         break;
 
     case kErrorNoBufs:

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -122,6 +122,11 @@ public:
     void TransmitDone(Error aError);
 
 private:
+    enum : uint8_t
+    {
+        kMaxArgs = OPENTHREAD_CONFIG_DIAG_CMD_LINE_ARGS_MAX,
+    };
+
     struct Command
     {
         const char *mName;
@@ -140,6 +145,7 @@ private:
         uint8_t  mLastLqi;
     };
 
+    Error ParseCmd(char *aString, uint8_t &aArgsLength, char *aArgs[]);
     Error ProcessChannel(uint8_t aArgsLength, char *aArgs[], char *aOutput, size_t aOutputMaxLen);
     Error ProcessPower(uint8_t aArgsLength, char *aArgs[], char *aOutput, size_t aOutputMaxLen);
     Error ProcessRadio(uint8_t aArgsLength, char *aArgs[], char *aOutput, size_t aOutputMaxLen);

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -84,7 +84,7 @@ exit:
     return error;
 }
 
-Error ParseCmd(char *aCommandString, uint8_t &aArgsLength, char *aArgs[], uint8_t aArgsLengthMax)
+Error ParseCmd(char *aCommandString, uint8_t &aArgsLength, Arg *aArgs, uint8_t aArgsLengthMax)
 {
     Error error = kErrorNone;
     char *cmd;
@@ -106,7 +106,8 @@ Error ParseCmd(char *aCommandString, uint8_t &aArgsLength, char *aArgs[], uint8_
         if ((*cmd != '\0') && ((aArgsLength == 0) || (*(cmd - 1) == '\0')))
         {
             VerifyOrExit(aArgsLength < aArgsLengthMax, error = kErrorInvalidArgs);
-            aArgs[aArgsLength++] = cmd;
+
+            aArgs[aArgsLength++].SetCString(cmd);
         }
     }
 
@@ -334,6 +335,14 @@ Error ParseAsHexString(const char *aString, uint16_t &aSize, uint8_t *aBuffer, H
 
 exit:
     return error;
+}
+
+void Arg::CopyArgsToStringArray(Arg aArgs[], uint8_t aArgsLength, char *aStrings[])
+{
+    for (uint8_t i = 0; i < aArgsLength; i++)
+    {
+        aStrings[i] = aArgs[i].GetCString();
+    }
 }
 
 } // namespace CmdLineParser

--- a/src/core/utils/parse_cmdline.hpp
+++ b/src/core/utils/parse_cmdline.hpp
@@ -35,6 +35,7 @@
 #define PARSE_CMD_LINE_HPP_
 
 #include <stdint.h>
+#include <string.h>
 
 #include <openthread/error.h>
 #include <openthread/ip6.h>
@@ -61,21 +62,6 @@ enum HexStringParseMode : uint8_t
     kDisallowTruncate, // Disallow truncation of hex string.
     kAllowTruncate,    // Allow truncation of hex string.
 };
-
-/**
- * This function parses a given command line string and breaks it into an argument list.
- *
- * Note: this method may change the input @p aCommandString, it will put a '\0' by the end of each argument,
- *       and @p aArgs will point to the arguments in the input @p aCommandString. Backslash ('\') can be used
- *       to escape separators (' ', '\t', '\r', '\n') and the backslash itself.
- *
- * @param[in]   aCommandString  A null-terminated input string.
- * @param[out]  aArgsLength     The argument counter of the command line.
- * @param[out]  aArgs           The argument vector of the command line.
- * @param[in]   aArgsLengthMax  The maximum argument counter.
- *
- */
-otError ParseCmd(char *aCommandString, uint8_t &aArgsLength, char *aArgs[], uint8_t aArgsLengthMax);
 
 /**
  * This function parses a string as a `uint8_t` value.
@@ -172,7 +158,7 @@ otError ParseAsInt16(const char *aString, int16_t &aInt16);
  * @param[in]  aString   The string to parse.
  * @param[out] aInt32    A reference to an `int32_t` variable to output the parsed value.
  *
- * @retval kErrorNone          The string was parsed successfully.
+ * @retval kErrorNone         The string was parsed successfully.
  * @retval kErrorInvalidArgs  The string does not contain valid number (e.g., value out of range).
  *
  */
@@ -181,7 +167,7 @@ otError ParseAsInt32(const char *aString, int32_t &aInt32);
 /**
  * This function parses a string as a `bool` value.
  *
- * Zero value is treated as `false, non-zero value as `true`.
+ * Zero value is treated as `false`, non-zero value as `true`.
  *
  * @param[in]  aString   The string to parse.
  * @param[out] aBool     A reference to a `bool` variable to output the parsed value.
@@ -200,7 +186,7 @@ otError ParseAsBool(const char *aString, bool &aBool);
  * @param[in]  aString   The string to parse.
  * @param[out] aAddress  A reference to an `otIp6Address` to output the parsed IPv6 address.
  *
- * @retval kErrorNone          The string was parsed successfully.
+ * @retval kErrorNone         The string was parsed successfully.
  * @retval kErrorInvalidArgs  The string does not contain valid IPv6 address.
  *
  */
@@ -218,7 +204,7 @@ inline otError ParseAsIp6Address(const char *aString, otIp6Address &aAddress)
  * @param[out] aPrefix   A reference to an `otIp6Prefix` to output the parsed IPv6 prefix.
  *
  * @retval kErrorNone         The string was parsed successfully.
- * @retval kErrorInvalidArgs  The string does not contain valid IPv6 prefix
+ * @retval kErrorInvalidArgs  The string does not contain a valid IPv6 prefix.
  *
  */
 otError ParseAsIp6Prefix(const char *aString, otIp6Prefix &aPrefix);
@@ -283,6 +269,298 @@ otError ParseAsHexString(const char *       aString,
                          uint16_t &         aSize,
                          uint8_t *          aBuffer,
                          HexStringParseMode aMode = kDisallowTruncate);
+
+/**
+ * This class represents a single argument from an argument list.
+ *
+ */
+class Arg
+{
+public:
+    /**
+     * This method returns the length (number of characters) in the argument C string.
+     *
+     * @returns The argument string length.
+     *
+     */
+    uint16_t GetLength(void) const { return static_cast<uint16_t>(strlen(mString)); }
+
+    /**
+     * This method gets the argument as a C string.
+     *
+     * @returns A pointer to the argument as a C string.
+     *
+     */
+    const char *GetCString(void) const { return mString; }
+
+    /**
+     * This method gets the argument as C string.
+     *
+     * @returns A pointer to the argument as a C string.
+     *
+     */
+    char *GetCString(void) { return mString; }
+
+    /**
+     * This method sets the argument with a given C string.
+     *
+     * @param[in] aString    A pointer to the new C string.
+     *
+     */
+    void SetCString(char *aString) { mString = aString; }
+
+    /**
+     * This method overload the operator `==` to evaluate whether the argument is equal to a given C string.
+     *
+     * @param[in] aString    The C string to compare with.
+     *
+     * @retval TRUE   If the argument is equal to @p aString.
+     * @retval FALSE  If the argument is not equal to @p aString.
+     *
+     */
+    bool operator==(const char *aString) const { return (strcmp(mString, aString) == 0); }
+
+    /**
+     * This method overload the operator `!=` to evaluate whether the argument is unequal to a given C string.
+     *
+     * @param[in] aString    The C string to compare with.
+     *
+     * @retval TRUE   If the argument is not equal to @p aString.
+     * @retval FALSE  If the argument is equal to @p aString.
+     *
+     */
+    bool operator!=(const char *aString) const { return !(*this == aString); }
+
+    /**
+     * This method parses the argument as a `uint8_t` value.
+     *
+     * The number is parsed as decimal or hex format (if contains `0x` or `0X` prefix).
+     *
+     * @param[out] aUint8    A reference to an `uint8_t` variable to output the parsed value.
+     *
+     * @retval kErrorNone         The argument was parsed successfully.
+     * @retval kErrorInvalidArgs  The argument does not contain valid number (e.g., value out of range).
+     *
+     */
+    otError ParseAsUint8(uint8_t &aUint8) const { return CmdLineParser::ParseAsUint8(mString, aUint8); }
+
+    /**
+     * This method parses the argument as a `uint16_t` value.
+     *
+     * The number is parsed as decimal or hex format (if contains `0x` or `0X` prefix).
+     *
+     * @param[out] aUint16   A reference to an `uint16_t` variable to output the parsed value.
+     *
+     * @retval kErrorNone         The argument was parsed successfully.
+     * @retval kErrorInvalidArgs  The argument does not contain valid number (e.g., value out of range).
+     *
+     */
+    otError ParseAsUint16(uint16_t &aUint16) const { return CmdLineParser::ParseAsUint16(mString, aUint16); }
+
+    /**
+     * This method parses the argument as a `uint32_t` value.
+     *
+     * The number is parsed as decimal or hex format (if contains `0x` or `0X` prefix).
+     *
+     * @param[out] aUint32   A reference to an `uint32_t` variable to output the parsed value.
+     *
+     * @retval kErrorNone         The argument was parsed successfully.
+     * @retval kErrorInvalidArgs  The argument does not contain valid number (e.g., value out of range).
+     *
+     */
+    otError ParseAsUint32(uint32_t &aUint32) const { return CmdLineParser::ParseAsUint32(mString, aUint32); }
+
+    /**
+     * This method parses the argument as a `uint64_t` value.
+     *
+     * The number is parsed as decimal or hex format (if contains `0x` or `0X` prefix).
+     *
+     * @param[out] aUint64   A reference to an `uint64_t` variable to output the parsed value.
+     *
+     * @retval kErrorNone         The argument was parsed successfully.
+     * @retval kErrorInvalidArgs  The argument does not contain valid number (e.g., value out of range).
+     *
+     */
+    otError ParseAsUint64(uint64_t &aUint64) const { return CmdLineParser::ParseAsUint64(mString, aUint64); }
+
+    /**
+     * This method parses the argument as a `int8_t` value.
+     *
+     * The number is parsed as decimal or hex format (if contains `0x` or `0X` prefix). The string can start with
+     * `+`/`-` sign.
+     *
+     * @param[out] aInt8     A reference to an `int8_t` variable to output the parsed value.
+     *
+     * @retval kErrorNone         The argument was parsed successfully.
+     * @retval kErrorInvalidArgs  The argument does not contain valid number (e.g., value out of range).
+     *
+     */
+    otError ParseAsInt8(int8_t &aInt8) const { return CmdLineParser::ParseAsInt8(mString, aInt8); }
+
+    /**
+     * This method parses the argument as a `int16_t` value.
+     *
+     * The number is parsed as decimal or hex format (if contains `0x` or `0X` prefix). The string can start with
+     * `+`/`-` sign.
+     *
+     * @param[out] aInt16    A reference to an `int16_t` variable to output the parsed value.
+     *
+     * @retval kErrorNone         The argument was parsed successfully.
+     * @retval kErrorInvalidArgs  The argument does not contain valid number (e.g., value out of range).
+     *
+     */
+    otError ParseAsInt16(int16_t &aInt16) const { return CmdLineParser::ParseAsInt16(mString, aInt16); }
+
+    /**
+     * This method parses the argument as a `int32_t` value.
+     *
+     * The number is parsed as decimal or hex format (if contains `0x` or `0X` prefix). The string can start with
+     * `+`/`-` sign.
+     *
+     * @param[out] aInt32    A reference to an `int32_t` variable to output the parsed value.
+     *
+     * @retval kErrorNone         The argument was parsed successfully.
+     * @retval kErrorInvalidArgs  The argument does not contain valid number (e.g., value out of range).
+     *
+     */
+    otError ParseAsInt32(int32_t &aInt32) const { return CmdLineParser::ParseAsInt32(mString, aInt32); }
+
+    /**
+     * This method parses the argument as a `bool` value.
+     *
+     * Zero value is treated as `false`, non-zero value as `true`.
+     *
+     * @param[out] aBool     A reference to a `bool` variable to output the parsed value.
+     *
+     * @retval kErrorNone         The argument was parsed successfully.
+     * @retval kErrorInvalidArgs  The argument does not contain valid number.
+     *
+     */
+    otError ParseAsBool(bool &aBool) const { return CmdLineParser::ParseAsBool(mString, aBool); }
+
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
+    /**
+     * This method parses the argument as an IPv6 address.
+     *
+     * @param[out] aAddress  A reference to an `otIp6Address` to output the parsed IPv6 address.
+     *
+     * @retval kErrorNone         The argument was parsed successfully.
+     * @retval kErrorInvalidArgs  The argument does not contain valid IPv6 address.
+     *
+     */
+    otError ParseAsIp6Address(otIp6Address &aAddress) const
+    {
+        return CmdLineParser::ParseAsIp6Address(mString, aAddress);
+    }
+
+    /**
+     * This method parses the argument as an IPv6 prefix.
+     *
+     * The string is parsed as `{IPv6Address}/{PrefixLength}`.
+     *
+     * @param[out] aPrefix   A reference to an `otIp6Prefix` to output the parsed IPv6 prefix.
+     *
+     * @retval kErrorNone         The argument was parsed successfully.
+     * @retval kErrorInvalidArgs  The argument does not contain a valid IPv6 prefix.
+     *
+     */
+    otError ParseAsIp6Prefix(otIp6Prefix &aPrefix) const { return CmdLineParser::ParseAsIp6Prefix(mString, aPrefix); }
+
+#endif // OPENTHREAD_FTD || OPENTHREAD_MTD
+
+    /**
+     * This method parses the argument as a hex string into a byte array of fixed expected size.
+     *
+     * This method returns `kErrorNone` only when the hex string contains exactly @p aSize bytes (after parsing). If
+     * there are fewer or more bytes in hex string that @p aSize, the parsed bytes (up to @p aSize) are copied into the
+     * `aBuffer` and `kErrorInvalidArgs` is returned.
+     *
+     * @param[out] aBuffer   A pointer to a buffer to output the parsed byte sequence.
+     * @param[in]  aSize     The expected size of byte sequence (number of bytes after parsing).
+     *
+     * @retval kErrorNone         The argument was parsed successfully.
+     * @retval kErrorInvalidArgs  The argument does not contain valid hex bytes and/or not @p aSize bytes.
+     *
+     */
+    otError ParseAsHexString(uint8_t *aBuffer, uint16_t aSize) const
+    {
+        return CmdLineParser::ParseAsHexString(mString, aBuffer, aSize);
+    }
+
+    /**
+     * This template method parses the argument as a hex string into a a given fixed size array.
+     *
+     * This method returns `kErrorNone` only when the hex string contains exactly @p kBufferSize bytes (after parsing).
+     * If there are fewer or more bytes in hex string that @p kBufferSize, the parsed bytes (up to @p kBufferSize) are
+     * copied into the `aBuffer` and `kErrorInvalidArgs` is returned.
+     *
+     * @tparam kBufferSize   The byte array size (number of bytes).
+     *
+     * @param[out] aBuffer   A reference to a byte array to output the parsed byte sequence.
+     *
+     * @retval kErrorNone         The argument was parsed successfully.
+     * @retval kErrorInvalidArgs  The argument does not contain valid hex bytes and/or not @p aSize bytes.
+     *
+     */
+    template <uint16_t kBufferSize> otError ParseAsHexString(uint8_t (&aBuffer)[kBufferSize])
+    {
+        return ParseAsHexString(aBuffer, kBufferSize);
+    }
+
+    /**
+     * This method parses the argument as a hex string into a byte array.
+     *
+     * If @p aMode disallows truncation (`kDisallowTruncate`), this method verifies that parses hex string bytes fit in
+     * @p aBuffer with its given size in @aSize. Otherwise when @p aMode allows truncation, extra bytes after @p aSize
+     * bytes are ignored.
+     *
+     * @param[inout]  aSize     On entry indicates the number of bytes in @p aBuffer (max size of @p aBuffer).
+     *                          On exit provides number of bytes parsed and copied into @p aBuffer
+     * @param[out]    aBuffer   A pointer to a buffer to output the parsed byte sequence.
+     * @param[in]     aMode     Indicates parsing mode whether to allow truncation or not.
+     *
+     * @retval kErrorNone        The argument was parsed successfully.
+     * @retval kErrorInvalidArgs The argument does not contain valid format or too many bytes (if truncation not
+     *                           allowed)
+     *
+     */
+    otError ParseAsHexString(uint16_t &aSize, uint8_t *aBuffer, HexStringParseMode aMode = kDisallowTruncate)
+    {
+        return CmdLineParser::ParseAsHexString(mString, aSize, aBuffer, aMode);
+    }
+
+    /**
+     * This static method copies the argument string pointers from an `Arg` array to a C string array.
+     *
+     * @note this method only copies the string pointer value (i.e., `GetString()` pointer) from `aArgs` array to the
+     * @p aStrings array (the content of strings are not copied).
+     *
+     * @param[in] aArgs         A pointer to an `Arg` array.
+     * @param[in] aArgsLength   Number of entries in the @p aArgs array.
+     * @param[out] aStrings     An `char *` array to populate with the argument string pointers. The @p aString array
+     *                          MUST contain at least @p aArgsLength entries.
+     *
+     */
+    static void CopyArgsToStringArray(Arg aArgs[], uint8_t aArgsLength, char *aStrings[]);
+
+private:
+    char *mString;
+};
+
+/**
+ * This function parses a given command line string and breaks it into an argument list.
+ *
+ * Note: this method may change the input @p aCommandString, it will put a '\0' by the end of each argument,
+ *       and @p aArgs will point to the arguments in the input @p aCommandString. Backslash ('\') can be used
+ *       to escape separators (' ', '\t', '\r', '\n') and the backslash itself.
+ *
+ * @param[in]   aCommandString  A null-terminated input string.
+ * @param[out]  aArgsLength     The argument counter of the command line.
+ * @param[out]  aArgs           The argument vector of the command line.
+ * @param[in]   aArgsLengthMax  The maximum argument counter.
+ *
+ */
+otError ParseCmd(char *aCommandString, uint8_t &aArgsLength, Arg aArgs[], uint8_t aArgsLengthMax);
 
 /**
  * @}


### PR DESCRIPTION
This commit adds a new `Arg` class in `parse_cmdline` which represents
a single argument (wrapper over a C string). The `Arg` class is then
used in CLI modules. This helps simplify the CLI code mainly using
simpler syntax, e.g., using an overload of `==` operator to compare an
argument with a C string, or calling `ParseAs{Type}()` methods
directly on an `Arg` instance.