### PR TITLE
[github-actions] do not delete artifacts if coverage upload fails

### DIFF
--- a/.github/workflows/otbr.yml
+++ b/.github/workflows/otbr.yml
@@ -222,7 +222,6 @@ jobs:
 
   delete-coverage-artifacts:
     needs: upload-coverage
-    if: always()
     runs-on: ubuntu-20.04
     steps:
     - uses: geekyeggo/delete-artifact@1-glob-support

--- a/.github/workflows/posix.yml
+++ b/.github/workflows/posix.yml
@@ -300,7 +300,6 @@ jobs:
 
   delete-coverage-artifacts:
     needs: upload-coverage
-    if: always()
     runs-on: ubuntu-20.04
     steps:
     - uses: geekyeggo/delete-artifact@1-glob-support

--- a/.github/workflows/simulation-1.1.yml
+++ b/.github/workflows/simulation-1.1.yml
@@ -379,7 +379,6 @@ jobs:
 
   delete-coverage-artifacts:
     needs: upload-coverage
-    if: always()
     runs-on: ubuntu-20.04
     steps:
     - uses: geekyeggo/delete-artifact@1-glob-support

--- a/.github/workflows/simulation-1.2.yml
+++ b/.github/workflows/simulation-1.2.yml
@@ -330,7 +330,6 @@ jobs:
 
   delete-coverage-artifacts:
     needs: upload-coverage
-    if: always()
     runs-on: ubuntu-20.04
     steps:
     - uses: geekyeggo/delete-artifact@1-glob-support

--- a/.github/workflows/toranj.yml
+++ b/.github/workflows/toranj.yml
@@ -146,7 +146,6 @@ jobs:
 
   delete-coverage-artifacts:
     needs: upload-coverage
-    if: always()
     runs-on: ubuntu-20.04
     steps:
     - uses: geekyeggo/delete-artifact@1-glob-support


### PR DESCRIPTION
Coverage upload can fail intermittently for various reasons. Do not
delete coverage artifacts if upload fails to avoid needing to re-run
the entire workflow.