### PR TITLE
[history-tracker] add support for neighbor table history

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (156)
+#define OPENTHREAD_API_VERSION (157)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README_HISTORY.md
+++ b/src/cli/README_HISTORY.md
@@ -11,6 +11,7 @@ The number of entries recorded for each history list is configurable through a s
 Usage : `history [command] ...`
 
 - [help](#help)
+- [neighbor](#neighbor)
 - [netinfo](#netinfo)
 - [rx](#rx)
 - [rxtx](#rxtx)
@@ -45,6 +46,7 @@ Print SRP client help menu.
 ```bash
 > history help
 help
+neighbor
 netinfo
 rx
 rxtx
@@ -53,11 +55,59 @@ Done
 >
 ```
 
+### neighbor
+
+Usage `history neighbor [list] [<num-entries>]`
+
+Print the neighbor table history. Each entry provides:
+
+- Type: Child or Router
+- Event: Added, Removed, Changed (e.g., mode change).
+- Extended Address
+- RLOC16
+- MLE Link Mode
+- Average RSS (in dBm) of received frames from neighbor at the time the entry was recorded
+
+Print the neighbor history as a table.
+
+```bash
+> history neighbor
+| Age                  | Type   | Event     | Extended Address | RLOC16 | Mode | Ave RSS |
++----------------------+--------+-----------+------------------+--------+------+---------+
+|         00:00:29.233 | Child  | Added     | ae5105292f0b9169 | 0x8404 | -    |     -20 |
+|         00:01:38.368 | Child  | Removed   | ae5105292f0b9169 | 0x8401 | -    |     -20 |
+|         00:04:27.181 | Child  | Changed   | ae5105292f0b9169 | 0x8401 | -    |     -20 |
+|         00:04:51.236 | Router | Added     | 865c7ca38a5fa960 | 0x9400 | rdn  |     -20 |
+|         00:04:51.587 | Child  | Removed   | 865c7ca38a5fa960 | 0x8402 | rdn  |     -20 |
+|         00:05:22.764 | Child  | Changed   | ae5105292f0b9169 | 0x8401 | rn   |     -20 |
+|         00:06:40.764 | Child  | Added     | 4ec99efc874a1841 | 0x8403 | r    |     -20 |
+|         00:06:44.060 | Child  | Added     | 865c7ca38a5fa960 | 0x8402 | rdn  |     -20 |
+|         00:06:49.515 | Child  | Added     | ae5105292f0b9169 | 0x8401 | -    |     -20 |
+Done
+```
+
+Print the neighbor history as a list.
+
+```bash
+
+> history neighbor list
+00:00:34.753 -> type:Child event:Added extaddr:ae5105292f0b9169 rloc16:0x8404 mode:- rss:-20
+00:01:43.888 -> type:Child event:Removed extaddr:ae5105292f0b9169 rloc16:0x8401 mode:- rss:-20
+00:04:32.701 -> type:Child event:Changed extaddr:ae5105292f0b9169 rloc16:0x8401 mode:- rss:-20
+00:04:56.756 -> type:Router event:Added extaddr:865c7ca38a5fa960 rloc16:0x9400 mode:rdn rss:-20
+00:04:57.107 -> type:Child event:Removed extaddr:865c7ca38a5fa960 rloc16:0x8402 mode:rdn rss:-20
+00:05:28.284 -> type:Child event:Changed extaddr:ae5105292f0b9169 rloc16:0x8401 mode:rn rss:-20
+00:06:46.284 -> type:Child event:Added extaddr:4ec99efc874a1841 rloc16:0x8403 mode:r rss:-20
+00:06:49.580 -> type:Child event:Added extaddr:865c7ca38a5fa960 rloc16:0x8402 mode:rdn rss:-20
+00:06:55.035 -> type:Child event:Added extaddr:ae5105292f0b9169 rloc16:0x8401 mode:- rss:-20
+Done
+```
+
 ### netinfo
 
 Usage `history netinfo [list] [<num-entries>]`
 
-Print the Network Info history. Each Network Info provides
+Print the Network Info history. Each Network Info provides:
 
 - Device Role
 - MLE Link Mode

--- a/src/cli/cli_history.hpp
+++ b/src/cli/cli_history.hpp
@@ -97,6 +97,7 @@ private:
 
     otError ProcessHelp(Arg aArgs[]);
     otError ProcessNetInfo(Arg aArgs[]);
+    otError ProcessNeighbor(Arg aArgs[]);
     otError ProcessRx(Arg aArgs[]);
     otError ProcessRxTx(Arg aArgs[]);
     otError ProcessTx(Arg aArgs[]);
@@ -111,8 +112,8 @@ private:
     static const char *MessageTypeToString(const otHistoryTrackerMessageInfo &aInfo);
 
     static constexpr Command sCommands[] = {
-        {"help", &History::ProcessHelp}, {"netinfo", &History::ProcessNetInfo}, {"rx", &History::ProcessRx},
-        {"rxtx", &History::ProcessRxTx}, {"tx", &History::ProcessTx},
+        {"help", &History::ProcessHelp}, {"neighbor", &History::ProcessNeighbor}, {"netinfo", &History::ProcessNetInfo},
+        {"rx", &History::ProcessRx},     {"rxtx", &History::ProcessRxTx},         {"tx", &History::ProcessTx},
     };
 
     static_assert(Utils::LookupTable::IsSorted(sCommands), "Command Table is not sorted");

--- a/src/core/api/history_tracker_api.cpp
+++ b/src/core/api/history_tracker_api.cpp
@@ -78,6 +78,16 @@ const otHistoryTrackerMessageInfo *otHistoryTrackerIterateTxHistory(otInstance *
         *static_cast<Utils::HistoryTracker::Iterator *>(aIterator), *aEntryAge);
 }
 
+const otHistoryTrackerNeighborInfo *otHistoryTrackerIterateNeighborHistory(otInstance *              aInstance,
+                                                                           otHistoryTrackerIterator *aIterator,
+                                                                           uint32_t *                aEntryAge)
+{
+    Instance &instance = *static_cast<Instance *>(aInstance);
+
+    return instance.Get<Utils::HistoryTracker>().IterateNeighborHistory(
+        *static_cast<Utils::HistoryTracker::Iterator *>(aIterator), *aEntryAge);
+}
+
 void otHistoryTrackerEntryAgeToString(uint32_t aEntryAge, char *aBuffer, uint16_t aSize)
 {
     Utils::HistoryTracker::EntryAgeToString(aEntryAge, aBuffer, aSize);

--- a/src/core/config/history_tracker.h
+++ b/src/core/config/history_tracker.h
@@ -91,4 +91,16 @@
 #define OPENTHREAD_CONFIG_HISTORY_TRACKER_EXCLUDE_THREAD_CONTROL_MESSAGES 1
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_HISTORY_TRACKER_NEIGHBOR_LIST_SIZE
+ *
+ * Specifies the maximum number of entries in neighbor table history list.
+ *
+ * Can be set to zero to configure History Tracker module not to collect any neighbor table history.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_HISTORY_TRACKER_NEIGHBOR_LIST_SIZE
+#define OPENTHREAD_CONFIG_HISTORY_TRACKER_NEIGHBOR_LIST_SIZE 64
+#endif
+
 #endif // CONFIG_HISTORY_TRACKER_H_

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -248,6 +248,7 @@ void ChildTable::Restore(void)
         child->SetLastHeard(TimerMilli::GetNow());
         child->SetVersion(static_cast<uint8_t>(childInfo.GetVersion()));
         Get<IndirectSender>().SetChildUseShortAddress(*child, true);
+        Get<NeighborTable>().Signal(NeighborTable::kChildAdded, *child);
         numChildren++;
     }
 

--- a/src/core/thread/neighbor_table.cpp
+++ b/src/core/thread/neighbor_table.cpp
@@ -257,7 +257,9 @@ exit:
 
 void NeighborTable::Signal(Event aEvent, const Neighbor &aNeighbor)
 {
+#if !OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
     if (mCallback != nullptr)
+#endif
     {
         EntryInfo info;
 
@@ -279,7 +281,14 @@ void NeighborTable::Signal(Event aEvent, const Neighbor &aNeighbor)
             break;
         }
 
-        mCallback(static_cast<otNeighborTableEvent>(aEvent), &info);
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+        Get<Utils::HistoryTracker>().RecordNeighborEvent(aEvent, info);
+
+        if (mCallback != nullptr)
+#endif
+        {
+            mCallback(static_cast<otNeighborTableEvent>(aEvent), &info);
+        }
     }
 
 #if OPENTHREAD_CONFIG_OTNS_ENABLE


### PR DESCRIPTION
This commit adds support in `HistoryTracker` to record the history of
changes to the neighbor table. An entry is recorded when a child or
router neighbor is added, removed, or changed. Each entry provides:

- Timestamp
- Type: Child or Router
- Event: Added, Removed, Changed
- Extended Address
- RLOC16
- MLE Link Mode (rx-on-when-idle, FTD/MDT, full-netdata).
- Average RSS (in dBm) of received frames from the neighbor at
  the time the entry was recorded.

This commit also updates CLI and adds `history neighbor` command
to get the neighbor history. It also updates the documentation.