### PR TITLE
[utils] replace `enum` constants with `constexpr`

### DIFF
--- a/src/core/utils/channel_manager.hpp
+++ b/src/core/utils/channel_manager.hpp
@@ -64,14 +64,11 @@ namespace Utils {
 class ChannelManager : public InstanceLocator, private NonCopyable
 {
 public:
-    enum
-    {
-        /**
-         * Minimum delay (in seconds) used for network channel change.
-         *
-         */
-        kMinimumDelay = OPENTHREAD_CONFIG_CHANNEL_MANAGER_MINIMUM_DELAY,
-    };
+    /**
+     * Minimum delay (in seconds) used for network channel change.
+     *
+     */
+    static constexpr uint16_t kMinimumDelay = OPENTHREAD_CONFIG_CHANNEL_MANAGER_MINIMUM_DELAY;
 
     /**
      * This constructor initializes a `ChanelManager` object.
@@ -244,31 +241,30 @@ public:
     void SetCcaFailureRateThreshold(uint16_t aThreshold);
 
 private:
-    enum
-    {
-        // Retry interval to resend Pending Dataset in case of tx failure (in ms).
-        kPendingDatasetTxRetryInterval = 20000,
+    // Retry interval to resend Pending Dataset in case of tx failure (in ms).
+    static constexpr uint32_t kPendingDatasetTxRetryInterval = 20000;
 
-        // Maximum jitter/wait time to start a requested channel change (in ms).
-        kRequestStartJitterInterval = 10000,
+    // Maximum jitter/wait time to start a requested channel change (in ms).
+    static constexpr uint32_t kRequestStartJitterInterval = 10000;
 
-        // The minimum number of RSSI samples required before using the collected data (by `ChannelMonitor`) to select
-        // a channel.
-        kMinChannelMonitorSampleCount = OPENTHREAD_CONFIG_CHANNEL_MANAGER_MINIMUM_MONITOR_SAMPLE_COUNT,
+    // The minimum number of RSSI samples required before using the collected data (by `ChannelMonitor`) to select
+    // a channel.
+    static constexpr uint32_t kMinChannelMonitorSampleCount =
+        OPENTHREAD_CONFIG_CHANNEL_MANAGER_MINIMUM_MONITOR_SAMPLE_COUNT;
 
-        // Minimum channel occupancy difference to prefer an unfavored channel over a favored one.
-        kThresholdToSkipFavored = OPENTHREAD_CONFIG_CHANNEL_MANAGER_THRESHOLD_TO_SKIP_FAVORED,
+    // Minimum channel occupancy difference to prefer an unfavored channel over a favored one.
+    static constexpr uint16_t kThresholdToSkipFavored = OPENTHREAD_CONFIG_CHANNEL_MANAGER_THRESHOLD_TO_SKIP_FAVORED;
 
-        // Minimum channel occupancy difference between current channel and the selected channel to trigger the channel
-        // change process to start.
-        kThresholdToChangeChannel = OPENTHREAD_CONFIG_CHANNEL_MANAGER_THRESHOLD_TO_CHANGE_CHANNEL,
+    // Minimum channel occupancy difference between current channel and the selected channel to trigger the channel
+    // change process to start.
+    static constexpr uint16_t kThresholdToChangeChannel = OPENTHREAD_CONFIG_CHANNEL_MANAGER_THRESHOLD_TO_CHANGE_CHANNEL;
 
-        // Default auto-channel-selection period (in seconds).
-        kDefaultAutoSelectInterval = OPENTHREAD_CONFIG_CHANNEL_MANAGER_DEFAULT_AUTO_SELECT_INTERVAL,
+    // Default auto-channel-selection period (in seconds).
+    static constexpr uint32_t kDefaultAutoSelectInterval =
+        OPENTHREAD_CONFIG_CHANNEL_MANAGER_DEFAULT_AUTO_SELECT_INTERVAL;
 
-        // Minimum CCA failure rate on current channel to start the channel selection process.
-        kCcaFailureRateThreshold = OPENTHREAD_CONFIG_CHANNEL_MANAGER_CCA_FAILURE_THRESHOLD,
-    };
+    // Minimum CCA failure rate on current channel to start the channel selection process.
+    static constexpr uint16_t kCcaFailureRateThreshold = OPENTHREAD_CONFIG_CHANNEL_MANAGER_CCA_FAILURE_THRESHOLD;
 
     enum State : uint8_t
     {

--- a/src/core/utils/channel_monitor.hpp
+++ b/src/core/utils/channel_monitor.hpp
@@ -74,28 +74,25 @@ namespace Utils {
 class ChannelMonitor : public InstanceLocator, private NonCopyable
 {
 public:
-    enum
-    {
-        /**
-         * The channel RSSI sample interval in milliseconds.
-         *
-         */
-        kSampleInterval = OPENTHREAD_CONFIG_CHANNEL_MONITOR_SAMPLE_INTERVAL,
+    /**
+     * The channel RSSI sample interval in milliseconds.
+     *
+     */
+    static constexpr uint32_t kSampleInterval = OPENTHREAD_CONFIG_CHANNEL_MONITOR_SAMPLE_INTERVAL;
 
-        /**
-         * The RSSI threshold in dBm.
-         *
-         * It is recommended that this value is set to same value as the CCA threshold used by radio.
-         *
-         */
-        kRssiThreshold = OPENTHREAD_CONFIG_CHANNEL_MONITOR_RSSI_THRESHOLD,
+    /**
+     * The RSSI threshold in dBm.
+     *
+     * It is recommended that this value is set to same value as the CCA threshold used by radio.
+     *
+     */
+    static constexpr int8_t kRssiThreshold = OPENTHREAD_CONFIG_CHANNEL_MONITOR_RSSI_THRESHOLD;
 
-        /**
-         * The averaging sample window length (in units of sample interval).
-         *
-         */
-        kSampleWindow = OPENTHREAD_CONFIG_CHANNEL_MONITOR_SAMPLE_WINDOW,
-    };
+    /**
+     * The averaging sample window length (in units of sample interval).
+     *
+     */
+    static constexpr uint32_t kSampleWindow = OPENTHREAD_CONFIG_CHANNEL_MONITOR_SAMPLE_WINDOW;
 
     /**
      * This constructor initializes the object.
@@ -186,18 +183,15 @@ public:
     Mac::ChannelMask FindBestChannels(const Mac::ChannelMask &aMask, uint16_t &aOccupancy) const;
 
 private:
-    enum
-    {
 #if (OPENTHREAD_CONFIG_RADIO_2P4GHZ_OQPSK_SUPPORT && OPENTHREAD_CONFIG_RADIO_915MHZ_OQPSK_SUPPORT)
-        kNumChannelMasks = 8,
+    static constexpr uint8_t kNumChannelMasks = 8;
 #else
-        kNumChannelMasks = 4,
+    static constexpr uint8_t kNumChannelMasks = 4;
 #endif
-        kNumChannels       = (Radio::kChannelMax - Radio::kChannelMin + 1),
-        kTimerInterval     = (kSampleInterval / kNumChannelMasks),
-        kMaxJitterInterval = 4096,
-        kMaxOccupancy      = 0xffff,
-    };
+    static constexpr uint8_t  kNumChannels       = (Radio::kChannelMax - Radio::kChannelMin + 1);
+    static constexpr uint32_t kTimerInterval     = (kSampleInterval / kNumChannelMasks);
+    static constexpr uint16_t kMaxJitterInterval = 4096;
+    static constexpr uint32_t kMaxOccupancy      = 0xffff;
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -159,11 +159,7 @@ public:
     void UpdateOnSend(Child &aChild);
 
 private:
-    enum
-    {
-        kDefaultSupervisionInterval = OPENTHREAD_CONFIG_CHILD_SUPERVISION_INTERVAL, // (seconds)
-        kOneSecond                  = 1000,                                         // One second interval (in ms).
-    };
+    static constexpr uint16_t kDefaultSupervisionInterval = OPENTHREAD_CONFIG_CHILD_SUPERVISION_INTERVAL; // (seconds)
 
     void SendMessage(Child &aChild);
     void CheckState(void);
@@ -235,10 +231,7 @@ public:
     void UpdateOnReceive(const Mac::Address &aSourceAddress, bool aIsSecure);
 
 private:
-    enum
-    {
-        kDefaultTimeout = OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT, // (seconds)
-    };
+    static constexpr uint16_t kDefaultTimeout = OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT; // (seconds)
 
     void        RestartTimer(void);
     static void HandleTimer(Timer &aTimer);

--- a/src/core/utils/flash.hpp
+++ b/src/core/utils/flash.hpp
@@ -137,10 +137,7 @@ public:
     void Wipe(void);
 
 private:
-    enum
-    {
-        kSwapMarkerSize = 4, // in bytes
-    };
+    static constexpr uint32_t kSwapMarkerSize = 4; // in bytes
 
     static const uint32_t sSwapActive   = 0xbe5cc5ee;
     static const uint32_t sSwapInactive = 0xbe5cc5ec;
@@ -186,14 +183,11 @@ private:
         void SetFirst(void) { mFlags &= ~kFlagFirst; }
 
     private:
-        enum
-        {
-            kFlagsInit       = 0xffff, ///< Flags initialize to all-ones.
-            kFlagAddBegin    = 1 << 0, ///< 0 indicates record write has started, 1 otherwise.
-            kFlagAddComplete = 1 << 1, ///< 0 indicates record write has completed, 1 otherwise.
-            kFlagDelete      = 1 << 2, ///< 0 indicates record was deleted, 1 otherwise.
-            kFlagFirst       = 1 << 3, ///< 0 indicates first record for key, 1 otherwise.
-        };
+        static constexpr uint16_t kFlagsInit       = 0xffff; // Flags initialize to all-ones.
+        static constexpr uint16_t kFlagAddBegin    = 1 << 0; // 0 indicates record write has started, 1 otherwise.
+        static constexpr uint16_t kFlagAddComplete = 1 << 1; // 0 indicates record write has completed, 1 otherwise.
+        static constexpr uint16_t kFlagDelete      = 1 << 2; // 0 indicates record was deleted, 1 otherwise.
+        static constexpr uint16_t kFlagFirst       = 1 << 3; // 0 indicates first record for key, 1 otherwise.
 
         uint16_t mKey;
         uint16_t mFlags;
@@ -214,10 +208,7 @@ private:
         }
 
     private:
-        enum
-        {
-            kMaxDataSize = 255,
-        };
+        static constexpr uint16_t kMaxDataSize = 255;
 
         uint8_t mData[kMaxDataSize];
     } OT_TOOL_PACKED_END;

--- a/src/core/utils/heap.hpp
+++ b/src/core/utils/heap.hpp
@@ -148,18 +148,13 @@ public:
     bool IsFree(void) const { return mSize != kGuardBlockSize && GetNext() != 0; }
 
 private:
-    enum
-    {
-        kGuardBlockSize = 0xffff, ///< Size value of the guard block.
-    };
+    static constexpr uint16_t kGuardBlockSize = 0xffff; // Size value of the guard block.
 
-    uint16_t mSize; ///< Number of bytes in mMemory.
+    uint16_t mSize; // Number of bytes in mMemory.
 
-    /**
-     * Memory for user, with size of *mNext* to ensure size of this
-     * structure is equal to size of block metadata, i.e. sizeof(mSize) + sizeof(mNext)
-     *
-     */
+    // Memory for user, with size of `mNext` to ensure size of this
+    // structure is equal to size of block metadata, i.e.,
+    // sizeof(mSize) + sizeof(mNext).
     uint8_t mMemory[sizeof(uint16_t)];
 };
 
@@ -231,21 +226,18 @@ public:
     size_t GetFreeSize(void) const { return mMemory.mFreeSize; }
 
 private:
-    enum
-    {
 #if OPENTHREAD_CONFIG_DTLS_ENABLE
-        kMemorySize = OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE, ///< Size of memory buffer (bytes).
+    static constexpr uint16_t kMemorySize = OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE;
 #else
-        kMemorySize = OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE_NO_DTLS, ///< Size of memory buffer (bytes).
+    static constexpr uint16_t kMemorySize = OPENTHREAD_CONFIG_HEAP_INTERNAL_SIZE_NO_DTLS;
 #endif
-        kAlignSize          = sizeof(void *),                                     ///< The alignment size.
-        kBlockRemainderSize = kAlignSize - sizeof(uint16_t) * 2,                  ///< Block unit remainder size.
-        kSuperBlockSize     = kAlignSize - sizeof(Block),                         ///< Super block size.
-        kFirstBlockSize     = kMemorySize - kAlignSize * 3 + kBlockRemainderSize, ///< First block size.
-        kSuperBlockOffset   = kAlignSize - sizeof(uint16_t),                      ///< Offset of the super block.
-        kFirstBlockOffset   = kAlignSize * 2 - sizeof(uint16_t),                  ///< Offset of the first block.
-        kGuardBlockOffset   = kMemorySize - sizeof(uint16_t),                     ///< Offset of the guard block.
-    };
+    static constexpr uint16_t kAlignSize          = sizeof(void *);
+    static constexpr uint16_t kBlockRemainderSize = kAlignSize - sizeof(uint16_t) * 2;
+    static constexpr uint16_t kSuperBlockSize     = kAlignSize - sizeof(Block);
+    static constexpr uint16_t kFirstBlockSize     = kMemorySize - kAlignSize * 3 + kBlockRemainderSize;
+    static constexpr uint16_t kSuperBlockOffset   = kAlignSize - sizeof(uint16_t);
+    static constexpr uint16_t kFirstBlockOffset   = kAlignSize * 2 - sizeof(uint16_t);
+    static constexpr uint16_t kGuardBlockOffset   = kMemorySize - sizeof(uint16_t);
 
     static_assert(kMemorySize % kAlignSize == 0, "The heap memory size is not aligned to kAlignSize!");
 

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -178,16 +178,13 @@ public:
     uint64_t GetHistoryBitmap(void) const { return mHistoryBitmap; }
 
 private:
-    enum
-    {
-        kMaxWindow            = 63, // Max window size
-        kDefaultRssiThreshold = 0,
+    static constexpr uint8_t kMaxWindow            = 63; // Max window size
+    static constexpr int8_t  kDefaultRssiThreshold = 0;
 
-        kMaxSampleInterval = 256, // in ms
-        kMinSampleInterval = 2,   // in ms
-        kMaxRandomDelay    = 4,   // in ms
-        kOneSecondInterval = 1000 // in ms
-    };
+    static constexpr uint16_t kMaxSampleInterval = 256;  // in ms
+    static constexpr uint16_t kMinSampleInterval = 2;    // in ms
+    static constexpr uint32_t kMaxRandomDelay    = 4;    // in ms
+    static constexpr uint32_t kOneSecondInterval = 1000; // in ms
 
     void        CheckState(void);
     void        SetJamState(bool aNewState);

--- a/src/core/utils/ping_sender.hpp
+++ b/src/core/utils/ping_sender.hpp
@@ -127,17 +127,10 @@ public:
         const Ip6::Address &GetDestination(void) const { return static_cast<const Ip6::Address &>(mDestination); }
 
     private:
-        enum : uint16_t
-        {
-            kDefaultSize  = OPENTHREAD_CONFIG_PING_SENDER_DEFAULT_SIZE,
-            kDefaultCount = OPENTHREAD_CONFIG_PING_SENDER_DEFAULT_COUNT,
-        };
-
-        enum : uint32_t
-        {
-            kDefaultInterval = OPENTHREAD_CONFIG_PING_SENDER_DEFAULT_INTEVRAL,
-            kDefaultTimeout  = OPENTHREAD_CONFIG_PING_SENDER_DEFAULT_TIMEOUT,
-        };
+        static constexpr uint16_t kDefaultSize     = OPENTHREAD_CONFIG_PING_SENDER_DEFAULT_SIZE;
+        static constexpr uint16_t kDefaultCount    = OPENTHREAD_CONFIG_PING_SENDER_DEFAULT_COUNT;
+        static constexpr uint32_t kDefaultInterval = OPENTHREAD_CONFIG_PING_SENDER_DEFAULT_INTEVRAL;
+        static constexpr uint32_t kDefaultTimeout  = OPENTHREAD_CONFIG_PING_SENDER_DEFAULT_TIMEOUT;
 
         void SetUnspecifiedToDefault(void);
         void InvokeReplyCallback(const Reply &aReply) const;

--- a/src/core/utils/slaac_address.hpp
+++ b/src/core/utils/slaac_address.hpp
@@ -65,18 +65,15 @@ class Slaac : public InstanceLocator, private NonCopyable
     friend class ot::Notifier;
 
 public:
-    enum
-    {
-        kIidSecretKeySize = 32, ///< Number of bytes in secret key for generating semantically opaque IID.
-    };
-
     /**
      * This type represents the secret key used for generating semantically opaque IID (per RFC 7217).
      *
      */
     struct IidSecretKey
     {
-        uint8_t m8[kIidSecretKeySize];
+        static constexpr uint16_t kSize = 32; ///< Secret key size for generating semantically opaque IID.
+
+        uint8_t m8[kSize];
     };
 
     /**
@@ -147,22 +144,19 @@ public:
                       uint8_t *                 aDadCounter      = nullptr) const;
 
 private:
-    enum
-    {
-        kMaxIidCreationAttempts = 256, // Maximum number of attempts when generating IID.
-    };
-
-    // Values for `UpdateMode` input parameter in `Update()`.
-    enum
-    {
-        kModeNone   = 0x0,    // No action.
-        kModeAdd    = 1 << 0, // Add new SLAAC addresses for new prefixes in network data.
-        kModeRemove = 1 << 1, // Remove SLAAC addresses.
-                              // When SLAAC is enabled, remove addresses with no matching prefix in network data,
-                              // When SLAAC is disabled, remove all previously added addresses.
-    };
+    static constexpr uint16_t kMaxIidCreationAttempts = 256; // Maximum number of attempts when generating IID.
 
     typedef uint8_t UpdateMode;
+
+    // Values for `UpdateMode` input parameter in `Update()`.
+
+    static constexpr UpdateMode kModeNone = 0x0;    // No action.
+    static constexpr UpdateMode kModeAdd  = 1 << 0; // Add new SLAAC addresses for new prefixes in network data.
+
+    // Remove SLAAC addresses.
+    // - When SLAAC is enabled, remove addresses with no matching prefix in network data,
+    // - When SLAAC is disabled, remove all previously added addresses.
+    static constexpr UpdateMode kModeRemove = 1 << 1;
 
     bool        ShouldFilter(const Ip6::Prefix &aPrefix) const;
     void        Update(UpdateMode aMode);

--- a/src/core/utils/srp_client_buffers.hpp
+++ b/src/core/utils/srp_client_buffers.hpp
@@ -60,50 +60,47 @@ namespace Utils {
 class SrpClientBuffers : public InstanceLocator, private NonCopyable
 {
 public:
-    enum : uint16_t
-    {
-        /**
-         * Maximum number of service entries in the pool.
-         *
-         */
-        kMaxServices = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_SERVICES,
+    /**
+     * Maximum number of service entries in the pool.
+     *
+     */
+    static constexpr uint16_t kMaxServices = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_SERVICES;
 
-        /**
-         * Max number of host address entries.
-         *
-         */
-        kMaxHostAddresses = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRESSES,
+    /**
+     * Max number of host address entries.
+     *
+     */
+    static constexpr uint16_t kMaxHostAddresses = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRESSES;
 
-        /**
-         * Size (number of char) of host name string (includes null `\0` termination char).
-         *
-         */
-        kHostNameSize = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_HOST_NAME_SIZE,
+    /**
+     * Size (number of char) of host name string (includes null `\0` termination char).
+     *
+     */
+    static constexpr uint16_t kHostNameSize = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_HOST_NAME_SIZE;
 
-        /**
-         * Size (number of char) of service name string (includes null `\0` termination char).
-         *
-         */
-        kServiceNameSize = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_SERVICE_NAME_SIZE,
+    /**
+     * Size (number of char) of service name string (includes null `\0` termination char).
+     *
+     */
+    static constexpr uint16_t kServiceNameSize = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_SERVICE_NAME_SIZE;
 
-        /**
-         * Array length for service subtype label.
-         *
-         */
-        kServiceMaxSubTypes = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_SERVICE_MAX_SUB_TYPES,
+    /**
+     * Array length for service subtype label.
+     *
+     */
+    static constexpr uint16_t kServiceMaxSubTypes = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_SERVICE_MAX_SUB_TYPES;
 
-        /**
-         * Size (number of char) of service instance name string (includes null `\0` termination char).
-         *
-         */
-        kInstanceNameSize = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_SERVICE_INSTANCE_NAME_SIZE,
+    /**
+     * Size (number of char) of service instance name string (includes null `\0` termination char).
+     *
+     */
+    static constexpr uint16_t kInstanceNameSize = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_SERVICE_INSTANCE_NAME_SIZE;
 
-        /**
-         * Size (number of bytes) of TXT record buffer.
-         *
-         */
-        kTxtBufferSize = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_TXT_BUFFER_SIZE,
-    };
+    /**
+     * Size (number of bytes) of TXT record buffer.
+     *
+     */
+    static constexpr uint16_t kTxtBufferSize = OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_TXT_BUFFER_SIZE;
 
     /**
      * This class represents a SRP client service entry from the pool.


### PR DESCRIPTION
This commit replaces the `enum` constants with `constexpr` definitions
in all the modules under `core/utils`. This commit also contains
some smaller changes: typo fixes in the comments, removal of unused
constants, and adding `uint` type to the named `enum` definitions.