### PR TITLE
[posix] fix fall-through issue

### DIFF
--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -423,6 +423,7 @@ void InfraNetif::ReceiveNetLinkMessage(void)
 
             OT_UNUSED_VARIABLE(errMsg);
             otLogWarnPlat("netlink NLMSG_ERROR response: seq=%u, error=%d", header->nlmsg_seq, errMsg->error);
+            break;
         }
         default:
             break;


### PR DESCRIPTION
When compiling OpenThread in Android, the compiler generates an error:
unannotated fall-through between switch labels [-Werror,-Wimplicit-fallthrough]

This CL adds a `break` to the switch label to resolve this issue.