### PR TITLE
[posix] fix cast-align build error in `netif.cpp`

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -523,8 +523,10 @@ void AddRtAttr(struct nlmsghdr *aHeader, uint32_t aMaxLen, uint8_t aType, const 
 
     assert(NLMSG_ALIGN(aHeader->nlmsg_len) + RTA_ALIGN(len) <= aMaxLen);
     OT_UNUSED_VARIABLE(aMaxLen);
-
-    rta           = (struct rtattr *)((char *)(aHeader) + NLMSG_ALIGN((aHeader)->nlmsg_len));
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wcast-align"
+    rta           = (struct rtattr *)(((char *)aHeader) + NLMSG_ALIGN((aHeader)->nlmsg_len));
+#pragma GCC diagnostic pop
     rta->rta_type = aType;
     rta->rta_len  = len;
     if (aLen)


### PR DESCRIPTION
Hi guys, I have faced same issue that described a year ago in closed thread.

https://github.com/openthread/openthread/issues/5647

It's connected to the broken cast, and without it - unable to build repo on the latest 'Raspberrypi-OS'. I have fixed it like it was fixed in previous thread. 

```log
$uname -a
Linux thread-srv 5.10.63-v7l+ #1459 SMP Wed Oct 6 16:41:57 BST 2021 armv7l GNU/Linux

$ cat /etc/debian_version 
11.1

```

```log
 CXX      libopenthread_posix_a-virtual_time.o
/home/pi/wrk/openthread/src/posix/../../src/posix/platform/netif.cpp: In function ‘void AddRtAttr(nlmsghdr*, uint32_t, uint8_t, const void*, uint8_t)’:
/home/pi/wrk/openthread/src/posix/../../src/posix/platform/netif.cpp:527:21: error: cast from ‘char*’ to ‘rtattr*’ increases required alignment of target type [-Werror=cast-align]
  527 |     rta           = (struct rtattr *)(((char *)aHeader) + NLMSG_ALIGN((aHeader)->nlmsg_len));
      |                     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[5]: *** [Makefile:1051: libopenthread_posix_a-netif.o] Error 1
```
