### PR TITLE
[mac] append header termination IE2 when data payload is present

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1569,8 +1569,10 @@ void MeshForwarder::AppendHeaderIe(const Message *aMessage, Mac::TxFrame &aFrame
 {
     uint8_t index     = 0;
     bool    iePresent = false;
-    bool    payloadPresent =
-        (aFrame.GetType() == Mac::Frame::kFcfFrameMacCmd) || (aMessage != nullptr && aMessage->GetLength() != 0);
+    // MIC is a part of Data Payload, so if it's present, Data Payload is not empty even if the message is
+    // MIC is always present when the frame is secured
+    bool payloadPresent = (aFrame.GetType() == Mac::Frame::kFcfFrameMacCmd) ||
+                          (aMessage != nullptr && aMessage->GetLength() != 0) || aFrame.GetSecurityEnabled();
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     if (aMessage != nullptr && aMessage->IsTimeSync())


### PR DESCRIPTION
MIC is a part of data payload, so if it's present, data payload is not empty even if the data message is empty
(ieee802154-2020 7.2.1 - General MAC frame format).
If so, according to Termination IE inclusion rules (ieee802154-2020 7.4.2.1 Table 7-6) Header Termination IE2 need to be applied.