### PR TITLE
[github-actions] make `test_set_mliid` more reliable

### DIFF
--- a/tests/scripts/thread-cert/test_set_mliid.py
+++ b/tests/scripts/thread-cert/test_set_mliid.py
@@ -50,7 +50,7 @@ class Test_SetMlIid(thread_cert.TestCase):
         self.nodes[LEADER].set_mliid('1122334455667788')
 
         self.nodes[LEADER].start()
-        self.simulator.go(4)
+        self.simulator.go(10)
         self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
 
         # Ensure set ML-IID was effective.


### PR DESCRIPTION
`test_set_mliid` has a small chance to fail. This commit uses a longer duration (10s) to make the test more reliable. 

The root cause why `LEADER` becomes Leader within 4s is still unknown and to be investigated. 