### PR TITLE
[rcp] make Spinel backward compatible with older RCP API

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -989,6 +989,7 @@ private:
     uint16_t     mShortAddress;
     uint16_t     mPanId;
     otRadioCaps  mRadioCaps;
+    unsigned int mRcpApiVersion;
     uint8_t      mChannel;
     int8_t       mRxSensitivity;
     otError      mTxError;

--- a/src/lib/spinel/spinel.h
+++ b/src/lib/spinel/spinel.h
@@ -389,7 +389,7 @@
  * Please see section "Spinel definition compatibility guideline" for more details.
  *
  */
-#define SPINEL_MIN_HOST_SUPPORTED_RCP_API_VERSION 4
+#define SPINEL_MIN_HOST_SUPPORTED_RCP_API_VERSION 1
 
 /**
  * @def SPINEL_FRAME_MAX_SIZE


### PR DESCRIPTION
In #6849, the `SPINEL_MIN_HOST_SUPPORTED_RCP_API_VERSION` has been bumped from 1 to 4, which means that this PR introduced a breaking change to the API.

This PR introduces small changes to restore backward compatibility (only if configured for Thread 1.1). I don't know if it's a useful enhancement, but for us it allows us to update the host stack without needing a firmware update. What do you think?



