### PR TITLE
[settings] set sensitive keys in platform settings initialization

### DIFF
--- a/examples/platforms/utils/settings_ram.c
+++ b/examples/platforms/utils/settings_ram.c
@@ -57,9 +57,11 @@ struct settingsBlock
 } OT_TOOL_PACKED_END;
 
 // settings API
-void otPlatSettingsInit(otInstance *aInstance)
+void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aCriticalKeys, uint16_t aCriticalKeysLength)
 {
     OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aCriticalKeys);
+    OT_UNUSED_VARIABLE(aCriticalKeysLength);
 
     sSettingsBufLength = 0;
 }

--- a/examples/platforms/utils/settings_ram.c
+++ b/examples/platforms/utils/settings_ram.c
@@ -57,11 +57,11 @@ struct settingsBlock
 } OT_TOOL_PACKED_END;
 
 // settings API
-void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aCriticalKeys, uint16_t aCriticalKeysLength)
+void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aSensitiveKeys, uint16_t aSensitiveKeysLength)
 {
     OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(aCriticalKeys);
-    OT_UNUSED_VARIABLE(aCriticalKeysLength);
+    OT_UNUSED_VARIABLE(aSensitiveKeys);
+    OT_UNUSED_VARIABLE(aSensitiveKeysLength);
 
     sSettingsBufLength = 0;
 }

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (198)
+#define OPENTHREAD_API_VERSION (199)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -55,7 +55,7 @@ extern "C" {
  * This enumeration defines the keys of settings.
  *
  * Note: When adding a new settings key, if the settings corresponding to the key contains security sensitive
- *       information, the developer MUST add the key to the array `kCriticalKeys`.
+ *       information, the developer MUST add the key to the array `kSensitiveKeys`.
  *
  */
 enum
@@ -82,15 +82,15 @@ enum
  *
  * This function also sets the critical keys that should be stored in the secure area.
  *
- * Note that the memory pointed by @p aCriticalKeys MUST not be released before @p aInstance is destroyed.
+ * Note that the memory pointed by @p aSensitiveKeys MUST not be released before @p aInstance is destroyed.
  *
- * @param[in]  aInstance            The OpenThread instance structure.
- * @param[in]  aCriticalKeys        A pointer to an array containing the list of critical keys. May be NULL only if
- *                                  @p aCriticalKeysLength is 0, which means that there is no critical keys.
- * @param[in]  aCriticalKeysLength  The number of entries in the @p aCriticalKeys array.
+ * @param[in]  aInstance             The OpenThread instance structure.
+ * @param[in]  aSensitiveKeys        A pointer to an array containing the list of critical keys. May be NULL only if
+ *                                   @p aSensitiveKeysLength is 0, which means that there is no critical keys.
+ * @param[in]  aSensitiveKeysLength  The number of entries in the @p aSensitiveKeys array.
  *
  */
-void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aCriticalKeys, uint16_t aCriticalKeysLength);
+void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aSensitiveKeys, uint16_t aSensitiveKeysLength);
 
 /**
  * Performs any de-initialization for the settings subsystem, if necessary.

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -80,10 +80,17 @@ enum
 /**
  * Performs any initialization for the settings subsystem, if necessary.
  *
- * @param[in]  aInstance The OpenThread instance structure.
+ * This function also sets the critical keys that should be stored in the secure area.
+ *
+ * Note that the memory pointed by @p aCriticalKeys MUST not be released before @p aInstance is destroyed.
+ *
+ * @param[in]  aInstance            The OpenThread instance structure.
+ * @param[in]  aCriticalKeys        A pointer to an array containing the list of critical keys. May be NULL only if
+ *                                  @p aCriticalKeysLength is 0, which means that there is no critical keys.
+ * @param[in]  aCriticalKeysLength  The number of entries in the @p aCriticalKeys array.
  *
  */
-void otPlatSettingsInit(otInstance *aInstance);
+void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aCriticalKeys, uint16_t aCriticalKeysLength);
 
 /**
  * Performs any de-initialization for the settings subsystem, if necessary.
@@ -92,18 +99,6 @@ void otPlatSettingsInit(otInstance *aInstance);
  *
  */
 void otPlatSettingsDeinit(otInstance *aInstance);
-
-/**
- * This function sets the critical keys that should be stored in the secure area.
- *
- * Note that the memory pointed by @p aKeys MUST not be released before @p aInstance is destroyed.
- *
- * @param[in]  aInstance    The OpenThread instance structure.
- * @param[in]  aKeys        A pointer to an array containing the list of critical keys.
- * @param[in]  aKeysLength  The number of entries in the @p aKeys array.
- *
- */
-void otPlatSettingsSetCriticalKeys(otInstance *aInstance, const uint16_t *aKeys, uint16_t aKeysLength);
 
 /// Fetches the value of a setting
 /** This function fetches the value of the setting identified

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -80,13 +80,13 @@ enum
 /**
  * Performs any initialization for the settings subsystem, if necessary.
  *
- * This function also sets the critical keys that should be stored in the secure area.
+ * This function also sets the sensitive keys that should be stored in the secure area.
  *
  * Note that the memory pointed by @p aSensitiveKeys MUST not be released before @p aInstance is destroyed.
  *
  * @param[in]  aInstance             The OpenThread instance structure.
- * @param[in]  aSensitiveKeys        A pointer to an array containing the list of critical keys. May be NULL only if
- *                                   @p aSensitiveKeysLength is 0, which means that there is no critical keys.
+ * @param[in]  aSensitiveKeys        A pointer to an array containing the list of sensitive keys. May be NULL only if
+ *                                   @p aSensitiveKeysLength is 0, which means that there is no sensitive keys.
  * @param[in]  aSensitiveKeysLength  The number of entries in the @p aSensitiveKeys array.
  *
  */

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -187,8 +187,8 @@ const char *SettingsBase::KeyToString(Key aKey)
 //---------------------------------------------------------------------------------------------------------------------
 // Settings
 
-// This array contains critical keys that should be stored in the secure area.
-const uint16_t Settings::kCriticalKeys[] = {
+// This array contains sensitive keys that should be stored in the secure area.
+const uint16_t Settings::kSensitiveKeys[] = {
     SettingsBase::kKeyActiveDataset,
     SettingsBase::kKeyPendingDataset,
     SettingsBase::kKeySrpEcdsaKey,
@@ -196,7 +196,7 @@ const uint16_t Settings::kCriticalKeys[] = {
 
 void Settings::Init(void)
 {
-    Get<SettingsDriver>().Init(kCriticalKeys, GetArrayLength(kCriticalKeys));
+    Get<SettingsDriver>().Init(kSensitiveKeys, GetArrayLength(kSensitiveKeys));
 }
 
 void Settings::Deinit(void)

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -196,8 +196,7 @@ const uint16_t Settings::kCriticalKeys[] = {
 
 void Settings::Init(void)
 {
-    Get<SettingsDriver>().Init();
-    Get<SettingsDriver>().SetCriticalKeys(kCriticalKeys, GetArrayLength(kCriticalKeys));
+    Get<SettingsDriver>().Init(kCriticalKeys, GetArrayLength(kCriticalKeys));
 }
 
 void Settings::Deinit(void)

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -1118,7 +1118,7 @@ private:
 
     static void Log(Action aAction, Error aError, Key aKey, const void *aValue = nullptr);
 
-    static const uint16_t kCriticalKeys[];
+    static const uint16_t kSensitiveKeys[];
 };
 
 } // namespace ot

--- a/src/core/common/settings_driver.hpp
+++ b/src/core/common/settings_driver.hpp
@@ -66,7 +66,7 @@ public:
     /**
      * This method initializes the settings storage driver.
      *
-     * @param[in]  aSensitiveKeys        A pointer to an array containing the list of critical keys.
+     * @param[in]  aSensitiveKeys        A pointer to an array containing the list of sensitive keys.
      * @param[in]  aSensitiveKeysLength  The number of entries in the @p aSensitiveKeys array.
      *
      */

--- a/src/core/common/settings_driver.hpp
+++ b/src/core/common/settings_driver.hpp
@@ -66,19 +66,19 @@ public:
     /**
      * This method initializes the settings storage driver.
      *
-     * @param[in]  aCriticalKeys        A pointer to an array containing the list of critical keys.
-     * @param[in]  aCriticalKeysLength  The number of entries in the @p aCriticalKeys array.
+     * @param[in]  aSensitiveKeys        A pointer to an array containing the list of critical keys.
+     * @param[in]  aSensitiveKeysLength  The number of entries in the @p aSensitiveKeys array.
      *
      */
-    void Init(const uint16_t *aCriticalKeys, uint16_t aCriticalKeysLength)
+    void Init(const uint16_t *aSensitiveKeys, uint16_t aSensitiveKeysLength)
     {
 #if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
-        OT_UNUSED_VARIABLE(aCriticalKeys);
-        OT_UNUSED_VARIABLE(aCriticalKeysLength);
+        OT_UNUSED_VARIABLE(aSensitiveKeys);
+        OT_UNUSED_VARIABLE(aSensitiveKeysLength);
 
         mFlash.Init();
 #else
-        otPlatSettingsInit(GetInstancePtr(), aCriticalKeys, aCriticalKeysLength);
+        otPlatSettingsInit(GetInstancePtr(), aSensitiveKeys, aSensitiveKeysLength);
 #endif
     }
 

--- a/src/core/common/settings_driver.hpp
+++ b/src/core/common/settings_driver.hpp
@@ -66,13 +66,19 @@ public:
     /**
      * This method initializes the settings storage driver.
      *
+     * @param[in]  aCriticalKeys        A pointer to an array containing the list of critical keys.
+     * @param[in]  aCriticalKeysLength  The number of entries in the @p aCriticalKeys array.
+     *
      */
-    void Init(void)
+    void Init(const uint16_t *aCriticalKeys, uint16_t aCriticalKeysLength)
     {
 #if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
+        OT_UNUSED_VARIABLE(aCriticalKeys);
+        OT_UNUSED_VARIABLE(aCriticalKeysLength);
+
         mFlash.Init();
 #else
-        otPlatSettingsInit(GetInstancePtr());
+        otPlatSettingsInit(GetInstancePtr(), aCriticalKeys, aCriticalKeysLength);
 #endif
     }
 
@@ -84,23 +90,6 @@ public:
     {
 #if !OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
         otPlatSettingsDeinit(GetInstancePtr());
-#endif
-    }
-
-    /**
-     * This method sets the critical keys that should be stored in a secure area.
-     *
-     * @param[in]  aKeys        A pointer to an array containing the list of critical keys.
-     * @param[in]  aKeysLength  The number of entries in the @p aKeys array.
-     *
-     */
-    void SetCriticalKeys(const uint16_t *aKeys, uint16_t aKeysLength)
-    {
-#if OPENTHREAD_CONFIG_PLATFORM_FLASH_API_ENABLE
-        OT_UNUSED_VARIABLE(aKeys);
-        OT_UNUSED_VARIABLE(aKeysLength);
-#else
-        otPlatSettingsSetCriticalKeys(GetInstancePtr(), aKeys, aKeysLength);
 #endif
     }
 

--- a/src/lib/spinel/radio_spinel_impl.hpp
+++ b/src/lib/spinel/radio_spinel_impl.hpp
@@ -431,7 +431,7 @@ otError RadioSpinel<InterfaceType, ProcessContextType>::RestoreDatasetFromNcp(vo
 {
     otError error = OT_ERROR_NONE;
 
-    Instance::Get().template Get<SettingsDriver>().Init();
+    Instance::Get().template Get<SettingsDriver>().Init(nullptr, 0);
 
     otLogInfoPlat("Trying to get saved dataset from NCP");
     SuccessOrExit(

--- a/src/posix/platform/settings.cpp
+++ b/src/posix/platform/settings.cpp
@@ -167,9 +167,19 @@ static void swapDiscard(otInstance *aInstance, int aFd)
     VerifyOrDie(0 == unlink(swapFileName), OT_EXIT_ERROR_ERRNO);
 }
 
-void otPlatSettingsInit(otInstance *aInstance)
+void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aCriticalKeys, uint16_t aCriticalKeysLength)
 {
+#if !OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    OT_UNUSED_VARIABLE(aCriticalKeys);
+    OT_UNUSED_VARIABLE(aCriticalKeysLength);
+#endif
+
     otError error = OT_ERROR_NONE;
+
+#if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
+    sKeys       = aCriticalKeys;
+    sKeysLength = aCriticalKeysLength;
+#endif
 
     // Don't touch the settings file the system runs in dry-run mode.
     VerifyOrExit(!IsSystemDryRun());
@@ -531,7 +541,7 @@ int main()
         data[i] = i;
     }
 
-    otPlatSettingsInit(instance);
+    otPlatSettingsInit(instance, nullptr, 0);
 
     // verify empty situation
     otPlatSettingsWipe(instance);

--- a/src/posix/platform/settings.cpp
+++ b/src/posix/platform/settings.cpp
@@ -167,18 +167,18 @@ static void swapDiscard(otInstance *aInstance, int aFd)
     VerifyOrDie(0 == unlink(swapFileName), OT_EXIT_ERROR_ERRNO);
 }
 
-void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aCriticalKeys, uint16_t aCriticalKeysLength)
+void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aSensitiveKeys, uint16_t aSensitiveKeysLength)
 {
 #if !OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    OT_UNUSED_VARIABLE(aCriticalKeys);
-    OT_UNUSED_VARIABLE(aCriticalKeysLength);
+    OT_UNUSED_VARIABLE(aSensitiveKeys);
+    OT_UNUSED_VARIABLE(aSensitiveKeysLength);
 #endif
 
     otError error = OT_ERROR_NONE;
 
 #if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    sKeys       = aCriticalKeys;
-    sKeysLength = aCriticalKeysLength;
+    sKeys       = aSensitiveKeys;
+    sKeysLength = aSensitiveKeysLength;
 #endif
 
     // Don't touch the settings file the system runs in dry-run mode.

--- a/tests/fuzz/fuzzer_platform.cpp
+++ b/tests/fuzz/fuzzer_platform.cpp
@@ -441,9 +441,11 @@ otError otPlatEntropyGet(uint8_t *aOutput, uint16_t aOutputLength)
     return OT_ERROR_NONE;
 }
 
-void otPlatSettingsInit(otInstance *aInstance)
+void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aCriticalKeys, uint16_t aCriticalKeysLength)
 {
     OT_UNUSED_VARIABLE(aInstance);
+    OT_UNUSED_VARIABLE(aCriticalKeys);
+    OT_UNUSED_VARIABLE(aCriticalKeysLength);
 }
 
 void otPlatSettingsDeinit(otInstance *aInstance)

--- a/tests/fuzz/fuzzer_platform.cpp
+++ b/tests/fuzz/fuzzer_platform.cpp
@@ -441,11 +441,11 @@ otError otPlatEntropyGet(uint8_t *aOutput, uint16_t aOutputLength)
     return OT_ERROR_NONE;
 }
 
-void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aCriticalKeys, uint16_t aCriticalKeysLength)
+void otPlatSettingsInit(otInstance *aInstance, const uint16_t *aSensitiveKeys, uint16_t aSensitiveKeysLength)
 {
     OT_UNUSED_VARIABLE(aInstance);
-    OT_UNUSED_VARIABLE(aCriticalKeys);
-    OT_UNUSED_VARIABLE(aCriticalKeysLength);
+    OT_UNUSED_VARIABLE(aSensitiveKeys);
+    OT_UNUSED_VARIABLE(aSensitiveKeysLength);
 }
 
 void otPlatSettingsDeinit(otInstance *aInstance)

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -330,7 +330,7 @@ OT_TOOL_WEAK void otPlatLog(otLogLevel, otLogRegion, const char *, ...)
 {
 }
 
-OT_TOOL_WEAK void otPlatSettingsInit(otInstance *)
+OT_TOOL_WEAK void otPlatSettingsInit(otInstance *, const uint16_t *, uint16_t)
 {
 }
 


### PR DESCRIPTION
This commit makes the core pass the sensitive keys to the platform settings initialization, so that the platform settings implementation can know which keys are sensitive keys during the initializing and do the migration when needed.
