### PR TITLE
[core] use `AsCoreType` in header files

### DIFF
--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -169,8 +169,7 @@ private:
     void        HandleProxyTransmit(const Coap::Message &aMessage);
     static bool HandleUdpReceive(void *aContext, const otMessage *aMessage, const otMessageInfo *aMessageInfo)
     {
-        return static_cast<BorderAgent *>(aContext)->HandleUdpReceive(
-            *static_cast<const Message *>(aMessage), *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+        return static_cast<BorderAgent *>(aContext)->HandleUdpReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo));
     }
     bool HandleUdpReceive(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -265,7 +265,7 @@ public:
          * @returns The Network Key in the Dataset.
          *
          */
-        const NetworkKey &GetNetworkKey(void) const { return static_cast<const NetworkKey &>(mNetworkKey); }
+        const NetworkKey &GetNetworkKey(void) const { return AsCoreType(&mNetworkKey); }
 
         /**
          * This method sets the Network Key in the Dataset.
@@ -288,7 +288,7 @@ public:
         NetworkKey &UpdateNetworkKey(void)
         {
             mComponents.mIsNetworkKeyPresent = true;
-            return static_cast<NetworkKey &>(mNetworkKey);
+            return AsCoreType(&mNetworkKey);
         }
 
         /**
@@ -308,10 +308,7 @@ public:
          * @returns The Network Name in the Dataset.
          *
          */
-        const Mac::NetworkName &GetNetworkName(void) const
-        {
-            return static_cast<const Mac::NetworkName &>(mNetworkName);
-        }
+        const Mac::NetworkName &GetNetworkName(void) const { return AsCoreType(&mNetworkName); }
 
         /**
          * This method sets the Network Name in the Dataset.
@@ -321,7 +318,7 @@ public:
          */
         void SetNetworkName(const Mac::NameData &aNetworkNameData)
         {
-            IgnoreError(static_cast<Mac::NetworkName &>(mNetworkName).Set(aNetworkNameData));
+            IgnoreError(AsCoreType(&mNetworkName).Set(aNetworkNameData));
             mComponents.mIsNetworkNamePresent = true;
         }
 
@@ -342,10 +339,7 @@ public:
          * @returns The Extended PAN ID in the Dataset.
          *
          */
-        const Mac::ExtendedPanId &GetExtendedPanId(void) const
-        {
-            return static_cast<const Mac::ExtendedPanId &>(mExtendedPanId);
-        }
+        const Mac::ExtendedPanId &GetExtendedPanId(void) const { return AsCoreType(&mExtendedPanId); }
 
         /**
          * This method sets the Extended PAN ID in the Dataset.
@@ -376,10 +370,7 @@ public:
          * @returns The Mesh Local Prefix in the Dataset.
          *
          */
-        const Mle::MeshLocalPrefix &GetMeshLocalPrefix(void) const
-        {
-            return static_cast<const Mle::MeshLocalPrefix &>(mMeshLocalPrefix);
-        }
+        const Mle::MeshLocalPrefix &GetMeshLocalPrefix(void) const { return AsCoreType(&mMeshLocalPrefix); }
 
         /**
          * This method sets the Mesh Local Prefix in the Dataset.
@@ -502,7 +493,7 @@ public:
          * @returns The PSKc in the Dataset.
          *
          */
-        const Pskc &GetPskc(void) const { return static_cast<const Pskc &>(mPskc); }
+        const Pskc &GetPskc(void) const { return AsCoreType(&mPskc); }
 
         /**
          * This method set the PSKc in the Dataset.
@@ -533,10 +524,7 @@ public:
          * @returns The Security Policy in the Dataset.
          *
          */
-        const SecurityPolicy &GetSecurityPolicy(void) const
-        {
-            return static_cast<const SecurityPolicy &>(mSecurityPolicy);
-        }
+        const SecurityPolicy &GetSecurityPolicy(void) const { return AsCoreType(&mSecurityPolicy); }
 
         /**
          * This method sets the Security Policy in the Dataset.

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -40,6 +40,7 @@
 
 #include <openthread/platform/radio.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
 #include "common/encoding.hpp"
@@ -161,8 +162,7 @@ exit:
 
 void Dtls::HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
-    static_cast<Dtls *>(aContext)->HandleUdpReceive(*static_cast<Message *>(aMessage),
-                                                    *static_cast<const Ip6::MessageInfo *>(aMessageInfo));
+    static_cast<Dtls *>(aContext)->HandleUdpReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo));
 }
 
 void Dtls::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -211,7 +211,7 @@ public:
 
         explicit QueryConfig(InitMode aMode);
 
-        Ip6::SockAddr &GetServerSockAddr(void) { return static_cast<Ip6::SockAddr &>(mServerSockAddr); }
+        Ip6::SockAddr &GetServerSockAddr(void) { return AsCoreType(&mServerSockAddr); }
 
         void SetResponseTimeout(uint32_t aResponseTimeout) { mResponseTimeout = aResponseTimeout; }
         void SetMaxTxAttempts(uint8_t aMaxTxAttempts) { mMaxTxAttempts = aMaxTxAttempts; }

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -150,7 +150,7 @@ public:
          * @returns The unicast address.
          *
          */
-        const Address &GetAddress(void) const { return static_cast<const Address &>(mAddress); }
+        const Address &GetAddress(void) const { return AsCoreType(&mAddress); }
 
         /**
          * This method returns the unicast address.
@@ -158,7 +158,7 @@ public:
          * @returns The unicast address.
          *
          */
-        Address &GetAddress(void) { return static_cast<Address &>(mAddress); }
+        Address &GetAddress(void) { return AsCoreType(&mAddress); }
 
         /**
          * This method returns the address's prefix length (in bits).
@@ -235,7 +235,7 @@ public:
          * @returns The multicast address.
          *
          */
-        const Address &GetAddress(void) const { return static_cast<const Address &>(mAddress); }
+        const Address &GetAddress(void) const { return AsCoreType(&mAddress); }
 
         /**
          * This method returns the multicast address.
@@ -243,7 +243,7 @@ public:
          * @returns The multicast address.
          *
          */
-        Address &GetAddress(void) { return static_cast<Address &>(mAddress); }
+        Address &GetAddress(void) { return AsCoreType(&mAddress); }
 
         /**
          * This method returns the next multicast address subscribed to the interface.

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -72,7 +72,7 @@ public:
      * @returns A reference to the local socket address.
      *
      */
-    Address &GetSockAddr(void) { return *static_cast<Address *>(&mSockAddr); }
+    Address &GetSockAddr(void) { return AsCoreType(&mSockAddr); }
 
     /**
      * This method returns a reference to the local socket address.
@@ -80,7 +80,7 @@ public:
      * @returns A reference to the local socket address.
      *
      */
-    const Address &GetSockAddr(void) const { return *static_cast<const Address *>(&mSockAddr); }
+    const Address &GetSockAddr(void) const { return AsCoreType(&mSockAddr); }
 
     /**
      * This method sets the local socket address.
@@ -112,7 +112,7 @@ public:
      * @returns A reference to the peer socket address.
      *
      */
-    Address &GetPeerAddr(void) { return *static_cast<Address *>(&mPeerAddr); }
+    Address &GetPeerAddr(void) { return AsCoreType(&mPeerAddr); }
 
     /**
      * This method returns a reference to the peer socket address.
@@ -120,7 +120,7 @@ public:
      * @returns A reference to the peer socket address.
      *
      */
-    const Address &GetPeerAddr(void) const { return *static_cast<const Address *>(&mPeerAddr); }
+    const Address &GetPeerAddr(void) const { return AsCoreType(&mPeerAddr); }
 
     /**
      * This method sets the peer's socket address.
@@ -298,7 +298,7 @@ public:
      * @returns A reference to the IPv6 address.
      *
      */
-    Address &GetAddress(void) { return *static_cast<Address *>(&mAddress); }
+    Address &GetAddress(void) { return AsCoreType(&mAddress); }
 
     /**
      * This method returns a reference to the IPv6 address.
@@ -306,7 +306,7 @@ public:
      * @returns A reference to the IPv6 address.
      *
      */
-    const Address &GetAddress(void) const { return *static_cast<const Address *>(&mAddress); }
+    const Address &GetAddress(void) const { return AsCoreType(&mAddress); }
 
     /**
      * This method sets the IPv6 address.

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -138,10 +138,7 @@ public:
          * @returns  The host IPv6 address at index @p aIndex.
          *
          */
-        const Ip6::Address &GetAddress(uint8_t aIndex) const
-        {
-            return static_cast<const Ip6::Address &>(mAddresses[aIndex]);
-        }
+        const Ip6::Address &GetAddress(uint8_t aIndex) const { return AsCoreType(&mAddresses[aIndex]); }
 
         /**
          * This method gets the state of `HostInfo`.
@@ -244,7 +241,7 @@ public:
          * @returns A pointer to an array of service TXT entries.
          *
          */
-        const Dns::TxtEntry *GetTxtEntries(void) const { return static_cast<const Dns::TxtEntry *>(mTxtEntries); }
+        const Dns::TxtEntry *GetTxtEntries(void) const { return AsCoreTypePtr(mTxtEntries); }
 
         /**
          * This method gets the number of entries in the service TXT entry array.

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -97,7 +97,7 @@ public:
          * @returns A reference to the local socket address.
          *
          */
-        SockAddr &GetSockName(void) { return *static_cast<SockAddr *>(&mSockName); }
+        SockAddr &GetSockName(void) { return AsCoreType(&mSockName); }
 
         /**
          * This method returns the local socket address.
@@ -105,7 +105,7 @@ public:
          * @returns A reference to the local socket address.
          *
          */
-        const SockAddr &GetSockName(void) const { return *static_cast<const SockAddr *>(&mSockName); }
+        const SockAddr &GetSockName(void) const { return AsCoreType(&mSockName); }
 
         /**
          * This method returns the peer's socket address.
@@ -113,7 +113,7 @@ public:
          * @returns A reference to the peer's socket address.
          *
          */
-        SockAddr &GetPeerName(void) { return *static_cast<SockAddr *>(&mPeerName); }
+        SockAddr &GetPeerName(void) { return AsCoreType(&mPeerName); }
 
         /**
          * This method returns the peer's socket address.
@@ -121,7 +121,7 @@ public:
          * @returns A reference to the peer's socket address.
          *
          */
-        const SockAddr &GetPeerName(void) const { return *static_cast<const SockAddr *>(&mPeerName); }
+        const SockAddr &GetPeerName(void) const { return AsCoreType(&mPeerName); }
 
     private:
         bool Matches(const MessageInfo &aMessageInfo) const;

--- a/src/core/radio/trel_interface.cpp
+++ b/src/core/radio/trel_interface.cpp
@@ -36,6 +36,7 @@
 
 #include <openthread/platform/trel-udp6.h>
 
+#include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
@@ -114,7 +115,7 @@ void Interface::CreateMulticastIp6Address(Ip6::Address &aIp6Address)
 
 extern "C" void otPlatTrelUdp6HandleReceived(otInstance *aInstance, uint8_t *aBuffer, uint16_t aLength)
 {
-    ot::Instance &instance = *static_cast<ot::Instance *>(aInstance);
+    ot::Instance &instance = ot::AsCoreType(aInstance);
 
     VerifyOrExit(instance.IsInitialized());
     instance.Get<ot::Trel::Interface>().HandleReceived(aBuffer, aLength);

--- a/src/core/thread/network_data_types.hpp
+++ b/src/core/thread/network_data_types.hpp
@@ -157,7 +157,7 @@ public:
      * @return The prefix.
      *
      */
-    const Ip6::Prefix &GetPrefix(void) const { return static_cast<const Ip6::Prefix &>(mPrefix); }
+    const Ip6::Prefix &GetPrefix(void) const { return AsCoreType(&mPrefix); }
 
     /**
      * This method gets the prefix.
@@ -165,7 +165,7 @@ public:
      * @return The prefix.
      *
      */
-    Ip6::Prefix &GetPrefix(void) { return static_cast<Ip6::Prefix &>(mPrefix); }
+    Ip6::Prefix &GetPrefix(void) { return AsCoreType(&mPrefix); }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
     /**
@@ -209,7 +209,7 @@ public:
      * @return The prefix.
      *
      */
-    const Ip6::Prefix &GetPrefix(void) const { return static_cast<const Ip6::Prefix &>(mPrefix); }
+    const Ip6::Prefix &GetPrefix(void) const { return AsCoreType(&mPrefix); }
 
     /**
      * This method gets the prefix.
@@ -217,7 +217,7 @@ public:
      * @return The prefix.
      *
      */
-    Ip6::Prefix &GetPrefix(void) { return static_cast<Ip6::Prefix &>(mPrefix); }
+    Ip6::Prefix &GetPrefix(void) { return AsCoreType(&mPrefix); }
 
     /**
      * This method sets the prefix.

--- a/src/core/utils/ping_sender.hpp
+++ b/src/core/utils/ping_sender.hpp
@@ -101,7 +101,7 @@ public:
          * @returns The ping source IPv6 address.
          *
          */
-        Ip6::Address &GetSource(void) { return static_cast<Ip6::Address &>(mSource); }
+        Ip6::Address &GetSource(void) { return AsCoreType(&mSource); }
 
         /**
          * This method gets the source IPv6 address of the ping.
@@ -109,7 +109,7 @@ public:
          * @returns The ping source IPv6 address.
          *
          */
-        const Ip6::Address &GetSource(void) const { return static_cast<const Ip6::Address &>(mSource); }
+        const Ip6::Address &GetSource(void) const { return AsCoreType(&mSource); }
 
         /**
          * This method gets the destination IPv6 address to ping.
@@ -117,7 +117,7 @@ public:
          * @returns The ping destination IPv6 address.
          *
          */
-        Ip6::Address &GetDestination(void) { return static_cast<Ip6::Address &>(mDestination); }
+        Ip6::Address &GetDestination(void) { return AsCoreType(&mDestination); }
 
         /**
          * This method gets the destination IPv6 address to ping.
@@ -125,7 +125,7 @@ public:
          * @returns The ping destination IPv6 address.
          *
          */
-        const Ip6::Address &GetDestination(void) const { return static_cast<const Ip6::Address &>(mDestination); }
+        const Ip6::Address &GetDestination(void) const { return AsCoreType(&mDestination); }
 
     private:
         static constexpr uint16_t kDefaultSize     = OPENTHREAD_CONFIG_PING_SENDER_DEFAULT_SIZE;


### PR DESCRIPTION
In PR #7128, the `DefineCoreType()` & `DefineMapEnum()` definitions
(which map the public and core types) were moved to header files
that define the corresponding core type. This allows us to use the
`AsCoreType()` in header files. This commit changes some of inline
methods in the core headers to use it.