### PR TITLE
[common] add `SerialNumber::Is{Greater/Less}>()`

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -422,6 +422,7 @@ openthread_core_files = [
   "common/random_manager.cpp",
   "common/random_manager.hpp",
   "common/retain_ptr.hpp",
+  "common/serial_number.hpp",
   "common/settings.cpp",
   "common/settings.hpp",
   "common/settings_driver.hpp",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -455,6 +455,7 @@ HEADERS_COMMON                                  = \
     common/random.hpp                             \
     common/random_manager.hpp                     \
     common/retain_ptr.hpp                         \
+    common/serial_number.hpp                      \
     common/settings.hpp                           \
     common/settings_driver.hpp                    \
     common/string.hpp                             \

--- a/src/core/common/serial_number.hpp
+++ b/src/core/common/serial_number.hpp
@@ -1,0 +1,100 @@
+/*
+ *  Copyright (c) 2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for serial number comparison similar to RFC-1982.
+ */
+
+#ifndef SERIAL_NUMBER_HPP_
+#define SERIAL_NUMBER_HPP_
+
+#include "openthread-core-config.h"
+
+#include <stdint.h>
+
+#include "common/numeric_limits.hpp"
+#include "common/type_traits.hpp"
+
+namespace ot {
+
+class SerialNumber
+{
+public:
+    /**
+     * This static method indicates whether or not a first serial number is strictly less than a second serial number.
+     *
+     * The comparison takes into account the wrapping of serial number values (similar to RFC-1982). It is semantically
+     * equivalent to `aFirst < aSecond`.
+     *
+     * @tparam UintType    The unsigned integer type.
+     *
+     * @param[in] aFirst   The first serial number.
+     * @param[in] aSecond  The second serial number.
+     *
+     * @retval TRUE  If @p aFirst is less than @p aSecond.
+     * @retval FALSE If @p aFirst is not less than @p aSecond.
+     *
+     */
+    template <typename UintType> static bool IsLess(UintType aFirst, UintType aSecond)
+    {
+        static_assert(TypeTraits::IsSame<UintType, uint8_t>::kValue || TypeTraits::IsSame<UintType, uint16_t>::kValue ||
+                          TypeTraits::IsSame<UintType, uint32_t>::kValue ||
+                          TypeTraits::IsSame<UintType, uint64_t>::kValue,
+                      "UintType MUST be an 8, 16, 32, or 64 bit `uint` type");
+
+        static constexpr UintType kNegativeMask = (NumericLimits<UintType>::kMax >> 1) + 1;
+
+        return ((aFirst - aSecond) & kNegativeMask) != 0;
+    }
+
+    /**
+     * This static method indicates whether or not a first serial number is strictly greater than a second serial
+     * number.
+     *
+     * The comparison takes into account the wrapping of serial number values (similar to RFC-1982). It is semantically
+     * equivalent to `aFirst > aSecond`.
+     *
+     * @tparam UintType    The unsigned integer type.
+     *
+     * @param[in] aFirst   The first serial number.
+     * @param[in] aSecond  The second serial number.
+     *
+     * @retval TRUE  If @p aFirst is greater than @p aSecond.
+     * @retval FALSE If @p aFirst is not greater than @p aSecond.
+     *
+     */
+    template <typename UintType> static bool IsGreater(UintType aFirst, UintType aSecond)
+    {
+        return IsLess(aSecond, aFirst);
+    }
+};
+
+} // namespace ot
+
+#endif // SERIAL_NUMBER_HPP_

--- a/src/core/common/time.hpp
+++ b/src/core/common/time.hpp
@@ -40,6 +40,7 @@
 #include <stdint.h>
 
 #include "common/equatable.hpp"
+#include "common/serial_number.hpp"
 
 namespace ot {
 
@@ -178,7 +179,7 @@ public:
      * @retval FALSE   This `Time` instance is not strictly before @p aOther.
      *
      */
-    bool operator<(const Time &aOther) const { return ((mValue - aOther.mValue) & (1UL << 31)) != 0; }
+    bool operator<(const Time &aOther) const { return SerialNumber::IsLess(mValue, aOther.mValue); }
 
     /**
      * This method indicates whether this `Time` instance is after or equal to another one.

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -38,6 +38,7 @@
 #include "common/locator_getters.hpp"
 #include "common/message.hpp"
 #include "common/random.hpp"
+#include "common/serial_number.hpp"
 #include "net/ip6.hpp"
 
 namespace ot {
@@ -187,14 +188,12 @@ Error Mpl::UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence)
         {
             // have existing entries for aSeedId
 
-            int8_t diff = static_cast<int8_t>(aSequence - mSeedSet[i].mSequence);
-
-            if (diff == 0)
+            if (aSequence == mSeedSet[i].mSequence)
             {
                 // already received, drop message
                 ExitNow(error = kErrorDrop);
             }
-            else if (insert == nullptr && diff < 0)
+            else if (insert == nullptr && SerialNumber::IsLess(aSequence, mSeedSet[i].mSequence))
             {
                 // insert in order of sequence
                 insert = &mSeedSet[i];

--- a/src/core/thread/network_data_service.hpp
+++ b/src/core/thread/network_data_service.hpp
@@ -42,6 +42,7 @@
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
+#include "common/serial_number.hpp"
 #include "net/socket.hpp"
 #include "thread/network_data_tlvs.hpp"
 
@@ -189,7 +190,7 @@ public:
          */
         bool IsSequenceNumberAheadOf(const Info &aOther) const
         {
-            return (((aOther.mSequenceNumber - mSequenceNumber) & (1U << 7)) != 0);
+            return SerialNumber::IsGreater(mSequenceNumber, aOther.mSequenceNumber);
         }
 
         Ip6::Address mAnycastAddress; ///< The anycast address associated with the DNS/SRP servers.

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -45,6 +45,7 @@
 #include "common/locator.hpp"
 #include "common/message.hpp"
 #include "common/random.hpp"
+#include "common/serial_number.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_types.hpp"
 #include "net/ip6.hpp"
@@ -546,7 +547,7 @@ public:
      * before @p aTag.
      *
      */
-    bool IsLastRxFragmentTagAfter(uint16_t aTag) const { return ((aTag - mLastRxFragmentTag) & (1U << 15)) != 0; }
+    bool IsLastRxFragmentTagAfter(uint16_t aTag) const { return SerialNumber::IsGreater(mLastRxFragmentTag, aTag); }
 
 #endif // OPENTHREAD_CONFIG_MULTI_RADIO
 

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -769,6 +769,27 @@ target_link_libraries(ot-test-meshcop
 
 add_test(NAME ot-test-meshcop COMMAND ot-test-meshcop)
 
+add_executable(ot-test-serial-number
+    test_serial_number.cpp
+)
+
+target_include_directories(ot-test-serial-number
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_options(ot-test-serial-number
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
+target_link_libraries(ot-test-serial-number
+    PRIVATE
+        ${COMMON_LIBS}
+)
+
+add_test(NAME ot-test-serial-number COMMAND ot-test-serial-number)
+
 add_executable(ot-test-string
     test_string.cpp
 )

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -140,6 +140,7 @@ check_PROGRAMS                                                     += \
     ot-test-pool                                                      \
     ot-test-priority-queue                                            \
     ot-test-pskc                                                      \
+    ot-test-serial-number                                             \
     ot-test-smart-ptrs                                                \
     ot-test-string                                                    \
     ot-test-timer                                                     \
@@ -287,6 +288,9 @@ ot_test_smart_ptrs_SOURCES      = $(COMMON_SOURCES) test_smart_ptrs.cpp
 
 ot_test_meshcop_LDADD           = $(COMMON_LDADD)
 ot_test_meshcop_SOURCES         = $(COMMON_SOURCES) test_meshcop.cpp
+
+ot_test_serial_number_LDADD     = $(COMMON_LDADD)
+ot_test_serial_number_SOURCES   = $(COMMON_SOURCES) test_serial_number.cpp
 
 ot_test_string_LDADD            = $(COMMON_LDADD)
 ot_test_string_SOURCES          = $(COMMON_SOURCES) test_string.cpp

--- a/tests/unit/test_serial_number.cpp
+++ b/tests/unit/test_serial_number.cpp
@@ -1,0 +1,78 @@
+/*
+ *  Copyright (c) 2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_platform.h"
+
+#include <openthread/config.h>
+
+#include "test_util.h"
+#include "common/code_utils.hpp"
+#include "common/numeric_limits.hpp"
+#include "common/serial_number.hpp"
+
+namespace ot {
+
+template <typename UintType> void TestSerialNumber(const char *aName)
+{
+    static constexpr UintType kMax = NumericLimits<UintType>::kMax;
+    static constexpr UintType kMid = kMax / 2;
+
+    static const UintType kNumbers[] = {0, 1, 20, kMid - 1, kMid, kMid + 1, kMax - 20, kMax - 1, kMax};
+
+    for (UintType number : kNumbers)
+    {
+        VerifyOrQuit(!SerialNumber::IsGreater<UintType>(number, number));
+        VerifyOrQuit(!SerialNumber::IsLess<UintType>(number, number));
+
+        VerifyOrQuit(SerialNumber::IsGreater<UintType>(number + 1, number));
+        VerifyOrQuit(SerialNumber::IsGreater<UintType>(number + kMid - 1, number));
+        VerifyOrQuit(SerialNumber::IsGreater<UintType>(number + kMid, number));
+        VerifyOrQuit(!SerialNumber::IsGreater<UintType>(number + kMid + 2, number));
+        VerifyOrQuit(!SerialNumber::IsGreater<UintType>(number + kMax - 1, number));
+
+        VerifyOrQuit(SerialNumber::IsLess<UintType>(number - 1, number));
+        VerifyOrQuit(SerialNumber::IsLess<UintType>(number - kMid + 1, number));
+        VerifyOrQuit(SerialNumber::IsLess<UintType>(number - kMid, number));
+        VerifyOrQuit(!SerialNumber::IsLess<UintType>(number - kMid - 2, number));
+        VerifyOrQuit(!SerialNumber::IsLess<UintType>(number - kMax + 1, number));
+    }
+
+    printf("TestSerialNumber<%s>() passed\n", aName);
+}
+
+} // namespace ot
+
+int main(void)
+{
+    ot::TestSerialNumber<uint8_t>("uint8_t");
+    ot::TestSerialNumber<uint16_t>("uint16_t");
+    ot::TestSerialNumber<uint32_t>("uint32_t");
+    ot::TestSerialNumber<uint64_t>("uint64_t");
+    printf("\nAll tests passed.\n");
+    return 0;
+}


### PR DESCRIPTION
This commit adds `SerialNumber` class which provides `static` methods
`IsGeater<UintType>()` and `IsLess<UintType()` to compare two serial
numbers, taking into account the wrapping of serial number values
(similar to RFC-1982). This is then used in `MleRouter` and other
modules. This helps us avoid casting of `uint` to `int` for the
comparison (such a casting is undefined behavior in C++11 though
toolchains often implement it as expected). This commit also adds a
unit test `test_serial_number` to validate the new methods.