### PR TITLE
[dua] resolve assert on dua registration when `childip max 1`

### DIFF
--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -483,15 +483,18 @@ void DuaManager::PerformNextRegistration(void)
 
             if (mChildDuaMask.Get(childIndex) && !mChildDuaRegisteredMask.Get(childIndex))
             {
-                mChildIndexDuaRegistering = childIndex;
-                break;
+                child  = Get<ChildTable>().GetChildAtIndex(childIndex);
+                duaPtr = child->GetDomainUnicastAddress();
+                if (duaPtr != nullptr)
+                {
+                    mChildIndexDuaRegistering = childIndex;
+                    break;
+                }
             }
         }
 
-        child  = Get<ChildTable>().GetChildAtIndex(mChildIndexDuaRegistering);
-        duaPtr = child->GetDomainUnicastAddress();
-
-        OT_ASSERT(duaPtr != nullptr);
+        // Previous for might end without finding any suitable candidate to register.
+        VerifyOrExit(duaPtr != nullptr, error = kErrorFailed);
 
         dua = *duaPtr;
         SuccessOrExit(error = Tlv::Append<ThreadTargetTlv>(*message, dua));


### PR DESCRIPTION
This commit removes assertion when child is supposed to register DUA
address but doesn't provide one or when Router dosen't accept one.
Instead now Router moves to registration for next unregistered child.

this PR will resolve #7151 