### PR TITLE
[mle] add `kBetterParent` in `AttachMode` enum

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1937,6 +1937,7 @@ uint32_t Mle::Reattach(void)
     switch (mAttachMode)
     {
     case kAnyPartition:
+    case kBetterParent:
         if (!IsChild())
         {
             if (mAlternatePanId != Mac::kPanIdBroadcast)
@@ -3528,6 +3529,7 @@ void Mle::HandleParentResponse(const Message &aMessage, const Ip6::MessageInfo &
         switch (mAttachMode)
         {
         case kAnyPartition:
+        case kBetterParent:
             VerifyOrExit(!isPartitionIdSame || isIdSequenceGreater);
             break;
 
@@ -4257,7 +4259,7 @@ void Mle::HandleParentSearchTimer(void)
     {
         LogInfo("PeriodicParentSearch: Parent RSS less than %d, searching for new parents", kParentSearchRssThreadhold);
         mParentSearchIsInBackoff = true;
-        Attach(kAnyPartition);
+        Attach(kBetterParent);
     }
 
 exit:
@@ -4560,6 +4562,7 @@ const char *Mle::AttachModeToString(AttachMode aMode)
         "SamePartitionRetry", // (2) kSamePartitionRetry
         "BetterPartition",    // (3) kBetterPartition
         "DowngradeToReed",    // (4) kDowngradeToReed
+        "BetterParent",       // (5) kBetterParent
     };
 
     static_assert(kAnyPartition == 0, "kAnyPartition value is incorrect");
@@ -4567,6 +4570,7 @@ const char *Mle::AttachModeToString(AttachMode aMode)
     static_assert(kSamePartitionRetry == 2, "kSamePartitionRetry value is incorrect");
     static_assert(kBetterPartition == 3, "kBetterPartition value is incorrect");
     static_assert(kDowngradeToReed == 4, "kDowngradeToReed value is incorrect");
+    static_assert(kBetterParent == 5, "kBetterParent value is incorrect");
 
     return kAttachModeStrings[aMode];
 }

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -794,6 +794,7 @@ protected:
         kSamePartitionRetry, ///< Attach to the same Thread partition (attempt 2 when losing connectivity).
         kBetterPartition,    ///< Attach to a better (i.e. higher weight/partition id) Thread partition.
         kDowngradeToReed,    ///< Attach to the same Thread partition during downgrade process.
+        kBetterParent,       ///< Attach to a better parent.
     };
 
     /**

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -335,6 +335,7 @@ void MleRouter::HandleChildStart(AttachMode aMode)
         break;
 
     case kAnyPartition:
+    case kBetterParent:
         // If attach was started due to receiving MLE Announce Messages, all rx-on-when-idle devices would
         // start attach immediately when receiving such Announce message as in Thread 1.1 specification,
         // Section 4.8.1,


### PR DESCRIPTION
This commit adds a new enumerator `kBetterParent` in `AttachMode`
enumeration. This new value is used by periodic parent search
feature only when searching for a better parent to help make
it explicit that attach process is started for this purpose.

----

_Background_:
The is used so we can tell an ongoing attach is triggered by the 
"periodic parent search" mechanism or not. In most situations 
we can treat this mode same as `kAnyPartition`. But this will be
useful in an upcoming change to the attach process (from SPEC-1036)
where we want different behavior (e.g., different number of parent 
requests) based on what started the attach cycle.

The PR contains the commit from https://github.com/openthread/openthread/pull/7515, please check and review the 
last commit on this PR. Thanks.