### PR TITLE
[diags] Also call `Diags::ReceiveDone` for RCP mode

### DIFF
--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -138,6 +138,11 @@ Error Diags::ProcessStop(uint8_t aArgsLength, char *aArgs[], char *aOutput, size
     return kErrorNone;
 }
 
+void Diags::ReceiveDone(otRadioFrame *aFrame, Error aError)
+{
+    otPlatDiagRadioReceived(&GetInstance(), aFrame, aError);
+}
+
 extern "C" void otPlatDiagAlarmFired(otInstance *aInstance)
 {
     otPlatDiagAlarmCallback(aInstance);

--- a/src/core/radio/radio_callbacks.cpp
+++ b/src/core/radio/radio_callbacks.cpp
@@ -64,9 +64,14 @@ void Radio::Callbacks::HandleDiagsReceiveDone(Mac::RxFrame *aFrame, Error aError
 #if OPENTHREAD_RADIO && !OPENTHREAD_RADIO_CLI
     // Pass it to notify OpenThread `Diags` module on host side.
     HandleReceiveDone(aFrame, aError);
-#else // For OPENTHREAD_FTD, OPENTHREAD_MTD and OPENTHREAD_RADIO(CLI)
-    Get<FactoryDiags::Diags>().ReceiveDone(aFrame, aError);
 #endif
+    /*
+     * Call Diags::ReceiveDone anyway.
+     * For host + RCP, `otPlatDiagRadioReceived` will be called on both sides.
+     * The posix host has an empty implementation for `otPlatDiagRadioReceived`
+     * and the RCP side has a platform-specific implementation.
+     */
+    Get<FactoryDiags::Diags>().ReceiveDone(aFrame, aError);
 }
 
 void Radio::Callbacks::HandleDiagsTransmitDone(Mac::TxFrame &aFrame, Error aError)


### PR DESCRIPTION
We have some platform-specific diag functionalities implemented in
`otPlatDiagRadioReceived`. However, for RCP mode, `otPlatDiagRadioReceived` is
called on the posix host which has an empty implementation. This PR implemented
Diags::ReceiveDone for RCP so that `otPlatDiagRadioReceived` will also be
called on RCP and has no effect on the host side.