### PR TITLE
Revert "[github-actions] push `README.md` to Dockerhub"

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -95,14 +95,3 @@ jobs:
       if: always() && github.repository == 'openthread/openthread' && github.event_name != 'pull_request'
       run: |
         docker buildx imagetools inspect ${{ steps.prepare.outputs.docker_image }}:${{ steps.prepare.outputs.version }}
-
-    - name: Push README
-      uses: christian-korneck/update-container-description-action@v1
-      if: success() && github.repository == 'openthread/openthread' && github.event_name != 'pull_request'
-      env:
-        DOCKER_USER: ${{ secrets.DOCKER_USERNAME }}
-        DOCKER_PASS: ${{ secrets.DOCKER_PASSWORD }}
-      with:
-        destination_container_repo: openthread/${{ matrix.docker_name }}
-        provider: dockerhub
-        readme_file: 'README.md'


### PR DESCRIPTION
Reverts openthread/openthread#7194

Current method does not work with personal access tokens.

> level=error msg="error pushing readme to repo server. See error message below. Run with \"--debug\" for more details. \n\nerror pushing README, bad status code for response: 403 FORBIDDEN. Server responded: \"access to the resource is forbidden with personal access token\". Try \"docker logout\" and \"docker login\". You cannot use a personal access token to log in and must use username and password. If you have 2FA auth enabled in Dockerhub you'll need to disable it for this tool to work. (This is an unfortunate Dockerhub limitation, see docs for more infos.)"

https://github.com/openthread/openthread/runs/4304604819?check_suite_focus=true