### PR TITLE
[cli] disallow concurrent commands

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -101,6 +101,7 @@ Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, voi
     , mOutputContext(aContext)
     , mUserCommands(nullptr)
     , mUserCommandsLength(0)
+    , mCommandIsPending(false)
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
     , mSntpQueryingInProgress(false)
 #endif
@@ -110,6 +111,7 @@ Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, voi
 #if OPENTHREAD_CONFIG_TCP_ENABLE && OPENTHREAD_CONFIG_CLI_TCP_ENABLE
     , mTcp(*this)
 #endif
+    , mTimer(*aInstance, HandleTimer, this)
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
     , mCoap(*this)
 #endif
@@ -139,22 +141,31 @@ Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, voi
 #if OPENTHREAD_FTD
     otThreadSetDiscoveryRequestCallback(mInstance, &Interpreter::HandleDiscoveryRequest, this);
 #endif
+
+    OutputPrompt();
 }
 
 void Interpreter::OutputResult(otError aError)
 {
-    switch (aError)
+    OT_ASSERT(mCommandIsPending);
+
+    VerifyOrExit(aError != OT_ERROR_PENDING);
+
+    if (aError == OT_ERROR_NONE)
     {
-    case OT_ERROR_NONE:
         OutputLine("Done");
-        break;
-
-    case OT_ERROR_PENDING:
-        break;
-
-    default:
+    }
+    else
+    {
         OutputLine("Error %d: %s", aError, otThreadErrorToString(aError));
     }
+
+    mCommandIsPending = false;
+    mTimer.Stop();
+    OutputPrompt();
+
+exit:
+    return;
 }
 
 void Interpreter::OutputBytes(const uint8_t *aBytes, uint16_t aLength)
@@ -3127,18 +3138,28 @@ void Interpreter::HandlePingStatistics(const otPingSenderStatistics *aStatistics
     }
 
     OutputLine("");
-    OutputResult(OT_ERROR_NONE);
+
+    if (!mPingIsAsync)
+    {
+        OutputResult(OT_ERROR_NONE);
+    }
 }
 
 otError Interpreter::ProcessPing(Arg aArgs[])
 {
     otError            error = OT_ERROR_NONE;
     otPingSenderConfig config;
+    bool               async = false;
 
     if (aArgs[0] == "stop")
     {
         otPingSenderStop(mInstance);
         ExitNow();
+    }
+    else if (aArgs[0] == "async")
+    {
+        async = true;
+        aArgs++;
     }
 
     memset(&config, 0, sizeof(config));
@@ -3206,7 +3227,14 @@ otError Interpreter::ProcessPing(Arg aArgs[])
     config.mStatisticsCallback = Interpreter::HandlePingStatistics;
     config.mCallbackContext    = this;
 
-    error = otPingSenderPing(mInstance, &config);
+    SuccessOrExit(error = otPingSenderPing(mInstance, &config));
+
+    mPingIsAsync = async;
+
+    if (!async)
+    {
+        error = kErrorPending;
+    }
 
 exit:
     return error;
@@ -4570,21 +4598,18 @@ void Interpreter::ProcessLine(char *aBuf)
 
     OT_ASSERT(aBuf != nullptr);
 
+    // Ignore the command if another command is pending.
+    VerifyOrExit(!mCommandIsPending, args[0].Clear());
+    mCommandIsPending = true;
+
     VerifyOrExit(StringLength(aBuf, kMaxLineLength) <= kMaxLineLength - 1, error = OT_ERROR_PARSE);
 
 #if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
     otLogNoteCli("Input: %s", aBuf);
 #endif
 
-    error = Utils::CmdLineParser::ParseCmd(aBuf, args);
-
-    if (error != OT_ERROR_NONE)
-    {
-        OutputLine("Error: too many args (max %d)", kMaxArgs);
-        ExitNow();
-    }
-
-    VerifyOrExit(!args[0].IsEmpty());
+    SuccessOrExit(error = Utils::CmdLineParser::ParseCmd(aBuf, args, kMaxArgs));
+    VerifyOrExit(!args[0].IsEmpty(), mCommandIsPending = false);
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
     if (otDiagIsEnabled(mInstance) && (args[0] != "diag"))
@@ -4609,6 +4634,10 @@ exit:
     if ((error != OT_ERROR_NONE) || !args[0].IsEmpty())
     {
         OutputResult(error);
+    }
+    else if (!mCommandIsPending)
+    {
+        OutputPrompt();
     }
 }
 
@@ -4667,6 +4696,7 @@ otError Interpreter::ProcessNetworkDiagnostic(Arg aArgs[])
     {
         SuccessOrExit(error = otThreadSendDiagnosticGet(mInstance, &address, tlvTypes, count,
                                                         &Interpreter::HandleDiagnosticGetResponse, this));
+        SetCommandTimeout(kNetworkDiagnosticTimeoutMsecs);
         error = OT_ERROR_PENDING;
     }
     else if (aArgs[0] == "reset")
@@ -4798,13 +4828,8 @@ void Interpreter::HandleDiagnosticGetResponse(otError                 aError,
         }
     }
 
-    if (aError == OT_ERROR_NOT_FOUND)
-    {
-        aError = OT_ERROR_NONE;
-    }
-
 exit:
-    OutputResult(aError);
+    return;
 }
 
 void Interpreter::OutputMode(uint8_t aIndentSize, const otLinkModeConfig &aMode)
@@ -5051,6 +5076,29 @@ void Interpreter::Initialize(otInstance *aInstance, otCliOutputCallback aCallbac
     Instance *instance = static_cast<Instance *>(aInstance);
 
     Interpreter::sInterpreter = new (&sInterpreterRaw) Interpreter(instance, aCallback, aContext);
+}
+
+void Interpreter::OutputPrompt(void)
+{
+    static const char sPrompt[] = "> ";
+
+    OutputFormat("%s", sPrompt);
+}
+
+void Interpreter::HandleTimer(Timer &aTimer)
+{
+    static_cast<Interpreter *>(static_cast<TimerMilliContext &>(aTimer).GetContext())->HandleTimer();
+}
+
+void Interpreter::HandleTimer(void)
+{
+    OutputResult(kErrorNone);
+}
+
+void Interpreter::SetCommandTimeout(uint32_t aTimeoutMilli)
+{
+    OT_ASSERT(mCommandIsPending);
+    mTimer.Start(aTimeoutMilli);
 }
 
 extern "C" void otCliInit(otInstance *aInstance, otCliOutputCallback aCallback, void *aContext)

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -336,6 +336,8 @@ private:
         kMaxLineLength    = OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH,
     };
 
+    static constexpr uint32_t kNetworkDiagnosticTimeoutMsecs = 5000;
+
     struct Command
     {
         const char *mName;
@@ -432,6 +434,7 @@ private:
         OutputTableSeperator(kTableNumColumns, aWidths);
     }
 
+    void OutputPrompt(void);
 #if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
     otError ParsePingInterval(const Arg &aArg, uint32_t &aInterval);
 #endif
@@ -760,6 +763,10 @@ private:
     bool IsLogging(void) const { return mIsLogging; }
     void SetIsLogging(bool aIsLogging) { mIsLogging = aIsLogging; }
 #endif
+    void SetCommandTimeout(uint32_t aTimeoutMilli);
+
+    static void HandleTimer(Timer &aTimer);
+    void        HandleTimer(void);
 
     static constexpr Command sCommands[] = {
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
@@ -945,6 +952,7 @@ private:
     const otCliCommand *mUserCommands;
     uint8_t             mUserCommandsLength;
     void *              mUserCommandsContext;
+    bool                mCommandIsPending;
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
     bool mSntpQueryingInProgress;
 #endif
@@ -956,6 +964,8 @@ private:
 #if OPENTHREAD_CONFIG_TCP_ENABLE && OPENTHREAD_CONFIG_CLI_TCP_ENABLE
     TcpExample mTcp;
 #endif
+
+    TimerMilliContext mTimer;
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
     Coap mCoap;
@@ -989,6 +999,9 @@ private:
     char     mOutputString[OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LOG_STRING_SIZE];
     uint16_t mOutputLength;
     bool     mIsLogging;
+#endif
+#if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
+    bool mPingIsAsync;
 #endif
 };
 

--- a/src/core/utils/ping_sender.cpp
+++ b/src/core/utils/ping_sender.cpp
@@ -97,7 +97,7 @@ PingSender::PingSender(Instance &aInstance)
 
 Error PingSender::Ping(const Config &aConfig)
 {
-    Error error = kErrorPending;
+    Error error = kErrorNone;
 
     VerifyOrExit(!mTimer.IsRunning(), error = kErrorBusy);
 

--- a/src/posix/cli_readline.cpp
+++ b/src/posix/cli_readline.cpp
@@ -56,8 +56,6 @@
 #include "openthread-core-config.h"
 #include "platform-posix.h"
 
-static const char sPrompt[] = "> ";
-
 static void InputCallback(char *aLine)
 {
     if (aLine != nullptr)
@@ -65,8 +63,8 @@ static void InputCallback(char *aLine)
         if (aLine[0] != '\0')
         {
             add_history(aLine);
-            otCliInputLine(aLine);
         }
+        otCliInputLine(aLine);
         free(aLine);
     }
     else
@@ -90,7 +88,9 @@ extern "C" void otAppCliInit(otInstance *aInstance)
 
     rl_set_screen_size(0, OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH);
 
-    rl_callback_handler_install(sPrompt, InputCallback);
+    rl_callback_handler_install("", InputCallback);
+    rl_already_prompted = true;
+
     otCliInit(aInstance, OutputCallback, nullptr);
 }
 

--- a/src/posix/cli_stdio.cpp
+++ b/src/posix/cli_stdio.cpp
@@ -49,7 +49,6 @@
 #include "platform-posix.h"
 
 namespace {
-constexpr char sPrompt[] = "> ";
 
 int OutputCallback(void *aContext, const char *aFormat, va_list aArguments)
 {
@@ -93,7 +92,6 @@ extern "C" void otAppCliProcess(const otSysMainloopContext *aMainloop)
         if (fgets(buffer, sizeof(buffer), stdin) != nullptr)
         {
             otCliInputLine(buffer);
-            dprintf(STDOUT_FILENO, "%s", sPrompt);
         }
         else
         {

--- a/src/posix/platform/daemon.cpp
+++ b/src/posix/platform/daemon.cpp
@@ -311,7 +311,6 @@ void Daemon::Process(const otSysMainloopContext &aContext)
             buffer[rval] = '\0';
             otLogInfoPlat("> %s", reinterpret_cast<const char *>(buffer));
             otCliInputLine(reinterpret_cast<char *>(buffer));
-            otCliOutputFormat("> ");
         }
         else
         {

--- a/tests/scripts/expect/_common.exp
+++ b/tests/scripts/expect/_common.exp
@@ -58,6 +58,7 @@ proc wait_for {command success {failure {[\r\n]FAILURE_NOT_EXPECTED[\r\n]}}} {
 }
 
 proc expect_line {line} {
+    set timeout 10
     expect -re "\[\r\n \]($line)(?=\[\r\n>\])"
     return $expect_out(1,string)
 }

--- a/tools/otci/otci/command_handlers.py
+++ b/tools/otci/otci/command_handlers.py
@@ -180,6 +180,8 @@ class OtCliCommandRunner(OTCommandHandler):
     def __otcli_read_routine(self):
         while not self.__should_close.isSet():
             line = self.__otcli.readline()
+            logging.debug('%s: %r', self.__otcli, line)
+
             if line.startswith('> '):
                 line = line[2:]
 


### PR DESCRIPTION
This commit disallows concurrent commands. 
With this commit, the CLI only execute a new command after it complete the previous command. CLI can also prompt properly after the command execution is done. 

Other fixes and enhancements:
- Fixes premature command prompt:
  **With this enhancement:**
  ```
  > ping fdde:ad00:beef:0:0:ff:fe00:fc00 10 3 1
  18 bytes from fdde:ad00:beef:0:0:ff:fe00:fc00: icmp_seq=1 hlim=64 time=0ms
  18 bytes from fdde:ad00:beef:0:0:ff:fe00:fc00: icmp_seq=2 hlim=64 time=0ms
  18 bytes from fdde:ad00:beef:0:0:ff:fe00:fc00: icmp_seq=3 hlim=64 time=0ms
  3 packets transmitted, 3 packets received. Packet loss = 0.0%. Round-trip min/avg/max = 0/0.0/0 ms.
  Done
  > scan
  | J | Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |
  +---+------------------+------------------+------+------------------+----+-----+-----+
  | 0 | OpenThread       | 000db80000000000 | face | 166e0a0000000001 | 11 | -20 |   0 |
  Done
  > networkdiagnostic get ff02::1 0 1
  DIAG_GET.rsp/ans from fe80:0:0:0:2437:8587:62c4:b2cc: 00082637858762c4b2cc01027400
  Ext Address: '2637858762c4b2cc'
  Rloc16: 0x7400
  DIAG_GET.rsp/ans from fe80:0:0:0:146e:a00:0:1: 0008166e0a000000000101028800
  Ext Address: '166e0a0000000001'
  Rloc16: 0x8800
  Done
  > <prompt>
  ```
  **Orignal:**
  ```
  > ping fdde:ad00:beef:0:0:ff:fe00:fc00 10 3 1
  > 18 bytes from fdde:ad00:beef:0:0:ff:fe00:fc00: icmp_seq=1 hlim=64 time=0ms
  18 bytes from fdde:ad00:beef:0:0:ff:fe00:fc00: icmp_seq=2 hlim=64 time=0ms
  18 bytes from fdde:ad00:beef:0:0:ff:fe00:fc00: icmp_seq=3 hlim=64 time=0ms
  3 packets transmitted, 3 packets received. Packet loss = 0.0%. Round-trip min/avg/max = 0/0.0/0 ms.
  Done
  scan
  | J | Network Name     | Extended PAN     | PAN  | MAC Address      | Ch | dBm | LQI |
  +---+------------------+------------------+------+------------------+----+-----+-----+
  > | 0 | OpenThread       | 000db80000000000 | face | 2637858762c4b2cc | 11 | -20 |   0 |
  Done
  networkdiagnostic get ff02::1 0 1
  > DIAG_GET.rsp/ans from fe80:0:0:0:146e:a00:0:1: 0008166e0a000000000101028800
  Ext Address: '166e0a0000000001'
  Rloc16: 0x8800
  Done
  DIAG_GET.rsp/ans from fe80:0:0:0:2437:8587:62c4:b2cc: 00082637858762c4b2cc01027400
  Ext Address: '2637858762c4b2cc'
  Rloc16: 0x7400
  Done
  <prompt>
  ```
- Add `ping async` command for ping in async mode: output `Done` immediately but print ping responses later on. 
- Fixes `networkdiagnostic get` outputs multiple `Done` by always waiting for 5 seconds. 

Depends-On: openthread/ot-ns#130