### PR TITLE
[dataset] accept too small Rotation Time in Security Policy TLV

### DIFF
--- a/src/core/meshcop/meshcop_tlvs.cpp
+++ b/src/core/meshcop/meshcop_tlvs.cpp
@@ -148,8 +148,7 @@ void SteeringDataTlv::CopyTo(SteeringData &aSteeringData) const
 
 bool SecurityPolicyTlv::IsValid(void) const
 {
-    return GetLength() >= sizeof(mRotationTime) && GetRotationTime() >= SecurityPolicy::kMinKeyRotationTime &&
-           GetFlagsLength() >= kThread11FlagsLength;
+    return GetLength() >= sizeof(mRotationTime) && GetFlagsLength() >= kThread11FlagsLength;
 }
 
 SecurityPolicy SecurityPolicyTlv::GetSecurityPolicy(void) const

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -37,6 +37,7 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
+#include "common/logging.hpp"
 #include "common/timer.hpp"
 #include "crypto/hkdf_sha256.hpp"
 #include "crypto/storage.hpp"
@@ -483,9 +484,16 @@ void KeyManager::SetKek(const Kek &aKek)
 
 void KeyManager::SetSecurityPolicy(const SecurityPolicy &aSecurityPolicy)
 {
-    OT_ASSERT(aSecurityPolicy.mRotationTime >= SecurityPolicy::kMinKeyRotationTime);
+    if (aSecurityPolicy.mRotationTime < SecurityPolicy::kMinKeyRotationTime)
+    {
+        otLogNoteMeshCoP("Key Rotation Time too small: %d", aSecurityPolicy.mRotationTime);
+        ExitNow();
+    }
 
     IgnoreError(Get<Notifier>().Update(mSecurityPolicy, aSecurityPolicy, kEventSecurityPolicyChanged));
+
+exit:
+    return;
 }
 
 void KeyManager::StartKeyRotationTimer(void)


### PR DESCRIPTION
Existing deployed networks may have Operational Datasets where the
Security Policy TLV includes a Rotation Time value of 0. Not accepting
such datasets does not allow a Thread device to attach properly.

This commit removes the requirement that the Rotation Time value must
be greater than the minimum value of one hour.

---

See this [openthread-users email](https://groups.google.com/g/openthread-users/c/UsgEMScMQlQ/m/wYKu-plXBQAJ) for context.