### PR TITLE
[posix] logging when infra/backbone interface is not provided

### DIFF
--- a/src/posix/platform/backbone.cpp
+++ b/src/posix/platform/backbone.cpp
@@ -48,7 +48,11 @@ static ot::Posix::MulticastRoutingManager sMulticastRoutingManager;
 
 void platformBackboneInit(const char *aInterfaceName)
 {
-    VerifyOrExit(aInterfaceName != nullptr && aInterfaceName[0] != '\0');
+    if (aInterfaceName == nullptr || aInterfaceName[0] == '\0')
+    {
+        otLogWarnPlat("Backbone Router feature is disabled: infra/backbone interface is missing");
+        ExitNow();
+    }
 
     VerifyOrDie(strnlen(aInterfaceName, sizeof(gBackboneNetifName)) < sizeof(gBackboneNetifName),
                 OT_EXIT_INVALID_ARGUMENTS);

--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -304,7 +304,11 @@ void InfraNetif::Init(const char *aIfName)
     ssize_t  rval;
     uint32_t ifIndex = 0;
 
-    VerifyOrExit(aIfName != nullptr && aIfName[0] != '\0');
+    if (aIfName == nullptr || aIfName[0] == '\0')
+    {
+        otLogWarnPlat("Border Routing feature is disabled: infra/backbone interface is missing");
+        ExitNow();
+    }
 
     VerifyOrDie(strnlen(aIfName, sizeof(mInfraIfName)) <= sizeof(mInfraIfName) - 1, OT_EXIT_INVALID_ARGUMENTS);
     strcpy(mInfraIfName, aIfName);
@@ -313,7 +317,7 @@ void InfraNetif::Init(const char *aIfName)
     ifIndex = if_nametoindex(aIfName);
     if (ifIndex == 0)
     {
-        otLogCritPlat("failed to get the index for infra interface %s", aIfName);
+        otLogCritPlat("Failed to get the index for infra interface %s", aIfName);
         DieNow(OT_EXIT_INVALID_ARGUMENTS);
     }
     mInfraIfIndex = ifIndex;
@@ -399,7 +403,7 @@ void InfraNetif::ReceiveNetLinkMessage(void)
     len = recv(mNetLinkSocket, msgBuffer.mBuffer, sizeof(msgBuffer.mBuffer), 0);
     if (len < 0)
     {
-        otLogCritPlat("failed to receive netlink message: %s", strerror(errno));
+        otLogCritPlat("Failed to receive netlink message: %s", strerror(errno));
         ExitNow();
     }
 
@@ -466,7 +470,7 @@ void InfraNetif::ReceiveIcmp6Message(void)
     rval = recvmsg(mInfraIfIcmp6Socket, &msg, 0);
     if (rval < 0)
     {
-        otLogWarnPlat("failed to receive ICMPv6 message: %s", strerror(errno));
+        otLogWarnPlat("Failed to receive ICMPv6 message: %s", strerror(errno));
         ExitNow(error = OT_ERROR_DROP);
     }
 
@@ -502,7 +506,7 @@ void InfraNetif::ReceiveIcmp6Message(void)
 exit:
     if (error != OT_ERROR_NONE)
     {
-        otLogDebgPlat("failed to handle ICMPv6 message: %s", otThreadErrorToString(error));
+        otLogDebgPlat("Failed to handle ICMPv6 message: %s", otThreadErrorToString(error));
     }
 }
 


### PR DESCRIPTION
The Backbone Router and Border Routing feature will be silently disabled when
the infra/backbone interface is not provided. We should at least print a warning
log in this case since it may not be intentional.