### PR TITLE
[srp-server] check allocated `UpdateMetadata` is not `nullptr`

### DIFF
--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -887,6 +887,7 @@ private:
 
     ServiceUpdateId AllocateId(void) { return mServiceUpdateId++; }
 
+    void  InformUpdateHandlerOrCommit(Error aError, Host &aHost, const MessageMetadata &aMetadata);
     void  CommitSrpUpdate(Error aError, Host &aHost, const MessageMetadata &aMessageMetadata);
     void  CommitSrpUpdate(Error aError, UpdateMetadata &aUpdateMetadata);
     void  CommitSrpUpdate(Error                    aError,


### PR DESCRIPTION
----

Please check the last commit.
Added it on top of commits from https://github.com/openthread/openthread/pull/7715