### PR TITLE
[tests] verify the number of published meshcop services

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
+++ b/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
@@ -99,15 +99,28 @@ class PublishMeshCopService(thread_cert.TestCase):
         self.check_meshcop_service(br1, host)
 
         # verify that there are two meshcop services
+        br2.set_network_name('ot-br2-1')
         br2.start()
         br2.disable_backbone_router()
         br2.enable_br()
         self.simulator.go(25)
+
         service_instances = host.browse_mdns_services('_meshcop._udp')
         self.assertEqual(len(service_instances), 2)
         br1_service = self.check_meshcop_service(br1, host)
         br2_service = self.check_meshcop_service(br2, host)
         self.assertNotEqual(br1_service['host'], br2_service['host'])
+
+        br1.stop_otbr_service()
+        self.simulator.go(5)
+        br2.enable_backbone_router()
+        self.simulator.go(5)
+        self.assertEqual(len(host.browse_mdns_services('_meshcop._udp')), 1)
+        br1.start_otbr_service()
+        self.simulator.go(10)
+        self.assertEqual(len(host.browse_mdns_services('_meshcop._udp')), 2)
+        self.check_meshcop_service(br1, host)
+        self.check_meshcop_service(br2, host)
 
     def check_meshcop_service(self, br, host):
         services = self.discover_all_meshcop_services(host)

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -137,6 +137,21 @@ class OtbrDocker:
 
         assert launch_ok
 
+        self.start_ot_ctl()
+
+    def __repr__(self):
+        return f'OtbrDocker<{self.nodeid}>'
+
+    def start_otbr_service(self):
+        self.bash('service otbr-agent start')
+        self.simulator.go(3)
+        self.start_ot_ctl()
+
+    def stop_otbr_service(self):
+        self.stop_ot_ctl()
+        self.bash('service otbr-agent stop')
+
+    def start_ot_ctl(self):
         cmd = f'docker exec -i {self._docker_name} ot-ctl'
         self.pexpect = pexpect.popen_spawn.PopenSpawn(cmd, timeout=30)
         if self.verbose:
@@ -152,8 +167,10 @@ class OtbrDocker:
             except pexpect.TIMEOUT:
                 timeout -= 0.1
 
-    def __repr__(self):
-        return f'OtbrDocker<{self.nodeid}>'
+    def stop_ot_ctl(self):
+        self.pexpect.sendeof()
+        self.pexpect.wait()
+        self.pexpect.proc.kill()
 
     def destroy(self):
         logging.info("Destroying %s", self)


### PR DESCRIPTION
There was a bug that avahi publisher may accidentally publish redundant meshcop services and leave the previous published one dangling. This PR https://github.com/openthread/ot-br-posix/pull/1104 fixes the bug.
