### PR TITLE
[netdata] allow `Publisher` to be built with service only

### DIFF
--- a/src/core/thread/network_data_publisher.cpp
+++ b/src/core/thread/network_data_publisher.cpp
@@ -836,6 +836,8 @@ Publisher::DnsSrpServiceEntry::Info::Info(Type aType, uint16_t aPortOrSeqNumber,
 
 #endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
+
 //---------------------------------------------------------------------------------------------------------------------
 // Publisher::PrefixEntry
 
@@ -1088,6 +1090,8 @@ void Publisher::PrefixEntry::CountExternalRouteEntries(uint8_t &aNumEntries, uin
 exit:
     return;
 }
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
 } // namespace NetworkData
 } // namespace ot


### PR DESCRIPTION
This commit adds missing `#if` check in `network_data_publisher.cpp`
to ensure it can be built when `CONFIG_BORDER_ROUTER_ENABLE` is
disabled (i.e., with `CONFIG_TMF_NETDATA_SERVICE_ENABLE` only).

---
_Background_:

- We already have this check in `netdworkdata_publisher.hpp` which ensures
we either have `SERVCIE_ENABLE` or `BORDER_ROUTER_ENABLE`:
```c++
#if !OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE && !OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
#error "OPENTHREAD_CONFIG_NETDATA_PUBLISHER_ENABLE requires either OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE"\
            "or OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE"
#endif
```
- The header file already has the proper `#if` checks.
- I considered adding a CI config to cover the config (i.e., service enabled without 
border router) but decided against it, since we don't expect this config combination 
to be practically used often. We don't (and cannot) cover all config combo in CI 
since adding more combo will increase CI build times.