### PR TITLE
[posix] add OT_TOOL_WEAK for otPlatLog

### DIFF
--- a/src/posix/platform/logging.cpp
+++ b/src/posix/platform/logging.cpp
@@ -36,6 +36,7 @@
 #include <openthread/platform/logging.h>
 
 #if OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED
+OT_TOOL_WEAK
 void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
 {
     OT_UNUSED_VARIABLE(aLogRegion);

--- a/src/posix/platform/logging.cpp
+++ b/src/posix/platform/logging.cpp
@@ -36,8 +36,7 @@
 #include <openthread/platform/logging.h>
 
 #if OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED
-OT_TOOL_WEAK
-void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
+OT_TOOL_WEAK void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
 {
     OT_UNUSED_VARIABLE(aLogRegion);
 


### PR DESCRIPTION
This PR avoids link error of duplicate `otPlatLog` symbol.