### PR TITLE
[docs] fix the link to route command in CLI doc

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -95,7 +95,7 @@ Done
 - [releaserouterid](#releaserouterid-routerid)
 - [reset](#reset)
 - [rloc16](#rloc16)
-- [route](#route-add-prefix-s-prf)
+- [route](#route)
 - [router](#router-list)
 - [routerdowngradethreshold](#routerdowngradethreshold)
 - [routereligible](#routereligible)


### PR DESCRIPTION
The link was previously broken and was not pointing at the first `route` command.