### PR TITLE
[srp-server] avoid re-accessing committed SRP updates

### DIFF
--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -305,9 +305,8 @@ void Server::HandleServiceUpdateResult(ServiceUpdateId aId, Error aError)
 
 void Server::HandleServiceUpdateResult(UpdateMetadata *aUpdate, Error aError)
 {
-    CommitSrpUpdate(aError, aUpdate->GetDnsHeader(), aUpdate->GetHost(), aUpdate->GetMessageInfo());
-
     IgnoreError(mOutstandingUpdates.Remove(*aUpdate));
+    CommitSrpUpdate(aError, aUpdate->GetDnsHeader(), aUpdate->GetHost(), aUpdate->GetMessageInfo());
     aUpdate->Free();
 
     if (mOutstandingUpdates.IsEmpty())


### PR DESCRIPTION
We should remove the `UpdateMetadata`  before committing the SRP update to ensure that
the same `UpdateMetadata` (and the `Host` object) can never be touched again.