### PR TITLE
[dnssd-server] add `otDnssdGetCounters` for telemetry

### DIFF
--- a/include/openthread/dnssd_server.h
+++ b/include/openthread/dnssd_server.h
@@ -148,6 +148,22 @@ typedef enum
 } otDnssdQueryType;
 
 /**
+ * This structure contains the counters of DNS-SD server.
+ *
+ */
+typedef struct otDnssdCounters
+{
+    uint32_t mSuccessResponse;        ///< The number of successful responses
+    uint32_t mServerFailureResponse;  ///< The number of server failure responses
+    uint32_t mFormatErrorResponse;    ///< The number of format error responses
+    uint32_t mNameErrorResponse;      ///< The number of name error responses
+    uint32_t mNotImplementedResponse; ///< The number of 'not implemented' responses
+    uint32_t mOtherResponse;          ///< The number of other responses
+
+    uint32_t mResolvedBySrp; ///< The number of queries completely resolved by the local SRP server
+} otDnssdCounters;
+
+/**
  * This function sets DNS-SD server query callbacks.
  *
  * The DNS-SD server calls @p aSubscribe to subscribe to a service or service instance to resolve a DNS-SD query and @p
@@ -218,6 +234,16 @@ const otDnssdQuery *otDnssdGetNextQuery(otInstance *aInstance, const otDnssdQuer
  *
  */
 otDnssdQueryType otDnssdGetQueryTypeAndName(const otDnssdQuery *aQuery, char (*aNameOutput)[OT_DNS_MAX_NAME_SIZE]);
+
+/**
+ * This function returns the counters of the DNS-SD server.
+ *
+ * @param[in]  aInstance  The OpenThread instance structure.
+ *
+ * @returns  A pointer to the counters of the DNS-SD server.
+ *
+ */
+const otDnssdCounters *otDnssdGetCounters(otInstance *aInstance);
 
 /**
  * @}

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (211)
+#define OPENTHREAD_API_VERSION (212)
 
 /**
  * @addtogroup api-instance

--- a/src/core/api/dns_server_api.cpp
+++ b/src/core/api/dns_server_api.cpp
@@ -81,4 +81,9 @@ otDnssdQueryType otDnssdGetQueryTypeAndName(const otDnssdQuery *aQuery, char (*a
     return MapEnum(Dns::ServiceDiscovery::Server::GetQueryTypeAndName(aQuery, *aNameOutput));
 }
 
+const otDnssdCounters *otDnssdGetCounters(otInstance *aInstance)
+{
+    return &AsCoreType(aInstance).Get<Dns::ServiceDiscovery::Server>().GetCounters();
+}
+
 #endif // OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -68,6 +68,14 @@ class Server : public InstanceLocator, private NonCopyable
 
 public:
     /**
+     * This class contains the counters of the DNS-SD server.
+     *
+     */
+    class Counters : public otDnssdCounters, public Clearable<Counters>
+    {
+    };
+
+    /**
      * This enumeration specifies a DNS-SD query type.
      *
      */
@@ -154,6 +162,14 @@ public:
      *
      */
     static DnsQueryType GetQueryTypeAndName(const otDnssdQuery *aQuery, char (&aName)[Name::kMaxNameSize]);
+
+    /**
+     * This method returns the counters of the DNS-SD server.
+     *
+     * @returns  A reference to the `Counters` instance.
+     *
+     */
+    const Counters &GetCounters(void) const { return mCounters; };
 
 private:
     class NameCompressInfo : public Clearable<NameCompressInfo>
@@ -273,7 +289,7 @@ private:
      * This class contains the compress information for a dns packet.
      *
      */
-    class QueryTransaction
+    class QueryTransaction : public InstanceLocatorInit
     {
     public:
         explicit QueryTransaction(void)
@@ -284,7 +300,8 @@ private:
         void                    Init(const Header &          aResponseHeader,
                                      Message &               aResponseMessage,
                                      const NameCompressInfo &aCompressInfo,
-                                     const Ip6::MessageInfo &aMessageInfo);
+                                     const Ip6::MessageInfo &aMessageInfo,
+                                     Instance &              aInstance);
         bool                    IsValid(void) const { return mResponseMessage != nullptr; }
         const Ip6::MessageInfo &GetMessageInfo(void) const { return mMessageInfo; }
         const Header &          GetResponseHeader(void) const { return mResponseHeader; }
@@ -347,7 +364,7 @@ private:
     static void             IncResourceRecordCount(Header &aHeader, bool aAdditional);
     static Error            FindNameComponents(const char *aName, const char *aDomain, NameComponentsOffsetInfo &aInfo);
     static Error            FindPreviousLabel(const char *aName, uint8_t &aStart, uint8_t &aStop);
-    static void             SendResponse(Header                  aHeader,
+    void                    SendResponse(Header                  aHeader,
                                          Header::Response        aResponseCode,
                                          Message &               aMessage,
                                          const Ip6::MessageInfo &aMessageInfo,
@@ -392,6 +409,8 @@ private:
     void        HandleTimer(void);
     void        ResetTimer(void);
 
+    void UpdateResponseCounters(Header::Response aResponseCode);
+
     static const char kDnssdProtocolUdp[];
     static const char kDnssdProtocolTcp[];
     static const char kDnssdSubTypeLabel[];
@@ -403,6 +422,8 @@ private:
     otDnssdQuerySubscribeCallback   mQuerySubscribe;
     otDnssdQueryUnsubscribeCallback mQueryUnsubscribe;
     TimerMilli                      mTimer;
+
+    Counters mCounters;
 };
 
 } // namespace ServiceDiscovery


### PR DESCRIPTION
This PR implements `otDnssdGetCounters` to report the statistics of the DNS-SD server.