### PR TITLE
[thci] add support for SSED DUT

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1204,6 +1204,10 @@ class OpenThreadTHCI(object):
                 print('join as sleepy end device')
                 mode = '-'
                 self.__setPollPeriod(self.__sedPollPeriod)
+            elif eRoleId == Thread_Device_Role.SSED:
+                print('join as SSED')
+                mode = '-'
+                self.setCSLperiod(self.cslPeriod)
             elif eRoleId == Thread_Device_Role.EndDevice:
                 print('join as end device')
                 mode = 'rn'
@@ -1454,6 +1458,7 @@ class OpenThreadTHCI(object):
         self.activetimestamp = ModuleHelper.Default_ActiveTimestamp
         # self.sedPollingRate = ModuleHelper.Default_Harness_SED_Polling_Rate
         self.__sedPollPeriod = 3 * 1000  # in milliseconds
+        self.cslPeriod = 500  # in milliseconds
         self.deviceRole = None
         self.provisioningUrl = ''
         self.hasActiveDatasetToCommit = False


### PR DESCRIPTION
Enable joining a network as SSED, which is required for several Thread 1.2 certification tests.