### PR TITLE
[coap] remove unnecessary value store

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -625,8 +625,6 @@ Error CoapBase::PrepareNextBlockRequest(Message::BlockType aType,
         aRequest.SetBlockWiseBlockNumber(aMessage.GetBlockWiseBlockNumber() + 1);
         aRequest.SetBlockWiseBlockSize(aMessage.GetBlockWiseBlockSize());
         aRequest.SetMoreBlocksFlag(aMoreBlocks);
-
-        isOptionSet = true;
     }
 
 exit:


### PR DESCRIPTION
To remove compiler warning:

  Value stored to 'isOptionSet' is never read