### PR TITLE
[dua] fix Parent failed to send reregister for MTD Child on receiving `ST_DUA_REREGISTER`

### DIFF
--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -257,10 +257,9 @@ private:
     // TODO: (DUA) may re-evaluate the alternative option of distributing the flags into the child table:
     //       - Child class itself have some padding - may save some RAM
     //       - Avoid cross reference between a bit-vector and the child entry
-    ChildMask mChildDuaMask;           ///< Child Mask for child who registers DUA via Child Update Request.
-    ChildMask mChildDuaRegisteredMask; ///< Child Mask for child's DUA that was registered by the parent on behalf.
-    uint16_t  mChildIndexDuaRegistering : 15; ///< Child Index of the DUA being registered.
-    bool      mRegisterCurrentChildIndex : 1; ///< Re-register the child just registered.
+    ChildMask mChildDuaMask;             ///< Child Mask for child who registers DUA via Child Update Request.
+    ChildMask mChildDuaRegisteredMask;   ///< Child Mask for child's DUA that was registered by the parent on behalf.
+    uint16_t  mChildIndexDuaRegistering; ///< Child Index of the DUA being registered.
 #endif
 };
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2052,10 +2052,8 @@ Error MleRouter::UpdateChildAddresses(const Message &aMessage, uint16_t aOffset,
 
                 if (oldDuaPtr != nullptr)
                 {
-                    if (oldDua != address)
-                    {
-                        Get<DuaManager>().UpdateChildDomainUnicastAddress(aChild, ChildDuaState::kChanged);
-                    }
+                    Get<DuaManager>().UpdateChildDomainUnicastAddress(
+                        aChild, oldDua != address ? ChildDuaState::kChanged : ChildDuaState::kUnchanged);
                 }
                 else
                 {

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -296,9 +296,10 @@ static_assert(kTimeSinceLastTransactionMax * 1000 > kTimeSinceLastTransactionMax
  */
 enum class ChildDuaState : uint8_t
 {
-    kAdded,   ///< A new DUA registered by the Child via Address Registration.
-    kChanged, ///< A different DUA registered by the Child via Address Registration.
-    kRemoved, ///< DUA registered by the Child is removed and not in Address Registration.
+    kAdded,     ///< A new DUA registered by the Child via Address Registration.
+    kChanged,   ///< A different DUA registered by the Child via Address Registration.
+    kRemoved,   ///< DUA registered by the Child is removed and not in Address Registration.
+    kUnchanged, ///< The Child registers the same DUA again.
 };
 
 #endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2


### PR DESCRIPTION
This commit enhances DUA response handling for `ST_DUA_REREGISTER`:
- Parent will stop registering DUA for MTD Child until the next `Child Update Request`
- MTD Child will re-register its DUA by `Child Update Request` or `DUA.req`