### PR TITLE
[tests] verify the `omr` entry in meshcop TXT

### DIFF
--- a/include/openthread/border_router.h
+++ b/include/openthread/border_router.h
@@ -191,6 +191,17 @@ otError otBorderRouterGetNextOnMeshPrefix(otInstance *           aInstance,
                                           otBorderRouterConfig * aConfig);
 
 /**
+ * This function checks if an IPv6 prefix is a valid OMR prefix.
+ *
+ * @param[in]     aInstance              A pointer to an OpenThread instance.
+ * @param[in]     aConfig                A pointer to an otBorderRouterConfig.
+ *
+ * @returns Whether this prefix is a valid OMR prefix.
+ *
+ */
+bool otBorderRouterIsValidOmrPrefix(otInstance *aInstance, const otBorderRouterConfig *aConfig);
+
+/**
  * Add an external route configuration to the local network data.
  *
  * @param[in]  aInstance A pointer to an OpenThread instance.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (193)
+#define OPENTHREAD_API_VERSION (194)
 
 /**
  * @addtogroup api-instance

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -64,6 +64,13 @@ otError otBorderRoutingGetOnLinkPrefix(otInstance *aInstance, otIp6Prefix *aPref
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetOnLinkPrefix(AsCoreType(aPrefix));
 }
 
+bool otBorderRouterIsValidOmrPrefix(otInstance *aInstance, const otBorderRouterConfig *aConfig)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    return BorderRouter::RoutingManager::IsValidOmrPrefix(AsCoreType(aConfig));
+}
+
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_NAT64_ENABLE
 otError otBorderRoutingGetNat64Prefix(otInstance *aInstance, otIp6Prefix *aPrefix)
 {

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -185,6 +185,15 @@ public:
      */
     Error HandleInfraIfStateChanged(uint32_t aInfraIfIndex, bool aIsRunning);
 
+    /**
+     * This method checks if the given OnMeshPrefixConfig represents a valid OMR prefix.
+     *
+     * @param[in]  aOnMeshPrefixConfig  The OnMeshPrefixConfig being checked.
+     *
+     * @returns  Whether the given OnMeshPrefixConfig represents a valid OMR prefix.
+     */
+    static bool IsValidOmrPrefix(const NetworkData::OnMeshPrefixConfig &aOnMeshPrefixConfig);
+
 private:
     typedef NetworkData::RoutePreference RoutePreference;
 
@@ -337,7 +346,6 @@ private:
     bool UpdateRouterAdvMessage(const RouterAdv::RouterAdvMessage *aRouterAdvMessage);
     void ResetDiscoveredPrefixStaleTimer(void);
 
-    static bool IsValidOmrPrefix(const NetworkData::OnMeshPrefixConfig &aOnMeshPrefixConfig);
     static bool IsValidOmrPrefix(const Ip6::Prefix &aOmrPrefix);
     static bool IsValidOnLinkPrefix(const RouterAdv::PrefixInfoOption &aPio);
     static bool IsValidOnLinkPrefix(const Ip6::Prefix &aOnLinkPrefix);

--- a/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
+++ b/tests/scripts/thread-cert/border_router/test_publish_meshcop_service.py
@@ -55,18 +55,18 @@ class PublishMeshCopService(thread_cert.TestCase):
     TOPOLOGY = {
         BR1: {
             'name': 'BR_1',
-            'allowlist': [],
             'is_otbr': True,
             'version': '1.2',
             'network_name': 'ot-br1',
+            'channel': 12,
             'boot_delay': 5,
         },
         BR2: {
             'name': 'BR_2',
-            'allowlist': [],
             'is_otbr': True,
             'version': '1.2',
             'network_name': 'ot-br2',
+            'channel': 13,
             'boot_delay': 5,
         },
         HOST: {
@@ -81,7 +81,6 @@ class PublishMeshCopService(thread_cert.TestCase):
         br2 = self.nodes[BR2]
         br2.disable_br()
 
-        # Use different network names to distinguish meshcop services
         br1.set_network_name('ot-br1')
         br2.set_network_name('ot-br2')
 
@@ -94,29 +93,32 @@ class PublishMeshCopService(thread_cert.TestCase):
         br1.start()
         self.simulator.go(20)
         self.assertEqual('leader', br1.get_state())
-        self.check_meshcop_service(br1, host)
+        br1_omr = ipaddress.IPv6Network(br1.get_br_omr_prefix()).network_address
+        self.check_meshcop_service(br1, host, br1_omr)
 
         br1.disable_backbone_router()
         self.simulator.go(10)
-        self.check_meshcop_service(br1, host)
+        self.check_meshcop_service(br1, host, br1_omr)
 
         br1.stop()
         br1.set_network_name('ot-br1-1')
         br1.start()
         self.simulator.go(10)
-        self.check_meshcop_service(br1, host)
+        self.check_meshcop_service(br1, host, br1_omr)
 
         # verify that there are two meshcop services
         br2.set_network_name('ot-br2-1')
         br2.start()
         br2.disable_backbone_router()
         br2.enable_br()
-        self.simulator.go(25)
+        self.simulator.go(20)
+
+        br2_omr = ipaddress.IPv6Network(br2.get_br_omr_prefix()).network_address
 
         service_instances = host.browse_mdns_services('_meshcop._udp')
         self.assertEqual(len(service_instances), 2)
-        br1_service = self.check_meshcop_service(br1, host)
-        br2_service = self.check_meshcop_service(br2, host)
+        br1_service = self.check_meshcop_service(br1, host, br1_omr)
+        br2_service = self.check_meshcop_service(br2, host, br2_omr)
         self.assertNotEqual(br1_service['host'], br2_service['host'])
 
         br1.stop_otbr_service()
@@ -127,19 +129,31 @@ class PublishMeshCopService(thread_cert.TestCase):
         br1.start_otbr_service()
         self.simulator.go(10)
         self.assertEqual(len(host.browse_mdns_services('_meshcop._udp')), 2)
-        self.check_meshcop_service(br1, host)
-        self.check_meshcop_service(br2, host)
+        self.check_meshcop_service(br1, host, br1_omr)
+        self.check_meshcop_service(br2, host, br2_omr)
 
-    def check_meshcop_service(self, br, host):
-        services = self.discover_all_meshcop_services(host)
+        # only the smallest OMR should be published in the network
+        br1.stop()
+        br1.set_active_dataset_hex(br2.get_active_dataset_hex())
+        br1.start()
+        br2.start()
+        self.simulator.go(10)
+        br1_omr = ipaddress.IPv6Network(br1.get_br_omr_prefix()).network_address
+        br2_omr = ipaddress.IPv6Network(br2.get_br_omr_prefix()).network_address
+        min_omr = min(br1_omr, br2_omr)
+        self.check_meshcop_service(br1, host, min_omr)
+        self.check_meshcop_service(br2, host, min_omr)
+
+    def check_meshcop_service(self, br, host, omr):
+        services = host.browse_mdns_services('_meshcop._udp')
         for service in services:
-            if service['txt']['nn'] == br.get_network_name():
-                self.check_meshcop_service_by_data(br, service)
+            if service['txt']['xa'].hex() == br.get_addr64():
+                self.check_meshcop_service_by_data(br, service, omr)
                 return service
         self.fail('MeshCoP service not found')
 
-    def check_meshcop_service_by_data(self, br, service_data):
-        sb_data = service_data['txt']['sb'].encode('raw_unicode_escape')
+    def check_meshcop_service_by_data(self, br, service_data, omr):
+        sb_data = service_data['txt']['sb']
         state_bitmap = int.from_bytes(sb_data, byteorder='big')
         logging.info(bin(state_bitmap))
         self.assertEqual((state_bitmap & 7), 1)  # connection mode = PskC
@@ -153,16 +167,16 @@ class PublishMeshCopService(thread_cert.TestCase):
         self.assertEqual((state_bitmap >> 7 & 1),
                          br.get_backbone_router_state() != 'Disabled')  # BBR is enabled or not
         self.assertEqual((state_bitmap >> 8 & 1), br.get_backbone_router_state() == 'Primary')  # BBR is primary or not
-        self.assertEqual(service_data['txt']['nn'], br.get_network_name())
-        self.assertEqual(service_data['txt']['rv'], '1')
-        self.assertIn(service_data['txt']['tv'], ['1.1.0', '1.1.1', '1.2.0'])
-
-    def discover_all_meshcop_services(self, host):
-        instance_names = host.browse_mdns_services('_meshcop._udp')
-        services = []
-        for instance_name in instance_names:
-            services.append(host.discover_mdns_service(instance_name, '_meshcop._udp', None))
-        return services
+        if omr is not None:
+            discovered_omr = service_data['txt']['omr']
+            self.assertEqual(discovered_omr[0], 64)
+            self.assertEqual(len(discovered_omr), 9)
+            self.assertEqual(ipaddress.IPv6Address(discovered_omr[1:] + bytes([0] * 8)), omr)
+        else:
+            self.assertTrue('omr' not in service_data['txt'])
+        self.assertEqual(service_data['txt']['nn'].decode('raw_unicode_escape'), br.get_network_name())
+        self.assertEqual(service_data['txt']['rv'].decode('raw_unicode_escape'), '1')
+        self.assertIn(service_data['txt']['tv'].decode('raw_unicode_escape'), ['1.1.0', '1.1.1', '1.2.0'])
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/border_router/test_srp_register_500_services_br.py
+++ b/tests/scripts/thread-cert/border_router/test_srp_register_500_services_br.py
@@ -60,7 +60,8 @@ class SrpRegister500ServicesBR(SrpRegister500Services):
         browse_retry = 3
         for i in range(browse_retry):
             try:
-                service_instances = set(host.browse_mdns_services(SERVICE_NAME, timeout=10))
+                service_instances = set(
+                    [service['instance'] for service in host.browse_mdns_services(SERVICE_NAME, timeout=10)])
                 print(service_instances)
 
                 for clientid in CLIENT_IDS:

--- a/tests/scripts/thread-cert/browse_service.py
+++ b/tests/scripts/thread-cert/browse_service.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2022, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+import sys
+import json
+import time
+import ipaddress
+import zeroconf
+from zeroconf import Zeroconf, ServiceBrowser
+
+# USAGE: python3 browse_service.py <service_type> <timeout (seconds)>
+# The script will print a JSON array containing all the discovered service instances
+# For example:
+# python3 tests/scripts/thread-cert/browse_service.py _meshcop._udp.local. 3
+#
+#  {
+#    "fullname": "OpenThread BorderRouter._meshcop._udp.local.",
+#    "instance": "OpenThread BorderRouter",
+#    "name": "_meshcop._udp.local.",
+#    "addresses": [],
+#    "port": 49154,
+#    "weight": 0,
+#    "priority": 0,
+#    "host_fullname": "host-5.local.",
+#    "host": "1eec0e6339fd-5",
+#    "txt": {
+#      "rv": "31",
+#      "nn": "6f742d6272312d31",
+#       ...
+#    }
+#  },
+
+services = []
+
+
+class Listener:
+
+    def add_service(self, zeroconf: Zeroconf, type: str, name: str):
+        services.append([type, name])
+
+    def remove_service(self, zeroconf: Zeroconf, type: str, name: str):
+        pass
+
+    def update_service(self, zeroconf: Zeroconf, type: str, name: str):
+        pass
+
+
+def to_dict(service: zeroconf.ServiceInfo):
+    if not hasattr(service, 'addresses'):
+        service.addresses = []
+    return {
+        'fullname': service.name,
+        'instance': service.get_name(),
+        'name': service.type,
+        'addresses': [str(ipaddress.ip_address(addr)) for addr in service.addresses],
+        'port': service.port,
+        'weight': service.weight,
+        'priority': service.priority,
+        'host_fullname': service.server,
+        'host': service.server.rstrip('.local.'),
+        'txt': dict([(key.decode('raw_unicode_escape'), value.hex()) for key, value in service.properties.items()]),
+    }
+
+
+def main():
+    global services
+
+    args = sys.argv[1:]
+    service_type = args[0]
+    timeout = int(args[1])
+
+    zeroconf = Zeroconf()
+    listener = Listener()
+    browser = ServiceBrowser(zeroconf, f'{service_type}', listener)
+    time.sleep(timeout)
+    services = [zeroconf.get_service_info(type, name) for type, name in services]
+    services = [to_dict(service) for service in filter(None, services)]
+    print(json.dumps(services))
+    zeroconf.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -36,6 +36,7 @@ import socket
 import subprocess
 import sys
 import time
+import json
 import traceback
 import typing
 import unittest
@@ -2159,6 +2160,16 @@ class NodeImpl:
         self.send_command(cmd)
         self._expect_done()
 
+    def get_active_dataset_hex(self):
+        cmd = 'dataset active -x'
+        self.send_command(cmd)
+        return self._expect_command_output()[0]
+
+    def set_active_dataset_hex(self, data):
+        cmd = f'dataset set active {data}'
+        self.send_command(cmd, expect_command_echo=False)
+        self._expect_done()
+
     def set_active_dataset(
         self,
         timestamp,
@@ -3252,19 +3263,18 @@ class LinuxHost():
 
         :param name: the service type name in format of '<service-name>.<protocol>'.
         :param timeout: timeout value in seconds before returning.
-        :return: A list of service instance names.
+        :return: A list of service instances.
         """
 
-        self.bash(f'dns-sd -Z {name} local. > /tmp/{name} 2>&1 &')
-        time.sleep(timeout)
-        self.bash('pkill dns-sd')
+        cmd = f'python3 /app/third_party/openthread/repo/tests/scripts/thread-cert/browse_service.py {name}.local. {timeout}'
+        services = json.loads(''.join(self.bash(cmd)))
 
-        instances = []
-        for line in self.bash(f'cat /tmp/{name}', encoding='raw_unicode_escape'):
-            elements = line.split()
-            if len(elements) >= 3 and elements[0] == name and elements[1] == 'PTR':
-                instances.append(elements[2][:-len('.' + name)])
-        return instances
+        for service in services:
+            for key, value in service['txt'].items():
+                service['txt'][key] = bytes.fromhex(value)
+
+        logging.info(f'services = {services}')
+        return services
 
     def discover_mdns_service(self, instance, name, host_name, timeout=2):
         """ Discover/resolve the mDNS service on ethernet.
@@ -3279,77 +3289,18 @@ class LinuxHost():
         The return value is a dict with the same key/values of srp_server_get_service
         except that we don't have a `deleted` field here.
         """
-        host_name_file = self.bash('mktemp')[0].strip()
-        service_data_file = self.bash('mktemp')[0].strip()
 
-        self.bash(f'dns-sd -Z {name} local. > {service_data_file} 2>&1 &')
-        time.sleep(timeout)
+        services = self.browse_mdns_services(name, timeout)
 
-        full_service_name = f'{instance}.{name}'
         # When hostname is unspecified, extract hostname from browse result
         if host_name is None:
-            for line in self.bash(f'cat {service_data_file}', encoding='raw_unicode_escape'):
-                elements = line.split()
-                if len(elements) >= 6 and elements[0] == full_service_name and elements[1] == 'SRV':
-                    host_name = elements[5].split('.')[0]
+            for service in services:
+                if service['instance'] == instance:
+                    host_name = service['host']
                     break
 
         assert (host_name is not None)
-        self.bash(f'dns-sd -G v6 {host_name}.local. > {host_name_file} 2>&1 &')
-        time.sleep(timeout)
 
-        self.bash('pkill dns-sd')
-        addresses = []
-        service = {}
-
-        logging.debug(self.bash(f'cat {host_name_file}', encoding='raw_unicode_escape'))
-        logging.debug(self.bash(f'cat {service_data_file}', encoding='raw_unicode_escape'))
-
-        # example output in the host file:
-        # Timestamp     A/R Flags if Hostname                               Address                                     TTL
-        # 9:38:09.274  Add     23 48 my-host.local.                         2001:0000:0000:0000:0000:0000:0000:0002%<0>  120
-        #
-        for line in self.bash(f'cat {host_name_file}', encoding='raw_unicode_escape'):
-            elements = line.split()
-            fullname = f'{host_name}.local.'
-            if fullname not in elements:
-                continue
-            addresses.append(elements[elements.index(fullname) + 1].split('%')[0])
-
-        logging.debug(f'addresses of {host_name}: {addresses}')
-
-        # example output of in the service file:
-        # _ipps._tcp                                      PTR     my-service._ipps._tcp
-        # my-service._ipps._tcp                           SRV     0 0 12345 my-host.local. ; Replace with unicast FQDN of target host
-        # my-service._ipps._tcp                           TXT     ""
-        #
-        is_txt = False
-        txt = ''
-        for line in self.bash(f'cat {service_data_file}', encoding='raw_unicode_escape'):
-            elements = line.split()
-            if len(elements) >= 2 and elements[0] == full_service_name and elements[1] == 'TXT':
-                is_txt = True
-            if is_txt:
-                txt += line.strip()
-                if line.strip().endswith('"'):
-                    is_txt = False
-                    txt_dict = self.__parse_dns_sd_txt(txt)
-                    logging.info(f'txt = {txt_dict}')
-                    service['txt'] = txt_dict
-
-            if not elements or elements[0] != full_service_name:
-                continue
-            if elements[1] == 'SRV':
-                service['fullname'] = elements[0]
-                service['instance'] = instance
-                service['name'] = name
-                service['priority'] = int(elements[2])
-                service['weight'] = int(elements[3])
-                service['port'] = int(elements[4])
-                service['host_fullname'] = elements[5]
-                assert (service['host_fullname'] == f'{host_name}.local.')
-                service['host'] = host_name
-                service['addresses'] = addresses
         return service if 'addresses' in service and service['addresses'] else None
 
     def start_radvd_service(self, prefix, slaac):
@@ -3384,19 +3335,6 @@ EOF
 
     def kill_radvd_service(self):
         self.bash('pkill radvd')
-
-    def __parse_dns_sd_txt(self, line: str):
-        # Example TXT entry:
-        # "xp=\\000\\013\\184\\000\\000\\000\\000\\000"
-        txt = {}
-        for entry in re.findall(r'"((?:[^\\]|\\.)*?)"', line):
-            if '=' not in entry:
-                continue
-
-            k, v = entry.split('=', 1)
-            txt[k] = v
-
-        return txt
 
 
 class OtbrNode(LinuxHost, NodeImpl, OtbrDocker):


### PR DESCRIPTION
As required by the latest spec, the border agent needs to publish an `omr` entry in the meshcop TXT record. If there are multiple OMR prefixes in netdata, the borderagent should publish the smallest one.

This PR is based on top of https://github.com/openthread/openthread/pull/7432.

Depends-On: openthread/ot-br-posix#1258