### PR TITLE
[message] update `Message:Settings` and the default settings

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (161)
+#define OPENTHREAD_API_VERSION (162)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/message.h
+++ b/include/openthread/message.h
@@ -103,8 +103,8 @@ typedef enum otMessagePriority
  */
 typedef struct otMessageSettings
 {
-    bool              mLinkSecurityEnabled; ///< TRUE if the message should be secured at Layer 2.
-    otMessagePriority mPriority;            ///< The message priority level.
+    bool    mLinkSecurityEnabled; ///< TRUE if the message should be secured at Layer 2.
+    uint8_t mPriority;            ///< Priority level (MUST be a `OT_MESSAGE_PRIORITY_*` from `otMessagePriority`).
 } otMessageSettings;
 
 /**

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -47,7 +47,7 @@ otMessage *otCoapNewMessage(otInstance *aInstance, const otMessageSettings *aSet
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.GetApplicationCoap().NewMessage(Message::Settings(aSettings));
+    return instance.GetApplicationCoap().NewMessage(Message::Settings::From(aSettings));
 }
 
 void otCoapMessageInit(otMessage *aMessage, otCoapType aType, otCoapCode aCode)

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -171,7 +171,7 @@ otMessage *otIp6NewMessage(otInstance *aInstance, const otMessageSettings *aSett
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Ip6::Ip6>().NewMessage(0, Message::Settings(aSettings));
+    return instance.Get<Ip6::Ip6>().NewMessage(0, Message::Settings::From(aSettings));
 }
 
 otMessage *otIp6NewMessageFromBuffer(otInstance *             aInstance,
@@ -184,7 +184,8 @@ otMessage *otIp6NewMessageFromBuffer(otInstance *             aInstance,
 
     if (aSettings != nullptr)
     {
-        message = instance.Get<Ip6::Ip6>().NewMessage(aData, aDataLength, Message::Settings(aSettings));
+        message =
+            instance.Get<Ip6::Ip6>().NewMessage(aData, aDataLength, *static_cast<const Message::Settings *>(aSettings));
     }
     else
     {

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -46,7 +46,7 @@ otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSett
 {
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    return instance.Get<Ip6::Udp>().NewMessage(0, Message::Settings(aSettings));
+    return instance.Get<Ip6::Udp>().NewMessage(0, Message::Settings::From(aSettings));
 }
 
 otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext)

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -193,18 +193,17 @@ uint16_t MessagePool::GetTotalBufferCount(void) const
 //---------------------------------------------------------------------------------------------------------------------
 // Message::Settings
 
-const Message::Settings Message::Settings::kDefault(Message::kWithLinkSecurity, Message::kPriorityNormal);
+const otMessageSettings Message::Settings::kDefault = {kWithLinkSecurity, kPriorityNormal};
 
 Message::Settings::Settings(LinkSecurityMode aSecurityMode, Priority aPriority)
-    : mLinkSecurityEnabled(aSecurityMode == kWithLinkSecurity)
-    , mPriority(aPriority)
 {
+    mLinkSecurityEnabled = aSecurityMode;
+    mPriority            = aPriority;
 }
 
-Message::Settings::Settings(const otMessageSettings *aSettings)
-    : mLinkSecurityEnabled((aSettings != nullptr) ? aSettings->mLinkSecurityEnabled : true)
-    , mPriority((aSettings != nullptr) ? static_cast<Priority>(aSettings->mPriority) : kPriorityNormal)
+const Message::Settings &Message::Settings::From(const otMessageSettings *aSettings)
 {
+    return (aSettings == nullptr) ? GetDefault() : *static_cast<const Settings *>(aSettings);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -307,10 +307,10 @@ public:
      * This enumeration represents the link security mode (used by `Settings` constructor).
      *
      */
-    enum LinkSecurityMode : uint8_t
+    enum LinkSecurityMode : bool
     {
-        kNoLinkSecurity,   ///< Link security disabled (no link security).
-        kWithLinkSecurity, ///< Link security enabled.
+        kNoLinkSecurity   = false, ///< Link security disabled (no link security).
+        kWithLinkSecurity = true,  ///< Link security enabled.
     };
 
     /**
@@ -339,7 +339,7 @@ public:
      * This class represents settings used for creating a new message.
      *
      */
-    class Settings
+    class Settings : public otMessageSettings
     {
     public:
         /**
@@ -352,21 +352,12 @@ public:
         Settings(LinkSecurityMode aSecurityMode, Priority aPriority);
 
         /**
-         * This constructor initializes the `Settings` object from a given `otMessageSettings`.
-         *
-         * @param[in] aSettings  A pointer to `otMessageSettings` to covert from. If nullptr default settings (link
-         *                       security enabled with `kPriorityNormal` priority) would be used.
-         *
-         */
-        explicit Settings(const otMessageSettings *aSettings);
-
-        /**
          * This method gets the message priority.
          *
          * @returns The message priority.
          *
          */
-        Priority GetPriority(void) const { return mPriority; }
+        Priority GetPriority(void) const { return static_cast<Priority>(mPriority); }
 
         /**
          * This method indicates whether the link security should be enabled.
@@ -377,18 +368,26 @@ public:
         bool IsLinkSecurityEnabled(void) const { return mLinkSecurityEnabled; }
 
         /**
+         * This static method converts a pointer to an `otMessageSettings` to a `Settings`.
+         *
+         * @param[in] aSettings  A pointer to `otMessageSettings` to covert from.
+         *                       If it is `nullptr`, then the default settings `GetDefault()` will be used.
+         *
+         * @returns A reference to the converted `Settings` or the default if @p aSettings is `nullptr`.
+         *
+         */
+        static const Settings &From(const otMessageSettings *aSettings);
+
+        /**
          * This static method returns the default settings with link security enabled and `kPriorityNormal` priority.
          *
          * @returns A reference to the default settings (link security enable and `kPriorityNormal` priority).
          *
          */
-        static const Settings &GetDefault(void) { return kDefault; }
+        static const Settings &GetDefault(void) { return static_cast<const Settings &>(kDefault); }
 
     private:
-        static const Settings kDefault;
-
-        bool     mLinkSecurityEnabled;
-        Priority mPriority;
+        static const otMessageSettings kDefault;
     };
 
     /**


### PR DESCRIPTION
This commit updates the `Message::Settings` such that it directly
inherits from the `otMessageSettings` C struct definition. This helps
simplify the initialization of the constant default `Settings`
instance (from `GetDefault()`) to avoid calling object constructor.
It also simplifies the conversion from an `otMessageSettings *` to
a `Settings` (if the pointer is not NULL, the `otMessageSetting`
instance itself can be directly used instead of creating a copy).