### PR TITLE
[cli] make OPENTHREAD_FTD and OPENTHREAD_MTD PUBLIC in cli library

### DIFF
--- a/src/cli/ftd.cmake
+++ b/src/cli/ftd.cmake
@@ -29,7 +29,7 @@
 add_library(openthread-cli-ftd)
 
 target_compile_definitions(openthread-cli-ftd
-    PRIVATE
+    PUBLIC
         OPENTHREAD_FTD=1
 )
 

--- a/src/cli/mtd.cmake
+++ b/src/cli/mtd.cmake
@@ -29,7 +29,7 @@
 add_library(openthread-cli-mtd)
 
 target_compile_definitions(openthread-cli-mtd
-    PRIVATE
+    PUBLIC
         OPENTHREAD_MTD=1
 )
 


### PR DESCRIPTION
The purpose is to make `OPENTHREAD_FTD` and `OPENTHREAD_MTD` available in `examples/apps/cli/main.c`

Fixes #6673 