### PR TITLE
[otci] allow callbacks on all read lines

### DIFF
--- a/tools/otci/otci/command_handlers.py
+++ b/tools/otci/otci/command_handlers.py
@@ -92,14 +92,13 @@ class OtCliCommandRunner(OTCommandHandler):
         self.__otcli: OtCliHandler = otcli
         self.__is_spinel_cli = is_spinel_cli
         self.__expect_command_echoback = not self.__is_spinel_cli
+        self.__line_read_callback = None
 
         self.__pending_lines = queue.Queue()
         self.__should_close = threading.Event()
         self.__otcli_reader = threading.Thread(target=self.__otcli_read_routine)
         self.__otcli_reader.setDaemon(True)
         self.__otcli_reader.start()
-
-        self.__line_read_callback = None
 
     def __repr__(self):
         return repr(self.__otcli)
@@ -204,6 +203,8 @@ class OtbrSshCommandRunner(OTCommandHandler):
         self.__ssh = paramiko.SSHClient()
         self.__ssh.set_missing_host_key_policy(paramiko.AutoAddPolicy())
 
+        self.__line_read_callback = None
+
         try:
             self.__ssh.connect(host,
                                port=port,
@@ -216,8 +217,6 @@ class OtbrSshCommandRunner(OTCommandHandler):
                 self.__ssh.get_transport().auth_none(username)
             else:
                 raise
-
-        self.__line_read_callback = None
 
     def __repr__(self):
         return f'{self.__host}:{self.__port}'

--- a/tools/otci/otci/command_handlers.py
+++ b/tools/otci/otci/command_handlers.py
@@ -251,4 +251,3 @@ class OtbrSshCommandRunner(OTCommandHandler):
 
     def set_line_read_callback(self, callback: Optional[Callable[[str], Any]]):
         self.__line_read_callback = callback
-

--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -30,7 +30,7 @@ import ipaddress
 import logging
 import re
 from collections import Counter
-from typing import List, Collection, Union, Tuple, Optional, Dict, Pattern, Any
+from typing import Callable, List, Collection, Union, Tuple, Optional, Dict, Pattern, Any
 
 from . import connectors
 from .command_handlers import OTCommandHandler, OtCliCommandRunner, OtbrSshCommandRunner
@@ -117,6 +117,10 @@ class OTCI(object):
     def set_logger(self, logger: logging.Logger):
         """Set the logger for the OTCI instance, or None to disable logging."""
         self.__logger = logger
+
+    def set_line_read_callback(self, callback: Optional[Callable[[str], Any]]):
+        """Set the callback that will be called for each line output by the CLI."""
+        self.__otcmd.set_line_read_callback(callback)
 
     #
     # Constant properties


### PR DESCRIPTION
This allows for registering a callback on all lines read from a device, making it possible to react to output from asynchronous cli commands while concurrently executing new commands on the same device. Normally, executing those new commands would result in the async command output being lost.

Known caveats:

1. The same limitations as with wait apply to `OtbrSshCommandRunner` (you can't get async output)
2. For `OtCliCommandRunner`, any commands sent to the device in the callback need to be offloaded to another thread. Otherwise the read routine thread will be blocked, and the command will timeout
