### PR TITLE
[dnssd-server] timeout same DNS-SD queries

### DIFF
--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -375,7 +375,7 @@ private:
                                   const otDnssdServiceInstanceInfo &aInstanceInfo);
     static bool       CanAnswerQuery(const Server::QueryTransaction &aQuery, const char *aHostFullName);
     void AnswerQuery(QueryTransaction &aQuery, const char *aHostFullName, const otDnssdHostInfo &aHostInfo);
-    void FinalizeQuery(QueryTransaction &aQuery, Header::Response aResponseCode);
+    void FinalizeQuery(QueryTransaction &aQuery, Header::Response aResponseCode, bool aFinalizeSameQueries = false);
     static DnsQueryType GetQueryTypeAndName(const Header & aHeader,
                                             const Message &aMessage,
                                             char (&aName)[Name::kMaxNameSize]);


### PR DESCRIPTION
This commit optimizes DNS-SD server to close DNS queries with same DNS name when one DNS query times out.