### PR TITLE
[docker] upgrade pip before installing cmake

### DIFF
--- a/etc/docker/environment/Dockerfile
+++ b/etc/docker/environment/Dockerfile
@@ -20,6 +20,7 @@ RUN set -x \
         inetutils-ping \
         ca-certificates \
     && update-ca-certificates \
+    && python3 -m pip install -U pip \
     && python3 -m pip install -U cmake \
     && python3 -m pip install wheel
 


### PR DESCRIPTION
To avoid errors such as this: https://github.com/openthread/openthread/runs/7621948528?check_suite_focus=true