### PR TITLE
[simulation] simulate energy scan

### DIFF
--- a/examples/platforms/simulation/platform-simulation.h
+++ b/examples/platforms/simulation/platform-simulation.h
@@ -163,10 +163,11 @@ void platformRadioReceive(otInstance *aInstance, uint8_t *aBuf, uint16_t aBufLen
  *
  * @param[in,out]  aReadFdSet   A pointer to the read file descriptors.
  * @param[in,out]  aWriteFdSet  A pointer to the write file descriptors.
+ * @param[in,out]  aTimeout     A pointer to the timeout.
  * @param[in,out]  aMaxFd       A pointer to the max file descriptor.
  *
  */
-void platformRadioUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, int *aMaxFd);
+void platformRadioUpdateFdSet(fd_set *aReadFdSet, fd_set *aWriteFdSet, struct timeval *aTimeout, int *aMaxFd);
 
 /**
  * This function performs radio driver processing.

--- a/examples/platforms/simulation/system.c
+++ b/examples/platforms/simulation/system.c
@@ -70,10 +70,11 @@ static void handleSignal(int aSignal)
  */
 enum
 {
-    OT_SIM_OPT_HELP        = 'h',
-    OT_SIM_OPT_SLEEP_TO_TX = 't',
-    OT_SIM_OPT_TIME_SPEED  = 's',
-    OT_SIM_OPT_UNKNOWN     = '?',
+    OT_SIM_OPT_HELP               = 'h',
+    OT_SIM_OPT_ENABLE_ENERGY_SCAN = 'E',
+    OT_SIM_OPT_SLEEP_TO_TX        = 't',
+    OT_SIM_OPT_TIME_SPEED         = 's',
+    OT_SIM_OPT_UNKNOWN            = '?',
 };
 
 static void PrintUsage(const char *aProgramName, int aExitCode)
@@ -82,9 +83,10 @@ static void PrintUsage(const char *aProgramName, int aExitCode)
             "Syntax:\n"
             "    %s [Options] NodeId\n"
             "Options:\n"
-            "    -h --help              Display this usage information.\n"
-            "    -t --sleep-to-tx       Let radio support direct transition from sleep to TX with CSMA.\n"
-            "    -s --time-speed=val    Speed up the time in simulation.\n",
+            "    -h --help                  Display this usage information.\n"
+            "    -E --enable-energy-scan    Enable energy scan capability.\n"
+            "    -t --sleep-to-tx           Let radio support direct transition from sleep to TX with CSMA.\n"
+            "    -s --time-speed=val        Speed up the time in simulation.\n",
             aProgramName);
 
     exit(aExitCode);
@@ -97,6 +99,7 @@ void otSysInit(int aArgCount, char *aArgVector[])
 
     static const struct option long_options[] = {
         {"help", no_argument, 0, OT_SIM_OPT_HELP},
+        {"enable-energy-scan", no_argument, 0, OT_SIM_OPT_SLEEP_TO_TX},
         {"sleep-to-tx", no_argument, 0, OT_SIM_OPT_SLEEP_TO_TX},
         {"time-speed", required_argument, 0, OT_SIM_OPT_TIME_SPEED},
         {0, 0, 0, 0},
@@ -112,7 +115,7 @@ void otSysInit(int aArgCount, char *aArgVector[])
 
     while (true)
     {
-        int c = getopt_long(aArgCount, aArgVector, "hts:", long_options, NULL);
+        int c = getopt_long(aArgCount, aArgVector, "Ehts:", long_options, NULL);
 
         if (c == -1)
         {
@@ -126,6 +129,9 @@ void otSysInit(int aArgCount, char *aArgVector[])
             break;
         case OT_SIM_OPT_HELP:
             PrintUsage(aArgVector[0], EXIT_SUCCESS);
+            break;
+        case OT_SIM_OPT_ENABLE_ENERGY_SCAN:
+            gRadioCaps |= OT_RADIO_CAPS_ENERGY_SCAN;
             break;
         case OT_SIM_OPT_SLEEP_TO_TX:
             gRadioCaps |= OT_RADIO_CAPS_SLEEP_TO_TX;
@@ -197,8 +203,8 @@ void otSysProcessDrivers(otInstance *aInstance)
     FD_ZERO(&error_fds);
 
     platformUartUpdateFdSet(&read_fds, &write_fds, &error_fds, &max_fd);
-    platformRadioUpdateFdSet(&read_fds, &write_fds, &max_fd);
     platformAlarmUpdateTimeout(&timeout);
+    platformRadioUpdateFdSet(&read_fds, &write_fds, &timeout, &max_fd);
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
     platformTrelUpdateFdSet(&read_fds, &write_fds, &timeout, &max_fd);
 #endif

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (208)
+#define OPENTHREAD_API_VERSION (209)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link_raw.h
+++ b/include/openthread/link_raw.h
@@ -236,6 +236,7 @@ typedef void (*otLinkRawEnergyScanDone)(otInstance *aInstance, int8_t aEnergySca
  * @param[in]  aCallback        A pointer to a function called on completion of a scanned channel.
  *
  * @retval OT_ERROR_NONE             Successfully started scanning the channel.
+ * @retval OT_ERROR_BUSY             The radio is performing enery scanning.
  * @retval OT_ERROR_NOT_IMPLEMENTED  The radio doesn't support energy scanning.
  * @retval OT_ERROR_INVALID_STATE    If the raw link-layer isn't enabled.
  *

--- a/include/openthread/platform/radio.h
+++ b/include/openthread/platform/radio.h
@@ -857,6 +857,7 @@ int8_t otPlatRadioGetRssi(otInstance *aInstance);
  * @param[in] aScanDuration  The duration, in milliseconds, for the channel to be scanned.
  *
  * @retval OT_ERROR_NONE             Successfully started scanning the channel.
+ * @retval OT_ERROR_BUSY             The radio is performing enery scanning.
  * @retval OT_ERROR_NOT_IMPLEMENTED  The radio doesn't support energy scanning.
  *
  */

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -164,6 +164,7 @@ public:
      * @param[in]  aCallback        A pointer to a function called on completion of a scanned channel.
      *
      * @retval kErrorNone            Successfully started scanning the channel.
+     * @retval kErrorBusy            The radio is performing energy scanning.
      * @retval kErrorNotImplemented  The radio doesn't support energy scanning.
      * @retval kErrorInvalidState    If the raw link-layer isn't enabled.
      *

--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -572,6 +572,7 @@ public:
      * @param[in] aScanDuration  The duration, in milliseconds, for the channel to be scanned.
      *
      * @retval kErrorNone            Successfully started scanning the channel.
+     * @retval kErrorBusy            The radio is performing energy scanning.
      * @retval kErrorInvalidState    The radio was disabled or transmitting.
      * @retval kErrorNotImplemented  Energy scan is not supported by radio link.
      *

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -379,6 +379,7 @@ public:
      * @param[in] aScanDuration  The duration, in milliseconds, for the channel to be scanned.
      *
      * @retval kErrorNone            Successfully started scanning the channel.
+     * @retval kErrorBusy            The radio is performing energy scanning.
      * @retval kErrorInvalidState    The radio was disabled or transmitting.
      * @retval kErrorNotImplemented  Energy scan is not supported (applicable in link-raw/radio mode only).
      *

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -522,6 +522,7 @@ public:
      * @param[in] aScanDuration  The duration, in milliseconds, for the channel to be scanned.
      *
      * @retval kErrorNone            Successfully started scanning the channel.
+     * @retval kErrorBusy            The radio is performing energy scanning.
      * @retval kErrorNotImplemented  The radio doesn't support energy scanning.
      *
      */

--- a/tests/scripts/expect/posix-rcp-energy-scan.exp
+++ b/tests/scripts/expect/posix-rcp-energy-scan.exp
@@ -1,0 +1,42 @@
+#!/usr/bin/expect -f
+#
+#  Copyright (c) 2022, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+source "tests/scripts/expect/_common.exp"
+
+spawn_node 1 "rcp" "spinel+hdlc+forkpty://$::env(OT_SIMULATION_APPS)/ncp/ot-rcp?forkpty-arg=1&forkpty-arg=-E&no-reset=1"
+
+send "ifconfig up\n"
+expect_line "Done"
+# Actually returns last otPlatRadioGetRssi
+send "scan energy 0\n"
+expect_line "Done"
+# Actually performs energy scan on RCP
+send "scan energy 100\n"
+expect_line "Done"
+dispose_all


### PR DESCRIPTION
This commit implements energy scan in simulation platform.

Verified locally
```bash
> ifconfig up
Done
> scan energy 100
| Ch | RSSI |
+----+------+
| 11 |  -98 |
| 12 |  -98 |
| 13 |  -98 |
| 14 |  -98 |
| 15 |  -98 |
| 16 |  -98 |
| 17 |  -30 |
| 18 |  -98 |
| 19 |  -98 |
| 20 |  -30 |
| 21 |  -30 |
| 22 |  -98 |
| 23 |  -30 |
| 24 |  -98 |
| 25 |  -30 |
| 26 |  -30 |
Done
```