### PR TITLE
[csl] allow more tx failures when sending CSL data poll

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -917,12 +917,10 @@ Neighbor *MeshForwarder::UpdateNeighborOnSentFrame(Mac::TxFrame &aFrame, Error a
                                    /* aFailLimit */ Mle::kFailedCslDataPollTransmissions);
     }
     else
+#endif
     {
         UpdateNeighborLinkFailures(*neighbor, aError, /* aAllowNeighborRemove */ true);
     }
-#else
-    UpdateNeighborLinkFailures(*neighbor, aError, /* aAllowNeighborRemove */ true);
-#endif
 
 exit:
     return neighbor;

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -462,7 +462,10 @@ private:
     void          HandleReceivedFrame(Mac::RxFrame &aFrame);
     Mac::TxFrame *HandleFrameRequest(Mac::TxFrames &aTxFrames);
     Neighbor *    UpdateNeighborOnSentFrame(Mac::TxFrame &aFrame, Error aError, const Mac::Address &aMacDest);
-    void          UpdateNeighborLinkFailures(Neighbor &aNeighbor, Error aError, bool aAllowNeighborRemove);
+    void          UpdateNeighborLinkFailures(Neighbor &aNeighbor,
+                                             Error     aError,
+                                             bool      aAllowNeighborRemove,
+                                             uint8_t   aFailLimit = Mle::kFailedRouterTransmissions);
     void          HandleSentFrame(Mac::TxFrame &aFrame, Error aError);
     void          UpdateSendMessage(Error aFrameTxError, Mac::Address &aMacDest, Neighbor *aNeighbor);
     void          RemoveMessageIfNoPendingTx(Message &aMessage);

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -132,6 +132,9 @@ constexpr uint32_t kAdvertiseIntervalMax = 32; ///< Max Advertise interval (in s
 #endif
 
 constexpr uint8_t kFailedRouterTransmissions = 4;
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+constexpr uint8_t kFailedCslDataPollTransmissions = 15;
+#endif
 
 constexpr uint8_t  kRouterIdReuseDelay     = 100; ///< (in sec)
 constexpr uint32_t kRouterIdSequencePeriod = 10;  ///< (in sec)


### PR DESCRIPTION
Currently, we disable retries on radio/submac of data polls with CSL IE (I believe to avoid sending outdated CSL IE).
To compensate for this, we use kMaxCslPollRetxAttempts (default 15) instead of kMaxPollRetxAttempts (default 4), which gives us more possible retx on mac.
 
Assuming we get NoAck error, depending on the presence of CSL IE, there will be: 
a) 4 attempts (on mac) with up to 15 retries on radio/submac (if no CSL IE)
b) 4 attempts on mac (if CSL IE present) because child is considered detached from parent after 4 data poll transmissions that returned NoAck error. 
So in the end, the increased number of RetxAttempts does not have a full effect - we start to reattach after 4 retx while having 15 retx allowed.

This PR adds kFailedCslDataPollTransmissions constant that will be used instead of kFailedRouterTransmissions in case of data poll with CSL IE on Child-Parent link.