### PR TITLE
[config] add `border_routing.h` and `border_agent.h`

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -752,7 +752,9 @@ source_set("libopenthread_core_config") {
   public = [
     "config/announce_sender.h",
     "config/backbone_router.h",
+    "config/border_agent.h",
     "config/border_router.h",
+    "config/border_routing.h",
     "config/channel_manager.h",
     "config/channel_monitor.h",
     "config/child_supervision.h",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -478,7 +478,9 @@ HEADERS_COMMON                                  = \
     common/uptime.hpp                             \
     config/announce_sender.h                      \
     config/backbone_router.h                      \
+    config/border_agent.h                         \
     config/border_router.h                        \
+    config/border_routing.h                       \
     config/channel_manager.h                      \
     config/channel_monitor.h                      \
     config/child_supervision.h                    \

--- a/src/core/config/border_agent.h
+++ b/src/core/config/border_agent.h
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2021, The OpenThread Authors.
+ *  Copyright (c) 2019, The OpenThread Authors.
  *  All rights reserved.
  *
  *  Redistribution and use in source and binary forms, with or without
@@ -28,38 +28,31 @@
 
 /**
  * @file
- *   This file includes compile-time configurations for DTLS.
+ *   This file includes compile-time configurations for Border Agent.
  *
  */
 
-#ifndef CONFIG_DTLS_H_
-#define CONFIG_DTLS_H_
-
-#include "config/border_agent.h"
-#include "config/coap.h"
-#include "config/commissioner.h"
-#include "config/joiner.h"
+#ifndef CONFIG_BORDER_AGENT_H_
+#define CONFIG_BORDER_AGENT_H_
 
 /**
- * @def OPENTHREAD_CONFIG_DTLS_MAX_CONTENT_LEN
+ * @def OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
  *
- * The max length of the OpenThread dtls content buffer.
+ * Define to 1 to enable Border Agent support.
  *
  */
-#ifndef OPENTHREAD_CONFIG_DTLS_MAX_CONTENT_LEN
-#define OPENTHREAD_CONFIG_DTLS_MAX_CONTENT_LEN MBEDTLS_SSL_IN_CONTENT_LEN
+#ifndef OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
+#define OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE 0
 #endif
 
 /**
- * @def OPENTHREAD_CONFIG_DTLS_ENABLE
+ * @def OPENTHREAD_CONFIG_BORDER_AGENT_UDP_PORT
  *
- *  Define to 1 to enable DTLS.
+ * Specifies the Border Agent UDP port, and use 0 for ephemeral port.
  *
  */
-#ifndef OPENTHREAD_CONFIG_DTLS_ENABLE
-#define OPENTHREAD_CONFIG_DTLS_ENABLE                                                     \
-    (OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE || OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE || \
-     OPENTHREAD_CONFIG_COMMISSIONER_ENABLE || OPENTHREAD_CONFIG_JOINER_ENABLE)
+#ifndef OPENTHREAD_CONFIG_BORDER_AGENT_UDP_PORT
+#define OPENTHREAD_CONFIG_BORDER_AGENT_UDP_PORT 0
 #endif
 
-#endif // CONFIG_DTLS_H_
+#endif // CONFIG_BORDER_AGENT_H_

--- a/src/core/config/border_router.h
+++ b/src/core/config/border_router.h
@@ -36,16 +36,6 @@
 #define CONFIG_BORDER_ROUTER_H_
 
 /**
- * @def OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
- *
- * Define to 1 to enable Border Agent support.
- *
- */
-#ifndef OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE
-#define OPENTHREAD_CONFIG_BORDER_AGENT_ENABLE 0
-#endif
-
-/**
  * @def OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
  *
  * Define to 1 to enable Border Router support.
@@ -79,67 +69,6 @@
  */
 #ifndef OPENTHREAD_CONFIG_BORDER_ROUTER_REQUEST_ROUTER_ROLE
 #define OPENTHREAD_CONFIG_BORDER_ROUTER_REQUEST_ROUTER_ROLE 1
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
- *
- * Define to 1 to enable Border Routing support.
- *
- */
-#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-#define OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE 0
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_ROUTERS
- *
- * Specifies maximum number of routers (on infra link) to track by routing manager.
- *
- */
-#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_ROUTERS
-#define OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_ROUTERS 16
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_PREFIXES
- *
- * Specifies maximum number of discovered prefixes (on-link prefixes on the infra link) maintained by routing manager.
- *
- */
-#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_PREFIXES
-#define OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_PREFIXES 64
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_ON_MESH_PREFIXES
- *
- * Specified maximum number of on-mesh prefixes (discovered from Thread Network Data) that are included as Route Info
- * Option in emitted Router Advertisement messages.
- *
- */
-#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_ON_MESH_PREFIXES
-#define OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_ON_MESH_PREFIXES 16
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_BORDER_ROUTING_NAT64_ENABLE
- *
- * Define to 1 to enable Border Routing NAT64 support.
- *
- */
-#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_NAT64_ENABLE
-#define OPENTHREAD_CONFIG_BORDER_ROUTING_NAT64_ENABLE 0
-#endif
-
-/**
- * @def OPENTHREAD_CONFIG_BORDER_AGENT_UDP_PORT
- *
- * Specifies the Border Agent UDP port, and use 0 for ephemeral port.
- *
- */
-#ifndef OPENTHREAD_CONFIG_BORDER_AGENT_UDP_PORT
-#define OPENTHREAD_CONFIG_BORDER_AGENT_UDP_PORT 0
 #endif
 
 #endif // CONFIG_BORDER_ROUTER_H_

--- a/src/core/config/border_routing.h
+++ b/src/core/config/border_routing.h
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2021-22, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes compile-time configurations for Border Routing Manager.
+ *
+ */
+
+#ifndef CONFIG_BORDER_ROUTING_H_
+#define CONFIG_BORDER_ROUTING_H_
+
+/**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+ *
+ * Define to 1 to enable Border Routing Manager feature.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE 0
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_ROUTERS
+ *
+ * Specifies maximum number of routers (on infra link) to track by routing manager.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_ROUTERS
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_ROUTERS 16
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_PREFIXES
+ *
+ * Specifies maximum number of discovered prefixes (on-link prefixes on the infra link) maintained by routing manager.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_PREFIXES
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_PREFIXES 64
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_ON_MESH_PREFIXES
+ *
+ * Specified maximum number of on-mesh prefixes (discovered from Thread Network Data) that are included as Route Info
+ * Option in emitted Router Advertisement messages.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_ON_MESH_PREFIXES
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_ON_MESH_PREFIXES 16
+#endif
+
+/**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_NAT64_ENABLE
+ *
+ * Define to 1 to enable Border Routing NAT64 support.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_NAT64_ENABLE
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_NAT64_ENABLE 0
+#endif
+
+#endif // CONFIG_BORDER_ROUTING_H_

--- a/src/core/config/netdata_publisher.h
+++ b/src/core/config/netdata_publisher.h
@@ -36,6 +36,7 @@
 #define CONFIG_NETDATA_PUBLISHER_H_
 
 #include "config/border_router.h"
+#include "config/border_routing.h"
 #include "config/srp_server.h"
 
 /**

--- a/src/core/openthread-core-config.h
+++ b/src/core/openthread-core-config.h
@@ -58,7 +58,9 @@
 
 #include "config/announce_sender.h"
 #include "config/backbone_router.h"
+#include "config/border_agent.h"
 #include "config/border_router.h"
+#include "config/border_routing.h"
 #include "config/channel_manager.h"
 #include "config/channel_monitor.h"
 #include "config/child_supervision.h"


### PR DESCRIPTION
This commit adds `border_routing.h` and `border_agent.h` header
files for OT configuration related to Border Routing Manager and
Border Agent (removing the definitions from `border_router.h`).