### PR TITLE
[thci] support 1.3 border router configurations

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -261,11 +261,6 @@ class OpenThreadTHCI(object):
     def _onCommissionStop(self):
         """Called when commissioning stops."""
 
-    @abstractmethod
-    def __restartAgentService(self):
-        """Called when restarting the agent service"""
-        pass
-
     def __sendCommand(self, cmd, expectEcho=True):
         cmd = self._cmdPrefix + cmd
         # self.log("command: %s", cmd)
@@ -3260,6 +3255,9 @@ class OpenThread(OpenThreadTHCI, IThci):
         pass
 
     def _deviceAfterReset(self):
+        pass
+
+    def __restartAgentService(self):
         pass
 
     def _beforeRegisterMulticast(self, sAddr, timeout):

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -197,7 +197,6 @@ class OpenThreadTHCI(object):
     NETWORK_ATTACHMENT_TIMEOUT = 10
 
     IsBorderRouter = False
-    IsBackboneRouter = False
     IsHost = False
 
     externalCommissioner = None
@@ -559,13 +558,9 @@ class OpenThreadTHCI(object):
         ]:
             self.__setRouterSelectionJitter(1)
         elif self.deviceRole in [Thread_Device_Role.BR_1, Thread_Device_Role.BR_2]:
-            if self.DeviceCapability == OT12BR_CAPBS:
-                self.IsBackboneRouter = True
-            else:
-                self.IsBackboneRouter = False
             self.__setRouterSelectionJitter(1)
 
-        if self.IsBackboneRouter:
+        if self.DeviceCapability == OT12BR_CAPBS:
             # Configure default BBR dataset
             self.__configBbrDataset(SeqNum=self.bbrSeqNum,
                                     MlrTimeout=self.bbrMlrTimeout,
@@ -1398,7 +1393,6 @@ class OpenThreadTHCI(object):
         # indicate whether the default domain prefix is used.
         self.__useDefaultDomainPrefix = (self.DeviceCapability == OT12BR_CAPBS)
         self.__isUdpOpened = False
-        self.IsBackboneRouter = False
         self.IsHost = False
 
         # remove stale multicast addresses

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1395,11 +1395,8 @@ class OpenThreadTHCI(object):
         # indicate that the channel has been set, in case the channel was set
         # to default when joining network
         self.hasSetChannel = False
-        if self.DeviceCapability == OT12BR_CAPBS:
-            # indicate whether the default domain prefix is used.
-            self.__useDefaultDomainPrefix = True
-        else:
-            self.__useDefaultDomainPrefix = False
+        # indicate whether the default domain prefix is used.
+        self.__useDefaultDomainPrefix = (self.DeviceCapability == OT12BR_CAPBS)
         self.__isUdpOpened = False
         self.IsBackboneRouter = False
         self.IsHost = False

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -439,7 +439,7 @@ class OpenThread_BR(OpenThreadTHCI, IThci):
         if hop_limit is None:
             hop_limit = 5
 
-        if self.IsHost or self.DeviceCapability == OT12BR_CAPBS or self.DeviceCapability == OT13BR_CAPBS:
+        if self.IsHost or self.IsBorderRouter:
             ifName = 'eth0'
         else:
             ifName = 'wpan0'
@@ -465,7 +465,7 @@ class OpenThread_BR(OpenThreadTHCI, IThci):
         """
         hop_limit = 5
 
-        if self.IsHost or self.DeviceCapability == OT12BR_CAPBS or self.DeviceCapability == OT13BR_CAPBS:
+        if self.IsHost or self.IsBorderRouter:
             ifName = 'eth0'
         else:
             ifName = 'wpan0'

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -439,7 +439,7 @@ class OpenThread_BR(OpenThreadTHCI, IThci):
         if hop_limit is None:
             hop_limit = 5
 
-        if self.IsHost or self.IsBackboneRouter:
+        if self.IsHost or self.DeviceCapability == OT12BR_CAPBS or self.DeviceCapability == OT13BR_CAPBS:
             ifName = 'eth0'
         else:
             ifName = 'wpan0'
@@ -465,7 +465,7 @@ class OpenThread_BR(OpenThreadTHCI, IThci):
         """
         hop_limit = 5
 
-        if self.IsHost or self.IsBackboneRouter:
+        if self.IsHost or self.DeviceCapability == OT12BR_CAPBS or self.DeviceCapability == OT13BR_CAPBS:
             ifName = 'eth0'
         else:
             ifName = 'wpan0'


### PR DESCRIPTION
- Adding support for 1.3 style border router configurations which are different from the 1.2 style border router configurations.  The 'device capabilities' is used to differentiate between these 2 device types to assign them their needed configuration parameters.
- Also moving restartAgentService to the proper class.