### PR TITLE
[tcp] add rewrite of TCPlp's interface code to support OpenThread's TCP API

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -154,6 +154,7 @@ LOCAL_SHARED_LIBRARIES := libcutils
 
 LOCAL_CFLAGS                                             += \
     -DOPENTHREAD_ENABLE_ANDROID_NDK=1                       \
+    -Wno-sign-compare                                       \
     $(NULL)
 endif
 
@@ -473,6 +474,18 @@ LOCAL_SRC_FILES                                                  := \
     third_party/mbedtls/repo/library/x509write_crt.c                \
     third_party/mbedtls/repo/library/x509write_csr.c                \
     third_party/mbedtls/repo/library/xtea.c                         \
+    third_party/tcplp/bsdtcp/tcp_usrreq.c                           \
+    third_party/tcplp/bsdtcp/tcp_subr.c                             \
+    third_party/tcplp/bsdtcp/tcp_output.c                           \
+    third_party/tcplp/bsdtcp/cc/cc_newreno.c                        \
+    third_party/tcplp/bsdtcp/tcp_reass.c                            \
+    third_party/tcplp/bsdtcp/tcp_timewait.c                         \
+    third_party/tcplp/bsdtcp/tcp_sack.c                             \
+    third_party/tcplp/bsdtcp/tcp_input.c                            \
+    third_party/tcplp/bsdtcp/tcp_timer.c                            \
+    third_party/tcplp/lib/bitmap.c                                  \
+    third_party/tcplp/lib/cbuf.c                                    \
+    third_party/tcplp/lib/lbuf.c                                    \
     $(OPENTHREAD_PROJECT_SRC_FILES)                                 \
     $(NULL)
 

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (187)
+#define OPENTHREAD_API_VERSION (188)
 
 /**
  * @addtogroup api-instance

--- a/src/core/api/tcp_api.cpp
+++ b/src/core/api/tcp_api.cpp
@@ -87,7 +87,7 @@ otError otTcpSendByExtension(otTcpEndpoint *aEndpoint, size_t aNumBytes, uint32_
     return AsCoreType(aEndpoint).SendByExtension(aNumBytes, aFlags);
 }
 
-otError otTcpReceiveByReference(const otTcpEndpoint *aEndpoint, const otLinkedBuffer **aBuffer)
+otError otTcpReceiveByReference(otTcpEndpoint *aEndpoint, const otLinkedBuffer **aBuffer)
 {
     return AsCoreType(aEndpoint).ReceiveByReference(*aBuffer);
 }

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -42,10 +42,18 @@
 #include "common/error.hpp"
 #include "common/instance.hpp"
 #include "common/logging.hpp"
+#include "common/random.hpp"
+#include "net/checksum.hpp"
 #include "net/ip6.hpp"
+#include "net/netif.hpp"
+
+#include "../../third_party/tcplp/tcplp.h"
 
 namespace ot {
 namespace Ip6 {
+
+using ot::Encoding::BigEndian::HostSwap16;
+using ot::Encoding::BigEndian::HostSwap32;
 
 Tcp::Tcp(Instance &aInstance)
     : InstanceLocator(aInstance)
@@ -57,7 +65,8 @@ Tcp::Tcp(Instance &aInstance)
 
 Error Tcp::Endpoint::Initialize(Instance &aInstance, otTcpEndpointInitializeArgs &aArgs)
 {
-    Error error;
+    Error         error;
+    struct tcpcb &tp = GetTcb();
 
     SuccessOrExit(error = aInstance.Get<Tcp>().mEndpoints.Add(*this));
 
@@ -68,9 +77,30 @@ Error Tcp::Endpoint::Initialize(Instance &aInstance, otTcpEndpointInitializeArgs
     mReceiveAvailableCallback = aArgs.mReceiveAvailableCallback;
     mDisconnectedCallback     = aArgs.mDisconnectedCallback;
 
-    mInstance = &aInstance;
-
     memset(mTimers, 0x00, sizeof(mTimers));
+    memset(&mSockAddr, 0x00, sizeof(mSockAddr));
+    memset(&tp, 0x00, sizeof(tp));
+
+    /*
+     * Initialize buffers --- formerly in initialize_tcb.
+     */
+    {
+        uint8_t *recvbuf    = static_cast<uint8_t *>(aArgs.mReceiveBuffer);
+        size_t   recvbuflen = aArgs.mReceiveBufferSize - ((aArgs.mReceiveBufferSize + 8) / 9);
+        uint8_t *reassbmp   = recvbuf + recvbuflen;
+
+        lbuf_init(&tp.sendbuf);
+        cbuf_init(&tp.recvbuf, recvbuf, recvbuflen);
+        tp.reassbmp = reassbmp;
+        bmp_init(tp.reassbmp, BITS_TO_BYTES(recvbuflen));
+    }
+
+    tp.accepted_from = nullptr;
+    initialize_tcb(&tp);
+
+    /* Note that we do not need to zero-initialize mReceiveLinks. */
+
+    tp.instance = &aInstance;
 
 exit:
     return error;
@@ -78,57 +108,100 @@ exit:
 
 Instance &Tcp::Endpoint::GetInstance(void)
 {
-    return AsCoreType(mInstance);
+    struct tcpcb &tp = GetTcb();
+
+    return AsCoreType(tp.instance);
 }
 
 const SockAddr &Tcp::Endpoint::GetLocalAddress(void) const
 {
+    const struct tcpcb &tp = GetTcb();
+
     static otSockAddr temp;
+
+    memcpy(&temp.mAddress, &tp.laddr, sizeof(temp.mAddress));
+    temp.mPort = HostSwap16(tp.lport);
+
     return AsCoreType(&temp);
 }
 
 const SockAddr &Tcp::Endpoint::GetPeerAddress(void) const
 {
+    const struct tcpcb &tp = GetTcb();
+
     static otSockAddr temp;
+
+    memcpy(&temp.mAddress, &tp.faddr, sizeof(temp.mAddress));
+    temp.mPort = HostSwap16(tp.fport);
+
     return AsCoreType(&temp);
 }
 
 Error Tcp::Endpoint::Bind(const SockAddr &aSockName)
 {
-    OT_UNUSED_VARIABLE(aSockName);
+    Error         error;
+    struct tcpcb &tp = GetTcb();
 
-    return kErrorNotImplemented;
+    VerifyOrExit(!AsCoreType(&aSockName.mAddress).IsUnspecified(), error = kErrorInvalidArgs);
+    VerifyOrExit(GetInstance().Get<Tcp>().CanBind(aSockName), error = kErrorInvalidState);
+
+    memcpy(&tp.laddr, &aSockName.mAddress, sizeof(tp.laddr));
+    tp.lport = HostSwap16(aSockName.mPort);
+    error    = kErrorNone;
+
+exit:
+    return error;
 }
 
 Error Tcp::Endpoint::Connect(const SockAddr &aSockName, uint32_t aFlags)
 {
-    OT_UNUSED_VARIABLE(aSockName);
+    Error               error = kErrorNone;
+    struct tcpcb &      tp    = GetTcb();
+    struct sockaddr_in6 sin6p;
+
     OT_UNUSED_VARIABLE(aFlags);
 
-    return kErrorNotImplemented;
+    VerifyOrExit(tp.t_state == TCP6S_CLOSED, error = kErrorInvalidState);
+
+    memcpy(&sin6p.sin6_addr, &aSockName.mAddress, sizeof(sin6p.sin6_addr));
+    sin6p.sin6_port = HostSwap16(aSockName.mPort);
+    error           = BsdErrorToOtError(tcp6_usr_connect(&tp, &sin6p));
+
+exit:
+    return error;
 }
 
 Error Tcp::Endpoint::SendByReference(otLinkedBuffer &aBuffer, uint32_t aFlags)
 {
-    OT_UNUSED_VARIABLE(aBuffer);
-    OT_UNUSED_VARIABLE(aFlags);
+    struct tcpcb &tp = GetTcb();
 
-    return kErrorNotImplemented;
+    return BsdErrorToOtError(tcp_usr_send(&tp, (aFlags & OT_TCP_SEND_MORE_TO_COME) != 0, &aBuffer, 0));
 }
 
 Error Tcp::Endpoint::SendByExtension(size_t aNumBytes, uint32_t aFlags)
 {
-    OT_UNUSED_VARIABLE(aNumBytes);
-    OT_UNUSED_VARIABLE(aFlags);
+    Error         error;
+    bool          moreToCome = (aFlags & OT_TCP_SEND_MORE_TO_COME) != 0;
+    struct tcpcb &tp         = GetTcb();
+    int           bsdError;
 
-    return kErrorNotImplemented;
+    VerifyOrExit(lbuf_head(&tp.sendbuf) != nullptr, error = kErrorInvalidState);
+
+    bsdError = tcp_usr_send(&tp, moreToCome ? 1 : 0, nullptr, aNumBytes);
+    SuccessOrExit(error = BsdErrorToOtError(bsdError));
+
+exit:
+    return error;
 }
 
-Error Tcp::Endpoint::ReceiveByReference(const otLinkedBuffer *&aBuffer) const
+Error Tcp::Endpoint::ReceiveByReference(const otLinkedBuffer *&aBuffer)
 {
-    OT_UNUSED_VARIABLE(aBuffer);
+    struct tcpcb &tp = GetTcb();
 
-    return kErrorNotImplemented;
+    cbuf_reference(&tp.recvbuf, &mReceiveLinks[0], &mReceiveLinks[1]);
+    aBuffer = &mReceiveLinks[0];
+
+    return kErrorNone;
 }
 
 Error Tcp::Endpoint::ReceiveContiguify(void)
@@ -138,20 +211,35 @@ Error Tcp::Endpoint::ReceiveContiguify(void)
 
 Error Tcp::Endpoint::CommitReceive(size_t aNumBytes, uint32_t aFlags)
 {
-    OT_UNUSED_VARIABLE(aNumBytes);
+    Error         error = kErrorNone;
+    struct tcpcb &tp    = GetTcb();
+
     OT_UNUSED_VARIABLE(aFlags);
 
-    return kErrorNotImplemented;
+    VerifyOrExit(cbuf_used_space(&tp.recvbuf) >= aNumBytes, error = kErrorFailed);
+    VerifyOrExit(aNumBytes > 0, error = kErrorNone);
+
+    cbuf_pop(&tp.recvbuf, aNumBytes);
+    error = BsdErrorToOtError(tcp_usr_rcvd(&tp));
+
+exit:
+    return error;
 }
 
 Error Tcp::Endpoint::SendEndOfStream(void)
 {
-    return kErrorNotImplemented;
+    struct tcpcb &tp = GetTcb();
+
+    return BsdErrorToOtError(tcp_usr_shutdown(&tp));
 }
 
 Error Tcp::Endpoint::Abort(void)
 {
-    return kErrorNotImplemented;
+    struct tcpcb &tp = GetTcb();
+
+    tcp_usr_abort(&tp);
+    /* connection_lost will do any reinitialization work for this socket. */
+    return kErrorNone;
 }
 
 Error Tcp::Endpoint::Deinitialize(void)
@@ -163,25 +251,59 @@ Error Tcp::Endpoint::Deinitialize(void)
     SuccessOrExit(error = tcp.mEndpoints.Remove(*this));
     SetNext(nullptr);
 
+    SuccessOrExit(error = Abort());
+
 exit:
     return error;
 }
 
 uint8_t Tcp::Endpoint::TimerFlagToIndex(uint8_t aTimerFlag)
 {
-    OT_UNUSED_VARIABLE(aTimerFlag);
-    /*
-     * TODO: Convert from the timer flag provided by TCPlp to the index in
-     * our timers array.
-     */
-    return 0;
+    uint8_t timerIndex = 0;
+
+    switch (aTimerFlag)
+    {
+    case TT_DELACK:
+        timerIndex = kTimerDelack;
+        break;
+    case TT_REXMT:
+    case TT_PERSIST:
+        timerIndex = kTimerRexmtPersist;
+        break;
+    case TT_KEEP:
+        timerIndex = kTimerKeep;
+        break;
+    case TT_2MSL:
+        timerIndex = kTimer2Msl;
+        break;
+    }
+
+    return timerIndex;
 }
 
 bool Tcp::Endpoint::IsTimerActive(uint8_t aTimerIndex)
 {
-    OT_UNUSED_VARIABLE(aTimerIndex);
-    /* TODO: Check whether TCPlp has marked this timer as active. */
-    return false;
+    bool          active = false;
+    struct tcpcb *tp     = &GetTcb();
+
+    OT_ASSERT(aTimerIndex < kNumTimers);
+    switch (aTimerIndex)
+    {
+    case kTimerDelack:
+        active = tcp_timer_active(tp, TT_DELACK);
+        break;
+    case kTimerRexmtPersist:
+        active = tcp_timer_active(tp, TT_REXMT) || tcp_timer_active(tp, TT_PERSIST);
+        break;
+    case kTimerKeep:
+        active = tcp_timer_active(tp, TT_KEEP);
+        break;
+    case kTimer2Msl:
+        active = tcp_timer_active(tp, TT_2MSL);
+        break;
+    }
+
+    return active;
 }
 
 void Tcp::Endpoint::SetTimer(uint8_t aTimerFlag, uint32_t aDelay)
@@ -219,6 +341,9 @@ void Tcp::Endpoint::CancelTimer(uint8_t aTimerFlag)
 
 bool Tcp::Endpoint::FirePendingTimers(TimeMilli aNow, bool &aHasFutureTimer, TimeMilli &aEarliestFutureExpiry)
 {
+    bool          calledUserCallback = false;
+    struct tcpcb *tp                 = &GetTcb();
+
     /*
      * NOTE: Firing a timer might potentially activate/deactivate other timers.
      * If timers x and y expire at the same time, but the callback for timer x
@@ -242,8 +367,36 @@ bool Tcp::Endpoint::FirePendingTimers(TimeMilli aNow, bool &aHasFutureTimer, Tim
 
             if (expiry <= aNow)
             {
-                /* TODO: Call TCPlp's callback for this timer. */
-                /* If a user callback is called, then return true. */
+                /*
+                 * If a user callback is called, then return true. For TCPlp,
+                 * this only happens if the connection is dropped (e.g., it
+                 * times out).
+                 */
+                int dropped;
+
+                switch (timerIndex)
+                {
+                case kTimerDelack:
+                    dropped = tcp_timer_delack(tp);
+                    break;
+                case kTimerRexmtPersist:
+                    if (tcp_timer_active(tp, TT_REXMT))
+                    {
+                        dropped = tcp_timer_rexmt(tp);
+                    }
+                    else
+                    {
+                        dropped = tcp_timer_persist(tp);
+                    }
+                    break;
+                case kTimerKeep:
+                    dropped = tcp_timer_keep(tp);
+                    break;
+                case kTimer2Msl:
+                    dropped = tcp_timer_2msl(tp);
+                    break;
+                }
+                VerifyOrExit(dropped == 0, calledUserCallback = true);
             }
             else
             {
@@ -253,12 +406,31 @@ bool Tcp::Endpoint::FirePendingTimers(TimeMilli aNow, bool &aHasFutureTimer, Tim
         }
     }
 
-    return false;
+exit:
+    return calledUserCallback;
+}
+
+bool Tcp::Endpoint::Matches(const MessageInfo &aMessageInfo) const
+{
+    bool                matches = false;
+    const struct tcpcb *tp      = &GetTcb();
+
+    VerifyOrExit(tp->t_state != TCP6S_CLOSED);
+    VerifyOrExit(tp->lport == HostSwap16(aMessageInfo.GetSockPort()));
+    VerifyOrExit(tp->fport == HostSwap16(aMessageInfo.GetPeerPort()));
+    VerifyOrExit(GetLocalIp6Address().IsUnspecified() || GetLocalIp6Address() == aMessageInfo.GetSockAddr());
+    VerifyOrExit(GetForeignIp6Address() == aMessageInfo.GetPeerAddr());
+
+    matches = true;
+
+exit:
+    return matches;
 }
 
 Error Tcp::Listener::Initialize(Instance &aInstance, otTcpListenerInitializeArgs &aArgs)
 {
-    Error error;
+    Error                error;
+    struct tcpcb_listen *tpl = &GetTcbListen();
 
     SuccessOrExit(error = aInstance.Get<Tcp>().mListeners.Add(*this));
 
@@ -266,7 +438,8 @@ Error Tcp::Listener::Initialize(Instance &aInstance, otTcpListenerInitializeArgs
     mAcceptReadyCallback = aArgs.mAcceptReadyCallback;
     mAcceptDoneCallback  = aArgs.mAcceptDoneCallback;
 
-    mInstance = &aInstance;
+    memset(tpl, 0x00, sizeof(struct tcpcb_listen));
+    tpl->instance = &aInstance;
 
 exit:
     return error;
@@ -274,19 +447,36 @@ exit:
 
 Instance &Tcp::Listener::GetInstance(void)
 {
-    return AsCoreType(mInstance);
+    struct tcpcb_listen *tpl = &GetTcbListen();
+
+    return AsCoreType(tpl->instance);
 }
 
 Error Tcp::Listener::Listen(const SockAddr &aSockName)
 {
-    OT_UNUSED_VARIABLE(aSockName);
+    Error                error;
+    uint16_t             port = HostSwap16(aSockName.mPort);
+    struct tcpcb_listen *tpl  = &GetTcbListen();
 
-    return kErrorNotImplemented;
+    VerifyOrExit(GetInstance().Get<Tcp>().CanBind(aSockName), error = kErrorInvalidState);
+
+    memcpy(&tpl->laddr, &aSockName.mAddress, sizeof(tpl->laddr));
+    tpl->lport   = port;
+    tpl->t_state = TCP6S_LISTEN;
+    error        = kErrorNone;
+
+exit:
+    return error;
 }
 
 Error Tcp::Listener::StopListening(void)
 {
-    return kErrorNotImplemented;
+    struct tcpcb_listen *tpl = &GetTcbListen();
+
+    memset(&tpl->laddr, 0x00, sizeof(tpl->laddr));
+    tpl->lport   = 0;
+    tpl->t_state = TCP6S_CLOSED;
+    return kErrorNone;
 }
 
 Error Tcp::Listener::Deinitialize(void)
@@ -302,25 +492,236 @@ exit:
     return error;
 }
 
+bool Tcp::Listener::Matches(const MessageInfo &aMessageInfo) const
+{
+    bool                       matches = false;
+    const struct tcpcb_listen *tpl     = &GetTcbListen();
+
+    VerifyOrExit(tpl->t_state == TCP6S_LISTEN);
+    VerifyOrExit(tpl->lport == HostSwap16(aMessageInfo.GetSockPort()));
+    VerifyOrExit(GetLocalIp6Address().IsUnspecified() || GetLocalIp6Address() == aMessageInfo.GetSockAddr());
+
+    matches = true;
+
+exit:
+    return matches;
+}
+
 Error Tcp::HandleMessage(ot::Ip6::Header &aIp6Header, Message &aMessage, MessageInfo &aMessageInfo)
 {
-    OT_UNUSED_VARIABLE(aIp6Header);
-    OT_UNUSED_VARIABLE(aMessage);
-    OT_UNUSED_VARIABLE(aMessageInfo);
-
     Error error = kErrorNotImplemented;
 
-    for (Endpoint &active : mEndpoints)
+    /*
+     * The type uint32_t was chosen for alignment purposes. The size is the
+     * maximum TCP header size, including options.
+     */
+    uint32_t header[15];
+
+    uint16_t length = aIp6Header.GetPayloadLength();
+    uint8_t  headerSize;
+
+    struct ip6_hdr *ip6Header;
+    struct tcphdr * tcpHeader;
+
+    Endpoint *endpoint;
+    Endpoint *endpointPrev;
+
+    Listener *listener;
+    Listener *listenerPrev;
+
+    VerifyOrExit(length == aMessage.GetLength() - aMessage.GetOffset(), error = kErrorParse);
+    VerifyOrExit(length >= sizeof(Tcp::Header), error = kErrorParse);
+    SuccessOrExit(error = aMessage.Read(aMessage.GetOffset() + offsetof(struct tcphdr, th_off_x2), headerSize));
+    headerSize = static_cast<uint8_t>((headerSize >> TH_OFF_SHIFT) << 2);
+    VerifyOrExit(headerSize >= sizeof(struct tcphdr) && headerSize <= sizeof(header) &&
+                     static_cast<uint16_t>(headerSize) <= length,
+                 error = kErrorParse);
+    SuccessOrExit(error = Checksum::VerifyMessageChecksum(aMessage, aMessageInfo, kProtoTcp));
+    SuccessOrExit(error = aMessage.Read(aMessage.GetOffset(), &header[0], headerSize));
+
+    ip6Header = reinterpret_cast<struct ip6_hdr *>(&aIp6Header);
+    tcpHeader = reinterpret_cast<struct tcphdr *>(&header[0]);
+    tcp_fields_to_host(tcpHeader);
+
+    aMessageInfo.mPeerPort = HostSwap16(tcpHeader->th_sport);
+    aMessageInfo.mSockPort = HostSwap16(tcpHeader->th_dport);
+
+    endpoint = mEndpoints.FindMatching(aMessageInfo, endpointPrev);
+    if (endpoint != nullptr)
     {
-        OT_UNUSED_VARIABLE(active);
+        struct signals sig;
+        int            nextAction;
+        struct tcpcb * tp = &endpoint->GetTcb();
+
+        otLinkedBuffer *priorHead = lbuf_head(&tp->sendbuf);
+
+        memset(&sig, 0x00, sizeof(sig));
+        nextAction = tcp_input(ip6Header, tcpHeader, &aMessage, tp, nullptr, &sig);
+        if (nextAction != RELOOKUP_REQUIRED)
+        {
+            ProcessSignals(*endpoint, priorHead, sig);
+            ExitNow();
+        }
+        /* If the matching socket was in the TIME-WAIT state, then we try passive sockets. */
     }
 
-    for (Listener &passive : mListeners)
+    listener = mListeners.FindMatching(aMessageInfo, listenerPrev);
+    if (listener != nullptr)
     {
-        OT_UNUSED_VARIABLE(passive);
+        struct tcpcb_listen *tpl = &listener->GetTcbListen();
+
+        tcp_input(ip6Header, tcpHeader, &aMessage, nullptr, tpl, nullptr);
+        ExitNow();
+    }
+
+    tcp_dropwithreset(ip6Header, tcpHeader, nullptr, &InstanceLocator::GetInstance(), length - headerSize,
+                      ECONNREFUSED);
+
+exit:
+    return error;
+}
+
+void Tcp::ProcessSignals(Endpoint &aEndpoint, otLinkedBuffer *aPriorHead, struct signals &aSignals)
+{
+    VerifyOrExit(IsInitialized(aEndpoint) && !aEndpoint.IsClosed());
+    if (aEndpoint.mSendDoneCallback != nullptr)
+    {
+        otLinkedBuffer *curr = aPriorHead;
+
+        for (int i = 0; i != aSignals.links_popped; i++)
+        {
+            otLinkedBuffer *next = curr->mNext;
+
+            VerifyOrExit(i == 0 || (IsInitialized(aEndpoint) && !aEndpoint.IsClosed()));
+
+            curr->mNext = nullptr;
+            aEndpoint.mSendDoneCallback(&aEndpoint, curr);
+            curr = next;
+        }
+    }
+
+    VerifyOrExit(IsInitialized(aEndpoint) && !aEndpoint.IsClosed());
+    if (aSignals.conn_established && aEndpoint.mEstablishedCallback != nullptr)
+    {
+        aEndpoint.mEstablishedCallback(&aEndpoint);
+    }
+
+    VerifyOrExit(IsInitialized(aEndpoint) && !aEndpoint.IsClosed());
+    if ((aSignals.recvbuf_notempty || aSignals.rcvd_fin) && aEndpoint.mReceiveAvailableCallback != nullptr)
+    {
+        aEndpoint.mReceiveAvailableCallback(&aEndpoint, cbuf_used_space(&aEndpoint.GetTcb().recvbuf),
+                                            aEndpoint.GetTcb().reass_fin_index != -1,
+                                            cbuf_free_space(&aEndpoint.GetTcb().recvbuf));
+    }
+
+    VerifyOrExit(IsInitialized(aEndpoint) && !aEndpoint.IsClosed());
+    if (aEndpoint.GetTcb().t_state == TCP6S_TIME_WAIT && aEndpoint.mDisconnectedCallback != nullptr)
+    {
+        aEndpoint.mDisconnectedCallback(&aEndpoint, OT_TCP_DISCONNECTED_REASON_TIME_WAIT);
+    }
+
+exit:
+    return;
+}
+
+Error Tcp::BsdErrorToOtError(int aBsdError)
+{
+    Error error = kErrorFailed;
+
+    switch (aBsdError)
+    {
+    case 0:
+        error = kErrorNone;
+        break;
     }
 
     return error;
+}
+
+bool Tcp::CanBind(const SockAddr &aSockName)
+{
+    uint16_t port    = HostSwap16(aSockName.mPort);
+    bool     allowed = false;
+
+    for (Endpoint *endpoint = mEndpoints.GetHead(); endpoint != nullptr; endpoint = endpoint->GetNext())
+    {
+        struct tcpcb *tp = &endpoint->GetTcb();
+
+        if (tp->lport == port)
+        {
+            VerifyOrExit(!aSockName.GetAddress().IsUnspecified());
+            VerifyOrExit(!reinterpret_cast<Address *>(&tp->laddr)->IsUnspecified());
+            VerifyOrExit(memcmp(&endpoint->GetTcb().laddr, &aSockName.mAddress, sizeof(tp->laddr)) != 0);
+        }
+    }
+
+    for (Listener *listener = mListeners.GetHead(); listener != nullptr; listener = listener->GetNext())
+    {
+        struct tcpcb_listen *tpl = &listener->GetTcbListen();
+
+        if (tpl->lport == port)
+        {
+            VerifyOrExit(!aSockName.GetAddress().IsUnspecified());
+            VerifyOrExit(!reinterpret_cast<Address *>(&tpl->laddr)->IsUnspecified());
+            VerifyOrExit(memcmp(&tpl->laddr, &aSockName.mAddress, sizeof(tpl->laddr)) != 0);
+        }
+    }
+
+    allowed = true;
+
+exit:
+    return allowed;
+}
+
+bool Tcp::AutoBind(const SockAddr &aPeer, SockAddr &aToBind, bool aBindAddress, bool aBindPort)
+{
+    bool success;
+
+    if (aBindAddress)
+    {
+        MessageInfo                  peerInfo;
+        const Netif::UnicastAddress *netifAddress;
+
+        peerInfo.Clear();
+        peerInfo.SetPeerAddr(aPeer.GetAddress());
+        netifAddress = InstanceLocator::GetInstance().Get<Ip6>().SelectSourceAddress(peerInfo);
+        VerifyOrExit(netifAddress != nullptr, success = false);
+        aToBind.GetAddress() = netifAddress->GetAddress();
+    }
+
+    if (aBindPort)
+    {
+        /*
+         * TODO: Use a less naive algorithm to allocate ephemeral ports. For
+         * example, see RFC 6056.
+         */
+
+        for (uint16_t i = 0; i != kDynamicPortMax - kDynamicPortMin + 1; i++)
+        {
+            aToBind.SetPort(mEphemeralPort);
+
+            if (mEphemeralPort == kDynamicPortMax)
+            {
+                mEphemeralPort = kDynamicPortMin;
+            }
+            else
+            {
+                mEphemeralPort++;
+            }
+
+            if (CanBind(aToBind))
+            {
+                ExitNow(success = true);
+            }
+        }
+
+        ExitNow(success = false);
+    }
+
+    success = CanBind(aToBind);
+
+exit:
+    return success;
 }
 
 void Tcp::HandleTimer(Timer &aTimer)
@@ -394,5 +795,228 @@ restart:
 
 } // namespace Ip6
 } // namespace ot
+
+/*
+ * Implement TCPlp system stubs declared in tcplp.h.
+ *
+ * Because these functions have C linkage, it is important that only one
+ * definition is given for each function name, regardless of the namespace it
+ * in. For example, if we give two definitions of tcplp_sys_new_message, we
+ * will get errors, even if they are in different namespaces. To avoid
+ * confusion, I've put these functions outside of any namespace.
+ */
+
+using namespace ot;
+using namespace ot::Ip6;
+
+extern "C" {
+
+otMessage *tcplp_sys_new_message(otInstance *aInstance)
+{
+    Instance &instance = AsCoreType(aInstance);
+    Message * message  = instance.Get<ot::Ip6::Ip6>().NewMessage(0);
+
+    if (message)
+    {
+        message->SetLinkSecurityEnabled(true);
+    }
+
+    return message;
+}
+
+void tcplp_sys_free_message(otInstance *aInstance, otMessage *aMessage)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+    Message &message = AsCoreType(aMessage);
+    message.Free();
+}
+
+void tcplp_sys_send_message(otInstance *aInstance, otMessage *aMessage, otMessageInfo *aMessageInfo)
+{
+    Instance &   instance = AsCoreType(aInstance);
+    Message &    message  = AsCoreType(aMessage);
+    MessageInfo &info     = AsCoreType(aMessageInfo);
+
+    otLogDebgTcp("Sending TCP segment: payload_size = %d", static_cast<int>(message.GetLength()));
+
+    IgnoreError(instance.Get<ot::Ip6::Ip6>().SendDatagram(message, info, kProtoTcp));
+}
+
+uint32_t tcplp_sys_get_ticks(void)
+{
+    return TimerMilli::GetNow().GetValue();
+}
+
+uint32_t tcplp_sys_get_millis(void)
+{
+    return TimerMilli::GetNow().GetValue();
+}
+
+void tcplp_sys_set_timer(struct tcpcb *aTcb, uint8_t aTimerFlag, uint32_t aDelay)
+{
+    Tcp::Endpoint &endpoint = Tcp::Endpoint::FromTcb(*aTcb);
+    endpoint.SetTimer(aTimerFlag, aDelay);
+}
+
+void tcplp_sys_stop_timer(struct tcpcb *aTcb, uint8_t aTimerFlag)
+{
+    Tcp::Endpoint &endpoint = Tcp::Endpoint::FromTcb(*aTcb);
+    endpoint.CancelTimer(aTimerFlag);
+}
+
+struct tcpcb *tcplp_sys_accept_ready(struct tcpcb_listen *aTcbListen, struct in6_addr *aAddr, uint16_t aPort)
+{
+    Tcp::Listener &               listener = Tcp::Listener::FromTcbListen(*aTcbListen);
+    Tcp &                         tcp      = listener.GetInstance().Get<Tcp>();
+    struct tcpcb *                rv       = (struct tcpcb *)-1;
+    otSockAddr                    addr;
+    otTcpEndpoint *               endpointPtr;
+    otTcpIncomingConnectionAction action;
+
+    VerifyOrExit(listener.mAcceptReadyCallback != nullptr);
+
+    memcpy(&addr.mAddress, aAddr, sizeof(addr.mAddress));
+    addr.mPort = HostSwap16(aPort);
+    action     = listener.mAcceptReadyCallback(&listener, &addr, &endpointPtr);
+
+    VerifyOrExit(tcp.IsInitialized(listener) && !listener.IsClosed());
+
+    switch (action)
+    {
+    case OT_TCP_INCOMING_CONNECTION_ACTION_ACCEPT:
+    {
+        Tcp::Endpoint &endpoint = AsCoreType(endpointPtr);
+
+        /*
+         * The documentation says that the user must initialize the
+         * endpoint before passing it here, so we do a sanity check to make
+         * sure the endpoint is initialized and closed. That check may not
+         * be necessary, but we do it anyway.
+         */
+        VerifyOrExit(tcp.IsInitialized(endpoint) && endpoint.IsClosed());
+
+        rv = &endpoint.GetTcb();
+
+        break;
+    }
+    case OT_TCP_INCOMING_CONNECTION_ACTION_DEFER:
+        rv = nullptr;
+        break;
+    case OT_TCP_INCOMING_CONNECTION_ACTION_REFUSE:
+        rv = (struct tcpcb *)-1;
+        break;
+    }
+
+exit:
+    return rv;
+}
+
+bool tcplp_sys_accepted_connection(struct tcpcb_listen *aTcbListen,
+                                   struct tcpcb *       aAccepted,
+                                   struct in6_addr *    aAddr,
+                                   uint16_t             aPort)
+{
+    Tcp::Listener &listener = Tcp::Listener::FromTcbListen(*aTcbListen);
+    Tcp::Endpoint &endpoint = Tcp::Endpoint::FromTcb(*aAccepted);
+    Tcp &          tcp      = endpoint.GetInstance().Get<Tcp>();
+    bool           accepted = true;
+
+    if (listener.mAcceptDoneCallback != nullptr)
+    {
+        otSockAddr addr;
+
+        memcpy(&addr.mAddress, aAddr, sizeof(addr.mAddress));
+        addr.mPort = HostSwap16(aPort);
+        listener.mAcceptDoneCallback(&listener, &endpoint, &addr);
+
+        if (!tcp.IsInitialized(endpoint) || endpoint.IsClosed())
+        {
+            accepted = false;
+        }
+    }
+
+    return accepted;
+}
+
+void tcplp_sys_connection_lost(struct tcpcb *aTcb, uint8_t aErrNum)
+{
+    Tcp::Endpoint &endpoint = Tcp::Endpoint::FromTcb(*aTcb);
+
+    if (endpoint.mDisconnectedCallback != nullptr)
+    {
+        otTcpDisconnectedReason reason;
+
+        switch (aErrNum)
+        {
+        case CONN_LOST_NORMAL:
+            reason = OT_TCP_DISCONNECTED_REASON_NORMAL;
+            break;
+        case ECONNREFUSED:
+            reason = OT_TCP_DISCONNECTED_REASON_REFUSED;
+            break;
+        case ETIMEDOUT:
+            reason = OT_TCP_DISCONNECTED_REASON_TIMED_OUT;
+            break;
+        case ECONNRESET:
+        default:
+            reason = OT_TCP_DISCONNECTED_REASON_RESET;
+            break;
+        }
+        endpoint.mDisconnectedCallback(&endpoint, reason);
+    }
+}
+
+void tcplp_sys_on_state_change(struct tcpcb *aTcb, int aNewState)
+{
+    if (aNewState == TCP6S_CLOSED)
+    {
+        /* Re-initialize the TCB. */
+        cbuf_pop(&aTcb->recvbuf, cbuf_used_space(&aTcb->recvbuf));
+        aTcb->accepted_from = nullptr;
+        initialize_tcb(aTcb);
+    }
+    /* Any adaptive changes to the sleep interval would go here. */
+}
+
+void tcplp_sys_log(const char *aFormat, ...)
+{
+    char    buffer[128];
+    va_list args;
+    va_start(args, aFormat);
+    vsnprintf(buffer, sizeof(buffer), aFormat, args);
+    va_end(args);
+
+    otLogDebgTcp(buffer);
+}
+
+bool tcplp_sys_autobind(otInstance *      aInstance,
+                        const otSockAddr *aPeer,
+                        otSockAddr *      aToBind,
+                        bool              aBindAddress,
+                        bool              aBindPort)
+{
+    Instance &instance = AsCoreType(aInstance);
+
+    return instance.Get<Tcp>().AutoBind(*static_cast<const SockAddr *>(aPeer), *static_cast<SockAddr *>(aToBind),
+                                        aBindAddress, aBindPort);
+}
+
+uint32_t tcplp_sys_generate_isn()
+{
+    uint32_t isn;
+    IgnoreError(Random::Crypto::FillBuffer(reinterpret_cast<uint8_t *>(&isn), sizeof(isn)));
+    return isn;
+}
+
+uint16_t tcplp_sys_hostswap16(uint16_t aHostPort)
+{
+    return HostSwap16(aHostPort);
+}
+
+uint32_t tcplp_sys_hostswap32(uint32_t aHostPort)
+{
+    return HostSwap32(aHostPort);
+}
+}
 
 #endif // OPENTHREAD_CONFIG_TCP_ENABLE

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -28,6 +28,8 @@
 
 include $(abs_top_nlbuild_autotools_dir)/automake/pre.am
 
+COMMON_LIBTOOLFLAGS = --preserve-dup-deps
+
 #
 # Local headers to build against and distribute but not to install
 # since they are not part of the package.
@@ -74,7 +76,6 @@ AM_CPPFLAGS                                                        += \
 endif
 
 COMMON_LDADD                                                        = \
-    $(top_builddir)/third_party/tcplp/libtcplp.a                      \
     $(NULL)
 
 if OPENTHREAD_ENABLE_NCP
@@ -84,6 +85,8 @@ COMMON_LDADD                                                       += \
 endif
 
 COMMON_LDADD                                                       += \
+    $(top_builddir)/src/core/libopenthread-ftd.a                      \
+    $(top_builddir)/third_party/tcplp/libtcplp.a                      \
     $(top_builddir)/src/core/libopenthread-ftd.a                      \
     -lpthread                                                         \
     $(NULL)
@@ -184,128 +187,168 @@ COMMON_SOURCES               = test_platform.cpp test_util.cpp
 
 # Source, compiler, and linker options for test programs.
 
-ot_test_aes_LDADD               = $(COMMON_LDADD)
-ot_test_aes_SOURCES             = $(COMMON_SOURCES) test_aes.cpp
+ot_test_aes_LDADD                   = $(COMMON_LDADD)
+ot_test_aes_LIBTOOLFLAGS            = $(COMMON_LIBTOOLFLAGS)
+ot_test_aes_SOURCES                 = $(COMMON_SOURCES) test_aes.cpp
 
-ot_test_array_LDADD             = $(COMMON_LDADD)
-ot_test_array_SOURCES           = $(COMMON_SOURCES) test_array.cpp
+ot_test_array_LDADD                 = $(COMMON_LDADD)
+ot_test_array_LIBTOOLFLAGS          = $(COMMON_LIBTOOLFLAGS)
+ot_test_array_SOURCES               = $(COMMON_SOURCES) test_array.cpp
 
-ot_test_binary_search_LDADD     = $(COMMON_LDADD)
-ot_test_binary_search_SOURCES   = $(COMMON_SOURCES) test_binary_search.cpp
+ot_test_binary_search_LDADD         = $(COMMON_LDADD)
+ot_test_binary_search_LIBTOOLFLAGS  = $(COMMON_LIBTOOLFLAGS)
+ot_test_binary_search_SOURCES       = $(COMMON_SOURCES) test_binary_search.cpp
 
-ot_test_checksum_LDADD          = $(COMMON_LDADD)
-ot_test_checksum_SOURCES        = $(COMMON_SOURCES) test_checksum.cpp
+ot_test_checksum_LDADD              = $(COMMON_LDADD)
+ot_test_checksum_LIBTOOLFLAGS       = $(COMMON_LIBTOOLFLAGS)
+ot_test_checksum_SOURCES            = $(COMMON_SOURCES) test_checksum.cpp
 
-ot_test_child_LDADD             = $(COMMON_LDADD)
-ot_test_child_SOURCES           = $(COMMON_SOURCES) test_child.cpp
+ot_test_child_LDADD                 = $(COMMON_LDADD)
+ot_test_child_LIBTOOLFLAGS          = $(COMMON_LIBTOOLFLAGS)
+ot_test_child_SOURCES               = $(COMMON_SOURCES) test_child.cpp
 
-ot_test_child_table_LDADD       = $(COMMON_LDADD)
-ot_test_child_table_SOURCES     = $(COMMON_SOURCES) test_child_table.cpp
+ot_test_child_table_LDADD           = $(COMMON_LDADD)
+ot_test_child_table_LIBTOOLFLAGS    = $(COMMON_LIBTOOLFLAGS)
+ot_test_child_table_SOURCES         = $(COMMON_SOURCES) test_child_table.cpp
 
-ot_test_cmd_line_parser_LDADD   = $(COMMON_LDADD)
-ot_test_cmd_line_parser_SOURCES = $(COMMON_SOURCES) test_cmd_line_parser.cpp
+ot_test_cmd_line_parser_LDADD       = $(COMMON_LDADD)
+ot_test_cmd_line_parser_LIBTOOLFLAGS = $(COMMON_LIBTOOLFLAGS)
+ot_test_cmd_line_parser_SOURCES     = $(COMMON_SOURCES) test_cmd_line_parser.cpp
 
-ot_test_data_LDADD              = $(COMMON_LDADD)
-ot_test_data_SOURCES            = $(COMMON_SOURCES) test_data.cpp
+ot_test_data_LDADD                  = $(COMMON_LDADD)
+ot_test_data_LIBTOOLFLAGS           = $(COMMON_LIBTOOLFLAGS)
+ot_test_data_SOURCES                = $(COMMON_SOURCES) test_data.cpp
 
-ot_test_dns_LDADD               = $(COMMON_LDADD)
-ot_test_dns_SOURCES             = $(COMMON_SOURCES) test_dns.cpp
+ot_test_dns_LDADD                   = $(COMMON_LDADD)
+ot_test_dns_LIBTOOLFLAGS            = $(COMMON_LIBTOOLFLAGS)
+ot_test_dns_SOURCES                 = $(COMMON_SOURCES) test_dns.cpp
 
-ot_test_dso_LDADD               = $(COMMON_LDADD)
-ot_test_dso_SOURCES             = $(COMMON_SOURCES) test_dso.cpp
+ot_test_dso_LDADD                   = $(COMMON_LDADD)
+ot_test_dso_LIBTOOLFLAGS            = $(COMMON_LIBTOOLFLAGS)
+ot_test_dso_SOURCES                 = $(COMMON_SOURCES) test_dso.cpp
 
-ot_test_ecdsa_LDADD             = $(COMMON_LDADD)
-ot_test_ecdsa_SOURCES           = $(COMMON_SOURCES) test_ecdsa.cpp
+ot_test_ecdsa_LDADD                 = $(COMMON_LDADD)
+ot_test_ecdsa_LIBTOOLFLAGS          = $(COMMON_LIBTOOLFLAGS)
+ot_test_ecdsa_SOURCES               = $(COMMON_SOURCES) test_ecdsa.cpp
 
-ot_test_flash_LDADD             = $(COMMON_LDADD)
-ot_test_flash_SOURCES           = $(COMMON_SOURCES) test_flash.cpp
+ot_test_flash_LDADD                 = $(COMMON_LDADD)
+ot_test_flash_LIBTOOLFLAGS          = $(COMMON_LIBTOOLFLAGS)
+ot_test_flash_SOURCES               = $(COMMON_SOURCES) test_flash.cpp
 
-ot_test_hdlc_LDADD              = $(COMMON_LDADD)
-ot_test_hdlc_SOURCES            = $(COMMON_SOURCES) test_hdlc.cpp
+ot_test_hdlc_LDADD                  = $(COMMON_LDADD)
+ot_test_hdlc_LIBTOOLFLAGS           = $(COMMON_LIBTOOLFLAGS)
+ot_test_hdlc_SOURCES                = $(COMMON_SOURCES) test_hdlc.cpp
 
-ot_test_heap_LDADD              = $(COMMON_LDADD)
-ot_test_heap_SOURCES            = $(COMMON_SOURCES) test_heap.cpp
+ot_test_heap_LDADD                  = $(COMMON_LDADD)
+ot_test_heap_LIBTOOLFLAGS           = $(COMMON_LIBTOOLFLAGS)
+ot_test_heap_SOURCES                = $(COMMON_SOURCES) test_heap.cpp
 
-ot_test_heap_string_LDADD       = $(COMMON_LDADD)
-ot_test_heap_string_SOURCES     = $(COMMON_SOURCES) test_heap_string.cpp
+ot_test_heap_string_LDADD           = $(COMMON_LDADD)
+ot_test_heap_string_LIBTOOLFLAGS    = $(COMMON_LIBTOOLFLAGS)
+ot_test_heap_string_SOURCES         = $(COMMON_SOURCES) test_heap_string.cpp
 
-ot_test_hkdf_sha256_LDADD       = $(COMMON_LDADD)
-ot_test_hkdf_sha256_SOURCES     = $(COMMON_SOURCES) test_hkdf_sha256.cpp
+ot_test_hkdf_sha256_LDADD           = $(COMMON_LDADD)
+ot_test_hkdf_sha256_LIBTOOLFLAGS    = $(COMMON_LIBTOOLFLAGS)
+ot_test_hkdf_sha256_SOURCES         = $(COMMON_SOURCES) test_hkdf_sha256.cpp
 
-ot_test_hmac_sha256_LDADD       = $(COMMON_LDADD)
-ot_test_hmac_sha256_SOURCES     = $(COMMON_SOURCES) test_hmac_sha256.cpp
+ot_test_hmac_sha256_LDADD           = $(COMMON_LDADD)
+ot_test_hmac_sha256_LIBTOOLFLAGS    = $(COMMON_LIBTOOLFLAGS)
+ot_test_hmac_sha256_SOURCES         = $(COMMON_SOURCES) test_hmac_sha256.cpp
 
-ot_test_ip_address_LDADD        = $(COMMON_LDADD)
-ot_test_ip_address_SOURCES      = $(COMMON_SOURCES) test_ip_address.cpp
+ot_test_ip_address_LDADD            = $(COMMON_LDADD)
+ot_test_ip_address_LIBTOOLFLAGS     = $(COMMON_LIBTOOLFLAGS)
+ot_test_ip_address_SOURCES          = $(COMMON_SOURCES) test_ip_address.cpp
 
-ot_test_link_quality_LDADD      = $(COMMON_LDADD)
-ot_test_link_quality_SOURCES    = $(COMMON_SOURCES) test_link_quality.cpp
+ot_test_link_quality_LDADD          = $(COMMON_LDADD)
+ot_test_link_quality_LIBTOOLFLAGS   = $(COMMON_LIBTOOLFLAGS)
+ot_test_link_quality_SOURCES        = $(COMMON_SOURCES) test_link_quality.cpp
 
-ot_test_linked_list_LDADD       = $(COMMON_LDADD)
-ot_test_linked_list_SOURCES     = $(COMMON_SOURCES) test_linked_list.cpp
+ot_test_linked_list_LDADD           = $(COMMON_LDADD)
+ot_test_linked_list_LIBTOOLFLAGS    = $(COMMON_LIBTOOLFLAGS)
+ot_test_linked_list_SOURCES         = $(COMMON_SOURCES) test_linked_list.cpp
 
-ot_test_lowpan_LDADD            = $(COMMON_LDADD)
-ot_test_lowpan_SOURCES          = $(COMMON_SOURCES) test_lowpan.cpp
+ot_test_lowpan_LDADD                = $(COMMON_LDADD)
+ot_test_lowpan_LIBTOOLFLAGS         = $(COMMON_LIBTOOLFLAGS)
+ot_test_lowpan_SOURCES              = $(COMMON_SOURCES) test_lowpan.cpp
 
-ot_test_mac_frame_LDADD         = $(COMMON_LDADD)
-ot_test_mac_frame_SOURCES       = $(COMMON_SOURCES) test_mac_frame.cpp
+ot_test_mac_frame_LDADD             = $(COMMON_LDADD)
+ot_test_mac_frame_LIBTOOLFLAGS      = $(COMMON_LIBTOOLFLAGS)
+ot_test_mac_frame_SOURCES           = $(COMMON_SOURCES) test_mac_frame.cpp
 
-ot_test_macros_LDADD            = $(COMMON_LDADD)
-ot_test_macros_SOURCES          = $(COMMON_SOURCES) test_macros.cpp
+ot_test_macros_LDADD                = $(COMMON_LDADD)
+ot_test_macros_LIBTOOLFLAGS         = $(COMMON_LIBTOOLFLAGS)
+ot_test_macros_SOURCES              = $(COMMON_SOURCES) test_macros.cpp
 
-ot_test_message_LDADD           = $(COMMON_LDADD)
-ot_test_message_SOURCES         = $(COMMON_SOURCES) test_message.cpp
+ot_test_message_LDADD               = $(COMMON_LDADD)
+ot_test_message_LIBTOOLFLAGS        = $(COMMON_LIBTOOLFLAGS)
+ot_test_message_SOURCES             = $(COMMON_SOURCES) test_message.cpp
 
-ot_test_message_queue_LDADD     = $(COMMON_LDADD)
-ot_test_message_queue_SOURCES   = $(COMMON_SOURCES) test_message_queue.cpp
+ot_test_message_queue_LDADD         = $(COMMON_LDADD)
+ot_test_message_queue_LIBTOOLFLAGS  = $(COMMON_LIBTOOLFLAGS)
+ot_test_message_queue_SOURCES       = $(COMMON_SOURCES) test_message_queue.cpp
 
-ot_test_multicast_listeners_table_LDADD   = $(COMMON_LDADD)
+ot_test_multicast_listeners_table_LDADD = $(COMMON_LDADD)
+ot_test_multicast_listeners_table_LIBTOOLFLAGS = $(COMMON_LIBTOOLFLAGS)
 ot_test_multicast_listeners_table_SOURCES = $(COMMON_SOURCES) test_multicast_listeners_table.cpp
 
-ot_test_spinel_buffer_LDADD     = $(COMMON_LDADD)
-ot_test_spinel_buffer_SOURCES   = $(COMMON_SOURCES) test_spinel_buffer.cpp
+ot_test_spinel_buffer_LDADD         = $(COMMON_LDADD)
+ot_test_spinel_buffer_LIBTOOLFLAGS  = $(COMMON_LIBTOOLFLAGS)
+ot_test_spinel_buffer_SOURCES       = $(COMMON_SOURCES) test_spinel_buffer.cpp
 
-ot_test_ndproxy_table_LDADD     = $(COMMON_LDADD)
-ot_test_ndproxy_table_SOURCES   = $(COMMON_SOURCES) test_ndproxy_table.cpp
+ot_test_ndproxy_table_LDADD         = $(COMMON_LDADD)
+ot_test_ndproxy_table_LIBTOOLFLAGS  = $(COMMON_LIBTOOLFLAGS)
+ot_test_ndproxy_table_SOURCES       = $(COMMON_SOURCES) test_ndproxy_table.cpp
 
-ot_test_netif_LDADD             = $(COMMON_LDADD)
-ot_test_netif_SOURCES           = $(COMMON_SOURCES) test_netif.cpp
+ot_test_netif_LDADD                 = $(COMMON_LDADD)
+ot_test_netif_LIBTOOLFLAGS          = $(COMMON_LIBTOOLFLAGS)
+ot_test_netif_SOURCES               = $(COMMON_SOURCES) test_netif.cpp
 
-ot_test_network_data_LDADD      = $(COMMON_LDADD)
-ot_test_network_data_SOURCES    = $(COMMON_SOURCES) test_network_data.cpp
+ot_test_network_data_LDADD          = $(COMMON_LDADD)
+ot_test_network_data_LIBTOOLFLAGS    = $(COMMON_LIBTOOLFLAGS)
+ot_test_network_data_SOURCES        = $(COMMON_SOURCES) test_network_data.cpp
 
-ot_test_pool_LDADD              = $(COMMON_LDADD)
-ot_test_pool_SOURCES            = $(COMMON_SOURCES) test_pool.cpp
+ot_test_pool_LDADD                  = $(COMMON_LDADD)
+ot_test_pool_LIBTOOLFLAGS           = $(COMMON_LIBTOOLFLAGS)
+ot_test_pool_SOURCES                = $(COMMON_SOURCES) test_pool.cpp
 
-ot_test_priority_queue_LDADD    = $(COMMON_LDADD)
-ot_test_priority_queue_SOURCES  = $(COMMON_SOURCES) test_priority_queue.cpp
+ot_test_priority_queue_LDADD        = $(COMMON_LDADD)
+ot_test_priority_queue_LIBTOOLFLAGS = $(COMMON_LIBTOOLFLAGS)
+ot_test_priority_queue_SOURCES      = $(COMMON_SOURCES) test_priority_queue.cpp
 
-ot_test_pskc_LDADD              = $(COMMON_LDADD)
-ot_test_pskc_SOURCES            = $(COMMON_SOURCES) test_pskc.cpp
+ot_test_pskc_LDADD                  = $(COMMON_LDADD)
+ot_test_pskc_LIBTOOLFLAGS           = $(COMMON_LIBTOOLFLAGS)
+ot_test_pskc_SOURCES                = $(COMMON_SOURCES) test_pskc.cpp
 
-ot_test_smart_ptrs_LDADD        = $(COMMON_LDADD)
-ot_test_smart_ptrs_SOURCES      = $(COMMON_SOURCES) test_smart_ptrs.cpp
+ot_test_smart_ptrs_LDADD            = $(COMMON_LDADD)
+ot_test_smart_ptrs_LIBTOOLFLAGS     = $(COMMON_LIBTOOLFLAGS)
+ot_test_smart_ptrs_SOURCES          = $(COMMON_SOURCES) test_smart_ptrs.cpp
 
-ot_test_meshcop_LDADD           = $(COMMON_LDADD)
-ot_test_meshcop_SOURCES         = $(COMMON_SOURCES) test_meshcop.cpp
+ot_test_meshcop_LDADD               = $(COMMON_LDADD)
+ot_test_meshcop_LIBTOOLFLAGS        = $(COMMON_LIBTOOLFLAGS)
+ot_test_meshcop_SOURCES             = $(COMMON_SOURCES) test_meshcop.cpp
 
-ot_test_serial_number_LDADD     = $(COMMON_LDADD)
-ot_test_serial_number_SOURCES   = $(COMMON_SOURCES) test_serial_number.cpp
+ot_test_serial_number_LDADD         = $(COMMON_LDADD)
+ot_test_serial_number_LIBTOOLFLAGS  = $(COMMON_LIBTOOLFLAGS)
+ot_test_serial_number_SOURCES       = $(COMMON_SOURCES) test_serial_number.cpp
 
-ot_test_string_LDADD            = $(COMMON_LDADD)
-ot_test_string_SOURCES          = $(COMMON_SOURCES) test_string.cpp
+ot_test_string_LDADD                = $(COMMON_LDADD)
+ot_test_string_LIBTOOLFLAGS         = $(COMMON_LIBTOOLFLAGS)
+ot_test_string_SOURCES              = $(COMMON_SOURCES) test_string.cpp
 
-ot_test_spinel_decoder_LDADD    = $(COMMON_LDADD)
-ot_test_spinel_decoder_SOURCES  = $(COMMON_SOURCES) test_spinel_decoder.cpp
+ot_test_spinel_decoder_LDADD        = $(COMMON_LDADD)
+ot_test_spinel_decoder_LIBTOOLFLAGS = $(COMMON_LIBTOOLFLAGS)
+ot_test_spinel_decoder_SOURCES      = $(COMMON_SOURCES) test_spinel_decoder.cpp
 
-ot_test_spinel_encoder_LDADD    = $(COMMON_LDADD)
-ot_test_spinel_encoder_SOURCES  = $(COMMON_SOURCES) test_spinel_encoder.cpp
+ot_test_spinel_encoder_LDADD        = $(COMMON_LDADD)
+ot_test_spinel_encoder_LIBTOOLFLAGS = $(COMMON_LIBTOOLFLAGS)
+ot_test_spinel_encoder_SOURCES      = $(COMMON_SOURCES) test_spinel_encoder.cpp
 
-ot_test_timer_LDADD             = $(COMMON_LDADD)
-ot_test_timer_SOURCES           = $(COMMON_SOURCES) test_timer.cpp
+ot_test_timer_LDADD                 = $(COMMON_LDADD)
+ot_test_timer_LIBTOOLFLAGS          = $(COMMON_LIBTOOLFLAGS)
+ot_test_timer_SOURCES               = $(COMMON_SOURCES) test_timer.cpp
 
-ot_test_toolchain_LDADD         = $(NULL)
-ot_test_toolchain_SOURCES       = test_toolchain.cpp test_toolchain_c.c
+ot_test_toolchain_LDADD             = $(NULL)
+ot_test_toolchain_SOURCES           = test_toolchain.cpp test_toolchain_c.c
 
 if OPENTHREAD_BUILD_COVERAGE
 CLEANFILES                   = $(wildcard *.gcda *.gcno)

--- a/third_party/tcplp/bsdtcp/cc.h
+++ b/third_party/tcplp/bsdtcp/cc.h
@@ -57,8 +57,8 @@
  * the global linked list are removed.
  */
 
-#ifndef _NETINET_CC_H_
-#define _NETINET_CC_H_
+#ifndef TCPLP_NETINET_CC_H_
+#define TCPLP_NETINET_CC_H_
 
 /* XXX: TCP_CA_NAME_MAX define lives in tcp.h for compat reasons. */
 #include "tcp.h"

--- a/third_party/tcplp/bsdtcp/cc/cc_module.h
+++ b/third_party/tcplp/bsdtcp/cc/cc_module.h
@@ -40,8 +40,8 @@
  *   http://caia.swin.edu.au/urp/newtcp/
  */
 
-#ifndef _NETINET_CC_MODULE_H_
-#define _NETINET_CC_MODULE_H_
+#ifndef TCPLP_NETINET_CC_MODULE_H_
+#define TCPLP_NETINET_CC_MODULE_H_
 
 /* samkumar: This was already commented out in FreeBSD (I didn't do it). */
 /*

--- a/third_party/tcplp/bsdtcp/icmp_var.h
+++ b/third_party/tcplp/bsdtcp/icmp_var.h
@@ -35,8 +35,8 @@
  * weren't necessary (and often introduced additional dependencies).
  */
 
-#ifndef _NETINET_ICMP_VAR_H_
-#define _NETINET_ICMP_VAR_H_
+#ifndef TCPLP_NETINET_ICMP_VAR_H_
+#define TCPLP_NETINET_ICMP_VAR_H_
 /*
  * Identifiers for ICMP sysctl nodes
  */

--- a/third_party/tcplp/bsdtcp/ip.h
+++ b/third_party/tcplp/bsdtcp/ip.h
@@ -31,8 +31,8 @@
  * $FreeBSD$
  */
 
-#ifndef _NETINET_IP_H_
-#define	_NETINET_IP_H_
+#ifndef TCPLP_NETINET_IP_H_
+#define TCPLP_NETINET_IP_H_
 
 #define	IP_MAXPACKET	65535		/* maximum packet size */
 

--- a/third_party/tcplp/bsdtcp/ip6.h
+++ b/third_party/tcplp/bsdtcp/ip6.h
@@ -61,8 +61,8 @@
  *	@(#)ip.h	8.1 (Berkeley) 6/10/93
  */
 
-#ifndef _NETINET_IP6_H_
-#define _NETINET_IP6_H_
+#ifndef TCPLP_NETINET_IP6_H_
+#define TCPLP_NETINET_IP6_H_
 
 #include "types.h"
 

--- a/third_party/tcplp/bsdtcp/sys/queue.h
+++ b/third_party/tcplp/bsdtcp/sys/queue.h
@@ -30,8 +30,8 @@
  * $FreeBSD$
  */
 
-#ifndef _SYS_QUEUE_H_
-#define	_SYS_QUEUE_H_
+#ifndef TCPLP_SYS_QUEUE_H_
+#define	TCPLP_SYS_QUEUE_H_
 
 /* samkumar: Removing this, as it adds yet another dependency. */
 //#include <sys/cdefs.h>

--- a/third_party/tcplp/bsdtcp/tcp.h
+++ b/third_party/tcplp/bsdtcp/tcp.h
@@ -37,8 +37,8 @@
  * we should look at that very closely, and consider rewriting it.
  */
 
-#ifndef _NETINET_TCP_H_
-#define _NETINET_TCP_H_
+#ifndef TCPLP_NETINET_TCP_H_
+#define TCPLP_NETINET_TCP_H_
 
 #include <stdint.h>
 #include <stdio.h>
@@ -61,14 +61,28 @@ struct tcphdr {
 	uint16_t	th_dport;		/* destination port */
 	tcp_seq	th_seq;			/* sequence number */
 	tcp_seq	th_ack;			/* acknowledgement number */
-#if 1 //BYTE_ORDER == LITTLE_ENDIAN
+
+	/*
+	 * samkumar: The original FreeBSD code used bit fields for the offset and
+	 * unused bits, within this byte. I've rewritten it to avoid the use of
+	 * bit fields, so that the code is more portable. The original code, which
+	 * defined the order of bit fields based on the platform's endianness, is
+	 * included below, commented out using "#if 0".
+	 */
+	uint8_t th_off_x2; /* data offset and unused bits */
+#define	TH_OFF_SHIFT	4
+
+#if 0
+#if BYTE_ORDER == LITTLE_ENDIAN
 	uint8_t	th_x2:4,		/* (unused) */
 		th_off:4;		/* data offset */
 #endif
-#if 0 //BYTE_ORDER == BIG_ENDIAN
+#if BYTE_ORDER == BIG_ENDIAN
 	uint8_t	th_off:4,		/* data offset */
 		th_x2:4;		/* (unused) */
 #endif
+#endif
+
 	uint8_t	th_flags;
 #define	TH_FIN	0x01
 #define	TH_SYN	0x02

--- a/third_party/tcplp/bsdtcp/tcp_const.h
+++ b/third_party/tcplp/bsdtcp/tcp_const.h
@@ -43,9 +43,23 @@
 #include "tcp_var.h"
 #include "tcp_timer.h"
 
+/*
+ * samkumar: these are TCPlp-specific constants that I added. They were not
+ * present in the FreeBSD-derived code.
+ */
+
+#define FRAMES_PER_SEG 5
+#define FRAMECAP_6LOWPAN (122 - 11 - 5)
+#define IP6HDR_SIZE (2 + 1 + 1 + 16 + 16) // IPHC header (2) + Next header (1) + Hop count (1) + Dest. addr (16) + Src. addr (16)
 #define MSS_6LOWPAN ((FRAMES_PER_SEG * FRAMECAP_6LOWPAN) - IP6HDR_SIZE - sizeof(struct tcphdr))
 
-// I may change some of these flags later
+/*
+ * samkumar: The remaining constants were present in the original FreeBSD code,
+ * but I set their values.
+ */
+
+#define hz 1000 // number of ticks per second, assuming millisecond ticks
+
 enum tcp_input_consts {
 	tcp_keepcnt = TCPTV_KEEPCNT,
 	tcp_fast_finwait2_recycle = 0,

--- a/third_party/tcplp/bsdtcp/tcp_const.h
+++ b/third_party/tcplp/bsdtcp/tcp_const.h
@@ -35,8 +35,8 @@
  * often serve to enable, disable, or configure certain TCP-related features.
  */
 
-#ifndef _TCP_CONST_H_
-#define _TCP_CONST_H_
+#ifndef TCPLP_TCP_CONST_H_
+#define TCPLP_TCP_CONST_H_
 
 #include "../tcplp.h"
 

--- a/third_party/tcplp/bsdtcp/tcp_fsm.h
+++ b/third_party/tcplp/bsdtcp/tcp_fsm.h
@@ -33,8 +33,8 @@
 
 /* samkumar: Removed some #ifdef guards around constants needed for TCPlp. */
 
-#ifndef _NETINET_TCP_FSM_H_
-#define	_NETINET_TCP_FSM_H_
+#ifndef TCPLP_NETINET_TCP_FSM_H_
+#define	TCPLP_NETINET_TCP_FSM_H_
 
 #include "types.h"
 

--- a/third_party/tcplp/bsdtcp/tcp_input.c
+++ b/third_party/tcplp/bsdtcp/tcp_input.c
@@ -476,7 +476,7 @@ tcp_input(struct ip6_hdr* ip6, struct tcphdr* th, otMessage* msg, struct tcpcb* 
 
 	/*
 	 * samkumar: Logic that handled IPv4 was deleted below. I won't add a
-	 * comment everytime this is done, but I'm putting it here (one of the
+	 * comment every time this is done, but I'm putting it here (one of the
 	 * first instances of this) for clarity.
 	 */
 	iptos = (ntohl(ip6->ip6_flow) >> 20) & 0xff;
@@ -485,7 +485,7 @@ tcp_input(struct ip6_hdr* ip6, struct tcphdr* th, otMessage* msg, struct tcpcb* 
 	 * Check that TCP offset makes sense,
 	 * pull out TCP options and adjust length.		XXX
 	 */
-	off = th->th_off << 2;
+	off = (th->th_off_x2 >> TH_OFF_SHIFT) << 2;
 	if (off < sizeof (struct tcphdr) || off > tlen) {
 		goto drop;
 	}
@@ -1030,7 +1030,7 @@ tcp_do_segment(struct ip6_hdr* ip6, struct tcphdr *th, otMessage* msg,
 	 * Parse options on any incoming segment.
 	 */
 	tcp_dooptions(&to, (uint8_t *)(th + 1),
-	    (th->th_off << 2) - sizeof(struct tcphdr),
+	    ((th->th_off_x2 >> TH_OFF_SHIFT) << 2) - sizeof(struct tcphdr),
 	    (thflags & TH_SYN) ? TO_SYN : 0);
 
 	/*

--- a/third_party/tcplp/bsdtcp/tcp_output.c
+++ b/third_party/tcplp/bsdtcp/tcp_output.c
@@ -895,10 +895,11 @@ send:
 			size_t start_offset;
 			otLinkedBuffer* end;
 			size_t end_offset;
+			otLinkedBuffer* curr;
 			int rv = lbuf_getrange(&tp->sendbuf, off, len, &start, &start_offset, &end, &end_offset);
-			KASSERT(rv == 0, ("Reading send buffer out of range!\n"));
 			size_t message_offset = otMessageGetOffset(message) + sizeof(struct tcphdr) + optlen;
-			for (otLinkedBuffer* curr = start; curr != end->mNext; curr = curr->mNext) {
+			KASSERT(rv == 0, ("Reading send buffer out of range!\n"));
+			for (curr = start; curr != end->mNext; curr = curr->mNext) {
 				const uint8_t* data_to_copy = curr->mData;
 				size_t length_to_copy = curr->mLength;
 				if (curr == start) {

--- a/third_party/tcplp/bsdtcp/tcp_output.c
+++ b/third_party/tcplp/bsdtcp/tcp_output.c
@@ -1037,7 +1037,7 @@ send:
 	th->th_ack = htonl(tp->rcv_nxt);
 	if (optlen) {
 		bcopy(opt, th + 1, optlen);
-		th->th_off = (sizeof (struct tcphdr) + optlen) >> 2;
+		th->th_off_x2 = ((sizeof (struct tcphdr) + optlen) >> 2) << TH_OFF_SHIFT;
 	}
 	th->th_flags = flags;
 	/*

--- a/third_party/tcplp/bsdtcp/tcp_seq.h
+++ b/third_party/tcplp/bsdtcp/tcp_seq.h
@@ -30,8 +30,8 @@
  * $FreeBSD$
  */
 
-#ifndef _NETINET_TCP_SEQ_H_
-#define _NETINET_TCP_SEQ_H_
+#ifndef TCPLP_NETINET_TCP_SEQ_H_
+#define TCPLP_NETINET_TCP_SEQ_H_
 
 #include "../tcplp.h"
 

--- a/third_party/tcplp/bsdtcp/tcp_subr.c
+++ b/third_party/tcplp/bsdtcp/tcp_subr.c
@@ -48,12 +48,12 @@
 
 #include "tcp_const.h"
 
-/* samkumar: Eventually, replace this with OpenThread's random generator. */
-// A simple linear congruential number generator
-tcp_seq seed = (tcp_seq) 0xbeaddeed;
+/*
+ * samkumar: This is rewritten to have the host network stack to generate the
+ * ISN with appropriate randomness.
+ */
 tcp_seq tcp_new_isn(struct tcpcb* tp) {
-	seed = (((tcp_seq) 0xfaded011) * seed) + (tcp_seq) 0x1ead1eaf;
-	return seed;
+	return (uint32_t) tcplp_sys_generate_isn();
 }
 
 /*

--- a/third_party/tcplp/bsdtcp/tcp_subr.c
+++ b/third_party/tcplp/bsdtcp/tcp_subr.c
@@ -41,6 +41,7 @@
 #include "tcp_var.h"
 #include "tcp_seq.h"
 #include "tcp_timer.h"
+#include "sys/queue.h"
 #include "../lib/bitmap.h"
 #include "../lib/cbuf.h"
 #include "cc.h"
@@ -234,15 +235,16 @@ tcpip_fillheaders(struct tcpcb* tp, otMessageInfo* ip_ptr, void *tcp_ptr)
 	memcpy(&ip_ptr->mPeerAddr, &tp->faddr, sizeof(ip_ptr->mPeerAddr));
 
 	/* Fill in the TCP header */
-	/* samkumar: I kept the old code for ports commented out, for reference. */
+	/* samkumar: I kept the old code commented out, for reference. */
 	//th->th_sport = inp->inp_lport;
 	//th->th_dport = inp->inp_fport;
 	th->th_sport = tp->lport;
 	th->th_dport = tp->fport;
 	th->th_seq = 0;
 	th->th_ack = 0;
-	th->th_x2 = 0;
-	th->th_off = 5;
+	// th->th_x2 = 0;
+	// th->th_off = 5;
+	th->th_off_x2 = (5 << TH_OFF_SHIFT);
 	th->th_flags = 0;
 	th->th_win = 0;
 	th->th_urp = 0;
@@ -309,8 +311,10 @@ tcp_respond(struct tcpcb *tp, otInstance* instance, struct ip6_hdr* ip6gen, stru
 	nth->th_dport = thgen->th_sport;
 	nth->th_seq = htonl(seq);
 	nth->th_ack = htonl(ack);
-	nth->th_x2 = 0;
-	nth->th_off = sizeof(struct tcphdr) >> 2;
+	/* samkumar: original code for setting th_x2 and th_off, for reference. */
+	// nth->th_x2 = 0;
+	// nth->th_off = (sizeof (struct tcphdr) + optlen) >> 2;
+	nth->th_off_x2 = (sizeof(struct tcphdr) >> 2) << TH_OFF_SHIFT;
 	nth->th_flags = flags;
 	if (tp != NULL)
 		nth->th_win = htons((uint16_t) (win >> tp->rcv_scale));

--- a/third_party/tcplp/bsdtcp/tcp_timer.c
+++ b/third_party/tcplp/bsdtcp/tcp_timer.c
@@ -59,10 +59,11 @@ int V_tcp_pmtud_blackhole_activated_min_mss = 0;
 /*
  * samkumar: I changed these functions to accept "struct tcpcb* tp" their
  * argument instead of "void *xtp". This is possible since we're no longer
- * relying on FreeBSD's callout subsystem in TCPlp.
+ * relying on FreeBSD's callout subsystem in TCPlp. I also changed them to
+ * return 1 if the connection is dropped, or 0 otherwise.
  */
 
-void
+int
 tcp_timer_delack(struct tcpcb* tp)
 {
 	/* samkumar: I added this, to replace the code I removed below. */
@@ -80,9 +81,10 @@ tcp_timer_delack(struct tcpcb* tp)
 	 */
 	tp->t_flags |= TF_ACKNOW;
 	(void) tcp_output(tp);
+	return 0;
 }
 
-void
+int
 tcp_timer_keep(struct tcpcb* tp)
 {
 	uint32_t ticks = tcplp_sys_get_ticks();
@@ -158,17 +160,19 @@ tcp_timer_keep(struct tcpcb* tp)
 	 * that handled debug tracing/probes, vnet, and locking. I removed that
 	 * code.
 	 */
-	return;
+	return 0;
 
 dropit:
 	tp = tcp_drop(tp, ETIMEDOUT);
 	(void) tp; /* samkumar: prevent a compiler warning */
+	return 1;
 }
 
-void
+int
 tcp_timer_persist(struct tcpcb* tp)
 {
 	uint32_t ticks = tcplp_sys_get_ticks();
+	int dropped = 0;
 
 	/* samkumar: I added this, to replace the code I removed below. */
 	KASSERT(tpistimeractive(tp, TT_PERSIST), ("Persist timer running, but unmarked\n"));
@@ -202,6 +206,7 @@ tcp_timer_persist(struct tcpcb* tp)
 	    (ticks - tp->t_rcvtime >= tcp_maxpersistidle ||
 	     ticks - tp->t_rcvtime >= TCP_REXMTVAL(tp) * tcp_totbackoff)) {
 		tp = tcp_drop(tp, ETIMEDOUT);
+		dropped = 1;
 		goto out;
 	}
 
@@ -212,6 +217,7 @@ tcp_timer_persist(struct tcpcb* tp)
 	if (tp->t_state > TCPS_CLOSE_WAIT &&
 	    (ticks - tp->t_rcvtime) >= TCPTV_PERSMAX) {
 		tp = tcp_drop(tp, ETIMEDOUT);
+		dropped = 1;
 		goto out;
 	}
 
@@ -227,13 +233,14 @@ out:
 	 * tracing/probes, vnet, and locking. I removed that code.
 	 */
 	(void) tp; /* samkumar: prevent a compiler warning */
-	return;
+	return dropped;
 }
 
-void
+int
 tcp_timer_2msl(struct tcpcb* tp)
 {
 	uint32_t ticks = tcplp_sys_get_ticks();
+	int dropped = 0;
 
 	/* samkumar: I added this, to replace the code I removed below. */
 	KASSERT(tpistimeractive(tp, TT_2MSL), ("2MSL timer running, but unmarked\n"));
@@ -281,7 +288,8 @@ tcp_timer_2msl(struct tcpcb* tp)
 	if (tp->t_state == TCP6S_TIME_WAIT) {
 		tp = tcp_close(tp);
 		tcplp_sys_connection_lost(tp, CONN_LOST_NORMAL);
-		return;
+		dropped = 1;
+		return dropped;
 	}
 	/*
 	 * samkumar: This if statement also used to check that an inpcb is still
@@ -297,6 +305,7 @@ tcp_timer_2msl(struct tcpcb* tp)
 	    tpiscantrcv(tp)) {
 		tp = tcp_close(tp);
 		tcplp_sys_connection_lost(tp, CONN_LOST_NORMAL);
+		dropped = 1;
 	} else {
 		if (ticks - tp->t_rcvtime <= TP_MAXIDLE(tp)) {
 			/*
@@ -308,19 +317,22 @@ tcp_timer_2msl(struct tcpcb* tp)
 		} else {
 			tp = tcp_close(tp);
 			tcplp_sys_connection_lost(tp, CONN_LOST_NORMAL);
+			dropped = 1;
 		}
 	}
 	/*
 	 * samkumar: There used to be some code here that handled debug
 	 * tracing/probes, vnet, and locking. I removed that code.
 	 */
+	return dropped;
 }
 
-void
+int
 tcp_timer_rexmt(struct tcpcb *tp)
 {
 	int rexmt;
 	uint32_t ticks = tcplp_sys_get_ticks();
+	int dropped = 0;
 
 	/* samkumar: I added this, to replace the code I removed below. */
 	KASSERT(tpistimeractive(tp, TT_REXMT), ("Rexmt timer running, but unmarked\n"));
@@ -348,6 +360,7 @@ tcp_timer_rexmt(struct tcpcb *tp)
 
 		tp = tcp_drop(tp, tp->t_softerror ?
 			      tp->t_softerror : ETIMEDOUT);
+		dropped = 1;
 		goto out;
 	}
 	if (tp->t_state == TCPS_SYN_SENT) {
@@ -450,7 +463,7 @@ out:
 	 * tracing/probes, vnet, and locking. I removed that code.
 	 */
 	(void) tp; /* samkumar: Prevent a compiler warning */
-	return;
+	return dropped;
 }
 
 int

--- a/third_party/tcplp/bsdtcp/tcp_timer.h
+++ b/third_party/tcplp/bsdtcp/tcp_timer.h
@@ -154,11 +154,15 @@ static const int	tcp_backoff[TCP_MAXRXTSHIFT + 1] =
 
 static const int tcp_totbackoff = 2559;	/* sum of tcp_backoff[] */
 
-void tcp_timer_delack(struct tcpcb* tp);
-void tcp_timer_keep(struct tcpcb* tp);
-void tcp_timer_persist(struct tcpcb* tp);
-void tcp_timer_2msl(struct tcpcb* tp);
-void tcp_timer_rexmt(struct tcpcb *tp);
+/*
+ * samkumar: Changed return value to int to indicate whether connection was
+ * dropped or not.
+ */
+int tcp_timer_delack(struct tcpcb* tp);
+int tcp_timer_keep(struct tcpcb* tp);
+int tcp_timer_persist(struct tcpcb* tp);
+int tcp_timer_2msl(struct tcpcb* tp);
+int tcp_timer_rexmt(struct tcpcb *tp);
 int tcp_timer_active(struct tcpcb *tp, uint32_t timer_type);
 
 /*

--- a/third_party/tcplp/bsdtcp/tcp_timer.h
+++ b/third_party/tcplp/bsdtcp/tcp_timer.h
@@ -38,8 +38,8 @@
  * parameters) and global statistics (e.g. tcp_keepcnt).
  */
 
-#ifndef _NETINET_TCP_TIMER_H_
-#define _NETINET_TCP_TIMER_H_
+#ifndef TCPLP_NETINET_TCP_TIMER_H_
+#define TCPLP_NETINET_TCP_TIMER_H_
 
 #include "tcp_var.h"
 

--- a/third_party/tcplp/bsdtcp/tcp_timewait.c
+++ b/third_party/tcplp/bsdtcp/tcp_timewait.c
@@ -158,8 +158,7 @@ tcp_twrespond(struct tcpcb* tp, int flags)
 	nth->th_dport = tp->fport;
 	nth->th_seq = htonl(tp->snd_nxt);
 	nth->th_ack = htonl(tp->rcv_nxt);
-	nth->th_x2 = 0;
-	nth->th_off = (sizeof(struct tcphdr) + optlen) >> 2;
+	nth->th_off_x2 = ((sizeof(struct tcphdr) + optlen) >> 2) << TH_OFF_SHIFT;
 	nth->th_flags = flags;
 	nth->th_win = htons(tp->tw_last_win);
 	nth->th_urp = 0;

--- a/third_party/tcplp/bsdtcp/tcp_var.h
+++ b/third_party/tcplp/bsdtcp/tcp_var.h
@@ -30,8 +30,8 @@
  * $FreeBSD$
  */
 
-#ifndef _NETINET_TCP_VAR_H_
-#define _NETINET_TCP_VAR_H_
+#ifndef TCPLP_NETINET_TCP_VAR_H_
+#define TCPLP_NETINET_TCP_VAR_H_
 
 /* For memmove(). */
 #include <string.h>
@@ -49,8 +49,6 @@
 #include "tcp.h"
 #include "types.h"
 #include "ip6.h"
-
-#include "sys/queue.h"
 
 /* Implement byte-order-specific functions using OpenThread. */
 uint16_t tcplp_sys_hostswap16(uint16_t hostport);
@@ -104,7 +102,19 @@ struct sackhole {
 	tcp_seq start;		/* start seq no. of hole */
 	tcp_seq end;		/* end seq no. */
 	tcp_seq rxmit;		/* next seq. no in hole to be retransmitted */
-	TAILQ_ENTRY(sackhole) scblink;	/* scoreboard linkage */
+
+	/*
+	 * samkumar: I'm using this instead of the TAILQ_ENTRY macro to avoid
+	 * including sys/queue.h from this file. It's undesirable to include
+	 * sys/queue.h from this file because this file is part of the external
+	 * interface to TCPlp, and sys/queue.h pollutes the global namespace.
+	 * The original code that uses TAILQ_ENTRY is in a comment below.
+	 */
+	struct {
+		struct sackhole *tqe_next;	/* next element */
+		struct sackhole **tqe_prev;	/* address of previous next element */
+	} scblink;	/* scoreboard linkage */
+	// TAILQ_ENTRY(sackhole) scblink;	/* scoreboard linkage */
 };
 
 struct sackhint {
@@ -200,7 +210,7 @@ struct tcpcb {
 	int	t_segqlen;		/* segment reassembly queue length */
 #endif
 
-	int	t_dupacks;		/* consecutive dup acks recd */
+	int32_t	t_dupacks;		/* consecutive dup acks recd */
 
 #if 0
 	struct tcp_timer *t_timers;	/* All the TCP timers in one struct */
@@ -228,8 +238,8 @@ struct tcpcb {
 
 	tcp_seq	rcv_nxt;		/* receive next */
 	tcp_seq	rcv_adv;		/* advertised window */
-	uint64_t	rcv_wnd;		/* receive window */
 	tcp_seq	rcv_up;			/* receive urgent pointer */
+	uint64_t	rcv_wnd;		/* receive window */
 
 	uint64_t	snd_wnd;		/* send window */
 	uint64_t	snd_cwnd;		/* congestion-controlled window */
@@ -251,22 +261,37 @@ struct tcpcb {
 //	uint32_t	t_bw_spare1;		/* unused */
 //	tcp_seq	t_bw_spare2;		/* unused */
 
-	int	t_rxtcur;		/* current retransmit value (ticks) */
+	int32_t	t_rxtcur;		/* current retransmit value (ticks) */
 	uint32_t	t_maxseg;		/* maximum segment size */
-	int	t_srtt;			/* smoothed round-trip time */
-	int	t_rttvar;		/* variance in round-trip time */
+	int32_t	t_srtt;			/* smoothed round-trip time */
+	int32_t	t_rttvar;		/* variance in round-trip time */
 
-	int	t_rxtshift;		/* log(2) of rexmt exp. backoff */
+	int32_t	t_rxtshift;		/* log(2) of rexmt exp. backoff */
 	uint32_t	t_rttmin;		/* minimum rtt allowed */
 	uint32_t	t_rttbest;		/* best rtt we've seen */
+
+	int32_t	t_softerror;		/* possible error not yet reported */
+
 	uint64_t	t_rttupdated;		/* number of times rtt sampled */
 	uint64_t	max_sndwnd;		/* largest window peer has offered */
-
-	int	t_softerror;		/* possible error not yet reported */
 /* out-of-band data */
 //	char	t_oobflags;		/* have some */
 //	char	t_iobc;			/* input character */
+
+	tcp_seq	last_ack_sent;
+/* experimental */
+	tcp_seq	snd_recover_prev;	/* snd_recover prior to retransmit */
+	uint64_t	snd_cwnd_prev;		/* cwnd prior to retransmit */
+	uint64_t	snd_ssthresh_prev;	/* ssthresh prior to retransmit */
+//	int	t_sndzerowin;		/* zero-window updates sent */
+	uint32_t	t_badrxtwin;		/* window for retransmit recovery */
+	uint8_t	snd_limited;		/* segments limited transmitted */
+
 /* RFC 1323 variables */
+/*
+ * samkumar: Moved "RFC 1323 variables" after "experimental" to reduce
+ * compiler-inserted padding.
+ */
 	uint8_t	snd_scale;		/* window scaling for send window */
 	uint8_t	rcv_scale;		/* window scaling for recv window */
 	uint8_t	request_r_scale;	/* pending window scaling */
@@ -274,27 +299,28 @@ struct tcpcb {
 	uint32_t	ts_recent_age;		/* when last updated */
 	u_int32_t  ts_offset;		/* our timestamp offset */
 
-	tcp_seq	last_ack_sent;
-/* experimental */
-	uint64_t	snd_cwnd_prev;		/* cwnd prior to retransmit */
-	uint64_t	snd_ssthresh_prev;	/* ssthresh prior to retransmit */
-	tcp_seq	snd_recover_prev;	/* snd_recover prior to retransmit */
-//	int	t_sndzerowin;		/* zero-window updates sent */
-	uint32_t	t_badrxtwin;		/* window for retransmit recovery */
-	uint8_t	snd_limited;		/* segments limited transmitted */
-
 /* SACK related state */
-	int	snd_numholes;		/* number of holes seen by sender */
-	TAILQ_HEAD(sackhole_head, sackhole) snd_holes;
+	int32_t	snd_numholes;		/* number of holes seen by sender */
+	/*
+	 * samkumar: I replaced the TAILQ_HEAD macro invocation (commented out
+	 * below) with the code it stands for, to avoid having to #include
+	 * sys/queue.h in this file. See the comment above in struct sackhole for
+	 * more info.
+	 */
+	struct sackhole_head {
+		struct sackhole *tqh_first;	/* first element */
+		struct sackhole **tqh_last;	/* addr of last next element */
+	} snd_holes;
+	// TAILQ_HEAD(sackhole_head, sackhole) snd_holes;
 					/* SACK scoreboard (sorted) */
 	tcp_seq	snd_fack;		/* last seq number(+1) sack'd by rcv'r*/
-	int	rcv_numsacks;		/* # distinct sack blks present */
+	int32_t	rcv_numsacks;		/* # distinct sack blks present */
 	struct sackblk sackblks[MAX_SACK_BLKS]; /* seq nos. of sack blocks */
 	tcp_seq sack_newdata;		/* New data xmitted in this recovery
 					   episode starts at this seq number */
 	struct sackhint	sackhint;	/* SACK scoreboard hint */
 
-	int	t_rttlow;		/* smallest observed RTT */
+	int32_t	t_rttlow;		/* smallest observed RTT */
 #if 0
 	u_int32_t	rfbuf_ts;	/* recv buffer autoscaling timestamp */
 	int	rfbuf_cnt;		/* recv buffer autoscaling byte count */
@@ -303,7 +329,7 @@ struct tcpcb {
 //	int	t_sndrexmitpack;	/* retransmit packets sent */
 //	int	t_rcvoopack;		/* out-of-order packets received */
 //	void	*t_toe;			/* TOE pcb pointer */
-	int	t_bytes_acked;		/* # bytes acked during current RTT */
+	int32_t	t_bytes_acked;		/* # bytes acked during current RTT */
 //	struct cc_algo	*cc_algo;	/* congestion control algorithm */
 	struct cc_var	ccv[1];		/* congestion control specific vars */
 #if 0

--- a/third_party/tcplp/bsdtcp/types.h
+++ b/third_party/tcplp/bsdtcp/types.h
@@ -46,8 +46,8 @@
  * standard integer types (uint8_t, uint16_t, etc.).
  */
 
-#ifndef _SYS_TYPES_H_
-#define	_SYS_TYPES_H_
+#ifndef TCPLP_SYS_TYPES_H_
+#define TCPLP_SYS_TYPES_H_
 
 #include <stdint.h>
 

--- a/third_party/tcplp/tcplp.h
+++ b/third_party/tcplp/tcplp.h
@@ -50,14 +50,6 @@ extern "C" {
 #include <openthread/ip6.h>
 #include <openthread/message.h>
 
-#define hz 1000 // number of ticks per second
-#define MICROS_PER_TICK 1000 // number of microseconds per tick
-
-#define FRAMES_PER_SEG 5
-#define FRAMECAP_6LOWPAN (122 - 11 - 5)
-
-#define IP6HDR_SIZE (2 + 1 + 1 + 16 + 16) // IPHC header (2) + Next header (1) + Hop count (1) + Dest. addr (16) + Src. addr (16)
-
 #define RELOOKUP_REQUIRED -1
 #define CONN_LOST_NORMAL 0
 
@@ -85,6 +77,7 @@ void tcplp_sys_connection_lost(struct tcpcb* tcb, uint8_t errnum);
 void tcplp_sys_on_state_change(struct tcpcb* tcb, int newstate);
 void tcplp_sys_log(const char* format, ...);
 bool tcplp_sys_autobind(otInstance *aInstance, const otSockAddr *aPeer, otSockAddr *aToBind, bool aBindAddress, bool aBindPort);
+uint32_t tcplp_sys_generate_isn();
 
 #ifdef __cplusplus
 } // extern "C"


### PR DESCRIPTION
This is the ninth and final pull request in a series of pull requests (after #6744, #6770, #6790, #6857, #6885, #6925, #6926, and #7074) bringing TCPlp to OpenThread (see #6456). I'm making a series of small pull requests so that it's easier for the OpenThread community to review the code.

This pull request contributes support for the OpenThread TCP API (see #6411 and #6491) using the FreeBSD-derived functions from #7074. It is a rewrite of TCPlp's interface layer to support OpenThread's TCP API instead of the API used previously by TCPlp. Once this pull request is merged, the OpenThread CLI's TCP utility will work, and most of the OpenThread TCP API will work.

This pull request completes the sequence of pull requests bringing TCPlp to OpenThread. In previous pull requests, I pointed to #6650 for a preview of a working version of TCPlp in OpenThread. At this point, however, all functionality in #6650 is either merged into OpenThread's `main` branch or is included in this pull request. Therefore, #6650 is now obsolete and should be closed once this pull request is merged. To preview a working version of TCPlp in OpenThread, you should simply use the code in this pull request. I've done some testing and it seems to work fine. If you would like to try out TCP in OpenThread using the code in this pull request, the video I posted in #6650 (https://youtu.be/ppZ784YUKlI) might help you get started.

The remaining API features that are not yet supported, even with this pull request, include:
* TCP Fast Open
* `otTcpReceiveContiguify`

These features were not present in the original TCPlp code, so I feel it is most appropriate to contribute support for these features in other pull requests, separate from the pull requests contributing support for TCPlp.