### PR TITLE
[lowpan] update `Context` and add `FindContext()` methods

### DIFF
--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -36,6 +36,7 @@
 
 #include "openthread-core-config.h"
 
+#include "common/clearable.hpp"
 #include "common/debug.hpp"
 #include "common/frame_builder.hpp"
 #include "common/frame_data.hpp"
@@ -73,11 +74,12 @@ using ot::Encoding::BigEndian::HostSwap16;
  * This structure represents a LOWPAN_IPHC Context.
  *
  */
-struct Context
+struct Context : public Clearable<Context>
 {
     Ip6::Prefix mPrefix;       ///< The Prefix
     uint8_t     mContextId;    ///< The Context ID.
     bool        mCompressFlag; ///< The Context compression flag.
+    bool        mIsValid;      ///< Indicates whether the context is valid.
 };
 
 /**
@@ -268,6 +270,8 @@ private:
     static constexpr uint8_t kUdpChecksum = 1 << 2;
     static constexpr uint8_t kUdpPortMask = 3 << 0;
 
+    void  FindContextForId(uint8_t aContextId, Context &aContext) const;
+    void  FindContextToCompressAddress(const Ip6::Address &aIp6Address, Context &aContext) const;
     Error Compress(Message &           aMessage,
                    const Mac::Address &aMacSource,
                    const Mac::Address &aMacDest,
@@ -292,7 +296,6 @@ private:
     Error DecompressUdpHeader(Message &aMessage, FrameData &aFrameData, uint16_t aDatagramLength);
     Error DispatchToNextHeader(uint8_t aDispatch, uint8_t &aNextHeader);
 
-    static void  CopyContext(const Context &aContext, Ip6::Address &aAddress);
     static Error ComputeIid(const Mac::Address &aMacAddr, const Context &aContext, Ip6::Address &aIpAddress);
 };
 

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -137,9 +137,7 @@ Error LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context &aCon
 
     if (Get<Mle::MleRouter>().IsMeshLocalAddress(aAddress))
     {
-        aContext.mPrefix.Set(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-        aContext.mContextId    = Mle::kMeshLocalPrefixContextId;
-        aContext.mCompressFlag = true;
+        GetContextForMeshLocalPrefix(aContext);
     }
 
     while ((prefix = FindNextMatchingPrefix(aAddress, prefix)) != nullptr)
@@ -156,6 +154,7 @@ Error LeaderBase::GetContext(const Ip6::Address &aAddress, Lowpan::Context &aCon
             aContext.mPrefix.Set(prefix->GetPrefix(), prefix->GetPrefixLength());
             aContext.mContextId    = contextTlv->GetContextId();
             aContext.mCompressFlag = contextTlv->IsCompress();
+            aContext.mIsValid      = true;
         }
     }
 
@@ -170,9 +169,7 @@ Error LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext) cons
 
     if (aContextId == Mle::kMeshLocalPrefixContextId)
     {
-        aContext.mPrefix.Set(Get<Mle::MleRouter>().GetMeshLocalPrefix());
-        aContext.mContextId    = Mle::kMeshLocalPrefixContextId;
-        aContext.mCompressFlag = true;
+        GetContextForMeshLocalPrefix(aContext);
         ExitNow(error = kErrorNone);
     }
 
@@ -188,11 +185,20 @@ Error LeaderBase::GetContext(uint8_t aContextId, Lowpan::Context &aContext) cons
         aContext.mPrefix.Set(prefix->GetPrefix(), prefix->GetPrefixLength());
         aContext.mContextId    = contextTlv->GetContextId();
         aContext.mCompressFlag = contextTlv->IsCompress();
+        aContext.mIsValid      = true;
         ExitNow(error = kErrorNone);
     }
 
 exit:
     return error;
+}
+
+void LeaderBase::GetContextForMeshLocalPrefix(Lowpan::Context &aContext) const
+{
+    aContext.mPrefix.Set(Get<Mle::MleRouter>().GetMeshLocalPrefix());
+    aContext.mContextId    = Mle::kMeshLocalPrefixContextId;
+    aContext.mCompressFlag = true;
+    aContext.mIsValid      = true;
 }
 
 bool LeaderBase::IsOnMesh(const Ip6::Address &aAddress) const

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -298,6 +298,7 @@ private:
                               uint16_t *          aRloc16) const;
     Error DefaultRouteLookup(const PrefixTlv &aPrefix, uint16_t *aRloc16) const;
     Error SteeringDataCheck(const FilterIndexes &aFilterIndexes) const;
+    void  GetContextForMeshLocalPrefix(Lowpan::Context &aContext) const;
 
     uint8_t mTlvBuffer[kMaxSize];
 };


### PR DESCRIPTION
This commit contains smaller enhancements in `Lowpan` related to
`Context`. It adds a new member variable `mIsValid` to this struct
which indicates whether we have a valid context. It also adds new
methods `FindContextForId()` and `FindContextToCompressAddress()`.
These methods will either retrieve a related context or `Clear()`
it (to indicate that there is no valid context and also set its ID
to zero which is the default used in lowpan compression).