### PR TITLE
[routing-manager] add `OmrPrefix` class, include OMR preference in RIO

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -55,6 +55,7 @@
 #include "common/error.hpp"
 #include "common/locator.hpp"
 #include "common/notifier.hpp"
+#include "common/string.hpp"
 #include "common/timer.hpp"
 #include "net/ip6.hpp"
 #include "thread/network_data.hpp"
@@ -278,7 +279,27 @@ private:
         bool            mIsOnLinkPrefix;
     };
 
-    typedef Array<Ip6::Prefix, kMaxOmrPrefixNum>           OmrPrefixArray;
+    class OmrPrefix // An OMR Prefix
+    {
+    public:
+        static constexpr uint16_t       kInfoStringSize = 60;
+        typedef String<kInfoStringSize> InfoString;
+
+        void               Init(const Ip6::Prefix &aPrefix, RoutePreference aPreference);
+        void               InitFrom(NetworkData::OnMeshPrefixConfig &aOnMeshPrefixConfig);
+        const Ip6::Prefix &GetPrefix(void) const { return mPrefix; }
+        RoutePreference    GetPreference(void) const { return mPreference; }
+        void               SetPreference(RoutePreference aPreference) { mPreference = aPreference; }
+        bool               Matches(const Ip6::Prefix &aPrefix) const { return mPrefix == aPrefix; }
+        bool               IsFavoredOver(const OmrPrefix &aOther) const;
+        InfoString         ToString(void) const;
+
+    private:
+        Ip6::Prefix     mPrefix;
+        RoutePreference mPreference;
+    };
+
+    typedef Array<OmrPrefix, kMaxOmrPrefixNum>             OmrPrefixArray;
     typedef Array<ExternalPrefix, kMaxDiscoveredPrefixNum> ExternalPrefixArray;
 
     void  EvaluateState(void);

--- a/src/core/thread/network_data_types.hpp
+++ b/src/core/thread/network_data_types.hpp
@@ -190,6 +190,14 @@ public:
      */
     Ip6::Prefix &GetPrefix(void) { return AsCoreType(&mPrefix); }
 
+    /**
+     * This method gets the preference.
+     *
+     * @return The preference.
+     *
+     */
+    RoutePreference GetPreference(void) const { return RoutePreferenceFromValue(RoutePreferenceToValue(mPreference)); }
+
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
     /**
      * This method indicates whether or not the prefix configuration is valid.


### PR DESCRIPTION
This commit updates `RoutingManager` to track the preference of the
discovered OMR prefixes from Thread Network Data and advertise the
OMR prefixes with the same preference in Route Info Options in the
emitted Router Advertisements.

This commit adds `OmrPrefix` class (which tracks an OMR prefix along
with its preference) and provides helpers method (e.g., method to
compare two OMR prefixes to determine which one is favored, `ToString()`
method). The `EvaluateOmrPrefix()` is updated to use the new
`OmrPrefix` class.