### PR TITLE
[posix] enable all ICMPv6 echo handling for reference device

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -1651,7 +1651,11 @@ void platformNetifSetUp(void)
     OT_ASSERT(gInstance != nullptr);
 
     otIp6SetReceiveFilterEnabled(gInstance, true);
+#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    otIcmp6SetEchoMode(gInstance, OT_ICMP6_ECHO_HANDLER_ALL);
+#else
     otIcmp6SetEchoMode(gInstance, OT_ICMP6_ECHO_HANDLER_DISABLED);
+#endif
     otIp6SetReceiveCallback(gInstance, processReceive, gInstance);
     otIp6SetAddressCallback(gInstance, processAddressChange, gInstance);
 #if OPENTHREAD_POSIX_MULTICAST_PROMISCUOUS_REQUIRED


### PR DESCRIPTION
Set `OT_ICMP6_ECHO_HANDLER_ALL` when building reference device Posix border router.