### PR TITLE
[srp-server] free `aHost` in `CommitSrpUpdate()` in case of error

### DIFF
--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -637,7 +637,7 @@ private:
     const Service *FindService(const char *aFullName) const;
 
     void        HandleUpdate(const Dns::UpdateHeader &aDnsHeader, Host *aHost, const Ip6::MessageInfo &aMessageInfo);
-    void        AddHost(Host *aHost);
+    void        AddHost(Host &aHost);
     void        RemoveHost(Host *aHost, bool aRetainName, bool aNotifyServiceHandler);
     bool        HasNameConflictsWith(Host &aHost) const;
     void        SendResponse(const Dns::UpdateHeader &   aHeader,


### PR DESCRIPTION
This commit ensures that in `Srp::Server::CommitSrpUpdate()` the
`aHost` parameter is correctly freed in case of an error and an early
jump to exit (e.g., from `SuccessOrExit(aError)` at the start of this
method). The `aHost` is now freed at the `exit` label and a boolean
`shouldFreeHost` tracks whether or not it needs to be freed. The
boolean variable is set to `false` when  the ownership of `aHost` is
taken over (e.g., from the call to `AddHost(aHost)`).