### PR TITLE
[crypto] add feature flag around kEntropyMinThreshold

### DIFF
--- a/src/core/crypto/crypto_platform.cpp
+++ b/src/core/crypto/crypto_platform.cpp
@@ -67,7 +67,9 @@ using namespace Crypto;
 #if !OPENTHREAD_RADIO
 static mbedtls_ctr_drbg_context sCtrDrbgContext;
 static mbedtls_entropy_context  sEntropyContext;
-static constexpr uint16_t       kEntropyMinThreshold = 16;
+#ifndef OT_MBEDTLS_STRONG_DEFAULT_ENTROPY_PRESENT
+static constexpr uint16_t kEntropyMinThreshold = 16;
+#endif
 #endif
 
 OT_TOOL_WEAK void otPlatCryptoInit(void)
@@ -461,7 +463,7 @@ OT_TOOL_WEAK void otPlatCryptoRandomInit(void)
 #ifndef OT_MBEDTLS_STRONG_DEFAULT_ENTROPY_PRESENT
     mbedtls_entropy_add_source(&sEntropyContext, handleMbedtlsEntropyPoll, nullptr, kEntropyMinThreshold,
                                MBEDTLS_ENTROPY_SOURCE_STRONG);
-#endif // OT_MBEDTLS_STRONG_DEFAULT_ENTROPY_PRESENT
+#endif
 
     mbedtls_ctr_drbg_init(&sCtrDrbgContext);
 


### PR DESCRIPTION
To avoid "unused variable" compiler warning.

```
/Users/runner/work/ot-br-posix/ot-br-posix/third_party/openthread/repo/src/core/crypto/crypto_platform.cpp:70:33: fatal error: unused variable 'kEntropyMinThreshold' [-Wunused-const-variable]
static constexpr uint16_t       kEntropyMinThreshold = 16;
                                ^
1 error generated.
```

https://github.com/openthread/ot-br-posix/runs/5009245865?check_suite_focus=true