### PR TITLE
[test] fix `test_mle_msg_key_seq_jump`

### DIFF
--- a/tests/scripts/thread-cert/test_mle_msg_key_seq_jump.py
+++ b/tests/scripts/thread-cert/test_mle_msg_key_seq_jump.py
@@ -136,20 +136,21 @@ class MleMsgKeySeqJump(thread_cert.TestCase):
         # re-establish link again (using authoritative exchanges). Validate
         # that all nodes are using the new key seq.
 
-        self.simulator.go(40)
+        self.simulator.go(52)
         for node in nodes:
             self.assertEqual(node.get_key_sequence_counter(), 5)
 
         #-------------------------------------------------------------------
-        # Manually increase the key seq on leader. Wait for advertisement
-        # interval. This would trigger both reed and router to notice key
-        # seq jump and try to re-establish link (link request/accept exchange).
-        # Validate that they all adopt the new key seq.
+        # Manually increase the key seq on leader. Wait for max time between
+        # advertisements. This would trigger both reed and router
+        # to notice key seq jump and try to re-establish link (link
+        # request/accept exchange). Validate that they all adopt the new
+        # key seq.
 
         leader.set_key_sequence_counter(10)
         self.assertEqual(leader.get_key_sequence_counter(), 10)
 
-        self.simulator.go(40)
+        self.simulator.go(52)
 
         self.assertEqual(router.get_key_sequence_counter(), 10)
         self.assertEqual(reed.get_key_sequence_counter(), 10)
@@ -220,14 +221,14 @@ class MleMsgKeySeqJump(thread_cert.TestCase):
         self.assertEqual(reed.get_key_sequence_counter(), 20)
 
         #-------------------------------------------------------------------
-        # Move forward the key seq counter by one on router. Wait for
-        # advertisement interval. Validate that leader adopts the higher
+        # Move forward the key seq counter by one on router. Wait for max
+        # time between advertisements. Validate that leader adopts the higher
         # counter value.
 
         router.set_key_sequence_counter(21)
         self.assertEqual(router.get_key_sequence_counter(), 21)
 
-        self.simulator.go(40)
+        self.simulator.go(52)
         self.assertEqual(leader.get_key_sequence_counter(), 21)
         self.assertEqual(reed.get_key_sequence_counter(), 21)
 


### PR DESCRIPTION
This commit updates `test_mle_msg_key_seq_jump` to increase the wait
time after key index change for MLE advertisement transmissions. The
MLE advertisement uses trickle timer with max interval of 32 seconds.
Based on this the max interval between two consecutive advertisement
transmissions can be 1.5 times the trickle timer max interval or 48
seconds. The test uses 52 sec as wait time which includes a 4 sec
additional guard time to account for any action and/or message
exchanges after rx of an advertisement. This change should help
address the occasional failures of this test.