### PR TITLE
[srp-server] validate sub-types and treat as atomic

### DIFF
--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -585,6 +585,7 @@ public:
                                            bool        aIsSubType,
                                            TimeMilli   aUpdateTime);
         void                 RemoveService(Service *aService, RetainName aRetainName, NotifyMode aNotifyServiceHandler);
+        Error                AddCopyOfServiceAsDeletedIfNotPresent(const Service &aService, TimeMilli aUpdateTime);
         void                 FreeAllServices(void);
         void                 ClearResources(void);
         Error                MergeServicesAndResourcesFrom(Host &aHost);
@@ -594,6 +595,8 @@ public:
         const RetainPtr<Service::Description> FindServiceDescription(const char *aInstanceName) const;
         Service *                             FindService(const char *aServiceName, const char *aInstanceName);
         const Service *                       FindService(const char *aServiceName, const char *aInstanceName) const;
+        Service *                             FindBaseService(const char *aInstanceName);
+        const Service *                       FindBaseService(const char *aInstanceName) const;
 
         Host *                    mNext;
         Heap::String              mFullName;
@@ -977,6 +980,7 @@ private:
                           uint16_t                      aSigRdataOffset,
                           uint16_t                      aSigRdataLength,
                           const char *                  aSignerName) const;
+    Error ValidateServiceSubTypes(Host &aHost, const MessageMetadata &aMetadata);
     Error ProcessZoneSection(const Message &aMessage, MessageMetadata &aMetadata) const;
     Error ProcessHostDescriptionInstruction(Host &                 aHost,
                                             const Message &        aMessage,


### PR DESCRIPTION
This commit updates `Srp::Server` to treat the update instructions in
a received SRP message for a service and all its sub-types as atomic.
It adds a new method `ValidateServiceSubTypes()` which performs two
checks. First, it verifies that there is a matching base service for
all sub-type services in a received SRP Update message. Second, it
treats the sub-types in the message as atomic, i.e., whatever
information appears in the message is considered the entirety of
information about the service and its sub-types. In particular, any
previously registered service sub-type that does not appear in a new
SRP Update is removed (marked as deleted).

This commit updates `test_srp_sub_type.py` test-case to validate the
behavior of newly added mechanism (i.e. removal of older sub-types
when not present in the new SRP update message).