### PR TITLE
[dns] use case-insensitive DNS name match

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -221,6 +221,7 @@ LOCAL_SRC_FILES                                                  := \
     src/core/coap/coap_secure.cpp                                   \
     src/core/common/appender.cpp                                    \
     src/core/common/crc16.cpp                                       \
+    src/core/common/data.cpp                                        \
     src/core/common/error.cpp                                       \
     src/core/common/heap.cpp                                        \
     src/core/common/heap_data.cpp                                   \

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -382,6 +382,7 @@ openthread_core_files = [
   "common/const_cast.hpp",
   "common/crc16.cpp",
   "common/crc16.hpp",
+  "common/data.cpp",
   "common/data.hpp",
   "common/debug.hpp",
   "common/encoding.hpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -94,6 +94,7 @@ set(COMMON_SOURCES
     coap/coap_secure.cpp
     common/appender.cpp
     common/crc16.cpp
+    common/data.cpp
     common/error.cpp
     common/heap.cpp
     common/heap_data.cpp

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -184,6 +184,7 @@ SOURCES_COMMON                                  = \
     coap/coap_secure.cpp                          \
     common/appender.cpp                           \
     common/crc16.cpp                              \
+    common/data.cpp                               \
     common/error.cpp                              \
     common/heap.cpp                               \
     common/heap_data.cpp                          \

--- a/src/core/common/data.cpp
+++ b/src/core/common/data.cpp
@@ -1,0 +1,60 @@
+/*
+ *  Copyright (c) 2021, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file implements `Data` related function
+ */
+
+#include "data.hpp"
+
+namespace ot {
+
+bool DataUtils::MatchBytes(const uint8_t *aFirstBuffer,
+                           const uint8_t *aSecondBuffer,
+                           uint16_t       aLength,
+                           ByteMatcher    aMatcher)
+{
+    bool matches = true;
+
+    if (aMatcher == nullptr)
+    {
+        matches = (memcmp(aFirstBuffer, aSecondBuffer, aLength) == 0);
+        ExitNow();
+    }
+
+    while (aLength-- != 0)
+    {
+        VerifyOrExit(aMatcher(*aFirstBuffer++, *aSecondBuffer++), matches = false);
+    }
+
+exit:
+    return matches;
+}
+
+} // namespace ot

--- a/src/core/common/data.hpp
+++ b/src/core/common/data.hpp
@@ -59,6 +59,35 @@ enum DataLengthType : uint8_t
     kWithUint16Length, ///< Use `uint16_t` for data length
 };
 
+/**
+ * This type specifies a function pointer which matches two given bytes.
+ *
+ * Such a function is used as a parameter in `Data::MatchesByteIn()` method. This can be used to relax the definition
+ * of a match when comparing data bytes, e.g., can be used for case-insensitive string comparison.
+ *
+ * @param[in] aFirst   A first byte.
+ * @param[in] aSecond  A second byte.
+ *
+ * @retval TRUE  if @p aFirst matches @p aSecond.
+ * @retval FLASE if @p aFirst does not match @p aSecond.
+ *
+ */
+typedef bool (*ByteMatcher)(uint8_t aFirst, uint8_t aSecond);
+
+/**
+ * This class implements common utility methods used by `Data` and `MutableData`.
+ *
+ */
+class DataUtils
+{
+protected:
+    DataUtils(void) = default;
+    static bool MatchBytes(const uint8_t *aFirstBuffer,
+                           const uint8_t *aSecondBuffer,
+                           uint16_t       aLength,
+                           ByteMatcher    aMatcher);
+};
+
 template <DataLengthType kDataLengthType> class MutableData;
 
 /**
@@ -76,7 +105,7 @@ template <DataLengthType kDataLengthType> class MutableData;
  *
  */
 template <DataLengthType kDataLengthType>
-class Data : public Clearable<Data<kDataLengthType>>, public Unequatable<Data<kDataLengthType>>
+class Data : public Clearable<Data<kDataLengthType>>, public Unequatable<Data<kDataLengthType>>, private DataUtils
 {
     friend class MutableData<kDataLengthType>;
 
@@ -175,6 +204,23 @@ public:
      *
      */
     bool MatchesBytesIn(const void *aBuffer) const { return memcmp(mBuffer, aBuffer, mLength) == 0; }
+
+    /**
+     * This method compares the `Data` content with the bytes from a given buffer using a given `Matcher` function.
+     *
+     * It is up to the caller to ensure that @p aBuffer has enough bytes to compare with the current data length.
+     *
+     * @param[in] aBuffer   A pointer to a buffer to compare with the data.
+     * @param[in] aMatcher  A `ByteMatcher` function to match the bytes. If `nullptr`, bytes are compared directly.
+     *
+     * @retval TRUE   The `Data` content matches the bytes in @p aBuffer.
+     * @retval FALSE  The `Data` content does not match the byes in @p aBuffer.
+     *
+     */
+    bool MatchesBytesIn(const void *aBuffer, ByteMatcher aMatcher)
+    {
+        return MatchBytes(mBuffer, static_cast<const uint8_t *>(aBuffer), mLength, aMatcher);
+    }
 
     /**
      * This method overloads operator `==` to compare the `Data` content with the content from another one.

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -578,7 +578,7 @@ Error Message::Read(uint16_t aOffset, void *aBuf, uint16_t aLength) const
     return (ReadBytes(aOffset, aBuf, aLength) == aLength) ? kErrorNone : kErrorParse;
 }
 
-bool Message::CompareBytes(uint16_t aOffset, const void *aBuf, uint16_t aLength) const
+bool Message::CompareBytes(uint16_t aOffset, const void *aBuf, uint16_t aLength, ByteMatcher aMatcher) const
 {
     uint16_t       bytesToCompare = aLength;
     const uint8_t *bufPtr         = reinterpret_cast<const uint8_t *>(aBuf);
@@ -588,7 +588,7 @@ bool Message::CompareBytes(uint16_t aOffset, const void *aBuf, uint16_t aLength)
 
     while (chunk.GetLength() > 0)
     {
-        VerifyOrExit(chunk.MatchesBytesIn(bufPtr));
+        VerifyOrExit(chunk.MatchesBytesIn(bufPtr, aMatcher));
         bufPtr += chunk.GetLength();
         bytesToCompare -= chunk.GetLength();
         GetNextChunk(aLength, chunk);
@@ -601,7 +601,8 @@ exit:
 bool Message::CompareBytes(uint16_t       aOffset,
                            const Message &aOtherMessage,
                            uint16_t       aOtherOffset,
-                           uint16_t       aLength) const
+                           uint16_t       aLength,
+                           ByteMatcher    aMatcher) const
 {
     uint16_t bytesToCompare = aLength;
     Chunk    chunk;
@@ -610,7 +611,7 @@ bool Message::CompareBytes(uint16_t       aOffset,
 
     while (chunk.GetLength() > 0)
     {
-        VerifyOrExit(aOtherMessage.CompareBytes(aOtherOffset, chunk.GetBytes(), chunk.GetLength()));
+        VerifyOrExit(aOtherMessage.CompareBytes(aOtherOffset, chunk.GetBytes(), chunk.GetLength(), aMatcher));
         aOtherOffset += chunk.GetLength();
         bytesToCompare -= chunk.GetLength();
         GetNextChunk(aLength, chunk);

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -697,12 +697,14 @@ public:
      * @param[in]  aOffset    Byte offset within the message to read from for the comparison.
      * @param[in]  aBuf       A pointer to a data buffer to compare with the bytes from message.
      * @param[in]  aLength    Number of bytes in @p aBuf.
+     * @param[in]  aMatcher   A `ByteMatcher` function pointer to match the bytes. If `nullptr` then bytes are directly
+     *                        compared.
      *
      * @returns TRUE if there are enough bytes available in @p aMessage and they match the bytes from @p aBuf,
      *          FALSE otherwise.
      *
      */
-    bool CompareBytes(uint16_t aOffset, const void *aBuf, uint16_t aLength) const;
+    bool CompareBytes(uint16_t aOffset, const void *aBuf, uint16_t aLength, ByteMatcher aMatcher = nullptr) const;
 
     /**
      * This method compares the bytes in the message at a given offset with bytes read from another message.
@@ -714,11 +716,17 @@ public:
      * @param[in]  aOtherMessage  The other message to compare with.
      * @param[in]  aOtherOffset   Byte offset within @p aOtherMessage to read from for the comparison.
      * @param[in]  aLength        Number of bytes to compare.
+     * @param[in]  aMatcher       A `ByteMatcher` function pointer to match the bytes. If `nullptr` then bytes are
+     *                            directly compared.
      *
      * @returns TRUE if there are enough bytes available in both messages and they all match. FALSE otherwise.
      *
      */
-    bool CompareBytes(uint16_t aOffset, const Message &aOtherMessage, uint16_t aOtherOffset, uint16_t aLength) const;
+    bool CompareBytes(uint16_t       aOffset,
+                      const Message &aOtherMessage,
+                      uint16_t       aOtherOffset,
+                      uint16_t       aLength,
+                      ByteMatcher    aMatcher = nullptr) const;
 
     /**
      * This method compares the bytes in the message at a given offset with an object.

--- a/src/core/common/string.cpp
+++ b/src/core/common/string.cpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *  This file implements OpenThread String class.
+ *  This file implements OpenThread String class and functions.
  */
 
 #include "string.hpp"
@@ -38,11 +38,60 @@
 
 namespace ot {
 
+namespace {
+
+// The definitions below are included in an unnamed namespace
+// to limit their scope to this translation unit (this file).
+
+enum MatchType : uint8_t
+{
+    kNoMatch,
+    kPrefixMatch,
+    kFullMatch,
+};
+
+MatchType Match(const char *aString, const char *aPrefixString, StringMatchMode aMode)
+{
+    // This is file private function that is used by other functions.
+    // It matches @p aString with @p aPrefixString using match @ aMode.
+    //
+    // If @p aString and @p aPrefixString match and have the
+    // same length `kFullMatch` is returned. If @p aString starts
+    // with @p aPrefixString but contains more characters, then
+    // `kPrefixMatch` is returned. Otherwise `kNoMatch` is returned.
+
+    MatchType match = kNoMatch;
+
+    switch (aMode)
+    {
+    case kStringExactMatch:
+        while (*aPrefixString != kNullChar)
+        {
+            VerifyOrExit(*aString++ == *aPrefixString++);
+        }
+        break;
+
+    case kStringCaseInsensitiveMatch:
+        while (*aPrefixString != kNullChar)
+        {
+            VerifyOrExit(ToLowercase(*aString++) == ToLowercase(*aPrefixString++));
+        }
+        break;
+    }
+
+    match = (*aString == kNullChar) ? kFullMatch : kPrefixMatch;
+
+exit:
+    return match;
+}
+
+} // namespace
+
 uint16_t StringLength(const char *aString, uint16_t aMaxLength)
 {
     uint16_t ret;
 
-    for (ret = 0; (ret < aMaxLength) && (aString[ret] != 0); ret++)
+    for (ret = 0; (ret < aMaxLength) && (aString[ret] != kNullChar); ret++)
     {
         // Empty loop.
     }
@@ -54,7 +103,7 @@ const char *StringFind(const char *aString, char aChar)
 {
     const char *ret = nullptr;
 
-    for (; *aString != '\0'; aString++)
+    for (; *aString != kNullChar; aString++)
     {
         if (*aString == aChar)
         {
@@ -66,7 +115,7 @@ const char *StringFind(const char *aString, char aChar)
     return ret;
 }
 
-const char *StringFind(const char *aString, const char *aSubString)
+const char *StringFind(const char *aString, const char *aSubString, StringMatchMode aMode)
 {
     const char *ret    = nullptr;
     size_t      len    = strlen(aString);
@@ -76,7 +125,7 @@ const char *StringFind(const char *aString, const char *aSubString)
 
     for (size_t index = 0; index <= static_cast<size_t>(len - subLen); index++)
     {
-        if (memcmp(&aString[index], aSubString, subLen) == 0)
+        if (Match(&aString[index], aSubString, aMode) != kNoMatch)
         {
             ExitNow(ret = &aString[index]);
         }
@@ -86,19 +135,65 @@ exit:
     return ret;
 }
 
+bool StringStartsWith(const char *aString, const char *aPrefixString, StringMatchMode aMode)
+{
+    return Match(aString, aPrefixString, aMode) != kNoMatch;
+}
+
 bool StringEndsWith(const char *aString, char aChar)
 {
     size_t len = strlen(aString);
 
-    return len > 0 && aString[len - 1] == aChar;
+    return (len > 0) && (aString[len - 1] == aChar);
 }
 
-bool StringEndsWith(const char *aString, const char *aSubString)
+bool StringEndsWith(const char *aString, const char *aSubString, StringMatchMode aMode)
 {
     size_t len    = strlen(aString);
     size_t subLen = strlen(aSubString);
 
-    return (subLen > 0) && (len >= subLen) && (memcmp(aSubString, &aString[len - subLen], subLen) == 0);
+    return (subLen > 0) && (len >= subLen) && (Match(&aString[len - subLen], aSubString, aMode) != kNoMatch);
+}
+
+bool StringMatch(const char *aFirstString, const char *aSecondString, StringMatchMode aMode)
+{
+    return Match(aFirstString, aSecondString, aMode) == kFullMatch;
+}
+
+void StringConvertToLowercase(char *aString)
+{
+    for (; *aString != kNullChar; aString++)
+    {
+        *aString = ToLowercase(*aString);
+    }
+}
+
+void StringConvertToUppercase(char *aString)
+{
+    for (; *aString != kNullChar; aString++)
+    {
+        *aString = ToUppercase(*aString);
+    }
+}
+
+char ToLowercase(char aChar)
+{
+    if ((aChar >= 'A') && (aChar <= 'Z'))
+    {
+        aChar += 'a' - 'A';
+    }
+
+    return aChar;
+}
+
+char ToUppercase(char aChar)
+{
+    if ((aChar >= 'a') && (aChar <= 'z'))
+    {
+        aChar -= 'a' - 'A';
+    }
+
+    return aChar;
 }
 
 StringWriter::StringWriter(char *aBuffer, uint16_t aSize)
@@ -106,12 +201,12 @@ StringWriter::StringWriter(char *aBuffer, uint16_t aSize)
     , mLength(0)
     , mSize(aSize)
 {
-    mBuffer[0] = '\0';
+    mBuffer[0] = kNullChar;
 }
 
 StringWriter &StringWriter::Clear(void)
 {
-    mBuffer[0] = '\0';
+    mBuffer[0] = kNullChar;
     mLength    = 0;
     return *this;
 }
@@ -137,7 +232,7 @@ StringWriter &StringWriter::AppendVarArgs(const char *aFormat, va_list aArgs)
 
     if (IsTruncated())
     {
-        mBuffer[mSize - 1] = '\0';
+        mBuffer[mSize - 1] = kNullChar;
     }
 
     return *this;

--- a/src/core/common/string.hpp
+++ b/src/core/common/string.hpp
@@ -56,6 +56,18 @@ namespace ot {
  */
 
 /**
+ * This enumeration represents comparison mode when matching strings.
+ *
+ */
+enum StringMatchMode : uint8_t
+{
+    kStringExactMatch,           ///< Exact match of characters.
+    kStringCaseInsensitiveMatch, ///< Case insensitive match (uppercase and lowercase characters are treated as equal).
+};
+
+static constexpr char kNullChar = '\0'; ///< null character.
+
+/**
  * This function returns the number of characters that precede the terminating nullptr character.
  *
  * @param[in] aString      A pointer to the string.
@@ -83,11 +95,26 @@ const char *StringFind(const char *aString, char aChar);
  *
  * @param[in] aString     A pointer to the string.
  * @param[in] aSubString  A sub-string to search for.
+ * @param[in] aMode       The string comparison mode, exact match or case insensitive match.
  *
- * @returns The pointer to first occurrence of the @p aSubString in @p aString, or nullptr if cannot be found.
+ * @returns The pointer to first match of the @p aSubString in @p aString (using comparison @p aMode), or nullptr if
+ *          cannot be found.
  *
  */
-const char *StringFind(const char *aString, const char *aSubString);
+const char *StringFind(const char *aString, const char *aSubString, StringMatchMode aMode = kStringExactMatch);
+
+/**
+ * This function checks whether a null-terminated string starts with a given prefix string.
+ *
+ * @param[in] aString         A pointer to the string.
+ * @param[in] aPrefixString   A prefix string.
+ * @param[in] aMode           The string comparison mode, exact match or case insensitive match.
+ *
+ * @retval TRUE   If @p aString starts with @p aPrefixString.
+ * @retval FALSE  If @p aString does not start with @p aPrefixString.
+ *
+ */
+bool StringStartsWith(const char *aString, const char *aPrefixString, StringMatchMode aMode = kStringExactMatch);
 
 /**
  * This function checks whether a null-terminated string ends with a given character.
@@ -105,13 +132,67 @@ bool StringEndsWith(const char *aString, char aChar);
  * This function checks whether a null-terminated string ends with a given sub-string.
  *
  * @param[in] aString      A pointer to the string.
- * @param[in] aSubString   A sun-string to check against.
+ * @param[in] aSubString   A sub-string to check against.
+ * @param[in] aMode        The string comparison mode, exact match or case insensitive match.
  *
  * @retval TRUE   If @p aString ends with sub-string @p aSubString.
  * @retval FALSE  If @p aString does not end with sub-string @p aSubString.
  *
  */
-bool StringEndsWith(const char *aString, const char *aSubString);
+bool StringEndsWith(const char *aString, const char *aSubString, StringMatchMode aMode = kStringExactMatch);
+
+/**
+ * This method checks whether or not two null-terminated strings match.
+ *
+ * @param[in] aFirstString   A pointer to the first string.
+ * @param[in] aSecondString  A pointer to the second string.
+ * @param[in] aMode          The string comparison mode, exact match or case insensitive match.
+ *
+ * @retval TRUE   If @p aFirstString matches @p aSecondString using match mode @p aMode.
+ * @retval FALSE  If @p aFirstString does not match @p aSecondString using match mode @p aMode.
+ *
+ */
+bool StringMatch(const char *aFirstString, const char *aSecondString, StringMatchMode aMode = kStringExactMatch);
+
+/**
+ * This function converts all uppercase letter characters in a given string to lowercase.
+ *
+ * @param[inout] aString   A pointer to the string to convert.
+ *
+ */
+void StringConvertToLowercase(char *aString);
+
+/**
+ * This function converts all lowercase letter characters in a given string to uppercase.
+ *
+ * @param[inout] aString   A pointer to the string to convert.
+ *
+ */
+void StringConvertToUppercase(char *aString);
+
+/**
+ * This function converts an uppercase letter character to lowercase.
+ *
+ * If @p aChar is uppercase letter it is converted lowercase. Otherwise, it remains unchanged.
+ *
+ * @param[in] aChar   The character to convert
+ *
+ * @returns The character converted to lowercase.
+ *
+ */
+char ToLowercase(char aChar);
+
+/**
+ * This function converts a lowercase letter character to uppercase.
+ *
+ * If @p aChar is lowercase letter it is converted uppercase. Otherwise, it remains unchanged.
+ *
+ * @param[in] aChar   The character to convert
+ *
+ * @returns The character converted to uppercase.
+ *
+ */
+char ToUppercase(char aChar);
 
 /**
  * This class implements writing to a string buffer.
@@ -198,6 +279,18 @@ public:
      *
      */
     StringWriter &AppendHexBytes(const uint8_t *aBytes, uint16_t aLength);
+
+    /**
+     * This method converts all uppercase letter characters in the string to lowercase.
+     *
+     */
+    void ConvertToLowercase(void) { StringConvertToLowercase(mBuffer); }
+
+    /**
+     * This method converts all lowercase letter characters in the string to uppercase.
+     *
+     */
+    void ConvertToUppercase(void) { StringConvertToUppercase(mBuffer); }
 
 private:
     char *         mBuffer;

--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -872,7 +872,7 @@ public:
      * This static method compares a single name label from a message with a given label string.
      *
      * This method can be used to compare labels one by one. It checks whether the label read from @p aMessage matches
-     * @p aLabel string.
+     * @p aLabel string (case-insensitive comparison).
      *
      * Unlike `CompareName()` which requires the labels in the the name string to contain no dot '.' character, this
      * method allows @p aLabel to include any character.
@@ -883,7 +883,7 @@ public:
      *                                On exit and only when label is successfully read and does match @p aLabel,
      *                                @p aOffset is updated to point to the start of the next label.
      * @param[in]    aLabel           A pointer to a null terminated string containing the label to compare with.
-
+     *
      * @retval kErrorNone          The label from @p aMessage matches @p aLabel. @p aOffset is updated.
      * @retval kErrorNotFound      The label from @p aMessage does not match @p aLabel (note that @p aOffset is not
      *                             updated in this case).
@@ -895,9 +895,10 @@ public:
     /**
      * This static method parses and compares a full name from a message with a given name.
      *
-     * This method checks whether the encoded name in a message matches a given name string. It checks the name in
-     * the message in place and handles compressed names. If the name read from the message does not match @p aName, it
-     * returns `kErrorNotFound`. `kErrorNone` indicates that the name matches @p aName.
+     * This method checks whether the encoded name in a message matches a given name string (using case-insensitive
+     * comparison). It checks the name in the message in place and handles compressed names. If the name read from the
+     * message does not match @p aName, it returns `kErrorNotFound`. `kErrorNone` indicates that the name matches
+     * @p aName.
      *
      * The @p aName must follow  "<label1>.<label2>.<label3>", i.e., a sequence of labels separated by dot '.' char.
      * E.g., "example.com", "example.com." (same as previous one), "local.", "default.service.arpa", "." or "" (root).
@@ -922,9 +923,10 @@ public:
     /**
      * This static method parses and compares a full name from a message with a name from another message.
      *
-     * This method checks whether the encoded name in @p aMessage matches the name from @p aMessage2. It compares the
-     * names in both messages in place and handles compressed names. Note that this method works correctly even when
-     * the same message instance is used for both @p aMessage and @p aMessage2 (e.g., at different offsets).
+     * This method checks whether the encoded name in @p aMessage matches the name from @p aMessage2 (using
+     * case-insensitive comparison). It compares the names in both messages in place and handles compressed names. Note
+     * that this method works correctly even when the same message instance is used for both @p aMessage and
+     * @p aMessage2 (e.g., at different offsets).
      *
      * Only the name in @p aMessage is fully parsed and checked for parse errors. This method assumes that the name in
      * @p aMessage2 was previously parsed and validated before calling this method (if there is a parse error in
@@ -952,7 +954,8 @@ public:
     static Error CompareName(const Message &aMessage, uint16_t &aOffset, const Message &aMessage2, uint16_t aOffset2);
 
     /**
-     * This static method parses and compares a full name from a message with a given name.
+     * This static method parses and compares a full name from a message with a given name (using case-insensitive
+     * comparison).
      *
      * If @p aName is empty (not specified), then any name in @p aMessage is considered a match to it.
      *
@@ -985,8 +988,6 @@ public:
     static bool IsSubDomainOf(const char *aName, const char *aDomain);
 
 private:
-    static constexpr char kNullChar = '\0';
-
     // The first 2 bits of the encoded label specifies label type.
     //
     // - Value 00 indicates normal text label (lower 6-bits indicates the label length).
@@ -1001,6 +1002,8 @@ private:
 
     static constexpr uint16_t kPointerLabelTypeUint16 = 0xc000; // Pointer label type mask (first 2 bits).
     static constexpr uint16_t kPointerLabelOffsetMask = 0x3fff; // Mask for offset in a pointer label (lower 14 bits).
+
+    static constexpr bool kIsSingleLabel = true; // Used in `LabelIterator::CompareLable()`.
 
     struct LabelIterator
     {
@@ -1019,6 +1022,8 @@ private:
         bool  CompareLabel(const char *&aName, bool aIsSingleLabel) const;
         bool  CompareLabel(const LabelIterator &aOtherIterator) const;
         Error AppendLabel(Message &aMessage) const;
+
+        static bool CaseInsensitiveMatch(uint8_t aFirst, uint8_t aSecond);
 
         const Message &mMessage;          // Message to read labels from.
         uint16_t       mLabelStartOffset; // Offset in `mMessage` to the first char of current label text.
@@ -1182,7 +1187,6 @@ private:
 
     static constexpr uint8_t kMaxKeyValueEncodedSize = 255;
     static constexpr char    kKeyValueSeparator      = '=';
-    static constexpr char    kNullChar               = '\0';
 };
 
 /**

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -392,8 +392,8 @@ private:
     void        HandleTimer(void);
     void        ResetTimer(void);
 
-    static const char kDnssdProtocolUdp[4];
-    static const char kDnssdProtocolTcp[4];
+    static const char kDnssdProtocolUdp[];
+    static const char kDnssdProtocolTcp[];
     static const char kDnssdSubTypeLabel[];
     static const char kDefaultDomainName[];
     Ip6::Udp::Socket  mSocket;

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -325,10 +325,7 @@ public:
          * @retval  FALSE  If the service does not match the service instance name.
          *
          */
-        bool MatchesInstanceName(const char *aInstanceName) const
-        {
-            return (mDescription->mInstanceName == aInstanceName);
-        }
+        bool MatchesInstanceName(const char *aInstanceName) const;
 
         /**
          * This method tells whether this service matches a given service name.
@@ -339,7 +336,7 @@ public:
          * @retval  FALSE  If the service does not match the full service name.
          *
          */
-        bool MatchesServiceName(const char *aServiceName) const { return (mServiceName == aServiceName); }
+        bool MatchesServiceName(const char *aServiceName) const;
 
     private:
         struct Description : public LinkedListEntry<Description>,
@@ -348,7 +345,7 @@ public:
         {
             Error       Init(const char *aInstanceName, Host &aHost);
             const char *GetInstanceName(void) const { return mInstanceName.AsCString(); }
-            bool        Matches(const char *aInstanceName) const { return (mInstanceName == aInstanceName); }
+            bool        Matches(const char *aInstanceName) const;
             void        ClearResources(void);
             void        TakeResourcesFrom(Description &aDescription);
             Error       SetTxtDataFromMessage(const Message &aMessage, uint16_t aOffset, uint16_t aLength);
@@ -510,7 +507,7 @@ public:
          * @returns  A boolean that indicates whether the host matches the given name.
          *
          */
-        bool Matches(const char *aFullName) const { return (mFullName == aFullName); }
+        bool Matches(const char *aFullName) const;
 
     private:
         static constexpr uint16_t kMaxAddresses = OPENTHREAD_CONFIG_SRP_SERVER_MAX_ADDRESSES_NUM;

--- a/tests/unit/test_string.cpp
+++ b/tests/unit/test_string.cpp
@@ -49,7 +49,7 @@ template <uint16_t kSize> void PrintString(const char *aName, const String<kSize
 void TestStringWriter(void)
 {
     String<kStringSize> str;
-    constexpr char      kLongString[] = "abcdefghijklmnopqratuvwxyzabcdefghijklmnopqratuvwxyz";
+    const char          kLongString[] = "abcdefghijklmnopqratuvwxyzabcdefghijklmnopqratuvwxyz";
 
     printf("\nTest 1: StringWriter constructor\n");
 
@@ -147,12 +147,12 @@ void TestUtf8(void)
 void TestStringFind(void)
 {
     char emptyString[1] = {'\0'};
-    char testString[]   = "foo.bar.bar\\.";
+    char testString[]   = "Foo.bar.bar\\.";
     char testString2[]  = "abcabcabcdabc";
 
     printf("\nTest 6: StringFind() function\n");
 
-    VerifyOrQuit(StringFind(testString, 'f') == testString);
+    VerifyOrQuit(StringFind(testString, 'F') == testString);
     VerifyOrQuit(StringFind(testString, 'o') == &testString[1]);
     VerifyOrQuit(StringFind(testString, '.') == &testString[3]);
     VerifyOrQuit(StringFind(testString, 'r') == &testString[6]);
@@ -160,17 +160,19 @@ void TestStringFind(void)
     VerifyOrQuit(StringFind(testString, 'x') == nullptr);
     VerifyOrQuit(StringFind(testString, ',') == nullptr);
 
-    VerifyOrQuit(StringFind(emptyString, 'f') == nullptr);
+    VerifyOrQuit(StringFind(emptyString, 'F') == nullptr);
     VerifyOrQuit(StringFind(emptyString, '.') == nullptr);
 
-    VerifyOrQuit(StringFind(testString, "foo") == &testString[0]);
+    VerifyOrQuit(StringFind(testString, "Foo") == &testString[0]);
     VerifyOrQuit(StringFind(testString, "oo") == &testString[1]);
     VerifyOrQuit(StringFind(testString, "bar") == &testString[4]);
     VerifyOrQuit(StringFind(testString, "bar\\") == &testString[8]);
     VerifyOrQuit(StringFind(testString, "\\.") == &testString[11]);
     VerifyOrQuit(StringFind(testString, testString) == testString);
-    VerifyOrQuit(StringFind(testString, "fooo") == nullptr);
-    VerifyOrQuit(StringFind(testString, "far") == nullptr);
+    VerifyOrQuit(StringFind(testString, "Fooo") == nullptr);
+    VerifyOrQuit(StringFind(testString, "Far") == nullptr);
+    VerifyOrQuit(StringFind(testString, "FOO") == nullptr);
+    VerifyOrQuit(StringFind(testString, "BAR") == nullptr);
     VerifyOrQuit(StringFind(testString, "bar\\..") == nullptr);
     VerifyOrQuit(StringFind(testString, "") == &testString[0]);
 
@@ -182,26 +184,127 @@ void TestStringFind(void)
     VerifyOrQuit(StringFind(testString2, "abcabc") == &testString2[0]);
     VerifyOrQuit(StringFind(testString2, "abcabcd") == &testString2[3]);
 
+    VerifyOrQuit(StringFind(testString, "FOO", kStringCaseInsensitiveMatch) == &testString[0]);
+    VerifyOrQuit(StringFind(testString, "OO", kStringCaseInsensitiveMatch) == &testString[1]);
+    VerifyOrQuit(StringFind(testString, "BAR", kStringCaseInsensitiveMatch) == &testString[4]);
+    VerifyOrQuit(StringFind(testString, "BAR\\", kStringCaseInsensitiveMatch) == &testString[8]);
+    VerifyOrQuit(StringFind(testString, "\\.", kStringCaseInsensitiveMatch) == &testString[11]);
+    VerifyOrQuit(StringFind(testString, testString) == testString);
+    VerifyOrQuit(StringFind(testString, "FOOO", kStringCaseInsensitiveMatch) == nullptr);
+    VerifyOrQuit(StringFind(testString, "FAR", kStringCaseInsensitiveMatch) == nullptr);
+    VerifyOrQuit(StringFind(testString, "BAR\\..", kStringCaseInsensitiveMatch) == nullptr);
+    VerifyOrQuit(StringFind(testString, "", kStringCaseInsensitiveMatch) == &testString[0]);
+
+    VerifyOrQuit(StringFind(emptyString, "FOO", kStringCaseInsensitiveMatch) == nullptr);
+    VerifyOrQuit(StringFind(emptyString, "BAR", kStringCaseInsensitiveMatch) == nullptr);
+    VerifyOrQuit(StringFind(emptyString, "", kStringCaseInsensitiveMatch) == &emptyString[0]);
+
+    // Verify when sub-string has repeated patterns
+    VerifyOrQuit(StringFind(testString2, "ABCABC", kStringCaseInsensitiveMatch) == &testString2[0]);
+    VerifyOrQuit(StringFind(testString2, "ABCABCD", kStringCaseInsensitiveMatch) == &testString2[3]);
+
+    printf(" -- PASS\n");
+}
+
+void TestStringStartsWith(void)
+{
+    printf("\nTest 7: StringStartsWith() function\n");
+
+    VerifyOrQuit(StringStartsWith("FooBar", "Foo"));
+    VerifyOrQuit(!StringStartsWith("FooBar", "Ba"));
+    VerifyOrQuit(StringStartsWith("FooBar", "FooBar"));
+    VerifyOrQuit(!StringStartsWith("FooBar", "FooBarr"));
+    VerifyOrQuit(!StringStartsWith("FooBar", "foo"));
+    VerifyOrQuit(!StringStartsWith("FooBar", "FoO"));
+
+    VerifyOrQuit(!StringStartsWith("", "foo"));
+
+    VerifyOrQuit(StringStartsWith("FooBar", "FOO", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(!StringStartsWith("FooBar", "BA", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(StringStartsWith("FooBar", "FOOBAR", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(!StringStartsWith("FooBar", "FooBarr", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(StringStartsWith("FooBar", "foO", kStringCaseInsensitiveMatch));
+
+    VerifyOrQuit(!StringStartsWith("", "foo", kStringCaseInsensitiveMatch));
+
     printf(" -- PASS\n");
 }
 
 void TestStringEndsWith(void)
 {
-    printf("\nTest 7: StringEndsWith() function\n");
+    printf("\nTest 8: StringEndsWith() function\n");
 
-    VerifyOrQuit(StringEndsWith("foobar", 'r'));
-    VerifyOrQuit(!StringEndsWith("foobar", 'a'));
-    VerifyOrQuit(!StringEndsWith("foobar", '\0'));
+    VerifyOrQuit(StringEndsWith("FooBar", 'r'));
+    VerifyOrQuit(!StringEndsWith("FooBar", 'a'));
+    VerifyOrQuit(!StringEndsWith("FooBar", '\0'));
     VerifyOrQuit(StringEndsWith("a", 'a'));
     VerifyOrQuit(!StringEndsWith("a", 'b'));
 
-    VerifyOrQuit(StringEndsWith("foobar", "bar"));
-    VerifyOrQuit(!StringEndsWith("foobar", "ba"));
-    VerifyOrQuit(StringEndsWith("foobar", "foobar"));
-    VerifyOrQuit(!StringEndsWith("foobar", "foobarr"));
+    VerifyOrQuit(StringEndsWith("FooBar", "Bar"));
+    VerifyOrQuit(!StringEndsWith("FooBar", "Ba"));
+    VerifyOrQuit(StringEndsWith("FooBar", "FooBar"));
+    VerifyOrQuit(!StringEndsWith("FooBar", "FooBarr"));
 
     VerifyOrQuit(!StringEndsWith("", 'a'));
     VerifyOrQuit(!StringEndsWith("", "foo"));
+
+    VerifyOrQuit(StringEndsWith("FooBar", "baR", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(!StringEndsWith("FooBar", "bA", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(StringEndsWith("FooBar", "fOOBar", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(!StringEndsWith("FooBar", "Foobarr", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(!StringEndsWith("", "Foo", kStringCaseInsensitiveMatch));
+
+    printf(" -- PASS\n");
+}
+
+void TestStringMatch(void)
+{
+    printf("\nTest 9: StringMatch() function\n");
+
+    VerifyOrQuit(StringMatch("", ""));
+    VerifyOrQuit(StringMatch("FooBar", "FooBar"));
+    VerifyOrQuit(!StringMatch("FooBar", "FooBa"));
+    VerifyOrQuit(!StringMatch("FooBa", "FooBar"));
+    VerifyOrQuit(!StringMatch("FooBa", "FooBar"));
+    VerifyOrQuit(!StringMatch("FooBar", "fooBar"));
+    VerifyOrQuit(!StringMatch("FooBaR", "FooBar"));
+
+    VerifyOrQuit(StringMatch("", "", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(StringMatch("FooBar", "fOObAR", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(!StringMatch("FooBar", "fOObA", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(!StringMatch("FooBa", "FooBar", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(!StringMatch("FooBa", "FooBar", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(!StringMatch("Fooba", "fooBar", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(StringMatch("FooBar", "FOOBAR", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(StringMatch("FoobaR", "FooBar", kStringCaseInsensitiveMatch));
+    VerifyOrQuit(StringMatch("FOOBAR", "foobar", kStringCaseInsensitiveMatch));
+
+    printf(" -- PASS\n");
+}
+
+void TestStringToLowercase(void)
+{
+    const uint16_t kMaxSize = 100;
+
+    const char kTestString[]      = "!@#$%^&*()_+=[].,<>//;:\"'`~ \t\r\n";
+    const char kUppercaseString[] = "ABCDEFGHIJKLMNOPQRATUVWXYZABCDEFGHIJKLMNOPQRATUVWXYZ";
+    const char kLowercaseString[] = "abcdefghijklmnopqratuvwxyzabcdefghijklmnopqratuvwxyz";
+
+    char string[kMaxSize];
+
+    printf("\nTest 10: StringConvertToLowercase() function\n");
+
+    memcpy(string, kTestString, sizeof(kTestString));
+    StringConvertToLowercase(string);
+    VerifyOrQuit(memcmp(string, kTestString, sizeof(kTestString)) == 0);
+    StringConvertToUppercase(string);
+    VerifyOrQuit(memcmp(string, kTestString, sizeof(kTestString)) == 0);
+
+    memcpy(string, kUppercaseString, sizeof(kUppercaseString));
+    StringConvertToLowercase(string);
+    VerifyOrQuit(memcmp(string, kLowercaseString, sizeof(kLowercaseString)) == 0);
+    StringConvertToUppercase(string);
+    VerifyOrQuit(memcmp(string, kUppercaseString, sizeof(kUppercaseString)) == 0);
 
     printf(" -- PASS\n");
 }
@@ -214,7 +317,10 @@ int main(void)
     ot::TestStringLength();
     ot::TestUtf8();
     ot::TestStringFind();
+    ot::TestStringStartsWith();
     ot::TestStringEndsWith();
+    ot::TestStringMatch();
+    ot::TestStringToLowercase();
     printf("\nAll tests passed.\n");
     return 0;
 }


### PR DESCRIPTION

This PR contains the following related commits:

**[string] new functions for case-insensitive comparison**

This commit adds new string helper functions to convert between
lowercase and uppercase letters. It also adds new function
`StringStartsWith()` which determines whether the string starts with
a given prefix string and `StringMatch()` which compares and matches
two strings.

This commit also adds a new mechanism in all string helper functions
allowing the caller to specify the match mode to be used when
comparing strings: Either an exact match of characters, or a
case-insensitive match where uppercase and lowercase characters are
treated as equal.

This commit also updates `test_string` unit test to validate the new
functions and behaviors.

----

**[dns] change `Dns::Name::CompareName/Label()` to be case-insensitive**

This commit changes the `Dns::Name::CompareName/Label()` methods to
perform case-insensitive string comparison. This is realized by
adding a new flavor of `Data::MatchesBytesIn()` which accepts a
`ByteMatcher` function pointer. This allows the caller to relax the
definition of a match and how the bytes are compared. `Message` class
methods that compare bytes are also updated to allow `ByteMatcher` as
an input parameter. This commit also updates the unit test `test_dns`
to cover the new method and behaviors.

----

**[srp-server] use case-insensitive DNS name match**

This commit updates `Srp::Server` use case-insensitive DNS name
match for domain name, host, service, or service instance names.


-----

**[dnssd-server] use case-insensitive DNS name match**

This commit updates `Dns::ServiceDiscovery::Server` to use
case-insensitive string match when comparing DNS names. It also
updates `test_dnssd.py` to use mixed case names when browsing for or
resolving services. This validates the case-insensitive treatment
of names by SRP client and server and DNS-SD server (resolver) and
DNS client.