### PR TITLE
[mesh-local-prefix] remove coupling to Extended PAN ID

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -63,14 +63,10 @@ otError otThreadSetExtendedPanId(otInstance *aInstance, const otExtendedPanId *a
     Error                         error    = kErrorNone;
     Instance &                    instance = AsCoreType(aInstance);
     const MeshCoP::ExtendedPanId &extPanId = AsCoreType(aExtendedPanId);
-    Mle::MeshLocalPrefix          prefix;
 
     VerifyOrExit(instance.Get<Mle::MleRouter>().IsDisabled(), error = kErrorInvalidState);
 
     instance.Get<MeshCoP::ExtendedPanIdManager>().SetExtPanId(extPanId);
-
-    prefix.SetFromExtendedPanId(extPanId);
-    instance.Get<Mle::MleRouter>().SetMeshLocalPrefix(prefix);
 
     instance.Get<MeshCoP::ActiveDatasetManager>().Clear();
     instance.Get<MeshCoP::PendingDatasetManager>().Clear();

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -370,7 +370,10 @@ public:
          * @returns The Mesh Local Prefix in the Dataset.
          *
          */
-        const Mle::MeshLocalPrefix &GetMeshLocalPrefix(void) const { return AsCoreType(&mMeshLocalPrefix); }
+        const Ip6::NetworkPrefix &GetMeshLocalPrefix(void) const
+        {
+            return static_cast<const Ip6::NetworkPrefix &>(mMeshLocalPrefix);
+        }
 
         /**
          * This method sets the Mesh Local Prefix in the Dataset.
@@ -378,7 +381,7 @@ public:
          * @param[in] aMeshLocalPrefix   A Mesh Local Prefix.
          *
          */
-        void SetMeshLocalPrefix(const Mle::MeshLocalPrefix &aMeshLocalPrefix)
+        void SetMeshLocalPrefix(const Ip6::NetworkPrefix &aMeshLocalPrefix)
         {
             mMeshLocalPrefix                      = aMeshLocalPrefix;
             mComponents.mIsMeshLocalPrefixPresent = true;

--- a/src/core/meshcop/dataset_manager_ftd.cpp
+++ b/src/core/meshcop/dataset_manager_ftd.cpp
@@ -73,20 +73,20 @@ Error DatasetManager::AppendMleDatasetTlv(Message &aMessage) const
 
 Error DatasetManager::HandleSet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
-    Tlv                  tlv;
-    uint16_t             offset                   = aMessage.GetOffset();
-    bool                 isUpdateFromCommissioner = false;
-    bool                 doesAffectConnectivity   = false;
-    bool                 doesAffectNetworkKey     = false;
-    bool                 hasNetworkKey            = false;
-    StateTlv::State      state                    = StateTlv::kReject;
-    Dataset              dataset;
-    Timestamp            activeTimestamp;
-    ChannelTlv           channel;
-    uint16_t             sessionId;
-    Mle::MeshLocalPrefix meshLocalPrefix;
-    NetworkKey           networkKey;
-    uint16_t             panId;
+    Tlv                tlv;
+    uint16_t           offset                   = aMessage.GetOffset();
+    bool               isUpdateFromCommissioner = false;
+    bool               doesAffectConnectivity   = false;
+    bool               doesAffectNetworkKey     = false;
+    bool               hasNetworkKey            = false;
+    StateTlv::State    state                    = StateTlv::kReject;
+    Dataset            dataset;
+    Timestamp          activeTimestamp;
+    ChannelTlv         channel;
+    uint16_t           sessionId;
+    Ip6::NetworkPrefix meshLocalPrefix;
+    NetworkKey         networkKey;
+    uint16_t           panId;
 
     VerifyOrExit(Get<Mle::MleRouter>().IsLeader());
 

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -682,7 +682,7 @@ private:
  *
  */
 OT_TOOL_PACKED_BEGIN
-class MeshLocalPrefixTlv : public Tlv, public SimpleTlvInfo<Tlv::kMeshLocalPrefix, Mle::MeshLocalPrefix>
+class MeshLocalPrefixTlv : public Tlv, public SimpleTlvInfo<Tlv::kMeshLocalPrefix, Ip6::NetworkPrefix>
 {
 public:
     /**
@@ -718,7 +718,7 @@ public:
      * @returns The Mesh Local Prefix value.
      *
      */
-    const Mle::MeshLocalPrefix &GetMeshLocalPrefix(void) const { return mMeshLocalPrefix; }
+    const Ip6::NetworkPrefix &GetMeshLocalPrefix(void) const { return mMeshLocalPrefix; }
 
     /**
      * This method sets the Mesh Local Prefix value.
@@ -726,10 +726,10 @@ public:
      * @param[in]  aMeshLocalPrefix  A pointer to the Mesh Local Prefix value.
      *
      */
-    void SetMeshLocalPrefix(const Mle::MeshLocalPrefix &aMeshLocalPrefix) { mMeshLocalPrefix = aMeshLocalPrefix; }
+    void SetMeshLocalPrefix(const Ip6::NetworkPrefix &aMeshLocalPrefix) { mMeshLocalPrefix = aMeshLocalPrefix; }
 
 private:
-    Mle::MeshLocalPrefix mMeshLocalPrefix;
+    Ip6::NetworkPrefix mMeshLocalPrefix;
 } OT_TOOL_PACKED_END;
 
 class SteeringData;

--- a/src/core/net/dhcp6_server.hpp
+++ b/src/core/net/dhcp6_server.hpp
@@ -167,7 +167,7 @@ private:
          * @param[in]  aContextId        The 6LoWPAN Context ID.
          *
          */
-        void Set(const Ip6::Prefix &aPrefix, const Mle::MeshLocalPrefix &aMeshLocalPrefix, uint8_t aContextId)
+        void Set(const Ip6::Prefix &aPrefix, const Ip6::NetworkPrefix &aMeshLocalPrefix, uint8_t aContextId)
         {
             mPrefix = aPrefix;
 

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -1009,6 +1009,7 @@ private:
 
 } // namespace Ip6
 
+DefineCoreType(otIp6NetworkPrefix, Ip6::NetworkPrefix);
 DefineCoreType(otIp6Prefix, Ip6::Prefix);
 DefineCoreType(otIp6InterfaceIdentifier, Ip6::InterfaceIdentifier);
 DefineCoreType(otIp6Address, Ip6::Address);

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -64,6 +64,10 @@ namespace Mle {
 
 RegisterLogModule("Mle");
 
+const otMeshLocalPrefix Mle::sMeshLocalPrefixInit = {
+    {0xfd, 0xde, 0xad, 0x00, 0xbe, 0xef, 0x00, 0x00},
+};
+
 Mle::Mle(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mRetrieveNewNetworkData(false)
@@ -114,8 +118,6 @@ Mle::Mle(Instance &aInstance)
     , mParentResponseCb(nullptr)
     , mParentResponseCbContext(nullptr)
 {
-    MeshLocalPrefix meshLocalPrefix;
-
     mParent.Init(aInstance);
     mParentCandidate.Init(aInstance);
 
@@ -129,8 +131,6 @@ Mle::Mle(Instance &aInstance)
     mLinkLocal64.GetAddress().SetToLinkLocalAddress(Get<Mac::Mac>().GetExtAddress());
 
     mLeaderAloc.InitAsThreadOriginRealmLocalScope();
-
-    meshLocalPrefix.SetFromExtendedPanId(Get<MeshCoP::ExtendedPanIdManager>().GetExtPanId());
 
     mMeshLocal64.InitAsThreadOriginRealmLocalScope();
     mMeshLocal64.GetAddress().GetIid().GenerateRandom();
@@ -150,7 +150,7 @@ Mle::Mle(Instance &aInstance)
     mRealmLocalAllThreadNodes.GetAddress().mFields.m16[0] = HostSwap16(0xff33);
     mRealmLocalAllThreadNodes.GetAddress().mFields.m16[7] = HostSwap16(0x0001);
 
-    SetMeshLocalPrefix(meshLocalPrefix);
+    SetMeshLocalPrefix(AsCoreType(&sMeshLocalPrefixInit));
 
     // `SetMeshLocalPrefix()` also adds the Mesh-Local EID and subscribes
     // to the Link- and Realm-Local All Thread Nodes multicast addresses.
@@ -823,7 +823,7 @@ void Mle::UpdateLinkLocalAddress(void)
     Get<Notifier>().Signal(kEventThreadLinkLocalAddrChanged);
 }
 
-void Mle::SetMeshLocalPrefix(const MeshLocalPrefix &aMeshLocalPrefix)
+void Mle::SetMeshLocalPrefix(const Ip6::NetworkPrefix &aMeshLocalPrefix)
 {
     VerifyOrExit(GetMeshLocalPrefix() != aMeshLocalPrefix,
                  Get<Notifier>().SignalIfFirst(kEventThreadMeshLocalAddrChanged));

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -327,10 +327,7 @@ public:
      * @returns A reference to the Mesh Local Prefix.
      *
      */
-    const MeshLocalPrefix &GetMeshLocalPrefix(void) const
-    {
-        return static_cast<const MeshLocalPrefix &>(mMeshLocal16.GetAddress().GetPrefix());
-    }
+    const Ip6::NetworkPrefix &GetMeshLocalPrefix(void) const { return mMeshLocal16.GetAddress().GetPrefix(); }
 
     /**
      * This method sets the Mesh Local Prefix.
@@ -338,7 +335,7 @@ public:
      * @param[in]  aMeshLocalPrefix  A reference to the Mesh Local Prefix.
      *
      */
-    void SetMeshLocalPrefix(const MeshLocalPrefix &aMeshLocalPrefix);
+    void SetMeshLocalPrefix(const Ip6::NetworkPrefix &aMeshLocalPrefix);
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     /**
@@ -1755,7 +1752,7 @@ private:
         void     MarkAsNotInUse(void) { SetAloc16(kNotInUse); }
         uint16_t GetAloc16(void) const { return GetAddress().GetIid().GetLocator(); }
         void     SetAloc16(uint16_t aAloc16) { GetAddress().GetIid().SetLocator(aAloc16); }
-        void     ApplyMeshLocalPrefix(const MeshLocalPrefix &aPrefix) { GetAddress().SetPrefix(aPrefix); }
+        void     ApplyMeshLocalPrefix(const Ip6::NetworkPrefix &aPrefix) { GetAddress().SetPrefix(aPrefix); }
     };
 #endif
 
@@ -1901,6 +1898,8 @@ private:
 #endif
 
     otMleCounters mCounters;
+
+    static const otMeshLocalPrefix sMeshLocalPrefixInit;
 
     Ip6::Netif::UnicastAddress   mLinkLocal64;
     Ip6::Netif::UnicastAddress   mMeshLocal64;

--- a/src/core/thread/mle_types.cpp
+++ b/src/core/thread/mle_types.cpp
@@ -63,13 +63,5 @@ DeviceMode::InfoString DeviceMode::ToString(void) const
     return string;
 }
 
-void MeshLocalPrefix::SetFromExtendedPanId(const MeshCoP::ExtendedPanId &aExtendedPanId)
-{
-    m8[0] = 0xfd;
-    memcpy(&m8[1], aExtendedPanId.m8, 5);
-    m8[6] = 0x00;
-    m8[7] = 0x00;
-}
-
 } // namespace Mle
 } // namespace ot

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -416,24 +416,6 @@ private:
 };
 
 /**
- * This class represents a Mesh Local Prefix.
- *
- */
-OT_TOOL_PACKED_BEGIN
-class MeshLocalPrefix : public Ip6::NetworkPrefix
-{
-public:
-    /**
-     * This method derives and sets the Mesh Local Prefix from an Extended PAN ID.
-     *
-     * @param[in] aExtendedPanId   An Extended PAN ID.
-     *
-     */
-    void SetFromExtendedPanId(const MeshCoP::ExtendedPanId &aExtendedPanId);
-
-} OT_TOOL_PACKED_END;
-
-/**
  * This class represents the Thread Leader Data.
  *
  */
@@ -578,7 +560,6 @@ typedef Mac::Key Key;
 
 } // namespace Mle
 
-DefineCoreType(otMeshLocalPrefix, Mle::MeshLocalPrefix);
 DefineCoreType(otLeaderData, Mle::LeaderData);
 DefineMapEnum(otDeviceRole, Mle::DeviceRole);
 

--- a/tests/scripts/thread-cert/config.py
+++ b/tests/scripts/thread-cert/config.py
@@ -44,7 +44,6 @@ import simulator
 import sniffer
 from tlvs_parsing import SubTlvsFactory
 
-# This extended address will generate the MESH_LOCAL_PREFIX
 MESH_LOCAL_PREFIX = 'fd00:db8::/64'
 MESH_LOCAL_PREFIX_REGEX_PATTERN = '^fd00:0?db8:0{0,4}:0{0,4}'
 ROUTING_LOCATOR = '64/:0:ff:fe00:/16'

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -106,7 +106,7 @@ static void Init(void)
 {
     otMeshLocalPrefix meshLocalPrefix = {{0xfd, 0x00, 0xca, 0xfe, 0xfa, 0xce, 0x12, 0x34}};
 
-    sInstance->Get<Mle::MleRouter>().SetMeshLocalPrefix(static_cast<Mle::MeshLocalPrefix &>(meshLocalPrefix));
+    sInstance->Get<Mle::MleRouter>().SetMeshLocalPrefix(static_cast<Ip6::NetworkPrefix &>(meshLocalPrefix));
 
     // Emulate global prefixes with contextes.
     uint8_t mockNetworkData[] = {


### PR DESCRIPTION
Deriving the Mesh Local Prefix from the Extended PAN ID was carried
forward from legacy implementations. Removing this coupling to conform
to the existing Thread Specification.