### PR TITLE
[coap] add `otCoapMessageSetCode` (#7339)

### DIFF
--- a/include/openthread/coap.h
+++ b/include/openthread/coap.h
@@ -718,6 +718,15 @@ otCoapType otCoapMessageGetType(const otMessage *aMessage);
 otCoapCode otCoapMessageGetCode(const otMessage *aMessage);
 
 /**
+ * This function sets the Code value.
+ *
+ * @param[inout]  aMessage  A pointer to the CoAP message to initialize.
+ * @param[in]     aCode     CoAP message code.
+ *
+ */
+void otCoapMessageSetCode(otMessage *aMessage, otCoapCode aCode);
+
+/**
  * This method returns the CoAP Code as human readable string.
  *
  * @param[in]   aMessage    A pointer to the CoAP message.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (186)
+#define OPENTHREAD_API_VERSION (187)
 
 /**
  * @addtogroup api-instance

--- a/src/core/api/coap_api.cpp
+++ b/src/core/api/coap_api.cpp
@@ -144,6 +144,11 @@ otCoapCode otCoapMessageGetCode(const otMessage *aMessage)
     return static_cast<otCoapCode>(AsCoapMessage(aMessage).GetCode());
 }
 
+void otCoapMessageSetCode(otMessage *aMessage, otCoapCode aCode)
+{
+    AsCoapMessage(aMessage).SetCode(MapEnum(aCode));
+}
+
 const char *otCoapMessageCodeToString(const otMessage *aMessage)
 {
     return AsCoapMessage(aMessage).CodeToString();


### PR DESCRIPTION
Provide a setter for the message code to change it after
initialization of the message.

This complements the existing getter function 'otCoapMessageGetCode'.