### PR TITLE
[thci] wait for netdata to stabilize if `BORDER_ROUTING` is enabled

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1144,6 +1144,10 @@ class OpenThreadTHCI(object):
                         self, timeout * 2))
                 else:
                     return False
+
+        if self.IsBorderRouter:
+            self._waitBorderRoutingStabilize()
+
         return True
 
     @API
@@ -1607,6 +1611,30 @@ class OpenThreadTHCI(object):
                 return self.__executeCommand('netdata register')[-1] == 'Done'
         else:
             return False
+
+    @watched
+    def getNetworkData(self):
+        lines = self.__executeCommand('netdata show')
+        prefixes, routes, services = [], [], []
+        classify = None
+
+        for line in lines:
+            if line == 'Prefixes:':
+                classify = prefixes
+            elif line == 'Routes:':
+                classify = routes
+            elif line == 'Services:':
+                classify = services
+            elif line == 'Done':
+                classify = None
+            else:
+                classify.append(line)
+
+        return {
+            'Prefixes': prefixes,
+            'Routes': routes,
+            'Services': services,
+        }
 
     @API
     def setNetworkIDTimeout(self, iNwkIDTimeOut):
@@ -3110,6 +3138,14 @@ class OpenThreadTHCI(object):
     @API
     def setLeaderWeight(self, iWeight=72):
         self.__executeCommand('leaderweight %d' % iWeight)
+
+    @watched
+    def isBorderRoutingEnabled(self):
+        try:
+            self.__executeCommand('br omrprefix')
+            return True
+        except CommandError:
+            return False
 
     def __detectZephyr(self):
         """Detect if the device is running Zephyr and adapt in that case"""

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -695,3 +695,30 @@ class OpenThread_BR(OpenThreadTHCI, IThci):
         """
         self.externalCommissioner.MLR([sAddr], 0)
         return True
+
+    @watched
+    def _waitBorderRoutingStabilize(self):
+        """
+        Wait for Network Data to stabilize if BORDER_ROUTING is enabled.
+        """
+        if not self.isBorderRoutingEnabled():
+            return
+
+        MAX_TIMEOUT = 30
+        MIN_TIMEOUT = 15
+        CHECK_INTERVAL = 3
+
+        time.sleep(MIN_TIMEOUT)
+
+        lastNetData = self.getNetworkData()
+        for i in range((MAX_TIMEOUT - MIN_TIMEOUT) // CHECK_INTERVAL):
+            time.sleep(CHECK_INTERVAL)
+            curNetData = self.getNetworkData()
+
+            # Wait until the Network Data is not changing, and there is OMR Prefix and External Routes available
+            if curNetData == lastNetData and len(curNetData['Prefixes']) > 0 and len(curNetData['Routes']) > 0:
+                break
+
+            lastNetData = curNetData
+
+        return lastNetData


### PR DESCRIPTION
A BR with `BORDER_ROUTING` feature may add OMR prefix and external routes to the network data when Thread is started. 
The network data changes may incur additional Thread communications that may interfere with certification traffic.

This commit enhances THCI to wait for the network data to stabilize after the BR is started. 