### PR TITLE
[cli] adding helper `ProcessGet/Set()` to handle simpler commands

### DIFF
--- a/src/cli/cli_srp_client.cpp
+++ b/src/cli/cli_srp_client.cpp
@@ -260,40 +260,13 @@ exit:
 
 otError SrpClient::ProcessLeaseInterval(uint8_t aArgsLength, Arg aArgs[])
 {
-    otError  error = OT_ERROR_NONE;
-    uint32_t interval;
-
-    if (aArgsLength == 0)
-    {
-        mInterpreter.OutputLine("%u", otSrpClientGetLeaseInterval(mInterpreter.mInstance));
-        ExitNow();
-    }
-
-    VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
-    SuccessOrExit(error = aArgs[0].ParseAsUint32(interval));
-    otSrpClientSetLeaseInterval(mInterpreter.mInstance, interval);
-
-exit:
-    return error;
+    return mInterpreter.ProcessGetSet(aArgsLength, aArgs, otSrpClientGetLeaseInterval, otSrpClientSetLeaseInterval);
 }
 
 otError SrpClient::ProcessKeyLeaseInterval(uint8_t aArgsLength, Arg aArgs[])
 {
-    otError  error = OT_ERROR_NONE;
-    uint32_t interval;
-
-    if (aArgsLength == 0)
-    {
-        mInterpreter.OutputLine("%u", otSrpClientGetKeyLeaseInterval(mInterpreter.mInstance));
-        ExitNow();
-    }
-
-    VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
-    SuccessOrExit(error = aArgs[0].ParseAsUint32(interval));
-    otSrpClientSetKeyLeaseInterval(mInterpreter.mInstance, interval);
-
-exit:
-    return error;
+    return mInterpreter.ProcessGetSet(aArgsLength, aArgs, otSrpClientGetKeyLeaseInterval,
+                                      otSrpClientSetKeyLeaseInterval);
 }
 
 otError SrpClient::ProcessServer(uint8_t aArgsLength, Arg aArgs[])

--- a/src/core/utils/parse_cmdline.hpp
+++ b/src/core/utils/parse_cmdline.hpp
@@ -469,6 +469,19 @@ public:
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 
     /**
+     * This template method parses the argument as a specified value type.
+     *
+     * @tparam Type               The value type.
+     *
+     * @param[out] aValue         A reference to output the parsed value.
+     *
+     * @retval kErrorNone         The argument was parsed successfully.
+     * @retval kErrorInvalidArgs  The argument does not contain a valid value.
+     *
+     */
+    template <typename Type> otError ParseAs(Type &aValue) const;
+
+    /**
      * This method parses the argument as a hex string into a byte array of fixed expected size.
      *
      * This method returns `kErrorNone` only when the hex string contains exactly @p aSize bytes (after parsing). If
@@ -561,6 +574,63 @@ private:
  *
  */
 otError ParseCmd(char *aCommandString, uint8_t &aArgsLength, Arg aArgs[], uint8_t aArgsLengthMax);
+
+//- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+// Specializations of `Arg::ParseAs<Type>()` method.
+
+template <> inline otError Arg::ParseAs(uint8_t &aValue) const
+{
+    return ParseAsUint8(aValue);
+}
+
+template <> inline otError Arg::ParseAs(uint16_t &aValue) const
+{
+    return ParseAsUint16(aValue);
+}
+
+template <> inline otError Arg::ParseAs(uint32_t &aValue) const
+{
+    return ParseAsUint32(aValue);
+}
+
+template <> inline otError Arg::ParseAs(uint64_t &aValue) const
+{
+    return ParseAsUint64(aValue);
+}
+
+template <> inline otError Arg::ParseAs(bool &aValue) const
+{
+    return ParseAsBool(aValue);
+}
+
+template <> inline otError Arg::ParseAs(int8_t &aValue) const
+{
+    return ParseAsInt8(aValue);
+}
+
+template <> inline otError Arg::ParseAs(int16_t &aValue) const
+{
+    return ParseAsInt16(aValue);
+}
+
+template <> inline otError Arg::ParseAs(int32_t &aValue) const
+{
+    return ParseAsInt32(aValue);
+}
+
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
+
+template <> inline otError Arg::ParseAs(otIp6Address &aValue) const
+{
+    return ParseAsIp6Address(aValue);
+}
+
+template <> inline otError Arg::ParseAs(otIp6Prefix &aValue) const
+{
+    return ParseAsIp6Prefix(aValue);
+}
+
+#endif
 
 /**
  * @}


### PR DESCRIPTION
This commit adds a set of helper methods in `Cli` to process simple
commands where we are getting and/or setting a single `uint` value.
This replaces common pattern in processing of commands where if there
are no arguments, we output the value we retrieve by calling a related
getter OT API, otherwise we parse the argument (to get the proper
`uint` value) and call a related setter OT API. For example, for
"channel" command, we use the `otLinkGetChannel()` as the getter and
`otLinkSetChannel()` as setter.