### PR TITLE
[settings] simplify and enhance `Settings` (reuse similar patterns)

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -393,6 +393,7 @@ openthread_core_files = [
   "common/random_manager.hpp",
   "common/settings.cpp",
   "common/settings.hpp",
+  "common/settings_driver.hpp",
   "common/string.cpp",
   "common/string.hpp",
   "common/tasklet.cpp",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -399,6 +399,7 @@ HEADERS_COMMON                                  = \
     common/random.hpp                             \
     common/random_manager.hpp                     \
     common/settings.hpp                           \
+    common/settings_driver.hpp                    \
     common/string.hpp                             \
     common/tasklet.hpp                            \
     common/time.hpp                               \

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -125,7 +125,7 @@ Error RoutingManager::LoadOrGenerateRandomOmrPrefix(void)
 {
     Error error = kErrorNone;
 
-    if (Get<Settings>().ReadOmrPrefix(mLocalOmrPrefix) != kErrorNone || !IsValidOmrPrefix(mLocalOmrPrefix))
+    if (Get<Settings>().Read<Settings::OmrPrefix>(mLocalOmrPrefix) != kErrorNone || !IsValidOmrPrefix(mLocalOmrPrefix))
     {
         Ip6::NetworkPrefix randomOmrPrefix;
 
@@ -139,7 +139,7 @@ Error RoutingManager::LoadOrGenerateRandomOmrPrefix(void)
         }
 
         mLocalOmrPrefix.Set(randomOmrPrefix);
-        IgnoreError(Get<Settings>().SaveOmrPrefix(mLocalOmrPrefix));
+        IgnoreError(Get<Settings>().Save<Settings::OmrPrefix>(mLocalOmrPrefix));
     }
 
 exit:
@@ -150,7 +150,8 @@ Error RoutingManager::LoadOrGenerateRandomOnLinkPrefix(void)
 {
     Error error = kErrorNone;
 
-    if (Get<Settings>().ReadOnLinkPrefix(mLocalOnLinkPrefix) != kErrorNone || !IsValidOnLinkPrefix(mLocalOnLinkPrefix))
+    if (Get<Settings>().Read<Settings::OnLinkPrefix>(mLocalOnLinkPrefix) != kErrorNone ||
+        !IsValidOnLinkPrefix(mLocalOnLinkPrefix))
     {
         Ip6::NetworkPrefix randomOnLinkPrefix;
 
@@ -167,7 +168,7 @@ Error RoutingManager::LoadOrGenerateRandomOnLinkPrefix(void)
         randomOnLinkPrefix.m8[7] = 0;
         mLocalOnLinkPrefix.Set(randomOnLinkPrefix);
 
-        IgnoreError(Get<Settings>().SaveOnLinkPrefix(mLocalOnLinkPrefix));
+        IgnoreError(Get<Settings>().Save<Settings::OnLinkPrefix>(mLocalOnLinkPrefix));
     }
 
 exit:

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -33,8 +33,6 @@
 
 #include "settings.hpp"
 
-#include <openthread/platform/settings.h>
-
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
@@ -43,175 +41,145 @@
 #include "thread/mle.hpp"
 
 namespace ot {
-// This array contains critical keys that should be stored in the secure area.
-static const uint16_t kCriticalKeys[] = {SettingsBase::kKeyActiveDataset, SettingsBase::kKeyPendingDataset,
-                                         SettingsBase::kKeySrpEcdsaKey};
+
+//---------------------------------------------------------------------------------------------------------------------
+// SettingsBase
 
 // LCOV_EXCL_START
 
-#if (OPENTHREAD_CONFIG_LOG_UTIL != 0)
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO)
+#if OPENTHREAD_CONFIG_LOG_UTIL && (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO)
 
-void SettingsBase::LogNetworkInfo(const char *aAction, const NetworkInfo &aNetworkInfo) const
+void SettingsBase::NetworkInfo::Log(Action aAction) const
 {
     otLogInfoCore(
-        "Non-volatile: %s NetworkInfo {rloc:0x%04x, extaddr:%s, role:%s, mode:0x%02x, version:%hu, keyseq:0x%x, ...",
-        aAction, aNetworkInfo.GetRloc16(), aNetworkInfo.GetExtAddress().ToString().AsCString(),
-        Mle::Mle::RoleToString(static_cast<Mle::DeviceRole>(aNetworkInfo.GetRole())), aNetworkInfo.GetDeviceMode(),
-        aNetworkInfo.GetVersion(), aNetworkInfo.GetKeySequence());
+        "[settings] %s NetworkInfo {rloc:0x%04x, extaddr:%s, role:%s, mode:0x%02x, version:%hu, keyseq:0x%x, ...",
+        ActionToString(aAction), GetRloc16(), GetExtAddress().ToString().AsCString(),
+        Mle::Mle::RoleToString(static_cast<Mle::DeviceRole>(GetRole())), GetDeviceMode(), GetVersion(),
+        GetKeySequence());
 
-    otLogInfoCore("Non-volatile: ... pid:0x%x, mlecntr:0x%x, maccntr:0x%x, mliid:%s}",
-                  aNetworkInfo.GetPreviousPartitionId(), aNetworkInfo.GetMleFrameCounter(),
-                  aNetworkInfo.GetMacFrameCounter(), aNetworkInfo.GetMeshLocalIid().ToString().AsCString());
+    otLogInfoCore("[settings] ... pid:0x%x, mlecntr:0x%x, maccntr:0x%x, mliid:%s}", GetPreviousPartitionId(),
+                  GetMleFrameCounter(), GetMacFrameCounter(), GetMeshLocalIid().ToString().AsCString());
 }
 
-void SettingsBase::LogParentInfo(const char *aAction, const ParentInfo &aParentInfo) const
+void SettingsBase::ParentInfo::Log(Action aAction) const
 {
-    otLogInfoCore("Non-volatile: %s ParentInfo {extaddr:%s, version:%hu}", aAction,
-                  aParentInfo.GetExtAddress().ToString().AsCString(), aParentInfo.GetVersion());
+    otLogInfoCore("[settings] %s ParentInfo {extaddr:%s, version:%hu}", ActionToString(aAction),
+                  GetExtAddress().ToString().AsCString(), GetVersion());
 }
 
-void SettingsBase::LogChildInfo(const char *aAction, const ChildInfo &aChildInfo) const
+#if OPENTHREAD_FTD
+void SettingsBase::ChildInfo::Log(Action aAction) const
 {
-    otLogInfoCore("Non-volatile: %s ChildInfo {rloc:0x%04x, extaddr:%s, timeout:%u, mode:0x%02x, version:%hu}", aAction,
-                  aChildInfo.GetRloc16(), aChildInfo.GetExtAddress().ToString().AsCString(), aChildInfo.GetTimeout(),
-                  aChildInfo.GetMode(), aChildInfo.GetVersion());
-}
-
-#if OPENTHREAD_CONFIG_DUA_ENABLE
-void SettingsBase::LogDadInfo(const char *aAction, const DadInfo &aDadInfo) const
-{
-    otLogInfoCore("Non-volatile: %s DadInfo {DadCounter:%2d}", aAction, aDadInfo.GetDadCounter());
+    otLogInfoCore("[settings] %s ChildInfo {rloc:0x%04x, extaddr:%s, timeout:%u, mode:0x%02x, version:%hu}",
+                  ActionToString(aAction), GetRloc16(), GetExtAddress().ToString().AsCString(), GetTimeout(), GetMode(),
+                  GetVersion());
 }
 #endif
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-void SettingsBase::LogPrefix(const char *aAction, const char *aPrefixName, const Ip6::Prefix &aOmrPrefix) const
+
+#if OPENTHREAD_CONFIG_DUA_ENABLE
+void SettingsBase::DadInfo::Log(Action aAction) const
 {
-    otLogInfoCore("Non-volatile: %s %s %s", aAction, aPrefixName, aOmrPrefix.ToString().AsCString());
+    otLogInfoCore("[settings] %s DadInfo {DadCounter:%2d}", ActionToString(aAction), GetDadCounter());
+}
+#endif
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+void SettingsBase::LogPrefix(Action aAction, Key aKey, const Ip6::Prefix &aPrefix)
+{
+    otLogInfoCore("[settings] %s %s %s", ActionToString(aAction), KeyToString(aKey), aPrefix.ToString().AsCString());
 }
 #endif
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE && OPENTHREAD_CONFIG_SRP_CLIENT_SAVE_SELECTED_SERVER_ENABLE
-void SettingsBase::LogSrpClientInfo(const char *aAction, const SrpClientInfo &aSrpClientInfo) const
+void SettingsBase::SrpClientInfo::Log(Action aAction) const
 {
-    otLogInfoCore("Non-volatile: %s SrpClientInfo {Server:[%s]:%u}", aAction,
-                  aSrpClientInfo.GetServerAddress().ToString().AsCString(), aSrpClientInfo.GetServerPort());
+    otLogInfoCore("[settings] %s SrpClientInfo {Server:[%s]:%u}", ActionToString(aAction),
+                  GetServerAddress().ToString().AsCString(), GetServerPort());
 }
 #endif
 
-#endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO)
+#endif // OPENTHREAD_CONFIG_LOG_UTIL && (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO)
 
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN)
-
-void SettingsBase::LogFailure(Error error, const char *aText, bool aIsDelete) const
+#if OPENTHREAD_CONFIG_LOG_UTIL && (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN)
+const char *SettingsBase::ActionToString(Action aAction)
 {
-    if ((error != kErrorNone) && (!aIsDelete || (error != kErrorNotFound)))
-    {
-        otLogWarnCore("Non-volatile: Error %s %s", ErrorToString(error), aText);
-    }
-}
+    static const char *const kActionStrings[] = {
+        "Read",     // (0) kActionRead
+        "Saved",    // (1) kActionSave
+        "Re-saved", // (2) kActionResave
+        "Deleted",  // (3) kActionDelete
+#if OPENTHREAD_FTD
+        "Added",      // (4) kActionAdd,
+        "Removed",    // (5) kActionRemove,
+        "Deleted all" // (6) kActionDeleteAll
+#endif
+    };
 
-#endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN)
-#endif // #if (OPENTHREAD_CONFIG_LOG_UTIL != 0)
+    static_assert(0 == kActionRead, "kActionRead value is incorrect");
+    static_assert(1 == kActionSave, "kActionSave value is incorrect");
+    static_assert(2 == kActionResave, "kActionResave value is incorrect");
+    static_assert(3 == kActionDelete, "kActionDelete value is incorrect");
+#if OPENTHREAD_FTD
+    static_assert(4 == kActionAdd, "kActionAdd value is incorrect");
+    static_assert(5 == kActionRemove, "kActionRemove value is incorrect");
+    static_assert(6 == kActionDeleteAll, "kActionDeleteAll value is incorrect");
+#endif
+
+    return kActionStrings[aAction];
+}
+#endif // OPENTHREAD_CONFIG_LOG_UTIL && (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN)
+
+#if OPENTHREAD_CONFIG_LOG_UTIL && (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO)
+const char *SettingsBase::KeyToString(Key aKey)
+{
+    static const char *const kKeyStrings[] = {
+        "",                  // (0)  (Unused)
+        "ActiveDataset",     // (1)  kKeyActiveDataset
+        "PendingDataset",    // (2)  kKeyPendingDataset
+        "NetworkInfo",       // (3)  kKeyNetworkInfo
+        "ParentInfo",        // (4)  kKeyParentInfo
+        "ChildInfo",         // (5)  kKeyChildInfo
+        "",                  // (6)  kKeyReserved
+        "SlaacIidSecretKey", // (7)  kKeySlaacIidSecretKey
+        "DadInfo",           // (8)  kKeyDadInfo
+        "OmrPrefix",         // (9)  kKeyOmrPrefix
+        "OnLinkPrefix",      // (10) kKeyOnLinkPrefix
+        "SrpEcdsaKey",       // (11) kKeySrpEcdsaKey
+        "SrpClientInfo",     // (12) kKeySrpClientInfo
+    };
+
+    static_assert(1 == kKeyActiveDataset, "kKeyActiveDataset value is incorrect");
+    static_assert(2 == kKeyPendingDataset, "kKeyPendingDataset value is incorrect");
+    static_assert(3 == kKeyNetworkInfo, "kKeyNetworkInfo value is incorrect");
+    static_assert(4 == kKeyParentInfo, "kKeyParentInfo value is incorrect");
+    static_assert(5 == kKeyChildInfo, "kKeyChildInfo value is incorrect");
+    static_assert(6 == kKeyReserved, "kKeyReserved value is incorrect");
+    static_assert(7 == kKeySlaacIidSecretKey, "kKeySlaacIidSecretKey value is incorrect");
+    static_assert(8 == kKeyDadInfo, "kKeyDadInfo value is incorrect");
+    static_assert(9 == kKeyOmrPrefix, "kKeyOmrPrefix value is incorrect");
+    static_assert(10 == kKeyOnLinkPrefix, "kKeyOnLinkPrefix value is incorrect");
+    static_assert(11 == kKeySrpEcdsaKey, "kKeySrpEcdsaKey value is incorrect");
+    static_assert(12 == kKeySrpClientInfo, "kKeySrpClientInfo value is incorrect");
+
+    static_assert(kLastKey == kKeySrpClientInfo, "kLastKey is not valid");
+
+    OT_ASSERT(aKey <= kLastKey);
+
+    return kKeyStrings[aKey];
+}
+#endif // OPENTHREAD_CONFIG_LOG_UTIL && (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO)
 
 // LCOV_EXCL_STOP
 
-#if !OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+//---------------------------------------------------------------------------------------------------------------------
+// Settings
 
-SettingsDriver::SettingsDriver(Instance &aInstance)
-    : InstanceLocator(aInstance)
-{
-}
-
-void SettingsDriver::Init(void)
-{
-    otPlatSettingsInit(&GetInstance());
-}
-
-void SettingsDriver::Deinit(void)
-{
-    otPlatSettingsDeinit(&GetInstance());
-}
-
-void SettingsDriver::SetCriticalKeys(const uint16_t *aKeys, uint16_t aKeysLength)
-{
-    otPlatSettingsSetCriticalKeys(&GetInstance(), aKeys, aKeysLength);
-}
-
-Error SettingsDriver::Add(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
-{
-    return otPlatSettingsAdd(&GetInstance(), aKey, aValue, aValueLength);
-}
-
-Error SettingsDriver::Delete(uint16_t aKey, int aIndex)
-{
-    return otPlatSettingsDelete(&GetInstance(), aKey, aIndex);
-}
-
-Error SettingsDriver::Get(uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength) const
-{
-    return otPlatSettingsGet(&GetInstance(), aKey, aIndex, aValue, aValueLength);
-}
-
-Error SettingsDriver::Set(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
-{
-    return otPlatSettingsSet(&GetInstance(), aKey, aValue, aValueLength);
-}
-
-void SettingsDriver::Wipe(void)
-{
-    otPlatSettingsWipe(&GetInstance());
-}
-
-#else // !OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
-
-SettingsDriver::SettingsDriver(Instance &aInstance)
-    : InstanceLocator(aInstance)
-    , mFlash(aInstance)
-{
-}
-
-void SettingsDriver::Init(void)
-{
-    mFlash.Init();
-}
-
-void SettingsDriver::Deinit(void)
-{
-}
-
-void SettingsDriver::SetCriticalKeys(const uint16_t *aKeys, uint16_t aKeysLength)
-{
-    OT_UNUSED_VARIABLE(aKeys);
-    OT_UNUSED_VARIABLE(aKeysLength);
-}
-
-Error SettingsDriver::Add(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
-{
-    return mFlash.Add(aKey, aValue, aValueLength);
-}
-
-Error SettingsDriver::Delete(uint16_t aKey, int aIndex)
-{
-    return mFlash.Delete(aKey, aIndex);
-}
-
-Error SettingsDriver::Get(uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength) const
-{
-    return mFlash.Get(aKey, aIndex, aValue, aValueLength);
-}
-
-Error SettingsDriver::Set(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
-{
-    return mFlash.Set(aKey, aValue, aValueLength);
-}
-
-void SettingsDriver::Wipe(void)
-{
-    mFlash.Wipe();
-}
-
-#endif // !OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+// This array contains critical keys that should be stored in the secure area.
+const uint16_t Settings::kCriticalKeys[] = {
+    SettingsBase::kKeyActiveDataset,
+    SettingsBase::kKeyPendingDataset,
+    SettingsBase::kKeySrpEcdsaKey,
+};
 
 void Settings::Init(void)
 {
@@ -227,14 +195,16 @@ void Settings::Deinit(void)
 void Settings::Wipe(void)
 {
     Get<SettingsDriver>().Wipe();
-    otLogInfoCore("Non-volatile: Wiped all info");
+    otLogInfoCore("[settings] Wiped all info");
 }
 
 Error Settings::SaveOperationalDataset(bool aIsActive, const MeshCoP::Dataset &aDataset)
 {
-    Error error = Save(aIsActive ? kKeyActiveDataset : kKeyPendingDataset, aDataset.GetBytes(), aDataset.GetSize());
+    Key   key   = (aIsActive ? kKeyActiveDataset : kKeyPendingDataset);
+    Error error = Get<SettingsDriver>().Set(key, aDataset.GetBytes(), aDataset.GetSize());
 
-    LogFailure(error, "saving OperationalDataset", false);
+    Log(kActionSave, error, key);
+
     return error;
 }
 
@@ -243,7 +213,8 @@ Error Settings::ReadOperationalDataset(bool aIsActive, MeshCoP::Dataset &aDatase
     Error    error  = kErrorNone;
     uint16_t length = MeshCoP::Dataset::kMaxSize;
 
-    SuccessOrExit(error = Read(aIsActive ? kKeyActiveDataset : kKeyPendingDataset, aDataset.GetBytes(), length));
+    SuccessOrExit(error = Get<SettingsDriver>().Get(aIsActive ? kKeyActiveDataset : kKeyPendingDataset,
+                                                    aDataset.GetBytes(), &length));
     VerifyOrExit(length <= MeshCoP::Dataset::kMaxSize, error = kErrorNotFound);
 
     aDataset.SetSize(length);
@@ -254,126 +225,30 @@ exit:
 
 Error Settings::DeleteOperationalDataset(bool aIsActive)
 {
-    Error error = Delete(aIsActive ? kKeyActiveDataset : kKeyPendingDataset);
+    Key   key   = (aIsActive ? kKeyActiveDataset : kKeyPendingDataset);
+    Error error = Get<SettingsDriver>().Delete(key);
 
-    LogFailure(error, "deleting OperationalDataset", true);
+    Log(kActionDelete, error, key);
 
     return error;
 }
 
-Error Settings::ReadNetworkInfo(NetworkInfo &aNetworkInfo) const
-{
-    Error    error;
-    uint16_t length = sizeof(NetworkInfo);
-
-    aNetworkInfo.Init();
-    SuccessOrExit(error = Read(kKeyNetworkInfo, &aNetworkInfo, length));
-    LogNetworkInfo("Read", aNetworkInfo);
-
-exit:
-    return error;
-}
-
-Error Settings::SaveNetworkInfo(const NetworkInfo &aNetworkInfo)
-{
-    Error       error = kErrorNone;
-    NetworkInfo prevNetworkInfo;
-    uint16_t    length = sizeof(prevNetworkInfo);
-
-    if ((Read(kKeyNetworkInfo, &prevNetworkInfo, length) == kErrorNone) && (length == sizeof(NetworkInfo)) &&
-        (prevNetworkInfo == aNetworkInfo))
-    {
-        LogNetworkInfo("Re-saved", aNetworkInfo);
-        ExitNow();
-    }
-
-    SuccessOrExit(error = Save(kKeyNetworkInfo, &aNetworkInfo, sizeof(NetworkInfo)));
-    LogNetworkInfo("Saved", aNetworkInfo);
-
-exit:
-    LogFailure(error, "saving NetworkInfo", false);
-    return error;
-}
-
-Error Settings::DeleteNetworkInfo(void)
-{
-    Error error;
-
-    SuccessOrExit(error = Delete(kKeyNetworkInfo));
-    otLogInfoCore("Non-volatile: Deleted NetworkInfo");
-
-exit:
-    LogFailure(error, "deleting NetworkInfo", true);
-    return error;
-}
-
-Error Settings::ReadParentInfo(ParentInfo &aParentInfo) const
-{
-    Error    error;
-    uint16_t length = sizeof(ParentInfo);
-
-    aParentInfo.Init();
-    SuccessOrExit(error = Read(kKeyParentInfo, &aParentInfo, length));
-    LogParentInfo("Read", aParentInfo);
-
-exit:
-    return error;
-}
-
-Error Settings::SaveParentInfo(const ParentInfo &aParentInfo)
-{
-    Error      error = kErrorNone;
-    ParentInfo prevParentInfo;
-    uint16_t   length = sizeof(ParentInfo);
-
-    if ((Read(kKeyParentInfo, &prevParentInfo, length) == kErrorNone) && (length == sizeof(ParentInfo)) &&
-        (prevParentInfo == aParentInfo))
-    {
-        LogParentInfo("Re-saved", aParentInfo);
-        ExitNow();
-    }
-
-    SuccessOrExit(error = Save(kKeyParentInfo, &aParentInfo, sizeof(ParentInfo)));
-    LogParentInfo("Saved", aParentInfo);
-
-exit:
-    LogFailure(error, "saving ParentInfo", false);
-    return error;
-}
-
-Error Settings::DeleteParentInfo(void)
-{
-    Error error;
-
-    SuccessOrExit(error = Delete(kKeyParentInfo));
-    otLogInfoCore("Non-volatile: Deleted ParentInfo");
-
-exit:
-    LogFailure(error, "deleting ParentInfo", true);
-    return error;
-}
-
+#if OPENTHREAD_FTD
 Error Settings::AddChildInfo(const ChildInfo &aChildInfo)
 {
-    Error error;
+    Error error = Get<SettingsDriver>().Add(kKeyChildInfo, &aChildInfo, sizeof(aChildInfo));
 
-    SuccessOrExit(error = Add(kKeyChildInfo, &aChildInfo, sizeof(aChildInfo)));
-    LogChildInfo("Added", aChildInfo);
+    Log(kActionAdd, error, kKeyChildInfo, &aChildInfo);
 
-exit:
-    LogFailure(error, "adding ChildInfo", false);
     return error;
 }
 
 Error Settings::DeleteAllChildInfo(void)
 {
-    Error error;
+    Error error = Get<SettingsDriver>().Delete(kKeyChildInfo);
 
-    SuccessOrExit(error = Delete(kKeyChildInfo));
-    otLogInfoCore("Non-volatile: Deleted all ChildInfo");
+    Log(kActionDeleteAll, error, kKeyChildInfo);
 
-exit:
-    LogFailure(error, "deleting all ChildInfo", true);
     return error;
 }
 
@@ -400,10 +275,9 @@ Error Settings::ChildInfoIterator::Delete(void)
 
     VerifyOrExit(!mIsDone, error = kErrorInvalidState);
     SuccessOrExit(error = Get<SettingsDriver>().Delete(kKeyChildInfo, mIndex));
-    LogChildInfo("Removed", mChildInfo);
 
 exit:
-    LogFailure(error, "removing ChildInfo entry", true);
+    Log(kActionRemove, error, kKeyChildInfo, &mChildInfo);
     return error;
 }
 
@@ -415,239 +289,169 @@ void Settings::ChildInfoIterator::Read(void)
     mChildInfo.Init();
     SuccessOrExit(
         error = Get<SettingsDriver>().Get(kKeyChildInfo, mIndex, reinterpret_cast<uint8_t *>(&mChildInfo), &length));
-    LogChildInfo("Read", mChildInfo);
 
 exit:
+    Log(kActionRead, error, kKeyChildInfo, &mChildInfo);
     mIsDone = (error != kErrorNone);
 }
+#endif // OPENTHREAD_FTD
+
+Error Settings::ReadEntry(Key aKey, void *aValue, uint16_t aMaxLength) const
+{
+    Error    error;
+    uint16_t length = aMaxLength;
+
+    error = Get<SettingsDriver>().Get(aKey, aValue, &length);
+    Log(kActionRead, error, aKey, aValue);
+
+    return error;
+}
+
+Error Settings::SaveEntry(Key aKey, const void *aValue, void *aPrev, uint16_t aLength)
+{
+    Error    error      = kErrorNone;
+    uint16_t readLength = aLength;
+    Action   action     = kActionSave;
+
+    if ((Get<SettingsDriver>().Get(aKey, aPrev, &readLength) == kErrorNone) && (readLength == aLength) &&
+        (memcmp(aValue, aPrev, aLength) == 0))
+    {
+        action = kActionResave;
+    }
+    else
+    {
+        error = Get<SettingsDriver>().Set(aKey, aValue, aLength);
+    }
+
+    Log(action, error, aKey, aValue);
+
+    return error;
+}
+
+Error Settings::DeleteEntry(Key aKey)
+{
+    Error error = Get<SettingsDriver>().Delete(aKey);
+
+    Log(kActionDelete, error, aKey);
+
+    return error;
+}
+
+void Settings::Log(Action aAction, Error aError, Key aKey, const void *aValue)
+{
+    OT_UNUSED_VARIABLE(aAction);
+    OT_UNUSED_VARIABLE(aKey);
+    OT_UNUSED_VARIABLE(aError);
+    OT_UNUSED_VARIABLE(aValue);
+
+#if OPENTHREAD_CONFIG_LOG_UTIL
+
+    if (aError != kErrorNone)
+    {
+        // Log error if log level is at "warn" or higher.
+
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN)
+        const char *actionText = "";
+
+        switch (aAction)
+        {
+        case kActionSave:
+        case kActionResave:
+            actionText = "saving";
+            break;
+
+        case kActionDelete:
+            VerifyOrExit(aError != kErrorNotFound);
+            actionText = "deleting";
+            break;
+
+#if OPENTHREAD_FTD
+        case kActionAdd:
+            actionText = "adding";
+            break;
+
+        case kActionRemove:
+            VerifyOrExit(aError != kErrorNotFound);
+            actionText = "removing";
+            break;
+
+        case kActionDeleteAll:
+            VerifyOrExit(aError != kErrorNotFound);
+            actionText = "deleting all";
+            break;
+#endif
+        case kActionRead:
+            ExitNow();
+        }
+
+        otLogWarnCore("[settings] Error %s %s %s", ErrorToString(aError), actionText, KeyToString(aKey));
+
+#endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN)
+
+        ExitNow();
+    }
+
+    // We reach here when `aError` is `kErrorNone`.
+    // Log success if log level is at "info" or higher.
+
+#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO)
+    if (aValue != nullptr)
+    {
+        switch (aKey)
+        {
+        case kKeyNetworkInfo:
+            reinterpret_cast<const NetworkInfo *>(aValue)->Log(aAction);
+            break;
+
+        case kKeyParentInfo:
+            reinterpret_cast<const ParentInfo *>(aValue)->Log(aAction);
+            break;
+
+#if OPENTHREAD_FTD
+        case kKeyChildInfo:
+            reinterpret_cast<const ChildInfo *>(aValue)->Log(aAction);
+            break;
+#endif
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
-Error Settings::ReadDadInfo(DadInfo &aDadInfo) const
-{
-    Error    error;
-    uint16_t length = sizeof(DadInfo);
-
-    aDadInfo.Init();
-    SuccessOrExit(error = Read(kKeyDadInfo, &aDadInfo, length));
-    LogDadInfo("Read", aDadInfo);
-
-exit:
-    return error;
-}
-
-Error Settings::SaveDadInfo(const DadInfo &aDadInfo)
-{
-    Error    error = kErrorNone;
-    DadInfo  prevDadInfo;
-    uint16_t length = sizeof(DadInfo);
-
-    if ((Read(kKeyDadInfo, &prevDadInfo, length) == kErrorNone) && (length == sizeof(DadInfo)) &&
-        (prevDadInfo == aDadInfo))
-    {
-        LogDadInfo("Re-saved", aDadInfo);
-        ExitNow();
-    }
-
-    SuccessOrExit(error = Save(kKeyDadInfo, &aDadInfo, sizeof(DadInfo)));
-    LogDadInfo("Saved", aDadInfo);
-
-exit:
-    LogFailure(error, "saving DadInfo", false);
-    return error;
-}
-
-Error Settings::DeleteDadInfo(void)
-{
-    Error error;
-
-    SuccessOrExit(error = Delete(kKeyDadInfo));
-    otLogInfoCore("Non-volatile: Deleted DadInfo");
-
-exit:
-    LogFailure(error, "deleting DadInfo", true);
-    return error;
-}
-#endif // OPENTHREAD_CONFIG_DUA_ENABLE
+        case kKeyDadInfo:
+            reinterpret_cast<const DadInfo *>(aValue)->Log(aAction);
+            break;
+#endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-Error Settings::SaveOmrPrefix(const Ip6::Prefix &aOmrPrefix)
-{
-    Error       error = kErrorNone;
-    Ip6::Prefix prevOmrPrefix;
-    uint16_t    length = sizeof(prevOmrPrefix);
+        case kKeyOmrPrefix:
+        case kKeyOnLinkPrefix:
+            LogPrefix(aAction, aKey, *reinterpret_cast<const Ip6::Prefix *>(aValue));
+            break;
+#endif
 
-    if ((Read(kKeyOmrPrefix, &prevOmrPrefix, length) == kErrorNone) && (length == sizeof(prevOmrPrefix)) &&
-        (prevOmrPrefix == aOmrPrefix))
-    {
-        LogPrefix("Re-saved", "OMR prefix", aOmrPrefix);
-        ExitNow();
+#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE && OPENTHREAD_CONFIG_SRP_CLIENT_SAVE_SELECTED_SERVER_ENABLE
+        case kKeySrpClientInfo:
+            reinterpret_cast<const SrpClientInfo *>(aValue)->Log(aAction);
+            break;
+#endif
+
+        default:
+            // For any other keys, we do not want to include the value
+            // in the log, so even if it is given we set `aValue` to
+            // `nullptr`. This ensures that we just log the action and
+            // the key.
+            aValue = nullptr;
+            break;
+        }
     }
 
-    SuccessOrExit(error = Save(kKeyOmrPrefix, &aOmrPrefix, sizeof(aOmrPrefix)));
-    LogPrefix("Saved", "OMR prefix", aOmrPrefix);
-
-exit:
-    LogFailure(error, "saving OMR prefix", false);
-    return error;
-}
-
-Error Settings::ReadOmrPrefix(Ip6::Prefix &aOmrPrefix) const
-{
-    Error    error;
-    uint16_t length = sizeof(aOmrPrefix);
-
-    aOmrPrefix.Clear();
-    SuccessOrExit(error = Read(kKeyOmrPrefix, &aOmrPrefix, length));
-    LogPrefix("Read", "OMR prefix", aOmrPrefix);
-
-exit:
-    return error;
-}
-
-Error Settings::SaveOnLinkPrefix(const Ip6::Prefix &aOnLinkPrefix)
-{
-    Error       error = kErrorNone;
-    Ip6::Prefix prevOnLinkPrefix;
-    uint16_t    length = sizeof(prevOnLinkPrefix);
-
-    if ((Read(kKeyOnLinkPrefix, &prevOnLinkPrefix, length) == kErrorNone) && (length == sizeof(prevOnLinkPrefix)) &&
-        (prevOnLinkPrefix == aOnLinkPrefix))
+    if (aValue == nullptr)
     {
-        LogPrefix("Re-saved", "on-link prefix", aOnLinkPrefix);
-        ExitNow();
+        otLogInfoCore("[settings] %s %s", ActionToString(aAction), KeyToString(aKey));
     }
-
-    SuccessOrExit(error = Save(kKeyOnLinkPrefix, &aOnLinkPrefix, sizeof(aOnLinkPrefix)));
-    LogPrefix("Saved", "on-link prefix", aOnLinkPrefix);
+#endif // (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO)
 
 exit:
-    LogFailure(error, "saving on-link prefix", false);
-    return error;
-}
 
-Error Settings::ReadOnLinkPrefix(Ip6::Prefix &aOnLinkPrefix) const
-{
-    Error    error;
-    uint16_t length = sizeof(aOnLinkPrefix);
-
-    aOnLinkPrefix.Clear();
-    SuccessOrExit(error = Read(kKeyOnLinkPrefix, &aOnLinkPrefix, length));
-    LogPrefix("Read", "on-link prefix", aOnLinkPrefix);
-
-exit:
-    return error;
-}
-#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-
-#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
-
-Error Settings::SaveSrpKey(const Crypto::Ecdsa::P256::KeyPair &aKeyPair)
-{
-    Error error = kErrorNone;
-
-    SuccessOrExit(error = Save(kKeySrpEcdsaKey, aKeyPair.GetDerBytes(), aKeyPair.GetDerLength()));
-    otLogInfoCore("Non-volatile: Saved SRP key");
-
-exit:
-    LogFailure(error, "saving SRP key", false);
-    return error;
-}
-
-Error Settings::ReadSrpKey(Crypto::Ecdsa::P256::KeyPair &aKeyPair) const
-{
-    Error    error;
-    uint16_t length = Crypto::Ecdsa::P256::KeyPair::kMaxDerSize;
-
-    SuccessOrExit(error = Read(kKeySrpEcdsaKey, aKeyPair.GetDerBytes(), length));
-    VerifyOrExit(length <= Crypto::Ecdsa::P256::KeyPair::kMaxDerSize, error = kErrorNotFound);
-    aKeyPair.SetDerLength(static_cast<uint8_t>(length));
-    otLogInfoCore("Non-volatile: Read SRP key");
-
-exit:
-    return error;
-}
-
-Error Settings::DeleteSrpKey(void)
-{
-    Error error;
-
-    SuccessOrExit(error = Delete(kKeySrpEcdsaKey));
-    otLogInfoCore("Non-volatile: Deleted SRP key");
-
-exit:
-    LogFailure(error, "deleting SRP key", true);
-    return error;
-}
-
-#if OPENTHREAD_CONFIG_SRP_CLIENT_SAVE_SELECTED_SERVER_ENABLE
-
-Error Settings::SaveSrpClientInfo(const SrpClientInfo &aSrpClientInfo)
-{
-    Error         error = kErrorNone;
-    SrpClientInfo prevInfo;
-    uint16_t      length = sizeof(SrpClientInfo);
-
-    if ((Read(kKeySrpClientInfo, &prevInfo, length) == kErrorNone) && (length == sizeof(SrpClientInfo)) &&
-        (prevInfo == aSrpClientInfo))
-    {
-        LogSrpClientInfo("Re-saved", aSrpClientInfo);
-        ExitNow();
-    }
-
-    SuccessOrExit(error = Save(kKeySrpClientInfo, &aSrpClientInfo, sizeof(SrpClientInfo)));
-    LogSrpClientInfo("Saved", aSrpClientInfo);
-
-exit:
-    LogFailure(error, "saving SrpClientInfo", /* aIsDelete */ false);
-    return error;
-}
-
-Error Settings::ReadSrpClientInfo(SrpClientInfo &aSrpClientInfo) const
-{
-    Error    error;
-    uint16_t length = sizeof(SrpClientInfo);
-
-    aSrpClientInfo.Init();
-    SuccessOrExit(error = Read(kKeySrpClientInfo, &aSrpClientInfo, length));
-    LogSrpClientInfo("Read", aSrpClientInfo);
-
-exit:
-    return error;
-}
-
-Error Settings::DeleteSrpClientInfo(void)
-{
-    Error error;
-
-    SuccessOrExit(error = Delete(kKeySrpClientInfo));
-    otLogInfoCore("Non-volatile: Deleted SrpClientInfo");
-
-exit:
-    LogFailure(error, "deleting SrpClientInfo", true);
-    return error;
-}
-
-#endif // OPENTHREAD_CONFIG_SRP_CLIENT_SAVE_SELECTED_SERVER_ENABLE
-#endif // OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
-
-Error Settings::Read(Key aKey, void *aBuffer, uint16_t &aSize) const
-{
-    return Get<SettingsDriver>().Get(aKey, 0, reinterpret_cast<uint8_t *>(aBuffer), &aSize);
-}
-
-Error Settings::Save(Key aKey, const void *aValue, uint16_t aSize)
-{
-    return Get<SettingsDriver>().Set(aKey, reinterpret_cast<const uint8_t *>(aValue), aSize);
-}
-
-Error Settings::Add(Key aKey, const void *aValue, uint16_t aSize)
-{
-    return Get<SettingsDriver>().Add(aKey, reinterpret_cast<const uint8_t *>(aValue), aSize);
-}
-
-Error Settings::Delete(Key aKey)
-{
-    return Get<SettingsDriver>().Delete(aKey, -1);
+#endif // OPENTHREAD_CONFIG_LOG_UTIL
+    return;
 }
 
 } // namespace ot

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -43,6 +43,7 @@
 #include "common/equatable.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
+#include "common/settings_driver.hpp"
 #include "mac/mac_types.hpp"
 #include "net/ip6_address.hpp"
 #include "utils/flash.hpp"
@@ -59,109 +60,7 @@ namespace MeshCoP {
 class Dataset;
 }
 
-class SettingsDriver : public InstanceLocator, private NonCopyable
-{
-public:
-    /**
-     * Constructor.
-     */
-    explicit SettingsDriver(Instance &aInstance);
-
-    /**
-     * This method initializes the settings storage driver.
-     *
-     */
-    void Init(void);
-
-    /**
-     * This method deinitializes the settings driver.
-     *
-     */
-    void Deinit(void);
-
-    /**
-     * This method sets the critical keys that should be stored in a secure area.
-     *
-     * @param[in]  aKeys        A pointer to an array containing the list of critical keys.
-     * @param[in]  aKeysLength  The number of entries in the @p aKeys array.
-     *
-     */
-    void SetCriticalKeys(const uint16_t *aKeys, uint16_t aKeysLength);
-
-    /**
-     * This method adds a value to @p aKey.
-     *
-     * @param[in]  aKey          The key associated with the value.
-     * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
-     *                           MUST NOT be nullptr if @p aValueLength is non-zero.
-     * @param[in]  aValueLength  The length of the data pointed to by @p aValue. May be zero.
-     *
-     * @retval kErrorNone     The value was added.
-     * @retval kErrorNoBufs   Not enough space to store the value.
-     *
-     */
-    Error Add(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
-
-    /**
-     * This method removes a value from @p aKey.
-     *
-     * @param[in] aKey    The key associated with the value.
-     * @param[in] aIndex  The index of the value to be removed.
-     *                    If set to -1, all values for @p aKey will be removed.
-     *
-     * @retval kErrorNone       The given key and index was found and removed successfully.
-     * @retval kErrorNotFound   The given key or index was not found.
-     *
-     */
-    Error Delete(uint16_t aKey, int aIndex);
-
-    /**
-     * This method fetches the value identified by @p aKey.
-     *
-     * @param[in]     aKey          The key associated with the requested value.
-     * @param[in]     aIndex        The index of the specific item to get.
-     * @param[out]    aValue        A pointer to where the value of the setting should be written.
-     *                              May be nullptr if just testing for the presence or length of a key.
-     * @param[inout]  aValueLength  A pointer to the length of the value.
-     *                              When called, this should point to an integer containing the maximum bytes that
-     *                              can be written to @p aValue.
-     *                              At return, the actual length of the setting is written.
-     *                              May be nullptr if performing a presence check.
-     *
-     * @retval kErrorNone        The value was fetched successfully.
-     * @retval kErrorNotFound    The key was not found.
-     *
-     */
-    Error Get(uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength) const;
-
-    /**
-     * This method sets or replaces the value identified by @p aKey.
-     *
-     * If there was more than one value previously associated with @p aKey, then they are all deleted and replaced with
-     * this single entry.
-     *
-     * @param[in]  aKey          The key associated with the value.
-     * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
-     *                           MUST NOT be nullptr if @p aValueLength is non-zero.
-     * @param[in]  aValueLength  The length of the data pointed to by @p aValue. May be zero.
-     *
-     * @retval kErrorNone     The value was changed.
-     * @retval kErrorNoBufs   Not enough space to store the value.
-     *
-     */
-    Error Set(uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
-
-    /**
-     * This method removes all values.
-     *
-     */
-    void Wipe(void);
-
-#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
-private:
-    Flash mFlash;
-#endif
-};
+class Settings;
 
 /**
  * This class defines the base class used by `Settings` and `Settings::ChildInfoIterator`.
@@ -171,6 +70,20 @@ private:
  */
 class SettingsBase : public InstanceLocator
 {
+protected:
+    enum Action : uint8_t
+    {
+        kActionRead,
+        kActionSave,
+        kActionResave,
+        kActionDelete,
+#if OPENTHREAD_FTD
+        kActionAdd,
+        kActionRemove,
+        kActionDeleteAll,
+#endif
+    };
+
 public:
     /**
      * Rules for updating existing value structures.
@@ -195,13 +108,39 @@ public:
      */
 
     /**
+     * This enumeration defines the keys of settings.
+     *
+     */
+    enum Key : uint16_t
+    {
+        kKeyActiveDataset     = OT_SETTINGS_KEY_ACTIVE_DATASET,
+        kKeyPendingDataset    = OT_SETTINGS_KEY_PENDING_DATASET,
+        kKeyNetworkInfo       = OT_SETTINGS_KEY_NETWORK_INFO,
+        kKeyParentInfo        = OT_SETTINGS_KEY_PARENT_INFO,
+        kKeyChildInfo         = OT_SETTINGS_KEY_CHILD_INFO,
+        kKeyReserved          = OT_SETTINGS_KEY_RESERVED,
+        kKeySlaacIidSecretKey = OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY,
+        kKeyDadInfo           = OT_SETTINGS_KEY_DAD_INFO,
+        kKeyOmrPrefix         = OT_SETTINGS_KEY_OMR_PREFIX,
+        kKeyOnLinkPrefix      = OT_SETTINGS_KEY_ON_LINK_PREFIX,
+        kKeySrpEcdsaKey       = OT_SETTINGS_KEY_SRP_ECDSA_KEY,
+        kKeySrpClientInfo     = OT_SETTINGS_KEY_SRP_CLIENT_INFO,
+    };
+
+    static constexpr Key kLastKey = kKeySrpClientInfo; ///< The last (numerically) enumerator value in `Key`.
+
+    /**
      * This structure represents the device's own network information for settings storage.
      *
      */
     OT_TOOL_PACKED_BEGIN
-    class NetworkInfo : public Equatable<NetworkInfo>, private Clearable<NetworkInfo>
+    class NetworkInfo : private Clearable<NetworkInfo>
     {
+        friend class Settings;
+
     public:
+        static constexpr Key kKey = kKeyNetworkInfo; ///< The associated key.
+
         /**
          * This method initializes the `NetworkInfo` object.
          *
@@ -382,6 +321,8 @@ public:
         void SetVersion(uint16_t aVersion) { mVersion = Encoding::LittleEndian::HostSwap16(aVersion); }
 
     private:
+        void Log(Action aAction) const;
+
         uint8_t                  mRole;                ///< Current Thread role.
         uint8_t                  mDeviceMode;          ///< Device mode setting.
         uint16_t                 mRloc16;              ///< RLOC16
@@ -399,9 +340,13 @@ public:
      *
      */
     OT_TOOL_PACKED_BEGIN
-    class ParentInfo : public Equatable<ParentInfo>, private Clearable<ParentInfo>
+    class ParentInfo : private Clearable<ParentInfo>
     {
+        friend class Settings;
+
     public:
+        static constexpr Key kKey = kKeyParentInfo; ///< The associated key.
+
         /**
          * This method initializes the `ParentInfo` object.
          *
@@ -445,10 +390,13 @@ public:
         void SetVersion(uint16_t aVersion) { mVersion = Encoding::LittleEndian::HostSwap16(aVersion); }
 
     private:
+        void Log(Action aAction) const;
+
         Mac::ExtAddress mExtAddress; ///< Extended Address
         uint16_t        mVersion;    ///< Version
     } OT_TOOL_PACKED_END;
 
+#if OPENTHREAD_FTD
     /**
      * This structure represents the child information for settings storage.
      *
@@ -456,7 +404,11 @@ public:
     OT_TOOL_PACKED_BEGIN
     class ChildInfo
     {
+        friend class Settings;
+
     public:
+        static constexpr Key kKey = kKeyChildInfo; ///< The associated key.
+
         /**
          * This method clears the struct object (setting all the fields to zero).
          *
@@ -548,21 +500,46 @@ public:
         void SetVersion(uint16_t aVersion) { mVersion = Encoding::LittleEndian::HostSwap16(aVersion); }
 
     private:
+        void Log(Action aAction) const;
+
         Mac::ExtAddress mExtAddress; ///< Extended Address
         uint32_t        mTimeout;    ///< Timeout
         uint16_t        mRloc16;     ///< RLOC16
         uint8_t         mMode;       ///< The MLE device mode
         uint16_t        mVersion;    ///< Version
     } OT_TOOL_PACKED_END;
+#endif // OPENTHREAD_FTD
 
+#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
+    /**
+     * This class defines constants and types for SLAAC IID Secret key settings.
+     *
+     */
+    class SlaacIidSecretKey
+    {
+    public:
+        static constexpr Key kKey = kKeySlaacIidSecretKey; ///< The associated key.
+
+        typedef Utils::Slaac::IidSecretKey ValueType; ///< The associated value type.
+
+    private:
+        SlaacIidSecretKey(void) = default;
+    };
+#endif
+
+#if OPENTHREAD_CONFIG_DUA_ENABLE
     /**
      * This structure represents the duplicate address detection information for settings storage.
      *
      */
     OT_TOOL_PACKED_BEGIN
-    class DadInfo : public Equatable<DadInfo>, private Clearable<DadInfo>
+    class DadInfo : private Clearable<DadInfo>
     {
+        friend class Settings;
+
     public:
+        static constexpr Key kKey = kKeyDadInfo; ///< The associated key.
+
         /**
          * This method initializes the `DadInfo` object.
          *
@@ -586,17 +563,73 @@ public:
         void SetDadCounter(uint8_t aDadCounter) { mDadCounter = aDadCounter; }
 
     private:
+        void Log(Action aAction) const;
+
         uint8_t mDadCounter; ///< Dad Counter used to resolve address conflict in Thread 1.2 DUA feature.
     } OT_TOOL_PACKED_END;
+#endif // OPENTHREAD_CONFIG_DUA_ENABLE
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    /**
+     * This class defines constants and types for OMR prefix settings.
+     *
+     */
+    class OmrPrefix
+    {
+    public:
+        static constexpr Key kKey = kKeyOmrPrefix; ///< The associated key.
+
+        typedef Ip6::Prefix ValueType; ///< The associated value type.
+
+    private:
+        OmrPrefix(void) = default;
+    };
+
+    /**
+     * This class defines constants and types for on-link prefix settings.
+     *
+     */
+    class OnLinkPrefix
+    {
+    public:
+        static constexpr Key kKey = kKeyOnLinkPrefix; ///< The associated key.
+
+        typedef Ip6::Prefix ValueType; ///< The associated value type.
+
+    private:
+        OnLinkPrefix(void) = default;
+    };
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+
+#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+    /**
+     * This class defines constants and types for SRP ECDSA key settings.
+     *
+     */
+    class SrpEcdsaKey
+    {
+    public:
+        static constexpr Key kKey = kKeySrpEcdsaKey; ///< The associated key.
+
+        typedef Crypto::Ecdsa::P256::KeyPair ValueType; ///< The associated value type.
+
+    private:
+        SrpEcdsaKey(void) = default;
+    };
+
+#if OPENTHREAD_CONFIG_SRP_CLIENT_SAVE_SELECTED_SERVER_ENABLE
     /**
      * This structure represents the SRP client info (selected server address).
      *
      */
     OT_TOOL_PACKED_BEGIN
-    class SrpClientInfo : public Equatable<SrpClientInfo>, private Clearable<SrpClientInfo>
+    class SrpClientInfo : private Clearable<SrpClientInfo>
     {
+        friend class Settings;
+
     public:
+        static constexpr Key kKey = kKeySrpClientInfo; ///< The associated key.
+
         /**
          * This method initializes the `SrpClientInfo` object.
          *
@@ -636,29 +669,13 @@ public:
         void SetServerPort(uint16_t aPort) { mServerPort = Encoding::LittleEndian::HostSwap16(aPort); }
 
     private:
+        void Log(Action aAction) const;
+
         Ip6::Address mServerAddress;
         uint16_t     mServerPort; // (in little-endian encoding)
     } OT_TOOL_PACKED_END;
-
-    /**
-     * This enumeration defines the keys of settings.
-     *
-     */
-    enum Key
-    {
-        kKeyActiveDataset     = OT_SETTINGS_KEY_ACTIVE_DATASET,
-        kKeyPendingDataset    = OT_SETTINGS_KEY_PENDING_DATASET,
-        kKeyNetworkInfo       = OT_SETTINGS_KEY_NETWORK_INFO,
-        kKeyParentInfo        = OT_SETTINGS_KEY_PARENT_INFO,
-        kKeyChildInfo         = OT_SETTINGS_KEY_CHILD_INFO,
-        kKeyReserved          = OT_SETTINGS_KEY_RESERVED,
-        kKeySlaacIidSecretKey = OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY,
-        kKeyDadInfo           = OT_SETTINGS_KEY_DAD_INFO,
-        kKeyOmrPrefix         = OT_SETTINGS_KEY_OMR_PREFIX,
-        kKeyOnLinkPrefix      = OT_SETTINGS_KEY_ON_LINK_PREFIX,
-        kKeySrpEcdsaKey       = OT_SETTINGS_KEY_SRP_ECDSA_KEY,
-        kKeySrpClientInfo     = OT_SETTINGS_KEY_SRP_CLIENT_INFO,
-    };
+#endif // OPENTHREAD_CONFIG_SRP_CLIENT_SAVE_SELECTED_SERVER_ENABLE
+#endif // OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
 
 protected:
     explicit SettingsBase(Instance &aInstance)
@@ -666,34 +683,15 @@ protected:
     {
     }
 
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_UTIL != 0)
-    void LogNetworkInfo(const char *aAction, const NetworkInfo &aNetworkInfo) const;
-    void LogParentInfo(const char *aAction, const ParentInfo &aParentInfo) const;
-    void LogChildInfo(const char *aAction, const ChildInfo &aChildInfo) const;
-#if OPENTHREAD_CONFIG_DUA_ENABLE
-    void LogDadInfo(const char *aAction, const DadInfo &aDadInfo) const;
-#endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    void LogPrefix(const char *aAction, const char *aPrefixName, const Ip6::Prefix &aOmrPrefix) const;
+    static void LogPrefix(Action aAction, Key aKey, const Ip6::Prefix &aPrefix);
 #endif
-    void LogSrpClientInfo(const char *aAction, const SrpClientInfo &aSrpClientInfo) const;
-#else // (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_UTIL != 0)
-    void LogNetworkInfo(const char *, const NetworkInfo &) const {}
-    void LogParentInfo(const char *, const ParentInfo &) const {}
-    void LogChildInfo(const char *, const ChildInfo &) const {}
-#if OPENTHREAD_CONFIG_DUA_ENABLE
-    void LogDadInfo(const char *, const DadInfo &) const {}
-#endif
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    void LogPrefix(const char *, const char *, const Ip6::Prefix &) const {}
-#endif
-    void LogSrpClientInfo(const char *, const SrpClientInfo &) const {}
-#endif // (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_UTIL != 0)
 
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && (OPENTHREAD_CONFIG_LOG_UTIL != 0)
-    void LogFailure(Error aError, const char *aAction, bool aIsDelete) const;
-#else
-    void LogFailure(Error, const char *, bool) const {}
+#if OPENTHREAD_CONFIG_LOG_UTIL && (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN)
+    static const char *KeyToString(Key aKey);
+#endif
+#if OPENTHREAD_CONFIG_LOG_UTIL && (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO)
+    static const char *ActionToString(Action aAction);
 #endif
 };
 
@@ -776,113 +774,124 @@ public:
     Error DeleteOperationalDataset(bool aIsActive);
 
     /**
-     * This method saves Network Info.
+     * This template method reads a specified settings entry.
      *
-     * @param[in]   aNetworkInfo          A reference to a `NetworkInfo` structure to be saved.
+     * The template type `EntryType` specifies the entry's value data structure. It must provide the following:
      *
-     * @retval kErrorNone             Successfully saved Network Info in settings.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
+     *  - It must provide a constant `EntryType::kKey` to specify the associated entry settings key.
+     *  - It must provide method `Init()` to initialize the `aEntry` object.
      *
-     */
-    Error SaveNetworkInfo(const NetworkInfo &aNetworkInfo);
-
-    /**
-     * This method reads Network Info.
+     * This version of `Read<EntryType>` is intended for use with entries that define a data structure which represents
+     * the entry's value, e.g., `NetworkInfo`, `ParentInfo`, `DadInfo`, etc.
      *
-     * @param[out]   aNetworkInfo         A reference to a `NetworkInfo` structure to output the read content.
+     * @tparam EntryType              The settings entry type.
      *
-     * @retval kErrorNone             Successfully read the Network Info.
+     * @param[out] aEntry             A reference to a entry data structure to output the read content.
+     *
+     * @retval kErrorNone             Successfully read the entry.
      * @retval kErrorNotFound         No corresponding value in the setting store.
      * @retval kErrorNotImplemented   The platform does not implement settings functionality.
      *
      */
-    Error ReadNetworkInfo(NetworkInfo &aNetworkInfo) const;
-
-    /**
-     * This method deletes Network Info from settings.
-     *
-     * @retval kErrorNone            Successfully deleted the value.
-     * @retval kErrorNotImplemented  The platform does not implement settings functionality.
-     *
-     */
-    Error DeleteNetworkInfo(void);
-
-    /**
-     * This method saves Parent Info.
-     *
-     * @param[in]   aParentInfo           A reference to a `ParentInfo` structure to be saved.
-     *
-     * @retval kErrorNone             Successfully saved Parent Info in settings.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
-     *
-     */
-    Error SaveParentInfo(const ParentInfo &aParentInfo);
-
-    /**
-     * This method reads Parent Info.
-     *
-     * @param[out]   aParentInfo         A reference to a `ParentInfo` structure to output the read content.
-     *
-     * @retval kErrorNone             Successfully read the Parent Info.
-     * @retval kErrorNotFound         No corresponding value in the setting store.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
-     *
-     */
-    Error ReadParentInfo(ParentInfo &aParentInfo) const;
-
-    /**
-     * This method deletes Parent Info from settings.
-     *
-     * @retval kErrorNone            Successfully deleted the value.
-     * @retval kErrorNotImplemented  The platform does not implement settings functionality.
-     *
-     */
-    Error DeleteParentInfo(void);
-
-#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
-
-    /**
-     * This method saves the SLAAC IID secret key.
-     *
-     * @param[in]   aKey                  The SLAAC IID secret key.
-     *
-     * @retval kErrorNone             Successfully saved the value.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
-     *
-     */
-    Error SaveSlaacIidSecretKey(const Utils::Slaac::IidSecretKey &aKey)
+    template <typename EntryType> Error Read(EntryType &aEntry) const
     {
-        return Save(kKeySlaacIidSecretKey, &aKey, sizeof(Utils::Slaac::IidSecretKey));
+        aEntry.Init();
+
+        return ReadEntry(EntryType::kKey, &aEntry, sizeof(EntryType));
     }
 
     /**
-     * This method reads the SLAAC IID secret key.
+     * This template method reads a specified settings entry.
      *
-     * @param[out]   aKey          A reference to a SLAAC IID secret key to output the read value.
+     * The template type `EntryType` provides information about the entry's value type. It must provide the following:
+     *
+     *  - It must provide a constant `EntryType::kKey` to specify the associated entry settings key.
+     *  - It must provide a nested type `EntryType::ValueType` to specify the associated entry value type.
+     *
+     * This version of `Read<EntryType>` is intended for use with entries that have a simple entry value type (which can
+     * be represented by an existing type), e.g., `OmrPrefx` (using `Ip6::Prefix` as the value type).
+     *
+     * @tparam EntryType              The settings entry type.
+     *
+     * @param[out] aValue             A reference to a value type object to output the read content.
      *
      * @retval kErrorNone             Successfully read the value.
      * @retval kErrorNotFound         No corresponding value in the setting store.
      * @retval kErrorNotImplemented   The platform does not implement settings functionality.
      *
      */
-    Error ReadSlaacIidSecretKey(Utils::Slaac::IidSecretKey &aKey)
+    template <typename EntryType> Error Read(typename EntryType::ValueType &aValue) const
     {
-        uint16_t length = sizeof(aKey);
-
-        return Read(kKeySlaacIidSecretKey, &aKey, length);
+        return ReadEntry(EntryType::kKey, &aValue, sizeof(typename EntryType::ValueType));
     }
 
     /**
-     * This method deletes the SLAAC IID secret key value from settings.
+     * This template method saves a specified settings entry.
+     *
+     * The template type `EntryType` specifies the entry's value data structure. It must provide the following:
+     *
+     *  - It must provide a constant `EntryType::kKey` to specify the associated entry settings key.
+     *
+     * This version of `Save<EntryType>` is intended for use with entries that define a data structure which represents
+     * the entry's value, e.g., `NetworkInfo`, `ParentInfo`, `DadInfo`, etc.
+     *
+     * @tparam EntryType              The settings entry type.
+     *
+     * @param[in] aEntry              The entry value to be saved.
+     *
+     * @retval kErrorNone             Successfully saved Network Info in settings.
+     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
+     *
+     */
+    template <typename EntryType> Error Save(const EntryType &aEntry)
+    {
+        EntryType prev;
+
+        return SaveEntry(EntryType::kKey, &aEntry, &prev, sizeof(EntryType));
+    }
+
+    /**
+     * This template method saves a specified settings entry.
+     *
+     * The template type `EntryType` provides information about the entry's value type. It must provide the following:
+     *
+     *  - It must provide a constant `EntryType::kKey` to specify the associated entry settings key.
+     *  - It must provide a nested type `EntryType::ValueType` to specify the associated entry value type.
+     *
+     * This version of `Save<EntryType>` is intended for use with entries that have a simple entry value type (which can
+     * be represented by an existing type), e.g., `OmrPrefx` (using `Ip6::Prefix` as the value type).
+     *
+     * @tparam EntryType              The settings entry type.
+     *
+     * @param[in] aEntry              The entry value to be saved.
+     *
+     * @retval kErrorNone             Successfully saved Network Info in settings.
+     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
+     *
+     */
+    template <typename EntryType> Error Save(const typename EntryType::ValueType &aValue)
+    {
+        typename EntryType::ValueType prev;
+
+        return SaveEntry(EntryType::kKey, &aValue, &prev, sizeof(typename EntryType::ValueType));
+    }
+
+    /**
+     * This template method deletes a specified setting entry.
+     *
+     * The template type `EntryType` provides information about the entry's key.
+     *
+     *  - It must provide a constant `EntryType::kKey` to specify the associated entry settings key.
+     *
+     * @tparam EntryType             The settings entry type.
      *
      * @retval kErrorNone            Successfully deleted the value.
      * @retval kErrorNotImplemented  The platform does not implement settings functionality.
      *
      */
-    Error DeleteSlaacIidSecretKey(void) { return Delete(kKeySlaacIidSecretKey); }
+    template <typename EntryType> Error Delete(void) { return DeleteEntry(EntryType::kKey); }
 
-#endif // OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
-
+#if OPENTHREAD_FTD
     /**
      * This method adds a Child Info entry to settings.
      *
@@ -1029,161 +1038,10 @@ public:
         uint16_t  mIndex;
         bool      mIsDone;
     };
-
-#if OPENTHREAD_CONFIG_DUA_ENABLE
-
-    /**
-     * This method saves duplicate address detection information.
-     *
-     * @param[in]   aDadInfo           A reference to a `DadInfo` structure to be saved.
-     *
-     * @retval kErrorNone             Successfully saved duplicate address detection information in settings.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
-     *
-     */
-    Error SaveDadInfo(const DadInfo &aDadInfo);
-
-    /**
-     * This method reads duplicate address detection information.
-     *
-     * @param[out]   aDadInfo         A reference to a `DadInfo` structure to output the read content.
-     *
-     * @retval kErrorNone             Successfully read the duplicate address detection information.
-     * @retval kErrorNotFound         No corresponding value in the setting store.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
-     *
-     */
-    Error ReadDadInfo(DadInfo &aDadInfo) const;
-
-    /**
-     * This method deletes duplicate address detection information from settings.
-     *
-     * @retval kErrorNone            Successfully deleted the value.
-     * @retval kErrorNotImplemented  The platform does not implement settings functionality.
-     *
-     */
-    Error DeleteDadInfo(void);
-
-#endif // OPENTHREAD_CONFIG_DUA_ENABLE
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    /**
-     * This method saves OMR prefix.
-     *
-     * @param[in]  aOmrPrefix  An OMR prefix to be saved.
-     *
-     * @retval kErrorNone             Successfully saved the OMR prefix in settings.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
-     *
-     */
-    Error SaveOmrPrefix(const Ip6::Prefix &aOmrPrefix);
-
-    /**
-     * This method reads OMR prefix.
-     *
-     * @param[out]  aOmrPrefix  A reference to a `Ip6::Prefix` structure to output the OMR prefix.
-     *
-     * @retval kErrorNone            Successfully read the OMR prefix.
-     * @retval kErrorNotFound        No corresponding value in the setting store.
-     * @retval kErrorNotImplemented  The platform does not implement settings functionality.
-     *
-     */
-    Error ReadOmrPrefix(Ip6::Prefix &aOmrPrefix) const;
-
-    /**
-     * This method saves on-link prefix.
-     *
-     * @param[in]  aOnLinkPrefix  An on-link prefix to be saved.
-     *
-     * @retval kErrorNone             Successfully saved the on-link prefix in settings.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
-     *
-     */
-    Error SaveOnLinkPrefix(const Ip6::Prefix &aOnLinkPrefix);
-
-    /**
-     * This method reads on-link prefix.
-     *
-     * @param[out]  aOnLinkPrefix  A reference to a `Ip6::Prefix` structure to output the on-link prefix.
-     *
-     * @retval kErrorNone            Successfully read the on-link prefix.
-     * @retval kErrorNotFound        No corresponding value in the setting store.
-     * @retval kErrorNotImplemented  The platform does not implement settings functionality.
-     *
-     */
-    Error ReadOnLinkPrefix(Ip6::Prefix &aOnLinkPrefix) const;
-#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-
-#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
-    /**
-     * This method saves SRP client ECDSA key pair.
-     *
-     * @param[in]   aKeyPair              A reference to an SRP ECDSA key-pair to save.
-     *
-     * @retval kErrorNone             Successfully saved key-pair information in settings.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
-     *
-     */
-    Error SaveSrpKey(const Crypto::Ecdsa::P256::KeyPair &aKeyPair);
-
-    /**
-     * This method reads SRP client ECDSA key pair.
-     *
-     * @param[out]   aKeyPair             A reference to a ECDA `KeyPair` to output the read content.
-     *
-     * @retval kErrorNone             Successfully read key-pair information.
-     * @retval kErrorNotFound         No corresponding value in the setting store.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
-     *
-     */
-    Error ReadSrpKey(Crypto::Ecdsa::P256::KeyPair &aKeyPair) const;
-
-    /**
-     * This method deletes SRP client ECDSA key pair from settings.
-     *
-     * @retval kErrorNone            Successfully deleted the value.
-     * @retval kErrorNotImplemented  The platform does not implement settings functionality.
-     *
-     */
-    Error DeleteSrpKey(void);
-
-#if OPENTHREAD_CONFIG_SRP_CLIENT_SAVE_SELECTED_SERVER_ENABLE
-    /**
-     * This method saves SRP client info.
-     *
-     * @param[in] aSrpClientInfo      The `SrpClientInfo` to save.
-     *
-     * @retval kErrorNone             Successfully saved the information in settings.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
-     *
-     */
-    Error SaveSrpClientInfo(const SrpClientInfo &aSrpClientInfo);
-
-    /**
-     * This method reads SRP client info.
-     *
-     * @param[out] aSrpClientInfo     A reference to a `SrpClientInfo` to output the read content.
-     *
-     * @retval kErrorNone             Successfully read the information.
-     * @retval kErrorNotFound         No corresponding value in the setting store.
-     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
-     *
-     */
-    Error ReadSrpClientInfo(SrpClientInfo &aSrpClientInfo) const;
-
-    /**
-     * This method deletes SRP client info from settings.
-     *
-     * @retval kErrorNone            Successfully deleted the value.
-     * @retval kErrorNotImplemented  The platform does not implement settings functionality.
-     *
-     */
-    Error DeleteSrpClientInfo(void);
-
-#endif // OPENTHREAD_CONFIG_SRP_CLIENT_SAVE_SELECTED_SERVER_ENABLE
-#endif // OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+#endif // OPENTHREAD_FTD
 
 private:
+#if OPENTHREAD_FTD
     class ChildInfoIteratorBuilder : public InstanceLocator
     {
     public:
@@ -1195,11 +1053,15 @@ private:
         ChildInfoIterator begin(void) { return ChildInfoIterator(GetInstance()); }
         ChildInfoIterator end(void) { return ChildInfoIterator(GetInstance(), ChildInfoIterator::kEndIterator); }
     };
+#endif
 
-    Error Read(Key aKey, void *aBuffer, uint16_t &aSize) const;
-    Error Save(Key aKey, const void *aValue, uint16_t aSize);
-    Error Add(Key aKey, const void *aValue, uint16_t aSize);
-    Error Delete(Key aKey);
+    Error ReadEntry(Key aKey, void *aValue, uint16_t aMaxLength) const;
+    Error SaveEntry(Key aKey, const void *aValue, void *aPrev, uint16_t aLength);
+    Error DeleteEntry(Key aKey);
+
+    static void Log(Action aAction, Error aError, Key aKey, const void *aValue = nullptr);
+
+    static const uint16_t kCriticalKeys[];
 };
 
 } // namespace ot

--- a/src/core/common/settings_driver.hpp
+++ b/src/core/common/settings_driver.hpp
@@ -1,0 +1,254 @@
+/*
+ *  Copyright (c) 2016-21, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for settings driver.
+ */
+
+#ifndef SETTINGS_DRIVER_HPP_
+#define SETTINGS_DRIVER_HPP_
+
+#include "openthread-core-config.h"
+
+#include <openthread/platform/settings.h>
+
+#include "common/encoding.hpp"
+#include "common/error.hpp"
+#include "common/locator.hpp"
+#include "common/non_copyable.hpp"
+#include "utils/flash.hpp"
+
+namespace ot {
+
+class SettingsDriver : public InstanceLocator, private NonCopyable
+{
+public:
+    /**
+     * This constructor initializes the `SettingsDriver`.
+     *
+     * @param[in]  aInstance     A reference to the OpenThread instance.
+     *
+     */
+    explicit SettingsDriver(Instance &aInstance)
+        : InstanceLocator(aInstance)
+#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+        , mFlash(aInstance)
+#endif
+    {
+    }
+
+    /**
+     * This method initializes the settings storage driver.
+     *
+     */
+    void Init(void)
+    {
+#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+        mFlash.Init();
+#else
+        otPlatSettingsInit(GetInstancePtr());
+#endif
+    }
+
+    /**
+     * This method deinitializes the settings driver.
+     *
+     */
+    void Deinit(void)
+    {
+#if !OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+        otPlatSettingsDeinit(GetInstancePtr());
+#endif
+    }
+
+    /**
+     * This method sets the critical keys that should be stored in a secure area.
+     *
+     * @param[in]  aKeys        A pointer to an array containing the list of critical keys.
+     * @param[in]  aKeysLength  The number of entries in the @p aKeys array.
+     *
+     */
+    void SetCriticalKeys(const uint16_t *aKeys, uint16_t aKeysLength)
+    {
+#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+        OT_UNUSED_VARIABLE(aKeys);
+        OT_UNUSED_VARIABLE(aKeysLength);
+#else
+        otPlatSettingsSetCriticalKeys(GetInstancePtr(), aKeys, aKeysLength);
+#endif
+    }
+
+    /**
+     * This method adds a value to @p aKey.
+     *
+     * @param[in]  aKey          The key associated with the value.
+     * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
+     *                           MUST NOT be nullptr if @p aValueLength is non-zero.
+     * @param[in]  aValueLength  The length of the data pointed to by @p aValue. May be zero.
+     *
+     * @retval kErrorNone     The value was added.
+     * @retval kErrorNoBufs   Not enough space to store the value.
+     *
+     */
+    Error Add(uint16_t aKey, const void *aValue, uint16_t aValueLength)
+    {
+        Error          error;
+        const uint8_t *value = reinterpret_cast<const uint8_t *>(aValue);
+
+#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+        error = mFlash.Add(aKey, value, aValueLength);
+#else
+        error = otPlatSettingsAdd(GetInstancePtr(), aKey, value, aValueLength);
+#endif
+        return error;
+    }
+
+    /**
+     * This method removes a value from @p aKey.
+     *
+     * @param[in] aKey    The key associated with the value.
+     * @param[in] aIndex  The index of the value to be removed.
+     *                    If set to -1, all values for @p aKey will be removed.
+     *
+     * @retval kErrorNone       The given key and index was found and removed successfully.
+     * @retval kErrorNotFound   The given key or index was not found.
+     *
+     */
+    Error Delete(uint16_t aKey, int aIndex = -1)
+    {
+        Error error;
+
+#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+        error = mFlash.Delete(aKey, aIndex);
+#else
+        error = otPlatSettingsDelete(GetInstancePtr(), aKey, aIndex);
+#endif
+        return error;
+    }
+
+    /**
+     * This method fetches the value identified by @p aKey at a given @p aIndex.
+     *
+     * @param[in]     aKey          The key associated with the requested value.
+     * @param[in]     aIndex        The index of the specific item to get.
+     * @param[out]    aValue        A pointer to where the value of the setting should be written.
+     *                              May be nullptr if just testing for the presence or length of a key.
+     * @param[inout]  aValueLength  A pointer to the length of the value.
+     *                              When called, this should point to an integer containing the maximum bytes that
+     *                              can be written to @p aValue.
+     *                              At return, the actual length of the setting is written.
+     *                              May be nullptr if performing a presence check.
+     *
+     * @retval kErrorNone        The value was fetched successfully.
+     * @retval kErrorNotFound    The key was not found.
+     *
+     */
+    Error Get(uint16_t aKey, int aIndex, void *aValue, uint16_t *aValueLength) const
+    {
+        Error    error;
+        uint8_t *value = reinterpret_cast<uint8_t *>(aValue);
+
+#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+        error = mFlash.Get(aKey, aIndex, value, aValueLength);
+#else
+        error = otPlatSettingsGet(GetInstancePtr(), aKey, aIndex, value, aValueLength);
+#endif
+        return error;
+    }
+
+    /**
+     * This method fetches the value identified by @p aKey.
+     *
+     * @param[in]     aKey          The key associated with the requested value.
+     * @param[out]    aValue        A pointer to where the value of the setting should be written.
+     *                              May be nullptr if just testing for the presence or length of a key.
+     * @param[inout]  aValueLength  A pointer to the length of the value.
+     *                              When called, this should point to an integer containing the maximum bytes that
+     *                              can be written to @p aValue.
+     *                              At return, the actual length of the setting is written.
+     *                              May be nullptr if performing a presence check.
+     *
+     * @retval kErrorNone        The value was fetched successfully.
+     * @retval kErrorNotFound    The key was not found.
+     *
+     */
+    Error Get(uint16_t aKey, void *aValue, uint16_t *aValueLength) const { return Get(aKey, 0, aValue, aValueLength); }
+
+    /**
+     * This method sets or replaces the value identified by @p aKey.
+     *
+     * If there was more than one value previously associated with @p aKey, then they are all deleted and replaced with
+     * this single entry.
+     *
+     * @param[in]  aKey          The key associated with the value.
+     * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
+     *                           MUST NOT be nullptr if @p aValueLength is non-zero.
+     * @param[in]  aValueLength  The length of the data pointed to by @p aValue. May be zero.
+     *
+     * @retval kErrorNone     The value was changed.
+     * @retval kErrorNoBufs   Not enough space to store the value.
+     *
+     */
+    Error Set(uint16_t aKey, const void *aValue, uint16_t aValueLength)
+    {
+        Error          error;
+        const uint8_t *value = reinterpret_cast<const uint8_t *>(aValue);
+
+#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+        error = mFlash.Set(aKey, value, aValueLength);
+#else
+        error = otPlatSettingsSet(GetInstancePtr(), aKey, value, aValueLength);
+#endif
+        return error;
+    }
+
+    /**
+     * This method removes all values.
+     *
+     */
+    void Wipe(void)
+    {
+#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+        mFlash.Wipe();
+#else
+        otPlatSettingsWipe(GetInstancePtr());
+#endif
+    }
+
+private:
+    otInstance *GetInstancePtr(void) const { return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance()); }
+
+#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+    Flash mFlash;
+#endif
+};
+
+} // namespace ot
+
+#endif // SETTINGS_DRIVER_HPP_

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -559,7 +559,7 @@ void Client::ChangeHostAndServiceStates(const ItemState *aNewStates)
     {
         if (mAutoStartIsUsingAnycastAddress)
         {
-            IgnoreError(Get<Settings>().DeleteSrpClientInfo());
+            IgnoreError(Get<Settings>().Delete<Settings::SrpClientInfo>());
         }
         else
         {
@@ -568,7 +568,7 @@ void Client::ChangeHostAndServiceStates(const ItemState *aNewStates)
             info.SetServerAddress(GetServerAddress().GetAddress());
             info.SetServerPort(GetServerAddress().GetPort());
 
-            IgnoreError(Get<Settings>().SaveSrpClientInfo(info));
+            IgnoreError(Get<Settings>().Save(info));
         }
     }
 #endif
@@ -745,7 +745,7 @@ Error Client::ReadOrGenerateKey(Crypto::Ecdsa::P256::KeyPair &aKeyPair)
 {
     Error error;
 
-    error = Get<Settings>().ReadSrpKey(aKeyPair);
+    error = Get<Settings>().Read<Settings::SrpEcdsaKey>(aKeyPair);
 
     if (error == kErrorNone)
     {
@@ -758,7 +758,7 @@ Error Client::ReadOrGenerateKey(Crypto::Ecdsa::P256::KeyPair &aKeyPair)
     }
 
     SuccessOrExit(error = aKeyPair.Generate());
-    IgnoreError(Get<Settings>().SaveSrpKey(aKeyPair));
+    IgnoreError(Get<Settings>().Save<Settings::SrpEcdsaKey>(aKeyPair));
 
 exit:
     return error;
@@ -1566,7 +1566,7 @@ void Client::ProcessAutoStart(void)
 #if OPENTHREAD_CONFIG_SRP_CLIENT_SAVE_SELECTED_SERVER_ENABLE
     if (!IsRunning())
     {
-        hasSavedServerInfo = (Get<Settings>().ReadSrpClientInfo(savedInfo) == kErrorNone);
+        hasSavedServerInfo = (Get<Settings>().Read(savedInfo) == kErrorNone);
     }
 #endif
 

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -213,7 +213,7 @@ void DuaManager::Restore(void)
 {
     Settings::DadInfo dadInfo;
 
-    SuccessOrExit(Get<Settings>().ReadDadInfo(dadInfo));
+    SuccessOrExit(Get<Settings>().Read(dadInfo));
     mDadCounter = dadInfo.GetDadCounter();
 
 exit:
@@ -225,7 +225,7 @@ Error DuaManager::Store(void)
     Settings::DadInfo dadInfo;
 
     dadInfo.SetDadCounter(mDadCounter);
-    return Get<Settings>().SaveDadInfo(dadInfo);
+    return Get<Settings>().Save(dadInfo);
 }
 
 void DuaManager::AddDomainUnicastAddress(void)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -329,7 +329,7 @@ Error Mle::Restore(void)
     Get<DuaManager>().Restore();
 #endif
 
-    SuccessOrExit(error = Get<Settings>().ReadNetworkInfo(networkInfo));
+    SuccessOrExit(error = Get<Settings>().Read(networkInfo));
 
     Get<KeyManager>().SetCurrentKeySequence(networkInfo.GetKeySequence());
     Get<KeyManager>().SetMleFrameCounter(networkInfo.GetMleFrameCounter());
@@ -362,7 +362,7 @@ Error Mle::Restore(void)
 
     if (!IsActiveRouter(networkInfo.GetRloc16()))
     {
-        error = Get<Settings>().ReadParentInfo(parentInfo);
+        error = Get<Settings>().Read(parentInfo);
 
         if (error != kErrorNone)
         {
@@ -433,7 +433,7 @@ Error Mle::Store(void)
             parentInfo.SetExtAddress(mParent.GetExtAddress());
             parentInfo.SetVersion(mParent.GetVersion());
 
-            SuccessOrExit(error = Get<Settings>().SaveParentInfo(parentInfo));
+            SuccessOrExit(error = Get<Settings>().Save(parentInfo));
         }
     }
     else
@@ -446,7 +446,7 @@ Error Mle::Store(void)
         // address. If there is a previously saved `NetworkInfo`, we
         // just update the key sequence and MAC and MLE frame counters.
 
-        SuccessOrExit(Get<Settings>().ReadNetworkInfo(networkInfo));
+        SuccessOrExit(Get<Settings>().Read(networkInfo));
     }
 
     networkInfo.SetKeySequence(Get<KeyManager>().GetCurrentKeySequence());
@@ -456,7 +456,7 @@ Error Mle::Store(void)
                                    OPENTHREAD_CONFIG_STORE_FRAME_COUNTER_AHEAD);
     networkInfo.SetDeviceMode(mDeviceMode.Get());
 
-    SuccessOrExit(error = Get<Settings>().SaveNetworkInfo(networkInfo));
+    SuccessOrExit(error = Get<Settings>().Save(networkInfo));
 
     Get<KeyManager>().SetStoredMleFrameCounter(networkInfo.GetMleFrameCounter());
     Get<KeyManager>().SetStoredMacFrameCounter(networkInfo.GetMacFrameCounter());

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -326,7 +326,7 @@ void Slaac::GetIidSecretKey(IidSecretKey &aKey) const
 {
     Error error;
 
-    error = Get<Settings>().ReadSlaacIidSecretKey(aKey);
+    error = Get<Settings>().Read<Settings::SlaacIidSecretKey>(aKey);
     VerifyOrExit(error != kErrorNone);
 
     // If there is no previously saved secret key, generate
@@ -339,7 +339,7 @@ void Slaac::GetIidSecretKey(IidSecretKey &aKey) const
         IgnoreError(Random::Crypto::FillBuffer(aKey.m8, sizeof(IidSecretKey)));
     }
 
-    IgnoreError(Get<Settings>().SaveSlaacIidSecretKey(aKey));
+    IgnoreError(Get<Settings>().Save<Settings::SlaacIidSecretKey>(aKey));
 
     otLogInfoUtil("SLAAC: Generated and saved secret key");
 

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -2293,7 +2293,7 @@ void RadioSpinel<InterfaceType, ProcessContextType>::RestoreProperties(void)
 
     if (mInstance != nullptr)
     {
-        SuccessOrDie(static_cast<Instance *>(mInstance)->template Get<Settings>().ReadNetworkInfo(networkInfo));
+        SuccessOrDie(static_cast<Instance *>(mInstance)->template Get<Settings>().Read(networkInfo));
         SuccessOrDie(
             Set(SPINEL_PROP_RCP_MAC_FRAME_COUNTER, SPINEL_DATATYPE_UINT32_S, networkInfo.GetMacFrameCounter()));
     }


### PR DESCRIPTION
This commit updates the `Settings` implementation. It adds template
versions of methods `Read<EntryType>()`, `Save<EntryType>()`, and
`Delete<EntryType>()` which make it easier for other modules to use,
while ensuing to share a common underlying implementation for all
entry types.

The settings entry types (e.g., `NetworkInfo`, `ParentInfo`, etc.) are
changed in this commit to provide a constant `kKey` specifying the
associated setting key with the entry. For simple entries, a related
class is added to define the `kKey` constant and the associated value
type (e.g., `OmrPrefix` defines `Ip6::Prefix` as its `ValueType`).
This model makes it easier to add new setting keys and entries in
future.

This commit also simplifies the logging in `Settings`. The entry types
now provide `Log()` method to log their data and a common
`Settings::Log()` method is added which handles all logging (on
success or in case of an error).

Finally, this commit moves the `SettingsDriver` definition to its own
`common/settings_driver.hpp` header file and and ensures that its
methods are defined as inline.

------

Notes:
- This PR is currently contains the commit from https://github.com/openthread/openthread/pull/6672 (it is actually written over this commit so to make rebase easier). Please only review and check the second commit. Thanks. 
   - The code size report also includes this commit. The new commit will actually reduce code size (from ~200 to 500 for different build configs). 
- A lot of the methods are actually removed (replaced by the template version) in `settings.cpp` so the diff looks complex and I suggest just looking at the new implementation 😃 
