### PR TITLE
[script] fix Thread version for check-simulation-build

### DIFF
--- a/script/check-simulation-build-autotools
+++ b/script/check-simulation-build-autotools
@@ -94,32 +94,39 @@ build_all_features()
         "-DOPENTHREAD_CONFIG_MLR_ENABLE=1"
     )
 
+    # Build Thread 1.1 with full features and no log
     export CPPFLAGS="${options[*]} -DOPENTHREAD_CONFIG_LOG_LEVEL=OT_LOG_LEVEL_NONE"
     reset_source
-    make -f examples/Makefile-simulation
+    make -f examples/Makefile-simulation THREAD_VERSION=1.1
 
+    # Build Thread 1.1 with full features and full logs
     export CPPFLAGS="${options[*]}"
     reset_source
-    make -f examples/Makefile-simulation FULL_LOGS=1
+    make -f examples/Makefile-simulation THREAD_VERSION=1.1 FULL_LOGS=1
 
+    # Build Thread 1.1 with full features and full logs (Logs defined as macros)
     export CPPFLAGS="${options[*]} -DOPENTHREAD_CONFIG_LOG_DEFINE_AS_MACRO_ONLY=1"
-    make -f examples/Makefile-simulation FULL_LOGS=1
+    make -f examples/Makefile-simulation THREAD_VERSION=1.1 FULL_LOGS=1
 
+    # Build Thread 1.2 with full features and logs
     export CPPFLAGS="${options[*]} ${options_1_2[*]} -DOPENTHREAD_CONFIG_LOG_LEVEL=OT_LOG_LEVEL_NONE"
     reset_source
     make -f examples/Makefile-simulation THREAD_VERSION=1.2
 
+    # Build Thread 1.2 with full features and full logs
     export CPPFLAGS="${options[*]} ${options_1_2[*]}"
     reset_source
     make -f examples/Makefile-simulation THREAD_VERSION=1.2 FULL_LOGS=1
 
+    # Build Thread 1.1 with ASSERT disabled
     export CPPFLAGS="${options[*]} -DOPENTHREAD_CONFIG_ASSERT_ENABLE=0"
     reset_source
-    make -f examples/Makefile-simulation
+    make -f examples/Makefile-simulation THREAD_VERSION=1.1
 
+    # Build Thread 1.1 OTNS
     export CPPFLAGS="${options[*]}"
     reset_source
-    make -f examples/Makefile-simulation OTNS=1
+    make -f examples/Makefile-simulation THREAD_VERSION=1.1 OTNS=1
 }
 
 build_nest_common()

--- a/script/check-simulation-build-cmake
+++ b/script/check-simulation-build-cmake
@@ -40,7 +40,7 @@ build_all_features()
 {
     # Build Thread 1.1 with full features
     reset_source
-    "$(dirname "$0")"/cmake-build simulation
+    "$(dirname "$0")"/cmake-build simulation -DOT_THREAD_VERSION=1.1
 
     # Build Thread 1.2 with full features
     reset_source
@@ -56,7 +56,7 @@ build_all_features()
 
     # Build with Vendor Extension
     reset_source
-    "$(dirname "$0")"/cmake-build simulation -DOT_VENDOR_EXTENSION=../../src/core/common/extension_example.cpp
+    "$(dirname "$0")"/cmake-build simulation -DOT_THREAD_VERSION=1.1 -DOT_VENDOR_EXTENSION=../../src/core/common/extension_example.cpp
 
     # Build Thread 1.2 with no additional features
     reset_source


### PR DESCRIPTION
The default Thread version has been set to 1.2 when building. Our test
script which checks building hasn't been updated accordingly. Currently it
specifies the version when it 1.2 is wanted and doesn't specify it when 1.1
is wanted. However, if THREAD_VERSIOn is not specified, the version would be
1.2. This PR fixes this error.