### PR TITLE
[array] select the index/length `uint` type based on array size

### DIFF
--- a/src/core/common/array.hpp
+++ b/src/core/common/array.hpp
@@ -306,6 +306,75 @@ public:
     bool Contains(const Type &aEntry) const { return Find(aEntry) != nullptr; }
 
     /**
+     * This template method finds the first element in the array matching a given indicator.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against elements
+     * in the array. To check that an element matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` element in the array. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in]  aIndicator  An indicator to match with elements in the array.
+     *
+     * @returns A pointer to the matched array element, or nullptr if a match could not be found.
+     *
+     */
+    template <typename Indicator> Type *FindMatching(const Indicator &aIndicator)
+    {
+        return const_cast<Type *>(const_cast<const Array *>(this)->FindMatching(aIndicator));
+    }
+
+    /**
+     * This template method finds the first element in the array matching a given indicator.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against elements
+     * in the array. To check that an element matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` element in the array. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in]  aIndicator  An indicator to match with elements in the array.
+     *
+     * @returns A pointer to the matched array element, or nullptr if a match could not be found.
+     *
+     */
+    template <typename Indicator> const Type *FindMatching(const Indicator &aIndicator) const
+    {
+        const Type *matched = nullptr;
+
+        for (const Type &element : *this)
+        {
+            if (element.Matches(aIndicator))
+            {
+                matched = &element;
+                break;
+            }
+        }
+
+        return matched;
+    }
+
+    /**
+     * This template method indicates whether or not the array contains an element matching a given indicator.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against elements
+     * in the array. To check that an element matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` element in the array. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in]  aIndicator  An indicator to match with elements in the array.
+     *
+     * @retval TRUE   The array contains a matching element with @p aIndicator.
+     * @retval FALSE  The array does not contain a matching element with @p aIndicator.
+     *
+     */
+    template <typename Indicator> bool ContainsMatching(const Indicator &aIndicator) const
+    {
+        return FindMatching(aIndicator) != nullptr;
+    }
+
+    /**
      * This method overloads assignment `=` operator to copy elements from another array into the array.
      *
      * The method uses assignment `=` operator on `Type` to copy each element from @p aOtherArray into the elements of

--- a/src/core/common/type_traits.hpp
+++ b/src/core/common/type_traits.hpp
@@ -104,6 +104,27 @@ template <typename Type> struct IsSame<Type, Type> : public TrueValue
 {
 };
 
+/**
+ * This type selects between two given types based on a boolean condition at compile time.
+ *
+ * It provides member type named `Type` which is defined as `TypeOnTrue` if `kCondition` is `true` at compile time, or
+ * as `TypeOnFalse` if `kCondition` is `false`.
+ *
+ * @tparam kCondition   The boolean condition which is used to select between the two types.
+ * @tparam TypeOnTrue   The type to select when `kCondition` is `true`.
+ * @tparam TypeOnFalse  The type to select when `kCondition` is `false`.
+ *
+ */
+template <bool kCondition, typename TypeOnTrue, typename TypeOnFalse> struct Conditional
+{
+    typedef TypeOnFalse Type; ///< The selected type based on `kCondition`.
+};
+
+template <typename TypeOnTrue, typename TypeOnFalse> struct Conditional<true, TypeOnTrue, TypeOnFalse>
+{
+    typedef TypeOnTrue Type;
+};
+
 } // namespace TypeTraits
 } // namespace ot
 

--- a/tests/unit/test_array.cpp
+++ b/tests/unit/test_array.cpp
@@ -36,6 +36,7 @@
 #include "common/array.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
+#include "common/type_traits.hpp"
 
 #include "test_util.h"
 
@@ -47,7 +48,7 @@ void TestArray(void)
     constexpr uint16_t kStartValue = 100;
 
     Array<uint16_t, kMaxSize> array;
-    uint16_t                  index;
+    uint8_t                   index;
     uint16_t                  seed;
 
     // All methods after constructor
@@ -62,7 +63,7 @@ void TestArray(void)
 
     seed = kStartValue;
 
-    for (uint16_t len = 1; len <= kMaxSize; len++)
+    for (uint8_t len = 1; len <= kMaxSize; len++)
     {
         for (uint8_t iter = 0; iter < 2; iter++)
         {
@@ -146,7 +147,7 @@ void TestArray(void)
     VerifyOrQuit(array.PushBack(0) == kErrorNoBufs);
     VerifyOrQuit(array.PushBack() == nullptr);
 
-    for (uint16_t len = kMaxSize; len >= 1; len--)
+    for (uint8_t len = kMaxSize; len >= 1; len--)
     {
         uint16_t *entry;
 
@@ -244,12 +245,25 @@ void TestArrayCopy(void)
     }
 }
 
+void TestArrayIndexType(void)
+{
+    typedef Array<uint16_t, 255>           Array1;
+    typedef Array<uint16_t, 256>           Array2;
+    typedef Array<uint16_t, 100, uint16_t> Array3;
+
+    static_assert(TypeTraits::IsSame<Array1::IndexType, uint8_t>::kValue, "Array1::IndexType is incorrect");
+    static_assert(TypeTraits::IsSame<Array2::IndexType, uint16_t>::kValue, "Array2::IndexType is incorrect");
+    static_assert(TypeTraits::IsSame<Array3::IndexType, uint16_t>::kValue, "Array3::IndexType is incorrect");
+}
+
 } // namespace ot
 
 int main(void)
 {
     ot::TestArray();
     ot::TestArrayCopy();
+    ot::TestArrayIndexType();
+
     printf("All tests passed\n");
     return 0;
 }

--- a/tests/unit/test_array.cpp
+++ b/tests/unit/test_array.cpp
@@ -171,7 +171,7 @@ void TestArray(void)
     VerifyOrQuit(array.IsEmpty());
 }
 
-void TestArrayCopy(void)
+void TestArrayCopyAndFindMatching(void)
 {
     constexpr uint16_t kMaxSize = 10;
 
@@ -186,6 +186,8 @@ void TestArrayCopy(void)
         }
 
         bool operator==(const Entry &aOther) { return (mName == aOther.mName) && (mYear == aOther.mYear); }
+        bool Matches(const char *aName) const { return strcmp(aName, mName) == 0; }
+        bool Matches(uint16_t aYear) const { return aYear == mYear; }
 
         const char *mName;
         uint16_t    mYear;
@@ -243,6 +245,33 @@ void TestArrayCopy(void)
             VerifyOrQuit(array2[index] == array4[index]);
         }
     }
+
+    SuccessOrQuit(array2.PushBack(ps5));
+    VerifyOrQuit(array2.GetLength() == 5);
+
+    for (const Entry &entry : array2)
+    {
+        Entry *match;
+
+        printf("- Name:%-3s Year:%d\n", entry.mName, entry.mYear);
+
+        match = array2.FindMatching(entry.mName);
+        VerifyOrQuit(match != nullptr);
+        VerifyOrQuit(match == &entry);
+        VerifyOrQuit(array2.ContainsMatching(entry.mName));
+
+        match = array2.FindMatching(entry.mYear);
+        VerifyOrQuit(match != nullptr);
+        VerifyOrQuit(match == &entry);
+        VerifyOrQuit(array2.ContainsMatching(entry.mYear));
+    }
+
+    VerifyOrQuit(array2.FindMatching("PS6") == nullptr);
+    VerifyOrQuit(!array2.ContainsMatching("PS6"));
+    VerifyOrQuit(array2.FindMatching(static_cast<uint16_t>(2001)) == nullptr);
+    VerifyOrQuit(!array2.ContainsMatching(static_cast<uint16_t>(2001)));
+
+    printf("\n");
 }
 
 void TestArrayIndexType(void)
@@ -261,7 +290,7 @@ void TestArrayIndexType(void)
 int main(void)
 {
     ot::TestArray();
-    ot::TestArrayCopy();
+    ot::TestArrayCopyAndFindMatching();
     ot::TestArrayIndexType();
 
     printf("All tests passed\n");


### PR DESCRIPTION
This commit enhances the template `Array` class implementation to
allow the `uint` type used for array size (which is also used for
length and index) to be specified as a template type parameter. If
not explicitly specified, a default `uint` type is selected based on
the array size `kMaxSize`, i.e., if `kMaxSize <= 255` then `uint8_t`
will be used, otherwise `uint16_t` will be used.

------------

Added a second related commit in this PR:

**[array] add `FindMatching()` and `ContainsMatching()` (#6872)**

This commit adds template `Find/ContainsMatching<Indicator>()` methods
which search in the array to find the first element matching a given
indicator. Unit test `test_array` is also updated to check the
behavior of newly added methods.