### PR TITLE
[cli] make command output consistent

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -4862,17 +4862,20 @@ void Interpreter::ProcessLine(char *aBuf)
     Arg            args[kMaxArgs];
     uint8_t        argsLength;
     const Command *command;
-    otError        error;
+    otError        error = OT_ERROR_NONE;
 
-    VerifyOrExit(aBuf != nullptr && StringLength(aBuf, kMaxLineLength) <= kMaxLineLength - 1);
+    OT_ASSERT(aBuf != nullptr);
 
-    VerifyOrExit(Utils::CmdLineParser::ParseCmd(aBuf, argsLength, args, kMaxArgs) == OT_ERROR_NONE,
-                 OutputLine("Error: too many args (max %d)", kMaxArgs));
+    VerifyOrExit(StringLength(aBuf, kMaxLineLength) <= kMaxLineLength - 1, error = OT_ERROR_PARSE);
+
+    SuccessOrExit(error = Utils::CmdLineParser::ParseCmd(aBuf, argsLength, args, kMaxArgs));
     VerifyOrExit(argsLength >= 1);
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-    VerifyOrExit((!otDiagIsEnabled(mInstance) || (args[0] == "diag")),
-                 OutputLine("under diagnostics mode, execute 'diag stop' before running any other commands."));
+    VerifyOrExit((!otDiagIsEnabled(mInstance) || (args[0] == "diag")), {
+        OutputLine("under diagnostics mode, execute 'diag stop' before running any other commands.");
+        error = OT_ERROR_INVALID_STATE;
+    });
 #endif
 
     command = Utils::LookupTable::Find(args[0].GetCString(), sCommands);
@@ -4885,10 +4888,12 @@ void Interpreter::ProcessLine(char *aBuf)
     {
         error = ProcessUserCommands(argsLength, args);
     }
-    OutputResult(error);
 
 exit:
-    return;
+    if (error != OT_ERROR_NONE || argsLength > 0)
+    {
+        OutputResult(error);
+    }
 }
 
 otError Interpreter::ProcessUserCommands(uint8_t aArgsLength, Arg aArgs[])

--- a/tests/scripts/thread-cert/test_diag.py
+++ b/tests/scripts/thread-cert/test_diag.py
@@ -84,7 +84,7 @@ class TestDiag(thread_cert.TestCase):
             ('diag', 'diagnostics mode is disabled\r\n'),
             (
                 'diag 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32',
-                r'Error: too many args \(max 32\)\r\n',
+                r'Error 7: InvalidArgs\r\n',
             ),
         ]
 


### PR DESCRIPTION
This commit makes the CLI command output consistent under all cases:
- Output `Error 6: Parse` when the command line is too long (no output originally).
- Output `Error 7: InvalidArgs` when the command line has too many arguments. The original output is `Error: too many args (max %d)`, which does not strictly follow the `Error <code>: <msg>` pattern.
- Output `Error 13: InvalidState` for running non-diag command in diagnosis mode to follow `Error <code>: <msg>` pattern.
