### PR TITLE
[srp-server] take ownership of resources on updating existing `Service`

### DIFF
--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -230,9 +230,8 @@ public:
     private:
         explicit Service(void);
         Error SetFullName(const char *aFullName) { return mFullName.Set(aFullName); }
-        Error SetTxtData(const uint8_t *aTxtData, uint16_t aTxtDataLength);
         Error SetTxtDataFromMessage(const Message &aMessage, uint16_t aOffset, uint16_t aLength);
-        Error CopyResourcesFrom(const Service &aService);
+        void  TakeResourcesFrom(Service &aService);
         void  ClearResources(void);
 
         HeapString       mFullName;


### PR DESCRIPTION
This commit changes the `Srp::Server` to take ownership of resources
(e.g., heap allocated buffer for TXT data) when updating an existing
`Service` entry (instead of copying the data). With this change, the
method `Service::SetTxtData()` is no longer needed and is removed.

---

_Background on this PR_:
- Taking ownership (move semantic) would be helpful for adding service subtype
  support (https://github.com/openthread/openthread/issues/6714) - We will have a list of subtype `HeapString` labels in the `Service` 
and the move model would allow us to move/merge them (instead of copy).
- I added it as a separate PR (small change) to make it easier to review. Thanks.