### PR TITLE
[netdata] update `Service::DnsSrpUnicast` to include `Origin`

### DIFF
--- a/src/core/thread/network_data_service.cpp
+++ b/src/core/thread/network_data_service.cpp
@@ -239,6 +239,7 @@ Error Manager::GetNextDnsSrpUnicastInfo(Iterator &aIterator, DnsSrpUnicast::Info
 
                 aInfo.mSockAddr.SetAddress(serverData->GetAddress());
                 aInfo.mSockAddr.SetPort(serverData->GetPort());
+                aInfo.mOrigin = DnsSrpUnicast::kFromServerData;
                 ExitNow();
             }
 
@@ -250,6 +251,7 @@ Error Manager::GetNextDnsSrpUnicastInfo(Iterator &aIterator, DnsSrpUnicast::Info
                 aInfo.mSockAddr.GetAddress().SetToRoutingLocator(Get<Mle::Mle>().GetMeshLocalPrefix(),
                                                                  aIterator.mServerSubTlv->GetServer16());
                 aInfo.mSockAddr.SetPort(Encoding::BigEndian::ReadUint16(data.GetBytes()));
+                aInfo.mOrigin = DnsSrpUnicast::kFromServerData;
                 ExitNow();
             }
         }
@@ -271,6 +273,7 @@ Error Manager::GetNextDnsSrpUnicastInfo(Iterator &aIterator, DnsSrpUnicast::Info
             dnsServiceData = reinterpret_cast<const DnsSrpUnicast::ServiceData *>(serviceData.GetBytes());
             aInfo.mSockAddr.SetAddress(dnsServiceData->GetAddress());
             aInfo.mSockAddr.SetPort(dnsServiceData->GetPort());
+            aInfo.mOrigin = DnsSrpUnicast::kFromServiceData;
             ExitNow();
         }
 

--- a/src/core/thread/network_data_service.hpp
+++ b/src/core/thread/network_data_service.hpp
@@ -260,12 +260,23 @@ public:
     static const uint8_t kServiceData = kServiceNumber;
 
     /**
+     * This enumeration represents the origin a `DnsSrpUnicast` entry.
+     *
+     */
+    enum Origin : uint8_t
+    {
+        kFromServiceData, ///< Socket address is from service data.
+        kFromServerData,  ///< Socket address is from server data.
+    };
+
+    /**
      * This structure represents information about an DNS/SRP server parsed from related Network Data service entries.
      *
      */
     struct Info
     {
         Ip6::SockAddr mSockAddr; ///< The socket address (IPv6 address and port) of the DNS/SRP server.
+        Origin        mOrigin;   ///< The origin of the socket address (whether from service or server data).
     };
 
     /**


### PR DESCRIPTION
This commit updates `NetworkData::Service::DnsSrpUnicast` to indicate
`Origin` of the entry, whether the server IPv6 address and port
number is included as part of service data or server data. This will
be used by clients to prefer entries with the info in service data
(which coveys the infra-structure provided (authoritative) server)
over the ones in server data (which are used by Thread BRs).

This commit also updates the unit test `test_network_data` to validate
the new behavior.