### PR TITLE
[posix] allow empty backbone interface name

### DIFF
--- a/src/posix/platform/backbone.cpp
+++ b/src/posix/platform/backbone.cpp
@@ -50,7 +50,7 @@ void platformBackboneInit(otInstance *aInstance, const char *aInterfaceName)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    VerifyOrExit(aInterfaceName != nullptr && aInterfaceName != "");
+    VerifyOrExit(aInterfaceName != nullptr && aInterfaceName[0] != '\0');
 
     VerifyOrDie(strnlen(aInterfaceName, IFNAMSIZ) <= IFNAMSIZ - 1, OT_EXIT_INVALID_ARGUMENTS);
     strncpy(gBackboneNetifName, aInterfaceName, sizeof(gBackboneNetifName));

--- a/src/posix/platform/backbone.cpp
+++ b/src/posix/platform/backbone.cpp
@@ -50,7 +50,7 @@ void platformBackboneInit(otInstance *aInstance, const char *aInterfaceName)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    VerifyOrExit(aInterfaceName != nullptr);
+    VerifyOrExit(aInterfaceName != nullptr && aInterfaceName != "");
 
     VerifyOrDie(strnlen(aInterfaceName, IFNAMSIZ) <= IFNAMSIZ - 1, OT_EXIT_INVALID_ARGUMENTS);
     strncpy(gBackboneNetifName, aInterfaceName, sizeof(gBackboneNetifName));

--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -273,7 +273,7 @@ void InfraNetif::Init(otInstance *aInstance, const char *aIfName)
     ssize_t  rval;
     uint32_t ifIndex = 0;
 
-    VerifyOrExit(aIfName != nullptr);
+    VerifyOrExit(aIfName != nullptr && aIfName[0] != '\0');
 
     VerifyOrDie(strnlen(aIfName, sizeof(mInfraIfName)) <= sizeof(mInfraIfName) - 1, OT_EXIT_INVALID_ARGUMENTS);
     strcpy(mInfraIfName, aIfName);


### PR DESCRIPTION
Add the empty string check for backbone interface.

Fixes #6684 