### PR TITLE
[tests] disable some checks in Cert_9_2_09

### DIFF
--- a/tests/scripts/thread-cert/Cert_9_2_09_PendingPartition.py
+++ b/tests/scripts/thread-cert/Cert_9_2_09_PendingPartition.py
@@ -643,6 +643,15 @@ class Cert_9_2_09_PendingPartition(thread_cert.TestCase):
                    ).\
             must_next()
 
+        #
+        # Disable steps 32, 33, and 34 until a solution is
+        # found. Depending on timing, there may be one MLE Data
+        # Request/Response exchange for both Active and Pending
+        # Operational Datasets or individual MLE Data Request/Response
+        # exchange for each Active and Pending Operational Dataset
+        # separately.
+        #
+
         # Step 32: Leader sends a MLE Data Response to Commissioner including the following TLVs:
         #             - Source Address TLV
         #             - Leader Data TLV
@@ -656,30 +665,30 @@ class Cert_9_2_09_PendingPartition(thread_cert.TestCase):
         #                 - Channel TLV : ‘Primary’
         #                 - PAN ID TLV : 0xABCD
         #                 - Network Name TLV : 'TEST'
-        with pkts.save_index():
-            pkts.filter_mle_cmd(MLE_DATA_RESPONSE).\
-                filter_wpan_src64(LEADER).\
-                filter_wpan_dst64(COMMISSIONER).\
-                filter(lambda p: {
-                                  SOURCE_ADDRESS_TLV,
-                                  LEADER_DATA_TLV,
-                                  ACTIVE_TIMESTAMP_TLV,
-                                  PENDING_TIMESTAMP_TLV,
-                                  PENDING_OPERATION_DATASET_TLV
-                                  } <= set(p.mle.tlv.type) and\
-                       p.thread_nwd.tlv.stable == [0] and\
-                       NWD_COMMISSIONING_DATA_TLV in p.thread_nwd.tlv.type and\
-                       NM_COMMISSIONER_SESSION_ID_TLV in p.thread_meshcop.tlv.type and\
-                       NM_BORDER_AGENT_LOCATOR_TLV in p.thread_meshcop.tlv.type and\
-                       p.mle.tlv.active_tstamp == ROUTER2_ACTIVE_TIMESTAMP and\
-                       p.mle.tlv.pending_tstamp == ROUTER2_PENDING_TIMESTAMP and\
-                       p.thread_meshcop.tlv.net_name == [ROUTER2_NET_NAME, ROUTER2_NET_NAME] and\
-                       p.thread_meshcop.tlv.delay_timer < ROUTER2_DELAY_TIMER and\
-                       p.thread_meshcop.tlv.active_tstamp == ROUTER2_PENDING_ACTIVE_TIMESTAMP and\
-                       p.thread_meshcop.tlv.channel == [CHANNEL_INIT, CHANNEL_FINAL] and\
-                       p.thread_meshcop.tlv.pan_id == [PANID_INIT, PANID_FINAL]
-                       ).\
-                must_next()
+        #with pkts.save_index():
+        #    pkts.filter_mle_cmd(MLE_DATA_RESPONSE).\
+        #        filter_wpan_src64(LEADER).\
+        #        filter_wpan_dst64(COMMISSIONER).\
+        #        filter(lambda p: {
+        #                          SOURCE_ADDRESS_TLV,
+        #                          LEADER_DATA_TLV,
+        #                          ACTIVE_TIMESTAMP_TLV,
+        #                          PENDING_TIMESTAMP_TLV,
+        #                          PENDING_OPERATION_DATASET_TLV
+        #                          } <= set(p.mle.tlv.type) and\
+        #               p.thread_nwd.tlv.stable == [0] and\
+        #               NWD_COMMISSIONING_DATA_TLV in p.thread_nwd.tlv.type and\
+        #               NM_COMMISSIONER_SESSION_ID_TLV in p.thread_meshcop.tlv.type and\
+        #               NM_BORDER_AGENT_LOCATOR_TLV in p.thread_meshcop.tlv.type and\
+        #               p.mle.tlv.active_tstamp == ROUTER2_ACTIVE_TIMESTAMP and\
+        #               p.mle.tlv.pending_tstamp == ROUTER2_PENDING_TIMESTAMP and\
+        #               p.thread_meshcop.tlv.net_name == [ROUTER2_NET_NAME, ROUTER2_NET_NAME] and\
+        #               p.thread_meshcop.tlv.delay_timer < ROUTER2_DELAY_TIMER and\
+        #               p.thread_meshcop.tlv.active_tstamp == ROUTER2_PENDING_ACTIVE_TIMESTAMP and\
+        #               p.thread_meshcop.tlv.channel == [CHANNEL_INIT, CHANNEL_FINAL] and\
+        #               p.thread_meshcop.tlv.pan_id == [PANID_INIT, PANID_FINAL]
+        #               ).\
+        #        must_next()
 
         # Step 33: Router_1 MUST send a unicast MLE Data Request to the Leader, including the
         #          following TLVs:
@@ -687,19 +696,19 @@ class Cert_9_2_09_PendingPartition(thread_cert.TestCase):
         #                - Network Data TLV
         #             - Active Timestamp TLV (10s)
         #             - Pending Timestamp TLV (30s)
-        pkts.filter_wpan_src64(ROUTER_1).\
-            filter_wpan_dst64(LEADER).\
-            filter_mle_cmd(MLE_DATA_REQUEST).\
-            filter(lambda p: {
-                              TLV_REQUEST_TLV,
-                              NETWORK_DATA_TLV,
-                              ACTIVE_TIMESTAMP_TLV
-                              } <= set(p.mle.tlv.type) and\
-                   p.mle.tlv.active_tstamp == TIMESTAMP_INIT and\
-                   p.mle.tlv.pending_tstamp == COMM_PENDING_TIMESTAMP and\
-                   p.thread_meshcop.tlv.type is nullField
-                   ).\
-            must_next()
+        #pkts.filter_wpan_src64(ROUTER_1).\
+        #    filter_wpan_dst64(LEADER).\
+        #    filter_mle_cmd(MLE_DATA_REQUEST).\
+        #    filter(lambda p: {
+        #                      TLV_REQUEST_TLV,
+        #                      NETWORK_DATA_TLV,
+        #                      ACTIVE_TIMESTAMP_TLV
+        #                      } <= set(p.mle.tlv.type) and\
+        #           p.mle.tlv.active_tstamp == TIMESTAMP_INIT and\
+        #           p.mle.tlv.pending_tstamp == COMM_PENDING_TIMESTAMP and\
+        #           p.thread_meshcop.tlv.type is nullField
+        #           ).\
+        #    must_next()
 
         # Step 34: Leader sends a MLE Data Response to Router_1 including the following TLVs:
         #             - Source Address TLV
@@ -713,24 +722,24 @@ class Cert_9_2_09_PendingPartition(thread_cert.TestCase):
         #                 - Delay Timer TLV <~ 200s>
         #                 - Channel TLV : ‘Primary’
         #                 - PAN ID TLV : 0xABCD
-        pkts.filter_mle_cmd(MLE_DATA_RESPONSE).\
-            filter_wpan_src64(LEADER).\
-            filter_wpan_dst64(ROUTER_1).\
-            filter(lambda p: {
-                              SOURCE_ADDRESS_TLV,
-                              LEADER_DATA_TLV,
-                              ACTIVE_TIMESTAMP_TLV,
-                              PENDING_TIMESTAMP_TLV,
-                              PENDING_OPERATION_DATASET_TLV
-                              } <= set(p.mle.tlv.type) and\
-                   p.mle.tlv.active_tstamp == ROUTER2_ACTIVE_TIMESTAMP and\
-                   p.mle.tlv.pending_tstamp == ROUTER2_PENDING_TIMESTAMP and\
-                   p.thread_meshcop.tlv.delay_timer < ROUTER2_DELAY_TIMER and\
-                   p.thread_meshcop.tlv.active_tstamp == ROUTER2_PENDING_ACTIVE_TIMESTAMP and\
-                   p.thread_meshcop.tlv.channel == [CHANNEL_INIT, CHANNEL_FINAL] and\
-                   p.thread_meshcop.tlv.pan_id == [PANID_INIT, PANID_FINAL]
-                   ).\
-            must_next()
+        #pkts.filter_mle_cmd(MLE_DATA_RESPONSE).\
+        #    filter_wpan_src64(LEADER).\
+        #    filter_wpan_dst64(ROUTER_1).\
+        #    filter(lambda p: {
+        #                      SOURCE_ADDRESS_TLV,
+        #                      LEADER_DATA_TLV,
+        #                      ACTIVE_TIMESTAMP_TLV,
+        #                      PENDING_TIMESTAMP_TLV,
+        #                      PENDING_OPERATION_DATASET_TLV
+        #                      } <= set(p.mle.tlv.type) and\
+        #           p.mle.tlv.active_tstamp == ROUTER2_ACTIVE_TIMESTAMP and\
+        #           p.mle.tlv.pending_tstamp == ROUTER2_PENDING_TIMESTAMP and\
+        #           p.thread_meshcop.tlv.delay_timer < ROUTER2_DELAY_TIMER and\
+        #           p.thread_meshcop.tlv.active_tstamp == ROUTER2_PENDING_ACTIVE_TIMESTAMP and\
+        #           p.thread_meshcop.tlv.channel == [CHANNEL_INIT, CHANNEL_FINAL] and\
+        #           p.thread_meshcop.tlv.pan_id == [PANID_INIT, PANID_FINAL]
+        #           ).\
+        #    must_next()
 
         # Step 36: The DUT MUST respond with an ICMPv6 Echo Reply
         _pkt = pkts.filter_ping_request().\


### PR DESCRIPTION
Disable steps 32, 33, and 34 until a solution is found. Depending on
timing, there may be one MLE Data Request/Response exchange for both
Active and Pending Operational Datasets or individual MLE Data
Request/Response exchange for each Active and Pending Operational
Dataset separately.

---

See #7763 