### PR TITLE
[dns-sd] add DNS-SD server network interface binding configuration

### DIFF
--- a/script/test
+++ b/script/test
@@ -273,6 +273,7 @@ do_build_otbr_docker()
         "-DOT_SRP_CLIENT=ON"
         "-DOT_TREL=OFF"
         "-DOTBR_DUA_ROUTING=ON"
+        "-DCMAKE_CXX_FLAGS='-DOPENTHREAD_CONFIG_DNSSD_SERVER_BIND_UNSPECIFIED_NETIF=1'"
     )
     local otbr_docker_image=${OTBR_DOCKER_IMAGE:-otbr-ot12-backbone-ci}
 

--- a/src/core/config/dnssd_server.h
+++ b/src/core/config/dnssd_server.h
@@ -56,6 +56,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_DNSSD_SERVER_BIND_UNSPECIFIED_NETIF
+ *
+ * Define to 1 to bind DNS-SD server to unspecified interface, 0 to bind to Thread interface.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_DNSSD_SERVER_BIND_UNSPECIFIED_NETIF
+#define OPENTHREAD_CONFIG_DNSSD_SERVER_BIND_UNSPECIFIED_NETIF 0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_DNSSD_QUERY_TIMEOUT
  *
  * Specifies the default wait time that DNS-SD Server waits for a query response (e.g. from Discovery Proxy).

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -69,7 +69,7 @@ Error Server::Start(void)
     VerifyOrExit(!IsRunning());
 
     SuccessOrExit(error = mSocket.Open(&Server::HandleUdpReceive, this));
-    SuccessOrExit(error = mSocket.Bind(kPort, OT_NETIF_UNSPECIFIED));
+    SuccessOrExit(error = mSocket.Bind(kPort, kBindUnspecifiedNetif ? OT_NETIF_UNSPECIFIED : OT_NETIF_THREAD));
 
 exit:
     otLogInfoDns("[server] started: %s", ErrorToString(error));

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -71,6 +71,8 @@ public:
         kDnsQueryResolveHost = OT_DNSSD_QUERY_TYPE_RESOLVE_HOST, ///< Service type resolve hostname.
     };
 
+    static constexpr uint16_t kPort = OPENTHREAD_CONFIG_DNSSD_SERVER_PORT; ///< The DNS-SD server port.
+
     /**
      * This constructor initializes the object.
      *
@@ -224,7 +226,7 @@ private:
         uint16_t    mHostNameOffset;     // Offset of host name serialization into the response message.
     };
 
-    static constexpr uint16_t kPort                 = OPENTHREAD_CONFIG_DNSSD_SERVER_PORT;
+    static constexpr bool     kBindUnspecifiedNetif = OPENTHREAD_CONFIG_DNSSD_SERVER_BIND_UNSPECIFIED_NETIF;
     static constexpr uint8_t  kProtocolLabelLength  = 4;
     static constexpr uint8_t  kSubTypeLabelLength   = 4;
     static constexpr uint16_t kMaxConcurrentQueries = 32;

--- a/src/core/net/udp6.cpp
+++ b/src/core/net/udp6.cpp
@@ -558,6 +558,9 @@ bool Udp::IsPortInUse(uint16_t aPort) const
 bool Udp::ShouldUsePlatformUdp(uint16_t aPort) const
 {
     return (aPort != Mle::kUdpPort && aPort != Tmf::kUdpPort
+#if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE && !OPENTHREAD_CONFIG_DNSSD_SERVER_BIND_UNSPECIFIED_NETIF
+            && aPort != Dns::ServiceDiscovery::Server::kPort
+#endif
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
             && aPort != Get<MeshCoP::BorderAgent>().GetUdpProxyPort()
 #endif


### PR DESCRIPTION
This commit allows DNS-SD server to configure the network interface to bind the UDP socket.