### PR TITLE
[csl] allow scheduling delayed reception in any radio state

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -1165,18 +1165,19 @@ void SubMac::HandleCslTimer(void)
         }
 
         Get<Radio>().UpdateCslSampleTime(mCslSampleTime.GetValue());
-        if (mState == kStateCslSample)
+
+        if (RadioSupportsReceiveTiming())
         {
-            if (RadioSupportsReceiveTiming())
+            if (mState != kStateDisabled && mCslChannel)
             {
                 IgnoreError(Get<Radio>().ReceiveAt(mCslChannel, mCslSampleTime.GetValue() - periodUs - timeAhead,
                                                    timeAhead + timeAfter));
             }
-            else
-            {
-                IgnoreError(Get<Radio>().Receive(mCslChannel));
-                LogDebg("CSL sample %u, duration %u", mCslTimer.GetNow().GetValue(), timeAhead + timeAfter);
-            }
+        }
+        else if (mState == kStateCslSample)
+        {
+            IgnoreError(Get<Radio>().Receive(mCslChannel));
+            LogDebg("CSL sample %u, duration %u", mCslTimer.GetNow().GetValue(), timeAhead + timeAfter);
         }
         break;
 


### PR DESCRIPTION
When radio supports receive timing it makes no sense to restrict
scheduling future reception slots while the radio state is for
instance transmitting or receiving, as long as CSL parameters are
properly configured.