### PR TITLE
[cli] inline simple sub-command process methods

### DIFF
--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -407,12 +407,7 @@ private:
     otError ProcessFem(Arg aArgs[]);
     otError ProcessIfconfig(Arg aArgs[]);
     otError ProcessIpAddr(Arg aArgs[]);
-    otError ProcessIpAddrAdd(Arg aArgs[]);
-    otError ProcessIpAddrDel(Arg aArgs[]);
     otError ProcessIpMulticastAddr(Arg aArgs[]);
-    otError ProcessIpMulticastAddrAdd(Arg aArgs[]);
-    otError ProcessIpMulticastAddrDel(Arg aArgs[]);
-    otError ProcessMulticastPromiscuous(Arg aArgs[]);
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
     otError ProcessJoiner(Arg aArgs[]);
 #endif
@@ -445,8 +440,6 @@ private:
 #endif
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE && OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
     otError ProcessMlr(Arg aArgs[]);
-
-    otError ProcessMlrReg(Arg aArgs[]);
 
     static void HandleMlrRegResult(void *              aContext,
                                    otError             aError,
@@ -497,9 +490,6 @@ private:
     otError ProcessPollPeriod(Arg aArgs[]);
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
     otError ProcessPrefix(Arg aArgs[]);
-    otError ProcessPrefixAdd(Arg aArgs[]);
-    otError ProcessPrefixRemove(Arg aArgs[]);
-    otError ProcessPrefixList(void);
 #endif
     otError ProcessPromiscuous(Arg aArgs[]);
 #if OPENTHREAD_FTD
@@ -519,9 +509,6 @@ private:
 #endif
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
     otError ProcessRoute(Arg aArgs[]);
-    otError ProcessRouteAdd(Arg aArgs[]);
-    otError ProcessRouteRemove(Arg aArgs[]);
-    otError ProcessRouteList(void);
 #endif
 #if OPENTHREAD_FTD
     otError ProcessRouter(Arg aArgs[]);
@@ -558,10 +545,6 @@ private:
     otError ProcessMacFilterRss(Arg aArgs[]);
 #endif
     otError ProcessMac(Arg aArgs[]);
-    otError ProcessMacRetries(Arg aArgs[]);
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    otError ProcessMacSend(Arg aArgs[]);
-#endif
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
     otError ProcessTrel(Arg aArgs[]);
 #endif


### PR DESCRIPTION


----

- The main intention behind this PR is to simplify and harmonize the CLI 
  `Process{Command}()` methods.
- This can help us move to new model later (in a future PR) where we can use
  template specializations for each `Process<Command>` rather than defining different
  methods (which in turn can help simplify the command lookup table  maintenance).