### PR TITLE
[coex] add an option to control default coex state

### DIFF
--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -139,7 +139,7 @@ static uint32_t sCslPeriod;
 #endif
 
 #if OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE
-static bool sRadioCoexEnabled = true;
+static bool sRadioCoexEnabled = OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_DEFAULT_ON;
 #endif
 
 otRadioCaps gRadioCaps =

--- a/src/core/config/platform.h
+++ b/src/core/config/platform.h
@@ -108,6 +108,18 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_DEFAULT_ON
+ *
+ * Define to 1 if you want to turn on radio coexistence implemented in platform during initialization. This option
+ * only takes effect when `OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE` is set. When this option is set, coex will
+ * be turned on during initialization. Otherwise, coex needs to be turned on manually.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_DEFAULT_ON
+#define OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_DEFAULT_ON 1
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_PLATFORM_RADIO_SPINEL_RX_FRAME_BUFFER_SIZE
  *
  * Specifies the rx frame buffer size used by `SpinelInterface` in RCP host (posix) code. This is applicable/used when


### PR DESCRIPTION
For some developing products, we may expect that the coex code is enabled in the build but it's not turned on by default/