### PR TITLE
[tcp] fix minor bugs

### DIFF
--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -450,10 +450,10 @@ void TcpExample::HandleTcpDisconnected(otTcpEndpoint *aEndpoint, otTcpDisconnect
 {
     static const char *const kReasonStrings[] = {
         "Disconnected",            // (0) OT_TCP_DISCONNECTED_REASON_NORMAL
-        "Entered TIME-WAIT state", // (1) OT_TCP_DISCONNECTED_REASON_REFUSED
-        "Connection timed out",    // (2) OT_TCP_DISCONNECTED_REASON_RESET
-        "Connection refused",      // (3) OT_TCP_DISCONNECTED_REASON_TIME_WAIT
-        "Connection reset",        // (4) OT_TCP_DISCONNECTED_REASON_TIMED_OUT
+        "Connection refused",      // (1) OT_TCP_DISCONNECTED_REASON_REFUSED
+        "Connection reset",        // (2) OT_TCP_DISCONNECTED_REASON_RESET
+        "Entered TIME-WAIT state", // (3) OT_TCP_DISCONNECTED_REASON_TIME_WAIT
+        "Connection timed out",    // (4) OT_TCP_DISCONNECTED_REASON_TIMED_OUT
     };
 
     OT_UNUSED_VARIABLE(aEndpoint);

--- a/third_party/tcplp/bsdtcp/tcp_reass.c
+++ b/third_party/tcplp/bsdtcp/tcp_reass.c
@@ -57,7 +57,7 @@ tcp_reass(struct tcpcb* tp, struct tcphdr* th, int* tlenp, otMessage* data, off_
 	size_t offset;
 	size_t start_index;
 	size_t usedbefore;
-	int tlen = *tlenp;
+	int tlen;
 	size_t merged = 0;
 	int flags = 0;
 
@@ -67,6 +67,8 @@ tcp_reass(struct tcpcb* tp, struct tcphdr* th, int* tlenp, otMessage* data, off_
 	 */
 	if (th == NULL)
 		goto present;
+
+	tlen = *tlenp;
 
 	/* Insert the new segment queue entry into place. */
 	KASSERT(SEQ_GEQ(th->th_seq, tp->rcv_nxt), ("Adding past segment to the reassembly queue\n"));


### PR DESCRIPTION
This pull request fixes minor bugs in TCP.

1. The first change fixes a bug where the TCP CLI prints out an incorrect message when a connection is terminated. This appears to have been introduced in #7279.
2. The second change fixes a null pointer dereference when accepting a TCP connection. This issue is purely theoretical at the moment, because in the case where the dereferenced pointer is NULL, the dereferenced value is not used, and so the compiler optimizes out the memory access (so it seems). As a result, TCP actually runs without issues. But I've fixed it anyway, to avoid depending on that behavior.