### PR TITLE
[ip6] filter ICMP6 fragments when it should handle echo request

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1054,6 +1054,17 @@ Error Ip6::ProcessReceiveCallback(Message &          aMessage,
         }
     }
 
+    if (aIpProto == kProtoFragment && mIcmp.ShouldHandleEchoRequest(aMessageInfo))
+    {
+        FragmentHeader fragmentHeader;
+
+        if (aMessage.Read(aMessage.GetOffset(), fragmentHeader) == kErrorNone)
+        {
+            // do not pass fragments of ICMP messages (echo request/reply)
+            VerifyOrExit(fragmentHeader.GetNextHeader() != kProtoIcmp6, error = kErrorDrop);
+        }
+    }
+
     switch (aMessageOwnership)
     {
     case Message::kTakeCustody:


### PR DESCRIPTION
This PR fixes the case where ICMPv6 echo requests which needed data fragmentation are handled by the OpenThread stack. The echo request fragments should be filtered since they have been already processed rather than forwarded.

Things to consider:
Let change aAllowReceiveFilter to true here: https://github.com/openthread/openthread/blob/7ec658e47a39e1c3c55651e584e0748b259d2d4d/src/core/net/ip6.cpp#L914-L915 and disable filter if forwarding is required?