### PR TITLE
[github-actions] fix MATN_15_ChangeOfPrimaryBBRTriggersRegistration.py

### DIFF
--- a/tests/scripts/thread-cert/border_router/MATN_15_ChangeOfPrimaryBBRTriggersRegistration.py
+++ b/tests/scripts/thread-cert/border_router/MATN_15_ChangeOfPrimaryBBRTriggersRegistration.py
@@ -181,7 +181,7 @@ class MATN_15_ChangeOfPrimaryBBRTriggersRegistration(thread_cert.TestCase):
         # Where the payload contains:
         # Status TLV: ST_MLR_SUCCESS
         pkts.filter_wpan_src64(vars['BR_2']) \
-            .filter_ipv6_dst(vars['TD_RLOC']) \
+            .filter_ipv6_dst(_pkt.ipv6.src) \
             .filter_coap_ack('/n/mr') \
             .filter(lambda
                         p: p.coap.mid == _pkt.coap.mid and
@@ -190,7 +190,7 @@ class MATN_15_ChangeOfPrimaryBBRTriggersRegistration(thread_cert.TestCase):
 
         # 5. Router_1 forwards the response to TD.
         pkts.filter_wpan_src64(vars['Router_1']) \
-            .filter_ipv6_2dsts(vars['TD_RLOC'], vars['TD_LLA']) \
+            .filter_ipv6_dst(_pkt.ipv6.src) \
             .filter_coap_ack('/n/mr') \
             .filter(lambda
                         p: p.coap.mid == _pkt.coap.mid and


### PR DESCRIPTION
The test case failed because pktverify failed to find an ACK packet sent to `TD`. However, `TD_RLOC` has changed during the test while we were using the latter RLOC to verify the packet. Therefore it wasn't able to find the packet. 

As said by @simonlingoogle in: https://github.com/openthread/openthread/issues/6602

> One finding is that the TD registers it's MA just at the same moment as it sends ADDR_SOL.req.
This caused the TD to change its RLOC, so that it can not receive the MLR.rsp.

For this test case, we can verify the existence of that ACK packet using the source address of its according CON packet. 

Fixes #6602 