### PR TITLE
[tests] update meshcop service test case

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
+++ b/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
@@ -59,6 +59,7 @@ class PublishMeshCopService(thread_cert.TestCase):
             'is_otbr': True,
             'version': '1.2',
             'network_name': 'ot-br1',
+            'boot_delay': 5,
         },
         BR2: {
             'name': 'BR_2',
@@ -66,6 +67,7 @@ class PublishMeshCopService(thread_cert.TestCase):
             'is_otbr': True,
             'version': '1.2',
             'network_name': 'ot-br2',
+            'boot_delay': 5,
         },
         HOST: {
             'name': 'Host',
@@ -79,10 +81,15 @@ class PublishMeshCopService(thread_cert.TestCase):
         br2 = self.nodes[BR2]
         br2.disable_br()
 
+        # Use different network names to distinguish meshcop services
+        br1.set_network_name('ot-br1')
+        br2.set_network_name('ot-br2')
+
         host.start(start_radvd=False)
         self.simulator.go(20)
 
         self.assertEqual(br1.get_state(), 'disabled')
+        self.check_meshcop_service(br1, host)
         br1.start()
         self.simulator.go(20)
         self.assertEqual('leader', br1.get_state())

--- a/tests/scripts/thread-cert/thread_cert.py
+++ b/tests/scripts/thread-cert/thread_cert.py
@@ -162,6 +162,8 @@ class TestCase(NcpSupportMixin, unittest.TestCase):
                 version=params['version'],
                 is_bbr=params['is_bbr'],
             )
+            if 'boot_delay' in params:
+                self.simulator.go(params['boot_delay'])
 
             self.nodes[i] = node
 


### PR DESCRIPTION
This PR aims to fix https://github.com/openthread/ot-br-posix/issues/736.

The spec asks border router to publish meshcop service even when thread interface is inactive. I implemented this feature in openthread/ot-br-posix#991. I added a test case in this PR to verify the feature. 

I also introduced `boot_delay` to add delays between booting nodes. In this way we can let border routers not starting at the  same time, so that there will be fewer renaming conflicts. This can make the test more stable.

Depends-On: openthread/ot-br-posix#991

