### PR TITLE
[efr32] fix build issue with ECDSA and SRP_CLIENT options enabled #6549

### DIFF
--- a/examples/platforms/efr32/src/mbedtls_config.h
+++ b/examples/platforms/efr32/src/mbedtls_config.h
@@ -20,6 +20,18 @@
 #define MBEDTLS_SSL_MAX_CONTENT_LEN 768 /**< Maximum fragment length in bytes */
 #endif
 
+// Enable necessary mbedtls functions when ECDSA is enabled
+#if OPENTHREAD_CONFIG_ECDSA_ENABLE
+#define MBEDTLS_BASE64_C
+#define MBEDTLS_ECDH_C
+#define MBEDTLS_ECDSA_C
+#define MBEDTLS_ECDSA_DETERMINISTIC
+#define MBEDTLS_HMAC_DRBG_C
+#define MBEDTLS_OID_C
+#define MBEDTLS_PEM_PARSE_C
+#define MBEDTLS_PK_WRITE_C
+#endif
+
 // <q SL_MBEDTLS_SSL_MAX_FRAGMENT_LENGTH> Enable support for RFC 6066 max_fragment_length extension in SSL.
 // <i> Default: 1
 // <i> Enable support for RFC 6066 max_fragment_length extension in SSL.

--- a/third_party/silabs/cmake/mbedtls.cmake
+++ b/third_party/silabs/cmake/mbedtls.cmake
@@ -43,6 +43,11 @@ target_compile_definitions(silabs-mbedtls
         ${OT_PLATFORM_DEFINES}
 )
 
+target_link_libraries(silabs-mbedtls
+    PRIVATE
+        ot-config
+)
+
 target_include_directories(silabs-mbedtls
     PUBLIC
         ${SILABS_MBEDTLS_DIR}/include
@@ -84,12 +89,14 @@ set(SILABS_MBEDTLS_SOURCES
     ${SILABS_MBEDTLS_DIR}/library/ecp.c
     ${SILABS_MBEDTLS_DIR}/library/entropy.c
     ${SILABS_MBEDTLS_DIR}/library/error.c
+    ${SILABS_MBEDTLS_DIR}/library/hmac_drbg.c
     ${SILABS_MBEDTLS_DIR}/library/md.c
     ${SILABS_MBEDTLS_DIR}/library/oid.c
     ${SILABS_MBEDTLS_DIR}/library/pem.c
     ${SILABS_MBEDTLS_DIR}/library/pk_wrap.c
     ${SILABS_MBEDTLS_DIR}/library/pk.c
     ${SILABS_MBEDTLS_DIR}/library/pkparse.c
+    ${SILABS_MBEDTLS_DIR}/library/pkwrite.c
     ${SILABS_MBEDTLS_DIR}/library/platform_util.c
     ${SILABS_MBEDTLS_DIR}/library/platform.c
     ${SILABS_MBEDTLS_DIR}/library/rsa_internal.c


### PR DESCRIPTION
This commit add missing preprocessors to fix the build issue when ECDSA and SRP_CLIENT options are enabled.

Built and test with cmake:

```
./script/cmake-build efr32mg12 -DBOARD=brd4166a -DOT_COAP=ON -DOT_ECDSA=ON -DOT_SRP_CLIENT=ON
```