### PR TITLE
[netif] define related types (unicast/mcast addr, iterator) as nested types

### DIFF
--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -87,7 +87,7 @@ otError otIp6AddUnicastAddress(otInstance *aInstance, const otNetifAddress *aAdd
     Instance &instance = *static_cast<Instance *>(aInstance);
 
     return instance.Get<ThreadNetif>().AddExternalUnicastAddress(
-        *static_cast<const Ip6::NetifUnicastAddress *>(aAddress));
+        *static_cast<const Ip6::Netif::UnicastAddress *>(aAddress));
 }
 
 otError otIp6RemoveUnicastAddress(otInstance *aInstance, const otIp6Address *aAddress)
@@ -266,9 +266,9 @@ bool otIp6IsAddressUnspecified(const otIp6Address *aAddress)
 
 otError otIp6SelectSourceAddress(otInstance *aInstance, otMessageInfo *aMessageInfo)
 {
-    Error                           error    = kErrorNone;
-    Instance &                      instance = *static_cast<Instance *>(aInstance);
-    const Ip6::NetifUnicastAddress *netifAddr;
+    Error                             error    = kErrorNone;
+    Instance &                        instance = *static_cast<Instance *>(aInstance);
+    const Ip6::Netif::UnicastAddress *netifAddr;
 
     netifAddr = instance.Get<Ip6::Ip6>().SelectSourceAddress(*static_cast<Ip6::MessageInfo *>(aMessageInfo));
     VerifyOrExit(netifAddr != nullptr, error = kErrorNotFound);

--- a/src/core/backbone_router/bbr_local.hpp
+++ b/src/core/backbone_router/bbr_local.hpp
@@ -280,7 +280,7 @@ private:
 
     NetworkData::OnMeshPrefixConfig mDomainPrefixConfig;
 
-    Ip6::NetifUnicastAddress             mBackboneRouterPrimaryAloc;
+    Ip6::Netif::UnicastAddress           mBackboneRouterPrimaryAloc;
     Ip6::Address                         mAllNetworkBackboneRouters;
     Ip6::Address                         mAllDomainBackboneRouters;
     otBackboneRouterDomainPrefixCallback mDomainPrefixCallback;

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -189,8 +189,8 @@ private:
     Coap::Resource mPendingSet;
     Coap::Resource mProxyTransmit;
 
-    Ip6::Udp::Receiver       mUdpReceiver; ///< The UDP receiver to receive packets from external commissioner
-    Ip6::NetifUnicastAddress mCommissionerAloc;
+    Ip6::Udp::Receiver         mUdpReceiver; ///< The UDP receiver to receive packets from external commissioner
+    Ip6::Netif::UnicastAddress mCommissionerAloc;
 
     TimerMilli mTimer;
     State      mState;

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -462,7 +462,7 @@ private:
     EnergyScanClient    mEnergyScan;
     PanIdQueryClient    mPanIdQuery;
 
-    Ip6::NetifUnicastAddress mCommissionerAloc;
+    Ip6::Netif::UnicastAddress mCommissionerAloc;
 
     char mProvisioningUrl[OT_PROVISIONING_URL_MAX_SIZE + 1]; // + 1 is for null char at end of string.
 

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -57,7 +57,7 @@ Client::Client(Instance &aInstance)
     memset(mIdentityAssociations, 0, sizeof(mIdentityAssociations));
 }
 
-bool Client::MatchNetifAddressWithPrefix(const Ip6::NetifUnicastAddress &aNetifAddress, const Ip6::Prefix &aIp6Prefix)
+bool Client::MatchNetifAddressWithPrefix(const Ip6::Netif::UnicastAddress &aNetifAddress, const Ip6::Prefix &aIp6Prefix)
 {
     return aNetifAddress.HasPrefix(aIp6Prefix);
 }

--- a/src/core/net/dhcp6_client.hpp
+++ b/src/core/net/dhcp6_client.hpp
@@ -99,18 +99,18 @@ private:
 
     struct IdentityAssociation
     {
-        Ip6::NetifUnicastAddress mNetifAddress;
-        uint32_t                 mPreferredLifetime;
-        uint32_t                 mValidLifetime;
-        uint16_t                 mPrefixAgentRloc;
-        IaStatus                 mStatus;
+        Ip6::Netif::UnicastAddress mNetifAddress;
+        uint32_t                   mPreferredLifetime;
+        uint32_t                   mValidLifetime;
+        uint16_t                   mPrefixAgentRloc;
+        IaStatus                   mStatus;
     };
 
     void Start(void);
     void Stop(void);
 
-    static bool MatchNetifAddressWithPrefix(const Ip6::NetifUnicastAddress &aNetifAddress,
-                                            const Ip6::Prefix &             aIp6Prefix);
+    static bool MatchNetifAddressWithPrefix(const Ip6::Netif::UnicastAddress &aNetifAddress,
+                                            const Ip6::Prefix &               aIp6Prefix);
 
     void Solicit(uint16_t aRloc16);
 

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -130,7 +130,7 @@ private:
          * @returns the ALOC.
          *
          */
-        Ip6::NetifUnicastAddress &GetAloc(void) { return mAloc; }
+        Ip6::Netif::UnicastAddress &GetAloc(void) { return mAloc; }
 
         /**
          * This method returns the IPv6 prefix.
@@ -176,8 +176,8 @@ private:
         }
 
     private:
-        Ip6::NetifUnicastAddress mAloc;
-        Ip6::Prefix              mPrefix;
+        Ip6::Netif::UnicastAddress mAloc;
+        Ip6::Prefix                mPrefix;
     };
 
     static constexpr uint16_t kNumPrefixes = OPENTHREAD_CONFIG_DHCP6_SERVER_NUM_PREFIXES;

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -219,10 +219,10 @@ exit:
 
 Error Ip6::AddTunneledMplOption(Message &aMessage, Header &aHeader, MessageInfo &aMessageInfo)
 {
-    Error                      error = kErrorNone;
-    Header                     tunnelHeader;
-    const NetifUnicastAddress *source;
-    MessageInfo                messageInfo(aMessageInfo);
+    Error                        error = kErrorNone;
+    Header                       tunnelHeader;
+    const Netif::UnicastAddress *source;
+    MessageInfo                  messageInfo(aMessageInfo);
 
     // Use IP-in-IP encapsulation (RFC2473) and ALL_MPL_FORWARDERS address.
     messageInfo.GetPeerAddr().SetToRealmLocalAllMplForwarders();
@@ -468,7 +468,7 @@ Error Ip6::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aI
 
     if (aMessageInfo.GetSockAddr().IsUnspecified() || aMessageInfo.GetSockAddr().IsMulticast())
     {
-        const NetifUnicastAddress *source = SelectSourceAddress(aMessageInfo);
+        const Netif::UnicastAddress *source = SelectSourceAddress(aMessageInfo);
 
         VerifyOrExit(source != nullptr, error = kErrorInvalidSourceAddress);
         header.SetSource(source->GetAddress());
@@ -1367,15 +1367,15 @@ exit:
     return rval;
 }
 
-const NetifUnicastAddress *Ip6::SelectSourceAddress(MessageInfo &aMessageInfo)
+const Netif::UnicastAddress *Ip6::SelectSourceAddress(MessageInfo &aMessageInfo)
 {
-    Address *                  destination                 = &aMessageInfo.GetPeerAddr();
-    uint8_t                    destinationScope            = destination->GetScope();
-    const bool                 destinationIsRoutingLocator = Get<Mle::Mle>().IsRoutingLocator(*destination);
-    const NetifUnicastAddress *rvalAddr                    = nullptr;
-    uint8_t                    rvalPrefixMatched           = 0;
+    Address *                    destination                 = &aMessageInfo.GetPeerAddr();
+    uint8_t                      destinationScope            = destination->GetScope();
+    const bool                   destinationIsRoutingLocator = Get<Mle::Mle>().IsRoutingLocator(*destination);
+    const Netif::UnicastAddress *rvalAddr                    = nullptr;
+    uint8_t                      rvalPrefixMatched           = 0;
 
-    for (const NetifUnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr; addr = addr->GetNext())
+    for (const Netif::UnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr; addr = addr->GetNext())
     {
         const Address *candidateAddr = &addr->GetAddress();
         uint8_t        candidatePrefixMatched;
@@ -1482,7 +1482,7 @@ bool Ip6::IsOnLink(const Address &aAddress) const
         ExitNow(rval = true);
     }
 
-    for (const NetifUnicastAddress *cur = Get<ThreadNetif>().GetUnicastAddresses(); cur; cur = cur->GetNext())
+    for (const Netif::UnicastAddress *cur = Get<ThreadNetif>().GetUnicastAddresses(); cur; cur = cur->GetNext())
     {
         if (cur->GetAddress().PrefixMatch(aAddress) >= cur->mPrefixLength)
         {

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -287,7 +287,7 @@ public:
      * @returns A pointer to the selected IPv6 source address or nullptr if no source address was found.
      *
      */
-    const NetifUnicastAddress *SelectSourceAddress(MessageInfo &aMessageInfo);
+    const Netif::UnicastAddress *SelectSourceAddress(MessageInfo &aMessageInfo);
 
     /**
      * This method returns a reference to the send queue.

--- a/src/core/net/nd_agent.hpp
+++ b/src/core/net/nd_agent.hpp
@@ -76,7 +76,7 @@ private:
     void FreeAloc(void) { mAloc.mNext = &mAloc; }
     bool IsAlocInUse(void) const { return mAloc.mNext != &mAloc; }
 
-    Ip6::NetifUnicastAddress mAloc;
+    Ip6::Netif::UnicastAddress mAloc;
 };
 
 } // namespace NeighborDiscovery

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -45,7 +45,7 @@ namespace Ip6 {
 class AddressInfo : public otIp6AddressInfo
 {
 public:
-    explicit AddressInfo(const NetifUnicastAddress &aAddress)
+    explicit AddressInfo(const Netif::UnicastAddress &aAddress)
     {
         mAddress      = &aAddress.mAddress;
         mPrefixLength = aAddress.mPrefixLength;
@@ -53,7 +53,7 @@ public:
         mPreferred    = aAddress.mPreferred;
     }
 
-    explicit AddressInfo(const NetifMulticastAddress &aAddress)
+    explicit AddressInfo(const Netif::MulticastAddress &aAddress)
     {
         mAddress      = &aAddress.GetAddress();
         mPrefixLength = kMulticastPrefixLength;
@@ -103,6 +103,9 @@ const otNetifMulticastAddress Netif::kLinkLocalAllRoutersMulticastAddress = {
     {{{0xff, 0x02, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02}}},
     &Netif::kRealmLocalAllRoutersMulticastAddress};
 
+//---------------------------------------------------------------------------------------------------------------------
+// Netif
+
 Netif::Netif(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mMulticastPromiscuous(false)
@@ -118,9 +121,9 @@ bool Netif::IsMulticastSubscribed(const Address &aAddress) const
 
 void Netif::SubscribeAllNodesMulticast(void)
 {
-    NetifMulticastAddress *tail;
-    NetifMulticastAddress &linkLocalAllNodesAddress =
-        static_cast<NetifMulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
+    MulticastAddress *tail;
+    MulticastAddress &linkLocalAllNodesAddress =
+        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
 
     VerifyOrExit(!mMulticastAddresses.Contains(linkLocalAllNodesAddress));
 
@@ -144,7 +147,7 @@ void Netif::SubscribeAllNodesMulticast(void)
 
     VerifyOrExit(mAddressCallback != nullptr);
 
-    for (const NetifMulticastAddress *entry = &linkLocalAllNodesAddress; entry; entry = entry->GetNext())
+    for (const MulticastAddress *entry = &linkLocalAllNodesAddress; entry; entry = entry->GetNext())
     {
         AddressInfo addressInfo(*entry);
 
@@ -158,9 +161,9 @@ exit:
 
 void Netif::UnsubscribeAllNodesMulticast(void)
 {
-    NetifMulticastAddress *      prev;
-    const NetifMulticastAddress &linkLocalAllNodesAddress =
-        static_cast<NetifMulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
+    MulticastAddress *      prev;
+    const MulticastAddress &linkLocalAllNodesAddress =
+        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
 
     // The tail of multicast address linked list contains the
     // fixed addresses. Search if LinkLocalAll is present
@@ -178,7 +181,7 @@ void Netif::UnsubscribeAllNodesMulticast(void)
     //    LinkLocalAllRouters -> RealmLocalAllRouters -> LinkLocalAll
     //         -> RealmLocalAll -> RealmLocalAllMpl.
 
-    OT_ASSERT(prev != static_cast<NetifMulticastAddress *>(
+    OT_ASSERT(prev != static_cast<MulticastAddress *>(
                           const_cast<otNetifMulticastAddress *>(&kRealmLocalAllRoutersMulticastAddress)));
 
     if (prev == nullptr)
@@ -194,7 +197,7 @@ void Netif::UnsubscribeAllNodesMulticast(void)
 
     VerifyOrExit(mAddressCallback != nullptr);
 
-    for (const NetifMulticastAddress *entry = &linkLocalAllNodesAddress; entry; entry = entry->GetNext())
+    for (const MulticastAddress *entry = &linkLocalAllNodesAddress; entry; entry = entry->GetNext())
     {
         AddressInfo addressInfo(*entry);
 
@@ -208,14 +211,14 @@ exit:
 
 void Netif::SubscribeAllRoutersMulticast(void)
 {
-    Error                  error                      = kErrorNone;
-    NetifMulticastAddress *prev                       = nullptr;
-    NetifMulticastAddress &linkLocalAllRoutersAddress = static_cast<NetifMulticastAddress &>(
-        const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
-    NetifMulticastAddress &linkLocalAllNodesAddress =
-        static_cast<NetifMulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
-    NetifMulticastAddress &realmLocalAllRoutersAddress = static_cast<NetifMulticastAddress &>(
-        const_cast<otNetifMulticastAddress &>(kRealmLocalAllRoutersMulticastAddress));
+    Error             error = kErrorNone;
+    MulticastAddress *prev  = nullptr;
+    MulticastAddress &linkLocalAllRoutersAddress =
+        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
+    MulticastAddress &linkLocalAllNodesAddress =
+        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
+    MulticastAddress &realmLocalAllRoutersAddress =
+        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kRealmLocalAllRoutersMulticastAddress));
 
     error = mMulticastAddresses.Find(linkLocalAllNodesAddress, prev);
 
@@ -254,8 +257,8 @@ void Netif::SubscribeAllRoutersMulticast(void)
 
     VerifyOrExit(mAddressCallback != nullptr);
 
-    for (const NetifMulticastAddress *entry = &linkLocalAllRoutersAddress; entry != &linkLocalAllNodesAddress;
-         entry                              = entry->GetNext())
+    for (const MulticastAddress *entry = &linkLocalAllRoutersAddress; entry != &linkLocalAllNodesAddress;
+         entry                         = entry->GetNext())
     {
         AddressInfo addressInfo(*entry);
 
@@ -269,11 +272,11 @@ exit:
 
 void Netif::UnsubscribeAllRoutersMulticast(void)
 {
-    NetifMulticastAddress *prev;
-    NetifMulticastAddress &linkLocalAllRoutersAddress = static_cast<NetifMulticastAddress &>(
-        const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
-    NetifMulticastAddress &linkLocalAllNodesAddress =
-        static_cast<NetifMulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
+    MulticastAddress *prev;
+    MulticastAddress &linkLocalAllRoutersAddress =
+        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
+    MulticastAddress &linkLocalAllNodesAddress =
+        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
 
     // The tail of multicast address linked list contains the
     // fixed addresses. We check for the chain of five addresses:
@@ -300,8 +303,8 @@ void Netif::UnsubscribeAllRoutersMulticast(void)
 
     VerifyOrExit(mAddressCallback != nullptr);
 
-    for (const NetifMulticastAddress *entry = &linkLocalAllRoutersAddress; entry != &linkLocalAllNodesAddress;
-         entry                              = entry->GetNext())
+    for (const MulticastAddress *entry = &linkLocalAllRoutersAddress; entry != &linkLocalAllNodesAddress;
+         entry                         = entry->GetNext())
     {
         AddressInfo addressInfo(*entry);
 
@@ -313,12 +316,12 @@ exit:
     return;
 }
 
-bool Netif::IsMulticastAddressExternal(const NetifMulticastAddress &aAddress) const
+bool Netif::IsMulticastAddressExternal(const MulticastAddress &aAddress) const
 {
-    return mExtMulticastAddressPool.IsPoolEntry(static_cast<const ExternalNetifMulticastAddress &>(aAddress));
+    return mExtMulticastAddressPool.IsPoolEntry(static_cast<const ExternalMulticastAddress &>(aAddress));
 }
 
-void Netif::SubscribeMulticast(NetifMulticastAddress &aAddress)
+void Netif::SubscribeMulticast(MulticastAddress &aAddress)
 {
     SuccessOrExit(mMulticastAddresses.Add(aAddress));
 
@@ -337,7 +340,7 @@ exit:
     return;
 }
 
-void Netif::UnsubscribeMulticast(const NetifMulticastAddress &aAddress)
+void Netif::UnsubscribeMulticast(const MulticastAddress &aAddress)
 {
     SuccessOrExit(mMulticastAddresses.Remove(aAddress));
 
@@ -357,10 +360,10 @@ exit:
 
 Error Netif::SubscribeExternalMulticast(const Address &aAddress)
 {
-    Error                  error                      = kErrorNone;
-    NetifMulticastAddress &linkLocalAllRoutersAddress = static_cast<NetifMulticastAddress &>(
-        const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
-    ExternalNetifMulticastAddress *entry;
+    Error             error = kErrorNone;
+    MulticastAddress &linkLocalAllRoutersAddress =
+        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
+    ExternalMulticastAddress *entry;
 
     VerifyOrExit(aAddress.IsMulticast(), error = kErrorInvalidArgs);
     VerifyOrExit(!IsMulticastSubscribed(aAddress), error = kErrorAlready);
@@ -369,7 +372,7 @@ Error Netif::SubscribeExternalMulticast(const Address &aAddress)
     // LinkLocalAllRouters -> RealmLocalAllRouters -> LinkLocalAllNodes
     // -> RealmLocalAllNodes -> RealmLocalAllMpl.
 
-    for (const NetifMulticastAddress *cur = &linkLocalAllRoutersAddress; cur; cur = cur->GetNext())
+    for (const MulticastAddress *cur = &linkLocalAllRoutersAddress; cur; cur = cur->GetNext())
     {
         VerifyOrExit(cur->GetAddress() != aAddress, error = kErrorInvalidArgs);
     }
@@ -390,9 +393,9 @@ exit:
 
 Error Netif::UnsubscribeExternalMulticast(const Address &aAddress)
 {
-    Error                  error = kErrorNone;
-    NetifMulticastAddress *entry;
-    NetifMulticastAddress *prev;
+    Error             error = kErrorNone;
+    MulticastAddress *entry;
+    MulticastAddress *prev;
 
     entry = mMulticastAddresses.FindMatching(aAddress, prev);
     VerifyOrExit(entry != nullptr, error = kErrorNotFound);
@@ -401,7 +404,7 @@ Error Netif::UnsubscribeExternalMulticast(const Address &aAddress)
 
     mMulticastAddresses.PopAfter(prev);
 
-    mExtMulticastAddressPool.Free(static_cast<ExternalNetifMulticastAddress &>(*entry));
+    mExtMulticastAddressPool.Free(static_cast<ExternalMulticastAddress &>(*entry));
 
     Get<Notifier>().Signal(kEventIp6MulticastUnsubscribed);
 
@@ -411,9 +414,9 @@ exit:
 
 void Netif::UnsubscribeAllExternalMulticastAddresses(void)
 {
-    NetifMulticastAddress *next;
+    MulticastAddress *next;
 
-    for (NetifMulticastAddress *entry = mMulticastAddresses.GetHead(); entry != nullptr; entry = next)
+    for (MulticastAddress *entry = mMulticastAddresses.GetHead(); entry != nullptr; entry = next)
     {
         next = entry->GetNext();
 
@@ -430,7 +433,7 @@ void Netif::SetAddressCallback(otIp6AddressCallback aCallback, void *aCallbackCo
     mAddressCallbackContext = aCallbackContext;
 }
 
-void Netif::AddUnicastAddress(NetifUnicastAddress &aAddress)
+void Netif::AddUnicastAddress(UnicastAddress &aAddress)
 {
     SuccessOrExit(mUnicastAddresses.Add(aAddress));
 
@@ -449,7 +452,7 @@ exit:
     return;
 }
 
-void Netif::RemoveUnicastAddress(const NetifUnicastAddress &aAddress)
+void Netif::RemoveUnicastAddress(const UnicastAddress &aAddress)
 {
     SuccessOrExit(mUnicastAddresses.Remove(aAddress));
 
@@ -466,10 +469,10 @@ exit:
     return;
 }
 
-Error Netif::AddExternalUnicastAddress(const NetifUnicastAddress &aAddress)
+Error Netif::AddExternalUnicastAddress(const UnicastAddress &aAddress)
 {
-    Error                error = kErrorNone;
-    NetifUnicastAddress *entry;
+    Error           error = kErrorNone;
+    UnicastAddress *entry;
 
     VerifyOrExit(!aAddress.GetAddress().IsMulticast(), error = kErrorInvalidArgs);
 
@@ -501,9 +504,9 @@ exit:
 
 Error Netif::RemoveExternalUnicastAddress(const Address &aAddress)
 {
-    Error                error = kErrorNone;
-    NetifUnicastAddress *entry;
-    NetifUnicastAddress *prev;
+    Error           error = kErrorNone;
+    UnicastAddress *entry;
+    UnicastAddress *prev;
 
     entry = mUnicastAddresses.FindMatching(aAddress, prev);
     VerifyOrExit(entry != nullptr, error = kErrorNotFound);
@@ -520,9 +523,9 @@ exit:
 
 void Netif::RemoveAllExternalUnicastAddresses(void)
 {
-    NetifUnicastAddress *next;
+    UnicastAddress *next;
 
-    for (NetifUnicastAddress *entry = mUnicastAddresses.GetHead(); entry != nullptr; entry = next)
+    for (UnicastAddress *entry = mUnicastAddresses.GetHead(); entry != nullptr; entry = next)
     {
         next = entry->GetNext();
 
@@ -538,12 +541,15 @@ bool Netif::HasUnicastAddress(const Address &aAddress) const
     return mUnicastAddresses.ContainsMatching(aAddress);
 }
 
-bool Netif::IsUnicastAddressExternal(const NetifUnicastAddress &aAddress) const
+bool Netif::IsUnicastAddressExternal(const UnicastAddress &aAddress) const
 {
     return mExtUnicastAddressPool.IsPoolEntry(aAddress);
 }
 
-void NetifUnicastAddress::InitAsThreadOrigin(bool aPreferred)
+//---------------------------------------------------------------------------------------------------------------------
+// Netif::UnicastAddress
+
+void Netif::UnicastAddress::InitAsThreadOrigin(bool aPreferred)
 {
     Clear();
     mPrefixLength  = NetworkPrefix::kLength;
@@ -552,13 +558,13 @@ void NetifUnicastAddress::InitAsThreadOrigin(bool aPreferred)
     mValid         = true;
 }
 
-void NetifUnicastAddress::InitAsThreadOriginRealmLocalScope(void)
+void Netif::UnicastAddress::InitAsThreadOriginRealmLocalScope(void)
 {
     InitAsThreadOrigin();
     SetScopeOverride(Address::kRealmLocalScope);
 }
 
-void NetifUnicastAddress::InitAsThreadOriginGlobalScope(void)
+void Netif::UnicastAddress::InitAsThreadOriginGlobalScope(void)
 {
     Clear();
     mAddressOrigin = OT_ADDRESS_ORIGIN_THREAD;
@@ -566,13 +572,35 @@ void NetifUnicastAddress::InitAsThreadOriginGlobalScope(void)
     SetScopeOverride(Address::kGlobalScope);
 }
 
-void NetifUnicastAddress::InitAsSlaacOrigin(uint8_t aPrefixLength, bool aPreferred)
+void Netif::UnicastAddress::InitAsSlaacOrigin(uint8_t aPrefixLength, bool aPreferred)
 {
     Clear();
     mPrefixLength  = aPrefixLength;
     mAddressOrigin = OT_ADDRESS_ORIGIN_SLAAC;
     mPreferred     = aPreferred;
     mValid         = true;
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+// Netif::ExternalMulticastAddress::Iterator
+
+Netif::ExternalMulticastAddress::Iterator::Iterator(const Netif &aNetif, Address::TypeFilter aFilter)
+    : ItemPtrIterator(nullptr)
+    , mNetif(aNetif)
+    , mFilter(aFilter)
+{
+    AdvanceFrom(mNetif.GetMulticastAddresses());
+}
+
+void Netif::ExternalMulticastAddress::Iterator::AdvanceFrom(const MulticastAddress *aAddr)
+{
+    while (aAddr != nullptr &&
+           !(mNetif.IsMulticastAddressExternal(*aAddr) && aAddr->GetAddress().MatchesFilter(mFilter)))
+    {
+        aAddr = aAddr->GetNext();
+    }
+
+    mItem = const_cast<ExternalMulticastAddress *>(static_cast<const ExternalMulticastAddress *>(aAddr));
 }
 
 } // namespace Ip6

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -65,202 +65,6 @@ class Ip6;
  */
 
 /**
- * This class implements an IPv6 network interface unicast address.
- *
- */
-class NetifUnicastAddress : public otNetifAddress,
-                            public LinkedListEntry<NetifUnicastAddress>,
-                            public Clearable<NetifUnicastAddress>
-{
-    friend class Netif;
-    friend class LinkedList<NetifUnicastAddress>;
-
-public:
-    /**
-     * This method clears and initializes the unicast address as a preferred, valid, thread-origin address with 64-bit
-     * prefix length.
-     *
-     * @param[in]   aPreferred  Whether to initialize as a preferred address.
-     *
-     */
-    void InitAsThreadOrigin(bool aPreferred = false);
-
-    /**
-     * This method clears and initializes the unicast address as a valid (but not preferred), thread-origin, realm-local
-     * scope (overridden) address with 64-bit prefix length.
-     *
-     */
-    void InitAsThreadOriginRealmLocalScope(void);
-
-    /**
-     * This method clears and initializes the unicast address as a valid (but not preferred), thread-origin, global
-     * scope address.
-     *
-     */
-    void InitAsThreadOriginGlobalScope(void);
-
-    /**
-     * This method clears and initializes the unicast address as a valid, SLAAC-origin address with a given preferred
-     * flag and a given prefix length.
-     *
-     * @param[in] aPrefixLength    The prefix length (in bits).
-     * @param[in] aPreferred       The preferred flag.
-     *
-     */
-    void InitAsSlaacOrigin(uint8_t aPrefixLength, bool aPreferred);
-
-    /**
-     * This method returns the unicast address.
-     *
-     * @returns The unicast address.
-     *
-     */
-    const Address &GetAddress(void) const { return static_cast<const Address &>(mAddress); }
-
-    /**
-     * This method returns the unicast address.
-     *
-     * @returns The unicast address.
-     *
-     */
-    Address &GetAddress(void) { return static_cast<Address &>(mAddress); }
-
-    /**
-     * This method returns the address's prefix length (in bits).
-     *
-     * @returns The prefix length (in bits).
-     *
-     */
-    uint8_t GetPrefixLength(void) const { return mPrefixLength; }
-
-    /**
-     * This method indicates whether the address has a given prefix (i.e. same prefix length and matches the prefix).
-     *
-     * @param[in] aPrefix   A prefix to check against.
-     *
-     * @retval TRUE  The address has and fully matches the @p aPrefix.
-     * @retval FALSE The address does not contain or match the @p aPrefix.
-     *
-     */
-    bool HasPrefix(const Prefix &aPrefix) const
-    {
-        return (mPrefixLength == aPrefix.GetLength()) && GetAddress().MatchesPrefix(aPrefix);
-    }
-
-    /**
-     * This method returns the IPv6 scope value.
-     *
-     * @returns The IPv6 scope value.
-     *
-     */
-    uint8_t GetScope(void) const
-    {
-        return mScopeOverrideValid ? static_cast<uint8_t>(mScopeOverride) : GetAddress().GetScope();
-    }
-
-    /**
-     * This method sets the IPv6 scope override value.
-     *
-     * @param[in]  aScope  The IPv6 scope value.
-     *
-     */
-    void SetScopeOverride(uint8_t aScope)
-    {
-        mScopeOverride      = aScope;
-        mScopeOverrideValid = true;
-    }
-
-private:
-    bool Matches(const Address &aAddress) const { return GetAddress() == aAddress; }
-};
-
-/**
- * This class implements an IPv6 network interface multicast address.
- *
- */
-class NetifMulticastAddress : public otNetifMulticastAddress,
-                              public LinkedListEntry<NetifMulticastAddress>,
-                              public Clearable<NetifMulticastAddress>
-{
-    friend class Netif;
-    friend class LinkedList<NetifMulticastAddress>;
-
-public:
-    /**
-     * This method returns the multicast address.
-     *
-     * @returns The multicast address.
-     *
-     */
-    const Address &GetAddress(void) const { return static_cast<const Address &>(mAddress); }
-
-    /**
-     * This method returns the multicast address.
-     *
-     * @returns The multicast address.
-     *
-     */
-    Address &GetAddress(void) { return static_cast<Address &>(mAddress); }
-
-    /**
-     * This method returns the next multicast address subscribed to the interface.
-     *
-     * @returns A pointer to the next multicast address.
-     *
-     */
-    const NetifMulticastAddress *GetNext(void) const { return static_cast<const NetifMulticastAddress *>(mNext); }
-
-    /**
-     * This method returns the next multicast address subscribed to the interface.
-     *
-     * @returns A pointer to the next multicast address.
-     *
-     */
-    NetifMulticastAddress *GetNext(void)
-    {
-        return static_cast<NetifMulticastAddress *>(const_cast<otNetifMulticastAddress *>(mNext));
-    }
-
-private:
-    bool Matches(const Address &aAddress) const { return GetAddress() == aAddress; }
-};
-
-class ExternalNetifMulticastAddress : public NetifMulticastAddress
-{
-    friend class Netif;
-    friend class LinkedList<ExternalNetifMulticastAddress>;
-
-public:
-#if OPENTHREAD_CONFIG_MLR_ENABLE
-    /**
-     * This method returns the current Multicast Listener Registration (MLR) state.
-     *
-     * @returns The current Multicast Listener Registration state.
-     *
-     */
-    MlrState GetMlrState(void) const { return mMlrState; }
-
-    /**
-     * This method sets the Multicast Listener Registration (MLR) state.
-     *
-     * @param[in] aState  The new Multicast Listener Registration state.
-     *
-     */
-    void SetMlrState(MlrState aState) { mMlrState = aState; }
-#endif
-
-private:
-    ExternalNetifMulticastAddress *GetNext(void)
-    {
-        return static_cast<ExternalNetifMulticastAddress *>(const_cast<otNetifMulticastAddress *>(mNext));
-    }
-
-#if OPENTHREAD_CONFIG_MLR_ENABLE
-    MlrState mMlrState;
-#endif
-};
-
-/**
  * This class implements an IPv6 network interface.
  *
  */
@@ -268,63 +72,256 @@ class Netif : public InstanceLocator, public LinkedListEntry<Netif>, private Non
 {
     friend class Ip6;
     friend class Address;
-    class ExternalMulticastAddressIteratorBuilder;
 
 public:
     /**
-     * This class represents an iterator for iterating external multicast addresses in a Netif instance.
+     * This class implements an IPv6 network interface unicast address.
      *
      */
-    class ExternalMulticastAddressIterator
-        : public ItemPtrIterator<ExternalNetifMulticastAddress, ExternalMulticastAddressIterator>
+    class UnicastAddress : public otNetifAddress,
+                           public LinkedListEntry<UnicastAddress>,
+                           public Clearable<UnicastAddress>
     {
-        friend class ItemPtrIterator<ExternalNetifMulticastAddress, ExternalMulticastAddressIterator>;
-        friend class ExternalMulticastAddressIteratorBuilder;
+        friend class LinkedList<UnicastAddress>;
 
     public:
         /**
-         * This constructor initializes an `ExternalMulticastAddressIterator` instance to start from the first external
-         * multicast address that matches a given IPv6 address type filter.
+         * This method clears and initializes the unicast address as a preferred, valid, thread-origin address with
+         * 64-bit prefix length.
          *
-         * @param[in] aNetif   A reference to the Netif instance.
-         * @param[in] aFilter  The IPv6 address type filter.
+         * @param[in]   aPreferred  Whether to initialize as a preferred address.
          *
          */
-        explicit ExternalMulticastAddressIterator(const Netif &aNetif, Address::TypeFilter aFilter = Address::kTypeAny)
-            : ItemPtrIterator(nullptr)
-            , mNetif(aNetif)
-            , mFilter(aFilter)
+        void InitAsThreadOrigin(bool aPreferred = false);
+
+        /**
+         * This method clears and initializes the unicast address as a valid (but not preferred), thread-origin,
+         * realm-local scope (overridden) address with 64-bit prefix length.
+         *
+         */
+        void InitAsThreadOriginRealmLocalScope(void);
+
+        /**
+         * This method clears and initializes the unicast address as a valid (but not preferred), thread-origin, global
+         * scope address.
+         *
+         */
+        void InitAsThreadOriginGlobalScope(void);
+
+        /**
+         * This method clears and initializes the unicast address as a valid, SLAAC-origin address with a given
+         * preferred flag and a given prefix length.
+         *
+         * @param[in] aPrefixLength    The prefix length (in bits).
+         * @param[in] aPreferred       The preferred flag.
+         *
+         */
+        void InitAsSlaacOrigin(uint8_t aPrefixLength, bool aPreferred);
+
+        /**
+         * This method returns the unicast address.
+         *
+         * @returns The unicast address.
+         *
+         */
+        const Address &GetAddress(void) const { return static_cast<const Address &>(mAddress); }
+
+        /**
+         * This method returns the unicast address.
+         *
+         * @returns The unicast address.
+         *
+         */
+        Address &GetAddress(void) { return static_cast<Address &>(mAddress); }
+
+        /**
+         * This method returns the address's prefix length (in bits).
+         *
+         * @returns The prefix length (in bits).
+         *
+         */
+        uint8_t GetPrefixLength(void) const { return mPrefixLength; }
+
+        /**
+         * This method indicates whether the address has a given prefix (i.e. same prefix length and matches the
+         * prefix).
+         *
+         * @param[in] aPrefix   A prefix to check against.
+         *
+         * @retval TRUE  The address has and fully matches the @p aPrefix.
+         * @retval FALSE The address does not contain or match the @p aPrefix.
+         *
+         */
+        bool HasPrefix(const Prefix &aPrefix) const
         {
-            AdvanceFrom(mNetif.GetMulticastAddresses());
+            return (mPrefixLength == aPrefix.GetLength()) && GetAddress().MatchesPrefix(aPrefix);
+        }
+
+        /**
+         * This method returns the IPv6 scope value.
+         *
+         * @returns The IPv6 scope value.
+         *
+         */
+        uint8_t GetScope(void) const
+        {
+            return mScopeOverrideValid ? static_cast<uint8_t>(mScopeOverride) : GetAddress().GetScope();
+        }
+
+        /**
+         * This method sets the IPv6 scope override value.
+         *
+         * @param[in]  aScope  The IPv6 scope value.
+         *
+         */
+        void SetScopeOverride(uint8_t aScope)
+        {
+            mScopeOverride      = aScope;
+            mScopeOverrideValid = true;
         }
 
     private:
-        enum IteratorType : uint8_t
-        {
-            kEndIterator,
-        };
+        bool Matches(const Address &aAddress) const { return GetAddress() == aAddress; }
+    };
 
-        ExternalMulticastAddressIterator(const Netif &aNetif, IteratorType)
-            : mNetif(aNetif)
+    /**
+     * This class implements an IPv6 network interface multicast address.
+     *
+     */
+    class MulticastAddress : public otNetifMulticastAddress,
+                             public LinkedListEntry<MulticastAddress>,
+                             public Clearable<MulticastAddress>
+    {
+        friend class LinkedList<MulticastAddress>;
+
+    public:
+        /**
+         * This method returns the multicast address.
+         *
+         * @returns The multicast address.
+         *
+         */
+        const Address &GetAddress(void) const { return static_cast<const Address &>(mAddress); }
+
+        /**
+         * This method returns the multicast address.
+         *
+         * @returns The multicast address.
+         *
+         */
+        Address &GetAddress(void) { return static_cast<Address &>(mAddress); }
+
+        /**
+         * This method returns the next multicast address subscribed to the interface.
+         *
+         * @returns A pointer to the next multicast address.
+         *
+         */
+        const MulticastAddress *GetNext(void) const { return static_cast<const MulticastAddress *>(mNext); }
+
+        /**
+         * This method returns the next multicast address subscribed to the interface.
+         *
+         * @returns A pointer to the next multicast address.
+         *
+         */
+        MulticastAddress *GetNext(void)
         {
+            return static_cast<MulticastAddress *>(const_cast<otNetifMulticastAddress *>(mNext));
         }
 
-        void AdvanceFrom(const NetifMulticastAddress *aAddr)
+    private:
+        bool Matches(const Address &aAddress) const { return GetAddress() == aAddress; }
+    };
+
+    class ExternalMulticastAddress : public MulticastAddress
+    {
+        friend class Netif;
+        friend class LinkedList<ExternalMulticastAddress>;
+
+    public:
+        /**
+         * This class represents an iterator for iterating external multicast addresses in a `Netif` instance.
+         *
+         */
+        class Iterator : public ItemPtrIterator<ExternalMulticastAddress, Iterator>
         {
-            while (aAddr != nullptr &&
-                   !(mNetif.IsMulticastAddressExternal(*aAddr) && aAddr->GetAddress().MatchesFilter(mFilter)))
+            friend class ItemPtrIterator<ExternalMulticastAddress, Iterator>;
+            friend class Netif;
+
+        public:
+            /**
+             * This constructor initializes an `Iterator` instance to start from the first external multicast address
+             * that matches a given IPv6 address type filter.
+             *
+             * @param[in] aNetif   A reference to the `Netif` instance.
+             * @param[in] aFilter  The IPv6 address type filter.
+             *
+             */
+            explicit Iterator(const Netif &aNetif, Address::TypeFilter aFilter = Address::kTypeAny);
+
+        private:
+            class Builder
             {
-                aAddr = aAddr->GetNext();
+            public:
+                Builder(const Netif &aNetif, Address::TypeFilter aFilter)
+                    : mNetif(aNetif)
+                    , mFilter(aFilter)
+                {
+                }
+
+                Iterator begin(void) { return Iterator(mNetif, mFilter); }
+                Iterator end(void) { return Iterator(mNetif, Iterator::kEndIterator); }
+
+            private:
+                const Netif &       mNetif;
+                Address::TypeFilter mFilter;
+            };
+
+            enum IteratorType : uint8_t
+            {
+                kEndIterator,
+            };
+
+            Iterator(const Netif &aNetif, IteratorType)
+                : mNetif(aNetif)
+            {
             }
 
-            mItem =
-                const_cast<ExternalNetifMulticastAddress *>(static_cast<const ExternalNetifMulticastAddress *>(aAddr));
+            void AdvanceFrom(const MulticastAddress *aAddr);
+            void Advance(void) { AdvanceFrom(mItem->GetNext()); }
+
+            const Netif &       mNetif;
+            Address::TypeFilter mFilter;
+        };
+
+#if OPENTHREAD_CONFIG_MLR_ENABLE
+        /**
+         * This method returns the current Multicast Listener Registration (MLR) state.
+         *
+         * @returns The current Multicast Listener Registration state.
+         *
+         */
+        MlrState GetMlrState(void) const { return mMlrState; }
+
+        /**
+         * This method sets the Multicast Listener Registration (MLR) state.
+         *
+         * @param[in] aState  The new Multicast Listener Registration state.
+         *
+         */
+        void SetMlrState(MlrState aState) { mMlrState = aState; }
+#endif
+
+    private:
+        ExternalMulticastAddress *GetNext(void)
+        {
+            return static_cast<ExternalMulticastAddress *>(const_cast<otNetifMulticastAddress *>(mNext));
         }
 
-        void Advance(void) { AdvanceFrom(mItem->GetNext()); }
-
-        const Netif &       mNetif;
-        Address::TypeFilter mFilter;
+#if OPENTHREAD_CONFIG_MLR_ENABLE
+        MlrState mMlrState;
+#endif
     };
 
     /**
@@ -350,7 +347,7 @@ public:
      * @returns A pointer to the head of the linked list of unicast addresses.
      *
      */
-    const NetifUnicastAddress *GetUnicastAddresses(void) const { return mUnicastAddresses.GetHead(); }
+    const UnicastAddress *GetUnicastAddresses(void) const { return mUnicastAddresses.GetHead(); }
 
     /**
      * This method adds a unicast address to the network interface.
@@ -361,7 +358,7 @@ public:
      * @param[in]  aAddress  A reference to the unicast address.
      *
      */
-    void AddUnicastAddress(NetifUnicastAddress &aAddress);
+    void AddUnicastAddress(UnicastAddress &aAddress);
 
     /**
      * This method removes a unicast address from the network interface.
@@ -372,7 +369,7 @@ public:
      * @param[in]  aAddress  A reference to the unicast address.
      *
      */
-    void RemoveUnicastAddress(const NetifUnicastAddress &aAddress);
+    void RemoveUnicastAddress(const UnicastAddress &aAddress);
 
     /**
      * This method indicates whether or not an address is assigned to the interface.
@@ -394,7 +391,7 @@ public:
      * @retval FALSE  If @p aAddress is not assigned to the network interface.
      *
      */
-    bool HasUnicastAddress(const NetifUnicastAddress &aAddress) const { return mUnicastAddresses.Contains(aAddress); }
+    bool HasUnicastAddress(const UnicastAddress &aAddress) const { return mUnicastAddresses.Contains(aAddress); }
 
     /**
      * This method indicates whether a unicast address is an external or internal address.
@@ -405,7 +402,7 @@ public:
      * @retval FALSE  The address is not an external address (it is an OpenThread internal address).
      *
      */
-    bool IsUnicastAddressExternal(const NetifUnicastAddress &aAddress) const;
+    bool IsUnicastAddressExternal(const UnicastAddress &aAddress) const;
 
     /**
      * This method adds an external (to OpenThread) unicast address to the network interface.
@@ -421,7 +418,7 @@ public:
      * @retval kErrorNoBufs       The maximum number of allowed external addresses are already added.
      *
      */
-    Error AddExternalUnicastAddress(const NetifUnicastAddress &aAddress);
+    Error AddExternalUnicastAddress(const UnicastAddress &aAddress);
 
     /**
      * This method removes a external (to OpenThread) unicast address from the network interface.
@@ -473,7 +470,7 @@ public:
      * @returns A pointer to the head of the linked list of multicast addresses.
      *
      */
-    const NetifMulticastAddress *GetMulticastAddresses(void) const { return mMulticastAddresses.GetHead(); }
+    const MulticastAddress *GetMulticastAddresses(void) const { return mMulticastAddresses.GetHead(); }
 
     /**
      * This method indicates whether a multicast address is an external or internal address.
@@ -484,7 +481,7 @@ public:
      * @retval FALSE  The address is not an external address (it is an OpenThread internal address).
      *
      */
-    bool IsMulticastAddressExternal(const NetifMulticastAddress &aAddress) const;
+    bool IsMulticastAddressExternal(const MulticastAddress &aAddress) const;
 
     /**
      * This method subscribes the network interface to a multicast address.
@@ -495,7 +492,7 @@ public:
      * @param[in]  aAddress  A reference to the multicast address.
      *
      */
-    void SubscribeMulticast(NetifMulticastAddress &aAddress);
+    void SubscribeMulticast(MulticastAddress &aAddress);
 
     /**
      * This method unsubscribes the network interface to a multicast address.
@@ -506,7 +503,7 @@ public:
      * @param[in]  aAddress  A reference to the multicast address.
      *
      */
-    void UnsubscribeMulticast(const NetifMulticastAddress &aAddress);
+    void UnsubscribeMulticast(const MulticastAddress &aAddress);
 
     /**
      * This method subscribes the network interface to the external (to OpenThread) multicast address.
@@ -567,23 +564,24 @@ public:
      *
      * This method should be used like follows: to iterate over all external multicast addresses
      *
-     *     for (Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+     *     for (Ip6::Netif::ExternalMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
      *     { ... }
      *
      * or to iterate over a subset of external multicast addresses determined by a given address type filter
      *
-     *     for (Ip6::ExternalNetifMulticastAddress &addr :
-     * Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal)) { ... }
+     *     for (Ip6::Netif::ExternalMulticastAddress &addr :
+     *          Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
+     *     { ... }
      *
      * @param[in] aFilter  The IPv6 address type filter.
      *
-     * @returns An `ExternalMulticastAddressIteratorBuilder` instance.
+     * @returns An `ExternalMulticastAddress::Iterator::Builder` instance.
      *
      */
-    ExternalMulticastAddressIteratorBuilder IterateExternalMulticastAddresses(
+    ExternalMulticastAddress::Iterator::Builder IterateExternalMulticastAddresses(
         Address::TypeFilter aFilter = Address::kTypeAny)
     {
-        return ExternalMulticastAddressIteratorBuilder(*this, aFilter);
+        return ExternalMulticastAddress::Iterator::Builder(*this, aFilter);
     }
 
     /**
@@ -593,7 +591,7 @@ public:
      * @retval FALSE The network interface is not subscribed to any external multicast address.
      *
      */
-    bool HasAnyExternalMulticastAddress(void) const { return !ExternalMulticastAddressIterator(*this).IsDone(); }
+    bool HasAnyExternalMulticastAddress(void) const { return !ExternalMulticastAddress::Iterator(*this).IsDone(); }
 
 protected:
     /**
@@ -613,35 +611,15 @@ protected:
     void UnsubscribeAllNodesMulticast(void);
 
 private:
-    class ExternalMulticastAddressIteratorBuilder
-    {
-    public:
-        ExternalMulticastAddressIteratorBuilder(const Netif &aNetif, Address::TypeFilter aFilter)
-            : mNetif(aNetif)
-            , mFilter(aFilter)
-        {
-        }
-
-        ExternalMulticastAddressIterator begin(void) { return ExternalMulticastAddressIterator(mNetif, mFilter); }
-        ExternalMulticastAddressIterator end(void)
-        {
-            return ExternalMulticastAddressIterator(mNetif, ExternalMulticastAddressIterator::kEndIterator);
-        }
-
-    private:
-        const Netif &       mNetif;
-        Address::TypeFilter mFilter;
-    };
-
-    LinkedList<NetifUnicastAddress>   mUnicastAddresses;
-    LinkedList<NetifMulticastAddress> mMulticastAddresses;
-    bool                              mMulticastPromiscuous;
+    LinkedList<UnicastAddress>   mUnicastAddresses;
+    LinkedList<MulticastAddress> mMulticastAddresses;
+    bool                         mMulticastPromiscuous;
 
     otIp6AddressCallback mAddressCallback;
     void *               mAddressCallbackContext;
 
-    Pool<NetifUnicastAddress, OPENTHREAD_CONFIG_IP6_MAX_EXT_UCAST_ADDRS>           mExtUnicastAddressPool;
-    Pool<ExternalNetifMulticastAddress, OPENTHREAD_CONFIG_IP6_MAX_EXT_MCAST_ADDRS> mExtMulticastAddressPool;
+    Pool<UnicastAddress, OPENTHREAD_CONFIG_IP6_MAX_EXT_UCAST_ADDRS>           mExtUnicastAddressPool;
+    Pool<ExternalMulticastAddress, OPENTHREAD_CONFIG_IP6_MAX_EXT_MCAST_ADDRS> mExtMulticastAddressPool;
 
     static const otNetifMulticastAddress kRealmLocalAllMplForwardersMulticastAddress;
     static const otNetifMulticastAddress kLinkLocalAllNodesMulticastAddress;

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -726,8 +726,8 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
     SuccessOrExit(error = Tlv::Find<ThreadTargetTlv>(aMessage, target));
     SuccessOrExit(error = Tlv::Find<ThreadMeshLocalEidTlv>(aMessage, meshLocalIid));
 
-    for (const Ip6::NetifUnicastAddress *address = Get<ThreadNetif>().GetUnicastAddresses(); address;
-         address                                 = address->GetNext())
+    for (const Ip6::Netif::UnicastAddress *address = Get<ThreadNetif>().GetUnicastAddresses(); address;
+         address                                   = address->GetNext())
     {
         if (address->GetAddress() == target && Get<Mle::MleRouter>().GetMeshLocal64().GetIid() != meshLocalIid)
         {

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -233,8 +233,8 @@ private:
     DuaState  mDuaState;
     uint8_t   mDadCounter;
     TimeMilli mLastRegistrationTime; // The time (in milliseconds) when sent last DUA.req or received DUA.rsp.
-    Ip6::InterfaceIdentifier mFixedDuaInterfaceIdentifier;
-    Ip6::NetifUnicastAddress mDomainUnicastAddress;
+    Ip6::InterfaceIdentifier   mFixedDuaInterfaceIdentifier;
+    Ip6::Netif::UnicastAddress mDomainUnicastAddress;
 #endif
 
     union

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -130,7 +130,7 @@ Mle::Mle(Instance &aInstance)
     mLeaderAloc.InitAsThreadOriginRealmLocalScope();
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    for (Ip6::NetifUnicastAddress &serviceAloc : mServiceAlocs)
+    for (Ip6::Netif::UnicastAddress &serviceAloc : mServiceAlocs)
     {
         serviceAloc.InitAsThreadOriginRealmLocalScope();
         serviceAloc.GetAddress().GetIid().SetLocator(Mac::kShortAddrInvalid);
@@ -882,7 +882,7 @@ void Mle::ApplyMeshLocalPrefix(void)
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
-    for (Ip6::NetifUnicastAddress &serviceAloc : mServiceAlocs)
+    for (Ip6::Netif::UnicastAddress &serviceAloc : mServiceAlocs)
     {
         if (serviceAloc.GetAddress().GetIid().GetLocator() != Mac::kShortAddrInvalid)
         {
@@ -1247,7 +1247,8 @@ bool Mle::HasUnregisteredAddress(void)
     // Checks whether there are any addresses in addition to the mesh-local
     // address that need to be registered.
 
-    for (const Ip6::NetifUnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr; addr = addr->GetNext())
+    for (const Ip6::Netif::UnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr;
+         addr                                   = addr->GetNext())
     {
         if (!addr->GetAddress().IsLinkLocal() && !IsRoutingLocator(addr->GetAddress()) &&
             !IsAnycastLocator(addr->GetAddress()) && addr->GetAddress() != GetMeshLocal64())
@@ -1313,7 +1314,8 @@ Error Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMode 
     }
 #endif // OPENTHREAD_CONFIG_DUA_ENABLE
 
-    for (const Ip6::NetifUnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr; addr = addr->GetNext())
+    for (const Ip6::Netif::UnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr;
+         addr                                   = addr->GetNext())
     {
         if (addr->GetAddress().IsLinkLocal() || IsRoutingLocator(addr->GetAddress()) ||
             IsAnycastLocator(addr->GetAddress()) || addr->GetAddress() == GetMeshLocal64())
@@ -1360,7 +1362,7 @@ Error Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMode 
 #endif
     )
     {
-        for (const Ip6::NetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+        for (const Ip6::Netif::MulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
         {
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
             // For Thread 1.2 MED, skip multicast address with scope not

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1594,7 +1594,7 @@ protected:
 
 #endif
 
-    Ip6::NetifUnicastAddress mLeaderAloc; ///< Leader anycast locator
+    Ip6::Netif::UnicastAddress mLeaderAloc; ///< Leader anycast locator
 
     LeaderData    mLeaderData;               ///< Last received Leader Data TLV.
     bool          mRetrieveNewNetworkData;   ///< Indicating new Network Data is needed if set.
@@ -1889,16 +1889,16 @@ private:
     uint64_t mAlternateTimestamp;
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    Ip6::NetifUnicastAddress mServiceAlocs[kMaxServiceAlocs];
+    Ip6::Netif::UnicastAddress mServiceAlocs[kMaxServiceAlocs];
 #endif
 
     otMleCounters mCounters;
 
-    Ip6::NetifUnicastAddress   mLinkLocal64;
-    Ip6::NetifUnicastAddress   mMeshLocal64;
-    Ip6::NetifUnicastAddress   mMeshLocal16;
-    Ip6::NetifMulticastAddress mLinkLocalAllThreadNodes;
-    Ip6::NetifMulticastAddress mRealmLocalAllThreadNodes;
+    Ip6::Netif::UnicastAddress   mLinkLocal64;
+    Ip6::Netif::UnicastAddress   mMeshLocal64;
+    Ip6::Netif::UnicastAddress   mMeshLocal16;
+    Ip6::Netif::MulticastAddress mLinkLocalAllThreadNodes;
+    Ip6::Netif::MulticastAddress mRealmLocalAllThreadNodes;
 
     otThreadParentResponseCallback mParentResponseCb;
     void *                         mParentResponseCbContext;

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -93,7 +93,7 @@ void MlrManager::UpdateLocalSubscriptions(void)
 {
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
     // Check multicast addresses are newly listened against Children
-    for (Ip6::ExternalNetifMulticastAddress &addr :
+    for (Ip6::Netif::ExternalMulticastAddress &addr :
          Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
         if (addr.GetMlrState() == kMlrStateToRegister && IsAddressMlrRegisteredByAnyChild(addr.GetAddress()))
@@ -113,7 +113,7 @@ bool MlrManager::IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress) con
 
     OT_ASSERT(aAddress.IsMulticastLargerThanRealmLocal());
 
-    for (const Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+    for (const Ip6::Netif::ExternalMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
     {
         if (addr.GetAddress() == aAddress && addr.GetMlrState() == kMlrStateRegistered)
         {
@@ -237,7 +237,7 @@ void MlrManager::SendMulticastListenerRegistration(void)
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
     // Append Netif multicast addresses
-    for (Ip6::ExternalNetifMulticastAddress &addr :
+    for (Ip6::Netif::ExternalMulticastAddress &addr :
          Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
         if (addressesNum >= kIp6AddressesNumMax)
@@ -541,7 +541,7 @@ exit:
 void MlrManager::SetMulticastAddressMlrState(MlrState aFromState, MlrState aToState)
 {
 #if OPENTHREAD_CONFIG_MLR_ENABLE
-    for (Ip6::ExternalNetifMulticastAddress &addr :
+    for (Ip6::Netif::ExternalMulticastAddress &addr :
          Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
         if (addr.GetMlrState() == aFromState)
@@ -573,7 +573,7 @@ void MlrManager::FinishMulticastListenerRegistration(bool                aSucces
     mMlrPending = false;
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
-    for (Ip6::ExternalNetifMulticastAddress &addr :
+    for (Ip6::Netif::ExternalMulticastAddress &addr :
          Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
         if (addr.GetMlrState() == kMlrStateRegistering)
@@ -683,7 +683,7 @@ void MlrManager::LogMulticastAddresses(void)
     otLogDebgMlr("-------- Multicast Addresses --------");
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
-    for (const Ip6::ExternalNetifMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
+    for (const Ip6::Netif::ExternalMulticastAddress &addr : Get<ThreadNetif>().IterateExternalMulticastAddresses())
     {
         otLogDebgMlr("%-32s%c", addr.GetAddress().ToString().AsCString(), "-rR"[addr.GetMlrState()]);
     }
@@ -784,7 +784,7 @@ void MlrManager::CheckInvariants(void) const
     OT_ASSERT(!mMlrPending || mSendDelay == 0);
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
-    for (Ip6::ExternalNetifMulticastAddress &addr :
+    for (Ip6::Netif::ExternalMulticastAddress &addr :
          Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
         registeringNum += (addr.GetMlrState() == kMlrStateRegistering);

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -190,7 +190,8 @@ Error NetworkDiagnostic::AppendIp6AddressList(Message &aMessage)
 
     tlv.Init();
 
-    for (const Ip6::NetifUnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr; addr = addr->GetNext())
+    for (const Ip6::Netif::UnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr;
+         addr                                   = addr->GetNext())
     {
         count++;
     }
@@ -198,7 +199,8 @@ Error NetworkDiagnostic::AppendIp6AddressList(Message &aMessage)
     tlv.SetLength(count * sizeof(Ip6::Address));
     SuccessOrExit(error = aMessage.Append(tlv));
 
-    for (const Ip6::NetifUnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr; addr = addr->GetNext())
+    for (const Ip6::Netif::UnicastAddress *addr = Get<ThreadNetif>().GetUnicastAddresses(); addr;
+         addr                                   = addr->GetNext())
     {
         SuccessOrExit(error = aMessage.Append(addr->GetAddress()));
     }

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -133,7 +133,7 @@ exit:
 }
 
 bool Slaac::DoesConfigMatchNetifAddr(const NetworkData::OnMeshPrefixConfig &aConfig,
-                                     const Ip6::NetifUnicastAddress &       aAddr)
+                                     const Ip6::Netif::UnicastAddress &     aAddr)
 {
     return (((aConfig.mOnMesh && (aAddr.mPrefixLength == aConfig.mPrefix.mLength)) ||
              (!aConfig.mOnMesh && (aAddr.mPrefixLength == 128))) &&
@@ -151,7 +151,7 @@ void Slaac::Update(UpdateMode aMode)
         // If enabled, remove any SLAAC addresses with no matching on-mesh prefix,
         // otherwise (when disabled) remove all previously added SLAAC addresses.
 
-        for (Ip6::NetifUnicastAddress &slaacAddr : mAddresses)
+        for (Ip6::Netif::UnicastAddress &slaacAddr : mAddresses)
         {
             if (!slaacAddr.mValid)
             {
@@ -208,8 +208,8 @@ void Slaac::Update(UpdateMode aMode)
 
             found = false;
 
-            for (const Ip6::NetifUnicastAddress *netifAddr = Get<ThreadNetif>().GetUnicastAddresses();
-                 netifAddr != nullptr; netifAddr           = netifAddr->GetNext())
+            for (const Ip6::Netif::UnicastAddress *netifAddr = Get<ThreadNetif>().GetUnicastAddresses();
+                 netifAddr != nullptr; netifAddr             = netifAddr->GetNext())
             {
                 if (DoesConfigMatchNetifAddr(config, *netifAddr))
                 {
@@ -222,7 +222,7 @@ void Slaac::Update(UpdateMode aMode)
             {
                 bool added = false;
 
-                for (Ip6::NetifUnicastAddress &slaacAddr : mAddresses)
+                for (Ip6::Netif::UnicastAddress &slaacAddr : mAddresses)
                 {
                     if (slaacAddr.mValid)
                     {
@@ -252,10 +252,10 @@ void Slaac::Update(UpdateMode aMode)
     }
 }
 
-Error Slaac::GenerateIid(Ip6::NetifUnicastAddress &aAddress,
-                         uint8_t *                 aNetworkId,
-                         uint8_t                   aNetworkIdLength,
-                         uint8_t *                 aDadCounter) const
+Error Slaac::GenerateIid(Ip6::Netif::UnicastAddress &aAddress,
+                         uint8_t *                   aNetworkId,
+                         uint8_t                     aNetworkIdLength,
+                         uint8_t *                   aDadCounter) const
 {
     /*
      *  This method generates a semantically opaque IID per RFC 7217.

--- a/src/core/utils/slaac_address.hpp
+++ b/src/core/utils/slaac_address.hpp
@@ -138,10 +138,10 @@ public:
      * @retval kErrorFailed  If no valid IID was generated.
      *
      */
-    Error GenerateIid(Ip6::NetifUnicastAddress &aAddress,
-                      uint8_t *                 aNetworkId       = nullptr,
-                      uint8_t                   aNetworkIdLength = 0,
-                      uint8_t *                 aDadCounter      = nullptr) const;
+    Error GenerateIid(Ip6::Netif::UnicastAddress &aAddress,
+                      uint8_t *                   aNetworkId       = nullptr,
+                      uint8_t                     aNetworkIdLength = 0,
+                      uint8_t *                   aDadCounter      = nullptr) const;
 
 private:
     static constexpr uint16_t kMaxIidCreationAttempts = 256; // Maximum number of attempts when generating IID.
@@ -163,11 +163,11 @@ private:
     void        GetIidSecretKey(IidSecretKey &aKey) const;
     void        HandleNotifierEvents(Events aEvents);
     static bool DoesConfigMatchNetifAddr(const NetworkData::OnMeshPrefixConfig &aConfig,
-                                         const Ip6::NetifUnicastAddress &       aAddr);
+                                         const Ip6::Netif::UnicastAddress &     aAddr);
 
-    bool                     mEnabled;
-    otIp6SlaacPrefixFilter   mFilter;
-    Ip6::NetifUnicastAddress mAddresses[OPENTHREAD_CONFIG_IP6_SLAAC_NUM_ADDRESSES];
+    bool                       mEnabled;
+    otIp6SlaacPrefixFilter     mFilter;
+    Ip6::Netif::UnicastAddress mAddresses[OPENTHREAD_CONFIG_IP6_SLAAC_NUM_ADDRESSES];
 };
 
 /**

--- a/tests/unit/test_netif.cpp
+++ b/tests/unit/test_netif.cpp
@@ -65,7 +65,7 @@ void VerifyMulticastAddressList(const Ip6::Netif &aNetif, Ip6::Address aAddresse
         VerifyOrQuit(aNetif.IsMulticastSubscribed(aAddresses[i]));
     }
 
-    for (const Ip6::NetifMulticastAddress *addr = aNetif.GetMulticastAddresses(); addr; addr = addr->GetNext())
+    for (const Ip6::Netif::MulticastAddress *addr = aNetif.GetMulticastAddresses(); addr; addr = addr->GetNext())
     {
         bool didFind = false;
 
@@ -93,8 +93,8 @@ void TestNetifMulticastAddresses(void)
     TestNetif    netif(*instance);
     Ip6::Address addresses[kMaxAddresses];
 
-    Ip6::Address               address;
-    Ip6::NetifMulticastAddress netifAddress;
+    Ip6::Address                 address;
+    Ip6::Netif::MulticastAddress netifAddress;
 
     const char *kLinkLocalAllNodes    = "ff02::01";
     const char *kRealmLocalAllNodes   = "ff03::01";


### PR DESCRIPTION
This commit renames and moves the related types in `Netif` module like
`UnicastAddress`, `MulticastAddress`, etc. under `Netif` class (as a
nested type). It also moves iterator types under the related type
(for example, `ExternalMulticastAddressIteratorBuilder` becomes
`Iterator::Builder` under `ExternalMulticastAddress` class. These
changes help simplify the code (allow us to use shorter names in the
`Netif` implementation).