### PR TITLE
[posix] fix unused variable when log level is less than OT_LOG_LEVEL_CRIT

### DIFF
--- a/src/posix/platform/misc.cpp
+++ b/src/posix/platform/misc.cpp
@@ -78,7 +78,7 @@ otError otPlatSetMcuPowerState(otInstance *aInstance, otPlatMcuPowerState aState
 
 void otPlatAssertFail(const char *aFilename, int aLineNumber)
 {
-#if OPENTHREAD_CONFIG_LOG_LEVEL < OT_LOG_LEVEL_CRIT
+#if OPENTHREAD_CONFIG_LOG_PLATFORM && OPENTHREAD_CONFIG_LOG_LEVEL < OT_LOG_LEVEL_CRIT
     OT_UNUSED_VARIABLE(aFilename);
     OT_UNUSED_VARIABLE(aLineNumber);
 #else

--- a/src/posix/platform/misc.cpp
+++ b/src/posix/platform/misc.cpp
@@ -78,7 +78,12 @@ otError otPlatSetMcuPowerState(otInstance *aInstance, otPlatMcuPowerState aState
 
 void otPlatAssertFail(const char *aFilename, int aLineNumber)
 {
+#if OPENTHREAD_CONFIG_LOG_LEVEL < OT_LOG_LEVEL_CRIT
+    OT_UNUSED_VARIABLE(aFilename);
+    OT_UNUSED_VARIABLE(aLineNumber);
+#else
     otLogCritPlat("assert failed at %s:%d", aFilename, aLineNumber);
+#endif
     // For debug build, use assert to genreate a core dump
     assert(false);
     exit(1);


### PR DESCRIPTION
Encountered this problem while building POSIX stack with logging enabled.