### PR TITLE
[settings] reserve settings keys for vendor use

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (199)
+#define OPENTHREAD_API_VERSION (200)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -75,6 +75,10 @@ enum
     OT_SETTINGS_KEY_SRP_SERVER_INFO      = 0x000d, ///< The SRP server info (UDP port).
     OT_SETTINGS_KEY_LEGACY_NAT64_PREFIX  = 0x000e, ///< Reserved. Legacy NAT64 prefix.
     OT_SETTINGS_KEY_BR_ULA_PREFIX        = 0x000f, ///< BR ULA prefix.
+
+    // Keys in range 0x1000-0x1fff are reserved for vendor-specific use.
+    OT_SETTINGS_KEY_VENDOR_RESERVED_BEGIN = 0x1000,
+    OT_SETTINGS_KEY_VENDOR_RESERVED_END   = 0x2000,
 };
 
 /**

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -76,9 +76,9 @@ enum
     OT_SETTINGS_KEY_LEGACY_NAT64_PREFIX  = 0x000e, ///< Reserved. Legacy NAT64 prefix.
     OT_SETTINGS_KEY_BR_ULA_PREFIX        = 0x000f, ///< BR ULA prefix.
 
-    // Keys in range 0x1000-0x1fff are reserved for vendor-specific use.
-    OT_SETTINGS_KEY_VENDOR_RESERVED_BEGIN = 0x1000,
-    OT_SETTINGS_KEY_VENDOR_RESERVED_END   = 0x2000,
+    // Keys in range 0x8000-0xffff are reserved for vendor-specific use.
+    OT_SETTINGS_KEY_VENDOR_RESERVED_BEGIN = 0x8000,
+    OT_SETTINGS_KEY_VENDOR_RESERVED_END   = 0x10000,
 };
 
 /**

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -78,7 +78,7 @@ enum
 
     // Keys in range 0x8000-0xffff are reserved for vendor-specific use.
     OT_SETTINGS_KEY_VENDOR_RESERVED_BEGIN = 0x8000,
-    OT_SETTINGS_KEY_VENDOR_RESERVED_END   = 0x10000,
+    OT_SETTINGS_KEY_VENDOR_RESERVED_MAX   = 0xffff,
 };
 
 /**

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -77,8 +77,8 @@ enum
     OT_SETTINGS_KEY_BR_ULA_PREFIX        = 0x000f, ///< BR ULA prefix.
 
     // Keys in range 0x8000-0xffff are reserved for vendor-specific use.
-    OT_SETTINGS_KEY_VENDOR_RESERVED_BEGIN = 0x8000,
-    OT_SETTINGS_KEY_VENDOR_RESERVED_MAX   = 0xffff,
+    OT_SETTINGS_KEY_VENDOR_RESERVED_MIN = 0x8000,
+    OT_SETTINGS_KEY_VENDOR_RESERVED_MAX = 0xffff,
 };
 
 /**

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -128,6 +128,8 @@ public:
     };
 
     static constexpr Key kLastKey = kKeyBrUlaPrefix; ///< The last (numerically) enumerator value in `Key`.
+    static_assert(static_cast<int>(kLastKey) < static_cast<int>(OT_SETTINGS_KEY_VENDOR_RESERVED_BEGIN),
+                  "Core settings keys overlap with Vender reserved keys");
 
     /**
      * This structure represents the device's own network information for settings storage.

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -129,7 +129,7 @@ public:
 
     static constexpr Key kLastKey = kKeyBrUlaPrefix; ///< The last (numerically) enumerator value in `Key`.
     static_assert(static_cast<uint16_t>(kLastKey) < static_cast<uint16_t>(OT_SETTINGS_KEY_VENDOR_RESERVED_MIN),
-                  "Core settings keys overlap with Vender reserved keys");
+                  "Core settings keys overlap with vendor reserved keys");
 
     /**
      * This structure represents the device's own network information for settings storage.

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -128,7 +128,7 @@ public:
     };
 
     static constexpr Key kLastKey = kKeyBrUlaPrefix; ///< The last (numerically) enumerator value in `Key`.
-    static_assert(static_cast<int>(kLastKey) < static_cast<int>(OT_SETTINGS_KEY_VENDOR_RESERVED_BEGIN),
+    static_assert(static_cast<uint16_t>(kLastKey) < static_cast<uint16_t>(OT_SETTINGS_KEY_VENDOR_RESERVED_BEGIN),
                   "Core settings keys overlap with Vender reserved keys");
 
     /**

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -128,7 +128,7 @@ public:
     };
 
     static constexpr Key kLastKey = kKeyBrUlaPrefix; ///< The last (numerically) enumerator value in `Key`.
-    static_assert(static_cast<uint16_t>(kLastKey) < static_cast<uint16_t>(OT_SETTINGS_KEY_VENDOR_RESERVED_BEGIN),
+    static_assert(static_cast<uint16_t>(kLastKey) < static_cast<uint16_t>(OT_SETTINGS_KEY_VENDOR_RESERVED_MIN),
                   "Core settings keys overlap with Vender reserved keys");
 
     /**


### PR DESCRIPTION
This PR reserves a range of settings keys for vendors to use in their extensions.