### PR TITLE
[mac] add "Radio Filter" mechanism

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (175)
+#define OPENTHREAD_API_VERSION (176)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -865,6 +865,33 @@ void otLinkFilterClearAllRssIn(otInstance *aInstance);
 otError otLinkFilterGetNextRssIn(otInstance *aInstance, otMacFilterIterator *aIterator, otMacFilterEntry *aEntry);
 
 /**
+ * This function enables/disables IEEE 802.15.4 radio filter mode.
+ *
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
+ *
+ * The radio filter is mainly intended for testing. It can be used to temporarily block all tx/rx on the 802.15.4 radio.
+ * When radio filter is enabled, radio is put to sleep instead of receive (to ensure device does not receive any frame
+ * and/or potentially send ack). Also the frame transmission requests return immediately without sending the frame over
+ * the air (return "no ack" error if ack is requested, otherwise return success).
+ *
+ * @param[in] aInstance         A pointer to an OpenThread instance.
+ * @param[in] aFilterEnabled    TRUE to enable radio filter, FALSE to disable
+ *
+ */
+void otLinkSetRadioFilterEnabled(otInstance *aInstance, bool aFilterEnabled);
+
+/**
+ * This function indicates whether the IEEE 802.15.4 radio filter is enabled or not.
+ *
+ * This function is available when OPENTHREAD_CONFIG_MAC_FILTER_ENABLE configuration is enabled.
+ *
+ * @retval TRUE   If the radio filter is enabled.
+ * @retval FALSE  If the radio filter is disabled.
+ *
+ */
+bool otLinkIsRadioFilterEnabled(otInstance *aInstance);
+
+/**
  * This method converts received signal strength to link quality.
  *
  * @param[in]  aInstance  A pointer to an OpenThread instance.

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -89,6 +89,7 @@ Done
 - [prefix](#prefix)
 - [promiscuous](#promiscuous)
 - [pskc](#pskc--p-keypassphrase)
+- [radiofilter](#radiofilter)
 - [rcp](#rcp)
 - [region](#region)
 - [releaserouterid](#releaserouterid-routerid)
@@ -2180,6 +2181,44 @@ Disable radio promiscuous operation.
 
 ```bash
 > promiscuous disable
+Done
+```
+
+### radiofilter
+
+`OPENTHREAD_CONFIG_MAC_FILTER_ENABLE` is required.
+
+The radio filter is mainly intended for testing. It can be used to temporarily block all tx/rx on the IEEE 802.15.4 radio.
+
+When radio filter is enabled, radio is put to sleep instead of receive (to ensure device does not receive any frame and/or potentially send ack). Also the frame transmission requests return immediately without sending the frame over the air (return "no ack" error if ack is requested, otherwise return success).
+
+Get radio filter status (enabled or disabled).
+
+```bash
+> radiofilter
+Disabled
+Done
+```
+
+### radiofilter enable
+
+`OPENTHREAD_CONFIG_MAC_FILTER_ENABLE` is required.
+
+Enable radio radio filter.
+
+```bash
+> radiofilter enable
+Done
+```
+
+### radiofilter disable
+
+`OPENTHREAD_CONFIG_MAC_FILTER_ENABLE` is required.
+
+Disable radio radio filter.
+
+```bash
+> radiofilter disable
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3666,6 +3666,28 @@ otError Interpreter::ProcessPreferRouterId(Arg aArgs[])
 }
 #endif
 
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+otError Interpreter::ProcessRadioFilter(Arg aArgs[])
+{
+    otError error = OT_ERROR_NONE;
+
+    if (aArgs[0].IsEmpty())
+    {
+        OutputEnabledDisabledStatus(otLinkIsRadioFilterEnabled(GetInstancePtr()));
+    }
+    else
+    {
+        bool enable;
+
+        SuccessOrExit(error = ParseEnableOrDisable(aArgs[0], enable));
+        otLinkSetRadioFilterEnabled(GetInstancePtr(), enable);
+    }
+
+exit:
+    return error;
+}
+#endif
+
 otError Interpreter::ProcessRcp(Arg aArgs[])
 {
     otError     error   = OT_ERROR_NONE;

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -511,6 +511,7 @@ private:
     otError ProcessPskcRef(Arg aArgs[]);
 #endif
 #endif
+    otError ProcessRadioFilter(Arg aArgs[]);
     otError ProcessRcp(Arg aArgs[]);
     otError ProcessRegion(Arg aArgs[]);
 #if OPENTHREAD_FTD
@@ -816,6 +817,9 @@ private:
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
         {"pskcref", &Interpreter::ProcessPskcRef},
 #endif
+#endif
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+        {"radiofilter", &Interpreter::ProcessRadioFilter},
 #endif
         {"rcp", &Interpreter::ProcessRcp},
         {"region", &Interpreter::ProcessRegion},

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -266,6 +266,20 @@ otError otLinkFilterGetNextRssIn(otInstance *aInstance, otMacFilterIterator *aIt
     return AsCoreType(aInstance).Get<Mac::Filter>().GetNextRssIn(*aIterator, *aEntry);
 }
 
+#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
+void otLinkSetRadioFilterEnabled(otInstance *aInstance, bool aFilterEnabled)
+{
+    return AsCoreType(aInstance).Get<Mac::Mac>().SetRadioFilterEnabled(aFilterEnabled);
+}
+
+bool otLinkIsRadioFilterEnabled(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<Mac::Mac>().IsRadioFilterEnabled();
+}
+#endif
+
+#endif // OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+
 uint8_t otLinkConvertRssToLinkQuality(otInstance *aInstance, int8_t aRss)
 {
     return LinkQualityInfo::ConvertRssToLinkQuality(AsCoreType(aInstance).Get<Mac::Mac>().GetNoiseFloor(), aRss);
@@ -276,8 +290,6 @@ int8_t otLinkConvertLinkQualityToRss(otInstance *aInstance, uint8_t aLinkQuality
     return LinkQualityInfo::ConvertLinkQualityToRss(AsCoreType(aInstance).Get<Mac::Mac>().GetNoiseFloor(),
                                                     aLinkQuality);
 }
-
-#endif // OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
 
 #if OPENTHREAD_CONFIG_MAC_RETRY_SUCCESS_HISTOGRAM_ENABLE
 const uint32_t *otLinkGetTxDirectRetrySuccessHistogram(otInstance *aInstance, uint8_t *aNumberOfEntries)

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2481,5 +2481,13 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
 
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE && OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
+void Mac::SetRadioFilterEnabled(bool aFilterEnabled)
+{
+    mLinks.GetSubMac().SetRadioFilterEnabled(aFilterEnabled);
+    UpdateIdleMode();
+}
+#endif
+
 } // namespace Mac
 } // namespace ot

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -752,6 +752,29 @@ public:
     }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE && OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
+    /**
+     * This method enables/disables the 802.15.4 radio filter.
+     *
+     * When radio filter is enabled, radio is put to sleep instead of receive (to ensure device does not receive any
+     * frame and/or potentially send ack). Also the frame transmission requests return immediately without sending the
+     * frame over the air (return "no ack" error if ack is requested, otherwise return success).
+     *
+     * @param[in] aFilterEnabled    TRUE to enable radio filter, FALSE to disable.
+     *
+     */
+    void SetRadioFilterEnabled(bool aFilterEnabled);
+
+    /**
+     * This method indicates whether the 802.15.4 radio filter is enabled or not.
+     *
+     * @retval TRUE   If the radio filter is enabled.
+     * @retval FALSE  If the radio filter is disabled.
+     *
+     */
+    bool IsRadioFilterEnabled(void) const { return mLinks.GetSubMac().IsRadioFilterEnabled(); }
+#endif
+
 private:
     static constexpr int8_t   kInvalidRssiValue  = SubMac::kInvalidRssiValue;
     static constexpr uint16_t kMaxCcaSampleCount = OPENTHREAD_CONFIG_CCA_FAILURE_RATE_AVERAGING_WINDOW;

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -77,6 +77,10 @@ void SubMac::Init(void)
     mEnergyScanMaxRssi = kInvalidRssiValue;
     mEnergyScanEndTime = Time{0};
 
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+    mRadioFilterEnabled = false;
+#endif
+
     mPrevKey.Clear();
     mCurrKey.Clear();
     mNextKey.Clear();
@@ -219,7 +223,18 @@ exit:
 
 Error SubMac::Receive(uint8_t aChannel)
 {
-    Error error = Get<Radio>().Receive(aChannel);
+    Error error;
+
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+    if (mRadioFilterEnabled)
+    {
+        error = Get<Radio>().Sleep();
+    }
+    else
+#endif
+    {
+        error = Get<Radio>().Receive(aChannel);
+    }
 
     if (error != kErrorNone)
     {
@@ -242,6 +257,10 @@ Error SubMac::CslSample(uint8_t aPanChannel)
     {
         mCslChannel = aPanChannel;
     }
+
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+    VerifyOrExit(!mRadioFilterEnabled, error = Get<Radio>().Sleep());
+#endif
 
     switch (mCslState)
     {
@@ -268,7 +287,7 @@ exit:
     }
     return error;
 }
-#endif
+#endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
 void SubMac::HandleReceiveDone(RxFrame *aFrame, Error aError)
 {
@@ -301,7 +320,12 @@ void SubMac::HandleReceiveDone(RxFrame *aFrame, Error aError)
     }
 #endif
 
-    mCallbacks.ReceiveDone(aFrame, aError);
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+    if (!mRadioFilterEnabled)
+#endif
+    {
+        mCallbacks.ReceiveDone(aFrame, aError);
+    }
 }
 
 Error SubMac::Send(void)
@@ -327,6 +351,14 @@ Error SubMac::Send(void)
 #endif
         break;
     }
+
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+    if (mRadioFilterEnabled)
+    {
+        mCallbacks.TransmitDone(mTransmitFrame, nullptr, mTransmitFrame.GetAckRequest() ? kErrorNoAck : kErrorNone);
+        ExitNow();
+    }
+#endif
 
     ProcessTransmitSecurity();
     mCsmaBackoffs    = 0;
@@ -606,7 +638,20 @@ exit:
 
 int8_t SubMac::GetRssi(void) const
 {
-    return Get<Radio>().GetRssi();
+    int8_t rssi;
+
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+    if (mRadioFilterEnabled)
+    {
+        rssi = kInvalidRssiValue;
+    }
+    else
+#endif
+    {
+        rssi = Get<Radio>().GetRssi();
+    }
+
+    return rssi;
 }
 
 int8_t SubMac::GetNoiseFloor(void)
@@ -636,6 +681,10 @@ Error SubMac::EnergyScan(uint8_t aScanChannel, uint16_t aScanDuration)
 #endif
         break;
     }
+
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+    VerifyOrExit(!mRadioFilterEnabled, HandleEnergyScanDone(kInvalidRssiValue));
+#endif
 
     if (RadioSupportsEnergyScan())
     {

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -548,6 +548,29 @@ public:
      */
     void SetFrameCounter(uint32_t aFrameCounter);
 
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+    /**
+     * This method enables/disables the radio filter.
+     *
+     * When radio filter is enabled, radio is put to sleep instead of receive (to ensure device does not receive any
+     * frame and/or potentially send ack). Also the frame transmission requests return immediately without sending the
+     * frame over the air (return "no ack" error if ack is requested, otherwise return success).
+     *
+     * @param[in] aFilterEnabled    TRUE to enable radio filter, FALSE to disable.
+     *
+     */
+    void SetRadioFilterEnabled(bool aFilterEnabled) { mRadioFilterEnabled = aFilterEnabled; }
+
+    /**
+     * This method indicates whether the radio filter is enabled or not.
+     *
+     * @retval TRUE   If the radio filter is enabled.
+     * @retval FALSE  If the radio filter is disabled.
+     *
+     */
+    bool IsRadioFilterEnabled(void) const { return mRadioFilterEnabled; }
+#endif
+
 private:
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     static void HandleCslTimer(Timer &aTimer);
@@ -645,13 +668,16 @@ private:
     static const char *CslStateToString(CslState aCslState);
 #endif
 
-    otRadioCaps        mRadioCaps;
-    State              mState;
-    uint8_t            mCsmaBackoffs;
-    uint8_t            mTransmitRetries;
-    ShortAddress       mShortAddress;
-    ExtAddress         mExtAddress;
-    bool               mRxOnWhenBackoff;
+    otRadioCaps  mRadioCaps;
+    State        mState;
+    uint8_t      mCsmaBackoffs;
+    uint8_t      mTransmitRetries;
+    ShortAddress mShortAddress;
+    ExtAddress   mExtAddress;
+    bool         mRxOnWhenBackoff : 1;
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+    bool mRadioFilterEnabled : 1;
+#endif
     int8_t             mEnergyScanMaxRssi;
     TimeMilli          mEnergyScanEndTime;
     TxFrame &          mTransmitFrame;

--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -179,6 +179,7 @@ EXTRA_DIST                                                         = \
     test_on_mesh_prefix.py                                           \
     test_pbbr_aloc.py                                                \
     test_ping.py                                                     \
+    test_radio_filter.py                                             \
     test_reed_address_solicit_rejected.py                            \
     test_reset.py                                                    \
     test_route_table.py                                              \
@@ -252,6 +253,7 @@ check_SCRIPTS                                                      = \
     test_on_mesh_prefix.py                                           \
     test_pbbr_aloc.py                                                \
     test_ping.py                                                     \
+    test_radio_filter.py                                             \
     test_reed_address_solicit_rejected.py                            \
     test_reset.py                                                    \
     test_route_table.py                                              \

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -839,6 +839,21 @@ class NodeImpl:
         self.send_command(cmd)
         self._expect_done()
 
+    def radiofilter_is_enabled(self) -> bool:
+        states = [r'Disabled', r'Enabled']
+        self.send_command('radiofilter')
+        return self._expect_result(states) == 'Enabled'
+
+    def radiofilter_enable(self):
+        cmd = 'radiofilter enable'
+        self.send_command(cmd)
+        self._expect_done()
+
+    def radiofilter_disable(self):
+        cmd = 'radiofilter disable'
+        self.send_command(cmd)
+        self._expect_done()
+
     def get_bbr_registration_jitter(self):
         self.send_command('bbr jitter')
         return int(self._expect_result(r'\d+'))
@@ -1999,6 +2014,18 @@ class NodeImpl:
                     'lqi': lqi,
                 })
             return networks
+
+    def scan_energy(self, timeout=10):
+        self.send_command('scan energy')
+        self.simulator.go(timeout)
+        rssi_list = []
+        for line in self._expect_command_output()[2:]:
+            _, channel, rssi, _ = line.split('|')
+            rssi_list.append({
+                'channel': int(channel.strip()),
+                'rssi': int(rssi.strip()),
+            })
+        return rssi_list
 
     def ping(self, ipaddr, num_responses=1, size=8, timeout=5, count=1, interval=1, hoplimit=64, interface=None):
         args = f'{ipaddr} {size} {count} {interval} {hoplimit} {timeout}'

--- a/tests/scripts/thread-cert/test_radio_filter.py
+++ b/tests/scripts/thread-cert/test_radio_filter.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2021, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import ipaddress
+import unittest
+
+import config
+import command
+import thread_cert
+
+# Test description:
+#
+# This test verifies the radio filter mechanism.
+#
+# Topology:
+#
+#   Leader -- Router
+#     |
+#     |
+#   Child
+#
+#
+
+LEADER = 1
+ROUTER = 2
+SED = 3
+
+WAIT_TIME = 5
+
+
+class RadioFilter(thread_cert.TestCase):
+    USE_MESSAGE_FACTORY = False
+    SUPPORT_NCP = False
+
+    TOPOLOGY = {
+        LEADER: {
+            'mode': 'rdn',
+            'allowlist': [ROUTER, SED]
+        },
+        ROUTER: {
+            'mode': 'rdn',
+            'allowlist': [LEADER]
+        },
+        SED: {
+            'is_mtd': True,
+            'mode': '-',
+            'timeout': config.DEFAULT_CHILD_TIMEOUT,
+            'allowlist': [LEADER]
+        },
+    }
+
+    def test(self):
+        leader = self.nodes[LEADER]
+        router = self.nodes[ROUTER]
+        sed = self.nodes[SED]
+
+        nodes = [leader, router, sed]
+
+        leader.start()
+        self.simulator.go(WAIT_TIME)
+        self.assertEqual(leader.get_state(), 'leader')
+
+        router.start()
+        self.simulator.go(WAIT_TIME)
+        self.assertEqual(router.get_state(), 'router')
+
+        sed.start()
+        sed.set_pollperiod(40)
+        self.simulator.go(WAIT_TIME)
+        self.assertEqual(sed.get_state(), 'child')
+
+        # Validate initial state of `radiofilter` upon start
+        for node in nodes:
+            self.assertFalse(node.radiofilter_is_enabled())
+
+        leader_mleid = leader.get_mleid()
+        router_mleid = router.get_mleid()
+        sed_mleid = sed.get_mleid()
+
+        # Validate connections by pinging from leader, SED, and router
+        self.assertTrue(leader.ping(router_mleid))
+        self.assertTrue(sed.ping(leader_mleid))
+        self.assertTrue(router.ping(leader_mleid))
+
+        # Validate behavior when `radiofilter` is enabled on router
+        router.radiofilter_enable()
+        self.assertTrue(router.radiofilter_is_enabled())
+        self.assertFalse(leader.ping(router_mleid))
+        self.assertFalse(router.ping(leader_mleid))
+
+        # Validate behavior when `radiofilter` is disabled on router
+        router.radiofilter_disable()
+        self.assertFalse(router.radiofilter_is_enabled())
+        self.assertTrue(leader.ping(router_mleid))
+        self.assertTrue(router.ping(leader_mleid))
+
+        # Validate `radiofilter` behavior on sed.
+        self.assertTrue(sed.ping(leader_mleid))
+
+        sed.radiofilter_enable()
+        self.assertTrue(sed.radiofilter_is_enabled())
+        self.assertFalse(sed.ping(leader_mleid))
+
+        self.assertTrue(sed.radiofilter_is_enabled())
+        self.assertEqual(sed.get_state(), 'detached')
+
+        sed.radiofilter_disable()
+        self.assertFalse(sed.radiofilter_is_enabled())
+
+        self.simulator.go(WAIT_TIME)
+        self.assertEqual(sed.get_state(), 'child')
+        self.assertTrue(leader.ping(sed_mleid))
+        self.assertTrue(sed.ping(leader_mleid))
+
+        # Validate energy scan when `radiofilter` is enabled
+        scan_result = leader.scan_energy()
+        self.assertTrue(len(scan_result) > 0)
+        leader.radiofilter_enable()
+        self.assertTrue(leader.radiofilter_is_enabled())
+        scan_result = leader.scan_energy()
+        self.assertTrue(len(scan_result) == 0)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit implements new radio filter mechanism in OpenThread The
radio filter is mainly intended for testing. It can be used to
temporarily block all tx/rx on the IEEE 802.15.4 radio. When radio
filter is enabled, radio is put to sleep instead of receive(to ensure
device does not receive any frame and/or potentially send ack). Also
the frame transmission requests return immediately without sending
the frame over the air (return "no ack" error if ack is requested,
otherwise return success). This commit also add CLI command
`radiofilter` for this feature. It also adds `test_radio_filter` to
validate the behavior of the new feature. This feature requires
`OPENTHREAD_CONFIG_MAC_FILTER_ENABLE`.