### PR TITLE
[meshcop] update handling of Active/Pending Timestamp TLVs

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -191,7 +191,7 @@ void Dataset::ConvertTo(Info &aDatasetInfo) const
         switch (cur->GetType())
         {
         case Tlv::kActiveTimestamp:
-            aDatasetInfo.SetActiveTimestamp(static_cast<const ActiveTimestampTlv *>(cur)->GetSeconds());
+            aDatasetInfo.SetActiveTimestamp(static_cast<const ActiveTimestampTlv *>(cur)->GetTimestamp().GetSeconds());
             break;
 
         case Tlv::kChannel:
@@ -235,7 +235,8 @@ void Dataset::ConvertTo(Info &aDatasetInfo) const
             break;
 
         case Tlv::kPendingTimestamp:
-            aDatasetInfo.SetPendingTimestamp(static_cast<const PendingTimestampTlv *>(cur)->GetSeconds());
+            aDatasetInfo.SetPendingTimestamp(
+                static_cast<const PendingTimestampTlv *>(cur)->GetTimestamp().GetSeconds());
             break;
 
         case Tlv::kPskc:
@@ -288,20 +289,20 @@ Error Dataset::SetFrom(const Info &aDatasetInfo)
 
     if (aDatasetInfo.IsActiveTimestampPresent())
     {
-        ActiveTimestampTlv tlv;
-        tlv.Init();
-        tlv.SetSeconds(aDatasetInfo.GetActiveTimestamp());
-        tlv.SetTicks(0);
-        IgnoreError(SetTlv(tlv));
+        Timestamp timestamp;
+
+        timestamp.Clear();
+        timestamp.SetSeconds(aDatasetInfo.GetActiveTimestamp());
+        IgnoreError(SetTlv(Tlv::kActiveTimestamp, timestamp));
     }
 
     if (aDatasetInfo.IsPendingTimestampPresent())
     {
-        PendingTimestampTlv tlv;
-        tlv.Init();
-        tlv.SetSeconds(aDatasetInfo.GetPendingTimestamp());
-        tlv.SetTicks(0);
-        IgnoreError(SetTlv(tlv));
+        Timestamp timestamp;
+
+        timestamp.Clear();
+        timestamp.SetSeconds(aDatasetInfo.GetPendingTimestamp());
+        IgnoreError(SetTlv(Tlv::kPendingTimestamp, timestamp));
     }
 
     if (aDatasetInfo.IsDelayPresent())
@@ -371,25 +372,27 @@ Error Dataset::SetFrom(const Info &aDatasetInfo)
     return error;
 }
 
-const Timestamp *Dataset::GetTimestamp(Type aType) const
+Error Dataset::GetTimestamp(Type aType, Timestamp &aTimestamp) const
 {
-    const Timestamp *timestamp = nullptr;
+    Error error = kErrorNone;
 
     if (aType == kActive)
     {
         const ActiveTimestampTlv *tlv = GetTlv<ActiveTimestampTlv>();
-        VerifyOrExit(tlv != nullptr);
-        timestamp = static_cast<const Timestamp *>(tlv);
+
+        VerifyOrExit(tlv != nullptr, error = kErrorNotFound);
+        aTimestamp = tlv->GetTimestamp();
     }
     else
     {
         const PendingTimestampTlv *tlv = GetTlv<PendingTimestampTlv>();
-        VerifyOrExit(tlv != nullptr);
-        timestamp = static_cast<const Timestamp *>(tlv);
+
+        VerifyOrExit(tlv != nullptr, error = kErrorNotFound);
+        aTimestamp = tlv->GetTimestamp();
     }
 
 exit:
-    return timestamp;
+    return error;
 }
 
 void Dataset::SetTimestamp(Type aType, const Timestamp &aTimestamp)

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -729,19 +729,21 @@ public:
     TimeMilli GetUpdateTime(void) const { return mUpdateTime; }
 
     /**
-     * This method returns a reference to the Timestamp.
+     * This method gets the Timestamp (Active or Pending).
      *
-     * @param[in]  aType       The type of the dataset, active or pending.
+     * @param[in]  aType       The type: active or pending.
+     * @param[out] aTimestamp  A reference to a `Timestamp` to output the value.
      *
-     * @returns A pointer to the Timestamp.
+     * @retval kErrorNone      Timestamp was read successfully. @p aTimestamp is updated.
+     * @retval kErrorNotFound  Could not find the requested Timestamp TLV.
      *
      */
-    const Timestamp *GetTimestamp(Type aType) const;
+    Error GetTimestamp(Type aType, Timestamp &aTimestamp) const;
 
     /**
      * This method sets the Timestamp value.
      *
-     * @param[in] aType        The type of the dataset, active or pending.
+     * @param[in] aType        The type: active or pending.
      * @param[in] aTimestamp   A Timestamp.
      *
      */

--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -55,35 +55,28 @@ DatasetLocal::DatasetLocal(Instance &aInstance, Dataset::Type aType)
     , mTimestampPresent(false)
     , mSaved(false)
 {
-    mTimestamp.Init();
+    mTimestamp.Clear();
 }
 
 void DatasetLocal::Clear(void)
 {
     IgnoreError(Get<Settings>().DeleteOperationalDataset(IsActive()));
-    mTimestamp.Init();
+    mTimestamp.Clear();
     mTimestampPresent = false;
     mSaved            = false;
 }
 
 Error DatasetLocal::Restore(Dataset &aDataset)
 {
-    const Timestamp *timestamp;
-    Error            error;
+    Error error;
 
     mTimestampPresent = false;
 
     error = Read(aDataset);
     SuccessOrExit(error);
 
-    mSaved    = true;
-    timestamp = aDataset.GetTimestamp(mType);
-
-    if (timestamp != nullptr)
-    {
-        mTimestamp        = *timestamp;
-        mTimestampPresent = true;
-    }
+    mSaved            = true;
+    mTimestampPresent = (aDataset.GetTimestamp(mType, mTimestamp) == kErrorNone);
 
 exit:
     return error;
@@ -177,8 +170,7 @@ Error DatasetLocal::Save(const otOperationalDatasetTlvs &aDataset)
 
 Error DatasetLocal::Save(const Dataset &aDataset)
 {
-    const Timestamp *timestamp;
-    Error            error = kErrorNone;
+    Error error = kErrorNone;
 
     if (aDataset.GetSize() == 0)
     {
@@ -194,19 +186,8 @@ Error DatasetLocal::Save(const Dataset &aDataset)
         otLogInfoMeshCoP("%s dataset set", Dataset::TypeToString(mType));
     }
 
-    timestamp = aDataset.GetTimestamp(mType);
-
-    if (timestamp != nullptr)
-    {
-        mTimestamp        = *timestamp;
-        mTimestampPresent = true;
-    }
-    else
-    {
-        mTimestampPresent = false;
-    }
-
-    mUpdateTime = TimerMilli::GetNow();
+    mTimestampPresent = (aDataset.GetTimestamp(mType, mTimestamp) == kErrorNone);
+    mUpdateTime       = TimerMilli::GetNow();
 
 exit:
     return error;

--- a/src/core/meshcop/dataset_updater.cpp
+++ b/src/core/meshcop/dataset_updater.cpp
@@ -150,7 +150,8 @@ void DatasetUpdater::PreparePendingDataset(void)
 
     {
         ActiveTimestampTlv *tlv = dataset.GetTlv<ActiveTimestampTlv>();
-        tlv->AdvanceRandomTicks();
+
+        tlv->GetTimestamp().AdvanceRandomTicks();
     }
 
     SuccessOrExit(error = Get<PendingDataset>().Save(dataset));

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -1003,7 +1003,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ActiveTimestampTlv : public Tlv, public Timestamp, public SimpleTlvInfo<Tlv::kActiveTimestamp, Timestamp>
+class ActiveTimestampTlv : public Tlv, public SimpleTlvInfo<Tlv::kActiveTimestamp, Timestamp>
 {
 public:
     /**
@@ -1014,7 +1014,7 @@ public:
     {
         SetType(kActiveTimestamp);
         SetLength(sizeof(*this) - sizeof(Tlv));
-        Timestamp::Init();
+        mTimestamp.Clear();
     }
 
     /**
@@ -1025,6 +1025,33 @@ public:
      *
      */
     bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(Tlv); }
+
+    /**
+     * This method gets the timestamp.
+     *
+     * @returns The timestamp.
+     *
+     */
+    const Timestamp &GetTimestamp(void) const { return mTimestamp; }
+
+    /**
+     * This method returns a reference to the timestamp.
+     *
+     * @returns A reference to the timestamp.
+     *
+     */
+    Timestamp &GetTimestamp(void) { return mTimestamp; }
+
+    /**
+     * This method sets the timestamp.
+     *
+     * @param[in] aTimestamp   The new timestamp.
+     *
+     */
+    void SetTimestamp(const Timestamp &aTimestamp) { mTimestamp = aTimestamp; }
+
+private:
+    Timestamp mTimestamp;
 } OT_TOOL_PACKED_END;
 
 /**
@@ -1137,7 +1164,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class PendingTimestampTlv : public Tlv, public Timestamp, public SimpleTlvInfo<Tlv::kPendingTimestamp, Timestamp>
+class PendingTimestampTlv : public Tlv, public SimpleTlvInfo<Tlv::kPendingTimestamp, Timestamp>
 {
 public:
     /**
@@ -1148,7 +1175,7 @@ public:
     {
         SetType(kPendingTimestamp);
         SetLength(sizeof(*this) - sizeof(Tlv));
-        Timestamp::Init();
+        mTimestamp.Clear();
     }
 
     /**
@@ -1159,6 +1186,33 @@ public:
      *
      */
     bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(Tlv); }
+
+    /**
+     * This method gets the timestamp.
+     *
+     * @returns The timestamp.
+     *
+     */
+    const Timestamp &GetTimestamp(void) const { return mTimestamp; }
+
+    /**
+     * This method returns a reference to the timestamp.
+     *
+     * @returns A reference to the timestamp.
+     *
+     */
+    Timestamp &GetTimestamp(void) { return mTimestamp; }
+
+    /**
+     * This method sets the timestamp.
+     *
+     * @param[in] aTimestamp   The new timestamp.
+     *
+     */
+    void SetTimestamp(const Timestamp &aTimestamp) { mTimestamp = aTimestamp; }
+
+private:
+    Timestamp mTimestamp;
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/meshcop/timestamp.hpp
+++ b/src/core/meshcop/timestamp.hpp
@@ -41,6 +41,7 @@
 
 #include <openthread/platform/toolchain.h>
 
+#include "common/clearable.hpp"
 #include "common/encoding.hpp"
 #include "common/random.hpp"
 
@@ -55,15 +56,9 @@ using ot::Encoding::BigEndian::HostSwap32;
  *
  */
 OT_TOOL_PACKED_BEGIN
-class Timestamp
+class Timestamp : public Clearable<Timestamp>
 {
 public:
-    /**
-     * This method initializes the Timestamp
-     *
-     */
-    void Init(void) { memset(this, 0, sizeof(*this)); }
-
     /**
      * This method compares this timestamp to another.
      *

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -219,6 +219,18 @@ typedef UintTlvInfo<Tlv::kVersion, uint16_t> VersionTlv;
 typedef UintTlvInfo<Tlv::kPanId, uint16_t> PanIdTlv;
 
 /**
+ * This class defines Active Timestamp TLV constants and types.
+ *
+ */
+typedef SimpleTlvInfo<Tlv::kActiveTimestamp, MeshCoP::Timestamp> ActiveTimestampTlv;
+
+/**
+ * This class defines Pending Timestamp TLV constants and types.
+ *
+ */
+typedef SimpleTlvInfo<Tlv::kPendingTimestamp, MeshCoP::Timestamp> PendingTimestampTlv;
+
+/**
  * This class defines CSL Timeout TLV constants and types.
  *
  */
@@ -1190,68 +1202,6 @@ private:
 } OT_TOOL_PACKED_END;
 
 #endif // OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-
-/**
- * This class implements Active Timestamp TLV generation and parsing.
- *
- */
-OT_TOOL_PACKED_BEGIN
-class ActiveTimestampTlv : public Tlv,
-                           public MeshCoP::Timestamp,
-                           public SimpleTlvInfo<Tlv::kActiveTimestamp, MeshCoP::Timestamp>
-{
-public:
-    /**
-     * This method initializes the TLV.
-     *
-     */
-    void Init(void)
-    {
-        SetType(Tlv::kActiveTimestamp);
-        SetLength(sizeof(*this) - sizeof(Tlv));
-        Timestamp::Init();
-    }
-
-    /**
-     * This method indicates whether or not the TLV appears to be well-formed.
-     *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     *
-     */
-    bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(Tlv); }
-} OT_TOOL_PACKED_END;
-
-/**
- * This class implements Pending Timestamp TLV generation and parsing.
- *
- */
-OT_TOOL_PACKED_BEGIN
-class PendingTimestampTlv : public Tlv,
-                            public MeshCoP::Timestamp,
-                            public SimpleTlvInfo<Tlv::kPendingTimestamp, MeshCoP::Timestamp>
-{
-public:
-    /**
-     * This method initializes the TLV.
-     *
-     */
-    void Init(void)
-    {
-        SetType(Tlv::kPendingTimestamp);
-        SetLength(sizeof(*this) - sizeof(Tlv));
-        Timestamp::Init();
-    }
-
-    /**
-     * This method indicates whether or not the TLV appears to be well-formed.
-     *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     *
-     */
-    bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(Tlv); }
-} OT_TOOL_PACKED_END;
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE)
 /**


### PR DESCRIPTION
This commit updates and simplifies processing of Active/Pending
Timestamp TLVs (in MeshCoP and MLE) by using TLV helper methods
that read/write the TLV's timestamp value from/in a message.