### PR TITLE
[mle] check router ID match when sending Child Id Response

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3078,7 +3078,7 @@ Error MleRouter::SendChildIdResponse(Child &aChild)
     SuccessOrExit(error = AppendActiveTimestamp(*message));
     SuccessOrExit(error = AppendPendingTimestamp(*message));
 
-    if (aChild.GetRloc16() == 0)
+    if ((aChild.GetRloc16() == 0) || !RouterIdMatch(aChild.GetRloc16(), GetRloc16()))
     {
         uint16_t rloc16;
 


### PR DESCRIPTION
This commit updates the `SendChildIdResponse()` to check in the case
that the child already has a previously assigned RLOC16 that it
matches the current router ID of the parent and if not we assign a new
RLOC16 to it in the "Child ID Response".

----

Should help address https://github.com/openthread/openthread/issues/7366.