### PR TITLE
[mle] enhance `ProcessRouteTlv()` to update neighbor pointer

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3153,12 +3153,13 @@ void Mle::HandleAdvertisement(RxInfo &aRxInfo)
 #if OPENTHREAD_FTD
             if (IsFullThreadDevice())
             {
-                RouteTlv route;
-
-                if ((Tlv::FindTlv(aRxInfo.mMessage, route) == kErrorNone) && route.IsValid())
+                switch (Get<MleRouter>().ProcessRouteTlv(aRxInfo))
                 {
-                    // Overwrite Route Data
-                    IgnoreError(Get<MleRouter>().ProcessRouteTlv(route));
+                case kErrorNone:
+                case kErrorNotFound:
+                    break;
+                default:
+                    ExitNow(error = kErrorParse);
                 }
             }
 #endif
@@ -3795,11 +3796,13 @@ void Mle::HandleChildIdResponse(RxInfo &aRxInfo)
 #if OPENTHREAD_FTD
     if (IsFullThreadDevice())
     {
-        RouteTlv route;
-
-        if (Tlv::FindTlv(aRxInfo.mMessage, route) == kErrorNone)
+        switch (Get<MleRouter>().ProcessRouteTlv(aRxInfo))
         {
-            SuccessOrExit(error = Get<MleRouter>().ProcessRouteTlv(route));
+        case kErrorNone:
+        case kErrorNotFound:
+            break;
+        default:
+            ExitNow(error = kErrorParse);
         }
     }
 #endif

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -603,7 +603,8 @@ private:
     void HandleTimeSync(RxInfo &aRxInfo);
 #endif
 
-    Error ProcessRouteTlv(const RouteTlv &aRoute);
+    Error ProcessRouteTlv(RxInfo &aRxInfo);
+    Error ProcessRouteTlv(RxInfo &aRxInfo, RouteTlv &aRouteTlv);
     void  StopAdvertiseTrickleTimer(void);
     Error SendAddressSolicit(ThreadStatusTlv::Status aStatus);
     void  SendAddressRelease(void);


### PR DESCRIPTION
This commit updates `MleRouter::ProcessRouteTlv()` to not only read
and process Route TLV from a received MLE message but also to update
the `mNeighbor` pointer (in `RxInfo`) which indicates the neighbor
from which the MLE message was received.

During processing of Route TLV, the entries in the router table may
shuffle. If the `mNeighbor` was pointing to an entry in `RouterTable`
it may be invalid afterwards. The new implementation ensures that
`mNeighbor` is correctly updated to point the same entry.

This change addresses a scenario where in `Mle::HandleAdvertisement()`
a potentially invalid (or set to null) `mNeighbor` may be checked
after Route TLV is processed from `MleRouter::HandleAdvertisement()`
call.

----

_Background_:
- This change should help make `ProcessRouteTlv()` safer to use.
- Some more detail on the specific situation when processing MLE adv msgs.
   - In `Mle::HandleAdvertisement()` under `FTD` and if device is attached we can call `MleRouter::HandleAdvertisement()`. 
   - The `MleRouter` method can then process Route TLV which can shuffle up the router/neighbor table entries and make any previous `Neighbor *` we have invalid or incorrect.
   - I think we have added in past guard check in `MleRouter::HandleAdvertisement()` where we would set the neighbor to `null` after `ProcessRouteTlv()`:
   ```c++
        if (processRouteTlv)
        {
            SuccessOrExit(error = ProcessRouteTlv(route));
            if (Get<RouterTable>().Contains(*aRxInfo.mNeighbor))
            {
                aRxInfo.mNeighbor = nullptr; // aRxInfo.mNeighbor is no longer valid after `ProcessRouteTlv`
            }
        }
   ```
   - But the issue is that upon returning from `MleRouter` method, the `Mle::HandleAdvertisement` will still use and check the neighbor.
   ```c++
     case kRoleRouter:
    case kRoleLeader:
        VerifyOrExit(aRxInfo.mNeighbor && aRxInfo.mNeighbor->IsStateValid());
        break;
   ```
   - The recent change adding `RxInfo` causes the `mNeighbor` being set to `nullptr` to be passed back to `Mle` method.
   - However, even before this change, we were facing the issue that the neighbor pointer can become  invalid after the call to `ProcessRouteTlv()`.
