### PR TITLE
[cli] support 1 or more mcast addresses for `ipmaddr add` command

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2103,18 +2103,19 @@ exit:
 
 otError Interpreter::ProcessIpMulticastAddrAdd(Arg aArgs[])
 {
-    otError      error = OT_ERROR_INVALID_ARGS;
     otIp6Address address;
 
-    Arg *arg = &aArgs[0];
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    for ( ; !arg->IsEmpty(); arg++) {
-#else
-    if (!arg->IsEmpty()) {
-#endif
+    otError      error = OT_ERROR_INVALID_ARGS;
+    for ( Arg *arg = &aArgs[0]; !arg->IsEmpty(); arg++) {
         SuccessOrExit(error = arg->ParseAsIp6Address(address));
         SuccessOrExit(error = otIp6SubscribeMulticastAddress(GetInstancePtr(), &address));
     }
+#else
+    otError      error;
+    SuccessOrExit(error = aArgs[0].ParseAsIp6Address(address));
+    error = otIp6SubscribeMulticastAddress(GetInstancePtr(), &address);
+#endif
 exit:
     return error;
 }

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2105,8 +2105,14 @@ otError Interpreter::ProcessIpMulticastAddrAdd(Arg aArgs[])
 {
     otError      error;
     otIp6Address address;
+    otIp6Address address2;
 
     SuccessOrExit(error = aArgs[0].ParseAsIp6Address(address));
+    if (!aArgs[1].IsEmpty())
+    {
+        SuccessOrExit(error = aArgs[1].ParseAsIp6Address(address2));
+        SuccessOrExit(error = otIp6SubscribeMulticastAddress(GetInstancePtr(), &address2));
+    }
     error = otIp6SubscribeMulticastAddress(GetInstancePtr(), &address);
 
 exit:

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2106,8 +2106,12 @@ otError Interpreter::ProcessIpMulticastAddrAdd(Arg aArgs[])
     otError      error = OT_ERROR_INVALID_ARGS;
     otIp6Address address;
 
-    for (Arg *arg = &aArgs[0]; !arg->IsEmpty(); arg++)
-    {
+    Arg *arg = &aArgs[0];
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    for ( ; !arg->IsEmpty(); arg++) {
+#else
+    if (!arg->IsEmpty()) {
+#endif
         SuccessOrExit(error = arg->ParseAsIp6Address(address));
         SuccessOrExit(error = otIp6SubscribeMulticastAddress(GetInstancePtr(), &address));
     }

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2106,13 +2106,14 @@ otError Interpreter::ProcessIpMulticastAddrAdd(Arg aArgs[])
     otIp6Address address;
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    otError      error = OT_ERROR_INVALID_ARGS;
-    for ( Arg *arg = &aArgs[0]; !arg->IsEmpty(); arg++) {
+    otError error = OT_ERROR_INVALID_ARGS;
+    for (Arg *arg = &aArgs[0]; !arg->IsEmpty(); arg++)
+    {
         SuccessOrExit(error = arg->ParseAsIp6Address(address));
         SuccessOrExit(error = otIp6SubscribeMulticastAddress(GetInstancePtr(), &address));
     }
 #else
-    otError      error;
+    otError error;
     SuccessOrExit(error = aArgs[0].ParseAsIp6Address(address));
     error = otIp6SubscribeMulticastAddress(GetInstancePtr(), &address);
 #endif

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2103,18 +2103,14 @@ exit:
 
 otError Interpreter::ProcessIpMulticastAddrAdd(Arg aArgs[])
 {
-    otError      error;
+    otError      error = OT_ERROR_INVALID_ARGS;
     otIp6Address address;
-    otIp6Address address2;
 
-    SuccessOrExit(error = aArgs[0].ParseAsIp6Address(address));
-    if (!aArgs[1].IsEmpty())
+    for (Arg *arg = &aArgs[0]; !arg->IsEmpty(); arg++)
     {
-        SuccessOrExit(error = aArgs[1].ParseAsIp6Address(address2));
-        SuccessOrExit(error = otIp6SubscribeMulticastAddress(GetInstancePtr(), &address2));
+        SuccessOrExit(error = arg->ParseAsIp6Address(address));
+        SuccessOrExit(error = otIp6SubscribeMulticastAddress(GetInstancePtr(), &address));
     }
-    error = otIp6SubscribeMulticastAddress(GetInstancePtr(), &address);
-
 exit:
     return error;
 }


### PR DESCRIPTION
Proposed CLI change for same reason as #7252 . Because the 2 addresses are registered sequentially from the same method call, the OpenThread stack will not have had the opportunity to send out MLR.req with a single address. So this should result in sending out one MLR.req with two addresses inside, if 2 addresses are provided.  Without changes in the APIs.