### PR TITLE
[mle] add `RemoveDelayedMessage()` helper method

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1831,7 +1831,8 @@ private:
     bool     PrepareAnnounceState(void);
     void     SendAnnounce(uint8_t aChannel, AnnounceMode aMode);
     void     SendAnnounce(uint8_t aChannel, const Ip6::Address &aDestination, AnnounceMode aMode = kNormalAnnounce);
-    void     RemoveDelayedDataRequestMessage(const Ip6::Address &aDestination);
+    void RemoveDelayedMessage(Message::SubType aSubType, MessageType aMessageType, const Ip6::Address *aDestination);
+    void RemoveDelayedDataRequestMessage(const Ip6::Address &aDestination);
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
     Error SendLinkMetricsManagementResponse(const Ip6::Address &aDestination, LinkMetrics::Status aStatus);
 #endif


### PR DESCRIPTION
This commit adds `Mle::RemoveDelayedMessage()` helper method which
removes messages with a given sub-type and an optional destination
IPv6 address from the `mDelayedResponses` message queue.