### PR TITLE
[gcov] use __gcov_dump() instead for gcc 11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -188,7 +188,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        gcc_ver: [5, 6, 7, 8, 9, 10]
+        gcc_ver: [5, 6, 7, 8, 9, 10, 11]
     env:
       CC: gcc-${{ matrix.gcc_ver }}
       CXX: g++-${{ matrix.gcc_ver }}
@@ -199,6 +199,11 @@ jobs:
     - name: Bootstrap
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+        case ${{ matrix.gcc_ver }} in
+          11)
+            sudo add-apt-repository -y ppa:ubuntu-toolchain-r/test
+            ;;
+        esac
         sudo apt-get --no-install-recommends install -y gcc-${{ matrix.gcc_ver }} g++-${{ matrix.gcc_ver }} ninja-build libreadline-dev libncurses-dev
     - name: Build
       run: |

--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -39,6 +39,8 @@
 #include "cli/cli_config.h"
 #include "common/code_utils.hpp"
 
+#include "lib/platform/reset_util.h"
+
 /**
  * This function initializes the CLI app.
  *
@@ -46,19 +48,6 @@
  *
  */
 extern void otAppCliInit(otInstance *aInstance);
-
-#if OPENTHREAD_EXAMPLES_SIMULATION
-#include <setjmp.h>
-#include <unistd.h>
-
-jmp_buf gResetJump;
-
-void __gcov_flush();
-#endif
-
-#ifndef OPENTHREAD_ENABLE_COVERAGE
-#define OPENTHREAD_ENABLE_COVERAGE 0
-#endif
 
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 void *otPlatCAlloc(size_t aNum, size_t aSize)
@@ -93,16 +82,7 @@ int main(int argc, char *argv[])
 {
     otInstance *instance;
 
-#if OPENTHREAD_EXAMPLES_SIMULATION
-    if (setjmp(gResetJump))
-    {
-        alarm(0);
-#if OPENTHREAD_ENABLE_COVERAGE
-        __gcov_flush();
-#endif
-        execvp(argv[0], argv);
-    }
-#endif
+    OT_SETUP_RESET_JUMP(argv);
 
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
     size_t   otInstanceBufferLength = 0;

--- a/examples/apps/ncp/main.c
+++ b/examples/apps/ncp/main.c
@@ -36,6 +36,7 @@
 
 #include "openthread-system.h"
 
+#include "lib/platform/reset_util.h"
 /**
  * This function initializes the NCP app.
  *
@@ -43,19 +44,6 @@
  *
  */
 extern void otAppNcpInit(otInstance *aInstance);
-
-#if OPENTHREAD_EXAMPLES_SIMULATION
-#include <setjmp.h>
-#include <unistd.h>
-
-jmp_buf gResetJump;
-
-void __gcov_flush();
-#endif
-
-#ifndef OPENTHREAD_ENABLE_COVERAGE
-#define OPENTHREAD_ENABLE_COVERAGE 0
-#endif
 
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 void *otPlatCAlloc(size_t aNum, size_t aSize)
@@ -78,16 +66,7 @@ int main(int argc, char *argv[])
 {
     otInstance *instance;
 
-#if OPENTHREAD_EXAMPLES_SIMULATION
-    if (setjmp(gResetJump))
-    {
-        alarm(0);
-#if OPENTHREAD_ENABLE_COVERAGE
-        __gcov_flush();
-#endif
-        execvp(argv[0], argv);
-    }
-#endif
+    OT_SETUP_RESET_JUMP(argv);
 
 #if OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
     size_t   otInstanceBufferLength = 0;

--- a/src/lib/platform/Makefile.am
+++ b/src/lib/platform/Makefile.am
@@ -40,4 +40,8 @@ libopenthread_platform_a_SOURCES            = \
     exit_code.h                               \
     $(NULL)
 
+noinst_HEADERS                              = \
+    reset_util.h                              \
+    $(NULL)
+
 include $(abs_top_nlbuild_autotools_dir)/automake/post.am

--- a/src/lib/platform/reset_util.h
+++ b/src/lib/platform/reset_util.h
@@ -1,0 +1,67 @@
+/*
+ *  Copyright (c) 2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef OT_LIB_PLATFORM_RESET_UTIL_H_
+#define OT_LIB_PLATFORM_RESET_UTIL_H_
+
+#if defined(OPENTHREAD_ENABLE_COVERAGE) && OPENTHREAD_ENABLE_COVERAGE && defined(__GNUC__)
+#if __GNUC__ >= 11
+void __gcov_dump();
+void __gcov_reset();
+
+static void flush_gcov(void)
+{
+    __gcov_dump();
+    __gcov_reset();
+}
+#else
+void __gcov_flush(void);
+#define flush_gcov __gcov_flush
+#endif // __GNUC__ >= 11
+#else
+#define flush_gcov()
+#endif // defined(OPENTHREAD_ENABLE_COVERAGE) && OPENTHREAD_ENABLE_COVERAGE && defined(__GNUC__)
+
+#if defined(__linux__) || defined(__APPLE__)
+#include <setjmp.h>
+#include <unistd.h>
+jmp_buf gResetJump;
+
+#define OT_SETUP_RESET_JUMP(kArgv) \
+    if (setjmp(gResetJump))        \
+    {                              \
+        alarm(0);                  \
+        flush_gcov();              \
+        execvp(kArgv[0], kArgv);   \
+    }
+
+#else
+#define OT_SETUP_RESET_JUMP(ARGV)
+#endif // defined(__linux__) || defined(__APPLE__)
+
+#endif // OT_LIB_PLATFORM_RESET_UTIL_H_

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -68,9 +68,7 @@
 #include <openthread/openthread-system.h>
 #include <openthread/platform/misc.h>
 
-#ifndef OPENTHREAD_ENABLE_COVERAGE
-#define OPENTHREAD_ENABLE_COVERAGE 0
-#endif
+#include "lib/platform/reset_util.h"
 
 /**
  * This function initializes NCP app.
@@ -131,10 +129,6 @@ typedef struct PosixConfig
     bool             mPrintRadioVersion; ///< Whether to print radio firmware version.
     bool             mIsVerbose;         ///< Whether to print log to stderr.
 } PosixConfig;
-
-static jmp_buf gResetJump;
-
-void __gcov_flush();
 
 /**
  * This enumeration defines the argument return values.
@@ -370,14 +364,7 @@ int main(int argc, char *argv[])
     prctl(PR_SET_PDEATHSIG, SIGHUP);
 #endif
 
-    if (setjmp(gResetJump))
-    {
-        alarm(0);
-#if OPENTHREAD_ENABLE_COVERAGE
-        __gcov_flush();
-#endif
-        execvp(argv[0], argv);
-    }
+    OT_SETUP_RESET_JUMP(argv);
 
     ParseArg(argc, argv, &config);
     openlog(argv[0], LOG_PID | (config.mIsVerbose ? LOG_PERROR : 0), LOG_DAEMON);


### PR DESCRIPTION
__gcov_flush is removed from gcc 11.