### PR TITLE
[mle] handle rx key seq update based on MLE message class

### DIFF
--- a/src/core/thread/child_table.hpp
+++ b/src/core/thread/child_table.hpp
@@ -304,6 +304,22 @@ public:
      */
     bool HasSleepyChildWithAddress(const Ip6::Address &aIp6Address) const;
 
+    /**
+     * This method indicates whether the child table contains a given `Neighbor` instance.
+     *
+     * @param[in]  aNeighbor  A reference to a `Neighbor`.
+     *
+     * @retval TRUE  if @p aNeighbor is a `Child` in the child table.
+     * @retval FALSE if @p aNeighbor is not a `Child` in the child table.
+     *
+     */
+    bool Contains(const Neighbor &aNeighbor) const
+    {
+        const Child *child = static_cast<const Child *>(&aNeighbor);
+
+        return (mChildren <= child) && (child < GetArrayEnd(mChildren));
+    }
+
 private:
     static constexpr uint16_t kMaxChildren = OPENTHREAD_CONFIG_MLE_MAX_CHILDREN;
 

--- a/tests/scripts/thread-cert/Makefile.am
+++ b/tests/scripts/thread-cert/Makefile.am
@@ -175,6 +175,7 @@ EXTRA_DIST                                                         = \
     test_mac802154.py                                                \
     test_mac_scan.py                                                 \
     test_mle.py                                                      \
+    test_mle_msg_key_seq_jump.py                                     \
     test_netdata_publisher.py                                        \
     test_network_data.py                                             \
     test_network_layer.py                                            \
@@ -255,6 +256,7 @@ check_SCRIPTS                                                      = \
     test_mac802154.py                                                \
     test_mac_scan.py                                                 \
     test_mle.py                                                      \
+    test_mle_msg_key_seq_jump.py                                     \
     test_netdata_publisher.py                                        \
     test_network_data.py                                             \
     test_network_layer.py                                            \

--- a/tests/scripts/thread-cert/test_mle_msg_key_seq_jump.py
+++ b/tests/scripts/thread-cert/test_mle_msg_key_seq_jump.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+#
+#  Copyright (c) 2022, The OpenThread Authors.
+#  All rights reserved.
+#
+#  Redistribution and use in source and binary forms, with or without
+#  modification, are permitted provided that the following conditions are met:
+#  1. Redistributions of source code must retain the above copyright
+#     notice, this list of conditions and the following disclaimer.
+#  2. Redistributions in binary form must reproduce the above copyright
+#     notice, this list of conditions and the following disclaimer in the
+#     documentation and/or other materials provided with the distribution.
+#  3. Neither the name of the copyright holder nor the
+#     names of its contributors may be used to endorse or promote products
+#     derived from this software without specific prior written permission.
+#
+#  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+#  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+#  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+#  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+#  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+#  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+#  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+#  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+#  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+#  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+#  POSSIBILITY OF SUCH DAMAGE.
+#
+
+import ipaddress
+import unittest
+
+import command
+import config
+import thread_cert
+
+# Test description:
+#
+#   This test verifies behavior of MLE related to handling of received
+#   larger key sequence based on the MLE message class (authoritative,
+#   or peer).
+#
+#
+# Topology:
+#
+#   leader ---  router
+#    |    \
+#    |     \
+#  child   reed
+#
+
+LEADER = 1
+CHILD = 2
+REED = 3
+ROUTER = 4
+
+
+class MleMsgKeySeqJump(thread_cert.TestCase):
+    USE_MESSAGE_FACTORY = False
+    SUPPORT_NCP = False
+
+    TOPOLOGY = {
+        LEADER: {
+            'name': 'LEADER',
+            'mode': 'rdn',
+        },
+        CHILD: {
+            'name': 'CHILD',
+            'is_mtd': True,
+            'mode': 'rn',
+        },
+        REED: {
+            'name': 'REED',
+            'mode': 'rn'
+        },
+        ROUTER: {
+            'name': 'ROUTER',
+            'mode': 'rdn',
+        },
+    }
+
+    def test(self):
+        leader = self.nodes[LEADER]
+        child = self.nodes[CHILD]
+        reed = self.nodes[REED]
+        router = self.nodes[ROUTER]
+
+        nodes = [leader, child, reed, router]
+
+        #-------------------------------------------------------------------
+        # Form the network.
+
+        for node in nodes:
+            node.set_key_sequence_counter(0)
+
+        leader.start()
+        self.simulator.go(15)
+        self.assertEqual(leader.get_state(), 'leader')
+
+        child.start()
+        reed.start()
+        self.simulator.go(5)
+        self.assertEqual(child.get_state(), 'child')
+        self.assertEqual(reed.get_state(), 'child')
+
+        router.start()
+        self.simulator.go(5)
+        self.assertEqual(router.get_state(), 'router')
+
+        #-------------------------------------------------------------------
+        # Validate the initial key seq counter on all nodes
+
+        for node in nodes:
+            self.assertEqual(node.get_key_sequence_counter(), 0)
+
+        #-------------------------------------------------------------------
+        # Manually increase the key seq on child. Then change MLE mode on
+        # child which triggers a "Child Update Request" to its parent
+        # (leader). The key jump noticed on parent side would trigger an
+        # authoritative MLE Child Update exchange (including challenge and
+        # response TLVs) and causes the parent (leader) to also adopt the
+        # larger key seq.
+
+        child.set_key_sequence_counter(5)
+        self.assertEqual(child.get_key_sequence_counter(), 5)
+
+        child.set_mode('r')
+        self.simulator.go(1)
+
+        self.assertEqual(child.get_key_sequence_counter(), 5)
+        self.assertEqual(leader.get_key_sequence_counter(), 5)
+
+        #-------------------------------------------------------------------
+        # Wait long enough for MLE Advertisement to be sent. This would
+        # trigger reed and router to also notice key seq jump and try to
+        # re-establish link again (using authoritative exchanges). Validate
+        # that all nodes are using the new key seq.
+
+        self.simulator.go(40)
+        for node in nodes:
+            self.assertEqual(node.get_key_sequence_counter(), 5)
+
+        #-------------------------------------------------------------------
+        # Manually increase the key seq on leader. Wait for advertisement
+        # interval. This would trigger both reed and router to notice key
+        # seq jump and try to re-establish link (link request/accept exchange).
+        # Validate that they all adopt the new key seq.
+
+        leader.set_key_sequence_counter(10)
+        self.assertEqual(leader.get_key_sequence_counter(), 10)
+
+        self.simulator.go(40)
+
+        self.assertEqual(router.get_key_sequence_counter(), 10)
+        self.assertEqual(reed.get_key_sequence_counter(), 10)
+
+        #-------------------------------------------------------------------
+        # Change MLE mode on child to trigger a "Child Update Request" exchange
+        # which should then update the key seq on child as well.
+
+        child.set_mode('rn')
+        self.simulator.go(5)
+        self.assertEqual(child.get_key_sequence_counter(), 10)
+
+        #-------------------------------------------------------------------
+        # Stop all other nodes except for leader. Move the leader key seq
+        # forward and then restart all other node. Validate that router,
+        # reed and child all re-attach successfully and adopt the higher key
+        # sequence.
+
+        router.stop()
+        reed.stop()
+        child.stop()
+
+        leader.set_key_sequence_counter(15)
+        self.assertEqual(leader.get_key_sequence_counter(), 15)
+
+        child.start()
+        reed.start()
+        router.start()
+        self.simulator.go(5)
+
+        self.assertEqual(child.get_state(), 'child')
+        self.assertEqual(reed.get_state(), 'child')
+        self.assertEqual(router.get_state(), 'router')
+
+        for node in nodes:
+            self.assertEqual(node.get_key_sequence_counter(), 15)
+
+        #-------------------------------------------------------------------
+        # Stop all other nodes except for leader. Move the child key seq
+        # forward and then restart child. Ensure it re-attached successfully
+        # to leader and that leader adopts the higher key seq counter.
+
+        router.stop()
+        reed.stop()
+        child.stop()
+
+        child.set_key_sequence_counter(20)
+        self.assertEqual(child.get_key_sequence_counter(), 20)
+
+        child.start()
+        self.simulator.go(5)
+
+        self.assertEqual(child.get_state(), 'child')
+        self.assertEqual(leader.get_key_sequence_counter(), 20)
+
+        #-------------------------------------------------------------------
+        # Restart router and reed and ensure they are re-attached and get the
+        # higher key seq counter.
+
+        router.start()
+        reed.start()
+
+        self.simulator.go(5)
+        self.assertEqual(router.get_state(), 'router')
+        self.assertEqual(reed.get_state(), 'child')
+
+        self.assertEqual(router.get_key_sequence_counter(), 20)
+        self.assertEqual(reed.get_key_sequence_counter(), 20)
+
+        #-------------------------------------------------------------------
+        # Move forward the key seq counter by one on router. Wait for
+        # advertisement interval. Validate that leader adopts the higher
+        # counter value.
+
+        router.set_key_sequence_counter(21)
+        self.assertEqual(router.get_key_sequence_counter(), 21)
+
+        self.simulator.go(40)
+        self.assertEqual(leader.get_key_sequence_counter(), 21)
+        self.assertEqual(reed.get_key_sequence_counter(), 21)
+
+        child.set_mode('r')
+        self.simulator.go(2)
+        self.assertEqual(child.get_key_sequence_counter(), 21)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This commit implements new mechanism in `Mle` related to key sequence
update when an MLE message is received with a larger key sequence
compared to the one being used by `KeyManager`. The MLE messages are
categorized into classes of Authoritative, Tentative, or Peer
depending on the MLE command type and included TLVs. The class
determines different actions: ~Tentative is used where the sender of
MLE message may not be sure that its key seq is in sync with the rest
of the Thread network, so the receiver will not adopt the key seq.~
Authoritative indicates sender is confident that its key seq is in
sync, so receiver will adopt the larger key seq. Peer class is used
when both sender and receiver think they are in sync. In this case,
if the MLE message is from a known neighbor, receiver will adopt the
larger key seq if the difference is one, otherwise it will try to
re-establish link with the neighbor using Authoritative message
exchanges (e.g. sending Link Request or Child Update Request).

----

- This is related to [SPEC-1025](https://threadgroup.atlassian.net/browse/SPEC-1025) and Thread spec sections 7.3.12

----

Here are how different MLE message are categorized into different calsses:

```
Advertisement                  Peer
DataRequest                    Peer
DataResponse                   Peer
ParentRequest                  Peer
ParentResponse                 Authoritative      (always includes the ResponseTlv)
ChildIdRequest                 Authoritative      (always includes the ResponseTlv)
ChildIdResponse                Peer
Announce                       Peer
ChildUpdateRequest             Peer 
ChildUpdateResponse            Authoritative if has ResponseTlv, Peer otherwise.
LinkRequest                    Peer
LinkAccept                     Authoritative     (only if has ResponseTlv)
LinkAcceptAndRequest           Authoritative     (only if has ResponseTlv)
LinkMetricsManagementRequest   Peer
LinkMetricsManagementResponse  Peer
LinkProbe                      Peer
TimeSync                       Peer              (OT only for Time Sync feature).
```

High-level algorithm on when to adopt a higher rx key seq:

```
A) If rx key seq > dev key seq 
   ~Tentative: Do not adopt the rx key seq~
   Authoritative: Do adopt the rx key seq
   Peer:
           If from a known neighbor 
               If delta > 1, do not adopt, try to re-establish link
               if delta = 1, do adopt
           else
               do not adopt

B) If rx key seq == dev key seq
    No changes

C) If rx key seq < dev key seq
    Do not adopt (still process the message)
```

The "re-establish link" mechasnim:
```
If device is child and neighbor (from which MLE msg is rcved) is parent -> Send Child Update Request with Challenge TLV
If device is FTD:
    If neighbor is a router -> Send Link Request (include challenge TLV)
    If neighbor is a child of device -> Send Child Update Request (with Challenge TLV).
```

