### PR TITLE
[netdata] add `NetworkData::Type` enum for full or stable subset

### DIFF
--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -74,7 +74,8 @@ otError otBorderRoutingGetNat64Prefix(otInstance *aInstance, otIp6Prefix *aPrefi
 
 otError otBorderRouterGetNetData(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)
 {
-    return AsCoreType(aInstance).Get<NetworkData::Local>().CopyNetworkData(aStable, aData, *aDataLength);
+    return AsCoreType(aInstance).Get<NetworkData::Local>().CopyNetworkData(
+        aStable ? NetworkData::kStableSubset : NetworkData::kFullSet, aData, *aDataLength);
 }
 
 otError otBorderRouterAddOnMeshPrefix(otInstance *aInstance, const otBorderRouterConfig *aConfig)

--- a/src/core/api/netdata_api.cpp
+++ b/src/core/api/netdata_api.cpp
@@ -42,7 +42,8 @@ using namespace ot;
 
 otError otNetDataGet(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)
 {
-    return AsCoreType(aInstance).Get<NetworkData::Leader>().CopyNetworkData(aStable, aData, *aDataLength);
+    return AsCoreType(aInstance).Get<NetworkData::Leader>().CopyNetworkData(
+        aStable ? NetworkData::kStableSubset : NetworkData::kFullSet, aData, *aDataLength);
 }
 
 otError otNetDataGetNextOnMeshPrefix(otInstance *           aInstance,
@@ -85,12 +86,12 @@ exit:
 
 uint8_t otNetDataGetVersion(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderData().GetDataVersion();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderData().GetDataVersion(NetworkData::kFullSet);
 }
 
 uint8_t otNetDataGetStableVersion(otInstance *aInstance)
 {
-    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderData().GetStableDataVersion();
+    return AsCoreType(aInstance).Get<Mle::MleRouter>().GetLeaderData().GetDataVersion(NetworkData::kStableSubset);
 }
 
 otError otNetDataSteeringDataCheckJoiner(otInstance *aInstance, const otExtAddress *aEui64)

--- a/src/core/api/server_api.cpp
+++ b/src/core/api/server_api.cpp
@@ -44,7 +44,8 @@ using namespace ot;
 
 otError otServerGetNetDataLocal(otInstance *aInstance, bool aStable, uint8_t *aData, uint8_t *aDataLength)
 {
-    return AsCoreType(aInstance).Get<NetworkData::Local>().CopyNetworkData(aStable, aData, *aDataLength);
+    return AsCoreType(aInstance).Get<NetworkData::Local>().CopyNetworkData(
+        aStable ? NetworkData::kStableSubset : NetworkData::kFullSet, aData, *aDataLength);
 }
 
 otError otServerAddService(otInstance *aInstance, const otServiceConfig *aConfig)

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -50,6 +50,7 @@
 #include "thread/mle_tlvs.hpp"
 #include "thread/mle_types.hpp"
 #include "thread/neighbor_table.hpp"
+#include "thread/network_data_types.hpp"
 #include "thread/topology.hpp"
 
 namespace ot {
@@ -308,20 +309,20 @@ public:
     bool IsFullThreadDevice(void) const { return mDeviceMode.IsFullThreadDevice(); }
 
     /**
-     * This method indicates whether or not the device requests Full Network Data.
-     *
-     * @returns TRUE if requests Full Network Data, FALSE otherwise.
-     *
-     */
-    bool IsFullNetworkData(void) const { return mDeviceMode.IsFullNetworkData(); }
-
-    /**
      * This method indicates whether or not the device is a Minimal End Device.
      *
      * @returns TRUE if the device is a Minimal End Device, FALSE otherwise.
      *
      */
     bool IsMinimalEndDevice(void) const { return mDeviceMode.IsMinimalEndDevice(); }
+
+    /**
+     * This method gets the Network Data type (full set or stable subset) that this device requests.
+     *
+     * @returns The Network Data type requested by this device.
+     *
+     */
+    NetworkData::Type GetNetworkDataType(void) const { return mDeviceMode.GetNetworkDataType(); }
 
     /**
      * This method returns a pointer to the Mesh Local Prefix.
@@ -1122,13 +1123,13 @@ protected:
      * This method appends a Network Data TLV to the message.
      *
      * @param[in]  aMessage     A reference to the message.
-     * @param[in]  aStableOnly  TRUE to append stable data, FALSE otherwise.
+     * @param[in]  aType        The Network Data type to append, full set or stable subset.
      *
      * @retval kErrorNone     Successfully appended the Network Data TLV.
      * @retval kErrorNoBufs   Insufficient buffers available to append the Network Data TLV.
      *
      */
-    Error AppendNetworkData(Message &aMessage, bool aStableOnly);
+    Error AppendNetworkData(Message &aMessage, NetworkData::Type aType);
 
     /**
      * This method appends a TLV Request TLV to a message.

--- a/src/core/thread/mle_tlvs.hpp
+++ b/src/core/thread/mle_tlvs.hpp
@@ -692,8 +692,8 @@ public:
     {
         mPartitionId       = HostSwap32(aLeaderData.GetPartitionId());
         mWeighting         = aLeaderData.GetWeighting();
-        mDataVersion       = aLeaderData.GetDataVersion();
-        mStableDataVersion = aLeaderData.GetStableDataVersion();
+        mDataVersion       = aLeaderData.GetDataVersion(NetworkData::kFullSet);
+        mStableDataVersion = aLeaderData.GetDataVersion(NetworkData::kStableSubset);
         mLeaderRouterId    = aLeaderData.GetLeaderRouterId();
     }
 

--- a/src/core/thread/mle_types.cpp
+++ b/src/core/thread/mle_types.cpp
@@ -42,7 +42,7 @@ void DeviceMode::Get(ModeConfig &aModeConfig) const
 {
     aModeConfig.mRxOnWhenIdle = IsRxOnWhenIdle();
     aModeConfig.mDeviceType   = IsFullThreadDevice();
-    aModeConfig.mNetworkData  = IsFullNetworkData();
+    aModeConfig.mNetworkData  = (GetNetworkDataType() == NetworkData::kFullSet);
 }
 
 void DeviceMode::Set(const ModeConfig &aModeConfig)
@@ -58,7 +58,7 @@ DeviceMode::InfoString DeviceMode::ToString(void) const
     InfoString string;
 
     string.Append("rx-on:%s ftd:%s full-net:%s", ToYesNo(IsRxOnWhenIdle()), ToYesNo(IsFullThreadDevice()),
-                  ToYesNo(IsFullNetworkData()));
+                  ToYesNo(GetNetworkDataType() == NetworkData::kFullSet));
 
     return string;
 }

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -50,6 +50,7 @@
 #include "common/string.hpp"
 #include "mac/mac_types.hpp"
 #include "net/ip6_address.hpp"
+#include "thread/network_data_types.hpp"
 
 namespace ot {
 namespace Mle {
@@ -380,13 +381,15 @@ public:
     bool IsFullThreadDevice(void) const { return (mMode & kModeFullThreadDevice) != 0; }
 
     /**
-     * This method indicates whether or not the device requests Full Network Data.
+     * This method gets the Network Data type (full set or stable subset) that the device requests.
      *
-     * @retval TRUE   If the device requests Full Network Data.
-     * @retval FALSE  If the device does not request Full Network Data (only stable Network Data).
+     * @returns The Network Data type requested by this device.
      *
      */
-    bool IsFullNetworkData(void) const { return (mMode & kModeFullNetworkData) != 0; }
+    NetworkData::Type GetNetworkDataType(void) const
+    {
+        return (mMode & kModeFullNetworkData) ? NetworkData::kFullSet : NetworkData::kStableSubset;
+    }
 
     /**
      * This method indicates whether or not the device is a Minimal End Device.
@@ -482,12 +485,17 @@ public:
     void SetWeighting(uint8_t aWeighting) { mWeighting = aWeighting; }
 
     /**
-     * This method returns the Data Version value.
+     * This method returns the Data Version value for a type (full set or stable subset).
      *
-     * @returns The Data Version value.
+     * @param[in] aType   The Network Data type (full set or stable subset).
+     *
+     * @returns The Data Version value for @p aType.
      *
      */
-    uint8_t GetDataVersion(void) const { return mDataVersion; }
+    uint8_t GetDataVersion(NetworkData::Type aType) const
+    {
+        return (aType == NetworkData::kFullSet) ? mDataVersion : mStableDataVersion;
+    }
 
     /**
      * This method sets the Data Version value.
@@ -496,14 +504,6 @@ public:
      *
      */
     void SetDataVersion(uint8_t aVersion) { mDataVersion = aVersion; }
-
-    /**
-     * This method returns the Stable Data Version value.
-     *
-     * @returns The Stable Data Version value.
-     *
-     */
-    uint8_t GetStableDataVersion(void) const { return mStableDataVersion; }
 
     /**
      * This method sets the Stable Data Version value.

--- a/src/core/thread/network_data.cpp
+++ b/src/core/thread/network_data.cpp
@@ -47,19 +47,19 @@
 namespace ot {
 namespace NetworkData {
 
-Error NetworkData::CopyNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength) const
+Error NetworkData::CopyNetworkData(Type aType, uint8_t *aData, uint8_t &aDataLength) const
 {
     Error              error;
     MutableNetworkData netDataCopy(GetInstance(), aData, 0, aDataLength);
 
-    SuccessOrExit(error = CopyNetworkData(aStable, netDataCopy));
+    SuccessOrExit(error = CopyNetworkData(aType, netDataCopy));
     aDataLength = netDataCopy.GetLength();
 
 exit:
     return error;
 }
 
-Error NetworkData::CopyNetworkData(bool aStable, MutableNetworkData &aNetworkData) const
+Error NetworkData::CopyNetworkData(Type aType, MutableNetworkData &aNetworkData) const
 {
     Error error = kErrorNone;
 
@@ -68,7 +68,7 @@ Error NetworkData::CopyNetworkData(bool aStable, MutableNetworkData &aNetworkDat
     memcpy(aNetworkData.GetBytes(), mTlvs, mLength);
     aNetworkData.SetLength(mLength);
 
-    if (aStable)
+    if (aType == kStableSubset)
     {
         aNetworkData.RemoveTemporaryData();
     }

--- a/src/core/thread/network_data.hpp
+++ b/src/core/thread/network_data.hpp
@@ -168,28 +168,28 @@ public:
     /**
      * This method provides full or stable copy of the Thread Network Data.
      *
-     * @param[in]    aStable      TRUE when copying the stable version, FALSE when copying the full version.
+     * @param[in]    aType        The Network Data type to copy, the full set or stable subset.
      * @param[out]   aData        A pointer to the data buffer to copy the Network Data into.
      * @param[inout] aDataLength  On entry, size of the data buffer pointed to by @p aData.
      *                            On exit, number of copied bytes.
      *
-     * @retval kErrorNone       Successfully copied full Thread Network Data.
+     * @retval kErrorNone       Successfully copied Thread Network Data.
      * @retval kErrorNoBufs     Not enough space in @p aData to fully copy Thread Network Data.
      *
      */
-    Error CopyNetworkData(bool aStable, uint8_t *aData, uint8_t &aDataLength) const;
+    Error CopyNetworkData(Type aType, uint8_t *aData, uint8_t &aDataLength) const;
 
     /**
      * This method provides full or stable copy of the Thread Network Data.
      *
-     * @param[in]    aStable      TRUE when copying the stable version, FALSE when copying the full version.
+     * @param[in]    aType        The Network Data type to copy, the full set or stable subset.
      * @param[out]   aNetworkData A reference to a `MutableNetworkData` to copy the Network Data into.
      *
-     * @retval kErrorNone       Successfully copied full Thread Network Data.
+     * @retval kErrorNone       Successfully copied Thread Network Data.
      * @retval kErrorNoBufs     Not enough space in @p aNetworkData to fully copy Thread Network Data.
      *
      */
-    Error CopyNetworkData(bool aStable, MutableNetworkData &aNetworkData) const;
+    Error CopyNetworkData(Type aType, MutableNetworkData &aNetworkData) const;
 
     /**
      * This method provides the next On Mesh prefix in the Thread Network Data.

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -346,7 +346,7 @@ Error LeaderBase::DefaultRouteLookup(const PrefixTlv &aPrefix, uint16_t *aRloc16
 
 Error LeaderBase::SetNetworkData(uint8_t        aVersion,
                                  uint8_t        aStableVersion,
-                                 bool           aStableOnly,
+                                 Type           aType,
                                  const Message &aMessage,
                                  uint16_t       aMessageOffset)
 {
@@ -363,7 +363,7 @@ Error LeaderBase::SetNetworkData(uint8_t        aVersion,
     mVersion       = aVersion;
     mStableVersion = aStableVersion;
 
-    if (aStableOnly)
+    if (aType == kStableSubset)
     {
         RemoveTemporaryData();
     }

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -85,20 +85,14 @@ public:
     void Reset(void);
 
     /**
-     * This method returns the Thread Network Data version.
+     * This method returns the Data Version value for a type (full set or stable subset).
      *
-     * @returns The Thread Network Data version.
+     * @param[in] aType   The Network Data type (full set or stable subset).
      *
-     */
-    uint8_t GetVersion(void) const { return mVersion; }
-
-    /**
-     * This method returns the Thread Network Data stable version.
-     *
-     * @returns The Thread Network Data stable version.
+     * @returns The Data Version value for @p aType.
      *
      */
-    uint8_t GetStableVersion(void) const { return mStableVersion; }
+    uint8_t GetVersion(Type aType) const { return (aType == kFullSet) ? mVersion : mStableVersion; }
 
     /**
      * This method retrieves the 6LoWPAN Context information based on a given IPv6 address.
@@ -157,7 +151,7 @@ public:
      *
      * @param[in]  aVersion        The Version value.
      * @param[in]  aStableVersion  The Stable Version value.
-     * @param[in]  aStableOnly     TRUE if storing only the stable data, FALSE otherwise.
+     * @param[in]  aType           The Network Data type to set, the full set or stable subset.
      * @param[in]  aMessage        A reference to the MLE message.
      * @param[in]  aMessageOffset  The offset in @p aMessage for the Network Data TLV.
      *
@@ -167,7 +161,7 @@ public:
      */
     Error SetNetworkData(uint8_t        aVersion,
                          uint8_t        aStableVersion,
-                         bool           aStableOnly,
+                         Type           aType,
                          const Message &aMessage,
                          uint16_t       aMessageOffset);
 

--- a/src/core/thread/network_data_types.hpp
+++ b/src/core/thread/network_data_types.hpp
@@ -69,6 +69,16 @@ class ServiceTlv;
 class ServerTlv;
 
 /**
+ * This enumeration represents the Network Data type.
+ *
+ */
+enum Type : uint8_t
+{
+    kFullSet,      ///< Full Network Data set.
+    kStableSubset, ///< Stable Network Data subset.
+};
+
+/**
  * This enumeration type represents the route preference values as a signed integer (per RFC-4191).
  *
  */

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -346,8 +346,8 @@ Error NetworkDiagnostic::FillRequestedTlvs(const Message &       aRequest,
             tlv.Init();
             tlv.SetPartitionId(leaderData.GetPartitionId());
             tlv.SetWeighting(leaderData.GetWeighting());
-            tlv.SetDataVersion(leaderData.GetDataVersion());
-            tlv.SetStableDataVersion(leaderData.GetStableDataVersion());
+            tlv.SetDataVersion(leaderData.GetDataVersion(NetworkData::kFullSet));
+            tlv.SetStableDataVersion(leaderData.GetDataVersion(NetworkData::kStableSubset));
             tlv.SetLeaderRouterId(leaderData.GetLeaderRouterId());
 
             SuccessOrExit(error = tlv.AppendTo(aResponse));
@@ -646,7 +646,7 @@ static inline void ParseMode(const Mle::DeviceMode &aMode, otLinkModeConfig &aLi
 {
     aLinkModeConfig.mRxOnWhenIdle = aMode.IsRxOnWhenIdle();
     aLinkModeConfig.mDeviceType   = aMode.IsFullThreadDevice();
-    aLinkModeConfig.mNetworkData  = aMode.IsFullNetworkData();
+    aLinkModeConfig.mNetworkData  = (aMode.GetNetworkDataType() == NetworkData::kFullSet);
 }
 
 static inline void ParseConnectivity(const ConnectivityTlv &    aConnectivityTlv,

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -79,7 +79,7 @@ void Neighbor::Info::SetFrom(const Neighbor &aNeighbor)
     mMessageErrorRate = aNeighbor.GetLinkInfo().GetMessageErrorRate();
     mRxOnWhenIdle     = aNeighbor.IsRxOnWhenIdle();
     mFullThreadDevice = aNeighbor.IsFullThreadDevice();
-    mFullNetworkData  = aNeighbor.IsFullNetworkData();
+    mFullNetworkData  = (aNeighbor.GetNetworkDataType() == NetworkData::kFullSet);
 }
 
 void Neighbor::Init(Instance &aInstance)
@@ -242,7 +242,7 @@ void Child::Info::SetFrom(const Child &aChild)
     mVersion            = aChild.GetVersion();
     mRxOnWhenIdle       = aChild.IsRxOnWhenIdle();
     mFullThreadDevice   = aChild.IsFullThreadDevice();
-    mFullNetworkData    = aChild.IsFullNetworkData();
+    mFullNetworkData    = (aChild.GetNetworkDataType() == NetworkData::kFullSet);
     mIsStateRestoring   = aChild.IsStateRestoring();
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     mIsCslSynced = aChild.IsCslSynchronized();

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -56,6 +56,7 @@
 #include "thread/link_quality.hpp"
 #include "thread/mle_tlvs.hpp"
 #include "thread/mle_types.hpp"
+#include "thread/network_data_types.hpp"
 #include "thread/radio_selector.hpp"
 
 namespace ot {
@@ -353,12 +354,12 @@ public:
     bool IsFullThreadDevice(void) const { return GetDeviceMode().IsFullThreadDevice(); }
 
     /**
-     * This method indicates whether or not the device requests Full Network Data.
+     * This method gets the Network Data type (full set or stable subset) that the device requests.
      *
-     * @returns TRUE if requests Full Network Data, FALSE otherwise.
+     * @returns The Network Data type.
      *
      */
-    bool IsFullNetworkData(void) const { return GetDeviceMode().IsFullNetworkData(); }
+    NetworkData::Type GetNetworkDataType(void) const { return GetDeviceMode().GetNetworkDataType(); }
 
     /**
      * This method sets all bytes of the Extended Address to zero.

--- a/src/core/utils/history_tracker.cpp
+++ b/src/core/utils/history_tracker.cpp
@@ -345,7 +345,7 @@ void HistoryTracker::RecordNetworkDataChange(void)
         }
     }
 
-    SuccessOrAssert(Get<NetworkData::Leader>().CopyNetworkData(/* aSatble */ false, mPreviousNetworkData));
+    SuccessOrAssert(Get<NetworkData::Leader>().CopyNetworkData(NetworkData::kFullSet, mPreviousNetworkData));
 }
 
 void HistoryTracker::RecordOnMeshPrefixEvent(NetDataEvent aEvent, const NetworkData::OnMeshPrefixConfig &aPrefix)

--- a/src/core/utils/otns.cpp
+++ b/src/core/utils/otns.cpp
@@ -155,7 +155,7 @@ void Otns::EmitTransmit(const Mac::TxFrame &aFrame)
 void Otns::EmitDeviceMode(Mle::DeviceMode aMode)
 {
     EmitStatus("mode=%s%s%s", aMode.IsRxOnWhenIdle() ? "r" : "", aMode.IsFullThreadDevice() ? "d" : "",
-               aMode.IsFullNetworkData() ? "n" : "");
+               (aMode.GetNetworkDataType() == NetworkData::kFullSet) ? "n" : "");
 }
 
 void Otns::EmitCoapSend(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -129,7 +129,7 @@ static void Init(void)
 
     SuccessOrQuit(message->AppendBytes(mockNetworkData, sizeof(mockNetworkData)));
 
-    IgnoreError(sInstance->Get<NetworkData::Leader>().SetNetworkData(0, 0, true, *message, 0));
+    IgnoreError(sInstance->Get<NetworkData::Leader>().SetNetworkData(0, 0, NetworkData::kStableSubset, *message, 0));
 }
 
 /**


### PR DESCRIPTION
This commit adds `NetworkData::Type` enumeration to indicate full set
or stable subset. It also adds helper method `GetNetworkDataType()`
in `Neighbor` and `Mle` to indicate what type of Network Data device
requests.