### PR TITLE
[cli] add `wait` command

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -112,6 +112,7 @@ Done
 - [unsecureport](#unsecureport-add-port)
 - [uptime](#uptime)
 - [version](#version)
+- [wait](#wait-duration)
 
 ## OpenThread Command Details
 
@@ -2846,3 +2847,16 @@ Done
 Factory Diagnostics module is enabled only when building OpenThread with `OPENTHREAD_CONFIG_DIAG_ENABLE=1` option. Go [diagnostics module][diag] for more information.
 
 [diag]: ../../src/core/diags/README.md
+
+### wait <duration>
+
+Wait for a given duration. `wait` command will block the CLI for the given duration and output `Done` lastly.
+
+Tip: `wait` command can be used to capture asynchronous CLI output.
+
+- duration: The time in milliseconds to wait.
+
+```bash
+> wait 3000
+Done
+```

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -4300,6 +4300,22 @@ exit:
     return error;
 }
 
+otError Interpreter::ProcessWait(Arg aArgs[])
+{
+    OT_UNUSED_VARIABLE(aArgs);
+
+    otError  error;
+    uint32_t msecs;
+
+    SuccessOrExit(error = aArgs[0].ParseAsUint32(msecs));
+
+    SetCommandTimeout(msecs);
+    error = OT_ERROR_PENDING;
+
+exit:
+    return error;
+}
+
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
 otError Interpreter::ProcessCommissioner(Arg aArgs[])
 {

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -668,6 +668,8 @@ private:
     otError ProcessUptime(Arg aArgs[]);
 #endif
     otError ProcessVersion(Arg aArgs[]);
+    otError ProcessWait(Arg aArgs[]);
+
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
     otError ProcessMacFilter(Arg aArgs[]);
     void    PrintMacFilter(void);
@@ -966,6 +968,7 @@ private:
         {"uptime", &Interpreter::ProcessUptime},
 #endif
         {"version", &Interpreter::ProcessVersion},
+        {"wait", &Interpreter::ProcessWait},
     };
 
     static_assert(Utils::LookupTable::IsSorted(sCommands), "Command Table is not sorted");

--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -152,6 +152,7 @@ EXTRA_DIST                                                         = \
     sniffer.py                                                       \
     sniffer_transport.py                                             \
     test_anycast.py                                                  \
+    test_cli_wait.py                                                 \
     test_coap.py                                                     \
     test_coap_block.py                                               \
     test_coap_observe.py                                             \
@@ -221,6 +222,7 @@ check_PROGRAMS                                                     = \
 
 check_SCRIPTS                                                      = \
     test_anycast.py                                                  \
+    test_cli_wait.py                                                 \
     test_coap.py                                                     \
     test_coap_block.py                                               \
     test_coap_observe.py                                             \

--- a/tests/scripts/thread-cert/test_cli_wait.py
+++ b/tests/scripts/thread-cert/test_cli_wait.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2021, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import unittest
+
+import thread_cert
+
+# Test description:
+#
+# The purpose of this test is to verify the functionality of CLI wait command.
+#
+# Topology:
+#
+#  ROUTER_1 ----- ROUTER_2
+#
+
+ROUTER_1 = 1
+ROUTER_2 = 2
+
+PORT = 12345
+
+
+class TestPing(thread_cert.TestCase):
+    USE_MESSAGE_FACTORY = False
+    SUPPORT_NCP = False
+
+    TOPOLOGY = {
+        ROUTER_1: {
+            'name': 'Router_1',
+        },
+        ROUTER_2: {
+            'name': 'Router_2',
+        },
+    }
+
+    def test(self):
+        router1 = self.nodes[ROUTER_1]
+        router2 = self.nodes[ROUTER_2]
+
+        router1.start()
+        self.simulator.go(5)
+        self.assertEqual('leader', router1.get_state())
+
+        router2.start()
+        self.simulator.go(5)
+        self.assertEqual('router', router2.get_state())
+
+        router1.udp_start("::", PORT)
+        router2.udp_start("::", PORT)
+
+        router1_rloc = router1.get_rloc()
+
+        # Verify that `wait` command can be used to get received UDP messages.
+        router1.udp_send(ipaddr=router2.get_rloc(), port=PORT, bytes=b'AAAA')
+        self.assertEqual(router2.wait(5000), [f'4 bytes from {router1_rloc} 12345 AAAA'])
+        router1.udp_send(ipaddr=router2.get_rloc(), port=PORT, bytes=b'BBBB')
+        self.assertEqual(router2.wait(5000), [f'4 bytes from {router1_rloc} 12345 BBBB'])
+
+        router1.udp_send(ipaddr=router2.get_rloc(), port=PORT, bytes=b'CCCC')
+        router1.udp_send(ipaddr=router2.get_rloc(), port=PORT, bytes=b'DDDD')
+        self.assertEqual(router2.wait(5000), [
+            f'4 bytes from {router1_rloc} 12345 CCCC',
+            f'4 bytes from {router1_rloc} 12345 DDDD',
+        ])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit adds the `wait` command which waits for a given duration and output `Done`.

The `wait` command can be useful for retrieving asynchronous CLI outputs, especially for `ot-ctl` which can only read CLI output when it's executing a command. 
For example, we can use wait to receive UDP messages:


**on node1:**
```
> udp open
Done
> udp bind :: 12345
Done
> wait 10000
5 bytes from <node2-ip> 12345 hello
Done
```

**on node2:**
```
> udp open
Done
> udp bind :: 12345
Done
> udp send <node1-ip> 12345 hello
Done
```