### PR TITLE
[border-routing] add configuration for Vicarious Router Solicitation

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -69,7 +69,9 @@ RoutingManager::RoutingManager(Instance &aInstance)
     , mDiscoveredPrefixStaleTimer(aInstance, HandleDiscoveredPrefixStaleTimer)
     , mRouterAdvertisementTimer(aInstance, HandleRouterAdvertisementTimer)
     , mRouterAdvertisementCount(0)
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
     , mVicariousRouterSolicitTimer(aInstance, HandleVicariousRouterSolicitTimer)
+#endif
     , mRouterSolicitTimer(aInstance, HandleRouterSolicitTimer)
     , mRouterSolicitCount(0)
     , mRoutingPolicyTimer(aInstance, HandleRoutingPolicyTimer)
@@ -246,7 +248,9 @@ void RoutingManager::Stop(void)
     mRouterAdvertisementTimer.Stop();
     mRouterAdvertisementCount = 0;
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
     mVicariousRouterSolicitTimer.Stop();
+#endif
     mRouterSolicitTimer.Stop();
     mRouterSolicitCount = 0;
 
@@ -638,7 +642,9 @@ void RoutingManager::StartRouterSolicitationDelay(void)
 
     VerifyOrExit(!mRouterSolicitTimer.IsRunning() && mRouterSolicitCount == 0);
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
     mVicariousRouterSolicitTimer.Stop();
+#endif
 
     static_assert(kMaxRtrSolicitationDelay > 0, "invalid maximum Router Solicitation delay");
     randomDelay = Random::NonCrypto::GetUint32InRange(0, Time::SecToMsec(kMaxRtrSolicitationDelay));
@@ -817,6 +823,7 @@ void RoutingManager::HandleRouterAdvertisementTimer(void)
     EvaluateRoutingPolicy();
 }
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
 void RoutingManager::HandleVicariousRouterSolicitTimer(Timer &aTimer)
 {
     aTimer.Get<RoutingManager>().HandleVicariousRouterSolicitTimer();
@@ -835,6 +842,7 @@ void RoutingManager::HandleVicariousRouterSolicitTimer(void)
         }
     }
 }
+#endif
 
 void RoutingManager::HandleRouterSolicitTimer(Timer &aTimer)
 {
@@ -944,11 +952,13 @@ void RoutingManager::HandleRouterSolicit(const Ip6::Address &aSrcAddress,
     otLogInfoBr("Received Router Solicitation from %s on interface %u", aSrcAddress.ToString().AsCString(),
                 mInfraIfIndex);
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
     if (!mVicariousRouterSolicitTimer.IsRunning())
     {
         mTimeVicariousRouterSolicitStart = TimerMilli::GetNow();
         mVicariousRouterSolicitTimer.Start(Time::SecToMsec(kVicariousSolicitationTime));
     }
+#endif
 
     // Schedule Router Advertisements with random delay.
     randomDelay = Random::NonCrypto::GetUint32InRange(0, kMaxRaDelayTime);

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -291,8 +291,10 @@ private:
 
     static void HandleRouterAdvertisementTimer(Timer &aTimer);
     void        HandleRouterAdvertisementTimer(void);
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
     static void HandleVicariousRouterSolicitTimer(Timer &aTimer);
     void        HandleVicariousRouterSolicitTimer(void);
+#endif
     static void HandleRouterSolicitTimer(Timer &aTimer);
     void        HandleRouterSolicitTimer(void);
     static void HandleDiscoveredPrefixInvalidTimer(Timer &aTimer);
@@ -374,8 +376,10 @@ private:
     TimerMilli mRouterAdvertisementTimer;
     uint32_t   mRouterAdvertisementCount;
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
     TimerMilli mVicariousRouterSolicitTimer;
     TimeMilli  mTimeVicariousRouterSolicitStart;
+#endif
     TimerMilli mRouterSolicitTimer;
     TimeMilli  mTimeRouterSolicitStart;
     uint8_t    mRouterSolicitCount;

--- a/src/core/config/border_router.h
+++ b/src/core/config/border_router.h
@@ -66,6 +66,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
+ *
+ * Define to 1 to enable Border Routing Vicarious Router Solicitation.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_BORDER_AGENT_UDP_PORT
  *
  * Specifies the Border Agent UDP port, and use 0 for ephemeral port.


### PR DESCRIPTION
This commit adds `OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE` configuration to allow disabling `Vicarious Router Solicitation` feature. 