### PR TITLE
Add new chip QPG6105 in targets list

### DIFF
--- a/examples/platforms/Makefile.am
+++ b/examples/platforms/Makefile.am
@@ -38,6 +38,7 @@ EXTRA_DIST                              = \
     nrf528xx                              \
     qpg6095                               \
     qpg6100                               \
+    qpg6105                               \
     qpg7015m                              \
     samr21                                \
     $(NULL)

--- a/examples/platforms/qpg6105/README.md
+++ b/examples/platforms/qpg6105/README.md
@@ -1,0 +1,1 @@
+The OpenThread on QPG6105 example has moved to https://github.com/openthread/ot-qorvo


### PR DESCRIPTION
Small update for Makefile.am to add the new chip in the distributions list