### PR TITLE
[test] enhance `{Verify/Success}OrQuit()` and their use in unit test

### DIFF
--- a/tests/unit/test_aes.cpp
+++ b/tests/unit/test_aes.cpp
@@ -65,22 +65,22 @@ void TestMacBeaconFrame(void)
         0xAC, 0xDE, 0x48, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x05, 0x02,
     };
 
-    VerifyOrQuit(instance != nullptr, "Null OpenThread instance");
+    VerifyOrQuit(instance != nullptr);
 
     aesCcm.SetKey(key, sizeof(key));
     aesCcm.Init(headerLength, payloadLength, tagLength, nonce, sizeof(nonce));
     aesCcm.Header(test, headerLength);
-    VerifyOrQuit(aesCcm.GetTagLength() == tagLength, "AesCcm::GetTagLength() failed");
+    VerifyOrQuit(aesCcm.GetTagLength() == tagLength);
     aesCcm.Finalize(test + headerLength);
 
-    VerifyOrQuit(memcmp(test, encrypted, sizeof(encrypted)) == 0, "TestMacBeaconFrame encrypt failed");
+    VerifyOrQuit(memcmp(test, encrypted, sizeof(encrypted)) == 0);
 
     aesCcm.Init(headerLength, payloadLength, tagLength, nonce, sizeof(nonce));
     aesCcm.Header(test, headerLength);
-    VerifyOrQuit(aesCcm.GetTagLength() == tagLength, "AesCcm::GetTagLength() failed");
+    VerifyOrQuit(aesCcm.GetTagLength() == tagLength);
     aesCcm.Finalize(test + headerLength);
 
-    VerifyOrQuit(memcmp(test, decrypted, sizeof(decrypted)) == 0, "TestMacBeaconFrame decrypt failed");
+    VerifyOrQuit(memcmp(test, decrypted, sizeof(decrypted)) == 0);
 
     testFreeInstance(instance);
 }
@@ -124,17 +124,17 @@ void TestMacCommandFrame()
     aesCcm.Init(headerLength, payloadLength, tagLength, nonce, sizeof(nonce));
     aesCcm.Header(test, headerLength);
     aesCcm.Payload(test + headerLength, test + headerLength, payloadLength, ot::Crypto::AesCcm::kEncrypt);
-    VerifyOrQuit(aesCcm.GetTagLength() == tagLength, "AesCcm::GetTagLength() failed");
+    VerifyOrQuit(aesCcm.GetTagLength() == tagLength);
     aesCcm.Finalize(test + headerLength + payloadLength);
-    VerifyOrQuit(memcmp(test, encrypted, sizeof(encrypted)) == 0, "TestMacCommandFrame encrypt failed");
+    VerifyOrQuit(memcmp(test, encrypted, sizeof(encrypted)) == 0);
 
     aesCcm.Init(headerLength, payloadLength, tagLength, nonce, sizeof(nonce));
     aesCcm.Header(test, headerLength);
     aesCcm.Payload(test + headerLength, test + headerLength, payloadLength, ot::Crypto::AesCcm::kDecrypt);
-    VerifyOrQuit(aesCcm.GetTagLength() == tagLength, "AesCcm::GetTagLength() failed");
+    VerifyOrQuit(aesCcm.GetTagLength() == tagLength);
     aesCcm.Finalize(test + headerLength + payloadLength);
 
-    VerifyOrQuit(memcmp(test, decrypted, sizeof(decrypted)) == 0, "TestMacCommandFrame decrypt failed");
+    VerifyOrQuit(memcmp(test, decrypted, sizeof(decrypted)) == 0);
 }
 
 int main(void)

--- a/tests/unit/test_checksum.cpp
+++ b/tests/unit/test_checksum.cpp
@@ -107,7 +107,7 @@ uint16_t CalculateChecksum(const Ip6::Address &aSource,
     data.mPseudoHeader.mProtocol      = Encoding::BigEndian::HostSwap32(aIpProto);
     data.mPseudoHeader.mPayloadLength = Encoding::BigEndian::HostSwap32(payloadLength);
 
-    SuccessOrQuit(aMessage.Read(aMessage.GetOffset(), data.mPayload, payloadLength), "Message::Read() failed");
+    SuccessOrQuit(aMessage.Read(aMessage.GetOffset(), data.mPayload, payloadLength));
 
     return CalculateChecksum(&data, sizeof(PseudoHeader) + payloadLength);
 }
@@ -122,7 +122,7 @@ void CorruptMessage(Message &aMessage)
 
     byteOffset = Random::NonCrypto::GetUint16InRange(0, aMessage.GetLength());
 
-    SuccessOrQuit(aMessage.Read(byteOffset, byte), "Read failed");
+    SuccessOrQuit(aMessage.Read(byteOffset, byte));
 
     bitOffset = Random::NonCrypto::GetUint8InRange(0, CHAR_BIT);
 
@@ -144,7 +144,7 @@ void TestUdpMessageChecksum(void)
 
     Instance *instance = static_cast<Instance *>(testInitInstance());
 
-    VerifyOrQuit(instance != nullptr, "Null OpenThread instance\n");
+    VerifyOrQuit(instance != nullptr);
 
     for (uint16_t size = kMinSize; size <= kMaxSize; size++)
     {
@@ -153,7 +153,7 @@ void TestUdpMessageChecksum(void)
         Ip6::MessageInfo messageInfo;
 
         VerifyOrQuit(message != nullptr, "Ip6::NewMesssage() failed");
-        SuccessOrQuit(message->SetLength(size), "Message::SetLength() failed");
+        SuccessOrQuit(message->SetLength(size));
 
         // Write UDP header with a random payload.
 
@@ -170,28 +170,26 @@ void TestUdpMessageChecksum(void)
             message->WriteBytes(sizeof(udpHeader), &buffer[0], payloadSize);
         }
 
-        SuccessOrQuit(messageInfo.GetSockAddr().FromString(kSourceAddress), "FromString() failed");
-        SuccessOrQuit(messageInfo.GetPeerAddr().FromString(kDestAddress), "FromString() failed");
+        SuccessOrQuit(messageInfo.GetSockAddr().FromString(kSourceAddress));
+        SuccessOrQuit(messageInfo.GetPeerAddr().FromString(kDestAddress));
 
         // Verify that the `Checksum::UpdateMessageChecksum` correctly
         // updates the checksum field in the UDP header on the message.
 
         Checksum::UpdateMessageChecksum(*message, messageInfo.GetSockAddr(), messageInfo.GetPeerAddr(), Ip6::kProtoUdp);
 
-        SuccessOrQuit(message->Read(message->GetOffset(), udpHeader), "Message::Read() failed");
-        VerifyOrQuit(udpHeader.GetChecksum() != 0, "Failed to update checksum");
+        SuccessOrQuit(message->Read(message->GetOffset(), udpHeader));
+        VerifyOrQuit(udpHeader.GetChecksum() != 0);
 
         // Verify that the calculated UDP checksum is valid.
 
-        VerifyOrQuit(
-            CalculateChecksum(messageInfo.GetSockAddr(), messageInfo.GetPeerAddr(), Ip6::kProtoUdp, *message) == 0xffff,
-            "UDP checksum does not match expected value");
+        VerifyOrQuit(CalculateChecksum(messageInfo.GetSockAddr(), messageInfo.GetPeerAddr(), Ip6::kProtoUdp,
+                                       *message) == 0xffff);
 
         // Verify that `Checksum::VerifyMessageChecksum()` accepts the
         // message and its calculated checksum.
 
-        SuccessOrQuit(Checksum::VerifyMessageChecksum(*message, messageInfo, Ip6::kProtoUdp),
-                      "Checksum::VerifyMessageChecksum() failed");
+        SuccessOrQuit(Checksum::VerifyMessageChecksum(*message, messageInfo, Ip6::kProtoUdp));
 
         // Corrupt the message and verify that checksum is no longer accepted.
 
@@ -226,7 +224,7 @@ void TestIcmp6MessageChecksum(void)
         Ip6::MessageInfo  messageInfo;
 
         VerifyOrQuit(message != nullptr, "Ip6::NewMesssage() failed");
-        SuccessOrQuit(message->SetLength(size), "Message::SetLength() failed");
+        SuccessOrQuit(message->SetLength(size));
 
         // Write ICMP6 header with a random payload.
 
@@ -243,8 +241,8 @@ void TestIcmp6MessageChecksum(void)
             message->WriteBytes(sizeof(icmp6Header), &buffer[0], payloadSize);
         }
 
-        SuccessOrQuit(messageInfo.GetSockAddr().FromString(kSourceAddress), "FromString() failed");
-        SuccessOrQuit(messageInfo.GetPeerAddr().FromString(kDestAddress), "FromString() failed");
+        SuccessOrQuit(messageInfo.GetSockAddr().FromString(kSourceAddress));
+        SuccessOrQuit(messageInfo.GetPeerAddr().FromString(kDestAddress));
 
         // Verify that the `Checksum::UpdateMessageChecksum` correctly
         // updates the checksum field in the ICMP6 header on the message.
@@ -252,20 +250,18 @@ void TestIcmp6MessageChecksum(void)
         Checksum::UpdateMessageChecksum(*message, messageInfo.GetSockAddr(), messageInfo.GetPeerAddr(),
                                         Ip6::kProtoIcmp6);
 
-        SuccessOrQuit(message->Read(message->GetOffset(), icmp6Header), "Message::Read() failed");
+        SuccessOrQuit(message->Read(message->GetOffset(), icmp6Header));
         VerifyOrQuit(icmp6Header.GetChecksum() != 0, "Failed to update checksum");
 
         // Verify that the calculated ICMP6 checksum is valid.
 
         VerifyOrQuit(CalculateChecksum(messageInfo.GetSockAddr(), messageInfo.GetPeerAddr(), Ip6::kProtoIcmp6,
-                                       *message) == 0xffff,
-                     "UDP checksum does not match expected value");
+                                       *message) == 0xffff);
 
         // Verify that `Checksum::VerifyMessageChecksum()` accepts the
         // message and its calculated checksum.
 
-        SuccessOrQuit(Checksum::VerifyMessageChecksum(*message, messageInfo, Ip6::kProtoIcmp6),
-                      "Checksum::VerifyMessageChecksum() failed");
+        SuccessOrQuit(Checksum::VerifyMessageChecksum(*message, messageInfo, Ip6::kProtoIcmp6));
 
         // Corrupt the message and verify that checksum is no longer accepted.
 
@@ -292,9 +288,8 @@ public:
         VerifyOrQuit(checksum.GetValue() == 0, "Incorrect initial checksum value");
 
         checksum.AddData(kTestVector, sizeof(kTestVector));
-        VerifyOrQuit(checksum.GetValue() == kTestVectorChecksum, "Checksum::AddData() failed");
-        VerifyOrQuit(checksum.GetValue() == CalculateChecksum(kTestVector, sizeof(kTestVector)),
-                     "Checksum::AddData() failed");
+        VerifyOrQuit(checksum.GetValue() == kTestVectorChecksum);
+        VerifyOrQuit(checksum.GetValue() == CalculateChecksum(kTestVector, sizeof(kTestVector)), );
     }
 };
 

--- a/tests/unit/test_child.cpp
+++ b/tests/unit/test_child.cpp
@@ -52,7 +52,7 @@ void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, co
 
     for (uint8_t index = 0; index < aAddressListLength; index++)
     {
-        VerifyOrQuit(aChild.HasIp6Address(aAddressList[index]), "HasIp6Address() failed");
+        VerifyOrQuit(aChild.HasIp6Address(aAddressList[index]));
     }
 
     memset(addressObserved, 0, sizeof(addressObserved));
@@ -82,7 +82,7 @@ void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, co
 
         if (sInstance->Get<Mle::MleRouter>().IsMeshLocalAddress(aAddressList[index]))
         {
-            SuccessOrQuit(aChild.GetMeshLocalIp6Address(address), "Child::GetMeshLocalIp6Address() failed\n");
+            SuccessOrQuit(aChild.GetMeshLocalIp6Address(address));
             VerifyOrQuit(address == aAddressList[index], "GetMeshLocalIp6Address() did not return expected address");
             hasMeshLocal = true;
         }
@@ -120,7 +120,7 @@ void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, co
                 break;
             }
 
-            VerifyOrQuit(address.MatchesFilter(filter), "Address::MatchesFilter() failed");
+            VerifyOrQuit(address.MatchesFilter(filter));
 
             for (uint8_t index = 0; index < aAddressListLength; index++)
             {
@@ -151,13 +151,13 @@ void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, co
 
         for (const Ip6::Address &address : aChild.IterateIp6Addresses())
         {
-            VerifyOrQuit(iter1 == iter2, "AddressIterator:operator== failed");
-            VerifyOrQuit(!iter1.IsDone(), "AddressIterator::IsDone() failed");
-            VerifyOrQuit(*iter1.GetAddress() == address, "AddressIterator::GetAddress() failed");
-            VerifyOrQuit(*iter1.GetAddress() == *iter2.GetAddress(), "AddressIterator::GetAddress() failed");
+            VerifyOrQuit(iter1 == iter2);
+            VerifyOrQuit(!iter1.IsDone());
+            VerifyOrQuit(*iter1.GetAddress() == address);
+            VerifyOrQuit(*iter1.GetAddress() == *iter2.GetAddress());
 
             iterIndex = iter1.GetAsIndex();
-            VerifyOrQuit(iter2.GetAsIndex() == iterIndex, "AddressIterator: GetAsIndex() failed");
+            VerifyOrQuit(iter2.GetAsIndex() == iterIndex);
 
             {
                 Child::AddressIterator iter3(aChild, iterIndex);
@@ -168,16 +168,16 @@ void VerifyChildIp6Addresses(const Child &aChild, uint8_t aAddressListLength, co
             }
 
             iter1++;
-            VerifyOrQuit(iter1 != iter2, "AddressIterator:operator!= failed");
+            VerifyOrQuit(iter1 != iter2);
             iter2++;
         }
 
-        VerifyOrQuit(iter1.IsDone(), "AddressIterator::IsDone() failed");
-        VerifyOrQuit(iter2.IsDone(), "AddressIterator::IsDone() failed");
-        VerifyOrQuit(iter1 == iter2, "AddressIterator:operator== failed");
+        VerifyOrQuit(iter1.IsDone());
+        VerifyOrQuit(iter2.IsDone());
+        VerifyOrQuit(iter1 == iter2);
 
         iterIndex = iter1.GetAsIndex();
-        VerifyOrQuit(iter2.GetAsIndex() == iterIndex, "AddressIterator: GetAsIndex() failed");
+        VerifyOrQuit(iter2.GetAsIndex() == iterIndex);
 
         {
             Child::AddressIterator iter3(aChild, iterIndex);
@@ -203,7 +203,7 @@ void TestChildIp6Address(void)
     meshLocalIid.SetBytes(meshLocalIidArray);
 
     sInstance = testInitInstance();
-    VerifyOrQuit(sInstance != nullptr, "Null instance");
+    VerifyOrQuit(sInstance != nullptr);
 
     child.Init(*sInstance);
 
@@ -222,7 +222,7 @@ void TestChildIp6Address(void)
     for (const char *ip6Address : ip6Addresses)
     {
         VerifyOrQuit(numAddresses < kMaxChildIp6Addresses, "Too many IPv6 addresses in the unit test");
-        SuccessOrQuit(addresses[numAddresses++].FromString(ip6Address), "could not convert IPv6 address from string");
+        SuccessOrQuit(addresses[numAddresses++].FromString(ip6Address));
     }
 
     printf(" -- PASS\n");
@@ -238,7 +238,7 @@ void TestChildIp6Address(void)
 
     for (uint8_t index = 0; index < numAddresses; index++)
     {
-        SuccessOrQuit(child.AddIp6Address(addresses[index]), "AddIp6Address() failed");
+        SuccessOrQuit(child.AddIp6Address(addresses[index]));
         VerifyChildIp6Addresses(child, 1, &addresses[index]);
 
         child.ClearIp6Addresses();
@@ -252,7 +252,7 @@ void TestChildIp6Address(void)
 
     for (uint8_t index = 0; index < numAddresses; index++)
     {
-        SuccessOrQuit(child.AddIp6Address(addresses[index]), "AddIp6Address() failed");
+        SuccessOrQuit(child.AddIp6Address(addresses[index]));
         VerifyChildIp6Addresses(child, index + 1, addresses);
     }
 
@@ -275,7 +275,7 @@ void TestChildIp6Address(void)
 
     for (uint8_t index = 0; index < numAddresses; index++)
     {
-        SuccessOrQuit(child.RemoveIp6Address(addresses[index]), "RemoveIp6Address() failed");
+        SuccessOrQuit(child.RemoveIp6Address(addresses[index]));
         VerifyChildIp6Addresses(child, numAddresses - 1 - index, &addresses[index + 1]);
 
         VerifyOrQuit(child.RemoveIp6Address(addresses[index]) == kErrorNotFound,
@@ -290,12 +290,12 @@ void TestChildIp6Address(void)
 
     for (uint8_t index = 0; index < numAddresses; index++)
     {
-        SuccessOrQuit(child.AddIp6Address(addresses[index]), "AddIp6Address() failed");
+        SuccessOrQuit(child.AddIp6Address(addresses[index]));
     }
 
     for (uint8_t index = numAddresses - 1; index > 0; index--)
     {
-        SuccessOrQuit(child.RemoveIp6Address(addresses[index]), "RemoveIp6Address() failed");
+        SuccessOrQuit(child.RemoveIp6Address(addresses[index]));
         VerifyChildIp6Addresses(child, index, &addresses[0]);
 
         VerifyOrQuit(child.RemoveIp6Address(addresses[index]) == kErrorNotFound,
@@ -313,10 +313,10 @@ void TestChildIp6Address(void)
 
         for (uint8_t index = 0; index < numAddresses; index++)
         {
-            SuccessOrQuit(child.AddIp6Address(addresses[index]), "AddIp6Address() failed");
+            SuccessOrQuit(child.AddIp6Address(addresses[index]));
         }
 
-        SuccessOrQuit(child.RemoveIp6Address(addresses[indexToRemove]), "RemoveIp6Address() failed");
+        SuccessOrQuit(child.RemoveIp6Address(addresses[indexToRemove]));
 
         VerifyOrQuit(child.RemoveIp6Address(addresses[indexToRemove]) == kErrorNotFound,
                      "RemoveIp6Address() did not fail when removing an address not on the list");

--- a/tests/unit/test_child_table.cpp
+++ b/tests/unit/test_child_table.cpp
@@ -192,16 +192,16 @@ void VerifyChildTableContent(ChildTable &aTable, uint16_t aChildListLength, cons
 
             // Verify that when iterator is done, it points to `nullptr`.
 
-            VerifyOrQuit(iter.GetChild() == nullptr, "iterator GetChild() failed");
+            VerifyOrQuit(iter.GetChild() == nullptr);
 
             iter++;
             VerifyOrQuit(iter.IsDone(), "iterator Advance() (after iterator is done) failed");
-            VerifyOrQuit(iter.GetChild() == nullptr, "iterator GetChild() failed");
+            VerifyOrQuit(iter.GetChild() == nullptr);
 
             // Verify that the number of children matches the number of entries we get from iterator.
 
-            VerifyOrQuit(aTable.GetNumChildren(filter) == numChildren, "GetNumChildren() failed");
-            VerifyOrQuit(aTable.HasChildren(filter) == (numChildren != 0), "HasChildren() failed");
+            VerifyOrQuit(aTable.GetNumChildren(filter) == numChildren);
+            VerifyOrQuit(aTable.HasChildren(filter) == (numChildren != 0));
 
             // Verify that there is no missing or extra entry between the expected list
             // and what was observed/returned by the iterator.
@@ -298,7 +298,7 @@ void TestChildTable(void)
     Error       error;
 
     sInstance = testInitInstance();
-    VerifyOrQuit(sInstance != nullptr, "Null instance");
+    VerifyOrQuit(sInstance != nullptr);
 
     table = &sInstance->Get<ChildTable>();
 
@@ -310,8 +310,8 @@ void TestChildTable(void)
 
     for (Child::StateFilter filter : kAllFilters)
     {
-        VerifyOrQuit(table->HasChildren(filter) == false, "HasChildren() failed after init");
-        VerifyOrQuit(table->GetNumChildren(filter) == 0, "GetNumChildren() failed after init");
+        VerifyOrQuit(table->HasChildren(filter) == false);
+        VerifyOrQuit(table->GetNumChildren(filter) == 0);
     }
 
     printf(" -- PASS\n");
@@ -375,7 +375,7 @@ void TestChildTable(void)
 
     error = table->SetMaxChildrenAllowed(testNumAllowedChildren);
     VerifyOrQuit(error == kErrorNone, "SetMaxChildrenAllowed() failed");
-    VerifyOrQuit(table->GetMaxChildrenAllowed() == testNumAllowedChildren, "GetMaxChildrenAllowed() failed");
+    VerifyOrQuit(table->GetMaxChildrenAllowed() == testNumAllowedChildren);
 
     for (uint16_t num = 0; num < testNumAllowedChildren; num++)
     {

--- a/tests/unit/test_cmd_line_parser.cpp
+++ b/tests/unit/test_cmd_line_parser.cpp
@@ -258,15 +258,15 @@ void TestParsingHexStrings(void)
     // Verify `ParseAsHexString(const char *aString, uint8_t *aBuffer, uint16_t aSize)`
 
     buffer[0] = 0xff;
-    SuccessOrQuit(ParseAsHexString("0", buffer, 1), "ParseAsHexString() failed");
+    SuccessOrQuit(ParseAsHexString("0", buffer, 1));
     VerifyOrQuit(buffer[0] == 0, "ParseAsHexString() parsed incorrectly");
 
     buffer[0] = 0;
-    SuccessOrQuit(ParseAsHexString("7e", buffer, 1), "ParseAsHexString() failed");
+    SuccessOrQuit(ParseAsHexString("7e", buffer, 1));
     VerifyOrQuit(buffer[0] == 0x7e, "ParseAsHexString() parsed incorrectly");
 
     VerifyOrQuit(ParseAsHexString("123", buffer, 1) != OT_ERROR_NONE, "ParseAsHexString() passed with bad input");
-    SuccessOrQuit(ParseAsHexString("123", buffer, 2), "ParseAsHexString() failed");
+    SuccessOrQuit(ParseAsHexString("123", buffer, 2));
     VerifyOrQuit(buffer[0] == 1 && buffer[1] == 0x23, "ParseAsHexString() parsed incorrectly");
 
     VerifyOrQuit(ParseAsHexString("123x", buffer, 2) != OT_ERROR_NONE, "ParseAsHexString() passed with bad input");
@@ -277,10 +277,10 @@ void TestParsingHexStrings(void)
     VerifyOrQuit(ParseAsHexString("1122", buf3) != OT_ERROR_NONE, "ParseAsHexString() passed with bad input");
     VerifyOrQuit(ParseAsHexString("1122334", buf3) != OT_ERROR_NONE, "ParseAsHexString() passed with bad input");
     VerifyOrQuit(ParseAsHexString("11223344", buf3) != OT_ERROR_NONE, "ParseAsHexString() passed with bad input");
-    SuccessOrQuit(ParseAsHexString("abbade", buf3), "ParseAsHexString() failed");
+    SuccessOrQuit(ParseAsHexString("abbade", buf3));
 
     VerifyOrQuit(buf3[0] == 0xab && buf3[1] == 0xba && buf3[2] == 0xde, "ParseAsHexString() parsed incorrectly");
-    SuccessOrQuit(ParseAsHexString("012345", buf3), "ParseAsHexString() failed");
+    SuccessOrQuit(ParseAsHexString("012345", buf3));
     VerifyOrQuit(buf3[0] == 0x01 && buf3[1] == 0x23 && buf3[2] == 0x45, "ParseAsHexString() parsed incorrectly");
     SuccessOrQuit(ParseAsHexString("12345", buf3), "ParseAsHexString() failed with odd length");
     VerifyOrQuit(buf3[0] == 0x01 && buf3[1] == 0x23 && buf3[2] == 0x45, "ParseAsHexString() parsed incorrectly");
@@ -293,12 +293,12 @@ void TestParsingHexStrings(void)
     printf("----------------------------------------------------------\n");
     len = sizeof(buffer);
 
-    SuccessOrQuit(ParseAsHexString(kEvenHexString, len, buffer), "ParseAsHexString() failed");
+    SuccessOrQuit(ParseAsHexString(kEvenHexString, len, buffer));
     VerifyOrQuit(len == sizeof(kEvenParsedArray), "ParseAsHexString() parsed incorrectly");
     VerifyOrQuit(memcmp(buffer, kEvenParsedArray, len) == 0, "ParseAsHexString() parsed incorrectly");
     DumpBuffer(kEvenHexString, buffer, len);
 
-    SuccessOrQuit(ParseAsHexString(kOddHexString, len, buffer), "ParseAsHexString() failed");
+    SuccessOrQuit(ParseAsHexString(kOddHexString, len, buffer));
     VerifyOrQuit(len == sizeof(kOddParsedArray), "ParseAsHexString() parsed incorrectly");
     VerifyOrQuit(memcmp(buffer, kOddParsedArray, len) == 0, "ParseAsHexString() parsed incorrectly");
     DumpBuffer(kOddHexString, buffer, len);

--- a/tests/unit/test_dns.cpp
+++ b/tests/unit/test_dns.cpp
@@ -153,32 +153,32 @@ void TestDnsName(void)
 
         subDomain = "my-service._ipps._tcp.local.";
         domain    = "local.";
-        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() failed");
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain));
 
         subDomain = "my-service._ipps._tcp.local";
         domain    = "local.";
-        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() failed");
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain));
 
         subDomain = "my-service._ipps._tcp.local.";
         domain    = "local";
-        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() failed");
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain));
 
         subDomain = "my-service._ipps._tcp.local";
         domain    = "local";
-        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() failed");
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain));
 
         subDomain = "my-service._ipps._tcp.default.service.arpa.";
         domain    = "default.service.arpa.";
-        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() failed");
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain));
 
         subDomain = "my-service._ipps._tcp.default.service.arpa.";
         domain    = "service.arpa.";
-        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() failed");
+        VerifyOrQuit(Dns::Name::IsSubDomainOf(subDomain, domain));
 
         // Verify it doesn't match a portion of a label.
         subDomain = "my-service._ipps._tcp.default.service.arpa.";
         domain    = "vice.arpa.";
-        VerifyOrQuit(!Dns::Name::IsSubDomainOf(subDomain, domain), "Name::IsSubDomainOf() succeed");
+        VerifyOrQuit(!Dns::Name::IsSubDomainOf(subDomain, domain));
     }
 
     printf("----------------------------------------------------------------\n");
@@ -188,10 +188,10 @@ void TestDnsName(void)
     {
         IgnoreError(message->SetLength(0));
 
-        SuccessOrQuit(Dns::Name::AppendName(test.mName, *message), "Name::AppendName() failed");
+        SuccessOrQuit(Dns::Name::AppendName(test.mName, *message));
 
         len = message->GetLength();
-        SuccessOrQuit(message->Read(0, buffer, len), "Message::Read() failed");
+        SuccessOrQuit(message->Read(0, buffer, len));
 
         DumpBuffer(test.mName, buffer, len);
 
@@ -200,7 +200,7 @@ void TestDnsName(void)
 
         // Parse and skip over the name
         offset = 0;
-        SuccessOrQuit(Dns::Name::ParseName(*message, offset), "Name::ParseName() failed");
+        SuccessOrQuit(Dns::Name::ParseName(*message, offset));
         VerifyOrQuit(offset == len, "Name::ParseName() returned incorrect offset");
 
         // Read labels one by one.
@@ -209,7 +209,7 @@ void TestDnsName(void)
         for (uint8_t index = 0; test.mLabels[index] != nullptr; index++)
         {
             labelLength = sizeof(label);
-            SuccessOrQuit(Dns::Name::ReadLabel(*message, offset, label, labelLength), "Name::ReadLabel() failed");
+            SuccessOrQuit(Dns::Name::ReadLabel(*message, offset, label, labelLength));
 
             printf("Label[%d] = \"%s\"\n", index, label);
 
@@ -223,7 +223,7 @@ void TestDnsName(void)
 
         // Read entire name
         offset = 0;
-        SuccessOrQuit(Dns::Name::ReadName(*message, offset, name, sizeof(name)), "Name::ReadName() failed");
+        SuccessOrQuit(Dns::Name::ReadName(*message, offset, name, sizeof(name)));
 
         printf("Read name =\"%s\"\n", name);
 
@@ -247,8 +247,7 @@ void TestDnsName(void)
         {
             uint16_t startOffset = offset;
 
-            SuccessOrQuit(Dns::Name::CompareLabel(*message, offset, test.mLabels[index]),
-                          "Name::CompareLabel() failed");
+            SuccessOrQuit(Dns::Name::CompareLabel(*message, offset, test.mLabels[index]));
             VerifyOrQuit(offset != startOffset, "Name::CompareLabel() did not change offset");
 
             VerifyOrQuit(Dns::Name::CompareLabel(*message, startOffset, kBadLabel) == kErrorNotFound,
@@ -257,7 +256,7 @@ void TestDnsName(void)
 
         // Compare the whole name.
         offset = 0;
-        SuccessOrQuit(Dns::Name::CompareName(*message, offset, test.mExpectedReadName), "Name::CompareName() failed");
+        SuccessOrQuit(Dns::Name::CompareName(*message, offset, test.mExpectedReadName));
         VerifyOrQuit(offset == len, "Name::CompareName() returned incorrect offset");
 
         offset = 0;
@@ -270,7 +269,7 @@ void TestDnsName(void)
         offset = 0;
         strcpy(name, test.mExpectedReadName);
         name[strlen(name) - 1] = '\0';
-        SuccessOrQuit(Dns::Name::CompareName(*message, offset, name), "Name::CompareName() failed with root");
+        SuccessOrQuit(Dns::Name::CompareName(*message, offset, name));
         VerifyOrQuit(offset == len, "Name::CompareName() returned incorrect offset");
 
         if (strlen(name) >= 1)
@@ -284,8 +283,7 @@ void TestDnsName(void)
 
         // Compare the name with itself read from message.
         offset = 0;
-        SuccessOrQuit(Dns::Name::CompareName(*message, offset, *message, offset),
-                      "Name::CompareName() with itself failed");
+        SuccessOrQuit(Dns::Name::CompareName(*message, offset, *message, offset));
         VerifyOrQuit(offset == len, "Name::CompareName() returned incorrect offset");
     }
 
@@ -296,19 +294,18 @@ void TestDnsName(void)
     {
         if (maxLengthName[strlen(maxLengthName) - 1] == '.')
         {
-            VerifyOrQuit(strlen(maxLengthName) == kMaxNameLength, "invalid max length string");
+            VerifyOrQuit(strlen(maxLengthName) == kMaxNameLength);
         }
         else
         {
-            VerifyOrQuit(strlen(maxLengthName) == kMaxNameLength - 1, "invalid max length string");
+            VerifyOrQuit(strlen(maxLengthName) == kMaxNameLength - 1);
         }
 
         IgnoreError(message->SetLength(0));
 
         printf("\"%s\"\n", maxLengthName);
 
-        VerifyOrQuit(Dns::Name::AppendName(maxLengthName, *message) == kErrorNone,
-                     "Name::AppendName() failed with max length name");
+        SuccessOrQuit(Dns::Name::AppendName(maxLengthName, *message));
     }
 
     printf("----------------------------------------------------------------\n");
@@ -320,8 +317,7 @@ void TestDnsName(void)
 
         printf("\"%s\"\n", invalidName);
 
-        VerifyOrQuit(Dns::Name::AppendName(invalidName, *message) == kErrorInvalidArgs,
-                     "Name::AppendName() did not fail with an invalid name");
+        VerifyOrQuit(Dns::Name::AppendName(invalidName, *message) == kErrorInvalidArgs);
     }
 
     printf("----------------------------------------------------------------\n");
@@ -331,11 +327,11 @@ void TestDnsName(void)
     {
         IgnoreError(message->SetLength(0));
 
-        SuccessOrQuit(Dns::Name::AppendMultipleLabels(test.mName, *message), "Name::Append() failed");
-        SuccessOrQuit(Dns::Name::AppendTerminator(*message), "Name::AppendTerminator() failed");
+        SuccessOrQuit(Dns::Name::AppendMultipleLabels(test.mName, *message));
+        SuccessOrQuit(Dns::Name::AppendTerminator(*message));
 
         len = message->GetLength();
-        SuccessOrQuit(message->Read(0, buffer, len), "Message::Read() failed");
+        SuccessOrQuit(message->Read(0, buffer, len));
 
         DumpBuffer(test.mName, buffer, len);
 
@@ -352,13 +348,13 @@ void TestDnsName(void)
 
         for (uint8_t index = 0; test.mLabels[index] != nullptr; index++)
         {
-            SuccessOrQuit(Dns::Name::AppendLabel(test.mLabels[index], *message), "Name::AppendLabel() failed");
+            SuccessOrQuit(Dns::Name::AppendLabel(test.mLabels[index], *message));
         }
 
-        SuccessOrQuit(Dns::Name::AppendTerminator(*message), "Name::AppendTerminator() failed");
+        SuccessOrQuit(Dns::Name::AppendTerminator(*message));
 
         len = message->GetLength();
-        SuccessOrQuit(message->Read(0, buffer, len), "Message::Read() failed");
+        SuccessOrQuit(message->Read(0, buffer, len));
 
         DumpBuffer(test.mName, buffer, len);
 
@@ -429,62 +425,59 @@ void TestDnsCompressedName(void)
     VerifyOrQuit(instance != nullptr, "Null OpenThread instance");
 
     messagePool = &instance->Get<MessagePool>();
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr, "Message::New failed");
+    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
 
     // Append name1 "F.ISI.ARPA"
 
     for (uint8_t index = 0; index < kHeaderOffset + kGuardBlockSize; index++)
     {
-        SuccessOrQuit(message->Append(index), "Message::Append() failed");
+        SuccessOrQuit(message->Append(index));
     }
 
     message->SetOffset(kHeaderOffset);
 
     name1Offset = message->GetLength();
-    SuccessOrQuit(Dns::Name::AppendName(kName, *message), "Name::AppendName() failed");
+    SuccessOrQuit(Dns::Name::AppendName(kName, *message));
 
     // Append name2 "FOO.F.ISI.ARPA" as a compressed name after some guard/extra bytes
 
     for (uint8_t index = 0; index < kGuardBlockSize; index++)
     {
         uint8_t value = 0xff;
-        SuccessOrQuit(message->Append(value), "Message::Append() failed");
+        SuccessOrQuit(message->Append(value));
     }
 
     name2Offset = message->GetLength();
 
-    SuccessOrQuit(Dns::Name::AppendLabel(kLabel1, *message), "Name::AppendLabel() failed");
-    SuccessOrQuit(Dns::Name::AppendPointerLabel(name1Offset - kHeaderOffset, *message),
-                  "Name::AppendPointerLabel() failed");
+    SuccessOrQuit(Dns::Name::AppendLabel(kLabel1, *message));
+    SuccessOrQuit(Dns::Name::AppendPointerLabel(name1Offset - kHeaderOffset, *message));
 
     // Append name3 "ISI.ARPA" as a compressed name after some guard/extra bytes
 
     for (uint8_t index = 0; index < kGuardBlockSize; index++)
     {
         uint8_t value = 0xaa;
-        SuccessOrQuit(message->Append(value), "Message::Append() failed");
+        SuccessOrQuit(message->Append(value));
     }
 
     name3Offset = message->GetLength();
-    SuccessOrQuit(Dns::Name::AppendPointerLabel(name1Offset + kIsiRelativeIndex - kHeaderOffset, *message),
-                  "Name::AppendPointerLabel() failed");
+    SuccessOrQuit(Dns::Name::AppendPointerLabel(name1Offset + kIsiRelativeIndex - kHeaderOffset, *message));
 
     name4Offset = message->GetLength();
-    SuccessOrQuit(Dns::Name::AppendLabel(kInstanceLabel, *message), "Name::AppendLabel() failed");
-    SuccessOrQuit(Dns::Name::AppendPointerLabel(name1Offset - kHeaderOffset, *message),
-                  "Name::AppendPointerLabel() failed");
+    SuccessOrQuit(Dns::Name::AppendLabel(kInstanceLabel, *message));
+    SuccessOrQuit(Dns::Name::AppendPointerLabel(name1Offset - kHeaderOffset, *message));
 
     printf("----------------------------------------------------------------\n");
     printf("Read and parse the uncompressed name-1 \"F.ISI.ARPA\"\n");
 
-    SuccessOrQuit(message->Read(name1Offset, buffer, sizeof(kEncodedName)), "Message::Read() failed");
+    SuccessOrQuit(message->Read(name1Offset, buffer, sizeof(kEncodedName)));
 
     DumpBuffer(kName, buffer, sizeof(kEncodedName));
     VerifyOrQuit(memcmp(buffer, kEncodedName, sizeof(kEncodedName)) == 0,
                  "Encoded name data does not match expected data");
 
     offset = name1Offset;
-    SuccessOrQuit(Dns::Name::ParseName(*message, offset), "Name::ParseName() failed");
+    SuccessOrQuit(Dns::Name::ParseName(*message, offset));
 
     VerifyOrQuit(offset == name1Offset + sizeof(kEncodedName), "Name::ParseName() returned incorrect offset");
 
@@ -493,7 +486,7 @@ void TestDnsCompressedName(void)
     for (const char *nameLabel : kName1Labels)
     {
         labelLength = sizeof(label);
-        SuccessOrQuit(Dns::Name::ReadLabel(*message, offset, label, labelLength), "Name::ReadLabel() failed");
+        SuccessOrQuit(Dns::Name::ReadLabel(*message, offset, label, labelLength));
 
         printf("label: \"%s\"\n", label);
         VerifyOrQuit(strcmp(label, nameLabel) == 0, "Name::ReadLabel() did not get expected label");
@@ -505,7 +498,7 @@ void TestDnsCompressedName(void)
                  "Name::ReadLabel() failed at end of the name");
 
     offset = name1Offset;
-    SuccessOrQuit(Dns::Name::ReadName(*message, offset, name, sizeof(name)), "Name::ReadName() failed");
+    SuccessOrQuit(Dns::Name::ReadName(*message, offset, name, sizeof(name)));
     printf("Read name =\"%s\"\n", name);
     VerifyOrQuit(strcmp(name, kExpectedReadName1) == 0, "Name::ReadName() did not return expected name");
     VerifyOrQuit(offset == name1Offset + sizeof(kEncodedName), "Name::ReadName() returned incorrect offset");
@@ -514,11 +507,11 @@ void TestDnsCompressedName(void)
 
     for (const char *nameLabel : kName1Labels)
     {
-        SuccessOrQuit(Dns::Name::CompareLabel(*message, offset, nameLabel), "Name::ComapreLabel() failed");
+        SuccessOrQuit(Dns::Name::CompareLabel(*message, offset, nameLabel));
     }
 
     offset = name1Offset;
-    SuccessOrQuit(Dns::Name::CompareName(*message, offset, kExpectedReadName1), "Name::CompareName() failed");
+    SuccessOrQuit(Dns::Name::CompareName(*message, offset, kExpectedReadName1));
     VerifyOrQuit(offset == name1Offset + sizeof(kEncodedName), "Name::CompareName() returned incorrect offset");
 
     offset = name1Offset;
@@ -527,7 +520,7 @@ void TestDnsCompressedName(void)
     VerifyOrQuit(offset == name1Offset + sizeof(kEncodedName), "Name::CompareName() returned incorrect offset");
 
     offset = name1Offset;
-    SuccessOrQuit(Dns::Name::CompareName(*message, offset, *message, offset), "Name::CompareName() with itself failed");
+    SuccessOrQuit(Dns::Name::CompareName(*message, offset, *message, offset));
     VerifyOrQuit(offset == name1Offset + sizeof(kEncodedName), "Name::CompareName() returned incorrect offset");
 
     offset = name1Offset;
@@ -538,11 +531,11 @@ void TestDnsCompressedName(void)
     printf("----------------------------------------------------------------\n");
     printf("Read and parse compressed name-2 \"FOO.F.ISI.ARPA\"\n");
 
-    SuccessOrQuit(message->Read(name2Offset, buffer, kName2EncodedSize), "Message::Read() failed");
+    SuccessOrQuit(message->Read(name2Offset, buffer, kName2EncodedSize));
     DumpBuffer("name2(compressed)", buffer, kName2EncodedSize);
 
     offset = name2Offset;
-    SuccessOrQuit(Dns::Name::ParseName(*message, offset), "Name::ParseName() failed");
+    SuccessOrQuit(Dns::Name::ParseName(*message, offset));
     VerifyOrQuit(offset == name2Offset + kName2EncodedSize, "Name::ParseName() returned incorrect offset");
 
     offset = name2Offset;
@@ -550,7 +543,7 @@ void TestDnsCompressedName(void)
     for (const char *nameLabel : kName2Labels)
     {
         labelLength = sizeof(label);
-        SuccessOrQuit(Dns::Name::ReadLabel(*message, offset, label, labelLength), "Name::ReadLabel() failed");
+        SuccessOrQuit(Dns::Name::ReadLabel(*message, offset, label, labelLength));
 
         printf("label: \"%s\"\n", label);
         VerifyOrQuit(strcmp(label, nameLabel) == 0, "Name::ReadLabel() did not get expected label");
@@ -562,7 +555,7 @@ void TestDnsCompressedName(void)
                  "Name::ReadLabel() failed at end of the name");
 
     offset = name2Offset;
-    SuccessOrQuit(Dns::Name::ReadName(*message, offset, name, sizeof(name)), "Name::ReadName() failed");
+    SuccessOrQuit(Dns::Name::ReadName(*message, offset, name, sizeof(name)));
     printf("Read name =\"%s\"\n", name);
     VerifyOrQuit(strcmp(name, kExpectedReadName2) == 0, "Name::ReadName() did not return expected name");
     VerifyOrQuit(offset == name2Offset + kName2EncodedSize, "Name::ReadName() returned incorrect offset");
@@ -571,11 +564,11 @@ void TestDnsCompressedName(void)
 
     for (const char *nameLabel : kName2Labels)
     {
-        SuccessOrQuit(Dns::Name::CompareLabel(*message, offset, nameLabel), "Name::ComapreLabel() failed");
+        SuccessOrQuit(Dns::Name::CompareLabel(*message, offset, nameLabel));
     }
 
     offset = name2Offset;
-    SuccessOrQuit(Dns::Name::CompareName(*message, offset, kExpectedReadName2), "Name::CompareName() failed");
+    SuccessOrQuit(Dns::Name::CompareName(*message, offset, kExpectedReadName2));
     VerifyOrQuit(offset == name2Offset + kName2EncodedSize, "Name::CompareName() returned incorrect offset");
 
     offset = name2Offset;
@@ -595,11 +588,11 @@ void TestDnsCompressedName(void)
     printf("----------------------------------------------------------------\n");
     printf("Read and parse compressed name-3 \"ISI.ARPA\"\n");
 
-    SuccessOrQuit(message->Read(name3Offset, buffer, kName3EncodedSize), "Message::Read() failed");
+    SuccessOrQuit(message->Read(name3Offset, buffer, kName3EncodedSize));
     DumpBuffer("name2(compressed)", buffer, kName3EncodedSize);
 
     offset = name3Offset;
-    SuccessOrQuit(Dns::Name::ParseName(*message, offset), "Name::ParseName() failed");
+    SuccessOrQuit(Dns::Name::ParseName(*message, offset));
     VerifyOrQuit(offset == name3Offset + kName3EncodedSize, "Name::ParseName() returned incorrect offset");
 
     offset = name3Offset;
@@ -607,7 +600,7 @@ void TestDnsCompressedName(void)
     for (const char *nameLabel : kName3Labels)
     {
         labelLength = sizeof(label);
-        SuccessOrQuit(Dns::Name::ReadLabel(*message, offset, label, labelLength), "Name::ReadLabel() failed");
+        SuccessOrQuit(Dns::Name::ReadLabel(*message, offset, label, labelLength));
 
         printf("label: \"%s\"\n", label);
         VerifyOrQuit(strcmp(label, nameLabel) == 0, "Name::ReadLabel() did not get expected label");
@@ -619,7 +612,7 @@ void TestDnsCompressedName(void)
                  "Name::ReadLabel() failed at end of the name");
 
     offset = name3Offset;
-    SuccessOrQuit(Dns::Name::ReadName(*message, offset, name, sizeof(name)), "Name::ReadName() failed");
+    SuccessOrQuit(Dns::Name::ReadName(*message, offset, name, sizeof(name)));
     printf("Read name =\"%s\"\n", name);
     VerifyOrQuit(strcmp(name, kExpectedReadName3) == 0, "Name::ReadName() did not return expected name");
     VerifyOrQuit(offset == name3Offset + kName3EncodedSize, "Name::ReadName() returned incorrect offset");
@@ -628,11 +621,11 @@ void TestDnsCompressedName(void)
 
     for (const char *nameLabel : kName3Labels)
     {
-        SuccessOrQuit(Dns::Name::CompareLabel(*message, offset, nameLabel), "Name::ComapreLabel() failed");
+        SuccessOrQuit(Dns::Name::CompareLabel(*message, offset, nameLabel));
     }
 
     offset = name3Offset;
-    SuccessOrQuit(Dns::Name::CompareName(*message, offset, kExpectedReadName3), "Name::CompareName() failed");
+    SuccessOrQuit(Dns::Name::CompareName(*message, offset, kExpectedReadName3));
     VerifyOrQuit(offset == name3Offset + kName3EncodedSize, "Name::CompareName() returned incorrect offset");
 
     offset = name3Offset;
@@ -652,11 +645,11 @@ void TestDnsCompressedName(void)
     printf("----------------------------------------------------------------\n");
     printf("Read and parse the uncompressed name-4 \"Human\\.Readable.F.ISI.ARPA\"\n");
 
-    SuccessOrQuit(message->Read(name4Offset, buffer, kName4EncodedSize), "Message::Read() failed");
+    SuccessOrQuit(message->Read(name4Offset, buffer, kName4EncodedSize));
     DumpBuffer("name4(compressed)", buffer, kName4EncodedSize);
 
     offset = name4Offset;
-    SuccessOrQuit(Dns::Name::ParseName(*message, offset), "Name::ParseName() failed");
+    SuccessOrQuit(Dns::Name::ParseName(*message, offset));
     VerifyOrQuit(offset == name4Offset + kName4EncodedSize, "Name::ParseName() returned incorrect offset");
 
     offset = name4Offset;
@@ -664,7 +657,7 @@ void TestDnsCompressedName(void)
     for (const char *nameLabel : kName4Labels)
     {
         labelLength = sizeof(label);
-        SuccessOrQuit(Dns::Name::ReadLabel(*message, offset, label, labelLength), "Name::ReadLabel() failed");
+        SuccessOrQuit(Dns::Name::ReadLabel(*message, offset, label, labelLength));
 
         printf("label: \"%s\"\n", label);
         VerifyOrQuit(strcmp(label, nameLabel) == 0, "Name::ReadLabel() did not get expected label");
@@ -680,7 +673,7 @@ void TestDnsCompressedName(void)
 
     for (const char *nameLabel : kName4Labels)
     {
-        SuccessOrQuit(Dns::Name::CompareLabel(*message, offset, nameLabel), "Name::ComapreLabel() failed");
+        SuccessOrQuit(Dns::Name::CompareLabel(*message, offset, nameLabel));
     }
 
     offset = name4Offset;
@@ -693,7 +686,7 @@ void TestDnsCompressedName(void)
     printf("----------------------------------------------------------------\n");
     printf("Append names from one message to another\n");
 
-    VerifyOrQuit((message2 = messagePool->New(Message::kTypeIp6, 0)) != nullptr, "Message::New failed");
+    VerifyOrQuit((message2 = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
 
     dnsName1.SetFromMessage(*message, name1Offset);
     dnsName2.SetFromMessage(*message, name2Offset);
@@ -701,28 +694,28 @@ void TestDnsCompressedName(void)
     dnsName4.SetFromMessage(*message, name4Offset);
 
     offset = 0;
-    SuccessOrQuit(dnsName1.AppendTo(*message2), "Name::AppendTo() failed");
-    SuccessOrQuit(dnsName2.AppendTo(*message2), "Name::AppendTo() failed");
-    SuccessOrQuit(dnsName3.AppendTo(*message2), "Name::AppendTo() failed");
-    SuccessOrQuit(dnsName4.AppendTo(*message2), "Name::AppendTo() failed");
+    SuccessOrQuit(dnsName1.AppendTo(*message2));
+    SuccessOrQuit(dnsName2.AppendTo(*message2));
+    SuccessOrQuit(dnsName3.AppendTo(*message2));
+    SuccessOrQuit(dnsName4.AppendTo(*message2));
 
-    SuccessOrQuit(message2->Read(0, buffer, message2->GetLength()), "Message::Read() failed");
+    SuccessOrQuit(message2->Read(0, buffer, message2->GetLength()));
     DumpBuffer("message2", buffer, message2->GetLength());
 
     // Now compare the names one by one in `message2`. Note that
     // `CompareName()` will update `offset` on success.
 
-    VerifyOrQuit(Dns::Name::CompareName(*message2, offset, dnsName1) == kErrorNone, "Incorrect name after AppendTo()");
-    VerifyOrQuit(Dns::Name::CompareName(*message2, offset, dnsName2) == kErrorNone, "Incorrect name after AppendTo()");
-    VerifyOrQuit(Dns::Name::CompareName(*message2, offset, dnsName3) == kErrorNone, "Incorrect name after AppendTo()");
-    VerifyOrQuit(Dns::Name::CompareName(*message2, offset, dnsName4) == kErrorNone, "Incorrect name after AppendTo()");
+    SuccessOrQuit(Dns::Name::CompareName(*message2, offset, dnsName1));
+    SuccessOrQuit(Dns::Name::CompareName(*message2, offset, dnsName2));
+    SuccessOrQuit(Dns::Name::CompareName(*message2, offset, dnsName3));
+    SuccessOrQuit(Dns::Name::CompareName(*message2, offset, dnsName4));
 
     offset = 0;
-    SuccessOrQuit(Dns::Name::ReadName(*message2, offset, name, sizeof(name)), "ReadName() failed");
+    SuccessOrQuit(Dns::Name::ReadName(*message2, offset, name, sizeof(name)));
     printf("- Name1 after `AppendTo()`: \"%s\"\n", name);
-    SuccessOrQuit(Dns::Name::ReadName(*message2, offset, name, sizeof(name)), "ReadName() failed");
+    SuccessOrQuit(Dns::Name::ReadName(*message2, offset, name, sizeof(name)));
     printf("- Name2 after `AppendTo()`: \"%s\"\n", name);
-    SuccessOrQuit(Dns::Name::ReadName(*message2, offset, name, sizeof(name)), "ReadName() failed");
+    SuccessOrQuit(Dns::Name::ReadName(*message2, offset, name, sizeof(name)));
     printf("- Name3 after `AppendTo()`: \"%s\"\n", name);
     // `ReadName()` for name-4 will fail due to first label containing dot char.
 
@@ -794,31 +787,31 @@ void TestHeaderAndResourceRecords(void)
     VerifyOrQuit(instance != nullptr, "Null OpenThread instance");
 
     messagePool = &instance->Get<MessagePool>();
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr, "Message::New failed");
+    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
 
     printf("----------------------------------------------------------------\n");
     printf("Preparing the message\n");
 
-    SuccessOrQuit(message->Append(kMessageString), "Message::Append() failed");
+    SuccessOrQuit(message->Append(kMessageString));
 
     // Header
 
     headerOffset = message->GetLength();
-    SuccessOrQuit(header.SetRandomMessageId(), "Header::SetRandomMessageId() failed");
+    SuccessOrQuit(header.SetRandomMessageId());
     messageId = header.GetMessageId();
     header.SetType(Dns::Header::kTypeResponse);
     header.SetQuestionCount(kQuestionCount);
     header.SetAnswerCount(kAnswerCount);
     header.SetAdditionalRecordCount(kAdditionalCount);
-    SuccessOrQuit(message->Append(header), "Message::Append() failed");
+    SuccessOrQuit(message->Append(header));
     message->SetOffset(headerOffset);
 
     // Question section
 
     serviceNameOffset = message->GetLength() - headerOffset;
-    SuccessOrQuit(Dns::Name::AppendMultipleLabels(kServiceLabels, *message), "AppendMultipleLabels() failed");
-    SuccessOrQuit(Dns::Name::AppendName(kDomainName, *message), "AppendName() failed");
-    SuccessOrQuit(message->Append(Dns::Question(Dns::ResourceRecord::kTypePtr)), "Message::Append() failed");
+    SuccessOrQuit(Dns::Name::AppendMultipleLabels(kServiceLabels, *message));
+    SuccessOrQuit(Dns::Name::AppendName(kDomainName, *message));
+    SuccessOrQuit(message->Append(Dns::Question(Dns::ResourceRecord::kTypePtr)));
 
     // Answer section
 
@@ -826,13 +819,13 @@ void TestHeaderAndResourceRecords(void)
 
     for (const char *instanceLabel : kInstanceLabels)
     {
-        SuccessOrQuit(Dns::Name::AppendPointerLabel(serviceNameOffset, *message), "AppendPointerLabel() failed");
+        SuccessOrQuit(Dns::Name::AppendPointerLabel(serviceNameOffset, *message));
         ptrRecord.Init();
         ptrRecord.SetTtl(kTtl);
         offset = message->GetLength();
-        SuccessOrQuit(message->Append(ptrRecord), "Message::Append() failed");
-        SuccessOrQuit(Dns::Name::AppendLabel(instanceLabel, *message), "AppendLabel failed");
-        SuccessOrQuit(Dns::Name::AppendPointerLabel(serviceNameOffset, *message), "AppendPointerLabel() failed");
+        SuccessOrQuit(message->Append(ptrRecord));
+        SuccessOrQuit(Dns::Name::AppendLabel(instanceLabel, *message));
+        SuccessOrQuit(Dns::Name::AppendPointerLabel(serviceNameOffset, *message));
         ptrRecord.SetLength(message->GetLength() - offset - sizeof(Dns::ResourceRecord));
         message->Write(offset, ptrRecord);
     }
@@ -846,39 +839,39 @@ void TestHeaderAndResourceRecords(void)
         uint16_t instanceNameOffset = message->GetLength() - headerOffset;
 
         // SRV record
-        SuccessOrQuit(Dns::Name::AppendName(instanceName, *message), "AppendName() failed");
+        SuccessOrQuit(Dns::Name::AppendName(instanceName, *message));
         srvRecord.Init();
         srvRecord.SetTtl(kTtl);
         srvRecord.SetPort(kSrvPort);
         srvRecord.SetWeight(kSrvWeight);
         srvRecord.SetPriority(kSrvPriority);
         offset = message->GetLength();
-        SuccessOrQuit(message->Append(srvRecord), "Message::Append() failed");
+        SuccessOrQuit(message->Append(srvRecord));
         hostNameOffset = message->GetLength() - headerOffset;
-        SuccessOrQuit(Dns::Name::AppendName(kHostName, *message), "AppendName() failed");
+        SuccessOrQuit(Dns::Name::AppendName(kHostName, *message));
         srvRecord.SetLength(message->GetLength() - offset - sizeof(Dns::ResourceRecord));
         message->Write(offset, srvRecord);
 
         // TXT record
-        SuccessOrQuit(Dns::Name::AppendPointerLabel(instanceNameOffset, *message), "AppendPointerLabel() failed");
+        SuccessOrQuit(Dns::Name::AppendPointerLabel(instanceNameOffset, *message));
         txtRecord.Init();
         txtRecord.SetTtl(kTxtTtl);
         txtRecord.SetLength(sizeof(kTxtData));
-        SuccessOrQuit(message->Append(txtRecord), "Message::Append() failed");
-        SuccessOrQuit(message->Append(kTxtData), "Message::Append() failed");
+        SuccessOrQuit(message->Append(txtRecord));
+        SuccessOrQuit(message->Append(kTxtData));
     }
 
-    SuccessOrQuit(hostAddress.FromString(kHostAddress), "Address::FromString() failed");
-    SuccessOrQuit(Dns::Name::AppendPointerLabel(hostNameOffset, *message), "AppendPointerLabel() failed");
+    SuccessOrQuit(hostAddress.FromString(kHostAddress));
+    SuccessOrQuit(Dns::Name::AppendPointerLabel(hostNameOffset, *message));
     aaaaRecord.Init();
     aaaaRecord.SetTtl(kTtl);
     aaaaRecord.SetAddress(hostAddress);
-    SuccessOrQuit(message->Append(aaaaRecord), "Message::Append()");
+    SuccessOrQuit(message->Append(aaaaRecord));
 
     // Dump the entire message
 
     VerifyOrQuit(message->GetLength() < kMaxSize, "Message is too long");
-    SuccessOrQuit(message->Read(0, buffer, message->GetLength()), "Message::Read() failed");
+    SuccessOrQuit(message->Read(0, buffer, message->GetLength()));
     DumpBuffer("message", buffer, message->GetLength());
 
     printf("----------------------------------------------------------------\n");
@@ -891,20 +884,20 @@ void TestHeaderAndResourceRecords(void)
     // Header
 
     VerifyOrQuit(offset == headerOffset, "headerOffset is incorrect");
-    SuccessOrQuit(message->Read(offset, header), "Message::Read() failed");
+    SuccessOrQuit(message->Read(offset, header));
     offset += sizeof(header);
 
-    VerifyOrQuit(header.GetMessageId() == messageId, "Header::GetMessageId() failed");
-    VerifyOrQuit(header.GetType() == Dns::Header::kTypeResponse, "Header::GetType() failed");
-    VerifyOrQuit(header.GetQuestionCount() == kQuestionCount, "Header::GetQuestionCount() failed");
-    VerifyOrQuit(header.GetAnswerCount() == kAnswerCount, "Header::GetAnswerCount() failed");
-    VerifyOrQuit(header.GetAdditionalRecordCount() == kAdditionalCount, "Header::GetAdditionalRecordCount() failed");
+    VerifyOrQuit(header.GetMessageId() == messageId);
+    VerifyOrQuit(header.GetType() == Dns::Header::kTypeResponse);
+    VerifyOrQuit(header.GetQuestionCount() == kQuestionCount);
+    VerifyOrQuit(header.GetAnswerCount() == kAnswerCount);
+    VerifyOrQuit(header.GetAdditionalRecordCount() == kAdditionalCount);
 
     printf("- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - \n");
     printf("Question Section\n");
 
     SuccessOrQuit(Dns::Name::CompareName(*message, offset, kServiceName), "Question name does not match");
-    VerifyOrQuit(message->Compare(offset, Dns::Question(Dns::ResourceRecord::kTypePtr)), "Question does not match");
+    VerifyOrQuit(message->Compare(offset, Dns::Question(Dns::ResourceRecord::kTypePtr)));
     offset += sizeof(Dns::Question);
 
     printf("PTR for \"%s\"\n", kServiceName);
@@ -916,11 +909,11 @@ void TestHeaderAndResourceRecords(void)
 
     for (const char *instanceName : kInstanceNames)
     {
-        SuccessOrQuit(Dns::Name::CompareName(*message, offset, kServiceName), "ServiceName is incorrect");
-        SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, ptrRecord), "ReadRecord() failed");
+        SuccessOrQuit(Dns::Name::CompareName(*message, offset, kServiceName));
+        SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, ptrRecord));
         VerifyOrQuit(ptrRecord.GetTtl() == kTtl, "Read PTR is incorrect");
 
-        SuccessOrQuit(ptrRecord.ReadPtrName(*message, offset, name, sizeof(name)), "ReadName() failed");
+        SuccessOrQuit(ptrRecord.ReadPtrName(*message, offset, name, sizeof(name)));
         VerifyOrQuit(strcmp(name, instanceName) == 0, "Inst1 name is incorrect");
 
         printf("    \"%s\" PTR %u %d \"%s\"\n", kServiceName, ptrRecord.GetTtl(), ptrRecord.GetLength(), name);
@@ -929,7 +922,7 @@ void TestHeaderAndResourceRecords(void)
     VerifyOrQuit(offset == additionalSectionOffset, "offset is incorrect after answer section parse");
 
     offset = answerSectionOffset;
-    SuccessOrQuit(Dns::ResourceRecord::ParseRecords(*message, offset, kAnswerCount), "ParseRecords() failed");
+    SuccessOrQuit(Dns::ResourceRecord::ParseRecords(*message, offset, kAnswerCount));
     VerifyOrQuit(offset == additionalSectionOffset, "offset is incorrect after answer section parse");
 
     printf("Use FindRecord() to find and iterate through all the records:\n");
@@ -941,13 +934,11 @@ void TestHeaderAndResourceRecords(void)
     {
         uint16_t prevNumRecords = numRecords;
 
-        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(kServiceName)),
-                      "FindRecord failed");
+        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(kServiceName)));
         VerifyOrQuit(numRecords == prevNumRecords - 1, "Incorrect num records");
-        SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, ptrRecord), "ReadRecord() failed");
+        SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, ptrRecord));
         VerifyOrQuit(ptrRecord.GetTtl() == kTtl, "Read PTR is incorrect");
-        SuccessOrQuit(ptrRecord.ReadPtrName(*message, offset, label, sizeof(label), name, sizeof(name)),
-                      "ReadName() failed");
+        SuccessOrQuit(ptrRecord.ReadPtrName(*message, offset, label, sizeof(label), name, sizeof(name)));
         printf("    \"%s\" PTR %u %d inst:\"%s\" at \"%s\"\n", kServiceName, ptrRecord.GetTtl(), ptrRecord.GetLength(),
                label, name);
     }
@@ -964,8 +955,7 @@ void TestHeaderAndResourceRecords(void)
 
     while (numRecords > 0)
     {
-        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(kServiceName)),
-                      "FindRecord failed");
+        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(kServiceName)));
         VerifyOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, srvRecord) == kErrorNotFound,
                      "ReadRecord() did not fail with non-matching type");
     }
@@ -988,34 +978,33 @@ void TestHeaderAndResourceRecords(void)
     for (const char *instanceName : kInstanceNames)
     {
         // SRV record
-        SuccessOrQuit(Dns::Name::CompareName(*message, offset, instanceName), "Instance is incorrect");
-        SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, srvRecord), "ReadRecord() failed");
-        VerifyOrQuit(srvRecord.GetTtl() == kTtl, "Read SRV is incorrect");
-        VerifyOrQuit(srvRecord.GetPort() == kSrvPort, "Read SRV port is incorrect");
-        VerifyOrQuit(srvRecord.GetWeight() == kSrvWeight, "Read SRV weight is incorrect");
-        VerifyOrQuit(srvRecord.GetPriority() == kSrvPriority, "Read SRV priority is incorrect");
-        SuccessOrQuit(srvRecord.ReadTargetHostName(*message, offset, name, sizeof(name)),
-                      "ReadTargetHostName() failed");
-        VerifyOrQuit(strcmp(name, kHostName) == 0, "Inst1 name is incorrect");
+        SuccessOrQuit(Dns::Name::CompareName(*message, offset, instanceName));
+        SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, srvRecord));
+        VerifyOrQuit(srvRecord.GetTtl() == kTtl);
+        VerifyOrQuit(srvRecord.GetPort() == kSrvPort);
+        VerifyOrQuit(srvRecord.GetWeight() == kSrvWeight);
+        VerifyOrQuit(srvRecord.GetPriority() == kSrvPriority);
+        SuccessOrQuit(srvRecord.ReadTargetHostName(*message, offset, name, sizeof(name)));
+        VerifyOrQuit(strcmp(name, kHostName) == 0);
         printf("    \"%s\" SRV %u %d %d %d %d \"%s\"\n", instanceName, srvRecord.GetTtl(), srvRecord.GetLength(),
                srvRecord.GetPort(), srvRecord.GetWeight(), srvRecord.GetPriority(), name);
 
         // TXT record
-        SuccessOrQuit(Dns::Name::CompareName(*message, offset, instanceName), "Instance is incorrect");
-        SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, txtRecord), "ReadRecord() failed");
-        VerifyOrQuit(txtRecord.GetTtl() == kTxtTtl, "Read TXT is incorrect");
+        SuccessOrQuit(Dns::Name::CompareName(*message, offset, instanceName));
+        SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, txtRecord));
+        VerifyOrQuit(txtRecord.GetTtl() == kTxtTtl);
         len = sizeof(buffer);
-        SuccessOrQuit(txtRecord.ReadTxtData(*message, offset, buffer, len), "ReadTxtData() failed");
-        VerifyOrQuit(len == sizeof(kTxtData), "TXT data length is not valid");
-        VerifyOrQuit(memcmp(buffer, kTxtData, len) == 0, "TXT data is not valid");
+        SuccessOrQuit(txtRecord.ReadTxtData(*message, offset, buffer, len));
+        VerifyOrQuit(len == sizeof(kTxtData));
+        VerifyOrQuit(memcmp(buffer, kTxtData, len) == 0);
         printf("    \"%s\" TXT %u %d \"%s\"\n", instanceName, txtRecord.GetTtl(), txtRecord.GetLength(),
                reinterpret_cast<const char *>(buffer));
     }
 
-    SuccessOrQuit(Dns::Name::CompareName(*message, offset, kHostName), "HostName is incorrect");
-    SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, aaaaRecord), "ReadRecord() failed");
-    VerifyOrQuit(aaaaRecord.GetTtl() == kTtl, "Read AAAA is incorrect");
-    VerifyOrQuit(aaaaRecord.GetAddress() == hostAddress, "Read host address is incorrect");
+    SuccessOrQuit(Dns::Name::CompareName(*message, offset, kHostName));
+    SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, aaaaRecord));
+    VerifyOrQuit(aaaaRecord.GetTtl() == kTtl);
+    VerifyOrQuit(aaaaRecord.GetAddress() == hostAddress);
     printf("    \"%s\" AAAA %u %d \"%s\"\n", kHostName, aaaaRecord.GetTtl(), aaaaRecord.GetLength(),
            aaaaRecord.GetAddress().ToString().AsCString());
 
@@ -1023,7 +1012,7 @@ void TestHeaderAndResourceRecords(void)
 
     // Use `ParseRecords()` to parse all records
     offset = additionalSectionOffset;
-    SuccessOrQuit(Dns::ResourceRecord::ParseRecords(*message, offset, kAdditionalCount), "ParseRecords() failed");
+    SuccessOrQuit(Dns::ResourceRecord::ParseRecords(*message, offset, kAdditionalCount));
     VerifyOrQuit(offset == message->GetLength(), "offset is incorrect after additional section parse");
 
     printf("Use FindRecord() to search for specific name:\n");
@@ -1033,16 +1022,14 @@ void TestHeaderAndResourceRecords(void)
         offset     = additionalSectionOffset;
         numRecords = kAdditionalCount;
 
-        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(instanceName)),
-                      "FindRecord failed");
-        SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, srvRecord), "ReadRecord() failed");
-        SuccessOrQuit(Dns::Name::ParseName(*message, offset), "ParseName() failed");
+        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(instanceName)));
+        SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, srvRecord));
+        SuccessOrQuit(Dns::Name::ParseName(*message, offset));
         printf("    \"%s\" SRV %u %d %d %d %d\n", instanceName, srvRecord.GetTtl(), srvRecord.GetLength(),
                srvRecord.GetPort(), srvRecord.GetWeight(), srvRecord.GetPriority());
 
-        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(instanceName)),
-                      "FindRecord failed");
-        SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, txtRecord), "ReadRecord() failed");
+        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(instanceName)));
+        SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, txtRecord));
         offset += txtRecord.GetLength();
         printf("    \"%s\" TXT %u %d\n", instanceName, txtRecord.GetTtl(), txtRecord.GetLength());
 
@@ -1055,10 +1042,10 @@ void TestHeaderAndResourceRecords(void)
 
     offset     = additionalSectionOffset;
     numRecords = kAdditionalCount;
-    SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(kHostName)),
-                  "FindRecord() failed");
-    SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, record), "ReadRecord() failed");
-    VerifyOrQuit(record.GetType() == Dns::ResourceRecord::kTypeAaaa, "Read record has incorrect type");
+    SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, numRecords, Dns::Name(kHostName)));
+
+    SuccessOrQuit(Dns::ResourceRecord::ReadRecord(*message, offset, record));
+    VerifyOrQuit(record.GetType() == Dns::ResourceRecord::kTypeAaaa);
     offset += record.GetLength();
     VerifyOrQuit(offset == message->GetLength(), "offset is incorrect after additional section parse");
 
@@ -1069,8 +1056,7 @@ void TestHeaderAndResourceRecords(void)
     {
         offset = answerSectionOffset;
         SuccessOrQuit(
-            Dns::ResourceRecord::FindRecord(*message, offset, kAnswerCount, index, Dns::Name(kServiceName), ptrRecord),
-            "FindRecord() failed");
+            Dns::ResourceRecord::FindRecord(*message, offset, kAnswerCount, index, Dns::Name(kServiceName), ptrRecord));
 
         printf("   index:%d -> \"%s\" PTR %u %d\n", index, kServiceName, ptrRecord.GetTtl(), ptrRecord.GetLength());
     }
@@ -1102,40 +1088,34 @@ void TestHeaderAndResourceRecords(void)
         // There is a single SRV and TXT entry for each instance
         offset = additionalSectionOffset;
         SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, kAdditionalCount, /* aIndex */ 0,
-                                                      Dns::Name(instanceName), srvRecord),
-                      "FindRecord() failed");
+                                                      Dns::Name(instanceName), srvRecord));
         printf("    \"%s\" SRV %u %d %d %d %d \n", instanceName, srvRecord.GetTtl(), srvRecord.GetLength(),
                srvRecord.GetPort(), srvRecord.GetWeight(), srvRecord.GetPriority());
 
         offset = additionalSectionOffset;
         SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, kAdditionalCount, /* aIndex */ 0,
-                                                      Dns::Name(instanceName), txtRecord),
-                      "FindRecord() failed");
+                                                      Dns::Name(instanceName), txtRecord));
         printf("    \"%s\" TXT %u %d\n", instanceName, txtRecord.GetTtl(), txtRecord.GetLength());
 
         offset = additionalSectionOffset;
         VerifyOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, kAdditionalCount, /* aIndex */ 1,
-                                                     Dns::Name(instanceName), srvRecord) == kErrorNotFound,
-                     "FindRecord() did not fail with bad index");
+                                                     Dns::Name(instanceName), srvRecord) == kErrorNotFound);
 
         offset = additionalSectionOffset;
         VerifyOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, kAdditionalCount, /* aIndex */ 1,
-                                                     Dns::Name(instanceName), txtRecord) == kErrorNotFound,
-                     "FindRecord() did not fail with bad index");
+                                                     Dns::Name(instanceName), txtRecord) == kErrorNotFound);
     }
 
     for (index = 0; index < kAdditionalCount; index++)
     {
         offset = additionalSectionOffset;
         // Find record with empty name (matching any) and any type.
-        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, kAdditionalCount, index, Dns::Name(), record),
-                      "FindRecord() failed");
+        SuccessOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, kAdditionalCount, index, Dns::Name(), record));
     }
 
     offset = additionalSectionOffset;
     VerifyOrQuit(Dns::ResourceRecord::FindRecord(*message, offset, kAdditionalCount, index, Dns::Name(), record) ==
-                     kErrorNotFound,
-                 "FindRecord() did not fail with bad index");
+                 kErrorNotFound);
 
     message->Free();
     testFreeInstance(instance);
@@ -1218,25 +1198,23 @@ void TestDnsTxtEntry(void)
     printf("TestDnsTxtEntry()\n");
 
     instance = static_cast<Instance *>(testInitInstance());
-    VerifyOrQuit(instance != nullptr, "Null OpenThread instance");
+    VerifyOrQuit(instance != nullptr);
 
     messagePool = &instance->Get<MessagePool>();
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr, "Message::New failed");
+    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
 
-    SuccessOrQuit(Dns::TxtEntry::AppendEntries(kTxtEntries, OT_ARRAY_LENGTH(kTxtEntries), *message),
-                  "TxtEntry::AppendEntries() failed");
+    SuccessOrQuit(Dns::TxtEntry::AppendEntries(kTxtEntries, OT_ARRAY_LENGTH(kTxtEntries), *message));
 
     txtDataLength = message->GetLength();
     VerifyOrQuit(txtDataLength < kMaxTxtDataSize, "TXT data is too long");
 
-    SuccessOrQuit(message->Read(0, txtData, txtDataLength), "Failed to read txt data from message");
+    SuccessOrQuit(message->Read(0, txtData, txtDataLength));
     DumpBuffer("txt data", txtData, txtDataLength);
 
     index = 0;
     for (const EncodedTxtData &encodedData : kEncodedTxtData)
     {
-        VerifyOrQuit(memcmp(&txtData[index], encodedData.mData, encodedData.mLength) == 0,
-                     "TxtData is incorrectly encoded");
+        VerifyOrQuit(memcmp(&txtData[index], encodedData.mData, encodedData.mLength) == 0);
         index += encodedData.mLength;
     }
 
@@ -1258,24 +1236,19 @@ void TestDnsTxtEntry(void)
             VerifyOrQuit(txtEntry.mKey == nullptr, "TxtEntry key does not match expected value for long key");
             VerifyOrQuit(txtEntry.mValueLength == expectedKeyLength + expectedTxtEntry.mValueLength + sizeof(char),
                          "TxtEntry value length is incorrect for long key");
-            VerifyOrQuit(memcmp(txtEntry.mValue, expectedTxtEntry.mKey, expectedKeyLength) == 0,
-                         "txtEntry value does match expected content");
-            VerifyOrQuit(txtEntry.mValue[expectedKeyLength] == static_cast<uint8_t>('='),
-                         "txtEntry value does match expected content");
+            VerifyOrQuit(memcmp(txtEntry.mValue, expectedTxtEntry.mKey, expectedKeyLength) == 0);
+            VerifyOrQuit(txtEntry.mValue[expectedKeyLength] == static_cast<uint8_t>('='));
             VerifyOrQuit(memcmp(&txtEntry.mValue[expectedKeyLength + sizeof(uint8_t)], expectedTxtEntry.mValue,
-                                expectedTxtEntry.mValueLength) == 0,
-                         "txtEntry value does match expected content");
+                                expectedTxtEntry.mValueLength) == 0);
             continue;
         }
 
-        VerifyOrQuit(strcmp(txtEntry.mKey, expectedTxtEntry.mKey) == 0, "TxtEntry key does not match expected value");
-        VerifyOrQuit(txtEntry.mValueLength == expectedTxtEntry.mValueLength,
-                     "TxtEntry value length does not match expected value");
+        VerifyOrQuit(strcmp(txtEntry.mKey, expectedTxtEntry.mKey) == 0);
+        VerifyOrQuit(txtEntry.mValueLength == expectedTxtEntry.mValueLength);
 
         if (txtEntry.mValueLength != 0)
         {
-            VerifyOrQuit(memcmp(txtEntry.mValue, expectedTxtEntry.mValue, txtEntry.mValueLength) == 0,
-                         "TxtEntry value does not match expected content");
+            VerifyOrQuit(memcmp(txtEntry.mValue, expectedTxtEntry.mValue, txtEntry.mValueLength) == 0);
         }
         else
         {
@@ -1298,14 +1271,14 @@ void TestDnsTxtEntry(void)
 
     // Verify appending empty txt data
 
-    SuccessOrQuit(message->SetLength(0), "Message::SetLength() failed");
+    SuccessOrQuit(message->SetLength(0));
     SuccessOrQuit(Dns::TxtEntry::AppendEntries(nullptr, 0, *message), "AppendEntries() failed with empty array");
     txtDataLength = message->GetLength();
     VerifyOrQuit(txtDataLength == sizeof(uint8_t), "Data length is incorrect with empty array");
-    SuccessOrQuit(message->Read(0, txtData, txtDataLength), "Failed to read txt data from message");
+    SuccessOrQuit(message->Read(0, txtData, txtDataLength));
     VerifyOrQuit(txtData[0] == 0, "Data is invalid with empty array");
 
-    SuccessOrQuit(message->SetLength(0), "Message::SetLength() failed");
+    SuccessOrQuit(message->SetLength(0));
     txtEntry.mKey         = nullptr;
     txtEntry.mValue       = nullptr;
     txtEntry.mValueLength = 0;

--- a/tests/unit/test_ecdsa.cpp
+++ b/tests/unit/test_ecdsa.cpp
@@ -92,7 +92,7 @@ void TestEcdsaVector(void)
 
     DumpBuffer("KeyPair", keyPair.GetDerBytes(), keyPair.GetDerLength());
 
-    SuccessOrQuit(keyPair.GetPublicKey(publicKey), "KeyPair::GetPublicKey() failed");
+    SuccessOrQuit(keyPair.GetPublicKey(publicKey));
     DumpBuffer("PublicKey", publicKey.GetBytes(), Ecdsa::P256::PublicKey::kSize);
 
     VerifyOrQuit(sizeof(kPublicKey) == Ecdsa::P256::PublicKey::kSize, "Example public key is invalid");
@@ -107,20 +107,19 @@ void TestEcdsaVector(void)
     DumpBuffer("Hash", hash.GetBytes(), sizeof(hash));
 
     printf("\nSign the message ----------------------------------------------------------\n");
-    SuccessOrQuit(keyPair.Sign(hash, signature), "KeyPair::Sign() failed");
+    SuccessOrQuit(keyPair.Sign(hash, signature));
     DumpBuffer("Signature", signature.GetBytes(), sizeof(signature));
 
     printf("\nCheck signature against expected sequence----------------------------------\n");
     DumpBuffer("Expected signature", kExpectedSignature, sizeof(kExpectedSignature));
 
-    VerifyOrQuit(sizeof(kExpectedSignature) == sizeof(signature), "Signature length does not match expected size");
-    VerifyOrQuit(memcmp(signature.GetBytes(), kExpectedSignature, sizeof(kExpectedSignature)) == 0,
-                 "Signature does not match expected value");
+    VerifyOrQuit(sizeof(kExpectedSignature) == sizeof(signature));
+    VerifyOrQuit(memcmp(signature.GetBytes(), kExpectedSignature, sizeof(kExpectedSignature)) == 0);
 
     printf("Signature matches expected sequence.\n");
 
     printf("\nVerify the signature ------------------------------------------------------\n");
-    SuccessOrQuit(publicKey.Verify(hash, signature), "PublicKey::Verify() failed");
+    SuccessOrQuit(publicKey.Verify(hash, signature));
     printf("\nSignature was verified successfully.\n\n");
 
     testFreeInstance(instance);
@@ -144,11 +143,11 @@ void TestEdsaKeyGenerationSignAndVerify(void)
     printf("Test ECDA key generation, signing and verification\n");
 
     printf("\nGenerating key-pair -------------------------------------------------------\n");
-    SuccessOrQuit(keyPair.Generate(), "KeyPair::Generate() failed");
+    SuccessOrQuit(keyPair.Generate());
 
     DumpBuffer("KeyPair", keyPair.GetDerBytes(), keyPair.GetDerLength());
 
-    SuccessOrQuit(keyPair.GetPublicKey(publicKey), "KeyPair::GetPublicKey() failed");
+    SuccessOrQuit(keyPair.GetPublicKey(publicKey));
     DumpBuffer("PublicKey", publicKey.GetBytes(), Ecdsa::P256::PublicKey::kSize);
 
     printf("\nHash the message ----------------------------------------------------------\n");
@@ -159,11 +158,11 @@ void TestEdsaKeyGenerationSignAndVerify(void)
     DumpBuffer("Hash", hash.GetBytes(), sizeof(hash));
 
     printf("\nSign the message ----------------------------------------------------------\n");
-    SuccessOrQuit(keyPair.Sign(hash, signature), "KeyPair::Sign() failed");
+    SuccessOrQuit(keyPair.Sign(hash, signature));
     DumpBuffer("Signature", signature.GetBytes(), sizeof(signature));
 
     printf("\nVerify the signature ------------------------------------------------------\n");
-    SuccessOrQuit(publicKey.Verify(hash, signature), "PublicKey::Verify() failed");
+    SuccessOrQuit(publicKey.Verify(hash, signature));
     printf("\nSignature was verified successfully.");
 
     sha256.Start();

--- a/tests/unit/test_flash.cpp
+++ b/tests/unit/test_flash.cpp
@@ -57,8 +57,8 @@ void TestFlash(void)
 
     // No records in settings
 
-    VerifyOrQuit(flash.Delete(0, 0) == kErrorNotFound, "Delete() failed");
-    VerifyOrQuit(flash.Get(0, 0, nullptr, nullptr) == kErrorNotFound, "Get() failed");
+    VerifyOrQuit(flash.Delete(0, 0) == kErrorNotFound);
+    VerifyOrQuit(flash.Get(0, 0, nullptr, nullptr) == kErrorNotFound);
 
     // Multiple records with different keys
 
@@ -66,27 +66,27 @@ void TestFlash(void)
     {
         uint16_t length = key;
 
-        SuccessOrQuit(flash.Add(key, writeBuffer, length), "Add() failed");
+        SuccessOrQuit(flash.Add(key, writeBuffer, length));
     }
 
     for (uint16_t key = 0; key < 16; key++)
     {
         uint16_t length = key;
 
-        SuccessOrQuit(flash.Get(key, 0, readBuffer, &length), "Get() failed");
+        SuccessOrQuit(flash.Get(key, 0, readBuffer, &length));
         VerifyOrQuit(length == key, "Get() did not return expected length");
         VerifyOrQuit(memcmp(readBuffer, writeBuffer, length) == 0, "Get() did not return expected value");
     }
 
     for (uint16_t key = 0; key < 16; key++)
     {
-        SuccessOrQuit(flash.Delete(key, 0), "Delete() failed");
+        SuccessOrQuit(flash.Delete(key, 0));
     }
 
     for (uint16_t key = 0; key < 16; key++)
     {
-        VerifyOrQuit(flash.Delete(key, 0) == kErrorNotFound, "Delete() failed");
-        VerifyOrQuit(flash.Get(key, 0, nullptr, nullptr) == kErrorNotFound, "Get() failed");
+        VerifyOrQuit(flash.Delete(key, 0) == kErrorNotFound);
+        VerifyOrQuit(flash.Get(key, 0, nullptr, nullptr) == kErrorNotFound);
     }
 
     // Multiple records with the same key
@@ -95,25 +95,25 @@ void TestFlash(void)
     {
         uint16_t length = index;
 
-        SuccessOrQuit(flash.Add(0, writeBuffer, length), "Add() failed");
+        SuccessOrQuit(flash.Add(0, writeBuffer, length));
     }
 
     for (uint16_t index = 0; index < 16; index++)
     {
         uint16_t length = index;
 
-        SuccessOrQuit(flash.Get(0, index, readBuffer, &length), "Get() failed");
+        SuccessOrQuit(flash.Get(0, index, readBuffer, &length));
         VerifyOrQuit(length == index, "Get() did not return expected length");
         VerifyOrQuit(memcmp(readBuffer, writeBuffer, length) == 0, "Get() did not return expected value");
     }
 
     for (uint16_t index = 0; index < 16; index++)
     {
-        SuccessOrQuit(flash.Delete(0, 0), "Delete() failed");
+        SuccessOrQuit(flash.Delete(0, 0));
     }
 
-    VerifyOrQuit(flash.Delete(0, 0) == kErrorNotFound, "Delete() failed");
-    VerifyOrQuit(flash.Get(0, 0, nullptr, nullptr) == kErrorNotFound, "Get() failed");
+    VerifyOrQuit(flash.Delete(0, 0) == kErrorNotFound);
+    VerifyOrQuit(flash.Get(0, 0, nullptr, nullptr) == kErrorNotFound);
 
     // Multiple records with the same key
 
@@ -123,11 +123,11 @@ void TestFlash(void)
 
         if ((index % 4) == 0)
         {
-            SuccessOrQuit(flash.Set(0, writeBuffer, length), "Add() failed");
+            SuccessOrQuit(flash.Set(0, writeBuffer, length));
         }
         else
         {
-            SuccessOrQuit(flash.Add(0, writeBuffer, length), "Add() failed");
+            SuccessOrQuit(flash.Add(0, writeBuffer, length));
         }
     }
 
@@ -135,18 +135,18 @@ void TestFlash(void)
     {
         uint16_t length = index + 12;
 
-        SuccessOrQuit(flash.Get(0, index, readBuffer, &length), "Get() failed");
+        SuccessOrQuit(flash.Get(0, index, readBuffer, &length));
         VerifyOrQuit(length == (index + 12), "Get() did not return expected length");
         VerifyOrQuit(memcmp(readBuffer, writeBuffer, length) == 0, "Get() did not return expected value");
     }
 
     for (uint16_t index = 0; index < 4; index++)
     {
-        SuccessOrQuit(flash.Delete(0, 0), "Delete() failed");
+        SuccessOrQuit(flash.Delete(0, 0));
     }
 
-    VerifyOrQuit(flash.Delete(0, 0) == kErrorNotFound, "Delete() failed");
-    VerifyOrQuit(flash.Get(0, 0, nullptr, nullptr) == kErrorNotFound, "Get() failed");
+    VerifyOrQuit(flash.Delete(0, 0) == kErrorNotFound);
+    VerifyOrQuit(flash.Get(0, 0, nullptr, nullptr) == kErrorNotFound);
 
     // Wipe()
 
@@ -154,15 +154,15 @@ void TestFlash(void)
     {
         uint16_t length = key;
 
-        SuccessOrQuit(flash.Add(key, writeBuffer, length), "Add() failed");
+        SuccessOrQuit(flash.Add(key, writeBuffer, length));
     }
 
     flash.Wipe();
 
     for (uint16_t key = 0; key < 16; key++)
     {
-        VerifyOrQuit(flash.Delete(key, 0) == kErrorNotFound, "Delete() failed");
-        VerifyOrQuit(flash.Get(key, 0, nullptr, nullptr) == kErrorNotFound, "Get() failed");
+        VerifyOrQuit(flash.Delete(key, 0) == kErrorNotFound);
+        VerifyOrQuit(flash.Get(key, 0, nullptr, nullptr) == kErrorNotFound);
     }
 
     // Test swap
@@ -172,14 +172,14 @@ void TestFlash(void)
         uint16_t key    = index & 0xf;
         uint16_t length = index & 0xf;
 
-        SuccessOrQuit(flash.Set(key, writeBuffer, length), "Set() failed");
+        SuccessOrQuit(flash.Set(key, writeBuffer, length));
     }
 
     for (uint16_t key = 0; key < 16; key++)
     {
         uint16_t length = key;
 
-        SuccessOrQuit(flash.Get(key, 0, readBuffer, &length), "Get() failed");
+        SuccessOrQuit(flash.Get(key, 0, readBuffer, &length));
         VerifyOrQuit(length == key, "Get() did not return expected length");
         VerifyOrQuit(memcmp(readBuffer, writeBuffer, length) == 0, "Get() did not return expected value");
     }

--- a/tests/unit/test_hdlc.cpp
+++ b/tests/unit/test_hdlc.cpp
@@ -79,49 +79,46 @@ void TestHdlcFrameBuffer(void)
 
     printf("Testing Hdlc::FrameBuffer");
 
-    VerifyOrQuit(frameBuffer.IsEmpty(), "IsEmpty() failed after constructor");
-    VerifyOrQuit(frameBuffer.GetLength() == 0, "GetLength() failed after constructor");
+    VerifyOrQuit(frameBuffer.IsEmpty(), "after constructor");
+    VerifyOrQuit(frameBuffer.GetLength() == 0, "after constructor");
 
-    SuccessOrQuit(WriteToBuffer(sOpenThreadText, frameBuffer), "WriteByte() failed");
+    SuccessOrQuit(WriteToBuffer(sOpenThreadText, frameBuffer));
 
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) - 1, "GetLength() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sOpenThreadText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) - 1);
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sOpenThreadText, frameBuffer.GetLength()) == 0);
 
-    VerifyOrQuit(frameBuffer.CanWrite(1), "CanWrite() failed");
-    VerifyOrQuit(!frameBuffer.IsEmpty(), "IsEmpty() failed");
+    VerifyOrQuit(frameBuffer.CanWrite(1));
+    VerifyOrQuit(!frameBuffer.IsEmpty());
 
-    SuccessOrQuit(WriteToBuffer(sHelloText, frameBuffer), "WriteByte() failed");
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) + sizeof(sHelloText) - 2, "GetLength() failed");
+    SuccessOrQuit(WriteToBuffer(sHelloText, frameBuffer));
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) + sizeof(sHelloText) - 2);
 
     frameBuffer.UndoLastWrites(sizeof(sHelloText) - 1);
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) - 1, "GetLength() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sOpenThreadText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) - 1);
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sOpenThreadText, frameBuffer.GetLength()) == 0);
 
-    VerifyOrQuit(!frameBuffer.IsEmpty(), "IsEmpty() failed");
+    VerifyOrQuit(!frameBuffer.IsEmpty());
     frameBuffer.Clear();
-    VerifyOrQuit(frameBuffer.IsEmpty(), "IsEmpty() failed after Clear()");
-    VerifyOrQuit(frameBuffer.GetLength() == 0, "GetLength() failed after Clear()");
+    VerifyOrQuit(frameBuffer.IsEmpty(), "after Clear()");
+    VerifyOrQuit(frameBuffer.GetLength() == 0, "after Clear()");
 
-    SuccessOrQuit(WriteToBuffer(sMottoText, frameBuffer), "WriteByte() failed");
+    SuccessOrQuit(WriteToBuffer(sMottoText, frameBuffer));
 
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sMottoText) - 1, "GetLength() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sMottoText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sMottoText) - 1);
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sMottoText, frameBuffer.GetLength()) == 0);
 
     frameBuffer.Clear();
-    VerifyOrQuit(frameBuffer.CanWrite(kBufferSize), "CanWrite(kBufferSize) failed unexpectedly");
+    VerifyOrQuit(frameBuffer.CanWrite(kBufferSize));
     VerifyOrQuit(frameBuffer.CanWrite(kBufferSize + 1) == false, "CanWrite(kBufferSize + 1) did not fail as expected");
 
     for (uint16_t i = 0; i < kBufferSize; i++)
     {
-        VerifyOrQuit(frameBuffer.CanWrite(1), "CanWrite() failed unexpectedly");
-        SuccessOrQuit(frameBuffer.WriteByte(i & 0xff), "WriteByte() failed unexpectedly");
+        VerifyOrQuit(frameBuffer.CanWrite(1));
+        SuccessOrQuit(frameBuffer.WriteByte(i & 0xff));
     }
 
-    VerifyOrQuit(frameBuffer.CanWrite(1) == false, "CanWrite() did not fail with full buffer");
-    VerifyOrQuit(frameBuffer.WriteByte(0) == OT_ERROR_NO_BUFS, "WriteByte() did not fail with full buffer");
+    VerifyOrQuit(frameBuffer.CanWrite(1) == false, "did not fail with full buffer");
+    VerifyOrQuit(frameBuffer.WriteByte(0) == OT_ERROR_NO_BUFS, "did not fail with full buffer");
 
     printf(" -- PASS\n");
 }
@@ -139,88 +136,81 @@ void TestHdlcMultiFrameBuffer(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Check state after constructor
 
-    VerifyOrQuit(!frameBuffer.HasFrame(), "HasFrame() failed after constructor");
-    VerifyOrQuit(!frameBuffer.HasSavedFrame(), "HasSavedFrame() failed after constructor");
-    VerifyOrQuit(frameBuffer.GetLength() == 0, "GetLength() failed after constructor");
-    VerifyOrQuit(frameBuffer.GetNextSavedFrame(frame, length) == OT_ERROR_NOT_FOUND,
-                 "GetNextSavedFrame() incorrect behavior after constructor");
+    VerifyOrQuit(!frameBuffer.HasFrame(), "after constructor");
+    VerifyOrQuit(!frameBuffer.HasSavedFrame(), "after constructor");
+    VerifyOrQuit(frameBuffer.GetLength() == 0, "after constructor");
+    VerifyOrQuit(frameBuffer.GetNextSavedFrame(frame, length) == OT_ERROR_NOT_FOUND, "after constructor");
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Write multiple frames, save them and read later
 
-    SuccessOrQuit(WriteToBuffer(sMottoText, frameBuffer), "WriteByte() failed");
+    SuccessOrQuit(WriteToBuffer(sMottoText, frameBuffer));
 
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sMottoText) - 1, "GetLength() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sMottoText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
-
-    frameBuffer.SaveFrame();
-
-    VerifyOrQuit(!frameBuffer.HasFrame(), "HasFrame() failed after SaveFrame()");
-    VerifyOrQuit(frameBuffer.HasSavedFrame(), "HasSavedFrame() failed after SaveFrame()");
-    VerifyOrQuit(frameBuffer.GetLength() == 0, "GetLength() failed after SaveFrame()");
-
-    SuccessOrQuit(WriteToBuffer(sHelloText, frameBuffer), "WriteByte() failed");
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHelloText) - 1, "GetLength() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sHelloText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sMottoText) - 1);
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sMottoText, frameBuffer.GetLength()) == 0);
 
     frameBuffer.SaveFrame();
 
-    VerifyOrQuit(!frameBuffer.HasFrame(), "HasFrame() failed after SaveFrame()");
-    VerifyOrQuit(frameBuffer.HasSavedFrame(), "HasSavedFrame() failed after SaveFrame()");
-    VerifyOrQuit(frameBuffer.GetLength() == 0, "GetLength() failed after SaveFrame()");
+    VerifyOrQuit(!frameBuffer.HasFrame(), "after SaveFrame()");
+    VerifyOrQuit(frameBuffer.HasSavedFrame(), "after SaveFrame()");
+    VerifyOrQuit(frameBuffer.GetLength() == 0, "after SaveFrame()");
 
-    SuccessOrQuit(WriteToBuffer(sOpenThreadText, frameBuffer), "WriteByte() failed");
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) - 1, "GetLength() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sOpenThreadText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
+    SuccessOrQuit(WriteToBuffer(sHelloText, frameBuffer));
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHelloText) - 1);
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sHelloText, frameBuffer.GetLength()) == 0);
+
+    frameBuffer.SaveFrame();
+
+    VerifyOrQuit(!frameBuffer.HasFrame(), "after SaveFrame()");
+    VerifyOrQuit(frameBuffer.HasSavedFrame(), "after SaveFrame()");
+    VerifyOrQuit(frameBuffer.GetLength() == 0, "after SaveFrame()");
+
+    SuccessOrQuit(WriteToBuffer(sOpenThreadText, frameBuffer));
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) - 1);
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sOpenThreadText, frameBuffer.GetLength()) == 0);
 
     frameBuffer.DiscardFrame();
 
-    VerifyOrQuit(!frameBuffer.HasFrame(), "HasFrame() failed after DiscardFrame()");
-    VerifyOrQuit(frameBuffer.HasSavedFrame(), "HasSavedFrame() failed after SaveFrame()");
-    VerifyOrQuit(frameBuffer.GetLength() == 0, "GetLength() failed after DiscardFrame()");
+    VerifyOrQuit(!frameBuffer.HasFrame(), "after DiscardFrame()");
+    VerifyOrQuit(frameBuffer.HasSavedFrame(), "after SaveFrame()");
+    VerifyOrQuit(frameBuffer.GetLength() == 0, "after DiscardFrame()");
 
-    SuccessOrQuit(WriteToBuffer(sMottoText, frameBuffer), "WriteByte() failed");
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sMottoText) - 1, "GetLength() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sMottoText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
+    SuccessOrQuit(WriteToBuffer(sMottoText, frameBuffer));
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sMottoText) - 1);
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sMottoText, frameBuffer.GetLength()) == 0);
 
     frameBuffer.DiscardFrame();
 
-    VerifyOrQuit(!frameBuffer.HasFrame(), "HasFrame() failed after DiscardFrame()");
-    VerifyOrQuit(frameBuffer.GetLength() == 0, "GetLength() failed after DiscardFrame()");
+    VerifyOrQuit(!frameBuffer.HasFrame(), "after DiscardFrame()");
+    VerifyOrQuit(frameBuffer.GetLength() == 0, "after DiscardFrame()");
 
-    SuccessOrQuit(WriteToBuffer(sHexText, frameBuffer), "WriteByte() failed");
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHexText) - 1, "GetLength() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sHexText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
+    SuccessOrQuit(WriteToBuffer(sHexText, frameBuffer));
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHexText) - 1);
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sHexText, frameBuffer.GetLength()) == 0);
 
     frameBuffer.SaveFrame();
 
-    VerifyOrQuit(!frameBuffer.HasFrame(), "HasFrame() failed after SaveFrame()");
-    VerifyOrQuit(frameBuffer.HasSavedFrame(), "HasSavedFrame() failed after SaveFrame()");
-    VerifyOrQuit(frameBuffer.GetLength() == 0, "GetLength() failed after SaveFrame()");
+    VerifyOrQuit(!frameBuffer.HasFrame(), "after SaveFrame()");
+    VerifyOrQuit(frameBuffer.HasSavedFrame(), "after SaveFrame()");
+    VerifyOrQuit(frameBuffer.GetLength() == 0, "after SaveFrame()");
 
-    SuccessOrQuit(WriteToBuffer(sOpenThreadText, frameBuffer), "WriteByte() failed");
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) - 1, "GetLength() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sOpenThreadText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
+    SuccessOrQuit(WriteToBuffer(sOpenThreadText, frameBuffer));
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) - 1);
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sOpenThreadText, frameBuffer.GetLength()) == 0);
 
     // Read the first saved frame and check the content
     frame = nullptr;
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sMottoText) - 1, "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sMottoText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
 
     // Read the second saved frame and check the content
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sHelloText) - 1, "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sHelloText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
 
     // Read the third saved frame and check the content
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sHexText) - 1, "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sHexText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
 
@@ -230,35 +220,35 @@ void TestHdlcMultiFrameBuffer(void)
                  "GetNextSavedFrame() incorrect behavior after all frames were read");
     VerifyOrQuit(newFrame == nullptr, "GetNextSavedFrame() incorrect behavior after all frames were read");
 
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) - 1, "GetLength() failed");
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) - 1);
     VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sOpenThreadText, frameBuffer.GetLength()) == 0,
                  "GetFrame() content is incorrect");
 
     frameBuffer.SaveFrame();
 
     // Read the fourth saved frame and check the content
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sOpenThreadText) - 1, "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sOpenThreadText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
 
     // Re-read all the saved frames
     frame = nullptr;
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sMottoText) - 1, "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sMottoText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
 
     // Second saved frame
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sHelloText) - 1, "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sHelloText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
 
     // Third saved frame
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sHexText) - 1, "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sHexText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
 
     // Fourth saved frame and check the content
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sOpenThreadText) - 1, "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sOpenThreadText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
 
@@ -267,94 +257,85 @@ void TestHdlcMultiFrameBuffer(void)
 
     frameBuffer.Clear();
 
-    VerifyOrQuit(!frameBuffer.HasFrame(), "HasFrame() failed after Clear()");
-    VerifyOrQuit(!frameBuffer.HasSavedFrame(), "HasSavedFrame() failed after Clear()");
-    VerifyOrQuit(frameBuffer.GetLength() == 0, "GetLength() failed after Clear()");
+    VerifyOrQuit(!frameBuffer.HasFrame(), "after Clear()");
+    VerifyOrQuit(!frameBuffer.HasSavedFrame(), "after Clear()");
+    VerifyOrQuit(frameBuffer.GetLength() == 0, "after Clear()");
 
-    SuccessOrQuit(WriteToBuffer(sOpenThreadText, frameBuffer), "WriteByte() failed");
+    SuccessOrQuit(WriteToBuffer(sOpenThreadText, frameBuffer));
     frameBuffer.SaveFrame();
 
-    SuccessOrQuit(WriteToBuffer(sHelloText, frameBuffer), "WriteByte() failed");
+    SuccessOrQuit(WriteToBuffer(sHelloText, frameBuffer));
     frameBuffer.SaveFrame();
-    VerifyOrQuit(frameBuffer.HasSavedFrame(), "HasFrame() incorrect behavior after SaveFrame()");
+    VerifyOrQuit(frameBuffer.HasSavedFrame(), "after SaveFrame()");
 
     frame = nullptr;
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
-    VerifyOrQuit(frameBuffer.HasSavedFrame(), "HasFrame() incorrect behavior after SaveFrame()");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
+    VerifyOrQuit(frameBuffer.HasSavedFrame(), "after GetNextSavedFrame()");
 
     frameBuffer.Clear();
 
     frame = nullptr;
-    VerifyOrQuit(frameBuffer.GetNextSavedFrame(frame, length) == OT_ERROR_NOT_FOUND,
-                 "GetNextSavedFrame() incorrect behavior after Clear()");
+    VerifyOrQuit(frameBuffer.GetNextSavedFrame(frame, length) == OT_ERROR_NOT_FOUND, "after Clear()");
 
-    VerifyOrQuit(!frameBuffer.HasFrame(), "HasFrame() incorrect behavior after Clear()");
-    VerifyOrQuit(!frameBuffer.HasSavedFrame(), "HasFrame() incorrect behavior after Clear()");
-    VerifyOrQuit(frameBuffer.CanWrite(kBufferSize - (kFrameHeaderSize - 1)) == false,
-                 "CanWrite() incorrect behavior after Clear()");
-    VerifyOrQuit(frameBuffer.CanWrite(kBufferSize - kFrameHeaderSize) == true,
-                 "CanWrite() incorrect behavior after Clear()");
+    VerifyOrQuit(!frameBuffer.HasFrame(), "after Clear()");
+    VerifyOrQuit(!frameBuffer.HasSavedFrame(), "after Clear()");
+    VerifyOrQuit(frameBuffer.CanWrite(kBufferSize - (kFrameHeaderSize - 1)) == false, "after Clear()");
+    VerifyOrQuit(frameBuffer.CanWrite(kBufferSize - kFrameHeaderSize) == true, "after Clear()");
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Verify behavior of `ClearSavedFrames()`
 
-    SuccessOrQuit(WriteToBuffer(sHelloText, frameBuffer), "WriteByte() failed");
+    SuccessOrQuit(WriteToBuffer(sHelloText, frameBuffer));
     frameBuffer.SaveFrame();
-    SuccessOrQuit(WriteToBuffer(sOpenThreadText, frameBuffer), "WriteByte() failed");
+    SuccessOrQuit(WriteToBuffer(sOpenThreadText, frameBuffer));
     frameBuffer.SaveFrame();
-    SuccessOrQuit(WriteToBuffer(sMottoText, frameBuffer), "WriteByte() failed");
+    SuccessOrQuit(WriteToBuffer(sMottoText, frameBuffer));
     frameBuffer.SaveFrame();
-    SuccessOrQuit(WriteToBuffer(sHexText, frameBuffer), "WriteByte() failed");
+    SuccessOrQuit(WriteToBuffer(sHexText, frameBuffer));
 
     frame = nullptr;
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sHelloText) - 1, "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sHelloText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
 
     frameBuffer.ClearSavedFrames();
 
-    VerifyOrQuit(frameBuffer.HasFrame(), "HasFrame() failed after ClearSavedFrames()");
-    VerifyOrQuit(!frameBuffer.HasSavedFrame(), "HasSavedFrame() failed after ClearSavedFrames()");
+    VerifyOrQuit(frameBuffer.HasFrame(), "after ClearSavedFrames()");
+    VerifyOrQuit(!frameBuffer.HasSavedFrame(), "after ClearSavedFrames()");
 
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHexText) - 1, "Frame length is incorrect after ClearSavedFrames()");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sHexText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect after ClearSavedFrames()");
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHexText) - 1, "after ClearSavedFrames()");
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sHexText, frameBuffer.GetLength()) == 0);
 
     frameBuffer.SaveFrame();
 
-    SuccessOrQuit(WriteToBuffer(sHelloText, frameBuffer), "WriteByte() failed");
+    SuccessOrQuit(WriteToBuffer(sHelloText, frameBuffer));
 
     frame = nullptr;
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sHexText) - 1, "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sHexText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
 
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHelloText) - 1,
-                 "Frame length is incorrect after ClearSavedFrames()");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sHelloText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect after ClearSavedFrames()");
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHelloText) - 1, "after ClearSavedFrames()");
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sHelloText, frameBuffer.GetLength()) == 0, "after ClearSavedFrames()");
 
     frameBuffer.ClearSavedFrames();
     frameBuffer.DiscardFrame();
 
-    VerifyOrQuit(!frameBuffer.HasFrame(), "HasFrame() incorrect behavior after all frames are read and discarded");
-    VerifyOrQuit(!frameBuffer.HasSavedFrame(), "HasFrame() incorrect behavior after all read or discarded");
-    VerifyOrQuit(frameBuffer.CanWrite(kBufferSize - (kFrameHeaderSize - 1)) == false,
-                 "CanWrite() incorrect behavior after all read or discarded");
-    VerifyOrQuit(frameBuffer.CanWrite(kBufferSize - kFrameHeaderSize) == true,
-                 "CanWrite() incorrect behavior after all read of discarded");
+    VerifyOrQuit(!frameBuffer.HasFrame(), "after all frames are read and discarded");
+    VerifyOrQuit(!frameBuffer.HasSavedFrame(), "after all read or discarded");
+    VerifyOrQuit(frameBuffer.CanWrite(kBufferSize - (kFrameHeaderSize - 1)) == false, "after all read or discarded");
+    VerifyOrQuit(frameBuffer.CanWrite(kBufferSize - kFrameHeaderSize) == true, "after all read of discarded");
 
-    SuccessOrQuit(WriteToBuffer(sHelloText, frameBuffer), "WriteByte() failed");
+    SuccessOrQuit(WriteToBuffer(sHelloText, frameBuffer));
 
     frameBuffer.ClearSavedFrames();
 
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHelloText) - 1, "GetLength() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sHelloText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHelloText) - 1);
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sHelloText, frameBuffer.GetLength()) == 0);
 
     frameBuffer.SaveFrame();
     frame = nullptr;
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sHelloText) - 1, "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sHelloText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
 
@@ -363,97 +344,89 @@ void TestHdlcMultiFrameBuffer(void)
 
     frameBuffer.Clear();
 
-    VerifyOrQuit(frameBuffer.GetSkipLength() == 0, "GetSkipLength() incorrect behavior after Clear()");
-    VerifyOrQuit(frameBuffer.SetSkipLength(sizeof(sSkipText)) == OT_ERROR_NONE, "SetSkipLength() failed");
-    SuccessOrQuit(WriteToBuffer(sMottoText, frameBuffer), "WriteByte() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sMottoText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
+    VerifyOrQuit(frameBuffer.GetSkipLength() == 0, "after Clear()");
+    VerifyOrQuit(frameBuffer.SetSkipLength(sizeof(sSkipText)) == OT_ERROR_NONE);
+    SuccessOrQuit(WriteToBuffer(sMottoText, frameBuffer));
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sMottoText, frameBuffer.GetLength()) == 0);
     memcpy(frameBuffer.GetFrame() - sizeof(sSkipText), sSkipText, sizeof(sSkipText));
-    VerifyOrQuit(frameBuffer.GetSkipLength() == sizeof(sSkipText), "GetSkipLength() failed");
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sMottoText) - 1, "GetLength() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sMottoText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
+    VerifyOrQuit(frameBuffer.GetSkipLength() == sizeof(sSkipText));
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sMottoText) - 1);
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sMottoText, frameBuffer.GetLength()) == 0);
 
     frameBuffer.SaveFrame();
-    VerifyOrQuit(!frameBuffer.HasFrame(), "HasFrame() incorrect behavior after SaveFrame()");
-    VerifyOrQuit(frameBuffer.HasSavedFrame(), "HasFrame() incorrect behavior after SaveFrame()");
-    VerifyOrQuit(frameBuffer.GetSkipLength() == 0, "GetSkipLength() incorrect behavior after SaveFrame()");
+    VerifyOrQuit(!frameBuffer.HasFrame(), "after SaveFrame()");
+    VerifyOrQuit(frameBuffer.HasSavedFrame(), "after SaveFrame()");
+    VerifyOrQuit(frameBuffer.GetSkipLength() == 0, "after SaveFrame()");
 
-    VerifyOrQuit(frameBuffer.SetSkipLength(sizeof(sSkipText)) == OT_ERROR_NONE, "SetSkipLength() failed");
-    SuccessOrQuit(WriteToBuffer(sOpenThreadText, frameBuffer), "WriteByte() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sOpenThreadText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
+    VerifyOrQuit(frameBuffer.SetSkipLength(sizeof(sSkipText)) == OT_ERROR_NONE);
+    SuccessOrQuit(WriteToBuffer(sOpenThreadText, frameBuffer));
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sOpenThreadText, frameBuffer.GetLength()) == 0);
     memcpy(frameBuffer.GetFrame() - sizeof(sSkipText), sSkipText, sizeof(sSkipText));
-    VerifyOrQuit(frameBuffer.GetSkipLength() == sizeof(sSkipText), "GetSkipLength() failed");
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) - 1, "GetLength() failed");
-    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sOpenThreadText, frameBuffer.GetLength()) == 0,
-                 "GetFrame() content is incorrect");
+    VerifyOrQuit(frameBuffer.GetSkipLength() == sizeof(sSkipText));
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sOpenThreadText) - 1);
+    VerifyOrQuit(memcmp(frameBuffer.GetFrame(), sOpenThreadText, frameBuffer.GetLength()) == 0);
 
     frameBuffer.SaveFrame();
-    VerifyOrQuit(!frameBuffer.HasFrame(), "HasFrame() incorrect behavior after SaveFrame()");
-    VerifyOrQuit(frameBuffer.HasSavedFrame(), "HasFrame() incorrect behavior after SaveFrame()");
-    VerifyOrQuit(frameBuffer.GetSkipLength() == 0, "GetSkipLength() incorrect behavior after SaveFrame()");
+    VerifyOrQuit(!frameBuffer.HasFrame(), "after SaveFrame()");
+    VerifyOrQuit(frameBuffer.HasSavedFrame(), "after SaveFrame()");
+    VerifyOrQuit(frameBuffer.GetSkipLength() == 0, "after SaveFrame()");
 
     frame = nullptr;
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sMottoText) - 1, "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sMottoText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
     VerifyOrQuit(memcmp(frame - sizeof(sSkipText), sSkipText, sizeof(sSkipText)) == 0,
                  "GetNextSavedFrame() reserved frame buffer content is incorrect");
 
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sOpenThreadText) - 1, "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sOpenThreadText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
     VerifyOrQuit(memcmp(frame - sizeof(sSkipText), sSkipText, sizeof(sSkipText)) == 0,
                  "GetNextSavedFrame() reserved frame buffer content is incorrect");
 
     frameBuffer.Clear();
-    VerifyOrQuit(frameBuffer.SetSkipLength(kBufferSize - (kFrameHeaderSize - 1)) == OT_ERROR_NO_BUFS,
-                 "SetSkipLength() incorrect behavior after Clear()");
-    VerifyOrQuit(frameBuffer.SetSkipLength(kBufferSize - kFrameHeaderSize) == OT_ERROR_NONE,
-                 "SetSkipLength() incorrect behavior after Clear()");
+    VerifyOrQuit(frameBuffer.SetSkipLength(kBufferSize - (kFrameHeaderSize - 1)) == OT_ERROR_NO_BUFS, "after Clear()");
+    VerifyOrQuit(frameBuffer.SetSkipLength(kBufferSize - kFrameHeaderSize) == OT_ERROR_NONE, "after Clear()");
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Verify behavior of `SetLength()` and `GetLength()`
 
     frameBuffer.Clear();
-    VerifyOrQuit((frame = frameBuffer.GetFrame()) != nullptr, "GetFrame() failed");
+    VerifyOrQuit((frame = frameBuffer.GetFrame()) != nullptr);
     memcpy(frame, sHelloText, sizeof(sHelloText));
-    VerifyOrQuit(frameBuffer.SetLength(sizeof(sHelloText)) == OT_ERROR_NONE, "SetLength() failed");
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHelloText), "GetLength() failed");
-    VerifyOrQuit(frameBuffer.HasFrame(), "HasFrame() is incorrect");
+    VerifyOrQuit(frameBuffer.SetLength(sizeof(sHelloText)) == OT_ERROR_NONE);
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHelloText));
+    VerifyOrQuit(frameBuffer.HasFrame());
     frameBuffer.SaveFrame();
 
-    VerifyOrQuit((frame = frameBuffer.GetFrame()) != nullptr, "GetFrame() failed");
+    VerifyOrQuit((frame = frameBuffer.GetFrame()) != nullptr);
     memcpy(frame, sMottoText, sizeof(sMottoText));
-    VerifyOrQuit(frameBuffer.SetLength(sizeof(sMottoText)) == OT_ERROR_NONE, "SetLength() failed");
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sMottoText), "GetLength() failed");
-    VerifyOrQuit(frameBuffer.HasFrame(), "HasFrame() is incorrect");
+    VerifyOrQuit(frameBuffer.SetLength(sizeof(sMottoText)) == OT_ERROR_NONE);
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sMottoText));
+    VerifyOrQuit(frameBuffer.HasFrame());
     frameBuffer.SaveFrame();
 
-    VerifyOrQuit((frame = frameBuffer.GetFrame()) != nullptr, "GetFrame() failed");
+    VerifyOrQuit((frame = frameBuffer.GetFrame()) != nullptr);
     memcpy(frame, sHexText, sizeof(sHexText));
-    VerifyOrQuit(frameBuffer.SetLength(sizeof(sHexText)) == OT_ERROR_NONE, "SetLength() failed");
-    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHexText), "GetLength() failed");
+    VerifyOrQuit(frameBuffer.SetLength(sizeof(sHexText)) == OT_ERROR_NONE);
+    VerifyOrQuit(frameBuffer.GetLength() == sizeof(sHexText));
     frameBuffer.DiscardFrame();
-    VerifyOrQuit(!frameBuffer.HasFrame(), "HasFrame() is incorrect");
+    VerifyOrQuit(!frameBuffer.HasFrame());
 
     frame = nullptr;
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sHelloText), "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sHelloText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
 
-    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(frameBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sMottoText), "GetNextSavedFrame() length is incorrect");
     VerifyOrQuit(memcmp(frame, sMottoText, length) == 0, "GetNextSavedFrame() frame content is incorrect");
 
-    SuccessOrQuit(!frameBuffer.GetNextSavedFrame(frame, length), "GetNextSavedFrame() failed unexpectedly");
+    SuccessOrQuit(!frameBuffer.GetNextSavedFrame(frame, length));
 
     frameBuffer.Clear();
-    VerifyOrQuit(frameBuffer.SetLength(kBufferSize - (kFrameHeaderSize - 1)) == OT_ERROR_NO_BUFS,
-                 "SetLength() incorrect behavior after Clear()");
-    VerifyOrQuit(frameBuffer.SetLength(kBufferSize - kFrameHeaderSize) == OT_ERROR_NONE,
-                 "SetLength() incorrect behavior after Clear()");
+    VerifyOrQuit(frameBuffer.SetLength(kBufferSize - (kFrameHeaderSize - 1)) == OT_ERROR_NO_BUFS, "after Clear()");
+    VerifyOrQuit(frameBuffer.SetLength(kBufferSize - kFrameHeaderSize) == OT_ERROR_NONE, "after Clear()");
 
     printf(" -- PASS\n");
 }
@@ -487,35 +460,35 @@ void TestEncoderDecoder(void)
 
     printf("Testing Hdlc::Encoder and Hdlc::Decoder");
 
-    SuccessOrQuit(encoder.BeginFrame(), "Encoder::BeginFrame() failed");
-    SuccessOrQuit(encoder.Encode(sOpenThreadText, sizeof(sOpenThreadText) - 1), "Encoder::Encode() failed");
-    SuccessOrQuit(encoder.EndFrame(), "Encoder::EndFrame() failed");
+    SuccessOrQuit(encoder.BeginFrame());
+    SuccessOrQuit(encoder.Encode(sOpenThreadText, sizeof(sOpenThreadText) - 1));
+    SuccessOrQuit(encoder.EndFrame());
     encoderBuffer.SaveFrame();
 
-    SuccessOrQuit(encoder.BeginFrame(), "Encoder::BeginFrame() failed");
-    SuccessOrQuit(encoder.Encode(sMottoText, sizeof(sMottoText) - 1), "Encoder::Encode() failed");
-    SuccessOrQuit(encoder.EndFrame(), "Encoder::EndFrame() failed");
+    SuccessOrQuit(encoder.BeginFrame());
+    SuccessOrQuit(encoder.Encode(sMottoText, sizeof(sMottoText) - 1));
+    SuccessOrQuit(encoder.EndFrame());
     encoderBuffer.SaveFrame();
 
-    SuccessOrQuit(encoder.BeginFrame(), "Encoder::BeginFrame() failed");
-    SuccessOrQuit(encoder.Encode(sHdlcSpecials, sizeof(sHdlcSpecials)), "Encoder::Encode() failed");
-    SuccessOrQuit(encoder.EndFrame(), "Encoder::EndFrame() failed");
+    SuccessOrQuit(encoder.BeginFrame());
+    SuccessOrQuit(encoder.Encode(sHdlcSpecials, sizeof(sHdlcSpecials)));
+    SuccessOrQuit(encoder.EndFrame());
     encoderBuffer.SaveFrame();
 
-    SuccessOrQuit(encoder.BeginFrame(), "Encoder::BeginFrame() failed");
-    SuccessOrQuit(encoder.Encode(sHelloText, sizeof(sHelloText) - 1), "Encoder::Encode() failed");
-    SuccessOrQuit(encoder.EndFrame(), "Encoder::EndFrame() failed");
+    SuccessOrQuit(encoder.BeginFrame());
+    SuccessOrQuit(encoder.Encode(sHelloText, sizeof(sHelloText) - 1));
+    SuccessOrQuit(encoder.EndFrame());
     encoderBuffer.SaveFrame();
 
-    SuccessOrQuit(encoder.BeginFrame(), "Encoder::BeginFrame() failed");
+    SuccessOrQuit(encoder.BeginFrame());
     // Empty frame
-    SuccessOrQuit(encoder.EndFrame(), "Encoder::EndFrame() failed");
+    SuccessOrQuit(encoder.EndFrame());
     encoderBuffer.SaveFrame();
 
     byte = kFlagSequence;
-    SuccessOrQuit(encoder.BeginFrame(), "Encoder::BeginFrame() failed");
-    SuccessOrQuit(encoder.Encode(&byte, sizeof(uint8_t)), "Encoder::Encode() failed");
-    SuccessOrQuit(encoder.EndFrame(), "Encoder::EndFrame() failed");
+    SuccessOrQuit(encoder.BeginFrame());
+    SuccessOrQuit(encoder.Encode(&byte, sizeof(uint8_t)));
+    SuccessOrQuit(encoder.EndFrame());
     encoderBuffer.SaveFrame();
 
     // Feed the encoded frames to decoder and save the content
@@ -525,7 +498,7 @@ void TestEncoderDecoder(void)
 
         decoder.Decode(frame, length);
 
-        VerifyOrQuit(decoderContext.mWasCalled, "Decoder::Decode() failed");
+        VerifyOrQuit(decoderContext.mWasCalled);
         VerifyOrQuit(decoderContext.mError == OT_ERROR_NONE, "Decoder::Decode() returned incorrect error code");
 
         decoderBuffer.SaveFrame();
@@ -533,26 +506,26 @@ void TestEncoderDecoder(void)
 
     // Verify the decoded frames match the original frames
     frame = nullptr;
-    SuccessOrQuit(decoderBuffer.GetNextSavedFrame(frame, length), "Incorrect decoded frame");
+    SuccessOrQuit(decoderBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sOpenThreadText) - 1, "Decoded frame length does not match original frame");
     VerifyOrQuit(memcmp(frame, sOpenThreadText, length) == 0, "Decoded frame content does not match original frame");
 
-    SuccessOrQuit(decoderBuffer.GetNextSavedFrame(frame, length), "Incorrect decoded frame");
+    SuccessOrQuit(decoderBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sMottoText) - 1, "Decoded frame length does not match original frame");
     VerifyOrQuit(memcmp(frame, sMottoText, length) == 0, "Decoded frame content does not match original frame");
 
-    SuccessOrQuit(decoderBuffer.GetNextSavedFrame(frame, length), "Incorrect decoded frame");
+    SuccessOrQuit(decoderBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sHdlcSpecials), "Decoded frame length does not match original frame");
     VerifyOrQuit(memcmp(frame, sHdlcSpecials, length) == 0, "Decoded frame content does not match original frame");
 
-    SuccessOrQuit(decoderBuffer.GetNextSavedFrame(frame, length), "Incorrect decoded frame");
+    SuccessOrQuit(decoderBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(sHelloText) - 1, "Decoded frame length does not match original frame");
     VerifyOrQuit(memcmp(frame, sHelloText, length) == 0, "Decoded frame content does not match original frame");
 
-    SuccessOrQuit(decoderBuffer.GetNextSavedFrame(frame, length), "Incorrect decoded frame");
+    SuccessOrQuit(decoderBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == 0, "Decoded frame length does not match original frame");
 
-    SuccessOrQuit(decoderBuffer.GetNextSavedFrame(frame, length), "Incorrect decoded frame");
+    SuccessOrQuit(decoderBuffer.GetNextSavedFrame(frame, length));
     VerifyOrQuit(length == sizeof(uint8_t), "Decoded frame length does not match original frame");
     VerifyOrQuit(*frame == kFlagSequence, "Decoded frame content does not match original frame");
 
@@ -562,7 +535,7 @@ void TestEncoderDecoder(void)
     decoderBuffer.Clear();
 
     // Test `Encoder` behavior when running out of buffer space
-    SuccessOrQuit(encoder.BeginFrame(), "Encoder::BeginFrame() failed");
+    SuccessOrQuit(encoder.BeginFrame());
 
     error = OT_ERROR_NONE;
 
@@ -580,15 +553,15 @@ void TestEncoderDecoder(void)
 
     // Test `Decoder` behavior with incorrect FCS
 
-    SuccessOrQuit(encoder.BeginFrame(), "Encoder::BeginFrame() failed");
-    SuccessOrQuit(encoder.Encode(sMottoText, sizeof(sMottoText) - 1), "Encoder::Encode() failed");
-    SuccessOrQuit(encoder.EndFrame(), "Encoder::EndFrame() failed");
+    SuccessOrQuit(encoder.BeginFrame());
+    SuccessOrQuit(encoder.Encode(sMottoText, sizeof(sMottoText) - 1));
+    SuccessOrQuit(encoder.EndFrame());
 
     encoderBuffer.GetFrame()[0] ^= 0x0a; // Change the first byte in the frame to cause FCS failure
 
     decoderContext.mWasCalled = false;
     decoder.Decode(encoderBuffer.GetFrame(), encoderBuffer.GetLength());
-    VerifyOrQuit(decoderContext.mWasCalled, "Decoder::Decode() failed");
+    VerifyOrQuit(decoderContext.mWasCalled);
     VerifyOrQuit(decoderContext.mError == OT_ERROR_PARSE, "Decoder::Decode() did not fail with bad FCS");
 
     decoderBuffer.Clear();
@@ -597,7 +570,7 @@ void TestEncoderDecoder(void)
 
     decoderContext.mWasCalled = false;
     decoder.Decode(badShortFrame, sizeof(badShortFrame));
-    VerifyOrQuit(decoderContext.mWasCalled, "Decoder::Decode() failed");
+    VerifyOrQuit(decoderContext.mWasCalled);
     VerifyOrQuit(decoderContext.mError == OT_ERROR_PARSE, "Decoder::Decode() did not fail for short frame");
 
     decoderBuffer.Clear();
@@ -607,13 +580,13 @@ void TestEncoderDecoder(void)
     byte                      = kFlagSequence;
     decoderContext.mWasCalled = false;
     decoder.Decode(&byte, sizeof(uint8_t));
-    VerifyOrQuit(!decoderContext.mWasCalled, "Decoder::Decode() failed");
+    VerifyOrQuit(!decoderContext.mWasCalled);
     decoder.Decode(&byte, sizeof(uint8_t));
-    VerifyOrQuit(!decoderContext.mWasCalled, "Decoder::Decode() failed");
+    VerifyOrQuit(!decoderContext.mWasCalled);
     decoder.Decode(&byte, sizeof(uint8_t));
-    VerifyOrQuit(!decoderContext.mWasCalled, "Decoder::Decode() failed");
+    VerifyOrQuit(!decoderContext.mWasCalled);
     decoder.Decode(&byte, sizeof(uint8_t));
-    VerifyOrQuit(!decoderContext.mWasCalled, "Decoder::Decode() failed");
+    VerifyOrQuit(!decoderContext.mWasCalled);
 
     printf(" -- PASS\n");
 }
@@ -650,16 +623,16 @@ void TestFuzzEncoderDecoder(void)
             frame[i] = static_cast<uint8_t>(GetRandom(256));
         }
 
-        SuccessOrQuit(encoder.BeginFrame(), "Encoder::BeginFrame() failed");
-        SuccessOrQuit(encoder.Encode(frame, length), "Encoder::Encode() failed");
-        SuccessOrQuit(encoder.EndFrame(), "Encoder::EndFrame() failed");
+        SuccessOrQuit(encoder.BeginFrame());
+        SuccessOrQuit(encoder.Encode(frame, length));
+        SuccessOrQuit(encoder.EndFrame());
 
         VerifyOrQuit(!encoderBuffer.IsEmpty(), "Encoded frame is empty");
         VerifyOrQuit(encoderBuffer.GetLength() > length, "Encoded frame is too short");
 
         decoderContext.mWasCalled = false;
         decoder.Decode(encoderBuffer.GetFrame(), encoderBuffer.GetLength());
-        VerifyOrQuit(decoderContext.mWasCalled, "Decoder::Decode() failed");
+        VerifyOrQuit(decoderContext.mWasCalled);
         VerifyOrQuit(decoderContext.mError == OT_ERROR_NONE, "Decoder::Decode() returned incorrect error code");
 
         VerifyOrQuit(!decoderBuffer.IsEmpty(), "Decoded frame is empty");

--- a/tests/unit/test_heap_string.cpp
+++ b/tests/unit/test_heap_string.cpp
@@ -56,19 +56,19 @@ void VerifyString(const char *aName, const HeapString &aString, const char *aExp
 
     if (aExpectedString == nullptr)
     {
-        VerifyOrQuit(aString.IsNull(), "IsNull() is incorrect");
-        VerifyOrQuit(aString.AsCString() == nullptr, "AsCString() is incorrect");
-        VerifyOrQuit(aString != "something", "operator!=() failed");
+        VerifyOrQuit(aString.IsNull());
+        VerifyOrQuit(aString.AsCString() == nullptr);
+        VerifyOrQuit(aString != "something");
     }
     else
     {
-        VerifyOrQuit(!aString.IsNull(), "IsNull() is incorrect");
-        VerifyOrQuit(aString.AsCString() != nullptr, "AsCString() is incorrect");
+        VerifyOrQuit(!aString.IsNull());
+        VerifyOrQuit(aString.AsCString() != nullptr);
         VerifyOrQuit(strcmp(aString.AsCString(), aExpectedString) == 0, "String content is incorrect");
-        VerifyOrQuit(aString != nullptr, "operator!=() failed");
+        VerifyOrQuit(aString != nullptr);
     }
 
-    VerifyOrQuit(aString == aExpectedString, "operator==() failed");
+    VerifyOrQuit(aString == aExpectedString);
 }
 
 // Function returning a `HeapString` by value.
@@ -76,7 +76,7 @@ HeapString GetName(void)
 {
     HeapString name;
 
-    SuccessOrQuit(name.Set("name"), "Set() failed");
+    SuccessOrQuit(name.Set("name"));
 
     return name;
 }
@@ -93,28 +93,28 @@ void TestHeapString(void)
 
     printf("------------------------------------------------------------------------------------\n");
     printf("Set(const char *aCstring)\n\n");
-    SuccessOrQuit(str1.Set("hello"), "Set() failed");
+    SuccessOrQuit(str1.Set("hello"));
     VerifyString("str1", str1, "hello");
     oldBuffer = str1.AsCString();
 
-    SuccessOrQuit(str1.Set("0123456789"), "Set() failed");
+    SuccessOrQuit(str1.Set("0123456789"));
     VerifyString("str1", str1, "0123456789");
     printf("\tDid reuse its old buffer: %s\n", str1.AsCString() == oldBuffer ? "yes" : "no");
     oldBuffer = str1.AsCString();
 
-    SuccessOrQuit(str1.Set("9876543210"), "Set() failed");
+    SuccessOrQuit(str1.Set("9876543210"));
     VerifyString("str1", str1, "9876543210");
     printf("\tDid reuse its old buffer (same length): %s\n", str1.AsCString() == oldBuffer ? "yes" : "no");
 
     printf("------------------------------------------------------------------------------------\n");
     printf("Set(const HeapString &)\n\n");
-    SuccessOrQuit(str2.Set(str1), "Set() failed");
+    SuccessOrQuit(str2.Set(str1));
     VerifyString("str2", str2, str1.AsCString());
 
-    SuccessOrQuit(str1.Set(nullptr), "Set() failed");
+    SuccessOrQuit(str1.Set(nullptr));
     VerifyString("str1", str1, nullptr);
 
-    SuccessOrQuit(str2.Set(str1), "Set() failed");
+    SuccessOrQuit(str2.Set(str1));
     VerifyString("str2", str2, nullptr);
 
     printf("------------------------------------------------------------------------------------\n");
@@ -122,7 +122,7 @@ void TestHeapString(void)
     str1.Free();
     VerifyString("str1", str1, nullptr);
 
-    SuccessOrQuit(str1.Set("hello again"), "Set() failed");
+    SuccessOrQuit(str1.Set("hello again"));
     VerifyString("str1", str1, "hello again");
 
     str1.Free();
@@ -130,7 +130,7 @@ void TestHeapString(void)
 
     printf("------------------------------------------------------------------------------------\n");
     printf("Set() move semantics\n\n");
-    SuccessOrQuit(str1.Set("old name"), "Set() failed");
+    SuccessOrQuit(str1.Set("old name"));
     PrintString("str1", str1);
     SuccessOrQuit(str1.Set(GetName()), "Set() with move semantics failed");
     VerifyString("str1", str1, "name");

--- a/tests/unit/test_hkdf_sha256.cpp
+++ b/tests/unit/test_hkdf_sha256.cpp
@@ -123,7 +123,7 @@ void TestHkdfSha256(void)
 
     otInstance *instance = testInitInstance();
 
-    VerifyOrQuit(instance != nullptr, "Null OpenThread instance");
+    VerifyOrQuit(instance != nullptr);
 
     for (const TestVector *test = &kTestVectors[0]; test < OT_ARRAY_END(kTestVectors); test++)
     {

--- a/tests/unit/test_hmac_sha256.cpp
+++ b/tests/unit/test_hmac_sha256.cpp
@@ -90,10 +90,10 @@ void TestSha256(void)
     uint16_t     offsets[OT_ARRAY_LENGTH(kTestCases)];
     uint8_t      index;
 
-    VerifyOrQuit(instance != nullptr, "Null OpenThread instance");
+    VerifyOrQuit(instance != nullptr);
 
     messagePool = &instance->Get<MessagePool>();
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr, "Message::New failed");
+    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
 
     for (const TestCase &testCase : kTestCases)
     {
@@ -104,7 +104,7 @@ void TestSha256(void)
         sha256.Update(testCase.mData, static_cast<uint16_t>(strlen(testCase.mData)));
         sha256.Finish(hash);
 
-        VerifyOrQuit(hash == static_cast<const Crypto::HmacSha256::Hash &>(testCase.mHash), "HMAC-SHA-256 failed");
+        VerifyOrQuit(hash == static_cast<const Crypto::HmacSha256::Hash &>(testCase.mHash));
     }
 
     // Append all test case `mData` in the message.
@@ -113,11 +113,10 @@ void TestSha256(void)
 
     for (const TestCase &testCase : kTestCases)
     {
-        SuccessOrQuit(message->Append("Hello"), "Message::Append() failed");
+        SuccessOrQuit(message->Append("Hello"));
         offsets[index++] = message->GetLength();
-        SuccessOrQuit(message->AppendBytes(testCase.mData, static_cast<uint16_t>(strlen(testCase.mData))),
-                      "Message::AppendBytes() failed");
-        SuccessOrQuit(message->Append("There!"), "Message::Append() failed");
+        SuccessOrQuit(message->AppendBytes(testCase.mData, static_cast<uint16_t>(strlen(testCase.mData))));
+        SuccessOrQuit(message->Append("There!"));
     }
 
     index = 0;
@@ -131,7 +130,7 @@ void TestSha256(void)
         sha256.Update(*message, offsets[index++], static_cast<uint16_t>(strlen(testCase.mData)));
         sha256.Finish(hash);
 
-        VerifyOrQuit(hash == static_cast<const Crypto::HmacSha256::Hash &>(testCase.mHash), "HMAC-SHA-256 failed");
+        VerifyOrQuit(hash == static_cast<const Crypto::HmacSha256::Hash &>(testCase.mHash));
     }
 
     testFreeInstance(instance);
@@ -235,10 +234,10 @@ void TestHmacSha256(void)
 
     printf("TestHmacSha256\n");
 
-    VerifyOrQuit(instance != nullptr, "Null OpenThread instance");
+    VerifyOrQuit(instance != nullptr);
 
     messagePool = &instance->Get<MessagePool>();
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr, "Message::New failed");
+    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
 
     for (const TestCase &testCase : kTestCases)
     {
@@ -249,7 +248,7 @@ void TestHmacSha256(void)
         hmac.Update(testCase.mData, testCase.mDataLength);
         hmac.Finish(hash);
 
-        VerifyOrQuit(hash == static_cast<const Crypto::HmacSha256::Hash &>(testCase.mHash), "HMAC-SHA-256 failed");
+        VerifyOrQuit(hash == static_cast<const Crypto::HmacSha256::Hash &>(testCase.mHash));
     }
 
     // Append all test case `mData` in the message.
@@ -258,10 +257,10 @@ void TestHmacSha256(void)
 
     for (const TestCase &testCase : kTestCases)
     {
-        SuccessOrQuit(message->Append("Hello"), "Message::Append() failed");
+        SuccessOrQuit(message->Append("Hello"));
         offsets[index++] = message->GetLength();
-        SuccessOrQuit(message->AppendBytes(testCase.mData, testCase.mDataLength), "Message::AppendBytes() failed");
-        SuccessOrQuit(message->Append("There"), "Message::Append() failed");
+        SuccessOrQuit(message->AppendBytes(testCase.mData, testCase.mDataLength));
+        SuccessOrQuit(message->Append("There"));
     }
 
     index = 0;
@@ -275,7 +274,7 @@ void TestHmacSha256(void)
         hmac.Update(*message, offsets[index++], testCase.mDataLength);
         hmac.Finish(hash);
 
-        VerifyOrQuit(hash == static_cast<const Crypto::HmacSha256::Hash &>(testCase.mHash), "HMAC-SHA-256 failed");
+        VerifyOrQuit(hash == static_cast<const Crypto::HmacSha256::Hash &>(testCase.mHash));
     }
 
     message->Free();

--- a/tests/unit/test_ip_address.cpp
+++ b/tests/unit/test_ip_address.cpp
@@ -301,15 +301,15 @@ void TestIp6Prefix(void)
 
             printf("Prefix %s\n", prefix.ToString().AsCString());
 
-            VerifyOrQuit(prefix.GetLength() == prefixLength, "Prefix::GetLength() failed");
-            VerifyOrQuit(prefix.IsValid(), "Prefix::IsValid() failed");
-            VerifyOrQuit(prefix.IsEqual(prefixBytes, prefixLength), "Prefix::IsEqual() failed");
+            VerifyOrQuit(prefix.GetLength() == prefixLength);
+            VerifyOrQuit(prefix.IsValid());
+            VerifyOrQuit(prefix.IsEqual(prefixBytes, prefixLength));
 
-            VerifyOrQuit(address1.MatchesPrefix(prefix), "Address::MatchesPrefix() failed");
-            VerifyOrQuit(!address2.MatchesPrefix(prefix), "Address::MatchedPrefix() failed");
+            VerifyOrQuit(address1.MatchesPrefix(prefix));
+            VerifyOrQuit(!address2.MatchesPrefix(prefix));
 
-            VerifyOrQuit(prefix == prefix, "Prefix::operator==() failed");
-            VerifyOrQuit(!(prefix < prefix), "Prefix::operator<() failed");
+            VerifyOrQuit(prefix == prefix);
+            VerifyOrQuit(!(prefix < prefix));
 
             for (uint8_t subPrefixLength = 1; subPrefixLength <= prefixLength; subPrefixLength++)
             {
@@ -317,21 +317,19 @@ void TestIp6Prefix(void)
 
                 subPrefix.Set(prefixBytes, subPrefixLength);
 
-                VerifyOrQuit(prefix.ContainsPrefix(subPrefix), "Prefix::ContainsPrefix() failed");
+                VerifyOrQuit(prefix.ContainsPrefix(subPrefix));
 
                 if (prefixLength == subPrefixLength)
                 {
-                    VerifyOrQuit(prefix == subPrefix, "Prefix::operator==() failed");
-                    VerifyOrQuit(prefix.IsEqual(subPrefix.GetBytes(), subPrefix.GetLength()),
-                                 "Prefix::IsEqual() failed");
-                    VerifyOrQuit(!(subPrefix < prefix), "Prefix::operator<() failed");
+                    VerifyOrQuit(prefix == subPrefix);
+                    VerifyOrQuit(prefix.IsEqual(subPrefix.GetBytes(), subPrefix.GetLength()));
+                    VerifyOrQuit(!(subPrefix < prefix));
                 }
                 else
                 {
-                    VerifyOrQuit(prefix != subPrefix, "Prefix::operator!= failed");
-                    VerifyOrQuit(!prefix.IsEqual(subPrefix.GetBytes(), subPrefix.GetLength()),
-                                 "Prefix::IsEqual() failed");
-                    VerifyOrQuit(subPrefix < prefix, "Prefix::operator<() failed");
+                    VerifyOrQuit(prefix != subPrefix);
+                    VerifyOrQuit(!prefix.IsEqual(subPrefix.GetBytes(), subPrefix.GetLength()));
+                    VerifyOrQuit(subPrefix < prefix);
                 }
             }
 
@@ -343,17 +341,17 @@ void TestIp6Prefix(void)
                 bool            isPrefixSmaller;
 
                 prefix2 = prefix;
-                VerifyOrQuit(prefix == prefix2, "Prefix::operator==() failed");
+                VerifyOrQuit(prefix == prefix2);
 
                 // Flip the `bitNumber` bit between `prefix` and `prefix2`
 
                 prefix2.mPrefix.mFields.m8[index] ^= mask;
-                VerifyOrQuit(prefix != prefix2, "Prefix::operator==() failed");
+                VerifyOrQuit(prefix != prefix2);
 
                 isPrefixSmaller = ((prefix.GetBytes()[index] & mask) == 0);
 
-                VerifyOrQuit((prefix < prefix2) == isPrefixSmaller, "Prefix::operator<() failed");
-                VerifyOrQuit((prefix2 < prefix) == !isPrefixSmaller, "Prefix::operator<() failed");
+                VerifyOrQuit((prefix < prefix2) == isPrefixSmaller);
+                VerifyOrQuit((prefix2 < prefix) == !isPrefixSmaller);
             }
         }
     }
@@ -394,10 +392,10 @@ void TestIp4Ip6Translation(void)
         ot::Ip6::Address address;
         ot::Ip6::Address expectedAddress;
 
-        SuccessOrQuit(address.FromString(testCase.mPrefix), "Ip6::FromString() failed");
+        SuccessOrQuit(address.FromString(testCase.mPrefix));
         prefix.Set(address.GetBytes(), testCase.mLength);
 
-        SuccessOrQuit(expectedAddress.FromString(testCase.mIp6Address), "Ip6::FromString() failed");
+        SuccessOrQuit(expectedAddress.FromString(testCase.mIp6Address));
 
         address.SynthesizeFromIp4Address(prefix, ip4Address);
 
@@ -441,15 +439,15 @@ void TestIp6Header(void)
     header.SetSource(source);
     header.SetDestination(destination);
 
-    VerifyOrQuit(header.IsValid(), "Header::IsValid() failed");
-    VerifyOrQuit(header.IsVersion6(), "Header::Init() failed");
+    VerifyOrQuit(header.IsValid());
+    VerifyOrQuit(header.IsVersion6());
 
-    VerifyOrQuit(header.GetDscp() == ot::Ip6::kDscpCs7, "Get/SetDscp() failed");
-    VerifyOrQuit(header.GetPayloadLength() == kPayloadLength, "Get/SetPayloadLength() failed");
-    VerifyOrQuit(header.GetNextHeader() == ot::Ip6::kProtoUdp, "Get/SetNextHeader() failed");
-    VerifyOrQuit(header.GetHopLimit() == kHopLimit, "Get/SetHopLimit() failed");
-    VerifyOrQuit(header.GetSource() == source, "Get/SetSource() failed");
-    VerifyOrQuit(header.GetDestination() == destination, "Get/SetSource() failed");
+    VerifyOrQuit(header.GetDscp() == ot::Ip6::kDscpCs7);
+    VerifyOrQuit(header.GetPayloadLength() == kPayloadLength);
+    VerifyOrQuit(header.GetNextHeader() == ot::Ip6::kProtoUdp);
+    VerifyOrQuit(header.GetHopLimit() == kHopLimit);
+    VerifyOrQuit(header.GetSource() == source);
+    VerifyOrQuit(header.GetDestination() == destination);
 
     // Verify the offsets to different fields.
 

--- a/tests/unit/test_link_quality.cpp
+++ b/tests/unit/test_link_quality.cpp
@@ -71,11 +71,11 @@ void VerifyRawRssValue(int8_t aAverage, uint16_t aRawValue)
     if (aAverage != OT_RADIO_RSSI_INVALID)
     {
         VerifyOrQuit(aAverage == -static_cast<int16_t>((aRawValue + (kRawAverageMultiple / 2)) >> kRawAverageBitShift),
-                     "TestLinkQualityInfo failed - Raw value does not match the average.");
+                     "Raw value does not match the average.");
     }
     else
     {
-        VerifyOrQuit(aRawValue == 0, "TestLinkQualityInfo failed - Raw value does not match the average.");
+        VerifyOrQuit(aRawValue == 0, "Raw value does not match the average.");
     }
 }
 
@@ -92,7 +92,7 @@ void TestLinkQualityData(RssTestData aRssData)
     size_t          i;
 
     sInstance = testInitInstance();
-    VerifyOrQuit(sInstance != nullptr, "Null instance");
+    VerifyOrQuit(sInstance != nullptr);
     linkInfo.Init(*sInstance);
 
     printf("- - - - - - - - - - - - - - - - - -\n");
@@ -106,17 +106,16 @@ void TestLinkQualityData(RssTestData aRssData)
         min = MIN_RSS(rss, min);
         max = MAX_RSS(rss, max);
         linkInfo.AddRss(rss);
-        VerifyOrQuit(linkInfo.GetLastRss() == rss, "TestLinkQualityInfo failed - GetLastRss() is incorrect");
+        VerifyOrQuit(linkInfo.GetLastRss() == rss);
         ave = linkInfo.GetAverageRss();
-        VerifyOrQuit(ave >= min, "TestLinkQualityInfo failed - GetAverageRss() is smaller than min value.");
-        VerifyOrQuit(ave <= max, "TestLinkQualityInfo failed - GetAverageRss() is larger than min value");
+        VerifyOrQuit(ave >= min, "GetAverageRss() is smaller than min value.");
+        VerifyOrQuit(ave <= max, "GetAverageRss() is larger than min value");
         VerifyRawRssValue(linkInfo.GetAverageRss(), linkInfo.GetAverageRssRaw());
         printf("%02u) AddRss(%4d): ", static_cast<unsigned int>(i), rss);
         PrintOutcome(linkInfo);
     }
 
-    VerifyOrQuit(linkInfo.GetLinkQuality() == aRssData.mExpectedLinkQuality,
-                 "TestLinkQualityInfo failed - GetLinkQuality() is incorrect");
+    VerifyOrQuit(linkInfo.GetLinkQuality() == aRssData.mExpectedLinkQuality);
 }
 
 // Check and verify the raw average RSS value to match the value from GetAverage().
@@ -128,11 +127,11 @@ void VerifyRawRssValue(RssAverager &aRssAverager)
     if (average != OT_RADIO_RSSI_INVALID)
     {
         VerifyOrQuit(average == -static_cast<int16_t>((rawValue + (kRawAverageMultiple / 2)) >> kRawAverageBitShift),
-                     "TestLinkQualityInfo failed - Raw value does not match the average.");
+                     "Raw value does not match the average.");
     }
     else
     {
-        VerifyOrQuit(rawValue == 0, "TestLinkQualityInfo failed - Raw value does not match the average.");
+        VerifyOrQuit(rawValue == 0, "Raw value does not match the average.");
     }
 }
 
@@ -165,8 +164,7 @@ void TestRssAveraging(void)
     rssAverager.Clear();
 
     printf("\nAfter Clear: ");
-    VerifyOrQuit(rssAverager.GetAverage() == OT_RADIO_RSSI_INVALID,
-                 "TestLinkQualityInfo failed - Initial value from GetAverage() is incorrect.");
+    VerifyOrQuit(rssAverager.GetAverage() == OT_RADIO_RSSI_INVALID, "Initial value from GetAverage() is incorrect.");
     VerifyRawRssValue(rssAverager);
     PrintOutcome(rssAverager);
 
@@ -175,7 +173,7 @@ void TestRssAveraging(void)
     rss = -70;
     printf("AddRss(%d): ", rss);
     IgnoreError(rssAverager.Add(rss));
-    VerifyOrQuit(rssAverager.GetAverage() == rss, "TestLinkQualityInfo - GetAverage() failed after a single AddRss().");
+    VerifyOrQuit(rssAverager.GetAverage() == rss, "GetAverage() failed after a single AddRss().");
     VerifyRawRssValue(rssAverager);
     PrintOutcome(rssAverager);
 
@@ -184,8 +182,7 @@ void TestRssAveraging(void)
 
     printf("Clear(): ");
     rssAverager.Clear();
-    VerifyOrQuit(rssAverager.GetAverage() == OT_RADIO_RSSI_INVALID,
-                 "TestLinkQualityInfo failed - GetAverage() after Clear() is incorrect.");
+    VerifyOrQuit(rssAverager.GetAverage() == OT_RADIO_RSSI_INVALID, "GetAverage() after Clear() is incorrect.");
     VerifyRawRssValue(rssAverager);
     PrintOutcome(rssAverager);
 
@@ -203,8 +200,7 @@ void TestRssAveraging(void)
         for (i = 0; i < kNumRssAdds; i++)
         {
             IgnoreError(rssAverager.Add(rss));
-            VerifyOrQuit(rssAverager.GetAverage() == rss,
-                         "TestLinkQualityInfo failed - GetAverage() returned incorrect value.");
+            VerifyOrQuit(rssAverager.GetAverage() == rss, "GetAverage() returned incorrect value.");
             VerifyRawRssValue(rssAverager);
         }
 
@@ -232,8 +228,7 @@ void TestRssAveraging(void)
             IgnoreError(rssAverager.Add(rss));
             IgnoreError(rssAverager.Add(rss2));
             printf("AddRss(%4d), AddRss(%4d): ", rss, rss2);
-            VerifyOrQuit(rssAverager.GetAverage() == ((rss + rss2) >> 1),
-                         "TestLinkQualityInfo failed - GetAverage() returned incorrect value.");
+            VerifyOrQuit(rssAverager.GetAverage() == ((rss + rss2) >> 1), "GetAverage() returned incorrect value.");
             VerifyRawRssValue(rssAverager);
             PrintOutcome(rssAverager);
         }
@@ -266,10 +261,8 @@ void TestRssAveraging(void)
             IgnoreError(rssAverager.Add(rss2));
             printf("AddRss(%4d) %d times, AddRss(%4d): ", rss, kNumRssAdds, rss2);
             ave = rssAverager.GetAverage();
-            VerifyOrQuit(ave >= MIN_RSS(rss, rss2),
-                         "TestLinkQualityInfo failed - GetAverage() returned incorrect value.");
-            VerifyOrQuit(ave <= MAX_RSS(rss, rss2),
-                         "TestLinkQualityInfo failed - GetAverage() returned incorrect value.");
+            VerifyOrQuit(ave >= MIN_RSS(rss, rss2), "GetAverage() returned incorrect value.");
+            VerifyOrQuit(ave <= MAX_RSS(rss, rss2), "GetAverage() returned incorrect value.");
             VerifyRawRssValue(rssAverager);
             PrintOutcome(rssAverager);
         }
@@ -299,13 +292,11 @@ void TestRssAveraging(void)
                 IgnoreError(rssAverager.Add(rss));
                 IgnoreError(rssAverager.Add(rss2));
                 ave = rssAverager.GetAverage();
-                VerifyOrQuit(ave >= MIN_RSS(rss, rss2),
-                             "TestLinkQualityInfo failed - GetAverage() is smaller than min value.");
-                VerifyOrQuit(ave <= MAX_RSS(rss, rss2),
-                             "TestLinkQualityInfo failed - GetAverage() is larger than min value.");
+                VerifyOrQuit(ave >= MIN_RSS(rss, rss2), "GetAverage() is smaller than min value.");
+                VerifyOrQuit(ave <= MAX_RSS(rss, rss2), "GetAverage() is larger than min value.");
                 diff = ave;
                 diff -= (rss + rss2) >> 1;
-                VerifyOrQuit(ABS(diff) <= kRssAverageMaxDiff, "TestLinkQualityInfo failed - GetAverage() is incorrect");
+                VerifyOrQuit(ABS(diff) <= kRssAverageMaxDiff, "GetAverage() is incorrect");
                 VerifyRawRssValue(rssAverager);
             }
 

--- a/tests/unit/test_linked_list.cpp
+++ b/tests/unit/test_linked_list.cpp
@@ -79,17 +79,17 @@ void VerifyLinkedListContent(const ot::LinkedList<Entry> *aList, ...)
         argEntry = va_arg(args, Entry *);
         VerifyOrQuit(argEntry != nullptr, "List contains more entries than expected");
         VerifyOrQuit(argEntry == entry, "List does not contain the same entry");
-        VerifyOrQuit(aList->Contains(*argEntry), "List::Contains() failed");
-        VerifyOrQuit(aList->ContainsMatching(argEntry->GetName()), "List::ContainsMatching() failed");
-        VerifyOrQuit(aList->ContainsMatching(argEntry->GetId()), "List::ContainsMatching() failed");
+        VerifyOrQuit(aList->Contains(*argEntry));
+        VerifyOrQuit(aList->ContainsMatching(argEntry->GetName()));
+        VerifyOrQuit(aList->ContainsMatching(argEntry->GetId()));
 
-        SuccessOrQuit(aList->Find(*argEntry, prev), "List::Find() failed");
+        SuccessOrQuit(aList->Find(*argEntry, prev));
         VerifyOrQuit(prev == argPrev, "List::Find() returned prev entry is incorrect");
 
-        VerifyOrQuit(aList->FindMatching(argEntry->GetName(), prev) == argEntry, "List::FindMatching() failed");
+        VerifyOrQuit(aList->FindMatching(argEntry->GetName(), prev) == argEntry);
         VerifyOrQuit(prev == argPrev, "List::FindMatching() returned prev entry is incorrect");
 
-        VerifyOrQuit(aList->FindMatching(argEntry->GetId(), prev) == argEntry, "List::FindMatching() failed");
+        VerifyOrQuit(aList->FindMatching(argEntry->GetId(), prev) == argEntry);
         VerifyOrQuit(prev == argPrev, "List::FindMatching() returned prev entry is incorrect");
 
         argPrev = argEntry;
@@ -98,15 +98,13 @@ void VerifyLinkedListContent(const ot::LinkedList<Entry> *aList, ...)
     argEntry = va_arg(args, Entry *);
     VerifyOrQuit(argEntry == nullptr, "List contains less entries than expected");
 
-    VerifyOrQuit(aList->GetTail() == argPrev, "List::GetTail() failed");
+    VerifyOrQuit(aList->GetTail() == argPrev);
 
-    VerifyOrQuit(!aList->ContainsMatching("none"), "List::ContainsMatching() succeeded for a missing entry");
-    VerifyOrQuit(!aList->ContainsMatching(unusedId), "List::ContainsMatching() succeeded for a missing entry");
+    VerifyOrQuit(!aList->ContainsMatching("none"), "succeeded for a missing entry");
+    VerifyOrQuit(!aList->ContainsMatching(unusedId), "succeeded for a missing entry");
 
-    VerifyOrQuit(aList->FindMatching("none", prev) == nullptr,
-                 "LinkedList::FindMatching() succeeded for a missing entry");
-    VerifyOrQuit(aList->FindMatching(unusedId, prev) == nullptr,
-                 "LinkedList::FindMatching() succeeded for a missing entry");
+    VerifyOrQuit(aList->FindMatching("none", prev) == nullptr, "succeeded for a missing entry");
+    VerifyOrQuit(aList->FindMatching(unusedId, prev) == nullptr, "succeeded for a missing entry");
 }
 
 void TestLinkedList(void)
@@ -115,81 +113,81 @@ void TestLinkedList(void)
     Entry *               prev;
     ot::LinkedList<Entry> list;
 
-    VerifyOrQuit(list.IsEmpty(), "LinkedList::IsEmpty() failed after init");
-    VerifyOrQuit(list.GetHead() == nullptr, "LinkedList::GetHead() failed after init");
-    VerifyOrQuit(list.Pop() == nullptr, "LinkedList::Pop() failed when empty");
-    VerifyOrQuit(list.Find(a, prev) == ot::kErrorNotFound, "LinkedList::Find() succeeded for a missing entry");
+    VerifyOrQuit(list.IsEmpty(), "failed after init");
+    VerifyOrQuit(list.GetHead() == nullptr, "failed after init");
+    VerifyOrQuit(list.Pop() == nullptr, "failed when empty");
+    VerifyOrQuit(list.Find(a, prev) == ot::kErrorNotFound, "succeeded when empty");
 
     VerifyLinkedListContent(&list, nullptr);
 
     list.Push(a);
-    VerifyOrQuit(!list.IsEmpty(), "LinkedList::IsEmpty() failed");
+    VerifyOrQuit(!list.IsEmpty());
     VerifyLinkedListContent(&list, &a, nullptr);
-    VerifyOrQuit(list.Find(b, prev) == ot::kErrorNotFound, "LinkedList::Find() succeeded for a missing entry");
+    VerifyOrQuit(list.Find(b, prev) == ot::kErrorNotFound, "succeeded for a missing entry");
 
-    SuccessOrQuit(list.Add(b), "LinkedList::Add() failed");
+    SuccessOrQuit(list.Add(b));
     VerifyLinkedListContent(&list, &b, &a, nullptr);
-    VerifyOrQuit(list.Find(c, prev) == ot::kErrorNotFound, "LinkedList::Find() succeeded for a missing entry");
+    VerifyOrQuit(list.Find(c, prev) == ot::kErrorNotFound, "succeeded for a missing entry");
 
     list.Push(c);
     VerifyLinkedListContent(&list, &c, &b, &a, nullptr);
 
-    SuccessOrQuit(list.Add(d), "LinkedList::Add() failed");
+    SuccessOrQuit(list.Add(d));
     VerifyLinkedListContent(&list, &d, &c, &b, &a, nullptr);
 
-    SuccessOrQuit(list.Add(e), "LinkedList::Add() failed");
+    SuccessOrQuit(list.Add(e));
     VerifyLinkedListContent(&list, &e, &d, &c, &b, &a, nullptr);
 
-    VerifyOrQuit(list.Add(a) == ot::kErrorAlready, "LinkedList::Add() did not detect duplicate");
-    VerifyOrQuit(list.Add(b) == ot::kErrorAlready, "LinkedList::Add() did not detect duplicate");
-    VerifyOrQuit(list.Add(d) == ot::kErrorAlready, "LinkedList::Add() did not detect duplicate");
-    VerifyOrQuit(list.Add(e) == ot::kErrorAlready, "LinkedList::Add() did not detect duplicate");
+    VerifyOrQuit(list.Add(a) == ot::kErrorAlready, "did not detect duplicate");
+    VerifyOrQuit(list.Add(b) == ot::kErrorAlready, "did not detect duplicate");
+    VerifyOrQuit(list.Add(d) == ot::kErrorAlready, "did not detect duplicate");
+    VerifyOrQuit(list.Add(e) == ot::kErrorAlready, "did not detect duplicate");
 
-    VerifyOrQuit(list.Pop() == &e, "LinkedList::Pop() failed");
+    VerifyOrQuit(list.Pop() == &e);
     VerifyLinkedListContent(&list, &d, &c, &b, &a, nullptr);
-    VerifyOrQuit(list.Find(e, prev) == ot::kErrorNotFound, "LinkedList::Find() succeeded for a missing entry");
+    VerifyOrQuit(list.Find(e, prev) == ot::kErrorNotFound, "succeeded for a missing entry");
 
-    VerifyOrQuit(list.FindMatching(d.GetName(), prev) == &d, "List::FindMatching() failed");
-    VerifyOrQuit(prev == nullptr, "List::FindMatching() failed");
-    VerifyOrQuit(list.FindMatching(c.GetId(), prev) == &c, "List::FindMatching() failed");
-    VerifyOrQuit(prev == &d, "List::FindMatching() failed");
-    VerifyOrQuit(list.FindMatching(b.GetName(), prev) == &b, "List::FindMatching() failed");
-    VerifyOrQuit(prev == &c, "List::FindMatching() failed");
-    VerifyOrQuit(list.FindMatching(a.GetId(), prev) == &a, "List::FindMatching() failed");
-    VerifyOrQuit(prev == &b, "List::FindMatching() failed");
-    VerifyOrQuit(list.FindMatching(e.GetId(), prev) == nullptr, "List::FindMatching() succeeded for a missing entry");
-    VerifyOrQuit(list.FindMatching(e.GetName(), prev) == nullptr, "List::FindMatching() succeeded for a missing entry");
+    VerifyOrQuit(list.FindMatching(d.GetName(), prev) == &d);
+    VerifyOrQuit(prev == nullptr);
+    VerifyOrQuit(list.FindMatching(c.GetId(), prev) == &c);
+    VerifyOrQuit(prev == &d);
+    VerifyOrQuit(list.FindMatching(b.GetName(), prev) == &b);
+    VerifyOrQuit(prev == &c);
+    VerifyOrQuit(list.FindMatching(a.GetId(), prev) == &a);
+    VerifyOrQuit(prev == &b);
+    VerifyOrQuit(list.FindMatching(e.GetId(), prev) == nullptr, "succeeded for a missing entry");
+    VerifyOrQuit(list.FindMatching(e.GetName(), prev) == nullptr, "succeeded for a missing entry");
 
     list.SetHead(&e);
     VerifyLinkedListContent(&list, &e, &d, &c, &b, &a, nullptr);
 
-    SuccessOrQuit(list.Remove(c), "LinkedList::Remove() failed");
+    SuccessOrQuit(list.Remove(c));
     VerifyLinkedListContent(&list, &e, &d, &b, &a, nullptr);
 
-    VerifyOrQuit(list.Remove(c) == ot::kErrorNotFound, "LinkedList::Remove() failed");
+    VerifyOrQuit(list.Remove(c) == ot::kErrorNotFound);
     VerifyLinkedListContent(&list, &e, &d, &b, &a, nullptr);
-    VerifyOrQuit(list.Find(c, prev) == ot::kErrorNotFound, "LinkedList::Find() succeeded for a missing entry");
+    VerifyOrQuit(list.Find(c, prev) == ot::kErrorNotFound, "succeeded for a missing entry");
 
-    SuccessOrQuit(list.Remove(e), "LinkedList::Remove() failed");
+    SuccessOrQuit(list.Remove(e));
     VerifyLinkedListContent(&list, &d, &b, &a, nullptr);
-    VerifyOrQuit(list.Find(e, prev) == ot::kErrorNotFound, "LinkedList::Find() succeeded for a missing entry");
+    VerifyOrQuit(list.Find(e, prev) == ot::kErrorNotFound, "succeeded for a missing entry");
 
-    SuccessOrQuit(list.Remove(a), "LinkedList::Remove() failed");
+    SuccessOrQuit(list.Remove(a));
     VerifyLinkedListContent(&list, &d, &b, nullptr);
-    VerifyOrQuit(list.Find(a, prev) == ot::kErrorNotFound, "LinkedList::Find() succeeded for a missing entry");
+    VerifyOrQuit(list.Find(a, prev) == ot::kErrorNotFound, "succeeded for a missing entry");
 
     list.Push(a);
     list.Push(c);
     list.Push(e);
     VerifyLinkedListContent(&list, &e, &c, &a, &d, &b, nullptr);
 
-    VerifyOrQuit(list.PopAfter(&a) == &d, "LinkedList::PopAfter() failed");
+    VerifyOrQuit(list.PopAfter(&a) == &d);
     VerifyLinkedListContent(&list, &e, &c, &a, &b, nullptr);
 
-    VerifyOrQuit(list.PopAfter(&b) == nullptr, "LinkedList::PopAfter() failed");
+    VerifyOrQuit(list.PopAfter(&b) == nullptr);
     VerifyLinkedListContent(&list, &e, &c, &a, &b, nullptr);
 
-    VerifyOrQuit(list.PopAfter(&e) == &c, "LinkedList::PopAfter() failed");
+    VerifyOrQuit(list.PopAfter(&e) == &c);
     VerifyLinkedListContent(&list, &e, &a, &b, nullptr);
 
     list.PushAfter(c, b);
@@ -198,38 +196,37 @@ void TestLinkedList(void)
     list.PushAfter(d, a);
     VerifyLinkedListContent(&list, &e, &a, &d, &b, &c, nullptr);
 
-    VerifyOrQuit(list.PopAfter(nullptr) == &e, "LinkedList::PopAfter() failed");
+    VerifyOrQuit(list.PopAfter(nullptr) == &e);
     VerifyLinkedListContent(&list, &a, &d, &b, &c, nullptr);
 
-    VerifyOrQuit(list.PopAfter(nullptr) == &a, "LinkedList::PopAfter() failed");
+    VerifyOrQuit(list.PopAfter(nullptr) == &a);
     VerifyLinkedListContent(&list, &d, &b, &c, nullptr);
 
     list.Push(e);
     list.Push(a);
     VerifyLinkedListContent(&list, &a, &e, &d, &b, &c, nullptr);
 
-    VerifyOrQuit(list.RemoveMatching(a.GetName()) == &a, "LinkedList::RemoveMatching() failed");
+    VerifyOrQuit(list.RemoveMatching(a.GetName()) == &a);
     VerifyLinkedListContent(&list, &e, &d, &b, &c, nullptr);
 
-    VerifyOrQuit(list.RemoveMatching(c.GetId()) == &c, "LinkedList::RemoveMatching() failed");
+    VerifyOrQuit(list.RemoveMatching(c.GetId()) == &c);
     VerifyLinkedListContent(&list, &e, &d, &b, nullptr);
 
-    VerifyOrQuit(list.RemoveMatching(c.GetId()) == nullptr, "LinkedList::RemoveMatching() succeeded for missing entry");
-    VerifyOrQuit(list.RemoveMatching(a.GetName()) == nullptr,
-                 "LinkedList::RemoveMatching() succeeded for missing entry");
+    VerifyOrQuit(list.RemoveMatching(c.GetId()) == nullptr, "succeeded for missing entry");
+    VerifyOrQuit(list.RemoveMatching(a.GetName()) == nullptr, "succeeded for missing entry");
 
-    VerifyOrQuit(list.RemoveMatching(d.GetId()) == &d, "LinkedList::RemoveMatching() failed");
+    VerifyOrQuit(list.RemoveMatching(d.GetId()) == &d);
     VerifyLinkedListContent(&list, &e, &b, nullptr);
 
     list.Clear();
-    VerifyOrQuit(list.IsEmpty(), "LinkedList::IsEmpty() failed after Clear()");
-    VerifyOrQuit(list.PopAfter(nullptr) == nullptr, "LinkedList::PopAfter() failed");
+    VerifyOrQuit(list.IsEmpty(), "failed after Clear()");
+    VerifyOrQuit(list.PopAfter(nullptr) == nullptr);
     VerifyLinkedListContent(&list, nullptr);
-    VerifyOrQuit(list.Find(a, prev) == ot::kErrorNotFound, "LinkedList::Find() succeeded for a missing entry");
-    VerifyOrQuit(list.FindMatching(b.GetName(), prev) == nullptr, "LinkedList::FindMatching() succeeded when empty");
-    VerifyOrQuit(list.FindMatching(c.GetId(), prev) == nullptr, "LinkedList::FindMatching() succeeded when empty");
-    VerifyOrQuit(list.RemoveMatching(a.GetName()) == nullptr, "LinkedList::RemoveMatching() succeeded when empty");
-    VerifyOrQuit(list.Remove(a) == ot::kErrorNotFound, "LinkedList::Remove() succeeded when empty");
+    VerifyOrQuit(list.Find(a, prev) == ot::kErrorNotFound, "succeeded for a missing entry");
+    VerifyOrQuit(list.FindMatching(b.GetName(), prev) == nullptr, "succeeded when empty");
+    VerifyOrQuit(list.FindMatching(c.GetId(), prev) == nullptr, "succeeded when empty");
+    VerifyOrQuit(list.RemoveMatching(a.GetName()) == nullptr, "succeeded when empty");
+    VerifyOrQuit(list.Remove(a) == ot::kErrorNotFound, "succeeded when empty");
 }
 
 int main(void)

--- a/tests/unit/test_lookup_table.cpp
+++ b/tests/unit/test_lookup_table.cpp
@@ -80,10 +80,8 @@ void TestLookupTable(void)
     constexpr Entry kDuplicateEntryTable[] = {Entry("duplicate"), Entry("duplicate")};
 
     static_assert(ot::Utils::LookupTable::IsSorted(kTable), "LookupTable::IsSorted() failed");
-    static_assert(!ot::Utils::LookupTable::IsSorted(kUnsortedTable),
-                  "LookupTable::IsSorted() failed for unsorted table");
-    static_assert(!ot::Utils::LookupTable::IsSorted(kDuplicateEntryTable),
-                  "LookupTable::IsSorted() failed for table with duplicate entries");
+    static_assert(!ot::Utils::LookupTable::IsSorted(kUnsortedTable), "failed for unsorted table");
+    static_assert(!ot::Utils::LookupTable::IsSorted(kDuplicateEntryTable), "failed for table with duplicate entries");
 
     for (const TableEntry &tableEntry : kTable)
     {
@@ -100,8 +98,7 @@ void TestLookupTable(void)
         VerifyOrQuit(entry == nullptr, "LookupTable::Find() failed with non-matching name");
     }
 
-    VerifyOrQuit(ot::Utils::LookupTable::Find("dragon age", kTable) == nullptr,
-                 "LookupTable::Find() failed with non exiting mathc");
+    VerifyOrQuit(ot::Utils::LookupTable::Find("dragon age", kTable) == nullptr, "failed with non-exiting match");
 }
 
 int main(void)

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -78,24 +78,24 @@ void TestIphcVector::GetUncompressedStream(uint8_t *aIp6, uint16_t &aIp6Length)
 
 void TestIphcVector::GetUncompressedStream(Message &aMessage)
 {
-    SuccessOrQuit(aMessage.Append(mIpHeader), "6lo: Message::Append failed");
+    SuccessOrQuit(aMessage.Append(mIpHeader));
 
     if (mExtHeader.mLength)
     {
-        SuccessOrQuit(aMessage.AppendBytes(mExtHeader.mData, mExtHeader.mLength), "6lo: Message::Append failed");
+        SuccessOrQuit(aMessage.AppendBytes(mExtHeader.mData, mExtHeader.mLength));
     }
 
     if (mIpTunneledHeader.GetPayloadLength())
     {
-        SuccessOrQuit(aMessage.Append(mIpTunneledHeader), "6lo: Message::Append failed");
+        SuccessOrQuit(aMessage.Append(mIpTunneledHeader));
     }
 
     if (mUdpHeader.GetLength())
     {
-        SuccessOrQuit(aMessage.Append(mUdpHeader), "6lo: Message::Append failed");
+        SuccessOrQuit(aMessage.Append(mUdpHeader));
     }
 
-    SuccessOrQuit(aMessage.AppendBytes(mPayload.mData, mPayload.mLength), "6lo: Message::Append failed");
+    SuccessOrQuit(aMessage.AppendBytes(mPayload.mData, mPayload.mLength));
 }
 
 /**
@@ -125,9 +125,9 @@ static void Init(void)
     };
 
     Message *message = sInstance->Get<MessagePool>().New(Message::kTypeIp6, 0);
-    VerifyOrQuit(message != nullptr, "6lo: Ip6::NewMessage failed");
+    VerifyOrQuit(message != nullptr, "Ip6::NewMessage failed");
 
-    SuccessOrQuit(message->AppendBytes(mockNetworkData, sizeof(mockNetworkData)), "6lo: Message::Append failed");
+    SuccessOrQuit(message->AppendBytes(mockNetworkData, sizeof(mockNetworkData)));
 
     IgnoreError(sInstance->Get<NetworkData::Leader>().SetNetworkData(0, 0, true, *message, 0));
 }
@@ -171,13 +171,12 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
     {
         Lowpan::BufferWriter buffer(result, 127);
 
-        VerifyOrQuit((message = sInstance->Get<MessagePool>().New(Message::kTypeIp6, 0)) != nullptr,
-                     "6lo: Ip6::NewMessage failed");
+        VerifyOrQuit((message = sInstance->Get<MessagePool>().New(Message::kTypeIp6, 0)) != nullptr);
 
         aVector.GetUncompressedStream(*message);
 
-        VerifyOrQuit(sLowpan->Compress(*message, aVector.mMacSource, aVector.mMacDestination, buffer) == aVector.mError,
-                     "6lo: Lowpan:Compress failed");
+        VerifyOrQuit(sLowpan->Compress(*message, aVector.mMacSource, aVector.mMacDestination, buffer) ==
+                     aVector.mError);
 
         if (aVector.mError == kErrorNone)
         {
@@ -190,9 +189,9 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
             DumpBuffer("Resulted LOWPAN_IPHC compressed frame", result,
                        compressBytes + message->GetLength() - message->GetOffset());
 
-            VerifyOrQuit(compressBytes == aVector.mIphcHeader.mLength, "6lo: Lowpan::Compress failed");
-            VerifyOrQuit(message->GetOffset() == aVector.mPayloadOffset, "6lo: Lowpan::Compress failed");
-            VerifyOrQuit(memcmp(iphc, result, iphcLength) == 0, "6lo: Lowpan::Compress failed");
+            VerifyOrQuit(compressBytes == aVector.mIphcHeader.mLength, "Lowpan::Compress failed");
+            VerifyOrQuit(message->GetOffset() == aVector.mPayloadOffset, "Lowpan::Compress failed");
+            VerifyOrQuit(memcmp(iphc, result, iphcLength) == 0, "Lowpan::Compress failed");
         }
 
         message->Free();
@@ -201,8 +200,7 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
 
     if (aDecompress)
     {
-        VerifyOrQuit((message = sInstance->Get<MessagePool>().New(Message::kTypeIp6, 0)) != nullptr,
-                     "6lo: Ip6::NewMessage failed");
+        VerifyOrQuit((message = sInstance->Get<MessagePool>().New(Message::kTypeIp6, 0)) != nullptr);
 
         int decompressedBytes =
             sLowpan->Decompress(*message, aVector.mMacSource, aVector.mMacDestination, iphc, iphcLength, 0);
@@ -218,14 +216,14 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
             DumpBuffer("Resulted IPv6 uncompressed packet", result,
                        message->GetLength() + iphcLength - static_cast<uint16_t>(decompressedBytes));
 
-            VerifyOrQuit(decompressedBytes == aVector.mIphcHeader.mLength, "6lo: Lowpan::Decompress failed");
-            VerifyOrQuit(message->GetOffset() == aVector.mPayloadOffset, "6lo: Lowpan::Decompress failed");
-            VerifyOrQuit(message->GetOffset() == message->GetLength(), "6lo: Lowpan::Decompress failed");
-            VerifyOrQuit(memcmp(ip6, result, ip6Length) == 0, "6lo: Lowpan::Decompress failed");
+            VerifyOrQuit(decompressedBytes == aVector.mIphcHeader.mLength, "Lowpan::Decompress failed");
+            VerifyOrQuit(message->GetOffset() == aVector.mPayloadOffset, "Lowpan::Decompress failed");
+            VerifyOrQuit(message->GetOffset() == message->GetLength(), "Lowpan::Decompress failed");
+            VerifyOrQuit(memcmp(ip6, result, ip6Length) == 0, "Lowpan::Decompress failed");
         }
         else
         {
-            VerifyOrQuit(decompressedBytes < 0, "6lo: Lowpan::Decompress failed");
+            VerifyOrQuit(decompressedBytes < 0, "Lowpan::Decompress failed");
         }
 
         message->Free();
@@ -1849,22 +1847,22 @@ void TestLowpanMeshHeader(void)
     Lowpan::MeshHeader meshHeader;
 
     meshHeader.Init(kSourceAddr, kDestAddr, 1);
-    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "MeshHeader::GetSource() failed after Init()");
-    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "MeshHeader::GetDestination() failed after Init()");
-    VerifyOrQuit(meshHeader.GetHopsLeft() == 1, "MeshHeader::GetHopsLeft() failed after Init()");
+    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "failed after Init()");
+    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "failed after Init()");
+    VerifyOrQuit(meshHeader.GetHopsLeft() == 1, "failed after Init()");
 
     length = meshHeader.WriteTo(frame);
-    VerifyOrQuit(length == meshHeader.GetHeaderLength(), "MeshHeader::GetHeaderLength() failed");
+    VerifyOrQuit(length == meshHeader.GetHeaderLength());
     VerifyOrQuit(length == sizeof(kMeshHeader1), "MeshHeader::WriteTo() returned length is incorrect");
     VerifyOrQuit(memcmp(frame, kMeshHeader1, length) == 0, "MeshHeader::WriteTo() failed");
 
     memset(&meshHeader, 0, sizeof(meshHeader));
-    VerifyOrQuit(Lowpan::MeshHeader::IsMeshHeader(frame, length), "IsMeshHeader() failed");
-    SuccessOrQuit(meshHeader.ParseFrom(frame, length, headerLength), "MeshHeader::ParseFrom() failed");
+    VerifyOrQuit(Lowpan::MeshHeader::IsMeshHeader(frame, length));
+    SuccessOrQuit(meshHeader.ParseFrom(frame, length, headerLength));
     VerifyOrQuit(headerLength == length, "MeshHeader::ParseFrom() returned length is incorrect");
-    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "MeshHeader::GetSource() failed after ParseFrom()");
-    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "MeshHeader::GetDestination() failed after ParseFrom()");
-    VerifyOrQuit(meshHeader.GetHopsLeft() == 1, "MeshHeader::GetHopsLeft() failed after ParseFrom()");
+    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "failed after ParseFrom()");
+    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "failed after ParseFrom()");
+    VerifyOrQuit(meshHeader.GetHopsLeft() == 1, "failed after ParseFrom()");
 
     VerifyOrQuit(meshHeader.ParseFrom(frame, length - 1, headerLength) == kErrorParse,
                  "MeshHeader::ParseFrom() did not fail with incorrect length");
@@ -1872,36 +1870,35 @@ void TestLowpanMeshHeader(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - -
 
     meshHeader.Init(kSourceAddr, kDestAddr, 0x20);
-    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "MeshHeader::GetSource() failed after Init()");
-    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "MeshHeader::GetDestination() failed after Init()");
-    VerifyOrQuit(meshHeader.GetHopsLeft() == 0x20, "MeshHeader::GetHopsLeft() failed after Init()");
+    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "failed after Init()");
+    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "failed after Init()");
+    VerifyOrQuit(meshHeader.GetHopsLeft() == 0x20, "failed after Init()");
 
     length = meshHeader.WriteTo(frame);
     VerifyOrQuit(length == sizeof(kMeshHeader2), "MeshHeader::WriteTo() returned length is incorrect");
-    VerifyOrQuit(length == meshHeader.GetHeaderLength(), "MeshHeader::GetHeaderLength() failed");
+    VerifyOrQuit(length == meshHeader.GetHeaderLength());
     VerifyOrQuit(memcmp(frame, kMeshHeader2, length) == 0, "MeshHeader::WriteTo() failed");
 
     memset(&meshHeader, 0, sizeof(meshHeader));
-    VerifyOrQuit(Lowpan::MeshHeader::IsMeshHeader(frame, length), "IsMeshHeader() failed");
-    SuccessOrQuit(meshHeader.ParseFrom(frame, length, headerLength), "MeshHeader::ParseFrom() failed");
+    VerifyOrQuit(Lowpan::MeshHeader::IsMeshHeader(frame, length));
+    SuccessOrQuit(meshHeader.ParseFrom(frame, length, headerLength));
     VerifyOrQuit(headerLength == length, "MeshHeader::ParseFrom() returned length is incorrect");
-    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "MeshHeader::GetSource() failed after ParseFrom()");
-    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "MeshHeader::GetDestination() failed after ParseFrom()");
-    VerifyOrQuit(meshHeader.GetHopsLeft() == 0x20, "MeshHeader::GetHopsLeft() failed after ParseFrom()");
+    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "failed after ParseFrom()");
+    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "failed after ParseFrom()");
+    VerifyOrQuit(meshHeader.GetHopsLeft() == 0x20, "failed after ParseFrom()");
 
     VerifyOrQuit(meshHeader.ParseFrom(frame, length - 1, headerLength) == kErrorParse,
                  "MeshHeader::ParseFrom() did not fail with incorrect length");
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - -
 
-    SuccessOrQuit(meshHeader.ParseFrom(kMeshHeader3, sizeof(kMeshHeader3), headerLength),
-                  "MeshHeader::ParseFrom() failed");
+    SuccessOrQuit(meshHeader.ParseFrom(kMeshHeader3, sizeof(kMeshHeader3), headerLength));
     VerifyOrQuit(headerLength == sizeof(kMeshHeader3), "MeshHeader::ParseFrom() returned length is incorrect");
-    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "MeshHeader::GetSource() failed after Init()");
-    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "MeshHeader::GetDestination() failed after Init()");
-    VerifyOrQuit(meshHeader.GetHopsLeft() == 1, "MeshHeader::GetHopsLeft() failed after Init()");
+    VerifyOrQuit(meshHeader.GetSource() == kSourceAddr, "failed after ParseFrom()");
+    VerifyOrQuit(meshHeader.GetDestination() == kDestAddr, "failed after ParseFrom()");
+    VerifyOrQuit(meshHeader.GetHopsLeft() == 1, "failed after ParseFrom()");
 
-    VerifyOrQuit(meshHeader.WriteTo(frame) == sizeof(kMeshHeader1), "MeshHeader::WriteTo() failed");
+    VerifyOrQuit(meshHeader.WriteTo(frame) == sizeof(kMeshHeader1));
 
     VerifyOrQuit(meshHeader.ParseFrom(kMeshHeader3, sizeof(kMeshHeader3) - 1, headerLength) == kErrorParse,
                  "MeshHeader::ParseFrom() did not fail with incorrect length");
@@ -1931,9 +1928,9 @@ void TestLowpanFragmentHeader(void)
     Lowpan::FragmentHeader fragHeader;
 
     fragHeader.InitFirstFragment(kSize, kTag);
-    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "FragmentHeader::GetDatagramSize() failed after Init");
-    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "FragmentHeader::GetDatagramTag() failed after Init()");
-    VerifyOrQuit(fragHeader.GetDatagramOffset() == 0, "FragmentHeader::GetDatagramOffset() failed after Init()");
+    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "failed after Init");
+    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "failed after Init()");
+    VerifyOrQuit(fragHeader.GetDatagramOffset() == 0, "failed after Init()");
 
     length = fragHeader.WriteTo(frame);
     VerifyOrQuit(length == Lowpan::FragmentHeader::kFirstFragmentHeaderSize,
@@ -1942,12 +1939,12 @@ void TestLowpanFragmentHeader(void)
     VerifyOrQuit(memcmp(frame, kFragHeader1, length) == 0, "FragmentHeader::WriteTo() failed");
 
     memset(&fragHeader, 0, sizeof(fragHeader));
-    VerifyOrQuit(Lowpan::FragmentHeader::IsFragmentHeader(frame, length), "IsFragmentHeader() failed");
-    SuccessOrQuit(fragHeader.ParseFrom(frame, length, headerLength), "FragmentHeader::ParseFrom() failed");
+    VerifyOrQuit(Lowpan::FragmentHeader::IsFragmentHeader(frame, length));
+    SuccessOrQuit(fragHeader.ParseFrom(frame, length, headerLength));
     VerifyOrQuit(headerLength == length, "FragmentHeader::ParseFrom() returned length is incorrect");
-    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "FragmentHeader::GetDatagramSize() failed after ParseFrom()");
-    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "FragmentHeader::GetDatagramTag() failed after ParseFrom()");
-    VerifyOrQuit(fragHeader.GetDatagramOffset() == 0, "FragmentHeader::GetDatagramOffset() failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramOffset() == 0, "failed after ParseFrom()");
 
     VerifyOrQuit(fragHeader.ParseFrom(frame, length - 1, headerLength) == kErrorParse,
                  "FragmentHeader::ParseFrom() did not fail with incorrect length");
@@ -1955,9 +1952,9 @@ void TestLowpanFragmentHeader(void)
     //- - - - - - - - - - - - - - - - - - - - - - - - - -
 
     fragHeader.Init(kSize, kTag, kOffset);
-    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "FragmentHeader::GetDatagramSize() failed after Init");
-    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "FragmentHeader::GetDatagramTag() failed after Init()");
-    VerifyOrQuit(fragHeader.GetDatagramOffset() == kOffset, "FragmentHeader::GetDatagramOffset() failed after Init()");
+    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "failed after Init");
+    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "failed after Init()");
+    VerifyOrQuit(fragHeader.GetDatagramOffset() == kOffset, "failed after Init()");
 
     // Check the truncation of offset (to be multiple of 8).
     fragHeader.Init(kSize, kTag, kOffset + 1);
@@ -1972,13 +1969,12 @@ void TestLowpanFragmentHeader(void)
     VerifyOrQuit(memcmp(frame, kFragHeader2, length) == 0, "FragmentHeader::WriteTo() failed");
 
     memset(&fragHeader, 0, sizeof(fragHeader));
-    VerifyOrQuit(Lowpan::FragmentHeader::IsFragmentHeader(frame, length), "IsFragmentHeader() failed");
-    SuccessOrQuit(fragHeader.ParseFrom(frame, length, headerLength), "FragmentHeader::ParseFrom() failed");
+    VerifyOrQuit(Lowpan::FragmentHeader::IsFragmentHeader(frame, length));
+    SuccessOrQuit(fragHeader.ParseFrom(frame, length, headerLength));
     VerifyOrQuit(headerLength == length, "FragmentHeader::ParseFrom() returned length is incorrect");
-    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "FragmentHeader::GetDatagramSize() failed after ParseFrom()");
-    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "FragmentHeader::GetDatagramTag() failed after ParseFrom()");
-    VerifyOrQuit(fragHeader.GetDatagramOffset() == kOffset,
-                 "FragmentHeader::GetDatagramOffset() failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramOffset() == kOffset, "failed after ParseFrom()");
 
     VerifyOrQuit(fragHeader.ParseFrom(frame, length - 1, headerLength) == kErrorParse,
                  "FragmentHeader::ParseFrom() did not fail with incorrect length");
@@ -1987,11 +1983,11 @@ void TestLowpanFragmentHeader(void)
 
     length = sizeof(kFragHeader3);
     memcpy(frame, kFragHeader3, length);
-    SuccessOrQuit(fragHeader.ParseFrom(frame, length, headerLength), "FragmentHeader::ParseFrom() failed");
+    SuccessOrQuit(fragHeader.ParseFrom(frame, length, headerLength));
     VerifyOrQuit(headerLength == length, "FragmentHeader::ParseFrom() returned length is incorrect");
-    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "FragmentHeader::GetDatagramSize() failed after ParseFrom()");
-    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "FragmentHeader::GetDatagramTag() failed after ParseFrom()");
-    VerifyOrQuit(fragHeader.GetDatagramOffset() == 0, "FragmentHeader::GetDatagramOffset() failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramSize() == kSize, "failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramTag() == kTag, "failed after ParseFrom()");
+    VerifyOrQuit(fragHeader.GetDatagramOffset() == 0, "failed after ParseFrom()");
 
     VerifyOrQuit(fragHeader.ParseFrom(frame, length - 1, headerLength) == kErrorParse,
                  "FragmentHeader::ParseFrom() did not fail with incorrect length");

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -73,83 +73,83 @@ void TestMacAddress(void)
     VerifyOrQuit(!extAddr.IsGroup(), "Random Extended Address should not have its Group bit set");
 
     extAddr.CopyTo(buffer);
-    VerifyOrQuit(memcmp(extAddr.m8, buffer, OT_EXT_ADDRESS_SIZE) == 0, "ExtAddress::CopyTo() failed");
+    VerifyOrQuit(memcmp(extAddr.m8, buffer, OT_EXT_ADDRESS_SIZE) == 0);
 
     extAddr.CopyTo(buffer, Mac::ExtAddress::kReverseByteOrder);
-    VerifyOrQuit(CompareReversed(extAddr.m8, buffer, OT_EXT_ADDRESS_SIZE), "ExtAddress::CopyTo() failed");
+    VerifyOrQuit(CompareReversed(extAddr.m8, buffer, OT_EXT_ADDRESS_SIZE));
 
     extAddr.Set(kExtAddr);
-    VerifyOrQuit(memcmp(extAddr.m8, kExtAddr, OT_EXT_ADDRESS_SIZE) == 0, "ExtAddress::Set() failed");
+    VerifyOrQuit(memcmp(extAddr.m8, kExtAddr, OT_EXT_ADDRESS_SIZE) == 0);
 
     extAddr.Set(kExtAddr, Mac::ExtAddress::kReverseByteOrder);
-    VerifyOrQuit(CompareReversed(extAddr.m8, kExtAddr, OT_EXT_ADDRESS_SIZE), "ExtAddress::Set() failed");
+    VerifyOrQuit(CompareReversed(extAddr.m8, kExtAddr, OT_EXT_ADDRESS_SIZE));
 
     extAddr.SetLocal(true);
-    VerifyOrQuit(extAddr.IsLocal(), "ExtAddress::SetLocal() failed");
+    VerifyOrQuit(extAddr.IsLocal());
     extAddr.SetLocal(false);
-    VerifyOrQuit(!extAddr.IsLocal(), "ExtAddress::SetLocal() failed");
+    VerifyOrQuit(!extAddr.IsLocal());
     extAddr.ToggleLocal();
-    VerifyOrQuit(extAddr.IsLocal(), "ExtAddress::SetLocal() failed");
+    VerifyOrQuit(extAddr.IsLocal());
     extAddr.ToggleLocal();
-    VerifyOrQuit(!extAddr.IsLocal(), "ExtAddress::SetLocal() failed");
+    VerifyOrQuit(!extAddr.IsLocal());
 
     extAddr.SetGroup(true);
-    VerifyOrQuit(extAddr.IsGroup(), "ExtAddress::SetGroup() failed");
+    VerifyOrQuit(extAddr.IsGroup());
     extAddr.SetGroup(false);
-    VerifyOrQuit(!extAddr.IsGroup(), "ExtAddress::SetGroup() failed");
+    VerifyOrQuit(!extAddr.IsGroup());
     extAddr.ToggleGroup();
-    VerifyOrQuit(extAddr.IsGroup(), "ExtAddress::SetGroup() failed");
+    VerifyOrQuit(extAddr.IsGroup());
     extAddr.ToggleGroup();
-    VerifyOrQuit(!extAddr.IsGroup(), "ExtAddress::SetGroup() failed");
+    VerifyOrQuit(!extAddr.IsGroup());
 
     // Mac::Address
 
     VerifyOrQuit(addr.IsNone(), "Address constructor failed");
-    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeNone, "Address::GetType() failed");
+    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeNone);
 
     addr.SetShort(kShortAddr);
-    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeShort, "Address::GetType() failed");
+    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeShort);
     VerifyOrQuit(addr.IsShort(), "Address::SetShort() failed");
     VerifyOrQuit(!addr.IsExtended(), "Address::SetShort() failed");
-    VerifyOrQuit(addr.GetShort() == kShortAddr, "Address::GetShort() failed");
+    VerifyOrQuit(addr.GetShort() == kShortAddr);
 
     addr.SetExtended(extAddr);
-    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeExtended, "Address::GetType() failed");
+    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeExtended);
     VerifyOrQuit(!addr.IsShort(), "Address::SetExtended() failed");
     VerifyOrQuit(addr.IsExtended(), "Address::SetExtended() failed");
-    VerifyOrQuit(addr.GetExtended() == extAddr, "Address::GetExtended() failed");
+    VerifyOrQuit(addr.GetExtended() == extAddr);
 
     addr.SetExtended(extAddr.m8, Mac::ExtAddress::kReverseByteOrder);
-    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeExtended, "Address::GetType() failed");
+    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeExtended);
     VerifyOrQuit(!addr.IsShort(), "Address::SetExtended() failed");
     VerifyOrQuit(addr.IsExtended(), "Address::SetExtended() failed");
     VerifyOrQuit(CompareReversed(addr.GetExtended().m8, extAddr.m8, OT_EXT_ADDRESS_SIZE),
                  "Address::SetExtended() reverse byte order failed");
 
     addr.SetNone();
-    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeNone, "Address::GetType() failed");
+    VerifyOrQuit(addr.GetType() == Mac::Address::kTypeNone);
     VerifyOrQuit(addr.IsNone(), "Address:SetNone() failed");
     VerifyOrQuit(!addr.IsShort(), "Address::SetNone() failed");
     VerifyOrQuit(!addr.IsExtended(), "Address::SetNone() failed");
 
-    VerifyOrQuit(!addr.IsBroadcast(), "Address:IsBroadcast() failed");
-    VerifyOrQuit(!addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed");
+    VerifyOrQuit(!addr.IsBroadcast(), "Address:SetNone() failed");
+    VerifyOrQuit(!addr.IsShortAddrInvalid());
 
     addr.SetExtended(extAddr);
-    VerifyOrQuit(!addr.IsBroadcast(), "Address:IsBroadcast() failed");
-    VerifyOrQuit(!addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed");
+    VerifyOrQuit(!addr.IsBroadcast());
+    VerifyOrQuit(!addr.IsShortAddrInvalid());
 
     addr.SetShort(kShortAddr);
-    VerifyOrQuit(!addr.IsBroadcast(), "Address:IsBroadcast() failed");
-    VerifyOrQuit(!addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed");
+    VerifyOrQuit(!addr.IsBroadcast());
+    VerifyOrQuit(!addr.IsShortAddrInvalid());
 
     addr.SetShort(Mac::kShortAddrBroadcast);
-    VerifyOrQuit(addr.IsBroadcast(), "Address:IsBroadcast() failed");
-    VerifyOrQuit(!addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed");
+    VerifyOrQuit(addr.IsBroadcast());
+    VerifyOrQuit(!addr.IsShortAddrInvalid());
 
     addr.SetShort(Mac::kShortAddrInvalid);
-    VerifyOrQuit(!addr.IsBroadcast(), "Address:IsBroadcast() failed");
-    VerifyOrQuit(addr.IsShortAddrInvalid(), "Address:IsShortAddrInvalid() failed");
+    VerifyOrQuit(!addr.IsBroadcast());
+    VerifyOrQuit(addr.IsShortAddrInvalid());
 
     testFreeInstance(instance);
 }
@@ -158,11 +158,10 @@ void CompareNetworkName(const Mac::NetworkName &aNetworkName, const char *aNameS
 {
     uint8_t len = static_cast<uint8_t>(strlen(aNameString));
 
-    VerifyOrQuit(strcmp(aNetworkName.GetAsCString(), aNameString) == 0, "NetworkName does not match expected value");
+    VerifyOrQuit(strcmp(aNetworkName.GetAsCString(), aNameString) == 0);
 
-    VerifyOrQuit(aNetworkName.GetAsData().GetLength() == len, "NetworkName:GetAsData().GetLength() is incorrect");
-    VerifyOrQuit(memcmp(aNetworkName.GetAsData().GetBuffer(), aNameString, len) == 0,
-                 "NetworkName:GetAsData().GetBuffer() is incorrect");
+    VerifyOrQuit(aNetworkName.GetAsData().GetLength() == len);
+    VerifyOrQuit(memcmp(aNetworkName.GetAsData().GetBuffer(), aNameString, len) == 0);
 }
 
 void TestMacNetworkName(void)
@@ -179,35 +178,34 @@ void TestMacNetworkName(void)
 
     CompareNetworkName(networkName, kEmptyName);
 
-    SuccessOrQuit(networkName.Set(Mac::NameData(kName1, sizeof(kName1))), "NetworkName::Set() failed");
+    SuccessOrQuit(networkName.Set(Mac::NameData(kName1, sizeof(kName1))));
     CompareNetworkName(networkName, kName1);
 
-    VerifyOrQuit(networkName.Set(Mac::NameData(kName1, sizeof(kName1))) == kErrorAlready,
-                 "NetworkName::Set() accepted same name without returning kErrorAlready");
+    VerifyOrQuit(networkName.Set(Mac::NameData(kName1, sizeof(kName1))) == kErrorAlready, "failed to detect duplicate");
     CompareNetworkName(networkName, kName1);
 
     VerifyOrQuit(networkName.Set(Mac::NameData(kName1, sizeof(kName1) - 1)) == kErrorAlready,
-                 "NetworkName::Set() accepted same name without returning kErrorAlready");
+                 "failed to detect duplicate");
 
-    SuccessOrQuit(networkName.Set(Mac::NameData(kName2, sizeof(kName2))), "NetworkName::Set() failed");
+    SuccessOrQuit(networkName.Set(Mac::NameData(kName2, sizeof(kName2))));
     CompareNetworkName(networkName, kName2);
 
-    SuccessOrQuit(networkName.Set(Mac::NameData(kEmptyName, 0)), "NetworkName::Set() failed");
+    SuccessOrQuit(networkName.Set(Mac::NameData(kEmptyName, 0)));
     CompareNetworkName(networkName, kEmptyName);
 
-    SuccessOrQuit(networkName.Set(Mac::NameData(kLongName, sizeof(kLongName))), "NetworkName::Set() failed");
+    SuccessOrQuit(networkName.Set(Mac::NameData(kLongName, sizeof(kLongName))));
     CompareNetworkName(networkName, kLongName);
 
     VerifyOrQuit(networkName.Set(Mac::NameData(kLongName, sizeof(kLongName) - 1)) == kErrorAlready,
-                 "NetworkName::Set() accepted same name without returning kErrorAlready");
+                 "failed to detect duplicate");
 
-    SuccessOrQuit(networkName.Set(Mac::NameData(nullptr, 0)), "NetworkName::Set() failed");
+    SuccessOrQuit(networkName.Set(Mac::NameData(nullptr, 0)));
     CompareNetworkName(networkName, kEmptyName);
 
-    SuccessOrQuit(networkName.Set(Mac::NameData(kName1, sizeof(kName1))), "NetworkName::Set() failed");
+    SuccessOrQuit(networkName.Set(Mac::NameData(kName1, sizeof(kName1))));
 
     VerifyOrQuit(networkName.Set(Mac::NameData(kTooLongName, sizeof(kTooLongName))) == kErrorInvalidArgs,
-                 "NetworkName::Set() accepted an invalid (too long) name");
+                 "accepted an invalid (too long) name");
 
     CompareNetworkName(networkName, kName1);
 
@@ -280,9 +278,9 @@ void TestMacHeader(void)
         frame.mRadioType = 0;
 
         frame.InitMacHeader(test.fcf, test.secCtl);
-        VerifyOrQuit(frame.GetHeaderLength() == test.headerLength, "MacHeader test failed");
-        VerifyOrQuit(frame.GetFooterLength() == test.footerLength, "MacHeader test failed");
-        VerifyOrQuit(frame.GetLength() == test.headerLength + test.footerLength, "MacHeader test failed");
+        VerifyOrQuit(frame.GetHeaderLength() == test.headerLength);
+        VerifyOrQuit(frame.GetFooterLength() == test.footerLength);
+        VerifyOrQuit(frame.GetLength() == test.headerLength + test.footerLength);
     }
 }
 
@@ -298,11 +296,11 @@ void VerifyChannelMaskContent(const Mac::ChannelMask &aMask, uint8_t *aChannels,
             if (channel == aChannels[index])
             {
                 index++;
-                VerifyOrQuit(aMask.ContainsChannel(channel), "ChannelMask.ContainsChannel() failed");
+                VerifyOrQuit(aMask.ContainsChannel(channel));
             }
             else
             {
-                VerifyOrQuit(!aMask.ContainsChannel(channel), "ChannelMask.ContainsChannel() failed");
+                VerifyOrQuit(!aMask.ContainsChannel(channel));
             }
         }
     }
@@ -319,14 +317,14 @@ void VerifyChannelMaskContent(const Mac::ChannelMask &aMask, uint8_t *aChannels,
 
     if (aLength == 1)
     {
-        VerifyOrQuit(aMask.IsSingleChannel(), "ChannelMask.IsSingleChannel() failed");
+        VerifyOrQuit(aMask.IsSingleChannel());
     }
     else
     {
-        VerifyOrQuit(!aMask.IsSingleChannel(), "ChannelMask.IsSingleChannel() failed");
+        VerifyOrQuit(!aMask.IsSingleChannel());
     }
 
-    VerifyOrQuit(aLength == aMask.GetNumberOfChannels(), "ChannelMask.GetNumberOfChannels() failed");
+    VerifyOrQuit(aLength == aMask.GetNumberOfChannels());
 }
 
 void TestMacChannelMask(void)
@@ -349,18 +347,18 @@ void TestMacChannelMask(void)
 
     printf("Testing Mac::ChannelMask\n");
 
-    VerifyOrQuit(mask1.IsEmpty(), "ChannelMask::IsEmpty failed");
+    VerifyOrQuit(mask1.IsEmpty());
     printf("empty = %s\n", mask1.ToString().AsCString());
-    VerifyOrQuit(strcmp(mask1.ToString().AsCString(), kEmptyMaskString) == 0, "ChannelMask::ToString() failed");
+    VerifyOrQuit(strcmp(mask1.ToString().AsCString(), kEmptyMaskString) == 0);
 
-    VerifyOrQuit(!mask2.IsEmpty(), "ChannelMask::IsEmpty failed");
-    VerifyOrQuit(mask2.GetMask() == Radio::kSupportedChannels, "ChannelMask::GetMask() failed");
+    VerifyOrQuit(!mask2.IsEmpty());
+    VerifyOrQuit(mask2.GetMask() == Radio::kSupportedChannels);
     printf("allChannels = %s\n", mask2.ToString().AsCString());
-    VerifyOrQuit(strcmp(mask2.ToString().AsCString(), kAllChannelsString) == 0, "ChannelMask::ToString() failed");
+    VerifyOrQuit(strcmp(mask2.ToString().AsCString(), kAllChannelsString) == 0);
 
     mask1.SetMask(Radio::kSupportedChannels);
-    VerifyOrQuit(!mask1.IsEmpty(), "ChannelMask::IsEmpty failed");
-    VerifyOrQuit(mask1.GetMask() == Radio::kSupportedChannels, "ChannelMask::GetMask() failed");
+    VerifyOrQuit(!mask1.IsEmpty());
+    VerifyOrQuit(mask1.GetMask() == Radio::kSupportedChannels);
 
     VerifyChannelMaskContent(mask1, allChannels, sizeof(allChannels));
 
@@ -372,7 +370,7 @@ void TestMacChannelMask(void)
     }
 
     mask1.Clear();
-    VerifyOrQuit(mask1.IsEmpty(), "ChannelMask::IsEmpty failed");
+    VerifyOrQuit(mask1.IsEmpty());
     VerifyChannelMaskContent(mask1, nullptr, 0);
 
     for (uint8_t channel : channels1)
@@ -381,9 +379,9 @@ void TestMacChannelMask(void)
     }
 
     printf("channels1 = %s\n", mask1.ToString().AsCString());
-    VerifyOrQuit(strcmp(mask1.ToString().AsCString(), kChannels1String) == 0, "ChannelMask::ToString() failed");
+    VerifyOrQuit(strcmp(mask1.ToString().AsCString(), kChannels1String) == 0);
 
-    VerifyOrQuit(!mask1.IsEmpty(), "ChannelMask::IsEmpty failed");
+    VerifyOrQuit(!mask1.IsEmpty());
     VerifyChannelMaskContent(mask1, channels1, sizeof(channels1));
 
     mask2.Clear();
@@ -394,33 +392,33 @@ void TestMacChannelMask(void)
     }
 
     printf("channels2 = %s\n", mask2.ToString().AsCString());
-    VerifyOrQuit(strcmp(mask2.ToString().AsCString(), kChannels2String) == 0, "ChannelMask::ToString() failed");
+    VerifyOrQuit(strcmp(mask2.ToString().AsCString(), kChannels2String) == 0);
 
-    VerifyOrQuit(!mask2.IsEmpty(), "ChannelMask::IsEmpty failed");
+    VerifyOrQuit(!mask2.IsEmpty());
     VerifyChannelMaskContent(mask2, channels2, sizeof(channels2));
 
     mask1.Intersect(mask2);
     VerifyChannelMaskContent(mask1, channels3, sizeof(channels3));
     printf("channels3 = %s\n", mask1.ToString().AsCString());
-    VerifyOrQuit(strcmp(mask1.ToString().AsCString(), kChannels3String) == 0, "ChannelMask::ToString() failed");
+    VerifyOrQuit(strcmp(mask1.ToString().AsCString(), kChannels3String) == 0);
 
     mask2.Clear();
     mask2.AddChannel(channles4[0]);
     VerifyChannelMaskContent(mask2, channles4, sizeof(channles4));
 
     printf("channels4 = %s\n", mask2.ToString().AsCString());
-    VerifyOrQuit(strcmp(mask2.ToString().AsCString(), kChannels4String) == 0, "ChannelMask::ToString() failed");
+    VerifyOrQuit(strcmp(mask2.ToString().AsCString(), kChannels4String) == 0);
 
     mask1.Clear();
     mask2.Clear();
-    VerifyOrQuit(mask1 == mask2, "ChannelMask::operator== failed");
+    VerifyOrQuit(mask1 == mask2);
 
     mask1.SetMask(Radio::kSupportedChannels);
     mask2.SetMask(Radio::kSupportedChannels);
-    VerifyOrQuit(mask1 == mask2, "ChannelMask::operator== failed");
+    VerifyOrQuit(mask1 == mask2);
 
     mask1.Clear();
-    VerifyOrQuit(mask1 != mask2, "ChannelMask::operator== failed");
+    VerifyOrQuit(mask1 != mask2);
 }
 
 void TestMacFrameApi(void)
@@ -438,7 +436,6 @@ void TestMacFrameApi(void)
     uint8_t mac_cmd_psdu2[] = {0x6b, 0xaa, 0x8d, 0xce, 0xfa, 0x00, 0x68, 0x01, 0x68, 0x0d,
                                0x08, 0x00, 0x00, 0x00, 0x01, 0x04, 0x0d, 0xed, 0x0b, 0x35,
                                0x0c, 0x80, 0x3f, 0x04, 0x4b, 0x88, 0x89, 0xd6, 0x59, 0xe1};
-    Error   error;
     uint8_t scf; // SecurityControlField
 #endif
 
@@ -458,16 +455,16 @@ void TestMacFrameApi(void)
     //   FCS: 0x9bd2 (Correct)
     frame.mPsdu   = ack_psdu1;
     frame.mLength = sizeof(ack_psdu1);
-    VerifyOrQuit(frame.GetType() == Mac::Frame::kFcfFrameAck, "Mac::Frame::GetType() failed\n");
-    VerifyOrQuit(frame.GetSecurityEnabled() == false, "Mac::Frame::GetSecurityEnabled() failed\n");
-    VerifyOrQuit(frame.GetFramePending() == false, "Mac::Frame::GetFramePendIng() failed\n");
-    VerifyOrQuit(frame.GetAckRequest() == false, "Mac::Frame::GetAckRequest failed\n");
-    VerifyOrQuit(frame.IsIePresent() == false, "Mac::Frame::IsIePresent failed\n");
-    VerifyOrQuit(frame.IsDstPanIdPresent() == false, "Mac::Frame::IsDstPanIdPresent failed\n");
-    VerifyOrQuit(frame.IsDstAddrPresent() == false, "Mac::Frame::IsDstAddrPresent failed\n");
-    VerifyOrQuit(frame.GetVersion() == Mac::Frame::kFcfFrameVersion2006, "Mac::Frame::GetVersion failed\n");
-    VerifyOrQuit(frame.IsSrcAddrPresent() == false, "Mac::Frame::IsSrcAddrPresent failed\n");
-    VerifyOrQuit(frame.GetSequence() == 94, "Mac::Frame::GetSequence failed\n");
+    VerifyOrQuit(frame.GetType() == Mac::Frame::kFcfFrameAck);
+    VerifyOrQuit(!frame.GetSecurityEnabled());
+    VerifyOrQuit(!frame.GetFramePending());
+    VerifyOrQuit(!frame.GetAckRequest());
+    VerifyOrQuit(!frame.IsIePresent());
+    VerifyOrQuit(!frame.IsDstPanIdPresent());
+    VerifyOrQuit(!frame.IsDstAddrPresent());
+    VerifyOrQuit(frame.GetVersion() == Mac::Frame::kFcfFrameVersion2006);
+    VerifyOrQuit(!frame.IsSrcAddrPresent());
+    VerifyOrQuit(frame.GetSequence() == 94);
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
     // IEEE 802.15.4-2015 Data
@@ -479,17 +476,15 @@ void TestMacFrameApi(void)
     //     Security Control Field: 0x0d
     frame.mPsdu   = data_psdu1;
     frame.mLength = sizeof(data_psdu1);
-    VerifyOrQuit(frame.IsVersion2015() == true, "Mac::Frame::IsVersion2015 failed\n");
-    VerifyOrQuit(frame.IsDstPanIdPresent() == true, "Mac::Frame::IsDstPanIdPresent failed\n");
-    VerifyOrQuit(frame.IsDstAddrPresent() == true, "Mac::Frame::IsDstAddrPresent failed\n");
-    VerifyOrQuit(frame.IsSrcAddrPresent() == true, "Mac::Frame::IsSrcAddrPresent failed\n");
-    VerifyOrQuit((error = frame.GetSecurityControlField(scf)) == kErrorNone,
-                 "Mac::Frame::GetSecurityControlField failed\n");
-    VerifyOrQuit(scf == 0x0d, "Mac::Frame::GetSecurityControlField value failed\n");
+    VerifyOrQuit(frame.IsVersion2015());
+    VerifyOrQuit(frame.IsDstPanIdPresent());
+    VerifyOrQuit(frame.IsDstAddrPresent());
+    VerifyOrQuit(frame.IsSrcAddrPresent());
+    SuccessOrQuit(frame.GetSecurityControlField(scf));
+    VerifyOrQuit(scf == 0x0d);
     frame.SetSecurityControlField(0xff);
-    VerifyOrQuit((error = frame.GetSecurityControlField(scf)) == kErrorNone,
-                 "Mac::Frame::GetSecurityControlField failed\n");
-    VerifyOrQuit(scf == 0xff, "Mac::Frame::SetSecurityControlField value failed\n");
+    SuccessOrQuit(frame.GetSecurityControlField(scf));
+    VerifyOrQuit(scf == 0xff);
 #endif // OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 
     // IEEE 802.15.4-2006 Mac Command
@@ -498,15 +493,14 @@ void TestMacFrameApi(void)
     uint8_t commandId;
     frame.mPsdu   = mac_cmd_psdu1;
     frame.mLength = sizeof(mac_cmd_psdu1);
-    VerifyOrQuit(frame.GetSequence() == 133, "Mac::Frame::GetSequence failed\n");
-    VerifyOrQuit(frame.GetVersion() == Mac::Frame::kFcfFrameVersion2006, "Mac::Frame::GetVersion failed\n");
-    VerifyOrQuit(frame.GetType() == Mac::Frame::kFcfFrameMacCmd, "Mac::Frame::GetType failed\n");
-    VerifyOrQuit(frame.GetCommandId(commandId) == kErrorNone, "Mac::Frame::GetCommandId failed\n");
-    VerifyOrQuit(commandId == Mac::Frame::kMacCmdDataRequest, "Mac::Frame::GetCommandId value not correct\n");
-    VerifyOrQuit(frame.SetCommandId(Mac::Frame::kMacCmdBeaconRequest) == kErrorNone,
-                 "Mac::Frame::SetCommandId failed\n");
-    VerifyOrQuit(frame.GetCommandId(commandId) == kErrorNone, "Mac::Frame::GetCommandId failed\n");
-    VerifyOrQuit(commandId == Mac::Frame::kMacCmdBeaconRequest, "Mac::Frame::SetCommandId value not correct\n");
+    VerifyOrQuit(frame.GetSequence() == 133);
+    VerifyOrQuit(frame.GetVersion() == Mac::Frame::kFcfFrameVersion2006);
+    VerifyOrQuit(frame.GetType() == Mac::Frame::kFcfFrameMacCmd);
+    SuccessOrQuit(frame.GetCommandId(commandId));
+    VerifyOrQuit(commandId == Mac::Frame::kMacCmdDataRequest);
+    SuccessOrQuit(frame.SetCommandId(Mac::Frame::kMacCmdBeaconRequest));
+    SuccessOrQuit(frame.GetCommandId(commandId));
+    VerifyOrQuit(commandId == Mac::Frame::kMacCmdBeaconRequest);
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
     // IEEE 802.15.4-2015 Mac Command
@@ -517,16 +511,15 @@ void TestMacFrameApi(void)
     //   Command Identifier: Data Request (0x04)
     frame.mPsdu   = mac_cmd_psdu2;
     frame.mLength = sizeof(mac_cmd_psdu2);
-    VerifyOrQuit(frame.GetSequence() == 141, "Mac::Frame::GetSequence failed\n");
-    VerifyOrQuit(frame.IsVersion2015() == true, "Mac::Frame::IsVersion2015 failed\n");
-    VerifyOrQuit(frame.GetType() == Mac::Frame::kFcfFrameMacCmd, "Mac::Frame::GetVersion failed\n");
-    VerifyOrQuit(frame.GetCommandId(commandId) == kErrorNone, "Mac::Frame::GetCommandId failed\n");
-    VerifyOrQuit(commandId == Mac::Frame::kMacCmdDataRequest, "Mac::Frame::GetCommandId value not correct\n");
+    VerifyOrQuit(frame.GetSequence() == 141);
+    VerifyOrQuit(frame.IsVersion2015());
+    VerifyOrQuit(frame.GetType() == Mac::Frame::kFcfFrameMacCmd);
+    SuccessOrQuit(frame.GetCommandId(commandId));
+    VerifyOrQuit(commandId == Mac::Frame::kMacCmdDataRequest);
     printf("commandId:%d\n", commandId);
-    VerifyOrQuit(frame.SetCommandId(Mac::Frame::kMacCmdOrphanNotification) == kErrorNone,
-                 "Mac::Frame::SetCommandId failed\n");
-    VerifyOrQuit(frame.GetCommandId(commandId) == kErrorNone, "Mac::Frame::GetCommandId failed\n");
-    VerifyOrQuit(commandId == Mac::Frame::kMacCmdOrphanNotification, "Mac::Frame::SetCommandId value not correct\n");
+    SuccessOrQuit(frame.SetCommandId(Mac::Frame::kMacCmdOrphanNotification));
+    SuccessOrQuit(frame.GetCommandId(commandId));
+    VerifyOrQuit(commandId == Mac::Frame::kMacCmdOrphanNotification);
 
 #endif
 }
@@ -568,25 +561,18 @@ void TestMacFrameAckGeneration(void)
     receivedFrame.mLength = sizeof(data_psdu1);
 
     ackFrame.GenerateImmAck(receivedFrame, false);
-    VerifyOrQuit(ackFrame.mLength == Mac::Frame::kImmAckLength,
-                 "Mac::Frame::GenerateImmAck() failed, length incorrect\n");
-    VerifyOrQuit(ackFrame.GetType() == Mac::Frame::kFcfFrameAck,
-                 "Mac::Frame::GenerateImmAck() failed, GetType() incorrect\n");
-    VerifyOrQuit(ackFrame.GetSecurityEnabled() == false,
-                 "Mac::Frame::GenerateImmAck failed, GetSecurityEnabled() incorrect\n");
-    VerifyOrQuit(ackFrame.GetFramePending() == false,
-                 "Mac::Frame::GenerateImmAck failed, GetFramePending() incorrect\n");
-    VerifyOrQuit(ackFrame.GetAckRequest() == false, "Mac::Frame::GenerateImmAck failed, GetAckRequest() incorrect\n");
-    VerifyOrQuit(ackFrame.IsIePresent() == false, "Mac::Frame::GenerateImmAck failed, IsIePresent() incorrect\n");
-    VerifyOrQuit(ackFrame.IsDstPanIdPresent() == false,
-                 "Mac::Frame::GenerateImmAck failed, IsDstPanIdPresent() incorrect\n");
-    VerifyOrQuit(ackFrame.IsDstAddrPresent() == false,
-                 "Mac::Frame::GenerateImmAck failed, IsDstAddrPresent() incorrect\n");
-    VerifyOrQuit(ackFrame.IsSrcAddrPresent() == false,
-                 "Mac::Frame::GenerateImmAck failed, IsSrcAddrPresent() incorrect\n");
-    VerifyOrQuit(ackFrame.GetVersion() == Mac::Frame::kFcfFrameVersion2006,
-                 "Mac::Frame::GenerateImmAck failed, GetVersion() incorrect\n");
-    VerifyOrQuit(ackFrame.GetSequence() == 189, "Mac::Frame::GenerateImmAck failed, GetSequence() incorrect\n");
+    VerifyOrQuit(ackFrame.mLength == Mac::Frame::kImmAckLength);
+    VerifyOrQuit(ackFrame.GetType() == Mac::Frame::kFcfFrameAck);
+    VerifyOrQuit(!ackFrame.GetSecurityEnabled());
+    VerifyOrQuit(!ackFrame.GetFramePending());
+
+    VerifyOrQuit(!ackFrame.GetAckRequest());
+    VerifyOrQuit(!ackFrame.IsIePresent());
+    VerifyOrQuit(!ackFrame.IsDstPanIdPresent());
+    VerifyOrQuit(!ackFrame.IsDstAddrPresent());
+    VerifyOrQuit(!ackFrame.IsSrcAddrPresent());
+    VerifyOrQuit(ackFrame.GetVersion() == Mac::Frame::kFcfFrameVersion2006);
+    VerifyOrQuit(ackFrame.GetSequence() == 189);
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
     // Received Frame 2
@@ -635,29 +621,21 @@ void TestMacFrameAckGeneration(void)
 
     IgnoreError(ackFrame.GenerateEnhAck(receivedFrame, false, ie_data, sizeof(ie_data)));
     csl = reinterpret_cast<Mac::CslIe *>(ackFrame.GetHeaderIe(Mac::CslIe::kHeaderIeId) + sizeof(Mac::HeaderIe));
-    VerifyOrQuit(ackFrame.mLength == 23,
-                 "Mac::Frame::GenerateEnhAck() failed, length incorrect\n"); // 23 is the length of the correct ack
-    VerifyOrQuit(ackFrame.GetType() == Mac::Frame::kFcfFrameAck,
-                 "Mac::Frame::GenerateEnhAck() failed, GetType() incorrect\n");
-    VerifyOrQuit(ackFrame.GetSecurityEnabled() == true,
-                 "Mac::Frame::GenerateEnhAck failed, GetSecurityEnabled() incorrect\n");
-    VerifyOrQuit(ackFrame.IsIePresent() == true, "Mac::Frame::GenerateEnhAck failed, IsIePresent() incorrect\n");
-    VerifyOrQuit(ackFrame.IsDstPanIdPresent() == false,
-                 "Mac::Frame::GenerateEnhAck failed, IsDstPanIdPresent() incorrect\n");
-    VerifyOrQuit(ackFrame.IsDstAddrPresent() == true,
-                 "Mac::Frame::GenerateEnhAck failed, IsDstAddrPresent() incorrect\n");
-    VerifyOrQuit(ackFrame.IsSrcAddrPresent() == false,
-                 "Mac::Frame::GenerateEnhAck failed, IsSrcAddrPresent() incorrect\n");
-    VerifyOrQuit(ackFrame.GetVersion() == Mac::Frame::kFcfFrameVersion2015,
-                 "Mac::Frame::GenerateEnhAck failed, GetVersion() incorrect\n");
-    VerifyOrQuit(ackFrame.GetSequence() == 142, "Mac::Frame::GenerateEnhAck failed, GetSequence() incorrect\n");
-    VerifyOrQuit(csl->GetPeriod() == 3125 && csl->GetPhase() == 3105,
-                 "Mac::Frame::GenerateEnhAck failed, CslIe incorrect\n");
+    VerifyOrQuit(ackFrame.mLength == 23);
+    VerifyOrQuit(ackFrame.GetType() == Mac::Frame::kFcfFrameAck);
+    VerifyOrQuit(ackFrame.GetSecurityEnabled());
+    VerifyOrQuit(ackFrame.IsIePresent());
+    VerifyOrQuit(!ackFrame.IsDstPanIdPresent());
+    VerifyOrQuit(ackFrame.IsDstAddrPresent());
+    VerifyOrQuit(!ackFrame.IsSrcAddrPresent());
+    VerifyOrQuit(ackFrame.GetVersion() == Mac::Frame::kFcfFrameVersion2015);
+    VerifyOrQuit(ackFrame.GetSequence() == 142);
+    VerifyOrQuit(csl->GetPeriod() == 3125 && csl->GetPhase() == 3105);
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     ackFrame.SetCslIe(123, 456);
     csl = reinterpret_cast<Mac::CslIe *>(ackFrame.GetHeaderIe(Mac::CslIe::kHeaderIeId) + sizeof(Mac::HeaderIe));
-    VerifyOrQuit(csl->GetPeriod() == 123 && csl->GetPhase() == 456, "Mac::Frame::SetCslIe failed, CslIe incorrect\n");
+    VerifyOrQuit(csl->GetPeriod() == 123 && csl->GetPhase() == 456);
 #endif
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 }

--- a/tests/unit/test_macros.cpp
+++ b/tests/unit/test_macros.cpp
@@ -84,36 +84,36 @@ void TestMacros(void)
 {
     // Verify `OT_FIRST_ARG()` macro.
 
-    VerifyOrQuit(OT_FIRST_ARG(1) == 1, "OT_FIRST_ARG() failed");
-    VerifyOrQuit(OT_FIRST_ARG(1, 2, 3) == 1, "OT_FIRST_ARG() failed");
-    VerifyOrQuit(OT_FIRST_ARG(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12) == 1, "OT_FIRST_ARG() failed");
+    VerifyOrQuit(OT_FIRST_ARG(1) == 1);
+    VerifyOrQuit(OT_FIRST_ARG(1, 2, 3) == 1);
+    VerifyOrQuit(OT_FIRST_ARG(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12) == 1);
 
     // Verify `OT_REST_ARGS()` macro.
 
-    VerifyOrQuit(NumberOfArgs(OT_REST_ARGS(1)) == 0, "OT_REST_ARGS() failed for empty");
+    VerifyOrQuit(NumberOfArgs(OT_REST_ARGS(1)) == 0);
 
-    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1)) == 1, "OT_REST_ARGS() failed");
-    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1, 2)) == 2, "OT_REST_ARGS() failed");
-    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1, 2, 3)) == 3, "OT_REST_ARGS() failed");
-    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1, 2, 3, 4)) == 4, "OT_REST_ARGS() failed");
-    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1, 2, 3, 4, 5)) == 5, "OT_REST_ARGS() failed");
-    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1, 2, 3, 4, 5, 6)) == 6, "OT_REST_ARGS() failed");
-    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1, 2, 3, 4, 5, 6, 7)) == 7, "OT_REST_ARGS() failed");
+    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1)) == 1);
+    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1, 2)) == 2);
+    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1, 2, 3)) == 3);
+    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1, 2, 3, 4)) == 4);
+    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1, 2, 3, 4, 5)) == 5);
+    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1, 2, 3, 4, 5, 6)) == 6);
+    VerifyOrQuit(NumberOfArgs(0 OT_REST_ARGS(1, 2, 3, 4, 5, 6, 7)) == 7);
 
-    VerifyOrQuit(Sum(100 OT_REST_ARGS(1)) == 100, "OT_REST_ARGS() failed");
-    VerifyOrQuit(Sum(100 OT_REST_ARGS(1, 2)) == 102, "OT_REST_ARGS() failed");
-    VerifyOrQuit(Sum(100 OT_REST_ARGS(1, 2, 3)) == 105, "OT_REST_ARGS() failed");
-    VerifyOrQuit(Sum(100 OT_REST_ARGS(1, 2, 3, 4)) == 109, "OT_REST_ARGS() failed");
-    VerifyOrQuit(Sum(100 OT_REST_ARGS(1, 2, 3, 4, 5)) == 114, "OT_REST_ARGS() failed");
-    VerifyOrQuit(Sum(100 OT_REST_ARGS(1, 2, 3, 4, 5, 6)) == 120, "OT_REST_ARGS() failed");
-    VerifyOrQuit(Sum(100 OT_REST_ARGS(1, 2, 3, 4, 5, 6, 7)) == 127, "OT_REST_ARGS() failed");
+    VerifyOrQuit(Sum(100 OT_REST_ARGS(1)) == 100);
+    VerifyOrQuit(Sum(100 OT_REST_ARGS(1, 2)) == 102);
+    VerifyOrQuit(Sum(100 OT_REST_ARGS(1, 2, 3)) == 105);
+    VerifyOrQuit(Sum(100 OT_REST_ARGS(1, 2, 3, 4)) == 109);
+    VerifyOrQuit(Sum(100 OT_REST_ARGS(1, 2, 3, 4, 5)) == 114);
+    VerifyOrQuit(Sum(100 OT_REST_ARGS(1, 2, 3, 4, 5, 6)) == 120);
+    VerifyOrQuit(Sum(100 OT_REST_ARGS(1, 2, 3, 4, 5, 6, 7)) == 127);
 
     // Verify `OT_SECOND_ARG()` macro.
 
-    VerifyOrQuit(NumberOfArgs(OT_SECOND_ARG(1)) == 0, "OT_SECOND_ARG() failed");
-    VerifyOrQuit(NumberOfArgs(OT_SECOND_ARG(1, 2)) == 1, "OT_SECOND_ARG() failed");
+    VerifyOrQuit(NumberOfArgs(OT_SECOND_ARG(1)) == 0);
+    VerifyOrQuit(NumberOfArgs(OT_SECOND_ARG(1, 2)) == 1);
 
-    VerifyOrQuit(OT_SECOND_ARG(1, 2) == 2, "OT_SECOND_ARG() failed");
+    VerifyOrQuit(OT_SECOND_ARG(1, 2) == 2);
 }
 
 void TestVerifyOrExitSuccessNoAction(void)

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -56,20 +56,20 @@ void TestMessage(void)
     memset(zeroBuffer, 0, sizeof(zeroBuffer));
 
     instance = static_cast<Instance *>(testInitInstance());
-    VerifyOrQuit(instance != nullptr, "Null OpenThread instance\n");
+    VerifyOrQuit(instance != nullptr);
 
     messagePool = &instance->Get<MessagePool>();
 
     Random::NonCrypto::FillBuffer(writeBuffer, kMaxSize);
 
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr, "Message::New failed");
-    SuccessOrQuit(message->SetLength(kMaxSize), "Message::SetLength failed");
+    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
+    SuccessOrQuit(message->SetLength(kMaxSize));
     message->WriteBytes(0, writeBuffer, kMaxSize);
-    SuccessOrQuit(message->Read(0, readBuffer, kMaxSize), "Message::Read failed");
-    VerifyOrQuit(memcmp(writeBuffer, readBuffer, kMaxSize) == 0, "Message compare failed");
-    VerifyOrQuit(message->CompareBytes(0, readBuffer, kMaxSize), "Message::CompareBytes failed");
-    VerifyOrQuit(message->Compare(0, readBuffer), "Message::Compare failed");
-    VerifyOrQuit(message->GetLength() == kMaxSize, "Message::GetLength failed");
+    SuccessOrQuit(message->Read(0, readBuffer, kMaxSize));
+    VerifyOrQuit(memcmp(writeBuffer, readBuffer, kMaxSize) == 0);
+    VerifyOrQuit(message->CompareBytes(0, readBuffer, kMaxSize));
+    VerifyOrQuit(message->Compare(0, readBuffer));
+    VerifyOrQuit(message->GetLength() == kMaxSize);
 
     for (uint16_t offset = 0; offset < kMaxSize; offset++)
     {
@@ -82,16 +82,16 @@ void TestMessage(void)
 
             message->WriteBytes(offset, &writeBuffer[offset], length);
 
-            SuccessOrQuit(message->Read(0, readBuffer, kMaxSize), "Message::Read failed");
-            VerifyOrQuit(memcmp(writeBuffer, readBuffer, kMaxSize) == 0, "Message compare failed");
-            VerifyOrQuit(message->Compare(0, writeBuffer), "Message::Compare() failed");
+            SuccessOrQuit(message->Read(0, readBuffer, kMaxSize));
+            VerifyOrQuit(memcmp(writeBuffer, readBuffer, kMaxSize) == 0);
+            VerifyOrQuit(message->Compare(0, writeBuffer));
 
             memset(readBuffer, 0, sizeof(readBuffer));
-            SuccessOrQuit(message->Read(offset, readBuffer, length), "Message::Read failed");
-            VerifyOrQuit(memcmp(readBuffer, &writeBuffer[offset], length) == 0, "Message compare failed");
-            VerifyOrQuit(memcmp(&readBuffer[length], zeroBuffer, kMaxSize - length) == 0, "Message read after length");
+            SuccessOrQuit(message->Read(offset, readBuffer, length));
+            VerifyOrQuit(memcmp(readBuffer, &writeBuffer[offset], length) == 0);
+            VerifyOrQuit(memcmp(&readBuffer[length], zeroBuffer, kMaxSize - length) == 0, "read after length");
 
-            VerifyOrQuit(message->CompareBytes(offset, &writeBuffer[offset], length), "Message::CompareBytes() failed");
+            VerifyOrQuit(message->CompareBytes(offset, &writeBuffer[offset], length));
 
             if (length == 0)
             {
@@ -102,11 +102,11 @@ void TestMessage(void)
             // `CompareBytes()` correctly fails.
 
             writeBuffer[offset]++;
-            VerifyOrQuit(!message->CompareBytes(offset, &writeBuffer[offset], length), "CompareBytes() failed");
+            VerifyOrQuit(!message->CompareBytes(offset, &writeBuffer[offset], length));
             writeBuffer[offset]--;
 
             writeBuffer[offset + length - 1]++;
-            VerifyOrQuit(!message->CompareBytes(offset, &writeBuffer[offset], length), "CompareBytes() failed");
+            VerifyOrQuit(!message->CompareBytes(offset, &writeBuffer[offset], length));
             writeBuffer[offset + length - 1]--;
         }
 
@@ -120,21 +120,21 @@ void TestMessage(void)
             readLength = message->ReadBytes(offset, readBuffer, length);
 
             VerifyOrQuit(readLength < length, "Message::ReadBytes() returned longer length");
-            VerifyOrQuit(readLength == kMaxSize - offset, "Message::Read failed");
-            VerifyOrQuit(memcmp(readBuffer, &writeBuffer[offset], readLength) == 0, "Message compare failed");
+            VerifyOrQuit(readLength == kMaxSize - offset);
+            VerifyOrQuit(memcmp(readBuffer, &writeBuffer[offset], readLength) == 0);
             VerifyOrQuit(memcmp(&readBuffer[readLength], zeroBuffer, kMaxSize - readLength) == 0, "read after length");
 
-            VerifyOrQuit(!message->CompareBytes(offset, readBuffer, length), "Message::CompareBytes failed");
-            VerifyOrQuit(message->CompareBytes(offset, readBuffer, readLength), "Message::CompareBytes failed");
+            VerifyOrQuit(!message->CompareBytes(offset, readBuffer, length));
+            VerifyOrQuit(message->CompareBytes(offset, readBuffer, readLength));
         }
     }
 
-    VerifyOrQuit(message->GetLength() == kMaxSize, "Message::GetLength failed");
+    VerifyOrQuit(message->GetLength() == kMaxSize);
 
     // Test `Message::CopyTo()` behavior.
 
-    VerifyOrQuit((message2 = messagePool->New(Message::kTypeIp6, 0)) != nullptr, "Message::New failed");
-    SuccessOrQuit(message2->SetLength(kMaxSize), "Message::SetLength failed");
+    VerifyOrQuit((message2 = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
+    SuccessOrQuit(message2->SetLength(kMaxSize));
 
     for (uint16_t srcOffset = 0; srcOffset < kMaxSize; srcOffset += kOffsetStep)
     {
@@ -157,19 +157,16 @@ void TestMessage(void)
                     VerifyOrQuit(bytesCopied == kMaxSize - srcOffset, "CopyTo() failed");
                 }
 
-                SuccessOrQuit(message2->Read(0, readBuffer, kMaxSize), "Message::Read failed");
+                SuccessOrQuit(message2->Read(0, readBuffer, kMaxSize));
 
                 VerifyOrQuit(memcmp(&readBuffer[0], zeroBuffer, dstOffset) == 0, "read before length");
-                VerifyOrQuit(memcmp(&readBuffer[dstOffset], &writeBuffer[srcOffset], bytesCopied) == 0,
-                             "Compare failed");
+                VerifyOrQuit(memcmp(&readBuffer[dstOffset], &writeBuffer[srcOffset], bytesCopied) == 0);
                 VerifyOrQuit(
                     memcmp(&readBuffer[dstOffset + bytesCopied], zeroBuffer, kMaxSize - bytesCopied - dstOffset) == 0,
                     "read after length");
 
-                VerifyOrQuit(message->CompareBytes(srcOffset, *message2, dstOffset, bytesCopied),
-                             "Message::CompareBytes with two messages failed");
-                VerifyOrQuit(message2->CompareBytes(dstOffset, *message, srcOffset, bytesCopied),
-                             "Message::CompareBytes with two messages failed");
+                VerifyOrQuit(message->CompareBytes(srcOffset, *message2, dstOffset, bytesCopied));
+                VerifyOrQuit(message2->CompareBytes(dstOffset, *message, srcOffset, bytesCopied));
             }
         }
     }
@@ -185,7 +182,7 @@ void TestMessage(void)
         bytesCopied = message->CopyTo(srcOffset, 0, kMaxSize, *message);
         VerifyOrQuit(bytesCopied == kMaxSize - srcOffset, "CopyTo() failed");
 
-        SuccessOrQuit(message->Read(0, readBuffer, kMaxSize), "Message::Read failed");
+        SuccessOrQuit(message->Read(0, readBuffer, kMaxSize));
 
         VerifyOrQuit(memcmp(&readBuffer[0], &writeBuffer[srcOffset], bytesCopied) == 0,
                      "CopyTo() changed before srcOffset");
@@ -204,17 +201,15 @@ void TestMessage(void)
             for (uint16_t length = 0; length <= kMaxSize - srcOffset; length += kLengthStep)
             {
                 IgnoreError(message2->SetLength(0));
-                SuccessOrQuit(message2->AppendBytes(zeroBuffer, dstOffset), "AppendBytes() failed");
+                SuccessOrQuit(message2->AppendBytes(zeroBuffer, dstOffset));
 
-                SuccessOrQuit(message2->AppendBytesFromMessage(*message, srcOffset, length),
-                              "AppendBytesFromMessage() failed");
+                SuccessOrQuit(message2->AppendBytesFromMessage(*message, srcOffset, length));
 
-                VerifyOrQuit(message2->CompareBytes(dstOffset, *message, srcOffset, length),
-                             "CompareBytes failed after AppendBytesFromMessage()");
+                VerifyOrQuit(message2->CompareBytes(dstOffset, *message, srcOffset, length));
             }
 
-            VerifyOrQuit(message2->AppendBytesFromMessage(*message, srcOffset, kMaxSize - srcOffset + 1) == kErrorParse,
-                         "AppendBytesFromMessage() did not fail with invalid length");
+            VerifyOrQuit(message2->AppendBytesFromMessage(*message, srcOffset, kMaxSize - srcOffset + 1) ==
+                         kErrorParse);
         }
     }
 
@@ -229,11 +224,9 @@ void TestMessage(void)
             // Reset the `message` to its original size.
             IgnoreError(message->SetLength(size));
 
-            SuccessOrQuit(message->AppendBytesFromMessage(*message, srcOffset, length),
-                          "AppendBytesFromMessage() failed");
+            SuccessOrQuit(message->AppendBytesFromMessage(*message, srcOffset, length));
 
-            VerifyOrQuit(message->CompareBytes(size, *message, srcOffset, length),
-                         "CompareBytes failed after AppendBytesFromMessage()");
+            VerifyOrQuit(message->CompareBytes(size, *message, srcOffset, length));
         }
     }
 

--- a/tests/unit/test_message_queue.cpp
+++ b/tests/unit/test_message_queue.cpp
@@ -55,21 +55,21 @@ void VerifyMessageQueueContent(ot::MessageQueue &aMessageQueue, int aExpectedLen
     if (aExpectedLength == 0)
     {
         message = aMessageQueue.GetHead();
-        VerifyOrQuit(message == nullptr, "MessageQueue is not empty when expected len is zero.");
+        VerifyOrQuit(message == nullptr, "not empty when expected len is zero.");
     }
     else
     {
         for (message = aMessageQueue.GetHead(); message != nullptr; message = message->GetNext())
         {
-            VerifyOrQuit(aExpectedLength != 0, "MessageQueue contains more entries than expected");
+            VerifyOrQuit(aExpectedLength != 0, "contains more entries than expected");
 
             msgArg = va_arg(args, ot::Message *);
-            VerifyOrQuit(msgArg == message, "MessageQueue content does not match what is expected.");
+            VerifyOrQuit(msgArg == message, "content does not match what is expected.");
 
             aExpectedLength--;
         }
 
-        VerifyOrQuit(aExpectedLength == 0, "MessageQueue contains less entries than expected");
+        VerifyOrQuit(aExpectedLength == 0, "less entries than expected");
     }
 
     va_end(args);
@@ -82,14 +82,14 @@ void TestMessageQueue(void)
     uint16_t         msgCount, bufferCount;
 
     sInstance = testInitInstance();
-    VerifyOrQuit(sInstance != nullptr, "Null instance");
+    VerifyOrQuit(sInstance != nullptr);
 
     sMessagePool = &sInstance->Get<ot::MessagePool>();
 
     for (ot::Message *&msg : messages)
     {
         msg = sMessagePool->New(ot::Message::kTypeIp6, 0);
-        VerifyOrQuit(msg != nullptr, "Message::New failed");
+        VerifyOrQuit(msg != nullptr, "Message::New() failed");
     }
 
     VerifyMessageQueueContent(messageQueue, 0);
@@ -189,22 +189,22 @@ void VerifyMessageQueueContentUsingOtApi(otMessageQueue *aQueue, int aExpectedLe
     if (aExpectedLength == 0)
     {
         message = otMessageQueueGetHead(aQueue);
-        VerifyOrQuit(message == nullptr, "MessageQueue is not empty when expected len is zero.");
+        VerifyOrQuit(message == nullptr, "not empty when expected len is zero.");
     }
     else
     {
         for (message = otMessageQueueGetHead(aQueue); message != nullptr;
              message = otMessageQueueGetNext(aQueue, message))
         {
-            VerifyOrQuit(aExpectedLength != 0, "MessageQueue contains more entries than expected");
+            VerifyOrQuit(aExpectedLength != 0, "more entries than expected");
 
             msgArg = va_arg(args, otMessage *);
-            VerifyOrQuit(msgArg == message, "MessageQueue content does not match what is expected.");
+            VerifyOrQuit(msgArg == message, "does not match what is expected.");
 
             aExpectedLength--;
         }
 
-        VerifyOrQuit(aExpectedLength == 0, "MessageQueue contains less entries than expected");
+        VerifyOrQuit(aExpectedLength == 0, "less entries than expected");
     }
 
     va_end(args);
@@ -218,7 +218,7 @@ void TestMessageQueueOtApis(void)
     otMessageQueue queue, queue2;
 
     sInstance = testInitInstance();
-    VerifyOrQuit(sInstance != nullptr, "Null instance");
+    VerifyOrQuit(sInstance != nullptr);
 
     for (otMessage *&msg : messages)
     {

--- a/tests/unit/test_multicast_listeners_table.cpp
+++ b/tests/unit/test_multicast_listeners_table.cpp
@@ -74,7 +74,7 @@ void TestMulticastListenersTable(void)
     InitTestTimer();
 
     sInstance = testInitInstance();
-    VerifyOrQuit(sInstance != nullptr, "Null OpenThread instance");
+    VerifyOrQuit(sInstance != nullptr);
 
     MulticastListenersTable &table = sInstance->Get<MulticastListenersTable>();
 
@@ -88,15 +88,15 @@ void TestMulticastListenersTable(void)
 
     sNow = 1;
     // Add valid MAs should succeed
-    SuccessOrQuit(table.Add(static_cast<const Ip6::Address &>(MA401), TimerMilli::GetNow()), "Add failed");
-    SuccessOrQuit(table.Add(static_cast<const Ip6::Address &>(MA501), TimerMilli::GetNow()), "Add failed");
+    SuccessOrQuit(table.Add(static_cast<const Ip6::Address &>(MA401), TimerMilli::GetNow()));
+    SuccessOrQuit(table.Add(static_cast<const Ip6::Address &>(MA501), TimerMilli::GetNow()));
     VerifyOrQuit(table.Count() == 2, "Table count is wrong");
 
     // Add invalid MAs should fail with kErrorInvalidArgs
     VerifyOrQuit(table.Add(static_cast<const Ip6::Address &>(MA201), TimerMilli::GetNow()) == kErrorInvalidArgs,
-                 "Add should fail");
+                 "failed to detect bad arg");
     VerifyOrQuit(table.Add(static_cast<const Ip6::Address &>(MA301), TimerMilli::GetNow()) == kErrorInvalidArgs,
-                 "Add should fail");
+                 "failed to detect bad arg");
 
     // Expire should expire outdated Listeners
     sNow = 2;
@@ -112,13 +112,13 @@ void TestMulticastListenersTable(void)
         address                = static_cast<const Ip6::Address &>(MA401);
         address.mFields.m16[7] = HostSwap16(i);
 
-        SuccessOrQuit(table.Add(address, TimerMilli::GetNow() + i), "Add failed");
+        SuccessOrQuit(table.Add(address, TimerMilli::GetNow() + i));
         VerifyOrQuit(table.Count() == i + 1, "Table count is wrong");
     }
 
     // Now the table is full, we can't add more addresses
     VerifyOrQuit(table.Add(static_cast<const Ip6::Address &>(MA501), TimerMilli::GetNow()) == kErrorNoBufs,
-                 "Add should fail");
+                 "succeeded when table is full");
 
     // Expire one Listener at a time
     for (uint16_t i = 0; i < OPENTHREAD_CONFIG_MAX_MULTICAST_LISTENERS; i++)
@@ -174,7 +174,7 @@ void testMulticastListenersTableAPIs(Instance *aInstance)
         VerifyOrQuit(false, "Table should be empty");
     }
 
-    SuccessOrQuit(otBackboneRouterMulticastListenerAdd(aInstance, &MA401, 30), "Add failed");
+    SuccessOrQuit(otBackboneRouterMulticastListenerAdd(aInstance, &MA401, 30));
 
     table_size = 0, iter = OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ITERATOR_INIT;
     while (otBackboneRouterMulticastListenerGetNext(aInstance, &iter, &info) == kErrorNone)

--- a/tests/unit/test_ndproxy_table.cpp
+++ b/tests/unit/test_ndproxy_table.cpp
@@ -61,7 +61,7 @@ void TestNdProxyTable(void)
     Error error;
 
     sInstance = testInitInstance();
-    VerifyOrQuit(sInstance != nullptr, "Null OpenThread instance");
+    VerifyOrQuit(sInstance != nullptr);
 
     BackboneRouter::NdProxyTable &table = sInstance->Get<BackboneRouter::NdProxyTable>();
 
@@ -71,10 +71,9 @@ void TestNdProxyTable(void)
     Ip6::InterfaceIdentifier notExistMeshLocalIid = generateRandomIid(OPENTHREAD_CONFIG_NDPROXY_TABLE_ENTRY_NUM);
 
     // Reregister address IID when there are enough room should succeed.
-    error = table.Register(existedAddressIid, existedMeshLocalIid, 0, nullptr);
-    VerifyOrQuit(error == kErrorNone, "Register failed");
-    VerifyOrQuit(table.IsRegistered(existedAddressIid), "should be registered");
-    VerifyOrQuit(!table.IsRegistered(notExistAddressIid), "should not be registered");
+    SuccessOrQuit(table.Register(existedAddressIid, existedMeshLocalIid, 0, nullptr));
+    VerifyOrQuit(table.IsRegistered(existedAddressIid));
+    VerifyOrQuit(!table.IsRegistered(notExistAddressIid));
 
     for (uint16_t i = 1; i < OPENTHREAD_CONFIG_NDPROXY_TABLE_ENTRY_NUM; i++)
     {
@@ -82,27 +81,23 @@ void TestNdProxyTable(void)
         Ip6::InterfaceIdentifier meshLocalIid = generateRandomIid(i);
 
         // Reregister address IID when there are enough room should succeed.
-        error = table.Register(addressIid, meshLocalIid, i, nullptr);
-        VerifyOrQuit(error == kErrorNone, "Register failed");
+        SuccessOrQuit(table.Register(addressIid, meshLocalIid, i, nullptr));
 
-        VerifyOrQuit(table.IsRegistered(addressIid), "should be registered");
+        VerifyOrQuit(table.IsRegistered(addressIid));
 
         // Reregister the same address IID should always succeed.
-        error = table.Register(addressIid, meshLocalIid, i, nullptr);
-        VerifyOrQuit(error == kErrorNone, "Register again failed");
+        SuccessOrQuit(table.Register(addressIid, meshLocalIid, i, nullptr));
 
         // Register the same address IID with a different ML-IID should fail.
-        error = table.Register(addressIid, notExistMeshLocalIid, i, nullptr);
-        VerifyOrQuit(error == kErrorDuplicated, "Register duplicate should fail");
+        VerifyOrQuit(table.Register(addressIid, notExistMeshLocalIid, i, nullptr) == kErrorDuplicated);
 
-        VerifyOrQuit(table.IsRegistered(addressIid), "should be registered");
+        VerifyOrQuit(table.IsRegistered(addressIid));
     }
 
     // Now the table is full, registering another IID should fail.
-    error =
-        table.Register(notExistAddressIid, notExistMeshLocalIid, OPENTHREAD_CONFIG_NDPROXY_TABLE_ENTRY_NUM, nullptr);
-    VerifyOrQuit(error == kErrorNoBufs, "should fail with no bufs");
-    VerifyOrQuit(!table.IsRegistered(notExistAddressIid), "should not be registered");
+    VerifyOrQuit(table.Register(notExistAddressIid, notExistMeshLocalIid, OPENTHREAD_CONFIG_NDPROXY_TABLE_ENTRY_NUM,
+                                nullptr) == kErrorNoBufs);
+    VerifyOrQuit(!table.IsRegistered(notExistAddressIid));
 }
 
 } // namespace ot

--- a/tests/unit/test_netif.cpp
+++ b/tests/unit/test_netif.cpp
@@ -62,7 +62,7 @@ void VerifyMulticastAddressList(const Ip6::Netif &aNetif, Ip6::Address aAddresse
 
     for (uint8_t i = 0; i < aLength; i++)
     {
-        VerifyOrQuit(aNetif.IsMulticastSubscribed(aAddresses[i]), "IsMulticastSubscribed() failed");
+        VerifyOrQuit(aNetif.IsMulticastSubscribed(aAddresses[i]));
     }
 
     for (const Ip6::NetifMulticastAddress *addr = aNetif.GetMulticastAddresses(); addr; addr = addr->GetNext())
@@ -148,7 +148,7 @@ void TestNetifMulticastAddresses(void)
     VerifyMulticastAddressList(netif, &addresses[5], 1);
 
     IgnoreError(address.FromString(kTestAddress2));
-    SuccessOrQuit(netif.SubscribeExternalMulticast(address), "SubscribeExternalMulticast() failed");
+    SuccessOrQuit(netif.SubscribeExternalMulticast(address));
     VerifyMulticastAddressList(netif, &addresses[5], 2);
 
     netif.SubscribeAllNodesMulticast();
@@ -164,7 +164,7 @@ void TestNetifMulticastAddresses(void)
     VerifyMulticastAddressList(netif, &addresses[0], 7);
 
     IgnoreError(address.FromString(kTestAddress3));
-    SuccessOrQuit(netif.SubscribeExternalMulticast(address), "SubscribeExternalMulticast() failed");
+    SuccessOrQuit(netif.SubscribeExternalMulticast(address));
     VerifyMulticastAddressList(netif, &addresses[0], 8);
 
     IgnoreError(address.FromString(kTestAddress1)); // same as netifAddress (internal)

--- a/tests/unit/test_network_data.cpp
+++ b/tests/unit/test_network_data.cpp
@@ -80,7 +80,7 @@ void TestNetworkDataIterator(void)
     ExternalRouteConfig config;
 
     instance = testInitInstance();
-    VerifyOrQuit(instance != nullptr, "Null OpenThread instance\n");
+    VerifyOrQuit(instance != nullptr);
 
     {
         const uint8_t kNetworkData[] = {
@@ -124,10 +124,9 @@ void TestNetworkDataIterator(void)
 
         for (const auto &route : routes)
         {
-            SuccessOrQuit(netData.GetNextExternalRoute(iter, config), "GetNextExternalRoute() failed");
+            SuccessOrQuit(netData.GetNextExternalRoute(iter, config));
             PrintExternalRouteConfig(config);
-            VerifyOrQuit(CompareExternalRouteConfig(config, route) == true,
-                         "external route config does not match expectation");
+            VerifyOrQuit(CompareExternalRouteConfig(config, route));
         }
     }
 
@@ -211,10 +210,9 @@ void TestNetworkDataIterator(void)
 
         for (const auto &route : routes)
         {
-            SuccessOrQuit(netData.GetNextExternalRoute(iter, config), "GetNextExternalRoute() failed");
+            SuccessOrQuit(netData.GetNextExternalRoute(iter, config));
             PrintExternalRouteConfig(config);
-            VerifyOrQuit(CompareExternalRouteConfig(config, route) == true,
-                         "external route config does not match expectation");
+            VerifyOrQuit(CompareExternalRouteConfig(config, route));
         }
     }
 
@@ -257,40 +255,40 @@ public:
 
         const ServiceTlv *tlv;
 
-        SuccessOrQuit(AddService(kServiceData1), "AddService() failed");
-        SuccessOrQuit(AddService(kServiceData2), "AddService() failed");
-        SuccessOrQuit(AddService(kServiceData3), "AddService() failed");
-        SuccessOrQuit(AddService(kServiceData4), "AddService() failed");
-        SuccessOrQuit(AddService(kServiceData5), "AddService() failed");
+        SuccessOrQuit(AddService(kServiceData1));
+        SuccessOrQuit(AddService(kServiceData2));
+        SuccessOrQuit(AddService(kServiceData3));
+        SuccessOrQuit(AddService(kServiceData4));
+        SuccessOrQuit(AddService(kServiceData5));
 
         DumpBuffer("netdata", mTlvs, mLength);
 
         // Iterate through all entries that start with { 0x02 } (kServiceData1)
         tlv = nullptr;
         tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1));
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData1), "FindNextMatchingService() failed");
+        SuccessOrQuit(ValidateServiceData(tlv, kServiceData1));
         tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1));
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData4), "FindNextMatchingService() failed");
+        SuccessOrQuit(ValidateServiceData(tlv, kServiceData4));
         tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1));
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData5), "FindNextMatchingService() failed");
+        SuccessOrQuit(ValidateServiceData(tlv, kServiceData5));
         tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1));
         VerifyOrQuit(tlv == nullptr, "FindNextMatchingService() returned extra TLV");
 
         // Iterate through all entries that start with { 0xab } (kServiceData2)
         tlv = nullptr;
         tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData2, sizeof(kServiceData2));
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData2), "FindNextMatchingService() failed");
+        SuccessOrQuit(ValidateServiceData(tlv, kServiceData2));
         tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData2, sizeof(kServiceData2));
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData3), "FindNextMatchingService() failed");
+        SuccessOrQuit(ValidateServiceData(tlv, kServiceData3));
         tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData2, sizeof(kServiceData2));
         VerifyOrQuit(tlv == nullptr, "FindNextMatchingService() returned extra TLV");
 
         // Iterate through all entries that start with kServiceData5
         tlv = nullptr;
         tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData5, sizeof(kServiceData5));
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData4), "FindNextMatchingService() failed");
+        SuccessOrQuit(ValidateServiceData(tlv, kServiceData4));
         tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData5, sizeof(kServiceData5));
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData5), "FindNextMatchingService() failed");
+        SuccessOrQuit(ValidateServiceData(tlv, kServiceData5));
         tlv = FindNextMatchingService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData5, sizeof(kServiceData5));
         VerifyOrQuit(tlv == nullptr, "FindNextMatchingService() returned extra TLV");
     }
@@ -304,7 +302,7 @@ void TestNetworkDataFindNextService(void)
     printf("\nTestNetworkDataFindNextService()\n");
 
     instance = testInitInstance();
-    VerifyOrQuit(instance != nullptr, "Null OpenThread instance\n");
+    VerifyOrQuit(instance != nullptr);
 
     {
         TestNetworkData netData(*instance);
@@ -332,7 +330,7 @@ void TestNetworkDataDsnSrpServices(void)
     printf("\nTestNetworkDataDsnSrpServices()\n");
 
     instance = testInitInstance();
-    VerifyOrQuit(instance != nullptr, "Null OpenThread instance\n");
+    VerifyOrQuit(instance != nullptr);
 
     {
         struct AnycastEntry
@@ -342,7 +340,7 @@ void TestNetworkDataDsnSrpServices(void)
 
             bool Matches(Service::DnsSrpAnycast::Info aInfo) const
             {
-                VerifyOrQuit(aInfo.mAnycastAddress.GetIid().IsAnycastServiceLocator(), "Anycast address is invalid");
+                VerifyOrQuit(aInfo.mAnycastAddress.GetIid().IsAnycastServiceLocator());
 
                 return (aInfo.mAnycastAddress.GetIid().GetLocator() == mAloc16) &&
                        (aInfo.mSequenceNumber == mSequenceNumber);
@@ -358,7 +356,7 @@ void TestNetworkDataDsnSrpServices(void)
             {
                 Ip6::SockAddr sockAddr;
 
-                SuccessOrQuit(sockAddr.GetAddress().FromString(mAddress), "Ip6::Address::FromString() failed");
+                SuccessOrQuit(sockAddr.GetAddress().FromString(mAddress));
                 sockAddr.SetPort(mPort);
 
                 return (aInfo.mSockAddr == sockAddr);
@@ -405,7 +403,7 @@ void TestNetworkDataDsnSrpServices(void)
 
         for (const AnycastEntry &entry : kAnycastEntries)
         {
-            SuccessOrQuit(manager.GetNextDnsSrpAnycastInfo(iterator, anycastInfo), "GetNextDnsSrpAnycastInfo() failed");
+            SuccessOrQuit(manager.GetNextDnsSrpAnycastInfo(iterator, anycastInfo));
 
             printf("\nanycastInfo { %s, seq:%d }", anycastInfo.mAnycastAddress.ToString().AsCString(),
                    anycastInfo.mSequenceNumber);
@@ -418,7 +416,7 @@ void TestNetworkDataDsnSrpServices(void)
 
         // Find the preferred "DNS/SRP Anycast Service" entries in Network Data
 
-        SuccessOrQuit(manager.FindPreferredDnsSrpAnycastInfo(anycastInfo), "FindPreferredDnsSrpAnycastInfo() failed");
+        SuccessOrQuit(manager.FindPreferredDnsSrpAnycastInfo(anycastInfo));
 
         printf("\n\nPreferred anycastInfo { %s, seq:%d }", anycastInfo.mAnycastAddress.ToString().AsCString(),
                anycastInfo.mSequenceNumber);
@@ -433,7 +431,7 @@ void TestNetworkDataDsnSrpServices(void)
 
         for (const UnicastEntry &entry : kUnicastEntries)
         {
-            SuccessOrQuit(manager.GetNextDnsSrpUnicastInfo(iterator, unicastInfo), "GetNextDnsSrpUnicastInfo() failed");
+            SuccessOrQuit(manager.GetNextDnsSrpUnicastInfo(iterator, unicastInfo));
             printf("\nunicastInfo %s", unicastInfo.mSockAddr.ToString().AsCString());
 
             VerifyOrQuit(entry.Matches(unicastInfo), "GetNextDnsSrpUnicastInfo() returned incorrect info");

--- a/tests/unit/test_pool.cpp
+++ b/tests/unit/test_pool.cpp
@@ -70,12 +70,12 @@ void VerifyEntry(EntryPool &aPool, const Entry &aEntry, bool aInitWithInstance)
     uint16_t         index;
     const EntryPool &constPool = const_cast<const EntryPool &>(aPool);
 
-    VerifyOrQuit(aPool.IsPoolEntry(aEntry), "Pool::IsPoolEntry() failed");
+    VerifyOrQuit(aPool.IsPoolEntry(aEntry));
     VerifyOrQuit(!aPool.IsPoolEntry(sNonPoolEntry), "Pool::IsPoolEntry() succeeded for non-pool entry");
 
     index = aPool.GetIndexOf(aEntry);
-    VerifyOrQuit(&aPool.GetEntryAt(index) == &aEntry, "Pool::GetEntryAt() failed");
-    VerifyOrQuit(&constPool.GetEntryAt(index) == &aEntry, "Pool::GetEntryAt() failed");
+    VerifyOrQuit(&aPool.GetEntryAt(index) == &aEntry);
+    VerifyOrQuit(&constPool.GetEntryAt(index) == &aEntry);
 
     VerifyOrQuit(aEntry.IsInitializedWithInstance() == aInitWithInstance, "Pool did not correctly Init() entry");
 }
@@ -84,7 +84,7 @@ void TestPool(EntryPool &aPool, bool aInitWithInstance)
 {
     Entry *entries[kPoolSize];
 
-    VerifyOrQuit(aPool.GetSize() == kPoolSize, "Pool::GetSize() failed");
+    VerifyOrQuit(aPool.GetSize() == kPoolSize);
 
     for (Entry *&entry : entries)
     {

--- a/tests/unit/test_priority_queue.cpp
+++ b/tests/unit/test_priority_queue.cpp
@@ -59,14 +59,10 @@ void VerifyPriorityQueueContent(ot::PriorityQueue &aPriorityQueue, int aExpected
         message = aPriorityQueue.GetHead();
         VerifyOrQuit(message == nullptr, "PriorityQueue is not empty when expected len is zero.");
 
-        VerifyOrQuit(aPriorityQueue.GetHeadForPriority(ot::Message::kPriorityLow) == nullptr,
-                     "GetHeadForPriority() non-nullptr when empty");
-        VerifyOrQuit(aPriorityQueue.GetHeadForPriority(ot::Message::kPriorityNormal) == nullptr,
-                     "GetHeadForPriority() non-nullptr when empty");
-        VerifyOrQuit(aPriorityQueue.GetHeadForPriority(ot::Message::kPriorityHigh) == nullptr,
-                     "GetHeadForPriority() non-nullptr when empty");
-        VerifyOrQuit(aPriorityQueue.GetHeadForPriority(ot::Message::kPriorityNet) == nullptr,
-                     "GetHeadForPriority() non-nullptr when empty");
+        VerifyOrQuit(aPriorityQueue.GetHeadForPriority(ot::Message::kPriorityLow) == nullptr);
+        VerifyOrQuit(aPriorityQueue.GetHeadForPriority(ot::Message::kPriorityNormal) == nullptr);
+        VerifyOrQuit(aPriorityQueue.GetHeadForPriority(ot::Message::kPriorityHigh) == nullptr);
+        VerifyOrQuit(aPriorityQueue.GetHeadForPriority(ot::Message::kPriorityNet) == nullptr);
     }
     else
     {
@@ -83,15 +79,14 @@ void VerifyPriorityQueueContent(ot::PriorityQueue &aPriorityQueue, int aExpected
                 {
                     // Check the `GetHeadForPriority` is nullptr if there are no expected message for this priority
                     // level.
-                    VerifyOrQuit(
-                        aPriorityQueue.GetHeadForPriority(static_cast<ot::Message::Priority>(curPriority)) == nullptr,
-                        "PriorityQueue::GetHeadForPriority is non-nullptr when no expected msg for this priority.");
+                    VerifyOrQuit(aPriorityQueue.GetHeadForPriority(static_cast<ot::Message::Priority>(curPriority)) ==
+                                     nullptr,
+                                 "is non-nullptr when no expected msg for this priority.");
                 }
 
                 // Check the `GetHeadForPriority`.
                 VerifyOrQuit(aPriorityQueue.GetHeadForPriority(static_cast<ot::Message::Priority>(curPriority)) ==
-                                 msgArg,
-                             "PriorityQueue::GetHeadForPriority failed.");
+                             msgArg);
             }
 
             // Check the queued message to match the one from argument list
@@ -106,7 +101,7 @@ void VerifyPriorityQueueContent(ot::PriorityQueue &aPriorityQueue, int aExpected
         for (curPriority--; curPriority >= 0; curPriority--)
         {
             VerifyOrQuit(aPriorityQueue.GetHeadForPriority(static_cast<ot::Message::Priority>(curPriority)) == nullptr,
-                         "PriorityQueue::GetHeadForPriority is non-nullptr when no expected msg for this priority.");
+                         "is non-nullptr when no expected msg for this priority.");
         }
     }
 
@@ -125,21 +120,21 @@ void VerifyMsgQueueContent(ot::MessageQueue &aMessageQueue, int aExpectedLength,
     if (aExpectedLength == 0)
     {
         message = aMessageQueue.GetHead();
-        VerifyOrQuit(message == nullptr, "MessageQueue is not empty when expected len is zero.");
+        VerifyOrQuit(message == nullptr, "is not empty when expected len is zero.");
     }
     else
     {
         for (message = aMessageQueue.GetHead(); message != nullptr; message = message->GetNext())
         {
-            VerifyOrQuit(aExpectedLength != 0, "MessageQueue contains more entries than expected");
+            VerifyOrQuit(aExpectedLength != 0, "contains more entries than expected");
 
             msgArg = va_arg(args, ot::Message *);
-            VerifyOrQuit(msgArg == message, "MessageQueue content does not match what is expected.");
+            VerifyOrQuit(msgArg == message, "content does not match what is expected.");
 
             aExpectedLength--;
         }
 
-        VerifyOrQuit(aExpectedLength == 0, "MessageQueue contains less entries than expected");
+        VerifyOrQuit(aExpectedLength == 0, "contains less entries than expected");
     }
 
     va_end(args);
@@ -165,39 +160,39 @@ void TestPriorityQueue(void)
     for (int i = 0; i < kNumNewPriorityTestMessages; i++)
     {
         msgNet[i] = messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kPriorityNet);
-        VerifyOrQuit(msgNet[i] != nullptr, "Message::New failed");
+        VerifyOrQuit(msgNet[i] != nullptr);
         msgHigh[i] = messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kPriorityHigh);
-        VerifyOrQuit(msgHigh[i] != nullptr, "Message::New failed");
+        VerifyOrQuit(msgHigh[i] != nullptr);
         msgNor[i] = messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kPriorityNormal);
-        VerifyOrQuit(msgNor[i] != nullptr, "Message::New failed");
+        VerifyOrQuit(msgNor[i] != nullptr);
         msgLow[i] = messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kPriorityLow);
-        VerifyOrQuit(msgLow[i] != nullptr, "Message::New failed");
+        VerifyOrQuit(msgLow[i] != nullptr);
     }
 
     // Use the function "SetPriority()" to allocate messages with different priorities
     for (int i = kNumNewPriorityTestMessages; i < kNumTestMessages; i++)
     {
         msgNet[i] = messagePool->New(ot::Message::kTypeIp6, 0);
-        VerifyOrQuit(msgNet[i] != nullptr, "Message::New failed");
-        SuccessOrQuit(msgNet[i]->SetPriority(ot::Message::kPriorityNet), "Message:SetPriority failed");
+        VerifyOrQuit(msgNet[i] != nullptr);
+        SuccessOrQuit(msgNet[i]->SetPriority(ot::Message::kPriorityNet));
         msgHigh[i] = messagePool->New(ot::Message::kTypeIp6, 0);
-        VerifyOrQuit(msgHigh[i] != nullptr, "Message::New failed");
-        SuccessOrQuit(msgHigh[i]->SetPriority(ot::Message::kPriorityHigh), "Message:SetPriority failed");
+        VerifyOrQuit(msgHigh[i] != nullptr);
+        SuccessOrQuit(msgHigh[i]->SetPriority(ot::Message::kPriorityHigh));
         msgNor[i] = messagePool->New(ot::Message::kTypeIp6, 0);
-        VerifyOrQuit(msgNor[i] != nullptr, "Message::New failed");
-        SuccessOrQuit(msgNor[i]->SetPriority(ot::Message::kPriorityNormal), "Message:SetPriority failed");
+        VerifyOrQuit(msgNor[i] != nullptr);
+        SuccessOrQuit(msgNor[i]->SetPriority(ot::Message::kPriorityNormal));
         msgLow[i] = messagePool->New(ot::Message::kTypeIp6, 0);
-        VerifyOrQuit(msgLow[i] != nullptr, "Message::New failed");
-        SuccessOrQuit(msgLow[i]->SetPriority(ot::Message::kPriorityLow), "Message:SetPriority failed");
+        VerifyOrQuit(msgLow[i] != nullptr);
+        SuccessOrQuit(msgLow[i]->SetPriority(ot::Message::kPriorityLow));
     }
 
     // Check the `GetPriority()`
     for (int i = 0; i < kNumTestMessages; i++)
     {
-        VerifyOrQuit(msgLow[i]->GetPriority() == ot::Message::kPriorityLow, "Message::GetPriority failed.");
-        VerifyOrQuit(msgNor[i]->GetPriority() == ot::Message::kPriorityNormal, "Message::GetPriority failed.");
-        VerifyOrQuit(msgHigh[i]->GetPriority() == ot::Message::kPriorityHigh, "Message::GetPriority failed.");
-        VerifyOrQuit(msgNet[i]->GetPriority() == ot::Message::kPriorityNet, "Message::GetPriority failed.");
+        VerifyOrQuit(msgLow[i]->GetPriority() == ot::Message::kPriorityLow);
+        VerifyOrQuit(msgNor[i]->GetPriority() == ot::Message::kPriorityNormal);
+        VerifyOrQuit(msgHigh[i]->GetPriority() == ot::Message::kPriorityHigh);
+        VerifyOrQuit(msgNet[i]->GetPriority() == ot::Message::kPriorityNet);
     }
 
     // Verify case of an empty queue.
@@ -250,25 +245,18 @@ void TestPriorityQueue(void)
     queue.Enqueue(*msgLow[0]);
     VerifyPriorityQueueContent(queue, 3, msgHigh[0], msgNor[0], msgLow[0]);
 
-    SuccessOrQuit(msgNor[0]->SetPriority(ot::Message::kPriorityNet),
-                  "SetPriority failed for an already queued message.");
+    SuccessOrQuit(msgNor[0]->SetPriority(ot::Message::kPriorityNet));
     VerifyPriorityQueueContent(queue, 3, msgNor[0], msgHigh[0], msgLow[0]);
-    SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityLow),
-                  "SetPriority failed for an already queued message.");
+    SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityLow));
     VerifyPriorityQueueContent(queue, 3, msgNor[0], msgHigh[0], msgLow[0]);
-    SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityNormal),
-                  "SetPriority failed for an already queued message.");
+    SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityNormal));
     VerifyPriorityQueueContent(queue, 3, msgNor[0], msgHigh[0], msgLow[0]);
-    SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityHigh),
-                  "SetPriority failed for an already queued message.");
+    SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityHigh));
     VerifyPriorityQueueContent(queue, 3, msgNor[0], msgHigh[0], msgLow[0]);
-    SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityNet),
-                  "SetPriority failed for an already queued message.");
+    SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityNet));
     VerifyPriorityQueueContent(queue, 3, msgNor[0], msgLow[0], msgHigh[0]);
-    SuccessOrQuit(msgNor[0]->SetPriority(ot::Message::kPriorityNormal),
-                  "SetPriority failed for an already queued message.");
-    SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityLow),
-                  "SetPriority failed for an already queued message.");
+    SuccessOrQuit(msgNor[0]->SetPriority(ot::Message::kPriorityNormal));
+    SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityLow));
     VerifyPriorityQueueContent(queue, 3, msgHigh[0], msgNor[0], msgLow[0]);
 
     messageQueue.Enqueue(*msgNor[1]);
@@ -277,12 +265,10 @@ void TestPriorityQueue(void)
     VerifyMsgQueueContent(messageQueue, 3, msgNor[1], msgHigh[1], msgNet[1]);
 
     // Change priority of message and check for not in messageQueue.
-    SuccessOrQuit(msgNor[1]->SetPriority(ot::Message::kPriorityNet),
-                  "SetPriority failed for an already queued message.");
+    SuccessOrQuit(msgNor[1]->SetPriority(ot::Message::kPriorityNet));
     VerifyMsgQueueContent(messageQueue, 3, msgNor[1], msgHigh[1], msgNet[1]);
 
-    SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityHigh),
-                  "SetPriority failed for an already queued message.");
+    SuccessOrQuit(msgLow[0]->SetPriority(ot::Message::kPriorityHigh));
     VerifyPriorityQueueContent(queue, 3, msgHigh[0], msgLow[0], msgNor[0]);
     VerifyMsgQueueContent(messageQueue, 3, msgNor[1], msgHigh[1], msgNet[1]);
 

--- a/tests/unit/test_pskc.cpp
+++ b/tests/unit/test_pskc.cpp
@@ -45,9 +45,8 @@ void TestMinimumPassphrase(void)
     const char            passphrase[]   = "123456";
     otInstance *          instance       = testInitInstance();
     SuccessOrQuit(ot::MeshCoP::GeneratePskc(passphrase, *reinterpret_cast<const ot::Mac::NetworkName *>("OpenThread"),
-                                            static_cast<const ot::Mac::ExtendedPanId &>(xpanid), pskc),
-                  "TestMinimumPassphrase failed to generate PSKc");
-    VerifyOrQuit(memcmp(pskc.m8, expectedPskc, sizeof(pskc)) == 0, "TestMinimumPassphrase got wrong pskc");
+                                            static_cast<const ot::Mac::ExtendedPanId &>(xpanid), pskc));
+    VerifyOrQuit(memcmp(pskc.m8, expectedPskc, sizeof(pskc)) == 0);
     testFreeInstance(instance);
 }
 
@@ -76,9 +75,8 @@ void TestMaximumPassphrase(void)
 
     otInstance *instance = testInitInstance();
     SuccessOrQuit(ot::MeshCoP::GeneratePskc(passphrase, *reinterpret_cast<const ot::Mac::NetworkName *>("OpenThread"),
-                                            static_cast<const ot::Mac::ExtendedPanId &>(xpanid), pskc),
-                  "TestMaximumPassphrase failed to generate PSKc");
-    VerifyOrQuit(memcmp(pskc.m8, expectedPskc, sizeof(pskc)) == 0, "TestMaximumPassphrase got wrong pskc");
+                                            static_cast<const ot::Mac::ExtendedPanId &>(xpanid), pskc));
+    VerifyOrQuit(memcmp(pskc.m8, expectedPskc, sizeof(pskc)) == 0);
     testFreeInstance(instance);
 }
 
@@ -92,9 +90,8 @@ void TestExampleInSpec(void)
 
     otInstance *instance = testInitInstance();
     SuccessOrQuit(ot::MeshCoP::GeneratePskc(passphrase, *reinterpret_cast<const ot::Mac::NetworkName *>("Test Network"),
-                                            static_cast<const ot::Mac::ExtendedPanId &>(xpanid), pskc),
-                  "ExampleInSpec failed to generate PSKc");
-    VerifyOrQuit(memcmp(pskc.m8, expectedPskc, sizeof(pskc)) == 0, "TestExampleInSpec got wrong pskc");
+                                            static_cast<const ot::Mac::ExtendedPanId &>(xpanid), pskc));
+    VerifyOrQuit(memcmp(pskc.m8, expectedPskc, sizeof(pskc)) == 0);
     testFreeInstance(instance);
 }
 

--- a/tests/unit/test_spinel_buffer.cpp
+++ b/tests/unit/test_spinel_buffer.cpp
@@ -178,16 +178,16 @@ void WriteTestFrame1(Spinel::Buffer &aNcpBuffer, Spinel::Buffer::Priority aPrior
 
     message = sMessagePool->New(Message::kTypeIp6, 0);
     VerifyOrQuit(message != nullptr, "Null Message");
-    SuccessOrQuit(message->SetLength(sizeof(sMottoText)), "Could not set the length of message.");
+    SuccessOrQuit(message->SetLength(sizeof(sMottoText)));
     message->Write(0, sMottoText);
 
     oldContext = sContext;
     aNcpBuffer.InFrameBegin(aPriority);
-    SuccessOrQuit(aNcpBuffer.InFrameFeedData(sMottoText, sizeof(sMottoText)), "InFrameFeedData() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameFeedData(sMysteryText, sizeof(sMysteryText)), "InFrameFeedData() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(message), "InFrameFeedMessage() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameFeedData(sHelloText, sizeof(sHelloText)), "InFrameFeedData() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameEnd(), "InFrameEnd() failed.");
+    SuccessOrQuit(aNcpBuffer.InFrameFeedData(sMottoText, sizeof(sMottoText)));
+    SuccessOrQuit(aNcpBuffer.InFrameFeedData(sMysteryText, sizeof(sMysteryText)));
+    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(message));
+    SuccessOrQuit(aNcpBuffer.InFrameFeedData(sHelloText, sizeof(sHelloText)));
+    SuccessOrQuit(aNcpBuffer.InFrameEnd());
     VerifyOrQuit(oldContext.mFrameAddedCount + 1 == sContext.mFrameAddedCount, "FrameAddedCallback failed.");
     VerifyOrQuit(oldContext.mFrameRemovedCount == sContext.mFrameRemovedCount, "FrameRemovedCallback failed.");
 }
@@ -197,19 +197,19 @@ void VerifyAndRemoveFrame1(Spinel::Buffer &aNcpBuffer)
     CallbackContext oldContext = sContext;
 
     sExpectedRemovedTag = aNcpBuffer.OutFrameGetTag();
-    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
-    SuccessOrQuit(aNcpBuffer.OutFrameBegin(), "OutFrameBegin() failed unexpectedly.");
-    VerifyOrQuit(sExpectedRemovedTag == aNcpBuffer.OutFrameGetTag(), "OutFrameGetTag() value changed unexpectedly.");
-    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
+    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == kTestFrame1Size);
+    SuccessOrQuit(aNcpBuffer.OutFrameBegin());
+    VerifyOrQuit(sExpectedRemovedTag == aNcpBuffer.OutFrameGetTag());
+    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == kTestFrame1Size);
     ReadAndVerifyContent(aNcpBuffer, sMottoText, sizeof(sMottoText));
     ReadAndVerifyContent(aNcpBuffer, sMysteryText, sizeof(sMysteryText));
     ReadAndVerifyContent(aNcpBuffer, sMottoText, sizeof(sMottoText));
     ReadAndVerifyContent(aNcpBuffer, sHelloText, sizeof(sHelloText));
-    VerifyOrQuit(aNcpBuffer.OutFrameHasEnded() == true, "Frame longer than expected.");
+    VerifyOrQuit(aNcpBuffer.OutFrameHasEnded(), "Frame longer than expected.");
     VerifyOrQuit(aNcpBuffer.OutFrameReadByte() == 0, "ReadByte() returned non-zero after end of frame.");
-    VerifyOrQuit(sExpectedRemovedTag == aNcpBuffer.OutFrameGetTag(), "OutFrameGetTag() value changed unexpectedly.");
-    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
-    SuccessOrQuit(aNcpBuffer.OutFrameRemove(), "Remove() failed.");
+    VerifyOrQuit(sExpectedRemovedTag == aNcpBuffer.OutFrameGetTag());
+    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == kTestFrame1Size);
+    SuccessOrQuit(aNcpBuffer.OutFrameRemove());
     VerifyOrQuit(oldContext.mFrameAddedCount == sContext.mFrameAddedCount, "FrameAddedCallback failed.");
     VerifyOrQuit(oldContext.mFrameRemovedCount + 1 == sContext.mFrameRemovedCount, "FrameRemovedCallback failed.");
 }
@@ -222,19 +222,19 @@ void WriteTestFrame2(Spinel::Buffer &aNcpBuffer, Spinel::Buffer::Priority aPrior
 
     message1 = sMessagePool->New(Message::kTypeIp6, 0);
     VerifyOrQuit(message1 != nullptr, "Null Message");
-    SuccessOrQuit(message1->SetLength(sizeof(sMysteryText)), "Could not set the length of message.");
+    SuccessOrQuit(message1->SetLength(sizeof(sMysteryText)));
     message1->Write(0, sMysteryText);
 
     message2 = sMessagePool->New(Message::kTypeIp6, 0);
     VerifyOrQuit(message2 != nullptr, "Null Message");
-    SuccessOrQuit(message2->SetLength(sizeof(sHelloText)), "Could not set the length of message.");
+    SuccessOrQuit(message2->SetLength(sizeof(sHelloText)));
     message2->Write(0, sHelloText);
 
     aNcpBuffer.InFrameBegin(aPriority);
-    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(message1), "InFrameFeedMessage() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameFeedData(sOpenThreadText, sizeof(sOpenThreadText)), "InFrameFeedData() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(message2), "InFrameFeedMessage() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameEnd(), "InFrameEnd() failed.");
+    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(message1));
+    SuccessOrQuit(aNcpBuffer.InFrameFeedData(sOpenThreadText, sizeof(sOpenThreadText)));
+    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(message2));
+    SuccessOrQuit(aNcpBuffer.InFrameEnd());
 
     VerifyOrQuit(oldContext.mFrameAddedCount + 1 == sContext.mFrameAddedCount, "FrameAddedCallback failed.");
     VerifyOrQuit(oldContext.mFrameRemovedCount == sContext.mFrameRemovedCount, "FrameRemovedCallback failed.");
@@ -244,17 +244,17 @@ void VerifyAndRemoveFrame2(Spinel::Buffer &aNcpBuffer)
 {
     CallbackContext oldContext = sContext;
 
-    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == kTestFrame2Size, "GetLength() is incorrect.");
-    SuccessOrQuit(aNcpBuffer.OutFrameBegin(), "OutFrameBegin() failed unexpectedly.");
-    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == kTestFrame2Size, "GetLength() is incorrect.");
+    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == kTestFrame2Size);
+    SuccessOrQuit(aNcpBuffer.OutFrameBegin());
+    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == kTestFrame2Size);
     ReadAndVerifyContent(aNcpBuffer, sMysteryText, sizeof(sMysteryText));
     ReadAndVerifyContent(aNcpBuffer, sOpenThreadText, sizeof(sOpenThreadText));
     ReadAndVerifyContent(aNcpBuffer, sHelloText, sizeof(sHelloText));
-    VerifyOrQuit(aNcpBuffer.OutFrameHasEnded() == true, "Frame longer than expected.");
+    VerifyOrQuit(aNcpBuffer.OutFrameHasEnded(), "Frame longer than expected.");
     VerifyOrQuit(aNcpBuffer.OutFrameReadByte() == 0, "ReadByte() returned non-zero after end of frame.");
     sExpectedRemovedTag = aNcpBuffer.OutFrameGetTag();
-    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == kTestFrame2Size, "GetLength() is incorrect.");
-    SuccessOrQuit(aNcpBuffer.OutFrameRemove(), "Remove() failed.");
+    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == kTestFrame2Size);
+    SuccessOrQuit(aNcpBuffer.OutFrameRemove());
 
     VerifyOrQuit(oldContext.mFrameAddedCount == sContext.mFrameAddedCount, "FrameAddedCallback failed.");
     VerifyOrQuit(oldContext.mFrameRemovedCount + 1 == sContext.mFrameRemovedCount, "FrameRemovedCallback failed.");
@@ -269,12 +269,12 @@ void WriteTestFrame3(Spinel::Buffer &aNcpBuffer, Spinel::Buffer::Priority aPrior
     VerifyOrQuit(message1 != nullptr, "Null Message");
 
     // An empty message with no content.
-    SuccessOrQuit(message1->SetLength(0), "Could not set the length of message.");
+    SuccessOrQuit(message1->SetLength(0));
 
     aNcpBuffer.InFrameBegin(aPriority);
-    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(message1), "InFrameFeedMessage() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameFeedData(sMysteryText, sizeof(sMysteryText)), "InFrameFeedData() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameEnd(), "InFrameEnd() failed.");
+    SuccessOrQuit(aNcpBuffer.InFrameFeedMessage(message1));
+    SuccessOrQuit(aNcpBuffer.InFrameFeedData(sMysteryText, sizeof(sMysteryText)));
+    SuccessOrQuit(aNcpBuffer.InFrameEnd());
 
     VerifyOrQuit(oldContext.mFrameAddedCount + 1 == sContext.mFrameAddedCount, "FrameAddedCallback failed.");
     VerifyOrQuit(oldContext.mFrameRemovedCount == sContext.mFrameRemovedCount, "FrameRemovedCallback failed.");
@@ -284,15 +284,15 @@ void VerifyAndRemoveFrame3(Spinel::Buffer &aNcpBuffer)
 {
     CallbackContext oldContext = sContext;
 
-    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == sizeof(sMysteryText), "GetLength() is incorrect.");
-    SuccessOrQuit(aNcpBuffer.OutFrameBegin(), "OutFrameBegin() failed unexpectedly.");
-    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == sizeof(sMysteryText), "GetLength() is incorrect.");
+    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == sizeof(sMysteryText));
+    SuccessOrQuit(aNcpBuffer.OutFrameBegin());
+    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == sizeof(sMysteryText));
     ReadAndVerifyContent(aNcpBuffer, sMysteryText, sizeof(sMysteryText));
-    VerifyOrQuit(aNcpBuffer.OutFrameHasEnded() == true, "Frame longer than expected.");
+    VerifyOrQuit(aNcpBuffer.OutFrameHasEnded(), "Frame longer than expected.");
     VerifyOrQuit(aNcpBuffer.OutFrameReadByte() == 0, "ReadByte() returned non-zero after end of frame.");
     sExpectedRemovedTag = aNcpBuffer.OutFrameGetTag();
-    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == sizeof(sMysteryText), "GetLength() is incorrect.");
-    SuccessOrQuit(aNcpBuffer.OutFrameRemove(), "Remove() failed.");
+    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == sizeof(sMysteryText));
+    SuccessOrQuit(aNcpBuffer.OutFrameRemove());
 
     VerifyOrQuit(oldContext.mFrameAddedCount == sContext.mFrameAddedCount, "FrameAddedCallback failed.");
     VerifyOrQuit(oldContext.mFrameRemovedCount + 1 == sContext.mFrameRemovedCount, "FrameRemovedCallback failed.");
@@ -303,8 +303,8 @@ void WriteTestFrame4(Spinel::Buffer &aNcpBuffer, Spinel::Buffer::Priority aPrior
     CallbackContext oldContext = sContext;
 
     aNcpBuffer.InFrameBegin(aPriority);
-    SuccessOrQuit(aNcpBuffer.InFrameFeedData(sOpenThreadText, sizeof(sOpenThreadText)), "InFrameFeedData() failed.");
-    SuccessOrQuit(aNcpBuffer.InFrameEnd(), "InFrameEnd() failed.");
+    SuccessOrQuit(aNcpBuffer.InFrameFeedData(sOpenThreadText, sizeof(sOpenThreadText)));
+    SuccessOrQuit(aNcpBuffer.InFrameEnd());
 
     VerifyOrQuit(oldContext.mFrameAddedCount + 1 == sContext.mFrameAddedCount, "FrameAddedCallback failed.");
     VerifyOrQuit(oldContext.mFrameRemovedCount == sContext.mFrameRemovedCount, "FrameRemovedCallback failed.");
@@ -314,15 +314,15 @@ void VerifyAndRemoveFrame4(Spinel::Buffer &aNcpBuffer)
 {
     CallbackContext oldContext = sContext;
 
-    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == sizeof(sOpenThreadText), "GetLength() is incorrect.");
-    SuccessOrQuit(aNcpBuffer.OutFrameBegin(), "OutFrameBegin() failed unexpectedly.");
-    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == sizeof(sOpenThreadText), "GetLength() is incorrect.");
+    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == sizeof(sOpenThreadText));
+    SuccessOrQuit(aNcpBuffer.OutFrameBegin());
+    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == sizeof(sOpenThreadText));
     ReadAndVerifyContent(aNcpBuffer, sOpenThreadText, sizeof(sOpenThreadText));
-    VerifyOrQuit(aNcpBuffer.OutFrameHasEnded() == true, "Frame longer than expected.");
+    VerifyOrQuit(aNcpBuffer.OutFrameHasEnded(), "Frame longer than expected.");
     VerifyOrQuit(aNcpBuffer.OutFrameReadByte() == 0, "ReadByte() returned non-zero after end of frame.");
     sExpectedRemovedTag = aNcpBuffer.OutFrameGetTag();
-    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == sizeof(sOpenThreadText), "GetLength() is incorrect.");
-    SuccessOrQuit(aNcpBuffer.OutFrameRemove(), "Remove() failed.");
+    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == sizeof(sOpenThreadText));
+    SuccessOrQuit(aNcpBuffer.OutFrameRemove());
 
     VerifyOrQuit(oldContext.mFrameAddedCount == sContext.mFrameAddedCount, "FrameAddedCallback failed.");
     VerifyOrQuit(oldContext.mFrameRemovedCount + 1 == sContext.mFrameRemovedCount, "FrameRemovedCallback failed.");
@@ -359,7 +359,7 @@ void TestBuffer(void)
     printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
     printf("\nTest 1: Check initial buffer state");
 
-    VerifyOrQuit(ncpBuffer.IsEmpty() == true, "Not empty after init.");
+    VerifyOrQuit(ncpBuffer.IsEmpty(), "Not empty after init.");
     VerifyOrQuit(ncpBuffer.InFrameGetLastTag() == Spinel::Buffer::kInvalidTag, "Incorrect tag after init.");
     VerifyOrQuit(ncpBuffer.OutFrameGetTag() == Spinel::Buffer::kInvalidTag, "Incorrect OutFrameTag after init.");
 
@@ -386,7 +386,7 @@ void TestBuffer(void)
         VerifyOrQuit(ncpBuffer.IsEmpty() == false, "IsEmpty() is incorrect when buffer is non-empty");
 
         VerifyAndRemoveFrame1(ncpBuffer);
-        VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty() is incorrect when buffer is empty.");
+        VerifyOrQuit(ncpBuffer.IsEmpty(), "IsEmpty() is incorrect when buffer is empty.");
     }
 
     // Always add as high priority.
@@ -397,7 +397,7 @@ void TestBuffer(void)
         VerifyOrQuit(ncpBuffer.IsEmpty() == false, "IsEmpty() is incorrect when buffer is non-empty");
 
         VerifyAndRemoveFrame1(ncpBuffer);
-        VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty() is incorrect when buffer is empty.");
+        VerifyOrQuit(ncpBuffer.IsEmpty(), "IsEmpty() is incorrect when buffer is empty.");
     }
 
     // Every 5th add as high priority.
@@ -408,7 +408,7 @@ void TestBuffer(void)
         VerifyOrQuit(ncpBuffer.IsEmpty() == false, "IsEmpty() is incorrect when buffer is non-empty");
 
         VerifyAndRemoveFrame1(ncpBuffer);
-        VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty() is incorrect when buffer is empty.");
+        VerifyOrQuit(ncpBuffer.IsEmpty(), "IsEmpty() is incorrect when buffer is empty.");
     }
 
     printf(" -- PASS\n");
@@ -449,7 +449,7 @@ void TestBuffer(void)
         VerifyAndRemoveFrame2(ncpBuffer);
         VerifyAndRemoveFrame3(ncpBuffer);
 
-        VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty() is incorrect when buffer is empty.");
+        VerifyOrQuit(ncpBuffer.IsEmpty(), "IsEmpty() is incorrect when buffer is empty.");
     }
 
     printf(" -- PASS\n");
@@ -524,14 +524,14 @@ void TestBuffer(void)
         WriteTestFrame3(ncpBuffer, Spinel::Buffer::kPriorityHigh);
 
         ncpBuffer.InFrameBegin((j % 2) == 0 ? Spinel::Buffer::kPriorityHigh : Spinel::Buffer::kPriorityLow);
-        SuccessOrQuit(ncpBuffer.InFrameFeedData(sHelloText, sizeof(sHelloText)), "InFrameFeedData() failed.");
+        SuccessOrQuit(ncpBuffer.InFrameFeedData(sHelloText, sizeof(sHelloText)));
 
         message = sMessagePool->New(Message::kTypeIp6, 0);
         VerifyOrQuit(message != nullptr, "Null Message");
-        SuccessOrQuit(message->SetLength(sizeof(sMysteryText)), "Could not set the length of message.");
+        SuccessOrQuit(message->SetLength(sizeof(sMysteryText)));
         message->Write(0, sMysteryText);
 
-        SuccessOrQuit(ncpBuffer.InFrameFeedMessage(message), "InFrameFeedMessage() failed.");
+        SuccessOrQuit(ncpBuffer.InFrameFeedMessage(message));
 
         // Start writing a new frame in middle of an unfinished frame. Ensure the first one is discarded.
         WriteTestFrame1(ncpBuffer, frame1IsHighPriority ? Spinel::Buffer::kPriorityHigh : Spinel::Buffer::kPriorityLow);
@@ -543,7 +543,7 @@ void TestBuffer(void)
         VerifyAndRemoveFrame3(ncpBuffer);
 
         // Start reading few bytes from the frame
-        SuccessOrQuit(ncpBuffer.OutFrameBegin(), "OutFrameBegin() failed.");
+        SuccessOrQuit(ncpBuffer.OutFrameBegin());
         ncpBuffer.OutFrameReadByte();
         ncpBuffer.OutFrameReadByte();
         ncpBuffer.OutFrameReadByte();
@@ -560,7 +560,7 @@ void TestBuffer(void)
             VerifyAndRemoveFrame1(ncpBuffer);
         }
 
-        VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty() is incorrect when buffer is empty.");
+        VerifyOrQuit(ncpBuffer.IsEmpty(), "IsEmpty() is incorrect when buffer is empty.");
     }
 
     printf(" -- PASS\n");
@@ -575,8 +575,8 @@ void TestBuffer(void)
 
     VerifyOrQuit(ncpBuffer.InFrameGetLastTag() == Spinel::Buffer::kInvalidTag, "Incorrect last tag after Clear().");
     VerifyOrQuit(ncpBuffer.OutFrameGetTag() == Spinel::Buffer::kInvalidTag, "Incorrect OutFrameTag after Clear().");
-    VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty() is incorrect when buffer is empty.");
-    VerifyOrQuit(ncpBuffer.OutFrameHasEnded() == true, "OutFrameHasEnded() is incorrect when no data in buffer.");
+    VerifyOrQuit(ncpBuffer.IsEmpty(), "IsEmpty() is incorrect when buffer is empty.");
+    VerifyOrQuit(ncpBuffer.OutFrameHasEnded(), "OutFrameHasEnded() is incorrect when no data in buffer.");
     VerifyOrQuit(ncpBuffer.OutFrameRemove() == OT_ERROR_NOT_FOUND,
                  "Remove() returned incorrect error status when buffer is empty.");
     VerifyOrQuit(ncpBuffer.OutFrameGetLength() == 0,
@@ -585,8 +585,8 @@ void TestBuffer(void)
     WriteTestFrame1(ncpBuffer, Spinel::Buffer::kPriorityLow);
     VerifyAndRemoveFrame1(ncpBuffer);
 
-    VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty() is incorrect when buffer is empty.");
-    VerifyOrQuit(ncpBuffer.OutFrameHasEnded() == true, "OutFrameHasEnded() is incorrect when no data in buffer.");
+    VerifyOrQuit(ncpBuffer.IsEmpty(), "IsEmpty() is incorrect when buffer is empty.");
+    VerifyOrQuit(ncpBuffer.OutFrameHasEnded(), "OutFrameHasEnded() is incorrect when no data in buffer.");
     VerifyOrQuit(ncpBuffer.OutFrameRemove() == OT_ERROR_NOT_FOUND,
                  "Remove() returned incorrect error status when buffer is empty.");
     VerifyOrQuit(ncpBuffer.OutFrameGetLength() == 0,
@@ -598,10 +598,10 @@ void TestBuffer(void)
     printf("\nTest 7: OutFrameRead() in parts\n");
 
     ncpBuffer.InFrameBegin(Spinel::Buffer::kPriorityLow);
-    SuccessOrQuit(ncpBuffer.InFrameFeedData(sMottoText, sizeof(sMottoText)), "InFrameFeedData() failed.");
-    SuccessOrQuit(ncpBuffer.InFrameEnd(), "InFrameEnd() failed.");
+    SuccessOrQuit(ncpBuffer.InFrameFeedData(sMottoText, sizeof(sMottoText)));
+    SuccessOrQuit(ncpBuffer.InFrameEnd());
 
-    SuccessOrQuit(ncpBuffer.OutFrameBegin(), "OutFrameBegin() failed.");
+    SuccessOrQuit(ncpBuffer.OutFrameBegin());
     readOffset = 0;
 
     while ((readLen = ncpBuffer.OutFrameRead(sizeof(readBuffer), readBuffer)) != 0)
@@ -616,7 +616,7 @@ void TestBuffer(void)
 
     VerifyOrQuit(readOffset == sizeof(sMottoText), "Read len does not match expected length.");
 
-    SuccessOrQuit(ncpBuffer.OutFrameRemove(), "OutFrameRemove() failed.");
+    SuccessOrQuit(ncpBuffer.OutFrameRemove());
 
     printf("\n -- PASS\n");
 
@@ -625,17 +625,17 @@ void TestBuffer(void)
 
     WriteTestFrame1(ncpBuffer, Spinel::Buffer::kPriorityLow);
     WriteTestFrame2(ncpBuffer, Spinel::Buffer::kPriorityLow);
-    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
-    SuccessOrQuit(ncpBuffer.OutFrameRemove(), "Remove() failed.");
+    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size);
+    SuccessOrQuit(ncpBuffer.OutFrameRemove());
     VerifyAndRemoveFrame2(ncpBuffer);
     printf(" -- PASS\n");
 
     printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
     printf("\nTest 9: Check length when front frame gets changed (a higher priority frame is added)");
     WriteTestFrame1(ncpBuffer, Spinel::Buffer::kPriorityLow);
-    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
+    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size);
     WriteTestFrame3(ncpBuffer, Spinel::Buffer::kPriorityHigh);
-    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame3Size, "GetLength() is incorrect.");
+    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame3Size);
     VerifyAndRemoveFrame3(ncpBuffer);
     VerifyAndRemoveFrame1(ncpBuffer);
     printf(" -- PASS\n");
@@ -643,46 +643,46 @@ void TestBuffer(void)
     printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
     printf("\nTest 10: Active out frame remaining unchanged when a higher priority frame is written while reading it");
     WriteTestFrame1(ncpBuffer, Spinel::Buffer::kPriorityLow);
-    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
-    SuccessOrQuit(ncpBuffer.OutFrameBegin(), "OutFrameBegin() failed unexpectedly.");
-    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
+    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size);
+    SuccessOrQuit(ncpBuffer.OutFrameBegin());
+    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size);
     ReadAndVerifyContent(ncpBuffer, sMottoText, sizeof(sMottoText));
     WriteTestFrame2(ncpBuffer, Spinel::Buffer::kPriorityHigh);
-    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
+    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size);
     ReadAndVerifyContent(ncpBuffer, sMysteryText, sizeof(sMysteryText));
-    SuccessOrQuit(ncpBuffer.OutFrameBegin(), "OutFrameBegin() failed unexpectedly.");
-    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
+    SuccessOrQuit(ncpBuffer.OutFrameBegin());
+    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size);
     ReadAndVerifyContent(ncpBuffer, sMottoText, sizeof(sMottoText));
     ReadAndVerifyContent(ncpBuffer, sMysteryText, sizeof(sMysteryText));
     ReadAndVerifyContent(ncpBuffer, sMottoText, sizeof(sMottoText));
     ReadAndVerifyContent(ncpBuffer, sHelloText, sizeof(sHelloText));
-    VerifyOrQuit(ncpBuffer.OutFrameHasEnded() == true, "Frame longer than expected.");
+    VerifyOrQuit(ncpBuffer.OutFrameHasEnded(), "Frame longer than expected.");
     WriteTestFrame3(ncpBuffer, Spinel::Buffer::kPriorityHigh);
     WriteTestFrame4(ncpBuffer, Spinel::Buffer::kPriorityLow);
-    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
+    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size);
     VerifyAndRemoveFrame1(ncpBuffer);
     VerifyAndRemoveFrame2(ncpBuffer);
     VerifyAndRemoveFrame3(ncpBuffer);
     VerifyAndRemoveFrame4(ncpBuffer);
     // Repeat test reversing frame priority orders.
     WriteTestFrame1(ncpBuffer, Spinel::Buffer::kPriorityHigh);
-    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
-    SuccessOrQuit(ncpBuffer.OutFrameBegin(), "OutFrameBegin() failed unexpectedly.");
-    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
+    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size);
+    SuccessOrQuit(ncpBuffer.OutFrameBegin());
+    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size);
     ReadAndVerifyContent(ncpBuffer, sMottoText, sizeof(sMottoText));
     WriteTestFrame2(ncpBuffer, Spinel::Buffer::kPriorityLow);
-    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
+    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size);
     ReadAndVerifyContent(ncpBuffer, sMysteryText, sizeof(sMysteryText));
-    SuccessOrQuit(ncpBuffer.OutFrameBegin(), "OutFrameBegin() failed unexpectedly.");
-    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
+    SuccessOrQuit(ncpBuffer.OutFrameBegin());
+    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size);
     ReadAndVerifyContent(ncpBuffer, sMottoText, sizeof(sMottoText));
     ReadAndVerifyContent(ncpBuffer, sMysteryText, sizeof(sMysteryText));
     ReadAndVerifyContent(ncpBuffer, sMottoText, sizeof(sMottoText));
     ReadAndVerifyContent(ncpBuffer, sHelloText, sizeof(sHelloText));
-    VerifyOrQuit(ncpBuffer.OutFrameHasEnded() == true, "Frame longer than expected.");
+    VerifyOrQuit(ncpBuffer.OutFrameHasEnded(), "Frame longer than expected.");
     WriteTestFrame3(ncpBuffer, Spinel::Buffer::kPriorityHigh);
     WriteTestFrame4(ncpBuffer, Spinel::Buffer::kPriorityLow);
-    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size, "GetLength() is incorrect.");
+    VerifyOrQuit(ncpBuffer.OutFrameGetLength() == kTestFrame1Size);
     VerifyAndRemoveFrame1(ncpBuffer);
     VerifyAndRemoveFrame3(ncpBuffer);
     VerifyAndRemoveFrame2(ncpBuffer);
@@ -693,26 +693,26 @@ void TestBuffer(void)
     printf("\n Test 11: Read and remove in middle of an active input frame write");
     WriteTestFrame1(ncpBuffer, Spinel::Buffer::kPriorityLow);
     ncpBuffer.InFrameBegin(Spinel::Buffer::kPriorityHigh);
-    SuccessOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, sizeof(sOpenThreadText)), "InFrameFeedData() failed.");
+    SuccessOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, sizeof(sOpenThreadText)));
     VerifyAndRemoveFrame1(ncpBuffer);
-    VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty() failed.");
-    SuccessOrQuit(ncpBuffer.InFrameEnd(), "InFrameEnd() failed.");
+    VerifyOrQuit(ncpBuffer.IsEmpty());
+    SuccessOrQuit(ncpBuffer.InFrameEnd());
     VerifyAndRemoveFrame4(ncpBuffer);
     // Repeat the test reversing priorities
     WriteTestFrame1(ncpBuffer, Spinel::Buffer::kPriorityHigh);
     ncpBuffer.InFrameBegin(Spinel::Buffer::kPriorityLow);
-    SuccessOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, sizeof(sOpenThreadText)), "InFrameFeedData() failed.");
+    SuccessOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, sizeof(sOpenThreadText)));
     VerifyAndRemoveFrame1(ncpBuffer);
-    VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty() failed.");
-    SuccessOrQuit(ncpBuffer.InFrameEnd(), "InFrameEnd() failed.");
+    VerifyOrQuit(ncpBuffer.IsEmpty());
+    SuccessOrQuit(ncpBuffer.InFrameEnd());
     VerifyAndRemoveFrame4(ncpBuffer);
     // Repeat the test with same priorities
     WriteTestFrame1(ncpBuffer, Spinel::Buffer::kPriorityHigh);
     ncpBuffer.InFrameBegin(Spinel::Buffer::kPriorityHigh);
-    SuccessOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, sizeof(sOpenThreadText)), "InFrameFeedData() failed.");
+    SuccessOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, sizeof(sOpenThreadText)));
     VerifyAndRemoveFrame1(ncpBuffer);
-    VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty() failed.");
-    SuccessOrQuit(ncpBuffer.InFrameEnd(), "InFrameEnd() failed.");
+    VerifyOrQuit(ncpBuffer.IsEmpty());
+    SuccessOrQuit(ncpBuffer.InFrameEnd());
     VerifyAndRemoveFrame4(ncpBuffer);
     printf(" -- PASS\n");
 
@@ -720,31 +720,31 @@ void TestBuffer(void)
     printf("\n Test 12: Check returned error status");
     WriteTestFrame1(ncpBuffer, Spinel::Buffer::kPriorityLow);
     ncpBuffer.InFrameBegin(Spinel::Buffer::kPriorityHigh);
-    VerifyOrQuit(ncpBuffer.InFrameFeedData(buffer, sizeof(buffer)) == OT_ERROR_NO_BUFS, "Incorrect error status");
+    VerifyOrQuit(ncpBuffer.InFrameFeedData(buffer, sizeof(buffer)) == OT_ERROR_NO_BUFS);
     VerifyAndRemoveFrame1(ncpBuffer);
-    VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty() failed.");
+    VerifyOrQuit(ncpBuffer.IsEmpty());
 
     WriteTestFrame1(ncpBuffer, Spinel::Buffer::kPriorityLow);
     WriteTestFrame2(ncpBuffer, Spinel::Buffer::kPriorityHigh);
     // Ensure writes with starting `InFrameBegin()` fail
-    VerifyOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, 1) == OT_ERROR_INVALID_STATE, "Incorrect error status");
-    VerifyOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, 0) == OT_ERROR_INVALID_STATE, "Incorrect error status");
-    VerifyOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, 0) == OT_ERROR_INVALID_STATE, "Incorrect error status");
-    VerifyOrQuit(ncpBuffer.InFrameEnd() == OT_ERROR_INVALID_STATE, "Incorrect error status");
+    VerifyOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, 1) == OT_ERROR_INVALID_STATE);
+    VerifyOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, 0) == OT_ERROR_INVALID_STATE);
+    VerifyOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, 0) == OT_ERROR_INVALID_STATE);
+    VerifyOrQuit(ncpBuffer.InFrameEnd() == OT_ERROR_INVALID_STATE);
     message = sMessagePool->New(Message::kTypeIp6, 0);
     VerifyOrQuit(message != nullptr, "Null Message");
-    SuccessOrQuit(message->SetLength(sizeof(sMysteryText)), "Could not set the length of message.");
+    SuccessOrQuit(message->SetLength(sizeof(sMysteryText)));
     message->Write(0, sMysteryText);
-    VerifyOrQuit(ncpBuffer.InFrameFeedMessage(message) == OT_ERROR_INVALID_STATE, "Incorrect error status");
+    VerifyOrQuit(ncpBuffer.InFrameFeedMessage(message) == OT_ERROR_INVALID_STATE);
     message->Free();
-    VerifyOrQuit(ncpBuffer.InFrameEnd() == OT_ERROR_INVALID_STATE, "Incorrect error status");
+    VerifyOrQuit(ncpBuffer.InFrameEnd() == OT_ERROR_INVALID_STATE);
     VerifyAndRemoveFrame2(ncpBuffer);
     VerifyAndRemoveFrame1(ncpBuffer);
-    VerifyOrQuit(ncpBuffer.IsEmpty(), "IsEmpty() failed");
+    VerifyOrQuit(ncpBuffer.IsEmpty());
     VerifyOrQuit(ncpBuffer.OutFrameBegin() == OT_ERROR_NOT_FOUND, "OutFrameBegin() failed on empty queue");
     WriteTestFrame1(ncpBuffer, Spinel::Buffer::kPriorityHigh);
     VerifyAndRemoveFrame1(ncpBuffer);
-    VerifyOrQuit(ncpBuffer.IsEmpty(), "IsEmpty() failed");
+    VerifyOrQuit(ncpBuffer.IsEmpty());
     printf(" -- PASS\n");
 
     printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
@@ -754,18 +754,18 @@ void TestBuffer(void)
     ncpBuffer.InFrameBegin(Spinel::Buffer::kPriorityHigh);
     VerifyAndRemoveFrame1(ncpBuffer);
     VerifyAndRemoveFrame2(ncpBuffer);
-    SuccessOrQuit(ncpBuffer.InFrameFeedData(buffer, sizeof(buffer) - 4), "InFrameFeedData() failed.");
-    SuccessOrQuit(ncpBuffer.InFrameEnd(), "InFrameEnd() failed.");
-    SuccessOrQuit(ncpBuffer.OutFrameRemove(), "OutFrameRemove() failed.");
+    SuccessOrQuit(ncpBuffer.InFrameFeedData(buffer, sizeof(buffer) - 4));
+    SuccessOrQuit(ncpBuffer.InFrameEnd());
+    SuccessOrQuit(ncpBuffer.OutFrameRemove());
     // Repeat the test with a low priority buffer write
     WriteTestFrame1(ncpBuffer, Spinel::Buffer::kPriorityHigh);
     WriteTestFrame2(ncpBuffer, Spinel::Buffer::kPriorityLow);
     ncpBuffer.InFrameBegin(Spinel::Buffer::kPriorityLow);
     VerifyAndRemoveFrame1(ncpBuffer);
     VerifyAndRemoveFrame2(ncpBuffer);
-    SuccessOrQuit(ncpBuffer.InFrameFeedData(buffer, sizeof(buffer) - 4), "InFrameFeedData() failed.");
-    SuccessOrQuit(ncpBuffer.InFrameEnd(), "InFrameEnd() failed.");
-    SuccessOrQuit(ncpBuffer.OutFrameRemove(), "OutFrameRemove() failed.");
+    SuccessOrQuit(ncpBuffer.InFrameFeedData(buffer, sizeof(buffer) - 4));
+    SuccessOrQuit(ncpBuffer.InFrameEnd());
+    SuccessOrQuit(ncpBuffer.OutFrameRemove());
     printf(" -- PASS\n");
 
     printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
@@ -782,14 +782,14 @@ void TestBuffer(void)
         priority = ((j % 3) == 0) ? Spinel::Buffer::kPriorityHigh : Spinel::Buffer::kPriorityLow;
         index    = static_cast<uint16_t>(j % sizeof(sHexText));
         ncpBuffer.InFrameBegin(priority);
-        SuccessOrQuit(ncpBuffer.InFrameFeedData(sHexText, index), "InFrameFeedData() failed.");
-        SuccessOrQuit(ncpBuffer.InFrameGetPosition(pos1), "InFrameGetPosition() failed");
-        SuccessOrQuit(ncpBuffer.InFrameFeedData(sMysteryText, sizeof(sHexText) - index), "InFrameFeedData() failed.");
-        VerifyOrQuit(ncpBuffer.InFrameGetDistance(pos1) == sizeof(sHexText) - index, "InFrameGetDistance() failed");
+        SuccessOrQuit(ncpBuffer.InFrameFeedData(sHexText, index));
+        SuccessOrQuit(ncpBuffer.InFrameGetPosition(pos1));
+        SuccessOrQuit(ncpBuffer.InFrameFeedData(sMysteryText, sizeof(sHexText) - index));
+        VerifyOrQuit(ncpBuffer.InFrameGetDistance(pos1) == sizeof(sHexText) - index);
 
         if (addExtra)
         {
-            SuccessOrQuit(ncpBuffer.InFrameFeedData(sHelloText, sizeof(sHelloText)), "InFrameFeedData() failed.");
+            SuccessOrQuit(ncpBuffer.InFrameFeedData(sHelloText, sizeof(sHelloText)));
         }
 
         SuccessOrQuit(ncpBuffer.InFrameOverwrite(pos1, sHexText + index, sizeof(sHexText) - index),
@@ -797,10 +797,10 @@ void TestBuffer(void)
         VerifyOrQuit(ncpBuffer.InFrameGetDistance(pos1) ==
                          sizeof(sHexText) - index + (addExtra ? sizeof(sHelloText) : 0),
                      "InFrameGetDistance() failed");
-        SuccessOrQuit(ncpBuffer.InFrameEnd(), "InFrameEnd() failed.");
-        VerifyOrQuit(ncpBuffer.InFrameGetPosition(pos2) == OT_ERROR_INVALID_STATE, "GetPosition failed.");
-        VerifyOrQuit(ncpBuffer.InFrameOverwrite(pos1, sHexText, 0) != OT_ERROR_NONE, "Failed to give error.");
-        SuccessOrQuit(ncpBuffer.OutFrameBegin(), "OutFrameBegin() failed");
+        SuccessOrQuit(ncpBuffer.InFrameEnd());
+        VerifyOrQuit(ncpBuffer.InFrameGetPosition(pos2) == OT_ERROR_INVALID_STATE);
+        VerifyOrQuit(ncpBuffer.InFrameOverwrite(pos1, sHexText, 0) != OT_ERROR_NONE);
+        SuccessOrQuit(ncpBuffer.OutFrameBegin());
         ReadAndVerifyContent(ncpBuffer, sHexText, sizeof(sHexText));
 
         if (addExtra)
@@ -808,8 +808,8 @@ void TestBuffer(void)
             ReadAndVerifyContent(ncpBuffer, sHelloText, sizeof(sHelloText));
         }
 
-        SuccessOrQuit(ncpBuffer.OutFrameRemove(), "OutFrameRemove() failed");
-        VerifyOrQuit(ncpBuffer.InFrameGetPosition(pos2) == OT_ERROR_INVALID_STATE, "GetPosition failed");
+        SuccessOrQuit(ncpBuffer.OutFrameRemove());
+        VerifyOrQuit(ncpBuffer.InFrameGetPosition(pos2) == OT_ERROR_INVALID_STATE);
     }
 
     printf(" -- PASS\n");
@@ -828,32 +828,30 @@ void TestBuffer(void)
         priority = ((j % 3) == 0) ? Spinel::Buffer::kPriorityHigh : Spinel::Buffer::kPriorityLow;
         index    = static_cast<uint16_t>(j % sizeof(sHexText));
         ncpBuffer.InFrameBegin(priority);
-        SuccessOrQuit(ncpBuffer.InFrameFeedData(sHexText, index), "InFrameFeedData() failed.");
-        SuccessOrQuit(ncpBuffer.InFrameGetPosition(pos1), "InFrameGetPosition() failed");
-        SuccessOrQuit(ncpBuffer.InFrameFeedData(sMysteryText, sizeof(sHexText) - index), "InFrameFeedData() failed.");
-        VerifyOrQuit(ncpBuffer.InFrameGetDistance(pos1) == sizeof(sHexText) - index, "InFrameGetDistance() failed");
+        SuccessOrQuit(ncpBuffer.InFrameFeedData(sHexText, index));
+        SuccessOrQuit(ncpBuffer.InFrameGetPosition(pos1));
+        SuccessOrQuit(ncpBuffer.InFrameFeedData(sMysteryText, sizeof(sHexText) - index));
+        VerifyOrQuit(ncpBuffer.InFrameGetDistance(pos1) == sizeof(sHexText) - index);
 
         if (addExtra)
         {
-            SuccessOrQuit(ncpBuffer.InFrameFeedData(sHelloText, sizeof(sHelloText)), "InFrameFeedData() failed.");
+            SuccessOrQuit(ncpBuffer.InFrameFeedData(sHelloText, sizeof(sHelloText)));
         }
 
-        SuccessOrQuit(ncpBuffer.InFrameReset(pos1), "InFrameReset() failed.");
-        SuccessOrQuit(ncpBuffer.InFrameFeedData(sHexText + index, sizeof(sHexText) - index),
-                      "InFrameOverwrite() failed.");
+        SuccessOrQuit(ncpBuffer.InFrameReset(pos1));
+        SuccessOrQuit(ncpBuffer.InFrameFeedData(sHexText + index, sizeof(sHexText) - index));
 
         if (addExtra)
         {
-            SuccessOrQuit(ncpBuffer.InFrameReset(pos1), "InFrameReset() failed.");
-            SuccessOrQuit(ncpBuffer.InFrameFeedData(sHexText + index, sizeof(sHexText) - index),
-                          "InFrameOverwrite() failed.");
+            SuccessOrQuit(ncpBuffer.InFrameReset(pos1));
+            SuccessOrQuit(ncpBuffer.InFrameFeedData(sHexText + index, sizeof(sHexText) - index));
         }
 
-        VerifyOrQuit(ncpBuffer.InFrameGetDistance(pos1) == sizeof(sHexText) - index, "InFrameGetDistance() failed");
-        SuccessOrQuit(ncpBuffer.InFrameEnd(), "InFrameEnd() failed.");
-        SuccessOrQuit(ncpBuffer.OutFrameBegin(), "OutFrameBegin() failed");
+        VerifyOrQuit(ncpBuffer.InFrameGetDistance(pos1) == sizeof(sHexText) - index);
+        SuccessOrQuit(ncpBuffer.InFrameEnd());
+        SuccessOrQuit(ncpBuffer.OutFrameBegin());
         ReadAndVerifyContent(ncpBuffer, sHexText, sizeof(sHexText));
-        SuccessOrQuit(ncpBuffer.OutFrameRemove(), "OutFrameRemove() failed");
+        SuccessOrQuit(ncpBuffer.OutFrameRemove());
     }
 
     printf(" -- PASS\n");
@@ -893,8 +891,7 @@ uint32_t GetRandom(uint32_t max)
 
     if (kUseTrueRandomNumberGenerator)
     {
-        SuccessOrQuit(Random::Crypto::FillBuffer(reinterpret_cast<uint8_t *>(&value), sizeof(value)),
-                      "Random::Crypto::FillBuffer() failed.");
+        SuccessOrQuit(Random::Crypto::FillBuffer(reinterpret_cast<uint8_t *>(&value), sizeof(value)));
     }
     else
     {
@@ -937,14 +934,14 @@ otError ReadRandomFrame(uint32_t aLength, Spinel::Buffer &aNcpBuffer, uint8_t pr
 {
     CallbackContext oldContext = sContext;
 
-    SuccessOrQuit(aNcpBuffer.OutFrameBegin(), "OutFrameBegin failed");
-    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == aLength, "OutFrameGetLength() does not match");
+    SuccessOrQuit(aNcpBuffer.OutFrameBegin());
+    VerifyOrQuit(aNcpBuffer.OutFrameGetLength() == aLength);
 
     // Read and verify that the content is same as sFrameBuffer values...
     ReadAndVerifyContent(aNcpBuffer, sFrameBuffer[priority], static_cast<uint16_t>(aLength));
     sExpectedRemovedTag = aNcpBuffer.OutFrameGetTag();
 
-    SuccessOrQuit(aNcpBuffer.OutFrameRemove(), "OutFrameRemove failed");
+    SuccessOrQuit(aNcpBuffer.OutFrameRemove());
 
     sFrameBufferTailIndex[priority] -= aLength;
     memmove(sFrameBuffer[priority], sFrameBuffer[priority] + aLength, sFrameBufferTailIndex[priority]);
@@ -1045,7 +1042,7 @@ void TestFuzzBuffer(void)
 
         if (lensArrayCount[0] == 0 && lensArrayCount[1] == 0)
         {
-            VerifyOrQuit(ncpBuffer.IsEmpty() == true, "IsEmpty failed.");
+            VerifyOrQuit(ncpBuffer.IsEmpty());
             printf("EMPTY ");
         }
     }

--- a/tests/unit/test_spinel_decoder.cpp
+++ b/tests/unit/test_spinel_decoder.cpp
@@ -120,69 +120,69 @@ void TestDecoder(void)
 
     decoder.Init(buffer, static_cast<uint16_t>(frameLen));
 
-    VerifyOrQuit(decoder.GetFrame() == &buffer[0], "GetFrame() failed.");
-    VerifyOrQuit(decoder.GetLength() == frameLen, "GetLength() failed.");
+    VerifyOrQuit(decoder.GetFrame() == &buffer[0]);
+    VerifyOrQuit(decoder.GetLength() == frameLen);
 
-    VerifyOrQuit(decoder.GetReadLength() == 0, "GetReadLength() failed.");
-    VerifyOrQuit(decoder.GetRemainingLength() == frameLen, "GetRemainingLength() failed.");
-    VerifyOrQuit(decoder.IsAllRead() == false, "IsAllRead() failed.");
+    VerifyOrQuit(decoder.GetReadLength() == 0);
+    VerifyOrQuit(decoder.GetRemainingLength() == frameLen);
+    VerifyOrQuit(decoder.IsAllRead() == false);
 
-    SuccessOrQuit(decoder.ReadBool(b_1), "ReadBool() failed.");
-    SuccessOrQuit(decoder.ReadBool(b_2), "ReadBool() failed.");
-    SuccessOrQuit(decoder.ReadUint8(u8), "ReadUint8() failed.");
-    SuccessOrQuit(decoder.ReadInt8(i8), "ReadUint8() failed.");
-    SuccessOrQuit(decoder.ReadUint16(u16), "ReadUint16() failed.");
-    SuccessOrQuit(decoder.ReadInt16(i16), "ReadInt16() failed.");
-    SuccessOrQuit(decoder.ReadUint32(u32), "ReadUint32() failed.");
-    SuccessOrQuit(decoder.ReadInt32(i32), "ReadUint32() failed.");
-    SuccessOrQuit(decoder.ReadUint64(u64), "ReadUint64() failed.");
-    SuccessOrQuit(decoder.ReadInt64(i64), "ReadUint64() failed.");
+    SuccessOrQuit(decoder.ReadBool(b_1));
+    SuccessOrQuit(decoder.ReadBool(b_2));
+    SuccessOrQuit(decoder.ReadUint8(u8));
+    SuccessOrQuit(decoder.ReadInt8(i8));
+    SuccessOrQuit(decoder.ReadUint16(u16));
+    SuccessOrQuit(decoder.ReadInt16(i16));
+    SuccessOrQuit(decoder.ReadUint32(u32));
+    SuccessOrQuit(decoder.ReadInt32(i32));
+    SuccessOrQuit(decoder.ReadUint64(u64));
+    SuccessOrQuit(decoder.ReadInt64(i64));
 
     // Check the state
-    VerifyOrQuit(decoder.GetReadLength() != 0, "GetReadLength() failed.");
-    VerifyOrQuit(decoder.GetRemainingLength() == frameLen - decoder.GetReadLength(), "GetRemainingLength() failed.");
-    VerifyOrQuit(decoder.IsAllRead() == false, "IsAllRead() failed.");
+    VerifyOrQuit(decoder.GetReadLength() != 0);
+    VerifyOrQuit(decoder.GetRemainingLength() == frameLen - decoder.GetReadLength());
+    VerifyOrQuit(decoder.IsAllRead() == false);
 
-    SuccessOrQuit(decoder.ReadUintPacked(u_1), "ReadUintPacked() failed.");
+    SuccessOrQuit(decoder.ReadUintPacked(u_1));
 
-    SuccessOrQuit(decoder.ReadUintPacked(u_2), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_3), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_4), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadIp6Address(ip6Addr), "ReadIp6Addr() failed.");
-    SuccessOrQuit(decoder.ReadEui48(eui48), "ReadEui48() failed.");
-    SuccessOrQuit(decoder.ReadEui64(eui64), "ReadEui64() failed.");
-    SuccessOrQuit(decoder.ReadUtf8(utf_1), "ReadUtf8() failed.");
-    SuccessOrQuit(decoder.ReadUtf8(utf_2), "ReadUtf8() failed.");
-    SuccessOrQuit(decoder.ReadDataWithLen(dataPtr_1, dataLen_1), "ReadDataWithLen() failed.");
-    SuccessOrQuit(decoder.ReadData(dataPtr_2, dataLen_2), "ReadData() failed.");
+    SuccessOrQuit(decoder.ReadUintPacked(u_2));
+    SuccessOrQuit(decoder.ReadUintPacked(u_3));
+    SuccessOrQuit(decoder.ReadUintPacked(u_4));
+    SuccessOrQuit(decoder.ReadIp6Address(ip6Addr));
+    SuccessOrQuit(decoder.ReadEui48(eui48));
+    SuccessOrQuit(decoder.ReadEui64(eui64));
+    SuccessOrQuit(decoder.ReadUtf8(utf_1));
+    SuccessOrQuit(decoder.ReadUtf8(utf_2));
+    SuccessOrQuit(decoder.ReadDataWithLen(dataPtr_1, dataLen_1));
+    SuccessOrQuit(decoder.ReadData(dataPtr_2, dataLen_2));
 
-    VerifyOrQuit(decoder.GetReadLength() == frameLen, "GetReadLength() failed.");
-    VerifyOrQuit(decoder.GetRemainingLength() == 0, "GetRemainingLength() failed.");
-    VerifyOrQuit(decoder.IsAllRead() == true, "IsAllRead() failed.");
+    VerifyOrQuit(decoder.GetReadLength() == frameLen);
+    VerifyOrQuit(decoder.GetRemainingLength() == 0);
+    VerifyOrQuit(decoder.IsAllRead() == true);
 
-    VerifyOrQuit(b_1 == kBool_1, "ReadBool() parse failed.");
-    VerifyOrQuit(b_2 == kBool_2, "ReadBool() parse failed.");
-    VerifyOrQuit(u8 == kUint8, "ReadUint8() parse failed.");
-    VerifyOrQuit(i8 == kInt8, "ReadUint8() parse failed.");
-    VerifyOrQuit(u16 == kUint16, "ReadUint16() parse failed.");
-    VerifyOrQuit(i16 == kInt16, "ReadInt16() parse failed.");
-    VerifyOrQuit(u32 == kUint32, "ReadUint32() parse failed.");
-    VerifyOrQuit(i32 == kInt32, "ReadInt32() parse failed.");
-    VerifyOrQuit(u64 == kUint64, "ReadUint64() parse failed.");
-    VerifyOrQuit(i64 == kInt64, "ReadInt64() parse failed.");
-    VerifyOrQuit(u_1 == kUint_1, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(u_2 == kUint_2, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(u_3 == kUint_3, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(u_4 == kUint_4, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0, "ReadIp6Address() parse failed.");
-    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0, "ReadEui48() parse failed.");
-    VerifyOrQuit(memcmp(eui64, &kEui64, sizeof(spinel_eui64_t)) == 0, "ReadEui64() parse failed.");
-    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0, "ReadUtf8() parse failed.");
-    VerifyOrQuit(memcmp(utf_2, kString_2, sizeof(kString_2)) == 0, "ReadUtf8() parse failed.");
-    VerifyOrQuit(dataLen_1 == sizeof(kData), "ReadData() parse failed.");
-    VerifyOrQuit(memcmp(dataPtr_1, &kData, sizeof(kData)) == 0, "ReadData() parse failed.");
-    VerifyOrQuit(dataLen_2 == sizeof(kData), "ReadData() parse failed.");
-    VerifyOrQuit(memcmp(dataPtr_2, &kData, sizeof(kData)) == 0, "ReadData() parse failed.");
+    VerifyOrQuit(b_1 == kBool_1);
+    VerifyOrQuit(b_2 == kBool_2);
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(i8 == kInt8);
+    VerifyOrQuit(u16 == kUint16);
+    VerifyOrQuit(i16 == kInt16);
+    VerifyOrQuit(u32 == kUint32);
+    VerifyOrQuit(i32 == kInt32);
+    VerifyOrQuit(u64 == kUint64);
+    VerifyOrQuit(i64 == kInt64);
+    VerifyOrQuit(u_1 == kUint_1);
+    VerifyOrQuit(u_2 == kUint_2);
+    VerifyOrQuit(u_3 == kUint_3);
+    VerifyOrQuit(u_4 == kUint_4);
+    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0);
+    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0);
+    VerifyOrQuit(memcmp(eui64, &kEui64, sizeof(spinel_eui64_t)) == 0);
+    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0);
+    VerifyOrQuit(memcmp(utf_2, kString_2, sizeof(kString_2)) == 0);
+    VerifyOrQuit(dataLen_1 == sizeof(kData));
+    VerifyOrQuit(memcmp(dataPtr_1, &kData, sizeof(kData)) == 0);
+    VerifyOrQuit(dataLen_2 == sizeof(kData));
+    VerifyOrQuit(memcmp(dataPtr_2, &kData, sizeof(kData)) == 0);
 
     printf(" -- PASS\n");
 
@@ -190,104 +190,104 @@ void TestDecoder(void)
     printf("\nTest 2: Test Reset(), SavePosition(), ResetToSaved()");
 
     // `ResetToSaved()` should fail if there is no saved position
-    VerifyOrQuit(decoder.ResetToSaved() == OT_ERROR_INVALID_STATE, "ResetToSaved() did not fail");
+    VerifyOrQuit(decoder.ResetToSaved() == OT_ERROR_INVALID_STATE);
 
     decoder.Reset();
 
-    VerifyOrQuit(decoder.GetFrame() == &buffer[0], "GetFrame() failed.");
-    VerifyOrQuit(decoder.GetLength() == frameLen, "GetLength() failed.");
-    VerifyOrQuit(decoder.GetReadLength() == 0, "GetReadLength() failed.");
-    VerifyOrQuit(decoder.GetRemainingLength() == frameLen, "GetRemainingLength() failed.");
-    VerifyOrQuit(decoder.IsAllRead() == false, "IsAllRead() failed.");
+    VerifyOrQuit(decoder.GetFrame() == &buffer[0]);
+    VerifyOrQuit(decoder.GetLength() == frameLen);
+    VerifyOrQuit(decoder.GetReadLength() == 0);
+    VerifyOrQuit(decoder.GetRemainingLength() == frameLen);
+    VerifyOrQuit(decoder.IsAllRead() == false);
 
-    SuccessOrQuit(decoder.ReadBool(b_1), "ReadBool() failed.");
-    SuccessOrQuit(decoder.ReadBool(b_2), "ReadBool() failed.");
-    SuccessOrQuit(decoder.ReadUint8(u8), "ReadUint8() failed.");
-    SuccessOrQuit(decoder.ReadInt8(i8), "ReadUint8() failed.");
-    SuccessOrQuit(decoder.ReadUint16(u16), "ReadUint16() failed.");
-    SuccessOrQuit(decoder.ReadInt16(i16), "ReadInt16() failed.");
-    SuccessOrQuit(decoder.ReadUint32(u32), "ReadUint32() failed.");
-    SuccessOrQuit(decoder.ReadInt32(i32), "ReadUint32() failed.");
+    SuccessOrQuit(decoder.ReadBool(b_1));
+    SuccessOrQuit(decoder.ReadBool(b_2));
+    SuccessOrQuit(decoder.ReadUint8(u8));
+    SuccessOrQuit(decoder.ReadInt8(i8));
+    SuccessOrQuit(decoder.ReadUint16(u16));
+    SuccessOrQuit(decoder.ReadInt16(i16));
+    SuccessOrQuit(decoder.ReadUint32(u32));
+    SuccessOrQuit(decoder.ReadInt32(i32));
 
     // `ResetToSaved()` should fail if there is no saved position
-    VerifyOrQuit(decoder.ResetToSaved() == OT_ERROR_INVALID_STATE, "ResetToSaved() did not fail");
+    VerifyOrQuit(decoder.ResetToSaved() == OT_ERROR_INVALID_STATE);
 
     // Save position
     decoder.SavePosition();
 
-    SuccessOrQuit(decoder.ReadUint64(u64), "ReadUint64() failed.");
-    SuccessOrQuit(decoder.ReadInt64(i64), "ReadUint64() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_1), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_2), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_3), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_4), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadIp6Address(ip6Addr), "ReadIp6Addr() failed.");
+    SuccessOrQuit(decoder.ReadUint64(u64));
+    SuccessOrQuit(decoder.ReadInt64(i64));
+    SuccessOrQuit(decoder.ReadUintPacked(u_1));
+    SuccessOrQuit(decoder.ReadUintPacked(u_2));
+    SuccessOrQuit(decoder.ReadUintPacked(u_3));
+    SuccessOrQuit(decoder.ReadUintPacked(u_4));
+    SuccessOrQuit(decoder.ReadIp6Address(ip6Addr));
 
-    VerifyOrQuit(b_1 == kBool_1, "ReadBool() parse failed.");
-    VerifyOrQuit(b_2 == kBool_2, "ReadBool() parse failed.");
-    VerifyOrQuit(u8 == kUint8, "ReadUint8() parse failed.");
-    VerifyOrQuit(i8 == kInt8, "ReadUint8() parse failed.");
-    VerifyOrQuit(u16 == kUint16, "ReadUint16() parse failed.");
-    VerifyOrQuit(i16 == kInt16, "ReadInt16() parse failed.");
-    VerifyOrQuit(u32 == kUint32, "ReadUint32() parse failed.");
-    VerifyOrQuit(i32 == kInt32, "ReadUint32() parse failed.");
-    VerifyOrQuit(u64 == kUint64, "ReadUint64() parse failed.");
-    VerifyOrQuit(i64 == kInt64, "ReadInt64() parse failed.");
-    VerifyOrQuit(u_1 == kUint_1, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(u_2 == kUint_2, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(u_3 == kUint_3, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(u_4 == kUint_4, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0, "ReadIp6Address() parse failed.");
+    VerifyOrQuit(b_1 == kBool_1);
+    VerifyOrQuit(b_2 == kBool_2);
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(i8 == kInt8);
+    VerifyOrQuit(u16 == kUint16);
+    VerifyOrQuit(i16 == kInt16);
+    VerifyOrQuit(u32 == kUint32);
+    VerifyOrQuit(i32 == kInt32);
+    VerifyOrQuit(u64 == kUint64);
+    VerifyOrQuit(i64 == kInt64);
+    VerifyOrQuit(u_1 == kUint_1);
+    VerifyOrQuit(u_2 == kUint_2);
+    VerifyOrQuit(u_3 == kUint_3);
+    VerifyOrQuit(u_4 == kUint_4);
+    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0);
 
-    SuccessOrQuit(decoder.ResetToSaved(), "ResetToSaved() failed");
+    SuccessOrQuit(decoder.ResetToSaved());
 
-    SuccessOrQuit(decoder.ReadUint64(u64), "ReadUint64() failed.");
-    SuccessOrQuit(decoder.ReadInt64(i64), "ReadUint64() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_1), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_2), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_3), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_4), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadIp6Address(ip6Addr), "ReadIp6Addr() failed.");
+    SuccessOrQuit(decoder.ReadUint64(u64));
+    SuccessOrQuit(decoder.ReadInt64(i64));
+    SuccessOrQuit(decoder.ReadUintPacked(u_1));
+    SuccessOrQuit(decoder.ReadUintPacked(u_2));
+    SuccessOrQuit(decoder.ReadUintPacked(u_3));
+    SuccessOrQuit(decoder.ReadUintPacked(u_4));
+    SuccessOrQuit(decoder.ReadIp6Address(ip6Addr));
 
-    VerifyOrQuit(u64 == kUint64, "ReadUint64() parse failed.");
-    VerifyOrQuit(i64 == kInt64, "ReadInt64() parse failed.");
-    VerifyOrQuit(u_1 == kUint_1, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(u_2 == kUint_2, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(u_3 == kUint_3, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(u_4 == kUint_4, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0, "ReadIp6Address() parse failed.");
+    VerifyOrQuit(u64 == kUint64);
+    VerifyOrQuit(i64 == kInt64);
+    VerifyOrQuit(u_1 == kUint_1);
+    VerifyOrQuit(u_2 == kUint_2);
+    VerifyOrQuit(u_3 == kUint_3);
+    VerifyOrQuit(u_4 == kUint_4);
+    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0);
 
     // Go back to save position again.
-    SuccessOrQuit(decoder.ResetToSaved(), "ResetToSaved() failed");
+    SuccessOrQuit(decoder.ResetToSaved());
 
-    SuccessOrQuit(decoder.ReadUint64(u64), "ReadUint64() failed.");
-    SuccessOrQuit(decoder.ReadInt64(i64), "ReadUint64() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_1), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_2), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_3), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadUintPacked(u_4), "ReadUintPacked() failed.");
-    SuccessOrQuit(decoder.ReadIp6Address(ip6Addr), "ReadIp6Addr() failed.");
+    SuccessOrQuit(decoder.ReadUint64(u64));
+    SuccessOrQuit(decoder.ReadInt64(i64));
+    SuccessOrQuit(decoder.ReadUintPacked(u_1));
+    SuccessOrQuit(decoder.ReadUintPacked(u_2));
+    SuccessOrQuit(decoder.ReadUintPacked(u_3));
+    SuccessOrQuit(decoder.ReadUintPacked(u_4));
+    SuccessOrQuit(decoder.ReadIp6Address(ip6Addr));
 
-    VerifyOrQuit(u64 == kUint64, "ReadUint64() parse failed.");
-    VerifyOrQuit(i64 == kInt64, "ReadInt64() parse failed.");
-    VerifyOrQuit(u_1 == kUint_1, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(u_2 == kUint_2, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(u_3 == kUint_3, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(u_4 == kUint_4, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0, "ReadIp6Address() parse failed.");
+    VerifyOrQuit(u64 == kUint64);
+    VerifyOrQuit(i64 == kInt64);
+    VerifyOrQuit(u_1 == kUint_1);
+    VerifyOrQuit(u_2 == kUint_2);
+    VerifyOrQuit(u_3 == kUint_3);
+    VerifyOrQuit(u_4 == kUint_4);
+    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0);
 
     // Ensure saved position is cleared when decoder is reset or re-initialized.
 
     decoder.Reset();
 
     // `ResetToSaved()` should fail if there is no saved position
-    VerifyOrQuit(decoder.ResetToSaved() == OT_ERROR_INVALID_STATE, "ResetToSaved() did not fail");
+    VerifyOrQuit(decoder.ResetToSaved() == OT_ERROR_INVALID_STATE);
 
     decoder.SavePosition();
-    SuccessOrQuit(decoder.ResetToSaved(), "ResetToSaved() failed");
+    SuccessOrQuit(decoder.ResetToSaved());
 
     decoder.Init(buffer, static_cast<uint16_t>(frameLen));
-    VerifyOrQuit(decoder.ResetToSaved() == OT_ERROR_INVALID_STATE, "ResetToSaved() did not fail");
+    VerifyOrQuit(decoder.ResetToSaved() == OT_ERROR_INVALID_STATE);
 
     printf(" -- PASS\n");
 
@@ -306,22 +306,22 @@ void TestDecoder(void)
 
     decoder.Init(buffer, static_cast<uint16_t>(frameLen));
 
-    SuccessOrQuit(decoder.ReadUint8(u8), "ReadUint8() failed.");
-    SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(decoder.ReadUint8(u8));
+    SuccessOrQuit(decoder.OpenStruct());
     {
-        SuccessOrQuit(decoder.ReadUint32(u32), "ReadUint32() failed.");
-        SuccessOrQuit(decoder.ReadEui48(eui48), "ReadEui48() failed.");
-        SuccessOrQuit(decoder.ReadUintPacked(u_3), "ReadUintPacked() failed.");
+        SuccessOrQuit(decoder.ReadUint32(u32));
+        SuccessOrQuit(decoder.ReadEui48(eui48));
+        SuccessOrQuit(decoder.ReadUintPacked(u_3));
     }
-    SuccessOrQuit(decoder.CloseStruct(), "CloseStruct() failed.");
-    SuccessOrQuit(decoder.ReadInt16(i16), "ReadInt16() failed.");
-    VerifyOrQuit(decoder.IsAllRead() == true, "IsAllRead() failed.");
+    SuccessOrQuit(decoder.CloseStruct());
+    SuccessOrQuit(decoder.ReadInt16(i16));
+    VerifyOrQuit(decoder.IsAllRead() == true);
 
-    VerifyOrQuit(u8 == kUint8, "ReadUint8() parse failed.");
-    VerifyOrQuit(i16 == kInt16, "ReadInt16() parse failed.");
-    VerifyOrQuit(u32 == kUint32, "ReadUint32() parse failed.");
-    VerifyOrQuit(u_3 == kUint_3, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0, "ReadEui48() parse failed.");
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(i16 == kInt16);
+    VerifyOrQuit(u32 == kUint32);
+    VerifyOrQuit(u_3 == kUint_3);
+    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0);
 
     printf(" -- PASS\n");
 
@@ -332,17 +332,17 @@ void TestDecoder(void)
 
     decoder.Init(buffer, static_cast<uint16_t>(frameLen));
 
-    SuccessOrQuit(decoder.ReadUint8(u8), "ReadUint8() failed.");
-    SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(decoder.ReadUint8(u8));
+    SuccessOrQuit(decoder.OpenStruct());
     {
-        SuccessOrQuit(decoder.ReadUint32(u32), "ReadUint32() failed.");
+        SuccessOrQuit(decoder.ReadUint32(u32));
         // Skip the remaining fields in the struct
     }
-    SuccessOrQuit(decoder.CloseStruct(), "CloseStruct() failed.");
-    SuccessOrQuit(decoder.ReadInt16(i16), "ReadInt16() failed.");
+    SuccessOrQuit(decoder.CloseStruct());
+    SuccessOrQuit(decoder.ReadInt16(i16));
 
-    VerifyOrQuit(u8 == kUint8, "ReadUint8() parse failed.");
-    VerifyOrQuit(i16 == kInt16, "ReadInt16() parse failed.");
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(i16 == kInt16);
 
     printf(" -- PASS\n");
 
@@ -353,54 +353,54 @@ void TestDecoder(void)
 
     decoder.Init(buffer, static_cast<uint16_t>(frameLen));
 
-    VerifyOrQuit(decoder.GetFrame() == &buffer[0], "GetFrame() failed.");
-    VerifyOrQuit(decoder.GetLength() == frameLen, "GetLength() failed.");
+    VerifyOrQuit(decoder.GetFrame() == &buffer[0]);
+    VerifyOrQuit(decoder.GetLength() == frameLen);
 
-    VerifyOrQuit(decoder.GetReadLength() == 0, "GetReadLength() failed.");
-    VerifyOrQuit(decoder.GetRemainingLength() == frameLen, "GetRemainingLength() failed.");
-    VerifyOrQuit(decoder.IsAllRead() == false, "IsAllRead() failed.");
+    VerifyOrQuit(decoder.GetReadLength() == 0);
+    VerifyOrQuit(decoder.GetRemainingLength() == frameLen);
+    VerifyOrQuit(decoder.IsAllRead() == false);
 
     // When not in an struct,  `etRemainingLengthInStruct()` should consider the whole frame.
-    VerifyOrQuit(decoder.GetRemainingLengthInStruct() == frameLen, "GetRemLengthInStruct() failed.");
-    VerifyOrQuit(decoder.IsAllReadInStruct() == false, "IsAllReadInStruct() failed.");
+    VerifyOrQuit(decoder.GetRemainingLengthInStruct() == frameLen);
+    VerifyOrQuit(decoder.IsAllReadInStruct() == false);
 
-    SuccessOrQuit(decoder.ReadUint8(u8), "ReadUint8() failed.");
-    SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(decoder.ReadUint8(u8));
+    SuccessOrQuit(decoder.OpenStruct());
     {
-        VerifyOrQuit(decoder.IsAllReadInStruct() == false, "IsAllReadInStruct() failed.");
+        VerifyOrQuit(decoder.IsAllReadInStruct() == false);
 
-        SuccessOrQuit(decoder.ReadUint32(u32), "ReadUint32() failed.");
-        SuccessOrQuit(decoder.ReadEui48(eui48), "ReadEui48() failed.");
-        SuccessOrQuit(decoder.ReadUintPacked(u_3), "ReadUintPacked() failed.");
+        SuccessOrQuit(decoder.ReadUint32(u32));
+        SuccessOrQuit(decoder.ReadEui48(eui48));
+        SuccessOrQuit(decoder.ReadUintPacked(u_3));
 
-        VerifyOrQuit(decoder.IsAllReadInStruct() == true, "IsAllReadInStruct() failed.");
-        VerifyOrQuit(decoder.GetRemainingLengthInStruct() == 0, "GetRemLengthInStruct() failed.");
+        VerifyOrQuit(decoder.IsAllReadInStruct() == true);
+        VerifyOrQuit(decoder.GetRemainingLengthInStruct() == 0);
 
         // Try reading beyond end of the struct and ensure it fails.
-        VerifyOrQuit(decoder.ReadUint8(u8) == OT_ERROR_PARSE, "ReadUint8() did not fail.");
+        VerifyOrQuit(decoder.ReadUint8(u8) == OT_ERROR_PARSE);
 
         // `ReadData()` at end of struct should still succeed but return zero as the data length.
-        SuccessOrQuit(decoder.ReadData(dataPtr_1, dataLen_1), "ReadData() failed.");
-        VerifyOrQuit(dataLen_1 == 0, "ReadData() parse value failed.");
+        SuccessOrQuit(decoder.ReadData(dataPtr_1, dataLen_1));
+        VerifyOrQuit(dataLen_1 == 0);
     }
-    SuccessOrQuit(decoder.CloseStruct(), "CloseStruct() failed.");
+    SuccessOrQuit(decoder.CloseStruct());
 
-    VerifyOrQuit(decoder.IsAllReadInStruct() == false, "IsAllReadInStruct() failed.");
-    SuccessOrQuit(decoder.ReadInt16(i16), "ReadInt16() failed.");
-    VerifyOrQuit(decoder.IsAllRead() == true, "IsAllRead() failed.");
+    VerifyOrQuit(decoder.IsAllReadInStruct() == false);
+    SuccessOrQuit(decoder.ReadInt16(i16));
+    VerifyOrQuit(decoder.IsAllRead() == true);
 
-    VerifyOrQuit(decoder.GetRemainingLengthInStruct() == 0, "GetRemLengthInStruct() failed.");
-    VerifyOrQuit(decoder.IsAllReadInStruct() == true, "IsAllReadInStruct() failed.");
+    VerifyOrQuit(decoder.GetRemainingLengthInStruct() == 0);
+    VerifyOrQuit(decoder.IsAllReadInStruct() == true);
 
     // `ReadData()` at end of frame should still succeed but return zero as the data length.
-    SuccessOrQuit(decoder.ReadData(dataPtr_1, dataLen_1), "ReadData() failed.");
-    VerifyOrQuit(dataLen_1 == 0, "ReadData() parse value failed.");
+    SuccessOrQuit(decoder.ReadData(dataPtr_1, dataLen_1));
+    VerifyOrQuit(dataLen_1 == 0);
 
-    VerifyOrQuit(u8 == kUint8, "ReadUint8() parse failed.");
-    VerifyOrQuit(i16 == kInt16, "ReadInt16() parse failed.");
-    VerifyOrQuit(u32 == kUint32, "ReadUint32() parse failed.");
-    VerifyOrQuit(u_3 == kUint_3, "ReadUintPacked() parse failed.");
-    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0, "ReadEui48() parse failed.");
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(i16 == kInt16);
+    VerifyOrQuit(u32 == kUint32);
+    VerifyOrQuit(u_3 == kUint_3);
+    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0);
 
     printf(" -- PASS\n");
 
@@ -418,39 +418,39 @@ void TestDecoder(void)
 
     decoder.Init(buffer, static_cast<uint16_t>(frameLen));
 
-    SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(decoder.OpenStruct());
     {
-        SuccessOrQuit(decoder.ReadUint8(u8), "ReadUint8() failed.");
-        SuccessOrQuit(decoder.ReadUtf8(utf_1), "ReadUtf8() failed.");
-        SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+        SuccessOrQuit(decoder.ReadUint8(u8));
+        SuccessOrQuit(decoder.ReadUtf8(utf_1));
+        SuccessOrQuit(decoder.OpenStruct());
         {
-            SuccessOrQuit(decoder.ReadBool(b_1), "ReadBool() failed.");
-            SuccessOrQuit(decoder.ReadIp6Address(ip6Addr), "ReadIp6Addr() failed.");
+            SuccessOrQuit(decoder.ReadBool(b_1));
+            SuccessOrQuit(decoder.ReadIp6Address(ip6Addr));
         }
-        SuccessOrQuit(decoder.CloseStruct(), "CloseStruct() failed.");
-        SuccessOrQuit(decoder.ReadUint16(u16), "ReadUint16() failed.");
+        SuccessOrQuit(decoder.CloseStruct());
+        SuccessOrQuit(decoder.ReadUint16(u16));
     }
-    SuccessOrQuit(decoder.CloseStruct(), "CloseStruct() failed.");
-    SuccessOrQuit(decoder.ReadEui48(eui48), "ReadEui48() failed.");
-    SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(decoder.CloseStruct());
+    SuccessOrQuit(decoder.ReadEui48(eui48));
+    SuccessOrQuit(decoder.OpenStruct());
     {
-        SuccessOrQuit(decoder.ReadUint32(u32), "ReadUint32() failed.");
+        SuccessOrQuit(decoder.ReadUint32(u32));
     }
-    SuccessOrQuit(decoder.CloseStruct(), "CloseStruct() failed.");
-    SuccessOrQuit(decoder.ReadInt32(i32), "WriteUint32() failed.");
+    SuccessOrQuit(decoder.CloseStruct());
+    SuccessOrQuit(decoder.ReadInt32(i32));
 
-    VerifyOrQuit(decoder.GetReadLength() == frameLen, "GetReadLength() failed.");
-    VerifyOrQuit(decoder.GetRemainingLength() == 0, "GetRemainingLength() failed.");
-    VerifyOrQuit(decoder.IsAllRead() == true, "IsAllRead() failed.");
+    VerifyOrQuit(decoder.GetReadLength() == frameLen);
+    VerifyOrQuit(decoder.GetRemainingLength() == 0);
+    VerifyOrQuit(decoder.IsAllRead() == true);
 
-    VerifyOrQuit(b_1 == kBool_1, "ReadBool() parse failed.");
-    VerifyOrQuit(u8 == kUint8, "ReadUint8() parse failed.");
-    VerifyOrQuit(u16 == kUint16, "ReadUint16() parse failed.");
-    VerifyOrQuit(u32 == kUint32, "ReadUint32() parse failed.");
-    VerifyOrQuit(i32 == kInt32, "ReadUint32() parse failed.");
-    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0, "ReadIp6Address() parse failed.");
-    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0, "ReadEui48() parse failed.");
-    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0, "ReadUtf8() parse failed.");
+    VerifyOrQuit(b_1 == kBool_1);
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(u16 == kUint16);
+    VerifyOrQuit(u32 == kUint32);
+    VerifyOrQuit(i32 == kInt32);
+    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0);
+    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0);
+    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0);
 
     printf(" -- PASS\n");
 
@@ -461,58 +461,58 @@ void TestDecoder(void)
 
     decoder.Init(buffer, static_cast<uint16_t>(frameLen));
 
-    SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(decoder.OpenStruct());
     {
-        SuccessOrQuit(decoder.ReadUint8(u8), "ReadUint8() failed.");
+        SuccessOrQuit(decoder.ReadUint8(u8));
 
         decoder.SavePosition();
 
-        SuccessOrQuit(decoder.ReadUtf8(utf_1), "ReadUtf8() failed.");
-        SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+        SuccessOrQuit(decoder.ReadUtf8(utf_1));
+        SuccessOrQuit(decoder.OpenStruct());
         {
-            SuccessOrQuit(decoder.ReadBool(b_1), "ReadBool() failed.");
+            SuccessOrQuit(decoder.ReadBool(b_1));
         }
 
         // Verify the read content so far.
 
-        VerifyOrQuit(u8 == kUint8, "ReadUint8() parse failed.");
-        VerifyOrQuit(b_1 == kBool_1, "ReadBool() parse failed.");
-        VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0, "ReadUtf8() parse failed.");
+        VerifyOrQuit(u8 == kUint8);
+        VerifyOrQuit(b_1 == kBool_1);
+        VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0);
 
         // Do not close the inner struct and jump to previously saved position and re-read the content.
 
-        SuccessOrQuit(decoder.ResetToSaved(), "ResetToSaved() failed.");
+        SuccessOrQuit(decoder.ResetToSaved());
 
-        SuccessOrQuit(decoder.ReadUtf8(utf_1), "ReadUtf8() failed.");
-        SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+        SuccessOrQuit(decoder.ReadUtf8(utf_1));
+        SuccessOrQuit(decoder.OpenStruct());
         {
-            SuccessOrQuit(decoder.ReadBool(b_1), "ReadBool() failed.");
-            SuccessOrQuit(decoder.ReadIp6Address(ip6Addr), "ReadIp6Addr() failed.");
+            SuccessOrQuit(decoder.ReadBool(b_1));
+            SuccessOrQuit(decoder.ReadIp6Address(ip6Addr));
         }
-        SuccessOrQuit(decoder.CloseStruct(), "CloseStruct() failed.");
-        SuccessOrQuit(decoder.ReadUint16(u16), "ReadUint16() failed.");
+        SuccessOrQuit(decoder.CloseStruct());
+        SuccessOrQuit(decoder.ReadUint16(u16));
     }
-    SuccessOrQuit(decoder.CloseStruct(), "CloseStruct() failed.");
-    SuccessOrQuit(decoder.ReadEui48(eui48), "ReadEui48() failed.");
-    SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(decoder.CloseStruct());
+    SuccessOrQuit(decoder.ReadEui48(eui48));
+    SuccessOrQuit(decoder.OpenStruct());
     {
-        SuccessOrQuit(decoder.ReadUint32(u32), "ReadUint32() failed.");
+        SuccessOrQuit(decoder.ReadUint32(u32));
     }
-    SuccessOrQuit(decoder.CloseStruct(), "CloseStruct() failed.");
-    SuccessOrQuit(decoder.ReadInt32(i32), "WriteUint32() failed.");
+    SuccessOrQuit(decoder.CloseStruct());
+    SuccessOrQuit(decoder.ReadInt32(i32));
 
-    VerifyOrQuit(decoder.GetReadLength() == frameLen, "GetReadLength() failed.");
-    VerifyOrQuit(decoder.GetRemainingLength() == 0, "GetRemainingLength() failed.");
-    VerifyOrQuit(decoder.IsAllRead() == true, "IsAllRead() failed.");
+    VerifyOrQuit(decoder.GetReadLength() == frameLen);
+    VerifyOrQuit(decoder.GetRemainingLength() == 0);
+    VerifyOrQuit(decoder.IsAllRead() == true);
 
-    VerifyOrQuit(b_1 == kBool_1, "ReadBool() parse failed.");
-    VerifyOrQuit(u8 == kUint8, "ReadUint8() parse failed.");
-    VerifyOrQuit(u16 == kUint16, "ReadUint16() parse failed.");
-    VerifyOrQuit(u32 == kUint32, "ReadUint32() parse failed.");
-    VerifyOrQuit(i32 == kInt32, "ReadUint32() parse failed.");
-    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0, "ReadIp6Address() parse failed.");
-    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0, "ReadEui48() parse failed.");
-    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0, "ReadUtf8() parse failed.");
+    VerifyOrQuit(b_1 == kBool_1);
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(u16 == kUint16);
+    VerifyOrQuit(u32 == kUint32);
+    VerifyOrQuit(i32 == kInt32);
+    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0);
+    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0);
+    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0);
 
     printf(" -- PASS\n");
 
@@ -523,52 +523,52 @@ void TestDecoder(void)
 
     decoder.Init(buffer, static_cast<uint16_t>(frameLen));
 
-    SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(decoder.OpenStruct());
     {
-        SuccessOrQuit(decoder.ReadUint8(u8), "ReadUint8() failed.");
-        SuccessOrQuit(decoder.ReadUtf8(utf_1), "ReadUtf8() failed.");
-        SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+        SuccessOrQuit(decoder.ReadUint8(u8));
+        SuccessOrQuit(decoder.ReadUtf8(utf_1));
+        SuccessOrQuit(decoder.OpenStruct());
         {
             // Save position at start of the struct
             decoder.SavePosition();
-            SuccessOrQuit(decoder.ReadBool(b_1), "ReadBool() failed.");
+            SuccessOrQuit(decoder.ReadBool(b_1));
 
             // Verify the read content so far.
 
-            VerifyOrQuit(u8 == kUint8, "ReadUint8() parse failed.");
-            VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0, "ReadUtf8() parse failed.");
-            VerifyOrQuit(b_1 == kBool_1, "ReadBool() parse failed.");
+            VerifyOrQuit(u8 == kUint8);
+            VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0);
+            VerifyOrQuit(b_1 == kBool_1);
 
             // Do not close the struct and jump to the previously saved position and re-read the content.
 
-            SuccessOrQuit(decoder.ResetToSaved(), "ResetToSaved() failed.");
-            SuccessOrQuit(decoder.ReadBool(b_1), "ReadBool() failed.");
-            SuccessOrQuit(decoder.ReadIp6Address(ip6Addr), "ReadIp6Addr() failed.");
+            SuccessOrQuit(decoder.ResetToSaved());
+            SuccessOrQuit(decoder.ReadBool(b_1));
+            SuccessOrQuit(decoder.ReadIp6Address(ip6Addr));
         }
-        SuccessOrQuit(decoder.CloseStruct(), "CloseStruct() failed.");
-        SuccessOrQuit(decoder.ReadUint16(u16), "ReadUint16() failed.");
+        SuccessOrQuit(decoder.CloseStruct());
+        SuccessOrQuit(decoder.ReadUint16(u16));
     }
-    SuccessOrQuit(decoder.CloseStruct(), "CloseStruct() failed.");
-    SuccessOrQuit(decoder.ReadEui48(eui48), "ReadEui48() failed.");
-    SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(decoder.CloseStruct());
+    SuccessOrQuit(decoder.ReadEui48(eui48));
+    SuccessOrQuit(decoder.OpenStruct());
     {
-        SuccessOrQuit(decoder.ReadUint32(u32), "ReadUint32() failed.");
+        SuccessOrQuit(decoder.ReadUint32(u32));
     }
-    SuccessOrQuit(decoder.CloseStruct(), "CloseStruct() failed.");
-    SuccessOrQuit(decoder.ReadInt32(i32), "WriteUint32() failed.");
+    SuccessOrQuit(decoder.CloseStruct());
+    SuccessOrQuit(decoder.ReadInt32(i32));
 
-    VerifyOrQuit(decoder.GetReadLength() == frameLen, "GetReadLength() failed.");
-    VerifyOrQuit(decoder.GetRemainingLength() == 0, "GetRemainingLength() failed.");
-    VerifyOrQuit(decoder.IsAllRead() == true, "IsAllRead() failed.");
+    VerifyOrQuit(decoder.GetReadLength() == frameLen);
+    VerifyOrQuit(decoder.GetRemainingLength() == 0);
+    VerifyOrQuit(decoder.IsAllRead() == true);
 
-    VerifyOrQuit(b_1 == kBool_1, "ReadBool() parse failed.");
-    VerifyOrQuit(u8 == kUint8, "ReadUint8() parse failed.");
-    VerifyOrQuit(u16 == kUint16, "ReadUint16() parse failed.");
-    VerifyOrQuit(u32 == kUint32, "ReadUint32() parse failed.");
-    VerifyOrQuit(i32 == kInt32, "ReadUint32() parse failed.");
-    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0, "ReadIp6Address() parse failed.");
-    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0, "ReadEui48() parse failed.");
-    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0, "ReadUtf8() parse failed.");
+    VerifyOrQuit(b_1 == kBool_1);
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(u16 == kUint16);
+    VerifyOrQuit(u32 == kUint32);
+    VerifyOrQuit(i32 == kInt32);
+    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0);
+    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0);
+    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0);
 
     printf(" -- PASS\n");
 
@@ -579,23 +579,23 @@ void TestDecoder(void)
 
     decoder.Init(buffer, static_cast<uint16_t>(frameLen));
 
-    SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(decoder.OpenStruct());
     {
-        SuccessOrQuit(decoder.ReadUint8(u8), "ReadUint8() failed.");
-        SuccessOrQuit(decoder.ReadUtf8(utf_1), "ReadUtf8() failed.");
-        SuccessOrQuit(decoder.OpenStruct(), "OpenStruct() failed.");
+        SuccessOrQuit(decoder.ReadUint8(u8));
+        SuccessOrQuit(decoder.ReadUtf8(utf_1));
+        SuccessOrQuit(decoder.OpenStruct());
         {
-            SuccessOrQuit(decoder.ReadBool(b_1), "ReadBool() failed.");
+            SuccessOrQuit(decoder.ReadBool(b_1));
 
             decoder.SavePosition();
 
-            SuccessOrQuit(decoder.ReadIp6Address(ip6Addr), "ReadIp6Addr() failed.");
+            SuccessOrQuit(decoder.ReadIp6Address(ip6Addr));
         }
-        SuccessOrQuit(decoder.CloseStruct(), "CloseStruct() failed.");
-        SuccessOrQuit(decoder.ReadUint16(u16), "ReadUint16() failed.");
+        SuccessOrQuit(decoder.CloseStruct());
+        SuccessOrQuit(decoder.ReadUint16(u16));
 
         // `ResetToSaved()` should fail since the enclosing struct for the saved position is closed.
-        VerifyOrQuit(decoder.ResetToSaved() == OT_ERROR_INVALID_STATE, "ResetToSaved() did not fail.");
+        VerifyOrQuit(decoder.ResetToSaved() == OT_ERROR_INVALID_STATE);
     }
 
     printf(" -- PASS\n");
@@ -614,26 +614,26 @@ void TestDecoder(void)
 
     decoder.SavePosition();
 
-    SuccessOrQuit(decoder.ReadUint8(u8), "ReadUint8() failed.");
-    VerifyOrQuit(u8 == kUint8, "ReadUint8() parse failed.");
+    SuccessOrQuit(decoder.ReadUint8(u8));
+    VerifyOrQuit(u8 == kUint8);
 
     // `OpenStruct()` should fail, since it expects a length 10 but there are not enough
     // bytes in the frame.
-    VerifyOrQuit(decoder.OpenStruct() == OT_ERROR_PARSE, "OpenStruct() did not fail.");
+    VerifyOrQuit(decoder.OpenStruct() == OT_ERROR_PARSE);
 
-    SuccessOrQuit(decoder.ResetToSaved(), "ResetToSaved() failed.");
+    SuccessOrQuit(decoder.ResetToSaved());
 
-    SuccessOrQuit(decoder.ReadUint8(u8), "ReadUint8() failed.");
-    VerifyOrQuit(u8 == kUint8, "ReadUint8() parse failed.");
-    VerifyOrQuit(decoder.ReadDataWithLen(dataPtr_1, dataLen_1) == OT_ERROR_PARSE, "ReadDataWithLen() did not fail.");
+    SuccessOrQuit(decoder.ReadUint8(u8));
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(decoder.ReadDataWithLen(dataPtr_1, dataLen_1) == OT_ERROR_PARSE);
 
-    SuccessOrQuit(decoder.ResetToSaved(), "ResetToSaved() failed.");
-    SuccessOrQuit(decoder.ReadUint8(u8), "ReadUint8() failed.");
-    SuccessOrQuit(decoder.ReadUint16(u16), "ReadUint16() failed.");
-    SuccessOrQuit(decoder.ReadBool(b_1), "ReadUint16() failed.");
+    SuccessOrQuit(decoder.ResetToSaved());
+    SuccessOrQuit(decoder.ReadUint8(u8));
+    SuccessOrQuit(decoder.ReadUint16(u16));
+    SuccessOrQuit(decoder.ReadBool(b_1));
 
     // Try reading beyond end of frame.
-    VerifyOrQuit(decoder.ReadUint8(u8) == OT_ERROR_PARSE, "ReadUint8() did not fail");
+    VerifyOrQuit(decoder.ReadUint8(u8) == OT_ERROR_PARSE);
 
     printf(" -- PASS\n");
 }

--- a/tests/unit/test_spinel_encoder.cpp
+++ b/tests/unit/test_spinel_encoder.cpp
@@ -117,31 +117,31 @@ void TestEncoder(void)
     printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
     printf("\nTest 1: Encoding of simple types");
 
-    SuccessOrQuit(encoder.BeginFrame(Spinel::Buffer::kPriorityLow), "BeginFrame() failed.");
-    SuccessOrQuit(encoder.WriteBool(kBool_1), "WriteBool() failed.");
-    SuccessOrQuit(encoder.WriteBool(kBool_2), "WriteBool() failed.");
-    SuccessOrQuit(encoder.WriteUint8(kUint8), "WriteUint8() failed.");
-    SuccessOrQuit(encoder.WriteInt8(kInt8), "WriteUint8() failed.");
-    SuccessOrQuit(encoder.WriteUint16(kUint16), "WriteUint16() failed.");
-    SuccessOrQuit(encoder.WriteInt16(kInt16), "WriteInt16() failed.");
-    SuccessOrQuit(encoder.WriteUint32(kUint32), "WriteUint32() failed.");
-    SuccessOrQuit(encoder.WriteInt32(kInt32), "WriteUint32() failed.");
-    SuccessOrQuit(encoder.WriteUint64(kUint64), "WriteUint64() failed.");
-    SuccessOrQuit(encoder.WriteInt64(kInt64), "WriteUint64() failed.");
-    SuccessOrQuit(encoder.WriteUintPacked(kUint_1), "WriteUintPacked() failed.");
-    SuccessOrQuit(encoder.WriteUintPacked(kUint_2), "WriteUintPacked() failed.");
-    SuccessOrQuit(encoder.WriteUintPacked(kUint_3), "WriteUintPacked() failed.");
-    SuccessOrQuit(encoder.WriteUintPacked(kUint_4), "WriteUintPacked() failed.");
-    SuccessOrQuit(encoder.WriteIp6Address(kIp6Addr), "WriteIp6Addr() failed.");
-    SuccessOrQuit(encoder.WriteEui48(kEui48), "WriteEui48() failed.");
-    SuccessOrQuit(encoder.WriteEui64(kEui64), "WriteEui64() failed.");
-    SuccessOrQuit(encoder.WriteUtf8(kString_1), "WriteUtf8() failed.");
-    SuccessOrQuit(encoder.WriteUtf8(kString_2), "WriteUtf8() failed.");
-    SuccessOrQuit(encoder.WriteData((const uint8_t *)kData, sizeof(kData)), "WriteData() failed.");
-    SuccessOrQuit(encoder.EndFrame(), "EndFrame() failed.");
+    SuccessOrQuit(encoder.BeginFrame(Spinel::Buffer::kPriorityLow));
+    SuccessOrQuit(encoder.WriteBool(kBool_1));
+    SuccessOrQuit(encoder.WriteBool(kBool_2));
+    SuccessOrQuit(encoder.WriteUint8(kUint8));
+    SuccessOrQuit(encoder.WriteInt8(kInt8));
+    SuccessOrQuit(encoder.WriteUint16(kUint16));
+    SuccessOrQuit(encoder.WriteInt16(kInt16));
+    SuccessOrQuit(encoder.WriteUint32(kUint32));
+    SuccessOrQuit(encoder.WriteInt32(kInt32));
+    SuccessOrQuit(encoder.WriteUint64(kUint64));
+    SuccessOrQuit(encoder.WriteInt64(kInt64));
+    SuccessOrQuit(encoder.WriteUintPacked(kUint_1));
+    SuccessOrQuit(encoder.WriteUintPacked(kUint_2));
+    SuccessOrQuit(encoder.WriteUintPacked(kUint_3));
+    SuccessOrQuit(encoder.WriteUintPacked(kUint_4));
+    SuccessOrQuit(encoder.WriteIp6Address(kIp6Addr));
+    SuccessOrQuit(encoder.WriteEui48(kEui48));
+    SuccessOrQuit(encoder.WriteEui64(kEui64));
+    SuccessOrQuit(encoder.WriteUtf8(kString_1));
+    SuccessOrQuit(encoder.WriteUtf8(kString_2));
+    SuccessOrQuit(encoder.WriteData((const uint8_t *)kData, sizeof(kData)));
+    SuccessOrQuit(encoder.EndFrame());
 
     DumpBuffer("Buffer", buffer, 256);
-    SuccessOrQuit(ReadFrame(ncpBuffer, frame, frameLen), "ReadFrame() failed.");
+    SuccessOrQuit(ReadFrame(ncpBuffer, frame, frameLen));
     DumpBuffer("Frame", frame, frameLen);
 
     parsedLen = spinel_datatype_unpack(
@@ -155,48 +155,48 @@ void TestEncoder(void)
         &b_1, &b_2, &u8, &i8, &u16, &i16, &u32, &i32, &u64, &i64, &u_1, &u_2, &u_3, &u_4, &ip6Addr, &eui48, &eui64,
         &utf_1, &utf_2, &dataPtr, &dataLen);
 
-    VerifyOrQuit(parsedLen == frameLen, "spinel parse failed");
-    VerifyOrQuit(b_1 == kBool_1, "WriteBool() parse failed.");
-    VerifyOrQuit(b_2 == kBool_2, "WriteBool() parse failed.");
-    VerifyOrQuit(u8 == kUint8, "WriteUint8() parse failed.");
-    VerifyOrQuit(i8 == kInt8, "WriteUint8() parse failed.");
-    VerifyOrQuit(u16 == kUint16, "WriteUint16() parse failed.");
-    VerifyOrQuit(i16 == kInt16, "WriteInt16() parse failed.");
-    VerifyOrQuit(u32 == kUint32, "WriteUint32() parse failed.");
-    VerifyOrQuit(i32 == kInt32, "WriteUint32() parse failed.");
-    VerifyOrQuit(u64 == kUint64, "WriteUint64() parse failed.");
-    VerifyOrQuit(i64 == kInt64, "WriteUint64() parse failed.");
-    VerifyOrQuit(u_1 == kUint_1, "WriteUintPacked() parse failed.");
-    VerifyOrQuit(u_2 == kUint_2, "WriteUintPacked() parse failed.");
-    VerifyOrQuit(u_3 == kUint_3, "WriteUintPacked() parse failed.");
-    VerifyOrQuit(u_4 == kUint_4, "WriteUintPacked() parse failed.");
-    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0, "WriteIp6Address() parse failed.");
-    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0, "WriteEui48() parse failed.");
-    VerifyOrQuit(memcmp(eui64, &kEui64, sizeof(spinel_eui64_t)) == 0, "WriteEui64() parse failed.");
-    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0, "WriteUtf8() parse failed.");
-    VerifyOrQuit(memcmp(utf_2, kString_2, sizeof(kString_2)) == 0, "WriteUtf8() parse failed.");
-    VerifyOrQuit(dataLen == sizeof(kData), "WriteData() parse failed.");
-    VerifyOrQuit(memcmp(dataPtr, &kData, sizeof(kData)) == 0, "WriteData() parse failed.");
+    VerifyOrQuit(parsedLen == frameLen);
+    VerifyOrQuit(b_1 == kBool_1);
+    VerifyOrQuit(b_2 == kBool_2);
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(i8 == kInt8);
+    VerifyOrQuit(u16 == kUint16);
+    VerifyOrQuit(i16 == kInt16);
+    VerifyOrQuit(u32 == kUint32);
+    VerifyOrQuit(i32 == kInt32);
+    VerifyOrQuit(u64 == kUint64);
+    VerifyOrQuit(i64 == kInt64);
+    VerifyOrQuit(u_1 == kUint_1);
+    VerifyOrQuit(u_2 == kUint_2);
+    VerifyOrQuit(u_3 == kUint_3);
+    VerifyOrQuit(u_4 == kUint_4);
+    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0);
+    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0);
+    VerifyOrQuit(memcmp(eui64, &kEui64, sizeof(spinel_eui64_t)) == 0);
+    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0);
+    VerifyOrQuit(memcmp(utf_2, kString_2, sizeof(kString_2)) == 0);
+    VerifyOrQuit(dataLen == sizeof(kData));
+    VerifyOrQuit(memcmp(dataPtr, &kData, sizeof(kData)) == 0);
 
     printf(" -- PASS\n");
 
     printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
     printf("\nTest 2: Test a single simple struct.");
 
-    SuccessOrQuit(encoder.BeginFrame(Spinel::Buffer::kPriorityLow), "BeginFrame() failed.");
-    SuccessOrQuit(encoder.WriteUint8(kUint8), "WriteUint8() failed.");
-    SuccessOrQuit(encoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(encoder.BeginFrame(Spinel::Buffer::kPriorityLow));
+    SuccessOrQuit(encoder.WriteUint8(kUint8));
+    SuccessOrQuit(encoder.OpenStruct());
     {
-        SuccessOrQuit(encoder.WriteUint32(kUint32), "WriteUint32() failed.");
-        SuccessOrQuit(encoder.WriteEui48(kEui48), "WriteEui48() failed.");
-        SuccessOrQuit(encoder.WriteUintPacked(kUint_3), "WriteUintPacked() failed.");
+        SuccessOrQuit(encoder.WriteUint32(kUint32));
+        SuccessOrQuit(encoder.WriteEui48(kEui48));
+        SuccessOrQuit(encoder.WriteUintPacked(kUint_3));
     }
-    SuccessOrQuit(encoder.CloseStruct(), "CloseStruct() failed.");
-    SuccessOrQuit(encoder.WriteInt16(kInt16), "WriteInt16() failed.");
-    SuccessOrQuit(encoder.EndFrame(), "EndFrame() failed.");
+    SuccessOrQuit(encoder.CloseStruct());
+    SuccessOrQuit(encoder.WriteInt16(kInt16));
+    SuccessOrQuit(encoder.EndFrame());
 
     DumpBuffer("Buffer", buffer, 256);
-    SuccessOrQuit(ReadFrame(ncpBuffer, frame, frameLen), "ReadFrame() failed.");
+    SuccessOrQuit(ReadFrame(ncpBuffer, frame, frameLen));
     DumpBuffer("Frame", frame, frameLen);
 
     parsedLen = spinel_datatype_unpack(
@@ -207,12 +207,12 @@ void TestEncoder(void)
          ),
         &u8, &u32, &eui48, &u_3, &i16);
 
-    VerifyOrQuit(parsedLen == frameLen, "spinel parse failed");
-    VerifyOrQuit(u8 == kUint8, "WriteUint8() parse failed.");
-    VerifyOrQuit(i16 == kInt16, "WriteInt16() parse failed.");
-    VerifyOrQuit(u32 == kUint32, "WriteUint32() parse failed.");
-    VerifyOrQuit(u_3 == kUint_3, "WriteUintPacked() parse failed.");
-    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0, "WriteEui48() parse failed.");
+    VerifyOrQuit(parsedLen == frameLen);
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(i16 == kInt16);
+    VerifyOrQuit(u32 == kUint32);
+    VerifyOrQuit(u_3 == kUint_3);
+    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0);
 
     // Parse the struct as a "data with len".
     parsedLen = spinel_datatype_unpack(frame, (spinel_size_t)frameLen,
@@ -221,41 +221,41 @@ void TestEncoder(void)
                                         ),
                                        &u8, &dataPtr, &dataLen, &i16);
 
-    VerifyOrQuit(parsedLen == frameLen, "spinel parse failed");
-    VerifyOrQuit(u8 == kUint8, "WriteUint8() parse failed.");
-    VerifyOrQuit(i16 == kInt16, "WriteInt16() parse failed.");
+    VerifyOrQuit(parsedLen == frameLen);
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(i16 == kInt16);
 
     printf(" -- PASS\n");
 
     printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
     printf("\nTest 3: Test multiple structs and struct within struct.");
 
-    SuccessOrQuit(encoder.BeginFrame(Spinel::Buffer::kPriorityLow), "BeginFrame() failed.");
-    SuccessOrQuit(encoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(encoder.BeginFrame(Spinel::Buffer::kPriorityLow));
+    SuccessOrQuit(encoder.OpenStruct());
     {
-        SuccessOrQuit(encoder.WriteUint8(kUint8), "WriteUint8() failed.");
-        SuccessOrQuit(encoder.WriteUtf8(kString_1), "WriteUtf8() failed.");
-        SuccessOrQuit(encoder.OpenStruct(), "OpenStruct() failed.");
+        SuccessOrQuit(encoder.WriteUint8(kUint8));
+        SuccessOrQuit(encoder.WriteUtf8(kString_1));
+        SuccessOrQuit(encoder.OpenStruct());
         {
-            SuccessOrQuit(encoder.WriteBool(kBool_1), "WriteBool() failed.");
-            SuccessOrQuit(encoder.WriteIp6Address(kIp6Addr), "WriteIp6Addr() failed.");
+            SuccessOrQuit(encoder.WriteBool(kBool_1));
+            SuccessOrQuit(encoder.WriteIp6Address(kIp6Addr));
         }
-        SuccessOrQuit(encoder.CloseStruct(), "CloseStruct() failed.");
-        SuccessOrQuit(encoder.WriteUint16(kUint16), "WriteUint16() failed.");
+        SuccessOrQuit(encoder.CloseStruct());
+        SuccessOrQuit(encoder.WriteUint16(kUint16));
     }
-    SuccessOrQuit(encoder.CloseStruct(), "CloseStruct() failed.");
-    SuccessOrQuit(encoder.WriteEui48(kEui48), "WriteEui48() failed.");
-    SuccessOrQuit(encoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(encoder.CloseStruct());
+    SuccessOrQuit(encoder.WriteEui48(kEui48));
+    SuccessOrQuit(encoder.OpenStruct());
     {
-        SuccessOrQuit(encoder.WriteUint32(kUint32), "WriteUint32() failed.");
+        SuccessOrQuit(encoder.WriteUint32(kUint32));
     }
-    SuccessOrQuit(encoder.CloseStruct(), "CloseStruct() failed.");
-    SuccessOrQuit(encoder.WriteInt32(kInt32), "WriteUint32() failed.");
-    SuccessOrQuit(encoder.EndFrame(), "EndFrame() failed.");
+    SuccessOrQuit(encoder.CloseStruct());
+    SuccessOrQuit(encoder.WriteInt32(kInt32));
+    SuccessOrQuit(encoder.EndFrame());
 
     DumpBuffer("Buffer", buffer, 256 + 100);
 
-    SuccessOrQuit(ReadFrame(ncpBuffer, frame, frameLen), "ReadFrame() failed.");
+    SuccessOrQuit(ReadFrame(ncpBuffer, frame, frameLen));
 
     parsedLen = spinel_datatype_unpack(
         frame, (spinel_size_t)frameLen,
@@ -264,36 +264,36 @@ void TestEncoder(void)
              SPINEL_DATATYPE_EUI48_S SPINEL_DATATYPE_STRUCT_S(SPINEL_DATATYPE_UINT32_S) SPINEL_DATATYPE_INT32_S),
         &u8, &utf_1, &b_1, &ip6Addr, &u16, &eui48, &u32, &i32);
 
-    VerifyOrQuit(parsedLen == frameLen, "spinel parse failed");
-    VerifyOrQuit(b_1 == kBool_1, "WriteBool() parse failed.");
-    VerifyOrQuit(u8 == kUint8, "WriteUint8() parse failed.");
-    VerifyOrQuit(u16 == kUint16, "WriteUint16() parse failed.");
-    VerifyOrQuit(u32 == kUint32, "WriteUint32() parse failed.");
-    VerifyOrQuit(i32 == kInt32, "WriteUint32() parse failed.");
-    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0, "WriteIp6Address() parse failed.");
-    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0, "WriteEui48() parse failed.");
-    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0, "WriteUtf8() parse failed.");
+    VerifyOrQuit(parsedLen == frameLen);
+    VerifyOrQuit(b_1 == kBool_1);
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(u16 == kUint16);
+    VerifyOrQuit(u32 == kUint32);
+    VerifyOrQuit(i32 == kInt32);
+    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0);
+    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0);
+    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0);
 
     printf(" -- PASS\n");
 
     printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
     printf("\nTest 4: Test unclosed struct.");
 
-    SuccessOrQuit(encoder.BeginFrame(Spinel::Buffer::kPriorityLow), "BeginFrame() failed.");
-    SuccessOrQuit(encoder.WriteUint8(kUint8), "WriteUint8() failed.");
-    SuccessOrQuit(encoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(encoder.BeginFrame(Spinel::Buffer::kPriorityLow));
+    SuccessOrQuit(encoder.WriteUint8(kUint8));
+    SuccessOrQuit(encoder.OpenStruct());
     {
-        SuccessOrQuit(encoder.WriteUint32(kUint32), "WriteUint32() failed.");
-        SuccessOrQuit(encoder.OpenStruct(), "OpenStruct() failed.");
+        SuccessOrQuit(encoder.WriteUint32(kUint32));
+        SuccessOrQuit(encoder.OpenStruct());
         {
-            SuccessOrQuit(encoder.WriteEui48(kEui48), "WriteEui48() failed.");
-            SuccessOrQuit(encoder.WriteUintPacked(kUint_3), "WriteUintPacked() failed.");
+            SuccessOrQuit(encoder.WriteEui48(kEui48));
+            SuccessOrQuit(encoder.WriteUintPacked(kUint_3));
             // Do not close the structs expecting `EndFrame()` to close them.
         }
     }
-    SuccessOrQuit(encoder.EndFrame(), "EndFrame() failed.");
+    SuccessOrQuit(encoder.EndFrame());
 
-    SuccessOrQuit(ReadFrame(ncpBuffer, frame, frameLen), "ReadFrame() failed.");
+    SuccessOrQuit(ReadFrame(ncpBuffer, frame, frameLen));
 
     parsedLen = spinel_datatype_unpack(
         frame, (spinel_size_t)frameLen,
@@ -301,43 +301,43 @@ void TestEncoder(void)
             SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_STRUCT_S(SPINEL_DATATYPE_EUI48_S SPINEL_DATATYPE_UINT_PACKED_S))),
         &u8, &u32, &eui48, &u_3);
 
-    VerifyOrQuit(parsedLen == frameLen, "spinel parse failed");
-    VerifyOrQuit(u8 == kUint8, "WriteUint8() parse failed.");
-    VerifyOrQuit(u32 == kUint32, "WriteUint32() parse failed.");
-    VerifyOrQuit(u_3 == kUint_3, "WriteUintPacked() parse failed.");
-    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0, "WriteEui48() parse failed.");
+    VerifyOrQuit(parsedLen == frameLen);
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(u32 == kUint32);
+    VerifyOrQuit(u_3 == kUint_3);
+    VerifyOrQuit(memcmp(eui48, &kEui48, sizeof(spinel_eui48_t)) == 0);
 
     printf(" -- PASS\n");
 
     printf("\n- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -");
     printf("\nTest 5: Test saving position and reseting back to a saved position");
 
-    SuccessOrQuit(encoder.BeginFrame(Spinel::Buffer::kPriorityLow), "BeginFrame() failed.");
-    SuccessOrQuit(encoder.WriteUint8(kUint8), "WriteUint8() failed.");
-    SuccessOrQuit(encoder.OpenStruct(), "OpenStruct() failed.");
+    SuccessOrQuit(encoder.BeginFrame(Spinel::Buffer::kPriorityLow));
+    SuccessOrQuit(encoder.WriteUint8(kUint8));
+    SuccessOrQuit(encoder.OpenStruct());
     {
-        SuccessOrQuit(encoder.WriteUint32(kUint32), "WriteUint32() failed.");
+        SuccessOrQuit(encoder.WriteUint32(kUint32));
 
         // Save position in middle a first open struct.
-        SuccessOrQuit(encoder.SavePosition(), "SavePosition failed.");
-        SuccessOrQuit(encoder.OpenStruct(), "OpenStruct() failed.");
+        SuccessOrQuit(encoder.SavePosition());
+        SuccessOrQuit(encoder.OpenStruct());
         {
-            SuccessOrQuit(encoder.WriteEui48(kEui48), "WriteEui48() failed.");
-            SuccessOrQuit(encoder.WriteUintPacked(kUint_3), "WriteUintPacked() failed.");
+            SuccessOrQuit(encoder.WriteEui48(kEui48));
+            SuccessOrQuit(encoder.WriteUintPacked(kUint_3));
         }
 
         // Reset to saved position in middle of the second open struct which should be discarded.
 
-        SuccessOrQuit(encoder.ResetToSaved(), "ResetToSaved() failed.");
+        SuccessOrQuit(encoder.ResetToSaved());
 
-        SuccessOrQuit(encoder.WriteIp6Address(kIp6Addr), "WriteIp6Addr() failed.");
-        SuccessOrQuit(encoder.WriteEui64(kEui64), "WriteEui64() failed.");
+        SuccessOrQuit(encoder.WriteIp6Address(kIp6Addr));
+        SuccessOrQuit(encoder.WriteEui64(kEui64));
     }
-    SuccessOrQuit(encoder.CloseStruct(), "CloseStruct() failed.");
-    SuccessOrQuit(encoder.WriteUtf8(kString_1), "WriteUtf8() failed.");
-    SuccessOrQuit(encoder.EndFrame(), "EndFrame() failed.");
+    SuccessOrQuit(encoder.CloseStruct());
+    SuccessOrQuit(encoder.WriteUtf8(kString_1));
+    SuccessOrQuit(encoder.EndFrame());
 
-    SuccessOrQuit(ReadFrame(ncpBuffer, frame, frameLen), "ReadFrame() failed.");
+    SuccessOrQuit(ReadFrame(ncpBuffer, frame, frameLen));
 
     parsedLen = spinel_datatype_unpack(
         frame, (spinel_size_t)frameLen,
@@ -345,14 +345,14 @@ void TestEncoder(void)
             SPINEL_DATATYPE_UINT32_S SPINEL_DATATYPE_IPv6ADDR_S SPINEL_DATATYPE_EUI64_S) SPINEL_DATATYPE_UTF8_S),
         &u8, &u32, &ip6Addr, &eui64, &utf_1);
 
-    VerifyOrQuit(parsedLen == frameLen, "spinel parse failed");
+    VerifyOrQuit(parsedLen == frameLen);
 
-    VerifyOrQuit(u8 == kUint8, "WriteUint8() parse failed.");
-    VerifyOrQuit(u32 == kUint32, "WriteUint32() parse failed.");
-    VerifyOrQuit(i32 == kInt32, "WriteUint32() parse failed.");
-    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0, "WriteIp6Address() parse failed.");
-    VerifyOrQuit(memcmp(eui64, &kEui64, sizeof(spinel_eui64_t)) == 0, "WriteEui64() parse failed.");
-    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0, "WriteUtf8() parse failed.");
+    VerifyOrQuit(u8 == kUint8);
+    VerifyOrQuit(u32 == kUint32);
+    VerifyOrQuit(i32 == kInt32);
+    VerifyOrQuit(memcmp(ip6Addr, &kIp6Addr, sizeof(spinel_ipv6addr_t)) == 0);
+    VerifyOrQuit(memcmp(eui64, &kEui64, sizeof(spinel_eui64_t)) == 0);
+    VerifyOrQuit(memcmp(utf_1, kString_1, sizeof(kString_1)) == 0);
 
     printf(" -- PASS\n");
 }

--- a/tests/unit/test_steering_data.cpp
+++ b/tests/unit/test_steering_data.cpp
@@ -53,22 +53,22 @@ void TestSteeringData(void)
     steeringData.SetToPermitAllJoiners();
 
     DumpBuffer("After SetToPermitAllJoiners()", steeringData.GetData(), steeringData.GetLength());
-    VerifyOrQuit(steeringData.GetLength() == 1, "GetLength is incorrect after SetToPermitAllJoiners()");
-    VerifyOrQuit(steeringData.PermitsAllJoiners(), "PermitsAllJoiners() failed after SetToPermitAllJoiners()");
-    VerifyOrQuit(!steeringData.IsEmpty(), "IsEmpty() failed after SetToPermitAllJoiners()");
-    VerifyOrQuit(steeringData.Contains(joinerId1), "Contains(joinerId1) failed after SetToPermitAllJoiners()");
-    VerifyOrQuit(steeringData.Contains(joinerId2), "Contains(joinerId2) failed after SetToPermitAllJoiners()");
-    VerifyOrQuit(steeringData.Contains(indexes), "Contains(indexes) failed after SetToPermitAllJoiners()");
+    VerifyOrQuit(steeringData.GetLength() == 1, "after SetToPermitAllJoiners()");
+    VerifyOrQuit(steeringData.PermitsAllJoiners(), "after SetToPermitAllJoiners()");
+    VerifyOrQuit(!steeringData.IsEmpty(), "after SetToPermitAllJoiners()");
+    VerifyOrQuit(steeringData.Contains(joinerId1), "after SetToPermitAllJoiners()");
+    VerifyOrQuit(steeringData.Contains(joinerId2), "after SetToPermitAllJoiners()");
+    VerifyOrQuit(steeringData.Contains(indexes), "after SetToPermitAllJoiners()");
 
     steeringData.Clear();
 
     DumpBuffer("After Clear()", steeringData.GetData(), steeringData.GetLength());
-    VerifyOrQuit(steeringData.GetLength() == 1, "GetLength is incorrect after Clear()");
-    VerifyOrQuit(!steeringData.PermitsAllJoiners(), "PermitsAllJoiners() failed after Clear()");
-    VerifyOrQuit(steeringData.IsEmpty(), "IsEmpty() failed after Clear()");
-    VerifyOrQuit(!steeringData.Contains(joinerId1), "Contains(joinerId1) failed after Clear()");
-    VerifyOrQuit(!steeringData.Contains(joinerId2), "Contains(joinerId2) failed after Clear()");
-    VerifyOrQuit(!steeringData.Contains(indexes), "Contains(indexes) failed after Clear()");
+    VerifyOrQuit(steeringData.GetLength() == 1, "after Clear()");
+    VerifyOrQuit(!steeringData.PermitsAllJoiners(), "after Clear()");
+    VerifyOrQuit(steeringData.IsEmpty(), "after Clear()");
+    VerifyOrQuit(!steeringData.Contains(joinerId1), "after Clear()");
+    VerifyOrQuit(!steeringData.Contains(joinerId2), "after Clear()");
+    VerifyOrQuit(!steeringData.Contains(indexes), "after Clear()");
 
     for (uint8_t len = 1; len <= MeshCoP::SteeringData::kMaxLength; len++)
     {
@@ -76,38 +76,38 @@ void TestSteeringData(void)
 
         steeringData.Init(len);
 
-        VerifyOrQuit(steeringData.GetLength() == len, "GetLength is incorrect after Init()");
+        VerifyOrQuit(steeringData.GetLength() == len, "after Init()");
         VerifyOrQuit(steeringData.IsEmpty(), "IsEmpy() failed after Init()");
-        VerifyOrQuit(!steeringData.PermitsAllJoiners(), "PermitsAllJoiners() failed after Init()");
-        VerifyOrQuit(!steeringData.Contains(joinerId1), "Contains(joinerId1) failed after Init()");
-        VerifyOrQuit(!steeringData.Contains(joinerId2), "Contains(joinerId2) failed after Init()");
-        VerifyOrQuit(!steeringData.Contains(indexes), "Contains(indexes) failed after Init()");
+        VerifyOrQuit(!steeringData.PermitsAllJoiners(), "after Init()");
+        VerifyOrQuit(!steeringData.Contains(joinerId1), "after Init()");
+        VerifyOrQuit(!steeringData.Contains(joinerId2), "after Init()");
+        VerifyOrQuit(!steeringData.Contains(indexes), "after Init()");
 
         steeringData.UpdateBloomFilter(joinerId1);
         DumpBuffer("After UpdateBloomFilter(joinerId1)", steeringData.GetData(), steeringData.GetLength());
-        VerifyOrQuit(steeringData.GetLength() == len, "GetLength is incorrect after UpdateBloomFilter()");
+        VerifyOrQuit(steeringData.GetLength() == len, "after UpdateBloomFilter()");
         VerifyOrQuit(!steeringData.IsEmpty(), "IsEmpy() failed after UpdateBloomFilter()");
-        VerifyOrQuit(!steeringData.PermitsAllJoiners(), "PermitsAllJoiners() failed after UpdateBloomFilter");
-        VerifyOrQuit(steeringData.Contains(joinerId1), "Contains(joinerId1) failed after UpdateBloomFilter");
+        VerifyOrQuit(!steeringData.PermitsAllJoiners(), "after UpdateBloomFilter");
+        VerifyOrQuit(steeringData.Contains(joinerId1), "after UpdateBloomFilter");
 
         steeringData.UpdateBloomFilter(joinerId2);
         DumpBuffer("After UpdateBloomFilter(joinerId2)", steeringData.GetData(), steeringData.GetLength());
-        VerifyOrQuit(steeringData.GetLength() == len, "GetLength is incorrect after UpdateBloomFilter()");
+        VerifyOrQuit(steeringData.GetLength() == len, "after UpdateBloomFilter()");
         VerifyOrQuit(!steeringData.IsEmpty(), "IsEmpy() failed after UpdateBloomFilter()");
-        VerifyOrQuit(!steeringData.PermitsAllJoiners(), "PermitsAllJoiners() failed after UpdateBloomFilter");
-        VerifyOrQuit(steeringData.Contains(joinerId1), "Contains(joinerId1) failed after UpdateBloomFilter");
-        VerifyOrQuit(steeringData.Contains(joinerId2), "Contains(joinerId2) failed after UpdateBloomFilter");
-        VerifyOrQuit(steeringData.Contains(indexes), "Contains(joinerId2) failed after UpdateBloomFilter");
+        VerifyOrQuit(!steeringData.PermitsAllJoiners(), "after UpdateBloomFilter");
+        VerifyOrQuit(steeringData.Contains(joinerId1), "after UpdateBloomFilter");
+        VerifyOrQuit(steeringData.Contains(joinerId2), "after UpdateBloomFilter");
+        VerifyOrQuit(steeringData.Contains(indexes), "after UpdateBloomFilter");
     }
 
     steeringData.Init(0);
 
-    VerifyOrQuit(steeringData.GetLength() == 0, "GetLength is incorrect after Init()");
+    VerifyOrQuit(steeringData.GetLength() == 0, "after Init()");
     VerifyOrQuit(steeringData.IsEmpty(), "IsEmpy() failed after Init()");
-    VerifyOrQuit(!steeringData.PermitsAllJoiners(), "PermitsAllJoiners() failed after Init()");
-    VerifyOrQuit(!steeringData.Contains(joinerId1), "Contains(joinerId1) failed after Init()");
-    VerifyOrQuit(!steeringData.Contains(joinerId2), "Contains(joinerId2) failed after Init()");
-    VerifyOrQuit(!steeringData.Contains(indexes), "Contains(indexes) failed after Init()");
+    VerifyOrQuit(!steeringData.PermitsAllJoiners(), "after Init()");
+    VerifyOrQuit(!steeringData.Contains(joinerId1), "after Init()");
+    VerifyOrQuit(!steeringData.Contains(joinerId2), "after Init()");
+    VerifyOrQuit(!steeringData.Contains(indexes), "after Init()");
 }
 
 } // namespace ot

--- a/tests/unit/test_string.cpp
+++ b/tests/unit/test_string.cpp
@@ -53,10 +53,10 @@ void TestStringWriter(void)
 
     printf("\nTest 1: StringWriter constructor\n");
 
-    VerifyOrQuit(str.GetSize() == kStringSize, "GetSize() failed");
-    VerifyOrQuit(str.GetLength() == 0, "GetLength() failed for empty string");
+    VerifyOrQuit(str.GetSize() == kStringSize);
+    VerifyOrQuit(str.GetLength() == 0, "failed for empty string");
 
-    VerifyOrQuit(strcmp(str.AsCString(), "") == 0, "String content is incorrect");
+    VerifyOrQuit(strcmp(str.AsCString(), "") == 0);
 
     PrintString("str", str);
 
@@ -65,13 +65,13 @@ void TestStringWriter(void)
     printf("\nTest 2: StringWriter::Append() method\n");
 
     str.Append("Hi");
-    VerifyOrQuit(str.GetLength() == 2, "GetLength() failed");
-    VerifyOrQuit(strcmp(str.AsCString(), "Hi") == 0, "String content is incorrect");
+    VerifyOrQuit(str.GetLength() == 2);
+    VerifyOrQuit(strcmp(str.AsCString(), "Hi") == 0);
     PrintString("str", str);
 
     str.Append("%s%d", "!", 12);
-    VerifyOrQuit(str.GetLength() == 5, "GetLength() failed");
-    VerifyOrQuit(strcmp(str.AsCString(), "Hi!12") == 0, "String content is incorrect");
+    VerifyOrQuit(str.GetLength() == 5);
+    VerifyOrQuit(strcmp(str.AsCString(), "Hi!12") == 0);
     PrintString("str", str);
 
     str.Append(kLongString);
@@ -83,17 +83,17 @@ void TestStringWriter(void)
 
     str.Clear();
     str.Append("Hello");
-    VerifyOrQuit(str.GetLength() == 5, "GetLength() failed for empty string");
-    VerifyOrQuit(strcmp(str.AsCString(), "Hello") == 0, "String content is incorrect");
+    VerifyOrQuit(str.GetLength() == 5);
+    VerifyOrQuit(strcmp(str.AsCString(), "Hello") == 0);
     PrintString("str", str);
 
     str.Clear();
-    VerifyOrQuit(str.GetLength() == 0, "GetLength() failed for empty string");
-    VerifyOrQuit(strcmp(str.AsCString(), "") == 0, "String content is incorrect");
+    VerifyOrQuit(str.GetLength() == 0, "failed after Clear()");
+    VerifyOrQuit(strcmp(str.AsCString(), "") == 0);
 
     str.Append("%d", 12);
-    VerifyOrQuit(str.GetLength() == 2, "GetLength() failed");
-    VerifyOrQuit(strcmp(str.AsCString(), "12") == 0, "String content is incorrect");
+    VerifyOrQuit(str.GetLength() == 2);
+    VerifyOrQuit(strcmp(str.AsCString(), "12") == 0);
     PrintString("str", str);
 
     str.Clear();
@@ -112,17 +112,17 @@ void TestStringLength(void)
 
     printf("\nTest 4: String::StringLength() method\n");
 
-    VerifyOrQuit(StringLength(string_a, 0) == 0, "StringLength() 0len 0 fails");
-    VerifyOrQuit(StringLength(string_a, 1) == 0, "StringLength() 0len 1 fails");
-    VerifyOrQuit(StringLength(string_a, 2) == 0, "StringLength() 0len 2 fails");
+    VerifyOrQuit(StringLength(string_a, 0) == 0);
+    VerifyOrQuit(StringLength(string_a, 1) == 0);
+    VerifyOrQuit(StringLength(string_a, 2) == 0);
 
-    VerifyOrQuit(StringLength(string_b, 0) == 0, "StringLength() 3len 0 fails");
-    VerifyOrQuit(StringLength(string_b, 1) == 1, "StringLength() 3len 1 fails");
-    VerifyOrQuit(StringLength(string_b, 2) == 2, "StringLength() 3len 2 fails");
-    VerifyOrQuit(StringLength(string_b, 3) == 3, "StringLength() 3len 3 fails");
-    VerifyOrQuit(StringLength(string_b, 4) == 3, "StringLength() 3len 4 fails");
-    VerifyOrQuit(StringLength(string_b, 5) == 3, "StringLength() 3len 5 fails");
-    VerifyOrQuit(StringLength(string_b, 6) == 3, "StringLength() 3len 6 fails");
+    VerifyOrQuit(StringLength(string_b, 0) == 0);
+    VerifyOrQuit(StringLength(string_b, 1) == 1);
+    VerifyOrQuit(StringLength(string_b, 2) == 2);
+    VerifyOrQuit(StringLength(string_b, 3) == 3);
+    VerifyOrQuit(StringLength(string_b, 4) == 3);
+    VerifyOrQuit(StringLength(string_b, 5) == 3);
+    VerifyOrQuit(StringLength(string_b, 6) == 3);
 
     printf(" -- PASS\n");
 }
@@ -131,13 +131,13 @@ void TestUtf8(void)
 {
     printf("\nTest 5: IsValidUtf8String() function\n");
 
-    VerifyOrQuit(IsValidUtf8String("An ASCII string"), "IsValidUtf8String() ASCII string fails");
-    VerifyOrQuit(IsValidUtf8String(u8"Строка UTF-8"), "IsValidUtf8String() UTF-8 string fails");
-    VerifyOrQuit(!IsValidUtf8String("\xbf"), "IsValidUtf8String() illegal string fails");
-    VerifyOrQuit(!IsValidUtf8String("\xdf"), "IsValidUtf8String() illegal string fails");
-    VerifyOrQuit(!IsValidUtf8String("\xef\x80"), "IsValidUtf8String() illegal string fails");
-    VerifyOrQuit(!IsValidUtf8String("\xf7\x80\x80"), "IsValidUtf8String() illegal string fails");
-    VerifyOrQuit(!IsValidUtf8String("\xff"), "IsValidUtf8String() illegal string fails");
+    VerifyOrQuit(IsValidUtf8String("An ASCII string"));
+    VerifyOrQuit(IsValidUtf8String(u8"Строка UTF-8"));
+    VerifyOrQuit(!IsValidUtf8String("\xbf"));
+    VerifyOrQuit(!IsValidUtf8String("\xdf"));
+    VerifyOrQuit(!IsValidUtf8String("\xef\x80"));
+    VerifyOrQuit(!IsValidUtf8String("\xf7\x80\x80"));
+    VerifyOrQuit(!IsValidUtf8String("\xff"));
 
     printf(" -- PASS\n");
 }
@@ -150,35 +150,35 @@ void TestStringFind(void)
 
     printf("\nTest 6: StringFind() function\n");
 
-    VerifyOrQuit(StringFind(testString, 'f') == testString, "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, 'o') == &testString[1], "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, '.') == &testString[3], "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, 'r') == &testString[6], "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, '\\') == &testString[11], "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, 'x') == nullptr, "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, ',') == nullptr, "StringFind() failed");
+    VerifyOrQuit(StringFind(testString, 'f') == testString);
+    VerifyOrQuit(StringFind(testString, 'o') == &testString[1]);
+    VerifyOrQuit(StringFind(testString, '.') == &testString[3]);
+    VerifyOrQuit(StringFind(testString, 'r') == &testString[6]);
+    VerifyOrQuit(StringFind(testString, '\\') == &testString[11]);
+    VerifyOrQuit(StringFind(testString, 'x') == nullptr);
+    VerifyOrQuit(StringFind(testString, ',') == nullptr);
 
-    VerifyOrQuit(StringFind(emptyString, 'f') == nullptr, "StringFind() failed");
-    VerifyOrQuit(StringFind(emptyString, '.') == nullptr, "StringFind() failed");
+    VerifyOrQuit(StringFind(emptyString, 'f') == nullptr);
+    VerifyOrQuit(StringFind(emptyString, '.') == nullptr);
 
-    VerifyOrQuit(StringFind(testString, "foo") == &testString[0], "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, "oo") == &testString[1], "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, "bar") == &testString[4], "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, "bar\\") == &testString[8], "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, "\\.") == &testString[11], "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, testString) == testString, "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, "fooo") == nullptr, "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, "far") == nullptr, "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, "bar\\..") == nullptr, "StringFind() failed");
-    VerifyOrQuit(StringFind(testString, "") == &testString[0], "StringFind() failed");
+    VerifyOrQuit(StringFind(testString, "foo") == &testString[0]);
+    VerifyOrQuit(StringFind(testString, "oo") == &testString[1]);
+    VerifyOrQuit(StringFind(testString, "bar") == &testString[4]);
+    VerifyOrQuit(StringFind(testString, "bar\\") == &testString[8]);
+    VerifyOrQuit(StringFind(testString, "\\.") == &testString[11]);
+    VerifyOrQuit(StringFind(testString, testString) == testString);
+    VerifyOrQuit(StringFind(testString, "fooo") == nullptr);
+    VerifyOrQuit(StringFind(testString, "far") == nullptr);
+    VerifyOrQuit(StringFind(testString, "bar\\..") == nullptr);
+    VerifyOrQuit(StringFind(testString, "") == &testString[0]);
 
-    VerifyOrQuit(StringFind(emptyString, "foo") == nullptr, "StringFind() failed");
-    VerifyOrQuit(StringFind(emptyString, "bar") == nullptr, "StringFind() failed");
-    VerifyOrQuit(StringFind(emptyString, "") == &emptyString[0], "StringFind() failed");
+    VerifyOrQuit(StringFind(emptyString, "foo") == nullptr);
+    VerifyOrQuit(StringFind(emptyString, "bar") == nullptr);
+    VerifyOrQuit(StringFind(emptyString, "") == &emptyString[0]);
 
     // Verify when sub-string has repeated patterns
-    VerifyOrQuit(StringFind(testString2, "abcabc") == &testString2[0], "StringFind() failed");
-    VerifyOrQuit(StringFind(testString2, "abcabcd") == &testString2[3], "StringFind() failed");
+    VerifyOrQuit(StringFind(testString2, "abcabc") == &testString2[0]);
+    VerifyOrQuit(StringFind(testString2, "abcabcd") == &testString2[3]);
 
     printf(" -- PASS\n");
 }
@@ -187,19 +187,19 @@ void TestStringEndsWith(void)
 {
     printf("\nTest 7: StringEndsWith() function\n");
 
-    VerifyOrQuit(StringEndsWith("foobar", 'r'), "StringEndsWith() failed");
-    VerifyOrQuit(!StringEndsWith("foobar", 'a'), "StringEndsWith() failed");
-    VerifyOrQuit(!StringEndsWith("foobar", '\0'), "StringEndsWith() failed");
-    VerifyOrQuit(StringEndsWith("a", 'a'), "StringEndsWith() failed");
-    VerifyOrQuit(!StringEndsWith("a", 'b'), "StringEndsWith() failed");
+    VerifyOrQuit(StringEndsWith("foobar", 'r'));
+    VerifyOrQuit(!StringEndsWith("foobar", 'a'));
+    VerifyOrQuit(!StringEndsWith("foobar", '\0'));
+    VerifyOrQuit(StringEndsWith("a", 'a'));
+    VerifyOrQuit(!StringEndsWith("a", 'b'));
 
-    VerifyOrQuit(StringEndsWith("foobar", "bar"), "StringEndsWith() failed");
-    VerifyOrQuit(!StringEndsWith("foobar", "ba"), "StringEndsWith() failed");
-    VerifyOrQuit(StringEndsWith("foobar", "foobar"), "StringEndsWith() failed");
-    VerifyOrQuit(!StringEndsWith("foobar", "foobarr"), "StringEndsWith() failed");
+    VerifyOrQuit(StringEndsWith("foobar", "bar"));
+    VerifyOrQuit(!StringEndsWith("foobar", "ba"));
+    VerifyOrQuit(StringEndsWith("foobar", "foobar"));
+    VerifyOrQuit(!StringEndsWith("foobar", "foobarr"));
 
-    VerifyOrQuit(!StringEndsWith("", 'a'), "StringEndsWith() failed");
-    VerifyOrQuit(!StringEndsWith("", "foo"), "StringEndsWith() failed");
+    VerifyOrQuit(!StringEndsWith("", 'a'));
+    VerifyOrQuit(!StringEndsWith("", "foo"));
 
     printf(" -- PASS\n");
 }

--- a/tests/unit/test_timer.cpp
+++ b/tests/unit/test_timer.cpp
@@ -142,22 +142,22 @@ template <typename TimerType> int TestOneTimer(void)
     sNow = kTimeT0;
     timer.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.");
-    VerifyOrQuit(sPlatT0 == 1000 && sPlatDt == 10, "TestOneTimer: Start params Failed.");
-    VerifyOrQuit(timer.IsRunning(), "TestOneTimer: Timer running Failed.");
-    VerifyOrQuit(sTimerOn, "TestOneTimer: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == 1000 && sPlatDt == 10, "Start params Failed.");
+    VerifyOrQuit(timer.IsRunning(), "Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "Platform Timer State Failed.");
 
     sNow += kTimerInterval;
 
     AlarmFired<TimerType>(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestOneTimer: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestOneTimer: Handler CallCount Failed.");
-    VerifyOrQuit(timer.IsRunning() == false, "TestOneTimer: Timer running Failed.");
-    VerifyOrQuit(sTimerOn == false, "TestOneTimer: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "Handler CallCount Failed.");
+    VerifyOrQuit(timer.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "Platform Timer State Failed.");
 
     // Test one Timer that spans the 32-bit wrap.
 
@@ -166,22 +166,22 @@ template <typename TimerType> int TestOneTimer(void)
     sNow = 0 - (kTimerInterval - 2);
     timer.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.");
-    VerifyOrQuit(sPlatT0 == 0 - (kTimerInterval - 2) && sPlatDt == 10, "TestOneTimer: Start params Failed.");
-    VerifyOrQuit(timer.IsRunning(), "TestOneTimer: Timer running Failed.");
-    VerifyOrQuit(sTimerOn, "TestOneTimer: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == 0 - (kTimerInterval - 2) && sPlatDt == 10, "Start params Failed.");
+    VerifyOrQuit(timer.IsRunning(), "Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "Platform Timer State Failed.");
 
     sNow += kTimerInterval;
 
     AlarmFired<TimerType>(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestOneTimer: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestOneTimer: Handler CallCount Failed.");
-    VerifyOrQuit(timer.IsRunning() == false, "TestOneTimer: Timer running Failed.");
-    VerifyOrQuit(sTimerOn == false, "TestOneTimer: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "Handler CallCount Failed.");
+    VerifyOrQuit(timer.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "Platform Timer State Failed.");
 
     // Test one Timer that is late by several msec
 
@@ -190,22 +190,22 @@ template <typename TimerType> int TestOneTimer(void)
     sNow = kTimeT0;
     timer.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.");
-    VerifyOrQuit(sPlatT0 == 1000 && sPlatDt == 10, "TestOneTimer: Start params Failed.");
-    VerifyOrQuit(timer.IsRunning(), "TestOneTimer: Timer running Failed.");
-    VerifyOrQuit(sTimerOn, "TestOneTimer: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == 1000 && sPlatDt == 10, "Start params Failed.");
+    VerifyOrQuit(timer.IsRunning(), "Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "Platform Timer State Failed.");
 
     sNow += kTimerInterval + 5;
 
     AlarmFired<TimerType>(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestOneTimer: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestOneTimer: Handler CallCount Failed.");
-    VerifyOrQuit(timer.IsRunning() == false, "TestOneTimer: Timer running Failed.");
-    VerifyOrQuit(sTimerOn == false, "TestOneTimer: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "Handler CallCount Failed.");
+    VerifyOrQuit(timer.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "Platform Timer State Failed.");
 
     // Test one Timer that is early by several msec
 
@@ -214,32 +214,32 @@ template <typename TimerType> int TestOneTimer(void)
     sNow = kTimeT0;
     timer.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestOneTimer: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.");
-    VerifyOrQuit(sPlatT0 == 1000 && sPlatDt == 10, "TestOneTimer: Start params Failed.");
-    VerifyOrQuit(timer.IsRunning(), "TestOneTimer: Timer running Failed.");
-    VerifyOrQuit(sTimerOn, "TestOneTimer: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == 1000 && sPlatDt == 10, "Start params Failed.");
+    VerifyOrQuit(timer.IsRunning(), "Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "Platform Timer State Failed.");
 
     sNow += kTimerInterval - 2;
 
     AlarmFired<TimerType>(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestOneTimer: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestOneTimer: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestOneTimer: Handler CallCount Failed.");
-    VerifyOrQuit(timer.IsRunning() == true, "TestOneTimer: Timer running Failed.");
-    VerifyOrQuit(sTimerOn == true, "TestOneTimer: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "Handler CallCount Failed.");
+    VerifyOrQuit(timer.IsRunning() == true, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn == true, "Platform Timer State Failed.");
 
     sNow += kTimerInterval;
 
     AlarmFired<TimerType>(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestOneTimer: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestOneTimer: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestOneTimer: Handler CallCount Failed.");
-    VerifyOrQuit(timer.IsRunning() == false, "TestOneTimer: Timer running Failed.");
-    VerifyOrQuit(sTimerOn == false, "TestOneTimer: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "Handler CallCount Failed.");
+    VerifyOrQuit(timer.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "Platform Timer State Failed.");
 
     printf(" --> PASSED\n");
 
@@ -269,47 +269,47 @@ template <typename TimerType> int TestTwoTimers(void)
     sNow = kTimeT0;
     timer1.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.");
-    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.");
-    VerifyOrQuit(timer1.IsRunning(), "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning(), "Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "Platform Timer State Failed.");
 
     sNow += kTimerInterval;
 
     timer2.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.");
-    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.");
-    VerifyOrQuit(timer1.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning() == true, "Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == true, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "Platform Timer State Failed.");
 
     AlarmFired<TimerType>(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTwoTimers: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestTwoTimers: Handler CallCount Failed.");
-    VerifyOrQuit(timer1.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.");
-    VerifyOrQuit(sPlatT0 == sNow && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.");
-    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(sTimerOn == true, "TestTwoTimers: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "Handler CallCount Failed.");
+    VerifyOrQuit(timer1.GetFiredCounter() == 1, "Fire Counter failed.");
+    VerifyOrQuit(sPlatT0 == sNow && sPlatDt == kTimerInterval, "Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == true, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn == true, "Platform Timer State Failed.");
 
     sNow += kTimerInterval;
     AlarmFired<TimerType>(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTwoTimers: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestTwoTimers: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 2, "TestTwoTimers: Handler CallCount Failed.");
-    VerifyOrQuit(timer2.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.");
-    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(sTimerOn == false, "TestTwoTimers: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 2, "Handler CallCount Failed.");
+    VerifyOrQuit(timer2.GetFiredCounter() == 1, "Fire Counter failed.");
+    VerifyOrQuit(timer1.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "Platform Timer State Failed.");
 
     // Test when second timer starts at the fire time of first timer (before AlarmFired<TimerType>()) and its fire time
     // is before the first timer. Ensure that the second timer handler is invoked before the first one.
@@ -321,41 +321,41 @@ template <typename TimerType> int TestTwoTimers(void)
     sNow = kTimeT0;
     timer1.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.");
-    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.");
-    VerifyOrQuit(timer1.IsRunning(), "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning(), "Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "Platform Timer State Failed.");
 
     sNow += kTimerInterval;
 
     timer2.StartAt(ot::TimeMilli(kTimeT0), kTimerInterval - 2); // Timer 2 is even before timer 1
 
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.");
-    VerifyOrQuit(timer1.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "Handler CallCount Failed.");
+    VerifyOrQuit(timer1.IsRunning() == true, "Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == true, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "Platform Timer State Failed.");
 
     AlarmFired<TimerType>(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestTwoTimers: Handler CallCount Failed.");
-    VerifyOrQuit(timer2.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.");
-    VerifyOrQuit(sPlatT0 == sNow && sPlatDt == 0, "TestTwoTimers: Start params Failed.");
-    VerifyOrQuit(timer1.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(sTimerOn == true, "TestTwoTimers: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "Handler CallCount Failed.");
+    VerifyOrQuit(timer2.GetFiredCounter() == 1, "Fire Counter failed.");
+    VerifyOrQuit(sPlatT0 == sNow && sPlatDt == 0, "Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning() == true, "Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn == true, "Platform Timer State Failed.");
 
     AlarmFired<TimerType>(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestTwoTimers: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 2, "TestTwoTimers: Handler CallCount Failed.");
-    VerifyOrQuit(timer1.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.");
-    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(sTimerOn == false, "TestTwoTimers: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 2, "Handler CallCount Failed.");
+    VerifyOrQuit(timer1.GetFiredCounter() == 1, "Fire Counter failed.");
+    VerifyOrQuit(timer1.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "Platform Timer State Failed.");
 
     // Timer 1 fire callback is late by some ticks/ms, and second timer is scheduled (before call to
     // AlarmFired) with a maximum interval. This is to test (corner-case) scenario where the fire time of two
@@ -368,47 +368,47 @@ template <typename TimerType> int TestTwoTimers(void)
     sNow = kTimeT0;
     timer1.Start(kTimerInterval);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.");
-    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "TestTwoTimers: Start params Failed.");
-    VerifyOrQuit(timer1.IsRunning(), "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "Handler CallCount Failed.");
+    VerifyOrQuit(sPlatT0 == kTimeT0 && sPlatDt == kTimerInterval, "Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning(), "Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "Platform Timer State Failed.");
 
     sNow += kTimerInterval + 5;
 
     timer2.Start(ot::Timer::kMaxDelay);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "TestTwoTimers: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "TestTwoTimers: Handler CallCount Failed.");
-    VerifyOrQuit(timer1.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(sTimerOn, "TestTwoTimers: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 1, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 0, "Handler CallCount Failed.");
+    VerifyOrQuit(timer1.IsRunning() == true, "Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == true, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn, "Platform Timer State Failed.");
 
     AlarmFired<TimerType>(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTwoTimers: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "TestTwoTimers: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "TestTwoTimers: Handler CallCount Failed.");
-    VerifyOrQuit(timer1.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.");
-    VerifyOrQuit(sPlatT0 == sNow, "TestTwoTimers: Start params Failed.");
-    VerifyOrQuit(sPlatDt == ot::Timer::kMaxDelay, "TestTwoTimers: Start params Failed.");
-    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(timer2.IsRunning() == true, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(sTimerOn == true, "TestTwoTimers: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 0, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 1, "Handler CallCount Failed.");
+    VerifyOrQuit(timer1.GetFiredCounter() == 1, "Fire Counter failed.");
+    VerifyOrQuit(sPlatT0 == sNow, "Start params Failed.");
+    VerifyOrQuit(sPlatDt == ot::Timer::kMaxDelay, "Start params Failed.");
+    VerifyOrQuit(timer1.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == true, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn == true, "Platform Timer State Failed.");
 
     sNow += ot::Timer::kMaxDelay;
     AlarmFired<TimerType>(instance);
 
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "TestTwoTimers: Start CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "TestTwoTimers: Stop CallCount Failed.");
-    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 2, "TestTwoTimers: Handler CallCount Failed.");
-    VerifyOrQuit(timer2.GetFiredCounter() == 1, "TestTwoTimers: Fire Counter failed.");
-    VerifyOrQuit(timer1.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(timer2.IsRunning() == false, "TestTwoTimers: Timer running Failed.");
-    VerifyOrQuit(sTimerOn == false, "TestTwoTimers: Platform Timer State Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStart] == 2, "Start CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexAlarmStop] == 1, "Stop CallCount Failed.");
+    VerifyOrQuit(sCallCount[kCallCountIndexTimerHandler] == 2, "Handler CallCount Failed.");
+    VerifyOrQuit(timer2.GetFiredCounter() == 1, "Fire Counter failed.");
+    VerifyOrQuit(timer1.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(timer2.IsRunning() == false, "Timer running Failed.");
+    VerifyOrQuit(sTimerOn == false, "Platform Timer State Failed.");
 
     printf(" --> PASSED\n");
 

--- a/tests/unit/test_toolchain.cpp
+++ b/tests/unit/test_toolchain.cpp
@@ -53,7 +53,7 @@ void test_packed1(void)
 
     static_assert(sizeof(packed_t) == 7, "packed_t should be packed to 7 bytes");
 
-    VerifyOrQuit(sizeof(packed_t) == 7, "Toolchain::OT_TOOL_PACKED failed 1");
+    VerifyOrQuit(sizeof(packed_t) == 7, "OT_TOOL_PACKED failed 1");
 }
 
 void test_packed2(void)
@@ -67,7 +67,7 @@ void test_packed2(void)
 
     static_assert(sizeof(packed_t) == 4, "packed_t should be packed to 4 bytes");
 
-    VerifyOrQuit(sizeof(packed_t) == 4, "Toolchain::OT_TOOL_PACKED failed 2");
+    VerifyOrQuit(sizeof(packed_t) == 4, "OT_TOOL_PACKED failed 2");
 }
 
 void test_packed_union(void)
@@ -90,7 +90,7 @@ void test_packed_union(void)
 
     static_assert(sizeof(packed_t) == 5, "packed_t should be packed to 5 bytes");
 
-    VerifyOrQuit(sizeof(packed_t) == 5, "Toolchain::OT_TOOL_PACKED failed 3");
+    VerifyOrQuit(sizeof(packed_t) == 5, "OT_TOOL_PACKED failed 3");
 }
 
 void test_packed_enum(void)
@@ -99,7 +99,7 @@ void test_packed_enum(void)
     neighbor.SetState(ot::Neighbor::kStateValid);
 
     // Make sure that when we read the 3 bit field it is read as unsigned, so it return '4'
-    VerifyOrQuit(neighbor.GetState() == ot::Neighbor::kStateValid, "Toolchain::OT_TOOL_PACKED failed 4");
+    VerifyOrQuit(neighbor.GetState() == ot::Neighbor::kStateValid, "OT_TOOL_PACKED failed 4");
 }
 
 void test_addr_sizes(void)
@@ -111,7 +111,7 @@ void test_addr_sizes(void)
 
 void test_addr_bitfield(void)
 {
-    VerifyOrQuit(CreateNetif_c().mScopeOverrideValid == true, "Toolchain::test_addr_size_cpp");
+    VerifyOrQuit(CreateNetif_c().mScopeOverrideValid == true, "test_addr_size_cpp");
 }
 
 void test_packed_alignment(void)
@@ -129,7 +129,7 @@ void test_packed_alignment(void)
     const uint8_t *packedStructBytes = reinterpret_cast<const uint8_t *>(&packedStruct);
     uint8_t        buffer[sizeof(PackedStruct) * 2 + 1];
 
-    VerifyOrQuit(sizeof(PackedStruct) == 7, "Toolchain::OT_TOOL_PACKED failed");
+    VerifyOrQuit(sizeof(PackedStruct) == 7, "OT_TOOL_PACKED failed");
 
     packedStruct.mUint32 = 0x12345678;
     packedStruct.mByte   = 0xfe;
@@ -145,22 +145,21 @@ void test_packed_alignment(void)
 
         for (uint16_t i = 0; i < start; i++)
         {
-            VerifyOrQuit(buffer[i] == 0, "Toolchain::OT_TOOL_PACKED alignment failed - pre-size write");
+            VerifyOrQuit(buffer[i] == 0, "OT_TOOL_PACKED alignment failed - pre-size write");
         }
 
-        VerifyOrQuit(memcmp(ptr, packedStructBytes, sizeof(PackedStruct)) == 0,
-                     "Toolchain::OT_TOOL_PACKED alignment failed");
+        VerifyOrQuit(memcmp(ptr, packedStructBytes, sizeof(PackedStruct)) == 0, "OT_TOOL_PACKED alignment failed");
 
         for (uint16_t i = start + sizeof(packedStruct); i < sizeof(buffer); i++)
         {
-            VerifyOrQuit(buffer[i] == 0, "Toolchain::OT_TOOL_PACKED alignment failed - post-size write");
+            VerifyOrQuit(buffer[i] == 0, "OT_TOOL_PACKED alignment failed - post-size write");
         }
 
         memset(&packedStructCopy, 0, sizeof(PackedStruct));
         packedStructCopy = *reinterpret_cast<PackedStruct *>(ptr);
 
         VerifyOrQuit(memcmp(&packedStructCopy, &packedStruct, sizeof(PackedStruct)) == 0,
-                     "Toolchain::OT_TOOL_PACKED failed - read error");
+                     "OT_TOOL_PACKED failed - read error");
     }
 }
 

--- a/tests/unit/test_util.h
+++ b/tests/unit/test_util.h
@@ -32,6 +32,8 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include "common/arg_macros.hpp"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -41,17 +43,18 @@ extern "C" {
  * given error messages and exits the program.
  *
  * @param[in]  aStatus     A scalar error status to be evaluated against zero (0).
- * @param[in]  aMessage    A message (text string) to print on failure.
+ * @param[in]  aMessage    An optional message (constant C string) to print on failure.
  *
  */
-#define SuccessOrQuit(aStatus, aMessage)                                                \
-    do                                                                                  \
-    {                                                                                   \
-        if ((aStatus) != 0)                                                             \
-        {                                                                               \
-            fprintf(stderr, "\nFAILED %s:%d - %s\n", __FUNCTION__, __LINE__, aMessage); \
-            exit(-1);                                                                   \
-        }                                                                               \
+#define SuccessOrQuit(...)                                                                                      \
+    do                                                                                                          \
+    {                                                                                                           \
+        if ((OT_FIRST_ARG(__VA_ARGS__)) != 0)                                                                   \
+        {                                                                                                       \
+            fprintf(stderr, "\nFAILED %s:%d - SuccessOrQuit(%s)" OT_SECOND_ARG(__VA_ARGS__) "\n", __FUNCTION__, \
+                    __LINE__, _Stringize(OT_FIRST_ARG(__VA_ARGS__)));                                           \
+            exit(-1);                                                                                           \
+        }                                                                                                       \
     } while (false)
 
 /**
@@ -59,18 +62,23 @@ extern "C" {
  * program.
  *
  * @param[in]  aCondition  A Boolean expression to be evaluated.
- * @param[in]  aMessage    A message (text string) to print on failure.
+ * @param[in]  aMessage    An optional message (constant C string) to print on failure.
  *
  */
-#define VerifyOrQuit(aCondition, aMessage)                                              \
-    do                                                                                  \
-    {                                                                                   \
-        if (!(aCondition))                                                              \
-        {                                                                               \
-            fprintf(stderr, "\nFAILED %s:%d - %s\n", __FUNCTION__, __LINE__, aMessage); \
-            exit(-1);                                                                   \
-        }                                                                               \
+#define VerifyOrQuit(...)                                                                                       \
+    do                                                                                                          \
+    {                                                                                                           \
+        if (!(OT_FIRST_ARG(__VA_ARGS__)))                                                                       \
+        {                                                                                                       \
+            fprintf(stderr, "\nFAILED %s:%d - VerifyOrQuit(%s) " OT_SECOND_ARG(__VA_ARGS__) "\n", __FUNCTION__, \
+                    __LINE__, _Stringize(OT_FIRST_ARG(__VA_ARGS__)));                                           \
+            exit(-1);                                                                                           \
+        }                                                                                                       \
     } while (false)
+
+// Private macros to convert `aArg` to string
+#define _Stringize(aArg) _Stringize2(aArg)
+#define _Stringize2(aArg) #aArg
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This commit updates `VerifyOrQuit()` and `SuccessOrQuit()` macros to
include the failed condition in the error message that is printed on
a failure (in addition to function name and line number where the
error happened). This commit also changes the second parameter
(`aMessage`) to in these macros to be optional.

This commit also updates unit tests to remove the second `aMessage`
string in cases where the failure can be inferred from the condition
itself.

----

Here are some examples of error messages:
```
FAILED TestDnsName:198 - VerifyOrQuit(len != test.mEncodedLength) Encoded length does not match expected value
FAILED TestStringEndsWith:190 - VerifyOrQuit(!StringEndsWith("foobar", 'r')) 
```