### PR TITLE
[build] enable coexistence parameter build

### DIFF
--- a/etc/gn/openthread.gni
+++ b/etc/gn/openthread.gni
@@ -231,6 +231,9 @@ if (openthread_enable_core_config_args) {
     # Enable builtin mbedtls management
     openthread_config_enable_builtin_mbedtls_management =
         openthread_external_mbedtls == ""
+
+    # Enable radio coexistence
+    openthread_config_coexistence_enable = false
   }
 }
 

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -264,6 +264,10 @@ if (openthread_enable_core_config_args) {
     if (openthread_config_otns_enable) {
       defines += [ "OPENTHREAD_CONFIG_OTNS_ENABLE=1" ]
     }
+
+    if (openthread_config_coexistence_enable) {
+      defines += [ "OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE=1" ]
+    }
   }
 }
 


### PR DESCRIPTION
This commit enables defining OPENTHREAD_CONFIG_PLATFORM_RADIO_COEX_ENABLE,
which can be used by external build system (i.e. MATTER) to override the
platform defaults. This is useful for platforms having transceivers that
also support coexistence between multiple protocols (WiFi/BLE etc.)