### PR TITLE
[csl] fix switch between SSED -> MED -> SSED modes

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2387,10 +2387,14 @@ void Mac::SetCslPeriod(uint16_t aPeriod)
 
     Get<DataPollSender>().RecalculatePollPeriod();
 
-    if (IsCslEnabled())
+    if ((GetCslPeriod() == 0) || IsCslEnabled())
     {
         IgnoreError(Get<Radio>().EnableCsl(GetCslPeriod(), Get<Mle::Mle>().GetParent().GetRloc16(),
                                            &Get<Mle::Mle>().GetParent().GetExtAddress()));
+    }
+
+    if (IsCslEnabled())
+    {
         Get<Mle::Mle>().ScheduleChildUpdateRequest();
     }
 
@@ -2399,7 +2403,12 @@ void Mac::SetCslPeriod(uint16_t aPeriod)
 
 bool Mac::IsCslEnabled(void) const
 {
-    return (GetCslPeriod() > 0) && !GetRxOnWhenIdle() && Get<Mle::MleRouter>().IsChild() &&
+    return !GetRxOnWhenIdle() && IsCslCapable();
+}
+
+bool Mac::IsCslCapable(void) const
+{
+    return (GetCslPeriod() > 0) && Get<Mle::MleRouter>().IsChild() &&
            Get<Mle::Mle>().GetParent().IsEnhancedKeepAliveSupported();
 }
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -703,6 +703,14 @@ public:
     bool IsCslEnabled(void) const;
 
     /**
+     * This method indicates whether Link is capable of starting CSL.
+     *
+     * @retval TURE if Link is capable of starting CSL, FALSE otherwise.
+     *
+     */
+    bool IsCslCapable(void) const;
+
+    /**
      * This method returns CSL parent clock accuracy, in ± ppm.
      *
      * @retval CSL parent clock accuracy, in ± ppm.
@@ -739,7 +747,6 @@ public:
     {
         mLinks.GetSubMac().SetCslParentUncertainty(aCslParentUncert);
     }
-
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
 private:

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -692,10 +692,10 @@ void Mle::SetStateChild(uint16_t aRloc16)
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    if (Get<Mac::Mac>().IsCslEnabled())
+    if (Get<Mac::Mac>().IsCslCapable())
     {
-        IgnoreError(Get<Radio>().EnableCsl(Get<Mac::Mac>().GetCslPeriod(), GetParent().GetRloc16(),
-                                           &GetParent().GetExtAddress()));
+        uint32_t period = IsRxOnWhenIdle() ? 0 : Get<Mac::Mac>().GetCslPeriod();
+        IgnoreError(Get<Radio>().EnableCsl(period, GetParent().GetRloc16(), &GetParent().GetExtAddress()));
         ScheduleChildUpdateRequest();
     }
 #endif


### PR DESCRIPTION
This commit introduces two changes. First is adding capablility to turn
off CSL, by implementing missing 0 value handling.
Secondly adds proper transition between SSED (CSL on) and MED states
(CSL off).