### PR TITLE
[posix] resolve the RCP timeout issue

### DIFF
--- a/src/posix/platform/spi_interface.cpp
+++ b/src/posix/platform/spi_interface.cpp
@@ -823,9 +823,9 @@ exit:
 
 otError SpiInterface::SendFrame(const uint8_t *aFrame, uint16_t aLength)
 {
-    const uint32_t kMaxNumRetries = 5;
-    otError        error          = OT_ERROR_NONE;
-    uint32_t       count          = 0;
+    const uint8_t kMaxNumRetries = 5;
+    otError       error          = OT_ERROR_NONE;
+    uint8_t       count          = 0;
 
     VerifyOrExit(aLength < (kMaxFrameSize - kSpiFrameHeaderSize), error = OT_ERROR_NO_BUFS);
     VerifyOrExit(!mSpiTxIsReady, error = OT_ERROR_BUSY);
@@ -837,9 +837,9 @@ otError SpiInterface::SendFrame(const uint8_t *aFrame, uint16_t aLength)
 
     while (count < kMaxNumRetries)
     {
-        count++;
         VerifyOrExit((error = PushPullSpi()) != OT_ERROR_NONE);
         usleep(1000);
+        count++;
     }
 
 exit:


### PR DESCRIPTION
When calling `scan energy` command continuously, the SPI based RCP Host
crashes and the log outputs RCP timeout error message. The root cause is
that the interval between two Spinel commands is very small. After
processing the previous SPI packet, the RCP needs to take a certain amount
of time to re-set the TX/RX buffer of the SPI slave controller. During
the process of RCP setting the SPI slave TX/RX buffers, the Host starts
an SPI transfer, and then the RCP side loses the packet at this time.

This PR checks the result of the SPI transmission when sending the Spinel
command. If the SPI transmission is failed, the Host retransmits the SPI
frame. This PR also change the fd of the interrupt pin to O_NONBLOCK mode.