### PR TITLE
[crypto] compilation fix for clang10 -Wdeprecated-copy (delete KeyMat…

### DIFF
--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -539,7 +539,11 @@ public:
      */
     bool operator==(const KeyMaterial &aOther) const;
 
+#if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
+
     KeyMaterial(const KeyMaterial &) = delete;
+
+#endif
 
 private:
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE


### PR DESCRIPTION
Deleting a copy constructor without specifying an explicit assignment operator causes an error in clang10 (-Wdeprecated-copy). Since explicit assignment operator defined in OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE case, added the copy constructor deletion also under the same. If the macro is not enabled, implicit copy constructor and assignment operator would take effect. 