### PR TITLE
[ip6] update `Ip6::Prefix` comparison

### DIFF
--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -77,13 +77,17 @@ bool Prefix::IsEqual(const uint8_t *aPrefixBytes, uint8_t aPrefixLength) const
 bool Prefix::operator<(const Prefix &aOther) const
 {
     bool    isSmaller;
+    uint8_t minLength;
     uint8_t matchedLength;
 
-    VerifyOrExit(GetLength() == aOther.GetLength(), isSmaller = GetLength() < aOther.GetLength());
+    minLength     = OT_MIN(GetLength(), aOther.GetLength());
+    matchedLength = MatchLength(GetBytes(), aOther.GetBytes(), SizeForLength(minLength));
 
-    matchedLength = MatchLength(GetBytes(), aOther.GetBytes(), GetBytesSize());
-
-    VerifyOrExit(matchedLength < GetLength(), isSmaller = false);
+    if (matchedLength >= minLength)
+    {
+        isSmaller = (GetLength() < aOther.GetLength());
+        ExitNow();
+    }
 
     isSmaller = GetBytes()[matchedLength / CHAR_BIT] < aOther.GetBytes()[matchedLength / CHAR_BIT];
 

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -266,8 +266,10 @@ public:
     /**
      * This method overloads operator `<` to compare two prefixes.
      *
-     * A prefix with shorter length is considered smaller than the one with longer length. If the prefix lengths are
-     * equal, then the prefix bytes are compared directly.
+     * If the two prefixes have the same length N, then the bytes are compared directly (as two big-endian N-bit
+     * numbers). If the two prefix have different lengths, the shorter prefix is padded by `0` bit up to the longer
+     * prefix length N before the bytes are compared (as big-endian N-bit numbers). If all bytes are equal, the prefix
+     * with shorter length is considered smaller.
      *
      * @param[in] aOther  The other prefix to compare against.
      *


### PR DESCRIPTION
This commit updates `Ip6::Prefix` comparison (overload of `<`
operator). If the two prefixes have same length N, then the bytes are
compared directly (as two big-endian N-bit numbers). If the two
prefix have different lengths, the shorter prefix is padded by `0`
bit up to the longer prefix length N before the bytes are compared
(as big-endian N-bit numbers). If all bytes are equal, the prefix
with shorter length is considered smaller.

This commit also updates `test_ip_address` unit test to validate
the new comparison behavior.