### PR TITLE
[toranj] update `test-018-child-supervision` to make it more robust

### DIFF
--- a/tests/toranj/ncp/test-018-child-supervision.py
+++ b/tests/toranj/ncp/test-018-child-supervision.py
@@ -98,6 +98,8 @@ child_table = wpan.parse_child_table_result(parent.get(wpan.WPAN_THREAD_CHILD_TA
 verify(len(child_table) == 1)
 verify(int(child_table[0].timeout, 0) == CHILD_TIMEOUT)
 
+time.sleep(1)
+
 # Enabling allowlisting on parent
 #
 # Since child is not in parent's allowlist, the data polls from child


### PR DESCRIPTION
This commit adds a small wait time between steps in the toranj
`test-018-child-supervision` to help make the test more robust. The
test adds some extra time for child to finish the "child update
request/response" exchange with the parent before enabling MAC
filter.

----

Background
- This was discovered from PR: https://github.com/openthread/openthread/pull/7686
- Stress test of the change here : https://github.com/abtink/openthread/runs/6379042520?check_suite_focus=true