### PR TITLE
[border-agent] remove tracking UDP Proxy port

### DIFF
--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -109,13 +109,14 @@ public:
     void ApplyMeshLocalPrefix(void);
 
     /**
-     * This method returns the UDP Proxy port to which the commissioner is currently
-     * bound.
+     * This method gets the Commissioner ALOC.
      *
-     * @returns  The current UDP Proxy port or 0 if no Proxy Transmit has been received yet.
+     * Note: should only be called when the Border Agent is active.
+     *
+     * @returns  The Commissioner ALOC.
      *
      */
-    uint16_t GetUdpProxyPort(void) const { return mUdpProxyPort; }
+    const Ip6::Address &GetCommissionerAloc(void) const;
 
 private:
     class ForwardContext : public InstanceLocatorInit
@@ -194,7 +195,6 @@ private:
 
     TimerMilli mTimer;
     State      mState;
-    uint16_t   mUdpProxyPort;
 };
 
 } // namespace MeshCoP

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1041,9 +1041,10 @@ Error Ip6::ProcessReceiveCallback(Message &          aMessage,
             Udp::Header udp;
 
             IgnoreError(aMessage.Read(aMessage.GetOffset(), udp));
-            VerifyOrExit(Get<Udp>().ShouldUsePlatformUdp(udp.GetDestinationPort()) &&
-                             !Get<Udp>().IsPortInUse(udp.GetDestinationPort()),
-                         error = kErrorNoRoute);
+            VerifyOrExit(
+                Get<Udp>().ShouldReceiveWithPlatformUdp(aMessageInfo.GetSockAddr(), udp.GetDestinationPort()) &&
+                    !Get<Udp>().IsPortInUse(udp.GetDestinationPort()),
+                error = kErrorNoRoute);
             break;
         }
 
@@ -1299,7 +1300,7 @@ start:
 #if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
             if (nextHeader == kProtoUdp)
             {
-                VerifyOrExit(Get<Udp>().ShouldUsePlatformUdp(destPort), error = kErrorDrop);
+                VerifyOrExit(Get<Udp>().ShouldPortUsePlatformUdp(destPort), error = kErrorDrop);
             }
 #else
             OT_UNUSED_VARIABLE(destPort);

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -609,7 +609,20 @@ public:
      * @retval False when the port belongs to the stack.
      *
      */
-    bool ShouldUsePlatformUdp(uint16_t aPort) const;
+    bool ShouldPortUsePlatformUdp(uint16_t aPort) const;
+
+    /**
+     * This method returns whether a received UDP message with the socket address and udp port belongs to the platform
+     * or the stack.
+     *
+     * @param[in] aSockAddr     The socket address of the received UDP message.
+     * @param[in] aPort         The port of the received UDP message.
+     *
+     * @retval True     When the message belongs to the platform.
+     * @retval False    When the message belongs to the stack.
+     *
+     */
+    bool ShouldReceiveWithPlatformUdp(const Address &aSockAddr, uint16_t aPort) const;
 
 private:
     static constexpr uint16_t kDynamicPortMin = 49152; // Service Name and Transport Protocol Port Number Registry
@@ -624,7 +637,7 @@ private:
     void AddSocket(SocketHandle &aSocket);
     void RemoveSocket(SocketHandle &aSocket);
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
-    bool ShouldUsePlatformUdp(const SocketHandle &aSocket) const;
+    bool ShouldSocketUsePlatformUdp(const SocketHandle &aSocket) const;
 #endif
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE


### PR DESCRIPTION
According to Thread Spec. 8.6.2:
```
The Border Agent accepts all (unicast) UDP traffic destined to the Commissioner ALOC
corresponding to a particular Commissioner Session ID. Such Commissioner Anycast traffic
is encapsulated and forwarded to the Commissioner via UDP_RX.ntf commands over the
Commissioner Session.
```

This commit passes all UDP messages destined to `Commissioner ALOC` to the Thread stack when the `Border Agent` is active, to be more inline with the Spec.