### PR TITLE
[routing-manager] retry sending failed RS messages

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -198,7 +198,7 @@ private:
     static constexpr uint32_t kRtrSolicitationInterval     = 4;   // Interval between RSs. In sec.
     static constexpr uint32_t kMaxRtrSolicitationDelay     = 1;   // Max delay for initial solicitation. In sec.
     static constexpr uint32_t kMaxRoutingPolicyDelay       = 1;   // Max delay for routing policy evaluation. In sec.
-    static constexpr uint32_t kRtrSolicitationRetryDelay   = 60;  // The delay before re-trying failed RS tx. In Sec.
+    static constexpr uint32_t kRtrSolicitationRetryDelay   = 60;  // The delay before retrying failed RS tx. In Sec.
 
     // The STALE_RA_TIME in seconds. The Routing Manager will consider the prefixes
     // and learned RA parameters STALE when they are not refreshed in STALE_RA_TIME

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -198,6 +198,7 @@ private:
     static constexpr uint32_t kRtrSolicitationInterval     = 4;   // Interval between RSs. In sec.
     static constexpr uint32_t kMaxRtrSolicitationDelay     = 1;   // Max delay for initial solicitation. In sec.
     static constexpr uint32_t kMaxRoutingPolicyDelay       = 1;   // Max delay for routing policy evaluation. In sec.
+    static constexpr uint32_t kRtrSolicitationRetryDelay   = 60;  // The delay before re-trying failed RS tx. In Sec.
 
     // The STALE_RA_TIME in seconds. The Routing Manager will consider the prefixes
     // and learned RA parameters STALE when they are not refreshed in STALE_RA_TIME

--- a/tests/scripts/thread-cert/border_router/test_single_border_router.py
+++ b/tests/scripts/thread-cert/border_router/test_single_border_router.py
@@ -267,8 +267,9 @@ class SingleBorderRouter(thread_cert.TestCase):
 
         br.enable_ether()
 
-        # It takes around 10 seconds to start sending RA messages.
-        self.simulator.go(15)
+        # The routing manager may fail to send RS and will wait for 60 seconds
+        # before retrying.
+        self.simulator.go(80)
         self.collect_ipaddrs()
 
         logging.info("BR     addrs: %r", br.get_addrs())


### PR DESCRIPTION
Current implement will start evaluating on-link prefix before successfully sending
`kMaxRtrSolicitations=3` RS messages. This commit fixes this issue by retrying
sending failed RS messages in `kRtrSolicitationRetryFailDelay=60` seconds.
