### PR TITLE
[continuous-integration] fix test_dua_routing.py

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (172)
+#define OPENTHREAD_API_VERSION (173)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -740,6 +740,38 @@ void otThreadRegisterNeighborTableCallback(otInstance *aInstance, otNeighborTabl
 void otThreadSetCcmEnabled(otInstance *aInstance, bool aEnabled);
 
 /**
+ * This function gets the range of router IDs that are allowed to assign to nodes within the thread network.
+ *
+ * @note This API requires `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE`, and is only used for test purpose. All the
+ * router IDs in the range [aMinRouterId, aMaxRouterId] are allowed.
+ *
+ * @param[in]   aInstance     A pointer to an OpenThread instance.
+ * @param[out]  aMinRouterId  The minimum router ID.
+ * @param[out]  aMaxRouterId  The maximum router ID.
+ *
+ * @sa otThreadSetRouterIdRange
+ *
+ */
+void otThreadGetRouterIdRange(otInstance *aInstance, uint8_t *aMinRouterId, uint8_t *aMaxRouterId);
+
+/**
+ * This function sets the range of router IDs that are allowed to assign to nodes within the thread network.
+ *
+ * @note This API requires `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE`, and is only used for test purpose. All the
+ * router IDs in the range [aMinRouterId, aMaxRouterId] are allowed.
+ *
+ * @param[in]  aInstance     A pointer to an OpenThread instance.
+ * @param[in]  aMinRouterId  The minimum router ID.
+ * @param[in]  aMaxRouterId  The maximum router ID.
+ *
+ * @retval  OT_ERROR_NONE           Successfully set the range.
+ * @retval  OT_ERROR_INVALID_ARGS   aMinRouterId > aMaxRouterId, or the range is not covered by [0, 62].
+ *
+ * @sa otThreadGetRouterIdRange
+ *
+ */
+otError otThreadSetRouterIdRange(otInstance *aInstance, uint8_t aMinRouterId, uint8_t aMaxRouterId);
+/**
  * @}
  *
  */

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3225,6 +3225,31 @@ otError Interpreter::ProcessParentPriority(Arg aArgs[])
 }
 #endif
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+otError Interpreter::ProcessRouterIdRange(Arg *aArgs)
+{
+    uint8_t minRouterId;
+    uint8_t maxRouterId;
+    otError error = OT_ERROR_NONE;
+
+    if (aArgs[0].IsEmpty())
+    {
+        otThreadGetRouterIdRange(GetInstancePtr(), &minRouterId, &maxRouterId);
+        OutputLine("%d %d", minRouterId, maxRouterId);
+    }
+    else
+    {
+        SuccessOrExit(error = aArgs[0].ParseAsUint8(minRouterId));
+        SuccessOrExit(error = aArgs[1].ParseAsUint8(maxRouterId));
+        VerifyOrExit(aArgs[2].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+        SuccessOrExit(error = otThreadSetRouterIdRange(GetInstancePtr(), minRouterId, maxRouterId));
+    }
+
+exit:
+    return error;
+}
+#endif
+
 #if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
 
 void Interpreter::HandlePingReply(const otPingSenderReply *aReply, void *aContext)

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -564,6 +564,9 @@ private:
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
     otError ProcessTrel(Arg aArgs[]);
 #endif
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    otError ProcessRouterIdRange(Arg *aArgs);
+#endif
 
 #if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
     static void HandlePingReply(const otPingSenderReply *aReply, void *aContext);
@@ -830,6 +833,9 @@ private:
         {"router", &Interpreter::ProcessRouter},
         {"routerdowngradethreshold", &Interpreter::ProcessRouterDowngradeThreshold},
         {"routereligible", &Interpreter::ProcessRouterEligible},
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+        {"routeridrange", &Interpreter::ProcessRouterIdRange},
+#endif
         {"routerselectionjitter", &Interpreter::ProcessRouterSelectionJitter},
         {"routerupgradethreshold", &Interpreter::ProcessRouterUpgradeThreshold},
 #endif

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -370,4 +370,16 @@ void otThreadSetCcmEnabled(otInstance *aInstance, bool aEnabled)
 }
 #endif
 
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+void otThreadGetRouterIdRange(otInstance *aInstance, uint8_t *aMinRouterId, uint8_t *aMaxRouterId)
+{
+    AsCoreType(aInstance).Get<RouterTable>().GetRouterIdRange(*aMinRouterId, *aMaxRouterId);
+}
+
+otError otThreadSetRouterIdRange(otInstance *aInstance, uint8_t aMinRouterId, uint8_t aMaxRouterId)
+{
+    return AsCoreType(aInstance).Get<RouterTable>().SetRouterIdRange(aMinRouterId, aMaxRouterId);
+}
+#endif
+
 #endif // OPENTHREAD_FTD

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -338,6 +338,12 @@ public:
      */
     IteratorBuilder Iterate(void) { return IteratorBuilder(GetInstance()); }
 
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    void GetRouterIdRange(uint8_t &aMinRouterId, uint8_t &aMaxRouterId) const;
+
+    Error SetRouterIdRange(uint8_t aMinRouterId, uint8_t aMaxRouterId);
+#endif
+
 private:
     class IteratorBuilder : public InstanceLocator
     {
@@ -369,6 +375,10 @@ private:
     TimeMilli        mRouterIdSequenceLastUpdated;
     uint8_t          mRouterIdSequence;
     uint8_t          mActiveRouterCount;
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    uint8_t mMinRouterId;
+    uint8_t mMaxRouterId;
+#endif
 };
 
 } // namespace ot

--- a/tests/scripts/thread-cert/backbone/test_dua_routing.py
+++ b/tests/scripts/thread-cert/backbone/test_dua_routing.py
@@ -70,6 +70,7 @@ class TestNdProxy(thread_cert.TestCase):
             'is_otbr': True,
             'version': '1.2',
             'channel': CH1,
+            'router_id_range': [0, 30],
         },
         SBBR: {
             'name': 'SBBR',
@@ -93,6 +94,7 @@ class TestNdProxy(thread_cert.TestCase):
             'is_otbr': True,
             'version': '1.2',
             'channel': CH2,
+            'router_id_range': [31, 60],
         },
         ROUTER2: {
             'name': 'ROUTER2',

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -2932,6 +2932,17 @@ class NodeImpl:
 
         return rxtx_list
 
+    def set_router_id_range(self, min_router_id: int, max_router_id: int):
+        cmd = f'routeridrange {min_router_id} {max_router_id}'
+        self.send_command(cmd)
+        self._expect_command_output()
+
+    def get_router_id_range(self):
+        cmd = 'routeridrange'
+        self.send_command(cmd)
+        line = self._expect_command_output()[0]
+        return [int(item) for item in line.split()]
+
 
 class Node(NodeImpl, OtCli):
     pass

--- a/tests/scripts/thread-cert/thread_cert.py
+++ b/tests/scripts/thread-cert/thread_cert.py
@@ -230,6 +230,9 @@ class TestCase(NcpSupportMixin, unittest.TestCase):
             if 'bbr_registration_jitter' in params:
                 self.nodes[i].set_bbr_registration_jitter(params['bbr_registration_jitter'])
 
+            if 'router_id_range' in params:
+                self.nodes[i].set_router_id_range(params['router_id_range'][0], params['router_id_range'][1])
+
         # we have to add allowlist after nodes are all created
         for i, params in initial_topology.items():
             allowlist = params['allowlist']


### PR DESCRIPTION
This PR fixes #6566.

Added new API/CLI for reference devices to set allowed ranges of router IDs. When the allowed ID range is set, the leader will only assign router IDs in the range. In this way, we can assign non-overlapping router ID ranges to different thread networks so that no RLOC16s will collide across multiple thread networks. Hence #6566 can be fixed.