### PR TITLE
[radio-spinel] fix incorrect RX channel after frame TX on another channel

### DIFF
--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -1514,6 +1514,8 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::EnergyScan(uint8_t aScan
     SuccessOrExit(error = Set(SPINEL_PROP_MAC_SCAN_PERIOD, SPINEL_DATATYPE_UINT16_S, aScanDuration));
     SuccessOrExit(error = Set(SPINEL_PROP_MAC_SCAN_STATE, SPINEL_DATATYPE_UINT8_S, SPINEL_SCAN_STATE_ENERGY));
 
+    mChannel = aScanChannel;
+
 exit:
     return error;
 }
@@ -1923,6 +1925,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::Transmit(otRadioFrame &a
         // Waiting for `TransmitDone` event.
         mState        = kStateTransmitting;
         mTxRadioEndUs = otPlatTimeGet() + TX_WAIT_US;
+        mChannel      = mTransmitFrame->mChannel;
     }
 
 exit:


### PR DESCRIPTION
This commit fixes a bug in `RadioSpinel` platform implementation where
the request from OT core stack to enter RX mode may be ignored
causing the RCP/radio to stay in RX mode on an incorrect channel.

This situation can happen after a frame TX request on a different
channel (note that the `otRadioFrame` struct specifies the channel on
which the frame should be transmitted). After frame TX, radio driver
is expected to enter RX mode on the same channel on which the frame
TX happened. The OpenThread MAC layer always explicitly instructs the
radio to enter RX mode on the PAN channel (from `Mac::UpdateIdleMode()`
which in turn calls the radio platform API `otPlatRadioRecive()` with
the channel passed in as a parameter). The earlier `RadioSpinel`
platform implementation cached the channel in a local member variable
and skipped setting the channel on RCP if the channel was same as
before (setting the `SPINEL_PROP_PHY_CHAN` instructs the RCP to enter
RX mode on the correct channel).

-------

This may help address https://github.com/openthread/ot-br-posix/issues/935.

------

I looked at history of the `RadioSpinel` code. Seems like this behavior/bug 
may have present since the very first implementation:  
- https://github.com/openthread/openthread/pull/2690 

The question is how it was not detected earlier. I think a bunch of  behaviors
helped mask this issue
- A follow-up frame tx (on PAN channel) can cause RCP to get back to 
same channel (router would send "Link Adv" every ~30sec).
-  "channel monitor" feature which periodically issues energy scan can 
force the  RCP to get back to the right channel
- I would like us to figure out a test-case that covers this  situation 
specifically.

---------

Adding one more note on this:
- I recalled that in `SubMac `implementation, the OT core would put the radio in 
RX mode before any TX request (the radio is put in RX on same channel as TX),
i.e. we have a call to `otPlatRadioReceive()` before the `otPlatRadioTransmit()`
- This would basically ensure that existing `RadioSpinel` code to function correctly
(since there would be call to `Receive()` and change the cached `mChannel` before
any tx request).
- However, the behavior in `SubMac` was changed from 
https://github.com/openthread/openthread/pull/4697
- With this change the call to `Receive()` would be skipped if the radio supports 
the newly added capability `OT_RADIO_CAPS_SLEEP_TO_TX` falg.
- I think Nordic radio driver includes this flag and `RadioSpinel` would simply
forward the same set of capability flags it gets from its RCP.
- So looks like this error situation (with `RadioSpinel` driver) is a regression after 
the above PR.