### PR TITLE
[meshcop] update deprecated functions for Mbed TLS  `v3.2.1`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -135,7 +135,7 @@ jobs:
     - uses: actions/checkout@v2
       with:
         repository: ARMmbed/mbedtls
-        ref: v3.1.0
+        ref: v3.2.1
         path: third_party/mbedtls/repo
     - name: Build
       run: |

--- a/src/core/meshcop/dtls.cpp
+++ b/src/core/meshcop/dtls.cpp
@@ -66,7 +66,11 @@ const mbedtls_ecp_group_id Dtls::sCurves[] = {MBEDTLS_ECP_DP_SECP256R1, MBEDTLS_
 #endif
 
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED) || defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
+#if (MBEDTLS_VERSION_NUMBER >= 0x03020000)
+const uint16_t Dtls::sHashes[] = {MBEDTLS_MD_SHA256, MBEDTLS_MD_NONE};
+#else
 const int Dtls::sHashes[] = {MBEDTLS_MD_SHA256, MBEDTLS_MD_NONE};
+#endif
 #endif
 
 Dtls::Dtls(Instance &aInstance, bool aLayerTwoSecurity)
@@ -289,8 +293,13 @@ Error Dtls::Setup(bool aClient)
 #endif
 
     mbedtls_ssl_conf_rng(&mConf, Crypto::MbedTls::CryptoSecurePrng, nullptr);
+#if (MBEDTLS_VERSION_NUMBER >= 0x03020000)
+    mbedtls_ssl_conf_min_tls_version(&mConf, MBEDTLS_SSL_VERSION_TLS1_2);
+    mbedtls_ssl_conf_max_tls_version(&mConf, MBEDTLS_SSL_VERSION_TLS1_2);
+#else
     mbedtls_ssl_conf_min_version(&mConf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
     mbedtls_ssl_conf_max_version(&mConf, MBEDTLS_SSL_MAJOR_VERSION_3, MBEDTLS_SSL_MINOR_VERSION_3);
+#endif
 
     OT_ASSERT(mCipherSuites[1] == 0);
     mbedtls_ssl_conf_ciphersuites(&mConf, mCipherSuites);
@@ -302,7 +311,11 @@ Error Dtls::Setup(bool aClient)
         mbedtls_ssl_conf_curves(&mConf, sCurves);
 #endif
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED) || defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
+#if (MBEDTLS_VERSION_NUMBER >= 0x03020000)
+        mbedtls_ssl_conf_sig_algs(&mConf, sHashes);
+#else
         mbedtls_ssl_conf_sig_hashes(&mConf, sHashes);
+#endif
 #endif
     }
 

--- a/src/core/meshcop/dtls.hpp
+++ b/src/core/meshcop/dtls.hpp
@@ -411,17 +411,17 @@ private:
 
 #else
 
-    static int HandleMbedtlsExportKeys(void *               aContext,
-                                       const unsigned char *aMasterSecret,
-                                       const unsigned char *aKeyBlock,
-                                       size_t               aMacLength,
-                                       size_t               aKeyLength,
-                                       size_t               aIvLength);
-    int        HandleMbedtlsExportKeys(const unsigned char *aMasterSecret,
-                                       const unsigned char *aKeyBlock,
-                                       size_t               aMacLength,
-                                       size_t               aKeyLength,
-                                       size_t               aIvLength);
+    static int       HandleMbedtlsExportKeys(void *               aContext,
+                                             const unsigned char *aMasterSecret,
+                                             const unsigned char *aKeyBlock,
+                                             size_t               aMacLength,
+                                             size_t               aKeyLength,
+                                             size_t               aIvLength);
+    int              HandleMbedtlsExportKeys(const unsigned char *aMasterSecret,
+                                             const unsigned char *aKeyBlock,
+                                             size_t               aMacLength,
+                                             size_t               aKeyLength,
+                                             size_t               aIvLength);
 
 #endif // (MBEDTLS_VERSION_NUMBER >= 0x03000000)
 #endif // MBEDTLS_SSL_EXPORT_KEYS
@@ -449,7 +449,11 @@ private:
 #endif
 
 #if defined(MBEDTLS_KEY_EXCHANGE__WITH_CERT__ENABLED) || defined(MBEDTLS_KEY_EXCHANGE_WITH_CERT_ENABLED)
+#if (MBEDTLS_VERSION_NUMBER >= 0x03020000)
+    static const uint16_t sHashes[];
+#else
     static const int sHashes[];
+#endif
 #endif
 
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE


### PR DESCRIPTION
## Description

- Updated the following deprecated APIs with their respective alternatives -
  - `mbedtls_ssl_conf_min_version` => `mbedtls_ssl_conf_min_tls_version`
  - `mbedtls_ssl_conf_max_version` => `mbedtls_ssl_conf_min_tls_version`
  - `mbedtls_ssl_conf_sig_hashes` => `mbedtls_ssl_conf_sig_algs`
- Updated the parameter data-type for `mbedtls_ssl_conf_sig_algs` (list of allowed signature algorithms) from `int` to `uint16_t`
- Added macros for backward compatibility