### PR TITLE
[meshcop] separate Extended PAN ID from Mac

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -280,6 +280,7 @@ LOCAL_SRC_FILES                                                  := \
     src/core/meshcop/dataset_updater.cpp                            \
     src/core/meshcop/dtls.cpp                                       \
     src/core/meshcop/energy_scan_client.cpp                         \
+    src/core/meshcop/extended_panid.cpp                             \
     src/core/meshcop/joiner.cpp                                     \
     src/core/meshcop/joiner_router.cpp                              \
     src/core/meshcop/meshcop.cpp                                    \

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -509,6 +509,8 @@ openthread_core_files = [
   "meshcop/dtls.hpp",
   "meshcop/energy_scan_client.cpp",
   "meshcop/energy_scan_client.hpp",
+  "meshcop/extended_panid.cpp",
+  "meshcop/extended_panid.hpp",
   "meshcop/joiner.cpp",
   "meshcop/joiner.hpp",
   "meshcop/joiner_router.cpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -146,6 +146,7 @@ set(COMMON_SOURCES
     meshcop/dataset_updater.cpp
     meshcop/dtls.cpp
     meshcop/energy_scan_client.cpp
+    meshcop/extended_panid.cpp
     meshcop/joiner.cpp
     meshcop/joiner_router.cpp
     meshcop/meshcop.cpp

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -236,6 +236,7 @@ SOURCES_COMMON                                  = \
     meshcop/dataset_updater.cpp                   \
     meshcop/dtls.cpp                              \
     meshcop/energy_scan_client.cpp                \
+    meshcop/extended_panid.cpp                    \
     meshcop/joiner.cpp                            \
     meshcop/joiner_router.cpp                     \
     meshcop/meshcop.cpp                           \
@@ -536,6 +537,7 @@ HEADERS_COMMON                                  = \
     meshcop/dataset_updater.hpp                   \
     meshcop/dtls.hpp                              \
     meshcop/energy_scan_client.hpp                \
+    meshcop/extended_panid.hpp                    \
     meshcop/joiner.hpp                            \
     meshcop/joiner_router.hpp                     \
     meshcop/meshcop.hpp                           \

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -55,19 +55,19 @@ void otThreadSetChildTimeout(otInstance *aInstance, uint32_t aTimeout)
 
 const otExtendedPanId *otThreadGetExtendedPanId(otInstance *aInstance)
 {
-    return &AsCoreType(aInstance).Get<Mac::Mac>().GetExtendedPanId();
+    return &AsCoreType(aInstance).Get<MeshCoP::ExtendedPanIdManager>().GetExtPanId();
 }
 
 otError otThreadSetExtendedPanId(otInstance *aInstance, const otExtendedPanId *aExtendedPanId)
 {
-    Error                     error    = kErrorNone;
-    Instance &                instance = AsCoreType(aInstance);
-    const Mac::ExtendedPanId &extPanId = AsCoreType(aExtendedPanId);
-    Mle::MeshLocalPrefix      prefix;
+    Error                         error    = kErrorNone;
+    Instance &                    instance = AsCoreType(aInstance);
+    const MeshCoP::ExtendedPanId &extPanId = AsCoreType(aExtendedPanId);
+    Mle::MeshLocalPrefix          prefix;
 
     VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
-    instance.Get<Mac::Mac>().SetExtendedPanId(extPanId);
+    instance.Get<MeshCoP::ExtendedPanIdManager>().SetExtPanId(extPanId);
 
     prefix.SetFromExtendedPanId(extPanId);
     instance.Get<Mle::MleRouter>().SetMeshLocalPrefix(prefix);

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -71,6 +71,7 @@
 #include "crypto/mbedtls.hpp"
 #include "meshcop/border_agent.hpp"
 #include "meshcop/dataset_updater.hpp"
+#include "meshcop/extended_panid.hpp"
 #include "net/ip6.hpp"
 #include "thread/announce_sender.hpp"
 #include "thread/link_metrics.hpp"
@@ -700,6 +701,11 @@ template <> inline Coap::CoapSecure &Instance::Get(void)
     return mThreadNetif.mCoapSecure;
 }
 #endif
+
+template <> inline MeshCoP::ExtendedPanIdManager &Instance::Get(void)
+{
+    return mThreadNetif.mExtendedPanIdManager;
+}
 
 template <> inline MeshCoP::ActiveDataset &Instance::Get(void)
 {

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -63,10 +63,6 @@ const otExtAddress Mac::sMode2ExtAddress = {
     {0x35, 0x06, 0xfe, 0xb8, 0x23, 0xd4, 0x87, 0x12},
 };
 
-const otExtendedPanId Mac::sExtendedPanidInit = {
-    {0xde, 0xad, 0x00, 0xbe, 0xef, 0x00, 0xca, 0xfe},
-};
-
 const char Mac::sNetworkNameInit[] = "OpenThread";
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
@@ -123,13 +119,11 @@ Mac::Mac(Instance &aInstance)
 
     mCcaSuccessRateTracker.Clear();
     ResetCounters();
-    mExtendedPanId.Clear();
 
     SetEnabled(true);
     mLinks.Enable();
 
     Get<KeyManager>().UpdateKeyMaterial();
-    SetExtendedPanId(AsCoreType(&sExtendedPanidInit));
     IgnoreError(SetNetworkName(sNetworkNameInit));
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
     IgnoreError(SetDomainName(sDomainNameInit));
@@ -499,11 +493,6 @@ void Mac::SetPanId(PanId aPanId)
 
 exit:
     return;
-}
-
-void Mac::SetExtendedPanId(const ExtendedPanId &aExtendedPanId)
-{
-    IgnoreError(Get<Notifier>().Update(mExtendedPanId, aExtendedPanId, kEventThreadExtPanIdChanged));
 }
 
 void Mac::RequestDirectFrameTransmission(void)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -402,22 +402,6 @@ public:
     void SetPanId(PanId aPanId);
 
     /**
-     * This method returns the IEEE 802.15.4 Extended PAN Identifier.
-     *
-     * @returns The IEEE 802.15.4 Extended PAN Identifier.
-     *
-     */
-    const ExtendedPanId &GetExtendedPanId(void) const { return mExtendedPanId; }
-
-    /**
-     * This method sets the IEEE 802.15.4 Extended PAN Identifier.
-     *
-     * @param[in]  aExtendedPanId  The IEEE 802.15.4 Extended PAN Identifier.
-     *
-     */
-    void SetExtendedPanId(const ExtendedPanId &aExtendedPanId);
-
-    /**
      * This method returns the maximum number of frame retries during direct transmission.
      *
      * @returns The maximum number of retries during direct transmission.
@@ -870,10 +854,9 @@ private:
 #endif
     static const char *OperationToString(Operation aOperation);
 
-    static const otExtAddress    sMode2ExtAddress;
-    static const otExtendedPanId sExtendedPanidInit;
-    static const char            sNetworkNameInit[];
-    static const char            sDomainNameInit[];
+    static const otExtAddress sMode2ExtAddress;
+    static const char         sNetworkNameInit[];
+    static const char         sDomainNameInit[];
 
     bool mEnabled : 1;
     bool mShouldTxPollBeforeData : 1;
@@ -885,17 +868,16 @@ private:
     bool mShouldDelaySleep : 1;
     bool mDelayingSleep : 1;
 #endif
-    Operation     mOperation;
-    uint16_t      mPendingOperations;
-    uint8_t       mBeaconSequence;
-    uint8_t       mDataSequence;
-    uint8_t       mBroadcastTransmitCount;
-    PanId         mPanId;
-    uint8_t       mPanChannel;
-    uint8_t       mRadioChannel;
-    ChannelMask   mSupportedChannelMask;
-    ExtendedPanId mExtendedPanId;
-    NetworkName   mNetworkName;
+    Operation   mOperation;
+    uint16_t    mPendingOperations;
+    uint8_t     mBeaconSequence;
+    uint8_t     mDataSequence;
+    uint8_t     mBroadcastTransmitCount;
+    PanId       mPanId;
+    uint8_t     mPanChannel;
+    uint8_t     mRadioChannel;
+    ChannelMask mSupportedChannelMask;
+    NetworkName mNetworkName;
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
     DomainName mDomainName;
 #endif

--- a/src/core/mac/mac_types.cpp
+++ b/src/core/mac/mac_types.cpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file implements MAC types such as Address, Extended PAN Identifier, Network Name, etc.
+ *   This file implements MAC types.
  */
 
 #include "mac_types.hpp"
@@ -106,15 +106,6 @@ Address::InfoString Address::ToString(void) const
     {
         string.Append("0x%04x", GetShort());
     }
-
-    return string;
-}
-
-ExtendedPanId::InfoString ExtendedPanId::ToString(void) const
-{
-    InfoString string;
-
-    string.AppendHexBytes(m8, sizeof(ExtendedPanId));
 
     return string;
 }

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -28,7 +28,7 @@
 
 /**
  * @file
- *   This file includes definitions for MAC types such as Address, Extended PAN Identifier, Network Name, etc.
+ *   This file includes definitions for MAC types.
  */
 
 #ifndef MAC_TYPES_HPP_
@@ -553,32 +553,6 @@ private:
 };
 
 /**
- * This structure represents an IEEE 802.15.4 Extended PAN Identifier.
- *
- */
-OT_TOOL_PACKED_BEGIN
-class ExtendedPanId : public otExtendedPanId, public Equatable<ExtendedPanId>, public Clearable<ExtendedPanId>
-{
-public:
-    static constexpr uint16_t kInfoStringSize = 17; ///< Max chars for the info string (`ToString()`).
-
-    /**
-     * This type defines the fixed-length `String` object returned from `ToString()`.
-     *
-     */
-    typedef String<kInfoStringSize> InfoString;
-
-    /**
-     * This method converts an address to a string.
-     *
-     * @returns An `InfoString` containing the string representation of the Extended PAN Identifier.
-     *
-     */
-    InfoString ToString(void) const;
-
-} OT_TOOL_PACKED_END;
-
-/**
  * This class represents a name string as data (pointer to a char buffer along with a length).
  *
  * @note The char array does NOT need to be null terminated.
@@ -1024,7 +998,6 @@ private:
 
 DefineCoreType(otExtAddress, Mac::ExtAddress);
 DefineCoreType(otMacKey, Mac::Key);
-DefineCoreType(otExtendedPanId, Mac::ExtendedPanId);
 DefineCoreType(otNetworkName, Mac::NetworkName);
 
 } // namespace ot

--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -555,7 +555,7 @@ Error Dataset::ApplyConfiguration(Instance &aInstance, bool *aIsNetworkKeyUpdate
             break;
 
         case Tlv::kExtendedPanId:
-            mac.SetExtendedPanId(As<ExtendedPanIdTlv>(cur)->GetExtendedPanId());
+            aInstance.Get<MeshCoP::ExtendedPanIdManager>().SetExtPanId(As<ExtendedPanIdTlv>(cur)->GetExtendedPanId());
             break;
 
         case Tlv::kNetworkName:

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -339,7 +339,7 @@ public:
          * @returns The Extended PAN ID in the Dataset.
          *
          */
-        const Mac::ExtendedPanId &GetExtendedPanId(void) const { return AsCoreType(&mExtendedPanId); }
+        const MeshCoP::ExtendedPanId &GetExtendedPanId(void) const { return AsCoreType(&mExtendedPanId); }
 
         /**
          * This method sets the Extended PAN ID in the Dataset.
@@ -347,7 +347,7 @@ public:
          * @param[in] aExtendedPanId   An Extended PAN ID.
          *
          */
-        void SetExtendedPanId(const Mac::ExtendedPanId &aExtendedPanId)
+        void SetExtendedPanId(const MeshCoP::ExtendedPanId &aExtendedPanId)
         {
             mExtendedPanId                      = aExtendedPanId;
             mComponents.mIsExtendedPanIdPresent = true;

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -334,7 +334,7 @@ Error ActiveDataset::GenerateLocal(void)
 
     if (dataset.GetTlv<ExtendedPanIdTlv>() == nullptr)
     {
-        IgnoreError(dataset.SetTlv(Tlv::kExtendedPanId, Get<Mac::Mac>().GetExtendedPanId()));
+        IgnoreError(dataset.SetTlv(Tlv::kExtendedPanId, Get<MeshCoP::ExtendedPanIdManager>().GetExtPanId()));
     }
 
     if (dataset.GetTlv<MeshLocalPrefixTlv>() == nullptr)

--- a/src/core/meshcop/extended_panid.hpp
+++ b/src/core/meshcop/extended_panid.hpp
@@ -1,0 +1,117 @@
+/*
+ *  Copyright (c) 2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for managing the Extended PAN ID.
+ *
+ */
+
+#ifndef MESHCOP_EXTENDED_PANID_HPP_
+#define MESHCOP_EXTENDED_PANID_HPP_
+
+#include "openthread-core-config.h"
+
+#include <openthread/dataset.h>
+
+#include "common/as_core_type.hpp"
+#include "common/clearable.hpp"
+#include "common/equatable.hpp"
+#include "common/locator.hpp"
+#include "common/non_copyable.hpp"
+#include "common/string.hpp"
+
+namespace ot {
+namespace MeshCoP {
+
+/**
+ * This class represents an Extended PAN Identifier.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class ExtendedPanId : public otExtendedPanId, public Equatable<ExtendedPanId>, public Clearable<ExtendedPanId>
+{
+public:
+    static constexpr uint16_t kInfoStringSize = 17; ///< Max chars for the info string (`ToString()`).
+
+    /**
+     * This type defines the fixed-length `String` object returned from `ToString()`.
+     *
+     */
+    typedef String<kInfoStringSize> InfoString;
+
+    /**
+     * This method converts an address to a string.
+     *
+     * @returns An `InfoString` containing the string representation of the Extended PAN Identifier.
+     *
+     */
+    InfoString ToString(void) const;
+
+} OT_TOOL_PACKED_END;
+
+class ExtendedPanIdManager : public InstanceLocator, private NonCopyable
+{
+public:
+    /**
+     * Constructor.
+     *
+     * @param[in]  aInstance  A reference to the OpenThread instance.
+     *
+     */
+    explicit ExtendedPanIdManager(Instance &aInstance);
+
+    /**
+     * This method returns the Extended PAN Identifier.
+     *
+     * @returns The Extended PAN Identifier.
+     *
+     */
+    const ExtendedPanId &GetExtPanId(void) const { return mExtendedPanId; }
+
+    /**
+     * This method sets the Extended PAN Identifier.
+     *
+     * @param[in]  aExtendedPanId  The Extended PAN Identifier.
+     *
+     */
+    void SetExtPanId(const ExtendedPanId &aExtendedPanId);
+
+private:
+    static const otExtendedPanId sExtendedPanidInit;
+
+    ExtendedPanId mExtendedPanId;
+};
+
+} // namespace MeshCoP
+
+DefineCoreType(otExtendedPanId, MeshCoP::ExtendedPanId);
+
+} // namespace ot
+
+#endif // MESHCOP_EXTENDED_PANID_HPP_

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -325,7 +325,7 @@ Coap::Message *JoinerRouter::PrepareJoinerEntrustMessage(void)
     Get<KeyManager>().GetNetworkKey(networkKey);
     SuccessOrExit(error = Tlv::Append<NetworkKeyTlv>(*message, networkKey));
     SuccessOrExit(error = Tlv::Append<MeshLocalPrefixTlv>(*message, Get<Mle::MleRouter>().GetMeshLocalPrefix()));
-    SuccessOrExit(error = Tlv::Append<ExtendedPanIdTlv>(*message, Get<Mac::Mac>().GetExtendedPanId()));
+    SuccessOrExit(error = Tlv::Append<ExtendedPanIdTlv>(*message, Get<MeshCoP::ExtendedPanIdManager>().GetExtPanId()));
 
     networkName.Init();
     networkName.SetNetworkName(Get<Mac::Mac>().GetNetworkName().GetAsData());

--- a/src/core/meshcop/meshcop.cpp
+++ b/src/core/meshcop/meshcop.cpp
@@ -316,10 +316,10 @@ exit:
 }
 
 #if OPENTHREAD_FTD
-Error GeneratePskc(const char *              aPassPhrase,
-                   const Mac::NetworkName &  aNetworkName,
-                   const Mac::ExtendedPanId &aExtPanId,
-                   Pskc &                    aPskc)
+Error GeneratePskc(const char *                  aPassPhrase,
+                   const Mac::NetworkName &      aNetworkName,
+                   const MeshCoP::ExtendedPanId &aExtPanId,
+                   Pskc &                        aPskc)
 {
     Error      error        = kErrorNone;
     const char saltPrefix[] = "Thread";

--- a/src/core/meshcop/meshcop.hpp
+++ b/src/core/meshcop/meshcop.hpp
@@ -420,10 +420,10 @@ private:
  * @retval kErrorInvalidArgs   If the length of passphrase is out of range.
  *
  */
-Error GeneratePskc(const char *              aPassPhrase,
-                   const Mac::NetworkName &  aNetworkName,
-                   const Mac::ExtendedPanId &aExtPanId,
-                   Pskc &                    aPskc);
+Error GeneratePskc(const char *                  aPassPhrase,
+                   const Mac::NetworkName &      aNetworkName,
+                   const MeshCoP::ExtendedPanId &aExtPanId,
+                   Pskc &                        aPskc);
 
 /**
  * This function computes the Joiner ID from a factory-assigned IEEE EUI-64.

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -47,6 +47,7 @@
 #include "common/string.hpp"
 #include "common/tlvs.hpp"
 #include "mac/mac_types.hpp"
+#include "meshcop/extended_panid.hpp"
 #include "meshcop/timestamp.hpp"
 #include "net/ip6_address.hpp"
 #include "radio/radio.hpp"
@@ -445,7 +446,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class ExtendedPanIdTlv : public Tlv, public SimpleTlvInfo<Tlv::kExtendedPanId, Mac::ExtendedPanId>
+class ExtendedPanIdTlv : public Tlv, public SimpleTlvInfo<Tlv::kExtendedPanId, MeshCoP::ExtendedPanId>
 {
 public:
     /**
@@ -473,7 +474,7 @@ public:
      * @returns The Extended PAN ID value.
      *
      */
-    const Mac::ExtendedPanId &GetExtendedPanId(void) const { return mExtendedPanId; }
+    const MeshCoP::ExtendedPanId &GetExtendedPanId(void) const { return mExtendedPanId; }
 
     /**
      * This method sets the Extended PAN ID value.
@@ -481,10 +482,10 @@ public:
      * @param[in]  aExtendedPanId  An Extended PAN ID value.
      *
      */
-    void SetExtendedPanId(const Mac::ExtendedPanId &aExtendedPanId) { mExtendedPanId = aExtendedPanId; }
+    void SetExtendedPanId(const MeshCoP::ExtendedPanId &aExtendedPanId) { mExtendedPanId = aExtendedPanId; }
 
 private:
-    Mac::ExtendedPanId mExtendedPanId;
+    MeshCoP::ExtendedPanId mExtendedPanId;
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/radio/trel_interface.hpp
+++ b/src/core/radio/trel_interface.hpp
@@ -94,7 +94,10 @@ public:
          * @returns The Extended PAN Identifier of the TREL peer.
          *
          */
-        const Mac::ExtendedPanId &GetExtPanId(void) const { return static_cast<const Mac::ExtendedPanId &>(mExtPanId); }
+        const MeshCoP::ExtendedPanId &GetExtPanId(void) const
+        {
+            return static_cast<const MeshCoP::ExtendedPanId &>(mExtPanId);
+        }
 
         /**
          * This method returns the IPv6 socket address of the discovered TREL peer.
@@ -137,7 +140,7 @@ public:
         };
 
         void SetExtAddress(const Mac::ExtAddress &aExtAddress) { mExtAddress = aExtAddress; }
-        void SetExtPanId(const Mac::ExtendedPanId &aExtPanId) { mExtPanId = aExtPanId; }
+        void SetExtPanId(const MeshCoP::ExtendedPanId &aExtPanId) { mExtPanId = aExtPanId; }
         void SetSockAddr(const Ip6::SockAddr &aSockAddr) { mSockAddr = aSockAddr; }
         void Log(const char *aAction) const;
     };
@@ -241,9 +244,9 @@ private:
 
     static void HandleRegisterServiceTask(Tasklet &aTasklet);
     void        RegisterService(void);
-    Error       ParsePeerInfoTxtData(const Peer::Info &  aInfo,
-                                     Mac::ExtAddress &   aExtAddress,
-                                     Mac::ExtendedPanId &aExtPanId) const;
+    Error       ParsePeerInfoTxtData(const Peer::Info &      aInfo,
+                                     Mac::ExtAddress &       aExtAddress,
+                                     MeshCoP::ExtendedPanId &aExtPanId) const;
     Peer *      GetNewPeerEntry(void);
     void        RemovePeerEntry(Peer &aEntry);
 

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -131,7 +131,7 @@ Mle::Mle(Instance &aInstance)
 
     mLeaderAloc.InitAsThreadOriginRealmLocalScope();
 
-    meshLocalPrefix.SetFromExtendedPanId(Get<Mac::Mac>().GetExtendedPanId());
+    meshLocalPrefix.SetFromExtendedPanId(Get<MeshCoP::ExtendedPanIdManager>().GetExtPanId());
 
     mMeshLocal64.InitAsThreadOriginRealmLocalScope();
     mMeshLocal64.GetAddress().GetIid().GenerateRandom();

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2889,7 +2889,7 @@ void MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Messa
     Tlv                          tlv;
     MeshCoP::Tlv                 meshcopTlv;
     MeshCoP::DiscoveryRequestTlv discoveryRequest;
-    Mac::ExtendedPanId           extPanId;
+    MeshCoP::ExtendedPanId       extPanId;
     uint16_t                     offset;
     uint16_t                     end;
 
@@ -2921,7 +2921,7 @@ void MleRouter::HandleDiscoveryRequest(const Message &aMessage, const Ip6::Messa
 
         case MeshCoP::Tlv::kExtendedPanId:
             SuccessOrExit(error = Tlv::Read<MeshCoP::ExtendedPanIdTlv>(aMessage, offset, extPanId));
-            VerifyOrExit(Get<Mac::Mac>().GetExtendedPanId() != extPanId, error = kErrorDrop);
+            VerifyOrExit(Get<MeshCoP::ExtendedPanIdManager>().GetExtPanId() != extPanId, error = kErrorDrop);
 
             break;
 
@@ -3018,7 +3018,8 @@ Error MleRouter::SendDiscoveryResponse(const Ip6::Address &aDestination, const M
     SuccessOrExit(error = discoveryResponse.AppendTo(*message));
 
     // Extended PAN ID TLV
-    SuccessOrExit(error = Tlv::Append<MeshCoP::ExtendedPanIdTlv>(*message, Get<Mac::Mac>().GetExtendedPanId()));
+    SuccessOrExit(
+        error = Tlv::Append<MeshCoP::ExtendedPanIdTlv>(*message, Get<MeshCoP::ExtendedPanIdManager>().GetExtPanId()));
 
     // Network Name TLV
     networkName.Init();

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -49,6 +49,7 @@
 #include "common/equatable.hpp"
 #include "common/string.hpp"
 #include "mac/mac_types.hpp"
+#include "meshcop/extended_panid.hpp"
 #include "net/ip6_address.hpp"
 #include "thread/network_data_types.hpp"
 
@@ -428,7 +429,7 @@ public:
      * @param[in] aExtendedPanId   An Extended PAN ID.
      *
      */
-    void SetFromExtendedPanId(const Mac::ExtendedPanId &aExtendedPanId);
+    void SetFromExtendedPanId(const MeshCoP::ExtendedPanId &aExtendedPanId);
 
 } OT_TOOL_PACKED_END;
 

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -82,6 +82,7 @@ ThreadNetif::ThreadNetif(Instance &aInstance)
 #endif
     , mActiveDataset(aInstance)
     , mPendingDataset(aInstance)
+    , mExtendedPanIdManager(aInstance)
     , mIp6Filter(aInstance)
     , mKeyManager(aInstance)
     , mLowpan(aInstance)

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -45,6 +45,7 @@
 #include "meshcop/border_agent.hpp"
 #include "meshcop/commissioner.hpp"
 #include "meshcop/dataset_manager.hpp"
+#include "meshcop/extended_panid.hpp"
 #include "meshcop/joiner.hpp"
 #include "meshcop/joiner_router.hpp"
 #include "meshcop/meshcop_leader.hpp"
@@ -197,15 +198,16 @@ private:
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
     Sntp::Client mSntpClient;
 #endif
-    MeshCoP::ActiveDataset  mActiveDataset;
-    MeshCoP::PendingDataset mPendingDataset;
-    Ip6::Filter             mIp6Filter;
-    KeyManager              mKeyManager;
-    Lowpan::Lowpan          mLowpan;
-    Mac::Mac                mMac;
-    MeshForwarder           mMeshForwarder;
-    Mle::MleRouter          mMleRouter;
-    Mle::DiscoverScanner    mDiscoverScanner;
+    MeshCoP::ActiveDataset        mActiveDataset;
+    MeshCoP::PendingDataset       mPendingDataset;
+    MeshCoP::ExtendedPanIdManager mExtendedPanIdManager;
+    Ip6::Filter                   mIp6Filter;
+    KeyManager                    mKeyManager;
+    Lowpan::Lowpan                mLowpan;
+    Mac::Mac                      mMac;
+    MeshForwarder                 mMeshForwarder;
+    Mle::MleRouter                mMleRouter;
+    Mle::DiscoverScanner          mDiscoverScanner;
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     RadioSelector mRadioSelector;
 #endif

--- a/tests/unit/test_pskc.cpp
+++ b/tests/unit/test_pskc.cpp
@@ -44,7 +44,7 @@ void TestMinimumPassphrase(void)
     const char            passphrase[]   = "123456";
     otInstance *          instance       = testInitInstance();
     SuccessOrQuit(ot::MeshCoP::GeneratePskc(passphrase, *reinterpret_cast<const ot::Mac::NetworkName *>("OpenThread"),
-                                            static_cast<const ot::Mac::ExtendedPanId &>(xpanid), pskc));
+                                            static_cast<const ot::MeshCoP::ExtendedPanId &>(xpanid), pskc));
     VerifyOrQuit(memcmp(pskc.m8, expectedPskc, OT_PSKC_MAX_SIZE) == 0);
     testFreeInstance(instance);
 }
@@ -74,7 +74,7 @@ void TestMaximumPassphrase(void)
 
     otInstance *instance = testInitInstance();
     SuccessOrQuit(ot::MeshCoP::GeneratePskc(passphrase, *reinterpret_cast<const ot::Mac::NetworkName *>("OpenThread"),
-                                            static_cast<const ot::Mac::ExtendedPanId &>(xpanid), pskc));
+                                            static_cast<const ot::MeshCoP::ExtendedPanId &>(xpanid), pskc));
     VerifyOrQuit(memcmp(pskc.m8, expectedPskc, sizeof(pskc.m8)) == 0);
     testFreeInstance(instance);
 }
@@ -89,7 +89,7 @@ void TestExampleInSpec(void)
 
     otInstance *instance = testInitInstance();
     SuccessOrQuit(ot::MeshCoP::GeneratePskc(passphrase, *reinterpret_cast<const ot::Mac::NetworkName *>("Test Network"),
-                                            static_cast<const ot::Mac::ExtendedPanId &>(xpanid), pskc));
+                                            static_cast<const ot::MeshCoP::ExtendedPanId &>(xpanid), pskc));
     VerifyOrQuit(memcmp(pskc.m8, expectedPskc, sizeof(pskc.m8)) == 0);
     testFreeInstance(instance);
 }


### PR DESCRIPTION
With the removal of Thread payload from IEEE 802.15.4 Beacons, the MAC
layer no longer needs to maintain the Extended PAN ID.