### PR TITLE
[mle] simplify `Start()`, `Stop()`, and `SendAnnounce()`

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -481,11 +481,11 @@ otError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
 
     if (aEnabled)
     {
-        error = instance.Get<Mle::MleRouter>().Start(/* aAnnounceAttach */ false);
+        error = instance.Get<Mle::MleRouter>().Start();
     }
     else
     {
-        instance.Get<Mle::MleRouter>().Stop(true);
+        instance.Get<Mle::MleRouter>().Stop();
     }
 
     return error;

--- a/src/core/thread/announce_sender.cpp
+++ b/src/core/thread/announce_sender.cpp
@@ -123,7 +123,7 @@ exit:
 
 void AnnounceSenderBase::HandleTimer(void)
 {
-    Get<Mle::MleRouter>().SendAnnounce(mChannel, false);
+    Get<Mle::MleRouter>().SendAnnounce(mChannel);
 
     // Go to the next channel in the mask. If we have reached the end
     // of the channel mask, we start over from the first channel in

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -188,7 +188,7 @@ Error Mle::Disable(void)
 {
     Error error = kErrorNone;
 
-    Stop(false);
+    Stop(kKeepNetworkDatasets);
     SuccessOrExit(error = mSocket.Close());
     Get<ThreadNetif>().RemoveUnicastAddress(mLinkLocal64);
 
@@ -196,7 +196,7 @@ exit:
     return error;
 }
 
-Error Mle::Start(bool aAnnounceAttach)
+Error Mle::Start(StartMode aMode)
 {
     Error error = kErrorNone;
 
@@ -218,12 +218,12 @@ Error Mle::Start(bool aAnnounceAttach)
 
     Get<KeyManager>().Start();
 
-    if (!aAnnounceAttach)
+    if (aMode == kNormalAttach)
     {
         mReattachState = kReattachStart;
     }
 
-    if (aAnnounceAttach || (GetRloc16() == Mac::kShortAddrInvalid))
+    if ((aMode == kAnnounceAttach) || (GetRloc16() == Mac::kShortAddrInvalid))
     {
         IgnoreError(BecomeChild(kAttachAny));
     }
@@ -246,9 +246,9 @@ exit:
     return error;
 }
 
-void Mle::Stop(bool aClearNetworkDatasets)
+void Mle::Stop(StopMode aMode)
 {
-    if (aClearNetworkDatasets)
+    if (aMode == kUpdateNetworkDatasets)
     {
         Get<MeshCoP::ActiveDataset>().HandleDetach();
         Get<MeshCoP::PendingDataset>().HandleDetach();
@@ -1808,7 +1808,7 @@ void Mle::HandleAttachTimer(void)
     case kAttachStateAnnounce:
         if (shouldAnnounce && (GetNextAnnouceChannel(mAnnounceChannel) == kErrorNone))
         {
-            SendAnnounce(mAnnounceChannel, /* aOrphanAnnounce */ true);
+            SendAnnounce(mAnnounceChannel, kOrphanAnnounce);
             delay = mAnnounceDelay;
             break;
         }
@@ -2462,16 +2462,16 @@ exit:
     return error;
 }
 
-void Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce)
+void Mle::SendAnnounce(uint8_t aChannel, AnnounceMode aMode)
 {
     Ip6::Address destination;
 
     destination.SetToLinkLocalAllNodesMulticast();
 
-    SendAnnounce(aChannel, aOrphanAnnounce, destination);
+    SendAnnounce(aChannel, destination, aMode);
 }
 
-void Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Address &aDestination)
+void Mle::SendAnnounce(uint8_t aChannel, const Ip6::Address &aDestination, AnnounceMode aMode)
 {
     Error              error = kErrorNone;
     ChannelTlv         channel;
@@ -2489,18 +2489,19 @@ void Mle::SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Addres
     channel.SetChannel(Get<Mac::Mac>().GetPanChannel());
     SuccessOrExit(error = channel.AppendTo(*message));
 
-    if (aOrphanAnnounce)
+    switch (aMode)
     {
+    case kOrphanAnnounce:
         activeTimestamp.Init();
         activeTimestamp.SetSeconds(0);
         activeTimestamp.SetTicks(0);
         activeTimestamp.SetAuthoritative(true);
-
         SuccessOrExit(error = activeTimestamp.AppendTo(*message));
-    }
-    else
-    {
+        break;
+
+    case kNormalAnnounce:
         SuccessOrExit(error = AppendActiveTimestamp(*message));
+        break;
     }
 
     SuccessOrExit(error = Tlv::Append<PanIdTlv>(*message, Get<Mac::Mac>().GetPanId()));
@@ -3944,10 +3945,10 @@ void Mle::HandleAnnounce(const Message &aMessage, const Ip6::MessageInfo &aMessa
     }
     else if (localTimestamp->Compare(timestamp) < 0)
     {
-        SendAnnounce(channel, false);
+        SendAnnounce(channel);
 
 #if OPENTHREAD_CONFIG_MLE_SEND_UNICAST_ANNOUNCE_RESPONSE
-        SendAnnounce(channel, false, aMessageInfo.GetPeerAddr());
+        SendAnnounce(channel, aMessageInfo.GetPeerAddr());
 #endif
     }
     else
@@ -4031,7 +4032,7 @@ void Mle::ProcessAnnounce(void)
 
     otLogNoteMle("Processing Announce - channel %d, panid 0x%02x", newChannel, newPanId);
 
-    Stop(/* aClearNetworkDatasets */ false);
+    Stop(kKeepNetworkDatasets);
 
     // Save the current/previous channel and pan-id
     mAlternateChannel   = Get<Mac::Mac>().GetPanChannel();
@@ -4041,7 +4042,7 @@ void Mle::ProcessAnnounce(void)
     IgnoreError(Get<Mac::Mac>().SetPanChannel(newChannel));
     Get<Mac::Mac>().SetPanId(newPanId);
 
-    IgnoreError(Start(/* aAnnounceAttach */ true));
+    IgnoreError(Start(kAnnounceAttach));
 }
 
 uint16_t Mle::GetNextHop(uint16_t aDestination) const

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -129,22 +129,17 @@ public:
     /**
      * This method starts the MLE protocol operation.
      *
-     * @param[in]  aAnnounceAttach True if attach on the announced thread network with newer active timestamp,
-     *                             or False if not.
-     *
      * @retval kErrorNone           Successfully started the protocol operation.
      * @retval kErrorInvalidState   IPv6 interface is down or device is in raw-link mode.
      *
      */
-    Error Start(bool aAnnounceAttach);
+    Error Start(void) { return Start(kNormalAttach); }
 
     /**
      * This method stops the MLE protocol operation.
      *
-     * @param[in]  aClearNetworkDatasets  True to clear network datasets, False not.
-     *
      */
-    void Stop(bool aClearNetworkDatasets);
+    void Stop(void) { Stop(kUpdateNetworkDatasets); }
 
     /**
      * This method restores network information from non-volatile memory.
@@ -168,10 +163,9 @@ public:
      * This method generates an MLE Announce message.
      *
      * @param[in]  aChannel        The channel to use when transmitting.
-     * @param[in]  aOrphanAnnounce To indicate if MLE Announce is sent from an orphan end device.
      *
      */
-    void SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce);
+    void SendAnnounce(uint8_t aChannel) { SendAnnounce(aChannel, kNormalAnnounce); }
 
     /**
      * This method causes the Thread interface to detach from the Thread network.
@@ -1630,6 +1624,24 @@ private:
     static constexpr uint32_t kAttachBackoffDelayToResetCounter =
         OPENTHREAD_CONFIG_MLE_ATTACH_BACKOFF_DELAY_TO_RESET_BACKOFF_INTERVAL;
 
+    enum StartMode : uint8_t // Used in `Start()`.
+    {
+        kNormalAttach,
+        kAnnounceAttach, // Try to attach on the announced thread network with newer active timestamp.
+    };
+
+    enum StopMode : uint8_t // Used in `Stop()`.
+    {
+        kKeepNetworkDatasets,
+        kUpdateNetworkDatasets,
+    };
+
+    enum AnnounceMode : uint8_t // Used in `SendAnnounce()`
+    {
+        kNormalAnnounce,
+        kOrphanAnnounce,
+    };
+
     enum ParentRequestType : uint8_t
     {
         kParentRequestTypeRouters,         // Parent Request to all routers.
@@ -1751,6 +1763,8 @@ private:
         uint8_t  mCommand;
     } OT_TOOL_PACKED_END;
 
+    Error       Start(StartMode aMode);
+    void        Stop(StopMode aMode);
     void        HandleNotifierEvents(Events aEvents);
     static void HandleAttachTimer(Timer &aTimer);
     void        HandleAttachTimer(void);
@@ -1797,7 +1811,8 @@ private:
     Error    GetNextAnnouceChannel(uint8_t &aChannel) const;
     bool     HasMoreChannelsToAnnouce(void) const;
     bool     PrepareAnnounceState(void);
-    void     SendAnnounce(uint8_t aChannel, bool aOrphanAnnounce, const Ip6::Address &aDestination);
+    void     SendAnnounce(uint8_t aChannel, AnnounceMode aMode);
+    void     SendAnnounce(uint8_t aChannel, const Ip6::Address &aDestination, AnnounceMode aMode = kNormalAnnounce);
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
     Error SendLinkMetricsManagementResponse(const Ip6::Address &aDestination, LinkMetrics::Status aStatus);
 #endif


### PR DESCRIPTION
This commit updates `Start()`, `Stop()` and `SendAnnounce()` in `Mle`
to remove the extra parameters from the `public` versions of these
methods (adding a `private` version with extra parameter for use by
`Mle` class itself). It also adds `StartMode`, `StopMode`, and
`AnnounceMode` enumerations to use as parameter type (instead of
`bool`) in these methods which helps with code readability.