### PR TITLE
[thci] allow to specify custom commands

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -450,6 +450,26 @@ class OpenThreadTHCI(object):
 
     @watched
     def __parseExtraParams(self, Param9):
+        """
+        Parse `Param9` for extra THCI parameters.
+
+        `Param9` should be a JSON string encoded in URL-safe base64 encoding.
+
+        Defined Extra THCI Parameters:
+        - "cmd-start-otbr-agent"   : The command to start otbr-agent (default: systemctl start otbr-agent)
+        - "cmd-stop-otbr-agent"    : The command to stop otbr-agent (default: systemctl stop otbr-agent)
+        - "cmd-restart-otbr-agent" : The command to restart otbr-agent (default: systemctl restart otbr-agent)
+
+        For example, Param9 can be generated as below:
+        Param9 = base64.urlsafe_b64encode(json.dumps({
+            "cmd-start-otbr-agent": "service otbr-agent start",
+            "cmd-stop-otbr-agent": "service otbr-agent stop",
+            "cmd-restart-otbr-agent": "service otbr-agent restart",
+        }))
+
+        :param Param9: A JSON string encoded in URL-safe base64 encoding.
+        :return: A dict containing extra THCI parameters.
+        """
         if not Param9 or not Param9.strip():
             return {}
 

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -30,7 +30,7 @@
 >> Device : OpenThread THCI
 >> Class : OpenThread
 """
-
+import base64
 import functools
 import ipaddress
 import logging
@@ -39,6 +39,7 @@ import traceback
 import re
 import socket
 import time
+import json
 from abc import abstractmethod
 
 import serial
@@ -405,6 +406,7 @@ class OpenThreadTHCI(object):
 
         self.mac = params.get('EUI')
         self.backboneNetif = params.get('Param8') or 'eth0'
+        self.extraParams = self.__parseExtraParams(params.get('Param9'))
 
         self.UIStatusMsg = ''
         self.AutoDUTEnable = False
@@ -445,6 +447,15 @@ class OpenThreadTHCI(object):
             return '[%s:%d]' % (self.telnetIp, self.telnetPort)
         else:
             return '[%s]' % self.port
+
+    @watched
+    def __parseExtraParams(self, Param9):
+        if not Param9 or not Param9.strip():
+            return {}
+
+        jsonStr = base64.urlsafe_b64decode(Param9)
+        params = json.loads(jsonStr)
+        return params
 
     @API
     def closeConnection(self):

--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -620,7 +620,8 @@ class OpenThread_BR(OpenThreadTHCI, IThci):
             self.__cli_output_lines.append(line)
 
     def __restartAgentService(self):
-        self.bash('systemctl restart otbr-agent')
+        restart_cmd = self.extraParams.get('cmd-restart-otbr-agent', 'systemctl restart otbr-agent')
+        self.bash(restart_cmd)
 
     def __truncateSyslog(self):
         self.bash('truncate -s 0 /var/log/syslog')
@@ -653,14 +654,16 @@ class OpenThread_BR(OpenThreadTHCI, IThci):
     @API
     def powerDown(self):
         self.log('Powering down BBR')
-        self.bash('systemctl stop otbr-agent')
         super(OpenThread_BR, self).powerDown()
+        stop_cmd = self.extraParams.get('cmd-stop-otbr-agent', 'systemctl stop otbr-agent')
+        self.bash(stop_cmd)
 
     # Override powerUp
     @API
     def powerUp(self):
         self.log('Powering up BBR')
-        self.bash('systemctl start otbr-agent')
+        start_cmd = self.extraParams.get('cmd-start-otbr-agent', 'systemctl start otbr-agent')
+        self.bash(start_cmd)
         super(OpenThread_BR, self).powerUp()
 
     # Override forceSetSlaac


### PR DESCRIPTION
This commit uses `Param9` to specify custom commands for Thread BR THCI to control `otbr-agent`.