### PR TITLE
[mle] perform slow operation after sending Child ID Response

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1771,7 +1771,7 @@ void Mle::HandleAttachTimer(void)
     if (HasAcceptableParentCandidate() && (SendChildIdRequest() == kErrorNone))
     {
         SetAttachState(kAttachStateChildIdRequest);
-        delay = kParentRequestReedTimeout;
+        delay = kMaxChildIdResponseTimeout;
         ExitNow();
     }
 

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3131,8 +3131,6 @@ Error MleRouter::SendChildIdResponse(Child &aChild)
         SuccessOrExit(error = AppendChildAddresses(*message, aChild));
     }
 
-    SetChildStateToValid(aChild);
-
     if (!aChild.IsRxOnWhenIdle())
     {
         Get<IndirectSender>().SetChildUseShortAddress(aChild, false);
@@ -3149,6 +3147,10 @@ Error MleRouter::SendChildIdResponse(Child &aChild)
     SuccessOrExit(error = SendMessage(*message, destination));
 
     Log(kMessageSend, kTypeChildIdResponse, destination, aChild.GetRloc16());
+
+    // On purpose deferring access to settings after sending the response to comply with
+    // the kMaxChildIdResponseTimeout timing
+    SetChildStateToValid(aChild);
 
 exit:
     FreeMessageOnError(message, error);

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -97,6 +97,7 @@ constexpr uint32_t kChildUpdateRequestPendingDelay = 100;  ///< Delay for aggreg
 constexpr uint8_t  kMaxTransmissionCount           = 3;    ///< Max number of times an MLE message may be transmitted
 constexpr uint32_t kMaxResponseDelay               = 1000; ///< Max response delay for a multicast request (in msec)
 constexpr uint32_t kMaxChildIdRequestTimeout       = 5000; ///< Max delay to rx a Child ID Request (in msec)
+constexpr uint32_t kMaxChildIdResponseTimeout      = 1250; ///< Max delay to rx a Child ID Response (in msec)
 constexpr uint32_t kMaxChildUpdateResponseTimeout  = 2000; ///< Max delay to rx a Child Update Response (in msec)
 constexpr uint32_t kMaxLinkRequestTimeout          = 2000; ///< Max delay to rx a Link Accept
 


### PR DESCRIPTION
OpenThread children will retry Child ID Requests in case the response
is not received within 1250 ms. When using slow settings subsystem
it could happen that storing the child information would take longer
and response would come later than expected.

This commit defers settings storage after sending the message to
avoid such situation.