### PR TITLE
[mac] replace `enum` constants with `constexpr`

### DIFF
--- a/src/core/mac/channel_mask.hpp
+++ b/src/core/mac/channel_mask.hpp
@@ -65,11 +65,13 @@ namespace Mac {
 class ChannelMask : public Unequatable<ChannelMask>
 {
 public:
-    enum
-    {
-        kChannelIteratorFirst = 0xff, ///< Value to pass in `GetNextChannel()` to get the first channel in the mask.
-        kInfoStringSize       = 45,   ///< Recommended buffer size to use with `ToString()`.
-    };
+    /**
+     * This constant specifies the value to pass in `GetNextChannel()` to get the first channel in the mask.
+     *
+     */
+    static constexpr uint8_t kChannelIteratorFirst = 0xff;
+
+    static constexpr uint16_t kInfoStringSize = 45; ///< Recommended buffer size to use with `ToString()`.
 
     /**
      * This type defines the fixed-length `String` object returned from `ToString()`.

--- a/src/core/mac/data_poll_handler.hpp
+++ b/src/core/mac/data_poll_handler.hpp
@@ -68,16 +68,13 @@ class DataPollHandler : public InstanceLocator, private NonCopyable
     friend class Mac::Mac;
 
 public:
-    enum
-    {
-        kMaxPollTriggeredTxAttempts = OPENTHREAD_CONFIG_MAC_MAX_TX_ATTEMPTS_INDIRECT_POLLS,
-    };
+    static constexpr uint8_t kMaxPollTriggeredTxAttempts = OPENTHREAD_CONFIG_MAC_MAX_TX_ATTEMPTS_INDIRECT_POLLS;
 
     /**
      * This enumeration defines frame change request types used as input to `RequestFrameChange()`.
      *
      */
-    enum FrameChange
+    enum FrameChange : uint8_t
     {
         kPurgeFrame,   ///< Indicates that previous frame should be purged. Any ongoing indirect tx should be aborted.
         kReplaceFrame, ///< Indicates that previous frame needs to be replaced with a new higher priority one.

--- a/src/core/mac/data_poll_sender.hpp
+++ b/src/core/mac/data_poll_sender.hpp
@@ -63,12 +63,9 @@ namespace ot {
 class DataPollSender : public InstanceLocator, private NonCopyable
 {
 public:
-    enum
-    {
-        kDefaultFastPolls  = 8,  ///< Default number of fast poll transmissions (@sa StartFastPolls).
-        kMaxFastPolls      = 15, ///< Maximum number of fast poll transmissions allowed.
-        kMaxFastPollsUsers = 63, ///< Maximum number of the users of fast poll transmissions allowed.
-    };
+    static constexpr uint8_t kDefaultFastPolls  = 8;  ///< Default number of fast poll tx (@sa StartFastPolls).
+    static constexpr uint8_t kMaxFastPolls      = 15; ///< Maximum number of fast poll tx allowed.
+    static constexpr uint8_t kMaxFastPollsUsers = 63; ///< Maximum number of the users of fast poll tx allowed.
 
     /**
      * This constructor initializes the data poll sender object.
@@ -259,17 +256,11 @@ public:
     Mac::TxFrame *PrepareDataRequest(Mac::TxFrames &aTxFrames);
 
 private:
-    enum
-    {
-        kQuickPollsAfterTimeout = 5, ///< Maximum number of quick data poll tx in case of back-to-back poll timeouts.
-        kMaxPollRetxAttempts = OPENTHREAD_CONFIG_FAILED_CHILD_TRANSMISSIONS, ///< Maximum number of retransmit attempts
-                                                                             ///< of data poll (mac data request).
-        kMaxCslPollRetxAttempts =
-            OPENTHREAD_CONFIG_MAC_DEFAULT_MAX_FRAME_RETRIES_DIRECT, ///< Maximum number of retransmit attempts of data
-                                                                    ///< poll with CSL IE (mac data request).
-    };
+    static constexpr uint8_t kQuickPollsAfterTimeout = 5; // Quick data poll tx in case of back-to-back poll timeouts.
+    static constexpr uint8_t kMaxPollRetxAttempts    = OPENTHREAD_CONFIG_FAILED_CHILD_TRANSMISSIONS;
+    static constexpr uint8_t kMaxCslPollRetxAttempts = OPENTHREAD_CONFIG_MAC_DEFAULT_MAX_FRAME_RETRIES_DIRECT;
 
-    enum PollPeriodSelector
+    enum PollPeriodSelector : uint8_t
     {
         kUsePreviousPollPeriod,
         kRecalculatePollPeriod,

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2436,10 +2436,7 @@ exit:
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
 void Mac::ProcessEnhAckProbing(const RxFrame &aFrame, const Neighbor &aNeighbor)
 {
-    enum
-    {
-        kEnhAckProbingIeMaxLen = 2,
-    };
+    constexpr uint8_t kEnhAckProbingIeMaxLen = 2;
 
     const HeaderIe *enhAckProbingIe =
         reinterpret_cast<const HeaderIe *>(aFrame.GetThreadIe(ThreadIe::kEnhAckProbingIe));

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -70,31 +70,20 @@ class Neighbor;
 
 namespace Mac {
 
-/**
- * Protocol parameters and constants.
- *
- */
-enum
-{
-    kDataPollTimeout = 100, ///< Timeout for receiving Data Frame (milliseconds).
-    kSleepDelay      = 300, ///< Max sleep delay when frame is pending (milliseconds).
+constexpr uint32_t kDataPollTimeout = 100; ///< Timeout for receiving Data Frame (in msec).
+constexpr uint32_t kSleepDelay      = 300; ///< Max sleep delay when frame is pending (in msec).
 
-    kScanDurationDefault = OPENTHREAD_CONFIG_MAC_SCAN_DURATION, ///< Default interval between channels (milliseconds).
+constexpr uint16_t kScanDurationDefault = OPENTHREAD_CONFIG_MAC_SCAN_DURATION; ///< Duration per channel (in msec).
 
-    kMaxCsmaBackoffsDirect =
-        OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_DIRECT, ///< macMaxCsmaBackoffs for direct transmissions
-    kMaxCsmaBackoffsIndirect =
-        OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_INDIRECT, ///< macMaxCsmaBackoffs for indirect transmissions
-    kMaxCsmaBackoffsCsl = 0,                              ///< macMaxCsmaBackoffs for CSL transmissions
+constexpr uint8_t kMaxCsmaBackoffsDirect   = OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_DIRECT;
+constexpr uint8_t kMaxCsmaBackoffsIndirect = OPENTHREAD_CONFIG_MAC_MAX_CSMA_BACKOFFS_INDIRECT;
+constexpr uint8_t kMaxCsmaBackoffsCsl      = 0;
 
-    kDefaultMaxFrameRetriesDirect =
-        OPENTHREAD_CONFIG_MAC_DEFAULT_MAX_FRAME_RETRIES_DIRECT, ///< macDefaultMaxFrameRetries for direct transmissions
-    kDefaultMaxFrameRetriesIndirect =
-        OPENTHREAD_CONFIG_MAC_DEFAULT_MAX_FRAME_RETRIES_INDIRECT, ///< macDefaultMaxFrameRetries for indirect
-    kMaxFrameRetriesCsl = 0,                                      ///< macMaxFrameRetries for CSL transmissions
+constexpr uint8_t kDefaultMaxFrameRetriesDirect   = OPENTHREAD_CONFIG_MAC_DEFAULT_MAX_FRAME_RETRIES_DIRECT;
+constexpr uint8_t kDefaultMaxFrameRetriesIndirect = OPENTHREAD_CONFIG_MAC_DEFAULT_MAX_FRAME_RETRIES_INDIRECT;
+constexpr uint8_t kMaxFrameRetriesCsl             = 0;
 
-    kTxNumBcast = OPENTHREAD_CONFIG_MAC_TX_NUM_BCAST ///< Number of times each broadcast frame is transmitted
-};
+constexpr uint8_t kTxNumBcast = OPENTHREAD_CONFIG_MAC_TX_NUM_BCAST; ///< Num of times broadcast frame is tx.
 
 /**
  * This type defines the function pointer called on receiving an IEEE 802.15.4 Beacon during an Active Scan.
@@ -754,12 +743,8 @@ public:
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
 private:
-    enum
-    {
-        kInvalidRssiValue  = SubMac::kInvalidRssiValue,
-        kMaxCcaSampleCount = OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW,
-        kMaxAcquisitionId  = 0xffff,
-    };
+    static constexpr int8_t   kInvalidRssiValue  = SubMac::kInvalidRssiValue;
+    static constexpr uint16_t kMaxCcaSampleCount = OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW;
 
     enum Operation : uint8_t
     {

--- a/src/core/mac/mac_filter.hpp
+++ b/src/core/mac/mac_filter.hpp
@@ -85,10 +85,7 @@ public:
         kModeDenylist  = OT_MAC_FILTER_ADDRESS_MODE_DENYLIST,  ///< Enable denylist address filter mode.
     };
 
-    enum : int8_t
-    {
-        kFixedRssDisabled = OT_MAC_FILTER_FIXED_RSS_DISABLED, ///< Value to indicate no fixed RSS is set.
-    };
+    static constexpr int8_t kFixedRssDisabled = OT_MAC_FILTER_FIXED_RSS_DISABLED; ///< Value when no fixed RSS is set.
 
     /**
      * This constructor initializes the filter.
@@ -192,7 +189,7 @@ public:
     void ClearDefaultRssIn(void) { mDefaultRssIn = kFixedRssDisabled; }
 
     /**
-     * This method clears all the received signal strength settings (inlcuding the default RSS-In).
+     * This method clears all the received signal strength settings (including the default RSS-In).
      *
      */
     void ClearAllRssIn(void);
@@ -225,10 +222,7 @@ public:
     Error Apply(const ExtAddress &aExtAddress, int8_t &aRss);
 
 private:
-    enum
-    {
-        kMaxEntries = OPENTHREAD_CONFIG_MAC_FILTER_SIZE, // The maximum number of filter entries.
-    };
+    static constexpr uint16_t kMaxEntries = OPENTHREAD_CONFIG_MAC_FILTER_SIZE;
 
     struct FilterEntry
     {

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -124,17 +124,10 @@ private:
     // | Length    | Element ID | Type=0 |
     // +-----------+------------+--------+
 
-    enum : uint8_t
-    {
-        kSize       = 2,
-        kIdOffset   = 7,
-        kLengthMask = 0x7f
-    };
-
-    enum : uint16_t
-    {
-        kIdMask = 0x00ff << kIdOffset,
-    };
+    static constexpr uint8_t  kSize       = 2;
+    static constexpr uint8_t  kIdOffset   = 7;
+    static constexpr uint8_t  kLengthMask = 0x7f;
+    static constexpr uint16_t kIdMask     = 0x00ff << kIdOffset;
 
     union OT_TOOL_PACKED_FIELD
     {
@@ -154,11 +147,8 @@ OT_TOOL_PACKED_BEGIN
 class VendorIeHeader
 {
 public:
-    enum : uint8_t
-    {
-        kHeaderIeId    = 0x00,
-        kIeContentSize = sizeof(uint8_t) * 4,
-    };
+    static constexpr uint8_t kHeaderIeId    = 0x00;
+    static constexpr uint8_t kIeContentSize = sizeof(uint8_t) * 4;
 
     /**
      * This method returns the Vendor OUI.
@@ -193,10 +183,7 @@ public:
     void SetSubType(uint8_t aSubType) { mSubType = aSubType; }
 
 private:
-    enum : uint8_t
-    {
-        kOuiSize = 3,
-    };
+    static constexpr uint8_t kOuiSize = 3;
 
     uint8_t mOui[kOuiSize];
     uint8_t mSubType;
@@ -211,21 +198,10 @@ OT_TOOL_PACKED_BEGIN
 class TimeIe : public VendorIeHeader
 {
 public:
-    enum : uint32_t
-    {
-        kVendorOuiNest = 0x18b430,
-    };
-
-    enum : uint8_t
-    {
-        kVendorIeTime = 0x01,
-    };
-
-    enum
-    {
-        kHeaderIeId    = VendorIeHeader::kHeaderIeId,
-        kIeContentSize = VendorIeHeader::kIeContentSize + sizeof(uint8_t) + sizeof(uint64_t),
-    };
+    static constexpr uint32_t kVendorOuiNest = 0x18b430;
+    static constexpr uint8_t  kVendorIeTime  = 0x01;
+    static constexpr uint8_t  kHeaderIeId    = VendorIeHeader::kHeaderIeId;
+    static constexpr uint8_t  kIeContentSize = VendorIeHeader::kIeContentSize + sizeof(uint8_t) + sizeof(uint64_t);
 
     /**
      * This method initializes the time IE.
@@ -279,21 +255,10 @@ private:
 class ThreadIe
 {
 public:
-    enum : uint8_t
-    {
-        kHeaderIeId    = VendorIeHeader::kHeaderIeId,
-        kIeContentSize = VendorIeHeader::kIeContentSize,
-    };
-
-    enum : uint32_t
-    {
-        kVendorOuiThreadCompanyId = 0xeab89b,
-    };
-
-    enum SubType : uint8_t
-    {
-        kEnhAckProbingIe = 0x00,
-    };
+    static constexpr uint8_t  kHeaderIeId               = VendorIeHeader::kHeaderIeId;
+    static constexpr uint8_t  kIeContentSize            = VendorIeHeader::kIeContentSize;
+    static constexpr uint32_t kVendorOuiThreadCompanyId = 0xeab89b;
+    static constexpr uint8_t  kEnhAckProbingIe          = 0x00;
 };
 #endif
 
@@ -307,80 +272,77 @@ public:
 class Frame : public otRadioFrame
 {
 public:
-    enum
-    {
-        kFcfSize             = sizeof(uint16_t),
-        kDsnSize             = sizeof(uint8_t),
-        kSecurityControlSize = sizeof(uint8_t),
-        kFrameCounterSize    = sizeof(uint32_t),
-        kCommandIdSize       = sizeof(uint8_t),
-        k154FcsSize          = sizeof(uint16_t),
+    static constexpr uint8_t kFcfSize             = sizeof(uint16_t);
+    static constexpr uint8_t kDsnSize             = sizeof(uint8_t);
+    static constexpr uint8_t kSecurityControlSize = sizeof(uint8_t);
+    static constexpr uint8_t kFrameCounterSize    = sizeof(uint32_t);
+    static constexpr uint8_t kCommandIdSize       = sizeof(uint8_t);
+    static constexpr uint8_t k154FcsSize          = sizeof(uint16_t);
 
-        kFcfFrameBeacon      = 0 << 0,
-        kFcfFrameData        = 1 << 0,
-        kFcfFrameAck         = 2 << 0,
-        kFcfFrameMacCmd      = 3 << 0,
-        kFcfFrameTypeMask    = 7 << 0,
-        kFcfSecurityEnabled  = 1 << 3,
-        kFcfFramePending     = 1 << 4,
-        kFcfAckRequest       = 1 << 5,
-        kFcfPanidCompression = 1 << 6,
-        kFcfIePresent        = 1 << 9,
-        kFcfDstAddrNone      = 0 << 10,
-        kFcfDstAddrShort     = 2 << 10,
-        kFcfDstAddrExt       = 3 << 10,
-        kFcfDstAddrMask      = 3 << 10,
-        kFcfFrameVersion2006 = 1 << 12,
-        kFcfFrameVersion2015 = 2 << 12,
-        kFcfFrameVersionMask = 3 << 12,
-        kFcfSrcAddrNone      = 0 << 14,
-        kFcfSrcAddrShort     = 2 << 14,
-        kFcfSrcAddrExt       = 3 << 14,
-        kFcfSrcAddrMask      = 3 << 14,
+    static constexpr uint16_t kFcfFrameBeacon      = 0 << 0;
+    static constexpr uint16_t kFcfFrameData        = 1 << 0;
+    static constexpr uint16_t kFcfFrameAck         = 2 << 0;
+    static constexpr uint16_t kFcfFrameMacCmd      = 3 << 0;
+    static constexpr uint16_t kFcfFrameTypeMask    = 7 << 0;
+    static constexpr uint16_t kFcfSecurityEnabled  = 1 << 3;
+    static constexpr uint16_t kFcfFramePending     = 1 << 4;
+    static constexpr uint16_t kFcfAckRequest       = 1 << 5;
+    static constexpr uint16_t kFcfPanidCompression = 1 << 6;
+    static constexpr uint16_t kFcfIePresent        = 1 << 9;
+    static constexpr uint16_t kFcfDstAddrNone      = 0 << 10;
+    static constexpr uint16_t kFcfDstAddrShort     = 2 << 10;
+    static constexpr uint16_t kFcfDstAddrExt       = 3 << 10;
+    static constexpr uint16_t kFcfDstAddrMask      = 3 << 10;
+    static constexpr uint16_t kFcfFrameVersion2006 = 1 << 12;
+    static constexpr uint16_t kFcfFrameVersion2015 = 2 << 12;
+    static constexpr uint16_t kFcfFrameVersionMask = 3 << 12;
+    static constexpr uint16_t kFcfSrcAddrNone      = 0 << 14;
+    static constexpr uint16_t kFcfSrcAddrShort     = 2 << 14;
+    static constexpr uint16_t kFcfSrcAddrExt       = 3 << 14;
+    static constexpr uint16_t kFcfSrcAddrMask      = 3 << 14;
 
-        kSecNone      = 0 << 0,
-        kSecMic32     = 1 << 0,
-        kSecMic64     = 2 << 0,
-        kSecMic128    = 3 << 0,
-        kSecEnc       = 4 << 0,
-        kSecEncMic32  = 5 << 0,
-        kSecEncMic64  = 6 << 0,
-        kSecEncMic128 = 7 << 0,
-        kSecLevelMask = 7 << 0,
+    static constexpr uint8_t kSecNone      = 0 << 0;
+    static constexpr uint8_t kSecMic32     = 1 << 0;
+    static constexpr uint8_t kSecMic64     = 2 << 0;
+    static constexpr uint8_t kSecMic128    = 3 << 0;
+    static constexpr uint8_t kSecEnc       = 4 << 0;
+    static constexpr uint8_t kSecEncMic32  = 5 << 0;
+    static constexpr uint8_t kSecEncMic64  = 6 << 0;
+    static constexpr uint8_t kSecEncMic128 = 7 << 0;
+    static constexpr uint8_t kSecLevelMask = 7 << 0;
 
-        kMic0Size   = 0,
-        kMic32Size  = 32 / CHAR_BIT,
-        kMic64Size  = 64 / CHAR_BIT,
-        kMic128Size = 128 / CHAR_BIT,
-        kMaxMicSize = kMic128Size,
+    static constexpr uint8_t kMic0Size   = 0;
+    static constexpr uint8_t kMic32Size  = 32 / CHAR_BIT;
+    static constexpr uint8_t kMic64Size  = 64 / CHAR_BIT;
+    static constexpr uint8_t kMic128Size = 128 / CHAR_BIT;
+    static constexpr uint8_t kMaxMicSize = kMic128Size;
 
-        kKeyIdMode0    = 0 << 3,
-        kKeyIdMode1    = 1 << 3,
-        kKeyIdMode2    = 2 << 3,
-        kKeyIdMode3    = 3 << 3,
-        kKeyIdModeMask = 3 << 3,
+    static constexpr uint8_t kKeyIdMode0    = 0 << 3;
+    static constexpr uint8_t kKeyIdMode1    = 1 << 3;
+    static constexpr uint8_t kKeyIdMode2    = 2 << 3;
+    static constexpr uint8_t kKeyIdMode3    = 3 << 3;
+    static constexpr uint8_t kKeyIdModeMask = 3 << 3;
 
-        kKeySourceSizeMode0 = 0,
-        kKeySourceSizeMode1 = 0,
-        kKeySourceSizeMode2 = 4,
-        kKeySourceSizeMode3 = 8,
+    static constexpr uint8_t kKeySourceSizeMode0 = 0;
+    static constexpr uint8_t kKeySourceSizeMode1 = 0;
+    static constexpr uint8_t kKeySourceSizeMode2 = 4;
+    static constexpr uint8_t kKeySourceSizeMode3 = 8;
 
-        kKeyIndexSize = sizeof(uint8_t),
+    static constexpr uint8_t kKeyIndexSize = sizeof(uint8_t);
 
-        kMacCmdAssociationRequest         = 1,
-        kMacCmdAssociationResponse        = 2,
-        kMacCmdDisassociationNotification = 3,
-        kMacCmdDataRequest                = 4,
-        kMacCmdPanidConflictNotification  = 5,
-        kMacCmdOrphanNotification         = 6,
-        kMacCmdBeaconRequest              = 7,
-        kMacCmdCoordinatorRealignment     = 8,
-        kMacCmdGtsRequest                 = 9,
+    static constexpr uint8_t kMacCmdAssociationRequest         = 1;
+    static constexpr uint8_t kMacCmdAssociationResponse        = 2;
+    static constexpr uint8_t kMacCmdDisassociationNotification = 3;
+    static constexpr uint8_t kMacCmdDataRequest                = 4;
+    static constexpr uint8_t kMacCmdPanidConflictNotification  = 5;
+    static constexpr uint8_t kMacCmdOrphanNotification         = 6;
+    static constexpr uint8_t kMacCmdBeaconRequest              = 7;
+    static constexpr uint8_t kMacCmdCoordinatorRealignment     = 8;
+    static constexpr uint8_t kMacCmdGtsRequest                 = 9;
 
-        kImmAckLength = kFcfSize + kDsnSize + k154FcsSize,
+    static constexpr uint8_t kImmAckLength = kFcfSize + kDsnSize + k154FcsSize;
 
-        kInfoStringSize = 128, ///< Max chars needed for the info string representation (@sa ToInfoString()).
-    };
+    static constexpr uint16_t kInfoStringSize = 128; ///< Max chars for `InfoString` (ToInfoString()).
 
     /**
      * This type defines the fixed-length `String` object returned from `ToInfoString()` method.
@@ -956,8 +918,8 @@ public:
      *                          appended at `aIndex` on input. And on output, `aIndex` will be set to the end of the
      *                          IE just appended.
      *
-     * @tparam  IeType  The Header IE type, it MUST contain an enum `kHeaderIeId` equal to the IE's Id
-     *                  and an enum `kIeContentSize` indicating the IE body's size.
+     * @tparam  IeType  The Header IE type, it MUST contain a constant `kHeaderIeId` equal to the IE's Id
+     *                  and a constant `kIeContentSize` indicating the IE body's size.
      *
      * @retval kErrorNone      Successfully appended the Header IE.
      * @retval kErrorNotFound  The position for first IE is not found.
@@ -1104,13 +1066,10 @@ public:
     uint16_t GetFrameControlField(void) const;
 
 protected:
-    enum
-    {
-        kInvalidIndex  = 0xff,
-        kInvalidSize   = kInvalidIndex,
-        kMaxPsduSize   = kInvalidSize - 1,
-        kSequenceIndex = kFcfSize,
-    };
+    static constexpr uint8_t kInvalidIndex  = 0xff;
+    static constexpr uint8_t kInvalidSize   = kInvalidIndex;
+    static constexpr uint8_t kMaxPsduSize   = kInvalidSize - 1;
+    static constexpr uint8_t kSequenceIndex = kFcfSize;
 
     uint8_t FindDstPanIdIndex(void) const;
     uint8_t FindDstAddrIndex(void) const;
@@ -1457,10 +1416,7 @@ OT_TOOL_PACKED_BEGIN
 class Beacon
 {
 public:
-    enum
-    {
-        kSuperFrameSpec = 0x0fff, ///< Superframe Specification value.
-    };
+    static constexpr uint16_t kSuperFrameSpec = 0x0fff; ///< Superframe Specification value.
 
     /**
      * This method initializes the Beacon message.
@@ -1515,20 +1471,14 @@ OT_TOOL_PACKED_BEGIN
 class BeaconPayload
 {
 public:
-    enum
-    {
-        kProtocolId     = 3,  ///< Thread Protocol ID.
-        kInfoStringSize = 92, ///< Max chars for the info string (@sa ToInfoString()).
-    };
+    static constexpr uint8_t kProtocolId      = 3;                     ///< Thread Protocol ID.
+    static constexpr uint8_t kProtocolVersion = 2;                     ///< Thread Protocol version.
+    static constexpr uint8_t kVersionOffset   = 4;                     ///< Version field bit offset.
+    static constexpr uint8_t kVersionMask     = 0xf << kVersionOffset; ///< Version field mask.
+    static constexpr uint8_t kNativeFlag      = 1 << 3;                ///< Native Commissioner flag.
+    static constexpr uint8_t kJoiningFlag     = 1 << 0;                ///< Joining Permitted flag.
 
-    enum
-    {
-        kProtocolVersion = 2,                     ///< Thread Protocol version.
-        kVersionOffset   = 4,                     ///< Version field bit offset.
-        kVersionMask     = 0xf << kVersionOffset, ///< Version field mask.
-        kNativeFlag      = 1 << 3,                ///< Native Commissioner flag.
-        kJoiningFlag     = 1 << 0,                ///< Joining Permitted flag.
-    };
+    static constexpr uint16_t kInfoStringSize = 92; ///< Max chars for the info string (@sa ToInfoString()).
 
     /**
      * This type defines the fixed-length `String` object returned from `ToInfoString()` method.
@@ -1676,11 +1626,8 @@ OT_TOOL_PACKED_BEGIN
 class CslIe
 {
 public:
-    enum : uint8_t
-    {
-        kHeaderIeId    = 0x1a,
-        kIeContentSize = sizeof(uint16_t) * 2,
-    };
+    static constexpr uint8_t kHeaderIeId    = 0x1a;
+    static constexpr uint8_t kIeContentSize = sizeof(uint16_t) * 2;
 
     /**
      * This method returns the CSL Period.
@@ -1728,11 +1675,8 @@ private:
 class Termination2Ie
 {
 public:
-    enum : uint8_t
-    {
-        kHeaderIeId    = 0x7f,
-        kIeContentSize = 0,
-    };
+    static constexpr uint8_t kHeaderIeId    = 0x7f;
+    static constexpr uint8_t kIeContentSize = 0;
 };
 
 /**

--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -289,10 +289,7 @@ class Links : public InstanceLocator
     friend class ot::Instance;
 
 public:
-    enum
-    {
-        kInvalidRssiValue = SubMac::kInvalidRssiValue, ///< Invalid Received Signal Strength Indicator (RSSI) value.
-    };
+    static const int8_t kInvalidRssiValue = SubMac::kInvalidRssiValue; ///< Invalid RSSI value.
 
     /**
      * This constructor initializes the `Links` object.
@@ -662,10 +659,7 @@ public:
 #endif
 
 private:
-    enum
-    {
-        kDefaultNoiseFloor = -100,
-    };
+    static constexpr int8_t kDefaultNoiseFloor = -100;
 
     SubMac mSubMac;
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -56,24 +56,22 @@ namespace Mac {
  *
  */
 
-enum
-{
-    kShortAddrBroadcast = 0xffff,
-    kShortAddrInvalid   = 0xfffe,
-    kPanIdBroadcast     = 0xffff,
-};
-
 /**
  * This type represents the IEEE 802.15.4 PAN ID.
  *
  */
 typedef otPanId PanId;
 
+constexpr PanId kPanIdBroadcast = 0xffff; ///< Broadcast PAN ID.
+
 /**
  * This type represents the IEEE 802.15.4 Short Address.
  *
  */
 typedef otShortAddress ShortAddress;
+
+constexpr ShortAddress kShortAddrBroadcast = 0xffff; ///< Broadcast Short Address.
+constexpr ShortAddress kShortAddrInvalid   = 0xfffe; ///< Invalid Short Address.
 
 /**
  * This function generates a random IEEE 802.15.4 PAN ID.
@@ -91,10 +89,7 @@ OT_TOOL_PACKED_BEGIN
 class ExtAddress : public otExtAddress, public Equatable<ExtAddress>, public Clearable<ExtAddress>
 {
 public:
-    enum
-    {
-        kInfoStringSize = 17, // Max chars for the info string (`ToString()`).
-    };
+    static constexpr uint16_t kInfoStringSize = 17; ///< Max chars for the info string (`ToString()`).
 
     /**
      * This type defines the fixed-length `String` object returned from `ToString()`.
@@ -106,10 +101,10 @@ public:
      * This enumeration type specifies the copy byte order when Extended Address is being copied to/from a buffer.
      *
      */
-    enum CopyByteOrder
+    enum CopyByteOrder : uint8_t
     {
-        kNormalByteOrder,  // Copy address bytes in normal order (as provided in array buffer).
-        kReverseByteOrder, // Copy address bytes in reverse byte order.
+        kNormalByteOrder,  ///< Copy address bytes in normal order (as provided in array buffer).
+        kReverseByteOrder, ///< Copy address bytes in reverse byte order.
     };
 
     /**
@@ -226,13 +221,10 @@ public:
     InfoString ToString(void) const;
 
 private:
-    static void CopyAddress(uint8_t *aDst, const uint8_t *aSrc, CopyByteOrder aByteOrder);
+    static constexpr uint8_t kGroupFlag = (1 << 0);
+    static constexpr uint8_t kLocalFlag = (1 << 1);
 
-    enum
-    {
-        kGroupFlag = 1 << 0,
-        kLocalFlag = 1 << 1,
-    };
+    static void CopyAddress(uint8_t *aDst, const uint8_t *aSrc, CopyByteOrder aByteOrder);
 } OT_TOOL_PACKED_END;
 
 /**
@@ -252,7 +244,7 @@ public:
      * This enumeration specifies the IEEE 802.15.4 Address type.
      *
      */
-    enum Type
+    enum Type : uint8_t
     {
         kTypeNone,     ///< No address.
         kTypeShort,    ///< IEEE 802.15.4 Short Address.
@@ -424,10 +416,7 @@ OT_TOOL_PACKED_BEGIN
 class Key : public otMacKey, public Equatable<Key>, public Clearable<Key>
 {
 public:
-    enum
-    {
-        kSize = OT_MAC_KEY_SIZE, // Key size in bytes.
-    };
+    static constexpr uint16_t kSize = OT_MAC_KEY_SIZE; ///< Key size in bytes.
 
     /**
      * This method gets a pointer to the buffer containing the key.
@@ -447,10 +436,7 @@ OT_TOOL_PACKED_BEGIN
 class ExtendedPanId : public otExtendedPanId, public Equatable<ExtendedPanId>, public Clearable<ExtendedPanId>
 {
 public:
-    enum
-    {
-        kInfoStringSize = 17, // Max chars for the info string (`ToString()`).
-    };
+    static constexpr uint16_t kInfoStringSize = 17; ///< Max chars for the info string (`ToString()`).
 
     /**
      * This type defines the fixed-length `String` object returned from `ToString()`.
@@ -532,10 +518,11 @@ private:
 class NetworkName : public otNetworkName
 {
 public:
-    enum
-    {
-        kMaxSize = OT_NETWORK_NAME_MAX_SIZE, // Maximum number of chars in Network Name (excludes null char).
-    };
+    /**
+     * This constant specified the maximum number of chars in Network Name (excludes null char).
+     *
+     */
+    static constexpr uint8_t kMaxSize = OT_NETWORK_NAME_MAX_SIZE;
 
     /**
      * This constructor initializes the IEEE802.15.4 Network Name as an empty string.
@@ -612,7 +599,7 @@ typedef NetworkName DomainName;
  * This enumeration defines the radio link types.
  *
  */
-enum RadioType
+enum RadioType : uint8_t
 {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
     kRadioTypeIeee802154, ///< IEEE 802.15.4 (2.4GHz) link type.
@@ -622,15 +609,12 @@ enum RadioType
 #endif
 };
 
-enum
-{
-    /**
-     * This constant specifies the number of supported radio link types.
-     *
-     */
-    kNumRadioTypes = (((OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE) ? 1 : 0) +
-                      ((OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE) ? 1 : 0)),
-};
+/**
+ * This constant specifies the number of supported radio link types.
+ *
+ */
+constexpr uint8_t kNumRadioTypes = (((OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE) ? 1 : 0) +
+                                    ((OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE) ? 1 : 0));
 
 /**
  * This class represents a set of radio links.
@@ -639,10 +623,7 @@ enum
 class RadioTypes
 {
 public:
-    enum
-    {
-        kInfoStringSize = 32, ///< Max chars for the info string (`ToString()`).
-    };
+    static constexpr uint16_t kInfoStringSize = 32; ///< Max chars for the info string (`ToString()`).
 
     /**
      * This type defines the fixed-length `String` object returned from `ToString()`.

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -406,7 +406,7 @@ void SubMac::StartCsmaBackoff(void)
     }
 
     backoff = Random::NonCrypto::GetUint32InRange(0, static_cast<uint32_t>(1UL << backoffExponent));
-    backoff *= (static_cast<uint32_t>(kUnitBackoffPeriod) * OT_RADIO_SYMBOL_TIME);
+    backoff *= (kUnitBackoffPeriod * OT_RADIO_SYMBOL_TIME);
 
     if (mRxOnWhenBackoff)
     {

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -92,10 +92,7 @@ class SubMac : public InstanceLocator, private NonCopyable
     friend class Radio::Callbacks;
 
 public:
-    enum
-    {
-        kInvalidRssiValue = 127, ///< Invalid Received Signal Strength Indicator (RSSI) value.
-    };
+    static constexpr int8_t kInvalidRssiValue = 127; ///< Invalid Received Signal Strength Indicator (RSSI) value.
 
     /**
      * This class defines the callbacks notifying `SubMac` user of changes and events.
@@ -535,55 +532,51 @@ private:
     void        GetCslWindowEdges(uint32_t &ahead, uint32_t &after);
 #endif
 
-    enum
-    {
-        kMinBE             = 3,   ///< macMinBE (IEEE 802.15.4-2006).
-        kMaxBE             = 5,   ///< macMaxBE (IEEE 802.15.4-2006).
-        kUnitBackoffPeriod = 20,  ///< Number of symbols (IEEE 802.15.4-2006).
-        kMinBackoff        = 1,   ///< Minimum backoff (milliseconds).
-        kAckTimeout        = 16,  ///< Timeout for waiting on an ACK (milliseconds).
-        kCcaSampleInterval = 128, ///< CCA sample interval, 128 usec.
+    static constexpr uint8_t  kMinBE             = 3;   // macMinBE (IEEE 802.15.4-2006).
+    static constexpr uint8_t  kMaxBE             = 5;   // macMaxBE (IEEE 802.15.4-2006).
+    static constexpr uint32_t kUnitBackoffPeriod = 20;  // Number of symbols (IEEE 802.15.4-2006).
+    static constexpr uint32_t kAckTimeout        = 16;  // Timeout for waiting on an ACK (in msec).
+    static constexpr uint32_t kCcaSampleInterval = 128; // CCA sample interval, 128 usec.
 
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
-        kEnergyScanRssiSampleInterval = 128, ///< RSSI sample interval during energy scan, 128 usec
+    static constexpr uint32_t kEnergyScanRssiSampleInterval = 128; // RSSI sample interval for energy scan, 128 usec
 #else
-        kEnergyScanRssiSampleInterval = 1, ///< RSSI sample interval during energy scan, 1 ms
+    static constexpr uint32_t kEnergyScanRssiSampleInterval = 1; // RSSI sample interval during energy scan, 1 msec
 #endif
-    };
 
     enum State : uint8_t
     {
-        kStateDisabled,    ///< Radio is disabled.
-        kStateSleep,       ///< Radio is in sleep.
-        kStateReceive,     ///< Radio in in receive.
-        kStateCsmaBackoff, ///< CSMA backoff before transmission.
-        kStateTransmit,    ///< Radio is transmitting.
-        kStateEnergyScan,  ///< Energy scan.
+        kStateDisabled,    // Radio is disabled.
+        kStateSleep,       // Radio is in sleep.
+        kStateReceive,     // Radio in in receive.
+        kStateCsmaBackoff, // CSMA backoff before transmission.
+        kStateTransmit,    // Radio is transmitting.
+        kStateEnergyScan,  // Energy scan.
 #if !OPENTHREAD_MTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
-        kStateCslTransmit, ///< CSL transmission.
+        kStateCslTransmit, // CSL transmission.
 #endif
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-        kStateCslSample, ///< CSL receive.
+        kStateCslSample, // CSL receive.
 #endif
     };
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    enum : uint32_t{
-        kMinCslWindow = OPENTHREAD_CONFIG_CSL_MIN_RECEIVE_ON, ///< CSL receive window for the longest possible
-                                                              ///< frame and ack duration.
-        kCslReceiveTimeAhead =
-            OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD, ///< CSL receivers would wake up `kCslReceiveTimeAhead` earlier
-                                                      ///< than expected sample window. The time is in unit of
-                                                      ///< microseconds.
-    };
-    /**
-     * CSL state, always updated by `mCslTimer`.
-     *
-     */
+    // CSL receive window for the longest possible frame and
+    // ack duration.
+    static constexpr uint32_t kMinCslWindow = OPENTHREAD_CONFIG_CSL_MIN_RECEIVE_ON;
+
+    // CSL receivers would wake up `kCslReceiveTimeAhead` earlier
+    // than expected sample window. The value is in usec.
+    static constexpr uint32_t kCslReceiveTimeAhead = OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD;
+
+    static constexpr uint8_t kCslWorstCrystalPpm  = 255; // Worst possible crystal accuracy, in units of ± ppm.
+    static constexpr uint8_t kCslWorstUncertainty = 255; // Worst possible scheduling uncertainty, in units of 100 us.
+    static constexpr uint8_t kUsPerUncertUnit     = 100; // Number of microseconds by uncertainty unit.
+
     enum CslState : uint8_t{
-        kCslIdle = 0, ///< CSL receiver is not started.
-        kCslSample,   ///< Sampling CSL channel.
-        kCslSleep,    ///< Radio in sleep.
+        kCslIdle,   // CSL receiver is not started.
+        kCslSample, // Sampling CSL channel.
+        kCslSleep,  // Radio in sleep.
     };
 #endif
 
@@ -648,25 +641,20 @@ private:
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
     TimerMicro mTimer;
 #else
-    TimerMilli mTimer;
+    TimerMilli                mTimer;
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    uint16_t mCslPeriod;      ///< The CSL sample period, in units of 10 symbols (160 microseconds).
-    uint8_t  mCslChannel : 7; ///< The actually CSL sample channel. If `mIsCslChannelSpecified` is 0, this should be
-                              ///< equal to the Pan channel of `Mac`.
-    uint8_t mIsCslChannelSpecified : 1; ///< Indicates whether or not the CSL channel was explicitly specified by
-                                        ///< the user.
-
-    TimeMicro mCslSampleTime;     ///< The CSL sample time of the current period.
-    TimeMicro mCslLastSync;       ///< The timestamp of the last successful CSL syncronization.
-    uint8_t   mCslParentAccuracy; ///< Drift of timer used for scheduling CSL transmission by the parent, in ± ppm.
-    uint8_t   mCslParentUncert; ///< Uncertainty of the scheduling CSL of transmission by the parent, in ±10 us units.
-
-    CslState mCslState;
-
+    uint16_t   mCslPeriod;                 // The CSL sample period, in units of 10 symbols (160 microseconds).
+    uint8_t    mCslChannel : 7;            // The CSL sample channel (only when `mIsCslChannelSpecified` is `true`).
+    uint8_t    mIsCslChannelSpecified : 1; // Whether the CSL channel was explicitly set
+    TimeMicro  mCslSampleTime;             // The CSL sample time of the current period.
+    TimeMicro  mCslLastSync;               // The timestamp of the last successful CSL synchronization.
+    uint8_t    mCslParentAccuracy;         // Drift of timer used for scheduling CSL tx by the parent, in ± ppm.
+    uint8_t    mCslParentUncert;           // Uncertainty of the scheduling CSL of tx by the parent, in ±10 us units.
+    CslState   mCslState;
     TimerMicro mCslTimer;
-#endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+#endif
 };
 
 /**

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -47,9 +47,13 @@ namespace ot {
 enum
 {
     kUsPerTenSymbols = OT_US_PER_TEN_SYMBOLS, ///< The microseconds per 10 symbols.
+
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    kMinCslPeriod = OPENTHREAD_CONFIG_MAC_CSL_MIN_PERIOD * 1000 /
-                    kUsPerTenSymbols, ///< Minimum CSL period supported in units of 10 symbols.
+    /**
+     * Minimum CSL period supported in units of 10 symbols.
+     *
+     */
+    kMinCslPeriod  = OPENTHREAD_CONFIG_MAC_CSL_MIN_PERIOD * 1000 / kUsPerTenSymbols,
     kMaxCslTimeout = OPENTHREAD_CONFIG_MAC_CSL_MAX_TIMEOUT
 #endif
 };


### PR DESCRIPTION
This commit replaces the `enum` constants with `constexpr` definitions
in all the modules under `core/mac`. The `constexpr` constants have
the advantage that thet are explicitly typed while still being
compile-time constants with no code size overhead.

This commit also contains some smaller changes: typo fixes in the
comments, removal of unused constants, and adding type to the named
`enum` definitions.

---

We originally used `enum` for constants due to OT complying to 
`C++03`  which we transitioned to `C++11` from PR https://github.com/openthread/openthread/pull/5077.