### PR TITLE
[ip6] log encapsulated IPv6 messages

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1213,6 +1213,7 @@ start:
         {
             // Remove encapsulating header and start over.
             aMessage.RemoveHeader(aMessage.GetOffset());
+            Get<MeshForwarder>().LogMessage(MeshForwarder::kMessageReceive, aMessage, nullptr, kErrorNone);
             goto start;
         }
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -157,6 +157,7 @@ class MeshForwarder : public InstanceLocator, private NonCopyable
     friend class Instance;
     friend class DataPollSender;
     friend class IndirectSender;
+    friend class Ip6::Ip6;
     friend class Mle::DiscoverScanner;
     friend class TimeTicker;
     friend class Utils::HistoryTracker;


### PR DESCRIPTION
When an encapsulated IPv6 header is found, log the message.