### PR TITLE
[mesh-forwarder] call `UpdateRoutes` on rx of first fragment frame

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1242,6 +1242,10 @@ void MeshForwarder::HandleFragment(const uint8_t *       aFrame,
     {
         uint16_t datagramSize = fragmentHeader.GetDatagramSize();
 
+#if OPENTHREAD_FTD
+        UpdateRoutes(aFrame, aFrameLength, aMacSource, aMacDest);
+#endif
+
         error = FrameToMessage(aFrame, aFrameLength, datagramSize, aMacSource, aMacDest, message);
         SuccessOrExit(error);
 


### PR DESCRIPTION
This commit ensures to call `UpdateRoutes()` on rx of a first lowpan
fragment frame. `UpdateRoutes()` can then update the snooped address
cache entries and check if the message is from a previous child (which
indicates that the child has switched to a new parent). This change
should help address an issue with "inform previous parent" behavior
not removing the child when `MULTI_RADIO` is enabled (due to frag
header added to the frames for duplication detection under
multi-radio).

---

See https://github.com/openthread/openthread/pull/7005#issuecomment-920606847 for more details on the "inform previous parent" issue.