### PR TITLE
[meshcop] fix issues in sending updated datasets to leader

### DIFF
--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -363,7 +363,7 @@ private:
     enum
     {
         kMaxDatasetTlvs = 16,   // Maximum number of TLVs in a Dataset.
-        kDelayNoBufs    = 1000, // Milliseconds
+        kSendSetDelay   = 5000, // Milliseconds
     };
 
     bool       mCoapPending : 1;


### PR DESCRIPTION
This commit fixes a couple issues with sending MGMT_SET.req to update
the leader with a new operational dataset.

- When handling an MLE Child ID Response message,
  DatasetManager::Save() is called before the role is updated to
  child. As a result, a device with a newer dataset prior to attaching
  the network will not send a MGMT_SET.req message. This commit adds a
  delay to allow the role to change to child.

- When receiving a MGMT_SET.rsp, the device will immediately check if
  it should send a MGMT_SET.req message again. However, the
  operational dataset may not have had a chance to propagate from the
  leader. This commit adds additional delay to allow the new
  operational dataset to propagate.

Fixes #6804 