### PR TITLE
[github-actions] set MAX_JOBS=3 for `Border Router` tests

### DIFF
--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -125,6 +125,7 @@ jobs:
       PYTHONUNBUFFERED: 1
       VERBOSE: 1
       BORDER_ROUTING: 1
+      MAX_JOBS: 3
     steps:
     - uses: actions/checkout@v2
     - name: Build OTBR Docker


### PR DESCRIPTION
This commit sets `MAX_JOBS` to 3 for Border Router tests (using OTBR Docker) to improve reliability.

The original `MAX_JOBS` value is 10. 

Related metrics:
- Border Router tests takes 12 minutes with MAX_JOBS=10
- Border Router tests takes 24 minutes with MAX_JOBS=3