### PR TITLE
[dnssd] add api for accessing queries in the dnssd server

### DIFF
--- a/include/openthread/dnssd_server.h
+++ b/include/openthread/dnssd_server.h
@@ -37,6 +37,7 @@
 
 #include <stdint.h>
 
+#include <openthread/dns.h>
 #include <openthread/error.h>
 #include <openthread/ip6.h>
 
@@ -100,6 +101,12 @@ typedef void (*otDnssdQuerySubscribeCallback)(void *aContext, const char *aFullN
 typedef void (*otDnssdQueryUnsubscribeCallback)(void *aContext, const char *aFullName);
 
 /**
+ * This opaque type represents a DNS-SD query.
+ *
+ */
+typedef void otDnssdQuery;
+
+/**
  * This structure represents information of a discovered service instance for a DNS-SD query.
  *
  */
@@ -127,6 +134,18 @@ typedef struct otDnssdHostInfo
     const otIp6Address *mAddresses;  ///< Host IPv6 addresses.
     uint32_t            mTtl;        ///< Service TTL (in seconds).
 } otDnssdHostInfo;
+
+/**
+ * This enumeration specifies a DNS-SD query type.
+ *
+ */
+typedef enum
+{
+    OT_DNSSD_QUERY_TYPE_NONE         = 0, ///< Service type unspecified.
+    OT_DNSSD_QUERY_TYPE_BROWSE       = 1, ///< Service type browse service.
+    OT_DNSSD_QUERY_TYPE_RESOLVE      = 2, ///< Service type resolve service instance.
+    OT_DNSSD_QUERY_TYPE_RESOLVE_HOST = 3, ///< Service type resolve hostname.
+} otDnssdQueryType;
 
 /**
  * This function sets DNS-SD server query callbacks.
@@ -177,6 +196,28 @@ void otDnssdQueryHandleDiscoveredServiceInstance(otInstance *                aIn
  *
  */
 void otDnssdQueryHandleDiscoveredHost(otInstance *aInstance, const char *aHostFullName, otDnssdHostInfo *aHostInfo);
+
+/**
+ * This function aquires the next query in the DNS-SD server.
+ *
+ * @param[in] aInstance         The OpenThread instance structure.
+ * @param[in] aQuery            The query pointer. Pass NULL to get the first query.
+ *
+ * @returns  A pointer to the query or NULL if no more queries.
+ *
+ */
+const otDnssdQuery *otDnssdGetNextQuery(otInstance *aInstance, const otDnssdQuery *aQuery);
+
+/**
+ * This function aquires the DNS-SD query type and name for a specific query.
+ *
+ * @param[in]   aQuery            The query pointer acquired from `otDnssdGetNextQuery`.
+ * @param[out]  aNameOutput       The name output buffer, which should be `OT_DNS_MAX_NAME_SIZE` bytes long.
+ *
+ * @returns The DNS-SD query type.
+ *
+ */
+otDnssdQueryType otDnssdGetQueryTypeAndName(const otDnssdQuery *aQuery, char (*aNameOutput)[OT_DNS_MAX_NAME_SIZE]);
 
 /**
  * @}

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (116)
+#define OPENTHREAD_API_VERSION (117)
 
 /**
  * @addtogroup api-instance

--- a/src/core/api/dns_server_api.cpp
+++ b/src/core/api/dns_server_api.cpp
@@ -41,8 +41,6 @@ using namespace ot;
 
 #if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
 
-using QueryTransaction = ot::Dns::ServiceDiscovery::Server::QueryTransaction;
-
 void otDnssdQuerySetCallbacks(otInstance *                    aInstance,
                               otDnssdQuerySubscribeCallback   aSubscribe,
                               otDnssdQueryUnsubscribeCallback aUnsubscribe,
@@ -77,22 +75,18 @@ void otDnssdQueryHandleDiscoveredHost(otInstance *aInstance, const char *aHostFu
 
 const otDnssdQuery *otDnssdGetNextQuery(otInstance *aInstance, const otDnssdQuery *aQuery)
 {
-    Instance &              instance = *static_cast<Instance *>(aInstance);
-    const QueryTransaction *query    = static_cast<const QueryTransaction *>(aQuery);
+    Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Dns::ServiceDiscovery::Server>().GetNextQuery(query);
+    return instance.Get<Dns::ServiceDiscovery::Server>().GetNextQuery(aQuery);
 }
 
 otDnssdQueryType otDnssdGetQueryTypeAndName(const otDnssdQuery *aQuery, char (*aNameOutput)[OT_DNS_MAX_NAME_SIZE])
 {
-    otDnssdQueryType        type  = OT_DNSSD_QUERY_TYPE_NONE;
-    const QueryTransaction *query = static_cast<const QueryTransaction *>(aQuery);
+    otDnssdQueryType type = OT_DNSSD_QUERY_TYPE_NONE;
 
     OT_ASSERT(aQuery != nullptr);
     OT_ASSERT(aNameOutput != nullptr);
-    OT_ASSERT(query->IsValid());
-    type = static_cast<otDnssdQueryType>(Dns::ServiceDiscovery::Server::GetQueryTypeAndName(
-        query->GetResponseHeader(), query->GetResponseMessage(), *aNameOutput));
+    type = static_cast<otDnssdQueryType>(Dns::ServiceDiscovery::Server::GetQueryTypeAndName(aQuery, *aNameOutput));
 
     return type;
 }

--- a/src/core/api/dns_server_api.cpp
+++ b/src/core/api/dns_server_api.cpp
@@ -41,6 +41,8 @@ using namespace ot;
 
 #if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
 
+using QueryTransaction = ot::Dns::ServiceDiscovery::Server::QueryTransaction;
+
 void otDnssdQuerySetCallbacks(otInstance *                    aInstance,
                               otDnssdQuerySubscribeCallback   aSubscribe,
                               otDnssdQueryUnsubscribeCallback aUnsubscribe,
@@ -71,6 +73,28 @@ void otDnssdQueryHandleDiscoveredHost(otInstance *aInstance, const char *aHostFu
     OT_ASSERT(aHostInfo != nullptr);
 
     instance.Get<Dns::ServiceDiscovery::Server>().HandleDiscoveredHost(aHostFullName, *aHostInfo);
+}
+
+const otDnssdQuery *otDnssdGetNextQuery(otInstance *aInstance, const otDnssdQuery *aQuery)
+{
+    Instance &              instance = *static_cast<Instance *>(aInstance);
+    const QueryTransaction *query    = static_cast<const QueryTransaction *>(aQuery);
+
+    return instance.Get<Dns::ServiceDiscovery::Server>().GetNextQuery(query);
+}
+
+otDnssdQueryType otDnssdGetQueryTypeAndName(const otDnssdQuery *aQuery, char (*aNameOutput)[OT_DNS_MAX_NAME_SIZE])
+{
+    otDnssdQueryType        type  = OT_DNSSD_QUERY_TYPE_NONE;
+    const QueryTransaction *query = static_cast<const QueryTransaction *>(aQuery);
+
+    OT_ASSERT(aQuery != nullptr);
+    OT_ASSERT(aNameOutput != nullptr);
+    OT_ASSERT(query->IsValid());
+    type = static_cast<otDnssdQueryType>(Dns::ServiceDiscovery::Server::GetQueryTypeAndName(
+        query->GetResponseHeader(), query->GetResponseMessage(), *aNameOutput));
+
+    return type;
 }
 
 #endif // OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -962,14 +962,15 @@ void Server::HandleDiscoveredHost(const char *aHostFullName, const otDnssdHostIn
     }
 }
 
-const Server::QueryTransaction *Server::GetNextQuery(const QueryTransaction *aQuery) const
+const otDnssdQuery *Server::GetNextQuery(const otDnssdQuery *aQuery) const
 {
     const QueryTransaction *now   = &mQueryTransactions[0];
     const QueryTransaction *found = nullptr;
+    const QueryTransaction *query = static_cast<const QueryTransaction *>(aQuery);
 
     if (aQuery != nullptr)
     {
-        now = aQuery + 1;
+        now = query + 1;
     }
     for (; now < &mQueryTransactions[OT_ARRAY_LENGTH(mQueryTransactions)]; now++)
     {
@@ -979,7 +980,15 @@ const Server::QueryTransaction *Server::GetNextQuery(const QueryTransaction *aQu
             break;
         }
     }
-    return found;
+    return static_cast<const otDnssdQuery *>(found);
+}
+
+Server::DnsQueryType Server::GetQueryTypeAndName(const otDnssdQuery *aQuery, char (&aName)[Name::kMaxNameSize])
+{
+    const QueryTransaction *query = static_cast<const QueryTransaction *>(aQuery);
+
+    OT_ASSERT(query->IsValid());
+    return GetQueryTypeAndName(query->GetResponseHeader(), query->GetResponseMessage(), aName);
 }
 
 Server::DnsQueryType Server::GetQueryTypeAndName(const Header & aHeader,

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -445,6 +445,7 @@ Error Server::AppendInstanceName(Message &aMessage, const char *aName, NameCompr
 exit:
     return error;
 }
+
 Error Server::AppendTxtRecord(Message &         aMessage,
                               const char *      aInstanceName,
                               const void *      aTxtData,
@@ -763,7 +764,7 @@ Error Server::ResolveByQueryCallbacks(Header &                aResponseHeader,
 
     VerifyOrExit(mQuerySubscribe != nullptr, error = kErrorFailed);
 
-    queryType = GetQueryType(aResponseHeader, aResponseMessage, name);
+    queryType = GetQueryTypeAndName(aResponseHeader, aResponseMessage, name);
     VerifyOrExit(queryType != kDnsQueryNone, error = kErrorNotImplemented);
 
     query = NewQuery(aResponseHeader, aResponseMessage, aCompressInfo, aMessageInfo);
@@ -810,7 +811,7 @@ bool Server::CanAnswerQuery(const QueryTransaction &          aQuery,
     DnsQueryType sdType;
     bool         canAnswer = false;
 
-    sdType = GetQueryType(aQuery.GetResponseHeader(), aQuery.GetResponseMessage(), name);
+    sdType = GetQueryTypeAndName(aQuery.GetResponseHeader(), aQuery.GetResponseMessage(), name);
 
     switch (sdType)
     {
@@ -832,7 +833,7 @@ bool Server::CanAnswerQuery(const Server::QueryTransaction &aQuery, const char *
     char         name[Name::kMaxNameSize];
     DnsQueryType sdType;
 
-    sdType = GetQueryType(aQuery.GetResponseHeader(), aQuery.GetResponseMessage(), name);
+    sdType = GetQueryTypeAndName(aQuery.GetResponseHeader(), aQuery.GetResponseMessage(), name);
     return (sdType == kDnsQueryResolveHost) && (strcmp(name, aHostFullName) == 0);
 }
 
@@ -961,9 +962,29 @@ void Server::HandleDiscoveredHost(const char *aHostFullName, const otDnssdHostIn
     }
 }
 
-Server::DnsQueryType Server::GetQueryType(const Header & aHeader,
-                                          const Message &aMessage,
-                                          char (&aName)[Name::kMaxNameSize])
+const Server::QueryTransaction *Server::GetNextQuery(const QueryTransaction *aQuery) const
+{
+    const QueryTransaction *now   = &mQueryTransactions[0];
+    const QueryTransaction *found = nullptr;
+
+    if (aQuery != nullptr)
+    {
+        now = aQuery + 1;
+    }
+    for (; now < &mQueryTransactions[OT_ARRAY_LENGTH(mQueryTransactions)]; now++)
+    {
+        if (now->IsValid())
+        {
+            found = now;
+            break;
+        }
+    }
+    return found;
+}
+
+Server::DnsQueryType Server::GetQueryTypeAndName(const Header & aHeader,
+                                                 const Message &aMessage,
+                                                 char (&aName)[Name::kMaxNameSize])
 {
     DnsQueryType sdType = kDnsQueryNone;
 
@@ -1098,7 +1119,7 @@ void Server::FinalizeQuery(QueryTransaction &aQuery, Header::Response aResponseC
 
     OT_ASSERT(mQueryUnsubscribe != nullptr);
 
-    sdType = GetQueryType(aQuery.GetResponseHeader(), aQuery.GetResponseMessage(), name);
+    sdType = GetQueryTypeAndName(aQuery.GetResponseHeader(), aQuery.GetResponseMessage(), name);
 
     OT_ASSERT(sdType != kDnsQueryNone);
     OT_UNUSED_VARIABLE(sdType);

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -58,6 +58,93 @@ namespace ServiceDiscovery {
  */
 class Server : public InstanceLocator, private NonCopyable
 {
+public:
+    /**
+     * This enumeration specifies a dns-sd query type.
+     *
+     */
+    enum DnsQueryType : uint8_t
+    {
+        kDnsQueryNone        = OT_DNSSD_QUERY_TYPE_NONE,         ///< Service type unspecified.
+        kDnsQueryBrowse      = OT_DNSSD_QUERY_TYPE_BROWSE,       ///< Service type browse service.
+        kDnsQueryResolve     = OT_DNSSD_QUERY_TYPE_RESOLVE,      ///< Service type resolve service instance.
+        kDnsQueryResolveHost = OT_DNSSD_QUERY_TYPE_RESOLVE_HOST, ///< Service type resolve hostname.
+    };
+
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in]  aInstance     A reference to the OpenThread instance.
+     *
+     */
+    explicit Server(Instance &aInstance);
+
+    /**
+     * This method starts the DNS-SD server.
+     *
+     * @retval kErrorNone     Successfully started the DNS-SD server.
+     * @retval kErrorFailed   If failed to open or bind the UDP socket.
+     *
+     */
+    Error Start(void);
+
+    /**
+     * This method stops the DNS-SD server.
+     *
+     */
+    void Stop(void);
+
+    /**
+     * This method sets DNS-SD query callbacks.
+     *
+     * @param[in] aSubscribe    A pointer to the callback function to subscribe a service or service instance.
+     * @param[in] aUnsubscribe  A pointer to the callback function to unsubscribe a service or service instance.
+     * @param[in] aContext      A pointer to the application-specific context.
+     *
+     */
+    void SetQueryCallbacks(otDnssdQuerySubscribeCallback   aSubscribe,
+                           otDnssdQueryUnsubscribeCallback aUnsubscribe,
+                           void *                          aContext);
+
+    /**
+     * This method notifies a discovered service instance.
+     *
+     * @param[in] aServiceFullName  The null-terminated full service name.
+     * @param[in] aInstanceInfo     A reference to the discovered service instance information.
+     *
+     */
+    void HandleDiscoveredServiceInstance(const char *aServiceFullName, const otDnssdServiceInstanceInfo &aInstanceInfo);
+
+    /**
+     * This method notifies a discovered host.
+     *
+     * @param[in] aHostFullName     The null-terminated full host name.
+     * @param[in] aHostInfo         A reference to the discovered host information.
+     *
+     */
+    void HandleDiscoveredHost(const char *aHostFullName, const otDnssdHostInfo &aHostInfo);
+
+    /**
+     * This function aquires the next query in the server.
+     *
+     * @param[in] aQuery            The query pointer. Pass nullptr to get the first query.
+     *
+     * @returns  A pointer to the query or nullptr if no more queries.
+     *
+     */
+    const otDnssdQuery *GetNextQuery(const otDnssdQuery *aQuery) const;
+
+    /**
+     * This function aquires the dns-sd query type and name for a specific query.
+     *
+     * @param[in]   aQuery            The query pointer.
+     * @param[out]  aNameOutput       The name output buffer.
+     *
+     * @returns The dns-sd query type.
+     *
+     */
+    static DnsQueryType GetQueryTypeAndName(const otDnssdQuery *aQuery, char (&aName)[Name::kMaxNameSize]);
+
 private:
     class NameCompressInfo : public Clearable<NameCompressInfo>
     {
@@ -127,12 +214,12 @@ private:
             }
         }
 
+    private:
         static bool MatchCompressedName(const Message &aMessage, uint16_t aOffset, const char *aName)
         {
             return aOffset != kUnknownOffset && Name::CompareName(aMessage, aOffset, aName) == kErrorNone;
         }
 
-    private:
         const char *mDomainName;         // The serialized domain name.
         uint16_t    mDomainNameOffset;   // Offset of domain name serialization into the response message.
         uint16_t    mServiceNameOffset;  // Offset of service name serialization into the response message.
@@ -140,154 +227,6 @@ private:
         uint16_t    mHostNameOffset;     // Offset of host name serialization into the response message.
     };
 
-    /**
-     * This enumeration specifies a dns-sd query type.
-     *
-     */
-    enum DnsQueryType : uint8_t
-    {
-        kDnsQueryNone        = OT_DNSSD_QUERY_TYPE_NONE,         ///< Service type unspecified.
-        kDnsQueryBrowse      = OT_DNSSD_QUERY_TYPE_BROWSE,       ///< Service type browse service.
-        kDnsQueryResolve     = OT_DNSSD_QUERY_TYPE_RESOLVE,      ///< Service type resolve service instance.
-        kDnsQueryResolveHost = OT_DNSSD_QUERY_TYPE_RESOLVE_HOST, ///< Service type resolve hostname.
-    };
-
-public:
-    /**
-     * This class contains the compress information for a dns packet.
-     *
-     */
-    class QueryTransaction
-    {
-        friend class Server;
-
-    public:
-        explicit QueryTransaction(void)
-            : mResponseMessage(nullptr)
-        {
-        }
-
-        /**
-         * This method acquires the response header for the query.
-         *
-         * @returns A const reference to the response header.
-         *
-         */
-        const Header &GetResponseHeader(void) const { return mResponseHeader; }
-
-        /**
-         * This method acquires the response message for the query.
-         *
-         * @returns A const reference to the response message.
-         *
-         */
-        const Message &GetResponseMessage(void) const { return *mResponseMessage; }
-
-        /**
-         * This method checks whether the query is valid.
-         *
-         * @returns Whether the query is valid.
-         *
-         */
-        bool IsValid(void) const { return mResponseMessage != nullptr; }
-
-    private:
-        void                    Init(const Header &          aResponseHeader,
-                                     Message &               aResponseMessage,
-                                     const NameCompressInfo &aCompressInfo,
-                                     const Ip6::MessageInfo &aMessageInfo);
-        const Ip6::MessageInfo &GetMessageInfo(void) const { return mMessageInfo; }
-        Header &                GetResponseHeader(void) { return mResponseHeader; }
-        Message &               GetResponseMessage(void) { return *mResponseMessage; }
-        TimeMilli               GetStartTime(void) const { return mStartTime; }
-        NameCompressInfo &      GetNameCompressInfo(void) { return mCompressInfo; };
-        void                    Finalize(Header::Response aResponseMessage, Ip6::Udp::Socket &aSocket);
-
-        Header           mResponseHeader;
-        Message *        mResponseMessage;
-        NameCompressInfo mCompressInfo;
-        Ip6::MessageInfo mMessageInfo;
-        TimeMilli        mStartTime;
-    };
-
-    /**
-     * This constructor initializes the object.
-     *
-     * @param[in]  aInstance     A reference to the OpenThread instance.
-     *
-     */
-    explicit Server(Instance &aInstance);
-
-    /**
-     * This method starts the DNS-SD server.
-     *
-     * @retval kErrorNone     Successfully started the DNS-SD server.
-     * @retval kErrorFailed   If failed to open or bind the UDP socket.
-     *
-     */
-    Error Start(void);
-
-    /**
-     * This method stops the DNS-SD server.
-     *
-     */
-    void Stop(void);
-
-    /**
-     * This method sets DNS-SD query callbacks.
-     *
-     * @param[in] aSubscribe    A pointer to the callback function to subscribe a service or service instance.
-     * @param[in] aUnsubscribe  A pointer to the callback function to unsubscribe a service or service instance.
-     * @param[in] aContext      A pointer to the application-specific context.
-     *
-     */
-    void SetQueryCallbacks(otDnssdQuerySubscribeCallback   aSubscribe,
-                           otDnssdQueryUnsubscribeCallback aUnsubscribe,
-                           void *                          aContext);
-
-    /**
-     * This method notifies a discovered service instance.
-     *
-     * @param[in] aServiceFullName  The null-terminated full service name.
-     * @param[in] aInstanceInfo     A reference to the discovered service instance information.
-     *
-     */
-    void HandleDiscoveredServiceInstance(const char *aServiceFullName, const otDnssdServiceInstanceInfo &aInstanceInfo);
-
-    /**
-     * This method notifies a discovered host.
-     *
-     * @param[in] aHostFullName     The null-terminated full host name.
-     * @param[in] aHostInfo         A reference to the discovered host information.
-     *
-     */
-    void HandleDiscoveredHost(const char *aHostFullName, const otDnssdHostInfo &aHostInfo);
-
-    /**
-     * This function aquires the next query in the server.
-     *
-     * @param[in] aQuery            The query pointer. Pass nullptr to get the first query.
-     *
-     * @returns  A pointer to the query or nullptr if no more queries.
-     *
-     */
-    const QueryTransaction *GetNextQuery(const QueryTransaction *aQuery) const;
-
-    /**
-     * This function aquires the dns-sd query type and name for a specific query.
-     *
-     * @param[in]   aHeader           The query header.
-     * @param[in]   aMessage          The query message.
-     * @param[out]  aNameOutput       The name output buffer.
-     *
-     * @returns The dns-sd query type.
-     *
-     */
-    static DnsQueryType GetQueryTypeAndName(const Header & aHeader,
-                                            const Message &aMessage,
-                                            char (&aName)[Name::kMaxNameSize]);
-
-private:
     enum
     {
         kPort                 = OPENTHREAD_CONFIG_DNSSD_SERVER_PORT,
@@ -324,6 +263,39 @@ private:
                                  // service or instance.
         uint8_t mInstanceOffset; // The offset to the beginning of <Instance> or `kNotPresent` if the name is not a
                                  // instance.
+    };
+
+    /**
+     * This class contains the compress information for a dns packet.
+     *
+     */
+    class QueryTransaction
+    {
+    public:
+        explicit QueryTransaction(void)
+            : mResponseMessage(nullptr)
+        {
+        }
+
+        void                    Init(const Header &          aResponseHeader,
+                                     Message &               aResponseMessage,
+                                     const NameCompressInfo &aCompressInfo,
+                                     const Ip6::MessageInfo &aMessageInfo);
+        bool                    IsValid(void) const { return mResponseMessage != nullptr; }
+        const Ip6::MessageInfo &GetMessageInfo(void) const { return mMessageInfo; }
+        const Header &          GetResponseHeader(void) const { return mResponseHeader; }
+        Header &                GetResponseHeader(void) { return mResponseHeader; }
+        const Message &         GetResponseMessage(void) const { return *mResponseMessage; }
+        Message &               GetResponseMessage(void) { return *mResponseMessage; }
+        TimeMilli               GetStartTime(void) const { return mStartTime; }
+        NameCompressInfo &      GetNameCompressInfo(void) { return mCompressInfo; };
+        void                    Finalize(Header::Response aResponseMessage, Ip6::Udp::Socket &aSocket);
+
+        Header           mResponseHeader;
+        Message *        mResponseMessage;
+        NameCompressInfo mCompressInfo;
+        Ip6::MessageInfo mMessageInfo;
+        TimeMilli        mStartTime;
     };
 
     enum : uint32_t
@@ -379,7 +351,6 @@ private:
                                          Message &               aMessage,
                                          const Ip6::MessageInfo &aMessageInfo,
                                          Ip6::Udp::Socket &      aSocket);
-
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
     Header::Response                   ResolveBySrp(Header &                  aResponseHeader,
                                                     Message &                 aResponseMessage,
@@ -410,8 +381,11 @@ private:
                                   const char *                      aServiceFullName,
                                   const otDnssdServiceInstanceInfo &aInstanceInfo);
     static bool       CanAnswerQuery(const Server::QueryTransaction &aQuery, const char *aHostFullName);
-    void        AnswerQuery(QueryTransaction &aQuery, const char *aHostFullName, const otDnssdHostInfo &aHostInfo);
-    void        FinalizeQuery(QueryTransaction &aQuery, Header::Response aResponseCode);
+    void AnswerQuery(QueryTransaction &aQuery, const char *aHostFullName, const otDnssdHostInfo &aHostInfo);
+    void FinalizeQuery(QueryTransaction &aQuery, Header::Response aResponseCode);
+    static DnsQueryType GetQueryTypeAndName(const Header & aHeader,
+                                            const Message &aMessage,
+                                            char (&aName)[Name::kMaxNameSize]);
     static bool HasQuestion(const Header &aHeader, const Message &aMessage, const char *aName, uint16_t aQuestionType);
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);


### PR DESCRIPTION
This commit allows the platform implementations to access the name and
the type of the queries, thus reducing the memory overhead of
extra bookkeeping.

Depends-On: https://github.com/openthread/ot-br-posix/pull/841