### PR TITLE
[routing-manager] fix small OMR prefix election issue

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -305,6 +305,7 @@ private:
     void  EvaluateOmrPrefix(OmrPrefixArray &aNewOmrPrefixes);
     Error PublishLocalOmrPrefix(void);
     void  UnpublishLocalOmrPrefix(void);
+    bool  IsOmrPrefixAddedToLocalNetworkData(void) const;
     Error AddExternalRoute(const Ip6::Prefix &aPrefix, RoutePreference aRoutePreference, bool aNat64 = false);
     void  RemoveExternalRoute(const Ip6::Prefix &aPrefix);
     void  StartRouterSolicitationDelay(void);

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -69,6 +69,20 @@ Error Local::RemoveOnMeshPrefix(const Ip6::Prefix &aPrefix)
     return RemovePrefix(aPrefix, NetworkDataTlv::kTypeBorderRouter);
 }
 
+bool Local::ContainsOnMeshPrefix(const Ip6::Prefix &aPrefix) const
+{
+    const PrefixTlv *tlv;
+    bool             contains = false;
+
+    VerifyOrExit((tlv = FindPrefix(aPrefix)) != nullptr);
+    VerifyOrExit(tlv->FindSubTlv(NetworkDataTlv::kTypeBorderRouter) != nullptr);
+
+    contains = true;
+
+exit:
+    return contains;
+}
+
 Error Local::AddHasRoutePrefix(const ExternalRouteConfig &aConfig)
 {
     Error error = kErrorInvalidArgs;

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -98,6 +98,17 @@ public:
     Error RemoveOnMeshPrefix(const Ip6::Prefix &aPrefix);
 
     /**
+     * This method indicates whether or not the Thread Network Data contains a given on mesh prefix.
+     *
+     * @param[in]  aPrefix   The on mesh prefix to check.
+     *
+     * @retval TRUE  if Network Data contains mesh prefix @p aPrefix.
+     * @retval FALSE if Network Data does not contain mesh prefix @p aPrefix.
+     *
+     */
+    bool ContainsOnMeshPrefix(const Ip6::Prefix &aPrefix) const;
+
+    /**
      * This method adds a Has Route entry to the Thread Network data.
      *
      * @param[in]  aConfig       A reference to the external route configuration.


### PR DESCRIPTION
This commit fixes two small issues regarding OMR prefix election:
- This commit handles the case where `mLocalOmrPrefix` is already in Leader's Network Data, but not locally added. It is possible when the BR restores the Network Data from Leader. In such case the BR should re-add `mLocalOmrPrefix` to local Network Data so that it keeps advertising OMR Prefix. Otherwise, the OMR Prefix will be removed from Leader's Network Data because of Network Data inconsistentency, and then all BRs start to re-elect OMR Prefix. So, the change will make the OMR Prefix more stable in some corner cases.
- The change here checks if `mLocalOmrPrefix` was added to the Local Network Data, instead of checking if `mLocalOmrPrefix` is added to the Leader's Network Data.
Here the BR has already decided that it should not be advertising `mLocalOmrPrefix`. Whether or not `mLocalOmrPrefix` is in Leader's Network Data is relevant. The BR only needs to remove `mLocalOmrPrefix` from Local Network Data and eventually Local Network Data will synchronize with Leader's Network Data. 
The original code also has a potential issue that the BR may send `NET_DATA.ntf` to Leader indefinitely when these conditions are met:
  - `mLocalOmrPrefix` was added to Local Network Data
  - `mLocalOmrPrefix` is not added to Leader' Network Data because there is no more space in Leader's Network Data