### PR TITLE
[build] allow specify build date time

### DIFF
--- a/script/check-android-build
+++ b/script/check-android-build
@@ -45,8 +45,26 @@ check_targets()
     done
 }
 
+check_datetime()
+{
+    local datetime
+
+    datetime="$(date)"
+    cat >openthread-config-datetime.h <<EOF
+#include <openthread-config-android.h>
+#define OPENTHREAD_BUILD_DATETIME "$datetime"
+EOF
+
+    OPENTHREAD_PROJECT_CFLAGS="-I$PWD -DOPENTHREAD_CONFIG_FILE=\\\"openthread-config-datetime.h\\\" \
+        -DOPENTHREAD_PROJECT_CORE_CONFIG_FILE=\\\"openthread-core-posix-config.h\\\"" \
+        make showcommands ot-cli
+    grep "$datetime" -ao "out/target/product/generic/system/bin/ot-cli"
+    make clean-ot-cli
+}
+
 main()
 {
+    OPENTHREAD_ENABLE_ANDROID_MK=1 ANDROID_NDK=1 check_datetime
     OPENTHREAD_ENABLE_ANDROID_MK=1 ANDROID_NDK=1 USE_OTBR_DAEMON=1 check_targets ot-cli ot-ctl
     OPENTHREAD_ENABLE_ANDROID_MK=1 ANDROID_NDK=1 check_targets ot-cli spi-hdlc-adapter
 }

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -42,13 +42,19 @@
 #include "common/new.hpp"
 #include "radio/radio.hpp"
 
+#if !defined(OPENTHREAD_BUILD_DATETIME)
 #ifdef __ANDROID__
 #ifdef OPENTHREAD_ENABLE_ANDROID_NDK
 #include <sys/system_properties.h>
 #else
 #include <cutils/properties.h>
 #endif
+#else // __ANDROID__
+#if defined(__DATE__)
+#define OPENTHREAD_BUILD_DATETIME "; " __DATE__ " " __TIME__
 #endif
+#endif // __ANDROID__
+#endif // !defined(OPENTHREAD_BUILD_DATETIME)
 
 using namespace ot;
 
@@ -142,7 +148,7 @@ const char *otGetVersionString(void)
      * image will be undefined and may change.
      */
 
-#ifdef __ANDROID__
+#if !defined(OPENTHREAD_BUILD_DATETIME) && defined(__ANDROID__)
 
 #ifdef OPENTHREAD_ENABLE_ANDROID_NDK
     static char sVersion[100 + PROP_VALUE_MAX];
@@ -166,11 +172,11 @@ const char *otGetVersionString(void)
     static
 #endif
     const char sVersion[] = PACKAGE_NAME "/" PACKAGE_VERSION "; " OPENTHREAD_CONFIG_PLATFORM_INFO
-#if defined(__DATE__)
-                                         "; " __DATE__ " " __TIME__
+#ifdef OPENTHREAD_BUILD_DATETIME
+        OPENTHREAD_BUILD_DATETIME
 #endif
 #ifdef PLATFORM_VERSION_ATTR_SUFFIX
-                                             PLATFORM_VERSION_ATTR_SUFFIX
+            PLATFORM_VERSION_ATTR_SUFFIX
 #endif
         ; // Trailing semicolon to end statement.
 


### PR DESCRIPTION
This commit adds a macro for specifying OpenThread build date time,
which can be empty so that this field can be omitted.