### PR TITLE
[meshcop] support native commissioner

### DIFF
--- a/.github/workflows/simulation-1.1.yml
+++ b/.github/workflows/simulation-1.1.yml
@@ -320,7 +320,7 @@ jobs:
         name: cov-expects
         path: tmp/coverage.info
 
-  external-commissioner:
+  ot-commissioner:
     runs-on: ubuntu-20.04
     env:
       THREAD_VERSION: 1.1
@@ -360,7 +360,7 @@ jobs:
         ./script/test generate_coverage gcc
     - uses: actions/upload-artifact@v2
       with:
-        name: cov-external-commissioner
+        name: cov-ot-commissioner
         path: tmp/coverage.info
 
   multiple-instance:
@@ -490,7 +490,7 @@ jobs:
     - cli-mtd
     - cli-time-sync
     - expects
-    - external-commissioner
+    - ot-commissioner
     - multiple-instance
     - ncp-gcc-m32
     - ncp-clang

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -57,11 +57,6 @@ class ThreadNetif;
 
 namespace MeshCoP {
 
-enum
-{
-    kNativeCommissionerUdpPort = 49191, ///< UDP port of native commissioner service.
-};
-
 /**
  * This type represents a Joiner PSKd.
  *

--- a/src/core/net/ip6_filter.hpp
+++ b/src/core/net/ip6_filter.hpp
@@ -36,6 +36,7 @@
 
 #include "openthread-core-config.h"
 
+#include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
 
@@ -56,14 +57,16 @@ namespace Ip6 {
  * This class implements an IPv6 datagram filter.
  *
  */
-class Filter : private NonCopyable
+class Filter : public InstanceLocator, private NonCopyable
 {
 public:
     /**
      * This constructor initializes the Filter object.
      *
+     * @param[in]  aInstance  A reference to the OpenThread instance.
+     *
      */
-    Filter(void);
+    explicit Filter(Instance &aInstance);
 
     /**
      * This method indicates whether or not the IPv6 datagram passes the filter.
@@ -128,21 +131,12 @@ public:
      */
     const uint16_t *GetUnsecurePorts(uint8_t &aNumEntries) const;
 
-    /**
-     * This method sets whether to allow native commissioner traffic.
-     *
-     * @param[in]   aAllow  Whether to allow native commissioner traffic.
-     *
-     */
-    void AllowNativeCommissioner(bool aAllow) { mAllowNativeCommissioner = aAllow; }
-
 private:
     enum
     {
         kMaxUnsecurePorts = 2,
     };
     uint16_t mUnsecurePorts[kMaxUnsecurePorts];
-    bool     mAllowNativeCommissioner;
 };
 
 } // namespace Ip6

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1582,11 +1582,6 @@ void Mle::HandleNotifierEvents(Events aEvents)
         }
     }
 
-    if (aEvents.Contains(kEventSecurityPolicyChanged))
-    {
-        Get<Ip6::Filter>().AllowNativeCommissioner(Get<KeyManager>().GetSecurityPolicy().mNativeCommissioningEnabled);
-    }
-
 exit:
     return;
 }

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2914,14 +2914,16 @@ Error MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, const M
     discoveryResponse.Init();
     discoveryResponse.SetVersion(kThreadVersion);
 
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
     if (Get<KeyManager>().GetSecurityPolicy().mNativeCommissioningEnabled)
     {
-        SuccessOrExit(error =
-                          Tlv::Append<MeshCoP::CommissionerUdpPortTlv>(*message, MeshCoP::kNativeCommissionerUdpPort));
+        SuccessOrExit(
+            error = Tlv::Append<MeshCoP::CommissionerUdpPortTlv>(*message, Get<MeshCoP::BorderAgent>().GetUdpPort()));
 
         discoveryResponse.SetNativeCommissioner(true);
     }
     else
+#endif
     {
         discoveryResponse.SetNativeCommissioner(false);
     }

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -79,6 +79,7 @@ ThreadNetif::ThreadNetif(Instance &aInstance)
 #endif
     , mActiveDataset(aInstance)
     , mPendingDataset(aInstance)
+    , mIp6Filter(aInstance)
     , mKeyManager(aInstance)
     , mLowpan(aInstance)
     , mMac(aInstance)

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -576,8 +576,14 @@ static void processTransmit(otInstance *aInstance)
     rval = read(sTunFd, packet, sizeof(packet));
     VerifyOrExit(rval > 0, error = OT_ERROR_FAILED);
 
-    message = otIp6NewMessage(aInstance, nullptr);
-    VerifyOrExit(message != nullptr, error = OT_ERROR_NO_BUFS);
+    {
+        otMessageSettings settings;
+
+        settings.mLinkSecurityEnabled = (otThreadGetDeviceRole(aInstance) != OT_DEVICE_ROLE_DISABLED);
+        settings.mPriority            = OT_MESSAGE_PRIORITY_LOW;
+        message                       = otIp6NewMessage(aInstance, &settings);
+        VerifyOrExit(message != nullptr, error = OT_ERROR_NO_BUFS);
+    }
 
 #if defined(__APPLE__) || defined(__NetBSD__) || defined(__FreeBSD__)
     // BSD tunnel drivers have (for legacy reasons), may have a 4-byte header on them


### PR DESCRIPTION
This commit adds native commissioner support with the following changes:

* Accept unsecure traffic when Thread is not enabled.
* Accept traffic to border agent service when native commissioner is
  allowed.

Depends-On: openthread/ot-commissioner#201