### PR TITLE
[posix] set compile-time minimum log level to debug

### DIFF
--- a/src/posix/platform/openthread-core-posix-config.h
+++ b/src/posix/platform/openthread-core-posix-config.h
@@ -65,6 +65,27 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_LOG_LEVEL
+ *
+ * Define the compile-time log level which is the lowest log level
+ * that can be set at run-time by `otLoggingSetLevel`.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_LOG_LEVEL
+#define OPENTHREAD_CONFIG_LOG_LEVEL OT_LOG_LEVEL_DEBG
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_LOG_LEVEL_INIT
+ *
+ * The initial log level used when OpenThread is initialized. See
+ * `OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE`.
+ */
+#ifndef OPENTHREAD_CONFIG_LOG_LEVEL_INIT
+#define OPENTHREAD_CONFIG_LOG_LEVEL_INIT OT_LOG_LEVEL_CRIT
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE
  *
  * Define as 1 to enable dynamic log level control.


### PR DESCRIPTION
The compile-time log level definition is the lowest log level
that can be set by `otLoggingSetLevel`. This is useful for
dumping more logs for testing.