### PR TITLE
[common] add template helper `AsConst()/AsNonConst()` functions

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -372,6 +372,7 @@ openthread_core_files = [
   "common/bit_vector.hpp",
   "common/clearable.hpp",
   "common/code_utils.hpp",
+  "common/const_cast.hpp",
   "common/crc16.cpp",
   "common/crc16.hpp",
   "common/debug.hpp",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -386,6 +386,7 @@ HEADERS_COMMON                                  = \
     common/bit_vector.hpp                         \
     common/clearable.hpp                          \
     common/code_utils.hpp                         \
+    common/const_cast.hpp                         \
     common/crc16.hpp                              \
     common/debug.hpp                              \
     common/encoding.hpp                           \

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -40,6 +40,7 @@
 
 #include "common/clearable.hpp"
 #include "common/code_utils.hpp"
+#include "common/const_cast.hpp"
 #include "common/encoding.hpp"
 #include "common/message.hpp"
 #include "net/ip6.hpp"
@@ -966,7 +967,7 @@ private:
         return *static_cast<const HelpData *>(OT_ALIGN(mBuffer.mHead.mData, kHelpDataAlignment));
     }
 
-    HelpData &GetHelpData(void) { return const_cast<HelpData &>(static_cast<const Message *>(this)->GetHelpData()); }
+    HelpData &GetHelpData(void) { return AsNonConst(AsConst(this)->GetHelpData()); }
 
     uint8_t *GetToken(void) { return GetHelpData().mHeader.mToken; }
 

--- a/src/core/common/array.hpp
+++ b/src/core/common/array.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "common/code_utils.hpp"
+#include "common/const_cast.hpp"
 #include "common/error.hpp"
 #include "common/numeric_limits.hpp"
 #include "common/type_traits.hpp"
@@ -264,7 +265,7 @@ public:
      * @returns A pointer to matched array element, or `nullptr` if a match could not be found.
      *
      */
-    Type *Find(const Type &aEntry) { return const_cast<Type *>(const_cast<const Array *>(this)->Find(aEntry)); }
+    Type *Find(const Type &aEntry) { return AsNonConst(AsConst(this)->Find(aEntry)); }
 
     /**
      * This method finds the first match of a given entry in the array.
@@ -321,7 +322,7 @@ public:
      */
     template <typename Indicator> Type *FindMatching(const Indicator &aIndicator)
     {
-        return const_cast<Type *>(const_cast<const Array *>(this)->FindMatching(aIndicator));
+        return AsNonConst(AsConst(this)->FindMatching(aIndicator));
     }
 
     /**

--- a/src/core/common/const_cast.hpp
+++ b/src/core/common/const_cast.hpp
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes helper methods to cast between const and non-const objects and/or pointers.
+ */
+
+#ifndef CONST_CAST_HPP_
+#define CONST_CAST_HPP_
+
+#include "openthread-core-config.h"
+
+namespace ot {
+
+/**
+ * This template method casts a given non-const reference to a const reference.
+ *
+ * @tparam Type        The reference type.
+ *
+ * @param[in] aObject  A non-const reference to an object.
+ *
+ * @returns A const reference to @p aObject reference.
+ *
+ */
+template <typename Type> const Type &AsConst(Type &aObject)
+{
+    return const_cast<const Type &>(aObject);
+}
+
+/**
+ * This template method casts a given non-const pointer to a const pointer.
+ *
+ * @tparam Type        The pointer type.
+ *
+ * @param[in] aPointer  A non-const pointer to an object.
+ *
+ * @returns A const pointer to @p aPointer pointer.
+ *
+ */
+template <typename Type> const Type *AsConst(Type *aPointer)
+{
+    return const_cast<const Type *>(aPointer);
+}
+
+/**
+ * This template method casts a given const reference to a non-const reference.
+ *
+ * @tparam Type        The reference type.
+ *
+ * @param[in] aObject  A const reference to an object.
+ *
+ * @returns A non-const reference to @p aObject reference.
+ *
+ */
+template <typename Type> Type &AsNonConst(const Type &aObject)
+{
+    return const_cast<Type &>(aObject);
+}
+
+/**
+ * This template method casts a given const pointer to a non-const pointer.
+ *
+ * @tparam Type        The pointer type.
+ *
+ * @param[in] aPointer  A const pointer to an object.
+ *
+ * @returns A non-const pointer to @p aPointer pointer.
+ *
+ */
+template <typename Type> Type *AsNonConst(const Type *aPointer)
+{
+    return const_cast<Type *>(aPointer);
+}
+
+} // namespace ot
+
+#endif // CONST_CAST_HPP_

--- a/src/core/common/linked_list.hpp
+++ b/src/core/common/linked_list.hpp
@@ -38,6 +38,7 @@
 
 #include <stdio.h>
 
+#include "common/const_cast.hpp"
 #include "common/error.hpp"
 #include "common/iterator_utils.hpp"
 
@@ -392,7 +393,7 @@ public:
      */
     Error Find(const Type &aEntry, Type *&aPrevEntry)
     {
-        return const_cast<const LinkedList *>(this)->Find(aEntry, const_cast<const Type *&>(aPrevEntry));
+        return AsConst(this)->Find(aEntry, const_cast<const Type *&>(aPrevEntry));
     }
 
     /**
@@ -459,7 +460,7 @@ public:
     template <typename Indicator>
     Type *FindMatching(const Type *aBegin, const Type *aEnd, const Indicator &aIndicator, Type *&aPrevEntry)
     {
-        return const_cast<Type *>(FindMatching(aBegin, aEnd, aIndicator, const_cast<const Type *&>(aPrevEntry)));
+        return AsNonConst(FindMatching(aBegin, aEnd, aIndicator, const_cast<const Type *&>(aPrevEntry)));
     }
 
     /**
@@ -504,8 +505,7 @@ public:
      */
     template <typename Indicator> Type *FindMatching(const Indicator &aIndicator, Type *&aPrevEntry)
     {
-        return const_cast<Type *>(
-            const_cast<const LinkedList *>(this)->FindMatching(aIndicator, const_cast<const Type *&>(aPrevEntry)));
+        return AsNonConst(AsConst(this)->FindMatching(aIndicator, const_cast<const Type *&>(aPrevEntry)));
     }
 
     /**
@@ -545,7 +545,7 @@ public:
      */
     template <typename Indicator> Type *FindMatching(const Indicator &aIndicator)
     {
-        return const_cast<Type *>(const_cast<const LinkedList *>(this)->FindMatching(aIndicator));
+        return AsNonConst(AsConst(this)->FindMatching(aIndicator));
     }
 
     /**
@@ -575,7 +575,7 @@ public:
      * @returns A pointer to the tail entry in the linked list or nullptr if the list is empty.
      *
      */
-    Type *GetTail(void) { return const_cast<Type *>(const_cast<const LinkedList *>(this)->GetTail()); }
+    Type *GetTail(void) { return AsNonConst(AsConst(this)->GetTail()); }
 
     // The following methods are intended to support range-based `for`
     // loop iteration over the linked-list entries and should not be

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -42,6 +42,7 @@
 #include <openthread/platform/messagepool.h>
 
 #include "common/code_utils.hpp"
+#include "common/const_cast.hpp"
 #include "common/encoding.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
@@ -1359,7 +1360,7 @@ private:
 
     struct WritableChunk : public Chunk
     {
-        uint8_t *GetData(void) const { return const_cast<uint8_t *>(mData); }
+        uint8_t *GetData(void) const { return AsNonConst(mData); }
     };
 
     void GetFirstChunk(uint16_t aOffset, uint16_t &aLength, Chunk &chunk) const;
@@ -1367,12 +1368,12 @@ private:
 
     void GetFirstChunk(uint16_t aOffset, uint16_t &aLength, WritableChunk &aChunk)
     {
-        const_cast<const Message *>(this)->GetFirstChunk(aOffset, aLength, static_cast<Chunk &>(aChunk));
+        AsConst(this)->GetFirstChunk(aOffset, aLength, static_cast<Chunk &>(aChunk));
     }
 
     void GetNextChunk(uint16_t &aLength, WritableChunk &aChunk)
     {
-        const_cast<const Message *>(this)->GetNextChunk(aLength, static_cast<Chunk &>(aChunk));
+        AsConst(this)->GetNextChunk(aLength, static_cast<Chunk &>(aChunk));
     }
 };
 

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -39,6 +39,7 @@
 #include <limits.h>
 #include <stdint.h>
 
+#include "common/const_cast.hpp"
 #include "common/encoding.hpp"
 #include "mac/mac_types.hpp"
 
@@ -866,7 +867,7 @@ public:
      * @returns A pointer to the MAC Payload.
      *
      */
-    uint8_t *GetPayload(void) { return const_cast<uint8_t *>(const_cast<const Frame *>(this)->GetPayload()); }
+    uint8_t *GetPayload(void) { return AsNonConst(AsConst(this)->GetPayload()); }
 
     /**
      * This const method returns a pointer to the MAC Payload.
@@ -882,7 +883,7 @@ public:
      * @returns A pointer to the MAC Footer.
      *
      */
-    uint8_t *GetFooter(void) { return const_cast<uint8_t *>(const_cast<const Frame *>(this)->GetFooter()); }
+    uint8_t *GetFooter(void) { return AsNonConst(AsConst(this)->GetFooter()); }
 
     /**
      * This const method returns a pointer to the MAC Footer.
@@ -900,7 +901,7 @@ public:
      * @returns A pointer to the Time IE, nullptr if not found.
      *
      */
-    TimeIe *GetTimeIe(void) { return const_cast<TimeIe *>(const_cast<const Frame *>(this)->GetTimeIe()); }
+    TimeIe *GetTimeIe(void) { return AsNonConst(AsConst(this)->GetTimeIe()); }
 
     /**
      * This method returns a pointer to the vendor specific Time IE.
@@ -938,10 +939,7 @@ public:
      * @returns A pointer to the Header IE, nullptr if not found.
      *
      */
-    uint8_t *GetHeaderIe(uint8_t aIeId)
-    {
-        return const_cast<uint8_t *>(const_cast<const Frame *>(this)->GetHeaderIe(aIeId));
-    }
+    uint8_t *GetHeaderIe(uint8_t aIeId) { return AsNonConst(AsConst(this)->GetHeaderIe(aIeId)); }
 
     /**
      * This method returns a pointer to the Header IE.
@@ -963,10 +961,7 @@ public:
      * @returns A pointer to the Thread IE, nullptr if not found.
      *
      */
-    uint8_t *GetThreadIe(uint8_t aSubType)
-    {
-        return const_cast<uint8_t *>(const_cast<const Frame *>(this)->GetThreadIe(aSubType));
-    }
+    uint8_t *GetThreadIe(uint8_t aSubType) { return AsNonConst(AsConst(this)->GetThreadIe(aSubType)); }
 
     /**
      * This method returns a pointer to a specific Thread IE.

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -40,6 +40,7 @@
 #include <openthread/dataset.h>
 
 #include "common/clearable.hpp"
+#include "common/const_cast.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/timer.hpp"
@@ -637,7 +638,7 @@ public:
      * @returns A pointer to the TLV or nullptr if none is found.
      *
      */
-    Tlv *GetTlv(Tlv::Type aType) { return const_cast<Tlv *>(const_cast<const Dataset *>(this)->GetTlv(aType)); }
+    Tlv *GetTlv(Tlv::Type aType) { return AsNonConst(AsConst(this)->GetTlv(aType)); }
 
     /**
      * This method returns a pointer to the TLV with a given type.

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -33,6 +33,7 @@
 
 #include "meshcop_tlvs.hpp"
 
+#include "common/const_cast.hpp"
 #include "common/debug.hpp"
 #include "common/string.hpp"
 #include "meshcop/meshcop.hpp"
@@ -262,7 +263,7 @@ exit:
 
 ChannelMaskEntryBase *ChannelMaskBaseTlv::GetFirstEntry(void)
 {
-    return const_cast<ChannelMaskEntryBase *>(static_cast<const ChannelMaskBaseTlv *>(this)->GetFirstEntry());
+    return AsNonConst(AsConst(this)->GetFirstEntry());
 }
 
 void ChannelMaskTlv::SetChannelMask(uint32_t aChannelMask)

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -41,6 +41,7 @@
 #include <openthread/dataset.h>
 #include <openthread/platform/radio.h>
 
+#include "common/const_cast.hpp"
 #include "common/encoding.hpp"
 #include "common/message.hpp"
 #include "common/string.hpp"
@@ -207,7 +208,7 @@ public:
      */
     static Tlv *FindTlv(uint8_t *aTlvsStart, uint16_t aTlvsLength, Type aType)
     {
-        return const_cast<Tlv *>(FindTlv(const_cast<const uint8_t *>(aTlvsStart), aTlvsLength, aType));
+        return AsNonConst(FindTlv(AsConst(aTlvsStart), aTlvsLength, aType));
     }
 
     /**
@@ -1325,10 +1326,7 @@ public:
      * @returns A pointer to next Channel Mask Entry.
      *
      */
-    ChannelMaskEntryBase *GetNext(void)
-    {
-        return const_cast<ChannelMaskEntryBase *>(static_cast<const ChannelMaskEntryBase *>(this)->GetNext());
-    }
+    ChannelMaskEntryBase *GetNext(void) { return AsNonConst(AsConst(this)->GetNext()); }
 
 private:
     uint8_t mChannelPage;

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -123,7 +123,7 @@ void Netif::SubscribeAllNodesMulticast(void)
 {
     MulticastAddress *tail;
     MulticastAddress &linkLocalAllNodesAddress =
-        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
+        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllNodesMulticastAddress));
 
     VerifyOrExit(!mMulticastAddresses.Contains(linkLocalAllNodesAddress));
 
@@ -163,7 +163,7 @@ void Netif::UnsubscribeAllNodesMulticast(void)
 {
     MulticastAddress *      prev;
     const MulticastAddress &linkLocalAllNodesAddress =
-        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
+        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllNodesMulticastAddress));
 
     // The tail of multicast address linked list contains the
     // fixed addresses. Search if LinkLocalAll is present
@@ -181,8 +181,7 @@ void Netif::UnsubscribeAllNodesMulticast(void)
     //    LinkLocalAllRouters -> RealmLocalAllRouters -> LinkLocalAll
     //         -> RealmLocalAll -> RealmLocalAllMpl.
 
-    OT_ASSERT(prev != static_cast<MulticastAddress *>(
-                          const_cast<otNetifMulticastAddress *>(&kRealmLocalAllRoutersMulticastAddress)));
+    OT_ASSERT(prev != static_cast<MulticastAddress *>(AsNonConst(&kRealmLocalAllRoutersMulticastAddress)));
 
     if (prev == nullptr)
     {
@@ -214,11 +213,11 @@ void Netif::SubscribeAllRoutersMulticast(void)
     Error             error = kErrorNone;
     MulticastAddress *prev  = nullptr;
     MulticastAddress &linkLocalAllRoutersAddress =
-        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
+        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllRoutersMulticastAddress));
     MulticastAddress &linkLocalAllNodesAddress =
-        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
+        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllNodesMulticastAddress));
     MulticastAddress &realmLocalAllRoutersAddress =
-        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kRealmLocalAllRoutersMulticastAddress));
+        static_cast<MulticastAddress &>(AsNonConst(kRealmLocalAllRoutersMulticastAddress));
 
     error = mMulticastAddresses.Find(linkLocalAllNodesAddress, prev);
 
@@ -274,9 +273,9 @@ void Netif::UnsubscribeAllRoutersMulticast(void)
 {
     MulticastAddress *prev;
     MulticastAddress &linkLocalAllRoutersAddress =
-        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
+        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllRoutersMulticastAddress));
     MulticastAddress &linkLocalAllNodesAddress =
-        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllNodesMulticastAddress));
+        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllNodesMulticastAddress));
 
     // The tail of multicast address linked list contains the
     // fixed addresses. We check for the chain of five addresses:
@@ -362,7 +361,7 @@ Error Netif::SubscribeExternalMulticast(const Address &aAddress)
 {
     Error             error = kErrorNone;
     MulticastAddress &linkLocalAllRoutersAddress =
-        static_cast<MulticastAddress &>(const_cast<otNetifMulticastAddress &>(kLinkLocalAllRoutersMulticastAddress));
+        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllRoutersMulticastAddress));
     ExternalMulticastAddress *entry;
 
     VerifyOrExit(aAddress.IsMulticast(), error = kErrorInvalidArgs);
@@ -600,7 +599,7 @@ void Netif::ExternalMulticastAddress::Iterator::AdvanceFrom(const MulticastAddre
         aAddr = aAddr->GetNext();
     }
 
-    mItem = const_cast<ExternalMulticastAddress *>(static_cast<const ExternalMulticastAddress *>(aAddr));
+    mItem = AsNonConst(static_cast<const ExternalMulticastAddress *>(aAddr));
 }
 
 } // namespace Ip6

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -38,6 +38,7 @@
 
 #include "common/clearable.hpp"
 #include "common/code_utils.hpp"
+#include "common/const_cast.hpp"
 #include "common/iterator_utils.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
@@ -225,10 +226,7 @@ public:
          * @returns A pointer to the next multicast address.
          *
          */
-        MulticastAddress *GetNext(void)
-        {
-            return static_cast<MulticastAddress *>(const_cast<otNetifMulticastAddress *>(mNext));
-        }
+        MulticastAddress *GetNext(void) { return static_cast<MulticastAddress *>(AsNonConst(mNext)); }
 
     private:
         bool Matches(const Address &aAddress) const { return GetAddress() == aAddress; }
@@ -314,10 +312,7 @@ public:
 #endif
 
     private:
-        ExternalMulticastAddress *GetNext(void)
-        {
-            return static_cast<ExternalMulticastAddress *>(const_cast<otNetifMulticastAddress *>(mNext));
-        }
+        ExternalMulticastAddress *GetNext(void) { return static_cast<ExternalMulticastAddress *>(AsNonConst(mNext)); }
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
         MlrState mMlrState;

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
 
+#include "common/const_cast.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
 #include "common/logging.hpp"
@@ -1802,7 +1803,7 @@ const Server::Service::Description *Server::Host::FindServiceDescription(const c
 
 Server::Service::Description *Server::Host::FindServiceDescription(const char *aInstanceName)
 {
-    return const_cast<Service::Description *>(const_cast<const Host *>(this)->FindServiceDescription(aInstanceName));
+    return AsNonConst(AsConst(this)->FindServiceDescription(aInstanceName));
 }
 
 const Server::Service *Server::Host::FindService(const char *aServiceName, const char *aInstanceName) const
@@ -1812,7 +1813,7 @@ const Server::Service *Server::Host::FindService(const char *aServiceName, const
 
 Server::Service *Server::Host::FindService(const char *aServiceName, const char *aInstanceName)
 {
-    return const_cast<Service *>(const_cast<const Host *>(this)->FindService(aServiceName, aInstanceName));
+    return AsNonConst(AsConst(this)->FindService(aServiceName, aInstanceName));
 }
 
 Error Server::Host::AddIp6Address(const Ip6::Address &aIp6Address)

--- a/src/core/thread/child_table.hpp
+++ b/src/core/thread/child_table.hpp
@@ -38,6 +38,7 @@
 
 #if OPENTHREAD_FTD
 
+#include "common/const_cast.hpp"
 #include "common/iterator_utils.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
@@ -322,10 +323,7 @@ private:
         Child::StateFilter mFilter;
     };
 
-    Child *FindChild(const Child::AddressMatcher &aMatcher)
-    {
-        return const_cast<Child *>(const_cast<const ChildTable *>(this)->FindChild(aMatcher));
-    }
+    Child *FindChild(const Child::AddressMatcher &aMatcher) { return AsNonConst(AsConst(this)->FindChild(aMatcher)); }
 
     const Child *FindChild(const Child::AddressMatcher &aMatcher) const;
     void         RefreshStoredChildren(void);

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -41,6 +41,7 @@
 
 #include "coap/coap.hpp"
 #include "common/clearable.hpp"
+#include "common/const_cast.hpp"
 #include "common/equatable.hpp"
 #include "common/locator.hpp"
 #include "common/timer.hpp"
@@ -356,7 +357,7 @@ protected:
      */
     PrefixTlv *FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength)
     {
-        return const_cast<PrefixTlv *>(const_cast<const NetworkData *>(this)->FindPrefix(aPrefix, aPrefixLength));
+        return AsNonConst(AsConst(this)->FindPrefix(aPrefix, aPrefixLength));
     }
 
     /**
@@ -406,8 +407,7 @@ protected:
      */
     static PrefixTlv *FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength, uint8_t *aTlvs, uint8_t aTlvsLength)
     {
-        return const_cast<PrefixTlv *>(
-            FindPrefix(aPrefix, aPrefixLength, const_cast<const uint8_t *>(aTlvs), aTlvsLength));
+        return AsNonConst(FindPrefix(aPrefix, aPrefixLength, AsConst(aTlvs), aTlvsLength));
     }
 
     /**
@@ -442,8 +442,8 @@ protected:
                             uint8_t          aServiceDataLength,
                             ServiceMatchMode aServiceMatchMode)
     {
-        return const_cast<ServiceTlv *>(const_cast<const NetworkData *>(this)->FindService(
-            aEnterpriseNumber, aServiceData, aServiceDataLength, aServiceMatchMode));
+        return AsNonConst(
+            AsConst(this)->FindService(aEnterpriseNumber, aServiceData, aServiceDataLength, aServiceMatchMode));
     }
 
     /**
@@ -482,9 +482,8 @@ protected:
                                    uint8_t *        aTlvs,
                                    uint8_t          aTlvsLength)
     {
-        return const_cast<ServiceTlv *>(FindService(aEnterpriseNumber, aServiceData, aServiceDataLength,
-                                                    aServiceMatchMode, const_cast<const uint8_t *>(aTlvs),
-                                                    aTlvsLength));
+        return AsNonConst(FindService(aEnterpriseNumber, aServiceData, aServiceDataLength, aServiceMatchMode,
+                                      AsConst(aTlvs), aTlvsLength));
     }
 
     /**

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -39,6 +39,7 @@
 #include <stdint.h>
 
 #include "coap/coap.hpp"
+#include "common/const_cast.hpp"
 #include "common/timer.hpp"
 #include "net/ip6_address.hpp"
 #include "thread/mle_router.hpp"
@@ -172,10 +173,7 @@ public:
      * @returns A pointer to the Commissioning Data or nullptr if no Commissioning Data exists.
      *
      */
-    CommissioningDataTlv *GetCommissioningData(void)
-    {
-        return const_cast<CommissioningDataTlv *>(const_cast<const LeaderBase *>(this)->GetCommissioningData());
-    }
+    CommissioningDataTlv *GetCommissioningData(void) { return AsNonConst(AsConst(this)->GetCommissioningData()); }
 
     /**
      * This method returns a pointer to the Commissioning Data.
@@ -195,7 +193,7 @@ public:
      */
     MeshCoP::Tlv *GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aType)
     {
-        return const_cast<MeshCoP::Tlv *>(const_cast<const LeaderBase *>(this)->GetCommissioningDataSubTlv(aType));
+        return AsNonConst(AsConst(this)->GetCommissioningDataSubTlv(aType));
     }
 
     /**

--- a/src/core/thread/network_data_publisher.cpp
+++ b/src/core/thread/network_data_publisher.cpp
@@ -37,6 +37,7 @@
 #if OPENTHREAD_CONFIG_NETDATA_PUBLISHER_ENABLE
 
 #include "common/code_utils.hpp"
+#include "common/const_cast.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
 #include "common/random.hpp"
@@ -161,7 +162,7 @@ exit:
 
 Publisher::PrefixEntry *Publisher::FindMatchingPrefixEntry(const Ip6::Prefix &aPrefix)
 {
-    return const_cast<PrefixEntry *>(const_cast<const Publisher *>(this)->FindMatchingPrefixEntry(aPrefix));
+    return AsNonConst(AsConst(this)->FindMatchingPrefixEntry(aPrefix));
 }
 
 const Publisher::PrefixEntry *Publisher::FindMatchingPrefixEntry(const Ip6::Prefix &aPrefix) const

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/netdata.h>
 
+#include "common/const_cast.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
 #include "common/equatable.hpp"
@@ -221,8 +222,7 @@ public:
      */
     static NetworkDataTlv *Find(NetworkDataTlv *aStart, NetworkDataTlv *aEnd, Type aType)
     {
-        return const_cast<NetworkDataTlv *>(
-            Find(const_cast<const NetworkDataTlv *>(aStart), const_cast<const NetworkDataTlv *>(aEnd), aType));
+        return AsNonConst(Find(AsConst(aStart), AsConst(aEnd), aType));
     }
 
     /**
@@ -283,8 +283,7 @@ public:
      */
     static NetworkDataTlv *Find(NetworkDataTlv *aStart, NetworkDataTlv *aEnd, Type aType, bool aStable)
     {
-        return const_cast<NetworkDataTlv *>(
-            Find(const_cast<const NetworkDataTlv *>(aStart), const_cast<const NetworkDataTlv *>(aEnd), aType, aStable));
+        return AsNonConst(Find(AsConst(aStart), AsConst(aEnd), aType, aStable));
     }
 
     /**
@@ -793,10 +792,7 @@ public:
      * @returns A pointer to the TLV if found, or nullptr if not found.
      *
      */
-    NetworkDataTlv *FindSubTlv(Type aType)
-    {
-        return const_cast<NetworkDataTlv *>(const_cast<const PrefixTlv *>(this)->FindSubTlv(aType));
-    }
+    NetworkDataTlv *FindSubTlv(Type aType) { return AsNonConst(AsConst(this)->FindSubTlv(aType)); }
 
     /**
      * This method searches in the sub-TLVs to find the first one matching a given TLV type.
@@ -819,7 +815,7 @@ public:
      */
     NetworkDataTlv *FindSubTlv(Type aType, bool aStable)
     {
-        return const_cast<NetworkDataTlv *>(const_cast<const PrefixTlv *>(this)->FindSubTlv(aType, aStable));
+        return AsNonConst(AsConst(this)->FindSubTlv(aType, aStable));
     }
 
     /**

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -33,6 +33,7 @@
 
 #if OPENTHREAD_FTD
 
+#include "common/const_cast.hpp"
 #include "common/encoding.hpp"
 #include "common/iterator_utils.hpp"
 #include "common/locator.hpp"
@@ -218,10 +219,7 @@ public:
      * @returns A pointer to the router or nullptr if the router could not be found.
      *
      */
-    Router *GetRouter(uint8_t aRouterId)
-    {
-        return const_cast<Router *>(const_cast<const RouterTable *>(this)->GetRouter(aRouterId));
-    }
+    Router *GetRouter(uint8_t aRouterId) { return AsNonConst(AsConst(this)->GetRouter(aRouterId)); }
 
     /**
      * This method returns the router for a given router id.
@@ -356,16 +354,13 @@ private:
     void          UpdateAllocation(void);
     const Router *GetFirstEntry(void) const;
     const Router *GetNextEntry(const Router *aRouter) const;
-    Router *GetFirstEntry(void) { return const_cast<Router *>(const_cast<const RouterTable *>(this)->GetFirstEntry()); }
-    Router *GetNextEntry(Router *aRouter)
-    {
-        return const_cast<Router *>(const_cast<const RouterTable *>(this)->GetNextEntry(aRouter));
-    }
+    Router *      GetFirstEntry(void) { return AsNonConst(AsConst(this)->GetFirstEntry()); }
+    Router *      GetNextEntry(Router *aRouter) { return AsNonConst(AsConst(this)->GetNextEntry(aRouter)); }
 
     const Router *FindRouter(const Router::AddressMatcher &aMatcher) const;
     Router *      FindRouter(const Router::AddressMatcher &aMatcher)
     {
-        return const_cast<Router *>(const_cast<const RouterTable *>(this)->FindRouter(aMatcher));
+        return AsNonConst(AsConst(this)->FindRouter(aMatcher));
     }
 
     Router           mRouters[Mle::kMaxRouters];

--- a/src/core/utils/heap.hpp
+++ b/src/core/utils/heap.hpp
@@ -42,6 +42,7 @@
 #include <stddef.h>
 #include <stdint.h>
 
+#include "common/const_cast.hpp"
 #include "common/non_copyable.hpp"
 
 namespace ot {
@@ -208,7 +209,7 @@ public:
      */
     bool IsClean(void) const
     {
-        Heap &       self  = *const_cast<Heap *>(this);
+        Heap &       self  = *AsNonConst(this);
         const Block &super = self.BlockSuper();
         const Block &first = self.BlockRight(super);
         return super.GetNext() == self.BlockOffset(first) && first.GetSize() == kFirstBlockSize;


### PR DESCRIPTION
This commit adds a new header `common/const_cast.hpp` which provides
template functions `AsConst()` and `AsNonConst()` to cast between
const and non-const references or pointers. The template functions
simplify the code (act as syntactic suagr) by allowing the compiler
to infer the underlying reference/pointer types.