### PR TITLE
[cli] add option to print more information for `ipaddress`

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -1279,6 +1279,16 @@ fe80:0:0:0:f3d9:2a82:c8d8:fe43
 Done
 ```
 
+Use `-v` to get more verbose informations about the address.
+
+```bash
+> ipaddr -v
+fdde:ad00:beef:0:0:ff:fe00:0 origin:thread
+fdde:ad00:beef:0:558:f56b:d688:799 origin:thread
+fe80:0:0:0:f3d9:2a82:c8d8:fe43 origin:thread
+Done
+```
+
 ### ipaddr add \<ipaddr\>
 
 Add an IPv6 address to the Thread interface.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2056,9 +2056,28 @@ exit:
     return error;
 }
 
+const char *AddressOriginToString(uint8_t aOrigin)
+{
+    static const char *const kOriginStrings[4] = {
+        "thread", // 0, OT_ADDRESS_ORIGIN_THREAD
+        "slaac",  // 1, OT_ADDRESS_ORIGIN_SLAAC
+        "dhcp6",  // 2, OT_ADDRESS_ORIGIN_DHCPV6
+        "manual", // 3, OT_ADDRESS_ORIGIN_MANUAL
+    };
+
+    return aOrigin < OT_ARRAY_LENGTH(kOriginStrings) ? kOriginStrings[aOrigin] : "unknown";
+}
+
 otError Interpreter::ProcessIpAddr(Arg aArgs[])
 {
-    otError error = OT_ERROR_NONE;
+    otError error   = OT_ERROR_NONE;
+    bool    verbose = false;
+
+    if (aArgs[0] == "-v")
+    {
+        aArgs++;
+        verbose = true;
+    }
 
     if (aArgs[0].IsEmpty())
     {
@@ -2066,7 +2085,12 @@ otError Interpreter::ProcessIpAddr(Arg aArgs[])
 
         for (const otNetifAddress *addr = unicastAddrs; addr; addr = addr->mNext)
         {
-            OutputIp6AddressLine(addr->mAddress);
+            OutputIp6Address(addr->mAddress);
+            if (verbose)
+            {
+                OutputFormat(" origin:%s", AddressOriginToString(addr->mAddressOrigin));
+            }
+            OutputLine("");
         }
     }
     else


### PR DESCRIPTION
This commit adds a new sub-command for `ipaddr` to print more informations .