### PR TITLE
[settings] remove unused/deprecated definitions

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (213)
+#define OPENTHREAD_API_VERSION (214)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -55,7 +55,8 @@ extern "C" {
  * This enumeration defines the keys of settings.
  *
  * Note: When adding a new settings key, if the settings corresponding to the key contains security sensitive
- *       information, the developer MUST add the key to the array `kSensitiveKeys`.
+ *       information, the developer MUST add the key to the array `aSensitiveKeys` which is passed in
+ *       `otPlatSettingsInit()`.
  *
  */
 enum
@@ -65,16 +66,19 @@ enum
     OT_SETTINGS_KEY_NETWORK_INFO         = 0x0003, ///< Thread network information.
     OT_SETTINGS_KEY_PARENT_INFO          = 0x0004, ///< Parent information.
     OT_SETTINGS_KEY_CHILD_INFO           = 0x0005, ///< Child information.
-    OT_SETTINGS_KEY_RESERVED             = 0x0006, ///< Reserved (previously auto-start).
     OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY = 0x0007, ///< SLAAC key to generate semantically opaque IID.
     OT_SETTINGS_KEY_DAD_INFO             = 0x0008, ///< Duplicate Address Detection (DAD) information.
-    OT_SETTINGS_KEY_LEGACY_OMR_PREFIX    = 0x0009, ///< Reserved. Legacy Off-mesh routable (OMR) prefix.
-    OT_SETTINGS_KEY_ON_LINK_PREFIX       = 0x000a, ///< On-link prefix for infrastructure link.
     OT_SETTINGS_KEY_SRP_ECDSA_KEY        = 0x000b, ///< SRP client ECDSA public/private key pair.
     OT_SETTINGS_KEY_SRP_CLIENT_INFO      = 0x000c, ///< The SRP client info (selected SRP server address).
     OT_SETTINGS_KEY_SRP_SERVER_INFO      = 0x000d, ///< The SRP server info (UDP port).
-    OT_SETTINGS_KEY_LEGACY_NAT64_PREFIX  = 0x000e, ///< Reserved. Legacy NAT64 prefix.
     OT_SETTINGS_KEY_BR_ULA_PREFIX        = 0x000f, ///< BR ULA prefix.
+
+    // Deprecated and reserved key values:
+    //
+    //   0x0006  previously auto-start.
+    //   0x0009  previously OMR prefix.
+    //   0x000a  previously on-link prefix.
+    //   0x000e  previously NAT64 prefix.
 
     // Keys in range 0x8000-0xffff are reserved for vendor-specific use.
     OT_SETTINGS_KEY_VENDOR_RESERVED_MIN = 0x8000,

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -195,8 +195,6 @@ exit:
 
 void RoutingManager::GenerateOmrPrefix(void)
 {
-    IgnoreError(Get<Settings>().Delete<Settings::LegacyOmrPrefix>());
-
     mLocalOmrPrefix = mBrUlaPrefix;
     mLocalOmrPrefix.SetSubnetId(kOmrPrefixSubnetId);
     mLocalOmrPrefix.SetLength(kOmrPrefixLength);

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -146,15 +146,15 @@ const char *SettingsBase::KeyToString(Key aKey)
         "NetworkInfo",       // (3)  kKeyNetworkInfo
         "ParentInfo",        // (4)  kKeyParentInfo
         "ChildInfo",         // (5)  kKeyChildInfo
-        "",                  // (6)  kKeyReserved
+        "",                  // (6)  Removed (previously auto-start).
         "SlaacIidSecretKey", // (7)  kKeySlaacIidSecretKey
         "DadInfo",           // (8)  kKeyDadInfo
-        "LegacyOmrPrefix",   // (9)  kKeyLegacyOmrPrefix
-        "OnLinkPrefix",      // (10) kKeyOnLinkPrefix
+        "",                  // (9)  Removed (previously OMR prefix).
+        "",                  // (10) Removed (previously on-link prefix).
         "SrpEcdsaKey",       // (11) kKeySrpEcdsaKey
         "SrpClientInfo",     // (12) kKeySrpClientInfo
         "SrpServerInfo",     // (13) kKeySrpServerInfo
-        "LegacyNat64Prefix", // (14) kKeyLegacyNat64Prefix
+        "",                  // (14) Removed (previously NAT64 prefix)
         "BrUlaPrefix",       // (15) kKeyBrUlaPrefix
     };
 
@@ -163,15 +163,11 @@ const char *SettingsBase::KeyToString(Key aKey)
     static_assert(3 == kKeyNetworkInfo, "kKeyNetworkInfo value is incorrect");
     static_assert(4 == kKeyParentInfo, "kKeyParentInfo value is incorrect");
     static_assert(5 == kKeyChildInfo, "kKeyChildInfo value is incorrect");
-    static_assert(6 == kKeyReserved, "kKeyReserved value is incorrect");
     static_assert(7 == kKeySlaacIidSecretKey, "kKeySlaacIidSecretKey value is incorrect");
     static_assert(8 == kKeyDadInfo, "kKeyDadInfo value is incorrect");
-    static_assert(9 == kKeyLegacyOmrPrefix, "kKeyLegacyOmrPrefix value is incorrect");
-    static_assert(10 == kKeyOnLinkPrefix, "kKeyOnLinkPrefix value is incorrect");
     static_assert(11 == kKeySrpEcdsaKey, "kKeySrpEcdsaKey value is incorrect");
     static_assert(12 == kKeySrpClientInfo, "kKeySrpClientInfo value is incorrect");
     static_assert(13 == kKeySrpServerInfo, "kKeySrpServerInfo value is incorrect");
-    static_assert(14 == kKeyLegacyNat64Prefix, "kKeyLegacyNat64Prefix value is incorrect");
     static_assert(15 == kKeyBrUlaPrefix, "kKeyBrUlaPrefix value is incorrect");
 
     static_assert(kLastKey == kKeyBrUlaPrefix, "kLastKey is not valid");
@@ -435,9 +431,6 @@ void Settings::Log(Action aAction, Error aError, Key aKey, const void *aValue)
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
         case kKeyBrUlaPrefix:
-        case kKeyLegacyOmrPrefix:
-        case kKeyOnLinkPrefix:
-        case kKeyLegacyNat64Prefix:
             LogPrefix(aAction, aKey, *reinterpret_cast<const Ip6::Prefix *>(aValue));
             break;
 #endif

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -112,15 +112,11 @@ public:
         kKeyNetworkInfo       = OT_SETTINGS_KEY_NETWORK_INFO,
         kKeyParentInfo        = OT_SETTINGS_KEY_PARENT_INFO,
         kKeyChildInfo         = OT_SETTINGS_KEY_CHILD_INFO,
-        kKeyReserved          = OT_SETTINGS_KEY_RESERVED,
         kKeySlaacIidSecretKey = OT_SETTINGS_KEY_SLAAC_IID_SECRET_KEY,
         kKeyDadInfo           = OT_SETTINGS_KEY_DAD_INFO,
-        kKeyLegacyOmrPrefix   = OT_SETTINGS_KEY_LEGACY_OMR_PREFIX,
-        kKeyOnLinkPrefix      = OT_SETTINGS_KEY_ON_LINK_PREFIX,
         kKeySrpEcdsaKey       = OT_SETTINGS_KEY_SRP_ECDSA_KEY,
         kKeySrpClientInfo     = OT_SETTINGS_KEY_SRP_CLIENT_INFO,
         kKeySrpServerInfo     = OT_SETTINGS_KEY_SRP_SERVER_INFO,
-        kKeyLegacyNat64Prefix = OT_SETTINGS_KEY_LEGACY_NAT64_PREFIX,
         kKeyBrUlaPrefix       = OT_SETTINGS_KEY_BR_ULA_PREFIX,
     };
 
@@ -583,37 +579,7 @@ public:
     private:
         BrUlaPrefix(void) = default;
     };
-
-    /**
-     * This class defines constants and types for legacy OMR prefix settings.
-     *
-     */
-    class LegacyOmrPrefix
-    {
-    public:
-        static constexpr Key kKey = kKeyLegacyOmrPrefix; ///< The associated key.
-
-        typedef Ip6::Prefix ValueType; ///< The associated value type.
-
-    private:
-        LegacyOmrPrefix(void) = default;
-    };
-
-    /**
-     * This class defines constants and types for on-link prefix settings.
-     *
-     */
-    class OnLinkPrefix
-    {
-    public:
-        static constexpr Key kKey = kKeyOnLinkPrefix; ///< The associated key.
-
-        typedef Ip6::Prefix ValueType; ///< The associated value type.
-
-    private:
-        OnLinkPrefix(void) = default;
-    };
-#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+#endif
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
     /**


### PR DESCRIPTION
This commit removes deprecated `Settings` definitions, in particular
the OMR prefix, on-link prefix, and NAT64 prefix.