### PR TITLE
[netdata] remove duplicate prefixes in local network data

### DIFF
--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -64,11 +64,6 @@ exit:
     return error;
 }
 
-Error Local::RemoveOnMeshPrefix(const Ip6::Prefix &aPrefix)
-{
-    return RemovePrefix(aPrefix, NetworkDataTlv::kTypeBorderRouter);
-}
-
 bool Local::ContainsOnMeshPrefix(const Ip6::Prefix &aPrefix) const
 {
     const PrefixTlv *tlv;
@@ -95,18 +90,13 @@ exit:
     return error;
 }
 
-Error Local::RemoveHasRoutePrefix(const Ip6::Prefix &aPrefix)
-{
-    return RemovePrefix(aPrefix, NetworkDataTlv::kTypeHasRoute);
-}
-
 Error Local::AddPrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvType, uint16_t aFlags, bool aStable)
 {
     Error      error = kErrorNone;
     uint8_t    subTlvLength;
     PrefixTlv *prefixTlv;
 
-    IgnoreError(RemovePrefix(aPrefix, aSubTlvType));
+    IgnoreError(RemovePrefix(aPrefix));
 
     subTlvLength = (aSubTlvType == NetworkDataTlv::kTypeBorderRouter)
                        ? sizeof(BorderRouterTlv) + sizeof(BorderRouterEntry)
@@ -147,13 +137,12 @@ exit:
     return error;
 }
 
-Error Local::RemovePrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvType)
+Error Local::RemovePrefix(const Ip6::Prefix &aPrefix)
 {
     Error      error = kErrorNone;
     PrefixTlv *tlv;
 
     VerifyOrExit((tlv = FindPrefix(aPrefix)) != nullptr, error = kErrorNotFound);
-    VerifyOrExit(tlv->FindSubTlv(aSubTlvType) != nullptr, error = kErrorNotFound);
     RemoveTlv(tlv);
 
 exit:

--- a/src/core/thread/network_data_local.hpp
+++ b/src/core/thread/network_data_local.hpp
@@ -95,7 +95,7 @@ public:
      * @retval kErrorNotFound   Could not find the Border Router entry.
      *
      */
-    Error RemoveOnMeshPrefix(const Ip6::Prefix &aPrefix);
+    Error RemoveOnMeshPrefix(const Ip6::Prefix &aPrefix) { return RemovePrefix(aPrefix); }
 
     /**
      * This method indicates whether or not the Thread Network Data contains a given on mesh prefix.
@@ -129,7 +129,7 @@ public:
      * @retval kErrorNotFound   Could not find the Border Router entry.
      *
      */
-    Error RemoveHasRoutePrefix(const Ip6::Prefix &aPrefix);
+    Error RemoveHasRoutePrefix(const Ip6::Prefix &aPrefix) { return RemovePrefix(aPrefix); }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
@@ -183,7 +183,7 @@ private:
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
     Error AddPrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvType, uint16_t aFlags, bool aStable);
-    Error RemovePrefix(const Ip6::Prefix &aPrefix, NetworkDataTlv::Type aSubTlvType);
+    Error RemovePrefix(const Ip6::Prefix &aPrefix);
     void  UpdateRloc(PrefixTlv &aPrefixTlv);
 #endif
 


### PR DESCRIPTION
The current implementation attempts to remove existing on-mesh prefix
entry when adding an on-mesh prefix entry with the same prefix. The
same logic exists for external routes. However, the existing code does
not work properly when both on-mesh prefixes and external routes exist
with the same prefix.

This commit simply updates the logic to always remove existing entries
with the same prefix, regardless of whether they are on-mesh prefix or
external route. This is in contrast to trying to keep both on-mesh
prefix and external route with the same prefix simultaneously. There
is no obvious use case for having both the on-mesh prefix and external
route exist at the same time.

Thanks go @gabekassel for identifying this issue.