### PR TITLE
[mle] skip removing and re-adding of RLOC IPv6 address on no change

### DIFF
--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -358,6 +358,8 @@ public:
      * This method is intended for addresses internal to OpenThread. The @p aAddress instance is directly added in the
      * unicast address linked list.
      *
+     * If @p aAddress is already added, the call to `AddUnicastAddress()` with the same address will perform no action.
+     *
      * @param[in]  aAddress  A reference to the unicast address.
      *
      */
@@ -368,6 +370,8 @@ public:
      *
      * This method is intended for addresses internal to OpenThread. The @p aAddress instance is removed from the
      * unicast address linked list.
+     *
+     * If @p aAddress is not in the list, the call to `RemoveUnicastAddress()` will perform no action.
      *
      * @param[in]  aAddress  A reference to the unicast address.
      *

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -915,22 +915,23 @@ void Mle::SetRloc16(uint16_t aRloc16)
     if (aRloc16 != oldRloc16)
     {
         otLogNoteMle("RLOC16 %04x -> %04x", oldRloc16, aRloc16);
-
-        // Clear cached CoAP with old RLOC source
-        if (oldRloc16 != Mac::kShortAddrInvalid)
-        {
-            Get<Tmf::Agent>().ClearRequests(mMeshLocal16.GetAddress());
-        }
     }
 
-    Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal16);
+    if (Get<ThreadNetif>().HasUnicastAddress(mMeshLocal16) &&
+        (mMeshLocal16.GetAddress().GetIid().GetLocator() != aRloc16))
+    {
+        Get<ThreadNetif>().RemoveUnicastAddress(mMeshLocal16);
+        Get<Tmf::Agent>().ClearRequests(mMeshLocal16.GetAddress());
+    }
 
     Get<Mac::Mac>().SetShortAddress(aRloc16);
     Get<Ip6::Mpl>().SetSeedId(aRloc16);
 
     if (aRloc16 != Mac::kShortAddrInvalid)
     {
-        // mesh-local 16
+        // We can always call `AddUnicastAddress(mMeshLocat16)` and if
+        // the address is already added, it will perform no action.
+
         mMeshLocal16.GetAddress().GetIid().SetLocator(aRloc16);
         Get<ThreadNetif>().AddUnicastAddress(mMeshLocal16);
 #if OPENTHREAD_FTD


### PR DESCRIPTION
This commit updates `Mle::SetRloc16()` to skip removing and re-adding
of the `mMeshLocal16` IPv6 address when it does not change.

It also updates how the cached COAP messages are cleared such that
they are cleared only if the address gets changed.