### PR TITLE
[netdata] update srp/dns anycast entry seq num selection

### DIFF
--- a/src/core/thread/network_data_service.hpp
+++ b/src/core/thread/network_data_service.hpp
@@ -174,25 +174,6 @@ public:
      */
     struct Info
     {
-        /**
-         * This method indicates whether or not the sequence number from the current `Info` is ahead of (more recent
-         * than) the sequence number from another `Info`.
-         *
-         * The sequence numbers comparison follows the Serial Number Arithmetic logic from RFC-1982. It is semantically
-         * equivalent to `GetSequenceNumber() > aOther.GetSequenceNumber()` while handling roll-over of the `uint8_t`
-         * values.
-         *
-         * @param[in] aOther   The other `Info` to compare with.
-         *
-         * @retval TRUE  The `Info` is ahead of @p aOther.
-         * @retval FALSE The `Info` is not ahead of @p aOther.
-         *
-         */
-        bool IsSequenceNumberAheadOf(const Info &aOther) const
-        {
-            return SerialNumber::IsGreater(mSequenceNumber, aOther.mSequenceNumber);
-        }
-
         Ip6::Address mAnycastAddress; ///< The anycast address associated with the DNS/SRP servers.
         uint8_t      mSequenceNumber; ///< Sequence number used to notify SRP client if they need to re-register.
     };


### PR DESCRIPTION
This commit enhances the selection algorithm for the preferred entry
when there are multiple "DNS/SRP Service Anycast" entries in the
Thread Network Data. The sequence number (which is `uint8_t`) is used
for selecting the preferred entry and the larger value is preferred.
The seq numbers are compared using "serial number arithmetic"
(RFC-1982) but if we have 3 or more entries the notion of a largest
seq number may not be well-defined under the "serial number
arithmetic" comparison (e.g., for `{10, 130, 250}` there is no
largest seq number since `130 > 10`, `250 > 130` and `10 > 250`). In
such a case the algorithm selects the entry with largest seq number
in normal sense.

This commit updates `FindPreferredDnsSrpAnycastInfo()` to implement
the new algorithm. It also updates `test_network_data` unit test to
add many test cases related to the selection algorithm.

-------

This is related to [SPEC-1056](https://threadgroup.atlassian.net/browse/SPEC-1056).