### PR TITLE
[cli] reuse `AddressOriginToString()` among CLI modules

### DIFF
--- a/src/cli/README_HISTORY.md
+++ b/src/cli/README_HISTORY.md
@@ -67,7 +67,7 @@ Print the unicast IPv6 address history. Each entry provides:
 
 - Event: Added or Removed.
 - Address: Unicast address along with its prefix length (in bits).
-- Origin: Thread, SLAAC, DHCPv6, or Manual.
+- Origin: thread, slaac, dhcp6, or manual.
 - Address Scope.
 - Flags: Preferred, Valid, and RLOC (whether the address is RLOC).
 
@@ -77,15 +77,15 @@ Print the unicast IPv6 address history as table.
 > history ipaddr
 | Age                  | Event   | Address / PrefixLength                      | Origin |Scope| P | V | R |
 +----------------------+---------+---------------------------------------------+--------+-----+---+---+---+
-|         00:00:04.991 | Removed | 2001:dead:beef:cafe:c4cb:caba:8d55:e30b/64  | SLAAC  |  14 | Y | Y | N |
-|         00:00:44.647 | Added   | 2001:dead:beef:cafe:c4cb:caba:8d55:e30b/64  | SLAAC  |  14 | Y | Y | N |
-|         00:01:07.199 | Added   | fd00:0:0:0:0:0:0:1/64                       | Manual |  14 | Y | Y | N |
-|         00:02:17.885 | Added   | fdde:ad00:beef:0:0:ff:fe00:fc00/64          | Thread |   3 | N | Y | N |
-|         00:02:17.885 | Added   | fdde:ad00:beef:0:0:ff:fe00:5400/64          | Thread |   3 | N | Y | Y |
-|         00:02:20.107 | Removed | fdde:ad00:beef:0:0:ff:fe00:5400/64          | Thread |   3 | N | Y | Y |
-|         00:02:21.575 | Added   | fdde:ad00:beef:0:0:ff:fe00:5400/64          | Thread |   3 | N | Y | Y |
-|         00:02:21.575 | Added   | fdde:ad00:beef:0:ecea:c4fc:ad96:4655/64     | Thread |   3 | N | Y | N |
-|         00:02:23.904 | Added   | fe80:0:0:0:3c12:a4d2:fbe0:31ad/64           | Thread |   2 | Y | Y | N |
+|         00:00:04.991 | Removed | 2001:dead:beef:cafe:c4cb:caba:8d55:e30b/64  | slaac  |  14 | Y | Y | N |
+|         00:00:44.647 | Added   | 2001:dead:beef:cafe:c4cb:caba:8d55:e30b/64  | slaac  |  14 | Y | Y | N |
+|         00:01:07.199 | Added   | fd00:0:0:0:0:0:0:1/64                       | manual |  14 | Y | Y | N |
+|         00:02:17.885 | Added   | fdde:ad00:beef:0:0:ff:fe00:fc00/64          | thread |   3 | N | Y | N |
+|         00:02:17.885 | Added   | fdde:ad00:beef:0:0:ff:fe00:5400/64          | thread |   3 | N | Y | Y |
+|         00:02:20.107 | Removed | fdde:ad00:beef:0:0:ff:fe00:5400/64          | thread |   3 | N | Y | Y |
+|         00:02:21.575 | Added   | fdde:ad00:beef:0:0:ff:fe00:5400/64          | thread |   3 | N | Y | Y |
+|         00:02:21.575 | Added   | fdde:ad00:beef:0:ecea:c4fc:ad96:4655/64     | thread |   3 | N | Y | N |
+|         00:02:23.904 | Added   | fe80:0:0:0:3c12:a4d2:fbe0:31ad/64           | thread |   2 | Y | Y | N |
 Done
 ```
 
@@ -93,11 +93,11 @@ Print the unicast IPv6 address history as a list (the last 5 entries).
 
 ```bash
 > history ipaddr list 5
-00:00:20.327 -> event:Removed address:2001:dead:beef:cafe:c4cb:caba:8d55:e30b prefixlen:64 origin:SLAAC scope:14 preferred:yes valid:yes rloc:no
-00:00:59.983 -> event:Added address:2001:dead:beef:cafe:c4cb:caba:8d55:e30b prefixlen:64 origin:SLAAC scope:14 preferred:yes valid:yes rloc:no
-00:01:22.535 -> event:Added address:fd00:0:0:0:0:0:0:1 prefixlen:64 origin:Manual scope:14 preferred:yes valid:yes rloc:no
-00:02:33.221 -> event:Added address:fdde:ad00:beef:0:0:ff:fe00:fc00 prefixlen:64 origin:Thread scope:3 preferred:no valid:yes rloc:no
-00:02:33.221 -> event:Added address:fdde:ad00:beef:0:0:ff:fe00:5400 prefixlen:64 origin:Thread scope:3 preferred:no valid:yes rloc:yes
+00:00:20.327 -> event:Removed address:2001:dead:beef:cafe:c4cb:caba:8d55:e30b prefixlen:64 origin:slaac scope:14 preferred:yes valid:yes rloc:no
+00:00:59.983 -> event:Added address:2001:dead:beef:cafe:c4cb:caba:8d55:e30b prefixlen:64 origin:slaac scope:14 preferred:yes valid:yes rloc:no
+00:01:22.535 -> event:Added address:fd00:0:0:0:0:0:0:1 prefixlen:64 origin:manual scope:14 preferred:yes valid:yes rloc:no
+00:02:33.221 -> event:Added address:fdde:ad00:beef:0:0:ff:fe00:fc00 prefixlen:64 origin:thread scope:3 preferred:no valid:yes rloc:no
+00:02:33.221 -> event:Added address:fdde:ad00:beef:0:0:ff:fe00:5400 prefixlen:64 origin:thread scope:3 preferred:no valid:yes rloc:yes
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2056,7 +2056,7 @@ exit:
     return error;
 }
 
-const char *AddressOriginToString(uint8_t aOrigin)
+const char *Interpreter::AddressOriginToString(uint8_t aOrigin)
 {
     static const char *const kOriginStrings[4] = {
         "thread", // 0, OT_ADDRESS_ORIGIN_THREAD
@@ -2064,6 +2064,11 @@ const char *AddressOriginToString(uint8_t aOrigin)
         "dhcp6",  // 2, OT_ADDRESS_ORIGIN_DHCPV6
         "manual", // 3, OT_ADDRESS_ORIGIN_MANUAL
     };
+
+    static_assert(0 == OT_ADDRESS_ORIGIN_THREAD, "OT_ADDRESS_ORIGIN_THREAD value is incorrect");
+    static_assert(1 == OT_ADDRESS_ORIGIN_SLAAC, "OT_ADDRESS_ORIGIN_SLAAC value is incorrect");
+    static_assert(2 == OT_ADDRESS_ORIGIN_DHCPV6, "OT_ADDRESS_ORIGIN_DHCPV6 value is incorrect");
+    static_assert(3 == OT_ADDRESS_ORIGIN_MANUAL, "OT_ADDRESS_ORIGIN_MANUAL value is incorrect");
 
     return aOrigin < OT_ARRAY_LENGTH(kOriginStrings) ? kOriginStrings[aOrigin] : "unknown";
 }

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -204,6 +204,16 @@ public:
      */
     static const char *LinkModeToString(const otLinkModeConfig &aLinkMode, char (&aStringBuffer)[kLinkModeStringSize]);
 
+    /**
+     * This method converts an IPv6 address origin `OT_ADDRESS_ORIGIN_*` value to human-readable string.
+     *
+     * @param[in] aOrigin   The IPv6 address origin to convert.
+     *
+     * @returns A human-readable string representation of @p aOrigin.
+     *
+     */
+    static const char *AddressOriginToString(uint8_t aOrigin);
+
 protected:
     static Interpreter *sInterpreter;
 

--- a/src/cli/cli_history.cpp
+++ b/src/cli/cli_history.cpp
@@ -129,15 +129,15 @@ otError History::ProcessIpAddr(Arg aArgs[])
             sprintf(&addressString[strlen(addressString)], "/%d", info->mPrefixLength);
 
             OutputLine("| %20s | %-7s | %-43s | %-6s | %3d | %c | %c | %c |", ageString, kEventStrings[info->mEvent],
-                       addressString, AddressOriginToString(info->mAddressOrigin), info->mScope,
+                       addressString, Interpreter::AddressOriginToString(info->mAddressOrigin), info->mScope,
                        info->mPreferred ? 'Y' : 'N', info->mValid ? 'Y' : 'N', info->mRloc ? 'Y' : 'N');
         }
         else
         {
             OutputLine("%s -> event:%s address:%s prefixlen:%d origin:%s scope:%d preferred:%s valid:%s rloc:%s",
                        ageString, kEventStrings[info->mEvent], addressString, info->mPrefixLength,
-                       AddressOriginToString(info->mAddressOrigin), info->mScope, info->mPreferred ? "yes" : "no",
-                       info->mValid ? "yes" : "no", info->mRloc ? "yes" : "no");
+                       Interpreter::AddressOriginToString(info->mAddressOrigin), info->mScope,
+                       info->mPreferred ? "yes" : "no", info->mValid ? "yes" : "no", info->mRloc ? "yes" : "no");
         }
     }
 
@@ -194,7 +194,8 @@ otError History::ProcessIpMulticastAddr(Arg aArgs[])
         otIp6AddressToString(&info->mAddress, addressString, sizeof(addressString));
 
         OutputLine(isList ? "%s -> event:%s address:%s origin:%s" : "| %20s | %-12s | %-39s | %-6s |", ageString,
-                   kEventStrings[info->mEvent], addressString, AddressOriginToString(info->mAddressOrigin));
+                   kEventStrings[info->mEvent], addressString,
+                   Interpreter::AddressOriginToString(info->mAddressOrigin));
     }
 
 exit:
@@ -322,35 +323,6 @@ otError History::ProcessRxTx(Arg aArgs[])
 otError History::ProcessTx(Arg aArgs[])
 {
     return ProcessRxTxHistory(kTx, aArgs);
-}
-
-const char *History::AddressOriginToString(uint8_t aOrigin)
-{
-    const char *str = "Unknown";
-
-    switch (aOrigin)
-    {
-    case OT_ADDRESS_ORIGIN_THREAD:
-        str = "Thread";
-        break;
-
-    case OT_ADDRESS_ORIGIN_SLAAC:
-        str = "SLAAC";
-        break;
-
-    case OT_ADDRESS_ORIGIN_DHCPV6:
-        str = "DHCPv6";
-        break;
-
-    case OT_ADDRESS_ORIGIN_MANUAL:
-        str = "Manual";
-        break;
-
-    default:
-        break;
-    }
-
-    return str;
 }
 
 const char *History::MessagePriorityToString(uint8_t aPriority)

--- a/src/cli/cli_history.hpp
+++ b/src/cli/cli_history.hpp
@@ -108,7 +108,6 @@ private:
     void    OutputRxTxEntryListFormat(const otHistoryTrackerMessageInfo &aInfo, uint32_t aEntryAge, bool aIsRx);
     void    OutputRxTxEntryTableFormat(const otHistoryTrackerMessageInfo &aInfo, uint32_t aEntryAge, bool aIsRx);
 
-    static const char *AddressOriginToString(uint8_t aOrigin);
     static const char *MessagePriorityToString(uint8_t aPriority);
     static const char *RadioTypeToString(const otHistoryTrackerMessageInfo &aInfo);
     static const char *MessageTypeToString(const otHistoryTrackerMessageInfo &aInfo);


### PR DESCRIPTION
This commit changes `AddressOriginToString()` to be a public `static`
method of `Cli::Interpreter` so we can reuse it in `Cli::History`
module and potentially other modules in future. It also removes
similar method from `Cli::History`.