### PR TITLE
[thci] find IPv6 border agents only

### DIFF
--- a/tests/scripts/thread-cert/find_border_agents.py
+++ b/tests/scripts/thread-cert/find_border_agents.py
@@ -29,7 +29,7 @@
 import ipaddress
 import sys
 import time
-from zeroconf import ServiceBrowser, ServiceStateChange, Zeroconf, DNSAddress, DNSService, DNSText
+from zeroconf import IPVersion, ServiceBrowser, ServiceStateChange, Zeroconf, DNSAddress, DNSService, DNSText
 
 
 def on_service_state_change(zeroconf, service_type, name, state_change):
@@ -83,7 +83,7 @@ def parse_cache(cache):
 
 def main():
     # Browse border agents
-    zeroconf = Zeroconf()
+    zeroconf = Zeroconf(ip_version=IPVersion.V6Only)
     ServiceBrowser(zeroconf, "_meshcop._udp.local.", handlers=[on_service_state_change])
     time.sleep(2)
     cache = zeroconf.cache.cache

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -70,9 +70,7 @@ from GRLLibs.UtilityModules.enums import (
 )
 
 if TESTHARNESS_VERSION == TESTHARNESS_1_2:
-    from GRLLibs.UtilityModules.enums import (
-        DevCapb,)
-
+    from GRLLibs.UtilityModules.enums import DevCapb
     import commissioner
     from commissioner_impl import OTCommissioner
 
@@ -1497,8 +1495,9 @@ class OpenThreadTHCI(object):
         self.panId = ModuleHelper.Default_PanId
         self.xpanId = ModuleHelper.Default_XpanId
         self.meshLocalPrefix = ModuleHelper.Default_MLPrefix
-        # OT only accept hex format PSKc for now
-        self.pskc = '00000000000000000000000000000001'
+        stretchedPSKc = Thread_PBKDF2.get(ModuleHelper.Default_PSKc, ModuleHelper.Default_XpanId,
+                                          ModuleHelper.Default_NwkName)
+        self.pskc = hex(stretchedPSKc).rstrip('L').lstrip('0x')
         self.securityPolicySecs = ModuleHelper.Default_SecurityPolicy
         self.securityPolicyFlags = 'onrcb'
         self.activetimestamp = ModuleHelper.Default_ActiveTimestamp

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -648,7 +648,7 @@ EOF"
     def mdns_query(self, dst='ff02::fb', service='_meshcop._udp.local', addrs_blacklist=[]):
         print('mdns_query %s %s %s' % (dst, service, addrs_blacklist))
 
-        # For BBR-TC-03 or DH test cases just send a query
+        # For BBR-TC-03 or DH test cases (empty arguments) just send a query
         if dst == 'ff02::fb' and not addrs_blacklist:
             self.bash('dig -p 5353 @%s %s ptr' % (dst, service), sudo=False)
             return
@@ -659,8 +659,9 @@ EOF"
         for line in output:
             print(line)
             alias, link_local_addr, port, thread_status = eval(line)
-            if thread_status == 2 and link_local_addr not in addrs_blacklist:
-                return '%s%%eth0' % link_local_addr, port
+            if thread_status == 2 and link_local_addr:
+                if (dst and link_local_addr in dst) or (link_local_addr not in addrs_blacklist):
+                    return '%s%%eth0' % link_local_addr, port
 
         raise Exception('No active Border Agents found')
 


### PR DESCRIPTION
Without this fix some Border Agents will not send mDNS responses
with AAAA record for IPv6 link local address.