### PR TITLE
[border-router] border routing optional at runtime

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -145,6 +145,7 @@ LOCAL_EXPORT_C_INCLUDE_DIRS     := \
 
 LOCAL_CPPFLAGS                                                              := \
     -std=c++11                                                                 \
+    -Wno-error=non-virtual-dtor                                                \
     -pedantic-errors                                                           \
     $(NULL)
 
@@ -355,6 +356,7 @@ LOCAL_SRC_FILES                                                  := \
     src/posix/platform/hdlc_interface.cpp                           \
     src/posix/platform/infra_if.cpp                                 \
     src/posix/platform/logging.cpp                                  \
+    src/posix/platform/mainloop.cpp                                 \
     src/posix/platform/memory.cpp                                   \
     src/posix/platform/misc.cpp                                     \
     src/posix/platform/multicast_routing.cpp                        \

--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -76,6 +76,7 @@ add_library(openthread-posix
     hdlc_interface.cpp
     infra_if.cpp
     logging.cpp
+    mainloop.cpp
     memory.cpp
     misc.cpp
     multicast_routing.cpp

--- a/src/posix/platform/Makefile.am
+++ b/src/posix/platform/Makefile.am
@@ -51,6 +51,7 @@ libopenthread_posix_a_SOURCES             = \
     hdlc_interface.cpp                      \
     infra_if.cpp                            \
     logging.cpp                             \
+    mainloop.cpp                            \
     memory.cpp                              \
     misc.cpp                                \
     multicast_routing.cpp                   \
@@ -72,6 +73,7 @@ libopenthread_posix_a_LIBADD                                                    
 
 noinst_HEADERS                            = \
     hdlc_interface.hpp                      \
+    mainloop.hpp                            \
     multicast_routing.hpp                   \
     openthread-posix-config.h               \
     platform-posix.h                        \

--- a/src/posix/platform/infra_if.hpp
+++ b/src/posix/platform/infra_if.hpp
@@ -1,0 +1,132 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the infrastructure interface for posix.
+ */
+
+#include "openthread-posix-config.h"
+
+#include <net/if.h>
+
+#include "core/common/non_copyable.hpp"
+#include "posix/platform/mainloop.hpp"
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+
+namespace ot {
+namespace Posix {
+
+/**
+ * This class manages infrastructure network interface.
+ *
+ */
+class InfraNetif : public Mainloop::Source, private NonCopyable
+{
+public:
+    /**
+     * This method updates the fd_set and timeout for mainloop.
+     *
+     * @param[inout]    aContext    A reference to the mainloop context.
+     *
+     */
+    void Update(otSysMainloopContext &aContext) override;
+
+    /**
+     * This method performs infrastructure network interface processing.
+     *
+     * @param[in]   aContext   A reference to the mainloop context.
+     *
+     */
+    void Process(const otSysMainloopContext &aContext) override;
+
+    /**
+     * This method initializes the infrastructure network interface.
+     *
+     * @param[in]  aInstance    A pointer to an OpenThread instance.
+     * @param[in]  aIfName      A pointer to infrastructure network interface name.
+     *
+     */
+    void Init(otInstance *aInstance, const char *aIfName);
+
+    /**
+     * This method deinitializes the infrastructure network interface.
+     *
+     */
+    void Deinit(void);
+
+    /**
+     * This method checks whether the infrastructure network interface is running.
+     *
+     */
+    bool IsRunning(void) const;
+
+    /**
+     * This method sends an ICMPv6 Neighbor Discovery message on given infrastructure interface.
+     *
+     * See RFC 4861: https://tools.ietf.org/html/rfc4861.
+     *
+     * @param[in]  aInfraIfIndex  The index of the infrastructure interface this message is sent to.
+     * @param[in]  aDestAddress   The destination address this message is sent to.
+     * @param[in]  aBuffer        The ICMPv6 message buffer. The ICMPv6 checksum is left zero and the
+     *                            platform should do the checksum calculate.
+     * @param[in]  aBufferLength  The length of the message buffer.
+     *
+     * @note  Per RFC 4861, the implementation should send the message with IPv6 link-local source address
+     *        of interface @p aInfraIfIndex and IP Hop Limit 255.
+     *
+     * @retval OT_ERROR_NONE    Successfully sent the ICMPv6 message.
+     * @retval OT_ERROR_FAILED  Failed to send the ICMPv6 message.
+     *
+     */
+    otError SendIcmp6Nd(uint32_t            aInfraIfIndex,
+                        const otIp6Address &aDestAddress,
+                        const uint8_t *     aBuffer,
+                        uint16_t            aBufferLength);
+    /**
+     * This function gets the infrastructure network interface singleton.
+     *
+     * @returns The singleton object.
+     */
+    static InfraNetif &Get(void);
+
+private:
+    otInstance *mInstance;
+    char        mInfraIfName[IFNAMSIZ];
+    uint32_t    mInfraIfIndex       = 0;
+    int         mInfraIfIcmp6Socket = -1;
+    int         mNetLinkSocket      = -1;
+
+    void ReceiveNetLinkMessage(void);
+    void ReceiveIcmp6Message(void);
+};
+
+} // namespace Posix
+} // namespace ot
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE

--- a/src/posix/platform/mainloop.hpp
+++ b/src/posix/platform/mainloop.hpp
@@ -1,0 +1,126 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for the SPI interface to radio (RCP).
+ */
+
+#ifndef OT_POSIX_PLATFORM_MAINLOOP_HPP_
+#define OT_POSIX_PLATFORM_MAINLOOP_HPP_
+
+#include <openthread/openthread-system.h>
+
+namespace ot {
+namespace Posix {
+namespace Mainloop {
+
+/**
+ * This class is the base for all mainloop event sources.
+ *
+ */
+class Source
+{
+    friend class Manager;
+
+public:
+    /**
+     * This method registers events in the mainloop.
+     *
+     * @param[inout]    aContext    A reference to the mainloop context.
+     *
+     */
+    virtual void Update(otSysMainloopContext &aContext) = 0;
+
+    /**
+     * This method processes the mainloop events.
+     *
+     * @param[in]   aContext    A reference to the mainloop context.
+     *
+     */
+    virtual void Process(const otSysMainloopContext &aContext) = 0;
+
+private:
+    Source *mNext = nullptr;
+};
+
+/**
+ * This class manages mainloop.
+ *
+ */
+class Manager
+{
+public:
+    /**
+     * This method updates event polls in the mainloop context.
+     *
+     * @param[inout]    aContext    A reference to the mainloop context.
+     *
+     */
+    void Update(otSysMainloopContext &aContext);
+
+    /**
+     * This method processes events in the mainloop context.
+     *
+     * @param[in]   aContext    A reference to the mainloop context.
+     *
+     */
+    void Process(const otSysMainloopContext &aContext);
+
+    /**
+     * This method adds a new event source into the mainloop.
+     *
+     * @param[in]   aSource     A reference to the event source.
+     *
+     */
+    void Add(Source &aSource);
+
+    /**
+     * This method removes an event source from the mainloop.
+     *
+     * @param[in]   aSource     A reference to the event source.
+     *
+     */
+    void Remove(Source &aSource);
+
+    /**
+     * This function returns the Mainloop singleton.
+     *
+     * @returns A refernce to the Mainloop singleton.
+     *
+     */
+    static Manager &Get(void);
+
+private:
+    Source *mSources = nullptr;
+};
+
+} // namespace Mainloop
+} // namespace Posix
+} // namespace ot
+#endif // OT_POSIX_PLATFORM_MAINLOOP_HPP_

--- a/src/posix/platform/multicast_routing.cpp
+++ b/src/posix/platform/multicast_routing.cpp
@@ -57,6 +57,7 @@ void MulticastRoutingManager::Init(otInstance *aInstance)
 
     otBackboneRouterSetMulticastListenerCallback(aInstance,
                                                  &MulticastRoutingManager::HandleBackboneMulticastListenerEvent, this);
+    Mainloop::Manager::Get().Add(*this);
 }
 
 void MulticastRoutingManager::HandleBackboneMulticastListenerEvent(void *                                 aContext,
@@ -138,24 +139,24 @@ exit:
     return found;
 }
 
-void MulticastRoutingManager::UpdateFdSet(fd_set &aReadFdSet, int &aMaxFd) const
+void MulticastRoutingManager::Update(otSysMainloopContext &aContext)
 {
     VerifyOrExit(IsEnabled());
 
-    FD_SET(mMulticastRouterSock, &aReadFdSet);
-    aMaxFd = OT_MAX(aMaxFd, mMulticastRouterSock);
+    FD_SET(mMulticastRouterSock, &aContext.mReadFdSet);
+    aContext.mMaxFd = OT_MAX(aContext.mMaxFd, mMulticastRouterSock);
 
 exit:
     return;
 }
 
-void MulticastRoutingManager::Process(const fd_set &aReadFdSet)
+void MulticastRoutingManager::Process(const otSysMainloopContext &aContext)
 {
     VerifyOrExit(IsEnabled());
 
     ExpireMulticastForwardingCache();
 
-    if (FD_ISSET(mMulticastRouterSock, &aReadFdSet))
+    if (FD_ISSET(mMulticastRouterSock, &aContext.mReadFdSet))
     {
         ProcessMulticastRouterMessages();
     }

--- a/src/posix/platform/multicast_routing.hpp
+++ b/src/posix/platform/multicast_routing.hpp
@@ -43,6 +43,7 @@
 #include "core/common/non_copyable.hpp"
 #include "core/net/ip6_address.hpp"
 #include "lib/url/url.hpp"
+#include "posix/platform/mainloop.hpp"
 
 namespace ot {
 namespace Posix {
@@ -51,7 +52,7 @@ namespace Posix {
  * This class implements Multicast Routing management.
  *
  */
-class MulticastRoutingManager : private NonCopyable
+class MulticastRoutingManager : public Mainloop::Source, private NonCopyable
 {
 public:
     /**
@@ -59,9 +60,9 @@ public:
      *
      */
     explicit MulticastRoutingManager()
+
         : mLastExpireTime(0)
         , mMulticastRouterSock(-1)
-        , mInstance(nullptr)
     {
     }
 
@@ -76,19 +77,18 @@ public:
     /**
      * This method updates the fd_set and timeout for mainloop.
      *
-     * @param[inout]    aReadFdSet      A reference to fd_set for polling read.
-     * @param[inout]    aMaxFd          A reference to the current max fd in fd_sets.
+     * @param[inout]    aContext    A reference to the mainloop context.
      *
      */
-    void UpdateFdSet(fd_set &aReadFdSet, int &aMaxFd) const;
+    void Update(otSysMainloopContext &aContext) override;
 
     /**
      * This method performs Multicast Routing processing.
      *
-     * @param[in]   aReadFdSet   A reference to read file descriptors.
+     * @param[in]   aContext    A reference to the mainloop context.
      *
      */
-    void Process(const fd_set &aReadFdSet);
+    void Process(const otSysMainloopContext &aContext) override;
 
     /**
      * This method handles Thread state changes.

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -463,23 +463,6 @@ extern unsigned int gNetifIndex;
 void platformBackboneInit(otInstance *aInstance, const char *aInterfaceName);
 
 /**
- * This function updates the file descriptor sets with file descriptors used by the platform Backbone network.
- *
- * @param[inout]  aReadFdSet   A reference to the read file descriptors.
- * @param[inout]  aMaxFd       A reference to the max file descriptor.
- *
- */
-void platformBackboneUpdateFdSet(fd_set &aReadFdSet, int &aMaxFd);
-
-/**
- * This function performs platform Backbone network processing.
- *
- * @param[in]   aReadFdSet  A reference to the read file descriptors.
- *
- */
-void platformBackboneProcess(const fd_set &aReadSet);
-
-/**
  * This function performs notifies state changes to platform Backbone network.
  *
  * @param[in]   aInstance       A pointer to the OpenThread instance.
@@ -501,47 +484,12 @@ extern char gBackboneNetifName[IFNAMSIZ];
 extern unsigned int gBackboneNetifIndex;
 
 /**
- * This function initializes the infrastructure interface.
- *
- * @param[in]  aInstance  The OpenThread instance.
- * @param[in]  aIfName    The name of the infrastructure interface.
- *
- * @returns  The index of the infrastructure interface.
- *
- */
-uint32_t platformInfraIfInit(otInstance *aInstance, const char *aIfName);
-
-/**
- * This function deinitializes the infrastructure interface.
- *
- */
-void platformInfraIfDeinit(void);
-
-/**
  * This function tells if the infrastructure interface is running.
  *
  * @returns TRUE if the infrastructure interface is running, FALSE if not.
  *
  */
 bool platformInfraIfIsRunning(void);
-
-/**
- * This function updates the read fd set.
- *
- * @param[out]  aReadFdSet  The fd set to be updated.
- * @param[out]  aMaxFd      The maximum fd to be updated.
- *
- */
-void platformInfraIfUpdateFdSet(fd_set &aReadFdSet, int &aMaxFd);
-
-/**
- * This function processes possible events on the infrastructure interface.
- *
- * @param[in]  aInstance   The OpenThread instance.
- * @param[in]  aReadFdSet  The fd set which may contain read vents.
- *
- */
-void platformInfraIfProcess(otInstance *aInstance, const fd_set &aReadFdSet);
 
 /**
  * This function enables daemon.


### PR DESCRIPTION
This commit allows launching an OpenThread daemon which was built with
backbone-router and border-routing support but disabling them at runtime
by not specifying the `-B` option.
