### PR TITLE
[netdata] remove `mType` in `NetworkData` class

### DIFF
--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -47,13 +47,6 @@
 namespace ot {
 namespace NetworkData {
 
-NetworkData::NetworkData(Instance &aInstance, Type aType)
-    : InstanceLocator(aInstance)
-    , mType(aType)
-{
-    mLength = 0;
-}
-
 Error NetworkData::GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength) const
 {
     Error error = kErrorNone;
@@ -693,7 +686,10 @@ void NetworkData::RemoveTlv(NetworkDataTlv *aTlv)
     NetworkData::RemoveTlv(mTlvs, mLength, aTlv);
 }
 
-Error NetworkData::SendServerDataNotification(uint16_t aRloc16, Coap::ResponseHandler aHandler, void *aContext)
+Error NetworkData::SendServerDataNotification(uint16_t              aRloc16,
+                                              bool                  aAppendNetDataTlv,
+                                              Coap::ResponseHandler aHandler,
+                                              void *                aContext)
 {
     Error            error   = kErrorNone;
     Coap::Message *  message = nullptr;
@@ -704,7 +700,7 @@ Error NetworkData::SendServerDataNotification(uint16_t aRloc16, Coap::ResponseHa
     SuccessOrExit(error = message->InitAsConfirmablePost(UriPath::kServerData));
     SuccessOrExit(error = message->SetPayloadMarker());
 
-    if (mType == kTypeLocal)
+    if (aAppendNetDataTlv)
     {
         ThreadTlv tlv;
         tlv.SetType(ThreadTlv::kThreadNetworkData);

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -112,23 +112,16 @@ public:
     static constexpr uint8_t kMaxSize = 254; ///< Maximum size of Thread Network Data in bytes.
 
     /**
-     * This enumeration specifies the type of Network Data (local or leader).
-     *
-     */
-    enum Type : uint8_t
-    {
-        kTypeLocal,  ///< Local Network Data.
-        kTypeLeader, ///< Leader Network Data.
-    };
-
-    /**
      * This constructor initializes the object.
      *
      * @param[in]  aInstance     A reference to the OpenThread instance.
-     * @param[in]  aType         Network data type
      *
      */
-    NetworkData(Instance &aInstance, Type aType);
+    explicit NetworkData(Instance &aInstance)
+        : InstanceLocator(aInstance)
+        , mLength(0)
+    {
+    }
 
     /**
      * This method clears the network data.
@@ -594,15 +587,19 @@ protected:
     /**
      * This method sends a Server Data Notification message to the Leader.
      *
-     * @param[in]  aRloc16   The old RLOC16 value that was previously registered.
-     * @param[in]  aHandler  A function pointer that is called when the transaction ends.
-     * @param[in]  aContext  A pointer to arbitrary context information.
+     * @param[in]  aRloc16            The old RLOC16 value that was previously registered.
+     * @param[in]  aAppendNetDataTlv  Indicates whether or not to append Thread Network Data TLV to the message.
+     * @param[in]  aHandler           A function pointer that is called when the transaction ends.
+     * @param[in]  aContext           A pointer to arbitrary context information.
      *
      * @retval kErrorNone     Successfully enqueued the notification message.
      * @retval kErrorNoBufs   Insufficient message buffers to generate the notification message.
      *
      */
-    Error SendServerDataNotification(uint16_t aRloc16, Coap::ResponseHandler aHandler, void *aContext);
+    Error SendServerDataNotification(uint16_t              aRloc16,
+                                     bool                  aAppendNetDataTlv,
+                                     Coap::ResponseHandler aHandler,
+                                     void *                aContext);
 
     uint8_t mTlvs[kMaxSize]; ///< The Network Data buffer.
     uint8_t mLength;         ///< The number of valid bytes in @var mTlvs.
@@ -691,8 +688,6 @@ private:
                              const uint8_t *   aServiceData,
                              uint8_t           aServiceDataLength,
                              ServiceMatchMode  aServiceMatchMode);
-
-    const Type mType;
 };
 
 } // namespace NetworkData

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -53,12 +53,6 @@
 namespace ot {
 namespace NetworkData {
 
-LeaderBase::LeaderBase(Instance &aInstance)
-    : NetworkData(aInstance, kTypeLeader)
-{
-    Reset();
-}
-
 void LeaderBase::Reset(void)
 {
     mVersion       = Random::NonCrypto::GetUint8();

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -71,7 +71,11 @@ public:
      * @param[in]  aInstance     A reference to the OpenThread instance.
      *
      */
-    explicit LeaderBase(Instance &aInstance);
+    explicit LeaderBase(Instance &aInstance)
+        : NetworkData(aInstance)
+    {
+        Reset();
+    }
 
     /**
      * This method reset the Thread Network Data.

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -1364,7 +1364,7 @@ Error Leader::RemoveStaleChildEntries(Coap::ResponseHandler aHandler, void *aCon
             Get<ChildTable>().FindChild(rloc16, Child::kInStateValid) == nullptr)
         {
             // In Thread 1.1 Specification 5.15.6.1, only one RLOC16 TLV entry may appear in SRV_DATA.ntf.
-            error = SendServerDataNotification(rloc16, aHandler, aContext);
+            error = SendServerDataNotification(rloc16, /* aAppendNetDataTlv */ false, aHandler, aContext);
             ExitNow();
         }
     }

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -47,12 +47,6 @@
 namespace ot {
 namespace NetworkData {
 
-Local::Local(Instance &aInstance)
-    : NetworkData(aInstance, kTypeLocal)
-    , mOldRloc(Mac::kShortAddrInvalid)
-{
-}
-
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
 Error Local::AddOnMeshPrefix(const OnMeshPrefixConfig &aConfig)
@@ -329,7 +323,7 @@ Error Local::UpdateInconsistentServerData(Coap::ResponseHandler aHandler, void *
         mOldRloc = Mac::kShortAddrInvalid;
     }
 
-    SuccessOrExit(error = SendServerDataNotification(mOldRloc, aHandler, aContext));
+    SuccessOrExit(error = SendServerDataNotification(mOldRloc, /* aAppendNetDataTlv */ true, aHandler, aContext));
     mOldRloc = rloc;
 
 exit:

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -64,10 +64,14 @@ public:
     /**
      * This constructor initializes the local Network Data.
      *
-     * @param[in]  aNetif  A reference to the Thread network interface.
+     * @param[in]  aInstance     A reference to the OpenThread instance.
      *
      */
-    explicit Local(Instance &aInstance);
+    explicit Local(Instance &aInstance)
+        : NetworkData(aInstance)
+        , mOldRloc(Mac::kShortAddrInvalid)
+    {
+    }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
     /**

--- a/tests/unit/test_network_data.cpp
+++ b/tests/unit/test_network_data.cpp
@@ -68,7 +68,7 @@ void TestNetworkDataIterator(void)
     {
     public:
         TestNetworkData(ot::Instance *aInstance, const uint8_t *aTlvs, uint8_t aTlvsLength)
-            : NetworkData(*aInstance, kTypeLeader)
+            : NetworkData(*aInstance)
         {
             memcpy(mTlvs, aTlvs, aTlvsLength);
             mLength = aTlvsLength;


### PR DESCRIPTION
This commit simplifies the `NetworkData` class by removing the `mType`.
Instead we add a new parameter in `SendServerDataNotification()` which
indicates whether to append the Network Data TLV to the message or
not (which was previously determined by `mType`).