### PR TITLE
[srp-client] add `Srp::Client::ClearService()`

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (119)
+#define OPENTHREAD_API_VERSION (120)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/srp_client.h
+++ b/include/openthread/srp_client.h
@@ -474,6 +474,26 @@ otError otSrpClientAddService(otInstance *aInstance, otSrpClientService *aServic
 otError otSrpClientRemoveService(otInstance *aInstance, otSrpClientService *aService);
 
 /**
+ * This function clears a service, immediately removing it from the client service list.
+ *
+ * Unlike `otSrpClientRemoveService()` which sends an update message to the server to remove the service, this function
+ * clears the service from the client's service list without any interaction with the server. On a successful call to
+ * this function, the `otSrpClientCallback` will NOT be called and the @p aService entry can be reclaimed and re-used
+ * by the caller immediately.
+ *
+ * This function can be used along with a subsequent call to `otSrpClientAddService()` (potentially reusing the same @p
+ * aService entry with the same service and instance names) to update some of the parameters in an existing service.
+ *
+ * @param[in] aInstance        A pointer to the OpenThread instance.
+ * @param[in] aService         A pointer to a `otSrpClientService` instance to delete.
+ *
+ * @retval OT_ERROR_NONE       The @p aService is deleted successfully. It can be reclaimed and re-used immediately.
+ * @retval OT_ERROR_NOT_FOUND  The service could not be found in the list.
+ *
+ */
+otError otSrpClientClearService(otInstance *aInstance, otSrpClientService *aService);
+
+/**
  * This function gets the list of services being managed by client.
  *
  * @param[in] aInstance        A pointer to the OpenThread instance.
@@ -507,8 +527,8 @@ otError otSrpClientRemoveHostAndServices(otInstance *aInstance, bool aRemoveKeyL
 /**
  * This function clears all host info and all the services.
  *
- * Unlike `otSrpClientRemoveHostAndServices()` which sends an update message to server to remove/unregister all the
- * info, this function clears all the info immediately without any interaction with server.
+ * Unlike `otSrpClientRemoveHostAndServices()` which sends an update message to the server to remove all the info, this
+ * function clears all the info immediately without any interaction with the server.
  *
  * @param[in] aInstance        A pointer to the OpenThread instance.
  *

--- a/src/cli/README_SRP_CLIENT.md
+++ b/src/cli/README_SRP_CLIENT.md
@@ -328,6 +328,17 @@ Remove a service with a give instance name and service name.
 Done
 ```
 
+### service clear
+
+Usage: `srp client service clear <instancename> <servicename>`
+
+Clear a service with a give instance name and service name (unlike `service remove`, with `service clear` no update is sent to server and the entry is immediately removed from client list).
+
+```bash
+> srp client service clear ins2 _test2._udp
+Done
+```
+
 ### service key
 
 Usage `srp client service key [enable|disable]`

--- a/src/core/api/srp_client_api.cpp
+++ b/src/core/api/srp_client_api.cpp
@@ -165,6 +165,13 @@ otError otSrpClientRemoveService(otInstance *aInstance, otSrpClientService *aSer
     return instance.Get<Srp::Client>().RemoveService(*static_cast<Srp::Client::Service *>(aService));
 }
 
+otError otSrpClientClearService(otInstance *aInstance, otSrpClientService *aService)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<Srp::Client>().ClearService(*static_cast<Srp::Client::Service *>(aService));
+}
+
 const otSrpClientService *otSrpClientGetServices(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -447,6 +447,19 @@ void Client::UpdateServiceStateToRemove(Service &aService)
     }
 }
 
+Error Client::ClearService(Service &aService)
+{
+    Error error;
+
+    SuccessOrExit(error = mServices.Remove(aService));
+    aService.SetNext(nullptr);
+    aService.SetState(kRemoved);
+    UpdateState();
+
+exit:
+    return error;
+}
+
 Error Client::RemoveHostAndServices(bool aShouldRemoveKeyLease)
 {
     Error error = kErrorNone;

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -500,6 +500,22 @@ public:
     Error RemoveService(Service &aService);
 
     /**
+     * This method clears a service, immediately removing it from the client service list.
+     *
+     * Unlike `RemoveService()` which sends an update message to the server to remove the service, this method clears
+     * the service from the client's service list without any interaction with the server. On a successful call
+     * to this method, the `Callback` will NOT be called and the @p aService entry can be reclaimed and re-used by the
+     * caller immediately.
+     *
+     * @param[in] aService     A service to delete from the list.
+     *
+     * @retval kErrorNone      The @p aService is cleared successfully. It can be reclaimed and re-used immediately.
+     * @retval kErrorNotFound  The service could not be found in the list.
+     *
+     */
+    Error ClearService(Service &aService);
+
+    /**
      * This method gets the list of services being managed by client.
      *
      * @returns The list of services.
@@ -530,8 +546,8 @@ public:
     /**
      * This method clears all host info and all the services.
      *
-     * Unlike `RemoveHostAndServices()` which sends an update message to server to remove/unregister all the info, this
-     * method clears all the info immediately without any interaction with server.
+     * Unlike `RemoveHostAndServices()` which sends an update message to the server to remove all the info, this method
+     * clears all the info immediately without any interaction with the server.
      *
      */
     void ClearHostAndServices(void);
@@ -751,7 +767,6 @@ private:
     void         ChangeHostAndServiceStates(const ItemState *aNewStates);
     void         InvokeCallback(Error aError) const;
     void         InvokeCallback(Error aError, const HostInfo &aHostInfo, const Service *aRemovedServices) const;
-    void         ClearHostInfoAndServices(void);
     void         HandleHostInfoOrServiceChange(void);
     void         SendUpdate(void);
     Error        PrepareUpdateMessage(Message &aMessage);

--- a/src/lib/spinel/spinel.h
+++ b/src/lib/spinel/spinel.h
@@ -4112,7 +4112,9 @@ enum
     /** Format: `A(t(UUSSSd))` - Read/Insert/Remove
      * Required capability: `SPINEL_CAP_SRP_CLIENT`.
      *
-     * This property provide a list/array of services. Data per item is
+     * This property provides a list/array of services.
+     *
+     * Data per item for `SPINEL_CMD_PROP_VALUE_GET` and/or `SPINEL_CMD_PROP_VALUE_INSERT` operation is as follows:
      *
      *   `U` : The service name labels (e.g., "_chip._udp", not the full domain name.
      *   `U` : The service instance name label (not the full name).
@@ -4120,7 +4122,15 @@ enum
      *   `S` : The service priority.
      *   `S` : The service weight.
      *
-     * During remove operation, only service name and service instance name would be used.
+     * For `SPINEL_CMD_PROP_VALUE_REMOVE` command, the following format is used:
+     *
+     *   `U` : The service name labels (e.g., "_chip._udp", not the full domain name.
+     *   `U` : The service instance name label (not the full name).
+     *   `b` : Indicates whether to clear the service entry (optional).
+     *
+     * The last boolean (`b`) field is optional. When included it indicates on `true` to clear the service (clear it
+     * on client immediately with no interaction to server) and on `false` to remove the service (inform server and
+     * wait for the service entry to be removed on server). If it is not included, the value is `false`.
      *
      */
     SPINEL_PROP_SRP_CLIENT_SERVICES = SPINEL_PROP_OPENTHREAD__BEGIN + 23,
@@ -4129,12 +4139,12 @@ enum
     /** Format: `b` : Write only
      * Required capability: `SPINEL_CAP_SRP_CLIENT`.
      *
-     * Writing to this property starts the remove process of the host info and all services.
+     * Writing to this property with starts the remove process of the host info and all services.
      * Please see `otSrpClientRemoveHostAndServices()` for more details.
      *
      * Format is:
      *
-     *    `b` : A boolean indicating whether or not the host key lease should also be removed.
+     *    `b` : A boolean indicating whether or not the host key lease should also be cleared.
      *
      */
     SPINEL_PROP_SRP_CLIENT_HOST_SERVICES_REMOVE = SPINEL_PROP_OPENTHREAD__BEGIN + 24,


### PR DESCRIPTION
This method clears a service from SRP client, immediately removing it
from the list. Unlike `RemoveService()` which sends an update message
to server to remove/unregister the service, this method clears the
service from client list without any interaction with server. On a
successful call to this method, the `Callback` will NOT be called and
service entry can be reclaimed and re-used by the caller immediately.

This method can be used along with a subsequent call to `AddService()`
(potentially reusing the same service entry with the same service and
instance names) to update some of the parameters in an existing
service.

This commit adds `otSrpClientClearService()` as a related public OT
API and support for this in CLI (command `service delete`). It also
adds support for the deleting service in `NcpBase` and spinel.
