### PR TITLE
[build] fix android-check

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -365,6 +365,7 @@ LOCAL_SRC_FILES                                                  := \
     src/posix/platform/backbone.cpp                                 \
     src/posix/platform/daemon.cpp                                   \
     src/posix/platform/entropy.cpp                                  \
+    src/posix/platform/firewall.cpp                                 \
     src/posix/platform/hdlc_interface.cpp                           \
     src/posix/platform/infra_if.cpp                                 \
     src/posix/platform/logging.cpp                                  \
@@ -380,6 +381,7 @@ LOCAL_SRC_FILES                                                  := \
     src/posix/platform/system.cpp                                   \
     src/posix/platform/trel_udp6.cpp                                \
     src/posix/platform/udp.cpp                                      \
+    src/posix/platform/utils.cpp                                    \
     third_party/mbedtls/repo/library/aes.c                          \
     third_party/mbedtls/repo/library/aesni.c                        \
     third_party/mbedtls/repo/library/arc4.c                         \


### PR DESCRIPTION
The android-check was broken after ingress filtering (https://github.com/openthread/openthread/pull/7043) was checked in. This is because the newly added cpp files are missing in Android.mk. This PR adds the files in Android.mk so that CI should be passing.