### PR TITLE
[cli] process exit in ot-ctl

### DIFF
--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -37,6 +37,7 @@
 
 #include "openthread-system.h"
 #include "cli/cli_config.h"
+#include "common/code_utils.hpp"
 
 /**
  * This function initializes the CLI app.
@@ -75,6 +76,18 @@ void otTaskletsSignalPending(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
 }
+
+#if OPENTHREAD_POSIX && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
+static void ProcessExit(void *aContext, uint8_t aArgsLength, char *aArgs[])
+{
+    OT_UNUSED_VARIABLE(aContext);
+    OT_UNUSED_VARIABLE(aArgsLength);
+    OT_UNUSED_VARIABLE(aArgs);
+
+    exit(EXIT_SUCCESS);
+}
+static const otCliCommand kCommands[] = {{"exit", ProcessExit}};
+#endif
 
 int main(int argc, char *argv[])
 {
@@ -116,6 +129,10 @@ pseudo_reset:
     assert(instance);
 
     otAppCliInit(instance);
+
+#if OPENTHREAD_POSIX && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
+    otCliSetUserCommands(kCommands, OT_ARRAY_LENGTH(kCommands), instance);
+#endif
 
     while (!otSysPseudoResetWasRequested())
     {

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1761,18 +1761,6 @@ exit:
     return error;
 }
 
-#if OPENTHREAD_POSIX && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
-otError Interpreter::ProcessExit(uint8_t aArgsLength, Arg aArgs[])
-{
-    OT_UNUSED_VARIABLE(aArgsLength);
-    OT_UNUSED_VARIABLE(aArgs);
-
-    exit(EXIT_SUCCESS);
-
-    return OT_ERROR_NONE;
-}
-#endif
-
 otError Interpreter::ProcessLog(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -702,9 +702,6 @@ private:
         {"eidcache", &Interpreter::ProcessEidCache},
 #endif
         {"eui64", &Interpreter::ProcessEui64},
-#if OPENTHREAD_POSIX && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
-        {"exit", &Interpreter::ProcessExit},
-#endif
         {"extaddr", &Interpreter::ProcessExtAddress},
         {"extpanid", &Interpreter::ProcessExtPanId},
         {"factoryreset", &Interpreter::ProcessFactoryReset},

--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -81,11 +81,45 @@ static_assert(kLineBufferSize >= sizeof("Error "), "kLineBufferSize is too small
 
 int sSessionFd = -1;
 
+void QuitOnExit(const char *aBuffer)
+{
+    constexpr char kExit[] = "exit";
+
+    while (*aBuffer == ' ' || *aBuffer == '\t')
+    {
+        ++aBuffer;
+    }
+
+    VerifyOrExit(strstr(aBuffer, kExit) == aBuffer);
+
+    aBuffer += sizeof(kExit) - 1;
+
+    while (*aBuffer == ' ' || *aBuffer == '\t')
+    {
+        ++aBuffer;
+    }
+
+    switch (*aBuffer)
+    {
+    case '\0':
+    case '\r':
+    case '\n':
+        exit(OT_EXIT_SUCCESS);
+        break;
+    default:
+        break;
+    }
+
+exit:
+    return;
+}
+
 #if OPENTHREAD_USE_READLINE
 void InputCallback(char *aLine)
 {
     if (aLine != nullptr)
     {
+        QuitOnExit(aLine);
         add_history(aLine);
         dprintf(sSessionFd, "%s\n", aLine);
         free(aLine);
@@ -316,6 +350,7 @@ int main(int argc, char *argv[])
 #else
             VerifyOrExit(fgets(buffer, sizeof(buffer), stdin) != nullptr, ret = OT_EXIT_FAILURE);
 
+            QuitOnExit(buffer);
             VerifyOrExit(DoWrite(sSessionFd, buffer, strlen(buffer)), ret = OT_EXIT_FAILURE);
 #endif
         }

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -342,7 +342,23 @@ static void ProcessNetif(void *aContext, uint8_t aArgsLength, char *aArgs[])
     otCliOutputFormat("%s:%u\r\n", otSysGetThreadNetifName(), otSysGetThreadNetifIndex());
 }
 
-static const otCliCommand kCommands[] = {{"netif", ProcessNetif}};
+#if !OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
+static void ProcessExit(void *aContext, uint8_t aArgsLength, char *aArgs[])
+{
+    OT_UNUSED_VARIABLE(aContext);
+    OT_UNUSED_VARIABLE(aArgsLength);
+    OT_UNUSED_VARIABLE(aArgs);
+
+    exit(EXIT_SUCCESS);
+}
+#endif
+
+static const otCliCommand kCommands[] = {
+#if !OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
+    {"exit", ProcessExit},
+#endif
+    {"netif", ProcessNetif},
+};
 
 int main(int argc, char *argv[])
 {


### PR DESCRIPTION
The exit command should only exit ot-ctl itself in daemon mode. This
commit adds processing exit command in the ot-ctl.

This commit also moves the exit command implementation out from core
as a user command on simulation and posix cli mode.