### PR TITLE
[csl] fix the csl channel logic on transmitter

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2657,11 +2657,6 @@ void MleRouter::HandleChildUpdateRequest(RxInfo &aRxInfo)
         {
             child->SetCslChannel(static_cast<uint8_t>(cslChannel.GetChannel()));
         }
-        else
-        {
-            // Set CSL Channel unspecified.
-            child->SetCslChannel(0);
-        }
     }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
 

--- a/tests/scripts/thread-cert/v1_2_test_csl_transmission.py
+++ b/tests/scripts/thread-cert/v1_2_test_csl_transmission.py
@@ -82,15 +82,6 @@ class SSED_CslTransmission(thread_cert.TestCase):
         self.assertTrue(self.nodes[LEADER].ping(self.nodes[SSED_1].get_rloc()))
         self.simulator.go(5)
 
-        self.nodes[SSED_1].set_csl_channel(0)
-        self.simulator.go(1)
-        self.assertTrue(self.nodes[LEADER].ping(self.nodes[SSED_1].get_rloc()))
-        self.simulator.go(5)
-
-        ssed_messages = self.simulator.get_messages_sent_by(SSED_1)
-        msg = ssed_messages.next_mle_message(mle.CommandType.CHILD_UPDATE_REQUEST)
-        msg.assertMleMessageDoesNotContainTlv(mle.CslChannel)
-
         self.nodes[SSED_1].set_csl_period(0)
         self.assertFalse(self.nodes[LEADER].ping(self.nodes[SSED_1].get_rloc()))
         self.simulator.go(2)


### PR DESCRIPTION
Currently whenever the CSL Transmitter receives a Child Update 
Request from an SSED, it will update the CSL Channel. If there is a
CSL Channel TLV, it will set the CSL Channel to that value. Otherwise
it will set the channel to 'unspecified'. Considering Child Update
Request is also used by SSED to keep synchronization (by some 
implemenations). And those SSEDs don't expect to update the CSL
Channel by not appending a CSL Channel TLV in these Child Update 
Requests. So we should keep the CSL Channel unchanged if there is
no CSL Channel TLV.