### PR TITLE
[srp-client] add API to specify TTL

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (210)
+#define OPENTHREAD_API_VERSION (211)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/srp_client.h
+++ b/include/openthread/srp_client.h
@@ -316,6 +316,34 @@ void otSrpClientDisableAutoStartMode(otInstance *aInstance);
 bool otSrpClientIsAutoStartModeEnabled(otInstance *aInstance);
 
 /**
+ * This function gets the TTL value in every record included in SRP update requests.
+ *
+ * Note that this is the TTL requested by the SRP client. The server may choose to accept a different TTL.
+ *
+ * By default, the TTL will equal the lease interval. Passing 0 or a value larger than the lease interval via
+ * `otSrpClientSetTtl()` will also cause the TTL to equal the lease interval.
+ *
+ * @param[in] aInstance  A pointer to the OpenThread instance.
+ *
+ * @returns The TTL (in seconds).
+ *
+ */
+uint32_t otSrpClientGetTtl(otInstance *aInstance);
+
+/**
+ * This function sets the TTL value in every record included in SRP update requests.
+ *
+ * Changing the TTL does not impact the TTL of already registered services/host-info.
+ * It only affects future SRP update messages (i.e., adding new services and/or refreshes of the existing services).
+ *
+ * @param[in] aInstance   A pointer to the OpenThread instance.
+ * @param[in] aTtl        The TTL (in seconds). If value is zero or greater than lease interval, the TTL is set to the
+ *                        lease interval.
+ *
+ */
+void otSrpClientSetTtl(otInstance *aInstance, uint32_t aTtl);
+
+/**
  * This function gets the lease interval used in SRP update requests.
  *
  * Note that this is the lease duration requested by the SRP client. The server may choose to accept a different lease

--- a/src/cli/README_SRP_CLIENT.md
+++ b/src/cli/README_SRP_CLIENT.md
@@ -15,6 +15,7 @@ Usage : `srp client [command] ...`
 - [start](#start)
 - [state](#state)
 - [stop](#stop)
+- [ttl](#ttl)
 
 ## Command Details
 
@@ -36,6 +37,7 @@ service
 start
 state
 stop
+ttl
 Done
 ```
 
@@ -407,5 +409,25 @@ Stop the SRP client.
 
 ```bash
 > srp client stop
+Done
+```
+
+### ttl
+
+Usage: `srp client ttl [value]`
+
+Get the TTL (in seconds).
+
+```bash
+> srp client ttl
+7200
+Done
+>
+```
+
+Set the TTL.
+
+```bash
+> srp client ttl 3600
 Done
 ```

--- a/src/cli/cli_srp_client.cpp
+++ b/src/cli/cli_srp_client.cpp
@@ -525,6 +525,11 @@ exit:
     return error;
 }
 
+template <> otError SrpClient::Process<Cmd("ttl")>(Arg aArgs[])
+{
+    return Interpreter::GetInterpreter().ProcessGetSet(aArgs, otSrpClientGetTtl, otSrpClientSetTtl);
+}
+
 void SrpClient::HandleCallback(otError                    aError,
                                const otSrpClientHostInfo *aHostInfo,
                                const otSrpClientService * aServices,
@@ -578,7 +583,7 @@ otError SrpClient::Process(Arg aArgs[])
     static constexpr Command kCommands[] = {
         CmdEntry("autostart"),     CmdEntry("callback"), CmdEntry("host"),    CmdEntry("keyleaseinterval"),
         CmdEntry("leaseinterval"), CmdEntry("server"),   CmdEntry("service"), CmdEntry("start"),
-        CmdEntry("state"),         CmdEntry("stop"),
+        CmdEntry("state"),         CmdEntry("stop"),     CmdEntry("ttl"),
     };
 
     static_assert(BinarySearch::IsSorted(kCommands), "kCommands is not sorted");

--- a/src/core/api/srp_client_api.cpp
+++ b/src/core/api/srp_client_api.cpp
@@ -84,6 +84,16 @@ bool otSrpClientIsAutoStartModeEnabled(otInstance *aInstance)
 }
 #endif // OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
 
+uint32_t otSrpClientGetTtl(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<Srp::Client>().GetTtl();
+}
+
+void otSrpClientSetTtl(otInstance *aInstance, uint32_t aTtl)
+{
+    return AsCoreType(aInstance).Get<Srp::Client>().SetTtl(aTtl);
+}
+
 uint32_t otSrpClientGetLeaseInterval(otInstance *aInstance)
 {
     return AsCoreType(aInstance).Get<Srp::Client>().GetLeaseInterval();

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -245,6 +245,7 @@ Client::Client(Instance &aInstance)
     , mUpdateMessageId(0)
     , mRetryWaitInterval(kMinRetryWaitInterval)
     , mAcceptedLeaseInterval(0)
+    , mTtl(0)
     , mLeaseInterval(kDefaultLease)
     , mKeyLeaseInterval(kDefaultKeyLease)
     , mSocket(aInstance)
@@ -911,7 +912,7 @@ Error Client::AppendServiceInstructions(Service &aService, Message &aMessage, In
     // to NONE and TTL to zero (RFC 2136 - section 2.5.4).
 
     rr.Init(Dns::ResourceRecord::kTypePtr, removing ? Dns::PtrRecord::kClassNone : Dns::PtrRecord::kClassInternet);
-    rr.SetTtl(removing ? 0 : mLeaseInterval);
+    rr.SetTtl(removing ? 0 : GetTtl());
     offset = aMessage.GetLength();
     SuccessOrExit(error = aMessage.Append(rr));
 
@@ -970,7 +971,7 @@ Error Client::AppendServiceInstructions(Service &aService, Message &aMessage, In
 
     SuccessOrExit(error = Dns::Name::AppendPointerLabel(instanceNameOffset, aMessage));
     srv.Init();
-    srv.SetTtl(mLeaseInterval);
+    srv.SetTtl(GetTtl());
     srv.SetPriority(aService.GetPriority());
     srv.SetWeight(aService.GetWeight());
     srv.SetPort(aService.GetPort());
@@ -1024,7 +1025,7 @@ Error Client::AppendHostDescriptionInstruction(Message &aMessage, Info &aInfo) c
     // AAAA RRs
 
     rr.Init(Dns::ResourceRecord::kTypeAaaa);
-    rr.SetTtl(mLeaseInterval);
+    rr.SetTtl(GetTtl());
     rr.SetLength(sizeof(Ip6::Address));
 
     for (uint8_t index = 0; index < mHostInfo.GetNumAddresses(); index++)
@@ -1051,7 +1052,7 @@ Error Client::AppendKeyRecord(Message &aMessage, Info &aInfo) const
     Crypto::Ecdsa::P256::PublicKey publicKey;
 
     key.Init();
-    key.SetTtl(mLeaseInterval);
+    key.SetTtl(GetTtl());
     key.SetFlags(Dns::KeyRecord::kAuthConfidPermitted, Dns::KeyRecord::kOwnerNonZone,
                  Dns::KeyRecord::kSignatoryFlagGeneral);
     key.SetProtocol(Dns::KeyRecord::kProtocolDnsSec);

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -411,6 +411,31 @@ public:
     void SetCallback(Callback aCallback, void *aContext);
 
     /**
+     * This method gets the TTL used in SRP update requests.
+     *
+     * Note that this is the TTL requested by the SRP client. The server may choose to accept a different TTL.
+     *
+     * By default, the TTL will equal the lease interval. Passing 0 or a value larger than the lease interval via
+     * `otSrpClientSetTtl()` will also cause the TTL to equal the lease interval.
+     *
+     * @returns The TTL (in seconds).
+     *
+     */
+    uint32_t GetTtl(void) const { return (0 < mTtl && mTtl < mLeaseInterval) ? mTtl : mLeaseInterval; }
+
+    /**
+     * This method sets the TTL used in SRP update requests.
+     *
+     * Changing the TTL does not impact the TTL of already registered services/host-info.
+     * It only changes any future SRP update messages (i.e adding new services and/or refreshes of existing services).
+     *
+     * @param[in] aTtl  The TTL (in seconds). If value is zero or greater than lease interval, the TTL is set to the
+     *                  lease interval.
+     *
+     */
+    void SetTtl(uint32_t aTtl) { mTtl = aTtl; }
+
+    /**
      * This method gets the lease interval used in SRP update requests.
      *
      * Note that this is lease duration that would be requested by the SRP client. Server may choose to accept a
@@ -922,6 +947,7 @@ private:
 
     TimeMilli mLeaseRenewTime;
     uint32_t  mAcceptedLeaseInterval;
+    uint32_t  mTtl;
     uint32_t  mLeaseInterval;
     uint32_t  mKeyLeaseInterval;
 

--- a/tests/scripts/thread-cert/node.py
+++ b/tests/scripts/thread-cert/node.py
@@ -1156,6 +1156,16 @@ class NodeImpl:
         self.send_command(cmd)
         return int(self._expect_result('\d+'))
 
+    def srp_client_set_ttl(self, ttl: int):
+        cmd = f'srp client ttl {ttl}'
+        self.send_command(cmd)
+        self._expect_done()
+
+    def srp_client_get_ttl(self) -> int:
+        cmd = 'srp client ttl'
+        self.send_command(cmd)
+        return int(self._expect_result('\d+'))
+
     #
     # TREL utilities
     #


### PR DESCRIPTION
---
The SRP Server and Advertising Proxy also need updating to make use of the TTL.