### PR TITLE
make Source class's desturctor virtual

### DIFF
--- a/src/posix/platform/mainloop.hpp
+++ b/src/posix/platform/mainloop.hpp
@@ -65,6 +65,12 @@ public:
      */
     virtual void Process(const otSysMainloopContext &aContext) = 0;
 
+    /**
+     * This method mark desturctor virtual.
+     *
+     */
+    virtual ~Source() = 0;
+
 private:
     Source *mNext = nullptr;
 };


### PR DESCRIPTION
It's good practice to make base class's destructor virtual.