### PR TITLE
[core] use const array lookup for converting enum to string

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -452,24 +452,17 @@ otError Interpreter::ProcessBorderAgent(Arg aArgs[])
     }
     else if (aArgs[0] == "state")
     {
-        const char *state;
+        static const char *const kStateStrings[] = {
+            "Stopped"  // (0) OT_BORDER_AGENT_STATE_STOPPED
+            "Started", // (1) OT_BORDER_AGENT_STATE_STARTED
+            "Active",  // (2) OT_BORDER_AGENT_STATE_ACTIVE
+        };
 
-        switch (otBorderAgentGetState(GetInstancePtr()))
-        {
-        case OT_BORDER_AGENT_STATE_STOPPED:
-            state = "Stopped";
-            break;
-        case OT_BORDER_AGENT_STATE_STARTED:
-            state = "Started";
-            break;
-        case OT_BORDER_AGENT_STATE_ACTIVE:
-            state = "Active";
-            break;
-        default:
-            state = "Unknown";
-            break;
-        }
-        OutputLine(state);
+        static_assert(0 == OT_BORDER_AGENT_STATE_STOPPED, "OT_BORDER_AGENT_STATE_STOPPED value is incorrect");
+        static_assert(1 == OT_BORDER_AGENT_STATE_STARTED, "OT_BORDER_AGENT_STATE_STARTED value is incorrect");
+        static_assert(2 == OT_BORDER_AGENT_STATE_ACTIVE, "OT_BORDER_AGENT_STATE_ACTIVE value is incorrect");
+
+        OutputLine("%s", Stringify(otBorderAgentGetState(GetInstancePtr()), kStateStrings));
     }
     else
     {
@@ -664,18 +657,17 @@ otError Interpreter::ProcessBackboneRouterLocal(Arg aArgs[])
     }
     else if (aArgs[0] == "state")
     {
-        switch (otBackboneRouterGetState(GetInstancePtr()))
-        {
-        case OT_BACKBONE_ROUTER_STATE_DISABLED:
-            OutputLine("Disabled");
-            break;
-        case OT_BACKBONE_ROUTER_STATE_SECONDARY:
-            OutputLine("Secondary");
-            break;
-        case OT_BACKBONE_ROUTER_STATE_PRIMARY:
-            OutputLine("Primary");
-            break;
-        }
+        static const char *const kStateStrings[] = {
+            "Disabled",  // (0) OT_BACKBONE_ROUTER_STATE_DISABLED
+            "Secondary", // (1) OT_BACKBONE_ROUTER_STATE_SECONDARY
+            "Primary",   // (2) OT_BACKBONE_ROUTER_STATE_PRIMARY
+        };
+
+        static_assert(0 == OT_BACKBONE_ROUTER_STATE_DISABLED, "OT_BACKBONE_ROUTER_STATE_DISABLED value is incorrect");
+        static_assert(1 == OT_BACKBONE_ROUTER_STATE_SECONDARY, "OT_BACKBONE_ROUTER_STATE_SECONDARY value is incorrect");
+        static_assert(2 == OT_BACKBONE_ROUTER_STATE_PRIMARY, "OT_BACKBONE_ROUTER_STATE_PRIMARY value is incorrect");
+
+        OutputLine("%s", Stringify(otBackboneRouterGetState(GetInstancePtr()), kStateStrings));
     }
     else if (aArgs[0] == "config")
     {
@@ -1768,7 +1760,7 @@ const char *EidCacheStateToString(otCacheEntryState aState)
         "retry",
     };
 
-    return static_cast<uint8_t>(aState) < OT_ARRAY_LENGTH(kStateStrings) ? kStateStrings[aState] : "unknown";
+    return Interpreter::Stringify(aState, kStateStrings);
 }
 
 void Interpreter::OutputEidCacheEntry(const otCacheEntryInfo &aEntry)
@@ -2070,7 +2062,7 @@ const char *Interpreter::AddressOriginToString(uint8_t aOrigin)
     static_assert(2 == OT_ADDRESS_ORIGIN_DHCPV6, "OT_ADDRESS_ORIGIN_DHCPV6 value is incorrect");
     static_assert(3 == OT_ADDRESS_ORIGIN_MANUAL, "OT_ADDRESS_ORIGIN_MANUAL value is incorrect");
 
-    return aOrigin < OT_ARRAY_LENGTH(kOriginStrings) ? kOriginStrings[aOrigin] : "unknown";
+    return Stringify(aOrigin, kOriginStrings);
 }
 
 otError Interpreter::ProcessIpAddr(Arg aArgs[])
@@ -2376,43 +2368,32 @@ void Interpreter::HandleLinkMetricsEnhAckProbingIe(otShortAddress             aS
 
 const char *Interpreter::LinkMetricsStatusToStr(uint8_t aStatus)
 {
-    uint8_t            strIndex                = 0;
-    static const char *linkMetricsStatusText[] = {
-        "Success",
-        "Cannot support new series",
-        "Series ID already registered",
-        "Series ID not recognized",
-        "No matching series ID",
-        "Other error",
-        "Unknown error",
+    static const char *const kStatusStrings[] = {
+        "Success",                      // (0) OT_LINK_METRICS_STATUS_SUCCESS
+        "Cannot support new series",    // (1) OT_LINK_METRICS_STATUS_CANNOT_SUPPORT_NEW_SERIES
+        "Series ID already registered", // (2) OT_LINK_METRICS_STATUS_SERIESID_ALREADY_REGISTERED
+        "Series ID not recognized",     // (3) OT_LINK_METRICS_STATUS_SERIESID_NOT_RECOGNIZED
+        "No matching series ID",        // (4) OT_LINK_METRICS_STATUS_NO_MATCHING_FRAMES_RECEIVED
     };
 
-    switch (aStatus)
+    const char *str = "Unknown error";
+
+    static_assert(0 == OT_LINK_METRICS_STATUS_SUCCESS, "STATUS_SUCCESS is incorrect");
+    static_assert(1 == OT_LINK_METRICS_STATUS_CANNOT_SUPPORT_NEW_SERIES, "CANNOT_SUPPORT_NEW_SERIES is incorrect");
+    static_assert(2 == OT_LINK_METRICS_STATUS_SERIESID_ALREADY_REGISTERED, "SERIESID_ALREADY_REGISTERED is incorrect");
+    static_assert(3 == OT_LINK_METRICS_STATUS_SERIESID_NOT_RECOGNIZED, "SERIESID_NOT_RECOGNIZED is incorrect");
+    static_assert(4 == OT_LINK_METRICS_STATUS_NO_MATCHING_FRAMES_RECEIVED, "NO_MATCHING_FRAMES_RECEIVED is incorrect");
+
+    if (aStatus < OT_ARRAY_LENGTH(kStatusStrings))
     {
-    case OT_LINK_METRICS_STATUS_SUCCESS:
-        strIndex = 0;
-        break;
-    case OT_LINK_METRICS_STATUS_CANNOT_SUPPORT_NEW_SERIES:
-        strIndex = 1;
-        break;
-    case OT_LINK_METRICS_STATUS_SERIESID_ALREADY_REGISTERED:
-        strIndex = 2;
-        break;
-    case OT_LINK_METRICS_STATUS_SERIESID_NOT_RECOGNIZED:
-        strIndex = 3;
-        break;
-    case OT_LINK_METRICS_STATUS_NO_MATCHING_FRAMES_RECEIVED:
-        strIndex = 4;
-        break;
-    case OT_LINK_METRICS_STATUS_OTHER_ERROR:
-        strIndex = 5;
-        break;
-    default:
-        strIndex = 6;
-        break;
+        str = kStatusStrings[aStatus];
+    }
+    else if (aStatus == OT_LINK_METRICS_STATUS_OTHER_ERROR)
+    {
+        str = "Other error";
     }
 
-    return linkMetricsStatusText[strIndex];
+    return str;
 }
 
 otError Interpreter::ProcessLinkMetrics(Arg aArgs[])

--- a/src/cli/cli_commissioner.cpp
+++ b/src/cli/cli_commissioner.cpp
@@ -325,22 +325,17 @@ void Commissioner::HandleStateChanged(otCommissionerState aState)
 
 const char *Commissioner::StateToString(otCommissionerState aState)
 {
-    const char *rval = "unknown";
+    static const char *const kStateString[] = {
+        "disabled",    // (0) OT_COMMISSIONER_STATE_DISABLED
+        "petitioning", // (1) OT_COMMISSIONER_STATE_PETITION
+        "active",      // (2) OT_COMMISSIONER_STATE_ACTIVE
+    };
 
-    switch (aState)
-    {
-    case OT_COMMISSIONER_STATE_DISABLED:
-        rval = "disabled";
-        break;
-    case OT_COMMISSIONER_STATE_PETITION:
-        rval = "petitioning";
-        break;
-    case OT_COMMISSIONER_STATE_ACTIVE:
-        rval = "active";
-        break;
-    }
+    static_assert(0 == OT_COMMISSIONER_STATE_DISABLED, "OT_COMMISSIONER_STATE_DISABLED value is incorrect");
+    static_assert(1 == OT_COMMISSIONER_STATE_PETITION, "OT_COMMISSIONER_STATE_PETITION value is incorrect");
+    static_assert(2 == OT_COMMISSIONER_STATE_ACTIVE, "OT_COMMISSIONER_STATE_ACTIVE value is incorrect");
 
-    return rval;
+    return Stringify(aState, kStateString);
 }
 
 void Commissioner::HandleJoinerEvent(otCommissionerJoinerEvent aEvent,
@@ -355,28 +350,23 @@ void Commissioner::HandleJoinerEvent(otCommissionerJoinerEvent aEvent,
                                      const otJoinerInfo *      aJoinerInfo,
                                      const otExtAddress *      aJoinerId)
 {
+    static const char *const kEventStrings[] = {
+        "start",    // (0) OT_COMMISSIONER_JOINER_START
+        "connect",  // (1) OT_COMMISSIONER_JOINER_CONNECTED
+        "finalize", // (2) OT_COMMISSIONER_JOINER_FINALIZE
+        "end",      // (3) OT_COMMISSIONER_JOINER_END
+        "remove",   // (4) OT_COMMISSIONER_JOINER_REMOVED
+    };
+
+    static_assert(0 == OT_COMMISSIONER_JOINER_START, "OT_COMMISSIONER_JOINER_START value is incorrect");
+    static_assert(1 == OT_COMMISSIONER_JOINER_CONNECTED, "OT_COMMISSIONER_JOINER_CONNECTED value is incorrect");
+    static_assert(2 == OT_COMMISSIONER_JOINER_FINALIZE, "OT_COMMISSIONER_JOINER_FINALIZE value is incorrect");
+    static_assert(3 == OT_COMMISSIONER_JOINER_END, "OT_COMMISSIONER_JOINER_END value is incorrect");
+    static_assert(4 == OT_COMMISSIONER_JOINER_REMOVED, "OT_COMMISSIONER_JOINER_REMOVED value is incorrect");
+
     OT_UNUSED_VARIABLE(aJoinerInfo);
 
-    OutputFormat("Commissioner: Joiner ");
-
-    switch (aEvent)
-    {
-    case OT_COMMISSIONER_JOINER_START:
-        OutputFormat("start ");
-        break;
-    case OT_COMMISSIONER_JOINER_CONNECTED:
-        OutputFormat("connect ");
-        break;
-    case OT_COMMISSIONER_JOINER_FINALIZE:
-        OutputFormat("finalize ");
-        break;
-    case OT_COMMISSIONER_JOINER_END:
-        OutputFormat("end ");
-        break;
-    case OT_COMMISSIONER_JOINER_REMOVED:
-        OutputFormat("remove ");
-        break;
-    }
+    OutputFormat("Commissioner: Joiner %s ", Stringify(aEvent, kEventStrings));
 
     if (aJoinerId != nullptr)
     {

--- a/src/cli/cli_history.cpp
+++ b/src/cli/cli_history.cpp
@@ -128,14 +128,15 @@ otError History::ProcessIpAddr(Arg aArgs[])
         {
             sprintf(&addressString[strlen(addressString)], "/%d", info->mPrefixLength);
 
-            OutputLine("| %20s | %-7s | %-43s | %-6s | %3d | %c | %c | %c |", ageString, kEventStrings[info->mEvent],
-                       addressString, Interpreter::AddressOriginToString(info->mAddressOrigin), info->mScope,
+            OutputLine("| %20s | %-7s | %-43s | %-6s | %3d | %c | %c | %c |", ageString,
+                       Stringify(info->mEvent, kEventStrings), addressString,
+                       Interpreter::AddressOriginToString(info->mAddressOrigin), info->mScope,
                        info->mPreferred ? 'Y' : 'N', info->mValid ? 'Y' : 'N', info->mRloc ? 'Y' : 'N');
         }
         else
         {
             OutputLine("%s -> event:%s address:%s prefixlen:%d origin:%s scope:%d preferred:%s valid:%s rloc:%s",
-                       ageString, kEventStrings[info->mEvent], addressString, info->mPrefixLength,
+                       ageString, Stringify(info->mEvent, kEventStrings), addressString, info->mPrefixLength,
                        Interpreter::AddressOriginToString(info->mAddressOrigin), info->mScope,
                        info->mPreferred ? "yes" : "no", info->mValid ? "yes" : "no", info->mRloc ? "yes" : "no");
         }
@@ -194,7 +195,7 @@ otError History::ProcessIpMulticastAddr(Arg aArgs[])
         otIp6AddressToString(&info->mAddress, addressString, sizeof(addressString));
 
         OutputLine(isList ? "%s -> event:%s address:%s origin:%s" : "| %20s | %-12s | %-39s | %-6s |", ageString,
-                   kEventStrings[info->mEvent], addressString,
+                   Stringify(info->mEvent, kEventStrings), addressString,
                    Interpreter::AddressOriginToString(info->mAddressOrigin));
     }
 
@@ -327,31 +328,19 @@ otError History::ProcessTx(Arg aArgs[])
 
 const char *History::MessagePriorityToString(uint8_t aPriority)
 {
-    const char *str = "unkn";
+    static const char *const kPriorityStrings[] = {
+        "low",  // (0) OT_HISTORY_TRACKER_MSG_PRIORITY_LOW
+        "norm", // (1) OT_HISTORY_TRACKER_MSG_PRIORITY_NORMAL
+        "high", // (2) OT_HISTORY_TRACKER_MSG_PRIORITY_HIGH
+        "net",  // (3) OT_HISTORY_TRACKER_MSG_PRIORITY_NET
+    };
 
-    switch (aPriority)
-    {
-    case OT_HISTORY_TRACKER_MSG_PRIORITY_LOW:
-        str = "low";
-        break;
+    static_assert(0 == OT_HISTORY_TRACKER_MSG_PRIORITY_LOW, "MSG_PRIORITY_LOW value is incorrect");
+    static_assert(1 == OT_HISTORY_TRACKER_MSG_PRIORITY_NORMAL, "MSG_PRIORITY_NORMAL value is incorrect");
+    static_assert(2 == OT_HISTORY_TRACKER_MSG_PRIORITY_HIGH, "MSG_PRIORITY_HIGH value is incorrect");
+    static_assert(3 == OT_HISTORY_TRACKER_MSG_PRIORITY_NET, "MSG_PRIORITY_NET value is incorrect");
 
-    case OT_HISTORY_TRACKER_MSG_PRIORITY_NORMAL:
-        str = "norm";
-        break;
-
-    case OT_HISTORY_TRACKER_MSG_PRIORITY_HIGH:
-        str = "high";
-        break;
-
-    case OT_HISTORY_TRACKER_MSG_PRIORITY_NET:
-        str = "net";
-        break;
-
-    default:
-        break;
-    }
-
-    return str;
+    return Stringify(aPriority, kPriorityStrings, "unkn");
 }
 
 const char *History::RadioTypeToString(const otHistoryTrackerMessageInfo &aInfo)

--- a/src/cli/cli_output.cpp
+++ b/src/cli/cli_output.cpp
@@ -47,6 +47,8 @@
 namespace ot {
 namespace Cli {
 
+const char OutputBase::kUnknownString[] = "unknown";
+
 Output::Output(otInstance *aInstance, otCliOutputCallback aCallback, void *aCallbackContext)
     : mInstance(aInstance)
     , mCallback(aCallback)

--- a/src/cli/cli_output.hpp
+++ b/src/cli/cli_output.hpp
@@ -47,10 +47,45 @@ namespace ot {
 namespace Cli {
 
 /**
+ * This class is the base class for `Output` and `OutputWrapper` providing common helper methods.
+ *
+ */
+class OutputBase
+{
+public:
+    static const char kUnknownString[]; // Constant string "unknown".
+
+    /**
+     * This template static method converts an enumeration value to a string using a table array.
+     *
+     * @tparam EnumType       The `enum` type.
+     * @tparam kLength        The table array length (number of entries in the array).
+     *
+     * @param[in] aEnum       The enumeration value to convert (MUST be of `EnumType`).
+     * @param[in] aTable      A reference to the array of strings of length @p kLength. `aTable[e]` is the string
+     *                        representation of enumeration value `e`.
+     * @param[in] aNotFound   The string to return if the @p aEnum is not in the @p aTable.
+     *
+     * @returns The string representation of @p aEnum from @p aTable, or @p aNotFound if it is not in the table.
+     *
+     */
+    template <typename EnumType, uint16_t kLength>
+    static const char *Stringify(EnumType aEnum,
+                                 const char *const (&aTable)[kLength],
+                                 const char *aNotFound = kUnknownString)
+    {
+        return (static_cast<uint16_t>(aEnum) < kLength) ? aTable[static_cast<uint16_t>(aEnum)] : aNotFound;
+    }
+
+protected:
+    OutputBase(void) = default;
+};
+
+/**
  * This class provides CLI output helper methods.
  *
  */
-class Output
+class Output : public OutputBase
 {
 public:
     /**
@@ -337,7 +372,7 @@ private:
 #endif
 };
 
-class OutputWrapper
+class OutputWrapper : public OutputBase
 {
 protected:
     explicit OutputWrapper(Output &aOutput)

--- a/src/cli/cli_srp_server.cpp
+++ b/src/cli/cli_srp_server.cpp
@@ -114,23 +114,19 @@ otError SrpServer::ProcessDomain(Arg aArgs[])
 
 otError SrpServer::ProcessState(Arg aArgs[])
 {
+    static const char *const kStateStrings[] = {
+        "disabled", // (0) OT_SRP_SERVER_STATE_DISABLED
+        "running",  // (1) OT_SRP_SERVER_STATE_RUNNING
+        "stopped",  // (2) OT_SRP_SERVER_STATE_STOPPED
+    };
+
     OT_UNUSED_VARIABLE(aArgs);
 
-    switch (otSrpServerGetState(GetInstancePtr()))
-    {
-    case OT_SRP_SERVER_STATE_DISABLED:
-        OutputLine("disabled");
-        break;
-    case OT_SRP_SERVER_STATE_RUNNING:
-        OutputLine("running");
-        break;
-    case OT_SRP_SERVER_STATE_STOPPED:
-        OutputLine("stopped");
-        break;
-    default:
-        OutputLine("invalid state");
-        break;
-    }
+    static_assert(0 == OT_SRP_SERVER_STATE_DISABLED, "OT_SRP_SERVER_STATE_DISABLED value is incorrect");
+    static_assert(1 == OT_SRP_SERVER_STATE_RUNNING, "OT_SRP_SERVER_STATE_RUNNING value is incorrect");
+    static_assert(2 == OT_SRP_SERVER_STATE_STOPPED, "OT_SRP_SERVER_STATE_STOPPED value is incorrect");
+
+    OutputLine("%s", Stringify(otSrpServerGetState(GetInstancePtr()), kStateStrings));
 
     return OT_ERROR_NONE;
 }
@@ -216,7 +212,7 @@ otError SrpServer::ProcessHost(Arg aArgs[])
             }
         }
 
-        OutputFormat("]\r\n");
+        OutputLine("]");
     }
 
 exit:

--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -448,26 +448,23 @@ void TcpExample::HandleTcpReceiveAvailable(otTcpEndpoint *aEndpoint,
 
 void TcpExample::HandleTcpDisconnected(otTcpEndpoint *aEndpoint, otTcpDisconnectedReason aReason)
 {
+    static const char *const kReasonStrings[] = {
+        "Disconnected",            // (0) OT_TCP_DISCONNECTED_REASON_NORMAL
+        "Entered TIME-WAIT state", // (1) OT_TCP_DISCONNECTED_REASON_REFUSED
+        "Connection timed out",    // (2) OT_TCP_DISCONNECTED_REASON_RESET
+        "Connection refused",      // (3) OT_TCP_DISCONNECTED_REASON_TIME_WAIT
+        "Connection reset",        // (4) OT_TCP_DISCONNECTED_REASON_TIMED_OUT
+    };
+
     OT_UNUSED_VARIABLE(aEndpoint);
 
-    switch (aReason)
-    {
-    case OT_TCP_DISCONNECTED_REASON_NORMAL:
-        OutputLine("TCP: Disconnected");
-        break;
-    case OT_TCP_DISCONNECTED_REASON_TIME_WAIT:
-        OutputLine("TCP: Entered TIME-WAIT state");
-        break;
-    case OT_TCP_DISCONNECTED_REASON_TIMED_OUT:
-        OutputLine("TCP: Connection timed out");
-        break;
-    case OT_TCP_DISCONNECTED_REASON_REFUSED:
-        OutputLine("TCP: Connection refused");
-        break;
-    case OT_TCP_DISCONNECTED_REASON_RESET:
-        OutputLine("TCP: Connection reset");
-        break;
-    }
+    static_assert(0 == OT_TCP_DISCONNECTED_REASON_NORMAL, "OT_TCP_DISCONNECTED_REASON_NORMAL value is incorrect");
+    static_assert(1 == OT_TCP_DISCONNECTED_REASON_REFUSED, "OT_TCP_DISCONNECTED_REASON_REFUSED value is incorrect");
+    static_assert(2 == OT_TCP_DISCONNECTED_REASON_RESET, "OT_TCP_DISCONNECTED_REASON_RESET value is incorrect");
+    static_assert(3 == OT_TCP_DISCONNECTED_REASON_TIME_WAIT, "OT_TCP_DISCONNECTED_REASON_TIME_WAIT value is incorrect");
+    static_assert(4 == OT_TCP_DISCONNECTED_REASON_TIMED_OUT, "OT_TCP_DISCONNECTED_REASON_TIMED_OUT value is incorrect");
+
+    OutputLine("TCP: %s", Stringify(aReason, kReasonStrings));
 
     // We set this to false even for the TIME-WAIT state, so that we can reuse
     // the active socket if an incoming connection comes in instead of waiting

--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -82,6 +82,7 @@ exit:
 }
 
 #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_BBR == 1)
+
 void Leader::LogBackboneRouterPrimary(State aState, const BackboneRouterConfig &aConfig) const
 {
     OT_UNUSED_VARIABLE(aConfig);
@@ -102,71 +103,45 @@ void Leader::LogDomainPrefix(DomainPrefixState aState, const Ip6::Prefix &aPrefi
 
 const char *Leader::StateToString(State aState)
 {
-    const char *logString = "Unknown";
+    static const char *const kStateStrings[] = {
+        "None",            //  (0) kStateNone
+        "Added",           //  (1) kStateAdded
+        "Removed",         //  (2) kStateRemoved
+        "Rereg triggered", //  (3) kStateToTriggerRereg
+        "Refreshed",       //  (4) kStateRefreshed
+        "Unchanged",       //  (5) kStateUnchanged
+    };
 
-    switch (aState)
-    {
-    case kStateNone:
-        logString = "None";
-        break;
+    static_assert(0 == kStateNone, "kStateNone value is incorrect");
+    static_assert(1 == kStateAdded, "kStateAdded value is incorrect");
+    static_assert(2 == kStateRemoved, "kStateRemoved value is incorrect");
+    static_assert(3 == kStateToTriggerRereg, "kStateToTriggerRereg value is incorrect");
+    static_assert(4 == kStateRefreshed, "kStateRefreshed value is incorrect");
+    static_assert(5 == kStateUnchanged, "kStateUnchanged value is incorrect");
 
-    case kStateAdded:
-        logString = "Added";
-        break;
-
-    case kStateRemoved:
-        logString = "Removed";
-        break;
-
-    case kStateToTriggerRereg:
-        logString = "Rereg triggered";
-        break;
-
-    case kStateRefreshed:
-        logString = "Refreshed";
-        break;
-
-    case kStateUnchanged:
-        logString = "Unchanged";
-        break;
-
-    default:
-        break;
-    }
-
-    return logString;
+    return kStateStrings[aState];
 }
 
 const char *Leader::DomainPrefixStateToString(DomainPrefixState aState)
 {
-    const char *logString = "Unknown";
+    static const char *const kPrefixStateStrings[] = {
+        "None",      // (0) kDomainPrefixNone
+        "Added",     // (1) kDomainPrefixAdded
+        "Removed",   // (2) kDomainPrefixRemoved
+        "Refreshed", // (3) kDomainPrefixRefreshed
+        "Unchanged", // (4) kDomainPrefixUnchanged
+    };
 
-    switch (aState)
-    {
-    case kDomainPrefixNone:
-        logString = "None";
-        break;
+    static_assert(0 == kDomainPrefixNone, "kDomainPrefixNone value is incorrect");
+    static_assert(1 == kDomainPrefixAdded, "kDomainPrefixAdded value is incorrect");
+    static_assert(2 == kDomainPrefixRemoved, "kDomainPrefixRemoved value is incorrect");
+    static_assert(3 == kDomainPrefixRefreshed, "kDomainPrefixRefreshed value is incorrect");
+    static_assert(4 == kDomainPrefixUnchanged, "kDomainPrefixUnchanged value is incorrect");
 
-    case kDomainPrefixAdded:
-        logString = "Added";
-        break;
-
-    case kDomainPrefixRemoved:
-        logString = "Removed";
-        break;
-
-    case kDomainPrefixRefreshed:
-        logString = "Refreshed";
-        break;
-
-    case kDomainPrefixUnchanged:
-        logString = "Unchanged";
-        break;
-    }
-
-    return logString;
+    return kPrefixStateStrings[aState];
 }
-#endif
+
+#endif // (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && (OPENTHREAD_CONFIG_LOG_BBR == 1)
 
 void Leader::Update(void)
 {

--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -449,14 +449,19 @@ void Link::SetState(State aState)
 
 const char *Link::StateToString(State aState)
 {
-    static const char *kStateStrings[] = {
-        "Disabled", // kStateDisabled
-        "Sleep",    // kStateSleep
-        "Receive",  // kStateReceive
-        "Transmit", // kStateTransmit
+    static const char *const kStateStrings[] = {
+        "Disabled", // (0) kStateDisabled
+        "Sleep",    // (1) kStateSleep
+        "Receive",  // (2) kStateReceive
+        "Transmit", // (3) kStateTransmit
     };
 
-    return (static_cast<uint8_t>(aState) < OT_ARRAY_LENGTH(kStateStrings)) ? kStateStrings[aState] : "Unknown";
+    static_assert(0 == kStateDisabled, "kStateDisabled value is incorrect");
+    static_assert(1 == kStateSleep, "kStateSleep value is incorrect");
+    static_assert(2 == kStateReceive, "kStateReceive value is incorrect");
+    static_assert(3 == kStateTransmit, "kStateTransmit value is incorrect");
+
+    return kStateStrings[aState];
 }
 
 // LCOV_EXCL_STOP

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -989,52 +989,39 @@ void AddressResolver::LogCacheEntryChange(EntryChange       aChange,
                                           const CacheEntry &aEntry,
                                           CacheEntryList *  aList)
 {
-    const char *change = "";
-    const char *reason = "";
+    static const char *const kChangeStrings[] = {
+        "added",   // (0) kEntryAdded
+        "updated", // (1) kEntryUpdated
+        "removed", // (2) kEntryRemoved
+    };
 
-    switch (aChange)
-    {
-    case kEntryAdded:
-        change = "added";
-        break;
-    case kEntryUpdated:
-        change = "updated";
-        break;
-    case kEntryRemoved:
-        change = "removed";
-        break;
-    }
+    static const char *const kReasonStrings[] = {
+        "query request",          // (0) kReasonQueryRequest
+        "snoop",                  // (1) kReasonSnoop
+        "rx notification",        // (2) kReasonReceivedNotification
+        "removing router id",     // (3) kReasonRemovingRouterId
+        "removing rloc16",        // (4) kReasonRemovingRloc16
+        "rx icmp no route",       // (5) kReasonReceivedIcmpDstUnreachNoRoute
+        "evicting for new entry", // (6) kReasonEvictingForNewEntry
+        "removing eid",           // (7) kReasonRemovingEid
+    };
 
-    switch (aReason)
-    {
-    case kReasonQueryRequest:
-        reason = "query request";
-        break;
-    case kReasonSnoop:
-        reason = "snoop";
-        break;
-    case kReasonReceivedNotification:
-        reason = "rx notification";
-        break;
-    case kReasonRemovingRouterId:
-        reason = "removing router id";
-        break;
-    case kReasonRemovingRloc16:
-        reason = "removing rloc16";
-        break;
-    case kReasonReceivedIcmpDstUnreachNoRoute:
-        reason = "rx icmp no route";
-        break;
-    case kReasonEvictingForNewEntry:
-        reason = "evicting for new entry";
-        break;
-    case kReasonRemovingEid:
-        reason = "removing eid";
-        break;
-    }
+    static_assert(0 == kEntryAdded, "kEntryAdded value is incorrect");
+    static_assert(1 == kEntryUpdated, "kEntryUpdated value is incorrect");
+    static_assert(2 == kEntryRemoved, "kEntryRemoved value is incorrect");
 
-    otLogNoteArp("Cache entry %s: %s, 0x%04x%s%s - %s", change, aEntry.GetTarget().ToString().AsCString(),
-                 aEntry.GetRloc16(), (aList == nullptr) ? "" : ", list:", ListToString(aList), reason);
+    static_assert(0 == kReasonQueryRequest, "kReasonQueryRequest value is incorrect");
+    static_assert(1 == kReasonSnoop, "kReasonSnoop value is incorrect");
+    static_assert(2 == kReasonReceivedNotification, "kReasonReceivedNotification value is incorrect");
+    static_assert(3 == kReasonRemovingRouterId, "kReasonRemovingRouterId value is incorrect");
+    static_assert(4 == kReasonRemovingRloc16, "kReasonRemovingRloc16 value is incorrect");
+    static_assert(5 == kReasonReceivedIcmpDstUnreachNoRoute, "kReasonReceivedIcmpDstUnreachNoRoute value is incorrect");
+    static_assert(6 == kReasonEvictingForNewEntry, "kReasonEvictingForNewEntry value is incorrect");
+    static_assert(7 == kReasonRemovingEid, "kReasonRemovingEid value is incorrect");
+
+    otLogNoteArp("Cache entry %s: %s, 0x%04x%s%s - %s", kChangeStrings[aChange],
+                 aEntry.GetTarget().ToString().AsCString(), aEntry.GetRloc16(),
+                 (aList == nullptr) ? "" : ", list:", ListToString(aList), kReasonStrings[aReason]);
 }
 
 const char *AddressResolver::ListToString(const CacheEntryList *aList) const

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -199,18 +199,27 @@ void Neighbor::RemoveAllForwardTrackingSeriesInfo(void)
 
 const char *Neighbor::StateToString(State aState)
 {
-    static const char *kStateStrings[] = {
-        "Invalid",        // kStateInvalid
-        "Restored",       // kStateRestored
-        "ParentReq",      // kStateParentRequest
-        "ParentRes",      // kStateParentResponse
-        "ChildIdReq",     // kStateChildIdRequest
-        "LinkReq",        // kStateLinkRequest
-        "ChildUpdateReq", // kStateChildUpdateRequest
-        "Valid",          // kStateValid
+    static const char *const kStateStrings[] = {
+        "Invalid",        // (0) kStateInvalid
+        "Restored",       // (1) kStateRestored
+        "ParentReq",      // (2) kStateParentRequest
+        "ParentRes",      // (3) kStateParentResponse
+        "ChildIdReq",     // (4) kStateChildIdRequest
+        "LinkReq",        // (5) kStateLinkRequest
+        "ChildUpdateReq", // (6) kStateChildUpdateRequest
+        "Valid",          // (7) kStateValid
     };
 
-    return static_cast<uint8_t>(aState) < OT_ARRAY_LENGTH(kStateStrings) ? kStateStrings[aState] : "Unknown";
+    static_assert(0 == kStateInvalid, "kStateInvalid value is incorrect");
+    static_assert(1 == kStateRestored, "kStateRestored value is incorrect");
+    static_assert(2 == kStateParentRequest, "kStateParentRequest value is incorrect");
+    static_assert(3 == kStateParentResponse, "kStateParentResponse value is incorrect");
+    static_assert(4 == kStateChildIdRequest, "kStateChildIdRequest value is incorrect");
+    static_assert(5 == kStateLinkRequest, "kStateLinkRequest value is incorrect");
+    static_assert(6 == kStateChildUpdateRequest, "kStateChildUpdateRequest value is incorrect");
+    static_assert(7 == kStateValid, "kStateValid value is incorrect");
+
+    return kStateStrings[aState];
 }
 
 #if OPENTHREAD_FTD


### PR DESCRIPTION
This commit updates different modules in OT core and CLI to use
`const` array lookup to convert an enumeration value to string.