### PR TITLE
[mle] `mParentChanges` counter without `INFORM_PREVIOUS_PARENT`

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (173)
+#define OPENTHREAD_API_VERSION (174)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -168,10 +168,7 @@ typedef struct otMleCounters
     uint16_t mBetterPartitionAttachAttempts; ///< Number of attempts to attach to a better partition.
 
     /**
-     * Number of times device changed its parents.
-     *
-     * Support for this counter requires the feature option OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH to
-     * be enabled.
+     * Number of times device changed its parent.
      *
      * A parent change can happen if device detaches from its current parent and attaches to a different one, or even
      * while device is attached when the periodic parent search feature is enabled  (please see option

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1887,9 +1887,7 @@ private:
     uint32_t mCslTimeout;
 #endif
 
-#if OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
     uint16_t mPreviousParentRloc;
-#endif
 
 #if OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE
     bool       mParentSearchIsInBackoff : 1;


### PR DESCRIPTION
This commit allows `mParentChanges` counter which tracks number of
times device (as a child) switches its parent to be used without
`INFORM_PREVIOUS_PARENT` feature.

----
For background on this, please see: https://github.com/openthread/openthread/pull/2982#discussion_r742753755 