### PR TITLE
Allow setting a custom OMR prefix (required for 1.3.0 cert. test cases)

### DIFF
--- a/include/openthread/border_router.h
+++ b/include/openthread/border_router.h
@@ -128,6 +128,18 @@ void otBorderRoutingSetRouteInfoOptionPreference(otInstance *aInstance, otRouteP
 otError otBorderRoutingGetOmrPrefix(otInstance *aInstance, otIp6Prefix *aPrefix);
 
 /**
+ * This function sets the off-mesh-routable (OMR) prefix.
+ *
+ * @param[in]  aInstance         A pointer to an OpenThread instance.
+ * @param[in]  aPrefix           A pointer to the OMR Prefix.
+ *
+ * @retval  OT_ERROR_INVALID_STATE  The Border Routing Manager is not initialized yet.
+ * @retval  OT_ERROR_NONE           Successfully set the OMR prefix.
+ *
+ */
+otError otBorderRoutingSetOmrPrefix(otInstance *aInstance, otIp6Prefix *aPrefix);
+
+/**
  * Gets the On-Link Prefix for the adjacent infrastructure link, for example `fd41:2650:a6f5:0::/64`.
  *
  * An On-Link Prefix is a randomly generated 64-bit prefix that's advertised on the infrastructure

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (223)
+#define OPENTHREAD_API_VERSION (224)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -364,11 +364,14 @@ Done
 
 ### br omrprefix
 
-Get the randomly generated off-mesh-routable prefix of the Border Router.
+Get (or optionally set) the randomly generated off-mesh-routable prefix of the Border Router.
 
 ```bash
 > br omrprefix
 fdfc:1ff5:1512:5622::/64
+Done
+
+> br omrprefix fdfc:1ff5:1512:5622::/64
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -557,8 +557,7 @@ template <> otError Interpreter::Process<Cmd("br")>(Arg aArgs[])
         {
             SuccessOrExit(error = aArgs[1].ParseAsIp6Prefix(omrPrefix));
             VerifyOrExit(omrPrefix.mLength == OT_IP6_PREFIX_BITSIZE, error = OT_ERROR_INVALID_ARGS);
-            error =
-                otBorderRoutingSetOmrPrefix(GetInstancePtr(), &omrPrefix);
+            error = otBorderRoutingSetOmrPrefix(GetInstancePtr(), &omrPrefix);
         }
     }
     /**

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -548,6 +548,18 @@ template <> otError Interpreter::Process<Cmd("br")>(Arg aArgs[])
 
         SuccessOrExit(error = otBorderRoutingGetOmrPrefix(GetInstancePtr(), &omrPrefix));
         OutputIp6PrefixLine(omrPrefix);
+        if (aArgs[1].IsEmpty())
+        {
+            SuccessOrExit(error = otBorderRoutingGetOmrPrefix(GetInstancePtr(), &omrPrefix));
+            OutputIp6PrefixLine(omrPrefix);
+        }
+        else
+        {
+            SuccessOrExit(error = aArgs[1].ParseAsIp6Prefix(omrPrefix));
+            VerifyOrExit(omrPrefix.mLength == OT_IP6_PREFIX_BITSIZE, error = OT_ERROR_INVALID_ARGS);
+            error =
+                otBorderRoutingSetOmrPrefix(GetInstancePtr(), &omrPrefix);
+        }
     }
     /**
      * @cli br onlinkprefix

--- a/src/core/api/border_router_api.cpp
+++ b/src/core/api/border_router_api.cpp
@@ -71,6 +71,11 @@ otError otBorderRoutingGetOmrPrefix(otInstance *aInstance, otIp6Prefix *aPrefix)
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetOmrPrefix(AsCoreType(aPrefix));
 }
 
+otError otBorderRoutingSetOmrPrefix(otInstance *aInstance, otIp6Prefix *aPrefix)
+{
+    return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().SetOmrPrefix(AsCoreType(aPrefix));
+}
+
 otError otBorderRoutingGetOnLinkPrefix(otInstance *aInstance, otIp6Prefix *aPrefix)
 {
     return AsCoreType(aInstance).Get<BorderRouter::RoutingManager>().GetOnLinkPrefix(AsCoreType(aPrefix));

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -152,6 +152,18 @@ exit:
     return error;
 }
 
+Error RoutingManager::SetOmrPrefix(Ip6::Prefix &aPrefix)
+{
+    Error error = kErrorNone;
+
+    VerifyOrExit(IsInitialized(), error = kErrorInvalidState);
+    mLocalOmrPrefix = aPrefix;
+    SuccessOrExit(PublishLocalOmrPrefix());
+
+exit:
+    return error;
+}
+
 Error RoutingManager::GetOnLinkPrefix(Ip6::Prefix &aPrefix)
 {
     Error error = kErrorNone;

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -153,6 +153,17 @@ public:
     Error GetOmrPrefix(Ip6::Prefix &aPrefix);
 
     /**
+     * This method sets the off-mesh-routable (OMR) prefix.
+     *
+     * @param[out]  aPrefix  A reference to the OMR prefix.
+     *
+     * @retval  kErrorInvalidState  The Border Routing Manager is not initialized yet.
+     * @retval  kErrorNone          Successfully set the OMR prefix.
+     *
+     */
+    Error SetOmrPrefix(Ip6::Prefix &aPrefix);
+
+    /**
      * This method returns the on-link prefix for the adjacent  infrastructure link.
      *
      * The randomly generated 64-bit prefix will be advertised


### PR DESCRIPTION
The latest 1.3.0 test spec includes cases where the harness is asked to set a manual OMR prefix on a BR reference device in order to test some OMR selection criteria. This change expands the `br omrprefix` command to take an optional prefix value to set our own OMR prefix.