### PR TITLE
[thci] unify IPv6 prefix representation

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1649,6 +1649,7 @@ class OpenThreadTHCI(object):
             False: fail to remove the prefix entry from border router
         """
         print('%s call removeRouterPrefix' % self)
+        assert(ipaddress.IPv6Network(prefixEntry.decode()))
         cmd = 'prefix remove %s/64' % prefixEntry
         print(cmd)
         if self.__executeCommand(cmd)[-1] == 'Done':
@@ -1688,6 +1689,7 @@ class OpenThreadTHCI(object):
         """
         print('%s call configBorderRouter' % self)
         assert TESTHARNESS_VERSION == TESTHARNESS_1_2 or P_dp == 0
+        assert(ipaddress.IPv6Network(P_Prefix.decode()))
 
         # turn off default domain prefix if configBorderRouter is called before joining network
         if TESTHARNESS_VERSION == TESTHARNESS_1_2 and P_dp == 0 and not self.__isOpenThreadRunning():
@@ -1858,6 +1860,7 @@ class OpenThreadTHCI(object):
             False: fail to configure the border router with a given external route prefix
         """
         print('%s call configExternalRouter' % self)
+        assert(ipaddress.IPv6Network(P_Prefix.decode()))
         prf = ''
         stable = ''
         if R_Preference == 1:

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1649,7 +1649,7 @@ class OpenThreadTHCI(object):
             False: fail to remove the prefix entry from border router
         """
         print('%s call removeRouterPrefix' % self)
-        assert(ipaddress.IPv6Network(prefixEntry.decode()))
+        assert (ipaddress.IPv6Network(prefixEntry.decode()))
         cmd = 'prefix remove %s/64' % prefixEntry
         print(cmd)
         if self.__executeCommand(cmd)[-1] == 'Done':
@@ -1689,7 +1689,7 @@ class OpenThreadTHCI(object):
         """
         print('%s call configBorderRouter' % self)
         assert TESTHARNESS_VERSION == TESTHARNESS_1_2 or P_dp == 0
-        assert(ipaddress.IPv6Network(P_Prefix.decode()))
+        assert (ipaddress.IPv6Network(P_Prefix.decode()))
 
         # turn off default domain prefix if configBorderRouter is called before joining network
         if TESTHARNESS_VERSION == TESTHARNESS_1_2 and P_dp == 0 and not self.__isOpenThreadRunning():
@@ -1860,7 +1860,7 @@ class OpenThreadTHCI(object):
             False: fail to configure the border router with a given external route prefix
         """
         print('%s call configExternalRouter' % self)
-        assert(ipaddress.IPv6Network(P_Prefix.decode()))
+        assert (ipaddress.IPv6Network(P_Prefix.decode()))
         prf = ''
         stable = ''
         if R_Preference == 1:

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -681,26 +681,6 @@ class OpenThreadTHCI(object):
 
         return None
 
-    def __convertIp6PrefixStringToIp6Address(self, strIp6Prefix):
-        """convert IPv6 prefix string to IPv6 dotted-quad format
-           for example:
-           2001000000000000 -> 2001:0000:0000:0000::
-
-        Args:
-            strIp6Prefix: IPv6 address string
-
-        Returns:
-            IPv6 address dotted-quad format
-        """
-        prefix1 = strIp6Prefix.rstrip('L')
-        prefix2 = self.__lstrip0x(prefix1)
-        hexPrefix = str(prefix2).ljust(16, '0')
-        hexIter = iter(hexPrefix)
-        finalMac = ':'.join(a + b + c + d for a, b, c, d in zip(hexIter, hexIter, hexIter, hexIter))
-        prefix = str(finalMac)
-        strIp6Prefix = prefix[:19]
-        return strIp6Prefix + '::'
-
     # pylint: disable=no-self-use
     def __convertLongToHex(self, iValue, fillZeros=None):
         """convert a long hex integer to string
@@ -1662,17 +1642,14 @@ class OpenThreadTHCI(object):
         """remove the configured prefix on a border router
 
         Args:
-            prefixEntry: a on-mesh prefix entry
+            prefixEntry: a on-mesh prefix entry in IPv6 dotted-quad format
 
         Returns:
             True: successful to remove the prefix entry from border router
             False: fail to remove the prefix entry from border router
         """
         print('%s call removeRouterPrefix' % self)
-        print(prefixEntry)
-        prefix = self.__convertIp6PrefixStringToIp6Address(str(prefixEntry))
-        prefixLen = 64
-        cmd = 'prefix remove %s/%d' % (prefix, prefixLen)
+        cmd = 'prefix remove %s/64' % prefixEntry
         print(cmd)
         if self.__executeCommand(cmd)[-1] == 'Done':
             # send server data ntf to leader
@@ -1683,7 +1660,7 @@ class OpenThreadTHCI(object):
     @API
     def configBorderRouter(
         self,
-        P_Prefix=None,
+        P_Prefix="fd00:7d03:7d03:7d03::",
         P_stable=1,
         P_default=1,
         P_slaac_preferred=0,
@@ -1696,7 +1673,7 @@ class OpenThreadTHCI(object):
         """configure the border router with a given prefix entry parameters
 
         Args:
-            P_Prefix: IPv6 prefix that is available on the Thread Network
+            P_Prefix: IPv6 prefix that is available on the Thread Network in IPv6 dotted-quad format
             P_stable: true if the default router is expected to be stable network data
             P_default: true if border router offers the default route for P_Prefix
             P_slaac_preferred: true if allowing auto-configure address using P_Prefix
@@ -1716,19 +1693,6 @@ class OpenThreadTHCI(object):
         if TESTHARNESS_VERSION == TESTHARNESS_1_2 and P_dp == 0 and not self.__isOpenThreadRunning():
             self.__useDefaultDomainPrefix = False
 
-        if TESTHARNESS_VERSION == TESTHARNESS_1_2 and self.IsBackboneRouter:
-            # TestHarness 1.2 converts 0x2001000000000000 to "2001000000000000"
-            if P_Prefix is None:
-                P_Prefix = 0xfd007d037d037d03
-
-            P_Prefix = '%016x' % P_Prefix
-        else:
-            # TestHarness 1.1 converts 2001000000000000 to "2001000000000000" (it's wrong, but not fixed yet.)
-            P_Prefix = str(P_Prefix)
-            int(P_Prefix, 16)
-
-        prefix = self.__convertIp6PrefixStringToIp6Address(P_Prefix)
-        print(prefix)
         parameter = ''
         prf = ''
 
@@ -1764,7 +1728,7 @@ class OpenThreadTHCI(object):
         else:
             pass
 
-        cmd = 'prefix add %s/64 %s %s' % (prefix, parameter, prf)
+        cmd = 'prefix add %s/64 %s %s' % (P_Prefix, parameter, prf)
         print(cmd)
         if self.__executeCommand(cmd)[-1] == 'Done':
             # if prefix configured before starting OpenThread stack
@@ -1882,7 +1846,7 @@ class OpenThreadTHCI(object):
         """configure border router with a given external route prefix entry
 
         Args:
-            P_Prefix: IPv6 prefix for the route
+            P_Prefix: IPv6 prefix for the route in IPv6 dotted-quad format
             P_Stable: is true if the external route prefix is stable network data
             R_Preference: a two-bit signed integer indicating Router preference
                           1: high
@@ -1894,10 +1858,8 @@ class OpenThreadTHCI(object):
             False: fail to configure the border router with a given external route prefix
         """
         print('%s call configExternalRouter' % self)
-        print(P_Prefix)
         prf = ''
         stable = ''
-        prefix = self.__convertIp6PrefixStringToIp6Address(str(P_Prefix))
         if R_Preference == 1:
             prf = 'high'
         elif R_Preference == 0:
@@ -1909,9 +1871,9 @@ class OpenThreadTHCI(object):
 
         if P_stable:
             stable += 's'
-            cmd = 'route add %s/64 %s %s' % (prefix, stable, prf)
+            cmd = 'route add %s/64 %s %s' % (P_Prefix, stable, prf)
         else:
-            cmd = 'route add %s/64 %s' % (prefix, prf)
+            cmd = 'route add %s/64 %s' % (P_Prefix, prf)
         print(cmd)
 
         if self.__executeCommand(cmd)[-1] == 'Done':


### PR DESCRIPTION
Switch to IPv6 dotted-quad format in all uses.

See https://threadgroup.atlassian.net/browse/DEV-2195