### PR TITLE
[trel] change TXT data format to use binary value

### DIFF
--- a/src/core/net/dns_types.hpp
+++ b/src/core/net/dns_types.hpp
@@ -1137,7 +1137,17 @@ public:
      * @param[in] aValueLength   Number of bytes in @p aValue buffer.
      *
      */
-    TxtEntry(const char *aKey, const uint8_t *aValue, uint8_t aValueLength)
+    TxtEntry(const char *aKey, const uint8_t *aValue, uint8_t aValueLength) { Init(aKey, aValue, aValueLength); }
+
+    /**
+     * This method initializes a `TxtEntry` object.
+     *
+     * @param[in] aKey           A pointer to the key string.
+     * @param[in] aValue         A pointer to a buffer containing the value.
+     * @param[in] aValueLength   Number of bytes in @p aValue buffer.
+     *
+     */
+    void Init(const char *aKey, const uint8_t *aValue, uint8_t aValueLength)
     {
         mKey         = aKey;
         mValue       = aValue;


### PR DESCRIPTION
This commit changes the TXT record data format to use binary value
for extended address and extended PAN ID entries.

Depends-On: openthread/ot-br-posix#1234
