### PR TITLE
[gcov] use __gcov_dump() instead for clang 12/13

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang_ver: ["6.0", "7", "8", "9"]
+        clang_ver: ["6.0", "7", "8", "9", "10", "11", "12", "13"]
     env:
       CC: clang-${{ matrix.clang_ver }}
       CXX: clang++-${{ matrix.clang_ver }}
@@ -226,7 +226,14 @@ jobs:
           submodules: true
       - name: Bootstrap
         run: |
-          sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
+          sudo rm /etc/apt/sources.list.d/*
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal main
+          deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal main
+          # 13
+          deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main
+          deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main' | sudo tee -a /etc/apt/sources.list
+          sudo apt-get update
           sudo apt-get --no-install-recommends install -y clang-${{ matrix.clang_ver }} clang++-${{ matrix.clang_ver }} ninja-build libreadline-dev libncurses-dev
       - name: Build
         run: |
@@ -239,7 +246,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang_ver: ["6.0", "7", "8", "9"]
+        clang_ver: ["6.0", "7", "8", "9", "10", "11", "12", "13"]
     env:
       CC: clang-${{ matrix.clang_ver }}
       CXX: clang++-${{ matrix.clang_ver }}
@@ -253,6 +260,12 @@ jobs:
       - name: Bootstrap
         run: |
           sudo dpkg --add-architecture i386
+          wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          echo 'deb http://apt.llvm.org/focal/ llvm-toolchain-focal main
+          deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal main
+          # 13
+          deb http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main
+          deb-src http://apt.llvm.org/focal/ llvm-toolchain-focal-13 main' | sudo tee -a /etc/apt/sources.list
           sudo apt-get update
           sudo apt-get --no-install-recommends install -y clang-${{ matrix.clang_ver }} clang++-${{ matrix.clang_ver }} ninja-build
           sudo apt-get --no-install-recommends install -y g++-multilib libreadline-dev:i386 libncurses-dev:i386

--- a/src/core/thread/mlr_manager.cpp
+++ b/src/core/thread/mlr_manager.cpp
@@ -776,7 +776,7 @@ void MlrManager::LogMlrResponse(Error               aResult,
 
 void MlrManager::CheckInvariants(void) const
 {
-#if OPENTHREAD_EXAMPLES_SIMULATION
+#if OPENTHREAD_EXAMPLES_SIMULATION && OPENTHREAD_CONFIG_ASSERT_ENABLE
     uint16_t registeringNum = 0;
 
     OT_ASSERT(!mMlrPending || mSendDelay == 0);

--- a/src/lib/platform/reset_util.h
+++ b/src/lib/platform/reset_util.h
@@ -30,7 +30,8 @@
 #define OT_LIB_PLATFORM_RESET_UTIL_H_
 
 #if defined(OPENTHREAD_ENABLE_COVERAGE) && OPENTHREAD_ENABLE_COVERAGE && defined(__GNUC__)
-#if __GNUC__ >= 11
+#if __GNUC__ >= 11 || (defined(__clang__) && (defined(__APPLE__) && (__clang_major__ >= 13)) || \
+                       (!defined(__APPLE__) && (__clang_major__ >= 12)))
 void __gcov_dump();
 void __gcov_reset();
 
@@ -42,7 +43,8 @@ static void flush_gcov(void)
 #else
 void __gcov_flush(void);
 #define flush_gcov __gcov_flush
-#endif // __GNUC__ >= 11
+#endif /* __GNUC__ >= 11 || (defined(__clang__) && (defined(__APPLE__) && (__clang_major__ >= 13)) || \
+                             (!defined(__APPLE__) && (__clang_major__ >= 12))) */
 #else
 #define flush_gcov()
 #endif // defined(OPENTHREAD_ENABLE_COVERAGE) && OPENTHREAD_ENABLE_COVERAGE && defined(__GNUC__)


### PR DESCRIPTION
Use gcov_dump when using clang on MacOS and the version is 13 or above
or when using clang on a non MacOS system and the version is 12 or above.

This is a follow on change to #7629.