### PR TITLE
[debug] adding `SuccessOrAssert()` helper macro

### DIFF
--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -100,17 +100,11 @@ Error CoapSecure::Connect(const Ip6::SockAddr &aSockAddr, ConnectedCallback aCal
 
 void CoapSecure::SetPsk(const MeshCoP::JoinerPskd &aPskd)
 {
-    Error error;
-
-    OT_UNUSED_VARIABLE(error);
-
     static_assert(static_cast<uint16_t>(MeshCoP::JoinerPskd::kMaxLength) <=
                       static_cast<uint16_t>(MeshCoP::Dtls::kPskMaxLength),
                   "The maximum length of DTLS PSK is smaller than joiner PSKd");
 
-    error = mDtls.SetPsk(reinterpret_cast<const uint8_t *>(aPskd.GetAsCString()), aPskd.GetLength());
-
-    OT_ASSERT(error == kErrorNone);
+    SuccessOrAssert(mDtls.SetPsk(reinterpret_cast<const uint8_t *>(aPskd.GetAsCString()), aPskd.GetLength()));
 }
 
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE

--- a/src/core/common/debug.hpp
+++ b/src/core/common/debug.hpp
@@ -92,4 +92,20 @@
 
 #endif // OPENTHREAD_CONFIG_ASSERT_ENABLE
 
+/**
+ * This macro checks a given status (which is expected to be successful) against zero (0) which indicates success,
+ * and `OT_ASSERT()` if it is not.
+ *
+ * @param[in]  aStatus     A scalar status to be evaluated against zero (0).
+ *
+ */
+#define SuccessOrAssert(aStatus) \
+    do                           \
+    {                            \
+        if ((aStatus) != 0)      \
+        {                        \
+            OT_ASSERT(false);    \
+        }                        \
+    } while (false)
+
 #endif // DEBUG_HPP_

--- a/src/core/common/random_manager.cpp
+++ b/src/core/common/random_manager.cpp
@@ -54,9 +54,6 @@ RandomManager::CryptoCtrDrbg RandomManager::sCtrDrbg;
 RandomManager::RandomManager(void)
 {
     uint32_t seed;
-    Error    error;
-
-    OT_UNUSED_VARIABLE(error);
 
     OT_ASSERT(sInitCount < 0xffff);
 
@@ -66,11 +63,9 @@ RandomManager::RandomManager(void)
     sEntropy.Init();
     sCtrDrbg.Init();
 
-    error = Random::Crypto::FillBuffer(reinterpret_cast<uint8_t *>(&seed), sizeof(seed));
-    OT_ASSERT(error == kErrorNone);
+    SuccessOrAssert(Random::Crypto::FillBuffer(reinterpret_cast<uint8_t *>(&seed), sizeof(seed)));
 #else
-    error = otPlatEntropyGet(reinterpret_cast<uint8_t *>(&seed), sizeof(seed));
-    OT_ASSERT(error == kErrorNone);
+    SuccessOrAssert(otPlatEntropyGet(reinterpret_cast<uint8_t *>(&seed), sizeof(seed)));
 #endif
 
     sPrng.Init(seed);

--- a/src/core/crypto/aes_ecb.cpp
+++ b/src/core/crypto/aes_ecb.cpp
@@ -40,35 +40,24 @@ namespace Crypto {
 
 AesEcb::AesEcb(void)
 {
-    Error err = kErrorNone;
-
     mContext.mContext     = mContextStorage;
     mContext.mContextSize = sizeof(mContextStorage);
-    err                   = otPlatCryptoAesInit(&mContext);
-
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoAesInit(&mContext));
 }
 
 void AesEcb::SetKey(const Key &aKey)
 {
-    Error err = otPlatCryptoAesSetKey(&mContext, &aKey);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoAesSetKey(&mContext, &aKey));
 }
 
 void AesEcb::Encrypt(const uint8_t aInput[kBlockSize], uint8_t aOutput[kBlockSize])
 {
-    Error err = otPlatCryptoAesEncrypt(&mContext, aInput, aOutput);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoAesEncrypt(&mContext, aInput, aOutput));
 }
 
 AesEcb::~AesEcb(void)
 {
-    Error err = otPlatCryptoAesFree(&mContext);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoAesFree(&mContext));
 }
 
 } // namespace Crypto

--- a/src/core/crypto/hkdf_sha256.cpp
+++ b/src/core/crypto/hkdf_sha256.cpp
@@ -45,36 +45,24 @@ namespace Crypto {
 
 HkdfSha256::HkdfSha256(void)
 {
-    Error err = kErrorNone;
-
     mContext.mContext     = mContextStorage;
     mContext.mContextSize = sizeof(mContextStorage);
-    err                   = otPlatCryptoHkdfInit(&mContext);
-
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoHkdfInit(&mContext));
 }
 
 HkdfSha256::~HkdfSha256(void)
 {
-    Error err = otPlatCryptoHkdfDeinit(&mContext);
-
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoHkdfDeinit(&mContext));
 }
 
 void HkdfSha256::Extract(const uint8_t *aSalt, uint16_t aSaltLength, const Key &aInputKey)
 {
-    Error err = otPlatCryptoHkdfExtract(&mContext, aSalt, aSaltLength, &aInputKey);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoHkdfExtract(&mContext, aSalt, aSaltLength, &aInputKey));
 }
 
 void HkdfSha256::Expand(const uint8_t *aInfo, uint16_t aInfoLength, uint8_t *aOutputKey, uint16_t aOutputKeyLength)
 {
-    Error err = otPlatCryptoHkdfExpand(&mContext, aInfo, aInfoLength, aOutputKey, aOutputKeyLength);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoHkdfExpand(&mContext, aInfo, aInfoLength, aOutputKey, aOutputKeyLength));
 }
 
 } // namespace Crypto

--- a/src/core/crypto/hmac_sha256.cpp
+++ b/src/core/crypto/hmac_sha256.cpp
@@ -41,42 +41,30 @@ namespace Crypto {
 
 HmacSha256::HmacSha256(void)
 {
-    Error err = kErrorNone;
-
     mContext.mContext     = mContextStorage;
     mContext.mContextSize = sizeof(mContextStorage);
 
-    err = otPlatCryptoHmacSha256Init(&mContext);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoHmacSha256Init(&mContext));
 }
 
 HmacSha256::~HmacSha256(void)
 {
-    Error err = otPlatCryptoHmacSha256Deinit(&mContext);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoHmacSha256Deinit(&mContext));
 }
 
 void HmacSha256::Start(const Key &aKey)
 {
-    Error err = otPlatCryptoHmacSha256Start(&mContext, &aKey);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoHmacSha256Start(&mContext, &aKey));
 }
 
 void HmacSha256::Update(const void *aBuf, uint16_t aBufLength)
 {
-    Error err = otPlatCryptoHmacSha256Update(&mContext, aBuf, aBufLength);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoHmacSha256Update(&mContext, aBuf, aBufLength));
 }
 
 void HmacSha256::Finish(Hash &aHash)
 {
-    Error err = otPlatCryptoHmacSha256Finish(&mContext, aHash.m8, Hash::kSize);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoHmacSha256Finish(&mContext, aHash.m8, Hash::kSize));
 }
 
 void HmacSha256::Update(const Message &aMessage, uint16_t aOffset, uint16_t aLength)

--- a/src/core/crypto/sha256.cpp
+++ b/src/core/crypto/sha256.cpp
@@ -42,35 +42,24 @@ namespace Crypto {
 
 Sha256::Sha256(void)
 {
-    Error err = kErrorNone;
-
     mContext.mContext     = mContextStorage;
     mContext.mContextSize = sizeof(mContextStorage);
-    err                   = otPlatCryptoSha256Init(&mContext);
-
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoSha256Init(&mContext));
 }
 
 Sha256::~Sha256(void)
 {
-    Error err = otPlatCryptoSha256Deinit(&mContext);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoSha256Deinit(&mContext));
 }
 
 void Sha256::Start(void)
 {
-    Error err = otPlatCryptoSha256Start(&mContext);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoSha256Start(&mContext));
 }
 
 void Sha256::Update(const void *aBuf, uint16_t aBufLength)
 {
-    Error err = otPlatCryptoSha256Update(&mContext, aBuf, aBufLength);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoSha256Update(&mContext, aBuf, aBufLength));
 }
 
 void Sha256::Update(const Message &aMessage, uint16_t aOffset, uint16_t aLength)
@@ -88,9 +77,8 @@ void Sha256::Update(const Message &aMessage, uint16_t aOffset, uint16_t aLength)
 
 void Sha256::Finish(Hash &aHash)
 {
-    Error err = otPlatCryptoSha256Finish(&mContext, aHash.m8, Hash::kSize);
-    OT_ASSERT(err == kErrorNone);
-    OT_UNUSED_VARIABLE(err);
+    SuccessOrAssert(otPlatCryptoSha256Finish(&mContext, aHash.m8, Hash::kSize));
 }
+
 } // namespace Crypto
 } // namespace ot

--- a/src/core/crypto/storage.cpp
+++ b/src/core/crypto/storage.cpp
@@ -46,9 +46,8 @@ Error Key::ExtractKey(uint8_t *aKeyBuffer, uint16_t &aKeyLength) const
 
     OT_ASSERT(IsKeyRef());
 
-    error = Crypto::Storage::ExportKey(GetKeyRef(), aKeyBuffer, aKeyLength, readKeyLength);
+    SuccessOrAssert(Crypto::Storage::ExportKey(GetKeyRef(), aKeyBuffer, aKeyLength, readKeyLength));
 
-    OT_ASSERT(error == kErrorNone);
     VerifyOrExit(readKeyLength <= aKeyLength, error = kErrorNoBufs);
 
     aKeyLength = static_cast<uint16_t>(readKeyLength);
@@ -65,14 +64,9 @@ LiteralKey::LiteralKey(const Key &aKey)
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
     if (aKey.IsKeyRef())
     {
-        Error error;
-
         mKey    = mBuffer;
         mLength = sizeof(mBuffer);
-        error   = aKey.ExtractKey(mBuffer, mLength);
-
-        OT_ASSERT(error == kErrorNone);
-        OT_UNUSED_VARIABLE(error);
+        SuccessOrAssert(aKey.ExtractKey(mBuffer, mLength));
     }
 #endif
 }

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -273,17 +273,12 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, 
             {
                 uint32_t frameCounter;
                 uint8_t  keyId;
-                Error    error;
 
-                error = aFrame.GetFrameCounter(frameCounter);
-                OT_ASSERT(error == kErrorNone);
+                SuccessOrAssert(aFrame.GetFrameCounter(frameCounter));
                 aChild.SetIndirectFrameCounter(frameCounter);
 
-                error = aFrame.GetKeyId(keyId);
-                OT_ASSERT(error == kErrorNone);
+                SuccessOrAssert(aFrame.GetKeyId(keyId));
                 aChild.SetIndirectKeyId(keyId);
-
-                OT_UNUSED_VARIABLE(error);
             }
 
             ExitNow();

--- a/src/core/mac/mac_links.cpp
+++ b/src/core/mac/mac_links.cpp
@@ -156,10 +156,7 @@ void Links::Send(TxFrame &aFrame, RadioTypes aRadioTypes)
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
     if (aRadioTypes.Contains(kRadioTypeIeee802154))
     {
-        Error error = mSubMac.Send();
-
-        OT_ASSERT(error == kErrorNone);
-        OT_UNUSED_VARIABLE(error);
+        SuccessOrAssert(mSubMac.Send());
     }
 #endif
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE

--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -511,11 +511,7 @@ public:
     void Send(void)
     {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-        {
-            Error error = mSubMac.Send();
-            OT_ASSERT(error == kErrorNone);
-            OT_UNUSED_VARIABLE(error);
-        }
+        SuccessOrAssert(mSubMac.Send());
 #endif
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
         mTrel.Send();

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -355,18 +355,15 @@ void KeyMaterial::SetFrom(const Key &aKey, bool aIsExportable)
 {
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
     {
-        Error  error;
         KeyRef keyRef = 0;
 
         DestroyKey();
 
-        error = Crypto::Storage::ImportKey(keyRef, Crypto::Storage::kKeyTypeAes, Crypto::Storage::kKeyAlgorithmAesEcb,
-                                           (aIsExportable ? Crypto::Storage::kUsageExport : 0) |
-                                               Crypto::Storage::kUsageEncrypt | Crypto::Storage::kUsageDecrypt,
-                                           Crypto::Storage::kTypeVolatile, aKey.GetBytes(), Key::kSize);
-
-        OT_ASSERT(error == kErrorNone);
-        OT_UNUSED_VARIABLE(error);
+        SuccessOrAssert(Crypto::Storage::ImportKey(keyRef, Crypto::Storage::kKeyTypeAes,
+                                                   Crypto::Storage::kKeyAlgorithmAesEcb,
+                                                   (aIsExportable ? Crypto::Storage::kUsageExport : 0) |
+                                                       Crypto::Storage::kUsageEncrypt | Crypto::Storage::kUsageDecrypt,
+                                                   Crypto::Storage::kTypeVolatile, aKey.GetBytes(), Key::kSize));
 
         SetKeyRef(keyRef);
     }
@@ -383,12 +380,9 @@ void KeyMaterial::ExtractKey(Key &aKey)
 
     if (Crypto::Storage::IsKeyRefValid(GetKeyRef()))
     {
-        Error  error;
         size_t keySize;
 
-        error = Crypto::Storage::ExportKey(GetKeyRef(), aKey.m8, Key::kSize, keySize);
-        OT_ASSERT(error == kErrorNone);
-        OT_UNUSED_VARIABLE(error);
+        SuccessOrAssert(Crypto::Storage::ExportKey(GetKeyRef(), aKey.m8, Key::kSize, keySize));
     }
 #else
     aKey = GetKey();

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -184,7 +184,7 @@ Error SubMac::Enable(void)
     SetState(kStateSleep);
 
 exit:
-    OT_ASSERT(error == kErrorNone);
+    SuccessOrAssert(error);
     return error;
 }
 
@@ -455,8 +455,7 @@ void SubMac::BeginTransmit(void)
 
     if ((mRadioCaps & OT_RADIO_CAPS_SLEEP_TO_TX) == 0)
     {
-        error = Get<Radio>().Receive(mTransmitFrame.GetChannel());
-        OT_ASSERT(error == kErrorNone);
+        SuccessOrAssert(Get<Radio>().Receive(mTransmitFrame.GetChannel()));
     }
 
     SetState(kStateTransmit);
@@ -474,7 +473,8 @@ void SubMac::BeginTransmit(void)
         mTransmitFrame.mInfo.mTxInfo.mTxDelayBaseTime = 0;
         error                                         = Get<Radio>().Transmit(mTransmitFrame);
     }
-    OT_ASSERT(error == kErrorNone);
+
+    SuccessOrAssert(error);
 
 exit:
     return;
@@ -644,8 +644,7 @@ Error SubMac::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration)
     }
     else if (ShouldHandleEnergyScan())
     {
-        error = Get<Radio>().Receive(aScanChannel);
-        OT_ASSERT(error == kErrorNone);
+        SuccessOrAssert(Get<Radio>().Receive(aScanChannel));
 
         SetState(kStateEnergyScan);
         mEnergyScanMaxRssi = kInvalidRssiValue;

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -187,13 +187,7 @@ bool InterfaceIdentifier::IsReservedSubnetAnycast(void) const
 
 void InterfaceIdentifier::GenerateRandom(void)
 {
-    Error error;
-
-    OT_UNUSED_VARIABLE(error);
-
-    error = Random::Crypto::FillBuffer(mFields.m8, kSize);
-
-    OT_ASSERT(error == kErrorNone);
+    SuccessOrAssert(Random::Crypto::FillBuffer(mFields.m8, kSize));
 }
 
 void InterfaceIdentifier::SetBytes(const uint8_t *aBuffer)

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -427,10 +427,7 @@ void Mpl::Metadata::ReadFrom(const Message &aMessage)
 
 void Mpl::Metadata::RemoveFrom(Message &aMessage) const
 {
-    Error error = aMessage.SetLength(aMessage.GetLength() - sizeof(*this));
-
-    OT_ASSERT(error == kErrorNone);
-    OT_UNUSED_VARIABLE(error);
+    SuccessOrAssert(aMessage.SetLength(aMessage.GetLength() - sizeof(*this)));
 }
 
 void Mpl::Metadata::UpdateIn(Message &aMessage) const

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -226,8 +226,7 @@ exit:
 
 void Netif::SubscribeAllRoutersMulticast(void)
 {
-    Error             error = kErrorNone;
-    MulticastAddress *prev  = nullptr;
+    MulticastAddress *prev = nullptr;
     MulticastAddress &linkLocalAllRoutersAddress =
         static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllRoutersMulticastAddress));
     MulticastAddress &linkLocalAllNodesAddress =
@@ -235,13 +234,10 @@ void Netif::SubscribeAllRoutersMulticast(void)
     MulticastAddress &realmLocalAllRoutersAddress =
         static_cast<MulticastAddress &>(AsNonConst(kRealmLocalAllRoutersMulticastAddress));
 
-    error = mMulticastAddresses.Find(linkLocalAllNodesAddress, prev);
-
     // This method MUST be called after `SubscribeAllNodesMulticast()`
     // Ensure that the `LinkLocalAll` was found on the list.
 
-    OT_ASSERT(error == kErrorNone);
-    OT_UNUSED_VARIABLE(error);
+    SuccessOrAssert(mMulticastAddresses.Find(linkLocalAllNodesAddress, prev));
 
     // The tail of multicast address linked list contains the
     // fixed addresses. We either have a chain of five addresses

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -426,10 +426,7 @@ public:
      */
     void ReadFrom(const Message &aMessage)
     {
-        Error error = aMessage.Read(aMessage.GetLength() - sizeof(*this), *this);
-
-        OT_ASSERT(error == kErrorNone);
-        OT_UNUSED_VARIABLE(error);
+        SuccessOrAssert(aMessage.Read(aMessage.GetLength() - sizeof(*this), *this));
     }
 
     /**

--- a/src/core/radio/radio.cpp
+++ b/src/core/radio/radio.cpp
@@ -37,13 +37,8 @@ namespace ot {
 void Radio::Init(void)
 {
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-    Error error = OT_ERROR_NONE;
-
-    OT_UNUSED_VARIABLE(error);
-
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    error = EnableCsl(0, Mac::kShortAddrInvalid, nullptr);
-    OT_ASSERT(error == OT_ERROR_NONE);
+    SuccessOrAssert(EnableCsl(0, Mac::kShortAddrInvalid, nullptr));
 #endif
 
     EnableSrcMatch(false);
@@ -52,11 +47,8 @@ void Radio::Init(void)
 
     if (IsEnabled())
     {
-        error = Sleep();
-        OT_ASSERT(error == OT_ERROR_NONE);
-
-        error = Disable();
-        OT_ASSERT(error == OT_ERROR_NONE);
+        SuccessOrAssert(Sleep());
+        SuccessOrAssert(Disable());
     }
 
     SetPanId(Mac::kPanIdBroadcast);

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -523,13 +523,10 @@ void KeyManager::GetNetworkKey(NetworkKey &aNetworkKey) const
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
     if (Crypto::Storage::IsKeyRefValid(mNetworkKeyRef))
     {
-        Error  error = kErrorNone;
         size_t keyLen;
 
-        error = Crypto::Storage::ExportKey(mNetworkKeyRef, aNetworkKey.m8, NetworkKey::kSize, keyLen);
-        OT_ASSERT(error == kErrorNone);
+        SuccessOrAssert(Crypto::Storage::ExportKey(mNetworkKeyRef, aNetworkKey.m8, NetworkKey::kSize, keyLen));
         OT_ASSERT(keyLen == NetworkKey::kSize);
-        OT_UNUSED_VARIABLE(error);
     }
     else
     {
@@ -545,13 +542,10 @@ void KeyManager::GetPskc(Pskc &aPskc) const
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
     if (Crypto::Storage::IsKeyRefValid(mPskcRef))
     {
-        Error  error = kErrorNone;
         size_t keyLen;
 
-        error = Crypto::Storage::ExportKey(mPskcRef, aPskc.m8, Pskc::kSize, keyLen);
-        OT_ASSERT(error == kErrorNone);
+        SuccessOrAssert(Crypto::Storage::ExportKey(mPskcRef, aPskc.m8, Pskc::kSize, keyLen));
         OT_ASSERT(keyLen == Pskc::kSize);
-        OT_UNUSED_VARIABLE(error);
     }
     else
     {
@@ -566,7 +560,6 @@ void KeyManager::GetPskc(Pskc &aPskc) const
 
 void KeyManager::StoreNetworkKey(const NetworkKey &aNetworkKey, bool aOverWriteExisting)
 {
-    Error         error;
     NetworkKeyRef keyRef;
 
     keyRef = kNetworkKeyPsaItsOffset;
@@ -584,10 +577,10 @@ void KeyManager::StoreNetworkKey(const NetworkKey &aNetworkKey, bool aOverWriteE
 
     Crypto::Storage::DestroyKey(keyRef);
 
-    error = Crypto::Storage::ImportKey(keyRef, Crypto::Storage::kKeyTypeHmac, Crypto::Storage::kKeyAlgorithmHmacSha256,
-                                       Crypto::Storage::kUsageSignHash | Crypto::Storage::kUsageExport,
-                                       Crypto::Storage::kTypePersistent, aNetworkKey.m8, NetworkKey::kSize);
-    OT_ASSERT(error == kErrorNone);
+    SuccessOrAssert(Crypto::Storage::ImportKey(keyRef, Crypto::Storage::kKeyTypeHmac,
+                                               Crypto::Storage::kKeyAlgorithmHmacSha256,
+                                               Crypto::Storage::kUsageSignHash | Crypto::Storage::kUsageExport,
+                                               Crypto::Storage::kTypePersistent, aNetworkKey.m8, NetworkKey::kSize));
 
 exit:
     if (mNetworkKeyRef != keyRef)
@@ -601,15 +594,12 @@ exit:
 void KeyManager::StorePskc(const Pskc &aPskc)
 {
     PskcRef keyRef = kPskcPsaItsOffset;
-    Error   error  = kErrorNone;
 
     Crypto::Storage::DestroyKey(keyRef);
 
-    error = Crypto::Storage::ImportKey(keyRef, Crypto::Storage::kKeyTypeRaw, Crypto::Storage::kKeyAlgorithmVendor,
-                                       Crypto::Storage::kUsageExport, Crypto::Storage::kTypePersistent, aPskc.m8,
-                                       Pskc::kSize);
-    OT_ASSERT(error == kErrorNone);
-    OT_UNUSED_VARIABLE(error);
+    SuccessOrAssert(Crypto::Storage::ImportKey(keyRef, Crypto::Storage::kKeyTypeRaw,
+                                               Crypto::Storage::kKeyAlgorithmVendor, Crypto::Storage::kUsageExport,
+                                               Crypto::Storage::kTypePersistent, aPskc.m8, Pskc::kSize));
 
     if (mPskcRef != keyRef)
     {

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -775,9 +775,6 @@ start:
                                     maxPayloadLength - headerLength - Lowpan::FragmentHeader::kFirstFragmentHeaderSize);
         uint8_t              hcLength;
         Mac::Address         meshSource, meshDest;
-        Error                error;
-
-        OT_UNUSED_VARIABLE(error);
 
         if (aAddMeshHeader)
         {
@@ -790,8 +787,7 @@ start:
             meshDest   = aMacDest;
         }
 
-        error = Get<Lowpan::Lowpan>().Compress(aMessage, meshSource, meshDest, buffer);
-        OT_ASSERT(error == kErrorNone);
+        SuccessOrAssert(Get<Lowpan::Lowpan>().Compress(aMessage, meshSource, meshDest, buffer));
 
         hcLength = static_cast<uint8_t>(buffer.GetWritePointer() - payload);
         headerLength += hcLength;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1307,9 +1307,7 @@ Error Mle::AppendAddressRegistration(Message &aMessage, AddressRegistrationMode 
 
     if (Get<ThreadNetif>().HasUnicastAddress(domainUnicastAddress))
     {
-        error = Get<NetworkData::Leader>().GetContext(domainUnicastAddress, context);
-
-        OT_ASSERT(error == kErrorNone);
+        SuccessOrAssert(Get<NetworkData::Leader>().GetContext(domainUnicastAddress, context));
 
         // Prioritize DUA, compressed entry
         entry.SetContextId(context.mContextId);
@@ -4611,9 +4609,7 @@ void Mle::DelayedResponseMetadata::ReadFrom(const Message &aMessage)
 
 void Mle::DelayedResponseMetadata::RemoveFrom(Message &aMessage) const
 {
-    Error error = aMessage.SetLength(aMessage.GetLength() - sizeof(*this));
-    OT_ASSERT(error == kErrorNone);
-    OT_UNUSED_VARIABLE(error);
+    SuccessOrAssert(aMessage.SetLength(aMessage.GetLength() - sizeof(*this)));
 }
 
 } // namespace Mle

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1219,8 +1219,7 @@ otError NcpBase::CommandHandler_RESET(uint8_t aHeader)
 
     if (mDecoder.GetRemainingLengthInStruct() > 0)
     {
-        error = mDecoder.ReadUint8(reset_type);
-        OT_ASSERT(error == OT_ERROR_NONE);
+        SuccessOrAssert(error = mDecoder.ReadUint8(reset_type));
     }
 
 #if OPENTHREAD_RADIO
@@ -1235,8 +1234,8 @@ otError NcpBase::CommandHandler_RESET(uint8_t aHeader)
 
         ResetCounters();
 
-        error = WriteLastStatusFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_STATUS_RESET_POWER_ON);
-        OT_ASSERT(error == OT_ERROR_NONE);
+        SuccessOrAssert(
+            error = WriteLastStatusFrame(SPINEL_HEADER_FLAG | SPINEL_HEADER_IID_0, SPINEL_STATUS_RESET_POWER_ON));
     }
     else
 #endif

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -3771,8 +3771,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_SRP_CLIENT_HOST_NAME>
     SuccessOrExit(error = otSrpClientSetHostName(mInstance, name));
 
     strcpy(hostNameBuffer, name);
-    error = otSrpClientSetHostName(mInstance, hostNameBuffer);
-    OT_ASSERT(error == OT_ERROR_NONE);
+    SuccessOrAssert(error = otSrpClientSetHostName(mInstance, hostNameBuffer));
 
 exit:
     return error;
@@ -3820,8 +3819,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_SRP_CLIENT_HOST_ADDRE
 
     memcpy(hostAddressArray, addresses, sizeof(addresses));
 
-    error = otSrpClientSetHostAddresses(mInstance, hostAddressArray, numAddresses);
-    OT_ASSERT(error == OT_ERROR_NONE);
+    SuccessOrAssert(error = otSrpClientSetHostAddresses(mInstance, hostAddressArray, numAddresses));
 
 exit:
     return error;


### PR DESCRIPTION
This commit adds a new macro `SuccessOrAssert()` which checks a given
status value against zero (zero status indicates success or no error)
and `OT_ASSERT()` if is is not. This helper macro is then used by
other modules where we want to assert that some method/function is
not returning an error which helps simplicity the code.

----

This macro is named similar to `SuccessOrExit` (and `VerifyOrExit`). 
It replaces the common pattern:
```c++
{
   Error error;

   error = SomeFunction();
   OT_ASSERT(error == kErrorNone);
   OT_UNUSED_VARIABLE(error);
}
```
Note that `OT_ASSERT(SomeFunction() == kErrorNone)` is not correct 
since when assert is disabled, `OT_ASSERT(aCond)` becomes NOOP and then
the `SomeFunction()` call will not happen. 