### PR TITLE
[netdata] allow zero-len external route prefix

### DIFF
--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -267,7 +267,7 @@ Error LeaderBase::ExternalRouteLookup(uint8_t             aDomainId,
             continue;
         }
 
-        if (prefixLength <= bestMatchLength)
+        if ((bestRouteEntry != nullptr) && (prefixLength <= bestMatchLength))
         {
             continue;
         }

--- a/src/core/thread/network_data_types.cpp
+++ b/src/core/thread/network_data_types.cpp
@@ -51,8 +51,7 @@ static bool IsPrefixValid(Instance &aInstance, const Ip6::Prefix &aPrefix)
     // Check that prefix length is within the valid range and the prefix
     // does not overlap with the mesh-local prefix.
 
-    return (aPrefix.GetLength() > 0) && aPrefix.IsValid() &&
-           !aPrefix.ContainsPrefix(aInstance.Get<Mle::Mle>().GetMeshLocalPrefix());
+    return aPrefix.IsValid() && !aPrefix.ContainsPrefix(aInstance.Get<Mle::Mle>().GetMeshLocalPrefix());
 }
 
 bool OnMeshPrefixConfig::IsValid(Instance &aInstance) const
@@ -76,6 +75,7 @@ bool OnMeshPrefixConfig::IsValid(Instance &aInstance) const
 
     VerifyOrExit(IsPreferenceValid(mPreference));
     VerifyOrExit(IsPrefixValid(aInstance, GetPrefix()));
+    VerifyOrExit(GetPrefix().GetLength() > 0);
 
     isValid = true;
 

--- a/tests/scripts/expect/cli-misc.exp
+++ b/tests/scripts/expect/cli-misc.exp
@@ -164,6 +164,13 @@ expect "0:0:0:0::/64 s low"
 send "route remove ::/64\n"
 expect_line "Done"
 
+send "route add ::/0 s low\n"
+expect_line "Done"
+send "route\n"
+expect "0:0:0:0::/0 s low"
+send "route remove ::/0\n"
+expect_line "Done"
+
 send "diag start\n"
 expect ": InvalidState"
 

--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -181,6 +181,7 @@ EXTRA_DIST                                                         = \
     test_srp_name_conflicts.py                                       \
     test_srp_register_single_service.py                              \
     test_srp_sub_type.py                                             \
+    test_zero_len_external_route.py                                  \
     thread_cert.py                                                   \
     tlvs_parsing.py                                                  \
     thread_cert.py                                                   \
@@ -240,6 +241,7 @@ check_SCRIPTS                                                      = \
     test_srp_name_conflicts.py                                       \
     test_srp_register_single_service.py                              \
     test_srp_sub_type.py                                             \
+    test_zero_len_external_route.py                                  \
     Cert_5_1_01_RouterAttach.py                                      \
     Cert_5_1_02_ChildAddressTimeout.py                               \
     Cert_5_1_03_RouterAddressReallocation.py                         \

--- a/tests/scripts/thread-cert/test_zero_len_external_route.py
+++ b/tests/scripts/thread-cert/test_zero_len_external_route.py
@@ -33,7 +33,7 @@ import thread_cert
 
 # Test description:
 #
-#   This test verifies the behavior of network when a zero length external router prefix "::/0" is added.
+#   This test verifies the behavior of the network when a zero length external route prefix "::/0" is added.
 #
 # Topology:
 #

--- a/tests/scripts/thread-cert/test_zero_len_external_route.py
+++ b/tests/scripts/thread-cert/test_zero_len_external_route.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2021, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import unittest
+
+import thread_cert
+
+# Test description:
+#
+#   This test verifies the behavior of network when a zero length external router prefix "::/0" is added.
+#
+# Topology:
+#
+#    leader --- router1
+#       \         /
+#        \       /
+#         router2
+#
+
+LEADER = 1
+ROUTER1 = 2
+ROUTER2 = 3
+
+
+class ZeroLengthExternalRoute(thread_cert.TestCase):
+    USE_MESSAGE_FACTORY = False
+    SUPPORT_NCP = False
+
+    TOPOLOGY = {
+        LEADER: {
+            'name': 'LEADER',
+            'mode': 'rdn',
+        },
+        ROUTER1: {
+            'name': 'ROUTER2',
+            'mode': 'rdn',
+        },
+        ROUTER2: {
+            'name': 'ROUTER2',
+            'mode': 'rdn',
+        },
+    }
+
+    def test(self):
+        leader = self.nodes[LEADER]
+        router1 = self.nodes[ROUTER1]
+        router2 = self.nodes[ROUTER2]
+
+        # Start the nodes and form the network.
+
+        leader.start()
+        self.simulator.go(5)
+        self.assertEqual(leader.get_state(), 'leader')
+
+        router1.start()
+        router2.start()
+        self.simulator.go(5)
+        self.assertEqual(router1.get_state(), 'router')
+        self.assertEqual(router2.get_state(), 'router')
+
+        # Add an on-mesh prefix with SLAAC on router2 (without default
+        # route flag).
+
+        router2.add_prefix('fd00:1234::/64', 'paos')
+        router2.register_netdata()
+
+        # Add a zero length external route on router1. Also add an IPv6
+        # address on router1.
+
+        router1.add_route('::/0', stable=True)
+        router1.add_ipaddr('fd00:abcd::1')
+        router1.register_netdata()
+        self.simulator.go(5)
+
+        # Ping from leader the address added on router1. The zero
+        # length external route should ensure the message is routed
+        # to router1.
+
+        self.assertTrue(leader.ping('fd00:abcd::1'))
+
+        # Change the on-mesh prefix on router2 to now also have
+        # the default route flag.
+
+        router2.remove_prefix('fd00:1234::/64')
+        router2.add_prefix('fd00:5678::/64', 'paros')
+        router2.register_netdata()
+        self.simulator.go(5)
+
+        # Again ping from leader the same address. The explicit
+        # external route (even with zero length) on router1 should
+        # still be preferred over the default route flag of the
+        # on-mesh prefix from router2.
+
+        self.assertTrue(leader.ping('fd00:abcd::1'))
+
+        # Remove the external route on router1.
+
+        router1.remove_route("::/0")
+        router1.register_netdata()
+        self.simulator.go(5)
+
+        # Now the ping should fail since the message would be routed
+        # to router2 (due to its on-mesh prefix with default route
+        # flag).
+
+        self.assertFalse(leader.ping('fd00:abcd::1'))
+
+        # Remove the address from router1 and add it on router2 and
+        # ping it again from leader to verify that the message is
+        # being routed to router2.
+
+        router1.del_ipaddr('fd00:abcd::1')
+        router2.add_ipaddr('fd00:abcd::1')
+        self.simulator.go(5)
+        self.assertTrue(leader.ping('fd00:abcd::1'))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit allows a zero-len prefix `::/0` to be added as an external
route in Network Data. Such a prefix can act as a default route.