### PR TITLE
[srp-client] skip appending services on host remove retry

### DIFF
--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -767,7 +767,7 @@ Error Client::PrepareUpdateMessage(Message &aMessage)
 
     // Prepare Update section
 
-    if (mHostInfo.GetState() != kToRemove)
+    if ((mHostInfo.GetState() != kToRemove) && (mHostInfo.GetState() != kRemoving))
     {
         for (Service &service : mServices)
         {


### PR DESCRIPTION
This commit updates `Srp::Client` to skip appending services when the
host is being removed. On the first attempt the `mHostInfo.GetState()`
will be `kToRemove` but on the retries it will be `kRemoving`.

---

_Background:_
- Indirect follow up to https://github.com/openthread/openthread/pull/7216.
- It is an enhancement. There is no harm in including  services in a remove host
message but more efficient to omit them.