### PR TITLE
[coap] ensure to set token on next block request

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -638,6 +638,7 @@ Error CoapBase::PrepareNextBlockRequest(Message::BlockType aType,
     blockOption = (aType == Message::kBlockType1) ? kOptionBlock1 : kOptionBlock2;
 
     aRequest.Init(kTypeConfirmable, static_cast<ot::Coap::Code>(aRequestOld.GetCode()));
+    SuccessOrExit(error = aRequest.SetTokenFromMessage(aRequestOld));
     SuccessOrExit(error = iterator.Init(aRequestOld));
 
     // Copy options from last response to next message


### PR DESCRIPTION
This commit updates `PrepareNextBlockRequest()` to set the token
on new request message from old request.

----

Should help resolve https://github.com/openthread/openthread/issues/7976. 
Thanks @dilipzi for finding and reporting this.