### PR TITLE
[routing-manager] resend failed RS messages in 4 seconds

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -219,8 +219,9 @@ private:
     static constexpr uint32_t kRtrSolicitationInterval     = 4;      // Interval between RSs. In sec.
     static constexpr uint32_t kMaxRtrSolicitationDelay     = 1;      // Max delay for initial solicitation. In sec.
     static constexpr uint32_t kRoutingPolicyEvaluationJitter = 1000; // Jitter for routing policy evaluation. In msec.
-    static constexpr uint32_t kRtrSolicitationRetryDelay     = 60;   // The delay before retrying failed RS tx. In Sec.
-    static constexpr uint32_t kMinDelayBetweenRtrAdvs        = 3000; // Min delay (msec) between consecutive RAs.
+    static constexpr uint32_t kRtrSolicitationRetryDelay =
+        kRtrSolicitationInterval;                             // The delay before retrying failed RS tx. In Sec.
+    static constexpr uint32_t kMinDelayBetweenRtrAdvs = 3000; // Min delay (msec) between consecutive RAs.
 
     // The STALE_RA_TIME in seconds. The Routing Manager will consider the prefixes
     // and learned RA parameters STALE when they are not refreshed in STALE_RA_TIME

--- a/tests/scripts/thread-cert/border_router/test_single_border_router.py
+++ b/tests/scripts/thread-cert/border_router/test_single_border_router.py
@@ -267,9 +267,9 @@ class SingleBorderRouter(thread_cert.TestCase):
 
         br.enable_ether()
 
-        # The routing manager may fail to send RS and will wait for 60 seconds
+        # The routing manager may fail to send RS and will wait for 4 seconds
         # before retrying.
-        self.simulator.go(80)
+        self.simulator.go(20)
         self.collect_ipaddrs()
 
         logging.info("BR     addrs: %r", br.get_addrs())


### PR DESCRIPTION
Current `Routing Manager` implementation will try to send the failed RS messages in 60 seconds.
RS failures happen often when the infra interface is re-enabled which is the case of rebooting, and
it could not be acceptable for the border router to take 1 minute to recover the IPv6 connectivity
after reboot.

To resolve this issue, this commit changes the delay to `kRtrSolicitationInterval` (4 seconds)
which is the interval between two successful RS messages.