### PR TITLE
[network-name] implement additional validation rules

### DIFF
--- a/src/core/common/string.cpp
+++ b/src/core/common/string.cpp
@@ -172,6 +172,8 @@ bool IsValidUtf8String(const char *aString, size_t aLength)
 
         if ((byte & 0x80) == 0)
         {
+            // We don't allow control characters.
+            VerifyOrExit(!iscntrl(byte), ret = false);
             continue;
         }
 

--- a/src/core/common/string.hpp
+++ b/src/core/common/string.hpp
@@ -237,6 +237,7 @@ private:
 
 /**
  * This function validates whether a given byte sequence (string) follows UTF-8 encoding.
+ * Control characters are not allowed.
  *
  * @param[in]  aString  A null-terminated byte sequence.
  *
@@ -248,6 +249,7 @@ bool IsValidUtf8String(const char *aString);
 
 /**
  * This function validates whether a given byte sequence (string) follows UTF-8 encoding.
+ * Control characters are not allowed.
  *
  * @param[in]  aString  A byte sequence.
  * @param[in]  aLength  Length of the sequence.

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -155,6 +155,7 @@ Error NetworkName::Set(const char *aNameString)
     Error    error;
     NameData data(aNameString, kMaxSize + 1);
 
+    VerifyOrExit(data.GetLength() >= 1, error = kErrorInvalidArgs);
     VerifyOrExit(IsValidUtf8String(aNameString), error = kErrorInvalidArgs);
 
     error = Set(data);

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -136,7 +136,7 @@ void NetworkNameTlv::SetNetworkName(const Mac::NameData &aNameData)
 
 bool NetworkNameTlv::IsValid(void) const
 {
-    return IsValidUtf8String(mNetworkName, GetLength());
+    return GetLength() >= 1 && IsValidUtf8String(mNetworkName, GetLength());
 }
 
 void SteeringDataTlv::CopyTo(SteeringData &aSteeringData) const

--- a/tests/unit/test_string.cpp
+++ b/tests/unit/test_string.cpp
@@ -138,6 +138,8 @@ void TestUtf8(void)
     VerifyOrQuit(!IsValidUtf8String("\xef\x80"));
     VerifyOrQuit(!IsValidUtf8String("\xf7\x80\x80"));
     VerifyOrQuit(!IsValidUtf8String("\xff"));
+    VerifyOrQuit(!IsValidUtf8String("NUL\x00NUL", 7)); // UTF-8 NUL
+    VerifyOrQuit(!IsValidUtf8String("abcde\x11"));     // control character
 
     printf(" -- PASS\n");
 }


### PR DESCRIPTION
According to [SPEC-981](https://threadgroup.atlassian.net/browse/SPEC-981), we need to verify 3 more things while setting a network name:

1. The name length >= 1.
2. There are no UTF control characters in the name.
3. There are no UTF NUL characters in the name. This is covered by the second rule.