### PR TITLE
[srp-server] Choose a UDP port different from the last one on a reboot

### DIFF
--- a/src/cli/ftd.cmake
+++ b/src/cli/ftd.cmake
@@ -29,7 +29,7 @@
 add_library(openthread-cli-ftd)
 
 target_compile_definitions(openthread-cli-ftd
-    PRIVATE
+    PUBLIC
         OPENTHREAD_FTD=1
 )
 

--- a/src/cli/mtd.cmake
+++ b/src/cli/mtd.cmake
@@ -29,7 +29,7 @@
 add_library(openthread-cli-mtd)
 
 target_compile_definitions(openthread-cli-mtd
-    PRIVATE
+    PUBLIC
         OPENTHREAD_MTD=1
 )
 

--- a/src/core/config/srp_server.h
+++ b/src/core/config/srp_server.h
@@ -56,6 +56,26 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT
+ *
+ * Specifies the minimum port number of the reserved UDP port range for the SRP server.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SRP_SERVER_RESERVED_UDP_PORT_MIN
+#define OPENTHREAD_CONFIG_SRP_SERVER_RESERVED_UDP_PORT_MIN 53535
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT
+ *
+ * Specifies the maximum port number of the reserved UDP port range for the SRP server.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SRP_SERVER_RESERVED_UDP_PORT_MAX
+#define OPENTHREAD_CONFIG_SRP_SERVER_RESERVED_UDP_PORT_MAX 53553
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_SRP_SERVER_SERVICE_UPDATE_TIMEOUT
  *
  * Specifies the timeout value (in milliseconds) for the service update handler.

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -452,8 +452,13 @@ void Server::Start(void)
     {
         found = true;
         it.Clear();
-        while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(it, info) == kErrorNone)
+        otLogInfoSrp("Get Anycast Info: %d", Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(it, info));
+        it.Clear();
+        while (Get<NetworkData::Leader>().Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(it, info) ==
+               kErrorNone)
         {
+            otLogInfoSrp("MLEID: %s My Address: %s", Get<Mle::Mle>().GetMeshLocal64().ToString().AsCString(),
+                         info.mSockAddr.GetAddress().ToString().AsCString());
             if (Get<Mle::Mle>().GetMeshLocal64() == info.mSockAddr.GetAddress())
             {
                 hasRecord = true;
@@ -464,6 +469,7 @@ void Server::Start(void)
                 }
             }
         }
+        otLogInfoSrp("Failed to get info: %d", Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(it, info));
         if (found)
         {
             break;
@@ -472,6 +478,11 @@ void Server::Start(void)
     if (!hasRecord || !found)
     {
         port = Random::NonCrypto::GetUint16InRange(kReservedPortMin, kReservedPortMax);
+        otLogInfoSrp("[server] will be listening on random port: %u", port);
+    }
+    else
+    {
+        otLogInfoSrp("[server] will be listening on determined port: %u", port);
     }
     SuccessOrExit(error = mSocket.Bind(port, OT_NETIF_THREAD));
     SuccessOrExit(error = PublishServerData());

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -454,7 +454,7 @@ void Server::Start(void)
         it.Clear();
         while (Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(it, info) == kErrorNone)
         {
-            if (Get<Mle::Mle>().GetMeshLocal16() == info.mSockAddr.GetAddress())
+            if (Get<Mle::Mle>().GetMeshLocal64() == info.mSockAddr.GetAddress())
             {
                 hasRecord = true;
                 if (port == info.mSockAddr.GetPort())

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -78,7 +78,9 @@ class Server : public InstanceLocator, private NonCopyable
 public:
     enum : uint16_t
     {
-        kUdpPort = OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT, ///< The SRP Server UDP listening port.
+        kUdpPort         = OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT, ///< The SRP Server UDP listening port.
+        kReservedPortMin = OPENTHREAD_CONFIG_SRP_SERVER_RESERVED_UDP_PORT_MIN,
+        kReservedPortMax = OPENTHREAD_CONFIG_SRP_SERVER_RESERVED_UDP_PORT_MAX,
     };
 
     /**
@@ -655,6 +657,7 @@ private:
 
     void                  HandleServiceUpdateResult(UpdateMetadata *aUpdate, Error aError);
     const UpdateMetadata *FindOutstandingUpdate(const Ip6::MessageInfo &aMessageInfo, uint16_t aDnsMessageId);
+    uint16_t              FindPort() const;
 
     Ip6::Udp::Socket                mSocket;
     otSrpServerServiceUpdateHandler mServiceUpdateHandler;

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -371,6 +371,11 @@ exit:
     return error;
 }
 
+bool Udp::IsReservedPort(uint16_t aPort)
+{
+    return aPort == Tmf::kUdpPort || (kSrpServerPortMin <= aPort && aPort <= kSrpServerPortMax);
+}
+
 void Udp::AddSocket(SocketHandle &aSocket)
 {
     SuccessOrExit(mSockets.Add(aSocket));
@@ -407,7 +412,7 @@ exit:
 
 uint16_t Udp::GetEphemeralPort(void)
 {
-    uint16_t rval = mEphemeralPort;
+    uint16_t &rval = mEphemeralPort;
 
     do
     {
@@ -419,7 +424,7 @@ uint16_t Udp::GetEphemeralPort(void)
         {
             mEphemeralPort = kDynamicPortMin;
         }
-    } while (rval == Tmf::kUdpPort);
+    } while (IsReservedPort(rval));
 
     return rval;
 }

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -587,9 +587,13 @@ public:
 private:
     enum
     {
-        kDynamicPortMin = 49152, ///< Service Name and Transport Protocol Port Number Registry
-        kDynamicPortMax = 65535, ///< Service Name and Transport Protocol Port Number Registry
+        kDynamicPortMin   = 49152, ///< Service Name and Transport Protocol Port Number Registry
+        kDynamicPortMax   = 65535, ///< Service Name and Transport Protocol Port Number Registry
+        kSrpServerPortMin = OPENTHREAD_CONFIG_SRP_SERVER_RESERVED_UDP_PORT_MIN,
+        kSrpServerPortMax = OPENTHREAD_CONFIG_SRP_SERVER_RESERVED_UDP_PORT_MAX,
     };
+
+    static bool IsReservedPort(uint16_t aPort);
 
     void AddSocket(SocketHandle &aSocket);
     void RemoveSocket(SocketHandle &aSocket);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1495,6 +1495,11 @@ exit:
 
 void Mle::HandleNotifierEvents(Events aEvents)
 {
+    NetworkData::Service::Manager::Iterator   it;
+    NetworkData::Service::DnsSrpUnicast::Info info;
+    otLogInfoMle("!!!!!!!!!!!!! get it: %s %d", Get<>(),
+                 Get<NetworkData::Leader>().Get<NetworkData::Service::Manager>().GetNextDnsSrpUnicastInfo(it, info));
+
     VerifyOrExit(!IsDisabled());
 
     if (aEvents.Contains(kEventThreadRoleChanged))
@@ -4263,7 +4268,7 @@ const char *Mle::MessageTypeToString(MessageType aType)
     static_assert(kTypeLinkProbe == 30, "kTypeLinkProbe value is incorrect)");
 #endif
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-#else  // OPENTHREAD_FTD
+#else // OPENTHREAD_FTD
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_ENABLE
     static_assert(kTypeLinkMetricsManagementRequest == 16, "kTypeLinkMetricsManagementRequest value is incorrect)");
     static_assert(kTypeLinkMetricsManagementResponse == 17, "kTypeLinkMetricsManagementResponse value is incorrect)");

--- a/tests/scripts/thread-cert/test_srp_server_reboot_port.py
+++ b/tests/scripts/thread-cert/test_srp_server_reboot_port.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2021, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import ipaddress
+import unittest
+
+import command
+import thread_cert
+
+# Test description:
+#   This test verifies an SRP server will try to bind to a UDP port that wasn't
+# previously used by the same device.
+#
+# Topology:
+#
+#   CLIENT (leader) -- SERVER1 (router)
+#      |
+#      |
+#   SERVER2 (router)
+#
+
+CLIENT = 1
+SERVER1 = 2
+SERVER2 = 3
+
+
+class SrpAutoStartMode(thread_cert.TestCase):
+    USE_MESSAGE_FACTORY = False
+    SUPPORT_NCP = False
+
+    TOPOLOGY = {
+        CLIENT: {
+            'name': 'SRP_CLIENT',
+            'masterkey': '00112233445566778899aabbccddeeff',
+            'mode': 'rdn',
+        },
+        SERVER1: {
+            'name': 'SRP_SERVER1',
+            'masterkey': '00112233445566778899aabbccddeeff',
+            'mode': 'rdn',
+        },
+        SERVER2: {
+            'name': 'SRP_SERVER2',
+            'masterkey': '00112233445566778899aabbccddeeff',
+            'mode': 'rdn',
+        },
+    }
+
+    def test(self):
+        client = self.nodes[CLIENT]
+        server1 = self.nodes[SERVER1]
+        server2 = self.nodes[SERVER2]
+
+        #
+        # 0. Start the server & client devices.
+        #
+
+        client.srp_server_set_enabled(False)
+        client.start()
+        self.simulator.go(5)
+        self.assertEqual(client.get_state(), 'leader')
+
+        server1.srp_server_set_enabled(True)
+        server2.srp_server_set_enabled(False)
+        server1.start()
+        server2.start()
+        self.simulator.go(5)
+        self.assertEqual(server1.get_state(), 'router')
+        self.assertEqual(server2.get_state(), 'router')
+
+        #
+        # 1. Enable auto start mode on client and check that server1 is used.
+        #
+
+        self.assertEqual(client.srp_client_get_state(), 'Disabled')
+        client.srp_client_enable_auto_start_mode()
+        self.assertEqual(client.srp_client_get_auto_start_mode(), 'Enabled')
+        self.simulator.go(2)
+
+        self.assertEqual(client.srp_client_get_state(), 'Enabled')
+        self.assertTrue(server1.has_ipaddr(client.srp_client_get_server_address()))
+
+        #
+        # 2. Disable server1 and check client is stopped/disabled.
+        #
+
+        server1.srp_server_set_enabled(False)
+        self.simulator.go(5)
+        self.assertEqual(client.srp_client_get_state(), 'Disabled')
+
+        #
+        # 3. Enable server2 and check client starts again.
+        #
+
+        server2.srp_server_set_enabled(True)
+        self.simulator.go(5)
+        self.assertEqual(client.srp_client_get_state(), 'Enabled')
+        server2_address = client.srp_client_get_server_address()
+
+        #
+        # 4. Enable both servers and check client stays with server2.
+        #
+
+        server1.srp_server_set_enabled(True)
+        self.simulator.go(2)
+        self.assertEqual(client.srp_client_get_state(), 'Enabled')
+        self.assertEqual(client.srp_client_get_server_address(), server2_address)
+
+        #
+        # 5. Disable server2 and check client switches to server1.
+        #
+
+        server2.srp_server_set_enabled(False)
+        self.simulator.go(5)
+        self.assertEqual(client.srp_client_get_state(), 'Enabled')
+        self.assertNotEqual(client.srp_client_get_server_address(), server2_address)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This PR implements a mechanism to let an SRP server listen to a different UDP port on a reboot. 

- When an SRP server starts, it reads the UDP port used in the last time from `Settings`. Then the SRP server listens to the next port in the reserved range. 
- When SRP server successfully starts, store its UDP port in `Settings`. 