### PR TITLE
[core] remove extra `#if` config check before header includes

### DIFF
--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -38,9 +38,7 @@
 #include "common/as_core_type.hpp"
 #include "common/locator_getters.hpp"
 #include "common/logging.hpp"
-#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
 #include "utils/slaac_address.hpp"
-#endif
 
 using namespace ot;
 

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -47,6 +47,8 @@
 
 #include "common/as_core_type.hpp"
 #include "common/error.hpp"
+#include "common/extension.hpp"
+#include "common/message.hpp"
 #include "common/non_copyable.hpp"
 #include "common/random_manager.hpp"
 #include "common/tasklet.hpp"
@@ -54,64 +56,33 @@
 #include "common/timer.hpp"
 #include "common/uptime.hpp"
 #include "diags/factory_diags.hpp"
-#include "radio/radio.hpp"
-
-#if OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
-#include "common/message.hpp"
 #include "mac/link_raw.hpp"
-#endif
+#include "radio/radio.hpp"
+#include "utils/otns.hpp"
+
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
+#include "backbone_router/bbr_leader.hpp"
+#include "backbone_router/bbr_local.hpp"
+#include "border_router/routing_manager.hpp"
 #include "common/code_utils.hpp"
 #include "common/notifier.hpp"
 #include "common/settings.hpp"
 #include "crypto/mbedtls.hpp"
 #include "meshcop/border_agent.hpp"
-#if (OPENTHREAD_CONFIG_DATASET_UPDATER_ENABLE || OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE) && OPENTHREAD_FTD
 #include "meshcop/dataset_updater.hpp"
-#endif
 #include "net/ip6.hpp"
 #include "thread/announce_sender.hpp"
+#include "thread/link_metrics.hpp"
 #include "thread/link_quality.hpp"
 #include "thread/thread_netif.hpp"
 #include "thread/tmf.hpp"
-#include "utils/heap.hpp"
-#if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
-#include "utils/ping_sender.hpp"
-#endif
-#if OPENTHREAD_CONFIG_CHANNEL_MANAGER_ENABLE && OPENTHREAD_FTD
 #include "utils/channel_manager.hpp"
-#endif
-#if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
 #include "utils/channel_monitor.hpp"
-#endif
-#if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
+#include "utils/heap.hpp"
 #include "utils/history_tracker.hpp"
-#endif
-
-#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-#include "backbone_router/bbr_leader.hpp"
-
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-#include "backbone_router/bbr_local.hpp"
-#endif
-
-#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
-#include "thread/link_metrics.hpp"
-#endif
-
-#endif // (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-#include "border_router/routing_manager.hpp"
-#endif
-
+#include "utils/ping_sender.hpp"
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD
-#if OPENTHREAD_ENABLE_VENDOR_EXTENSION
-#include "common/extension.hpp"
-#endif
-#if OPENTHREAD_CONFIG_OTNS_ENABLE
-#include "utils/otns.hpp"
-#endif
+
 /**
  * @addtogroup core-instance
  *

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -44,15 +44,11 @@
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
 #include "common/settings_driver.hpp"
+#include "crypto/ecdsa.hpp"
 #include "mac/mac_types.hpp"
 #include "net/ip6_address.hpp"
 #include "utils/flash.hpp"
-#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
 #include "utils/slaac_address.hpp"
-#endif
-#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
-#include "crypto/ecdsa.hpp"
-#endif
 
 namespace ot {
 

--- a/src/core/net/dhcp6.hpp
+++ b/src/core/net/dhcp6.hpp
@@ -36,6 +36,8 @@
 
 #include "openthread-core-config.h"
 
+#if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE || OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
+
 #include "common/clearable.hpp"
 #include "common/equatable.hpp"
 #include "common/message.hpp"
@@ -667,5 +669,7 @@ public:
 
 } // namespace Dhcp6
 } // namespace ot
+
+#endif // #if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE || OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
 
 #endif // DHCP6_HPP_

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -36,44 +36,16 @@
 
 #include "openthread-core-config.h"
 
-#include "coap/coap_secure.hpp"
-#include "mac/mac.hpp"
-#include "thread/tmf.hpp"
-
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-#include "meshcop/border_agent.hpp"
-#endif
-#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-#include "meshcop/commissioner.hpp"
-#endif // OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-
-#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-#include "backbone_router/bbr_leader.hpp"
-#endif
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
 #include "backbone_router/backbone_tmf.hpp"
+#include "backbone_router/bbr_leader.hpp"
 #include "backbone_router/bbr_local.hpp"
 #include "backbone_router/bbr_manager.hpp"
-#endif
-
-#if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
-#include "thread/mlr_manager.hpp"
-#endif
-
-#if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)
-#include "thread/dua_manager.hpp"
-#endif
-
-#if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
-#include "net/srp_server.hpp"
-#endif
-
+#include "coap/coap_secure.hpp"
+#include "mac/mac.hpp"
+#include "meshcop/border_agent.hpp"
+#include "meshcop/commissioner.hpp"
 #include "meshcop/dataset_manager.hpp"
-
-#if OPENTHREAD_CONFIG_JOINER_ENABLE
 #include "meshcop/joiner.hpp"
-#endif // OPENTHREAD_CONFIG_JOINER_ENABLE
-
 #include "meshcop/joiner_router.hpp"
 #include "meshcop/meshcop_leader.hpp"
 #include "net/dhcp6.hpp"
@@ -86,16 +58,19 @@
 #include "net/netif.hpp"
 #include "net/sntp_client.hpp"
 #include "net/srp_client.hpp"
+#include "net/srp_server.hpp"
 #include "thread/address_resolver.hpp"
 #include "thread/announce_begin_server.hpp"
 #include "thread/anycast_locator.hpp"
 #include "thread/discover_scanner.hpp"
+#include "thread/dua_manager.hpp"
 #include "thread/energy_scan_server.hpp"
 #include "thread/key_manager.hpp"
 #include "thread/link_metrics.hpp"
 #include "thread/mesh_forwarder.hpp"
 #include "thread/mle.hpp"
 #include "thread/mle_router.hpp"
+#include "thread/mlr_manager.hpp"
 #include "thread/network_data_local.hpp"
 #include "thread/network_data_notifier.hpp"
 #include "thread/network_data_publisher.hpp"
@@ -104,16 +79,11 @@
 #include "thread/panid_query_server.hpp"
 #include "thread/radio_selector.hpp"
 #include "thread/time_sync_service.hpp"
+#include "thread/tmf.hpp"
 #include "utils/child_supervision.hpp"
-#include "utils/srp_client_buffers.hpp"
-
-#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
-#include "utils/slaac_address.hpp"
-#endif
-
-#if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
 #include "utils/jam_detector.hpp"
-#endif // OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
+#include "utils/slaac_address.hpp"
+#include "utils/srp_client_buffers.hpp"
 
 namespace ot {
 


### PR DESCRIPTION
This commit removes the extra `#if` config checks in core files before
`#include` of different headers. Such a check is not necessary since
the OT core headers all start with any related `#if` config check.