### PR TITLE
[dtls] ensure mbedtls_ssl_key_export_type is defined

### DIFF
--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -391,6 +391,7 @@ private:
     static int HandleMbedtlsTransmit(void *aContext, const unsigned char *aBuf, size_t aLength);
     int        HandleMbedtlsTransmit(const unsigned char *aBuf, size_t aLength);
 
+#ifdef MBEDTLS_SSL_EXPORT_KEYS
 #if (MBEDTLS_VERSION_NUMBER >= 0x03000000)
 
     static void HandleMbedtlsExportKeys(void *                      aContext,
@@ -422,7 +423,8 @@ private:
                                        size_t               aKeyLength,
                                        size_t               aIvLength);
 
-#endif
+#endif // (MBEDTLS_VERSION_NUMBER >= 0x03000000)
+#endif // MBEDTLS_SSL_EXPORT_KEYS
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);


### PR DESCRIPTION
For certain external mbedTLS configurations, there is no much sense to define `MBEDTLS_SSL_EXPORT_KEYS` when OT has Joiner || Commissioner || DTLS functionalities disabled.

This commit only ensures that such builds don't fail. The `mbedtls_ssl_key_export_type` type is defined only when `MBEDTLS_SSL_EXPORT_KEYS` is defined, while `dtls.hpp` is always taken into the build process.