### PR TITLE
[link-metrics] fix Link Metrics Status Sub-TLV value

### DIFF
--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -724,7 +724,7 @@ LinkMetrics::LinkMetricsStatus LinkMetrics::ConfigureEnhAckProbing(LinkMetricsEn
     LinkMetricsStatus status = kLinkMetricsStatusSuccess;
     Error             error  = kErrorNone;
 
-    VerifyOrExit(!aLinkMetrics.mReserved, status = kLinkMetricsStatusCannotSupportNewSeries);
+    VerifyOrExit(!aLinkMetrics.mReserved, status = kLinkMetricsStatusOtherError);
 
     if (aEnhAckFlags == kEnhAckRegister)
     {

--- a/tests/scripts/thread-cert/v1_2_LowPower_7_1_01_SingleProbeLinkMetricsWithEnhancedAcks.py
+++ b/tests/scripts/thread-cert/v1_2_LowPower_7_1_01_SingleProbeLinkMetricsWithEnhancedAcks.py
@@ -375,11 +375,11 @@ class LowPower_7_1_01(thread_cert.TestCase):
         # Step 19 - Leader automatically responds to the invalid query from SSED_1 with a failure
         # The DUT MUST send Link Metrics Management Response to SSED_1containing the following:
         # - MLE Link Metrics Management TLV
-        # -- Link Metrics Status Sub-TLV = 1 (Failure)
+        # -- Link Metrics Status Sub-TLV = 254 (Failure)
         pkts.filter_wpan_src64(LEADER) \
             .filter_wpan_dst64(SSED_1) \
             .filter_mle_cmd(consts.MLE_LINK_METRICS_MANAGEMENT_RESPONSE) \
-            .filter(lambda p: p.mle.tlv.link_status_sub_tlv == consts.LINK_METRICS_ENH_ACK_PROBING_REGISTER) \
+            .filter(lambda p: p.mle.tlv.link_status_sub_tlv == consts.LINK_METRICS_STATUS_OTHER_ERROR) \
             .must_next()
 
 


### PR DESCRIPTION
When the Initiator requests a reserved Metric Type ID Flag the status value should be "Value 254: Failure – Other failure".