### PR TITLE
[tcp] fix uninitialized variable warning in TcpExample::ProcessBenchmark()

### DIFF
--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -213,7 +213,7 @@ exit:
 
 otError TcpExample::ProcessBenchmark(Arg aArgs[])
 {
-    otError  error;
+    otError  error = OT_ERROR_NONE;
     uint32_t toSendOut;
 
     VerifyOrExit(!mSendBusy, error = OT_ERROR_BUSY);


### PR DESCRIPTION
This closes https://github.com/openthread/openthread/issues/6952