### PR TITLE
[posix] add a virtual destructor for ot::Posix::Mainloop::Source

### DIFF
--- a/src/posix/platform/mainloop.hpp
+++ b/src/posix/platform/mainloop.hpp
@@ -64,7 +64,7 @@ public:
      *
      */
     virtual void Process(const otSysMainloopContext &aContext) = 0;
-    
+
     virtual ~Source(void) = default;
 
 private:

--- a/src/posix/platform/mainloop.hpp
+++ b/src/posix/platform/mainloop.hpp
@@ -64,6 +64,8 @@ public:
      *
      */
     virtual void Process(const otSysMainloopContext &aContext) = 0;
+    
+    virtual ~Source(void) = default;
 
 private:
     Source *mNext = nullptr;


### PR DESCRIPTION
I'm making this change because the absence of virtual destructor may cause build error in some build systems.