### PR TITLE
[tests] add wait time in test_border_router_as_fed.py

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_border_router_as_fed.py
+++ b/tests/scripts/thread-cert/border_router/test_border_router_as_fed.py
@@ -87,7 +87,7 @@ class TestBorderRouterAsFed(thread_cert.TestCase):
         self.simulator.go(5)
         self.assertEqual('child', br.get_state())
 
-        self.simulator.go(10)
+        self.simulator.go(20)
         self.assertEqual('child', br.get_state())
 
         # Leader can ping to/from the Host on infra link.


### PR DESCRIPTION
This commit adds some wait time before connectivity
validation to mitigate the impact of #7660 which
introduces some random delay before publishing
external route into network data.