### PR TITLE
[thci] discard IPv4 link local address in mDNS browsing

### DIFF
--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -665,7 +665,10 @@ EOF"
             for ba in border_agents:
                 for record in cache[ba.server_name]:
                     if isinstance(record, DNSAddress):
-                        addr = ipaddress.ip_address(record.address)
+                        try:
+                            addr = ipaddress.IPv6Address(record.address)
+                        except Exception:
+                            continue
                         if addr.is_link_local:
                             ba.link_local_addr = str(addr)
                             break

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -665,11 +665,8 @@ EOF"
             for ba in border_agents:
                 for record in cache[ba.server_name]:
                     if isinstance(record, DNSAddress):
-                        try:
-                            addr = ipaddress.IPv6Address(record.address)
-                        except Exception:
-                            continue
-                        if addr.is_link_local:
+                        addr = ipaddress.ip_address(record.address)
+                        if isinstance(addr, ipaddress.IPv6Address) and addr.is_link_local:
                             ba.link_local_addr = str(addr)
                             break
 


### PR DESCRIPTION
When looking for the Border Agent's link local address in the mDNS response do not consider a possible IPv4 address record.