### PR TITLE
[cert] add ability to configure CCM mode

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (171)
+#define OPENTHREAD_API_VERSION (172)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -728,6 +728,18 @@ typedef void (*otNeighborTableCallback)(otNeighborTableEvent aEvent, const otNei
 void otThreadRegisterNeighborTableCallback(otInstance *aInstance, otNeighborTableCallback aCallback);
 
 /**
+ * This function sets whether the device was commissioned using CCM.
+ *
+ * @note This API requires `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE`, and is only used by Thread Test Harness
+ *       to indicate whether this device was commissioned using CCM.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ * @param[in]  aEnabled   TRUE if the device was commissioned using CCM, FALSE otherwise.
+ *
+ */
+void otThreadSetCcmEnabled(otInstance *aInstance, bool aEnabled);
+
+/**
  * @}
  *
  */

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -841,6 +841,22 @@ exit:
     return error;
 }
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+otError Interpreter::ProcessCcm(Arg aArgs[])
+{
+    otError error = OT_ERROR_NONE;
+    bool    enable;
+
+    VerifyOrExit(!aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_COMMAND);
+
+    SuccessOrExit(error = ParseEnableOrDisable(aArgs[1], enable));
+    otThreadSetCcmEnabled(GetInstancePtr(), enable);
+
+exit:
+    return error;
+}
+#endif
+
 otError Interpreter::ProcessChannel(Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -326,6 +326,9 @@ private:
     // Process methods only on FTD/MTD
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
     otError ProcessCcaThreshold(Arg aArgs[]);
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    otError ProcessCcm(Arg aArgs[]);
+#endif
     otError ProcessBufferInfo(Arg aArgs[]);
     otError ProcessChannel(Arg aArgs[]);
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
@@ -670,6 +673,9 @@ private:
 #endif
         {"bufferinfo", &Interpreter::ProcessBufferInfo},
         {"ccathreshold", &Interpreter::ProcessCcaThreshold},
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+        {"ccm", &Interpreter::ProcessCcm},
+#endif
         {"channel", &Interpreter::ProcessChannel},
 #if OPENTHREAD_FTD
         {"child", &Interpreter::ProcessChild},

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -363,6 +363,11 @@ otError otThreadSendProactiveBackboneNotification(otInstance *              aIns
         AsCoreType(aTarget), AsCoreType(aMlIid), aTimeSinceLastTransaction);
 }
 #endif
+
+void otThreadSetCcmEnabled(otInstance *aInstance, bool aEnabled)
+{
+    AsCoreType(aInstance).Get<Mle::MleRouter>().SetCcmEnabled(aEnabled);
+}
 #endif
 
 #endif // OPENTHREAD_FTD

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -70,6 +70,7 @@ MleRouter::MleRouter(Instance &aInstance)
     , mLeaderWeight(kLeaderWeight)
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     , mPreferredLeaderPartitionId(0)
+    , mCcmEnabled(false)
 #endif
     , mRouterEligible(true)
     , mAddressSolicitPending(false)
@@ -122,7 +123,11 @@ bool MleRouter::IsRouterEligible(void) const
 #else
     if (secPolicy.mCommercialCommissioningEnabled)
     {
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+        VerifyOrExit(mCcmEnabled || secPolicy.mNonCcmRoutersEnabled);
+#else
         VerifyOrExit(secPolicy.mNonCcmRoutersEnabled);
+#endif
     }
     if (!secPolicy.mRoutersEnabled)
     {

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -552,6 +552,14 @@ public:
      *
      */
     Error SetMaxChildIpAddresses(uint8_t aMaxIpAddresses);
+
+    /**
+     * This method sets whether the device was commissioned using CCM.
+     *
+     * @param[in]  aEnabled  TRUE if the device was commissioned using CCM, FALSE otherwise.
+     *
+     */
+    void SetCcmEnabled(bool aEnabled) { mCcmEnabled = aEnabled; }
 #endif
 
 private:
@@ -672,6 +680,7 @@ private:
     uint8_t  mLeaderWeight;
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     uint32_t mPreferredLeaderPartitionId; ///< only for certification testing
+    bool     mCcmEnabled : 1;
 #endif
     bool mRouterEligible : 1;
     bool mAddressSolicitPending : 1;


### PR DESCRIPTION
Thread Test Harness requires devices to operate as if they were
commissioned using CCM. This commit adds the ability to configure the
device to behave as if it was commissioned using CCM. This
functionality requires `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` to
be enabled.