### PR TITLE
[posix-netif] configure metric for prefix routes

### DIFF
--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -127,6 +127,17 @@
 #endif
 
 /**
+ * @def OPENTHREAD_POSIX_CONFIG_NETIF_PREFIX_ROUTE_METRIC
+ *
+ * This setting configures the prefix route metric on the Thread network interface.
+ * Define as 0 to use use the default prefix route metric.
+ *
+ */
+#ifndef OPENTHREAD_POSIX_CONFIG_NETIF_PREFIX_ROUTE_METRIC
+#define OPENTHREAD_POSIX_CONFIG_NETIF_PREFIX_ROUTE_METRIC 0
+#endif
+
+/**
  * @def OPENTHREAD_POSIX_CONFIG_INSTALL_EXTERNAL_ROUTES_ENABLE
  *
  * Define as 1 to add external routes to POSIX kernel when external routes are changed in netdata.


### PR DESCRIPTION
This commit allows configuring route metric for the prefix routes of IPv6 addresses added to the Thread network interface.

This commit also simplifies `UpdateUnicastLinux` by using `AddRtAttr`.

--- 

Background:

We found a routing issue for the OMR prefix where there are two BRs within the same Thread network, and both BRs are connected to the same infrastructure link. When forwarding a message with OMR destination, one BR would redirect the message to the other BR and the other BR would redirect the message back. This creates message looping until the TTL is decreased to zero. 

The cause is that the BRs could add OMR routes by hearing RA RIO with a smaller metric than that of the prefix routes via Thread interface (usually 256). 

So, this commit uses smaller metric for prefix routes to make sure BRs would forward messages to Thread network without looping. 