### PR TITLE
[net-diags] set the sock addr based on dest in GetQuery response

### DIFF
--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -494,7 +494,7 @@ void NetworkDiagnostic::HandleDiagnosticGetQuery(Coap::Message &aMessage, const 
         SuccessOrExit(error = message->SetPayloadMarker());
     }
 
-    if (aMessageInfo.GetSockAddr().IsLinkLocal() || aMessageInfo.GetSockAddr().IsLinkLocalMulticast())
+    if (aMessageInfo.GetPeerAddr().IsLinkLocal())
     {
         messageInfo.SetSockAddr(Get<Mle::MleRouter>().GetLinkLocalAddress());
     }


### PR DESCRIPTION
This commit updates how the `MessageInfo` for a "GetQuery" response
is prepared so that we use link-local source if the destination of
response is also using link-local address.

----

I think the code as is behaves correctly as well, since we expect the
sender to use link-local source when using a link-local destination.
But determining the local sock address based on destination (peer address)
is a more direct check and more reasonable. It also hamonizes the code 
for "GetQuery" with other similar situations in `network_diagnostics.cpp` 
where `MessageInfo` is prepared.

----

Digging into history I see this was added from 
- #3935

which I think intended to use the same pattern , i.e. determine the source (link-local 
or mesh-local) based on destination address type.