### PR TITLE
[network-data] fix missing header in `network_data_publisher.cpp`

### DIFF
--- a/src/core/thread/network_data_publisher.cpp
+++ b/src/core/thread/network_data_publisher.cpp
@@ -40,6 +40,7 @@
 #include "common/const_cast.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
+#include "common/logging.hpp"
 #include "common/random.hpp"
 #include "thread/network_data_local.hpp"
 #include "thread/network_data_service.hpp"


### PR DESCRIPTION
Build error happens when building simulation with config:

```
cmake ../.. -GNinja -DOT_PLATFORM=simulation -DOT_DNSSD_SERVER=ON -DOT_DNS_CLIENT=ON -DOT_SRP_CLIENT=ON -DOT_ECDSA=ON -DOT_SRP_SERVER=ON -DOT_SERVICE=ON -DOT_NETDATA_PUBLISHER=ON -DOT_BORDER_ROUTER=ON
```

Error message is:

```
../../src/core/thread/network_data_publisher.cpp: In member function ‘void ot::NetworkData::Publisher::Entry::SetState(ot::NetworkData::Publisher::Entry::State)’:
../../src/core/thread/network_data_publisher.cpp:264:5: error: ‘otLogInfoNetData’ was not declared in this scope
  264 |     otLogInfoNetData("Publisher: %s - State: %s -> %s", ToString(/* aIncludeState */ false).AsCString(),
      |     ^~~~~~~~~~~~~~~~
```

This PR adds the missing header to fix the issue.