### PR TITLE
[tests] give more time for SRP client to upgrade to router

### DIFF
--- a/tests/scripts/thread-cert/test_srp_lease.py
+++ b/tests/scripts/thread-cert/test_srp_lease.py
@@ -84,7 +84,7 @@ class SrpRegisterSingleService(thread_cert.TestCase):
 
         client.srp_server_set_enabled(False)
         client.start()
-        self.simulator.go(5)
+        self.simulator.go(10)
         self.assertEqual(client.get_state(), 'router')
 
         #


### PR DESCRIPTION
https://github.com/openthread/openthread/issues/6690 indicates that there are chances that a SRP client may not be able
to upgrade to a router in 5 seconds. This commit gives it 10 seconds to upgrade.

```txt
2021-05-27T17:51:04.6018976Z ======================================================================
2021-05-27T17:51:04.6021398Z FAIL: test (__main__.SrpRegisterSingleService)
2021-05-27T17:51:04.6022746Z ----------------------------------------------------------------------
2021-05-27T17:51:04.6024043Z Traceback (most recent call last):
2021-05-27T17:51:04.6025888Z   File "./tests/scripts/thread-cert/test_srp_lease.py", line 88, in test
2021-05-27T17:51:04.6027733Z     self.assertEqual(client.get_state(), 'router')
2021-05-27T17:51:04.6029001Z AssertionError: 'child' != 'router'
2021-05-27T17:51:04.6030288Z - child
2021-05-27T17:51:04.6030875Z + router
```