### PR TITLE
[posix] fix platform UDP init compile error

### DIFF
--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -140,7 +140,7 @@ otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
     platformNetifInit(instance, aPlatformConfig->mInterfaceName);
 #elif OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
-    ot::Posix::Udp::Init(instance, aPlatformConfig->mInterfaceName);
+    ot::Posix::Udp::Get().Init(instance, aPlatformConfig->mInterfaceName);
 #else
     gNetifName[0] = '\0';
 #endif


### PR DESCRIPTION
This commit fixes the platform UDP compile error when platform Netif is not enabled. 