### PR TITLE
[thci] fix `mdns_query`

### DIFF
--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -613,7 +613,7 @@ EOF"
 
         result = self.bash('dig -p 5353 @%s %s ptr +time=2 +retry=2' % (dst, service))
 
-        if dst in 'ff02::fb' and not addrs_blacklist:
+        if dst == 'ff02::fb' and not addrs_blacklist:
             return (0, '')
 
         # Remove responses from unwanted devices

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -612,9 +612,12 @@ EOF"
         print('mdns_query %s %s %s' % (dst, service, addrs_blacklist))
 
         result = self.bash('dig -p 5353 @%s %s ptr +time=2 +retry=2' % (dst, service))
-        responses = ' '.join(result).split(';; ANSWER SECTION:')
+
+        if dst in 'ff02::fb' and not addrs_blacklist:
+            return (0, '')
 
         # Remove responses from unwanted devices
+        responses = ' '.join(result).split(';; ANSWER SECTION:')
         for response in responses:
             if not set(response.split()).isdisjoint(set(addrs_blacklist)):
                 break


### PR DESCRIPTION
Avoid parsing responses for not expected cases.

Fixes some issues with Thread 1.2 certification test cases in which it's not required to parse the mDNS response.