### PR TITLE
[srp-client] disallow adding of duplicate services (same service/instc name)

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (112)
+#define OPENTHREAD_API_VERSION (113)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/srp_client.h
+++ b/include/openthread/srp_client.h
@@ -446,7 +446,7 @@ otError otSrpClientSetHostAddresses(otInstance *aInstance, const otIp6Address *a
 
  * @retval OT_ERROR_NONE          The addition of service started successfully. The `otSrpClientCallback` will be
  *                                called to report the status.
- * @retval OT_ERROR_ALREADY       The same service is already in the list.
+ * @retval OT_ERROR_ALREADY       A service with the same service and instance names is already in the list.
  * @retval OT_ERROR_INVALID_ARGS  The service structure is invalid (e.g., bad service name or `otDnsTxtEntry`).
  *
  */

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -127,6 +127,16 @@ exit:
     return;
 }
 
+bool Client::Service::Matches(const Service &aOther) const
+{
+    // This method indicates whether or not two service entries match,
+    // i.e., have the same service and instance names. This is intended
+    // for use by `LinkedList::FindMatching()` to search within the
+    // `mServices` list.
+
+    return (strcmp(GetName(), aOther.GetName()) == 0) && (strcmp(GetInstanceName(), aOther.GetInstanceName()) == 0);
+}
+
 //---------------------------------------------------------------------
 // Client
 
@@ -386,7 +396,7 @@ Error Client::AddService(Service &aService)
 {
     Error error;
 
-    VerifyOrExit(!mServices.Contains(aService), error = kErrorAlready);
+    VerifyOrExit(mServices.FindMatching(aService) == nullptr, error = kErrorAlready);
 
     SuccessOrExit(error = aService.Init());
     mServices.Push(aService);

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -163,6 +163,7 @@ public:
     class Service : public otSrpClientService, public LinkedListEntry<Service>
     {
         friend class Client;
+        friend class LinkedList<Service>;
 
     public:
         /**
@@ -242,6 +243,7 @@ public:
         void      SetState(ItemState aState);
         TimeMilli GetLeaseRenewTime(void) const { return TimeMilli(mData); }
         void      SetLeaseRenewTime(TimeMilli aTime) { mData = aTime.GetValue(); }
+        bool      Matches(const Service &aOther) const;
     };
 
     /**
@@ -477,7 +479,7 @@ public:
      *
      * @retval kErrorNone          The addition of service started successfully. The `Callback` will be called to
      *                             report the status.
-     * @retval kErrorAlready       The same service is already in the list.
+     * @retval kErrorAlready       A service with the same service and instance names is already in the list.
      * @retval kErrorInvalidArgs   The service structure is invalid (e.g., bad service name or `TxEntry`).
      *
      */


### PR DESCRIPTION
This commit updates `Srp::Client::AddService()` to reject and return
`kErrorAlready` if the caller tries to add duplicate service entries
(services with matching service and instance names).