### PR TITLE
[core] replace `enum` constants with `constexpr`

### DIFF
--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -103,8 +103,7 @@ otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriP
 
 uint16_t otCoapBlockSizeFromExponent(otCoapBlockSzx aSize)
 {
-    return static_cast<uint16_t>(
-        1 << (static_cast<uint8_t>(aSize) + static_cast<uint8_t>(Coap::Message::kBlockSzxBase)));
+    return static_cast<uint16_t>(1 << (static_cast<uint8_t>(aSize) + Coap::Message::kBlockSzxBase));
 }
 
 otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSzx aSize)

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -120,14 +120,11 @@ public:
     static const TxParameters &GetDefault(void) { return static_cast<const TxParameters &>(kDefaultTxParameters); }
 
 private:
-    enum
-    {
-        kDefaultAckTimeout                 = 2000, // in millisecond
-        kDefaultAckRandomFactorNumerator   = 3,
-        kDefaultAckRandomFactorDenominator = 2,
-        kDefaultMaxRetransmit              = 4,
-        kDefaultMaxLatency                 = 100000, // in millisecond
-    };
+    static constexpr uint32_t kDefaultAckTimeout                 = 2000; // in msec
+    static constexpr uint8_t  kDefaultAckRandomFactorNumerator   = 3;
+    static constexpr uint8_t  kDefaultAckRandomFactorDenominator = 2;
+    static constexpr uint8_t  kDefaultMaxRetransmit              = 4;
+    static constexpr uint32_t kDefaultMaxLatency                 = 100000; // in msec
 
     uint32_t CalculateInitialRetransmissionTimeout(void) const;
     uint32_t CalculateExchangeLifetime(void) const;
@@ -330,10 +327,7 @@ public:
     const MessageQueue &GetResponses(void) const { return mQueue; }
 
 private:
-    enum
-    {
-        kMaxCachedResponses = OPENTHREAD_CONFIG_COAP_SERVER_MAX_CACHED_RESPONSES,
-    };
+    static constexpr uint16_t kMaxCachedResponses = OPENTHREAD_CONFIG_COAP_SERVER_MAX_CACHED_RESPONSES;
 
     struct ResponseMetadata
     {
@@ -365,9 +359,7 @@ class CoapBase : public InstanceLocator, private NonCopyable
 
 public:
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
-    enum {
-        kMaxBlockLength = OPENTHREAD_CONFIG_COAP_MAX_BLOCK_LENGTH,
-    };
+    static constexpr uint16_t kMaxBlockLength = OPENTHREAD_CONFIG_COAP_MAX_BLOCK_LENGTH;
 #endif
 
     /**

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -134,7 +134,7 @@ enum Code : uint8_t
  * CoAP Option Numbers.
  *
  */
-enum : uint16_t
+enum OptionNumber : uint16_t
 {
     kOptionIfMatch       = OT_COAP_OPTION_IF_MATCH,       ///< If-Match
     kOptionUriHost       = OT_COAP_OPTION_URI_HOST,       ///< Uri-Host
@@ -166,12 +166,9 @@ class Message : public ot::Message
     friend class Option;
 
 public:
-    enum : uint8_t
-    {
-        kDefaultTokenLength = OT_COAP_DEFAULT_TOKEN_LENGTH, ///< Default token length
-        kMaxReceivedUriPath = 32,                           ///< Maximum supported URI path on received messages.
-        kMaxTokenLength     = OT_COAP_MAX_TOKEN_LENGTH,     ///< Maximum token length.
-    };
+    static constexpr uint8_t kDefaultTokenLength = OT_COAP_DEFAULT_TOKEN_LENGTH; ///< Default token length.
+    static constexpr uint8_t kMaxReceivedUriPath = 32;                           ///< Max URI path length on rx msgs.
+    static constexpr uint8_t kMaxTokenLength     = OT_COAP_MAX_TOKEN_LENGTH;     ///< Maximum token length.
 
     typedef ot::Coap::Type Type; ///< CoAP Type.
     typedef ot::Coap::Code Code; ///< CoAP Code.
@@ -180,16 +177,13 @@ public:
      * CoAP Block1/Block2 Types
      *
      */
-    enum BlockType
+    enum BlockType : uint8_t
     {
         kBlockType1 = 1,
         kBlockType2 = 2,
     };
 
-    enum
-    {
-        kBlockSzxBase = 4,
-    };
+    static constexpr uint8_t kBlockSzxBase = 4;
 
     /**
      * This method initializes the CoAP header.
@@ -860,79 +854,67 @@ public:
     const Message *GetNextCoapMessage(void) const { return static_cast<const Message *>(GetNext()); }
 
 private:
-    enum : uint8_t
-    {
-        /*
-         * Header field first byte (RFC 7252).
-         *
-         *    7 6 5 4 3 2 1 0
-         *   +-+-+-+-+-+-+-+-+
-         *   |Ver| T |  TKL  |  (Version, Type and Token Length).
-         *   +-+-+-+-+-+-+-+-+
-         */
-        kVersionOffset     = 6,
-        kVersionMask       = 0x3 << kVersionOffset,
-        kVersion1          = 1,
-        kTypeOffset        = 4,
-        kTypeMask          = 0x3 << kTypeOffset,
-        kTokenLengthOffset = 0,
-        kTokenLengthMask   = 0xf << kTokenLengthOffset,
+    /*
+     * Header field first byte (RFC 7252).
+     *
+     *    7 6 5 4 3 2 1 0
+     *   +-+-+-+-+-+-+-+-+
+     *   |Ver| T |  TKL  |  (Version, Type and Token Length).
+     *   +-+-+-+-+-+-+-+-+
+     */
+    static constexpr uint8_t kVersionOffset     = 6;
+    static constexpr uint8_t kVersionMask       = 0x3 << kVersionOffset;
+    static constexpr uint8_t kVersion1          = 1;
+    static constexpr uint8_t kTypeOffset        = 4;
+    static constexpr uint8_t kTypeMask          = 0x3 << kTypeOffset;
+    static constexpr uint8_t kTokenLengthOffset = 0;
+    static constexpr uint8_t kTokenLengthMask   = 0xf << kTokenLengthOffset;
 
-        /*
-         *
-         * Option Format (RFC 7252).
-         *
-         *      7   6   5   4   3   2   1   0
-         *    +---------------+---------------+
-         *    |  Option Delta | Option Length |   1 byte
-         *    +---------------+---------------+
-         *    /         Option Delta          /   0-2 bytes
-         *    \          (extended)           \
-         *    +-------------------------------+
-         *    /         Option Length         /   0-2 bytes
-         *    \          (extended)           \
-         *    +-------------------------------+
-         *    /         Option Value          /   0 or more bytes
-         *    +-------------------------------+
-         *
-         */
+    /*
+     *
+     * Option Format (RFC 7252).
+     *
+     *      7   6   5   4   3   2   1   0
+     *    +---------------+---------------+
+     *    |  Option Delta | Option Length |   1 byte
+     *    +---------------+---------------+
+     *    /         Option Delta          /   0-2 bytes
+     *    \          (extended)           \
+     *    +-------------------------------+
+     *    /         Option Length         /   0-2 bytes
+     *    \          (extended)           \
+     *    +-------------------------------+
+     *    /         Option Value          /   0 or more bytes
+     *    +-------------------------------+
+     *
+     */
 
-        kOptionDeltaOffset  = 4,
-        kOptionDeltaMask    = 0xf << kOptionDeltaOffset,
-        kOptionLengthOffset = 0,
-        kOptionLengthMask   = 0xf << kOptionLengthOffset,
+    static constexpr uint8_t kOptionDeltaOffset  = 4;
+    static constexpr uint8_t kOptionDeltaMask    = 0xf << kOptionDeltaOffset;
+    static constexpr uint8_t kOptionLengthOffset = 0;
+    static constexpr uint8_t kOptionLengthMask   = 0xf << kOptionLengthOffset;
 
-        kMaxOptionHeaderSize = 5,
+    static constexpr uint8_t kMaxOptionHeaderSize = 5;
 
-        kOption1ByteExtension = 13, // Indicates a one-byte extension.
-        kOption2ByteExtension = 14, // Indicates a two-byte extension.
+    static constexpr uint8_t kOption1ByteExtension = 13; // Indicates a one-byte extension.
+    static constexpr uint8_t kOption2ByteExtension = 14; // Indicates a two-byte extension.
 
-        kPayloadMarker = 0xff,
+    static constexpr uint8_t kPayloadMarker = 0xff;
 
-        kHelpDataAlignment = sizeof(uint16_t), ///< Alignment of help data.
-    };
+    static constexpr uint8_t kHelpDataAlignment = sizeof(uint16_t); // Alignment of help data.
 
-    enum : uint16_t
-    {
-        kMinHeaderLength = 4,
-        kMaxHeaderLength = 512,
+    static constexpr uint16_t kMinHeaderLength = 4;
+    static constexpr uint16_t kMaxHeaderLength = 512;
 
-        kOption1ByteExtensionOffset = 13,  ///< Delta/Length offset as specified (RFC 7252).
-        kOption2ByteExtensionOffset = 269, ///< Delta/Length offset as specified (RFC 7252).
-    };
+    static constexpr uint16_t kOption1ByteExtensionOffset = 13;  // Delta/Length offset as specified (RFC 7252).
+    static constexpr uint16_t kOption2ByteExtensionOffset = 269; // Delta/Length offset as specified (RFC 7252).
 
-    enum
-    {
-        kBlockSzxOffset = 0,
-        kBlockMOffset   = 3,
-        kBlockNumOffset = 4,
-    };
+    static constexpr uint8_t kBlockSzxOffset = 0;
+    static constexpr uint8_t kBlockMOffset   = 3;
+    static constexpr uint8_t kBlockNumOffset = 4;
 
-    enum : uint32_t
-    {
-        kObserveMask = 0xffffff,
-        kBlockNumMax = 0xffff,
-    };
+    static constexpr uint32_t kObserveMask = 0xffffff;
+    static constexpr uint32_t kBlockNumMax = 0xffff;
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
     struct BlockWiseData
@@ -1190,11 +1172,11 @@ public:
         uint16_t GetPayloadMessageOffset(void) const { return mNextOptionOffset; }
 
     private:
-        enum : uint16_t
-        {
-            kIteratorDoneLength         = 0xffff, // `mOption.mLength` value to indicate iterator is done.
-            kNextOptionOffsetParseError = 0,      // Special `mNextOptionOffset` value to indicate a parse error.
-        };
+        // `mOption.mLength` value to indicate iterator is done.
+        static constexpr uint16_t kIteratorDoneLength = 0xffff;
+
+        // Special `mNextOptionOffset` value to indicate a parse error.
+        static constexpr uint16_t kNextOptionOffsetParseError = 0;
 
         void MarkAsDone(void) { mOption.mLength = kIteratorDoneLength; }
         void MarkAsParseErrored(void) { MarkAsDone(), mNextOptionOffset = kNextOptionOffsetParseError; }

--- a/src/core/common/crc16.hpp
+++ b/src/core/common/crc16.hpp
@@ -47,7 +47,7 @@ namespace ot {
 class Crc16
 {
 public:
-    enum Polynomial
+    enum Polynomial : uint16_t
     {
         kCcitt = 0x1021, ///< CRC16_CCITT
         kAnsi  = 0x8005, ///< CRC16-ANSI

--- a/src/core/common/logging.cpp
+++ b/src/core/common/logging.cpp
@@ -226,11 +226,8 @@ exit:
 }
 #endif
 
-enum : uint8_t
-{
-    kStringLineLength = 80,
-    kDumpBytesPerLine = 16,
-};
+static constexpr uint8_t kStringLineLength = 80;
+static constexpr uint8_t kDumpBytesPerLine = 16;
 
 static void DumpLine(otLogLevel aLogLevel, otLogRegion aLogRegion, const uint8_t *aBytes, const size_t aLength)
 {
@@ -279,10 +276,7 @@ static void DumpLine(otLogLevel aLogLevel, otLogRegion aLogRegion, const uint8_t
 
 void otDump(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aId, const void *aBuf, const size_t aLength)
 {
-    enum : uint8_t
-    {
-        kWidth = 72,
-    };
+    constexpr uint8_t kWidth = 72;
 
     size_t                        idLen = strlen(aId);
     ot::String<kStringLineLength> string;

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -134,11 +134,8 @@ class HmacSha256;
         }                                                        \
     } while (false)
 
-enum
-{
-    kNumBuffers = OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS,
-    kBufferSize = OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE,
-};
+constexpr uint16_t kNumBuffers = OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS;
+constexpr uint16_t kBufferSize = OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE;
 
 class Message;
 class MessagePool;
@@ -285,11 +282,8 @@ private:
      */
     const uint8_t *GetData(void) const { return mBuffer.mData; }
 
-    enum
-    {
-        kBufferDataSize     = kBufferSize - sizeof(otMessageBuffer),
-        kHeadBufferDataSize = kBufferDataSize - sizeof(MessageMetadata),
-    };
+    static constexpr uint16_t kBufferDataSize     = kBufferSize - sizeof(otMessageBuffer);
+    static constexpr uint16_t kHeadBufferDataSize = kBufferDataSize - sizeof(MessageMetadata);
 
 protected:
     union
@@ -321,7 +315,7 @@ public:
      * This enumeration represents the message type.
      *
      */
-    enum Type
+    enum Type : uint8_t
     {
         kTypeIp6          = 0, ///< A full uncompressed IPv6 packet
         kType6lowpan      = 1, ///< A 6lowpan frame
@@ -334,7 +328,7 @@ public:
      * This enumeration represents the message sub-type.
      *
      */
-    enum SubType
+    enum SubType : uint8_t
     {
         kSubTypeNone                   = 0,  ///< None
         kSubTypeMleAnnounce            = 1,  ///< MLE Announce
@@ -349,7 +343,7 @@ public:
         kSubTypeMleChildIdRequest      = 10, ///< MLE Child ID Request
     };
 
-    enum Priority
+    enum Priority : uint8_t
     {
         kPriorityLow    = OT_MESSAGE_PRIORITY_LOW,      ///< Low priority level.
         kPriorityNormal = OT_MESSAGE_PRIORITY_NORMAL,   ///< Normal priority level.
@@ -357,16 +351,13 @@ public:
         kPriorityNet    = OT_MESSAGE_PRIORITY_HIGH + 1, ///< Network Control priority level.
     };
 
-    enum
-    {
-        kNumPriorities = 4, ///< Number of priority levels.
-    };
+    static constexpr uint8_t kNumPriorities = 4; ///< Number of priority levels.
 
     /**
      * This enumeration represents the link security mode (used by `Settings` constructor).
      *
      */
-    enum LinkSecurityMode
+    enum LinkSecurityMode : uint8_t
     {
         kNoLinkSecurity,   ///< Link security disabled (no link security).
         kWithLinkSecurity, ///< Link security enabled.
@@ -1400,7 +1391,7 @@ public:
      * should be added in the queue.
      *
      */
-    enum QueuePosition
+    enum QueuePosition : uint8_t
     {
         kQueuePositionHead, ///< Indicates the head (front) of the list.
         kQueuePositionTail, ///< Indicates the tail (end) of the list.

--- a/src/core/common/notifier.hpp
+++ b/src/core/common/notifier.hpp
@@ -297,13 +297,15 @@ public:
     }
 
 private:
-    enum
-    {
-        kMaxExternalHandlers   = OPENTHREAD_CONFIG_MAX_STATECHANGE_HANDLERS,
-        kFlagsStringLineLimit  = 70, // Character limit to divide the log into multiple lines in `LogChangedFlags()`.
-        kMaxFlagNameLength     = 25, // Max length for string representation of a flag by `FlagToString()`.
-        kFlagsStringBufferSize = kFlagsStringLineLimit + kMaxFlagNameLength,
-    };
+    static constexpr uint16_t kMaxExternalHandlers = OPENTHREAD_CONFIG_MAX_STATECHANGE_HANDLERS;
+
+    // Character limit to divide the log into multiple lines in `LogChangedFlags()`.
+    static constexpr uint16_t kFlagsStringLineLimit = 70;
+
+    // Max length for string representation of a flag by `FlagToString()`.
+    static constexpr uint8_t kMaxFlagNameLength = 25;
+
+    static constexpr uint16_t kFlagsStringBufferSize = kFlagsStringLineLimit + kMaxFlagNameLength;
 
     struct ExternalCallback
     {

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -1062,7 +1062,7 @@ public:
         }
 
     private:
-        enum IteratorType
+        enum IteratorType : uint8_t
         {
             kEndIterator,
         };

--- a/src/core/common/time.hpp
+++ b/src/core/common/time.hpp
@@ -249,10 +249,7 @@ public:
     static uint32_t MsecToSec(uint32_t aMilliseconds) { return aMilliseconds / 1000u; }
 
 private:
-    enum
-    {
-        kDistantFuture = (1UL << 31),
-    };
+    static constexpr uint32_t kDistantFuture = (1UL << 31);
 
     uint32_t mValue;
 };

--- a/src/core/common/time_ticker.hpp
+++ b/src/core/common/time_ticker.hpp
@@ -109,11 +109,8 @@ public:
     bool IsReceiverRegistered(Receiver aReceiver) const { return (mReceivers & Mask(aReceiver)) != 0; }
 
 private:
-    enum : uint32_t
-    {
-        kTickInterval  = 1000, // in msec.
-        kRestartJitter = 4,    // in msec, jitter added when restarting the timer [-4,+4] ms.
-    };
+    static constexpr uint32_t kTickInterval  = 1000; // in msec.
+    static constexpr uint32_t kRestartJitter = 4;    // in msec, jitter added when restarting the timer [-4,+4] ms.
 
     constexpr static uint32_t Mask(Receiver aReceiver) { return static_cast<uint32_t>(1U) << aReceiver; }
 

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -58,13 +58,10 @@ class Tlv
 {
 public:
     /**
-     * Length values.
+     * The maximum length of the Base TLV format.
      *
      */
-    enum
-    {
-        kBaseTlvMaxLength = OT_NETWORK_BASE_TLV_MAX_LENGTH, ///< The maximum length of the Base TLV format.
-    };
+    static constexpr uint8_t kBaseTlvMaxLength = OT_NETWORK_BASE_TLV_MAX_LENGTH;
 
     /**
      * This method returns the Type value.
@@ -431,10 +428,7 @@ public:
     }
 
 protected:
-    enum
-    {
-        kExtendedLength = 255, ///< Extended Length value
-    };
+    static const uint8_t kExtendedLength = 255; // Extended Length value.
 
 private:
     static Error Find(const Message &aMessage, uint8_t aType, uint16_t *aOffset, uint16_t *aSize, bool *aIsExtendedTlv);
@@ -483,10 +477,7 @@ private:
 template <uint8_t kTlvTypeValue> class TlvInfo
 {
 public:
-    enum : uint8_t
-    {
-        kType = kTlvTypeValue, ///< The TLV Type value.
-    };
+    static constexpr uint8_t kType = kTlvTypeValue; ///< The TLV Type value.
 };
 
 /**

--- a/src/core/common/trickle_timer.hpp
+++ b/src/core/common/trickle_timer.hpp
@@ -68,15 +68,12 @@ public:
         kModePlainTimer, ///< Operate as a plain periodic timer with random interval selected within min/max intervals.
     };
 
-    enum : uint16_t
-    {
-        /**
-         * Special value for redundancy constant (aka `k`) to indicate infinity (when used, it disables trickle timer's
-         * suppression behavior, invoking the handler callback independent of number of "consistent" events).
-         *
-         */
-        kInfiniteRedundancyConstant = NumericLimits<uint16_t>::kMax,
-    };
+    /**
+     * Special value for redundancy constant (aka `k`) to indicate infinity (when used, it disables trickle timer's
+     * suppression behavior, invoking the handler callback independent of number of "consistent" events).
+     *
+     */
+    static constexpr uint16_t kInfiniteRedundancyConstant = NumericLimits<uint16_t>::kMax;
 
     /**
      * This function pointer is called when the timer expires (i.e., transmission should happen).

--- a/src/core/crypto/aes_ccm.hpp
+++ b/src/core/crypto/aes_ccm.hpp
@@ -59,18 +59,15 @@ namespace Crypto {
 class AesCcm
 {
 public:
-    enum
-    {
-        kMinTagLength = 4,                  ///< Minimum tag length (in bytes).
-        kMaxTagLength = AesEcb::kBlockSize, ///< Maximum tag length (in bytes).
-        kNonceSize    = 13,                 ///< Size of IEEE 802.15.4 Nonce (in bytes).
-    };
+    static constexpr uint8_t kMinTagLength = 4;                  ///< Minimum tag length (in bytes).
+    static constexpr uint8_t kMaxTagLength = AesEcb::kBlockSize; ///< Maximum tag length (in bytes).
+    static constexpr uint8_t kNonceSize    = 13;                 ///< Size of IEEE 802.15.4 Nonce (in bytes).
 
     /**
      * This enumeration type represent the encryption vs decryption mode.
      *
      */
-    enum Mode
+    enum Mode : uint8_t
     {
         kEncrypt, // Encryption mode.
         kDecrypt, // Decryption mode.

--- a/src/core/crypto/aes_ecb.hpp
+++ b/src/core/crypto/aes_ecb.hpp
@@ -55,10 +55,7 @@ namespace Crypto {
 class AesEcb
 {
 public:
-    enum
-    {
-        kBlockSize = 16, ///< AES-128 block size (bytes).
-    };
+    static constexpr uint8_t kBlockSize = 16; ///< AES-128 block size (bytes).
 
     /**
      * Constructor to initialize the mbedtls_aes_context.

--- a/src/core/crypto/ecdsa.hpp
+++ b/src/core/crypto/ecdsa.hpp
@@ -64,15 +64,13 @@ namespace Ecdsa {
 class P256
 {
 public:
-    enum : uint16_t
-    {
-        kFieldBitLength = 256, ///< Prime field bit length used by the P-256 curve.
-    };
+    static constexpr uint16_t kFieldBitLength = 256; ///< Prime field bit length used by the P-256 curve.
 
-    enum : uint8_t
-    {
-        kMpiSize = kFieldBitLength / 8, ///< Max bytes in binary representation of an MPI (multi-precision int).
-    };
+    /**
+     * Max bytes in binary representation of an MPI (multi-precision int).
+     *
+     */
+    static constexpr uint8_t kMpiSize = kFieldBitLength / 8;
 
     class PublicKey;
     class KeyPair;
@@ -91,10 +89,7 @@ public:
         friend class PublicKey;
 
     public:
-        enum : uint8_t
-        {
-            kSize = 2 * kMpiSize, ///< Size of the signature in bytes (two times the curve MPI size).
-        };
+        static constexpr uint8_t kSize = 2 * kMpiSize; ///< Signature size in bytes (two times the curve MPI size).
 
         /**
          * This method returns the signature as a byte array.
@@ -128,10 +123,11 @@ public:
     class KeyPair
     {
     public:
-        enum : uint8_t
-        {
-            kMaxDerSize = 125, ///< Max buffer size (in bytes) for representing the key-pair in DER format.
-        };
+        /**
+         * Max buffer size (in bytes) for representing the key-pair in DER format.
+         *
+         */
+        static constexpr uint8_t kMaxDerSize = 125;
 
         /**
          * This constructor initializes a `KeyPair` as empty (no key).
@@ -237,10 +233,7 @@ public:
         friend class KeyPair;
 
     public:
-        enum
-        {
-            kSize = kMpiSize * 2, ///< Size of the public key in bytes.
-        };
+        static constexpr uint8_t kSize = kMpiSize * 2; ///< Size of the public key in bytes.
 
         /**
          * This method gets the pointer to the buffer containing the public key (as an uncompressed curve point).

--- a/src/core/crypto/pbkdf2_cmac.hpp
+++ b/src/core/crypto/pbkdf2_cmac.hpp
@@ -50,10 +50,7 @@ namespace Pbkdf2 {
  *
  */
 
-enum : uint16_t
-{
-    kMaxSaltLength = 30, ///< Max SALT length: salt prefix (6) + extended panid (8) + network name (16)
-};
+constexpr uint16_t kMaxSaltLength = 30; ///< Max SALT length: salt prefix (6) + extended panid (8) + network name (16)
 
 /**
  * This function performs PKCS#5 PBKDF2 using CMAC (AES-CMAC-PRF-128).

--- a/src/core/crypto/sha256.hpp
+++ b/src/core/crypto/sha256.hpp
@@ -73,10 +73,7 @@ public:
     class Hash : public otCryptoSha256Hash, public Clearable<Hash>, public Equatable<Hash>
     {
     public:
-        enum : uint8_t
-        {
-            kSize = OT_CRYPTO_SHA256_HASH_SIZE, ///< SHA-256 hash size (bytes)
-        };
+        static const uint8_t kSize = OT_CRYPTO_SHA256_HASH_SIZE; ///< SHA-256 hash size (bytes)
 
         /**
          * This method returns a pointer to a byte array containing the hash value.

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -532,10 +532,7 @@ exit:
 
 void Diags::ProcessLine(const char *aString, char *aOutput, size_t aOutputMaxLen)
 {
-    enum
-    {
-        kMaxCommandBuffer = OPENTHREAD_CONFIG_DIAG_CMD_LINE_BUFFER_SIZE,
-    };
+    constexpr uint16_t kMaxCommandBuffer = OPENTHREAD_CONFIG_DIAG_CMD_LINE_BUFFER_SIZE;
 
     Error   error = kErrorNone;
     char    buffer[kMaxCommandBuffer];

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -122,10 +122,7 @@ public:
     void TransmitDone(Error aError);
 
 private:
-    enum : uint8_t
-    {
-        kMaxArgs = OPENTHREAD_CONFIG_DIAG_CMD_LINE_ARGS_MAX,
-    };
+    static constexpr uint8_t kMaxArgs = OPENTHREAD_CONFIG_DIAG_CMD_LINE_ARGS_MAX;
 
     struct Command
     {


### PR DESCRIPTION
This PR contains a set of separate commits changing the constants 
to use `constexpr` instead of `enume` under under different 
sub-folders: `coap`, `common`, `crypto` and `diags`.
