### PR TITLE
[routing-manager] simplify invalidation of specific prefix

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -327,7 +327,7 @@ private:
     void HandleRouterAdvertisement(const InfraIf::Icmp6Packet &aPacket, const Ip6::Address &aSrcAddress);
     bool UpdateDiscoveredOnLinkPrefix(const RouterAdv::PrefixInfoOption &aPio);
     void UpdateDiscoveredOmrPrefix(const RouterAdv::RouteInfoOption &aRio);
-    void InvalidateDiscoveredPrefixes(const Ip6::Prefix *aPrefix = nullptr, bool aIsOnLinkPrefix = true);
+    void InvalidateDiscoveredPrefixes(void);
     void InvalidateAllDiscoveredPrefixes(void);
     bool NetworkDataContainsOmrPrefix(const Ip6::Prefix &aPrefix) const;
     bool UpdateRouterAdvMessage(const RouterAdv::RouterAdvMessage *aRouterAdvMessage);


### PR DESCRIPTION
This commit simplifies the mechanism to invalidate/remove a specific
prefix entry in `mDiscoveredPrefixes` list. Instead of passing the
prefix to invalidate as an input to `InvalidateDiscoveredPrefixes()`
method, we directly set the valid lifetime to zero on the entry in
the list before calling the `InvalidateDiscoveredPrefixes()` to then
remove all expired entries.

This change addresses an issue in `HandleRouterSolicitTimer()` where
while iterating over the `mDiscoveredPrefixes` list we could call
`InvalidateDiscoveredPrefixes()` which then removed an entry from the
list (thus changing the list).