### PR TITLE
[message] add range-based `for` loop for message/priority queue

### DIFF
--- a/src/core/coap/coap_message.cpp
+++ b/src/core/coap/coap_message.cpp
@@ -476,6 +476,16 @@ const char *Message::CodeToString(void) const
 }
 #endif // OPENTHREAD_CONFIG_COAP_API_ENABLE
 
+Message::Iterator MessageQueue::begin(void)
+{
+    return Message::Iterator(GetHead());
+}
+
+Message::ConstIterator MessageQueue::begin(void) const
+{
+    return Message::ConstIterator(GetHead());
+}
+
 Error Option::Iterator::Init(const Message &aMessage)
 {
     Error    error  = kErrorParse;

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -199,6 +199,15 @@ const Message::Settings &Message::Settings::From(const otMessageSettings *aSetti
 }
 
 //---------------------------------------------------------------------------------------------------------------------
+// Message::Iterator
+
+void Message::Iterator::Advance(void)
+{
+    mItem = mNext;
+    mNext = NextMessage(mNext);
+}
+
+//---------------------------------------------------------------------------------------------------------------------
 // Message
 
 Error Message::ResizeMessage(uint16_t aLength)
@@ -740,16 +749,6 @@ void Message::SetPriorityQueue(PriorityQueue *aPriorityQueue)
 //---------------------------------------------------------------------------------------------------------------------
 // MessageQueue
 
-MessageQueue::MessageQueue(void)
-{
-    SetTail(nullptr);
-}
-
-Message *MessageQueue::GetHead(void) const
-{
-    return (GetTail() == nullptr) ? nullptr : GetTail()->Next();
-}
-
 void MessageQueue::Enqueue(Message &aMessage, QueuePosition aPosition)
 {
     OT_ASSERT(!aMessage.IsInAQueue());
@@ -821,37 +820,39 @@ void MessageQueue::DequeueAndFreeAll(void)
     }
 }
 
+Message::Iterator MessageQueue::begin(void)
+{
+    return Message::Iterator(GetHead());
+}
+
+Message::ConstIterator MessageQueue::begin(void) const
+{
+    return Message::ConstIterator(GetHead());
+}
+
 void MessageQueue::GetInfo(uint16_t &aMessageCount, uint16_t &aBufferCount) const
 {
     aMessageCount = 0;
     aBufferCount  = 0;
 
-    for (const Message *message = GetHead(); message != nullptr; message = message->GetNext())
+    for (const Message &message : *this)
     {
         aMessageCount++;
-        aBufferCount += message->GetBufferCount();
+        aBufferCount += message.GetBufferCount();
     }
 }
 
 //---------------------------------------------------------------------------------------------------------------------
 // PriorityQueue
 
-PriorityQueue::PriorityQueue(void)
-{
-    for (Message *&tail : mTails)
-    {
-        tail = nullptr;
-    }
-}
-
-Message *PriorityQueue::FindFirstNonNullTail(Message::Priority aStartPriorityLevel) const
+const Message *PriorityQueue::FindFirstNonNullTail(Message::Priority aStartPriorityLevel) const
 {
     // Find the first non-`nullptr` tail starting from the given priority
     // level and moving forward (wrapping from priority value
     // `kNumPriorities` -1 back to 0).
 
-    Message *tail = nullptr;
-    uint8_t  priority;
+    const Message *tail = nullptr;
+    uint8_t        priority;
 
     priority = static_cast<uint8_t>(aStartPriorityLevel);
 
@@ -869,19 +870,15 @@ Message *PriorityQueue::FindFirstNonNullTail(Message::Priority aStartPriorityLev
     return tail;
 }
 
-Message *PriorityQueue::GetHead(void) const
+const Message *PriorityQueue::GetHead(void) const
 {
-    Message *tail;
-
-    tail = FindFirstNonNullTail(Message::kPriorityLow);
-
-    return (tail == nullptr) ? nullptr : tail->Next();
+    return Message::NextOf(FindFirstNonNullTail(Message::kPriorityLow));
 }
 
-Message *PriorityQueue::GetHeadForPriority(Message::Priority aPriority) const
+const Message *PriorityQueue::GetHeadForPriority(Message::Priority aPriority) const
 {
-    Message *head;
-    Message *previousTail;
+    const Message *head;
+    const Message *previousTail;
 
     if (mTails[aPriority] != nullptr)
     {
@@ -899,7 +896,7 @@ Message *PriorityQueue::GetHeadForPriority(Message::Priority aPriority) const
     return head;
 }
 
-Message *PriorityQueue::GetTail(void) const
+const Message *PriorityQueue::GetTail(void) const
 {
     return FindFirstNonNullTail(Message::kPriorityLow);
 }
@@ -983,15 +980,25 @@ void PriorityQueue::DequeueAndFreeAll(void)
     }
 }
 
+Message::Iterator PriorityQueue::begin(void)
+{
+    return Message::Iterator(GetHead());
+}
+
+Message::ConstIterator PriorityQueue::begin(void) const
+{
+    return Message::ConstIterator(GetHead());
+}
+
 void PriorityQueue::GetInfo(uint16_t &aMessageCount, uint16_t &aBufferCount) const
 {
     aMessageCount = 0;
     aBufferCount  = 0;
 
-    for (const Message *message = GetHead(); message != nullptr; message = message->GetNext())
+    for (const Message &message : *this)
     {
         aMessageCount++;
-        aBufferCount += message->GetBufferCount();
+        aBufferCount += message.GetBufferCount();
     }
 }
 

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -344,14 +344,10 @@ void Mpl::HandleRetransmissionTimer(void)
     TimeMilli now      = TimerMilli::GetNow();
     TimeMilli nextTime = now.GetDistantFuture();
     Metadata  metadata;
-    Message * message;
-    Message * nextMessage;
 
-    for (message = mBufferedMessageSet.GetHead(); message != nullptr; message = nextMessage)
+    for (Message &message : mBufferedMessageSet)
     {
-        nextMessage = message->GetNext();
-
-        metadata.ReadFrom(*message);
+        metadata.ReadFrom(message);
 
         if (now < metadata.mTransmissionTime)
         {
@@ -367,7 +363,7 @@ void Mpl::HandleRetransmissionTimer(void)
 
             if (metadata.mTransmissionCount < GetTimerExpirations())
             {
-                Message *messageCopy = message->Clone(message->GetLength() - sizeof(Metadata));
+                Message *messageCopy = message.Clone(message.GetLength() - sizeof(Metadata));
 
                 if (messageCopy != nullptr)
                 {
@@ -380,7 +376,7 @@ void Mpl::HandleRetransmissionTimer(void)
                 }
 
                 metadata.GenerateNextTransmissionTime(now, kDataMessageInterval);
-                metadata.UpdateIn(*message);
+                metadata.UpdateIn(message);
 
                 if (nextTime > metadata.mTransmissionTime)
                 {
@@ -389,22 +385,22 @@ void Mpl::HandleRetransmissionTimer(void)
             }
             else
             {
-                mBufferedMessageSet.Dequeue(*message);
+                mBufferedMessageSet.Dequeue(message);
 
                 if (metadata.mTransmissionCount == GetTimerExpirations())
                 {
                     if (metadata.mTransmissionCount > 1)
                     {
-                        message->SetSubType(Message::kSubTypeMplRetransmission);
+                        message.SetSubType(Message::kSubTypeMplRetransmission);
                     }
 
-                    metadata.RemoveFrom(*message);
-                    Get<Ip6>().EnqueueDatagram(*message);
+                    metadata.RemoveFrom(message);
+                    Get<Ip6>().EnqueueDatagram(message);
                 }
                 else
                 {
                     // Stop retransmitting if the number of timer expirations is already exceeded.
-                    message->Free();
+                    message.Free();
                 }
             }
         }

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -136,18 +136,13 @@ exit:
 
 void IndirectSender::ClearAllMessagesForSleepyChild(Child &aChild)
 {
-    Message *message;
-    Message *nextMessage;
-
     VerifyOrExit(aChild.GetIndirectMessageCount() > 0);
 
-    for (message = Get<MeshForwarder>().mSendQueue.GetHead(); message; message = nextMessage)
+    for (Message &message : Get<MeshForwarder>().mSendQueue)
     {
-        nextMessage = message->GetNext();
+        message.ClearChildMask(Get<ChildTable>().GetChildIndex(aChild));
 
-        message->ClearChildMask(Get<ChildTable>().GetChildIndex(aChild));
-
-        Get<MeshForwarder>().RemoveMessageIfNoPendingTx(*message);
+        Get<MeshForwarder>().RemoveMessageIfNoPendingTx(message);
     }
 
     aChild.SetIndirectMessage(nullptr);
@@ -186,12 +181,12 @@ void IndirectSender::HandleChildModeChange(Child &aChild, Mle::DeviceMode aOldMo
     {
         uint16_t childIndex = Get<ChildTable>().GetChildIndex(aChild);
 
-        for (Message *message = Get<MeshForwarder>().mSendQueue.GetHead(); message; message = message->GetNext())
+        for (Message &message : Get<MeshForwarder>().mSendQueue)
         {
-            if (message->GetChildMask(childIndex))
+            if (message.GetChildMask(childIndex))
             {
-                message->ClearChildMask(childIndex);
-                message->SetDirectTransmission();
+                message.ClearChildMask(childIndex);
+                message.SetDirectTransmission();
             }
         }
 
@@ -214,19 +209,20 @@ void IndirectSender::HandleChildModeChange(Child &aChild, Mle::DeviceMode aOldMo
 
 Message *IndirectSender::FindIndirectMessage(Child &aChild, bool aSupervisionTypeOnly)
 {
-    Message *message;
+    Message *msg        = nullptr;
     uint16_t childIndex = Get<ChildTable>().GetChildIndex(aChild);
 
-    for (message = Get<MeshForwarder>().mSendQueue.GetHead(); message; message = message->GetNext())
+    for (Message &message : Get<MeshForwarder>().mSendQueue)
     {
-        if (message->GetChildMask(childIndex) &&
-            (!aSupervisionTypeOnly || (message->GetType() == Message::kTypeSupervision)))
+        if (message.GetChildMask(childIndex) &&
+            (!aSupervisionTypeOnly || (message.GetType() == Message::kTypeSupervision)))
         {
+            msg = &message;
             break;
         }
     }
 
-    return message;
+    return msg;
 }
 
 void IndirectSender::RequestMessageUpdate(Child &aChild)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1982,15 +1982,12 @@ void Mle::HandleDelayedResponseTimer(void)
 {
     TimeMilli now          = TimerMilli::GetNow();
     TimeMilli nextSendTime = now.GetDistantFuture();
-    Message * nextMessage;
 
-    for (Message *message = mDelayedResponses.GetHead(); message != nullptr; message = nextMessage)
+    for (Message &message : mDelayedResponses)
     {
         DelayedResponseMetadata metadata;
 
-        nextMessage = message->GetNext();
-
-        metadata.ReadFrom(*message);
+        metadata.ReadFrom(message);
 
         if (now < metadata.mSendTime)
         {
@@ -2001,8 +1998,8 @@ void Mle::HandleDelayedResponseTimer(void)
         }
         else
         {
-            mDelayedResponses.Dequeue(*message);
-            SendDelayedResponse(*message, metadata);
+            mDelayedResponses.Dequeue(message);
+            SendDelayedResponse(message, metadata);
         }
     }
 
@@ -2053,20 +2050,16 @@ void Mle::RemoveDelayedDataRequestMessage(const Ip6::Address &aDestination)
 
 void Mle::RemoveDelayedMessage(Message::SubType aSubType, MessageType aMessageType, const Ip6::Address *aDestination)
 {
-    Message *nextMessage;
-
-    for (Message *message = mDelayedResponses.GetHead(); message != nullptr; message = nextMessage)
+    for (Message &message : mDelayedResponses)
     {
         DelayedResponseMetadata metadata;
 
-        nextMessage = message->GetNext();
+        metadata.ReadFrom(message);
 
-        metadata.ReadFrom(*message);
-
-        if ((message->GetSubType() == aSubType) &&
+        if ((message.GetSubType() == aSubType) &&
             ((aDestination == nullptr) || (metadata.mDestination == *aDestination)))
         {
-            mDelayedResponses.DequeueAndFree(*message);
+            mDelayedResponses.DequeueAndFree(message);
             Log(kMessageRemoveDelayed, aMessageType, metadata.mDestination);
         }
     }

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3166,9 +3166,9 @@ Error MleRouter::SendChildUpdateRequest(Child &aChild)
     {
         uint16_t childIndex = Get<ChildTable>().GetChildIndex(aChild);
 
-        for (message = Get<MeshForwarder>().GetSendQueue().GetHead(); message; message = message->GetNext())
+        for (const Message &msg : Get<MeshForwarder>().GetSendQueue())
         {
-            if (message->GetChildMask(childIndex) && message->GetSubType() == Message::kSubTypeMleChildUpdateRequest)
+            if (msg.GetChildMask(childIndex) && msg.GetSubType() == Message::kSubTypeMleChildUpdateRequest)
             {
                 // No need to send the resync "Child Update Request" to the sleepy child
                 // if there is one already queued.

--- a/tests/unit/test_message_queue.cpp
+++ b/tests/unit/test_message_queue.cpp
@@ -46,9 +46,10 @@ static ot::MessagePool *sMessagePool;
 // This function verifies the content of the message queue to match the passed in messages
 void VerifyMessageQueueContent(ot::MessageQueue &aMessageQueue, int aExpectedLength, ...)
 {
-    va_list      args;
-    ot::Message *message;
-    ot::Message *msgArg;
+    const ot::MessageQueue &constQueue = aMessageQueue;
+    va_list                 args;
+    ot::Message *           message;
+    ot::Message *           msgArg;
 
     va_start(args, aExpectedLength);
 
@@ -69,10 +70,34 @@ void VerifyMessageQueueContent(ot::MessageQueue &aMessageQueue, int aExpectedLen
             aExpectedLength--;
         }
 
-        VerifyOrQuit(aExpectedLength == 0, "less entries than expected");
+        VerifyOrQuit(aExpectedLength == 0, "fewer entries than expected");
     }
 
     va_end(args);
+
+    // Check range-based `for` loop iteration using non-const iterator
+
+    message = aMessageQueue.GetHead();
+
+    for (ot::Message &msg : aMessageQueue)
+    {
+        VerifyOrQuit(message == &msg, "`for` loop iteration does not match expected");
+        message = message->GetNext();
+    }
+
+    VerifyOrQuit(message == nullptr, "`for` loop iteration resulted in fewer entries than expected");
+
+    // Check  range-base `for` iteration using const iterator
+
+    message = aMessageQueue.GetHead();
+
+    for (const ot::Message &constMsg : constQueue)
+    {
+        VerifyOrQuit(message == &constMsg, "`for` loop iteration does not match expected");
+        message = message->GetNext();
+    }
+
+    VerifyOrQuit(message == nullptr, "`for` loop iteration resulted in fewer entries than expected");
 }
 
 void TestMessageQueue(void)
@@ -173,6 +198,47 @@ void TestMessageQueue(void)
     VerifyMessageQueueContent(messageQueue, 1, messages[0]);
     messageQueue.Dequeue(*messages[0]);
     VerifyMessageQueueContent(messageQueue, 0);
+
+    // Range-based `for` and dequeue during iteration
+
+    for (uint16_t removeIndex = 0; removeIndex < 5; removeIndex++)
+    {
+        uint16_t index = 0;
+
+        messageQueue.Enqueue(*messages[0]);
+        messageQueue.Enqueue(*messages[1]);
+        messageQueue.Enqueue(*messages[2]);
+        messageQueue.Enqueue(*messages[3]);
+        messageQueue.Enqueue(*messages[4]);
+        VerifyMessageQueueContent(messageQueue, 5, messages[0], messages[1], messages[2], messages[3], messages[4]);
+
+        // While iterating over the queue remove the entry at `removeIndex`
+        for (ot::Message &message : messageQueue)
+        {
+            if (index == removeIndex)
+            {
+                messageQueue.Dequeue(message);
+            }
+
+            VerifyOrQuit(&message == messages[index++]);
+        }
+
+        index = 0;
+
+        // Iterate over the queue and remove all
+        for (ot::Message &message : messageQueue)
+        {
+            if (index == removeIndex)
+            {
+                index++;
+            }
+
+            VerifyOrQuit(&message == messages[index++]);
+            messageQueue.Dequeue(message);
+        }
+
+        VerifyMessageQueueContent(messageQueue, 0);
+    }
 
     testFreeInstance(sInstance);
 }

--- a/tests/unit/test_priority_queue.cpp
+++ b/tests/unit/test_priority_queue.cpp
@@ -42,11 +42,12 @@
 // This function verifies the content of the priority queue to match the passed in messages
 void VerifyPriorityQueueContent(ot::PriorityQueue &aPriorityQueue, int aExpectedLength, ...)
 {
-    va_list      args;
-    ot::Message *message;
-    ot::Message *msgArg;
-    int8_t       curPriority = ot::Message::kNumPriorities;
-    uint16_t     msgCount, bufCount;
+    const ot::PriorityQueue &constQueue = aPriorityQueue;
+    va_list                  args;
+    ot::Message *            message;
+    ot::Message *            msgArg;
+    int8_t                   curPriority = ot::Message::kNumPriorities;
+    uint16_t                 msgCount, bufCount;
 
     // Check the `GetInfo`
     aPriorityQueue.GetInfo(msgCount, bufCount);
@@ -106,6 +107,30 @@ void VerifyPriorityQueueContent(ot::PriorityQueue &aPriorityQueue, int aExpected
     }
 
     va_end(args);
+
+    // Check range-based `for` loop iteration using non-const iterator
+
+    message = aPriorityQueue.GetHead();
+
+    for (ot::Message &msg : aPriorityQueue)
+    {
+        VerifyOrQuit(message == &msg, "`for` loop iteration does not match expected");
+        message = message->GetNext();
+    }
+
+    VerifyOrQuit(message == nullptr, "`for` loop iteration resulted in fewer entries than expected");
+
+    // Check  range-base `for` iteration using const iterator
+
+    message = aPriorityQueue.GetHead();
+
+    for (const ot::Message &constMsg : constQueue)
+    {
+        VerifyOrQuit(message == &constMsg, "`for` loop iteration does not match expected");
+        message = message->GetNext();
+    }
+
+    VerifyOrQuit(message == nullptr, "`for` loop iteration resulted in fewer entries than expected");
 }
 
 // This function verifies the content of the message queue to match the passed in messages
@@ -289,6 +314,56 @@ void TestPriorityQueue(void)
     queue.Dequeue(*msgLow[0]);
     VerifyPriorityQueueContent(queue, 1, msgNor[0]);
     VerifyMsgQueueContent(messageQueue, 1, msgNor[1]);
+
+    queue.Dequeue(*msgNor[0]);
+    VerifyPriorityQueueContent(queue, 0);
+    messageQueue.Dequeue(*msgNor[1]);
+    VerifyMsgQueueContent(messageQueue, 0);
+
+    for (ot::Message *message : msgNor)
+    {
+        SuccessOrQuit(message->SetPriority(ot::Message::kPriorityNormal));
+    }
+
+    // Range-based `for` and dequeue during iteration
+
+    for (uint16_t removeIndex = 0; removeIndex < 4; removeIndex++)
+    {
+        uint16_t index = 0;
+
+        queue.Enqueue(*msgNor[0]);
+        queue.Enqueue(*msgNor[1]);
+        queue.Enqueue(*msgNor[2]);
+        queue.Enqueue(*msgNor[3]);
+        VerifyPriorityQueueContent(queue, 4, msgNor[0], msgNor[1], msgNor[2], msgNor[3]);
+
+        // While iterating over the queue remove the entry at `removeIndex`
+        for (ot::Message &message : queue)
+        {
+            if (index == removeIndex)
+            {
+                queue.Dequeue(message);
+            }
+
+            VerifyOrQuit(&message == msgNor[index++]);
+        }
+
+        index = 0;
+
+        // Iterate over the queue and remove all
+        for (ot::Message &message : queue)
+        {
+            if (index == removeIndex)
+            {
+                index++;
+            }
+
+            VerifyOrQuit(&message == msgNor[index++]);
+            queue.Dequeue(message);
+        }
+
+        VerifyPriorityQueueContent(queue, 0);
+    }
 
     testFreeInstance(instance);
 }


### PR DESCRIPTION
This commit adds support for range-based `for` loop iteration over
`MessageQueue` and `PriorityQueue`. It adds `ConstIterator` and
`Iterator` in `Message` class. The non-const `for` loop iteration
(which uses `Message::Iterator`) works properly and is safe to use
even when the entry is removed from the queue during iteration. This
commit updates other core modules to use the new `for` loop iteration
model which helps simplify the code. It also updates the unit tests
to validate the behavior of the newly added iteration mechanisms.

----

The non-const version implements and hides the common pattern where we 
update and remember the `nextMessage` at the start of loop iteration (so 
we can remove the `message` entry from the queue while iterating over it), into 
the `Message::Iterator` class itself.

So the common pattern
```c++
Message *message, 
Message *nextMessage;

for (message = aQueue.GetHead(); message != nullptr; message = nextMessage)
{
    nextMessage = message->GetNext();
    ...
}
```
can be replaced with:
```c++
for (Message &message: aQueue)
{
    ...
}
```
