### PR TITLE
[routing-manager] fix BR incorrectly removing route for local on-link prefix

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -616,8 +616,25 @@ void RoutingManager::HandleOnLinkPrefixDeprecateTimer(Timer &aTimer)
 
 void RoutingManager::HandleOnLinkPrefixDeprecateTimer(void)
 {
+    bool discoveredLocalOnLinkPrefix = false;
+
+    OT_ASSERT(!mIsAdvertisingLocalOnLinkPrefix);
+
     LogInfo("Local on-link prefix %s expired", mLocalOnLinkPrefix.ToString().AsCString());
-    UnpublishExternalRoute(mLocalOnLinkPrefix);
+
+    for (const ExternalPrefix &prefix : mDiscoveredPrefixes)
+    {
+        if (prefix.mIsOnLinkPrefix && prefix.mPrefix == mLocalOnLinkPrefix)
+        {
+            discoveredLocalOnLinkPrefix = true;
+            break;
+        }
+    }
+
+    if (!discoveredLocalOnLinkPrefix)
+    {
+        UnpublishExternalRoute(mLocalOnLinkPrefix);
+    }
 }
 
 void RoutingManager::DeprecateOnLinkPrefix(void)


### PR DESCRIPTION
This commit fixes a bug that BR could incorrectly remove the route of the local on-link prefix in Network Data when it's still advertising the local on-link prefix. 

This is a short-term fix because in the long term we want to refactor how `RoutingManager` manages external routes and the default route.