### PR TITLE
[backbone-router] relax matching BBR dataset

### DIFF
--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -457,7 +457,7 @@ protected:
      * @param[in]  aEnterpriseNumber  Enterprise Number.
      * @param[in]  aServiceData       A pointer to a Service Data.
      * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
-     * @param[in]  aServiceMatchMode  The Service Data match mode. @sa ServiceDataMatchMode
+     * @param[in]  aServiceMatchMode  The Service Data match mode.
      *
      * @returns A pointer to the Service TLV if one is found or nullptr if no matching Service TLV exists.
      *
@@ -473,7 +473,7 @@ protected:
      * @param[in]  aEnterpriseNumber  Enterprise Number.
      * @param[in]  aServiceData       A pointer to a Service Data.
      * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
-     * @param[in]  aServiceMatchMode  The Service Data match mode. @sa ServiceDataMatchMode
+     * @param[in]  aServiceMatchMode  The Service Data match mode.
      * @param[in]  aTlvs              A pointer to a specified tlvs buffer.
      * @param[in]  aTlvsLength        The specified tlvs buffer length pointed to by @p aTlvs.
      *
@@ -498,7 +498,7 @@ protected:
      * @param[in]  aEnterpriseNumber  Enterprise Number.
      * @param[in]  aServiceData       A pointer to a Service Data.
      * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
-     * @param[in]  aServiceMatchMode  The Service Data match mode. @sa ServiceDataMatchMode
+     * @param[in]  aServiceMatchMode  The Service Data match mode.
      * @param[in]  aTlvs              A pointer to a specified tlvs buffer.
      * @param[in]  aTlvsLength        The specified tlvs buffer length pointed to by @p aTlvs.
      *
@@ -523,7 +523,7 @@ protected:
      * @param[in]  aEnterpriseNumber  Enterprise Number.
      * @param[in]  aServiceData       A pointer to a Service Data to match with Service TLVs.
      * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
-     * @param[in]  aServiceMatchMode  The Service Data match mode. @sa ServiceDataMatchMode
+     * @param[in]  aServiceMatchMode  The Service Data match mode.
      *
      * @returns A pointer to the next matching Service TLV if one is found or nullptr if it cannot be found.
      *

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -309,6 +309,16 @@ public:
 
 protected:
     /**
+     * This enumeration defines Service Data match mode.
+     *
+     */
+    enum ServiceMatchMode : uint8_t
+    {
+        kServicePrefixMatch, ///< Match the Service Data by prefix.
+        kServiceExactMatch,  ///< Match the full Service Data exactly.
+    };
+
+    /**
      * This method returns a pointer to the start of Network Data TLV sequence.
      *
      * @returns A pointer to the start of Network Data TLV sequence.
@@ -427,14 +437,18 @@ protected:
      * @param[in]  aEnterpriseNumber  Enterprise Number.
      * @param[in]  aServiceData       A pointer to a Service Data.
      * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
+     * @param[in]  aServiceMatchMode  The Service Data match mode. @sa ServiceDataMatchMode
      *
      * @returns A pointer to the Service TLV if one is found or nullptr if no matching Service TLV exists.
      *
      */
-    ServiceTlv *FindService(uint32_t aEnterpriseNumber, const uint8_t *aServiceData, uint8_t aServiceDataLength)
+    ServiceTlv *FindService(uint32_t         aEnterpriseNumber,
+                            const uint8_t *  aServiceData,
+                            uint8_t          aServiceDataLength,
+                            ServiceMatchMode aServiceMatchMode)
     {
-        return const_cast<ServiceTlv *>(
-            const_cast<const NetworkData *>(this)->FindService(aEnterpriseNumber, aServiceData, aServiceDataLength));
+        return const_cast<ServiceTlv *>(const_cast<const NetworkData *>(this)->FindService(
+            aEnterpriseNumber, aServiceData, aServiceDataLength, aServiceMatchMode));
     }
 
     /**
@@ -443,78 +457,82 @@ protected:
      * @param[in]  aEnterpriseNumber  Enterprise Number.
      * @param[in]  aServiceData       A pointer to a Service Data.
      * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
+     * @param[in]  aServiceMatchMode  The Service Data match mode. @sa ServiceDataMatchMode
      *
      * @returns A pointer to the Service TLV if one is found or nullptr if no matching Service TLV exists.
      *
      */
-    const ServiceTlv *FindService(uint32_t       aEnterpriseNumber,
-                                  const uint8_t *aServiceData,
-                                  uint8_t        aServiceDataLength) const;
+    const ServiceTlv *FindService(uint32_t         aEnterpriseNumber,
+                                  const uint8_t *  aServiceData,
+                                  uint8_t          aServiceDataLength,
+                                  ServiceMatchMode aServiceMatchMode) const;
 
     /**
      * This method returns a pointer to a Service TLV in a specified tlvs buffer.
      *
      * @param[in]  aEnterpriseNumber  Enterprise Number.
-     * @param[in]  aServiceData       A pointer to an Service Data.
+     * @param[in]  aServiceData       A pointer to a Service Data.
      * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
+     * @param[in]  aServiceMatchMode  The Service Data match mode. @sa ServiceDataMatchMode
      * @param[in]  aTlvs              A pointer to a specified tlvs buffer.
      * @param[in]  aTlvsLength        The specified tlvs buffer length pointed to by @p aTlvs.
      *
      * @returns A pointer to the Service TLV if one is found or nullptr if no matching Service TLV exists.
      *
      */
-    static ServiceTlv *FindService(uint32_t       aEnterpriseNumber,
-                                   const uint8_t *aServiceData,
-                                   uint8_t        aServiceDataLength,
-                                   uint8_t *      aTlvs,
-                                   uint8_t        aTlvsLength)
+    static ServiceTlv *FindService(uint32_t         aEnterpriseNumber,
+                                   const uint8_t *  aServiceData,
+                                   uint8_t          aServiceDataLength,
+                                   ServiceMatchMode aServiceMatchMode,
+                                   uint8_t *        aTlvs,
+                                   uint8_t          aTlvsLength)
     {
         return const_cast<ServiceTlv *>(FindService(aEnterpriseNumber, aServiceData, aServiceDataLength,
-                                                    const_cast<const uint8_t *>(aTlvs), aTlvsLength));
+                                                    aServiceMatchMode, const_cast<const uint8_t *>(aTlvs),
+                                                    aTlvsLength));
     }
 
     /**
      * This method returns a pointer to a Service TLV in a specified tlvs buffer.
      *
      * @param[in]  aEnterpriseNumber  Enterprise Number.
-     * @param[in]  aServiceData       A pointer to an Service Data.
+     * @param[in]  aServiceData       A pointer to a Service Data.
      * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
+     * @param[in]  aServiceMatchMode  The Service Data match mode. @sa ServiceDataMatchMode
      * @param[in]  aTlvs              A pointer to a specified tlvs buffer.
      * @param[in]  aTlvsLength        The specified tlvs buffer length pointed to by @p aTlvs.
      *
      * @returns A pointer to the Service TLV if one is found or nullptr if no matching Service TLV exists.
      *
      */
-    static const ServiceTlv *FindService(uint32_t       aEnterpriseNumber,
-                                         const uint8_t *aServiceData,
-                                         uint8_t        aServiceDataLength,
-                                         const uint8_t *aTlvs,
-                                         uint8_t        aTlvsLength);
+    static const ServiceTlv *FindService(uint32_t         aEnterpriseNumber,
+                                         const uint8_t *  aServiceData,
+                                         uint8_t          aServiceDataLength,
+                                         ServiceMatchMode aServiceMatchMode,
+                                         const uint8_t *  aTlvs,
+                                         uint8_t          aTlvsLength);
 
     /**
      * This method returns the next pointer to a matching Service TLV.
      *
      * This method can be used to iterate over all Service TLVs that start with a given Service Data.
      *
-     * Unlike `FindService()` method which searches for a Service TLV with an exact match with the given Service Data,
-     * this method performs a relaxed check allowing a matching Service TLV to contain additional bytes after
-     * @p aServiceData, i.e., a Service TLV is considered to match if its Service Data length is larger than or equal
-     * to @p aServiceDataLength and its first @p aServiceDataLength Service Data bytes are equal to @p aServiceData.
-     *
-     * @param[in]  aPrevServiceTlv    Set to nullptr to start from the beginning of the TLVs (finding the first
-     *                                matching Service TLV), or a pointer to the previous Service TLV returned from
-     *                                this method to iterate to the next matching Service TLV.
+     * @param[in]  aPrevServiceTlv    Set to nullptr to start from the beginning of the TLVs (finding the first matching
+     *                                Service TLV), or a pointer to the previous Service TLV returned from this method
+     *                                to iterate to the next matching Service TLV.
      * @param[in]  aEnterpriseNumber  Enterprise Number.
      * @param[in]  aServiceData       A pointer to a Service Data to match with Service TLVs.
      * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
+     * @param[in]  aServiceMatchMode  The Service Data match mode. @sa ServiceDataMatchMode
      *
      * @returns A pointer to the next matching Service TLV if one is found or nullptr if it cannot be found.
      *
      */
-    const ServiceTlv *FindNextMatchingService(const ServiceTlv *aPrevServiceTlv,
-                                              uint32_t          aEnterpriseNumber,
-                                              const uint8_t *   aServiceData,
-                                              uint8_t           aServiceDataLength) const;
+    const ServiceTlv *FindNextService(const ServiceTlv *aPrevServiceTlv,
+                                      uint32_t          aEnterpriseNumber,
+                                      const uint8_t *   aServiceData,
+                                      uint8_t           aServiceDataLength,
+                                      ServiceMatchMode  aServiceMatchMode) const;
 
     /**
      * This method indicates whether there is space in Network Data to insert/append new info and grow it by a given
@@ -668,13 +686,6 @@ private:
         ServiceConfig *      mService;
     };
 
-    static const ServiceTlv *FindService(uint32_t       aEnterpriseNumber,
-                                         const uint8_t *aServiceData,
-                                         uint8_t        aServiceDataLength,
-                                         bool           aExactServiceDataMatch,
-                                         const uint8_t *aTlvs,
-                                         uint8_t        aTlvsLength);
-
     Error Iterate(Iterator &aIterator, uint16_t aRloc16, Config &aConfig) const;
 
     static void RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, PrefixTlv &aPrefix);
@@ -682,6 +693,12 @@ private:
 
     static void Remove(uint8_t *aData, uint8_t &aDataLength, uint8_t *aRemoveStart, uint8_t aRemoveLength);
     static void RemoveTlv(uint8_t *aData, uint8_t &aDataLength, NetworkDataTlv *aTlv);
+
+    static bool MatchService(const ServiceTlv &aServiceTlv,
+                             uint32_t          aEnterpriseNumber,
+                             const uint8_t *   aServiceData,
+                             uint8_t           aServiceDataLength,
+                             ServiceMatchMode  aServiceMatchMode);
 
     const Type mType;
 };

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -437,7 +437,7 @@ protected:
      * @param[in]  aEnterpriseNumber  Enterprise Number.
      * @param[in]  aServiceData       A pointer to a Service Data.
      * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
-     * @param[in]  aServiceMatchMode  The Service Data match mode. @sa ServiceDataMatchMode
+     * @param[in]  aServiceMatchMode  The Service Data match mode.
      *
      * @returns A pointer to the Service TLV if one is found or nullptr if no matching Service TLV exists.
      *

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -433,7 +433,7 @@ Error Leader::Validate(const uint8_t *aTlvs, uint8_t aTlvsLength, uint16_t aRloc
             // Ensure there is no duplicate Service TLV with same
             // Enterprise Number and Service Data.
             VerifyOrExit(FindService(service->GetEnterpriseNumber(), service->GetServiceData(),
-                                     service->GetServiceDataLength(), aTlvs, offset) == nullptr,
+                                     service->GetServiceDataLength(), kServiceExactMatch, aTlvs, offset) == nullptr,
                          error = kErrorParse);
 
             SuccessOrExit(error = ValidateService(*service, aRloc16));
@@ -786,9 +786,9 @@ exit:
 
 Error Leader::AddService(const ServiceTlv &aService, ChangedFlags &aChangedFlags)
 {
-    Error       error = kErrorNone;
-    ServiceTlv *dstService =
-        FindService(aService.GetEnterpriseNumber(), aService.GetServiceData(), aService.GetServiceDataLength());
+    Error            error      = kErrorNone;
+    ServiceTlv *     dstService = FindService(aService.GetEnterpriseNumber(), aService.GetServiceData(),
+                                         aService.GetServiceDataLength(), kServiceExactMatch);
     const ServerTlv *server;
 
     if (dstService == nullptr)
@@ -1080,7 +1080,7 @@ void Leader::RemoveRloc(uint16_t       aRloc16,
             ServiceTlv *      service = static_cast<ServiceTlv *>(cur);
             const ServiceTlv *excludeService =
                 FindService(service->GetEnterpriseNumber(), service->GetServiceData(), service->GetServiceDataLength(),
-                            aExcludeTlvs, aExcludeTlvsLength);
+                            kServiceExactMatch, aExcludeTlvs, aExcludeTlvsLength);
 
             RemoveRlocInService(*service, aRloc16, aMatchMode, excludeService, aChangedFlags);
 

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -236,7 +236,8 @@ Error Local::RemoveService(uint32_t aEnterpriseNumber, const uint8_t *aServiceDa
     Error       error = kErrorNone;
     ServiceTlv *tlv;
 
-    VerifyOrExit((tlv = FindService(aEnterpriseNumber, aServiceData, aServiceDataLength)) != nullptr,
+    VerifyOrExit((tlv = FindService(aEnterpriseNumber, aServiceData, aServiceDataLength, kServiceExactMatch)) !=
+                     nullptr,
                  error = kErrorNotFound);
     RemoveTlv(tlv);
 

--- a/src/core/thread/network_data_service.cpp
+++ b/src/core/thread/network_data_service.cpp
@@ -100,29 +100,35 @@ void Manager::GetBackboneRouterPrimary(ot::BackboneRouter::BackboneRouterConfig 
 {
     const ServerTlv *                 rvalServerTlv  = nullptr;
     const BackboneRouter::ServerData *rvalServerData = nullptr;
-    Iterator                          iterator;
+    const ServiceTlv *                serviceTlv     = nullptr;
 
     aConfig.mServer16 = Mac::kShortAddrInvalid;
 
-    iterator.mServiceTlv = Get<Leader>().FindService(kThreadEnterpriseNumber, &BackboneRouter::kServiceData,
-                                                     sizeof(BackboneRouter::kServiceData));
-
-    while (IterateToNextServer(iterator) == kErrorNone)
+    while ((serviceTlv = Get<Leader>().FindNextService(
+                serviceTlv, kThreadEnterpriseNumber, &BackboneRouter::kServiceData, BackboneRouter::kServiceDataMinSize,
+                NetworkData::kServicePrefixMatch)) != nullptr)
     {
-        const BackboneRouter::ServerData *serverData;
+        Iterator iterator;
 
-        if (iterator.mServerSubTlv->GetServerDataLength() < sizeof(BackboneRouter::ServerData))
+        iterator.mServiceTlv = serviceTlv;
+
+        while (IterateToNextServer(iterator) == kErrorNone)
         {
-            continue;
-        }
+            const BackboneRouter::ServerData *serverData;
 
-        serverData = reinterpret_cast<const BackboneRouter::ServerData *>(iterator.mServerSubTlv->GetServerData());
+            if (iterator.mServerSubTlv->GetServerDataLength() < sizeof(BackboneRouter::ServerData))
+            {
+                continue;
+            }
 
-        if (rvalServerTlv == nullptr ||
-            IsBackboneRouterPreferredTo(*iterator.mServerSubTlv, *serverData, *rvalServerTlv, *rvalServerData))
-        {
-            rvalServerTlv  = iterator.mServerSubTlv;
-            rvalServerData = serverData;
+            serverData = reinterpret_cast<const BackboneRouter::ServerData *>(iterator.mServerSubTlv->GetServerData());
+
+            if (rvalServerTlv == nullptr ||
+                IsBackboneRouterPreferredTo(*iterator.mServerSubTlv, *serverData, *rvalServerTlv, *rvalServerData))
+            {
+                rvalServerTlv  = iterator.mServerSubTlv;
+                rvalServerData = serverData;
+            }
         }
     }
 
@@ -165,7 +171,8 @@ Error Manager::GetNextDnsSrpAnycastInfo(Iterator &aIterator, DnsSrpAnycast::Info
 
     do
     {
-        tlv = Get<Leader>().FindNextMatchingService(tlv, kThreadEnterpriseNumber, &serviceData, sizeof(serviceData));
+        tlv = Get<Leader>().FindNextService(tlv, kThreadEnterpriseNumber, &serviceData, sizeof(serviceData),
+                                            NetworkData::kServicePrefixMatch);
         VerifyOrExit(tlv != nullptr, error = kErrorNotFound);
 
     } while (tlv->GetServiceDataLength() < sizeof(DnsSrpAnycast::ServiceData));
@@ -238,8 +245,8 @@ Error Manager::GetNextDnsSrpUnicastInfo(Iterator &aIterator, DnsSrpUnicast::Info
         // Find the next matching Service TLV.
 
         aIterator.mServiceTlv =
-            Get<Leader>().FindNextMatchingService(aIterator.mServiceTlv, kThreadEnterpriseNumber,
-                                                  &DnsSrpUnicast::kServiceData, sizeof(DnsSrpUnicast::kServiceData));
+            Get<Leader>().FindNextService(aIterator.mServiceTlv, kThreadEnterpriseNumber, &DnsSrpUnicast::kServiceData,
+                                          sizeof(DnsSrpUnicast::kServiceData), NetworkData::kServicePrefixMatch);
 
         VerifyOrExit(aIterator.mServiceTlv != nullptr, error = kErrorNotFound);
 

--- a/src/core/thread/network_data_service.hpp
+++ b/src/core/thread/network_data_service.hpp
@@ -72,7 +72,8 @@ public:
      * The service data contains only the service number (THREAD_SERVICE_DATA_BBR) as a single byte.
      *
      */
-    static const uint8_t kServiceData = 0x01;
+    static const uint8_t     kServiceData        = 0x01;
+    static constexpr uint8_t kServiceDataMinSize = 1;
 
     /**
      * This class implements the generation and parsing of "Backbone Router Service" server data.

--- a/tests/unit/test_network_data.cpp
+++ b/tests/unit/test_network_data.cpp
@@ -265,32 +265,42 @@ public:
 
         // Iterate through all entries that start with { 0x02 } (kServiceData1)
         tlv = nullptr;
-        tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1),
+                              kServicePrefixMatch);
         SuccessOrQuit(ValidateServiceData(tlv, kServiceData1));
-        tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1),
+                              kServicePrefixMatch);
         SuccessOrQuit(ValidateServiceData(tlv, kServiceData4));
-        tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1),
+                              kServicePrefixMatch);
         SuccessOrQuit(ValidateServiceData(tlv, kServiceData5));
-        tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1));
-        VerifyOrQuit(tlv == nullptr, "FindNextMatchingService() returned extra TLV");
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1),
+                              kServicePrefixMatch);
+        VerifyOrQuit(tlv == nullptr, "FindNextService() returned extra TLV");
 
         // Iterate through all entries that start with { 0xab } (kServiceData2)
         tlv = nullptr;
-        tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData2, sizeof(kServiceData2));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData2, sizeof(kServiceData2),
+                              kServicePrefixMatch);
         SuccessOrQuit(ValidateServiceData(tlv, kServiceData2));
-        tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData2, sizeof(kServiceData2));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData2, sizeof(kServiceData2),
+                              kServicePrefixMatch);
         SuccessOrQuit(ValidateServiceData(tlv, kServiceData3));
-        tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData2, sizeof(kServiceData2));
-        VerifyOrQuit(tlv == nullptr, "FindNextMatchingService() returned extra TLV");
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData2, sizeof(kServiceData2),
+                              kServicePrefixMatch);
+        VerifyOrQuit(tlv == nullptr, "FindNextService() returned extra TLV");
 
         // Iterate through all entries that start with kServiceData5
         tlv = nullptr;
-        tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData5, sizeof(kServiceData5));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData5, sizeof(kServiceData5),
+                              kServicePrefixMatch);
         SuccessOrQuit(ValidateServiceData(tlv, kServiceData4));
-        tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData5, sizeof(kServiceData5));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData5, sizeof(kServiceData5),
+                              kServicePrefixMatch);
         SuccessOrQuit(ValidateServiceData(tlv, kServiceData5));
-        tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData5, sizeof(kServiceData5));
-        VerifyOrQuit(tlv == nullptr, "FindNextMatchingService() returned extra TLV");
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData5, sizeof(kServiceData5),
+                              kServicePrefixMatch);
+        VerifyOrQuit(tlv == nullptr, "FindNextService() returned extra TLV");
     }
 };
 


### PR DESCRIPTION
This commit relaxes BBR dataset matching to only compare the first byte of Service Data (i.e. `0x01`). 

This commit also requires all Service TLV searching methods to explicitly specify `aExactServiceDataMatch` argument, helping to reduce unconscious mistakes.