### PR TITLE
[log] add `OT_SHOULD_LOG_AT(aLevel)`

### DIFF
--- a/script/check-simulation-build-autotools
+++ b/script/check-simulation-build-autotools
@@ -99,7 +99,7 @@ build_all_features()
     )
 
     # Build Thread 1.1 with full features and no log
-    export CPPFLAGS="${options[*]} -DOPENTHREAD_CONFIG_LOG_LEVEL=OT_LOG_LEVEL_NONE"
+    export CPPFLAGS="${options[*]} -DOPENTHREAD_CONFIG_LOG_OUTPUT=OT_LOG_OUTPUT_NONE"
     reset_source
     make -f examples/Makefile-simulation THREAD_VERSION=1.1
 
@@ -109,7 +109,7 @@ build_all_features()
     make -f examples/Makefile-simulation THREAD_VERSION=1.1 FULL_LOGS=1
 
     # Build Thread 1.2 with full features and logs
-    export CPPFLAGS="${options[*]} ${options_1_2[*]} -DOPENTHREAD_CONFIG_LOG_LEVEL=OT_LOG_LEVEL_NONE"
+    export CPPFLAGS="${options[*]} ${options_1_2[*]} -DOPENTHREAD_CONFIG_LOG_OUTPUT=OT_LOG_OUTPUT_NONE"
     reset_source
     make -f examples/Makefile-simulation THREAD_VERSION=1.2
 

--- a/src/core/api/logging_api.cpp
+++ b/src/core/api/logging_api.cpp
@@ -63,7 +63,7 @@ static const char kPlatformModuleName[] = "Platform";
 
 void otLogCritPlat(const char *aFormat, ...)
 {
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_CRIT) && OPENTHREAD_CONFIG_LOG_PLATFORM
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_CRIT) && OPENTHREAD_CONFIG_LOG_PLATFORM
     va_list args;
 
     va_start(args, aFormat);
@@ -77,7 +77,7 @@ void otLogCritPlat(const char *aFormat, ...)
 
 void otLogWarnPlat(const char *aFormat, ...)
 {
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && OPENTHREAD_CONFIG_LOG_PLATFORM
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN) && OPENTHREAD_CONFIG_LOG_PLATFORM
     va_list args;
 
     va_start(args, aFormat);
@@ -90,7 +90,7 @@ void otLogWarnPlat(const char *aFormat, ...)
 
 void otLogNotePlat(const char *aFormat, ...)
 {
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE) && OPENTHREAD_CONFIG_LOG_PLATFORM
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE) && OPENTHREAD_CONFIG_LOG_PLATFORM
     va_list args;
 
     va_start(args, aFormat);
@@ -103,7 +103,7 @@ void otLogNotePlat(const char *aFormat, ...)
 
 void otLogInfoPlat(const char *aFormat, ...)
 {
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && OPENTHREAD_CONFIG_LOG_PLATFORM
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO) && OPENTHREAD_CONFIG_LOG_PLATFORM
     va_list args;
 
     va_start(args, aFormat);
@@ -116,7 +116,7 @@ void otLogInfoPlat(const char *aFormat, ...)
 
 void otLogDebgPlat(const char *aFormat, ...)
 {
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG) && OPENTHREAD_CONFIG_LOG_PLATFORM
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG) && OPENTHREAD_CONFIG_LOG_PLATFORM
     va_list args;
 
     va_start(args, aFormat);
@@ -129,8 +129,7 @@ void otLogDebgPlat(const char *aFormat, ...)
 
 void otDumpCritPlat(const char *aText, const void *aData, uint16_t aDataLength)
 {
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_CRIT) && OPENTHREAD_CONFIG_LOG_PLATFORM && \
-    OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_CRIT) && OPENTHREAD_CONFIG_LOG_PLATFORM && OPENTHREAD_CONFIG_LOG_PKT_DUMP
     Logger::DumpInModule(kPlatformModuleName, kLogLevelCrit, aText, aData, aDataLength);
 #else
     OT_UNUSED_VARIABLE(aText);
@@ -141,8 +140,7 @@ void otDumpCritPlat(const char *aText, const void *aData, uint16_t aDataLength)
 
 void otDumpWarnPlat(const char *aText, const void *aData, uint16_t aDataLength)
 {
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && OPENTHREAD_CONFIG_LOG_PLATFORM && \
-    OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN) && OPENTHREAD_CONFIG_LOG_PLATFORM && OPENTHREAD_CONFIG_LOG_PKT_DUMP
     Logger::DumpInModule(kPlatformModuleName, kLogLevelWarn, aText, aData, aDataLength);
 #else
     OT_UNUSED_VARIABLE(aText);
@@ -153,8 +151,7 @@ void otDumpWarnPlat(const char *aText, const void *aData, uint16_t aDataLength)
 
 void otDumpNotePlat(const char *aText, const void *aData, uint16_t aDataLength)
 {
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE) && OPENTHREAD_CONFIG_LOG_PLATFORM && \
-    OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE) && OPENTHREAD_CONFIG_LOG_PLATFORM && OPENTHREAD_CONFIG_LOG_PKT_DUMP
     Logger::DumpInModule(kPlatformModuleName, kLogLevelNote, aText, aData, aDataLength);
 #else
     OT_UNUSED_VARIABLE(aText);
@@ -165,8 +162,7 @@ void otDumpNotePlat(const char *aText, const void *aData, uint16_t aDataLength)
 
 void otDumpInfoPlat(const char *aText, const void *aData, uint16_t aDataLength)
 {
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && OPENTHREAD_CONFIG_LOG_PLATFORM && \
-    OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO) && OPENTHREAD_CONFIG_LOG_PLATFORM && OPENTHREAD_CONFIG_LOG_PKT_DUMP
     Logger::DumpInModule(kPlatformModuleName, kLogLevelInfo, aText, aData, aDataLength);
 #else
     OT_UNUSED_VARIABLE(aText);
@@ -177,8 +173,7 @@ void otDumpInfoPlat(const char *aText, const void *aData, uint16_t aDataLength)
 
 void otDumpDebgPlat(const char *aText, const void *aData, uint16_t aDataLength)
 {
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG) && OPENTHREAD_CONFIG_LOG_PLATFORM && \
-    OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG) && OPENTHREAD_CONFIG_LOG_PLATFORM && OPENTHREAD_CONFIG_LOG_PKT_DUMP
     Logger::DumpInModule(kPlatformModuleName, kLogLevelDebg, aText, aData, aDataLength);
 #else
     OT_UNUSED_VARIABLE(aText);
@@ -189,7 +184,7 @@ void otDumpDebgPlat(const char *aText, const void *aData, uint16_t aDataLength)
 
 void otLogCli(otLogLevel aLogLevel, const char *aFormat, ...)
 {
-#if OPENTHREAD_CONFIG_LOG_CLI
+#if OT_SHOULD_LOG && OPENTHREAD_CONFIG_LOG_CLI
     static const char kCliModuleName[] = "Cli";
 
     va_list args;

--- a/src/core/backbone_router/bbr_leader.cpp
+++ b/src/core/backbone_router/bbr_leader.cpp
@@ -37,7 +37,6 @@
 
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
-#include "common/log.hpp"
 
 namespace ot {
 namespace BackboneRouter {
@@ -83,7 +82,7 @@ exit:
     return error;
 }
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 void Leader::LogBackboneRouterPrimary(State aState, const BackboneRouterConfig &aConfig) const
 {
@@ -143,7 +142,7 @@ const char *Leader::DomainPrefixStateToString(DomainPrefixState aState)
     return kPrefixStateStrings[aState];
 }
 
-#endif // OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 void Leader::Update(void)
 {

--- a/src/core/backbone_router/bbr_leader.hpp
+++ b/src/core/backbone_router/bbr_leader.hpp
@@ -44,6 +44,7 @@
 #include "coap/coap.hpp"
 #include "coap/coap_message.hpp"
 #include "common/locator.hpp"
+#include "common/log.hpp"
 #include "common/non_copyable.hpp"
 #include "net/ip6_address.hpp"
 
@@ -175,7 +176,7 @@ public:
 private:
     void UpdateBackboneRouterPrimary(void);
     void UpdateDomainPrefixConfig(void);
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
     void               LogBackboneRouterPrimary(State aState, const BackboneRouterConfig &aConfig) const;
     void               LogDomainPrefix(DomainPrefixState aState, const Ip6::Prefix &aPrefix) const;
     static const char *StateToString(State aState);

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -460,7 +460,7 @@ void Local::AddDomainPrefixToNetworkData(void)
     LogDomainPrefix("Add", error);
 }
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 void Local::LogDomainPrefix(const char *aAction, Error aError)
 {
     LogInfo("%s Domain Prefix: %s, %s", aAction, mDomainPrefixConfig.GetPrefix().ToString().AsCString(),

--- a/src/core/backbone_router/bbr_local.hpp
+++ b/src/core/backbone_router/bbr_local.hpp
@@ -55,6 +55,7 @@
 
 #include "backbone_router/bbr_leader.hpp"
 #include "common/locator.hpp"
+#include "common/log.hpp"
 #include "common/non_copyable.hpp"
 #include "net/netif.hpp"
 #include "thread/network_data.hpp"
@@ -274,7 +275,7 @@ private:
     void AddDomainPrefixToNetworkData(void);
     void RemoveDomainPrefixFromNetworkData(void);
     void SequenceNumberIncrease(void);
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
     void LogBackboneRouterService(const char *aAction, Error aError);
     void LogDomainPrefix(const char *aAction, Error aError);
 #else

--- a/src/core/common/log.cpp
+++ b/src/core/common/log.cpp
@@ -60,6 +60,8 @@
 
 namespace ot {
 
+#if OT_SHOULD_LOG
+
 template <LogLevel kLogLevel> void Logger::LogAtLevel(const char *aModuleName, const char *aFormat, ...)
 {
     va_list args;
@@ -258,5 +260,7 @@ exit:
     return;
 }
 #endif // OPENTHREAD_CONFIG_LOG_PKT_DUMP
+
+#endif // OT_SHOULD_LOG
 
 } // namespace ot

--- a/src/core/common/log.hpp
+++ b/src/core/common/log.hpp
@@ -43,6 +43,24 @@
 namespace ot {
 
 /**
+ * @def OT_SHOULD_LOG
+ *
+ * This definition indicates whether or not logging is enabled.
+ *
+ */
+#define OT_SHOULD_LOG (OPENTHREAD_CONFIG_LOG_OUTPUT != OPENTHREAD_CONFIG_LOG_OUTPUT_NONE)
+
+/**
+ * This macro indicates whether the OpenThread logging is enabled at a given log level.
+ *
+ * @param[in] aLevel   The log level to check.
+ *
+ * @returns TRUE if logging is enabled at @p aLevel, FALSE otherwise.
+ *
+ */
+#define OT_SHOULD_LOG_AT(aLevel) (OT_SHOULD_LOG && (OPENTHREAD_CONFIG_LOG_LEVEL >= (aLevel)))
+
+/**
  * This enumeration represents the log level.
  *
  */
@@ -58,6 +76,7 @@ enum LogLevel : uint8_t
 
 constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 
+#if OT_SHOULD_LOG && (OPENTHREAD_CONFIG_LOG_LEVEL != OT_LOG_LEVEL_NONE)
 /**
  * This macro registers log module name.
  *
@@ -77,8 +96,11 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
     }                                                                \
     static_assert(sizeof(kLogModuleName) <= kMaxLogModuleNameLength + 1, "Log module name is too long")
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_CRIT
+#else
+#define RegisterLogModule(aName) static_assert(true, "Consume the required semi-colon at the end of macro")
+#endif
 
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_CRIT)
 /**
  * This macro emits a log message at critical log level.
  *
@@ -90,7 +112,7 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 #define LogCrit(...)
 #endif
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
 /**
  * This macro emits a log message at warning log level.
  *
@@ -102,7 +124,7 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 #define LogWarn(...)
 #endif
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 /**
  * This macro emits a log message at note log level.
  *
@@ -114,7 +136,7 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 #define LogNote(...)
 #endif
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 /**
  * This macro emits a log message at info log level.
  *
@@ -126,7 +148,7 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 #define LogInfo(...)
 #endif
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
 /**
  * This macro emits a log message at debug log level.
  *
@@ -138,6 +160,7 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 #define LogDebg(...)
 #endif
 
+#if OT_SHOULD_LOG
 /**
  * This macro emits a log message at a given log level.
  *
@@ -146,7 +169,11 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
  *
  */
 #define LogAt(aLogLevel, ...) Logger::LogInModule(kLogModuleName, aLogLevel, __VA_ARGS__)
+#else
+#define LogAt(aLogLevel, ...)
+#endif
 
+#if OT_SHOULD_LOG
 /**
  * This macro emits a log message independent of the configured log level.
  *
@@ -154,8 +181,11 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
  *
  */
 #define LogAlways(...) Logger::LogInModule("", kLogLevelNone, __VA_ARGS__)
+#else
+#define LogAlways(...)
+#endif
 
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+#if OT_SHOULD_LOG && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 /**
  * This macro emit a log message for the certification test.
  *
@@ -167,7 +197,7 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 #define LogCert(...)
 #endif
 
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_CRIT) && OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_CRIT) && OPENTHREAD_CONFIG_LOG_PKT_DUMP
 /**
  * This macro generates a memory dump at log level critical.
  *
@@ -181,7 +211,7 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 #define DumpCrit(aText, aData, aDataLength)
 #endif
 
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN) && OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN) && OPENTHREAD_CONFIG_LOG_PKT_DUMP
 /**
  * This macro generates a memory dump at log level warning.
  *
@@ -195,7 +225,7 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 #define DumpWarn(aText, aData, aDataLength)
 #endif
 
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE) && OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE) && OPENTHREAD_CONFIG_LOG_PKT_DUMP
 /**
  * This macro generates a memory dump at log level note.
  *
@@ -209,7 +239,7 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 #define DumpNote(aText, aData, aDataLength)
 #endif
 
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO) && OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO) && OPENTHREAD_CONFIG_LOG_PKT_DUMP
 /**
  * This macro generates a memory dump at log level info.
  *
@@ -223,7 +253,7 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 #define DumpInfo(aText, aData, aDataLength)
 #endif
 
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG) && OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG) && OPENTHREAD_CONFIG_LOG_PKT_DUMP
 /**
  * This macro generates a memory dump at log level debug.
  *
@@ -237,7 +267,7 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 #define DumpDebg(aText, aData, aDataLength)
 #endif
 
-#if OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#if OT_SHOULD_LOG && OPENTHREAD_CONFIG_LOG_PKT_DUMP
 /**
  * This macro generates a memory dump independent of the configured log level.
  *
@@ -249,7 +279,7 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 #define DumpAlways(aText, aData, aDataLength) Logger::DumpInModule("", kLogLevelNone, aText, aData, aDataLength)
 #endif
 
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE && OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#if OT_SHOULD_LOG && OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE && OPENTHREAD_CONFIG_LOG_PKT_DUMP
 /**
  * This macro generates a memory dump for certification test.
  *
@@ -264,6 +294,8 @@ constexpr uint8_t kMaxLogModuleNameLength = 14; ///< Maximum module name length
 #endif
 
 //----------------------------------------------------------------------------------------------------------------------
+
+#if OT_SHOULD_LOG
 
 class Logger
 {
@@ -339,7 +371,8 @@ extern template void Logger::DumpAtLevel<kLogLevelDebg>(const char *aModuleName,
                                                         const char *aText,
                                                         const void *aData,
                                                         uint16_t    aDataLength);
-#endif
+#endif // OPENTHREAD_CONFIG_LOG_PKT_DUMP
+#endif // OT_SHOULD_LOG
 
 } // namespace ot
 

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -216,7 +216,7 @@ exit:
 
 // LCOV_EXCL_START
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 void Notifier::LogEvents(Events aEvents) const
 {
@@ -303,7 +303,7 @@ const char *Notifier::EventToString(Event aEvent) const
     return retval;
 }
 
-#else // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#else // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_INFO)
 
 void Notifier::LogEvents(Events) const
 {
@@ -314,7 +314,7 @@ const char *Notifier::EventToString(Event) const
     return "";
 }
 
-#endif // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#endif // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_INFO)
 
 // LCOV_EXCL_STOP
 

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -37,7 +37,6 @@
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
-#include "common/log.hpp"
 #include "meshcop/dataset.hpp"
 #include "thread/mle.hpp"
 
@@ -50,7 +49,7 @@ RegisterLogModule("Settings");
 
 // LCOV_EXCL_START
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 void SettingsBase::NetworkInfo::Log(Action aAction) const
 {
@@ -106,9 +105,9 @@ void SettingsBase::SrpServerInfo::Log(Action aAction) const
 }
 #endif
 
-#endif // OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 const char *SettingsBase::ActionToString(Action aAction)
 {
     static const char *const kActionStrings[] = {
@@ -135,9 +134,9 @@ const char *SettingsBase::ActionToString(Action aAction)
 
     return kActionStrings[aAction];
 }
-#endif // OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
 const char *SettingsBase::KeyToString(Key aKey)
 {
     static const char *const kKeyStrings[] = {
@@ -179,7 +178,7 @@ const char *SettingsBase::KeyToString(Key aKey)
 
     return kKeyStrings[aKey];
 }
-#endif // OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
+#endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
 
 // LCOV_EXCL_STOP
 
@@ -360,7 +359,7 @@ void Settings::Log(Action aAction, Error aError, Key aKey, const void *aValue)
     {
         // Log error if log level is at "warn" or higher.
 
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN)
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
         const char *actionText = "";
 
         switch (aAction)
@@ -396,7 +395,7 @@ void Settings::Log(Action aAction, Error aError, Key aKey, const void *aValue)
 
         LogWarn("Error %s %s %s", ErrorToString(aError), actionText, KeyToString(aKey));
 
-#endif // #if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN)
+#endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
 
         ExitNow();
     }
@@ -404,7 +403,7 @@ void Settings::Log(Action aAction, Error aError, Key aKey, const void *aValue)
     // We reach here when `aError` is `kErrorNone`.
     // Log success if log level is at "info" or higher.
 
-#if (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO)
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
     if (aValue != nullptr)
     {
         switch (aKey)
@@ -463,7 +462,7 @@ void Settings::Log(Action aAction, Error aError, Key aKey, const void *aValue)
     {
         LogInfo("%s %s", ActionToString(aAction), KeyToString(aKey));
     }
-#endif // (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO)
+#endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 exit:
     return;

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -42,6 +42,7 @@
 #include "common/encoding.hpp"
 #include "common/equatable.hpp"
 #include "common/locator.hpp"
+#include "common/log.hpp"
 #include "common/non_copyable.hpp"
 #include "common/settings_driver.hpp"
 #include "crypto/ecdsa.hpp"
@@ -744,10 +745,10 @@ protected:
     static void LogPrefix(Action aAction, Key aKey, const Ip6::Prefix &aPrefix);
 #endif
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
     static const char *KeyToString(Key aKey);
 #endif
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
     static const char *ActionToString(Action aAction);
 #endif
 };

--- a/src/core/mac/link_raw.cpp
+++ b/src/core/mac/link_raw.cpp
@@ -271,7 +271,7 @@ exit:
 
 // LCOV_EXCL_START
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 void LinkRaw::RecordFrameTransmitStatus(const TxFrame &aFrame,
                                         const RxFrame *aAckFrame,

--- a/src/core/mac/link_raw.hpp
+++ b/src/core/mac/link_raw.hpp
@@ -41,6 +41,7 @@
 #include <openthread/link_raw.h>
 
 #include "common/locator.hpp"
+#include "common/log.hpp"
 #include "common/non_copyable.hpp"
 #include "mac/mac_frame.hpp"
 #include "mac/sub_mac.hpp"
@@ -277,6 +278,7 @@ public:
      */
     Error SetMacFrameCounter(uint32_t aMacFrameCounter);
 
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
     /**
      * This method records the status of a frame transmission attempt and is mainly used for logging failures.
      *
@@ -294,7 +296,6 @@ public:
      *                        when there was an error in transmission (i.e., `aError` is not NONE).
      *
      */
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
     void RecordFrameTransmitStatus(const TxFrame &aFrame,
                                    const RxFrame *aAckFrame,
                                    Error          aError,

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -42,7 +42,6 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
-#include "common/log.hpp"
 #include "common/random.hpp"
 #include "common/string.hpp"
 #include "crypto/aes_ccm.hpp"
@@ -2190,7 +2189,7 @@ void Mac::ResetRetrySuccessHistogram()
 
 // LCOV_EXCL_START
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 const char *Mac::OperationToString(Operation aOperation)
 {
@@ -2281,7 +2280,7 @@ void Mac::LogBeacon(const char *aActionText, const BeaconPayload &aBeaconPayload
     LogInfo("%s Beacon, %s", aActionText, aBeaconPayload.ToInfoString().AsCString());
 }
 
-#else // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#else // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 void Mac::LogFrameRxFailure(const RxFrame *, Error) const
 {
@@ -2295,7 +2294,7 @@ void Mac::LogFrameTxFailure(const TxFrame &, Error, uint8_t, bool) const
 {
 }
 
-#endif // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 // LCOV_EXCL_STOP
 

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -40,6 +40,7 @@
 #include <openthread/platform/time.h>
 
 #include "common/locator.hpp"
+#include "common/log.hpp"
 #include "common/non_copyable.hpp"
 #include "common/tasklet.hpp"
 #include "common/time.hpp"

--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -37,6 +37,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/debug.hpp"
+#include "common/log.hpp"
 #include "radio/trel_link.hpp"
 #if !OPENTHREAD_RADIO || OPENTHREAD_CONFIG_MAC_SOFTWARE_TX_SECURITY_ENABLE
 #include "crypto/aes_ccm.hpp"
@@ -1379,7 +1380,7 @@ exit:
 
 // LCOV_EXCL_START
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 
 Frame::InfoString Frame::ToInfoString(void) const
 {
@@ -1459,7 +1460,7 @@ BeaconPayload::InfoString BeaconPayload::ToInfoString(void) const
     return string;
 }
 
-#endif // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 
 // LCOV_EXCL_STOP
 

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -43,7 +43,6 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
-#include "common/log.hpp"
 #include "common/string.hpp"
 #include "meshcop/joiner.hpp"
 #include "meshcop/joiner_router.hpp"
@@ -1210,7 +1209,7 @@ exit:
 
 // LCOV_EXCL_START
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 const char *Commissioner::StateToString(State aState)
 {
@@ -1256,7 +1255,7 @@ void Commissioner::LogJoinerEntry(const char *, const Joiner &) const
 {
 }
 
-#endif // OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 // LCOV_EXCL_STOP
 

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -45,6 +45,7 @@
 #include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/locator.hpp"
+#include "common/log.hpp"
 #include "common/non_copyable.hpp"
 #include "common/timer.hpp"
 #include "mac/mac_types.hpp"

--- a/src/core/meshcop/meshcop.cpp
+++ b/src/core/meshcop/meshcop.cpp
@@ -36,7 +36,6 @@
 #include "common/crc16.hpp"
 #include "common/debug.hpp"
 #include "common/locator_getters.hpp"
-#include "common/log.hpp"
 #include "common/string.hpp"
 #include "crypto/pbkdf2_cmac.hpp"
 #include "crypto/sha256.hpp"
@@ -357,7 +356,7 @@ exit:
 }
 #endif // OPENTHREAD_FTD
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
 void LogError(const char *aActionText, Error aError)
 {
     if (aError != kErrorNone && aError != kErrorAlready)

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -47,6 +47,7 @@
 #include "common/as_core_type.hpp"
 #include "common/clearable.hpp"
 #include "common/equatable.hpp"
+#include "common/log.hpp"
 #include "common/message.hpp"
 #include "common/string.hpp"
 #include "mac/mac_types.hpp"
@@ -445,7 +446,7 @@ void ComputeJoinerId(const Mac::ExtAddress &aEui64, Mac::ExtAddress &aJoinerId);
  */
 Error GetBorderAgentRloc(ThreadNetif &aNetIf, uint16_t &aRloc);
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
 /**
  * This function emits a log message indicating an error during a MeshCoP action.
  *

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -35,7 +35,7 @@
 #include "common/debug.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
-#include "common/log.hpp"
+
 #include "common/numeric_limits.hpp"
 #include "common/random.hpp"
 #include "common/settings.hpp"
@@ -1868,7 +1868,7 @@ const char *Client::ItemStateToString(ItemState aState)
     return kItemStateStrings[aState];
 }
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 const char *Client::StateToString(State aState)
 {
@@ -1901,7 +1901,7 @@ void Client::LogRetryWaitInterval(void) const
             (interval < kLogInMsecLimit) ? "ms" : "sec");
 }
 
-#endif // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 } // namespace Srp
 } // namespace ot

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -39,6 +39,7 @@
 #include "common/clearable.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
+#include "common/log.hpp"
 #include "common/message.hpp"
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
@@ -843,7 +844,7 @@ private:
 #endif
 #endif
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
     static const char *StateToString(State aState);
     void               LogRetryWaitInterval(void) const;
 #else

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -1540,7 +1540,7 @@ exit:
     return matches;
 }
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 void Server::Service::Log(Action aAction) const
 {
     static const char *const kActionStrings[] = {
@@ -1578,7 +1578,7 @@ void Server::Service::Log(Action aAction) const
 void Server::Service::Log(Action) const
 {
 }
-#endif // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 //---------------------------------------------------------------------------------------------------------------------
 // Server::Service::Description

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -995,7 +995,7 @@ exit:
 
 // LCOV_EXCL_START
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 
 void AddressResolver::LogCacheEntryChange(EntryChange       aChange,
                                           Reason            aReason,
@@ -1049,13 +1049,13 @@ exit:
     return str;
 }
 
-#else // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#else // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 
 void AddressResolver::LogCacheEntryChange(EntryChange, Reason, const CacheEntry &, CacheEntryList *)
 {
 }
 
-#endif // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 
 // LCOV_EXCL_STOP
 

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1704,7 +1704,7 @@ exit:
     return error;
 }
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 
 const char *MeshForwarder::MessageActionToString(MessageAction aAction, Error aError)
 {
@@ -1884,7 +1884,7 @@ void MeshForwarder::LogLowpanHcFrameDrop(Error               aError,
             aFrameLength, aMacSource.ToString().AsCString(), aMacDest.ToString().AsCString(), ToYesNo(aIsSecure));
 }
 
-#else // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#else // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_NOTE)
 
 void MeshForwarder::LogMessage(MessageAction, const Message &, const Mac::Address *, Error)
 {
@@ -1907,7 +1907,7 @@ void MeshForwarder::LogLowpanHcFrameDrop(Error, uint16_t, const Mac::Address &, 
 {
 }
 
-#endif // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#endif // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_NOTE)
 
 // LCOV_EXCL_STOP
 

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -536,7 +536,7 @@ private:
     otError ForwardDuaToBackboneLink(Message &aMessage, const Ip6::Address &aDst);
 #endif
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
     const char *MessageActionToString(MessageAction aAction, Error aError);
     const char *MessagePriorityToString(const Message &aMessage);
 
@@ -577,7 +577,7 @@ private:
                        const Mac::Address *aAddress,
                        Error               aError,
                        LogLevel            aLogLevel);
-#endif // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 
     PriorityQueue mSendQueue;
     MessageQueue  mReassemblyList;

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -1024,7 +1024,7 @@ exit:
 
 // LCOV_EXCL_START
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 
 Error MeshForwarder::LogMeshFragmentHeader(MessageAction       aAction,
                                            const Message &     aMessage,
@@ -1209,7 +1209,7 @@ exit:
     return;
 }
 
-#endif // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 
 // LCOV_EXCL_STOP
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -43,7 +43,6 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
-#include "common/log.hpp"
 #include "common/random.hpp"
 #include "common/serial_number.hpp"
 #include "common/settings.hpp"
@@ -4311,7 +4310,7 @@ void Mle::UpdateParentSearchState(void)
 }
 #endif // OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 void Mle::Log(MessageAction aAction, MessageType aType, const Ip6::Address &aAddress)
 {
     Log(aAction, aType, aAddress, Mac::kShortAddrInvalid);
@@ -4336,7 +4335,7 @@ void Mle::Log(MessageAction aAction, MessageType aType, const Ip6::Address &aAdd
 }
 #endif
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
 void Mle::LogProcessError(MessageType aType, Error aError)
 {
     LogError(kMessageReceive, aType, aError);
@@ -4513,7 +4512,7 @@ const char *Mle::MessageTypeActionToSuffixString(MessageType aType, MessageActio
     return str;
 }
 
-#endif // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
+#endif // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_WARN)
 
 const char *Mle::RoleToString(DeviceRole aRole)
 {
@@ -4536,7 +4535,7 @@ const char *Mle::RoleToString(DeviceRole aRole)
 
 // LCOV_EXCL_START
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 
 const char *Mle::AttachModeToString(AttachMode aMode)
 {
@@ -4597,7 +4596,7 @@ const char *Mle::ReattachStateToString(ReattachState aState)
     return kReattachStateStrings[aState];
 }
 
-#endif // OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#endif // OT_SHOULD_LOG_AT( OT_LOG_LEVEL_NOTE)
 
 // LCOV_EXCL_STOP
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -38,6 +38,7 @@
 
 #include "common/encoding.hpp"
 #include "common/locator.hpp"
+#include "common/log.hpp"
 #include "common/non_copyable.hpp"
 #include "common/notifier.hpp"
 #include "common/timer.hpp"
@@ -1453,7 +1454,7 @@ protected:
      */
     Error AddDelayedResponse(Message &aMessage, const Ip6::Address &aDestination, uint16_t aDelay);
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
     /**
      * This static method emits a log message with an IPv6 address.
      *
@@ -1477,9 +1478,9 @@ protected:
 #else
     static void Log(MessageAction, MessageType, const Ip6::Address &) {}
     static void Log(MessageAction, MessageType, const Ip6::Address &, uint16_t) {}
-#endif // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#endif // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_INFO)
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
     /**
      * This static method emits a log message indicating an error in processing of a message.
      *
@@ -1506,7 +1507,7 @@ protected:
 #else
     static void LogProcessError(MessageType, Error) {}
     static void LogSendError(MessageType, Error) {}
-#endif // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
+#endif // #if OT_SHOULD_LOG_AT( OT_LOG_LEVEL_WARN)
 
     /**
      * This method triggers MLE Announce on previous channel after the Thread device successfully
@@ -1526,7 +1527,7 @@ protected:
      */
     bool IsAnnounceAttach(void) const { return mAlternatePanId != Mac::kPanIdBroadcast; }
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_NOTE
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
     /**
      * This method converts an `AttachMode` enumeration value into a human-readable string.
      *
@@ -1861,7 +1862,7 @@ private:
     void        UpdateParentSearchState(void);
 #endif
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
     static void        LogError(MessageAction aAction, MessageType aType, Error aError);
     static const char *MessageActionToString(MessageAction aAction);
     static const char *MessageTypeToString(MessageType aType);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -40,7 +40,6 @@
 #include "common/encoding.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
-#include "common/log.hpp"
 #include "common/random.hpp"
 #include "common/serial_number.hpp"
 #include "common/settings.hpp"
@@ -1552,7 +1551,7 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
         ResetAdvertiseInterval();
     }
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
     VerifyOrExit(changed);
     LogInfo("Route table updated");

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -682,7 +682,7 @@ void MlrManager::UpdateReregistrationDelay(bool aRereg)
 
 void MlrManager::LogMulticastAddresses(void)
 {
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
     LogDebg("-------- Multicast Addresses --------");
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE
@@ -703,7 +703,7 @@ void MlrManager::LogMulticastAddresses(void)
     }
 #endif
 
-#endif // OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
+#endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
 }
 
 void MlrManager::AppendToUniqueAddressList(Ip6::Address (&aAddresses)[kIp6AddressesNumMax],
@@ -761,7 +761,7 @@ void MlrManager::LogMlrResponse(Error               aResult,
     OT_UNUSED_VARIABLE(aFailedAddresses);
     OT_UNUSED_VARIABLE(aFailedAddressNum);
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_WARN
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_WARN)
     if (aResult == kErrorNone && aError == kErrorNone && aStatus == ThreadStatusTlv::MlrStatus::kMlrSuccess)
     {
         LogInfo("Receive MLR.rsp OK");

--- a/src/core/thread/radio_selector.cpp
+++ b/src/core/thread/radio_selector.cpp
@@ -355,7 +355,7 @@ Mac::RadioType RadioSelector::SelectPollFrameRadio(const Neighbor &aParent)
 
 // LCOV_EXCL_START
 
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 void RadioSelector::Log(LogLevel        aLogLevel,
                         const char *    aActionText,
@@ -385,13 +385,13 @@ exit:
     return;
 }
 
-#else // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#else // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 void RadioSelector::Log(LogLevel, const char *, Mac::RadioType, const Neighbor &)
 {
 }
 
-#endif // #if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
 
 // LCOV_EXCL_STOP
 

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -191,7 +191,7 @@ void ChannelMonitor::HandleEnergyScanResult(Mac::EnergyScanResult *aResult)
 
 void ChannelMonitor::LogResults(void)
 {
-#if OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_INFO
+#if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)
     const size_t        kStringSize = 128;
     String<kStringSize> logString;
 

--- a/src/posix/platform/multicast_routing.cpp
+++ b/src/posix/platform/multicast_routing.cpp
@@ -480,7 +480,7 @@ const char *MulticastRoutingManager::MifIndexToString(MifIndex aMif)
 
 void MulticastRoutingManager::DumpMulticastForwardingCache(void) const
 {
-#if OPENTHREAD_CONFIG_LOG_PLATFORM && OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG
+#if OPENTHREAD_CONFIG_LOG_PLATFORM && (OPENTHREAD_CONFIG_LOG_LEVEL >= OT_LOG_LEVEL_DEBG)
     otLogDebgPlat("MulticastRoutingManager: ==================== MFC ENTRIES ====================");
 
     for (const MulticastForwardingCache &mfc : mMulticastForwardingCacheTable)


### PR DESCRIPTION
This commit adds new helper macro `OT_SHOULD_LOG_AT(aLevel)` which
indicates whether logging is enabled at a given log level. This helps
simplify the code and makes sure the the condition used for enabling
logging related functions/methods is consistent across all the core
modules.

With this change, when `OPENTHREAD_CONFIG_LOG_OUTPUT` is set to
`LOG_OUTPUT_NONE` (which practically disables all logging), all the
related code/methods that are used to prepare the log line
(e.g. `Mac::OperationToString()`) are excluded from the build
(become empty functions/methods). This way, under `LOG_OUTPUT = NONE`
instead of preparing the log line and then passing it to an empty
`otPlatLog()` implementation to be dropped, the code is optimized to
not prepare the log line in first place.