### PR TITLE
[mlr-manager] add short delay for processing `Ip6MulticastSubscribed` event

### DIFF
--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -142,6 +142,8 @@ public:
 #endif
 
 private:
+    static constexpr uint32_t kUpdateLocalSubscriptionsDelay = 10;
+
     void HandleNotifierEvents(Events aEvents);
 
     void  SendMulticastListenerRegistration(void);
@@ -175,8 +177,10 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
-    void UpdateLocalSubscriptions(void);
-    bool IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress) const;
+    static void HandleDelayTimer(Timer &aTimer);
+    void        HandleDelayTimer(void);
+    void        UpdateLocalSubscriptions(void);
+    bool        IsAddressMlrRegisteredByNetif(const Ip6::Address &aAddress) const;
 #endif
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE
@@ -224,6 +228,9 @@ private:
     bool mMlrPending : 1;
 #if (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE) && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
     bool mRegisterMulticastListenersPending : 1;
+#endif
+#if OPENTHREAD_CONFIG_MLR_ENABLE
+    TimerMilli mDelayTimer;
 #endif
 };
 


### PR DESCRIPTION
This commit updates `MlrManager` such that it adds a short wait delay
before taking action when an IPv6 multicast address is added, i.e., it
processes a `kEventIp6MulticastSubscribed` event from `Notifier` and
calls `UpdateLocalSubscriptions()`. The delay is added only when the
`mDelayTimer` is not already running (i.e. on the first event). This
allows user to add multiple addresses back-to-back and ensure that
they are processed together.

----

**_Background_**:
This is another solution for potentially addressing same issue as from
- https://github.com/openthread/openthread/pull/7253, or 
- https://github.com/openthread/openthread/pull/7252