### PR TITLE
[ip6] add public APIs to convert an IPv6 address or prefix to string

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (114)
+#define OPENTHREAD_API_VERSION (115)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -562,7 +562,7 @@ const uint16_t *otIp6GetUnsecurePorts(otInstance *aInstance, uint8_t *aNumEntrie
 bool otIp6IsAddressEqual(const otIp6Address *aFirst, const otIp6Address *aSecond);
 
 /**
- * Convert a human-readable IPv6 address string into a binary representation.
+ * This function converts a human-readable IPv6 address string into a binary representation.
  *
  * @param[in]   aString   A pointer to a NULL-terminated string.
  * @param[out]  aAddress  A pointer to an IPv6 address.
@@ -572,6 +572,39 @@ bool otIp6IsAddressEqual(const otIp6Address *aFirst, const otIp6Address *aSecond
  *
  */
 otError otIp6AddressFromString(const char *aString, otIp6Address *aAddress);
+
+#define OT_IP6_ADDRESS_STRING_SIZE 40 ///< Recommended size for string representation of an IPv6 address.
+
+/**
+ * This function converts a given IPv6 address to a human-readable string.
+ *
+ * The IPv6 address string is formatted as 16 hex values separated by ':' (i.e., "%x:%x:%x:...:%x").
+ *
+ * If the resulting string does not fit in @p aBuffer (within its @p aSize characters), the string will be truncated
+ * but the outputted string is always null-terminated.
+ *
+ * @param[in]  aAddress  A pointer to an IPv6 address (MUST NOT be NULL).
+ * @param[out] aBuffer   A pointer to a char array to output the string (MUST NOT be NULL).
+ * @param[in]  aSize     The size of @p aBuffer (in bytes). Recommended to use `OT_IP6_ADDRESS_STRING_SIZE`.
+ *
+ */
+void otIp6AddressToString(const otIp6Address *aAddress, char *aBuffer, uint16_t aSize);
+
+#define OT_IP6_PREFIX_STRING_SIZE 45 ///< Recommended size for string representation of an IPv6 prefix.
+/**
+ * This function converts a given IPv6 prefix to a human-readable string.
+ *
+ * The IPv6 address string is formatted as "%x:%x:%x:...[::]/plen".
+ *
+ * If the resulting string does not fit in @p aBuffer (within its @p aSize characters), the string will be truncated
+ * but the outputted string is always null-terminated.
+ *
+ * @param[in]  aPrefix   A pointer to an IPv6 prefix (MUST NOT be NULL).
+ * @param[out] aBuffer   A pointer to a char array to output the string (MUST NOT be NULL).
+ * @param[in]  aSize     The size of @p aBuffer (in bytes). Recommended to use `OT_IP6_PREFIX_STRING_SIZE`.
+ *
+ */
+void otIp6PrefixToString(const otIp6Prefix *aPrefix, char *aBuffer, uint16_t aSize);
 
 /**
  * This function returns the prefix match length (bits) for two IPv6 addresses.

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -591,6 +591,7 @@ otError otIp6AddressFromString(const char *aString, otIp6Address *aAddress);
 void otIp6AddressToString(const otIp6Address *aAddress, char *aBuffer, uint16_t aSize);
 
 #define OT_IP6_PREFIX_STRING_SIZE 45 ///< Recommended size for string representation of an IPv6 prefix.
+
 /**
  * This function converts a given IPv6 prefix to a human-readable string.
  *

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -82,12 +82,9 @@
 #include <openthread/platform/debug_uart.h>
 #endif
 
-#include "common/encoding.hpp"
 #include "common/new.hpp"
 #include "common/string.hpp"
 #include "mac/channel_mask.hpp"
-
-using ot::Encoding::BigEndian::HostSwap16;
 
 namespace ot {
 namespace Cli {
@@ -164,10 +161,11 @@ void Interpreter::OutputEnabledDisabledStatus(bool aEnabled)
 
 int Interpreter::OutputIp6Address(const otIp6Address &aAddress)
 {
-    return OutputFormat(
-        "%x:%x:%x:%x:%x:%x:%x:%x", HostSwap16(aAddress.mFields.m16[0]), HostSwap16(aAddress.mFields.m16[1]),
-        HostSwap16(aAddress.mFields.m16[2]), HostSwap16(aAddress.mFields.m16[3]), HostSwap16(aAddress.mFields.m16[4]),
-        HostSwap16(aAddress.mFields.m16[5]), HostSwap16(aAddress.mFields.m16[6]), HostSwap16(aAddress.mFields.m16[7]));
+    char string[OT_IP6_ADDRESS_STRING_SIZE];
+
+    otIp6AddressToString(&aAddress, string, sizeof(string));
+
+    return OutputFormat("%s", string);
 }
 
 otError Interpreter::ParseEnableOrDisable(const Arg &aArg, bool &aEnable)

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -160,9 +160,11 @@ void NetworkData::OutputRoute(const otExternalRouteConfig &aConfig)
 
 void NetworkData::OutputIp6Prefix(const otIp6Prefix &aPrefix)
 {
-    mInterpreter.OutputFormat("%x:%x:%x:%x::/%d", HostSwap16(aPrefix.mPrefix.mFields.m16[0]),
-                              HostSwap16(aPrefix.mPrefix.mFields.m16[1]), HostSwap16(aPrefix.mPrefix.mFields.m16[2]),
-                              HostSwap16(aPrefix.mPrefix.mFields.m16[3]), aPrefix.mLength);
+    char string[OT_IP6_PREFIX_STRING_SIZE];
+
+    otIp6PrefixToString(&aPrefix, string, sizeof(string));
+
+    mInterpreter.OutputFormat("%s", string);
 }
 
 void NetworkData::OutputPreference(signed int aPreference)

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -232,6 +232,16 @@ otError otIp6AddressFromString(const char *aString, otIp6Address *aAddress)
     return static_cast<Ip6::Address *>(aAddress)->FromString(aString);
 }
 
+void otIp6AddressToString(const otIp6Address *aAddress, char *aBuffer, uint16_t aSize)
+{
+    static_cast<const Ip6::Address *>(aAddress)->ToString(aBuffer, aSize);
+}
+
+void otIp6PrefixToString(const otIp6Prefix *aPrefix, char *aBuffer, uint16_t aSize)
+{
+    static_cast<const Ip6::Prefix *>(aPrefix)->ToString(aBuffer, aSize);
+}
+
 uint8_t otIp6PrefixMatch(const otIp6Address *aFirst, const otIp6Address *aSecond)
 {
     OT_ASSERT(aFirst != nullptr && aSecond != nullptr);

--- a/src/core/common/string.hpp
+++ b/src/core/common/string.hpp
@@ -131,11 +131,18 @@ public:
     /**
      * This constructor initializes the object as cleared on the provided buffer.
      *
+     * @param[in] aBuffer  A pointer to the char buffer to write into.
+     * @param[in] aSize    The size of @p aBuffer.
+     *
      */
     StringWriter(char *aBuffer, uint16_t aSize);
 
     /**
      * This constructor initializes the object as cleared on a fixed-size string.
+     *
+     * @tparam kSize  The size of the string (number of chars).
+     *
+     * @param[in] aStringBuffer   A reference to a `String<kSize` to write into.
      *
      */
     template <uint16_t kSize>

--- a/src/core/common/string.hpp
+++ b/src/core/common/string.hpp
@@ -142,7 +142,7 @@ public:
      *
      * @tparam kSize  The size of the string (number of chars).
      *
-     * @param[in] aStringBuffer   A reference to a `String<kSize` to write into.
+     * @param[in] aStringBuffer   A reference to a `String<kSize>` to write into.
      *
      */
     template <uint16_t kSize>

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -128,21 +128,31 @@ Prefix::InfoString Prefix::ToString(void) const
 {
     InfoString   string;
     StringWriter writer(string);
-    uint8_t      sizeInUint16 = (GetBytesSize() + sizeof(uint16_t) - 1) / sizeof(uint16_t);
 
-    for (uint16_t i = 0; i < sizeInUint16; i++)
-    {
-        writer.Append("%s%x", (i > 0) ? ":" : "", HostSwap16(mPrefix.mFields.m16[i]));
-    }
+    ToString(writer);
+
+    return string;
+}
+
+void Prefix::ToString(char *aBuffer, uint16_t aSize) const
+{
+    StringWriter writer(aBuffer, aSize);
+
+    ToString(writer);
+}
+
+void Prefix::ToString(StringWriter &aWriter) const
+{
+    uint8_t sizeInUint16 = (GetBytesSize() + sizeof(uint16_t) - 1) / sizeof(uint16_t);
+
+    static_cast<const Address &>(mPrefix).AppendHexWords(aWriter, sizeInUint16);
 
     if (GetBytesSize() < Address::kSize - 1)
     {
-        writer.Append("::");
+        aWriter.Append("::");
     }
 
-    writer.Append("/%d", mLength);
-
-    return string;
+    aWriter.Append("/%d", mLength);
 }
 
 //---------------------------------------------------------------------------------------------------------------------
@@ -634,10 +644,36 @@ Address::InfoString Address::ToString(void) const
     InfoString   string;
     StringWriter writer(string);
 
-    writer.Append("%x:%x:%x:%x:%x:%x:%x:%x", HostSwap16(mFields.m16[0]), HostSwap16(mFields.m16[1]),
-                  HostSwap16(mFields.m16[2]), HostSwap16(mFields.m16[3]), HostSwap16(mFields.m16[4]),
-                  HostSwap16(mFields.m16[5]), HostSwap16(mFields.m16[6]), HostSwap16(mFields.m16[7]));
+    ToString(writer);
+
     return string;
+}
+
+void Address::ToString(char *aBuffer, uint16_t aSize) const
+{
+    StringWriter writer(aBuffer, aSize);
+    ToString(writer);
+}
+
+void Address::ToString(StringWriter &aWriter) const
+{
+    AppendHexWords(aWriter, OT_ARRAY_LENGTH(mFields.m16));
+}
+
+void Address::AppendHexWords(StringWriter &aWriter, uint8_t aLength) const
+{
+    // Appends the first `aLength` elements in `mFields.m16[]` array
+    // as hex words.
+
+    for (uint8_t index = 0; index < aLength; index++)
+    {
+        if (index > 0)
+        {
+            aWriter.Append(":");
+        }
+
+        aWriter.Append("%x", HostSwap16(mFields.m16[index]));
+    }
 }
 
 const Address &Address::GetLinkLocalAllNodesMulticast(void)

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -101,7 +101,7 @@ public:
 
     enum : uint16_t
     {
-        kInfoStringSize = 45, ///< Max chars for the info string (`ToString()`).
+        kInfoStringSize = OT_IP6_PREFIX_STRING_SIZE, ///< Max chars for the info string (`ToString()`).
     };
 
     /**
@@ -275,11 +275,29 @@ public:
     /**
      * This method converts the prefix to a string.
      *
+     * The IPv6 prefix string is formatted as "%x:%x:%x:...[::]/plen".
+     *
      * @returns An `InfoString` containing the string representation of the Prefix.
      *
      */
     InfoString ToString(void) const;
 
+    /**
+     * This method converts the prefix to a string.
+     *
+     * The IPv6 prefix string is formatted as "%x:%x:%x:...[::]/plen".
+     *
+     * If the resulting string does not fit in @p aBuffer (within its @p aSize characters), the string will be
+     * truncated but the outputted string is always null-terminated.
+     *
+     * @param[out] aBuffer   A pointer to a char array to output the string (MUST NOT be nullptr).
+     * @param[in]  aSize     The size of @p aBuffer (in bytes).
+     *
+     */
+    void ToString(char *aBuffer, uint16_t aSize) const;
+
+private:
+    void ToString(StringWriter &aWriter) const;
 } OT_TOOL_PACKED_END;
 
 /**
@@ -489,6 +507,8 @@ private:
 OT_TOOL_PACKED_BEGIN
 class Address : public otIp6Address, public Equatable<Address>, public Clearable<Address>
 {
+    friend class Prefix;
+
 public:
     /**
      * Masks
@@ -505,8 +525,8 @@ public:
      */
     enum
     {
-        kSize                 = OT_IP6_ADDRESS_SIZE, ///< Size of an IPv6 Address (in bytes).
-        kIp6AddressStringSize = 40, ///< Max buffer size in bytes to store an IPv6 address in string format.
+        kSize           = OT_IP6_ADDRESS_SIZE,        ///< Size of an IPv6 Address (in bytes).
+        kInfoStringSize = OT_IP6_ADDRESS_STRING_SIZE, ///< Max string size for an IPv6 address in string format.
     };
 
     /**
@@ -540,7 +560,7 @@ public:
      * This type defines the fixed-length `String` object returned from `ToString()`.
      *
      */
-    typedef String<kIp6AddressStringSize> InfoString;
+    typedef String<kInfoStringSize> InfoString;
 
     /**
      * This method gets the IPv6 address as a pointer to a byte array.
@@ -917,12 +937,28 @@ public:
     Error FromString(const char *aString);
 
     /**
-     * This method converts an IPv6 address object to a string
+     * This method converts the IPv6 address to a string.
+     *
+     * The IPv6 address string is formatted as 16 hex values separated by ':' (i.e., "%x:%x:%x:...:%x").
      *
      * @returns An `InfoString` representing the IPv6 address.
      *
      */
     InfoString ToString(void) const;
+
+    /**
+     * This method convert the IPv6 address to a C string.
+     *
+     * The IPv6 address string is formatted as 16 hex values separated by ':' (i.e., "%x:%x:%x:...:%x").
+     *
+     * If the resulting string does not fit in @p aBuffer (within its @p aSize characters), the string will be
+     * truncated but the outputted string is always null-terminated.
+     *
+     * @param[out] aBuffer   A pointer to a char array to output the string (MUST NOT be nullptr).
+     * @param[in]  aSize     The size of @p aBuffer (in bytes).
+     *
+     */
+    void ToString(char *aBuffer, uint16_t aSize) const;
 
     /**
      * This method overloads operator `<` to compare two IPv6 addresses.
@@ -938,6 +974,8 @@ public:
 private:
     void SetPrefix(uint8_t aOffset, const uint8_t *aPrefix, uint8_t aPrefixLength);
     void SetToLocator(const NetworkPrefix &aNetworkPrefix, uint16_t aLocator);
+    void ToString(StringWriter &aWriter) const;
+    void AppendHexWords(StringWriter &aWriter, uint8_t aLength) const;
 
     static const Address &GetLinkLocalAllNodesMulticast(void);
     static const Address &GetLinkLocalAllRoutersMulticast(void);


### PR DESCRIPTION
This commit adds new public OpenThread APIs to convert an IPv6 address
or an IPv6 prefix to a human-readable string representation. The
implementation is shared with the `Address/Prefix::ToString()` used by
core modules (through adding a private `ToString(StringWriter &)`
method which can then be used with a `String<kSize>` or a char
buffer).