### PR TITLE
[github-actions] fix brew install issue on macOS

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -270,6 +270,7 @@ jobs:
         submodules: true
     - name: Bootstrap
       run: |
+        rm -f '/usr/local/bin/2to3'
         brew update
         brew install automake m4 ninja
         [ ${{ matrix.CC }} != clang ] || brew install llvm

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -230,6 +230,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Bootstrap
       run: |
+        rm -f '/usr/local/bin/2to3'
         brew update
         brew install ninja socat
     - name: Build


### PR DESCRIPTION
This is a PR attempting to fix https://github.com/openthread/openthread/issues/6989. 

When `brew install ninja`, python 3.9 is being installed as a dependency. However, the installation failed because there is a conflict on binary `/usr/local/bin/2to3`.