### PR TITLE
[diag] add 'diag rcp echo' command

### DIFF
--- a/src/core/diags/README.md
+++ b/src/core/diags/README.md
@@ -171,3 +171,63 @@ last received packet: rssi=-61, lqi=98
 stop diagnostics mode
 status 0x00
 ```
+
+### diag rcp
+
+RCP-related diagnostics commands. These commands are used for debugging and testing only.
+
+#### diag rcp start
+
+Start RCP diagnostics mode.
+
+```bash
+> diag rcp start
+Done
+```
+
+#### diag rcp stop
+
+Stop RCP diagnostics mode.
+
+```bash
+> diag rcp stop
+Done
+```
+
+#### diag rcp channel \<channel\>
+
+Set the RCP IEEE 802.15.4 Channel value for diagnostics module.
+
+```bash
+> diag channel 11
+Done
+```
+
+#### diag rcp power \<power\>
+
+Set the RCP tx power value(dBm) for diagnostics module.
+
+```bash
+> diag rcp power 0
+Done
+```
+
+#### diag rcp echo \<message\>
+
+RCP echoes the given message.
+
+```bash
+> diag echo 0123456789
+0123456789
+Done
+```
+
+#### diag rcp echo -n \<number\>
+
+RCP echoes the message with the given number of bytes.
+
+```bash
+> diag echo -n 20
+01234567890123456789
+Done
+```

--- a/src/core/diags/factory_diags.cpp
+++ b/src/core/diags/factory_diags.cpp
@@ -70,10 +70,8 @@ namespace FactoryDiags {
 #if OPENTHREAD_RADIO && !OPENTHREAD_RADIO_CLI
 
 const struct Diags::Command Diags::sCommands[] = {
-    {"channel", &Diags::ProcessChannel},
-    {"power", &Diags::ProcessPower},
-    {"start", &Diags::ProcessStart},
-    {"stop", &Diags::ProcessStop},
+    {"channel", &Diags::ProcessChannel}, {"echo", &Diags::ProcessEcho}, {"power", &Diags::ProcessPower},
+    {"start", &Diags::ProcessStart},     {"stop", &Diags::ProcessStop},
 };
 
 Diags::Diags(Instance &aInstance)
@@ -108,6 +106,43 @@ Error Diags::ProcessPower(uint8_t aArgsLength, char *aArgs[], char *aOutput, siz
     SuccessOrExit(error = ParseLong(aArgs[0], value));
 
     otPlatDiagTxPowerSet(static_cast<int8_t>(value));
+
+exit:
+    AppendErrorResult(error, aOutput, aOutputMaxLen);
+    return error;
+}
+
+Error Diags::ProcessEcho(uint8_t aArgsLength, char *aArgs[], char *aOutput, size_t aOutputMaxLen)
+{
+    otError error = kErrorNone;
+
+    if (aArgsLength == 1)
+    {
+        snprintf(aOutput, aOutputMaxLen, "%s\r\n", aArgs[0]);
+    }
+    else if ((aArgsLength == 2) && (strcmp(aArgs[0], "-n") == 0))
+    {
+        const uint8_t kReservedLen = 3; // 1 byte '\r', 1 byte '\n' and 1 byte '\0'
+        uint32_t      outputMaxLen = static_cast<uint32_t>(aOutputMaxLen) - kReservedLen;
+        long          value;
+        uint32_t      i;
+        uint32_t      number;
+
+        SuccessOrExit(error = ParseLong(aArgs[1], value));
+        number = static_cast<uint32_t>(value);
+        number = (number < outputMaxLen) ? number : outputMaxLen;
+
+        for (i = 0; i < number; i++)
+        {
+            aOutput[i] = '0' + i % 10;
+        }
+
+        snprintf(&aOutput[i], aOutputMaxLen - i, "\r\n");
+    }
+    else
+    {
+        error = kErrorInvalidArgs;
+    }
 
 exit:
     AppendErrorResult(error, aOutput, aOutputMaxLen);

--- a/src/core/diags/factory_diags.hpp
+++ b/src/core/diags/factory_diags.hpp
@@ -151,6 +151,9 @@ private:
     Error ProcessStart(uint8_t aArgsLength, char *aArgs[], char *aOutput, size_t aOutputMaxLen);
     Error ProcessStats(uint8_t aArgsLength, char *aArgs[], char *aOutput, size_t aOutputMaxLen);
     Error ProcessStop(uint8_t aArgsLength, char *aArgs[], char *aOutput, size_t aOutputMaxLen);
+#if OPENTHREAD_RADIO && !OPENTHREAD_RADIO_CLI
+    Error ProcessEcho(uint8_t aArgsLength, char *aArgs[], char *aOutput, size_t aOutputMaxLen);
+#endif
 
     void TransmitPacket(void);
 

--- a/tests/scripts/expect/posix-diag-rcp.exp
+++ b/tests/scripts/expect/posix-diag-rcp.exp
@@ -53,5 +53,17 @@ expect "status 0x7"
 expect_line "Done"
 send "diag rcp power 10\n"
 expect_line "Done"
+send "diag rcp echo\n"
+expect "failed"
+expect "status 0x7"
+expect_line "Done"
+send "diag rcp echo 0123456789\n"
+expect_line "0123456789"
+expect_line "Done"
+send "diag rcp echo -n 0\n"
+expect_line "Done"
+send "diag rcp echo -n 253\n"
+expect_line {[0-9]{253}}
+expect_line "Done"
 
 dispose_all


### PR DESCRIPTION
There is no command that can generate different sizes of Spinel
frames for testing the SPI/UART interface. This commit adds a
diag command 'diag rcp echo' to RCP for testing SPI/UART interface.