### PR TITLE
[tests] attempt to fix intermittent failures of MATN-12

### DIFF
--- a/tests/scripts/thread-cert/border_router/MATN_12_HopLimitProcessing.py
+++ b/tests/scripts/thread-cert/border_router/MATN_12_HopLimitProcessing.py
@@ -151,6 +151,7 @@ class MATN_12_HopLimitProcessing(thread_cert.TestCase):
         self.collect_rloc16s()
         self.collect_rlocs()
         self.collect_extra_vars()
+        self.simulator.go(5)
 
     def verify(self, pv: pktverify.packet_verifier.PacketVerifier):
         pkts = pv.pkts

--- a/tests/scripts/thread-cert/border_router/MATN_12_HopLimitProcessing.py
+++ b/tests/scripts/thread-cert/border_router/MATN_12_HopLimitProcessing.py
@@ -151,7 +151,6 @@ class MATN_12_HopLimitProcessing(thread_cert.TestCase):
         self.collect_rloc16s()
         self.collect_rlocs()
         self.collect_extra_vars()
-        self.simulator.go(5)
 
     def verify(self, pv: pktverify.packet_verifier.PacketVerifier):
         pkts = pv.pkts

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -135,7 +135,7 @@ class OtbrDocker:
         assert launch_ok
 
         cmd = f'docker exec -i {self._docker_name} ot-ctl'
-        self.pexpect = pexpect.popen_spawn.PopenSpawn(cmd, timeout=10)
+        self.pexpect = pexpect.popen_spawn.PopenSpawn(cmd, timeout=15)
 
         # Add delay to ensure that the process is ready to receive commands.
         timeout = 0.4

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -135,7 +135,7 @@ class OtbrDocker:
         assert launch_ok
 
         cmd = f'docker exec -i {self._docker_name} ot-ctl'
-        self.pexpect = pexpect.popen_spawn.PopenSpawn(cmd, timeout=15)
+        self.pexpect = pexpect.popen_spawn.PopenSpawn(cmd, timeout=30)
 
         # Add delay to ensure that the process is ready to receive commands.
         timeout = 0.4


### PR DESCRIPTION
The test failed because the script failed to read the output of `ipaddr rloc`. I suspect it can be fixed by adding some wait time at the end of the test.