### PR TITLE
[tests] stop otbr-agent service for host nodes

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
+++ b/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
@@ -79,7 +79,6 @@ class PublishMeshCopService(thread_cert.TestCase):
         br2 = self.nodes[BR2]
         br2.disable_br()
 
-        host.bash('service otbr-agent stop')
         host.start(start_radvd=False)
         self.simulator.go(20)
 

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -3265,6 +3265,7 @@ class HostNode(LinuxHost, OtbrDocker):
         self.nodeid = nodeid
         self.name = name or ('Host%d' % nodeid)
         super().__init__(nodeid, **kwargs)
+        self.bash('service otbr-agent stop')
 
     def start(self, start_radvd=True, prefix=config.DOMAIN_PREFIX, slaac=False):
         self._setup_sysctl()


### PR DESCRIPTION
HostNode is based on OtbrDocker, which has otbr-agent service started by default. We should disable this service on HostNode otherwise the border router test cases won't have the exact expected topology.