### PR TITLE
[nat64] fetch NAT64 prefix from infrastructure interface and advertise it to netdata

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -197,6 +197,7 @@ LOCAL_SRC_FILES                                                  := \
     src/core/api/logging_api.cpp                                    \
     src/core/api/message_api.cpp                                    \
     src/core/api/multi_radio_api.cpp                                \
+    src/core/api/nat64_api.cpp                                      \
     src/core/api/netdata_api.cpp                                    \
     src/core/api/netdata_publisher_api.cpp                          \
     src/core/api/netdiag_api.cpp                                    \
@@ -583,6 +584,7 @@ LOCAL_CPPFLAGS                                                              := \
     $(NULL)
 
 LOCAL_LDLIBS                               := \
+    -lanl                                     \
     -lrt                                      \
     -lutil
 

--- a/include/openthread/border_routing.h
+++ b/include/openthread/border_routing.h
@@ -228,6 +228,23 @@ otError otBorderRoutingGetOnLinkPrefix(otInstance *aInstance, otIp6Prefix *aPref
 otError otBorderRoutingGetNat64Prefix(otInstance *aInstance, otIp6Prefix *aPrefix);
 
 /**
+ * Gets the currently favored NAT64 prefix.
+ *
+ * The favored NAT64 prefix can be discovered from infrastructure link or can be this device's local NAT64 prefix.
+ *
+ * @param[in]   aInstance    A pointer to an OpenThread instance.
+ * @param[out]  aPrefix      A pointer to output the favored NAT64 prefix.
+ * @param[out]  aPreference  A pointer to output the preference associated the favored prefix.
+ *
+ * @retval  OT_ERROR_INVALID_STATE  The Border Routing Manager is not initialized yet.
+ * @retval  OT_ERROR_NONE           Successfully retrieved the favored NAT64 prefix.
+ *
+ */
+otError otBorderRoutingGetFavoredNat64Prefix(otInstance *       aInstance,
+                                             otIp6Prefix *      aPrefix,
+                                             otRoutePreference *aPreference);
+
+/**
  * This function initializes an `otBorderRoutingPrefixTableIterator`.
  *
  * An iterator MUST be initialized before it is used.

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (233)
+#define OPENTHREAD_API_VERSION (234)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -680,6 +680,16 @@ void otIp6PrefixToString(const otIp6Prefix *aPrefix, char *aBuffer, uint16_t aSi
 uint8_t otIp6PrefixMatch(const otIp6Address *aFirst, const otIp6Address *aSecond);
 
 /**
+ * This method gets a prefix with @p aLength from @p aAddress.
+ *
+ * @param[in]  aAddress   A pointer to an IPv6 address.
+ * @param[in]  aLength    The length of prefix in bits.
+ * @param[out] aPrefix    A pointer to output the IPv6 prefix.
+ *
+ */
+void otIp6GetPrefix(const otIp6Address *aAddress, uint8_t aLength, otIp6Prefix *aPrefix);
+
+/**
  * This function indicates whether or not a given IPv6 address is the Unspecified Address.
  *
  * @param[in]  aAddress   A pointer to an IPv6 address.

--- a/include/openthread/nat64.h
+++ b/include/openthread/nat64.h
@@ -35,6 +35,7 @@
 #ifndef OPENTHREAD_NAT64_H_
 #define OPENTHREAD_NAT64_H_
 
+#include <openthread/ip6.h>
 #include <openthread/message.h>
 
 #ifdef __cplusplus
@@ -86,6 +87,32 @@ typedef struct otIp4Cidr
     otIp4Address mAddress;
     uint8_t      mLength;
 } otIp4Cidr;
+
+/**
+ * Test if two IPv4 addresses are the same.
+ *
+ * @param[in]  aFirst   A pointer to the first IPv4 address to compare.
+ * @param[in]  aSecond  A pointer to the second IPv4 address to compare.
+ *
+ * @retval TRUE   The two IPv4 addresses are the same.
+ * @retval FALSE  The two IPv4 addresses are not the same.
+ *
+ */
+bool otIp4IsAddressEqual(const otIp4Address *aFirst, const otIp4Address *aSecond);
+
+/**
+ * Set @p aIp4Address by performing NAT64 address translation from @p aIp6Address as specified
+ * in RFC 6052.
+ *
+ * The NAT64 @p aPrefixLength MUST be one of the following values: 32, 40, 48, 56, 64, or 96, otherwise the behavior
+ * of this method is undefined.
+ *
+ * @param[in]  aPrefixLength  The prefix length to use for IPv4/IPv6 translation.
+ * @param[in]  aIp6Address    A pointer to an IPv6 address.
+ * @param[out] aIp4Address    A pointer to output the IPv4 address.
+ *
+ */
+void otIp4ExtractFromIp6Address(uint8_t aPrefixLength, const otIp6Address *aIp6Address, otIp4Address *aIp4Address);
 
 /**
  * @}

--- a/include/openthread/platform/infra_if.h
+++ b/include/openthread/platform/infra_if.h
@@ -134,6 +134,35 @@ extern void otPlatInfraIfRecvIcmp6Nd(otInstance *        aInstance,
 extern otError otPlatInfraIfStateChanged(otInstance *aInstance, uint32_t aInfraIfIndex, bool aIsRunning);
 
 /**
+ * Send a request to discover the NAT64 prefix on the infrastructure interface with @p aInfraIfIndex.
+ *
+ * OpenThread will call this method periodically to monitor the presence or change of NAT64 prefix.
+ *
+ * @param[in]  aInfraIfIndex  The index of the infrastructure interface to discover the NAT64 prefix.
+ *
+ * @retval  OT_ERROR_NONE    Successfully request NAT64 prefix discovery.
+ * @retval  OT_ERROR_FAILED  Failed to request NAT64 prefix discovery.
+ *
+ */
+otError otPlatInfraIfDiscoverNat64Prefix(uint32_t aInfraIfIndex);
+
+/**
+ * The infra interface driver calls this method to notify OpenThread that
+ * the discovery of NAT64 prefix is done.
+ *
+ * This method is expected to be invoked after calling otPlatInfraIfDiscoverNat64Prefix.
+ * If no NAT64 prefix is discovered, @p aIp6Prefix shall point to an empty prefix with zero length.
+ *
+ * @param[in]  aInstance      The OpenThread instance structure.
+ * @param[in]  aInfraIfIndex  The index of the infrastructure interface on which the NAT64 prefix is discovered.
+ * @param[in]  aIp6Prefix     A pointer to NAT64 prefix.
+ *
+ */
+extern void otPlatInfraIfDiscoverNat64PrefixDone(otInstance *       aInstance,
+                                                 uint32_t           aInfraIfIndex,
+                                                 const otIp6Prefix *aIp6Prefix);
+
+/**
  * @}
  *
  */

--- a/script/test
+++ b/script/test
@@ -325,6 +325,7 @@ do_build_otbr_docker()
             --build-arg REFERENCE_DEVICE=1 \
             --build-arg OT_BACKBONE_CI=1 \
             --build-arg NAT64="${NAT64}" \
+            --build-arg DNS64="${NAT64}" \
             --build-arg REST_API=0 \
             --build-arg WEB_GUI=0 \
             --build-arg MDNS="${OTBR_MDNS:-mDNSResponder}" \

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -603,6 +603,25 @@ template <> otError Interpreter::Process<Cmd("br")>(Arg aArgs[])
         SuccessOrExit(error = otBorderRoutingGetNat64Prefix(GetInstancePtr(), &nat64Prefix));
         OutputIp6PrefixLine(nat64Prefix);
     }
+    /**
+     * @cli br favorednat64prefix
+     * @code
+     * br favorednat64prefix
+     * fd14:1078:b3d5:b0b0:0:0::/96 prf:low
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otBorderRoutingGetFavoredNat64Prefix
+     */
+    else if (aArgs[0] == "favorednat64prefix")
+    {
+        otIp6Prefix       prefix;
+        otRoutePreference preference;
+
+        SuccessOrExit(error = otBorderRoutingGetFavoredNat64Prefix(GetInstancePtr(), &prefix, &preference));
+        OutputIp6Prefix(prefix);
+        OutputLine(" prf:%s", PreferenceToString(preference));
+    }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTING_NAT64_ENABLE
     /**
      * @cli br rioprf (high,med,low)

--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -336,6 +336,7 @@ openthread_core_files = [
   "api/logging_api.cpp",
   "api/message_api.cpp",
   "api/multi_radio_api.cpp",
+  "api/nat64_api.cpp",
   "api/netdata_api.cpp",
   "api/netdata_publisher_api.cpp",
   "api/netdiag_api.cpp",

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -63,6 +63,7 @@ set(COMMON_SOURCES
     api/logging_api.cpp
     api/message_api.cpp
     api/multi_radio_api.cpp
+    api/nat64_api.cpp
     api/netdata_api.cpp
     api/netdata_publisher_api.cpp
     api/netdiag_api.cpp

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -153,6 +153,7 @@ SOURCES_COMMON                                  = \
     api/logging_api.cpp                           \
     api/message_api.cpp                           \
     api/multi_radio_api.cpp                       \
+    api/nat64_api.cpp                             \
     api/netdata_api.cpp                           \
     api/netdata_publisher_api.cpp                 \
     api/netdiag_api.cpp                           \

--- a/src/core/api/border_routing_api.cpp
+++ b/src/core/api/border_routing_api.cpp
@@ -92,6 +92,21 @@ otError otBorderRoutingGetNat64Prefix(otInstance *aInstance, otIp6Prefix *aPrefi
 {
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetNat64Prefix(AsCoreType(aPrefix));
 }
+
+otError otBorderRoutingGetFavoredNat64Prefix(otInstance *       aInstance,
+                                             otIp6Prefix *      aPrefix,
+                                             otRoutePreference *aPreference)
+{
+    otError                                       error;
+    BorderRouter::RoutingManager::RoutePreference preference;
+
+    SuccessOrExit(error = AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetFavoredNat64Prefix(
+                      AsCoreType(aPrefix), preference));
+    *aPreference = static_cast<otRoutePreference>(preference);
+
+exit:
+    return error;
+}
 #endif
 
 void otBorderRoutingPrefixTableInitIterator(otInstance *aInstance, otBorderRoutingPrefixTableIterator *aIterator)

--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -208,6 +208,11 @@ uint8_t otIp6PrefixMatch(const otIp6Address *aFirst, const otIp6Address *aSecond
     return AsCoreType(aFirst).PrefixMatch(AsCoreType(aSecond));
 }
 
+void otIp6GetPrefix(const otIp6Address *aAddress, uint8_t aLength, otIp6Prefix *aPrefix)
+{
+    AsCoreType(aAddress).GetPrefix(aLength, AsCoreType(aPrefix));
+}
+
 bool otIp6IsAddressUnspecified(const otIp6Address *aAddress)
 {
     return AsCoreType(aAddress).IsUnspecified();

--- a/src/core/api/nat64_api.cpp
+++ b/src/core/api/nat64_api.cpp
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021, The OpenThread Authors.
+ *  Copyright (c) 2022, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -26,36 +26,23 @@
  *  POSSIBILITY OF SUCH DAMAGE.
  */
 
-#include "platform-simulation.h"
+/**
+ * @file
+ *   This file implements the OpenThread APIs for handling IPv4 (NAT64) messages
+ */
 
-#include <openthread/platform/infra_if.h>
+#include <openthread/nat64.h>
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-bool otPlatInfraIfHasAddress(uint32_t aInfraIfIndex, const otIp6Address *aAddress)
+#include "net/ip4_types.hpp"
+
+using namespace ot;
+
+bool otIp4IsAddressEqual(const otIp4Address *aFirst, const otIp4Address *aSecond)
 {
-    OT_UNUSED_VARIABLE(aInfraIfIndex);
-    OT_UNUSED_VARIABLE(aAddress);
-
-    return false;
+    return AsCoreType(aFirst) == AsCoreType(aSecond);
 }
 
-otError otPlatInfraIfSendIcmp6Nd(uint32_t            aInfraIfIndex,
-                                 const otIp6Address *aDestAddress,
-                                 const uint8_t *     aBuffer,
-                                 uint16_t            aBufferLength)
+void otIp4ExtractFromIp6Address(uint8_t aPrefixLength, const otIp6Address *aIp6Address, otIp4Address *aIp4Address)
 {
-    OT_UNUSED_VARIABLE(aInfraIfIndex);
-    OT_UNUSED_VARIABLE(aDestAddress);
-    OT_UNUSED_VARIABLE(aBuffer);
-    OT_UNUSED_VARIABLE(aBufferLength);
-
-    return OT_ERROR_FAILED;
+    AsCoreType(aIp4Address).ExtractFromIp6Address(aPrefixLength, AsCoreType(aIp6Address));
 }
-
-otError otPlatInfraIfDiscoverNat64Prefix(uint32_t aInfraIfIndex)
-{
-    OT_UNUSED_VARIABLE(aInfraIfIndex);
-
-    return OT_ERROR_FAILED;
-}
-#endif

--- a/src/core/border_router/infra_if.hpp
+++ b/src/core/border_router/infra_if.hpp
@@ -152,6 +152,26 @@ public:
     void HandledReceived(uint32_t aIfIndex, const Ip6::Address &aSource, const Icmp6Packet &aPacket);
 
     /**
+     * This method sends a request to discover the NAT64 prefix on the infrastructure interface.
+     *
+     * @note  This method MUST be used when interface is initialized.
+     *
+     * @retval  kErrorNone    Successfully request NAT64 prefix discovery.
+     * @retval  kErrorFailed  Failed to request NAT64 prefix discovery.
+     *
+     */
+    Error DiscoverNat64Prefix(void);
+
+    /**
+     * This method processes the discovered NAT64 prefix.
+     *
+     * @param[in]  aIfIndex    The infrastructure interface index on which the host address is received.
+     * @param[in]  aPrefix     The NAT64 prefix on the infrastructure link.
+     *
+     */
+    void DiscoverNat64PrefixDone(uint32_t aIfIndex, const Ip6::Prefix &aPrefix);
+
+    /**
      * This method handles infrastructure interface state changes.
      *
      * @param[in]  aIfIndex         The infrastructure interface index.

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -804,6 +804,15 @@ public:
     }
 
     /**
+     * This method gets a prefix of the IPv6 address with a given length.
+     *
+     * @param[in]  aLength  The length of prefix in bits.
+     * @param[out] aPrefix  A reference to a prefix to output the fetched prefix.
+     *
+     */
+    void GetPrefix(uint8_t aLength, Prefix &aPrefix) const { aPrefix.Set(mFields.m8, aLength); }
+
+    /**
      * This method indicates whether the IPv6 address matches a given prefix.
      *
      * @param[in] aPrefix  An IPv6 prefix to match with.

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -102,7 +102,8 @@ Error LeaderBase::GetPreferredNat64Prefix(ExternalRouteConfig &aConfig) const
             continue;
         }
 
-        if ((error == kErrorNotFound) || (config.mPreference > aConfig.mPreference))
+        if ((error == kErrorNotFound) || (config.mPreference > aConfig.mPreference) ||
+            (config.mPreference == aConfig.mPreference && config.GetPrefix() < aConfig.GetPrefix()))
         {
             aConfig = config;
             error   = kErrorNone;

--- a/src/posix/Makefile.am
+++ b/src/posix/Makefile.am
@@ -62,6 +62,7 @@ LDADD_COMMON                                                           = \
 
 if OPENTHREAD_TARGET_LINUX
 LDADD_COMMON                                                          += \
+    -lanl                                                                \
     -lrt                                                                 \
     $(NULL)
 endif

--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -118,6 +118,7 @@ target_link_libraries(openthread-posix
         ot-posix-config
         util
         $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Linux>:rt>
+        $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Linux>:anl>
 )
 
 target_compile_definitions(openthread-posix

--- a/src/posix/platform/infra_if.hpp
+++ b/src/posix/platform/infra_if.hpp
@@ -34,6 +34,7 @@
 #include "openthread-posix-config.h"
 
 #include <net/if.h>
+#include <openthread/nat64.h>
 
 #include "core/common/non_copyable.hpp"
 #include "posix/platform/mainloop.hpp"
@@ -130,6 +131,18 @@ public:
                         uint16_t            aBufferLength);
 
     /**
+     * This method sends an asynchronous address lookup for the well-known host name "ipv4only.arpa"
+     * to discover the NAT64 prefix.
+     *
+     * @param[in]  aInfraIfIndex  The index of the infrastructure interface the address look-up is sent to.
+     *
+     * @retval  OT_ERROR_NONE    Successfully request address look-up.
+     * @retval  OT_ERROR_FAILED  Failed to request address look-up.
+     *
+     */
+    otError DiscoverNat64Prefix(uint32_t aInfraIfIndex);
+
+    /**
      * This method gets the infrastructure network interface name.
      *
      * @returns The infrastructure network interface name, or `nullptr` if not specified.
@@ -146,14 +159,20 @@ public:
     static InfraNetif &Get(void);
 
 private:
-    char     mInfraIfName[IFNAMSIZ];
-    uint32_t mInfraIfIndex       = 0;
-    int      mInfraIfIcmp6Socket = -1;
-    int      mNetLinkSocket      = -1;
+    static const char         kWellKnownIpv4OnlyName[];   // "ipv4only.arpa"
+    static const otIp4Address kWellKnownIpv4OnlyAddress1; // 192.0.0.170
+    static const otIp4Address kWellKnownIpv4OnlyAddress2; // 192.0.0.171
+    static const uint8_t      kValidNat64PrefixLength[];
 
-    void ReceiveNetLinkMessage(void);
-    void ReceiveIcmp6Message(void);
-    bool HasLinkLocalAddress(void) const;
+    char            mInfraIfName[IFNAMSIZ];
+    static uint32_t mInfraIfIndex;
+    int             mInfraIfIcmp6Socket = -1;
+    int             mNetLinkSocket      = -1;
+
+    void        ReceiveNetLinkMessage(void);
+    void        ReceiveIcmp6Message(void);
+    bool        HasLinkLocalAddress(void) const;
+    static void DiscoverNat64PrefixDone(union sigval sv);
 };
 
 } // namespace Posix

--- a/tests/scripts/thread-cert/border_router/nat64/test_multi_border_routers.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_multi_border_routers.py
@@ -51,6 +51,8 @@ ROUTER = 2
 BR2 = 3
 HOST = 4
 
+NAT64_PREFIX_REFRESH_DELAY = 305
+
 
 class Nat64MultiBorderRouter(thread_cert.TestCase):
     USE_MESSAGE_FACTORY = False
@@ -90,6 +92,8 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
 
         br1.start()
         self.simulator.go(config.LEADER_STARTUP_DELAY)
+        br1.bash("service bind9 stop")
+        self.simulator.go(NAT64_PREFIX_REFRESH_DELAY)
         self.assertEqual('leader', br1.get_state())
 
         router.start()
@@ -97,44 +101,65 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         self.assertEqual('router', router.get_state())
 
         #
-        # Case 1. BR2 joins the network later and it will not add
-        #         its local nat64 prefix to Network Data.
+        # Case 1. BR2 with an infrastructure prefix joins the network later and
+        #         it will add the infrastructure nat64 prefix to Network Data.
         #
         br2.start()
         self.simulator.go(config.BORDER_ROUTER_STARTUP_DELAY)
         self.assertEqual('router', br2.get_state())
 
-        # Only 1 NAT64 prefix in Network Data.
-        self.simulator.go(30)
-        self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
-        self.assertEqual(len(br2.get_netdata_nat64_prefix()), 1)
-        self.assertEqual(br1.get_netdata_nat64_prefix()[0], br2.get_netdata_nat64_prefix()[0])
-        nat64_prefix = br1.get_netdata_nat64_prefix()[0]
+        self.simulator.go(10)
+        self.assertNotEqual(br1.get_br_favored_nat64_prefix(), br2.get_br_favored_nat64_prefix())
+        br1_local_nat64_prefix = br1.get_br_nat64_prefix()
+        br2_infra_nat64_prefix = br2.get_br_favored_nat64_prefix()
 
-        # The NAT64 prefix in Network Data is same as BR1's local NAT64 prefix.
-        br1_nat64_prefix = br1.get_br_nat64_prefix()
-        br2_nat64_prefix = br2.get_br_nat64_prefix()
-        self.assertEqual(nat64_prefix, br1_nat64_prefix)
-        self.assertNotEqual(nat64_prefix, br2_nat64_prefix)
+        self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
+        nat64_prefix = br1.get_netdata_nat64_prefix()[0]
+        self.assertEqual(nat64_prefix, br2_infra_nat64_prefix)
+        self.assertNotEqual(nat64_prefix, br1_local_nat64_prefix)
+
+        br2.disable_br()
 
         #
-        # Case 2. Disable and re-enable border routing on BR1.
+        # Case 2. Re-enables BR2 with a local prefix and it will not add
+        #         its local nat64 prefix to Network Data.
+        #
+        br2.bash("service bind9 stop")
+        self.simulator.go(5)
+        br2.enable_br()
+
+        self.simulator.go(10)
+        self.assertNotEqual(br2_infra_nat64_prefix, br2.get_br_favored_nat64_prefix())
+        br2_local_nat64_prefix = br2.get_br_nat64_prefix()
+
+        self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
+        nat64_prefix = br1.get_netdata_nat64_prefix()[0]
+        self.assertEqual(nat64_prefix, br1_local_nat64_prefix)
+        self.assertNotEqual(nat64_prefix, br2_local_nat64_prefix)
+
+        #
+        # Case 3. Disable border routing on BR1.
+        #         BR1 withdraws its prefix and BR2 advertises its prefix.
         #
         br1.disable_br()
-        self.simulator.go(30)
 
-        # BR1 withdraws its prefix and BR2 advertises its prefix.
+        self.simulator.go(10)
         self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
-        self.assertEqual(br2_nat64_prefix, br1.get_netdata_nat64_prefix()[0])
-        self.assertNotEqual(br1_nat64_prefix, br1.get_netdata_nat64_prefix()[0])
+        nat64_prefix = br1.get_netdata_nat64_prefix()[0]
+        self.assertEqual(br2_local_nat64_prefix, nat64_prefix)
+        self.assertNotEqual(br1_local_nat64_prefix, nat64_prefix)
 
+        #
+        # Case 4. Re-enable border routing on BR1.
+        #         NAT64 prefix in Network Data is still advertised by BR2.
+        #
         br1.enable_br()
-        self.simulator.go(config.BORDER_ROUTER_STARTUP_DELAY)
 
-        # NAT64 prefix in Network Data is still advertised by BR2.
+        self.simulator.go(10)
         self.assertEqual(len(br1.get_netdata_nat64_prefix()), 1)
-        self.assertEqual(br2_nat64_prefix, br1.get_netdata_nat64_prefix()[0])
-        self.assertNotEqual(br1_nat64_prefix, br1.get_netdata_nat64_prefix()[0])
+        nat64_prefix = br1.get_netdata_nat64_prefix()[0]
+        self.assertEqual(br2_local_nat64_prefix, nat64_prefix)
+        self.assertNotEqual(br1_local_nat64_prefix, nat64_prefix)
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/border_router/nat64/test_with_infrastructure_prefix.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_with_infrastructure_prefix.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2022, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS 'AS IS'
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+import unittest
+
+import config
+import thread_cert
+
+# Test description:
+#   This test verifies the advertisement of infrastructure NAT64 prefix in Thread network.
+#
+#
+# Topology:
+#
+#   ----------------(eth)--------------------
+#           |
+#          BR (with DNS64 on infrastructure interface)
+#           |
+#        ROUTER
+#
+
+BR = 1
+ROUTER = 2
+
+# The prefix is set smaller than the default infrastructure NAT64 prefix.
+SMALL_NAT64_PREFIX = "2000:0:0:1:0:0::/96"
+
+NAT64_PREFIX_REFRESH_DELAY = 305
+
+
+class Nat64SingleBorderRouter(thread_cert.TestCase):
+    USE_MESSAGE_FACTORY = False
+
+    TOPOLOGY = {
+        BR: {
+            'name': 'BR',
+            'allowlist': [ROUTER],
+            'is_otbr': True,
+            'version': '1.2',
+        },
+        ROUTER: {
+            'name': 'Router',
+            'allowlist': [BR],
+            'version': '1.2',
+        },
+    }
+
+    def test(self):
+        br = self.nodes[BR]
+        router = self.nodes[ROUTER]
+
+        br.start()
+        self.simulator.go(config.LEADER_STARTUP_DELAY)
+        self.assertEqual('leader', br.get_state())
+
+        router.start()
+        self.simulator.go(config.ROUTER_STARTUP_DELAY)
+        self.assertEqual('router', router.get_state())
+
+        # Case 1 BR advertise the infrastructure prefix
+        infra_nat64_prefix = br.get_br_favored_nat64_prefix()
+
+        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
+        nat64_prefix = br.get_netdata_nat64_prefix()[0]
+        self.assertEqual(nat64_prefix, infra_nat64_prefix)
+
+        # Case 2 Withdraw infrastructure prefix when a smaller prefix in medium
+        # preference is present
+        br.add_route(SMALL_NAT64_PREFIX, stable=False, nat64=True, prf='med')
+        br.register_netdata()
+        self.simulator.go(5)
+
+        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
+        self.assertNotEqual(infra_nat64_prefix, br.get_netdata_nat64_prefix()[0])
+
+        br.remove_route(SMALL_NAT64_PREFIX)
+        br.register_netdata()
+        self.simulator.go(10)
+
+        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
+        self.assertEqual(nat64_prefix, infra_nat64_prefix)
+
+        # Case 3 No change when a smaller prefix in low preference is present
+        br.add_route(SMALL_NAT64_PREFIX, stable=False, nat64=True, prf='low')
+        br.register_netdata()
+        self.simulator.go(5)
+
+        self.assertEqual(len(br.get_netdata_nat64_prefix()), 2)
+        self.assertEqual(br.get_netdata_nat64_prefix(), [infra_nat64_prefix, SMALL_NAT64_PREFIX])
+
+        br.remove_route(SMALL_NAT64_PREFIX)
+        br.register_netdata()
+        self.simulator.go(5)
+
+        # Case 4 Infrastructure nat64 prefix no longer presents
+        br.bash("service bind9 stop")
+        self.simulator.go(NAT64_PREFIX_REFRESH_DELAY)
+
+        local_nat64_prefix = br.get_br_nat64_prefix()
+        self.assertNotEqual(local_nat64_prefix, infra_nat64_prefix)
+        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
+        self.assertEqual(br.get_netdata_nat64_prefix()[0], local_nat64_prefix)
+
+        # Case 5 Infrastructure nat64 prefix is recovered
+        br.bash("service bind9 start")
+        self.simulator.go(NAT64_PREFIX_REFRESH_DELAY)
+
+        self.assertEqual(br.get_br_favored_nat64_prefix(), infra_nat64_prefix)
+        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
+        self.assertEqual(br.get_netdata_nat64_prefix()[0], infra_nat64_prefix)
+
+        # Case 6 Change infrastructure nat64 prefix
+        br.bash("sed -i 's/dns64 /\/\/dns64 /' /etc/bind/named.conf.options")
+        br.bash("sed -i '/\/\/dns64 /a dns64 " + SMALL_NAT64_PREFIX + " {};' /etc/bind/named.conf.options")
+        br.bash("service bind9 restart")
+        self.simulator.go(NAT64_PREFIX_REFRESH_DELAY)
+
+        self.assertEqual(br.get_br_favored_nat64_prefix(), SMALL_NAT64_PREFIX)
+        self.assertEqual(len(br.get_netdata_nat64_prefix()), 1)
+        self.assertEqual(br.get_netdata_nat64_prefix()[0], SMALL_NAT64_PREFIX)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -492,6 +492,11 @@ OT_TOOL_WEAK otError otPlatInfraIfSendIcmp6Nd(uint32_t, const otIp6Address *, co
 {
     return OT_ERROR_FAILED;
 }
+
+OT_TOOL_WEAK otError otPlatInfraIfDiscoverNat64Prefix(uint32_t)
+{
+    return OT_ERROR_FAILED;
+}
 #endif
 
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE


### PR DESCRIPTION
This commit fetches the NAT64 prefix on infrastructure interface and advertise it to Network Data at medium preference.

- Use `getaddrinfo_a()` function to asynchronously lookup the ipv6 address of the special domain `ipv4only.arpa`. The infrastructure NAT64 prefix is extracted from the domain answer.
- `mInfraIfNat64PrefixStaleTimer` is scheduled to monitor the presence and change of infrastructure NAT64 prefix.  
- `EvaluateNat64Prefix` evaluates whether to advertise the infrastructure prefix or the local ULA prefix or neither. When there is a new infrastructure prefix, it will withdraw the legacy one and add the new one. When the infrastructure prefix no longer exists, it will withdraw the legacy one and add the local ULA prefix. When the infrastructure prefix presents again, it will add the infrastructure prefix and withdraw the local ULA prefix.

New tests are added to test the scenarios when infrastructure NAT64 prefix exists. 
`DNS64` on OTBR is turned on to enable `bind9` with NAT64 prefix on infrastructure interface for these tests. `bind9` is explicitly turned off when testing local ULA prefix.
Since bind9 is conflict with other components like dnssd, all nat64 tests are moved under /nat64 directory and configured separately.

The case that two or more BRs have same infrastructure NAT64 prefix is not covered by this commit and will be followed up later.