### PR TITLE
[csl] ensures `SubMac`is informed when CSL support changes

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2267,27 +2267,24 @@ exit:
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 void Mac::UpdateCsl(void)
 {
-    uint16_t period;
-    uint8_t  channel;
-
-    VerifyOrExit(IsCslSupported());
-
-    period  = Get<Mle::Mle>().IsRxOnWhenIdle() ? 0 : GetCslPeriod();
-    channel = GetCslChannel() ? GetCslChannel() : mRadioChannel;
+    uint16_t period  = IsCslEnabled() ? GetCslPeriod() : 0;
+    uint8_t  channel = GetCslChannel() ? GetCslChannel() : mRadioChannel;
 
     if (mLinks.UpdateCsl(period, channel, Get<Mle::Mle>().GetParent().GetRloc16(),
                          &Get<Mle::Mle>().GetParent().GetExtAddress()))
     {
-        Get<DataPollSender>().RecalculatePollPeriod();
-        if (period)
+        if (Get<Mle::Mle>().IsChild())
         {
-            Get<Mle::Mle>().ScheduleChildUpdateRequest();
+            Get<DataPollSender>().RecalculatePollPeriod();
+
+            if (period != 0)
+            {
+                Get<Mle::Mle>().ScheduleChildUpdateRequest();
+            }
         }
+
         UpdateIdleMode();
     }
-
-exit:
-    return;
 }
 
 void Mac::SetCslChannel(uint8_t aChannel)

--- a/tests/scripts/thread-cert/v1_2_test_csl_transmission.py
+++ b/tests/scripts/thread-cert/v1_2_test_csl_transmission.py
@@ -125,6 +125,23 @@ class SSED_CslTransmission(thread_cert.TestCase):
         ssed_messages = self.simulator.get_messages_sent_by(SSED_1)
         self.assertIsNotNone(ssed_messages.next_data_poll())
 
+        # Check if SSED is able to resynchronize with the parent after it is gone longer than the timeout
+        self.nodes[LEADER].start()
+        self.simulator.go(config.LEADER_STARTUP_DELAY)
+        self.nodes[SSED_1].set_csl_timeout(8)
+        self.nodes[SSED_1].set_timeout(10)
+        self.simulator.go(2)
+        self.nodes[LEADER].stop()
+        self.simulator.go(25)
+        self.flush_all()
+        self.nodes[LEADER].start()
+        self.simulator.go(config.LEADER_STARTUP_DELAY)
+        self.assertEqual(self.nodes[LEADER].get_state(), 'leader')
+        self.simulator.go(5)
+        self.assertEqual(self.nodes[SSED_1].get_state(), 'child')
+        ssed_messages = self.simulator.get_messages_sent_by(SSED_1)
+        self.assertIsNotNone(ssed_messages.next_mle_message(mle.CommandType.CHILD_UPDATE_REQUEST))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This commit changes `Mac::UpdateCsl()` to ensure we inform `SubMac`
and disable CSL when CSL support changes (e.g., device gets
detached). This ensures that `SubMac` internal variables (CSL period,
channel) are updated on a detach and if the device later attaches
again, we detect the change in CSL configuration and trigger the tx
of MLE Child Update Request.

---

Please see https://github.com/openthread/openthread/pull/7915 for more details.