### PR TITLE
[thci] override `forceSetSlaac` for border router

### DIFF
--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -647,3 +647,9 @@ EOF"
         print('powerUp')
         self.bash('sudo service otbr-agent start')
         super(OpenThread_BR, self).powerUp()
+
+    # Override forceSetSlaac
+    @API
+    def forceSetSlaac(self, slaacAddress):
+        print('forceSetSlaac %s' % slaacAddress)
+        self.bash('sudo ip -6 addr add %s/64 dev wpan0' % slaacAddress)


### PR DESCRIPTION
Manually configured addresses need to be added to the TUN interface in order for the host to handle them.

Discussion in https://github.com/openthread/openthread/pull/7145