### PR TITLE
[thci] selectively configure Domain Prefix advertisement on the host

### DIFF
--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -587,7 +587,7 @@ class OpenThread_BR(OpenThreadTHCI, IThci):
             conf += "\n    };"
         conf += "\n};"
         conf += "\nEOF"
-        cmd = 'sh -c "cat >/tmp/radvd.conf <<%s"' % conf
+        cmd = 'sh -c "cat >/etc/radvd.conf <<%s"' % conf
 
         self.bash(cmd)
         self.bash('service radvd restart')


### PR DESCRIPTION
Implement changes in `setupHost` method to be able to selectively
configure the RA for the Domain Prefix.

See https://threadgroup.atlassian.net/browse/DEV-2191 discussion.