### PR TITLE
[csl] simplify receiver states and scheduling

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -583,7 +583,7 @@ public:
      * @returns CSL channel.
      *
      */
-    uint8_t GetCslChannel(void) const { return mLinks.GetSubMac().GetCslChannel(); }
+    uint8_t GetCslChannel(void) const { return mCslChannel; }
 
     /**
      * This method sets the CSL channel.
@@ -594,12 +594,10 @@ public:
     void SetCslChannel(uint8_t aChannel);
 
     /**
-     * This method indicates if CSL channel has been explicitly specified by the upper layer.
-     *
-     * @returns If CSL channel has been specified.
+     * This method centralizes CSL state switching conditions evaluating, configuring SubMac accordingly.
      *
      */
-    bool IsCslChannelSpecified(void) const { return mLinks.GetSubMac().IsCslChannelSpecified(); }
+    void UpdateCsl(void);
 
     /**
      * This method gets the CSL period.
@@ -607,7 +605,7 @@ public:
      * @returns CSL period in units of 10 symbols.
      *
      */
-    uint16_t GetCslPeriod(void) const { return mLinks.GetSubMac().GetCslPeriod(); }
+    uint16_t GetCslPeriod(void) const { return mCslPeriod; }
 
     /**
      * This method sets the CSL period.
@@ -634,6 +632,15 @@ public:
      *
      */
     bool IsCslCapable(void) const;
+
+    /**
+     * This method indicates whether the device is connected to a parent which supports CSL.
+     *
+     * @retval TRUE   If parent supports CSL.
+     * @retval FALSE  If parent does not support CSL.
+     *
+     */
+    bool IsCslSupported(void) const;
 
     /**
      * This method returns CSL parent clock accuracy, in ± ppm.
@@ -820,6 +827,11 @@ private:
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     TimeMilli mCslTxFireTime;
 #endif
+#endif
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+    // When Mac::mCslChannel is 0, it indicates that CSL channel has not been specified by the upper layer.
+    uint8_t  mCslChannel;
+    uint16_t mCslPeriod;
 #endif
 
     union

--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -457,18 +457,42 @@ public:
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     /**
-     * This method transitions all radios link to CSL sample state.
+     * This method configures CSL parameters in all radios.
      *
-     * CSL sample state is only applicable and used for 15.4 radio link. Other link are transitioned to sleep state.
+     * @param[in]  aPeriod    The CSL period.
+     * @param[in]  aChannel   The CSL channel.
+     * @param[in]  aShortAddr The short source address of CSL receiver's peer.
+     * @param[in]  aExtAddr   The extended source address of CSL receiver's peer.
      *
-     * @param[in]  aPanChannel  The current phy channel used by the device. This param will only take effect when CSL
-     *                          channel hasn't been explicitly specified.
+     * @retval  TRUE if CSL Period or CSL Channel changed.
+     * @retval  FALSE if CSL Period and CSL Channel did not change.
+     *
      */
-    void CslSample(uint8_t aPanChannel)
+    bool UpdateCsl(uint16_t aPeriod, uint8_t aChannel, otShortAddress aShortAddr, const otExtAddress *aExtAddr)
     {
-        OT_UNUSED_VARIABLE(aPanChannel);
+        bool retval = false;
+
+        OT_UNUSED_VARIABLE(aPeriod);
+        OT_UNUSED_VARIABLE(aChannel);
+        OT_UNUSED_VARIABLE(aShortAddr);
+        OT_UNUSED_VARIABLE(aExtAddr);
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
-        IgnoreError(mSubMac.CslSample(aPanChannel));
+        retval = mSubMac.UpdateCsl(aPeriod, aChannel, aShortAddr, aExtAddr);
+#endif
+        return retval;
+    }
+
+    /**
+     * This method transitions all radios link to CSL sample state, given that a non-zero CSL period is configured.
+     *
+     * CSL sample state is only applicable and used for 15.4 radio link. Other link are transitioned to sleep state
+     * when CSL period is non-zero.
+     *
+     */
+    void CslSample(void)
+    {
+#if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE
+        mSubMac.CslSample();
 #endif
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
         mTrel.Sleep();

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -95,12 +95,11 @@ void SubMac::Init(void)
     mTimer.Stop();
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    mCslPeriod             = 0;
-    mCslChannel            = 0;
-    mIsCslChannelSpecified = false;
-    mCslSampleTime         = TimeMicro{0};
-    mCslLastSync           = TimeMicro{0};
-    mCslState              = kCslIdle;
+    mCslPeriod     = 0;
+    mCslChannel    = 0;
+    mIsCslSampling = false;
+    mCslSampleTime = TimeMicro{0};
+    mCslLastSync   = TimeMicro{0};
     mCslTimer.Stop();
 #endif
 }
@@ -201,6 +200,10 @@ Error SubMac::Disable(void)
 {
     Error error;
 
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+    mCslTimer.Stop();
+#endif
+
     mTimer.Stop();
     SuccessOrExit(error = Get<Radio>().Sleep());
     SuccessOrExit(error = Get<Radio>().Disable());
@@ -254,43 +257,26 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-Error SubMac::CslSample(uint8_t aPanChannel)
+void SubMac::CslSample(void)
 {
-    Error error = kErrorNone;
-
-    if (!IsCslChannelSpecified())
-    {
-        mCslChannel = aPanChannel;
-    }
-
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
-    VerifyOrExit(!mRadioFilterEnabled, error = Get<Radio>().Sleep());
+    VerifyOrExit(!mRadioFilterEnabled, IgnoreError(Get<Radio>().Sleep()));
 #endif
-
-    switch (mCslState)
-    {
-    case kCslSample:
-        error = Get<Radio>().Receive(mCslChannel);
-        break;
-    case kCslSleep:
-#if !OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
-        error = Get<Radio>().Sleep(); // Don't actually sleep for debugging
-#endif
-        break;
-    case kCslIdle:
-        ExitNow(error = kErrorInvalidState);
-    default:
-        OT_ASSERT(false);
-    }
 
     SetState(kStateCslSample);
 
-exit:
-    if (error != kErrorNone)
+    if (mIsCslSampling && !RadioSupportsReceiveTiming())
     {
-        LogWarn("CslSample() failed, error: %s", ErrorToString(error));
+        IgnoreError(Get<Radio>().Receive(mCslChannel));
+        ExitNow();
     }
-    return error;
+
+#if !OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
+    IgnoreError(Get<Radio>().Sleep()); // Don't actually sleep for debugging
+#endif
+
+exit:
+    return;
 }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
@@ -318,7 +304,7 @@ void SubMac::HandleReceiveDone(RxFrame *aFrame, Error aError)
 #if OPENTHREAD_CONFIG_MAC_CSL_DEBUG_ENABLE
         // Split the log into two lines for RTT to output
         LogDebg("Received frame in state (SubMac %s, CSL %s), timestamp %u", StateToString(mState),
-                CslStateToString(mCslState), static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp));
+                mIsCslSampling ? "CslSample" : "CslSleep", static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp));
         LogDebg("Target sample start time %u, time drift %d", mCslSampleTime.GetValue(),
                 static_cast<uint32_t>(aFrame->mInfo.mRxInfo.mTimestamp) - mCslSampleTime.GetValue());
 #endif
@@ -1055,63 +1041,35 @@ const char *SubMac::StateToString(State aState)
     return kStateStrings[aState];
 }
 
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-const char *SubMac::CslStateToString(CslState aCslState)
-{
-    static const char *const kCslStateStrings[] = {
-        "CslIdle",   // (0) kCslIdle
-        "CslSample", // (1) kCslSample
-        "CslSleep",  // (2) kCslSleep
-    };
-
-    static_assert(kCslIdle == 0, "kCslIdle value is incorrect");
-    static_assert(kCslSample == 1, "kCslSample value is incorrect");
-    static_assert(kCslSleep == 2, "kCslSleep value is incorrect");
-
-    return kCslStateStrings[aCslState];
-}
-#endif
-
 // LCOV_EXCL_STOP
 
 //---------------------------------------------------------------------------------------------------------------------
 // CSL Receiver methods
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-void SubMac::SetCslChannel(uint8_t aChannel)
+bool SubMac::UpdateCsl(uint16_t aPeriod, uint8_t aChannel, otShortAddress aShortAddr, const otExtAddress *aExtAddr)
 {
+    bool diffPeriod  = aPeriod != mCslPeriod;
+    bool diffChannel = aChannel != mCslChannel;
+    bool retval      = diffPeriod || diffChannel;
+
+    VerifyOrExit(retval);
     mCslChannel = aChannel;
-}
 
-void SubMac::SetCslPeriod(uint16_t aPeriod)
-{
-    VerifyOrExit(mCslPeriod != aPeriod);
-
+    VerifyOrExit(diffPeriod);
     mCslPeriod = aPeriod;
+    IgnoreError(Get<Radio>().EnableCsl(aPeriod, aShortAddr, aExtAddr));
 
     mCslTimer.Stop();
-
     if (mCslPeriod > 0)
     {
         mCslSampleTime = TimeMicro(static_cast<uint32_t>(otPlatRadioGetNow(&GetInstance())));
-        mCslState      = kCslSleep;
+        mIsCslSampling = false;
         HandleCslTimer();
     }
-    else
-    {
-        mCslState = kCslIdle;
-
-        if (mState == kStateCslSample)
-        {
-            IgnoreError(Get<Radio>().Sleep());
-            SetState(kStateSleep);
-        }
-    }
-
-    LogDebg("CSL Period: %u", mCslPeriod);
 
 exit:
-    return;
+    return retval;
 }
 
 void SubMac::HandleCslTimer(Timer &aTimer)
@@ -1135,11 +1093,9 @@ void SubMac::HandleCslTimer(void)
 
     GetCslWindowEdges(timeAhead, timeAfter);
 
-    switch (mCslState)
+    if (mIsCslSampling)
     {
-    case kCslSample:
-        mCslState = kCslSleep;
-
+        mIsCslSampling = false;
         mCslTimer.FireAt(mCslSampleTime - timeAhead);
         if (mState == kStateCslSample)
         {
@@ -1148,9 +1104,9 @@ void SubMac::HandleCslTimer(void)
 #endif
             LogDebg("CSL sleep %u", mCslTimer.GetNow().GetValue());
         }
-        break;
-
-    case kCslSleep:
+    }
+    else
+    {
         if (RadioSupportsReceiveTiming())
         {
             mCslSampleTime += periodUs;
@@ -1160,33 +1116,22 @@ void SubMac::HandleCslTimer(void)
         else
         {
             mCslTimer.FireAt(mCslSampleTime + timeAfter);
-            mCslState = kCslSample;
+            mIsCslSampling = true;
             mCslSampleTime += periodUs;
         }
 
         Get<Radio>().UpdateCslSampleTime(mCslSampleTime.GetValue());
 
-        if (RadioSupportsReceiveTiming())
+        if (RadioSupportsReceiveTiming() && (mState != kStateDisabled))
         {
-            if (mState != kStateDisabled && mCslChannel)
-            {
-                IgnoreError(Get<Radio>().ReceiveAt(mCslChannel, mCslSampleTime.GetValue() - periodUs - timeAhead,
-                                                   timeAhead + timeAfter));
-            }
+            IgnoreError(Get<Radio>().ReceiveAt(mCslChannel, mCslSampleTime.GetValue() - periodUs - timeAhead,
+                                               timeAhead + timeAfter));
         }
         else if (mState == kStateCslSample)
         {
             IgnoreError(Get<Radio>().Receive(mCslChannel));
             LogDebg("CSL sample %u, duration %u", mCslTimer.GetNow().GetValue(), timeAhead + timeAfter);
         }
-        break;
-
-    case kCslIdle:
-        break;
-
-    default:
-        OT_ASSERT(false);
-        break;
     }
 }
 


### PR DESCRIPTION
After enabling the scheduling of delayed reception slots in #7677 they would be configured even when the device switched to MED mode.

This commit introduces some simplifications around the CSL states and scheduling:
- Mantain the CSL timer stopped if not in CSL Receiver mode.
- Keep the CSL Period and Channel values in the MAC in order to use them as an indication of CSL Receiver mode in the Sub-Mac.