### PR TITLE
[mesh-forwarder] fix and enhance `LogMessage()`

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1212,7 +1212,7 @@ start:
         {
             // Remove encapsulating header and start over.
             aMessage.RemoveHeader(aMessage.GetOffset());
-            Get<MeshForwarder>().LogMessage(MeshForwarder::kMessageReceive, aMessage, nullptr, kErrorNone);
+            Get<MeshForwarder>().LogMessage(MeshForwarder::kMessageReceive, aMessage);
             goto start;
         }
 

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -320,7 +320,7 @@ void IndirectSender::UpdateIndirectMessage(Child &aChild)
         mDataPollHandler.HandleNewFrame(aChild);
 
         aChild.GetMacAddress(childAddress);
-        Get<MeshForwarder>().LogMessage(MeshForwarder::kMessagePrepareIndirect, *message, &childAddress, kErrorNone);
+        Get<MeshForwarder>().LogMessage(MeshForwarder::kMessagePrepareIndirect, *message, kErrorNone, &childAddress);
     }
 }
 
@@ -519,7 +519,7 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
         if (!aFrame.IsEmpty())
         {
             IgnoreError(aFrame.GetDstAddr(macDest));
-            Get<MeshForwarder>().LogMessage(MeshForwarder::kMessageTransmit, *message, &macDest, txError);
+            Get<MeshForwarder>().LogMessage(MeshForwarder::kMessageTransmit, *message, txError, &macDest);
         }
 
         if (message->GetType() == Message::kTypeIp6)

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -512,7 +512,11 @@ private:
     void PauseMessageTransmissions(void) { mTxPaused = true; }
     void ResumeMessageTransmissions(void);
 
-    void LogMessage(MessageAction aAction, const Message &aMessage, const Mac::Address *aAddress, Error aError);
+    void LogMessage(MessageAction       aAction,
+                    const Message &     aMessage,
+                    Error               aError   = kErrorNone,
+                    const Mac::Address *aAddress = nullptr);
+
     void LogFrame(const char *aActionText, const Mac::Frame &aFrame, Error aError);
     void LogFragmentFrameDrop(Error                         aError,
                               uint16_t                      aFrameLength,

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -169,7 +169,7 @@ void MeshForwarder::HandleResolved(const Ip6::Address &aEid, Error aError)
             }
             else
             {
-                LogMessage(kMessageDrop, message, nullptr, aError);
+                LogMessage(kMessageDrop, message, aError);
                 message.Free();
             }
         }
@@ -349,7 +349,7 @@ void MeshForwarder::RemoveDataResponseMessages(void)
             mSendMessage = nullptr;
         }
 
-        LogMessage(kMessageDrop, message, nullptr, kErrorNone);
+        LogMessage(kMessageDrop, message);
         mSendQueue.DequeueAndFree(message);
     }
 }
@@ -807,7 +807,7 @@ void MeshForwarder::HandleMesh(uint8_t *             aFrame,
         message->SetRadioType(static_cast<Mac::RadioType>(aLinkInfo.mRadioType));
 #endif
 
-        LogMessage(kMessageReceive, *message, &aMacSource, kErrorNone);
+        LogMessage(kMessageReceive, *message, kErrorNone, &aMacSource);
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
         // Since the message will be forwarded, we clear the radio


### PR DESCRIPTION
This commit updates `LogMessage()` in `MeshForwarder`:
- Fixes `MessageActionToString()` so when there is a passed-in error
  it correctly returns the related action string (and only when
  `aAction == kMessageTransmit` it returned "Failed to send").
- Changes the order of parameters in `LogMessage()` and uses default
  value for parameters to simplify its use.