### PR TITLE
[message] simplify method for allocating new message from pool

### DIFF
--- a/src/core/coap/coap_secure.cpp
+++ b/src/core/coap/coap_secure.cpp
@@ -189,7 +189,7 @@ void CoapSecure::HandleDtlsReceive(uint8_t *aBuf, uint16_t aLength)
 {
     ot::Message *message = nullptr;
 
-    VerifyOrExit((message = Get<MessagePool>().New(Message::kTypeIp6, Message::GetHelpDataReserved())) != nullptr);
+    VerifyOrExit((message = Get<MessagePool>().Allocate(Message::kTypeIp6, Message::GetHelpDataReserved())) != nullptr);
     SuccessOrExit(message->AppendBytes(aBuf, aLength));
 
     CoapBase::Receive(*message, mDtls.GetMessageInfo());

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -346,13 +346,24 @@ public:
     {
     public:
         /**
-         * This constructor initializes the Settings object.
+         * This constructor initializes the `Settings` object.
          *
          * @param[in]  aSecurityMode  A link security mode.
          * @param[in]  aPriority      A message priority.
          *
          */
         Settings(LinkSecurityMode aSecurityMode, Priority aPriority);
+
+        /**
+         * This constructor initializes the `Settings` with a given message priority and link security enabled.
+         *
+         * @param[in]  aPriority      A message priority.
+         *
+         */
+        explicit Settings(Priority aPriority)
+            : Settings(kWithLinkSecurity, aPriority)
+        {
+        }
 
         /**
          * This method gets the message priority.
@@ -1461,21 +1472,7 @@ public:
     explicit MessagePool(Instance &aInstance);
 
     /**
-     * This method is used to obtain a new message.
-     *
-     * The link security is enabled by default on the newly obtained message.
-     *
-     * @param[in]  aType           The message type.
-     * @param[in]  aReserveHeader  The number of header bytes to reserve.
-     * @param[in]  aPriority       The priority level of the message.
-     *
-     * @returns A pointer to the message or nullptr if no message buffers are available.
-     *
-     */
-    Message *New(Message::Type aType, uint16_t aReserveHeader, Message::Priority aPriority);
-
-    /**
-     * This method is used to obtain a new message with specified settings.
+     * This method allocates a new message with specified settings.
      *
      * @param[in]  aType           The message type.
      * @param[in]  aReserveHeader  The number of header bytes to reserve.
@@ -1484,9 +1481,9 @@ public:
      * @returns A pointer to the message or nullptr if no message buffers are available.
      *
      */
-    Message *New(Message::Type            aType,
-                 uint16_t                 aReserveHeader,
-                 const Message::Settings &aSettings = Message::Settings::GetDefault());
+    Message *Allocate(Message::Type            aType,
+                      uint16_t                 aReserveHeader = 0,
+                      const Message::Settings &aSettings      = Message::Settings::GetDefault());
 
     /**
      * This method is used to free a message and return all message buffers to the buffer pool.

--- a/src/core/meshcop/dataset_updater.cpp
+++ b/src/core/meshcop/dataset_updater.cpp
@@ -65,7 +65,7 @@ Error DatasetUpdater::RequestUpdate(const MeshCoP::Dataset::Info &aDataset, Call
     VerifyOrExit(!aDataset.IsActiveTimestampPresent() && !aDataset.IsPendingTimestampPresent(),
                  error = kErrorInvalidArgs);
 
-    message = Get<MessagePool>().New(Message::kTypeOther, 0);
+    message = Get<MessagePool>().Allocate(Message::kTypeOther);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = message->Append(aDataset));

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -222,7 +222,7 @@ exit:
 void JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessageInfo, const Kek &aKek)
 {
     Error                 error   = kErrorNone;
-    Message *             message = Get<MessagePool>().New(Message::kTypeOther, 0);
+    Message *             message = Get<MessagePool>().Allocate(Message::kTypeOther);
     JoinerEntrustMetadata metadata;
 
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -728,7 +728,7 @@ Error Client::AllocateQuery(const QueryInfo &aInfo, const char *aLabel, const ch
 {
     Error error = kErrorNone;
 
-    aQuery = Get<MessagePool>().New(Message::kTypeOther, /* aReserveHeader */ 0);
+    aQuery = Get<MessagePool>().Allocate(Message::kTypeOther);
     VerifyOrExit(aQuery != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = aQuery->Append(aInfo));

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -80,13 +80,13 @@ Ip6::Ip6(Instance &aInstance)
 
 Message *Ip6::NewMessage(uint16_t aReserved, const Message::Settings &aSettings)
 {
-    return Get<MessagePool>().New(Message::kTypeIp6,
-                                  sizeof(Header) + sizeof(HopByHopHeader) + sizeof(OptionMpl) + aReserved, aSettings);
+    return Get<MessagePool>().Allocate(
+        Message::kTypeIp6, sizeof(Header) + sizeof(HopByHopHeader) + sizeof(OptionMpl) + aReserved, aSettings);
 }
 
 Message *Ip6::NewMessage(const uint8_t *aData, uint16_t aDataLength, const Message::Settings &aSettings)
 {
-    Message *message = Get<MessagePool>().New(Message::kTypeIp6, 0, aSettings);
+    Message *message = Get<MessagePool>().Allocate(Message::kTypeIp6, /* aReserveHeader */ 0, aSettings);
 
     VerifyOrExit(message != nullptr);
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1400,7 +1400,7 @@ Error MeshForwarder::FrameToMessage(const uint8_t *     aFrame,
     error = GetFramePriority(aFrame, aFrameLength, aMacSource, aMacDest, priority);
     SuccessOrExit(error);
 
-    aMessage = Get<MessagePool>().New(Message::kTypeIp6, 0, priority);
+    aMessage = Get<MessagePool>().Allocate(Message::kTypeIp6, /* aReserveHeader */ 0, Message::Settings(priority));
     VerifyOrExit(aMessage, error = kErrorNoBufs);
 
     headerLength =
@@ -1547,7 +1547,7 @@ Error MeshForwarder::SendEmptyMessage(void)
                      Get<Mle::MleRouter>().GetParent().IsStateValidOrRestoring(),
                  error = kErrorInvalidState);
 
-    message = Get<MessagePool>().New(Message::kTypeMacEmptyData, 0);
+    message = Get<MessagePool>().Allocate(Message::kTypeMacEmptyData);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
     SuccessOrExit(error = SendMessage(*message));

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -805,7 +805,8 @@ void MeshForwarder::HandleMesh(uint8_t *             aFrame,
         meshHeader.DecrementHopsLeft();
 
         GetForwardFramePriority(aFrame, aFrameLength, meshSource, meshDest, priority);
-        message = Get<MessagePool>().New(Message::kType6lowpan, /* aReserveHeader */ 0, priority);
+        message =
+            Get<MessagePool>().Allocate(Message::kType6lowpan, /* aReserveHeader */ 0, Message::Settings(priority));
         VerifyOrExit(message != nullptr, error = kErrorNoBufs);
 
         SuccessOrExit(error = message->SetLength(meshHeader.GetHeaderLength() + aFrameLength));

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -80,7 +80,7 @@ void ChildSupervisor::SendMessage(Child &aChild)
 
     VerifyOrExit(aChild.GetIndirectMessageCount() == 0);
 
-    message = Get<MessagePool>().New(Message::kTypeSupervision, sizeof(uint8_t));
+    message = Get<MessagePool>().Allocate(Message::kTypeSupervision, sizeof(uint8_t));
     VerifyOrExit(message != nullptr);
 
     // Supervision message is an empty payload 15.4 data frame.

--- a/tests/unit/test_dns.cpp
+++ b/tests/unit/test_dns.cpp
@@ -142,7 +142,7 @@ void TestDnsName(void)
     VerifyOrQuit(instance != nullptr, "Null OpenThread instance");
 
     messagePool = &instance->Get<MessagePool>();
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr, "Message::New failed");
+    VerifyOrQuit((message = messagePool->Allocate(Message::kTypeIp6)) != nullptr);
 
     message->SetOffset(0);
 
@@ -468,7 +468,7 @@ void TestDnsCompressedName(void)
     VerifyOrQuit(instance != nullptr, "Null OpenThread instance");
 
     messagePool = &instance->Get<MessagePool>();
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
+    VerifyOrQuit((message = messagePool->Allocate(Message::kTypeIp6)) != nullptr);
 
     // Append name1 "F.ISI.ARPA"
 
@@ -729,7 +729,7 @@ void TestDnsCompressedName(void)
     printf("----------------------------------------------------------------\n");
     printf("Append names from one message to another\n");
 
-    VerifyOrQuit((message2 = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
+    VerifyOrQuit((message2 = messagePool->Allocate(Message::kTypeIp6)) != nullptr);
 
     dnsName1.SetFromMessage(*message, name1Offset);
     dnsName2.SetFromMessage(*message, name2Offset);
@@ -830,7 +830,7 @@ void TestHeaderAndResourceRecords(void)
     VerifyOrQuit(instance != nullptr, "Null OpenThread instance");
 
     messagePool = &instance->Get<MessagePool>();
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
+    VerifyOrQuit((message = messagePool->Allocate(Message::kTypeIp6)) != nullptr);
 
     printf("----------------------------------------------------------------\n");
     printf("Preparing the message\n");
@@ -1245,7 +1245,7 @@ void TestDnsTxtEntry(void)
     VerifyOrQuit(instance != nullptr);
 
     messagePool = &instance->Get<MessagePool>();
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
+    VerifyOrQuit((message = messagePool->Allocate(Message::kTypeIp6)) != nullptr);
 
     data.Init(txtData, sizeof(txtData));
     SuccessOrQuit(Dns::TxtEntry::AppendEntries(kTxtEntries, OT_ARRAY_LENGTH(kTxtEntries), data));

--- a/tests/unit/test_heap_string.cpp
+++ b/tests/unit/test_heap_string.cpp
@@ -215,7 +215,7 @@ void TestHeapData(void)
     VerifyOrQuit(instance != nullptr, "Null OpenThread instance");
 
     messagePool = &instance->Get<MessagePool>();
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr, "Message::New failed");
+    VerifyOrQuit((message = messagePool->Allocate(Message::kTypeIp6)) != nullptr);
 
     message->SetOffset(0);
 

--- a/tests/unit/test_hmac_sha256.cpp
+++ b/tests/unit/test_hmac_sha256.cpp
@@ -93,7 +93,7 @@ void TestSha256(void)
     VerifyOrQuit(instance != nullptr);
 
     messagePool = &instance->Get<MessagePool>();
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
+    VerifyOrQuit((message = messagePool->Allocate(Message::kTypeIp6)) != nullptr);
 
     for (const TestCase &testCase : kTestCases)
     {
@@ -236,7 +236,7 @@ void TestHmacSha256(void)
     VerifyOrQuit(instance != nullptr);
 
     messagePool = &instance->Get<MessagePool>();
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
+    VerifyOrQuit((message = messagePool->Allocate(Message::kTypeIp6)) != nullptr);
 
     for (const TestCase &testCase : kTestCases)
     {

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -124,7 +124,7 @@ static void Init(void)
         0x02, 0x40                                                              // Context ID = 2, C = FALSE
     };
 
-    Message *message = sInstance->Get<MessagePool>().New(Message::kTypeIp6, 0);
+    Message *message = sInstance->Get<MessagePool>().Allocate(Message::kTypeIp6);
     VerifyOrQuit(message != nullptr, "Ip6::NewMessage failed");
 
     SuccessOrQuit(message->AppendBytes(mockNetworkData, sizeof(mockNetworkData)));
@@ -171,7 +171,7 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
     {
         Lowpan::BufferWriter buffer(result, 127);
 
-        VerifyOrQuit((message = sInstance->Get<MessagePool>().New(Message::kTypeIp6, 0)) != nullptr);
+        VerifyOrQuit((message = sInstance->Get<MessagePool>().Allocate(Message::kTypeIp6)) != nullptr);
 
         aVector.GetUncompressedStream(*message);
 
@@ -200,7 +200,7 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
 
     if (aDecompress)
     {
-        VerifyOrQuit((message = sInstance->Get<MessagePool>().New(Message::kTypeIp6, 0)) != nullptr);
+        VerifyOrQuit((message = sInstance->Get<MessagePool>().Allocate(Message::kTypeIp6)) != nullptr);
 
         int decompressedBytes =
             sLowpan->Decompress(*message, aVector.mMacSource, aVector.mMacDestination, iphc, iphcLength, 0);

--- a/tests/unit/test_message.cpp
+++ b/tests/unit/test_message.cpp
@@ -65,7 +65,7 @@ void TestMessage(void)
 
     Random::NonCrypto::FillBuffer(writeBuffer, kMaxSize);
 
-    VerifyOrQuit((message = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
+    VerifyOrQuit((message = messagePool->Allocate(Message::kTypeIp6)) != nullptr);
     SuccessOrQuit(message->SetLength(kMaxSize));
     message->WriteBytes(0, writeBuffer, kMaxSize);
     SuccessOrQuit(message->Read(0, readBuffer, kMaxSize));
@@ -136,7 +136,7 @@ void TestMessage(void)
 
     // Test `Message::CopyTo()` behavior.
 
-    VerifyOrQuit((message2 = messagePool->New(Message::kTypeIp6, 0)) != nullptr);
+    VerifyOrQuit((message2 = messagePool->Allocate(Message::kTypeIp6)) != nullptr);
     SuccessOrQuit(message2->SetLength(kMaxSize));
 
     for (uint16_t srcOffset = 0; srcOffset < kMaxSize; srcOffset += kOffsetStep)
@@ -258,7 +258,7 @@ void TestAppender(void)
     instance = static_cast<Instance *>(testInitInstance());
     VerifyOrQuit(instance != nullptr);
 
-    message = instance->Get<MessagePool>().New(Message::kTypeIp6, 0);
+    message = instance->Get<MessagePool>().Allocate(Message::kTypeIp6);
     VerifyOrQuit(message != nullptr);
 
     memset(buffer, 0, sizeof(buffer));

--- a/tests/unit/test_message_queue.cpp
+++ b/tests/unit/test_message_queue.cpp
@@ -88,8 +88,8 @@ void TestMessageQueue(void)
 
     for (ot::Message *&msg : messages)
     {
-        msg = sMessagePool->New(ot::Message::kTypeIp6, 0);
-        VerifyOrQuit(msg != nullptr, "Message::New() failed");
+        msg = sMessagePool->Allocate(ot::Message::kTypeIp6);
+        VerifyOrQuit(msg != nullptr, "Message::Allocate() failed");
     }
 
     VerifyMessageQueueContent(messageQueue, 0);

--- a/tests/unit/test_priority_queue.cpp
+++ b/tests/unit/test_priority_queue.cpp
@@ -156,32 +156,33 @@ void TestPriorityQueue(void)
 
     messagePool = &instance->Get<ot::MessagePool>();
 
-    // Use the function "New()" to allocate messages with different priorities
+    // Use the function "Allocate()" to allocate messages with different priorities
     for (int i = 0; i < kNumNewPriorityTestMessages; i++)
     {
-        msgNet[i] = messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kPriorityNet);
+        msgNet[i] = messagePool->Allocate(ot::Message::kTypeIp6, 0, ot::Message::Settings(ot::Message::kPriorityNet));
         VerifyOrQuit(msgNet[i] != nullptr);
-        msgHigh[i] = messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kPriorityHigh);
+        msgHigh[i] = messagePool->Allocate(ot::Message::kTypeIp6, 0, ot::Message::Settings(ot::Message::kPriorityHigh));
         VerifyOrQuit(msgHigh[i] != nullptr);
-        msgNor[i] = messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kPriorityNormal);
+        msgNor[i] =
+            messagePool->Allocate(ot::Message::kTypeIp6, 0, ot::Message::Settings(ot::Message::kPriorityNormal));
         VerifyOrQuit(msgNor[i] != nullptr);
-        msgLow[i] = messagePool->New(ot::Message::kTypeIp6, 0, ot::Message::kPriorityLow);
+        msgLow[i] = messagePool->Allocate(ot::Message::kTypeIp6, 0, ot::Message::Settings(ot::Message::kPriorityLow));
         VerifyOrQuit(msgLow[i] != nullptr);
     }
 
     // Use the function "SetPriority()" to allocate messages with different priorities
     for (int i = kNumNewPriorityTestMessages; i < kNumTestMessages; i++)
     {
-        msgNet[i] = messagePool->New(ot::Message::kTypeIp6, 0);
+        msgNet[i] = messagePool->Allocate(ot::Message::kTypeIp6);
         VerifyOrQuit(msgNet[i] != nullptr);
         SuccessOrQuit(msgNet[i]->SetPriority(ot::Message::kPriorityNet));
-        msgHigh[i] = messagePool->New(ot::Message::kTypeIp6, 0);
+        msgHigh[i] = messagePool->Allocate(ot::Message::kTypeIp6);
         VerifyOrQuit(msgHigh[i] != nullptr);
         SuccessOrQuit(msgHigh[i]->SetPriority(ot::Message::kPriorityHigh));
-        msgNor[i] = messagePool->New(ot::Message::kTypeIp6, 0);
+        msgNor[i] = messagePool->Allocate(ot::Message::kTypeIp6);
         VerifyOrQuit(msgNor[i] != nullptr);
         SuccessOrQuit(msgNor[i]->SetPriority(ot::Message::kPriorityNormal));
-        msgLow[i] = messagePool->New(ot::Message::kTypeIp6, 0);
+        msgLow[i] = messagePool->Allocate(ot::Message::kTypeIp6);
         VerifyOrQuit(msgLow[i] != nullptr);
         SuccessOrQuit(msgLow[i]->SetPriority(ot::Message::kPriorityLow));
     }

--- a/tests/unit/test_spinel_buffer.cpp
+++ b/tests/unit/test_spinel_buffer.cpp
@@ -176,7 +176,7 @@ void WriteTestFrame1(Spinel::Buffer &aNcpBuffer, Spinel::Buffer::Priority aPrior
     Message *       message;
     CallbackContext oldContext;
 
-    message = sMessagePool->New(Message::kTypeIp6, 0);
+    message = sMessagePool->Allocate(Message::kTypeIp6);
     VerifyOrQuit(message != nullptr, "Null Message");
     SuccessOrQuit(message->SetLength(sizeof(sMottoText)));
     message->Write(0, sMottoText);
@@ -220,12 +220,12 @@ void WriteTestFrame2(Spinel::Buffer &aNcpBuffer, Spinel::Buffer::Priority aPrior
     Message *       message2;
     CallbackContext oldContext = sContext;
 
-    message1 = sMessagePool->New(Message::kTypeIp6, 0);
+    message1 = sMessagePool->Allocate(Message::kTypeIp6);
     VerifyOrQuit(message1 != nullptr, "Null Message");
     SuccessOrQuit(message1->SetLength(sizeof(sMysteryText)));
     message1->Write(0, sMysteryText);
 
-    message2 = sMessagePool->New(Message::kTypeIp6, 0);
+    message2 = sMessagePool->Allocate(Message::kTypeIp6);
     VerifyOrQuit(message2 != nullptr, "Null Message");
     SuccessOrQuit(message2->SetLength(sizeof(sHelloText)));
     message2->Write(0, sHelloText);
@@ -265,7 +265,7 @@ void WriteTestFrame3(Spinel::Buffer &aNcpBuffer, Spinel::Buffer::Priority aPrior
     Message *       message1;
     CallbackContext oldContext = sContext;
 
-    message1 = sMessagePool->New(Message::kTypeIp6, 0);
+    message1 = sMessagePool->Allocate(Message::kTypeIp6);
     VerifyOrQuit(message1 != nullptr, "Null Message");
 
     // An empty message with no content.
@@ -526,7 +526,7 @@ void TestBuffer(void)
         ncpBuffer.InFrameBegin((j % 2) == 0 ? Spinel::Buffer::kPriorityHigh : Spinel::Buffer::kPriorityLow);
         SuccessOrQuit(ncpBuffer.InFrameFeedData(sHelloText, sizeof(sHelloText)));
 
-        message = sMessagePool->New(Message::kTypeIp6, 0);
+        message = sMessagePool->Allocate(Message::kTypeIp6);
         VerifyOrQuit(message != nullptr, "Null Message");
         SuccessOrQuit(message->SetLength(sizeof(sMysteryText)));
         message->Write(0, sMysteryText);
@@ -731,7 +731,7 @@ void TestBuffer(void)
     VerifyOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, 0) == OT_ERROR_INVALID_STATE);
     VerifyOrQuit(ncpBuffer.InFrameFeedData(sOpenThreadText, 0) == OT_ERROR_INVALID_STATE);
     VerifyOrQuit(ncpBuffer.InFrameEnd() == OT_ERROR_INVALID_STATE);
-    message = sMessagePool->New(Message::kTypeIp6, 0);
+    message = sMessagePool->Allocate(Message::kTypeIp6);
     VerifyOrQuit(message != nullptr, "Null Message");
     SuccessOrQuit(message->SetLength(sizeof(sMysteryText)));
     message->Write(0, sMysteryText);


### PR DESCRIPTION
This commit removes different `MessagePool` methods that can be used
to allocate a new message  and combines them into one `Allocate()`
method which uses `Message::Settings`. The `Message::Settings` is
also updated to provide new constructor initializing it with a given
message priority only.

---

Follow up from 
- https://github.com/openthread/openthread/pull/7203.