### PR TITLE
[posix] allow kernel to assign netlink socket port ID

### DIFF
--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -163,7 +163,6 @@ int CreateNetLinkSocket(void)
     memset(&addr, 0, sizeof(addr));
     addr.nl_family = AF_NETLINK;
     addr.nl_groups = RTMGRP_LINK | RTMGRP_IPV6_IFADDR;
-    addr.nl_pid    = getpid();
 
     rval = bind(sock, reinterpret_cast<struct sockaddr *>(&addr), sizeof(addr));
     VerifyOrDie(rval == 0, OT_EXIT_ERROR_ERRNO);


### PR DESCRIPTION
This commit fixes a potential bug that the netlink socket may fail to bind due to port ID conflict.

[man 7 netlink](https://man7.org/linux/man-pages/man7/netlink.7.html):
```
If the application sets nl_pid before calling bind(2), then it is up to 
the application to make sure that nl_pid is unique. If the application
sets it to 0, the kernel takes care of assigning it.
```