### PR TITLE
[border-routing] fix stale prefixes checking timer

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1344,7 +1344,7 @@ void RoutingManager::ResetDiscoveredPrefixStaleTimer(void)
 
     OT_ASSERT(mIsRunning);
 
-    // The stale timer is responding for sending RS to re-check the stale On-Link/OMR prefixes or RA message.
+    // The stale timer triggers sending RS to check the state of On-Link/OMR prefixes and host RA messages.
     // The rules for calculating the next stale time:
     // 1. If BR learns RA header from Host daemons, it should send RS when the RA header is stale.
     // 2. If BR discovered any on-link prefix, it should send RS when all on-link prefixes are stale.
@@ -1362,13 +1362,16 @@ void RoutingManager::ResetDiscoveredPrefixStaleTimer(void)
     {
         TimeMilli prefixStaleTime = externalPrefix.GetStaleTime();
 
-        if (externalPrefix.mIsOnLinkPrefix && !externalPrefix.IsDeprecated())
+        if (externalPrefix.mIsOnLinkPrefix)
         {
-            // Check for least recent stale On-Link Prefixes if BR is not advertising local On-Link Prefix.
-            maxOnlinkPrefixStaleTime      = OT_MAX(maxOnlinkPrefixStaleTime, prefixStaleTime);
-            requireCheckStaleOnlinkPrefix = true;
+            if (!externalPrefix.IsDeprecated())
+            {
+                // Check for least recent stale On-Link Prefixes if BR is not advertising local On-Link Prefix.
+                maxOnlinkPrefixStaleTime      = OT_MAX(maxOnlinkPrefixStaleTime, prefixStaleTime);
+                requireCheckStaleOnlinkPrefix = true;
+            }
         }
-        else if (!externalPrefix.mIsOnLinkPrefix)
+        else
         {
             // Check for most recent stale OMR Prefixes
             nextStaleTime = OT_MIN(nextStaleTime, prefixStaleTime);

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -315,6 +315,7 @@ private:
     void InvalidateAllDiscoveredPrefixes(void);
     bool NetworkDataContainsOmrPrefix(const Ip6::Prefix &aPrefix) const;
     bool UpdateRouterAdvMessage(const RouterAdv::RouterAdvMessage *aRouterAdvMessage);
+    void ResetDiscoveredPrefixStaleTimer(void);
 
     static bool IsValidOmrPrefix(const NetworkData::OnMeshPrefixConfig &aOnMeshPrefixConfig);
     static bool IsValidOmrPrefix(const Ip6::Prefix &aOmrPrefix);
@@ -370,6 +371,7 @@ private:
     // and updated with RA messages initiated from infra interface.
     RouterAdv::RouterAdvMessage mRouterAdvMessage;
     TimeMilli                   mTimeRouterAdvMessageLastUpdate;
+    bool                        mLearntRouterAdvMessageFromHost;
 
     TimerMilli mDiscoveredPrefixInvalidTimer;
     TimerMilli mDiscoveredPrefixStaleTimer;


### PR DESCRIPTION
Current implementation will reschedule the Stale Timer when discovered on-link or
OMR prefixes or RA messages are updated, but it has a few issues:
1. It's counting the maximum stale time of all on-link prefixes so that we will schedule
    Router Solicitation when all on-link prefixes become stale. But it failed to filter out
    OMR prefixes in the `mDiscoveredPrefixes` list. This results in incorrect stale time
    calculation.
2. A deprecated on-link-prefix is not removed from `mDiscoveredPrefixes` directly
    but the preferred lifetime is set to zero. We are not filtering out deprecated
    on-link prefixes when calculating stale time and this results in zero stale timer
    delay if there are no non-deprecated on-link prefixes.

This commit fixes those issues by having a dedicated `ResetDiscoveredPrefixStaleTimer`
to reschedule the stale timer with following rules whenever discovered prefixes or learnt
RA messages are updated:
1. If BR learns RA header from Host daemons, it should send RS when the RA header is stale.
2. If BR discovered any on-link prefix, it should send RS when all on-link prefixes are stale.
3. If BR discovered any OMR prefix, it should send RS when the first OMR prefix is stale.

`ResetDiscoveredPrefixStaleTimer` is supposed to correctly calculate stale timer timeout
whenever it's called. 