### PR TITLE
[mlr] send BMLR.ntf for de-registration

### DIFF
--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -242,6 +242,8 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
         if (timeout == 0)
         {
             mMulticastListenersTable.Remove(address);
+
+            // Put successfully de-registered addresses at the end of `addresses`.
             addresses[kIp6AddressesNumMax - (++successAddressNum)] = address;
         }
         else

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -242,6 +242,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
         if (timeout == 0)
         {
             mMulticastListenersTable.Remove(address);
+            addresses[kIp6AddressesNumMax - (++successAddressNum)] = address;
         }
         else
         {

--- a/tests/scripts/thread-cert/backbone/test_bmlr.py
+++ b/tests/scripts/thread-cert/backbone/test_bmlr.py
@@ -189,11 +189,12 @@ class BBR_5_11_01(thread_cert.TestCase):
             thread_meshcop.tlv.ipv6_addr == ['{MA5}']
             and thread_nm.tlv.timeout == 0
         """)
-        # Verify PBBR not sends `/b/bmr` on the Backbone link for MA5.
-        pkts.filter_eth_src(PBBR_ETH).filter_coap_request('/b/bmr').filter(f"""
+        # Verify PBBR sends `/b/bmr` on the Backbone link for MA5 with timeout equal to zero.
+        pkts.filter_eth_src(PBBR_ETH).filter_coap_request('/b/bmr').must_next().must_verify(f"""
             thread_meshcop.tlv.ipv6_addr == ['{MA5}']
+            and thread_bl.tlv.timeout == 0
             and ipv6.src.is_link_local
-        """).must_not_next()
+        """)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
BBR should send BMLR.ntf to the backbone upon successful de-registration as well.

This is verified in certification tests MATN-TC-17 and MATN-TC-18.