### PR TITLE
[common] adding `AsCoreType()` to covert from public to core types

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (163)
+#define OPENTHREAD_API_VERSION (164)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/srp_server.h
+++ b/include/openthread/srp_server.h
@@ -59,13 +59,13 @@ extern "C" {
  * This opaque type represents a SRP service host.
  *
  */
-typedef void otSrpServerHost;
+typedef struct otSrpServerHost otSrpServerHost;
 
 /**
  * This opaque type represents a SRP service.
  *
  */
-typedef void otSrpServerService;
+typedef struct otSrpServerService otSrpServerService;
 
 /**
  * The ID of a SRP service update transaction on the SRP Server.

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -369,6 +369,7 @@ openthread_core_files = [
   "coap/coap_secure.hpp",
   "common/arg_macros.hpp",
   "common/array.hpp",
+  "common/as_core_type.hpp",
   "common/bit_vector.hpp",
   "common/clearable.hpp",
   "common/code_utils.hpp",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -389,6 +389,7 @@ HEADERS_COMMON                                  = \
     coap/coap_secure.hpp                          \
     common/arg_macros.hpp                         \
     common/array.hpp                              \
+    common/as_core_type.hpp                       \
     common/bit_vector.hpp                         \
     common/clearable.hpp                          \
     common/code_utils.hpp                         \

--- a/src/core/api/backbone_router_api.cpp
+++ b/src/core/api/backbone_router_api.cpp
@@ -36,17 +36,17 @@
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 
 #include <openthread/backbone_router.h>
-#include "common/instance.hpp"
+
+#include "common/as_core_type.hpp"
+#include "common/locator_getters.hpp"
 
 using namespace ot;
 
 otError otBackboneRouterGetPrimary(otInstance *aInstance, otBackboneRouterConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aConfig != nullptr);
 
-    return instance.Get<BackboneRouter::Leader>().GetConfig(*aConfig);
+    return AsCoreType(aInstance).Get<BackboneRouter::Leader>().GetConfig(*aConfig);
 }
 
 #endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)

--- a/src/core/api/backbone_router_ftd_api.cpp
+++ b/src/core/api/backbone_router_ftd_api.cpp
@@ -38,80 +38,62 @@
 
 #include <openthread/backbone_router_ftd.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
+#include "common/locator_getters.hpp"
 
 using namespace ot;
 
 void otBackboneRouterSetEnabled(otInstance *aInstance, bool aEnabled)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<BackboneRouter::Local>().SetEnabled(aEnabled);
+    return AsCoreType(aInstance).Get<BackboneRouter::Local>().SetEnabled(aEnabled);
 }
 
 otBackboneRouterState otBackboneRouterGetState(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<BackboneRouter::Local>().GetState();
+    return AsCoreType(aInstance).Get<BackboneRouter::Local>().GetState();
 }
 
 void otBackboneRouterGetConfig(otInstance *aInstance, otBackboneRouterConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aConfig != nullptr);
 
-    instance.Get<BackboneRouter::Local>().GetConfig(*aConfig);
+    AsCoreType(aInstance).Get<BackboneRouter::Local>().GetConfig(*aConfig);
 }
 
 otError otBackboneRouterSetConfig(otInstance *aInstance, const otBackboneRouterConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aConfig != nullptr);
 
-    return instance.Get<BackboneRouter::Local>().SetConfig(*aConfig);
+    return AsCoreType(aInstance).Get<BackboneRouter::Local>().SetConfig(*aConfig);
 }
 
 otError otBackboneRouterRegister(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<BackboneRouter::Local>().AddService(true /* Force registration */);
+    return AsCoreType(aInstance).Get<BackboneRouter::Local>().AddService(true /* Force registration */);
 }
 
 uint8_t otBackboneRouterGetRegistrationJitter(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<BackboneRouter::Local>().GetRegistrationJitter();
+    return AsCoreType(aInstance).Get<BackboneRouter::Local>().GetRegistrationJitter();
 }
 
 void otBackboneRouterSetRegistrationJitter(otInstance *aInstance, uint8_t aJitter)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<BackboneRouter::Local>().SetRegistrationJitter(aJitter);
+    return AsCoreType(aInstance).Get<BackboneRouter::Local>().SetRegistrationJitter(aJitter);
 }
 
 otError otBackboneRouterGetDomainPrefix(otInstance *aInstance, otBorderRouterConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aConfig != nullptr);
 
-    return instance.Get<BackboneRouter::Local>().GetDomainPrefix(
-        *static_cast<NetworkData::OnMeshPrefixConfig *>(aConfig));
+    return AsCoreType(aInstance).Get<BackboneRouter::Local>().GetDomainPrefix(AsCoreType(aConfig));
 }
 
 void otBackboneRouterSetDomainPrefixCallback(otInstance *                         aInstance,
                                              otBackboneRouterDomainPrefixCallback aCallback,
                                              void *                               aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<BackboneRouter::Local>().SetDomainPrefixCallback(aCallback, aContext);
+    return AsCoreType(aInstance).Get<BackboneRouter::Local>().SetDomainPrefixCallback(aCallback, aContext);
 }
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
@@ -119,19 +101,15 @@ void otBackboneRouterSetNdProxyCallback(otInstance *                    aInstanc
                                         otBackboneRouterNdProxyCallback aCallback,
                                         void *                          aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<BackboneRouter::NdProxyTable>().SetCallback(aCallback, aContext);
+    AsCoreType(aInstance).Get<BackboneRouter::NdProxyTable>().SetCallback(aCallback, aContext);
 }
 
 otError otBackboneRouterGetNdProxyInfo(otInstance *                 aInstance,
                                        const otIp6Address *         aDua,
                                        otBackboneRouterNdProxyInfo *aNdProxyInfo)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<BackboneRouter::NdProxyTable>().GetInfo(reinterpret_cast<const Ip6::Address &>(*aDua),
-                                                                *aNdProxyInfo);
+    return AsCoreType(aInstance).Get<BackboneRouter::NdProxyTable>().GetInfo(
+        reinterpret_cast<const Ip6::Address &>(*aDua), *aNdProxyInfo);
 }
 #endif // OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
 
@@ -140,21 +118,17 @@ void otBackboneRouterSetMulticastListenerCallback(otInstance *                  
                                                   otBackboneRouterMulticastListenerCallback aCallback,
                                                   void *                                    aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<BackboneRouter::MulticastListenersTable>().SetCallback(aCallback, aContext);
+    AsCoreType(aInstance).Get<BackboneRouter::MulticastListenersTable>().SetCallback(aCallback, aContext);
 }
 
 otError otBackboneRouterMulticastListenerGetNext(otInstance *                           aInstance,
                                                  otChildIp6AddressIterator *            aIterator,
                                                  otBackboneRouterMulticastListenerInfo *aListenerInfo)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aIterator != nullptr);
     OT_ASSERT(aListenerInfo != nullptr);
 
-    return instance.Get<BackboneRouter::MulticastListenersTable>().GetNext(*aIterator, *aListenerInfo);
+    return AsCoreType(aInstance).Get<BackboneRouter::MulticastListenersTable>().GetNext(*aIterator, *aListenerInfo);
 }
 #endif
 
@@ -164,41 +138,33 @@ void otBackboneRouterConfigNextDuaRegistrationResponse(otInstance *             
                                                        const otIp6InterfaceIdentifier *aMlIid,
                                                        uint8_t                         aStatus)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<BackboneRouter::Manager>().ConfigNextDuaRegistrationResponse(
-        static_cast<const Ip6::InterfaceIdentifier *>(aMlIid), aStatus);
+    AsCoreType(aInstance).Get<BackboneRouter::Manager>().ConfigNextDuaRegistrationResponse(AsCoreTypePtr(aMlIid),
+                                                                                           aStatus);
 }
 #endif
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
 void otBackboneRouterConfigNextMulticastListenerRegistrationResponse(otInstance *aInstance, uint8_t aStatus)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aStatus <= ThreadStatusTlv::kMlrStatusMax);
 
-    instance.Get<BackboneRouter::Manager>().ConfigNextMulticastListenerRegistrationResponse(
+    AsCoreType(aInstance).Get<BackboneRouter::Manager>().ConfigNextMulticastListenerRegistrationResponse(
         static_cast<ThreadStatusTlv::MlrStatus>(aStatus));
 }
 
 void otBackboneRouterMulticastListenerClear(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<BackboneRouter::MulticastListenersTable>().Clear();
+    AsCoreType(aInstance).Get<BackboneRouter::MulticastListenersTable>().Clear();
 }
 
 otError otBackboneRouterMulticastListenerAdd(otInstance *aInstance, const otIp6Address *aAddress, uint32_t aTimeout)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aAddress != nullptr);
 
     if (aTimeout == 0)
     {
         BackboneRouter::BackboneRouterConfig config;
-        instance.Get<BackboneRouter::Local>().GetConfig(config);
+        AsCoreType(aInstance).Get<BackboneRouter::Local>().GetConfig(config);
         aTimeout = config.mMlrTimeout;
     }
 
@@ -206,8 +172,8 @@ otError otBackboneRouterMulticastListenerAdd(otInstance *aInstance, const otIp6A
         aTimeout > static_cast<uint32_t>(Mle::kMlrTimeoutMax) ? static_cast<uint32_t>(Mle::kMlrTimeoutMax) : aTimeout;
     aTimeout = Time::SecToMsec(aTimeout);
 
-    return instance.Get<BackboneRouter::MulticastListenersTable>().Add(static_cast<const Ip6::Address &>(*aAddress),
-                                                                       TimerMilli::GetNow() + aTimeout);
+    return AsCoreType(aInstance).Get<BackboneRouter::MulticastListenersTable>().Add(AsCoreType(aAddress),
+                                                                                    TimerMilli::GetNow() + aTimeout);
 }
 #endif // OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
 #endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE

--- a/src/core/api/border_agent_api.cpp
+++ b/src/core/api/border_agent_api.cpp
@@ -37,23 +37,19 @@
 
 #include <openthread/border_agent.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
 
 otBorderAgentState otBorderAgentGetState(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return static_cast<otBorderAgentState>(instance.Get<MeshCoP::BorderAgent>().GetState());
+    return MapEnum(AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().GetState());
 }
 
 uint16_t otBorderAgentGetUdpPort(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::BorderAgent>().GetUdpPort();
+    return AsCoreType(aInstance).Get<MeshCoP::BorderAgent>().GetUdpPort();
 }
 
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -38,68 +38,56 @@
 #include <openthread/border_router.h>
 
 #include "border_router/routing_manager.hpp"
+#include "common/as_core_type.hpp"
 #include "common/debug.hpp"
-#include "common/instance.hpp"
 
 using namespace ot;
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex, bool aInfraIfIsRunning)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<BorderRouter::RoutingManager>().Init(aInfraIfIndex, aInfraIfIsRunning);
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().Init(aInfraIfIndex, aInfraIfIsRunning);
 }
 
 otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<BorderRouter::RoutingManager>().SetEnabled(aEnabled);
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().SetEnabled(aEnabled);
 }
 
 otError otBorderRoutingGetOmrPrefix(otInstance *aInstance, otIp6Prefix *aPrefix)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<BorderRouter::RoutingManager>().GetOmrPrefix(static_cast<Ip6::Prefix &>(*aPrefix));
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetOmrPrefix(AsCoreType(aPrefix));
 }
 
 otError otBorderRoutingGetOnLinkPrefix(otInstance *aInstance, otIp6Prefix *aPrefix)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<BorderRouter::RoutingManager>().GetOnLinkPrefix(static_cast<Ip6::Prefix &>(*aPrefix));
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetOnLinkPrefix(AsCoreType(aPrefix));
 }
 
 #endif
 
 otError otBorderRouterGetNetData(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aData != nullptr && aDataLength != nullptr);
 
-    return instance.Get<NetworkData::Local>().GetNetworkData(aStable, aData, *aDataLength);
+    return AsCoreType(aInstance).Get<NetworkData::Local>().GetNetworkData(aStable, aData, *aDataLength);
 }
 
 otError otBorderRouterAddOnMeshPrefix(otInstance *aInstance, const otBorderRouterConfig *aConfig)
 {
-    Error                                  error    = kErrorNone;
-    Instance &                             instance = *static_cast<Instance *>(aInstance);
-    const NetworkData::OnMeshPrefixConfig *config   = static_cast<const NetworkData::OnMeshPrefixConfig *>(aConfig);
+    Error error = kErrorNone;
 
     OT_ASSERT(aConfig != nullptr);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     if (aConfig->mDp)
     {
-        error = instance.Get<BackboneRouter::Local>().SetDomainPrefix(*config);
+        error = AsCoreType(aInstance).Get<BackboneRouter::Local>().SetDomainPrefix(AsCoreType(aConfig));
     }
     else
 #endif
     {
-        error = instance.Get<NetworkData::Local>().AddOnMeshPrefix(*config);
+        error = AsCoreType(aInstance).Get<NetworkData::Local>().AddOnMeshPrefix(AsCoreType(aConfig));
     }
 
     return error;
@@ -107,19 +95,17 @@ otError otBorderRouterAddOnMeshPrefix(otInstance *aInstance, const otBorderRoute
 
 otError otBorderRouterRemoveOnMeshPrefix(otInstance *aInstance, const otIp6Prefix *aPrefix)
 {
-    Error              error    = kErrorNone;
-    Instance &         instance = *static_cast<Instance *>(aInstance);
-    const Ip6::Prefix *prefix   = static_cast<const Ip6::Prefix *>(aPrefix);
+    Error error = kErrorNone;
 
     OT_ASSERT(aPrefix != nullptr);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    error = instance.Get<BackboneRouter::Local>().RemoveDomainPrefix(*prefix);
+    error = AsCoreType(aInstance).Get<BackboneRouter::Local>().RemoveDomainPrefix(AsCoreType(aPrefix));
 
     if (error == kErrorNotFound)
 #endif
     {
-        error = instance.Get<NetworkData::Local>().RemoveOnMeshPrefix(*prefix);
+        error = AsCoreType(aInstance).Get<NetworkData::Local>().RemoveOnMeshPrefix(AsCoreType(aPrefix));
     }
 
     return error;
@@ -129,50 +115,37 @@ otError otBorderRouterGetNextOnMeshPrefix(otInstance *           aInstance,
                                           otNetworkDataIterator *aIterator,
                                           otBorderRouterConfig * aConfig)
 {
-    Instance &                       instance = *static_cast<Instance *>(aInstance);
-    NetworkData::OnMeshPrefixConfig *config   = static_cast<NetworkData::OnMeshPrefixConfig *>(aConfig);
-
     OT_ASSERT(aIterator != nullptr && aConfig != nullptr);
 
-    return instance.Get<NetworkData::Local>().GetNextOnMeshPrefix(*aIterator, *config);
+    return AsCoreType(aInstance).Get<NetworkData::Local>().GetNextOnMeshPrefix(*aIterator, AsCoreType(aConfig));
 }
 
 otError otBorderRouterAddRoute(otInstance *aInstance, const otExternalRouteConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aConfig != nullptr);
 
-    return instance.Get<NetworkData::Local>().AddHasRoutePrefix(
-        *static_cast<const NetworkData::ExternalRouteConfig *>(aConfig));
+    return AsCoreType(aInstance).Get<NetworkData::Local>().AddHasRoutePrefix(AsCoreType(aConfig));
 }
 
 otError otBorderRouterRemoveRoute(otInstance *aInstance, const otIp6Prefix *aPrefix)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aPrefix != nullptr);
 
-    return instance.Get<NetworkData::Local>().RemoveHasRoutePrefix(*static_cast<const Ip6::Prefix *>(aPrefix));
+    return AsCoreType(aInstance).Get<NetworkData::Local>().RemoveHasRoutePrefix(AsCoreType(aPrefix));
 }
 
 otError otBorderRouterGetNextRoute(otInstance *           aInstance,
                                    otNetworkDataIterator *aIterator,
                                    otExternalRouteConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aIterator != nullptr && aConfig != nullptr);
 
-    return instance.Get<NetworkData::Local>().GetNextExternalRoute(
-        *aIterator, *static_cast<NetworkData::ExternalRouteConfig *>(aConfig));
+    return AsCoreType(aInstance).Get<NetworkData::Local>().GetNextExternalRoute(*aIterator, AsCoreType(aConfig));
 }
 
 otError otBorderRouterRegister(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<NetworkData::Notifier>().HandleServerDataUpdated();
+    AsCoreType(aInstance).Get<NetworkData::Notifier>().HandleServerDataUpdated();
 
     return kErrorNone;
 }

--- a/src/core/api/channel_manager_api.cpp
+++ b/src/core/api/channel_manager_api.cpp
@@ -37,7 +37,7 @@
 
 #include <openthread/channel_manager.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 #include "utils/channel_manager.hpp"
 
@@ -45,109 +45,79 @@ using namespace ot;
 
 void otChannelManagerRequestChannelChange(otInstance *aInstance, uint8_t aChannel)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Utils::ChannelManager>().RequestChannelChange(aChannel);
+    AsCoreType(aInstance).Get<Utils::ChannelManager>().RequestChannelChange(aChannel);
 }
 
 uint8_t otChannelManagerGetRequestedChannel(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelManager>().GetRequestedChannel();
+    return AsCoreType(aInstance).Get<Utils::ChannelManager>().GetRequestedChannel();
 }
 
 uint16_t otChannelManagerGetDelay(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelManager>().GetDelay();
+    return AsCoreType(aInstance).Get<Utils::ChannelManager>().GetDelay();
 }
 
 otError otChannelManagerSetDelay(otInstance *aInstance, uint16_t aDelay)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelManager>().SetDelay(aDelay);
+    return AsCoreType(aInstance).Get<Utils::ChannelManager>().SetDelay(aDelay);
 }
 
 #if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
 otError otChannelManagerRequestChannelSelect(otInstance *aInstance, bool aSkipQualityCheck)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelManager>().RequestChannelSelect(aSkipQualityCheck);
+    return AsCoreType(aInstance).Get<Utils::ChannelManager>().RequestChannelSelect(aSkipQualityCheck);
 }
 #endif
 
 void otChannelManagerSetAutoChannelSelectionEnabled(otInstance *aInstance, bool aEnabled)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Utils::ChannelManager>().SetAutoChannelSelectionEnabled(aEnabled);
+    AsCoreType(aInstance).Get<Utils::ChannelManager>().SetAutoChannelSelectionEnabled(aEnabled);
 }
 
 bool otChannelManagerGetAutoChannelSelectionEnabled(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelManager>().GetAutoChannelSelectionEnabled();
+    return AsCoreType(aInstance).Get<Utils::ChannelManager>().GetAutoChannelSelectionEnabled();
 }
 
 otError otChannelManagerSetAutoChannelSelectionInterval(otInstance *aInstance, uint32_t aInterval)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelManager>().SetAutoChannelSelectionInterval(aInterval);
+    return AsCoreType(aInstance).Get<Utils::ChannelManager>().SetAutoChannelSelectionInterval(aInterval);
 }
 
 uint32_t otChannelManagerGetAutoChannelSelectionInterval(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelManager>().GetAutoChannelSelectionInterval();
+    return AsCoreType(aInstance).Get<Utils::ChannelManager>().GetAutoChannelSelectionInterval();
 }
 
 uint32_t otChannelManagerGetSupportedChannels(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelManager>().GetSupportedChannels();
+    return AsCoreType(aInstance).Get<Utils::ChannelManager>().GetSupportedChannels();
 }
 
 void otChannelManagerSetSupportedChannels(otInstance *aInstance, uint32_t aChannelMask)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelManager>().SetSupportedChannels(aChannelMask);
+    return AsCoreType(aInstance).Get<Utils::ChannelManager>().SetSupportedChannels(aChannelMask);
 }
 
 uint32_t otChannelManagerGetFavoredChannels(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelManager>().GetFavoredChannels();
+    return AsCoreType(aInstance).Get<Utils::ChannelManager>().GetFavoredChannels();
 }
 
 void otChannelManagerSetFavoredChannels(otInstance *aInstance, uint32_t aChannelMask)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelManager>().SetFavoredChannels(aChannelMask);
+    return AsCoreType(aInstance).Get<Utils::ChannelManager>().SetFavoredChannels(aChannelMask);
 }
 
 uint16_t otChannelManagerGetCcaFailureRateThreshold(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelManager>().GetCcaFailureRateThreshold();
+    return AsCoreType(aInstance).Get<Utils::ChannelManager>().GetCcaFailureRateThreshold();
 }
 
 void otChannelManagerSetCcaFailureRateThreshold(otInstance *aInstance, uint16_t aThreshold)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelManager>().SetCcaFailureRateThreshold(aThreshold);
+    return AsCoreType(aInstance).Get<Utils::ChannelManager>().SetCcaFailureRateThreshold(aThreshold);
 }
 
 #endif // OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD

--- a/src/core/api/channel_monitor_api.cpp
+++ b/src/core/api/channel_monitor_api.cpp
@@ -37,23 +37,21 @@
 
 #include <openthread/channel_monitor.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
 
 otError otChannelMonitorSetEnabled(otInstance *aInstance, bool aEnabled)
 {
-    Utils::ChannelMonitor &monitor = static_cast<Instance *>(aInstance)->Get<Utils::ChannelMonitor>();
+    Utils::ChannelMonitor &monitor = AsCoreType(aInstance).Get<Utils::ChannelMonitor>();
 
     return aEnabled ? monitor.Start() : monitor.Stop();
 }
 
 bool otChannelMonitorIsEnabled(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelMonitor>().IsRunning();
+    return AsCoreType(aInstance).Get<Utils::ChannelMonitor>().IsRunning();
 }
 
 uint32_t otChannelMonitorGetSampleInterval(otInstance *aInstance)
@@ -79,16 +77,12 @@ uint32_t otChannelMonitorGetSampleWindow(otInstance *aInstance)
 
 uint32_t otChannelMonitorGetSampleCount(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelMonitor>().GetSampleCount();
+    return AsCoreType(aInstance).Get<Utils::ChannelMonitor>().GetSampleCount();
 }
 
 uint16_t otChannelMonitorGetChannelOccupancy(otInstance *aInstance, uint8_t aChannel)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChannelMonitor>().GetChannelOccupancy(aChannel);
+    return AsCoreType(aInstance).Get<Utils::ChannelMonitor>().GetChannelOccupancy(aChannel);
 }
 
 #endif // OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE

--- a/src/core/api/child_supervision_api.cpp
+++ b/src/core/api/child_supervision_api.cpp
@@ -37,7 +37,7 @@
 
 #include <openthread/child_supervision.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
@@ -46,32 +46,24 @@ using namespace ot;
 
 uint16_t otChildSupervisionGetInterval(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::ChildSupervisor>().GetSupervisionInterval();
+    return AsCoreType(aInstance).Get<Utils::ChildSupervisor>().GetSupervisionInterval();
 }
 
 void otChildSupervisionSetInterval(otInstance *aInstance, uint16_t aInterval)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Utils::ChildSupervisor>().SetSupervisionInterval(aInterval);
+    AsCoreType(aInstance).Get<Utils::ChildSupervisor>().SetSupervisionInterval(aInterval);
 }
 
 #endif
 
 uint16_t otChildSupervisionGetCheckTimeout(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::SupervisionListener>().GetTimeout();
+    return AsCoreType(aInstance).Get<Utils::SupervisionListener>().GetTimeout();
 }
 
 void otChildSupervisionSetCheckTimeout(otInstance *aInstance, uint16_t aTimeout)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Utils::SupervisionListener>().SetTimeout(aTimeout);
+    AsCoreType(aInstance).Get<Utils::SupervisionListener>().SetTimeout(aTimeout);
 }
 
 #endif // OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -38,29 +38,27 @@
 #include <openthread/coap.h>
 
 #include "coap/coap_message.hpp"
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
 
 otMessage *otCoapNewMessage(otInstance *aInstance, const otMessageSettings *aSettings)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoap().NewMessage(Message::Settings::From(aSettings));
+    return AsCoreType(aInstance).GetApplicationCoap().NewMessage(Message::Settings::From(aSettings));
 }
 
 void otCoapMessageInit(otMessage *aMessage, otCoapType aType, otCoapCode aCode)
 {
-    static_cast<Coap::Message *>(aMessage)->Init(static_cast<Coap::Type>(aType), static_cast<Coap::Code>(aCode));
+    AsCoapMessage(aMessage).Init(MapEnum(aType), MapEnum(aCode));
 }
 
 otError otCoapMessageInitResponse(otMessage *aResponse, const otMessage *aRequest, otCoapType aType, otCoapCode aCode)
 {
-    Coap::Message &      response = *static_cast<Coap::Message *>(aResponse);
-    const Coap::Message &request  = *static_cast<const Coap::Message *>(aRequest);
+    Coap::Message &      response = AsCoapMessage(aResponse);
+    const Coap::Message &request  = AsCoapMessage(aRequest);
 
-    response.Init(static_cast<Coap::Type>(aType), static_cast<Coap::Code>(aCode));
+    response.Init(MapEnum(aType), MapEnum(aCode));
     response.SetMessageId(request.GetMessageId());
 
     return response.SetTokenFromMessage(request);
@@ -68,37 +66,37 @@ otError otCoapMessageInitResponse(otMessage *aResponse, const otMessage *aReques
 
 otError otCoapMessageSetToken(otMessage *aMessage, const uint8_t *aToken, uint8_t aTokenLength)
 {
-    return static_cast<Coap::Message *>(aMessage)->SetToken(aToken, aTokenLength);
+    return AsCoapMessage(aMessage).SetToken(aToken, aTokenLength);
 }
 
 void otCoapMessageGenerateToken(otMessage *aMessage, uint8_t aTokenLength)
 {
-    IgnoreError(static_cast<Coap::Message *>(aMessage)->GenerateRandomToken(aTokenLength));
+    IgnoreError(AsCoapMessage(aMessage).GenerateRandomToken(aTokenLength));
 }
 
 otError otCoapMessageAppendContentFormatOption(otMessage *aMessage, otCoapOptionContentFormat aContentFormat)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendContentFormatOption(aContentFormat);
+    return AsCoapMessage(aMessage).AppendContentFormatOption(aContentFormat);
 }
 
 otError otCoapMessageAppendOption(otMessage *aMessage, uint16_t aNumber, uint16_t aLength, const void *aValue)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendOption(aNumber, aLength, aValue);
+    return AsCoapMessage(aMessage).AppendOption(aNumber, aLength, aValue);
 }
 
 otError otCoapMessageAppendUintOption(otMessage *aMessage, uint16_t aNumber, uint32_t aValue)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendUintOption(aNumber, aValue);
+    return AsCoapMessage(aMessage).AppendUintOption(aNumber, aValue);
 }
 
 otError otCoapMessageAppendObserveOption(otMessage *aMessage, uint32_t aObserve)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendObserveOption(aObserve);
+    return AsCoapMessage(aMessage).AppendObserveOption(aObserve);
 }
 
 otError otCoapMessageAppendUriPathOptions(otMessage *aMessage, const char *aUriPath)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendUriPathOptions(aUriPath);
+    return AsCoapMessage(aMessage).AppendUriPathOptions(aUriPath);
 }
 
 uint16_t otCoapBlockSizeFromExponent(otCoapBlockSzx aSize)
@@ -108,72 +106,72 @@ uint16_t otCoapBlockSizeFromExponent(otCoapBlockSzx aSize)
 
 otError otCoapMessageAppendBlock2Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSzx aSize)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(Coap::Message::kBlockType2, aNum, aMore, aSize);
+    return AsCoapMessage(aMessage).AppendBlockOption(Coap::Message::kBlockType2, aNum, aMore, aSize);
 }
 
 otError otCoapMessageAppendBlock1Option(otMessage *aMessage, uint32_t aNum, bool aMore, otCoapBlockSzx aSize)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendBlockOption(Coap::Message::kBlockType1, aNum, aMore, aSize);
+    return AsCoapMessage(aMessage).AppendBlockOption(Coap::Message::kBlockType1, aNum, aMore, aSize);
 }
 
 otError otCoapMessageAppendProxyUriOption(otMessage *aMessage, const char *aUriPath)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendProxyUriOption(aUriPath);
+    return AsCoapMessage(aMessage).AppendProxyUriOption(aUriPath);
 }
 
 otError otCoapMessageAppendMaxAgeOption(otMessage *aMessage, uint32_t aMaxAge)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendMaxAgeOption(aMaxAge);
+    return AsCoapMessage(aMessage).AppendMaxAgeOption(aMaxAge);
 }
 
 otError otCoapMessageAppendUriQueryOption(otMessage *aMessage, const char *aUriQuery)
 {
-    return static_cast<Coap::Message *>(aMessage)->AppendUriQueryOption(aUriQuery);
+    return AsCoapMessage(aMessage).AppendUriQueryOption(aUriQuery);
 }
 
 otError otCoapMessageSetPayloadMarker(otMessage *aMessage)
 {
-    return static_cast<Coap::Message *>(aMessage)->SetPayloadMarker();
+    return AsCoapMessage(aMessage).SetPayloadMarker();
 }
 
 otCoapType otCoapMessageGetType(const otMessage *aMessage)
 {
-    return static_cast<otCoapType>(static_cast<const Coap::Message *>(aMessage)->GetType());
+    return static_cast<otCoapType>(AsCoapMessage(aMessage).GetType());
 }
 
 otCoapCode otCoapMessageGetCode(const otMessage *aMessage)
 {
-    return static_cast<otCoapCode>(static_cast<const Coap::Message *>(aMessage)->GetCode());
+    return static_cast<otCoapCode>(AsCoapMessage(aMessage).GetCode());
 }
 
 const char *otCoapMessageCodeToString(const otMessage *aMessage)
 {
-    return static_cast<const Coap::Message *>(aMessage)->CodeToString();
+    return AsCoapMessage(aMessage).CodeToString();
 }
 
 uint16_t otCoapMessageGetMessageId(const otMessage *aMessage)
 {
-    return static_cast<const Coap::Message *>(aMessage)->GetMessageId();
+    return AsCoapMessage(aMessage).GetMessageId();
 }
 
 uint8_t otCoapMessageGetTokenLength(const otMessage *aMessage)
 {
-    return static_cast<const Coap::Message *>(aMessage)->GetTokenLength();
+    return AsCoapMessage(aMessage).GetTokenLength();
 }
 
 const uint8_t *otCoapMessageGetToken(const otMessage *aMessage)
 {
-    return static_cast<const Coap::Message *>(aMessage)->GetToken();
+    return AsCoapMessage(aMessage).GetToken();
 }
 
 otError otCoapOptionIteratorInit(otCoapOptionIterator *aIterator, const otMessage *aMessage)
 {
-    return static_cast<Coap::Option::Iterator *>(aIterator)->Init(*static_cast<const Coap::Message *>(aMessage));
+    return AsCoreType(aIterator).Init(AsCoapMessage(aMessage));
 }
 
 const otCoapOption *otCoapOptionIteratorGetFirstOptionMatching(otCoapOptionIterator *aIterator, uint16_t aOption)
 {
-    Coap::Option::Iterator &iterator = *static_cast<Coap::Option::Iterator *>(aIterator);
+    Coap::Option::Iterator &iterator = AsCoreType(aIterator);
 
     IgnoreError(iterator.Init(iterator.GetMessage(), aOption));
     return iterator.GetOption();
@@ -181,7 +179,7 @@ const otCoapOption *otCoapOptionIteratorGetFirstOptionMatching(otCoapOptionItera
 
 const otCoapOption *otCoapOptionIteratorGetFirstOption(otCoapOptionIterator *aIterator)
 {
-    Coap::Option::Iterator &iterator = *static_cast<Coap::Option::Iterator *>(aIterator);
+    Coap::Option::Iterator &iterator = AsCoreType(aIterator);
 
     IgnoreError(iterator.Init(iterator.GetMessage()));
     return iterator.GetOption();
@@ -189,7 +187,7 @@ const otCoapOption *otCoapOptionIteratorGetFirstOption(otCoapOptionIterator *aIt
 
 const otCoapOption *otCoapOptionIteratorGetNextOptionMatching(otCoapOptionIterator *aIterator, uint16_t aOption)
 {
-    Coap::Option::Iterator &iterator = *static_cast<Coap::Option::Iterator *>(aIterator);
+    Coap::Option::Iterator &iterator = AsCoreType(aIterator);
 
     IgnoreError(iterator.Advance(aOption));
     return iterator.GetOption();
@@ -197,7 +195,7 @@ const otCoapOption *otCoapOptionIteratorGetNextOptionMatching(otCoapOptionIterat
 
 const otCoapOption *otCoapOptionIteratorGetNextOption(otCoapOptionIterator *aIterator)
 {
-    Coap::Option::Iterator &iterator = *static_cast<Coap::Option::Iterator *>(aIterator);
+    Coap::Option::Iterator &iterator = AsCoreType(aIterator);
 
     IgnoreError(iterator.Advance());
     return iterator.GetOption();
@@ -205,12 +203,12 @@ const otCoapOption *otCoapOptionIteratorGetNextOption(otCoapOptionIterator *aIte
 
 otError otCoapOptionIteratorGetOptionUintValue(otCoapOptionIterator *aIterator, uint64_t *aValue)
 {
-    return static_cast<Coap::Option::Iterator *>(aIterator)->ReadOptionValue(*aValue);
+    return AsCoreType(aIterator).ReadOptionValue(*aValue);
 }
 
 otError otCoapOptionIteratorGetOptionValue(otCoapOptionIterator *aIterator, void *aValue)
 {
-    return static_cast<Coap::Option::Iterator *>(aIterator)->ReadOptionValue(aValue);
+    return AsCoreType(aIterator).ReadOptionValue(aValue);
 }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
@@ -224,7 +222,6 @@ otError otCoapSendRequestBlockWiseWithParameters(otInstance *                aIn
                                                  otCoapBlockwiseReceiveHook  aReceiveHook)
 {
     Error                     error;
-    Instance &                instance     = *static_cast<Instance *>(aInstance);
     const Coap::TxParameters &txParameters = Coap::TxParameters::From(aTxParameters);
 
     if (aTxParameters != nullptr)
@@ -232,9 +229,9 @@ otError otCoapSendRequestBlockWiseWithParameters(otInstance *                aIn
         VerifyOrExit(txParameters.IsValid(), error = kErrorInvalidArgs);
     }
 
-    error = instance.GetApplicationCoap().SendMessage(*static_cast<Coap::Message *>(aMessage),
-                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-                                                      txParameters, aHandler, aContext, aTransmitHook, aReceiveHook);
+    error = AsCoreType(aInstance).GetApplicationCoap().SendMessage(AsCoapMessage(aMessage), AsCoreType(aMessageInfo),
+                                                                   txParameters, aHandler, aContext, aTransmitHook,
+                                                                   aReceiveHook);
 
 exit:
     return error;
@@ -248,8 +245,8 @@ otError otCoapSendRequestWithParameters(otInstance *              aInstance,
                                         void *                    aContext,
                                         const otCoapTxParameters *aTxParameters)
 {
-    Error                     error;
-    Instance &                instance     = *static_cast<Instance *>(aInstance);
+    Error error;
+
     const Coap::TxParameters &txParameters = Coap::TxParameters::From(aTxParameters);
 
     if (aTxParameters != nullptr)
@@ -257,9 +254,8 @@ otError otCoapSendRequestWithParameters(otInstance *              aInstance,
         VerifyOrExit(txParameters.IsValid(), error = kErrorInvalidArgs);
     }
 
-    error = instance.GetApplicationCoap().SendMessage(*static_cast<Coap::Message *>(aMessage),
-                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-                                                      txParameters, aHandler, aContext);
+    error = AsCoreType(aInstance).GetApplicationCoap().SendMessage(AsCoapMessage(aMessage), AsCoreType(aMessageInfo),
+                                                                   txParameters, aHandler, aContext);
 
 exit:
     return error;
@@ -267,53 +263,39 @@ exit:
 
 otError otCoapStart(otInstance *aInstance, uint16_t aPort)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoap().Start(aPort);
+    return AsCoreType(aInstance).GetApplicationCoap().Start(aPort);
 }
 
 otError otCoapStop(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoap().Stop();
+    return AsCoreType(aInstance).GetApplicationCoap().Stop();
 }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 void otCoapAddBlockWiseResource(otInstance *aInstance, otCoapBlockwiseResource *aResource)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoap().AddBlockWiseResource(*static_cast<Coap::ResourceBlockWise *>(aResource));
+    AsCoreType(aInstance).GetApplicationCoap().AddBlockWiseResource(AsCoreType(aResource));
 }
 
 void otCoapRemoveBlockWiseResource(otInstance *aInstance, otCoapBlockwiseResource *aResource)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoap().RemoveBlockWiseResource(*static_cast<Coap::ResourceBlockWise *>(aResource));
+    AsCoreType(aInstance).GetApplicationCoap().RemoveBlockWiseResource(AsCoreType(aResource));
 }
 #endif
 
 void otCoapAddResource(otInstance *aInstance, otCoapResource *aResource)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoap().AddResource(*static_cast<Coap::Resource *>(aResource));
+    AsCoreType(aInstance).GetApplicationCoap().AddResource(AsCoreType(aResource));
 }
 
 void otCoapRemoveResource(otInstance *aInstance, otCoapResource *aResource)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoap().RemoveResource(*static_cast<Coap::Resource *>(aResource));
+    AsCoreType(aInstance).GetApplicationCoap().RemoveResource(AsCoreType(aResource));
 }
 
 void otCoapSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandler, void *aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoap().SetDefaultHandler(aHandler, aContext);
+    AsCoreType(aInstance).GetApplicationCoap().SetDefaultHandler(aHandler, aContext);
 }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
@@ -324,11 +306,9 @@ otError otCoapSendResponseBlockWiseWithParameters(otInstance *                aI
                                                   void *                      aContext,
                                                   otCoapBlockwiseTransmitHook aTransmitHook)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoap().SendMessage(
-        *static_cast<Coap::Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-        Coap::TxParameters::From(aTxParameters), nullptr, aContext, aTransmitHook, nullptr);
+    return AsCoreType(aInstance).GetApplicationCoap().SendMessage(AsCoapMessage(aMessage), AsCoreType(aMessageInfo),
+                                                                  Coap::TxParameters::From(aTxParameters), nullptr,
+                                                                  aContext, aTransmitHook, nullptr);
 }
 #endif
 
@@ -337,11 +317,8 @@ otError otCoapSendResponseWithParameters(otInstance *              aInstance,
                                          const otMessageInfo *     aMessageInfo,
                                          const otCoapTxParameters *aTxParameters)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoap().SendMessage(*static_cast<Coap::Message *>(aMessage),
-                                                     *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-                                                     Coap::TxParameters::From(aTxParameters), nullptr, nullptr);
+    return AsCoreType(aInstance).GetApplicationCoap().SendMessage(
+        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), Coap::TxParameters::From(aTxParameters), nullptr, nullptr);
 }
 
 #endif // OPENTHREAD_CONFIG_COAP_API_ENABLE

--- a/src/core/api/coap_secure_api.cpp
+++ b/src/core/api/coap_secure_api.cpp
@@ -40,16 +40,14 @@
 
 #include "coap/coap_message.hpp"
 #include "coap/coap_secure.hpp"
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
 
 otError otCoapSecureStart(otInstance *aInstance, uint16_t aPort)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoapSecure().Start(aPort);
+    return AsCoreType(aInstance).GetApplicationCoapSecure().Start(aPort);
 }
 
 #ifdef MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
@@ -59,22 +57,20 @@ void otCoapSecureSetCertificate(otInstance *   aInstance,
                                 const uint8_t *aPrivateKey,
                                 uint32_t       aPrivateKeyLength)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aX509Cert != nullptr && aX509Length != 0 && aPrivateKey != nullptr && aPrivateKeyLength != 0);
 
-    instance.GetApplicationCoapSecure().SetCertificate(aX509Cert, aX509Length, aPrivateKey, aPrivateKeyLength);
+    AsCoreType(aInstance).GetApplicationCoapSecure().SetCertificate(aX509Cert, aX509Length, aPrivateKey,
+                                                                    aPrivateKeyLength);
 }
 
 void otCoapSecureSetCaCertificateChain(otInstance *   aInstance,
                                        const uint8_t *aX509CaCertificateChain,
                                        uint32_t       aX509CaCertChainLength)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aX509CaCertificateChain != nullptr && aX509CaCertChainLength != 0);
 
-    instance.GetApplicationCoapSecure().SetCaCertificateChain(aX509CaCertificateChain, aX509CaCertChainLength);
+    AsCoreType(aInstance).GetApplicationCoapSecure().SetCaCertificateChain(aX509CaCertificateChain,
+                                                                           aX509CaCertChainLength);
 }
 #endif // MBEDTLS_KEY_EXCHANGE_ECDHE_ECDSA_ENABLED
 
@@ -85,11 +81,9 @@ void otCoapSecureSetPsk(otInstance *   aInstance,
                         const uint8_t *aPskIdentity,
                         uint16_t       aPskIdLength)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aPsk != nullptr && aPskLength != 0 && aPskIdentity != nullptr && aPskIdLength != 0);
 
-    instance.GetApplicationCoapSecure().SetPreSharedKey(aPsk, aPskLength, aPskIdentity, aPskIdLength);
+    AsCoreType(aInstance).GetApplicationCoapSecure().SetPreSharedKey(aPsk, aPskLength, aPskIdentity, aPskIdLength);
 }
 #endif // MBEDTLS_KEY_EXCHANGE_PSK_ENABLED
 
@@ -99,17 +93,14 @@ otError otCoapSecureGetPeerCertificateBase64(otInstance *   aInstance,
                                              size_t *       aCertLength,
                                              size_t         aCertBufferSize)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoapSecure().GetPeerCertificateBase64(aPeerCert, aCertLength, aCertBufferSize);
+    return AsCoreType(aInstance).GetApplicationCoapSecure().GetPeerCertificateBase64(aPeerCert, aCertLength,
+                                                                                     aCertBufferSize);
 }
 #endif // defined(MBEDTLS_BASE64_C) && defined(MBEDTLS_SSL_KEEP_PEER_CERTIFICATE)
 
 void otCoapSecureSetSslAuthMode(otInstance *aInstance, bool aVerifyPeerCertificate)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoapSecure().SetSslAuthMode(aVerifyPeerCertificate);
+    AsCoreType(aInstance).GetApplicationCoapSecure().SetSslAuthMode(aVerifyPeerCertificate);
 }
 
 otError otCoapSecureConnect(otInstance *                    aInstance,
@@ -117,38 +108,27 @@ otError otCoapSecureConnect(otInstance *                    aInstance,
                             otHandleCoapSecureClientConnect aHandler,
                             void *                          aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoapSecure().Connect(*static_cast<const Ip6::SockAddr *>(aSockAddr), aHandler,
-                                                       aContext);
+    return AsCoreType(aInstance).GetApplicationCoapSecure().Connect(AsCoreType(aSockAddr), aHandler, aContext);
 }
 
 void otCoapSecureDisconnect(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoapSecure().Disconnect();
+    AsCoreType(aInstance).GetApplicationCoapSecure().Disconnect();
 }
 
 bool otCoapSecureIsConnected(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoapSecure().IsConnected();
+    return AsCoreType(aInstance).GetApplicationCoapSecure().IsConnected();
 }
 
 bool otCoapSecureIsConnectionActive(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoapSecure().IsConnectionActive();
+    return AsCoreType(aInstance).GetApplicationCoapSecure().IsConnectionActive();
 }
 
 void otCoapSecureStop(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoapSecure().Stop();
+    AsCoreType(aInstance).GetApplicationCoapSecure().Stop();
 }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
@@ -159,10 +139,8 @@ otError otCoapSecureSendRequestBlockWise(otInstance *                aInstance,
                                          otCoapBlockwiseTransmitHook aTransmitHook,
                                          otCoapBlockwiseReceiveHook  aReceiveHook)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoapSecure().SendMessage(*static_cast<Coap::Message *>(aMessage), aHandler, aContext,
-                                                           aTransmitHook, aReceiveHook);
+    return AsCoreType(aInstance).GetApplicationCoapSecure().SendMessage(AsCoapMessage(aMessage), aHandler, aContext,
+                                                                        aTransmitHook, aReceiveHook);
 }
 #endif
 
@@ -171,55 +149,41 @@ otError otCoapSecureSendRequest(otInstance *          aInstance,
                                 otCoapResponseHandler aHandler,
                                 void *                aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoapSecure().SendMessage(*static_cast<Coap::Message *>(aMessage), aHandler, aContext);
+    return AsCoreType(aInstance).GetApplicationCoapSecure().SendMessage(AsCoapMessage(aMessage), aHandler, aContext);
 }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
 void otCoapSecureAddBlockWiseResource(otInstance *aInstance, otCoapBlockwiseResource *aResource)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoapSecure().AddBlockWiseResource(*static_cast<Coap::ResourceBlockWise *>(aResource));
+    AsCoreType(aInstance).GetApplicationCoapSecure().AddBlockWiseResource(AsCoreType(aResource));
 }
 
 void otCoapSecureRemoveBlockWiseResource(otInstance *aInstance, otCoapBlockwiseResource *aResource)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoapSecure().RemoveBlockWiseResource(*static_cast<Coap::ResourceBlockWise *>(aResource));
+    AsCoreType(aInstance).GetApplicationCoapSecure().RemoveBlockWiseResource(AsCoreType(aResource));
 }
 #endif
 
 void otCoapSecureAddResource(otInstance *aInstance, otCoapResource *aResource)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoapSecure().AddResource(*static_cast<Coap::Resource *>(aResource));
+    AsCoreType(aInstance).GetApplicationCoapSecure().AddResource(AsCoreType(aResource));
 }
 
 void otCoapSecureRemoveResource(otInstance *aInstance, otCoapResource *aResource)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoapSecure().RemoveResource(*static_cast<Coap::Resource *>(aResource));
+    AsCoreType(aInstance).GetApplicationCoapSecure().RemoveResource(AsCoreType(aResource));
 }
 
 void otCoapSecureSetClientConnectedCallback(otInstance *                    aInstance,
                                             otHandleCoapSecureClientConnect aHandler,
                                             void *                          aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoapSecure().SetClientConnectedCallback(aHandler, aContext);
+    AsCoreType(aInstance).GetApplicationCoapSecure().SetClientConnectedCallback(aHandler, aContext);
 }
 
 void otCoapSecureSetDefaultHandler(otInstance *aInstance, otCoapRequestHandler aHandler, void *aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.GetApplicationCoapSecure().SetDefaultHandler(aHandler, aContext);
+    AsCoreType(aInstance).GetApplicationCoapSecure().SetDefaultHandler(aHandler, aContext);
 }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
@@ -229,20 +193,15 @@ otError otCoapSecureSendResponseBlockWise(otInstance *                aInstance,
                                           void *                      aContext,
                                           otCoapBlockwiseTransmitHook aTransmitHook)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoapSecure().SendMessage(*static_cast<Coap::Message *>(aMessage),
-                                                           *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-                                                           nullptr, aContext, aTransmitHook);
+    return AsCoreType(aInstance).GetApplicationCoapSecure().SendMessage(
+        AsCoapMessage(aMessage), AsCoreType(aMessageInfo), nullptr, aContext, aTransmitHook);
 }
 #endif
 
 otError otCoapSecureSendResponse(otInstance *aInstance, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.GetApplicationCoapSecure().SendMessage(*static_cast<Coap::Message *>(aMessage),
-                                                           *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    return AsCoreType(aInstance).GetApplicationCoapSecure().SendMessage(AsCoapMessage(aMessage),
+                                                                        AsCoreType(aMessageInfo));
 }
 
 #endif // OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE

--- a/src/core/api/commissioner_api.cpp
+++ b/src/core/api/commissioner_api.cpp
@@ -37,7 +37,7 @@
 
 #include <openthread/commissioner.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
@@ -47,22 +47,18 @@ otError otCommissionerStart(otInstance *                 aInstance,
                             otCommissionerJoinerCallback aJoinerCallback,
                             void *                       aCallbackContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Commissioner>().Start(aStateCallback, aJoinerCallback, aCallbackContext);
+    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().Start(aStateCallback, aJoinerCallback, aCallbackContext);
 }
 
 otError otCommissionerStop(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Commissioner>().Stop(/* aResign */ true);
+    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().Stop(/* aResign */ true);
 }
 
 otError otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aEui64, const char *aPskd, uint32_t aTimeout)
 {
     Error                  error;
-    MeshCoP::Commissioner &commissioner = static_cast<Instance *>(aInstance)->Get<MeshCoP::Commissioner>();
+    MeshCoP::Commissioner &commissioner = AsCoreType(aInstance).Get<MeshCoP::Commissioner>();
 
     if (aEui64 == nullptr)
     {
@@ -70,7 +66,7 @@ otError otCommissionerAddJoiner(otInstance *aInstance, const otExtAddress *aEui6
         ExitNow();
     }
 
-    error = commissioner.AddJoiner(*static_cast<const Mac::ExtAddress *>(aEui64), aPskd, aTimeout);
+    error = commissioner.AddJoiner(AsCoreType(aEui64), aPskd, aTimeout);
 
 exit:
     return error;
@@ -81,23 +77,18 @@ otError otCommissionerAddJoinerWithDiscerner(otInstance *             aInstance,
                                              const char *             aPskd,
                                              uint32_t                 aTimeout)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Commissioner>().AddJoiner(*static_cast<const MeshCoP::JoinerDiscerner *>(aDiscerner),
-                                                           aPskd, aTimeout);
+    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().AddJoiner(AsCoreType(aDiscerner), aPskd, aTimeout);
 }
 
 otError otCommissionerGetNextJoinerInfo(otInstance *aInstance, uint16_t *aIterator, otJoinerInfo *aJoiner)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Commissioner>().GetNextJoinerInfo(*aIterator, *aJoiner);
+    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().GetNextJoinerInfo(*aIterator, *aJoiner);
 }
 
 otError otCommissionerRemoveJoiner(otInstance *aInstance, const otExtAddress *aEui64)
 {
     Error                  error;
-    MeshCoP::Commissioner &commissioner = static_cast<Instance *>(aInstance)->Get<MeshCoP::Commissioner>();
+    MeshCoP::Commissioner &commissioner = AsCoreType(aInstance).Get<MeshCoP::Commissioner>();
 
     if (aEui64 == nullptr)
     {
@@ -105,7 +96,7 @@ otError otCommissionerRemoveJoiner(otInstance *aInstance, const otExtAddress *aE
         ExitNow();
     }
 
-    error = commissioner.RemoveJoiner(*static_cast<const Mac::ExtAddress *>(aEui64), /* aTimeout */ 0);
+    error = commissioner.RemoveJoiner(AsCoreType(aEui64), /* aTimeout */ 0);
 
 exit:
     return error;
@@ -113,24 +104,17 @@ exit:
 
 otError otCommissionerRemoveJoinerWithDiscerner(otInstance *aInstance, const otJoinerDiscerner *aDiscerner)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Commissioner>().RemoveJoiner(
-        *static_cast<const MeshCoP::JoinerDiscerner *>(aDiscerner), 0);
+    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().RemoveJoiner(AsCoreType(aDiscerner), 0);
 }
 
 otError otCommissionerSetProvisioningUrl(otInstance *aInstance, const char *aProvisioningUrl)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Commissioner>().SetProvisioningUrl(aProvisioningUrl);
+    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().SetProvisioningUrl(aProvisioningUrl);
 }
 
 const char *otCommissionerGetProvisioningUrl(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Commissioner>().GetProvisioningUrl();
+    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().GetProvisioningUrl();
 }
 
 otError otCommissionerAnnounceBegin(otInstance *        aInstance,
@@ -139,10 +123,8 @@ otError otCommissionerAnnounceBegin(otInstance *        aInstance,
                                     uint16_t            aPeriod,
                                     const otIp6Address *aAddress)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Commissioner>().GetAnnounceBeginClient().SendRequest(
-        aChannelMask, aCount, aPeriod, *static_cast<const Ip6::Address *>(aAddress));
+    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().GetAnnounceBeginClient().SendRequest(
+        aChannelMask, aCount, aPeriod, AsCoreType(aAddress));
 }
 
 otError otCommissionerEnergyScan(otInstance *                       aInstance,
@@ -154,11 +136,8 @@ otError otCommissionerEnergyScan(otInstance *                       aInstance,
                                  otCommissionerEnergyReportCallback aCallback,
                                  void *                             aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Commissioner>().GetEnergyScanClient().SendQuery(
-        aChannelMask, aCount, aPeriod, aScanDuration, *static_cast<const Ip6::Address *>(aAddress), aCallback,
-        aContext);
+    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().GetEnergyScanClient().SendQuery(
+        aChannelMask, aCount, aPeriod, aScanDuration, AsCoreType(aAddress), aCallback, aContext);
 }
 
 otError otCommissionerPanIdQuery(otInstance *                        aInstance,
@@ -168,17 +147,13 @@ otError otCommissionerPanIdQuery(otInstance *                        aInstance,
                                  otCommissionerPanIdConflictCallback aCallback,
                                  void *                              aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Commissioner>().GetPanIdQueryClient().SendQuery(
-        aPanId, aChannelMask, *static_cast<const Ip6::Address *>(aAddress), aCallback, aContext);
+    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().GetPanIdQueryClient().SendQuery(
+        aPanId, aChannelMask, AsCoreType(aAddress), aCallback, aContext);
 }
 
 otError otCommissionerSendMgmtGet(otInstance *aInstance, const uint8_t *aTlvs, uint8_t aLength)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Commissioner>().SendMgmtCommissionerGetRequest(aTlvs, aLength);
+    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().SendMgmtCommissionerGetRequest(aTlvs, aLength);
 }
 
 otError otCommissionerSendMgmtSet(otInstance *                  aInstance,
@@ -186,23 +161,17 @@ otError otCommissionerSendMgmtSet(otInstance *                  aInstance,
                                   const uint8_t *               aTlvs,
                                   uint8_t                       aLength)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Commissioner>().SendMgmtCommissionerSetRequest(*aDataset, aTlvs, aLength);
+    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().SendMgmtCommissionerSetRequest(*aDataset, aTlvs, aLength);
 }
 
 uint16_t otCommissionerGetSessionId(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Commissioner>().GetSessionId();
+    return AsCoreType(aInstance).Get<MeshCoP::Commissioner>().GetSessionId();
 }
 
 otCommissionerState otCommissionerGetState(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return static_cast<otCommissionerState>(instance.Get<MeshCoP::Commissioner>().GetState());
+    return MapEnum(AsCoreType(aInstance).Get<MeshCoP::Commissioner>().GetState());
 }
 
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE

--- a/src/core/api/crypto_api.cpp
+++ b/src/core/api/crypto_api.cpp
@@ -36,6 +36,7 @@
 #include <openthread/crypto.h>
 #include <openthread/error.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/locator_getters.hpp"
@@ -43,6 +44,7 @@
 #include "crypto/ecdsa.hpp"
 #include "crypto/hmac_sha256.hpp"
 
+using namespace ot;
 using namespace ot::Crypto;
 
 void otCryptoHmacSha256(const otCryptoKey *aKey, const uint8_t *aBuf, uint16_t aBufLength, otCryptoSha256Hash *aHash)
@@ -51,9 +53,9 @@ void otCryptoHmacSha256(const otCryptoKey *aKey, const uint8_t *aBuf, uint16_t a
 
     OT_ASSERT((aKey != nullptr) && (aBuf != nullptr) && (aHash != nullptr));
 
-    hmac.Start(*static_cast<const Key *>(aKey));
+    hmac.Start(AsCoreType(aKey));
     hmac.Update(aBuf, aBufLength);
-    hmac.Finish(*static_cast<HmacSha256::Hash *>(aHash));
+    hmac.Finish(ot::AsCoreType(aHash));
 }
 
 void otCryptoAesCcm(const otCryptoKey *aKey,
@@ -71,7 +73,7 @@ void otCryptoAesCcm(const otCryptoKey *aKey,
     AesCcm aesCcm;
     OT_ASSERT((aNonce != nullptr) && (aPlainText != nullptr) && (aCipherText != nullptr) && (aTag != nullptr));
 
-    aesCcm.SetKey(*static_cast<const Key *>(aKey));
+    aesCcm.SetKey(AsCoreType(aKey));
     aesCcm.Init(aHeaderLength, aLength, aTagLength, aNonce, aNonceLength);
 
     if (aHeaderLength != 0)

--- a/src/core/api/dataset_api.cpp
+++ b/src/core/api/dataset_api.cpp
@@ -35,7 +35,7 @@
 
 #include <openthread/dataset.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 #include "meshcop/dataset_manager.hpp"
 #include "meshcop/meshcop.hpp"
@@ -44,81 +44,63 @@ using namespace ot;
 
 bool otDatasetIsCommissioned(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::ActiveDataset>().IsCommissioned();
+    return AsCoreType(aInstance).Get<MeshCoP::ActiveDataset>().IsCommissioned();
 }
 
 otError otDatasetGetActive(otInstance *aInstance, otOperationalDataset *aDataset)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aDataset != nullptr);
 
-    return instance.Get<MeshCoP::ActiveDataset>().Read(*static_cast<MeshCoP::Dataset::Info *>(aDataset));
+    return AsCoreType(aInstance).Get<MeshCoP::ActiveDataset>().Read(AsCoreType(aDataset));
 }
 
 otError otDatasetGetActiveTlvs(otInstance *aInstance, otOperationalDatasetTlvs *aDataset)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aDataset != nullptr);
 
-    return instance.Get<MeshCoP::ActiveDataset>().Read(*aDataset);
+    return AsCoreType(aInstance).Get<MeshCoP::ActiveDataset>().Read(*aDataset);
 }
 
 otError otDatasetSetActive(otInstance *aInstance, const otOperationalDataset *aDataset)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aDataset != nullptr);
 
-    return instance.Get<MeshCoP::ActiveDataset>().Save(*static_cast<const MeshCoP::Dataset::Info *>(aDataset));
+    return AsCoreType(aInstance).Get<MeshCoP::ActiveDataset>().Save(AsCoreType(aDataset));
 }
 
 otError otDatasetSetActiveTlvs(otInstance *aInstance, const otOperationalDatasetTlvs *aDataset)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aDataset != nullptr);
 
-    return instance.Get<MeshCoP::ActiveDataset>().Save(*aDataset);
+    return AsCoreType(aInstance).Get<MeshCoP::ActiveDataset>().Save(*aDataset);
 }
 
 otError otDatasetGetPending(otInstance *aInstance, otOperationalDataset *aDataset)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aDataset != nullptr);
 
-    return instance.Get<MeshCoP::PendingDataset>().Read(*static_cast<MeshCoP::Dataset::Info *>(aDataset));
+    return AsCoreType(aInstance).Get<MeshCoP::PendingDataset>().Read(AsCoreType(aDataset));
 }
 
 otError otDatasetGetPendingTlvs(otInstance *aInstance, otOperationalDatasetTlvs *aDataset)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aDataset != nullptr);
 
-    return instance.Get<MeshCoP::PendingDataset>().Read(*aDataset);
+    return AsCoreType(aInstance).Get<MeshCoP::PendingDataset>().Read(*aDataset);
 }
 
 otError otDatasetSetPending(otInstance *aInstance, const otOperationalDataset *aDataset)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aDataset != nullptr);
 
-    return instance.Get<MeshCoP::PendingDataset>().Save(*static_cast<const MeshCoP::Dataset::Info *>(aDataset));
+    return AsCoreType(aInstance).Get<MeshCoP::PendingDataset>().Save(AsCoreType(aDataset));
 }
 
 otError otDatasetSetPendingTlvs(otInstance *aInstance, const otOperationalDatasetTlvs *aDataset)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aDataset != nullptr);
 
-    return instance.Get<MeshCoP::PendingDataset>().Save(*aDataset);
+    return AsCoreType(aInstance).Get<MeshCoP::PendingDataset>().Save(*aDataset);
 }
 
 otError otDatasetSendMgmtActiveGet(otInstance *                          aInstance,
@@ -127,10 +109,8 @@ otError otDatasetSendMgmtActiveGet(otInstance *                          aInstan
                                    uint8_t                               aLength,
                                    const otIp6Address *                  aAddress)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::ActiveDataset>().SendGetRequest(
-        *static_cast<const MeshCoP::Dataset::Components *>(aDatasetComponents), aTlvTypes, aLength, aAddress);
+    return AsCoreType(aInstance).Get<MeshCoP::ActiveDataset>().SendGetRequest(AsCoreType(aDatasetComponents), aTlvTypes,
+                                                                              aLength, aAddress);
 }
 
 otError otDatasetSendMgmtActiveSet(otInstance *                aInstance,
@@ -140,10 +120,8 @@ otError otDatasetSendMgmtActiveSet(otInstance *                aInstance,
                                    otDatasetMgmtSetCallback    aCallback,
                                    void *                      aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::ActiveDataset>().SendSetRequest(*static_cast<const MeshCoP::Dataset::Info *>(aDataset),
-                                                                 aTlvs, aLength, aCallback, aContext);
+    return AsCoreType(aInstance).Get<MeshCoP::ActiveDataset>().SendSetRequest(AsCoreType(aDataset), aTlvs, aLength,
+                                                                              aCallback, aContext);
 }
 
 otError otDatasetSendMgmtPendingGet(otInstance *                          aInstance,
@@ -152,10 +130,8 @@ otError otDatasetSendMgmtPendingGet(otInstance *                          aInsta
                                     uint8_t                               aLength,
                                     const otIp6Address *                  aAddress)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::PendingDataset>().SendGetRequest(
-        *static_cast<const MeshCoP::Dataset::Components *>(aDatasetComponents), aTlvTypes, aLength, aAddress);
+    return AsCoreType(aInstance).Get<MeshCoP::PendingDataset>().SendGetRequest(AsCoreType(aDatasetComponents),
+                                                                               aTlvTypes, aLength, aAddress);
 }
 
 otError otDatasetSendMgmtPendingSet(otInstance *                aInstance,
@@ -165,10 +141,8 @@ otError otDatasetSendMgmtPendingSet(otInstance *                aInstance,
                                     otDatasetMgmtSetCallback    aCallback,
                                     void *                      aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::PendingDataset>().SendSetRequest(
-        *static_cast<const MeshCoP::Dataset::Info *>(aDataset), aTlvs, aLength, aCallback, aContext);
+    return AsCoreType(aInstance).Get<MeshCoP::PendingDataset>().SendSetRequest(AsCoreType(aDataset), aTlvs, aLength,
+                                                                               aCallback, aContext);
 }
 
 #if OPENTHREAD_FTD
@@ -177,14 +151,13 @@ otError otDatasetGeneratePskc(const char *           aPassPhrase,
                               const otExtendedPanId *aExtPanId,
                               otPskc *               aPskc)
 {
-    return MeshCoP::GeneratePskc(aPassPhrase, *static_cast<const Mac::NetworkName *>(aNetworkName),
-                                 *static_cast<const Mac::ExtendedPanId *>(aExtPanId), *static_cast<Pskc *>(aPskc));
+    return MeshCoP::GeneratePskc(aPassPhrase, AsCoreType(aNetworkName), AsCoreType(aExtPanId), AsCoreType(aPskc));
 }
 #endif // OPENTHREAD_FTD
 
 otError otNetworkNameFromString(otNetworkName *aNetworkName, const char *aNameString)
 {
-    otError error = static_cast<Mac::NetworkName *>(aNetworkName)->Set(aNameString);
+    otError error = AsCoreType(aNetworkName).Set(aNameString);
 
     return (error == OT_ERROR_ALREADY) ? OT_ERROR_NONE : error;
 }
@@ -196,7 +169,7 @@ otError otDatasetParseTlvs(const otOperationalDatasetTlvs *aDatasetTlvs, otOpera
 
     dataset.SetFrom(*aDatasetTlvs);
     VerifyOrExit(dataset.IsValid(), error = kErrorInvalidArgs);
-    dataset.ConvertTo(*static_cast<MeshCoP::Dataset::Info *>(aDataset));
+    dataset.ConvertTo(AsCoreType(aDataset));
 
 exit:
     return error;

--- a/src/core/api/dataset_ftd_api.cpp
+++ b/src/core/api/dataset_ftd_api.cpp
@@ -37,30 +37,24 @@
 
 #include <openthread/dataset_ftd.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
 
 otError otDatasetCreateNewNetwork(otInstance *aInstance, otOperationalDataset *aDataset)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::ActiveDataset>().CreateNewNetwork(*static_cast<MeshCoP::Dataset::Info *>(aDataset));
+    return AsCoreType(aInstance).Get<MeshCoP::ActiveDataset>().CreateNewNetwork(AsCoreType(aDataset));
 }
 
 uint32_t otDatasetGetDelayTimerMinimal(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Leader>().GetDelayTimerMinimal();
+    return AsCoreType(aInstance).Get<MeshCoP::Leader>().GetDelayTimerMinimal();
 }
 
 otError otDatasetSetDelayTimerMinimal(otInstance *aInstance, uint32_t aDelayTimerMinimal)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Leader>().SetDelayTimerMinimal(aDelayTimerMinimal);
+    return AsCoreType(aInstance).Get<MeshCoP::Leader>().SetDelayTimerMinimal(aDelayTimerMinimal);
 }
 
 #endif // OPENTHREAD_FTD

--- a/src/core/api/dataset_updater_api.cpp
+++ b/src/core/api/dataset_updater_api.cpp
@@ -37,7 +37,7 @@
 
 #include <openthread/dataset_updater.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 #include "meshcop/dataset_updater.hpp"
 
@@ -48,24 +48,18 @@ otError otDatasetUpdaterRequestUpdate(otInstance *                aInstance,
                                       otDatasetUpdaterCallback    aCallback,
                                       void *                      aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::DatasetUpdater>().RequestUpdate(*static_cast<const MeshCoP::Dataset::Info *>(aDataset),
-                                                                 aCallback, aContext);
+    return AsCoreType(aInstance).Get<MeshCoP::DatasetUpdater>().RequestUpdate(AsCoreType(aDataset), aCallback,
+                                                                              aContext);
 }
 
 void otDatasetUpdaterCancelUpdate(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<MeshCoP::DatasetUpdater>().CancelUpdate();
+    AsCoreType(aInstance).Get<MeshCoP::DatasetUpdater>().CancelUpdate();
 }
 
 bool otDatasetUpdaterIsUpdateOngoing(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::DatasetUpdater>().IsUpdateOngoing();
+    return AsCoreType(aInstance).Get<MeshCoP::DatasetUpdater>().IsUpdateOngoing();
 }
 
 #endif // OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE && OPENTHREAD_FTD

--- a/src/core/api/diags_api.cpp
+++ b/src/core/api/diags_api.cpp
@@ -37,30 +37,24 @@
 
 #include <openthread/diag.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
 
 void otDiagProcessCmdLine(otInstance *aInstance, const char *aString, char *aOutput, size_t aOutputMaxLen)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<FactoryDiags::Diags>().ProcessLine(aString, aOutput, aOutputMaxLen);
+    AsCoreType(aInstance).Get<FactoryDiags::Diags>().ProcessLine(aString, aOutput, aOutputMaxLen);
 }
 
 otError otDiagProcessCmd(otInstance *aInstance, uint8_t aArgsLength, char *aArgs[], char *aOutput, size_t aOutputMaxLen)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<FactoryDiags::Diags>().ProcessCmd(aArgsLength, aArgs, aOutput, aOutputMaxLen);
+    return AsCoreType(aInstance).Get<FactoryDiags::Diags>().ProcessCmd(aArgsLength, aArgs, aOutput, aOutputMaxLen);
 }
 
 bool otDiagIsEnabled(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<FactoryDiags::Diags>().IsEnabled();
+    return AsCoreType(aInstance).Get<FactoryDiags::Diags>().IsEnabled();
 }
 
 #endif // OPENTHREAD_CONFIG_DIAG_ENABLE

--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -35,21 +35,18 @@
 
 #include <openthread/dns_client.h>
 
-#include "common/instance.hpp"
-#include "common/locator_getters.hpp"
-#include "net/dns_client.hpp"
-#include "net/dns_types.hpp"
+#include "common/as_core_type.hpp"
 
 using namespace ot;
 
 void otDnsInitTxtEntryIterator(otDnsTxtEntryIterator *aIterator, const uint8_t *aTxtData, uint16_t aTxtDataLength)
 {
-    static_cast<Dns::TxtEntry::Iterator *>(aIterator)->Init(aTxtData, aTxtDataLength);
+    AsCoreType(aIterator).Init(aTxtData, aTxtDataLength);
 }
 
 otError otDnsGetNextTxtEntry(otDnsTxtEntryIterator *aIterator, otDnsTxtEntry *aEntry)
 {
-    return static_cast<Dns::TxtEntry::Iterator *>(aIterator)->GetNextEntry(*static_cast<Dns::TxtEntry *>(aEntry));
+    return AsCoreType(aIterator).GetNextEntry(AsCoreType(aEntry));
 }
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
@@ -68,22 +65,18 @@ bool otDnsIsNameCompressionEnabled(void)
 
 const otDnsQueryConfig *otDnsClientGetDefaultConfig(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<Dns::Client>().GetDefaultConfig();
+    return &AsCoreType(aInstance).Get<Dns::Client>().GetDefaultConfig();
 }
 
 void otDnsClientSetDefaultConfig(otInstance *aInstance, const otDnsQueryConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     if (aConfig != nullptr)
     {
-        instance.Get<Dns::Client>().SetDefaultConfig(*static_cast<const Dns::Client::QueryConfig *>(aConfig));
+        AsCoreType(aInstance).Get<Dns::Client>().SetDefaultConfig(AsCoreType(aConfig));
     }
     else
     {
-        instance.Get<Dns::Client>().ResetDefaultConfig();
+        AsCoreType(aInstance).Get<Dns::Client>().ResetDefaultConfig();
     }
 }
 
@@ -93,19 +86,15 @@ otError otDnsClientResolveAddress(otInstance *            aInstance,
                                   void *                  aContext,
                                   const otDnsQueryConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Dns::Client>().ResolveAddress(aHostName, aCallback, aContext,
-                                                      static_cast<const Dns::Client::QueryConfig *>(aConfig));
+    return AsCoreType(aInstance).Get<Dns::Client>().ResolveAddress(aHostName, aCallback, aContext,
+                                                                   AsCoreTypePtr(aConfig));
 }
 
 otError otDnsAddressResponseGetHostName(const otDnsAddressResponse *aResponse,
                                         char *                      aNameBuffer,
                                         uint16_t                    aNameBufferSize)
 {
-    const Dns::Client::AddressResponse &response = *static_cast<const Dns::Client::AddressResponse *>(aResponse);
-
-    return response.GetHostName(aNameBuffer, aNameBufferSize);
+    return AsCoreType(aResponse).GetHostName(aNameBuffer, aNameBufferSize);
 }
 
 otError otDnsAddressResponseGetAddress(const otDnsAddressResponse *aResponse,
@@ -113,10 +102,9 @@ otError otDnsAddressResponseGetAddress(const otDnsAddressResponse *aResponse,
                                        otIp6Address *              aAddress,
                                        uint32_t *                  aTtl)
 {
-    const Dns::Client::AddressResponse &response = *static_cast<const Dns::Client::AddressResponse *>(aResponse);
-    uint32_t                            ttl;
+    uint32_t ttl;
 
-    return response.GetAddress(aIndex, *static_cast<Ip6::Address *>(aAddress), (aTtl != nullptr) ? *aTtl : ttl);
+    return AsCoreType(aResponse).GetAddress(aIndex, AsCoreType(aAddress), (aTtl != nullptr) ? *aTtl : ttl);
 }
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE
@@ -127,19 +115,14 @@ otError otDnsClientBrowse(otInstance *            aInstance,
                           void *                  aContext,
                           const otDnsQueryConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Dns::Client>().Browse(aServiceName, aCallback, aContext,
-                                              static_cast<const Dns::Client::QueryConfig *>(aConfig));
+    return AsCoreType(aInstance).Get<Dns::Client>().Browse(aServiceName, aCallback, aContext, AsCoreTypePtr(aConfig));
 }
 
 otError otDnsBrowseResponseGetServiceName(const otDnsBrowseResponse *aResponse,
                                           char *                     aNameBuffer,
                                           uint16_t                   aNameBufferSize)
 {
-    const Dns::Client::BrowseResponse &response = *static_cast<const Dns::Client::BrowseResponse *>(aResponse);
-
-    return response.GetServiceName(aNameBuffer, aNameBufferSize);
+    return AsCoreType(aResponse).GetServiceName(aNameBuffer, aNameBufferSize);
 }
 
 otError otDnsBrowseResponseGetServiceInstance(const otDnsBrowseResponse *aResponse,
@@ -147,18 +130,14 @@ otError otDnsBrowseResponseGetServiceInstance(const otDnsBrowseResponse *aRespon
                                               char *                     aLabelBuffer,
                                               uint8_t                    aLabelBufferSize)
 {
-    const Dns::Client::BrowseResponse &response = *static_cast<const Dns::Client::BrowseResponse *>(aResponse);
-
-    return response.GetServiceInstance(aIndex, aLabelBuffer, aLabelBufferSize);
+    return AsCoreType(aResponse).GetServiceInstance(aIndex, aLabelBuffer, aLabelBufferSize);
 }
 
 otError otDnsBrowseResponseGetServiceInfo(const otDnsBrowseResponse *aResponse,
                                           const char *               aInstanceLabel,
                                           otDnsServiceInfo *         aServiceInfo)
 {
-    const Dns::Client::BrowseResponse &response = *static_cast<const Dns::Client::BrowseResponse *>(aResponse);
-
-    return response.GetServiceInfo(aInstanceLabel, *static_cast<Dns::Client::ServiceInfo *>(aServiceInfo));
+    return AsCoreType(aResponse).GetServiceInfo(aInstanceLabel, AsCoreType(aServiceInfo));
 }
 
 otError otDnsBrowseResponseGetHostAddress(const otDnsBrowseResponse *aResponse,
@@ -167,11 +146,9 @@ otError otDnsBrowseResponseGetHostAddress(const otDnsBrowseResponse *aResponse,
                                           otIp6Address *             aAddress,
                                           uint32_t *                 aTtl)
 {
-    const Dns::Client::BrowseResponse &response = *static_cast<const Dns::Client::BrowseResponse *>(aResponse);
-    uint32_t                           ttl;
+    uint32_t ttl;
 
-    return response.GetHostAddress(aHostName, aIndex, *static_cast<Ip6::Address *>(aAddress),
-                                   aTtl != nullptr ? *aTtl : ttl);
+    return AsCoreType(aResponse).GetHostAddress(aHostName, aIndex, AsCoreType(aAddress), aTtl != nullptr ? *aTtl : ttl);
 }
 
 otError otDnsClientResolveService(otInstance *            aInstance,
@@ -181,10 +158,8 @@ otError otDnsClientResolveService(otInstance *            aInstance,
                                   void *                  aContext,
                                   const otDnsQueryConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Dns::Client>().ResolveService(aInstanceLabel, aServiceName, aCallback, aContext,
-                                                      static_cast<const Dns::Client::QueryConfig *>(aConfig));
+    return AsCoreType(aInstance).Get<Dns::Client>().ResolveService(aInstanceLabel, aServiceName, aCallback, aContext,
+                                                                   AsCoreTypePtr(aConfig));
 }
 
 otError otDnsServiceResponseGetServiceName(const otDnsServiceResponse *aResponse,
@@ -193,16 +168,12 @@ otError otDnsServiceResponseGetServiceName(const otDnsServiceResponse *aResponse
                                            char *                      aNameBuffer,
                                            uint16_t                    aNameBufferSize)
 {
-    const Dns::Client::ServiceResponse &response = *static_cast<const Dns::Client::ServiceResponse *>(aResponse);
-
-    return response.GetServiceName(aLabelBuffer, aLabelBufferSize, aNameBuffer, aNameBufferSize);
+    return AsCoreType(aResponse).GetServiceName(aLabelBuffer, aLabelBufferSize, aNameBuffer, aNameBufferSize);
 }
 
 otError otDnsServiceResponseGetServiceInfo(const otDnsServiceResponse *aResponse, otDnsServiceInfo *aServiceInfo)
 {
-    const Dns::Client::ServiceResponse &response = *static_cast<const Dns::Client::ServiceResponse *>(aResponse);
-
-    return response.GetServiceInfo(*static_cast<Dns::Client::ServiceInfo *>(aServiceInfo));
+    return AsCoreType(aResponse).GetServiceInfo(AsCoreType(aServiceInfo));
 }
 
 otError otDnsServiceResponseGetHostAddress(const otDnsServiceResponse *aResponse,
@@ -211,11 +182,10 @@ otError otDnsServiceResponseGetHostAddress(const otDnsServiceResponse *aResponse
                                            otIp6Address *              aAddress,
                                            uint32_t *                  aTtl)
 {
-    const Dns::Client::ServiceResponse &response = *static_cast<const Dns::Client::ServiceResponse *>(aResponse);
-    uint32_t                            ttl;
+    uint32_t ttl;
 
-    return response.GetHostAddress(aHostName, aIndex, *static_cast<Ip6::Address *>(aAddress),
-                                   (aTtl != nullptr) ? *aTtl : ttl);
+    return AsCoreType(aResponse).GetHostAddress(aHostName, aIndex, AsCoreType(aAddress),
+                                                (aTtl != nullptr) ? *aTtl : ttl);
 }
 
 #endif // OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE

--- a/src/core/api/dns_server_api.cpp
+++ b/src/core/api/dns_server_api.cpp
@@ -33,7 +33,7 @@
 
 #include "openthread-core-config.h"
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "net/dns_types.hpp"
 #include "net/dnssd_server.hpp"
 
@@ -46,49 +46,39 @@ void otDnssdQuerySetCallbacks(otInstance *                    aInstance,
                               otDnssdQueryUnsubscribeCallback aUnsubscribe,
                               void *                          aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Dns::ServiceDiscovery::Server>().SetQueryCallbacks(aSubscribe, aUnsubscribe, aContext);
+    AsCoreType(aInstance).Get<Dns::ServiceDiscovery::Server>().SetQueryCallbacks(aSubscribe, aUnsubscribe, aContext);
 }
 
 void otDnssdQueryHandleDiscoveredServiceInstance(otInstance *                aInstance,
                                                  const char *                aServiceFullName,
                                                  otDnssdServiceInstanceInfo *aInstanceInfo)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aServiceFullName != nullptr);
     OT_ASSERT(aInstanceInfo != nullptr);
 
-    instance.Get<Dns::ServiceDiscovery::Server>().HandleDiscoveredServiceInstance(aServiceFullName, *aInstanceInfo);
+    AsCoreType(aInstance).Get<Dns::ServiceDiscovery::Server>().HandleDiscoveredServiceInstance(aServiceFullName,
+                                                                                               *aInstanceInfo);
 }
 
 void otDnssdQueryHandleDiscoveredHost(otInstance *aInstance, const char *aHostFullName, otDnssdHostInfo *aHostInfo)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aHostFullName != nullptr);
     OT_ASSERT(aHostInfo != nullptr);
 
-    instance.Get<Dns::ServiceDiscovery::Server>().HandleDiscoveredHost(aHostFullName, *aHostInfo);
+    AsCoreType(aInstance).Get<Dns::ServiceDiscovery::Server>().HandleDiscoveredHost(aHostFullName, *aHostInfo);
 }
 
 const otDnssdQuery *otDnssdGetNextQuery(otInstance *aInstance, const otDnssdQuery *aQuery)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Dns::ServiceDiscovery::Server>().GetNextQuery(aQuery);
+    return AsCoreType(aInstance).Get<Dns::ServiceDiscovery::Server>().GetNextQuery(aQuery);
 }
 
 otDnssdQueryType otDnssdGetQueryTypeAndName(const otDnssdQuery *aQuery, char (*aNameOutput)[OT_DNS_MAX_NAME_SIZE])
 {
-    otDnssdQueryType type = OT_DNSSD_QUERY_TYPE_NONE;
-
     OT_ASSERT(aQuery != nullptr);
     OT_ASSERT(aNameOutput != nullptr);
-    type = static_cast<otDnssdQueryType>(Dns::ServiceDiscovery::Server::GetQueryTypeAndName(aQuery, *aNameOutput));
 
-    return type;
+    return MapEnum(Dns::ServiceDiscovery::Server::GetQueryTypeAndName(aQuery, *aNameOutput));
 }
 
 #endif // OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE

--- a/src/core/api/history_tracker_api.cpp
+++ b/src/core/api/history_tracker_api.cpp
@@ -37,7 +37,7 @@
 
 #include <openthread/history_tracker.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 #include "utils/history_tracker.hpp"
 
@@ -45,47 +45,35 @@ using namespace ot;
 
 void otHistoryTrackerInitIterator(otHistoryTrackerIterator *aIterator)
 {
-    static_cast<Utils::HistoryTracker::Iterator *>(aIterator)->Init();
+    AsCoreType(aIterator).Init();
 }
 
 const otHistoryTrackerNetworkInfo *otHistoryTrackerIterateNetInfoHistory(otInstance *              aInstance,
                                                                          otHistoryTrackerIterator *aIterator,
                                                                          uint32_t *                aEntryAge)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::HistoryTracker>().IterateNetInfoHistory(
-        *static_cast<Utils::HistoryTracker::Iterator *>(aIterator), *aEntryAge);
+    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateNetInfoHistory(AsCoreType(aIterator), *aEntryAge);
 }
 
 const otHistoryTrackerMessageInfo *otHistoryTrackerIterateRxHistory(otInstance *              aInstance,
                                                                     otHistoryTrackerIterator *aIterator,
                                                                     uint32_t *                aEntryAge)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::HistoryTracker>().IterateRxHistory(
-        *static_cast<Utils::HistoryTracker::Iterator *>(aIterator), *aEntryAge);
+    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateRxHistory(AsCoreType(aIterator), *aEntryAge);
 }
 
 const otHistoryTrackerMessageInfo *otHistoryTrackerIterateTxHistory(otInstance *              aInstance,
                                                                     otHistoryTrackerIterator *aIterator,
                                                                     uint32_t *                aEntryAge)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::HistoryTracker>().IterateTxHistory(
-        *static_cast<Utils::HistoryTracker::Iterator *>(aIterator), *aEntryAge);
+    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateTxHistory(AsCoreType(aIterator), *aEntryAge);
 }
 
 const otHistoryTrackerNeighborInfo *otHistoryTrackerIterateNeighborHistory(otInstance *              aInstance,
                                                                            otHistoryTrackerIterator *aIterator,
                                                                            uint32_t *                aEntryAge)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::HistoryTracker>().IterateNeighborHistory(
-        *static_cast<Utils::HistoryTracker::Iterator *>(aIterator), *aEntryAge);
+    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateNeighborHistory(AsCoreType(aIterator), *aEntryAge);
 }
 
 void otHistoryTrackerEntryAgeToString(uint32_t aEntryAge, char *aBuffer, uint16_t aSize)

--- a/src/core/api/icmp6_api.cpp
+++ b/src/core/api/icmp6_api.cpp
@@ -35,30 +35,24 @@
 
 #include <openthread/icmp6.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
 
 otIcmp6EchoMode otIcmp6GetEchoMode(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Icmp>().GetEchoMode();
+    return AsCoreType(aInstance).Get<Ip6::Icmp>().GetEchoMode();
 }
 
 void otIcmp6SetEchoMode(otInstance *aInstance, otIcmp6EchoMode aMode)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Ip6::Icmp>().SetEchoMode(aMode);
+    AsCoreType(aInstance).Get<Ip6::Icmp>().SetEchoMode(aMode);
 }
 
 otError otIcmp6RegisterHandler(otInstance *aInstance, otIcmp6Handler *aHandler)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Icmp>().RegisterHandler(*static_cast<Ip6::Icmp::Handler *>(aHandler));
+    return AsCoreType(aInstance).Get<Ip6::Icmp>().RegisterHandler(AsCoreType(aHandler));
 }
 
 otError otIcmp6SendEchoRequest(otInstance *         aInstance,
@@ -66,8 +60,6 @@ otError otIcmp6SendEchoRequest(otInstance *         aInstance,
                                const otMessageInfo *aMessageInfo,
                                uint16_t             aIdentifier)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Icmp>().SendEchoRequest(*static_cast<Message *>(aMessage),
-                                                     *static_cast<const Ip6::MessageInfo *>(aMessageInfo), aIdentifier);
+    return AsCoreType(aInstance).Get<Ip6::Icmp>().SendEchoRequest(AsCoreType(aMessage), AsCoreType(aMessageInfo),
+                                                                  aIdentifier);
 }

--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -36,7 +36,7 @@
 #include <openthread/instance.h>
 #include <openthread/platform/misc.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 #include "common/logging.hpp"
 #include "common/new.hpp"
@@ -78,9 +78,7 @@ otInstance *otInstanceInitSingle(void)
 bool otInstanceIsInitialized(otInstance *aInstance)
 {
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.IsInitialized();
+    return AsCoreType(aInstance).IsInitialized();
 #else
     OT_UNUSED_VARIABLE(aInstance);
     return true;
@@ -89,60 +87,45 @@ bool otInstanceIsInitialized(otInstance *aInstance)
 
 void otInstanceFinalize(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-    instance.Finalize();
+    AsCoreType(aInstance).Finalize();
 }
 
 void otInstanceReset(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Reset();
+    AsCoreType(aInstance).Reset();
 }
 
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
 uint64_t otInstanceGetUptime(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Uptime>().GetUptime();
+    return AsCoreType(aInstance).Get<Uptime>().GetUptime();
 }
 
 void otInstanceGetUptimeAsString(otInstance *aInstance, char *aBuffer, uint16_t aSize)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Uptime>().GetUptime(aBuffer, aSize);
+    AsCoreType(aInstance).Get<Uptime>().GetUptime(aBuffer, aSize);
 }
 #endif
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
 otError otSetStateChangedCallback(otInstance *aInstance, otStateChangedCallback aCallback, void *aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Notifier>().RegisterCallback(aCallback, aContext);
+    return AsCoreType(aInstance).Get<Notifier>().RegisterCallback(aCallback, aContext);
 }
 
 void otRemoveStateChangeCallback(otInstance *aInstance, otStateChangedCallback aCallback, void *aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Notifier>().RemoveCallback(aCallback, aContext);
+    AsCoreType(aInstance).Get<Notifier>().RemoveCallback(aCallback, aContext);
 }
 
 void otInstanceFactoryReset(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.FactoryReset();
+    AsCoreType(aInstance).FactoryReset();
 }
 
 otError otInstanceErasePersistentInfo(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.ErasePersistentInfo();
+    return AsCoreType(aInstance).ErasePersistentInfo();
 }
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
@@ -203,7 +186,5 @@ const char *otGetVersionString(void)
 
 const char *otGetRadioVersionString(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Radio>().GetVersionString();
+    return AsCoreType(aInstance).Get<Radio>().GetVersionString();
 }

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -35,7 +35,7 @@
 
 #include <openthread/ip6.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 #include "common/logging.hpp"
 #if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
@@ -47,7 +47,7 @@ using namespace ot;
 otError otIp6SetEnabled(otInstance *aInstance, bool aEnabled)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
     VerifyOrExit(!instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
@@ -70,108 +70,77 @@ exit:
 
 bool otIp6IsEnabled(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<ThreadNetif>().IsUp();
+    return AsCoreType(aInstance).Get<ThreadNetif>().IsUp();
 }
 
 const otNetifAddress *otIp6GetUnicastAddresses(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<ThreadNetif>().GetUnicastAddresses().GetHead();
+    return AsCoreType(aInstance).Get<ThreadNetif>().GetUnicastAddresses().GetHead();
 }
 
 otError otIp6AddUnicastAddress(otInstance *aInstance, const otNetifAddress *aAddress)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<ThreadNetif>().AddExternalUnicastAddress(
-        *static_cast<const Ip6::Netif::UnicastAddress *>(aAddress));
+    return AsCoreType(aInstance).Get<ThreadNetif>().AddExternalUnicastAddress(AsCoreType(aAddress));
 }
 
 otError otIp6RemoveUnicastAddress(otInstance *aInstance, const otIp6Address *aAddress)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<ThreadNetif>().RemoveExternalUnicastAddress(*static_cast<const Ip6::Address *>(aAddress));
+    return AsCoreType(aInstance).Get<ThreadNetif>().RemoveExternalUnicastAddress(AsCoreType(aAddress));
 }
 
 const otNetifMulticastAddress *otIp6GetMulticastAddresses(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<ThreadNetif>().GetMulticastAddresses().GetHead();
+    return AsCoreType(aInstance).Get<ThreadNetif>().GetMulticastAddresses().GetHead();
 }
 
 otError otIp6SubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<ThreadNetif>().SubscribeExternalMulticast(*static_cast<const Ip6::Address *>(aAddress));
+    return AsCoreType(aInstance).Get<ThreadNetif>().SubscribeExternalMulticast(AsCoreType(aAddress));
 }
 
 otError otIp6UnsubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<ThreadNetif>().UnsubscribeExternalMulticast(*static_cast<const Ip6::Address *>(aAddress));
+    return AsCoreType(aInstance).Get<ThreadNetif>().UnsubscribeExternalMulticast(AsCoreType(aAddress));
 }
 
 bool otIp6IsMulticastPromiscuousEnabled(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<ThreadNetif>().IsMulticastPromiscuousEnabled();
+    return AsCoreType(aInstance).Get<ThreadNetif>().IsMulticastPromiscuousEnabled();
 }
 
 void otIp6SetMulticastPromiscuousEnabled(otInstance *aInstance, bool aEnabled)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<ThreadNetif>().SetMulticastPromiscuous(aEnabled);
+    AsCoreType(aInstance).Get<ThreadNetif>().SetMulticastPromiscuous(aEnabled);
 }
 
 void otIp6SetReceiveCallback(otInstance *aInstance, otIp6ReceiveCallback aCallback, void *aCallbackContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Ip6::Ip6>().SetReceiveDatagramCallback(aCallback, aCallbackContext);
+    AsCoreType(aInstance).Get<Ip6::Ip6>().SetReceiveDatagramCallback(aCallback, aCallbackContext);
 }
 
 void otIp6SetAddressCallback(otInstance *aInstance, otIp6AddressCallback aCallback, void *aCallbackContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<ThreadNetif>().SetAddressCallback(aCallback, aCallbackContext);
+    AsCoreType(aInstance).Get<ThreadNetif>().SetAddressCallback(aCallback, aCallbackContext);
 }
 
 bool otIp6IsReceiveFilterEnabled(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Ip6>().IsReceiveIp6FilterEnabled();
+    return AsCoreType(aInstance).Get<Ip6::Ip6>().IsReceiveIp6FilterEnabled();
 }
 
 void otIp6SetReceiveFilterEnabled(otInstance *aInstance, bool aEnabled)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Ip6::Ip6>().SetReceiveIp6FilterEnabled(aEnabled);
+    AsCoreType(aInstance).Get<Ip6::Ip6>().SetReceiveIp6FilterEnabled(aEnabled);
 }
 
 otError otIp6Send(otInstance *aInstance, otMessage *aMessage)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Ip6>().SendRaw(*static_cast<Message *>(aMessage));
+    return AsCoreType(aInstance).Get<Ip6::Ip6>().SendRaw(AsCoreType(aMessage));
 }
 
 otMessage *otIp6NewMessage(otInstance *aInstance, const otMessageSettings *aSettings)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Ip6>().NewMessage(0, Message::Settings::From(aSettings));
+    return AsCoreType(aInstance).Get<Ip6::Ip6>().NewMessage(0, Message::Settings::From(aSettings));
 }
 
 otMessage *otIp6NewMessageFromBuffer(otInstance *             aInstance,
@@ -179,99 +148,79 @@ otMessage *otIp6NewMessageFromBuffer(otInstance *             aInstance,
                                      uint16_t                 aDataLength,
                                      const otMessageSettings *aSettings)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-    Message * message;
-
-    if (aSettings != nullptr)
-    {
-        message =
-            instance.Get<Ip6::Ip6>().NewMessage(aData, aDataLength, *static_cast<const Message::Settings *>(aSettings));
-    }
-    else
-    {
-        message = instance.Get<Ip6::Ip6>().NewMessage(aData, aDataLength);
-    }
-
-    return message;
+    return (aSettings != nullptr)
+               ? AsCoreType(aInstance).Get<Ip6::Ip6>().NewMessage(aData, aDataLength, AsCoreType(aSettings))
+               : AsCoreType(aInstance).Get<Ip6::Ip6>().NewMessage(aData, aDataLength);
 }
 
 otError otIp6AddUnsecurePort(otInstance *aInstance, uint16_t aPort)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Filter>().AddUnsecurePort(aPort);
+    return AsCoreType(aInstance).Get<Ip6::Filter>().AddUnsecurePort(aPort);
 }
 
 otError otIp6RemoveUnsecurePort(otInstance *aInstance, uint16_t aPort)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Filter>().RemoveUnsecurePort(aPort);
+    return AsCoreType(aInstance).Get<Ip6::Filter>().RemoveUnsecurePort(aPort);
 }
 
 void otIp6RemoveAllUnsecurePorts(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Ip6::Filter>().RemoveAllUnsecurePorts();
+    AsCoreType(aInstance).Get<Ip6::Filter>().RemoveAllUnsecurePorts();
 }
 
 const uint16_t *otIp6GetUnsecurePorts(otInstance *aInstance, uint8_t *aNumEntries)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Filter>().GetUnsecurePorts(*aNumEntries);
+    return AsCoreType(aInstance).Get<Ip6::Filter>().GetUnsecurePorts(*aNumEntries);
 }
 
 bool otIp6IsAddressEqual(const otIp6Address *aFirst, const otIp6Address *aSecond)
 {
-    return *static_cast<const Ip6::Address *>(aFirst) == *static_cast<const Ip6::Address *>(aSecond);
+    return AsCoreType(aFirst) == AsCoreType(aSecond);
 }
 
 bool otIp6ArePrefixesEqual(const otIp6Prefix *aFirst, const otIp6Prefix *aSecond)
 {
-    return *static_cast<const Ip6::Prefix *>(aFirst) == *static_cast<const Ip6::Prefix *>(aSecond);
+    return AsCoreType(aFirst) == AsCoreType(aSecond);
 }
 
 otError otIp6AddressFromString(const char *aString, otIp6Address *aAddress)
 {
-    return static_cast<Ip6::Address *>(aAddress)->FromString(aString);
+    return AsCoreType(aAddress).FromString(aString);
 }
 
 void otIp6AddressToString(const otIp6Address *aAddress, char *aBuffer, uint16_t aSize)
 {
-    static_cast<const Ip6::Address *>(aAddress)->ToString(aBuffer, aSize);
+    AsCoreType(aAddress).ToString(aBuffer, aSize);
 }
 
 void otIp6SockAddrToString(const otSockAddr *aSockAddr, char *aBuffer, uint16_t aSize)
 {
-    static_cast<const Ip6::SockAddr *>(aSockAddr)->ToString(aBuffer, aSize);
+    AsCoreType(aSockAddr).ToString(aBuffer, aSize);
 }
 
 void otIp6PrefixToString(const otIp6Prefix *aPrefix, char *aBuffer, uint16_t aSize)
 {
-    static_cast<const Ip6::Prefix *>(aPrefix)->ToString(aBuffer, aSize);
+    AsCoreType(aPrefix).ToString(aBuffer, aSize);
 }
 
 uint8_t otIp6PrefixMatch(const otIp6Address *aFirst, const otIp6Address *aSecond)
 {
     OT_ASSERT(aFirst != nullptr && aSecond != nullptr);
 
-    return static_cast<const Ip6::Address *>(aFirst)->PrefixMatch(*static_cast<const Ip6::Address *>(aSecond));
+    return AsCoreType(aFirst).PrefixMatch(AsCoreType(aSecond));
 }
 
 bool otIp6IsAddressUnspecified(const otIp6Address *aAddress)
 {
-    return static_cast<const Ip6::Address *>(aAddress)->IsUnspecified();
+    return AsCoreType(aAddress).IsUnspecified();
 }
 
 otError otIp6SelectSourceAddress(otInstance *aInstance, otMessageInfo *aMessageInfo)
 {
-    Error                             error    = kErrorNone;
-    Instance &                        instance = *static_cast<Instance *>(aInstance);
+    Error                             error = kErrorNone;
     const Ip6::Netif::UnicastAddress *netifAddr;
 
-    netifAddr = instance.Get<Ip6::Ip6>().SelectSourceAddress(*static_cast<Ip6::MessageInfo *>(aMessageInfo));
+    netifAddr = AsCoreType(aInstance).Get<Ip6::Ip6>().SelectSourceAddress(AsCoreType(aMessageInfo));
     VerifyOrExit(netifAddr != nullptr, error = kErrorNotFound);
     aMessageInfo->mSockAddr = netifAddr->GetAddress();
 
@@ -287,10 +236,8 @@ otError otIp6RegisterMulticastListeners(otInstance *                            
                                         otIp6RegisterMulticastListenersCallback aCallback,
                                         void *                                  aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MlrManager>().RegisterMulticastListeners(aAddresses, aAddressNum, aTimeout, aCallback,
-                                                                 aContext);
+    return AsCoreType(aInstance).Get<MlrManager>().RegisterMulticastListeners(aAddresses, aAddressNum, aTimeout,
+                                                                              aCallback, aContext);
 }
 #endif
 
@@ -298,12 +245,12 @@ otError otIp6RegisterMulticastListeners(otInstance *                            
 
 bool otIp6IsSlaacEnabled(otInstance *aInstance)
 {
-    return static_cast<Instance *>(aInstance)->Get<Utils::Slaac>().IsEnabled();
+    return AsCoreType(aInstance).Get<Utils::Slaac>().IsEnabled();
 }
 
 void otIp6SetSlaacEnabled(otInstance *aInstance, bool aEnabled)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     if (aEnabled)
     {
@@ -317,9 +264,7 @@ void otIp6SetSlaacEnabled(otInstance *aInstance, bool aEnabled)
 
 void otIp6SetSlaacPrefixFilter(otInstance *aInstance, otIp6SlaacPrefixFilter aFilter)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Utils::Slaac>().SetFilter(aFilter);
+    AsCoreType(aInstance).Get<Utils::Slaac>().SetFilter(aFilter);
 }
 
 #endif // OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
@@ -328,9 +273,7 @@ void otIp6SetSlaacPrefixFilter(otInstance *aInstance, otIp6SlaacPrefixFilter aFi
 
 otError otIp6SetMeshLocalIid(otInstance *aInstance, const otIp6InterfaceIdentifier *aIid)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().SetMeshLocalIid(static_cast<const Ip6::InterfaceIdentifier &>(*aIid));
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().SetMeshLocalIid(AsCoreType(aIid));
 }
 
 #endif

--- a/src/core/api/jam_detection_api.cpp
+++ b/src/core/api/jam_detection_api.cpp
@@ -37,88 +37,66 @@
 
 #include <openthread/jam_detection.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
 
 otError otJamDetectionSetRssiThreshold(otInstance *aInstance, int8_t aRssiThreshold)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Utils::JamDetector>().SetRssiThreshold(aRssiThreshold);
+    AsCoreType(aInstance).Get<Utils::JamDetector>().SetRssiThreshold(aRssiThreshold);
 
     return kErrorNone;
 }
 
 int8_t otJamDetectionGetRssiThreshold(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::JamDetector>().GetRssiThreshold();
+    return AsCoreType(aInstance).Get<Utils::JamDetector>().GetRssiThreshold();
 }
 
 otError otJamDetectionSetWindow(otInstance *aInstance, uint8_t aWindow)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::JamDetector>().SetWindow(aWindow);
+    return AsCoreType(aInstance).Get<Utils::JamDetector>().SetWindow(aWindow);
 }
 
 uint8_t otJamDetectionGetWindow(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::JamDetector>().GetWindow();
+    return AsCoreType(aInstance).Get<Utils::JamDetector>().GetWindow();
 }
 
 otError otJamDetectionSetBusyPeriod(otInstance *aInstance, uint8_t aBusyPeriod)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::JamDetector>().SetBusyPeriod(aBusyPeriod);
+    return AsCoreType(aInstance).Get<Utils::JamDetector>().SetBusyPeriod(aBusyPeriod);
 }
 
 uint8_t otJamDetectionGetBusyPeriod(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::JamDetector>().GetBusyPeriod();
+    return AsCoreType(aInstance).Get<Utils::JamDetector>().GetBusyPeriod();
 }
 
 otError otJamDetectionStart(otInstance *aInstance, otJamDetectionCallback aCallback, void *aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::JamDetector>().Start(aCallback, aContext);
+    return AsCoreType(aInstance).Get<Utils::JamDetector>().Start(aCallback, aContext);
 }
 
 otError otJamDetectionStop(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::JamDetector>().Stop();
+    return AsCoreType(aInstance).Get<Utils::JamDetector>().Stop();
 }
 
 bool otJamDetectionIsEnabled(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::JamDetector>().IsEnabled();
+    return AsCoreType(aInstance).Get<Utils::JamDetector>().IsEnabled();
 }
 
 bool otJamDetectionGetState(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::JamDetector>().GetState();
+    return AsCoreType(aInstance).Get<Utils::JamDetector>().GetState();
 }
 
 uint64_t otJamDetectionGetHistoryBitmap(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::JamDetector>().GetHistoryBitmap();
+    return AsCoreType(aInstance).Get<Utils::JamDetector>().GetHistoryBitmap();
 }
 
 #endif // OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE

--- a/src/core/api/joiner_api.cpp
+++ b/src/core/api/joiner_api.cpp
@@ -37,7 +37,7 @@
 
 #include <openthread/joiner.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
@@ -52,41 +52,33 @@ otError otJoinerStart(otInstance *     aInstance,
                       otJoinerCallback aCallback,
                       void *           aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Joiner>().Start(aPskd, aProvisioningUrl, aVendorName, aVendorModel, aVendorSwVersion,
-                                                 aVendorData, aCallback, aContext);
+    return AsCoreType(aInstance).Get<MeshCoP::Joiner>().Start(aPskd, aProvisioningUrl, aVendorName, aVendorModel,
+                                                              aVendorSwVersion, aVendorData, aCallback, aContext);
 }
 
 void otJoinerStop(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<MeshCoP::Joiner>().Stop();
+    AsCoreType(aInstance).Get<MeshCoP::Joiner>().Stop();
 }
 
 otJoinerState otJoinerGetState(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return static_cast<otJoinerState>(instance.Get<MeshCoP::Joiner>().GetState());
+    return MapEnum(AsCoreType(aInstance).Get<MeshCoP::Joiner>().GetState());
 }
 
 const otExtAddress *otJoinerGetId(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<MeshCoP::Joiner>().GetId();
+    return &AsCoreType(aInstance).Get<MeshCoP::Joiner>().GetId();
 }
 
 otError otJoinerSetDiscerner(otInstance *aInstance, otJoinerDiscerner *aDiscerner)
 {
     Error            error  = kErrorNone;
-    MeshCoP::Joiner &joiner = static_cast<Instance *>(aInstance)->Get<MeshCoP::Joiner>();
+    MeshCoP::Joiner &joiner = AsCoreType(aInstance).Get<MeshCoP::Joiner>();
 
     if (aDiscerner != nullptr)
     {
-        error = joiner.SetDiscerner(*static_cast<const MeshCoP::JoinerDiscerner *>(aDiscerner));
+        error = joiner.SetDiscerner(AsCoreType(aDiscerner));
     }
     else
     {
@@ -98,9 +90,7 @@ otError otJoinerSetDiscerner(otInstance *aInstance, otJoinerDiscerner *aDiscerne
 
 const otJoinerDiscerner *otJoinerGetDiscerner(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::Joiner>().GetDiscerner();
+    return AsCoreType(aInstance).Get<MeshCoP::Joiner>().GetDiscerner();
 }
 
 #endif // OPENTHREAD_CONFIG_JOINER_ENABLE

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -35,7 +35,7 @@
 
 #include <openthread/link.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 #include "mac/mac.hpp"
 #include "radio/radio.hpp"
@@ -44,7 +44,7 @@ using namespace ot;
 
 uint8_t otLinkGetChannel(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
     uint8_t   channel;
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
@@ -64,7 +64,7 @@ uint8_t otLinkGetChannel(otInstance *aInstance)
 otError otLinkSetChannel(otInstance *aInstance, uint8_t aChannel)
 {
     Error     error;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
 #if OPENTHREAD_CONFIG_LINK_RAW_ENABLE
     if (instance.Get<Mac::LinkRaw>().IsEnabled())
@@ -86,19 +86,17 @@ exit:
 
 uint32_t otLinkGetSupportedChannelMask(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().GetSupportedChannelMask().GetMask();
+    return AsCoreType(aInstance).Get<Mac::Mac>().GetSupportedChannelMask().GetMask();
 }
 
 otError otLinkSetSupportedChannelMask(otInstance *aInstance, uint32_t aChannelMask)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
-    instance.Get<Mac::Mac>().SetSupportedChannelMask(static_cast<Mac::ChannelMask>(aChannelMask));
+    instance.Get<Mac::Mac>().SetSupportedChannelMask(Mac::ChannelMask(aChannelMask));
 
 exit:
     return error;
@@ -106,20 +104,18 @@ exit:
 
 const otExtAddress *otLinkGetExtendedAddress(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<Mac::Mac>().GetExtAddress();
+    return &AsCoreType(aInstance).Get<Mac::Mac>().GetExtAddress();
 }
 
 otError otLinkSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     OT_ASSERT(aExtAddress != nullptr);
     VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
-    instance.Get<Mac::Mac>().SetExtAddress(*static_cast<const Mac::ExtAddress *>(aExtAddress));
+    instance.Get<Mac::Mac>().SetExtAddress(AsCoreType(aExtAddress));
 
     instance.Get<Mle::MleRouter>().UpdateLinkLocalAddress();
 
@@ -129,22 +125,18 @@ exit:
 
 void otLinkGetFactoryAssignedIeeeEui64(otInstance *aInstance, otExtAddress *aEui64)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Radio>().GetIeeeEui64(*static_cast<Mac::ExtAddress *>(aEui64));
+    AsCoreType(aInstance).Get<Radio>().GetIeeeEui64(AsCoreType(aEui64));
 }
 
 otPanId otLinkGetPanId(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().GetPanId();
+    return AsCoreType(aInstance).Get<Mac::Mac>().GetPanId();
 }
 
 otError otLinkSetPanId(otInstance *aInstance, otPanId aPanId)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
@@ -158,60 +150,44 @@ exit:
 
 uint32_t otLinkGetPollPeriod(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<DataPollSender>().GetKeepAlivePollPeriod();
+    return AsCoreType(aInstance).Get<DataPollSender>().GetKeepAlivePollPeriod();
 }
 
 otError otLinkSetPollPeriod(otInstance *aInstance, uint32_t aPollPeriod)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<DataPollSender>().SetExternalPollPeriod(aPollPeriod);
+    return AsCoreType(aInstance).Get<DataPollSender>().SetExternalPollPeriod(aPollPeriod);
 }
 
 otError otLinkSendDataRequest(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<DataPollSender>().SendDataPoll();
+    return AsCoreType(aInstance).Get<DataPollSender>().SendDataPoll();
 }
 
 otShortAddress otLinkGetShortAddress(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().GetShortAddress();
+    return AsCoreType(aInstance).Get<Mac::Mac>().GetShortAddress();
 }
 
 uint8_t otLinkGetMaxFrameRetriesDirect(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().GetMaxFrameRetriesDirect();
+    return AsCoreType(aInstance).Get<Mac::Mac>().GetMaxFrameRetriesDirect();
 }
 
 void otLinkSetMaxFrameRetriesDirect(otInstance *aInstance, uint8_t aMaxFrameRetriesDirect)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mac::Mac>().SetMaxFrameRetriesDirect(aMaxFrameRetriesDirect);
+    AsCoreType(aInstance).Get<Mac::Mac>().SetMaxFrameRetriesDirect(aMaxFrameRetriesDirect);
 }
 
 #if OPENTHREAD_FTD
 
 uint8_t otLinkGetMaxFrameRetriesIndirect(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().GetMaxFrameRetriesIndirect();
+    return AsCoreType(aInstance).Get<Mac::Mac>().GetMaxFrameRetriesIndirect();
 }
 
 void otLinkSetMaxFrameRetriesIndirect(otInstance *aInstance, uint8_t aMaxFrameRetriesIndirect)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mac::Mac>().SetMaxFrameRetriesIndirect(aMaxFrameRetriesIndirect);
+    AsCoreType(aInstance).Get<Mac::Mac>().SetMaxFrameRetriesIndirect(aMaxFrameRetriesIndirect);
 }
 
 #endif // OPENTHREAD_FTD
@@ -220,112 +196,85 @@ void otLinkSetMaxFrameRetriesIndirect(otInstance *aInstance, uint8_t aMaxFrameRe
 
 otMacFilterAddressMode otLinkFilterGetAddressMode(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return static_cast<otMacFilterAddressMode>(instance.Get<Mac::Filter>().GetMode());
+    return MapEnum(AsCoreType(aInstance).Get<Mac::Filter>().GetMode());
 }
 
 void otLinkFilterSetAddressMode(otInstance *aInstance, otMacFilterAddressMode aMode)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mac::Filter>().SetMode(static_cast<Mac::Filter::Mode>(aMode));
+    AsCoreType(aInstance).Get<Mac::Filter>().SetMode(MapEnum(aMode));
 }
 
 otError otLinkFilterAddAddress(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aExtAddress != nullptr);
 
-    return instance.Get<Mac::Filter>().AddAddress(*static_cast<const Mac::ExtAddress *>(aExtAddress));
+    return AsCoreType(aInstance).Get<Mac::Filter>().AddAddress(AsCoreType(aExtAddress));
 }
 
 void otLinkFilterRemoveAddress(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aExtAddress != nullptr);
 
-    instance.Get<Mac::Filter>().RemoveAddress(*static_cast<const Mac::ExtAddress *>(aExtAddress));
+    AsCoreType(aInstance).Get<Mac::Filter>().RemoveAddress(AsCoreType(aExtAddress));
 }
 
 void otLinkFilterClearAddresses(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Filter>().ClearAddresses();
+    return AsCoreType(aInstance).Get<Mac::Filter>().ClearAddresses();
 }
 
 otError otLinkFilterGetNextAddress(otInstance *aInstance, otMacFilterIterator *aIterator, otMacFilterEntry *aEntry)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aIterator != nullptr && aEntry != nullptr);
 
-    return instance.Get<Mac::Filter>().GetNextAddress(*aIterator, *aEntry);
+    return AsCoreType(aInstance).Get<Mac::Filter>().GetNextAddress(*aIterator, *aEntry);
 }
 
 otError otLinkFilterAddRssIn(otInstance *aInstance, const otExtAddress *aExtAddress, int8_t aRss)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aExtAddress != nullptr);
 
-    return instance.Get<Mac::Filter>().AddRssIn(*static_cast<const Mac::ExtAddress *>(aExtAddress), aRss);
+    return AsCoreType(aInstance).Get<Mac::Filter>().AddRssIn(AsCoreType(aExtAddress), aRss);
 }
 
 void otLinkFilterRemoveRssIn(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aExtAddress != nullptr);
 
-    instance.Get<Mac::Filter>().RemoveRssIn(*static_cast<const Mac::ExtAddress *>(aExtAddress));
+    AsCoreType(aInstance).Get<Mac::Filter>().RemoveRssIn(AsCoreType(aExtAddress));
 }
 
 void otLinkFilterSetDefaultRssIn(otInstance *aInstance, int8_t aRss)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mac::Filter>().SetDefaultRssIn(aRss);
+    AsCoreType(aInstance).Get<Mac::Filter>().SetDefaultRssIn(aRss);
 }
 
 void otLinkFilterClearDefaultRssIn(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mac::Filter>().ClearDefaultRssIn();
+    AsCoreType(aInstance).Get<Mac::Filter>().ClearDefaultRssIn();
 }
 
 void otLinkFilterClearAllRssIn(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mac::Filter>().ClearAllRssIn();
+    AsCoreType(aInstance).Get<Mac::Filter>().ClearAllRssIn();
 }
 
 otError otLinkFilterGetNextRssIn(otInstance *aInstance, otMacFilterIterator *aIterator, otMacFilterEntry *aEntry)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aIterator != nullptr && aEntry != nullptr);
 
-    return instance.Get<Mac::Filter>().GetNextRssIn(*aIterator, *aEntry);
+    return AsCoreType(aInstance).Get<Mac::Filter>().GetNextRssIn(*aIterator, *aEntry);
 }
 
 uint8_t otLinkConvertRssToLinkQuality(otInstance *aInstance, int8_t aRss)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return LinkQualityInfo::ConvertRssToLinkQuality(instance.Get<Mac::Mac>().GetNoiseFloor(), aRss);
+    return LinkQualityInfo::ConvertRssToLinkQuality(AsCoreType(aInstance).Get<Mac::Mac>().GetNoiseFloor(), aRss);
 }
 
 int8_t otLinkConvertLinkQualityToRss(otInstance *aInstance, uint8_t aLinkQuality)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return LinkQualityInfo::ConvertLinkQualityToRss(instance.Get<Mac::Mac>().GetNoiseFloor(), aLinkQuality);
+    return LinkQualityInfo::ConvertLinkQualityToRss(AsCoreType(aInstance).Get<Mac::Mac>().GetNoiseFloor(),
+                                                    aLinkQuality);
 }
 
 #endif // OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
@@ -333,9 +282,7 @@ int8_t otLinkConvertLinkQualityToRss(otInstance *aInstance, uint8_t aLinkQuality
 #if OPENTHREAD_CONFIG_MAC_RETRY_SUCCESS_HISTOGRAM_ENABLE
 const uint32_t *otLinkGetTxDirectRetrySuccessHistogram(otInstance *aInstance, uint8_t *aNumberOfEntries)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().GetDirectRetrySuccessHistogram(*aNumberOfEntries);
+    return AsCoreType(aInstance).Get<Mac::Mac>().GetDirectRetrySuccessHistogram(*aNumberOfEntries);
 }
 
 const uint32_t *otLinkGetTxIndirectRetrySuccessHistogram(otInstance *aInstance, uint8_t *aNumberOfEntries)
@@ -343,9 +290,7 @@ const uint32_t *otLinkGetTxIndirectRetrySuccessHistogram(otInstance *aInstance, 
     const uint32_t *histogram = nullptr;
 
 #if OPENTHREAD_FTD
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    histogram = instance.Get<Mac::Mac>().GetIndirectRetrySuccessHistogram(*aNumberOfEntries);
+    histogram = AsCoreType(aInstance).Get<Mac::Mac>().GetIndirectRetrySuccessHistogram(*aNumberOfEntries);
 #else
     OT_UNUSED_VARIABLE(aInstance);
     *aNumberOfEntries = 0;
@@ -356,30 +301,24 @@ const uint32_t *otLinkGetTxIndirectRetrySuccessHistogram(otInstance *aInstance, 
 
 void otLinkResetTxRetrySuccessHistogram(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mac::Mac>().ResetRetrySuccessHistogram();
+    AsCoreType(aInstance).Get<Mac::Mac>().ResetRetrySuccessHistogram();
 }
 #endif // OPENTHREAD_CONFIG_MAC_RETRY_SUCCESS_HISTOGRAM_ENABLE
 
 void otLinkSetPcapCallback(otInstance *aInstance, otLinkPcapCallback aPcapCallback, void *aCallbackContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mac::Mac>().SetPcapCallback(aPcapCallback, aCallbackContext);
+    AsCoreType(aInstance).Get<Mac::Mac>().SetPcapCallback(aPcapCallback, aCallbackContext);
 }
 
 bool otLinkIsPromiscuous(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().IsPromiscuous();
+    return AsCoreType(aInstance).Get<Mac::Mac>().IsPromiscuous();
 }
 
 otError otLinkSetPromiscuous(otInstance *aInstance, bool aPromiscuous)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     // cannot enable IEEE 802.15.4 promiscuous mode if the Thread interface is enabled
     VerifyOrExit(!instance.Get<ThreadNetif>().IsUp(), error = kErrorInvalidState);
@@ -393,7 +332,7 @@ exit:
 otError otLinkSetEnabled(otInstance *aInstance, bool aEnable)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     // cannot disable the link layer if the Thread interface is enabled
     VerifyOrExit(!instance.Get<ThreadNetif>().IsUp(), error = kErrorInvalidState);
@@ -406,23 +345,17 @@ exit:
 
 bool otLinkIsEnabled(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().IsEnabled();
+    return AsCoreType(aInstance).Get<Mac::Mac>().IsEnabled();
 }
 
 const otMacCounters *otLinkGetCounters(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<Mac::Mac>().GetCounters();
+    return &AsCoreType(aInstance).Get<Mac::Mac>().GetCounters();
 }
 
 void otLinkResetCounters(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mac::Mac>().ResetCounters();
+    AsCoreType(aInstance).Get<Mac::Mac>().ResetCounters();
 }
 
 otError otLinkActiveScan(otInstance *             aInstance,
@@ -431,16 +364,12 @@ otError otLinkActiveScan(otInstance *             aInstance,
                          otHandleActiveScanResult aCallback,
                          void *                   aCallbackContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().ActiveScan(aScanChannels, aScanDuration, aCallback, aCallbackContext);
+    return AsCoreType(aInstance).Get<Mac::Mac>().ActiveScan(aScanChannels, aScanDuration, aCallback, aCallbackContext);
 }
 
 bool otLinkIsActiveScanInProgress(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().IsActiveScanInProgress();
+    return AsCoreType(aInstance).Get<Mac::Mac>().IsActiveScanInProgress();
 }
 
 otError otLinkEnergyScan(otInstance *             aInstance,
@@ -449,46 +378,37 @@ otError otLinkEnergyScan(otInstance *             aInstance,
                          otHandleEnergyScanResult aCallback,
                          void *                   aCallbackContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().EnergyScan(aScanChannels, aScanDuration, aCallback, aCallbackContext);
+    return AsCoreType(aInstance).Get<Mac::Mac>().EnergyScan(aScanChannels, aScanDuration, aCallback, aCallbackContext);
 }
 
 bool otLinkIsEnergyScanInProgress(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().IsEnergyScanInProgress();
+    return AsCoreType(aInstance).Get<Mac::Mac>().IsEnergyScanInProgress();
 }
 
 bool otLinkIsInTransmitState(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().IsInTransmitState();
+    return AsCoreType(aInstance).Get<Mac::Mac>().IsInTransmitState();
 }
 
 uint16_t otLinkGetCcaFailureRate(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().GetCcaFailureRate();
+    return AsCoreType(aInstance).Get<Mac::Mac>().GetCcaFailureRate();
 }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 uint8_t otLinkCslGetChannel(otInstance *aInstance)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::Mac>().GetCslChannel();
+    return AsCoreType(aInstance).Get<Mac::Mac>().GetCslChannel();
 }
 
 otError otLinkCslSetChannel(otInstance *aInstance, uint8_t aChannel)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
     VerifyOrExit(Radio::IsCslChannelValid(aChannel), error = kErrorInvalidArgs);
 
-    instance.Get<Mac::Mac>().SetCslChannel(aChannel);
+    AsCoreType(aInstance).Get<Mac::Mac>().SetCslChannel(aChannel);
 
 exit:
     return error;
@@ -496,16 +416,15 @@ exit:
 
 uint16_t otLinkCslGetPeriod(otInstance *aInstance)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::Mac>().GetCslPeriod();
+    return AsCoreType(aInstance).Get<Mac::Mac>().GetCslPeriod();
 }
 
 otError otLinkCslSetPeriod(otInstance *aInstance, uint16_t aPeriod)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
     VerifyOrExit((aPeriod == 0 || kMinCslPeriod <= aPeriod), error = kErrorInvalidArgs);
-    instance.Get<Mac::Mac>().SetCslPeriod(aPeriod);
+    AsCoreType(aInstance).Get<Mac::Mac>().SetCslPeriod(aPeriod);
 
 exit:
     return error;
@@ -513,16 +432,15 @@ exit:
 
 uint32_t otLinkCslGetTimeout(otInstance *aInstance)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mle::MleRouter>().GetCslTimeout();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetCslTimeout();
 }
 
 otError otLinkCslSetTimeout(otInstance *aInstance, uint32_t aTimeout)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
     VerifyOrExit(kMaxCslTimeout >= aTimeout, error = kErrorInvalidArgs);
-    instance.Get<Mle::MleRouter>().SetCslTimeout(aTimeout);
+    AsCoreType(aInstance).Get<Mle::MleRouter>().SetCslTimeout(aTimeout);
 
 exit:
     return error;
@@ -533,8 +451,6 @@ exit:
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 otError otLinkSendEmptyData(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshForwarder>().SendEmptyMessage();
+    return AsCoreType(aInstance).Get<MeshForwarder>().SendEmptyMessage();
 }
 #endif

--- a/src/core/api/link_metrics_api.cpp
+++ b/src/core/api/link_metrics_api.cpp
@@ -37,8 +37,7 @@
 
 #include <openthread/link_metrics.h>
 
-#include "common/instance.hpp"
-#include "net/ip6_address.hpp"
+#include "common/as_core_type.hpp"
 
 using namespace ot;
 
@@ -51,11 +50,10 @@ otError otLinkMetricsQuery(otInstance *                aInstance,
 {
     OT_ASSERT(aDestination != nullptr);
 
-    static_cast<Instance *>(aInstance)->Get<LinkMetrics::LinkMetrics>().SetReportCallback(aCallback, aCallbackContext);
+    AsCoreType(aInstance).Get<LinkMetrics::LinkMetrics>().SetReportCallback(aCallback, aCallbackContext);
 
-    return static_cast<Instance *>(aInstance)->Get<LinkMetrics::LinkMetrics>().Query(
-        static_cast<const Ip6::Address &>(*aDestination), aSeriesId,
-        static_cast<const LinkMetrics::Metrics *>(aLinkMetricsFlags));
+    return AsCoreType(aInstance).Get<LinkMetrics::LinkMetrics>().Query(AsCoreType(aDestination), aSeriesId,
+                                                                       AsCoreTypePtr(aLinkMetricsFlags));
 }
 
 otError otLinkMetricsConfigForwardTrackingSeries(otInstance *                      aInstance,
@@ -68,13 +66,12 @@ otError otLinkMetricsConfigForwardTrackingSeries(otInstance *                   
 {
     OT_ASSERT(aDestination != nullptr);
 
-    LinkMetrics::LinkMetrics &linkMetrics = static_cast<Instance *>(aInstance)->Get<LinkMetrics::LinkMetrics>();
+    LinkMetrics::LinkMetrics &linkMetrics = AsCoreType(aInstance).Get<LinkMetrics::LinkMetrics>();
 
     linkMetrics.SetMgmtResponseCallback(aCallback, aCallbackContext);
 
-    return linkMetrics.SendMgmtRequestForwardTrackingSeries(
-        static_cast<const Ip6::Address &>(*aDestination), aSeriesId, aSeriesFlags,
-        static_cast<const LinkMetrics::Metrics *>(aLinkMetricsFlags));
+    return linkMetrics.SendMgmtRequestForwardTrackingSeries(AsCoreType(aDestination), aSeriesId, aSeriesFlags,
+                                                            AsCoreTypePtr(aLinkMetricsFlags));
 }
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
@@ -89,14 +86,13 @@ otError otLinkMetricsConfigEnhAckProbing(otInstance *                           
 {
     OT_ASSERT(aDestination != nullptr);
 
-    LinkMetrics::LinkMetrics &linkMetrics = static_cast<Instance *>(aInstance)->Get<LinkMetrics::LinkMetrics>();
+    LinkMetrics::LinkMetrics &linkMetrics = AsCoreType(aInstance).Get<LinkMetrics::LinkMetrics>();
 
     linkMetrics.SetMgmtResponseCallback(aCallback, aCallbackContext);
     linkMetrics.SetEnhAckProbingCallback(aEnhAckCallback, aEnhAckCallbackContext);
 
-    return linkMetrics.SendMgmtRequestEnhAckProbing(static_cast<const Ip6::Address &>(*aDestination),
-                                                    static_cast<LinkMetrics::EnhAckFlags>(aEnhAckFlags),
-                                                    static_cast<const LinkMetrics::Metrics *>(aLinkMetricsFlags));
+    return linkMetrics.SendMgmtRequestEnhAckProbing(AsCoreType(aDestination), MapEnum(aEnhAckFlags),
+                                                    AsCoreTypePtr(aLinkMetricsFlags));
 }
 
 otError otLinkMetricsSendLinkProbe(otInstance *        aInstance,
@@ -105,9 +101,9 @@ otError otLinkMetricsSendLinkProbe(otInstance *        aInstance,
                                    uint8_t             aLength)
 {
     OT_ASSERT(aDestination != nullptr);
-    LinkMetrics::LinkMetrics &linkMetrics = static_cast<Instance *>(aInstance)->Get<LinkMetrics::LinkMetrics>();
+    LinkMetrics::LinkMetrics &linkMetrics = AsCoreType(aInstance).Get<LinkMetrics::LinkMetrics>();
 
-    return linkMetrics.SendLinkProbe(static_cast<const Ip6::Address &>(*aDestination), aSeriesId, aLength);
+    return linkMetrics.SendLinkProbe(AsCoreType(aDestination), aSeriesId, aLength);
 }
 #endif
 

--- a/src/core/api/link_raw_api.cpp
+++ b/src/core/api/link_raw_api.cpp
@@ -41,8 +41,8 @@
 #include <openthread/platform/diag.h>
 #include <openthread/platform/time.h>
 
+#include "common/as_core_type.hpp"
 #include "common/debug.hpp"
-#include "common/instance.hpp"
 #include "common/locator_getters.hpp"
 #include "common/random.hpp"
 #include "mac/mac_frame.hpp"
@@ -51,28 +51,28 @@ using namespace ot;
 
 otError otLinkRawSetReceiveDone(otInstance *aInstance, otLinkRawReceiveDone aCallback)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().SetReceiveDone(aCallback);
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().SetReceiveDone(aCallback);
 }
 
 bool otLinkRawIsEnabled(otInstance *aInstance)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().IsEnabled();
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().IsEnabled();
 }
 
 otError otLinkRawSetShortAddress(otInstance *aInstance, uint16_t aShortAddress)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().SetShortAddress(aShortAddress);
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().SetShortAddress(aShortAddress);
 }
 
 bool otLinkRawGetPromiscuous(otInstance *aInstance)
 {
-    return static_cast<Instance *>(aInstance)->Get<Radio>().GetPromiscuous();
+    return AsCoreType(aInstance).Get<Radio>().GetPromiscuous();
 }
 
 otError otLinkRawSetPromiscuous(otInstance *aInstance, bool aEnable)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
     instance.Get<Radio>().SetPromiscuous(aEnable);
@@ -84,7 +84,7 @@ exit:
 otError otLinkRawSleep(otInstance *aInstance)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
@@ -96,27 +96,27 @@ exit:
 
 otError otLinkRawReceive(otInstance *aInstance)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().Receive();
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().Receive();
 }
 
 otRadioFrame *otLinkRawGetTransmitBuffer(otInstance *aInstance)
 {
-    return &static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().GetTransmitFrame();
+    return &AsCoreType(aInstance).Get<Mac::LinkRaw>().GetTransmitFrame();
 }
 
 otError otLinkRawTransmit(otInstance *aInstance, otLinkRawTransmitDone aCallback)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().Transmit(aCallback);
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().Transmit(aCallback);
 }
 
 int8_t otLinkRawGetRssi(otInstance *aInstance)
 {
-    return static_cast<Instance *>(aInstance)->Get<Radio>().GetRssi();
+    return AsCoreType(aInstance).Get<Radio>().GetRssi();
 }
 
 otRadioCaps otLinkRawGetCaps(otInstance *aInstance)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().GetCaps();
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().GetCaps();
 }
 
 otError otLinkRawEnergyScan(otInstance *            aInstance,
@@ -124,13 +124,13 @@ otError otLinkRawEnergyScan(otInstance *            aInstance,
                             uint16_t                aScanDuration,
                             otLinkRawEnergyScanDone aCallback)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().EnergyScan(aScanChannel, aScanDuration, aCallback);
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().EnergyScan(aScanChannel, aScanDuration, aCallback);
 }
 
 otError otLinkRawSrcMatchEnable(otInstance *aInstance, bool aEnable)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
@@ -143,7 +143,7 @@ exit:
 otError otLinkRawSrcMatchAddShortEntry(otInstance *aInstance, uint16_t aShortAddress)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
@@ -157,7 +157,7 @@ otError otLinkRawSrcMatchAddExtEntry(otInstance *aInstance, const otExtAddress *
 {
     Mac::ExtAddress address;
     Error           error    = kErrorNone;
-    Instance &      instance = *static_cast<Instance *>(aInstance);
+    Instance &      instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
@@ -171,7 +171,7 @@ exit:
 otError otLinkRawSrcMatchClearShortEntry(otInstance *aInstance, uint16_t aShortAddress)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
     error = instance.Get<Radio>().ClearSrcMatchShortEntry(aShortAddress);
@@ -184,7 +184,7 @@ otError otLinkRawSrcMatchClearExtEntry(otInstance *aInstance, const otExtAddress
 {
     Mac::ExtAddress address;
     Error           error    = kErrorNone;
-    Instance &      instance = *static_cast<Instance *>(aInstance);
+    Instance &      instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
@@ -198,7 +198,7 @@ exit:
 otError otLinkRawSrcMatchClearShortEntries(otInstance *aInstance)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
@@ -211,7 +211,7 @@ exit:
 otError otLinkRawSrcMatchClearExtEntries(otInstance *aInstance)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.Get<Mac::LinkRaw>().IsEnabled(), error = kErrorInvalidState);
 
@@ -228,14 +228,13 @@ otError otLinkRawSetMacKey(otInstance *    aInstance,
                            const otMacKey *aCurrKey,
                            const otMacKey *aNextKey)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().SetMacKey(
-        aKeyIdMode, aKeyId, *static_cast<const Mac::Key *>(aPrevKey), *static_cast<const Mac::Key *>(aCurrKey),
-        *static_cast<const Mac::Key *>(aNextKey));
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().SetMacKey(aKeyIdMode, aKeyId, AsCoreType(aPrevKey),
+                                                               AsCoreType(aCurrKey), AsCoreType(aNextKey));
 }
 
 otError otLinkRawSetMacFrameCounter(otInstance *aInstance, uint32_t aMacFrameCounter)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().SetMacFrameCounter(aMacFrameCounter);
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().SetMacFrameCounter(aMacFrameCounter);
 }
 
 uint64_t otLinkRawGetRadioTime(otInstance *aInstance)
@@ -254,38 +253,37 @@ otDeviceRole otThreadGetDeviceRole(otInstance *aInstance)
 
 uint8_t otLinkGetChannel(otInstance *aInstance)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().GetChannel();
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().GetChannel();
 }
 
 otError otLinkSetChannel(otInstance *aInstance, uint8_t aChannel)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().SetChannel(aChannel);
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().SetChannel(aChannel);
 }
 
 otPanId otLinkGetPanId(otInstance *aInstance)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().GetPanId();
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().GetPanId();
 }
 
 otError otLinkSetPanId(otInstance *aInstance, uint16_t aPanId)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().SetPanId(aPanId);
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().SetPanId(aPanId);
 }
 
 const otExtAddress *otLinkGetExtendedAddress(otInstance *aInstance)
 {
-    return &static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().GetExtAddress();
+    return &AsCoreType(aInstance).Get<Mac::LinkRaw>().GetExtAddress();
 }
 
 otError otLinkSetExtendedAddress(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().SetExtAddress(
-        *static_cast<const Mac::ExtAddress *>(aExtAddress));
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().SetExtAddress(AsCoreType(aExtAddress));
 }
 
 uint16_t otLinkGetShortAddress(otInstance *aInstance)
 {
-    return static_cast<Instance *>(aInstance)->Get<Mac::LinkRaw>().GetShortAddress();
+    return AsCoreType(aInstance).Get<Mac::LinkRaw>().GetShortAddress();
 }
 
 void otLinkGetFactoryAssignedIeeeEui64(otInstance *aInstance, otExtAddress *aEui64)

--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -35,82 +35,71 @@
 
 #include <openthread/message.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
 
 void otMessageFree(otMessage *aMessage)
 {
-    static_cast<Message *>(aMessage)->Free();
+    AsCoreType(aMessage).Free();
 }
 
 uint16_t otMessageGetLength(const otMessage *aMessage)
 {
-    const Message &message = *static_cast<const Message *>(aMessage);
-    return message.GetLength();
+    return AsCoreType(aMessage).GetLength();
 }
 
 otError otMessageSetLength(otMessage *aMessage, uint16_t aLength)
 {
-    Message &message = *static_cast<Message *>(aMessage);
-    return message.SetLength(aLength);
+    return AsCoreType(aMessage).SetLength(aLength);
 }
 
 uint16_t otMessageGetOffset(const otMessage *aMessage)
 {
-    const Message &message = *static_cast<const Message *>(aMessage);
-    return message.GetOffset();
+    return AsCoreType(aMessage).GetOffset();
 }
 
 void otMessageSetOffset(otMessage *aMessage, uint16_t aOffset)
 {
-    Message &message = *static_cast<Message *>(aMessage);
-    message.SetOffset(aOffset);
+    AsCoreType(aMessage).SetOffset(aOffset);
 }
 
 bool otMessageIsLinkSecurityEnabled(const otMessage *aMessage)
 {
-    const Message &message = *static_cast<const Message *>(aMessage);
-    return message.IsLinkSecurityEnabled();
+    return AsCoreType(aMessage).IsLinkSecurityEnabled();
 }
 
 void otMessageSetDirectTransmission(otMessage *aMessage, bool aEnabled)
 {
-    Message &message = *static_cast<Message *>(aMessage);
-
     if (aEnabled)
     {
-        message.SetDirectTransmission();
+        AsCoreType(aMessage).SetDirectTransmission();
     }
     else
     {
-        message.ClearDirectTransmission();
+        AsCoreType(aMessage).ClearDirectTransmission();
     }
 }
 
 int8_t otMessageGetRss(const otMessage *aMessage)
 {
-    const Message &message = *static_cast<const Message *>(aMessage);
-    return message.GetAverageRss();
+    return AsCoreType(aMessage).GetAverageRss();
 }
 
 otError otMessageAppend(otMessage *aMessage, const void *aBuf, uint16_t aLength)
 {
-    Message &message = *static_cast<Message *>(aMessage);
-    return message.AppendBytes(aBuf, aLength);
+    return AsCoreType(aMessage).AppendBytes(aBuf, aLength);
 }
 
 uint16_t otMessageRead(const otMessage *aMessage, uint16_t aOffset, void *aBuf, uint16_t aLength)
 {
-    const Message &message = *static_cast<const Message *>(aMessage);
-    return message.ReadBytes(aOffset, aBuf, aLength);
+    return AsCoreType(aMessage).ReadBytes(aOffset, aBuf, aLength);
 }
 
 int otMessageWrite(otMessage *aMessage, uint16_t aOffset, const void *aBuf, uint16_t aLength)
 {
-    Message &message = *static_cast<Message *>(aMessage);
-    message.WriteBytes(aOffset, aBuf, aLength);
+    AsCoreType(aMessage).WriteBytes(aOffset, aBuf, aLength);
 
     return aLength;
 }
@@ -122,32 +111,22 @@ void otMessageQueueInit(otMessageQueue *aQueue)
 
 void otMessageQueueEnqueue(otMessageQueue *aQueue, otMessage *aMessage)
 {
-    Message &     message = *static_cast<Message *>(aMessage);
-    MessageQueue &queue   = *static_cast<MessageQueue *>(aQueue);
-
-    queue.Enqueue(message);
+    AsCoreType(aQueue).Enqueue(AsCoreType(aMessage));
 }
 
 void otMessageQueueEnqueueAtHead(otMessageQueue *aQueue, otMessage *aMessage)
 {
-    Message &     message = *static_cast<Message *>(aMessage);
-    MessageQueue &queue   = *static_cast<MessageQueue *>(aQueue);
-
-    queue.Enqueue(message, MessageQueue::kQueuePositionHead);
+    AsCoreType(aQueue).Enqueue(AsCoreType(aMessage), MessageQueue::kQueuePositionHead);
 }
 
 void otMessageQueueDequeue(otMessageQueue *aQueue, otMessage *aMessage)
 {
-    Message &     message = *static_cast<Message *>(aMessage);
-    MessageQueue &queue   = *static_cast<MessageQueue *>(aQueue);
-
-    queue.Dequeue(message);
+    AsCoreType(aQueue).Dequeue(AsCoreType(aMessage));
 }
 
 otMessage *otMessageQueueGetHead(otMessageQueue *aQueue)
 {
-    MessageQueue &queue = *static_cast<MessageQueue *>(aQueue);
-    return queue.GetHead();
+    return AsCoreType(aQueue).GetHead();
 }
 
 otMessage *otMessageQueueGetNext(otMessageQueue *aQueue, const otMessage *aMessage)
@@ -156,13 +135,8 @@ otMessage *otMessageQueueGetNext(otMessageQueue *aQueue, const otMessage *aMessa
 
     VerifyOrExit(aMessage != nullptr, next = nullptr);
 
-    {
-        const Message &message = *static_cast<const Message *>(aMessage);
-        MessageQueue & queue   = *static_cast<MessageQueue *>(aQueue);
-
-        VerifyOrExit(message.GetMessageQueue() == &queue, next = nullptr);
-        next = message.GetNext();
-    }
+    VerifyOrExit(AsCoreType(aMessage).GetMessageQueue() == aQueue, next = nullptr);
+    next = AsCoreType(aMessage).GetNext();
 
 exit:
     return next;
@@ -172,7 +146,7 @@ exit:
 void otMessageGetBufferInfo(otInstance *aInstance, otBufferInfo *aBufferInfo)
 {
     uint16_t  messages, buffers;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     aBufferInfo->mTotalBuffers = instance.Get<MessagePool>().GetTotalBufferCount();
 

--- a/src/core/api/multi_radio_api.cpp
+++ b/src/core/api/multi_radio_api.cpp
@@ -37,9 +37,8 @@
 
 #include <openthread/multi_radio.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
-#include "common/debug.hpp"
-#include "common/instance.hpp"
 #include "common/locator_getters.hpp"
 #include "thread/radio_selector.hpp"
 
@@ -49,12 +48,11 @@ otError otMultiRadioGetNeighborInfo(otInstance *              aInstance,
                                     const otExtAddress *      aExtAddress,
                                     otMultiRadioNeighborInfo *aNeighborInfo)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error     error = kErrorNone;
     Neighbor *neighbor;
 
-    neighbor = instance.Get<NeighborTable>().FindNeighbor(*static_cast<const Mac::ExtAddress *>(aExtAddress),
-                                                          Neighbor::kInStateAnyExceptInvalid);
+    neighbor = AsCoreType(aInstance).Get<NeighborTable>().FindNeighbor(AsCoreType(aExtAddress),
+                                                                       Neighbor::kInStateAnyExceptInvalid);
     VerifyOrExit(neighbor != nullptr, error = kErrorNotFound);
 
     neighbor->PopulateMultiRadioInfo(*aNeighborInfo);

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -35,31 +35,27 @@
 
 #include <openthread/netdata.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
 
 otError otNetDataGet(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aData != nullptr && aDataLength != nullptr);
 
-    return instance.Get<NetworkData::Leader>().GetNetworkData(aStable, aData, *aDataLength);
+    return AsCoreType(aInstance).Get<NetworkData::Leader>().GetNetworkData(aStable, aData, *aDataLength);
 }
 
 otError otNetDataGetNextOnMeshPrefix(otInstance *           aInstance,
                                      otNetworkDataIterator *aIterator,
                                      otBorderRouterConfig * aConfig)
 {
-    Error                            error    = kErrorNone;
-    Instance &                       instance = *static_cast<Instance *>(aInstance);
-    NetworkData::OnMeshPrefixConfig *config   = static_cast<NetworkData::OnMeshPrefixConfig *>(aConfig);
+    Error error = kErrorNone;
 
     VerifyOrExit(aIterator && aConfig, error = kErrorInvalidArgs);
 
-    error = instance.Get<NetworkData::Leader>().GetNextOnMeshPrefix(*aIterator, *config);
+    error = AsCoreType(aInstance).Get<NetworkData::Leader>().GetNextOnMeshPrefix(*aIterator, AsCoreType(aConfig));
 
 exit:
     return error;
@@ -67,13 +63,11 @@ exit:
 
 otError otNetDataGetNextRoute(otInstance *aInstance, otNetworkDataIterator *aIterator, otExternalRouteConfig *aConfig)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
     VerifyOrExit(aIterator && aConfig, error = kErrorInvalidArgs);
 
-    error = instance.Get<NetworkData::Leader>().GetNextExternalRoute(
-        *aIterator, *static_cast<NetworkData::ExternalRouteConfig *>(aConfig));
+    error = AsCoreType(aInstance).Get<NetworkData::Leader>().GetNextExternalRoute(*aIterator, AsCoreType(aConfig));
 
 exit:
     return error;
@@ -81,13 +75,11 @@ exit:
 
 otError otNetDataGetNextService(otInstance *aInstance, otNetworkDataIterator *aIterator, otServiceConfig *aConfig)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
     VerifyOrExit(aIterator && aConfig, error = kErrorInvalidArgs);
 
-    error = instance.Get<NetworkData::Leader>().GetNextService(*aIterator,
-                                                               *static_cast<NetworkData::ServiceConfig *>(aConfig));
+    error = AsCoreType(aInstance).Get<NetworkData::Leader>().GetNextService(*aIterator, AsCoreType(aConfig));
 
 exit:
     return error;
@@ -95,26 +87,20 @@ exit:
 
 uint8_t otNetDataGetVersion(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetLeaderData().GetDataVersion();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderData().GetDataVersion();
 }
 
 uint8_t otNetDataGetStableVersion(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetLeaderData().GetStableDataVersion();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderData().GetStableDataVersion();
 }
 
 otError otNetDataSteeringDataCheckJoiner(otInstance *aInstance, const otExtAddress *aEui64)
 {
-    return static_cast<Instance *>(aInstance)->Get<NetworkData::Leader>().SteeringDataCheckJoiner(
-        *static_cast<const Mac::ExtAddress *>(aEui64));
+    return AsCoreType(aInstance).Get<NetworkData::Leader>().SteeringDataCheckJoiner(AsCoreType(aEui64));
 }
 
 otError otNetDataSteeringDataCheckJoinerWithDiscerner(otInstance *aInstance, const otJoinerDiscerner *aDiscerner)
 {
-    return static_cast<Instance *>(aInstance)->Get<NetworkData::Leader>().SteeringDataCheckJoiner(
-        *static_cast<const MeshCoP::JoinerDiscerner *>(aDiscerner));
+    return AsCoreType(aInstance).Get<NetworkData::Leader>().SteeringDataCheckJoiner(AsCoreType(aDiscerner));
 }

--- a/src/core/api/netdata_publisher_api.cpp
+++ b/src/core/api/netdata_publisher_api.cpp
@@ -37,7 +37,7 @@
 
 #include <openthread/netdata_publisher.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
@@ -46,47 +46,34 @@ using namespace ot;
 
 void otNetDataPublishDnsSrpServiceAnycast(otInstance *aInstance, uint8_t aSequenceNumber)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<NetworkData::Publisher>().PublishDnsSrpServiceAnycast(aSequenceNumber);
+    AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishDnsSrpServiceAnycast(aSequenceNumber);
 }
 
 void otNetDataPublishDnsSrpServiceUnicast(otInstance *aInstance, const otIp6Address *aAddress, uint16_t aPort)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<NetworkData::Publisher>().PublishDnsSrpServiceUnicast(*static_cast<const Ip6::Address *>(aAddress),
-                                                                       aPort);
+    AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishDnsSrpServiceUnicast(AsCoreType(aAddress), aPort);
 }
 
 void otNetDataPublishDnsSrpServiceUnicastMeshLocalEid(otInstance *aInstance, uint16_t aPort)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<NetworkData::Publisher>().PublishDnsSrpServiceUnicast(aPort);
+    AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishDnsSrpServiceUnicast(aPort);
 }
 
 bool otNetDataIsDnsSrpServiceAdded(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<NetworkData::Publisher>().IsDnsSrpServiceAdded();
+    return AsCoreType(aInstance).Get<NetworkData::Publisher>().IsDnsSrpServiceAdded();
 }
 
 void otNetDataSetDnsSrpServicePublisherCallback(otInstance *                            aInstance,
                                                 otNetDataDnsSrpServicePublisherCallback aCallback,
                                                 void *                                  aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<NetworkData::Publisher>().SetDnsSrpServiceCallback(aCallback, aContext);
+    AsCoreType(aInstance).Get<NetworkData::Publisher>().SetDnsSrpServiceCallback(aCallback, aContext);
 }
 
 void otNetDataUnpublishDnsSrpService(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<NetworkData::Publisher>().UnpublishDnsSrpService();
+    AsCoreType(aInstance).Get<NetworkData::Publisher>().UnpublishDnsSrpService();
 }
 
 #endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
@@ -95,41 +82,29 @@ void otNetDataUnpublishDnsSrpService(otInstance *aInstance)
 
 otError otNetDataPublishOnMeshPrefix(otInstance *aInstance, const otBorderRouterConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<NetworkData::Publisher>().PublishOnMeshPrefix(
-        *static_cast<const NetworkData::OnMeshPrefixConfig *>(aConfig));
+    return AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishOnMeshPrefix(AsCoreType(aConfig));
 }
 
 otError otNetDataPublishExternalRoute(otInstance *aInstance, const otExternalRouteConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<NetworkData::Publisher>().PublishExternalRoute(
-        *static_cast<const NetworkData::ExternalRouteConfig *>(aConfig));
+    return AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishExternalRoute(AsCoreType(aConfig));
 }
 
 bool otNetDataIsPrefixAdded(otInstance *aInstance, const otIp6Prefix *aPrefix)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<NetworkData::Publisher>().IsPrefixAdded(*static_cast<const Ip6::Prefix *>(aPrefix));
+    return AsCoreType(aInstance).Get<NetworkData::Publisher>().IsPrefixAdded(AsCoreType(aPrefix));
 }
 
 void otNetDataSetPrefixPublisherCallback(otInstance *                     aInstance,
                                          otNetDataPrefixPublisherCallback aCallback,
                                          void *                           aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<NetworkData::Publisher>().SetPrefixCallback(aCallback, aContext);
+    return AsCoreType(aInstance).Get<NetworkData::Publisher>().SetPrefixCallback(aCallback, aContext);
 }
 
 otError otNetDataUnpublishPrefix(otInstance *aInstance, const otIp6Prefix *aPrefix)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<NetworkData::Publisher>().UnpublishPrefix(*static_cast<const Ip6::Prefix *>(aPrefix));
+    return AsCoreType(aInstance).Get<NetworkData::Publisher>().UnpublishPrefix(AsCoreType(aPrefix));
 }
 
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE

--- a/src/core/api/netdiag_api.cpp
+++ b/src/core/api/netdiag_api.cpp
@@ -37,7 +37,8 @@
 
 #include <openthread/netdiag.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
+#include "common/locator_getters.hpp"
 
 using namespace ot;
 
@@ -45,8 +46,7 @@ otError otThreadGetNextDiagnosticTlv(const otMessage *      aMessage,
                                      otNetworkDiagIterator *aIterator,
                                      otNetworkDiagTlv *     aNetworkDiagTlv)
 {
-    return NetworkDiagnostic::NetworkDiagnostic::GetNextDiagTlv(*static_cast<const Coap::Message *>(aMessage),
-                                                                *aIterator, *aNetworkDiagTlv);
+    return NetworkDiagnostic::NetworkDiagnostic::GetNextDiagTlv(AsCoapMessage(aMessage), *aIterator, *aNetworkDiagTlv);
 }
 
 otError otThreadSendDiagnosticGet(otInstance *                   aInstance,
@@ -56,10 +56,8 @@ otError otThreadSendDiagnosticGet(otInstance *                   aInstance,
                                   otReceiveDiagnosticGetCallback aCallback,
                                   void *                         aCallbackContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<NetworkDiagnostic::NetworkDiagnostic>().SendDiagnosticGet(
-        *static_cast<const Ip6::Address *>(aDestination), aTlvTypes, aCount, aCallback, aCallbackContext);
+    return AsCoreType(aInstance).Get<NetworkDiagnostic::NetworkDiagnostic>().SendDiagnosticGet(
+        AsCoreType(aDestination), aTlvTypes, aCount, aCallback, aCallbackContext);
 }
 
 otError otThreadSendDiagnosticReset(otInstance *        aInstance,
@@ -67,10 +65,8 @@ otError otThreadSendDiagnosticReset(otInstance *        aInstance,
                                     const uint8_t       aTlvTypes[],
                                     uint8_t             aCount)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<NetworkDiagnostic::NetworkDiagnostic>().SendDiagnosticReset(
-        *static_cast<const Ip6::Address *>(aDestination), aTlvTypes, aCount);
+    return AsCoreType(aInstance).Get<NetworkDiagnostic::NetworkDiagnostic>().SendDiagnosticReset(
+        AsCoreType(aDestination), aTlvTypes, aCount);
 }
 
 #endif // OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE

--- a/src/core/api/network_time_api.cpp
+++ b/src/core/api/network_time_api.cpp
@@ -37,26 +37,23 @@
 
 #include <openthread/network_time.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
 
 otNetworkTimeStatus otNetworkTimeGet(otInstance *aInstance, uint64_t *aNetworkTime)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<TimeSync>().GetTime(*aNetworkTime);
+    return AsCoreType(aInstance).Get<TimeSync>().GetTime(*aNetworkTime);
 }
 
 otError otNetworkTimeSetSyncPeriod(otInstance *aInstance, uint16_t aTimeSyncPeriod)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
-    VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
+    VerifyOrExit(AsCoreType(aInstance).Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
-    instance.Get<TimeSync>().SetTimeSyncPeriod(aTimeSyncPeriod);
+    AsCoreType(aInstance).Get<TimeSync>().SetTimeSyncPeriod(aTimeSyncPeriod);
 
 exit:
     return error;
@@ -64,19 +61,16 @@ exit:
 
 uint16_t otNetworkTimeGetSyncPeriod(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<TimeSync>().GetTimeSyncPeriod();
+    return AsCoreType(aInstance).Get<TimeSync>().GetTimeSyncPeriod();
 }
 
 otError otNetworkTimeSetXtalThreshold(otInstance *aInstance, uint16_t aXtalThreshold)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
-    VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
+    VerifyOrExit(AsCoreType(aInstance).Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
-    instance.Get<TimeSync>().SetXtalThreshold(aXtalThreshold);
+    AsCoreType(aInstance).Get<TimeSync>().SetXtalThreshold(aXtalThreshold);
 
 exit:
     return error;
@@ -84,16 +78,12 @@ exit:
 
 uint16_t otNetworkTimeGetXtalThreshold(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<TimeSync>().GetXtalThreshold();
+    return AsCoreType(aInstance).Get<TimeSync>().GetXtalThreshold();
 }
 
 void otNetworkTimeSyncSetCallback(otInstance *aInstance, otNetworkTimeSyncCallbackFn aCallback, void *aCallbackContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<TimeSync>().SetTimeSyncCallback(aCallback, aCallbackContext);
+    return AsCoreType(aInstance).Get<TimeSync>().SetTimeSyncCallback(aCallback, aCallbackContext);
 }
 
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE

--- a/src/core/api/ping_sender_api.cpp
+++ b/src/core/api/ping_sender_api.cpp
@@ -35,7 +35,7 @@
 
 #include <openthread/ping_sender.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
@@ -44,16 +44,12 @@ using namespace ot;
 
 otError otPingSenderPing(otInstance *aInstance, const otPingSenderConfig *aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::PingSender>().Ping(*static_cast<const Utils::PingSender::Config *>(aConfig));
+    return AsCoreType(aInstance).Get<Utils::PingSender>().Ping(AsCoreType(aConfig));
 }
 
 void otPingSenderStop(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Utils::PingSender>().Stop();
+    AsCoreType(aInstance).Get<Utils::PingSender>().Stop();
 }
 
 #endif // OPENTHREAD_CONFIG_PING_SENDER_ENABLE

--- a/src/core/api/server_api.cpp
+++ b/src/core/api/server_api.cpp
@@ -37,31 +37,28 @@
 
 #include <openthread/server.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
 
 otError otServerGetNetDataLocal(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aData != nullptr && aDataLength != nullptr);
 
-    return instance.Get<NetworkData::Local>().GetNetworkData(aStable, aData, *aDataLength);
+    return AsCoreType(aInstance).Get<NetworkData::Local>().GetNetworkData(aStable, aData, *aDataLength);
 }
 
 otError otServerAddService(otInstance *aInstance, const otServiceConfig *aConfig)
 {
-    Instance &               instance = *static_cast<Instance *>(aInstance);
     NetworkData::ServiceData serviceData;
     NetworkData::ServerData  serverData;
 
     serviceData.Init(&aConfig->mServiceData[0], aConfig->mServiceDataLength);
     serverData.Init(&aConfig->mServerConfig.mServerData[0], aConfig->mServerConfig.mServerDataLength);
 
-    return instance.Get<NetworkData::Local>().AddService(aConfig->mEnterpriseNumber, serviceData,
-                                                         aConfig->mServerConfig.mStable, serverData);
+    return AsCoreType(aInstance).Get<NetworkData::Local>().AddService(aConfig->mEnterpriseNumber, serviceData,
+                                                                      aConfig->mServerConfig.mStable, serverData);
 }
 
 otError otServerRemoveService(otInstance *   aInstance,
@@ -69,23 +66,20 @@ otError otServerRemoveService(otInstance *   aInstance,
                               const uint8_t *aServiceData,
                               uint8_t        aServiceDataLength)
 {
-    Instance &               instance = *static_cast<Instance *>(aInstance);
     NetworkData::ServiceData serviceData;
 
     serviceData.Init(aServiceData, aServiceDataLength);
 
-    return instance.Get<NetworkData::Local>().RemoveService(aEnterpriseNumber, serviceData);
+    return AsCoreType(aInstance).Get<NetworkData::Local>().RemoveService(aEnterpriseNumber, serviceData);
 }
 
 otError otServerGetNextService(otInstance *aInstance, otNetworkDataIterator *aIterator, otServiceConfig *aConfig)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
     VerifyOrExit(aIterator && aConfig, error = kErrorInvalidArgs);
 
-    error = instance.Get<NetworkData::Local>().GetNextService(*aIterator,
-                                                              *static_cast<NetworkData::ServiceConfig *>(aConfig));
+    error = AsCoreType(aInstance).Get<NetworkData::Local>().GetNextService(*aIterator, AsCoreType(aConfig));
 
 exit:
     return error;
@@ -93,9 +87,7 @@ exit:
 
 otError otServerRegister(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<NetworkData::Notifier>().HandleServerDataUpdated();
+    AsCoreType(aInstance).Get<NetworkData::Notifier>().HandleServerDataUpdated();
 
     return kErrorNone;
 }

--- a/src/core/api/sntp_api.cpp
+++ b/src/core/api/sntp_api.cpp
@@ -37,7 +37,7 @@
 
 #include <openthread/sntp.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
@@ -47,16 +47,12 @@ otError otSntpClientQuery(otInstance *          aInstance,
                           otSntpResponseHandler aHandler,
                           void *                aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Sntp::Client>().Query(aQuery, aHandler, aContext);
+    return AsCoreType(aInstance).Get<Sntp::Client>().Query(aQuery, aHandler, aContext);
 }
 
 void otSntpClientSetUnixEra(otInstance *aInstance, uint32_t aUnixEra)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Sntp::Client>().SetUnixEra(aUnixEra);
+    return AsCoreType(aInstance).Get<Sntp::Client>().SetUnixEra(aUnixEra);
 }
 
 #endif // OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE

--- a/src/core/api/srp_client_api.cpp
+++ b/src/core/api/srp_client_api.cpp
@@ -37,175 +37,127 @@
 
 #include <openthread/srp_client.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
-#include "net/srp_client.hpp"
 
 using namespace ot;
 
 otError otSrpClientStart(otInstance *aInstance, const otSockAddr *aServerSockAddr)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().Start(*static_cast<const Ip6::SockAddr *>(aServerSockAddr));
+    return AsCoreType(aInstance).Get<Srp::Client>().Start(AsCoreType(aServerSockAddr));
 }
 
 void otSrpClientStop(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().Stop();
+    return AsCoreType(aInstance).Get<Srp::Client>().Stop();
 }
 
 bool otSrpClientIsRunning(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().IsRunning();
+    return AsCoreType(aInstance).Get<Srp::Client>().IsRunning();
 }
 
 const otSockAddr *otSrpClientGetServerAddress(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<Srp::Client>().GetServerAddress();
+    return &AsCoreType(aInstance).Get<Srp::Client>().GetServerAddress();
 }
 
 void otSrpClientSetCallback(otInstance *aInstance, otSrpClientCallback aCallback, void *aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Srp::Client>().SetCallback(aCallback, aContext);
+    AsCoreType(aInstance).Get<Srp::Client>().SetCallback(aCallback, aContext);
 }
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
 void otSrpClientEnableAutoStartMode(otInstance *aInstance, otSrpClientAutoStartCallback aCallback, void *aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Srp::Client>().EnableAutoStartMode(aCallback, aContext);
+    AsCoreType(aInstance).Get<Srp::Client>().EnableAutoStartMode(aCallback, aContext);
 }
 
 void otSrpClientDisableAutoStartMode(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Srp::Client>().DisableAutoStartMode();
+    AsCoreType(aInstance).Get<Srp::Client>().DisableAutoStartMode();
 }
 
 bool otSrpClientIsAutoStartModeEnabled(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().IsAutoStartModeEnabled();
+    return AsCoreType(aInstance).Get<Srp::Client>().IsAutoStartModeEnabled();
 }
 #endif // OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
 
 uint32_t otSrpClientGetLeaseInterval(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().GetLeaseInterval();
+    return AsCoreType(aInstance).Get<Srp::Client>().GetLeaseInterval();
 }
 
 void otSrpClientSetLeaseInterval(otInstance *aInstance, uint32_t aInterval)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().SetLeaseInterval(aInterval);
+    return AsCoreType(aInstance).Get<Srp::Client>().SetLeaseInterval(aInterval);
 }
 
 uint32_t otSrpClientGetKeyLeaseInterval(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().GetKeyLeaseInterval();
+    return AsCoreType(aInstance).Get<Srp::Client>().GetKeyLeaseInterval();
 }
 
 void otSrpClientSetKeyLeaseInterval(otInstance *aInstance, uint32_t aInterval)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().SetKeyLeaseInterval(aInterval);
+    return AsCoreType(aInstance).Get<Srp::Client>().SetKeyLeaseInterval(aInterval);
 }
 
 const otSrpClientHostInfo *otSrpClientGetHostInfo(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<Srp::Client>().GetHostInfo();
+    return &AsCoreType(aInstance).Get<Srp::Client>().GetHostInfo();
 }
 
 otError otSrpClientSetHostName(otInstance *aInstance, const char *aName)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().SetHostName(aName);
+    return AsCoreType(aInstance).Get<Srp::Client>().SetHostName(aName);
 }
 
 otError otSrpClientSetHostAddresses(otInstance *aInstance, const otIp6Address *aIp6Addresses, uint8_t aNumAddresses)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().SetHostAddresses(static_cast<const Ip6::Address *>(aIp6Addresses),
-                                                        aNumAddresses);
+    return AsCoreType(aInstance).Get<Srp::Client>().SetHostAddresses(AsCoreTypePtr(aIp6Addresses), aNumAddresses);
 }
 
 otError otSrpClientAddService(otInstance *aInstance, otSrpClientService *aService)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().AddService(*static_cast<Srp::Client::Service *>(aService));
+    return AsCoreType(aInstance).Get<Srp::Client>().AddService(AsCoreType(aService));
 }
 
 otError otSrpClientRemoveService(otInstance *aInstance, otSrpClientService *aService)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().RemoveService(*static_cast<Srp::Client::Service *>(aService));
+    return AsCoreType(aInstance).Get<Srp::Client>().RemoveService(AsCoreType(aService));
 }
 
 otError otSrpClientClearService(otInstance *aInstance, otSrpClientService *aService)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().ClearService(*static_cast<Srp::Client::Service *>(aService));
+    return AsCoreType(aInstance).Get<Srp::Client>().ClearService(AsCoreType(aService));
 }
 
 const otSrpClientService *otSrpClientGetServices(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().GetServices().GetHead();
+    return AsCoreType(aInstance).Get<Srp::Client>().GetServices().GetHead();
 }
 
 otError otSrpClientRemoveHostAndServices(otInstance *aInstance, bool aRemoveKeyLease, bool aSendUnregToServer)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().RemoveHostAndServices(aRemoveKeyLease, aSendUnregToServer);
+    return AsCoreType(aInstance).Get<Srp::Client>().RemoveHostAndServices(aRemoveKeyLease, aSendUnregToServer);
 }
 
 void otSrpClientClearHostAndServices(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Srp::Client>().ClearHostAndServices();
+    AsCoreType(aInstance).Get<Srp::Client>().ClearHostAndServices();
 }
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_DOMAIN_NAME_API_ENABLE
 const char *otSrpClientGetDomainName(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().GetDomainName();
+    return AsCoreType(aInstance).Get<Srp::Client>().GetDomainName();
 }
 
 otError otSrpClientSetDomainName(otInstance *aInstance, const char *aDomainName)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().SetDomainName(aDomainName);
+    return AsCoreType(aInstance).Get<Srp::Client>().SetDomainName(aDomainName);
 }
 #endif // OPENTHREAD_CONFIG_SRP_CLIENT_DOMAIN_NAME_API_ENABLE
 
@@ -213,22 +165,18 @@ const char *otSrpClientItemStateToString(otSrpClientItemState aItemState)
 {
     OT_ASSERT(aItemState <= OT_SRP_CLIENT_ITEM_STATE_REMOVED);
 
-    return Srp::Client::ItemStateToString(static_cast<Srp::Client::ItemState>(aItemState));
+    return Srp::Client::ItemStateToString(MapEnum(aItemState));
 }
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 void otSrpClientSetServiceKeyRecordEnabled(otInstance *aInstance, bool aEnabled)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Srp::Client>().SetServiceKeyRecordEnabled(aEnabled);
+    AsCoreType(aInstance).Get<Srp::Client>().SetServiceKeyRecordEnabled(aEnabled);
 }
 
 bool otSrpClientIsServiceKeyRecordEnabled(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Client>().IsServiceKeyRecordEnabled();
+    return AsCoreType(aInstance).Get<Srp::Client>().IsServiceKeyRecordEnabled();
 }
 #endif
 

--- a/src/core/api/srp_client_buffers_api.cpp
+++ b/src/core/api/srp_client_buffers_api.cpp
@@ -35,9 +35,8 @@
 
 #include <openthread/srp_client_buffers.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
-#include "utils/srp_client_buffers.hpp"
 
 using namespace ot;
 
@@ -45,58 +44,47 @@ using namespace ot;
 
 char *otSrpClientBuffersGetHostNameString(otInstance *aInstance, uint16_t *aSize)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::SrpClientBuffers>().GetHostNameString(*aSize);
+    return AsCoreType(aInstance).Get<Utils::SrpClientBuffers>().GetHostNameString(*aSize);
 }
 
 otIp6Address *otSrpClientBuffersGetHostAddressesArray(otInstance *aInstance, uint8_t *aArrayLength)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::SrpClientBuffers>().GetHostAddressesArray(*aArrayLength);
+    return AsCoreType(aInstance).Get<Utils::SrpClientBuffers>().GetHostAddressesArray(*aArrayLength);
 }
 
 otSrpClientBuffersServiceEntry *otSrpClientBuffersAllocateService(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Utils::SrpClientBuffers>().AllocateService();
+    return AsCoreType(aInstance).Get<Utils::SrpClientBuffers>().AllocateService();
 }
 
 void otSrpClientBuffersFreeService(otInstance *aInstance, otSrpClientBuffersServiceEntry *aService)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Utils::SrpClientBuffers>().FreeService(
-        *static_cast<Utils::SrpClientBuffers::ServiceEntry *>(aService));
+    AsCoreType(aInstance).Get<Utils::SrpClientBuffers>().FreeService(AsCoreType(aService));
 }
 
 void otSrpClientBuffersFreeAllServices(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Utils::SrpClientBuffers>().FreeAllServices();
+    AsCoreType(aInstance).Get<Utils::SrpClientBuffers>().FreeAllServices();
 }
 
 char *otSrpClientBuffersGetServiceEntryServiceNameString(otSrpClientBuffersServiceEntry *aEntry, uint16_t *aSize)
 {
-    return static_cast<Utils::SrpClientBuffers::ServiceEntry *>(aEntry)->GetServiceNameString(*aSize);
+    return AsCoreType(aEntry).GetServiceNameString(*aSize);
 }
 
 char *otSrpClientBuffersGetServiceEntryInstanceNameString(otSrpClientBuffersServiceEntry *aEntry, uint16_t *aSize)
 {
-    return static_cast<Utils::SrpClientBuffers::ServiceEntry *>(aEntry)->GetInstanceNameString(*aSize);
+    return AsCoreType(aEntry).GetInstanceNameString(*aSize);
 }
 
 uint8_t *otSrpClientBuffersGetServiceEntryTxtBuffer(otSrpClientBuffersServiceEntry *aEntry, uint16_t *aSize)
 {
-    return static_cast<Utils::SrpClientBuffers::ServiceEntry *>(aEntry)->GetTxtBuffer(*aSize);
+    return AsCoreType(aEntry).GetTxtBuffer(*aSize);
 }
 
 const char **otSrpClientBuffersGetSubTypeLabelsArray(otSrpClientBuffersServiceEntry *aEntry, uint16_t *aArrayLength)
 {
-    return static_cast<Utils::SrpClientBuffers::ServiceEntry *>(aEntry)->GetSubTypeLabelsArray(*aArrayLength);
+    return AsCoreType(aEntry).GetSubTypeLabelsArray(*aArrayLength);
 }
 
 #endif // OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE

--- a/src/core/api/srp_server_api.cpp
+++ b/src/core/api/srp_server_api.cpp
@@ -37,128 +37,97 @@
 
 #include <openthread/srp_server.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
 
 const char *otSrpServerGetDomain(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Server>().GetDomain();
+    return AsCoreType(aInstance).Get<Srp::Server>().GetDomain();
 }
 
 otError otSrpServerSetDomain(otInstance *aInstance, const char *aDomain)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Server>().SetDomain(aDomain);
+    return AsCoreType(aInstance).Get<Srp::Server>().SetDomain(aDomain);
 }
 
 otSrpServerState otSrpServerGetState(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return static_cast<otSrpServerState>(instance.Get<Srp::Server>().GetState());
+    return MapEnum(AsCoreType(aInstance).Get<Srp::Server>().GetState());
 }
 
 otSrpServerAddressMode otSrpServerGetAddressMode(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return static_cast<otSrpServerAddressMode>(instance.Get<Srp::Server>().GetAddressMode());
+    return MapEnum(AsCoreType(aInstance).Get<Srp::Server>().GetAddressMode());
 }
 
 otError otSrpServerSetAddressMode(otInstance *aInstance, otSrpServerAddressMode aMode)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Server>().SetAddressMode(static_cast<Srp::Server::AddressMode>(aMode));
+    return AsCoreType(aInstance).Get<Srp::Server>().SetAddressMode(MapEnum(aMode));
 }
 
 uint8_t otSrpServerGetAnycastModeSequenceNumber(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Server>().GetAnycastModeSequenceNumber();
+    return AsCoreType(aInstance).Get<Srp::Server>().GetAnycastModeSequenceNumber();
 }
 
 otError otSrpServerSetAnycastModeSequenceNumber(otInstance *aInstance, uint8_t aSequenceNumber)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Server>().SetAnycastModeSequenceNumber(aSequenceNumber);
+    return AsCoreType(aInstance).Get<Srp::Server>().SetAnycastModeSequenceNumber(aSequenceNumber);
 }
 
 void otSrpServerSetEnabled(otInstance *aInstance, bool aEnabled)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Srp::Server>().SetEnabled(aEnabled);
+    AsCoreType(aInstance).Get<Srp::Server>().SetEnabled(aEnabled);
 }
 
 void otSrpServerGetLeaseConfig(otInstance *aInstance, otSrpServerLeaseConfig *aLeaseConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Srp::Server>().GetLeaseConfig(static_cast<Srp::Server::LeaseConfig &>(*aLeaseConfig));
+    AsCoreType(aInstance).Get<Srp::Server>().GetLeaseConfig(AsCoreType(aLeaseConfig));
 }
 
 otError otSrpServerSetLeaseConfig(otInstance *aInstance, const otSrpServerLeaseConfig *aLeaseConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Server>().SetLeaseConfig(static_cast<const Srp::Server::LeaseConfig &>(*aLeaseConfig));
+    return AsCoreType(aInstance).Get<Srp::Server>().SetLeaseConfig(AsCoreType(aLeaseConfig));
 }
 
 void otSrpServerSetServiceUpdateHandler(otInstance *                    aInstance,
                                         otSrpServerServiceUpdateHandler aServiceHandler,
                                         void *                          aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Srp::Server>().SetServiceHandler(aServiceHandler, aContext);
+    AsCoreType(aInstance).Get<Srp::Server>().SetServiceHandler(aServiceHandler, aContext);
 }
 
 void otSrpServerHandleServiceUpdateResult(otInstance *aInstance, otSrpServerServiceUpdateId aId, otError aError)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Srp::Server>().HandleServiceUpdateResult(aId, aError);
+    AsCoreType(aInstance).Get<Srp::Server>().HandleServiceUpdateResult(aId, aError);
 }
 
 const otSrpServerHost *otSrpServerGetNextHost(otInstance *aInstance, const otSrpServerHost *aHost)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Srp::Server>().GetNextHost(static_cast<const Srp::Server::Host *>(aHost));
+    return AsCoreType(aInstance).Get<Srp::Server>().GetNextHost(AsCoreTypePtr(aHost));
 }
 
 bool otSrpServerHostIsDeleted(const otSrpServerHost *aHost)
 {
-    return static_cast<const Srp::Server::Host *>(aHost)->IsDeleted();
+    return AsCoreType(aHost).IsDeleted();
 }
 
 const char *otSrpServerHostGetFullName(const otSrpServerHost *aHost)
 {
-    return static_cast<const Srp::Server::Host *>(aHost)->GetFullName();
+    return AsCoreType(aHost).GetFullName();
 }
 
 const otIp6Address *otSrpServerHostGetAddresses(const otSrpServerHost *aHost, uint8_t *aAddressesNum)
 {
-    auto host = static_cast<const Srp::Server::Host *>(aHost);
-
-    return host->GetAddresses(*aAddressesNum);
+    return AsCoreType(aHost).GetAddresses(*aAddressesNum);
 }
 
 const otSrpServerService *otSrpServerHostGetNextService(const otSrpServerHost *   aHost,
                                                         const otSrpServerService *aService)
 {
-    auto host = static_cast<const Srp::Server::Host *>(aHost);
-
-    return host->FindNextService(static_cast<const Srp::Server::Service *>(aService),
-                                 Srp::Server::kFlagsBaseTypeServiceOnly);
+    return AsCoreType(aHost).FindNextService(AsCoreTypePtr(aService), Srp::Server::kFlagsBaseTypeServiceOnly);
 }
 
 const otSrpServerService *otSrpServerHostFindNextService(const otSrpServerHost *   aHost,
@@ -167,69 +136,64 @@ const otSrpServerService *otSrpServerHostFindNextService(const otSrpServerHost *
                                                          const char *              aServiceName,
                                                          const char *              aInstanceName)
 {
-    auto host = static_cast<const Srp::Server::Host *>(aHost);
-
-    return host->FindNextService(static_cast<const Srp::Server::Service *>(aPrevService), aFlags, aServiceName,
-                                 aInstanceName);
+    return AsCoreType(aHost).FindNextService(AsCoreTypePtr(aPrevService), aFlags, aServiceName, aInstanceName);
 }
 
 bool otSrpServerServiceIsDeleted(const otSrpServerService *aService)
 {
-    return static_cast<const Srp::Server::Service *>(aService)->IsDeleted();
+    return AsCoreType(aService).IsDeleted();
 }
 
 bool otSrpServerServiceIsSubType(const otSrpServerService *aService)
 {
-    return static_cast<const Srp::Server::Service *>(aService)->IsSubType();
+    return AsCoreType(aService).IsSubType();
 }
 
 const char *otSrpServerServiceGetFullName(const otSrpServerService *aService)
 {
-    return static_cast<const Srp::Server::Service *>(aService)->GetInstanceName();
+    return AsCoreType(aService).GetInstanceName();
 }
 
 const char *otSrpServerServiceGetInstanceName(const otSrpServerService *aService)
 {
-    return static_cast<const Srp::Server::Service *>(aService)->GetInstanceName();
+    return AsCoreType(aService).GetInstanceName();
 }
 
 const char *otSrpServerServiceGetServiceName(const otSrpServerService *aService)
 {
-    return static_cast<const Srp::Server::Service *>(aService)->GetServiceName();
+    return AsCoreType(aService).GetServiceName();
 }
 
 otError otSrpServerServiceGetServiceSubTypeLabel(const otSrpServerService *aService, char *aLabel, uint8_t aMaxSize)
 {
-    return static_cast<const Srp::Server::Service *>(aService)->GetServiceSubTypeLabel(aLabel, aMaxSize);
+    return AsCoreType(aService).GetServiceSubTypeLabel(aLabel, aMaxSize);
 }
 
 uint16_t otSrpServerServiceGetPort(const otSrpServerService *aService)
 {
-    return static_cast<const Srp::Server::Service *>(aService)->GetPort();
+    return AsCoreType(aService).GetPort();
 }
 
 uint16_t otSrpServerServiceGetWeight(const otSrpServerService *aService)
 {
-    return static_cast<const Srp::Server::Service *>(aService)->GetWeight();
+    return AsCoreType(aService).GetWeight();
 }
 
 uint16_t otSrpServerServiceGetPriority(const otSrpServerService *aService)
 {
-    return static_cast<const Srp::Server::Service *>(aService)->GetPriority();
+    return AsCoreType(aService).GetPriority();
 }
 
 const uint8_t *otSrpServerServiceGetTxtData(const otSrpServerService *aService, uint16_t *aDataLength)
 {
-    const Srp::Server::Service &service = *static_cast<const Srp::Server::Service *>(aService);
+    *aDataLength = AsCoreType(aService).GetTxtDataLength();
 
-    *aDataLength = service.GetTxtDataLength();
-
-    return service.GetTxtData();
+    return AsCoreType(aService).GetTxtData();
 }
 
 const otSrpServerHost *otSrpServerServiceGetHost(const otSrpServerService *aService)
 {
-    return &static_cast<const Srp::Server::Service *>(aService)->GetHost();
+    return &AsCoreType(aService).GetHost();
 }
 
 #endif // OPENTHREAD_CONFIG_SRP_SERVER_ENABLE

--- a/src/core/api/tasklet_api.cpp
+++ b/src/core/api/tasklet_api.cpp
@@ -35,8 +35,8 @@
 
 #include <openthread/tasklet.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
-#include "common/instance.hpp"
 #include "common/locator_getters.hpp"
 #include "common/logging.hpp"
 
@@ -44,10 +44,8 @@ using namespace ot;
 
 void otTaskletsProcess(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     VerifyOrExit(otInstanceIsInitialized(aInstance));
-    instance.Get<Tasklet::Scheduler>().ProcessQueuedTasklets();
+    AsCoreType(aInstance).Get<Tasklet::Scheduler>().ProcessQueuedTasklets();
 
 exit:
     return;
@@ -55,11 +53,9 @@ exit:
 
 bool otTaskletsArePending(otInstance *aInstance)
 {
-    bool      retval   = false;
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
+    bool retval = false;
     VerifyOrExit(otInstanceIsInitialized(aInstance));
-    retval = instance.Get<Tasklet::Scheduler>().AreTaskletsPending();
+    retval = AsCoreType(aInstance).Get<Tasklet::Scheduler>().AreTaskletsPending();
 
 exit:
     return retval;

--- a/src/core/api/tcp_api.cpp
+++ b/src/core/api/tcp_api.cpp
@@ -37,156 +37,114 @@
 
 #include <openthread/tcp.h>
 
-#include "common/instance.hpp"
-#include "net/tcp6.hpp"
+#include "common/as_core_type.hpp"
+#include "common/locator_getters.hpp"
 
 using namespace ot;
 
 otError otTcpEndpointInitialize(otInstance *aInstance, otTcpEndpoint *aEndpoint, otTcpEndpointInitializeArgs *aArgs)
 {
-    Ip6::Tcp::Endpoint &endpoint = *static_cast<Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return endpoint.Initialize(*static_cast<Instance *>(aInstance), *aArgs);
+    return AsCoreType(aEndpoint).Initialize(AsCoreType(aInstance), *aArgs);
 }
 
 otInstance *otTcpEndpointGetInstance(otTcpEndpoint *aEndpoint)
 {
-    Ip6::Tcp::Endpoint &endpoint = *static_cast<Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return &endpoint.GetInstance();
+    return &AsCoreType(aEndpoint).GetInstance();
 }
 
 void *otTcpEndpointGetContext(otTcpEndpoint *aEndpoint)
 {
-    Ip6::Tcp::Endpoint &endpoint = *static_cast<Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return endpoint.GetContext();
+    return AsCoreType(aEndpoint).GetContext();
 }
 
 const otSockAddr *otTcpGetLocalAddress(const otTcpEndpoint *aEndpoint)
 {
-    const Ip6::Tcp::Endpoint &endpoint = *static_cast<const Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return &endpoint.GetLocalAddress();
+    return &AsCoreType(aEndpoint).GetLocalAddress();
 }
 
 const otSockAddr *otTcpGetPeerAddress(const otTcpEndpoint *aEndpoint)
 {
-    const Ip6::Tcp::Endpoint &endpoint = *static_cast<const Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return &endpoint.GetPeerAddress();
+    return &AsCoreType(aEndpoint).GetPeerAddress();
 }
 
 otError otTcpBind(otTcpEndpoint *aEndpoint, const otSockAddr *aSockName)
 {
-    Ip6::Tcp::Endpoint &endpoint = *static_cast<Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return endpoint.Bind(*static_cast<const Ip6::SockAddr *>(aSockName));
+    return AsCoreType(aEndpoint).Bind(AsCoreType(aSockName));
 }
 
 otError otTcpConnect(otTcpEndpoint *aEndpoint, const otSockAddr *aSockName, uint32_t aFlags)
 {
-    Ip6::Tcp::Endpoint &endpoint = *static_cast<Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return endpoint.Connect(*static_cast<const Ip6::SockAddr *>(aSockName), aFlags);
+    return AsCoreType(aEndpoint).Connect(AsCoreType(aSockName), aFlags);
 }
 
 otError otTcpSendByReference(otTcpEndpoint *aEndpoint, otLinkedBuffer *aBuffer, uint32_t aFlags)
 {
-    Ip6::Tcp::Endpoint &endpoint = *static_cast<Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return endpoint.SendByReference(*aBuffer, aFlags);
+    return AsCoreType(aEndpoint).SendByReference(*aBuffer, aFlags);
 }
 
 otError otTcpSendByExtension(otTcpEndpoint *aEndpoint, size_t aNumBytes, uint32_t aFlags)
 {
-    Ip6::Tcp::Endpoint &endpoint = *static_cast<Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return endpoint.SendByExtension(aNumBytes, aFlags);
+    return AsCoreType(aEndpoint).SendByExtension(aNumBytes, aFlags);
 }
 
 otError otTcpReceiveByReference(const otTcpEndpoint *aEndpoint, const otLinkedBuffer **aBuffer)
 {
-    const Ip6::Tcp::Endpoint &endpoint = *static_cast<const Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return endpoint.ReceiveByReference(*aBuffer);
+    return AsCoreType(aEndpoint).ReceiveByReference(*aBuffer);
 }
 
 otError otTcpReceiveContiguify(otTcpEndpoint *aEndpoint)
 {
-    Ip6::Tcp::Endpoint &endpoint = *static_cast<Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return endpoint.ReceiveContiguify();
+    return AsCoreType(aEndpoint).ReceiveContiguify();
 }
 
 otError otTcpCommitReceive(otTcpEndpoint *aEndpoint, size_t aNumBytes, uint32_t aFlags)
 {
-    Ip6::Tcp::Endpoint &endpoint = *static_cast<Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return endpoint.CommitReceive(aNumBytes, aFlags);
+    return AsCoreType(aEndpoint).CommitReceive(aNumBytes, aFlags);
 }
 
 otError otTcpSendEndOfStream(otTcpEndpoint *aEndpoint)
 {
-    Ip6::Tcp::Endpoint &endpoint = *static_cast<Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return endpoint.SendEndOfStream();
+    return AsCoreType(aEndpoint).SendEndOfStream();
 }
 
 otError otTcpAbort(otTcpEndpoint *aEndpoint)
 {
-    Ip6::Tcp::Endpoint &endpoint = *static_cast<Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return endpoint.Abort();
+    return AsCoreType(aEndpoint).Abort();
 }
 
 otError otTcpEndpointDeinitialize(otTcpEndpoint *aEndpoint)
 {
-    Ip6::Tcp::Endpoint &endpoint = *static_cast<Ip6::Tcp::Endpoint *>(aEndpoint);
-
-    return endpoint.Deinitialize();
+    return AsCoreType(aEndpoint).Deinitialize();
 }
 
 otError otTcpListenerInitialize(otInstance *aInstance, otTcpListener *aListener, otTcpListenerInitializeArgs *aArgs)
 {
-    Ip6::Tcp::Listener &listener = *static_cast<Ip6::Tcp::Listener *>(aListener);
-
-    return listener.Initialize(*static_cast<Instance *>(aInstance), *aArgs);
+    return AsCoreType(aListener).Initialize(AsCoreType(aInstance), *aArgs);
 }
 
 otInstance *otTcpListenerGetInstance(otTcpListener *aListener)
 {
-    Ip6::Tcp::Listener &listener = *static_cast<Ip6::Tcp::Listener *>(aListener);
-
-    return &listener.GetInstance();
+    return &AsCoreType(aListener).GetInstance();
 }
 
 void *otTcpListenerGetContext(otTcpListener *aListener)
 {
-    Ip6::Tcp::Listener &listener = *static_cast<Ip6::Tcp::Listener *>(aListener);
-
-    return listener.GetContext();
+    return AsCoreType(aListener).GetContext();
 }
 
 otError otTcpListen(otTcpListener *aListener, const otSockAddr *aSockName)
 {
-    Ip6::Tcp::Listener &listener = *static_cast<Ip6::Tcp::Listener *>(aListener);
-
-    return listener.Listen(*static_cast<const Ip6::SockAddr *>(aSockName));
+    return AsCoreType(aListener).Listen(AsCoreType(aSockName));
 }
 
 otError otTcpStopListening(otTcpListener *aListener)
 {
-    Ip6::Tcp::Listener &listener = *static_cast<Ip6::Tcp::Listener *>(aListener);
-
-    return listener.StopListening();
+    return AsCoreType(aListener).StopListening();
 }
 
 otError otTcpListenerDeinitialize(otTcpListener *aListener)
 {
-    Ip6::Tcp::Listener &listener = *static_cast<Ip6::Tcp::Listener *>(aListener);
-
-    return listener.Deinitialize();
+    return AsCoreType(aListener).Deinitialize();
 }
 
 #endif // OPENTHREAD_CONFIG_TCP_ENABLE

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -37,39 +37,32 @@
 
 #include <openthread/thread.h>
 
+#include "common/as_core_type.hpp"
 #include "common/debug.hpp"
-#include "common/instance.hpp"
 #include "common/locator_getters.hpp"
-#include "common/settings.hpp"
 
 using namespace ot;
 
 uint32_t otThreadGetChildTimeout(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetTimeout();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetTimeout();
 }
 
 void otThreadSetChildTimeout(otInstance *aInstance, uint32_t aTimeout)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mle::MleRouter>().SetTimeout(aTimeout);
+    AsCoreType(aInstance).Get<Mle::MleRouter>().SetTimeout(aTimeout);
 }
 
 const otExtendedPanId *otThreadGetExtendedPanId(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<Mac::Mac>().GetExtendedPanId();
+    return &AsCoreType(aInstance).Get<Mac::Mac>().GetExtendedPanId();
 }
 
 otError otThreadSetExtendedPanId(otInstance *aInstance, const otExtendedPanId *aExtendedPanId)
 {
     Error                     error    = kErrorNone;
-    Instance &                instance = *static_cast<Instance *>(aInstance);
-    const Mac::ExtendedPanId &extPanId = *static_cast<const Mac::ExtendedPanId *>(aExtendedPanId);
+    Instance &                instance = AsCoreType(aInstance);
+    const Mac::ExtendedPanId &extPanId = AsCoreType(aExtendedPanId);
     Mle::MeshLocalPrefix      prefix;
 
     VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
@@ -88,56 +81,47 @@ exit:
 
 otError otThreadGetLeaderRloc(otInstance *aInstance, otIp6Address *aLeaderRloc)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aLeaderRloc != nullptr);
 
-    return instance.Get<Mle::MleRouter>().GetLeaderAddress(*static_cast<Ip6::Address *>(aLeaderRloc));
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderAddress(AsCoreType(aLeaderRloc));
 }
 
 otLinkModeConfig otThreadGetLinkMode(otInstance *aInstance)
 {
     otLinkModeConfig config;
-    Instance &       instance = *static_cast<Instance *>(aInstance);
 
-    instance.Get<Mle::MleRouter>().GetDeviceMode().Get(config);
+    AsCoreType(aInstance).Get<Mle::MleRouter>().GetDeviceMode().Get(config);
 
     return config;
 }
 
 otError otThreadSetLinkMode(otInstance *aInstance, otLinkModeConfig aConfig)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().SetDeviceMode(Mle::DeviceMode(aConfig));
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().SetDeviceMode(Mle::DeviceMode(aConfig));
 }
 
 void otThreadGetNetworkKey(otInstance *aInstance, otNetworkKey *aNetworkKey)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<KeyManager>().GetNetworkKey(*static_cast<NetworkKey *>(aNetworkKey));
+    AsCoreType(aInstance).Get<KeyManager>().GetNetworkKey(AsCoreType(aNetworkKey));
 }
 
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
 otNetworkKeyRef otThreadGetNetworkKeyRef(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<KeyManager>().GetNetworkKeyRef();
+    return AsCoreType(aInstance).Get<KeyManager>().GetNetworkKeyRef();
 }
 #endif
 
 otError otThreadSetNetworkKey(otInstance *aInstance, const otNetworkKey *aKey)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     OT_ASSERT(aKey != nullptr);
 
     VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
-    instance.Get<KeyManager>().SetNetworkKey(*static_cast<const NetworkKey *>(aKey));
+    instance.Get<KeyManager>().SetNetworkKey(AsCoreType(aKey));
 
     instance.Get<MeshCoP::ActiveDataset>().Clear();
     instance.Get<MeshCoP::PendingDataset>().Clear();
@@ -150,13 +134,13 @@ exit:
 otError otThreadSetNetworkKeyRef(otInstance *aInstance, otNetworkKeyRef aKeyRef)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(aKeyRef != 0, error = kErrorInvalidArgs);
 
     VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
-    instance.Get<KeyManager>().SetNetworkKeyRef(static_cast<NetworkKeyRef>(aKeyRef));
+    instance.Get<KeyManager>().SetNetworkKeyRef((aKeyRef));
     instance.Get<MeshCoP::ActiveDataset>().Clear();
     instance.Get<MeshCoP::PendingDataset>().Clear();
 
@@ -167,35 +151,28 @@ exit:
 
 const otIp6Address *otThreadGetRloc(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<Mle::MleRouter>().GetMeshLocal16();
+    return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetMeshLocal16();
 }
 
 const otIp6Address *otThreadGetMeshLocalEid(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<Mle::MleRouter>().GetMeshLocal64();
+    return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetMeshLocal64();
 }
 
 const otMeshLocalPrefix *otThreadGetMeshLocalPrefix(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<Mle::MleRouter>().GetMeshLocalPrefix();
+    return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetMeshLocalPrefix();
 }
 
 otError otThreadSetMeshLocalPrefix(otInstance *aInstance, const otMeshLocalPrefix *aMeshLocalPrefix)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
-    VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
+    VerifyOrExit(AsCoreType(aInstance).Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
-    instance.Get<Mle::MleRouter>().SetMeshLocalPrefix(*static_cast<const Mle::MeshLocalPrefix *>(aMeshLocalPrefix));
-    instance.Get<MeshCoP::ActiveDataset>().Clear();
-    instance.Get<MeshCoP::PendingDataset>().Clear();
+    AsCoreType(aInstance).Get<Mle::MleRouter>().SetMeshLocalPrefix(AsCoreType(aMeshLocalPrefix));
+    AsCoreType(aInstance).Get<MeshCoP::ActiveDataset>().Clear();
+    AsCoreType(aInstance).Get<MeshCoP::PendingDataset>().Clear();
 
 exit:
     return error;
@@ -203,49 +180,38 @@ exit:
 
 const otIp6Address *otThreadGetLinkLocalIp6Address(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<Mle::MleRouter>().GetLinkLocalAddress();
+    return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetLinkLocalAddress();
 }
 
 const otIp6Address *otThreadGetLinkLocalAllThreadNodesMulticastAddress(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<Mle::MleRouter>().GetLinkLocalAllThreadNodesAddress();
+    return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetLinkLocalAllThreadNodesAddress();
 }
 
 const otIp6Address *otThreadGetRealmLocalAllThreadNodesMulticastAddress(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<Mle::MleRouter>().GetRealmLocalAllThreadNodesAddress();
+    return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetRealmLocalAllThreadNodesAddress();
 }
 
 otError otThreadGetServiceAloc(otInstance *aInstance, uint8_t aServiceId, otIp6Address *aServiceAloc)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetServiceAloc(aServiceId, *static_cast<Ip6::Address *>(aServiceAloc));
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetServiceAloc(aServiceId, AsCoreType(aServiceAloc));
 }
 
 const char *otThreadGetNetworkName(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().GetNetworkName().GetAsCString();
+    return AsCoreType(aInstance).Get<Mac::Mac>().GetNetworkName().GetAsCString();
 }
 
 otError otThreadSetNetworkName(otInstance *aInstance, const char *aNetworkName)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
-    VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
+    VerifyOrExit(AsCoreType(aInstance).Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
-    error = instance.Get<Mac::Mac>().SetNetworkName(aNetworkName);
-    instance.Get<MeshCoP::ActiveDataset>().Clear();
-    instance.Get<MeshCoP::PendingDataset>().Clear();
+    error = AsCoreType(aInstance).Get<Mac::Mac>().SetNetworkName(aNetworkName);
+    AsCoreType(aInstance).Get<MeshCoP::ActiveDataset>().Clear();
+    AsCoreType(aInstance).Get<MeshCoP::PendingDataset>().Clear();
 
 exit:
     return error;
@@ -254,19 +220,16 @@ exit:
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 const char *otThreadGetDomainName(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mac::Mac>().GetDomainName().GetAsCString();
+    return AsCoreType(aInstance).Get<Mac::Mac>().GetDomainName().GetAsCString();
 }
 
 otError otThreadSetDomainName(otInstance *aInstance, const char *aDomainName)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
-    VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
+    VerifyOrExit(AsCoreType(aInstance).Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
-    error = instance.Get<Mac::Mac>().SetDomainName(aDomainName);
+    error = AsCoreType(aInstance).Get<Mac::Mac>().SetDomainName(aDomainName);
 
 exit:
     return error;
@@ -275,17 +238,15 @@ exit:
 #if OPENTHREAD_CONFIG_DUA_ENABLE
 otError otThreadSetFixedDuaInterfaceIdentifier(otInstance *aInstance, const otIp6InterfaceIdentifier *aIid)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-    Error     error    = kErrorNone;
+    Error error = kErrorNone;
 
     if (aIid)
     {
-        error = instance.Get<DuaManager>().SetFixedDuaInterfaceIdentifier(
-            *static_cast<const Ip6::InterfaceIdentifier *>(aIid));
+        error = AsCoreType(aInstance).Get<DuaManager>().SetFixedDuaInterfaceIdentifier(AsCoreType(aIid));
     }
     else
     {
-        instance.Get<DuaManager>().ClearFixedDuaInterfaceIdentifier();
+        AsCoreType(aInstance).Get<DuaManager>().ClearFixedDuaInterfaceIdentifier();
     }
 
     return error;
@@ -293,7 +254,7 @@ otError otThreadSetFixedDuaInterfaceIdentifier(otInstance *aInstance, const otIp
 
 const otIp6InterfaceIdentifier *otThreadGetFixedDuaInterfaceIdentifier(otInstance *aInstance)
 {
-    Instance &                      instance = *static_cast<Instance *>(aInstance);
+    Instance &                      instance = AsCoreType(aInstance);
     const otIp6InterfaceIdentifier *iid      = nullptr;
 
     if (instance.Get<DuaManager>().IsFixedDuaInterfaceIdentifierSet())
@@ -309,76 +270,59 @@ const otIp6InterfaceIdentifier *otThreadGetFixedDuaInterfaceIdentifier(otInstanc
 
 uint32_t otThreadGetKeySequenceCounter(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<KeyManager>().GetCurrentKeySequence();
+    return AsCoreType(aInstance).Get<KeyManager>().GetCurrentKeySequence();
 }
 
 void otThreadSetKeySequenceCounter(otInstance *aInstance, uint32_t aKeySequenceCounter)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<KeyManager>().SetCurrentKeySequence(aKeySequenceCounter);
+    AsCoreType(aInstance).Get<KeyManager>().SetCurrentKeySequence(aKeySequenceCounter);
 }
 
 uint32_t otThreadGetKeySwitchGuardTime(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<KeyManager>().GetKeySwitchGuardTime();
+    return AsCoreType(aInstance).Get<KeyManager>().GetKeySwitchGuardTime();
 }
 
 void otThreadSetKeySwitchGuardTime(otInstance *aInstance, uint32_t aKeySwitchGuardTime)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<KeyManager>().SetKeySwitchGuardTime(aKeySwitchGuardTime);
+    AsCoreType(aInstance).Get<KeyManager>().SetKeySwitchGuardTime(aKeySwitchGuardTime);
 }
 
 otError otThreadBecomeDetached(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().BecomeDetached();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().BecomeDetached();
 }
 
 otError otThreadBecomeChild(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().BecomeChild(Mle::kAttachAny);
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().BecomeChild(Mle::kAttachAny);
 }
 
 otError otThreadGetNextNeighborInfo(otInstance *aInstance, otNeighborInfoIterator *aIterator, otNeighborInfo *aInfo)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT((aInfo != nullptr) && (aIterator != nullptr));
 
-    return instance.Get<NeighborTable>().GetNextNeighborInfo(*aIterator, *static_cast<Neighbor::Info *>(aInfo));
+    return AsCoreType(aInstance).Get<NeighborTable>().GetNextNeighborInfo(*aIterator, AsCoreType(aInfo));
 }
 
 otDeviceRole otThreadGetDeviceRole(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return static_cast<otDeviceRole>(instance.Get<Mle::MleRouter>().GetRole());
+    return MapEnum(AsCoreType(aInstance).Get<Mle::MleRouter>().GetRole());
 }
 
 const char *otThreadDeviceRoleToString(otDeviceRole aRole)
 {
-    return Mle::Mle::RoleToString(static_cast<Mle::DeviceRole>(aRole));
+    return Mle::Mle::RoleToString(MapEnum(aRole));
 }
 
 otError otThreadGetLeaderData(otInstance *aInstance, otLeaderData *aLeaderData)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-    Error     error    = kErrorNone;
+    Error error = kErrorNone;
 
     OT_ASSERT(aLeaderData != nullptr);
 
-    VerifyOrExit(instance.Get<Mle::MleRouter>().IsAttached(), error = kErrorDetached);
-    *aLeaderData = instance.Get<Mle::MleRouter>().GetLeaderData();
+    VerifyOrExit(AsCoreType(aInstance).Get<Mle::MleRouter>().IsAttached(), error = kErrorDetached);
+    *aLeaderData = AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderData();
 
 exit:
     return error;
@@ -386,46 +330,37 @@ exit:
 
 uint8_t otThreadGetLeaderRouterId(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetLeaderId();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderId();
 }
 
 uint8_t otThreadGetLeaderWeight(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetLeaderData().GetWeighting();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderData().GetWeighting();
 }
 
 uint32_t otThreadGetPartitionId(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetLeaderData().GetPartitionId();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderData().GetPartitionId();
 }
 
 uint16_t otThreadGetRloc16(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetRloc16();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetRloc16();
 }
 
 otError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-    Error     error    = kErrorNone;
-    Router *  parent;
+    Error   error = kErrorNone;
+    Router *parent;
 
     OT_ASSERT(aParentInfo != nullptr);
 
     // Reference device needs get the original parent's info even after the node state changed.
 #if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    VerifyOrExit(instance.Get<Mle::MleRouter>().IsChild(), error = kErrorInvalidState);
+    VerifyOrExit(AsCoreType(aInstance).Get<Mle::MleRouter>().IsChild(), error = kErrorInvalidState);
 #endif
 
-    parent = &instance.Get<Mle::MleRouter>().GetParent();
+    parent = &AsCoreType(aInstance).Get<Mle::MleRouter>().GetParent();
 
     aParentInfo->mExtAddress     = parent->GetExtAddress();
     aParentInfo->mRloc16         = parent->GetRloc16();
@@ -446,12 +381,11 @@ exit:
 
 otError otThreadGetParentAverageRssi(otInstance *aInstance, int8_t *aParentRssi)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
     OT_ASSERT(aParentRssi != nullptr);
 
-    *aParentRssi = instance.Get<Mle::MleRouter>().GetParent().GetLinkInfo().GetAverageRss();
+    *aParentRssi = AsCoreType(aInstance).Get<Mle::MleRouter>().GetParent().GetLinkInfo().GetAverageRss();
 
     VerifyOrExit(*aParentRssi != OT_RADIO_RSSI_INVALID, error = kErrorFailed);
 
@@ -461,12 +395,11 @@ exit:
 
 otError otThreadGetParentLastRssi(otInstance *aInstance, int8_t *aLastRssi)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
     OT_ASSERT(aLastRssi != nullptr);
 
-    *aLastRssi = instance.Get<Mle::MleRouter>().GetParent().GetLinkInfo().GetLastRss();
+    *aLastRssi = AsCoreType(aInstance).Get<Mle::MleRouter>().GetParent().GetLinkInfo().GetLastRss();
 
     VerifyOrExit(*aLastRssi != OT_RADIO_RSSI_INVALID, error = kErrorFailed);
 
@@ -476,16 +409,15 @@ exit:
 
 otError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
     if (aEnabled)
     {
-        error = instance.Get<Mle::MleRouter>().Start();
+        error = AsCoreType(aInstance).Get<Mle::MleRouter>().Start();
     }
     else
     {
-        instance.Get<Mle::MleRouter>().Stop();
+        AsCoreType(aInstance).Get<Mle::MleRouter>().Stop();
     }
 
     return error;
@@ -498,9 +430,7 @@ uint16_t otThreadGetVersion(void)
 
 bool otThreadIsSingleton(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().IsSingleton();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().IsSingleton();
 }
 
 otError otThreadDiscover(otInstance *             aInstance,
@@ -511,10 +441,8 @@ otError otThreadDiscover(otInstance *             aInstance,
                          otHandleActiveScanResult aCallback,
                          void *                   aCallbackContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::DiscoverScanner>().Discover(
-        static_cast<Mac::ChannelMask>(aScanChannels), aPanId, aJoiner, aEnableEui64Filtering,
+    return AsCoreType(aInstance).Get<Mle::DiscoverScanner>().Discover(
+        Mac::ChannelMask(aScanChannels), aPanId, aJoiner, aEnableEui64Filtering,
         /* aFilterIndexes (use hash of factory EUI64) */ nullptr, aCallback, aCallbackContext);
 }
 
@@ -523,53 +451,39 @@ otError otThreadSetJoinerAdvertisement(otInstance *   aInstance,
                                        const uint8_t *aAdvData,
                                        uint8_t        aAdvDataLength)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::DiscoverScanner>().SetJoinerAdvertisement(aOui, aAdvData, aAdvDataLength);
+    return AsCoreType(aInstance).Get<Mle::DiscoverScanner>().SetJoinerAdvertisement(aOui, aAdvData, aAdvDataLength);
 }
 
 bool otThreadIsDiscoverInProgress(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::DiscoverScanner>().IsInProgress();
+    return AsCoreType(aInstance).Get<Mle::DiscoverScanner>().IsInProgress();
 }
 
 const otIpCounters *otThreadGetIp6Counters(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<MeshForwarder>().GetCounters();
+    return &AsCoreType(aInstance).Get<MeshForwarder>().GetCounters();
 }
 
 void otThreadResetIp6Counters(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<MeshForwarder>().ResetCounters();
+    AsCoreType(aInstance).Get<MeshForwarder>().ResetCounters();
 }
 
 const otMleCounters *otThreadGetMleCounters(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return &instance.Get<Mle::MleRouter>().GetCounters();
+    return &AsCoreType(aInstance).Get<Mle::MleRouter>().GetCounters();
 }
 
 void otThreadResetMleCounters(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mle::MleRouter>().ResetCounters();
+    AsCoreType(aInstance).Get<Mle::MleRouter>().ResetCounters();
 }
 
 void otThreadRegisterParentResponseCallback(otInstance *                   aInstance,
                                             otThreadParentResponseCallback aCallback,
                                             void *                         aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mle::MleRouter>().RegisterParentResponseStatsCallback(aCallback, aContext);
+    AsCoreType(aInstance).Get<Mle::MleRouter>().RegisterParentResponseStatsCallback(aCallback, aContext);
 }
 
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -37,161 +37,119 @@
 
 #include <openthread/thread_ftd.h>
 
-#include "backbone_router/bbr_manager.hpp"
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
-#include "thread/mle_types.hpp"
-#include "thread/topology.hpp"
 
 using namespace ot;
 
 uint16_t otThreadGetMaxAllowedChildren(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<ChildTable>().GetMaxChildrenAllowed();
+    return AsCoreType(aInstance).Get<ChildTable>().GetMaxChildrenAllowed();
 }
 
 otError otThreadSetMaxAllowedChildren(otInstance *aInstance, uint16_t aMaxChildren)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<ChildTable>().SetMaxChildrenAllowed(aMaxChildren);
+    return AsCoreType(aInstance).Get<ChildTable>().SetMaxChildrenAllowed(aMaxChildren);
 }
 
 uint8_t otThreadGetMaxChildIpAddresses(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetMaxChildIpAddresses();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetMaxChildIpAddresses();
 }
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 otError otThreadSetMaxChildIpAddresses(otInstance *aInstance, uint8_t aMaxIpAddresses)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().SetMaxChildIpAddresses(aMaxIpAddresses);
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().SetMaxChildIpAddresses(aMaxIpAddresses);
 }
 #endif
 
 bool otThreadIsRouterEligible(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().IsRouterEligible();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().IsRouterEligible();
 }
 
 otError otThreadSetRouterEligible(otInstance *aInstance, bool aEligible)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().SetRouterEligible(aEligible);
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().SetRouterEligible(aEligible);
 }
 
 otError otThreadSetPreferredRouterId(otInstance *aInstance, uint8_t aRouterId)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().SetPreferredRouterId(aRouterId);
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().SetPreferredRouterId(aRouterId);
 }
 
 uint8_t otThreadGetLocalLeaderWeight(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetLeaderWeight();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderWeight();
 }
 
 void otThreadSetLocalLeaderWeight(otInstance *aInstance, uint8_t aWeight)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mle::MleRouter>().SetLeaderWeight(aWeight);
+    AsCoreType(aInstance).Get<Mle::MleRouter>().SetLeaderWeight(aWeight);
 }
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 uint32_t otThreadGetPreferredLeaderPartitionId(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetPreferredLeaderPartitionId();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetPreferredLeaderPartitionId();
 }
 
 void otThreadSetPreferredLeaderPartitionId(otInstance *aInstance, uint32_t aPartitionId)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mle::MleRouter>().SetPreferredLeaderPartitionId(aPartitionId);
+    AsCoreType(aInstance).Get<Mle::MleRouter>().SetPreferredLeaderPartitionId(aPartitionId);
 }
 #endif
 
 uint16_t otThreadGetJoinerUdpPort(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<MeshCoP::JoinerRouter>().GetJoinerUdpPort();
+    return AsCoreType(aInstance).Get<MeshCoP::JoinerRouter>().GetJoinerUdpPort();
 }
 
 otError otThreadSetJoinerUdpPort(otInstance *aInstance, uint16_t aJoinerUdpPort)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<MeshCoP::JoinerRouter>().SetJoinerUdpPort(aJoinerUdpPort);
+    AsCoreType(aInstance).Get<MeshCoP::JoinerRouter>().SetJoinerUdpPort(aJoinerUdpPort);
 
     return kErrorNone;
 }
 
 uint32_t otThreadGetContextIdReuseDelay(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<NetworkData::Leader>().GetContextIdReuseDelay();
+    return AsCoreType(aInstance).Get<NetworkData::Leader>().GetContextIdReuseDelay();
 }
 
 void otThreadSetContextIdReuseDelay(otInstance *aInstance, uint32_t aDelay)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<NetworkData::Leader>().SetContextIdReuseDelay(aDelay);
+    AsCoreType(aInstance).Get<NetworkData::Leader>().SetContextIdReuseDelay(aDelay);
 }
 
 uint8_t otThreadGetNetworkIdTimeout(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetNetworkIdTimeout();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetNetworkIdTimeout();
 }
 
 void otThreadSetNetworkIdTimeout(otInstance *aInstance, uint8_t aTimeout)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mle::MleRouter>().SetNetworkIdTimeout(aTimeout);
+    AsCoreType(aInstance).Get<Mle::MleRouter>().SetNetworkIdTimeout(aTimeout);
 }
 
 uint8_t otThreadGetRouterUpgradeThreshold(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetRouterUpgradeThreshold();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetRouterUpgradeThreshold();
 }
 
 void otThreadSetRouterUpgradeThreshold(otInstance *aInstance, uint8_t aThreshold)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mle::MleRouter>().SetRouterUpgradeThreshold(aThreshold);
+    AsCoreType(aInstance).Get<Mle::MleRouter>().SetRouterUpgradeThreshold(aThreshold);
 }
 
 otError otThreadReleaseRouterId(otInstance *aInstance, uint8_t aRouterId)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
     VerifyOrExit(aRouterId <= Mle::kMaxRouterId, error = kErrorInvalidArgs);
 
-    error = instance.Get<RouterTable>().Release(aRouterId);
+    error = AsCoreType(aInstance).Get<RouterTable>().Release(aRouterId);
 
 exit:
     return error;
@@ -199,17 +157,16 @@ exit:
 
 otError otThreadBecomeRouter(otInstance *aInstance)
 {
-    Error     error    = kErrorInvalidState;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorInvalidState;
 
-    switch (instance.Get<Mle::MleRouter>().GetRole())
+    switch (AsCoreType(aInstance).Get<Mle::MleRouter>().GetRole())
     {
     case Mle::kRoleDisabled:
     case Mle::kRoleDetached:
         break;
 
     case Mle::kRoleChild:
-        error = instance.Get<Mle::MleRouter>().BecomeRouter(ThreadStatusTlv::kHaveChildIdRequest);
+        error = AsCoreType(aInstance).Get<Mle::MleRouter>().BecomeRouter(ThreadStatusTlv::kHaveChildIdRequest);
         break;
 
     case Mle::kRoleRouter:
@@ -223,55 +180,41 @@ otError otThreadBecomeRouter(otInstance *aInstance)
 
 otError otThreadBecomeLeader(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().BecomeLeader();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().BecomeLeader();
 }
 
 uint8_t otThreadGetRouterDowngradeThreshold(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetRouterDowngradeThreshold();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetRouterDowngradeThreshold();
 }
 
 void otThreadSetRouterDowngradeThreshold(otInstance *aInstance, uint8_t aThreshold)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mle::MleRouter>().SetRouterDowngradeThreshold(aThreshold);
+    AsCoreType(aInstance).Get<Mle::MleRouter>().SetRouterDowngradeThreshold(aThreshold);
 }
 
 uint8_t otThreadGetRouterSelectionJitter(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetRouterSelectionJitter();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetRouterSelectionJitter();
 }
 
 void otThreadSetRouterSelectionJitter(otInstance *aInstance, uint8_t aRouterJitter)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    IgnoreError(instance.Get<Mle::MleRouter>().SetRouterSelectionJitter(aRouterJitter));
+    IgnoreError(AsCoreType(aInstance).Get<Mle::MleRouter>().SetRouterSelectionJitter(aRouterJitter));
 }
 
 otError otThreadGetChildInfoById(otInstance *aInstance, uint16_t aChildId, otChildInfo *aChildInfo)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aChildInfo != nullptr);
 
-    return instance.Get<ChildTable>().GetChildInfoById(aChildId, *static_cast<Child::Info *>(aChildInfo));
+    return AsCoreType(aInstance).Get<ChildTable>().GetChildInfoById(aChildId, AsCoreType(aChildInfo));
 }
 
 otError otThreadGetChildInfoByIndex(otInstance *aInstance, uint16_t aChildIndex, otChildInfo *aChildInfo)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aChildInfo != nullptr);
 
-    return instance.Get<ChildTable>().GetChildInfoByIndex(aChildIndex, *static_cast<Child::Info *>(aChildInfo));
+    return AsCoreType(aInstance).Get<ChildTable>().GetChildInfoByIndex(aChildIndex, AsCoreType(aChildInfo));
 }
 
 otError otThreadGetChildNextIp6Address(otInstance *               aInstance,
@@ -279,13 +222,12 @@ otError otThreadGetChildNextIp6Address(otInstance *               aInstance,
                                        otChildIp6AddressIterator *aIterator,
                                        otIp6Address *             aAddress)
 {
-    Error        error    = kErrorNone;
-    Instance &   instance = *static_cast<Instance *>(aInstance);
+    Error        error = kErrorNone;
     const Child *child;
 
     OT_ASSERT(aIterator != nullptr && aAddress != nullptr);
 
-    child = instance.Get<ChildTable>().GetChildAtIndex(aChildIndex);
+    child = AsCoreType(aInstance).Get<ChildTable>().GetChildAtIndex(aChildIndex);
     VerifyOrExit(child != nullptr, error = kErrorInvalidArgs);
     VerifyOrExit(child->IsStateValidOrRestoring(), error = kErrorInvalidArgs);
 
@@ -305,9 +247,7 @@ exit:
 
 uint8_t otThreadGetRouterIdSequence(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<RouterTable>().GetRouterIdSequence();
+    return AsCoreType(aInstance).Get<RouterTable>().GetRouterIdSequence();
 }
 
 uint8_t otThreadGetMaxRouterId(otInstance *aInstance)
@@ -318,57 +258,46 @@ uint8_t otThreadGetMaxRouterId(otInstance *aInstance)
 
 otError otThreadGetRouterInfo(otInstance *aInstance, uint16_t aRouterId, otRouterInfo *aRouterInfo)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT(aRouterInfo != nullptr);
 
-    return instance.Get<RouterTable>().GetRouterInfo(aRouterId, *static_cast<Router::Info *>(aRouterInfo));
+    return AsCoreType(aInstance).Get<RouterTable>().GetRouterInfo(aRouterId, AsCoreType(aRouterInfo));
 }
 
 otError otThreadGetNextCacheEntry(otInstance *aInstance, otCacheEntryInfo *aEntryInfo, otCacheEntryIterator *aIterator)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
     OT_ASSERT((aIterator != nullptr) && (aEntryInfo != nullptr));
 
-    return instance.Get<AddressResolver>().GetNextCacheEntry(*aEntryInfo, *aIterator);
+    return AsCoreType(aInstance).Get<AddressResolver>().GetNextCacheEntry(*aEntryInfo, *aIterator);
 }
 
 #if OPENTHREAD_CONFIG_MLE_STEERING_DATA_SET_OOB_ENABLE
 void otThreadSetSteeringData(otInstance *aInstance, const otExtAddress *aExtAddress)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mle::MleRouter>().SetSteeringData(static_cast<const Mac::ExtAddress *>(aExtAddress));
+    AsCoreType(aInstance).Get<Mle::MleRouter>().SetSteeringData(AsCoreTypePtr(aExtAddress));
 }
 #endif
 
 void otThreadGetPskc(otInstance *aInstance, otPskc *aPskc)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<KeyManager>().GetPskc(*static_cast<Pskc *>(aPskc));
+    AsCoreType(aInstance).Get<KeyManager>().GetPskc(AsCoreType(aPskc));
 }
 
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
 otPskcRef otThreadGetPskcRef(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<KeyManager>().GetPskcRef();
+    return AsCoreType(aInstance).Get<KeyManager>().GetPskcRef();
 }
 #endif
 
 otError otThreadSetPskc(otInstance *aInstance, const otPskc *aPskc)
 {
-    Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Error error = kErrorNone;
 
-    VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
+    VerifyOrExit(AsCoreType(aInstance).Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
-    instance.Get<KeyManager>().SetPskc(*static_cast<const Pskc *>(aPskc));
-    instance.Get<MeshCoP::ActiveDataset>().Clear();
-    instance.Get<MeshCoP::PendingDataset>().Clear();
+    AsCoreType(aInstance).Get<KeyManager>().SetPskc(AsCoreType(aPskc));
+    AsCoreType(aInstance).Get<MeshCoP::ActiveDataset>().Clear();
+    AsCoreType(aInstance).Get<MeshCoP::PendingDataset>().Clear();
 
 exit:
     return error;
@@ -378,7 +307,7 @@ exit:
 otError otThreadSetPskcRef(otInstance *aInstance, otPskcRef aKeyRef)
 {
     Error     error    = kErrorNone;
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(aKeyRef != 0, error = kErrorInvalidArgs);
     VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
@@ -394,32 +323,24 @@ exit:
 
 int8_t otThreadGetParentPriority(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().GetAssignParentPriority();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetAssignParentPriority();
 }
 
 otError otThreadSetParentPriority(otInstance *aInstance, int8_t aParentPriority)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Mle::MleRouter>().SetAssignParentPriority(aParentPriority);
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().SetAssignParentPriority(aParentPriority);
 }
 
 void otThreadRegisterNeighborTableCallback(otInstance *aInstance, otNeighborTableCallback aCallback)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<NeighborTable>().RegisterCallback(aCallback);
+    AsCoreType(aInstance).Get<NeighborTable>().RegisterCallback(aCallback);
 }
 
 void otThreadSetDiscoveryRequestCallback(otInstance *                     aInstance,
                                          otThreadDiscoveryRequestCallback aCallback,
                                          void *                           aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Mle::MleRouter>().SetDiscoveryRequestCallback(aCallback, aContext);
+    AsCoreType(aInstance).Get<Mle::MleRouter>().SetDiscoveryRequestCallback(aCallback, aContext);
 }
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
@@ -428,11 +349,8 @@ void otThreadSendAddressNotification(otInstance *              aInstance,
                                      otIp6Address *            aTarget,
                                      otIp6InterfaceIdentifier *aMlIid)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<AddressResolver>().SendAddressQueryResponse(static_cast<Ip6::Address &>(*aTarget),
-                                                             static_cast<Ip6::InterfaceIdentifier &>(*aMlIid), nullptr,
-                                                             static_cast<Ip6::Address &>(*aDestination));
+    AsCoreType(aInstance).Get<AddressResolver>().SendAddressQueryResponse(AsCoreType(aTarget), AsCoreType(aMlIid),
+                                                                          nullptr, AsCoreType(aDestination));
 }
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
@@ -441,11 +359,8 @@ otError otThreadSendProactiveBackboneNotification(otInstance *              aIns
                                                   otIp6InterfaceIdentifier *aMlIid,
                                                   uint32_t                  aTimeSinceLastTransaction)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<BackboneRouter::Manager>().SendProactiveBackboneNotification(
-        static_cast<Ip6::Address &>(*aTarget), static_cast<Ip6::InterfaceIdentifier &>(*aMlIid),
-        aTimeSinceLastTransaction);
+    return AsCoreType(aInstance).Get<BackboneRouter::Manager>().SendProactiveBackboneNotification(
+        AsCoreType(aTarget), AsCoreType(aMlIid), aTimeSinceLastTransaction);
 }
 #endif
 #endif

--- a/src/core/api/udp_api.cpp
+++ b/src/core/api/udp_api.cpp
@@ -35,79 +35,56 @@
 
 #include <openthread/udp.h>
 
-#include "common/instance.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
-#include "common/new.hpp"
-#include "net/udp6.hpp"
 
 using namespace ot;
 
 otMessage *otUdpNewMessage(otInstance *aInstance, const otMessageSettings *aSettings)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Udp>().NewMessage(0, Message::Settings::From(aSettings));
+    return AsCoreType(aInstance).Get<Ip6::Udp>().NewMessage(0, Message::Settings::From(aSettings));
 }
 
 otError otUdpOpen(otInstance *aInstance, otUdpSocket *aSocket, otUdpReceive aCallback, void *aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Udp>().Open(*static_cast<Ip6::Udp::SocketHandle *>(aSocket), aCallback, aContext);
+    return AsCoreType(aInstance).Get<Ip6::Udp>().Open(AsCoreType(aSocket), aCallback, aContext);
 }
 
 bool otUdpIsOpen(otInstance *aInstance, const otUdpSocket *aSocket)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Udp>().IsOpen(*static_cast<const Ip6::Udp::SocketHandle *>(aSocket));
+    return AsCoreType(aInstance).Get<Ip6::Udp>().IsOpen(AsCoreType(aSocket));
 }
 
 otError otUdpClose(otInstance *aInstance, otUdpSocket *aSocket)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Udp>().Close(*static_cast<Ip6::Udp::SocketHandle *>(aSocket));
+    return AsCoreType(aInstance).Get<Ip6::Udp>().Close(AsCoreType(aSocket));
 }
 
 otError otUdpBind(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr *aSockName, otNetifIdentifier aNetif)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Udp>().Bind(*static_cast<Ip6::Udp::SocketHandle *>(aSocket),
-                                         *static_cast<const Ip6::SockAddr *>(aSockName), aNetif);
+    return AsCoreType(aInstance).Get<Ip6::Udp>().Bind(AsCoreType(aSocket), AsCoreType(aSockName), aNetif);
 }
 
 otError otUdpConnect(otInstance *aInstance, otUdpSocket *aSocket, const otSockAddr *aSockName)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Udp>().Connect(*static_cast<Ip6::Udp::SocketHandle *>(aSocket),
-                                            *static_cast<const Ip6::SockAddr *>(aSockName));
+    return AsCoreType(aInstance).Get<Ip6::Udp>().Connect(AsCoreType(aSocket), AsCoreType(aSockName));
 }
 
 otError otUdpSend(otInstance *aInstance, otUdpSocket *aSocket, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Udp>().SendTo(*static_cast<Ip6::Udp::SocketHandle *>(aSocket),
-                                           *static_cast<Message *>(aMessage),
-                                           *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    return AsCoreType(aInstance).Get<Ip6::Udp>().SendTo(AsCoreType(aSocket), AsCoreType(aMessage),
+                                                        AsCoreType(aMessageInfo));
 }
 
 otUdpSocket *otUdpGetSockets(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Udp>().GetUdpSockets();
+    return AsCoreType(aInstance).Get<Ip6::Udp>().GetUdpSockets();
 }
 
 #if OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE
 void otUdpForwardSetForwarder(otInstance *aInstance, otUdpForwarder aForwarder, void *aContext)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<Ip6::Udp>().SetUdpForwarder(aForwarder, aContext);
+    AsCoreType(aInstance).Get<Ip6::Udp>().SetUdpForwarder(aForwarder, aContext);
 }
 
 void otUdpForwardReceive(otInstance *        aInstance,
@@ -117,47 +94,38 @@ void otUdpForwardReceive(otInstance *        aInstance,
                          uint16_t            aSockPort)
 {
     Ip6::MessageInfo messageInfo;
-    Instance &       instance = *static_cast<Instance *>(aInstance);
 
     OT_ASSERT(aMessage != nullptr && aPeerAddr != nullptr);
 
-    messageInfo.SetSockAddr(instance.Get<Mle::MleRouter>().GetMeshLocal16());
+    messageInfo.SetSockAddr(AsCoreType(aInstance).Get<Mle::MleRouter>().GetMeshLocal16());
     messageInfo.SetSockPort(aSockPort);
-    messageInfo.SetPeerAddr(*static_cast<const ot::Ip6::Address *>(aPeerAddr));
+    messageInfo.SetPeerAddr(AsCoreType(aPeerAddr));
     messageInfo.SetPeerPort(aPeerPort);
     messageInfo.SetIsHostInterface(true);
 
-    instance.Get<Ip6::Udp>().HandlePayload(*static_cast<ot::Message *>(aMessage), messageInfo);
+    AsCoreType(aInstance).Get<Ip6::Udp>().HandlePayload(AsCoreType(aMessage), messageInfo);
 
-    static_cast<ot::Message *>(aMessage)->Free();
+    AsCoreType(aMessage).Free();
 }
 #endif // OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE
 
 otError otUdpAddReceiver(otInstance *aInstance, otUdpReceiver *aUdpReceiver)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Udp>().AddReceiver(*static_cast<Ip6::Udp::Receiver *>(aUdpReceiver));
+    return AsCoreType(aInstance).Get<Ip6::Udp>().AddReceiver(AsCoreType(aUdpReceiver));
 }
 
 otError otUdpRemoveReceiver(otInstance *aInstance, otUdpReceiver *aUdpReceiver)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Udp>().RemoveReceiver(*static_cast<Ip6::Udp::Receiver *>(aUdpReceiver));
+    return AsCoreType(aInstance).Get<Ip6::Udp>().RemoveReceiver(AsCoreType(aUdpReceiver));
 }
 
 otError otUdpSendDatagram(otInstance *aInstance, otMessage *aMessage, otMessageInfo *aMessageInfo)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Udp>().SendDatagram(*static_cast<ot::Message *>(aMessage),
-                                                 *static_cast<Ip6::MessageInfo *>(aMessageInfo), Ip6::kProtoUdp);
+    return AsCoreType(aInstance).Get<Ip6::Udp>().SendDatagram(AsCoreType(aMessage), AsCoreType(aMessageInfo),
+                                                              Ip6::kProtoUdp);
 }
 
 bool otUdpIsPortInUse(otInstance *aInstance, uint16_t port)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<Ip6::Udp>().IsPortInUse(port);
+    return AsCoreType(aInstance).Get<Ip6::Udp>().IsPortInUse(port);
 }

--- a/src/core/common/as_core_type.hpp
+++ b/src/core/common/as_core_type.hpp
@@ -1,0 +1,368 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes helper functions to convert between public OT C structs and corresponding core C++ classes.
+ */
+
+#ifndef AS_CORE_TYPE_HPP_
+#define AS_CORE_TYPE_HPP_
+
+#include "openthread-core-config.h"
+
+#include "common/instance.hpp"
+#include "crypto/sha256.hpp"
+#include "mac/mac_filter.hpp"
+#include "net/dns_types.hpp"
+
+namespace ot {
+
+/**
+ * This structure relates a given public OT type to its corresponding core C++ class/type.
+ *
+ * @tparam FromType  The public OT type.
+ *
+ * Specializations of this template struct are provided for different `FromType` which include a member type definition
+ * named `Type` to provide the corresponding core class/type related to `FromType.
+ *
+ * For example, `CoreType<otIp6Address>::Type` is defined as `Ip6::Address`.
+ *
+ */
+template <typename FromType> struct CoreType;
+
+/**
+ * This function converts a pointer to public OT type (C struct) to the corresponding core C++ type reference.
+ *
+ * @tparam Type   The public OT type to convert.
+ *
+ * @param[in] aObject   A pointer to the object to convert.
+ *
+ * @returns A reference of the corresponding C++ type matching @p aObject.
+ *
+ */
+template <typename Type> typename CoreType<Type>::Type &AsCoreType(Type *aObject)
+{
+    return *static_cast<typename CoreType<Type>::Type *>(aObject);
+}
+
+/**
+ * This function converts a const pointer to public OT type (C struct) to the corresponding core C++ type reference.
+ *
+ * @tparam Type   The public OT type to convert.
+ *
+ * @param[in] aObject   A const pointer to the object to convert.
+ *
+ * @returns A const reference of the corresponding C++ type matching @p aObject.
+ *
+ */
+template <typename Type> const typename CoreType<Type>::Type &AsCoreType(const Type *aObject)
+{
+    return *static_cast<const typename CoreType<Type>::Type *>(aObject);
+}
+
+/**
+ * This function converts a pointer to public OT type (C struct) to the corresponding core C++ type pointer.
+ *
+ * @tparam Type   The public OT type to convert.
+ *
+ * @param[in] aObject   A pointer to the object to convert.
+ *
+ * @returns A pointer of the corresponding C++ type matching @p aObject.
+ *
+ */
+template <typename Type> typename CoreType<Type>::Type *AsCoreTypePtr(Type *aObject)
+{
+    return static_cast<typename CoreType<Type>::Type *>(aObject);
+}
+
+/**
+ * This function converts a const pointer to public OT type (C struct) to the corresponding core C++ type pointer.
+ *
+ * @tparam Type   The public OT type to convert.
+ *
+ * @param[in] aObject   A pointer to the object to convert.
+ *
+ * @returns A const pointer of the corresponding C++ type matching @p aObject.
+ *
+ */
+template <typename Type> const typename CoreType<Type>::Type *AsCoreTypePtr(const Type *aObject)
+{
+    return static_cast<const typename CoreType<Type>::Type *>(aObject);
+}
+
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
+
+/**
+ * This method casts an `otMessage` pointer to a `Coap::Message` reference.
+ *
+ * @param[in] aMessage   A pointer to an `otMessage`.
+ *
+ * @returns A reference to `Coap::Message` matching @p aMessage.
+ *
+ */
+inline Coap::Message &AsCoapMessage(otMessage *aMessage)
+{
+    return *static_cast<Coap::Message *>(aMessage);
+}
+
+/**
+ * This method casts an `otMessage` pointer to a `Coap::Message` reference.
+ *
+ * @param[in] aMessage   A pointer to an `otMessage`.
+ *
+ * @returns A reference to `Coap::Message` matching @p aMessage.
+ *
+ */
+inline Coap::Message *AsCoapMessagePtr(otMessage *aMessage)
+{
+    return static_cast<Coap::Message *>(aMessage);
+}
+
+/**
+ * This method casts an `otMessage` pointer to a `Coap::Message` pointer.
+ *
+ * @param[in] aMessage   A pointer to an `otMessage`.
+ *
+ * @returns A pointer to `Coap::Message` matching @p aMessage.
+ *
+ */
+inline const Coap::Message &AsCoapMessage(const otMessage *aMessage)
+{
+    return *static_cast<const Coap::Message *>(aMessage);
+}
+
+/**
+ * This method casts an `otMessage` pointer to a `Coap::Message` reference.
+ *
+ * @param[in] aMessage   A pointer to an `otMessage`.
+ *
+ * @returns A pointer to `Coap::Message` matching @p aMessage.
+ *
+ */
+inline const Coap::Message *AsCoapMessagePtr(const otMessage *aMessage)
+{
+    return static_cast<const Coap::Message *>(aMessage);
+}
+
+#endif // #if OPENTHREAD_FTD || OPENTHREAD_MTD
+
+/**
+ * This structure maps two enumeration types.
+ *
+ * @tparam FromEnumType  The enum type.
+ *
+ * Specializations of this template struct are provided which include a member type definition named `Type` to provide
+ * the related `enum` type mapped with `FromEnumType`.
+ *
+ * For example, `MappedEnum<otMacFilterAddressMode>::Type` is defined as `Mac::Filter::Mode`.
+ *
+ */
+template <typename FromEnumType> struct MappedEnum;
+
+/**
+ * This function convert an enumeration type value to a related enumeration type value.
+ *
+ * @param[in] aValue   The enumeration value to convert
+ *
+ * @returns The matching enumeration value.
+ *
+ */
+template <typename EnumType> const typename MappedEnum<EnumType>::Type MapEnum(EnumType aValue)
+{
+    return static_cast<typename MappedEnum<EnumType>::Type>(aValue);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
+// Private macros and definitions
+
+// Helper macro to define specialization of `CoreType` struct relating `BaseType` with `SubType`.
+#define DefineCoreType(BaseType, SubType) \
+    template <> struct CoreType<BaseType> \
+    {                                     \
+        using Type = SubType;             \
+    }
+
+// Helper macro to map two related enumeration types.
+#define DefineMapEnum(FirstEnumType, SecondEnumType) \
+    template <> struct MappedEnum<FirstEnumType>     \
+    {                                                \
+        using Type = SecondEnumType;                 \
+    };                                               \
+                                                     \
+    template <> struct MappedEnum<SecondEnumType>    \
+    {                                                \
+        using Type = FirstEnumType;                  \
+    }
+
+DefineCoreType(otInstance, Instance);
+
+// Message
+DefineCoreType(otMessage, Message);
+DefineCoreType(otMessageSettings, Message::Settings);
+DefineCoreType(otMessageBuffer, Buffer);
+DefineCoreType(otMessageQueue, MessageQueue);
+
+// Mac
+DefineCoreType(otRadioFrame, Mac::Frame);
+DefineCoreType(otExtAddress, Mac::ExtAddress);
+DefineCoreType(otMacKey, Mac::Key);
+DefineCoreType(otExtendedPanId, Mac::ExtendedPanId);
+DefineCoreType(otNetworkName, Mac::NetworkName);
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+DefineMapEnum(otMacFilterAddressMode, Mac::Filter::Mode);
+#endif
+
+DefineCoreType(otCryptoKey, Crypto::Key);
+DefineCoreType(otCryptoSha256Hash, Crypto::Sha256::Hash);
+
+#if OPENTHREAD_FTD || OPENTHREAD_MTD
+
+// Thread
+DefineCoreType(otThreadLinkInfo, ThreadLinkInfo);
+DefineCoreType(otSecurityPolicy, SecurityPolicy);
+DefineCoreType(otNetworkKey, NetworkKey);
+DefineCoreType(otPskc, Pskc);
+
+DefineCoreType(otNeighborInfo, Neighbor::Info);
+DefineCoreType(otRouterInfo, Router::Info);
+#if OPENTHREAD_FTD
+DefineCoreType(otChildInfo, Child::Info);
+#endif
+
+// Ip6
+DefineCoreType(otIp6Prefix, Ip6::Prefix);
+DefineCoreType(otIp6InterfaceIdentifier, Ip6::InterfaceIdentifier);
+DefineCoreType(otIp6Address, Ip6::Address);
+DefineCoreType(otMessageInfo, Ip6::MessageInfo);
+DefineCoreType(otSockAddr, Ip6::SockAddr);
+DefineCoreType(otNetifAddress, Ip6::Netif::UnicastAddress);
+DefineCoreType(otNetifMulticastAddress, Ip6::Netif::MulticastAddress);
+DefineCoreType(otIcmp6Header, Ip6::Icmp::Header);
+DefineCoreType(otIcmp6Handler, Ip6::Icmp::Handler);
+DefineCoreType(otUdpSocket, Ip6::Udp::SocketHandle);
+DefineCoreType(otUdpReceiver, Ip6::Udp::Receiver);
+DefineCoreType(otTcpEndpoint, Ip6::Tcp::Endpoint);
+DefineCoreType(otTcpListener, Ip6::Tcp::Listener);
+
+// Mle
+DefineCoreType(otMeshLocalPrefix, Mle::MeshLocalPrefix);
+DefineCoreType(otLeaderData, Mle::LeaderData);
+DefineMapEnum(otDeviceRole, Mle::DeviceRole);
+
+// LinkMetrics
+#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
+DefineCoreType(otLinkMetrics, LinkMetrics::Metrics);
+DefineCoreType(otLinkMetricsValues, LinkMetrics::MetricsValues);
+DefineMapEnum(otLinkMetricsEnhAckFlags, LinkMetrics::EnhAckFlags);
+#endif
+
+// NetworkData
+DefineCoreType(otBorderRouterConfig, NetworkData::OnMeshPrefixConfig);
+DefineCoreType(otExternalRouteConfig, NetworkData::ExternalRouteConfig);
+DefineCoreType(otServiceConfig, NetworkData::ServiceConfig);
+DefineCoreType(otServerConfig, NetworkData::ServiceConfig::ServerConfig);
+
+// MeshCoP
+DefineCoreType(otOperationalDatasetComponents, MeshCoP::Dataset::Components);
+DefineCoreType(otOperationalDataset, MeshCoP::Dataset::Info);
+DefineCoreType(otJoinerPskd, MeshCoP::JoinerPskd);
+DefineCoreType(otJoinerDiscerner, MeshCoP::JoinerDiscerner);
+DefineCoreType(otSteeringData, MeshCoP::SteeringData);
+#if OPENTHREAD_CONFIG_JOINER_ENABLE
+DefineMapEnum(otJoinerState, MeshCoP::Joiner::State);
+#endif
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
+DefineMapEnum(otCommissionerState, MeshCoP::Commissioner::State);
+#endif
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
+DefineMapEnum(otBorderAgentState, MeshCoP::BorderAgent::State);
+#endif
+
+// Coap
+DefineCoreType(otCoapTxParameters, Coap::TxParameters);
+DefineCoreType(otCoapResource, Coap::Resource);
+DefineCoreType(otCoapOption, Coap::Option);
+DefineCoreType(otCoapOptionIterator, Coap::Option::Iterator);
+DefineMapEnum(otCoapType, Coap::Type);
+DefineMapEnum(otCoapCode, Coap::Code);
+#if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
+DefineCoreType(otCoapBlockwiseResource, Coap::ResourceBlockWise);
+#endif
+
+// Dns
+DefineCoreType(otDnsTxtEntry, Dns::TxtEntry);
+DefineCoreType(otDnsTxtEntryIterator, Dns::TxtEntry::Iterator);
+#if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
+DefineCoreType(otDnsQueryConfig, Dns::Client::QueryConfig);
+DefineCoreType(otDnsAddressResponse, Dns::Client::AddressResponse);
+#if OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE
+DefineCoreType(otDnsBrowseResponse, Dns::Client::BrowseResponse);
+DefineCoreType(otDnsServiceResponse, Dns::Client::ServiceResponse);
+DefineCoreType(otDnsServiceInfo, Dns::Client::ServiceInfo);
+#endif
+#endif
+#if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
+DefineMapEnum(otDnssdQueryType, Dns::ServiceDiscovery::Server::DnsQueryType);
+#endif
+
+// Srp
+#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+DefineCoreType(otSrpClientHostInfo, Srp::Client::HostInfo);
+DefineCoreType(otSrpClientService, Srp::Client::Service);
+DefineMapEnum(otSrpClientItemState, Srp::Client::ItemState);
+#endif
+#if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
+DefineCoreType(otSrpServerLeaseConfig, Srp::Server::LeaseConfig);
+DefineCoreType(otSrpServerHost, Srp::Server::Host);
+DefineCoreType(otSrpServerService, Srp::Server::Service);
+DefineMapEnum(otSrpServerState, Srp::Server::State);
+DefineMapEnum(otSrpServerAddressMode, Srp::Server::AddressMode);
+#endif
+
+// Utils
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+DefineCoreType(otHistoryTrackerIterator, Utils::HistoryTracker::Iterator);
+DefineCoreType(otHistoryTrackerNetworkInfo, Utils::HistoryTracker::NetworkInfo);
+DefineCoreType(otHistoryTrackerMessageInfo, Utils::HistoryTracker::MessageInfo);
+DefineCoreType(otHistoryTrackerNeighborInfo, Utils::HistoryTracker::NeighborInfo);
+#endif
+#if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
+DefineCoreType(otPingSenderReply, Utils::PingSender::Reply);
+DefineCoreType(otPingSenderConfig, Utils::PingSender::Config);
+DefineCoreType(otPingSenderStatistics, Utils::PingSender::Statistics);
+#endif
+#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
+DefineCoreType(otSrpClientBuffersServiceEntry, Utils::SrpClientBuffers::ServiceEntry);
+#endif
+
+#endif // #if OPENTHREAD_FTD || OPENTHREAD_MTD
+
+} // namespace ot
+
+#endif // AS_CORE_TYPE_HPP_

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -67,6 +67,14 @@
 #include "net/udp6.hpp"
 #include "thread/network_data_publisher.hpp"
 
+struct otSrpServerHost
+{
+};
+
+struct otSrpServerService
+{
+};
+
 namespace ot {
 
 namespace Dns {
@@ -127,7 +135,7 @@ public:
      * This class implements a server-side SRP service.
      *
      */
-    class Service : public LinkedListEntry<Service>, private NonCopyable
+    class Service : public otSrpServerService, public LinkedListEntry<Service>, private NonCopyable
     {
         friend class Server;
         friend class LinkedList<Service>;
@@ -369,7 +377,7 @@ public:
      * This class implements the Host which registers services on the SRP server.
      *
      */
-    class Host : public LinkedListEntry<Host>, public InstanceLocator, private NonCopyable
+    class Host : public otSrpServerHost, public LinkedListEntry<Host>, public InstanceLocator, private NonCopyable
     {
         friend class LinkedListEntry<Host>;
         friend class Server;


### PR DESCRIPTION
This commit adds header file `common/as_core_type.hpp` which adds many
flavors of helper methods `AsCoreType()` which help convert from a
public C OpenThread type to its corresponding C++ core type (e.g.,
`otIp6Address` to `Ip6::Address`). This commit also adds `MapEnum()`
methods to convert between public and core `enum` definitions (e.g.,
`otMacFilterAddressMode` and `Mac::Filter::Mode`). These helper
methods act as syntactic sugar helping simplify the implementations
of OT API functions (in `api/{module}_api.cpp` files).