### PR TITLE
[tests] fix intermittent failure in Cert_9_2_09_PendingPartition.py

### DIFF
--- a/tests/scripts/thread-cert/Cert_9_2_09_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_09_PendingPartition.py
@@ -165,6 +165,11 @@ class Cert_9_2_09_PendingPartition(thread_cert.TestCase):
         self.assertEqual(self.nodes[ROUTER1].get_state(), 'router')
         self.assertEqual(self.nodes[ROUTER2].get_state(), 'leader')
 
+        # Keeping network id timeout at 70 can result in ROUTER2
+        # occasionally creating its own partition. Reset back to 120
+        # here to avoid occasional test failures.
+        self.nodes[ROUTER2].set_network_id_timeout(120)
+
         self.nodes[ROUTER2].commissioner_start()
         self.simulator.go(3)
         self.nodes[ROUTER2].send_mgmt_active_set(


### PR DESCRIPTION
Keeping network id timeout at 70 can result in ROUTER2 occasionally
creating its own partition. Reset back to 120 to avoid occasional test
failures.

Fixes #5992 