### PR TITLE
[bbr] add `bbr skipseqnuminc` command for reference device

### DIFF
--- a/include/openthread/backbone_router_ftd.h
+++ b/include/openthread/backbone_router_ftd.h
@@ -273,6 +273,19 @@ void otBackboneRouterMulticastListenerClear(otInstance *aInstance);
  */
 otError otBackboneRouterMulticastListenerAdd(otInstance *aInstance, const otIp6Address *aAddress, uint32_t aTimeout);
 
+/**
+ * This method configures the ability to increase or not the BBR Dataset Sequence Number when a
+ * BBR recovers its BBR Dataset from the Leader's Network Data.
+ *
+ * Note: available only when `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is enabled.
+ *       Only used for certification.
+ *
+ * @param[in] aInstance  A pointer to an OpenThread instance.
+ * @param[in] aSkip      Whether to skip the increase of Sequence Number or not.
+ *
+ */
+void otBackboneRouterConfigSkipSeqNumIncrease(otInstance *aInstance, bool aSkip);
+
 #define OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ITERATOR_INIT \
     0 ///< Initializer for otBackboneRouterMulticastListenerIterator
 

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (182)
+#define OPENTHREAD_API_VERSION (183)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -324,14 +324,14 @@ Set jitter (in seconds) for Backbone Router registration for Thread 1.2 FTD.
 Done
 ```
 
-### bbr skipseqnoinc
+### bbr skipseqnuminc
 
 Skip increase of Sequence Number when updating the local BBR Dataset from the Network Data.
 
 Only for testing/reference device.
 
 ```bash
-> bbr skipseqnoinc
+> bbr skipseqnuminc
 Done
 ```
 

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -324,6 +324,17 @@ Set jitter (in seconds) for Backbone Router registration for Thread 1.2 FTD.
 Done
 ```
 
+### bbr skipseqnoinc
+
+Skip increase of Sequence Number when updating the local BBR Dataset from the Network Data.
+
+Only for testing/reference device.
+
+```bash
+> bbr skipseqnoinc
+Done
+```
+
 ### ba
 
 Show current Border Agent information.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -564,7 +564,13 @@ otError Interpreter::ProcessBackboneRouter(Arg aArgs[])
             }
 #endif
         }
-
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+        else if (aArgs[0] == "skipseqnoinc")
+        {
+            otBackboneRouterConfigSkipSeqNumIncrease(GetInstancePtr(), true);
+            ExitNow();
+        }
+#endif
         SuccessOrExit(error = ProcessBackboneRouterLocal(aArgs));
     }
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -565,7 +565,7 @@ otError Interpreter::ProcessBackboneRouter(Arg aArgs[])
 #endif
         }
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-        else if (aArgs[0] == "skipseqnoinc")
+        else if (aArgs[0] == "skipseqnuminc")
         {
             otBackboneRouterConfigSkipSeqNumIncrease(GetInstancePtr(), true);
             ExitNow();

--- a/src/core/api/backbone_router_ftd_api.cpp
+++ b/src/core/api/backbone_router_ftd_api.cpp
@@ -176,6 +176,12 @@ otError otBackboneRouterMulticastListenerAdd(otInstance *aInstance, const otIp6A
                                                                                     TimerMilli::GetNow() + aTimeout);
 }
 #endif // OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
+
+void otBackboneRouterConfigSkipSeqNumIncrease(otInstance *aInstance, bool aSkip)
+{
+    AsCoreType(aInstance).Get<BackboneRouter::Local>().ConfigSkipSeqNumIncrease(aSkip);
+}
+
 #endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -267,7 +267,12 @@ void Local::HandleBackboneRouterPrimaryUpdate(Leader::State aState, const Backbo
     {
         // Here original PBBR restores its Backbone Router Service from Thread Network,
         // Intentionally skips the state update as PBBR will refresh its service.
-        mSequenceNumber      = aConfig.mSequenceNumber + 1;
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+        // BBR-TC-02 forces Sequence Number for the reference device with raw UDP API
+        mSequenceNumber = aConfig.mSequenceNumber;
+#else
+        mSequenceNumber = aConfig.mSequenceNumber + 1;
+#endif
         mReregistrationDelay = aConfig.mReregistrationDelay;
         mMlrTimeout          = aConfig.mMlrTimeout;
         Get<Notifier>().Signal(kEventThreadBackboneRouterLocalChanged);

--- a/src/core/backbone_router/bbr_local.hpp
+++ b/src/core/backbone_router/bbr_local.hpp
@@ -254,6 +254,20 @@ public:
      */
     void SetDomainPrefixCallback(otBackboneRouterDomainPrefixCallback aCallback, void *aContext);
 
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    /**
+     * This method configures the ability to increase or not the BBR Dataset Sequence Number when a
+     * BBR recovers its BBR Dataset from the Leader's Network Data.
+     *
+     * Note: available only when `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is enabled.
+     *       Only used for certification.
+     *
+     * @param[in] aSkip  Whether to skip the increase of Sequence Number or not.
+     *
+     */
+    void ConfigSkipSeqNumIncrease(bool aSkip);
+#endif
+
 private:
     void SetState(BackboneRouterState aState);
     void RemoveService(void);
@@ -285,6 +299,10 @@ private:
     Ip6::Address                         mAllDomainBackboneRouters;
     otBackboneRouterDomainPrefixCallback mDomainPrefixCallback;
     void *                               mDomainPrefixCallbackContext;
+
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    bool mSkipSeqNumIncrease : 1;
+#endif
 };
 
 } // namespace BackboneRouter

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -559,11 +559,8 @@ class OpenThreadTHCI(object):
             False: fail to set the behavior.
         """
         print('call __skipSeqNoIncrease()')
-        try:
-            cmd = 'bbr skipseqnoinc'
-            return self.__executeCommand(cmd)[-1] == 'Done'
-        except Exception as e:
-            ModuleHelper.WriteIntoDebugLogger('__setAddressFilterMode() Error: ' + str(e))
+        cmd = 'bbr skipseqnoinc'
+        return self.__executeCommand(cmd)[-1] == 'Done'
 
     def __startOpenThread(self):
         """start OpenThread stack

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -559,7 +559,7 @@ class OpenThreadTHCI(object):
             False: fail to set the behavior.
         """
         print('call __skipSeqNoIncrease()')
-        cmd = 'bbr skipseqnoinc'
+        cmd = 'bbr skipseqnuminc'
         return self.__executeCommand(cmd)[-1] == 'Done'
 
     def __startOpenThread(self):

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -551,6 +551,20 @@ class OpenThreadTHCI(object):
         except Exception as e:
             ModuleHelper.WriteIntoDebugLogger('__setAddressFilterMode() Error: ' + str(e))
 
+    def __skipSeqNoIncrease(self):
+        """skip sequence number increase when recovering BBR Dataset from Network Data
+
+        Returns:
+            True: successful to set the behavior.
+            False: fail to set the behavior.
+        """
+        print('call __skipSeqNoIncrease()')
+        try:
+            cmd = 'bbr skipseqnoinc'
+            return self.__executeCommand(cmd)[-1] == 'Done'
+        except Exception as e:
+            ModuleHelper.WriteIntoDebugLogger('__setAddressFilterMode() Error: ' + str(e))
+
     def __startOpenThread(self):
         """start OpenThread stack
 
@@ -1231,6 +1245,8 @@ class OpenThreadTHCI(object):
                 if self.AutoDUTEnable is False:
                     # set ROUTER_DOWNGRADE_THRESHOLD
                     self.__setRouterDowngradeThreshold(33)
+                    # skip increase of Sequence Number for BBR-TC-02
+                    self.__skipSeqNoIncrease()
             elif eRoleId == Thread_Device_Role.SED:
                 print('join as sleepy end device')
                 mode = '-'


### PR DESCRIPTION
When building a reference device do not increase the BBR Dataset Sequence Number when restoring from the received Network Data.
The Thread Harness uses the THCI send_udp to publish convenient BBR dataset on behalf of the reference device.