### PR TITLE
[thci] avoid further delay after `ping` command

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1388,7 +1388,6 @@ class OpenThreadTHCI(object):
         print('destination: %s' % strDestination)
         cmd = 'ping %s %s 1 1 %d %d' % (strDestination, str(ilength), hop_limit, timeout)
         self.__executeCommand(cmd)
-        time.sleep(1)
 
     @API
     def multicast_Ping(self, destination, length=20):


### PR DESCRIPTION
Test L5.3.5 is failing sometimes because there are unwanted data
requests during the second ping round. This can be mitigated by
finishing earlier with this round so there is no need for children
to synchronize CSL.