### PR TITLE
[cmake] add option for RCP specific mbedtls library

### DIFF
--- a/examples/apps/cli/radio.cmake
+++ b/examples/apps/cli/radio.cmake
@@ -37,13 +37,17 @@ if(NOT DEFINED OT_PLATFORM_LIB_RCP)
     set(OT_PLATFORM_LIB_RCP ${OT_PLATFORM_LIB})
 endif()
 
+if(NOT DEFINED OT_MBEDTLS_RCP)
+    set(OT_MBEDTLS_RCP ${OT_MBEDTLS})
+endif()
+
 target_link_libraries(ot-cli-radio PRIVATE
     openthread-cli-radio
     ${OT_PLATFORM_LIB_RCP}
     openthread-radio-cli
     ${OT_PLATFORM_LIB_RCP}
     openthread-cli-radio
-    ${OT_MBEDTLS}
+    ${OT_MBEDTLS_RCP}
     ot-config
 )
 

--- a/src/cli/radio.cmake
+++ b/src/cli/radio.cmake
@@ -46,10 +46,14 @@ target_sources(openthread-cli-radio
         cli_output.cpp
 )
 
+if(NOT DEFINED OT_MBEDTLS_RCP)
+    set(OT_MBEDTLS_RCP ${OT_MBEDTLS})
+endif()
+
 target_link_libraries(openthread-cli-radio
     PUBLIC
         openthread-radio
     PRIVATE
-        ${OT_MBEDTLS}
+        ${OT_MBEDTLS_RCP}
         ot-config
 )

--- a/src/core/radio_cli.cmake
+++ b/src/core/radio_cli.cmake
@@ -47,8 +47,12 @@ if(OT_VENDOR_EXTENSION)
   target_sources(openthread-radio-cli PRIVATE ${OT_VENDOR_EXTENSION})
 endif()
 
+if(NOT DEFINED OT_MBEDTLS_RCP)
+    set(OT_MBEDTLS_RCP ${OT_MBEDTLS})
+endif()
+
 target_link_libraries(openthread-radio-cli
     PRIVATE
-        ${OT_MBEDTLS}
+        ${OT_MBEDTLS_RCP}
         ot-config
 )


### PR DESCRIPTION
This PR enables a different mbedtls library to be used for RCP builds.
Proposed change will make it possible to use a PSA Crypto mbedtls library for FTD/MTD images while using a non-PSA crypto library on RCPs