### PR TITLE
[cli] add `joiner state` command

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (179)
+#define OPENTHREAD_API_VERSION (180)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/joiner.h
+++ b/include/openthread/joiner.h
@@ -146,7 +146,7 @@ void otJoinerStop(otInstance *aInstance);
 otJoinerState otJoinerGetState(otInstance *aInstance);
 
 /**
- * This method gets the Joiner ID.
+ * This function gets the Joiner ID.
  *
  * If a Joiner Discerner is not set, Joiner ID is the first 64 bits of the result of computing SHA-256 over
  * factory-assigned IEEE EUI-64. Otherwise the Joiner ID is calculated from the Joiner Discerner value.
@@ -161,7 +161,7 @@ otJoinerState otJoinerGetState(otInstance *aInstance);
 const otExtAddress *otJoinerGetId(otInstance *aInstance);
 
 /**
- * This method sets the Joiner Discerner.
+ * This function sets the Joiner Discerner.
  *
  * The Joiner Discerner is used to calculate the Joiner ID used during commissioning/joining process.
  *
@@ -180,7 +180,7 @@ const otExtAddress *otJoinerGetId(otInstance *aInstance);
 otError otJoinerSetDiscerner(otInstance *aInstance, otJoinerDiscerner *aDiscerner);
 
 /**
- * This method gets the Joiner Discerner.
+ * This function gets the Joiner Discerner.
  *
  * @param[in]   aInstance       A pointer to the OpenThread instance.
  *
@@ -188,6 +188,16 @@ otError otJoinerSetDiscerner(otInstance *aInstance, otJoinerDiscerner *aDiscerne
  *
  */
 const otJoinerDiscerner *otJoinerGetDiscerner(otInstance *aInstance);
+
+/**
+ * This function converts a given joiner state enumeration value to a human-readable string.
+ *
+ * @param[in] aState   The joiner state.
+ *
+ * @returns A human-readable string representation of @p aState.
+ *
+ */
+const char *otJoinerStateToString(otJoinerState aState);
 
 /**
  * @}

--- a/src/cli/README_JOINER.md
+++ b/src/cli/README_JOINER.md
@@ -10,6 +10,7 @@ See [README_COMMISSIONING.md](README_COMMISSIONING.md).
 - [discerner](#discerner)
 - [id](#id)
 - [start](#start)
+- [state](#state)
 - [stop](#stop)
 
 ## Command Details
@@ -25,6 +26,7 @@ Print joiner help menu.
 help
 id
 start
+state
 stop
 Done
 ```
@@ -72,6 +74,25 @@ This command will cause the device to start the Joiner process.
 
 ```bash
 > joiner start J01NM3
+Done
+```
+
+### state
+
+Usage: `joiner state`
+
+Print the Joiner state.
+
+- Idle
+- Discover
+- Connecting
+- Connected
+- Entrust
+- Joined
+
+```bash
+> joiner state
+Idle
 Done
 ```
 

--- a/src/cli/cli_joiner.cpp
+++ b/src/cli/cli_joiner.cpp
@@ -128,6 +128,15 @@ otError Joiner::ProcessStop(Arg aArgs[])
     return OT_ERROR_NONE;
 }
 
+otError Joiner::ProcessState(Arg aArgs[])
+{
+    OT_UNUSED_VARIABLE(aArgs);
+
+    OutputLine("%s", otJoinerStateToString(otJoinerGetState(GetInstancePtr())));
+
+    return OT_ERROR_NONE;
+}
+
 otError Joiner::Process(Arg aArgs[])
 {
     otError        error = OT_ERROR_INVALID_COMMAND;

--- a/src/cli/cli_joiner.hpp
+++ b/src/cli/cli_joiner.hpp
@@ -87,13 +87,14 @@ private:
     otError ProcessId(Arg aArgs[]);
     otError ProcessStart(Arg aArgs[]);
     otError ProcessStop(Arg aArgs[]);
+    otError ProcessState(Arg aArgs[]);
 
     static void HandleCallback(otError aError, void *aContext);
     void        HandleCallback(otError aError);
 
     static constexpr Command sCommands[] = {
-        {"discerner", &Joiner::ProcessDiscerner}, {"help", &Joiner::ProcessHelp}, {"id", &Joiner::ProcessId},
-        {"start", &Joiner::ProcessStart},         {"stop", &Joiner::ProcessStop},
+        {"discerner", &Joiner::ProcessDiscerner}, {"help", &Joiner::ProcessHelp},   {"id", &Joiner::ProcessId},
+        {"start", &Joiner::ProcessStart},         {"state", &Joiner::ProcessState}, {"stop", &Joiner::ProcessStop},
     };
 
     static_assert(Utils::LookupTable::IsSorted(sCommands), "Command Table is not sorted");

--- a/src/core/api/joiner_api.cpp
+++ b/src/core/api/joiner_api.cpp
@@ -38,6 +38,7 @@
 #include <openthread/joiner.h>
 
 #include "common/as_core_type.hpp"
+#include "common/debug.hpp"
 #include "common/locator_getters.hpp"
 
 using namespace ot;
@@ -91,6 +92,13 @@ otError otJoinerSetDiscerner(otInstance *aInstance, otJoinerDiscerner *aDiscerne
 const otJoinerDiscerner *otJoinerGetDiscerner(otInstance *aInstance)
 {
     return AsCoreType(aInstance).Get<MeshCoP::Joiner>().GetDiscerner();
+}
+
+const char *otJoinerStateToString(otJoinerState aState)
+{
+    OT_ASSERT(aState <= OT_JOINER_STATE_JOINED);
+
+    return MeshCoP::Joiner::StateToString(MapEnum(aState));
 }
 
 #endif // OPENTHREAD_CONFIG_JOINER_ENABLE

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -168,6 +168,16 @@ public:
      */
     Error ClearDiscerner(void);
 
+    /**
+     * This method converts a given Joiner state to its human-readable string representation.
+     *
+     * @param[in] aState  The Joiner state to convert.
+     *
+     * @returns A human-readable string representation of @p aState.
+     *
+     */
+    static const char *StateToString(State aState);
+
 private:
     static constexpr uint16_t kJoinerUdpPort = OPENTHREAD_CONFIG_JOINER_UDP_PORT;
 
@@ -200,8 +210,6 @@ private:
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-
-    static const char *StateToString(State aState);
 
     void    SetState(State aState);
     void    SetIdFromIeeeEui64(void);


### PR DESCRIPTION
This commit adds new CLI command `joiner state` to get the current
state of `Joiner`. It also adds new public OT API to convert a given
`otJoinerState` to a string.