### PR TITLE
[meshcop] ensure msg has timestamp TLV in `DatasetManager::HandleSet()`

### DIFF
--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -121,10 +121,17 @@ Error DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInfo 
         VerifyOrExit(pendingTimestamp.IsValid());
     }
 
-    // verify the request includes a timestamp that is ahead of the locally stored value
-    timestamp = (type == Tlv::kActiveTimestamp) ? static_cast<Timestamp *>(&activeTimestamp)
-                                                : static_cast<Timestamp *>(&pendingTimestamp);
+    if (type == Tlv::kActiveTimestamp)
+    {
+        timestamp = static_cast<Timestamp *>(&activeTimestamp);
+    }
+    else
+    {
+        VerifyOrExit(pendingTimestamp.GetLength() > 0);
+        timestamp = static_cast<Timestamp *>(&pendingTimestamp);
+    }
 
+    // verify the request includes a timestamp that is ahead of the locally stored value
     VerifyOrExit(mLocal.Compare(timestamp) > 0);
 
     // check channel


### PR DESCRIPTION
This commit fixes `DatasetManager::HandleSet()` to add a check to
ensure that the message contains `PendingTimestampTlv` when the
Pending Dataset is being updated.