### PR TITLE
[dua] allow MTD to handle ADDR_ERR.ntf messages

### DIFF
--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -576,6 +576,11 @@ template <> inline Ip6::Filter &Instance::Get(void)
     return mThreadNetif.mIp6Filter;
 }
 
+template <> inline AddressResolver &Instance::Get(void)
+{
+    return mThreadNetif.mAddressResolver;
+}
+
 #if OPENTHREAD_FTD
 
 template <> inline IndirectSender &Instance::Get(void)
@@ -599,11 +604,6 @@ template <> inline CslTxScheduler &Instance::Get(void)
     return mThreadNetif.mMeshForwarder.mIndirectSender.mCslTxScheduler;
 }
 #endif
-
-template <> inline AddressResolver &Instance::Get(void)
-{
-    return mThreadNetif.mAddressResolver;
-}
 
 template <> inline MeshCoP::Leader &Instance::Get(void)
 {

--- a/src/core/thread/address_resolver.cpp
+++ b/src/core/thread/address_resolver.cpp
@@ -33,8 +33,6 @@
 
 #include "address_resolver.hpp"
 
-#if OPENTHREAD_FTD
-
 #include "coap/coap_message.hpp"
 #include "common/as_core_type.hpp"
 #include "common/code_utils.hpp"
@@ -57,17 +55,23 @@ RegisterLogModule("AddrResolver");
 AddressResolver::AddressResolver(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mAddressError(UriPath::kAddressError, &AddressResolver::HandleAddressError, this)
+#if OPENTHREAD_FTD
     , mAddressQuery(UriPath::kAddressQuery, &AddressResolver::HandleAddressQuery, this)
     , mAddressNotification(UriPath::kAddressNotify, &AddressResolver::HandleAddressNotification, this)
     , mCacheEntryPool(aInstance)
     , mIcmpHandler(&AddressResolver::HandleIcmpReceive, this)
+#endif
 {
     Get<Tmf::Agent>().AddResource(mAddressError);
+#if OPENTHREAD_FTD
     Get<Tmf::Agent>().AddResource(mAddressQuery);
     Get<Tmf::Agent>().AddResource(mAddressNotification);
 
     IgnoreError(Get<Ip6::Icmp>().RegisterHandler(mIcmpHandler));
+#endif
 }
+
+#if OPENTHREAD_FTD
 
 void AddressResolver::Clear(void)
 {
@@ -703,6 +707,8 @@ exit:
     }
 }
 
+#endif // OPENTHREAD_FTD
+
 void AddressResolver::HandleAddressError(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
     static_cast<AddressResolver *>(aContext)->HandleAddressError(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
@@ -713,8 +719,10 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
     Error                    error = kErrorNone;
     Ip6::Address             target;
     Ip6::InterfaceIdentifier meshLocalIid;
-    Mac::ExtAddress          extAddr;
-    Ip6::Address             destination;
+#if OPENTHREAD_FTD
+    Mac::ExtAddress extAddr;
+    Ip6::Address    destination;
+#endif
 
     VerifyOrExit(aMessage.IsPostRequest(), error = kErrorDrop);
 
@@ -751,6 +759,7 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
         }
     }
 
+#if OPENTHREAD_FTD
     meshLocalIid.ConvertToExtAddress(extAddr);
 
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
@@ -774,6 +783,7 @@ void AddressResolver::HandleAddressError(Coap::Message &aMessage, const Ip6::Mes
             }
         }
     }
+#endif // OPENTHREAD_FTD
 
 exit:
 
@@ -782,6 +792,8 @@ exit:
         LogWarn("Error while processing address error notification: %s", ErrorToString(error));
     }
 }
+
+#if OPENTHREAD_FTD
 
 void AddressResolver::HandleAddressQuery(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
 {
@@ -1073,6 +1085,6 @@ exit:
     return;
 }
 
-} // namespace ot
-
 #endif // OPENTHREAD_FTD
+
+} // namespace ot

--- a/src/core/thread/address_resolver.hpp
+++ b/src/core/thread/address_resolver.hpp
@@ -36,8 +36,6 @@
 
 #include "openthread-core-config.h"
 
-#if OPENTHREAD_FTD
-
 #include "coap/coap.hpp"
 #include "common/linked_list.hpp"
 #include "common/locator.hpp"
@@ -87,6 +85,7 @@ public:
      */
     explicit AddressResolver(Instance &aInstance);
 
+#if OPENTHREAD_FTD
     /**
      * This method clears the EID-to-RLOC cache.
      *
@@ -317,9 +316,12 @@ private:
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
+#endif // OPENTHREAD_FTD
+
     static void HandleAddressError(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleAddressError(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
+#if OPENTHREAD_FTD
     static void HandleAddressQuery(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleAddressQuery(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
@@ -345,7 +347,9 @@ private:
 
     static AddressResolver::CacheEntry *GetEntryAfter(CacheEntry *aPrev, CacheEntryList &aList);
 
+#endif // OPENTHREAD_FTD
     Coap::Resource mAddressError;
+#if OPENTHREAD_FTD
     Coap::Resource mAddressQuery;
     Coap::Resource mAddressNotification;
 
@@ -356,6 +360,7 @@ private:
     CacheEntryList mQueryRetryList;
 
     Ip6::Icmp::Handler mIcmpHandler;
+#endif //  OPENTHREAD_FTD
 };
 
 /**
@@ -363,7 +368,5 @@ private:
  */
 
 } // namespace ot
-
-#endif //  OPENTHREAD_FTD
 
 #endif // ADDRESS_RESOLVER_HPP_

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -91,6 +91,7 @@ ThreadNetif::ThreadNetif(Instance &aInstance)
     , mMeshForwarder(aInstance)
     , mMleRouter(aInstance)
     , mDiscoverScanner(aInstance)
+    , mAddressResolver(aInstance)
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     , mRadioSelector(aInstance)
 #endif
@@ -127,7 +128,6 @@ ThreadNetif::ThreadNetif(Instance &aInstance)
 #if OPENTHREAD_FTD
     , mJoinerRouter(aInstance)
     , mLeader(aInstance)
-    , mAddressResolver(aInstance)
 #endif
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)
     , mBackboneRouterLeader(aInstance)

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -210,6 +210,7 @@ private:
     MeshForwarder                  mMeshForwarder;
     Mle::MleRouter                 mMleRouter;
     Mle::DiscoverScanner           mDiscoverScanner;
+    AddressResolver                mAddressResolver;
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     RadioSelector mRadioSelector;
 #endif
@@ -251,7 +252,6 @@ private:
 #if OPENTHREAD_FTD
     MeshCoP::JoinerRouter mJoinerRouter;
     MeshCoP::Leader       mLeader;
-    AddressResolver       mAddressResolver;
 #endif // OPENTHREAD_FTD
 
 #if (OPENTHREAD_CONFIG_THREAD_VERSION >= OT_THREAD_VERSION_1_2)

--- a/tests/scripts/thread-cert/v1_2_test_dua_handle_address_error.py
+++ b/tests/scripts/thread-cert/v1_2_test_dua_handle_address_error.py
@@ -77,6 +77,7 @@ class TestDomainUnicastAddress(thread_cert.TestCase):
         },
         MED: {
             'version': '1.2',
+            'is_mtd': True,
             'allowlist': [ROUTER],
             'mode': 'rn',
         },


### PR DESCRIPTION
An MTD interface should be able to handle Address Error Notifications
as per Thread Specification section 5.6.4.