### PR TITLE
[cli] add option to disable prompt

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -4976,6 +4976,7 @@ void Interpreter::Initialize(otInstance *aInstance, otCliOutputCallback aCallbac
 
 void Interpreter::OutputPrompt(void)
 {
+#if OPENTHREAD_CONFIG_CLI_PROMPT_ENABLE
     static const char sPrompt[] = "> ";
 
     // The `OutputFormat()` below is adding the prompt which is not
@@ -4986,6 +4987,7 @@ void Interpreter::OutputPrompt(void)
     SetEmittingCommandOutput(false);
     OutputFormat("%s", sPrompt);
     SetEmittingCommandOutput(true);
+#endif // OPENTHREAD_CONFIG_CLI_PROMPT_ENABLE
 }
 
 void Interpreter::HandleTimer(Timer &aTimer)

--- a/src/cli/cli_config.h
+++ b/src/cli/cli_config.h
@@ -113,4 +113,17 @@
 #define OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LOG_STRING_SIZE OPENTHREAD_CONFIG_CLI_MAX_LINE_LENGTH
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_CLI_PROMPT_ENABLE
+ *
+ * Enable CLI prompt.
+ *
+ * When enabled, the CLI will print prompt on the output after processing a command.
+ * Otherwise, no prompt is added to the output.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_CLI_PROMPT_ENABLE
+#define OPENTHREAD_CONFIG_CLI_PROMPT_ENABLE 1
+#endif
+
 #endif // CONFIG_CLI_H_


### PR DESCRIPTION
After changes in https://github.com/openthread/openthread/commit/6153855ae06f95903177d040dfc6fff994faf505, CLI prompt is printed on every CLI backend, not only CLI UART.

When running OT CLI in Zephyr, it's not desired to print a prompt after executing a command, as OT CLI is tightly integrated with Zephyr shell module which provides its own prompt.

Add a config option which allows to disable CLI prompt on the output.

Signed-off-by: Robert Lubos <robert.lubos@nordicsemi.no>