### PR TITLE
[mle] include the CCM flag in the Discovery Response

### DIFF
--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -2248,6 +2248,33 @@ public:
         }
     }
 
+    /**
+     * This method indicates whether or not the Commercial Commissioning Mode flag is set.
+     *
+     * @retval TRUE   If the Commercial Commissioning Mode flag is set.
+     * @retval FALSE  If the Commercial Commissioning Mode flag is not set.
+     *
+     */
+    bool IsCommercialCommissioningMode(void) const { return (mFlags & kCCMMask) != 0; }
+
+    /**
+     * This method sets the Native Commissioner flag.
+     *
+     * @param[in]  aNativeCommissioner  TRUE if set, FALSE otherwise.
+     *
+     */
+    void SetCommercialCommissioningMode(bool aCCM)
+    {
+        if (aCCM)
+        {
+            mFlags |= kCCMMask;
+        }
+        else
+        {
+            mFlags &= ~kCCMMask;
+        }
+    }
+
 private:
     enum
     {
@@ -2255,6 +2282,8 @@ private:
         kVersionMask   = 0xf << kVersionOffset,
         kNativeOffset  = 3,
         kNativeMask    = 1 << kNativeOffset,
+        kCCMOffset     = 2,
+        kCCMMask       = 1 << kCCMOffset,
     };
     uint8_t mFlags;
     uint8_t mReserved;

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -2258,9 +2258,9 @@ public:
     bool IsCommercialCommissioningMode(void) const { return (mFlags & kCCMMask) != 0; }
 
     /**
-     * This method sets the Native Commissioner flag.
+     * This method sets the Commercial Commissioning Mode flag.
      *
-     * @param[in]  aNativeCommissioner  TRUE if set, FALSE otherwise.
+     * @param[in]  aCCM  TRUE if set, FALSE otherwise.
      *
      */
     void SetCommercialCommissioningMode(bool aCCM)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2930,6 +2930,11 @@ Error MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, const M
         discoveryResponse.SetNativeCommissioner(false);
     }
 
+    if (Get<KeyManager>().GetSecurityPolicy().mCommercialCommissioningEnabled)
+    {
+        discoveryResponse.SetCommercialCommissioningMode(true);
+    }
+
     SuccessOrExit(error = discoveryResponse.AppendTo(*message));
 
     // Extended PAN ID TLV


### PR DESCRIPTION
Commercial Commissioning Mode flag from the Security Policy has to be set in the Discovery Response TLV of the MLE Discovery Response messages.