### PR TITLE
[ip6] remove `UNSECURE_TRAFFIC_MANAGED_BY_STACK_ENABLE` config

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -73,7 +73,6 @@ ifeq ($(USE_OTBR_DAEMON), 1)
 OPENTHREAD_PUBLIC_CFLAGS                                         += \
     -DOPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE=1                     \
     -DOPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE=1                       \
-    -DOPENTHREAD_CONFIG_UNSECURE_TRAFFIC_MANAGED_BY_STACK_ENABLE=1  \
     -DOPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE=1                       \
     $(NULL)
 else

--- a/src/core/config/ip6.h
+++ b/src/core/config/ip6.h
@@ -161,23 +161,6 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_UNSECURE_TRAFFIC_MANAGED_BY_STACK_ENABLE
- *
- * Define as 1 to enable dynamic unsecure port management
- *
- * If this feature is enabled, OpenThread will automaitically disable link-level
- * security for packets sent with unsecure source ports. Once we receive a secure
- * packet sent to the unsecure port, this port will be removed from the unsecure
- * port list.
- *
- * Enable only if you know well about its behavior.
- *
- */
-#ifndef OPENTHREAD_CONFIG_UNSECURE_TRAFFIC_MANAGED_BY_STACK_ENABLE
-#define OPENTHREAD_CONFIG_UNSECURE_TRAFFIC_MANAGED_BY_STACK_ENABLE 0
-#endif
-
-/**
  * @def OPENTHREAD_CONFIG_TCP_ENABLE
  *
  * Define as 1 to enable TCP.

--- a/src/core/config/openthread-core-config-check.h
+++ b/src/core/config/openthread-core-config-check.h
@@ -526,4 +526,8 @@
 #error "OPENTHREAD_CONFIG_PLAT_LOG_FUNCTION was removed and no longer supported"
 #endif
 
+#ifdef OPENTHREAD_CONFIG_UNSECURE_TRAFFIC_MANAGED_BY_STACK_ENABLE
+#error "OPENTHREAD_CONFIG_UNSECURE_TRAFFIC_MANAGED_BY_STACK_ENABLE was removed and no longer supported"
+#endif
+
 #endif // OPENTHREAD_CORE_CONFIG_CHECK_H_


### PR DESCRIPTION


----

Background:
- Please see discussion at https://github.com/openthread/openthread/pull/7343#discussion_r792089798
- This config and its behavior was added to enable certain internal use-case (weave pairing) - which is no longer needed.
- If we need similar behavior (in future) it would be better to add this at next layer (e.g. otbr or wpantund), i.e. the next layer can perform a similar check (parse and get the UDP port to determine whether to disable link security  before passing the packet down to OT stack).