### PR TITLE
[crypto] move context to platforms

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (168)
+#define OPENTHREAD_API_VERSION (169)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/crypto.h
+++ b/include/openthread/platform/crypto.h
@@ -54,6 +54,8 @@ extern "C" {
  *
  */
 
+#define OT_CRYPTO_CONTEXT_IN_PLACE_STORAGE_SIZE 288
+
 /**
  * This enumeration defines the key types.
  *
@@ -117,6 +119,14 @@ typedef struct otCryptoKey
     uint16_t       mKeyLength; ///< The key length in bytes (applicable when `mKey` is not NULL).
     uint32_t       mKeyRef;    ///< The PSA key ref (requires `mKey` to be NULL).
 } otCryptoKey;
+
+typedef struct otCryptoContext
+{
+    void *   mContext;     ///< Pointer to the context.
+    uint16_t mContextSize; ///< The length of the context in bytes.
+    uint64_t mInPlaceStorage[OT_CRYPTO_CONTEXT_IN_PLACE_STORAGE_SIZE /
+                             sizeof(uint64_t)]; ///< In place storage for on-stack memory allocation.
+} otCryptoContext;
 
 /**
  * Initialize the Crypto module.
@@ -206,57 +216,46 @@ bool otPlatCryptoHasKey(otCryptoKeyRef aKeyRef);
  * Initialize the HMAC operation.
  *
  * @param[in]  aContext          Context for HMAC operation.
- * @param[in]  aContextSize      Context size HMAC operation.
  *
  * @retval OT_ERROR_NONE          Successfully initialized HMAC operation.
  * @retval OT_ERROR_FAILED        Failed to initialize HMAC operation.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext was NULL
  *
- * @note In case PSA is supported pointer to psa_mac_operation_t will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_md_context_t will be provided.
+ * @note The platform driver shall point the context to the correct object such as psa_mac_operation_t or
+ *       mbedtls_md_context_t.
  *
  */
-otError otPlatCryptoHmacSha256Init(void *aContext, size_t aContextSize);
+otError otPlatCryptoHmacSha256Init(otCryptoContext *aContext);
 
 /**
  * Uninitialize the HMAC operation.
  *
  * @param[in]  aContext          Context for HMAC operation.
- * @param[in]  aContextSize      Context size HMAC operation.
- *
  *
  * @retval OT_ERROR_NONE          Successfully uninitialized HMAC operation.
  * @retval OT_ERROR_FAILED        Failed to uninitialized HMAC operation.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext was NULL
  *
- * @note In case PSA is supported pointer to psa_mac_operation_t will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_md_context_t will be provided.
- *
  */
-otError otPlatCryptoHmacSha256Deinit(void *aContext, size_t aContextSize);
+otError otPlatCryptoHmacSha256Deinit(otCryptoContext *aContext);
 
 /**
  * Start HMAC operation.
  *
  * @param[in]  aContext           Context for HMAC operation.
- * @param[in]  aContextSize       Context size HMAC operation.
  * @param[in]  aKey               Key material to be used for for HMAC operation.
  *
  * @retval OT_ERROR_NONE          Successfully started HMAC operation.
  * @retval OT_ERROR_FAILED        Failed to start HMAC operation.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext or @p aKey was NULL
  *
- * @note In case PSA is supported pointer to psa_mac_operation_t will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_md_context_t will be provided.
- *
  */
-otError otPlatCryptoHmacSha256Start(void *aContext, size_t aContextSize, const otCryptoKey *aKey);
+otError otPlatCryptoHmacSha256Start(otCryptoContext *aContext, const otCryptoKey *aKey);
 
 /**
  * Update the HMAC operation with new input.
  *
  * @param[in]  aContext           Context for HMAC operation.
- * @param[in]  aContextSize       Context size HMAC operation.
  * @param[in]  aBuf               A pointer to the input buffer.
  * @param[in]  aBufLength         The length of @p aBuf in bytes.
  *
@@ -264,17 +263,13 @@ otError otPlatCryptoHmacSha256Start(void *aContext, size_t aContextSize, const o
  * @retval OT_ERROR_FAILED        Failed to update HMAC operation.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext or @p aBuf was NULL
  *
- * @note In case PSA is supported pointer to psa_mac_operation_t will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_md_context_t will be provided.
- *
  */
-otError otPlatCryptoHmacSha256Update(void *aContext, size_t aContextSize, const void *aBuf, uint16_t aBufLength);
+otError otPlatCryptoHmacSha256Update(otCryptoContext *aContext, const void *aBuf, uint16_t aBufLength);
 
 /**
  * Complete the HMAC operation.
  *
  * @param[in]  aContext           Context for HMAC operation.
- * @param[in]  aContextSize       Context size HMAC operation.
  * @param[out] aBuf               A pointer to the output buffer.
  * @param[in]  aBufLength         The length of @p aBuf in bytes.
  *
@@ -282,50 +277,42 @@ otError otPlatCryptoHmacSha256Update(void *aContext, size_t aContextSize, const 
  * @retval OT_ERROR_FAILED        Failed to complete HMAC operation.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext or @p aBuf was NULL
  *
- * @note In case PSA is supported pointer to psa_mac_operation_t will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_md_context_t will be provided.
- *
  */
-otError otPlatCryptoHmacSha256Finish(void *aContext, size_t aContextSize, uint8_t *aBuf, size_t aBufLength);
+otError otPlatCryptoHmacSha256Finish(otCryptoContext *aContext, uint8_t *aBuf, size_t aBufLength);
 
 /**
  * Initialise the AES operation.
  *
  * @param[in]  aContext           Context for AES operation.
- * @param[in]  aContextSize       Context size AES operation.
  *
  * @retval OT_ERROR_NONE          Successfully Initialised AES operation.
  * @retval OT_ERROR_FAILED        Failed to Initialise AES operation.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext was NULL
+ * @retval OT_ERROR_NO_BUFS       Cannot allocate the context.
  *
- * @note In case PSA is supported pointer to psa_key_id will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_aes_context_t will be provided.
+ * @note The platform driver shall point the context to the correct object such as psa_key_id
+ *       or mbedtls_aes_context_t.
  *
  */
-otError otPlatCryptoAesInit(void *aContext, size_t aContextSize);
+otError otPlatCryptoAesInit(otCryptoContext *aContext);
 
 /**
  * Set the key for AES operation.
  *
  * @param[in]  aContext           Context for AES operation.
- * @param[in]  aContextSize       Context size AES operation.
  * @param[out] aKey               Key to use for AES operation.
  *
  * @retval OT_ERROR_NONE          Successfully set the key for AES operation.
  * @retval OT_ERROR_FAILED        Failed to set the key for AES operation.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext or @p aKey was NULL
  *
- * @note In case PSA is supported pointer to psa_key_id will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_aes_context_t will be provided.
- *
  */
-otError otPlatCryptoAesSetKey(void *aContext, size_t aContextSize, const otCryptoKey *aKey);
+otError otPlatCryptoAesSetKey(otCryptoContext *aContext, const otCryptoKey *aKey);
 
 /**
  * Encrypt the given data.
  *
  * @param[in]  aContext           Context for AES operation.
- * @param[in]  aContextSize       Context size AES operation.
  * @param[in]  aInput             Pointer to the input buffer.
  * @param[in]  aOutput            Pointer to the output buffer.
  *
@@ -333,33 +320,40 @@ otError otPlatCryptoAesSetKey(void *aContext, size_t aContextSize, const otCrypt
  * @retval OT_ERROR_FAILED        Failed to encrypt @p aInput.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext or @p aKey or @p aOutput were NULL
  *
- * @note In case PSA is supported pointer to psa_key_id will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_aes_context_t will be provided.
- *
  */
-otError otPlatCryptoAesEncrypt(void *aContext, size_t aContextSize, const uint8_t *aInput, uint8_t *aOutput);
+otError otPlatCryptoAesEncrypt(otCryptoContext *aContext, const uint8_t *aInput, uint8_t *aOutput);
 
 /**
  * Free the AES context.
  *
  * @param[in]  aContext           Context for AES operation.
- * @param[in]  aContextSize       Context size AES operation.
  *
  * @retval OT_ERROR_NONE          Successfully freed AES context.
  * @retval OT_ERROR_FAILED        Failed to free AES context.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext was NULL
  *
- * @note In case PSA is supported pointer to psa_key_id will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_aes_context_t will be provided.
+ */
+otError otPlatCryptoAesFree(otCryptoContext *aContext);
+
+/**
+ * Initialise the HKDF context.
+ *
+ * @param[in]  aContext           Context for HKDF operation.
+ *
+ * @retval OT_ERROR_NONE          Successfully Initialised AES operation.
+ * @retval OT_ERROR_FAILED        Failed to Initialise AES operation.
+ * @retval OT_ERROR_INVALID_ARGS  @p aContext was NULL
+ *
+ * @note The platform driver shall point the context to the correct object such as psa_key_derivation_operation_t
+ *       or HmacSha256::Hash
  *
  */
-otError otPlatCryptoAesFree(void *aContext, size_t aContextSize);
+otError otPlatCryptoHkdfInit(otCryptoContext *aContext);
 
 /**
  * Perform HKDF Expand step.
  *
  * @param[in]  aContext           Operation context for HKDF operation.
- * @param[in]  aContextSize       Context size HKDF operation.
  * @param[in]  aInfo              Pointer to the Info sequence.
  * @param[in]  aInfoLength        Length of the Info sequence.
  * @param[out] aOutputKey         Pointer to the output Key.
@@ -367,20 +361,19 @@ otError otPlatCryptoAesFree(void *aContext, size_t aContextSize);
  *
  * @retval OT_ERROR_NONE          HKDF Expand was successful.
  * @retval OT_ERROR_FAILED        HKDF Expand failed.
+ * @retval OT_ERROR_INVALID_ARGS  @p aContext was NULL
  *
  */
-otError otPlatCryptoHkdfExpand(void *         aContext,
-                               size_t         aContextSize,
-                               const uint8_t *aInfo,
-                               uint16_t       aInfoLength,
-                               uint8_t *      aOutputKey,
-                               uint16_t       aOutputKeyLength);
+otError otPlatCryptoHkdfExpand(otCryptoContext *aContext,
+                               const uint8_t *  aInfo,
+                               uint16_t         aInfoLength,
+                               uint8_t *        aOutputKey,
+                               uint16_t         aOutputKeyLength);
 
 /**
  * Perform HKDF Extract step.
  *
  * @param[in]  aContext           Operation context for HKDF operation.
- * @param[in]  aContextSize       Context size HKDF operation.
  * @param[in]  aSalt              Pointer to the Salt for HKDF.
  * @param[in]  aInfoLength        length of Salt.
  * @param[in]  aInputKey          Pointer to the input key.
@@ -389,62 +382,66 @@ otError otPlatCryptoHkdfExpand(void *         aContext,
  * @retval OT_ERROR_FAILED        HKDF Extract failed.
  *
  */
-otError otPlatCryptoHkdfExtract(void *             aContext,
-                                size_t             aContextSize,
+otError otPlatCryptoHkdfExtract(otCryptoContext *  aContext,
                                 const uint8_t *    aSalt,
                                 uint16_t           aSaltLength,
                                 const otCryptoKey *aInputKey);
 
 /**
+ * UnInitialise the HKDF context.
+ *
+ * @param[in]  aContext           Context for HKDF operation.
+ *
+ * @retval OT_ERROR_NONE          Successfully un-initialised HKDF operation.
+ * @retval OT_ERROR_FAILED        Failed to un-initialised HKDF operation.
+ * @retval OT_ERROR_INVALID_ARGS  @p aContext was NULL
+ *
+ */
+otError otPlatCryptoHkdfDeinit(otCryptoContext *aContext);
+
+/**
  * Initialise the SHA-256 operation.
  *
  * @param[in]  aContext           Context for SHA-256 operation.
- * @param[in]  aContextSize       Context size SHA-256 operation.
  *
  * @retval OT_ERROR_NONE          Successfully initialised SHA-256 operation.
  * @retval OT_ERROR_FAILED        Failed to initialise SHA-256 operation.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext was NULL
  *
- * @note In case PSA is supported pointer to psa_hash_operation_t will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_sha256_context will be provided.
+ *
+ * @note The platform driver shall point the context to the correct object such as psa_hash_operation_t
+ *       or mbedtls_sha256_context.
  */
-otError otPlatCryptoSha256Init(void *aContext, size_t aContextSize);
+otError otPlatCryptoSha256Init(otCryptoContext *aContext);
 
 /**
  * UnInitialise the SHA-256 operation.
  *
  * @param[in]  aContext           Context for SHA-256 operation.
- * @param[in]  aContextSize       Context size SHA-256 operation.
  *
  * @retval OT_ERROR_NONE          Successfully un-initialised SHA-256 operation.
  * @retval OT_ERROR_FAILED        Failed to un-initialised SHA-256 operation.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext was NULL
  *
- * @note In case PSA is supported pointer to psa_hash_operation_t will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_sha256_context will be provided.
  */
-otError otPlatCryptoSha256Deinit(void *aContext, size_t aContextSize);
+otError otPlatCryptoSha256Deinit(otCryptoContext *aContext);
 
 /**
  * Start SHA-256 operation.
  *
  * @param[in]  aContext           Context for SHA-256 operation.
- * @param[in]  aContextSize       Context size SHA-256 operation.
  *
  * @retval OT_ERROR_NONE          Successfully started SHA-256 operation.
  * @retval OT_ERROR_FAILED        Failed to start SHA-256 operation.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext was NULL
  *
- * @note In case PSA is supported pointer to psa_hash_operation_t will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_sha256_context will be provided.
  */
-otError otPlatCryptoSha256Start(void *aContext, size_t aContextSize);
+otError otPlatCryptoSha256Start(otCryptoContext *aContext);
 
 /**
  * Update SHA-256 operation with new input.
  *
  * @param[in]  aContext           Context for SHA-256 operation.
- * @param[in]  aContextSize       Context size SHA-256 operation.
  * @param[in]  aBuf               A pointer to the input buffer.
  * @param[in]  aBufLength         The length of @p aBuf in bytes.
  *
@@ -452,10 +449,8 @@ otError otPlatCryptoSha256Start(void *aContext, size_t aContextSize);
  * @retval OT_ERROR_FAILED        Failed to update SHA-256 operation.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext or @p aBuf was NULL
  *
- * @note In case PSA is supported pointer to psa_hash_operation_t will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_sha256_context will be provided.
  */
-otError otPlatCryptoSha256Update(void *aContext, size_t aContextSize, const void *aBuf, uint16_t aBufLength);
+otError otPlatCryptoSha256Update(otCryptoContext *aContext, const void *aBuf, uint16_t aBufLength);
 
 /**
  * Finish SHA-256 operation.
@@ -469,10 +464,8 @@ otError otPlatCryptoSha256Update(void *aContext, size_t aContextSize, const void
  * @retval OT_ERROR_FAILED        Failed to complete SHA-256 operation.
  * @retval OT_ERROR_INVALID_ARGS  @p aContext or @p aHash was NULL
  *
- * @note In case PSA is supported pointer to psa_hash_operation_t will be passed as input.
- * In case of mbedTLS, pointer to  mbedtls_sha256_context will be provided.
  */
-otError otPlatCryptoSha256Finish(void *aContext, size_t aContextSize, uint8_t *aHash, uint16_t aHashSize);
+otError otPlatCryptoSha256Finish(otCryptoContext *aContext, uint8_t *aHash, uint16_t aHashSize);
 
 /**
  * @}

--- a/include/openthread/platform/crypto.h
+++ b/include/openthread/platform/crypto.h
@@ -118,6 +118,12 @@ typedef struct otCryptoKey
     uint32_t       mKeyRef;    ///< The PSA key ref (requires `mKey` to be NULL).
 } otCryptoKey;
 
+/**
+ * @struct otCryptoContext
+ *
+ * This structure stores the context object for platform APIs.
+ *
+ */
 typedef struct otCryptoContext
 {
     void *   mContext;     ///< Pointer to the context.
@@ -384,7 +390,7 @@ otError otPlatCryptoHkdfExtract(otCryptoContext *  aContext,
                                 const otCryptoKey *aInputKey);
 
 /**
- * UnInitialise the HKDF context.
+ * Uninitialize the HKDF context.
  *
  * @param[in]  aContext           Context for HKDF operation.
  *
@@ -411,7 +417,7 @@ otError otPlatCryptoHkdfDeinit(otCryptoContext *aContext);
 otError otPlatCryptoSha256Init(otCryptoContext *aContext);
 
 /**
- * UnInitialise the SHA-256 operation.
+ * Uninitialize the SHA-256 operation.
  *
  * @param[in]  aContext           Context for SHA-256 operation.
  *

--- a/include/openthread/platform/crypto.h
+++ b/include/openthread/platform/crypto.h
@@ -54,8 +54,6 @@ extern "C" {
  *
  */
 
-#define OT_CRYPTO_CONTEXT_IN_PLACE_STORAGE_SIZE 288
-
 /**
  * This enumeration defines the key types.
  *
@@ -124,8 +122,6 @@ typedef struct otCryptoContext
 {
     void *   mContext;     ///< Pointer to the context.
     uint16_t mContextSize; ///< The length of the context in bytes.
-    uint64_t mInPlaceStorage[OT_CRYPTO_CONTEXT_IN_PLACE_STORAGE_SIZE /
-                             sizeof(uint64_t)]; ///< In place storage for on-stack memory allocation.
 } otCryptoContext;
 
 /**

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -431,6 +431,7 @@ openthread_core_files = [
   "crypto/aes_ccm.hpp",
   "crypto/aes_ecb.cpp",
   "crypto/aes_ecb.hpp",
+  "crypto/context_size.hpp",
   "crypto/crypto_platform.cpp",
   "crypto/ecdsa.cpp",
   "crypto/ecdsa.hpp",

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -723,6 +723,7 @@ source_set("libopenthread_core_config") {
     "config/child_supervision.h",
     "config/coap.h",
     "config/commissioner.h",
+    "config/crypto.h",
     "config/dataset_updater.h",
     "config/dhcp6_client.h",
     "config/dhcp6_server.h",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -460,6 +460,7 @@ HEADERS_COMMON                                  = \
     config/child_supervision.h                    \
     config/coap.h                                 \
     config/commissioner.h                         \
+    config/crypto.h                               \
     config/dataset_updater.h                      \
     config/dhcp6_client.h                         \
     config/dhcp6_server.h                         \

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -490,6 +490,7 @@ HEADERS_COMMON                                  = \
     config/tmf.h                                  \
     crypto/aes_ccm.hpp                            \
     crypto/aes_ecb.hpp                            \
+    crypto/context_size.hpp                       \
     crypto/ecdsa.hpp                              \
     crypto/hkdf_sha256.hpp                        \
     crypto/hmac_sha256.hpp                        \

--- a/src/core/config/crypto.h
+++ b/src/core/config/crypto.h
@@ -30,43 +30,25 @@
 #define CONFIG_CRYPTO_H_
 
 /**
- * @def OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
+ * @def OPENTHREAD_CONFIG_CRYPTO_LIB
  *
- * The size of the AES context byte array.
+ * Selects the crypto backend library for OpenThread.
+ *
+ * There are several options available
+ * - @sa OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
+ * - @sa OPENTHREAD_CONFIG_CRYPTO_LIB_PSA
+ * - @sa OPENTHREAD_CONFIG_CRYPTO_LIB_PLATFORM
  *
  */
-#ifndef OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_AES_CONTEXT_SIZE 288
+#ifndef OPENTHREAD_CONFIG_CRYPTO_LIB
+#define OPENTHREAD_CONFIG_CRYPTO_LIB OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
 #endif
 
-/**
- * @def OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
- *
- * The size of the HMAC_SHA256 context byte array.
- *
- */
-#ifndef OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE 32
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
- *
- * The size of the HKDF context byte array.
- *
- */
-#ifndef OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE 288
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
- *
- * The size of the SHA256 context byte array.
- *
- */
-#ifndef OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE 288
-#endif
+/** Use mbedtls v2.x as crypto library */
+#define OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2 0
+/** Use ARM Platform Security Library as crypto library */
+#define OPENTHREAD_CONFIG_CRYPTO_LIB_PSA 1
+/** Use platform provided crypto library */
+#define OPENTHREAD_CONFIG_CRYPTO_LIB_PLATFORM 2
 
 #endif // CONFIG_CRYPTO_H_

--- a/src/core/config/crypto.h
+++ b/src/core/config/crypto.h
@@ -35,17 +35,17 @@
  * Selects the crypto backend library for OpenThread.
  *
  * There are several options available
- * - @sa OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
+ * - @sa OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS
  * - @sa OPENTHREAD_CONFIG_CRYPTO_LIB_PSA
  * - @sa OPENTHREAD_CONFIG_CRYPTO_LIB_PLATFORM
  *
  */
 #ifndef OPENTHREAD_CONFIG_CRYPTO_LIB
-#define OPENTHREAD_CONFIG_CRYPTO_LIB OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
+#define OPENTHREAD_CONFIG_CRYPTO_LIB OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS
 #endif
 
-/** Use mbedtls v2.x as crypto library */
-#define OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2 0
+/** Use mbedtls as crypto library */
+#define OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS 0
 /** Use ARM Platform Security Library as crypto library */
 #define OPENTHREAD_CONFIG_CRYPTO_LIB_PSA 1
 /** Use platform provided crypto library */
@@ -60,7 +60,7 @@
  *
  */
 #ifndef OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_AES_CONTEXT_SIZE (sizeof(void *))
+#error "OPENTHREAD_CONFIG_AES_CONTEXT_SIZE is missing"
 #endif
 
 /**
@@ -70,7 +70,7 @@
  *
  */
 #ifndef OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE (sizeof(void *))
+#error "OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE is missing"
 #endif
 
 /**
@@ -80,7 +80,7 @@
  *
  */
 #ifndef OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE (sizeof(void *))
+#error "OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE is missing"
 #endif
 
 /**
@@ -90,7 +90,7 @@
  *
  */
 #ifndef OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE (sizeof(void *))
+#error "OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE is missing"
 #endif
 
 #endif // OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_PLATFORM

--- a/src/core/config/crypto.h
+++ b/src/core/config/crypto.h
@@ -51,4 +51,48 @@
 /** Use platform provided crypto library */
 #define OPENTHREAD_CONFIG_CRYPTO_LIB_PLATFORM 2
 
+#if OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_PLATFORM
+
+/**
+ * @def OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
+ *
+ * The size of the AES context byte array. Only applicable with OPENTHREAD_CONFIG_CRYPTO_LIB_PLATFORM.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_AES_CONTEXT_SIZE (sizeof(void *))
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
+ *
+ * The size of the HMAC_SHA256 context byte array. Only applicable with OPENTHREAD_CONFIG_CRYPTO_LIB_PLATFORM.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE (sizeof(void *))
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
+ *
+ * The size of the HKDF context byte array. Only applicable with OPENTHREAD_CONFIG_CRYPTO_LIB_PLATFORM.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE (sizeof(void *))
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
+ *
+ * The size of the SHA256 context byte array. Only applicable with OPENTHREAD_CONFIG_CRYPTO_LIB_PLATFORM.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE (sizeof(void *))
+#endif
+
+#endif // OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_PLATFORM
+
 #endif // CONFIG_CRYPTO_H_

--- a/src/core/config/crypto.h
+++ b/src/core/config/crypto.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2016, The OpenThread Authors.
+ *  Copyright (c) 2021, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,81 +26,47 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-/**
- * @file
- *   This file includes definitions for performing AES-ECB computations.
- */
-
-#ifndef AES_ECB_HPP_
-#define AES_ECB_HPP_
-
-#include "openthread-core-config.h"
-
-#include <mbedtls/aes.h>
-#include <openthread/platform/crypto.h>
-
-#include "common/code_utils.hpp"
-#include "crypto/storage.hpp"
-
-namespace ot {
-namespace Crypto {
+#ifndef CONFIG_CRYPTO_H_
+#define CONFIG_CRYPTO_H_
 
 /**
- * @addtogroup core-security
+ * @def OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
  *
- * @{
+ * The size of the AES context byte array.
  *
  */
+#ifndef OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_AES_CONTEXT_SIZE 288
+#endif
 
 /**
- * This class implements AES ECB computation.
+ * @def OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
+ *
+ * The size of the HMAC_SHA256 context byte array.
  *
  */
-class AesEcb
-{
-public:
-    static constexpr uint8_t kBlockSize = 16; ///< AES-128 block size (bytes).
-
-    /**
-     * Constructor to initialize the mbedtls_aes_context.
-     *
-     */
-    AesEcb(void);
-
-    /**
-     * Destructor to free the mbedtls_aes_context.
-     *
-     */
-    ~AesEcb(void);
-
-    /**
-     * This method sets the key.
-     *
-     * @param[in]  aKey     Crypto Key used for ECB operation
-     *
-     */
-    void SetKey(const Key &aKey);
-
-    /**
-     * This method encrypts data.
-     *
-     * @param[in]   aInput   A pointer to the input buffer.
-     * @param[out]  aOutput  A pointer to the output buffer.
-     *
-     */
-    void Encrypt(const uint8_t aInput[kBlockSize], uint8_t aOutput[kBlockSize]);
-
-private:
-    otCryptoContext mContext;
-    OT_DEFINE_ALIGNED_VAR(mContextStorage, OPENTHREAD_CONFIG_AES_CONTEXT_SIZE, uint64_t);
-};
+#ifndef OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE 32
+#endif
 
 /**
- * @}
+ * @def OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
+ *
+ * The size of the HKDF context byte array.
  *
  */
+#ifndef OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE 288
+#endif
 
-} // namespace Crypto
-} // namespace ot
+/**
+ * @def OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
+ *
+ * The size of the SHA256 context byte array.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE 288
+#endif
 
-#endif // AES_ECB_HPP_
+#endif // CONFIG_CRYPTO_H_

--- a/src/core/crypto/aes_ecb.cpp
+++ b/src/core/crypto/aes_ecb.cpp
@@ -40,28 +40,28 @@ namespace Crypto {
 
 AesEcb::AesEcb(void)
 {
-    Error err = otPlatCryptoAesInit(&mContext, sizeof(mContext));
+    Error err = otPlatCryptoAesInit(&mContext);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }
 
 void AesEcb::SetKey(const Key &aKey)
 {
-    Error err = otPlatCryptoAesSetKey(&mContext, sizeof(mContext), &aKey);
+    Error err = otPlatCryptoAesSetKey(&mContext, &aKey);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }
 
 void AesEcb::Encrypt(const uint8_t aInput[kBlockSize], uint8_t aOutput[kBlockSize])
 {
-    Error err = otPlatCryptoAesEncrypt(&mContext, sizeof(mContext), aInput, aOutput);
+    Error err = otPlatCryptoAesEncrypt(&mContext, aInput, aOutput);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }
 
 AesEcb::~AesEcb(void)
 {
-    Error err = otPlatCryptoAesFree(&mContext, sizeof(mContext));
+    Error err = otPlatCryptoAesFree(&mContext);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }

--- a/src/core/crypto/aes_ecb.cpp
+++ b/src/core/crypto/aes_ecb.cpp
@@ -40,7 +40,9 @@ namespace Crypto {
 
 AesEcb::AesEcb(void)
 {
-    Error err = otPlatCryptoAesInit(&mContext);
+    mContext.mContext     = mContextStorage;
+    mContext.mContextSize = sizeof(mContextStorage);
+    Error err             = otPlatCryptoAesInit(&mContext);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }

--- a/src/core/crypto/aes_ecb.cpp
+++ b/src/core/crypto/aes_ecb.cpp
@@ -40,9 +40,12 @@ namespace Crypto {
 
 AesEcb::AesEcb(void)
 {
+    Error err = kErrorNone;
+
     mContext.mContext     = mContextStorage;
     mContext.mContextSize = sizeof(mContextStorage);
-    Error err             = otPlatCryptoAesInit(&mContext);
+    err                   = otPlatCryptoAesInit(&mContext);
+
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }

--- a/src/core/crypto/aes_ecb.hpp
+++ b/src/core/crypto/aes_ecb.hpp
@@ -89,13 +89,7 @@ public:
     void Encrypt(const uint8_t aInput[kBlockSize], uint8_t aOutput[kBlockSize]);
 
 private:
-    union AesEcbContext
-    {
-        uint32_t            mKeyRef;
-        mbedtls_aes_context mContext;
-    };
-
-    AesEcbContext mContext;
+    otCryptoContext mContext;
 };
 
 /**

--- a/src/core/crypto/aes_ecb.hpp
+++ b/src/core/crypto/aes_ecb.hpp
@@ -92,7 +92,7 @@ public:
 
 private:
     otCryptoContext mContext;
-    OT_DEFINE_ALIGNED_VAR(mContextStorage, OPENTHREAD_CONFIG_AES_CONTEXT_SIZE, uint64_t);
+    OT_DEFINE_ALIGNED_VAR(mContextStorage, kAesContextSize, uint64_t);
 };
 
 /**

--- a/src/core/crypto/aes_ecb.hpp
+++ b/src/core/crypto/aes_ecb.hpp
@@ -36,10 +36,10 @@
 
 #include "openthread-core-config.h"
 
-#include <mbedtls/aes.h>
 #include <openthread/platform/crypto.h>
 
 #include "common/code_utils.hpp"
+#include "crypto/context_size.hpp"
 #include "crypto/storage.hpp"
 
 namespace ot {

--- a/src/core/crypto/context_size.hpp
+++ b/src/core/crypto/context_size.hpp
@@ -26,119 +26,47 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#ifndef CRYPTO_CONTEXT_H_
-#define CRYPTO_CONTEXT_H_
+#ifndef CRYPTO_CONTEXT_HPP_
+#define CRYPTO_CONTEXT_HPP_
 
 #include "openthread-core-config.h"
+#include "openthread/crypto.h"
 
 #if OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
-
 #include <mbedtls/aes.h>
 #include <mbedtls/md.h>
 #include <mbedtls/sha256.h>
+#elif OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_PSA
+#include <psa/crypto.h>
+#endif // OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
 
-/**
- * @def OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
- *
- * The size of the AES context byte array.
- *
- */
-#ifndef OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_AES_CONTEXT_SIZE (sizeof(mbedtls_aes_context))
-#endif
+namespace ot {
+namespace Crypto {
 
-/**
- * @def OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
- *
- * The size of the HMAC_SHA256 context byte array.
- *
- */
-#ifndef OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE (sizeof(mbedtls_md_context_t))
-#endif
+#if OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
 
-/**
- * @def OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
- *
- * The size of the HKDF context byte array.
- *
- */
-#ifndef OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE (sizeof(ot::Crypto::Sha256::Hash))
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
- *
- * The size of the SHA256 context byte array.
- *
- */
-#ifndef OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE (sizeof(mbedtls_sha256_context))
-#endif
+constexpr uint16_t kAesContextSize        = sizeof(mbedtls_aes_context);
+constexpr uint16_t kHmacSha256ContextSize = sizeof(mbedtls_md_context_t);
+constexpr uint16_t kHkdfContextSize       = sizeof(otCryptoSha256Hash);
+constexpr uint16_t kSha256ContextSize     = sizeof(mbedtls_sha256_context);
 
 #elif OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_PSA
 
-#include <psa/crypto.h>
-
-/**
- * @def OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
- *
- * The size of the AES context byte array.
- *
- */
-#ifndef OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_AES_CONTEXT_SIZE (sizeof(uint32_t))
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
- *
- * The size of the HMAC_SHA256 context byte array.
- *
- */
-#ifndef OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE (sizeof(psa_mac_operation_t))
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
- *
- * The size of the HKDF context byte array.
- *
- */
-#ifndef OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE (sizeof(psa_key_derivation_operation_t))
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
- *
- * The size of the SHA256 context byte array.
- *
- */
-#ifndef OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
-#define OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE (sizeof(psa_hash_operation_t))
-#endif
+constexpr uint16_t kAesContextSize        = sizeof(uint32_t);
+constexpr uint16_t kHmacSha256ContextSize = sizeof(psa_mac_operation_t);
+constexpr uint16_t kHkdfContextSize       = sizeof(psa_key_derivation_operation_t);
+constexpr uint16_t kSha256ContextSize     = sizeof(psa_hash_operation_t);
 
 #else
 
-#ifndef OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
-#error "OPENTHREAD_CONFIG_AES_CONTEXT_SIZE should be defined in platform config"
-#endif
-
-#ifndef OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
-#error "OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE should be defined in platform config"
-#endif
-
-#ifndef OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
-#error "OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE should be defined in platform config"
-#endif
-
-#ifndef OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
-#error "OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE should be defined in platform config"
-#endif
+constexpr uint16_t kAesContextSize        = OPENTHREAD_CONFIG_AES_CONTEXT_SIZE;
+constexpr uint16_t kHmacSha256ContextSize = OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE;
+constexpr uint16_t kHkdfContextSize       = OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE;
+constexpr uint16_t kSha256ContextSize     = OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE;
 
 #endif // OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
 
-#endif // CRYPTO_CONTEXT_H_
+} // namespace Crypto
+} // namespace ot
+
+#endif // CRYPTO_CONTEXT_HPP_

--- a/src/core/crypto/context_size.hpp
+++ b/src/core/crypto/context_size.hpp
@@ -32,18 +32,18 @@
 #include "openthread-core-config.h"
 #include "openthread/crypto.h"
 
-#if OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
+#if OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS
 #include <mbedtls/aes.h>
 #include <mbedtls/md.h>
 #include <mbedtls/sha256.h>
 #elif OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_PSA
 #include <psa/crypto.h>
-#endif // OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
+#endif // OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS
 
 namespace ot {
 namespace Crypto {
 
-#if OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
+#if OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS
 
 constexpr uint16_t kAesContextSize        = sizeof(mbedtls_aes_context);
 constexpr uint16_t kHmacSha256ContextSize = sizeof(mbedtls_md_context_t);
@@ -52,7 +52,7 @@ constexpr uint16_t kSha256ContextSize     = sizeof(mbedtls_sha256_context);
 
 #elif OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_PSA
 
-constexpr uint16_t kAesContextSize        = sizeof(uint32_t);
+constexpr uint16_t kAesContextSize        = sizeof(psa_key_id_t);
 constexpr uint16_t kHmacSha256ContextSize = sizeof(psa_mac_operation_t);
 constexpr uint16_t kHkdfContextSize       = sizeof(psa_key_derivation_operation_t);
 constexpr uint16_t kSha256ContextSize     = sizeof(psa_hash_operation_t);
@@ -64,7 +64,7 @@ constexpr uint16_t kHmacSha256ContextSize = OPENTHREAD_CONFIG_HMAC_SHA256_CONTEX
 constexpr uint16_t kHkdfContextSize       = OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE;
 constexpr uint16_t kSha256ContextSize     = OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE;
 
-#endif // OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
+#endif // OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS
 
 } // namespace Crypto
 } // namespace ot

--- a/src/core/crypto/context_size.hpp
+++ b/src/core/crypto/context_size.hpp
@@ -1,0 +1,144 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef CRYPTO_CONTEXT_H_
+#define CRYPTO_CONTEXT_H_
+
+#include "openthread-core-config.h"
+
+#if OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
+
+#include <mbedtls/aes.h>
+#include <mbedtls/md.h>
+#include <mbedtls/sha256.h>
+
+/**
+ * @def OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
+ *
+ * The size of the AES context byte array.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_AES_CONTEXT_SIZE (sizeof(mbedtls_aes_context))
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
+ *
+ * The size of the HMAC_SHA256 context byte array.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE (sizeof(mbedtls_md_context_t))
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
+ *
+ * The size of the HKDF context byte array.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE (sizeof(ot::Crypto::Sha256::Hash))
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
+ *
+ * The size of the SHA256 context byte array.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE (sizeof(mbedtls_sha256_context))
+#endif
+
+#elif OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_PSA
+
+#include <psa/crypto.h>
+
+/**
+ * @def OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
+ *
+ * The size of the AES context byte array.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_AES_CONTEXT_SIZE (sizeof(uint32_t))
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
+ *
+ * The size of the HMAC_SHA256 context byte array.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE (sizeof(psa_mac_operation_t))
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
+ *
+ * The size of the HKDF context byte array.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE (sizeof(psa_key_derivation_operation_t))
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
+ *
+ * The size of the SHA256 context byte array.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
+#define OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE (sizeof(psa_hash_operation_t))
+#endif
+
+#else
+
+#ifndef OPENTHREAD_CONFIG_AES_CONTEXT_SIZE
+#error "OPENTHREAD_CONFIG_AES_CONTEXT_SIZE should be defined in platform config"
+#endif
+
+#ifndef OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE
+#error "OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE should be defined in platform config"
+#endif
+
+#ifndef OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE
+#error "OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE should be defined in platform config"
+#endif
+
+#ifndef OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE
+#error "OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE should be defined in platform config"
+#endif
+
+#endif // OPENTHREAD_CONFIG_CRYPTO_LIB == OPENTHREAD_CONFIG_CRYPTO_LIB_MBEDTLS_2
+
+#endif // CRYPTO_CONTEXT_H_

--- a/src/core/crypto/crypto_platform.cpp
+++ b/src/core/crypto/crypto_platform.cpp
@@ -235,6 +235,7 @@ OT_TOOL_WEAK otError otPlatCryptoHkdfExpand(otCryptoContext *aContext,
 
     VerifyOrExit(aContext != nullptr, error = kErrorInvalidArgs);
     VerifyOrExit(aContext->mContextSize >= sizeof(HmacSha256::Hash), error = kErrorFailed);
+
     prk = static_cast<HmacSha256::Hash *>(aContext->mContext);
 
     // The aOutputKey is calculated as follows [RFC5889]:
@@ -292,10 +293,10 @@ OT_TOOL_WEAK otError otPlatCryptoHkdfExtract(otCryptoContext *  aContext,
 
     VerifyOrExit(aContext != nullptr, error = kErrorInvalidArgs);
     VerifyOrExit(aContext->mContextSize >= sizeof(HmacSha256::Hash), error = kErrorFailed);
+
     prk = static_cast<HmacSha256::Hash *>(aContext->mContext);
 
     cryptoKey.Set(aSalt, aSaltLength);
-
     // PRK is calculated as HMAC-Hash(aSalt, aInputKey)
     hmac.Start(cryptoKey);
     hmac.Update(inputKey.GetBytes(), inputKey.GetLength());
@@ -361,6 +362,7 @@ OT_TOOL_WEAK otError otPlatCryptoSha256Start(otCryptoContext *aContext)
 
     VerifyOrExit(aContext != nullptr, error = kErrorInvalidArgs);
     VerifyOrExit(aContext->mContextSize >= sizeof(mbedtls_sha256_context), error = kErrorFailed);
+
     context = static_cast<mbedtls_sha256_context *>(aContext->mContext);
 
 #if (MBEDTLS_VERSION_NUMBER >= 0x03000000)
@@ -380,6 +382,7 @@ OT_TOOL_WEAK otError otPlatCryptoSha256Update(otCryptoContext *aContext, const v
 
     VerifyOrExit(aContext != nullptr, error = kErrorInvalidArgs);
     VerifyOrExit(aContext->mContextSize >= sizeof(mbedtls_sha256_context), error = kErrorFailed);
+
     context = static_cast<mbedtls_sha256_context *>(aContext->mContext);
 
 #if (MBEDTLS_VERSION_NUMBER >= 0x03000000)
@@ -403,6 +406,7 @@ OT_TOOL_WEAK otError otPlatCryptoSha256Finish(otCryptoContext *aContext, uint8_t
 
     VerifyOrExit(aContext != nullptr, error = kErrorInvalidArgs);
     VerifyOrExit(aContext->mContextSize >= sizeof(mbedtls_sha256_context), error = kErrorFailed);
+
     context = static_cast<mbedtls_sha256_context *>(aContext->mContext);
 
 #if (MBEDTLS_VERSION_NUMBER >= 0x03000000)

--- a/src/core/crypto/crypto_platform.cpp
+++ b/src/core/crypto/crypto_platform.cpp
@@ -32,8 +32,6 @@
 
 #include "openthread-core-config.h"
 
-#include <new>
-
 #include <mbedtls/aes.h>
 #include <mbedtls/md.h>
 #include <mbedtls/sha256.h>
@@ -45,6 +43,7 @@
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
+#include "common/new.hpp"
 #include "config/crypto.h"
 #include "crypto/hmac_sha256.hpp"
 #include "crypto/storage.hpp"
@@ -361,7 +360,7 @@ OT_TOOL_WEAK otError otPlatCryptoSha256Start(otCryptoContext *aContext)
     mbedtls_sha256_context *context;
 
     VerifyOrExit(aContext != nullptr, error = kErrorInvalidArgs);
-    VerifyOrExit(aContextSize >= sizeof(mbedtls_sha256_context), error = kErrorFailed);
+    VerifyOrExit(aContext->mContextSize >= sizeof(mbedtls_sha256_context), error = kErrorFailed);
     context = static_cast<mbedtls_sha256_context *>(aContext->mContext);
 
 #if (MBEDTLS_VERSION_NUMBER >= 0x03000000)

--- a/src/core/crypto/hkdf_sha256.cpp
+++ b/src/core/crypto/hkdf_sha256.cpp
@@ -37,20 +37,35 @@
 
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
+#include "openthread/platform/crypto.h"
 
 namespace ot {
 namespace Crypto {
 
+HkdfSha256::HkdfSha256()
+{
+    Error err = otPlatCryptoHkdfInit(&mContext);
+    OT_ASSERT(err == kErrorNone);
+    OT_UNUSED_VARIABLE(err);
+}
+
+HkdfSha256::~HkdfSha256()
+{
+    Error err = otPlatCryptoHkdfDeinit(&mContext);
+    OT_ASSERT(err == kErrorNone);
+    OT_UNUSED_VARIABLE(err);
+}
+
 void HkdfSha256::Extract(const uint8_t *aSalt, uint16_t aSaltLength, const Key &aInputKey)
 {
-    Error err = otPlatCryptoHkdfExtract(&mContext, sizeof(mContext), aSalt, aSaltLength, &aInputKey);
+    Error err = otPlatCryptoHkdfExtract(&mContext, aSalt, aSaltLength, &aInputKey);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }
 
 void HkdfSha256::Expand(const uint8_t *aInfo, uint16_t aInfoLength, uint8_t *aOutputKey, uint16_t aOutputKeyLength)
 {
-    Error err = otPlatCryptoHkdfExpand(&mContext, sizeof(mContext), aInfo, aInfoLength, aOutputKey, aOutputKeyLength);
+    Error err = otPlatCryptoHkdfExpand(&mContext, aInfo, aInfoLength, aOutputKey, aOutputKeyLength);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }

--- a/src/core/crypto/hkdf_sha256.cpp
+++ b/src/core/crypto/hkdf_sha256.cpp
@@ -44,7 +44,9 @@ namespace Crypto {
 
 HkdfSha256::HkdfSha256()
 {
-    Error err = otPlatCryptoHkdfInit(&mContext);
+    mContext.mContext     = mContextStorage;
+    mContext.mContextSize = sizeof(mContextStorage);
+    Error err             = otPlatCryptoHkdfInit(&mContext);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }

--- a/src/core/crypto/hkdf_sha256.cpp
+++ b/src/core/crypto/hkdf_sha256.cpp
@@ -37,23 +37,28 @@
 
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
+#include "common/error.hpp"
 #include "openthread/platform/crypto.h"
 
 namespace ot {
 namespace Crypto {
 
-HkdfSha256::HkdfSha256()
+HkdfSha256::HkdfSha256(void)
 {
+    Error err = kErrorNone;
+
     mContext.mContext     = mContextStorage;
     mContext.mContextSize = sizeof(mContextStorage);
-    Error err             = otPlatCryptoHkdfInit(&mContext);
+    err                   = otPlatCryptoHkdfInit(&mContext);
+
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }
 
-HkdfSha256::~HkdfSha256()
+HkdfSha256::~HkdfSha256(void)
 {
     Error err = otPlatCryptoHkdfDeinit(&mContext);
+
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }

--- a/src/core/crypto/hkdf_sha256.hpp
+++ b/src/core/crypto/hkdf_sha256.hpp
@@ -99,7 +99,7 @@ public:
 
 private:
     otCryptoContext mContext;
-    OT_DEFINE_ALIGNED_VAR(mContextStorage, OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE, uint64_t);
+    OT_DEFINE_ALIGNED_VAR(mContextStorage, kHkdfContextSize, uint64_t);
 };
 
 /**

--- a/src/core/crypto/hkdf_sha256.hpp
+++ b/src/core/crypto/hkdf_sha256.hpp
@@ -40,6 +40,7 @@
 #include <psa/crypto.h>
 
 #include "crypto/hmac_sha256.hpp"
+#include "openthread/platform/crypto.h"
 
 namespace ot {
 namespace Crypto {
@@ -58,6 +59,18 @@ namespace Crypto {
 class HkdfSha256
 {
 public:
+    /**
+     * Constructor to initialize the context.
+     *
+     */
+    HkdfSha256();
+
+    /**
+     * Destructor to free the context.
+     *
+     */
+    ~HkdfSha256();
+
     /**
      * This method performs the HKDF Extract step.
      *
@@ -85,13 +98,7 @@ public:
     void Expand(const uint8_t *aInfo, uint16_t aInfoLength, uint8_t *aOutputKey, uint16_t aOutputKeyLength);
 
 private:
-    union HkdfContext
-    {
-        HmacSha256::Hash               mPrk; // Pseudo-Random Key (derived from Extract step).
-        psa_key_derivation_operation_t mOperation;
-    };
-
-    HkdfContext mContext;
+    otCryptoContext mContext;
 };
 
 /**

--- a/src/core/crypto/hkdf_sha256.hpp
+++ b/src/core/crypto/hkdf_sha256.hpp
@@ -37,8 +37,7 @@
 
 #include "openthread-core-config.h"
 
-#include <psa/crypto.h>
-
+#include "common/code_utils.hpp"
 #include "crypto/hmac_sha256.hpp"
 #include "openthread/platform/crypto.h"
 
@@ -99,6 +98,7 @@ public:
 
 private:
     otCryptoContext mContext;
+    OT_DEFINE_ALIGNED_VAR(mContextStorage, OPENTHREAD_CONFIG_HKDF_CONTEXT_SIZE, uint64_t);
 };
 
 /**

--- a/src/core/crypto/hkdf_sha256.hpp
+++ b/src/core/crypto/hkdf_sha256.hpp
@@ -38,6 +38,7 @@
 #include "openthread-core-config.h"
 
 #include "common/code_utils.hpp"
+#include "crypto/context_size.hpp"
 #include "crypto/hmac_sha256.hpp"
 #include "openthread/platform/crypto.h"
 
@@ -62,13 +63,13 @@ public:
      * Constructor to initialize the context.
      *
      */
-    HkdfSha256();
+    HkdfSha256(void);
 
     /**
      * Destructor to free the context.
      *
      */
-    ~HkdfSha256();
+    ~HkdfSha256(void);
 
     /**
      * This method performs the HKDF Extract step.

--- a/src/core/crypto/hmac_sha256.cpp
+++ b/src/core/crypto/hmac_sha256.cpp
@@ -40,35 +40,35 @@ namespace Crypto {
 
 HmacSha256::HmacSha256(void)
 {
-    Error err = otPlatCryptoHmacSha256Init(&mContext, sizeof(mContext));
+    Error err = otPlatCryptoHmacSha256Init(&mContext);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }
 
 HmacSha256::~HmacSha256(void)
 {
-    Error err = otPlatCryptoHmacSha256Deinit(&mContext, sizeof(mContext));
+    Error err = otPlatCryptoHmacSha256Deinit(&mContext);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }
 
 void HmacSha256::Start(const Key &aKey)
 {
-    Error err = otPlatCryptoHmacSha256Start(&mContext, sizeof(mContext), &aKey);
+    Error err = otPlatCryptoHmacSha256Start(&mContext, &aKey);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }
 
 void HmacSha256::Update(const void *aBuf, uint16_t aBufLength)
 {
-    Error err = otPlatCryptoHmacSha256Update(&mContext, sizeof(mContext), aBuf, aBufLength);
+    Error err = otPlatCryptoHmacSha256Update(&mContext, aBuf, aBufLength);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }
 
 void HmacSha256::Finish(Hash &aHash)
 {
-    Error err = otPlatCryptoHmacSha256Finish(&mContext, sizeof(mContext), aHash.m8, Hash::kSize);
+    Error err = otPlatCryptoHmacSha256Finish(&mContext, aHash.m8, Hash::kSize);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }

--- a/src/core/crypto/hmac_sha256.cpp
+++ b/src/core/crypto/hmac_sha256.cpp
@@ -33,6 +33,7 @@
 
 #include "hmac_sha256.hpp"
 #include "common/debug.hpp"
+#include "common/error.hpp"
 #include "common/message.hpp"
 
 namespace ot {
@@ -40,9 +41,12 @@ namespace Crypto {
 
 HmacSha256::HmacSha256(void)
 {
+    Error err = kErrorNone;
+
     mContext.mContext     = mContextStorage;
     mContext.mContextSize = sizeof(mContextStorage);
-    Error err             = otPlatCryptoHmacSha256Init(&mContext);
+
+    err = otPlatCryptoHmacSha256Init(&mContext);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }

--- a/src/core/crypto/hmac_sha256.cpp
+++ b/src/core/crypto/hmac_sha256.cpp
@@ -40,7 +40,9 @@ namespace Crypto {
 
 HmacSha256::HmacSha256(void)
 {
-    Error err = otPlatCryptoHmacSha256Init(&mContext);
+    mContext.mContext     = mContextStorage;
+    mContext.mContextSize = sizeof(mContextStorage);
+    Error err             = otPlatCryptoHmacSha256Init(&mContext);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }

--- a/src/core/crypto/hmac_sha256.hpp
+++ b/src/core/crypto/hmac_sha256.hpp
@@ -41,6 +41,7 @@
 #include <openthread/platform/crypto.h>
 
 #include "common/code_utils.hpp"
+#include "crypto/context_size.hpp"
 #include "crypto/sha256.hpp"
 #include "crypto/storage.hpp"
 

--- a/src/core/crypto/hmac_sha256.hpp
+++ b/src/core/crypto/hmac_sha256.hpp
@@ -134,7 +134,7 @@ public:
 
 private:
     otCryptoContext mContext;
-    OT_DEFINE_ALIGNED_VAR(mContextStorage, OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE, uint64_t);
+    OT_DEFINE_ALIGNED_VAR(mContextStorage, kHmacSha256ContextSize, uint64_t);
 };
 
 /**

--- a/src/core/crypto/hmac_sha256.hpp
+++ b/src/core/crypto/hmac_sha256.hpp
@@ -38,9 +38,6 @@
 
 #include <stdint.h>
 
-#include <mbedtls/md.h>
-#include <psa/crypto.h>
-
 #include <openthread/platform/crypto.h>
 
 #include "crypto/sha256.hpp"
@@ -134,13 +131,7 @@ public:
     void Finish(Hash &aHash);
 
 private:
-    union HmacContext
-    {
-        psa_mac_operation_t  mOperation;
-        mbedtls_md_context_t mContext;
-    };
-
-    HmacContext mContext;
+    otCryptoContext mContext;
 };
 
 /**

--- a/src/core/crypto/hmac_sha256.hpp
+++ b/src/core/crypto/hmac_sha256.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/platform/crypto.h>
 
+#include "common/code_utils.hpp"
 #include "crypto/sha256.hpp"
 #include "crypto/storage.hpp"
 
@@ -132,6 +133,7 @@ public:
 
 private:
     otCryptoContext mContext;
+    OT_DEFINE_ALIGNED_VAR(mContextStorage, OPENTHREAD_CONFIG_HMAC_SHA256_CONTEXT_SIZE, uint64_t);
 };
 
 /**

--- a/src/core/crypto/sha256.cpp
+++ b/src/core/crypto/sha256.cpp
@@ -42,28 +42,28 @@ namespace Crypto {
 
 Sha256::Sha256(void)
 {
-    Error err = otPlatCryptoSha256Init(&mContext, sizeof(mContext));
+    Error err = otPlatCryptoSha256Init(&mContext);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }
 
 Sha256::~Sha256(void)
 {
-    Error err = otPlatCryptoSha256Deinit(&mContext, sizeof(mContext));
+    Error err = otPlatCryptoSha256Deinit(&mContext);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }
 
 void Sha256::Start(void)
 {
-    Error err = otPlatCryptoSha256Start(&mContext, sizeof(mContext));
+    Error err = otPlatCryptoSha256Start(&mContext);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }
 
 void Sha256::Update(const void *aBuf, uint16_t aBufLength)
 {
-    Error err = otPlatCryptoSha256Update(&mContext, sizeof(mContext), aBuf, aBufLength);
+    Error err = otPlatCryptoSha256Update(&mContext, aBuf, aBufLength);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }
@@ -83,7 +83,7 @@ void Sha256::Update(const Message &aMessage, uint16_t aOffset, uint16_t aLength)
 
 void Sha256::Finish(Hash &aHash)
 {
-    Error err = otPlatCryptoSha256Finish(&mContext, sizeof(mContext), aHash.m8, Hash::kSize);
+    Error err = otPlatCryptoSha256Finish(&mContext, aHash.m8, Hash::kSize);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }

--- a/src/core/crypto/sha256.cpp
+++ b/src/core/crypto/sha256.cpp
@@ -42,7 +42,9 @@ namespace Crypto {
 
 Sha256::Sha256(void)
 {
-    Error err = otPlatCryptoSha256Init(&mContext);
+    mContext.mContext     = mContextStorage;
+    mContext.mContextSize = sizeof(mContextStorage);
+    Error err             = otPlatCryptoSha256Init(&mContext);
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }

--- a/src/core/crypto/sha256.cpp
+++ b/src/core/crypto/sha256.cpp
@@ -42,9 +42,12 @@ namespace Crypto {
 
 Sha256::Sha256(void)
 {
+    Error err = kErrorNone;
+
     mContext.mContext     = mContextStorage;
     mContext.mContextSize = sizeof(mContextStorage);
-    Error err             = otPlatCryptoSha256Init(&mContext);
+    err                   = otPlatCryptoSha256Init(&mContext);
+
     OT_ASSERT(err == kErrorNone);
     OT_UNUSED_VARIABLE(err);
 }

--- a/src/core/crypto/sha256.hpp
+++ b/src/core/crypto/sha256.hpp
@@ -45,6 +45,7 @@
 #include "common/code_utils.hpp"
 #include "common/equatable.hpp"
 #include "common/type_traits.hpp"
+#include "crypto/context_size.hpp"
 
 namespace ot {
 

--- a/src/core/crypto/sha256.hpp
+++ b/src/core/crypto/sha256.hpp
@@ -38,9 +38,6 @@
 
 #include <stdint.h>
 
-#include <mbedtls/sha256.h>
-#include <psa/crypto.h>
-
 #include <openthread/crypto.h>
 #include <openthread/platform/crypto.h>
 
@@ -146,13 +143,7 @@ public:
     void Finish(Hash &aHash);
 
 private:
-    union Sha256Context
-    {
-        psa_hash_operation_t   mOperation;
-        mbedtls_sha256_context mContext;
-    };
-
-    Sha256Context mContext;
+    otCryptoContext mContext;
 };
 
 /**

--- a/src/core/crypto/sha256.hpp
+++ b/src/core/crypto/sha256.hpp
@@ -146,7 +146,7 @@ public:
 
 private:
     otCryptoContext mContext;
-    OT_DEFINE_ALIGNED_VAR(mContextStorage, OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE, uint64_t);
+    OT_DEFINE_ALIGNED_VAR(mContextStorage, kSha256ContextSize, uint64_t);
 };
 
 /**

--- a/src/core/crypto/sha256.hpp
+++ b/src/core/crypto/sha256.hpp
@@ -42,6 +42,7 @@
 #include <openthread/platform/crypto.h>
 
 #include "common/clearable.hpp"
+#include "common/code_utils.hpp"
 #include "common/equatable.hpp"
 #include "common/type_traits.hpp"
 
@@ -144,6 +145,7 @@ public:
 
 private:
     otCryptoContext mContext;
+    OT_DEFINE_ALIGNED_VAR(mContextStorage, OPENTHREAD_CONFIG_SHA256_CONTEXT_SIZE, uint64_t);
 };
 
 /**

--- a/src/core/openthread-core-config.h
+++ b/src/core/openthread-core-config.h
@@ -64,6 +64,7 @@
 #include "config/child_supervision.h"
 #include "config/coap.h"
 #include "config/commissioner.h"
+#include "config/crypto.h"
 #include "config/dataset_updater.h"
 #include "config/dhcp6_client.h"
 #include "config/dhcp6_server.h"


### PR DESCRIPTION
The context objects don't necessarily exist on every platform. 

This PR move the context to platform drivers to avoid build errors.