### PR TITLE
[string] use `StringFind()` in core modules

### DIFF
--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -39,6 +39,7 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/random.hpp"
+#include "common/string.hpp"
 
 namespace ot {
 namespace Coap {
@@ -229,7 +230,7 @@ Error Message::AppendUriPathOptions(const char *aUriPath)
     const char *cur   = aUriPath;
     const char *end;
 
-    while ((end = strchr(cur, '/')) != nullptr)
+    while ((end = StringFind(cur, '/')) != nullptr)
     {
         SuccessOrExit(error = AppendOption(kOptionUriPath, static_cast<uint16_t>(end - cur), cur));
         cur = end + 1;

--- a/src/core/utils/parse_cmdline.cpp
+++ b/src/core/utils/parse_cmdline.cpp
@@ -37,6 +37,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/numeric_limits.hpp"
+#include "common/string.hpp"
 #include "net/ip6_address.hpp"
 
 namespace ot {
@@ -258,7 +259,7 @@ Error ParseAsIp6Prefix(const char *aString, otIp6Prefix &aPrefix)
     char        string[kMaxIp6AddressStringSize];
     const char *prefixLengthStr;
 
-    prefixLengthStr = strchr(aString, '/');
+    prefixLengthStr = StringFind(aString, '/');
     VerifyOrExit(prefixLengthStr != nullptr);
 
     VerifyOrExit(prefixLengthStr - aString < static_cast<int32_t>(sizeof(string)));


### PR DESCRIPTION
This commit replaces uses of `strchr()` with `StringFind()`.