### PR TITLE
[cli] harmonize passing of arguments to command handlers

### DIFF
--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -171,9 +171,9 @@ otError Coap::ProcessResource(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
-    if (aArgsLength > 1)
+    if (aArgsLength > 0)
     {
-        VerifyOrExit(aArgs[1].GetLength() < kMaxUriLength, error = OT_ERROR_INVALID_ARGS);
+        VerifyOrExit(aArgs[0].GetLength() < kMaxUriLength, error = OT_ERROR_INVALID_ARGS);
 
         mResource.mUriPath = mUriPath;
         mResource.mContext = this;
@@ -183,13 +183,13 @@ otError Coap::ProcessResource(uint8_t aArgsLength, Arg aArgs[])
         mResource.mReceiveHook  = &Coap::BlockwiseReceiveHook;
         mResource.mTransmitHook = &Coap::BlockwiseTransmitHook;
 
-        if (aArgsLength > 2)
+        if (aArgsLength > 1)
         {
-            SuccessOrExit(error = aArgs[2].ParseAsUint32(mBlockCount));
+            SuccessOrExit(error = aArgs[1].ParseAsUint32(mBlockCount));
         }
 #endif
 
-        strncpy(mUriPath, aArgs[1].GetCString(), sizeof(mUriPath) - 1);
+        strncpy(mUriPath, aArgs[0].GetCString(), sizeof(mUriPath) - 1);
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
         otCoapAddBlockWiseResource(mInterpreter.mInstance, &mResource);
@@ -214,10 +214,10 @@ otError Coap::ProcessSet(uint8_t aArgsLength, Arg aArgs[])
 #endif
     otError error = OT_ERROR_NONE;
 
-    if (aArgsLength > 1)
+    if (aArgsLength > 0)
     {
-        VerifyOrExit(aArgs[1].GetLength() < sizeof(mResourceContent), error = OT_ERROR_INVALID_ARGS);
-        strncpy(mResourceContent, aArgs[1].GetCString(), sizeof(mResourceContent));
+        VerifyOrExit(aArgs[0].GetLength() < sizeof(mResourceContent), error = OT_ERROR_INVALID_ARGS);
+        strncpy(mResourceContent, aArgs[0].GetCString(), sizeof(mResourceContent));
         mResourceContent[sizeof(mResourceContent) - 1] = '\0';
 
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
@@ -296,14 +296,14 @@ otError Coap::ProcessParameters(uint8_t aArgsLength, Arg aArgs[])
     bool *              defaultTxParameters;
     otCoapTxParameters *txParameters;
 
-    VerifyOrExit(aArgsLength > 1, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    if (aArgs[1] == "request")
+    if (aArgs[0] == "request")
     {
         txParameters        = &mRequestTxParameters;
         defaultTxParameters = &mUseDefaultRequestTxParameters;
     }
-    else if (aArgs[1] == "response")
+    else if (aArgs[0] == "response")
     {
         txParameters        = &mResponseTxParameters;
         defaultTxParameters = &mUseDefaultResponseTxParameters;
@@ -313,20 +313,20 @@ otError Coap::ProcessParameters(uint8_t aArgsLength, Arg aArgs[])
         ExitNow(error = OT_ERROR_INVALID_ARGS);
     }
 
-    if (aArgsLength > 2)
+    if (aArgsLength > 1)
     {
-        if (aArgs[2] == "default")
+        if (aArgs[1] == "default")
         {
             *defaultTxParameters = true;
         }
         else
         {
-            VerifyOrExit(aArgsLength >= 6, error = OT_ERROR_INVALID_ARGS);
+            VerifyOrExit(aArgsLength >= 5, error = OT_ERROR_INVALID_ARGS);
 
-            SuccessOrExit(error = aArgs[2].ParseAsUint32(txParameters->mAckTimeout));
-            SuccessOrExit(error = aArgs[3].ParseAsUint8(txParameters->mAckRandomFactorNumerator));
-            SuccessOrExit(error = aArgs[4].ParseAsUint8(txParameters->mAckRandomFactorDenominator));
-            SuccessOrExit(error = aArgs[5].ParseAsUint8(txParameters->mMaxRetransmit));
+            SuccessOrExit(error = aArgs[1].ParseAsUint32(txParameters->mAckTimeout));
+            SuccessOrExit(error = aArgs[2].ParseAsUint8(txParameters->mAckRandomFactorNumerator));
+            SuccessOrExit(error = aArgs[3].ParseAsUint8(txParameters->mAckRandomFactorDenominator));
+            SuccessOrExit(error = aArgs[4].ParseAsUint8(txParameters->mMaxRetransmit));
 
             VerifyOrExit(txParameters->mAckRandomFactorNumerator > txParameters->mAckRandomFactorDenominator,
                          error = OT_ERROR_INVALID_ARGS);
@@ -335,7 +335,7 @@ otError Coap::ProcessParameters(uint8_t aArgsLength, Arg aArgs[])
         }
     }
 
-    mInterpreter.OutputLine("Transmission parameters for %s:", aArgs[1].GetCString());
+    mInterpreter.OutputLine("Transmission parameters for %s:", aArgs[0].GetCString());
 
     if (*defaultTxParameters)
     {
@@ -407,58 +407,58 @@ otError Coap::ProcessRequest(uint8_t aArgsLength, Arg aArgs[], otCoapCode aCoapC
     }
 #endif
 
-    VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aArgsLength > 1, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = aArgs[1].ParseAsIp6Address(coapDestinationIp));
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Address(coapDestinationIp));
 
-    VerifyOrExit(aArgs[2].GetLength() < kMaxUriLength, error = OT_ERROR_INVALID_ARGS);
-    strncpy(coapUri, aArgs[2].GetCString(), sizeof(coapUri) - 1);
+    VerifyOrExit(aArgs[1].GetLength() < kMaxUriLength, error = OT_ERROR_INVALID_ARGS);
+    strncpy(coapUri, aArgs[1].GetCString(), sizeof(coapUri) - 1);
 
     // CoAP-Type
-    if (aArgsLength > 3)
+    if (aArgsLength > 2)
     {
-        if (aArgs[3] == "con")
+        if (aArgs[2] == "con")
         {
             coapType = OT_COAP_TYPE_CONFIRMABLE;
         }
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
-        else if (aArgs[3] == "block-16")
+        else if (aArgs[2] == "block-16")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
             coapBlockSize = OT_COAP_OPTION_BLOCK_SZX_16;
         }
-        else if (aArgs[3] == "block-32")
+        else if (aArgs[2] == "block-32")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
             coapBlockSize = OT_COAP_OPTION_BLOCK_SZX_32;
         }
-        else if (aArgs[3] == "block-64")
+        else if (aArgs[2] == "block-64")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
             coapBlockSize = OT_COAP_OPTION_BLOCK_SZX_64;
         }
-        else if (aArgs[3] == "block-128")
+        else if (aArgs[2] == "block-128")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
             coapBlockSize = OT_COAP_OPTION_BLOCK_SZX_128;
         }
-        else if (aArgs[3] == "block-256")
+        else if (aArgs[2] == "block-256")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
             coapBlockSize = OT_COAP_OPTION_BLOCK_SZX_256;
         }
-        else if (aArgs[3] == "block-512")
+        else if (aArgs[2] == "block-512")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
             coapBlockSize = OT_COAP_OPTION_BLOCK_SZX_512;
         }
-        else if (aArgs[3] == "block-1024")
+        else if (aArgs[2] == "block-1024")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
@@ -504,17 +504,17 @@ otError Coap::ProcessRequest(uint8_t aArgsLength, Arg aArgs[], otCoapCode aCoapC
     }
 #endif
 
-    if (aArgsLength > 4)
+    if (aArgsLength > 3)
     {
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
         if (coapBlock)
         {
-            SuccessOrExit(error = aArgs[4].ParseAsUint32(mBlockCount));
+            SuccessOrExit(error = aArgs[3].ParseAsUint32(mBlockCount));
         }
         else
         {
 #endif
-            payloadLength = aArgs[4].GetLength();
+            payloadLength = aArgs[3].GetLength();
 
             if (payloadLength > 0)
             {
@@ -528,7 +528,7 @@ otError Coap::ProcessRequest(uint8_t aArgsLength, Arg aArgs[], otCoapCode aCoapC
     // Embed content into message if given
     if (payloadLength > 0)
     {
-        SuccessOrExit(error = otMessageAppend(message, aArgs[4].GetCString(), payloadLength));
+        SuccessOrExit(error = otMessageAppend(message, aArgs[3].GetCString(), payloadLength));
     }
 
     memset(&messageInfo, 0, sizeof(messageInfo));
@@ -595,7 +595,7 @@ otError Coap::Process(uint8_t aArgsLength, Arg aArgs[])
     command = Utils::LookupTable::Find(aArgs[0].GetCString(), sCommands);
     VerifyOrExit(command != nullptr, error = OT_ERROR_INVALID_COMMAND);
 
-    error = (this->*command->mHandler)(aArgsLength, aArgs);
+    error = (this->*command->mHandler)(aArgsLength - 1, aArgs + 1);
 
 exit:
     return error;

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -108,9 +108,9 @@ otError CoapSecure::ProcessResource(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
-    if (aArgsLength > 1)
+    if (aArgsLength > 0)
     {
-        VerifyOrExit(aArgs[1].GetLength() < kMaxUriLength, error = OT_ERROR_INVALID_ARGS);
+        VerifyOrExit(aArgs[0].GetLength() < kMaxUriLength, error = OT_ERROR_INVALID_ARGS);
 
         mResource.mUriPath = mUriPath;
         mResource.mContext = this;
@@ -120,13 +120,13 @@ otError CoapSecure::ProcessResource(uint8_t aArgsLength, Arg aArgs[])
         mResource.mReceiveHook  = &CoapSecure::BlockwiseReceiveHook;
         mResource.mTransmitHook = &CoapSecure::BlockwiseTransmitHook;
 
-        if (aArgsLength > 2)
+        if (aArgsLength > 1)
         {
-            SuccessOrExit(error = aArgs[2].ParseAsUint32(mBlockCount));
+            SuccessOrExit(error = aArgs[1].ParseAsUint32(mBlockCount));
         }
 #endif
 
-        strncpy(mUriPath, aArgs[1].GetCString(), sizeof(mUriPath) - 1);
+        strncpy(mUriPath, aArgs[0].GetCString(), sizeof(mUriPath) - 1);
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
         otCoapSecureAddBlockWiseResource(mInterpreter.mInstance, &mResource);
 #else
@@ -146,10 +146,10 @@ otError CoapSecure::ProcessSet(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
-    if (aArgsLength > 1)
+    if (aArgsLength > 0)
     {
-        VerifyOrExit(aArgs[1].GetLength() < sizeof(mResourceContent), error = OT_ERROR_INVALID_ARGS);
-        strncpy(mResourceContent, aArgs[1].GetCString(), sizeof(mResourceContent));
+        VerifyOrExit(aArgs[0].GetLength() < sizeof(mResourceContent), error = OT_ERROR_INVALID_ARGS);
+        strncpy(mResourceContent, aArgs[0].GetCString(), sizeof(mResourceContent));
         mResourceContent[sizeof(mResourceContent) - 1] = '\0';
     }
     else
@@ -166,15 +166,15 @@ otError CoapSecure::ProcessStart(uint8_t aArgsLength, Arg aArgs[])
     otError error;
     bool    verifyPeerCert = true;
 
-    if (aArgsLength > 1)
+    if (aArgsLength > 0)
     {
-        if (aArgs[1] == "false")
+        if (aArgs[0] == "false")
         {
             verifyPeerCert = false;
         }
         else
         {
-            VerifyOrExit(aArgs[1] == "true", error = OT_ERROR_INVALID_ARGS);
+            VerifyOrExit(aArgs[0] == "true", error = OT_ERROR_INVALID_ARGS);
         }
     }
 
@@ -250,55 +250,55 @@ otError CoapSecure::ProcessRequest(uint8_t aArgsLength, Arg aArgs[], otCoapCode 
     BlockType      coapBlockType = (aCoapCode == OT_COAP_CODE_GET) ? kBlockType2 : kBlockType1;
 #endif
 
-    if (aArgsLength > 1)
+    if (aArgsLength > 0)
     {
-        strncpy(coapUri, aArgs[1].GetCString(), sizeof(coapUri) - 1);
+        strncpy(coapUri, aArgs[0].GetCString(), sizeof(coapUri) - 1);
     }
 
-    if (aArgsLength > 2)
+    if (aArgsLength > 1)
     {
-        if (aArgs[2] == "con")
+        if (aArgs[1] == "con")
         {
             coapType = OT_COAP_TYPE_CONFIRMABLE;
         }
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
-        else if (aArgs[2] == "block-16")
+        else if (aArgs[1] == "block-16")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
             coapBlockSize = OT_COAP_OPTION_BLOCK_SZX_16;
         }
-        else if (aArgs[2] == "block-32")
+        else if (aArgs[1] == "block-32")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
             coapBlockSize = OT_COAP_OPTION_BLOCK_SZX_32;
         }
-        else if (aArgs[2] == "block-64")
+        else if (aArgs[1] == "block-64")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
             coapBlockSize = OT_COAP_OPTION_BLOCK_SZX_64;
         }
-        else if (aArgs[2] == "block-128")
+        else if (aArgs[1] == "block-128")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
             coapBlockSize = OT_COAP_OPTION_BLOCK_SZX_128;
         }
-        else if (aArgs[2] == "block-256")
+        else if (aArgs[1] == "block-256")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
             coapBlockSize = OT_COAP_OPTION_BLOCK_SZX_256;
         }
-        else if (aArgs[2] == "block-512")
+        else if (aArgs[1] == "block-512")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
             coapBlockSize = OT_COAP_OPTION_BLOCK_SZX_512;
         }
-        else if (aArgs[2] == "block-1024")
+        else if (aArgs[1] == "block-1024")
         {
             coapType      = OT_COAP_TYPE_CONFIRMABLE;
             coapBlock     = true;
@@ -328,17 +328,17 @@ otError CoapSecure::ProcessRequest(uint8_t aArgsLength, Arg aArgs[], otCoapCode 
     }
 #endif
 
-    if (aArgsLength > 3)
+    if (aArgsLength > 2)
     {
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
         if (coapBlock)
         {
-            SuccessOrExit(error = aArgs[3].ParseAsUint32(mBlockCount));
+            SuccessOrExit(error = aArgs[2].ParseAsUint32(mBlockCount));
         }
         else
         {
 #endif
-            payloadLength = aArgs[3].GetLength();
+            payloadLength = aArgs[2].GetLength();
 
             if (payloadLength > 0)
             {
@@ -351,7 +351,7 @@ otError CoapSecure::ProcessRequest(uint8_t aArgsLength, Arg aArgs[], otCoapCode 
 
     if (payloadLength > 0)
     {
-        SuccessOrExit(error = otMessageAppend(message, aArgs[3].GetCString(), payloadLength));
+        SuccessOrExit(error = otMessageAppend(message, aArgs[2].GetCString(), payloadLength));
     }
 
     if ((coapType == OT_COAP_TYPE_CONFIRMABLE) || (aCoapCode == OT_COAP_CODE_GET))
@@ -391,17 +391,15 @@ otError CoapSecure::ProcessConnect(uint8_t aArgsLength, Arg aArgs[])
     otError    error;
     otSockAddr sockaddr;
 
-    VerifyOrExit(aArgsLength > 1, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    // Destination IPv6 address
     memset(&sockaddr, 0, sizeof(sockaddr));
-    SuccessOrExit(error = aArgs[1].ParseAsIp6Address(sockaddr.mAddress));
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Address(sockaddr.mAddress));
     sockaddr.mPort = OT_DEFAULT_COAP_SECURE_PORT;
 
-    // check for port specification
-    if (aArgsLength > 2)
+    if (aArgsLength > 1)
     {
-        SuccessOrExit(error = aArgs[2].ParseAsUint16(sockaddr.mPort));
+        SuccessOrExit(error = aArgs[1].ParseAsUint16(sockaddr.mPort));
     }
 
     SuccessOrExit(error = otCoapSecureConnect(mInterpreter.mInstance, &sockaddr, &CoapSecure::HandleConnected, this));
@@ -426,17 +424,17 @@ otError CoapSecure::ProcessPsk(uint8_t aArgsLength, Arg aArgs[])
     otError  error = OT_ERROR_NONE;
     uint16_t length;
 
-    VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aArgsLength > 1, error = OT_ERROR_INVALID_ARGS);
 
-    length = aArgs[1].GetLength();
+    length = aArgs[0].GetLength();
     VerifyOrExit(length <= sizeof(mPsk), error = OT_ERROR_INVALID_ARGS);
     mPskLength = static_cast<uint8_t>(length);
-    memcpy(mPsk, aArgs[1].GetCString(), mPskLength);
+    memcpy(mPsk, aArgs[0].GetCString(), mPskLength);
 
-    length = aArgs[2].GetLength();
+    length = aArgs[1].GetLength();
     VerifyOrExit(length <= sizeof(mPskId), error = OT_ERROR_INVALID_ARGS);
     mPskIdLength = static_cast<uint8_t>(length);
-    memcpy(mPskId, aArgs[2].GetCString(), mPskIdLength);
+    memcpy(mPskId, aArgs[1].GetCString(), mPskIdLength);
 
     otCoapSecureSetPsk(mInterpreter.mInstance, mPsk, mPskLength, mPskId, mPskIdLength);
     mUseCertificate = false;
@@ -475,7 +473,7 @@ otError CoapSecure::Process(uint8_t aArgsLength, Arg aArgs[])
     command = Utils::LookupTable::Find(aArgs[0].GetCString(), sCommands);
     VerifyOrExit(command != nullptr, error = OT_ERROR_INVALID_COMMAND);
 
-    error = (this->*command->mHandler)(aArgsLength, aArgs);
+    error = (this->*command->mHandler)(aArgsLength - 1, aArgs + 1);
 
 exit:
     return error;

--- a/src/cli/cli_commissioner.cpp
+++ b/src/cli/cli_commissioner.cpp
@@ -63,12 +63,12 @@ otError Commissioner::ProcessAnnounce(uint8_t aArgsLength, Arg aArgs[])
     uint16_t     period;
     otIp6Address address;
 
-    VerifyOrExit(aArgsLength > 4, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aArgsLength > 3, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = aArgs[1].ParseAsUint32(mask));
-    SuccessOrExit(error = aArgs[2].ParseAsUint8(count));
-    SuccessOrExit(error = aArgs[3].ParseAsUint16(period));
-    SuccessOrExit(error = aArgs[4].ParseAsIp6Address(address));
+    SuccessOrExit(error = aArgs[0].ParseAsUint32(mask));
+    SuccessOrExit(error = aArgs[1].ParseAsUint8(count));
+    SuccessOrExit(error = aArgs[2].ParseAsUint16(period));
+    SuccessOrExit(error = aArgs[3].ParseAsIp6Address(address));
 
     SuccessOrExit(error = otCommissionerAnnounceBegin(mInterpreter.mInstance, mask, count, period, &address));
 
@@ -85,13 +85,13 @@ otError Commissioner::ProcessEnergy(uint8_t aArgsLength, Arg aArgs[])
     uint16_t     scanDuration;
     otIp6Address address;
 
-    VerifyOrExit(aArgsLength > 5, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aArgsLength > 4, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = aArgs[1].ParseAsUint32(mask));
-    SuccessOrExit(error = aArgs[2].ParseAsUint8(count));
-    SuccessOrExit(error = aArgs[3].ParseAsUint16(period));
-    SuccessOrExit(error = aArgs[4].ParseAsUint16(scanDuration));
-    SuccessOrExit(error = aArgs[5].ParseAsIp6Address(address));
+    SuccessOrExit(error = aArgs[0].ParseAsUint32(mask));
+    SuccessOrExit(error = aArgs[1].ParseAsUint8(count));
+    SuccessOrExit(error = aArgs[2].ParseAsUint16(period));
+    SuccessOrExit(error = aArgs[3].ParseAsUint16(scanDuration));
+    SuccessOrExit(error = aArgs[4].ParseAsIp6Address(address));
 
     SuccessOrExit(error = otCommissionerEnergyScan(mInterpreter.mInstance, mask, count, period, scanDuration, &address,
                                                    &Commissioner::HandleEnergyReport, this));
@@ -107,17 +107,17 @@ otError Commissioner::ProcessJoiner(uint8_t aArgsLength, Arg aArgs[])
     const otExtAddress *addrPtr = nullptr;
     otJoinerDiscerner   discerner;
 
-    VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aArgsLength > 1, error = OT_ERROR_INVALID_ARGS);
 
     memset(&discerner, 0, sizeof(discerner));
 
-    if (aArgs[2] == "*")
+    if (aArgs[1] == "*")
     {
         // Intentionally empty
     }
-    else if ((error = Interpreter::ParseJoinerDiscerner(aArgs[2], discerner)) == OT_ERROR_NOT_FOUND)
+    else if ((error = Interpreter::ParseJoinerDiscerner(aArgs[1], discerner)) == OT_ERROR_NOT_FOUND)
     {
-        SuccessOrExit(error = aArgs[2].ParseAsHexString(addr.m8));
+        SuccessOrExit(error = aArgs[1].ParseAsHexString(addr.m8));
         addrPtr = &addr;
     }
     else if (error != OT_ERROR_NONE)
@@ -125,29 +125,29 @@ otError Commissioner::ProcessJoiner(uint8_t aArgsLength, Arg aArgs[])
         ExitNow();
     }
 
-    if (aArgs[1] == "add")
+    if (aArgs[0] == "add")
     {
-        VerifyOrExit(aArgsLength > 3, error = OT_ERROR_INVALID_ARGS);
+        VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
         // Timeout parameter is optional - if not specified, use default value.
         uint32_t timeout = kDefaultJoinerTimeout;
 
-        if (aArgsLength > 4)
+        if (aArgsLength > 3)
         {
-            SuccessOrExit(error = aArgs[4].ParseAsUint32(timeout));
+            SuccessOrExit(error = aArgs[3].ParseAsUint32(timeout));
         }
 
         if (discerner.mLength)
         {
             SuccessOrExit(error = otCommissionerAddJoinerWithDiscerner(mInterpreter.mInstance, &discerner,
-                                                                       aArgs[3].GetCString(), timeout));
+                                                                       aArgs[2].GetCString(), timeout));
         }
         else
         {
             SuccessOrExit(error =
-                              otCommissionerAddJoiner(mInterpreter.mInstance, addrPtr, aArgs[3].GetCString(), timeout));
+                              otCommissionerAddJoiner(mInterpreter.mInstance, addrPtr, aArgs[2].GetCString(), timeout));
         }
     }
-    else if (aArgs[1] == "remove")
+    else if (aArgs[0] == "remove")
     {
         if (discerner.mLength)
         {
@@ -173,7 +173,7 @@ otError Commissioner::ProcessMgmtGet(uint8_t aArgsLength, Arg aArgs[])
     uint8_t tlvs[32];
     uint8_t length = 0;
 
-    for (uint8_t index = 1; index < aArgsLength; index++)
+    for (uint8_t index = 0; index < aArgsLength; index++)
     {
         VerifyOrExit(static_cast<size_t>(length) < sizeof(tlvs), error = OT_ERROR_NO_BUFS);
 
@@ -225,7 +225,7 @@ otError Commissioner::ProcessMgmtSet(uint8_t aArgsLength, Arg aArgs[])
 
     memset(&dataset, 0, sizeof(dataset));
 
-    for (uint8_t index = 1; index < aArgsLength; index++)
+    for (uint8_t index = 0; index < aArgsLength; index++)
     {
         if (aArgs[index] == "locator")
         {
@@ -283,11 +283,11 @@ otError Commissioner::ProcessPanId(uint8_t aArgsLength, Arg aArgs[])
     uint32_t     mask;
     otIp6Address address;
 
-    VerifyOrExit(aArgsLength > 3, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aArgsLength > 2, error = OT_ERROR_INVALID_ARGS);
 
-    SuccessOrExit(error = aArgs[1].ParseAsUint16(panId));
-    SuccessOrExit(error = aArgs[2].ParseAsUint32(mask));
-    SuccessOrExit(error = aArgs[3].ParseAsIp6Address(address));
+    SuccessOrExit(error = aArgs[0].ParseAsUint16(panId));
+    SuccessOrExit(error = aArgs[1].ParseAsUint32(mask));
+    SuccessOrExit(error = aArgs[2].ParseAsIp6Address(address));
 
     SuccessOrExit(error = otCommissionerPanIdQuery(mInterpreter.mInstance, panId, mask, &address,
                                                    &Commissioner::HandlePanIdConflict, this));
@@ -299,7 +299,7 @@ exit:
 otError Commissioner::ProcessProvisioningUrl(uint8_t aArgsLength, Arg aArgs[])
 {
     return otCommissionerSetProvisioningUrl(mInterpreter.mInstance,
-                                            (aArgsLength > 1) ? aArgs[1].GetCString() : nullptr);
+                                            (aArgsLength > 0) ? aArgs[0].GetCString() : nullptr);
 }
 
 otError Commissioner::ProcessSessionId(uint8_t aArgsLength, Arg aArgs[])
@@ -422,7 +422,7 @@ otError Commissioner::Process(uint8_t aArgsLength, Arg aArgs[])
     command = Utils::LookupTable::Find(aArgs[0].GetCString(), sCommands);
     VerifyOrExit(command != nullptr);
 
-    error = (this->*command->mHandler)(aArgsLength, aArgs);
+    error = (this->*command->mHandler)(aArgsLength - 1, aArgs + 1);
 
 exit:
     return error;

--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -48,24 +48,24 @@ otError Joiner::ProcessDiscerner(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
-    if (aArgsLength == 2)
+    if (aArgsLength == 1)
     {
         otJoinerDiscerner discerner;
 
         memset(&discerner, 0, sizeof(discerner));
 
-        if (aArgs[1] == "clear")
+        if (aArgs[0] == "clear")
         {
             SuccessOrExit(error = otJoinerSetDiscerner(mInterpreter.mInstance, nullptr));
         }
         else
         {
-            VerifyOrExit(OT_ERROR_NONE == Interpreter::ParseJoinerDiscerner(aArgs[1], discerner),
+            VerifyOrExit(OT_ERROR_NONE == Interpreter::ParseJoinerDiscerner(aArgs[0], discerner),
                          error = OT_ERROR_INVALID_ARGS);
             SuccessOrExit(error = otJoinerSetDiscerner(mInterpreter.mInstance, &discerner));
         }
     }
-    else if (aArgsLength == 1)
+    else if (aArgsLength == 0)
     {
         const otJoinerDiscerner *discerner = otJoinerGetDiscerner(mInterpreter.mInstance);
 
@@ -111,14 +111,14 @@ otError Joiner::ProcessStart(uint8_t aArgsLength, Arg aArgs[])
     otError     error;
     const char *provisioningUrl = nullptr;
 
-    VerifyOrExit(aArgsLength > 1, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aArgsLength > 0, error = OT_ERROR_INVALID_ARGS);
 
-    if (aArgsLength > 2)
+    if (aArgsLength > 1)
     {
-        provisioningUrl = aArgs[2].GetCString();
+        provisioningUrl = aArgs[1].GetCString();
     }
 
-    error = otJoinerStart(mInterpreter.mInstance, aArgs[1].GetCString(), provisioningUrl, PACKAGE_NAME,
+    error = otJoinerStart(mInterpreter.mInstance, aArgs[0].GetCString(), provisioningUrl, PACKAGE_NAME,
                           OPENTHREAD_CONFIG_PLATFORM_INFO, PACKAGE_VERSION, nullptr, &Joiner::HandleCallback, this);
 
 exit:
@@ -145,7 +145,7 @@ otError Joiner::Process(uint8_t aArgsLength, Arg aArgs[])
     command = Utils::LookupTable::Find(aArgs[0].GetCString(), sCommands);
     VerifyOrExit(command != nullptr);
 
-    error = (this->*command->mHandler)(aArgsLength, aArgs);
+    error = (this->*command->mHandler)(aArgsLength - 1, aArgs + 1);
 
 exit:
     return error;

--- a/src/cli/cli_srp_server.cpp
+++ b/src/cli/cli_srp_server.cpp
@@ -55,7 +55,7 @@ otError SrpServer::Process(uint8_t aArgsLength, Arg aArgs[])
     command = Utils::LookupTable::Find(aArgs[0].GetCString(), sCommands);
     VerifyOrExit(command != nullptr);
 
-    error = (this->*command->mHandler)(aArgsLength, aArgs);
+    error = (this->*command->mHandler)(aArgsLength - 1, aArgs + 1);
 
 exit:
     return error;
@@ -65,9 +65,9 @@ otError SrpServer::ProcessDomain(uint8_t aArgsLength, Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
 
-    if (aArgsLength > 1)
+    if (aArgsLength > 0)
     {
-        SuccessOrExit(error = otSrpServerSetDomain(mInterpreter.mInstance, aArgs[1].GetCString()));
+        SuccessOrExit(error = otSrpServerSetDomain(mInterpreter.mInstance, aArgs[0].GetCString()));
     }
     else
     {
@@ -103,15 +103,15 @@ otError SrpServer::ProcessLease(uint8_t aArgsLength, Arg aArgs[])
     otError                error = OT_ERROR_NONE;
     otSrpServerLeaseConfig leaseConfig;
 
-    if (aArgsLength == 5)
+    if (aArgsLength == 4)
     {
-        SuccessOrExit(error = aArgs[1].ParseAsUint32(leaseConfig.mMinLease));
-        SuccessOrExit(error = aArgs[2].ParseAsUint32(leaseConfig.mMaxLease));
-        SuccessOrExit(error = aArgs[3].ParseAsUint32(leaseConfig.mMinKeyLease));
-        SuccessOrExit(error = aArgs[4].ParseAsUint32(leaseConfig.mMaxKeyLease));
+        SuccessOrExit(error = aArgs[0].ParseAsUint32(leaseConfig.mMinLease));
+        SuccessOrExit(error = aArgs[1].ParseAsUint32(leaseConfig.mMaxLease));
+        SuccessOrExit(error = aArgs[2].ParseAsUint32(leaseConfig.mMinKeyLease));
+        SuccessOrExit(error = aArgs[3].ParseAsUint32(leaseConfig.mMaxKeyLease));
         error = otSrpServerSetLeaseConfig(mInterpreter.mInstance, &leaseConfig);
     }
-    else if (aArgsLength == 1)
+    else if (aArgsLength == 0)
     {
         otSrpServerGetLeaseConfig(mInterpreter.mInstance, &leaseConfig);
         mInterpreter.OutputLine("min lease: %u", leaseConfig.mMinLease);
@@ -135,7 +135,7 @@ otError SrpServer::ProcessHost(uint8_t aArgsLength, Arg aArgs[])
     otError                error = OT_ERROR_NONE;
     const otSrpServerHost *host;
 
-    VerifyOrExit(aArgsLength <= 1, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aArgsLength == 0, error = OT_ERROR_INVALID_ARGS);
 
     host = nullptr;
     while ((host = otSrpServerGetNextHost(mInterpreter.mInstance, host)) != nullptr)
@@ -199,7 +199,7 @@ otError SrpServer::ProcessService(uint8_t aArgsLength, Arg aArgs[])
     otError                error = OT_ERROR_NONE;
     const otSrpServerHost *host;
 
-    VerifyOrExit(aArgsLength <= 1, error = OT_ERROR_INVALID_ARGS);
+    VerifyOrExit(aArgsLength == 0, error = OT_ERROR_INVALID_ARGS);
 
     host = nullptr;
     while ((host = otSrpServerGetNextHost(mInterpreter.mInstance, host)) != nullptr)


### PR DESCRIPTION
This commit updates how the arguments are passed to different CLI
command handles such that the same model is now used by all CLI
modules where all the previously parsed and consumed arguments are
removed and only the remaining un-parsed arguments are passed to the
next handler.

