### PR TITLE
[ip6] fix message leak when using platform TCP

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -946,19 +946,13 @@ Error Ip6::HandlePayload(Message &          aMessage,
                          Message::Ownership aMessageOwnership)
 {
     Error    error   = kErrorNone;
-    Message *message = nullptr;
+    Message *message = (aMessageOwnership == Message::kTakeCustody) ? &aMessage : nullptr;
 
     VerifyOrExit(aIpProto == kProtoUdp || aIpProto == kProtoIcmp6);
 
-    switch (aMessageOwnership)
+    if (aMessageOwnership == Message::kCopyToUse)
     {
-    case Message::kTakeCustody:
-        message = &aMessage;
-        break;
-
-    case Message::kCopyToUse:
         VerifyOrExit((message = aMessage.Clone()) != nullptr, error = kErrorNoBufs);
-        break;
     }
 
     switch (aIpProto)


### PR DESCRIPTION
When using platform TCP, the `Ip6::HandlePayload` function will be called with `aIpProto = kProtoTcp` and `aMessageOwnerShip = kTakeCustody`.

 The `FreeMessage(message);` will be called with `message = nullptr` currently, causing the message to leak. This PR fixes this issue.