### PR TITLE
[routing-manager] prefer OMR prefix with higher Pref

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -405,9 +405,9 @@ void RoutingManager::EvaluateOmrPrefix(OmrPrefixArray &aNewOmrPrefixes)
 {
     NetworkData::Iterator           iterator = NetworkData::kIteratorInit;
     NetworkData::OnMeshPrefixConfig onMeshPrefixConfig;
-    Ip6::Prefix *                   electedOmrPrefix = nullptr;
-    signed int                      electedOmrPrefixPreference;
-    Ip6::Prefix *                   publishedLocalOmrPrefix = nullptr;
+    Ip6::Prefix *                   electedOmrPrefix           = nullptr;
+    signed int                      electedOmrPrefixPreference = 0;
+    Ip6::Prefix *                   publishedLocalOmrPrefix    = nullptr;
 
     OT_ASSERT(mIsRunning);
 
@@ -469,8 +469,8 @@ void RoutingManager::EvaluateOmrPrefix(OmrPrefixArray &aNewOmrPrefixes)
         }
         else if (IsOmrPrefixAddedToLocalNetworkData())
         {
-            LogInfo("EvaluateOmrPrefix: There is already a smaller OMR prefix %s in the Thread network",
-                    electedOmrPrefix->ToString().AsCString());
+            LogInfo("EvaluateOmrPrefix: There is already a preferred OMR prefix %s (pref=%d) in the Thread network",
+                    electedOmrPrefix->ToString().AsCString(), electedOmrPrefixPreference);
 
             UnpublishLocalOmrPrefix();
 

--- a/tests/scripts/thread-cert/border_router/test_manual_omr_prefix.py
+++ b/tests/scripts/thread-cert/border_router/test_manual_omr_prefix.py
@@ -80,7 +80,7 @@ class ManualOmrsPrefix(thread_cert.TestCase):
         # Add a smaller OMR prefix. Verify BR_1 withdraws its OMR prefix.
         self._test_manual_omr_prefix('2001::/64', 'paros', expect_withdraw=True)
         # Add a bigger OMR prefix. Verify BR_1 does not withdraw its OMR prefix.
-        self._test_manual_omr_prefix('fdff:ffff:1::/64', 'paros', expect_withdraw=False)
+        self._test_manual_omr_prefix('fdff:ffff:1::/64', 'paros', expect_withdraw=False, prf='med')
         # Add a high preference bigger OMR prefix. Verify BR_1 withdraws its OMR prefix.
         self._test_manual_omr_prefix('fdff:ffff:2::/64', 'paros', expect_withdraw=True, prf='high')
         # Add a smaller but invalid OMR prefix (P_on_mesh = 0). Verify BR_1 does not withdraw its OMR prefix.


### PR DESCRIPTION
This commit fixes the issue that the OMR prefix with higher Pref is not preferred. 