### PR TITLE
[mle] ensure Link Metrics methods free newly allocated msg on error

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2532,7 +2532,9 @@ Error Mle::SendLinkMetricsManagementResponse(const Ip6::Address &aDestination, L
     SuccessOrExit(error = message->Append(aStatus));
 
     SuccessOrExit(error = SendMessage(*message, aDestination));
+
 exit:
+    FreeMessageOnError(message, error);
     return error;
 }
 #endif
@@ -2555,7 +2557,9 @@ Error Mle::SendLinkProbe(const Ip6::Address &aDestination, uint8_t aSeriesId, ui
     SuccessOrExit(error = message->AppendBytes(aBuf, aLength));
 
     SuccessOrExit(error = SendMessage(*message, aDestination));
+
 exit:
+    FreeMessageOnError(message, error);
     return error;
 }
 #endif
@@ -4495,6 +4499,7 @@ Error Mle::SendLinkMetricsManagementRequest(const Ip6::Address &aDestination, co
     SuccessOrExit(error = SendMessage(*message, aDestination));
 
 exit:
+    FreeMessageOnError(message, error);
     return error;
 }
 #endif


### PR DESCRIPTION
This commit fixes methods `SendLinkMetricsManagementResponse()`,
`SendLinkMetricsManagementRequest()` and `SendLinkProbe()` in `Mle`
to ensure that the allocated MLE message is freed on an error. Note
that on success the `Mle::SendMessage()` will take the ownership of
the allocated `Message`.