### PR TITLE
[build] fix uninitialized variables

### DIFF
--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -371,6 +371,8 @@ void MlrManager::HandleRegisterMulticastListenersResponse(otMessage *          a
     otIp6RegisterMulticastListenersCallback callback         = mRegisterMulticastListenersCallback;
     void *                                  context          = mRegisterMulticastListenersContext;
 
+    failedAddresses[0].Clear(); // suppress -Wuninitialized
+
     mRegisterMulticastListenersPending  = false;
     mRegisterMulticastListenersCallback = nullptr;
     mRegisterMulticastListenersContext  = nullptr;
@@ -474,6 +476,8 @@ void MlrManager::HandleMulticastListenerRegistrationResponse(Coap::Message *    
     Error        error;
     Ip6::Address failedAddresses[kIp6AddressesNumMax];
     uint8_t      failedAddressNum = 0;
+
+    failedAddresses[0].Clear(); // suppress -Wuninitialized
 
     error = ParseMulticastListenerRegistrationResponse(aResult, aMessage, status, failedAddresses, failedAddressNum);
 


### PR DESCRIPTION
When making a Release build of otbr-agent, it will throw errors on uninitialized variables. This PR aims to fix such errors.