### PR TITLE
[thci] fix issue with isPowerDown flag and reset method 

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -325,7 +325,7 @@ class OpenThreadTHCI(object):
             expected    str: the expected string
             times       int: number of tries
         """
-        print('[%s] Expecting [%s]' % (self, expected))
+        self.log('Expecting [%s]' % (expected))
 
         deadline = time.time() + timeout
         while True:
@@ -342,7 +342,7 @@ class OpenThreadTHCI(object):
 
             matched = line.endswith(expected) if endswith else line == expected
             if matched:
-                print('[%s] Expected [%s]' % (self, expected))
+                self.log('Expected [%s]' % (expected))
                 return
 
         raise Exception('failed to find expected string[%s]' % expected)
@@ -421,7 +421,8 @@ class OpenThreadTHCI(object):
 
         # init serial port
         self._connect()
-        self.__detectZephyr()
+        if not self.IsBorderRouter:
+            self.__detectZephyr()
         if TESTHARNESS_VERSION == TESTHARNESS_1_2:
             self.__discoverDeviceCapability()
         self.UIStatusMsg = self.getVersionNumber()
@@ -1786,8 +1787,7 @@ class OpenThreadTHCI(object):
             P_Prefix = '%016x' % P_Prefix
         else:
             # TestHarness 1.1 converts 2001000000000000 to "2001000000000000" (it's wrong, but not fixed yet.)
-            P_Prefix = str(P_Prefix)
-            int(P_Prefix, 16)
+            P_Prefix = '%016x' % P_Prefix
 
         prefix = self.__convertIp6PrefixStringToIp6Address(P_Prefix)
         print(prefix)
@@ -3619,7 +3619,7 @@ class OpenThread(OpenThreadTHCI, IThci):
             for _ in range(int(timeout / 0.5)):
                 time.sleep(0.5)
                 try:
-                    self.__handle = serial.Serial(self.port, 115200, timeout=0)
+                    self.__handle = serial.Serial(self.port, 115200, timeout=0, write_timeout=1)
                     self.sleep(1)
                     self.__handle.write('\r\n')
                     self.sleep(0.1)

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -56,6 +56,8 @@ assert OTBR_AGENT_SYSLOG_PATTERN.search(
     'Jun 23 05:21:22 raspberrypi otbr-agent[323]: =========[[THCI] direction=send | type=JOIN_FIN.req | len=039]==========]'
 ).group(1) == '=========[[THCI] direction=send | type=JOIN_FIN.req | len=039]==========]'
 
+logging.getLogger('paramiko').setLevel(logging.WARNING)
+
 
 class SSHHandle(object):
 
@@ -191,7 +193,7 @@ class SerialHandle:
         raise Exception('%s: failed to find end of response' % self.port)
 
     def __bashExpect(self, expected, timeout=20, endswith=False):
-        print('[%s] Expecting [%r]' % (self.port, expected))
+        self.log('Expecting [%r]' % (expected))
 
         deadline = time.time() + timeout
         while time.time() < deadline:
@@ -303,6 +305,9 @@ class OpenThread_BR(OpenThreadTHCI, IThci):
             self.__handle = None
 
     def _deviceBeforeReset(self):
+        if self.isPowerDown:
+            self.log('Powering up the device')
+            self.powerUp()
         if self.IsHost:
             self.__stopRadvdService()
             self.bash('sudo ip -6 addr del 910b::1 dev eth0 || true')
@@ -637,14 +642,14 @@ EOF"
     # Override powerDown
     @API
     def powerDown(self):
-        print('powerDown')
+        self.log('Powering down BBR')
         self.bash('sudo service otbr-agent stop')
         super(OpenThread_BR, self).powerDown()
 
     # Override powerUp
     @API
     def powerUp(self):
-        print('powerUp')
+        self.log('Powering up BBR')
         self.bash('sudo service otbr-agent start')
         super(OpenThread_BR, self).powerUp()
 


### PR DESCRIPTION
Some certification tests are failing because otbr-agent service is not started back after calling powerDown (isPowerDown flag is kept False and reset function fails on checking thread state - since the service is stopped, we can't return status)

Also minor fixes for printing logs, disabling paramiko DEBUG level