### PR TITLE
Remove the check for "secured" enhanced ACK for CSL calculations

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -273,7 +273,7 @@ void SubMac::HandleReceiveDone(RxFrame *aFrame, Error aError)
     if (aFrame != nullptr && aError == kErrorNone)
     {
         // Assuming the risk of the parent missing the Enh-ACK in favor of smaller CSL receive window
-        if ((mCslPeriod > 0) && aFrame->mInfo.mRxInfo.mAckedWithSecEnhAck)
+        if (mCslPeriod > 0)
         {
             mCslLastSync = TimeMicro(static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp));
         }

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -273,7 +273,7 @@ void SubMac::HandleReceiveDone(RxFrame *aFrame, Error aError)
     if (aFrame != nullptr && aError == kErrorNone)
     {
         // Assuming the risk of the parent missing the Enh-ACK in favor of smaller CSL receive window
-        if (mCslPeriod > 0)
+        if ((mCslPeriod > 0) && aFrame->IsVersion2015() && aFrame->GetAckRequest())
         {
             mCslLastSync = TimeMicro(static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp));
         }


### PR DESCRIPTION
When an enhanced ACK is generated, it is secured if the incoming data message is also secured.  (For example, messages such as an unsecured Child Update Response can get an unsecured enhanced ACK.)