### PR TITLE
[otci] fix OTCI.wait arg order

### DIFF
--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -75,7 +75,7 @@ class OTCI(object):
 
             while duration > 0:
                 output = self.__otcmd.wait(1)
-                if match_line(expect_line, output):
+                if any(match_line(line, expect_line) for line in output):
                     success = True
                     break
 


### PR DESCRIPTION
In wait, [match_line is called with the arguments flipped](https://github.com/openthread/openthread/blob/main/tools/otci/otci/otci.py#L78). The first argument is supposed to the be the line being checked, and the second is supposed to be the pattern to match. The reason this still works for strings is because output is treated as a list of lines to expect, and each is just compared with == to the actual expected line