### PR TITLE
[crypto] compilation fix for clang10 -Wdeprecated-copy

### DIFF
--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -469,6 +469,8 @@ public:
      *
      */
     KeyMaterial &operator=(const KeyMaterial &aOther);
+
+    KeyMaterial(const KeyMaterial &) = delete;
 #endif
 
     /**
@@ -538,8 +540,6 @@ public:
      *
      */
     bool operator==(const KeyMaterial &aOther) const;
-
-    KeyMaterial(const KeyMaterial &) = delete;
 
 private:
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE


### PR DESCRIPTION
Deleting a copy constructor without specifying an explicit assignment operator causes an error in clang10 (-Wdeprecated-copy). Since explicit assignment operator defined in OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE case, added the copy constructor deletion also under the same. If the macro is not enabled, implicit copy constructor and assignment operator would take effect.