### PR TITLE
[posix-netif] lower transmit log level for `OT_ERROR_DROP`

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -849,7 +849,7 @@ exit:
     {
         if (error == OT_ERROR_DROP)
         {
-            otLogInfoPlat("[netif] Message dropped by Thread", otThreadErrorToString(error));
+            otLogNotePlat("[netif] Message dropped by Thread", otThreadErrorToString(error));
         }
         else
         {

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -847,7 +847,14 @@ exit:
 
     if (error != OT_ERROR_NONE)
     {
-        otLogWarnPlat("[netif] Failed to transmit, error:%s", otThreadErrorToString(error));
+        if (error == OT_ERROR_DROP)
+        {
+            otLogInfoPlat("[netif] Message dropped by Thread", otThreadErrorToString(error));
+        }
+        else
+        {
+            otLogWarnPlat("[netif] Failed to transmit, error:%s", otThreadErrorToString(error));
+        }
     }
 }
 


### PR DESCRIPTION
This commit helps reduce posix-netif WARN logs when transmitting messages to Thread. 

There are certain ICMPv6 messages (e.g. MLDv2) that OpenThread will filter when transmitting, so the error `OT_ERROR_DROP` is expected. 
This commit also assumes that OpenThread knows what it's doing when it choose to drop a message, thus using lower log level for `OT_ERROR_DROP`.