### PR TITLE
[routing-manager] use sizeof explicit type `Ip6::Icmp::Header`

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -340,9 +340,10 @@ void RoutingManager::RecvIcmp6Message(uint32_t            aInfraIfIndex,
 
     VerifyOrExit(IsInitialized() && mIsRunning, error = kErrorDrop);
     VerifyOrExit(aInfraIfIndex == mInfraIfIndex, error = kErrorDrop);
-    VerifyOrExit(aBuffer != nullptr && aBufferLength >= sizeof(*icmp6Header), error = kErrorParse);
+    VerifyOrExit(aBuffer != nullptr, error = kErrorInvalidArgs);
 
     icmp6Header = reinterpret_cast<const Ip6::Icmp::Header *>(aBuffer);
+    VerifyOrExit(aBufferLength >= sizeof(*icmp6Header), error = kErrorParse);
 
     switch (icmp6Header->GetType())
     {

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -340,7 +340,7 @@ void RoutingManager::RecvIcmp6Message(uint32_t            aInfraIfIndex,
 
     VerifyOrExit(IsInitialized() && mIsRunning, error = kErrorDrop);
     VerifyOrExit(aInfraIfIndex == mInfraIfIndex, error = kErrorDrop);
-    VerifyOrExit(aBuffer != nullptr && aBufferLength >= sizeof(*icmp6Header), error = kErrorParse);
+    VerifyOrExit(aBuffer != nullptr && aBufferLength >= sizeof(Ip6::Icmp::Header), error = kErrorParse);
 
     icmp6Header = reinterpret_cast<const Ip6::Icmp::Header *>(aBuffer);
 

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -340,10 +340,9 @@ void RoutingManager::RecvIcmp6Message(uint32_t            aInfraIfIndex,
 
     VerifyOrExit(IsInitialized() && mIsRunning, error = kErrorDrop);
     VerifyOrExit(aInfraIfIndex == mInfraIfIndex, error = kErrorDrop);
-    VerifyOrExit(aBuffer != nullptr, error = kErrorInvalidArgs);
+    VerifyOrExit(aBuffer != nullptr && aBufferLength >= sizeof(*icmp6Header), error = kErrorParse);
 
     icmp6Header = reinterpret_cast<const Ip6::Icmp::Header *>(aBuffer);
-    VerifyOrExit(aBufferLength >= sizeof(*icmp6Header), error = kErrorParse);
 
     switch (icmp6Header->GetType())
     {


### PR DESCRIPTION
While using sizeof(*icmp6Header) before it is initialized to something
is not wrong, it is possible this will be flagged by some code checker
tools. Lets check using direct type.