### PR TITLE
[border-routing] cancel delayed Routing Policy evaluation for Router Solicitation

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -288,6 +288,7 @@ private:
     void  StartRouterSolicitationDelay(void);
     Error SendRouterSolicitation(void);
     void  SendRouterAdvertisement(const OmrPrefixArray &aNewOmrPrefixes, const Ip6::Prefix *aNewOnLinkPrefix);
+    bool  IsRouterSolicitationInProgress(void) const;
 
     static void HandleRouterAdvertisementTimer(Timer &aTimer);
     void        HandleRouterAdvertisementTimer(void);


### PR DESCRIPTION
This commit enhances Border Routing to cancel delayed Routing Policy evaluation if Router Solicitation is started or ongoing.

Based on #7242 