### PR TITLE
[android] disable legacy support

### DIFF
--- a/include/openthread-config-android.h
+++ b/include/openthread-config-android.h
@@ -54,9 +54,6 @@
 /* Define to 1 to enable the joiner role. */
 #define OPENTHREAD_CONFIG_JOINER_ENABLE 1
 
-/* Define to 1 if you want to use legacy network support */
-#define OPENTHREAD_CONFIG_LEGACY_ENABLE 1
-
 /* Define to 1 to enable the NCP HDLC interface. */
 #define OPENTHREAD_CONFIG_NCP_HDLC_ENABLE 1
 


### PR DESCRIPTION
This commit disables the legacy network support.

Tested by GitHub workflow.