### PR TITLE
[crypto] allow zero `aKeyRef` in `SetPskcRef()` or `SetNetworkKeyRef()`

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -152,8 +152,6 @@ otError otThreadSetNetworkKeyRef(otInstance *aInstance, otNetworkKeyRef aKeyRef)
     Error     error    = kErrorNone;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(aKeyRef != 0, error = kErrorInvalidArgs);
-
     VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
     instance.Get<KeyManager>().SetNetworkKeyRef(static_cast<NetworkKeyRef>(aKeyRef));

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -380,7 +380,6 @@ otError otThreadSetPskcRef(otInstance *aInstance, otPskcRef aKeyRef)
     Error     error    = kErrorNone;
     Instance &instance = *static_cast<Instance *>(aInstance);
 
-    VerifyOrExit(aKeyRef != 0, error = kErrorInvalidArgs);
     VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
     instance.Get<KeyManager>().SetPskcRef(aKeyRef);


### PR DESCRIPTION

----

@hemanth-silabs, I think there may be no reason to disallow zero for `aKeyRef`. Do you agree?
I think initially zero value was used to indicate invalid/unassigned key ref but it was later changed to this:
```c++
constexpr KeyRef kInvalidKeyRef = 0x80000000; ///< Invalid `KeyRef` 
```