### PR TITLE
[netdata] always check `IsConsistent()` before netdata registration

### DIFF
--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -184,12 +184,6 @@ void Local::UpdateRloc(PrefixTlv &aPrefixTlv)
     }
 }
 
-bool Local::IsConsistent(void) const
-{
-    return Get<Leader>().ContainsEntriesFrom(*this, Get<Mle::MleRouter>().GetRloc16()) &&
-           ContainsEntriesFrom(Get<Leader>(), Get<Mle::MleRouter>().GetRloc16());
-}
-
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
@@ -293,6 +287,12 @@ void Local::UpdateRloc(void)
     }
 }
 
+bool Local::IsConsistent(void) const
+{
+    return Get<Leader>().ContainsEntriesFrom(*this, Get<Mle::MleRouter>().GetRloc16()) &&
+           ContainsEntriesFrom(Get<Leader>(), Get<Mle::MleRouter>().GetRloc16());
+}
+
 Error Local::UpdateInconsistentServerData(Coap::ResponseHandler aHandler, void *aContext)
 {
     Error    error = kErrorNone;
@@ -308,9 +308,7 @@ Error Local::UpdateInconsistentServerData(Coap::ResponseHandler aHandler, void *
 
     UpdateRloc();
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
     VerifyOrExit(!IsConsistent(), error = kErrorNotFound);
-#endif
 
     if (mOldRloc == rloc)
     {

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -179,11 +179,12 @@ public:
 
 private:
     void UpdateRloc(void);
+    bool IsConsistent(void) const;
+
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
     Error AddPrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvType, uint16_t aFlags, bool aStable);
     Error RemovePrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvType);
     void  UpdateRloc(PrefixTlv &aPrefixTlv);
-    bool  IsConsistent(void) const;
 #endif
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE


### PR DESCRIPTION
This commit removes the `#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE`
around the call to `IsConsistent()` which checks whether there is any
difference between local network entries and ones from leader network
data and decide to send a "Server Data Notification" message to
leader. This change ensures that services are updated correctly under
the uncommon config combination where `TMF_NETDATA_SERVICE_ENABLE` is
enabled without `BORDER_ROUTER_ENABLE`.

