### PR TITLE
[address-resolver] simplify updating snooped cache entries

### DIFF
--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -132,28 +132,17 @@ public:
     void Remove(const Ip6::Address &aEid);
 
     /**
-     * This method updates an existing cache entry for the EID.
-     *
-     * @param[in]  aEid               A reference to the EID.
-     * @param[in]  aRloc16            The RLOC16 corresponding to @p aEid.
-     *
-     * @retval kErrorNone          Successfully updates an existing cache entry.
-     * @retval kErrorNotFound      No cache entry with @p aEid.
-     *
-     */
-    Error UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16);
-
-    /**
-     * This method adds a snooped cache entry for a given EID.
+     * This method updates an existing entry or adds a snooped cache entry for a given EID.
      *
      * The method is intended to add an entry for snoop optimization (inspection of a received message to create a
      * cache entry mapping an EID to a RLOC).
      *
-     * @param[in]  aEid               A reference to the EID.
-     * @param[in]  aRloc16            The RLOC16 corresponding to @p aEid.
+     * @param[in] aEid             A reference to the EID.
+     * @param[in] aRloc16          The RLOC16 corresponding to @p aEid.
+     * @param[in] aDest            The short MAC address destination of the received snooped message.
      *
      */
-    void AddSnoopedCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16);
+    void UpdateSnoopedCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16, Mac::ShortAddress aDest);
 
     /**
      * This method returns the RLOC16 for a given EID, initiates an Address Query if allowed and the mapping is not
@@ -313,6 +302,7 @@ private:
     CacheEntry *FindCacheEntry(const Ip6::Address &aEid, CacheEntryList *&aList, CacheEntry *&aPrevEntry);
     CacheEntry *NewCacheEntry(bool aSnoopedEntry);
     void        RemoveCacheEntry(CacheEntry &aEntry, CacheEntryList &aList, CacheEntry *aPrevEntry, Reason aReason);
+    Error       UpdateCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16);
 
     Error SendAddressQuery(const Ip6::Address &aEid);
 

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -819,22 +819,11 @@ void MeshForwarder::UpdateRoutes(const uint8_t *     aFrame,
     if (!ip6Header.GetSource().GetIid().IsLocator() &&
         Get<NetworkData::Leader>().IsOnMesh(ip6Header.GetSource()) /* only for on mesh address which may require AQ */)
     {
-        if (Get<AddressResolver>().UpdateCacheEntry(ip6Header.GetSource(), aMeshSource.GetShort()) == kErrorNotFound)
-        {
-            // Thread 1.1 Specification 5.5.2.2: FTDs MAY add/update
-            // EID-to-RLOC Map Cache entries by inspecting packets
-            // being received. We exclude frames from an MTD child
-            // source and verify that the destination is the device
-            // itself or an MTD child of the device.
+        // FTDs MAY add/update EID-to-RLOC Map Cache entries by
+        // inspecting packets being received.
 
-            if (Get<Mle::MleRouter>().IsFullThreadDevice() &&
-                !Get<Mle::MleRouter>().IsMinimalChild(aMeshSource.GetShort()) &&
-                (aMeshDest.GetShort() == Get<Mac::Mac>().GetShortAddress() ||
-                 Get<Mle::MleRouter>().IsMinimalChild(aMeshDest.GetShort())))
-            {
-                Get<AddressResolver>().AddSnoopedCacheEntry(ip6Header.GetSource(), aMeshSource.GetShort());
-            }
-        }
+        Get<AddressResolver>().UpdateSnoopedCacheEntry(ip6Header.GetSource(), aMeshSource.GetShort(),
+                                                       aMeshDest.GetShort());
     }
 
     neighbor = Get<NeighborTable>().FindNeighbor(ip6Header.GetSource());


### PR DESCRIPTION
This commit updates `UpdateSnoopedCacheEntry()` to perform the
common checks before adding a snooped entry (e.g., ensuring the
snooped entry source is not the an MTD child of the device).