### PR TITLE
[cli] smaller style changes

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -241,19 +241,16 @@ otError Interpreter::ProcessVersion(Arg aArgs[])
     if (aArgs[0].IsEmpty())
     {
         OutputLine("%s", otGetVersionString());
-        ExitNow();
     }
-
-    if (aArgs[0] == "api")
+    else if (aArgs[0] == "api")
     {
         OutputLine("%d", OPENTHREAD_API_VERSION);
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_COMMAND);
+        error = OT_ERROR_INVALID_COMMAND;
     }
 
-exit:
     return error;
 }
 
@@ -466,13 +463,12 @@ otError Interpreter::ProcessBorderAgent(Arg aArgs[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_COMMAND);
+        error = OT_ERROR_INVALID_COMMAND;
     }
 
-exit:
     return error;
 }
-#endif
+#endif // OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 otError Interpreter::ProcessBorderRouting(Arg aArgs[])
@@ -500,13 +496,13 @@ otError Interpreter::ProcessBorderRouting(Arg aArgs[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_COMMAND);
+        error = OT_ERROR_INVALID_COMMAND;
     }
 
 exit:
     return error;
 }
-#endif
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
 otError Interpreter::ProcessBackboneRouter(Arg aArgs[])
@@ -568,6 +564,7 @@ otError Interpreter::ProcessBackboneRouter(Arg aArgs[])
             }
 #endif
         }
+
         SuccessOrExit(error = ProcessBackboneRouterLocal(aArgs));
     }
 
@@ -1247,7 +1244,7 @@ otError Interpreter::ProcessCoexMetrics(Arg aArgs[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_ARGS);
+        error = OT_ERROR_INVALID_ARGS;
     }
 
 exit:
@@ -1339,7 +1336,7 @@ otError Interpreter::ProcessCounters(Arg aArgs[])
         }
         else
         {
-            ExitNow(error = OT_ERROR_INVALID_ARGS);
+            error = OT_ERROR_INVALID_ARGS;
         }
     }
     else if (aArgs[0] == "mle")
@@ -1377,7 +1374,7 @@ otError Interpreter::ProcessCounters(Arg aArgs[])
         }
         else
         {
-            ExitNow(error = OT_ERROR_INVALID_ARGS);
+            error = OT_ERROR_INVALID_ARGS;
         }
     }
     else if (aArgs[0] == "ip")
@@ -1410,15 +1407,14 @@ otError Interpreter::ProcessCounters(Arg aArgs[])
         }
         else
         {
-            ExitNow(error = OT_ERROR_INVALID_ARGS);
+            error = OT_ERROR_INVALID_ARGS;
         }
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_ARGS);
+        error = OT_ERROR_INVALID_ARGS;
     }
 
-exit:
     return error;
 }
 
@@ -1426,7 +1422,6 @@ exit:
 otError Interpreter::ProcessCsl(Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
-    ;
 
     if (aArgs[0].IsEmpty())
     {
@@ -1473,7 +1468,7 @@ otError Interpreter::ProcessDelayTimerMin(Arg aArgs[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_ARGS);
+        error = OT_ERROR_INVALID_ARGS;
     }
 
 exit:
@@ -2083,42 +2078,40 @@ otError Interpreter::ProcessIpAddr(Arg aArgs[])
         for (const otNetifAddress *addr = unicastAddrs; addr; addr = addr->mNext)
         {
             OutputIp6Address(addr->mAddress);
+
             if (verbose)
             {
                 OutputFormat(" origin:%s", AddressOriginToString(addr->mAddressOrigin));
             }
+
             OutputLine("");
         }
     }
+    else if (aArgs[0] == "add")
+    {
+        error = ProcessIpAddrAdd(aArgs + 1);
+    }
+    else if (aArgs[0] == "del")
+    {
+        error = ProcessIpAddrDel(aArgs + 1);
+    }
+    else if (aArgs[0] == "linklocal")
+    {
+        OutputIp6AddressLine(*otThreadGetLinkLocalIp6Address(GetInstancePtr()));
+    }
+    else if (aArgs[0] == "rloc")
+    {
+        OutputIp6AddressLine(*otThreadGetRloc(GetInstancePtr()));
+    }
+    else if (aArgs[0] == "mleid")
+    {
+        OutputIp6AddressLine(*otThreadGetMeshLocalEid(GetInstancePtr()));
+    }
     else
     {
-        if (aArgs[0] == "add")
-        {
-            SuccessOrExit(error = ProcessIpAddrAdd(aArgs + 1));
-        }
-        else if (aArgs[0] == "del")
-        {
-            SuccessOrExit(error = ProcessIpAddrDel(aArgs + 1));
-        }
-        else if (aArgs[0] == "linklocal")
-        {
-            OutputIp6AddressLine(*otThreadGetLinkLocalIp6Address(GetInstancePtr()));
-        }
-        else if (aArgs[0] == "rloc")
-        {
-            OutputIp6AddressLine(*otThreadGetRloc(GetInstancePtr()));
-        }
-        else if (aArgs[0] == "mleid")
-        {
-            OutputIp6AddressLine(*otThreadGetMeshLocalEid(GetInstancePtr()));
-        }
-        else
-        {
-            ExitNow(error = OT_ERROR_INVALID_COMMAND);
-        }
+        error = OT_ERROR_INVALID_COMMAND;
     }
 
-exit:
     return error;
 }
 
@@ -2186,35 +2179,31 @@ otError Interpreter::ProcessIpMulticastAddr(Arg aArgs[])
             OutputIp6AddressLine(addr->mAddress);
         }
     }
+    else if (aArgs[0] == "add")
+    {
+        error = ProcessIpMulticastAddrAdd(aArgs + 1);
+    }
+    else if (aArgs[0] == "del")
+    {
+        error = ProcessIpMulticastAddrDel(aArgs + 1);
+    }
+    else if (aArgs[0] == "promiscuous")
+    {
+        error = ProcessMulticastPromiscuous(aArgs + 1);
+    }
+    else if (aArgs[0] == "llatn")
+    {
+        OutputIp6AddressLine(*otThreadGetLinkLocalAllThreadNodesMulticastAddress(GetInstancePtr()));
+    }
+    else if (aArgs[0] == "rlatn")
+    {
+        OutputIp6AddressLine(*otThreadGetRealmLocalAllThreadNodesMulticastAddress(GetInstancePtr()));
+    }
     else
     {
-        if (aArgs[0] == "add")
-        {
-            SuccessOrExit(error = ProcessIpMulticastAddrAdd(aArgs + 1));
-        }
-        else if (aArgs[0] == "del")
-        {
-            SuccessOrExit(error = ProcessIpMulticastAddrDel(aArgs + 1));
-        }
-        else if (aArgs[0] == "promiscuous")
-        {
-            SuccessOrExit(error = ProcessMulticastPromiscuous(aArgs + 1));
-        }
-        else if (aArgs[0] == "llatn")
-        {
-            OutputIp6AddressLine(*otThreadGetLinkLocalAllThreadNodesMulticastAddress(GetInstancePtr()));
-        }
-        else if (aArgs[0] == "rlatn")
-        {
-            OutputIp6AddressLine(*otThreadGetRealmLocalAllThreadNodesMulticastAddress(GetInstancePtr()));
-        }
-        else
-        {
-            ExitNow(error = OT_ERROR_INVALID_COMMAND);
-        }
+        error = OT_ERROR_INVALID_COMMAND;
     }
 
-exit:
     return error;
 }
 
@@ -2659,18 +2648,15 @@ exit:
 otError Interpreter::ProcessPskc(Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;
+    otPskc  pskc;
 
     if (aArgs[0].IsEmpty())
     {
-        otPskc pskc;
-
         otThreadGetPskc(GetInstancePtr(), &pskc);
         OutputBytesLine(pskc.m8);
     }
     else
     {
-        otPskc pskc;
-
         if (aArgs[1].IsEmpty())
         {
             SuccessOrExit(error = aArgs[0].ParseAsHexString(pskc.m8));
@@ -2687,7 +2673,7 @@ otError Interpreter::ProcessPskc(Arg aArgs[])
             ExitNow(error = OT_ERROR_INVALID_ARGS);
         }
 
-        SuccessOrExit(error = otThreadSetPskc(GetInstancePtr(), &pskc));
+        error = otThreadSetPskc(GetInstancePtr(), &pskc);
     }
 
 exit:
@@ -2716,7 +2702,7 @@ otError Interpreter::ProcessPskcRef(Arg aArgs[])
             ExitNow(error = OT_ERROR_INVALID_ARGS);
         }
 
-        SuccessOrExit(error = otThreadSetPskcRef(GetInstancePtr(), pskcRef));
+        error = otThreadSetPskcRef(GetInstancePtr(), pskcRef);
     }
 
 exit:
@@ -3274,7 +3260,7 @@ otError Interpreter::ProcessRouterIdRange(Arg *aArgs)
         SuccessOrExit(error = aArgs[0].ParseAsUint8(minRouterId));
         SuccessOrExit(error = aArgs[1].ParseAsUint8(maxRouterId));
         VerifyOrExit(aArgs[2].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-        SuccessOrExit(error = otThreadSetRouterIdRange(GetInstancePtr(), minRouterId, maxRouterId));
+        error = otThreadSetRouterIdRange(GetInstancePtr(), minRouterId, maxRouterId);
     }
 
 exit:
@@ -3668,15 +3654,15 @@ otError Interpreter::ProcessPrefix(Arg aArgs[])
 
     if (aArgs[0].IsEmpty())
     {
-        SuccessOrExit(error = ProcessPrefixList());
+        error = ProcessPrefixList();
     }
     else if (aArgs[0] == "add")
     {
-        SuccessOrExit(error = ProcessPrefixAdd(aArgs + 1));
+        error = ProcessPrefixAdd(aArgs + 1);
     }
     else if (aArgs[0] == "remove")
     {
-        SuccessOrExit(error = ProcessPrefixRemove(aArgs + 1));
+        error = ProcessPrefixRemove(aArgs + 1);
     }
     else if (aArgs[0] == "meshlocal")
     {
@@ -3684,10 +3670,9 @@ otError Interpreter::ProcessPrefix(Arg aArgs[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_COMMAND);
+        error = OT_ERROR_INVALID_COMMAND;
     }
 
-exit:
     return error;
 }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
@@ -3866,22 +3851,21 @@ otError Interpreter::ProcessRoute(Arg aArgs[])
 
     if (aArgs[0].IsEmpty())
     {
-        SuccessOrExit(error = ProcessRouteList());
+        error = ProcessRouteList();
     }
     else if (aArgs[0] == "add")
     {
-        SuccessOrExit(error = ProcessRouteAdd(aArgs + 1));
+        error = ProcessRouteAdd(aArgs + 1);
     }
     else if (aArgs[0] == "remove")
     {
-        SuccessOrExit(error = ProcessRouteRemove(aArgs + 1));
+        error = ProcessRouteRemove(aArgs + 1);
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_COMMAND);
+        error = OT_ERROR_INVALID_COMMAND;
     }
 
-exit:
     return error;
 }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
@@ -4125,14 +4109,7 @@ otError Interpreter::ProcessSingleton(Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
 
-    if (otThreadIsSingleton(GetInstancePtr()))
-    {
-        OutputLine("true");
-    }
-    else
-    {
-        OutputLine("false");
-    }
+    OutputLine(otThreadIsSingleton(GetInstancePtr()) ? "true" : "false");
 
     return OT_ERROR_NONE;
 }
@@ -4251,34 +4228,29 @@ otError Interpreter::ProcessState(Arg aArgs[])
     {
         OutputLine("%s", otThreadDeviceRoleToString(otThreadGetDeviceRole(GetInstancePtr())));
     }
+    else if (aArgs[0] == "detached")
+    {
+        error = otThreadBecomeDetached(GetInstancePtr());
+    }
+    else if (aArgs[0] == "child")
+    {
+        error = otThreadBecomeChild(GetInstancePtr());
+    }
+#if OPENTHREAD_FTD
+    else if (aArgs[0] == "router")
+    {
+        error = otThreadBecomeRouter(GetInstancePtr());
+    }
+    else if (aArgs[0] == "leader")
+    {
+        error = otThreadBecomeLeader(GetInstancePtr());
+    }
+#endif
     else
     {
-        if (aArgs[0] == "detached")
-        {
-            SuccessOrExit(error = otThreadBecomeDetached(GetInstancePtr()));
-        }
-        else if (aArgs[0] == "child")
-        {
-            SuccessOrExit(error = otThreadBecomeChild(GetInstancePtr()));
-        }
-
-#if OPENTHREAD_FTD
-        else if (aArgs[0] == "router")
-        {
-            SuccessOrExit(error = otThreadBecomeRouter(GetInstancePtr()));
-        }
-        else if (aArgs[0] == "leader")
-        {
-            SuccessOrExit(error = otThreadBecomeLeader(GetInstancePtr()));
-        }
-#endif
-        else
-        {
-            ExitNow(error = OT_ERROR_INVALID_ARGS);
-        }
+        error = OT_ERROR_INVALID_ARGS;
     }
 
-exit:
     return error;
 }
 
@@ -4324,7 +4296,7 @@ otError Interpreter::ProcessTxPower(Arg aArgs[])
     else
     {
         SuccessOrExit(error = aArgs[0].ParseAsInt8(power));
-        SuccessOrExit(error = otPlatRadioSetTransmitPower(GetInstancePtr(), power));
+        error = otPlatRadioSetTransmitPower(GetInstancePtr(), power);
     }
 
 exit:
@@ -4381,10 +4353,9 @@ otError Interpreter::ProcessUnsecurePort(Arg aArgs[])
     }
     else
     {
-        ExitNow(error = OT_ERROR_INVALID_COMMAND);
+        error = OT_ERROR_INVALID_COMMAND;
     }
 
-exit:
     return error;
 }
 
@@ -4443,20 +4414,17 @@ otError Interpreter::ProcessMacFilter(Arg aArgs[])
     {
         PrintMacFilter();
     }
+    else if (aArgs[0] == "addr")
+    {
+        error = ProcessMacFilterAddress(aArgs + 1);
+    }
+    else if (aArgs[0] == "rss")
+    {
+        error = ProcessMacFilterRss(aArgs + 1);
+    }
     else
     {
-        if (aArgs[0] == "addr")
-        {
-            error = ProcessMacFilterAddress(aArgs + 1);
-        }
-        else if (aArgs[0] == "rss")
-        {
-            error = ProcessMacFilterRss(aArgs + 1);
-        }
-        else
-        {
-            error = OT_ERROR_INVALID_COMMAND;
-        }
+        error = OT_ERROR_INVALID_COMMAND;
     }
 
     return error;
@@ -4559,51 +4527,48 @@ otError Interpreter::ProcessMacFilterAddress(Arg aArgs[])
             OutputLine("");
         }
     }
+    else if (aArgs[0] == "disable")
+    {
+        VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+        otLinkFilterSetAddressMode(GetInstancePtr(), OT_MAC_FILTER_ADDRESS_MODE_DISABLED);
+    }
+    else if (aArgs[0] == "allowlist")
+    {
+        VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+        otLinkFilterSetAddressMode(GetInstancePtr(), OT_MAC_FILTER_ADDRESS_MODE_ALLOWLIST);
+    }
+    else if (aArgs[0] == "denylist")
+    {
+        VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+        otLinkFilterSetAddressMode(GetInstancePtr(), OT_MAC_FILTER_ADDRESS_MODE_DENYLIST);
+    }
+    else if (aArgs[0] == "add")
+    {
+        SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
+        error = otLinkFilterAddAddress(GetInstancePtr(), &extAddr);
+
+        VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY);
+
+        if (!aArgs[2].IsEmpty())
+        {
+            int8_t rss;
+
+            SuccessOrExit(error = aArgs[2].ParseAsInt8(rss));
+            SuccessOrExit(error = otLinkFilterAddRssIn(GetInstancePtr(), &extAddr, rss));
+        }
+    }
+    else if (aArgs[0] == "remove")
+    {
+        SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
+        otLinkFilterRemoveAddress(GetInstancePtr(), &extAddr);
+    }
+    else if (aArgs[0] == "clear")
+    {
+        otLinkFilterClearAddresses(GetInstancePtr());
+    }
     else
     {
-        if (aArgs[0] == "disable")
-        {
-            VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-            otLinkFilterSetAddressMode(GetInstancePtr(), OT_MAC_FILTER_ADDRESS_MODE_DISABLED);
-        }
-        else if (aArgs[0] == "allowlist")
-        {
-            VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-            otLinkFilterSetAddressMode(GetInstancePtr(), OT_MAC_FILTER_ADDRESS_MODE_ALLOWLIST);
-        }
-        else if (aArgs[0] == "denylist")
-        {
-            VerifyOrExit(aArgs[1].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
-            otLinkFilterSetAddressMode(GetInstancePtr(), OT_MAC_FILTER_ADDRESS_MODE_DENYLIST);
-        }
-        else if (aArgs[0] == "add")
-        {
-            SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
-            error = otLinkFilterAddAddress(GetInstancePtr(), &extAddr);
-
-            VerifyOrExit(error == OT_ERROR_NONE || error == OT_ERROR_ALREADY);
-
-            if (!aArgs[2].IsEmpty())
-            {
-                int8_t rss;
-
-                SuccessOrExit(error = aArgs[2].ParseAsInt8(rss));
-                SuccessOrExit(error = otLinkFilterAddRssIn(GetInstancePtr(), &extAddr, rss));
-            }
-        }
-        else if (aArgs[0] == "remove")
-        {
-            SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
-            otLinkFilterRemoveAddress(GetInstancePtr(), &extAddr);
-        }
-        else if (aArgs[0] == "clear")
-        {
-            otLinkFilterClearAddresses(GetInstancePtr());
-        }
-        else
-        {
-            error = OT_ERROR_INVALID_COMMAND;
-        }
+        error = OT_ERROR_INVALID_COMMAND;
     }
 
 exit:
@@ -4645,60 +4610,57 @@ otError Interpreter::ProcessMacFilterRss(Arg aArgs[])
             }
         }
     }
-    else
+    else if (aArgs[0] == "add-lqi")
     {
-        if (aArgs[0] == "add-lqi")
-        {
-            uint8_t linkQuality;
+        uint8_t linkQuality;
 
-            SuccessOrExit(error = aArgs[2].ParseAsUint8(linkQuality));
-            VerifyOrExit(linkQuality <= 3, error = OT_ERROR_INVALID_ARGS);
-            rss = otLinkConvertLinkQualityToRss(GetInstancePtr(), linkQuality);
+        SuccessOrExit(error = aArgs[2].ParseAsUint8(linkQuality));
+        VerifyOrExit(linkQuality <= 3, error = OT_ERROR_INVALID_ARGS);
+        rss = otLinkConvertLinkQualityToRss(GetInstancePtr(), linkQuality);
 
-            if (aArgs[1] == "*")
-            {
-                otLinkFilterSetDefaultRssIn(GetInstancePtr(), rss);
-            }
-            else
-            {
-                SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
-                SuccessOrExit(error = otLinkFilterAddRssIn(GetInstancePtr(), &extAddr, rss));
-            }
-        }
-        else if (aArgs[0] == "add")
+        if (aArgs[1] == "*")
         {
-            SuccessOrExit(error = aArgs[2].ParseAsInt8(rss));
-
-            if (aArgs[1] == "*")
-            {
-                otLinkFilterSetDefaultRssIn(GetInstancePtr(), rss);
-            }
-            else
-            {
-                SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
-                SuccessOrExit(error = otLinkFilterAddRssIn(GetInstancePtr(), &extAddr, rss));
-            }
-        }
-        else if (aArgs[0] == "remove")
-        {
-            if (aArgs[1] == "*")
-            {
-                otLinkFilterClearDefaultRssIn(GetInstancePtr());
-            }
-            else
-            {
-                SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
-                otLinkFilterRemoveRssIn(GetInstancePtr(), &extAddr);
-            }
-        }
-        else if (aArgs[0] == "clear")
-        {
-            otLinkFilterClearAllRssIn(GetInstancePtr());
+            otLinkFilterSetDefaultRssIn(GetInstancePtr(), rss);
         }
         else
         {
-            error = OT_ERROR_INVALID_COMMAND;
+            SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
+            error = otLinkFilterAddRssIn(GetInstancePtr(), &extAddr, rss);
         }
+    }
+    else if (aArgs[0] == "add")
+    {
+        SuccessOrExit(error = aArgs[2].ParseAsInt8(rss));
+
+        if (aArgs[1] == "*")
+        {
+            otLinkFilterSetDefaultRssIn(GetInstancePtr(), rss);
+        }
+        else
+        {
+            SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
+            error = otLinkFilterAddRssIn(GetInstancePtr(), &extAddr, rss);
+        }
+    }
+    else if (aArgs[0] == "remove")
+    {
+        if (aArgs[1] == "*")
+        {
+            otLinkFilterClearDefaultRssIn(GetInstancePtr());
+        }
+        else
+        {
+            SuccessOrExit(error = aArgs[1].ParseAsHexString(extAddr.m8));
+            otLinkFilterRemoveRssIn(GetInstancePtr(), &extAddr);
+        }
+    }
+    else if (aArgs[0] == "clear")
+    {
+        otLinkFilterClearAllRssIn(GetInstancePtr());
+    }
+    else
+    {
+        error = OT_ERROR_INVALID_COMMAND;
     }
 
 exit:

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -397,9 +397,6 @@ private:
     otError ProcessEidCache(Arg aArgs[]);
 #endif
     otError ProcessEui64(Arg aArgs[]);
-#if OPENTHREAD_POSIX && !defined(FUZZING_BUILD_MODE_UNSAFE_FOR_PRODUCTION)
-    otError ProcessExit(Arg aArgs[]);
-#endif
     otError ProcessLog(Arg aArgs[]);
     otError ProcessExtAddress(Arg aArgs[]);
     otError ProcessExtPanId(Arg aArgs[]);
@@ -470,10 +467,6 @@ private:
     otError ProcessNeighbor(Arg aArgs[]);
 #endif
     otError ProcessNetworkData(Arg aArgs[]);
-    otError ProcessNetworkDataPrefix(void);
-    otError ProcessNetworkDataRoute(void);
-    otError ProcessNetworkDataService(void);
-
     otError ProcessNetstat(Arg aArgs[]);
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     otError ProcessService(Arg aArgs[]);

--- a/src/cli/cli_srp_client.cpp
+++ b/src/cli/cli_srp_client.cpp
@@ -151,10 +151,8 @@ otError SrpClient::ProcessHost(Arg aArgs[])
     if (aArgs[0].IsEmpty())
     {
         OutputHostInfo(0, *otSrpClientGetHostInfo(GetInstancePtr()));
-        ExitNow();
     }
-
-    if (aArgs[0] == "name")
+    else if (aArgs[0] == "name")
     {
         if (aArgs[1].IsEmpty())
         {
@@ -316,10 +314,8 @@ otError SrpClient::ProcessService(Arg aArgs[])
     if (aArgs[0].IsEmpty())
     {
         OutputServiceList(0, otSrpClientGetServices(GetInstancePtr()));
-        ExitNow();
     }
-
-    if (aArgs[0] == "add")
+    else if (aArgs[0] == "add")
     {
         error = ProcessServiceAdd(aArgs);
     }


### PR DESCRIPTION
This commit contains smaller changes in CLI modules:

- Remove unused method declarations.
- Remove unnecessary `SuccessOrExit()` or `ExitNow()`.
- Convert `else` blocks into `else if` sequence (to remove extra
  indentation).