### PR TITLE
Disabling OPENTHREAD_CONFIG_LOG_MAC makes otbr-agent processing faster

### DIFF
--- a/src/core/config/logging.h
+++ b/src/core/config/logging.h
@@ -180,7 +180,7 @@
  *
  */
 #ifndef OPENTHREAD_CONFIG_LOG_MAC
-#define OPENTHREAD_CONFIG_LOG_MAC 1
+#define OPENTHREAD_CONFIG_LOG_MAC 0
 #endif
 
 /**


### PR DESCRIPTION
We noticed an issue with OPENTHREAD_CONFIG_LOG_MAC when running OTBR on slower host processors (when compared to a RPi 3B+). These logs would add up to 7ms on every HDLC-lite frame processing time, heavily affecting BR throughput. It seems the issue is masked on RPis.

Thanks @jwhui for pointing us to the right direction when looking at this problem.

My question is whether all the low level logs listed in this configuration file shouldn't be disabled by default.

@AliakbarEski @gabekassel @ndyck14