### PR TITLE
[udp] allow Reference Devices to send UDP messages to TMF port

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1289,10 +1289,14 @@ start:
             sourcePort = HostSwap16(sourcePort);
             destPort   = HostSwap16(destPort);
 
+#if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
             if (nextHeader == kProtoUdp)
             {
                 VerifyOrExit(Get<Udp>().ShouldUsePlatformUdp(destPort), error = kErrorDrop);
             }
+#else
+            OT_UNUSED_VARIABLE(destPort);
+#endif
 
 #if OPENTHREAD_CONFIG_UNSECURE_TRAFFIC_MANAGED_BY_STACK_ENABLE
             // check whether source port is an unsecure port


### PR DESCRIPTION
This commit allows Reference Devices to send UDP messages to TMF port, which was prohibited by #5911 .

**Background**:
TestHarness sends constructed TMF messages in many TCs to validate the behavior of nodes on receiving these TMF messages.   

Fixes DUA-TC-09