### PR TITLE
[dua] send DUA.ntf to notify Child of unsuccessful DUA registration

### DIFF
--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -663,7 +663,6 @@ Error DuaManager::ProcessDuaResponse(Coap::Message &aMessage)
             break;
         case ThreadStatusTlv::kDuaInvalid:
         case ThreadStatusTlv::kDuaDuplicate:
-            SendAddressNotification(target, static_cast<ThreadStatusTlv::DuaStatus>(status), *child);
             IgnoreError(child->RemoveIp6Address(target));
             mChildDuaMask.Set(mChildIndexDuaRegistering, false);
             mChildDuaRegisteredMask.Set(mChildIndexDuaRegistering, false);
@@ -673,6 +672,11 @@ Error DuaManager::ProcessDuaResponse(Coap::Message &aMessage)
         case ThreadStatusTlv::kDuaGeneralFailure:
             UpdateReregistrationDelay();
             break;
+        }
+
+        if (status != ThreadStatusTlv::kDuaSuccess)
+        {
+            SendAddressNotification(target, static_cast<ThreadStatusTlv::DuaStatus>(status), *child);
         }
     }
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE


### PR DESCRIPTION
Parent should send DUA.ntf to Child that requested the DUA when status is not `ST_DUA_SUCCESS`, according to Thread 1.2 Spec. 5.23.6.2. 

Fixes DUA-TC-17.