### PR TITLE
[thci] allow to use Zephyr platforms

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -76,9 +76,6 @@ if TESTHARNESS_VERSION == TESTHARNESS_1_2:
 
 from IThci import IThci
 
-CMD_PREFIX = ''
-"""Prefix to be included before the CLI commands"""
-
 LINESEPX = re.compile(r'\r\n|\n')
 """regex: used to split lines"""
 


### PR DESCRIPTION
On initialization, detect if the device is running Zephyr and in that case modify the commands prefix and line ends.