### PR TITLE
[continuous-integration] fix test_firewall.py

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_firewall.py
+++ b/tests/scripts/thread-cert/border_router/test_firewall.py
@@ -95,7 +95,7 @@ class Firewall(thread_cert.TestCase):
         router1.add_ipmaddr(MA1)
         router1.register_netdata()
 
-        self.simulator.go(5)
+        self.simulator.go(20)
 
         def host_ping_ether(dest, interface, ttl=10, add_interface=False, add_route=False, gateway=None):
             if add_interface:


### PR DESCRIPTION
According to a previous CI run, 5 seconds may not be enough for OTBR to set up DUA route in the kernel. I'm extending the wait time to make the test less flaky.