### PR TITLE
[ip6] set priority on fragments when fragmenting an IPv6 datagram

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -651,6 +651,7 @@ Error Ip6::FragmentDatagram(Message &aMessage, uint8_t aIpProto)
         fragmentHeader.SetOffset(offset);
 
         VerifyOrExit((fragment = NewMessage(0)) != nullptr, error = kErrorNoBufs);
+        IgnoreError(fragment->SetPriority(aMessage.GetPriority()));
         SuccessOrExit(error = fragment->SetLength(aMessage.GetOffset() + sizeof(fragmentHeader) + payloadFragment));
 
         header.SetPayloadLength(payloadFragment + sizeof(fragmentHeader));


### PR DESCRIPTION
This commit updates `Ip6::FragmentDatagram()` to set the priority on
every fragment message to match the original IPv6 message. This
ensures that as fragments are enqueued in the priority queue they
follow the same priority as the original IPv6 message.