### PR TITLE
[address-resolver] add `LookUp()` method to check cache entries

### DIFF
--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -508,9 +508,7 @@ NdProxyTable &Manager::GetNdProxyTable(void)
 
 bool Manager::ShouldForwardDuaToBackbone(const Ip6::Address &aAddress)
 {
-    bool              forwardToBackbone = false;
-    Mac::ShortAddress rloc16;
-    Error             error;
+    bool forwardToBackbone = false;
 
     VerifyOrExit(Get<Local>().IsPrimary());
     VerifyOrExit(Get<Leader>().IsDomainUnicast(aAddress));
@@ -519,9 +517,8 @@ bool Manager::ShouldForwardDuaToBackbone(const Ip6::Address &aAddress)
     VerifyOrExit(!mNdProxyTable.IsRegistered(aAddress.GetIid()));
     // Do not forward to Backbone if the DUA belongs to a MTD Child (which may have failed in DUA registration)
     VerifyOrExit(Get<NeighborTable>().FindNeighbor(aAddress) == nullptr);
-    // Forawrd to Backbone only if the DUA is resolved to the PBBR's RLOC16
-    error = Get<AddressResolver>().Resolve(aAddress, rloc16, /* aAllowAddressQuery */ false);
-    VerifyOrExit(error == kErrorNone && rloc16 == Get<Mle::MleRouter>().GetRloc16());
+    // Forward to Backbone only if the DUA is resolved to the PBBR's RLOC16
+    VerifyOrExit(Get<AddressResolver>().LookUp(aAddress) == Get<Mle::MleRouter>().GetRloc16());
 
     forwardToBackbone = true;
 

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -459,6 +459,14 @@ void AddressResolver::RestartAddressQueries(void)
     }
 }
 
+Mac::ShortAddress AddressResolver::LookUp(const Ip6::Address &aEid)
+{
+    Mac::ShortAddress rloc16 = Mac::kShortAddrInvalid;
+
+    IgnoreError(Resolve(aEid, rloc16, /* aAllowAddressQuery */ false));
+    return rloc16;
+}
+
 Error AddressResolver::Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRloc16, bool aAllowAddressQuery)
 {
     Error           error = kErrorNone;
@@ -474,6 +482,7 @@ Error AddressResolver::Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRlo
         // allocate a new entry and perform address query. We do not
         // allow first-time address query entries to be evicted till
         // timeout.
+
         VerifyOrExit(aAllowAddressQuery, error = kErrorNotFound);
 
         entry = NewCacheEntry(/* aSnoopedEntry */ false);
@@ -503,9 +512,12 @@ Error AddressResolver::Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRlo
         ExitNow();
     }
 
-    // Note that if `aAllowAddressQuery` is `false` then the `entry` is definitely already in a list, i.e., we cannot
-    // not get here with `aAllowAddressQuery` being `false` and `entry` being a newly allocated one, due to the
-    // `VerifyOrExit` check that `aAllowAddressQuery` is `true` before allocating a new cache entry.
+    // Note that if `aAllowAddressQuery` is `false` then the `entry`
+    // is definitely already in a list, i.e., we cannot not get here
+    // with `aAllowAddressQuery` being `false` and `entry` being a
+    // newly allocated one, due to the `VerifyOrExit` check that
+    // `aAllowAddressQuery` is `true` before allocating a new cache
+    // entry.
     VerifyOrExit(aAllowAddressQuery, error = kErrorNotFound);
 
     if (list == &mQueryList)

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -145,21 +145,31 @@ public:
     void UpdateSnoopedCacheEntry(const Ip6::Address &aEid, Mac::ShortAddress aRloc16, Mac::ShortAddress aDest);
 
     /**
-     * This method returns the RLOC16 for a given EID, initiates an Address Query if allowed and the mapping is not
-     * known.
+     * This method returns the RLOC16 for a given EID, initiates an Address Query if the mapping is not known.
      *
      * @param[in]   aEid                A reference to the EID.
      * @param[out]  aRloc16             The RLOC16 corresponding to @p aEid.
-     * @param[in]   aAllowAddressQuery  Allow to initiate Address Query if the mapping is not known.
      *
      * @retval kErrorNone           Successfully provided the RLOC16.
      * @retval kErrorAddressQuery   Initiated an Address Query if allowed.
      * @retval kErrorDrop           Earlier Address Query for the EID timed out. In retry timeout interval.
      * @retval kErrorNoBufs         Insufficient buffer space available to send Address Query.
-     * @retval kErrorNotFound       The mapping was not found and Address Query was not allowed.
      *
      */
-    Error Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRloc16, bool aAllowAddressQuery = true);
+    Error Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRloc16)
+    {
+        return Resolve(aEid, aRloc16, /* aAllowAddressQuery */ true);
+    }
+
+    /**
+     * This method looks up the RLOC16 for a given EID in the address cache.
+     *
+     * @param[in]   aEid                A reference to the EID.
+     *
+     * @returns The RLOC16 mapping to @p aEid or `Mac::kShortAddrInvalid` if it is not found in the address cache.
+     *
+     */
+    Mac::ShortAddress LookUp(const Ip6::Address &aEid);
 
     /**
      * This method restarts any ongoing address queries.
@@ -295,6 +305,7 @@ private:
 
     CacheEntryPool &GetCacheEntryPool(void) { return mCacheEntryPool; }
 
+    Error       Resolve(const Ip6::Address &aEid, Mac::ShortAddress &aRloc16, bool aAllowAddressQuery);
     void        Remove(Mac::ShortAddress aRloc16, bool aMatchRouterId);
     void        Remove(const Ip6::Address &aEid, Reason aReason);
     CacheEntry *FindCacheEntry(const Ip6::Address &aEid, CacheEntryList *&aList, CacheEntry *&aPrevEntry);

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -188,15 +188,13 @@ void MeshForwarder::HandleResolved(const Ip6::Address &aEid, Error aError)
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
 Error MeshForwarder::ForwardDuaToBackboneLink(Message &aMessage, const Ip6::Address &aDst)
 {
-    Error    error = kErrorNone;
-    uint16_t dstRloc16;
-    uint8_t  ttl;
+    Error   error = kErrorNone;
+    uint8_t ttl;
 
     VerifyOrExit(Get<BackboneRouter::Local>().IsPrimary() && Get<BackboneRouter::Leader>().IsDomainUnicast(aDst),
                  error = kErrorNoRoute);
 
-    IgnoreError(Get<AddressResolver>().Resolve(aDst, dstRloc16, /* aAllowAddressQuery */ false));
-    VerifyOrExit(dstRloc16 == Get<Mle::MleRouter>().GetRloc16(), error = kErrorNoRoute);
+    VerifyOrExit(Get<AddressResolver>().LookUp(aDst) == Get<Mle::MleRouter>().GetRloc16(), error = kErrorNoRoute);
 
     // Avoid decreasing TTL twice
     IgnoreError(aMessage.Read(Ip6::Header::kHopLimitFieldOffset, ttl));


### PR DESCRIPTION
This commit adds `AddressResolver::LookUp()` method which resolves
an EID to an RLOC17 by checking if an existing entry already exists
in the address cache table.