### PR TITLE
[key-manager] set frame counter on `SubMac` on a counter reset

### DIFF
--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -388,7 +388,7 @@ void KeyManager::SetCurrentKeySequence(uint32_t aKeySequence)
     mKeySequence = aKeySequence;
     UpdateKeyMaterial();
 
-    mMacFrameCounters.Reset();
+    SetAllMacFrameCounters(0);
     mMleFrameCounter = 0;
 
     Get<Notifier>().Signal(kEventThreadKeySeqCounterChanged);


### PR DESCRIPTION
This commit changes `KeyManager` to use `SetAllMacFrameCounter(0)` to
reset the frame counter(s). This would then ensure that the new
counter value is also set on `SubMac` and radio platform layer
(which can handle the 15.4 frame counter assignments). This addresses
an issue where on Key Sequence update the frame counter values on
`SubMac` and radio platform can remain unchanged.

----

Please see https://github.com/openthread/openthread/pull/7029#issuecomment-927463921 and related comment in the other PR.

I think it would good idea to add a test-case to verify the key seq change (and that the frame counter reset somehow) so we can detect it if it gets broken. I don't have any immediate ideas on how to add such a test (suggestions/ideas are welcome). But since I feel this is an important issue to fix I would say we leave the test for a future PR.
