### PR TITLE
[netdata] add generic `Data` class & `NetworkData::Service/ServerData` 

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -375,6 +375,7 @@ openthread_core_files = [
   "common/const_cast.hpp",
   "common/crc16.cpp",
   "common/crc16.hpp",
+  "common/data.hpp",
   "common/debug.hpp",
   "common/encoding.hpp",
   "common/equatable.hpp",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -394,6 +394,7 @@ HEADERS_COMMON                                  = \
     common/code_utils.hpp                         \
     common/const_cast.hpp                         \
     common/crc16.hpp                              \
+    common/data.hpp                               \
     common/debug.hpp                              \
     common/encoding.hpp                           \
     common/equatable.hpp                          \

--- a/src/core/api/server_api.cpp
+++ b/src/core/api/server_api.cpp
@@ -53,12 +53,15 @@ otError otServerGetNetDataLocal(otInstance *aInstance, bool aStable, uint8_t *aD
 
 otError otServerAddService(otInstance *aInstance, const otServiceConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &               instance = *static_cast<Instance *>(aInstance);
+    NetworkData::ServiceData serviceData;
+    NetworkData::ServerData  serverData;
 
-    return instance.Get<NetworkData::Local>().AddService(aConfig->mEnterpriseNumber, &aConfig->mServiceData[0],
-                                                         aConfig->mServiceDataLength, aConfig->mServerConfig.mStable,
-                                                         &aConfig->mServerConfig.mServerData[0],
-                                                         aConfig->mServerConfig.mServerDataLength);
+    serviceData.Init(&aConfig->mServiceData[0], aConfig->mServiceDataLength);
+    serverData.Init(&aConfig->mServerConfig.mServerData[0], aConfig->mServerConfig.mServerDataLength);
+
+    return instance.Get<NetworkData::Local>().AddService(aConfig->mEnterpriseNumber, serviceData,
+                                                         aConfig->mServerConfig.mStable, serverData);
 }
 
 otError otServerRemoveService(otInstance *   aInstance,
@@ -66,9 +69,12 @@ otError otServerRemoveService(otInstance *   aInstance,
                               const uint8_t *aServiceData,
                               uint8_t        aServiceDataLength)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &               instance = *static_cast<Instance *>(aInstance);
+    NetworkData::ServiceData serviceData;
 
-    return instance.Get<NetworkData::Local>().RemoveService(aEnterpriseNumber, aServiceData, aServiceDataLength);
+    serviceData.Init(aServiceData, aServiceDataLength);
+
+    return instance.Get<NetworkData::Local>().RemoveService(aEnterpriseNumber, serviceData);
 }
 
 otError otServerGetNextService(otInstance *aInstance, otNetworkDataIterator *aIterator, otServiceConfig *aConfig)

--- a/src/core/common/data.hpp
+++ b/src/core/common/data.hpp
@@ -1,0 +1,325 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for a `Data` and `MutableData`.
+ */
+
+#ifndef DATA_HPP_
+#define DATA_HPP_
+
+#include "openthread-core-config.h"
+
+#include <stdint.h>
+#include <string.h>
+
+#include "common/clearable.hpp"
+#include "common/code_utils.hpp"
+#include "common/const_cast.hpp"
+#include "common/equatable.hpp"
+#include "common/error.hpp"
+#include "common/type_traits.hpp"
+
+namespace ot {
+
+/**
+ * This enumeration type is used as the template parameter in `Data` and `MutableData` to indicate the `uint` type to
+ * use for the data length.
+ *
+ */
+enum DataLengthType : uint8_t
+{
+    kWithUint8Length,  ///< Use `uint8_t` for data length.
+    kWithUint16Length, ///< Use `uint16_t` for data length
+};
+
+template <DataLengthType kDataLengthType> class MutableData;
+
+/**
+ * This type represents a generic `Data` which is simply a wrapper over a pointer to a buffer with a given data length.
+ *
+ * The data length can be either `uint8_t` or `uint16_t` (determined by the template parameter `kDataLengthType`).
+ *
+ * While a `Data` instance itself can change (for example, it can be updated to point to another buffer), it always
+ * treats the content of the buffer as immutable.
+ *
+ * A `Data` instance MUST be initialized (using any of the `Init()` methods) before calling any other methods on the
+ * instance (e.g., `GetBytes()` or `GetLength()`), otherwise the behavior is undefined.
+ *
+ * @tparam kDataLengthType   Determines the data length type (`uint8_t` or `uint16_t`).
+ *
+ */
+template <DataLengthType kDataLengthType>
+class Data : public Clearable<Data<kDataLengthType>>, public Unequatable<Data<kDataLengthType>>
+{
+    friend class MutableData<kDataLengthType>;
+
+public:
+    /**
+     * This type represents the data length type (`uint8_t` or `uint16_t`).
+     *
+     */
+    using LengthType = typename TypeTraits::Conditional<kDataLengthType == kWithUint8Length, uint8_t, uint16_t>::Type;
+
+    /**
+     * This method initializes the `Data` to point to a given buffer with a given length.
+     *
+     * @param[in] aBuffer   A pointer to a buffer containing the data.
+     * @param[in] aLength   The data length (number of bytes in @p aBuffer)
+     *
+     */
+    void Init(const void *aBuffer, LengthType aLength)
+    {
+        mBuffer = static_cast<const uint8_t *>(aBuffer);
+        mLength = aLength;
+    }
+
+    /**
+     * This method initializes the `Data` to point to a range of bytes in a given buffer.
+     *
+     * The range is specified by the pointers to its start @p aStart and its end @p aEnd. `Data` will point to the
+     * bytes in the buffer from @p aStart up to but excluding @p aEnd (i.e., `aStart <= bytes < aEnd`).
+     *
+     * @param[in] aStart  Pointer to the start of the range.
+     * @param[in] aEnd    Pointer to the end of the range.
+     *
+     */
+    void InitFromRange(const uint8_t *aStart, const uint8_t *aEnd)
+    {
+        Init(aStart, static_cast<LengthType>(aEnd - aStart));
+    }
+
+    /**
+     * This template method initializes the `Data` to point to the content of an object.
+     *
+     * @tparm ObjectType   The object type (MUST not be a pointer type).
+     *
+     * @param[in] aObject   The object to initialize the `Data` with.
+     *
+     */
+    template <typename ObjectType> void InitFrom(const ObjectType &aObject)
+    {
+        static_assert(!TypeTraits::IsPointer<ObjectType>::kValue, "ObjectType MUST not be a pointer");
+        Init(&aObject, sizeof(aObject));
+    }
+
+    /**
+     * This method returns a pointer to the data bytes buffer.
+     *
+     * @returns A pointer to the data bytes buffer (can be `nullptr` if `Data` is cleared).
+     *
+     */
+    const uint8_t *GetBytes(void) const { return mBuffer; }
+
+    /**
+     * This method returns the data length.
+     *
+     * @returns The data length (number of bytes).
+     *
+     */
+    LengthType GetLength(void) const { return mLength; }
+
+    /**
+     * This method copies the `Data` bytes to a given buffer.
+     *
+     * It is up to the caller to ensure that @p aBuffer has enough space for the current data length.
+     *
+     * @param[out] aBuffer  The buffer to copy the bytes into.
+     *
+     */
+    void CopyBytesTo(uint8_t *aBuffer) const { memcpy(aBuffer, mBuffer, mLength); }
+
+    /**
+     * This method overloads operator `==` to compare the `Data` content with the content from another one.
+     *
+     * @param[in] aOtherData   The other `Data` to compare with.
+     *
+     * @retval TRUE   The two `Data` instances have matching content (same length and same bytes).
+     * @retval FALSE  The two `Data` instances do not have matching content.
+     *
+     */
+    bool operator==(const Data &aOtherData) const
+    {
+        return (mLength == aOtherData.mLength) && (memcmp(mBuffer, aOtherData.mBuffer, mLength) == 0);
+    }
+
+    /**
+     * This method checks whether the `Data` starts with the same byte content as from another `Data` instance.
+     *
+     * This method checks that the `Data` instance contains the same bytes as @p aOtherData but allows it to have
+     * additional bytes at the end.
+     *
+     * @param[in] aOtherData  The other `Data` to compare with.
+     *
+     * @retval TRUE   This `Data` starts with the same byte content as in @p aOtherData.
+     * @retval FALSE  This `Data` does not start with the same byte content as in @p aOtherData.
+     *
+     */
+    bool StartsWith(const Data &aOtherData) const
+    {
+        return (mLength >= aOtherData.mLength) && (memcmp(mBuffer, aOtherData.mBuffer, aOtherData.mLength) == 0);
+    }
+
+private:
+    const uint8_t *mBuffer;
+    LengthType     mLength;
+};
+
+/**
+ * This type represents a generic `MutableData` which is simply a wrapper over a pointer to a buffer with a given data
+ * length.
+ *
+ * It inherits from `Data` but unlike `Data` which treats its buffer content as immutable, `MutableData` allows its
+ * data buffer content to be changed.
+ *
+ * A `MutableData` instance MUST be initialized (using any of the `Init()` methods) before calling any other methods
+ * (e.g., `GetBytes()` or `GetLength()`), otherwise the behavior is undefined.
+
+ *
+ */
+template <DataLengthType kDataLengthType> class MutableData : public Data<kDataLengthType>
+{
+    using Base = Data<kDataLengthType>;
+    using Base::mBuffer;
+    using Base::mLength;
+
+public:
+    /**
+     * This type represents the data length type (`uint8_t` or `uint16_t`).
+     *
+     */
+    using LengthType = typename Base::LengthType;
+
+    /**
+     * This method initializes the `MutableData` to point to a given buffer with a given length.
+     *
+     * @param[in] aBuffer   A pointer to a buffer containing the data.
+     * @param[in] aLength   The data length (number of bytes in @p aBuffer)
+     *
+     */
+    void Init(void *aBuffer, LengthType aLength) { Base::Init(aBuffer, aLength); }
+
+    /**
+     * This method initializes the `MutableData` to point to a range of bytes in a given buffer.
+     *
+     * The range is specified by the pointers to its start @p aStart and its end @p aEnd. `Data` will point to the
+     * bytes in the buffer from @p aStart up to but excluding @p aEnd (i.e., `aStart <= bytes < aEnd`).
+     *
+     * @param[in] aStart  Pointer to the start of the range.
+     * @param[in] aEnd    Pointer to the end of the range.
+     *
+     */
+    void InitFormRange(uint8_t *aStart, uint8_t *aEnd) { Base::InitFormRange(aStart, aEnd); }
+
+    /**
+     * This template method initializes the `MutableData` to point to the content of an object.
+     *
+     * @tparm ObjectType   The object type (MUST not be a pointer type).
+     *
+     * @param[in] aObject   The object to initialize the `MutableData` with.
+     *
+     */
+    template <typename ObjectType> void InitFrom(ObjectType &aObject)
+    {
+        static_assert(!TypeTraits::IsPointer<ObjectType>::kValue, "ObjectType MUST not be a pointer");
+        Init(&aObject, sizeof(aObject));
+    }
+
+    /**
+     * This method returns a pointer to the data bytes buffer.
+     *
+     * @returns A pointer to the data bytes buffer (can be `nullptr` if `Data` is empty or uninitialized).
+     *
+     */
+    uint8_t *GetBytes(void) { return AsNonConst(Base::GetBytes()); }
+
+    /**
+     * This method returns a pointer to the data bytes buffer.
+     *
+     * @returns A pointer to the data bytes buffer (can be `nullptr` if `Data` is empty or uninitialized).
+     *
+     */
+    const uint8_t *GetBytes(void) const { return Base::GetBytes(); }
+
+    /**
+     * This method clears all the bytes (sets them to zero) in the buffer pointed by the `MutableData`.
+     *
+     */
+    void ClearBytes(void) { memset(GetBytes(), 0, mLength); }
+
+    /**
+     * This method copies the bytes from a given buffer into the `MutableData` buffer.
+     *
+     * If the current `MutableData` length is larger than or equal to @p aLength, then all the bytes are copied
+     * from @p aBuffer into the buffer of `MutableData` and the `MutableData`'s length is changed to @p aLength.
+     *
+     * If the current `MutableData` length is smaller than @p aLength, then the method returns `kErrorNoBufs` but still
+     * copies as many bytes as can fit.
+     *
+     * @param[in] aBuffer  A pointer to a buffer to copy from.
+     * @param[in] aLength  The length of @p aBuffer (number of bytes).
+     *
+     * @retval kErrorNone    Successfully copied the bytes into `MutableData` buffer and adjusted its length.
+     * @retval kErrorNoBufs  `MutableData` buffer cannot fit the given @p aLength bytes.
+     *
+     */
+    Error CopyBytesFrom(const uint8_t *aBuffer, LengthType aLength)
+    {
+        Error error = (mLength >= aLength) ? kErrorNone : kErrorNoBufs;
+
+        mLength = OT_MIN(mLength, aLength);
+        memcpy(AsNonConst(mBuffer), aBuffer, mLength);
+
+        return error;
+    }
+
+    /**
+     * This method copies the bytes from an given `Data` instance into the `MutableData` buffer.
+     *
+     * If the current `MutableData` length is larger than or equal to the @p aData length, then all the bytes are copied
+     * from @p aData into the buffer of `MutableData` and the `MutableData`'s length is adjusted accordingly.
+     *
+     * If the current `MutableData` length is smaller than @p aData length, then as many bytes as can fit are copied
+     * and the method returns `kErrorNoBufs`.
+     *
+     * @param[in] aData      A `Data` instance to copy the content from.
+     *
+     * @retval kErrorNone    Successfully copied the bytes into `MutableData` buffer and adjusted its length.
+     * @retval kErrorNoBufs  `MutableData` buffer cannot fit the given @p aData bytes.
+     *
+     */
+    Error CopyBytesFrom(const Data<kDataLengthType> &aData)
+    {
+        return CopyBytesFrom(aData.GetBytes(), aData.GetLength());
+    }
+};
+
+} // namespace ot
+
+#endif // DATA_HPP_

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -558,27 +558,25 @@ const PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix,
     return prefixTlv;
 }
 
-const ServiceTlv *NetworkData::FindService(uint32_t         aEnterpriseNumber,
-                                           const uint8_t *  aServiceData,
-                                           uint8_t          aServiceDataLength,
-                                           ServiceMatchMode aServiceMatchMode) const
+const ServiceTlv *NetworkData::FindService(uint32_t           aEnterpriseNumber,
+                                           const ServiceData &aServiceData,
+                                           ServiceMatchMode   aServiceMatchMode) const
 {
-    return FindService(aEnterpriseNumber, aServiceData, aServiceDataLength, aServiceMatchMode, mTlvs, mLength);
+    return FindService(aEnterpriseNumber, aServiceData, aServiceMatchMode, mTlvs, mLength);
 }
 
-const ServiceTlv *NetworkData::FindService(uint32_t         aEnterpriseNumber,
-                                           const uint8_t *  aServiceData,
-                                           uint8_t          aServiceDataLength,
-                                           ServiceMatchMode aServiceMatchMode,
-                                           const uint8_t *  aTlvs,
-                                           uint8_t          aTlvsLength)
+const ServiceTlv *NetworkData::FindService(uint32_t           aEnterpriseNumber,
+                                           const ServiceData &aServiceData,
+                                           ServiceMatchMode   aServiceMatchMode,
+                                           const uint8_t *    aTlvs,
+                                           uint8_t            aTlvsLength)
 {
     TlvIterator       tlvIterator(aTlvs, aTlvsLength);
     const ServiceTlv *serviceTlv;
 
     while ((serviceTlv = tlvIterator.Iterate<ServiceTlv>()) != nullptr)
     {
-        if (MatchService(*serviceTlv, aEnterpriseNumber, aServiceData, aServiceDataLength, aServiceMatchMode))
+        if (MatchService(*serviceTlv, aEnterpriseNumber, aServiceData, aServiceMatchMode))
         {
             break;
         }
@@ -587,11 +585,10 @@ const ServiceTlv *NetworkData::FindService(uint32_t         aEnterpriseNumber,
     return serviceTlv;
 }
 
-const ServiceTlv *NetworkData::FindNextService(const ServiceTlv *aPrevServiceTlv,
-                                               uint32_t          aEnterpriseNumber,
-                                               const uint8_t *   aServiceData,
-                                               uint8_t           aServiceDataLength,
-                                               ServiceMatchMode  aServiceMatchMode) const
+const ServiceTlv *NetworkData::FindNextService(const ServiceTlv * aPrevServiceTlv,
+                                               uint32_t           aEnterpriseNumber,
+                                               const ServiceData &aServiceData,
+                                               ServiceMatchMode   aServiceMatchMode) const
 {
     const uint8_t *tlvs;
     uint8_t        length;
@@ -607,32 +604,38 @@ const ServiceTlv *NetworkData::FindNextService(const ServiceTlv *aPrevServiceTlv
         length = static_cast<uint8_t>((mTlvs + mLength) - tlvs);
     }
 
-    return FindService(aEnterpriseNumber, aServiceData, aServiceDataLength, aServiceMatchMode, tlvs, length);
+    return FindService(aEnterpriseNumber, aServiceData, aServiceMatchMode, tlvs, length);
 }
 
-bool NetworkData::MatchService(const ServiceTlv &aServiceTlv,
-                               uint32_t          aEnterpriseNumber,
-                               const uint8_t *   aServiceData,
-                               uint8_t           aServiceDataLength,
-                               ServiceMatchMode  aServiceMatchMode)
+const ServiceTlv *NetworkData::FindNextThreadService(const ServiceTlv * aPrevServiceTlv,
+                                                     const ServiceData &aServiceData,
+                                                     ServiceMatchMode   aServiceMatchMode) const
 {
-    bool match = false;
+    return FindNextService(aPrevServiceTlv, ServiceTlv::kThreadEnterpriseNumber, aServiceData, aServiceMatchMode);
+}
 
-    VerifyOrExit(aServiceTlv.GetEnterpriseNumber() == aEnterpriseNumber &&
-                 aServiceTlv.GetServiceDataLength() >= aServiceDataLength);
+bool NetworkData::MatchService(const ServiceTlv & aServiceTlv,
+                               uint32_t           aEnterpriseNumber,
+                               const ServiceData &aServiceData,
+                               ServiceMatchMode   aServiceMatchMode)
+{
+    bool        match = false;
+    ServiceData serviceData;
+
+    VerifyOrExit(aServiceTlv.GetEnterpriseNumber() == aEnterpriseNumber);
+
+    aServiceTlv.GetServiceData(serviceData);
 
     switch (aServiceMatchMode)
     {
     case kServiceExactMatch:
-        VerifyOrExit(aServiceTlv.GetServiceDataLength() == aServiceDataLength);
-        OT_FALL_THROUGH;
+        match = (serviceData == aServiceData);
+        break;
 
     case kServicePrefixMatch:
-        VerifyOrExit(memcmp(aServiceTlv.GetServiceData(), aServiceData, aServiceDataLength) == 0);
+        match = serviceData.StartsWith(aServiceData);
         break;
     }
-
-    match = true;
 
 exit:
     return match;

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -423,44 +423,38 @@ protected:
      * This method returns a pointer to a matching Service TLV.
      *
      * @param[in]  aEnterpriseNumber  Enterprise Number.
-     * @param[in]  aServiceData       A pointer to a Service Data.
-     * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
+     * @param[in]  aServiceData       A Service Data.
      * @param[in]  aServiceMatchMode  The Service Data match mode.
      *
      * @returns A pointer to the Service TLV if one is found or nullptr if no matching Service TLV exists.
      *
      */
-    ServiceTlv *FindService(uint32_t         aEnterpriseNumber,
-                            const uint8_t *  aServiceData,
-                            uint8_t          aServiceDataLength,
-                            ServiceMatchMode aServiceMatchMode)
+    ServiceTlv *FindService(uint32_t           aEnterpriseNumber,
+                            const ServiceData &aServiceData,
+                            ServiceMatchMode   aServiceMatchMode)
     {
-        return AsNonConst(
-            AsConst(this)->FindService(aEnterpriseNumber, aServiceData, aServiceDataLength, aServiceMatchMode));
+        return AsNonConst(AsConst(this)->FindService(aEnterpriseNumber, aServiceData, aServiceMatchMode));
     }
 
     /**
      * This method returns a pointer to a matching Service TLV.
      *
      * @param[in]  aEnterpriseNumber  Enterprise Number.
-     * @param[in]  aServiceData       A pointer to a Service Data.
-     * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
+     * @param[in]  aServiceData       A Service Data.
      * @param[in]  aServiceMatchMode  The Service Data match mode.
      *
      * @returns A pointer to the Service TLV if one is found or nullptr if no matching Service TLV exists.
      *
      */
-    const ServiceTlv *FindService(uint32_t         aEnterpriseNumber,
-                                  const uint8_t *  aServiceData,
-                                  uint8_t          aServiceDataLength,
-                                  ServiceMatchMode aServiceMatchMode) const;
+    const ServiceTlv *FindService(uint32_t           aEnterpriseNumber,
+                                  const ServiceData &aServiceData,
+                                  ServiceMatchMode   aServiceMatchMode) const;
 
     /**
      * This method returns a pointer to a Service TLV in a specified tlvs buffer.
      *
      * @param[in]  aEnterpriseNumber  Enterprise Number.
-     * @param[in]  aServiceData       A pointer to a Service Data.
-     * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
+     * @param[in]  aServiceData       A Service Data.
      * @param[in]  aServiceMatchMode  The Service Data match mode.
      * @param[in]  aTlvs              A pointer to a specified tlvs buffer.
      * @param[in]  aTlvsLength        The specified tlvs buffer length pointed to by @p aTlvs.
@@ -468,23 +462,20 @@ protected:
      * @returns A pointer to the Service TLV if one is found or nullptr if no matching Service TLV exists.
      *
      */
-    static ServiceTlv *FindService(uint32_t         aEnterpriseNumber,
-                                   const uint8_t *  aServiceData,
-                                   uint8_t          aServiceDataLength,
-                                   ServiceMatchMode aServiceMatchMode,
-                                   uint8_t *        aTlvs,
-                                   uint8_t          aTlvsLength)
+    static ServiceTlv *FindService(uint32_t           aEnterpriseNumber,
+                                   const ServiceData &aServiceData,
+                                   ServiceMatchMode   aServiceMatchMode,
+                                   uint8_t *          aTlvs,
+                                   uint8_t            aTlvsLength)
     {
-        return AsNonConst(FindService(aEnterpriseNumber, aServiceData, aServiceDataLength, aServiceMatchMode,
-                                      AsConst(aTlvs), aTlvsLength));
+        return AsNonConst(FindService(aEnterpriseNumber, aServiceData, aServiceMatchMode, AsConst(aTlvs), aTlvsLength));
     }
 
     /**
      * This method returns a pointer to a Service TLV in a specified tlvs buffer.
      *
      * @param[in]  aEnterpriseNumber  Enterprise Number.
-     * @param[in]  aServiceData       A pointer to a Service Data.
-     * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
+     * @param[in]  aServiceData       A Service Data.
      * @param[in]  aServiceMatchMode  The Service Data match mode.
      * @param[in]  aTlvs              A pointer to a specified tlvs buffer.
      * @param[in]  aTlvsLength        The specified tlvs buffer length pointed to by @p aTlvs.
@@ -492,12 +483,11 @@ protected:
      * @returns A pointer to the Service TLV if one is found or nullptr if no matching Service TLV exists.
      *
      */
-    static const ServiceTlv *FindService(uint32_t         aEnterpriseNumber,
-                                         const uint8_t *  aServiceData,
-                                         uint8_t          aServiceDataLength,
-                                         ServiceMatchMode aServiceMatchMode,
-                                         const uint8_t *  aTlvs,
-                                         uint8_t          aTlvsLength);
+    static const ServiceTlv *FindService(uint32_t           aEnterpriseNumber,
+                                         const ServiceData &aServiceData,
+                                         ServiceMatchMode   aServiceMatchMode,
+                                         const uint8_t *    aTlvs,
+                                         uint8_t            aTlvsLength);
 
     /**
      * This method returns the next pointer to a matching Service TLV.
@@ -508,18 +498,34 @@ protected:
      *                                Service TLV), or a pointer to the previous Service TLV returned from this method
      *                                to iterate to the next matching Service TLV.
      * @param[in]  aEnterpriseNumber  Enterprise Number.
-     * @param[in]  aServiceData       A pointer to a Service Data to match with Service TLVs.
-     * @param[in]  aServiceDataLength The Service Data length pointed to by @p aServiceData.
+     * @param[in]  aServiceData       A Service Data to match with Service TLVs.
      * @param[in]  aServiceMatchMode  The Service Data match mode.
      *
      * @returns A pointer to the next matching Service TLV if one is found or nullptr if it cannot be found.
      *
      */
-    const ServiceTlv *FindNextService(const ServiceTlv *aPrevServiceTlv,
-                                      uint32_t          aEnterpriseNumber,
-                                      const uint8_t *   aServiceData,
-                                      uint8_t           aServiceDataLength,
-                                      ServiceMatchMode  aServiceMatchMode) const;
+    const ServiceTlv *FindNextService(const ServiceTlv * aPrevServiceTlv,
+                                      uint32_t           aEnterpriseNumber,
+                                      const ServiceData &aServiceData,
+                                      ServiceMatchMode   aServiceMatchMode) const;
+
+    /**
+     * This method returns the next pointer to a matching Thread Service TLV (with Thread Enterprise number).
+     *
+     * This method can be used to iterate over all Thread Service TLVs that start with a given Service Data.
+     *
+     * @param[in]  aPrevServiceTlv    Set to nullptr to start from the beginning of the TLVs (finding the first matching
+     *                                Service TLV), or a pointer to the previous Service TLV returned from this method
+     *                                to iterate to the next matching Service TLV.
+     * @param[in]  aServiceData       A Service Data to match with Service TLVs.
+     * @param[in]  aServiceMatchMode  The Service Data match mode.
+     *
+     * @returns A pointer to the next matching Thread Service TLV if one is found or nullptr if it cannot be found.
+     *
+     */
+    const ServiceTlv *FindNextThreadService(const ServiceTlv * aPrevServiceTlv,
+                                            const ServiceData &aServiceData,
+                                            ServiceMatchMode   aServiceMatchMode) const;
 
     /**
      * This method indicates whether there is space in Network Data to insert/append new info and grow it by a given
@@ -682,11 +688,10 @@ private:
     static void Remove(uint8_t *aData, uint8_t &aDataLength, uint8_t *aRemoveStart, uint8_t aRemoveLength);
     static void RemoveTlv(uint8_t *aData, uint8_t &aDataLength, NetworkDataTlv *aTlv);
 
-    static bool MatchService(const ServiceTlv &aServiceTlv,
-                             uint32_t          aEnterpriseNumber,
-                             const uint8_t *   aServiceData,
-                             uint8_t           aServiceDataLength,
-                             ServiceMatchMode  aServiceMatchMode);
+    static bool MatchService(const ServiceTlv & aServiceTlv,
+                             uint32_t           aEnterpriseNumber,
+                             const ServiceData &aServiceData,
+                             ServiceMatchMode   aServiceMatchMode);
 };
 
 } // namespace NetworkData

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -61,21 +61,21 @@ void LeaderBase::Reset(void)
     Get<ot::Notifier>().Signal(kEventThreadNetdataChanged);
 }
 
-Error LeaderBase::GetServiceId(uint32_t       aEnterpriseNumber,
-                               const uint8_t *aServiceData,
-                               uint8_t        aServiceDataLength,
-                               bool           aServerStable,
-                               uint8_t &      aServiceId) const
+Error LeaderBase::GetServiceId(uint32_t           aEnterpriseNumber,
+                               const ServiceData &aServiceData,
+                               bool               aServerStable,
+                               uint8_t &          aServiceId) const
 {
     Error         error    = kErrorNotFound;
     Iterator      iterator = kIteratorInit;
     ServiceConfig serviceConfig;
+    ServiceData   serviceData;
 
     while (GetNextService(iterator, serviceConfig) == kErrorNone)
     {
-        if (aEnterpriseNumber == serviceConfig.mEnterpriseNumber &&
-            aServiceDataLength == serviceConfig.mServiceDataLength &&
-            memcmp(aServiceData, serviceConfig.mServiceData, aServiceDataLength) == 0 &&
+        serviceConfig.GetServiceData(serviceData);
+
+        if (aEnterpriseNumber == serviceConfig.mEnterpriseNumber && aServiceData == serviceData &&
             aServerStable == serviceConfig.mServerConfig.mStable)
         {
             aServiceId = serviceConfig.mServiceId;

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -260,20 +260,18 @@ public:
      * This method gets the Service ID for the specified service.
      *
      * @param[in]  aEnterpriseNumber  Enterprise Number (IANA-assigned) for Service TLV
-     * @param[in]  aServiceData       A pointer to the Service Data
-     * @param[in]  aServiceDataLength The length of @p aServiceData in bytes.
-     * @param[in]  aServerStable      The Stable flag value for Server TLV
+     * @param[in]  aServiceData       The Service Data.
+     * @param[in]  aServerStable      The Stable flag value for Server TLV.
      * @param[out] aServiceId         A reference where to put the Service ID.
      *
      * @retval kErrorNone       Successfully got the Service ID.
      * @retval kErrorNotFound   The specified service was not found.
      *
      */
-    Error GetServiceId(uint32_t       aEnterpriseNumber,
-                       const uint8_t *aServiceData,
-                       uint8_t        aServiceDataLength,
-                       bool           aServerStable,
-                       uint8_t &      aServiceId) const;
+    Error GetServiceId(uint32_t           aEnterpriseNumber,
+                       const ServiceData &aServiceData,
+                       bool               aServerStable,
+                       uint8_t &          aServiceId) const;
 
 protected:
     uint8_t mStableVersion;

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -125,36 +125,31 @@ public:
     /**
      * This method adds a Service entry to the Thread Network local data.
      *
-     * @param[in]  aEnterpriseNumber  Enterprise Number (IANA-assigned) for Service TLV
-     * @param[in]  aServiceData       A pointer to the Service Data
-     * @param[in]  aServiceDataLength The length of @p aServiceData in bytes.
-     * @param[in]  aServerStable      The Stable flag value for Server TLV
-     * @param[in]  aServerData        A pointer to the Server Data
-     * @param[in]  aServerDataLength  The length of @p aServerData in bytes.
+     * @param[in]  aEnterpriseNumber  Enterprise Number (IANA-assigned) for Service TLV.
+     * @param[in]  aServiceData       The Service Data.
+     * @param[in]  aServerStable      The Stable flag value for Server TLV.
+     * @param[in]  aServerData        The Server Data.
      *
      * @retval kErrorNone     Successfully added the Service entry.
      * @retval kErrorNoBufs   Insufficient space to add the Service entry.
      *
      */
-    Error AddService(uint32_t       aEnterpriseNumber,
-                     const uint8_t *aServiceData,
-                     uint8_t        aServiceDataLength,
-                     bool           aServerStable,
-                     const uint8_t *aServerData,
-                     uint8_t        aServerDataLength);
+    Error AddService(uint32_t           aEnterpriseNumber,
+                     const ServiceData &aServiceData,
+                     bool               aServerStable,
+                     const ServerData & aServerData);
 
     /**
      * This method removes a Service entry from the Thread Network local data.
      *
      * @param[in]  aEnterpriseNumber   Enterprise Number of the service to be deleted.
-     * @param[in]  aServiceData        A pointer to the service data.
-     * @param[in]  aServiceDataLength  The length of @p aServiceData in bytes.
+     * @param[in]  aServiceData        The service data.
      *
      * @retval kErrorNone       Successfully removed the Service entry.
      * @retval kErrorNotFound   Could not find the Service entry.
      *
      */
-    Error RemoveService(uint32_t aEnterpriseNumber, const uint8_t *aServiceData, uint8_t aServiceDataLength);
+    Error RemoveService(uint32_t aEnterpriseNumber, const ServiceData &aServiceData);
 #endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
     /**

--- a/src/core/thread/network_data_publisher.cpp
+++ b/src/core/thread/network_data_publisher.cpp
@@ -731,10 +731,12 @@ void Publisher::DnsSrpServiceEntry::CountAnycastEntries(uint8_t &aNumEntries, ui
 
     Service::DnsSrpAnycast::ServiceData serviceData(mInfo.GetSequenceNumber());
     const ServiceTlv *                  serviceTlv = nullptr;
+    ServiceData                         data;
 
-    while ((serviceTlv = Get<Leader>().FindNextService(
-                serviceTlv, Service::kThreadEnterpriseNumber, reinterpret_cast<const uint8_t *>(&serviceData),
-                serviceData.GetLength(), NetworkData::kServicePrefixMatch)) != nullptr)
+    data.Init(&serviceData, serviceData.GetLength());
+
+    while ((serviceTlv = Get<Leader>().FindNextThreadService(serviceTlv, data, NetworkData::kServicePrefixMatch)) !=
+           nullptr)
     {
         TlvIterator      subTlvIterator(*serviceTlv);
         const ServerTlv *serverSubTlv;
@@ -757,10 +759,12 @@ void Publisher::DnsSrpServiceEntry::CountUnicastEntries(uint8_t &aNumEntries, ui
     // the Network Data.
 
     const ServiceTlv *serviceTlv = nullptr;
+    ServiceData       data;
 
-    while ((serviceTlv = Get<Leader>().FindNextService(
-                serviceTlv, Service::kThreadEnterpriseNumber, &Service::DnsSrpUnicast::kServiceData,
-                sizeof(Service::DnsSrpUnicast::kServiceData), NetworkData::kServicePrefixMatch)) != nullptr)
+    data.InitFrom(Service::DnsSrpUnicast::kServiceData);
+
+    while ((serviceTlv = Get<Leader>().FindNextThreadService(serviceTlv, data, NetworkData::kServicePrefixMatch)) !=
+           nullptr)
     {
         TlvIterator      subTlvIterator(*serviceTlv);
         const ServerTlv *serverSubTlv;

--- a/src/core/thread/network_data_service.hpp
+++ b/src/core/thread/network_data_service.hpp
@@ -160,6 +160,14 @@ public:
     static constexpr uint8_t kServiceNumber = 0x5c; ///< The service number of a `DnsSrpAnycast` entry.
 
     /**
+     * This constant variable represents the short version of service data.
+     *
+     * The short version of service data contains only service number as a single byte.
+     *
+     */
+    static const uint8_t kServiceData = kServiceNumber;
+
+    /**
      * This structure represents information about an DNS/SRP server parsed from related Network Data service entries.
      *
      */

--- a/src/core/thread/network_data_tlvs.cpp
+++ b/src/core/thread/network_data_tlvs.cpp
@@ -92,6 +92,32 @@ const NetworkDataTlv *PrefixTlv::FindSubTlv(Type aType, bool aStable) const
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+// ServiceTlv
+
+void ServiceTlv::Init(uint8_t aServiceId, uint32_t aEnterpriseNumber, const ServiceData &aServiceData)
+{
+    NetworkDataTlv::Init();
+    SetType(kTypeService);
+
+    mFlagsServiceId = (aEnterpriseNumber == kThreadEnterpriseNumber) ? kThreadEnterpriseFlag : 0;
+    mFlagsServiceId |= (aServiceId & kServiceIdMask);
+
+    if (aEnterpriseNumber != kThreadEnterpriseNumber)
+    {
+        mShared.mEnterpriseNumber = HostSwap32(aEnterpriseNumber);
+        mServiceDataLength        = aServiceData.GetLength();
+        aServiceData.CopyBytesTo(&mServiceDataLength + sizeof(uint8_t));
+    }
+    else
+    {
+        mShared.mServiceDataLengthThreadEnterprise = aServiceData.GetLength();
+        aServiceData.CopyBytesTo(&mShared.mServiceDataLengthThreadEnterprise + sizeof(uint8_t));
+    }
+
+    SetLength(GetFieldsLength());
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 // TlvIterator
 
 const NetworkDataTlv *TlvIterator::Iterate(NetworkDataTlv::Type aType)

--- a/src/core/thread/network_data_types.cpp
+++ b/src/core/thread/network_data_types.cpp
@@ -219,10 +219,13 @@ bool ServiceConfig::ServerConfig::operator==(const ServerConfig &aOther) const
 
 void ServiceConfig::ServerConfig::SetFrom(const ServerTlv &aServerTlv)
 {
+    ServerData serverData;
+
+    aServerTlv.GetServerData(serverData);
     mStable           = aServerTlv.IsStable();
     mRloc16           = aServerTlv.GetServer16();
-    mServerDataLength = aServerTlv.GetServerDataLength();
-    memcpy(&mServerData, aServerTlv.GetServerData(), mServerDataLength);
+    mServerDataLength = serverData.GetLength();
+    serverData.CopyBytesTo(mServerData);
 }
 
 bool ServiceConfig::operator==(const ServiceConfig &aOther) const
@@ -234,12 +237,15 @@ bool ServiceConfig::operator==(const ServiceConfig &aOther) const
 
 void ServiceConfig::SetFrom(const ServiceTlv &aServiceTlv, const ServerTlv &aServerTlv)
 {
+    ServiceData serviceData;
+
     Clear();
 
+    aServiceTlv.GetServiceData(serviceData);
     mServiceId         = aServiceTlv.GetServiceId();
     mEnterpriseNumber  = aServiceTlv.GetEnterpriseNumber();
-    mServiceDataLength = aServiceTlv.GetServiceDataLength();
-    memcpy(&mServiceData, aServiceTlv.GetServiceData(), mServiceDataLength);
+    mServiceDataLength = serviceData.GetLength();
+    serviceData.CopyBytesTo(mServiceData);
     GetServerConfig().SetFrom(aServerTlv);
 }
 

--- a/src/core/thread/network_data_types.hpp
+++ b/src/core/thread/network_data_types.hpp
@@ -39,6 +39,7 @@
 #include <openthread/netdata.h>
 
 #include "common/clearable.hpp"
+#include "common/data.hpp"
 #include "common/debug.hpp"
 #include "common/equatable.hpp"
 #include "net/ip6_address.hpp"
@@ -250,6 +251,22 @@ private:
 };
 
 /**
+ * This class represents a Service Data.
+ *
+ */
+class ServiceData : public Data<kWithUint8Length>
+{
+};
+
+/**
+ * This class represents a Server Data.
+ *
+ */
+class ServerData : public Data<kWithUint8Length>
+{
+};
+
+/**
  * This type represents a Service configuration.
  *
  */
@@ -268,6 +285,14 @@ public:
 
     public:
         /**
+         * This method gets the Server Data.
+         *
+         * @param[out] aServerData   A reference to a`ServerData` to return the data.
+         *
+         */
+        void GetServerData(ServerData &aServerData) const { aServerData.Init(mServerData, mServerDataLength); }
+
+        /**
          * This method overloads operator `==` to evaluate whether or not two `ServerConfig` instances are equal.
          *
          * @param[in]  aOther  The other `ServerConfig` instance to compare with.
@@ -281,6 +306,14 @@ public:
     private:
         void SetFrom(const ServerTlv &aServerTlv);
     };
+
+    /**
+     * This method gets the Service Data.
+     *
+     * @param[out] aServiceData   A reference to a `ServiceData` to return the data.
+     *
+     */
+    void GetServiceData(ServiceData &aServiceData) const { aServiceData.Init(mServiceData, mServiceDataLength); }
 
     /**
      * This method gets the Server configuration.

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -192,6 +192,27 @@ target_link_libraries(ot-test-cmd-line-parser
 
 add_test(NAME ot-test-cmd-line-parser COMMAND ot-test-cmd-line-parser)
 
+add_executable(ot-test-data
+    test_data.cpp
+)
+
+target_include_directories(ot-test-data
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_options(ot-test-data
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
+target_link_libraries(ot-test-data
+    PRIVATE
+        ${COMMON_LIBS}
+)
+
+add_test(NAME ot-test-data COMMAND ot-test-data)
+
 add_executable(ot-test-dns
     test_dns.cpp
 )

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -113,6 +113,7 @@ check_PROGRAMS                                                     += \
     ot-test-child                                                     \
     ot-test-child-table                                               \
     ot-test-cmd-line-parser                                           \
+    ot-test-data                                                      \
     ot-test-dns                                                       \
     ot-test-ecdsa                                                     \
     ot-test-flash                                                     \
@@ -196,6 +197,9 @@ ot_test_child_table_SOURCES     = $(COMMON_SOURCES) test_child_table.cpp
 
 ot_test_cmd_line_parser_LDADD   = $(COMMON_LDADD)
 ot_test_cmd_line_parser_SOURCES = $(COMMON_SOURCES) test_cmd_line_parser.cpp
+
+ot_test_data_LDADD              = $(COMMON_LDADD)
+ot_test_data_SOURCES            = $(COMMON_SOURCES) test_data.cpp
 
 ot_test_dns_LDADD               = $(COMMON_LDADD)
 ot_test_dns_SOURCES             = $(COMMON_SOURCES) test_dns.cpp

--- a/tests/unit/test_data.cpp
+++ b/tests/unit/test_data.cpp
@@ -1,0 +1,208 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <openthread/config.h>
+
+#include "test_platform.h"
+#include "test_util.hpp"
+
+#include "common/data.hpp"
+
+namespace ot {
+
+template <DataLengthType kDataLengthType> void TestData(void)
+{
+    typedef Data<kDataLengthType> Data;
+
+    const uint8_t kData[]     = {0x12, 0x03, 0x19, 0x77};
+    const uint8_t kDataCopy[] = {0x12, 0x03, 0x19, 0x77};
+
+    Data     data;
+    Data     data2;
+    uint8_t  buffer[sizeof(kData) + 1];
+    uint8_t  u8;
+    uint16_t u16;
+
+    data.Clear();
+    data2.Clear();
+    VerifyOrQuit(data.GetLength() == 0);
+    VerifyOrQuit(data.GetBytes() == nullptr);
+    VerifyOrQuit(data == data2);
+    VerifyOrQuit(data.StartsWith(data));
+    VerifyOrQuit(data2.StartsWith(data));
+
+    data.Init(kData, sizeof(kData));
+    VerifyOrQuit(data.GetLength() == sizeof(kData));
+    VerifyOrQuit(data.GetBytes() == &kData[0]);
+    VerifyOrQuit(data == data);
+    VerifyOrQuit(data.StartsWith(data));
+
+    memset(buffer, 0, sizeof(buffer));
+    data.CopyBytesTo(buffer);
+    VerifyOrQuit(memcmp(buffer, kData, sizeof(kData)) == 0);
+    VerifyOrQuit(buffer[sizeof(kData)] == 0);
+
+    data2.InitFrom(kDataCopy);
+    VerifyOrQuit(data2.GetLength() == sizeof(kDataCopy));
+    VerifyOrQuit(data2.GetBytes() == &kDataCopy[0]);
+    VerifyOrQuit(data == data2);
+    VerifyOrQuit(data.StartsWith(data2));
+    VerifyOrQuit(data2.StartsWith(data));
+
+    data2.Init(kDataCopy, sizeof(kDataCopy) - 1);
+    VerifyOrQuit(data != data2);
+    VerifyOrQuit(data.StartsWith(data2));
+    VerifyOrQuit(!data2.StartsWith(data));
+
+    data2.InitFromRange(&kDataCopy[0], &kDataCopy[2]);
+    VerifyOrQuit(data2.GetLength() == 2);
+    VerifyOrQuit(data2.GetBytes() == &kDataCopy[0]);
+    VerifyOrQuit(data != data2);
+    VerifyOrQuit(data.StartsWith(data2));
+    VerifyOrQuit(!data2.StartsWith(data));
+
+    data2 = data;
+    VerifyOrQuit(data2 == data);
+
+    data.Clear();
+    VerifyOrQuit(data.GetLength() == 0);
+    VerifyOrQuit(data.GetBytes() == nullptr);
+    VerifyOrQuit(data != data2);
+    VerifyOrQuit(!data.StartsWith(data2));
+    VerifyOrQuit(data2.StartsWith(data));
+
+    memset(buffer, 0xaa, sizeof(buffer));
+    data.CopyBytesTo(buffer);
+    VerifyOrQuit(buffer[0] == 0xaa);
+
+    data.InitFrom(u8);
+    VerifyOrQuit(data.GetLength() == sizeof(u8));
+    VerifyOrQuit(data.GetBytes() == &u8);
+
+    data.InitFrom(u16);
+    VerifyOrQuit(data.GetLength() == sizeof(u16));
+    VerifyOrQuit(data.GetBytes() == reinterpret_cast<uint8_t *>(&u16));
+
+    printf("- TestData<%s> passed\n", kDataLengthType == kWithUint8Length ? "kWithUint8Length" : "kWithUint16Length");
+}
+
+template <DataLengthType kDataLengthType> void TestMutableData(void)
+{
+    typedef Data<kDataLengthType>        Data;
+    typedef MutableData<kDataLengthType> MutableData;
+
+    constexpr uint8_t kMaxSize = 20;
+
+    const uint8_t kData[]  = {10, 20, 3, 15, 10, 00, 60, 16};
+    const uint8_t kData2[] = {0xab, 0xbc, 0xcd, 0xde, 0xef};
+
+    MutableData mutableData;
+    Data        data;
+    uint8_t     buffer[kMaxSize];
+    uint8_t     u8;
+    uint16_t    u16;
+
+    data.Init(kData, sizeof(kData));
+
+    mutableData.Clear();
+    VerifyOrQuit(mutableData.GetLength() == 0);
+    VerifyOrQuit(mutableData.GetBytes() == nullptr);
+
+    mutableData.Init(buffer, sizeof(buffer));
+    VerifyOrQuit(mutableData.GetLength() == sizeof(buffer));
+    VerifyOrQuit(mutableData.GetBytes() == &buffer[0]);
+
+    SuccessOrQuit(mutableData.CopyBytesFrom(kData, sizeof(kData)));
+    VerifyOrQuit(mutableData.GetLength() == sizeof(kData));
+    VerifyOrQuit(mutableData.GetBytes() == &buffer[0]);
+    VerifyOrQuit(mutableData == data);
+
+    SuccessOrQuit(mutableData.CopyBytesFrom(kData2, sizeof(kData2)));
+    VerifyOrQuit(mutableData.GetLength() == sizeof(kData2));
+    VerifyOrQuit(mutableData.GetBytes() == &buffer[0]);
+    VerifyOrQuit(memcmp(mutableData.GetBytes(), kData2, sizeof(kData2)) == 0);
+
+    memset(buffer, 0, sizeof(buffer));
+    mutableData.InitFrom(buffer);
+    SuccessOrQuit(mutableData.CopyBytesFrom(kData, sizeof(kData)));
+    VerifyOrQuit(mutableData == data);
+
+    memset(buffer, 0, sizeof(buffer));
+    SuccessOrQuit(mutableData.CopyBytesFrom(data));
+    VerifyOrQuit(mutableData == data);
+
+    memset(buffer, 0, sizeof(buffer));
+    mutableData.InitFromRange(&buffer[0], &buffer[2]);
+    VerifyOrQuit(mutableData.GetLength() == 2);
+    VerifyOrQuit(mutableData.GetBytes() == &buffer[0]);
+
+    VerifyOrQuit(mutableData.CopyBytesFrom(kData, sizeof(kData)) == kErrorNoBufs);
+    VerifyOrQuit(mutableData.GetLength() == 2);
+    VerifyOrQuit(mutableData.GetBytes() == &buffer[0]);
+    VerifyOrQuit(memcmp(mutableData.GetBytes(), kData, 2) == 0);
+
+    VerifyOrQuit(mutableData.CopyBytesFrom(data) == kErrorNoBufs);
+    VerifyOrQuit(mutableData.GetLength() == 2);
+    VerifyOrQuit(mutableData.GetBytes() == &buffer[0]);
+    VerifyOrQuit(memcmp(mutableData.GetBytes(), kData, 2) == 0);
+
+    memset(buffer, 0xff, sizeof(buffer));
+    mutableData.InitFrom(buffer);
+    VerifyOrQuit(mutableData.GetLength() == sizeof(buffer));
+    VerifyOrQuit(mutableData.GetBytes() == &buffer[0]);
+
+    u8 = 0xaa;
+    mutableData.InitFrom(u8);
+    VerifyOrQuit(mutableData.GetLength() == sizeof(u8));
+    VerifyOrQuit(mutableData.GetBytes() == &u8);
+    mutableData.ClearBytes();
+    VerifyOrQuit(u8 == 0);
+
+    u16 = 0x1234;
+    mutableData.InitFrom(u16);
+    VerifyOrQuit(mutableData.GetLength() == sizeof(u16));
+    VerifyOrQuit(mutableData.GetBytes() == reinterpret_cast<uint8_t *>(&u16));
+    mutableData.ClearBytes();
+    VerifyOrQuit(u16 == 0);
+
+    printf("- TestMutableData<%s> passed\n",
+           kDataLengthType == kWithUint8Length ? "kWithUint8Length" : "kWithUint16Length");
+}
+
+} // namespace ot
+
+int main(void)
+{
+    ot::TestData<ot::kWithUint8Length>();
+    ot::TestData<ot::kWithUint16Length>();
+    ot::TestMutableData<ot::kWithUint8Length>();
+    ot::TestMutableData<ot::kWithUint16Length>();
+
+    printf("All tests passed\n");
+    return 0;
+}

--- a/tests/unit/test_network_data.cpp
+++ b/tests/unit/test_network_data.cpp
@@ -229,20 +229,24 @@ public:
     {
     }
 
-    template <uint8_t kSize> Error AddService(const uint8_t (&aServiceData)[kSize])
+    Error AddService(const ServiceData &aServiceData)
     {
-        return Local::AddService(ServiceTlv::kThreadEnterpriseNumber, aServiceData, kSize, true, nullptr, 0);
+        return Local::AddService(ServiceTlv::kThreadEnterpriseNumber, aServiceData, true, ServerData());
     }
 
-    template <uint8_t kSize>
-    Error ValidateServiceData(const ServiceTlv *aServiceTlv, const uint8_t (&aServiceData)[kSize]) const
+    Error ValidateServiceData(const ServiceTlv *aServiceTlv, const ServiceData &aServiceData) const
     {
-        return
+        Error       error = kErrorFailed;
+        ServiceData serviceData;
 
-            ((aServiceTlv != nullptr) && (aServiceTlv->GetServiceDataLength() == kSize) &&
-             (memcmp(aServiceTlv->GetServiceData(), aServiceData, kSize) == 0))
-                ? kErrorNone
-                : kErrorFailed;
+        VerifyOrExit(aServiceTlv != nullptr);
+        aServiceTlv->GetServiceData(serviceData);
+
+        VerifyOrExit(aServiceData == serviceData);
+        error = kErrorNone;
+
+    exit:
+        return error;
     }
 
     void Test(void)
@@ -254,52 +258,53 @@ public:
         const uint8_t kServiceData5[] = {0x02, 0xab, 0xcd};
 
         const ServiceTlv *tlv;
+        ServiceData       serviceData1;
+        ServiceData       serviceData2;
+        ServiceData       serviceData3;
+        ServiceData       serviceData4;
+        ServiceData       serviceData5;
 
-        SuccessOrQuit(AddService(kServiceData1));
-        SuccessOrQuit(AddService(kServiceData2));
-        SuccessOrQuit(AddService(kServiceData3));
-        SuccessOrQuit(AddService(kServiceData4));
-        SuccessOrQuit(AddService(kServiceData5));
+        serviceData1.InitFrom(kServiceData1);
+        serviceData2.InitFrom(kServiceData2);
+        serviceData3.InitFrom(kServiceData3);
+        serviceData4.InitFrom(kServiceData4);
+        serviceData5.InitFrom(kServiceData5);
+
+        SuccessOrQuit(AddService(serviceData1));
+        SuccessOrQuit(AddService(serviceData2));
+        SuccessOrQuit(AddService(serviceData3));
+        SuccessOrQuit(AddService(serviceData4));
+        SuccessOrQuit(AddService(serviceData5));
 
         DumpBuffer("netdata", mTlvs, mLength);
 
         // Iterate through all entries that start with { 0x02 } (kServiceData1)
         tlv = nullptr;
-        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1),
-                              kServicePrefixMatch);
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData1));
-        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1),
-                              kServicePrefixMatch);
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData4));
-        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1),
-                              kServicePrefixMatch);
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData5));
-        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData1, sizeof(kServiceData1),
-                              kServicePrefixMatch);
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, serviceData1, kServicePrefixMatch);
+        SuccessOrQuit(ValidateServiceData(tlv, serviceData1));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, serviceData1, kServicePrefixMatch);
+        SuccessOrQuit(ValidateServiceData(tlv, serviceData4));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, serviceData1, kServicePrefixMatch);
+        SuccessOrQuit(ValidateServiceData(tlv, serviceData5));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, serviceData1, kServicePrefixMatch);
         VerifyOrQuit(tlv == nullptr, "FindNextService() returned extra TLV");
 
-        // Iterate through all entries that start with { 0xab } (kServiceData2)
+        // Iterate through all entries that start with { 0xab } (serviceData2)
         tlv = nullptr;
-        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData2, sizeof(kServiceData2),
-                              kServicePrefixMatch);
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData2));
-        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData2, sizeof(kServiceData2),
-                              kServicePrefixMatch);
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData3));
-        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData2, sizeof(kServiceData2),
-                              kServicePrefixMatch);
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, serviceData2, kServicePrefixMatch);
+        SuccessOrQuit(ValidateServiceData(tlv, serviceData2));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, serviceData2, kServicePrefixMatch);
+        SuccessOrQuit(ValidateServiceData(tlv, serviceData3));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, serviceData2, kServicePrefixMatch);
         VerifyOrQuit(tlv == nullptr, "FindNextService() returned extra TLV");
 
-        // Iterate through all entries that start with kServiceData5
+        // Iterate through all entries that start with serviceData5
         tlv = nullptr;
-        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData5, sizeof(kServiceData5),
-                              kServicePrefixMatch);
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData4));
-        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData5, sizeof(kServiceData5),
-                              kServicePrefixMatch);
-        SuccessOrQuit(ValidateServiceData(tlv, kServiceData5));
-        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, kServiceData5, sizeof(kServiceData5),
-                              kServicePrefixMatch);
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, serviceData5, kServicePrefixMatch);
+        SuccessOrQuit(ValidateServiceData(tlv, serviceData4));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, serviceData5, kServicePrefixMatch);
+        SuccessOrQuit(ValidateServiceData(tlv, serviceData5));
+        tlv = FindNextService(tlv, ServiceTlv::kThreadEnterpriseNumber, serviceData5, kServicePrefixMatch);
         VerifyOrQuit(tlv == nullptr, "FindNextService() returned extra TLV");
     }
 };


### PR DESCRIPTION
This PR contain two related commits:

**[common] adding `Data` and `MutableData`**

This commit adds two new generic types `Data` and `MutableData` which
are simply wrappers over a pointer to a buffer and a given data
length. The data length can be either `uint8_t` or `uint16_t` which
is determined by a template parameter. The `Data` treats the content
of the buffer as immutable  whereas `MutableData` allows it to be
changed. This commit also adds a unit test `tes_data` to verify the
behavior of newly added types.

**[netdata] add `ServiceData` and `ServerData` types**

This commit adds new types `NetworkData::ServiceData/ServerData`
(which use the `ot::Data` class) which help simplify different
`NetworkData` methods dealing with Service and Server TLVs.

------

Notes on this change:
- The model where we pass a pointer to a buffer along with its length is used in many places within OT core.
- The `Data` and `MutableData` provide a wrapper class over such data model
- In this PR we use them in Service and Server TLV (service/server data) but I think they can help simplify code in other places.