### PR TITLE
[posix] fix issue with logging CLI output

### DIFF
--- a/src/posix/platform/daemon.cpp
+++ b/src/posix/platform/daemon.cpp
@@ -80,7 +80,6 @@ int Daemon::OutputFormatV(const char *aFormat, va_list aArguments)
 
     VerifyOrExit(rval >= 0, otLogWarnPlat("Failed to format CLI output: %s", strerror(errno)));
 
-    otLogInfoPlat("%s", buf);
     VerifyOrExit(mSessionSocket != -1);
 
 #if defined(__linux__)


### PR DESCRIPTION
This commit reverts the change from PR #6639 which added logging
of the CLI output. Note that the CLI output can be generated and
outputted in smaller pieces (not as a whole line) so the model
from PR #6639 would emit each piece as a different log line which
is not desirable.

----

This is to address Issue https://github.com/openthread/openthread/issues/6665.