### PR TITLE
[thci] increase BBR Sequence Number when dataset changes

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -2964,8 +2964,9 @@ class OpenThreadTHCI(object):
         """
         assert not (SeqNumInc and SeqNum is not None), "Must not specify both SeqNumInc and SeqNum"
 
-        if MlrTimeout and MlrTimeout != self.bbrMlrTimeout or ReRegDelay and ReRegDelay != self.bbrReRegDelay:
-            SeqNumInc = True
+        if (MlrTimeout and MlrTimeout != self.bbrMlrTimeout) or (ReRegDelay and ReRegDelay != self.bbrReRegDelay):
+            if SeqNum is None:
+                SeqNumInc = True
 
         if SeqNumInc:
             if self.bbrSeqNum in (126, 127):

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -2963,6 +2963,10 @@ class OpenThreadTHCI(object):
             False: fail to set BBR Dataset
         """
         assert not (SeqNumInc and SeqNum is not None), "Must not specify both SeqNumInc and SeqNum"
+
+        if MlrTimeout and MlrTimeout != self.bbrMlrTimeout or ReRegDelay and ReRegDelay != self.bbrReRegDelay:
+            SeqNumInc = True
+
         if SeqNumInc:
             if self.bbrSeqNum in (126, 127):
                 self.bbrSeqNum = 0
@@ -3256,7 +3260,7 @@ class OpenThreadTHCI(object):
     @API
     def setMLRtimeout(self, iMsecs):
         """Setup BBR MLR Timeout to `iMsecs` seconds."""
-        self.__configBbrDataset(MlrTimeout=iMsecs)
+        self.setBbrDataset(MlrTimeout=iMsecs)
 
     @API
     def stopListeningToAddr(self, sAddr):

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -2974,6 +2974,8 @@ class OpenThreadTHCI(object):
                 self.bbrSeqNum = 128
             else:
                 self.bbrSeqNum = (self.bbrSeqNum + 1) % 256
+        else:
+            self.bbrSeqNum = SeqNum
 
         return self.__configBbrDataset(SeqNum=self.bbrSeqNum, MlrTimeout=MlrTimeout, ReRegDelay=ReRegDelay)
 


### PR DESCRIPTION
Make sure BBR Sequence Number is increased when Re-registration
Delay or MLR Timeout changes.

See https://threadgroup.atlassian.net/browse/DEV-2221