### PR TITLE
[posix] fix strncpy warning about null terminated string length

### DIFF
--- a/src/posix/platform/backbone.cpp
+++ b/src/posix/platform/backbone.cpp
@@ -53,7 +53,7 @@ void platformBackboneInit(otInstance *aInstance, const char *aInterfaceName)
     VerifyOrExit(aInterfaceName != nullptr && aInterfaceName[0] != '\0');
 
     VerifyOrDie(strnlen(aInterfaceName, IFNAMSIZ) <= IFNAMSIZ - 1, OT_EXIT_INVALID_ARGUMENTS);
-    strncpy(gBackboneNetifName, aInterfaceName, sizeof(gBackboneNetifName));
+    strncpy(gBackboneNetifName, aInterfaceName, sizeof(gBackboneNetifName) - 1);
 
     gBackboneNetifIndex = if_nametoindex(gBackboneNetifName);
     VerifyOrDie(gBackboneNetifIndex > 0, OT_EXIT_FAILURE);

--- a/src/posix/platform/backbone.cpp
+++ b/src/posix/platform/backbone.cpp
@@ -52,7 +52,7 @@ void platformBackboneInit(otInstance *aInstance, const char *aInterfaceName)
 
     VerifyOrExit(aInterfaceName != nullptr && aInterfaceName[0] != '\0');
 
-    VerifyOrDie(strnlen(aInterfaceName, IFNAMSIZ) <= IFNAMSIZ - 1, OT_EXIT_INVALID_ARGUMENTS);
+    VerifyOrDie(strnlen(aInterfaceName, sizeof(gBackboneNetifName)) < sizeof(gBackboneNetifName), OT_EXIT_INVALID_ARGUMENTS);
     strncpy(gBackboneNetifName, aInterfaceName, sizeof(gBackboneNetifName) - 1);
 
     gBackboneNetifIndex = if_nametoindex(gBackboneNetifName);

--- a/src/posix/platform/backbone.cpp
+++ b/src/posix/platform/backbone.cpp
@@ -52,7 +52,8 @@ void platformBackboneInit(otInstance *aInstance, const char *aInterfaceName)
 
     VerifyOrExit(aInterfaceName != nullptr && aInterfaceName[0] != '\0');
 
-    VerifyOrDie(strnlen(aInterfaceName, sizeof(gBackboneNetifName)) < sizeof(gBackboneNetifName), OT_EXIT_INVALID_ARGUMENTS);
+    VerifyOrDie(strnlen(aInterfaceName, sizeof(gBackboneNetifName)) < sizeof(gBackboneNetifName),
+                OT_EXIT_INVALID_ARGUMENTS);
     strcpy(gBackboneNetifName, aInterfaceName);
 
     gBackboneNetifIndex = if_nametoindex(gBackboneNetifName);

--- a/src/posix/platform/backbone.cpp
+++ b/src/posix/platform/backbone.cpp
@@ -53,7 +53,7 @@ void platformBackboneInit(otInstance *aInstance, const char *aInterfaceName)
     VerifyOrExit(aInterfaceName != nullptr && aInterfaceName[0] != '\0');
 
     VerifyOrDie(strnlen(aInterfaceName, sizeof(gBackboneNetifName)) < sizeof(gBackboneNetifName), OT_EXIT_INVALID_ARGUMENTS);
-    strncpy(gBackboneNetifName, aInterfaceName, sizeof(gBackboneNetifName) - 1);
+    strcpy(gBackboneNetifName, aInterfaceName);
 
     gBackboneNetifIndex = if_nametoindex(gBackboneNetifName);
     VerifyOrDie(gBackboneNetifIndex > 0, OT_EXIT_FAILURE);


### PR DESCRIPTION
I found a warining in src/posix/platform/backbone.cpp.

```
    inlined from ‘void platformBackboneInit(otInstance*, const char*)’ at ../../src/posix/platform/backbone.cpp:56:12:
/usr/include/x86_64-linux-gnu/bits/string_fortified.h:95:34: error: ‘char* __builtin_strncpy(char*, const char*, long unsigned int)’ specified bound 16 equals destination size [-Werror=stringop-truncation]
```

It can reproduce with enable backbone router function and compiling with '-O2' option.
(It may occur in other conditions, I think.)

The warning means that the length of the destination string region is the same as the max length designated by the argument, so it cannot contain a null terminator.
Just need to reduce max length.

https://www.gnu.org/software/libc/manual/html_node/Interface-Naming.html
And IFNAMSIZ is described as 'length that contains terminator' in GNU libc document.

The source checks the string length at the previous line correctly, so the line that causes a warning seems never run with the invalid condition.

The warning just mentions a bad manner.
But it is better to correct.
