### PR TITLE
[mle] fix incorrect `StatusTlv` when processing Child Update Response

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2771,7 +2771,7 @@ void MleRouter::HandleChildUpdateResponse(RxInfo &aRxInfo)
     }
 
     // Status
-    switch (Tlv::Find<ThreadStatusTlv>(aRxInfo.mMessage, status))
+    switch (Tlv::Find<StatusTlv>(aRxInfo.mMessage, status))
     {
     case kErrorNone:
         VerifyOrExit(status != StatusTlv::kError, RemoveNeighbor(*child));


### PR DESCRIPTION
This commit fixes `MleRouter::HandleChildUpdateResponse()` to use the
MLE `StatusTlv` instead of `ThreadStatusTlv` when parsing a received
MLE Child Update Response (from a child).

----

_Background and More Details:_

Discovered this while trying to debug the occasional failure of `test_mle_msg_key_seq_jump` (e.g. [link](https://github.com/openthread/openthread/runs/7552277940?check_suite_focus=true)).

- The "Thread Status TLV" type is `4` which maps to "MLE Response TLV" (uses 4 as type). 
- Before this fix  if the Child Update Response includes a `ResponseTlv`, the first byte of challenge/response bytes is read and treated as status which is then checked against `StatusTlv::kError = 1` to determine whether the child rejected the parent. 
- So if the first byte happens to be `1` then the parent would incorrectly parse the message reject the child (remove the child from its table). 
- Since the challenge is determined randomly, the chance of this 1 out 256 (which explains why it was not easy to reproduce the failure in `test_mle_msg_key_seq_jump`).

I feel this is not super critical.
- This issue can happen in two situations: (1) when parent is reset and is trying to recover the child or (2) on a key seq jump on child (which should be unlikely).
  - We only include challenge/response TLV in Child Update exchanges under the above situations
  - Then the random challenge bytes must also start with value 1.
  - Worse-case parent will reject the "Child Update Response" from child and then child needs to re-attach.
