### PR TITLE
[simulation] fix the wrong timeout value issue

### DIFF
--- a/examples/platforms/simulation/alarm.c
+++ b/examples/platforms/simulation/alarm.c
@@ -270,7 +270,7 @@ void platformAlarmUpdateTimeout(struct timeval *aTimeout)
             remaining = 1;
         }
 
-        aTimeout->tv_sec  = (time_t)remaining / US_PER_S;
+        aTimeout->tv_sec  = (time_t)(remaining / US_PER_S);
         aTimeout->tv_usec = remaining % US_PER_S;
     }
 }


### PR DESCRIPTION
When the type `time_t` is 32 bits wide, the current code will truncate
the value of time and returns a wrong value.