### PR TITLE
[thci] drop empty lines returned in command outout from the response

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -298,7 +298,9 @@ class OpenThreadTHCI(object):
                     continue
 
                 self.log("readline: %s", line)
-                response.append(line)
+                # skip empty lines
+                if line:
+                    response.append(line)
 
                 if line.endswith('Done'):
                     break


### PR DESCRIPTION
In some cases the first element from the output from __executeCommand might be empty line, which casues command failures like on below trace:
__executeCommand('extaddr',) returns ['', '166e0a0000000001', '', 'Done']
FUNC getMAC failed: invalid literal for int() with base 16: ''
This PR filters out empty string from the result of __executeCommand