### PR TITLE
[thci] do not set `P_slaac` flag for Domain prefix

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -3219,7 +3219,7 @@ class OpenThreadTHCI(object):
         return dua
 
     def __addDefaultDomainPrefix(self):
-        self.configBorderRouter(P_dp=1, P_slaac_preferred=1, P_stable=1, P_on_mesh=1, P_default=1)
+        self.configBorderRouter(P_dp=1, P_stable=1, P_on_mesh=1, P_default=1)
 
     def __setDUA(self, sDua):
         """specify the DUA before Thread Starts."""


### PR DESCRIPTION
According to the Thread Specification the `P_slaac` flag should be
set to false for the Domain prefix.

See: https://threadgroup.atlassian.net/browse/DEV-2220