### PR TITLE
[thci] retrieve BA port from mDNS response

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -2323,10 +2323,6 @@ class OpenThreadTHCI(object):
         return self.__executeCommand(cmd)[-1] == 'Done'
 
     @API
-    def getBorderAgentPort(self):
-        return int(self.__executeCommand('ba port')[0])
-
-    @API
     def startExternalCommissioner(self, baAddr, baPort):
         """Start external commissioner
         Args:

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -608,10 +608,10 @@ EOF"
             self.log('%s', line)
 
     @API
-    def mdns_query(self, service='_meshcop._udp.local', addrs_blacklist=[]):
-        print('mdns_query %s %s' % (service, addrs_blacklist))
+    def mdns_query(self, dst='ff02::fb', service='_meshcop._udp.local', addrs_blacklist=[]):
+        print('mdns_query %s %s %s' % (dst, service, addrs_blacklist))
 
-        result = self.bash('dig -p 5353 @ff02::fb %s ptr +time=2 +retry=2' % service)
+        result = self.bash('dig -p 5353 @%s %s ptr +time=2 +retry=2' % (dst, service))
         responses = ' '.join(result).split(';; ANSWER SECTION:')
 
         # Remove responses from unwanted devices

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -608,9 +608,31 @@ EOF"
             self.log('%s', line)
 
     @API
-    def mdns_query(self):
-        print('mdns_query')
-        self.bash('dig -p 5353 @ff02::fb _meshcop._udp.local ptr')
+    def mdns_query(self, service='_meshcop._udp.local', ref_dev_ll_addrs=[]):
+        print('mdns_query %s %s' % (service, ref_dev_ll_addrs))
+
+        result = self.bash('dig -p 5353 @ff02::fb %s ptr +time=2 +retry=2' % service)
+        responses = ' '.join(result).split(';; ANSWER SECTION:')
+
+        # Remove reference device responses
+        for response in responses:
+            if not set(response.split()).isdisjoint(set(ref_dev_ll_addrs)):
+                break
+
+        # Records patterns:
+        # raspberrypi-2.local.	10	IN	AAAA	fe80::81:46ff:fe0d:bfe.43684
+        # OpenThread_BorderRouter._meshcop._udp.local. 10\tIN SRV 0 0 49153 raspberrypi.local.
+        try:
+            addr = response.split('AAAA\tfe80')[1].split(' ')[0]
+            addr = 'fe80%s%%eth0' % addr
+        except Exception:
+            raise Exception('Unable to find the DUT address in the mDNS response')
+        try:
+            port = int(response.split('IN SRV')[1].split(' ')[3])
+        except Exception:
+            raise Exception('Unable to find the DUT port in the mDNS response')
+
+        return (addr, port)
 
     # Override powerDown
     @API

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -608,15 +608,15 @@ EOF"
             self.log('%s', line)
 
     @API
-    def mdns_query(self, service='_meshcop._udp.local', ref_dev_ll_addrs=[]):
-        print('mdns_query %s %s' % (service, ref_dev_ll_addrs))
+    def mdns_query(self, service='_meshcop._udp.local', addrs_blacklist=[]):
+        print('mdns_query %s %s' % (service, addrs_blacklist))
 
         result = self.bash('dig -p 5353 @ff02::fb %s ptr +time=2 +retry=2' % service)
         responses = ' '.join(result).split(';; ANSWER SECTION:')
 
-        # Remove reference device responses
+        # Remove responses from unwanted devices
         for response in responses:
-            if not set(response.split()).isdisjoint(set(ref_dev_ll_addrs)):
+            if not set(response.split()).isdisjoint(set(addrs_blacklist)):
                 break
 
         # Records patterns:


### PR DESCRIPTION
Modify `mdns_query` to accept a unicast destination and parse the mDSN response to find the Border Router's Border Agent port.