### PR TITLE
[docs] clarify `otPlatRadioGetNow()` as free-running

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (174)
+#define OPENTHREAD_API_VERSION (175)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -614,7 +614,10 @@ void otPlatRadioSetMacKey(otInstance *            aInstance,
 void otPlatRadioSetMacFrameCounter(otInstance *aInstance, uint32_t aMacFrameCounter);
 
 /**
- * Get the current estimated time (64bits width) of the radio chip.
+ * Get the current estimated time (in microseconds) of the radio chip.
+ *
+ * This microsecond timer must be a free-running timer. The timer must continue to advance with microsecond precision
+ * even when the radio is in the sleep state.
  *
  * @param[in]   aInstance    A pointer to an OpenThread instance.
  *


### PR DESCRIPTION
Fixes #7053 