### PR TITLE
[mle] record child netdata versions in `HandleChildUpdateRequest()`

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2481,6 +2481,15 @@ void MleRouter::HandleChildUpdateRequest(const Message &aMessage, const Ip6::Mes
     switch (ReadLeaderData(aMessage, leaderData))
     {
     case kErrorNone:
+        if (child->IsFullNetworkData())
+        {
+            child->SetNetworkDataVersion(leaderData.GetDataVersion());
+        }
+        else
+        {
+            child->SetNetworkDataVersion(leaderData.GetStableDataVersion());
+        }
+        break;
     case kErrorNotFound:
         break;
     default:


### PR DESCRIPTION
Thread Specification allows a parent to update child network data by
sending a unicast MLE Data Response. Receiving the child's Leader Data
in a MLE Child Update Request message should serve as an
acknowledgment when the network data is received.