### PR TITLE
[mle] fix comparing PAN ID to skip logging

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (190)
+#define OPENTHREAD_API_VERSION (191)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -60,11 +60,12 @@ extern "C" {
  */
 typedef struct otThreadLinkInfo
 {
-    uint16_t mPanId;        ///< Source PAN ID
-    uint8_t  mChannel;      ///< 802.15.4 Channel
-    int8_t   mRss;          ///< Received Signal Strength in dBm.
-    uint8_t  mLqi;          ///< Link Quality Indicator for a received message.
-    bool     mLinkSecurity; ///< Indicates whether or not link security is enabled.
+    uint16_t mPanId;                   ///< Source PAN ID
+    uint8_t  mChannel;                 ///< 802.15.4 Channel
+    int8_t   mRss;                     ///< Received Signal Strength in dBm.
+    uint8_t  mLqi;                     ///< Link Quality Indicator for a received message.
+    bool     mLinkSecurity : 1;        ///< Indicates whether or not link security is enabled.
+    bool     mIsDstPanIdBroadcast : 1; ///< Indicates whether or not destination PAN ID is broadcast.
 
     // Applicable/Required only when time sync feature (`OPENTHREAD_CONFIG_TIME_SYNC_ENABLE`) is enabled.
     uint8_t mTimeSyncSeq;       ///< The time sync sequence.

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -63,6 +63,17 @@ void ThreadLinkInfo::SetFrom(const Mac::RxFrame &aFrame)
         IgnoreError(aFrame.GetDstPanId(mPanId));
     }
 
+    {
+        Mac::PanId dstPanId;
+
+        if (kErrorNone != aFrame.GetDstPanId(dstPanId))
+        {
+            dstPanId = mPanId;
+        }
+
+        mIsDstPanIdBroadcast = (dstPanId == Mac::kPanIdBroadcast);
+    }
+
     mChannel      = aFrame.GetChannel();
     mRss          = aFrame.GetRssi();
     mLqi          = aFrame.GetLqi();

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -96,6 +96,15 @@ public:
     uint8_t GetChannel(void) const { return mChannel; }
 
     /**
+     * This method returns whether the Destination PAN ID is broadcast.
+     *
+     * @retval TRUE   If Destination PAN ID is broadcast.
+     * @retval FALSE  If Destination PAN ID is not broadcast.
+     *
+     */
+    bool IsDstPanIdBroadcast(void) const { return mIsDstPanIdBroadcast; }
+
+    /**
      * This method indicates whether or not link security is enabled.
      *
      * @retval TRUE   If link security is enabled.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2834,8 +2834,8 @@ void Mle::HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageIn
         // We skip logging security check failures for broadcast MLE
         // messages since it can be common to receive such messages
         // from adjacent Thread networks.
-        skipLoggingError = (aMessageInfo.GetSockAddr().IsMulticast() &&
-                            aMessageInfo.GetThreadLinkInfo()->GetPanId() == Mac::kPanIdBroadcast);
+        skipLoggingError =
+            (aMessageInfo.GetSockAddr().IsMulticast() && aMessageInfo.GetThreadLinkInfo()->IsDstPanIdBroadcast());
         ExitNow(error = kErrorSecurity);
     }
 #endif


### PR DESCRIPTION
This commit adds a flag in Thread link info to indicate whether
destination PAN ID is broadcast.

Verfied by running two simulation nodes (modified announce sender
interval) of different Thread networks and make sure there are no
logs of `[WARN]-MLE-----: Failed to process UDP: Security` when
receiving MLE Announce messages.