### PR TITLE
[cli] add helper method `ParsePreference()`

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -401,6 +401,55 @@ exit:
 
 #endif // OPENTHREAD_CONFIG_PING_SENDER_ENABLE
 
+otError Interpreter::ParsePreference(const Arg &aArg, otRoutePreference &aPreference)
+{
+    otError error = OT_ERROR_NONE;
+
+    if (aArg == "high")
+    {
+        aPreference = OT_ROUTE_PREFERENCE_HIGH;
+    }
+    else if (aArg == "med")
+    {
+        aPreference = OT_ROUTE_PREFERENCE_MED;
+    }
+    else if (aArg == "low")
+    {
+        aPreference = OT_ROUTE_PREFERENCE_LOW;
+    }
+    else
+    {
+        error = OT_ERROR_INVALID_ARGS;
+    }
+
+    return error;
+}
+
+const char *Interpreter::PreferenceToString(signed int aPreference)
+{
+    const char *str = "";
+
+    switch (aPreference)
+    {
+    case OT_ROUTE_PREFERENCE_LOW:
+        str = "low";
+        break;
+
+    case OT_ROUTE_PREFERENCE_MED:
+        str = "med";
+        break;
+
+    case OT_ROUTE_PREFERENCE_HIGH:
+        str = "high";
+        break;
+
+    default:
+        break;
+    }
+
+    return str;
+}
+
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
 template <> otError Interpreter::Process<Cmd("history")>(Arg aArgs[])
 {
@@ -560,30 +609,13 @@ template <> otError Interpreter::Process<Cmd("br")>(Arg aArgs[])
     {
         if (aArgs[1].IsEmpty())
         {
-            OutputLine("%s",
-                       NetworkData::PreferenceToString(otBorderRoutingGetRouteInfoOptionPreference(GetInstancePtr())));
+            OutputLine("%s", PreferenceToString(otBorderRoutingGetRouteInfoOptionPreference(GetInstancePtr())));
         }
         else
         {
             otRoutePreference preference;
 
-            if (aArgs[1] == "high")
-            {
-                preference = OT_ROUTE_PREFERENCE_HIGH;
-            }
-            else if (aArgs[1] == "med")
-            {
-                preference = OT_ROUTE_PREFERENCE_MED;
-            }
-            else if (aArgs[1] == "low")
-            {
-                preference = OT_ROUTE_PREFERENCE_LOW;
-            }
-            else
-            {
-                ExitNow(error = OT_ERROR_INVALID_ARGS);
-            }
-
+            SuccessOrExit(error = ParsePreference(aArgs[1], preference));
             otBorderRoutingSetRouteInfoOptionPreference(GetInstancePtr(), preference);
         }
     }
@@ -3602,17 +3634,11 @@ otError Interpreter::ParsePrefix(Arg aArgs[], otBorderRouterConfig &aConfig)
 
     for (; !aArgs->IsEmpty(); aArgs++)
     {
-        if (*aArgs == "high")
+        otRoutePreference preference;
+
+        if (ParsePreference(*aArgs, preference) == OT_ERROR_NONE)
         {
-            aConfig.mPreference = OT_ROUTE_PREFERENCE_HIGH;
-        }
-        else if (*aArgs == "med")
-        {
-            aConfig.mPreference = OT_ROUTE_PREFERENCE_MED;
-        }
-        else if (*aArgs == "low")
-        {
-            aConfig.mPreference = OT_ROUTE_PREFERENCE_LOW;
+            aConfig.mPreference = preference;
         }
         else
         {
@@ -3883,6 +3909,8 @@ otError Interpreter::ParseRoute(Arg aArgs[], otExternalRouteConfig &aConfig)
 
     for (; !aArgs->IsEmpty(); aArgs++)
     {
+        otRoutePreference preference;
+
         if (*aArgs == "s")
         {
             aConfig.mStable = true;
@@ -3891,17 +3919,9 @@ otError Interpreter::ParseRoute(Arg aArgs[], otExternalRouteConfig &aConfig)
         {
             aConfig.mNat64 = true;
         }
-        else if (*aArgs == "high")
+        else if (ParsePreference(*aArgs, preference) == OT_ERROR_NONE)
         {
-            aConfig.mPreference = OT_ROUTE_PREFERENCE_HIGH;
-        }
-        else if (*aArgs == "med")
-        {
-            aConfig.mPreference = OT_ROUTE_PREFERENCE_MED;
-        }
-        else if (*aArgs == "low")
-        {
-            aConfig.mPreference = OT_ROUTE_PREFERENCE_LOW;
+            aConfig.mPreference = preference;
         }
         else
         {

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -47,6 +47,7 @@
 #include <openthread/ip6.h>
 #include <openthread/link.h>
 #include <openthread/logging.h>
+#include <openthread/netdata.h>
 #include <openthread/ping_sender.h>
 #include <openthread/sntp.h>
 #if OPENTHREAD_CONFIG_TCP_ENABLE && OPENTHREAD_CONFIG_CLI_TCP_ENABLE
@@ -210,6 +211,29 @@ public:
      *
      */
     static const char *AddressOriginToString(uint8_t aOrigin);
+
+    /**
+     * This static method parses a given argument string as a route preference comparing it against  "high", "med", or
+     * "low".
+     *
+     * @param[in]  aArg          The argument string to parse.
+     * @param[out] aPreference   Reference to a `otRoutePreference` to return the parsed preference.
+     *
+     * @retval OT_ERROR_NONE             Successfully parsed @p aArg and updated @p aPreference.
+     * @retval OT_ERROR_INVALID_ARG      @p aArg is not a valid preference string "high", "med", or "low".
+     *
+     */
+    static otError ParsePreference(const Arg &aArg, otRoutePreference &aPreference);
+
+    /**
+     * This static method converts a route preference value to human-readable string.
+     *
+     * @param[in] aPreference   The preference value to convert (`OT_ROUTE_PREFERENCE_*` values).
+     *
+     * @returns A string representation @p aPreference.
+     *
+     */
+    static const char *PreferenceToString(signed int aPreference);
 
 protected:
     static Interpreter *sInterpreter;

--- a/src/cli/cli_history.cpp
+++ b/src/cli/cli_history.cpp
@@ -602,7 +602,7 @@ template <> otError History::Process<Cmd("prefix")>(Arg aArgs[])
         OutputLine(isList ? "%s -> event:%s prefix:%s flags:%s pref:%s rloc16:0x%04x"
                           : "| %20s | %-7s | %-43s | %-9s | %-4s | 0x%04x |",
                    ageString, Stringify(info->mEvent, kSimpleEventStrings), prefixString, flagsString,
-                   NetworkData::PreferenceToString(info->mPrefix.mPreference), info->mPrefix.mRloc16);
+                   Interpreter::PreferenceToString(info->mPrefix.mPreference), info->mPrefix.mRloc16);
     }
 
 exit:
@@ -652,7 +652,7 @@ template <> otError History::Process<Cmd("route")>(Arg aArgs[])
         OutputLine(isList ? "%s -> event:%s route:%s flags:%s pref:%s rloc16:0x%04x"
                           : "| %20s | %-7s | %-43s | %-9s | %-4s | 0x%04x |",
                    ageString, Stringify(info->mEvent, kSimpleEventStrings), prefixString, flagsString,
-                   NetworkData::PreferenceToString(info->mRoute.mPreference), info->mRoute.mRloc16);
+                   Interpreter::PreferenceToString(info->mRoute.mPreference), info->mRoute.mRloc16);
     }
 
 exit:

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -108,7 +108,7 @@ void NetworkData::OutputPrefix(const otBorderRouterConfig &aConfig)
         OutputFormat(" %s", flagsString);
     }
 
-    OutputLine(" %s %04x", PreferenceToString(aConfig.mPreference), aConfig.mRloc16);
+    OutputLine(" %s %04x", Interpreter::PreferenceToString(aConfig.mPreference), aConfig.mRloc16);
 }
 
 void NetworkData::RouteFlagsToString(const otExternalRouteConfig &aConfig, FlagsString &aString)
@@ -141,32 +141,7 @@ void NetworkData::OutputRoute(const otExternalRouteConfig &aConfig)
         OutputFormat(" %s", flagsString);
     }
 
-    OutputLine(" %s %04x", PreferenceToString(aConfig.mPreference), aConfig.mRloc16);
-}
-
-const char *NetworkData::PreferenceToString(signed int aPreference)
-{
-    const char *str = "";
-
-    switch (aPreference)
-    {
-    case OT_ROUTE_PREFERENCE_LOW:
-        str = "low";
-        break;
-
-    case OT_ROUTE_PREFERENCE_MED:
-        str = "med";
-        break;
-
-    case OT_ROUTE_PREFERENCE_HIGH:
-        str = "high";
-        break;
-
-    default:
-        break;
-    }
-
-    return str;
+    OutputLine(" %s %04x", Interpreter::PreferenceToString(aConfig.mPreference), aConfig.mRloc16);
 }
 
 void NetworkData::OutputService(const otServiceConfig &aConfig)

--- a/src/cli/cli_network_data.hpp
+++ b/src/cli/cli_network_data.hpp
@@ -125,16 +125,6 @@ public:
      */
     static void RouteFlagsToString(const otExternalRouteConfig &aConfig, FlagsString &aString);
 
-    /**
-     * This static method converts a route preference value to human-readable string.
-     *
-     * @param[in] aPreference   The preference value to convert (`OT_ROUTE_PREFERENCE_*` values).
-     *
-     * @returns A string representation @p aPreference.
-     *
-     */
-    static const char *PreferenceToString(signed int aPreference);
-
 private:
     using Command = CommandEntry<NetworkData>;
 


### PR DESCRIPTION
This commit adds a helper method `ParsePreference()` to parse a given
CLI argument string as a route preference comparing it against `"high"`,
`"med"`, or `"low"`. This commit also moves the `PreferenceToString()`
method from `Cli::NetworkData` to `Cli::Interpreter` class.