### PR TITLE
[cli] fix warning of strncpy

### DIFF
--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -533,8 +533,9 @@ otError Coap::ProcessRequest(Arg aArgs[], otCoapCode aCoapCode)
         memcpy(&mRequestAddr, &coapDestinationIp, sizeof(mRequestAddr));
         mRequestTokenLength = otCoapMessageGetTokenLength(message);
         memcpy(mRequestToken, otCoapMessageGetToken(message), mRequestTokenLength);
-        strncpy(mRequestUri, coapUri, sizeof(mRequestUri) - 1);
-        mRequestUri[sizeof(mRequestUri) - 1] = '\0'; // Fix gcc-9.2 warning
+        // Use `memcpy` instead of `strncpy` here because GCC will give warnings for `strncpy` when the dest's length is
+        // not bigger than the src's length.
+        memcpy(mRequestUri, coapUri, sizeof(mRequestUri) - 1);
     }
 #endif
 


### PR DESCRIPTION
I still got such warning:
```
warning: ‘char* strncpy(char*, const char*, size_t)’ output may be truncated copying 31 bytes from a string of length 31 (make distcheck)
```
when building `dist-check`: `make -f examples/Makefile-simulation distcheck`

My gcc version is: **gcc version 10.2.1 20210110 (Debian 10.2.1-6+build2)**

This PR fixes the warning. Using `memcpy` seems to be simplest, most efficient way.