### PR TITLE
[mle] send Delayed Data Request with latest Active/Pending Timestamp

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1448,15 +1448,19 @@ protected:
     /**
      * This method adds a message to the message queue. The queued message will be transmitted after given delay.
      *
-     * @param[in]  aMessage      The message to transmit after given delay.
-     * @param[in]  aDestination  The IPv6 address of the recipient of the message.
-     * @param[in]  aDelay        The delay in milliseconds before transmission of the message.
+     * @param[in]  aMessage             The message to transmit after given delay.
+     * @param[in]  aDestination         The IPv6 address of the recipient of the message.
+     * @param[in]  aDelay               The delay in milliseconds before transmission of the message.
+     * @param[in]  aAppendTimestamps    Whether or not to append Active and Pending Timestamps before sending.
      *
      * @retval kErrorNone     Successfully queued the message to transmit after the delay.
      * @retval kErrorNoBufs   Insufficient buffers to queue the message.
      *
      */
-    Error AddDelayedResponse(Message &aMessage, const Ip6::Address &aDestination, uint16_t aDelay);
+    Error AddDelayedResponse(Message &           aMessage,
+                             const Ip6::Address &aDestination,
+                             uint16_t            aDelay,
+                             bool                aAppendTimestamps = false);
 
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_MLE == 1)
     /**
@@ -1655,8 +1659,9 @@ private:
         void  ReadFrom(const Message &aMessage);
         void  RemoveFrom(Message &aMessage) const;
 
-        Ip6::Address mDestination; // IPv6 address of the message destination.
-        TimeMilli    mSendTime;    // Time when the message shall be sent.
+        Ip6::Address mDestination;          // IPv6 address of the message destination.
+        TimeMilli    mSendTime;             // Time when the message shall be sent.
+        bool         mAppendTimestamps : 1; // Append Active Timestamp and Pending Timestamp before sending.
     };
 
     OT_TOOL_PACKED_BEGIN


### PR DESCRIPTION
This commit fixes a potential bug that delayed Data Requests may use wrong Active and Pending Timestamps because the Active & Pending Timestamps may change while a Data Request is being delayed.