### PR TITLE
[github-actions] set `fail-fast: false` for matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -84,6 +84,7 @@ jobs:
     name: package-${{ matrix.compiler }}
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - compiler: gcc
@@ -144,6 +145,7 @@ jobs:
     name: arm-gcc-${{ matrix.gcc_ver }}
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - gcc_ver: 4
@@ -184,6 +186,7 @@ jobs:
     name: gcc-${{ matrix.gcc_ver }}
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         gcc_ver: [5, 6, 7, 8, 9, 10]
     env:
@@ -206,6 +209,7 @@ jobs:
     name: clang-${{ matrix.clang_ver }}
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         clang_ver: ["6.0", "7", "8", "9"]
     env:
@@ -228,6 +232,7 @@ jobs:
     name: clang-m32-${{ matrix.clang_ver }}
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         clang_ver: ["6.0", "7", "8", "9"]
     env:
@@ -273,6 +278,7 @@ jobs:
   macos:
     name: macos-${{ matrix.CC }}
     strategy:
+      fail-fast: false
       matrix:
         include:
           - CC: clang

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,6 +44,7 @@ jobs:
     name: buildx-${{ matrix.docker_name }}
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - docker_name: environment

--- a/.github/workflows/otci.yml
+++ b/.github/workflows/otci.yml
@@ -44,6 +44,7 @@ jobs:
     name: cli-sim VIRTUAL_TIME=${{ matrix.virtual_time }}
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         virtual_time: [0, 1]
     env:

--- a/.github/workflows/otns.yml
+++ b/.github/workflows/otns.yml
@@ -132,6 +132,7 @@ jobs:
     name: Stress ${{ matrix.suite }}
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         include:
           - suite: "network-forming"

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -183,6 +183,7 @@ jobs:
     name: pty-linux OT_DAEMON=${{ matrix.OT_DAEMON }}
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         OT_DAEMON: ['off', 'on']
     env:
@@ -227,6 +228,7 @@ jobs:
     name: pty-macos OT_DAEMON=${{ matrix.OT_DAEMON }}
     runs-on: macos-10.15
     strategy:
+      fail-fast: false
       matrix:
         OT_DAEMON: ['off', 'on']
     env:

--- a/.github/workflows/simulation-1.1.yml
+++ b/.github/workflows/simulation-1.1.yml
@@ -150,6 +150,7 @@ jobs:
     name: cli-mtd MESSAGE_USE_HEAP=${{ matrix.message_use_heap }}
     runs-on: ubuntu-20.04
     strategy:
+      fail-fast: false
       matrix:
         message_use_heap: [0, 1]
     env:

--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -54,6 +54,7 @@ jobs:
       CC: ${{ matrix.compiler.c }}
       CXX: ${{ matrix.compiler.cxx }}
     strategy:
+      fail-fast: false
       matrix:
         compiler: [{c: "gcc", cxx: "g++", gcov: "gcc"}, { c: "clang-10", cxx: "clang++-10", gcov: "llvm"}]
         arch: ["m32", "m64"]

--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -44,6 +44,7 @@ jobs:
     name: toranj-${{ matrix.TORANJ_RADIO }}
     runs-on: ubuntu-18.04
     strategy:
+      fail-fast: false
       matrix:
         TORANJ_RADIO: ['15.4', 'trel', 'multi']
     env:


### PR DESCRIPTION
This commit sets `fail-fast: false` for matrix in GitHub Actions so that tests in a matrix do not fail all at once. 
It's more convenient now that we can re-run failed tests. 