### PR TITLE
[thread-tlvs] define min/max num of addrs under `Ip6AddressesTlv`

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (220)
+#define OPENTHREAD_API_VERSION (221)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -781,6 +781,8 @@ typedef void (*otIp6RegisterMulticastListenersCallback)(void *              aCon
                                                         const otIp6Address *aFailedAddresses,
                                                         uint8_t             aFailedAddressNum);
 
+#define OT_IP6_MAX_MLR_ADDRESSES 15 ///< Max number of IPv6 addresses supported by Multicast Listener Registration.
+
 /**
  * This function registers Multicast Listeners to Primary Backbone Router.
  *

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2691,7 +2691,7 @@ template <> otError Interpreter::Process<Cmd("mlr")>(Arg aArgs[])
 
     if (aArgs[0] == "reg")
     {
-        otIp6Address addresses[kIp6AddressesNumMax];
+        otIp6Address addresses[OT_IP6_MAX_MLR_ADDRESSES];
         uint32_t     timeout;
         bool         hasTimeout   = false;
         uint8_t      numAddresses = 0;

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -165,7 +165,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
 
     uint16_t     addressesOffset, addressesLength;
     Ip6::Address address;
-    Ip6::Address addresses[kIp6AddressesNumMax];
+    Ip6::Address addresses[Ip6AddressesTlv::kMaxAddresses];
     uint8_t      failedAddressNum  = 0;
     uint8_t      successAddressNum = 0;
     TimeMilli    expireTime;
@@ -207,7 +207,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
                      kErrorNone,
                  error = kErrorParse);
     VerifyOrExit(addressesLength % sizeof(Ip6::Address) == 0, status = ThreadStatusTlv::kMlrGeneralFailure);
-    VerifyOrExit(addressesLength / sizeof(Ip6::Address) <= kIp6AddressesNumMax,
+    VerifyOrExit(addressesLength / sizeof(Ip6::Address) <= Ip6AddressesTlv::kMaxAddresses,
                  status = ThreadStatusTlv::kMlrGeneralFailure);
 
     if (!processTimeoutTlv)
@@ -244,7 +244,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
             mMulticastListenersTable.Remove(address);
 
             // Put successfully de-registered addresses at the end of `addresses`.
-            addresses[kIp6AddressesNumMax - (++successAddressNum)] = address;
+            addresses[Ip6AddressesTlv::kMaxAddresses - (++successAddressNum)] = address;
         }
         else
         {
@@ -278,7 +278,7 @@ void Manager::HandleMulticastListenerRegistration(const Coap::Message &aMessage,
             else
             {
                 // Put successfully registered addresses at the end of `addresses`.
-                addresses[kIp6AddressesNumMax - (++successAddressNum)] = address;
+                addresses[Ip6AddressesTlv::kMaxAddresses - (++successAddressNum)] = address;
             }
         }
     }
@@ -291,7 +291,7 @@ exit:
 
     if (successAddressNum > 0)
     {
-        SendBackboneMulticastListenerRegistration(&addresses[kIp6AddressesNumMax - successAddressNum],
+        SendBackboneMulticastListenerRegistration(&addresses[Ip6AddressesTlv::kMaxAddresses - successAddressNum],
                                                   successAddressNum, timeout);
     }
 }
@@ -341,7 +341,7 @@ void Manager::SendBackboneMulticastListenerRegistration(const Ip6::Address *aAdd
     Ip6AddressesTlv   addressesTlv;
     BackboneTmfAgent &backboneTmf = Get<BackboneRouter::BackboneTmfAgent>();
 
-    OT_ASSERT(aAddressNum >= kIp6AddressesNumMin && aAddressNum <= kIp6AddressesNumMax);
+    OT_ASSERT(aAddressNum >= Ip6AddressesTlv::kMinAddresses && aAddressNum <= Ip6AddressesTlv::kMaxAddresses);
 
     message = backboneTmf.NewNonConfirmablePostMessage(UriPath::kBackboneMlr);
     VerifyOrExit(message != nullptr, error = kErrorNoBufs);

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -230,7 +230,7 @@ void MlrManager::SendMulticastListenerRegistration(void)
 {
     Error           error;
     Mle::MleRouter &mle = Get<Mle::MleRouter>();
-    Ip6::Address    addresses[kIp6AddressesNumMax];
+    Ip6::Address    addresses[Ip6AddressesTlv::kMaxAddresses];
     uint8_t         addressesNum = 0;
 
     VerifyOrExit(!mMlrPending, error = kErrorBusy);
@@ -243,7 +243,7 @@ void MlrManager::SendMulticastListenerRegistration(void)
     for (Ip6::Netif::ExternalMulticastAddress &addr :
          Get<ThreadNetif>().IterateExternalMulticastAddresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
     {
-        if (addressesNum >= kIp6AddressesNumMax)
+        if (addressesNum >= Ip6AddressesTlv::kMaxAddresses)
         {
             break;
         }
@@ -260,7 +260,7 @@ void MlrManager::SendMulticastListenerRegistration(void)
     // Append Child multicast addresses
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
-        if (addressesNum >= kIp6AddressesNumMax)
+        if (addressesNum >= Ip6AddressesTlv::kMaxAddresses)
         {
             break;
         }
@@ -272,7 +272,7 @@ void MlrManager::SendMulticastListenerRegistration(void)
 
         for (const Ip6::Address &address : child.IterateIp6Addresses(Ip6::Address::kTypeMulticastLargerThanRealmLocal))
         {
-            if (addressesNum >= kIp6AddressesNumMax)
+            if (addressesNum >= Ip6AddressesTlv::kMaxAddresses)
             {
                 break;
             }
@@ -326,7 +326,7 @@ Error MlrManager::RegisterMulticastListeners(const otIp6Address *               
     Error error;
 
     VerifyOrExit(aAddresses != nullptr, error = kErrorInvalidArgs);
-    VerifyOrExit(aAddressNum > 0 && aAddressNum <= kIp6AddressesNumMax, error = kErrorInvalidArgs);
+    VerifyOrExit(aAddressNum > 0 && aAddressNum <= Ip6AddressesTlv::kMaxAddresses, error = kErrorInvalidArgs);
     VerifyOrExit(aContext == nullptr || aCallback != nullptr, error = kErrorInvalidArgs);
 #if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     VerifyOrExit(Get<MeshCoP::Commissioner>().IsActive(), error = kErrorInvalidState);
@@ -368,7 +368,7 @@ void MlrManager::HandleRegisterMulticastListenersResponse(otMessage *          a
 
     uint8_t                                 status;
     Error                                   error;
-    Ip6::Address                            failedAddresses[kIp6AddressesNumMax];
+    Ip6::Address                            failedAddresses[Ip6AddressesTlv::kMaxAddresses];
     uint8_t                                 failedAddressNum = 0;
     otIp6RegisterMulticastListenersCallback callback         = mRegisterMulticastListenersCallback;
     void *                                  context          = mRegisterMulticastListenersContext;
@@ -469,7 +469,7 @@ void MlrManager::HandleMulticastListenerRegistrationResponse(Coap::Message *    
 
     uint8_t      status;
     Error        error;
-    Ip6::Address failedAddresses[kIp6AddressesNumMax];
+    Ip6::Address failedAddresses[Ip6AddressesTlv::kMaxAddresses];
     uint8_t      failedAddressNum = 0;
 
     error = ParseMulticastListenerRegistrationResponse(aResult, aMessage, status, failedAddresses, failedAddressNum);
@@ -520,7 +520,7 @@ Error MlrManager::ParseMulticastListenerRegistrationResponse(Error          aRes
         kErrorNone)
     {
         VerifyOrExit(addressesLength % sizeof(Ip6::Address) == 0, error = kErrorParse);
-        VerifyOrExit(addressesLength / sizeof(Ip6::Address) <= kIp6AddressesNumMax, error = kErrorParse);
+        VerifyOrExit(addressesLength / sizeof(Ip6::Address) <= Ip6AddressesTlv::kMaxAddresses, error = kErrorParse);
 
         for (uint16_t offset = 0; offset < addressesLength; offset += sizeof(Ip6::Address))
         {
@@ -701,7 +701,7 @@ void MlrManager::LogMulticastAddresses(void)
 #endif // OT_SHOULD_LOG_AT(OT_LOG_LEVEL_DEBG)
 }
 
-void MlrManager::AppendToUniqueAddressList(Ip6::Address (&aAddresses)[kIp6AddressesNumMax],
+void MlrManager::AppendToUniqueAddressList(Ip6::Address (&aAddresses)[Ip6AddressesTlv::kMaxAddresses],
                                            uint8_t &           aAddressNum,
                                            const Ip6::Address &aAddress)
 {

--- a/src/core/thread/mlr_manager.hpp
+++ b/src/core/thread/mlr_manager.hpp
@@ -192,7 +192,7 @@ private:
                                              const Ip6::Address *aFailedAddresses,
                                              uint8_t             aFailedAddressNum);
 
-    void        AppendToUniqueAddressList(Ip6::Address (&aAddresses)[kIp6AddressesNumMax],
+    void        AppendToUniqueAddressList(Ip6::Address (&aAddresses)[Ip6AddressesTlv::kMaxAddresses],
                                           uint8_t &           aAddressNum,
                                           const Ip6::Address &aAddress);
     static bool AddressListContains(const Ip6::Address *aAddressList,

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -48,10 +48,6 @@ namespace ot {
 using ot::Encoding::BigEndian::HostSwap16;
 using ot::Encoding::BigEndian::HostSwap32;
 
-// Thread 1.2.0 5.19.13 limits the number of IPv6 addresses should be [1, 15].
-constexpr uint8_t kIp6AddressesNumMin = 1;
-constexpr uint8_t kIp6AddressesNumMax = 15;
-
 /**
  * This class implements Network Layer TLV generation and parsing.
  *
@@ -315,6 +311,10 @@ OT_TOOL_PACKED_BEGIN
 class Ip6AddressesTlv : public ThreadTlv, public TlvInfo<ThreadTlv::kIp6Addresses>
 {
 public:
+    // Thread 1.2.0 5.19.13 limits the number of IPv6 addresses to [1, 15].
+    static constexpr uint8_t kMinAddresses = 1;
+    static constexpr uint8_t kMaxAddresses = OT_IP6_MAX_MLR_ADDRESSES;
+
     /**
      * This method initializes the TLV.
      *
@@ -330,8 +330,9 @@ public:
      */
     bool IsValid(void) const
     {
-        return GetLength() >= sizeof(Ip6::Address) * kIp6AddressesNumMin &&
-               GetLength() <= sizeof(Ip6::Address) * kIp6AddressesNumMax && (GetLength() % sizeof(Ip6::Address)) == 0;
+        return GetLength() >= sizeof(Ip6::Address) * Ip6AddressesTlv::kMinAddresses &&
+               GetLength() <= sizeof(Ip6::Address) * Ip6AddressesTlv::kMaxAddresses &&
+               (GetLength() % sizeof(Ip6::Address)) == 0;
     }
 
     /**

--- a/src/ncp/ncp_base_mtd.cpp
+++ b/src/ncp/ncp_base_mtd.cpp
@@ -320,7 +320,7 @@ template <> otError NcpBase::HandlePropertyGet<SPINEL_PROP_THREAD_CSL_CHANNEL>(v
 template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_MLR_REQUEST>(void)
 {
     otError      error = OT_ERROR_NONE;
-    otIp6Address addresses[kIp6AddressesNumMax];
+    otIp6Address addresses[OT_IP6_MAX_MLR_ADDRESSES];
     uint8_t      addressesCount = 0U;
     bool         timeoutPresent = false;
     uint32_t     timeout;
@@ -329,7 +329,7 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_THREAD_MLR_REQUEST>(v
 
     while (mDecoder.GetRemainingLengthInStruct())
     {
-        VerifyOrExit(addressesCount < kIp6AddressesNumMax, error = OT_ERROR_NO_BUFS);
+        VerifyOrExit(addressesCount < Ip6AddressesTlv::kMaxAddresses, error = OT_ERROR_NO_BUFS);
         SuccessOrExit(error = mDecoder.ReadIp6Address(addresses[addressesCount]));
         ++addressesCount;
     }


### PR DESCRIPTION
This commit moves the definitions of constants related to min/max
number of IPv6 addresses that can be included in an IP6 Addresses TLV
to `Ip6AddressesTlv` class. It also adds a public OT constant in
`ip6.h` related to this for MLR feature which is then used in `cli`
and `ncp` modules so to avoid the use of OT core internal constant
from CLI/NCP.