### PR TITLE
[mle] check netif is up before processing discover scan

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (151)
+#define OPENTHREAD_API_VERSION (152)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -242,8 +242,10 @@ bool otThreadIsSingleton(otInstance *aInstance);
  *                                    scan completes.
  * @param[in]  aCallbackContext       A pointer to application-specific context.
  *
- * @retval OT_ERROR_NONE  Accepted the Thread Discovery request.
- * @retval OT_ERROR_BUSY  Already performing an Thread Discovery.
+ * @retval OT_ERROR_NONE           Successfully started a Thread Discovery Scan.
+ * @retval OT_ERROR_INVALID_STATE  The IPv6 interface is not enabled (netif is not up).
+ * @retval OT_ERROR_NO_BUFS        Could not allocate message for Discovery Request.
+ * @retval OT_ERROR_BUSY           Thread Discovery Scan is already in progress.
  *
  */
 otError otThreadDiscover(otInstance *             aInstance,

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -73,6 +73,8 @@ Error DiscoverScanner::Discover(const Mac::ChannelMask &aScanChannels,
     MeshCoP::DiscoveryRequestTlv    discoveryRequest;
     MeshCoP::JoinerAdvertisementTlv joinerAdvertisement;
 
+    VerifyOrExit(Get<ThreadNetif>().IsUp(), error = kErrorInvalidState);
+
     VerifyOrExit(mState == kStateIdle, error = kErrorBusy);
 
     mEnableFiltering = aEnableFiltering;

--- a/src/core/thread/discover_scanner.hpp
+++ b/src/core/thread/discover_scanner.hpp
@@ -115,9 +115,10 @@ public:
      * @param[in]  aHandler           A pointer to a function that is called on receiving an MLE Discovery Response.
      * @param[in]  aContext           A pointer to arbitrary context information.
      *
-     * @retval kErrorNone       Successfully started a Thread Discovery Scan.
-     * @retval kErrorNoBufs     Could not allocate message for Discovery Request.
-     * @retval kErrorBusy       Thread Discovery Scan is already in progress.
+     * @retval kErrorNone           Successfully started a Thread Discovery Scan.
+     * @retval kErrorInvalidState   The IPv6 interface is not enabled (netif is not up).
+     * @retval kErrorNoBufs         Could not allocate message for Discovery Request.
+     * @retval kErrorBusy           Thread Discovery Scan is already in progress.
      *
      */
     Error Discover(const Mac::ChannelMask &aScanChannels,

--- a/tests/scripts/expect/cli-scan-discover.exp
+++ b/tests/scripts/expect/cli-scan-discover.exp
@@ -78,6 +78,8 @@ expect -re "\\| +$channel \\| +-?\\d+ \\|"
 expect_line "Done"
 
 switch_node 3
+send "discover\n"
+expect "Error 13: InvalidState"
 send "ifconfig up\n"
 expect_line "Done"
 send "discover $channel\n"


### PR DESCRIPTION
This commit updates `Mle::DiscoverScanner` to check that IPv6
interface is enabled from `Discover()` (returns `kErrorInvalidState`
if netif is not up).