### PR TITLE
[config] include the default user configuration header

### DIFF
--- a/src/core/openthread-core-config.h
+++ b/src/core/openthread-core-config.h
@@ -44,6 +44,10 @@
 
 #ifdef OPENTHREAD_PROJECT_CORE_CONFIG_FILE
 #include OPENTHREAD_PROJECT_CORE_CONFIG_FILE
+#elif defined(OPENTHREAD_CONFIG_CORE_USER_CONFIG_HEADER_ENABLE)
+// This configuration header file should be implemented by the user when the
+// OPENTHREAD_CONFIG_CORE_USER_CONFIG_HEADER_ENABLE is defined to 1.
+#include "openthread-core-user-config.h"
 #endif
 
 #ifndef OPENTHREAD_CONFIG_THREAD_VERSION


### PR DESCRIPTION
OpenThread uses the compile option
`-DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=openthread-core-posix-config.h`
to specify the OpenThread configuration file. When the Blaze compiles
the OpenThread, the include scanner in Blaze does not understand the
cases where the header file to be scanned comes from a preprocessor
macro like this. Then the compilation fails.

This CL includes the default user implemented configuration header file
to avoid specifying the configuration file.