### PR TITLE
[routing-manager] derive on-link prefix from Extended PAN ID

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -317,7 +317,7 @@ private:
     bool  IsEnabled(void) const { return mIsEnabled; }
     Error LoadOrGenerateRandomBrUlaPrefix(void);
     void  GenerateOmrPrefix(void);
-    Error LoadOrGenerateRandomOnLinkPrefix(void);
+    void  GenerateOnLinkPrefix(void);
 
     const Ip6::Prefix *EvaluateOnLinkPrefix(void);
 

--- a/tests/scripts/thread-cert/border_router/test_multi_border_routers.py
+++ b/tests/scripts/thread-cert/border_router/test_multi_border_routers.py
@@ -191,12 +191,13 @@ class MultiBorderRouters(thread_cert.TestCase):
         br2_omr_prefix = br2.get_br_omr_prefix()
         self.assertEqual(br2_omr_prefix, br2.get_netdata_omr_prefixes()[0])
 
-        # Only BR2 will keep the route for BR1's on-link prefix
-        # and add route for on-link prefix of its own.
-        self.assertEqual(len(br1.get_netdata_non_nat64_prefixes()), 2)
-        self.assertEqual(len(router1.get_netdata_non_nat64_prefixes()), 2)
-        self.assertEqual(len(br2.get_netdata_non_nat64_prefixes()), 2)
-        self.assertEqual(len(router2.get_netdata_non_nat64_prefixes()), 2)
+        # There should be no changes to the external route for the
+        # on-link prefix, given that the on-link prefix is derived
+        # from the Extended PAN ID.
+        self.assertEqual(len(br1.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(router1.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(br2.get_netdata_non_nat64_prefixes()), 1)
+        self.assertEqual(len(router2.get_netdata_non_nat64_prefixes()), 1)
 
         br2_on_link_prefix = br2.get_br_on_link_prefix()
         self.assertEqual(set(map(IPv6Network, br2.get_netdata_non_nat64_prefixes())),

--- a/tests/scripts/thread-cert/border_router/test_single_border_router.py
+++ b/tests/scripts/thread-cert/border_router/test_single_border_router.py
@@ -28,6 +28,7 @@
 #
 import logging
 import unittest
+from ipaddress import IPv6Network
 
 import config
 import thread_cert
@@ -325,6 +326,25 @@ class SingleBorderRouter(thread_cert.TestCase):
         self.assertTrue(router.ping(host.get_ip6_address(config.ADDRESS_TYPE.ONLINK_GUA)[0]))
         self.assertTrue(router.ping(host.get_ip6_address(config.ADDRESS_TYPE.ONLINK_ULA)[0]))
         self.assertTrue(host.ping(router.get_ip6_address(config.ADDRESS_TYPE.OMR)[0], backbone=True))
+
+        #
+        # Case 7. Test if Border Router changes on-link prefix when
+        #         Extended PAN ID changes.
+        #
+
+        prefixA = br.get_br_on_link_prefix()
+
+        router.commissioner_start()
+        self.simulator.go(5)
+
+        router.send_mgmt_active_set(
+            active_timestamp=100,
+            extended_panid='0001020304050607',
+        )
+        self.simulator.go(10)
+
+        prefixB = br.get_br_on_link_prefix()
+        self.assertNotEqual(IPv6Network(prefixA), IPv6Network(prefixB))
 
 
 if __name__ == '__main__':

--- a/tests/scripts/thread-cert/border_router/test_vicarious_router_solicit.py
+++ b/tests/scripts/thread-cert/border_router/test_vicarious_router_solicit.py
@@ -67,6 +67,7 @@ class MultiThreadNetworks(thread_cert.TestCase):
             'version': '1.2',
             'channel': CHANNEL1,
             'router_selection_jitter': 1,
+            'extended_panid': '0001020304050607'
         },
         ROUTER1: {
             'name': 'Router_1',
@@ -74,6 +75,7 @@ class MultiThreadNetworks(thread_cert.TestCase):
             'version': '1.2',
             'channel': CHANNEL1,
             'router_selection_jitter': 1,
+            'extended_panid': '0001020304050607'
         },
         BR2: {
             'name': 'BR_2',
@@ -82,6 +84,7 @@ class MultiThreadNetworks(thread_cert.TestCase):
             'version': '1.2',
             'channel': CHANNEL2,
             'router_selection_jitter': 1,
+            'extended_panid': '08090a0b0c0d0e0f'
         },
         ROUTER2: {
             'name': 'Router_2',
@@ -89,6 +92,7 @@ class MultiThreadNetworks(thread_cert.TestCase):
             'version': '1.2',
             'channel': CHANNEL2,
             'router_selection_jitter': 1,
+            'extended_panid': '08090a0b0c0d0e0f'
         },
         HOST: {
             'name': 'Host',

--- a/tests/scripts/thread-cert/thread_cert.py
+++ b/tests/scripts/thread-cert/thread_cert.py
@@ -183,6 +183,8 @@ class TestCase(NcpSupportMixin, unittest.TestCase):
             self.nodes[i].set_panid(params['panid'])
             self.nodes[i].set_mode(params['mode'])
 
+            if 'extended_panid' in params:
+                self.nodes[i].set_extpanid(params['extended_panid'])
             if 'partition_id' in params:
                 self.nodes[i].set_preferred_partition_id(params['partition_id'])
             if 'channel' in params:


### PR DESCRIPTION
To align with latest Thread Specification.