### PR TITLE
[dua] fix infinite DUA.req loop

### DIFF
--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -474,7 +474,7 @@ void DuaManager::PerformNextRegistration(void)
         const Ip6::Address *duaPtr = nullptr;
         Child *             child  = nullptr;
 
-        if (!mChildDuaMask.Get(mChildIndexDuaRegistering))
+        if (!mChildDuaMask.Get(mChildIndexDuaRegistering) || mChildDuaRegisteredMask.Get(mChildIndexDuaRegistering))
         {
             for (Child &iter : Get<ChildTable>().Iterate(Child::kInStateValid))
             {


### PR DESCRIPTION
Fixes #6796 

Verified that this commit fixes the infinite DUA.req loop.

This is a quick fix. We still need to reactor `mChildIndexDuaRegistering` because there are still potential issues. 