### PR TITLE
[netdata] simplify checking if network data contains certain entries

### DIFF
--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -284,112 +284,106 @@ exit:
     return error;
 }
 
-bool NetworkData::ContainsOnMeshPrefixes(const NetworkData &aCompare, uint16_t aRloc16) const
+bool NetworkData::ContainsOnMeshPrefix(const OnMeshPrefixConfig &aPrefix) const
 {
-    Iterator           outerIterator = kIteratorInit;
-    OnMeshPrefixConfig outerConfig;
-    bool               rval = true;
+    bool               contains = false;
+    Iterator           iterator = kIteratorInit;
+    OnMeshPrefixConfig prefix;
 
-    while (aCompare.GetNextOnMeshPrefix(outerIterator, aRloc16, outerConfig) == kErrorNone)
+    while (GetNextOnMeshPrefix(iterator, aPrefix.mRloc16, prefix) == kErrorNone)
     {
-        Iterator           innerIterator = kIteratorInit;
-        OnMeshPrefixConfig innerConfig;
-        Error              error;
-
-        while ((error = GetNextOnMeshPrefix(innerIterator, aRloc16, innerConfig)) == kErrorNone)
+        if (prefix == aPrefix)
         {
-            if (outerConfig == innerConfig)
-            {
-                break;
-            }
-        }
-
-        if (error != kErrorNone)
-        {
-            ExitNow(rval = false);
+            contains = true;
+            break;
         }
     }
 
-exit:
-    return rval;
+    return contains;
 }
 
-bool NetworkData::ContainsExternalRoutes(const NetworkData &aCompare, uint16_t aRloc16) const
+bool NetworkData::ContainsExternalRoute(const ExternalRouteConfig &aRoute) const
 {
-    Iterator            outerIterator = kIteratorInit;
-    ExternalRouteConfig outerConfig;
-    bool                rval = true;
+    bool                contains = false;
+    Iterator            iterator = kIteratorInit;
+    ExternalRouteConfig route;
 
-    while (aCompare.GetNextExternalRoute(outerIterator, aRloc16, outerConfig) == kErrorNone)
+    while (GetNextExternalRoute(iterator, aRoute.mRloc16, route) == kErrorNone)
     {
-        Iterator            innerIterator = kIteratorInit;
-        ExternalRouteConfig innerConfig;
-        Error               error;
-
-        while ((error = GetNextExternalRoute(innerIterator, aRloc16, innerConfig)) == kErrorNone)
+        if (route == aRoute)
         {
-            if (outerConfig == innerConfig)
-            {
-                break;
-            }
-        }
-
-        if (error != kErrorNone)
-        {
-            ExitNow(rval = false);
+            contains = true;
+            break;
         }
     }
 
-exit:
-    return rval;
+    return contains;
 }
 
-bool NetworkData::ContainsServices(const NetworkData &aCompare, uint16_t aRloc16) const
+bool NetworkData::ContainsService(const ServiceConfig &aService) const
 {
-    Iterator      outerIterator = kIteratorInit;
-    ServiceConfig outerConfig;
-    bool          rval = true;
+    bool          contains = false;
+    Iterator      iterator = kIteratorInit;
+    ServiceConfig service;
 
-    while (aCompare.GetNextService(outerIterator, aRloc16, outerConfig) == kErrorNone)
+    while (GetNextService(iterator, aService.GetServerConfig().mRloc16, service) == kErrorNone)
     {
-        Iterator      innerIterator = kIteratorInit;
-        ServiceConfig innerConfig;
-        Error         error;
-
-        while ((error = GetNextService(innerIterator, aRloc16, innerConfig)) == kErrorNone)
+        if (service == aService)
         {
-            if (outerConfig == innerConfig)
-            {
-                break;
-            }
-        }
-
-        if (error != kErrorNone)
-        {
-            ExitNow(rval = false);
+            contains = true;
+            break;
         }
     }
 
-exit:
-    return rval;
+    return contains;
 }
 
 bool NetworkData::ContainsService(uint8_t aServiceId, uint16_t aRloc16) const
 {
+    bool     contains = false;
     Iterator iterator = kIteratorInit;
     uint8_t  serviceId;
-    bool     rval = false;
 
     while (GetNextServiceId(iterator, aRloc16, serviceId) == kErrorNone)
     {
         if (serviceId == aServiceId)
         {
-            ExitNow(rval = true);
+            contains = true;
+            break;
+        }
+    }
+
+    return contains;
+}
+
+bool NetworkData::ContainsEntriesFrom(const NetworkData &aComapre, uint16_t aRloc16) const
+{
+    bool     contains = true;
+    Iterator iterator = kIteratorInit;
+
+    while (true)
+    {
+        Config              config;
+        OnMeshPrefixConfig  prefix;
+        ExternalRouteConfig route;
+        ServiceConfig       service;
+
+        config.mOnMeshPrefix  = &prefix;
+        config.mExternalRoute = &route;
+        config.mService       = &service;
+
+        SuccessOrExit(aComapre.Iterate(iterator, aRloc16, config));
+
+        if (((config.mOnMeshPrefix != nullptr) && !ContainsOnMeshPrefix(*config.mOnMeshPrefix)) ||
+            ((config.mExternalRoute != nullptr) && !ContainsExternalRoute(*config.mExternalRoute)) ||
+            ((config.mService != nullptr) && !ContainsService(*config.mService)))
+        {
+            ExitNow(contains = false);
         }
     }
 
 exit:
-    return rval;
+    return contains;
 }
 
 void MutableNetworkData::RemoveTemporaryData(void)

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -280,56 +280,63 @@ public:
     Error GetNextServiceId(Iterator &aIterator, uint16_t aRloc16, uint8_t &aServiceId) const;
 
     /**
-     * This method indicates whether or not the Thread Network Data contains all of the on mesh prefix information
-     * in @p aCompare associated with @p aRloc16.
+     * This method indicates whether or not the Thread Network Data contains a given on mesh prefix entry.
      *
-     * @param[in]  aCompare  The Network Data to use for the query.
-     * @param[in]  aRloc16   The RLOC16 to consider.
+     * @param[in]  aPrefix   The on mesh prefix config to check.
      *
-     * @returns TRUE if this object contains all on mesh prefix information in @p aCompare associated with @p aRloc16,
-     *          FALSE otherwise.
+     * @retval TRUE  if Network Data contains an on mesh prefix matching @p aPrefix.
+     * @retval FALSE if Network Data does not contain an on mesh prefix matching @p aPrefix.
      *
      */
-    bool ContainsOnMeshPrefixes(const NetworkData &aCompare, uint16_t aRloc16) const;
+    bool ContainsOnMeshPrefix(const OnMeshPrefixConfig &aPrefix) const;
 
     /**
-     * This method indicates whether or not the Thread Network Data contains all of the external route information
-     * in @p aCompare associated with @p aRloc16.
+     * This method indicates whether or not the Thread Network Data contains a given external route entry.
      *
-     * @param[in]  aCompare  The Network Data to use for the query.
-     * @param[in]  aRloc16   The RLOC16 to consider.
+     * @param[in]  aRoute   The external route config to check.
      *
-     * @returns TRUE if this object contains all external route information in @p aCompare associated with @p aRloc16,
-     *          FALSE otherwise.
+     * @retval TRUE  if Network Data contains an external route matching @p aRoute.
+     * @retval FALSE if Network Data does not contain an external route matching @p aRoute.
      *
      */
-    bool ContainsExternalRoutes(const NetworkData &aCompare, uint16_t aRloc16) const;
+    bool ContainsExternalRoute(const ExternalRouteConfig &aRoute) const;
 
     /**
-     * This method indicates whether or not the Thread Network Data contains all of the service information
-     * in @p aCompare associated with @p aRloc16.
+     * This method indicates whether or not the Thread Network Data contains a given service entry.
      *
-     * @param[in]  aCompare  The Network Data to use for the query.
-     * @param[in]  aRloc16   The RLOC16 to consider.
+     * @param[in]  aService   The service config to check.
      *
-     * @returns TRUE if this object contains all service information in @p aCompare associated with @p aRloc16,
-     *          FALSE otherwise.
+     * @retval TRUE  if Network Data contains a service matching @p aService.
+     * @retval FALSE if Network Data does not contain a service matching @p aService.
      *
      */
-    bool ContainsServices(const NetworkData &aCompare, uint16_t aRloc16) const;
+    bool ContainsService(const ServiceConfig &aService) const;
 
     /**
-     * This method indicates whether or not the Thread Network Data contains the service with given Service ID
+     * This method indicates whether or not the Thread Network Data contains the service with a given Service ID
      * associated with @p aRloc16.
      *
      * @param[in]  aServiceId The Service ID to search for.
      * @param[in]  aRloc16    The RLOC16 to consider.
      *
-     * @returns TRUE if this object contains the service with given ID associated with @p aRloc16,
-     *          FALSE otherwise.
+     * @retval TRUE  if Network Data contains a service matching @p aServiceId for @p aRloc16.
+     * @retval FALSE if Network Data does not contain a service matching @p aServiceId for @p aRloc16.
      *
      */
     bool ContainsService(uint8_t aServiceId, uint16_t aRloc16) const;
+
+    /**
+     * This method indicates whether or not the Thread Network Data contains all the on mesh prefixes, external
+     * routes, and service entries as in another given Network Data associated with a given RLOC16.
+     *
+     * @param[in] aCompare         The Network Data to compare with.
+     * @param[in] aRloc16          The RLOC16 to consider.
+     *
+     * @retval TRUE  if Network Data contains all the same entries as in @p aCompare for @p aRloc16.
+     * @retval FALSE if Network Data does not contains all the same entries as in @p aCompare for @p aRloc16.
+     *
+     */
+    bool ContainsEntriesFrom(const NetworkData &aComapre, uint16_t aRloc16) const;
 
     /**
      * This method provides the next server RLOC16 in the Thread Network Data.

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -172,13 +172,11 @@ private:
     Error AddPrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvType, uint16_t aFlags, bool aStable);
     Error RemovePrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvType);
     void  UpdateRloc(PrefixTlv &aPrefixTlv);
-    bool  IsOnMeshPrefixConsistent(void) const;
-    bool  IsExternalRouteConsistent(void) const;
+    bool  IsConsistent(void) const;
 #endif
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     void UpdateRloc(ServiceTlv &aService);
-    bool IsServiceConsistent(void) const;
 #endif
 
     uint8_t  mTlvBuffer[kMaxSize];


### PR DESCRIPTION
This commit adds new methods in `NetworkData` to indicate whether or
not it contains a given on mesh prefix, external route, or service
entry. It also adds a new method to check whether it contains all
entries as in another given Network Data all associated with a given
RLOC16. This is then used to simplify comparison between `Local` and
`Leader` network data.

----
Some more details on this PR:
- It replaces existing `Contains{Prefixes/Routes/Services}` which check for a set
  of entries with simpler methods that check for one entry. I think these will be useful 
  in other situations (e.g., will use them in `HistoryTracker` to track net data changes)
- Combine all the `Local::Is{Prefix/Route/Service}Consistent()` into one that does 
  all the checks together.
  