### PR TITLE
[dataset] add API `otDatasetUpdaterRequestUpdateTlvs`

### DIFF
--- a/include/openthread/dataset_updater.h
+++ b/include/openthread/dataset_updater.h
@@ -94,6 +94,16 @@ otError otDatasetUpdaterRequestUpdate(otInstance *                aInstance,
                                       void *                      aContext);
 
 /**
+ * See otDatasetUpdaterRequestUpdate.
+ *
+ * @param aDatasetTlvs A pointer to the Dataset TLVs containing the fields to change.
+ */
+otError otDatasetUpdaterRequestUpdateTlvs(otInstance *                    aInstance,
+                                          const otOperationalDatasetTlvs *aDatasetTlvs,
+                                          otDatasetUpdaterCallback        aCallback,
+                                          void *                          aContext);
+
+/**
  * This function cancels an ongoing (if any) Operational Dataset update request.
  *
  * @param[in]  aInstance         A pointer to an OpenThread instance.

--- a/include/openthread/dataset_updater.h
+++ b/include/openthread/dataset_updater.h
@@ -94,9 +94,22 @@ otError otDatasetUpdaterRequestUpdate(otInstance *                aInstance,
                                       void *                      aContext);
 
 /**
- * See otDatasetUpdaterRequestUpdate.
+ * This function requests an update to Operational Dataset.
  *
- * @param aDatasetTlvs A pointer to the Dataset TLVs containing the fields to change.
+ * @p aDataset should contain the fields to be updated and their new value. It must not contain Active or Pending
+ * Timestamp fields. The Delay field is optional, if not provided a default value (1000 ms) would be used.
+ *
+ * @param[in]  aInstance               A pointer to an OpenThread instance.
+ * @param[in]  aDatasetTlvs            A pointer to the Dataset TLVs containing the fields to change.
+ * @param[in]  aCallback               A callback to indicate when Dataset update request finishes.
+ * @param[in]  aContext                An arbitrary context passed to callback.
+ *
+ * @retval OT_ERROR_NONE           Dataset update started successfully (@p aCallback will be invoked on completion).
+ * @retval OT_ERROR_INVALID_STATE  Device is disabled (MLE is disabled).
+ * @retval OT_ERROR_INVALID_ARGS   The @p aDataset is not valid (contains Active or Pending Timestamp).
+ * @retval OT_ERROR_BUSY           Cannot start update, a previous one is ongoing.
+ * @retval OT_ERROR_NO_BUFS        Could not allocated buffer to save Dataset.
+ *
  */
 otError otDatasetUpdaterRequestUpdateTlvs(otInstance *                    aInstance,
                                           const otOperationalDatasetTlvs *aDatasetTlvs,

--- a/include/openthread/dataset_updater.h
+++ b/include/openthread/dataset_updater.h
@@ -96,7 +96,7 @@ otError otDatasetUpdaterRequestUpdate(otInstance *                aInstance,
 /**
  * This function requests an update to Operational Dataset.
  *
- * @p aDataset should contain the fields to be updated and their new value. It must not contain Active or Pending
+ * @p aDatasetTlvs should contain dataset fields as encoded TLVs. It must not contain Active or Pending
  * Timestamp fields. The Delay field is optional, if not provided a default value (1000 ms) would be used.
  *
  * @param[in]  aInstance               A pointer to an OpenThread instance.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (141)
+#define OPENTHREAD_API_VERSION (142)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README_DATASET.md
+++ b/src/cli/README_DATASET.md
@@ -160,6 +160,7 @@ pending
 pendingtimestamp
 pskc
 securitypolicy
+updater
 Done
 ```
 
@@ -539,5 +540,38 @@ Set the Pending Operational Dataset using hex-encoded TLVs.
 
 ```bash
 dataset set pending 0e080000000000010000000300001035060004001fffe002084eb74ab03c56e6d00708fdc7fe165c83a67805108e2104f183e698da87e96efc1e45aa51030f4f70656e5468726561642d383631310102861104108d6273023d82c841eff0e68db86f35740c030000ff
+Done
+```
+
+### updater
+
+Usage: `dataset updater [<start [tlvs]|cancel>]`
+
+Request an update to the Operational Dataset.
+
+```bash
+> dataset updater start
+Done
+```
+
+Request an update to the Operational Dataset using the TLV format API.
+
+```bash
+> dataset updater start tlvs
+Done
+```
+
+Cancel an ongoing Operation Dataset update request.
+
+```bash
+> dataset updater cancel
+Done
+```
+
+Query the current status of the dataset updater.
+
+```bash
+> dataset updater
+Enabled
 Done
 ```

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -912,7 +912,22 @@ otError Dataset::ProcessUpdater(Arg aArgs[])
     }
     else if (aArgs[0] == "start")
     {
-        error = otDatasetUpdaterRequestUpdate(mInterpreter.mInstance, &sDataset, &Dataset::HandleDatasetUpdater, this);
+        if (aArgs[1] == "tlvs")
+        {
+            MeshCoP::Dataset         dataset;
+            otOperationalDatasetTlvs datasetTlvs;
+
+            SuccessOrExit(error = dataset.SetFrom(*static_cast<MeshCoP::Dataset::Info *>(&sDataset)));
+            dataset.ConvertTo(datasetTlvs);
+
+            error = otDatasetUpdaterRequestUpdateTlvs(mInterpreter.mInstance, &datasetTlvs,
+                                                      &Dataset::HandleDatasetUpdater, this);
+        }
+        else
+        {
+            error =
+                otDatasetUpdaterRequestUpdate(mInterpreter.mInstance, &sDataset, &Dataset::HandleDatasetUpdater, this);
+        }
     }
     else if (aArgs[0] == "cancel")
     {
@@ -923,6 +938,7 @@ otError Dataset::ProcessUpdater(Arg aArgs[])
         error = OT_ERROR_INVALID_ARGS;
     }
 
+exit:
     return error;
 }
 

--- a/src/core/api/dataset_updater_api.cpp
+++ b/src/core/api/dataset_updater_api.cpp
@@ -54,6 +54,21 @@ otError otDatasetUpdaterRequestUpdate(otInstance *                aInstance,
                                                                  aCallback, aContext);
 }
 
+otError otDatasetUpdaterRequestUpdateTlvs(otInstance *                    aInstance,
+                                          const otOperationalDatasetTlvs *aDatasetTlvs,
+                                          otDatasetUpdaterCallback        aCallback,
+                                          void *                          aContext)
+{
+    Instance &             instance = *static_cast<Instance *>(aInstance);
+    MeshCoP::Dataset::Info datasetInfo;
+    MeshCoP::Dataset       dataset;
+
+    dataset.SetFrom(*aDatasetTlvs);
+    dataset.ConvertTo(datasetInfo);
+
+    return instance.Get<MeshCoP::DatasetUpdater>().RequestUpdate(datasetInfo, aCallback, aContext);
+}
+
 void otDatasetUpdaterCancelUpdate(otInstance *aInstance)
 {
     Instance &instance = *static_cast<Instance *>(aInstance);

--- a/tests/scripts/expect/cli-dataset.exp
+++ b/tests/scripts/expect/cli-dataset.exp
@@ -44,7 +44,7 @@ expect -re {Network Key: [0-9a-f]{32}}
 expect -re {Network Name: [^\r\n]+}
 expect -re {PAN ID: 0x[0-9a-f]{4}}
 expect -re {PSKc: [0-9a-f]{32}}
-expect -re {Security Policy: \d+, o?n?r?c?b?}
+expect -re {Security Policy: \d+ o?n?r?c?b?}
 send "dataset pending\n"
 expect "Error 23: NotFound"
 send "dataset init active\n"
@@ -135,7 +135,7 @@ expect "Network Key: aabbccddeeff00112233445566778899"
 expect "Network Name: OT-network"
 expect "PAN ID: 0xface"
 expect "PSKc: 00112233445566778899aabbccddeeff"
-expect "Security Policy: 678, onrcb"
+expect "Security Policy: 678 onrcb"
 expect_line "Done"
 
 sleep 30
@@ -157,7 +157,7 @@ expect "Network Key: aabbccddeeff00112233445566778899"
 expect "Network Name: OT-network"
 expect "PAN ID: 0xface"
 expect "PSKc: 00112233445566778899aabbccddeeff"
-expect "Security Policy: 678, onrcb"
+expect "Security Policy: 678 onrcb"
 expect_line "Done"
 send "dataset clear\n"
 expect_line "Done"
@@ -177,7 +177,7 @@ expect "Network Key: aabbccddeeff00112233445566778899"
 expect "Network Name: OT-network"
 expect "PAN ID: 0xface"
 expect "PSKc: 00112233445566778899aabbccddeeff"
-expect "Security Policy: 678, onrcb"
+expect "Security Policy: 678 onrcb"
 expect_line "Done"
 send "dataset init pending\n"
 expect "Error 23: NotFound"
@@ -267,5 +267,48 @@ send "dataset securitypolicy 678 something_invalid\n"
 expect "Error 7: InvalidArgs"
 send "dataset set something_invalid 00\n"
 expect "Error 7: InvalidArgs"
+
+dispose_all
+
+spawn_node 1
+setup_leader
+
+send "dataset init new\n"
+expect_line "Done"
+send "dataset\n"
+expect -re {Network Key: ([0-9a-f]{32})}
+set network_key $expect_out(1,string)
+expect_line "Done"
+send "dataset clear\n"
+expect_line "Done"
+send "dataset networkkey $network_key\n"
+expect_line "Done"
+send "dataset updater start\n"
+expect_line "Done"
+sleep 1
+send "dataset pending\n"
+expect "Network Key: $network_key"
+expect_line "Done"
+send "dataset updater cancel\n"
+expect_line "Done"
+
+send "dataset init new\n"
+expect_line "Done"
+send "dataset\n"
+expect -re {Network Key: ([0-9a-f]{32})}
+set network_key $expect_out(1,string)
+expect_line "Done"
+send "dataset clear\n"
+expect_line "Done"
+send "dataset networkkey $network_key\n"
+expect_line "Done"
+send "dataset updater start tlvs\n"
+expect_line "Done"
+sleep 1
+send "dataset pending\n"
+expect "Network Key: $network_key"
+expect_line "Done"
+send "dataset updater cancel\n"
+expect_line "Done"
 
 dispose_all


### PR DESCRIPTION
This adds an API `otDatasetUpdaterRequestUpdateTlvs`, which is the same as `otDatasetUpdaterRequestUpdate` except that it accepts an `otOperationalDatasetTlvs` as a parameter.