### PR TITLE
[tcp] implement  otTcpReceiveContiguify

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (236)
+#define OPENTHREAD_API_VERSION (237)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/tcp.h
+++ b/include/openthread/tcp.h
@@ -294,7 +294,7 @@ typedef struct otTcpEndpointInitializeArgs
  * select a smaller buffer size.
  *
  */
-#define OT_TCP_RECEIVE_BUFFER_SIZE_FEW_HOPS 2599
+#define OT_TCP_RECEIVE_BUFFER_SIZE_FEW_HOPS 2598
 
 /**
  * @def OT_TCP_RECEIVE_BUFFER_SIZE_MANY_HOPS
@@ -306,7 +306,7 @@ typedef struct otTcpEndpointInitializeArgs
  * so), then it may be advisable to select a large buffer size manually.
  *
  */
-#define OT_TCP_RECEIVE_BUFFER_SIZE_MANY_HOPS 4158
+#define OT_TCP_RECEIVE_BUFFER_SIZE_MANY_HOPS 4157
 
 /**
  * Initializes a TCP endpoint.

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -234,7 +234,11 @@ Error Tcp::Endpoint::ReceiveByReference(const otLinkedBuffer *&aBuffer)
 
 Error Tcp::Endpoint::ReceiveContiguify(void)
 {
-    return kErrorNotImplemented;
+    struct tcpcb &tp = GetTcb();
+
+    cbuf_contiguify(&tp.recvbuf, tp.reassbmp);
+
+    return kErrorNone;
 }
 
 Error Tcp::Endpoint::CommitReceive(size_t aNumBytes, uint32_t aFlags)

--- a/third_party/tcplp/lib/bitmap.c
+++ b/third_party/tcplp/lib/bitmap.c
@@ -67,7 +67,9 @@ void bmp_setrange(uint8_t* buf, size_t start, size_t len) {
     } else {
         *first_byte_set |= first_byte_mask;
         memset(first_byte_set + 1, 0xFF, (size_t) (last_byte_set - first_byte_set - 1));
-        *last_byte_set |= last_byte_mask;
+        if (last_byte_mask != 0x00) {
+            *last_byte_set |= last_byte_mask;
+        }
     }
 }
 
@@ -89,7 +91,9 @@ void bmp_clrrange(uint8_t* buf, size_t start, size_t len) {
     } else {
         *first_byte_clear &= first_byte_mask;
         memset(first_byte_clear + 1, 0x00, (size_t) (last_byte_clear - first_byte_clear - 1));
-        *last_byte_clear &= last_byte_mask;
+        if (last_byte_mask != 0xFF) {
+            *last_byte_clear &= last_byte_mask;
+        }
     }
 }
 

--- a/third_party/tcplp/lib/bitmap.c
+++ b/third_party/tcplp/lib/bitmap.c
@@ -135,6 +135,67 @@ size_t bmp_countset(uint8_t* buf, size_t buflen, size_t start, size_t limit) {
     return numset;
 }
 
+static inline uint8_t bmp_read_bit(uint8_t* buf, size_t i) {
+    size_t byte_index = i >> 3;
+    size_t bit_index = i & 0x7; // Amount to left shift to get bit in MSB
+    return ((uint8_t) (buf[byte_index] << bit_index)) >> 7;
+}
+
+static inline void bmp_write_bit(uint8_t* buf, size_t i, uint8_t bit) {
+    size_t byte_index = i >> 3;
+    size_t bit_index = i & 0x7; // Amount to left shift to get bit in MSB
+    size_t bit_shift = 7 - bit_index; // Amount to right shift to get bit in LSB
+    buf[byte_index] = (buf[byte_index] & ~(1 << bit_shift)) | (bit << bit_shift);
+}
+
+static inline uint8_t bmp_read_byte(uint8_t* buf, size_t i) {
+    size_t byte_index = i >> 3;
+    size_t bit_index = i & 0x7; // Amount to left shift to get bit in MSB
+    if (bit_index == 0) {
+        return buf[byte_index];
+    }
+    return (buf[byte_index] << bit_index) | (buf[byte_index + 1] >> (8 - bit_index));
+}
+
+static inline void bmp_write_byte(uint8_t* buf, size_t i, uint8_t byte) {
+    size_t byte_index = i >> 3;
+    size_t bit_index = i & 0x7; // Amount to left shift to get bit in MSB
+    if (bit_index == 0) {
+        buf[byte_index] = byte;
+        return;
+    }
+    buf[byte_index] = (buf[byte_index] & (0xFF << (8 - bit_index))) | (byte >> bit_index);
+    buf[byte_index + 1] = (buf[byte_index + 1] & (0xFF >> bit_index)) | (byte << (8 - bit_index));
+}
+
+void bmp_swap(uint8_t* buf, size_t start_1, size_t start_2, size_t len) {
+    while ((len & 0x7) != 0) {
+        uint8_t bit_1 = bmp_read_bit(buf, start_1);
+        uint8_t bit_2 = bmp_read_bit(buf, start_2);
+        if (bit_1 != bit_2) {
+            bmp_write_bit(buf, start_1, bit_2);
+            bmp_write_bit(buf, start_2, bit_1);
+        }
+
+        start_1++;
+        start_2++;
+        len--;
+    }
+
+    while (len != 0) {
+        uint8_t byte_1 = bmp_read_byte(buf, start_1);
+        uint8_t byte_2 = bmp_read_byte(buf, start_2);
+        if (byte_1 != byte_2) {
+            bmp_write_byte(buf, start_1, byte_2);
+            bmp_write_byte(buf, start_2, byte_1);
+        }
+
+        start_1 += 8;
+        start_2 += 8;
+        len -= 8;
+    }
+}
+
 int bmp_isempty(uint8_t* buf, size_t buflen) {
     uint8_t* bufend = buf + buflen;
     while (buf < bufend) {

--- a/third_party/tcplp/lib/bitmap.h
+++ b/third_party/tcplp/lib/bitmap.h
@@ -57,6 +57,11 @@ void bmp_clrrange(uint8_t* buf, size_t start, size_t len);
    which case it returns exactly the number of set bits it found. */
 size_t bmp_countset(uint8_t* buf, size_t buflen, size_t start, size_t limit);
 
+/* Swaps two non-overlapping regions of the bitmap. START_1 is the index of
+   the first region, START_2 is the index of the secoind region, and LEN is
+   the length of each region, in bits. */
+void bmp_swap(uint8_t* buf, size_t start_1, size_t start_2, size_t len);
+
 /* Returns 1 if the bitmap is all zeros, and 0 otherwise. */
 int bmp_isempty(uint8_t* buf, size_t buflen);
 

--- a/third_party/tcplp/lib/cbuf.h
+++ b/third_party/tcplp/lib/cbuf.h
@@ -64,7 +64,7 @@ void cbuf_copy_from_message(void* arr, size_t arr_offset, const void* buffer, si
 /* Writes data to the back of the circular buffer using the specified copier. */
 size_t cbuf_write(struct cbufhead* chdr, const void* data, size_t data_offset, size_t data_len, cbuf_copier_t copy_from);
 
-/* Reads data from the front ofthe circular buffer using the specified copier. */
+/* Reads data from the front of the circular buffer using the specified copier. */
 size_t cbuf_read(struct cbufhead* chdr, void* data, size_t data_offset, size_t numbytes, int pop, cbuf_copier_t copy_into);
 
 /* Reads data at the specified offset, in bytes, from the front of the circular buffer using the specified copier. */
@@ -85,12 +85,15 @@ size_t cbuf_size(struct cbufhead* chdr);
 /* Returns true if the circular buffer is empty, and false if it is not empty. */
 bool cbuf_empty(struct cbufhead* chdr);
 
+/* Rotates the circular buffer's data so that the "used" portion begins at the beginning of the buffer. */
+void cbuf_contiguify(struct cbufhead* chdr, uint8_t* bitmap);
+
 /* Populates the provided otLinkedBuffers to reference the data currently in the circular buffer. */
 void cbuf_reference(const struct cbufhead* chdr, struct otLinkedBuffer* first, struct otLinkedBuffer* second);
 
 /* Writes DATA at the end of the circular buffer without making it available for
    reading. This data is said to be "out-of-sequence". OFFSET is position at
-   which to write these bytes, relative to the positoin where cbuf_write would
+   which to write these bytes, relative to the position where cbuf_write would
    write them. Each bit in the BITMAP corresponds to a byte in the circular
    buffer; the bits corresponding to the bytes containing the newly written
    data are set. The index of the first byte written is stored into FIRSTINDEX,

--- a/third_party/tcplp/lib/cbuf.h
+++ b/third_party/tcplp/lib/cbuf.h
@@ -42,7 +42,7 @@ struct otLinkedBuffer;
 /* Represents a circular buffer. */
 struct cbufhead {
     size_t r_index;
-    size_t w_index;
+    size_t used;
     size_t size;
     uint8_t* buf;
 };
@@ -105,7 +105,15 @@ size_t cbuf_reass_write(struct cbufhead* chdr, size_t offset, const void* data, 
 size_t cbuf_reass_merge(struct cbufhead* chdr, size_t numbytes, uint8_t* bitmap);
 
 /* Counts the number of contiguous out-of-sequence bytes at the specified
-   OFFSET, until the count reaches the specified LIMIT. */
+   OFFSET, until the count reaches the specified LIMIT. Note that, for a given,
+   limit, this function might overcount the length of the continuous
+   out-of-sequence bytes and return a greater number; the caller is assumed to
+   handle this appropriately (i.e., treating the limit not as a hard upper
+   bound on the return value, but rather as, "I don't care if more bits than
+   this are set"). Just because the function returns something more than
+   LIMIT, it doesn't necessarily mean that more than LIMIT bits are actually
+   set. Note that LIMIT should never be set to a value greater than the number
+   of bytes in the circular buffer. */
 size_t cbuf_reass_count_set(struct cbufhead* chdr, size_t offset, uint8_t* bitmap, size_t limit);
 
 /* Returns a true value iff INDEX is the index of a byte within OFFSET bytes


### PR DESCRIPTION
This pull requests the `otTcpReceiveContiguify` function in the OpenThread TCP API.

This function reorganizes data within the TCP receive buffer so that it is contiguous in memory. The purpose of this function was to ease programming for applications where the cost of reorganizing data within the receive buffer is acceptable.

The first commit modifies the circular buffering used by TCPlp to make it more memory efficient. The original implementation maintained the indices in to the array in such a way that it could not use all of the array at once; there always had to be one spare byte. This commit removes that restriction.

The second commit actually implements the `otTcpReceiveContiguify`. The algorithm itself can be understood as array rotation; the implementation runs in linear time in the full length of the array (even if only part of it is actually used to store data at the moment) with constant extra space overhead.