### PR TITLE
[cmake] add OT_BUILD_TESTING option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,10 +204,9 @@ endif()
 add_subdirectory(src)
 add_subdirectory(third_party EXCLUDE_FROM_ALL)
 
-if(OT_PLATFORM STREQUAL "simulation")
+if(OT_BUILD_TESTING)
     enable_testing()
 endif()
-
 add_subdirectory(tests)
 
 add_custom_target(print-ot-config ALL

--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -34,6 +34,8 @@ option(OT_FTD "enable FTD" ON)
 option(OT_MTD "enable MTD" ON)
 option(OT_RCP "enable RCP" ON)
 
+option(OT_BUILD_TESTING "enable build tests")
+
 option(OT_ASSERT "enable assert function OT_ASSERT()" ON)
 if(OT_ASSERT)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_ASSERT_ENABLE=1")

--- a/script/cmake-build
+++ b/script/cmake-build
@@ -68,6 +68,7 @@ readonly OT_PLATFORMS=(cc2538 simulation posix)
 readonly OT_POSIX_SIM_COMMON_OPTIONS=(
     "-DOT_BORDER_AGENT=ON"
     "-DOT_BORDER_ROUTER=ON"
+    "-DOT_BUILD_TESTING=ON"
     "-DOT_COAP=ON"
     "-DOT_COAP_BLOCK=ON"
     "-DOT_COAP_OBSERVE=ON"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -26,7 +26,7 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-if(OT_PLATFORM STREQUAL "simulation")
+if(OT_BUILD_TESTING)
     if(OT_FTD)
         add_subdirectory(unit)
     endif()


### PR DESCRIPTION
This commit adds an option `OT_BUILD_TESTING`(similar to CTest's `BUILD_TESTING`).