### PR TITLE
[message] update `Message::Chunk` definitions to use `Data`

### DIFF
--- a/src/core/common/data.hpp
+++ b/src/core/common/data.hpp
@@ -146,6 +146,14 @@ public:
     LengthType GetLength(void) const { return mLength; }
 
     /**
+     * This method sets the data length.
+     *
+     * @param[in] aLength   The data length (number of bytes).
+     *
+     */
+    void SetLength(LengthType aLength) { mLength = aLength; }
+
+    /**
      * This method copies the `Data` bytes to a given buffer.
      *
      * It is up to the caller to ensure that @p aBuffer has enough space for the current data length.
@@ -153,7 +161,20 @@ public:
      * @param[out] aBuffer  The buffer to copy the bytes into.
      *
      */
-    void CopyBytesTo(uint8_t *aBuffer) const { memcpy(aBuffer, mBuffer, mLength); }
+    void CopyBytesTo(void *aBuffer) const { memcpy(aBuffer, mBuffer, mLength); }
+
+    /**
+     * This method compares the `Data` content with the bytes from a given buffer.
+     *
+     * It is up to the caller to ensure that @p aBuffer has enough bytes to compare with the current data length.
+     *
+     * @param[in] aBuffer   A pointer to a buffer to compare with the data.
+     *
+     * @retval TRUE   The `Data` content matches the bytes in @p aBuffer.
+     * @retval FALSE  The `Data` content does not match the byes in @p aBuffer.
+     *
+     */
+    bool MatchesBytesIn(const void *aBuffer) const { return memcmp(mBuffer, aBuffer, mLength) == 0; }
 
     /**
      * This method overloads operator `==` to compare the `Data` content with the content from another one.
@@ -166,7 +187,7 @@ public:
      */
     bool operator==(const Data &aOtherData) const
     {
-        return (mLength == aOtherData.mLength) && (memcmp(mBuffer, aOtherData.mBuffer, mLength) == 0);
+        return (mLength == aOtherData.mLength) && MatchesBytesIn(aOtherData.mBuffer);
     }
 
     /**
@@ -183,7 +204,7 @@ public:
      */
     bool StartsWith(const Data &aOtherData) const
     {
-        return (mLength >= aOtherData.mLength) && (memcmp(mBuffer, aOtherData.mBuffer, aOtherData.mLength) == 0);
+        return (mLength >= aOtherData.mLength) && aOtherData.MatchesBytesIn(mBuffer);
     }
 
 private:

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -43,6 +43,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/const_cast.hpp"
+#include "common/data.hpp"
 #include "common/encoding.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
@@ -1208,30 +1209,31 @@ protected:
     void     SetReserved(uint16_t aReservedHeader) { GetMetadata().mReserved = aReservedHeader; }
 
 private:
-    struct Chunk
+    class Chunk : public Data<kWithUint16Length>
     {
-        const uint8_t *GetData(void) const { return mData; }
-        uint16_t       GetLength(void) const { return mLength; }
+    public:
+        const Buffer *GetBuffer(void) const { return mBuffer; }
+        void          SetBuffer(const Buffer *aBuffer) { mBuffer = aBuffer; }
 
-        const uint8_t *mData;   // Pointer to start of chunk data buffer.
-        uint16_t       mLength; // Length of chunk data (in bytes).
-        const Buffer * mBuffer; // Buffer containing the chunk
+    private:
+        const Buffer *mBuffer; // Buffer containing the chunk
     };
 
-    struct WritableChunk : public Chunk
+    class MutableChunk : public Chunk
     {
-        uint8_t *GetData(void) const { return AsNonConst(mData); }
+    public:
+        uint8_t *GetBytes(void) { return AsNonConst(Chunk::GetBytes()); }
     };
 
-    void GetFirstChunk(uint16_t aOffset, uint16_t &aLength, Chunk &chunk) const;
+    void GetFirstChunk(uint16_t aOffset, uint16_t &aLength, Chunk &aChunk) const;
     void GetNextChunk(uint16_t &aLength, Chunk &aChunk) const;
 
-    void GetFirstChunk(uint16_t aOffset, uint16_t &aLength, WritableChunk &aChunk)
+    void GetFirstChunk(uint16_t aOffset, uint16_t &aLength, MutableChunk &aChunk)
     {
         AsConst(this)->GetFirstChunk(aOffset, aLength, static_cast<Chunk &>(aChunk));
     }
 
-    void GetNextChunk(uint16_t &aLength, WritableChunk &aChunk)
+    void GetNextChunk(uint16_t &aLength, MutableChunk &aChunk)
     {
         AsConst(this)->GetNextChunk(aLength, static_cast<Chunk &>(aChunk));
     }

--- a/src/core/crypto/hmac_sha256.cpp
+++ b/src/core/crypto/hmac_sha256.cpp
@@ -81,7 +81,7 @@ void HmacSha256::Update(const Message &aMessage, uint16_t aOffset, uint16_t aLen
 
     while (chunk.GetLength() > 0)
     {
-        Update(chunk.GetData(), chunk.GetLength());
+        Update(chunk.GetBytes(), chunk.GetLength());
         aMessage.GetNextChunk(aLength, chunk);
     }
 }

--- a/src/core/crypto/sha256.cpp
+++ b/src/core/crypto/sha256.cpp
@@ -76,7 +76,7 @@ void Sha256::Update(const Message &aMessage, uint16_t aOffset, uint16_t aLength)
 
     while (chunk.GetLength() > 0)
     {
-        Update(chunk.GetData(), chunk.GetLength());
+        Update(chunk.GetBytes(), chunk.GetLength());
         aMessage.GetNextChunk(aLength, chunk);
     }
 }

--- a/src/core/net/checksum.cpp
+++ b/src/core/net/checksum.cpp
@@ -110,7 +110,7 @@ void Checksum::Calculate(const Ip6::Address &aSource,
 
     while (chunk.GetLength() > 0)
     {
-        AddData(chunk.GetData(), chunk.GetLength());
+        AddData(chunk.GetBytes(), chunk.GetLength());
         aMessage.GetNextChunk(length, chunk);
     }
 }

--- a/tests/unit/test_data.cpp
+++ b/tests/unit/test_data.cpp
@@ -66,6 +66,7 @@ template <DataLengthType kDataLengthType> void TestData(void)
     data.CopyBytesTo(buffer);
     VerifyOrQuit(memcmp(buffer, kData, sizeof(kData)) == 0);
     VerifyOrQuit(buffer[sizeof(kData)] == 0);
+    VerifyOrQuit(data.MatchesBytesIn(buffer));
 
     data2.InitFrom(kDataCopy);
     VerifyOrQuit(data2.GetLength() == sizeof(kDataCopy));
@@ -74,7 +75,10 @@ template <DataLengthType kDataLengthType> void TestData(void)
     VerifyOrQuit(data.StartsWith(data2));
     VerifyOrQuit(data2.StartsWith(data));
 
-    data2.Init(kDataCopy, sizeof(kDataCopy) - 1);
+    data2.SetLength(sizeof(kDataCopy) - 1);
+    VerifyOrQuit(data2.GetLength() == sizeof(kDataCopy) - 1);
+    VerifyOrQuit(data2.GetBytes() == &kDataCopy[0]);
+    VerifyOrQuit(data2.MatchesBytesIn(kDataCopy));
     VerifyOrQuit(data != data2);
     VerifyOrQuit(data.StartsWith(data2));
     VerifyOrQuit(!data2.StartsWith(data));


### PR DESCRIPTION
This commit updates the `Message::Chunk` type to use `Data` as its
base class (thus inheriting the common helper methods from it) which
helps simplify its use. This commit also adds couple of new methods in
`Data` class (method `SetLength()` to  change the `Data` length, and
`MatchesBytesIn()` to compare the `Data` content with bytes from a
given buffer). The `test_data` unit test is also updated to check the
newly added `Data` methods.