### PR TITLE
[posix-trel] allow using fixed TREL UDP port

### DIFF
--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -229,4 +229,15 @@
 #error "OPENTHREAD_CONFIG_POSIX_TREL_USE_NETLINK_SOCKET was removed (no longer applicable with TREL over DNS-SD)."
 #endif
 
+/**
+ * @def OPENTHREAD_POSIX_CONFIG_TREL_UDP_PORT
+ *
+ * This setting configures the TREL UDP port number.
+ * Define as 0 to use an ephemeral port number.
+ *
+ */
+#ifndef OPENTHREAD_POSIX_CONFIG_TREL_UDP_PORT
+#define OPENTHREAD_POSIX_CONFIG_TREL_UDP_PORT 0
+#endif
+
 #endif // OPENTHREAD_PLATFORM_CONFIG_H_

--- a/src/posix/platform/trel.cpp
+++ b/src/posix/platform/trel.cpp
@@ -137,7 +137,7 @@ static void PrepareSocket(uint16_t &aUdpPort)
     memset(&sockAddr, 0, sizeof(sockAddr));
     sockAddr.sin6_family = AF_INET6;
     sockAddr.sin6_addr   = in6addr_any;
-    sockAddr.sin6_port   = 0;
+    sockAddr.sin6_port   = OPENTHREAD_POSIX_CONFIG_TREL_UDP_PORT;
 
     if (bind(sSocket, (struct sockaddr *)&sockAddr, sizeof(sockAddr)) == -1)
     {


### PR DESCRIPTION
This commit adds the configuration `OPENTHREAD_CONFIG_POSIX_TREL_UDP_PORT` to allow TREL to use a fixed UDP port number on Posix platform.