### PR TITLE
[mesh-forwarder] simplify `CheckReachability()` and `Icmp::SendError()`

### DIFF
--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -61,6 +61,8 @@ using ot::Encoding::BigEndian::HostSwap16;
  *
  */
 
+class Headers;
+
 /**
  * This class implements ICMPv6.
  *
@@ -283,6 +285,20 @@ public:
      *
      */
     Error SendError(Header::Type aType, Header::Code aCode, const MessageInfo &aMessageInfo, const Message &aMessage);
+
+    /**
+     * This method sends an ICMPv6 error message.
+     *
+     * @param[in]  aType         The ICMPv6 message type.
+     * @param[in]  aCode         The ICMPv6 message code.
+     * @param[in]  aMessageInfo  A reference to the message info.
+     * @param[in]  aHeaders      The parsed headers from the error-causing IPv6 message.
+     *
+     * @retval kErrorNone     Successfully enqueued the ICMPv6 error message.
+     * @retval kErrorNoBufs   Insufficient buffers available.
+     *
+     */
+    Error SendError(Header::Type aType, Header::Code aCode, const MessageInfo &aMessageInfo, const Headers &aHeaders);
 
     /**
      * This method handles an ICMPv6 message.

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -471,7 +471,7 @@ private:
     Error RemoveAgedMessages(void);
 #endif
     void  SendMesh(Message &aMessage, Mac::TxFrame &aFrame);
-    void  SendDestinationUnreachable(uint16_t aMeshSource, const Message &aMessage);
+    void  SendDestinationUnreachable(uint16_t aMeshSource, const Ip6::Headers &aIp6Headers);
     Error UpdateIp6Route(Message &aMessage);
     Error UpdateIp6RouteFtd(Ip6::Header &ip6Header, Message &aMessage);
     void  EvaluateRoutingCost(uint16_t aDest, uint8_t &aBestCost, uint16_t &aBestDest) const;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3836,7 +3836,7 @@ bool Mle::IsMeshLocalAddress(const Ip6::Address &aAddress) const
     return (aAddress.GetPrefix() == GetMeshLocalPrefix());
 }
 
-Error Mle::CheckReachability(uint16_t aMeshDest, Ip6::Header &aIp6Header)
+Error Mle::CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6Header)
 {
     Error error;
 

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1456,7 +1456,7 @@ protected:
      * @retval kErrorNoRoute   The destination is not reachable and the message should be dropped.
      *
      */
-    Error CheckReachability(uint16_t aMeshDest, Ip6::Header &aIp6Header);
+    Error CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6Header);
 
     /**
      * This method returns the next hop towards an RLOC16 destination.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3677,7 +3677,7 @@ exit:
     return;
 }
 
-Error MleRouter::CheckReachability(uint16_t aMeshDest, Ip6::Header &aIp6Header)
+Error MleRouter::CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6Header)
 {
     Error error = kErrorNone;
 

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -388,7 +388,7 @@ public:
      * @retval kErrorNoRoute   The destination is not reachable and the message should be dropped.
      *
      */
-    Error CheckReachability(uint16_t aMeshDest, Ip6::Header &aIp6Header);
+    Error CheckReachability(uint16_t aMeshDest, const Ip6::Header &aIp6Header);
 
     /**
      * This method resolves 2-hop routing loops.


### PR DESCRIPTION
A new flavor of `Icmp::SendError()` is added which allows the caller
to provide the parsed `Ip6::Headers` of the error-causing message
instead the full `Message` instance. Note that the implementation of
`SendError()` only includes the IPv6 header of the error-causing
message in the payload of the ICMPv6 error message.

`MeshForwarder::CheckReachability()` method is updated to use the
recently added `Ip6::Headers` to parse the IPv6 headers from the
received frame. With the changes in this commit, we no longer need to
allocate a temporary `Message` which was used for reading the
decompressed IPv6 header and also to pass to `Icmp::SendError()` in
case of "destination unreachable" error.