### PR TITLE
[csl] update CSL on role change to router or leader

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -399,6 +399,10 @@ void MleRouter::SetStateRouter(uint16_t aRloc16)
             RemoveNeighbor(child);
         }
     }
+
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+    Get<Mac::Mac>().UpdateCsl();
+#endif
 }
 
 void MleRouter::SetStateLeader(uint16_t aRloc16, LeaderStartMode aStartMode)
@@ -439,6 +443,10 @@ void MleRouter::SetStateLeader(uint16_t aRloc16, LeaderStartMode aStartMode)
             RemoveNeighbor(child);
         }
     }
+
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+    Get<Mac::Mac>().UpdateCsl();
+#endif
 
     LogNote("Leader partition id 0x%x", mLeaderData.GetPartitionId());
 }


### PR DESCRIPTION
This commit adds a call to `Get<Mac::Mac>().UpdateCsl()` when there
is role change from `SetStateLeader()` or `SetStateRouter()`. This
ensures to disable CSL at `SubMac` and radio platform.

----

This is follow up from #7783 where a common `UpdateCsl()` is added to make decision when there is a change
- This is not critical change (since after we switch to router/leader role we won't enter sleep or CSL sample satte)
- But make sense for us to invoke the `UpdateCsl()` to disable it.

`UpdateCsl()` looks into 3 things from `Mle`:
- `Get<Mle::MleRouter>().IsChild()`
- `Get<Mle::Mle>().GetParent().IsEnhancedKeepAliveSupported()`
- `Get<Mle::Mle>().IsRxOnWhenIdle()`

We need to ensure to call`UpdateCsl()` when there is change in any of these. Here is what I tracked related to this:
- Role changes are covered from `Mle::SetState{Role}()` calls (we already did so in `SetStateChild()` and `SetStateDetached()` and when we disable we always call `SetStateDetached()`).
- Parent can change while we are attached (e.g. periodic parent search), but on a change we always call `SetStateChild()` which will trigger a call to `UpdateCsl()`
- Parent `IsEnhancedKeepAliveSupported()` is tied to the `VersionTlv` value from parent.
   - It is included in Parent Response message we get from parent (while we are attaching to it)
   - And it cannot change afterwards (while we are attached to parent).
- `IsRxOnWhenIdle()` can change when `DeviceMode` gets changed.
   - `Mle::SetDeviceMode()` triggers such a change.
   - `SetDeviceMode()` will call `SetStateChild()` if we are already a child, which will in turn call `UpdateCsl()`.







