### PR TITLE
[core] move mapping of public to core type in the related headers

### DIFF
--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -38,8 +38,8 @@
 #include <openthread/border_router.h>
 
 #include "border_router/routing_manager.hpp"
-#include "common/as_core_type.hpp"
 #include "common/debug.hpp"
+#include "common/instance.hpp"
 
 using namespace ot;
 

--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -35,7 +35,8 @@
 
 #include <openthread/dns_client.h>
 
-#include "common/as_core_type.hpp"
+#include "common/instance.hpp"
+#include "net/dns_types.hpp"
 
 using namespace ot;
 

--- a/src/core/api/dns_server_api.cpp
+++ b/src/core/api/dns_server_api.cpp
@@ -33,7 +33,7 @@
 
 #include "openthread-core-config.h"
 
-#include "common/as_core_type.hpp"
+#include "common/instance.hpp"
 #include "net/dns_types.hpp"
 #include "net/dnssd_server.hpp"
 

--- a/src/core/api/link_metrics_api.cpp
+++ b/src/core/api/link_metrics_api.cpp
@@ -38,6 +38,7 @@
 #include <openthread/link_metrics.h>
 
 #include "common/as_core_type.hpp"
+#include "common/locator_getters.hpp"
 
 using namespace ot;
 

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -34,6 +34,7 @@
 #include <openthread/coap.h>
 
 #include "coap/coap_message.hpp"
+#include "common/as_core_type.hpp"
 #include "common/debug.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
@@ -834,6 +835,13 @@ private:
 };
 
 } // namespace Coap
+
+DefineCoreType(otCoapTxParameters, Coap::TxParameters);
+DefineCoreType(otCoapResource, Coap::Resource);
+#if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
+DefineCoreType(otCoapBlockwiseResource, Coap::ResourceBlockWise);
+#endif
+
 } // namespace ot
 
 #endif // COAP_HPP_

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/coap.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/code_utils.hpp"
 #include "common/const_cast.hpp"
@@ -1218,6 +1219,64 @@ public:
  */
 
 } // namespace Coap
+
+DefineCoreType(otCoapOption, Coap::Option);
+DefineCoreType(otCoapOptionIterator, Coap::Option::Iterator);
+DefineMapEnum(otCoapType, Coap::Type);
+DefineMapEnum(otCoapCode, Coap::Code);
+
+/**
+ * This method casts an `otMessage` pointer to a `Coap::Message` reference.
+ *
+ * @param[in] aMessage   A pointer to an `otMessage`.
+ *
+ * @returns A reference to `Coap::Message` matching @p aMessage.
+ *
+ */
+inline Coap::Message &AsCoapMessage(otMessage *aMessage)
+{
+    return *static_cast<Coap::Message *>(aMessage);
+}
+
+/**
+ * This method casts an `otMessage` pointer to a `Coap::Message` reference.
+ *
+ * @param[in] aMessage   A pointer to an `otMessage`.
+ *
+ * @returns A reference to `Coap::Message` matching @p aMessage.
+ *
+ */
+inline Coap::Message *AsCoapMessagePtr(otMessage *aMessage)
+{
+    return static_cast<Coap::Message *>(aMessage);
+}
+
+/**
+ * This method casts an `otMessage` pointer to a `Coap::Message` pointer.
+ *
+ * @param[in] aMessage   A pointer to an `otMessage`.
+ *
+ * @returns A pointer to `Coap::Message` matching @p aMessage.
+ *
+ */
+inline const Coap::Message &AsCoapMessage(const otMessage *aMessage)
+{
+    return *static_cast<const Coap::Message *>(aMessage);
+}
+
+/**
+ * This method casts an `otMessage` pointer to a `Coap::Message` reference.
+ *
+ * @param[in] aMessage   A pointer to an `otMessage`.
+ *
+ * @returns A pointer to `Coap::Message` matching @p aMessage.
+ *
+ */
+inline const Coap::Message *AsCoapMessagePtr(const otMessage *aMessage)
+{
+    return static_cast<const Coap::Message *>(aMessage);
+}
+
 } // namespace ot
 
 #endif // COAP_HEADER_HPP_

--- a/src/core/common/as_core_type.hpp
+++ b/src/core/common/as_core_type.hpp
@@ -36,11 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#include "common/instance.hpp"
-#include "crypto/sha256.hpp"
-#include "mac/mac_filter.hpp"
-#include "net/dns_types.hpp"
-
 namespace ot {
 
 /**
@@ -116,62 +111,6 @@ template <typename Type> const typename CoreType<Type>::Type *AsCoreTypePtr(cons
     return static_cast<const typename CoreType<Type>::Type *>(aObject);
 }
 
-#if OPENTHREAD_FTD || OPENTHREAD_MTD
-
-/**
- * This method casts an `otMessage` pointer to a `Coap::Message` reference.
- *
- * @param[in] aMessage   A pointer to an `otMessage`.
- *
- * @returns A reference to `Coap::Message` matching @p aMessage.
- *
- */
-inline Coap::Message &AsCoapMessage(otMessage *aMessage)
-{
-    return *static_cast<Coap::Message *>(aMessage);
-}
-
-/**
- * This method casts an `otMessage` pointer to a `Coap::Message` reference.
- *
- * @param[in] aMessage   A pointer to an `otMessage`.
- *
- * @returns A reference to `Coap::Message` matching @p aMessage.
- *
- */
-inline Coap::Message *AsCoapMessagePtr(otMessage *aMessage)
-{
-    return static_cast<Coap::Message *>(aMessage);
-}
-
-/**
- * This method casts an `otMessage` pointer to a `Coap::Message` pointer.
- *
- * @param[in] aMessage   A pointer to an `otMessage`.
- *
- * @returns A pointer to `Coap::Message` matching @p aMessage.
- *
- */
-inline const Coap::Message &AsCoapMessage(const otMessage *aMessage)
-{
-    return *static_cast<const Coap::Message *>(aMessage);
-}
-
-/**
- * This method casts an `otMessage` pointer to a `Coap::Message` reference.
- *
- * @param[in] aMessage   A pointer to an `otMessage`.
- *
- * @returns A pointer to `Coap::Message` matching @p aMessage.
- *
- */
-inline const Coap::Message *AsCoapMessagePtr(const otMessage *aMessage)
-{
-    return static_cast<const Coap::Message *>(aMessage);
-}
-
-#endif // #if OPENTHREAD_FTD || OPENTHREAD_MTD
-
 /**
  * This structure maps two enumeration types.
  *
@@ -198,9 +137,6 @@ template <typename EnumType> const typename MappedEnum<EnumType>::Type MapEnum(E
     return static_cast<typename MappedEnum<EnumType>::Type>(aValue);
 }
 
-//---------------------------------------------------------------------------------------------------------------------
-// Private macros and definitions
-
 // Helper macro to define specialization of `CoreType` struct relating `BaseType` with `SubType`.
 #define DefineCoreType(BaseType, SubType) \
     template <> struct CoreType<BaseType> \
@@ -219,149 +155,6 @@ template <typename EnumType> const typename MappedEnum<EnumType>::Type MapEnum(E
     {                                                \
         using Type = FirstEnumType;                  \
     }
-
-DefineCoreType(otInstance, Instance);
-
-// Message
-DefineCoreType(otMessage, Message);
-DefineCoreType(otMessageSettings, Message::Settings);
-DefineCoreType(otMessageBuffer, Buffer);
-DefineCoreType(otMessageQueue, MessageQueue);
-
-// Mac
-DefineCoreType(otRadioFrame, Mac::Frame);
-DefineCoreType(otExtAddress, Mac::ExtAddress);
-DefineCoreType(otMacKey, Mac::Key);
-DefineCoreType(otExtendedPanId, Mac::ExtendedPanId);
-DefineCoreType(otNetworkName, Mac::NetworkName);
-#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
-DefineMapEnum(otMacFilterAddressMode, Mac::Filter::Mode);
-#endif
-
-DefineCoreType(otCryptoKey, Crypto::Key);
-DefineCoreType(otCryptoSha256Hash, Crypto::Sha256::Hash);
-
-#if OPENTHREAD_FTD || OPENTHREAD_MTD
-
-// Thread
-DefineCoreType(otThreadLinkInfo, ThreadLinkInfo);
-DefineCoreType(otSecurityPolicy, SecurityPolicy);
-DefineCoreType(otNetworkKey, NetworkKey);
-DefineCoreType(otPskc, Pskc);
-
-DefineCoreType(otNeighborInfo, Neighbor::Info);
-DefineCoreType(otRouterInfo, Router::Info);
-#if OPENTHREAD_FTD
-DefineCoreType(otChildInfo, Child::Info);
-#endif
-
-// Ip6
-DefineCoreType(otIp6Prefix, Ip6::Prefix);
-DefineCoreType(otIp6InterfaceIdentifier, Ip6::InterfaceIdentifier);
-DefineCoreType(otIp6Address, Ip6::Address);
-DefineCoreType(otMessageInfo, Ip6::MessageInfo);
-DefineCoreType(otSockAddr, Ip6::SockAddr);
-DefineCoreType(otNetifAddress, Ip6::Netif::UnicastAddress);
-DefineCoreType(otNetifMulticastAddress, Ip6::Netif::MulticastAddress);
-DefineCoreType(otIcmp6Header, Ip6::Icmp::Header);
-DefineCoreType(otIcmp6Handler, Ip6::Icmp::Handler);
-DefineCoreType(otUdpSocket, Ip6::Udp::SocketHandle);
-DefineCoreType(otUdpReceiver, Ip6::Udp::Receiver);
-DefineCoreType(otTcpEndpoint, Ip6::Tcp::Endpoint);
-DefineCoreType(otTcpListener, Ip6::Tcp::Listener);
-
-// Mle
-DefineCoreType(otMeshLocalPrefix, Mle::MeshLocalPrefix);
-DefineCoreType(otLeaderData, Mle::LeaderData);
-DefineMapEnum(otDeviceRole, Mle::DeviceRole);
-
-// LinkMetrics
-#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
-DefineCoreType(otLinkMetrics, LinkMetrics::Metrics);
-DefineCoreType(otLinkMetricsValues, LinkMetrics::MetricsValues);
-DefineMapEnum(otLinkMetricsEnhAckFlags, LinkMetrics::EnhAckFlags);
-#endif
-
-// NetworkData
-DefineCoreType(otBorderRouterConfig, NetworkData::OnMeshPrefixConfig);
-DefineCoreType(otExternalRouteConfig, NetworkData::ExternalRouteConfig);
-DefineCoreType(otServiceConfig, NetworkData::ServiceConfig);
-DefineCoreType(otServerConfig, NetworkData::ServiceConfig::ServerConfig);
-
-// MeshCoP
-DefineCoreType(otOperationalDatasetComponents, MeshCoP::Dataset::Components);
-DefineCoreType(otOperationalDataset, MeshCoP::Dataset::Info);
-DefineCoreType(otJoinerPskd, MeshCoP::JoinerPskd);
-DefineCoreType(otJoinerDiscerner, MeshCoP::JoinerDiscerner);
-DefineCoreType(otSteeringData, MeshCoP::SteeringData);
-#if OPENTHREAD_CONFIG_JOINER_ENABLE
-DefineMapEnum(otJoinerState, MeshCoP::Joiner::State);
-#endif
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-DefineMapEnum(otCommissionerState, MeshCoP::Commissioner::State);
-#endif
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-DefineMapEnum(otBorderAgentState, MeshCoP::BorderAgent::State);
-#endif
-
-// Coap
-DefineCoreType(otCoapTxParameters, Coap::TxParameters);
-DefineCoreType(otCoapResource, Coap::Resource);
-DefineCoreType(otCoapOption, Coap::Option);
-DefineCoreType(otCoapOptionIterator, Coap::Option::Iterator);
-DefineMapEnum(otCoapType, Coap::Type);
-DefineMapEnum(otCoapCode, Coap::Code);
-#if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
-DefineCoreType(otCoapBlockwiseResource, Coap::ResourceBlockWise);
-#endif
-
-// Dns
-DefineCoreType(otDnsTxtEntry, Dns::TxtEntry);
-DefineCoreType(otDnsTxtEntryIterator, Dns::TxtEntry::Iterator);
-#if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
-DefineCoreType(otDnsQueryConfig, Dns::Client::QueryConfig);
-DefineCoreType(otDnsAddressResponse, Dns::Client::AddressResponse);
-#if OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE
-DefineCoreType(otDnsBrowseResponse, Dns::Client::BrowseResponse);
-DefineCoreType(otDnsServiceResponse, Dns::Client::ServiceResponse);
-DefineCoreType(otDnsServiceInfo, Dns::Client::ServiceInfo);
-#endif
-#endif
-#if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
-DefineMapEnum(otDnssdQueryType, Dns::ServiceDiscovery::Server::DnsQueryType);
-#endif
-
-// Srp
-#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
-DefineCoreType(otSrpClientHostInfo, Srp::Client::HostInfo);
-DefineCoreType(otSrpClientService, Srp::Client::Service);
-DefineMapEnum(otSrpClientItemState, Srp::Client::ItemState);
-#endif
-#if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
-DefineCoreType(otSrpServerLeaseConfig, Srp::Server::LeaseConfig);
-DefineCoreType(otSrpServerHost, Srp::Server::Host);
-DefineCoreType(otSrpServerService, Srp::Server::Service);
-DefineMapEnum(otSrpServerState, Srp::Server::State);
-DefineMapEnum(otSrpServerAddressMode, Srp::Server::AddressMode);
-#endif
-
-// Utils
-#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-DefineCoreType(otHistoryTrackerIterator, Utils::HistoryTracker::Iterator);
-DefineCoreType(otHistoryTrackerNetworkInfo, Utils::HistoryTracker::NetworkInfo);
-DefineCoreType(otHistoryTrackerMessageInfo, Utils::HistoryTracker::MessageInfo);
-DefineCoreType(otHistoryTrackerNeighborInfo, Utils::HistoryTracker::NeighborInfo);
-#endif
-#if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
-DefineCoreType(otPingSenderReply, Utils::PingSender::Reply);
-DefineCoreType(otPingSenderConfig, Utils::PingSender::Config);
-DefineCoreType(otPingSenderStatistics, Utils::PingSender::Statistics);
-#endif
-#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
-DefineCoreType(otSrpClientBuffersServiceEntry, Utils::SrpClientBuffers::ServiceEntry);
-#endif
-
-#endif // #if OPENTHREAD_FTD || OPENTHREAD_MTD
 
 } // namespace ot
 

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -45,6 +45,7 @@
 #include <openthread/platform/memory.h>
 #endif
 
+#include "common/as_core_type.hpp"
 #include "common/error.hpp"
 #include "common/non_copyable.hpp"
 #include "common/random_manager.hpp"
@@ -443,6 +444,8 @@ private:
     static bool sDnsNameCompressionEnabled;
 #endif
 };
+
+DefineCoreType(otInstance, Instance);
 
 // Specializations of the `Get<Type>()` method.
 

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -41,6 +41,7 @@
 #include <openthread/message.h>
 #include <openthread/platform/messagepool.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/const_cast.hpp"
 #include "common/data.hpp"
@@ -1518,6 +1519,11 @@ private:
  * @}
  *
  */
+
+DefineCoreType(otMessageBuffer, Buffer);
+DefineCoreType(otMessageSettings, Message::Settings);
+DefineCoreType(otMessage, Message);
+DefineCoreType(otMessageQueue, MessageQueue);
 
 } // namespace ot
 

--- a/src/core/crypto/sha256.hpp
+++ b/src/core/crypto/sha256.hpp
@@ -41,6 +41,7 @@
 #include <openthread/crypto.h>
 #include <openthread/platform/crypto.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/code_utils.hpp"
 #include "common/equatable.hpp"
@@ -155,6 +156,9 @@ private:
  */
 
 } // namespace Crypto
+
+DefineCoreType(otCryptoSha256Hash, Crypto::Sha256::Hash);
+
 } // namespace ot
 
 #endif // SHA256_HPP_

--- a/src/core/crypto/storage.hpp
+++ b/src/core/crypto/storage.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/platform/crypto.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/code_utils.hpp"
 #include "common/error.hpp"
@@ -330,6 +331,9 @@ private:
 };
 
 } // namespace Crypto
+
+DefineCoreType(otCryptoKey, Crypto::Key);
+
 } // namespace ot
 
 #endif // STORAGE_HPP_

--- a/src/core/mac/mac_filter.hpp
+++ b/src/core/mac/mac_filter.hpp
@@ -40,6 +40,7 @@
 
 #include <stdint.h>
 
+#include "common/as_core_type.hpp"
 #include "common/non_copyable.hpp"
 #include "mac/mac_frame.hpp"
 
@@ -247,6 +248,9 @@ private:
  */
 
 } // namespace Mac
+
+DefineMapEnum(otMacFilterAddressMode, Mac::Filter::Mode);
+
 } // namespace ot
 
 #endif // OPENTHREAD_CONFIG_MAC_FILTER_ENABLE

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -39,6 +39,7 @@
 #include <limits.h>
 #include <stdint.h>
 
+#include "common/as_core_type.hpp"
 #include "common/const_cast.hpp"
 #include "common/encoding.hpp"
 #include "mac/mac_types.hpp"

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -42,6 +42,7 @@
 #include <openthread/link.h>
 #include <openthread/thread.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/data.hpp"
 #include "common/equatable.hpp"
@@ -1020,6 +1021,12 @@ private:
  */
 
 } // namespace Mac
+
+DefineCoreType(otExtAddress, Mac::ExtAddress);
+DefineCoreType(otMacKey, Mac::Key);
+DefineCoreType(otExtendedPanId, Mac::ExtendedPanId);
+DefineCoreType(otNetworkName, Mac::NetworkName);
+
 } // namespace ot
 
 #endif // MAC_TYPES_HPP_

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -41,6 +41,7 @@
 #include <openthread/border_agent.h>
 
 #include "coap/coap.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
@@ -198,6 +199,9 @@ private:
 };
 
 } // namespace MeshCoP
+
+DefineMapEnum(otBorderAgentState, MeshCoP::BorderAgent::State);
+
 } // namespace ot
 
 #endif // OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -42,6 +42,7 @@
 
 #include "coap/coap.hpp"
 #include "coap/coap_secure.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/timer.hpp"
@@ -474,6 +475,9 @@ private:
 };
 
 } // namespace MeshCoP
+
+DefineMapEnum(otCommissionerState, MeshCoP::Commissioner::State);
+
 } // namespace ot
 
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -39,6 +39,7 @@
 
 #include <openthread/dataset.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/const_cast.hpp"
 #include "common/locator.hpp"
@@ -963,6 +964,10 @@ template <> inline Error Dataset::SetTlv(Tlv::Type aType, const uint32_t &aValue
 }
 
 } // namespace MeshCoP
+
+DefineCoreType(otOperationalDatasetComponents, MeshCoP::Dataset::Components);
+DefineCoreType(otOperationalDataset, MeshCoP::Dataset::Info);
+
 } // namespace ot
 
 #endif // MESHCOP_DATASET_HPP_

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -43,6 +43,7 @@
 #include "coap/coap.hpp"
 #include "coap/coap_message.hpp"
 #include "coap/coap_secure.hpp"
+#include "common/as_core_type.hpp"
 #include "common/locator.hpp"
 #include "common/logging.hpp"
 #include "common/message.hpp"
@@ -241,6 +242,9 @@ private:
 };
 
 } // namespace MeshCoP
+
+DefineMapEnum(otJoinerState, MeshCoP::Joiner::State);
+
 } // namespace ot
 
 #endif // OPENTHREAD_CONFIG_JOINER_ENABLE

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -44,6 +44,7 @@
 #include <openthread/joiner.h>
 
 #include "coap/coap.hpp"
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/equatable.hpp"
 #include "common/message.hpp"
@@ -472,6 +473,10 @@ inline void LogError(const char *, Error)
 #endif
 
 } // namespace MeshCoP
+
+DefineCoreType(otJoinerPskd, MeshCoP::JoinerPskd);
+DefineCoreType(otJoinerDiscerner, MeshCoP::JoinerDiscerner);
+DefineCoreType(otSteeringData, MeshCoP::SteeringData);
 
 } // namespace ot
 

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -35,6 +35,7 @@
 
 #include <openthread/dns_client.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
@@ -746,6 +747,15 @@ private:
 };
 
 } // namespace Dns
+
+DefineCoreType(otDnsQueryConfig, Dns::Client::QueryConfig);
+DefineCoreType(otDnsAddressResponse, Dns::Client::AddressResponse);
+#if OPENTHREAD_CONFIG_DNS_CLIENT_SERVICE_DISCOVERY_ENABLE
+DefineCoreType(otDnsBrowseResponse, Dns::Client::BrowseResponse);
+DefineCoreType(otDnsServiceResponse, Dns::Client::ServiceResponse);
+DefineCoreType(otDnsServiceInfo, Dns::Client::ServiceInfo);
+#endif
+
 } // namespace ot
 
 #endif // OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE

--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -39,6 +39,7 @@
 #include <openthread/dns.h>
 #include <openthread/dns_client.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/encoding.hpp"
 #include "common/equatable.hpp"
@@ -2585,6 +2586,10 @@ public:
  */
 
 } // namespace Dns
+
+DefineCoreType(otDnsTxtEntry, Dns::TxtEntry);
+DefineCoreType(otDnsTxtEntryIterator, Dns::TxtEntry::Iterator);
+
 } // namespace ot
 
 #endif // DNS_HEADER_HPP_

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -35,6 +35,7 @@
 
 #include <openthread/dnssd_server.h>
 
+#include "common/as_core_type.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
 #include "common/timer.hpp"
@@ -406,6 +407,9 @@ private:
 
 } // namespace ServiceDiscovery
 } // namespace Dns
+
+DefineMapEnum(otDnssdQueryType, Dns::ServiceDiscovery::Server::DnsQueryType);
+
 } // namespace ot
 
 #endif // OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/icmp6.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/encoding.hpp"
 #include "common/linked_list.hpp"
@@ -345,6 +346,10 @@ private:
  */
 
 } // namespace Ip6
+
+DefineCoreType(otIcmp6Header, Ip6::Icmp::Header);
+DefineCoreType(otIcmp6Handler, Ip6::Icmp::Handler);
+
 } // namespace ot
 
 #endif // ICMP6_HPP_

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/ip6.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/encoding.hpp"
 #include "common/equatable.hpp"
@@ -991,6 +992,11 @@ private:
  */
 
 } // namespace Ip6
+
+DefineCoreType(otIp6Prefix, Ip6::Prefix);
+DefineCoreType(otIp6InterfaceIdentifier, Ip6::InterfaceIdentifier);
+DefineCoreType(otIp6Address, Ip6::Address);
+
 } // namespace ot
 
 #endif // IP6_ADDRESS_HPP_

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -36,6 +36,7 @@
 
 #include "openthread-core-config.h"
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/code_utils.hpp"
 #include "common/const_cast.hpp"
@@ -665,6 +666,10 @@ private:
  */
 
 } // namespace Ip6
+
+DefineCoreType(otNetifAddress, Ip6::Netif::UnicastAddress);
+DefineCoreType(otNetifMulticastAddress, Ip6::Netif::MulticastAddress);
+
 } // namespace ot
 
 #endif // NET_NETIF_HPP_

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -380,6 +380,10 @@ private:
  */
 
 } // namespace Ip6
+
+DefineCoreType(otMessageInfo, Ip6::MessageInfo);
+DefineCoreType(otSockAddr, Ip6::SockAddr);
+
 } // namespace ot
 
 #endif // NET_SOCKET_HPP_

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -35,6 +35,7 @@
 
 #include <openthread/srp_client.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
@@ -896,6 +897,11 @@ private:
 };
 
 } // namespace Srp
+
+DefineCoreType(otSrpClientHostInfo, Srp::Client::HostInfo);
+DefineCoreType(otSrpClientService, Srp::Client::Service);
+DefineMapEnum(otSrpClientItemState, Srp::Client::ItemState);
+
 } // namespace ot
 
 #endif // OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -53,6 +53,7 @@
 #include <openthread/ip6.h>
 #include <openthread/srp_server.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/heap_string.hpp"
 #include "common/linked_list.hpp"
@@ -889,6 +890,13 @@ private:
 };
 
 } // namespace Srp
+
+DefineCoreType(otSrpServerLeaseConfig, Srp::Server::LeaseConfig);
+DefineCoreType(otSrpServerHost, Srp::Server::Host);
+DefineCoreType(otSrpServerService, Srp::Server::Service);
+DefineMapEnum(otSrpServerState, Srp::Server::State);
+DefineMapEnum(otSrpServerAddressMode, Srp::Server::AddressMode);
+
 } // namespace ot
 
 #endif // OPENTHREAD_CONFIG_SRP_SERVER_ENABLE

--- a/src/core/net/tcp6.hpp
+++ b/src/core/net/tcp6.hpp
@@ -38,13 +38,13 @@
 
 #include <openthread/tcp.h>
 
-#include "net/ip6_headers.hpp"
-#include "net/socket.hpp"
-
+#include "common/as_core_type.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/timer.hpp"
+#include "net/ip6_headers.hpp"
+#include "net/socket.hpp"
 
 namespace ot {
 namespace Ip6 {
@@ -564,6 +564,10 @@ private:
 };
 
 } // namespace Ip6
+
+DefineCoreType(otTcpEndpoint, Ip6::Tcp::Endpoint);
+DefineCoreType(otTcpListener, Ip6::Tcp::Listener);
+
 } // namespace ot
 
 #endif // TCP6_HPP_

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -39,6 +39,7 @@
 #include <openthread/udp.h>
 #include <openthread/platform/udp.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
@@ -651,6 +652,10 @@ private:
  */
 
 } // namespace Ip6
+
+DefineCoreType(otUdpSocket, Ip6::Udp::SocketHandle);
+DefineCoreType(otUdpReceiver, Ip6::Udp::Receiver);
+
 } // namespace ot
 
 #endif // UDP6_HPP_

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -39,8 +39,9 @@
 #include <stdint.h>
 
 #include <openthread/dataset.h>
-
 #include <openthread/platform/crypto.h>
+
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/encoding.hpp"
 #include "common/equatable.hpp"
@@ -635,6 +636,10 @@ private:
 /**
  * @}
  */
+
+DefineCoreType(otSecurityPolicy, SecurityPolicy);
+DefineCoreType(otNetworkKey, NetworkKey);
+DefineCoreType(otPskc, Pskc);
 
 } // namespace ot
 

--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -45,6 +45,7 @@
 
 #include <openthread/link.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
@@ -453,6 +454,11 @@ private:
  */
 
 } // namespace LinkMetrics
+
+DefineCoreType(otLinkMetrics, LinkMetrics::Metrics);
+DefineCoreType(otLinkMetricsValues, LinkMetrics::MetricsValues);
+DefineMapEnum(otLinkMetricsEnhAckFlags, LinkMetrics::EnhAckFlags);
+
 } // namespace ot
 
 #endif // OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -36,6 +36,7 @@
 
 #include "openthread-core-config.h"
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
@@ -593,6 +594,8 @@ private:
  * @}
  *
  */
+
+DefineCoreType(otThreadLinkInfo, ThreadLinkInfo);
 
 } // namespace ot
 

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -42,6 +42,7 @@
 
 #include <openthread/thread.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
@@ -588,6 +589,11 @@ typedef Mac::Key Key;
  */
 
 } // namespace Mle
+
+DefineCoreType(otMeshLocalPrefix, Mle::MeshLocalPrefix);
+DefineCoreType(otLeaderData, Mle::LeaderData);
+DefineMapEnum(otDeviceRole, Mle::DeviceRole);
+
 } // namespace ot
 
 #endif // MLE_TYPES_HPP_

--- a/src/core/thread/network_data_types.hpp
+++ b/src/core/thread/network_data_types.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/netdata.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/data.hpp"
 #include "common/debug.hpp"
@@ -347,6 +348,11 @@ private:
 };
 
 } // namespace NetworkData
+
+DefineCoreType(otBorderRouterConfig, NetworkData::OnMeshPrefixConfig);
+DefineCoreType(otExternalRouteConfig, NetworkData::ExternalRouteConfig);
+DefineCoreType(otServiceConfig, NetworkData::ServiceConfig);
+DefineCoreType(otServerConfig, NetworkData::ServiceConfig::ServerConfig);
 
 /**
  * @}

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -38,6 +38,7 @@
 
 #include <openthread/thread_ftd.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/equatable.hpp"
 #include "common/linked_list.hpp"
@@ -1462,6 +1463,12 @@ private:
     uint8_t mCslClockUncertainty; ///< Scheduling uncertainty, in units of 10 us.
 #endif
 };
+
+DefineCoreType(otNeighborInfo, Neighbor::Info);
+#if OPENTHREAD_FTD
+DefineCoreType(otChildInfo, Child::Info);
+#endif
+DefineCoreType(otRouterInfo, Router::Info);
 
 } // namespace ot
 

--- a/src/core/utils/history_tracker.hpp
+++ b/src/core/utils/history_tracker.hpp
@@ -41,6 +41,7 @@
 #include <openthread/history_tracker.h>
 #include <openthread/platform/radio.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
@@ -395,6 +396,12 @@ private:
 };
 
 } // namespace Utils
+
+DefineCoreType(otHistoryTrackerIterator, Utils::HistoryTracker::Iterator);
+DefineCoreType(otHistoryTrackerNetworkInfo, Utils::HistoryTracker::NetworkInfo);
+DefineCoreType(otHistoryTrackerMessageInfo, Utils::HistoryTracker::MessageInfo);
+DefineCoreType(otHistoryTrackerNeighborInfo, Utils::HistoryTracker::NeighborInfo);
+
 } // namespace ot
 
 #endif // OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE

--- a/src/core/utils/ping_sender.hpp
+++ b/src/core/utils/ping_sender.hpp
@@ -40,6 +40,7 @@
 
 #include <openthread/ping_sender.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/locator.hpp"
 #include "common/message.hpp"
@@ -184,6 +185,11 @@ private:
 };
 
 } // namespace Utils
+
+DefineCoreType(otPingSenderReply, Utils::PingSender::Reply);
+DefineCoreType(otPingSenderConfig, Utils::PingSender::Config);
+DefineCoreType(otPingSenderStatistics, Utils::PingSender::Statistics);
+
 } // namespace ot
 
 #endif // OPENTHREAD_CONFIG_PING_SENDER_ENABLE

--- a/src/core/utils/srp_client_buffers.hpp
+++ b/src/core/utils/srp_client_buffers.hpp
@@ -36,8 +36,11 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
+
 #include <openthread/srp_client_buffers.h>
 
+#include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
@@ -46,8 +49,6 @@
 
 namespace ot {
 namespace Utils {
-
-#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
 
 #if !OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
 #error "OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE requires OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE feature."
@@ -260,9 +261,12 @@ private:
     Pool<ServiceEntry, kMaxServices> mServicePool;
 };
 
-#endif // OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
-
 } // namespace Utils
+
+DefineCoreType(otSrpClientBuffersServiceEntry, Utils::SrpClientBuffers::ServiceEntry);
+
 } // namespace ot
+
+#endif // OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
 
 #endif // SRP_CLIENT_BUFFERS_HPP_


### PR DESCRIPTION
This commit moves the `DefineCoreType()` & `DefineMapEnum()`
definitions (which map the public and core types) to the related
headers where the core type is defined, e.g., `otIp6Address` to
`Ip6::Address` map is now defined in `net/ip6_address.hpp`. This
allows us to use `AsCoreType()` in more places (avoid the header
file dependency/loop).

