### PR TITLE
[thread] replace `enum` constants with `constexpr`

### DIFF
--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -256,7 +256,7 @@ private:
     }
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
-    MlrState mMlrState : 2;
+    MlrState mMlrState;
 #endif
 };
 

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -197,17 +197,17 @@ public:
                           const Ip6::Address *            aDestination);
 
 private:
-    enum
-    {
-        kCacheEntries                  = OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_ENTRIES,
-        kMaxNonEvictableSnoopedEntries = OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES,
-        kAddressQueryTimeout           = OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_TIMEOUT,             // in seconds
-        kAddressQueryInitialRetryDelay = OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_INITIAL_RETRY_DELAY, // in seconds
-        kAddressQueryMaxRetryDelay     = OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_MAX_RETRY_DELAY,     // in seconds
-        kSnoopBlockEvictionTimeout     = OPENTHREAD_CONFIG_TMF_SNOOP_CACHE_ENTRY_TIMEOUT,         // in seconds
-        kIteratorListIndex             = 0,
-        kIteratorEntryIndex            = 1,
-    };
+    static constexpr uint16_t kCacheEntries                  = OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_ENTRIES;
+    static constexpr uint16_t kMaxNonEvictableSnoopedEntries = OPENTHREAD_CONFIG_TMF_ADDRESS_CACHE_MAX_SNOOP_ENTRIES;
+
+    // All time/delay values are in seconds
+    static constexpr uint16_t kAddressQueryTimeout           = OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_TIMEOUT;
+    static constexpr uint16_t kAddressQueryInitialRetryDelay = OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_INITIAL_RETRY_DELAY;
+    static constexpr uint16_t kAddressQueryMaxRetryDelay     = OPENTHREAD_CONFIG_TMF_ADDRESS_QUERY_MAX_RETRY_DELAY;
+    static constexpr uint16_t kSnoopBlockEvictionTimeout     = OPENTHREAD_CONFIG_TMF_SNOOP_CACHE_ENTRY_TIMEOUT;
+
+    static constexpr uint8_t kIteratorListIndex  = 0;
+    static constexpr uint8_t kIteratorEntryIndex = 1;
 
     class CacheEntry : public InstanceLocatorInit
     {
@@ -246,15 +246,13 @@ private:
         bool Matches(const Ip6::Address &aEid) const { return GetTarget() == aEid; }
 
     private:
-        enum
-        {
-            kNoNextIndex          = 0xffff,     // mNextIndex value when at end of list.
-            kInvalidLastTransTime = 0xffffffff, // Value indicating mLastTransactionTime is invalid.
-        };
+        static constexpr uint16_t kNoNextIndex          = 0xffff;     // `mNextIndex` value when at end of list.
+        static constexpr uint32_t kInvalidLastTransTime = 0xffffffff; // Value when `mLastTransactionTime` is invalid.
 
         Ip6::Address      mTarget;
         Mac::ShortAddress mRloc16;
         uint16_t          mNextIndex;
+
         union
         {
             struct
@@ -276,14 +274,14 @@ private:
     typedef Pool<CacheEntry, kCacheEntries> CacheEntryPool;
     typedef LinkedList<CacheEntry>          CacheEntryList;
 
-    enum EntryChange
+    enum EntryChange : uint8_t
     {
         kEntryAdded,
         kEntryUpdated,
         kEntryRemoved,
     };
 
-    enum Reason
+    enum Reason : uint8_t
     {
         kReasonQueryRequest,
         kReasonSnoop,

--- a/src/core/thread/announce_begin_server.hpp
+++ b/src/core/thread/announce_begin_server.hpp
@@ -68,12 +68,9 @@ public:
     void SendAnnounce(uint32_t aChannelMask, uint8_t aCount = kDefaultCount, uint16_t aPeriod = kDefaultPeriod);
 
 private:
-    enum
-    {
-        kDefaultCount  = 3,
-        kDefaultPeriod = 1000,
-        kDefaultJitter = 0,
-    };
+    static constexpr uint8_t  kDefaultCount  = 3;
+    static constexpr uint16_t kDefaultPeriod = 1000;
+    static constexpr uint16_t kDefaultJitter = 0;
 
     static void HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleRequest(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/thread/announce_sender.hpp
+++ b/src/core/thread/announce_sender.hpp
@@ -54,14 +54,11 @@ namespace ot {
 class AnnounceSenderBase : public InstanceLocator, private NonCopyable
 {
 protected:
-    enum : uint8_t
-    {
-        /**
-         * This constant defines the special channel value to start from the first channel in the channel mask.
-         *
-         */
-        kChannelIteratorFirst = Mac::ChannelMask::kChannelIteratorFirst,
-    };
+    /**
+     * This constant defines the special channel value to start from the first channel in the channel mask.
+     *
+     */
+    static constexpr uint8_t kChannelIteratorFirst = Mac::ChannelMask::kChannelIteratorFirst;
 
     /**
      * This constructor initializes the object.
@@ -227,37 +224,31 @@ public:
     void UpdateOnReceivedAnnounce(void);
 
 private:
-    enum : uint32_t
-    {
-        // Specifies the time interval (in milliseconds) between
-        // `AnnounceSender` transmit cycles. With in a cycle, device
-        // sends MLE Announcements on all channels from Active
-        // Dataset's channel mask.
-        kInterval = OPENTHREAD_CONFIG_ANNOUNCE_SENDER_INTERVAL,
+    // Specifies the time interval (in milliseconds) between
+    // `AnnounceSender` transmit cycles. Within a cycle, device
+    // sends MLE Announcements on all channels from Active
+    // Dataset's channel mask.
+    static constexpr uint32_t kInterval = OPENTHREAD_CONFIG_ANNOUNCE_SENDER_INTERVAL;
 
-        // Specifies the sub-interval (in millisecond) within a cycle
-        // to send MLE announcement messages. We use half of the cycle
-        // interval length for transmission. This ensures that the
-        // transmissions are finished before device needs to make a
-        // decision about the next cycle. This time is divided by the
-        // number of channels to determine the time between two
-        // successive Announce tx (on different channels).
-        kTxInterval = (kInterval / 2 + 1),
-    };
+    // Specifies the sub-interval (in millisecond) within a cycle
+    // to send MLE announcement messages. We use half of the cycle
+    // interval length for transmission. This ensures that the
+    // transmissions are finished before device needs to make a
+    // decision about the next cycle. This time is divided by the
+    // number of channels to determine the time between two
+    // successive Announce tx (on different channels).
+    static constexpr uint32_t kTxInterval = (kInterval / 2 + 1);
 
-    enum : uint16_t
-    {
-        // Specifies the number of MLE Announcement messages that the
-        // device must receive within a cycle interval to skip sending the
-        // Announcement itself. This is used as `mTrickleTimer` redundancy
-        // constant in `AnnounceSender`.
-        kRedundancyConstant = OPENTHREAD_CONFIG_ANNOUNCE_SENDER_REDUNDANCY_CONSTANT,
+    // Specifies the number of MLE Announcement messages that the
+    // device must receive within a cycle interval to skip sending the
+    // Announcement itself. This is used as `mTrickleTimer` redundancy
+    // constant in `AnnounceSender`.
+    static constexpr uint16_t kRedundancyConstant = OPENTHREAD_CONFIG_ANNOUNCE_SENDER_REDUNDANCY_CONSTANT;
 
-        // Jitter interval (in milliseconds) applied to the period
-        // between any two successive MLE Announcement transmissions
-        // (possibly) on different channels.
-        kMaxJitter = OPENTHREAD_CONFIG_ANNOUNCE_SENDER_JITTER_INTERVAL,
-    };
+    // Jitter interval (in milliseconds) applied to the period
+    // between any two successive MLE Announcement transmissions
+    // (possibly) on different channels.
+    static constexpr uint16_t kMaxJitter = OPENTHREAD_CONFIG_ANNOUNCE_SENDER_JITTER_INTERVAL;
 
     void        Stop(void);
     static void HandleTimer(Timer &aTimer);

--- a/src/core/thread/child_table.hpp
+++ b/src/core/thread/child_table.hpp
@@ -304,10 +304,7 @@ public:
     bool HasSleepyChildWithAddress(const Ip6::Address &aIp6Address) const;
 
 private:
-    enum
-    {
-        kMaxChildren = OPENTHREAD_CONFIG_MLE_MAX_CHILDREN,
-    };
+    static constexpr uint16_t kMaxChildren = OPENTHREAD_CONFIG_MLE_MAX_CHILDREN;
 
     class IteratorBuilder : public InstanceLocator
     {

--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -64,10 +64,7 @@ class CslTxScheduler : public InstanceLocator, private NonCopyable
     friend class IndirectSender;
 
 public:
-    enum
-    {
-        kMaxCslTriggeredTxAttempts = OPENTHREAD_CONFIG_MAC_MAX_TX_ATTEMPTS_INDIRECT_POLLS,
-    };
+    static constexpr uint8_t kMaxCslTriggeredTxAttempts = OPENTHREAD_CONFIG_MAC_MAX_TX_ATTEMPTS_INDIRECT_POLLS;
 
     /**
      * This class defines all the child info required for scheduling CSL transmissions.

--- a/src/core/thread/discover_scanner.hpp
+++ b/src/core/thread/discover_scanner.hpp
@@ -62,10 +62,11 @@ class DiscoverScanner : public InstanceLocator, private NonCopyable
     friend class Mle;
 
 public:
-    enum
-    {
-        kDefaultScanDuration = Mac::kScanDurationDefault, ///< Default scan duration (per channel), in milliseconds.
-    };
+    /**
+     * Default scan duration (per channel), in milliseconds.
+     *
+     */
+    static constexpr uint32_t kDefaultScanDuration = Mac::kScanDurationDefault;
 
     /**
      * This type represents Discover Scan result.
@@ -149,17 +150,14 @@ public:
     Error SetJoinerAdvertisement(uint32_t aOui, const uint8_t *aAdvData, uint8_t aAdvDataLength);
 
 private:
-    enum State
+    enum State : uint8_t
     {
         kStateIdle,
         kStateScanning,
         kStateScanDone,
     };
 
-    enum : uint32_t
-    {
-        kMaxOui = 0xffffff,
-    };
+    static constexpr uint32_t kMaxOui = 0xffffff;
 
     // Methods used by `MeshForwarder`
     Mac::TxFrame *PrepareDiscoveryRequestFrame(Mac::TxFrame &aFrame);

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -171,11 +171,8 @@ public:
 #endif
 
 private:
-    enum
-    {
-        kNewRouterRegistrationDelay = 3, ///< Delay (in seconds) for waiting link establishment for a new Router.
-        kNewDuaRegistrationDelay    = 1, ///< Delay (in seconds) for newly added DUA.
-    };
+    static constexpr uint8_t kNewRouterRegistrationDelay = 3; ///< Delay (in sec) to establish link for a new router.
+    static constexpr uint8_t kNewDuaRegistrationDelay    = 1; ///< Delay (in sec) for newly added DUA.
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     Error GenerateDomainUnicastAddressIid(void);
@@ -225,7 +222,7 @@ private:
     bool           mIsDuaPending : 1;
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
-    enum DuaState
+    enum DuaState : uint8_t
     {
         kNotExist,    ///< DUA is not available.
         kToRegister,  ///< DUA is to be registered.
@@ -233,9 +230,9 @@ private:
         kRegistered,  ///< DUA is registered.
     };
 
-    DuaState  mDuaState : 2;
+    DuaState  mDuaState;
     uint8_t   mDadCounter;
-    TimeMilli mLastRegistrationTime; ///< The time (in milliseconds) when sent last DUA.req or received DUA.rsp.
+    TimeMilli mLastRegistrationTime; // The time (in milliseconds) when sent last DUA.req or received DUA.rsp.
     Ip6::InterfaceIdentifier mFixedDuaInterfaceIdentifier;
     Ip6::NetifUnicastAddress mDomainUnicastAddress;
 #endif
@@ -244,22 +241,22 @@ private:
     {
         struct
         {
-            uint16_t mReregistrationDelay; ///< Delay (in seconds) for DUA re-registration.
-            uint8_t  mCheckDelay;          ///< Delay (in seconds) for checking whether or not registration is required.
+            uint16_t mReregistrationDelay; // Delay (in seconds) for DUA re-registration.
+            uint8_t  mCheckDelay;          // Delay (in seconds) for checking whether or not registration is required.
 #if OPENTHREAD_CONFIG_DUA_ENABLE
-            uint8_t mRegistrationDelay; ///< Delay (in seconds) for DUA registration.
+            uint8_t mRegistrationDelay; // Delay (in seconds) for DUA registration.
 #endif
         } mFields;
-        uint32_t mValue; ///< Non-zero indicates timer should start.
+        uint32_t mValue; // Non-zero indicates timer should start.
     } mDelay;
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE
     // TODO: (DUA) may re-evaluate the alternative option of distributing the flags into the child table:
     //       - Child class itself have some padding - may save some RAM
     //       - Avoid cross reference between a bit-vector and the child entry
-    ChildMask mChildDuaMask;             ///< Child Mask for child who registers DUA via Child Update Request.
-    ChildMask mChildDuaRegisteredMask;   ///< Child Mask for child's DUA that was registered by the parent on behalf.
-    uint16_t  mChildIndexDuaRegistering; ///< Child Index of the DUA being registered.
+    ChildMask mChildDuaMask;             // Child Mask for child who registers DUA via Child Update Request.
+    ChildMask mChildDuaRegisteredMask;   // Child Mask for child's DUA that was registered by the parent on behalf.
+    uint16_t  mChildIndexDuaRegistering; // Child Index of the DUA being registered.
 #endif
 };
 

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -63,11 +63,8 @@ public:
     explicit EnergyScanServer(Instance &aInstance);
 
 private:
-    enum
-    {
-        kScanDelay   = 1000, ///< SCAN_DELAY (milliseconds)
-        kReportDelay = 500,  ///< Delay before sending a report (milliseconds)
-    };
+    static constexpr uint32_t kScanDelay   = 1000; ///< SCAN_DELAY (milliseconds)
+    static constexpr uint32_t kReportDelay = 500;  ///< Delay before sending a report (milliseconds)
 
     static void HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleRequest(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/thread/indirect_sender.hpp
+++ b/src/core/thread/indirect_sender.hpp
@@ -203,14 +203,11 @@ public:
     void HandleChildModeChange(Child &aChild, Mle::DeviceMode aOldMode);
 
 private:
-    enum
-    {
-        /**
-         * Indicates whether to set/enable 15.4 ack request in the MAC header of a supervision message.
-         *
-         */
-        kSupervisionMsgAckRequest = (OPENTHREAD_CONFIG_CHILD_SUPERVISION_MSG_NO_ACK_REQUEST == 0) ? true : false,
-    };
+    /**
+     * Indicates whether to set/enable 15.4 ack request in the MAC header of a supervision message.
+     *
+     */
+    static constexpr bool kSupervisionMsgAckRequest = (OPENTHREAD_CONFIG_CHILD_SUPERVISION_MSG_NO_ACK_REQUEST == 0);
 
     // Callbacks from DataPollHandler
     Error PrepareFrameForChild(Mac::TxFrame &aFrame, FrameContext &aContext, Child &aChild);

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -69,17 +69,14 @@ namespace ot {
 class SecurityPolicy : public otSecurityPolicy, public Equatable<SecurityPolicy>
 {
 public:
-    enum : uint8_t
-    {
-        kVersionThresholdOffsetVersion = 3, ///< Offset between the Thread Version and the
-                                            ///< Version-thresold valid for Routing.
-    };
+    /**
+     * Offset between the Thread Version and the Version-threshold valid for Routing.
+     *
+     */
+    static constexpr uint8_t kVersionThresholdOffsetVersion = 3;
 
-    enum : uint16_t
-    {
-        kMinKeyRotationTime     = 1,   ///< The minimum Key Rotation Time in hours.
-        kDefaultKeyRotationTime = 672, ///< Default Key Rotation Time (in unit of hours).
-    };
+    static constexpr uint16_t kMinKeyRotationTime     = 1;   ///< The minimum Key Rotation Time in hours.
+    static constexpr uint16_t kDefaultKeyRotationTime = 672; ///< Default Key Rotation Time (in unit of hours).
 
     /**
      * This constructor initializes the object with default Key Rotation Time
@@ -114,22 +111,19 @@ public:
     void GetFlags(uint8_t *aFlags, uint8_t aFlagsLength) const;
 
 private:
-    enum : uint8_t
-    {
-        kDefaultFlags                   = 0xff,
-        kObtainNetworkKeyMask           = 1 << 7,
-        kNativeCommissioningMask        = 1 << 6,
-        kRoutersMask                    = 1 << 5,
-        kExternalCommissioningMask      = 1 << 4,
-        kBeaconsMask                    = 1 << 3,
-        kCommercialCommissioningMask    = 1 << 2,
-        kAutonomousEnrollmentMask       = 1 << 1,
-        kNetworkKeyProvisioningMask     = 1 << 0,
-        kTobleLinkMask                  = 1 << 7,
-        kNonCcmRoutersMask              = 1 << 6,
-        kReservedMask                   = 0x38,
-        kVersionThresholdForRoutingMask = 0x07,
-    };
+    static constexpr uint8_t kDefaultFlags                   = 0xff;
+    static constexpr uint8_t kObtainNetworkKeyMask           = 1 << 7;
+    static constexpr uint8_t kNativeCommissioningMask        = 1 << 6;
+    static constexpr uint8_t kRoutersMask                    = 1 << 5;
+    static constexpr uint8_t kExternalCommissioningMask      = 1 << 4;
+    static constexpr uint8_t kBeaconsMask                    = 1 << 3;
+    static constexpr uint8_t kCommercialCommissioningMask    = 1 << 2;
+    static constexpr uint8_t kAutonomousEnrollmentMask       = 1 << 1;
+    static constexpr uint8_t kNetworkKeyProvisioningMask     = 1 << 0;
+    static constexpr uint8_t kTobleLinkMask                  = 1 << 7;
+    static constexpr uint8_t kNonCcmRoutersMask              = 1 << 6;
+    static constexpr uint8_t kReservedMask                   = 0x38;
+    static constexpr uint8_t kVersionThresholdForRoutingMask = 0x07;
 
     void SetToDefaultFlags(void);
 };
@@ -485,11 +479,8 @@ public:
     void MacFrameCounterUpdated(uint32_t aMacFrameCounter);
 
 private:
-    enum
-    {
-        kDefaultKeySwitchGuardTime = 624,
-        kOneHourIntervalInMsec     = 3600u * 1000u,
-    };
+    static constexpr uint32_t kDefaultKeySwitchGuardTime = 624;
+    static constexpr uint32_t kOneHourIntervalInMsec     = 3600u * 1000u;
 
     OT_TOOL_PACKED_BEGIN
     struct Keys

--- a/src/core/thread/link_metrics_tlvs.hpp
+++ b/src/core/thread/link_metrics_tlvs.hpp
@@ -669,13 +669,9 @@ public:
     }
 
 private:
-    enum
-    {
-        kMaxTypeIdFlagsEnhAck = 3,
-
-        kEnhAckFlagsOffset = 0,
-        kTypeIdFlagsOffset = sizeof(TypeIdFlags),
-    };
+    static constexpr uint8_t  kMaxTypeIdFlagsEnhAck = 3;
+    static constexpr uint8_t  kEnhAckFlagsOffset    = 0;
+    static constexpr uint16_t kTypeIdFlagsOffset    = sizeof(TypeIdFlags);
 
     uint8_t mSubTlvs[sizeof(EnhAckFlags) + sizeof(TypeIdFlags) * kMaxTypeIdFlagsEnhAck];
 } OT_TOOL_PACKED_END;

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -224,6 +224,12 @@ int8_t LinkQualityInfo::ConvertLinkQualityToRss(int8_t aNoiseFloor, uint8_t aLin
 
 uint8_t LinkQualityInfo::CalculateLinkQuality(uint8_t aLinkMargin, uint8_t aLastLinkQuality)
 {
+    // Static private method to calculate the link quality from a given
+    // link margin while taking into account the last link quality
+    // value and adding the hysteresis value to the thresholds. If
+    // there is no previous value for link quality, the constant
+    // kNoLinkQuality should be passed as the second argument.
+
     uint8_t threshold1, threshold2, threshold3;
     uint8_t linkQuality = 0;
 

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -63,10 +63,7 @@ namespace ot {
 class SuccessRateTracker : public Clearable<SuccessRateTracker>
 {
 public:
-    enum
-    {
-        kMaxRateValue = 0xffff, ///< Indicates value corresponding to maximum (failure/success) rate of 100%.
-    };
+    static constexpr uint16_t kMaxRateValue = 0xffff; ///< Value corresponding to max (failure/success) rate of 100%.
 
     /**
      * This method adds a sample (success or failure) to `SuccessRateTracker`.
@@ -94,10 +91,7 @@ public:
     uint16_t GetSuccessRate(void) const { return kMaxRateValue - mFailureRate; }
 
 private:
-    enum
-    {
-        kDefaultWeight = 64,
-    };
+    static constexpr uint16_t kDefaultWeight = 64;
 
     uint16_t mFailureRate;
 };
@@ -111,10 +105,7 @@ private:
 class RssAverager : public Clearable<RssAverager>
 {
 public:
-    enum
-    {
-        kStringSize = 10, ///< Max chars needed for a string representation of average (@sa ToString()).
-    };
+    static constexpr uint16_t kStringSize = 10; ///< Max string size for average (@sa ToString()).
 
     /**
      * This type defines the fixed-length `String` object returned from `ToString()`.
@@ -184,15 +175,10 @@ private:
      * precision factor of -8.
      *
      */
-
-    enum
-    {
-        kPrecisionBitShift = 3, // Precision multiple for RSS average (1 << PrecisionBitShift).
-        kPrecision         = (1 << kPrecisionBitShift),
-        kPrecisionBitMask  = (kPrecision - 1),
-
-        kCoeffBitShift = 3, // Coefficient used for exponentially weighted filter (1 << kCoeffBitShift).
-    };
+    static constexpr uint8_t kPrecisionBitShift = 3; // Precision multiple for RSS average (1 << PrecisionBitShift).
+    static constexpr uint8_t kPrecision         = (1 << kPrecisionBitShift);
+    static constexpr uint8_t kPrecisionBitMask  = (kPrecision - 1);
+    static constexpr uint8_t kCoeffBitShift     = 3; // Coeff for exp weighted filter (1 << kCoeffBitShift).
 
     // Member variables fit into two bytes.
 
@@ -234,13 +220,10 @@ public:
     uint8_t GetCount(void) const { return mCount; }
 
 private:
-    enum
-    {
-        kCoeffBitShift = 3, ///< Coefficient used for exponentially weighted filter (1 << kCoeffBitShift).
-    };
+    static constexpr uint8_t kCoeffBitShift = 3; // Coeff used for exp weighted filter (1 << kCoeffBitShift).
 
-    uint8_t mAverage; ///< The average link quality indicator value.
-    uint8_t mCount;   ///< Number of LQI values added to averager so far.
+    uint8_t mAverage; // The average link quality indicator value.
+    uint8_t mCount;   // Number of LQI values added to averager so far.
 };
 
 /**
@@ -251,10 +234,7 @@ private:
 class LinkQualityInfo : public InstanceLocatorInit
 {
 public:
-    enum
-    {
-        kInfoStringSize = 50, ///< Max chars needed for the info string representation (@sa ToInfoString())
-    };
+    static constexpr uint16_t kInfoStringSize = 50; ///< `InfoString` size (@sa ToInfoString()).
 
     /**
      * This type defines the fixed-length `String` object returned from `ToInfoString()`.
@@ -425,44 +405,35 @@ public:
     static uint8_t ConvertRssToLinkQuality(int8_t aNoiseFloor, int8_t aRss);
 
     /**
-     * This method converts a link quality value to a typical received signal strength value .
-     * @note only for test
+     * This method converts a link quality value to a typical received signal strength value.
+     *
+     * @note only for test.
      *
      * @param[in]  aNoiseFloor   The noise floor value (in dBm).
      * @param[in]  aLinkQuality  The link quality value in [0, 3].
      *
-     * @returns The typical platform rssi.
+     * @returns The typical platform RSSI.
      *
      */
     static int8_t ConvertLinkQualityToRss(int8_t aNoiseFloor, uint8_t aLinkQuality);
 
 private:
-    enum
-    {
-        // Constants for obtaining link quality from link margin:
+    // Constants for obtaining link quality from link margin:
 
-        kThreshold3          = 20, ///< Link margin threshold for quality 3 link.
-        kThreshold2          = 10, ///< Link margin threshold for quality 2 link.
-        kThreshold1          = 2,  ///< Link margin threshold for quality 1 link.
-        kHysteresisThreshold = 2,  ///< Link margin hysteresis threshold.
+    static constexpr uint8_t kThreshold3          = 20; // Link margin threshold for quality 3 link.
+    static constexpr uint8_t kThreshold2          = 10; // Link margin threshold for quality 2 link.
+    static constexpr uint8_t kThreshold1          = 2;  // Link margin threshold for quality 1 link.
+    static constexpr uint8_t kHysteresisThreshold = 2;  // Link margin hysteresis threshold.
 
-        // constants for test:
+    static constexpr int8_t kLinkQuality3LinkMargin = 50; // link margin for Link Quality 3 (21 - 255)
+    static constexpr int8_t kLinkQuality2LinkMargin = 15; // link margin for Link Quality 3 (21 - 255)
+    static constexpr int8_t kLinkQuality1LinkMargin = 5;  // link margin for Link Quality 3 (21 - 255)
+    static constexpr int8_t kLinkQuality0LinkMargin = 0;  // link margin for Link Quality 3 (21 - 255)
 
-        kLinkQuality3LinkMargin = 50, ///< link margin for Link Quality 3 (21 - 255)
-        kLinkQuality2LinkMargin = 15, ///< link margin for Link Quality 3 (21 - 255)
-        kLinkQuality1LinkMargin = 5,  ///< link margin for Link Quality 3 (21 - 255)
-        kLinkQuality0LinkMargin = 0,  ///< link margin for Link Quality 3 (21 - 255)
-
-        kNoLinkQuality = 0xff, // Used to indicate that there is no previous/last link quality.
-    };
+    static constexpr uint8_t kNoLinkQuality = 0xff; // Indicate that there is no previous/last link quality.
 
     void SetLinkQuality(uint8_t aLinkQuality) { mLinkQuality = aLinkQuality; }
 
-    /* Static private method to calculate the link quality from a given link margin while taking into account the last
-     * link quality value and adding the hysteresis value to the thresholds. If there is no previous value for link
-     * quality, the constant kNoLinkQuality should be passed as the second argument.
-     *
-     */
     static uint8_t CalculateLinkQuality(uint8_t aLinkMargin, uint8_t aLastLinkQuality);
 
     RssAverager mRssAverager;

--- a/src/core/thread/lowpan.cpp
+++ b/src/core/thread/lowpan.cpp
@@ -1347,7 +1347,7 @@ uint16_t FragmentHeader::WriteTo(uint8_t *aFrame) const
 {
     uint8_t *cur = aFrame;
 
-    WriteUint16((kDispatch << 8) + mSize, cur);
+    WriteUint16((static_cast<uint16_t>(kDispatch) << 8) + mSize, cur);
     cur += sizeof(uint16_t);
 
     WriteUint16(mTag, cur);

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -309,54 +309,52 @@ public:
     int DecompressUdpHeader(Ip6::Udp::Header &aUdpHeader, const uint8_t *aBuf, uint16_t aBufLength);
 
 private:
-    enum
-    {
-        kHcDispatch     = 3 << 13,
-        kHcDispatchMask = 7 << 13,
+    static constexpr uint16_t kHcDispatch     = 3 << 13;
+    static constexpr uint16_t kHcDispatchMask = 7 << 13;
 
-        kHcTrafficClass    = 1 << 11,
-        kHcFlowLabel       = 2 << 11,
-        kHcTrafficFlow     = 3 << 11,
-        kHcTrafficFlowMask = 3 << 11,
-        kHcNextHeader      = 1 << 10,
-        kHcHopLimit1       = 1 << 8,
-        kHcHopLimit64      = 2 << 8,
-        kHcHopLimit255     = 3 << 8,
-        kHcHopLimitMask    = 3 << 8,
-        kHcContextId       = 1 << 7,
-        kHcSrcAddrContext  = 1 << 6,
-        kHcSrcAddrMode0    = 0 << 4,
-        kHcSrcAddrMode1    = 1 << 4,
-        kHcSrcAddrMode2    = 2 << 4,
-        kHcSrcAddrMode3    = 3 << 4,
-        kHcSrcAddrModeMask = 3 << 4,
-        kHcMulticast       = 1 << 3,
-        kHcDstAddrContext  = 1 << 2,
-        kHcDstAddrMode0    = 0 << 0,
-        kHcDstAddrMode1    = 1 << 0,
-        kHcDstAddrMode2    = 2 << 0,
-        kHcDstAddrMode3    = 3 << 0,
-        kHcDstAddrModeMask = 3 << 0,
+    static constexpr uint16_t kHcTrafficClass    = 1 << 11;
+    static constexpr uint16_t kHcFlowLabel       = 2 << 11;
+    static constexpr uint16_t kHcTrafficFlow     = 3 << 11;
+    static constexpr uint16_t kHcTrafficFlowMask = 3 << 11;
+    static constexpr uint16_t kHcNextHeader      = 1 << 10;
+    static constexpr uint16_t kHcHopLimit1       = 1 << 8;
+    static constexpr uint16_t kHcHopLimit64      = 2 << 8;
+    static constexpr uint16_t kHcHopLimit255     = 3 << 8;
+    static constexpr uint16_t kHcHopLimitMask    = 3 << 8;
+    static constexpr uint16_t kHcContextId       = 1 << 7;
+    static constexpr uint16_t kHcSrcAddrContext  = 1 << 6;
+    static constexpr uint16_t kHcSrcAddrMode0    = 0 << 4;
+    static constexpr uint16_t kHcSrcAddrMode1    = 1 << 4;
+    static constexpr uint16_t kHcSrcAddrMode2    = 2 << 4;
+    static constexpr uint16_t kHcSrcAddrMode3    = 3 << 4;
+    static constexpr uint16_t kHcSrcAddrModeMask = 3 << 4;
+    static constexpr uint16_t kHcMulticast       = 1 << 3;
+    static constexpr uint16_t kHcDstAddrContext  = 1 << 2;
+    static constexpr uint16_t kHcDstAddrMode0    = 0 << 0;
+    static constexpr uint16_t kHcDstAddrMode1    = 1 << 0;
+    static constexpr uint16_t kHcDstAddrMode2    = 2 << 0;
+    static constexpr uint16_t kHcDstAddrMode3    = 3 << 0;
+    static constexpr uint16_t kHcDstAddrModeMask = 3 << 0;
 
-        kExtHdrDispatch     = 0xe0,
-        kExtHdrDispatchMask = 0xf0,
+    static constexpr uint8_t kExtHdrDispatch     = 0xe0;
+    static constexpr uint8_t kExtHdrDispatchMask = 0xf0;
 
-        kExtHdrEidHbh      = 0x00,
-        kExtHdrEidRouting  = 0x02,
-        kExtHdrEidFragment = 0x04,
-        kExtHdrEidDst      = 0x06,
-        kExtHdrEidMobility = 0x08,
-        kExtHdrEidIp6      = 0x0e,
-        kExtHdrEidMask     = 0x0e,
+    static constexpr uint8_t kExtHdrEidHbh      = 0x00;
+    static constexpr uint8_t kExtHdrEidRouting  = 0x02;
+    static constexpr uint8_t kExtHdrEidFragment = 0x04;
+    static constexpr uint8_t kExtHdrEidDst      = 0x06;
+    static constexpr uint8_t kExtHdrEidMobility = 0x08;
+    static constexpr uint8_t kExtHdrEidIp6      = 0x0e;
+    static constexpr uint8_t kExtHdrEidMask     = 0x0e;
 
-        kExtHdrNextHeader = 0x01,
-        kExtHdrMaxLength  = 255,
+    static constexpr uint8_t  kExtHdrNextHeader = 0x01;
+    static constexpr uint16_t kExtHdrMaxLength  = 255;
 
-        kUdpDispatch     = 0xf0,
-        kUdpDispatchMask = 0xf8,
-        kUdpChecksum     = 1 << 2,
-        kUdpPortMask     = 3 << 0,
-    };
+    static constexpr uint8_t kUdpDispatch     = 0xf0;
+    static constexpr uint8_t kUdpDispatchMask = 0xf8;
+
+    static constexpr uint8_t kUdpChecksum = 1 << 2;
+    static constexpr uint8_t kUdpPortMask = 3 << 0;
 
     Error Compress(Message &           aMessage,
                    const Mac::Address &aMacSource,
@@ -393,10 +391,11 @@ private:
 class MeshHeader
 {
 public:
-    enum
-    {
-        kAdditionalHopsLeft = 1 ///< The additional value that is added to predicted value of the route cost.
-    };
+    /**
+     * The additional value that is added to predicted value of the route cost.
+     *
+     */
+    static constexpr uint8_t kAdditionalHopsLeft = 1;
 
     /**
      * This method initializes the Mesh Header with a given Mesh Source, Mesh Destination and Hops Left value.
@@ -530,17 +529,16 @@ public:
     uint16_t WriteTo(Message &aMessage, uint16_t aOffset) const;
 
 private:
-    enum
-    {
-        kDispatch             = 2 << 6,
-        kDispatchMask         = 3 << 6,
-        kHopsLeftMask         = 0x0f,
-        kSourceShort          = 1 << 5,
-        kDestShort            = 1 << 4,
-        kDeepHopsLeft         = 0x0f,
-        kMinHeaderLength      = sizeof(uint8_t) + sizeof(uint16_t) + sizeof(uint16_t), // dispatch byte + src + dest
-        kDeepHopsHeaderLength = kMinHeaderLength + sizeof(uint8_t),                    // min header + deep hops
-    };
+    static constexpr uint8_t kDispatch     = 2 << 6;
+    static constexpr uint8_t kDispatchMask = 3 << 6;
+    static constexpr uint8_t kHopsLeftMask = 0x0f;
+    static constexpr uint8_t kSourceShort  = 1 << 5;
+    static constexpr uint8_t kDestShort    = 1 << 4;
+    static constexpr uint8_t kDeepHopsLeft = 0x0f;
+
+    // Dispatch byte + src + dest
+    static constexpr uint16_t kMinHeaderLength      = sizeof(uint8_t) + sizeof(uint16_t) + sizeof(uint16_t);
+    static constexpr uint16_t kDeepHopsHeaderLength = kMinHeaderLength + sizeof(uint8_t); // min header + deep hops
 
     uint16_t mSource;
     uint16_t mDestination;
@@ -554,11 +552,8 @@ private:
 class FragmentHeader
 {
 public:
-    enum
-    {
-        kFirstFragmentHeaderSize      = 4, ///< First fragment header size in octets.
-        kSubsequentFragmentHeaderSize = 5, ///< Subsequent fragment header size in octets.
-    };
+    static constexpr uint16_t kFirstFragmentHeaderSize      = 4; ///< First fragment header size in octets.
+    static constexpr uint16_t kSubsequentFragmentHeaderSize = 5; ///< Subsequent fragment header size in octets.
 
     /**
      * This method initializes the Fragment Header as a first fragment.
@@ -661,17 +656,16 @@ public:
     uint16_t WriteTo(uint8_t *aFrame) const;
 
 private:
-    enum
-    {
-        kDispatch     = 0xc0,   // 0b1100_0000
-        kDispatchMask = 0xd8,   // 0b1101_1000 which accepts first frag (0b1100_0xxx) and next frag (0b1110_0xxx).
-        kOffsetFlag   = 1 << 5, // Dispatch flag to indicate first (no offset) vs. next (offset is present) fragment.
-        kSizeMask     = 0x7ff,  // 0b0111_1111_1111 (first 11 bits).
-        kOffsetMask   = 0xfff8, // Clears the last 3 bits to ensure offset is a multiple of 8.
-        kSizeIndex    = 0,      // Start index of Size field in the Fragment Header byte sequence.
-        kTagIndex     = 2,      // Start index of Tag field in the Fragment Header byte sequence.
-        kOffsetIndex  = 4,      // Start index of Offset field in the Fragment Header byte sequence.
-    };
+    static constexpr uint8_t kDispatch     = 0xc0;   // 0b1100_0000
+    static constexpr uint8_t kDispatchMask = 0xd8;   // 0b1101_1000 accepts first (0b1100_0xxx) and next (0b1110_0xxx).
+    static constexpr uint8_t kOffsetFlag   = 1 << 5; // Indicate first (no offset) vs. next (offset present) fragment.
+
+    static constexpr uint16_t kSizeMask   = 0x7ff;  // 0b0111_1111_1111 (first 11 bits).
+    static constexpr uint16_t kOffsetMask = 0xfff8; // Clears the last 3 bits to ensure offset is a multiple of 8.
+
+    static constexpr uint8_t kSizeIndex   = 0; // Start index of Size field in the Fragment Header byte sequence.
+    static constexpr uint8_t kTagIndex    = 2; // Start index of Tag field in the Fragment Header byte sequence.
+    static constexpr uint8_t kOffsetIndex = 4; // Start index of Offset field in the Fragment Header byte sequence.
 
     uint16_t mSize;
     uint16_t mTag;

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -322,21 +322,18 @@ public:
 #endif
 
 private:
-    enum : uint8_t
-    {
-        kReassemblyTimeout      = OPENTHREAD_CONFIG_6LOWPAN_REASSEMBLY_TIMEOUT, // Reassembly timeout (in seconds).
-        kMeshHeaderFrameMtu     = OT_RADIO_FRAME_MAX_SIZE, // Max. MTU allowed when generating a Mesh Header frame.
-        kMeshHeaderFrameFcsSize = sizeof(uint16_t),        // Frame FCS size for Mesh Header frame.
-    };
+    static constexpr uint8_t kReassemblyTimeout      = OPENTHREAD_CONFIG_6LOWPAN_REASSEMBLY_TIMEOUT; // in seconds.
+    static constexpr uint8_t kMeshHeaderFrameMtu     = OT_RADIO_FRAME_MAX_SIZE; // Max MTU with a Mesh Header frame.
+    static constexpr uint8_t kMeshHeaderFrameFcsSize = sizeof(uint16_t);        // Frame FCS size for Mesh Header frame.
 
-    enum MessageAction : uint8_t ///< Defines the action parameter in `LogMessageInfo()` method.
+    enum MessageAction : uint8_t
     {
-        kMessageReceive,         ///< Indicates that the message was received.
-        kMessageTransmit,        ///< Indicates that the message was sent.
-        kMessagePrepareIndirect, ///< Indicates that the message is being prepared for indirect tx.
-        kMessageDrop,            ///< Indicates that the outbound message is being dropped (e.g., dst unknown).
-        kMessageReassemblyDrop,  ///< Indicates that the message is being dropped from reassembly list.
-        kMessageEvict,           ///< Indicates that the message was evicted.
+        kMessageReceive,         // Indicates that the message was received.
+        kMessageTransmit,        // Indicates that the message was sent.
+        kMessagePrepareIndirect, // Indicates that the message is being prepared for indirect tx.
+        kMessageDrop,            // Indicates that the outbound message is being dropped (e.g., dst unknown).
+        kMessageReassemblyDrop,  // Indicates that the message is being dropped from reassembly list.
+        kMessageEvict,           // Indicates that the message was evicted.
     };
 
     enum AnycastType : uint8_t
@@ -377,10 +374,7 @@ private:
         bool   UpdateOnTimeTick(void);
 
     private:
-        enum : uint16_t
-        {
-            kNumEntries = OPENTHREAD_CONFIG_NUM_FRAGMENT_PRIORITY_ENTRIES,
-        };
+        static constexpr uint16_t kNumEntries = OPENTHREAD_CONFIG_NUM_FRAGMENT_PRIORITY_ENTRIES;
 
         Entry mEntries[kNumEntries];
     };

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -786,14 +786,14 @@ protected:
         kCommandLinkMetricsManagementRequest  = 18, ///< Link Metrics Management Request
         kCommandLinkMetricsManagementResponse = 19, ///< Link Metrics Management Response
         kCommandLinkProbe                     = 20, ///< Link Probe
-        kCommandTimeSync = 99, ///< Time Sync (applicable when OPENTHREAD_CONFIG_TIME_SYNC_ENABLE enabled)
+        kCommandTimeSync                      = 99, ///< Time Sync (when OPENTHREAD_CONFIG_TIME_SYNC_ENABLE enabled)
     };
 
     /**
      * States during attach (when searching for a parent).
      *
      */
-    enum AttachState
+    enum AttachState : uint8_t
     {
         kAttachStateIdle,                ///< Not currently searching for a parent.
         kAttachStateProcessAnnounce,     ///< Waiting to process a received Announce (to switch channel/pan-id).
@@ -808,7 +808,7 @@ protected:
      * States when reattaching network using stored dataset
      *
      */
-    enum ReattachState
+    enum ReattachState : uint8_t
     {
         kReattachStop    = 0, ///< Reattach process is disabled or finished
         kReattachStart   = 1, ///< Start reattach process
@@ -816,17 +816,14 @@ protected:
         kReattachPending = 3, ///< Reattach using stored Pending Dataset
     };
 
-    enum
-    {
-        kMleMaxResponseDelay = 1000u, ///< Maximum delay before responding to a multicast request.
-    };
+    static constexpr uint16_t kMleMaxResponseDelay = 1000u; ///< Max delay before responding to a multicast request.
 
     /**
      * This enumeration type is used in `AppendAddressRegistration()` to determine which addresses to include in the
      * appended Address Registration TLV.
      *
      */
-    enum AddressRegistrationMode
+    enum AddressRegistrationMode : uint8_t
     {
         kAppendAllAddresses,  ///< Append all addresses (unicast/multicast) in Address Registration TLV.
         kAppendMeshLocalOnly, ///< Only append the Mesh Local (ML-EID) address in Address Registration TLV.
@@ -935,10 +932,7 @@ protected:
      */
     struct RequestedTlvs
     {
-        enum
-        {
-            kMaxNumTlvs = 16, ///< Maximum number of TLVs in request array.
-        };
+        static constexpr uint8_t kMaxNumTlvs = 16; ///< Maximum number of TLVs in request array.
 
         uint8_t mTlvs[kMaxNumTlvs]; ///< Array of requested TLVs.
         uint8_t mNumTlvs;           ///< Number of TLVs in the array.
@@ -1619,45 +1613,40 @@ protected:
     uint8_t       mParentLeaderCost;
 
 private:
-    enum
-    {
-        kMleHopLimit        = 255,
-        kMleSecurityTagSize = 4, // Security tag size in bytes.
+    static constexpr uint8_t kMleHopLimit        = 255;
+    static constexpr uint8_t kMleSecurityTagSize = 4; // Security tag size in bytes.
 
-        // Parameters related to "periodic parent search" feature (CONFIG_ENABLE_PERIODIC_PARENT_SEARCH).
-        // All timer intervals are converted to milliseconds.
-        kParentSearchCheckInterval   = (OPENTHREAD_CONFIG_PARENT_SEARCH_CHECK_INTERVAL * 1000u),
-        kParentSearchBackoffInterval = (OPENTHREAD_CONFIG_PARENT_SEARCH_BACKOFF_INTERVAL * 1000u),
-        kParentSearchJitterInterval  = (15 * 1000u),
-        kParentSearchRssThreadhold   = OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD,
-    };
+    // Parameters related to "periodic parent search" feature (CONFIG_ENABLE_PERIODIC_PARENT_SEARCH).
+    // All timer intervals are converted to milliseconds.
+    static constexpr uint32_t kParentSearchCheckInterval   = (OPENTHREAD_CONFIG_PARENT_SEARCH_CHECK_INTERVAL * 1000u);
+    static constexpr uint32_t kParentSearchBackoffInterval = (OPENTHREAD_CONFIG_PARENT_SEARCH_BACKOFF_INTERVAL * 1000u);
+    static constexpr uint32_t kParentSearchJitterInterval  = (15 * 1000u);
+    static constexpr int8_t   kParentSearchRssThreadhold   = OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD;
 
     // Parameters for "attach backoff" feature (CONFIG_ENABLE_ATTACH_BACKOFF) - Intervals are in milliseconds.
-    enum : uint32_t
+    static constexpr uint32_t kAttachBackoffMinInterval = OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_MINIMUM_INTERVAL;
+    static constexpr uint32_t kAttachBackoffMaxInterval = OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_MAXIMUM_INTERVAL;
+    static constexpr uint32_t kAttachBackoffJitter      = OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_JITTER_INTERVAL;
+    static constexpr uint32_t kAttachBackoffDelayToResetCounter =
+        OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_DELAY_TO_RESET_BACKOFF_INTERVAL;
+
+    enum ParentRequestType : uint8_t
     {
-        kAttachBackoffMinInterval         = OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_MINIMUM_INTERVAL,
-        kAttachBackoffMaxInterval         = OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_MAXIMUM_INTERVAL,
-        kAttachBackoffJitter              = OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_JITTER_INTERVAL,
-        kAttachBackoffDelayToResetCounter = OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_DELAY_TO_RESET_BACKOFF_INTERVAL,
+        kParentRequestTypeRouters,         // Parent Request to all routers.
+        kParentRequestTypeRoutersAndReeds, // Parent Request to all routers and REEDs.
     };
 
-    enum ParentRequestType
+    enum ChildUpdateRequestState : uint8_t
     {
-        kParentRequestTypeRouters,         ///< Parent Request to all routers.
-        kParentRequestTypeRoutersAndReeds, ///< Parent Request to all routers and REEDs.
+        kChildUpdateRequestNone,    // No pending or active Child Update Request.
+        kChildUpdateRequestPending, // Pending Child Update Request due to relative OT_CHANGED event.
+        kChildUpdateRequestActive,  // Child Update Request has been sent and Child Update Response is expected.
     };
 
-    enum ChildUpdateRequestState
+    enum DataRequestState : uint8_t
     {
-        kChildUpdateRequestNone,    ///< No pending or active Child Update Request.
-        kChildUpdateRequestPending, ///< Pending Child Update Request due to relative OT_CHANGED event.
-        kChildUpdateRequestActive,  ///< Child Update Request has been sent and Child Update Response is expected.
-    };
-
-    enum DataRequestState
-    {
-        kDataRequestNone,   ///< Not waiting for a Data Response.
-        kDataRequestActive, ///< Data Request has been sent, Data Response is expected.
+        kDataRequestNone,   // Not waiting for a Data Response.
+        kDataRequestActive, // Data Request has been sent, Data Response is expected.
     };
 
     struct DelayedResponseMetadata
@@ -1674,7 +1663,7 @@ private:
     class Header
     {
     public:
-        enum SecuritySuite
+        enum SecuritySuite : uint8_t
         {
             k154Security = 0,
             kNoSecurity  = 255,

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -555,12 +555,9 @@ public:
 #endif
 
 private:
-    enum
-    {
-        kDiscoveryMaxJitter = 250u,  ///< Maximum jitter time used to delay Discovery Responses in milliseconds.
-        kStateUpdatePeriod  = 1000u, ///< State update period in milliseconds.
-        kUnsolicitedDataResponseJitter = 500u, ///< Maximum delay before unsolicited Data Response in milliseconds.
-    };
+    static constexpr uint16_t kDiscoveryMaxJitter            = 250;  // Max jitter delay Discovery Responses (in msec).
+    static constexpr uint32_t kStateUpdatePeriod             = 1000; // State update period (in msec).
+    static constexpr uint16_t kUnsolicitedDataResponseJitter = 500;  // Max delay for unsol Data Response (in msec).
 
     Error AppendConnectivity(Message &aMessage);
     Error AppendChildAddresses(Message &aMessage, Child &aChild);

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -73,7 +73,7 @@ public:
      * MLE TLV Types.
      *
      */
-    enum Type
+    enum Type : uint8_t
     {
         kSourceAddress         = 0,  ///< Source Address TLV
         kMode                  = 1,  ///< Mode TLV
@@ -393,15 +393,13 @@ public:
     }
 
 private:
-    enum
-    {
-        kLinkQualityOutOffset = 6,
-        kLinkQualityOutMask   = 3 << kLinkQualityOutOffset,
-        kLinkQualityInOffset  = 4,
-        kLinkQualityInMask    = 3 << kLinkQualityInOffset,
-        kRouteCostOffset      = 0,
-        kRouteCostMask        = 0xf << kRouteCostOffset,
-    };
+    static constexpr uint8_t kLinkQualityOutOffset = 6;
+    static constexpr uint8_t kLinkQualityOutMask   = 3 << kLinkQualityOutOffset;
+    static constexpr uint8_t kLinkQualityInOffset  = 4;
+    static constexpr uint8_t kLinkQualityInMask    = 3 << kLinkQualityInOffset;
+    static constexpr uint8_t kRouteCostOffset      = 0;
+    static constexpr uint8_t kRouteCostMask        = 0xf << kRouteCostOffset;
+
     uint8_t     mRouterIdSequence;
     RouterIdSet mRouterIdMask;
     uint8_t     mRouteData[kMaxRouterId + 1];
@@ -613,16 +611,14 @@ public:
     }
 
 private:
-    enum
-    {
-        kLinkQualityOutOffset = 6,
-        kLinkQualityOutMask   = 3 << kLinkQualityOutOffset,
-        kLinkQualityInOffset  = 4,
-        kLinkQualityInMask    = 3 << kLinkQualityInOffset,
-        kRouteCostOffset      = 0,
-        kRouteCostMask        = 0xf << kRouteCostOffset,
-        kOddEntryOffset       = 4,
-    };
+    static constexpr uint8_t kLinkQualityOutOffset = 6;
+    static constexpr uint8_t kLinkQualityOutMask   = 3 << kLinkQualityOutOffset;
+    static constexpr uint8_t kLinkQualityInOffset  = 4;
+    static constexpr uint8_t kLinkQualityInMask    = 3 << kLinkQualityInOffset;
+    static constexpr uint8_t kRouteCostOffset      = 0;
+    static constexpr uint8_t kRouteCostMask        = 0xf << kRouteCostOffset;
+    static constexpr uint8_t kOddEntryOffset       = 4;
+
     uint8_t     mRouterIdSequence;
     RouterIdSet mRouterIdMask;
     // Since we do hold 12 (compressible to 11) bits of data per router, each entry occupies 1.5 bytes,
@@ -704,11 +700,8 @@ private:
 class ScanMaskTlv : public UintTlvInfo<Tlv::kScanMask, uint8_t>
 {
 public:
-    enum
-    {
-        kRouterFlag    = 1 << 7, ///< Scan Mask Router Flag.
-        kEndDeviceFlag = 1 << 6, ///< Scan Mask End Device Flag.
-    };
+    static constexpr uint8_t kRouterFlag    = 1 << 7; ///< Scan Mask Router Flag.
+    static constexpr uint8_t kEndDeviceFlag = 1 << 6; ///< Scan Mask End Device Flag.
 
     /**
      * This method indicates whether or not the Router flag is set.
@@ -940,11 +933,8 @@ public:
     void SetSedDatagramCount(uint8_t aSedDatagramCount) { mSedDatagramCount = aSedDatagramCount; }
 
 private:
-    enum
-    {
-        kParentPriorityOffset = 6,
-        kParentPriorityMask   = 3 << kParentPriorityOffset,
-    };
+    static constexpr uint8_t kParentPriorityOffset = 6;
+    static constexpr uint8_t kParentPriorityMask   = 3 << kParentPriorityOffset;
 
     uint8_t  mParentPriority;
     uint8_t  mLinkQuality3;
@@ -1053,11 +1043,8 @@ public:
     void SetIp6Address(const Ip6::Address &aAddress) { mIp6Address = aAddress; }
 
 private:
-    enum
-    {
-        kCompressed = 1 << 7,
-        kCidMask    = 0xf,
-    };
+    static constexpr uint8_t kCompressed = 1 << 7;
+    static constexpr uint8_t kCidMask    = 0xf;
 
     uint8_t mControl;
     union

--- a/src/core/thread/mlr_types.hpp
+++ b/src/core/thread/mlr_types.hpp
@@ -51,7 +51,7 @@ namespace ot {
  * Multicast Listener Registration state for multicast addresses.
  *
  */
-enum MlrState
+enum MlrState : uint8_t
 {
     kMlrStateToRegister,  ///< The multicast address is to be registered.
     kMlrStateRegistering, ///< The multicast address is being registered.

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -91,16 +91,13 @@ class Manager;
  *
  */
 
-enum
-{
-    kIteratorInit = OT_NETWORK_DATA_ITERATOR_INIT, ///< Initializer for `Iterator` type.
-};
-
 /**
  * This type represents a Iterator used to iterate through Network Data info (e.g., see `GetNextOnMeshPrefix()`)
  *
  */
 typedef otNetworkDataIterator Iterator;
+
+constexpr Iterator kIteratorInit = OT_NETWORK_DATA_ITERATOR_INIT; ///< Initializer for `Iterator` type.
 
 /**
  * This class implements Network Data processing.
@@ -111,16 +108,13 @@ class NetworkData : public InstanceLocator
     friend class Service::Manager;
 
 public:
-    enum
-    {
-        kMaxSize = 254, ///< Maximum size of Thread Network Data in bytes.
-    };
+    static constexpr uint8_t kMaxSize = 254; ///< Maximum size of Thread Network Data in bytes.
 
     /**
      * This enumeration specifies the type of Network Data (local or leader).
      *
      */
-    enum Type
+    enum Type : uint8_t
     {
         kTypeLocal,  ///< Local Network Data.
         kTypeLeader, ///< Leader Network Data.
@@ -651,12 +645,9 @@ private:
         void MarkEntryAsNotNew(void) { SetEntryIndex(1); }
 
     private:
-        enum
-        {
-            kTlvPosition    = 0,
-            kSubTlvPosition = 1,
-            kEntryPosition  = 2,
-        };
+        static constexpr uint8_t kTlvPosition    = 0;
+        static constexpr uint8_t kSubTlvPosition = 1;
+        static constexpr uint8_t kEntryPosition  = 2;
 
         uint8_t GetTlvOffset(void) const { return mIteratorBuffer[kTlvPosition]; }
         uint8_t GetSubTlvOffset(void) const { return mIteratorBuffer[kSubTlvPosition]; }

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -72,7 +72,7 @@ public:
      * This enumeration defines the match mode constants to compare two RLOC16 values.
      *
      */
-    enum MatchMode
+    enum MatchMode : uint8_t
     {
         kMatchModeRloc16,   ///< Perform exact RLOC16 match.
         kMatchModeRouterId, ///< Perform Router ID match (match the router and any of its children).
@@ -197,7 +197,7 @@ private:
         bool mStableChanged; // Stable network data change (add/remove).
     };
 
-    enum UpdateStatus
+    enum UpdateStatus : uint8_t
     {
         kTlvRemoved, // TLV contained no sub TLVs and therefore is removed.
         kTlvUpdated, // TLV stable flag is updated based on its sub TLVs.
@@ -289,17 +289,10 @@ private:
     void IncrementVersions(bool aIncludeStable);
     void IncrementVersions(const ChangedFlags &aFlags);
 
-    /**
-     * Thread Specification Constants.
-     *
-     */
-    enum
-    {
-        kMinContextId        = 1,            ///< Minimum Context ID (0 is used for Mesh Local)
-        kNumContextIds       = 15,           ///< Maximum Context ID
-        kContextIdReuseDelay = 48 * 60 * 60, ///< CONTEXT_ID_REUSE_DELAY (seconds)
-        kStateUpdatePeriod   = 60 * 1000,    ///< State update period in milliseconds
-    };
+    static constexpr uint8_t  kMinContextId        = 1;            // Minimum Context ID (0 is used for Mesh Local)
+    static constexpr uint8_t  kNumContextIds       = 15;           // Maximum Context ID
+    static constexpr uint32_t kContextIdReuseDelay = 48 * 60 * 60; // in seconds
+    static constexpr uint32_t kStateUpdatePeriod   = 60 * 1000;    // State update period in milliseconds
 
     uint16_t   mContextUsed;
     TimeMilli  mContextLastUsed[kNumContextIds];

--- a/src/core/thread/network_data_notifier.hpp
+++ b/src/core/thread/network_data_notifier.hpp
@@ -70,12 +70,9 @@ public:
     void HandleServerDataUpdated(void);
 
 private:
-    enum
-    {
-        kDelayNoBufs                = 1000,   ///< milliseconds
-        kDelayRemoveStaleChildren   = 5000,   ///< milliseconds
-        kDelaySynchronizeServerData = 300000, ///< milliseconds
-    };
+    static constexpr uint32_t kDelayNoBufs                = 1000;   // in msec
+    static constexpr uint32_t kDelayRemoveStaleChildren   = 5000;   // in msec
+    static constexpr uint32_t kDelaySynchronizeServerData = 300000; // in msec
 
     void HandleNotifierEvents(Events aEvents);
 

--- a/src/core/thread/network_data_service.hpp
+++ b/src/core/thread/network_data_service.hpp
@@ -52,10 +52,7 @@ namespace Service {
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;
 
-enum : uint32_t
-{
-    kThreadEnterpriseNumber = ServiceTlv::kThreadEnterpriseNumber, ///< Thread enterprise number.
-};
+const uint32_t kThreadEnterpriseNumber = ServiceTlv::kThreadEnterpriseNumber; ///< Thread enterprise number.
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
@@ -160,10 +157,7 @@ public:
 class DnsSrpAnycast
 {
 public:
-    enum : uint8_t
-    {
-        kServiceNumber = 0x5c, ///< The service number of a `DnsSrpAnycast` entry.
-    };
+    static constexpr uint8_t kServiceNumber = 0x5c; ///< The service number of a `DnsSrpAnycast` entry.
 
     /**
      * This structure represents information about an DNS/SRP server parsed from related Network Data service entries.
@@ -246,10 +240,7 @@ public:
 class DnsSrpUnicast
 {
 public:
-    enum : uint8_t
-    {
-        kServiceNumber = 0x5d, ///< The service number of `DnsSrpUnicast` entry.
-    };
+    static constexpr uint8_t kServiceNumber = 0x5d; ///< The service number of `DnsSrpUnicast` entry.
 
     /**
      * This constant variable represents the short version of service data.

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -342,12 +342,10 @@ public:
     }
 
 private:
-    enum
-    {
-        kTypeOffset = 1,
-        kTypeMask   = 0x7f << kTypeOffset,
-        kStableMask = 1 << 0,
-    };
+    static constexpr uint8_t kTypeOffset = 1;
+    static constexpr uint8_t kTypeMask   = 0x7f << kTypeOffset;
+    static constexpr uint8_t kStableMask = 1 << 0;
+
     uint8_t mType;
     uint8_t mLength;
 } OT_TOOL_PACKED_END;
@@ -437,12 +435,9 @@ public:
     const HasRouteEntry *GetNext(void) const { return (this + 1); }
 
 private:
-    enum : uint8_t
-    {
-        kPreferenceOffset = 6,
-        kPreferenceMask   = 3 << kPreferenceOffset,
-        kNat64Flag        = 1 << 5,
-    };
+    static constexpr uint8_t kPreferenceOffset = 6;
+    static constexpr uint8_t kPreferenceMask   = 3 << kPreferenceOffset;
+    static constexpr uint8_t kNat64Flag        = 1 << 5;
 
     uint16_t mRloc;
     uint8_t  mFlags;
@@ -989,23 +984,16 @@ public:
     const BorderRouterEntry *GetNext(void) const { return (this + 1); }
 
 private:
-    enum : uint8_t
-    {
-        kPreferenceOffset = 14,
-    };
-
-    enum : uint16_t
-    {
-        kPreferenceMask   = 3 << kPreferenceOffset,
-        kPreferredFlag    = 1 << 13,
-        kSlaacFlag        = 1 << 12,
-        kDhcpFlag         = 1 << 11,
-        kConfigureFlag    = 1 << 10,
-        kDefaultRouteFlag = 1 << 9,
-        kOnMeshFlag       = 1 << 8,
-        kNdDnsFlag        = 1 << 7,
-        kDpFlag           = 1 << 6,
-    };
+    static constexpr uint8_t  kPreferenceOffset = 14;
+    static constexpr uint16_t kPreferenceMask   = 3 << kPreferenceOffset;
+    static constexpr uint16_t kPreferredFlag    = 1 << 13;
+    static constexpr uint16_t kSlaacFlag        = 1 << 12;
+    static constexpr uint16_t kDhcpFlag         = 1 << 11;
+    static constexpr uint16_t kConfigureFlag    = 1 << 10;
+    static constexpr uint16_t kDefaultRouteFlag = 1 << 9;
+    static constexpr uint16_t kOnMeshFlag       = 1 << 8;
+    static constexpr uint16_t kNdDnsFlag        = 1 << 7;
+    static constexpr uint16_t kDpFlag           = 1 << 6;
 
     uint16_t mRloc;
     uint16_t mFlags;
@@ -1177,12 +1165,10 @@ public:
     uint8_t GetContextLength(void) const { return mContextLength; }
 
 private:
-    enum
-    {
-        kCompressFlag    = 1 << 4,
-        kContextIdOffset = 0,
-        kContextIdMask   = 0xf << kContextIdOffset,
-    };
+    static constexpr uint8_t kCompressFlag    = 1 << 4;
+    static constexpr uint8_t kContextIdOffset = 0;
+    static constexpr uint8_t kContextIdMask   = 0xf << kContextIdOffset;
+
     uint8_t mFlags;
     uint8_t mContextLength;
 } OT_TOOL_PACKED_END;
@@ -1219,10 +1205,7 @@ class ServiceTlv : public NetworkDataTlv
 public:
     static constexpr Type kType = kTypeService; ///< The TLV Type.
 
-    enum : uint32_t
-    {
-        kThreadEnterpriseNumber = 44970, ///< Thread enterprise number.
-    };
+    static constexpr uint32_t kThreadEnterpriseNumber = 44970; ///< Thread enterprise number.
 
     /**
      * This method initializes the TLV.
@@ -1393,12 +1376,9 @@ private:
         return kMinLength + (IsThreadEnterprise() ? 0 : sizeof(uint32_t)) + GetServiceDataLength();
     }
 
-    enum
-    {
-        kThreadEnterpriseFlag = (1 << 7),
-        kServiceIdMask        = 0xf,
-        kMinLength            = sizeof(uint8_t) + sizeof(uint8_t), // Flags and Service Data length.
-    };
+    static constexpr uint8_t kThreadEnterpriseFlag = (1 << 7);
+    static constexpr uint8_t kServiceIdMask        = 0xf;
+    static constexpr uint8_t kMinLength            = sizeof(uint8_t) + sizeof(uint8_t); // Flags & Service Data length.
 
     // When `kThreadEnterpriseFlag is set in the `mFlagsServiceId`, the
     // `mEnterpriseNumber` field is elided and `mFlagsServiceId` is

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -66,16 +66,13 @@ namespace NetworkDiagnostic {
 class NetworkDiagnostic : public InstanceLocator, private NonCopyable
 {
 public:
-    enum
-    {
-        kIteratorInit = OT_NETWORK_DIAGNOSTIC_ITERATOR_INIT, ///< Initializer value for Iterator.
-    };
-
     /**
      * This type represents an iterator used to iterate through Network Diagnostic TLVs from `GetNextDiagTlv()`.
      *
      */
     typedef otNetworkDiagIterator Iterator;
+
+    static constexpr Iterator kIteratorInit = OT_NETWORK_DIAGNOSTIC_ITERATOR_INIT; ///< Initializer for Iterator.
 
     /**
      * This constructor initializes the object.

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -62,12 +62,6 @@ using ot::Encoding::BigEndian::HostSwap32;
  *
  */
 
-enum
-{
-    kNumResetTlvTypes = 1,
-    kNumTlvTypes      = 18,
-};
-
 /**
  * This class implements MLE TLV generation and parsing.
  *
@@ -80,7 +74,7 @@ public:
      * MLE TLV Types.
      *
      */
-    enum Type
+    enum Type : uint8_t
     {
         kExtMacAddress   = OT_NETWORK_DIAGNOSTIC_TLV_EXT_ADDRESS,
         kAddress16       = OT_NETWORK_DIAGNOSTIC_TLV_SHORT_ADDRESS,
@@ -366,11 +360,8 @@ public:
     void SetSedDatagramCount(uint8_t aSedDatagramCount) { mSedDatagramCount = aSedDatagramCount; }
 
 private:
-    enum
-    {
-        kParentPriorityOffset = 6,
-        kParentPriorityMask   = 3 << kParentPriorityOffset,
-    };
+    static constexpr uint8_t kParentPriorityOffset = 6;
+    static constexpr uint8_t kParentPriorityMask   = 3 << kParentPriorityOffset;
 
     uint8_t  mParentPriority;
     uint8_t  mLinkQuality3;
@@ -537,15 +528,13 @@ public:
     }
 
 private:
-    enum
-    {
-        kLinkQualityOutOffset = 6,
-        kLinkQualityOutMask   = 3 << kLinkQualityOutOffset,
-        kLinkQualityInOffset  = 4,
-        kLinkQualityInMask    = 3 << kLinkQualityInOffset,
-        kRouteCostOffset      = 0,
-        kRouteCostMask        = 0xf << kRouteCostOffset,
-    };
+    static constexpr uint8_t kLinkQualityOutOffset = 6;
+    static constexpr uint8_t kLinkQualityOutMask   = 3 << kLinkQualityOutOffset;
+    static constexpr uint8_t kLinkQualityInOffset  = 4;
+    static constexpr uint8_t kLinkQualityInMask    = 3 << kLinkQualityInOffset;
+    static constexpr uint8_t kRouteCostOffset      = 0;
+    static constexpr uint8_t kRouteCostMask        = 0xf << kRouteCostOffset;
+
     uint8_t          mRouterIdSequence;
     Mle::RouterIdSet mRouterIdMask;
     uint8_t          mRouteData[Mle::kMaxRouterId + 1];
@@ -1040,18 +1029,11 @@ public:
     }
 
 private:
-    /**
-     * Masks for fields.
-     *
-     */
-    enum
-    {
-        kTimeoutMask    = 0xf800,
-        kTimeoutOffset  = 11,
-        kReservedMask   = 0x0600,
-        kReservedOffset = 9,
-        kChildIdMask    = 0x1ff
-    };
+    static constexpr uint8_t  kTimeoutOffset  = 11;
+    static constexpr uint8_t  kReservedOffset = 9;
+    static constexpr uint16_t kTimeoutMask    = 0xf800;
+    static constexpr uint16_t kReservedMask   = 0x0600;
+    static constexpr uint16_t kChildIdMask    = 0x1f;
 
     uint16_t mTimeoutRsvChildId;
     uint8_t  mMode;

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -60,10 +60,7 @@ public:
     explicit PanIdQueryServer(Instance &aInstance);
 
 private:
-    enum
-    {
-        kScanDelay = 1000, ///< SCAN_DELAY (milliseconds)
-    };
+    static constexpr uint32_t kScanDelay = 1000; ///< SCAN_DELAY (in msec)
 
     static void HandleQuery(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleQuery(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);

--- a/src/core/thread/radio_selector.hpp
+++ b/src/core/thread/radio_selector.hpp
@@ -182,21 +182,21 @@ public:
     Mac::TxFrame &SelectRadio(Message &aMessage, const Mac::Address &aMacDest, Mac::TxFrames &aTxFrames);
 
 private:
-    enum
-    {
-        kPreferenceChangeOnTxError            = -35,  // Preference change on a tx error on a radio link.
-        kPreferenceChangeOnTxSuccess          = 25,   // Preference change on tx success on a radio link.
-        kPreferenceChangeOnDeferredAckSuccess = 25,   // Preference change on deferred ack success.
-        kPreferenceChangeOnDeferredAckTimeout = -100, // Preference change on deferred ack timeout.
-        kPreferenceChangeOnRx                 = 15,   // Preference change on new (secure) frame/msg rx on a radio link.
-        kPreferenceChangeOnRxDuplicate        = 15,   // Preference change on new (secure) duplicate frame/msg rx.
-        kMinPreference                        = 0,    // Minimum preference value.
-        kMaxPreference                        = 255,  // Maximum preference value.
-        kInitPreference                       = 200,  // Initial preference value
-        kHighPreference                       = 220,  // High preference.
-        kTrelProbeProbability                 = 25,   // Probability percentage to probe on TREL link
-        kRadioPreferenceStringSize            = 75,
-    };
+    static constexpr int16_t kPreferenceChangeOnTxError            = -35;  // Change on a tx error on a radio link.
+    static constexpr int16_t kPreferenceChangeOnTxSuccess          = 25;   // Change on tx success on a radio link.
+    static constexpr int16_t kPreferenceChangeOnDeferredAckSuccess = 25;   // Change on deferred ack success.
+    static constexpr int16_t kPreferenceChangeOnDeferredAckTimeout = -100; // Change on deferred ack timeout.
+    static constexpr int16_t kPreferenceChangeOnRx                 = 15;   // Change on new (secure) rx.
+    static constexpr int16_t kPreferenceChangeOnRxDuplicate        = 15;   // Change on new (secure) duplicate rx.
+
+    static constexpr uint8_t kMinPreference  = 0;   // Minimum preference value.
+    static constexpr uint8_t kMaxPreference  = 255; // Maximum preference value.
+    static constexpr uint8_t kInitPreference = 200; // Initial preference value
+    static constexpr uint8_t kHighPreference = 220; // High preference.
+
+    static constexpr uint8_t kTrelProbeProbability = 25; // Probability percentage to probe on TREL link
+
+    static constexpr uint16_t kRadioPreferenceStringSize = 75;
 
     otLogLevel     UpdatePreference(Neighbor &aNeighbor, Mac::RadioType aRadioType, int16_t aDifference);
     Mac::RadioType Select(Mac::RadioTypes aRadioOptions, const Neighbor &aNeighbor);

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -69,7 +69,7 @@ public:
         explicit Iterator(Instance &aInstance);
 
     private:
-        enum IteratorType
+        enum IteratorType : uint8_t
         {
             kEndIterator,
         };

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -48,12 +48,9 @@ namespace ot {
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;
 
-enum
-{
-    // Thread 1.2.0 5.19.13 limits the number of IPv6 addresses should be [1, 15].
-    kIp6AddressesNumMin = 1,
-    kIp6AddressesNumMax = 15,
-};
+// Thread 1.2.0 5.19.13 limits the number of IPv6 addresses should be [1, 15].
+constexpr uint8_t kIp6AddressesNumMin = 1;
+constexpr uint8_t kIp6AddressesNumMax = 15;
 
 /**
  * This class implements Network Layer TLV generation and parsing.
@@ -67,7 +64,7 @@ public:
      * Network Layer TLV Types.
      *
      */
-    enum Type
+    enum Type : uint8_t
     {
         kTarget                = 0,  ///< Target EID TLV
         kExtMacAddress         = 1,  ///< Extended MAC Address TLV
@@ -301,10 +298,7 @@ public:
     uint8_t *GetTlvs(void) { return mTlvs; }
 
 private:
-    enum
-    {
-        kMaxSize = 255,
-    };
+    static constexpr uint8_t kMaxSize = 255;
 
     uint8_t mTlvs[kMaxSize];
 } OT_TOOL_PACKED_END;

--- a/src/core/thread/tmf.hpp
+++ b/src/core/thread/tmf.hpp
@@ -39,10 +39,7 @@
 namespace ot {
 namespace Tmf {
 
-enum
-{
-    kUdpPort = 61631, ///< TMF UDP Port
-};
+constexpr uint16_t kUdpPort = 61631; ///< TMF UDP Port
 
 /**
  * This class implements functionality of the Thread TMF agent.

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -78,7 +78,7 @@ public:
      * Neighbor link states.
      *
      */
-    enum State
+    enum State : uint8_t
     {
         kStateInvalid,            ///< Neighbor link is invalid
         kStateRestored,           ///< Neighbor is restored from non-volatile memory
@@ -96,7 +96,7 @@ public:
      * Each filter definition accepts a subset of `State` values.
      *
      */
-    enum StateFilter
+    enum StateFilter : uint8_t
     {
         kInStateValid,                     ///< Accept neighbor only in `kStateValid`.
         kInStateValidOrRestoring,          ///< Accept neighbor with `IsStateValidOrRestoring()` being `true`.
@@ -831,10 +831,7 @@ class Child : public Neighbor,
     class AddressIteratorBuilder;
 
 public:
-    enum
-    {
-        kMaxRequestTlvs = 5,
-    };
+    static constexpr uint8_t kMaxRequestTlvs = 5;
 
     /**
      * This class represents diagnostic information for a Thread Child.
@@ -977,10 +974,7 @@ public:
             kEndIterator,
         };
 
-        enum : uint16_t
-        {
-            kMaxIndex = OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD,
-        };
+        static constexpr uint16_t kMaxIndex = OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD;
 
         AddressIterator(const Child &aChild, IteratorType)
             : mChild(aChild)
@@ -1265,10 +1259,7 @@ private:
 #error OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD should be at least set to 2.
 #endif
 
-    enum
-    {
-        kNumIp6Addresses = OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD - 1,
-    };
+    static constexpr uint16_t kNumIp6Addresses = OPENTHREAD_CONFIG_MLE_IP_ADDRS_PER_CHILD - 1;
 
     typedef BitVector<kNumIp6Addresses> ChildIp6AddressMask;
 


### PR DESCRIPTION
This commit replaces the `enum` constants with `constexpr` definitions
in all the modules under `core/thread`. This commit also contains
some smaller changes: typo fixes in the comments, removal of unused
constants, and adding `uint` type to the named `enum` definitions.

------

- I had this done even before #6875 
but somehow forgot to submit it as PR  😄 
- It's now rebased on `main`.
