### PR TITLE
[mle] simplify management of service ALOCs

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -585,7 +585,7 @@ public:
     /**
      * This method returns the Service ID corresponding to a Service ALOC16.
      *
-     * @param[in]  aAloc16  The Servicer ALOC16 value.
+     * @param[in]  aAloc16  The Service ALOC16 value.
      *
      * @returns The Service ID corresponding to given ALOC16.
      *
@@ -593,7 +593,7 @@ public:
     static uint8_t ServiceIdFromAloc(uint16_t aAloc16) { return static_cast<uint8_t>(aAloc16 - kAloc16ServiceStart); }
 
     /**
-     * This method returns the Service Aloc corresponding to a Service ID.
+     * This method returns the Service ALOC16 corresponding to a Service ID.
      *
      * @param[in]  aServiceId  The Service ID value.
      *
@@ -1763,6 +1763,22 @@ private:
         uint8_t  mCommand;
     } OT_TOOL_PACKED_END;
 
+#if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+    class ServiceAloc : public Ip6::Netif::UnicastAddress
+    {
+    public:
+        static constexpr uint16_t kNotInUse = Mac::kShortAddrInvalid;
+
+        ServiceAloc(void);
+
+        bool     IsInUse(void) const { return GetAloc16() != kNotInUse; }
+        void     MarkAsNotInUse(void) { SetAloc16(kNotInUse); }
+        uint16_t GetAloc16(void) const { return GetAddress().GetIid().GetLocator(); }
+        void     SetAloc16(uint16_t aAloc16) { GetAddress().GetIid().SetLocator(aAloc16); }
+        void     ApplyMeshLocalPrefix(const MeshLocalPrefix &aPrefix) { GetAddress().SetPrefix(aPrefix); }
+    };
+#endif
+
     Error       Start(StartMode aMode);
     void        Stop(StopMode aMode);
     void        HandleNotifierEvents(Events aEvents);
@@ -1829,11 +1845,8 @@ private:
     bool IsNetworkDataNewer(const LeaderData &aLeaderData);
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    /**
-     * This method scans for network data from the leader and updates IP addresses assigned to this
-     * interface to make sure that all Service ALOCs (0xfc10-0xfc1f) are properly set.
-     */
-    void UpdateServiceAlocs(void);
+    ServiceAloc *FindInServiceAlocs(uint16_t aAloc16);
+    void         UpdateServiceAlocs(void);
 #endif
 
 #if OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
@@ -1903,7 +1916,7 @@ private:
     uint64_t mAlternateTimestamp;
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    Ip6::Netif::UnicastAddress mServiceAlocs[kMaxServiceAlocs];
+    ServiceAloc mServiceAlocs[kMaxServiceAlocs];
 #endif
 
     otMleCounters mCounters;

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -272,18 +272,6 @@ exit:
     return error;
 }
 
-Error NetworkData::GetNextServiceId(Iterator &aIterator, uint16_t aRloc16, uint8_t &aServiceId) const
-{
-    Error         error;
-    ServiceConfig config;
-
-    SuccessOrExit(error = GetNextService(aIterator, aRloc16, config));
-    aServiceId = config.mServiceId;
-
-exit:
-    return error;
-}
-
 bool NetworkData::ContainsOnMeshPrefix(const OnMeshPrefixConfig &aPrefix) const
 {
     bool               contains = false;
@@ -329,24 +317,6 @@ bool NetworkData::ContainsService(const ServiceConfig &aService) const
     while (GetNextService(iterator, aService.GetServerConfig().mRloc16, service) == kErrorNone)
     {
         if (service == aService)
-        {
-            contains = true;
-            break;
-        }
-    }
-
-    return contains;
-}
-
-bool NetworkData::ContainsService(uint8_t aServiceId, uint16_t aRloc16) const
-{
-    bool     contains = false;
-    Iterator iterator = kIteratorInit;
-    uint8_t  serviceId;
-
-    while (GetNextServiceId(iterator, aRloc16, serviceId) == kErrorNone)
-    {
-        if (serviceId == aServiceId)
         {
             contains = true;
             break;

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -267,19 +267,6 @@ public:
     Error GetNextService(Iterator &aIterator, uint16_t aRloc16, ServiceConfig &aConfig) const;
 
     /**
-     * This method provides the next Service ID in the Thread Network Data for a given RLOC16.
-     *
-     * @param[inout]  aIterator  A reference to the Network Data iterator.
-     * @param[in]     aRloc16    The RLOC16 value.
-     * @param[out]    aServiceId A reference to variable where the Service ID will be placed.
-     *
-     * @retval kErrorNone       Successfully found the next service.
-     * @retval kErrorNotFound   No subsequent service exists in the Thread Network Data.
-     *
-     */
-    Error GetNextServiceId(Iterator &aIterator, uint16_t aRloc16, uint8_t &aServiceId) const;
-
-    /**
      * This method indicates whether or not the Thread Network Data contains a given on mesh prefix entry.
      *
      * @param[in]  aPrefix   The on mesh prefix config to check.
@@ -311,19 +298,6 @@ public:
      *
      */
     bool ContainsService(const ServiceConfig &aService) const;
-
-    /**
-     * This method indicates whether or not the Thread Network Data contains the service with a given Service ID
-     * associated with @p aRloc16.
-     *
-     * @param[in]  aServiceId The Service ID to search for.
-     * @param[in]  aRloc16    The RLOC16 to consider.
-     *
-     * @retval TRUE  if Network Data contains a service matching @p aServiceId for @p aRloc16.
-     * @retval FALSE if Network Data does not contain a service matching @p aServiceId for @p aRloc16.
-     *
-     */
-    bool ContainsService(uint8_t aServiceId, uint16_t aRloc16) const;
 
     /**
      * This method indicates whether or not the Thread Network Data contains all the on mesh prefixes, external


### PR DESCRIPTION
This commit updates the handling of service ALOCs in `Mle` by adding a
new class `ServiceAloc` (subclass of `Ip6::Netif::UnicastAddress`)
which provides some simple helper methods (e.g., `IsInUse()` to
indicate whether the entry is currently added to `ThreadNetif`). It
also simplifies `UpdateServiceAlocs()` which adds and removes ALOCs
based on the service entries in the Thread Network Data. These changes
allow us to remove some service related methods from `NetworkData`
which are no longer needed or used (harmonizing how we iterate over
service entries in Network Data).