### PR TITLE
[core] use `AsCoreType()` in core modules

### DIFF
--- a/src/core/api/instance_api.cpp
+++ b/src/core/api/instance_api.cpp
@@ -132,9 +132,7 @@ otError otInstanceErasePersistentInfo(otInstance *aInstance)
 #if OPENTHREAD_RADIO
 void otInstanceResetRadioStack(otInstance *aInstance)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.ResetRadioStack();
+    AsCoreType(aInstance).ResetRadioStack();
 }
 #endif
 

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
@@ -562,8 +563,7 @@ exit:
 
 void Manager::HandleBackboneQuery(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Manager *>(aContext)->HandleBackboneQuery(*static_cast<const Coap::Message *>(aMessage),
-                                                          *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Manager *>(aContext)->HandleBackboneQuery(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Manager::HandleBackboneQuery(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -597,8 +597,7 @@ exit:
 
 void Manager::HandleBackboneAnswer(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Manager *>(aContext)->HandleBackboneAnswer(*static_cast<const Coap::Message *>(aMessage),
-                                                           *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Manager *>(aContext)->HandleBackboneAnswer(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Manager::HandleBackboneAnswer(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/border_router/infra_if_platform.cpp
+++ b/src/core/border_router/infra_if_platform.cpp
@@ -37,6 +37,7 @@
 #include <openthread/platform/infra_if.h>
 
 #include "border_router/routing_manager.hpp"
+#include "common/as_core_type.hpp"
 #include "common/instance.hpp"
 
 using namespace ot;
@@ -47,17 +48,14 @@ extern "C" void otPlatInfraIfRecvIcmp6Nd(otInstance *        aInstance,
                                          const uint8_t *     aBuffer,
                                          uint16_t            aBufferLength)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    instance.Get<BorderRouter::RoutingManager>().RecvIcmp6Message(
-        aInfraIfIndex, static_cast<const Ip6::Address &>(*aSrcAddress), aBuffer, aBufferLength);
+    AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().RecvIcmp6Message(aInfraIfIndex, AsCoreType(aSrcAddress),
+                                                                               aBuffer, aBufferLength);
 }
 
 extern "C" otError otPlatInfraIfStateChanged(otInstance *aInstance, uint32_t aInfraIfIndex, bool aIsRunning)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
-
-    return instance.Get<BorderRouter::RoutingManager>().HandleInfraIfStateChanged(aInfraIfIndex, aIsRunning);
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().HandleInfraIfStateChanged(aInfraIfIndex,
+                                                                                               aIsRunning);
 }
 
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE

--- a/src/core/border_router/router_advertisement.cpp
+++ b/src/core/border_router/router_advertisement.cpp
@@ -36,6 +36,9 @@
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 
+#include "common/as_core_type.hpp"
+#include "common/code_utils.hpp"
+
 namespace ot {
 
 namespace BorderRouter {
@@ -107,7 +110,7 @@ void PrefixInfoOption::SetAutoAddrConfig(bool aAutoAddrConfig)
 void PrefixInfoOption::SetPrefix(const Ip6::Prefix &aPrefix)
 {
     mPrefixLength = aPrefix.mLength;
-    mPrefix       = static_cast<const Ip6::Address &>(aPrefix.mPrefix);
+    mPrefix       = AsCoreType(&aPrefix.mPrefix);
 }
 
 Ip6::Prefix PrefixInfoOption::GetPrefix(void) const
@@ -149,7 +152,7 @@ void RouteInfoOption::SetPrefix(const Ip6::Prefix &aPrefix)
     SetLength((aPrefix.mLength + kLengthUnit * CHAR_BIT - 1) / (kLengthUnit * CHAR_BIT) + 1);
 
     mPrefixLength = aPrefix.mLength;
-    mPrefix       = static_cast<const Ip6::Address &>(aPrefix.mPrefix);
+    mPrefix       = AsCoreType(&aPrefix.mPrefix);
 }
 
 Ip6::Prefix RouteInfoOption::GetPrefix(void) const

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -28,6 +28,7 @@
 
 #include "coap.hpp"
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -131,7 +132,7 @@ Message *CoapBase::NewMessage(const Message::Settings &aSettings)
 {
     Message *message = nullptr;
 
-    VerifyOrExit((message = static_cast<Message *>(Get<Ip6::Udp>().NewMessage(0, aSettings))) != nullptr);
+    VerifyOrExit((message = AsCoapMessagePtr(Get<Ip6::Udp>().NewMessage(0, aSettings))) != nullptr);
     message->SetOffset(0);
 
 exit:
@@ -143,7 +144,7 @@ Error CoapBase::Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo
     Error error;
 
 #if OPENTHREAD_CONFIG_OTNS_ENABLE
-    Get<Utils::Otns>().EmitCoapSend(static_cast<Message &>(aMessage), aMessageInfo);
+    Get<Utils::Otns>().EmitCoapSend(AsCoapMessage(&aMessage), aMessageInfo);
 #endif
 
     error = mSender(*this, aMessage, aMessageInfo);
@@ -151,7 +152,7 @@ Error CoapBase::Send(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo
 #if OPENTHREAD_CONFIG_OTNS_ENABLE
     if (error != kErrorNone)
     {
-        Get<Utils::Otns>().EmitCoapSendFailure(error, static_cast<Message &>(aMessage), aMessageInfo);
+        Get<Utils::Otns>().EmitCoapSendFailure(error, AsCoapMessage(&aMessage), aMessageInfo);
     }
 #endif
     return error;
@@ -776,8 +777,7 @@ Error CoapBase::ProcessBlock1Request(Message &                aMessage,
         VerifyOrExit((response = NewMessage()) != nullptr, error = kErrorFailed);
         response->Init(kTypeAck, kCodeContinue);
         response->SetMessageId(aMessage.GetMessageId());
-        IgnoreReturnValue(
-            response->SetToken(static_cast<const Message &>(aMessage).GetToken(), aMessage.GetTokenLength()));
+        IgnoreReturnValue(response->SetToken(AsConst(aMessage).GetToken(), aMessage.GetTokenLength()));
 
         response->SetBlockWiseBlockNumber(aMessage.GetBlockWiseBlockNumber());
         response->SetMoreBlocksFlag(aMessage.IsMoreBlocksFlagSet());
@@ -1002,7 +1002,7 @@ exit:
 
 void CoapBase::Receive(ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    Message &message = static_cast<Message &>(aMessage);
+    Message &message = AsCoapMessage(&aMessage);
 
     if (message.ParseHeader() != kErrorNone)
     {
@@ -1684,8 +1684,7 @@ exit:
 
 void Coap::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Coap *>(aContext)->Receive(*static_cast<Message *>(aMessage),
-                                           *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Coap *>(aContext)->Receive(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 Error Coap::Send(CoapBase &aCoapBase, ot::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -33,6 +33,7 @@
 
 #include "message.hpp"
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -203,7 +204,7 @@ Message::Settings::Settings(LinkSecurityMode aSecurityMode, Priority aPriority)
 
 const Message::Settings &Message::Settings::From(const otMessageSettings *aSettings)
 {
-    return (aSettings == nullptr) ? GetDefault() : *static_cast<const Settings *>(aSettings);
+    return (aSettings == nullptr) ? GetDefault() : AsCoreType(aSettings);
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/core/common/timer.cpp
+++ b/src/core/common/timer.cpp
@@ -33,6 +33,7 @@
 
 #include "timer.hpp"
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -214,10 +215,8 @@ void Timer::Scheduler::RemoveAll(const AlarmApi &aAlarmApi)
 
 extern "C" void otPlatAlarmMilliFired(otInstance *aInstance)
 {
-    Instance *instance = static_cast<Instance *>(aInstance);
-
     VerifyOrExit(otInstanceIsInitialized(aInstance));
-    instance->Get<TimerMilli::Scheduler>().ProcessTimers();
+    AsCoreType(aInstance).Get<TimerMilli::Scheduler>().ProcessTimers();
 
 exit:
     return;
@@ -259,10 +258,8 @@ void TimerMicro::RemoveAll(Instance &aInstance)
 
 extern "C" void otPlatAlarmMicroFired(otInstance *aInstance)
 {
-    Instance *instance = static_cast<Instance *>(aInstance);
-
     VerifyOrExit(otInstanceIsInitialized(aInstance));
-    instance->Get<TimerMicro::Scheduler>().ProcessTimers();
+    AsCoreType(aInstance).Get<TimerMicro::Scheduler>().ProcessTimers();
 
 exit:
     return;

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -41,6 +41,7 @@
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/diag.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
@@ -439,9 +440,7 @@ exit:
 
 extern "C" void otPlatDiagAlarmFired(otInstance *aInstance)
 {
-    Instance *instance = static_cast<Instance *>(aInstance);
-
-    instance->Get<Diags>().AlarmFired();
+    AsCoreType(aInstance).Get<Diags>().AlarmFired();
 }
 
 void Diags::AlarmFired(void)

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -35,6 +35,7 @@
 
 #include <stdio.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
@@ -137,7 +138,7 @@ Mac::Mac(Instance &aInstance)
     mLinks.Enable();
 
     Get<KeyManager>().UpdateKeyMaterial();
-    SetExtendedPanId(static_cast<const ExtendedPanId &>(sExtendedPanidInit));
+    SetExtendedPanId(AsCoreType(&sExtendedPanidInit));
     IgnoreError(SetNetworkName(sNetworkNameInit));
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
     IgnoreError(SetDomainName(sDomainNameInit));
@@ -146,7 +147,7 @@ Mac::Mac(Instance &aInstance)
     SetExtAddress(randomExtAddress);
     SetShortAddress(GetShortAddress());
 
-    mMode2KeyMaterial.SetFrom(static_cast<const Key &>(sMode2Key));
+    mMode2KeyMaterial.SetFrom(AsCoreType(&sMode2Key));
 }
 
 Error Mac::ActiveScan(uint32_t aScanChannels, uint16_t aScanDuration, ActiveScanHandler aHandler, void *aContext)
@@ -266,7 +267,7 @@ Error Mac::ConvertBeaconToActiveScanResult(const RxFrame *aBeaconFrame, ActiveSc
         aResult.mVersion    = beaconPayload->GetProtocolVersion();
         aResult.mIsJoinable = beaconPayload->IsJoiningPermitted();
         aResult.mIsNative   = beaconPayload->IsNative();
-        IgnoreError(static_cast<NetworkName &>(aResult.mNetworkName).Set(beaconPayload->GetNetworkName()));
+        IgnoreError(AsCoreType(&aResult.mNetworkName).Set(beaconPayload->GetNetworkName()));
         VerifyOrExit(IsValidUtf8String(aResult.mNetworkName.m8), error = kErrorParse);
         aResult.mExtendedPanId = beaconPayload->GetExtendedPanId();
     }
@@ -1008,7 +1009,7 @@ void Mac::ProcessTransmitSecurity(TxFrame &aFrame)
         aFrame.SetFrameCounter(mKeyIdMode2FrameCounter);
         aFrame.SetKeySource(keySource);
         aFrame.SetKeyId(0xff);
-        extAddress = static_cast<const ExtAddress *>(&sMode2ExtAddress);
+        extAddress = &AsCoreType(&sMode2ExtAddress);
         break;
     }
 
@@ -1702,7 +1703,7 @@ Error Mac::ProcessReceiveSecurity(RxFrame &aFrame, const Address &aSrcAddr, Neig
 
     case Frame::kKeyIdMode2:
         macKey     = &mMode2KeyMaterial;
-        extAddress = static_cast<const ExtAddress *>(&sMode2ExtAddress);
+        extAddress = &AsCoreType(&sMode2ExtAddress);
         break;
 
     default:

--- a/src/core/mac/mac_filter.cpp
+++ b/src/core/mac/mac_filter.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 
 namespace ot {
@@ -201,7 +202,7 @@ Error Filter::GetNextRssIn(Iterator &aIterator, Entry &aEntry)
     // Return the default RssIn at the end of list
     if ((aIterator == OT_ARRAY_LENGTH(mFilterEntries)) && (mDefaultRssIn != kFixedRssDisabled))
     {
-        static_cast<ExtAddress &>(aEntry.mExtAddress).Fill(0xff);
+        AsCoreType(&aEntry.mExtAddress).Fill(0xff);
         aEntry.mRssIn = mDefaultRssIn;
         error         = kErrorNone;
         aIterator++;

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -37,7 +37,6 @@
 
 #include <openthread/platform/time.h>
 
-#include "mac_frame.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -45,6 +44,7 @@
 #include "common/logging.hpp"
 #include "common/random.hpp"
 #include "common/time.hpp"
+#include "mac/mac_frame.hpp"
 
 namespace ot {
 namespace Mac {

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -36,6 +36,7 @@
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
 
 #include "coap/coap_message.hpp"
+#include "common/as_core_type.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
 #include "common/logging.hpp"
@@ -162,8 +163,7 @@ void BorderAgent::HandleCoapResponse(void *               aContext,
 
     ForwardContext &forwardContext = *static_cast<ForwardContext *>(aContext);
 
-    forwardContext.Get<BorderAgent>().HandleCoapResponse(forwardContext, static_cast<const Coap::Message *>(aMessage),
-                                                         aResult);
+    forwardContext.Get<BorderAgent>().HandleCoapResponse(forwardContext, AsCoapMessagePtr(aMessage), aResult);
 }
 
 void BorderAgent::HandleCoapResponse(ForwardContext &aForwardContext, const Coap::Message *aResponse, Error aResult)
@@ -222,7 +222,7 @@ template <Coap::Resource BorderAgent::*aResource>
 void BorderAgent::HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
     IgnoreError(static_cast<BorderAgent *>(aContext)->ForwardToLeader(
-        *static_cast<Coap::Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
+        AsCoapMessage(aMessage), AsCoreType(aMessageInfo),
         (static_cast<BorderAgent *>(aContext)->*aResource).GetUriPath(), false, false));
 }
 
@@ -231,9 +231,8 @@ void BorderAgent::HandleRequest<&BorderAgent::mCommissionerPetition>(void *     
                                                                      otMessage *          aMessage,
                                                                      const otMessageInfo *aMessageInfo)
 {
-    IgnoreError(static_cast<BorderAgent *>(aContext)->ForwardToLeader(
-        *static_cast<Coap::Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-        UriPath::kLeaderPetition, true, true));
+    IgnoreError(static_cast<BorderAgent *>(aContext)->ForwardToLeader(AsCoapMessage(aMessage), AsCoreType(aMessageInfo),
+                                                                      UriPath::kLeaderPetition, true, true));
 }
 
 template <>
@@ -241,8 +240,7 @@ void BorderAgent::HandleRequest<&BorderAgent::mCommissionerKeepAlive>(void *    
                                                                       otMessage *          aMessage,
                                                                       const otMessageInfo *aMessageInfo)
 {
-    static_cast<BorderAgent *>(aContext)->HandleKeepAlive(*static_cast<Coap::Message *>(aMessage),
-                                                          *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<BorderAgent *>(aContext)->HandleKeepAlive(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 template <>
@@ -251,7 +249,7 @@ void BorderAgent::HandleRequest<&BorderAgent::mRelayTransmit>(void *            
                                                               const otMessageInfo *aMessageInfo)
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
-    static_cast<BorderAgent *>(aContext)->HandleRelayTransmit(*static_cast<Coap::Message *>(aMessage));
+    static_cast<BorderAgent *>(aContext)->HandleRelayTransmit(AsCoapMessage(aMessage));
 }
 
 template <>
@@ -260,7 +258,7 @@ void BorderAgent::HandleRequest<&BorderAgent::mRelayReceive>(void *             
                                                              const otMessageInfo *aMessageInfo)
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
-    static_cast<BorderAgent *>(aContext)->HandleRelayReceive(*static_cast<Coap::Message *>(aMessage));
+    static_cast<BorderAgent *>(aContext)->HandleRelayReceive(AsCoapMessage(aMessage));
 }
 
 template <>
@@ -269,7 +267,7 @@ void BorderAgent::HandleRequest<&BorderAgent::mProxyTransmit>(void *            
                                                               const otMessageInfo *aMessageInfo)
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
-    static_cast<BorderAgent *>(aContext)->HandleProxyTransmit(*static_cast<Coap::Message *>(aMessage));
+    static_cast<BorderAgent *>(aContext)->HandleProxyTransmit(AsCoapMessage(aMessage));
 }
 
 BorderAgent::BorderAgent(Instance &aInstance)

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -38,6 +38,7 @@
 #include <stdio.h>
 
 #include "coap/coap_message.hpp"
+#include "common/as_core_type.hpp"
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
@@ -98,7 +99,7 @@ void Commissioner::SetState(State aState)
 
     if (mStateCallback)
     {
-        mStateCallback(static_cast<otCommissionerState>(mState), mCallbackContext);
+        mStateCallback(MapEnum(mState), mCallbackContext);
     }
 
 exit:
@@ -411,7 +412,7 @@ void Commissioner::SendCommissionerSet(void)
     dataset.mSessionId      = mSessionId;
     dataset.mIsSessionIdSet = true;
 
-    ComputeBloomFilter(static_cast<SteeringData &>(dataset.mSteeringData));
+    ComputeBloomFilter(AsCoreType(&dataset.mSteeringData));
     dataset.mIsSteeringDataSet = true;
 
     error = SendMgmtCommissionerSetRequest(dataset, nullptr, 0);
@@ -727,8 +728,8 @@ void Commissioner::HandleMgmtCommissionerGetResponse(void *               aConte
                                                      const otMessageInfo *aMessageInfo,
                                                      Error                aResult)
 {
-    static_cast<Commissioner *>(aContext)->HandleMgmtCommissionerGetResponse(
-        static_cast<Coap::Message *>(aMessage), static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
+    static_cast<Commissioner *>(aContext)->HandleMgmtCommissionerGetResponse(AsCoapMessagePtr(aMessage),
+                                                                             AsCoreTypePtr(aMessageInfo), aResult);
 }
 
 void Commissioner::HandleMgmtCommissionerGetResponse(Coap::Message *         aMessage,
@@ -801,8 +802,8 @@ void Commissioner::HandleMgmtCommissionerSetResponse(void *               aConte
                                                      const otMessageInfo *aMessageInfo,
                                                      Error                aResult)
 {
-    static_cast<Commissioner *>(aContext)->HandleMgmtCommissionerSetResponse(
-        static_cast<Coap::Message *>(aMessage), static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
+    static_cast<Commissioner *>(aContext)->HandleMgmtCommissionerSetResponse(AsCoapMessagePtr(aMessage),
+                                                                             AsCoreTypePtr(aMessageInfo), aResult);
 }
 
 void Commissioner::HandleMgmtCommissionerSetResponse(Coap::Message *         aMessage,
@@ -855,8 +856,8 @@ void Commissioner::HandleLeaderPetitionResponse(void *               aContext,
                                                 const otMessageInfo *aMessageInfo,
                                                 Error                aResult)
 {
-    static_cast<Commissioner *>(aContext)->HandleLeaderPetitionResponse(
-        static_cast<Coap::Message *>(aMessage), static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
+    static_cast<Commissioner *>(aContext)->HandleLeaderPetitionResponse(AsCoapMessagePtr(aMessage),
+                                                                        AsCoreTypePtr(aMessageInfo), aResult);
 }
 
 void Commissioner::HandleLeaderPetitionResponse(Coap::Message *         aMessage,
@@ -950,8 +951,8 @@ void Commissioner::HandleLeaderKeepAliveResponse(void *               aContext,
                                                  const otMessageInfo *aMessageInfo,
                                                  Error                aResult)
 {
-    static_cast<Commissioner *>(aContext)->HandleLeaderKeepAliveResponse(
-        static_cast<Coap::Message *>(aMessage), static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
+    static_cast<Commissioner *>(aContext)->HandleLeaderKeepAliveResponse(AsCoapMessagePtr(aMessage),
+                                                                         AsCoreTypePtr(aMessageInfo), aResult);
 }
 
 void Commissioner::HandleLeaderKeepAliveResponse(Coap::Message *         aMessage,
@@ -979,8 +980,7 @@ exit:
 
 void Commissioner::HandleRelayReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Commissioner *>(aContext)->HandleRelayReceive(*static_cast<Coap::Message *>(aMessage),
-                                                              *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Commissioner *>(aContext)->HandleRelayReceive(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Commissioner::HandleRelayReceive(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -1048,8 +1048,7 @@ exit:
 
 void Commissioner::HandleDatasetChanged(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Commissioner *>(aContext)->HandleDatasetChanged(*static_cast<Coap::Message *>(aMessage),
-                                                                *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Commissioner *>(aContext)->HandleDatasetChanged(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Commissioner::HandleDatasetChanged(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -1068,8 +1067,7 @@ exit:
 
 void Commissioner::HandleJoinerFinalize(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Commissioner *>(aContext)->HandleJoinerFinalize(*static_cast<Coap::Message *>(aMessage),
-                                                                *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Commissioner *>(aContext)->HandleJoinerFinalize(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Commissioner::HandleJoinerFinalize(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -36,6 +36,7 @@
 
 #include <stdio.h>
 
+#include "common/as_core_type.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
 #include "common/logging.hpp"
@@ -316,8 +317,8 @@ void DatasetManager::HandleMgmtSetResponse(void *               aContext,
                                            const otMessageInfo *aMessageInfo,
                                            Error                aError)
 {
-    static_cast<DatasetManager *>(aContext)->HandleMgmtSetResponse(
-        static_cast<Coap::Message *>(aMessage), static_cast<const Ip6::MessageInfo *>(aMessageInfo), aError);
+    static_cast<DatasetManager *>(aContext)->HandleMgmtSetResponse(AsCoapMessagePtr(aMessage),
+                                                                   AsCoreTypePtr(aMessageInfo), aError);
 }
 
 void DatasetManager::HandleMgmtSetResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aError)
@@ -642,7 +643,7 @@ Error DatasetManager::SendGetRequest(const Dataset::Components &aDatasetComponen
 
     if (aAddress != nullptr)
     {
-        messageInfo.SetPeerAddr(*static_cast<const Ip6::Address *>(aAddress));
+        messageInfo.SetPeerAddr(AsCoreType(aAddress));
     }
     else
     {
@@ -704,8 +705,7 @@ exit:
 
 void ActiveDataset::HandleGet(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<ActiveDataset *>(aContext)->HandleGet(*static_cast<Coap::Message *>(aMessage),
-                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<ActiveDataset *>(aContext)->HandleGet(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void ActiveDataset::HandleGet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const
@@ -855,8 +855,7 @@ exit:
 
 void PendingDataset::HandleGet(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<PendingDataset *>(aContext)->HandleGet(*static_cast<Coap::Message *>(aMessage),
-                                                       *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<PendingDataset *>(aContext)->HandleGet(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void PendingDataset::HandleGet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -41,6 +41,7 @@
 #include <openthread/platform/radio.h>
 
 #include "coap/coap_message.hpp"
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -406,8 +407,7 @@ void ActiveDataset::StopLeader(void)
 
 void ActiveDataset::HandleSet(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<ActiveDataset *>(aContext)->HandleSet(*static_cast<Coap::Message *>(aMessage),
-                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<ActiveDataset *>(aContext)->HandleSet(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void ActiveDataset::HandleSet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -432,8 +432,7 @@ void PendingDataset::StopLeader(void)
 
 void PendingDataset::HandleSet(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<PendingDataset *>(aContext)->HandleSet(*static_cast<Coap::Message *>(aMessage),
-                                                       *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<PendingDataset *>(aContext)->HandleSet(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void PendingDataset::HandleSet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/meshcop/energy_scan_client.cpp
+++ b/src/core/meshcop/energy_scan_client.cpp
@@ -36,6 +36,7 @@
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
 
 #include "coap/coap_message.hpp"
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
@@ -105,8 +106,7 @@ exit:
 
 void EnergyScanClient::HandleReport(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<EnergyScanClient *>(aContext)->HandleReport(*static_cast<Coap::Message *>(aMessage),
-                                                            *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<EnergyScanClient *>(aContext)->HandleReport(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void EnergyScanClient::HandleReport(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -37,6 +37,7 @@
 
 #include <stdio.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
@@ -304,11 +305,11 @@ void Joiner::SaveDiscoveredJoinerRouter(const Mle::DiscoverScanner::ScanResult &
     JoinerRouter *end = OT_ARRAY_END(mJoinerRouters);
     JoinerRouter *entry;
 
-    doesAllowAny = static_cast<const SteeringData &>(aResult.mSteeringData).PermitsAllJoiners();
+    doesAllowAny = AsCoreType(&aResult.mSteeringData).PermitsAllJoiners();
 
     otLogInfoMeshCoP("Joiner discover network: %s, pan:0x%04x, port:%d, chan:%d, rssi:%d, allow-any:%s",
-                     static_cast<const Mac::ExtAddress &>(aResult.mExtAddress).ToString().AsCString(), aResult.mPanId,
-                     aResult.mJoinerUdpPort, aResult.mChannel, aResult.mRssi, doesAllowAny ? "yes" : "no");
+                     AsCoreType(&aResult.mExtAddress).ToString().AsCString(), aResult.mPanId, aResult.mJoinerUdpPort,
+                     aResult.mChannel, aResult.mRssi, doesAllowAny ? "yes" : "no");
 
     priority = CalculatePriority(aResult.mRssi, doesAllowAny);
 
@@ -329,7 +330,7 @@ void Joiner::SaveDiscoveredJoinerRouter(const Mle::DiscoverScanner::ScanResult &
     memmove(entry + 1, entry,
             static_cast<size_t>(reinterpret_cast<uint8_t *>(end - 1) - reinterpret_cast<uint8_t *>(entry)));
 
-    entry->mExtAddr       = static_cast<const Mac::ExtAddress &>(aResult.mExtAddress);
+    entry->mExtAddr       = AsCoreType(&aResult.mExtAddress);
     entry->mPanId         = aResult.mPanId;
     entry->mJoinerUdpPort = aResult.mJoinerUdpPort;
     entry->mChannel       = aResult.mChannel;
@@ -524,8 +525,8 @@ void Joiner::HandleJoinerFinalizeResponse(void *               aContext,
                                           const otMessageInfo *aMessageInfo,
                                           Error                aResult)
 {
-    static_cast<Joiner *>(aContext)->HandleJoinerFinalizeResponse(
-        static_cast<Coap::Message *>(aMessage), static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
+    static_cast<Joiner *>(aContext)->HandleJoinerFinalizeResponse(AsCoapMessagePtr(aMessage), &AsCoreType(aMessageInfo),
+                                                                  aResult);
 }
 
 void Joiner::HandleJoinerFinalizeResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult)
@@ -557,8 +558,7 @@ exit:
 
 void Joiner::HandleJoinerEntrust(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Joiner *>(aContext)->HandleJoinerEntrust(*static_cast<Coap::Message *>(aMessage),
-                                                         *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Joiner *>(aContext)->HandleJoinerEntrust(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Joiner::HandleJoinerEntrust(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -37,6 +37,7 @@
 
 #include <stdio.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
@@ -124,8 +125,7 @@ void JoinerRouter::SetJoinerUdpPort(uint16_t aJoinerUdpPort)
 
 void JoinerRouter::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<JoinerRouter *>(aContext)->HandleUdpReceive(*static_cast<Message *>(aMessage),
-                                                            *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<JoinerRouter *>(aContext)->HandleUdpReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo));
 }
 
 void JoinerRouter::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -172,8 +172,7 @@ exit:
 
 void JoinerRouter::HandleRelayTransmit(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<JoinerRouter *>(aContext)->HandleRelayTransmit(*static_cast<Coap::Message *>(aMessage),
-                                                               *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<JoinerRouter *>(aContext)->HandleRelayTransmit(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void JoinerRouter::HandleRelayTransmit(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -392,8 +391,8 @@ void JoinerRouter::HandleJoinerEntrustResponse(void *               aContext,
                                                const otMessageInfo *aMessageInfo,
                                                Error                aResult)
 {
-    static_cast<JoinerRouter *>(aContext)->HandleJoinerEntrustResponse(
-        static_cast<Coap::Message *>(aMessage), static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
+    static_cast<JoinerRouter *>(aContext)->HandleJoinerEntrustResponse(AsCoapMessagePtr(aMessage),
+                                                                       AsCoreTypePtr(aMessageInfo), aResult);
 }
 
 void JoinerRouter::HandleJoinerEntrustResponse(Coap::Message *         aMessage,

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -38,6 +38,7 @@
 #include <stdio.h>
 
 #include "coap/coap_message.hpp"
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
@@ -66,8 +67,7 @@ Leader::Leader(Instance &aInstance)
 
 void Leader::HandlePetition(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Leader *>(aContext)->HandlePetition(*static_cast<Coap::Message *>(aMessage),
-                                                    *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Leader *>(aContext)->HandlePetition(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Leader::HandlePetition(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -154,8 +154,7 @@ exit:
 
 void Leader::HandleKeepAlive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Leader *>(aContext)->HandleKeepAlive(*static_cast<Coap::Message *>(aMessage),
-                                                     *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Leader *>(aContext)->HandleKeepAlive(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Leader::HandleKeepAlive(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/meshcop/panid_query_client.cpp
+++ b/src/core/meshcop/panid_query_client.cpp
@@ -36,6 +36,7 @@
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
 
 #include "coap/coap_message.hpp"
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -100,8 +101,7 @@ exit:
 
 void PanIdQueryClient::HandleConflict(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<PanIdQueryClient *>(aContext)->HandleConflict(*static_cast<Coap::Message *>(aMessage),
-                                                              *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<PanIdQueryClient *>(aContext)->HandleConflict(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void PanIdQueryClient::HandleConflict(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/net/dhcp6_client.cpp
+++ b/src/core/net/dhcp6_client.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
@@ -397,8 +398,7 @@ Error Client::AppendRapidCommit(Message &aMessage)
 
 void Client::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Client *>(aContext)->HandleUdpReceive(*static_cast<Message *>(aMessage),
-                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Client *>(aContext)->HandleUdpReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/net/dhcp6_server.cpp
+++ b/src/core/net/dhcp6_server.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
@@ -110,8 +111,7 @@ Error Server::UpdateService(void)
             continue;
         }
 
-        error = Get<NetworkData::Leader>().GetContext(static_cast<const Ip6::Address &>(config.mPrefix.mPrefix),
-                                                      lowpanContext);
+        error = Get<NetworkData::Leader>().GetContext(AsCoreType(&config.mPrefix.mPrefix), lowpanContext);
 
         if (error == kErrorNone)
         {
@@ -181,8 +181,7 @@ exit:
 
 void Server::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Server *>(aContext)->HandleUdpReceive(*static_cast<Message *>(aMessage),
-                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Server *>(aContext)->HandleUdpReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -30,6 +30,7 @@
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -258,12 +259,12 @@ Error Client::Response::FindServiceInfo(Section aSection, const Name &aName, Ser
 
     // Search in additional section for AAAA record for the host name.
 
-    error = FindHostAddress(kAdditionalDataSection, hostName, /* aIndex */ 0,
-                            static_cast<Ip6::Address &>(aServiceInfo.mHostAddress), aServiceInfo.mHostAddressTtl);
+    error = FindHostAddress(kAdditionalDataSection, hostName, /* aIndex */ 0, AsCoreType(&aServiceInfo.mHostAddress),
+                            aServiceInfo.mHostAddressTtl);
 
     if (error == kErrorNotFound)
     {
-        static_cast<Ip6::Address &>(aServiceInfo.mHostAddress).Clear();
+        AsCoreType(&aServiceInfo.mHostAddress).Clear();
         aServiceInfo.mHostAddressTtl = 0;
     }
     else
@@ -924,7 +925,7 @@ void Client::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessa
 {
     OT_UNUSED_VARIABLE(aMsgInfo);
 
-    static_cast<Client *>(aContext)->ProcessResponse(*static_cast<Message *>(aMessage));
+    static_cast<Client *>(aContext)->ProcessResponse(AsCoreType(aMessage));
 }
 
 void Client::ProcessResponse(const Message &aMessage)

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -109,8 +110,7 @@ void Server::Stop(void)
 
 void Server::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Server *>(aContext)->HandleUdpReceive(*static_cast<Message *>(aMessage),
-                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Server *>(aContext)->HandleUdpReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -918,7 +918,7 @@ void Server::AnswerQuery(QueryTransaction &                aQuery,
         {
             for (uint8_t i = 0; i < aInstanceInfo.mAddressNum; i++)
             {
-                const Ip6::Address &address = static_cast<const Ip6::Address &>(aInstanceInfo.mAddresses[i]);
+                const Ip6::Address &address = AsCoreType(&aInstanceInfo.mAddresses[i]);
 
                 OT_ASSERT(!address.IsUnspecified() && !address.IsLinkLocal() && !address.IsMulticast() &&
                           !address.IsLoopback());
@@ -946,7 +946,7 @@ void Server::AnswerQuery(QueryTransaction &aQuery, const char *aHostFullName, co
     {
         for (uint8_t i = 0; i < aHostInfo.mAddressNum; i++)
         {
-            const Ip6::Address &address = static_cast<const Ip6::Address &>(aHostInfo.mAddresses[i]);
+            const Ip6::Address &address = AsCoreType(&aHostInfo.mAddresses[i]);
 
             OT_ASSERT(!address.IsUnspecified() && !address.IsMulticast() && !address.IsLinkLocal() &&
                       !address.IsLoopback());

--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -35,6 +35,7 @@
 
 #include <stdio.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
@@ -144,7 +145,7 @@ void Prefix::ToString(StringWriter &aWriter) const
 {
     uint8_t sizeInUint16 = (GetBytesSize() + sizeof(uint16_t) - 1) / sizeof(uint16_t);
 
-    static_cast<const Address &>(mPrefix).AppendHexWords(aWriter, sizeInUint16);
+    AsCoreType(&mPrefix).AppendHexWords(aWriter, sizeInUint16);
 
     if (GetBytesSize() < Address::kSize - 1)
     {
@@ -659,27 +660,27 @@ void Address::AppendHexWords(StringWriter &aWriter, uint8_t aLength) const
 
 const Address &Address::GetLinkLocalAllNodesMulticast(void)
 {
-    return static_cast<const Address &>(Netif::kLinkLocalAllNodesMulticastAddress.mAddress);
+    return AsCoreType(&Netif::kLinkLocalAllNodesMulticastAddress.mAddress);
 }
 
 const Address &Address::GetLinkLocalAllRoutersMulticast(void)
 {
-    return static_cast<const Address &>(Netif::kLinkLocalAllRoutersMulticastAddress.mAddress);
+    return AsCoreType(&Netif::kLinkLocalAllRoutersMulticastAddress.mAddress);
 }
 
 const Address &Address::GetRealmLocalAllNodesMulticast(void)
 {
-    return static_cast<const Address &>(Netif::kRealmLocalAllNodesMulticastAddress.mAddress);
+    return AsCoreType(&Netif::kRealmLocalAllNodesMulticastAddress.mAddress);
 }
 
 const Address &Address::GetRealmLocalAllRoutersMulticast(void)
 {
-    return static_cast<const Address &>(Netif::kRealmLocalAllRoutersMulticastAddress.mAddress);
+    return AsCoreType(&Netif::kRealmLocalAllRoutersMulticastAddress.mAddress);
 }
 
 const Address &Address::GetRealmLocalAllMplForwarders(void)
 {
-    return static_cast<const Address &>(Netif::kRealmLocalAllMplForwardersMulticastAddress.mAddress);
+    return AsCoreType(&Netif::kRealmLocalAllMplForwardersMulticastAddress.mAddress);
 }
 
 } // namespace Ip6

--- a/src/core/net/nd_agent.cpp
+++ b/src/core/net/nd_agent.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_CONFIG_NEIGHBOR_DISCOVERY_AGENT_ENABLE
 
+#include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 #include "thread/lowpan.hpp"
 #include "thread/mle_router.hpp"
@@ -67,8 +68,7 @@ void Agent::UpdateService(void)
                 continue;
             }
 
-            error = Get<NetworkData::Leader>().GetContext(static_cast<const Ip6::Address &>(config.mPrefix.mPrefix),
-                                                          lowpanContext);
+            error = Get<NetworkData::Leader>().GetContext(AsCoreType(&config.mPrefix.mPrefix), lowpanContext);
 
             if ((error != kErrorNone) || (lowpanContext.mContextId != contextId))
             {
@@ -97,8 +97,7 @@ void Agent::UpdateService(void)
             continue;
         }
 
-        error = Get<NetworkData::Leader>().GetContext(static_cast<const Ip6::Address &>(config.mPrefix.mPrefix),
-                                                      lowpanContext);
+        error = Get<NetworkData::Leader>().GetContext(AsCoreType(&config.mPrefix.mPrefix), lowpanContext);
 
         if (error == kErrorNone)
         {

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -33,6 +33,7 @@
 
 #include "netif.hpp"
 
+#include "common/as_core_type.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
@@ -122,8 +123,7 @@ bool Netif::IsMulticastSubscribed(const Address &aAddress) const
 void Netif::SubscribeAllNodesMulticast(void)
 {
     MulticastAddress *tail;
-    MulticastAddress &linkLocalAllNodesAddress =
-        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllNodesMulticastAddress));
+    MulticastAddress &linkLocalAllNodesAddress = AsCoreType(&AsNonConst(kLinkLocalAllNodesMulticastAddress));
 
     VerifyOrExit(!mMulticastAddresses.Contains(linkLocalAllNodesAddress));
 
@@ -170,8 +170,7 @@ exit:
 void Netif::UnsubscribeAllNodesMulticast(void)
 {
     MulticastAddress *      prev;
-    const MulticastAddress &linkLocalAllNodesAddress =
-        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllNodesMulticastAddress));
+    const MulticastAddress &linkLocalAllNodesAddress = AsCoreType(&AsNonConst(kLinkLocalAllNodesMulticastAddress));
 
     // The tail of multicast address linked list contains the
     // fixed addresses. Search if LinkLocalAll is present
@@ -189,7 +188,7 @@ void Netif::UnsubscribeAllNodesMulticast(void)
     //    LinkLocalAllRouters -> RealmLocalAllRouters -> LinkLocalAll
     //         -> RealmLocalAll -> RealmLocalAllMpl.
 
-    OT_ASSERT(prev != static_cast<MulticastAddress *>(AsNonConst(&kRealmLocalAllRoutersMulticastAddress)));
+    OT_ASSERT(prev != AsCoreTypePtr(AsNonConst(&kRealmLocalAllRoutersMulticastAddress)));
 
     if (prev == nullptr)
     {
@@ -226,13 +225,10 @@ exit:
 
 void Netif::SubscribeAllRoutersMulticast(void)
 {
-    MulticastAddress *prev = nullptr;
-    MulticastAddress &linkLocalAllRoutersAddress =
-        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllRoutersMulticastAddress));
-    MulticastAddress &linkLocalAllNodesAddress =
-        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllNodesMulticastAddress));
-    MulticastAddress &realmLocalAllRoutersAddress =
-        static_cast<MulticastAddress &>(AsNonConst(kRealmLocalAllRoutersMulticastAddress));
+    MulticastAddress *prev                        = nullptr;
+    MulticastAddress &linkLocalAllRoutersAddress  = AsCoreType(&AsNonConst(kLinkLocalAllRoutersMulticastAddress));
+    MulticastAddress &linkLocalAllNodesAddress    = AsCoreType(&AsNonConst(kLinkLocalAllNodesMulticastAddress));
+    MulticastAddress &realmLocalAllRoutersAddress = AsCoreType(&AsNonConst(kRealmLocalAllRoutersMulticastAddress));
 
     // This method MUST be called after `SubscribeAllNodesMulticast()`
     // Ensure that the `LinkLocalAll` was found on the list.
@@ -292,10 +288,8 @@ exit:
 void Netif::UnsubscribeAllRoutersMulticast(void)
 {
     MulticastAddress *prev;
-    MulticastAddress &linkLocalAllRoutersAddress =
-        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllRoutersMulticastAddress));
-    MulticastAddress &linkLocalAllNodesAddress =
-        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllNodesMulticastAddress));
+    MulticastAddress &linkLocalAllRoutersAddress = AsCoreType(&AsNonConst(kLinkLocalAllRoutersMulticastAddress));
+    MulticastAddress &linkLocalAllNodesAddress   = AsCoreType(&AsNonConst(kLinkLocalAllNodesMulticastAddress));
 
     // The tail of multicast address linked list contains the
     // fixed addresses. We check for the chain of five addresses:
@@ -392,9 +386,8 @@ exit:
 
 Error Netif::SubscribeExternalMulticast(const Address &aAddress)
 {
-    Error             error = kErrorNone;
-    MulticastAddress &linkLocalAllRoutersAddress =
-        static_cast<MulticastAddress &>(AsNonConst(kLinkLocalAllRoutersMulticastAddress));
+    Error             error                      = kErrorNone;
+    MulticastAddress &linkLocalAllRoutersAddress = AsCoreType(&AsNonConst(kLinkLocalAllRoutersMulticastAddress));
     ExternalMulticastAddress *entry;
 
     VerifyOrExit(aAddress.IsMulticast(), error = kErrorInvalidArgs);

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -31,6 +31,7 @@
 
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -143,7 +144,7 @@ Error Client::Query(const otSntpQuery *aQuery, otSntpResponseHandler aHandler, v
 
     VerifyOrExit((message = NewMessage(header)) != nullptr, error = kErrorNoBufs);
 
-    messageInfo = static_cast<const Ip6::MessageInfo *>(aQuery->mMessageInfo);
+    messageInfo = AsCoreTypePtr(aQuery->mMessageInfo);
 
     queryMetadata.mTransmitTimestamp   = header.GetTransmitTimestampSeconds();
     queryMetadata.mTransmissionTime    = TimerMilli::GetNow() + kResponseTimeout;
@@ -331,8 +332,7 @@ void Client::HandleRetransmissionTimer(void)
 
 void Client::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Client *>(aContext)->HandleUdpReceive(*static_cast<Message *>(aMessage),
-                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Client *>(aContext)->HandleUdpReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Client::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -30,6 +30,7 @@
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -72,7 +73,7 @@ void Client::HostInfo::SetState(ItemState aState)
     if (aState != GetState())
     {
         otLogInfoSrp("[client] HostInfo %s -> %s", ItemStateToString(GetState()), ItemStateToString(aState));
-        mState = static_cast<otSrpClientItemState>(aState);
+        mState = MapEnum(aState);
     }
 }
 
@@ -136,7 +137,7 @@ void Client::Service::SetState(ItemState aState)
                      GetWeight(), GetPriority(), GetNumTxtEntries());
     }
 
-    mState = static_cast<otSrpClientItemState>(aState);
+    mState = MapEnum(aState);
 
 exit:
     return;
@@ -1168,7 +1169,7 @@ void Client::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessa
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    static_cast<Client *>(aContext)->ProcessResponse(*static_cast<Message *>(aMessage));
+    static_cast<Client *>(aContext)->ProcessResponse(AsCoreType(aMessage));
 }
 
 void Client::ProcessResponse(Message &aMessage)

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
 
+#include "common/as_core_type.hpp"
 #include "common/const_cast.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
@@ -1240,8 +1241,7 @@ exit:
 
 void Server::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Server *>(aContext)->HandleUdpReceive(*static_cast<Message *>(aMessage),
-                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Server *>(aContext)->HandleUdpReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Server::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -37,6 +37,7 @@
 
 #include "tcp6.hpp"
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/error.hpp"
 #include "common/instance.hpp"
@@ -77,19 +78,19 @@ exit:
 
 Instance &Tcp::Endpoint::GetInstance(void)
 {
-    return *static_cast<Instance *>(mInstance);
+    return AsCoreType(mInstance);
 }
 
 const SockAddr &Tcp::Endpoint::GetLocalAddress(void) const
 {
     static otSockAddr temp;
-    return *static_cast<SockAddr *>(&temp);
+    return AsCoreType(&temp);
 }
 
 const SockAddr &Tcp::Endpoint::GetPeerAddress(void) const
 {
     static otSockAddr temp;
-    return *static_cast<SockAddr *>(&temp);
+    return AsCoreType(&temp);
 }
 
 Error Tcp::Endpoint::Bind(const SockAddr &aSockName)
@@ -273,7 +274,7 @@ exit:
 
 Instance &Tcp::Listener::GetInstance(void)
 {
-    return *static_cast<Instance *>(mInstance);
+    return AsCoreType(mInstance);
 }
 
 Error Tcp::Listener::Listen(const SockAddr &aSockName)

--- a/src/core/radio/radio_platform.cpp
+++ b/src/core/radio/radio_platform.cpp
@@ -33,6 +33,7 @@
 #include <openthread/instance.h>
 #include <openthread/platform/time.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "radio/radio.hpp"
@@ -46,7 +47,7 @@ using namespace ot;
 
 extern "C" void otPlatRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
 {
-    Instance &    instance = *static_cast<Instance *>(aInstance);
+    Instance &    instance = AsCoreType(aInstance);
     Mac::RxFrame *rxFrame  = static_cast<Mac::RxFrame *>(aFrame);
 
     VerifyOrExit(instance.IsInitialized());
@@ -66,7 +67,7 @@ exit:
 
 extern "C" void otPlatRadioTxStarted(otInstance *aInstance, otRadioFrame *aFrame)
 {
-    Instance &    instance = *static_cast<Instance *>(aInstance);
+    Instance &    instance = AsCoreType(aInstance);
     Mac::TxFrame &txFrame  = *static_cast<Mac::TxFrame *>(aFrame);
 
     VerifyOrExit(instance.IsInitialized());
@@ -83,7 +84,7 @@ exit:
 
 extern "C" void otPlatRadioTxDone(otInstance *aInstance, otRadioFrame *aFrame, otRadioFrame *aAckFrame, otError aError)
 {
-    Instance &    instance = *static_cast<Instance *>(aInstance);
+    Instance &    instance = AsCoreType(aInstance);
     Mac::TxFrame &txFrame  = *static_cast<Mac::TxFrame *>(aFrame);
     Mac::RxFrame *ackFrame = static_cast<Mac::RxFrame *>(aAckFrame);
 
@@ -106,7 +107,7 @@ exit:
 
 extern "C" void otPlatRadioEnergyScanDone(otInstance *aInstance, int8_t aEnergyScanMaxRssi)
 {
-    Instance &instance = *static_cast<Instance *>(aInstance);
+    Instance &instance = AsCoreType(aInstance);
 
     VerifyOrExit(instance.IsInitialized());
     instance.Get<Radio::Callbacks>().HandleEnergyScanDone(aEnergyScanMaxRssi);
@@ -118,8 +119,7 @@ exit:
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
 extern "C" void otPlatDiagRadioReceiveDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
 {
-    Instance &    instance = *static_cast<Instance *>(aInstance);
-    Mac::RxFrame *rxFrame  = static_cast<Mac::RxFrame *>(aFrame);
+    Mac::RxFrame *rxFrame = static_cast<Mac::RxFrame *>(aFrame);
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     if (rxFrame != nullptr)
@@ -128,19 +128,18 @@ extern "C" void otPlatDiagRadioReceiveDone(otInstance *aInstance, otRadioFrame *
     }
 #endif
 
-    instance.Get<Radio::Callbacks>().HandleDiagsReceiveDone(rxFrame, aError);
+    AsCoreType(aInstance).Get<Radio::Callbacks>().HandleDiagsReceiveDone(rxFrame, aError);
 }
 
 extern "C" void otPlatDiagRadioTransmitDone(otInstance *aInstance, otRadioFrame *aFrame, otError aError)
 {
-    Instance &    instance = *static_cast<Instance *>(aInstance);
-    Mac::TxFrame &txFrame  = *static_cast<Mac::TxFrame *>(aFrame);
+    Mac::TxFrame &txFrame = *static_cast<Mac::TxFrame *>(aFrame);
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     txFrame.SetRadioType(Mac::kRadioTypeIeee802154);
 #endif
 
-    instance.Get<Radio::Callbacks>().HandleDiagsTransmitDone(txFrame, aError);
+    AsCoreType(aInstance).Get<Radio::Callbacks>().HandleDiagsTransmitDone(txFrame, aError);
 }
 #endif
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -36,6 +36,7 @@
 #if OPENTHREAD_FTD
 
 #include "coap/coap_message.hpp"
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
@@ -139,8 +140,8 @@ Error AddressResolver::GetNextCacheEntry(EntryInfo &aInfo, Iterator &aIterator) 
         VerifyOrExit(entry->IsLastTransactionTimeValid());
 
         aInfo.mLastTransTime = entry->GetLastTransactionTime();
-        static_cast<Ip6::Address &>(aInfo.mMeshLocalEid).SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-        static_cast<Ip6::Address &>(aInfo.mMeshLocalEid).SetIid(entry->GetMeshLocalIid());
+        AsCoreType(&aInfo.mMeshLocalEid).SetPrefix(Get<Mle::MleRouter>().GetMeshLocalPrefix());
+        AsCoreType(&aInfo.mMeshLocalEid).SetIid(entry->GetMeshLocalIid());
 
         ExitNow();
     }
@@ -583,8 +584,8 @@ exit:
 
 void AddressResolver::HandleAddressNotification(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<AddressResolver *>(aContext)->HandleAddressNotification(
-        *static_cast<Coap::Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<AddressResolver *>(aContext)->HandleAddressNotification(AsCoapMessage(aMessage),
+                                                                        AsCoreType(aMessageInfo));
 }
 
 void AddressResolver::HandleAddressNotification(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -699,8 +700,7 @@ exit:
 
 void AddressResolver::HandleAddressError(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<AddressResolver *>(aContext)->HandleAddressError(*static_cast<Coap::Message *>(aMessage),
-                                                                 *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<AddressResolver *>(aContext)->HandleAddressError(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -780,8 +780,7 @@ exit:
 
 void AddressResolver::HandleAddressQuery(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<AddressResolver *>(aContext)->HandleAddressQuery(*static_cast<Coap::Message *>(aMessage),
-                                                                 *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<AddressResolver *>(aContext)->HandleAddressQuery(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void AddressResolver::HandleAddressQuery(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -959,9 +958,8 @@ void AddressResolver::HandleIcmpReceive(void *               aContext,
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    static_cast<AddressResolver *>(aContext)->HandleIcmpReceive(*static_cast<Message *>(aMessage),
-                                                                *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-                                                                *static_cast<const Ip6::Icmp::Header *>(aIcmpHeader));
+    static_cast<AddressResolver *>(aContext)->HandleIcmpReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo),
+                                                                AsCoreType(aIcmpHeader));
 }
 
 void AddressResolver::HandleIcmpReceive(Message &                aMessage,

--- a/src/core/thread/announce_begin_server.cpp
+++ b/src/core/thread/announce_begin_server.cpp
@@ -36,6 +36,7 @@
 #include <openthread/platform/radio.h>
 
 #include "coap/coap_message.hpp"
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -64,8 +65,7 @@ void AnnounceBeginServer::SendAnnounce(uint32_t aChannelMask, uint8_t aCount, ui
 
 void AnnounceBeginServer::HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<AnnounceBeginServer *>(aContext)->HandleRequest(*static_cast<Coap::Message *>(aMessage),
-                                                                *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<AnnounceBeginServer *>(aContext)->HandleRequest(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void AnnounceBeginServer::HandleRequest(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/thread/anycast_locator.cpp
+++ b/src/core/thread/anycast_locator.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
@@ -96,8 +97,8 @@ void AnycastLocator::HandleResponse(void *               aContext,
                                     const otMessageInfo *aMessageInfo,
                                     Error                aError)
 {
-    static_cast<AnycastLocator *>(aContext)->HandleResponse(
-        static_cast<Coap::Message *>(aMessage), static_cast<const Ip6::MessageInfo *>(aMessageInfo), aError);
+    static_cast<AnycastLocator *>(aContext)->HandleResponse(AsCoapMessagePtr(aMessage), AsCoreTypePtr(aMessageInfo),
+                                                            aError);
 }
 
 void AnycastLocator::HandleResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aError)
@@ -135,8 +136,7 @@ exit:
 
 void AnycastLocator::HandleAnycastLocate(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<AnycastLocator *>(aContext)->HandleAnycastLocate(*static_cast<const Coap::Message *>(aMessage),
-                                                                 *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<AnycastLocator *>(aContext)->HandleAnycastLocate(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void AnycastLocator::HandleAnycastLocate(const Coap::Message &aRequest, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -33,6 +33,7 @@
 
 #include "discover_scanner.hpp"
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
@@ -315,7 +316,7 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
     result.mRssi    = linkInfo->mRss;
     result.mLqi     = linkInfo->mLqi;
 
-    aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(static_cast<Mac::ExtAddress &>(result.mExtAddress));
+    aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(AsCoreType(&result.mExtAddress));
 
     // Process MeshCoP TLVs
     while (offset < end)
@@ -332,22 +333,22 @@ void DiscoverScanner::HandleDiscoveryResponse(const Message &aMessage, const Ip6
             break;
 
         case MeshCoP::Tlv::kExtendedPanId:
-            SuccessOrExit(error = Tlv::Read<MeshCoP::ExtendedPanIdTlv>(
-                              aMessage, offset, static_cast<Mac::ExtendedPanId &>(result.mExtendedPanId)));
+            SuccessOrExit(
+                error = Tlv::Read<MeshCoP::ExtendedPanIdTlv>(aMessage, offset, AsCoreType(&result.mExtendedPanId)));
             break;
 
         case MeshCoP::Tlv::kNetworkName:
             IgnoreError(aMessage.Read(offset, networkName));
             if (networkName.IsValid())
             {
-                IgnoreError(static_cast<Mac::NetworkName &>(result.mNetworkName).Set(networkName.GetNetworkName()));
+                IgnoreError(AsCoreType(&result.mNetworkName).Set(networkName.GetNetworkName()));
             }
             break;
 
         case MeshCoP::Tlv::kSteeringData:
             if (meshcopTlv.GetLength() > 0)
             {
-                MeshCoP::SteeringData &steeringData = static_cast<MeshCoP::SteeringData &>(result.mSteeringData);
+                MeshCoP::SteeringData &steeringData = AsCoreType(&result.mSteeringData);
                 uint8_t                dataLength   = MeshCoP::SteeringData::kMaxLength;
 
                 if (meshcopTlv.GetLength() < dataLength)

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
@@ -543,6 +544,15 @@ exit:
     FreeMessageOnError(message, error);
 }
 
+void DuaManager::HandleDuaResponse(void *               aContext,
+                                   otMessage *          aMessage,
+                                   const otMessageInfo *aMessageInfo,
+                                   Error                aResult)
+{
+    static_cast<DuaManager *>(aContext)->HandleDuaResponse(AsCoapMessagePtr(aMessage), AsCoreTypePtr(aMessageInfo),
+                                                           aResult);
+}
+
 void DuaManager::HandleDuaResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult)
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
@@ -576,6 +586,10 @@ exit:
     otLogInfoDua("Received DUA.rsp: %s", ErrorToString(error));
 }
 
+void DuaManager::HandleDuaNotification(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
+{
+    static_cast<DuaManager *>(aContext)->HandleDuaNotification(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
+}
 void DuaManager::HandleDuaNotification(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     OT_UNUSED_VARIABLE(aMessageInfo);

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -199,21 +199,15 @@ private:
 
     void UpdateTimeTickerRegistration(void);
 
-    static void HandleDuaResponse(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo, Error aResult)
-    {
-        static_cast<DuaManager *>(aContext)->HandleDuaResponse(
-            static_cast<Coap::Message *>(aMessage), static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
-    }
+    static void HandleDuaResponse(void *               aContext,
+                                  otMessage *          aMessage,
+                                  const otMessageInfo *aMessageInfo,
+                                  Error                aResult);
+    void        HandleDuaResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
 
-    void HandleDuaResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
+    static void HandleDuaNotification(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
+    void        HandleDuaNotification(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleDuaNotification(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
-    {
-        static_cast<DuaManager *>(aContext)->HandleDuaNotification(
-            *static_cast<Coap::Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
-    }
-
-    void  HandleDuaNotification(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     Error ProcessDuaResponse(Coap::Message &aMessage);
 
     void PerformNextRegistration(void);

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -34,6 +34,7 @@
 #include "energy_scan_server.hpp"
 
 #include "coap/coap_message.hpp"
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -63,8 +64,7 @@ EnergyScanServer::EnergyScanServer(Instance &aInstance)
 
 void EnergyScanServer::HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<EnergyScanServer *>(aContext)->HandleRequest(*static_cast<Coap::Message *>(aMessage),
-                                                             *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<EnergyScanServer *>(aContext)->HandleRequest(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void EnergyScanServer::HandleRequest(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -36,6 +36,7 @@
 #include <openthread/platform/radio.h>
 #include <openthread/platform/time.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
@@ -2689,8 +2690,7 @@ exit:
 
 void Mle::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Mle *>(aContext)->HandleUdpReceive(*static_cast<Message *>(aMessage),
-                                                   *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Mle *>(aContext)->HandleUdpReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -34,6 +34,7 @@
 
 #if OPENTHREAD_FTD
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
@@ -2916,7 +2917,7 @@ void MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Messa
         {
             otThreadDiscoveryRequestInfo info;
 
-            aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(*static_cast<Mac::ExtAddress *>(&info.mExtAddress));
+            aMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(AsCoreType(&info.mExtAddress));
             info.mVersion  = discoveryRequest.GetVersion();
             info.mIsJoiner = discoveryRequest.IsJoiner();
 
@@ -3670,8 +3671,8 @@ void MleRouter::HandleAddressSolicitResponse(void *               aContext,
                                              const otMessageInfo *aMessageInfo,
                                              Error                aResult)
 {
-    static_cast<MleRouter *>(aContext)->HandleAddressSolicitResponse(
-        static_cast<Coap::Message *>(aMessage), static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
+    static_cast<MleRouter *>(aContext)->HandleAddressSolicitResponse(AsCoapMessagePtr(aMessage),
+                                                                     AsCoreTypePtr(aMessageInfo), aResult);
 }
 
 void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
@@ -3778,8 +3779,7 @@ bool MleRouter::IsExpectedToBecomeRouterSoon(void) const
 
 void MleRouter::HandleAddressSolicit(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<MleRouter *>(aContext)->HandleAddressSolicit(*static_cast<Coap::Message *>(aMessage),
-                                                             *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<MleRouter *>(aContext)->HandleAddressSolicit(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void MleRouter::HandleAddressSolicit(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -3905,8 +3905,7 @@ exit:
 
 void MleRouter::HandleAddressRelease(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<MleRouter *>(aContext)->HandleAddressRelease(*static_cast<Coap::Message *>(aMessage),
-                                                             *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<MleRouter *>(aContext)->HandleAddressRelease(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void MleRouter::HandleAddressRelease(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
@@ -353,8 +354,8 @@ void MlrManager::HandleRegisterMulticastListenersResponse(void *               a
                                                           const otMessageInfo *aMessageInfo,
                                                           Error                aResult)
 {
-    static_cast<MlrManager *>(aContext)->HandleRegisterMulticastListenersResponse(
-        static_cast<Coap::Message *>(aMessage), static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
+    static_cast<MlrManager *>(aContext)->HandleRegisterMulticastListenersResponse(AsCoapMessagePtr(aMessage),
+                                                                                  AsCoreTypePtr(aMessageInfo), aResult);
 }
 
 void MlrManager::HandleRegisterMulticastListenersResponse(otMessage *          aMessage,
@@ -374,8 +375,8 @@ void MlrManager::HandleRegisterMulticastListenersResponse(otMessage *          a
     mRegisterMulticastListenersCallback = nullptr;
     mRegisterMulticastListenersContext  = nullptr;
 
-    error = ParseMulticastListenerRegistrationResponse(aResult, static_cast<Coap::Message *>(aMessage), status,
-                                                       failedAddresses, failedAddressNum);
+    error = ParseMulticastListenerRegistrationResponse(aResult, AsCoapMessagePtr(aMessage), status, failedAddresses,
+                                                       failedAddressNum);
 
     if (callback != nullptr)
     {
@@ -460,7 +461,7 @@ void MlrManager::HandleMulticastListenerRegistrationResponse(void *             
                                                              Error                aResult)
 {
     static_cast<MlrManager *>(aContext)->HandleMulticastListenerRegistrationResponse(
-        static_cast<Coap::Message *>(aMessage), static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
+        AsCoapMessagePtr(aMessage), AsCoreTypePtr(aMessageInfo), aResult);
 }
 
 void MlrManager::HandleMulticastListenerRegistrationResponse(Coap::Message *         aMessage,

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -36,6 +36,7 @@
 #if OPENTHREAD_FTD
 
 #include "coap/coap_message.hpp"
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
@@ -133,8 +134,7 @@ void Leader::RemoveBorderRouter(uint16_t aRloc16, MatchMode aMatchMode)
 
 void Leader::HandleServerData(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Leader *>(aContext)->HandleServerData(*static_cast<Coap::Message *>(aMessage),
-                                                      *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Leader *>(aContext)->HandleServerData(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Leader::HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -178,8 +178,7 @@ exit:
 
 void Leader::HandleCommissioningSet(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Leader *>(aContext)->HandleCommissioningSet(*static_cast<Coap::Message *>(aMessage),
-                                                            *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Leader *>(aContext)->HandleCommissioningSet(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Leader::HandleCommissioningSet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -282,8 +281,7 @@ exit:
 
 void Leader::HandleCommissioningGet(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Leader *>(aContext)->HandleCommissioningGet(*static_cast<Coap::Message *>(aMessage),
-                                                            *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Leader *>(aContext)->HandleCommissioningGet(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Leader::HandleCommissioningGet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -36,6 +36,7 @@
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
 
 #include "coap/coap_message.hpp"
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
@@ -132,8 +133,8 @@ void NetworkDiagnostic::HandleDiagnosticGetResponse(void *               aContex
                                                     const otMessageInfo *aMessageInfo,
                                                     Error                aResult)
 {
-    static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticGetResponse(
-        static_cast<Coap::Message *>(aMessage), static_cast<const Ip6::MessageInfo *>(aMessageInfo), aResult);
+    static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticGetResponse(AsCoapMessagePtr(aMessage),
+                                                                            AsCoreTypePtr(aMessageInfo), aResult);
 }
 
 void NetworkDiagnostic::HandleDiagnosticGetResponse(Coap::Message *         aMessage,
@@ -159,8 +160,8 @@ void NetworkDiagnostic::HandleDiagnosticGetAnswer(void *               aContext,
                                                   otMessage *          aMessage,
                                                   const otMessageInfo *aMessageInfo)
 {
-    static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticGetAnswer(
-        *static_cast<Coap::Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticGetAnswer(AsCoapMessage(aMessage),
+                                                                          AsCoreType(aMessageInfo));
 }
 
 void NetworkDiagnostic::HandleDiagnosticGetAnswer(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -454,8 +455,8 @@ exit:
 
 void NetworkDiagnostic::HandleDiagnosticGetQuery(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticGetQuery(
-        *static_cast<Coap::Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticGetQuery(AsCoapMessage(aMessage),
+                                                                         AsCoreType(aMessageInfo));
 }
 
 void NetworkDiagnostic::HandleDiagnosticGetQuery(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -517,8 +518,8 @@ void NetworkDiagnostic::HandleDiagnosticGetRequest(void *               aContext
                                                    otMessage *          aMessage,
                                                    const otMessageInfo *aMessageInfo)
 {
-    static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticGetRequest(
-        *static_cast<Coap::Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticGetRequest(AsCoapMessage(aMessage),
+                                                                           AsCoreType(aMessageInfo));
 }
 
 void NetworkDiagnostic::HandleDiagnosticGetRequest(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -596,8 +597,8 @@ exit:
 
 void NetworkDiagnostic::HandleDiagnosticReset(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticReset(
-        *static_cast<Coap::Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<NetworkDiagnostic *>(aContext)->HandleDiagnosticReset(AsCoapMessage(aMessage),
+                                                                      AsCoreType(aMessageInfo));
 }
 
 void NetworkDiagnostic::HandleDiagnosticReset(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
@@ -728,8 +729,8 @@ Error NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
         switch (tlv.GetType())
         {
         case NetworkDiagnosticTlv::kExtMacAddress:
-            SuccessOrExit(error = Tlv::Read<ExtMacAddressTlv>(
-                              aMessage, offset, static_cast<Mac::ExtAddress &>(aNetworkDiagTlv.mData.mExtAddress)));
+            SuccessOrExit(
+                error = Tlv::Read<ExtMacAddressTlv>(aMessage, offset, AsCoreType(&aNetworkDiagTlv.mData.mExtAddress)));
             break;
 
         case NetworkDiagnosticTlv::kAddress16:

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -34,6 +34,7 @@
 #include "panid_query_server.hpp"
 
 #include "coap/coap_message.hpp"
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -58,8 +59,7 @@ PanIdQueryServer::PanIdQueryServer(Instance &aInstance)
 
 void PanIdQueryServer::HandleQuery(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<PanIdQueryServer *>(aContext)->HandleQuery(*static_cast<Coap::Message *>(aMessage),
-                                                           *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<PanIdQueryServer *>(aContext)->HandleQuery(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
 }
 
 void PanIdQueryServer::HandleQuery(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/utils/history_tracker.cpp
+++ b/src/core/utils/history_tracker.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/instance.hpp"
@@ -62,7 +63,7 @@ void HistoryTracker::RecordNetworkInfo(void)
 
     VerifyOrExit(entry != nullptr);
 
-    entry->mRole        = static_cast<otDeviceRole>(Get<Mle::Mle>().GetRole());
+    entry->mRole        = MapEnum(Get<Mle::Mle>().GetRole());
     entry->mRloc16      = Get<Mle::Mle>().GetRloc16();
     entry->mPartitionId = Get<Mle::Mle>().GetLeaderData().GetPartitionId();
     mode                = Get<Mle::Mle>().GetDeviceMode();

--- a/src/core/utils/ping_sender.cpp
+++ b/src/core/utils/ping_sender.cpp
@@ -35,6 +35,7 @@
 
 #if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
 
+#include "common/as_core_type.hpp"
 #include "common/encoding.hpp"
 #include "common/locator_getters.hpp"
 #include "common/random.hpp"
@@ -107,7 +108,7 @@ Error PingSender::Ping(const Config &aConfig)
     VerifyOrExit(mConfig.mInterval <= Timer::kMaxDelay, error = kErrorInvalidArgs);
 
     mStatistics.Clear();
-    mStatistics.mIsMulticast = static_cast<Ip6::Address *>(&mConfig.mDestination)->IsMulticast();
+    mStatistics.mIsMulticast = AsCoreType(&mConfig.mDestination).IsMulticast();
 
     mIdentifier++;
     SendPing();
@@ -189,9 +190,8 @@ void PingSender::HandleIcmpReceive(void *               aContext,
                                    const otMessageInfo *aMessageInfo,
                                    const otIcmp6Header *aIcmpHeader)
 {
-    reinterpret_cast<PingSender *>(aContext)->HandleIcmpReceive(*static_cast<Message *>(aMessage),
-                                                                *static_cast<const Ip6::MessageInfo *>(aMessageInfo),
-                                                                *static_cast<const Ip6::Icmp::Header *>(aIcmpHeader));
+    reinterpret_cast<PingSender *>(aContext)->HandleIcmpReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo),
+                                                                AsCoreType(aIcmpHeader));
 }
 
 void PingSender::HandleIcmpReceive(const Message &          aMessage,


### PR DESCRIPTION
This commit uses `AsCoreType()` and other functions from header
`as_core_types.hpp` to cast between public OT C style definitions to
the related C++ core types in the core modules.