### PR TITLE
[net] replace `enum` constants with `constexpr`

### DIFF
--- a/src/core/net/checksum.hpp
+++ b/src/core/net/checksum.hpp
@@ -101,10 +101,7 @@ private:
                        uint8_t             aIpProto,
                        const Message &     aMessage);
 
-    enum : uint16_t
-    {
-        kValidRxChecksum = 0xffff,
-    };
+    static constexpr uint16_t kValidRxChecksum = 0xffff;
 
     uint16_t mValue;
     bool     mAtOddIndex;

--- a/src/core/net/dhcp6.hpp
+++ b/src/core/net/dhcp6.hpp
@@ -59,18 +59,10 @@ using ot::Encoding::BigEndian::HostSwap32;
  *
  */
 
-/**
- * DHCPv6 constant
- *
- */
-enum
-{
-
-    kDhcpClientPort       = 546,
-    kDhcpServerPort       = 547,
-    kHardwareTypeEui64    = 27,
-    kHardwareTypeEthernet = 1,
-};
+constexpr uint16_t kDhcpClientPort       = 546;
+constexpr uint16_t kDhcpServerPort       = 547;
+constexpr uint16_t kHardwareTypeEui64    = 27;
+constexpr uint16_t kHardwareTypeEthernet = 1;
 
 /**
  * DHCPv6 Message Types
@@ -104,10 +96,7 @@ OT_TOOL_PACKED_BEGIN
 class TransactionId : public Equatable<TransactionId>, public Clearable<TransactionId>
 {
 public:
-    enum : uint16_t
-    {
-        kSize = 3, // Transaction Id size (in bytes).
-    };
+    static constexpr uint16_t kSize = 3; ///< Transaction Id size (in bytes).
 
     /**
      * This method generates a cryptographically secure random sequence to populate the transaction identifier.
@@ -413,11 +402,8 @@ OT_TOOL_PACKED_BEGIN
 class IaNa : public Option
 {
 public:
-    enum : uint32_t
-    {
-        kDefaultT1 = 0xffffffffU, ///< Default T1 value.
-        kDefaultT2 = 0xffffffffU, ///< Default T2 value.
-    };
+    static constexpr uint32_t kDefaultT1 = 0xffffffffU; ///< Default T1 value.
+    static constexpr uint32_t kDefaultT2 = 0xffffffffU; ///< Default T2 value.
 
     /**
      * This method initializes the DHCPv6 Option.
@@ -491,11 +477,8 @@ OT_TOOL_PACKED_BEGIN
 class IaAddress : public Option
 {
 public:
-    enum : uint32_t
-    {
-        kDefaultPreferredLifetime = 0xffffffffU, ///< Default preferred lifetime.
-        kDefaultValidLiftetime    = 0xffffffffU, ///< Default valid lifetime.
-    };
+    static constexpr uint32_t kDefaultPreferredLifetime = 0xffffffffU; ///< Default preferred lifetime.
+    static constexpr uint32_t kDefaultValidLiftetime    = 0xffffffffU; ///< Default valid lifetime.
 
     /**
      * This method initializes the DHCPv6 Option.

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -86,11 +86,8 @@ public:
     void UpdateAddresses(void);
 
 private:
-    enum
-    {
-        kTrickleTimerImin = 1,
-        kTrickleTimerImax = 120,
-    };
+    static constexpr uint32_t kTrickleTimerImin = 1;
+    static constexpr uint32_t kTrickleTimerImax = 120;
 
     enum IaStatus : uint8_t
     {

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -180,10 +180,7 @@ private:
         Ip6::Prefix              mPrefix;
     };
 
-    enum : uint16_t
-    {
-        kNumPrefixes = OPENTHREAD_CONFIG_DHCP6_SERVER_NUM_PREFIXES,
-    };
+    static constexpr uint16_t kNumPrefixes = OPENTHREAD_CONFIG_DHCP6_SERVER_NUM_PREFIXES;
 
     void Start(void);
     void Stop(void);

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -120,7 +120,7 @@ public:
          * This enumeration type represents the "Recursion Desired" (RD) flag in a `otDnsQueryConfig`.
          *
          */
-        enum RecursionFlag
+        enum RecursionFlag : uint8_t
         {
             kFlagUnspecified      = OT_DNS_FLAG_UNSPECIFIED,       ///< The flag is not specified.
             kFlagRecursionDesired = OT_DNS_FLAG_RECURSION_DESIRED, ///< Server can resolve the query recursively.
@@ -132,7 +132,7 @@ public:
          * This enumeration type represents the NAT64 mode.
          *
          */
-        enum Nat64Mode
+        enum Nat64Mode : uint8_t
         {
             kNat64Unspecified = OT_DNS_NAT64_UNSPECIFIED, ///< NAT64 mode is not specified. Use default NAT64 mode.
             kNat64Allow       = OT_DNS_NAT64_ALLOW,       ///< Allow NAT64 address translation
@@ -192,31 +192,13 @@ public:
 #endif
 
     private:
-        enum : uint32_t
-        {
-            kDefaultResponseTimeout = OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_RESPONSE_TIMEOUT, // in msec
-        };
-
-        enum : uint16_t
-        {
-            kDefaultServerPort = OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_SERVER_PORT,
-        };
-
-        enum : uint8_t
-        {
-            kDefaultMaxTxAttempts = OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_MAX_TX_ATTEMPTS,
-        };
-
-        enum : bool
-        {
-            kDefaultRecursionDesired = OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_RECURSION_DESIRED_FLAG,
-        };
+        static constexpr uint32_t kDefaultResponseTimeout = OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_RESPONSE_TIMEOUT;
+        static constexpr uint16_t kDefaultServerPort      = OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_SERVER_PORT;
+        static constexpr uint8_t  kDefaultMaxTxAttempts   = OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_MAX_TX_ATTEMPTS;
+        static constexpr bool kDefaultRecursionDesired    = OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_RECURSION_DESIRED_FLAG;
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_NAT64_ENABLE
-        enum : bool
-        {
-            kDefaultNat64Allowed = OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_NAT64_ALLOWED,
-        };
+        static constexpr bool kDefaultNat64Allowed = OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_NAT64_ALLOWED;
 #endif
 
         enum InitMode : uint8_t
@@ -714,10 +696,7 @@ private:
         // Followed by the name (service, host, instance) encoded as a `Dns::Name`.
     };
 
-    enum : uint16_t
-    {
-        kNameOffsetInQuery = sizeof(QueryInfo),
-    };
+    static constexpr uint16_t kNameOffsetInQuery = sizeof(QueryInfo);
 
     Error       StartQuery(QueryInfo &        aInfo,
                            const QueryConfig *aConfig,

--- a/src/core/net/dns_types.cpp
+++ b/src/core/net/dns_types.cpp
@@ -959,6 +959,7 @@ Error TxtEntry::AppendTo(Message &aMessage) const
 {
     Error    error = kErrorNone;
     uint16_t keyLength;
+    char     separator = kKeyValueSeparator;
 
     if (mKey == nullptr)
     {
@@ -985,7 +986,7 @@ Error TxtEntry::AppendTo(Message &aMessage) const
 
     SuccessOrExit(error = aMessage.Append<uint8_t>(static_cast<uint8_t>(keyLength + mValueLength + sizeof(char))));
     SuccessOrExit(error = aMessage.AppendBytes(mKey, keyLength));
-    SuccessOrExit(error = aMessage.Append<char>(kKeyValueSeparator));
+    SuccessOrExit(error = aMessage.Append(separator));
     error = aMessage.AppendBytes(mValue, mValueLength);
 
 exit:

--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -113,7 +113,7 @@ public:
      * Defines types of DNS message.
      *
      */
-    enum Type
+    enum Type : uint8_t
     {
         kTypeQuery    = 0,
         kTypeResponse = 1,
@@ -143,7 +143,7 @@ public:
      * Defines types of query.
      *
      */
-    enum QueryType
+    enum QueryType : uint8_t
     {
         kQueryTypeStandard = 0,
         kQueryTypeInverse  = 1,
@@ -258,7 +258,7 @@ public:
      * Defines response codes.
      *
      */
-    enum Response
+    enum Response : uint8_t
     {
         kResponseSuccess         = 0,  ///< Success (no error condition).
         kResponseFormatError     = 1,  ///< Server unable to interpret request due to format error.
@@ -385,27 +385,21 @@ public:
     void SetAdditionalRecordCount(uint16_t aCount) { mArCount = HostSwap16(aCount); }
 
 private:
-    /**
-     * Protocol Constants (RFC 1035).
-     *
-     */
-    enum
-    {
-        kQrFlagOffset = 7,                     // QR Flag offset.
-        kQrFlagMask   = 0x01 << kQrFlagOffset, // QR Flag mask.
-        kOpCodeOffset = 3,                     // OpCode field offset.
-        kOpCodeMask   = 0x0f << kOpCodeOffset, // OpCode field mask.
-        kAaFlagOffset = 2,                     // AA Flag offset.
-        kAaFlagMask   = 0x01 << kAaFlagOffset, // AA Flag mask.
-        kTcFlagOffset = 1,                     // TC Flag offset.
-        kTcFlagMask   = 0x01 << kTcFlagOffset, // TC Flag mask.
-        kRdFlagOffset = 0,                     // RD Flag offset.
-        kRdFlagMask   = 0x01 << kRdFlagOffset, // RD Flag mask.
-        kRaFlagOffset = 7,                     // RA Flag offset.
-        kRaFlagMask   = 0x01 << kRaFlagOffset, // RA Flag mask.
-        kRCodeOffset  = 0,                     // RCODE field offset.
-        kRCodeMask    = 0x0f << kRCodeOffset,  // RCODE field mask.
-    };
+    // Protocol Constants (RFC 1035).
+    static constexpr uint8_t kQrFlagOffset = 7;                     // QR Flag offset.
+    static constexpr uint8_t kQrFlagMask   = 0x01 << kQrFlagOffset; // QR Flag mask.
+    static constexpr uint8_t kOpCodeOffset = 3;                     // OpCode field offset.
+    static constexpr uint8_t kOpCodeMask   = 0x0f << kOpCodeOffset; // OpCode field mask.
+    static constexpr uint8_t kAaFlagOffset = 2;                     // AA Flag offset.
+    static constexpr uint8_t kAaFlagMask   = 0x01 << kAaFlagOffset; // AA Flag mask.
+    static constexpr uint8_t kTcFlagOffset = 1;                     // TC Flag offset.
+    static constexpr uint8_t kTcFlagMask   = 0x01 << kTcFlagOffset; // TC Flag mask.
+    static constexpr uint8_t kRdFlagOffset = 0;                     // RD Flag offset.
+    static constexpr uint8_t kRdFlagMask   = 0x01 << kRdFlagOffset; // RD Flag mask.
+    static constexpr uint8_t kRaFlagOffset = 7;                     // RA Flag offset.
+    static constexpr uint8_t kRaFlagMask   = 0x01 << kRaFlagOffset; // RA Flag mask.
+    static constexpr uint8_t kRCodeOffset  = 0;                     // RCODE field offset.
+    static constexpr uint8_t kRCodeMask    = 0x0f << kRCodeOffset;  // RCODE field mask.
 
     uint16_t mMessageId; // Message identifier for requester to match up replies to outstanding queries.
     uint8_t  mFlags[2];  // DNS header flags.
@@ -491,37 +485,31 @@ public:
 class Name : public Clearable<Name>
 {
 public:
-    enum : uint8_t
-    {
-        /**
-         * Max size (number of chars) in a name string array (includes null char at the end of string).
-         *
-         */
-        kMaxNameSize = OT_DNS_MAX_NAME_SIZE,
+    /**
+     * Max size (number of chars) in a name string array (includes null char at the end of string).
+     *
+     */
+    static constexpr uint8_t kMaxNameSize = OT_DNS_MAX_NAME_SIZE;
 
-        /**
-         * Maximum length in a name string (does not include null char at the end of string).
-         *
-         */
-        kMaxNameLength = kMaxNameSize - 1,
+    /**
+     * Maximum length in a name string (does not include null char at the end of string).
+     *
+     */
+    static constexpr uint8_t kMaxNameLength = kMaxNameSize - 1;
 
-        /**
-         * Max size (number of chars) in a label string array (includes null char at the end of the string).
-         *
-         */
-        kMaxLabelSize = OT_DNS_MAX_LABEL_SIZE,
+    /**
+     * Max size (number of chars) in a label string array (includes null char at the end of the string).
+     *
+     */
+    static constexpr uint8_t kMaxLabelSize = OT_DNS_MAX_LABEL_SIZE;
 
-        /**
-         * Maximum length in a label string (does not include null char at the end of string).
-         *
-         */
-        kMaxLabelLength = kMaxLabelSize - 1,
-    };
+    /**
+     * Maximum length in a label string (does not include null char at the end of string).
+     *
+     */
+    static constexpr uint8_t kMaxLabelLength = kMaxLabelSize - 1;
 
-    enum : char
-    {
-        kLabelSeperatorChar = '.',
-    };
+    static constexpr char kLabelSeperatorChar = '.';
 
     /**
      * This enumeration represents the name type.
@@ -995,38 +983,26 @@ public:
     static bool IsSubDomainOf(const char *aName, const char *aDomain);
 
 private:
-    enum : char
-    {
-        kNullChar = '\0',
-    };
+    static constexpr char kNullChar = '\0';
 
-    enum : uint8_t
-    {
-        // The first 2 bits of the encoded label specifies label type.
-        //
-        // - Value 00 indicates normal text label (lower 6-bits indicates the label length).
-        // - Value 11 indicates pointer label type (lower 14-bits indicates the pointer offset).
-        // - Values 01,10 are reserved (RFC 6891 recommends to not use)
+    // The first 2 bits of the encoded label specifies label type.
+    //
+    // - Value 00 indicates normal text label (lower 6-bits indicates the label length).
+    // - Value 11 indicates pointer label type (lower 14-bits indicates the pointer offset).
+    // - Values 01,10 are reserved (RFC 6891 recommends to not use)
 
-        kLabelTypeMask    = 0xc0, // 0b1100_0000 (first two bits)
-        kTextLabelType    = 0x00, // Text label type (00)
-        kPointerLabelType = 0xc0, // Pointer label type - compressed name (11)
+    static constexpr uint8_t kLabelTypeMask    = 0xc0; // 0b1100_0000 (first two bits)
+    static constexpr uint8_t kTextLabelType    = 0x00; // Text label type (00)
+    static constexpr uint8_t kPointerLabelType = 0xc0; // Pointer label type - compressed name (11)
 
-        kMaxEncodedLength = 255, ///< Max length of an encoded name.
-    };
+    static constexpr uint8_t kMaxEncodedLength = 255; ///< Max length of an encoded name.
 
-    enum : uint16_t
-    {
-        kPointerLabelTypeUint16 = 0xc000, // Pointer label type as `uint16_t` mask (first 2 bits).
-        kPointerLabelOffsetMask = 0x3fff, // Mask to get the offset field in a pointer label (lower 14 bits).
-    };
+    static constexpr uint16_t kPointerLabelTypeUint16 = 0xc000; // Pointer label type mask (first 2 bits).
+    static constexpr uint16_t kPointerLabelOffsetMask = 0x3fff; // Mask for offset in a pointer label (lower 14 bits).
 
     struct LabelIterator
     {
-        enum : uint16_t
-        {
-            kUnsetNameEndOffset = 0, // Special value indicating `mNameEndOffset` is not yet set.
-        };
+        static constexpr uint16_t kUnsetNameEndOffset = 0; // Special value indicating `mNameEndOffset` is not yet set.
 
         LabelIterator(const Message &aMessage, uint16_t aLabelOffset)
             : mMessage(aMessage)
@@ -1070,14 +1046,20 @@ class TxtEntry : public otDnsTxtEntry
     friend class TxtRecord;
 
 public:
-    enum : uint8_t
-    {
-        kMinKeyLength = OT_DNS_TXT_KEY_MIN_LENGTH, ///< Minimum length of key string (RFC 6763 - section 6.4).
-        kMaxKeyLength = OT_DNS_TXT_KEY_MAX_LENGTH, ///< Recommended max length of key string (RFC 6763 - section 6.4).
-    };
+    /**
+     * Minimum length of key string (RFC 6763 - section 6.4).
+     *
+     */
+    static constexpr uint8_t kMinKeyLength = OT_DNS_TXT_KEY_MIN_LENGTH;
 
     /**
-     * This class represents an iterator for TXT record entires (key/value pairs).
+     * Recommended max length of key string (RFC 6763 - section 6.4).
+     *
+     */
+    static constexpr uint8_t kMaxKeyLength = OT_DNS_TXT_KEY_MAX_LENGTH;
+
+    /**
+     * This class represents an iterator for TXT record entries (key/value pairs).
      *
      */
     class Iterator : public otDnsTxtEntryIterator
@@ -1117,11 +1099,8 @@ public:
         Error GetNextEntry(TxtEntry &aEntry);
 
     private:
-        enum : uint8_t
-        {
-            kIndexTxtLength   = 0,
-            kIndexTxtPosition = 1,
-        };
+        static constexpr uint8_t kIndexTxtLength   = 0;
+        static constexpr uint8_t kIndexTxtPosition = 1;
 
         const char *GetTxtData(void) const { return reinterpret_cast<const char *>(mPtr); }
         void        SetTxtData(const uint8_t *aTxtData) { mPtr = aTxtData; }
@@ -1182,16 +1161,9 @@ public:
     static Error AppendEntries(const TxtEntry *aEntries, uint8_t aNumEntries, Message &aMessage);
 
 private:
-    enum : uint8_t
-    {
-        kMaxKeyValueEncodedSize = 255,
-    };
-
-    enum : char
-    {
-        kKeyValueSeparator = '=',
-        kNullChar          = '\0',
-    };
+    static constexpr uint8_t kMaxKeyValueEncodedSize = 255;
+    static constexpr char    kKeyValueSeparator      = '=';
+    static constexpr char    kNullChar               = '\0';
 };
 
 /**
@@ -1204,36 +1176,24 @@ class ResourceRecord
     friend class OptRecord;
 
 public:
-    /**
-     * Resource Record Types.
-     *
-     */
-    enum : uint16_t
-    {
-        kTypeZero  = 0,   ///< Zero is used as a special indicator for the SIG RR (SIG(0) from RFC 2931).
-        kTypeA     = 1,   ///< Address record (IPv4).
-        kTypeSoa   = 6,   ///< Start of (zone of) authority.
-        kTypeCname = 5,   ///< CNAME record.
-        kTypePtr   = 12,  ///< PTR record.
-        kTypeTxt   = 16,  ///< TXT record.
-        kTypeSig   = 24,  ///< SIG record.
-        kTypeKey   = 25,  ///< KEY record.
-        kTypeAaaa  = 28,  ///< IPv6 address record.
-        kTypeSrv   = 33,  ///< SRV locator record.
-        kTypeOpt   = 41,  ///< Option record.
-        kTypeAny   = 255, ///< ANY record.
-    };
+    // Resource Record Types.
+    static constexpr uint16_t kTypeZero  = 0;   ///< Zero as special indicator for the SIG RR (SIG(0) from RFC 2931).
+    static constexpr uint16_t kTypeA     = 1;   ///< Address record (IPv4).
+    static constexpr uint16_t kTypeSoa   = 6;   ///< Start of (zone of) authority.
+    static constexpr uint16_t kTypeCname = 5;   ///< CNAME record.
+    static constexpr uint16_t kTypePtr   = 12;  ///< PTR record.
+    static constexpr uint16_t kTypeTxt   = 16;  ///< TXT record.
+    static constexpr uint16_t kTypeSig   = 24;  ///< SIG record.
+    static constexpr uint16_t kTypeKey   = 25;  ///< KEY record.
+    static constexpr uint16_t kTypeAaaa  = 28;  ///< IPv6 address record.
+    static constexpr uint16_t kTypeSrv   = 33;  ///< SRV locator record.
+    static constexpr uint16_t kTypeOpt   = 41;  ///< Option record.
+    static constexpr uint16_t kTypeAny   = 255; ///< ANY record.
 
-    /**
-     * Resource Record Class Codes.
-     *
-     */
-    enum : uint16_t
-    {
-        kClassInternet = 1,   ///< Class code Internet (IN).
-        kClassNone     = 254, ///< Class code None (NONE) - RFC 2136.
-        kClassAny      = 255, ///< Class code Any (ANY).
-    };
+    // Resource Record Class Codes.
+    static constexpr uint16_t kClassInternet = 1;   ///< Class code Internet (IN).
+    static constexpr uint16_t kClassNone     = 254; ///< Class code None (NONE) - RFC 2136.
+    static constexpr uint16_t kClassAny      = 255; ///< Class code Any (ANY).
 
     /**
      * This method initializes the resource record by setting its type and class.
@@ -1468,10 +1428,7 @@ protected:
     Error SkipRecord(const Message &aMessage, uint16_t &aOffset) const;
 
 private:
-    enum : uint8_t
-    {
-        kType = kTypeAny, // This is intended for used by `ReadRecord()` only.
-    };
+    static constexpr uint16_t kType = kTypeAny; // This is intended for used by `ReadRecord<RecordType>()` only.
 
     static Error FindRecord(const Message & aMessage,
                             uint16_t &      aOffset,
@@ -1506,10 +1463,7 @@ OT_TOOL_PACKED_BEGIN
 class ARecord : public ResourceRecord
 {
 public:
-    enum : uint16_t
-    {
-        kType = kTypeA, ///< The A record type.
-    };
+    static constexpr uint16_t kType = kTypeA; ///< The A record type.
 
     /**
      * This method initializes the A Resource Record by setting its type, class, and length.
@@ -1551,10 +1505,7 @@ OT_TOOL_PACKED_BEGIN
 class CnameRecord : public ResourceRecord
 {
 public:
-    enum : uint16_t
-    {
-        kType = kTypeCname, ///< The CNAME record type.
-    };
+    static constexpr uint16_t kType = kTypeCname; ///< The CNAME record type.
 
     /**
      * This method initializes the CNAME Resource Record by setting its type and class.
@@ -1605,10 +1556,7 @@ OT_TOOL_PACKED_BEGIN
 class PtrRecord : public ResourceRecord
 {
 public:
-    enum : uint16_t
-    {
-        kType = kTypePtr, ///< The PTR record type.
-    };
+    static constexpr uint16_t kType = kTypePtr; ///< The PTR record type.
 
     /**
      * This method initializes the PTR Resource Record by setting its type and class.
@@ -1693,10 +1641,7 @@ OT_TOOL_PACKED_BEGIN
 class TxtRecord : public ResourceRecord
 {
 public:
-    enum : uint16_t
-    {
-        kType = kTypeTxt, ///< The TXT record type.
-    };
+    static constexpr uint16_t kType = kTypeTxt; ///< The TXT record type.
 
     /**
      * This method initializes the TXT Resource Record by setting its type and class.
@@ -1750,10 +1695,7 @@ OT_TOOL_PACKED_BEGIN
 class AaaaRecord : public ResourceRecord
 {
 public:
-    enum : uint16_t
-    {
-        kType = kTypeAaaa, ///< The AAAA record type.
-    };
+    static constexpr uint16_t kType = kTypeAaaa; ///< The AAAA record type.
 
     /**
      * This method initializes the AAAA Resource Record by setting its type, class, and length.
@@ -1803,10 +1745,7 @@ OT_TOOL_PACKED_BEGIN
 class SrvRecord : public ResourceRecord
 {
 public:
-    enum : uint16_t
-    {
-        kType = kTypeSrv, ///< The SRV record type.
-    };
+    static constexpr uint16_t kType = kTypeSrv; ///< The SRV record type.
 
     /**
      * This method initializes the SRV Resource Record by settings its type and class.
@@ -1912,32 +1851,17 @@ OT_TOOL_PACKED_BEGIN
 class KeyRecord : public ResourceRecord
 {
 public:
-    enum : uint16_t
-    {
-        kType = kTypeKey, ///< The KEY record type.
-    };
+    static constexpr uint16_t kType = kTypeKey; ///< The KEY record type.
 
-    /**
-     * This enumeration defines protocol field values (RFC 2535 - section 3.1.3).
-     *
-     */
-    enum : uint8_t
-    {
-        kProtocolTls    = 1, ///< TLS protocol code.
-        kProtocolDnsSec = 3, ///< DNS security protocol code.
-    };
+    // Protocol field values (RFC 2535 - section 3.1.3).
+    static constexpr uint8_t kProtocolTls    = 1; ///< TLS protocol code.
+    static constexpr uint8_t kProtocolDnsSec = 3; ///< DNS security protocol code.
 
-    /**
-     * This enumeration defines algorithm field values (RFC 8624 - section 3.1).
-     *
-     */
-    enum : uint8_t
-    {
-        kAlgorithmEcdsaP256Sha256 = 13, ///< ECDSA-P256-SHA256 algorithm.
-        kAlgorithmEcdsaP384Sha384 = 14, ///< ECDSA-P384-SHA384 algorithm.
-        kAlgorithmEd25519         = 15, ///< ED25519 algorithm.
-        kAlgorithmEd448           = 16, ///< ED448 algorithm.
-    };
+    // Algorithm field values (RFC 8624 - section 3.1).
+    static constexpr uint8_t kAlgorithmEcdsaP256Sha256 = 13; ///< ECDSA-P256-SHA256 algorithm.
+    static constexpr uint8_t kAlgorithmEcdsaP384Sha384 = 14; ///< ECDSA-P384-SHA384 algorithm.
+    static constexpr uint8_t kAlgorithmEd25519         = 15; ///< ED25519 algorithm.
+    static constexpr uint8_t kAlgorithmEd448           = 16; ///< ED448 algorithm.
 
     /**
      * This enumeration type represents the use (or key type) flags (RFC 2535 - section 3.1.2).
@@ -1963,19 +1887,33 @@ public:
         kOwnerReserved = 0x03, ///< Reserved for future use.
     };
 
+    // Constants for flag bits for the "signatory" flags (RFC 2137).
+    //
+    // The flags defined are for non-zone (`kOwnerNoneZone`) keys (RFC 2137 - section 3.1.3).
+
     /**
-     * This enumeration defines flag bits for the "signatory" flags (RFC 2137).
-     *
-     * The flags defined are for non-zone (`kOwnerNoneZone`) keys (RFC 2137 - section 3.1.3).
+     * Key is authorized to attach, detach, and move zones.
      *
      */
-    enum : uint8_t
-    {
-        kSignatoryFlagZone    = 1 << 3, ///< Key is authorized to attach, detach, and move zones.
-        kSignatoryFlagStrong  = 1 << 2, ///< Key is authorized to add and delete RRs even if RRs auth with other key.
-        kSignatoryFlagUnique  = 1 << 1, ///< Key is authorized to add and update RRs for only a single owner name.
-        kSignatoryFlagGeneral = 1 << 0, ///< If the other flags are zero, this is used to indicate it is an update key.
-    };
+    static constexpr uint8_t kSignatoryFlagZone = 1 << 3;
+
+    /**
+     * Key is authorized to add and delete RRs even if RRs auth with other key.
+     *
+     */
+    static constexpr uint8_t kSignatoryFlagStrong = 1 << 2;
+
+    /**
+     * Key is authorized to add and update RRs for only a single owner name.
+     *
+     */
+    static constexpr uint8_t kSignatoryFlagUnique = 1 << 1;
+
+    /**
+     * If the other flags are zero, this is used to indicate it is an update key.
+     *
+     */
+    static constexpr uint8_t kSignatoryFlagGeneral = 1 << 0;
 
     /**
      * This method initializes the KEY Resource Record by setting its type and class.
@@ -2066,12 +2004,9 @@ public:
     void SetAlgorithm(uint8_t aAlgorithm) { mAlgorithm = aAlgorithm; }
 
 private:
-    enum : uint8_t
-    {
-        kUseFlagsMask       = 0xc0, // top two bits in the first flag byte.
-        kOwnerFlagsMask     = 0x03, // lowest two bits in the first flag byte.
-        kSignatoryFlagsMask = 0x0f, // lower 4 bits in the second flag byte.
-    };
+    static constexpr uint8_t kUseFlagsMask       = 0xc0; // top two bits in the first flag byte.
+    static constexpr uint8_t kOwnerFlagsMask     = 0x03; // lowest two bits in the first flag byte.
+    static constexpr uint8_t kSignatoryFlagsMask = 0x0f; // lower 4 bits in the second flag byte.
 
     // Flags format:
     //
@@ -2132,10 +2067,7 @@ OT_TOOL_PACKED_BEGIN
 class SigRecord : public ResourceRecord, public Clearable<SigRecord>
 {
 public:
-    enum : uint16_t
-    {
-        kType = kTypeSig, ///< The SIG record type.
-    };
+    static constexpr uint16_t kType = kTypeSig; ///< The SIG record type.
 
     /**
      * This method initializes the SIG Resource Record by setting its type and class.
@@ -2322,10 +2254,7 @@ OT_TOOL_PACKED_BEGIN
 class OptRecord : public ResourceRecord
 {
 public:
-    enum : uint16_t
-    {
-        kType = kTypeOpt, ///< The OPT record type.
-    };
+    static constexpr uint16_t kType = kTypeOpt; ///< The OPT record type.
 
     /**
      * This method initializes the OPT Resource Record by setting its type and clearing extended Response Code, version
@@ -2431,13 +2360,10 @@ private:
     //
     // The variable data part of OPT RR can contain zero of more `Option`.
 
-    enum : uint8_t
-    {
-        kExtRCodeByteIndex = 0,      // Byte index of Extended RCODE within the TTL field.
-        kVersionByteIndex  = 1,      // Byte index of Version within the TTL field.
-        kFlagByteIndex     = 2,      // Byte index of flag byte within the TTL field.
-        kDnsSecFlag        = 1 << 7, // DNSSec OK bit flag.
-    };
+    static constexpr uint8_t kExtRCodeByteIndex = 0;      // Byte index of Extended RCODE within the TTL field.
+    static constexpr uint8_t kVersionByteIndex  = 1;      // Byte index of Version within the TTL field.
+    static constexpr uint8_t kFlagByteIndex     = 2;      // Byte index of flag byte within the TTL field.
+    static constexpr uint8_t kDnsSecFlag        = 1 << 7; // DNSSec OK bit flag.
 
     uint8_t  GetTtlByteAt(uint8_t aIndex) const { return reinterpret_cast<const uint8_t *>(&mTtl)[aIndex]; }
     uint8_t &GetTtlByteAt(uint8_t aIndex) { return reinterpret_cast<uint8_t *>(&mTtl)[aIndex]; }
@@ -2452,14 +2378,7 @@ OT_TOOL_PACKED_BEGIN
 class Option
 {
 public:
-    /**
-     * This enumeration defines option code values.
-     *
-     */
-    enum : uint16_t
-    {
-        kUpdateLease = 2, ///< Update lease option code.
-    };
+    static constexpr uint16_t kUpdateLease = 2; ///< Update lease option code.
 
     /**
      * This method returns the option code value.
@@ -2519,10 +2438,7 @@ OT_TOOL_PACKED_BEGIN
 class LeaseOption : public Option
 {
 public:
-    enum : uint16_t
-    {
-        kOptionLength = sizeof(uint32_t) + sizeof(uint32_t), ///< Option length (lease and key lease values)
-    };
+    static constexpr uint16_t kOptionLength = sizeof(uint32_t) + sizeof(uint32_t); ///< lease and key lease values
 
     /**
      * This method initialize the Update Lease Option by setting the Option Code and Option Length.

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -160,10 +160,7 @@ private:
         {
         }
 
-        enum : uint16_t
-        {
-            kUnknownOffset = 0, // Unknown offset value (used when offset is not yet set).
-        };
+        static constexpr uint16_t kUnknownOffset = 0; // Unknown offset value (used when offset is not yet set).
 
         uint16_t GetDomainNameOffset(void) const { return mDomainNameOffset; }
 
@@ -227,21 +224,15 @@ private:
         uint16_t    mHostNameOffset;     // Offset of host name serialization into the response message.
     };
 
-    enum
-    {
-        kPort                 = OPENTHREAD_CONFIG_DNSSD_SERVER_PORT,
-        kProtocolLabelLength  = 4,
-        kSubTypeLabelLength   = 4,
-        kMaxConcurrentQueries = 32,
-    };
+    static constexpr uint16_t kPort                 = OPENTHREAD_CONFIG_DNSSD_SERVER_PORT;
+    static constexpr uint8_t  kProtocolLabelLength  = 4;
+    static constexpr uint8_t  kSubTypeLabelLength   = 4;
+    static constexpr uint16_t kMaxConcurrentQueries = 32;
 
     // This structure represents the splitting information of a full name.
     struct NameComponentsOffsetInfo
     {
-        enum : uint8_t
-        {
-            kNotPresent = 0xff, // Indicates the component is not present.
-        };
+        static constexpr uint8_t kNotPresent = 0xff; // Indicates the component is not present.
 
         explicit NameComponentsOffsetInfo(void)
             : mDomainOffset(kNotPresent)
@@ -301,10 +292,7 @@ private:
         TimeMilli        mStartTime;
     };
 
-    enum : uint32_t
-    {
-        kQueryTimeout = OPENTHREAD_CONFIG_DNSSD_QUERY_TIMEOUT,
-    };
+    static constexpr uint32_t kQueryTimeout = OPENTHREAD_CONFIG_DNSSD_QUERY_TIMEOUT;
 
     bool        IsRunning(void) const { return mSocket.IsBound(); }
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -101,13 +101,10 @@ public:
             kCodeFragmReasTimeEx   = OT_ICMP6_CODE_FRAGM_REAS_TIME_EX,   ///< Fragment Reassembly Time Exceeded
         };
 
-        enum : uint8_t
-        {
-            kTypeFieldOffset     = 0, ///< The byte offset of Type field in ICMP6 header.
-            kCodeFieldOffset     = 1, ///< The byte offset of Code field in ICMP6 header.
-            kChecksumFieldOffset = 2, ///< The byte offset of Checksum field in ICMP6 header.
-            kDataFieldOffset     = 4, ///< The byte offset of Data field in ICMP6 header.
-        };
+        static constexpr uint8_t kTypeFieldOffset     = 0; ///< The byte offset of Type field in ICMP6 header.
+        static constexpr uint8_t kCodeFieldOffset     = 1; ///< The byte offset of Code field in ICMP6 header.
+        static constexpr uint8_t kChecksumFieldOffset = 2; ///< The byte offset of Checksum field in ICMP6 header.
+        static constexpr uint8_t kDataFieldOffset     = 4; ///< The byte offset of Data field in ICMP6 header.
 
         /**
          * This method indicates whether the ICMPv6 message is an error message.

--- a/src/core/net/ip4_address.cpp
+++ b/src/core/net/ip4_address.cpp
@@ -41,11 +41,8 @@ namespace Ip4 {
 
 Error Address::FromString(const char *aString)
 {
-    enum : char
-    {
-        kSeperatorChar = '.',
-        kNullChar      = '\0',
-    };
+    constexpr char kSeperatorChar = '.';
+    constexpr char kNullChar      = '\0';
 
     Error error = kErrorParse;
 

--- a/src/core/net/ip4_address.hpp
+++ b/src/core/net/ip4_address.hpp
@@ -52,11 +52,8 @@ OT_TOOL_PACKED_BEGIN
 class Address : public Equatable<Address>, public Clearable<Address>
 {
 public:
-    enum : uint8_t
-    {
-        kSize              = 4,  ///< Size of an IPv4 Address (in bytes).
-        kAddressStringSize = 17, ///< String size used by `ToString()`.
-    };
+    static constexpr uint16_t kSize              = 4;  ///< Size of an IPv4 Address (in bytes).
+    static constexpr uint16_t kAddressStringSize = 17; ///< String size used by `ToString()`.
 
     /**
      * This type defines the fixed-length `String` object returned from `ToString()`.

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -108,20 +108,17 @@ class Ip6 : public InstanceLocator, private NonCopyable
     friend class Mpl;
 
 public:
-    enum : uint16_t
-    {
-        /**
-         * The max datagram length (in bytes) of an IPv6 message.
-         *
-         */
-        kMaxDatagramLength = OPENTHREAD_CONFIG_IP6_MAX_DATAGRAM_LENGTH,
+    /**
+     * The max datagram length (in bytes) of an IPv6 message.
+     *
+     */
+    static constexpr uint16_t kMaxDatagramLength = OPENTHREAD_CONFIG_IP6_MAX_DATAGRAM_LENGTH;
 
-        /**
-         * The max datagram length (in bytes) of an unfragmented IPv6 message.
-         *
-         */
-        kMaxAssembledDatagramLength = OPENTHREAD_CONFIG_IP6_MAX_ASSEMBLED_DATAGRAM,
-    };
+    /**
+     * The max datagram length (in bytes) of an unfragmented IPv6 message.
+     *
+     */
+    static constexpr uint16_t kMaxAssembledDatagramLength = OPENTHREAD_CONFIG_IP6_MAX_ASSEMBLED_DATAGRAM;
 
     /**
      * This constructor initializes the object.
@@ -309,21 +306,12 @@ public:
     static const char *IpProtoToString(uint8_t aIpProto);
 
 private:
-    enum : uint8_t
-    {
-        kDefaultHopLimit      = OPENTHREAD_CONFIG_IP6_HOP_LIMIT_DEFAULT,
-        kIp6ReassemblyTimeout = OPENTHREAD_CONFIG_IP6_REASSEMBLY_TIMEOUT,
-    };
+    static constexpr uint8_t kDefaultHopLimit      = OPENTHREAD_CONFIG_IP6_HOP_LIMIT_DEFAULT;
+    static constexpr uint8_t kIp6ReassemblyTimeout = OPENTHREAD_CONFIG_IP6_REASSEMBLY_TIMEOUT;
 
-    enum : uint16_t
-    {
-        kMinimalMtu = 1280,
-    };
+    static constexpr uint16_t kMinimalMtu = 1280;
 
-    enum : uint32_t
-    {
-        kStateUpdatePeriod = 1000,
-    };
+    static constexpr uint32_t kStateUpdatePeriod = 1000;
 
     static void HandleSendQueue(Tasklet &aTasklet);
     void        HandleSendQueue(void);

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -491,10 +491,7 @@ void Address::SynthesizeFromIp4Address(const Prefix &aPrefix, const Ip4::Address
     //    |96|     prefix                                    |    v4(32)     |
     //    +--+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---+
 
-    enum : uint8_t
-    {
-        kSkipIndex = 8,
-    };
+    constexpr uint8_t kSkipIndex = 8;
 
     uint8_t ip6Index;
 
@@ -518,17 +515,10 @@ void Address::SynthesizeFromIp4Address(const Prefix &aPrefix, const Ip4::Address
 
 Error Address::FromString(const char *aString)
 {
-    enum : uint8_t
-    {
-        kInvalidIndex = 0xff,
-    };
-
-    enum : char
-    {
-        kColonChar = ':',
-        kDotChar   = '.',
-        kNullChar  = '\0',
-    };
+    constexpr uint8_t kInvalidIndex = 0xff;
+    constexpr char    kColonChar    = ':';
+    constexpr char    kDotChar      = '.';
+    constexpr char    kNullChar     = '\0';
 
     Error   error      = kErrorParse;
     uint8_t index      = 0;

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -67,11 +67,8 @@ OT_TOOL_PACKED_BEGIN
 class NetworkPrefix : public otIp6NetworkPrefix, public Equatable<NetworkPrefix>, public Clearable<NetworkPrefix>
 {
 public:
-    enum
-    {
-        kSize   = OT_IP6_PREFIX_SIZE,            ///< Size in bytes.
-        kLength = OT_IP6_PREFIX_SIZE * CHAR_BIT, ///< Length of Network Prefix in bits.
-    };
+    static constexpr uint8_t kSize   = OT_IP6_PREFIX_SIZE;            ///< Size in bytes.
+    static constexpr uint8_t kLength = OT_IP6_PREFIX_SIZE * CHAR_BIT; ///< Length of Network Prefix in bits.
 
     /**
      * This method generates and sets the Network Prefix to a crypto-secure random Unique Local Address (ULA) based
@@ -93,16 +90,10 @@ OT_TOOL_PACKED_BEGIN
 class Prefix : public otIp6Prefix, public Clearable<Prefix>, public Unequatable<Prefix>
 {
 public:
-    enum : uint8_t
-    {
-        kMaxLength = OT_IP6_ADDRESS_SIZE * CHAR_BIT, ///< Max length of a prefix in bits.
-        kMaxSize   = OT_IP6_ADDRESS_SIZE,            ///< Max (byte) size of a prefix.
-    };
+    static constexpr uint8_t kMaxLength = OT_IP6_ADDRESS_SIZE * CHAR_BIT; ///< Max length of a prefix in bits.
+    static constexpr uint8_t kMaxSize   = OT_IP6_ADDRESS_SIZE;            ///< Max (byte) size of a prefix.
 
-    enum : uint16_t
-    {
-        kInfoStringSize = OT_IP6_PREFIX_STRING_SIZE, ///< Max chars for the info string (`ToString()`).
-    };
+    static constexpr uint16_t kInfoStringSize = OT_IP6_PREFIX_STRING_SIZE; ///< Info string size (`ToString()`).
 
     /**
      * This type defines the fixed-length `String` object returned from `ToString()`.
@@ -312,11 +303,9 @@ class InterfaceIdentifier : public otIp6InterfaceIdentifier,
     friend class Address;
 
 public:
-    enum
-    {
-        kSize           = OT_IP6_IID_SIZE, ///< Size of an IPv6 Interface Identifier (in bytes).
-        kInfoStringSize = 17,              ///< Max chars for the info string (`ToString()`).
-    };
+    static constexpr uint8_t kSize = OT_IP6_IID_SIZE; ///< Size of an IPv6 Interface Identifier (in bytes).
+
+    static constexpr uint16_t kInfoStringSize = 17; ///< Max chars for the info string (`ToString()`).
 
     /**
      * This type defines the fixed-length `String` object returned from `ToString()`.
@@ -492,11 +481,8 @@ public:
     InfoString ToString(void) const;
 
 private:
-    enum : uint8_t
-    {
-        kAloc16Mask            = 0xfc, // The mask for Aloc16.
-        kRloc16ReservedBitMask = 0x02, // The mask for the reserved bit of Rloc16.
-    };
+    static constexpr uint8_t kAloc16Mask            = 0xfc; // The mask for ALOC16.
+    static constexpr uint8_t kRloc16ReservedBitMask = 0x02; // The mask for the reserved bit of RLOC16.
 
 } OT_TOOL_PACKED_END;
 
@@ -510,39 +496,21 @@ class Address : public otIp6Address, public Equatable<Address>, public Clearable
     friend class Prefix;
 
 public:
-    /**
-     * Masks
-     *
-     */
-    enum
-    {
-        kAloc16Mask = InterfaceIdentifier::kAloc16Mask, ///< The mask for Aloc16.
-    };
+    static constexpr uint8_t kAloc16Mask = InterfaceIdentifier::kAloc16Mask; ///< The mask for ALOC16.
 
-    /**
-     * Constants
-     *
-     */
-    enum
-    {
-        kSize           = OT_IP6_ADDRESS_SIZE,        ///< Size of an IPv6 Address (in bytes).
-        kInfoStringSize = OT_IP6_ADDRESS_STRING_SIZE, ///< Max string size for an IPv6 address in string format.
-    };
+    static constexpr uint8_t kSize = OT_IP6_ADDRESS_SIZE; ///< Size of an IPv6 Address (in bytes).
 
-    /**
-     * IPv6 Address Scopes
-     */
-    enum
-    {
-        kNodeLocalScope      = 0,  ///< Node-Local scope
-        kInterfaceLocalScope = 1,  ///< Interface-Local scope
-        kLinkLocalScope      = 2,  ///< Link-Local scope
-        kRealmLocalScope     = 3,  ///< Realm-Local scope
-        kAdminLocalScope     = 4,  ///< Admin-Local scope
-        kSiteLocalScope      = 5,  ///< Site-Local scope
-        kOrgLocalScope       = 8,  ///< Organization-Local scope
-        kGlobalScope         = 14, ///< Global scope
-    };
+    static constexpr uint16_t kInfoStringSize = OT_IP6_ADDRESS_STRING_SIZE; ///< String Size for IPv6 address.
+
+    // IPv6 Address Scopes
+    static constexpr uint8_t kNodeLocalScope      = 0;  ///< Node-Local scope
+    static constexpr uint8_t kInterfaceLocalScope = 1;  ///< Interface-Local scope
+    static constexpr uint8_t kLinkLocalScope      = 2;  ///< Link-Local scope
+    static constexpr uint8_t kRealmLocalScope     = 3;  ///< Realm-Local scope
+    static constexpr uint8_t kAdminLocalScope     = 4;  ///< Admin-Local scope
+    static constexpr uint8_t kSiteLocalScope      = 5;  ///< Site-Local scope
+    static constexpr uint8_t kOrgLocalScope       = 8;  ///< Organization-Local scope
+    static constexpr uint8_t kGlobalScope         = 14; ///< Global scope
 
     /**
      * This enumeration defines IPv6 address type filter.
@@ -983,11 +951,8 @@ private:
     static const Address &GetRealmLocalAllRoutersMulticast(void);
     static const Address &GetRealmLocalAllMplForwarders(void);
 
-    enum
-    {
-        kMulticastNetworkPrefixLengthOffset = 3, ///< Prefix-Based Multicast Address (RFC3306).
-        kMulticastNetworkPrefixOffset       = 4, ///< Prefix-Based Multicast Address (RFC3306).
-    };
+    static constexpr uint8_t kMulticastNetworkPrefixLengthOffset = 3; // Prefix-Based Multicast Address (RFC3306).
+    static constexpr uint8_t kMulticastNetworkPrefixOffset       = 4; // Prefix-Based Multicast Address (RFC3306).
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/net/ip6_filter.hpp
+++ b/src/core/net/ip6_filter.hpp
@@ -132,10 +132,8 @@ public:
     const uint16_t *GetUnsecurePorts(uint8_t &aNumEntries) const;
 
 private:
-    enum
-    {
-        kMaxUnsecurePorts = 2,
-    };
+    static constexpr uint16_t kMaxUnsecurePorts = 2;
+
     uint16_t mUnsecurePorts[kMaxUnsecurePorts];
 };
 

--- a/src/core/net/ip6_headers.hpp
+++ b/src/core/net/ip6_headers.hpp
@@ -85,26 +85,21 @@ using ot::Encoding::BigEndian::HostSwap32;
  *
  */
 
-/**
- * Internet Protocol Numbers
- */
-enum
-{
-    kProtoHopOpts  = 0,  ///< IPv6 Hop-by-Hop Option
-    kProtoTcp      = 6,  ///< Transmission Control Protocol
-    kProtoUdp      = 17, ///< User Datagram
-    kProtoIp6      = 41, ///< IPv6 encapsulation
-    kProtoRouting  = 43, ///< Routing Header for IPv6
-    kProtoFragment = 44, ///< Fragment Header for IPv6
-    kProtoIcmp6    = 58, ///< ICMP for IPv6
-    kProtoNone     = 59, ///< No Next Header for IPv6
-    kProtoDstOpts  = 60, ///< Destination Options for IPv6
-};
+// Internet Protocol Numbers
+static constexpr uint8_t kProtoHopOpts  = 0;  ///< IPv6 Hop-by-Hop Option
+static constexpr uint8_t kProtoTcp      = 6;  ///< Transmission Control Protocol
+static constexpr uint8_t kProtoUdp      = 17; ///< User Datagram
+static constexpr uint8_t kProtoIp6      = 41; ///< IPv6 encapsulation
+static constexpr uint8_t kProtoRouting  = 43; ///< Routing Header for IPv6
+static constexpr uint8_t kProtoFragment = 44; ///< Fragment Header for IPv6
+static constexpr uint8_t kProtoIcmp6    = 58; ///< ICMP for IPv6
+static constexpr uint8_t kProtoNone     = 59; ///< No Next Header for IPv6
+static constexpr uint8_t kProtoDstOpts  = 60; ///< Destination Options for IPv6
 
 /**
  * Class Selectors
  */
-enum IpDscpCs
+enum IpDscpCs : uint8_t
 {
     kDscpCs0    = 0,    ///< Class selector codepoint 0
     kDscpCs1    = 8,    ///< Class selector codepoint 8
@@ -125,14 +120,11 @@ OT_TOOL_PACKED_BEGIN
 class Header
 {
 public:
-    enum : uint8_t
-    {
-        kPayloadLengthFieldOffset = 4,  ///< The byte offset of Payload Length field in IPv6 header.
-        kNextHeaderFieldOffset    = 6,  ///< The byte offset of Next Header field in IPv6 header.
-        kHopLimitFieldOffset      = 7,  ///< The byte offset of Hop Limit field in IPv6 header.
-        kSourceFieldOffset        = 8,  ///< The byte offset of Source Address field in IPv6 header.
-        kDestinationFieldOffset   = 24, ///< The byte offset of Destination Address field in IPv6 header.
-    };
+    static constexpr uint8_t kPayloadLengthFieldOffset = 4;  ///< Offset of Payload Length field in IPv6 header.
+    static constexpr uint8_t kNextHeaderFieldOffset    = 6;  ///< Offset of Next Header field in IPv6 header.
+    static constexpr uint8_t kHopLimitFieldOffset      = 7;  ///< Offset of Hop Limit field in IPv6 header.
+    static constexpr uint8_t kSourceFieldOffset        = 8;  ///< Offset of Source Address field in IPv6 header.
+    static constexpr uint8_t kDestinationFieldOffset   = 24; ///< Offset of Destination Address field in IPv6 header.
 
     /**
      * This method initializes the IPv6 header.
@@ -295,22 +287,11 @@ public:
     void SetDestination(const Address &aDestination) { mDestination = aDestination; }
 
 private:
-    enum : uint8_t
-    {
-        kVersion6    = 0x60,
-        kVersionMask = 0xf0, // To use with `mVersionClassFlow.m8[0]`
-        kDscpOffset  = 6,    // To use with `mVersionClassFlow.m16[0]`
-    };
-
-    enum : uint16_t
-    {
-        kDscpMask = 0x0fc0, // To use with `mVersionClassFlow.m16[0]`
-    };
-
-    enum : uint32_t
-    {
-        kVersionClassFlowInit = 0x60000000, // Version 6, TC and flow zero.
-    };
+    static constexpr uint8_t  kVersion6             = 0x60;
+    static constexpr uint8_t  kVersionMask          = 0xf0;       // To use with `mVersionClassFlow.m8[0]`
+    static constexpr uint8_t  kDscpOffset           = 6;          // To use with `mVersionClassFlow.m16[0]`
+    static constexpr uint16_t kDscpMask             = 0x0fc0;     // To use with `mVersionClassFlow.m16[0]`
+    static constexpr uint32_t kVersionClassFlowInit = 0x60000000; // Version 6, TC and flow zero.
 
     union OT_TOOL_PACKED_FIELD
     {
@@ -450,10 +431,7 @@ public:
     void SetLength(uint8_t aLength) { mLength = aLength; }
 
 private:
-    enum : uint8_t
-    {
-        kActionMask = 0xc0,
-    };
+    static constexpr uint8_t kActionMask = 0xc0;
 
     uint8_t mType;
     uint8_t mLength;
@@ -467,12 +445,9 @@ OT_TOOL_PACKED_BEGIN
 class OptionPadN : public OptionHeader
 {
 public:
-    enum
-    {
-        kType      = 0x01, ///< PadN type
-        kData      = 0x00, ///< PadN specific data
-        kMaxLength = 0x05  ///< Maximum length of PadN option data
-    };
+    static constexpr uint8_t kType      = 0x01; ///< PadN type
+    static constexpr uint8_t kData      = 0x00; ///< PadN specific data
+    static constexpr uint8_t kMaxLength = 0x05; ///< Maximum length of PadN option data
 
     /**
      * This method initializes the PadN header.
@@ -483,8 +458,8 @@ public:
      */
     void Init(uint8_t aPadLength)
     {
-        OptionHeader::SetType(kType);
-        OptionHeader::SetLength(aPadLength - sizeof(OptionHeader));
+        SetType(kType);
+        SetLength(aPadLength - sizeof(OptionHeader));
         memset(mPad, kData, aPadLength - sizeof(OptionHeader));
     }
 
@@ -495,7 +470,7 @@ public:
      * @returns The total IPv6 Option Length.
      *
      */
-    uint8_t GetTotalLength(void) const { return OptionHeader::GetLength() + sizeof(OptionHeader); }
+    uint8_t GetTotalLength(void) const { return GetLength() + sizeof(OptionHeader); }
 
 private:
     uint8_t mPad[kMaxLength];
@@ -509,10 +484,7 @@ OT_TOOL_PACKED_BEGIN
 class OptionPad1
 {
 public:
-    enum
-    {
-        kType = 0x00
-    };
+    static constexpr uint8_t kType = 0x00;
 
     /**
      * This method initializes the Pad1 header.
@@ -644,15 +616,12 @@ public:
     static inline uint16_t BytesToFragmentOffset(uint16_t aOffset) { return aOffset >> 3; }
 
 private:
-    uint8_t mNextHeader;
-    uint8_t mReserved;
+    static constexpr uint8_t  kOffsetOffset = 3;
+    static constexpr uint16_t kOffsetMask   = 0xfff8;
+    static constexpr uint16_t kMoreFlag     = 1;
 
-    enum
-    {
-        kOffsetOffset = 3,
-        kOffsetMask   = 0xfff8,
-        kMoreFlag     = 1,
-    };
+    uint8_t  mNextHeader;
+    uint8_t  mReserved;
     uint16_t mOffsetMore;
     uint32_t mIdentification;
 } OT_TOOL_PACKED_END;

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -63,11 +63,8 @@ OT_TOOL_PACKED_BEGIN
 class OptionMpl : public OptionHeader
 {
 public:
-    enum
-    {
-        kType      = 0x6d, /* 01 1 01101 */
-        kMinLength = 2
-    };
+    static constexpr uint8_t kType      = 0x6d; // 01 1 01101
+    static constexpr uint8_t kMinLength = 2;
 
     /**
      * This method initializes the MPL header.
@@ -91,8 +88,9 @@ public:
 
     /**
      * MPL Seed Id lengths.
+     *
      */
-    enum SeedIdLength
+    enum SeedIdLength : uint8_t
     {
         kSeedIdLength0  = 0 << 6, ///< 0-byte MPL Seed Id Length.
         kSeedIdLength2  = 1 << 6, ///< 2-byte MPL Seed Id Length.
@@ -173,11 +171,9 @@ public:
     void SetSeedId(uint16_t aSeedId) { mSeedId = HostSwap16(aSeedId); }
 
 private:
-    enum
-    {
-        kSeedIdLengthMask = 3 << 6,
-        kMaxFlag          = 1 << 5
-    };
+    static constexpr uint8_t kSeedIdLengthMask = 3 << 6;
+    static constexpr uint8_t kMaxFlag          = 1 << 5;
+
     uint8_t  mControl;
     uint8_t  mSequence;
     uint16_t mSeedId;
@@ -278,13 +274,10 @@ public:
 #endif // OPENTHREAD_FTD
 
 private:
-    enum
-    {
-        kNumSeedEntries      = OPENTHREAD_CONFIG_MPL_SEED_SET_ENTRIES,
-        kSeedEntryLifetime   = OPENTHREAD_CONFIG_MPL_SEED_SET_ENTRY_LIFETIME,
-        kSeedEntryLifetimeDt = 1000,
-        kDataMessageInterval = 64
-    };
+    static constexpr uint16_t kNumSeedEntries      = OPENTHREAD_CONFIG_MPL_SEED_SET_ENTRIES;
+    static constexpr uint32_t kSeedEntryLifetime   = OPENTHREAD_CONFIG_MPL_SEED_SET_ENTRY_LIFETIME;
+    static constexpr uint32_t kSeedEntryLifetimeDt = 1000;
+    static constexpr uint8_t  kDataMessageInterval = 64;
 
     struct SeedEntry
     {

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -299,7 +299,7 @@ public:
         }
 
     private:
-        enum IteratorType
+        enum IteratorType : uint8_t
         {
             kEndIterator,
         };

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -146,7 +146,7 @@ Error Client::Query(const otSntpQuery *aQuery, otSntpResponseHandler aHandler, v
     messageInfo = static_cast<const Ip6::MessageInfo *>(aQuery->mMessageInfo);
 
     queryMetadata.mTransmitTimestamp   = header.GetTransmitTimestampSeconds();
-    queryMetadata.mTransmissionTime    = TimerMilli::GetNow() + static_cast<uint32_t>(kResponseTimeout);
+    queryMetadata.mTransmissionTime    = TimerMilli::GetNow() + kResponseTimeout;
     queryMetadata.mSourceAddress       = messageInfo->GetSockAddr();
     queryMetadata.mDestinationPort     = messageInfo->GetPeerPort();
     queryMetadata.mDestinationAddress  = messageInfo->GetPeerAddr();

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -69,20 +69,13 @@ public:
      * Defines supported SNTP modes.
      *
      */
-    enum Mode
+    enum Mode : uint8_t
     {
         kModeClient = 3,
         kModeServer = 4,
     };
 
-    /**
-     * Kiss code length.
-     *
-     */
-    enum
-    {
-        kKissCodeLength = 4, ///< Length of the kiss code in ASCII format
-    };
+    static constexpr uint8_t kKissCodeLength = 4; ///< Length of the kiss code in ASCII format
 
     /**
      * This method returns the flags field value.
@@ -365,53 +358,29 @@ public:
     }
 
 private:
-    /**
-     * Protocol Constants (RFC 5905).
-     *
-     */
-    enum
-    {
-        /**
-         * Current NTP version.
-         *
-         */
-        kNtpVersion = 4,
+    static constexpr uint8_t kNtpVersion    = 4;                      // Current NTP version.
+    static constexpr uint8_t kLeapOffset    = 6;                      // Leap Indicator field offset.
+    static constexpr uint8_t kLeapMask      = 0x03 << kLeapOffset;    // Leap Indicator field mask.
+    static constexpr uint8_t kVersionOffset = 3;                      // Version field offset.
+    static constexpr uint8_t kVersionMask   = 0x07 << kVersionOffset; // Version field mask.
+    static constexpr uint8_t kModeOffset    = 0;                      // Mode field offset.
+    static constexpr uint8_t kModeMask      = 0x07 << kModeOffset;    // Mode filed mask.
 
-        /**
-         * Flags offsets and masks.
-         *
-         */
-        kLeapOffset    = 6,                      ///< Leap Indicator field offset.
-        kLeapMask      = 0x03 << kLeapOffset,    ///< Leap Indicator field mask.
-        kVersionOffset = 3,                      ///< Version field offset.
-        kVersionMask   = 0x07 << kVersionOffset, ///< Version field mask.
-        kModeOffset    = 0,                      ///< Mode field offset.
-        kModeMask      = 0x07 << kModeOffset,    ///< Mode filed mask.
-    };
-
-    /**
-     * SNTP Header fields.
-     *
-     */
-    uint8_t  mFlags;                      ///< SNTP flags: LI Leap Indicator, VN Version Number and Mode.
-    uint8_t  mStratum;                    ///< Packet Stratum.
-    uint8_t  mPoll;                       ///< Maximum interval between successive messages, in log2 seconds.
-    uint8_t  mPrecision;                  ///< The precision of the system clock, in log2 seconds.
-    uint32_t mRootDelay;                  ///< Total round-trip delay to the reference clock, in NTP short format.
-    uint32_t mRootDispersion;             ///< Total dispersion to the reference clock.
-    uint32_t mReferenceId;                ///< ID identifying the particular server or reference clock.
-    uint32_t mReferenceTimestampSeconds;  ///< Time when the system clock was last set or corrected, in NTP
-                                          ///< timestamp format.
-    uint32_t mReferenceTimestampFraction; ///< Fraction part of above value.
-    uint32_t mOriginateTimestampSeconds;  ///< Time at the client when the request departed for the server, in NTP
-                                          ///< timestamp format.
-    uint32_t mOriginateTimestampFraction; ///< Fraction part of above value.
-    uint32_t mReceiveTimestampSeconds;    ///< Time at the server when the request arrived from the client, in NTP
-                                          ///< timestamp format.
-    uint32_t mReceiveTimestampFraction;   ///< Fraction part of above value.
-    uint32_t mTransmitTimestampSeconds;   ///< Time at the server when the response left for the client, in NTP
-                                          ///< timestamp format.
-    uint32_t mTransmitTimestampFraction;  ///< Fraction part of above value.
+    uint8_t  mFlags;                      // SNTP flags: LI Leap Indicator, VN Version Number and Mode.
+    uint8_t  mStratum;                    // Packet Stratum.
+    uint8_t  mPoll;                       // Maximum interval between successive messages, in log2 seconds.
+    uint8_t  mPrecision;                  // The precision of the system clock, in log2 seconds.
+    uint32_t mRootDelay;                  // Total round-trip delay to the reference clock, in NTP short format.
+    uint32_t mRootDispersion;             // Total dispersion to the reference clock.
+    uint32_t mReferenceId;                // ID identifying the particular server or reference clock.
+    uint32_t mReferenceTimestampSeconds;  // Time the system clock was last set or corrected (NTP format).
+    uint32_t mReferenceTimestampFraction; // Fraction part of above value.
+    uint32_t mOriginateTimestampSeconds;  // Time at the client when the request departed for the server (NTP format).
+    uint32_t mOriginateTimestampFraction; // Fraction part of above value.
+    uint32_t mReceiveTimestampSeconds;    // Time at the server when the request arrived from the client (NTP format).
+    uint32_t mReceiveTimestampFraction;   // Fraction part of above value.
+    uint32_t mTransmitTimestampSeconds;   // Time at the server when the response left for the client (NTP format).
+    uint32_t mTransmitTimestampFraction;  // Fraction part of above value.
 } OT_TOOL_PACKED_END;
 
 /**
@@ -544,28 +513,10 @@ public:
     Error Query(const otSntpQuery *aQuery, otSntpResponseHandler aHandler, void *aContext);
 
 private:
-    /**
-     * Protocol Constants (RFC 5905).
-     *
-     */
-    enum
-    {
-        /**
-         * Number of seconds between 1st January 1900 and 1st January 1970.
-         *
-         */
-        kTimeAt1970 = 2208988800UL,
-    };
+    static constexpr uint32_t kTimeAt1970 = 2208988800UL; // num seconds between 1st Jan 1900 and 1st Jan 1970.
 
-    /**
-     * Retransmission parameters.
-     *
-     */
-    enum
-    {
-        kResponseTimeout = OPENTHREAD_CONFIG_SNTP_CLIENT_RESPONSE_TIMEOUT,
-        kMaxRetransmit   = OPENTHREAD_CONFIG_SNTP_CLIENT_MAX_RETRANSMIT,
-    };
+    static constexpr uint32_t kResponseTimeout = OPENTHREAD_CONFIG_SNTP_CLIENT_RESPONSE_TIMEOUT;
+    static constexpr uint8_t  kMaxRetransmit   = OPENTHREAD_CONFIG_SNTP_CLIENT_MAX_RETRANSMIT;
 
     Message *NewMessage(const Header &aHeader);
     Message *CopyAndEnqueueMessage(const Message &aMessage, const QueryMetadata &aQueryMetadata);

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -237,10 +237,7 @@ public:
 class SockAddr : public otSockAddr, public Clearable<SockAddr>, public Unequatable<SockAddr>
 {
 public:
-    enum : uint16_t
-    {
-        kInfoStringSize = OT_IP6_SOCK_ADDR_STRING_SIZE, ///< Max chars for the info string (`ToString()`).
-    };
+    static constexpr uint16_t kInfoStringSize = OT_IP6_SOCK_ADDR_STRING_SIZE; ///< Info string size (`ToString()`).
 
     /**
      * This type defines the fixed-length `String` object returned from `ToString()`.

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -726,10 +726,7 @@ exit:
 
 Error Client::PrepareUpdateMessage(Message &aMessage)
 {
-    enum : uint16_t
-    {
-        kHeaderOffset = 0,
-    };
+    constexpr uint16_t kHeaderOffset = 0;
 
     Error             error = kErrorNone;
     Dns::UpdateHeader header;
@@ -1909,11 +1906,7 @@ const char *Client::StateToString(State aState)
 
 void Client::LogRetryWaitInterval(void) const
 {
-    enum : uint16_t
-    {
-        kLogInMsecLimit = 5000, // Max interval (in msec) to log the value in msec unit
-        kMsecInSec      = 1000,
-    };
+    constexpr uint16_t kLogInMsecLimit = 5000; // Max interval (in msec) to log the value in msec unit
 
     uint32_t interval = GetRetryWaitInterval();
 

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -646,101 +646,95 @@ public:
 #endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 
 private:
-    enum : uint8_t
-    {
-        kFastPollsAfterUpdateTx = 11, // Number of fast data polls after SRP Update tx (11x 188ms = ~2 seconds)
+    // Number of fast data polls after SRP Update tx (11x 188ms = ~2 seconds)
+    static constexpr uint8_t kFastPollsAfterUpdateTx = 11;
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_SWITCH_SERVER_ON_FAILURE
-        kMaxTimeoutFailuresToSwitchServer = OPENTHREAD_CONFIG_SRP_CLIENT_MAX_TIMEOUT_FAILURES_TO_SWITCH_SERVER,
+    static constexpr uint8_t kMaxTimeoutFailuresToSwitchServer =
+        OPENTHREAD_CONFIG_SRP_CLIENT_MAX_TIMEOUT_FAILURES_TO_SWITCH_SERVER;
 #endif
-    };
 
-    enum : uint16_t
-    {
-        kUdpPayloadSize = Ip6::Ip6::kMaxDatagramLength - sizeof(Ip6::Udp::Header), // Max UDP payload size
-    };
+    static constexpr uint16_t kUdpPayloadSize = Ip6::Ip6::kMaxDatagramLength - sizeof(Ip6::Udp::Header);
 
-    enum : uint32_t
-    {
-        // -------------------------------
-        // Lease related constants
+    // -------------------------------
+    // Lease related constants
 
-        kDefaultLease    = OPENTHREAD_CONFIG_SRP_CLIENT_DEFAULT_LEASE,     // in seconds.
-        kDefaultKeyLease = OPENTHREAD_CONFIG_SRP_CLIENT_DEFAULT_KEY_LEASE, // in seconds.
+    static constexpr uint32_t kDefaultLease    = OPENTHREAD_CONFIG_SRP_CLIENT_DEFAULT_LEASE;     // in seconds.
+    static constexpr uint32_t kDefaultKeyLease = OPENTHREAD_CONFIG_SRP_CLIENT_DEFAULT_KEY_LEASE; // in seconds.
 
-        // The guard interval determines how much earlier (relative to
-        // the lease expiration time) the client will send an update
-        // to renew the lease.
-        kLeaseRenewGuardInterval = OPENTHREAD_CONFIG_SRP_CLIENT_LEASE_RENEW_GUARD_INTERVAL, // in seconds.
+    // The guard interval determines how much earlier (relative to
+    // the lease expiration time) the client will send an update
+    // to renew the lease. Value is in seconds.
+    static constexpr uint32_t kLeaseRenewGuardInterval = OPENTHREAD_CONFIG_SRP_CLIENT_LEASE_RENEW_GUARD_INTERVAL;
 
-        // Max allowed lease time to avoid timer roll-over (~24.8 days).
-        kMaxLease = (Timer::kMaxDelay / 1000) - 1,
+    // Max allowed lease time to avoid timer roll-over (~24.8 days).
+    static constexpr uint32_t kMaxLease = (Timer::kMaxDelay / 1000) - 1;
 
-        // Opportunistic early refresh: When sending an SRP update, the
-        // services that are not yet expired but are close, are allowed
-        // to refresh early and are included in the SRP update. This
-        // helps place more services on the same lease refresh schedule
-        // reducing number of messages sent to the SRP server. The
-        // "early lease renewal interval" is used to determine if a
-        // service can renew early. The interval is calculated by
-        // multiplying the accepted lease interval by the"early lease
-        // renewal factor" which is given as a fraction (numerator and
-        // denominator).
-        //
-        // If the factor is set to zero (numerator=0, denominator=1),
-        // the opportunistic early refresh behavior is disabled. If
-        // denominator is set to zero (the factor is set to infinity),
-        // then all services (including previously registered ones)
-        // are always included in SRP update message.
+    // Opportunistic early refresh: When sending an SRP update, the
+    // services that are not yet expired but are close, are allowed
+    // to refresh early and are included in the SRP update. This
+    // helps place more services on the same lease refresh schedule
+    // reducing number of messages sent to the SRP server. The
+    // "early lease renewal interval" is used to determine if a
+    // service can renew early. The interval is calculated by
+    // multiplying the accepted lease interval by the"early lease
+    // renewal factor" which is given as a fraction (numerator and
+    // denominator).
+    //
+    // If the factor is set to zero (numerator=0, denominator=1),
+    // the opportunistic early refresh behavior is disabled. If
+    // denominator is set to zero (the factor is set to infinity),
+    // then all services (including previously registered ones)
+    // are always included in SRP update message.
 
-        kEarlyLeaseRenewFactorNumerator   = OPENTHREAD_CONFIG_SRP_CLIENT_EARLY_LEASE_RENEW_FACTOR_NUMERATOR,
-        kEarlyLeaseRenewFactorDenominator = OPENTHREAD_CONFIG_SRP_CLIENT_EARLY_LEASE_RENEW_FACTOR_DENOMINATOR,
+    static constexpr uint32_t kEarlyLeaseRenewFactorNumerator =
+        OPENTHREAD_CONFIG_SRP_CLIENT_EARLY_LEASE_RENEW_FACTOR_NUMERATOR;
+    static constexpr uint32_t kEarlyLeaseRenewFactorDenominator =
+        OPENTHREAD_CONFIG_SRP_CLIENT_EARLY_LEASE_RENEW_FACTOR_DENOMINATOR;
 
-        // -------------------------------
-        // When there is a change (e.g., a new service is added/removed)
-        // that requires an update, the SRP client will wait for a short
-        // delay as specified by `kUpdateTxDelay` before sending an SRP
-        // update to server. This allows the user to provide more change
-        // that are then all sent in same update message.
-        kUpdateTxDelay = OPENTHREAD_CONFIG_SRP_CLIENT_UPDATE_TX_DELAY, // in msec.
+    // -------------------------------
+    // When there is a change (e.g., a new service is added/removed)
+    // that requires an update, the SRP client will wait for a short
+    // delay as specified by `kUpdateTxDelay` before sending an SRP
+    // update to server. This allows the user to provide more change
+    // that are then all sent in same update message.
+    static constexpr uint32_t kUpdateTxDelay = OPENTHREAD_CONFIG_SRP_CLIENT_UPDATE_TX_DELAY; // in msec.
 
-        // -------------------------------
-        // Retry related constants
-        //
-        // If the preparation or transmission of an SRP update message
-        // fails (e.g., no buffer to allocate the message), SRP client
-        // will retry after a short interval `kTxFailureRetryInterval`
-        // up to `kMaxTxFailureRetries` attempts. After this, the retry
-        // wait interval will be used (which keeps growing on each failure
-        // - please see bellow).
-        //
-        // If the update message is sent successfully but there is no
-        // response from server or if server rejects the update, the
-        // client will retransmit the update message after some wait
-        // interval. The wait interval starts from the minimum value and
-        // is increased by the growth factor on back-to-back failures up
-        // to the max value. The growth factor is given as a fraction
-        // (e.g., for 1.5, we can use 15 as the numerator and 10 as the
-        // denominator). A random jitter is added to the retry interval.
-        // If the current wait interval value is smaller than the jitter
-        // interval, then wait interval value itself is used as the
-        // jitter value. For example, with jitter interval of 2 seconds
-        // if the current retry interval is 800ms, then a random wait
-        // interval in [0,2*800] ms will be used.
+    // -------------------------------
+    // Retry related constants
+    //
+    // If the preparation or transmission of an SRP update message
+    // fails (e.g., no buffer to allocate the message), SRP client
+    // will retry after a short interval `kTxFailureRetryInterval`
+    // up to `kMaxTxFailureRetries` attempts. After this, the retry
+    // wait interval will be used (which keeps growing on each failure
+    // - please see bellow).
+    //
+    // If the update message is sent successfully but there is no
+    // response from server or if server rejects the update, the
+    // client will retransmit the update message after some wait
+    // interval. The wait interval starts from the minimum value and
+    // is increased by the growth factor on back-to-back failures up
+    // to the max value. The growth factor is given as a fraction
+    // (e.g., for 1.5, we can use 15 as the numerator and 10 as the
+    // denominator). A random jitter is added to the retry interval.
+    // If the current wait interval value is smaller than the jitter
+    // interval, then wait interval value itself is used as the
+    // jitter value. For example, with jitter interval of 2 seconds
+    // if the current retry interval is 800ms, then a random wait
+    // interval in [0,2*800] ms will be used.
 
-        kTxFailureRetryInterval               = 250, // in ms
-        kMaxTxFailureRetries                  = 8,   // num of quick retries after tx failure
-        kMinRetryWaitInterval                 = OPENTHREAD_CONFIG_SRP_CLIENT_MIN_RETRY_WAIT_INTERVAL, // in ms
-        kMaxRetryWaitInterval                 = OPENTHREAD_CONFIG_SRP_CLIENT_MAX_RETRY_WAIT_INTERVAL, // in ms
-        kRetryIntervalGrowthFactorNumerator   = OPENTHREAD_CONFIG_SRP_CLIENT_RETRY_INTERVAL_GROWTH_FACTOR_NUMERATOR,
-        kRetryIntervalGrowthFactorDenominator = OPENTHREAD_CONFIG_SRP_CLIENT_RETRY_INTERVAL_GROWTH_FACTOR_DENOMINATOR,
-    };
+    static constexpr uint32_t kTxFailureRetryInterval = 250; // in ms
+    static constexpr uint32_t kMaxTxFailureRetries    = 8;   // num of quick retries after tx failure
+    static constexpr uint32_t kMinRetryWaitInterval   = OPENTHREAD_CONFIG_SRP_CLIENT_MIN_RETRY_WAIT_INTERVAL; // in ms
+    static constexpr uint32_t kMaxRetryWaitInterval   = OPENTHREAD_CONFIG_SRP_CLIENT_MAX_RETRY_WAIT_INTERVAL; // in ms
+    static constexpr uint32_t kRetryIntervalGrowthFactorNumerator =
+        OPENTHREAD_CONFIG_SRP_CLIENT_RETRY_INTERVAL_GROWTH_FACTOR_NUMERATOR;
+    static constexpr uint32_t kRetryIntervalGrowthFactorDenominator =
+        OPENTHREAD_CONFIG_SRP_CLIENT_RETRY_INTERVAL_GROWTH_FACTOR_DENOMINATOR;
 
-    enum : uint16_t
-    {
-        kTxFailureRetryJitter = 10,                                                      // in ms
-        kRetryIntervalJitter  = OPENTHREAD_CONFIG_SRP_CLIENT_RETRY_WAIT_INTERVAL_JITTER, // in ms
-    };
+    static constexpr uint16_t kTxFailureRetryJitter = 10;                                                      // in ms
+    static constexpr uint16_t kRetryIntervalJitter  = OPENTHREAD_CONFIG_SRP_CLIENT_RETRY_WAIT_INTERVAL_JITTER; // in ms
 
     static_assert(kDefaultLease <= static_cast<uint32_t>(kMaxLease), "kDefaultLease is larger than max");
     static_assert(kDefaultKeyLease <= static_cast<uint32_t>(kMaxLease), "kDefaultKeyLease is larger than max");
@@ -755,20 +749,15 @@ private:
         kStateToRetry,  // SRP update tx failed, waiting to retry.
     };
 
-    enum : bool
-    {
-        kAutoStartDefaultMode = OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_DEFAULT_MODE,
-    };
+    static constexpr bool kAutoStartDefaultMode = OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_DEFAULT_MODE;
 
-    enum : uint16_t
-    {
-        kAnycastServerPort = 53, // Port number to use when server is discovered using "network data anycast service".
-    };
+    // Port number to use when server is discovered using "network data anycast service".
+    static constexpr uint16_t kAnycastServerPort = 53;
 
     // This enumeration type is used by the private `Start()` and
     // `Stop()` methods to indicate whether it is being requested by the
     // user or by the auto-start feature.
-    enum Requester
+    enum Requester : uint8_t
     {
         kRequesterUser,
 #if OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
@@ -786,10 +775,7 @@ private:
 
     struct Info : public Clearable<Info>
     {
-        enum : uint16_t
-        {
-            kUnknownOffset = 0, // Unknown offset value (used when offset is not yet set).
-        };
+        static constexpr uint16_t kUnknownOffset = 0; // Unknown offset value (used when offset is not yet set).
 
         uint16_t                     mDomainNameOffset; // Offset of domain name serialization
         uint16_t                     mHostNameOffset;   // Offset of host name serialization.

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -77,11 +77,8 @@ class Server : public InstanceLocator, private NonCopyable
     friend class Host;
 
 public:
-    enum : uint16_t
-    {
-        kUdpPortMin = OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT_MIN, ///< The reserved min SRP Server UDP listening port.
-        kUdpPortMax = OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT_MAX, ///< The reserved max SRP Server UDP listening port.
-    };
+    static constexpr uint16_t kUdpPortMin = OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT_MIN; ///< The reserved min port.
+    static constexpr uint16_t kUdpPortMax = OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT_MAX; ///< The reserved max port.
 
     static_assert(kUdpPortMin <= kUdpPortMax, "invalid port range");
 
@@ -111,13 +108,29 @@ public:
          */
         typedef otSrpServerServiceFlags Flags;
 
-        enum
-        {
-            kFlagBaseType = OT_SRP_SERVER_SERVICE_FLAG_BASE_TYPE, ///< Include base services (not a sub-type).
-            kFlagSubType  = OT_SRP_SERVER_SERVICE_FLAG_SUB_TYPE,  ///< Include sub-type services.
-            kFlagActive   = OT_SRP_SERVER_SERVICE_FLAG_ACTIVE,    ///< Include active (not deleted) services.
-            kFlagDeleted  = OT_SRP_SERVER_SERVICE_FLAG_DELETED,   ///< Include deleted services.
-        };
+        /**
+         * This `Flags` constant indicates to include base services (not a sub-type).
+         *
+         */
+        static constexpr Flags kFlagBaseType = OT_SRP_SERVER_SERVICE_FLAG_BASE_TYPE;
+
+        /**
+         * This `Flags` constant indicates to include sub-type services.
+         *
+         */
+        static constexpr Flags kFlagSubType = OT_SRP_SERVER_SERVICE_FLAG_SUB_TYPE;
+
+        /**
+         * This `Flags` constant indicates to include active (not deleted) services.
+         *
+         */
+        static constexpr Flags kFlagActive = OT_SRP_SERVER_SERVICE_FLAG_ACTIVE;
+
+        /**
+         * This `Flags` constant indicates to include deleted services.
+         *
+         */
+        static constexpr Flags kFlagDeleted = OT_SRP_SERVER_SERVICE_FLAG_DELETED;
 
         /**
          * This method tells if the SRP service has been deleted.
@@ -438,10 +451,7 @@ public:
         bool Matches(const char *aFullName) const { return (mFullName == aFullName); }
 
     private:
-        enum : uint8_t
-        {
-            kMaxAddressesNum = OPENTHREAD_CONFIG_SRP_SERVER_MAX_ADDRESSES_NUM,
-        };
+        static constexpr uint16_t kMaxAddressesNum = OPENTHREAD_CONFIG_SRP_SERVER_MAX_ADDRESSES_NUM;
 
         static Host *New(Instance &aInstance);
 
@@ -637,19 +647,13 @@ public:
     void HandleServiceUpdateResult(ServiceUpdateId aId, Error aError);
 
 private:
-    enum : uint16_t
-    {
-        kUdpPayloadSize = Ip6::Ip6::kMaxDatagramLength - sizeof(Ip6::Udp::Header), // Max UDP payload size
-    };
+    static constexpr uint16_t kUdpPayloadSize = Ip6::Ip6::kMaxDatagramLength - sizeof(Ip6::Udp::Header);
 
-    enum : uint32_t
-    {
-        kDefaultMinLease             = 60u * 30,        // Default minimum lease time, 30 min (in seconds).
-        kDefaultMaxLease             = 3600u * 2,       // Default maximum lease time, 2 hours (in seconds).
-        kDefaultMinKeyLease          = 3600u * 24,      // Default minimum key-lease time, 1 day (in seconds).
-        kDefaultMaxKeyLease          = 3600u * 24 * 14, // Default maximum key-lease time, 14 days (in seconds).
-        kDefaultEventsHandlerTimeout = OPENTHREAD_CONFIG_SRP_SERVER_SERVICE_UPDATE_TIMEOUT,
-    };
+    static constexpr uint32_t kDefaultMinLease             = 60u * 30;        // 30 min (in seconds).
+    static constexpr uint32_t kDefaultMaxLease             = 3600u * 2;       // 2 hours (in seconds).
+    static constexpr uint32_t kDefaultMinKeyLease          = 3600u * 24;      // 1 day (in seconds).
+    static constexpr uint32_t kDefaultMaxKeyLease          = 3600u * 24 * 14; // 14 days (in seconds).
+    static constexpr uint32_t kDefaultEventsHandlerTimeout = OPENTHREAD_CONFIG_SRP_SERVER_SERVICE_UPDATE_TIMEOUT;
 
     // This class includes metadata for processing a SRP update (register, deregister)
     // and sending DNS response to the client.

--- a/src/core/net/tcp6.hpp
+++ b/src/core/net/tcp6.hpp
@@ -410,10 +410,7 @@ public:
     class Header
     {
     public:
-        enum : uint8_t
-        {
-            kChecksumFieldOffset = 16, ///< The byte offset of the Checksum field in the TCP header.
-        };
+        static constexpr uint8_t kChecksumFieldOffset = 16; ///< Byte offset of the Checksum field in the TCP header.
 
         /**
          * This method returns the TCP Source Port.

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -331,13 +331,10 @@ public:
     class Header
     {
     public:
-        enum : uint8_t
-        {
-            kSourcePortFieldOffset = 0, ///< The byte offset of Source Port field in UDP header.
-            kDestPortFieldOffset   = 2, ///< The byte offset of Destination Port field in UDP header.
-            kLengthFieldOffset     = 4, ///< The byte offset of Length field in UDP header.
-            kChecksumFieldOffset   = 6, ///< The byte offset of Checksum field in UDP header.
-        };
+        static constexpr uint16_t kSourcePortFieldOffset = 0; ///< Byte offset of Source Port field in UDP header.
+        static constexpr uint16_t kDestPortFieldOffset   = 2; ///< Byte offset of Destination Port field in UDP header.
+        static constexpr uint16_t kLengthFieldOffset     = 4; ///< Byte offset of Length field in UDP header.
+        static constexpr uint16_t kChecksumFieldOffset   = 6; ///< Byte offset of Checksum field in UDP header.
 
         /**
          * This method returns the UDP Source Port.
@@ -615,15 +612,12 @@ public:
     bool ShouldUsePlatformUdp(uint16_t aPort) const;
 
 private:
-    enum
-    {
-        kDynamicPortMin = 49152, ///< Service Name and Transport Protocol Port Number Registry
-        kDynamicPortMax = 65535, ///< Service Name and Transport Protocol Port Number Registry
-        kSrpServerPortMin =
-            OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT_MIN, // The min port in the port range reserved for SRP server.
-        kSrpServerPortMax =
-            OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT_MAX, // The max port in the port range reserved for SRP server.
-    };
+    static constexpr uint16_t kDynamicPortMin = 49152; // Service Name and Transport Protocol Port Number Registry
+    static constexpr uint16_t kDynamicPortMax = 65535; // Service Name and Transport Protocol Port Number Registry
+
+    // Reserved range for use by SRP server
+    static constexpr uint16_t kSrpServerPortMin = OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT_MIN;
+    static constexpr uint16_t kSrpServerPortMax = OPENTHREAD_CONFIG_SRP_SERVER_UDP_PORT_MAX;
 
     static bool IsPortReserved(uint16_t aPort);
 


### PR DESCRIPTION
This commit replaces the `enum` constants with `constexpr` definitions
in all the modules under `core/net`. This commit also contains some
smaller changes: typo fixes in the comments, removal of unused
constants, and adding `uint` type to the named `enum` definitions.