### PR TITLE
[mle] wait till end of announce tx on all channels to attach

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1805,7 +1805,8 @@ private:
     uint32_t GetAttachStartDelay(void) const;
     Error    SendParentRequest(ParentRequestType aType);
     Error    SendChildIdRequest(void);
-    Error    SendOrphanAnnounce(void);
+    Error    GetNextAnnouceChannel(uint8_t &aChannel) const;
+    bool     HasMoreChannelsToAnnouce(void) const;
     bool     PrepareAnnounceState(void);
     void     SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Address &aDestination);
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE


### PR DESCRIPTION
This commit changes MLE module such that during an attach attempt in
the third phase where we send MLE Announce on all channels we wait
till the end of the phase (i.e., after MLE Announce tx on all
channels and transition from `kAttachStateAnnounce`) to process any
received "Parent Response" and try to attach to a parent. This
ensures that we wait long enough to receive "Parent Response" from
all potential parents during this phase. Note that at the start this
phase we send an extra "Parent Request to routers/REEDs" to have
another chance to find a parent.