### PR TITLE
[spinel] add spinel prop get/set log

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -856,6 +856,12 @@ private:
      */
     otError Remove(spinel_prop_key_t aKey, const char *aFormat, ...);
 
+    /**
+     * This method logs a property operated by get/set method.
+     *
+     */
+    void LogSpinelProperty(spinel_prop_key_t aKey, const char *aFormat, bool aGet, va_list aArgs);
+
     spinel_tid_t GetNextTid(void);
     void         FreeTid(spinel_tid_t tid) { mCmdTidsInUse &= ~(1 << tid); }
 
@@ -1007,6 +1013,11 @@ private:
     int64_t  mRadioTimeOffset;      ///< Time difference with estimated RCP time minus host time.
 
     MaxPowerTable mMaxPowerTable;
+
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG)
+    static constexpr uint16_t kPropLogBufferSize = 256;
+    char                      mPropLogBuffer[kPropLogBufferSize];
+#endif
 };
 
 } // namespace Spinel

--- a/src/lib/spinel/spinel_prop_display.hpp
+++ b/src/lib/spinel/spinel_prop_display.hpp
@@ -1,0 +1,317 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * This file ...
+ */
+
+#ifndef SPINEL_PROP_DISPLAY_HPP_
+#define SPINEL_PROP_DISPLAY_HPP_
+
+#include <inttypes.h>
+#include <stdio.h>
+
+#include "spinel.h"
+
+#include "common/code_utils.hpp"
+
+namespace ot {
+namespace Spinel {
+
+/**
+ * This function prints a basic spinel data type (not a STRUCT or an ARRAY) to a buffer.
+ *
+ * @param[in]   aDataType   The data type.
+ * @param[in]   aPtrArgs    If the argument in the argument list is a pointer to the value or a value.
+ * @param[in]   aArgs       A value identifying a variable arguments list.
+ * @param[out]  aBuf        The output buffer.
+ * @param[in]   aBufSize    The size of the output buffer.
+ *
+ * @returns If written successfully, it returns the length of bytes written. Otherwise a negative error code is
+ * returned.
+ *
+ */
+int32_t SpinelPropDisplaySimpleDataType(spinel_datatype_t aDataType,
+                                        bool              aPtrArgs,
+                                        va_list           aArgs,
+                                        char *            aBuf,
+                                        uint16_t          aBufSize)
+{
+    int32_t ret   = 0;
+    int32_t bytes = 0;
+
+    VerifyOrExit(aBuf != nullptr, ret = -1);
+
+    switch (aDataType)
+    {
+    case SPINEL_DATATYPE_BOOL_C:
+    {
+        bool val = aPtrArgs ? *va_arg(aArgs, bool *) : static_cast<bool>(va_arg(aArgs, int));
+        bytes    = snprintf(aBuf, aBufSize, "(BOOL: %d)", val);
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+        break;
+    }
+
+    case SPINEL_DATATYPE_UINT8_C:
+    {
+        uint8_t val = aPtrArgs ? (*va_arg(aArgs, uint8_t *)) : static_cast<uint8_t>(va_arg(aArgs, int));
+        bytes       = snprintf(aBuf, aBufSize, "(UINT8: %u)", val);
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+        break;
+    }
+
+    case SPINEL_DATATYPE_INT8_C:
+    {
+        int8_t val = aPtrArgs ? (*va_arg(aArgs, int8_t *)) : static_cast<int8_t>(va_arg(aArgs, int));
+        bytes      = snprintf(aBuf, aBufSize, "(INT8: %d)", val);
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+        break;
+    }
+
+    case SPINEL_DATATYPE_UINT16_C:
+    {
+        uint16_t val = aPtrArgs ? (*va_arg(aArgs, uint16_t *)) : static_cast<uint16_t>(va_arg(aArgs, int));
+        bytes        = snprintf(aBuf, aBufSize, "(UINT16: %u)", val);
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+        break;
+    }
+
+    case SPINEL_DATATYPE_INT16_C:
+    {
+        int16_t val = aPtrArgs ? (*va_arg(aArgs, int16_t *)) : static_cast<int16_t>(va_arg(aArgs, int));
+        bytes       = snprintf(aBuf, aBufSize, "(INT16: %d)", val);
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+        break;
+    }
+
+    case SPINEL_DATATYPE_UINT32_C:
+    {
+        uint32_t val = aPtrArgs ? (*va_arg(aArgs, uint32_t *)) : va_arg(aArgs, uint32_t);
+        bytes        = snprintf(aBuf, aBufSize, "(UINT32: %u)", val);
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+        break;
+    }
+
+    case SPINEL_DATATYPE_INT32_C:
+    {
+        int32_t val = aPtrArgs ? (*va_arg(aArgs, int32_t *)) : va_arg(aArgs, int32_t);
+        bytes       = snprintf(aBuf, aBufSize, "(INT32: %d)", val);
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+        break;
+    }
+
+    case SPINEL_DATATYPE_UINT64_C:
+    {
+        uint64_t val = aPtrArgs ? (*va_arg(aArgs, uint64_t *)) : va_arg(aArgs, uint64_t);
+        bytes        = snprintf(aBuf, aBufSize, "(UINT64: %" PRIu64 ")", val);
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+        break;
+    }
+
+    case SPINEL_DATATYPE_INT64_C:
+    {
+        int64_t val = aPtrArgs ? (*va_arg(aArgs, int64_t *)) : va_arg(aArgs, int64_t);
+        bytes       = snprintf(aBuf, aBufSize, "(INT64: %" PRId64 ")", val);
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+        break;
+    }
+
+    case SPINEL_DATATYPE_IPv6ADDR_C:
+    {
+        spinel_ipv6addr_t *aArgsPtr = va_arg(aArgs, spinel_ipv6addr_t *);
+        bytes =
+            snprintf(aBuf, aBufSize, "(IPv6: %x:%x:%x:%x:%x:%x:%x:%x)", (aArgsPtr->bytes[0] << 8) | aArgsPtr->bytes[1],
+                     (aArgsPtr->bytes[2] << 8) | aArgsPtr->bytes[3], (aArgsPtr->bytes[4] << 8) | aArgsPtr->bytes[5],
+                     (aArgsPtr->bytes[6] << 8) | aArgsPtr->bytes[7], (aArgsPtr->bytes[8] << 8) | aArgsPtr->bytes[9],
+                     (aArgsPtr->bytes[10] << 8) | aArgsPtr->bytes[11], (aArgsPtr->bytes[12] << 8) | aArgsPtr->bytes[13],
+                     (aArgsPtr->bytes[14] << 8) | aArgsPtr->bytes[15]);
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+        break;
+    }
+
+    case SPINEL_DATATYPE_EUI48_C:
+    {
+        spinel_eui48_t *aArgsPtr = va_arg(aArgs, spinel_eui48_t *);
+        bytes = snprintf(aBuf, aBufSize, "(EUI48: %x:%x:%x:%x:%x:%x)", aArgsPtr->bytes[0], aArgsPtr->bytes[1],
+                         aArgsPtr->bytes[2], aArgsPtr->bytes[3], aArgsPtr->bytes[4], aArgsPtr->bytes[5]);
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+        break;
+    }
+
+    case SPINEL_DATATYPE_EUI64_C:
+    {
+        spinel_eui64_t *aArgsPtr = va_arg(aArgs, spinel_eui64_t *);
+        bytes = snprintf(aBuf, aBufSize, "(EUI64: %x:%x:%x:%x:%x:%x:%x:%x)", aArgsPtr->bytes[0], aArgsPtr->bytes[1],
+                         aArgsPtr->bytes[2], aArgsPtr->bytes[3], aArgsPtr->bytes[4], aArgsPtr->bytes[5],
+                         aArgsPtr->bytes[6], aArgsPtr->bytes[7]);
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+        break;
+    }
+
+    case SPINEL_DATATYPE_UTF8_C:
+    {
+        uint8_t *data    = va_arg(aArgs, uint8_t *);
+        size_t   len_arg = va_arg(aArgs, size_t);
+        size_t   n;
+
+        bytes = snprintf(aBuf, aBufSize, "(UTF8: ");
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+
+        for (uint8_t i = 0, n = 0; i < len_arg; i++)
+        {
+            n = snprintf(aBuf + bytes, aBufSize - bytes, "%02x", data[i]);
+            VerifyOrExit(n > 0 && n < aBufSize - bytes, ret = -1);
+            bytes += n;
+        }
+
+        n = snprintf(aBuf + bytes, aBufSize - bytes, ")");
+        VerifyOrExit(n > 0 && n < aBufSize - bytes, ret = -1);
+        bytes += n;
+
+        break;
+    }
+
+    case SPINEL_DATATYPE_DATA_C:
+    {
+        uint8_t *data    = va_arg(aArgs, uint8_t *);
+        size_t   len_arg = va_arg(aArgs, size_t);
+        size_t   n;
+
+        bytes = snprintf(aBuf, aBufSize, "(DATA: ");
+        VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+
+        for (uint8_t i = 0, n = 0; i < len_arg; i++)
+        {
+            n = snprintf(aBuf + bytes, aBufSize - bytes, "%02x", data[i]);
+            VerifyOrExit(n > 0 && n < aBufSize - bytes, ret = -1);
+            bytes += n;
+        }
+
+        n = snprintf(aBuf + bytes, aBufSize - bytes, ")");
+        VerifyOrExit(n > 0 && n < aBufSize - bytes, ret = -1);
+        bytes += n;
+
+        break;
+    }
+
+    default:
+    {
+        ExitNow(ret = -1);
+        break;
+    }
+    }
+
+    ret = bytes;
+
+exit:
+    return ret;
+}
+
+/**
+ * This function prints a spinel property operated with Get/Set method to a buffer.
+ *
+ * @param[in]   aKey           The aKey of the spinel property.
+ * @param[in]   aPackFormat    C string that contains a format string follows the same specification of spinel.
+ * @param[in]   aPtrArgs       If the argument in the argument list is a pointer to the value or a value.
+ * @param[in]   aArgs          A value identifying a variable arguments list.
+ * @param[out]  aBuf           The output aBuffer.
+ * @param[in]   aBufSize       The size of the output aBuffer.
+ *
+ * @returns If written successfully, it returns the length of bytes written. Otherwise a negative error code is
+ * returned.
+ *
+ */
+int32_t SpinelPropDisplay(spinel_prop_key_t aKey,
+                          const char *      aPackFormat,
+                          bool              aPtrArgs,
+                          va_list           aArgs,
+                          char *            aBuf,
+                          uint16_t          aBufSize)
+{
+    int32_t ret   = 0;
+    int32_t bytes = 0;
+    int8_t  depth = 0;
+
+    VerifyOrExit(aPackFormat != nullptr && aBuf != nullptr, ret = -1);
+
+    bytes = snprintf(aBuf, aBufSize, "%s: ", spinel_prop_key_to_cstr(aKey));
+    VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+    ret += bytes;
+    aBuf += bytes;
+    aBufSize -= bytes;
+
+    for (; *aPackFormat != 0; aPackFormat++)
+    {
+        if (*aPackFormat == SPINEL_DATATYPE_STRUCT_C)
+        {
+            VerifyOrExit(*(++aPackFormat) == '(', ret = -1);
+            depth++;
+            bytes = snprintf(aBuf, aBufSize, "{");
+            VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+            ret += bytes;
+            aBuf += bytes;
+            aBufSize -= bytes;
+        }
+        else if (*aPackFormat == ')')
+        {
+            VerifyOrExit(--depth >= 0, ret = -1);
+            bytes = snprintf(aBuf, aBufSize, "}");
+            VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+            ret += bytes;
+            aBuf += bytes;
+            aBufSize -= bytes;
+        }
+        else
+        {
+            bytes = SpinelPropDisplaySimpleDataType(*aPackFormat, aPtrArgs, aArgs, aBuf, aBufSize);
+            VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+            ret += bytes;
+            aBuf += bytes;
+            aBufSize -= bytes;
+        }
+
+        if (aPackFormat[0] != '(' && aPackFormat[1] != 0 && aPackFormat[1] != ')')
+        {
+            bytes = snprintf(aBuf, aBufSize, ", ");
+            VerifyOrExit(bytes > 0 && bytes < aBufSize, ret = -1);
+            ret += bytes;
+            aBuf += bytes;
+            aBufSize -= bytes;
+        }
+    }
+
+    VerifyOrExit(depth == 0, ret = -1);
+
+exit:
+    return ret;
+}
+
+} // namespace Spinel
+} // namespace ot
+
+#endif // SPINEL_PROP_DISPLAY_HPP_

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -706,3 +706,20 @@ target_link_libraries(ot-test-timer
 )
 
 add_test(NAME ot-test-timer COMMAND ot-test-timer)
+
+add_executable(ot-test-spinel-prop-display
+    test_spinel_prop_display.cpp
+)
+
+target_include_directories(ot-test-spinel-prop-display
+    PRIVATE
+        ${PROJECT_SOURCE_DIR}/src/lib/spinel
+        ${COMMON_INCLUDES}
+)
+
+target_link_libraries(ot-test-spinel-prop-display
+    PRIVATE
+        openthread-spinel-ncp
+)
+
+add_test(NAME ot-test-spinel-prop-display COMMAND ot-test-spinel-prop-display)

--- a/tests/unit/test_spinel_prop_display.cpp
+++ b/tests/unit/test_spinel_prop_display.cpp
@@ -1,0 +1,316 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <ctype.h>
+#include <string.h>
+
+#include "common/code_utils.hpp"
+#include "lib/spinel/spinel_prop_display.hpp"
+
+#include "test_util.hpp"
+
+namespace ot {
+namespace Spinel {
+
+constexpr uint32_t kMaxBufferSize = 512;
+char               sBuffer[kMaxBufferSize];
+
+static int32_t SpinelDisplayPropSimpleDataType(uint32_t aDataType, ...)
+{
+    spinel_datatype_t dataType = static_cast<spinel_datatype_t>(aDataType);
+    int32_t           ret;
+    va_list           args;
+
+    va_start(args, aDataType);
+    ret = SpinelPropDisplaySimpleDataType(aDataType, /* aPtrArgs */ false, args, sBuffer, kMaxBufferSize);
+    va_end(args);
+
+    return ret;
+}
+
+static int32_t SpinelDisplayProp(spinel_prop_key_t aKey, bool aPtrArgs, uint16_t aBufSize, const char *aPackFormat, ...)
+{
+    int32_t ret;
+    va_list args;
+
+    va_start(args, aPackFormat);
+    ret = SpinelPropDisplay(aKey, aPackFormat, aPtrArgs, args, sBuffer, aBufSize);
+    va_end(args);
+
+    return ret;
+}
+
+static void TestPropDisplaySimpleDataType(void)
+{
+    int32_t ret;
+
+    const bool              kBool    = true;
+    const uint8_t           kUint8   = 255;
+    const int8_t            kInt8    = -127;
+    const uint16_t          kUint16  = 65535;
+    const int16_t           kInt16   = -32767;
+    const uint32_t          kUint32  = 4294967295;
+    const int32_t           kInt32   = -2147483647;
+    const uint64_t          kUint64  = 18446744073709551615U;
+    const int64_t           kInt64   = -9223372036854775807;
+    const spinel_ipv6addr_t kIp6Addr = {
+        {0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88, 0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00}};
+    const uint8_t kData[] = {11, 13, 17, 23};
+
+    const spinel_eui48_t kEui48 = {
+        {4, 8, 15, 16, 23, 42} // "Lost" EUI48!
+    };
+
+    const spinel_eui64_t kEui64 = {
+        {2, 3, 5, 7, 11, 13, 17, 19}, // "Prime" EUI64!
+    };
+
+    const uint8_t kUtf8[] = {0xE8, 0xB0, 0xB7, 0xE6, 0xAD, 0x8C}; // Google's Chinese Name
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_BOOL_C, kBool);
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(BOOL: 1)") == 0, "spinel_prop_display_simple_data_type failed to display BOOL");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_UINT8_C, kUint8);
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(UINT8: 255)") == 0, "spinel_prop_display_simple_data_type failed to display UINT8");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_INT8_C, kInt8);
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(INT8: -127)") == 0, "spinel_prop_display_simple_data_type failed to display INT8");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_UINT16_C, kUint16);
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(UINT16: 65535)") == 0,
+                 "spinel_prop_display_simple_data_type failed to display UINT16");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_INT16_C, kInt16);
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(INT16: -32767)") == 0,
+                 "spinel_prop_display_simple_data_type failed to display INT16");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_UINT32_C, kUint32);
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(UINT32: 4294967295)") == 0,
+                 "spinel_prop_display_simple_data_type failed to display UINT32");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_INT32_C, kInt32);
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(INT32: -2147483647)") == 0,
+                 "spinel_prop_display_simple_data_type failed to display INT32");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_UINT64_C, kUint64);
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(UINT64: 18446744073709551615)") == 0,
+                 "spinel_prop_display_simple_data_type failed to display UINT64");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_INT64_C, kInt64);
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(INT64: -9223372036854775807)") == 0,
+                 "spinel_prop_display_simple_data_type failed to display INT64");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_IPv6ADDR_C, &kIp6Addr);
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(IPv6: ffee:ddcc:bbaa:9988:7766:5544:3322:1100)") == 0,
+                 "spinel_prop_display_simple_data_type failed to display IPv6ADDR");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_EUI48_C, &kEui48);
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(EUI48: 4:8:f:10:17:2a)") == 0,
+                 "spinel_prop_display_simple_data_type failed to display EUI48");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_EUI64_C, &kEui64);
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(EUI64: 2:3:5:7:b:d:11:13)") == 0,
+                 "spinel_prop_display_simple_data_type failed to display EUI64");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_UTF8_C, &kUtf8, sizeof(kUtf8));
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(UTF8: e8b0b7e6ad8c)") == 0,
+                 "spinel_prop_display_simple_data_type failed to display UTF8");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayPropSimpleDataType(SPINEL_DATATYPE_DATA_C, &kData, sizeof(kData));
+    VerifyOrQuit(ret > 0, "spinel_prop_display_simple_data_type failed");
+    printf("%s\n", sBuffer);
+    VerifyOrQuit(strcmp(sBuffer, "(DATA: 0b0d1117)") == 0,
+                 "spinel_prop_display_simple_data_type failed to display DATA");
+}
+
+static void TestGetPropDisplay(void)
+{
+    int32_t ret;
+
+    const bool     kBool     = false;
+    const int8_t   kInt8     = 1;
+    const uint16_t kUint16   = 2;
+    const uint32_t kUint32_1 = 111;
+    const uint32_t kUint32_2 = 222;
+    const uint32_t kUint32_3 = 333;
+    const uint32_t kUint32_4 = 444;
+    const uint32_t kUint32_5 = 555;
+    const uint32_t kUint32_6 = 666;
+    const uint32_t kUint32_7 = 777;
+    const uint32_t kUint32_8 = 888;
+    const uint32_t kUint32_9 = 999;
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayProp(SPINEL_PROP_PHY_TX_POWER, /* aPtrArgs */ true, sizeof(sBuffer), SPINEL_DATATYPE_INT8_S,
+                            &kInt8);
+    VerifyOrQuit(ret > 0, "Get Prop display failed, SPINEL_PROP_PHY_TX_POWER");
+    printf("%s\n", sBuffer);
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayProp(SPINEL_PROP_RADIO_COEX_ENABLE, /* aPtrArgs */ true, sizeof(sBuffer), SPINEL_DATATYPE_BOOL_S,
+                            &kBool);
+    VerifyOrQuit(ret > 0, "Get Prop display failed, SPINEL_PROP_RADIO_COEX_ENABLE");
+    printf("%s\n", sBuffer);
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayProp(
+        SPINEL_PROP_RADIO_COEX_METRICS, /* aPtrArgs */ true, sizeof(sBuffer),
+        SPINEL_DATATYPE_STRUCT_S(
+            SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_UINT32_S
+                SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_UINT32_S)
+            SPINEL_DATATYPE_STRUCT_S(SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_UINT32_S
+                                         SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_UINT32_S
+                                             SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_UINT32_S)
+                SPINEL_DATATYPE_BOOL_S SPINEL_DATATYPE_UINT32_S,
+        &kUint32_1, &kUint32_2, &kUint32_3, &kUint32_4, &kUint32_5, &kUint32_6, &kUint32_7, &kUint32_8, &kUint32_9,
+        &kUint32_1, &kUint32_2, &kUint32_3, &kUint32_4, &kUint32_5, &kUint32_6, &kUint32_7, &kUint32_8, &kBool,
+        &kUint32_9);
+    VerifyOrQuit(ret > 0, "Get Prop display failed, SPINEL_PROP_RADIO_COEX_METRICS");
+    printf("%s\n", sBuffer);
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayProp(SPINEL_PROP_PHY_REGION_CODE, /* aPtrArgs */ true, sizeof(sBuffer), SPINEL_DATATYPE_UINT16_S,
+                            &kUint16);
+    VerifyOrQuit(ret > 0, "Get Prop display failed, SPINEL_PROP_PHY_REGION_CODE");
+    printf("%s\n", sBuffer);
+}
+
+static void TestSetPropDisplay(void)
+{
+}
+
+static void TestInvalidPropDisplay(void)
+{
+    int32_t            ret;
+    const uint16_t     kUint16          = 1;
+    constexpr uint32_t kShortBufferSize = 8;
+    const char *       kInvalidDataType = "Z";
+
+    // Test buffer overflow
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayProp(SPINEL_PROP_PHY_TX_POWER, /* aPtrArgs */ true, kShortBufferSize, SPINEL_DATATYPE_INT8_S,
+                            &kUint16);
+    VerifyOrQuit(ret == -1, "SpinelDisplayProp should get overflow error");
+
+    // Test invalid spinel data type
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayProp(SPINEL_PROP_PHY_TX_POWER, /* aPtrArgs */ true, sizeof(sBuffer), kInvalidDataType, &kUint16);
+    VerifyOrQuit(ret == -1, "SpinelDisplayProp should get invalid data type error");
+
+    // Test invalid pack format error
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayProp(SPINEL_PROP_PHY_TX_POWER, /* aPtrArgs */ true, sizeof(sBuffer), "t(s", &kUint16);
+    VerifyOrQuit(ret == -1, "SpinelDisplayProp should get invalid pack format error");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayProp(SPINEL_PROP_PHY_TX_POWER, /* aPtrArgs */ true, sizeof(sBuffer), "t((s)", &kUint16);
+    VerifyOrQuit(ret == -1, "SpinelDisplayProp should get invalid pack format error");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayProp(SPINEL_PROP_PHY_TX_POWER, /* aPtrArgs */ true, sizeof(sBuffer), "ts", &kUint16);
+    VerifyOrQuit(ret == -1, "SpinelDisplayProp should get invalid pack format error");
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    ret = SpinelDisplayProp(SPINEL_PROP_PHY_TX_POWER, /* aPtrArgs */ true, sizeof(sBuffer), "ts)", &kUint16);
+    VerifyOrQuit(ret == -1, "SpinelDisplayProp should get invalid pack format error");
+}
+
+static void TestOtherPropDisplay(void)
+{
+    bool     kBool   = true;
+    uint8_t  kUint8  = 1;
+    int8_t   kInt8   = 2;
+    uint16_t kUint16 = 3;
+    int16_t  kInt16  = 4;
+    uint32_t kUint32 = 5;
+    int32_t  kInt32  = 6;
+    uint64_t kUint64 = 7;
+    int64_t  kInt64  = 8;
+
+    memset(sBuffer, 0, sizeof(sBuffer));
+    int32_t ret =
+        SpinelDisplayProp(SPINEL_PROP_MAC_15_4_SADDR, /* aPtrArgs */ true, sizeof(sBuffer),
+                          SPINEL_DATATYPE_STRUCT_S(SPINEL_DATATYPE_BOOL_S SPINEL_DATATYPE_UINT16_S), &kBool, &kUint16);
+
+    VerifyOrQuit(ret > 0, "spinel_prop_display failed!");
+    printf("ret:%d\n%s\n", ret, sBuffer);
+}
+
+} // namespace Spinel
+} // namespace ot
+
+int main(void)
+{
+    ot::Spinel::TestPropDisplaySimpleDataType();
+    ot::Spinel::TestGetPropDisplay();
+    ot::Spinel::TestSetPropDisplay();
+    ot::Spinel::TestInvalidPropDisplay();
+    ot::Spinel::TestOtherPropDisplay();
+    printf("\nAll tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
This PR adds logging for spinel property when `Get/Set` method is 
called. For example, we have a property PROP_NAME whose format is
`t(bS)` and two arguments: a `BOOL(true)` and a `UINT16(3)`, we will 
log it as **`PROP_NAME: {(BOOL: 1), (UINT16: 3)}`**

The logging is implemented by a new method `spinel_prop_display`. 
`spinel_prop_display` accepts the spinel pack format and an argument
list, and then output the property to a buffer specified.

Note: The PR isn't completed and I haven't fully tested it (I need to
 refine the doc and add more tests). I'd like to have suggestions at 
an early stage so that I can avoid detours. Please help me review 
from a high-level perspective.