### PR TITLE
[history-tracker] add unicast/multicast IPv6 address history

### DIFF
--- a/include/openthread/history_tracker.h
+++ b/include/openthread/history_tracker.h
@@ -91,6 +91,44 @@ typedef struct otHistoryTrackerNetworkInfo
 } otHistoryTrackerNetworkInfo;
 
 /**
+ * This enumeration defines the events for an IPv6 (unicast or multicast) address info (i.e., whether address is added
+ * or removed).
+ *
+ */
+typedef enum
+{
+    OT_HISTORY_TRACKER_ADDRESS_EVENT_ADDED   = 0, ///< Address is added.
+    OT_HISTORY_TRACKER_ADDRESS_EVENT_REMOVED = 1, ///< Address is removed.
+} otHistoryTrackerAddressEvent;
+
+/**
+ * This structure represent a unicast IPv6 address info.
+ *
+ */
+typedef struct otHistoryTrackerUnicastAddressInfo
+{
+    otIp6Address                 mAddress;       ///< The unicast IPv6 address.
+    uint8_t                      mPrefixLength;  ///< The Prefix length (in bits).
+    uint8_t                      mAddressOrigin; ///< The address origin (`OT_ADDRESS_ORIGIN_*` constants).
+    otHistoryTrackerAddressEvent mEvent;         ///< Indicates the event (address is added/removed).
+    uint8_t                      mScope : 4;     ///< The IPv6 scope.
+    bool                         mPreferred : 1; ///< If the address is preferred.
+    bool                         mValid : 1;     ///< If the address is valid.
+    bool                         mRloc : 1;      ///< If the address is an RLOC.
+} otHistoryTrackerUnicastAddressInfo;
+
+/**
+ * This structure represent an IPv6 multicast address info.
+ *
+ */
+typedef struct otHistoryTrackerMulticastAddressInfo
+{
+    otIp6Address                 mAddress;       ///< The IPv6 multicast address.
+    uint8_t                      mAddressOrigin; ///< The address origin (`OT_ADDRESS_ORIGIN_*` constants).
+    otHistoryTrackerAddressEvent mEvent;         ///< Indicates the event (address is added/removed).
+} otHistoryTrackerMulticastAddressInfo;
+
+/**
  * Constants representing message priority used in `otHistoryTrackerMessageInfo` struct.
  *
  */
@@ -190,6 +228,42 @@ void otHistoryTrackerInitIterator(otHistoryTrackerIterator *aIterator);
 const otHistoryTrackerNetworkInfo *otHistoryTrackerIterateNetInfoHistory(otInstance *              aInstance,
                                                                          otHistoryTrackerIterator *aIterator,
                                                                          uint32_t *                aEntryAge);
+
+/**
+ * This function iterates over the entries in the unicast address history list.
+ *
+ * @param[in]    aInstance   A pointer to the OpenThread instance.
+ * @param[inout] aIterator   A pointer to an iterator. MUST be initialized or the behavior is undefined.
+ * @param[out]   aEntryAge   A pointer to a variable to output the entry's age. MUST NOT be NULL.
+ *                           Age is provided as the duration (in milliseconds) from when entry was recorded to
+ *                           @p aIterator initialization time. It is set to `OT_HISTORY_TRACKER_MAX_AGE` for entries
+ *                           older than max age.
+ *
+ * @returns A pointer to `otHistoryTrackerUnicastAddressInfo` entry or `NULL` if no more entries in the list.
+ *
+ */
+const otHistoryTrackerUnicastAddressInfo *otHistoryTrackerIterateUnicastAddressHistory(
+    otInstance *              aInstance,
+    otHistoryTrackerIterator *aIterator,
+    uint32_t *                aEntryAge);
+
+/**
+ * This function iterates over the entries in the multicast address history list.
+ *
+ * @param[in]    aInstance   A pointer to the OpenThread instance.
+ * @param[inout] aIterator   A pointer to an iterator. MUST be initialized or the behavior is undefined.
+ * @param[out]   aEntryAge   A pointer to a variable to output the entry's age. MUST NOT be NULL.
+ *                           Age is provided as the duration (in milliseconds) from when entry was recorded to
+ *                           @p aIterator initialization time. It is set to `OT_HISTORY_TRACKER_MAX_AGE` for entries
+ *                           older than max age.
+ *
+ * @returns A pointer to `otHistoryTrackerMulticastAddressInfo` entry or `NULL` if no more entries in the list.
+ *
+ */
+const otHistoryTrackerMulticastAddressInfo *otHistoryTrackerIterateMulticastAddressHistory(
+    otInstance *              aInstance,
+    otHistoryTrackerIterator *aIterator,
+    uint32_t *                aEntryAge);
 
 /**
  * This function iterates over the entries in the RX message history list.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (165)
+#define OPENTHREAD_API_VERSION (166)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README_HISTORY.md
+++ b/src/cli/README_HISTORY.md
@@ -11,6 +11,8 @@ The number of entries recorded for each history list is configurable through a s
 Usage : `history [command] ...`
 
 - [help](#help)
+- [ipaddr](#ipaddr)
+- [ipmaddr](#ipmaddr)
 - [neighbor](#neighbor)
 - [netinfo](#netinfo)
 - [rx](#rx)
@@ -46,6 +48,8 @@ Print SRP client help menu.
 ```bash
 > history help
 help
+ipaddr
+ipmaddr
 neighbor
 netinfo
 rx
@@ -53,6 +57,92 @@ rxtx
 tx
 Done
 >
+```
+
+### ipaddr
+
+Usage `history ipaddr [list] [<num-entries>]`
+
+Print the unicast IPv6 address history. Each entry provides:
+
+- Event: Added or Removed.
+- Address: Unicast address along with its prefix length (in bits).
+- Origin: Thread, SLAAC, DHCPv6, or Manual.
+- Address Scope.
+- Flags: Preferred, Valid, and RLOC (whether the address is RLOC).
+
+Print the unicast IPv6 address history as table.
+
+```bash
+> history ipaddr
+| Age                  | Event   | Address / PrefixLength                      | Origin |Scope| P | V | R |
++----------------------+---------+---------------------------------------------+--------+-----+---+---+---+
+|         00:00:04.991 | Removed | 2001:dead:beef:cafe:c4cb:caba:8d55:e30b/64  | SLAAC  |  14 | Y | Y | N |
+|         00:00:44.647 | Added   | 2001:dead:beef:cafe:c4cb:caba:8d55:e30b/64  | SLAAC  |  14 | Y | Y | N |
+|         00:01:07.199 | Added   | fd00:0:0:0:0:0:0:1/64                       | Manual |  14 | Y | Y | N |
+|         00:02:17.885 | Added   | fdde:ad00:beef:0:0:ff:fe00:fc00/64          | Thread |   3 | N | Y | N |
+|         00:02:17.885 | Added   | fdde:ad00:beef:0:0:ff:fe00:5400/64          | Thread |   3 | N | Y | Y |
+|         00:02:20.107 | Removed | fdde:ad00:beef:0:0:ff:fe00:5400/64          | Thread |   3 | N | Y | Y |
+|         00:02:21.575 | Added   | fdde:ad00:beef:0:0:ff:fe00:5400/64          | Thread |   3 | N | Y | Y |
+|         00:02:21.575 | Added   | fdde:ad00:beef:0:ecea:c4fc:ad96:4655/64     | Thread |   3 | N | Y | N |
+|         00:02:23.904 | Added   | fe80:0:0:0:3c12:a4d2:fbe0:31ad/64           | Thread |   2 | Y | Y | N |
+Done
+```
+
+Print the unicast IPv6 address history as a list (the last 5 entries).
+
+```bash
+> history ipaddr list 5
+00:00:20.327 -> event:Removed address:2001:dead:beef:cafe:c4cb:caba:8d55:e30b prefixlen:64 origin:SLAAC scope:14 preferred:yes valid:yes rloc:no
+00:00:59.983 -> event:Added address:2001:dead:beef:cafe:c4cb:caba:8d55:e30b prefixlen:64 origin:SLAAC scope:14 preferred:yes valid:yes rloc:no
+00:01:22.535 -> event:Added address:fd00:0:0:0:0:0:0:1 prefixlen:64 origin:Manual scope:14 preferred:yes valid:yes rloc:no
+00:02:33.221 -> event:Added address:fdde:ad00:beef:0:0:ff:fe00:fc00 prefixlen:64 origin:Thread scope:3 preferred:no valid:yes rloc:no
+00:02:33.221 -> event:Added address:fdde:ad00:beef:0:0:ff:fe00:5400 prefixlen:64 origin:Thread scope:3 preferred:no valid:yes rloc:yes
+Done
+```
+
+### ipmaddr
+
+Usage `history ipmaddr [list] [<num-entries>]`
+
+Print the multicast IPv6 address history. Each entry provides:
+
+- Event: Subscribed or Unsubscribed.
+- Address: Multicast address.
+- Origin: Thread, or Manual.
+
+Print the multicast IPv6 address history as table.
+
+```bash
+> history ipmaddr
+| Age                  | Event        | Multicast Address                       | Origin |
++----------------------+--------------+-----------------------------------------+--------+
+|         00:00:08.592 | Unsubscribed | ff05:0:0:0:0:0:0:1                      | Manual |
+|         00:01:25.353 | Subscribed   | ff05:0:0:0:0:0:0:1                      | Manual |
+|         00:01:54.953 | Subscribed   | ff03:0:0:0:0:0:0:2                      | Thread |
+|         00:01:54.953 | Subscribed   | ff02:0:0:0:0:0:0:2                      | Thread |
+|         00:01:59.329 | Subscribed   | ff33:40:fdde:ad00:beef:0:0:1            | Thread |
+|         00:01:59.329 | Subscribed   | ff32:40:fdde:ad00:beef:0:0:1            | Thread |
+|         00:02:01.129 | Subscribed   | ff03:0:0:0:0:0:0:fc                     | Thread |
+|         00:02:01.129 | Subscribed   | ff03:0:0:0:0:0:0:1                      | Thread |
+|         00:02:01.129 | Subscribed   | ff02:0:0:0:0:0:0:1                      | Thread |
+Done
+```
+
+Print the multicast IPv6 address history as a list.
+
+```bash
+> history ipmaddr list
+00:00:25.447 -> event:Unsubscribed address:ff05:0:0:0:0:0:0:1 origin:Manual
+00:01:42.208 -> event:Subscribed address:ff05:0:0:0:0:0:0:1 origin:Manual
+00:02:11.808 -> event:Subscribed address:ff03:0:0:0:0:0:0:2 origin:Thread
+00:02:11.808 -> event:Subscribed address:ff02:0:0:0:0:0:0:2 origin:Thread
+00:02:16.184 -> event:Subscribed address:ff33:40:fdde:ad00:beef:0:0:1 origin:Thread
+00:02:16.184 -> event:Subscribed address:ff32:40:fdde:ad00:beef:0:0:1 origin:Thread
+00:02:17.984 -> event:Subscribed address:ff03:0:0:0:0:0:0:fc origin:Thread
+00:02:17.984 -> event:Subscribed address:ff03:0:0:0:0:0:0:1 origin:Thread
+00:02:17.984 -> event:Subscribed address:ff02:0:0:0:0:0:0:1 origin:Thread
+Done
 ```
 
 ### neighbor

--- a/src/cli/cli_history.hpp
+++ b/src/cli/cli_history.hpp
@@ -96,6 +96,8 @@ private:
     };
 
     otError ProcessHelp(Arg aArgs[]);
+    otError ProcessIpAddr(Arg aArgs[]);
+    otError ProcessIpMulticastAddr(Arg aArgs[]);
     otError ProcessNetInfo(Arg aArgs[]);
     otError ProcessNeighbor(Arg aArgs[]);
     otError ProcessRx(Arg aArgs[]);
@@ -107,13 +109,20 @@ private:
     void    OutputRxTxEntryListFormat(const otHistoryTrackerMessageInfo &aInfo, uint32_t aEntryAge, bool aIsRx);
     void    OutputRxTxEntryTableFormat(const otHistoryTrackerMessageInfo &aInfo, uint32_t aEntryAge, bool aIsRx);
 
+    static const char *AddressOriginToString(uint8_t aOrigin);
     static const char *MessagePriorityToString(uint8_t aPriority);
     static const char *RadioTypeToString(const otHistoryTrackerMessageInfo &aInfo);
     static const char *MessageTypeToString(const otHistoryTrackerMessageInfo &aInfo);
 
     static constexpr Command sCommands[] = {
-        {"help", &History::ProcessHelp}, {"neighbor", &History::ProcessNeighbor}, {"netinfo", &History::ProcessNetInfo},
-        {"rx", &History::ProcessRx},     {"rxtx", &History::ProcessRxTx},         {"tx", &History::ProcessTx},
+        {"help", &History::ProcessHelp},
+        {"ipaddr", &History::ProcessIpAddr},
+        {"ipmaddr", &History::ProcessIpMulticastAddr},
+        {"neighbor", &History::ProcessNeighbor},
+        {"netinfo", &History::ProcessNetInfo},
+        {"rx", &History::ProcessRx},
+        {"rxtx", &History::ProcessRxTx},
+        {"tx", &History::ProcessTx},
     };
 
     static_assert(Utils::LookupTable::IsSorted(sCommands), "Command Table is not sorted");

--- a/src/core/api/history_tracker_api.cpp
+++ b/src/core/api/history_tracker_api.cpp
@@ -55,6 +55,24 @@ const otHistoryTrackerNetworkInfo *otHistoryTrackerIterateNetInfoHistory(otInsta
     return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateNetInfoHistory(AsCoreType(aIterator), *aEntryAge);
 }
 
+const otHistoryTrackerUnicastAddressInfo *otHistoryTrackerIterateUnicastAddressHistory(
+    otInstance *              aInstance,
+    otHistoryTrackerIterator *aIterator,
+    uint32_t *                aEntryAge)
+{
+    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateUnicastAddressHistory(AsCoreType(aIterator),
+                                                                                           *aEntryAge);
+}
+
+const otHistoryTrackerMulticastAddressInfo *otHistoryTrackerIterateMulticastAddressHistory(
+    otInstance *              aInstance,
+    otHistoryTrackerIterator *aIterator,
+    uint32_t *                aEntryAge)
+{
+    return AsCoreType(aInstance).Get<Utils::HistoryTracker>().IterateMulticastAddressHistory(AsCoreType(aIterator),
+                                                                                             *aEntryAge);
+}
+
 const otHistoryTrackerMessageInfo *otHistoryTrackerIterateRxHistory(otInstance *              aInstance,
                                                                     otHistoryTrackerIterator *aIterator,
                                                                     uint32_t *                aEntryAge)

--- a/src/core/config/history_tracker.h
+++ b/src/core/config/history_tracker.h
@@ -58,6 +58,30 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_HISTORY_TRACKER_UNICAST_ADDRESS_LIST_SIZE
+ *
+ * Specifies the maximum number of entries in unicast IPv6 address history list.
+ *
+ * Can be set to zero to configure History Tracker module not to collect any entries.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_HISTORY_TRACKER_UNICAST_ADDRESS_LIST_SIZE
+#define OPENTHREAD_CONFIG_HISTORY_TRACKER_UNICAST_ADDRESS_LIST_SIZE 20
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_HISTORY_TRACKER_MULTICAST_ADDRESS_LIST_SIZE
+ *
+ * Specifies the maximum number of entries in multicast IPv6 address history list.
+ *
+ * Can be set to zero to configure History Tracker module not to collect any entries.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_HISTORY_TRACKER_MULTICAST_ADDRESS_LIST_SIZE
+#define OPENTHREAD_CONFIG_HISTORY_TRACKER_MULTICAST_ADDRESS_LIST_SIZE 20
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_HISTORY_TRACKER_RX_LIST_SIZE
  *
  * Specifies the maximum number of entries in RX history list.

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -578,7 +578,7 @@ Error Client::ProcessIaAddress(Message &aMessage, uint16_t aOffset)
             idAssociation.mNetifAddress.mAddress       = option.GetAddress();
             idAssociation.mPreferredLifetime           = option.GetPreferredLifetime();
             idAssociation.mValidLifetime               = option.GetValidLifetime();
-            idAssociation.mNetifAddress.mAddressOrigin = OT_ADDRESS_ORIGIN_DHCPV6;
+            idAssociation.mNetifAddress.mAddressOrigin = Ip6::Netif::kOriginDhcp6;
             idAssociation.mNetifAddress.mPreferred     = option.GetPreferredLifetime() != 0;
             idAssociation.mNetifAddress.mValid         = option.GetValidLifetime() != 0;
             idAssociation.mStatus                      = kIaStatusSolicitReplied;

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -145,14 +145,22 @@ void Netif::SubscribeAllNodesMulticast(void)
 
     Get<Notifier>().Signal(kEventIp6MulticastSubscribed);
 
+#if !OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
     VerifyOrExit(mAddressCallback != nullptr);
+#endif
 
     for (const MulticastAddress *entry = &linkLocalAllNodesAddress; entry; entry = entry->GetNext())
     {
-        AddressInfo addressInfo(*entry);
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+        Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressAdded, *entry, kOriginThread);
 
-        mAddressCallback(&addressInfo,
-                         /* IsAdded */ true, mAddressCallbackContext);
+        if (mAddressCallback != nullptr)
+#endif
+        {
+            AddressInfo addressInfo(*entry);
+
+            mAddressCallback(&addressInfo, kAddressAdded, mAddressCallbackContext);
+        }
     }
 
 exit:
@@ -194,14 +202,22 @@ void Netif::UnsubscribeAllNodesMulticast(void)
 
     Get<Notifier>().Signal(kEventIp6MulticastUnsubscribed);
 
+#if !OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
     VerifyOrExit(mAddressCallback != nullptr);
+#endif
 
     for (const MulticastAddress *entry = &linkLocalAllNodesAddress; entry; entry = entry->GetNext())
     {
-        AddressInfo addressInfo(*entry);
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+        Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressRemoved, *entry, kOriginThread);
 
-        mAddressCallback(&addressInfo,
-                         /* IsAdded */ false, mAddressCallbackContext);
+        if (mAddressCallback != nullptr)
+#endif
+        {
+            AddressInfo addressInfo(*entry);
+
+            mAddressCallback(&addressInfo, kAddressRemoved, mAddressCallbackContext);
+        }
     }
 
 exit:
@@ -254,15 +270,23 @@ void Netif::SubscribeAllRoutersMulticast(void)
 
     Get<Notifier>().Signal(kEventIp6MulticastSubscribed);
 
+#if !OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
     VerifyOrExit(mAddressCallback != nullptr);
+#endif
 
     for (const MulticastAddress *entry = &linkLocalAllRoutersAddress; entry != &linkLocalAllNodesAddress;
          entry                         = entry->GetNext())
     {
-        AddressInfo addressInfo(*entry);
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+        Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressAdded, *entry, kOriginThread);
 
-        mAddressCallback(&addressInfo,
-                         /* IsAdded */ true, mAddressCallbackContext);
+        if (mAddressCallback != nullptr)
+#endif
+        {
+            AddressInfo addressInfo(*entry);
+
+            mAddressCallback(&addressInfo, kAddressAdded, mAddressCallbackContext);
+        }
     }
 
 exit:
@@ -300,15 +324,23 @@ void Netif::UnsubscribeAllRoutersMulticast(void)
 
     Get<Notifier>().Signal(kEventIp6MulticastUnsubscribed);
 
+#if !OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
     VerifyOrExit(mAddressCallback != nullptr);
+#endif
 
     for (const MulticastAddress *entry = &linkLocalAllRoutersAddress; entry != &linkLocalAllNodesAddress;
          entry                         = entry->GetNext())
     {
-        AddressInfo addressInfo(*entry);
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+        Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressRemoved, *entry, kOriginThread);
 
-        mAddressCallback(&addressInfo,
-                         /* IsAdded */ false, mAddressCallbackContext);
+        if (mAddressCallback != nullptr)
+#endif
+        {
+            AddressInfo addressInfo(*entry);
+
+            mAddressCallback(&addressInfo, kAddressRemoved, mAddressCallbackContext);
+        }
     }
 
 exit:
@@ -326,13 +358,15 @@ void Netif::SubscribeMulticast(MulticastAddress &aAddress)
 
     Get<Notifier>().Signal(kEventIp6MulticastSubscribed);
 
-    VerifyOrExit(mAddressCallback != nullptr);
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressAdded, aAddress, kOriginThread);
+#endif
 
+    if (mAddressCallback != nullptr)
     {
         AddressInfo addressInfo(aAddress);
 
-        mAddressCallback(&addressInfo,
-                         /* IsAdded */ true, mAddressCallbackContext);
+        mAddressCallback(&addressInfo, kAddressAdded, mAddressCallbackContext);
     }
 
 exit:
@@ -345,12 +379,15 @@ void Netif::UnsubscribeMulticast(const MulticastAddress &aAddress)
 
     Get<Notifier>().Signal(kEventIp6MulticastUnsubscribed);
 
-    VerifyOrExit(mAddressCallback != nullptr);
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressRemoved, aAddress, kOriginThread);
+#endif
+
+    if (mAddressCallback != nullptr)
     {
         AddressInfo addressInfo(aAddress);
 
-        mAddressCallback(&addressInfo,
-                         /* IsAdded */ false, mAddressCallbackContext);
+        mAddressCallback(&addressInfo, kAddressRemoved, mAddressCallbackContext);
     }
 
 exit:
@@ -384,6 +421,11 @@ Error Netif::SubscribeExternalMulticast(const Address &aAddress)
     entry->mMlrState = kMlrStateToRegister;
 #endif
     mMulticastAddresses.Push(*entry);
+
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressAdded, *entry, kOriginManual);
+#endif
+
     Get<Notifier>().Signal(kEventIp6MulticastSubscribed);
 
 exit:
@@ -402,6 +444,10 @@ Error Netif::UnsubscribeExternalMulticast(const Address &aAddress)
     VerifyOrExit(IsMulticastAddressExternal(*entry), error = kErrorInvalidArgs);
 
     mMulticastAddresses.PopAfter(prev);
+
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressRemoved, *entry, kOriginManual);
+#endif
 
     mExtMulticastAddressPool.Free(static_cast<ExternalMulticastAddress &>(*entry));
 
@@ -438,13 +484,15 @@ void Netif::AddUnicastAddress(UnicastAddress &aAddress)
 
     Get<Notifier>().Signal(aAddress.mRloc ? kEventThreadRlocAdded : kEventIp6AddressAdded);
 
-    VerifyOrExit(mAddressCallback != nullptr);
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressAdded, aAddress);
+#endif
 
+    if (mAddressCallback != nullptr)
     {
         AddressInfo addressInfo(aAddress);
 
-        mAddressCallback(&addressInfo,
-                         /* IsAdded */ true, mAddressCallbackContext);
+        mAddressCallback(&addressInfo, kAddressAdded, mAddressCallbackContext);
     }
 
 exit:
@@ -457,11 +505,15 @@ void Netif::RemoveUnicastAddress(const UnicastAddress &aAddress)
 
     Get<Notifier>().Signal(aAddress.mRloc ? kEventThreadRlocRemoved : kEventIp6AddressRemoved);
 
-    VerifyOrExit(mAddressCallback != nullptr);
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressRemoved, aAddress);
+#endif
+
+    if (mAddressCallback != nullptr)
     {
         AddressInfo addressInfo(aAddress);
 
-        mAddressCallback(&addressInfo, /* IsAdded */ false, mAddressCallbackContext);
+        mAddressCallback(&addressInfo, kAddressRemoved, mAddressCallbackContext);
     }
 
 exit:
@@ -495,6 +547,11 @@ Error Netif::AddExternalUnicastAddress(const UnicastAddress &aAddress)
 
     *entry = aAddress;
     mUnicastAddresses.Push(*entry);
+
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressAdded, *entry);
+#endif
+
     Get<Notifier>().Signal(kEventIp6AddressAdded);
 
 exit:
@@ -513,6 +570,11 @@ Error Netif::RemoveExternalUnicastAddress(const Address &aAddress)
     VerifyOrExit(IsUnicastAddressExternal(*entry), error = kErrorInvalidArgs);
 
     mUnicastAddresses.PopAfter(prev);
+
+#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+    Get<Utils::HistoryTracker>().RecordAddressEvent(kAddressRemoved, *entry);
+#endif
+
     mExtUnicastAddressPool.Free(*entry);
     Get<Notifier>().Signal(kEventIp6AddressRemoved);
 
@@ -552,7 +614,7 @@ void Netif::UnicastAddress::InitAsThreadOrigin(bool aPreferred)
 {
     Clear();
     mPrefixLength  = NetworkPrefix::kLength;
-    mAddressOrigin = OT_ADDRESS_ORIGIN_THREAD;
+    mAddressOrigin = kOriginThread;
     mPreferred     = aPreferred;
     mValid         = true;
 }
@@ -566,7 +628,7 @@ void Netif::UnicastAddress::InitAsThreadOriginRealmLocalScope(void)
 void Netif::UnicastAddress::InitAsThreadOriginGlobalScope(void)
 {
     Clear();
-    mAddressOrigin = OT_ADDRESS_ORIGIN_THREAD;
+    mAddressOrigin = kOriginThread;
     mValid         = true;
     SetScopeOverride(Address::kGlobalScope);
 }
@@ -575,7 +637,7 @@ void Netif::UnicastAddress::InitAsSlaacOrigin(uint8_t aPrefixLength, bool aPrefe
 {
     Clear();
     mPrefixLength  = aPrefixLength;
-    mAddressOrigin = OT_ADDRESS_ORIGIN_SLAAC;
+    mAddressOrigin = kOriginSlaac;
     mPreferred     = aPreferred;
     mValid         = true;
 }

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -76,6 +76,30 @@ class Netif : public InstanceLocator, private NonCopyable
 
 public:
     /**
+     * This enumeration represent an address event (added or removed)
+     *
+     * The boolean values are used for `aIsAdded` parameter in the call of `otIp6AddressCallback`.
+     *
+     */
+    enum AddressEvent : bool
+    {
+        kAddressRemoved = false, ///< Indicates that address was added.
+        kAddressAdded   = true,  ///< Indicates that address was removed.
+    };
+
+    /**
+     * This enumeration represents the address origin.
+     *
+     */
+    enum AddressOrigin : uint8_t
+    {
+        kOriginThread = OT_ADDRESS_ORIGIN_THREAD, ///< Thread assigned address (ALOC, RLOC, MLEID, etc)
+        kOriginSlaac  = OT_ADDRESS_ORIGIN_SLAAC,  ///< SLAAC assigned address
+        kOriginDhcp6  = OT_ADDRESS_ORIGIN_DHCPV6, ///< DHCPv6 assigned address
+        kOriginManual = OT_ADDRESS_ORIGIN_MANUAL, ///< Manually assigned address
+    };
+
+    /**
      * This class implements an IPv6 network interface unicast address.
      *
      */
@@ -180,6 +204,14 @@ public:
             mScopeOverride      = aScope;
             mScopeOverrideValid = true;
         }
+
+        /**
+         * This method gets the IPv6 address origin.
+         *
+         * @returns The address origin.
+         *
+         */
+        AddressOrigin GetOrigin(void) const { return static_cast<AddressOrigin>(mAddressOrigin); }
 
     private:
         bool Matches(const Address &aAddress) const { return GetAddress() == aAddress; }

--- a/src/core/utils/history_tracker.cpp
+++ b/src/core/utils/history_tracker.cpp
@@ -254,6 +254,42 @@ exit:
     return;
 }
 
+void HistoryTracker::RecordAddressEvent(Ip6::Netif::AddressEvent          aEvent,
+                                        const Ip6::Netif::UnicastAddress &aUnicastAddress)
+{
+    UnicastAddressInfo *entry = mUnicastAddressHistory.AddNewEntry();
+
+    VerifyOrExit(entry != nullptr);
+
+    entry->mAddress       = aUnicastAddress.GetAddress();
+    entry->mPrefixLength  = aUnicastAddress.GetPrefixLength();
+    entry->mAddressOrigin = aUnicastAddress.GetOrigin();
+    entry->mEvent         = (aEvent == Ip6::Netif::kAddressAdded) ? kAddressAdded : kAddressRemoved;
+    entry->mScope         = (aUnicastAddress.GetScope() & 0xf);
+    entry->mPreferred     = aUnicastAddress.mPreferred;
+    entry->mValid         = aUnicastAddress.mValid;
+    entry->mRloc          = aUnicastAddress.mRloc;
+
+exit:
+    return;
+}
+
+void HistoryTracker::RecordAddressEvent(Ip6::Netif::AddressEvent            aEvent,
+                                        const Ip6::Netif::MulticastAddress &aMulticastAddress,
+                                        Ip6::Netif::AddressOrigin           aAddressOrigin)
+{
+    MulticastAddressInfo *entry = mMulticastAddressHistory.AddNewEntry();
+
+    VerifyOrExit(entry != nullptr);
+
+    entry->mAddress       = aMulticastAddress.GetAddress();
+    entry->mAddressOrigin = aAddressOrigin;
+    entry->mEvent         = (aEvent == Ip6::Netif::kAddressAdded) ? kAddressAdded : kAddressRemoved;
+
+exit:
+    return;
+}
+
 void HistoryTracker::HandleNotifierEvents(Events aEvents)
 {
     if (aEvents.ContainsAny(kEventThreadRoleChanged | kEventThreadRlocAdded | kEventThreadRlocRemoved |
@@ -271,6 +307,8 @@ void HistoryTracker::HandleTimer(Timer &aTimer)
 void HistoryTracker::HandleTimer(void)
 {
     mNetInfoHistory.UpdateAgedEntries();
+    mUnicastAddressHistory.UpdateAgedEntries();
+    mMulticastAddressHistory.UpdateAgedEntries();
     mRxHistory.UpdateAgedEntries();
     mTxHistory.UpdateAgedEntries();
     mNeighborHistory.UpdateAgedEntries();


### PR DESCRIPTION
This commit adds support in `HistoryTracker` to record the history of
changes to the Thread interface's unicast and multicast IPv6 addresses.
An entry is recorded when an address is added or removed. For unicast
addresses, each entry provides:

- Timestamp
- Event: Added or Removed
- Address : Unicast address along with its prefix length (in bits).
- Origin: Thread, SLAAC, DHCPv6, or Manual.
- Address Scope.
- Flags: Preferred, Valid, and RLOC (whether the address is RLOC).

For multicast address history, each entry provides:

- Timestamp
- Event: Subscribed or Unsubscribed.
- Address : Multicast address.
- Origin: Thread or Manual.

This commit also updates CLI and adds `history ipaddr` and
`history ipmaddr` commands to get the lists. It also updates the
documentation in `README_HISTORY.md`.