### PR TITLE
[backbone-router] add cli command for MLR listeners

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -360,14 +360,13 @@ otError Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, Arg aArgs[])
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     else
     {
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
         if (aArgs[0] == "mgmt")
         {
             if (aArgsLength < 2)
             {
                 ExitNow(error = OT_ERROR_INVALID_COMMAND);
             }
-#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
             else if (aArgs[1] == "dua")
             {
                 uint8_t                   status;
@@ -396,7 +395,6 @@ otError Interpreter::ProcessBackboneRouter(uint8_t aArgsLength, Arg aArgs[])
             }
 #endif
         }
-#endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
         SuccessOrExit(error = ProcessBackboneRouterLocal(aArgsLength, aArgs));
     }
 
@@ -407,7 +405,7 @@ exit:
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
 
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE && OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
 otError Interpreter::ProcessBackboneRouterMgmtMlr(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_INVALID_COMMAND;
@@ -421,6 +419,7 @@ otError Interpreter::ProcessBackboneRouterMgmtMlr(uint8_t aArgsLength, Arg aArgs
             PrintMulticastListenersTable();
             error = OT_ERROR_NONE;
         }
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
         else if (aArgs[1] == "clear")
         {
             otBackboneRouterMulticastListenerClear(mInstance);
@@ -442,7 +441,9 @@ otError Interpreter::ProcessBackboneRouterMgmtMlr(uint8_t aArgsLength, Arg aArgs
 
             error = otBackboneRouterMulticastListenerAdd(mInstance, &address, timeout);
         }
+#endif
     }
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     else if (aArgs[0] == "response")
     {
         uint8_t status;
@@ -452,6 +453,7 @@ otError Interpreter::ProcessBackboneRouterMgmtMlr(uint8_t aArgsLength, Arg aArgs
 
         otBackboneRouterConfigNextMulticastListenerRegistrationResponse(mInstance, status);
     }
+#endif
     else
     {
         error = OT_ERROR_INVALID_COMMAND;
@@ -473,7 +475,7 @@ void Interpreter::PrintMulticastListenersTable(void)
     }
 }
 
-#endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE && OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
+#endif // OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
 
 otError Interpreter::ProcessBackboneRouterLocal(uint8_t aArgsLength, Arg aArgs[])
 {

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -347,7 +347,7 @@ private:
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     otError ProcessBackboneRouterLocal(uint8_t aArgsLength, Arg aArgs[]);
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE && OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
     otError ProcessBackboneRouterMgmtMlr(uint8_t aArgsLength, Arg aArgs[]);
     void    PrintMulticastListenersTable(void);
 #endif

--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -1993,6 +1993,15 @@ class OTCI(object):
         """Set jitter (in seconds) for Backbone Router registration for Thread 1.2 FTD."""
         self.execute_command(f'bbr jitter {val}')
 
+    def backbone_router_get_multicast_listeners(self) -> List[Tuple[Ip6Addr, int]]:
+        """Get Backbone Router Multicast Listeners."""
+        listeners = []
+        for line in self.execute_command('bbr mgmt mlr listener'):
+            ip, timeout = line.split()
+            listeners.append((Ip6Addr(ip), int(timeout)))
+
+        return listeners
+
     #
     # Thread 1.2 and DUA/MLR utilities
     #

--- a/tools/otci/tests/test_otci.py
+++ b/tools/otci/tests/test_otci.py
@@ -189,6 +189,8 @@ class TestOTCI(unittest.TestCase):
         leader.set_allowlist([leader.get_extaddr()])
         leader.disable_allowlist()
 
+        self.assertEqual([], leader.backbone_router_get_multicast_listeners())
+
         leader.add_ipmaddr('ff04::1')
         leader.del_ipmaddr('ff04::1')
         leader.add_ipmaddr('ff04::2')
@@ -223,6 +225,10 @@ class TestOTCI(unittest.TestCase):
         logging.info('leader bbr state: %r', leader.get_backbone_router_state())
         logging.info('leader bbr config: %r', leader.get_backbone_router_config())
         logging.info('leader PBBR: %r', leader.get_primary_backbone_router_info())
+
+        leader.wait(10)
+        self.assertEqual(1, len(leader.backbone_router_get_multicast_listeners()))
+        self.assertEqual('ff04::2', leader.backbone_router_get_multicast_listeners()[0][0])
 
         logging.info('leader bufferinfo: %r', leader.get_message_buffer_info())
 


### PR DESCRIPTION
This commit makes the CLI command for printing MLR listeners works for non Reference Devices.