### PR TITLE
[mac] remove the out-of-band frame tx API

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (130)
+#define OPENTHREAD_API_VERSION (131)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -507,22 +507,6 @@ otError otLinkSendDataRequest(otInstance *aInstance);
 bool otLinkIsInTransmitState(otInstance *aInstance);
 
 /**
- * This function enqueues an IEEE 802.15.4 out of band Frame for transmission.
- *
- * An Out of Band frame is one that was generated outside of OpenThread.
- *
- * @param[in] aInstance  A pointer to an OpenThread instance.
- * @param[in] aOobFrame  A pointer to the frame to transmit.
- *
- * @retval OT_ERROR_NONE           Successfully scheduled the frame transmission.
- * @retval OT_ERROR_ALREADY        MAC layer is busy sending a previously requested frame.
- * @retval OT_ERROR_INVALID_STATE  The MAC layer is not enabled.
- * @retval OT_ERROR_INVALID_ARGS   The argument @p aOobFrame is NULL.
- *
- */
-otError otLinkOutOfBandTransmitRequest(otInstance *aInstance, otRadioFrame *aOobFrame);
-
-/**
  * Get the IEEE 802.15.4 channel.
  *
  * @param[in] aInstance A pointer to an OpenThread instance.

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -468,13 +468,6 @@ bool otLinkIsInTransmitState(otInstance *aInstance)
     return instance.Get<Mac::Mac>().IsInTransmitState();
 }
 
-otError otLinkOutOfBandTransmitRequest(otInstance *aInstance, otRadioFrame *aOobFrame)
-{
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().RequestOutOfBandFrameTransmission(aOobFrame);
-}
-
 uint16_t otLinkGetCcaFailureRate(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -234,21 +234,6 @@ public:
 #endif
 
     /**
-     * This method requests an Out of Band frame for MAC Transmission.
-     *
-     * An Out of Band frame is one that was generated outside of OpenThread.
-     *
-     * @param[in]  aOobFrame  A pointer to the frame.
-     *
-     * @retval kErrorNone          Successfully scheduled the frame transmission.
-     * @retval kErrorAlready       MAC layer is busy sending a previously requested frame.
-     * @retval kErrorInvalidState  The MAC layer is not enabled.
-     * @retval kErrorInvalidArgs   The argument @p aOobFrame is nullptr.
-     *
-     */
-    Error RequestOutOfBandFrameTransmission(otRadioFrame *aOobFrame);
-
-    /**
      * This method requests transmission of a data poll (MAC Data Request) frame.
      *
      * @retval kErrorNone          Data poll transmission request is scheduled successfully.
@@ -747,7 +732,6 @@ private:
         kOperationTransmitDataDirect,
         kOperationTransmitPoll,
         kOperationWaitingForData,
-        kOperationTransmitOutOfBandFrame,
 #if OPENTHREAD_FTD
         kOperationTransmitDataIndirect,
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
@@ -843,7 +827,6 @@ private:
 #endif
 #endif
     bool mPendingTransmitPoll : 1;
-    bool mPendingTransmitOobFrame : 1;
     bool mPendingWaitingForData : 1;
     bool mShouldTxPollBeforeData : 1;
     bool mRxOnWhenIdle : 1;
@@ -890,7 +873,6 @@ private:
     Links              mLinks;
     Tasklet            mOperationTask;
     TimerMilli         mTimer;
-    TxFrame *          mOobFrame;
     otMacCounters      mCounters;
     uint32_t           mKeyIdMode2FrameCounter;
     SuccessRateTracker mCcaSuccessRateTracker;


### PR DESCRIPTION
This commit removes the API to enqueue an out of band frame for
transmission by MAC layer. This API was added as a work-around to
enable legacy (non-Thread based) frames to be sent along with Thread
frames. This model is no longer used and generally not recommended.
The preferred way to handle multi-radio/multi-protocol is to add
support for it in radio platform layer.