### PR TITLE
[tests] fix v1_2_LowPower_7_1_01_SingleProbeLinkMetricsWithEnhancedAcks

### DIFF
--- a/tests/scripts/thread-cert/v1_2_LowPower_7_1_01_SingleProbeLinkMetricsWithEnhancedAcks.py
+++ b/tests/scripts/thread-cert/v1_2_LowPower_7_1_01_SingleProbeLinkMetricsWithEnhancedAcks.py
@@ -84,8 +84,8 @@ class LowPower_7_1_01(thread_cert.TestCase):
 
         leader_addr = self.nodes[LEADER].get_ip6_address(ADDRESS_TYPE.LINK_LOCAL)
 
-        # Step 3 - Verify connectivity by instructing each device to sending an ICMPv6 Echo Request to the DUT
-        self.assertTrue(self.nodes[SED_1].ping(leader_addr, timeout=POLL_PERIOD / 1000))
+        # Step 3 - Verify connectivity by instructing each device to send an ICMPv6 Echo Request to the DUT
+        self.assertTrue(self.nodes[SED_1].ping(leader_addr, timeout=POLL_PERIOD * 2 / 1000))
         self.assertTrue(self.nodes[SSED_1].ping(leader_addr))
         self.simulator.go(5)
 


### PR DESCRIPTION
This PR fixes #6525.

From the pcap, it looks like the ping is there. I think probably the cause is that the ping reply came after the ping timeout (3s) just exceeded:
![Screen Shot 2021-04-29 at 10 33 41 PM](https://user-images.githubusercontent.com/12945188/116568440-10813580-a93b-11eb-9f69-1357b9a09e0a.png)
