### PR TITLE
[thci] register multicast addresses on the host side

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1582,7 +1582,10 @@ class OpenThreadTHCI(object):
         self.__isUdpOpened = False
         self.IsBackboneRouter = False
         self.IsHost = False
-        self._registeredMulticastAddrs = []
+
+        # remove stale multicast addresses
+        if self.IsBorderRouter:
+            self.stopListeningToAddr('')
 
         # BBR dataset
         self.bbrSeqNum = random.randint(0, 254)  # random seqnum except 255, so that BBR-TC-02 never need re-run

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1585,7 +1585,7 @@ class OpenThreadTHCI(object):
 
         # remove stale multicast addresses
         if self.IsBorderRouter:
-            self.stopListeningToAddr('')
+            self.stopListeningToAddrAll()
 
         # BBR dataset
         self.bbrSeqNum = random.randint(0, 254)  # random seqnum except 255, so that BBR-TC-02 never need re-run

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1582,6 +1582,7 @@ class OpenThreadTHCI(object):
         self.__isUdpOpened = False
         self.IsBackboneRouter = False
         self.IsHost = False
+        self._registeredMulticastAddrs = []
 
         # BBR dataset
         self.bbrSeqNum = random.randint(0, 254)  # random seqnum except 255, so that BBR-TC-02 never need re-run
@@ -3455,20 +3456,14 @@ class OpenThreadTHCI(object):
     def stopListeningToAddr(self, sAddr):
         print('%s call stopListeningToAddr' % self.port)
 
-        # convert to list for single element, for possible extension
-        # requirements.
-        if not isinstance(sAddr, list):
-            sAddr = [sAddr]
-
-        for addr in sAddr:
-            cmd = 'ipmaddr del ' + addr
-            try:
-                self.__executeCommand(cmd)
-            except CommandError as ex:
-                if ex.code == OT_ERROR_ALREADY:
-                    pass
-                else:
-                    raise
+        cmd = 'ipmaddr del ' + sAddr
+        try:
+            self.__executeCommand(cmd)
+        except CommandError as ex:
+            if ex.code == OT_ERROR_ALREADY:
+                pass
+            else:
+                raise
 
         return True
 
@@ -3479,40 +3474,16 @@ class OpenThreadTHCI(object):
         Args:
             sAddr   : str : Multicast address to be subscribed and notified OTA.
         """
-        # convert to list for single element, for possible extension
-        # requirements.
-        if not isinstance(sAddr, list):
-            sAddr = [sAddr]
 
-        if self.externalCommissioner is not None:
-            self.externalCommissioner.MLR(sAddr, timeout)
-            return True
+        cmd = 'ipmaddr add ' + str(sAddr)
 
-        # subscribe address one by one
-        for addr in sAddr:
-            cmd = 'ipmaddr add ' + str(addr)
-
-            try:
-                self.__executeCommand(cmd)
-            except CommandError as ex:
-                if ex.code == OT_ERROR_ALREADY:
-                    pass
-                else:
-                    raise
-
-    @API
-    def deregisterMulticast(self, sAddr):
-        """
-        Unsubscribe to a given IPv6 address.
-        Only used by External Commissioner.
-
-        Args:
-            sAddr   : str : Multicast address to be unsubscribed.
-        """
-        if not isinstance(sAddr, list):
-            sAddr = [sAddr]
-        self.externalCommissioner.MLR(sAddr, 0)
-        return True
+        try:
+            self.__executeCommand(cmd)
+        except CommandError as ex:
+            if ex.code == OT_ERROR_ALREADY:
+                pass
+            else:
+                raise
 
     @API
     def getMlrLogs(self):

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -313,8 +313,7 @@ class OpenThread_BR(OpenThreadTHCI, IThci):
             self.bash('sudo ip -6 addr del 910b::1 dev eth0 || true')
             self.bash('sudo ip -6 addr del fd00:7d03:7d03:7d03::1 dev eth0 || true')
 
-        for maddr in self._registeredMulticastAddrs:
-            self.stopListeningToAddr(maddr)
+        self.stopListeningToAddr('')
 
     def _deviceAfterReset(self):
         self.__dumpSyslog()
@@ -678,31 +677,24 @@ EOF"
             self.externalCommissioner.MLR([sAddr], timeout)
             return True
 
-        # Register
         cmd = 'sudo nohup ~/repo/openthread/tests/scripts/thread-cert/mcast6.py wpan0 %s' % sAddr
         cmd = cmd + ' > /dev/null 2>&1 &'
         self.bash(cmd)
-
-        # Add route
-        cmd = 'sudo ip -6 route add %s dev wpan0' % sAddr
-        self.bash(cmd)
-
-        self._registeredMulticastAddrs.append(sAddr)
 
         return True
 
     # Override stopListeningToAddr
     @API
     def stopListeningToAddr(self, sAddr):
-        # De-register
+        """
+        Unsubscribe to a given IPv6 address which was subscribed earlier wiht `registerMulticast`.
+
+        Args:
+            sAddr   : str : Multicast address to be unsubscribed. Use an empty string to unsubscribe
+                            all the active multicast addresses.
+        """
         cmd = 'sudo pkill -f mcast6.*%s' % sAddr
         self.bash(cmd)
-
-        # Remove route
-        cmd = 'sudo ip -6 route del %s dev wpan0' % sAddr
-        self.bash(cmd)
-
-        self._registeredMulticastAddrs.remove(sAddr)
 
     @API
     def deregisterMulticast(self, sAddr):

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -313,7 +313,7 @@ class OpenThread_BR(OpenThreadTHCI, IThci):
             self.bash('sudo ip -6 addr del 910b::1 dev eth0 || true')
             self.bash('sudo ip -6 addr del fd00:7d03:7d03:7d03::1 dev eth0 || true')
 
-        self.stopListeningToAddr('')
+        self.stopListeningToAddrAll()
 
     def _deviceAfterReset(self):
         self.__dumpSyslog()
@@ -695,6 +695,9 @@ EOF"
         """
         cmd = 'sudo pkill -f mcast6.*%s' % sAddr
         self.bash(cmd)
+
+    def stopListeningToAddrAll(self):
+        return self.stopListeningToAddr('')
 
     @API
     def deregisterMulticast(self, sAddr):


### PR DESCRIPTION
Make use of the `mcast6.py` application in order to listen to multicast traffic on the host side when required by the harness.