### PR TITLE
[common] adding `heap.hpp` header and `Heap` namespace     

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -221,6 +221,7 @@ LOCAL_SRC_FILES                                                  := \
     src/core/coap/coap_secure.cpp                                   \
     src/core/common/crc16.cpp                                       \
     src/core/common/error.cpp                                       \
+    src/core/common/heap.cpp                                        \
     src/core/common/heap_data.cpp                                   \
     src/core/common/heap_string.cpp                                 \
     src/core/common/instance.cpp                                    \

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -387,6 +387,8 @@ openthread_core_files = [
   "common/error.cpp",
   "common/error.hpp",
   "common/extension.hpp",
+  "common/heap.cpp",
+  "common/heap.hpp",
   "common/heap_data.cpp",
   "common/heap_data.hpp",
   "common/heap_string.cpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -94,6 +94,7 @@ set(COMMON_SOURCES
     coap/coap_secure.cpp
     common/crc16.cpp
     common/error.cpp
+    common/heap.cpp
     common/heap_data.cpp
     common/heap_string.cpp
     common/instance.cpp

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -184,6 +184,7 @@ SOURCES_COMMON                                  = \
     coap/coap_secure.cpp                          \
     common/crc16.cpp                              \
     common/error.cpp                              \
+    common/heap.cpp                               \
     common/heap_data.cpp                          \
     common/heap_string.cpp                        \
     common/instance.cpp                           \
@@ -427,6 +428,7 @@ HEADERS_COMMON                                  = \
     common/equatable.hpp                          \
     common/error.hpp                              \
     common/extension.hpp                          \
+    common/heap.hpp                               \
     common/heap_data.hpp                          \
     common/heap_string.hpp                        \
     common/instance.hpp                           \

--- a/src/core/api/heap_api.cpp
+++ b/src/core/api/heap_api.cpp
@@ -35,7 +35,7 @@
 
 #include <openthread/heap.h>
 
-#include "common/instance.hpp"
+#include "common/heap.hpp"
 
 #if OPENTHREAD_RADIO
 
@@ -62,11 +62,11 @@ void otHeapFree(void *aPointer)
 #else  // OPENTHREAD_RADIO
 void *otHeapCAlloc(size_t aCount, size_t aSize)
 {
-    return ot::Instance::HeapCAlloc(aCount, aSize);
+    return ot::Heap::CAlloc(aCount, aSize);
 }
 
 void otHeapFree(void *aPointer)
 {
-    ot::Instance::HeapFree(aPointer);
+    ot::Heap::Free(aPointer);
 }
 #endif // OPENTHREAD_RADIO

--- a/src/core/common/heap.hpp
+++ b/src/core/common/heap.hpp
@@ -28,72 +28,41 @@
 
 /**
  * @file
- *   This file implements the `Heap::String` (a heap allocated string).
+ *   This file includes definitions for `Heap`.
  */
 
-#include "heap_string.hpp"
+#ifndef HEAP_HPP_
+#define HEAP_HPP_
 
-#include "common/code_utils.hpp"
-#include "common/string.hpp"
+#include "openthread-core-config.h"
+
+#include <string.h>
 
 namespace ot {
 namespace Heap {
 
-Error String::Set(const char *aCString)
-{
-    Error  error = kErrorNone;
-    size_t curSize;
-    size_t newSize;
+/**
+ * This function allocates memory from heap for an array of given number of object of certain size.
+ *
+ * @param[in] aCount   Number of objects.
+ * @param[in] aSize    Size of each object.
+ *
+ * @returns A pointer to the allocated buffer or `nullptr` if fails to allocate.
+ *
+ */
+void *CAlloc(size_t aCount, size_t aSize);
 
-    VerifyOrExit(aCString != nullptr, Free());
-
-    curSize = (mStringBuffer != nullptr) ? strlen(mStringBuffer) + 1 : 0;
-    newSize = strlen(aCString) + 1;
-
-    if (curSize != newSize)
-    {
-        char *newBuffer = static_cast<char *>(Heap::CAlloc(sizeof(char), newSize));
-
-        VerifyOrExit(newBuffer != nullptr, error = kErrorNoBufs);
-
-        Heap::Free(mStringBuffer);
-        mStringBuffer = newBuffer;
-    }
-
-    memcpy(mStringBuffer, aCString, newSize);
-
-exit:
-    return error;
-}
-
-Error String::Set(String &&aString)
-{
-    VerifyOrExit(mStringBuffer != aString.mStringBuffer);
-
-    Heap::Free(mStringBuffer);
-    mStringBuffer         = aString.mStringBuffer;
-    aString.mStringBuffer = nullptr;
-
-exit:
-    return kErrorNone;
-}
-
-void String::Free(void)
-{
-    Heap::Free(mStringBuffer);
-    mStringBuffer = nullptr;
-}
-
-bool String::operator==(const char *aCString) const
-{
-    bool isEqual;
-
-    VerifyOrExit((aCString != nullptr) && (mStringBuffer != nullptr), isEqual = (mStringBuffer == aCString));
-    isEqual = (strcmp(mStringBuffer, aCString) == 0);
-
-exit:
-    return isEqual;
-}
+/**
+ * This function frees a previously heap allocated buffer.
+ *
+ * A heap allocated buffer MUST be freed only once.
+ *
+ * @param[in] aPointer   A pointer to the previously heap allocated buffer. Can be `nullptr` which does nothing.
+ *
+ */
+void Free(void *aPointer);
 
 } // namespace Heap
 } // namespace ot
+
+#endif // HEAP_HPP_

--- a/src/core/common/heap_data.cpp
+++ b/src/core/common/heap_data.cpp
@@ -28,18 +28,18 @@
 
 /**
  * @file
- *   This file implements the `HeapData` (a heap allocated data).
+ *   This file implements the `Heap::Data` (a heap allocated data).
  */
 
 #include "heap_data.hpp"
 
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
-#include "common/instance.hpp"
 
 namespace ot {
+namespace Heap {
 
-Error HeapData::SetFrom(const uint8_t *aBuffer, uint16_t aLength)
+Error Data::SetFrom(const uint8_t *aBuffer, uint16_t aLength)
 {
     Error error;
 
@@ -52,7 +52,7 @@ exit:
     return error;
 }
 
-Error HeapData::SetFrom(const Message &aMessage)
+Error Data::SetFrom(const Message &aMessage)
 {
     Error    error;
     uint16_t length = aMessage.GetLength() - aMessage.GetOffset();
@@ -66,25 +66,25 @@ exit:
     return error;
 }
 
-void HeapData::SetFrom(HeapData &&aHeapData)
+void Data::SetFrom(Data &&aData)
 {
     Free();
-    TakeFrom(aHeapData);
+    TakeFrom(aData);
 }
 
-void HeapData::Free(void)
+void Data::Free(void)
 {
-    Instance::HeapFree(mData.GetBytes());
+    Heap::Free(mData.GetBytes());
     mData.Init(nullptr, 0);
 }
 
-Error HeapData::UpdateBuffer(uint16_t aNewLength)
+Error Data::UpdateBuffer(uint16_t aNewLength)
 {
     Error error = kErrorNone;
 
     VerifyOrExit(aNewLength != mData.GetLength());
 
-    Instance::HeapFree(mData.GetBytes());
+    Heap::Free(mData.GetBytes());
 
     if (aNewLength == 0)
     {
@@ -92,7 +92,7 @@ Error HeapData::UpdateBuffer(uint16_t aNewLength)
     }
     else
     {
-        uint8_t *newBuffer = static_cast<uint8_t *>(Instance::HeapCAlloc(aNewLength, sizeof(uint8_t)));
+        uint8_t *newBuffer = static_cast<uint8_t *>(Heap::CAlloc(aNewLength, sizeof(uint8_t)));
 
         VerifyOrExit(newBuffer != nullptr, error = kErrorNoBufs);
         mData.Init(newBuffer, aNewLength);
@@ -102,10 +102,11 @@ exit:
     return error;
 }
 
-void HeapData::TakeFrom(HeapData &aHeapData)
+void Data::TakeFrom(Data &aData)
 {
-    mData.Init(aHeapData.mData.GetBytes(), aHeapData.GetLength());
-    aHeapData.mData.Init(nullptr, 0);
+    mData.Init(aData.mData.GetBytes(), aData.GetLength());
+    aData.mData.Init(nullptr, 0);
 }
 
+} // namespace Heap
 } // namespace ot

--- a/src/core/common/heap_data.hpp
+++ b/src/core/common/heap_data.hpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file includes definitions for `HeapData` (heap allocated data).
+ *   This file includes definitions for `Heap::Data` (heap allocated data).
  */
 
 #ifndef HEAP_DATA_HPP_
@@ -37,60 +37,62 @@
 #include "openthread-core-config.h"
 
 #include "common/data.hpp"
+#include "common/heap.hpp"
 #include "common/message.hpp"
 
 namespace ot {
+namespace Heap {
 
 /**
  * This class represents a heap allocated data.
  *
  */
-class HeapData
+class Data
 {
 public:
     /**
-     * This constructor initializes the `HeapData` as empty.
+     * This constructor initializes the `Heap::Data` as empty.
      *
      */
-    HeapData(void) { mData.Init(nullptr, 0); }
+    Data(void) { mData.Init(nullptr, 0); }
 
     /**
-     * This is the move constructor for `HeapData`.
+     * This is the move constructor for `Heap::Data`.
      *
-     * `HeapData` is non-copyable (copy constructor is deleted) but move constructor is provided to allow it to to be
+     * `Heap::Data` is non-copyable (copy constructor is deleted) but move constructor is provided to allow it to to be
      * used as return type (return by value) from functions/methods (which will then use move semantics).
      *
-     * @param[in] aHeapData   An rvalue reference to another `HeapData` to move from.
+     * @param[in] aData   An rvalue reference to another `Heap::Data` to move from.
      *
      */
-    HeapData(HeapData &&aHeapData) { TakeFrom(aHeapData); }
+    Data(Data &&aData) { TakeFrom(aData); }
 
     /**
-     * This is the destructor for `HeapData` object.
+     * This is the destructor for `Heap::Data` object.
      *
      */
-    ~HeapData(void) { Free(); }
+    ~Data(void) { Free(); }
 
     /**
-     * This method indicates whether or not the `HeapData` is null (i.e., it was never successfully set or it was
+     * This method indicates whether or not the `Heap::Data` is null (i.e., it was never successfully set or it was
      * freed).
      *
-     * @retval TRUE  The `HeapData` is null.
-     * @retval FALSE The `HeapData` is not null.
+     * @retval TRUE  The `Heap::Data` is null.
+     * @retval FALSE The `Heap::Data` is not null.
      *
      */
     bool IsNull(void) const { return (mData.GetBytes() == nullptr); }
 
     /**
-     * This method returns a pointer to the `HeapData` bytes buffer.
+     * This method returns a pointer to the `Heap::Data` bytes buffer.
      *
-     * @returns A pointer to data buffer or `nullptr` if the `HeapData` is null (never set or freed).
+     * @returns A pointer to data buffer or `nullptr` if the `Heap::Data` is null (never set or freed).
      *
      */
     const uint8_t *GetBytes(void) const { return mData.GetBytes(); }
 
     /**
-     * This method returns the `HeapData` length.
+     * This method returns the `Heap::Data` length.
      *
      * @returns The data length (number of bytes) or zero if the `HeadpData` is null.
      *
@@ -98,12 +100,12 @@ public:
     uint16_t GetLength(void) const { return mData.GetLength(); }
 
     /**
-     * This method sets the `HeapData` from the content of a given buffer.
+     * This method sets the `Heap::Data` from the content of a given buffer.
      *
      * @param[in] aBuffer     The buffer to copy bytes from.
      * @param[in] aLength     The buffer length (number of bytes).
      *
-     * @retval kErrorNone     Successfully set the `HeapData`.
+     * @retval kErrorNone     Successfully set the `Heap::Data`.
      * @retval kErrorNoBufs   Failed to allocate buffer.
      *
      */
@@ -117,33 +119,33 @@ public:
      * @param[in] aMessage    The message to copy bytes from (starting from offset till the end of message).
      * @param[in] aLength     The buffer length (number of bytes).
      *
-     * @retval kErrorNone     Successfully set the `HeapData`.
+     * @retval kErrorNone     Successfully set the `Heap::Data`.
      * @retval kErrorNoBufs   Failed to allocate buffer.
      *
      */
     Error SetFrom(const Message &aMessage);
 
     /**
-     * This method sets the `HeapData` from another one (move semantics).
+     * This method sets the `Heap::Data` from another one (move semantics).
      *
-     * @param[in] aHeapData   The other `HeapData` to set from (rvalue reference).
+     * @param[in] aData   The other `Heap::Data` to set from (rvalue reference).
      *
      */
-    void SetFrom(HeapData &&aHeapData);
+    void SetFrom(Data &&aData);
 
     /**
-     * This method appends the bytes from `HeapData` to a given message.
+     * This method appends the bytes from `Heap::Data` to a given message.
      *
      * @param[in] aMessage   The message to append the bytes into.
      *
-     * @retval kErrorNone     Successfully copied the bytes from `HeapData` into @p aMessage.
+     * @retval kErrorNone     Successfully copied the bytes from `Heap::Data` into @p aMessage.
      * @retval kErrorNoBufs   Failed to allocate buffer.
      *
      */
     Error CopyBytesTo(Message &aMessage) const { return aMessage.AppendBytes(mData.GetBytes(), mData.GetLength()); }
 
     /**
-     * This method copies the bytes from `HeapData` into a given buffer.
+     * This method copies the bytes from `Heap::Data` into a given buffer.
      *
      * It is up to the caller to ensure that @p aBuffer has enough space for the current data length.
      *
@@ -153,24 +155,25 @@ public:
     void CopyBytesTo(uint8_t *aBuffer) const { return mData.CopyBytesTo(aBuffer); }
 
     /**
-     * This method frees any buffer allocated by the `HeapData`.
+     * This method frees any buffer allocated by the `Heap::Data`.
      *
-     * The `HeapData` destructor will automatically call `Free()`. This method allows caller to free the buffer
+     * The `Heap::Data` destructor will automatically call `Free()`. This method allows caller to free the buffer
      * explicitly.
      *
      */
     void Free(void);
 
-    HeapData(const HeapData &) = delete;
-    HeapData &operator=(const HeapData &) = delete;
+    Data(const Data &) = delete;
+    Data &operator=(const Data &) = delete;
 
 private:
     Error UpdateBuffer(uint16_t aNewLength);
-    void  TakeFrom(HeapData &aHeapData);
+    void  TakeFrom(Data &aData);
 
     MutableData<kWithUint16Length> mData;
 };
 
+} // namespace Heap
 } // namespace ot
 
 #endif // HEAP_DATA_HPP_

--- a/src/core/common/heap_string.hpp
+++ b/src/core/common/heap_string.hpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file includes definitions for `HeapString` (a heap allocated string).
+ *   This file includes definitions for `Heap::String` (a heap allocated string).
  */
 
 #ifndef HEAP_STRING_HPP_
@@ -38,37 +38,39 @@
 
 #include "common/equatable.hpp"
 #include "common/error.hpp"
+#include "common/heap.hpp"
 
 namespace ot {
+namespace Heap {
 
 /**
  * This class represents a heap allocated string.
  *
- * The buffer to store the string is allocated from heap and is manged by the `HeapString` class itself, e.g., it may
- * be reused and/or freed and reallocated when the string is set. The `HeapString` destructor will always free the
+ * The buffer to store the string is allocated from heap and is manged by the `Heap::String` class itself, e.g., it may
+ * be reused and/or freed and reallocated when the string is set. The `Heap::String` destructor will always free the
  * allocated buffer.
  *
  */
-class HeapString : public Unequatable<HeapString>
+class String : public Unequatable<String>
 {
 public:
     /**
-     * This constructor initializes the `HeapString` as null (or empty).
+     * This constructor initializes the `String` as null (or empty).
      *
      */
-    HeapString(void)
+    String(void)
         : mStringBuffer(nullptr)
     {
     }
 
     /**
-     * This is the move constructor for `HeapString`.
+     * This is the move constructor for `String`.
      *
-     * `HeapString` is non-copyable (copy constructor is deleted) but move constructor is provided to allow it to to be
+     * `String` is non-copyable (copy constructor is deleted) but move constructor is provided to allow it to to be
      * used as return type (return by value) from functions/methods (which will then use move semantics).
      *
      */
-    HeapString(HeapString &&aString)
+    String(String &&aString)
         : mStringBuffer(aString.mStringBuffer)
     {
         aString.mStringBuffer = nullptr;
@@ -78,22 +80,22 @@ public:
      * This is the destructor for `HealString` object
      *
      */
-    ~HeapString(void) { Free(); }
+    ~String(void) { Free(); }
 
     /**
-     * This method indicates whether or not the `HeapString` is null (i.e., it was never successfully set or it was
+     * This method indicates whether or not the `String` is null (i.e., it was never successfully set or it was
      * freed).
      *
-     * @retval TRUE  The `HeapString` is null.
-     * @retval FALSE The `HeapString` is not null.
+     * @retval TRUE  The `String` is null.
+     * @retval FALSE The `String` is not null.
      *
      */
     bool IsNull(void) const { return (mStringBuffer == nullptr); }
 
     /**
-     * This method returns the `HeapString` as a C string.
+     * This method returns the `String` as a C string.
      *
-     * @returns A pointer to C string buffer or `nullptr` if the `HeapString` is null (never set or freed).
+     * @returns A pointer to C string buffer or `nullptr` if the `String` is null (never set or freed).
      *
      */
     const char *AsCString(void) const { return mStringBuffer; }
@@ -101,7 +103,7 @@ public:
     /**
      * This method sets the string from a given C string.
      *
-     * @param[in] aCString   A pointer to c string buffer. Can be `nullptr` which then frees the `HeapString`.
+     * @param[in] aCString   A pointer to c string buffer. Can be `nullptr` which then frees the `String`.
      *
      * @retval kErrorNone     Successfully set the string.
      * @retval kErrorNoBufs   Failed to allocate buffer for string.
@@ -110,40 +112,40 @@ public:
     Error Set(const char *aCString);
 
     /**
-     * This method sets the string from another `HeapString`.
+     * This method sets the string from another `String`.
      *
-     * @param[in] aString   The other `HeapString` to set from.
-     *
-     * @retval kErrorNone     Successfully set the string.
-     * @retval kErrorNoBufs   Failed to allocate buffer for string.
-     *
-     */
-    Error Set(const HeapString &aString) { return Set(aString.AsCString()); }
-
-    /**
-     * This method sets the string from another `HeapString`.
-     *
-     * @param[in] aString     The other `HeapString` to set from (rvalue reference using move semantics).
+     * @param[in] aString   The other `String` to set from.
      *
      * @retval kErrorNone     Successfully set the string.
      * @retval kErrorNoBufs   Failed to allocate buffer for string.
      *
      */
-    Error Set(HeapString &&aString);
+    Error Set(const String &aString) { return Set(aString.AsCString()); }
 
     /**
-     * This method frees any buffer allocated by the `HeapString`.
+     * This method sets the string from another `String`.
      *
-     * The `HeapString` destructor will automatically call `Free()`. This method allows caller to free buffer
+     * @param[in] aString     The other `String` to set from (rvalue reference using move semantics).
+     *
+     * @retval kErrorNone     Successfully set the string.
+     * @retval kErrorNoBufs   Failed to allocate buffer for string.
+     *
+     */
+    Error Set(String &&aString);
+
+    /**
+     * This method frees any buffer allocated by the `String`.
+     *
+     * The `String` destructor will automatically call `Free()`. This method allows caller to free buffer
      * explicitly.
      *
      */
     void Free(void);
 
     /**
-     * This method overloads operator `==` to evaluate whether or not the `HeapString` is equal to a given C string.
+     * This method overloads operator `==` to evaluate whether or not the `String` is equal to a given C string.
      *
-     * @param[in]  aCString  A C string to compare with. Can be `nullptr` which then checks if `HeapString` is null.
+     * @param[in]  aCString  A C string to compare with. Can be `nullptr` which then checks if `String` is null.
      *
      * @retval TRUE   If the two strings are equal.
      * @retval FALSE  If the two strings are not equal.
@@ -152,9 +154,9 @@ public:
     bool operator==(const char *aCString) const;
 
     /**
-     * This method overloads operator `!=` to evaluate whether or not the `HeapString` is unequal to a given C string.
+     * This method overloads operator `!=` to evaluate whether or not the `String` is unequal to a given C string.
      *
-     * @param[in]  aCString  A C string to compare with. Can be `nullptr` which then checks if `HeapString` is not null.
+     * @param[in]  aCString  A C string to compare with. Can be `nullptr` which then checks if `String` is not null.
      *
      * @retval TRUE   If the two strings are not equal.
      * @retval FALSE  If the two strings are equal.
@@ -163,7 +165,7 @@ public:
     bool operator!=(const char *aCString) const { return !(*this == aCString); }
 
     /**
-     * This method overloads operator `==` to evaluate whether or not two `HeapString` are equal.
+     * This method overloads operator `==` to evaluate whether or not two `String` are equal.
      *
      * @param[in]  aString  The other string to compare with.
      *
@@ -171,15 +173,16 @@ public:
      * @retval FALSE  If the two strings are not equal.
      *
      */
-    bool operator==(const HeapString &aString) const { return (*this == aString.AsCString()); }
+    bool operator==(const String &aString) const { return (*this == aString.AsCString()); }
 
-    HeapString(const HeapString &) = delete;
-    HeapString &operator=(const HeapString &) = delete;
+    String(const String &) = delete;
+    String &operator=(const String &) = delete;
 
 private:
     char *mStringBuffer;
 };
 
+} // namespace Heap
 } // namespace ot
 
 #endif // HEAP_STRING_HPP_

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -260,21 +260,15 @@ public:
      */
     Error ErasePersistentInfo(void);
 
-#if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-    static void  HeapFree(void *aPointer) { otPlatFree(aPointer); }
-    static void *HeapCAlloc(size_t aCount, size_t aSize) { return otPlatCAlloc(aCount, aSize); }
-#else
-    static void  HeapFree(void *aPointer) { sHeap.Free(aPointer); }
-    static void *HeapCAlloc(size_t aCount, size_t aSize) { return sHeap.CAlloc(aCount, aSize); }
-
+#if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
     /**
      * This method returns a reference to the Heap object.
      *
      * @returns A reference to the Heap object.
      *
      */
-    Utils::Heap &GetHeap(void) { return sHeap; }
-#endif // OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+    static Utils::Heap &GetHeap(void) { return sHeap; }
+#endif
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
     /**

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -36,6 +36,7 @@
 #include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
+#include "common/heap.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
 #include "common/logging.hpp"
@@ -119,7 +120,7 @@ Buffer *MessagePool::NewBuffer(Message::Priority aPriority)
 
     while ((
 #if OPENTHREAD_CONFIG_MESSAGE_USE_HEAP_ENABLE
-               buffer = static_cast<Buffer *>(Instance::HeapCAlloc(1, sizeof(Buffer)))
+               buffer = static_cast<Buffer *>(Heap::CAlloc(1, sizeof(Buffer)))
 #elif OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
                buffer = static_cast<Buffer *>(otPlatMessagePoolNew(&GetInstance()))
 #else
@@ -151,7 +152,7 @@ void MessagePool::FreeBuffers(Buffer *aBuffer)
     {
         Buffer *next = aBuffer->GetNextBuffer();
 #if OPENTHREAD_CONFIG_MESSAGE_USE_HEAP_ENABLE
-        Instance::HeapFree(aBuffer);
+        Heap::Free(aBuffer);
 #elif OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
         otPlatMessagePoolFree(&GetInstance(), aBuffer);
 #else
@@ -172,7 +173,7 @@ uint16_t MessagePool::GetFreeBufferCount(void) const
     uint16_t rval;
 
 #if OPENTHREAD_CONFIG_MESSAGE_USE_HEAP_ENABLE
-    rval = static_cast<uint16_t>(GetInstance().GetHeap().GetFreeSize() / sizeof(Buffer));
+    rval = static_cast<uint16_t>(Instance::GetHeap().GetFreeSize() / sizeof(Buffer));
 #elif OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
     rval = otPlatMessagePoolNumFreeBuffers(&GetInstance());
 #else
@@ -185,7 +186,7 @@ uint16_t MessagePool::GetFreeBufferCount(void) const
 uint16_t MessagePool::GetTotalBufferCount(void) const
 {
 #if OPENTHREAD_CONFIG_MESSAGE_USE_HEAP_ENABLE
-    return static_cast<uint16_t>(GetInstance().GetHeap().GetCapacity() / sizeof(Buffer));
+    return static_cast<uint16_t>(Instance::GetHeap().GetCapacity() / sizeof(Buffer));
 #else
     return OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS;
 #endif

--- a/src/core/crypto/mbedtls.cpp
+++ b/src/core/crypto/mbedtls.cpp
@@ -44,7 +44,7 @@
 #endif
 
 #include "common/error.hpp"
-#include "common/instance.hpp"
+#include "common/heap.hpp"
 
 namespace ot {
 namespace Crypto {
@@ -56,7 +56,7 @@ MbedTls::MbedTls(void)
     // mbedTLS's debug level is almost the same as OpenThread's
     mbedtls_debug_set_threshold(OPENTHREAD_CONFIG_LOG_LEVEL);
 #endif
-    mbedtls_platform_set_calloc_free(Instance::HeapCAlloc, Instance::HeapFree);
+    mbedtls_platform_set_calloc_free(Heap::CAlloc, Heap::Free);
 #endif // OPENTHREAD_CONFIG_ENABLE_BUILTIN_MBEDTLS_MANAGEMENT
 }
 

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -37,6 +37,7 @@
 
 #include "coap/coap_message.hpp"
 #include "common/as_core_type.hpp"
+#include "common/heap.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
 #include "common/logging.hpp"
@@ -215,7 +216,7 @@ exit:
         SendErrorMessage(aForwardContext, error);
     }
 
-    Instance::HeapFree(&aForwardContext);
+    Heap::Free(&aForwardContext);
 }
 
 template <Coap::Resource BorderAgent::*aResource>
@@ -503,7 +504,7 @@ Error BorderAgent::ForwardToLeader(const Coap::Message &   aMessage,
         SuccessOrExit(error = Get<Coap::CoapSecure>().SendAck(aMessage, aMessageInfo));
     }
 
-    forwardContext = static_cast<ForwardContext *>(Instance::HeapCAlloc(1, sizeof(ForwardContext)));
+    forwardContext = static_cast<ForwardContext *>(Heap::CAlloc(1, sizeof(ForwardContext)));
     VerifyOrExit(forwardContext != nullptr, error = kErrorNoBufs);
 
     forwardContext->Init(GetInstance(), aMessage, aPetition, aSeparate);
@@ -539,7 +540,7 @@ exit:
     {
         if (forwardContext != nullptr)
         {
-            Instance::HeapFree(forwardContext);
+            Heap::Free(forwardContext);
         }
 
         FreeMessage(message);

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -1442,7 +1442,7 @@ Server::Service *Server::Service::New(const char *aServiceName, Description &aDe
     void *   buf;
     Service *service = nullptr;
 
-    buf = Instance::HeapCAlloc(1, sizeof(Service));
+    buf = Heap::CAlloc(1, sizeof(Service));
     VerifyOrExit(buf != nullptr);
 
     service = new (buf) Service(aDescription, aIsSubType);
@@ -1459,7 +1459,7 @@ exit:
 
 void Server::Service::Free(void)
 {
-    Instance::HeapFree(this);
+    Heap::Free(this);
 }
 
 Server::Service::Service(Description &aDescription, bool aIsSubType)
@@ -1591,7 +1591,7 @@ Server::Service::Description *Server::Service::Description::New(const char *aIns
     void *       buf;
     Description *desc = nullptr;
 
-    buf = Instance::HeapCAlloc(1, sizeof(Description));
+    buf = Heap::CAlloc(1, sizeof(Description));
     VerifyOrExit(buf != nullptr);
 
     desc = new (buf) Description(aHost);
@@ -1609,7 +1609,7 @@ exit:
 void Server::Service::Description::Free(void)
 {
     mInstanceName.Free();
-    Instance::HeapFree(this);
+    Heap::Free(this);
 }
 
 Server::Service::Description::Description(Host &aHost)
@@ -1629,7 +1629,7 @@ Server::Service::Description::Description(Host &aHost)
 void Server::Service::Description::ClearResources(void)
 {
     mPort = 0;
-    Instance::HeapFree(mTxtData);
+    Heap::Free(mTxtData);
     mTxtData   = nullptr;
     mTxtLength = 0;
 }
@@ -1638,7 +1638,7 @@ void Server::Service::Description::TakeResourcesFrom(Description &aDescription)
 {
     // Take ownership and move the heap allocated `mTxtData` buffer
     // from `aDescription
-    Instance::HeapFree(mTxtData);
+    Heap::Free(mTxtData);
     mTxtData                = aDescription.mTxtData;
     mTxtLength              = aDescription.mTxtLength;
     aDescription.mTxtData   = nullptr;
@@ -1658,20 +1658,20 @@ Error Server::Service::Description::SetTxtDataFromMessage(const Message &aMessag
     Error    error = kErrorNone;
     uint8_t *txtData;
 
-    txtData = static_cast<uint8_t *>(Instance::HeapCAlloc(1, aLength));
+    txtData = static_cast<uint8_t *>(Heap::CAlloc(1, aLength));
     VerifyOrExit(txtData != nullptr, error = kErrorNoBufs);
 
     VerifyOrExit(aMessage.ReadBytes(aOffset, txtData, aLength) == aLength, error = kErrorParse);
     VerifyOrExit(Dns::TxtRecord::VerifyTxtData(txtData, aLength, /* aAllowEmpty */ false), error = kErrorParse);
 
-    Instance::HeapFree(mTxtData);
+    Heap::Free(mTxtData);
     mTxtData   = txtData;
     mTxtLength = aLength;
 
 exit:
     if (error != kErrorNone)
     {
-        Instance::HeapFree(txtData);
+        Heap::Free(txtData);
     }
 
     return error;
@@ -1685,7 +1685,7 @@ Server::Host *Server::Host::New(Instance &aInstance)
     void *buf;
     Host *host = nullptr;
 
-    buf = Instance::HeapCAlloc(1, sizeof(Host));
+    buf = Heap::CAlloc(1, sizeof(Host));
     VerifyOrExit(buf != nullptr);
 
     host = new (buf) Host(aInstance);
@@ -1698,7 +1698,7 @@ void Server::Host::Free(void)
 {
     FreeAllServices();
     mFullName.Free();
-    Instance::HeapFree(this);
+    Heap::Free(this);
 }
 
 Server::Host::Host(Instance &aInstance)
@@ -1987,7 +1987,7 @@ Server::UpdateMetadata *Server::UpdateMetadata::New(Instance &               aIn
     void *          buf;
     UpdateMetadata *update = nullptr;
 
-    buf = Instance::HeapCAlloc(1, sizeof(UpdateMetadata));
+    buf = Heap::CAlloc(1, sizeof(UpdateMetadata));
     VerifyOrExit(buf != nullptr);
 
     update = new (buf) UpdateMetadata(aInstance, aHeader, aHost, aMessageInfo);
@@ -1998,7 +1998,7 @@ exit:
 
 void Server::UpdateMetadata::Free(void)
 {
-    Instance::HeapFree(this);
+    Heap::Free(this);
 }
 
 Server::UpdateMetadata::UpdateMetadata(Instance &               aInstance,

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -56,6 +56,7 @@
 #include "common/array.hpp"
 #include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
+#include "common/heap.hpp"
 #include "common/heap_string.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
@@ -348,7 +349,7 @@ public:
             Error       SetTxtDataFromMessage(const Message &aMessage, uint16_t aOffset, uint16_t aLength);
 
             Description *mNext;
-            HeapString   mInstanceName;
+            Heap::String mInstanceName;
             Host &       mHost;
             uint16_t     mPriority;
             uint16_t     mWeight;
@@ -378,7 +379,7 @@ public:
         bool MatchesFlags(Flags aFlags) const;
         void Log(Action aAction) const;
 
-        HeapString   mServiceName;
+        Heap::String mServiceName;
         Description &mDescription;
         Service *    mNext;
         TimeMilli    mTimeLastUpdate;
@@ -530,7 +531,7 @@ public:
         const Service *             FindService(const char *aServiceName, const char *aInstanceName) const;
 
         Host *                             mNext;
-        HeapString                         mFullName;
+        Heap::String                       mFullName;
         Array<Ip6::Address, kMaxAddresses> mAddresses;
         Dns::Ecdsa256KeyRecord             mKey;
         uint32_t                           mLease;    // The LEASE time in seconds.
@@ -882,7 +883,7 @@ private:
     otSrpServerServiceUpdateHandler mServiceUpdateHandler;
     void *                          mServiceUpdateHandlerContext;
 
-    HeapString mDomain;
+    Heap::String mDomain;
 
     LeaseConfig mLeaseConfig;
 

--- a/src/core/utils/heap.hpp
+++ b/src/core/utils/heap.hpp
@@ -32,8 +32,8 @@
  *
  */
 
-#ifndef OT_HEAP_HPP_
-#define OT_HEAP_HPP_
+#ifndef OT_UTILS_HEAP_HPP_
+#define OT_UTILS_HEAP_HPP_
 
 #include "openthread-core-config.h"
 
@@ -350,4 +350,4 @@ private:
 
 #endif // !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 
-#endif // OT_HEAP_HPP_
+#endif // OT_UTILS_HEAP_HPP_

--- a/tests/unit/test_heap_string.cpp
+++ b/tests/unit/test_heap_string.cpp
@@ -39,7 +39,7 @@
 
 namespace ot {
 
-void PrintString(const char *aName, const HeapString &aString)
+void PrintString(const char *aName, const Heap::String &aString)
 {
     if (aString.IsNull())
     {
@@ -51,7 +51,7 @@ void PrintString(const char *aName, const HeapString &aString)
     }
 }
 
-void VerifyString(const char *aName, const HeapString &aString, const char *aExpectedString)
+void VerifyString(const char *aName, const Heap::String &aString, const char *aExpectedString)
 {
     PrintString(aName, aString);
 
@@ -72,10 +72,10 @@ void VerifyString(const char *aName, const HeapString &aString, const char *aExp
     VerifyOrQuit(aString == aExpectedString);
 }
 
-// Function returning a `HeapString` by value.
-HeapString GetName(void)
+// Function returning a `Heap::String` by value.
+Heap::String GetName(void)
 {
-    HeapString name;
+    Heap::String name;
 
     SuccessOrQuit(name.Set("name"));
 
@@ -84,9 +84,9 @@ HeapString GetName(void)
 
 void TestHeapString(void)
 {
-    HeapString  str1;
-    HeapString  str2;
-    const char *oldBuffer;
+    Heap::String str1;
+    Heap::String str2;
+    const char * oldBuffer;
 
     printf("====================================================================================\n");
     printf("TestHeapString\n\n");
@@ -111,7 +111,7 @@ void TestHeapString(void)
     printf("\tDid reuse its old buffer (same length): %s\n", str1.AsCString() == oldBuffer ? "yes" : "no");
 
     printf("------------------------------------------------------------------------------------\n");
-    printf("Set(const HeapString &)\n\n");
+    printf("Set(const Heap::String &)\n\n");
     SuccessOrQuit(str2.Set(str1));
     VerifyString("str2", str2, str1.AsCString());
 
@@ -150,29 +150,24 @@ void TestHeapString(void)
     printf("\n -- PASS\n");
 }
 
-void PrintData(const HeapData &aData)
+void PrintData(const Heap::Data &aData)
 {
     DumpBuffer("data", aData.GetBytes(), aData.GetLength());
 }
 
-template <uint16_t kLength> void VerifyData(const HeapData &aData, const uint8_t (&aArray)[kLength])
-{
-    VerifyData(aData, &aArray[0], kLength);
-}
-
 static const uint8_t kTestValue = 0x77;
 
-// Function returning a `HeapData` by value.
-HeapData GetData(void)
+// Function returning a `Heap::Data` by value.
+Heap::Data GetData(void)
 {
-    HeapData data;
+    Heap::Data data;
 
     SuccessOrQuit(data.SetFrom(&kTestValue, sizeof(kTestValue)));
 
     return data;
 }
 
-void VerifyData(const HeapData &aData, const uint8_t *aBytes, uint16_t aLength)
+void VerifyData(const Heap::Data &aData, const uint8_t *aBytes, uint16_t aLength)
 {
     static constexpr uint16_t kMaxLength = 100;
     uint8_t                   buffer[kMaxLength];
@@ -197,12 +192,17 @@ void VerifyData(const HeapData &aData, const uint8_t *aBytes, uint16_t aLength)
     }
 }
 
+template <uint16_t kLength> void VerifyData(const Heap::Data &aData, const uint8_t (&aArray)[kLength])
+{
+    VerifyData(aData, &aArray[0], kLength);
+}
+
 void TestHeapData(void)
 {
     Instance *     instance;
     MessagePool *  messagePool;
     Message *      message;
-    HeapData       data;
+    Heap::Data     data;
     const uint8_t *oldBuffer;
 
     static const uint8_t kData1[] = {10, 20, 3, 15, 100, 0, 60, 16};


### PR DESCRIPTION
This commit moves the heap functions `CAlloc` and `Free` from
`instance.hpp` header to a separate `heap.hpp` header file. The main
reason is to make it easier to include this header file from other
modules (avoid the header dependency/loop issues by requiring to
include `instance.hpp` to get access to heap functions). This commit
also defines a `Heap` namespace and moves other heap allocated types
under this namespace (`Heap::String` and `Heap::Data`).

