### PR TITLE
[routing-manager] ensure to clear the prefix for default route

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1906,6 +1906,7 @@ exit:
 
 void RoutingManager::DiscoveredPrefixTable::Entry::InitFrom(const Ip6::Nd::RouterAdvertMessage::Header &aRaHeader)
 {
+    mPrefix.Clear();
     mType                    = kTypeRoute;
     mValidLifetime           = aRaHeader.GetRouterLifetime();
     mShared.mRoutePreference = aRaHeader.GetDefaultRouterPreference();


### PR DESCRIPTION
This commit fixes the method setting the prefix table entry from
RA header as a default route by clearing `mPrefix` variable so
to set it as `::/0`.

----

Follow up to #7945. Thanks to @simonlingoogle  for noticing this.