### PR TITLE
[mle] avoid setting mode `D` flag on MTD builds

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -324,22 +324,19 @@ void Mle::Restore(void)
 
     SuccessOrExit(Get<Settings>().Read(networkInfo));
 
-#if OPENTHREAD_MTD
-    VerifyOrExit(!IsActiveRouter(networkInfo.GetRloc16()), error = kErrorInvalidState);
-#endif
-
     Get<KeyManager>().SetCurrentKeySequence(networkInfo.GetKeySequence());
     Get<KeyManager>().SetMleFrameCounter(networkInfo.GetMleFrameCounter());
     Get<KeyManager>().SetAllMacFrameCounters(networkInfo.GetMacFrameCounter());
 
 #if OPENTHREAD_MTD
+    VerifyOrExit(!IsActiveRouter(networkInfo.GetRloc16()));
     mDeviceMode.Set(networkInfo.GetDeviceMode() & ~DeviceMode::kModeFullThreadDevice);
 #else
     mDeviceMode.Set(networkInfo.GetDeviceMode());
 #endif
 
     // force re-attach when version mismatch.
-    VerifyOrExit(networkInfo.GetVersion() == kThreadVersion, error = kErrorInvalidState);
+    VerifyOrExit(networkInfo.GetVersion() == kThreadVersion);
 
     switch (networkInfo.GetRole())
     {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -324,6 +324,10 @@ void Mle::Restore(void)
 
     SuccessOrExit(Get<Settings>().Read(networkInfo));
 
+#if OPENTHREAD_MTD
+    VerifyOrExit(!(networkInfo.GetDeviceMode() & DeviceMode::kModeFullThreadDevice));
+#endif
+
     Get<KeyManager>().SetCurrentKeySequence(networkInfo.GetKeySequence());
     Get<KeyManager>().SetMleFrameCounter(networkInfo.GetMleFrameCounter());
     Get<KeyManager>().SetAllMacFrameCounters(networkInfo.GetMacFrameCounter());
@@ -754,6 +758,10 @@ Error Mle::SetDeviceMode(DeviceMode aDeviceMode)
 {
     Error      error   = kErrorNone;
     DeviceMode oldMode = mDeviceMode;
+
+#if OPENTHREAD_MTD
+    VerifyOrExit(!aDeviceMode.IsFullThreadDevice(), error = kErrorInvalidArgs);
+#endif
 
     VerifyOrExit(aDeviceMode.IsValid(), error = kErrorInvalidArgs);
     VerifyOrExit(mDeviceMode != aDeviceMode);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -329,7 +329,6 @@ void Mle::Restore(void)
     Get<KeyManager>().SetAllMacFrameCounters(networkInfo.GetMacFrameCounter());
 
 #if OPENTHREAD_MTD
-    VerifyOrExit(!IsActiveRouter(networkInfo.GetRloc16()));
     mDeviceMode.Set(networkInfo.GetDeviceMode() & ~DeviceMode::kModeFullThreadDevice);
 #else
     mDeviceMode.Set(networkInfo.GetDeviceMode());
@@ -349,7 +348,12 @@ void Mle::Restore(void)
         ExitNow();
     }
 
-    Get<Mac::Mac>().SetShortAddress(networkInfo.GetRloc16());
+#if OPENTHREAD_MTD
+    if (!IsActiveRouter(networkInfo.GetRloc16()))
+#endif
+    {
+        Get<Mac::Mac>().SetShortAddress(networkInfo.GetRloc16());
+    }
     Get<Mac::Mac>().SetExtAddress(networkInfo.GetExtAddress());
 
     mMeshLocal64.GetAddress().SetIid(networkInfo.GetMeshLocalIid());


### PR DESCRIPTION
When building with `OPENTHREAD_MTD` make sure that the device is
not configured as Full Thread Device, whether by the API or by the
stored settings.