### PR TITLE
[mle] add delay before orphan announce

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1780,7 +1780,7 @@ void Mle::HandleAttachTimer(void)
             SetAttachState(kAttachStateAnnounce);
             IgnoreError(SendParentRequest(kParentRequestTypeRoutersAndReeds));
             mAnnounceChannel = Mac::ChannelMask::kChannelIteratorFirst;
-            delay            = mAnnounceDelay;
+            delay = kParentRequestReedTimeout;
             break;
         }
 


### PR DESCRIPTION
`mAnnounceDelay` is about 80ms by default, seems too short to receive possible parent response for the third parent request before announce. 

Here adopts the same `kParentRequestReedTimeout` delay.