### PR TITLE
[sub-mac] fix semiWindow overflow in GetCslWindowEdges()

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -1198,7 +1198,8 @@ void SubMac::GetCslWindowEdges(uint32_t &aAhead, uint32_t &aAfter)
 
     elapsed = curTime - mCslLastSync.GetValue();
 
-    semiWindow = elapsed * (Get<Radio>().GetCslAccuracy() + mCslParentAccuracy) / 1000000;
+    semiWindow = static_cast<uint32_t>(static_cast<uint64_t>(elapsed) *
+                                       (Get<Radio>().GetCslAccuracy() + mCslParentAccuracy) / 1000000);
     semiWindow += mCslParentUncert * kUsPerUncertUnit;
 
     aAhead = (semiWindow + kCslReceiveTimeAhead > semiPeriod) ? semiPeriod : semiWindow + kCslReceiveTimeAhead;


### PR DESCRIPTION
Prevent possible overflow in semiWindow calculation by converting it to uint64_t accuracy.

On platforms with clock accuracy = 50ppm the overflow happens in 43 seconds from last CSL synchronization.
`semiWindow = 43000000 * (50 + 50) = 4300000000 > UINT32_MAX (4294967295)`