### PR TITLE
[mle] add `SendDelayedResponse()` method

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1788,6 +1788,7 @@ private:
     void        HandleAttachTimer(void);
     static void HandleDelayedResponseTimer(Timer &aTimer);
     void        HandleDelayedResponseTimer(void);
+    void        SendDelayedResponse(Message &aMessage, const DelayedResponseMetadata &aMetadata);
     static void HandleMessageTransmissionTimer(Timer &aTimer);
     void        HandleMessageTransmissionTimer(void);
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);


### PR DESCRIPTION

----

This change just moves the existing implementation to a method,
so that we can use `SuccessOrExit()` to exit early on error, replacing
lines such as:
```c++
error = (error == kErrorNone) ? AppendPendingTimestamp(*message) : error;
```