### PR TITLE
[rcp] report radio version in RCP mode instead of OT version

### DIFF
--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1978,7 +1978,11 @@ exit:
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_NCP_VERSION>(void)
 {
+#if OPENTHREAD_RADIO
+    return mEncoder.WriteUtf8(otGetRadioVersionString(mInstance));
+#else
     return mEncoder.WriteUtf8(otGetVersionString());
+#endif
 }
 
 template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_INTERFACE_COUNT>(void)


### PR DESCRIPTION
The `rcp version` cli command can be used to query the firmware version of the RCP.

Currently, the RCP reports the version of the OT library (running on the MCU), as returned by `otGetVersionString`.

This PR updates the version reported by the RCP, to return the radio version (`otGetRadioVersionString`), which falls back to `otGetVersionString` if the platform does not define a custom `otPlatRadioGetVersionString`.