### PR TITLE
[csl] fixes on the receiver window duration calculation

### DIFF
--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -584,10 +584,6 @@ private:
     // than expected sample window. The value is in usec.
     static constexpr uint32_t kCslReceiveTimeAhead = OPENTHREAD_CONFIG_CSL_RECEIVE_TIME_AHEAD;
 
-    static constexpr uint8_t kCslWorstCrystalPpm  = 255; // Worst possible crystal accuracy, in units of ± ppm.
-    static constexpr uint8_t kCslWorstUncertainty = 255; // Worst possible scheduling uncertainty, in units of 100 us.
-    static constexpr uint8_t kUsPerUncertUnit     = 100; // Number of microseconds by uncertainty unit.
-
     enum CslState : uint8_t{
         kCslIdle,   // CSL receiver is not started.
         kCslSample, // Sampling CSL channel.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3406,6 +3406,15 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
     SuccessOrExit(error = Tlv::FindTlv(aMessage, connectivity));
     VerifyOrExit(connectivity.IsValid(), error = kErrorParse);
 
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+    // CSL Accuracy
+    if (Tlv::FindTlv(aMessage, clockAccuracy) != kErrorNone)
+    {
+        clockAccuracy.SetCslClockAccuracy(kCslWorstCrystalPpm);
+        clockAccuracy.SetCslUncertainty(kCslWorstUncertainty);
+    }
+#endif
+
     // Share data with application, if requested.
     if (mParentResponseCb)
     {
@@ -3473,14 +3482,6 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
 
         // only consider partitions that are the same or better
         VerifyOrExit(compare >= 0);
-#endif
-
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-        if (Tlv::FindTlv(aMessage, clockAccuracy) != kErrorNone)
-        {
-            clockAccuracy.SetCslClockAccuracy(kCslWorstCrystalPpm);
-            clockAccuracy.SetCslUncertainty(kCslWorstUncertainty);
-        }
 #endif
 
         // only consider better parents if the partitions are the same


### PR DESCRIPTION
A couple of fixes:

- `kUsPerUncertUnit` was declared with two different values.
- `clockAccuracy` values were not properly read from the Parent Response.