### PR TITLE
[spinel] map `kMaxSpinelFrame` to `SPINEL_FRAME_MAX_SIZE`

### DIFF
--- a/src/lib/spinel/radio_spinel.hpp
+++ b/src/lib/spinel/radio_spinel.hpp
@@ -858,7 +858,7 @@ public:
 private:
     enum
     {
-        kMaxSpinelFrame        = SpinelInterface::kMaxFrameSize,
+        kMaxSpinelFrame        = SPINEL_FRAME_MAX_SIZE,
         kMaxWaitTime           = 2000, ///< Max time to wait for response in milliseconds.
         kVersionStringSize     = 128,  ///< Max size of version string.
         kCapsBufferSize        = 100,  ///< Max buffer size used to store `SPINEL_PROP_CAPS` value.


### PR DESCRIPTION
The current implementation does not differentiate the max spinel frame size that is used to pack a spinel command and the radio spinel RX frame buffer size which could contain multiple frames.
In radio_spinel_impl.hpp, only one spinel frame can be written when calling function “SendCommand” or “SendReset”.
Therefore the aim of this commit is to allocate, in such a context, only a buffer of one frame instead of a buffer that could contain multiple frames.