### PR TITLE
[nat64] fix build options for NAT64 tests

### DIFF
--- a/script/test
+++ b/script/test
@@ -46,7 +46,7 @@ readonly THREAD_VERSION="${THREAD_VERSION:-1.3}"
 readonly INTER_OP="${INTER_OP:-0}"
 readonly VERBOSE="${VERBOSE:-0}"
 readonly BORDER_ROUTING="${BORDER_ROUTING:-1}"
-readonly BORDER_ROUTING_NAT64="${BORDER_ROUTING_NAT64:-1}"
+readonly NAT64="${NAT64:-0}"
 readonly INTER_OP_BBR="${INTER_OP_BBR:-1}"
 
 readonly OT_COREDUMP_DIR="${PWD}/ot-core-dump"
@@ -296,10 +296,10 @@ do_build_otbr_docker()
         otbr_options+=("-DOTBR_TREL=OFF")
     fi
 
-    if [[ ${BORDER_ROUTING_NAT64} == 1 ]]; then
-        otbr_options+=("-DOT_BORDER_ROUTING_NAT64=ON")
+    if [[ ${NAT64} == 1 ]]; then
+        otbr_options+=("-DOTBR_BORDER_ROUTING_NAT64=ON")
     else
-        otbr_options+=("-DOT_BORDER_ROUTING_NAT64=OFF")
+        otbr_options+=("-DOTBR_BORDER_ROUTING_NAT64=OFF")
     fi
 
     local otbr_docker_image=${OTBR_DOCKER_IMAGE:-otbr-ot12-backbone-ci}
@@ -324,7 +324,7 @@ do_build_otbr_docker()
             --build-arg BACKBONE_ROUTER=1 \
             --build-arg REFERENCE_DEVICE=1 \
             --build-arg OT_BACKBONE_CI=1 \
-            --build-arg NAT64="${NAT64:-0}" \
+            --build-arg NAT64="${NAT64}" \
             --build-arg REST_API=0 \
             --build-arg WEB_GUI=0 \
             --build-arg MDNS="${OTBR_MDNS:-mDNSResponder}" \


### PR DESCRIPTION
This commit fixes the build options for NAT64 tests. A new option was added in ot-br-posix recently ([ref](https://github.com/openthread/ot-br-posix/pull/1455)).