### PR TITLE
[core] add "leave network" API

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (194)
+#define OPENTHREAD_API_VERSION (195)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -1010,6 +1010,14 @@ otError otThreadSendProactiveBackboneNotification(otInstance *              aIns
                                                   uint32_t                  aTimeSinceLastTransaction);
 
 /**
+ * This function detaches from the Thread network and forgets all credentials of the network.
+ *
+ * @param[in]  aInstance A pointer to an OpenThread instance.
+ *
+ */
+void otThreadLeaveNetwork(otInstance *aInstance);
+
+/**
  * @}
  *
  */

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2211,6 +2211,14 @@ template <> otError Interpreter::Process<Cmd("leaderweight")>(Arg aArgs[])
 }
 #endif // OPENTHREAD_FTD
 
+template <> otError Interpreter::Process<Cmd("leavenetwork")>(Arg aArgs[])
+{
+    OT_UNUSED_VARIABLE(aArgs);
+
+    otThreadLeaveNetwork(GetInstancePtr());
+    return kErrorNone;
+}
+
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
 void Interpreter::HandleLinkMetricsReport(const otIp6Address *       aAddress,
                                           const otLinkMetricsValues *aMetricsValues,
@@ -5046,6 +5054,7 @@ otError Interpreter::ProcessCommand(Arg aArgs[])
 #if OPENTHREAD_FTD
         CmdEntry("leaderweight"),
 #endif
+        CmdEntry("leavenetwork"),
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
         CmdEntry("linkmetrics"),
 #endif

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -501,4 +501,20 @@ bool otThreadIsAnycastLocateInProgress(otInstance *aInstance)
 }
 #endif
 
+void otThreadLeaveNetwork(otInstance *aInstance)
+{
+    static constexpr otOperationalDatasetTlvs kEmptyDatasetTlvs = {};
+
+    SuccessOrAssert(otThreadSetEnabled(aInstance, false));
+    if (otIp6IsEnabled(aInstance))
+    {
+        SuccessOrAssert(otIp6SetEnabled(aInstance, false));
+    }
+    SuccessOrAssert(otDatasetSetActiveTlvs(aInstance, &kEmptyDatasetTlvs));
+    SuccessOrAssert(otDatasetSetPendingTlvs(aInstance, &kEmptyDatasetTlvs));
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    SuccessOrAssert(AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().HandleLeavingNetwork());
+#endif
+}
+
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1504,6 +1504,20 @@ void RoutingManager::ResetDiscoveredPrefixStaleTimer(void)
     }
 }
 
+Error RoutingManager::HandleLeavingNetwork(void)
+{
+    Error error = kErrorNone;
+
+    SuccessOrExit(error = Get<Settings>().Delete<Settings::OmrPrefix>());
+    if (IsInitialized())
+    {
+        SuccessOrExit(error = LoadOrGenerateRandomOmrPrefix());
+    }
+
+exit:
+    return error;
+}
+
 } // namespace BorderRouter
 
 } // namespace ot

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -185,6 +185,14 @@ public:
      */
     Error HandleInfraIfStateChanged(uint32_t aInfraIfIndex, bool aIsRunning);
 
+    /**
+     * This method cleans up the persistent storage when leaving a Thread network.
+     *
+     * @retval kErrorNone     Successfully cleaned up the persistent storage.
+     * @retval kErrorFailed   Failed to generate prefixes.
+     */
+    Error HandleLeavingNetwork(void);
+
 private:
     typedef NetworkData::RoutePreference RoutePreference;
 

--- a/tests/scripts/thread-cert/border_router/test_leavenetwork.py
+++ b/tests/scripts/thread-cert/border_router/test_leavenetwork.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2022, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+# Test description:
+# The purpose of this test is to verify the functionality of leavenetwork command.
+#
+# Topology:
+#    ----------------(eth)--------------------
+#           |
+#          BR
+#
+
+import unittest
+import thread_cert
+
+BR = 1
+
+
+class TestLeaveNetwork(thread_cert.TestCase):
+    USE_MESSAGE_FACTORY = False
+
+    TOPOLOGY = {
+        BR: {
+            'name': 'BR',
+            'is_otbr': True,
+            'version': '1.2',
+        },
+    }
+
+    def test(self):
+        br = self.nodes[BR]
+
+        br.start()
+        self.simulator.go(5)
+        self.assertEqual('leader', br.get_state())
+
+        omr_prefix = br.get_br_omr_prefix()
+
+        br.leave_network()
+
+        self.assertNotEqual(omr_prefix, br.get_br_omr_prefix())
+        self.assertEqual('disabled', br.get_state())
+        self.assertTrue(br.get_active_dataset_tlvs() is None)
+        self.assertTrue(br.get_pending_dataset_tlvs() is None)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -2159,6 +2159,24 @@ class NodeImpl:
         self.send_command(cmd)
         self._expect_done()
 
+    def get_active_dataset_tlvs(self):
+        try:
+            self.send_command('dataset active -x')
+            return self._expect_command_output()[0].strip()
+        except Exception as ex:
+            if 'Error 23: NotFound' in str(ex):
+                return None
+            raise
+
+    def get_pending_dataset_tlvs(self):
+        try:
+            self.send_command('dataset pending -x')
+            return self._expect_command_output()[0].strip()
+        except Exception as ex:
+            if 'Error 23: NotFound' in str(ex):
+                return None
+            raise
+
     def set_active_dataset(
         self,
         timestamp,
@@ -3119,6 +3137,11 @@ class NodeImpl:
         self.send_command(cmd)
         line = self._expect_command_output()[0]
         return [int(item) for item in line.split()]
+
+    def leave_network(self):
+        cmd = 'leavenetwork'
+        self.send_command(cmd)
+        self._expect_done()
 
 
 class Node(NodeImpl, OtCli):


### PR DESCRIPTION
This commit adds the `otThreadLeaveNetwork` API to let the node detach from Thread network and forget credentials.