### PR TITLE
[cli] fix extra error output when handling user CLI commands

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -4901,7 +4901,7 @@ void Interpreter::ProcessLine(char *aBuf)
         ExitNow();
     }
 
-    SuccessOrExit(ProcessUserCommands(argsLength, args));
+    VerifyOrExit(ProcessUserCommands(argsLength, args) != OT_ERROR_NONE);
     OutputResult(OT_ERROR_INVALID_COMMAND);
 
 exit:

--- a/tests/scripts/expect/cli-misc.exp
+++ b/tests/scripts/expect/cli-misc.exp
@@ -173,4 +173,7 @@ expect "Done"
 send "ba state\n"
 expect "Done"
 
+send "invalidcommand\n"
+expect_line "Error 35: InvalidCommand"
+
 dispose_all


### PR DESCRIPTION
It also adds a check in `cli-misc.exp` to verify error on an invalid
CLI command.

------

Thanks to @lmnotran for noticing and reporting this (in https://github.com/openthread/openthread/pull/6524#discussion_r626058987).