### PR TITLE
[thci] fix registerMulticast when listAddr is string

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -3339,6 +3339,8 @@ class OpenThreadTHCI(object):
         Args:
             sAddr   : str : Multicast address to be subscribed and notified OTA.
         """
+        if isinstance(listAddr, str):
+            listAddr = [listAddr]
         for each_sAddr in listAddr:
             self._beforeRegisterMulticast(each_sAddr, timeout)
 


### PR DESCRIPTION
Fix issue when listAddr passed to registerMulticast is a string. In such case, in current implementation, we iterate over characters in the address string which is a bug.