### PR TITLE
[posix-netif] remove IFA_RT_PRIORITY definition

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -322,10 +322,6 @@ static uint8_t NetmaskToPrefixLength(const struct sockaddr_in6 *netmask)
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wcast-align"
 
-#if !defined(IFA_RT_PRIORITY)
-#define IFA_RT_PRIORITY 9
-#endif
-
 void AddRtAttr(struct nlmsghdr *aHeader, uint32_t aMaxLen, uint8_t aType, const void *aData, uint8_t aLen)
 {
     uint8_t        len = RTA_LENGTH(aLen);


### PR DESCRIPTION
`IFA_RT_PRIORITY` not defined basically means that the feature is not present. 
Defining it to 9 does not make it effective. 
This commit removes the `IFA_RT_PRIORITY` definition so that it would not compile on platforms that do not support `IFA_RT_PRIORITY`. 