### PR TITLE
[cli] add command to skip VR check when upgrading to router or leader

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (176)
+#define OPENTHREAD_API_VERSION (177)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread_ftd.h
+++ b/include/openthread/thread_ftd.h
@@ -740,6 +740,18 @@ void otThreadRegisterNeighborTableCallback(otInstance *aInstance, otNeighborTabl
 void otThreadSetCcmEnabled(otInstance *aInstance, bool aEnabled);
 
 /**
+ * This function sets whether the Security Policy TLV version-threshold for routing (VR field) is enabled.
+ *
+ * @note This API requires `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE`, and is only used by Thread Test Harness
+ *       to indicate that thread protocol version check VR should be skipped.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ * @param[in]  aEnabled   TRUE to enable Security Policy TLV version-threshold for routing, FALSE otherwise.
+ *
+ */
+void otThreadSetThreadVersionCheckEnabled(otInstance *aInstance, bool aEnabled);
+
+/**
  * This function gets the range of router IDs that are allowed to assign to nodes within the thread network.
  *
  * @note This API requires `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE`, and is only used for test purpose. All the

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -109,6 +109,7 @@ Done
 - [srp](README_SRP.md)
 - [thread](#thread-start)
 - [trel](#trel-enable)
+- [tvcheck](#tvcheck-enable)
 - [txpower](#txpower)
 - [udp](README_UDP.md)
 - [unsecureport](#unsecureport-add-port)
@@ -2630,6 +2631,32 @@ Disable TREL radio link.
 
 ```bash
 > trel disable
+Done
+```
+
+### tvcheck enable
+
+Enable thread version check when upgrading to router or leader.
+
+Note: Thread version check is enabled by default.
+
+`OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is required.
+
+```bash
+> tvcheck enable
+Done
+```
+
+### tvcheck disable
+
+Enable thread version check when upgrading to router or leader.
+
+Note: Thread version check is enabled by default.
+
+`OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is required.
+
+```bash
+> tvcheck disable
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -855,6 +855,21 @@ otError Interpreter::ProcessCcm(Arg aArgs[])
 exit:
     return error;
 }
+
+otError Interpreter::ProcessThreadVersionCheck(Arg aArgs[])
+{
+    otError error = OT_ERROR_NONE;
+    bool    enable;
+
+    VerifyOrExit(!aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_COMMAND);
+
+    SuccessOrExit(error = ParseEnableOrDisable(aArgs[0], enable));
+    otThreadSetThreadVersionCheckEnabled(GetInstancePtr(), enable);
+
+exit:
+    return error;
+}
+
 #endif
 
 otError Interpreter::ProcessChannel(Arg aArgs[])

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -328,6 +328,7 @@ private:
     otError ProcessCcaThreshold(Arg aArgs[]);
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     otError ProcessCcm(Arg aArgs[]);
+    otError ProcessThreadVersionCheck(Arg aArgs[]);
 #endif
     otError ProcessBufferInfo(Arg aArgs[]);
     otError ProcessChannel(Arg aArgs[]);
@@ -861,6 +862,9 @@ private:
         {"thread", &Interpreter::ProcessThread},
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
         {"trel", &Interpreter::ProcessTrel},
+#endif
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+        {"tvcheck", &Interpreter::ProcessThreadVersionCheck},
 #endif
         {"txpower", &Interpreter::ProcessTxPower},
         {"udp", &Interpreter::ProcessUdp},

--- a/src/core/api/thread_ftd_api.cpp
+++ b/src/core/api/thread_ftd_api.cpp
@@ -368,6 +368,11 @@ void otThreadSetCcmEnabled(otInstance *aInstance, bool aEnabled)
 {
     AsCoreType(aInstance).Get<Mle::MleRouter>().SetCcmEnabled(aEnabled);
 }
+
+void otThreadSetThreadVersionCheckEnabled(otInstance *aInstance, bool aEnabled)
+{
+    AsCoreType(aInstance).Get<Mle::MleRouter>().SetThreadVersionCheckEnabled(aEnabled);
+}
 #endif
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -72,6 +72,7 @@ MleRouter::MleRouter(Instance &aInstance)
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     , mPreferredLeaderPartitionId(0)
     , mCcmEnabled(false)
+    , mThreadVersionCheckEnabled(true)
 #endif
     , mRouterEligible(true)
     , mAddressSolicitPending(false)
@@ -132,8 +133,14 @@ bool MleRouter::IsRouterEligible(void) const
     }
     if (!secPolicy.mRoutersEnabled)
     {
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+        VerifyOrExit(!mThreadVersionCheckEnabled ||
+                     secPolicy.mVersionThresholdForRouting + SecurityPolicy::kVersionThresholdOffsetVersion <=
+                         kThreadVersion);
+#else
         VerifyOrExit(secPolicy.mVersionThresholdForRouting + SecurityPolicy::kVersionThresholdOffsetVersion <=
                      kThreadVersion);
+#endif
     }
 #endif
 

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -560,6 +560,14 @@ public:
      *
      */
     void SetCcmEnabled(bool aEnabled) { mCcmEnabled = aEnabled; }
+
+    /**
+     * This function sets whether the Security Policy TLV version-threshold for routing (VR field) is enabled.
+     *
+     * @param[in]  aEnabled  TRUE to enable Security Policy TLV version-threshold for routing, FALSE otherwise.
+     *
+     */
+    void SetThreadVersionCheckEnabled(bool aEnabled) { mThreadVersionCheckEnabled = aEnabled; }
 #endif
 
 private:
@@ -681,6 +689,7 @@ private:
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     uint32_t mPreferredLeaderPartitionId; ///< only for certification testing
     bool     mCcmEnabled : 1;
+    bool     mThreadVersionCheckEnabled : 1;
 #endif
     bool mRouterEligible : 1;
     bool mAddressSolicitPending : 1;


### PR DESCRIPTION
Thread harness requirest to create thread network without checking the
if the thread protocol version is correct. This commit adds capability
to disable this check.