### PR TITLE
[tests] fix intermittent failures in Cert_9_2_16

### DIFF
--- a/tests/scripts/thread-cert/Cert_9_2_16_ActivePendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_16_ActivePendingPartition.py
@@ -126,6 +126,7 @@ class Cert_9_2_16_ActivePendingPartition(thread_cert.TestCase):
 
         self.nodes[ROUTER2].reset()
         self._setUpRouter2()
+        self.simulator.go(100)
 
         self.nodes[COMMISSIONER].send_mgmt_pending_set(
             pending_timestamp=20,


### PR DESCRIPTION
Add additional delay to prevent link repair using MLE Link Request on
Adv timeout.