### PR TITLE
[netdata] enhance and simplify `NetworkData` class

### DIFF
--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -68,9 +68,7 @@ otError otBorderRoutingGetOnLinkPrefix(otInstance *aInstance, otIp6Prefix *aPref
 
 otError otBorderRouterGetNetData(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)
 {
-    OT_ASSERT(aData != nullptr && aDataLength != nullptr);
-
-    return AsCoreType(aInstance).Get<NetworkData::Local>().GetNetworkData(aStable, aData, *aDataLength);
+    return AsCoreType(aInstance).Get<NetworkData::Local>().CopyNetworkData(aStable, aData, *aDataLength);
 }
 
 otError otBorderRouterAddOnMeshPrefix(otInstance *aInstance, const otBorderRouterConfig *aConfig)

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -42,9 +42,7 @@ using namespace ot;
 
 otError otNetDataGet(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)
 {
-    OT_ASSERT(aData != nullptr && aDataLength != nullptr);
-
-    return AsCoreType(aInstance).Get<NetworkData::Leader>().GetNetworkData(aStable, aData, *aDataLength);
+    return AsCoreType(aInstance).Get<NetworkData::Leader>().CopyNetworkData(aStable, aData, *aDataLength);
 }
 
 otError otNetDataGetNextOnMeshPrefix(otInstance *           aInstance,

--- a/src/core/api/server_api.cpp
+++ b/src/core/api/server_api.cpp
@@ -44,9 +44,7 @@ using namespace ot;
 
 otError otServerGetNetDataLocal(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)
 {
-    OT_ASSERT(aData != nullptr && aDataLength != nullptr);
-
-    return AsCoreType(aInstance).Get<NetworkData::Local>().GetNetworkData(aStable, aData, *aDataLength);
+    return AsCoreType(aInstance).Get<NetworkData::Local>().CopyNetworkData(aStable, aData, *aDataLength);
 }
 
 otError otServerAddService(otInstance *aInstance, const otServiceConfig *aConfig)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1199,7 +1199,7 @@ Error Mle::AppendNetworkData(Message &aMessage, bool aStableOnly)
     VerifyOrExit(!mRetrieveNewNetworkData, error = kErrorInvalidState);
 
     length = sizeof(networkData);
-    IgnoreError(Get<NetworkData::Leader>().GetNetworkData(aStableOnly, networkData, length));
+    IgnoreError(Get<NetworkData::Leader>().CopyNetworkData(aStableOnly, networkData, length));
 
     error = Tlv::Append<NetworkDataTlv>(aMessage, networkData, length);
 

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -47,19 +47,30 @@
 namespace ot {
 namespace NetworkData {
 
-Error NetworkData::GetNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength) const
+Error NetworkData::CopyNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength) const
+{
+    Error              error;
+    MutableNetworkData netDataCopy(GetInstance(), aData, 0, aDataLength);
+
+    SuccessOrExit(error = CopyNetworkData(aStable, netDataCopy));
+    aDataLength = netDataCopy.GetLength();
+
+exit:
+    return error;
+}
+
+Error NetworkData::CopyNetworkData(bool aStable, MutableNetworkData &aNetworkData) const
 {
     Error error = kErrorNone;
 
-    OT_ASSERT(aData != nullptr);
-    VerifyOrExit(aDataLength >= mLength, error = kErrorNoBufs);
+    VerifyOrExit(aNetworkData.GetSize() >= mLength, error = kErrorNoBufs);
 
-    memcpy(aData, mTlvs, mLength);
-    aDataLength = mLength;
+    memcpy(aNetworkData.GetBytes(), mTlvs, mLength);
+    aNetworkData.SetLength(mLength);
 
     if (aStable)
     {
-        RemoveTemporaryData(aData, aDataLength);
+        aNetworkData.RemoveTemporaryData();
     }
 
 exit:
@@ -381,11 +392,11 @@ exit:
     return rval;
 }
 
-void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength)
+void MutableNetworkData::RemoveTemporaryData(void)
 {
-    NetworkDataTlv *cur = reinterpret_cast<NetworkDataTlv *>(aData);
+    NetworkDataTlv *cur = GetTlvsStart();
 
-    while (cur < reinterpret_cast<NetworkDataTlv *>(aData + aDataLength))
+    while (cur < GetTlvsEnd())
     {
         switch (cur->GetType())
         {
@@ -393,30 +404,28 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength)
         {
             PrefixTlv *prefix = static_cast<PrefixTlv *>(cur);
 
-            RemoveTemporaryData(aData, aDataLength, *prefix);
+            RemoveTemporaryDataIn(*prefix);
 
             if (prefix->GetSubTlvsLength() == 0)
             {
-                RemoveTlv(aData, aDataLength, cur);
+                RemoveTlv(cur);
                 continue;
             }
 
-            otDumpDebgNetData("remove prefix done", aData, aDataLength);
             break;
         }
 
         case NetworkDataTlv::kTypeService:
         {
             ServiceTlv *service = static_cast<ServiceTlv *>(cur);
-            RemoveTemporaryData(aData, aDataLength, *service);
+            RemoveTemporaryDataIn(*service);
 
             if (service->GetSubTlvsLength() == 0)
             {
-                RemoveTlv(aData, aDataLength, cur);
+                RemoveTlv(cur);
                 continue;
             }
 
-            otDumpDebgNetData("remove service done", aData, aDataLength);
             break;
         }
 
@@ -424,7 +433,7 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength)
             // remove temporary tlv
             if (!cur->IsStable())
             {
-                RemoveTlv(aData, aDataLength, cur);
+                RemoveTlv(cur);
                 continue;
             }
 
@@ -433,11 +442,9 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength)
 
         cur = cur->GetNext();
     }
-
-    otDumpDebgNetData("remove done", aData, aDataLength);
 }
 
-void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, PrefixTlv &aPrefix)
+void MutableNetworkData::RemoveTemporaryDataIn(PrefixTlv &aPrefix)
 {
     NetworkDataTlv *cur = aPrefix.GetSubTlvs();
 
@@ -494,13 +501,13 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Pref
         {
             // remove temporary tlv
             uint8_t subTlvSize = cur->GetSize();
-            RemoveTlv(aData, aDataLength, cur);
+            RemoveTlv(cur);
             aPrefix.SetSubTlvsLength(aPrefix.GetSubTlvsLength() - subTlvSize);
         }
     }
 }
 
-void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, ServiceTlv &aService)
+void MutableNetworkData::RemoveTemporaryDataIn(ServiceTlv &aService)
 {
     NetworkDataTlv *cur = aService.GetSubTlvs();
 
@@ -528,7 +535,7 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Serv
         {
             // remove temporary tlv
             uint8_t subTlvSize = cur->GetSize();
-            RemoveTlv(aData, aDataLength, cur);
+            RemoveTlv(cur);
             aService.SetSubTlvsLength(aService.GetSubTlvsLength() - subTlvSize);
         }
     }
@@ -536,15 +543,7 @@ void NetworkData::RemoveTemporaryData(uint8_t *aData, uint8_t &aDataLength, Serv
 
 const PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength) const
 {
-    return FindPrefix(aPrefix, aPrefixLength, mTlvs, mLength);
-}
-
-const PrefixTlv *NetworkData::FindPrefix(const uint8_t *aPrefix,
-                                         uint8_t        aPrefixLength,
-                                         const uint8_t *aTlvs,
-                                         uint8_t        aTlvsLength)
-{
-    TlvIterator      tlvIterator(aTlvs, aTlvsLength);
+    TlvIterator      tlvIterator(mTlvs, mLength);
     const PrefixTlv *prefixTlv;
 
     while ((prefixTlv = tlvIterator.Iterate<PrefixTlv>()) != nullptr)
@@ -562,16 +561,7 @@ const ServiceTlv *NetworkData::FindService(uint32_t           aEnterpriseNumber,
                                            const ServiceData &aServiceData,
                                            ServiceMatchMode   aServiceMatchMode) const
 {
-    return FindService(aEnterpriseNumber, aServiceData, aServiceMatchMode, mTlvs, mLength);
-}
-
-const ServiceTlv *NetworkData::FindService(uint32_t           aEnterpriseNumber,
-                                           const ServiceData &aServiceData,
-                                           ServiceMatchMode   aServiceMatchMode,
-                                           const uint8_t *    aTlvs,
-                                           uint8_t            aTlvsLength)
-{
-    TlvIterator       tlvIterator(aTlvs, aTlvsLength);
+    TlvIterator       tlvIterator(mTlvs, mLength);
     const ServiceTlv *serviceTlv;
 
     while ((serviceTlv = tlvIterator.Iterate<ServiceTlv>()) != nullptr)
@@ -604,7 +594,7 @@ const ServiceTlv *NetworkData::FindNextService(const ServiceTlv * aPrevServiceTl
         length = static_cast<uint8_t>((mTlvs + mLength) - tlvs);
     }
 
-    return FindService(aEnterpriseNumber, aServiceData, aServiceMatchMode, tlvs, length);
+    return NetworkData(GetInstance(), tlvs, length).FindService(aEnterpriseNumber, aServiceData, aServiceMatchMode);
 }
 
 const ServiceTlv *NetworkData::FindNextThreadService(const ServiceTlv * aPrevServiceTlv,
@@ -641,7 +631,7 @@ exit:
     return match;
 }
 
-NetworkDataTlv *NetworkData::AppendTlv(uint16_t aTlvSize)
+NetworkDataTlv *MutableNetworkData::AppendTlv(uint16_t aTlvSize)
 {
     NetworkDataTlv *tlv;
 
@@ -654,7 +644,7 @@ exit:
     return tlv;
 }
 
-void NetworkData::Insert(void *aStart, uint8_t aLength)
+void MutableNetworkData::Insert(void *aStart, uint8_t aLength)
 {
     uint8_t *start = reinterpret_cast<uint8_t *>(aStart);
 
@@ -663,36 +653,27 @@ void NetworkData::Insert(void *aStart, uint8_t aLength)
     mLength += aLength;
 }
 
-void NetworkData::Remove(uint8_t *aData, uint8_t &aDataLength, uint8_t *aRemoveStart, uint8_t aRemoveLength)
+void MutableNetworkData::Remove(void *aRemoveStart, uint8_t aRemoveLength)
 {
-    uint8_t *dataEnd   = aData + aDataLength;
-    uint8_t *removeEnd = aRemoveStart + aRemoveLength;
+    uint8_t *end         = GetBytes() + mLength;
+    uint8_t *removeStart = reinterpret_cast<uint8_t *>(aRemoveStart);
+    uint8_t *removeEnd   = removeStart + aRemoveLength;
 
-    OT_ASSERT((aRemoveLength <= aDataLength) && (aData <= aRemoveStart) && (removeEnd <= dataEnd));
+    OT_ASSERT((aRemoveLength <= mLength) && (GetBytes() <= removeStart) && (removeEnd <= end));
 
-    memmove(aRemoveStart, removeEnd, static_cast<uint8_t>(dataEnd - removeEnd));
-    aDataLength -= aRemoveLength;
+    memmove(removeStart, removeEnd, static_cast<uint8_t>(end - removeEnd));
+    mLength -= aRemoveLength;
 }
 
-void NetworkData::RemoveTlv(uint8_t *aData, uint8_t &aDataLength, NetworkDataTlv *aTlv)
+void MutableNetworkData::RemoveTlv(NetworkDataTlv *aTlv)
 {
-    Remove(aData, aDataLength, reinterpret_cast<uint8_t *>(aTlv), aTlv->GetSize());
-}
-
-void NetworkData::Remove(void *aRemoveStart, uint8_t aRemoveLength)
-{
-    NetworkData::Remove(mTlvs, mLength, reinterpret_cast<uint8_t *>(aRemoveStart), aRemoveLength);
-}
-
-void NetworkData::RemoveTlv(NetworkDataTlv *aTlv)
-{
-    NetworkData::RemoveTlv(mTlvs, mLength, aTlv);
+    Remove(aTlv, aTlv->GetSize());
 }
 
 Error NetworkData::SendServerDataNotification(uint16_t              aRloc16,
                                               bool                  aAppendNetDataTlv,
                                               Coap::ResponseHandler aHandler,
-                                              void *                aContext)
+                                              void *                aContext) const
 {
     Error            error   = kErrorNone;
     Coap::Message *  message = nullptr;

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -57,7 +57,7 @@ void LeaderBase::Reset(void)
 {
     mVersion       = Random::NonCrypto::GetUint8();
     mStableVersion = Random::NonCrypto::GetUint8();
-    mLength        = 0;
+    SetLength(0);
     Get<ot::Notifier>().Signal(kEventThreadNetdataChanged);
 }
 
@@ -356,16 +356,16 @@ Error LeaderBase::SetNetworkData(uint8_t        aVersion,
 
     SuccessOrExit(error = aMessage.Read(aMessageOffset, tlv));
 
-    length = aMessage.ReadBytes(aMessageOffset + sizeof(tlv), mTlvs, tlv.GetLength());
+    length = aMessage.ReadBytes(aMessageOffset + sizeof(tlv), GetBytes(), tlv.GetLength());
     VerifyOrExit(length == tlv.GetLength(), error = kErrorParse);
 
-    mLength        = tlv.GetLength();
+    SetLength(tlv.GetLength());
     mVersion       = aVersion;
     mStableVersion = aStableVersion;
 
     if (aStableOnly)
     {
-        RemoveTemporaryData(mTlvs, mLength);
+        RemoveTemporaryData();
     }
 
 #if OPENTHREAD_FTD
@@ -376,7 +376,7 @@ Error LeaderBase::SetNetworkData(uint8_t        aVersion,
     }
 #endif
 
-    otDumpDebgNetData("set network data", mTlvs, mLength);
+    otDumpDebgNetData("SetNetworkData", GetBytes(), GetLength());
 
     Get<ot::Notifier>().Signal(kEventThreadNetdataChanged);
 

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -63,7 +63,7 @@ namespace NetworkData {
  * This class implements the Thread Network Data maintained by the Leader.
  *
  */
-class LeaderBase : public NetworkData
+class LeaderBase : public MutableNetworkData
 {
 public:
     /**
@@ -73,7 +73,7 @@ public:
      *
      */
     explicit LeaderBase(Instance &aInstance)
-        : NetworkData(aInstance)
+        : MutableNetworkData(aInstance, mTlvBuffer, 0, sizeof(mTlvBuffer))
     {
         Reset();
     }
@@ -290,6 +290,8 @@ private:
                               uint16_t *          aRloc16) const;
     Error DefaultRouteLookup(const PrefixTlv &aPrefix, uint16_t *aRloc16) const;
     Error SteeringDataCheck(const FilterIndexes &aFilterIndexes) const;
+
+    uint8_t mTlvBuffer[kMaxSize];
 };
 
 /**
@@ -302,7 +304,11 @@ private:
 #if OPENTHREAD_MTD
 namespace ot {
 namespace NetworkData {
-typedef class LeaderBase Leader;
+class Leader : public LeaderBase
+{
+public:
+    using LeaderBase::LeaderBase;
+};
 } // namespace NetworkData
 } // namespace ot
 #elif OPENTHREAD_FTD

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -209,7 +209,7 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
-    void RegisterNetworkData(uint16_t aRloc16, const uint8_t *aTlvs, uint8_t aTlvsLength);
+    void RegisterNetworkData(uint16_t aRloc16, const NetworkData &aNetworkData);
 
     Error AddPrefix(const PrefixTlv &aPrefix, ChangedFlags &aChangedFlags);
     Error AddHasRoute(const HasRouteTlv &aHasRoute, PrefixTlv &aDstPrefix, ChangedFlags &aChangedFlags);
@@ -230,11 +230,10 @@ private:
     void RemoveCommissioningData(void);
 
     void RemoveRloc(uint16_t aRloc16, MatchMode aMatchMode, ChangedFlags &aChangedFlags);
-    void RemoveRloc(uint16_t       aRloc16,
-                    MatchMode      aMatchMode,
-                    const uint8_t *aExcludeTlvs,
-                    uint8_t        aExcludeTlvsLength,
-                    ChangedFlags & aChangedFlags);
+    void RemoveRloc(uint16_t           aRloc16,
+                    MatchMode          aMatchMode,
+                    const NetworkData &aExcludeNetworkData,
+                    ChangedFlags &     aChangedFlags);
     void RemoveRlocInPrefix(PrefixTlv &      aPrefix,
                             uint16_t         aRloc16,
                             MatchMode        aMatchMode,
@@ -260,7 +259,7 @@ private:
 
     static bool RlocMatch(uint16_t aFirstRloc16, uint16_t aSecondRloc16, MatchMode aMatchMode);
 
-    static Error Validate(const uint8_t *aTlvs, uint8_t aTlvsLength, uint16_t aRloc16);
+    static Error Validate(const NetworkData &aNetworkData, uint16_t aRloc16);
     static Error ValidatePrefix(const PrefixTlv &aPrefix, uint16_t aRloc16);
     static Error ValidateService(const ServiceTlv &aService, uint16_t aRloc16);
 

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -125,7 +125,7 @@ Error Local::AddPrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvT
         prefixTlv->GetSubTlvs()->SetStable();
     }
 
-    otDumpDebgNetData("add prefix done", mTlvs, mLength);
+    otDumpDebgNetData("AddPrefix", GetBytes(), GetLength());
 
 exit:
     return error;
@@ -141,7 +141,7 @@ Error Local::RemovePrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubT
     RemoveTlv(tlv);
 
 exit:
-    otDumpDebgNetData("remove done", mTlvs, mLength);
+    otDumpDebgNetData("RmvPrefix", GetBytes(), GetLength());
     return error;
 }
 
@@ -216,7 +216,7 @@ Error Local::AddService(uint32_t           aEnterpriseNumber,
         serverTlv->SetStable();
     }
 
-    otDumpDebgNetData("add service done", mTlvs, mLength);
+    otDumpDebgNetData("AddService", GetBytes(), GetLength());
 
 exit:
     return error;
@@ -232,7 +232,7 @@ Error Local::RemoveService(uint32_t aEnterpriseNumber, const ServiceData &aServi
     RemoveTlv(tlv);
 
 exit:
-    otDumpDebgNetData("remove service done", mTlvs, mLength);
+    otDumpDebgNetData("RmvService", GetBytes(), GetLength());
     return error;
 }
 

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -58,7 +58,7 @@ namespace NetworkData {
  * This class implements the Thread Network Data contributed by the local device.
  *
  */
-class Local : public NetworkData, private NonCopyable
+class Local : public MutableNetworkData, private NonCopyable
 {
 public:
     /**
@@ -68,7 +68,7 @@ public:
      *
      */
     explicit Local(Instance &aInstance)
-        : NetworkData(aInstance)
+        : MutableNetworkData(aInstance, mTlvBuffer, 0, sizeof(mTlvBuffer))
         , mOldRloc(Mac::kShortAddrInvalid)
     {
     }
@@ -181,6 +181,7 @@ private:
     bool IsServiceConsistent(void) const;
 #endif
 
+    uint8_t  mTlvBuffer[kMaxSize];
     uint16_t mOldRloc;
 };
 

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -355,11 +355,9 @@ Error NetworkDiagnostic::FillRequestedTlvs(const Message &       aRequest,
 
         case NetworkDiagnosticTlv::kNetworkData:
         {
-            uint8_t netData[NetworkData::NetworkData::kMaxSize];
-            uint8_t length = sizeof(netData);
+            NetworkData::NetworkData &netData = Get<NetworkData::Leader>();
 
-            IgnoreError(Get<NetworkData::Leader>().GetNetworkData(/* aStableOnly */ false, netData, length));
-            SuccessOrExit(error = Tlv::Append<NetworkDataTlv>(aResponse, netData, length));
+            SuccessOrExit(error = Tlv::Append<NetworkDataTlv>(aResponse, netData.GetBytes(), netData.GetLength()));
             break;
         }
 

--- a/tests/unit/test_network_data.cpp
+++ b/tests/unit/test_network_data.cpp
@@ -64,17 +64,6 @@ bool CompareExternalRouteConfig(const otExternalRouteConfig &aConfig1, const otE
 
 void TestNetworkDataIterator(void)
 {
-    class TestNetworkData : public NetworkData
-    {
-    public:
-        TestNetworkData(ot::Instance *aInstance, const uint8_t *aTlvs, uint8_t aTlvsLength)
-            : NetworkData(*aInstance)
-        {
-            memcpy(mTlvs, aTlvs, aTlvsLength);
-            mLength = aTlvsLength;
-        }
-    };
-
     ot::Instance *      instance;
     Iterator            iter = kIteratorInit;
     ExternalRouteConfig config;
@@ -115,7 +104,7 @@ void TestNetworkDataIterator(void)
             },
         };
 
-        TestNetworkData netData(instance, kNetworkData, sizeof(kNetworkData));
+        NetworkData netData(*instance, kNetworkData, sizeof(kNetworkData));
 
         iter = OT_NETWORK_DATA_ITERATOR_INIT;
 
@@ -201,7 +190,7 @@ void TestNetworkDataIterator(void)
             },
         };
 
-        TestNetworkData netData(instance, kNetworkData, sizeof(kNetworkData));
+        NetworkData netData(*instance, kNetworkData, sizeof(kNetworkData));
 
         iter = OT_NETWORK_DATA_ITERATOR_INIT;
 
@@ -276,7 +265,7 @@ public:
         SuccessOrQuit(AddService(serviceData4));
         SuccessOrQuit(AddService(serviceData5));
 
-        DumpBuffer("netdata", mTlvs, mLength);
+        DumpBuffer("netdata", GetBytes(), GetLength());
 
         // Iterate through all entries that start with { 0x02 } (kServiceData1)
         tlv = nullptr;
@@ -334,8 +323,8 @@ void TestNetworkDataDsnSrpServices(void)
     public:
         void Populate(const uint8_t *aTlvs, uint8_t aTlvsLength)
         {
-            memcpy(mTlvs, aTlvs, aTlvsLength);
-            mLength = aTlvsLength;
+            memcpy(GetBytes(), aTlvs, aTlvsLength);
+            SetLength(aTlvsLength);
         }
     };
 


### PR DESCRIPTION
This commit updates the `NetworkData` implementation to simplify it
and make it more flexible.  It changes `NetworkData` class such that
it delegates providing the buffer space to store the TLVs to its
sub-classes (`Local`/`Leader`) or its users. This allow us to remove
many `static` methods that expect inputs of `(aTlvs, aTlvsLength)`
and instead the use the `NetworkData` methods directly. Basically,
the `NetworkData` class can now be considered as a wrapper over a
pointer to a buffer containing a sequence of TLVs which provides
methods to parse and process the TLVs. `NetworkData` class assumes
that the TLVs (buffer content) is immutable and we have a new class
`MutableNetworkData` which provides methods to update (add, remove,
or modify) the TLVs.