### PR TITLE
[toranj] make `test-017` more robust

### DIFF
--- a/tests/toranj/ncp/test-017-parent-reset-child-recovery.py
+++ b/tests/toranj/ncp/test-017-parent-reset-child-recovery.py
@@ -151,8 +151,8 @@ def check_parent_is_associated():
 wpan.verify_within(check_parent_is_associated, 10)
 
 # Verify that all the children are recovered and present in the parent's
-# child table again (within 5 seconds).
-wpan.verify_within(check_child_table, 9)
+# child table again.
+wpan.verify_within(check_child_table, 15)
 
 # Verify that number of state changes on all children stays as before
 # (indicating they did not get detached).


### PR DESCRIPTION
This commit updates `test-017-parent-reset-child-recovery.py` to make
it more robust by increasing the wait time for children to be
recovered after parent/leader reset. This is related to the increase
in data poll period of sleepy children to 10 sec which was done
previously to accommodate for the increased start-up time of leader
(due to change in number of MLE Parent Requests).