### PR TITLE
[crypto] update emplace method to expect read failure during key export

### DIFF
--- a/src/core/meshcop/dataset_local.cpp
+++ b/src/core/meshcop/dataset_local.cpp
@@ -270,16 +270,27 @@ void DatasetLocal::EmplaceSecurelyStoredKeys(Dataset &aDataset) const
     KeyRef         pskcRef       = IsActive() ? kActiveDatasetPskcRef : kPendingDatasetPskcRef;
     NetworkKeyTlv *networkKeyTlv = aDataset.GetTlv<NetworkKeyTlv>();
     PskcTlv *      pskcTlv       = aDataset.GetTlv<PskcTlv>();
+    bool           moveKeys      = false;
     size_t         keyLen;
+    Error          error;
 
     if (networkKeyTlv != nullptr)
     {
         // If the dataset contains a network key, its real value must have been moved to
         // the secure storage upon saving the dataset, so restore it back now.
         NetworkKey networkKey;
-        SuccessOrAssert(ExportKey(networkKeyRef, networkKey.m8, NetworkKey::kSize, keyLen));
-        OT_ASSERT(keyLen == NetworkKey::kSize);
-        networkKeyTlv->SetNetworkKey(networkKey);
+        error = ExportKey(networkKeyRef, networkKey.m8, NetworkKey::kSize, keyLen);
+
+        if (error != kErrorNone)
+        {
+            // If ExportKey fails, key is not in secure storage and is stored in settings
+            moveKeys = true;
+        }
+        else
+        {
+            OT_ASSERT(keyLen == NetworkKey::kSize);
+            networkKeyTlv->SetNetworkKey(networkKey);
+        }
     }
 
     if (pskcTlv != nullptr)
@@ -287,9 +298,29 @@ void DatasetLocal::EmplaceSecurelyStoredKeys(Dataset &aDataset) const
         // If the dataset contains a PSKC, its real value must have been moved to
         // the secure storage upon saving the dataset, so restore it back now.
         Pskc pskc;
-        SuccessOrAssert(ExportKey(pskcRef, pskc.m8, Pskc::kSize, keyLen));
-        OT_ASSERT(keyLen == Pskc::kSize);
-        pskcTlv->SetPskc(pskc);
+        error = ExportKey(pskcRef, pskc.m8, Pskc::kSize, keyLen);
+
+        if (error != kErrorNone)
+        {
+            // If ExportKey fails, key is not in secure storage and is stored in settings
+            moveKeys = true;
+        }
+        else
+        {
+            OT_ASSERT(keyLen == Pskc::kSize);
+            pskcTlv->SetPskc(pskc);
+        }
+    }
+
+    if (moveKeys)
+    {
+        // Clear the networkkey and Pskc stored in the settings and move them to secure storage.
+        // Store the network key and PSKC in the secure storage instead of settings.
+        Dataset dataset;
+
+        dataset.Set(GetType(), aDataset);
+        MoveKeysToSecureStorage(dataset);
+        SuccessOrAssert(error = Get<Settings>().SaveOperationalDataset(IsActive(), dataset));
     }
 }
 #endif


### PR DESCRIPTION
In the current implementation, **EmplaceSecurelyStoredKeys** tries to read the network key and PSKc from secure storage to update the TLVs and asserts if the read fails. But if the device was previously running a non-PSA application, it won't have the keys in secure storage, and the device asserts. 

This PR proposes a way to move the the keys to secure storage, if the ExportKey fails. Once it is moved to secure storage, literal key stored in the settings is cleared.