### PR TITLE
[mlr] `MLR_TIMEOUT_MIN` does not apply to MLR.req

### DIFF
--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -224,7 +224,6 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
             uint32_t origTimeout = timeout;
 
             timeout = OT_MIN(timeout, static_cast<uint32_t>(Mle::kMlrTimeoutMax));
-            timeout = OT_MAX(timeout, static_cast<uint32_t>(Mle::kMlrTimeoutMin));
 
             if (timeout != origTimeout)
             {


### PR DESCRIPTION
Thread specification defines `MLR_TIMEOUT_MIN` as the minimum value of the MLR Timeout in the BBR Dataset, but this does not affect to the Timeout TLV in the Multicast Registration Request messages.