### PR TITLE
[mesh-forwarder] fix `RemoveDataResponseMessages()` accessing freed msg

### DIFF
--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -303,9 +303,12 @@ void MeshForwarder::RemoveMessages(Child &aChild, Message::SubType aSubType)
 void MeshForwarder::RemoveDataResponseMessages(void)
 {
     Ip6::Header ip6Header;
+    Message *   next;
 
-    for (Message *message = mSendQueue.GetHead(); message; message = message->GetNext())
+    for (Message *message = mSendQueue.GetHead(); message != nullptr; message = next)
     {
+        next = message->GetNext();
+
         if (message->GetSubType() != Message::kSubTypeMleDataResponse)
         {
             continue;


### PR DESCRIPTION
This commit fixes a bug in `RemoveDataResponseMessages()` where
`GetNext()` method may be called on an already dequeued and freed
`Message` instance (within the `for` loop iteration). The change in
this commit ensures to get and retain the `next` message before
potentially removing the message from the `mSendQueue` and freeing
it.

