### PR TITLE
[posix] add a method to get the infra interface name

### DIFF
--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -179,7 +179,7 @@ unsigned int otSysGetThreadNetifIndex(void);
 /**
  * This method returns the infrastructure network interface name.
  *
- * @returns The infrastructure network interface name.
+ * @returns The infrastructure network interface name, or `nullptr` if not specified.
  *
  */
 const char *otSysGetInfraNetifName(void);

--- a/src/posix/platform/include/openthread/openthread-system.h
+++ b/src/posix/platform/include/openthread/openthread-system.h
@@ -176,6 +176,14 @@ const char *otSysGetThreadNetifName(void);
  */
 unsigned int otSysGetThreadNetifIndex(void);
 
+/**
+ * This method returns the infrastructure network interface name.
+ *
+ * @returns The infrastructure network interface name.
+ *
+ */
+const char *otSysGetInfraNetifName(void);
+
 #ifdef __cplusplus
 } // end of extern "C"
 #endif

--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -101,6 +101,11 @@ bool platformInfraIfIsRunning(void)
     return ot::Posix::InfraNetif::Get().IsRunning();
 }
 
+const char *otSysGetInfraNetifName(void)
+{
+    return ot::Posix::InfraNetif::Get().GetNetifName();
+}
+
 namespace ot {
 namespace Posix {
 namespace {

--- a/src/posix/platform/infra_if.hpp
+++ b/src/posix/platform/infra_if.hpp
@@ -132,7 +132,8 @@ public:
     /**
      * This method gets the infrastructure network interface name.
      *
-     * @returns The infrastructure network interface name.
+     * @returns The infrastructure network interface name, or `nullptr` if not specified.
+     *
      */
     const char *GetNetifName(void) const { return (mInfraIfIndex != 0) ? mInfraIfName : nullptr; }
 
@@ -140,6 +141,7 @@ public:
      * This function gets the infrastructure network interface singleton.
      *
      * @returns The singleton object.
+     *
      */
     static InfraNetif &Get(void);
 

--- a/src/posix/platform/infra_if.hpp
+++ b/src/posix/platform/infra_if.hpp
@@ -128,6 +128,14 @@ public:
                         const otIp6Address &aDestAddress,
                         const uint8_t *     aBuffer,
                         uint16_t            aBufferLength);
+
+    /**
+     * This method gets the infrastructure network interface name.
+     *
+     * @returns The infrastructure network interface name.
+     */
+    const char *GetNetifName(void) const { return (mInfraIfIndex != 0) ? mInfraIfName : nullptr; }
+
     /**
      * This function gets the infrastructure network interface singleton.
      *


### PR DESCRIPTION
When setting the IP forwarding rule on Android platform, it needs to
specify the two interfaces between which IP forwarding is enabled.

This PR adds a method to get the infra interface name for setting IP
forwarding rule.