### PR TITLE
[ip6] clear radio type (link info) when forwarding received message

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1317,6 +1317,14 @@ start:
 #endif
         }
 
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+        // Since the message will be forwarded, we clear the radio
+        // type on the message to allow the radio type for tx to be
+        // selected later (based on the radios supported by the next
+        // hop).
+        aMessage.ClearRadioType();
+#endif
+
         // `SendMessage()` takes custody of message in the success case
         SuccessOrExit(error = Get<ThreadNetif>().SendMessage(aMessage));
         shouldFreeMessage = false;


### PR DESCRIPTION
This commit addresses an issue when forwarding received messages under
`MUTI_RADIO` config. We clear the radio type (which indicates the
radio on which the `Message` is received) when the same `Message`
instance is forwarded back to the Thread mesh to be sent out to a
neighbor. This then ensures that `RadioSelector` picks the radio to
send deadpanning on the neighbor's supported radios and their
preference.

This commit also updates `test-703-multi-radio-mesh-header-msg.py` to
verify and cover this situation.

----

Please see [openthread-users msg](https://groups.google.com/g/openthread-users/c/0mQneIyGgQU/m/w42N9mX7AQAJ) for more details/discussions on this.