### PR TITLE
[mle] skip thread version check in Thread reference device

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -132,8 +132,10 @@ bool MleRouter::IsRouterEligible(void) const
     }
     if (!secPolicy.mRoutersEnabled)
     {
+#if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
         VerifyOrExit(secPolicy.mVersionThresholdForRouting + SecurityPolicy::kVersionThresholdOffsetVersion <=
                      kThreadVersion);
+#endif
     }
 #endif
 


### PR DESCRIPTION
This change introduces skip of thread version check when upgrading to
router in REFERENCE DEVICE.