### PR TITLE
[posix] stop setting up and de-initializing uninitialized modules when dry run

### DIFF
--- a/src/posix/platform/settings.cpp
+++ b/src/posix/platform/settings.cpp
@@ -225,7 +225,10 @@ void otPlatSettingsDeinit(otInstance *aInstance)
     OT_UNUSED_VARIABLE(aInstance);
 
 #if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    otPosixSecureSettingsDeinit(aInstance);
+    if (!IsSystemDryRun())
+    {
+        otPosixSecureSettingsDeinit(aInstance);
+    }
 #endif
 
     VerifyOrExit(sSettingsFd != -1);

--- a/src/posix/platform/settings.cpp
+++ b/src/posix/platform/settings.cpp
@@ -224,11 +224,10 @@ void otPlatSettingsDeinit(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
+    VerifyOrExit(!IsSystemDryRun());
+
 #if OPENTHREAD_POSIX_CONFIG_SECURE_SETTINGS_ENABLE
-    if (!IsSystemDryRun())
-    {
-        otPosixSecureSettingsDeinit(aInstance);
-    }
+    otPosixSecureSettingsDeinit(aInstance);
 #endif
 
     VerifyOrExit(sSettingsFd != -1);

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -161,6 +161,8 @@ exit:
 
 void platformSetUp(void)
 {
+    VerifyOrExit(!gDryRun);
+
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     platformBackboneSetUp();
 #endif
@@ -184,6 +186,9 @@ void platformSetUp(void)
 #if OPENTHREAD_CONFIG_PLATFORM_NETIF_ENABLE || OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     SuccessOrDie(otSetStateChangedCallback(gInstance, processStateChange, gInstance));
 #endif
+
+exit:
+    return;
 }
 
 otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
@@ -196,16 +201,15 @@ otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
     gInstance = otInstanceInitSingle();
     OT_ASSERT(gInstance != nullptr);
 
-    if (!gDryRun)
-    {
-        platformSetUp();
-    }
+    platformSetUp();
 
     return gInstance;
 }
 
 void platformTearDown(void)
 {
+    VerifyOrExit(!gDryRun);
+
 #if OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
     ot::Posix::Daemon::Get().TearDown();
 #endif
@@ -225,6 +229,9 @@ void platformTearDown(void)
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     platformBackboneTearDown();
 #endif
+
+exit:
+    return;
 }
 
 void platformDeinit(void)
@@ -263,10 +270,7 @@ void otSysDeinit(void)
 {
     OT_ASSERT(gInstance != nullptr);
 
-    if (!gDryRun)
-    {
-        platformTearDown();
-    }
+    platformTearDown();
     otInstanceFinalize(gInstance);
     gInstance = nullptr;
     platformDeinit();

--- a/src/posix/platform/system.cpp
+++ b/src/posix/platform/system.cpp
@@ -196,7 +196,10 @@ otInstance *otSysInit(otPlatformConfig *aPlatformConfig)
     gInstance = otInstanceInitSingle();
     OT_ASSERT(gInstance != nullptr);
 
-    platformSetUp();
+    if (!gDryRun)
+    {
+        platformSetUp();
+    }
 
     return gInstance;
 }
@@ -230,6 +233,10 @@ void platformDeinit(void)
     virtualTimeDeinit();
 #endif
     platformRadioDeinit();
+
+    // For Dry-Run option, only the radio is initialized.
+    VerifyOrExit(!gDryRun);
+
 #if OPENTHREAD_CONFIG_PLATFORM_UDP_ENABLE
     ot::Posix::Udp::Get().Deinit();
 #endif
@@ -247,13 +254,19 @@ void platformDeinit(void)
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     platformBackboneDeinit();
 #endif
+
+exit:
+    return;
 }
 
 void otSysDeinit(void)
 {
     OT_ASSERT(gInstance != nullptr);
 
-    platformTearDown();
+    if (!gDryRun)
+    {
+        platformTearDown();
+    }
     otInstanceFinalize(gInstance);
     gInstance = nullptr;
     platformDeinit();


### PR DESCRIPTION
Initialization of these modules is not called when dry run, so setup and de-initialization should not be called either.