### PR TITLE
[mac] don't append header termination IE2 for empty data payload

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1582,10 +1582,8 @@ void MeshForwarder::AppendHeaderIe(const Message *aMessage, Mac::TxFrame &aFrame
 {
     uint8_t index     = 0;
     bool    iePresent = false;
-    // MIC is a part of Data Payload, so if it's present, Data Payload is not empty even if the message is
-    // MIC is always present when the frame is secured
-    bool payloadPresent = (aFrame.GetType() == Mac::Frame::kFcfFrameMacCmd) ||
-                          (aMessage != nullptr && aMessage->GetLength() != 0) || aFrame.GetSecurityEnabled();
+    bool    payloadPresent =
+        (aFrame.GetType() == Mac::Frame::kFcfFrameMacCmd) || (aMessage != nullptr && aMessage->GetLength() != 0);
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
     if (aMessage != nullptr && aMessage->IsTimeSync())


### PR DESCRIPTION
This commit reverts #6941.

It has been discussed here:
https://threadgroup.atlassian.net/browse/SPEC-1007

Conclusion:
"we do not require the HT2 IE if the only thing that follows
the header is the MIC"