### PR TITLE
[doc] update the BR name in comments/documentations

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -72,7 +72,7 @@ if(OT_BORDER_ROUTER)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE=1")
 endif()
 
-option(OT_BORDER_ROUTING "enable (duckhorn) border routing support")
+option(OT_BORDER_ROUTING "enable border routing support")
 if(OT_BORDER_ROUTING)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE=1")
 endif()

--- a/src/core/config/border_router.h
+++ b/src/core/config/border_router.h
@@ -58,7 +58,7 @@
 /**
  * @def OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
  *
- * Define to 1 to enable (Duckhorn) Border Routing support.
+ * Define to 1 to enable Border Routing support.
  *
  */
 #ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE

--- a/tests/scripts/thread-cert/border_router/test_dnssd_server.py
+++ b/tests/scripts/thread-cert/border_router/test_dnssd_server.py
@@ -35,7 +35,7 @@ import config
 import thread_cert
 
 # Test description:
-#   This test verifies DNS-SD server works on a Duckhorn BR and is accessible from a Host.
+#   This test verifies DNS-SD server works on a BR and is accessible from a Host.
 #
 # Topology:
 #    ----------------(eth)--------------------

--- a/tests/scripts/thread-cert/border_router/test_single_border_router.py
+++ b/tests/scripts/thread-cert/border_router/test_single_border_router.py
@@ -49,7 +49,7 @@ ROUTER = 2
 HOST = 3
 
 # The two prefixes are set small enough that a random-generated OMR prefix is
-# very likely greater than them. So that the duckhorn BR will remove the random-generated one.
+# very likely greater than them. So that the BR will remove the random-generated one.
 ON_MESH_PREFIX1 = "fd00:00:00:01::/64"
 ON_MESH_PREFIX2 = "fd00:00:00:02::/64"
 


### PR DESCRIPTION
This commit updates the BR name in comments and documentation
(removes the uses of "duckhorn")