### PR TITLE
[tests] restart SRP server (instead of device reset) to validate port change

### DIFF
--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -487,6 +487,7 @@ void Server::Stop(void)
 
     otLogInfoSrp("[server] stop listening on %hu", mSocket.GetSockName().mPort);
     IgnoreError(mSocket.Close());
+    mHasRegisteredAnyService = false;
 
 exit:
     return;

--- a/tests/scripts/thread-cert/test_srp_server_reboot_port.py
+++ b/tests/scripts/thread-cert/test_srp_server_reboot_port.py
@@ -35,7 +35,7 @@ import command
 import thread_cert
 
 # Test description:
-#   This test verifies when an SRP server reboots, it will listen to a UDP port
+#   This test verifies when an SRP server restarts, it will listen to a UDP port
 #   that wasn't used in the last time.
 #
 # Topology:
@@ -49,7 +49,7 @@ SERVER = 2
 REBOOT_TIMES = 25
 
 
-class SrpAutoStartMode(thread_cert.TestCase):
+class SrpServerRebootPort(thread_cert.TestCase):
     USE_MESSAGE_FACTORY = False
     SUPPORT_NCP = False
 
@@ -99,8 +99,6 @@ class SrpAutoStartMode(thread_cert.TestCase):
         #
         old_port = server.get_srp_server_port()
         server.srp_server_set_enabled(False)
-        server.reset()
-        server.start()
         self.simulator.go(5)
         server.srp_server_set_enabled(True)
         self.simulator.go(5)
@@ -124,8 +122,6 @@ class SrpAutoStartMode(thread_cert.TestCase):
             #
             old_port = server.get_srp_server_port()
             server.srp_server_set_enabled(False)
-            server.reset()
-            server.start()
             self.simulator.go(5)
 
             #


### PR DESCRIPTION
Added a second commit to this PR. First commit changes the test to do restart:

**[test] restart SRP server (instead of device reset) to validate port change (#6763)**

This commit updates `test_srp_server_reboot_port` to just restart the
SRP sever instead of performing a full device reset. The SRP restart
will trigger the port number change by the server which is the
behavior this test-case is intended to verify. This change should
help address intermittent failures of this test.

Second commit:

**[srp-server] ensure to clear `mHasRegisteredAnyService` on server stop (#6763)**

This commit updates `Srp::Server` to clear `mHasRegisteredAnyService`
when server is stopped and all the hosts and services are deleted.
This boolean flag is used to save the port number in non-volatile
settings so that we can ensure to pick a different port number the
next time the server starts.

This change addresses an issue where the port number may not be saved
and therefore not changed if the server is stopped and restarted
two times in a row.

---

Closes #6743.