### PR TITLE
[srp-server] free `mTxtData` buffer from `Description::Free()`

### DIFF
--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -1469,6 +1469,7 @@ exit:
 
 void Server::Service::Free(void)
 {
+    mServiceName.Free();
     Heap::Free(this);
 }
 
@@ -1619,6 +1620,7 @@ exit:
 void Server::Service::Description::Free(void)
 {
     mInstanceName.Free();
+    Heap::Free(mTxtData);
     Heap::Free(this);
 }
 


### PR DESCRIPTION
This commit fixes the potential memory leak of `mTxtData` when a
`Description` instance is freed. Also addresses similar situation
with `mServiceName` when `Service` instance is freed.