### PR TITLE
[routing-manager] `PublishExternalRoute()` to return  success on `kErrorAlready`     

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -565,7 +565,7 @@ Error RoutingManager::PublishExternalRoute(const Ip6::Prefix &aPrefix, RoutePref
         LogWarn("Failed to publish external route %s: %s", aPrefix.ToString().AsCString(), ErrorToString(error));
     }
 
-    return error;
+    return (error == kErrorAlready) ? kErrorNone : error;
 }
 
 void RoutingManager::UnpublishExternalRoute(const Ip6::Prefix &aPrefix)

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -383,7 +383,7 @@ void RoutingManager::HandleNotifierEvents(Events aEvents)
     {
         if (mIsAdvertisingLocalOnLinkPrefix)
         {
-            RemoveExternalRoute(mLocalOnLinkPrefix);
+            UnpublishExternalRoute(mLocalOnLinkPrefix);
             // TODO: consider deprecating/invalidating existing
             // on-link prefix
             mIsAdvertisingLocalOnLinkPrefix = false;


### PR DESCRIPTION
This commit changes `RoutingManager::PublishExternalRoute()` method
to return `kErrorAlready` as `kErrorNone` (i.e., if the prefix to be
published was previously published). This commit keeps the logging
the same (i.e. we still log on `Already` error so we can see when/if
this happens).

----

This is on top of a **modified** version of commit from @jwhui from https://github.com/openthread/openthread/pull/7707
I hope/expect this will address the test failure in [comment](https://github.com/openthread/openthread/pull/7707#issuecomment-1129517409).


