### PR TITLE
[netdata] wait for sync before accepting new data on leader restart

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -269,7 +269,7 @@ Error MleRouter::BecomeLeader(void)
     Get<NetworkData::Leader>().Reset();
     Get<MeshCoP::Leader>().SetEmptyCommissionerData();
 
-    SetStateLeader(Rloc16FromRouterId(leaderId));
+    SetStateLeader(Rloc16FromRouterId(leaderId), kStartingAsLeader);
 
 exit:
     return error;
@@ -401,7 +401,7 @@ void MleRouter::SetStateRouter(uint16_t aRloc16)
     }
 }
 
-void MleRouter::SetStateLeader(uint16_t aRloc16)
+void MleRouter::SetStateLeader(uint16_t aRloc16, LeaderStartMode aStartMode)
 {
     IgnoreError(Get<MeshCoP::ActiveDatasetManager>().Restore());
     IgnoreError(Get<MeshCoP::PendingDatasetManager>().Restore());
@@ -421,7 +421,7 @@ void MleRouter::SetStateLeader(uint16_t aRloc16)
     mPreviousPartitionIdRouter = mLeaderData.GetPartitionId();
     Get<TimeTicker>().RegisterReceiver(TimeTicker::kMleRouter);
 
-    Get<NetworkData::Leader>().Start();
+    Get<NetworkData::Leader>().Start(aStartMode);
     Get<MeshCoP::ActiveDatasetManager>().StartLeader();
     Get<MeshCoP::PendingDatasetManager>().StartLeader();
     Get<Tmf::Agent>().AddResource(mAddressSolicit);
@@ -938,7 +938,7 @@ Error MleRouter::HandleLinkAccept(RxInfo &aRxInfo, bool aRequest)
 
         if (mLeaderData.GetLeaderRouterId() == RouterIdFromRloc16(GetRloc16()))
         {
-            SetStateLeader(GetRloc16());
+            SetStateLeader(GetRloc16(), kRestoringLeaderRoleAfterReset);
         }
         else
         {

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -635,7 +635,7 @@ private:
                            const Message *     aRequestMessage = nullptr);
     Error SendDiscoveryResponse(const Ip6::Address &aDestination, const Message &aDiscoverRequestMessage);
     void  SetStateRouter(uint16_t aRloc16);
-    void  SetStateLeader(uint16_t aRloc16);
+    void  SetStateLeader(uint16_t aRloc16, LeaderStartMode aStartMode);
     void  StopLeader(void);
     void  SynchronizeChildNetworkData(void);
     Error UpdateChildAddresses(const Message &aMessage, uint16_t aOffset, Child &aChild);

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -218,6 +218,18 @@ constexpr uint16_t kAloc16NeighborDiscoveryAgentEnd   = 0xfc4e;
 constexpr uint8_t kServiceMinId = 0x00; ///< Minimal Service ID.
 constexpr uint8_t kServiceMaxId = 0x0f; ///< Maximal Service ID.
 
+/**
+ * This enumeration specifies the leader role start mode.
+ *
+ * The start mode indicates whether device is starting normally as leader or restoring its role after reset.
+ *
+ */
+enum LeaderStartMode : uint8_t
+{
+    kStartingAsLeader,              ///< Starting as leader normally.
+    kRestoringLeaderRoleAfterReset, ///< Restoring leader role after reset.
+};
+
 #if OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2
 
 /*

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -394,10 +394,9 @@ Error LeaderBase::SetNetworkData(uint8_t        aVersion,
     }
 
 #if OPENTHREAD_FTD
-    // Synchronize internal 6LoWPAN Context ID Set with recently obtained Network Data.
     if (Get<Mle::MleRouter>().IsLeader())
     {
-        Get<Leader>().UpdateContextsAfterReset();
+        Get<Leader>().HandleNetworkDataRestoredAfterReset();
     }
 #endif
 

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -95,8 +95,15 @@ public:
     /**
      * This method starts the Leader services.
      *
+     * The start mode indicates whether device is starting normally as leader or restoring its role as leader after
+     * reset. In the latter case, we do not accept any new registrations (`HandleServerData()`) and wait for
+     * `HandleNetworkDataRestoredAfterReset()` to indicate that the leader has successfully recovered the Network Data
+     * before allowing new Network Data registrations.
+     *
+     * @param[in] aStartMode   The start mode.
+     *
      */
-    void Start(void);
+    void Start(Mle::LeaderStartMode aStartMode);
 
     /**
      * This method stops the Leader services.
@@ -149,7 +156,7 @@ public:
      * Note that this method should be called only by the Leader once after reset.
      *
      */
-    void UpdateContextsAfterReset(void);
+    void HandleNetworkDataRestoredAfterReset(void);
 
     /**
      * This method scans network data for given Service ID and returns pointer to the respective TLV, if present.
@@ -305,7 +312,9 @@ private:
     static constexpr uint8_t  kNumContextIds       = 15;           // Maximum Context ID
     static constexpr uint32_t kContextIdReuseDelay = 48 * 60 * 60; // in seconds
     static constexpr uint32_t kStateUpdatePeriod   = 60 * 1000;    // State update period in milliseconds
+    static constexpr uint32_t kMaxNetDataSyncWait  = 60 * 1000;    // Maximum time to wait for netdata sync.
 
+    bool       mWaitingForNetDataSync;
     uint16_t   mContextUsed;
     TimeMilli  mContextLastUsed[kNumContextIds];
     uint32_t   mContextIdReuseDelay;


### PR DESCRIPTION
This commit adds a new mechanism related to Network Data recovery on
leader after restart. We determine whether device is starting normally
as leader or restoring its role as leader after restart. In the
latter case, we do not allow the device to accept any new Network Data
registrations until it has successfully recovered the Network Data
(received MLE Data Response).

This change help address situation where Network Data entries
registered with leader before it syncs and restores the Network Data
can be removed and then take a while to be re-registered.

----

- This should help address #7811 