### PR TITLE
[tlv] add `As<TlvType>()` helper methods

### DIFF
--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -189,9 +189,8 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
 
     if (Tlv::Find<ThreadCommissionerSessionIdTlv>(aMessage, commissionerSessionId) == kErrorNone)
     {
-        const MeshCoP::CommissionerSessionIdTlv *commissionerSessionIdTlv =
-            static_cast<const MeshCoP::CommissionerSessionIdTlv *>(
-                Get<NetworkData::Leader>().GetCommissioningDataSubTlv(MeshCoP::Tlv::kCommissionerSessionId));
+        const MeshCoP::CommissionerSessionIdTlv *commissionerSessionIdTlv = As<MeshCoP::CommissionerSessionIdTlv>(
+            Get<NetworkData::Leader>().GetCommissioningDataSubTlv(MeshCoP::Tlv::kCommissionerSessionId));
 
         VerifyOrExit(commissionerSessionIdTlv != nullptr &&
                          commissionerSessionIdTlv->GetCommissionerSessionId() == commissionerSessionId,

--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -41,8 +41,7 @@ namespace ot {
 
 uint32_t Tlv::GetSize(void) const
 {
-    return IsExtended() ? sizeof(ExtendedTlv) + static_cast<const ExtendedTlv *>(this)->GetLength()
-                        : sizeof(Tlv) + GetLength();
+    return IsExtended() ? sizeof(ExtendedTlv) + As<ExtendedTlv>(this)->GetLength() : sizeof(Tlv) + GetLength();
 }
 
 uint8_t *Tlv::GetValue(void)

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -469,6 +469,66 @@ private:
 } OT_TOOL_PACKED_END;
 
 /**
+ * This template method casts a `Tlv` pointer to a given subclass `TlvType` pointer.
+ *
+ * @tparam TlvType  The TLV type to cast into. MUST be a subclass of `Tlv`.
+ *
+ * @param[in] aTlv   A pointer to a `Tlv` to convert/cast to a `TlvType`.
+ *
+ * @returns A `TlvType` pointer to `aTlv`.
+ *
+ */
+template <class TlvType> TlvType *As(Tlv *aTlv)
+{
+    return static_cast<TlvType *>(aTlv);
+}
+
+/**
+ * This template method casts a `Tlv` pointer to a given subclass `TlvType` pointer.
+ *
+ * @tparam TlvType  The TLV type to cast into. MUST be a subclass of `Tlv`.
+ *
+ * @param[in] aTlv   A pointer to a `Tlv` to convert/cast to a `TlvType`.
+ *
+ * @returns A `TlvType` pointer to `aTlv`.
+ *
+ */
+template <class TlvType> const TlvType *As(const Tlv *aTlv)
+{
+    return static_cast<const TlvType *>(aTlv);
+}
+
+/**
+ * This template method casts a `Tlv` reference to a given subclass `TlvType` reference.
+ *
+ * @tparam TlvType  The TLV type to cast into. MUST be a subclass of `Tlv`.
+ *
+ * @param[in] aTlv   A reference to a `Tlv` to convert/cast to a `TlvType`.
+ *
+ * @returns A `TlvType` reference to `aTlv`.
+ *
+ */
+template <class TlvType> TlvType &As(Tlv &aTlv)
+{
+    return static_cast<TlvType &>(aTlv);
+}
+
+/**
+ * This template method casts a `Tlv` reference to a given subclass `TlvType` reference.
+ *
+ * @tparam TlvType  The TLV type to cast into. MUST be a subclass of `Tlv`.
+ *
+ * @param[in] aTlv   A reference to a `Tlv` to convert/cast to a `TlvType`.
+ *
+ * @returns A `TlvType` reference to `aTlv`.
+ *
+ */
+template <class TlvType> const TlvType &As(const Tlv &aTlv)
+{
+    return static_cast<const TlvType &>(aTlv);
+}
+
+/**
  * This class defines constants for a TLV.
  *
  * @tparam kTlvTypeValue   The TLV Type value.

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -191,16 +191,16 @@ void Dataset::ConvertTo(Info &aDatasetInfo) const
         switch (cur->GetType())
         {
         case Tlv::kActiveTimestamp:
-            aDatasetInfo.SetActiveTimestamp(static_cast<const ActiveTimestampTlv *>(cur)->GetTimestamp().GetSeconds());
+            aDatasetInfo.SetActiveTimestamp(As<ActiveTimestampTlv>(cur)->GetTimestamp().GetSeconds());
             break;
 
         case Tlv::kChannel:
-            aDatasetInfo.SetChannel(static_cast<const ChannelTlv *>(cur)->GetChannel());
+            aDatasetInfo.SetChannel(As<ChannelTlv>(cur)->GetChannel());
             break;
 
         case Tlv::kChannelMask:
         {
-            uint32_t mask = static_cast<const ChannelMaskTlv *>(cur)->GetChannelMask();
+            uint32_t mask = As<ChannelMaskTlv>(cur)->GetChannelMask();
 
             if (mask != 0)
             {
@@ -211,45 +211,40 @@ void Dataset::ConvertTo(Info &aDatasetInfo) const
         }
 
         case Tlv::kDelayTimer:
-            aDatasetInfo.SetDelay(static_cast<const DelayTimerTlv *>(cur)->GetDelayTimer());
+            aDatasetInfo.SetDelay(As<DelayTimerTlv>(cur)->GetDelayTimer());
             break;
 
         case Tlv::kExtendedPanId:
-            aDatasetInfo.SetExtendedPanId(static_cast<const ExtendedPanIdTlv *>(cur)->GetExtendedPanId());
+            aDatasetInfo.SetExtendedPanId(As<ExtendedPanIdTlv>(cur)->GetExtendedPanId());
             break;
 
         case Tlv::kMeshLocalPrefix:
-            aDatasetInfo.SetMeshLocalPrefix(static_cast<const MeshLocalPrefixTlv *>(cur)->GetMeshLocalPrefix());
+            aDatasetInfo.SetMeshLocalPrefix(As<MeshLocalPrefixTlv>(cur)->GetMeshLocalPrefix());
             break;
 
         case Tlv::kNetworkKey:
-            aDatasetInfo.SetNetworkKey(static_cast<const NetworkKeyTlv *>(cur)->GetNetworkKey());
+            aDatasetInfo.SetNetworkKey(As<NetworkKeyTlv>(cur)->GetNetworkKey());
             break;
 
         case Tlv::kNetworkName:
-            aDatasetInfo.SetNetworkName(static_cast<const NetworkNameTlv *>(cur)->GetNetworkName());
+            aDatasetInfo.SetNetworkName(As<NetworkNameTlv>(cur)->GetNetworkName());
             break;
 
         case Tlv::kPanId:
-            aDatasetInfo.SetPanId(static_cast<const PanIdTlv *>(cur)->GetPanId());
+            aDatasetInfo.SetPanId(As<PanIdTlv>(cur)->GetPanId());
             break;
 
         case Tlv::kPendingTimestamp:
-            aDatasetInfo.SetPendingTimestamp(
-                static_cast<const PendingTimestampTlv *>(cur)->GetTimestamp().GetSeconds());
+            aDatasetInfo.SetPendingTimestamp(As<PendingTimestampTlv>(cur)->GetTimestamp().GetSeconds());
             break;
 
         case Tlv::kPskc:
-            aDatasetInfo.SetPskc(static_cast<const PskcTlv *>(cur)->GetPskc());
+            aDatasetInfo.SetPskc(As<PskcTlv>(cur)->GetPskc());
             break;
 
         case Tlv::kSecurityPolicy:
-        {
-            const SecurityPolicyTlv *tlv = static_cast<const SecurityPolicyTlv *>(cur);
-
-            aDatasetInfo.SetSecurityPolicy(tlv->GetSecurityPolicy());
+            aDatasetInfo.SetSecurityPolicy(As<SecurityPolicyTlv>(cur)->GetSecurityPolicy());
             break;
-        }
 
         default:
             break;
@@ -486,8 +481,8 @@ Error Dataset::AppendMleDatasetTlv(Type aType, Message &aMessage) const
         }
         else if (cur->GetType() == Tlv::kDelayTimer)
         {
-            uint32_t      elapsed = TimerMilli::GetNow() - mUpdateTime;
-            DelayTimerTlv delayTimer(static_cast<const DelayTimerTlv &>(*cur));
+            uint32_t      elapsed    = TimerMilli::GetNow() - mUpdateTime;
+            DelayTimerTlv delayTimer = *As<DelayTimerTlv>(cur);
 
             if (delayTimer.GetDelayTimer() > elapsed)
             {
@@ -538,7 +533,7 @@ Error Dataset::ApplyConfiguration(Instance &aInstance, bool *aIsNetworkKeyUpdate
         {
         case Tlv::kChannel:
         {
-            uint8_t channel = static_cast<uint8_t>(static_cast<const ChannelTlv *>(cur)->GetChannel());
+            uint8_t channel = static_cast<uint8_t>(As<ChannelTlv>(cur)->GetChannel());
 
             error = mac.SetPanChannel(channel);
 
@@ -553,20 +548,20 @@ Error Dataset::ApplyConfiguration(Instance &aInstance, bool *aIsNetworkKeyUpdate
         }
 
         case Tlv::kPanId:
-            mac.SetPanId(static_cast<const PanIdTlv *>(cur)->GetPanId());
+            mac.SetPanId(As<PanIdTlv>(cur)->GetPanId());
             break;
 
         case Tlv::kExtendedPanId:
-            mac.SetExtendedPanId(static_cast<const ExtendedPanIdTlv *>(cur)->GetExtendedPanId());
+            mac.SetExtendedPanId(As<ExtendedPanIdTlv>(cur)->GetExtendedPanId());
             break;
 
         case Tlv::kNetworkName:
-            IgnoreError(mac.SetNetworkName(static_cast<const NetworkNameTlv *>(cur)->GetNetworkName()));
+            IgnoreError(mac.SetNetworkName(As<NetworkNameTlv>(cur)->GetNetworkName()));
             break;
 
         case Tlv::kNetworkKey:
         {
-            const NetworkKeyTlv *key = static_cast<const NetworkKeyTlv *>(cur);
+            const NetworkKeyTlv *key = As<NetworkKeyTlv>(cur);
             NetworkKey           networkKey;
 
             keyManager.GetNetworkKey(networkKey);
@@ -583,22 +578,18 @@ Error Dataset::ApplyConfiguration(Instance &aInstance, bool *aIsNetworkKeyUpdate
 #if OPENTHREAD_FTD
 
         case Tlv::kPskc:
-            keyManager.SetPskc(static_cast<const PskcTlv *>(cur)->GetPskc());
+            keyManager.SetPskc(As<PskcTlv>(cur)->GetPskc());
             break;
 
 #endif
 
         case Tlv::kMeshLocalPrefix:
-            aInstance.Get<Mle::MleRouter>().SetMeshLocalPrefix(
-                static_cast<const MeshLocalPrefixTlv *>(cur)->GetMeshLocalPrefix());
+            aInstance.Get<Mle::MleRouter>().SetMeshLocalPrefix(As<MeshLocalPrefixTlv>(cur)->GetMeshLocalPrefix());
             break;
 
         case Tlv::kSecurityPolicy:
-        {
-            const SecurityPolicyTlv *securityPolicy = static_cast<const SecurityPolicyTlv *>(cur);
-            keyManager.SetSecurityPolicy(securityPolicy->GetSecurityPolicy());
+            keyManager.SetSecurityPolicy(As<SecurityPolicyTlv>(cur)->GetSecurityPolicy());
             break;
-        }
 
         default:
             break;

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -647,7 +647,7 @@ public:
      */
     template <typename TlvType> TlvType *GetTlv(void)
     {
-        return static_cast<TlvType *>(GetTlv(static_cast<Tlv::Type>(TlvType::kType)));
+        return As<TlvType>(GetTlv(static_cast<Tlv::Type>(TlvType::kType)));
     }
 
     /**
@@ -658,7 +658,7 @@ public:
      */
     template <typename TlvType> const TlvType *GetTlv(void) const
     {
-        return static_cast<const TlvType *>(GetTlv(static_cast<Tlv::Type>(TlvType::kType)));
+        return As<TlvType>(GetTlv(static_cast<Tlv::Type>(TlvType::kType)));
     }
 
     /**

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -169,7 +169,7 @@ Error DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInfo 
 
         isUpdateFromCommissioner = true;
 
-        localId = static_cast<const CommissionerSessionIdTlv *>(
+        localId = As<CommissionerSessionIdTlv>(
             Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kCommissionerSessionId));
 
         VerifyOrExit(localId != nullptr && localId->GetCommissionerSessionId() == sessionId);
@@ -203,7 +203,7 @@ Error DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInfo 
 
             case Tlv::kDelayTimer:
             {
-                DelayTimerTlv &delayTimerTlv = static_cast<DelayTimerTlv &>(static_cast<Tlv &>(datasetTlv));
+                DelayTimerTlv &delayTimerTlv = As<DelayTimerTlv>(datasetTlv);
 
                 if (doesAffectNetworkKey && delayTimerTlv.GetDelayTimer() < DelayTimerTlv::kDelayTimerDefault)
                 {
@@ -241,7 +241,7 @@ Error DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInfo 
         const CommissionerSessionIdTlv *localSessionId;
         Ip6::Address                    destination;
 
-        localSessionId = static_cast<const CommissionerSessionIdTlv *>(
+        localSessionId = As<CommissionerSessionIdTlv>(
             Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kCommissionerSessionId));
         VerifyOrExit(localSessionId != nullptr);
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -106,8 +106,7 @@ uint16_t JoinerRouter::GetJoinerUdpPort(void)
 
     VerifyOrExit(!mIsJoinerPortConfigured, rval = mJoinerUdpPort);
 
-    joinerUdpPort = static_cast<const JoinerUdpPortTlv *>(
-        Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kJoinerUdpPort));
+    joinerUdpPort = As<JoinerUdpPortTlv>(Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kJoinerUdpPort));
     VerifyOrExit(joinerUdpPort != nullptr);
 
     rval = joinerUdpPort->GetUdpPort();

--- a/src/core/meshcop/meshcop.cpp
+++ b/src/core/meshcop/meshcop.cpp
@@ -303,7 +303,7 @@ Error GetBorderAgentRloc(ThreadNetif &aNetif, uint16_t &aRloc)
     Error                        error = kErrorNone;
     const BorderAgentLocatorTlv *borderAgentLocator;
 
-    borderAgentLocator = static_cast<const BorderAgentLocatorTlv *>(
+    borderAgentLocator = As<BorderAgentLocatorTlv>(
         aNetif.Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kBorderAgentLocator));
     VerifyOrExit(borderAgentLocator != nullptr, error = kErrorNotFound);
 

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -170,8 +170,8 @@ void Leader::HandleKeepAlive(Coap::Message &aMessage, const Ip6::MessageInfo &aM
 
     SuccessOrExit(Tlv::Find<CommissionerSessionIdTlv>(aMessage, sessionId));
 
-    borderAgentLocator = static_cast<BorderAgentLocatorTlv *>(
-        Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kBorderAgentLocator));
+    borderAgentLocator =
+        As<BorderAgentLocatorTlv>(Get<NetworkData::Leader>().GetCommissioningDataSubTlv(Tlv::kBorderAgentLocator));
 
     if ((borderAgentLocator == nullptr) || (sessionId != mSessionId))
     {

--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -48,39 +48,39 @@ bool Tlv::IsValid(const Tlv &aTlv)
     switch (aTlv.GetType())
     {
     case Tlv::kChannel:
-        rval = static_cast<const ChannelTlv &>(aTlv).IsValid();
+        rval = As<ChannelTlv>(aTlv).IsValid();
         break;
 
     case Tlv::kPanId:
-        rval = static_cast<const PanIdTlv &>(aTlv).IsValid();
+        rval = As<PanIdTlv>(aTlv).IsValid();
         break;
 
     case Tlv::kExtendedPanId:
-        rval = static_cast<const ExtendedPanIdTlv &>(aTlv).IsValid();
+        rval = As<ExtendedPanIdTlv>(aTlv).IsValid();
         break;
 
     case Tlv::kNetworkName:
-        rval = static_cast<const NetworkNameTlv &>(aTlv).IsValid();
+        rval = As<NetworkNameTlv>(aTlv).IsValid();
         break;
 
     case Tlv::kNetworkKey:
-        rval = static_cast<const NetworkKeyTlv &>(aTlv).IsValid();
+        rval = As<NetworkKeyTlv>(aTlv).IsValid();
         break;
 
     case Tlv::kPskc:
-        rval = static_cast<const PskcTlv &>(aTlv).IsValid();
+        rval = As<PskcTlv>(aTlv).IsValid();
         break;
 
     case Tlv::kMeshLocalPrefix:
-        rval = static_cast<const MeshLocalPrefixTlv &>(aTlv).IsValid();
+        rval = As<MeshLocalPrefixTlv>(aTlv).IsValid();
         break;
 
     case Tlv::kSecurityPolicy:
-        rval = static_cast<const SecurityPolicyTlv &>(aTlv).IsValid();
+        rval = As<SecurityPolicyTlv>(aTlv).IsValid();
         break;
 
     case Tlv::kChannelMask:
-        rval = static_cast<const ChannelMaskTlv &>(aTlv).IsValid();
+        rval = As<ChannelMaskTlv>(aTlv).IsValid();
         break;
 
     default:

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -139,7 +139,7 @@ public:
      * @returns A pointer to the next TLV.
      *
      */
-    Tlv *GetNext(void) { return static_cast<Tlv *>(ot::Tlv::GetNext()); }
+    Tlv *GetNext(void) { return As<Tlv>(ot::Tlv::GetNext()); }
 
     /**
      * This method returns a pointer to the next TLV.
@@ -147,7 +147,7 @@ public:
      * @returns A pointer to the next TLV.
      *
      */
-    const Tlv *GetNext(void) const { return static_cast<const Tlv *>(ot::Tlv::GetNext()); }
+    const Tlv *GetNext(void) const { return As<Tlv>(ot::Tlv::GetNext()); }
 
     /**
      * This static method reads the requested TLV out of @p aMessage.
@@ -235,7 +235,7 @@ public:
      */
     template <typename TlvType> static TlvType *FindTlv(uint8_t *aTlvsStart, uint16_t aTlvsLength)
     {
-        return static_cast<TlvType *>(FindTlv(aTlvsStart, aTlvsLength, static_cast<Tlv::Type>(TlvType::kType)));
+        return As<TlvType>(FindTlv(aTlvsStart, aTlvsLength, static_cast<Tlv::Type>(TlvType::kType)));
     }
 
     /**
@@ -250,7 +250,7 @@ public:
      */
     template <typename TlvType> static const TlvType *FindTlv(const uint8_t *aTlvsStart, uint16_t aTlvsLength)
     {
-        return static_cast<const TlvType *>(FindTlv(aTlvsStart, aTlvsLength, static_cast<Tlv::Type>(TlvType::kType)));
+        return As<TlvType>(FindTlv(aTlvsStart, aTlvsLength, static_cast<Tlv::Type>(TlvType::kType)));
     }
 
 } OT_TOOL_PACKED_END;

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -151,13 +151,13 @@ Error NetworkData::Iterate(Iterator &aIterator, uint16_t aRloc16, Config &aConfi
         case NetworkDataTlv::kTypePrefix:
             if ((aConfig.mOnMeshPrefix != nullptr) || (aConfig.mExternalRoute != nullptr))
             {
-                subTlvs = static_cast<const PrefixTlv *>(cur)->GetSubTlvs();
+                subTlvs = As<PrefixTlv>(cur)->GetSubTlvs();
             }
             break;
         case NetworkDataTlv::kTypeService:
             if (aConfig.mService != nullptr)
             {
-                subTlvs = static_cast<const ServiceTlv *>(cur)->GetSubTlvs();
+                subTlvs = As<ServiceTlv>(cur)->GetSubTlvs();
             }
             break;
         default:
@@ -175,13 +175,13 @@ Error NetworkData::Iterate(Iterator &aIterator, uint16_t aRloc16, Config &aConfi
         {
             if (cur->GetType() == NetworkDataTlv::kTypePrefix)
             {
-                const PrefixTlv *prefixTlv = static_cast<const PrefixTlv *>(cur);
+                const PrefixTlv *prefixTlv = As<PrefixTlv>(cur);
 
                 switch (subCur->GetType())
                 {
                 case NetworkDataTlv::kTypeBorderRouter:
                 {
-                    const BorderRouterTlv *borderRouter = static_cast<const BorderRouterTlv *>(subCur);
+                    const BorderRouterTlv *borderRouter = As<BorderRouterTlv>(subCur);
 
                     if (aConfig.mOnMeshPrefix == nullptr)
                     {
@@ -207,7 +207,7 @@ Error NetworkData::Iterate(Iterator &aIterator, uint16_t aRloc16, Config &aConfi
 
                 case NetworkDataTlv::kTypeHasRoute:
                 {
-                    const HasRouteTlv *hasRoute = static_cast<const HasRouteTlv *>(subCur);
+                    const HasRouteTlv *hasRoute = As<HasRouteTlv>(subCur);
 
                     if (aConfig.mExternalRoute == nullptr)
                     {
@@ -237,7 +237,7 @@ Error NetworkData::Iterate(Iterator &aIterator, uint16_t aRloc16, Config &aConfi
             }
             else // cur is `ServiceTLv`
             {
-                const ServiceTlv *service = static_cast<const ServiceTlv *>(cur);
+                const ServiceTlv *service = As<ServiceTlv>(cur);
 
                 if (aConfig.mService == nullptr)
                 {
@@ -246,7 +246,7 @@ Error NetworkData::Iterate(Iterator &aIterator, uint16_t aRloc16, Config &aConfi
 
                 if (subCur->GetType() == NetworkDataTlv::kTypeServer)
                 {
-                    const ServerTlv *server = static_cast<const ServerTlv *>(subCur);
+                    const ServerTlv *server = As<ServerTlv>(subCur);
 
                     if (!iterator.IsNewEntry())
                     {
@@ -402,7 +402,7 @@ void MutableNetworkData::RemoveTemporaryData(void)
         {
         case NetworkDataTlv::kTypePrefix:
         {
-            PrefixTlv *prefix = static_cast<PrefixTlv *>(cur);
+            PrefixTlv *prefix = As<PrefixTlv>(cur);
 
             RemoveTemporaryDataIn(*prefix);
 
@@ -417,7 +417,8 @@ void MutableNetworkData::RemoveTemporaryData(void)
 
         case NetworkDataTlv::kTypeService:
         {
-            ServiceTlv *service = static_cast<ServiceTlv *>(cur);
+            ServiceTlv *service = As<ServiceTlv>(cur);
+
             RemoveTemporaryDataIn(*service);
 
             if (service->GetSubTlvsLength() == 0)
@@ -456,7 +457,7 @@ void MutableNetworkData::RemoveTemporaryDataIn(PrefixTlv &aPrefix)
             {
             case NetworkDataTlv::kTypeBorderRouter:
             {
-                BorderRouterTlv *borderRouter = static_cast<BorderRouterTlv *>(cur);
+                BorderRouterTlv *borderRouter = As<BorderRouterTlv>(cur);
                 ContextTlv *     context      = aPrefix.FindSubTlv<ContextTlv>();
 
                 // Replace p_border_router_16
@@ -478,7 +479,7 @@ void MutableNetworkData::RemoveTemporaryDataIn(PrefixTlv &aPrefix)
 
             case NetworkDataTlv::kTypeHasRoute:
             {
-                HasRouteTlv *hasRoute = static_cast<HasRouteTlv *>(cur);
+                HasRouteTlv *hasRoute = As<HasRouteTlv>(cur);
 
                 // Replace r_border_router_16
                 for (HasRouteEntry *entry = hasRoute->GetFirstEntry(); entry <= hasRoute->GetLastEntry();
@@ -518,11 +519,8 @@ void MutableNetworkData::RemoveTemporaryDataIn(ServiceTlv &aService)
             switch (cur->GetType())
             {
             case NetworkDataTlv::kTypeServer:
-            {
-                ServerTlv *server = static_cast<ServerTlv *>(cur);
-                server->SetServer16(Mle::Mle::ServiceAlocFromId(aService.GetServiceId()));
+                As<ServerTlv>(cur)->SetServer16(Mle::Mle::ServiceAlocFromId(aService.GetServiceId()));
                 break;
-            }
 
             default:
                 break;

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -394,8 +394,7 @@ Error LeaderBase::SetCommissioningData(const uint8_t *aValue, uint8_t aValueLeng
     if (aValueLength > 0)
     {
         VerifyOrExit(aValueLength <= kMaxSize - sizeof(CommissioningDataTlv), error = kErrorNoBufs);
-        commissioningDataTlv =
-            static_cast<CommissioningDataTlv *>(AppendTlv(sizeof(CommissioningDataTlv) + aValueLength));
+        commissioningDataTlv = As<CommissioningDataTlv>(AppendTlv(sizeof(CommissioningDataTlv) + aValueLength));
         VerifyOrExit(commissioningDataTlv != nullptr, error = kErrorNoBufs);
 
         commissioningDataTlv->Init();
@@ -471,7 +470,7 @@ Error LeaderBase::SteeringDataCheck(const FilterIndexes &aFilterIndexes) const
     steeringDataTlv = GetCommissioningDataSubTlv(MeshCoP::Tlv::kSteeringData);
     VerifyOrExit(steeringDataTlv != nullptr, error = kErrorInvalidState);
 
-    static_cast<const MeshCoP::SteeringDataTlv *>(steeringDataTlv)->CopyTo(steeringData);
+    As<MeshCoP::SteeringDataTlv>(steeringDataTlv)->CopyTo(steeringData);
 
     VerifyOrExit(steeringData.Contains(aFilterIndexes), error = kErrorNotFound);
 

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -96,7 +96,7 @@ Error Local::AddPrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvT
                        ? sizeof(BorderRouterTlv) + sizeof(BorderRouterEntry)
                        : sizeof(HasRouteTlv) + sizeof(HasRouteEntry);
 
-    prefixTlv = static_cast<PrefixTlv *>(AppendTlv(sizeof(PrefixTlv) + aPrefix.GetBytesSize() + subTlvLength));
+    prefixTlv = As<PrefixTlv>(AppendTlv(sizeof(PrefixTlv) + aPrefix.GetBytesSize() + subTlvLength));
     VerifyOrExit(prefixTlv != nullptr, error = kErrorNoBufs);
 
     prefixTlv->Init(0, aPrefix);
@@ -104,7 +104,7 @@ Error Local::AddPrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvT
 
     if (aSubTlvType == NetworkDataTlv::kTypeBorderRouter)
     {
-        BorderRouterTlv *brTlv = static_cast<BorderRouterTlv *>(prefixTlv->GetSubTlvs());
+        BorderRouterTlv *brTlv = As<BorderRouterTlv>(prefixTlv->GetSubTlvs());
         brTlv->Init();
         brTlv->SetLength(brTlv->GetLength() + sizeof(BorderRouterEntry));
         brTlv->GetEntry(0)->Init();
@@ -112,7 +112,7 @@ Error Local::AddPrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvT
     }
     else // aSubTlvType is NetworkDataTlv::kTypeHasRoute
     {
-        HasRouteTlv *hasRouteTlv = static_cast<HasRouteTlv *>(prefixTlv->GetSubTlvs());
+        HasRouteTlv *hasRouteTlv = As<HasRouteTlv>(prefixTlv->GetSubTlvs());
         hasRouteTlv->Init();
         hasRouteTlv->SetLength(hasRouteTlv->GetLength() + sizeof(HasRouteEntry));
         hasRouteTlv->GetEntry(0)->Init();
@@ -154,11 +154,11 @@ void Local::UpdateRloc(PrefixTlv &aPrefixTlv)
         switch (cur->GetType())
         {
         case NetworkDataTlv::kTypeHasRoute:
-            static_cast<HasRouteTlv *>(cur)->GetEntry(0)->SetRloc(rloc16);
+            As<HasRouteTlv>(cur)->GetEntry(0)->SetRloc(rloc16);
             break;
 
         case NetworkDataTlv::kTypeBorderRouter:
-            static_cast<BorderRouterTlv *>(cur)->GetEntry(0)->SetRloc(rloc16);
+            As<BorderRouterTlv>(cur)->GetEntry(0)->SetRloc(rloc16);
             break;
 
         default:
@@ -198,13 +198,13 @@ Error Local::AddService(uint32_t           aEnterpriseNumber,
 
     VerifyOrExit(serviceTlvSize <= kMaxSize, error = kErrorNoBufs);
 
-    serviceTlv = static_cast<ServiceTlv *>(AppendTlv(serviceTlvSize));
+    serviceTlv = As<ServiceTlv>(AppendTlv(serviceTlvSize));
     VerifyOrExit(serviceTlv != nullptr, error = kErrorNoBufs);
 
     serviceTlv->Init(/* aServiceId */ 0, aEnterpriseNumber, aServiceData);
     serviceTlv->SetSubTlvsLength(sizeof(ServerTlv) + aServerData.GetLength());
 
-    serverTlv = static_cast<ServerTlv *>(serviceTlv->GetSubTlvs());
+    serverTlv = As<ServerTlv>(serviceTlv->GetSubTlvs());
     serverTlv->Init(Get<Mle::MleRouter>().GetRloc16(), aServerData);
 
     // According to Thread spec 1.1.1, section 5.18.6 Service TLV:
@@ -245,7 +245,7 @@ void Local::UpdateRloc(ServiceTlv &aService)
         switch (cur->GetType())
         {
         case NetworkDataTlv::kTypeServer:
-            static_cast<ServerTlv *>(cur)->SetServer16(rloc16);
+            As<ServerTlv>(cur)->SetServer16(rloc16);
             break;
 
         default:
@@ -271,14 +271,14 @@ void Local::UpdateRloc(void)
         {
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
         case NetworkDataTlv::kTypePrefix:
-            UpdateRloc(*static_cast<PrefixTlv *>(cur));
+            UpdateRloc(*As<PrefixTlv>(cur));
             break;
 #endif
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
         case NetworkDataTlv::kTypeService:
-            UpdateRloc(*static_cast<ServiceTlv *>(cur));
+            UpdateRloc(*As<ServiceTlv>(cur));
             break;
 #endif
 

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -61,6 +61,68 @@ using ot::Encoding::BigEndian::HostSwap32;
  *
  */
 
+class NetworkDataTlv;
+
+/**
+ * This template method casts a `NetworkDataTlv` pointer to a given subclass `TlvType` pointer.
+ *
+ * @tparam TlvType  The TLV type to cast into. MUST be a subclass of `NetworkDataTlv`.
+ *
+ * @param[in] aTlv   A pointer to a `NetworkDataTlv` to convert/cast to a `TlvType`.
+ *
+ * @returns A `TlvType` pointer to `aTlv`.
+ *
+ */
+template <class TlvType> TlvType *As(NetworkDataTlv *aTlv)
+{
+    return static_cast<TlvType *>(aTlv);
+}
+
+/**
+ * This template method casts a `NetworkDataTlv` pointer to a given subclass `TlvType` pointer.
+ *
+ * @tparam TlvType  The TLV type to cast into. MUST be a subclass of `NetworkDataTlv`.
+ *
+ * @param[in] aTlv   A pointer to a `NetworkDataTlv` to convert/cast to a `TlvType`.
+ *
+ * @returns A `TlvType` pointer to `aTlv`.
+ *
+ */
+template <class TlvType> const TlvType *As(const NetworkDataTlv *aTlv)
+{
+    return static_cast<const TlvType *>(aTlv);
+}
+
+/**
+ * This template method casts a `NetworkDataTlv` reference to a given subclass `TlvType` reference.
+ *
+ * @tparam TlvType  The TLV type to cast into. MUST be a subclass of `NetworkDataTlv`.
+ *
+ * @param[in] aTlv   A reference to a `NetworkDataTlv` to convert/cast to a `TlvType`.
+ *
+ * @returns A `TlvType` reference to `aTlv`.
+ *
+ */
+template <class TlvType> TlvType &As(NetworkDataTlv &aTlv)
+{
+    return static_cast<TlvType &>(aTlv);
+}
+
+/**
+ * This template method casts a `NetworkDataTlv` reference to a given subclass `TlvType` reference.
+ *
+ * @tparam TlvType  The TLV type to cast into. MUST be a subclass of `NetworkDataTlv`.
+ *
+ * @param[in] aTlv   A reference to a `NetworkDataTlv` to convert/cast to a `TlvType`.
+ *
+ * @returns A `TlvType` reference to `aTlv`.
+ *
+ */
+template <class TlvType> const TlvType &As(const NetworkDataTlv &aTlv)
+{
+    return static_cast<const TlvType &>(aTlv);
+}
+
 /**
  * This class implements Thread Network Data TLV generation and parsing.
  *
@@ -250,7 +312,7 @@ public:
      */
     template <typename TlvType> static TlvType *Find(NetworkDataTlv *aStart, NetworkDataTlv *aEnd)
     {
-        return static_cast<TlvType *>(Find(aStart, aEnd, TlvType::kType));
+        return As<TlvType>(Find(aStart, aEnd, TlvType::kType));
     }
 
     /**
@@ -266,7 +328,7 @@ public:
      */
     template <typename TlvType> static const TlvType *Find(const NetworkDataTlv *aStart, const NetworkDataTlv *aEnd)
     {
-        return static_cast<const TlvType *>(Find(aStart, aEnd, TlvType::kType));
+        return As<TlvType>(Find(aStart, aEnd, TlvType::kType));
     }
 
     /**
@@ -318,7 +380,7 @@ public:
      */
     template <typename TlvType> static TlvType *Find(NetworkDataTlv *aStart, NetworkDataTlv *aEnd, bool aStable)
     {
-        return static_cast<TlvType *>(Find(aStart, aEnd, TlvType::kType, aStable));
+        return As<TlvType>(Find(aStart, aEnd, TlvType::kType, aStable));
     }
 
     /**
@@ -337,7 +399,7 @@ public:
     template <typename TlvType>
     static const TlvType *Find(const NetworkDataTlv *aStart, const NetworkDataTlv *aEnd, bool aStable)
     {
-        return static_cast<const TlvType *>(Find(aStart, aEnd, TlvType::kType, aStable));
+        return As<TlvType>(Find(aStart, aEnd, TlvType::kType, aStable));
     }
 
 private:
@@ -738,7 +800,7 @@ public:
      */
     template <typename SubTlvType> SubTlvType *FindSubTlv(void)
     {
-        return static_cast<SubTlvType *>(FindSubTlv(SubTlvType::kType));
+        return As<SubTlvType>(FindSubTlv(SubTlvType::kType));
     }
 
     /**
@@ -751,7 +813,7 @@ public:
      */
     template <typename SubTlvType> const SubTlvType *FindSubTlv(void) const
     {
-        return static_cast<const SubTlvType *>(FindSubTlv(SubTlvType::kType));
+        return As<SubTlvType>(FindSubTlv(SubTlvType::kType));
     }
 
     /**
@@ -766,7 +828,7 @@ public:
      */
     template <typename SubTlvType> SubTlvType *FindSubTlv(bool aStable)
     {
-        return static_cast<SubTlvType *>(FindSubTlv(static_cast<Type>(SubTlvType::kType), aStable));
+        return As<SubTlvType>(FindSubTlv(static_cast<Type>(SubTlvType::kType), aStable));
     }
 
     /**
@@ -781,7 +843,7 @@ public:
      */
     template <typename SubTlvType> const SubTlvType *FindSubTlv(bool aStable) const
     {
-        return static_cast<const SubTlvType *>(FindSubTlv(static_cast<Type>(SubTlvType::kType), aStable));
+        return As<SubTlvType>(FindSubTlv(static_cast<Type>(SubTlvType::kType), aStable));
     }
 
     /**
@@ -1567,10 +1629,7 @@ public:
      * @returns A pointer to the next TLV, or nullptr if it can not be found.
      *
      */
-    template <typename TlvType> const TlvType *Iterate(void)
-    {
-        return static_cast<const TlvType *>(Iterate(TlvType::kType));
-    }
+    template <typename TlvType> const TlvType *Iterate(void) { return As<TlvType>(Iterate(TlvType::kType)); }
 
     /**
      * This template method iterates to the next TLV with a given type and stable flag.
@@ -1584,7 +1643,7 @@ public:
      */
     template <typename TlvType> const TlvType *Iterate(bool aStable)
     {
-        return static_cast<const TlvType *>(Iterate(TlvType::kType, aStable));
+        return As<TlvType>(Iterate(TlvType::kType, aStable));
     }
 
 private:

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -802,7 +802,7 @@ Error NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
 
         case NetworkDiagnosticTlv::kIp6AddressList:
         {
-            Ip6AddressListTlv &ip6AddrList = static_cast<Ip6AddressListTlv &>(tlv);
+            Ip6AddressListTlv &ip6AddrList = As<Ip6AddressListTlv>(tlv);
 
             VerifyOrExit(ip6AddrList.IsValid(), error = kErrorParse);
             VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mIp6AddrList.mList) >= ip6AddrList.GetLength(),
@@ -834,7 +834,7 @@ Error NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
 
         case NetworkDiagnosticTlv::kChildTable:
         {
-            ChildTableTlv &childTable = static_cast<ChildTableTlv &>(tlv);
+            ChildTableTlv &childTable = As<ChildTableTlv>(tlv);
 
             VerifyOrExit(childTable.IsValid(), error = kErrorParse);
             VerifyOrExit(childTable.GetNumEntries() <= OT_ARRAY_LENGTH(aNetworkDiagTlv.mData.mChildTable.mTable),


### PR DESCRIPTION
This commit adds a set of `As<TlvType>()` methods which cast from base
`Tlv` pointer or reference to a specific sub-class `TlvType` while
preserving whether the input parameter is `const` or not. This
basically acts as a syntax sugar for this commonly used pattern in the
code.