### PR TITLE
[docs] add NAT64 to Doxygen

### DIFF
--- a/doc/ot_api_doc.h
+++ b/doc/ot_api_doc.h
@@ -57,6 +57,7 @@
  * @defgroup api-dnssd-server         DNS-SD Server
  * @defgroup api-icmp6                ICMPv6
  * @defgroup api-ip6                  IPv6
+ * @defgroup api-nat64                NAT64
  * @defgroup api-srp                  SRP
  * @defgroup api-ping-sender          Ping Sender
  *


### PR DESCRIPTION
This is a follow-up to: https://github.com/openthread/openthread/pull/7824
I added the group definition under IPv6 Networking.