### PR TITLE
[csl] fix overflow in calculating semiWindow

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -1058,18 +1058,19 @@ void SubMac::GetCslWindowEdges(uint32_t &ahead, uint32_t &after)
 {
     uint32_t semiPeriod = mCslPeriod * kUsPerTenSymbols / 2;
     uint64_t curTime    = otPlatRadioGetNow(&GetInstance());
-    uint32_t elapsed, semiWindow;
+    uint64_t elapsed;
+    uint32_t semiWindow;
 
     if (mCslLastSync.GetValue() > curTime)
     {
-        elapsed = static_cast<uint32_t>(UINT64_MAX - mCslLastSync.GetValue() + curTime);
+        elapsed = UINT64_MAX - mCslLastSync.GetValue() + curTime;
     }
     else
     {
-        elapsed = static_cast<uint32_t>(curTime - mCslLastSync.GetValue());
+        elapsed = curTime - mCslLastSync.GetValue();
     }
 
-    semiWindow = elapsed * (Get<Radio>().GetCslAccuracy() + mCslParentDrift) / 1000000;
+    semiWindow = static_cast<uint32_t>(elapsed * (Get<Radio>().GetCslAccuracy() + mCslParentDrift) / 1000000);
     semiWindow += mCslParentUncert * kUsPerUncertUnit;
 
     ahead = (semiWindow + kCslReceiveTimeAhead > semiPeriod) ? semiPeriod : semiWindow + kCslReceiveTimeAhead;


### PR DESCRIPTION
As for:
```
semiWindow = elapsed * (Get<Radio>().GetCslAccuracy() + mCslParentDrift) / 1000000;
```
Consider that the worst `Get<Radio>().GetCslAccuracy()` and `mCslParentDrift` are both `255`, the max of `uint32` is `4294967295`, so when `elapsed` is  about `8500000`(just 8.5s elapsed since the last CSL sync), the product of `elapsed` and `(Get<Radio>().GetCslAccuracy() + mCslParentDrift)` will be overflowed.

In this PR, use the type `uint64_t` instead of `uint32_t` to avoid the overflow. 