### PR TITLE
[tcp] link third_party TCPlp module in CMake build

### DIFF
--- a/src/core/ftd.cmake
+++ b/src/core/ftd.cmake
@@ -43,5 +43,6 @@ target_sources(openthread-ftd PRIVATE ${COMMON_SOURCES})
 target_link_libraries(openthread-ftd
     PRIVATE
         ${OT_MBEDTLS}
+        tcplp
         ot-config
 )

--- a/src/core/mtd.cmake
+++ b/src/core/mtd.cmake
@@ -43,5 +43,6 @@ target_sources(openthread-mtd PRIVATE ${COMMON_SOURCES})
 target_link_libraries(openthread-mtd
     PRIVATE
         ${OT_MBEDTLS}
+        tcplp
         ot-config
 )

--- a/third_party/tcplp/CMakeLists.txt
+++ b/third_party/tcplp/CMakeLists.txt
@@ -44,3 +44,21 @@ target_include_directories(${tcplp_static_target}
         ${OT_PUBLIC_INCLUDES}
         $<TARGET_PROPERTY:ot-config,INTERFACE_INCLUDE_DIRECTORIES>
 )
+
+# TCPlp calls functions that are defined by the core OpenThread (like
+# "otMessageWrite()"), so we need to add the core library (FTD or MTD, as
+# appropriate) as a link dependency.
+
+if(OT_FTD)
+    target_link_libraries(${tcplp_static_target}
+        PRIVATE
+            openthread-ftd
+    )
+endif()
+
+if(OT_MTD)
+    target_link_libraries(${tcplp_static_target}
+        PRIVATE
+            openthread-mtd
+    )
+endif()


### PR DESCRIPTION
This is the sixth in a series of pull requests (after #6744, #6770, #6790, #6857, and #6885) bringing TCPlp to OpenThread. I'm making a series of small pull requests so that it's easier for the OpenThread community to review the code. If you'd like to preview a working version of TCPlp in OpenThread, see #6650.

This pull request changes the Makefiles so that the TCPlp module is linked in to the code when building OpenThread using CMake. This is necessary when `script/build` or `script/cmake-build` is used to build OpenThread.