### PR TITLE
[mle] drop Child ID Response if Router IDs do not match

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3650,11 +3650,12 @@ void Mle::HandleChildIdResponse(const Message &         aMessage,
 
     VerifyOrExit(mAttachState == kAttachStateChildIdRequest);
 
-    // Leader Data
-    SuccessOrExit(error = ReadLeaderData(aMessage, leaderData));
-
     // ShortAddress
     SuccessOrExit(error = Tlv::Find<Address16Tlv>(aMessage, shortAddress));
+    VerifyOrExit(RouterIdMatch(sourceAddress, shortAddress), error = kErrorRejected);
+
+    // Leader Data
+    SuccessOrExit(error = ReadLeaderData(aMessage, leaderData));
 
     // Network Data
     error = Tlv::FindTlvOffset(aMessage, Tlv::kNetworkData, networkDataOffset);


### PR DESCRIPTION
The Child ID Response message contains the RLOC16 that the Parent
assigns to the Child. Add a check to ensure that Parent's and Child's
Router IDs match. If the Router IDs do not match, drop the Child ID
Response message.