### PR TITLE
[mlr] remove unnecessary calls to `UpdateMldReport`

### DIFF
--- a/src/posix/platform/multicast_routing.cpp
+++ b/src/posix/platform/multicast_routing.cpp
@@ -370,7 +370,6 @@ void MulticastRoutingManager::RemoveInboundMulticastForwardingCache(const Ip6::A
     {
         if (mfc.IsValid() && mfc.mIif == kMifIndexBackbone && mfc.mGroupAddr == aGroupAddr)
         {
-            UpdateMldReport(mfc.mGroupAddr, false);
             RemoveMulticastForwardingCache(mfc);
         }
     }
@@ -395,7 +394,6 @@ void MulticastRoutingManager::ExpireMulticastForwardingCache(void)
         {
             if (!UpdateMulticastRouteInfo(mfc))
             {
-                UpdateMldReport(mfc.mGroupAddr, false);
                 // The multicast route is expired
                 RemoveMulticastForwardingCache(mfc);
             }
@@ -561,7 +559,6 @@ void MulticastRoutingManager::SaveMulticastForwardingCache(const Ip6::Address & 
     }
     else
     {
-        UpdateMldReport(oldest->mGroupAddr, false);
         RemoveMulticastForwardingCache(*oldest);
         oldest->Set(aSrcAddr, aGroupAddr, aIif, aOif);
     }


### PR DESCRIPTION
This commit removes incorrect calls to  `UpdateMldReport`. 

- `UpdateMldReport(MA, true)` should be called when a MA is registered, thus in `MulticastRoutingManager::Add`.
- `UpdateMldReport(MA, false)` should be called when a MA is expired, thus in `MulticastRoutingManager::Remove`.

Note that removing an Multicast Fowarding Cache (MFC) does not mean the MA is expired. The MFCs can be freely removed even when the MA is still registered and being renewed. 