### PR TITLE
[ip6] forward IPv6 fragments only if reassebling is disabled

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -912,10 +912,10 @@ Error Ip6::HandleExtensionHeaders(Message &    aMessage,
             break;
 
         case kProtoFragment:
-            // Always forward IPv6 fragments to the Host.
+#if !OPENTHREAD_CONFIG_IP6_FRAGMENTATION_ENABLE
             IgnoreError(ProcessReceiveCallback(aMessage, aMessageInfo, aNextHeader, aFromHost,
                                                /* aAllowReceiveFilter */ false, Message::kCopyToUse));
-
+#endif
             SuccessOrExit(error = HandleFragment(aMessage, aNetif, aMessageInfo, aFromHost));
             break;
 


### PR DESCRIPTION
IPv6 fragments are unconditionally forwarded to the host even if the option: OT_IP6_FRAGM for internal reassembling is enabled. It results with e.g. for RCP echo request are handled twice, by the OpenThread and by the host.

This commit changes it in this way that when OT_IP6_FRAGM is enabled IPv6 fragments are not forwarded to the host any more but handled internally only. When OT_IP6_FRAGM is disabled the IPv6 fragments are always forwarded to the host. This case is especially important for NCP architecture with spinel maximum frame size limitation (1500B).
Now the option: OT_IP6_FRAGM should be disabled for NCP to allow forwaring IPv6 fragments to the host.