### PR TITLE
[style] use `nullptr` with backticks in comment

### DIFF
--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -108,7 +108,7 @@ otError Joiner::ProcessStart(Arg aArgs[])
 
     error = otJoinerStart(GetInstancePtr(),
                           aArgs[0].GetCString(),           // aPskd
-                          aArgs[1].GetCString(),           // aProvisioningUrl (nullptr if aArgs[1] is empty)
+                          aArgs[1].GetCString(),           // aProvisioningUrl (`nullptr` if aArgs[1] is empty)
                           PACKAGE_NAME,                    // aVendorName
                           OPENTHREAD_CONFIG_PLATFORM_INFO, // aVendorModel
                           PACKAGE_VERSION,                 // aVendorSwVersion

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -88,7 +88,7 @@ public:
      * Note: available only when `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is enabled.
      *       Only used for test and certification.
      *
-     * @param[in] aMlIid    A pointer to the Mesh Local IID. If nullptr, respond with @p aStatus for any
+     * @param[in] aMlIid    A pointer to the Mesh Local IID. If `nullptr`, respond with @p aStatus for any
      *                      coming DUA.req, otherwise only respond the one with matching @p aMlIid.
      * @param[in] aStatus   The status to respond.
      *

--- a/src/core/border_router/router_advertisement.hpp
+++ b/src/core/border_router/router_advertisement.hpp
@@ -140,11 +140,11 @@ public:
     /**
      * This helper method returns a pointer to the next valid option in the buffer.
      *
-     * @param[in]  aCurOption     The current option. Use nullptr to get the first option.
+     * @param[in]  aCurOption     The current option. Use `nullptr` to get the first option.
      * @param[in]  aBuffer        The buffer within which the options are held.
      * @param[in]  aBufferLength  The length of the buffer.
      *
-     * @returns  A pointer to the next option if there are a valid one. Otherwise, nullptr.
+     * @returns  A pointer to the next option if there are a valid one. Otherwise, `nullptr`.
      *
      */
     static const Option *GetNextOption(const Option *aCurOption, const uint8_t *aBuffer, uint16_t aBufferLength);

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -681,7 +681,7 @@ Error RoutingManager::SendRouterSolicitation(void)
 // @param[in]  aNewOmrPrefixes   An array of the new OMR prefixes to be advertised.
 //                               Empty array means we should stop advertising OMR prefixes.
 // @param[in]  aOnLinkPrefix     A pointer to the new on-link prefix to be advertised.
-//                               nullptr means we should stop advertising on-link prefix.
+//                               `nullptr` means we should stop advertising on-link prefix.
 void RoutingManager::SendRouterAdvertisement(const OmrPrefixArray &aNewOmrPrefixes, const Ip6::Prefix *aNewOnLinkPrefix)
 {
     uint8_t  buffer[kMaxRouterAdvMessageLength];

--- a/src/core/coap/coap.hpp
+++ b/src/core/coap/coap.hpp
@@ -91,12 +91,12 @@ public:
     /**
      * This static method coverts a pointer to `otCoapTxParameters` to `Coap::TxParamters`
      *
-     * If the pointer is nullptr, the default parameters are used instead.
+     * If the pointer is `nullptr`, the default parameters are used instead.
      *
      * @param[in] aTxParameters   A pointer to tx parameter.
      *
-     * @returns A reference to corresponding `TxParamters` if  @p aTxParameters is not nullptr, otherwise the default tx
-     * parameters.
+     * @returns A reference to corresponding `TxParamters` if  @p aTxParameters is not `nullptr`, otherwise the default
+     *          tx parameters.
      *
      */
     static const TxParameters &From(const otCoapTxParameters *aTxParameters)
@@ -226,7 +226,7 @@ public:
     /**
      * This method gets the next entry in the linked list.
      *
-     * @returns A pointer to the next entry in the linked list or nullptr if at the end of the list.
+     * @returns A pointer to the next entry in the linked list or `nullptr` if at the end of the list.
      *
      */
     const ResourceBlockWise *GetNext(void) const
@@ -237,7 +237,7 @@ public:
     /**
      * This method gets the next entry in the linked list.
      *
-     * @returns A pointer to the next entry in the linked list or nullptr if at the end of the list.
+     * @returns A pointer to the next entry in the linked list or `nullptr` if at the end of the list.
      *
      */
     ResourceBlockWise *GetNext(void)
@@ -429,7 +429,7 @@ public:
     /* This method sets the default handler for unhandled CoAP requests.
      *
      * @param[in]  aHandler   A function pointer that shall be called when an unhandled request arrives.
-     * @param[in]  aContext   A pointer to arbitrary context information. May be nullptr if not used.
+     * @param[in]  aContext   A pointer to arbitrary context information. May be `nullptr` if not used.
      *
      */
     void SetDefaultHandler(RequestHandler aHandler, void *aContext);
@@ -439,7 +439,7 @@ public:
      *
      * @param[in]  aSettings  The message settings.
      *
-     * @returns A pointer to the message or nullptr if failed to allocate message.
+     * @returns A pointer to the message or `nullptr` if failed to allocate message.
      *
      */
     Message *NewMessage(const Message::Settings &aSettings = Message::Settings::GetDefault());
@@ -447,7 +447,7 @@ public:
     /**
      * This method creates a new message with a CoAP header that has Network Control priority level.
      *
-     * @returns A pointer to the message or nullptr if failed to allocate message.
+     * @returns A pointer to the message or `nullptr` if failed to allocate message.
      *
      */
     Message *NewPriorityMessage(void)
@@ -488,7 +488,7 @@ public:
      * This method sends a CoAP message with custom transmission parameters.
      *
      * If a response for a request is expected, respective function and context information should be provided.
-     * If no response is expected, these arguments should be nullptr pointers.
+     * If no response is expected, these arguments should be `nullptr` pointers.
      * If Message Id was not set in the header (equal to 0), this function will assign unique Message Id to the message.
      *
      * @param[in]  aMessage      A reference to the message to send.
@@ -512,7 +512,7 @@ public:
      * This method sends a CoAP message with default transmission parameters.
      *
      * If a response for a request is expected, respective function and context information should be provided.
-     * If no response is expected, these arguments should be nullptr pointers.
+     * If no response is expected, these arguments should be `nullptr` pointers.
      * If Message Id was not set in the header (equal to 0), this function will assign unique Message Id to the message.
      *
      * @param[in]  aMessage      A reference to the message to send.

--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -810,7 +810,7 @@ public:
      *
      * @param[in] aLength  Number of payload bytes to copy.
      *
-     * @returns A pointer to the message or nullptr if insufficient message buffers are available.
+     * @returns A pointer to the message or `nullptr` if insufficient message buffers are available.
      *
      */
     Message *Clone(uint16_t aLength) const;
@@ -822,7 +822,7 @@ public:
      * `Type`, `SubType`, `LinkSecurity`, `Offset`, `InterfaceId`, and `Priority` fields on the cloned message are also
      * copied from the original one.
      *
-     * @returns A pointer to the message or nullptr if insufficient message buffers are available.
+     * @returns A pointer to the message or `nullptr` if insufficient message buffers are available.
      *
      */
     Message *Clone(void) const { return Clone(GetLength()); }
@@ -839,7 +839,7 @@ public:
      * This method should be used when the message is in a `Coap::MessageQueue` (i.e., a queue containing only CoAP
      * messages).
      *
-     * @returns A pointer to the next message in the queue or nullptr if at the end of the queue.
+     * @returns A pointer to the next message in the queue or `nullptr` if at the end of the queue.
      *
      */
     Message *GetNextCoapMessage(void) { return static_cast<Message *>(GetNext()); }
@@ -850,7 +850,7 @@ public:
      * This method should be used when the message is in a `Coap::MessageQueue` (i.e., a queue containing only CoAP
      * messages).
      *
-     * @returns A pointer to the next message in the queue or nullptr if at the end of the queue.
+     * @returns A pointer to the next message in the queue or `nullptr` if at the end of the queue.
      *
      */
     const Message *GetNextCoapMessage(void) const { return static_cast<const Message *>(GetNext()); }
@@ -1141,7 +1141,7 @@ public:
         /**
          * This methods gets a pointer to the current CoAP Option to which the iterator is currently pointing.
          *
-         * @returns A pointer to the current CoAP Option, or nullptr if iterator is done (or there was an earlier
+         * @returns A pointer to the current CoAP Option, or `nullptr` if iterator is done (or there was an earlier
          *          parse error).
          *
          */

--- a/src/core/common/array.hpp
+++ b/src/core/common/array.hpp
@@ -317,7 +317,7 @@ public:
      *
      * @param[in]  aIndicator  An indicator to match with elements in the array.
      *
-     * @returns A pointer to the matched array element, or nullptr if a match could not be found.
+     * @returns A pointer to the matched array element, or `nullptr` if a match could not be found.
      *
      */
     template <typename Indicator> Type *FindMatching(const Indicator &aIndicator)
@@ -336,7 +336,7 @@ public:
      *
      * @param[in]  aIndicator  An indicator to match with elements in the array.
      *
-     * @returns A pointer to the matched array element, or nullptr if a match could not be found.
+     * @returns A pointer to the matched array element, or `nullptr` if a match could not be found.
      *
      */
     template <typename Indicator> const Type *FindMatching(const Indicator &aIndicator) const

--- a/src/core/common/linked_list.hpp
+++ b/src/core/common/linked_list.hpp
@@ -72,7 +72,7 @@ public:
     /**
      * This method gets the next entry in the linked list.
      *
-     * @returns A pointer to the next entry in the linked list or nullptr if at the end of the list.
+     * @returns A pointer to the next entry in the linked list or `nullptr` if at the end of the list.
      *
      */
     const Type *GetNext(void) const { return static_cast<const Type *>(static_cast<const Type *>(this)->mNext); }
@@ -80,7 +80,7 @@ public:
     /**
      * This method gets the next entry in the linked list.
      *
-     * @returns A pointer to the next entry in the linked list or nullptr if at the end of the list.
+     * @returns A pointer to the next entry in the linked list or `nullptr` if at the end of the list.
      *
      */
     Type *GetNext(void) { return static_cast<Type *>(static_cast<Type *>(this)->mNext); }
@@ -119,7 +119,7 @@ public:
     /**
      * This method returns the entry at the head of the linked list
      *
-     * @returns Pointer to the entry at the head of the linked list, or nullptr if the list is empty.
+     * @returns Pointer to the entry at the head of the linked list, or `nullptr` if the list is empty.
      *
      */
     Type *GetHead(void) { return mHead; }
@@ -127,7 +127,7 @@ public:
     /**
      * This method returns the entry at the head of the linked list.
      *
-     * @returns Pointer to the entry at the head of the linked list, or nullptr if the list is empty.
+     * @returns Pointer to the entry at the head of the linked list, or `nullptr` if the list is empty.
      *
      */
     const Type *GetHead(void) const { return mHead; }
@@ -185,7 +185,7 @@ public:
      *
      * @note This method does not change the popped entry itself, i.e., the popped entry next pointer stays as before.
      *
-     * @returns The entry that was popped if the list is not empty, or nullptr if the list is empty.
+     * @returns The entry that was popped if the list is not empty, or `nullptr` if the list is empty.
      *
      */
     Type *Pop(void)
@@ -205,10 +205,10 @@ public:
      *
      * @note This method does not change the popped entry itself, i.e., the popped entry next pointer stays as before.
      *
-     * @param[in] aPrevEntry  A pointer to a previous entry. If it is not nullptr the entry after this will be popped,
-     *                        otherwise (if it is nullptr) the entry at the head of the list is popped.
+     * @param[in] aPrevEntry  A pointer to a previous entry. If it is not `nullptr` the entry after this will be popped,
+     *                        otherwise (if it is `nullptr`) the entry at the head of the list is popped.
      *
-     * @returns Pointer to the entry that was popped, or nullptr if there is no entry to pop.
+     * @returns Pointer to the entry that was popped, or `nullptr` if there is no entry to pop.
      *
      */
     Type *PopAfter(Type *aPrevEntry)
@@ -333,7 +333,8 @@ public:
      *
      * @param[in] aIndicator   An entry indicator to match against entries in the list.
      *
-     * @returns A pointer to the removed matching entry if one could be found, or nullptr if no matching entry is found.
+     * @returns A pointer to the removed matching entry if one could be found, or `nullptr` if no matching entry is
+     *          found.
      *
      */
     template <typename Indicator> Type *RemoveMatching(const Indicator &aIndicator)
@@ -393,7 +394,7 @@ public:
      *
      * @param[in]  aEntry      A reference to an entry to find.
      * @param[out] aPrevEntry  A pointer to output the previous entry on success (when @p aEntry is found in the list).
-     *                         @p aPrevEntry is set to nullptr if @p aEntry is the head of the list. Otherwise it is
+     *                         @p aPrevEntry is set to `nullptr` if @p aEntry is the head of the list. Otherwise it is
      *                         updated to point to the previous entry before @p aEntry in the list.
      *
      * @retval kErrorNone      The entry was found in the list and @p aPrevEntry was updated successfully.
@@ -423,7 +424,7 @@ public:
      *
      * @param[in]  aEntry      A reference to an entry to find.
      * @param[out] aPrevEntry  A pointer to output the previous entry on success (when @p aEntry is found in the list).
-     *                         @p aPrevEntry is set to nullptr if @p aEntry is the head of the list. Otherwise it is
+     *                         @p aPrevEntry is set to `nullptr` if @p aEntry is the head of the list. Otherwise it is
      *                         updated to point to the previous entry before @p aEntry in the list.
      *
      * @retval kErrorNone      The entry was found in the list and @p aPrevEntry was updated successfully.
@@ -446,13 +447,14 @@ public:
      *     bool Type::Matches(const Indicator &aIndicator) const
      *
      * @param[in]  aBegin      A pointer to the begin of the range.
-     * @param[in]  aEnd        A pointer to the end of the range, or nullptr to search all entries after @p aBegin.
+     * @param[in]  aEnd        A pointer to the end of the range, or `nullptr` to search all entries after @p aBegin.
      * @param[in]  aIndicator  An indicator to match with entries in the list.
      * @param[out] aPrevEntry  A pointer to output the previous entry on success (when a match is found in the list).
-     *                         @p aPrevEntry is set to nullptr if the matching entry is the head of the list. Otherwise
-     *                         it is updated to point to the previous entry before the matching entry in the list.
+     *                         @p aPrevEntry is set to `nullptr` if the matching entry is the head of the list.
+     *                         Otherwise it is updated to point to the previous entry before the matching entry in the
+     *                         list.
      *
-     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     * @returns A pointer to the matching entry if one is found, or `nullptr` if no matching entry was found.
      *
      */
     template <typename Indicator>
@@ -487,13 +489,14 @@ public:
      *     bool Type::Matches(const Indicator &aIndicator) const
      *
      * @param[in]  aBegin      A pointer to the begin of the range.
-     * @param[in]  aEnd        A pointer to the end of the range, or nullptr to search all entries after @p aBegin.
+     * @param[in]  aEnd        A pointer to the end of the range, or `nullptr` to search all entries after @p aBegin.
      * @param[in]  aIndicator  An indicator to match with entries in the list.
      * @param[out] aPrevEntry  A pointer to output the previous entry on success (when a match is found in the list).
-     *                         @p aPrevEntry is set to nullptr if the matching entry is the head of the list. Otherwise
-     *                         it is updated to point to the previous entry before the matching entry in the list.
+     *                         @p aPrevEntry is set to `nullptr` if the matching entry is the head of the list.
+     *                         Otherwise it is updated to point to the previous entry before the matching entry in the
+     *                         list.
      *
-     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     * @returns A pointer to the matching entry if one is found, or `nullptr` if no matching entry was found.
      *
      */
     template <typename Indicator>
@@ -513,10 +516,11 @@ public:
      *
      * @param[in]  aIndicator  An indicator to match with entries in the list.
      * @param[out] aPrevEntry  A pointer to output the previous entry on success (when a match is found in the list).
-     *                         @p aPrevEntry is set to nullptr if the matching entry is the head of the list. Otherwise
-     *                         it is updated to point to the previous entry before the matching entry in the list.
+     *                         @p aPrevEntry is set to `nullptr` if the matching entry is the head of the list.
+     *                         Otherwise it is updated to point to the previous entry before the matching entry in the
+     *                         list.
      *
-     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     * @returns A pointer to the matching entry if one is found, or `nullptr` if no matching entry was found.
      *
      */
     template <typename Indicator> const Type *FindMatching(const Indicator &aIndicator, const Type *&aPrevEntry) const
@@ -536,10 +540,11 @@ public:
      *
      * @param[in]  aIndicator  An indicator to match with entries in the list.
      * @param[out] aPrevEntry  A pointer to output the previous entry on success (when a match is found in the list).
-     *                         @p aPrevEntry is set to nullptr if the matching entry is the head of the list. Otherwise
-     *                         it is updated to point to the previous entry before the matching entry in the list.
+     *                         @p aPrevEntry is set to `nullptr` if the matching entry is the head of the list.
+     *                         Otherwise it is updated to point to the previous entry before the matching entry in the
+     *                         list.
      *
-     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     * @returns A pointer to the matching entry if one is found, or `nullptr` if no matching entry was found.
      *
      */
     template <typename Indicator> Type *FindMatching(const Indicator &aIndicator, Type *&aPrevEntry)
@@ -558,7 +563,7 @@ public:
      *
      * @param[in]  aIndicator  An indicator to match with entries in the list.
      *
-     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     * @returns A pointer to the matching entry if one is found, or `nullptr` if no matching entry was found.
      *
      */
     template <typename Indicator> const Type *FindMatching(const Indicator &aIndicator) const
@@ -579,7 +584,7 @@ public:
      *
      * @param[in]  aIndicator  An indicator to match with entries in the list.
      *
-     * @returns A pointer to the matching entry if one is found, or nullptr if no matching entry was found.
+     * @returns A pointer to the matching entry if one is found, or `nullptr` if no matching entry was found.
      *
      */
     template <typename Indicator> Type *FindMatching(const Indicator &aIndicator)
@@ -590,7 +595,7 @@ public:
     /**
      * This method returns the tail of the linked list (i.e., the last entry in the list).
      *
-     * @returns A pointer to the tail entry in the linked list or nullptr if the list is empty.
+     * @returns A pointer to the tail entry in the linked list or `nullptr` if the list is empty.
      *
      */
     const Type *GetTail(void) const
@@ -611,7 +616,7 @@ public:
     /**
      * This method returns the tail of the linked list (i.e., the last entry in the list).
      *
-     * @returns A pointer to the tail entry in the linked list or nullptr if the list is empty.
+     * @returns A pointer to the tail entry in the linked list or `nullptr` if the list is empty.
      *
      */
     Type *GetTail(void) { return AsNonConst(AsConst(this)->GetTail()); }

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -844,7 +844,7 @@ PriorityQueue::PriorityQueue(void)
 
 Message *PriorityQueue::FindFirstNonNullTail(Message::Priority aStartPriorityLevel) const
 {
-    // Find the first non-nullptr tail starting from the given priority
+    // Find the first non-`nullptr` tail starting from the given priority
     // level and moving forward (wrapping from priority value
     // `kNumPriorities` -1 back to 0).
 

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -83,14 +83,14 @@ class HmacSha256;
  */
 
 /**
- * This macro frees a given message buffer if not nullptr.
+ * This macro frees a given message buffer if not `nullptr`.
  *
  * This macro and the ones that follow contain small but common code patterns used in many of the core modules. They
  * are intentionally defined as macros instead of inline methods/functions to ensure that they are fully inlined.
  * Note that an `inline` method/function is not necessarily always inlined by the toolchain and not inlining such
  * small implementations can add a rather large code-size overhead.
  *
- * @param[in] aMessage    A pointer to a `Message` to free (can be nullptr).
+ * @param[in] aMessage    A pointer to a `Message` to free (can be `nullptr`).
  *
  */
 #define FreeMessage(aMessage)      \
@@ -105,9 +105,9 @@ class HmacSha256;
 /**
  * This macro frees a given message buffer if a given `Error` indicates an error.
  *
- * The parameter @p aMessage can be nullptr in which case this macro does nothing.
+ * The parameter @p aMessage can be `nullptr` in which case this macro does nothing.
  *
- * @param[in] aMessage    A pointer to a `Message` to free (can be nullptr).
+ * @param[in] aMessage    A pointer to a `Message` to free (can be `nullptr`).
  * @param[in] aError      The `Error` to check.
  *
  */
@@ -123,7 +123,7 @@ class HmacSha256;
 /**
  * This macro frees a given message buffer if a given `Error` indicates an error and sets the `aMessage` to `nullptr`.
  *
- * @param[in] aMessage    A pointer to a `Message` to free (can be nullptr).
+ * @param[in] aMessage    A pointer to a `Message` to free (can be `nullptr`).
  * @param[in] aError      The `Error` to check.
  *
  */
@@ -413,7 +413,7 @@ public:
     /**
      * This method returns a pointer to the next message.
      *
-     * @returns A pointer to the next message in the list or nullptr if at the end of the list.
+     * @returns A pointer to the next message in the list or `nullptr` if at the end of the list.
      *
      */
     Message *GetNext(void) const;
@@ -831,7 +831,7 @@ public:
      * `Type`, `SubType`, `LinkSecurity`, `Offset`, `InterfaceId`, and `Priority` fields on the cloned message are also
      * copied from the original one.
      *
-     * @returns A pointer to the message or nullptr if insufficient message buffers are available.
+     * @returns A pointer to the message or `nullptr` if insufficient message buffers are available.
      *
      */
     Message *Clone(void) const { return Clone(GetLength()); }
@@ -1110,7 +1110,7 @@ public:
     /**
      * This method returns a pointer to the message queue (if any) where this message is queued.
      *
-     * @returns A pointer to the message queue or nullptr if not in any message queue.
+     * @returns A pointer to the message queue or `nullptr` if not in any message queue.
      *
      */
     MessageQueue *GetMessageQueue(void) const
@@ -1121,7 +1121,7 @@ public:
     /**
      * This method returns a pointer to the priority message queue (if any) where this message is queued.
      *
-     * @returns A pointer to the priority queue or nullptr if not in any priority queue.
+     * @returns A pointer to the priority queue or `nullptr` if not in any priority queue.
      *
      */
     PriorityQueue *GetPriorityQueue(void) const
@@ -1390,7 +1390,7 @@ public:
      *
      * @param[in] aPriority   Priority level.
      *
-     * @returns A pointer to the first message with given priority level or nullptr if there is no messages with
+     * @returns A pointer to the first message with given priority level or `nullptr` if there is no messages with
      *          this priority level.
      *
      */
@@ -1478,7 +1478,7 @@ public:
      * @param[in]  aReserveHeader  The number of header bytes to reserve.
      * @param[in]  aSettings       The message settings.
      *
-     * @returns A pointer to the message or nullptr if no message buffers are available.
+     * @returns A pointer to the message or `nullptr` if no message buffers are available.
      *
      */
     Message *Allocate(Message::Type            aType,

--- a/src/core/common/owning_list.hpp
+++ b/src/core/common/owning_list.hpp
@@ -99,8 +99,8 @@ public:
      *
      * @note This method does not change the popped entry itself, i.e., the popped entry next pointer stays as before.
      *
-     * @param[in] aPrevEntry  A pointer to a previous entry. If it is not nullptr the entry after this will be popped,
-     *                        otherwise (if it is nullptr) the entry at the head of the list is popped.
+     * @param[in] aPrevEntry  A pointer to a previous entry. If it is not `nullptr` the entry after this will be popped,
+     *                        otherwise (if it is `nullptr`) the entry at the head of the list is popped.
      *
      * @returns An `OwnerPtr` to the entry that was popped (set to null if there is no entry to pop).
      *

--- a/src/core/common/pool.hpp
+++ b/src/core/common/pool.hpp
@@ -99,7 +99,8 @@ public:
     /**
      * This method allocates a new object from the pool.
      *
-     * @returns A pointer to the newly allocated object, or nullptr if all entries from the pool are already allocated.
+     * @returns A pointer to the newly allocated object, or `nullptr` if all entries from the pool are already
+     *          allocated.
      *
      */
     Type *Allocate(void) { return mFreeList.Pop(); }

--- a/src/core/common/settings_driver.hpp
+++ b/src/core/common/settings_driver.hpp
@@ -109,7 +109,7 @@ public:
      *
      * @param[in]  aKey          The key associated with the value.
      * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
-     *                           MUST NOT be nullptr if @p aValueLength is non-zero.
+     *                           MUST NOT be `nullptr` if @p aValueLength is non-zero.
      * @param[in]  aValueLength  The length of the data pointed to by @p aValue. May be zero.
      *
      * @retval kErrorNone     The value was added.
@@ -158,12 +158,12 @@ public:
      * @param[in]     aKey          The key associated with the requested value.
      * @param[in]     aIndex        The index of the specific item to get.
      * @param[out]    aValue        A pointer to where the value of the setting should be written.
-     *                              May be nullptr if just testing for the presence or length of a key.
+     *                              May be `nullptr` if just testing for the presence or length of a key.
      * @param[inout]  aValueLength  A pointer to the length of the value.
      *                              When called, this should point to an integer containing the maximum bytes that
      *                              can be written to @p aValue.
      *                              At return, the actual length of the setting is written.
-     *                              May be nullptr if performing a presence check.
+     *                              May be `nullptr` if performing a presence check.
      *
      * @retval kErrorNone        The value was fetched successfully.
      * @retval kErrorNotFound    The key was not found.
@@ -187,12 +187,12 @@ public:
      *
      * @param[in]     aKey          The key associated with the requested value.
      * @param[out]    aValue        A pointer to where the value of the setting should be written.
-     *                              May be nullptr if just testing for the presence or length of a key.
+     *                              May be `nullptr` if just testing for the presence or length of a key.
      * @param[inout]  aValueLength  A pointer to the length of the value.
      *                              When called, this should point to an integer containing the maximum bytes that
      *                              can be written to @p aValue.
      *                              At return, the actual length of the setting is written.
-     *                              May be nullptr if performing a presence check.
+     *                              May be `nullptr` if performing a presence check.
      *
      * @retval kErrorNone        The value was fetched successfully.
      * @retval kErrorNotFound    The key was not found.
@@ -208,7 +208,7 @@ public:
      *
      * @param[in]  aKey          The key associated with the value.
      * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
-     *                           MUST NOT be nullptr if @p aValueLength is non-zero.
+     *                           MUST NOT be `nullptr` if @p aValueLength is non-zero.
      * @param[in]  aValueLength  The length of the data pointed to by @p aValue. May be zero.
      *
      * @retval kErrorNone     The value was changed.

--- a/src/core/common/string.hpp
+++ b/src/core/common/string.hpp
@@ -68,13 +68,13 @@ enum StringMatchMode : uint8_t
 static constexpr char kNullChar = '\0'; ///< null character.
 
 /**
- * This function returns the number of characters that precede the terminating nullptr character.
+ * This function returns the number of characters that precede the terminating null character.
  *
  * @param[in] aString      A pointer to the string.
  * @param[in] aMaxLength   The maximum length in bytes.
  *
- * @returns The number of characters that precede the terminating nullptr character or @p aMaxLength, whichever is
- * smaller.
+ * @returns The number of characters that precede the terminating null character or @p aMaxLength, whichever is
+ *          smaller.
  *
  */
 uint16_t StringLength(const char *aString, uint16_t aMaxLength);
@@ -85,7 +85,7 @@ uint16_t StringLength(const char *aString, uint16_t aMaxLength);
  * @param[in] aString     A pointer to the string.
  * @param[in] aChar       A char to search for in the string.
  *
- * @returns The pointer to first occurrence of the @p aChar in @p aString, or nullptr if cannot be found.
+ * @returns The pointer to first occurrence of the @p aChar in @p aString, or `nullptr` if cannot be found.
  *
  */
 const char *StringFind(const char *aString, char aChar);
@@ -97,7 +97,7 @@ const char *StringFind(const char *aString, char aChar);
  * @param[in] aSubString  A sub-string to search for.
  * @param[in] aMode       The string comparison mode, exact match or case insensitive match.
  *
- * @returns The pointer to first match of the @p aSubString in @p aString (using comparison @p aMode), or nullptr if
+ * @returns The pointer to first match of the @p aSubString in @p aString (using comparison @p aMode), or `nullptr` if
  *          cannot be found.
  *
  */

--- a/src/core/common/tasklet.cpp
+++ b/src/core/common/tasklet.cpp
@@ -70,9 +70,9 @@ void Tasklet::Scheduler::ProcessQueuedTasklets(void)
 
     // This method processes all tasklets queued when this is called. We
     // keep a copy the current list and then clear the main list by
-    // setting `mTail` to nullptr. A newly posted tasklet while processing
-    // the currently queued tasklets will then trigger a call to
-    // `otTaskletsSignalPending()`.
+    // setting `mTail` to `nullptr`. A newly posted tasklet while
+    // processing the currently queued tasklets will then trigger a call
+    // to `otTaskletsSignalPending()`.
 
     mTail = nullptr;
 

--- a/src/core/crypto/storage.hpp
+++ b/src/core/crypto/storage.hpp
@@ -130,7 +130,7 @@ inline bool IsKeyRefValid(KeyRef aKeyRef)
  *
  * @retval kErrorNone          Successfully imported the key.
  * @retval kErrorFailed        Failed to import the key.
- * @retval kErrorInvalidArgs   @p aKey was set to nullptr.
+ * @retval kErrorInvalidArgs   @p aKey was set to `nullptr`.
  *
  */
 inline Error ImportKey(KeyRef &       aKeyRef,
@@ -156,7 +156,7 @@ inline Error ImportKey(KeyRef &       aKeyRef,
  *
  * @retval kErrorNone          Successfully exported  @p aKeyRef.
  * @retval kErrorFailed        Failed to export @p aKeyRef.
- * @retval kErrorInvalidArgs   @p aBuffer was nullptr.
+ * @retval kErrorInvalidArgs   @p aBuffer was `nullptr`.
  *
  */
 inline Error ExportKey(KeyRef aKeyRef, uint8_t *aBuffer, size_t aBufferLen, size_t &aKeyLen)

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -103,7 +103,7 @@ public:
     /**
      * The radio driver calls this method to notify OpenThread diagnostics module of a received frame.
      *
-     * @param[in]  aFrame  A pointer to the received frame or nullptr if the receive operation failed.
+     * @param[in]  aFrame  A pointer to the received frame or `nullptr` if the receive operation failed.
      * @param[in]  aError  kErrorNone when successfully received a frame,
      *                     kErrorAbort when reception was aborted and a frame was not received,
      *                     kErrorNoBufs when a frame could not be received due to lack of rx buffer space.

--- a/src/core/mac/data_poll_handler.hpp
+++ b/src/core/mac/data_poll_handler.hpp
@@ -278,7 +278,7 @@ private:
 
     // In the current implementation of `DataPollHandler`, we can have a
     // single indirect tx operation active at MAC layer at each point of
-    // time. `mIndirectTxChild` indicates the child being handled (nullptr
+    // time. `mIndirectTxChild` indicates the child being handled (`nullptr`
     // indicates no active indirect tx). `mFrameContext` tracks the
     // context for the prepared frame for the current indirect tx.
 

--- a/src/core/mac/data_poll_sender.hpp
+++ b/src/core/mac/data_poll_sender.hpp
@@ -163,7 +163,7 @@ public:
      * This method informs the data poll sender to process a transmitted MAC frame.
      *
      * @param[in]  aFrame      A reference to the frame that was transmitted.
-     * @param[in]  aAckFrame   A pointer to the ACK frame, nullptr if no ACK was received.
+     * @param[in]  aAckFrame   A pointer to the ACK frame, `nullptr` if no ACK was received.
      * @param[in]  aError      kErrorNone when the frame was transmitted successfully,
      *                         kErrorNoAck when the frame was transmitted but no ACK was received,
      *                         kErrorChannelAccessFailure when the tx failed due to activity on the channel,

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -82,7 +82,7 @@ public:
     /**
      * This method enables/disables the raw link-layer.
      *
-     * @param[in]  aCallback  A pointer to a function called on receipt of a IEEE 802.15.4 frame, nullptr to disable
+     * @param[in]  aCallback  A pointer to a function called on receipt of a IEEE 802.15.4 frame, `nullptr` to disable
      *                        raw link-layer.
      *
      *
@@ -113,7 +113,7 @@ public:
     /**
      * This method invokes the mReceiveDoneCallback, if set.
      *
-     * @param[in]  aFrame    A pointer to the received frame or nullptr if the receive operation failed.
+     * @param[in]  aFrame    A pointer to the received frame or `nullptr` if the receive operation failed.
      * @param[in]  aError    kErrorNone when successfully received a frame,
      *                       kErrorAbort when reception was aborted and a frame was not received,
      *                       kErrorNoBufs when a frame could not be received due to lack of rx buffer space.
@@ -146,7 +146,7 @@ public:
      * This method invokes the mTransmitDoneCallback, if set.
      *
      * @param[in]  aFrame     The transmitted frame.
-     * @param[in]  aAckFrame  A pointer to the ACK frame, nullptr if no ACK was received.
+     * @param[in]  aAckFrame  A pointer to the ACK frame, `nullptr` if no ACK was received.
      * @param[in]  aError     kErrorNone when the frame was transmitted,
      *                        kErrorNoAck when the frame was transmitted but no ACK was received,
      *                        kErrorChannelAccessFailure tx failed due to activity on the channel,
@@ -284,7 +284,7 @@ public:
      * of a frame transmission request, this method is invoked on all frame transmission attempts.
      *
      * @param[in] aFrame      The transmitted frame.
-     * @param[in] aAckFrame   A pointer to the ACK frame, or nullptr if no ACK was received.
+     * @param[in] aAckFrame   A pointer to the ACK frame, or `nullptr` if no ACK was received.
      * @param[in] aError      kErrorNone when the frame was transmitted successfully,
      *                        kErrorNoAck when the frame was transmitted but no ACK was received,
      *                        kErrorChannelAccessFailure tx failed due to activity on the channel,

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -456,7 +456,7 @@ public:
     /**
      * This method is called to handle a received frame.
      *
-     * @param[in]  aFrame  A pointer to the received frame, or nullptr if the receive operation was aborted.
+     * @param[in]  aFrame  A pointer to the received frame, or `nullptr` if the receive operation was aborted.
      * @param[in]  aError  kErrorNone when successfully received a frame,
      *                     kErrorAbort when reception was aborted and a frame was not received.
      *
@@ -479,7 +479,7 @@ public:
      * of a frame transmission request, this method is invoked on all frame transmission attempts.
      *
      * @param[in] aFrame      The transmitted frame.
-     * @param[in] aAckFrame   A pointer to the ACK frame, or nullptr if no ACK was received.
+     * @param[in] aAckFrame   A pointer to the ACK frame, or `nullptr` if no ACK was received.
      * @param[in] aError      kErrorNone when the frame was transmitted successfully,
      *                        kErrorNoAck when the frame was transmitted but no ACK was received,
      *                        kErrorChannelAccessFailure tx failed due to activity on the channel,
@@ -499,7 +499,7 @@ public:
      * This method is called to handle transmit events.
      *
      * @param[in]  aFrame      The frame that was transmitted.
-     * @param[in]  aAckFrame   A pointer to the ACK frame, nullptr if no ACK was received.
+     * @param[in]  aAckFrame   A pointer to the ACK frame, `nullptr` if no ACK was received.
      * @param[in]  aError      kErrorNone when the frame was transmitted successfully,
      *                         kErrorNoAck when the frame was transmitted but no ACK was received,
      *                         kErrorChannelAccessFailure when the tx failed due to activity on the channel,
@@ -544,7 +544,7 @@ public:
      * This method registers a callback to provide received raw IEEE 802.15.4 frames.
      *
      * @param[in]  aPcapCallback     A pointer to a function that is called when receiving an IEEE 802.15.4 link frame
-     * or nullptr to disable the callback.
+     *                               or `nullptr` to disable the callback.
      * @param[in]  aCallbackContext  A pointer to application-specific context.
      *
      */

--- a/src/core/mac/mac_frame.hpp
+++ b/src/core/mac/mac_frame.hpp
@@ -899,7 +899,7 @@ public:
     /**
      * This method returns a pointer to the vendor specific Time IE.
      *
-     * @returns A pointer to the Time IE, nullptr if not found.
+     * @returns A pointer to the Time IE, `nullptr` if not found.
      *
      */
     TimeIe *GetTimeIe(void) { return AsNonConst(AsConst(this)->GetTimeIe()); }
@@ -907,7 +907,7 @@ public:
     /**
      * This method returns a pointer to the vendor specific Time IE.
      *
-     * @returns A pointer to the Time IE, nullptr if not found.
+     * @returns A pointer to the Time IE, `nullptr` if not found.
      *
      */
     const TimeIe *GetTimeIe(void) const;
@@ -937,7 +937,7 @@ public:
      *
      * @param[in] aIeId  The Element Id of the Header IE.
      *
-     * @returns A pointer to the Header IE, nullptr if not found.
+     * @returns A pointer to the Header IE, `nullptr` if not found.
      *
      */
     uint8_t *GetHeaderIe(uint8_t aIeId) { return AsNonConst(AsConst(this)->GetHeaderIe(aIeId)); }
@@ -947,7 +947,7 @@ public:
      *
      * @param[in] aIeId  The Element Id of the Header IE.
      *
-     * @returns A pointer to the Header IE, nullptr if not found.
+     * @returns A pointer to the Header IE, `nullptr` if not found.
      *
      */
     const uint8_t *GetHeaderIe(uint8_t aIeId) const;
@@ -959,7 +959,7 @@ public:
      *
      * @param[in] aSubType  The sub type of the Thread IE.
      *
-     * @returns A pointer to the Thread IE, nullptr if not found.
+     * @returns A pointer to the Thread IE, `nullptr` if not found.
      *
      */
     uint8_t *GetThreadIe(uint8_t aSubType) { return AsNonConst(AsConst(this)->GetThreadIe(aSubType)); }
@@ -971,7 +971,7 @@ public:
      *
      * @param[in] aSubType  The sub type of the Thread IE.
      *
-     * @returns A pointer to the Thread IE, nullptr if not found.
+     * @returns A pointer to the Thread IE, `nullptr` if not found.
      *
      */
     const uint8_t *GetThreadIe(uint8_t aSubType) const;

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -128,7 +128,7 @@ public:
         /**
          * This method notifies user of `SubMac` of a received frame.
          *
-         * @param[in]  aFrame    A pointer to the received frame or nullptr if the receive operation failed.
+         * @param[in]  aFrame    A pointer to the received frame or `nullptr` if the receive operation failed.
          * @param[in]  aError    kErrorNone when successfully received a frame,
          *                       kErrorAbort when reception was aborted and a frame was not received,
          *                       kErrorNoBufs when a frame could not be received due to lack of rx buffer space.
@@ -156,7 +156,7 @@ public:
          * of a frame transmission, this method is invoked on all frame transmission attempts.
          *
          * @param[in] aFrame      The transmitted frame.
-         * @param[in] aAckFrame   A pointer to the ACK frame, or nullptr if no ACK was received.
+         * @param[in] aAckFrame   A pointer to the ACK frame, or `nullptr` if no ACK was received.
          * @param[in] aError      kErrorNone when the frame was transmitted successfully,
          *                        kErrorNoAck when the frame was transmitted but no ACK was received,
          *                        kErrorChannelAccessFailure tx failed due to activity on the channel,
@@ -177,7 +177,7 @@ public:
          * the received ACK frame.
          *
          * @param[in]  aFrame     The transmitted frame.
-         * @param[in]  aAckFrame  A pointer to the ACK frame, nullptr if no ACK was received.
+         * @param[in]  aAckFrame  A pointer to the ACK frame, `nullptr` if no ACK was received.
          * @param[in]  aError     kErrorNone when the frame was transmitted,
          *                        kErrorNoAck when the frame was transmitted but no ACK was received,
          *                        kErrorChannelAccessFailure tx failed due to activity on the channel,
@@ -274,7 +274,7 @@ public:
      * This method registers a callback to provide received packet capture for IEEE 802.15.4 frames.
      *
      * @param[in]  aPcapCallback     A pointer to a function that is called when receiving an IEEE 802.15.4 link frame
-     *                                or nullptr to disable the callback.
+     *                               or `nullptr` to disable the callback.
      * @param[in]  aCallbackContext  A pointer to application-specific context.
      *
      */

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -229,7 +229,7 @@ public:
     /**
      * This method sets the Provisioning URL.
      *
-     * @param[in]  aProvisioningUrl  A pointer to the Provisioning URL (may be nullptr to set URL to empty string).
+     * @param[in]  aProvisioningUrl  A pointer to the Provisioning URL (may be `nullptr` to set URL to empty string).
      *
      * @retval kErrorNone         Successfully set the Provisioning URL.
      * @retval kErrorInvalidArgs  @p aProvisioningUrl is invalid (too long).

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -636,7 +636,7 @@ public:
      *
      * @param[in] aType  A TLV type.
      *
-     * @returns A pointer to the TLV or nullptr if none is found.
+     * @returns A pointer to the TLV or `nullptr` if none is found.
      *
      */
     Tlv *GetTlv(Tlv::Type aType) { return AsNonConst(AsConst(this)->GetTlv(aType)); }
@@ -646,7 +646,7 @@ public:
      *
      * @param[in] aType  The TLV type.
      *
-     * @returns A pointer to the TLV or nullptr if none is found.
+     * @returns A pointer to the TLV or `nullptr` if none is found.
      *
      */
     const Tlv *GetTlv(Tlv::Type aType) const;
@@ -654,7 +654,7 @@ public:
     /**
      * This template method returns a pointer to the TLV with a given template type `TlvType`
      *
-     * @returns A pointer to the TLV or nullptr if none is found.
+     * @returns A pointer to the TLV or `nullptr` if none is found.
      *
      */
     template <typename TlvType> TlvType *GetTlv(void)
@@ -665,7 +665,7 @@ public:
     /**
      * This template method returns a pointer to the TLV with a given template type `TlvType`
      *
-     * @returns A pointer to the TLV or nullptr if none is found.
+     * @returns A pointer to the TLV or `nullptr` if none is found.
      *
      */
     template <typename TlvType> const TlvType *GetTlv(void) const

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -87,11 +87,11 @@ public:
      * This method starts the Joiner service.
      *
      * @param[in]  aPskd             A pointer to the PSKd.
-     * @param[in]  aProvisioningUrl  A pointer to the Provisioning URL (may be nullptr).
-     * @param[in]  aVendorName       A pointer to the Vendor Name (may be nullptr).
-     * @param[in]  aVendorModel      A pointer to the Vendor Model (may be nullptr).
-     * @param[in]  aVendorSwVersion  A pointer to the Vendor SW Version (may be nullptr).
-     * @param[in]  aVendorData       A pointer to the Vendor Data (may be nullptr).
+     * @param[in]  aProvisioningUrl  A pointer to the Provisioning URL (may be `nullptr`).
+     * @param[in]  aVendorName       A pointer to the Vendor Name (may be `nullptr`).
+     * @param[in]  aVendorModel      A pointer to the Vendor Model (may be `nullptr`).
+     * @param[in]  aVendorSwVersion  A pointer to the Vendor SW Version (may be `nullptr`).
+     * @param[in]  aVendorData       A pointer to the Vendor Data (may be `nullptr`).
      * @param[in]  aCallback         A pointer to a function that is called when the join operation completes.
      * @param[in]  aContext          A pointer to application-specific context.
      *

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -203,7 +203,7 @@ public:
      * @param[in]  aTlvsLength The length (number of bytes) in TLV sequence.
      * @param[in]  aType       The TLV Type to search for.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     static Tlv *FindTlv(uint8_t *aTlvsStart, uint16_t aTlvsLength, Type aType)
@@ -218,7 +218,7 @@ public:
      * @param[in]  aTlvsLength The length (number of bytes) in TLV sequence.
      * @param[in]  aType       The TLV Type to search for.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     static const Tlv *FindTlv(const uint8_t *aTlvsStart, uint16_t aTlvsLength, Type aType);
@@ -230,7 +230,7 @@ public:
      * @param[in]  aTlvsStart  A pointer to the start of the sequence of TLVs to search within.
      * @param[in]  aTlvsLength The length (number of bytes) in TLV sequence.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     template <typename TlvType> static TlvType *FindTlv(uint8_t *aTlvsStart, uint16_t aTlvsLength)
@@ -245,7 +245,7 @@ public:
      * @param[in]  aTlvsStart  A pointer to the start of the sequence of TLVs to search within.
      * @param[in]  aTlvsLength The length (number of bytes) in TLV sequence.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     template <typename TlvType> static const TlvType *FindTlv(const uint8_t *aTlvsStart, uint16_t aTlvsLength)
@@ -1464,7 +1464,7 @@ public:
     /**
      * This method gets the first Channel Mask Entry in the Channel Mask TLV.
      *
-     * @returns A pointer to first Channel Mask Entry or nullptr if not found.
+     * @returns A pointer to first Channel Mask Entry or `nullptr` if not found.
      *
      */
     const ChannelMaskEntryBase *GetFirstEntry(void) const;
@@ -1472,7 +1472,7 @@ public:
     /**
      * This method gets the first Channel Mask Entry in the Channel Mask TLV.
      *
-     * @returns A pointer to first Channel Mask Entry or nullptr if not found.
+     * @returns A pointer to first Channel Mask Entry or `nullptr` if not found.
      *
      */
     ChannelMaskEntryBase *GetFirstEntry(void);

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -635,9 +635,9 @@ public:
     /**
      * This method sends a DNS service instance resolution query for a given service instance.
      *
-     * The @p aConfig can be nullptr. In this case the default config (from `GetDefaultConfig()`) will be used as
-     * the config for this query. In a non-nullptr @p aConfig, some of the fields can be left unspecified (value zero).
-     * The unspecified fields are then replaced by the values from the default config.
+     * The @p aConfig can be `nullptr`. In this case the default config (from `GetDefaultConfig()`) will be used as
+     * the config for this query. In a non-`nullptr` @p aConfig, some of the fields can be left unspecified (value
+     * zero). The unspecified fields are then replaced by the values from the default config.
      *
      * @param[in]  aServerSockAddr    The server socket address.
      * @param[in]  aInstanceLabel     The service instance label.

--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -673,7 +673,7 @@ public:
      * contain dot '.' character, which, for example, is useful for "Service Instance Names" where <Instance> portion
      * is a user-friendly name and can contain dot characters.
      *
-     * @param[in] aLabel              The label string to append. MUST NOT be nullptr.
+     * @param[in] aLabel              The label string to append. MUST NOT be `nullptr`.
      * @param[in] aMessage            The message to append to.
      *
      * @retval kErrorNone         Successfully encoded and appended the name label to @p aMessage.
@@ -692,7 +692,7 @@ public:
      * whole label. This allows the label string to even contain dot '.' character, which, for example, is useful for
      * "Service Instance Names" where <Instance> portion is a user-friendly name and can contain dot characters.
      *
-     * @param[in] aLabel         The label string to append. MUST NOT be nullptr.
+     * @param[in] aLabel         The label string to append. MUST NOT be `nullptr`.
      * @param[in] aLength        The length of the label to append.
      * @param[in] aMessage       The message to append to.
      *
@@ -715,7 +715,7 @@ public:
      * @note This method NEVER adds a label terminator (empty label) to the message, even in the case where @p aLabels
      * ends with a dot character, e.g., "host-1.test." is treated same as "host-1.test".
      *
-     * @param[in]  aLabels            A name label string. Can be nullptr (then treated as "").
+     * @param[in]  aLabels            A name label string. Can be `nullptr` (then treated as "").
      * @param[in]  aMessage           The message to which to append the encoded name.
      *
      * @retval kErrorNone         Successfully encoded and appended the name label(s) to @p aMessage.
@@ -741,7 +741,7 @@ public:
      * @note This method NEVER adds a label terminator (empty label) to the message, even in the case where @p aLabels
      * ends with a dot character, e.g., "host-1.test." is treated same as "host-1.test".
      *
-     * @param[in]  aLabels            A name label string. Can be nullptr (then treated as "").
+     * @param[in]  aLabels            A name label string. Can be `nullptr` (then treated as "").
      * @param[in]  aLength            The max length of the name labels to encode.
      * @param[in]  aMessage           The message to which to append the encoded name.
      *
@@ -789,7 +789,7 @@ public:
      * This method validates that the @p aName is a valid name format, i.e. no empty labels, and labels are
      * `kMaxLabelLength` (63) characters or less, and the name is `kMaxLength` (255) characters or less.
      *
-     * @param[in]  aName              A name string. Can be nullptr (then treated as "." or root).
+     * @param[in]  aName              A name string. Can be `nullptr` (then treated as "." or root).
      * @param[in]  aMessage           The message to append to.
      *
      * @retval kErrorNone         Successfully encoded and appended the name to @p aMessage.
@@ -1552,7 +1552,7 @@ public:
      *                                  On exit when successfully read, @p aOffset is updated to point to the byte
      *                                  after the entire PTR record (skipping over the record).
      * @param[out]    aNameBuffer       A pointer to a char array to output the read name as a null-terminated C string
-     *                                  (MUST NOT be nullptr).
+     *                                  (MUST NOT be `nullptr`).
      * @param[in]     aNameBufferSize   The size of @p aNameBuffer.
      *
      * @retval kErrorNone           The CNAME name was read successfully. @p aOffset and @p aNameBuffer are updated.
@@ -1603,7 +1603,7 @@ public:
      *                                  On exit when successfully read, @p aOffset is updated to point to the byte
      *                                  after the entire PTR record (skipping over the record).
      * @param[out]    aNameBuffer       A pointer to a char array to output the read name as a null-terminated C string
-     *                                  (MUST NOT be nullptr).
+     *                                  (MUST NOT be `nullptr`).
      * @param[in]     aNameBufferSize   The size of @p aNameBuffer.
      *
      * @retval kErrorNone           The PTR name was read successfully. @p aOffset and @p aNameBuffer are updated.
@@ -1636,7 +1636,7 @@ public:
      *                                  On exit, when successfully read, @p aOffset is updated to point to the byte
      *                                  after the entire PTR record (skipping over the record).
      * @param[out]    aLabelBuffer      A pointer to a char array to output the first label as a null-terminated C
-     *                                  string (MUST NOT be nullptr).
+     *                                  string (MUST NOT be `nullptr`).
      * @param[in]     aLabelBufferSize  The size of @p aLabelBuffer.
      * @param[out]    aNameBuffer       A pointer to a char array to output the rest of name (after first label). Can
      *                                  be `nullptr` if caller is only interested in the first label.
@@ -1841,7 +1841,7 @@ public:
      *                                  On exit when successfully read, @p aOffset is updated to point to the byte
      *                                  after the entire SRV record (skipping over the record).
      * @param[out]    aNameBuffer       A pointer to a char array to output the read name as a null-terminated C string
-     *                                  (MUST NOT be nullptr).
+     *                                  (MUST NOT be `nullptr`).
      * @param[in]     aNameBufferSize   The size of @p aNameBuffer.
      *
      * @retval kErrorNone            The host name was read successfully. @p aOffset and @p aNameBuffer are updated.
@@ -2244,7 +2244,7 @@ public:
      *                                  On exit when successfully read, @p aOffset is updated to point to the byte
      *                                  after the name field (i.e., start of signature field).
      * @param[out]    aNameBuffer       A pointer to a char array to output the read name as a null-terminated C string
-     *                                  (MUST NOT be nullptr).
+     *                                  (MUST NOT be `nullptr`).
      * @param[in]     aNameBufferSize   The size of @p aNameBuffer.
      *
      * @retval kErrorNone           The name was read successfully. @p aOffset and @p aNameBuffer are updated.

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -137,9 +137,9 @@ public:
     /**
      * This method acquires the next query in the server.
      *
-     * @param[in] aQuery            The query pointer. Pass nullptr to get the first query.
+     * @param[in] aQuery            The query pointer. Pass `nullptr` to get the first query.
      *
-     * @returns  A pointer to the query or nullptr if no more queries.
+     * @returns  A pointer to the query or `nullptr` if no more queries.
      *
      */
     const otDnssdQuery *GetNextQuery(const otDnssdQuery *aQuery) const;

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -240,7 +240,7 @@ public:
      *
      * @param[in]  aReserved  The number of header bytes to reserve after the ICMP header.
      *
-     * @returns A pointer to the message or nullptr if no buffers are available.
+     * @returns A pointer to the message or `nullptr` if no buffers are available.
      *
      */
     Message *NewMessage(uint16_t aReserved);

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -134,7 +134,7 @@ public:
      * @param[in]  aReserved  The number of header bytes to reserve following the IPv6 header.
      * @param[in]  aSettings  The message settings.
      *
-     * @returns A pointer to the message or nullptr if insufficient message buffers are available.
+     * @returns A pointer to the message or `nullptr` if insufficient message buffers are available.
      *
      */
     Message *NewMessage(uint16_t aReserved, const Message::Settings &aSettings = Message::Settings::GetDefault());
@@ -146,7 +146,7 @@ public:
      * @param[in]  aDataLength  The size of the IPV6 datagram buffer pointed by @p aData.
      * @param[in]  aSettings    The message settings.
      *
-     * @returns A pointer to the message or nullptr if malformed IPv6 header or insufficient message buffers are
+     * @returns A pointer to the message or `nullptr` if malformed IPv6 header or insufficient message buffers are
      * available.
      *
      */
@@ -160,7 +160,7 @@ public:
      * @param[in]  aData        A pointer to the IPv6 datagram buffer.
      * @param[in]  aDataLength  The size of the IPV6 datagram buffer pointed by @p aData.
      *
-     * @returns A pointer to the message or nullptr if malformed IPv6 header or insufficient message buffers are
+     * @returns A pointer to the message or `nullptr` if malformed IPv6 header or insufficient message buffers are
      * available.
      *
      */
@@ -231,7 +231,7 @@ public:
      * the Thread control traffic filter setting.
      *
      * @param[in]  aCallback         A pointer to a function that is called when an IPv6 datagram is received
-     *                               or nullptr to disable the callback.
+     *                               or `nullptr` to disable the callback.
      * @param[in]  aCallbackContext  A pointer to application-specific context.
      *
      * @sa IsReceiveIp6FilterEnabled
@@ -285,7 +285,7 @@ public:
      *
      * @param[in]  aMessageInfo  A reference to the message information.
      *
-     * @returns A pointer to the selected IPv6 source address or nullptr if no source address was found.
+     * @returns A pointer to the selected IPv6 source address or `nullptr` if no source address was found.
      *
      */
     const Netif::UnicastAddress *SelectSourceAddress(MessageInfo &aMessageInfo);

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -312,7 +312,7 @@ public:
      * If the resulting string does not fit in @p aBuffer (within its @p aSize characters), the string will be
      * truncated but the outputted string is always null-terminated.
      *
-     * @param[out] aBuffer   A pointer to a char array to output the string (MUST NOT be nullptr).
+     * @param[out] aBuffer   A pointer to a char array to output the string (MUST NOT be `nullptr`).
      * @param[in]  aSize     The size of @p aBuffer (in bytes).
      *
      */
@@ -953,7 +953,7 @@ public:
      * If the resulting string does not fit in @p aBuffer (within its @p aSize characters), the string will be
      * truncated but the outputted string is always null-terminated.
      *
-     * @param[out] aBuffer   A pointer to a char array to output the string (MUST NOT be nullptr).
+     * @param[out] aBuffer   A pointer to a char array to output the string (MUST NOT be `nullptr`).
      * @param[in]  aSize     The size of @p aBuffer (in bytes).
      *
      */

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -71,7 +71,7 @@ private:
  * Certain fixed multicast addresses are defined as a set of chained (linked-list) constant `otNetifMulticastAddress`
  * entries:
  *
- * LinkLocalAllRouters -> RealmLocalAllRouters -> LinkLocalAll -> RealmLocalAll -> RealmLocalAllMplForwarders -> nullptr
+ * LinkLocalAllRouters -> RealmLocalAllRouters -> LinkLocalAll -> RealmLocalAll -> RealmLocalAllMplForwarders.
  *
  * All or a portion of the chain is appended to the end of `mMulticastAddresses` linked-list. If the interface is
  * subscribed to all-routers multicast addresses (using `SubscribeAllRoutersMulticast()`) then all the five entries

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -117,7 +117,7 @@ public:
         /**
          * This method gets the host name (label) string.
          *
-         * @returns The host name (label) string, or nullptr if not yet set.
+         * @returns The host name (label) string, or `nullptr` if not yet set.
          *
          */
         const char *GetName(void) const { return mName; }
@@ -401,7 +401,7 @@ public:
      * The SRP client allows a single callback to be registered. So consecutive calls to this method will overwrite any
      * previously set callback functions.
      *
-     * @param[in] aCallback        The callback to notify of events and changes. Can be nullptr if not needed.
+     * @param[in] aCallback        The callback to notify of events and changes. Can be `nullptr` if not needed.
      * @param[in] aContext         An arbitrary context used with @p aCallback.
      *
      */

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -456,7 +456,7 @@ public:
          * This method returns the KEY resource of the host.
          *
          * @returns  A pointer to the ECDSA P 256 public key if there is valid one.
-         *           nullptr if no valid key exists.
+         *           `nullptr` if no valid key exists.
          *
          */
         const Dns::Ecdsa256KeyRecord *GetKey(void) const { return mKey.IsValid() ? &mKey : nullptr; }
@@ -637,7 +637,7 @@ public:
      * A trailing dot will be appended to @p aDomain if it is not already there.
      * This method should only be called before the SRP server is enabled.
      *
-     * @param[in]  aDomain  The domain to be set. MUST NOT be nullptr.
+     * @param[in]  aDomain  The domain to be set. MUST NOT be `nullptr`.
      *
      * @retval  kErrorNone          Successfully set the domain to @p aDomain.
      * @retval  kErrorInvalidState  The SRP server is already enabled and the Domain cannot be changed.
@@ -737,9 +737,9 @@ public:
     /**
      * This method returns the next registered SRP host.
      *
-     * @param[in]  aHost  The current SRP host; use nullptr to get the first SRP host.
+     * @param[in]  aHost  The current SRP host; use `nullptr` to get the first SRP host.
      *
-     * @returns  A pointer to the next SRP host or nullptr if no more SRP hosts can be found.
+     * @returns  A pointer to the next SRP host or `nullptr` if no more SRP hosts can be found.
      *
      */
     const Host *GetNextHost(const Host *aHost);

--- a/src/core/net/udp6.hpp
+++ b/src/core/net/udp6.hpp
@@ -155,7 +155,7 @@ public:
          * @param[in]  aReserved  The number of header bytes to reserve after the UDP header.
          * @param[in]  aSettings  The message settings (default is used if not provided).
          *
-         * @returns A pointer to the message or nullptr if no buffers are available.
+         * @returns A pointer to the message or `nullptr` if no buffers are available.
          *
          */
         Message *NewMessage(uint16_t aReserved, const Message::Settings &aSettings = Message::Settings::GetDefault());
@@ -527,7 +527,7 @@ public:
      * @param[in]  aReserved  The number of header bytes to reserve after the UDP header.
      * @param[in]  aSettings  The message settings.
      *
-     * @returns A pointer to the message or nullptr if no buffers are available.
+     * @returns A pointer to the message or `nullptr` if no buffers are available.
      *
      */
     Message *NewMessage(uint16_t aReserved, const Message::Settings &aSettings = Message::Settings::GetDefault());

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -127,7 +127,7 @@ public:
         /**
          * This callback method handles a "Receive Done" event from radio platform.
          *
-         * @param[in]  aFrame    A pointer to the received frame or nullptr if the receive operation failed.
+         * @param[in]  aFrame    A pointer to the received frame or `nullptr` if the receive operation failed.
          * @param[in]  aError    kErrorNone when successfully received a frame,
          *                       kErrorAbort when reception was aborted and a frame was not received,
          *                       kErrorNoBufs when a frame could not be received due to lack of rx buffer space.
@@ -147,7 +147,7 @@ public:
          * This callback method handles a "Transmit Done" event from radio platform.
          *
          * @param[in]  aFrame     The frame that was transmitted.
-         * @param[in]  aAckFrame  A pointer to the ACK frame, nullptr if no ACK was received.
+         * @param[in]  aAckFrame  A pointer to the ACK frame, `nullptr` if no ACK was received.
          * @param[in]  aError     kErrorNone when the frame was transmitted,
          *                        kErrorNoAck when the frame was transmitted but no ACK was received,
          *                        kErrorChannelAccessFailure tx could not take place due to activity on the
@@ -172,7 +172,7 @@ public:
         /**
          * This callback method handles a "Receive Done" event from radio platform when diagnostics mode is enabled.
          *
-         * @param[in]  aFrame    A pointer to the received frame or nullptr if the receive operation failed.
+         * @param[in]  aFrame    A pointer to the received frame or `nullptr` if the receive operation failed.
          * @param[in]  aError    kErrorNone when successfully received a frame,
          *                       kErrorAbort when reception was aborted and a frame was not received,
          *                       kErrorNoBufs when a frame could not be received due to lack of rx buffer space.

--- a/src/core/thread/discover_scanner.hpp
+++ b/src/core/thread/discover_scanner.hpp
@@ -79,7 +79,7 @@ public:
      * completes.
      *
      * The handler function format is `void (*oHandler)(ScanResult *aResult, void *aContext);`. End of scan is
-     * indicated by `aResult` pointer being set to nullptr.
+     * indicated by `aResult` pointer being set to `nullptr`.
      *
      */
     typedef otHandleActiveScanResult Handler;
@@ -111,7 +111,8 @@ public:
      * @param[in]  aEnableFiltering   Enable filtering MLE Discovery Responses with steering data not containing a
      *                                given filter indexes.
      * @param[in]  aFilterIndexes     A pointer to `FilterIndexes` to use for filtering (when enabled).
-     *                                If set to nullptr, filter indexes are derived from hash of factory-assigned EUI64.
+     *                                If set to `nullptr`, filter indexes are derived from hash of factory-assigned
+     *                                EUI64.
      * @param[in]  aHandler           A pointer to a function that is called on receiving an MLE Discovery Response.
      * @param[in]  aContext           A pointer to arbitrary context information.
      *

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -242,7 +242,7 @@ void IndirectSender::RequestMessageUpdate(Child &aChild)
 
     if ((curMessage != nullptr) && !curMessage->GetChildMask(Get<ChildTable>().GetChildIndex(aChild)))
     {
-        // Set the indirect message for this child to nullptr to ensure
+        // Set the indirect message for this child to `nullptr` to ensure
         // it is not processed on `HandleSentFrameToChild()` callback.
 
         aChild.SetIndirectMessage(nullptr);
@@ -270,18 +270,19 @@ void IndirectSender::RequestMessageUpdate(Child &aChild)
 
     if (curMessage == nullptr)
     {
-        // Current message is nullptr, but new message is not.
+        // Current message is `nullptr`, but new message is not.
         // We have a new indirect message.
 
         UpdateIndirectMessage(aChild);
         ExitNow();
     }
 
-    // Current message and new message differ and are both non-nullptr.
-    // We need to request the frame to be replaced. The current
-    // indirect message can be replaced only if it is the first
-    // fragment. If a next fragment frame for message is already
-    // prepared, we wait for the entire message to be delivered.
+    // Current message and new message differ and are both
+    // non-`nullptr`. We need to request the frame to be replaced.
+    // The current indirect message can be replaced only if it is
+    // the first fragment. If a next fragment frame for message is
+    // already prepared, we wait for the entire message to be
+    // delivered.
 
     VerifyOrExit(aChild.GetIndirectFragmentOffset() == 0);
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -935,7 +935,7 @@ protected:
     /**
      * This method allocates a new message buffer for preparing an MLE message.
      *
-     * @returns A pointer to the message or nullptr if insufficient message buffers are available.
+     * @returns A pointer to the message or `nullptr` if insufficient message buffers are available.
      *
      */
     Message *NewMleMessage(void);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1070,7 +1070,7 @@ uint8_t MleRouter::GetLinkCost(uint8_t aRouterId)
 
     router = mRouterTable.GetRouter(aRouterId);
 
-    // nullptr aRouterId indicates non-existing next hop, hence return kMaxRouteCost for it.
+    // `nullptr` aRouterId indicates non-existing next hop, hence return kMaxRouteCost for it.
     VerifyOrExit(router != nullptr);
 
     rval = mRouterTable.GetLinkCost(*router);

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -120,7 +120,7 @@ public:
      *
      * @param aAddresses   A pointer to IPv6 multicast addresses to register.
      * @param aAddressNum  The number of IPv6 multicast addresses.
-     * @param aTimeout     A pointer to the timeout (in seconds), or nullptr to use the default MLR timeout.
+     * @param aTimeout     A pointer to the timeout (in seconds), or `nullptr` to use the default MLR timeout.
      *                     A timeout of 0 seconds removes the Multicast Listener addresses.
      * @param aCallback    A callback function.
      * @param aContext     A user context pointer.

--- a/src/core/thread/neighbor_table.hpp
+++ b/src/core/thread/neighbor_table.hpp
@@ -95,7 +95,7 @@ public:
      * @param[in]  aShortAddress  A short address.
      * @param[in]  aFilter        A neighbor state filter
      *
-     * @returns A pointer to the `Neighbor` corresponding to @p aShortAddress, nullptr otherwise.
+     * @returns A pointer to the `Neighbor` corresponding to @p aShortAddress, `nullptr` otherwise.
      *
      */
     Neighbor *FindParent(Mac::ShortAddress     aShortAddress,
@@ -108,7 +108,7 @@ public:
      * @param[in]  aExtAddress   A MAC Extended Address.
      * @param[in]  aFilter       A neighbor state filter
      *
-     * @returns A pointer to the `Neighbor` corresponding to @p aExtAddress, nullptr otherwise.
+     * @returns A pointer to the `Neighbor` corresponding to @p aExtAddress, `nullptr` otherwise.
      *
      */
     Neighbor *FindParent(const Mac::ExtAddress &aExtAddress,
@@ -121,7 +121,7 @@ public:
      * @param[in]  aMacAddress  A MAC address.
      * @param[in]  aFilter      A neighbor state filter
      *
-     * @returns A pointer to the `Neighbor` corresponding to @p aMacAddress, nullptr otherwise.
+     * @returns A pointer to the `Neighbor` corresponding to @p aMacAddress, `nullptr` otherwise.
      *
      */
     Neighbor *FindParent(const Mac::Address &  aMacAddress,
@@ -133,7 +133,7 @@ public:
      * @param[in]  aShortAddress  A short address.
      * @param[in]  aFilter        A neighbor state filter.
      *
-     * @returns A pointer to the `Neighbor` corresponding to @p aShortAddress, nullptr otherwise.
+     * @returns A pointer to the `Neighbor` corresponding to @p aShortAddress, `nullptr` otherwise.
      *
      */
     Neighbor *FindNeighbor(Mac::ShortAddress     aShortAddress,
@@ -145,7 +145,7 @@ public:
      * @param[in]  aExtAddress   A MAC Extended Address.
      * @param[in]  aFilter       A neighbor state filter.
      *
-     * @returns A pointer to the `Neighbor` corresponding to @p aExtAddress, nullptr otherwise.
+     * @returns A pointer to the `Neighbor` corresponding to @p aExtAddress, `nullptr` otherwise.
      *
      */
     Neighbor *FindNeighbor(const Mac::ExtAddress &aExtAddress,
@@ -157,7 +157,7 @@ public:
      * @param[in]  aMacAddress  A MAC address.
      * @param[in]  aFilter      A neighbor state filter.
      *
-     * @returns A pointer to the `Neighbor` corresponding to @p aMacAddress, nullptr otherwise.
+     * @returns A pointer to the `Neighbor` corresponding to @p aMacAddress, `nullptr` otherwise.
      *
      */
     Neighbor *FindNeighbor(const Mac::Address &  aMacAddress,
@@ -171,7 +171,7 @@ public:
      * @param[in]  aIp6Address  An IPv6 address.
      * @pram[in]   aFilter      A neighbor state filter.
      *
-     * @returns A pointer to the `Neighbor` corresponding to @p aIp6Address, nullptr otherwise.
+     * @returns A pointer to the `Neighbor` corresponding to @p aIp6Address, `nullptr` otherwise.
      *
      */
     Neighbor *FindNeighbor(const Ip6::Address &  aIp6Address,
@@ -183,7 +183,7 @@ public:
      *
      * @param[in]  aMacAddress  A MAC address.
      *
-     * @returns A pointer to the Neighbor corresponding to @p aMacAddress, nullptr otherwise.
+     * @returns A pointer to the Neighbor corresponding to @p aMacAddress, `nullptr` otherwise.
      *
      */
     Neighbor *FindRxOnlyNeighborRouter(const Mac::Address &aMacAddress);
@@ -207,7 +207,7 @@ public:
     /**
      * This method registers the "neighbor table changed" callback function.
      *
-     * The provided callback (if non-nullptr) will be invoked when a child/router entry is being added/remove to/from
+     * The provided callback (if non-`nullptr`) will be invoked when a child/router entry is being added/remove to/from
      * the neighbor table. Subsequent calls to this method will overwrite the previous callback.
      *
      * @param[in] aCallback    A pointer to callback handler function.

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -130,12 +130,12 @@ Error NetworkData::Iterate(Iterator &aIterator, uint16_t aRloc16, Config &aConfi
     // Iterate to the next entry in Network Data matching `aRloc16`
     // (can be set to `Mac::kShortAddrBroadcast` to allow any RLOC).
     // The `aIterator` is used to track and save the current position.
-    // On input, the non-nullptr pointer members in `aConfig` specify the
-    // Network Data entry types (`mOnMeshPrefix`, `mExternalRoute`,
+    // On input, the non-`nullptr` pointer members in `aConfig` specify
+    // the Network Data entry types (`mOnMeshPrefix`, `mExternalRoute`,
     // `mService`) to iterate over. On successful exit, the `aConfig`
-    // is updated such that only one member pointer is not nullptr
-    // indicating the type of entry and the non-nullptr config is updated
-    // with the entry info.
+    // is updated such that only one member pointer is not `nullptr`
+    // indicating the type of entry and the non-`nullptr` config is
+    // updated with the entry info.
 
     Error               error = kErrorNotFound;
     NetworkDataIterator iterator(aIterator);

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -376,7 +376,7 @@ protected:
      * @param[in]  aPrefix        A pointer to an IPv6 prefix.
      * @param[in]  aPrefixLength  The prefix length pointed to by @p aPrefix (in bits).
      *
-     * @returns A pointer to the Prefix TLV if one is found or nullptr if no matching Prefix TLV exists.
+     * @returns A pointer to the Prefix TLV if one is found or `nullptr` if no matching Prefix TLV exists.
      *
      */
     const PrefixTlv *FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength) const;
@@ -386,7 +386,7 @@ protected:
      *
      * @param[in]  aPrefix        An IPv6 prefix.
      *
-     * @returns A pointer to the Prefix TLV if one is found or nullptr if no matching Prefix TLV exists.
+     * @returns A pointer to the Prefix TLV if one is found or `nullptr` if no matching Prefix TLV exists.
      *
      */
     const PrefixTlv *FindPrefix(const Ip6::Prefix &aPrefix) const
@@ -401,7 +401,7 @@ protected:
      * @param[in]  aServiceData       A Service Data.
      * @param[in]  aServiceMatchMode  The Service Data match mode.
      *
-     * @returns A pointer to the Service TLV if one is found or nullptr if no matching Service TLV exists.
+     * @returns A pointer to the Service TLV if one is found or `nullptr` if no matching Service TLV exists.
      *
      */
     const ServiceTlv *FindService(uint32_t           aEnterpriseNumber,
@@ -413,14 +413,14 @@ protected:
      *
      * This method can be used to iterate over all Service TLVs that start with a given Service Data.
      *
-     * @param[in]  aPrevServiceTlv    Set to nullptr to start from the beginning of the TLVs (finding the first matching
-     *                                Service TLV), or a pointer to the previous Service TLV returned from this method
-     *                                to iterate to the next matching Service TLV.
+     * @param[in]  aPrevServiceTlv    Set to `nullptr` to start from the beginning of the TLVs (finding the first
+     *                                matching Service TLV), or a pointer to the previous Service TLV returned from
+     *                                this method to iterate to the next matching Service TLV.
      * @param[in]  aEnterpriseNumber  Enterprise Number.
      * @param[in]  aServiceData       A Service Data to match with Service TLVs.
      * @param[in]  aServiceMatchMode  The Service Data match mode.
      *
-     * @returns A pointer to the next matching Service TLV if one is found or nullptr if it cannot be found.
+     * @returns A pointer to the next matching Service TLV if one is found or `nullptr` if it cannot be found.
      *
      */
     const ServiceTlv *FindNextService(const ServiceTlv * aPrevServiceTlv,
@@ -433,13 +433,13 @@ protected:
      *
      * This method can be used to iterate over all Thread Service TLVs that start with a given Service Data.
      *
-     * @param[in]  aPrevServiceTlv    Set to nullptr to start from the beginning of the TLVs (finding the first matching
-     *                                Service TLV), or a pointer to the previous Service TLV returned from this method
-     *                                to iterate to the next matching Service TLV.
+     * @param[in]  aPrevServiceTlv    Set to `nullptr` to start from the beginning of the TLVs (finding the first
+     *                                matching Service TLV), or a pointer to the previous Service TLV returned from
+     *                                this method to iterate to the next matching Service TLV.
      * @param[in]  aServiceData       A Service Data to match with Service TLVs.
      * @param[in]  aServiceMatchMode  The Service Data match mode.
      *
-     * @returns A pointer to the next matching Thread Service TLV if one is found or nullptr if it cannot be found.
+     * @returns A pointer to the next matching Thread Service TLV if one is found or `nullptr` if it cannot be found.
      *
      */
     const ServiceTlv *FindNextThreadService(const ServiceTlv * aPrevServiceTlv,
@@ -633,7 +633,7 @@ protected:
      * @param[in]  aPrefix        A pointer to an IPv6 prefix.
      * @param[in]  aPrefixLength  The prefix length pointed to by @p aPrefix (in bits).
      *
-     * @returns A pointer to the Prefix TLV if one is found or nullptr if no matching Prefix TLV exists.
+     * @returns A pointer to the Prefix TLV if one is found or `nullptr` if no matching Prefix TLV exists.
      *
      */
     PrefixTlv *FindPrefix(const uint8_t *aPrefix, uint8_t aPrefixLength)
@@ -646,7 +646,7 @@ protected:
      *
      * @param[in]  aPrefix        An IPv6 prefix.
      *
-     * @returns A pointer to the Prefix TLV if one is found or nullptr if no matching Prefix TLV exists.
+     * @returns A pointer to the Prefix TLV if one is found or `nullptr` if no matching Prefix TLV exists.
      *
      */
     PrefixTlv *FindPrefix(const Ip6::Prefix &aPrefix) { return FindPrefix(aPrefix.GetBytes(), aPrefix.GetLength()); }
@@ -660,7 +660,7 @@ protected:
      * @param[in]  aServiceData       A Service Data.
      * @param[in]  aServiceMatchMode  The Service Data match mode.
      *
-     * @returns A pointer to the Service TLV if one is found or nullptr if no matching Service TLV exists.
+     * @returns A pointer to the Service TLV if one is found or `nullptr` if no matching Service TLV exists.
      *
      */
     ServiceTlv *FindService(uint32_t           aEnterpriseNumber,
@@ -690,8 +690,8 @@ protected:
      *
      * @param[in]  aTlvSize  The size of TLV (total number of bytes including Type, Length, and Value fields)
      *
-     * @returns A pointer to the TLV if there is space to grow Network Data, or nullptr if no space to grow the Network
-     *          Data with requested @p aTlvSize number of bytes.
+     * @returns A pointer to the TLV if there is space to grow Network Data, or `nullptr` if no space to grow the
+     *          Network Data with requested @p aTlvSize number of bytes.
      *
      */
     NetworkDataTlv *AppendTlv(uint16_t aTlvSize);

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -174,7 +174,7 @@ public:
     /**
      * This method returns a pointer to the Commissioning Data.
      *
-     * @returns A pointer to the Commissioning Data or nullptr if no Commissioning Data exists.
+     * @returns A pointer to the Commissioning Data or `nullptr` if no Commissioning Data exists.
      *
      */
     CommissioningDataTlv *GetCommissioningData(void) { return AsNonConst(AsConst(this)->GetCommissioningData()); }
@@ -182,7 +182,7 @@ public:
     /**
      * This method returns a pointer to the Commissioning Data.
      *
-     * @returns A pointer to the Commissioning Data or nullptr if no Commissioning Data exists.
+     * @returns A pointer to the Commissioning Data or `nullptr` if no Commissioning Data exists.
      *
      */
     const CommissioningDataTlv *GetCommissioningData(void) const;
@@ -192,7 +192,7 @@ public:
      *
      * @param[in]  aType  The TLV type value.
      *
-     * @returns A pointer to the Commissioning Data Sub-TLV or nullptr if no Sub-TLV exists.
+     * @returns A pointer to the Commissioning Data Sub-TLV or `nullptr` if no Sub-TLV exists.
      *
      */
     MeshCoP::Tlv *GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aType)
@@ -205,7 +205,7 @@ public:
      *
      * @param[in]  aType  The TLV type value.
      *
-     * @returns A pointer to the Commissioning Data Sub-TLV or nullptr if no Sub-TLV exists.
+     * @returns A pointer to the Commissioning Data Sub-TLV or `nullptr` if no Sub-TLV exists.
      *
      */
     const MeshCoP::Tlv *GetCommissioningDataSubTlv(MeshCoP::Tlv::Type aType) const;

--- a/src/core/thread/network_data_tlvs.hpp
+++ b/src/core/thread/network_data_tlvs.hpp
@@ -217,7 +217,7 @@ public:
      * @param[in]  aEnd    A pointer to the end of the sequence of TLVs.
      * @param[in]  aType   The TLV type to find.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     static NetworkDataTlv *Find(NetworkDataTlv *aStart, NetworkDataTlv *aEnd, Type aType)
@@ -232,7 +232,7 @@ public:
      * @param[in]  aEnd    A pointer to the end of the sequence of TLVs.
      * @param[in]  aType   The TLV type to find.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     static const NetworkDataTlv *Find(const NetworkDataTlv *aStart, const NetworkDataTlv *aEnd, Type aType);
@@ -245,7 +245,7 @@ public:
      * @param[in]  aStart  A pointer to the start of the sequence of TLVs to search within.
      * @param[in]  aEnd    A pointer to the end of the sequence of TLVs.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     template <typename TlvType> static TlvType *Find(NetworkDataTlv *aStart, NetworkDataTlv *aEnd)
@@ -261,7 +261,7 @@ public:
      * @param[in]  aStart  A pointer to the start of the sequence of TLVs to search within.
      * @param[in]  aEnd    A pointer to the end of the sequence of TLVs.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     template <typename TlvType> static const TlvType *Find(const NetworkDataTlv *aStart, const NetworkDataTlv *aEnd)
@@ -278,7 +278,7 @@ public:
      * @param[in]  aType   The TLV type to find.
      * @param[in]  aStable TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     static NetworkDataTlv *Find(NetworkDataTlv *aStart, NetworkDataTlv *aEnd, Type aType, bool aStable)
@@ -295,7 +295,7 @@ public:
      * @param[in]  aType   The TLV type to find.
      * @param[in]  aStable TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     static const NetworkDataTlv *Find(const NetworkDataTlv *aStart,
@@ -313,7 +313,7 @@ public:
      * @param[in]  aEnd    A pointer to the end of the sequence of TLVs.
      * @param[in]  aStable TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     template <typename TlvType> static TlvType *Find(NetworkDataTlv *aStart, NetworkDataTlv *aEnd, bool aStable)
@@ -331,7 +331,7 @@ public:
      * @param[in]  aEnd    A pointer to the end of the sequence of TLVs.
      * @param[in]  aStable TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     template <typename TlvType>
@@ -733,7 +733,7 @@ public:
      *
      * @tparam     SubTlvType    The sub-TLV type to search for (MUST be a sub-class of `NetworkDataTlv`).
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     template <typename SubTlvType> SubTlvType *FindSubTlv(void)
@@ -746,7 +746,7 @@ public:
      *
      * @tparam     SubTlvType   The sub-TLV type to search for (MUST be a sub-class of `NetworkDataTlv`).
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     template <typename SubTlvType> const SubTlvType *FindSubTlv(void) const
@@ -761,7 +761,7 @@ public:
      *
      * @param[in]  aStable       TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     template <typename SubTlvType> SubTlvType *FindSubTlv(bool aStable)
@@ -776,7 +776,7 @@ public:
      *
      * @param[in]  aStable      TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     template <typename SubTlvType> const SubTlvType *FindSubTlv(bool aStable) const
@@ -789,7 +789,7 @@ public:
      *
      * @param[in]  aType        The sub-TLV type to search for.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     NetworkDataTlv *FindSubTlv(Type aType) { return AsNonConst(AsConst(this)->FindSubTlv(aType)); }
@@ -799,7 +799,7 @@ public:
      *
      * @param[in]  aType        The sub-TLV type to search for.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     const NetworkDataTlv *FindSubTlv(Type aType) const;
@@ -810,7 +810,7 @@ public:
      * @param[in]  aType        The sub-TLV type to search for.
      * @param[in]  aStable      TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     NetworkDataTlv *FindSubTlv(Type aType, bool aStable)
@@ -824,7 +824,7 @@ public:
      * @param[in]  aType        The sub-TLV type to search for.
      * @param[in]  aStable      TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
      *
-     * @returns A pointer to the TLV if found, or nullptr if not found.
+     * @returns A pointer to the TLV if found, or `nullptr` if not found.
      *
      */
     const NetworkDataTlv *FindSubTlv(Type aType, bool aStable) const;
@@ -1564,7 +1564,7 @@ public:
      *
      * @tparam  TlvType The TLV Type to search for (MUST be a sub-class of `NetworkDataTlv`).
      *
-     * @returns A pointer to the next TLV, or nullptr if it can not be found.
+     * @returns A pointer to the next TLV, or `nullptr` if it can not be found.
      *
      */
     template <typename TlvType> const TlvType *Iterate(void)
@@ -1579,7 +1579,7 @@ public:
      *
      * @param[in]  aStable      TRUE to find a stable TLV, FALSE to find a TLV not marked as stable.
      *
-     * @returns A pointer to the next TLV, or nullptr if it can not be found.
+     * @returns A pointer to the next TLV, or `nullptr` if it can not be found.
      *
      */
     template <typename TlvType> const TlvType *Iterate(bool aStable)

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -106,7 +106,7 @@ public:
     /**
      * This method allocates a router with a random router id.
      *
-     * @returns A pointer to the allocated router or nullptr if a router ID is not available.
+     * @returns A pointer to the allocated router or `nullptr` if a router ID is not available.
      *
      */
     Router *Allocate(void);
@@ -114,7 +114,7 @@ public:
     /**
      * This method allocates a router with a specified router id.
      *
-     * @returns A pointer to the allocated router or nullptr if the router id could not be allocated.
+     * @returns A pointer to the allocated router or `nullptr` if the router id could not be allocated.
      *
      */
     Router *Allocate(uint8_t aRouterId);
@@ -186,7 +186,7 @@ public:
      *
      * @param[in]  aRloc16  The RLOC16 value.
      *
-     * @returns A pointer to the router or nullptr if the router could not be found.
+     * @returns A pointer to the router or `nullptr` if the router could not be found.
      *
      */
     Router *GetNeighbor(uint16_t aRloc16);
@@ -196,7 +196,7 @@ public:
      *
      * @param[in]  aExtAddress  A reference to the IEEE Extended Address.
      *
-     * @returns A pointer to the router or nullptr if the router could not be found.
+     * @returns A pointer to the router or `nullptr` if the router could not be found.
      *
      */
     Router *GetNeighbor(const Mac::ExtAddress &aExtAddress);
@@ -206,7 +206,7 @@ public:
      *
      * @param[in]  aMacAddress  A MAC address
      *
-     * @returns A pointer to the router or nullptr if the router could not be found.
+     * @returns A pointer to the router or `nullptr` if the router could not be found.
      *
      */
     Router *GetNeighbor(const Mac::Address &aMacAddress);
@@ -216,7 +216,7 @@ public:
      *
      * @param[in]  aRouterId  The router id.
      *
-     * @returns A pointer to the router or nullptr if the router could not be found.
+     * @returns A pointer to the router or `nullptr` if the router could not be found.
      *
      */
     Router *GetRouter(uint8_t aRouterId) { return AsNonConst(AsConst(this)->GetRouter(aRouterId)); }
@@ -226,7 +226,7 @@ public:
      *
      * @param[in]  aRouterId  The router id.
      *
-     * @returns A pointer to the router or nullptr if the router could not be found.
+     * @returns A pointer to the router or `nullptr` if the router could not be found.
      *
      */
     const Router *GetRouter(uint8_t aRouterId) const;
@@ -236,7 +236,7 @@ public:
      *
      * @param[in]  aExtAddress  A reference to the IEEE Extended Address.
      *
-     * @returns A pointer to the router or nullptr if the router could not be found.
+     * @returns A pointer to the router or `nullptr` if the router could not be found.
      *
      */
     Router *GetRouter(const Mac::ExtAddress &aExtAddress);

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -921,7 +921,7 @@ public:
         /**
          * This method gets the current `Child` IPv6 Address to which the iterator is pointing.
          *
-         * @returns  A pointer to the associated IPv6 Address, or nullptr if iterator is done.
+         * @returns  A pointer to the associated IPv6 Address, or `nullptr` if iterator is done.
          *
          */
         const Ip6::Address *GetAddress(void) const;

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -143,8 +143,8 @@ public:
      *
      * @param[in] aMessage The message for which to get the destination.
      *
-     * @returns  A pointer to the destination child of the message, or nullptr if @p aMessage is not of supervision
-     * type.
+     * @returns  A pointer to the destination child of the message, or `nullptr` if @p aMessage is not of supervision
+     *           type.
      *
      */
     Child *GetDestination(const Message &aMessage) const;

--- a/src/core/utils/flash.hpp
+++ b/src/core/utils/flash.hpp
@@ -72,12 +72,12 @@ public:
      * @param[in]     aKey          The key associated with the requested value.
      * @param[in]     aIndex        The index of the specific item to get.
      * @param[out]    aValue        A pointer to where the value of the setting should be written.
-     *                              May be nullptr if just testing for the presence or length of a key.
+     *                              May be `nullptr` if just testing for the presence or length of a key.
      * @param[inout]  aValueLength  A pointer to the length of the value.
      *                              When called, this should point to an integer containing the maximum bytes that
      *                              can be written to @p aValue.
      *                              At return, the actual length of the setting is written.
-     *                              May be nullptr if performing a presence check.
+     *                              May be `nullptr` if performing a presence check.
      *
      * @retval kErrorNone       The value was fetched successfully.
      * @retval kErrorNotFound   The key was not found.
@@ -93,7 +93,7 @@ public:
      *
      * @param[in]  aKey          The key associated with the value.
      * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
-     *                           MUST NOT be nullptr if @p aValueLength is non-zero.
+     *                           MUST NOT be `nullptr` if @p aValueLength is non-zero.
      * @param[in]  aValueLength  The length of the data pointed to by @p aValue. May be zero.
      *
      * @retval kErrorNone     The value was changed.
@@ -107,7 +107,7 @@ public:
      *
      * @param[in]  aKey          The key associated with the value.
      * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
-     *                           MUST NOT be nullptr if @p aValueLength is non-zero.
+     *                           MUST NOT be `nullptr` if @p aValueLength is non-zero.
      * @param[in]  aValueLength  The length of the data pointed to by @p aValue. May be zero.
      *
      * @retval kErrorNone    The value was added.

--- a/src/core/utils/lookup_table.hpp
+++ b/src/core/utils/lookup_table.hpp
@@ -108,7 +108,7 @@ public:
      * @param[in] aName   A name string to search for within the table.
      * @param[in] aTable  A reference to an array of `kLength` entries on type `EntryType`
      *
-     * @returns A pointer to the entry in the table if a match is found, otherwise nullptr (no match in table).
+     * @returns A pointer to the entry in the table if a match is found, otherwise `nullptr` (no match in table).
      *
      */
     template <class EntryType, uint16_t kLength>

--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -264,7 +264,7 @@ Error Slaac::GenerateIid(Ip6::Netif::UnicastAddress &aAddress,
      *  - RID is random (but stable) Identifier.
      *  - For pseudo-random function `F()` SHA-256 is used in this method.
      *  - `Net_Iface` is set to constant string "wpan".
-     *  - `Network_ID` is not used if `aNetworkId` is nullptr (optional per RF-7217).
+     *  - `Network_ID` is not used if `aNetworkId` is `nullptr` (optional per RF-7217).
      *  - The `secret_key` is randomly generated on first use (using true
      *    random number generator) and saved in non-volatile settings for
      *    future use.


### PR DESCRIPTION


------

This PR is just style change, making the use of backtick `` ` `` consistent
(follow-up from https://github.com/openthread/openthread/pull/7189#discussion_r754818310)