### PR TITLE
[srp-client] allow callback to be invoked when client is stopped

### DIFF
--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -594,7 +594,6 @@ void Client::InvokeCallback(Error aError) const
 
 void Client::InvokeCallback(Error aError, const HostInfo &aHostInfo, const Service *aRemovedServices) const
 {
-    VerifyOrExit(GetState() != kStateStopped);
     VerifyOrExit(mCallback != nullptr);
     mCallback(aError, &aHostInfo, mServices.GetHead(), aRemovedServices, mCallbackContext);
 


### PR DESCRIPTION
This commit relaxes the condition for invoking the callback from SRP
client allowing it to be invoked when client is stopped.

Note that the user can call SRP client APIs to add or remove services
while it is stopped. A remove request may be processed immediately
(if the service has not yet been registered) and then the callback is
invoked to notify the caller to reclaim the service entry.