### PR TITLE
[srp-client] exclude sub-type PTR when service is being removed

### DIFF
--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -1001,7 +1001,7 @@ Error Client::AppendServiceInstructions(Service &aService, Message &aMessage, In
     UpdateRecordLengthInMessage(rr, offset, aMessage);
     aInfo.mRecordCount++;
 
-    if (aService.HasSubType())
+    if (aService.HasSubType() && !removing)
     {
         const char *subTypeLabel;
         uint16_t    subServiceNameOffset = 0;
@@ -1023,7 +1023,7 @@ Error Client::AppendServiceInstructions(Service &aService, Message &aMessage, In
                 SuccessOrExit(error = Dns::Name::AppendPointerLabel(subServiceNameOffset, aMessage));
             }
 
-            // `rr` is already initialized as PTR (add or remove).
+            // `rr` is already initialized as PTR.
             offset = aMessage.GetLength();
             SuccessOrExit(error = aMessage.Append(rr));
 


### PR DESCRIPTION
This commit updates the SRP client to not include sub-types PTR
records when the base service is being removed.

---

Please see https://github.com/project-chip/connectedhomeip/issues/18507#issuecomment-1178050134 for background
Addresses https://github.com/project-chip/connectedhomeip/issues/18507