### PR TITLE
[include] resolve the unknown type name issue

### DIFF
--- a/examples/platforms/utils/logging_rtt.h
+++ b/examples/platforms/utils/logging_rtt.h
@@ -41,6 +41,7 @@
 
 #include "openthread-core-config.h"
 #include <openthread/config.h>
+#include <openthread/platform/logging.h>
 
 #ifdef __cplusplus
 extern "C" {

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (141)
+#define OPENTHREAD_API_VERSION (142)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/memory.h
+++ b/include/openthread/platform/memory.h
@@ -35,6 +35,8 @@
 #ifndef OPENTHREAD_PLATFORM_MEMORY_H_
 #define OPENTHREAD_PLATFORM_MEMORY_H_
 
+#include <stddef.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif


### PR DESCRIPTION
When compiling OpenThread public header files independently, the
compiller generates errors, such as `unknown type name "size_t"`
and 'unknown type name "otLogLevel"'.

This commit adds the corresponding header files to the public
headers to resolve this issue.