### PR TITLE
[cmake] add build option to configure outgoing beacon payload

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -360,6 +360,11 @@ if (OT_TREL)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE=1")
 endif()
 
+option(OT_TX_BEACON_PAYLOAD "enable Thread beacon payload in outgoing beacons")
+if (OT_TX_BEACON_PAYLOAD)
+    target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_MAC_OUTGOING_BEACON_PAYLOAD_ENABLE=1")
+endif()
+
 option(OT_UDP_FORWARD "enable UDP forward support")
 if(OT_UDP_FORWARD)
     target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_UDP_FORWARD_ENABLE=1")


### PR DESCRIPTION
#7767 added a define for outgoing beacon payloads that is defaulted off `OPENTHREAD_CONFIG_MAC_OUTGOING_BEACON_PAYLOAD_ENABLE`

this adds a cmake option to configure this on. tested by passing this through as a cmake option when building OTBR and testing that beacon payloads were enabled. 