### PR TITLE
[thci] fix issue with not initialized isPowerDown flag

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -402,6 +402,7 @@ class OpenThreadTHCI(object):
 
         self.UIStatusMsg = ''
         self.AutoDUTEnable = False
+        self.isPowerDown = False
         self._is_net = False  # whether device is through ser2net
         self.logStatus = {
             'stop': 'stop',


### PR DESCRIPTION
When the GRL starts, it calls initialize() reset() method on each device. Reset method call fails due to missing (uninitialized) attribute 'isPowerDown'.