### PR TITLE
[mesh-forwarder] ensure message allocation with correct priority

### DIFF
--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -805,7 +805,7 @@ void MeshForwarder::HandleMesh(uint8_t *             aFrame,
         meshHeader.DecrementHopsLeft();
 
         GetForwardFramePriority(aFrame, aFrameLength, meshSource, meshDest, priority);
-        message = Get<MessagePool>().New(Message::kType6lowpan, priority);
+        message = Get<MessagePool>().New(Message::kType6lowpan, /* aReserveHeader */ 0, priority);
         VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
         SuccessOrExit(error = message->SetLength(meshHeader.GetHeaderLength() + aFrameLength));


### PR DESCRIPTION
This commit fixes the incorrect call to `MessagePool::New()` to
allocate a message in `MeshForwarder::HandleMesh()` method. The
existing code calls `New(Message::kType6lowpan, priority)` with two
parameters which maps to the flavor `New()` method with three
parameters with last one (`Message::Settings`) being optional
(having a default value). Basically, the existing code treats the
`priority` (second argument) as `aReserveHeader` parameter in the
`New()` instead of the message priority.

-------

_A bit more detail on this_:

We have two flavors of `MessagePool::New()`:
```c++
    Message *New(Message::Type aType, uint16_t aReserveHeader, Message::Priority aPriority);

    Message *New(Message::Type            aType,
                 uint16_t                 aReserveHeader,
                 const Message::Settings &aSettings = Message::Settings::GetDefault());
```

The second one has an optional paramter (uses default `Settings` if not provided).

The `New(Message::kType6lowpan, priority)` was intended to call the first one, but actually calls the second one, treating the `priority` as `aReserveHeader` and then using the default `Message::Settings`.

I think this was added from initial implementation of of QoS feature from [PR#3317]( https://github.com/openthread/openthread/pull/3317/files#diff-f13b9a6272f4eccc25573287d08108c30177064ca9891774c6e513b89ac8c0f3L970).

I think to avoid in future, it may be helpful to consider removing the first flavor and/or may be using  different names or change order of parameters, etc.
