### PR TITLE
[mle] configure poll/rx-on modes after child role change

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3681,16 +3681,6 @@ void Mle::HandleChildIdResponse(const Message &         aMessage,
 
     SetLeaderData(leaderData.GetPartitionId(), leaderData.GetWeighting(), leaderData.GetLeaderRouterId());
 
-    if (!IsRxOnWhenIdle())
-    {
-        Get<DataPollSender>().SetAttachMode(false);
-        Get<MeshForwarder>().SetRxOnWhenIdle(false);
-    }
-    else
-    {
-        Get<MeshForwarder>().SetRxOnWhenIdle(true);
-    }
-
 #if OPENTHREAD_FTD
     if (IsFullThreadDevice())
     {
@@ -3718,6 +3708,16 @@ void Mle::HandleChildIdResponse(const Message &         aMessage,
                                                           aMessage, networkDataOffset));
 
     SetStateChild(shortAddress);
+
+    if (!IsRxOnWhenIdle())
+    {
+        Get<DataPollSender>().SetAttachMode(false);
+        Get<MeshForwarder>().SetRxOnWhenIdle(false);
+    }
+    else
+    {
+        Get<MeshForwarder>().SetRxOnWhenIdle(true);
+    }
 
 exit:
     LogProcessError(kTypeChildIdResponse, error);


### PR DESCRIPTION
If we configure CSL parameters before a command to attach (see reproducer commands below), then the child has configured valid CSL state, but when trying to configure the auto-sync CSL poll timeout after attach, the check to `IsCslEnabled`->`IsCslCapable` fails because `IsChild()` fails.

When handling the child ID response success, we now trigger poll-sender's recalculation, and rx-on-idle states, after role change to child.

```bash
dataset channel 11
dataset panid 0xface
dataset networkkey 00112233445566778899aabbccddeeff
mode -
csl period 3125
csl timeout 30
dataset commit active
ifconfig up
thread start
```