### PR TITLE
[bbr] revert add `bbr skipseqnuminc` command for reference device

### DIFF
--- a/include/openthread/backbone_router_ftd.h
+++ b/include/openthread/backbone_router_ftd.h
@@ -273,19 +273,6 @@ void otBackboneRouterMulticastListenerClear(otInstance *aInstance);
  */
 otError otBackboneRouterMulticastListenerAdd(otInstance *aInstance, const otIp6Address *aAddress, uint32_t aTimeout);
 
-/**
- * This method configures the ability to increase or not the BBR Dataset Sequence Number when a
- * BBR recovers its BBR Dataset from the Leader's Network Data.
- *
- * Note: available only when `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is enabled.
- *       Only used for certification.
- *
- * @param[in] aInstance  A pointer to an OpenThread instance.
- * @param[in] aSkip      Whether to skip the increase of Sequence Number or not.
- *
- */
-void otBackboneRouterConfigSkipSeqNumIncrease(otInstance *aInstance, bool aSkip);
-
 #define OT_BACKBONE_ROUTER_MULTICAST_LISTENER_ITERATOR_INIT \
     0 ///< Initializer for otBackboneRouterMulticastListenerIterator
 

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (199)
+#define OPENTHREAD_API_VERSION (200)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -324,17 +324,6 @@ Set jitter (in seconds) for Backbone Router registration for Thread 1.2 FTD.
 Done
 ```
 
-### bbr skipseqnuminc
-
-Skip increase of Sequence Number when updating the local BBR Dataset from the Network Data.
-
-Only for testing/reference device.
-
-```bash
-> bbr skipseqnuminc
-Done
-```
-
 ### ba
 
 Show current Border Agent information.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -543,13 +543,6 @@ template <> otError Interpreter::Process<Cmd("bbr")>(Arg aArgs[])
             }
 #endif
         }
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-        else if (aArgs[0] == "skipseqnuminc")
-        {
-            otBackboneRouterConfigSkipSeqNumIncrease(GetInstancePtr(), true);
-            ExitNow(error = OT_ERROR_NONE);
-        }
-#endif
         SuccessOrExit(error = ProcessBackboneRouterLocal(aArgs));
     }
 

--- a/src/core/api/backbone_router_ftd_api.cpp
+++ b/src/core/api/backbone_router_ftd_api.cpp
@@ -177,11 +177,6 @@ otError otBackboneRouterMulticastListenerAdd(otInstance *aInstance, const otIp6A
 }
 #endif // OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
 
-void otBackboneRouterConfigSkipSeqNumIncrease(otInstance *aInstance, bool aSkip)
-{
-    AsCoreType(aInstance).Get<BackboneRouter::Local>().ConfigSkipSeqNumIncrease(aSkip);
-}
-
 #endif // OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 
 #endif // OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE

--- a/src/core/backbone_router/bbr_local.cpp
+++ b/src/core/backbone_router/bbr_local.cpp
@@ -59,9 +59,6 @@ Local::Local(Instance &aInstance)
     , mIsServiceAdded(false)
     , mDomainPrefixCallback(nullptr)
     , mDomainPrefixCallbackContext(nullptr)
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    , mSkipSeqNumIncrease(false)
-#endif
 {
     mDomainPrefixConfig.GetPrefix().SetLength(0);
 
@@ -275,19 +272,7 @@ void Local::HandleBackboneRouterPrimaryUpdate(Leader::State aState, const Backbo
         mSequenceNumber      = aConfig.mSequenceNumber;
         mReregistrationDelay = aConfig.mReregistrationDelay;
         mMlrTimeout          = aConfig.mMlrTimeout;
-
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-        if (mSkipSeqNumIncrease)
-        {
-            // BBR-TC-02 forces Sequence Number for the reference device with raw UDP API
-            // Do not increase Sequence Number in that case.
-        }
-        else
-#endif
-        {
-            SequenceNumberIncrease();
-        }
-
+        SequenceNumberIncrease();
         Get<Notifier>().Signal(kEventThreadBackboneRouterLocalChanged);
         if (AddService(true /* Force registration to refresh and restore Primary state */) == kErrorNone)
         {
@@ -479,13 +464,6 @@ void Local::SetDomainPrefixCallback(otBackboneRouterDomainPrefixCallback aCallba
     mDomainPrefixCallback        = aCallback;
     mDomainPrefixCallbackContext = aContext;
 }
-
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-void Local::ConfigSkipSeqNumIncrease(bool aSkip)
-{
-    mSkipSeqNumIncrease = aSkip;
-}
-#endif
 
 } // namespace BackboneRouter
 

--- a/src/core/backbone_router/bbr_local.hpp
+++ b/src/core/backbone_router/bbr_local.hpp
@@ -255,20 +255,6 @@ public:
      */
     void SetDomainPrefixCallback(otBackboneRouterDomainPrefixCallback aCallback, void *aContext);
 
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    /**
-     * This method configures the ability to increase or not the BBR Dataset Sequence Number when a
-     * BBR recovers its BBR Dataset from the Leader's Network Data.
-     *
-     * Note: available only when `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE` is enabled.
-     *       Only used for certification.
-     *
-     * @param[in] aSkip  Whether to skip the increase of Sequence Number or not.
-     *
-     */
-    void ConfigSkipSeqNumIncrease(bool aSkip);
-#endif
-
 private:
     void SetState(BackboneRouterState aState);
     void RemoveService(void);
@@ -301,10 +287,6 @@ private:
     Ip6::Address                         mAllDomainBackboneRouters;
     otBackboneRouterDomainPrefixCallback mDomainPrefixCallback;
     void *                               mDomainPrefixCallbackContext;
-
-#if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    bool mSkipSeqNumIncrease : 1;
-#endif
 };
 
 } // namespace BackboneRouter

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -533,17 +533,6 @@ class OpenThreadTHCI(object):
         cmd = 'macfilter addr ' + mode
         return self.__executeCommand(cmd)[-1] == 'Done'
 
-    def __skipSeqNoIncrease(self):
-        """skip sequence number increase when recovering BBR Dataset from Network Data
-
-        Returns:
-            True: successful to set the behavior.
-            False: fail to set the behavior.
-        """
-        print('call __skipSeqNoIncrease()')
-        cmd = 'bbr skipseqnuminc'
-        return self.__executeCommand(cmd)[-1] == 'Done'
-
     def __startOpenThread(self):
         """start OpenThread stack
 
@@ -1160,8 +1149,6 @@ class OpenThreadTHCI(object):
             if self.AutoDUTEnable is False:
                 # set ROUTER_DOWNGRADE_THRESHOLD
                 self.__setRouterDowngradeThreshold(33)
-                # skip increase of Sequence Number for BBR-TC-02
-                self.__skipSeqNoIncrease()
         elif eRoleId == Thread_Device_Role.SED:
             print('join as sleepy end device')
             mode = '-'


### PR DESCRIPTION
This reverts commit c9066b650695494917a87cc9e560a30dc397d3b8 (#7283).

Not needed after changes introduced by DEV-2179.