### PR TITLE
[mesh-forwarder] remove assert in `HandleFrameRequest`()`

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -528,7 +528,6 @@ Mac::TxFrame *MeshForwarder::HandleFrameRequest(Mac::TxFrames &aTxFrames)
             ExitNow(frame = nullptr);
         }
 
-        OT_ASSERT(frame->GetLength() != 7);
         break;
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE


### PR DESCRIPTION
----

Looks like we had this assert for frame length check against 7 since the very first commit on OT. Not sure if this is assert is still useful. 