### PR TITLE
[tests] update meshcop service instance name in test case

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
+++ b/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
@@ -95,8 +95,7 @@ class PublishMeshCopService(thread_cert.TestCase):
         self.simulator.go(5)
         self.check_meshcop_service(br, host)
 
-    def check_meshcop_service(self, br, host):
-        instance_name = r'OpenThread'
+    def check_meshcop_service(self, br, host, instance_name='OpenThread_BorderRouter'):
         data = host.discover_mdns_service(instance_name, '_meshcop._udp', None)
         sb_data = data['txt']['sb'].encode('raw_unicode_escape')
         state_bitmap = int.from_bytes(sb_data, byteorder='big')


### PR DESCRIPTION
This PR aims to update the meshcop service instance name in `test_publish_meshcop_service.py` to make it consistent with the change on ot-br-posix side. This should be merged at the same time with openthread/ot-br-posix#946.

Depends-On: openthread/ot-br-posix#946