### PR TITLE
[netdata] assign domain IDs during registration of new entries

### DIFF
--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -203,13 +203,26 @@ private:
         kTlvUpdated, // TLV stable flag is updated based on its sub TLVs.
     };
 
+    // A list of domain ID (`uint8_t`) values (implemented as a bit-vector).
+    class DomainIds : private BitVector<sizeof(uint8_t) * CHAR_BIT>
+    {
+    public:
+        void Add(uint8_t aDomindId) { Set(aDomindId, true); }
+        bool Contains(uint16_t aDomindId) const { return Get(aDomindId); }
+        void Clear(void) { return BitVector::Clear(); }
+    };
+
     static void HandleServerData(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
-    void RegisterNetworkData(uint16_t aRloc16, const uint8_t *aTlvs, uint8_t aTlvsLength);
+    void RegisterNetworkData(uint16_t aRloc16, uint8_t *aTlvs, uint8_t aTlvsLength);
+
+    void        UpdateDomainIds(uint8_t *aTlvs, uint8_t aTlvsLength) const;
+    static bool ContainsDomainId(uint8_t aDomainId, const uint8_t *aTlvs, uint8_t aTlvsLength);
+    static void ChangeDomainId(uint8_t aOldId, uint8_t aNewId, uint8_t *aTlvs, uint8_t aTlvsLength);
 
     Error AddPrefix(const PrefixTlv &aPrefix, ChangedFlags &aChangedFlags);
     Error AddHasRoute(const HasRouteTlv &aHasRoute, PrefixTlv &aDstPrefix, ChangedFlags &aChangedFlags);

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -610,6 +610,14 @@ public:
     uint8_t GetDomainId(void) const { return mDomainId; }
 
     /**
+     * This method sets the Domain ID value.
+     *
+     * @param[in] aDomainId  The Domain ID.
+     *
+     */
+    void SetDomaindId(uint8_t aDomainId) { mDomainId = aDomainId; }
+
+    /**
      * This method returns the Prefix Length value.
      *
      * @returns The Prefix Length value (in bits).

--- a/tests/toranj/test-013-off-mesh-route-traffic.py
+++ b/tests/toranj/test-013-off-mesh-route-traffic.py
@@ -120,6 +120,8 @@ OFF_MESH_ADDR_3 = OFF_MESH_ROUTE_3 + "3"
 
 # Add on-mesh prefix
 r1.config_gateway(ON_MESH_PREFIX)
+r2.config_gateway(ON_MESH_PREFIX)
+fed1.config_gateway(ON_MESH_PREFIX)
 
 # The off-mesh-routes are added as follows:
 # - `r1` adds OFF_MESH_ROUTE_1,


### PR DESCRIPTION
This commit adds support for assigning and updating domain ID values
to Prefix TLVs on leader when registering new entries into the Network
Data (per Thread spec).

A border router adding an external route entry can specify which
source prefix(es) should be used with the external route by assigning
the same domain ID to the related prefix TLVs. Leader changes the
domain ID values assigning new IDs to new prefixes and the same IDs to
any existing prefixes in the Network Data, while ensuring to maintain
the same relationships between prefix TLVs.