### PR TITLE
[github-actions] remove caching OTBR test results

### DIFF
--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -60,53 +60,33 @@ jobs:
     - uses: actions/checkout@v2
       with:
         submodules: true
-    - name: Get Border Router Test ID
-      id: unique_action_id
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      run: |
-        ./script/git-tool clone https://github.com/openthread/ot-br-posix.git --depth 1 "/tmp/otbr_unique_action_id"
-        echo ::set-output  name=id::${GITHUB_WORKFLOW}-${GITHUB_JOB}-${GITHUB_RUN_ID}-$(cd /tmp/otbr_unique_action_id/ && git rev-parse HEAD)
-    - name: Check cached result
-      id: check_cache_result
-      uses: actions/cache@v2
-      with:
-        path: |
-          _test_complete_
-        key: "_test_complete_${{ steps.unique_action_id.outputs.id }}"
     - name: Build OTBR Docker
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
       run: |
         ./script/test build_otbr_docker
     - name: Bootstrap
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y python3-setuptools python3-wheel ninja-build socat lcov
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       run: |
         ./script/test build
     - name: Get Thread-Wireshark
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       run: |
         ./script/test get_thread_wireshark
     - name: Run
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       run: |
         export CI_ENV="$(bash <(curl -s https://codecov.io/env)) -e GITHUB_ACTIONS -e COVERAGE"
         echo "CI_ENV=${CI_ENV}"
         sudo -E ./script/test cert_suite ./tests/scripts/thread-cert/backbone/*.py || (sudo chmod a+r *.log *.json *.pcap && false)
     - uses: actions/upload-artifact@v2
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       with:
         name: cov-thread-1-2-backbone-docker
         path: /tmp/coverage/
     - uses: actions/upload-artifact@v2
-      if: ${{ failure() && steps.check_cache_result.outputs.cache-hit != 'true' }}
+      if: ${{ failure() }}
       with:
         name: thread-1-2-backbone-results
         path: |
@@ -116,18 +96,12 @@ jobs:
           coredump_*
           otbr-agent_*
     - name: Generate Coverage
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       run: |
         ./script/test generate_coverage gcc
     - uses: actions/upload-artifact@v2
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       with:
         name: cov-thread-1-2-backbone
         path: tmp/coverage.info
-    - name: Cache test result
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
-      run: |
-        mkdir _test_complete_
 
   thread-border-router:
     runs-on: ubuntu-20.04
@@ -176,54 +150,34 @@ jobs:
       MAX_JOBS: 3
     steps:
     - uses: actions/checkout@v2
-    - name: Get Border Router Test ID
-      id: unique_action_id
-      env:
-        GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-      run: |
-        ./script/git-tool clone https://github.com/openthread/ot-br-posix.git --depth 1 "/tmp/otbr_unique_action_id"
-        echo ::set-output  name=id::${GITHUB_WORKFLOW}-${GITHUB_JOB}-${GITHUB_RUN_ID}-$(cd /tmp/otbr_unique_action_id/ && git rev-parse HEAD)-${{matrix.otbr_mdns}}-trel${{matrix.otbr_trel}}
-    - name: Check cached result
-      id: check_cache_result
-      uses: actions/cache@v2
-      with:
-        path: |
-          _test_complete_
-        key: "_test_complete_${{ steps.unique_action_id.outputs.id }}"
     - name: Build OTBR Docker
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       env:
         GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
         TREL: ${{ matrix.otbr_trel }}
       run: |
         ./script/test build_otbr_docker
     - name: Bootstrap
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
         sudo apt-get --no-install-recommends install -y python3-setuptools python3-wheel ninja-build socat lcov
         python3 -m pip install -r tests/scripts/thread-cert/requirements.txt
     - name: Build
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       run: |
         ./script/test build
     - name: Get Thread-Wireshark
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       run: |
         ./script/test get_thread_wireshark
     - name: Run
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       run: |
         export CI_ENV="$(bash <(curl -s https://codecov.io/env)) -e GITHUB_ACTIONS -e COVERAGE"
         echo "CI_ENV=${CI_ENV}"
         sudo -E ./script/test cert_suite ${{ matrix.cert_scripts }} || (sudo chmod a+r *.log *.json *.pcap && false)
     - uses: actions/upload-artifact@v2
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       with:
         name: cov-thread-border-router-docker
         path: /tmp/coverage/
     - uses: actions/upload-artifact@v2
-      if: ${{ failure() && steps.check_cache_result.outputs.cache-hit != 'true' }}
+      if: ${{ failure() }}
       with:
         name: thread-border-router-results
         path: |
@@ -233,18 +187,12 @@ jobs:
           coredump_*
           otbr-agent_*
     - name: Generate Coverage
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       run: |
         ./script/test generate_coverage gcc
     - uses: actions/upload-artifact@v2
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
       with:
         name: cov-thread-border-router
         path: tmp/coverage.info
-    - name: Cache test result
-      if: ${{ success() && steps.check_cache_result.outputs.cache-hit != 'true' }}
-      run: |
-        mkdir _test_complete_
 
   upload-coverage:
     needs:


### PR DESCRIPTION
Caching OTBR test results to avoid re-running all tests is no longer necessary now that GitHub Actions supports it natively. 