### PR TITLE
[tests] fix MATN_09_DefaultBRMulticastForwarding.py

### DIFF
--- a/tests/scripts/thread-cert/border_router/MATN_09_DefaultBRMulticastForwarding.py
+++ b/tests/scripts/thread-cert/border_router/MATN_09_DefaultBRMulticastForwarding.py
@@ -149,6 +149,8 @@ class MATN_09_FailureOfPrimaryBBROutboundMulticast(thread_cert.TestCase):
             .filter_ping_request() \
             .must_next()
 
+        initial_identifier = _pkt.icmpv6.echo.identifier
+
         # 2. BR_1 forwards the multicast ping packet with multicast address,
         # MA1, to the LAN.
         pkts.filter_eth_src(vars['BR_1_ETH']) \
@@ -177,6 +179,7 @@ class MATN_09_FailureOfPrimaryBBROutboundMulticast(thread_cert.TestCase):
         _pkt = pkts.filter_wpan_src64(vars['Router_1']) \
             .filter_AMPLFMA(mpl_seed_id=vars['Router_1_RLOC']) \
             .filter_ping_request() \
+            .filter(lambda p: p.icmpv6.echo.identifier != initial_identifier) \
             .must_next()
 
         # 6. BR_2 forwards the multicast ping packet with multicast address,


### PR DESCRIPTION
The second to the last packet verification statement expects a ping request sent by Router_1 after BR_2 became the PBBR.
However, this statement wrongly matches a ping request sent by Router_1 before BR_2 became the PBBR. 
I added a restriction of the echo identifier to make sure the packet verification statement doesn't match the previous ping request.