### PR TITLE
[simulation] fix handling of overflow in virtual-time simulation

### DIFF
--- a/examples/platforms/simulation/platform-simulation.h
+++ b/examples/platforms/simulation/platform-simulation.h
@@ -113,12 +113,12 @@ void platformAlarmUpdateTimeout(struct timeval *aTimeout);
 void platformAlarmProcess(otInstance *aInstance);
 
 /**
- * This function returns the next alarm event time.
+ * This function returns the duration to the next alarm event time (in micro seconds)
  *
- * @returns The next alarm fire time.
+ * @returns The duration (in micro seconds) to the next alarm event.
  *
  */
-int32_t platformAlarmGetNext(void);
+uint64_t platformAlarmGetNext(void);
 
 /**
  * This function returns the current alarm time.

--- a/examples/platforms/simulation/virtual_time/alarm-sim.c
+++ b/examples/platforms/simulation/virtual_time/alarm-sim.c
@@ -105,35 +105,40 @@ void otPlatAlarmMicroStop(otInstance *aInstance)
     sIsUsRunning = false;
 }
 
-int32_t platformAlarmGetNext(void)
+uint64_t platformAlarmGetNext(void)
 {
-    int32_t remaining = INT32_MAX;
+    uint64_t remaining = INT64_MAX;
 
     if (sIsMsRunning)
     {
         int32_t milli = (int32_t)(sMsAlarm - otPlatAlarmMilliGetNow());
 
-        remaining = milli * US_PER_MS;
-
-        if (remaining < 0 && milli > 0)
+        if (milli < 0)
         {
-            remaining = INT32_MAX;
+            remaining = 0;
+        }
+        else
+        {
+            remaining = (uint64_t)milli;
+            remaining *= US_PER_MS;
         }
     }
 
 #if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
-
     if (sIsUsRunning)
     {
         int32_t micro = (int32_t)(sUsAlarm - otPlatAlarmMicroGetNow());
 
-        if (remaining > micro)
+        if (micro < 0)
         {
-            remaining = micro;
+            remaining = 0;
+        }
+        else if (remaining > ((uint64_t)micro))
+        {
+            remaining = (uint64_t)micro;
         }
     }
-
-#endif // OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+#endif
 
     return remaining;
 }

--- a/examples/platforms/simulation/virtual_time/platform-sim.c
+++ b/examples/platforms/simulation/virtual_time/platform-sim.c
@@ -127,7 +127,7 @@ static void platformSendSleepEvent(void)
 
     assert(platformAlarmGetNext() > 0);
 
-    event.mDelay      = (uint64_t)platformAlarmGetNext();
+    event.mDelay      = platformAlarmGetNext();
     event.mEvent      = OT_SIM_EVENT_ALARM_FIRED;
     event.mDataLength = 0;
 


### PR DESCRIPTION
This commit updates `platformAlarmGetNext()` in `alarm-sim` in
virtual-time simulation platform to return the remaining duration
to the next alarm as `uint64_t` (in microseconds). This fixes the
issue with potential overflow in calculating the next alarm time.

---

Please check the comment on this PR for more details on the 
issue: https://github.com/openthread/openthread/pull/6968#issuecomment-907726266.
