### PR TITLE
[csl] prevent CslTxScheduler from entering the incorrect state

### DIFF
--- a/src/core/thread/csl_tx_scheduler.cpp
+++ b/src/core/thread/csl_tx_scheduler.cpp
@@ -232,7 +232,7 @@ void CslTxScheduler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError)
 
     VerifyOrExit(child != nullptr); // The result is no longer interested by upper layer
 
-    mCslTxChild   = nullptr;
+    mCslTxChild = nullptr;
 
     HandleSentFrame(aFrame, aError, *child);
 


### PR DESCRIPTION
[Problem description]
I have encountered `CslTxScheduler` entering the incorrect state causing the device to be unable to perform csl transmission.
The state is when `mCslTxChild` is null but `mCslTxMessage` is not null. As a result `Update()` call does not have any effect. 

I think that we enter the incorrect state when the following happens:
1. CSL transmission on mac is requested (`mCslTxChild` is set to the best child found in `RescheduleCslTx()`, `mCslTxMessage` is set to the child's IndirectMessage in `HandleFrameRequest()`)
2. During the ongoing mac CSL transmission, `Update()` is called (this method can be called from multiple places)
3. The `mCslTxChild`'s IndirectMessage differs from the `mCslTxMessage` ==> `mCslTxChild` is set to nullptr
4. After the finished csl transmission on mac, the `HandleSentFrame()` is called but it does not call `RescheduleCslTx()` so the `mCslTxChild` remains nullptr

Then every `Update()` call does not have any effect. To change that we would have to call `RescheduleCslTx()` or set the `mCslTxMessage` to null but there is no way of doing that.

[Proposed solution]
I believe that `mCslTxMessage` is "tracking" the mac transmission - it is to be set when transmission is requested, and to be cleared when the transmission ends. In this PR we are doing it in a clear way.

I also reviewed the implementation PR and I think that this problem could be missed. I am dropping the link: https://github.com/openthread/openthread/pull/4557/commits/eab32eb98e9ab78f1f77301ee7ea32b98f265411#r466199000
