### PR TITLE
[thci] remove unused methods

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -2710,16 +2710,6 @@ class OpenThreadTHCI(object):
         return self.__executeCommand(cmd)[-1] == 'Done'
 
     @API
-    def setActiveDataset(self, listActiveDataset=()):
-        # Unused by the scripts
-        pass
-
-    @API
-    def setCommisionerMode(self):
-        # Unused by the scripts
-        pass
-
-    @API
     def setPSKc(self, strPSKc):
         cmd = 'dataset pskc %s' % strPSKc
         self.hasActiveDatasetToCommit = True


### PR DESCRIPTION
`setActiveDataset` and `setCommisionerMode` have been removed from
the `iThci` abstract class in the latest harness release.