### PR TITLE
[backbone-router] fix deinit MulticastRoutingManager

### DIFF
--- a/src/posix/platform/multicast_routing.cpp
+++ b/src/posix/platform/multicast_routing.cpp
@@ -63,7 +63,7 @@ void MulticastRoutingManager::Init(otInstance *aInstance)
 void MulticastRoutingManager::Deinit(void)
 {
     Mainloop::Manager::Get().Remove(*this);
-    otBackboneRouterSetMulticastListenerCallback(mInstance, nullptr, nullptr);
+    mInstance = nullptr;
 }
 
 void MulticastRoutingManager::HandleBackboneMulticastListenerEvent(void *                                 aContext,


### PR DESCRIPTION
The OpenThread instance has already been deinitialized before the platform
`MulticastRoutingManager` is deinitialized. We can never reference to `mInstance` in `Deinit`.

- [X] WIP: needs to be verified on device.