### PR TITLE
[csl] update CSL information in radio when parent changes

### DIFF
--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -97,6 +97,7 @@ void SubMac::Init(void)
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     mCslPeriod     = 0;
     mCslChannel    = 0;
+    mCslPeerShort  = 0;
     mIsCslSampling = false;
     mCslSampleTime = TimeMicro{0};
     mCslLastSync   = TimeMicro{0};
@@ -1051,13 +1052,15 @@ bool SubMac::UpdateCsl(uint16_t aPeriod, uint8_t aChannel, otShortAddress aShort
 {
     bool diffPeriod  = aPeriod != mCslPeriod;
     bool diffChannel = aChannel != mCslChannel;
-    bool retval      = diffPeriod || diffChannel;
+    bool diffPeer    = aShortAddr != mCslPeerShort;
+    bool retval      = diffPeriod || diffChannel || diffPeer;
 
     VerifyOrExit(retval);
     mCslChannel = aChannel;
 
-    VerifyOrExit(diffPeriod);
-    mCslPeriod = aPeriod;
+    VerifyOrExit(diffPeriod || diffPeer);
+    mCslPeriod    = aPeriod;
+    mCslPeerShort = aShortAddr;
     IgnoreError(Get<Radio>().EnableCsl(aPeriod, aShortAddr, aExtAddr));
 
     mCslTimer.Stop();

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -662,6 +662,7 @@ private:
     uint8_t  mCslChannel : 7; // The CSL sample channel.
     bool mIsCslSampling : 1;  // Indicates that the radio is receiving in CSL state for platforms not supporting delayed
                               // reception.
+    uint16_t   mCslPeerShort; // The CSL peer short address.
     TimeMicro  mCslSampleTime;     // The CSL sample time of the current period.
     TimeMicro  mCslLastSync;       // The timestamp of the last successful CSL synchronization.
     uint8_t    mCslParentAccuracy; // Drift of timer used for scheduling CSL tx by the parent, in ± ppm.


### PR DESCRIPTION
Cover the case of parent change while the CSL child is still attached.