### PR TITLE
[tests] fix flaky advertising proxy tests

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_advertising_proxy.py
+++ b/tests/scripts/thread-cert/border_router/test_advertising_proxy.py
@@ -197,7 +197,7 @@ class SingleHostAndService(thread_cert.TestCase):
             client.srp_client_clear_service('my-service', '_ipps._tcp')
             client.srp_client_set_host_address(host_address)
             client.srp_client_add_service('my-service', '_ipps._tcp', service_port)
-            self.simulator.go(5)
+            self.simulator.go(10)
 
             self.check_host_and_service(server, client, host_address, 'my-service', service_port)
             self.host_check_mdns_service(host, host_address, 'my-service', service_port)

--- a/tests/scripts/thread-cert/border_router/test_advertising_proxy.py
+++ b/tests/scripts/thread-cert/border_router/test_advertising_proxy.py
@@ -181,7 +181,12 @@ class SingleHostAndService(thread_cert.TestCase):
         #
 
         client.srp_client_remove_service('my-service-1', '_ipps._tcp')
-        self.simulator.go(5)
+
+        # We previously had self.simulator.go(5) but got the issue that the client is scheduling
+        # the refresh timer with half of the lease time (10 seconds) and there will be chances
+        # that the client will be just in status "kToRefresh" after self.simulator.go(5). This will
+        # fail the checks in self.check_host_and_service() so updated to wait for 2 seconds.
+        self.simulator.go(2)
 
         self.check_host_and_service(server, client, '2001::2', 'my-service')
         self.host_check_mdns_service(host, '2001::2', 'my-service')

--- a/tests/scripts/thread-cert/border_router/test_advertising_proxy.py
+++ b/tests/scripts/thread-cert/border_router/test_advertising_proxy.py
@@ -192,6 +192,10 @@ class SingleHostAndService(thread_cert.TestCase):
         self.host_check_mdns_service(host, '2001::2', 'my-service')
         self.assertIsNone(host.discover_mdns_service('my-service-1', '_ipps._tcp', 'my-host'))
 
+        # Wait for KEY expiration of service 'my-service-1'.
+        # FIXME: workaround for https://github.com/openthread/ot-br-posix/issues/1071.
+        self.simulator.go(KEY_LEASE + 5)
+
         #
         # 8. Update both the host and the service in a loop and make sure the
         #    Advertising Proxy can follow.


### PR DESCRIPTION
There are failure logs show that the test scripts failed to verify updated SRP services via mDNS, but the SRP service status on the SRP client and server are verified okay.

```txt
2021-10-22T13:57:35.4956943Z FAIL: test (__main__.SingleHostAndService)
2021-10-22T13:57:35.4957783Z ----------------------------------------------------------------------
2021-10-22T13:57:35.4958403Z Traceback (most recent call last):
2021-10-22T13:57:35.4959313Z   File "./tests/scripts/thread-cert/border_router/test_advertising_proxy.py", line 203, in test
2021-10-22T13:57:35.4960362Z     self.host_check_mdns_service(host, host_address, 'my-service', service_port)
2021-10-22T13:57:35.4961477Z   File "./tests/scripts/thread-cert/border_router/test_advertising_proxy.py", line 220, in host_check_mdns_service
2021-10-22T13:57:35.4962481Z     self.assertEqual(service['port'], service_port)
2021-10-22T13:57:35.4963065Z AssertionError: 12345 != 12341
2021-10-22T13:57:35.4963345Z 
2021-10-22T13:57:35.4963974Z ----------------------------------------------------------------------
2021-10-22T13:57:35.4964475Z Ran 1 test in 223.176s
```
(find the full log file at https://github.com/openthread/openthread/issues/6654#issuecomment-950533485

This may indicate that the mDNS publisher doesn't refresh its DNS cache timely, so this commit is trying to double the time waiting for mDNS updates.