### PR TITLE
[mle] fix handling of MLE Orphan Announce messages

### DIFF
--- a/src/core/meshcop/timestamp.hpp
+++ b/src/core/meshcop/timestamp.hpp
@@ -141,6 +141,15 @@ public:
     void AdvanceRandomTicks(void);
 
     /**
+     * This method indicates whether the timestamp indicates an MLE Orphan Announce message.
+     *
+     * @retval TRUE   The timestamp indicates an Orphan Announce message.
+     * @retval FALSE  If the timestamp does not indicate an Orphan Announce message.
+     *
+     */
+    bool IsOrphanTimestamp(void) const { return GetSeconds() == 0 && GetTicks() == 0 && GetAuthoritative(); }
+
+    /**
      * This static method compares two timestamps.
      *
      * Either one or both @p aFirst or @p aSecond can be `nullptr`. A non-null timestamp is considered greater than


### PR DESCRIPTION
MLE Orphan Announce messages include a timestamp value that has both
seconds and ticks set to zero, but authoritative bit set. However, the
default Active Timestamp value is all zeros. As a result, an MLE
Orphan Announce timestamp can appear to be greater than the default
Active Timestamp value and cause a device to detach.

This commit adds a special case to check for the Orphan Announce
timestamp.

Fixes #7785 