### PR TITLE
[mle] ignore "Child Update Request" from a child not yet in valid state

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2796,7 +2796,7 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
 #if OPENTHREAD_FTD
         if (IsRouterOrLeader())
         {
-            Get<MleRouter>().HandleChildUpdateRequest(aMessage, aMessageInfo, keySequence);
+            Get<MleRouter>().HandleChildUpdateRequest(aMessage, aMessageInfo);
         }
         else
 #endif

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -586,14 +586,14 @@ private:
     Error HandleAdvertisement(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, Neighbor *);
     void  HandleParentRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void  HandleChildIdRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, uint32_t aKeySequence);
-    void HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, uint32_t aKeySequence);
-    void HandleChildUpdateResponse(const Message &         aMessage,
-                                   const Ip6::MessageInfo &aMessageInfo,
-                                   uint32_t                aKeySequence,
-                                   Neighbor *              aNeighbor);
-    void HandleDataRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, const Neighbor *aNeighbor);
-    void HandleNetworkDataUpdateRouter(void);
-    void HandleDiscoveryRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void  HandleChildUpdateRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void  HandleChildUpdateResponse(const Message &         aMessage,
+                                    const Ip6::MessageInfo &aMessageInfo,
+                                    uint32_t                aKeySequence,
+                                    Neighbor *              aNeighbor);
+    void  HandleDataRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, const Neighbor *aNeighbor);
+    void  HandleNetworkDataUpdateRouter(void);
+    void  HandleDiscoveryRequest(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     void HandleTimeSync(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, const Neighbor *aNeighbor);
 #endif


### PR DESCRIPTION
This commit updates `MleRouter::HandleChildUpdateRequest()` related to
how a "Child Update Request" message from a child is processed on a
parent. If the child is present in the parent's child table but it is
not yet in valid state, the parent ignores the received "Child Update
Request". This applies to a child being restored due to parent's reset
(child is in `kStateRestored`) or a child which is in the middle of
attach process (e.g., child is in `kStateParentRequest`). If a
matching child entry cannot be found in the parent's child table, the
behavior remains as before (i.e., parent sends a response with an
error Status TLV to notify the child to re-attach).

This change ensures that after a parent reset to restore a child, the
parent node is the one initiating and sending a "Child Update Request"
to the child and then receives a "Child Update Response" from it. Such
an exchange between the parent and the child will then include a
random challenge and response (authenticating the child and providing
replay protection). Also in this exchange the "Child Update Response"
from the child will include the the child's current MAC and MLE frame
counters, therefore ensuring that the parent correctly learns and
tracks the frame counters being used by the child.