### PR TITLE
[ncp] fix auto in enhanced loop

### DIFF
--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -4731,7 +4731,7 @@ void NcpBase::ProcessThreadChangedFlags(void)
 
     // Convert OT_CHANGED flags to corresponding NCP property update.
 
-    for (auto flag : kFlags)
+    for (auto &flag : kFlags)
     {
         uint32_t threadFlag = flag.mThreadFlag;
 


### PR DESCRIPTION
With current usage of `auto`, `flag` is a copy of the entries in `kFlags`, which causes an extra copy.