### PR TITLE
[network-data] limit router upgrade delay when registering

### DIFF
--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -321,7 +321,7 @@ void DuaManager::HandleNotifierEvents(Events aEvents)
             // Wait for link establishment with neighboring routers.
             UpdateRegistrationDelay(kNewRouterRegistrationDelay);
         }
-        else if (mle.IsExpectedToBecomeRouter())
+        else if (mle.IsExpectedToBecomeRouterSoon())
         {
             // Will check again in case the device decides to stay REED when jitter timeout expires.
             UpdateRegistrationDelay(mle.GetRouterSelectionJitterTimeout() + kNewRouterRegistrationDelay + 1);
@@ -435,7 +435,7 @@ void DuaManager::PerformNextRegistration(void)
     // Only send DUA.req when necessary
 #if OPENTHREAD_CONFIG_DUA_ENABLE
 #if OPENTHREAD_FTD
-    VerifyOrExit(mle.IsRouterOrLeader() || !mle.IsExpectedToBecomeRouter(), error = kErrorInvalidState);
+    VerifyOrExit(mle.IsRouterOrLeader() || !mle.IsExpectedToBecomeRouterSoon(), error = kErrorInvalidState);
 #endif
     VerifyOrExit(mle.IsFullThreadDevice() || mle.GetParent().IsThreadVersion1p1(), error = kErrorInvalidState);
 #endif // OPENTHREAD_CONFIG_DUA_ENABLE

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3698,10 +3698,13 @@ exit:
     InformPreviousChannel();
 }
 
-bool MleRouter::IsExpectedToBecomeRouter(void) const
+bool MleRouter::IsExpectedToBecomeRouterSoon(void) const
 {
+    static constexpr uint8_t kMaxDelay = 10;
+
     return IsRouterEligible() && IsChild() && !mAddressSolicitRejected &&
-           (GetRouterSelectionJitterTimeout() != 0 || mAddressSolicitPending);
+           ((GetRouterSelectionJitterTimeout() != 0 && GetRouterSelectionJitterTimeout() <= kMaxDelay) ||
+            mAddressSolicitPending);
 }
 
 void MleRouter::HandleAddressSolicit(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -327,11 +327,11 @@ public:
     /**
      * This method returns if the REED is expected to become Router soon.
      *
-     * @retval TRUE   If the REED is going to become Router.
-     * @retval FALSE  Otherwise.
+     * @retval TRUE   If the REED is going to become a Router soon.
+     * @retval FALSE  If the REED is not going to become a Router soon.
      *
      */
-    bool IsExpectedToBecomeRouter(void) const;
+    bool IsExpectedToBecomeRouterSoon(void) const;
 
     /**
      * This method removes a link to a neighbor.

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -402,13 +402,11 @@ Error Local::UpdateInconsistentServerData(Coap::ResponseHandler aHandler, void *
     bool     isConsistent = true;
 
 #if OPENTHREAD_FTD
-
     // Don't send this Server Data Notification if the device is going to upgrade to Router
-    if (Get<Mle::MleRouter>().IsExpectedToBecomeRouter())
+    if (Get<Mle::MleRouter>().IsExpectedToBecomeRouterSoon())
     {
         ExitNow(error = kErrorInvalidState);
     }
-
 #endif
 
     UpdateRloc();


### PR DESCRIPTION
If a device is a REED and waiting the random delay to upgrade to a
router, the device will wait to register its network data, since it
will have to register again after upgrading to a router. However, the
maximum delay for becoming a router is up to 2 minutes, which is a
long time to wait.

This commit limits the delay that a device will wait to register its
network data.