### PR TITLE
[bootstrap] Explicitly use arm-none-eabi-gcc from armmbed

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -100,7 +100,7 @@ install_packages_brew()
 
     # add ARM toolchain
     brew tap ArmMbed/homebrew-formulae
-    brew install arm-none-eabi-gcc
+    brew install armmbed/formulae/arm-none-eabi-gcc
 
     # check for gcc for simulation
     if ! command -v gcc; then


### PR DESCRIPTION
The bootstrap script taps `armmbed/formulae`, and then tries
to install `arm-none-eabi-gcc` from that tap. However, if the
user has already tapped a different tap that offers
`arm-none-eabi-gcc`, then the install will fail.

This change removes the ambiguity of the install by specifying
the tap to use.