### PR TITLE
[test] update `Cert_9_2_17_Orphan` to make it more robust

### DIFF
--- a/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
+++ b/tests/scripts/thread-cert/Cert_9_2_17_Orphan.py
@@ -116,10 +116,10 @@ class Cert_9_2_17_Orphan(thread_cert.TestCase):
 
         # Step 1: Ensure the topology is formed correctly
         # Verify that Leader_1 & Leader_2 are sending MLE Advertisements on separate channels.
+        pkts.copy().filter_wpan_src64(LEADER_1).filter_mle_cmd(MLE_ADVERTISEMENT).must_next()
+        pkts.copy().filter_wpan_src64(LEADER_2).filter_mle_cmd(MLE_ADVERTISEMENT).must_next()
         pkts.filter_wpan_src64(LEADER_1).filter_mle_cmd(MLE_CHILD_ID_RESPONSE).must_next().must_verify(
             lambda p: p.wpan.dst64 == ED and p.thread_meshcop.tlv.channel == [CHANNEL1])
-        pkts.filter_wpan_src64(LEADER_1).filter_mle_cmd(MLE_ADVERTISEMENT).must_next()
-        pkts.copy().filter_wpan_src64(LEADER_2).filter_mle_cmd(MLE_ADVERTISEMENT).must_next()
 
         # Step 4: powers-down Leader_1 and enables connectivity between the ED and Leader_2
         # ED MUST send a MLE Parent Request


### PR DESCRIPTION
This commit updates `Cert_9_2_17_Orphan` packet verification to check
that the two leaders are sending MLE advertisement before checking
for child attach (Child ID response). The current test checked this
after the child attach but leader 1 is turned off 5 seconds after
the child is attached which may not be enough time to ensure rx
of an advertisement (which every 30 seconds on average).

----

_Background:_
- Discovered this from https://github.com/openthread/openthread/pull/7538 (trying to update the tests after the change in this PR)