### PR TITLE
[srp-server] fix adding service with subtypes to existing host

### DIFF
--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -1781,7 +1781,14 @@ Error Server::Host::MergeServicesAndResourcesFrom(Host &aHost)
         newService->mIsDeleted      = false;
         newService->mIsCommitted    = true;
         newService->mTimeLastUpdate = TimerMilli::GetNow();
-        newService->mDescription.TakeResourcesFrom(service->mDescription);
+
+        if (!service->mIsSubType)
+        {
+            // (1) Service description is shared across a base type and all its subtypes.
+            // (2) `TakeResourcesFrom()` releases resources pinned to its argument.
+            // Therefore, make sure the function is called only for the base type.
+            newService->mDescription.TakeResourcesFrom(service->mDescription);
+        }
 
         newService->Log((existingService != nullptr) ? Service::kUpdateExisting : Service::kAddNew);
     }


### PR DESCRIPTION
When a new service with subtypes is added to an existing
host, the SRP server incorrectly merges the subtype service
copies so that the TXT information is lost, i.e. 0-length
TXT record is created.

Moreover, the OT DNS client cannot parse services with
0-length TXT record (instead of ignoring the TXT record
itself) causing that such a service cannot be examined
at all.

The problem is caused by incorrect merging of the service
description structure which is shared across all services
with the same instance name (i.e. among the base type
service and its subtypes).

Fixes #6900.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>