### PR TITLE
[logging] refine `NOTE` and `WARN` logs

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (194)
+#define OPENTHREAD_API_VERSION (195)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -344,8 +344,9 @@ otError otIp6SubscribeMulticastAddress(otInstance *aInstance, const otIp6Address
  * @param[in]  aAddress  A pointer to an IP Address.
  *
  * @retval OT_ERROR_NONE          Successfully unsubscribed to the Network Interface Multicast Address.
- * @retval OT_ERROR_INVALID_ARGS  The IP Address indicated by @p aAddress is an internal address.
+ * @retval OT_ERROR_REJECTED      The IP Address indicated by @p aAddress is an internal address.
  * @retval OT_ERROR_NOT_FOUND     The IP Address indicated by @p aAddress was not found.
+ *
  */
 otError otIp6UnsubscribeMulticastAddress(otInstance *aInstance, const otIp6Address *aAddress);
 

--- a/src/cli/cli_output.cpp
+++ b/src/cli/cli_output.cpp
@@ -279,7 +279,7 @@ void Output::OutputFormatV(const char *aFormat, va_list aArguments)
 
         if (lineEnd > mOutputString)
         {
-            otLogCli(OT_LOG_LEVEL_NOTE, "Output: %s", mOutputString);
+            otLogCli(OT_LOG_LEVEL_DEBG, "Output: %s", mOutputString);
         }
 
         lineEnd++;
@@ -320,7 +320,7 @@ void Output::OutputFormatV(const char *aFormat, va_list aArguments)
 
     if (truncated)
     {
-        otLogCli(OT_LOG_LEVEL_NOTE, "Output: %s ...", mOutputString);
+        otLogCli(OT_LOG_LEVEL_DEBG, "Output: %s ...", mOutputString);
         mOutputLength = 0;
     }
 
@@ -339,7 +339,7 @@ void Output::LogInput(const Arg *aArgs)
         inputString.Append(isFirst ? "%s" : " %s", aArgs->GetCString());
     }
 
-    otLogCli(OT_LOG_LEVEL_NOTE, "Input: %s", inputString.AsCString());
+    otLogCli(OT_LOG_LEVEL_DEBG, "Input: %s", inputString.AsCString());
 }
 #endif
 

--- a/src/core/backbone_router/ndproxy_table.cpp
+++ b/src/core/backbone_router/ndproxy_table.cpp
@@ -149,7 +149,7 @@ void NdProxyTable::Clear(void)
         mCallback(mCallbackContext, OT_BACKBONE_ROUTER_NDPROXY_CLEARED, nullptr);
     }
 
-    LogNote("NdProxyTable::Clear!");
+    LogInfo("NdProxyTable::Clear!");
 }
 
 Error NdProxyTable::Register(const Ip6::InterfaceIdentifier &aAddressIid,

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -586,7 +586,7 @@ void BorderAgent::Start(void)
     Coap::CoapSecure &coaps = Get<Coap::CoapSecure>();
     Pskc              pskc;
 
-    VerifyOrExit(mState == kStateStopped, error = kErrorAlready);
+    VerifyOrExit(mState == kStateStopped, error = kErrorNone);
 
     Get<KeyManager>().GetPskc(pskc);
     SuccessOrExit(error = coaps.Start(kBorderAgentUdpPort));

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -261,7 +261,7 @@ void DatasetManager::SendSet(void)
     VerifyOrExit(!mMgmtPending, error = kErrorBusy);
     VerifyOrExit(Get<Mle::MleRouter>().IsChild() || Get<Mle::MleRouter>().IsRouter(), error = kErrorInvalidState);
 
-    VerifyOrExit(Timestamp::Compare(GetTimestamp(), mLocal.GetTimestamp()) < 0, error = kErrorInvalidState);
+    VerifyOrExit(Timestamp::Compare(GetTimestamp(), mLocal.GetTimestamp()) < 0, error = kErrorAlready);
 
     if (IsActiveDataset())
     {

--- a/src/core/meshcop/meshcop.cpp
+++ b/src/core/meshcop/meshcop.cpp
@@ -360,7 +360,7 @@ exit:
 #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
 void LogError(const char *aActionText, Error aError)
 {
-    if (aError != kErrorNone)
+    if (aError != kErrorNone && aError != kErrorAlready)
     {
         LogWarn("Failed to %s: %s", aActionText, ErrorToString(aError));
     }

--- a/src/core/net/netif.cpp
+++ b/src/core/net/netif.cpp
@@ -430,7 +430,7 @@ Error Netif::UnsubscribeExternalMulticast(const Address &aAddress)
     entry = mMulticastAddresses.FindMatching(aAddress, prev);
     VerifyOrExit(entry != nullptr, error = kErrorNotFound);
 
-    VerifyOrExit(IsMulticastAddressExternal(*entry), error = kErrorInvalidArgs);
+    VerifyOrExit(IsMulticastAddressExternal(*entry), error = kErrorRejected);
 
     mMulticastAddresses.PopAfter(prev);
 
@@ -556,7 +556,7 @@ Error Netif::RemoveExternalUnicastAddress(const Address &aAddress)
     entry = mUnicastAddresses.FindMatching(aAddress, prev);
     VerifyOrExit(entry != nullptr, error = kErrorNotFound);
 
-    VerifyOrExit(IsUnicastAddressExternal(*entry), error = kErrorInvalidArgs);
+    VerifyOrExit(IsUnicastAddressExternal(*entry), error = kErrorRejected);
 
     mUnicastAddresses.PopAfter(prev);
 

--- a/src/core/net/netif.hpp
+++ b/src/core/net/netif.hpp
@@ -561,7 +561,7 @@ public:
      * @param[in]  aAddress  A reference to the multicast address.
      *
      * @retval kErrorNone         Successfully unsubscribed to the unicast address.
-     * @retval kErrorInvalidArgs  The address indicated by @p aAddress is an internal address.
+     * @retval kErrorRejected     The address indicated by @p aAddress is an internal address.
      * @retval kErrorNotFound     The multicast address was not found.
      *
      */

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -1032,7 +1032,7 @@ void AddressResolver::LogCacheEntryChange(EntryChange       aChange,
     static_assert(6 == kReasonEvictingForNewEntry, "kReasonEvictingForNewEntry value is incorrect");
     static_assert(7 == kReasonRemovingEid, "kReasonRemovingEid value is incorrect");
 
-    LogNote("Cache entry %s: %s, 0x%04x%s%s - %s", kChangeStrings[aChange], aEntry.GetTarget().ToString().AsCString(),
+    LogInfo("Cache entry %s: %s, 0x%04x%s%s - %s", kChangeStrings[aChange], aEntry.GetTarget().ToString().AsCString(),
             aEntry.GetRloc16(), (aList == nullptr) ? "" : ", list:", ListToString(aList), kReasonStrings[aReason]);
 }
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3125,7 +3125,7 @@ void Mle::HandleDataResponse(const Message &aMessage, const Ip6::MessageInfo &aM
 
     Log(kMessageReceive, kTypeDataResponse, aMessageInfo.GetPeerAddr());
 
-    VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), error = kErrorSecurity);
+    VerifyOrExit(aNeighbor && aNeighbor->IsStateValid(), error = kErrorDrop);
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
     if (Tlv::FindTlvValueOffset(aMessage, Tlv::kLinkMetricsReport, metricsReportValueOffset, length) == kErrorNone)
@@ -4351,8 +4351,16 @@ void Mle::LogError(MessageAction aAction, MessageType aType, Error aError)
 {
     if (aError != kErrorNone)
     {
-        LogWarn("Failed to %s %s%s: %s", aAction == kMessageSend ? "send" : "process", MessageTypeToString(aType),
-                MessageTypeActionToSuffixString(aType, aAction), ErrorToString(aError));
+        if (aAction == kMessageReceive && (aError == kErrorDrop || aError == kErrorNoRoute))
+        {
+            LogInfo("Failed to %s %s%s: %s", "process", MessageTypeToString(aType),
+                    MessageTypeActionToSuffixString(aType, aAction), ErrorToString(aError));
+        }
+        else
+        {
+            LogWarn("Failed to %s %s%s: %s", aAction == kMessageSend ? "send" : "process", MessageTypeToString(aType),
+                    MessageTypeActionToSuffixString(aType, aAction), ErrorToString(aError));
+        }
     }
 }
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1323,7 +1323,7 @@ Error MleRouter::HandleAdvertisement(const Message &aMessage, const Ip6::Message
             if (mParent.GetRloc16() != sourceAddress)
             {
                 IgnoreError(BecomeDetached());
-                ExitNow(error = kErrorNoRoute);
+                ExitNow(error = kErrorDetached);
             }
 
             if (IsFullThreadDevice())

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -160,7 +160,7 @@ static inline void LogIfFail(const char *aText, otError aError)
     OT_UNUSED_VARIABLE(aText);
     OT_UNUSED_VARIABLE(aError);
 
-    if (aError != OT_ERROR_NONE)
+    if (aError != OT_ERROR_NONE && aError != OT_ERROR_NO_ACK)
     {
         otLogWarnPlat("%s: %s", aText, otThreadErrorToString(aError));
     }

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -849,7 +849,7 @@ exit:
     {
         if (error == OT_ERROR_DROP)
         {
-            otLogNotePlat("[netif] Message dropped by Thread", otThreadErrorToString(error));
+            otLogInfoPlat("[netif] Message dropped by Thread", otThreadErrorToString(error));
         }
         else
         {
@@ -863,7 +863,7 @@ static void logAddrEvent(bool isAdd, const ot::Ip6::Address &aAddress, otError e
     OT_UNUSED_VARIABLE(aAddress);
 
     if ((error == OT_ERROR_NONE) || ((isAdd) && (error == OT_ERROR_ALREADY || error == OT_ERROR_REJECTED)) ||
-        ((!isAdd) && (error == OT_ERROR_NOT_FOUND)))
+        ((!isAdd) && (error == OT_ERROR_NOT_FOUND || error == OT_ERROR_REJECTED)))
     {
         otLogInfoPlat("[netif] %s [%s] %s%s", isAdd ? "ADD" : "DEL", aAddress.IsMulticast() ? "M" : "U",
                       aAddress.ToString().AsCString(),
@@ -950,7 +950,7 @@ static void processNetifAddrEvent(otInstance *aInstance, struct nlmsghdr *aNetli
                 }
 
                 logAddrEvent(/* isAdd */ false, addr, error);
-                if (error == OT_ERROR_NOT_FOUND)
+                if (error == OT_ERROR_NOT_FOUND || error == OT_ERROR_REJECTED)
                 {
                     error = OT_ERROR_NONE;
                 }

--- a/tests/unit/test_netif.cpp
+++ b/tests/unit/test_netif.cpp
@@ -168,11 +168,11 @@ void TestNetifMulticastAddresses(void)
     VerifyMulticastAddressList(netif, &addresses[0], 8);
 
     IgnoreError(address.FromString(kTestAddress1)); // same as netifAddress (internal)
-    VerifyOrQuit(netif.UnsubscribeExternalMulticast(address) == kErrorInvalidArgs,
+    VerifyOrQuit(netif.UnsubscribeExternalMulticast(address) == kErrorRejected,
                  "UnsubscribeExternalMulticast() did not fail when address was not external");
 
     IgnoreError(address.FromString(kRealmLocalAllMpl));
-    VerifyOrQuit(netif.UnsubscribeExternalMulticast(address) == kErrorInvalidArgs,
+    VerifyOrQuit(netif.UnsubscribeExternalMulticast(address) == kErrorRejected,
                  "UnsubscribeExternalMulticast() did not fail when address was fixed address");
 
     netif.UnsubscribeAllRoutersMulticast();


### PR DESCRIPTION
This commit refines `NOTE` and `WARN` logs:
- Certain `INFO` and `WARN` logs are changed to `INFO` since they are normal situations. 