### PR TITLE
[cli] allow to run `factoryreset` under the diag mode

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -262,7 +262,7 @@ void Interpreter::ProcessLine(char *aBuf)
     LogInput(args);
 
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
-    if (otDiagIsEnabled(GetInstancePtr()) && (args[0] != "diag"))
+    if (otDiagIsEnabled(GetInstancePtr()) && (args[0] != "diag") && (args[0] != "factoryreset"))
     {
         OutputLine("under diagnostics mode, execute 'diag stop' before running any other commands.");
         ExitNow(error = OT_ERROR_INVALID_STATE);


### PR DESCRIPTION
Before starting a test case, our test script calls the 'factoryreset'
to make the device enters a known state . But the previous test case
may fail to call the 'diag stop' before exiting. This case the next
test case failed to call the 'factoryreset '.

This commit allows the users to call 'factoryreset' under the diag mode.