### PR TITLE
[network-diagnostic] fix initialization of max child timeout

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -4337,9 +4337,9 @@ Error MleRouter::GetMaxChildTimeout(uint32_t &aTimeout) const
 {
     Error error = kErrorNotFound;
 
-    VerifyOrExit(IsRouterOrLeader(), error = kErrorInvalidState);
-
     aTimeout = 0;
+
+    VerifyOrExit(IsRouterOrLeader(), error = kErrorInvalidState);
 
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -4339,6 +4339,8 @@ Error MleRouter::GetMaxChildTimeout(uint32_t &aTimeout) const
 
     VerifyOrExit(IsRouterOrLeader(), error = kErrorInvalidState);
 
+    aTimeout = 0;
+
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
         if (child.IsFullThreadDevice())

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -430,7 +430,7 @@ Error NetworkDiagnostic::FillRequestedTlvs(const Message &       aRequest,
 #if OPENTHREAD_FTD
         case NetworkDiagnosticTlv::kMaxChildTimeout:
         {
-            uint32_t maxTimeout;
+            uint32_t maxTimeout = 0;
 
             if (Get<Mle::MleRouter>().GetMaxChildTimeout(maxTimeout) == kErrorNone)
             {

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -430,7 +430,7 @@ Error NetworkDiagnostic::FillRequestedTlvs(const Message &       aRequest,
 #if OPENTHREAD_FTD
         case NetworkDiagnosticTlv::kMaxChildTimeout:
         {
-            uint32_t maxTimeout = 0;
+            uint32_t maxTimeout;
 
             if (Get<Mle::MleRouter>().GetMaxChildTimeout(maxTimeout) == kErrorNone)
             {


### PR DESCRIPTION
`MleRouter::GetMaxChildTimeout` relies on the initial value of `maxTimeout`. This adds the correct initialization.