### PR TITLE
[srp-server] use `Heap::Data` to store TXT record data bytes

### DIFF
--- a/src/core/common/heap_data.cpp
+++ b/src/core/common/heap_data.cpp
@@ -54,13 +54,19 @@ exit:
 
 Error Data::SetFrom(const Message &aMessage)
 {
-    Error    error;
-    uint16_t length = aMessage.GetLength() - aMessage.GetOffset();
+    return SetFrom(aMessage, aMessage.GetOffset(), aMessage.GetLength() - aMessage.GetOffset());
+}
 
-    SuccessOrExit(error = UpdateBuffer(length));
-    VerifyOrExit(length != 0);
+Error Data::SetFrom(const Message &aMessage, uint16_t aOffset, uint16_t aLength)
+{
+    Error error;
 
-    SuccessOrAssert(aMessage.Read(aMessage.GetOffset(), mData.GetBytes(), mData.GetLength()));
+    VerifyOrExit(aOffset + aLength <= aMessage.GetLength(), error = kErrorParse);
+
+    SuccessOrExit(error = UpdateBuffer(aLength));
+    VerifyOrExit(aLength != 0);
+
+    SuccessOrAssert(aMessage.Read(aOffset, mData.GetBytes(), aLength));
 
 exit:
     return error;

--- a/src/core/common/heap_data.hpp
+++ b/src/core/common/heap_data.hpp
@@ -112,18 +112,33 @@ public:
     Error SetFrom(const uint8_t *aBuffer, uint16_t aLength);
 
     /**
-     * This method sets the `HeapData` from the content of a given message.
+     * This method sets the `Heap::Data` from the content of a given message.
      *
      * The bytes are copied from current offset in @p aMessage till the end of the message.
      *
      * @param[in] aMessage    The message to copy bytes from (starting from offset till the end of message).
-     * @param[in] aLength     The buffer length (number of bytes).
      *
      * @retval kErrorNone     Successfully set the `Heap::Data`.
      * @retval kErrorNoBufs   Failed to allocate buffer.
      *
      */
     Error SetFrom(const Message &aMessage);
+
+    /**
+     * This method sets the `Heap::Data` from the content of a given message read at a given offset up to a given
+     * length.
+     *
+     * @param[in] aMessage    The message to read and copy bytes from.
+     * @param[in] aOffset     The offset into the message to start reading the bytes from.
+     * @param[in] aLength     The number of bytes to read from message. If @p aMessage contains fewer bytes than
+     *                        requested, then `Heap::Data` is cleared and this method returns `kErrorParse`.
+     *
+     * @retval kErrorNone     Successfully set the `Heap::Data`.
+     * @retval kErrorNoBufs   Failed to allocate buffer.
+     * @retval kErrorParse    Not enough bytes in @p aMessage to read the requested @p aLength bytes.
+     *
+     */
+    Error SetFrom(const Message &aMessage, uint16_t aOffset, uint16_t aLength);
 
     /**
      * This method sets the `Heap::Data` from another one (move semantics).

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -57,6 +57,7 @@
 #include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/heap.hpp"
+#include "common/heap_data.hpp"
 #include "common/heap_string.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
@@ -276,7 +277,7 @@ public:
          * @returns A pointer to the buffer containing the TXT record data.
          *
          */
-        const uint8_t *GetTxtData(void) const { return mDescription.mTxtData; }
+        const uint8_t *GetTxtData(void) const { return mDescription.mTxtData.GetBytes(); }
 
         /**
          * This method returns the TXT record data length of the service instance.
@@ -284,7 +285,7 @@ public:
          * @return The TXT record data length (number of bytes in buffer returned from `GetTxtData()`).
          *
          */
-        uint16_t GetTxtDataLength(void) const { return mDescription.mTxtLength; }
+        uint16_t GetTxtDataLength(void) const { return mDescription.mTxtData.GetLength(); }
 
         /**
          * This method returns the host which the service instance reside on.
@@ -351,11 +352,10 @@ public:
             Description *mNext;
             Heap::String mInstanceName;
             Host &       mHost;
+            Heap::Data   mTxtData;
             uint16_t     mPriority;
             uint16_t     mWeight;
             uint16_t     mPort;
-            uint16_t     mTxtLength;
-            uint8_t *    mTxtData;
             uint32_t     mLease;    // The LEASE time in seconds.
             uint32_t     mKeyLease; // The KEY-LEASE time in seconds.
             TimeMilli    mUpdateTime;

--- a/tests/unit/test_heap_string.cpp
+++ b/tests/unit/test_heap_string.cpp
@@ -203,6 +203,7 @@ void TestHeapData(void)
     MessagePool *  messagePool;
     Message *      message;
     Heap::Data     data;
+    uint16_t       offset;
     const uint8_t *oldBuffer;
 
     static const uint8_t kData1[] = {10, 20, 3, 15, 100, 0, 60, 16};
@@ -260,6 +261,24 @@ void TestHeapData(void)
     message->SetOffset(sizeof(kData2));
     SuccessOrQuit(data.SetFrom(*message));
     VerifyData(data, kData3);
+
+    SuccessOrQuit(message->Append(kData4));
+
+    offset = 0;
+    SuccessOrQuit(data.SetFrom(*message, offset, sizeof(kData2)));
+    VerifyData(data, kData2);
+
+    offset = sizeof(kData2);
+    SuccessOrQuit(data.SetFrom(*message, offset, sizeof(kData3)));
+    VerifyData(data, kData3);
+
+    offset += sizeof(kData3);
+    SuccessOrQuit(data.SetFrom(*message, offset, sizeof(kData4)));
+    VerifyData(data, kData4);
+
+    VerifyOrQuit(data.SetFrom(*message, offset, sizeof(kData4) + 1) == kErrorParse);
+    VerifyOrQuit(data.SetFrom(*message, 0, message->GetLength() + 1) == kErrorParse);
+    VerifyOrQuit(data.SetFrom(*message, 1, message->GetLength()) == kErrorParse);
 
     printf("------------------------------------------------------------------------------------\n");
     printf("Free()\n");


### PR DESCRIPTION
This commit updates the `Srp::Server` to use the `Heap::Data` class
for storing the TXT record data bytes. This helps simplify the code.
This commit also adds a new helper method in `Heap::Data` to set
the data from a given number of bytes read from a `Message` at a
given offset. It also updates the unit test to cover the behavior
the new method.

----

This PR contains the commit from https://github.com/openthread/openthread/pull/7165.