### PR TITLE
[udp] fix potential infinite loop in `Udp::GetEphemeralPort`

### DIFF
--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -407,8 +407,6 @@ exit:
 
 uint16_t Udp::GetEphemeralPort(void)
 {
-    uint16_t &rval = mEphemeralPort;
-
     do
     {
         if (mEphemeralPort < kDynamicPortMax)
@@ -419,9 +417,9 @@ uint16_t Udp::GetEphemeralPort(void)
         {
             mEphemeralPort = kDynamicPortMin;
         }
-    } while (rval == Tmf::kUdpPort);
+    } while (mEphemeralPort == Tmf::kUdpPort);
 
-    return rval;
+    return mEphemeralPort;
 }
 
 Message *Udp::NewMessage(uint16_t aReserved, const Message::Settings &aSettings)

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -407,7 +407,7 @@ exit:
 
 uint16_t Udp::GetEphemeralPort(void)
 {
-    uint16_t rval = mEphemeralPort;
+    uint16_t &rval = mEphemeralPort;
 
     do
     {


### PR DESCRIPTION
The previous code will go into an infinite loop when `mEphemeralPort == Tmf::kUdpPort`, since `rval` is never updated in the loop.
```
uint16_t Udp::GetEphemeralPort(void)
{
    uint16_t rval = mEphemeralPort;

    do
    {
        if (mEphemeralPort < kDynamicPortMax)
        {
            mEphemeralPort++;
        }
        else
        {
            mEphemeralPort = kDynamicPortMin;
        }
    } while (rval == Tmf::kUdpPort);

    return rval;
}
```