### PR TITLE
[tcp] remove extraneous #define and restrict inclusion of TCPlp headers

### DIFF
--- a/third_party/tcplp/bsdtcp/tcp.h
+++ b/third_party/tcplp/bsdtcp/tcp.h
@@ -43,8 +43,6 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#define __func__ "BSD TCP function"
-
 #define KASSERT(COND, MSG) if (!(COND)) tcplp_sys_panic MSG
 
 typedef	uint32_t tcp_seq;

--- a/third_party/tcplp/bsdtcp/tcp_input.c
+++ b/third_party/tcplp/bsdtcp/tcp_input.c
@@ -103,7 +103,7 @@ static void	 tcp_dooptions(struct tcpopt *, uint8_t *, int, int);
 static void
 tcp_do_segment(struct ip6_hdr* ip6, struct tcphdr *th, otMessage* msg,
     struct tcpcb *tp, int drop_hdrlen, int tlen, uint8_t iptos,
-    struct signals* sig);
+    struct tcplp_signals* sig);
 static void	 tcp_xmit_timer(struct tcpcb *, int);
 void tcp_hc_get(/*struct in_conninfo *inc*/ struct tcpcb* tp, struct hc_metrics_lite *hc_metrics_lite);
 static void	 tcp_newreno_partial_ack(struct tcpcb *, struct tcphdr *);
@@ -431,7 +431,7 @@ tcp_dropwithreset(struct ip6_hdr* ip6, struct tcphdr *th, struct tcpcb *tp, otIn
 /* NOTE: tcp_fields_to_host(th) must be called before this function is called. */
 int
 tcp_input(struct ip6_hdr* ip6, struct tcphdr* th, otMessage* msg, struct tcpcb* tp, struct tcpcb_listen* tpl,
-          struct signals* sig)
+          struct tcplp_signals* sig)
 {
 	/*
 	 * samkumar: I significantly modified this function, compared to the
@@ -948,7 +948,7 @@ drop:
 static void
 tcp_do_segment(struct ip6_hdr* ip6, struct tcphdr *th, otMessage* msg,
     struct tcpcb *tp, int drop_hdrlen, int tlen, uint8_t iptos,
-    struct signals* sig)
+    struct tcplp_signals* sig)
 {
 	/*
 	 * samkumar: All code pertaining to locks, stats, and debug has been

--- a/third_party/tcplp/bsdtcp/tcp_reass.c
+++ b/third_party/tcplp/bsdtcp/tcp_reass.c
@@ -51,7 +51,7 @@
  * not need to update it if only part of the segment is trimmed off.
  */
 int
-tcp_reass(struct tcpcb* tp, struct tcphdr* th, int* tlenp, otMessage* data, off_t data_offset, struct signals* sig)
+tcp_reass(struct tcpcb* tp, struct tcphdr* th, int* tlenp, otMessage* data, off_t data_offset, struct tcplp_signals* sig)
 {
 	size_t mergeable, written;
 	size_t offset;

--- a/third_party/tcplp/bsdtcp/tcp_var.h
+++ b/third_party/tcplp/bsdtcp/tcp_var.h
@@ -161,7 +161,7 @@ struct tcpcb_listen {
 #define SACKHOLE_POOL_SIZE MAX_SACKHOLES
 #define SACKHOLE_BMP_SIZE BITS_TO_BYTES(SACKHOLE_POOL_SIZE)
 
-struct signals;
+struct tcplp_signals;
 
 /*
  * Tcp control block, one per tcp; fields:
@@ -577,14 +577,14 @@ int	 tcp_twcheck(struct tcpcb*, struct tcphdr *, int);
 void tcp_dropwithreset(struct ip6_hdr* ip6, struct tcphdr *th, struct tcpcb *tp, otInstance* instance,
     int tlen, int rstreason);
 int tcp_input(struct ip6_hdr* ip6, struct tcphdr* th, otMessage* msg, struct tcpcb* tp, struct tcpcb_listen* tpl,
-          struct signals* sig);
+          struct tcplp_signals* sig);
 int	 tcp_output(struct tcpcb *);
 void tcpip_maketemplate(struct tcpcb *, struct tcptemp*);
 void	 tcpip_fillheaders(struct tcpcb *, otMessageInfo *, void *);
 uint64_t	 tcp_maxmtu6(struct tcpcb*, struct tcp_ifcap *);
 int	 tcp_addoptions(struct tcpopt *, uint8_t *);
 int	 tcp_mssopt(struct tcpcb*);
-int	 tcp_reass(struct tcpcb *, struct tcphdr *, int *, otMessage *, off_t, struct signals*);
+int	 tcp_reass(struct tcpcb *, struct tcphdr *, int *, otMessage *, off_t, struct tcplp_signals*);
 void tcp_sack_init(struct tcpcb *); // Sam: new function that I added
 void	 tcp_sack_doack(struct tcpcb *, struct tcpopt *, tcp_seq);
 void	 tcp_update_sack_list(struct tcpcb *tp, tcp_seq rcv_laststart, tcp_seq rcv_lastend);

--- a/third_party/tcplp/tcplp.h
+++ b/third_party/tcplp/tcplp.h
@@ -53,7 +53,7 @@ extern "C" {
 #define RELOOKUP_REQUIRED -1
 #define CONN_LOST_NORMAL 0
 
-struct signals {
+struct tcplp_signals {
     int links_popped;
     bool conn_established;
     bool recvbuf_notempty;


### PR DESCRIPTION
This pull request fixes #7552.

First, this pull requests changes `third_party/tcplp/bsdtcp/tcp.h` so that it no longer does `#define __func__`. This line was necessary on one of the original platforms for which TCPlp was written. However, OpenThread assumes that `__func__` is appropriately defined by the toolchain, so there is no need to define it again.

The above change fixes issue #7552, but #7552 illustrates a broader problem, which is that global-scope artifacts (variables and macros) defined by TCPlp can affect other code in OpenThread. This is hard to avoid completely, as C does not have the notion of a namespace. However, it can be mitigated by limiting global-scope artifacts to as few translation units as possible. Therefore, this pull request also limit global-scope TCPlp artifacts to the `src/core/net/tcp6.cpp` translation unit, to prevent similar issues from occurring in the future. It does so by no longer including the entire `third_party/tcplp/tcplp.h` file from `src/core/net/tcp6.hpp`, instead only forward-declaring the 5 artifacts that are needed. This change required moving some function definitions from `src/core/net/tcp6.hpp` to `src/core/net/tcp6.cpp`, as those definitions required full access to the TCPlp headers.

Previously, `src/core/net/tcp6.hpp` included `third_party/tcplp/tcplp.h`, which caused global-scope TCPlp artifacts to be included in any translation unit that, directly or indirectly, included `src/core/net/tcp6.hpp`.