### PR TITLE
[thci] allow for sufficient time after a ping from OTBR

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1369,7 +1369,7 @@ class OpenThreadTHCI(object):
 
         while time.time() < start_time + timeout:
             time.sleep(0.3)
-            if TESTHARNESS_VERSION == TESTHARNESS_1_2 and not self.IsBorderRouter:
+            if not self.IsBorderRouter:
                 self._disconnect()
                 self._connect()
             try:
@@ -1493,7 +1493,7 @@ class OpenThreadTHCI(object):
         start_time = time.time()
         while time.time() < start_time + timeout:
             time.sleep(0.3)
-            if TESTHARNESS_VERSION == TESTHARNESS_1_2 and not self.IsBorderRouter:
+            if not self.IsBorderRouter:
                 self._disconnect()
                 self._connect()
             try:

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -423,7 +423,7 @@ class OpenThread_BR(OpenThreadTHCI, IThci):
         )
 
         self.bash(cmd)
-        time.sleep(1)
+        time.sleep(timeout)
 
     def multicast_Ping(self, destination, length=20):
         """send ICMPv6 echo request with a given length to a multicast destination


### PR DESCRIPTION
Some certification tests are failing because not enough delay is
applied after a Linux ping command is sent and the capture misses
the ICMP trasaction.

Also removing unneeded check for Thread 1.2 harness version when
reconnecting to the serial port after a reset.