### PR TITLE
[cmake] update option to enable CoAP Observe through CMake

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -134,7 +134,7 @@ endif()
 
 option(OT_COAP_OBSERVE "enable coap observe (RFC7641) api support")
 if(OT_COAP_OBSERVE)
-    list(APPEND OT_PRIVATE_DEFINES "OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE=1")
+    target_compile_definitions(ot-config INTERFACE "OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE=1")
 endif()
 
 option(OT_COMMISSIONER "enable commissioner support")


### PR DESCRIPTION
Change the definition of OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
through target_compile_detinifions().

Signed-off-by: Luis Ubieda <luisubiedas@gmail.com>