### PR TITLE
[dns64] add recursive DNS64 server

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -194,6 +194,11 @@ if(OT_DNSSD_SERVER)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE=1")
 endif()
 
+option(OT_RECURSIVE_DNS64_SERVER "enable recursive DNS64 server support")
+if(OT_RECURSIVE_DNS64_SERVER)
+    target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_RECURSIVE_DNS64_SERVER_ENABLE=1")
+endif()
+
 option(OT_DOC "Build OpenThread documentation")
 
 option(OT_ECDSA "enable ECDSA support")

--- a/etc/gn/openthread.gni
+++ b/etc/gn/openthread.gni
@@ -129,6 +129,9 @@ if (openthread_enable_core_config_args) {
     # Enable DNS-SD server support
     openthread_config_dnssd_server_enable = false
 
+    # Enable recursive DNS64 server support
+    openthread_config_recursive_dns64_server_enable = false
+
     # Enable ECDSA support
     openthread_config_ecdsa_enable = false
 

--- a/examples/common-switches.mk
+++ b/examples/common-switches.mk
@@ -78,6 +78,7 @@ NETDATA_PUBLISHER         ?= 0
 OTNS                      ?= 0
 PING_SENDER               ?= 1
 PLATFORM_UDP              ?= 0
+RECURSIVE_DNS64_SERVER    ?= 0
 REFERENCE_DEVICE          ?= 0
 SERVICE                   ?= 0
 SETTINGS_RAM              ?= 0
@@ -302,6 +303,10 @@ endif
 
 ifeq ($(PLATFORM_UDP),1)
 COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE=1
+endif
+
+ifeq ($(RECURSIVE_DNS64_SERVER),1)
+COMMONCFLAGS                   += -DOPENTHREAD_CONFIG_RECURSIVE_DNS64_SERVER_ENABLE=1
 endif
 
 # Enable features only required for reference device during certification.

--- a/include/openthread/dns_client.h
+++ b/include/openthread/dns_client.h
@@ -38,6 +38,7 @@
 #include <openthread/dns.h>
 #include <openthread/instance.h>
 #include <openthread/ip6.h>
+#include <openthread/udp.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -94,6 +95,7 @@ typedef struct otDnsQueryConfig
     uint8_t            mMaxTxAttempts;   ///< Maximum tx attempts before reporting failure. Zero for unspecified value.
     otDnsRecursionFlag mRecursionFlag;   ///< Indicates whether the server can resolve the query recursively or not.
     otDnsNat64Mode     mNat64Mode;       ///< Allow/Disallow NAT64 address translation during address resolution.
+    otNetifIdentifier  mNetif;           ///< The netif to send DNS queries. Zero for unspecified value.
 } otDnsQueryConfig;
 
 /**
@@ -133,8 +135,11 @@ const otDnsQueryConfig *otDnsClientGetDefaultConfig(otInstance *aInstance);
  * @param[in]  aInstance   A pointer to an OpenThread instance.
  * @param[in]  aConfig     A pointer to the new query config to use as default.
  *
+ * @retval OT_ERROR_NONE        The config was set successfully.
+ * @retval OT_ERROR_ALREADY     The underlying UDP socket failed.
+ *
  */
-void otDnsClientSetDefaultConfig(otInstance *aInstance, const otDnsQueryConfig *aConfig);
+otError otDnsClientSetDefaultConfig(otInstance *aInstance, const otDnsQueryConfig *aConfig);
 
 /**
  * This type is an opaque representation of a response to an address resolution DNS query.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (197)
+#define OPENTHREAD_API_VERSION (198)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1529,11 +1529,12 @@ template <> otError Interpreter::Process<Cmd("dns")>(Arg aArgs[])
             OutputLine("MaxTxAttempts: %u", defaultConfig->mMaxTxAttempts);
             OutputLine("RecursionDesired: %s",
                        (defaultConfig->mRecursionFlag == OT_DNS_FLAG_RECURSION_DESIRED) ? "yes" : "no");
+            OutputLine("Backbone: %s", defaultConfig->mNetif == OT_NETIF_BACKBONE ? "yes" : "no");
         }
         else
         {
             SuccessOrExit(error = GetDnsConfig(aArgs + 1, config));
-            otDnsClientSetDefaultConfig(GetInstancePtr(), config);
+            SuccessOrExit(error = otDnsClientSetDefaultConfig(GetInstancePtr(), config));
         }
     }
     else if (aArgs[0] == "resolve")
@@ -1588,10 +1589,11 @@ otError Interpreter::GetDnsConfig(Arg aArgs[], otDnsQueryConfig *&aConfig)
 {
     // This method gets the optional DNS config from `aArgs[]`.
     // The format: `[server IPv6 address] [server port] [timeout]
-    // [max tx attempt] [recursion desired]`.
+    // [max tx attempt] [recursion desired] [use backbone]`.
 
     otError error = OT_ERROR_NONE;
     bool    recursionDesired;
+    bool    useBackbone;
 
     memset(aConfig, 0, sizeof(otDnsQueryConfig));
 
@@ -1611,6 +1613,10 @@ otError Interpreter::GetDnsConfig(Arg aArgs[], otDnsQueryConfig *&aConfig)
     VerifyOrExit(!aArgs[4].IsEmpty());
     SuccessOrExit(error = aArgs[4].ParseAsBool(recursionDesired));
     aConfig->mRecursionFlag = recursionDesired ? OT_DNS_FLAG_RECURSION_DESIRED : OT_DNS_FLAG_NO_RECURSION;
+
+    VerifyOrExit(!aArgs[5].IsEmpty());
+    SuccessOrExit(error = aArgs[5].ParseAsBool(useBackbone));
+    aConfig->mNetif = useBackbone ? OT_NETIF_BACKBONE : OT_NETIF_UNSPECIFIED;
 
 exit:
     return error;

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -140,6 +140,10 @@ if (openthread_enable_core_config_args) {
       defines += [ "OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE=1" ]
     }
 
+    if (openthread_config_recursive_dns64_server_enable) {
+      defines += [ "OPENTHREAD_CONFIG_RECURSIVE_DNS64_SERVER_ENABLE=1" ]
+    }
+
     if (openthread_config_ecdsa_enable) {
       defines += [ "OPENTHREAD_CONFIG_ECDSA_ENABLE=1" ]
     }

--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -71,14 +71,17 @@ const otDnsQueryConfig *otDnsClientGetDefaultConfig(otInstance *aInstance)
 
 otError otDnsClientSetDefaultConfig(otInstance *aInstance, const otDnsQueryConfig *aConfig)
 {
+    otError error;
+
     if (aConfig != nullptr)
     {
-        return AsCoreType(aInstance).Get<Dns::Client>().SetDefaultConfig(AsCoreType(aConfig));
+        error = AsCoreType(aInstance).Get<Dns::Client>().SetDefaultConfig(AsCoreType(aConfig));
     }
     else
     {
-        return AsCoreType(aInstance).Get<Dns::Client>().ResetDefaultConfig();
+        error = AsCoreType(aInstance).Get<Dns::Client>().ResetDefaultConfig();
     }
+    return error;
 }
 
 otError otDnsClientResolveAddress(otInstance *            aInstance,

--- a/src/core/api/dns_api.cpp
+++ b/src/core/api/dns_api.cpp
@@ -69,15 +69,15 @@ const otDnsQueryConfig *otDnsClientGetDefaultConfig(otInstance *aInstance)
     return &AsCoreType(aInstance).Get<Dns::Client>().GetDefaultConfig();
 }
 
-void otDnsClientSetDefaultConfig(otInstance *aInstance, const otDnsQueryConfig *aConfig)
+otError otDnsClientSetDefaultConfig(otInstance *aInstance, const otDnsQueryConfig *aConfig)
 {
     if (aConfig != nullptr)
     {
-        AsCoreType(aInstance).Get<Dns::Client>().SetDefaultConfig(AsCoreType(aConfig));
+        return AsCoreType(aInstance).Get<Dns::Client>().SetDefaultConfig(AsCoreType(aConfig));
     }
     else
     {
-        AsCoreType(aInstance).Get<Dns::Client>().ResetDefaultConfig();
+        return AsCoreType(aInstance).Get<Dns::Client>().ResetDefaultConfig();
     }
 }
 

--- a/src/core/config/dnssd_server.h
+++ b/src/core/config/dnssd_server.h
@@ -46,6 +46,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_CONFIG_RECURSIVE_DNS64_SERVER_ENABLE
+ *
+ * Define to 1 to enable recursive DNS64 Server support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_RECURSIVE_DNS64_SERVER_ENABLE
+#define OPENTHREAD_CONFIG_RECURSIVE_DNS64_SERVER_ENABLE 0
+#endif
+
+/**
  * @def OPENTHREAD_CONFIG_DNSSD_SERVER_PORT
  *
  * Define the the DNS-SD Server port.

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -551,6 +551,7 @@ public:
      *
      * @retval kErrorNone     Successfully started the DNS client.
      * @retval kErrorAlready  The socket is already open.
+     * @retval kErrorFailed   The platform UDP open failed.
      *
      */
     Error Start(void);
@@ -574,8 +575,11 @@ public:
      *
      * @param[in] aQueryConfig   The new default query config.
      *
+     * @retval kErrorNone     Successfully started the DNS client.
+     * @retval kErrorFailed   The platform UDP open failed.
+     *
      */
-    void SetDefaultConfig(const QueryConfig &aQueryConfig);
+    Error SetDefaultConfig(const QueryConfig &aQueryConfig);
 
     /**
      * This method resets the default config to the config used when the OpenThread stack starts.
@@ -584,8 +588,10 @@ public:
      * `OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_SERVER_IP6_ADDRESS`, `_DEFAULT_SERVER_PORT`, or `_DEFAULT_RESPONSE_TIMEOUT`
      * etc. (see `config/dns_client.h` for all related config options).
      *
+     * @retval kErrorNone     Successfully started the DNS client.
+     * @retval kErrorFailed   The platform UDP open failed.
      */
-    void ResetDefaultConfig(void);
+    Error ResetDefaultConfig(void);
 
     /**
      * This method sends an address resolution DNS query for AAAA (IPv6) record for a given host name.
@@ -728,6 +734,7 @@ private:
 
     static constexpr uint16_t kNameOffsetInQuery = sizeof(QueryInfo);
 
+    Error       RestartOnNetifChange(otNetifIdentifier prevNetif);
     Error       StartQuery(QueryInfo &        aInfo,
                            const QueryConfig *aConfig,
                            const char *       aLabel,

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -255,6 +255,9 @@ Header::Response Server::AddQuestions(const Header &    aRequestHeader,
 
         if (Name::IsSubDomainOf(name, aCompressInfo.GetDomainName()))
         {
+            VerifyOrExit(kErrorNone ==
+                             FindNameComponents(name, aCompressInfo.GetDomainName(), nameComponentsOffsetInfo),
+                         response = Header::kResponseNameError);
             switch (question.GetType())
             {
             case ResourceRecord::kTypePtr:

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -367,10 +367,10 @@ private:
                                                          const Srp::Server::Service *aService);
 #endif
 
-    Error             ResolveByQueryCallbacks(Header &                aResponseHeader,
-                                              Message &               aResponseMessage,
-                                              NameCompressInfo &      aCompressInfo,
-                                              const Ip6::MessageInfo &aMessageInfo);
+    Error             ResolveByQuery(Header &                aResponseHeader,
+                                     Message &               aResponseMessage,
+                                     NameCompressInfo &      aCompressInfo,
+                                     const Ip6::MessageInfo &aMessageInfo);
     QueryTransaction *NewQuery(const Header &          aResponseHeader,
                                Message &               aResponseMessage,
                                const NameCompressInfo &aCompressInfo,
@@ -383,6 +383,7 @@ private:
                                   const otDnssdServiceInstanceInfo &aInstanceInfo);
     static bool       CanAnswerQuery(const Server::QueryTransaction &aQuery, const char *aHostFullName);
     void AnswerQuery(QueryTransaction &aQuery, const char *aHostFullName, const otDnssdHostInfo &aHostInfo);
+    void AnswerQuery(QueryTransaction &aQuery, const char *aHostFullName, const otDnsAddressResponse *aDnsResponse);
     void FinalizeQuery(QueryTransaction &aQuery, Header::Response aResponseCode);
     static DnsQueryType GetQueryTypeAndName(const Header & aHeader,
                                             const Message &aMessage,
@@ -391,6 +392,12 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
     void        ResetTimer(void);
+
+#if OPENTHREAD_CONFIG_RECURSIVE_DNS64_SERVER_ENABLE
+    Error       QueryRecursive(const char *name);
+    static void HandleRecursiveResolveResponse(otError aError, const otDnsAddressResponse *aResponse, void *aContext);
+    void        HandleRecursiveResolveResponse(otError aError, const otDnsAddressResponse *aResponse);
+#endif // OPENTHREAD_CONFIG_RECURSIVE_DNS64_SERVER_ENABLE
 
     static const char kDnssdProtocolUdp[];
     static const char kDnssdProtocolTcp[];


### PR DESCRIPTION
This PR adds a recursive DNS64 server on the border router so that the DNS64 process becomes transperant to the end devices.

The current DNS client with NAT64 implementation sends an A query to the configured DNS server and translates the response to the NAT64 translated IPv6 address in the response handler. This approach brings serveral difficulties for the application layer running on the OpenThread stack:

* Two different DNS servers need to be kept for DNS-SD discovery proxy and common name resolution.
* The NAT64 translation happens in the OpenThread DNS client while applications will typically use the `gethostbyname` function. This function can be provided by lwIP, zephyr or the kernel. These network stacks lack knowlege about the NAT64 prefix in the OpenThread network. The returned addresses are thus not accessible.

To overcome these difficluties, this PR proposes a recursive DNS64 server running together with the discovery delegate.

```
                                                                                             
                                                                                             
                                                                                             
+-------------------+  AAAA queries   +-----------------+ A queries   +---------------------+
|                   |---------------->|                 |------------>|                     |
|    End Device     |                 |  Border Router  |             | Upstream DNS server |
|                   |<----------------|                 |<------------|                     |
+-------------------+  AAAA response  +-----------------+ A response  +---------------------+
                                               |                                             
                                               |                                             
                                               | mDNS quries                                 
                                               v                                             
                                   +------------------------+                                
                                   |                        |                                
                                   |      Backbone LAN      |                                
                                   |                        |                                
                                   +------------------------+                                
                                                                                
```
After the change, the border router will be the only DNS server for the end device. The end device will send AAAA queries and receive corresponding responses both for local devices on the backbone link and the DNS64 addresses translated by the border router. Thus the `gethostbyname` function will work properly.

Main changes include:

* Support backbone interface in the DNS client so that the BR use the DNS client to query the upstream
* Support non-local hostnames in the DNS server
* Support recursive DNS64 server

The border router part of the change is at https://github.com/openthread/ot-br-posix/pull/1298.