### PR TITLE
[github-actions] use MeshCoP service name with spaces

### DIFF
--- a/script/test
+++ b/script/test
@@ -283,6 +283,7 @@ do_build_otbr_docker()
         "-DOT_FULL_LOGS=ON"
         "-DOT_UPTIME=ON"
         "-DOTBR_DUA_ROUTING=ON"
+        "-DOTBR_MESHCOP_SERVICE_INSTANCE_NAME=OpenThread\\x20Border\\x20Router"
         "-DCMAKE_CXX_FLAGS='-DOPENTHREAD_CONFIG_DNSSD_SERVER_BIND_UNSPECIFIED_NETIF=1'"
     )
 


### PR DESCRIPTION
This commit changes MeshCoP service name in CI to help make sure service names with spaces can be published correctly. 