### PR TITLE
[mesh-forwarder] tear down problematic child's links

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -938,7 +938,7 @@ void MeshForwarder::UpdateNeighborLinkFailures(Neighbor &aNeighbor,
     {
         aNeighbor.ResetLinkFailures();
     }
-    else if (aError == kErrorNoAck)
+    else if (aError == kErrorNoAck || !Get<Mle::MleRouter>().IsRouter())
     {
         aNeighbor.IncrementLinkFailures();
 


### PR DESCRIPTION
Allow children instances to remove links with parents when there
are continued transmission problems to a router.

For instance, in the event of a prolonged channel jamming longer
than the child's timeout the parent will remove the child, but the
child will keep active the link with the parent since the error
in the transmission is from CCA type. After the jamming is over
the child will still be able to retrieve ACKs from the parent,
being this enough to stay attached in Thread 1.2 networks, even
when the security processing will fail due to mismatching frame
counter.

After this fix the child will react faster and reatach to a new
(or same) parent.

Section 5.9.4 from the Thread Specification prevents to apply the
same logic for inter-router links.