### PR TITLE
[csl] properly provide IsDataPoll info for determining number of CSL retx

### DIFF
--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -216,7 +216,7 @@ void DataPollSender::HandlePollSent(Mac::TxFrame &aFrame, Error aError)
     if (!aFrame.IsEmpty())
     {
         IgnoreError(aFrame.GetDstAddr(macDest));
-        Get<MeshForwarder>().UpdateNeighborOnSentFrame(aFrame, aError, macDest);
+        Get<MeshForwarder>().UpdateNeighborOnSentFrame(aFrame, aError, macDest, /* aIsDataPoll */ true);
     }
 
     if (GetParent().IsStateInvalid())
@@ -259,8 +259,14 @@ void DataPollSender::HandlePollSent(Mac::TxFrame &aFrame, Error aError)
     default:
         mPollTxFailureCounter++;
 
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+        otLogInfoMac("Failed to send data poll, error:%s, retx:%d/%d", ErrorToString(aError), mPollTxFailureCounter,
+                     (aFrame.GetHeaderIe(Mac::CslIe::kHeaderIeId) != nullptr) ? kMaxCslPollRetxAttempts
+                                                                              : kMaxPollRetxAttempts);
+#else
         otLogInfoMac("Failed to send data poll, error:%s, retx:%d/%d", ErrorToString(aError), mPollTxFailureCounter,
                      kMaxPollRetxAttempts);
+#endif
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
         if (mPollTxFailureCounter <

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -883,8 +883,13 @@ start:
     return nextOffset;
 }
 
-Neighbor *MeshForwarder::UpdateNeighborOnSentFrame(Mac::TxFrame &aFrame, Error aError, const Mac::Address &aMacDest)
+Neighbor *MeshForwarder::UpdateNeighborOnSentFrame(Mac::TxFrame &      aFrame,
+                                                   Error               aError,
+                                                   const Mac::Address &aMacDest,
+                                                   bool                aIsDataPoll)
 {
+    OT_UNUSED_VARIABLE(aIsDataPoll);
+
     Neighbor *neighbor = nullptr;
 
     VerifyOrExit(mEnabled);
@@ -907,7 +912,7 @@ Neighbor *MeshForwarder::UpdateNeighborOnSentFrame(Mac::TxFrame &aFrame, Error a
 #endif // OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    if ((aFrame.GetHeaderIe(Mac::CslIe::kHeaderIeId) != nullptr) && aFrame.IsDataRequestCommand())
+    if ((aFrame.GetHeaderIe(Mac::CslIe::kHeaderIeId) != nullptr) && aIsDataPoll)
     {
         UpdateNeighborLinkFailures(*neighbor, aError, /* aAllowNeighborRemove */ true,
                                    /* aFailLimit */ Mle::kFailedCslDataPollTransmissions);

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -463,7 +463,10 @@ private:
 
     void          HandleReceivedFrame(Mac::RxFrame &aFrame);
     Mac::TxFrame *HandleFrameRequest(Mac::TxFrames &aTxFrames);
-    Neighbor *    UpdateNeighborOnSentFrame(Mac::TxFrame &aFrame, Error aError, const Mac::Address &aMacDest);
+    Neighbor *    UpdateNeighborOnSentFrame(Mac::TxFrame &      aFrame,
+                                            Error               aError,
+                                            const Mac::Address &aMacDest,
+                                            bool                aIsDataPoll = false);
     void          UpdateNeighborLinkFailures(Neighbor &aNeighbor,
                                              Error     aError,
                                              bool      aAllowNeighborRemove,


### PR DESCRIPTION
The `aFrame.IsDataRequestCommand()` call was checking the frame that had been already encrypted.

This PR fixes that by using `aIsDataPoll` parameter instead.