### PR TITLE
[diag] don't let the client of diag reserve the '\0' byte

### DIFF
--- a/include/openthread/diag.h
+++ b/include/openthread/diag.h
@@ -54,6 +54,9 @@ extern "C" {
 /**
  * This function processes a factory diagnostics command line.
  *
+ * The output of this function (the content written to @p aOutput) MUST terminate with `\0` and the `\0` is within the
+ * output buffer.
+ *
  * @param[in]   aInstance       A pointer to an OpenThread instance.
  * @param[in]   aArgsLength     The number of elements in @p aArgs.
  * @param[in]   aArgs           An array of arguments.
@@ -73,6 +76,9 @@ otError otDiagProcessCmd(otInstance *aInstance,
 
 /**
  * This function processes a factory diagnostics command line.
+ *
+ * The output of this function (the content written to @p aOutput) MUST terminate with `\0` and the `\0` is within the
+ * output buffer.
  *
  * @param[in]   aInstance       A pointer to an OpenThread instance.
  * @param[in]   aString         A NULL-terminated input string.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (137)
+#define OPENTHREAD_API_VERSION (138)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/diag.h
+++ b/include/openthread/platform/diag.h
@@ -59,6 +59,9 @@ extern "C" {
 /**
  * This function processes a factory diagnostics command line.
  *
+ * The output of this function (the content written to @p aOutput) MUST terminate with `\0` and the `\0` is within the
+ * output buffer.
+ *
  * @param[in]   aInstance       The OpenThread instance for current request.
  * @param[in]   aArgsLength     The number of arguments in @p aArgs.
  * @param[in]   aArgs           The arguments of diagnostics command line.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -4521,12 +4521,9 @@ otError Interpreter::ProcessDiag(Arg aArgs[])
     char    output[OPENTHREAD_CONFIG_DIAG_OUTPUT_BUFFER_SIZE];
 
     // all diagnostics related features are processed within diagnostics module
-    output[0]                  = '\0';
-    output[sizeof(output) - 1] = '\0';
-
     Arg::CopyArgsToStringArray(aArgs, args);
 
-    error = otDiagProcessCmd(mInstance, Arg::GetArgsLength(aArgs), args, output, sizeof(output) - 1);
+    error = otDiagProcessCmd(mInstance, Arg::GetArgsLength(aArgs), args, output, sizeof(output));
 
     OutputFormat("%s", output);
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1340,8 +1340,6 @@ otError NcpBase::HandlePropertySet_SPINEL_PROP_NEST_STREAM_MFG(uint8_t aHeader)
 
     VerifyOrExit(error == OT_ERROR_NONE, error = WriteLastStatusFrame(aHeader, ThreadErrorToSpinelStatus(error)));
 
-    output[sizeof(output) - 1] = '\0';
-
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
     // TODO do not pass mfg prefix
     // skip mfg prefix from wpantund
@@ -1351,7 +1349,7 @@ otError NcpBase::HandlePropertySet_SPINEL_PROP_NEST_STREAM_MFG(uint8_t aHeader)
     }
 #endif
 
-    otDiagProcessCmdLine(mInstance, string, output, sizeof(output) - 1);
+    otDiagProcessCmdLine(mInstance, string, output, sizeof(output));
 
     // Prepare the response
     SuccessOrExit(error = mEncoder.BeginFrame(aHeader, SPINEL_CMD_PROP_VALUE_IS, SPINEL_PROP_NEST_STREAM_MFG));


### PR DESCRIPTION
This PR initializes the `output` buffer to all zero.

The output buffer isn't initialized to all zero currently. This makes it possible that `OutputFormat` prints some random bytes at the end of the original output generated by processing the command.

I checked the output buffer by dumping the buffer:
**Before processing command:**
![diag_1](https://user-images.githubusercontent.com/12945188/122363363-75482c00-cf8b-11eb-9e3f-06a91c2c042a.png)
**After processing command:**
![diag-2](https://user-images.githubusercontent.com/12945188/122363469-8a24bf80-cf8b-11eb-8ed3-ba52fb53f386.png)

So it is possible that non `\0` characters come after the output and cause incorret output at the end. (In the above case, it happens to be `\0` after the output.)
