### PR TITLE
[dns-server] add DNS64 recursive query server support

### DIFF
--- a/include/openthread/dns.h
+++ b/include/openthread/dns.h
@@ -39,6 +39,7 @@
 
 #include <openthread/error.h>
 #include <openthread/instance.h>
+#include <openthread/ip6.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -166,6 +167,19 @@ void otDnsSetNameCompressionEnabled(bool aEnabled);
  *
  */
 bool otDnsIsNameCompressionEnabled(void);
+
+/**
+ * This function gets the NAT64 prefix.
+ *
+ * The resolved addresses for IPv4 hosts will begin with this prefix.
+ *
+ * @param[in]  aInstance    The OpenThread instance.
+ * @param[out] aPrefix      The NAT64 prefix.
+ *
+ * @retval OT_ERROR_NONE        The address is successfully fetched.
+ * @retval OT_ERROR_NOT_FOUND   There is no NAT64 prefix in the network.
+ */
+otError otDnsGetNat64Prefix(otInstance *aInstance, otIp6Prefix *aPrefix);
 
 /**
  * @}

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (138)
+#define OPENTHREAD_API_VERSION (139)
 
 /**
  * @addtogroup api-instance

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -27,6 +27,7 @@
  */
 
 #include "dns_client.hpp"
+#include "openthread/dns.h"
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
 
@@ -350,27 +351,11 @@ exit:
 
 Error Client::AddressResponse::GetNat64Prefix(Ip6::Prefix &aPrefix) const
 {
-    Error                            error      = kErrorNotFound;
-    NetworkData::Iterator            iterator   = NetworkData::kIteratorInit;
-    signed int                       preference = OT_ROUTE_PREFERENCE_LOW;
-    NetworkData::ExternalRouteConfig config;
+    otIp6Prefix prefix;
+    Error       error = otDnsGetNat64Prefix(mInstance, &prefix);
 
     aPrefix.Clear();
-
-    while (mInstance->Get<NetworkData::Leader>().GetNextExternalRoute(iterator, config) == kErrorNone)
-    {
-        if (!config.mNat64 || !config.GetPrefix().IsValidNat64())
-        {
-            continue;
-        }
-
-        if ((aPrefix.GetLength() == 0) || (config.mPreference > preference))
-        {
-            aPrefix    = config.GetPrefix();
-            preference = config.mPreference;
-            error      = kErrorNone;
-        }
-    }
+    aPrefix.Set(prefix.mPrefix.mFields.m8, prefix.mLength);
 
     return error;
 }

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -214,6 +214,8 @@ private:
             }
         }
 
+        bool IsRecursiveQuery() { return mDomainName == nullptr; }
+
     private:
         static bool MatchCompressedName(const Message &aMessage, uint16_t aOffset, const char *aName)
         {


### PR DESCRIPTION
The DNS64 server allows devices in the Thread network to visit IPv4
hostnames transparently via the 6-to-4 border router.

Depends-On: https://github.com/openthread/ot-br-posix/pull/932