### PR TITLE
[thci] fix RA configuration for eth0 in the host device

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -592,15 +592,10 @@ class OpenThreadTHCI(object):
             if self.__useDefaultDomainPrefix:
                 self.__addDefaultDomainPrefix()
 
-            self._deviceBeforeThreadStart()
-
         self.__executeCommand('ifconfig up')
         self.__executeCommand('thread start')
         self.isPowerDown = False
         return True
-
-    def _deviceBeforeThreadStart(self):
-        pass
 
     def __stopOpenThread(self):
         """stop OpenThread stack


### PR DESCRIPTION
`accept_ra` was not being set properly for host reference device.

Some cleanup is added for simplificaiton.