### PR TITLE
[dua] increase DUA registration test coverage

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1512,6 +1512,10 @@ class NodeImpl:
                 return addr
         return None
 
+    def get_mleid_iid(self):
+        ml_eid = ipaddress.IPv6Address(self.get_mleid())
+        return ml_eid.packed[8:].hex()
+
     def get_eidcaches(self):
         eidcaches = []
         self.send_command('eidcache')


### PR DESCRIPTION
Modify DUA registration test to check that ML-EID TLV content is as expected for every DUA.req sent.

It catches https://github.com/openthread/openthread/issues/6796

Depends on:
- [x] https://github.com/openthread/openthread/pull/6797