### PR TITLE
[posix] expose platform settings interfaces

### DIFF
--- a/src/posix/platform/settings.cpp
+++ b/src/posix/platform/settings.cpp
@@ -54,6 +54,7 @@
 
 #include "common/code_utils.hpp"
 #include "common/encoding.hpp"
+#include "posix/platform/settings.hpp"
 
 #include "system.hpp"
 
@@ -61,29 +62,19 @@ static const size_t kMaxFileNameSize = sizeof(OPENTHREAD_CONFIG_POSIX_SETTINGS_P
 
 static int sSettingsFd = -1;
 
-static otError platformSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex, int *aSwapFd);
-
 #if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-static const uint16_t *sKeys       = nullptr;
-static uint16_t        sKeysLength = 0;
+static const uint16_t *sSensitiveKeys       = nullptr;
+static uint16_t        sSensitiveKeysLength = 0;
 
-void otPlatSettingsSetCriticalKeys(otInstance *aInstance, const uint16_t *aKeys, uint16_t aKeysLength)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-
-    sKeys       = aKeys;
-    sKeysLength = aKeysLength;
-}
-
-static bool isCriticalKey(uint16_t aKey)
+static bool isSensitiveKey(uint16_t aKey)
 {
     bool ret = false;
 
-    VerifyOrExit(sKeys != nullptr);
+    VerifyOrExit(sSensitiveKeys != nullptr);
 
-    for (uint16_t i = 0; i < sKeysLength; i++)
+    for (uint16_t i = 0; i < sSensitiveKeysLength; i++)
     {
-        VerifyOrExit(aKey != sKeys[i], ret = true);
+        VerifyOrExit(aKey != sSensitiveKeys[i], ret = true);
     }
 
 exit:
@@ -177,16 +168,12 @@ void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aSensitiveKeys, u
     otError error = OT_ERROR_NONE;
 
 #if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    sKeys       = aSensitiveKeys;
-    sKeysLength = aSensitiveKeysLength;
+    sSensitiveKeys       = aSensitiveKeys;
+    sSensitiveKeysLength = aSensitiveKeysLength;
 #endif
 
     // Don't touch the settings file the system runs in dry-run mode.
     VerifyOrExit(!IsSystemDryRun());
-
-#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    otPosixSecureSettingsInit(aInstance);
-#endif
 
     {
         struct stat st;
@@ -222,6 +209,10 @@ void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aSensitiveKeys, u
         VerifyOrExit(offset == lseek(sSettingsFd, length, SEEK_CUR), error = OT_ERROR_PARSE);
     }
 
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    otPosixSecureSettingsInit(aInstance);
+#endif
+
 exit:
     if (error == OT_ERROR_PARSE)
     {
@@ -248,17 +239,101 @@ otError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    otError     error  = OT_ERROR_NOT_FOUND;
-    const off_t size   = lseek(sSettingsFd, 0, SEEK_END);
-    off_t       offset = lseek(sSettingsFd, 0, SEEK_SET);
+    otError error = OT_ERROR_NOT_FOUND;
 
     VerifyOrExit(!IsSystemDryRun());
 #if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    if (isCriticalKey(aKey))
+    if (isSensitiveKey(aKey))
     {
-        ExitNow(error = otPosixSecureSettingsGet(aInstance, aKey, aIndex, aValue, aValueLength));
+        error = otPosixSecureSettingsGet(aInstance, aKey, aIndex, aValue, aValueLength);
     }
+    else
 #endif
+    {
+        error = ot::Posix::PlatformSettingsGet(aInstance, aKey, aIndex, aValue, aValueLength);
+    }
+
+exit:
+    VerifyOrDie(error != OT_ERROR_PARSE, OT_EXIT_FAILURE);
+    return error;
+}
+
+otError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+{
+    otError error = OT_ERROR_NONE;
+
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    if (isSensitiveKey(aKey))
+    {
+        error = otPosixSecureSettingsSet(aInstance, aKey, aValue, aValueLength);
+    }
+    else
+#endif
+    {
+        ot::Posix::PlatformSettingsSet(aInstance, aKey, aValue, aValueLength);
+    }
+
+    return error;
+}
+
+otError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    otError error = OT_ERROR_NONE;
+
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    if (isSensitiveKey(aKey))
+    {
+        error = otPosixSecureSettingsAdd(aInstance, aKey, aValue, aValueLength);
+    }
+    else
+#endif
+    {
+        ot::Posix::PlatformSettingsAdd(aInstance, aKey, aValue, aValueLength);
+    }
+
+    return error;
+}
+
+otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
+{
+    otError error;
+
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    if (isSensitiveKey(aKey))
+    {
+        error = otPosixSecureSettingsDelete(aInstance, aKey, aIndex);
+    }
+    else
+#endif
+    {
+        error = ot::Posix::PlatformSettingsDelete(aInstance, aKey, aIndex, nullptr);
+    }
+
+    return error;
+}
+
+void otPlatSettingsWipe(otInstance *aInstance)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    otPosixSecureSettingsWipe(aInstance);
+#endif
+
+    VerifyOrDie(0 == ftruncate(sSettingsFd, 0), OT_EXIT_ERROR_ERRNO);
+}
+
+namespace ot {
+namespace Posix {
+
+otError PlatformSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength)
+{
+    OT_UNUSED_VARIABLE(aInstance);
+
+    otError     error  = OT_ERROR_NOT_FOUND;
+    const off_t size   = lseek(sSettingsFd, 0, SEEK_END);
+    off_t       offset = lseek(sSettingsFd, 0, SEEK_SET);
 
     VerifyOrExit(offset == 0 && size >= 0, error = OT_ERROR_PARSE);
 
@@ -305,23 +380,14 @@ otError otPlatSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint
     }
 
 exit:
-    VerifyOrDie(error != OT_ERROR_PARSE, OT_EXIT_FAILURE);
     return error;
 }
 
-otError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+void PlatformSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
 {
-    int     swapFd = -1;
-    otError error  = OT_ERROR_NONE;
+    int swapFd = -1;
 
-#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    if (isCriticalKey(aKey))
-    {
-        ExitNow(error = otPosixSecureSettingsSet(aInstance, aKey, aValue, aValueLength));
-    }
-#endif
-
-    switch (platformSettingsDelete(aInstance, aKey, -1, &swapFd))
+    switch (PlatformSettingsDelete(aInstance, aKey, -1, &swapFd))
     {
     case OT_ERROR_NONE:
     case OT_ERROR_NOT_FOUND:
@@ -338,27 +404,12 @@ otError otPlatSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *a
                 OT_EXIT_FAILURE);
 
     swapPersist(aInstance, swapFd);
-
-#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-exit:
-#endif
-    return error;
 }
 
-otError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
+void PlatformSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength)
 {
-    OT_UNUSED_VARIABLE(aInstance);
-
-    otError error  = OT_ERROR_NONE;
-    off_t   size   = lseek(sSettingsFd, 0, SEEK_END);
-    int     swapFd = swapOpen(aInstance);
-
-#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    if (isCriticalKey(aKey))
-    {
-        ExitNow(error = otPosixSecureSettingsAdd(aInstance, aKey, aValue, aValueLength));
-    }
-#endif
+    off_t size   = lseek(sSettingsFd, 0, SEEK_END);
+    int   swapFd = swapOpen(aInstance);
 
     if (size > 0)
     {
@@ -372,51 +423,10 @@ otError otPlatSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *a
                 OT_EXIT_FAILURE);
 
     swapPersist(aInstance, swapFd);
-
-#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-exit:
-#endif
-    return error;
 }
 
-otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
+otError PlatformSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex, int *aSwapFd)
 {
-    otError error;
-
-#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    if (isCriticalKey(aKey))
-    {
-        error = otPosixSecureSettingsDelete(aInstance, aKey, aIndex);
-    }
-    else
-#endif
-    {
-        error = platformSettingsDelete(aInstance, aKey, aIndex, nullptr);
-    }
-
-    return error;
-}
-
-/**
- * This function removes a setting either from swap file or persisted file.
- *
- * @param[in]  aInstance  The OpenThread instance structure.
- * @param[in]  aKey       The key associated with the requested setting.
- * @param[in]  aIndex     The index of the value to be removed. If set to -1, all values for this aKey will be removed.
- * @param[out] aSwapFd    A optional pointer to receive file descriptor of the generated swap file descriptor.
- *
- * @note
- *   If @p aSwapFd is null, operate deleting on the setting file.
- *   If @p aSwapFd is not null, operate on the swap file, and aSwapFd will point to the swap file descriptor.
- *
- * @retval OT_ERROR_NONE        The given key and index was found and removed successfully.
- * @retval OT_ERROR_NOT_FOUND   The given key or index was not found in the setting store.
- *
- */
-static otError platformSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex, int *aSwapFd)
-{
-    OT_UNUSED_VARIABLE(aInstance);
-
     otError error  = OT_ERROR_NOT_FOUND;
     off_t   size   = lseek(sSettingsFd, 0, SEEK_END);
     off_t   offset = lseek(sSettingsFd, 0, SEEK_SET);
@@ -491,15 +501,21 @@ exit:
     return error;
 }
 
-void otPlatSettingsWipe(otInstance *aInstance)
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+void PlatformSettingsGetSensitiveKeys(otInstance *aInstance, const uint16_t **aKeys, uint16_t *aKeysLength)
 {
     OT_UNUSED_VARIABLE(aInstance);
-#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    otPosixSecureSettingsWipe(aInstance);
+
+    assert(aKeys != nullptr);
+    assert(aKeysLength != nullptr);
+
+    *aKeys       = sSensitiveKeys;
+    *aKeysLength = sSensitiveKeysLength;
+}
 #endif
 
-    VerifyOrDie(0 == ftruncate(sSettingsFd, 0), OT_EXIT_ERROR_ERRNO);
-}
+} // namespace Posix
+} // namespace ot
 
 #ifndef SELF_TEST
 #define SELF_TEST 0

--- a/src/posix/platform/settings.hpp
+++ b/src/posix/platform/settings.hpp
@@ -1,0 +1,103 @@
+/*
+ *  Copyright (c) 2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef POSIX_PLATFORM_SETTINGS_HPP_
+#define POSIX_PLATFORM_SETTINGS_HPP_
+
+namespace ot {
+namespace Posix {
+
+/**
+ * This function gets a setting from the persisted file.
+ *
+ * @param[in]      aInstance     The OpenThread instance structure.
+ * @param[in]      aKey          The key associated with the requested setting.
+ * @param[in]      aIndex        The index of the specific item to get.
+ * @param[out]     aValue        A pointer to where the value of the setting should be written.
+ * @param[in,out]  aValueLength  A pointer to the length of the value.
+ *
+ * @retval OT_ERROR_NONE        The given setting was found and fetched successfully.
+ * @retval OT_ERROR_NOT_FOUND   The given key or index was not found in the setting store.
+ *
+ */
+otError PlatformSettingsGet(otInstance *aInstance, uint16_t aKey, int aIndex, uint8_t *aValue, uint16_t *aValueLength);
+
+/**
+ * This function sets a setting in the persisted file.
+ *
+ * @param[in]  aInstance     The OpenThread instance structure.
+ * @param[in]  aKey          The key associated with the requested setting.
+ * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
+ * @param[in]  aValueLength  The length of the data pointed to by aValue.
+ *
+ */
+void PlatformSettingsSet(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+
+/**
+ * This function adds a setting to the persisted file.
+ *
+ * @param[in]  aInstance     The OpenThread instance structure.
+ * @param[in]  aKey          The key associated with the requested setting.
+ * @param[in]  aValue        A pointer to where the new value of the setting should be read from.
+ * @param[in]  aValueLength  The length of the data pointed to by aValue.
+ *
+ */
+void PlatformSettingsAdd(otInstance *aInstance, uint16_t aKey, const uint8_t *aValue, uint16_t aValueLength);
+
+/**
+ * This function removes a setting either from swap file or persisted file.
+ *
+ * @param[in]  aInstance  The OpenThread instance structure.
+ * @param[in]  aKey       The key associated with the requested setting.
+ * @param[in]  aIndex     The index of the value to be removed. If set to -1, all values for this aKey will be removed.
+ * @param[out] aSwapFd    A optional pointer to receive file descriptor of the generated swap file descriptor.
+ *
+ * @note
+ *   If @p aSwapFd is null, operate deleting on the setting file.
+ *   If @p aSwapFd is not null, operate on the swap file, and aSwapFd will point to the swap file descriptor.
+ *
+ * @retval OT_ERROR_NONE        The given key and index was found and removed successfully.
+ * @retval OT_ERROR_NOT_FOUND   The given key or index was not found in the setting store.
+ *
+ */
+otError PlatformSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex, int *aSwapFd);
+
+/**
+ * This function gets the sensitive keys that should be stored in the secure area.
+ *
+ * @param[in]   aInstance    The OpenThread instance structure.
+ * @param[out]  aKeys        A pointer to where the pointer to the array containing sensitive keys should be written.
+ * @param[out]  aKeysLength  A pointer to where the count of sensitive keys should be written.
+ *
+ */
+void PlatformSettingsGetSensitiveKeys(otInstance *aInstance, const uint16_t **aKeys, uint16_t *aKeysLength);
+
+} // namespace Posix
+} // namespace ot
+
+#endif // POSIX_PLATFORM_SETTINGS_HPP_


### PR DESCRIPTION
This commit adds the `src/posix/platform/settings.hpp` file to make other components able to access the POSIX data file, so that secure settings implementation can use the same file as platform settings.