### PR TITLE
[message] allow msg pool using external heap

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (229)
+#define OPENTHREAD_API_VERSION (230)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/message.h
+++ b/include/openthread/message.h
@@ -287,8 +287,8 @@ typedef struct otMessageQueueInfo
  */
 typedef struct otBufferInfo
 {
-    uint16_t           mTotalBuffers;         ///< The total number of buffers in the messages pool.
-    uint16_t           mFreeBuffers;          ///< The number of free buffers.
+    uint16_t           mTotalBuffers;         ///< The total number of buffers in the messages pool (0xffff if unknown).
+    uint16_t           mFreeBuffers;          ///< The number of free buffers (0xffff if unknown).
     otMessageQueueInfo m6loSendQueue;         ///< Info about 6LoWPAN send queue.
     otMessageQueueInfo m6loReassemblyQueue;   ///< Info about 6LoWPAN reassembly queue.
     otMessageQueueInfo mIp6Queue;             ///< Info about IPv6 send queue.

--- a/script/check-simulation-build-autotools
+++ b/script/check-simulation-build-autotools
@@ -129,6 +129,11 @@ build_all_features()
     export CPPFLAGS="${options[*]}"
     reset_source
     make -f examples/Makefile-simulation THREAD_VERSION=1.1 OTNS=1
+
+    # Build Thread 1.3 with external heap and msg pool using heap
+    export CPPFLAGS="${options[*]} ${options_1_3[*]} -DOPENTHREAD_CONFIG_MESSAGE_USE_HEAP_ENABLE=1"
+    reset_source
+    make -f examples/Makefile-simulation THREAD_VERSION=1.3
 }
 
 build_nest_common()

--- a/src/core/common/message.cpp
+++ b/src/core/common/message.cpp
@@ -40,6 +40,7 @@
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
 #include "common/log.hpp"
+#include "common/numeric_limits.hpp"
 #include "net/checksum.hpp"
 #include "net/ip6.hpp"
 
@@ -163,7 +164,11 @@ uint16_t MessagePool::GetFreeBufferCount(void) const
     uint16_t rval;
 
 #if OPENTHREAD_CONFIG_MESSAGE_USE_HEAP_ENABLE
+#if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
     rval = static_cast<uint16_t>(Instance::GetHeap().GetFreeSize() / sizeof(Buffer));
+#else
+    rval = NumericLimits<uint16_t>::kMax;
+#endif
 #elif OPENTHREAD_CONFIG_PLATFORM_MESSAGE_MANAGEMENT
     rval = otPlatMessagePoolNumFreeBuffers(&GetInstance());
 #else
@@ -175,11 +180,19 @@ uint16_t MessagePool::GetFreeBufferCount(void) const
 
 uint16_t MessagePool::GetTotalBufferCount(void) const
 {
+    uint16_t rval;
+
 #if OPENTHREAD_CONFIG_MESSAGE_USE_HEAP_ENABLE
-    return static_cast<uint16_t>(Instance::GetHeap().GetCapacity() / sizeof(Buffer));
+#if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+    rval = static_cast<uint16_t>(Instance::GetHeap().GetCapacity() / sizeof(Buffer));
 #else
-    return OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS;
+    rval = NumericLimits<uint16_t>::kMax;
 #endif
+#else
+    rval = OPENTHREAD_CONFIG_NUM_MESSAGE_BUFFERS;
+#endif
+
+    return rval;
 }
 
 //---------------------------------------------------------------------------------------------------------------------

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -1682,7 +1682,7 @@ public:
     /**
      * This method returns the number of free buffers.
      *
-     * @returns The number of free buffers.
+     * @returns The number of free buffers, or 0xffff (UINT16_MAX) if number is unknown.
      *
      */
     uint16_t GetFreeBufferCount(void) const;
@@ -1690,7 +1690,7 @@ public:
     /**
      * This method returns the total number of buffers.
      *
-     * @returns The total number of buffers.
+     * @returns The total number of buffers, or 0xffff (UINT16_MAX) if number is unknown.
      *
      */
     uint16_t GetTotalBufferCount(void) const;


### PR DESCRIPTION
This commit updates the code to allow the config combination of
`OPENTHREAD_CONFIG_MESSAGE_USE_HEAP_ENABLE` along using external heap
`OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE`. This commit updates `Message`
`GetFreeBufferCount()` and `GetTotalBufferCount()` methods to return
special value `0xffff` under this config combo indicating the numbers
cannot be estimated.

This commit also updates `check-simulation-build-autotools` to add
such a build config so to be covered as part OT CI tests.

----

Should address https://github.com/openthread/openthread/issues/7931.