### PR TITLE
[github-actions] set fail-fast=false for border router tests

### DIFF
--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -132,6 +132,7 @@ jobs:
   thread-border-router:
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - otbr_mdns: "mDNSResponder"


### PR DESCRIPTION
This commit sets set fail-fast=false for border router tests.