### PR TITLE
[routing-manager] get/set preference to advertise OMR prefix in RA msg

### DIFF
--- a/include/openthread/border_router.h
+++ b/include/openthread/border_router.h
@@ -87,6 +87,31 @@ otError otBorderRoutingInit(otInstance *aInstance, uint32_t aInfraIfIndex, bool 
 otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled);
 
 /**
+ * This function gets the preference used when advertising Route Info Options (e.g., for discovered OMR prefixes) in
+ * Router Advertisement messages sent over the infrastructure link.
+ *
+ * @param[in] aInstance A pointer to an OpenThread instance.
+ *
+ * @returns The OMR prefix advertisement preference.
+ *
+ */
+otRoutePreference otBorderRoutingGetRouteInfoOptionPreference(otInstance *aInstance);
+
+/**
+ * This function sets the preference to use when advertising Route Info Options (e.g., for discovered OMR prefixes) in
+ * Router Advertisement messages sent over the infrastructure link.
+ *
+ * By default BR will use 'medium' preference level but this function allows the default value to be changed. As an
+ * example, it can be set to 'low' preference in the case where device is a temporary BR (a mobile BR or a
+ * battery-powered BR) to indicate that other BRs (if any) should be preferred over this BR on the infrastructure link.
+ *
+ * @param[in] aInstance     A pointer to an OpenThread instance.
+ * @param[in] aPreference   The route preference to use.
+ *
+ */
+void otBorderRoutingSetRouteInfoOptionPreference(otInstance *aInstance, otRoutePreference aPreference);
+
+/**
  * Gets the Off-Mesh-Routable (OMR) Prefix, for example `fdfc:1ff5:1512:5622::/64`.
  *
  * An OMR Prefix is a randomly generated 64-bit prefix that's published in the

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (222)
+#define OPENTHREAD_API_VERSION (223)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -394,6 +394,25 @@ fd14:1078:b3d5:b0b0:0:0::/96
 Done
 ```
 
+### br rioprf
+
+Get the preference used when advertising Route Info Options (e.g., for discovered OMR prefixes) in emitted Router Advertisement message.
+
+```bash
+> br rioprf
+med
+Done
+```
+
+### br rioprf \<prf\>
+
+Set the preference (which may be 'high', 'med', or 'low') to use when advertising Route Info Options (e.g., for discovered OMR prefixes) in emitted Router Advertisement message.
+
+```bash
+> br rioprf low
+Done
+```
+
 ### bufferinfo
 
 Show the current message buffer information.

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -536,6 +536,57 @@ template <> otError Interpreter::Process<Cmd("br")>(Arg aArgs[])
         OutputIp6PrefixLine(nat64Prefix);
     }
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTING_NAT64_ENABLE
+    /**
+     * @cli br rioprf [high\med\low]
+     *
+     * @code
+     * br rioprf
+     * med
+     * Done
+     * @endcode
+     *
+     * @cparam br rioprf [@ca{high}|@ca{med}|@ca{low}]
+     *
+     * @code
+     * br rioprf low
+     * Done
+     * @endcode
+     *
+     * @par api_copy
+     * #otBorderRoutingSetRouteInfoOptionPreference
+     *
+     */
+    else if ((aArgs[0] == "rioprf"))
+    {
+        if (aArgs[1].IsEmpty())
+        {
+            OutputLine("%s",
+                       NetworkData::PreferenceToString(otBorderRoutingGetRouteInfoOptionPreference(GetInstancePtr())));
+        }
+        else
+        {
+            otRoutePreference preference;
+
+            if (aArgs[1] == "high")
+            {
+                preference = OT_ROUTE_PREFERENCE_HIGH;
+            }
+            else if (aArgs[1] == "med")
+            {
+                preference = OT_ROUTE_PREFERENCE_MED;
+            }
+            else if (aArgs[1] == "low")
+            {
+                preference = OT_ROUTE_PREFERENCE_LOW;
+            }
+            else
+            {
+                ExitNow(error = OT_ERROR_INVALID_ARGS);
+            }
+
+            otBorderRoutingSetRouteInfoOptionPreference(GetInstancePtr(), preference);
+        }
+    }
     else
     {
         error = OT_ERROR_INVALID_COMMAND;

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -54,6 +54,18 @@ otError otBorderRoutingSetEnabled(otInstance *aInstance, bool aEnabled)
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().SetEnabled(aEnabled);
 }
 
+otRoutePreference otBorderRoutingGetRouteInfoOptionPreference(otInstance *aInstance)
+{
+    return static_cast<otRoutePreference>(
+        AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetRouteInfoOptionPreference());
+}
+
+void otBorderRoutingSetRouteInfoOptionPreference(otInstance *aInstance, otRoutePreference aPreference)
+{
+    AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().SetRouteInfoOptionPreference(
+        static_cast<NetworkData::RoutePreference>(aPreference));
+}
+
 otError otBorderRoutingGetOmrPrefix(otInstance *aInstance, otIp6Prefix *aPrefix)
 {
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetOmrPrefix(AsCoreType(aPrefix));

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -79,6 +79,8 @@ class RoutingManager : public InstanceLocator
     friend class ot::Instance;
 
 public:
+    typedef NetworkData::RoutePreference RoutePreference; ///< Route preference (high, medium, low).
+
     /**
      * This constructor initializes the routing manager.
      *
@@ -112,6 +114,29 @@ public:
      *
      */
     Error SetEnabled(bool aEnabled);
+
+    /**
+     * This method gets the preference used when advertising Route Info Options (e.g., for discovered OMR prefixes) in
+     * Router Advertisement messages sent over the infrastructure link.
+     *
+     * @returns The Route Info Option preference.
+     *
+     */
+    RoutePreference GetRouteInfoOptionPreference(void) const { return mRouteInfoOptionPreference; }
+
+    /**
+     * This method sets the preference to use when advertising Route Info Options (e.g., for discovered OMR prefixes)
+     * in Router Advertisement messages sent over the infrastructure link.
+     *
+     * By default BR will use 'medium' preference level but this method allows the default value to be changed. As an
+     * example, it can be set to 'low' preference in the case where device is a temporary BR (a mobile BR or a
+     * battery-powered BR) to indicate that other BRs (if any) should be preferred over this BR on the infrastructure
+     * link.
+     *
+     * @param[in] aPreference   The route preference to use.
+     *
+     */
+    void SetRouteInfoOptionPreference(RoutePreference aPreference);
 
     /**
      * This method returns the off-mesh-routable (OMR) prefix.
@@ -195,8 +220,6 @@ public:
     static bool IsValidOmrPrefix(const Ip6::Prefix &aOmrPrefix);
 
 private:
-    typedef NetworkData::RoutePreference RoutePreference;
-
     static constexpr uint16_t kMaxRouterAdvMessageLength = 256; // The maximum RA message length we can handle.
 
     // The maximum number of the OMR prefixes to advertise.
@@ -507,6 +530,8 @@ private:
     // manually configured OMR prefixes exist, they will also be
     // advertised on infra link.
     OmrPrefixArray mAdvertisedOmrPrefixes;
+
+    RoutePreference mRouteInfoOptionPreference;
 
     // The currently favored (smallest) discovered on-link prefix.
     // Prefix length of zero indicates there is none.


### PR DESCRIPTION
This commit adds new mechanism in `RoutingManager` to allow user to
get or set the preference level to use when advertising discovered
OMR prefixes as RIO entries in emitted RA messages on infra netif. By
default 'medium' preference is used. As example user can choose to
set the preference to 'low' when the device is acting as a temporary
BR (a mobile or battery-powered BR) to indicate that other BRs should
be preferred over this BR on the infra link.

An OMR prefix entry in the Thread Network Data has its own preference
value which is used to compare OMR prefixes and determine the favored
OMR prefix. This preference is unrelated to the preference value used
when advertising the discovered OMR prefix in RA message.

This commit also adds CLI sub-commands for newly added APIs and
updates the documentation.

----

This is related to [SPEC-1080](https://threadgroup.atlassian.net/browse/SPEC-1080).