### PR TITLE
[cli] enhance coex cli to show last time data

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -1199,25 +1199,31 @@ template <> otError Interpreter::Process<Cmd("coex")>(Arg aArgs[])
             {&otRadioCoexMetrics::mNumRxGrantNone, "Grant None"},
         };
 
+        static otRadioCoexMetrics sLastTimeMetrics;
+
         otRadioCoexMetrics metrics;
 
         SuccessOrExit(error = otPlatRadioGetCoexMetrics(GetInstancePtr(), &metrics));
 
         OutputLine("Stopped: %s", metrics.mStopped ? "true" : "false");
-        OutputLine("Grant Glitch: %u", metrics.mNumGrantGlitch);
+        OutputLine("Grant Glitch: %u (%u)", metrics.mNumGrantGlitch, sLastTimeMetrics.mNumGrantGlitch);
         OutputLine("Transmit metrics");
 
         for (const RadioCoexMetricName &metric : kTxMetricNames)
         {
-            OutputLine(kIndentSize, "%s: %u", metric.mName, metrics.*metric.mValuePtr);
+            OutputLine(kIndentSize, "%s: %u (%u)", metric.mName, metrics.*metric.mValuePtr,
+                       sLastTimeMetrics.*metric.mValuePtr);
         }
 
         OutputLine("Receive metrics");
 
         for (const RadioCoexMetricName &metric : kRxMetricNames)
         {
-            OutputLine(kIndentSize, "%s: %u", metric.mName, metrics.*metric.mValuePtr);
+            OutputLine(kIndentSize, "%s: %u (%u)", metric.mName, metrics.*metric.mValuePtr,
+                       sLastTimeMetrics.*metric.mValuePtr);
         }
+
+        memcpy(&sLastTimeMetrics, &metrics, sizeof(metrics));
     }
     else
     {


### PR DESCRIPTION
Some platforms implementation of coex metrics doesn't reset the 
metrics values each time after a query (They returns accumulated
value). In this way, when doing things like debugging, it's hard
to know the metrics during a recent period. This PR adds a static
variable to store the result of last-time query and print it in the 
cli query interface.