### PR TITLE
[srp-server] track lease time per service instance

### DIFF
--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -287,6 +287,8 @@ public:
             uint16_t     mPort;
             uint16_t     mTxtLength;
             uint8_t *    mTxtData;
+            uint32_t     mLease;    // The LEASE time in seconds.
+            uint32_t     mKeyLease; // The KEY-LEASE time in seconds.
             TimeMilli    mTimeLastUpdate;
         };
 

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1010,6 +1010,10 @@ class NodeImpl:
         self.send_command(f'srp client service remove {instance_name} {service_name}')
         self._expect_done()
 
+    def srp_client_clear_service(self, instance_name, service_name):
+        self.send_command(f'srp client service clear {instance_name} {service_name}')
+        self._expect_done()
+
     def srp_client_get_services(self):
         cmd = 'srp client service'
         self.send_command(cmd)

--- a/tests/scripts/thread-cert/test_srp_lease.py
+++ b/tests/scripts/thread-cert/test_srp_lease.py
@@ -135,6 +135,44 @@ class SrpRegisterSingleService(thread_cert.TestCase):
 
         self.check_host_and_service(server, client)
 
+        #
+        # 4. Clear the first service, shorten the lease time and register a second service.
+        #    Verify that the lease time of the first service is not affected by new SRP
+        #    registrations.
+        #
+
+        client.srp_client_clear_service('my-service', '_ipps._tcp')
+        server.srp_server_set_lease_range(50 * LEASE, 50 * LEASE, 50 * KEY_LEASE, 50 * KEY_LEASE)
+        client.srp_client_add_service('my-service2', '_ipps._tcp', 12345)
+
+        # Wait for the first service to expire.
+        self.simulator.go(LEASE + 2)
+        self.assertEqual(server.srp_server_get_service('my-service', '_ipps._tcp')['deleted'], 'true')
+
+        # Wait for the first service to be fully removed.
+        self.simulator.go(KEY_LEASE - LEASE + 2)
+        self.assertEqual(len(server.srp_server_get_services()), 1)
+        self.assertEqual(len(server.srp_server_get_hosts()), 1)
+
+        #
+        # 5. Clear the second service, lengthen the lease time and register a third service.
+        #    Verify that the lease time of the second service is not affected by new SRP
+        #    registrations.
+        #
+
+        client.srp_client_clear_service('my-service2', '_ipps._tcp')
+        server.srp_server_set_lease_range(LEASE, LEASE, KEY_LEASE, KEY_LEASE)
+        client.srp_client_add_service('my-service3', '_ipps._tcp', 12345)
+
+        # The second service has lease time of 50 * LEASE and should not expire.
+        self.simulator.go(LEASE + 2)
+        self.assertEqual(server.srp_server_get_service('my-service2', '_ipps._tcp')['deleted'], 'false')
+
+        # The second service has key-lease time of 50 * KEY_LEASE and should not expire.
+        self.simulator.go(KEY_LEASE - LEASE + 2)
+        self.assertEqual(len(server.srp_server_get_services()), 2)
+        self.assertEqual(len(server.srp_server_get_hosts()), 1)
+
     def check_host_and_service(self, server, client):
         """Check that we have properly registered host and service instance.
         """


### PR DESCRIPTION
The SRP draft 09 spec suggests that the SRP Servers SHOULD also track a lease time per service instance. 
>SRP Servers SHOULD also track a lease time per service instance.  The
   reason for doing this is that a client may re-register a host with a
   different set of services, and not remember that some different
   service instance had previously been registered.  In this case, when
   that service instance lease expires, the SRP server SHOULD remove the
   service instance (although the KEY record for the service instance
   SHOULD be retained until the key lease on that service expires).
   This is beneficial because if the SRP client continues to renew the
   host, but never mentions the stale service again, the stale service
   will continue to be advertised.