### PR TITLE
[mle] ensure MLE messages are sent via broadcast

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -365,7 +365,7 @@ Error MeshForwarder::UpdateIp6Route(Message &aMessage)
         // with link security disabled, an End Device transmits
         // multicasts, as IEEE 802.15.4 unicasts to its parent.
 
-        if (mle.IsChild() && aMessage.IsLinkSecurityEnabled())
+        if (mle.IsChild() && aMessage.IsLinkSecurityEnabled() && !aMessage.IsSubTypeMle())
         {
             mMacDest.SetShort(mle.GetNextHop(Mac::kShortAddrBroadcast));
         }


### PR DESCRIPTION
MLE Announce messages are sent with link security enabled. This commit
ensures that REEDs always send MLE Announce messages to the broadcast
destination address.