### PR TITLE
[posix] refine system initialization and deinitialization

### DIFF
--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -296,9 +296,8 @@ static otInstance *InitInstance(PosixConfig *aConfig)
     IgnoreError(otLoggingSetLevel(aConfig->mLogLevel));
 
     instance = otSysInit(&aConfig->mPlatformConfig);
+    VerifyOrDie(instance != NULL, OT_EXIT_FAILURE);
     syslog(LOG_INFO, "Thread interface: %s", otSysGetThreadNetifName());
-
-    atexit(otSysDeinit);
 
     if (aConfig->mPrintRadioVersion)
     {
@@ -324,9 +323,10 @@ void otTaskletsSignalPending(otInstance *aInstance)
 
 void otPlatReset(otInstance *aInstance)
 {
+    OT_UNUSED_VARIABLE(aInstance);
+
     gPlatResetReason = OT_PLAT_RESET_REASON_SOFTWARE;
 
-    otInstanceFinalize(aInstance);
     otSysDeinit();
 
     longjmp(gResetJump, 1);
@@ -430,7 +430,7 @@ int main(int argc, char *argv[])
 #endif
 
 exit:
-    otInstanceFinalize(instance);
+    otSysDeinit();
 
     return rval;
 }

--- a/src/posix/platform/backbone.cpp
+++ b/src/posix/platform/backbone.cpp
@@ -46,10 +46,8 @@ unsigned int gBackboneNetifIndex          = 0;
 static ot::Posix::MulticastRoutingManager sMulticastRoutingManager;
 #endif
 
-void platformBackboneInit(otInstance *aInstance, const char *aInterfaceName)
+void platformBackboneInit(const char *aInterfaceName)
 {
-    OT_UNUSED_VARIABLE(aInstance);
-
     VerifyOrExit(aInterfaceName != nullptr && aInterfaceName[0] != '\0');
 
     VerifyOrDie(strnlen(aInterfaceName, sizeof(gBackboneNetifName)) < sizeof(gBackboneNetifName),
@@ -61,20 +59,26 @@ void platformBackboneInit(otInstance *aInstance, const char *aInterfaceName)
 
     otLogInfoPlat("Backbone interface is configured to %s (%d)", gBackboneNetifName, gBackboneNetifIndex);
 
-#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
-    sMulticastRoutingManager.Init(aInstance);
-#endif
-
 exit:
     return;
 }
 
-void platformBackboneDeinit(void)
+void platformBackboneSetUp(void)
 {
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
-    sMulticastRoutingManager.Deinit();
+    sMulticastRoutingManager.SetUp();
 #endif
+}
 
+void platformBackboneTearDown(void)
+{
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
+    sMulticastRoutingManager.TearDown();
+#endif
+}
+
+void platformBackboneDeinit(void)
+{
     gBackboneNetifIndex = 0;
 
     memset(gBackboneNetifName, 0, sizeof(gBackboneNetifName));

--- a/src/posix/platform/daemon.cpp
+++ b/src/posix/platform/daemon.cpp
@@ -147,7 +147,7 @@ exit:
     }
 }
 
-void Daemon::Enable(otInstance *aInstance)
+void Daemon::SetUp(void)
 {
     struct sockaddr_un sockname;
     int                ret;
@@ -205,7 +205,7 @@ void Daemon::Enable(otInstance *aInstance)
     }
 
     otCliInit(
-        aInstance,
+        gInstance,
         [](void *aContext, const char *aFormat, va_list aArguments) -> int {
             return static_cast<Daemon *>(aContext)->OutputFormatV(aFormat, aArguments);
         },
@@ -217,7 +217,7 @@ exit:
     return;
 }
 
-void Daemon::Disable(void)
+void Daemon::TearDown(void)
 {
     Mainloop::Manager::Get().Remove(*this);
 

--- a/src/posix/platform/daemon.hpp
+++ b/src/posix/platform/daemon.hpp
@@ -41,8 +41,8 @@ class Daemon : public Mainloop::Source, private NonCopyable
 public:
     static Daemon &Get(void);
 
-    void Enable(otInstance *aInstance);
-    void Disable(void);
+    void SetUp(void);
+    void TearDown(void);
     void Update(otSysMainloopContext &aContext) override;
     void Process(const otSysMainloopContext &aContext) override;
 

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -81,7 +81,7 @@ typedef struct otPlatformConfig
 } otPlatformConfig;
 
 /**
- * This function performs all platform-specific initialization of OpenThread's drivers and initialize the OpenThread
+ * This function performs all platform-specific initialization of OpenThread's drivers and initializes the OpenThread
  * instance.
  *
  * @note This function is not called by the OpenThread library. Instead, the system/RTOS should call this function

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -81,7 +81,8 @@ typedef struct otPlatformConfig
 } otPlatformConfig;
 
 /**
- * This function performs all platform-specific initialization of OpenThread's drivers.
+ * This function performs all platform-specific initialization of OpenThread's drivers and initialize the OpenThread
+ * instance.
  *
  * @note This function is not called by the OpenThread library. Instead, the system/RTOS should call this function
  *       when initialization of OpenThread's drivers is most appropriate.
@@ -94,7 +95,8 @@ typedef struct otPlatformConfig
 otInstance *otSysInit(otPlatformConfig *aPlatformConfig);
 
 /**
- * This function performs all platform-specific deinitialization for OpenThread's drivers.
+ * This function finalizes the OpenThread instance and performs all platform-specific deinitialization for OpenThread's
+ * drivers.
  *
  * @note This function is not called by the OpenThread library. Instead, the system/RTOS should call this function
  *       when deinitialization of OpenThread's drivers is most appropriate.

--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -267,7 +267,7 @@ bool InfraNetif::IsRunning(void) const
     return (ifReq.ifr_flags & IFF_RUNNING);
 }
 
-void InfraNetif::Init(otInstance *aInstance, const char *aIfName)
+void InfraNetif::Init(const char *aIfName)
 {
     ssize_t  rval;
     uint32_t ifIndex = 0;
@@ -296,20 +296,33 @@ void InfraNetif::Init(otInstance *aInstance, const char *aIfName)
 
     mNetLinkSocket = CreateNetLinkSocket();
 
-    SuccessOrDie(otBorderRoutingInit(aInstance, ifIndex, platformInfraIfIsRunning()));
-    SuccessOrDie(otBorderRoutingSetEnabled(aInstance, /* aEnabled */ true));
+exit:
+    return;
+}
 
-    mInstance = aInstance;
+void InfraNetif::SetUp(void)
+{
+    OT_ASSERT(gInstance != nullptr);
+    VerifyOrExit(mInfraIfIndex != 0);
+
+    SuccessOrDie(otBorderRoutingInit(gInstance, mInfraIfIndex, platformInfraIfIsRunning()));
+    SuccessOrDie(otBorderRoutingSetEnabled(gInstance, /* aEnabled */ true));
     Mainloop::Manager::Get().Add(*this);
+exit:
+    return;
+}
 
+void InfraNetif::TearDown(void)
+{
+    VerifyOrExit(mInfraIfIndex != 0);
+
+    Mainloop::Manager::Get().Remove(*this);
 exit:
     return;
 }
 
 void InfraNetif::Deinit(void)
 {
-    Mainloop::Manager::Get().Remove(*this);
-
     if (mInfraIfIcmp6Socket != -1)
     {
         close(mInfraIfIcmp6Socket);
@@ -369,7 +382,7 @@ void InfraNetif::ReceiveNetLinkMessage(void)
         case RTM_DELADDR:
         case RTM_NEWLINK:
         case RTM_DELLINK:
-            SuccessOrDie(otPlatInfraIfStateChanged(mInstance, mInfraIfIndex, platformInfraIfIsRunning()));
+            SuccessOrDie(otPlatInfraIfStateChanged(gInstance, mInfraIfIndex, platformInfraIfIsRunning()));
             break;
         case NLMSG_ERROR:
         {
@@ -449,7 +462,7 @@ void InfraNetif::ReceiveIcmp6Message(void)
     // the hoplimit must be 255 and the source address must be a link-local address.
     VerifyOrExit(hopLimit == 255 && IN6_IS_ADDR_LINKLOCAL(&srcAddr.sin6_addr), error = OT_ERROR_DROP);
 
-    otPlatInfraIfRecvIcmp6Nd(mInstance, ifIndex, reinterpret_cast<otIp6Address *>(&srcAddr.sin6_addr), buffer,
+    otPlatInfraIfRecvIcmp6Nd(gInstance, ifIndex, reinterpret_cast<otIp6Address *>(&srcAddr.sin6_addr), buffer,
                              bufferLength);
 
 exit:

--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -317,6 +317,7 @@ void InfraNetif::TearDown(void)
     VerifyOrExit(mInfraIfIndex != 0);
 
     Mainloop::Manager::Get().Remove(*this);
+
 exit:
     return;
 }

--- a/src/posix/platform/infra_if.hpp
+++ b/src/posix/platform/infra_if.hpp
@@ -69,14 +69,33 @@ public:
     /**
      * This method initializes the infrastructure network interface.
      *
-     * @param[in]  aInstance    A pointer to an OpenThread instance.
+     * @note This method is called before OpenThread instance is created.
+     *
      * @param[in]  aIfName      A pointer to infrastructure network interface name.
      *
      */
-    void Init(otInstance *aInstance, const char *aIfName);
+    void Init(const char *aIfName);
+
+    /**
+     * This method sets up the infrastructure network interface.
+     *
+     * @note This method is called after OpenThread instance is created.
+     *
+     */
+    void SetUp(void);
+
+    /**
+     * This method tears down the infrastructure network interface.
+     *
+     * @note This method is called before OpenThread instance is destructed.
+     *
+     */
+    void TearDown(void);
 
     /**
      * This method deinitializes the infrastructure network interface.
+     *
+     * @note This method is called after OpenThread instance is destructed.
      *
      */
     void Deinit(void);
@@ -117,11 +136,10 @@ public:
     static InfraNetif &Get(void);
 
 private:
-    otInstance *mInstance;
-    char        mInfraIfName[IFNAMSIZ];
-    uint32_t    mInfraIfIndex       = 0;
-    int         mInfraIfIcmp6Socket = -1;
-    int         mNetLinkSocket      = -1;
+    char     mInfraIfName[IFNAMSIZ];
+    uint32_t mInfraIfIndex       = 0;
+    int      mInfraIfIcmp6Socket = -1;
+    int      mNetLinkSocket      = -1;
 
     void ReceiveNetLinkMessage(void);
     void ReceiveIcmp6Message(void);

--- a/src/posix/platform/multicast_routing.cpp
+++ b/src/posix/platform/multicast_routing.cpp
@@ -46,24 +46,27 @@
 
 #include <openthread/backbone_router_ftd.h>
 
+#include "core/common/debug.hpp"
 #include "core/common/logging.hpp"
 
 namespace ot {
 namespace Posix {
 
-void MulticastRoutingManager::Init(otInstance *aInstance)
+void MulticastRoutingManager::SetUp(void)
 {
-    mInstance = aInstance;
+    OT_ASSERT(gInstance != nullptr);
 
-    otBackboneRouterSetMulticastListenerCallback(aInstance,
+    otBackboneRouterSetMulticastListenerCallback(gInstance,
                                                  &MulticastRoutingManager::HandleBackboneMulticastListenerEvent, this);
     Mainloop::Manager::Get().Add(*this);
 }
 
-void MulticastRoutingManager::Deinit(void)
+void MulticastRoutingManager::TearDown(void)
 {
+    OT_ASSERT(gInstance != nullptr);
+
+    otBackboneRouterSetMulticastListenerCallback(gInstance, nullptr, nullptr);
     Mainloop::Manager::Get().Remove(*this);
-    mInstance = nullptr;
 }
 
 void MulticastRoutingManager::HandleBackboneMulticastListenerEvent(void *                                 aContext,
@@ -136,7 +139,7 @@ bool MulticastRoutingManager::HasMulticastListener(const Ip6::Address &aAddress)
     otBackboneRouterMulticastListenerIterator iter  = OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ITERATOR_INIT;
     otBackboneRouterMulticastListenerInfo     listenerInfo;
 
-    while (otBackboneRouterMulticastListenerGetNext(mInstance, &iter, &listenerInfo) == OT_ERROR_NONE)
+    while (otBackboneRouterMulticastListenerGetNext(gInstance, &iter, &listenerInfo) == OT_ERROR_NONE)
     {
         VerifyOrExit(static_cast<const Ip6::Address &>(listenerInfo.mAddress) != aAddress, found = true);
     }

--- a/src/posix/platform/multicast_routing.hpp
+++ b/src/posix/platform/multicast_routing.hpp
@@ -58,8 +58,8 @@ public:
     {
     }
 
-    void Init(otInstance *aInstance);
-    void Deinit(void);
+    void SetUp(void);
+    void TearDown(void);
     void Update(otSysMainloopContext &aContext) override;
     void Process(const otSysMainloopContext &aContext) override;
     void HandleStateChange(otInstance *aInstance, otChangedFlags aFlags);
@@ -134,7 +134,6 @@ private:
     MulticastForwardingCache mMulticastForwardingCacheTable[kMulitcastForwardingCacheTableSize];
     uint64_t                 mLastExpireTime;
     int                      mMulticastRouterSock;
-    otInstance *             mInstance;
 };
 
 } // namespace Posix

--- a/src/posix/platform/platform-posix.h
+++ b/src/posix/platform/platform-posix.h
@@ -172,12 +172,6 @@ void platformRadioInit(const char *aUrl);
 void platformRadioDeinit(void);
 
 /**
- * This function shuts down platform network interface.
- *
- */
-void platformNetifDeinit(void);
-
-/**
  * This function inputs a received radio frame.
  *
  * @param[in]  aInstance   A pointer to the OpenThread instance.
@@ -245,11 +239,38 @@ void platformUartProcess(const fd_set *aReadFdSet, const fd_set *aWriteFdSet, co
 /**
  * This function initializes platform netif.
  *
- * @param[in]   aInstance       A pointer to the OpenThread instance.
+ * @note This function is called before OpenThread instance is created.
+ *
  * @param[in]   aInterfaceName  A pointer to Thread network interface name.
  *
  */
-void platformNetifInit(otInstance *aInstance, const char *aInterfaceName);
+void platformNetifInit(const char *aInterfaceName);
+
+/**
+ * This function sets up platform netif.
+ *
+ * @note This function is called after OpenThread instance is created.
+ *
+ * @param[in]   aInstance       A pointer to the OpenThread instance.
+ *
+ */
+void platformNetifSetUp(void);
+
+/**
+ * This function tears down platform netif.
+ *
+ * @note This function is called before OpenThread instance is destructed.
+ *
+ */
+void platformNetifTearDown(void);
+
+/**
+ * This function deinitializes platform netif.
+ *
+ * @note This function is called after OpenThread instance is destructed.
+ *
+ */
+void platformNetifDeinit(void);
 
 /**
  * This function updates the file descriptor sets with file descriptors used by platform netif module.
@@ -430,14 +451,35 @@ extern unsigned int gNetifIndex;
 /**
  * This function initializes platform Backbone network.
  *
- * @param[in]   aInstance       A pointer to the OpenThread instance.
+ * @note This function is called before OpenThread instance is created.
+ *
  * @param[in]   aInterfaceName  A pointer to Thread network interface name.
  *
  */
-void platformBackboneInit(otInstance *aInstance, const char *aInterfaceName);
+void platformBackboneInit(const char *aInterfaceName);
+
+/**
+ * This function sets up platform Backbone network.
+ *
+ * @note This function is called after OpenThread instance is created.
+ *
+ * @param[in]   aInstance       A pointer to the OpenThread instance.
+ *
+ */
+void platformBackboneSetUp(void);
+
+/**
+ * This function tears down platform Backbone network.
+ *
+ * @note This function is called before OpenThread instance is destructed.
+ *
+ */
+void platformBackboneTearDown(void);
 
 /**
  * This function shuts down the platform Backbone network.
+ *
+ * @note This function is called after OpenThread instance is destructed.
  *
  */
 void platformBackboneDeinit(void);
@@ -450,6 +492,12 @@ void platformBackboneDeinit(void);
  *
  */
 void platformBackboneStateChange(otInstance *aInstance, otChangedFlags aFlags);
+
+/**
+ * A pointer to the OpenThread instance.
+ *
+ */
+extern otInstance *gInstance;
 
 /**
  * The name of Backbone network interface.

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -47,11 +47,14 @@
 #include <openthread/platform/radio.h>
 
 #include "common/code_utils.hpp"
+#include "common/debug.hpp"
 #include "posix/platform/daemon.hpp"
 #include "posix/platform/infra_if.hpp"
 #include "posix/platform/mainloop.hpp"
 #include "posix/platform/radio_url.hpp"
 #include "posix/platform/udp.hpp"
+
+otInstance *gInstance = nullptr;
 
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE || OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
 static void processStateChange(otChangedFlags aFlags, void *aContext)
@@ -115,10 +118,8 @@ static const char *getTrelRadioUrl(otPlatformConfig *aPlatformConfig)
 }
 #endif
 
-otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
+void platformInit(otPlatformConfig *aPlatformConfig)
 {
-    otInstance *instance = nullptr;
-
     platformAlarmInit(aPlatformConfig->mSpeedUpFactor, aPlatformConfig->mRealTimeSignal);
     platformRadioInit(get802154RadioUrl(aPlatformConfig));
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
@@ -126,40 +127,95 @@ otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
 #endif
     platformRandomInit();
 
-    instance = otInstanceInitSingle();
-    assert(instance != nullptr);
-
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    platformBackboneInit(instance, aPlatformConfig->mBackboneInterfaceName);
+    platformBackboneInit(aPlatformConfig->mBackboneInterfaceName);
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-    ot::Posix::InfraNetif::Get().Init(instance, aPlatformConfig->mBackboneInterfaceName);
+    ot::Posix::InfraNetif::Get().Init(aPlatformConfig->mBackboneInterfaceName);
+#endif
+
+    gNetifName[0] = '\0';
+
+#if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
+    platformNetifInit(aPlatformConfig->mInterfaceName);
+#endif
+
+#if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
+#if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
+    ot::Posix::Udp::Get().Init(otSysGetThreadNetifName());
+#else
+    ot::Posix::Udp::Get().Init(aPlatformConfig->mInterfaceName);
+#endif
+#endif
+}
+
+void platformSetUp(void)
+{
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+    platformBackboneSetUp();
+#endif
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    ot::Posix::InfraNetif::Get().SetUp();
 #endif
 
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
-    platformNetifInit(instance, aPlatformConfig->mInterfaceName);
-#elif OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
-    ot::Posix::Udp::Get().Init(instance, aPlatformConfig->mInterfaceName);
-#else
-    gNetifName[0] = '\0';
+    platformNetifSetUp();
+#endif
+
+#if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
+    ot::Posix::Udp::Get().SetUp();
+#endif
+
+#if OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
+    ot::Posix::Daemon::Get().SetUp();
 #endif
 
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE || OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    SuccessOrDie(otSetStateChangedCallback(instance, processStateChange, instance));
+    SuccessOrDie(otSetStateChangedCallback(gInstance, processStateChange, gInstance));
 #endif
-
-#if OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
-    ot::Posix::Daemon::Get().Enable(instance);
-#endif
-    return instance;
 }
 
-void otSysDeinit(void)
+otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
+{
+    OT_ASSERT(gInstance == nullptr);
+
+    platformInit(aPlatformConfig);
+
+    gInstance = otInstanceInitSingle();
+    OT_ASSERT(gInstance != nullptr);
+
+    platformSetUp();
+
+    return gInstance;
+}
+
+void platformTearDown(void)
 {
 #if OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
-    ot::Posix::Daemon::Get().Disable();
+    ot::Posix::Daemon::Get().TearDown();
 #endif
+
+#if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
+    ot::Posix::Udp::Get().TearDown();
+#endif
+
+#if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE
+    platformNetifTearDown();
+#endif
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    ot::Posix::InfraNetif::Get().TearDown();
+#endif
+
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+    platformBackboneTearDown();
+#endif
+}
+
+void platformDeinit(void)
+{
 #if OPENTHREAD_POSIX_VIRTUAL_TIME
     virtualTimeDeinit();
 #endif
@@ -181,6 +237,16 @@ void otSysDeinit(void)
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     platformBackboneDeinit();
 #endif
+}
+
+void otSysDeinit(void)
+{
+    OT_ASSERT(gInstance != nullptr);
+
+    platformTearDown();
+    otInstanceFinalize(gInstance);
+    gInstance = nullptr;
+    platformDeinit();
 }
 
 #if OPENTHREAD_POSIX_VIRTUAL_TIME

--- a/src/posix/platform/udp.cpp
+++ b/src/posix/platform/udp.cpp
@@ -550,7 +550,7 @@ void Udp::Update(otSysMainloopContext &aContext)
 {
     VerifyOrExit(gNetifIndex != 0);
 
-    for (otUdpSocket *socket = otUdpGetSockets(mInstance); socket != nullptr; socket = socket->mNext)
+    for (otUdpSocket *socket = otUdpGetSockets(gInstance); socket != nullptr; socket = socket->mNext)
     {
         int fd;
 
@@ -572,7 +572,7 @@ exit:
     return;
 }
 
-void Udp::Init(otInstance *aInstance, const char *aIfName)
+void Udp::Init(const char *aIfName)
 {
     if (aIfName == nullptr)
     {
@@ -589,17 +589,21 @@ void Udp::Init(otInstance *aInstance, const char *aIfName)
     }
 
     assert(gNetifIndex != 0);
+}
 
-    mInstance = aInstance;
+void Udp::SetUp(void)
+{
     Mainloop::Manager::Get().Add(*this);
+}
+
+void Udp::TearDown(void)
+{
+    Mainloop::Manager::Get().Remove(*this);
 }
 
 void Udp::Deinit(void)
 {
     // TODO All platform sockets should be closed
-
-    mInstance = nullptr;
-    Mainloop::Manager::Get().Remove(*this);
 }
 
 Udp &Udp::Get(void)
@@ -613,7 +617,7 @@ void Udp::Process(const otSysMainloopContext &aContext)
 {
     otMessageSettings msgSettings = {false, OT_MESSAGE_PRIORITY_NORMAL};
 
-    for (otUdpSocket *socket = otUdpGetSockets(mInstance); socket != nullptr; socket = socket->mNext)
+    for (otUdpSocket *socket = otUdpGetSockets(gInstance); socket != nullptr; socket = socket->mNext)
     {
         int fd = FdFromHandle(socket->mHandle);
 
@@ -632,7 +636,7 @@ void Udp::Process(const otSysMainloopContext &aContext)
                 continue;
             }
 
-            message = otUdpNewMessage(mInstance, &msgSettings);
+            message = otUdpNewMessage(gInstance, &msgSettings);
 
             if (message == nullptr)
             {

--- a/src/posix/platform/udp.hpp
+++ b/src/posix/platform/udp.hpp
@@ -39,13 +39,12 @@ class Udp : public Mainloop::Source, private NonCopyable
 public:
     static Udp &Get(void);
 
-    void Init(otInstance *aInstance, const char *aIfName);
+    void Init(const char *aIfName);
+    void SetUp(void);
+    void TearDown(void);
     void Deinit(void);
     void Update(otSysMainloopContext &aContext) override;
     void Process(const otSysMainloopContext &aContext) override;
-
-private:
-    otInstance *mInstance = nullptr;
 };
 
 } // namespace Posix


### PR DESCRIPTION
This commit refines system initialization and deinitialization by separating the process before and after OpenThread instance creation and destruction:

```
otSysInit():
  Call platformInit()
  Create OpenThread Instance as `gInstance`
  Call platformSetUp()

otSysDeinit():
  Call platformTearDown()
  Destroy OpenThread Instance `gInstance`
  Call platformDeinit()
```

This commit should help fix the issue that platform UDP sockets can not be created when constructing OpenThread instance. 

This commit contain other related changes:
- otSysDeinit now destroyes the OpenThread instance
- posix/platform code use a global variable `gInstance` to track the single global OpenThread instance, instead of using multiple pointers in multiple files. 

Depends-On: openthread/ot-br-posix#954