### PR TITLE
[tests] use xa instead of dd in the test case

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_dnssd_server.py
+++ b/tests/scripts/thread-cert/border_router/test_dnssd_server.py
@@ -239,7 +239,7 @@ class TestDnssdServerOnBr(thread_cert.TestCase):
                 'ADDITIONAL': [
                     (dp_instance_name, 'IN', 'SRV', 0, 0, check_border_agent_port, dp_hostname),
                     (dp_instance_name, 'IN', 'TXT', lambda txt: (isinstance(txt, dict) and txt.get(
-                        'nn') == network_name and 'xp' in txt and 'tv' in txt and 'dd' in txt)),
+                        'nn') == network_name and 'xp' in txt and 'tv' in txt and 'xa' in txt)),
                 ],
             })
 
@@ -259,7 +259,7 @@ class TestDnssdServerOnBr(thread_cert.TestCase):
                 'QUESTION': [(dp_instance_name, 'IN', 'SRV'),],
                 'ANSWER': [(dp_instance_name, 'IN', 'SRV', 0, 0, check_border_agent_port, dp_hostname),],
                 'ADDITIONAL': [(dp_instance_name, 'IN', 'TXT', lambda txt: (isinstance(txt, dict) and txt.get(
-                    'nn') == network_name and 'xp' in txt and 'tv' in txt and 'dd' in txt)),],
+                    'nn') == network_name and 'xp' in txt and 'tv' in txt and 'xa' in txt)),],
             })
 
         dig_result = digger.dns_dig(server_addr, dp_instance_name, 'TXT')
@@ -267,7 +267,7 @@ class TestDnssdServerOnBr(thread_cert.TestCase):
             dig_result, {
                 'QUESTION': [(dp_instance_name, 'IN', 'TXT'),],
                 'ANSWER': [(dp_instance_name, 'IN', 'TXT', lambda txt: (isinstance(txt, dict) and txt.get(
-                    'nn') == network_name and 'xp' in txt and 'tv' in txt and 'dd' in txt)),],
+                    'nn') == network_name and 'xp' in txt and 'tv' in txt and 'xa' in txt)),],
                 'ADDITIONAL': [(dp_instance_name, 'IN', 'SRV', 0, 0, check_border_agent_port, dp_hostname),],
             })
 


### PR DESCRIPTION
We are switching from dd to xa to conform the latest spec.

Depends-On: openthread/ot-br-posix#1111