### PR TITLE
[dnssd-server] fix TXT RR format when TXT length is zero

### DIFF
--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -488,17 +488,25 @@ Error Server::AppendTxtRecord(Message &         aMessage,
                               uint32_t          aTtl,
                               NameCompressInfo &aCompressInfo)
 {
-    Error     error = kErrorNone;
-    TxtRecord txtRecord;
+    Error         error = kErrorNone;
+    TxtRecord     txtRecord;
+    const uint8_t kEmptyTxt = '\0';
 
     SuccessOrExit(error = AppendInstanceName(aMessage, aInstanceName, aCompressInfo));
 
     txtRecord.Init();
     txtRecord.SetTtl(aTtl);
-    txtRecord.SetLength(aTxtLength);
+    txtRecord.SetLength(aTxtLength > 0 ? aTxtLength : sizeof(kEmptyTxt));
 
     SuccessOrExit(error = aMessage.Append(txtRecord));
-    error = aMessage.AppendBytes(aTxtData, aTxtLength);
+    if (aTxtLength > 0)
+    {
+        error = aMessage.AppendBytes(aTxtData, aTxtLength);
+    }
+    else
+    {
+        error = aMessage.Append(kEmptyTxt);
+    }
 
 exit:
     return error;

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -490,7 +490,7 @@ Error Server::AppendTxtRecord(Message &         aMessage,
 {
     Error         error = kErrorNone;
     TxtRecord     txtRecord;
-    const uint8_t kEmptyTxt = '\0';
+    const uint8_t kEmptyTxt = 0;
 
     SuccessOrExit(error = AppendInstanceName(aMessage, aInstanceName, aCompressInfo));
 


### PR DESCRIPTION
Background:
- mDNS implementations may return zero length TXT RR. 