### PR TITLE
[linked-list] add `RemoveAllMatching()` method

### DIFF
--- a/src/core/common/linked_list.hpp
+++ b/src/core/common/linked_list.hpp
@@ -350,6 +350,45 @@ public:
     }
 
     /**
+     * This template method removes all entries in the list matching a given entry indicator from the list and adds
+     * them to a new list.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
+     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * @param[in] aIndicator   An entry indicator to match against entries in the list.
+     * @param[in] aRemovedList The list to add the removed entries to.
+     *
+     */
+    template <typename Indicator> void RemoveAllMatching(const Indicator &aIndicator, LinkedList &aRemovedList)
+    {
+        Type *entry;
+        Type *prev;
+        Type *next;
+
+        for (prev = nullptr, entry = GetHead(); entry != nullptr; entry = next)
+        {
+            next = entry->GetNext();
+
+            if (entry->Matches(aIndicator))
+            {
+                PopAfter(prev);
+                aRemovedList.Push(*entry);
+
+                // When the entry is removed from the list
+                // we keep the `prev` pointer same as before.
+            }
+            else
+            {
+                prev = entry;
+            }
+        }
+    }
+
+    /**
      * This method searches within the linked list to find an entry and if found returns a pointer to previous entry.
      *
      * @param[in]  aEntry      A reference to an entry to find.

--- a/src/core/common/owning_list.hpp
+++ b/src/core/common/owning_list.hpp
@@ -128,6 +128,27 @@ public:
     {
         return OwnedPtr<Type>(LinkedList<Type>::RemoveMatching(aIndicator));
     }
+
+    /**
+     * This template method removes all entries in the list matching a given entry indicator from the list and adds
+     * them to a new list.
+     *
+     * The template type `Indicator` specifies the type of @p aIndicator object which is used to match against entries
+     * in the list. To check that an entry matches the given indicator, the `Matches()` method is invoked on each
+     * `Type` entry in the list. The `Matches()` method should be provided by `Type` class accordingly:
+     *
+     *     bool Type::Matches(const Indicator &aIndicator) const
+     *
+     * The ownership of the removed entries is transferred from the original list to the @p aRemovedList.
+     *
+     * @param[in] aIndicator   An entry indicator to match against entries in the list.
+     * @param[in] aRemovedList The list to add the removed entries to.
+     *
+     */
+    template <typename Indicator> void RemoveAllMatching(const Indicator &aIndicator, OwningList &aRemovedList)
+    {
+        RemoveAllMatching(aIndicator, aRemovedList);
+    }
 };
 
 } // namespace ot

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -1355,27 +1355,7 @@ void Client::HandleUpdateDone(void)
 
 void Client::GetRemovedServices(LinkedList<Service> &aRemovedServices)
 {
-    Service *service;
-    Service *prev;
-    Service *next;
-
-    for (prev = nullptr, service = mServices.GetHead(); service != nullptr; service = next)
-    {
-        next = service->GetNext();
-
-        if (service->GetState() == kRemoved)
-        {
-            mServices.PopAfter(prev);
-            aRemovedServices.Push(*service);
-
-            // When the service is removed from the list
-            // we keep the `prev` pointer same as before.
-        }
-        else
-        {
-            prev = service;
-        }
-    }
+    mServices.RemoveAllMatching(kRemoved, aRemovedServices);
 }
 
 Error Client::ReadResourceRecord(const Message &aMessage, uint16_t &aOffset, Dns::ResourceRecord &aRecord)

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -267,6 +267,7 @@ public:
         TimeMilli GetLeaseRenewTime(void) const { return TimeMilli(mData); }
         void      SetLeaseRenewTime(TimeMilli aTime) { mData = aTime.GetValue(); }
         bool      Matches(const Service &aOther) const;
+        bool      Matches(ItemState aState) const { return GetState() == aState; }
     };
 
     /**


### PR DESCRIPTION
This commit adds a new method `LinkedList::RemoveAllMatching()` which
removes all entries in the list matching a given entry indicator from
the list and adds them to a new "removed" list. A similar method is
also added in `OwningList`. This commit also updates the unit test
`test_linked_list` to validate the behavior of the new method.

This PR also contains a smaller related commit:

**[srp-client] use `LinkedList::RemoveAllMatching()`**

----

The `for` loop going over the linked-list entries while 
potentially removing some entries is kind of tricky (keeping
track of `prev`/`next` properly), so having a helper method
that does this can be helpful to avoid mistake.