### PR TITLE
[cmake] avoid unnecessary rebuild when git commit id changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,7 +101,6 @@ if(OT_PACKAGE_VERSION STREQUAL "")
     ot_git_version(OT_PACKAGE_VERSION)
     message(STATUS "Setting default package version: ${OT_PACKAGE_VERSION}")
 endif()
-target_compile_definitions(ot-config INTERFACE "PACKAGE_VERSION=\"${OT_PACKAGE_VERSION}\"")
 message(STATUS "Package Version: ${OT_PACKAGE_VERSION}")
 
 set(OT_THREAD_VERSION "1.2" CACHE STRING "Thread version chosen by the user at configure time")

--- a/src/cli/CMakeLists.txt
+++ b/src/cli/CMakeLists.txt
@@ -52,3 +52,7 @@ endif()
 if(OT_MTD)
     include(mtd.cmake)
 endif()
+
+set_property(SOURCE cli_joiner.cpp
+    APPEND PROPERTY COMPILE_DEFINITIONS "PACKAGE_VERSION=\"${OT_PACKAGE_VERSION}\""
+)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -239,3 +239,7 @@ endif()
 if(OT_RCP)
     include(radio.cmake)
 endif()
+
+set_property(SOURCE api/instance_api.cpp
+    APPEND PROPERTY COMPILE_DEFINITIONS "PACKAGE_VERSION=\"${OT_PACKAGE_VERSION}\""
+)

--- a/src/ncp/CMakeLists.txt
+++ b/src/ncp/CMakeLists.txt
@@ -69,3 +69,7 @@ endif()
 if(OT_RCP)
     include(radio.cmake)
 endif()
+
+set_property(SOURCE ncp_base_mtd.cpp
+    APPEND PROPERTY COMPILE_DEFINITIONS "PACKAGE_VERSION=\"${OT_PACKAGE_VERSION}\""
+)


### PR DESCRIPTION
This commit removes the PACKAGE_VERSION definition from the global
config target so that when the git commit id is changed, only a few
sources will be re-compiled.