### PR TITLE
[csl] adjust polling closer to the CSL Timeout end

### DIFF
--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -550,7 +550,8 @@ uint32_t DataPollSender::GetDefaultPollPeriod(void) const
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE && OPENTHREAD_CONFIG_MAC_CSL_AUTO_SYNC_ENABLE
     if (Get<Mac::Mac>().IsCslEnabled())
     {
-        period = OT_MIN(period, Time::SecToMsec(Get<Mle::MleRouter>().GetCslTimeout()));
+        period    = OT_MIN(period, Time::SecToMsec(Get<Mle::MleRouter>().GetCslTimeout()));
+        pollAhead = static_cast<uint32_t>(kRetxPollPeriod);
     }
 #endif
 


### PR DESCRIPTION
Thread Certification Harness makes use of CSL Timeout configurations
as low as 10 seconds, with the expectation that the SSED will try to
autosync very near to the end of the CSL Timeout.

However, the default configuration is to send a Data Request 4 secs
before, which makes several certification tests to fail due to
unexpected polling.

This commit sets the default `pollAhead` to 1 second, aligning better
with the certification testing expectations.

For the on field deployments it shouldn't be an issue that the Data
Request does not reach the parent exactly before the CSL Timeout
expiration since it will resynchronize anyway once one of the
retransmissions reaches the parent.