### PR TITLE
Add API to obtain Receiver Poll state at run-time.

### DIFF
--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -833,6 +833,16 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
 extern void otPlatRadioEnergyScanDone(otInstance *aInstance, int8_t aEnergyScanMaxRssi);
 
 /**
+ * This function indicates whether or not an IEEE 802.15.4 MAC is currently waiting for data.
+ * MAC module is in the receive state during a polling procedure pending external frame transmission.
+ *
+ * @param[in] aInstance A pointer to an OpenThread instance.
+ * @returns true if an IEEE 802.15.4 MAC is in the polling receive state, false otherwise.
+ *
+ */
+extern bool otPlatRadioIsRxStatePolling(otInstance *aInstance);
+
+/**
  * Enable/Disable source address match feature.
  *
  * The source address match feature controls how the radio layer decides the "frame pending" bit for acks sent in

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -228,6 +228,11 @@ bool Mac::IsInTransmitState(void) const
     return retval;
 }
 
+bool Mac::IsRxStatePolling(void) const
+{
+    return (mOperation == kOperationWaitingForData);
+}
+
 Error Mac::ConvertBeaconToActiveScanResult(const RxFrame *aBeaconFrame, ActiveScanResult &aResult)
 {
     Error                error = kErrorNone;

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -551,6 +551,13 @@ public:
     bool IsInTransmitState(void) const;
 
     /**
+     * This method returns if the MAC layer is in polling receive state.
+     *
+     * The MAC layer is in the receive state during a polling procedure pending external frame transmission.
+     */
+    bool IsRxStatePolling(void) const;
+
+    /**
      * This method registers a callback to provide received raw IEEE 802.15.4 frames.
      *
      * @param[in]  aPcapCallback     A pointer to a function that is called when receiving an IEEE 802.15.4 link frame

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -115,6 +115,18 @@ exit:
     return;
 }
 
+bool otPlatRadioIsRxStatePolling(otInstance *aInstance)
+{
+    Instance *instance = static_cast<Instance *>(aInstance);
+    bool ret = false;
+
+    if (instance->IsInitialized())
+    {
+        ret = instance->Get<Mac::Mac>().IsRxStatePolling();
+    }
+    return (ret);
+}
+
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
 extern "C" void otPlatDiagRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, Error aError)
 {

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -117,14 +117,9 @@ exit:
 
 bool otPlatRadioIsRxStatePolling(otInstance *aInstance)
 {
-    Instance *instance = static_cast<Instance *>(aInstance);
-    bool ret = false;
+    Instance &instance = *static_cast<Instance *>(aInstance);
 
-    if (instance->IsInitialized())
-    {
-        ret = instance->Get<Mac::Mac>().IsRxStatePolling();
-    }
-    return (ret);
+    return instance.Get<Mac::Mac>().IsRxStatePolling();
 }
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -36,6 +36,7 @@
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "radio/radio.hpp"
+#include "mac/mac.hpp"
 
 using namespace ot;
 

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -34,9 +34,9 @@
 #include <openthread/platform/time.h>
 
 #include "common/code_utils.hpp"
+#include "mac/mac.hpp"
 #include "common/instance.hpp"
 #include "radio/radio.hpp"
-#include "mac/mac.hpp"
 
 using namespace ot;
 


### PR DESCRIPTION
It is not currently possible to obtain the Polling state of the receiver from the radio layer via OTLink API's. This API is being added to add support for this use case.