### PR TITLE
[mac] always set Key Identifier for Transmit Security

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -328,9 +328,15 @@ void SubMac::ProcessTransmitSecurity(void)
     const ExtAddress *extAddress = nullptr;
     uint8_t           keyIdMode;
 
-    VerifyOrExit(ShouldHandleTransmitSecurity());
     VerifyOrExit(mTransmitFrame.GetSecurityEnabled());
     VerifyOrExit(!mTransmitFrame.IsSecurityProcessed());
+
+    if (!mTransmitFrame.IsARetransmission())
+    {
+        mTransmitFrame.SetKeyId(mKeyId);
+    }
+
+    VerifyOrExit(ShouldHandleTransmitSecurity());
 
     SuccessOrExit(mTransmitFrame.GetKeyIdMode(keyIdMode));
     VerifyOrExit(keyIdMode == Frame::kKeyIdMode1);
@@ -341,7 +347,6 @@ void SubMac::ProcessTransmitSecurity(void)
     {
         uint32_t frameCounter = GetFrameCounter();
 
-        mTransmitFrame.SetKeyId(mKeyId);
         mTransmitFrame.SetFrameCounter(frameCounter);
         UpdateFrameCounter(frameCounter + 1);
     }


### PR DESCRIPTION
For multi-layer application, the radio requires from the upper layer
to provide information for security processing like Key Identifier,
in the Auxiliary Security Header according to IEEE802.15.4-2015.

This change matters for handling security processing by radio only.