### PR TITLE
[routing-manager] fix calculation if an entry's stale time is in past

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1371,14 +1371,15 @@ void RoutingManager::ResetDiscoveredPrefixStaleTimer(void)
     // Check for stale Router Advertisement Message if learnt from Host.
     if (mLearntRouterAdvMessageFromHost)
     {
-        TimeMilli routerAdvMessageStaleTime = mTimeRouterAdvMessageLastUpdate + Time::SecToMsec(kRtrAdvStaleTime);
+        TimeMilli routerAdvMessageStaleTime =
+            OT_MAX(mTimeRouterAdvMessageLastUpdate + Time::SecToMsec(kRtrAdvStaleTime), now);
 
         nextStaleTime = OT_MIN(nextStaleTime, routerAdvMessageStaleTime);
     }
 
     for (ExternalPrefix &externalPrefix : mDiscoveredPrefixes)
     {
-        TimeMilli prefixStaleTime = externalPrefix.GetStaleTime();
+        TimeMilli prefixStaleTime = OT_MAX(externalPrefix.GetStaleTime(), now);
 
         if (externalPrefix.IsOnLinkPrefix())
         {


### PR DESCRIPTION
This commit updates the calculation of the next stale time in
`ResetDiscoveredPrefixStaleTimer()` in (unlikely) cases where the
stale time of a discovered prefix or RA header happens to be in past
(compared to `GetNow()`). In such a case, we use `now` as the stale
time of the entry. This then ensures that we can correctly
compare the stale time with `now.GetDistantFuture()`.

---

I expect the situation where stale time of an entry is in past would be unlikely, 
but better to do the proper thing in such cases.