### PR TITLE
[cli] fix invalid `commissioner mgmtget` cli arguments in tests

### DIFF
--- a/tests/scripts/expect/cli-commissioner.exp
+++ b/tests/scripts/expect/cli-commissioner.exp
@@ -65,7 +65,7 @@ send "commissioner mgmtset sessionid $sessionid steeringdata ffffffff joinerudpp
 expect_line "Done"
 send "commissioner mgmtset sessionid $sessionid locator 0x0100\n"
 expect_line "Done"
-send "commissioner mgmtget sessionid steeringdata joinerudpport locator binary 0b081209\n"
+send "commissioner mgmtget sessionid steeringdata joinerudpport locator -x 0b081209\n"
 expect_line "Done"
 send "commissioner stop\n"
 expect "Commissioner: disabled"


### PR DESCRIPTION
This commissioner fix the wrong commissioner mgmt cli args which
uses "binary" to indicate following binary args in HEX string -
the format has been changed to "-x" in PR#5549.

The cause why cli-commissioner.exp doesn't fail consistently is
not fixed by this commit.