### PR TITLE
[routing-manager] remove vicarious router discovery feature

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -237,13 +237,6 @@ private:
     // The value is chosen in range of [`kMaxRtrAdvInterval` upper bound (1800s), `kDefaultOnLinkPrefixLifetime`].
     static constexpr uint32_t kRtrAdvStaleTime = 1800;
 
-    // The VICARIOUS_SOLICIT_TIME in seconds. The Routing Manager will consider
-    // the discovered prefixes invalid if they are not refreshed after receiving
-    // a Router Solicitation message.
-    // The value is equal to Router Solicitation timeout.
-    static constexpr uint32_t kVicariousSolicitationTime =
-        kRtrSolicitationInterval * (kMaxRtrSolicitations - 1) + kMaxRtrSolicitationDelay;
-
     static_assert(kMinRtrAdvInterval <= 3 * kMaxRtrAdvInterval / 4, "invalid RA intervals");
     static_assert(kDefaultOmrPrefixLifetime >= kMaxRtrAdvInterval, "invalid default OMR prefix lifetime");
     static_assert(kDefaultOnLinkPrefixLifetime >= kMaxRtrAdvInterval, "invalid default on-link prefix lifetime");
@@ -327,10 +320,6 @@ private:
     void  SendRouterAdvertisement(const OmrPrefixArray &aNewOmrPrefixes, const Ip6::Prefix *aNewOnLinkPrefix);
     bool  IsRouterSolicitationInProgress(void) const;
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
-    static void HandleVicariousRouterSolicitTimer(Timer &aTimer);
-    void        HandleVicariousRouterSolicitTimer(void);
-#endif
     static void HandleRouterSolicitTimer(Timer &aTimer);
     void        HandleRouterSolicitTimer(void);
     static void HandleDiscoveredPrefixInvalidTimer(Timer &aTimer);
@@ -416,10 +405,6 @@ private:
     uint32_t  mRouterAdvertisementCount;
     TimeMilli mLastRouterAdvertisementSendTime;
 
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
-    TimerMilli mVicariousRouterSolicitTimer;
-    TimeMilli  mTimeVicariousRouterSolicitStart;
-#endif
     TimerMilli mRouterSolicitTimer;
     TimeMilli  mTimeRouterSolicitStart;
     uint8_t    mRouterSolicitCount;

--- a/src/core/config/border_router.h
+++ b/src/core/config/border_router.h
@@ -76,16 +76,6 @@
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
- *
- * Define to 1 to enable Border Routing Vicarious Router Solicitation.
- *
- */
-#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
-#define OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE 1
-#endif
-
-/**
  * @def OPENTHREAD_CONFIG_BORDER_ROUTING_NAT64_ENABLE
  *
  * Define to 1 to enable Border Routing NAT64 support.

--- a/src/core/config/openthread-core-config-check.h
+++ b/src/core/config/openthread-core-config-check.h
@@ -623,4 +623,8 @@
 #error "OPENTHREAD_CONFIG_PLATFORM_CSL_UNCERT was removed and no longer supported"
 #endif
 
+#ifdef OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE
+#error "OPENTHREAD_CONFIG_BORDER_ROUTING_VICARIOUS_RS_ENABLE was removed and no longer supported"
+#endif
+
 #endif // OPENTHREAD_CORE_CONFIG_CHECK_H_

--- a/tests/scripts/thread-cert/border_router/test_on_link_prefix.py
+++ b/tests/scripts/thread-cert/border_router/test_on_link_prefix.py
@@ -34,7 +34,7 @@ import config
 import thread_cert
 
 # Test description:
-#   This test verifies Vicarious Router Solicitation.
+#   This test verifies on-link prefix configuration.
 #
 # Topology:
 #    -------------(eth)----------------------------


### PR DESCRIPTION
The vicarious router discovery feature depends on the ability to
receive Router Advertisement messages sent in response to Router
Solicitation messages from other hosts. However, this does not work
since Router Advertisement messages are often sent unicast in
response.