### PR TITLE
[ip6] improve frame filtering

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (114)
+#define OPENTHREAD_API_VERSION (115)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -171,6 +171,17 @@ enum
 };
 
 /**
+ * This enumeration defines possible rx packets filtering modes
+ *
+ */
+typedef enum otIp6ReceiveFilterMode
+{
+    OT_IP6_RX_FILTER_MODE_NO_FILTER                     = 0, ///< Filter is disabled.
+    OT_IP6_RX_FILTER_MODE_FILTER_THREAD_CONTROL_TRAFFIC = 1, ///< Filter all Thread control traffic
+    OT_IP6_RX_FILTER_MODE_FILTER_ALL_THREAD_USED_PORTS  = 2, ///< Filter all ports being used by OpenThread.
+} otIp6ReceiveFilterMode;
+
+/**
  * This structure represents an IPv6 network interface unicast address.
  *
  */
@@ -402,16 +413,16 @@ typedef void (*otIp6ReceiveCallback)(otMessage *aMessage, void *aContext);
 /**
  * This function registers a callback to provide received IPv6 datagrams.
  *
- * By default, this callback does not pass Thread control traffic.  See otIp6SetReceiveFilterEnabled() to
- * change the Thread control traffic filter setting.
+ * By default, this callback does not pass Thread control traffic.  See otIp6SetReceiveFilterMode() to
+ * change the Thread filter setting.
  *
  * @param[in]  aInstance         A pointer to an OpenThread instance.
  * @param[in]  aCallback         A pointer to a function that is called when an IPv6 datagram is received or
  *                               NULL to disable the callback.
  * @param[in]  aCallbackContext  A pointer to application-specific context.
  *
- * @sa otIp6IsReceiveFilterEnabled
- * @sa otIp6SetReceiveFilterEnabled
+ * @sa otIp6GetReceiveFilterMode
+ * @sa otIp6SetReceiveFilterMode
  *
  */
 void otIp6SetReceiveCallback(otInstance *aInstance, otIp6ReceiveCallback aCallback, void *aCallbackContext);
@@ -452,7 +463,7 @@ typedef void (*otIp6AddressCallback)(const otIp6AddressInfo *aAddressInfo, bool 
 void otIp6SetAddressCallback(otInstance *aInstance, otIp6AddressCallback aCallback, void *aCallbackContext);
 
 /**
- * This function indicates whether or not Thread control traffic is filtered out when delivering IPv6 datagrams
+ * This function indicates how inbound traffic is filtered out when delivering IPv6 datagrams
  * via the callback specified in otIp6SetReceiveCallback().
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.
@@ -460,23 +471,23 @@ void otIp6SetAddressCallback(otInstance *aInstance, otIp6AddressCallback aCallba
  * @returns  TRUE if Thread control traffic is filtered out, FALSE otherwise.
  *
  * @sa otIp6SetReceiveCallback
- * @sa otIp6SetReceiveFilterEnabled
+ * @sa otIp6SetReceiveFilterMode
  *
  */
-bool otIp6IsReceiveFilterEnabled(otInstance *aInstance);
+otIp6ReceiveFilterMode otIp6GetReceiveFilterMode(otInstance *aInstance);
 
 /**
- * This function sets whether or not Thread control traffic is filtered out when delivering IPv6 datagrams
+ * This function sets sets how inbound traffic should be filtered out when delivering IPv6 datagrams
  * via the callback specified in otIp6SetReceiveCallback().
  *
- * @param[in]  aInstance A pointer to an OpenThread instance.
- * @param[in]  aEnabled  TRUE if Thread control traffic is filtered out, FALSE otherwise.
+ * @param[in]  aInstance   A pointer to an OpenThread instance.
+ * @param[in]  aFilterType TRUE if Thread control traffic is filtered out, FALSE otherwise.
  *
  * @sa otIp6SetReceiveCallback
- * @sa otIsReceiveIp6FilterEnabled
+ * @sa otIp6GetReceiveFilterMode
  *
  */
-void otIp6SetReceiveFilterEnabled(otInstance *aInstance, bool aEnabled);
+void otIp6SetReceiveFilterMode(otInstance *aInstance, otIp6ReceiveFilterMode aFilterMode);
 
 /**
  * This function sends an IPv6 datagram via the Thread interface.

--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -290,6 +290,18 @@ void otUdpForwardReceive(otInstance *        aInstance,
                          uint16_t            aSockPort);
 
 /**
+ * Determines if the given UDP port is exclusively opened by OpenThread API.
+ *
+ * @param[in]  aInstance            A pointer to an OpenThread instance.
+ * @param[in]  port                 UDP port number to verify.
+ *
+ * @retval true    The port is being used exclusively by OpenThread
+ * @retval false   The port is not used by any of the OpenThread API or is shared (e.g. is Backbone socket ).
+ *
+ */
+bool otUdpIsPortInUse(otInstance *aInstance, uint16_t port);
+
+/**
  * @}
  *
  */

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -146,18 +146,18 @@ void otIp6SetAddressCallback(otInstance *aInstance, otIp6AddressCallback aCallba
     instance.Get<ThreadNetif>().SetAddressCallback(aCallback, aCallbackContext);
 }
 
-bool otIp6IsReceiveFilterEnabled(otInstance *aInstance)
+void otIp6SetReceiveFilterMode(otInstance *aInstance, otIp6ReceiveFilterMode aFilterMode)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Ip6::Ip6>().IsReceiveIp6FilterEnabled();
+    return instance.Get<Ip6::Ip6>().SetReceiveFilterMode(aFilterMode);
 }
 
-void otIp6SetReceiveFilterEnabled(otInstance *aInstance, bool aEnabled)
+otIp6ReceiveFilterMode otIp6GetReceiveFilterMode(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    instance.Get<Ip6::Ip6>().SetReceiveIp6FilterEnabled(aEnabled);
+    return instance.Get<Ip6::Ip6>().GetReceiveFilterMode();
 }
 
 otError otIp6Send(otInstance *aInstance, otMessage *aMessage)

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -147,3 +147,10 @@ otError otUdpSendDatagram(otInstance *aInstance, otMessage *aMessage, otMessageI
     return instance.Get<Ip6::Udp>().SendDatagram(*static_cast<ot::Message *>(aMessage),
                                                  *static_cast<Ip6::MessageInfo *>(aMessageInfo), Ip6::kProtoUdp);
 }
+
+bool otUdpIsPortInUse(otInstance *aInstance, uint16_t port)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<Ip6::Udp>().IsPortInUse(port);
+}

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -228,42 +228,42 @@ public:
     /**
      * This method registers a callback to provide received raw IPv6 datagrams.
      *
-     * By default, this callback does not pass Thread control traffic.  See SetReceiveIp6FilterEnabled() to change
+     * By default, this callback does not pass Thread control traffic. See SetReceiveFilterMode() to change
      * the Thread control traffic filter setting.
      *
      * @param[in]  aCallback         A pointer to a function that is called when an IPv6 datagram is received
      *                               or nullptr to disable the callback.
      * @param[in]  aCallbackContext  A pointer to application-specific context.
      *
-     * @sa IsReceiveIp6FilterEnabled
-     * @sa SetReceiveIp6FilterEnabled
+     * @sa GetReceiveFilterMode
+     * @sa SetReceiveFilterMode
      *
      */
     void SetReceiveDatagramCallback(otIp6ReceiveCallback aCallback, void *aCallbackContext);
 
     /**
-     * This method indicates whether or not Thread control traffic is filtered out when delivering IPv6 datagrams
+     * This method indicates howtrafic is filtered out when delivering IPv6 datagrams
      * via the callback specified in SetReceiveIp6DatagramCallback().
      *
-     * @returns  TRUE if Thread control traffic is filtered out, FALSE otherwise.
+     * @returns  Received frames filtering mode.
      *
      * @sa SetReceiveDatagramCallback
-     * @sa SetReceiveIp6FilterEnabled
+     * @sa SetReceiveFilterMode
      *
      */
-    bool IsReceiveIp6FilterEnabled(void) const { return mIsReceiveIp6FilterEnabled; }
+    otIp6ReceiveFilterMode GetReceiveFilterMode(void) const { return mIp6ReceiveFilterType; }
 
     /**
-     * This method sets whether or not Thread control traffic is filtered out when delivering IPv6 datagrams
+     * This method sets how inbound traffic is filtered out when delivering IPv6 datagrams
      * via the callback specified in SetReceiveIp6DatagramCallback().
      *
-     * @param[in]  aEnabled  TRUE if Thread control traffic is filtered out, FALSE otherwise.
+     * @param[in]  aFilterMode  TRUE if Thread control traffic is filtered out, FALSE otherwise.
      *
      * @sa SetReceiveDatagramCallback
-     * @sa IsReceiveIp6FilterEnabled
+     * @sa GetReceiveFilterMode
      *
      */
-    void SetReceiveIp6FilterEnabled(bool aEnabled) { mIsReceiveIp6FilterEnabled = aEnabled; }
+    void SetReceiveFilterMode(otIp6ReceiveFilterMode aFilterMode) { mIp6ReceiveFilterType = aFilterMode; }
 
     /**
      * This method indicates whether or not IPv6 forwarding is enabled.
@@ -361,13 +361,14 @@ private:
                         MessageInfo &      aMessageInfo,
                         uint8_t            aIpProto,
                         Message::Ownership aMessageOwnership);
-    bool  ShouldForwardToThread(const MessageInfo &aMessageInfo, bool aFromNcpHost) const;
-    bool  IsOnLink(const Address &aAddress) const;
 
-    bool                 mForwardingEnabled;
-    bool                 mIsReceiveIp6FilterEnabled;
-    otIp6ReceiveCallback mReceiveIp6DatagramCallback;
-    void *               mReceiveIp6DatagramCallbackContext;
+    bool ShouldForwardToThread(const MessageInfo &aMessageInfo, bool aFromNcpHost) const;
+    bool IsOnLink(const Address &aAddress) const;
+
+    bool                   mForwardingEnabled;
+    otIp6ReceiveFilterMode mIp6ReceiveFilterType;
+    otIp6ReceiveCallback   mReceiveIp6DatagramCallback;
+    void *                 mReceiveIp6DatagramCallbackContext;
 
     PriorityQueue mSendQueue;
     Tasklet       mSendQueueTask;

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -527,6 +527,25 @@ exit:
     return;
 }
 
+bool Udp::IsPortInUse(uint16_t aPort) const
+{
+    bool found = false;
+    for (const SocketHandle *socket = mSockets.GetHead(); socket != nullptr; socket = socket->GetNext())
+    {
+        if (socket->GetSockName().GetPort() == aPort)
+        {
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+            if (!IsBackboneSocket(*socket))
+#endif
+            {
+                found = true;
+            }
+            break;
+        }
+    }
+    return found;
+}
+
 bool Udp::ShouldUsePlatformUdp(uint16_t aPort) const
 {
     return (aPort != Mle::kUdpPort && aPort != Tmf::kUdpPort

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -574,6 +574,18 @@ public:
 #endif
 
     /**
+     * This method returns whether a udp port is being used by OpenThread or any of it's optional
+     * features, e.g. CoAP API.
+     *
+     * @param[in]   aPort       The udp port
+     *
+     * @retval True when port is used by the OpenThread
+     * @retval False when the port is not used by OpenThrad.
+     *
+     */
+    bool IsPortInUse(uint16_t aPort) const;
+
+    /**
      * This method returns whether a udp port belongs to the platform or the stack.
      *
      * @param[in]   aPort       The udp port

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -281,7 +281,7 @@ NcpBase::NcpBase(Instance *aInstance)
     otMessageQueueInit(&mMessageQueue);
     IgnoreError(otSetStateChangedCallback(mInstance, &NcpBase::HandleStateChanged, this));
     otIp6SetReceiveCallback(mInstance, &NcpBase::HandleDatagramFromStack, this);
-    otIp6SetReceiveFilterEnabled(mInstance, true);
+    otIp6SetReceiveFilterMode(mInstance, OT_IP6_RX_FILTER_MODE_FILTER_THREAD_CONTROL_TRAFFIC);
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     otNetworkTimeSyncSetCallback(mInstance, &NcpBase::HandleTimeSyncUpdate, this);
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -2121,7 +2121,7 @@ exit:
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU>(void)
 {
     // Note reverse logic: passthru enabled = filter disabled
-    return mEncoder.WriteBool(!otIp6IsReceiveFilterEnabled(mInstance));
+    return mEncoder.WriteBool(otIp6GetReceiveFilterMode(mInstance) == OT_IP6_RX_FILTER_MODE_NO_FILTER);
 }
 
 template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_RLOC16_DEBUG_PASSTHRU>(void)
@@ -2132,7 +2132,8 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_RLOC16_DEBUG_P
     SuccessOrExit(error = mDecoder.ReadBool(enabled));
 
     // Note reverse logic: passthru enabled = filter disabled
-    otIp6SetReceiveFilterEnabled(mInstance, !enabled);
+    otIp6SetReceiveFilterMode(mInstance, enabled ? OT_IP6_RX_FILTER_MODE_NO_FILTER
+                                                 : OT_IP6_RX_FILTER_MODE_FILTER_THREAD_CONTROL_TRAFFIC);
 
 exit:
     return error;

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -1480,8 +1480,7 @@ void platformNetifInit(otInstance *aInstance, const char *aInterfaceName)
 #if OPENTHREAD_POSIX_USE_MLD_MONITOR
     mldListenerInit();
 #endif
-
-    otIp6SetReceiveFilterEnabled(aInstance, true);
+    otIp6SetReceiveFilterMode(aInstance, OT_IP6_RX_FILTER_MODE_FILTER_THREAD_CONTROL_TRAFFIC);
     otIcmp6SetEchoMode(aInstance, OT_ICMP6_ECHO_HANDLER_DISABLED);
     otIp6SetReceiveCallback(aInstance, processReceive, aInstance);
     otIp6SetAddressCallback(aInstance, processAddressChange, aInstance);


### PR DESCRIPTION
If OpenThread is part of an OS with it's own IP stack filtering only
control messages is insufficien.
Example could be that if application is using OpenThread API to listen
for CoAP messages received messages are passed also to the IP callback.
The message then is delivered to the OS IP stack and generates error
response: "ICMPv6 Destination Unreachable (Port unreachable)" as the
port is not open on the OS side. OS IP stack is unaware of the
OpenThread existence so it can not be filtered on that level and the
shim layer does not receive port, or protocol information from OT so it
can not filter out a frame without parsing it first.
The only reasonable solution seems to be extending filtering
capabilities to filter all "OpenThread initiated" comunication.
Added extended filtering option to filter all of the udp packets destiend
to the port that is handled by OpenThread.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>