### PR TITLE
[mac] tx beacon on the same radio as the request in multi-radio config

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -916,6 +916,7 @@ private:
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     RadioTypes mTxPendingRadioLinks;
+    RadioTypes mTxBeaconRadioLinks;
     Error      mTxError;
 #endif
 


### PR DESCRIPTION
This commit updates `Mac` under `MULTI_RADIO` config to limit the
radio links used when sending a MAC Beacon frame (which uses
broadcast destination and therefore by default would be sent on all
radios) to the same radio links from which the triggering Beacon
Request frame(s) were received. This ensures that when a multi-radio
node scans another multi-radio node we get one Beacon response on
each radio link.