### PR TITLE
[tmf] add local IPv6 DSCP values to indicate TMF message priority

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -428,10 +428,22 @@ Error Ip6::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aI
 {
     Error    error = kErrorNone;
     Header   header;
+    uint8_t  dscp;
     uint16_t payloadLength = aMessage.GetLength();
 
+    if ((aIpProto == kProtoUdp) &&
+        Get<Tmf::Agent>().IsTmfMessage(aMessageInfo.GetSockAddr(), aMessageInfo.GetPeerAddr(),
+                                       aMessageInfo.GetPeerPort()))
+    {
+        dscp = Tmf::Agent::PriorityToDscp(aMessage.GetPriority());
+    }
+    else
+    {
+        dscp = PriorityToDscp(aMessage.GetPriority());
+    }
+
     header.InitVersionTrafficClassFlow();
-    header.SetDscp(PriorityToDscp(aMessage.GetPriority()));
+    header.SetDscp(dscp);
     header.SetEcn(aMessageInfo.GetEcn());
     header.SetPayloadLength(payloadLength);
     header.SetNextHeader(aIpProto);

--- a/src/core/net/ip6_types.hpp
+++ b/src/core/net/ip6_types.hpp
@@ -89,7 +89,13 @@ enum IpDscpCs : uint8_t
     kDscpCs5    = 40,   ///< Class selector codepoint 40
     kDscpCs6    = 48,   ///< Class selector codepoint 48
     kDscpCs7    = 56,   ///< Class selector codepoint 56
-    kDscpCsMask = 0x38, ///< Class selector mask
+    kDscpCsMask = 0x38, ///< Class selector mask (0b111000)
+
+    // DSCP values to use within Thread mesh (from local codepoint space 0bxxxx11 [RFC 2474 - section 6]).
+
+    kDscpTmfNetPriority    = 0x07, ///< TMF network priority (0b000111).
+    kDscpTmfNormalPriority = 0x0f, ///< TMF normal priority  (0b001111).
+    kDscpTmfLowPriority    = 0x17, ///< TMF low priority     (0b010111).
 };
 
 /**

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1626,9 +1626,13 @@ Error MeshForwarder::GetFramePriority(const FrameData      &aFrameData,
     {
         uint16_t destPort = headers.GetUdpHeader().GetDestinationPort();
 
-        if ((destPort == Mle::kUdpPort) || (destPort == Tmf::kUdpPort))
+        if (destPort == Mle::kUdpPort)
         {
             aPriority = Message::kPriorityNet;
+        }
+        else if (Get<Tmf::Agent>().IsTmfMessage(headers.GetSourceAddress(), headers.GetDestinationAddress(), destPort))
+        {
+            aPriority = Tmf::Agent::DscpToPriority(headers.GetIp6Header().GetDscp());
         }
     }
 

--- a/src/core/thread/tmf.hpp
+++ b/src/core/thread/tmf.hpp
@@ -182,6 +182,26 @@ public:
      */
     bool IsTmfMessage(const Ip6::Address &aSourceAddress, const Ip6::Address &aDestAddress, uint16_t aDestPort) const;
 
+    /**
+     * This static method converts a TMF message priority to IPv6 header DSCP value.
+     *
+     * @param[in] aPriority  The message priority to convert.
+     *
+     * @returns The DSCP value corresponding to @p aPriority.
+     *
+     */
+    static uint8_t PriorityToDscp(Message::Priority aPriority);
+
+    /**
+     * This static method converts a IPv6 header DSCP value to message priority for TMF message.
+     *
+     * @param[in] aDscp      The IPv6 header DSCP value in a TMF message.
+     *
+     * @returns The message priority corresponding to the @p aDscp.
+     *
+     */
+    static Message::Priority DscpToPriority(uint8_t aDscp);
+
 private:
     template <Uri kUri> void HandleTmf(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 


### PR DESCRIPTION
This commit adds new IPv6 header DSCP values which indicate a TMF
message priority. This allows intermediate routers forwarding TMF
message to be able to determine and use the TMF message priority that
originator of the message selects (e.g. address query/notification
use net-level priority whereas network diagnostics message use normal
priority). This replaces the previous behavior where on intermediate
routers all TMF messages were treated as net-level priority.

The new DSCP values are allocated from local codepoint range
`0bxxxx11` (per RFC 2474 - section 6). If the sender does not use
TMF-specific DSCP values, we use `kPriorityNet` as default on
intermediate router. This ensures that senders that are using older
code (do not use the new) experience the same behavior as before.

----

Related to [SPEC-1136](https://threadgroup.atlassian.net/browse/SPEC-1136).