### PR TITLE
[tests] fix test_publish_meshcop_service.py

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
+++ b/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
@@ -92,6 +92,7 @@ class PublishMeshCopService(thread_cert.TestCase):
         self.check_meshcop_service(br, host)
 
         br.disable_backbone_router()
+        self.simulator.go(5)
         self.check_meshcop_service(br, host)
 
     def check_meshcop_service(self, br, host):


### PR DESCRIPTION
The test failed frequently because I forgot to add a delay before checking the meshcop service.