### PR TITLE
[coap] fix `CoapSecure::Stop()` accessing freed message instance

### DIFF
--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -84,9 +84,11 @@ exit:
 
 void CoapSecure::Stop(void)
 {
+    ot::Message *message;
+
     mDtls.Close();
 
-    for (ot::Message *message = mTransmitQueue.GetHead(); message != nullptr; message = message->GetNext())
+    while ((message = mTransmitQueue.GetHead()) != nullptr)
     {
         mTransmitQueue.Dequeue(*message);
         message->Free();


### PR DESCRIPTION
This commit fixes an issue in `CoapSecure::Stop()` accessing an
already dequeued and freed `Message` instance (from the `for` loop
iteration trying to `GetNext()` message). The code in this commit
removes the head element one by one (`MessageQueue::GetHead()`)
until the queue becomes empty.