### PR TITLE
[simulation] fix build with RAM settings

### DIFF
--- a/examples/platforms/utils/settings_ram.c
+++ b/examples/platforms/utils/settings_ram.c
@@ -231,7 +231,7 @@ otError otPlatSettingsDelete(otInstance *aInstance, uint16_t aKey, int aIndex)
 
 void otPlatSettingsWipe(otInstance *aInstance)
 {
-    otPlatSettingsInit(aInstance);
+    otPlatSettingsInit(aInstance, NULL, 0);
 }
 
 #endif // OPENTHREAD_SETTINGS_RAM

--- a/script/check-simulation-build-cmake
+++ b/script/check-simulation-build-cmake
@@ -89,6 +89,10 @@ build_all_features()
     # Build Thread 1.2 with full features and OT_ASSERT=OFF
     reset_source
     "$(dirname "$0")"/cmake-build simulation "${options[@]}" -DOT_DUA=ON -DOT_ASSERT=OFF
+
+    # Build with RAM settings
+    reset_source
+    "$(dirname "$0")"/cmake-build simulation -DOT_SETTINGS_RAM=ON
 }
 
 build_toranj()


### PR DESCRIPTION
This PR fixes the build error when `OPENTHREAD_SETTINGS_RAM` is enabled. Also adds a check to prevent this error in the future.