### PR TITLE
[routing-manager] add message to static_assert

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -658,7 +658,7 @@ void RoutingManager::SendRouterAdvertisement(const Ip6::Prefix *aNewOmrPrefixes,
     uint8_t  buffer[kMaxRouterAdvMessageLength];
     uint16_t bufferLength = 0;
 
-    static_assert(sizeof(mRouterAdvMessage) <= sizeof(buffer));
+    static_assert(sizeof(mRouterAdvMessage) <= sizeof(buffer), "RA buffer too small");
     memcpy(buffer, &mRouterAdvMessage, sizeof(mRouterAdvMessage));
     bufferLength += sizeof(mRouterAdvMessage);
 


### PR DESCRIPTION
static_assert with no message is a C++17 extension.

Thanks to @gabekassel for pointing this out.