### PR TITLE
[csl] fix the CSL RX window when not using RX AT mode (#7284)

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -1090,10 +1090,9 @@ void SubMac::HandleCslTimer(void)
         break;
 
     case kCslSleep:
-        mCslSampleTime += periodUs;
-
         if (RadioSupportsReceiveTiming())
         {
+            mCslSampleTime += periodUs;
             mCslTimer.FireAt(mCslSampleTime - timeAhead);
             timeAhead -= kCslReceiveTimeAhead;
         }
@@ -1101,6 +1100,7 @@ void SubMac::HandleCslTimer(void)
         {
             mCslTimer.FireAt(mCslSampleTime + timeAfter);
             mCslState = kCslSample;
+            mCslSampleTime += periodUs;
         }
 
         Get<Radio>().UpdateCslSampleTime(mCslSampleTime.GetValue());


### PR DESCRIPTION
The RX window when not using RX AT mode is much larger than the correct time and
what is reported by the Open Thread log.

In the case of "receive at" we want the timer to fire before the next RX window to program the
exact RX activity in the radio and in the other case, the timer will fire when the current RX
window will end to close the receiver and go to sleep.

This commit fixes the issue by increasing the sample time with the CSL period before starting the
timer in the case of RX AT and after in the normal RX case.