### PR TITLE
[diag] only do re-tx for diag sending

### DIFF
--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -160,6 +160,7 @@ Diags::Diags(Instance &aInstance)
     , mTxPower(0)
     , mTxLen(0)
     , mRepeatActive(false)
+    , mDiagSendOn(false)
 {
     mStats.Clear();
 }
@@ -378,6 +379,7 @@ void Diags::TransmitPacket(void)
         mTxPacket->mPsdu[i] = i;
     }
 
+    mDiagSendOn = true;
     IgnoreError(Get<Radio>().Transmit(*static_cast<Mac::TxFrame *>(mTxPacket)));
 }
 
@@ -480,6 +482,9 @@ void Diags::ReceiveDone(otRadioFrame *aFrame, Error aError)
 
 void Diags::TransmitDone(Error aError)
 {
+    VerifyOrExit(mDiagSendOn);
+    mDiagSendOn = false;
+
     if (aError == kErrorNone)
     {
         mStats.mSentPackets++;

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -169,6 +169,7 @@ private:
     int8_t        mTxPower;
     uint8_t       mTxLen;
     bool          mRepeatActive;
+    bool          mDiagSendOn;
 #endif
 };
 


### PR DESCRIPTION
Some platform diag commands (those not in factory_diags module) will
also do repeat sending and the same callback (Diags::TransmitDone)
will be called. However, in those cases, `mRepeatActive` won't be set.
And if some error (like 'CHANNEL_ACCESS_FAILURE') happened,
`TransmitPacket` will be called then, which makes the channel even
more busy, causing more 'CHANNEL_ACCESS_FAILURE', and so on. This PR
ensures that `TransmitPacket` will only be called again when using
`diag send`.