### PR TITLE
[github-actions] remove clang-6,7,8 from build check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -216,7 +216,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang_ver: ["6.0", "7", "8", "9", "10", "11", "12", "13"]
+        clang_ver: ["9", "10", "11", "12", "13"]
     env:
       CC: clang-${{ matrix.clang_ver }}
       CXX: clang++-${{ matrix.clang_ver }}
@@ -246,7 +246,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        clang_ver: ["6.0", "7", "8", "9", "10", "11", "12", "13"]
+        clang_ver: ["9", "10", "11", "12", "13"]
     env:
       CC: clang-${{ matrix.clang_ver }}
       CXX: clang++-${{ matrix.clang_ver }}


### PR DESCRIPTION
To avoid errors such as this: https://github.com/openthread/openthread/runs/7621940586?check_suite_focus=true