### PR TITLE
[border-routing] always respond to Router Solicit with `Router Advertisement`

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -956,7 +956,6 @@ void RoutingManager::HandleRouterSolicit(const Ip6::Address &aSrcAddress,
     OT_UNUSED_VARIABLE(aBuffer);
     OT_UNUSED_VARIABLE(aBufferLength);
 
-    VerifyOrExit(!IsRouterSolicitationInProgress());
     otLogInfoBr("Received Router Solicitation from %s on interface %u", aSrcAddress.ToString().AsCString(),
                 mInfraIfIndex);
 
@@ -971,10 +970,7 @@ void RoutingManager::HandleRouterSolicit(const Ip6::Address &aSrcAddress,
     // Schedule Router Advertisements with random delay.
     randomDelay = Random::NonCrypto::GetUint32InRange(0, kMaxRaDelayTime);
     otLogInfoBr("Router Advertisement scheduled in %u milliseconds", randomDelay);
-    mRouterAdvertisementTimer.Start(randomDelay);
-
-exit:
-    return;
+    mRouterAdvertisementTimer.FireAtIfEarlier(TimerMilli::GetNow() + randomDelay);
 }
 
 uint32_t RoutingManager::ExternalPrefix::GetPrefixExpireDelay(uint32_t aValidLifetime)


### PR DESCRIPTION
This commit fixes the bug that BR may not respond to a `Router Solicit`  with a `Router Advertisement` when the BR itself is Router Soliciting. 

This bug may cause `Vicarious Router Solicitation` more likely to fail because BRs may failed to send RA for vicarious RS. 