### PR TITLE
[test] extra wait on multiple prefix add in `test_netdata_publisher`

### DIFF
--- a/tests/scripts/thread-cert/test_netdata_publisher.py
+++ b/tests/scripts/thread-cert/test_netdata_publisher.py
@@ -416,7 +416,7 @@ class NetDataPublisher(thread_cert.TestCase):
 
         for node in routers:
             node.netdata_publish_prefix(ON_MESH_PREFIX, ON_MESH_FLAGS, 'med')
-        self.simulator.go(WAIT_TIME)
+            self.simulator.go(WAIT_TIME)
         prefixes = leader.get_prefixes()
         self.check_num_of_prefixes(prefixes, 0, 1 + len(routers), 0)
         self.assertTrue(1 + len(routers) >= DESIRED_NUM_ON_MESH_PREFIX)


### PR DESCRIPTION
This commit updates the `test_netdata_publisher` to add extra wait
time between adds (where the same on-mesh prefix is published on all
routers). This should help make the test robust and avoid the
situation where publishing the same prefix on all routers all
together could cause the number of entries in the Network Data to
temporarily go above the desired number. This can happen (though not
often) due to the randomness in how/when nodes using `Publisher` add
their entry in the Network Data.

----

This should help fix #6922. 
Please see https://github.com/openthread/openthread/issues/6922#issuecomment-898743403 for more details.