### PR TITLE
[posix] add support for ipv6 group join in multicastrouter

### DIFF
--- a/src/posix/platform/multicast_routing.hpp
+++ b/src/posix/platform/multicast_routing.hpp
@@ -108,6 +108,10 @@ private:
     void    Disable(void);
     void    Add(const Ip6::Address &aAddress);
     void    Remove(const Ip6::Address &aAddress);
+    void    UpdateMldReport(const Ip6::Address &aAddress, bool isAdd);
+    void    ToggleMcastIcmpReply(bool state);
+    void    EnableMcastIcmpReply(){ToggleMcastIcmpReply(false);};
+    void    DisableMcastIcmpReply(){ToggleMcastIcmpReply(true);};
     bool    HasMulticastListener(const Ip6::Address &aAddress) const;
     bool    IsEnabled(void) const { return mMulticastRouterSock >= 0; }
     void    InitMulticastRouterSock(void);


### PR DESCRIPTION
This commit adds support for joining and leaving multicast group in
order to send proper Multicast Listener Reports from thread network to
backbone link.