### PR TITLE
[tests] OTBR `get_addrs` returns only Thread addresses

### DIFF
--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -3217,9 +3217,6 @@ class OtbrNode(LinuxHost, NodeImpl, OtbrDocker):
     def __repr__(self):
         return f'Otbr<{self.nodeid}>'
 
-    def get_addrs(self) -> List[str]:
-        return super().get_addrs() + self.get_ether_addrs()
-
     def start(self):
         self._setup_sysctl()
         self.set_log_level(5)

--- a/tests/scripts/thread-cert/thread_cert.py
+++ b/tests/scripts/thread-cert/thread_cert.py
@@ -322,6 +322,10 @@ class TestCase(NcpSupportMixin, unittest.TestCase):
 
         for i, node in self.nodes.items():
             ipaddrs = node.get_addrs()
+
+            if hasattr(node, 'get_ether_addrs'):
+                ipaddrs += node.get_ether_addrs()
+
             test_info['ipaddrs'][i] = ipaddrs
             if not node.is_host:
                 mleid = node.get_mleid()


### PR DESCRIPTION
The intention is to make OTBR (in Docker) behaves same as normal simulation devices. 