### PR TITLE
[routing-table] do not reset LastHeard timestamp when removing router link

### DIFF
--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -324,7 +324,6 @@ exit:
 void RouterTable::RemoveRouterLink(Router &aRouter)
 {
     aRouter.SetLinkQualityOut(kLinkQuality0);
-    aRouter.SetLastHeard(TimerMilli::GetNow());
 
     for (Router *cur = GetFirstEntry(); cur != nullptr; cur = GetNextEntry(cur))
     {

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -323,7 +323,11 @@ exit:
 
 void RouterTable::RemoveRouterLink(Router &aRouter)
 {
-    aRouter.SetLinkQualityOut(kLinkQuality0);
+    if (aRouter.GetLinkQualityOut() != 0)
+    {
+        aRouter.SetLinkQualityOut(kLinkQuality0);
+        aRouter.SetLastHeard(TimerMilli::GetNow());
+    }
 
     for (Router *cur = GetFirstEntry(); cur != nullptr; cur = GetNextEntry(cur))
     {


### PR DESCRIPTION
The Last Heard timestamp should not be updated when removing Router Link.
