### PR TITLE
[instance] move `otMessageGetBufferInfo()` impl to `Instance`

### DIFF
--- a/src/core/api/message_api.cpp
+++ b/src/core/api/message_api.cpp
@@ -145,61 +145,6 @@ exit:
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
 void otMessageGetBufferInfo(otInstance *aInstance, otBufferInfo *aBufferInfo)
 {
-    uint16_t  messages, buffers;
-    Instance &instance = AsCoreType(aInstance);
-
-    aBufferInfo->mTotalBuffers = instance.Get<MessagePool>().GetTotalBufferCount();
-
-    aBufferInfo->mFreeBuffers = instance.Get<MessagePool>().GetFreeBufferCount();
-
-    instance.Get<MeshForwarder>().GetSendQueue().GetInfo(aBufferInfo->m6loSendMessages, aBufferInfo->m6loSendBuffers);
-
-    instance.Get<MeshForwarder>().GetReassemblyQueue().GetInfo(aBufferInfo->m6loReassemblyMessages,
-                                                               aBufferInfo->m6loReassemblyBuffers);
-
-#if OPENTHREAD_FTD
-    instance.Get<MeshForwarder>().GetResolvingQueue().GetInfo(aBufferInfo->mArpMessages, aBufferInfo->mArpBuffers);
-#else
-    aBufferInfo->mArpMessages             = 0;
-    aBufferInfo->mArpBuffers              = 0;
-#endif
-
-    instance.Get<Ip6::Ip6>().GetSendQueue().GetInfo(aBufferInfo->mIp6Messages, aBufferInfo->mIp6Buffers);
-
-#if OPENTHREAD_FTD
-    instance.Get<Ip6::Mpl>().GetBufferedMessageSet().GetInfo(aBufferInfo->mMplMessages, aBufferInfo->mMplBuffers);
-#else
-    aBufferInfo->mMplMessages             = 0;
-    aBufferInfo->mMplBuffers              = 0;
-#endif
-
-    instance.Get<Mle::MleRouter>().GetMessageQueue().GetInfo(aBufferInfo->mMleMessages, aBufferInfo->mMleBuffers);
-
-    instance.Get<Tmf::Agent>().GetRequestMessages().GetInfo(aBufferInfo->mCoapMessages, aBufferInfo->mCoapBuffers);
-    instance.Get<Tmf::Agent>().GetCachedResponses().GetInfo(messages, buffers);
-    aBufferInfo->mCoapMessages += messages;
-    aBufferInfo->mCoapBuffers += buffers;
-
-#if OPENTHREAD_CONFIG_DTLS_ENABLE
-    instance.Get<Coap::CoapSecure>().GetRequestMessages().GetInfo(aBufferInfo->mCoapSecureMessages,
-                                                                  aBufferInfo->mCoapSecureBuffers);
-    instance.Get<Coap::CoapSecure>().GetCachedResponses().GetInfo(messages, buffers);
-    aBufferInfo->mCoapSecureMessages += messages;
-    aBufferInfo->mCoapSecureBuffers += buffers;
-#else
-    aBufferInfo->mCoapSecureMessages      = 0;
-    aBufferInfo->mCoapSecureBuffers       = 0;
-#endif
-
-#if OPENTHREAD_CONFIG_COAP_API_ENABLE
-    instance.GetApplicationCoap().GetRequestMessages().GetInfo(aBufferInfo->mApplicationCoapMessages,
-                                                               aBufferInfo->mApplicationCoapBuffers);
-    instance.GetApplicationCoap().GetCachedResponses().GetInfo(messages, buffers);
-    aBufferInfo->mApplicationCoapMessages += messages;
-    aBufferInfo->mApplicationCoapBuffers += buffers;
-#else
-    aBufferInfo->mApplicationCoapMessages = 0;
-    aBufferInfo->mApplicationCoapBuffers  = 0;
-#endif
+    AsCoreType(aInstance).GetBufferInfo(AsCoreType(aBufferInfo));
 }
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -233,6 +233,7 @@ exit:
 }
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
+
 void Instance::FactoryReset(void)
 {
     Get<Settings>().Wipe();
@@ -248,6 +249,51 @@ Error Instance::ErasePersistentInfo(void)
 
 exit:
     return error;
+}
+
+void Instance::GetBufferInfo(BufferInfo &aInfo)
+{
+    uint16_t messages, buffers;
+
+    aInfo.Clear();
+
+    aInfo.mTotalBuffers = Get<MessagePool>().GetTotalBufferCount();
+    aInfo.mFreeBuffers  = Get<MessagePool>().GetFreeBufferCount();
+
+    Get<MeshForwarder>().GetSendQueue().GetInfo(aInfo.m6loSendMessages, aInfo.m6loSendBuffers);
+
+    Get<MeshForwarder>().GetReassemblyQueue().GetInfo(aInfo.m6loReassemblyMessages, aInfo.m6loReassemblyBuffers);
+
+#if OPENTHREAD_FTD
+    Get<MeshForwarder>().GetResolvingQueue().GetInfo(aInfo.mArpMessages, aInfo.mArpBuffers);
+#endif
+
+    Get<Ip6::Ip6>().GetSendQueue().GetInfo(aInfo.mIp6Messages, aInfo.mIp6Buffers);
+
+#if OPENTHREAD_FTD
+    Get<Ip6::Mpl>().GetBufferedMessageSet().GetInfo(aInfo.mMplMessages, aInfo.mMplBuffers);
+#endif
+
+    Get<Mle::MleRouter>().GetMessageQueue().GetInfo(aInfo.mMleMessages, aInfo.mMleBuffers);
+
+    Get<Tmf::Agent>().GetRequestMessages().GetInfo(aInfo.mCoapMessages, aInfo.mCoapBuffers);
+    Get<Tmf::Agent>().GetCachedResponses().GetInfo(messages, buffers);
+    aInfo.mCoapMessages += messages;
+    aInfo.mCoapBuffers += buffers;
+
+#if OPENTHREAD_CONFIG_DTLS_ENABLE
+    Get<Coap::CoapSecure>().GetRequestMessages().GetInfo(aInfo.mCoapSecureMessages, aInfo.mCoapSecureBuffers);
+    Get<Coap::CoapSecure>().GetCachedResponses().GetInfo(messages, buffers);
+    aInfo.mCoapSecureMessages += messages;
+    aInfo.mCoapSecureBuffers += buffers;
+#endif
+
+#if OPENTHREAD_CONFIG_COAP_API_ENABLE
+    GetApplicationCoap().GetRequestMessages().GetInfo(aInfo.mApplicationCoapMessages, aInfo.mApplicationCoapBuffers);
+    GetApplicationCoap().GetCachedResponses().GetInfo(messages, buffers);
+    aInfo.mApplicationCoapMessages += messages;
+    aInfo.mApplicationCoapBuffers += buffers;
+#endif
 }
 
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -113,6 +113,14 @@ namespace ot {
 class Instance : public otInstance, private NonCopyable
 {
 public:
+    /**
+     * This type represents the message buffer information (number of messages/buffers in all OT stack message queues).
+     *
+     */
+    class BufferInfo : public otBufferInfo, public Clearable<BufferInfo>
+    {
+    };
+
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
     /**
       * This static method initializes the OpenThread instance.
@@ -281,6 +289,14 @@ public:
     static bool IsDnsNameCompressionEnabled(void) { return sDnsNameCompressionEnabled; }
 #endif
 
+    /**
+     * This method retrieves the the Message Buffer information.
+     *
+     * @param[out]  aInfo  A `BufferInfo` where information is written.
+     *
+     */
+    void GetBufferInfo(BufferInfo &aInfo);
+
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 
     /**
@@ -408,6 +424,7 @@ private:
 };
 
 DefineCoreType(otInstance, Instance);
+DefineCoreType(otBufferInfo, Instance::BufferInfo);
 
 // Specializations of the `Get<Type>()` method.
 


### PR DESCRIPTION
This commit moves the implementation of `otMessageGetBufferInfo()`
from the `message_api.cpp` file to  `Instance` class.