### PR TITLE
[meshcop] replace `enum` constants with `constexpr`

### DIFF
--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -173,11 +173,7 @@ private:
     }
     bool HandleUdpReceive(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    enum
-    {
-        kKeepAliveTimeout = 50 * 1000, ///< Timeout to reject a commissioner.
-        kRestartDelay     = 1 * 1000,  ///< Delay to restart border agent service.
-    };
+    static constexpr uint32_t kKeepAliveTimeout = 50 * 1000; // Timeout to reject a commissioner.
 
     Ip6::MessageInfo mMessageInfo;
 

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -326,14 +326,11 @@ public:
     void ApplyMeshLocalPrefix(void);
 
 private:
-    enum
-    {
-        kPetitionAttemptDelay = 5,  ///< COMM_PET_ATTEMPT_DELAY (seconds)
-        kPetitionRetryCount   = 2,  ///< COMM_PET_RETRY_COUNT
-        kPetitionRetryDelay   = 1,  ///< COMM_PET_RETRY_DELAY (seconds)
-        kKeepAliveTimeout     = 50, ///< TIMEOUT_COMM_PET (seconds)
-        kRemoveJoinerDelay    = 20, ///< Delay to remove successfully joined joiner
-    };
+    static constexpr uint32_t kPetitionAttemptDelay = 5;  // COMM_PET_ATTEMPT_DELAY (seconds)
+    static constexpr uint8_t  kPetitionRetryCount   = 2;  // COMM_PET_RETRY_COUNT
+    static constexpr uint32_t kPetitionRetryDelay   = 1;  // COMM_PET_RETRY_DELAY (seconds)
+    static constexpr uint32_t kKeepAliveTimeout     = 50; // TIMEOUT_COMM_PET (seconds)
+    static constexpr uint32_t kRemoveJoinerDelay    = 20; // Delay to remove successfully joined joiner
 
     enum JoinerEvent : uint8_t
     {

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -59,18 +59,15 @@ class Dataset
     friend class DatasetLocal;
 
 public:
-    enum
-    {
-        kMaxSize      = OT_OPERATIONAL_DATASET_MAX_LENGTH, ///< Maximum size of MeshCoP Dataset (bytes)
-        kMaxValueSize = 16,                                ///< Maximum size of each Dataset TLV value (bytes)
-        kMaxGetTypes  = 64,                                ///< Maximum number of types in MGMT_GET.req
-    };
+    static constexpr uint8_t kMaxSize      = OT_OPERATIONAL_DATASET_MAX_LENGTH; ///< Max size of MeshCoP Dataset (bytes)
+    static constexpr uint8_t kMaxValueSize = 16;                                ///< Max size of a TLV value (bytes)
+    static constexpr uint8_t kMaxGetTypes  = 64;                                ///< Max number of types in MGMT_GET.req
 
     /**
      * This enumeration represents the Dataset type (active or pending).
      *
      */
-    enum Type
+    enum Type : uint8_t
     {
         kActive,  ///< Active Dataset
         kPending, ///< Pending Dataset

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -207,11 +207,6 @@ protected:
         Error ReadFromMessage(const Message &aMessage, uint16_t aOffset);
 
     private:
-        enum
-        {
-            kMaxValueSize = 16, // Maximum size of a Dataset TLV value (bytes).
-        };
-
         uint8_t mValue[Dataset::kMaxValueSize];
     } OT_TOOL_PACKED_END;
 
@@ -360,11 +355,8 @@ private:
     void SendSetResponse(const Coap::Message &aRequest, const Ip6::MessageInfo &aMessageInfo, StateTlv::State aState);
 #endif
 
-    enum
-    {
-        kMaxDatasetTlvs = 16,   // Maximum number of TLVs in a Dataset.
-        kSendSetDelay   = 5000, // Milliseconds
-    };
+    static constexpr uint8_t  kMaxDatasetTlvs = 16;   // Maximum number of TLVs in a Dataset.
+    static constexpr uint32_t kSendSetDelay   = 5000; // Milliseconds
 
     bool       mCoapPending : 1;
     TimerMilli mTimer;

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -298,7 +298,7 @@ Error DatasetManager::DatasetTlv::ReadFromMessage(const Message &aMessage, uint1
     Error error = kErrorNone;
 
     SuccessOrExit(error = aMessage.Read(aOffset, this, sizeof(Tlv)));
-    VerifyOrExit(GetLength() <= kMaxValueSize, error = kErrorParse);
+    VerifyOrExit(GetLength() <= Dataset::kMaxValueSize, error = kErrorParse);
     SuccessOrExit(error = aMessage.Read(aOffset + sizeof(Tlv), mValue, GetLength()));
     VerifyOrExit(Tlv::IsValid(*this), error = kErrorParse);
 

--- a/src/core/meshcop/dataset_updater.hpp
+++ b/src/core/meshcop/dataset_updater.hpp
@@ -119,12 +119,11 @@ public:
     bool IsUpdateOngoing(void) const { return mDataset != nullptr; }
 
 private:
-    enum : uint32_t
-    {
-        kDefaultDelay = OPENTHREAD_CONFIG_DATASET_UPDATER_DEFAULT_DELAY, // Default delay (in ms) in Pending Dataset.
+    // Default delay (in ms) in Pending Dataset.
+    static constexpr uint32_t kDefaultDelay = OPENTHREAD_CONFIG_DATASET_UPDATER_DEFAULT_DELAY;
 
-        kRetryInterval = 1000, // In ms. Retry interval when preparing and/or sending Pending Dataset fails.
-    };
+    // Retry interval (in ms) when preparing and/or sending Pending Dataset fails.
+    static constexpr uint32_t kRetryInterval = 1000;
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -67,10 +67,7 @@ namespace MeshCoP {
 class Dtls : public InstanceLocator
 {
 public:
-    enum
-    {
-        kPskMaxLength = 32, ///< Maximum PSK length.
-    };
+    static constexpr uint8_t kPskMaxLength = 32; ///< Maximum PSK length.
 
     /**
      * This constructor initializes the DTLS object.
@@ -355,15 +352,13 @@ private:
         kStateCloseNotify,  // The DTLS service is closing a connection.
     };
 
-    enum
-    {
-        kGuardTimeNewConnectionMilli = 2000,
+    static constexpr uint32_t kGuardTimeNewConnectionMilli = 2000;
+
 #if !OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-        kApplicationDataMaxLength = 1152,
+    static constexpr uint16_t kApplicationDataMaxLength = 1152;
 #else
-        kApplicationDataMaxLength = OPENTHREAD_CONFIG_DTLS_APPLICATION_DATA_MAX_LENGTH,
+    static constexpr uint16_t kApplicationDataMaxLength = OPENTHREAD_CONFIG_DTLS_APPLICATION_DATA_MAX_LENGTH;
 #endif
-    };
 
     void  FreeMbedtls(void);
     Error Setup(bool aClient);

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -168,12 +168,10 @@ public:
     Error ClearDiscerner(void);
 
 private:
-    enum
-    {
-        kJoinerUdpPort         = OPENTHREAD_CONFIG_JOINER_UDP_PORT,
-        kConfigExtAddressDelay = 100,  ///< [milliseconds]
-        kReponseTimeout        = 4000, ///< Maximum wait time to receive response [milliseconds].
-    };
+    static constexpr uint16_t kJoinerUdpPort = OPENTHREAD_CONFIG_JOINER_UDP_PORT;
+
+    static constexpr uint32_t kConfigExtAddressDelay = 100;  // in msec.
+    static constexpr uint32_t kReponseTimeout        = 4000; ///< Max wait time to receive response (in msec).
 
     struct JoinerRouter
     {

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -84,10 +84,7 @@ public:
     void SetJoinerUdpPort(uint16_t aJoinerUdpPort);
 
 private:
-    enum
-    {
-        kJoinerEntrustTxDelay = 50, ///< milliseconds
-    };
+    static constexpr uint32_t kJoinerEntrustTxDelay = 50; // in msec
 
     struct JoinerEntrustMetadata
     {

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -64,11 +64,8 @@ namespace MeshCoP {
 class JoinerPskd : public otJoinerPskd, public Clearable<JoinerPskd>, public Unequatable<JoinerPskd>
 {
 public:
-    enum
-    {
-        kMinLength = 6,                         ///< Minimum PSKd string length (excluding null char).
-        kMaxLength = OT_JOINER_MAX_PSKD_LENGTH, ///< Maximum PSKd string length (excluding null char)
-    };
+    static constexpr uint8_t kMinLength = 6;                         ///< Min PSKd string length (excludes null char)
+    static constexpr uint8_t kMaxLength = OT_JOINER_MAX_PSKD_LENGTH; ///< Max PSKd string length (excludes null char)
 
     /**
      * This method indicates whether the PSKd if well-formed and valid.
@@ -146,11 +143,9 @@ class JoinerDiscerner : public otJoinerDiscerner, public Unequatable<JoinerDisce
     friend class SteeringData;
 
 public:
-    enum
-    {
-        kMaxLength      = OT_JOINER_MAX_DISCERNER_LENGTH, ///< Maximum length of a Joiner Discerner in bits.
-        kInfoStringSize = 45,                             ///< Size of `InfoString` to use with `ToString()
-    };
+    static constexpr uint8_t kMaxLength = OT_JOINER_MAX_DISCERNER_LENGTH; ///< Max length of a Discerner in bits.
+
+    static constexpr uint16_t kInfoStringSize = 45; ///< Size of `InfoString` to use with `ToString()
 
     /**
      * This type defines the fixed-length `String` object returned from `ToString()`.
@@ -246,10 +241,7 @@ private:
 class SteeringData : public otSteeringData
 {
 public:
-    enum
-    {
-        kMaxLength = OT_STEERING_DATA_MAX_LENGTH, ///< Maximum Steering Data length (in bytes).
-    };
+    static constexpr uint8_t kMaxLength = OT_STEERING_DATA_MAX_LENGTH; ///< Maximum Steering Data length (in bytes).
 
     /**
      * This structure represents the hash bit index values for the bloom filter calculated from a Joiner ID.
@@ -259,10 +251,7 @@ public:
      */
     struct HashBitIndexes
     {
-        enum
-        {
-            kNumIndexes = 2, ///< Number of hash bit indexes.
-        };
+        static constexpr uint8_t kNumIndexes = 2; ///< Number of hash bit indexes.
 
         uint16_t mIndex[kNumIndexes]; ///< The hash bit index array.
     };
@@ -400,10 +389,7 @@ public:
     static void CalculateHashBitIndexes(const JoinerDiscerner &aDiscerner, HashBitIndexes &aIndexes);
 
 private:
-    enum
-    {
-        kPermitAll = 0xff,
-    };
+    static constexpr uint8_t kPermitAll = 0xff;
 
     uint8_t GetNumBits(void) const { return (mLength * CHAR_BIT); }
 

--- a/src/core/meshcop/meshcop_leader.hpp
+++ b/src/core/meshcop/meshcop_leader.hpp
@@ -109,10 +109,7 @@ public:
     void SetEmptyCommissionerData(void);
 
 private:
-    enum
-    {
-        kTimeoutLeaderPetition = 50, ///< TIMEOUT_LEAD_PET (seconds)
-    };
+    static constexpr uint32_t kTimeoutLeaderPetition = 50; // TIMEOUT_LEAD_PET (seconds)
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -72,7 +72,7 @@ public:
      * MeshCoP TLV Types.
      *
      */
-    enum Type
+    enum Type : uint8_t
     {
         kChannel                 = OT_MESHCOP_TLV_CHANNEL,                  ///< Channel TLV
         kPanId                   = OT_MESHCOP_TLV_PANID,                    ///< PAN ID TLV
@@ -843,10 +843,7 @@ OT_TOOL_PACKED_BEGIN
 class CommissionerIdTlv : public Tlv, public TlvInfo<Tlv::kCommissionerId>
 {
 public:
-    enum
-    {
-        kMaxLength = 64, ///< maximum length (bytes)
-    };
+    static constexpr uint8_t kMaxLength = 64; ///< maximum length (bytes)
 
     /**
      * This method initializes the TLV.
@@ -902,11 +899,6 @@ OT_TOOL_PACKED_BEGIN
 class CommissionerSessionIdTlv : public Tlv, public UintTlvInfo<Tlv::kCommissionerSessionId, uint16_t>
 {
 public:
-    enum
-    {
-        kType = kCommissionerSessionId, ///< The TLV Type.
-    };
-
     /**
      * This method initializes the TLV.
      *
@@ -990,11 +982,8 @@ public:
     void SetSecurityPolicy(const SecurityPolicy &aSecurityPolicy);
 
 private:
-    enum : uint8_t
-    {
-        kThread11FlagsLength = 1, ///< The Thread 1.1 Security Policy Flags length.
-        kThread12FlagsLength = 2, ///< The Thread 1.2 Security Policy Flags length.
-    };
+    static constexpr uint8_t kThread11FlagsLength = 1; // The Thread 1.1 Security Policy Flags length.
+    static constexpr uint8_t kThread12FlagsLength = 2; // The Thread 1.2 Security Policy Flags length.
 
     void     SetRotationTime(uint16_t aRotationTime) { mRotationTime = HostSwap16(aRotationTime); }
     uint16_t GetRotationTime(void) const { return HostSwap16(mRotationTime); }
@@ -1214,22 +1203,19 @@ public:
      */
     void SetDelayTimer(uint32_t aDelayTimer) { mDelayTimer = HostSwap32(aDelayTimer); }
 
-    enum
-    {
-        kMaxDelayTimer = 259200, ///< maximum delay timer value for a Pending Dataset in seconds
+    static constexpr uint32_t kMaxDelayTimer = 259200; ///< Maximum delay timer value for a Pending Dataset in seconds
 
-        /**
-         * Minimum Delay Timer value for a Pending Operational Dataset (ms)
-         *
-         */
-        kDelayTimerMinimal = OPENTHREAD_CONFIG_TMF_PENDING_DATASET_MINIMUM_DELAY,
+    /**
+     * Minimum Delay Timer value for a Pending Operational Dataset (ms)
+     *
+     */
+    static constexpr uint32_t kDelayTimerMinimal = OPENTHREAD_CONFIG_TMF_PENDING_DATASET_MINIMUM_DELAY;
 
-        /**
-         * Default Delay Timer value for a Pending Operational Dataset (ms)
-         *
-         */
-        kDelayTimerDefault = OPENTHREAD_CONFIG_TMF_PENDING_DATASET_DEFAULT_DELAY,
-    };
+    /**
+     * Default Delay Timer value for a Pending Operational Dataset (ms)
+     *
+     */
+    static constexpr uint32_t kDelayTimerDefault = OPENTHREAD_CONFIG_TMF_PENDING_DATASET_DEFAULT_DELAY;
 
 private:
     uint32_t mDelayTimer;
@@ -1486,10 +1472,7 @@ public:
     static uint32_t GetChannelMask(const Message &aMessage);
 
 private:
-    enum
-    {
-        kNumMaskEntries = Radio::kNumChannelPages,
-    };
+    static constexpr uint8_t kNumMaskEntries = Radio::kNumChannelPages;
 
     ChannelMaskEntry mEntries[kNumMaskEntries];
 } OT_TOOL_PACKED_END;
@@ -1530,10 +1513,11 @@ OT_TOOL_PACKED_BEGIN
 class ProvisioningUrlTlv : public Tlv, public TlvInfo<Tlv::kProvisioningUrl>
 {
 public:
-    enum
-    {
-        kMaxLength = OT_PROVISIONING_URL_MAX_SIZE, ///< Maximum number of chars in the Provisioning URL string.
-    };
+    /**
+     * Maximum number of chars in the Provisioning URL string.
+     *
+     */
+    static constexpr uint16_t kMaxLength = OT_PROVISIONING_URL_MAX_SIZE;
 
     /**
      * This method initializes the TLV.
@@ -1654,10 +1638,7 @@ public:
     }
 
 private:
-    enum
-    {
-        kMaxLength = 32,
-    };
+    static constexpr uint8_t kMaxLength = 32;
 
     char mVendorName[kMaxLength];
 } OT_TOOL_PACKED_END;
@@ -1718,10 +1699,7 @@ public:
     }
 
 private:
-    enum
-    {
-        kMaxLength = 32,
-    };
+    static constexpr uint8_t kMaxLength = 32;
 
     char mVendorModel[kMaxLength];
 } OT_TOOL_PACKED_END;
@@ -1782,10 +1760,7 @@ public:
     }
 
 private:
-    enum
-    {
-        kMaxLength = 16,
-    };
+    static constexpr uint8_t kMaxLength = 16;
 
     char mVendorSwVersion[kMaxLength];
 } OT_TOOL_PACKED_END;
@@ -1846,10 +1821,7 @@ public:
     }
 
 private:
-    enum
-    {
-        kMaxLength = 64,
-    };
+    static constexpr uint8_t kMaxLength = 64;
 
     char mVendorData[kMaxLength];
 } OT_TOOL_PACKED_END;
@@ -1985,25 +1957,21 @@ public:
     }
 
 private:
-    uint8_t mOui[3];
+    // For `mBuildRevision`
+    static constexpr uint8_t  kBuildOffset = 4;
+    static constexpr uint16_t kBuildMask   = 0xfff << kBuildOffset;
+    static constexpr uint8_t  kRevOffset   = 0;
+    static constexpr uint16_t kRevMask     = 0xf << kBuildOffset;
 
-    enum
-    {
-        kBuildOffset = 4,
-        kBuildMask   = 0xfff << kBuildOffset,
-        kRevOffset   = 0,
-        kRevMask     = 0xf << kBuildOffset,
-    };
+    // For `mMinorMajor`
+    static constexpr uint8_t kMinorOffset = 4;
+    static constexpr uint8_t kMinorMask   = 0xf << kMinorOffset;
+    static constexpr uint8_t kMajorOffset = 0;
+    static constexpr uint8_t kMajorMask   = 0xf << kMajorOffset;
+
+    uint8_t  mOui[3];
     uint16_t mBuildRevision;
-
-    enum
-    {
-        kMinorOffset = 4,
-        kMinorMask   = 0xf << kMinorOffset,
-        kMajorOffset = 0,
-        kMajorMask   = 0xf << kMajorOffset,
-    };
-    uint8_t mMinorMajor;
+    uint8_t  mMinorMajor;
 } OT_TOOL_PACKED_END;
 
 /**
@@ -2162,13 +2130,11 @@ public:
     }
 
 private:
-    enum
-    {
-        kVersionOffset = 4,
-        kVersionMask   = 0xf << kVersionOffset,
-        kJoinerOffset  = 3,
-        kJoinerMask    = 1 << kJoinerOffset,
-    };
+    static constexpr uint8_t kVersionOffset = 4;
+    static constexpr uint8_t kVersionMask   = 0xf << kVersionOffset;
+    static constexpr uint8_t kJoinerOffset  = 3;
+    static constexpr uint8_t kJoinerMask    = 1 << kJoinerOffset;
+
     uint8_t mFlags;
     uint8_t mReserved;
 } OT_TOOL_PACKED_END;
@@ -2276,15 +2242,13 @@ public:
     }
 
 private:
-    enum
-    {
-        kVersionOffset = 4,
-        kVersionMask   = 0xf << kVersionOffset,
-        kNativeOffset  = 3,
-        kNativeMask    = 1 << kNativeOffset,
-        kCCMOffset     = 2,
-        kCCMMask       = 1 << kCCMOffset,
-    };
+    static constexpr uint8_t kVersionOffset = 4;
+    static constexpr uint8_t kVersionMask   = 0xf << kVersionOffset;
+    static constexpr uint8_t kNativeOffset  = 3;
+    static constexpr uint8_t kNativeMask    = 1 << kNativeOffset;
+    static constexpr uint8_t kCCMOffset     = 2;
+    static constexpr uint8_t kCCMMask       = 1 << kCCMOffset;
+
     uint8_t mFlags;
     uint8_t mReserved;
 } OT_TOOL_PACKED_END;
@@ -2297,10 +2261,7 @@ OT_TOOL_PACKED_BEGIN
 class JoinerAdvertisementTlv : public Tlv, public TlvInfo<Tlv::kJoinerAdvertisement>
 {
 public:
-    enum
-    {
-        kAdvDataMaxLength = OT_JOINER_ADVDATA_MAX_LENGTH, ///< The Max Length of AdvData
-    };
+    static constexpr uint8_t kAdvDataMaxLength = OT_JOINER_ADVDATA_MAX_LENGTH; ///< The Max Length of AdvData
 
     /**
      * This method initializes the TLV.

--- a/src/core/meshcop/timestamp.hpp
+++ b/src/core/meshcop/timestamp.hpp
@@ -145,14 +145,11 @@ public:
     void AdvanceRandomTicks(void);
 
 private:
-    enum
-    {
-        kTicksOffset         = 1,
-        kTicksMask           = 0x7fff << kTicksOffset,
-        kMaxRandomTicks      = 0x7fff,
-        kAuthoritativeOffset = 0,
-        kAuthoritativeMask   = 1 << kAuthoritativeOffset,
-    };
+    static constexpr uint8_t  kTicksOffset         = 1;
+    static constexpr uint16_t kTicksMask           = 0x7fff << kTicksOffset;
+    static constexpr uint16_t kMaxRandomTicks      = 0x7fff;
+    static constexpr uint8_t  kAuthoritativeOffset = 0;
+    static constexpr uint16_t kAuthoritativeMask   = 1 << kAuthoritativeOffset;
 
     uint16_t mSeconds16; // bits 32-47
     uint32_t mSeconds32; // bits 0-31


### PR DESCRIPTION
This commit replaces the `enum` constants with `constexpr` definitions
in all the modules under `core/meshcop`. This commit also contains
some smaller changes: removal of unused constants, and adding `uint`
type to the named `enum` definitions.