### PR TITLE
[routing-manager] delay removing external route for on-link prefix

### DIFF
--- a/include/openthread/border_router.h
+++ b/include/openthread/border_router.h
@@ -87,6 +87,37 @@ otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex, bool 
 otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled);
 
 /**
+ * This method returns the off-mesh-routable (OMR) prefix.
+ *
+ * The randomly generated 64-bit prefix will be published
+ * in the Thread network if there isn't already an OMR prefix.
+ *
+ * @param[in]   aInstance  A pointer to an OpenThread instance.
+ * @param[out]  aPrefix    A pointer to where the prefix will be output to.
+ *
+ * @retval  OT_ERROR_INVALID_STATE  The Border Routing Manager is not initialized yet.
+ * @retval  OT_ERROR_NONE           Successfully retrieved the OMR prefix.
+ *
+ */
+otError otBorderRoutingGetOmrPrefix(otInstance *aInstance, otIp6Prefix *aPrefix);
+
+/**
+ * This method returns the on-link prefix for the adjacent infrastructure link.
+ *
+ * The randomly generated 64-bit prefix will be advertised
+ * on the infrastructure link if there isn't already a usable
+ * on-link prefix being advertised on the link.
+ *
+ * @param[in]   aInstance  A pointer to an OpenThread instance.
+ * @param[out]  aPrefix    A pointer to where the prefix will be output to.
+ *
+ * @retval  OT_ERROR_INVALID_STATE  The Border Routing Manager is not initialized yet.
+ * @retval  OT_ERROR_NONE           Successfully retrieved the on-link prefix.
+ *
+ */
+otError otBorderRoutingGetOnLinkPrefix(otInstance *aInstance, otIp6Prefix *aPrefix);
+
+/**
  * This method provides a full or stable copy of the local Thread Network Data.
  *
  * @param[in]     aInstance    A pointer to an OpenThread instance.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (148)
+#define OPENTHREAD_API_VERSION (149)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -356,6 +356,26 @@ Done
 Done
 ```
 
+### br omrprefix
+
+Get the randomly generated off-mesh-routable prefix of the Border Router.
+
+```bash
+> br omrprefix
+fdfc:1ff5:1512:5622::/64
+Done
+```
+
+### br onlinkprefix
+
+Get the randomly generated on-link prefix of the Border Router.
+
+```bash
+> br onlinkprefix
+fd41:2650:a6f5:0::/64
+Done
+```
+
 ### bufferinfo
 
 Show the current message buffer information.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -370,8 +370,30 @@ otError Interpreter::ProcessBorderRouting(Arg aArgs[])
     otError error = OT_ERROR_NONE;
     bool    enable;
 
-    SuccessOrExit(error = ParseEnableOrDisable(aArgs[0], enable));
-    error = otBorderRoutingSetEnabled(mInstance, enable);
+    if (ParseEnableOrDisable(aArgs[0], enable) == OT_ERROR_NONE)
+    {
+        SuccessOrExit(error = otBorderRoutingSetEnabled(mInstance, enable));
+    }
+    else if (aArgs[0] == "omrprefix")
+    {
+        otIp6Prefix omrPrefix;
+
+        SuccessOrExit(error = otBorderRoutingGetOmrPrefix(mInstance, &omrPrefix));
+        OutputIp6Prefix(omrPrefix);
+        OutputLine("");
+    }
+    else if (aArgs[0] == "onlinkprefix")
+    {
+        otIp6Prefix onLinkPrefix;
+
+        SuccessOrExit(error = otBorderRoutingGetOnLinkPrefix(mInstance, &onLinkPrefix));
+        OutputIp6Prefix(onLinkPrefix);
+        OutputLine("");
+    }
+    else
+    {
+        ExitNow(error = OT_ERROR_INVALID_COMMAND);
+    }
 
 exit:
     return error;
@@ -4641,6 +4663,15 @@ void Interpreter::OutputPrefix(const otMeshLocalPrefix &aPrefix)
 {
     OutputFormat("%x:%x:%x:%x::/64", (aPrefix.m8[0] << 8) | aPrefix.m8[1], (aPrefix.m8[2] << 8) | aPrefix.m8[3],
                  (aPrefix.m8[4] << 8) | aPrefix.m8[5], (aPrefix.m8[6] << 8) | aPrefix.m8[7]);
+}
+
+void Interpreter::OutputIp6Prefix(const otIp6Prefix &aPrefix)
+{
+    char string[OT_IP6_PREFIX_STRING_SIZE];
+
+    otIp6PrefixToString(&aPrefix, string, sizeof(string));
+
+    OutputFormat("%s", string);
 }
 
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -555,6 +555,7 @@ private:
     otError ProcessNetworkDataRoute(void);
     otError ProcessNetworkDataService(void);
     void    OutputPrefix(const otMeshLocalPrefix &aPrefix);
+    void    OutputIp6Prefix(const otIp6Prefix &aPrefix);
 
     otError ProcessNetstat(Arg aArgs[]);
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -63,7 +63,7 @@ void NetworkData::OutputPrefix(const otBorderRouterConfig &aConfig)
     char  flagsString[kMaxFlagStringSize];
     char *flagsPtr = &flagsString[0];
 
-    OutputIp6Prefix(aConfig.mPrefix);
+    mInterpreter.OutputIp6Prefix(aConfig.mPrefix);
 
     if (aConfig.mPreferred)
     {
@@ -135,7 +135,7 @@ void NetworkData::OutputRoute(const otExternalRouteConfig &aConfig)
     char  flagsString[kMaxFlagStringSize];
     char *flagsPtr = &flagsString[0];
 
-    OutputIp6Prefix(aConfig.mPrefix);
+    mInterpreter.OutputIp6Prefix(aConfig.mPrefix);
 
     if (aConfig.mStable)
     {
@@ -157,15 +157,6 @@ void NetworkData::OutputRoute(const otExternalRouteConfig &aConfig)
     OutputPreference(aConfig.mPreference);
 
     mInterpreter.OutputLine(" %04x", aConfig.mRloc16);
-}
-
-void NetworkData::OutputIp6Prefix(const otIp6Prefix &aPrefix)
-{
-    char string[OT_IP6_PREFIX_STRING_SIZE];
-
-    otIp6PrefixToString(&aPrefix, string, sizeof(string));
-
-    mInterpreter.OutputFormat("%s", string);
 }
 
 void NetworkData::OutputPreference(signed int aPreference)

--- a/src/cli/cli_network_data.hpp
+++ b/src/cli/cli_network_data.hpp
@@ -117,7 +117,6 @@ private:
     void    OutputPrefixes(void);
     void    OutputRoutes(void);
     void    OutputServices(void);
-    void    OutputIp6Prefix(const otIp6Prefix &aPrefix);
     void    OutputPreference(signed int aPreference);
 
     static constexpr Command sCommands[] = {

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -57,6 +57,21 @@ otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled)
 
     return instance.Get<BorderRouter::RoutingManager>().SetEnabled(aEnabled);
 }
+
+otError otBorderRoutingGetOmrPrefix(otInstance *aInstance, otIp6Prefix *aPrefix)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<BorderRouter::RoutingManager>().GetOmrPrefix(static_cast<Ip6::Prefix &>(*aPrefix));
+}
+
+otError otBorderRoutingGetOnLinkPrefix(otInstance *aInstance, otIp6Prefix *aPrefix)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<BorderRouter::RoutingManager>().GetOnLinkPrefix(static_cast<Ip6::Prefix &>(*aPrefix));
+}
+
 #endif
 
 otError otBorderRouterGetNetData(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)

--- a/src/core/border_router/router_advertisement.hpp
+++ b/src/core/border_router/router_advertisement.hpp
@@ -238,6 +238,14 @@ public:
     void SetPreferredLifetime(uint32_t aPreferredLifetime) { mPreferredLifetime = HostSwap32(aPreferredLifetime); }
 
     /**
+     * THis method returns the preferred lifetime of the prefix in seconds.
+     *
+     * @returns  The preferred lifetime in seconds.
+     *
+     */
+    uint32_t GetPreferredLifetime(void) const { return HostSwap32(mPreferredLifetime); }
+
+    /**
      * This method sets the prefix.
      *
      * @param[in]  aPrefix  The prefix contained in this option.
@@ -261,7 +269,8 @@ public:
      */
     bool IsValid(void) const
     {
-        return (GetSize() == sizeof(*this)) && (mPrefixLength <= OT_IP6_ADDRESS_SIZE * CHAR_BIT);
+        return (GetSize() == sizeof(*this)) && (mPrefixLength <= OT_IP6_ADDRESS_SIZE * CHAR_BIT) &&
+               (GetPreferredLifetime() <= GetValidLifetime());
     }
 
 private:

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -116,6 +116,28 @@ exit:
     return error;
 }
 
+Error RoutingManager::GetOmrPrefix(Ip6::Prefix &aPrefix)
+{
+    Error error = kErrorNone;
+
+    VerifyOrExit(IsInitialized(), error = kErrorInvalidState);
+    aPrefix = mLocalOmrPrefix;
+
+exit:
+    return error;
+}
+
+Error RoutingManager::GetOnLinkPrefix(Ip6::Prefix &aPrefix)
+{
+    Error error = kErrorNone;
+
+    VerifyOrExit(IsInitialized(), error = kErrorInvalidState);
+    aPrefix = mLocalOnLinkPrefix;
+
+exit:
+    return error;
+}
+
 Error RoutingManager::LoadOrGenerateRandomOmrPrefix(void)
 {
     Error error = kErrorNone;

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -110,6 +110,35 @@ public:
     Error SetEnabled(bool aEnabled);
 
     /**
+     * This method returns the off-mesh-routable (OMR) prefix.
+     *
+     * The randomly generated 64-bit prefix will be published
+     * in the Thread network if there isn't already a OMR prefix.
+     *
+     * @param[in]  aPrefix  A reference to where the prefix will be output to.
+     *
+     * @retval  kErrorInvalidState  The Border Routing Manager is not initialized yet.
+     * @retval  kErrorNone          Successfully retrieved the OMR prefix.
+     *
+     */
+    Error GetOmrPrefix(Ip6::Prefix &aPrefix);
+
+    /**
+     * This method returns the on-link prefix for the adjacent  infrastructure link.
+     *
+     * The randomly generated 64-bit prefix will be advertised
+     * on the infrastructure link if there isn't already a usable
+     * on-link prefix being advertised on the link.
+     *
+     * @param[in]  aPrefix  A reference to where the prefix will be output to.
+     *
+     * @retval  kErrorInvalidState  The Border Routing Manager is not initialized yet.
+     * @retval  kErrorNone          Successfully retrieved the on-link prefix.
+     *
+     */
+    Error GetOnLinkPrefix(Ip6::Prefix &aPrefix);
+
+    /**
      * This method receives an ICMPv6 message on the infrastructure interface.
      *
      * Malformed or undesired messages are dropped silently.

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -346,8 +346,7 @@ private:
     // randomly generated if non is found in persistent storage.
     Ip6::Prefix mLocalOnLinkPrefix;
 
-    // Could only be nullptr or a pointer to mLocalOnLinkPrefix.
-    const Ip6::Prefix *mAdvertisedOnLinkPrefix;
+    bool mIsAdvertisingLocalOnLinkPrefix;
 
     // The last time when the on-link prefix is advertised with
     // non-zero preferred lifetime.

--- a/tests/scripts/thread-cert/border_router/test_multi_thread_networks.py
+++ b/tests/scripts/thread-cert/border_router/test_multi_thread_networks.py
@@ -120,8 +120,8 @@ class MultiThreadNetworks(thread_cert.TestCase):
         self.assertTrue(len(br2.get_prefixes()) == 1)
         self.assertTrue(len(router2.get_prefixes()) == 1)
 
-        br1_omr_prefix = br1.get_prefixes()[0]
-        br2_omr_prefix = br2.get_prefixes()[0]
+        br1_omr_prefix = br1.get_omr_prefix()
+        br2_omr_prefix = br2.get_omr_prefix()
 
         self.assertNotEqual(br1_omr_prefix, br2_omr_prefix)
 

--- a/tests/scripts/thread-cert/border_router/test_radvd_coexist.py
+++ b/tests/scripts/thread-cert/border_router/test_radvd_coexist.py
@@ -107,6 +107,9 @@ class SingleBorderRouter(thread_cert.TestCase):
 
         self.assertEqual(len(br.get_ip6_address(config.ADDRESS_TYPE.OMR)), 1)
         self.assertEqual(len(router.get_ip6_address(config.ADDRESS_TYPE.OMR)), 1)
+
+        # radvd doesn't deprecates the PIO so that the Border Router will not
+        # advertise its own on-link prefix immediately.
         self.assertEqual(len(host.get_ip6_address(config.ADDRESS_TYPE.ONLINK_ULA)), 1)
 
         self.assertTrue(router.ping(host.get_ip6_address(config.ADDRESS_TYPE.ONLINK_ULA)[0]))

--- a/tests/scripts/thread-cert/border_router/test_single_border_router.py
+++ b/tests/scripts/thread-cert/border_router/test_single_border_router.py
@@ -318,12 +318,11 @@ class SingleBorderRouter(thread_cert.TestCase):
         br.start_radvd_service(prefix=config.ONLINK_GUA_PREFIX, slaac=True)
         self.simulator.go(5)
 
-        self.assertEqual(len(br.get_routes()), 1)
-        self.assertTrue(br.get_routes()[0].startswith(config.ONLINK_GUA_PREFIX.split('::/')[0]))
-        self.assertEqual(len(router.get_routes()), 1)
-        self.assertTrue(router.get_routes()[0].startswith(config.ONLINK_GUA_PREFIX.split('::/')[0]))
+        self.assertEqual(len(br.get_routes()), 2)
+        self.assertEqual(len(router.get_routes()), 2)
 
         self.assertTrue(router.ping(host.get_ip6_address(config.ADDRESS_TYPE.ONLINK_GUA)[0]))
+        self.assertTrue(router.ping(host.get_ip6_address(config.ADDRESS_TYPE.ONLINK_ULA)[0]))
         self.assertTrue(host.ping(router.get_ip6_address(config.ADDRESS_TYPE.OMR)[0], backbone=True))
 
 


### PR DESCRIPTION
This change includes three separate commits:
### [cli] add commands for getting Border Router OMR and on-link prefix
### [routing-manager] delay removing external route for on-link prefixes
Per RFC 4862 section 5.5.3, the SLAAC address of a on-link prefix
will not immediately be invalidated even if the on-link prefix is
sent with zero PIO valid lifetime but we currently removes the
external route for the on-link prefix when we see zero valid lifetime.
This results in an error case that a Thread device can not reach
a valid SLAAC address of a Wi-Fi host on the same infra link because
there is no routes for this address.
This commit fixes this issue by delay removing the external route
for the discovered on-link prefix untill its valid lifetime expires.
Meanwhile, the Border Router now considers a deprecated (zero preferred
lifetime) on-link prefix not usable. Thus, the Border Router will
start advertising its own on-link prefix when current on-link prefix
is deprecated.
### [routing-manager] replace mAdvertisedOnLinkPrefix with a boolean flag.
The mAdvertisedOnLinkPrefix can only be nullptr or mLocalOnLinkPrefix.
Change to use a boolean flag mIsAdvertisingOnLinkPrefix to make this
 explicit.

------
Prefer being merged as separate commits @jwhui 