### PR TITLE
[test] fix `test_ecdsa` to use array of char as message string

### DIFF
--- a/tests/unit/test_ecdsa.cpp
+++ b/tests/unit/test_ecdsa.cpp
@@ -129,7 +129,7 @@ void TestEdsaKeyGenerationSignAndVerify(void)
 {
     Instance *instance = testInitInstance();
 
-    const char *kMessage = "You are not a drop in the ocean. You are the entire ocean in a drop.";
+    const char kMessage[] = "You are not a drop in the ocean. You are the entire ocean in a drop.";
 
     Ecdsa::P256::KeyPair   keyPair;
     Ecdsa::P256::PublicKey publicKey;


### PR DESCRIPTION
This commit updates `kMessage` in `test_ecdsa.cpp` function which
verifies the signature generation to be an array of char instead of a
`char *`. This ensures that the use of `sizeof(kMessage)` correctly
gives the length of the message string (which is used during hash
calculation).

----

- Should help resolve https://github.com/openthread/openthread/issues/7444.