### PR TITLE
[continuous-integration] fix MATN-15 ChangeOfPrimaryBBRTriggersRegistration.py

### DIFF
--- a/tests/scripts/thread-cert/border_router/MATN_15_ChangeOfPrimaryBBRTriggersRegistration.py
+++ b/tests/scripts/thread-cert/border_router/MATN_15_ChangeOfPrimaryBBRTriggersRegistration.py
@@ -92,6 +92,7 @@ class MATN_15_ChangeOfPrimaryBBRTriggersRegistration(thread_cert.TestCase):
         TD: {
             'name': 'TD',
             'allowlist': [ROUTER_1],
+            'router_eligible': False,
             'version': '1.2',
             'partition_id': 1,
         },
@@ -116,7 +117,7 @@ class MATN_15_ChangeOfPrimaryBBRTriggersRegistration(thread_cert.TestCase):
 
         td.start()
         self.simulator.go(5)
-        self.assertEqual('router', td.get_state())
+        self.assertEqual('child', td.get_state())
 
         br2.start()
         self.simulator.go(5)


### PR DESCRIPTION
This PR fixes https://github.com/openthread/openthread/issues/6954.

In the previous version of this test case, the ED node was actually a REED, where the test plan asks it to be a ED. Changing the node to ED makes the topology more stable. I've run the test case 50 times locally and none of them failed.