### PR TITLE
[border-routing] add `otBorderRouterIsValidOmrPrefix` API

### DIFF
--- a/include/openthread/border_router.h
+++ b/include/openthread/border_router.h
@@ -191,6 +191,17 @@ otError otBorderRouterGetNextOnMeshPrefix(otInstance *           aInstance,
                                           otBorderRouterConfig * aConfig);
 
 /**
+ * This function checks if an IPv6 prefix is a valid OMR prefix.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ * @param[in]  aConfig    A pointer to an otBorderRouterConfig.
+ *
+ * @returns Whether this prefix is a valid OMR prefix.
+ *
+ */
+bool otBorderRouterIsValidOmrPrefix(otInstance *aInstance, const otBorderRouterConfig *aConfig);
+
+/**
  * Add an external route configuration to the local network data.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (195)
+#define OPENTHREAD_API_VERSION (196)
 
 /**
  * @addtogroup api-instance

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -64,6 +64,13 @@ otError otBorderRoutingGetOnLinkPrefix(otInstance *aInstance, otIp6Prefix *aPref
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetOnLinkPrefix(AsCoreType(aPrefix));
 }
 
+bool otBorderRouterIsValidOmrPrefix(otInstance *aInstance, const otBorderRouterConfig *aConfig)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return BorderRouter::RoutingManager::IsValidOmrPrefix(AsCoreType(aConfig));
+}
+
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_NAT64_ENABLE
 otError otBorderRoutingGetNat64Prefix(otInstance *aInstance, otIp6Prefix *aPrefix)
 {

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -185,6 +185,15 @@ public:
      */
     Error HandleInfraIfStateChanged(uint32_t aInfraIfIndex, bool aIsRunning);
 
+    /**
+     * This method checks if the given OnMeshPrefixConfig represents a valid OMR prefix.
+     *
+     * @param[in]  aOnMeshPrefixConfig  The OnMeshPrefixConfig being checked.
+     *
+     * @returns  Whether the given OnMeshPrefixConfig represents a valid OMR prefix.
+     */
+    static bool IsValidOmrPrefix(const NetworkData::OnMeshPrefixConfig &aOnMeshPrefixConfig);
+
 private:
     typedef NetworkData::RoutePreference RoutePreference;
 
@@ -338,7 +347,6 @@ private:
     bool UpdateRouterAdvMessage(const RouterAdv::RouterAdvMessage *aRouterAdvMessage);
     void ResetDiscoveredPrefixStaleTimer(void);
 
-    static bool IsValidOmrPrefix(const NetworkData::OnMeshPrefixConfig &aOnMeshPrefixConfig);
     static bool IsValidOmrPrefix(const Ip6::Prefix &aOmrPrefix);
     static bool IsValidOnLinkPrefix(const RouterAdv::PrefixInfoOption &aPio);
     static bool IsValidOnLinkPrefix(const Ip6::Prefix &aOnLinkPrefix);


### PR DESCRIPTION
As required by the latest spec, the border agent needs to publish an `omr` entry in the meshcop TXT record. To achieve that, the border agent should be able to go through all the on mesh prefixes in netdata and find the smallest OMR prefix among them. To check if an on mesh prefix is a valid OMR prefix, we need the `otBorderRouterIsValidOmrPrefix` API.

See also: https://github.com/openthread/openthread/pull/7433, https://github.com/openthread/ot-br-posix/pull/1258