### PR TITLE
[data-poll-sender] return `kErrorNone` when Data Request is already enqueued

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (209)
+#define OPENTHREAD_API_VERSION (210)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/link.h
+++ b/include/openthread/link.h
@@ -486,7 +486,6 @@ bool otLinkIsEnergyScanInProgress(otInstance *aInstance);
  * @param[in] aInstance  A pointer to an OpenThread instance.
  *
  * @retval OT_ERROR_NONE           Successfully enqueued an IEEE 802.15.4 Data Request message.
- * @retval OT_ERROR_ALREADY        An IEEE 802.15.4 Data Request message is already enqueued.
  * @retval OT_ERROR_INVALID_STATE  Device is not in rx-off-when-idle mode.
  * @retval OT_ERROR_NO_BUFS        Insufficient message buffers available.
  *

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -123,11 +123,6 @@ exit:
         StopPolling();
         break;
 
-    case kErrorAlready:
-        LogDebg("Data poll tx requested when a previous data request still in send queue.");
-        ScheduleNextPoll(kUsePreviousPollPeriod);
-        break;
-
     default:
         LogWarn("Unexpected error %s requesting data poll", ErrorToString(error));
         ScheduleNextPoll(kRecalculatePollPeriod);

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -482,7 +482,7 @@ Error Mac::RequestDataPollTransmission(void)
     Error error = kErrorNone;
 
     VerifyOrExit(IsEnabled(), error = kErrorInvalidState);
-    VerifyOrExit(!IsActiveOrPending(kOperationTransmitPoll), error = kErrorAlready);
+    VerifyOrExit(!IsActiveOrPending(kOperationTransmitPoll));
 
     // We ensure data frame and data poll tx requests are handled in the
     // order they are requested. So if we have a pending direct data frame

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -228,7 +228,6 @@ public:
      * This method requests transmission of a data poll (MAC Data Request) frame.
      *
      * @retval kErrorNone          Data poll transmission request is scheduled successfully.
-     * @retval kErrorAlready       MAC is busy sending earlier poll transmission request.
      * @retval kErrorInvalidState  The MAC layer is not enabled.
      *
      */


### PR DESCRIPTION
There are no use cases where `kErrorAlready` is useful.

---

This also addresses intermittent failures in `v1_2-sed_mac_send.exp` due to this check:
https://github.com/openthread/openthread/blob/5107ee623837ed5b20cae4e6758644c1ca772c56/tests/scripts/expect/v1_2-sed_mac_send.exp#L39