### PR TITLE
[border-routing] dump sent/received RA messages on infra if

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -765,9 +765,7 @@ void RoutingManager::SendRouterAdvertisement(const Ip6::Prefix *aNewOmrPrefixes,
         if (error == kErrorNone)
         {
             otLogInfoBr("Sent Router Advertisement on interface %u", mInfraIfIndex);
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-            otDumpCertBr("[BR-CERT] direction=send | type=RA |", buffer, bufferLength);
-#endif
+            otDumpDebgBr("[BR-CERT] direction=send | type=RA |", buffer, bufferLength);
         }
         else
         {
@@ -984,9 +982,7 @@ void RoutingManager::HandleRouterAdvertisement(const Ip6::Address &aSrcAddress,
 
     otLogInfoBr("Received Router Advertisement from %s on interface %u", aSrcAddress.ToString().AsCString(),
                 mInfraIfIndex);
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    otDumpCertBr("[BR-CERT] direction=recv | type=RA |", aBuffer, aBufferLength);
-#endif
+    otDumpDebgBr("[BR-CERT] direction=recv | type=RA |", aBuffer, aBufferLength);
 
     routerAdvMessage = reinterpret_cast<const RouterAdvMessage *>(aBuffer);
     optionsBegin     = aBuffer + sizeof(RouterAdvMessage);

--- a/src/core/common/logging.hpp
+++ b/src/core/common/logging.hpp
@@ -2326,6 +2326,74 @@ void otLogOtns(const char *aFormat, ...);
 #endif
 
 /**
+ * @def otDumpCritBr
+ *
+ * This function generates a memory dump with log level critical and region Border Routing.
+ *
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpWarnBr
+ *
+ * This function generates a memory dump with log level warning and region Border Routing.
+ *
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpNoteBr
+ *
+ * This function generates a memory dump with log level note and region Border Routing.
+ *
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpInfoBr
+ *
+ * This function generates a memory dump with log level info and region Border Routing.
+ *
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+
+/**
+ * @def otDumpDebgBr
+ *
+ * This function generates a memory dump with log level debug and region Border Routing.
+ *
+ * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
+ * @param[in]  aBuf         A pointer to the buffer.
+ * @param[in]  aLength      Number of bytes to print.
+ *
+ */
+#if OPENTHREAD_CONFIG_LOG_BR
+#define otDumpCritBr(aId, aBuf, aLength) otDumpCrit(OT_LOG_REGION_BR, aId, aBuf, aLength)
+#define otDumpWarnBr(aId, aBuf, aLength) otDumpWarn(OT_LOG_REGION_BR, aId, aBuf, aLength)
+#define otDumpNoteBr(aId, aBuf, aLength) otDumpNote(OT_LOG_REGION_BR, aId, aBuf, aLength)
+#define otDumpInfoBr(aId, aBuf, aLength) otDumpInfo(OT_LOG_REGION_BR, aId, aBuf, aLength)
+#define otDumpDebgBr(aId, aBuf, aLength) otDumpDebg(OT_LOG_REGION_BR, aId, aBuf, aLength)
+#else
+#define otDumpCritBr(aId, aBuf, aLength)
+#define otDumpWarnBr(aId, aBuf, aLength)
+#define otDumpNoteBr(aId, aBuf, aLength)
+#define otDumpInfoBr(aId, aBuf, aLength)
+#define otDumpDebgBr(aId, aBuf, aLength)
+#endif
+
+/**
  * @def otDumpCritDns
  *
  * This function generates a memory dump with log level critical and region DNS.
@@ -2475,22 +2543,6 @@ void otLogOtns(const char *aFormat, ...);
 #define otDumpCertMeshCoP(aId, aBuf, aLength) otDump(OT_LOG_LEVEL_NONE, OT_LOG_REGION_MESH_COP, aId, aBuf, aLength)
 #else
 #define otDumpCertMeshCoP(aId, aBuf, aLength)
-#endif
-
-/**
- * @def otDumpCertBr
- *
- * This function generates a memory dump with log level none for the BR certification test.
- *
- * @param[in]  aId          A pointer to a NULL-terminated string that is printed before the bytes.
- * @param[in]  aBuf         A pointer to the buffer.
- * @param[in]  aLength      Number of bytes to print.
- *
- */
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-#define otDumpCertBr(aId, aBuf, aLength) otDump(OT_LOG_LEVEL_NONE, OT_LOG_REGION_BR, aId, aBuf, aLength)
-#else
-#define otDumpCertBr(aId, aBuf, aLength)
 #endif
 
 /**


### PR DESCRIPTION
Dump the RA messages sent/received on infra if for testing scripts.
This commit removes the requirement of `OT_REFERENCE_DEVICE`
but always dump the RA messages at log level `DEBG`.
