### PR TITLE
[posix] add a virtual destructor for ot::Posix::Mainloop::Source

### DIFF
--- a/src/posix/platform/mainloop.hpp
+++ b/src/posix/platform/mainloop.hpp
@@ -65,6 +65,8 @@ public:
      */
     virtual void Process(const otSysMainloopContext &aContext) = 0;
 
+    virtual ~Source() = default;
+
 private:
     Source *mNext = nullptr;
 };


### PR DESCRIPTION
I'm doing so because the absence of virtual destructor may cause build error in some systems.