### PR TITLE
[tcp] apply ot-config compile options

### DIFF
--- a/third_party/tcplp/CMakeLists.txt
+++ b/third_party/tcplp/CMakeLists.txt
@@ -44,7 +44,11 @@ target_include_directories(${tcplp_static_target}
         ${CMAKE_CURRENT_SOURCE_DIR}/lib
     PRIVATE
         ${OT_PUBLIC_INCLUDES}
-        $<TARGET_PROPERTY:ot-config,INTERFACE_INCLUDE_DIRECTORIES>
+)
+
+target_link_libraries(${tcplp_static_target}
+    PRIVATE
+        ot-config
 )
 
 # TCPlp calls functions that are defined by the core OpenThread (like


### PR DESCRIPTION
The issue showed up when we upmerged the latest OpenThread revision to Zephyr.

tcplp uses stdio.h which, for some libc implementations, can depend on
Kconfig defines.

These Kconfig defines can be included through compile options in
ot-config.

Link with ot-config to get the compile options.

Signed-off-by: Sebastian Bøe <sebastian.boe@nordicsemi.no>