### PR TITLE
[mac] update `Mac::NameData` to use `Data`

### DIFF
--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -43,6 +43,7 @@
 #include <openthread/thread.h>
 
 #include "common/clearable.hpp"
+#include "common/data.hpp"
 #include "common/equatable.hpp"
 #include "common/string.hpp"
 #include "crypto/storage.hpp"
@@ -583,8 +584,10 @@ public:
  * @note The char array does NOT need to be null terminated.
  *
  */
-class NameData
+class NameData : private Data<kWithUint8Length>
 {
+    friend class NetworkName;
+
 public:
     /**
      * This constructor initializes the NameData object.
@@ -593,11 +596,7 @@ public:
      * @param[in] aLength   The length (number of chars) in the buffer.
      *
      */
-    NameData(const char *aBuffer, uint8_t aLength)
-        : mBuffer(aBuffer)
-        , mLength(aLength)
-    {
-    }
+    NameData(const char *aBuffer, uint8_t aLength) { Init(aBuffer, aLength); }
 
     /**
      * This method returns the pointer to char buffer (not necessarily null terminated).
@@ -605,7 +604,7 @@ public:
      * @returns The pointer to the char buffer.
      *
      */
-    const char *GetBuffer(void) const { return mBuffer; }
+    const char *GetBuffer(void) const { return reinterpret_cast<const char *>(GetBytes()); }
 
     /**
      * This method returns the length (number of chars in buffer).
@@ -613,7 +612,7 @@ public:
      * @returns The name length.
      *
      */
-    uint8_t GetLength(void) const { return mLength; }
+    uint8_t GetLength(void) const { return Data<kWithUint8Length>::GetLength(); }
 
     /**
      * This method copies the name data into a given char buffer with a given size.
@@ -628,17 +627,13 @@ public:
      *
      */
     uint8_t CopyTo(char *aBuffer, uint8_t aMaxSize) const;
-
-private:
-    const char *mBuffer;
-    uint8_t     mLength;
 };
 
 /**
  * This structure represents an IEEE802.15.4 Network Name.
  *
  */
-class NetworkName : public otNetworkName
+class NetworkName : public otNetworkName, public Unequatable<NetworkName>
 {
 public:
     /**

--- a/tests/unit/test_mac_frame.cpp
+++ b/tests/unit/test_mac_frame.cpp
@@ -175,6 +175,7 @@ void TestMacNetworkName(void)
     char             buffer[sizeof(kTooLongName) + 2];
     uint8_t          len;
     Mac::NetworkName networkName;
+    Mac::NetworkName networkName2;
 
     CompareNetworkName(networkName, kEmptyName);
 
@@ -224,6 +225,12 @@ void TestMacNetworkName(void)
     VerifyOrQuit(len == sizeof(kName1) - 1, "NameData::CopyTo() failed");
     VerifyOrQuit(memcmp(buffer, kName1, sizeof(kName1) - 1) == 0, "NameData::CopyTo() failed");
     VerifyOrQuit(buffer[sizeof(kName1)] == 0, "NameData::CopyTo() failed");
+
+    SuccessOrQuit(networkName2.Set(Mac::NameData(kName1, sizeof(kName1))));
+    VerifyOrQuit(networkName == networkName2);
+
+    SuccessOrQuit(networkName2.Set(kName2));
+    VerifyOrQuit(networkName != networkName2);
 }
 
 void TestMacHeader(void)


### PR DESCRIPTION
This commit updates `Mac::NameData` to use `Data` as its base
class and then use its method in the `NameData` implementation.