### PR TITLE
[cli] new config to log input command and the resulting output

### DIFF
--- a/examples/apps/cli/cli_uart.cpp
+++ b/examples/apps/cli/cli_uart.cpp
@@ -199,34 +199,6 @@ static otError ProcessCommand(void)
         sRxBuffer[--sRxLength] = '\0';
     }
 
-#if OPENTHREAD_CONFIG_LOG_OUTPUT != OPENTHREAD_CONFIG_LOG_OUTPUT_NONE
-    /*
-     * Note this is here for this reason:
-     *
-     * TEXT (command) input ... in a test automation script occurs
-     * rapidly and often without gaps between the command and the
-     * terminal CR
-     *
-     * In contrast as a human is typing there is a delay between the
-     * last character of a command and the terminal CR which executes
-     * a command.
-     *
-     * During that human induced delay a tasklet may be scheduled and
-     * the LOG becomes confusing and it is hard to determine when
-     * something happened.  Which happened first? the command-CR or
-     * the tasklet.
-     *
-     * Yes, while rare it is a race condition that is hard to debug.
-     *
-     * Thus this is here to affirmatively LOG exactly when the CLI
-     * command is being executed.
-     */
-#if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
-    /* TODO: how exactly do we get the instance here? */
-#else
-    otLogInfoCli("execute command: %s", sRxBuffer);
-#endif
-#endif
     if (sRxLength > 0)
     {
         otCliInputLine(sRxBuffer);

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -87,6 +87,9 @@ namespace ot {
  */
 namespace Cli {
 
+extern "C" void otCliPlatLogv(otLogLevel, otLogRegion, const char *, va_list);
+extern "C" void otCliPlatLogLine(otLogLevel, otLogRegion, const char *);
+
 /**
  * This class implements the CLI interpreter.
  *
@@ -103,6 +106,8 @@ class Interpreter
     friend class SrpServer;
     friend class TcpExample;
     friend class UdpExample;
+    friend void otCliPlatLogv(otLogLevel, otLogRegion, const char *, va_list);
+    friend void otCliPlatLogLine(otLogLevel, otLogRegion, const char *);
 
 public:
     typedef Utils::CmdLineParser::Arg Arg;
@@ -721,6 +726,11 @@ private:
     }
     void HandleDiscoveryRequest(const otThreadDiscoveryRequestInfo &aInfo);
 
+#if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
+    bool IsLogging(void) const { return mIsLogging; }
+    void SetIsLogging(bool aIsLogging) { mIsLogging = aIsLogging; }
+#endif
+
     static constexpr Command sCommands[] = {
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
         {"ba", &Interpreter::ProcessBorderAgent},
@@ -936,6 +946,12 @@ private:
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
     SrpServer mSrpServer;
+#endif
+
+#if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
+    char     mOutputString[OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LOG_STRING_SIZE];
+    uint16_t mOutputLength;
+    bool     mIsLogging;
 #endif
 };
 

--- a/src/cli/cli_config.h
+++ b/src/cli/cli_config.h
@@ -59,6 +59,7 @@
 #endif
 
 /**
+<<<<<<< HEAD
  * @def OPENTHREAD_CONFIG_CLI_TCP_ENABLE
  *
  * Indicates whether TCP should be enabled in the CLI tool.
@@ -85,6 +86,32 @@
  */
 #ifndef OPENTHREAD_CONFIG_CLI_TCP_RECEIVE_BUFFER_SIZE
 #define OPENTHREAD_CONFIG_CLI_TCP_RECEIVE_BUFFER_SIZE OT_TCP_RECEIVE_BUFFER_SIZE_FEW_HOPS
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
+ *
+ * Define as 1 for CLI to emit its command input string and the resulting output to the logs.
+ *
+ * By default this is enabled on any POSIX based platform (`OPENTHREAD_POSIX`) and only when CLI itself is not being
+ * used for logging.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
+#define OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE \
+    (OPENTHREAD_POSIX && (OPENTHREAD_CONFIG_LOG_OUTPUT != OPENTHREAD_CONFIG_LOG_OUTPUT_APP))
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LOG_STRING_SIZE
+ *
+ * The log string buffer size (in bytes).
+ *
+ * This is only used when `OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE` is enabled.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LOG_STRING_SIZE
+#define OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LOG_STRING_SIZE OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH
 #endif
 
 #endif // CONFIG_CLI_H_


### PR DESCRIPTION
This commit adds `OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE`
option which configures the CLI module to log its input command
string and the resulting output. This is done in addition to emitting
the output string to the console. By default this config is enabled
on all POSIX based platforms and when `LOG_OUTPUT` is not set to use
CLI console itself.

--------

Notes:
- This should hopefully help with debugging test failures (e.g., on github 
workflows).
- Suggested this model from https://github.com/openthread/openthread/issues/6665#issuecomment-855443633
(related to https://github.com/openthread/openthread/pull/6639 which caused
the the CLI output to be logged in pieces).
- The implementation in this PR emits the CLI output line by line to the log 
(each output line is emitted as a separate log line, so the logs mirror what 
is seen on the console output).
```
> netdata show
Prefixes:
2001:dead:beef:cafe::/64 paros med 2800
Routes:
Services:
44970 112233 aabbcc s 2800
Done

The related logs:

[NOTE]-CLI-----: Input: netdata show
[NOTE]-CLI-----: Output: Prefixes:
[NOTE]-CLI-----: Output: 2001:dead:beef:cafe::/64 paros med 2800
[NOTE]-CLI-----: Output: Routes:
[NOTE]-CLI-----: Output: Services:
[NOTE]-CLI-----: Output: 44970 112233 aabbcc s 2800
[NOTE]-CLI-----: Output: Done
```
- By default this config is not enabled when `LOG_OUTPUT` is using CLI 
itself (since such a log would be redundant). However, the implementation
works correctly under such a config. Here is an example when this is 
enabled:
```
> prefix add 2001:dead:beef:cafe::/64 paros med
[NOTE]-CLI-----: Input: prefix add 2001:dead:beef:cafe::/64 paros med
Done
[NOTE]-CLI-----: Output: Done
```
