### PR TITLE
[mac] remove "packed" requirement for `Mac::KeyMaterial`

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (167)
+#define OPENTHREAD_API_VERSION (168)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -212,21 +212,14 @@ typedef otCryptoKeyRef otMacKeyRef;
  * This structure represents a MAC Key.
  *
  */
-OT_TOOL_PACKED_BEGIN
-struct otMacKeyMaterial
+typedef struct otMacKeyMaterial
 {
     union
     {
         otMacKeyRef mKeyRef; ///< Reference to the key stored.
         otMacKey    mKey;    ///< Key stored as literal.
     } mKeyMaterial;
-} OT_TOOL_PACKED_END;
-
-/**
- * This structure represents a MAC Key reference.
- *
- */
-typedef struct otMacKeyMaterial otMacKeyMaterial;
+} otMacKeyMaterial;
 
 /**
  * This enumeration defines constants about key types.

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -439,7 +439,6 @@ typedef otMacKeyRef KeyRef;
  * This class represents a MAC Key Material.
  *
  */
-OT_TOOL_PACKED_BEGIN
 class KeyMaterial : public otMacKeyMaterial, public Unequatable<KeyMaterial>
 {
 public:
@@ -549,7 +548,7 @@ private:
 #endif
     Key &GetKey(void) { return static_cast<Key &>(mKeyMaterial.mKey); }
     void SetKey(const Key &aKey) { mKeyMaterial.mKey = aKey; }
-} OT_TOOL_PACKED_END;
+};
 
 /**
  * This structure represents an IEEE 802.15.4 Extended PAN Identifier.


### PR DESCRIPTION
This commit removes the `OT_TOOL_PACKED` requirement from types
`otMacKeyMaterial` and `Mac::KeyMaterial`. Generally, we define a
type as "packed"  if it may be embedded in a message/buffer (e.g. a
TLV) and/or may be cast from a buffer pointer. Neither case applies
to `KeyMaterial`.
