### PR TITLE
[routing-manager] start routing policy evaluation when on-link prefix state changes

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1132,9 +1132,12 @@ bool RoutingManager::UpdateDiscoveredPrefixes(const RouterAdv::PrefixInfoOption 
             existingPrefix->mValidLifetime = kTwoHoursInSeconds;
         }
 
+        // The on-link prefix routing policy may be affected when a
+        // discovered on-link prefix becomes deprecated or preferred.
+        needReevaluate = (onLinkPrefix.IsDeprecated() != existingPrefix->IsDeprecated());
+
         existingPrefix->mPreferredLifetime = onLinkPrefix.mPreferredLifetime;
         existingPrefix->mTimeLastUpdate    = onLinkPrefix.mTimeLastUpdate;
-        needReevaluate                     = (existingPrefix->mPreferredLifetime == 0);
     }
 
     mDiscoveredPrefixInvalidTimer.FireAtIfEarlier(existingPrefix->GetExpireTime());


### PR DESCRIPTION
We should re-evaluate routing policy only when a discovered on-link prefix
becomes deprecated or preferred. This change reduces sending RA messages
when another peer is keep advertising deprecated (preferred lifetime is zero)
on-link prefix.