### PR TITLE
[ip6] always enable ICMP6 filtering when forwarding to Thread

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1269,7 +1269,7 @@ start:
         hopLimit = header.GetHopLimit();
         aMessage.Write(Header::kHopLimitFieldOffset, hopLimit);
 
-        if (aFromNcpHost && nextHeader == kProtoIcmp6)
+        if (nextHeader == kProtoIcmp6)
         {
             uint8_t icmpType;
             bool    isAllowedType = false;


### PR DESCRIPTION
After #7187, we've observed MLDv2, RS and other ICMPv6 packets from the kernel forwarded to the Thread network. This is caused by the ICMP6 type check turned off by aFromNcpHost.

The PR turns ICMP filtering to always on when forwarding to the Thread network.