### PR TITLE
[settings] do not assert when SettingsFd is -1 in `Deinit`

### DIFF
--- a/src/posix/platform/settings.cpp
+++ b/src/posix/platform/settings.cpp
@@ -226,8 +226,11 @@ void otPlatSettingsDeinit(otInstance *aInstance)
     otPosixSecureSettingsDeinit(aInstance);
 #endif
 
-    assert(sSettingsFd != -1);
+    VerifyOrExit(sSettingsFd != -1);
     VerifyOrDie(close(sSettingsFd) == 0, OT_EXIT_ERROR_ERRNO);
+
+exit:
+    return;
 }
 
 otError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength)


### PR DESCRIPTION
We added a dry run option in #7031. So it is possible that the
settings fd is -1 when de-initialization. The assert here makes
the program crash. This PR updates it to a 'VerifyOrExit' to avoid
crashing.