### PR TITLE
[ip6][udp]improve frame filtering

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (114)
+#define OPENTHREAD_API_VERSION (115)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/udp.h
+++ b/include/openthread/udp.h
@@ -290,6 +290,18 @@ void otUdpForwardReceive(otInstance *        aInstance,
                          uint16_t            aSockPort);
 
 /**
+ * Determines if the given UDP port is exclusively opened by OpenThread API.
+ *
+ * @param[in]  aInstance            A pointer to an OpenThread instance.
+ * @param[in]  port                 UDP port number to verify.
+ *
+ * @retval true    The port is being used exclusively by OpenThread
+ * @retval false   The port is not used by any of the OpenThread API or is shared (e.g. is Backbone socket ).
+ *
+ */
+bool otUdpIsPortInUse(otInstance *aInstance, uint16_t port);
+
+/**
  * @}
  *
  */

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -147,3 +147,10 @@ otError otUdpSendDatagram(otInstance *aInstance, otMessage *aMessage, otMessageI
     return instance.Get<Ip6::Udp>().SendDatagram(*static_cast<ot::Message *>(aMessage),
                                                  *static_cast<Ip6::MessageInfo *>(aMessageInfo), Ip6::kProtoUdp);
 }
+
+bool otUdpIsPortInUse(otInstance *aInstance, uint16_t port)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<Ip6::Udp>().IsPortInUse(port);
+}

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -49,6 +49,7 @@
 #include "net/ip6_filter.hpp"
 #include "net/netif.hpp"
 #include "net/udp6.hpp"
+#include "openthread/ip6.h"
 #include "thread/mle.hpp"
 
 using IcmpType = ot::Ip6::Icmp::Header::Type;
@@ -1035,8 +1036,8 @@ Error Ip6::ProcessReceiveCallback(Message &          aMessage,
             Udp::Header udp;
 
             IgnoreError(aMessage.Read(aMessage.GetOffset(), udp));
-            VerifyOrExit(Get<Udp>().ShouldUsePlatformUdp(udp.GetDestinationPort()), error = kErrorNoRoute);
-
+            VerifyOrExit(Get<Udp>().ShouldUsePlatformUdp(udp.GetDestinationPort())
+                         && !Get<Udp>().IsPortInUse(udp.GetDestinationPort()), error = kErrorNoRoute);
             break;
         }
 

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -527,6 +527,25 @@ exit:
     return;
 }
 
+bool Udp::IsPortInUse(uint16_t aPort) const
+{
+    bool found = false;
+    for (const SocketHandle *socket = mSockets.GetHead(); socket != nullptr; socket = socket->GetNext())
+    {
+        if (socket->GetSockName().GetPort() == aPort)
+        {
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+            if (!IsBackboneSocket(*socket))
+#endif
+            {
+                found = true;
+            }
+            break;
+        }
+    }
+    return found;
+}
+
 bool Udp::ShouldUsePlatformUdp(uint16_t aPort) const
 {
     return (aPort != Mle::kUdpPort && aPort != Tmf::kUdpPort

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -574,6 +574,18 @@ public:
 #endif
 
     /**
+     * This method returns whether a udp port is being used by OpenThread or any of it's optional
+     * features, e.g. CoAP API.
+     *
+     * @param[in]   aPort       The udp port
+     *
+     * @retval True when port is used by the OpenThread
+     * @retval False when the port is not used by OpenThrad.
+     *
+     */
+    bool IsPortInUse(uint16_t aPort) const;
+
+    /**
      * This method returns whether a udp port belongs to the platform or the stack.
      *
      * @param[in]   aPort       The udp port


### PR DESCRIPTION
Second proposal for the solution  originating from PR #6545 - one to be selected and merged

If OpenThread is part of an OS with it's own IP stack filtering only
control messages is insufficien.
Example could be that if application is using OpenThread API to listen
for CoAP messages received messages are passed also to the IP callback.
The message then is delivered to the OS IP stack and generates error
response: "ICMPv6 Destination Unreachable (Port unreachable)" as the
port is not open on the OS side. OS IP stack is unaware of the
OpenThread existence so it can not be filtered on that level and the
shim layer does not receive port, or protocol information from OT so it
can not filter out a frame without parsing it first.
Extended filtering also to ports originating from OpenThread.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>