### PR TITLE
[mac] fix the `Mac::NetworkName` length check (`length >= 1`)

### DIFF
--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -155,7 +155,6 @@ Error NetworkName::Set(const char *aNameString)
     Error    error;
     NameData data(aNameString, kMaxSize + 1);
 
-    VerifyOrExit(data.GetLength() >= 1, error = kErrorInvalidArgs);
     VerifyOrExit(IsValidUtf8String(aNameString), error = kErrorInvalidArgs);
 
     error = Set(data);
@@ -169,7 +168,7 @@ Error NetworkName::Set(const NameData &aNameData)
     Error   error  = kErrorNone;
     uint8_t newLen = static_cast<uint8_t>(StringLength(aNameData.GetBuffer(), aNameData.GetLength()));
 
-    VerifyOrExit(newLen <= kMaxSize, error = kErrorInvalidArgs);
+    VerifyOrExit((0 < newLen) && (newLen <= kMaxSize), error = kErrorInvalidArgs);
 
     // Ensure the new name does not match the current one.
     VerifyOrExit(memcmp(m8, aNameData.GetBuffer(), newLen) || (m8[newLen] != '\0'), error = kErrorAlready);

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -190,8 +190,7 @@ void TestMacNetworkName(void)
     SuccessOrQuit(networkName.Set(Mac::NameData(kName2, sizeof(kName2))));
     CompareNetworkName(networkName, kName2);
 
-    SuccessOrQuit(networkName.Set(Mac::NameData(kEmptyName, 0)));
-    CompareNetworkName(networkName, kEmptyName);
+    VerifyOrQuit(networkName.Set(Mac::NameData(kEmptyName, 0)) == kErrorInvalidArgs);
 
     SuccessOrQuit(networkName.Set(Mac::NameData(kLongName, sizeof(kLongName))));
     CompareNetworkName(networkName, kLongName);
@@ -199,8 +198,7 @@ void TestMacNetworkName(void)
     VerifyOrQuit(networkName.Set(Mac::NameData(kLongName, sizeof(kLongName) - 1)) == kErrorAlready,
                  "failed to detect duplicate");
 
-    SuccessOrQuit(networkName.Set(Mac::NameData(nullptr, 0)));
-    CompareNetworkName(networkName, kEmptyName);
+    VerifyOrQuit(networkName.Set(kEmptyName) == kErrorInvalidArgs);
 
     SuccessOrQuit(networkName.Set(Mac::NameData(kName1, sizeof(kName1))));
 


### PR DESCRIPTION
This commit fixes the `NetworkName` check (for its length to be larger
than zero) which was recently added in commit e2f0afab5d. This commit
moves the name length check to method `Set(const NameData &aNameData)`
and after the `newLen` is calculated.

This commit also updates `TestMacNetworkName()` in unit test to verify
that setting the network name to an empty string correctly fails with
`kErrorInvalidArgs`.

----

- This was added in https://github.com/openthread/openthread/pull/6988
- Please see [comment in #6988](https://github.com/openthread/openthread/pull/6988/files#r710812831) for why we need the change