### PR TITLE
[instance] move definition of all OT core objects in `Instance`

### DIFF
--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -78,6 +78,121 @@ Instance::Instance(void)
     , mMessagePool(*this)
     , mIp6(*this)
     , mThreadNetif(*this)
+    , mTmfAgent(*this)
+#if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
+    , mDhcp6Client(*this)
+#endif
+#if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
+    , mDhcp6Server(*this)
+#endif
+#if OPENTHREAD_CONFIG_NEIGHBOR_DISCOVERY_AGENT_ENABLE
+    , mNeighborDiscoveryAgent(*this)
+#endif
+#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
+    , mSlaac(*this)
+#endif
+#if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
+    , mDnsClient(*this)
+#endif
+#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+    , mSrpClient(*this)
+#endif
+#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
+    , mSrpClientBuffers(*this)
+#endif
+#if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
+    , mDnssdServer(*this)
+#endif
+#if OPENTHREAD_CONFIG_DNS_DSO_ENABLE
+    , mDnsDso(*this)
+#endif
+#if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
+    , mSntpClient(*this)
+#endif
+    , mActiveDataset(*this)
+    , mPendingDataset(*this)
+    , mExtendedPanIdManager(*this)
+    , mNetworkNameManager(*this)
+    , mIp6Filter(*this)
+    , mKeyManager(*this)
+    , mLowpan(*this)
+    , mMac(*this)
+    , mMeshForwarder(*this)
+    , mMleRouter(*this)
+    , mDiscoverScanner(*this)
+    , mAddressResolver(*this)
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+    , mRadioSelector(*this)
+#endif
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+    , mNetworkDataLocal(*this)
+#endif
+    , mNetworkDataLeader(*this)
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+    , mNetworkDataNotifier(*this)
+#endif
+#if OPENTHREAD_CONFIG_NETDATA_PUBLISHER_ENABLE
+    , mNetworkDataPublisher(*this)
+#endif
+    , mNetworkDataServiceManager(*this)
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
+    , mNetworkDiagnostic(*this)
+#endif
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
+    , mBorderAgent(*this)
+#endif
+#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
+    , mCommissioner(*this)
+#endif
+#if OPENTHREAD_CONFIG_DTLS_ENABLE
+    , mCoapSecure(*this)
+#endif
+#if OPENTHREAD_CONFIG_JOINER_ENABLE
+    , mJoiner(*this)
+#endif
+#if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
+    , mJamDetector(*this)
+#endif
+#if OPENTHREAD_FTD
+    , mJoinerRouter(*this)
+    , mLeader(*this)
+#endif
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+    , mBackboneRouterLeader(*this)
+#endif
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+    , mBackboneRouterLocal(*this)
+    , mBackboneRouterManager(*this)
+#endif
+#if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
+    , mMlrManager(*this)
+#endif
+
+#if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)
+    , mDuaManager(*this)
+#endif
+#if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
+    , mSrpServer(*this)
+#endif
+
+#if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
+#if OPENTHREAD_FTD
+    , mChildSupervisor(*this)
+#endif
+    , mSupervisionListener(*this)
+#endif
+    , mAnnounceBegin(*this)
+    , mPanIdQuery(*this)
+    , mEnergyScan(*this)
+#if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE
+    , mAnycastLocator(*this)
+#endif
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    , mTimeSync(*this)
+#endif
+#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
+    , mLinkMetrics(*this)
+#endif
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
     , mApplicationCoap(*this)
 #endif

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -62,28 +62,72 @@
 #include "utils/otns.hpp"
 
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
+#include "backbone_router/backbone_tmf.hpp"
 #include "backbone_router/bbr_leader.hpp"
 #include "backbone_router/bbr_local.hpp"
+#include "backbone_router/bbr_manager.hpp"
 #include "border_router/routing_manager.hpp"
+#include "coap/coap_secure.hpp"
 #include "common/code_utils.hpp"
 #include "common/notifier.hpp"
 #include "common/settings.hpp"
 #include "crypto/mbedtls.hpp"
+#include "mac/mac.hpp"
 #include "meshcop/border_agent.hpp"
+#include "meshcop/commissioner.hpp"
+#include "meshcop/dataset_manager.hpp"
 #include "meshcop/dataset_updater.hpp"
 #include "meshcop/extended_panid.hpp"
+#include "meshcop/joiner.hpp"
+#include "meshcop/joiner_router.hpp"
+#include "meshcop/meshcop_leader.hpp"
 #include "meshcop/network_name.hpp"
+#include "net/dhcp6.hpp"
+#include "net/dhcp6_client.hpp"
+#include "net/dhcp6_server.hpp"
+#include "net/dns_client.hpp"
+#include "net/dns_dso.hpp"
+#include "net/dnssd_server.hpp"
 #include "net/ip6.hpp"
+#include "net/ip6_filter.hpp"
+#include "net/nd_agent.hpp"
+#include "net/netif.hpp"
+#include "net/sntp_client.hpp"
+#include "net/srp_client.hpp"
+#include "net/srp_server.hpp"
+#include "thread/address_resolver.hpp"
+#include "thread/announce_begin_server.hpp"
 #include "thread/announce_sender.hpp"
+#include "thread/anycast_locator.hpp"
+#include "thread/discover_scanner.hpp"
+#include "thread/dua_manager.hpp"
+#include "thread/energy_scan_server.hpp"
+#include "thread/key_manager.hpp"
 #include "thread/link_metrics.hpp"
 #include "thread/link_quality.hpp"
+#include "thread/mesh_forwarder.hpp"
+#include "thread/mle.hpp"
+#include "thread/mle_router.hpp"
+#include "thread/mlr_manager.hpp"
+#include "thread/network_data_local.hpp"
+#include "thread/network_data_notifier.hpp"
+#include "thread/network_data_publisher.hpp"
+#include "thread/network_data_service.hpp"
+#include "thread/network_diagnostic.hpp"
+#include "thread/panid_query_server.hpp"
+#include "thread/radio_selector.hpp"
 #include "thread/thread_netif.hpp"
+#include "thread/time_sync_service.hpp"
 #include "thread/tmf.hpp"
 #include "utils/channel_manager.hpp"
 #include "utils/channel_monitor.hpp"
+#include "utils/child_supervision.hpp"
 #include "utils/heap.hpp"
 #include "utils/history_tracker.hpp"
+#include "utils/jam_detector.hpp"
 #include "utils/ping_sender.hpp"
+#include "utils/slaac_address.hpp"
+#include "utils/srp_client_buffers.hpp"
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 
 /**
@@ -347,6 +391,7 @@ private:
     // (particularly, SubMac and Mac) to allow them to use its methods
     // from their constructor.
     Radio mRadio;
+
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
     Uptime mUptime;
 #endif
@@ -363,6 +408,153 @@ private:
 
     Ip6::Ip6    mIp6;
     ThreadNetif mThreadNetif;
+    Tmf::Agent  mTmfAgent;
+
+#if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
+    Dhcp6::Client mDhcp6Client;
+#endif
+
+#if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
+    Dhcp6::Server mDhcp6Server;
+#endif
+
+#if OPENTHREAD_CONFIG_NEIGHBOR_DISCOVERY_AGENT_ENABLE
+    NeighborDiscovery::Agent mNeighborDiscoveryAgent;
+#endif
+
+#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
+    Utils::Slaac mSlaac;
+#endif
+
+#if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
+    Dns::Client mDnsClient;
+#endif
+
+#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
+    Srp::Client mSrpClient;
+#endif
+
+#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
+    Utils::SrpClientBuffers mSrpClientBuffers;
+#endif
+
+#if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
+    Dns::ServiceDiscovery::Server mDnssdServer;
+#endif
+
+#if OPENTHREAD_CONFIG_DNS_DSO_ENABLE
+    Dns::Dso mDnsDso;
+#endif
+
+#if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
+    Sntp::Client mSntpClient;
+#endif
+
+    MeshCoP::ActiveDatasetManager  mActiveDataset;
+    MeshCoP::PendingDatasetManager mPendingDataset;
+    MeshCoP::ExtendedPanIdManager  mExtendedPanIdManager;
+    MeshCoP::NetworkNameManager    mNetworkNameManager;
+    Ip6::Filter                    mIp6Filter;
+    KeyManager                     mKeyManager;
+    Lowpan::Lowpan                 mLowpan;
+    Mac::Mac                       mMac;
+    MeshForwarder                  mMeshForwarder;
+    Mle::MleRouter                 mMleRouter;
+    Mle::DiscoverScanner           mDiscoverScanner;
+    AddressResolver                mAddressResolver;
+
+#if OPENTHREAD_CONFIG_MULTI_RADIO
+    RadioSelector mRadioSelector;
+#endif
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+    NetworkData::Local mNetworkDataLocal;
+#endif
+
+    NetworkData::Leader mNetworkDataLeader;
+
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
+    NetworkData::Notifier mNetworkDataNotifier;
+#endif
+
+#if OPENTHREAD_CONFIG_NETDATA_PUBLISHER_ENABLE
+    NetworkData::Publisher mNetworkDataPublisher;
+#endif
+
+    NetworkData::Service::Manager mNetworkDataServiceManager;
+
+#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
+    NetworkDiagnostic::NetworkDiagnostic mNetworkDiagnostic;
+#endif
+
+#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
+    MeshCoP::BorderAgent mBorderAgent;
+#endif
+
+#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
+    MeshCoP::Commissioner mCommissioner;
+#endif
+
+#if OPENTHREAD_CONFIG_DTLS_ENABLE
+    Coap::CoapSecure mCoapSecure;
+#endif
+
+#if OPENTHREAD_CONFIG_JOINER_ENABLE
+    MeshCoP::Joiner mJoiner;
+#endif
+
+#if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
+    Utils::JamDetector mJamDetector;
+#endif
+
+#if OPENTHREAD_FTD
+    MeshCoP::JoinerRouter mJoinerRouter;
+    MeshCoP::Leader       mLeader;
+#endif
+
+#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
+    BackboneRouter::Leader mBackboneRouterLeader;
+#endif
+
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
+    BackboneRouter::Local   mBackboneRouterLocal;
+    BackboneRouter::Manager mBackboneRouterManager;
+#endif
+
+#if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
+    MlrManager mMlrManager;
+#endif
+
+#if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)
+    DuaManager mDuaManager;
+#endif
+
+#if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
+    Srp::Server mSrpServer;
+#endif
+
+#if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
+#if OPENTHREAD_FTD
+    Utils::ChildSupervisor mChildSupervisor;
+#endif
+    Utils::SupervisionListener mSupervisionListener;
+#endif
+
+    AnnounceBeginServer mAnnounceBegin;
+    PanIdQueryServer    mPanIdQuery;
+    EnergyScanServer    mEnergyScan;
+
+#if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE
+    AnycastLocator mAnycastLocator;
+#endif
+
+#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
+    TimeSync mTimeSync;
+#endif
+
+#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
+    LinkMetrics::LinkMetrics mLinkMetrics;
+#endif
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
     Coap::Coap mApplicationCoap;
@@ -405,19 +597,23 @@ private:
 #endif
 
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
+
 #if OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
     Mac::LinkRaw mLinkRaw;
-#endif // OPENTHREAD_RADIO || OPENTHREAD_CONFIG_LINK_RAW_ENABLE
+#endif
 
 #if OPENTHREAD_CONFIG_LOG_LEVEL_DYNAMIC_ENABLE
     static LogLevel sLogLevel;
 #endif
+
 #if OPENTHREAD_ENABLE_VENDOR_EXTENSION
     Extension::ExtensionBase &mExtension;
 #endif
+
 #if OPENTHREAD_CONFIG_DIAG_ENABLE
     FactoryDiags::Diags mDiags;
 #endif
+
     bool mIsInitialized;
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE && (OPENTHREAD_FTD || OPENTHREAD_MTD)
@@ -475,45 +671,45 @@ template <> inline SettingsDriver &Instance::Get(void)
 
 template <> inline MeshForwarder &Instance::Get(void)
 {
-    return mThreadNetif.mMeshForwarder;
+    return mMeshForwarder;
 }
 
 #if OPENTHREAD_CONFIG_MULTI_RADIO
 template <> inline RadioSelector &Instance::Get(void)
 {
-    return mThreadNetif.mRadioSelector;
+    return mRadioSelector;
 }
 #endif
 
 template <> inline Mle::Mle &Instance::Get(void)
 {
-    return mThreadNetif.mMleRouter;
+    return mMleRouter;
 }
 
 template <> inline Mle::MleRouter &Instance::Get(void)
 {
-    return mThreadNetif.mMleRouter;
+    return mMleRouter;
 }
 
 template <> inline Mle::DiscoverScanner &Instance::Get(void)
 {
-    return mThreadNetif.mDiscoverScanner;
+    return mDiscoverScanner;
 }
 
 template <> inline NeighborTable &Instance::Get(void)
 {
-    return mThreadNetif.mMleRouter.mNeighborTable;
+    return mMleRouter.mNeighborTable;
 }
 
 #if OPENTHREAD_FTD
 template <> inline ChildTable &Instance::Get(void)
 {
-    return mThreadNetif.mMleRouter.mChildTable;
+    return mMleRouter.mChildTable;
 }
 
 template <> inline RouterTable &Instance::Get(void)
 {
-    return mThreadNetif.mMleRouter.mRouterTable;
+    return mMleRouter.mRouterTable;
 }
 #endif
 
@@ -534,144 +730,144 @@ template <> inline Ip6::Ip6 &Instance::Get(void)
 
 template <> inline Mac::Mac &Instance::Get(void)
 {
-    return mThreadNetif.mMac;
+    return mMac;
 }
 
 template <> inline Mac::SubMac &Instance::Get(void)
 {
-    return mThreadNetif.mMac.mLinks.mSubMac;
+    return mMac.mLinks.mSubMac;
 }
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 template <> inline Trel::Link &Instance::Get(void)
 {
-    return mThreadNetif.mMac.mLinks.mTrel;
+    return mMac.mLinks.mTrel;
 }
 
 template <> inline Trel::Interface &Instance::Get(void)
 {
-    return mThreadNetif.mMac.mLinks.mTrel.mInterface;
+    return mMac.mLinks.mTrel.mInterface;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE
 template <> inline Mac::Filter &Instance::Get(void)
 {
-    return mThreadNetif.mMac.mFilter;
+    return mMac.mFilter;
 }
 #endif
 
 template <> inline Lowpan::Lowpan &Instance::Get(void)
 {
-    return mThreadNetif.mLowpan;
+    return mLowpan;
 }
 
 template <> inline KeyManager &Instance::Get(void)
 {
-    return mThreadNetif.mKeyManager;
+    return mKeyManager;
 }
 
 template <> inline Ip6::Filter &Instance::Get(void)
 {
-    return mThreadNetif.mIp6Filter;
+    return mIp6Filter;
 }
 
 template <> inline AddressResolver &Instance::Get(void)
 {
-    return mThreadNetif.mAddressResolver;
+    return mAddressResolver;
 }
 
 #if OPENTHREAD_FTD
 
 template <> inline IndirectSender &Instance::Get(void)
 {
-    return mThreadNetif.mMeshForwarder.mIndirectSender;
+    return mMeshForwarder.mIndirectSender;
 }
 
 template <> inline SourceMatchController &Instance::Get(void)
 {
-    return mThreadNetif.mMeshForwarder.mIndirectSender.mSourceMatchController;
+    return mMeshForwarder.mIndirectSender.mSourceMatchController;
 }
 
 template <> inline DataPollHandler &Instance::Get(void)
 {
-    return mThreadNetif.mMeshForwarder.mIndirectSender.mDataPollHandler;
+    return mMeshForwarder.mIndirectSender.mDataPollHandler;
 }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
 template <> inline CslTxScheduler &Instance::Get(void)
 {
-    return mThreadNetif.mMeshForwarder.mIndirectSender.mCslTxScheduler;
+    return mMeshForwarder.mIndirectSender.mCslTxScheduler;
 }
 #endif
 
 template <> inline MeshCoP::Leader &Instance::Get(void)
 {
-    return mThreadNetif.mLeader;
+    return mLeader;
 }
 
 template <> inline MeshCoP::JoinerRouter &Instance::Get(void)
 {
-    return mThreadNetif.mJoinerRouter;
+    return mJoinerRouter;
 }
 #endif // OPENTHREAD_FTD
 
 template <> inline AnnounceBeginServer &Instance::Get(void)
 {
-    return mThreadNetif.mAnnounceBegin;
+    return mAnnounceBegin;
 }
 
 template <> inline DataPollSender &Instance::Get(void)
 {
-    return mThreadNetif.mMeshForwarder.mDataPollSender;
+    return mMeshForwarder.mDataPollSender;
 }
 
 template <> inline EnergyScanServer &Instance::Get(void)
 {
-    return mThreadNetif.mEnergyScan;
+    return mEnergyScan;
 }
 
 template <> inline PanIdQueryServer &Instance::Get(void)
 {
-    return mThreadNetif.mPanIdQuery;
+    return mPanIdQuery;
 }
 
 #if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE
 template <> inline AnycastLocator &Instance::Get(void)
 {
-    return mThreadNetif.mAnycastLocator;
+    return mAnycastLocator;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 template <> inline NetworkData::Local &Instance::Get(void)
 {
-    return mThreadNetif.mNetworkDataLocal;
+    return mNetworkDataLocal;
 }
 #endif
 
 template <> inline NetworkData::Leader &Instance::Get(void)
 {
-    return mThreadNetif.mNetworkDataLeader;
+    return mNetworkDataLeader;
 }
 
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 template <> inline NetworkData::Notifier &Instance::Get(void)
 {
-    return mThreadNetif.mNetworkDataNotifier;
+    return mNetworkDataNotifier;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_NETDATA_PUBLISHER_ENABLE
 template <> inline NetworkData::Publisher &Instance::Get(void)
 {
-    return mThreadNetif.mNetworkDataPublisher;
+    return mNetworkDataPublisher;
 }
 #endif
 
 template <> inline NetworkData::Service::Manager &Instance::Get(void)
 {
-    return mThreadNetif.mNetworkDataServiceManager;
+    return mNetworkDataServiceManager;
 }
 
 #if OPENTHREAD_CONFIG_TCP_ENABLE
@@ -698,138 +894,138 @@ template <> inline Ip6::Mpl &Instance::Get(void)
 
 template <> inline Tmf::Agent &Instance::Get(void)
 {
-    return mThreadNetif.mTmfAgent;
+    return mTmfAgent;
 }
 
 #if OPENTHREAD_CONFIG_DTLS_ENABLE
 template <> inline Coap::CoapSecure &Instance::Get(void)
 {
-    return mThreadNetif.mCoapSecure;
+    return mCoapSecure;
 }
 #endif
 
 template <> inline MeshCoP::ExtendedPanIdManager &Instance::Get(void)
 {
-    return mThreadNetif.mExtendedPanIdManager;
+    return mExtendedPanIdManager;
 }
 
 template <> inline MeshCoP::NetworkNameManager &Instance::Get(void)
 {
-    return mThreadNetif.mNetworkNameManager;
+    return mNetworkNameManager;
 }
 
 template <> inline MeshCoP::ActiveDatasetManager &Instance::Get(void)
 {
-    return mThreadNetif.mActiveDataset;
+    return mActiveDataset;
 }
 
 template <> inline MeshCoP::PendingDatasetManager &Instance::Get(void)
 {
-    return mThreadNetif.mPendingDataset;
+    return mPendingDataset;
 }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 template <> inline TimeSync &Instance::Get(void)
 {
-    return mThreadNetif.mTimeSync;
+    return mTimeSync;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
 template <> inline MeshCoP::Commissioner &Instance::Get(void)
 {
-    return mThreadNetif.mCommissioner;
+    return mCommissioner;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
 template <> inline MeshCoP::Joiner &Instance::Get(void)
 {
-    return mThreadNetif.mJoiner;
+    return mJoiner;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
 template <> inline Dns::Client &Instance::Get(void)
 {
-    return mThreadNetif.mDnsClient;
+    return mDnsClient;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
 template <> inline Srp::Client &Instance::Get(void)
 {
-    return mThreadNetif.mSrpClient;
+    return mSrpClient;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
 template <> inline Utils::SrpClientBuffers &Instance::Get(void)
 {
-    return mThreadNetif.mSrpClientBuffers;
+    return mSrpClientBuffers;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
 template <> inline Dns::ServiceDiscovery::Server &Instance::Get(void)
 {
-    return mThreadNetif.mDnssdServer;
+    return mDnssdServer;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_DNS_DSO_ENABLE
 template <> inline Dns::Dso &Instance::Get(void)
 {
-    return mThreadNetif.mDnsDso;
+    return mDnsDso;
 }
 #endif
 
 #if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
 template <> inline NetworkDiagnostic::NetworkDiagnostic &Instance::Get(void)
 {
-    return mThreadNetif.mNetworkDiagnostic;
+    return mNetworkDiagnostic;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
 template <> inline Dhcp6::Client &Instance::Get(void)
 {
-    return mThreadNetif.mDhcp6Client;
+    return mDhcp6Client;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
 template <> inline Dhcp6::Server &Instance::Get(void)
 {
-    return mThreadNetif.mDhcp6Server;
+    return mDhcp6Server;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_NEIGHBOR_DISCOVERY_AGENT_ENABLE
 template <> inline NeighborDiscovery::Agent &Instance::Get(void)
 {
-    return mThreadNetif.mNeighborDiscoveryAgent;
+    return mNeighborDiscoveryAgent;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
 template <> inline Utils::Slaac &Instance::Get(void)
 {
-    return mThreadNetif.mSlaac;
+    return mSlaac;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
 template <> inline Utils::JamDetector &Instance::Get(void)
 {
-    return mThreadNetif.mJamDetector;
+    return mJamDetector;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
 template <> inline Sntp::Client &Instance::Get(void)
 {
-    return mThreadNetif.mSntpClient;
+    return mSntpClient;
 }
 #endif
 
@@ -837,12 +1033,12 @@ template <> inline Sntp::Client &Instance::Get(void)
 #if OPENTHREAD_FTD
 template <> inline Utils::ChildSupervisor &Instance::Get(void)
 {
-    return mThreadNetif.mChildSupervisor;
+    return mChildSupervisor;
 }
 #endif
 template <> inline Utils::SupervisionListener &Instance::Get(void)
 {
-    return mThreadNetif.mSupervisionListener;
+    return mSupervisionListener;
 }
 #endif
 
@@ -884,7 +1080,7 @@ template <> inline MeshCoP::DatasetUpdater &Instance::Get(void)
 #if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
 template <> inline MeshCoP::BorderAgent &Instance::Get(void)
 {
-    return mThreadNetif.mBorderAgent;
+    return mBorderAgent;
 }
 #endif
 
@@ -904,57 +1100,57 @@ template <> inline MessagePool &Instance::Get(void)
 
 template <> inline BackboneRouter::Leader &Instance::Get(void)
 {
-    return mThreadNetif.mBackboneRouterLeader;
+    return mBackboneRouterLeader;
 }
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
 template <> inline BackboneRouter::Local &Instance::Get(void)
 {
-    return mThreadNetif.mBackboneRouterLocal;
+    return mBackboneRouterLocal;
 }
 template <> inline BackboneRouter::Manager &Instance::Get(void)
 {
-    return mThreadNetif.mBackboneRouterManager;
+    return mBackboneRouterManager;
 }
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
 template <> inline BackboneRouter::MulticastListenersTable &Instance::Get(void)
 {
-    return mThreadNetif.mBackboneRouterManager.GetMulticastListenersTable();
+    return mBackboneRouterManager.GetMulticastListenersTable();
 }
 #endif
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
 template <> inline BackboneRouter::NdProxyTable &Instance::Get(void)
 {
-    return mThreadNetif.mBackboneRouterManager.GetNdProxyTable();
+    return mBackboneRouterManager.GetNdProxyTable();
 }
 #endif
 
 template <> inline BackboneRouter::BackboneTmfAgent &Instance::Get(void)
 {
-    return mThreadNetif.mBackboneRouterManager.GetBackboneTmfAgent();
+    return mBackboneRouterManager.GetBackboneTmfAgent();
 }
 #endif
 
 #if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
 template <> inline MlrManager &Instance::Get(void)
 {
-    return mThreadNetif.mMlrManager;
+    return mMlrManager;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)
 template <> inline DuaManager &Instance::Get(void)
 {
-    return mThreadNetif.mDuaManager;
+    return mDuaManager;
 }
 #endif
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
 template <> inline LinkMetrics::LinkMetrics &Instance::Get(void)
 {
-    return mThreadNetif.mLinkMetrics;
+    return mLinkMetrics;
 }
 #endif
 
@@ -982,7 +1178,7 @@ template <> inline BorderRouter::InfraIf &Instance::Get(void)
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
 template <> inline Srp::Server &Instance::Get(void)
 {
-    return mThreadNetif.mSrpServer;
+    return mSrpServer;
 }
 #endif
 

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -49,122 +49,7 @@ namespace ot {
 
 ThreadNetif::ThreadNetif(Instance &aInstance)
     : Netif(aInstance)
-    , mTmfAgent(aInstance)
-#if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
-    , mDhcp6Client(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
-    , mDhcp6Server(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_NEIGHBOR_DISCOVERY_AGENT_ENABLE
-    , mNeighborDiscoveryAgent(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
-    , mSlaac(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
-    , mDnsClient(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
-    , mSrpClient(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
-    , mSrpClientBuffers(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
-    , mDnssdServer(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_DNS_DSO_ENABLE
-    , mDnsDso(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
-    , mSntpClient(aInstance)
-#endif
-    , mActiveDataset(aInstance)
-    , mPendingDataset(aInstance)
-    , mExtendedPanIdManager(aInstance)
-    , mNetworkNameManager(aInstance)
-    , mIp6Filter(aInstance)
-    , mKeyManager(aInstance)
-    , mLowpan(aInstance)
-    , mMac(aInstance)
-    , mMeshForwarder(aInstance)
-    , mMleRouter(aInstance)
-    , mDiscoverScanner(aInstance)
-    , mAddressResolver(aInstance)
-#if OPENTHREAD_CONFIG_MULTI_RADIO
-    , mRadioSelector(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    , mNetworkDataLocal(aInstance)
-#endif
-    , mNetworkDataLeader(aInstance)
-#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    , mNetworkDataNotifier(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_NETDATA_PUBLISHER_ENABLE
-    , mNetworkDataPublisher(aInstance)
-#endif
-    , mNetworkDataServiceManager(aInstance)
-#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
-    , mNetworkDiagnostic(aInstance)
-#endif
     , mIsUp(false)
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    , mBorderAgent(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-    , mCommissioner(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_DTLS_ENABLE
-    , mCoapSecure(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_JOINER_ENABLE
-    , mJoiner(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
-    , mJamDetector(aInstance)
-#endif
-#if OPENTHREAD_FTD
-    , mJoinerRouter(aInstance)
-    , mLeader(aInstance)
-#endif
-#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-    , mBackboneRouterLeader(aInstance)
-#endif
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    , mBackboneRouterLocal(aInstance)
-    , mBackboneRouterManager(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
-    , mMlrManager(aInstance)
-#endif
-
-#if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)
-    , mDuaManager(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
-    , mSrpServer(aInstance)
-#endif
-
-#if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
-#if OPENTHREAD_FTD
-    , mChildSupervisor(aInstance)
-#endif
-    , mSupervisionListener(aInstance)
-#endif
-    , mAnnounceBegin(aInstance)
-    , mPanIdQuery(aInstance)
-    , mEnergyScan(aInstance)
-#if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE
-    , mAnycastLocator(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    , mTimeSync(aInstance)
-#endif
-#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
-    , mLinkMetrics(aInstance)
-#endif
 {
 }
 
@@ -231,6 +116,11 @@ void ThreadNetif::Down(void)
 
 exit:
     return;
+}
+
+Error ThreadNetif::SendMessage(Message &aMessage)
+{
+    return Get<MeshForwarder>().SendMessage(aMessage);
 }
 
 Error ThreadNetif::RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination, uint8_t *aPrefixMatch)

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -36,57 +36,8 @@
 
 #include "openthread-core-config.h"
 
-#include "backbone_router/backbone_tmf.hpp"
-#include "backbone_router/bbr_leader.hpp"
-#include "backbone_router/bbr_local.hpp"
-#include "backbone_router/bbr_manager.hpp"
-#include "coap/coap_secure.hpp"
-#include "mac/mac.hpp"
-#include "meshcop/border_agent.hpp"
-#include "meshcop/commissioner.hpp"
-#include "meshcop/dataset_manager.hpp"
-#include "meshcop/extended_panid.hpp"
-#include "meshcop/joiner.hpp"
-#include "meshcop/joiner_router.hpp"
-#include "meshcop/meshcop_leader.hpp"
-#include "meshcop/network_name.hpp"
-#include "net/dhcp6.hpp"
-#include "net/dhcp6_client.hpp"
-#include "net/dhcp6_server.hpp"
-#include "net/dns_client.hpp"
-#include "net/dns_dso.hpp"
-#include "net/dnssd_server.hpp"
-#include "net/ip6_filter.hpp"
-#include "net/nd_agent.hpp"
+#include "net/ip6_address.hpp"
 #include "net/netif.hpp"
-#include "net/sntp_client.hpp"
-#include "net/srp_client.hpp"
-#include "net/srp_server.hpp"
-#include "thread/address_resolver.hpp"
-#include "thread/announce_begin_server.hpp"
-#include "thread/anycast_locator.hpp"
-#include "thread/discover_scanner.hpp"
-#include "thread/dua_manager.hpp"
-#include "thread/energy_scan_server.hpp"
-#include "thread/key_manager.hpp"
-#include "thread/link_metrics.hpp"
-#include "thread/mesh_forwarder.hpp"
-#include "thread/mle.hpp"
-#include "thread/mle_router.hpp"
-#include "thread/mlr_manager.hpp"
-#include "thread/network_data_local.hpp"
-#include "thread/network_data_notifier.hpp"
-#include "thread/network_data_publisher.hpp"
-#include "thread/network_data_service.hpp"
-#include "thread/network_diagnostic.hpp"
-#include "thread/panid_query_server.hpp"
-#include "thread/radio_selector.hpp"
-#include "thread/time_sync_service.hpp"
-#include "thread/tmf.hpp"
-#include "utils/child_supervision.hpp"
-#include "utils/jam_detector.hpp"
-#include "utils/slaac_address.hpp"
-#include "utils/srp_client_buffers.hpp"
 
 namespace ot {
 
@@ -101,8 +52,6 @@ namespace ot {
 
 class ThreadNetif : public Ip6::Netif
 {
-    friend class Instance;
-
 public:
     /**
      * This constructor initializes the Thread network interface.
@@ -141,7 +90,7 @@ public:
      * @retval kErrorNone  Successfully submitted the message to the interface.
      *
      */
-    Error SendMessage(Message &aMessage) { return mMeshForwarder.SendMessage(aMessage); }
+    Error SendMessage(Message &aMessage);
 
     /**
      * This method performs a route lookup.
@@ -168,128 +117,7 @@ public:
     bool IsOnMesh(const Ip6::Address &aAddress) const;
 
 private:
-    Tmf::Agent mTmfAgent;
-#if OPENTHREAD_CONFIG_DHCP6_CLIENT_ENABLE
-    Dhcp6::Client mDhcp6Client;
-#endif
-#if OPENTHREAD_CONFIG_DHCP6_SERVER_ENABLE
-    Dhcp6::Server mDhcp6Server;
-#endif
-#if OPENTHREAD_CONFIG_NEIGHBOR_DISCOVERY_AGENT_ENABLE
-    NeighborDiscovery::Agent mNeighborDiscoveryAgent;
-#endif
-#if OPENTHREAD_CONFIG_IP6_SLAAC_ENABLE
-    Utils::Slaac mSlaac;
-#endif
-#if OPENTHREAD_CONFIG_DNS_CLIENT_ENABLE
-    Dns::Client mDnsClient;
-#endif
-#if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
-    Srp::Client mSrpClient;
-#endif
-#if OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_ENABLE
-    Utils::SrpClientBuffers mSrpClientBuffers;
-#endif
-#if OPENTHREAD_CONFIG_DNSSD_SERVER_ENABLE
-    Dns::ServiceDiscovery::Server mDnssdServer;
-#endif
-#if OPENTHREAD_CONFIG_DNS_DSO_ENABLE
-    Dns::Dso mDnsDso;
-#endif
-#if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
-    Sntp::Client mSntpClient;
-#endif
-    MeshCoP::ActiveDatasetManager  mActiveDataset;
-    MeshCoP::PendingDatasetManager mPendingDataset;
-    MeshCoP::ExtendedPanIdManager  mExtendedPanIdManager;
-    MeshCoP::NetworkNameManager    mNetworkNameManager;
-    Ip6::Filter                    mIp6Filter;
-    KeyManager                     mKeyManager;
-    Lowpan::Lowpan                 mLowpan;
-    Mac::Mac                       mMac;
-    MeshForwarder                  mMeshForwarder;
-    Mle::MleRouter                 mMleRouter;
-    Mle::DiscoverScanner           mDiscoverScanner;
-    AddressResolver                mAddressResolver;
-#if OPENTHREAD_CONFIG_MULTI_RADIO
-    RadioSelector mRadioSelector;
-#endif
-#if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    NetworkData::Local mNetworkDataLocal;
-#endif // OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    NetworkData::Leader mNetworkDataLeader;
-#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE || OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
-    NetworkData::Notifier mNetworkDataNotifier;
-#endif
-#if OPENTHREAD_CONFIG_NETDATA_PUBLISHER_ENABLE
-    NetworkData::Publisher mNetworkDataPublisher;
-#endif
-    NetworkData::Service::Manager mNetworkDataServiceManager;
-#if OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
-    NetworkDiagnostic::NetworkDiagnostic mNetworkDiagnostic;
-#endif // OPENTHREAD_FTD || OPENTHREAD_CONFIG_TMF_NETWORK_DIAG_MTD_ENABLE
     bool mIsUp;
-
-#if OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-    MeshCoP::BorderAgent mBorderAgent;
-#endif
-#if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-    MeshCoP::Commissioner mCommissioner;
-#endif // OPENTHREAD_CONFIG_COMMISSIONER_ENABLE
-
-#if OPENTHREAD_CONFIG_DTLS_ENABLE
-    Coap::CoapSecure mCoapSecure;
-#endif // OPENTHREAD_CONFIG_DTLS_ENABLE
-
-#if OPENTHREAD_CONFIG_JOINER_ENABLE
-    MeshCoP::Joiner mJoiner;
-#endif // OPENTHREAD_CONFIG_JOINER_ENABLE
-
-#if OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
-    Utils::JamDetector mJamDetector;
-#endif // OPENTHREAD_CONFIG_JAM_DETECTION_ENABLE
-
-#if OPENTHREAD_FTD
-    MeshCoP::JoinerRouter mJoinerRouter;
-    MeshCoP::Leader       mLeader;
-#endif // OPENTHREAD_FTD
-
-#if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
-    BackboneRouter::Leader mBackboneRouterLeader;
-#endif
-#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
-    BackboneRouter::Local   mBackboneRouterLocal;
-    BackboneRouter::Manager mBackboneRouterManager;
-#endif
-#if OPENTHREAD_CONFIG_MLR_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_MLR_ENABLE)
-    MlrManager mMlrManager;
-#endif
-#if OPENTHREAD_CONFIG_DUA_ENABLE || (OPENTHREAD_FTD && OPENTHREAD_CONFIG_TMF_PROXY_DUA_ENABLE)
-    DuaManager mDuaManager;
-#endif
-#if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
-    Srp::Server mSrpServer;
-#endif
-
-#if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE
-#if OPENTHREAD_FTD
-    Utils::ChildSupervisor mChildSupervisor;
-#endif
-    Utils::SupervisionListener mSupervisionListener;
-#endif
-    AnnounceBeginServer mAnnounceBegin;
-    PanIdQueryServer    mPanIdQuery;
-    EnergyScanServer    mEnergyScan;
-#if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE
-    AnycastLocator mAnycastLocator;
-#endif
-
-#if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
-    TimeSync mTimeSync;
-#endif
-#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
-    LinkMetrics::LinkMetrics mLinkMetrics;
-#endif
 };
 
 /**


### PR DESCRIPTION
This commit moves all the OT core member variable definitions into
`Instance` class (from `ThreadNetif`).