### PR TITLE
[net-diag] fix `kChildIdMask` value

### DIFF
--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -1033,7 +1033,7 @@ private:
     static constexpr uint8_t  kReservedOffset = 9;
     static constexpr uint16_t kTimeoutMask    = 0xf800;
     static constexpr uint16_t kReservedMask   = 0x0600;
-    static constexpr uint16_t kChildIdMask    = 0x1f;
+    static constexpr uint16_t kChildIdMask    = 0x1ff;
 
     uint16_t mTimeoutRsvChildId;
     uint8_t  mMode;


### PR DESCRIPTION
The value is unintentionally changed to `0x1f` in https://github.com/openthread/openthread/pull/6895.