### PR TITLE
[ot-ctl] support no separator --

### DIFF
--- a/script/check-posix-pty
+++ b/script/check-posix-pty
@@ -124,6 +124,9 @@ do_check()
         OT_CTL="$PWD/build/posix/src/posix/ot-ctl"
         sudo "${OT_CTL}" -I "${NETIF_NAME}" panid 0xface | grep 'Done' || die 'failed to set panid with ot-ctl'
 
+        # verify supports options in OpenThread commands without separator --
+        sudo "${OT_CTL}" -I "${NETIF_NAME}" pskc -p 123456 | grep 'Done' || die 'unable to set pskc'
+
         # verify this reset and factoryreset end immediately
         sudo "${OT_CTL}" -I "${NETIF_NAME}" reset
         # sleep a while for daemon ready

--- a/src/posix/client.cpp
+++ b/src/posix/client.cpp
@@ -208,7 +208,7 @@ Config ParseArg(int &aArgCount, char **&aArgVector)
 
     optind = 1;
 
-    for (int index, option; (option = getopt_long(aArgCount, aArgVector, "I:h", kOptions, &index)) != -1;)
+    for (int index, option; (option = getopt_long(aArgCount, aArgVector, "+I:h", kOptions, &index)) != -1;)
     {
         switch (option)
         {


### PR DESCRIPTION
With this change, both the following command should work:

```bash
ot-ctl -I wpan0 pskc -p 123456
ot-ctl -I wpan0 -- pskc -p 123456
```