### PR TITLE
[mac] avoid potential assert with SetKeyId() on an invalid frame

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -331,14 +331,14 @@ void SubMac::ProcessTransmitSecurity(void)
     VerifyOrExit(mTransmitFrame.GetSecurityEnabled());
     VerifyOrExit(!mTransmitFrame.IsSecurityProcessed());
 
+    SuccessOrExit(mTransmitFrame.GetKeyIdMode(keyIdMode));
+
     if (!mTransmitFrame.IsARetransmission())
     {
         mTransmitFrame.SetKeyId(mKeyId);
     }
 
     VerifyOrExit(ShouldHandleTransmitSecurity());
-
-    SuccessOrExit(mTransmitFrame.GetKeyIdMode(keyIdMode));
     VerifyOrExit(keyIdMode == Frame::kKeyIdMode1);
 
     mTransmitFrame.SetAesKey(GetCurrentMacKey());


### PR DESCRIPTION
https://github.com/openthread/openthread/blob/f3671d5a758a3655fb9533986c297ffc190ce080/src/core/mac/mac_frame.cpp#L582