### PR TITLE
[cli] skip CLI prompt when emitting command input/output to logs

### DIFF
--- a/src/cli/cli_output.hpp
+++ b/src/cli/cli_output.hpp
@@ -41,6 +41,7 @@
 #include <openthread/cli.h>
 
 #include "cli_config.h"
+#include "utils/parse_cmdline.hpp"
 
 namespace ot {
 namespace Cli {
@@ -292,14 +293,21 @@ public:
     }
 
 protected:
+    typedef Utils::CmdLineParser::Arg Arg;
+
     void OutputFormatV(const char *aFormat, va_list aArguments);
 
 #if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
-    bool IsLogging(void) const { return mIsLogging; }
-    void SetIsLogging(bool aIsLogging) { mIsLogging = aIsLogging; }
+    void LogInput(const Arg *aArgs);
+    void SetEmittingCommandOutput(bool aEmittingOutput) { mEmittingCommandOutput = aEmittingOutput; }
+#else
+    void LogInput(const Arg *) {}
+    void SetEmittingCommandOutput(bool) {}
 #endif
 
 private:
+    static constexpr uint16_t kInputOutputLogStringSize = OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LOG_STRING_SIZE;
+
     void OutputTableHeader(uint8_t aNumColumns, const char *const aTitles[], const uint8_t aWidths[]);
     void OutputTableSeparator(uint8_t aNumColumns, const uint8_t aWidths[]);
 
@@ -307,9 +315,9 @@ private:
     otCliOutputCallback mCallback;
     void *              mCallbackContext;
 #if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
-    char     mOutputString[OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LOG_STRING_SIZE];
+    char     mOutputString[kInputOutputLogStringSize];
     uint16_t mOutputLength;
-    bool     mIsLogging;
+    bool     mEmittingCommandOutput;
 #endif
 };
 


### PR DESCRIPTION
This commit updates CLI to not include the CLI prompt string `"> "` when
emitting the command's input and output to the logs under the config
`OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE`. It also changes how
the input command is logged to avoid logging empty lines or extra
spaces in between the args.

----

Backgorund on this: 
- I think the promot was changed recently to be added by the `Cli` class itself (instead of platform). 
- I noticed with this the prompt `"> "` was being included in the logs from #7028.
- This PR now also makes the input look nicer:
```bash
> panid      0x1234     
Done

00:00:21.931 [NOTE]-CLI-----: Input: panid 0x1234
00:00:21.931 [NOTE]-CLI-----: Output: Done

> panid
0x1234
Done

00:00:25.594 [NOTE]-CLI-----: Input: panid
00:00:25.594 [NOTE]-CLI-----: Output: 0x1234
00:00:25.594 [NOTE]-CLI-----: Output: Done

```
