### PR TITLE
[mac] log `AddressFiltered` rx errors at debug level

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2234,6 +2234,7 @@ void Mac::LogFrameRxFailure(const RxFrame *aFrame, Error aError) const
     {
     case kErrorAbort:
     case kErrorNoFrameReceived:
+    case kErrorAddressFiltered:
     case kErrorDestinationAddressFiltered:
         logLevel = kLogLevelDebg;
         break;


### PR DESCRIPTION
This commit changes the log level used by `Mac` to log frame rx error
when error is `kErrorAddressFiltered` (from "info" to "debug" log
level). This error is used when the frame is filtered `Mac::Filter`.
This helps reduce the logs during simulation/testing when allow-list
or deny-list are used to form specific network topology.