### PR TITLE
[router-advert] `RouterAdvMessage` to provide default router prf

### DIFF
--- a/src/core/border_router/router_advertisement.cpp
+++ b/src/core/border_router/router_advertisement.cpp
@@ -112,7 +112,7 @@ void RouteInfoOption::SetPreference(RoutePreference aPreference)
     mResvdPrf |= (NetworkData::RoutePreferenceToValue(aPreference) << kPreferenceOffset) & kPreferenceMask;
 }
 
-RouteInfoOption::RoutePreference RouteInfoOption::GetPreference(void) const
+RoutePreference RouteInfoOption::GetPreference(void) const
 {
     return NetworkData::RoutePreferenceFromValue((mResvdPrf & kPreferenceMask) >> kPreferenceOffset);
 }
@@ -171,29 +171,24 @@ uint8_t RouteInfoOption::OptionLengthForPrefix(uint8_t aPrefixLength)
 
 void RouterAdvMessage::SetToDefault(void)
 {
-    mHeader.Clear();
-    mHeader.SetType(Ip6::Icmp::Header::kTypeRouterAdvert);
-    mReachableTime = 0;
-    mRetransTimer  = 0;
+    OT_UNUSED_VARIABLE(mCode);
+    OT_UNUSED_VARIABLE(mCurHopLimit);
+    OT_UNUSED_VARIABLE(mReachableTime);
+    OT_UNUSED_VARIABLE(mRetransTimer);
+
+    Clear();
+    mType = Ip6::Icmp::Header::kTypeRouterAdvert;
 }
 
-const RouterAdvMessage &RouterAdvMessage::operator=(const RouterAdvMessage &aOther)
+RoutePreference RouterAdvMessage::GetDefaultRouterPreference(void) const
 {
-    mHeader = aOther.mHeader;
-
-    // Set zero value and let platform do the calculation.
-    mHeader.SetChecksum(0);
-
-    mReachableTime = aOther.mReachableTime;
-    mRetransTimer  = aOther.mRetransTimer;
-
-    return *this;
+    return NetworkData::RoutePreferenceFromValue((mFlags & kPreferenceMask) >> kPreferenceOffset);
 }
 
-bool RouterAdvMessage::operator==(const RouterAdvMessage &aOther) const
+void RouterAdvMessage::SetDefaultRouterPreference(RoutePreference aPreference)
 {
-    return memcmp(&mHeader.mData, &aOther.mHeader.mData, sizeof(mHeader.mData)) == 0 &&
-           mReachableTime == aOther.mReachableTime && mRetransTimer == aOther.mRetransTimer;
+    mFlags &= ~kPreferenceMask;
+    mFlags |= (NetworkData::RoutePreferenceToValue(aPreference) << kPreferenceOffset) & kPreferenceMask;
 }
 
 //----------------------------------------------------------------------------------------------------------------------

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1483,6 +1483,7 @@ bool RoutingManager::UpdateRouterAdvMessage(const RouterAdv::RouterAdvMessage *a
     oldRouterAdvMessage = mRouterAdvMessage;
 
     mTimeRouterAdvMessageLastUpdate = TimerMilli::GetNow();
+
     if (aRouterAdvMessage == nullptr || aRouterAdvMessage->GetRouterLifetime() == 0)
     {
         mRouterAdvMessage.SetToDefault();
@@ -1490,7 +1491,12 @@ bool RoutingManager::UpdateRouterAdvMessage(const RouterAdv::RouterAdvMessage *a
     }
     else
     {
-        mRouterAdvMessage               = *aRouterAdvMessage;
+        // The checksum is set to zero in `mRouterAdvMessage`
+        // which indicates to platform that it needs to do the
+        // calculation and update it.
+
+        mRouterAdvMessage = *aRouterAdvMessage;
+        mRouterAdvMessage.SetChecksum(0);
         mLearntRouterAdvMessageFromHost = true;
     }
 


### PR DESCRIPTION
This commit updates and simplifies `RouterAdvMessage`:
- Adds new method to get and set the "default router preference"
- Removes custom overloads of operator `=` and `==` (which
  excluded the checksum field). Instead when we save a received RA
  in `RoutingManager` we directly set the checksum to zero so the
  normal (byte by byte) comparison would work.