### PR TITLE
[mle-router] fix uninitialized `message` in `SendChildUpdateRequest()`

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3160,7 +3160,7 @@ Error MleRouter::SendChildUpdateRequest(Child &aChild)
     static const uint8_t tlvs[] = {Tlv::kTimeout, Tlv::kAddressRegistration};
     Error                error  = kErrorNone;
     Ip6::Address         destination;
-    Message *            message;
+    Message *            message = nullptr;
 
     if (!aChild.IsRxOnWhenIdle())
     {


### PR DESCRIPTION
Fixes the following issue introduced in #7481:
```
../openthread/src/core/thread/mle_router.cpp:3163:26: note: ‘message’ was declared here
     Message *            message;
                          ^~~~~~~
```