### PR TITLE
[ip6] copy the parsed ECN value from IPv6 msg in `MessageInfo`

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1138,6 +1138,7 @@ start:
     messageInfo.SetPeerAddr(header.GetSource());
     messageInfo.SetSockAddr(header.GetDestination());
     messageInfo.SetHopLimit(header.GetHopLimit());
+    messageInfo.SetEcn(header.GetEcn());
     messageInfo.SetLinkInfo(aLinkMessageInfo);
 
     // determine destination of packet


### PR DESCRIPTION
This commit changes `Ip6::HandleDatagram()` so to copy the ECN value
parsed from IPv6 header of the message in the accompanying
`MessageInfo` data structure.