### PR TITLE
[dns-client] allow empty question section in response with error code

### DIFF
--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -978,12 +978,18 @@ Error Client::ParseResponse(Response &aResponse, QueryType &aType, Error &aRespo
 
     // Check the Question Section
 
-    VerifyOrExit(header.GetQuestionCount() == kQuestionCount[aType], error = kErrorParse);
-
-    for (uint8_t num = 0; num < kQuestionCount[aType]; num++)
+    if (header.GetQuestionCount() == kQuestionCount[aType])
     {
-        SuccessOrExit(error = Name::CompareName(message, offset, queryName));
-        offset += sizeof(Question);
+        for (uint8_t num = 0; num < kQuestionCount[aType]; num++)
+        {
+            SuccessOrExit(error = Name::CompareName(message, offset, queryName));
+            offset += sizeof(Question);
+        }
+    }
+    else
+    {
+        VerifyOrExit((header.GetResponseCode() != Header::kResponseSuccess) && (header.GetQuestionCount() == 0),
+                     error = kErrorParse);
     }
 
     // Check the answer, authority and additional record sections


### PR DESCRIPTION
This commit updates `Dns::Client` such that when parsing a query
response we allow and accept a message with empty question section if
the response code in header indicates an error. This ensures that the
`Dns::Client` can work with DNS name resolvers that may not echo back
the question section in case of an error response.