### PR TITLE
[common] adding `HeapString` class (heap allocated string) + use in `Srp::Server`

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -218,6 +218,7 @@ LOCAL_SRC_FILES                                                  := \
     src/core/coap/coap_secure.cpp                                   \
     src/core/common/crc16.cpp                                       \
     src/core/common/error.cpp                                       \
+    src/core/common/heap_string.cpp                                 \
     src/core/common/instance.cpp                                    \
     src/core/common/logging.cpp                                     \
     src/core/common/message.cpp                                     \

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -372,6 +372,8 @@ openthread_core_files = [
   "common/error.cpp",
   "common/error.hpp",
   "common/extension.hpp",
+  "common/heap_string.cpp",
+  "common/heap_string.hpp",
   "common/instance.cpp",
   "common/instance.hpp",
   "common/iterator_utils.hpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -91,6 +91,7 @@ set(COMMON_SOURCES
     coap/coap_secure.cpp
     common/crc16.cpp
     common/error.cpp
+    common/heap_string.cpp
     common/instance.cpp
     common/logging.cpp
     common/message.cpp

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -168,6 +168,7 @@ SOURCES_COMMON                                  = \
     coap/coap_secure.cpp                          \
     common/crc16.cpp                              \
     common/error.cpp                              \
+    common/heap_string.cpp                        \
     common/instance.cpp                           \
     common/logging.cpp                            \
     common/message.cpp                            \
@@ -384,6 +385,7 @@ HEADERS_COMMON                                  = \
     common/equatable.hpp                          \
     common/error.hpp                              \
     common/extension.hpp                          \
+    common/heap_string.hpp                        \
     common/instance.hpp                           \
     common/iterator_utils.hpp                     \
     common/linked_list.hpp                        \

--- a/src/core/common/heap_string.cpp
+++ b/src/core/common/heap_string.cpp
@@ -1,0 +1,98 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements the `HeapString` (a heap allocated string).
+ */
+
+#include "heap_string.hpp"
+
+#include "common/code_utils.hpp"
+#include "common/instance.hpp"
+#include "common/string.hpp"
+
+namespace ot {
+
+Error HeapString::Set(const char *aCString)
+{
+    Error  error = kErrorNone;
+    size_t curSize;
+    size_t newSize;
+
+    VerifyOrExit(aCString != nullptr, Free());
+
+    curSize = (mStringBuffer != nullptr) ? strlen(mStringBuffer) + 1 : 0;
+    newSize = strlen(aCString) + 1;
+
+    if (curSize != newSize)
+    {
+        char *newBuffer = static_cast<char *>(Instance::HeapCAlloc(sizeof(char), newSize));
+
+        VerifyOrExit(newBuffer != nullptr, error = kErrorNoBufs);
+
+        Instance::HeapFree(mStringBuffer);
+        mStringBuffer = newBuffer;
+    }
+
+    memcpy(mStringBuffer, aCString, newSize);
+
+exit:
+    return error;
+}
+
+Error HeapString::Set(HeapString &&aString)
+{
+    VerifyOrExit(mStringBuffer != aString.mStringBuffer);
+
+    Instance::HeapFree(mStringBuffer);
+    mStringBuffer         = aString.mStringBuffer;
+    aString.mStringBuffer = nullptr;
+
+exit:
+    return kErrorNone;
+}
+
+void HeapString::Free(void)
+{
+    Instance::HeapFree(mStringBuffer);
+    mStringBuffer = nullptr;
+}
+
+bool HeapString::operator==(const char *aCString) const
+{
+    bool isEqual;
+
+    VerifyOrExit((aCString != nullptr) && (mStringBuffer != nullptr), isEqual = (mStringBuffer == aCString));
+    isEqual = (strcmp(mStringBuffer, aCString) == 0);
+
+exit:
+    return isEqual;
+}
+
+} // namespace ot

--- a/src/core/common/heap_string.hpp
+++ b/src/core/common/heap_string.hpp
@@ -1,0 +1,185 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for `HeapString` (a heap allocated string).
+ */
+
+#ifndef HEAP_STRING_HPP_
+#define HEAP_STRING_HPP_
+
+#include "openthread-core-config.h"
+
+#include "common/equatable.hpp"
+#include "common/error.hpp"
+
+namespace ot {
+
+/**
+ * This class represents a heap allocated string.
+ *
+ * The buffer to store the string is allocated from heap and is manged by the `HeapString` class itself, e.g., it may
+ * be reused and/or freed and reallocated when the string is set. The `HeapString` destructor will always free the
+ * allocated buffer.
+ *
+ */
+class HeapString : public Unequatable<HeapString>
+{
+public:
+    /**
+     * This constructor initializes the `HeapString` as null (or empty).
+     *
+     */
+    HeapString(void)
+        : mStringBuffer(nullptr)
+    {
+    }
+
+    /**
+     * This is the move constructor for `HeapString`.
+     *
+     * `HeapString` is non-copyable (copy constructor is deleted) but move constructor is provided to allow it to to be
+     * used as return type (return by value) from functions/methods (which will then use move semantics).
+     *
+     */
+    HeapString(HeapString &&aString)
+        : mStringBuffer(aString.mStringBuffer)
+    {
+        aString.mStringBuffer = nullptr;
+    }
+
+    /**
+     * This is the destructor for `HealString` object
+     *
+     */
+    ~HeapString(void) { Free(); }
+
+    /**
+     * This method indicates whether or not the `HeapString` is null (i.e., it was never successfully set or it was
+     * freed).
+     *
+     * @retval TRUE  The `HeapString` is null.
+     * @retval FALSE The `HeapString` is not null.
+     *
+     */
+    bool IsNull(void) const { return (mStringBuffer == nullptr); }
+
+    /**
+     * This method returns the `HeapString` as a C string.
+     *
+     * @returns A pointer to C string buffer or `nullptr` if the `HeapString` is null (never set or freed).
+     *
+     */
+    const char *AsCString(void) const { return mStringBuffer; }
+
+    /**
+     * This method sets the string from a given C string.
+     *
+     * @param[in] aCString   A pointer to c string buffer. Can be `nullptr` which then frees the `HeapString`.
+     *
+     * @retval kErrorNone     Successfully set the string.
+     * @retval kErrorNoBufs   Failed to allocate buffer for string.
+     *
+     */
+    Error Set(const char *aCString);
+
+    /**
+     * This method sets the string from another `HeapString`.
+     *
+     * @param[in] aString   The other `HeapString` to set from.
+     *
+     * @retval kErrorNone     Successfully set the string.
+     * @retval kErrorNoBufs   Failed to allocate buffer for string.
+     *
+     */
+    Error Set(const HeapString &aString) { return Set(aString.AsCString()); }
+
+    /**
+     * This method sets the string from another `HeapString`.
+     *
+     * @param[in] aString     The other `HeapString` to set from (rvalue reference using move semantics).
+     *
+     * @retval kErrorNone     Successfully set the string.
+     * @retval kErrorNoBufs   Failed to allocate buffer for string.
+     *
+     */
+    Error Set(HeapString &&aString);
+
+    /**
+     * This method frees any buffer allocated by the `HeapString`.
+     *
+     * The `HeapString` destructor will automatically call `Free()`. This method allows caller to free buffer
+     * explicitly.
+     *
+     */
+    void Free(void);
+
+    /**
+     * This method overloads operator `==` to evaluate whether or not the `HeapString` is equal to a given C string.
+     *
+     * @param[in]  aCString  A C string to compare with. Can be `nullptr` which then checks if `HeapString` is null.
+     *
+     * @retval TRUE   If the two strings are equal.
+     * @retval FALSE  If the two strings are not equal.
+     *
+     */
+    bool operator==(const char *aCString) const;
+
+    /**
+     * This method overloads operator `!=` to evaluate whether or not the `HeapString` is unequal to a given C string.
+     *
+     * @param[in]  aCString  A C string to compare with. Can be `nullptr` which then checks if `HeapString` is not null.
+     *
+     * @retval TRUE   If the two strings are not equal.
+     * @retval FALSE  If the two strings are equal.
+     *
+     */
+    bool operator!=(const char *aCString) const { return !(*this == aCString); }
+
+    /**
+     * This method overloads operator `==` to evaluate whether or not two `HeapString` are equal.
+     *
+     * @param[in]  aString  The other string to compare with.
+     *
+     * @retval TRUE   If the two strings are equal.
+     * @retval FALSE  If the two strings are not equal.
+     *
+     */
+    bool operator==(const HeapString &aString) const { return (*this == aString.AsCString()); }
+
+    HeapString(const HeapString &) = delete;
+    HeapString &operator=(const HeapString &) = delete;
+
+private:
+    char *mStringBuffer;
+};
+
+} // namespace ot
+
+#endif // HEAP_STRING_HPP_

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -80,7 +80,6 @@ Server::Server(Instance &aInstance)
     , mSocket(aInstance)
     , mServiceUpdateHandler(nullptr)
     , mServiceUpdateHandlerContext(nullptr)
-    , mDomain(nullptr)
     , mLeaseTimer(aInstance, HandleLeaseTimer)
     , mOutstandingUpdatesTimer(aInstance, HandleOutstandingUpdatesTimer)
     , mServiceUpdateId(Random::NonCrypto::GetUint32())
@@ -88,11 +87,6 @@ Server::Server(Instance &aInstance)
     , mHasRegisteredAnyService(false)
 {
     IgnoreError(SetDomain(kDefaultDomain));
-}
-
-Server::~Server(void)
-{
-    Instance::HeapFree(mDomain);
 }
 
 void Server::SetServiceHandler(otSrpServerServiceUpdateHandler aServiceHandler, void *aServiceHandlerContext)
@@ -173,36 +167,34 @@ exit:
 
 Error Server::SetDomain(const char *aDomain)
 {
-    Error  error             = kErrorNone;
-    char * buf               = nullptr;
-    size_t appendTrailingDot = 0;
-    size_t length            = strlen(aDomain);
+    Error    error = kErrorNone;
+    uint16_t length;
 
     VerifyOrExit(!mEnabled, error = kErrorInvalidState);
 
-    VerifyOrExit(length > 0 && length < Dns::Name::kMaxNameSize, error = kErrorInvalidArgs);
-    if (aDomain[length - 1] != '.')
+    length = StringLength(aDomain, Dns::Name::kMaxNameSize);
+    VerifyOrExit((length > 0) && (length < Dns::Name::kMaxNameSize), error = kErrorInvalidArgs);
+
+    if (aDomain[length - 1] == '.')
     {
-        appendTrailingDot = 1;
+        error = mDomain.Set(aDomain);
     }
-
-    buf = static_cast<char *>(Instance::HeapCAlloc(1, length + appendTrailingDot + 1));
-    VerifyOrExit(buf != nullptr, error = kErrorNoBufs);
-
-    strcpy(buf, aDomain);
-    if (appendTrailingDot)
+    else
     {
+        // Need to append dot at the end
+
+        char buf[Dns::Name::kMaxNameSize];
+
+        VerifyOrExit(length < Dns::Name::kMaxNameSize - 1, error = kErrorInvalidArgs);
+
+        memcpy(buf, aDomain, length);
         buf[length]     = '.';
         buf[length + 1] = '\0';
+
+        error = mDomain.Set(buf);
     }
-    Instance::HeapFree(mDomain);
-    mDomain = buf;
 
 exit:
-    if (error != kErrorNone)
-    {
-        Instance::HeapFree(buf);
-    }
     return error;
 }
 
@@ -228,13 +220,13 @@ void Server::RemoveHost(Host *aHost, bool aRetainName, bool aNotifyServiceHandle
 
     if (aRetainName)
     {
-        otLogInfoSrp("[server] remove host '%s' (but retain its name)", aHost->mFullName);
+        otLogInfoSrp("[server] remove host '%s' (but retain its name)", aHost->GetFullName());
     }
     else
     {
         aHost->mKeyLease = 0;
         IgnoreError(mHosts.Remove(*aHost));
-        otLogInfoSrp("[server] fully remove host '%s'", aHost->mFullName);
+        otLogInfoSrp("[server] fully remove host '%s'", aHost->GetFullName());
     }
 
     if (aNotifyServiceHandler && mServiceUpdateHandler != nullptr)
@@ -286,7 +278,7 @@ bool Server::HasNameConflictsWith(Host &aHost) const
     // Check not only services of this host but all hosts.
     while ((service = aHost.GetNextService(service)) != nullptr)
     {
-        const Service *existingService = FindService(service->mFullName);
+        const Service *existingService = FindService(service->GetFullName());
         if (existingService != nullptr && *service->GetHost().GetKey() != *existingService->GetHost().GetKey())
         {
             ExitNow(hasConflicts = true);
@@ -383,7 +375,7 @@ void Server::CommitSrpUpdate(Error                    aError,
         existingHost->CopyResourcesFrom(aHost);
         while ((service = aHost.GetNextService(service)) != nullptr)
         {
-            Service *existingService = existingHost->FindService(service->mFullName);
+            Service *existingService = existingHost->FindService(service->GetFullName());
 
             if (service->mIsDeleted)
             {
@@ -391,12 +383,12 @@ void Server::CommitSrpUpdate(Error                    aError,
             }
             else
             {
-                Service *newService = existingHost->AddService(service->mFullName);
+                Service *newService = existingHost->AddService(service->GetFullName());
 
                 VerifyOrExit(newService != nullptr, aError = kErrorNoBufs);
                 SuccessOrExit(aError = newService->CopyResourcesFrom(*service));
                 otLogInfoSrp("[server] %s service %s", (existingService != nullptr) ? "update existing" : "add new",
-                             service->mFullName);
+                             service->GetFullName());
             }
         }
 
@@ -1030,7 +1022,7 @@ void Server::HandleUpdate(const Dns::UpdateHeader &aDnsHeader, Host *aHost, cons
             {
                 if (!existingService->mIsDeleted)
                 {
-                    Service *service = aHost->AddService(existingService->mFullName);
+                    Service *service = aHost->AddService(existingService->GetFullName());
                     VerifyOrExit(service != nullptr, error = kErrorNoBufs);
                     service->mIsDeleted = true;
                 }
@@ -1216,7 +1208,7 @@ void Server::HandleLeaseTimer(void)
 
                 if (service->GetKeyExpireTime() <= now)
                 {
-                    otLogInfoSrp("[server] KEY LEASE of service %s expired", service->mFullName);
+                    otLogInfoSrp("[server] KEY LEASE of service %s expired", service->GetFullName());
                     host->RemoveService(service, /* aRetainName */ false, /* aNotifyServiceHandler */ true);
                 }
                 else
@@ -1264,7 +1256,7 @@ void Server::HandleLeaseTimer(void)
                 }
                 else if (service->GetExpireTime() <= now)
                 {
-                    otLogInfoSrp("[server] LEASE of service %s expired", service->mFullName);
+                    otLogInfoSrp("[server] LEASE of service %s expired", service->GetFullName());
 
                     // The service is expired, delete it.
                     host->RemoveService(service, /* aRetainName */ true, /* aNotifyServiceHandler */ true);
@@ -1332,14 +1324,13 @@ exit:
 
 void Server::Service::Free(void)
 {
-    Instance::HeapFree(mFullName);
+    mFullName.Free();
     Instance::HeapFree(mTxtData);
     Instance::HeapFree(this);
 }
 
 Server::Service::Service(void)
-    : mFullName(nullptr)
-    , mPriority(0)
+    : mPriority(0)
     , mWeight(0)
     , mPort(0)
     , mTxtLength(0)
@@ -1348,23 +1339,6 @@ Server::Service::Service(void)
     , mNext(nullptr)
     , mTimeLastUpdate(TimerMilli::GetNow())
 {
-}
-
-Error Server::Service::SetFullName(const char *aFullName)
-{
-    OT_ASSERT(aFullName != nullptr);
-
-    Error error    = kErrorNone;
-    char *nameCopy = static_cast<char *>(Instance::HeapCAlloc(1, strlen(aFullName) + 1));
-
-    VerifyOrExit(nameCopy != nullptr, error = kErrorNoBufs);
-    strcpy(nameCopy, aFullName);
-
-    Instance::HeapFree(mFullName);
-    mFullName = nameCopy;
-
-exit:
-    return error;
 }
 
 TimeMilli Server::Service::GetExpireTime(void) const
@@ -1450,23 +1424,18 @@ exit:
     return error;
 }
 
-bool Server::Service::Matches(const char *aFullName) const
-{
-    return (mFullName != nullptr) && (strcmp(mFullName, aFullName) == 0);
-}
-
 bool Server::Service::MatchesServiceName(const char *aServiceName) const
 {
-    uint8_t i = static_cast<uint8_t>(strlen(mFullName));
+    uint8_t i = static_cast<uint8_t>(strlen(GetFullName()));
     uint8_t j = static_cast<uint8_t>(strlen(aServiceName));
 
-    while (i > 0 && j > 0 && mFullName[i - 1] == aServiceName[j - 1])
+    while (i > 0 && j > 0 && GetFullName()[i - 1] == aServiceName[j - 1])
     {
         i--;
         j--;
     }
 
-    return j == 0 && i > 0 && mFullName[i - 1] == '.';
+    return j == 0 && i > 0 && GetFullName()[i - 1] == '.';
 }
 
 Server::Host *Server::Host::New(Instance &aInstance)
@@ -1486,13 +1455,12 @@ exit:
 void Server::Host::Free(void)
 {
     FreeAllServices();
-    Instance::HeapFree(mFullName);
+    mFullName.Free();
     Instance::HeapFree(this);
 }
 
 Server::Host::Host(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mFullName(nullptr)
     , mAddressesNum(0)
     , mNext(nullptr)
     , mLease(0)
@@ -1500,26 +1468,6 @@ Server::Host::Host(Instance &aInstance)
     , mTimeLastUpdate(TimerMilli::GetNow())
 {
     mKey.Clear();
-}
-
-Error Server::Host::SetFullName(const char *aFullName)
-{
-    OT_ASSERT(aFullName != nullptr);
-
-    Error error    = kErrorNone;
-    char *nameCopy = static_cast<char *>(Instance::HeapCAlloc(1, strlen(aFullName) + 1));
-
-    VerifyOrExit(nameCopy != nullptr, error = kErrorNoBufs);
-    strcpy(nameCopy, aFullName);
-
-    if (mFullName != nullptr)
-    {
-        Instance::HeapFree(mFullName);
-    }
-    mFullName = nameCopy;
-
-exit:
-    return error;
 }
 
 void Server::Host::SetKey(Dns::Ecdsa256KeyRecord &aKey)
@@ -1571,11 +1519,11 @@ void Server::Host::RemoveService(Service *aService, bool aRetainName, bool aNoti
     if (aRetainName)
     {
         aService->ClearResources();
-        otLogInfoSrp("[server] remove service '%s' (but retain its name)", aService->mFullName);
+        otLogInfoSrp("[server] remove service '%s' (but retain its name)", aService->GetFullName());
     }
     else
     {
-        otLogInfoSrp("[server] fully remove service '%s'", aService->mFullName);
+        otLogInfoSrp("[server] fully remove service '%s'", aService->GetFullName());
     }
 
     if (aNotifyServiceHandler && server.mServiceUpdateHandler != nullptr)
@@ -1663,11 +1611,6 @@ Error Server::Host::AddIp6Address(const Ip6::Address &aIp6Address)
 
 exit:
     return error;
-}
-
-bool Server::Host::Matches(const char *aName) const
-{
-    return mFullName != nullptr && strcmp(mFullName, aName) == 0;
 }
 
 Server::UpdateMetadata *Server::UpdateMetadata::New(Instance &               aInstance,

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -50,6 +50,7 @@
 #include <openthread/srp_server.h>
 
 #include "common/clearable.hpp"
+#include "common/heap_string.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
@@ -137,7 +138,7 @@ public:
          * @returns  A pointer to the null-terminated service name string.
          *
          */
-        const char *GetFullName(void) const { return mFullName; }
+        const char *GetFullName(void) const { return mFullName.AsCString(); }
 
         /**
          * This method returns the port of the service instance.
@@ -213,7 +214,7 @@ public:
          * @returns  TRUE if the service matches the full name, FALSE if doesn't match.
          *
          */
-        bool Matches(const char *aFullName) const;
+        bool Matches(const char *aFullName) const { return (mFullName == aFullName); }
 
         /**
          * This method tells whether this service matches a given service name <Service>.<Domain>.
@@ -228,13 +229,13 @@ public:
 
     private:
         explicit Service(void);
-        Error SetFullName(const char *aFullName);
+        Error SetFullName(const char *aFullName) { return mFullName.Set(aFullName); }
         Error SetTxtData(const uint8_t *aTxtData, uint16_t aTxtDataLength);
         Error SetTxtDataFromMessage(const Message &aMessage, uint16_t aOffset, uint16_t aLength);
         Error CopyResourcesFrom(const Service &aService);
         void  ClearResources(void);
 
-        char *           mFullName;
+        HeapString       mFullName;
         uint16_t         mPriority;
         uint16_t         mWeight;
         uint16_t         mPort;
@@ -291,7 +292,7 @@ public:
          * @returns  A pointer to the null-terminated full host name.
          *
          */
-        const char *GetFullName(void) const { return mFullName; }
+        const char *GetFullName(void) const { return mFullName.AsCString(); }
 
         /**
          * This method returns addresses of the host.
@@ -369,7 +370,7 @@ public:
          * @returns  A boolean that indicates whether the host matches the given name.
          *
          */
-        bool Matches(const char *aName) const;
+        bool Matches(const char *aFullName) const { return (mFullName == aFullName); }
 
     private:
         enum : uint8_t
@@ -378,7 +379,7 @@ public:
         };
 
         explicit Host(Instance &aInstance);
-        Error    SetFullName(const char *aFullName);
+        Error    SetFullName(const char *aFullName) { return mFullName.Set(aFullName); }
         void     SetKey(Dns::Ecdsa256KeyRecord &aKey);
         void     SetLease(uint32_t aLease) { mLease = aLease; }
         void     SetKeyLease(uint32_t aKeyLease) { mKeyLease = aKeyLease; }
@@ -392,7 +393,7 @@ public:
         const Service *FindService(const char *aFullName) const;
         Error          AddIp6Address(const Ip6::Address &aIp6Address);
 
-        char *       mFullName;
+        HeapString   mFullName;
         Ip6::Address mAddresses[kMaxAddressesNum];
         uint8_t      mAddressesNum;
         Host *       mNext;
@@ -432,7 +433,6 @@ public:
      *
      */
     explicit Server(Instance &aInstance);
-    ~Server(void);
 
     /**
      * This method sets the SRP service events handler.
@@ -457,7 +457,7 @@ public:
      * @returns A pointer to the dot-joined domain string.
      *
      */
-    const char *GetDomain(void) const { return mDomain; }
+    const char *GetDomain(void) const { return mDomain.AsCString(); }
 
     /**
      * This method sets the domain on the SRP server.
@@ -662,7 +662,7 @@ private:
     otSrpServerServiceUpdateHandler mServiceUpdateHandler;
     void *                          mServiceUpdateHandlerContext;
 
-    char *mDomain;
+    HeapString mDomain;
 
     LeaseConfig mLeaseConfig;
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -258,6 +258,27 @@ target_link_libraries(ot-test-heap
 
 add_test(NAME ot-test-heap COMMAND ot-test-heap)
 
+add_executable(ot-test-heap-string
+    test_heap_string.cpp
+)
+
+target_include_directories(ot-test-heap-string
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_options(ot-test-heap-string
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
+target_link_libraries(ot-test-heap-string
+    PRIVATE
+        ${COMMON_LIBS}
+)
+
+add_test(NAME ot-test-heap-string COMMAND ot-test-heap-string)
+
 add_executable(ot-test-hkdf-sha256
     ${COMMON_SOURCES}
     test_hkdf_sha256.cpp

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -115,6 +115,7 @@ check_PROGRAMS                                                     += \
     ot-test-ecdsa                                                     \
     ot-test-flash                                                     \
     ot-test-heap                                                      \
+    ot-test-heap-string                                               \
     ot-test-hkdf-sha256                                               \
     ot-test-hmac-sha256                                               \
     ot-test-ip-address                                                \
@@ -205,6 +206,9 @@ ot_test_hdlc_SOURCES            = $(COMMON_SOURCES) test_hdlc.cpp
 
 ot_test_heap_LDADD              = $(COMMON_LDADD)
 ot_test_heap_SOURCES            = $(COMMON_SOURCES) test_heap.cpp
+
+ot_test_heap_string_LDADD       = $(COMMON_LDADD)
+ot_test_heap_string_SOURCES     = $(COMMON_SOURCES) test_heap_string.cpp
 
 ot_test_hkdf_sha256_LDADD       = $(COMMON_LDADD)
 ot_test_hkdf_sha256_SOURCES     = $(COMMON_SOURCES) test_hkdf_sha256.cpp

--- a/tests/unit/test_heap_string.cpp
+++ b/tests/unit/test_heap_string.cpp
@@ -1,0 +1,156 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_platform.h"
+
+#include <string.h>
+
+#include <openthread/config.h>
+
+#include "test_util.hpp"
+#include "common/code_utils.hpp"
+#include "common/heap_string.hpp"
+
+namespace ot {
+
+void PrintString(const char *aName, const HeapString &aString)
+{
+    if (aString.IsNull())
+    {
+        printf("%s = (null)\n", aName);
+    }
+    else
+    {
+        printf("%s = [%zu] \"%s\"\n", aName, strlen(aString.AsCString()), aString.AsCString());
+    }
+}
+
+void VerifyString(const char *aName, const HeapString &aString, const char *aExpectedString)
+{
+    PrintString(aName, aString);
+
+    if (aExpectedString == nullptr)
+    {
+        VerifyOrQuit(aString.IsNull(), "IsNull() is incorrect");
+        VerifyOrQuit(aString.AsCString() == nullptr, "AsCString() is incorrect");
+        VerifyOrQuit(aString != "something", "operator!=() failed");
+    }
+    else
+    {
+        VerifyOrQuit(!aString.IsNull(), "IsNull() is incorrect");
+        VerifyOrQuit(aString.AsCString() != nullptr, "AsCString() is incorrect");
+        VerifyOrQuit(strcmp(aString.AsCString(), aExpectedString) == 0, "String content is incorrect");
+        VerifyOrQuit(aString != nullptr, "operator!=() failed");
+    }
+
+    VerifyOrQuit(aString == aExpectedString, "operator==() failed");
+}
+
+// Function returning a `HeapString` by value.
+HeapString GetName(void)
+{
+    HeapString name;
+
+    SuccessOrQuit(name.Set("name"), "Set() failed");
+
+    return name;
+}
+
+void TestHeapString(void)
+{
+    HeapString  str1;
+    HeapString  str2;
+    const char *oldBuffer;
+
+    printf("------------------------------------------------------------------------------------\n");
+    printf("After constructor\n\n");
+    VerifyString("str1", str1, nullptr);
+
+    printf("------------------------------------------------------------------------------------\n");
+    printf("Set(const char *aCstring)\n\n");
+    SuccessOrQuit(str1.Set("hello"), "Set() failed");
+    VerifyString("str1", str1, "hello");
+    oldBuffer = str1.AsCString();
+
+    SuccessOrQuit(str1.Set("0123456789"), "Set() failed");
+    VerifyString("str1", str1, "0123456789");
+    printf("\tDid reuse its old buffer: %s\n", str1.AsCString() == oldBuffer ? "yes" : "no");
+    oldBuffer = str1.AsCString();
+
+    SuccessOrQuit(str1.Set("9876543210"), "Set() failed");
+    VerifyString("str1", str1, "9876543210");
+    printf("\tDid reuse its old buffer (same length): %s\n", str1.AsCString() == oldBuffer ? "yes" : "no");
+
+    printf("------------------------------------------------------------------------------------\n");
+    printf("Set(const HeapString &)\n\n");
+    SuccessOrQuit(str2.Set(str1), "Set() failed");
+    VerifyString("str2", str2, str1.AsCString());
+
+    SuccessOrQuit(str1.Set(nullptr), "Set() failed");
+    VerifyString("str1", str1, nullptr);
+
+    SuccessOrQuit(str2.Set(str1), "Set() failed");
+    VerifyString("str2", str2, nullptr);
+
+    printf("------------------------------------------------------------------------------------\n");
+    printf("Free()\n\n");
+    str1.Free();
+    VerifyString("str1", str1, nullptr);
+
+    SuccessOrQuit(str1.Set("hello again"), "Set() failed");
+    VerifyString("str1", str1, "hello again");
+
+    str1.Free();
+    VerifyString("str1", str1, nullptr);
+
+    printf("------------------------------------------------------------------------------------\n");
+    printf("Set() move semantics\n\n");
+    SuccessOrQuit(str1.Set("old name"), "Set() failed");
+    PrintString("str1", str1);
+    SuccessOrQuit(str1.Set(GetName()), "Set() with move semantics failed");
+    VerifyString("str1", str1, "name");
+
+    printf("------------------------------------------------------------------------------------\n");
+    printf("operator==() with two null string\n\n");
+    str1.Free();
+    str2.Free();
+    VerifyString("str1", str1, nullptr);
+    VerifyString("str2", str2, nullptr);
+    VerifyOrQuit(str1 == str2, "operator==() failed with two null strings");
+
+    printf("\n -- PASS\n");
+}
+
+} // namespace ot
+
+int main(void)
+{
+    ot::TestHeapString();
+    printf("\nAll tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
This PR contains two related commits:

**[common] adding `HeapString` class (heap allocated string)**

This commit adds a new class `HeapString` (a heap allocated string).
The buffer to store the string is allocated from heap and is managed
by the `HeapString` class itself, e.g., it may be reused and/or freed
and reallocated when the string is set. The `HeapString` destructor
will always free the allocated buffer.

This commit also adds a unit test `test_heap_string` for the new
class.

**[srp-server] update to use `HeapString` for names**