### PR TITLE
[toranj] relax test-017-parent-reset-child-recovery pass condition

### DIFF
--- a/tests/toranj/ncp/test-017-parent-reset-child-recovery.py
+++ b/tests/toranj/ncp/test-017-parent-reset-child-recovery.py
@@ -154,10 +154,13 @@ wpan.verify_within(check_parent_is_associated, 10)
 # child table again.
 wpan.verify_within(check_child_table, 15)
 
-# Verify that number of state changes on all children stays as before
+# Verify that number of state changes on at least one child stays as before
 # (indicating they did not get detached).
 for i in range(len(all_children)):
-    verify(child_num_state_changes[i] == len(wpan.parse_list(all_children[i].get("stat:ncp"))))
+    if child_num_state_changes[i] == len(wpan.parse_list(all_children[i].get("stat:ncp"))):
+        break
+else:
+    verify(False)
 
 # -----------------------------------------------------------------------------------------------------------------------
 # Test finished


### PR DESCRIPTION
This commit relaxes the pass condition for `test-017` which checks
that after a parent is reset it uses "MLE Child Update Request" to
recover its previous children. This is indirectly validated by
monitoring number of state/role changes on the children. With the
recent change which increases the number of MLE Parent Requests, the
window of time where parent is detached is increased and if during
this time a child tries to send to the parent it can detect that
parent is reset and detach itself causing the test to fail. This
commit relaxes the pass condition to at least one child recovering
using "Child Update" mechanism.

----

The recovery using MLE Child Update is already well-covered by 
other cert test, so we can consider disabling this test. I went for
relaxing the pass condition in this PR instead.