### PR TITLE
[cli] limit `radiofilter` command to when 15.4 radio link is enabled

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -3681,7 +3681,7 @@ otError Interpreter::ProcessPreferRouterId(Arg aArgs[])
 }
 #endif
 
-#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE && OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
 otError Interpreter::ProcessRadioFilter(Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -512,7 +512,9 @@ private:
     otError ProcessPskcRef(Arg aArgs[]);
 #endif
 #endif
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE && OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
     otError ProcessRadioFilter(Arg aArgs[]);
+#endif
     otError ProcessRcp(Arg aArgs[]);
     otError ProcessRegion(Arg aArgs[]);
 #if OPENTHREAD_FTD
@@ -819,7 +821,7 @@ private:
         {"pskcref", &Interpreter::ProcessPskcRef},
 #endif
 #endif
-#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
+#if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE && OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
         {"radiofilter", &Interpreter::ProcessRadioFilter},
 #endif
         {"rcp", &Interpreter::ProcessRcp},


### PR DESCRIPTION
This commit adds `OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE`
check to CLI methods related to `radiofilter` command which ensures that this 
command is  only available when 15.4 radio is enabled. This
allows us to build CLI app successfully with TREL radio only.