### PR TITLE
[ip6] add header `ip6_types.hpp` for common types and constants

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -549,6 +549,7 @@ openthread_core_files = [
   "net/ip6_headers.hpp",
   "net/ip6_mpl.cpp",
   "net/ip6_mpl.hpp",
+  "net/ip6_types.hpp",
   "net/nd_agent.cpp",
   "net/nd_agent.hpp",
   "net/netif.cpp",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -559,6 +559,7 @@ HEADERS_COMMON                                  = \
     net/ip6_filter.hpp                            \
     net/ip6_headers.hpp                           \
     net/ip6_mpl.hpp                               \
+    net/ip6_types.hpp                             \
     net/nd_agent.hpp                              \
     net/netif.hpp                                 \
     net/sntp_client.hpp                           \

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -456,7 +456,7 @@ Error Ip6::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aI
 
     header.Init();
     header.SetDscp(PriorityToDscp(aMessage.GetPriority()));
-    header.SetEcn(aMessageInfo.mEcn);
+    header.SetEcn(aMessageInfo.GetEcn());
     header.SetPayloadLength(payloadLength);
     header.SetNextHeader(aIpProto);
 

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -51,6 +51,7 @@
 #include "net/ip6_address.hpp"
 #include "net/ip6_headers.hpp"
 #include "net/ip6_mpl.hpp"
+#include "net/ip6_types.hpp"
 #include "net/netif.hpp"
 #include "net/socket.hpp"
 #include "net/tcp6.hpp"
@@ -108,18 +109,6 @@ class Ip6 : public InstanceLocator, private NonCopyable
     friend class Mpl;
 
 public:
-    /**
-     * The max datagram length (in bytes) of an IPv6 message.
-     *
-     */
-    static constexpr uint16_t kMaxDatagramLength = OPENTHREAD_CONFIG_IP6_MAX_DATAGRAM_LENGTH;
-
-    /**
-     * The max datagram length (in bytes) of an unfragmented IPv6 message.
-     *
-     */
-    static constexpr uint16_t kMaxAssembledDatagramLength = OPENTHREAD_CONFIG_IP6_MAX_ASSEMBLED_DATAGRAM;
-
     /**
      * This constructor initializes the object.
      *

--- a/src/core/net/ip6_headers.cpp
+++ b/src/core/net/ip6_headers.cpp
@@ -60,9 +60,9 @@ bool Header::IsValid(void) const
 
     // check Payload Length
 #if !OPENTHREAD_CONFIG_IP6_FRAGMENTATION_ENABLE
-    VerifyOrExit((sizeof(*this) + GetPayloadLength()) <= Ip6::kMaxDatagramLength, ret = false);
+    VerifyOrExit((sizeof(*this) + GetPayloadLength()) <= kMaxDatagramLength, ret = false);
 #else
-    VerifyOrExit((sizeof(*this) + GetPayloadLength()) <= Ip6::kMaxAssembledDatagramLength, ret = false);
+    VerifyOrExit((sizeof(*this) + GetPayloadLength()) <= kMaxAssembledDatagramLength, ret = false);
 #endif
 
 exit:

--- a/src/core/net/ip6_headers.hpp
+++ b/src/core/net/ip6_headers.hpp
@@ -41,6 +41,7 @@
 #include "common/encoding.hpp"
 #include "common/message.hpp"
 #include "net/ip6_address.hpp"
+#include "net/ip6_types.hpp"
 #include "net/netif.hpp"
 #include "net/socket.hpp"
 
@@ -84,33 +85,6 @@ using ot::Encoding::BigEndian::HostSwap32;
  * @{
  *
  */
-
-// Internet Protocol Numbers
-static constexpr uint8_t kProtoHopOpts  = OT_IP6_PROTO_HOP_OPTS; ///< IPv6 Hop-by-Hop Option
-static constexpr uint8_t kProtoTcp      = OT_IP6_PROTO_TCP;      ///< Transmission Control Protocol
-static constexpr uint8_t kProtoUdp      = OT_IP6_PROTO_UDP;      ///< User Datagram
-static constexpr uint8_t kProtoIp6      = OT_IP6_PROTO_IP6;      ///< IPv6 encapsulation
-static constexpr uint8_t kProtoRouting  = OT_IP6_PROTO_ROUTING;  ///< Routing Header for IPv6
-static constexpr uint8_t kProtoFragment = OT_IP6_PROTO_FRAGMENT; ///< Fragment Header for IPv6
-static constexpr uint8_t kProtoIcmp6    = OT_IP6_PROTO_ICMP6;    ///< ICMP for IPv6
-static constexpr uint8_t kProtoNone     = OT_IP6_PROTO_NONE;     ///< No Next Header for IPv6
-static constexpr uint8_t kProtoDstOpts  = OT_IP6_PROTO_DST_OPTS; ///< Destination Options for IPv6
-
-/**
- * Class Selectors
- */
-enum IpDscpCs : uint8_t
-{
-    kDscpCs0    = 0,    ///< Class selector codepoint 0
-    kDscpCs1    = 8,    ///< Class selector codepoint 8
-    kDscpCs2    = 16,   ///< Class selector codepoint 16
-    kDscpCs3    = 24,   ///< Class selector codepoint 24
-    kDscpCs4    = 32,   ///< Class selector codepoint 32
-    kDscpCs5    = 40,   ///< Class selector codepoint 40
-    kDscpCs6    = 48,   ///< Class selector codepoint 48
-    kDscpCs7    = 56,   ///< Class selector codepoint 56
-    kDscpCsMask = 0x38, ///< Class selector mask
-};
 
 /**
  * This class implements IPv6 header generation and parsing.
@@ -196,15 +170,15 @@ public:
      * @returns The IPv6 ECN value.
      *
      */
-    uint8_t GetEcn(void) const { return (mVersionClassFlow.m8[1] & kEcnMask) >> kEcnOffset; }
+    Ecn GetEcn(void) const { return static_cast<Ecn>((mVersionClassFlow.m8[1] & kEcnMask) >> kEcnOffset); }
 
     /**
-     * This method sets the Ipv6 ECN value.
+     * This method sets the IPv6 ECN value.
      *
-     * @param[in]  aEcn  The Ipv6 ECN value.
+     * @param[in]  aEcn  The IPv6 ECN value.
      *
      */
-    void SetEcn(uint8_t aEcn)
+    void SetEcn(Ecn aEcn)
     {
         mVersionClassFlow.m8[1] = (mVersionClassFlow.m8[1] & ~kEcnMask) | ((aEcn << kEcnOffset) & kEcnMask);
     }
@@ -313,11 +287,6 @@ private:
     static constexpr uint8_t  kEcnOffset            = 4;          // To use with `mVersionClassFlow.m8[1]`
     static constexpr uint8_t  kEcnMask              = 0x30;       // To use with `mVersionClassFlow.m8[1]`
     static constexpr uint32_t kVersionClassFlowInit = 0x60000000; // Version 6, TC and flow zero.
-
-    static constexpr uint8_t kEcnNotCapable = OT_ECN_NOT_CAPABLE; ///< Non-ECT
-    static constexpr uint8_t kEcnCapable0   = OT_ECN_CAPABLE_0;   ///< ECT(0)
-    static constexpr uint8_t kEcnCapable1   = OT_ECN_CAPABLE_1;   ///< ECT(1)
-    static constexpr uint8_t kEcnMarked     = OT_ECN_MARKED;      ///< Congestion encountered (CE)
 
     union OT_TOOL_PACKED_FIELD
     {

--- a/src/core/net/ip6_types.hpp
+++ b/src/core/net/ip6_types.hpp
@@ -1,0 +1,115 @@
+/*
+ *  Copyright (c) 2016-2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes types and constants for IPv6 processing.
+ */
+
+#ifndef IP6_TYPES_HPP_
+#define IP6_TYPES_HPP_
+
+#include "openthread-core-config.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+namespace ot {
+namespace Ip6 {
+
+/**
+ * @addtogroup core-ip6-ip6
+ *
+ * @brief
+ *   This module includes definitions for core IPv6 networking.
+ *
+ * @{
+ *
+ */
+
+// Internet Protocol Numbers
+static constexpr uint8_t kProtoHopOpts  = OT_IP6_PROTO_HOP_OPTS; ///< IPv6 Hop-by-Hop Option
+static constexpr uint8_t kProtoTcp      = OT_IP6_PROTO_TCP;      ///< Transmission Control Protocol
+static constexpr uint8_t kProtoUdp      = OT_IP6_PROTO_UDP;      ///< User Datagram
+static constexpr uint8_t kProtoIp6      = OT_IP6_PROTO_IP6;      ///< IPv6 encapsulation
+static constexpr uint8_t kProtoRouting  = OT_IP6_PROTO_ROUTING;  ///< Routing Header for IPv6
+static constexpr uint8_t kProtoFragment = OT_IP6_PROTO_FRAGMENT; ///< Fragment Header for IPv6
+static constexpr uint8_t kProtoIcmp6    = OT_IP6_PROTO_ICMP6;    ///< ICMP for IPv6
+static constexpr uint8_t kProtoNone     = OT_IP6_PROTO_NONE;     ///< No Next Header for IPv6
+static constexpr uint8_t kProtoDstOpts  = OT_IP6_PROTO_DST_OPTS; ///< Destination Options for IPv6
+
+/**
+ * The max datagram length (in bytes) of an IPv6 message.
+ *
+ */
+static constexpr uint16_t kMaxDatagramLength = OPENTHREAD_CONFIG_IP6_MAX_DATAGRAM_LENGTH;
+
+/**
+ * The max datagram length (in bytes) of an unfragmented IPv6 message.
+ *
+ */
+static constexpr uint16_t kMaxAssembledDatagramLength = OPENTHREAD_CONFIG_IP6_MAX_ASSEMBLED_DATAGRAM;
+
+/**
+ * Class Selectors
+ *
+ */
+enum IpDscpCs : uint8_t
+{
+    kDscpCs0    = 0,    ///< Class selector codepoint 0
+    kDscpCs1    = 8,    ///< Class selector codepoint 8
+    kDscpCs2    = 16,   ///< Class selector codepoint 16
+    kDscpCs3    = 24,   ///< Class selector codepoint 24
+    kDscpCs4    = 32,   ///< Class selector codepoint 32
+    kDscpCs5    = 40,   ///< Class selector codepoint 40
+    kDscpCs6    = 48,   ///< Class selector codepoint 48
+    kDscpCs7    = 56,   ///< Class selector codepoint 56
+    kDscpCsMask = 0x38, ///< Class selector mask
+};
+
+/**
+ * This enumeration represents the Explicit Congestion Notification (ECN) values.
+ *
+ */
+enum Ecn : uint8_t
+{
+    kEcnNotCapable = OT_ECN_NOT_CAPABLE, ///< Non ECN-Capable Transport (ECT).
+    kEcnCapable0   = OT_ECN_CAPABLE_0,   ///< ECN Capable Transport, ECT(0).
+    kEcnCapable1   = OT_ECN_CAPABLE_1,   ///< ECN Capable Transport, ECT(1).
+    kEcnMarked     = OT_ECN_MARKED,      ///< Congestion encountered.
+};
+
+/**
+ * @}
+ *
+ */
+
+} // namespace Ip6
+} // namespace ot
+
+#endif // IP6_TYPES_HPP_

--- a/src/core/net/socket.hpp
+++ b/src/core/net/socket.hpp
@@ -39,6 +39,7 @@
 #include "common/clearable.hpp"
 #include "common/equatable.hpp"
 #include "net/ip6_address.hpp"
+#include "net/ip6_types.hpp"
 
 namespace ot {
 
@@ -209,7 +210,7 @@ public:
      * @returns The ECN status, as represented in the IP header.
      *
      */
-    uint8_t GetEcn(void) const { return mEcn; }
+    Ecn GetEcn(void) const { return static_cast<Ecn>(mEcn); }
 
     /**
      * This method sets the ECN status.
@@ -217,7 +218,7 @@ public:
      * @param[in]  aEcn  The ECN status, as represented in the IP header.
      *
      */
-    void SetEcn(uint8_t aEcn) { mEcn = aEcn; }
+    void SetEcn(Ecn aEcn) { mEcn = aEcn; }
 
     /**
      * This method indicates whether peer is via the host interface.

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -669,7 +669,7 @@ private:
         OPENTHREAD_CONFIG_SRP_CLIENT_MAX_TIMEOUT_FAILURES_TO_SWITCH_SERVER;
 #endif
 
-    static constexpr uint16_t kUdpPayloadSize = Ip6::Ip6::kMaxDatagramLength - sizeof(Ip6::Udp::Header);
+    static constexpr uint16_t kUdpPayloadSize = Ip6::kMaxDatagramLength - sizeof(Ip6::Udp::Header);
 
     // -------------------------------
     // Lease related constants

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -756,7 +756,7 @@ public:
     void HandleServiceUpdateResult(ServiceUpdateId aId, Error aError);
 
 private:
-    static constexpr uint16_t kUdpPayloadSize = Ip6::Ip6::kMaxDatagramLength - sizeof(Ip6::Udp::Header);
+    static constexpr uint16_t kUdpPayloadSize = Ip6::kMaxDatagramLength - sizeof(Ip6::Udp::Header);
 
     static constexpr uint32_t kDefaultMinLease             = 60u * 30;        // 30 min (in seconds).
     static constexpr uint32_t kDefaultMaxLease             = 3600u * 2;       // 2 hours (in seconds).


### PR DESCRIPTION
This commit adds new header file `ip6_types.hpp` which includes
common IPv6 related types (enumerations) and constants. It also
moves the `Ecn` constants and define them as an `enum`.

---
_Background for this:_
Adding new header file is mainly to avoid header `#include` loops
and be able to see and use the same types/constants from different
headers (e.g., `socket.hpp` and `ip6_headers.hpp`, ect.).
