### PR TITLE
[mesh-forwarder] add `Mac::Addresses` (src and dst address)

### DIFF
--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -412,6 +412,16 @@ private:
 };
 
 /**
+ * This structure represents two MAC addresses corresponding to source and destination.
+ *
+ */
+struct Addresses
+{
+    Address mSource;      ///< Source address.
+    Address mDestination; ///< Destination address.
+};
+
+/**
  * This class represents a MAC key.
  *
  */

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1527,10 +1527,7 @@ exit:
     return error;
 }
 
-Error Headers::DecompressFrom(const Message &     aMessage,
-                              uint16_t            aOffset,
-                              const Mac::Address &aMacSource,
-                              const Mac::Address &aMacDest)
+Error Headers::DecompressFrom(const Message &aMessage, uint16_t aOffset, const Mac::Addresses &aMacAddrs)
 {
     static constexpr uint16_t kReadLength = sizeof(Lowpan::FragmentHeader::NextFrag) + sizeof(Headers);
 
@@ -1541,13 +1538,10 @@ Error Headers::DecompressFrom(const Message &     aMessage,
     frameLength = aMessage.ReadBytes(aOffset, frameBuffer, sizeof(frameBuffer));
     frameData.Init(frameBuffer, frameLength);
 
-    return DecompressFrom(frameData, aMacSource, aMacDest, aMessage.GetInstance());
+    return DecompressFrom(frameData, aMacAddrs, aMessage.GetInstance());
 }
 
-Error Headers::DecompressFrom(const FrameData &   aFrameData,
-                              const Mac::Address &aMacSource,
-                              const Mac::Address &aMacDest,
-                              Instance &          aInstance)
+Error Headers::DecompressFrom(const FrameData &aFrameData, const Mac::Addresses &aMacAddrs, Instance &aInstance)
 {
     Error                  error     = kErrorNone;
     FrameData              frameData = aFrameData;
@@ -1563,7 +1557,7 @@ Error Headers::DecompressFrom(const FrameData &   aFrameData,
     VerifyOrExit(Lowpan::Lowpan::IsLowpanHc(frameData), error = kErrorNotFound);
 
     SuccessOrExit(error = aInstance.Get<Lowpan::Lowpan>().DecompressBaseHeader(mIp6Header, nextHeaderCompressed,
-                                                                               aMacSource, aMacDest, frameData));
+                                                                               aMacAddrs, frameData));
 
     switch (mIp6Header.GetNextHeader())
     {

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -401,25 +401,20 @@ public:
      *
      * @param[in]  aMessage         The message from which to read the lowpan frame.
      * @param[in]  aOffset          The offset in @p aMessage to start reading the frame.
-     * @param[in]  aMacSource       The MAC source address.
-     * @param[in]  aMacDest         The MAC destination address.
+     * @param[in]  aMacAddrs        The MAC source and destination addresses.
      *
      * @retval kErrorNone           Successfully decompressed and parsed IPv6 and UDP/TCP/ICMP6 headers.
      * @retval kErrorNotFound       Lowpan frame is a next fragment and does not contain IPv6 headers.
      * @retval kErrorParse          Failed to parse the headers.
      *
      */
-    Error DecompressFrom(const Message &     aMessage,
-                         uint16_t            aOffset,
-                         const Mac::Address &aMacSource,
-                         const Mac::Address &aMacDest);
+    Error DecompressFrom(const Message &aMessage, uint16_t aOffset, const Mac::Addresses &aMacAddrs);
 
     /**
      * This method decompresses lowpan frame and parses the IPv6 and UDP/TCP/ICMP6 headers.
      *
      * @param[in]  aFrameData       The lowpan frame data.
-     * @param[in]  aMacSource       The MAC source address.
-     * @param[in]  aMacDest         The MAC destination address.
+     * @param[in]  aMacAddrs        The MAC source and destination addresses.
      * @param[in]  aInstance        The OpenThread instance.
      *
      * @retval kErrorNone           Successfully decompressed and parsed IPv6 and UDP/TCP/ICMP6 headers.
@@ -427,10 +422,7 @@ public:
      * @retval kErrorParse          Failed to parse the headers.
      *
      */
-    Error DecompressFrom(const FrameData &   aFrameData,
-                         const Mac::Address &aMacSource,
-                         const Mac::Address &aMacDest,
-                         Instance &          aInstance);
+    Error DecompressFrom(const FrameData &aFrameData, const Mac::Addresses &aMacAddrs, Instance &aInstance);
 
     /**
      * This method returns the IPv6 header.

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -360,24 +360,24 @@ exit:
 
 uint16_t IndirectSender::PrepareDataFrame(Mac::TxFrame &aFrame, Child &aChild, Message &aMessage)
 {
-    Ip6::Header  ip6Header;
-    Mac::Address macSource, macDest;
-    uint16_t     directTxOffset;
-    uint16_t     nextOffset;
+    Ip6::Header    ip6Header;
+    Mac::Addresses macAddrs;
+    uint16_t       directTxOffset;
+    uint16_t       nextOffset;
 
     // Determine the MAC source and destination addresses.
 
     IgnoreError(aMessage.Read(0, ip6Header));
 
-    Get<MeshForwarder>().GetMacSourceAddress(ip6Header.GetSource(), macSource);
+    Get<MeshForwarder>().GetMacSourceAddress(ip6Header.GetSource(), macAddrs.mSource);
 
     if (ip6Header.GetDestination().IsLinkLocal())
     {
-        Get<MeshForwarder>().GetMacDestinationAddress(ip6Header.GetDestination(), macDest);
+        Get<MeshForwarder>().GetMacDestinationAddress(ip6Header.GetDestination(), macAddrs.mDestination);
     }
     else
     {
-        aChild.GetMacAddress(macDest);
+        aChild.GetMacAddress(macAddrs.mDestination);
     }
 
     // Prepare the data frame from previous child's indirect offset.
@@ -385,7 +385,7 @@ uint16_t IndirectSender::PrepareDataFrame(Mac::TxFrame &aFrame, Child &aChild, M
     directTxOffset = aMessage.GetOffset();
     aMessage.SetOffset(aChild.GetIndirectFragmentOffset());
 
-    nextOffset = Get<MeshForwarder>().PrepareDataFrame(aFrame, aMessage, macSource, macDest);
+    nextOffset = Get<MeshForwarder>().PrepareDataFrame(aFrame, aMessage, macAddrs);
 
     aMessage.SetOffset(directTxOffset);
 

--- a/src/core/thread/lowpan.hpp
+++ b/src/core/thread/lowpan.hpp
@@ -127,17 +127,13 @@ public:
      * This method compresses an IPv6 header.
      *
      * @param[in]   aMessage       A reference to the IPv6 message.
-     * @param[in]   aMacSource     The MAC source address.
-     * @param[in]   aMacDest       The MAC destination address.
-     * @param[in]  aFrameBuilder   The `FrameBuilder` to use to append the compressed headers.
+     * @param[in]   aMacAddrs      The MAC source and destination addresses.
+     * @param[in]   aFrameBuilder  The `FrameBuilder` to use to append the compressed headers.
      *
      * @returns The size of the compressed header in bytes.
      *
      */
-    Error Compress(Message &           aMessage,
-                   const Mac::Address &aMacSource,
-                   const Mac::Address &aMacDest,
-                   FrameBuilder &      aFrameBuilder);
+    Error Compress(Message &aMessage, const Mac::Addresses &aMacAddrs, FrameBuilder &aFrameBuilder);
 
     /**
      * This method decompresses a LOWPAN_IPHC header.
@@ -145,8 +141,7 @@ public:
      * If the header is parsed successfully the @p aFrameData is updated to skip over the parsed header bytes.
      *
      * @param[out]    aMessage         A reference where the IPv6 header will be placed.
-     * @param[in]     aMacSource       The MAC source address.
-     * @param[in]     aMacDest         The MAC destination address.
+     * @param[in]     aMacAddrs        The MAC source and destination addresses.
      * @param[in,out] aFrameData       A frame data containing the LOWPAN_IPHC header.
      * @param[in]     aDatagramLength  The IPv6 datagram length.
      *
@@ -155,11 +150,10 @@ public:
      * @retval kErrorNoBufs  Could not grow @p aMessage to write the parsed IPv6 header.
      *
      */
-    Error Decompress(Message &           aMessage,
-                     const Mac::Address &aMacSource,
-                     const Mac::Address &aMacDest,
-                     FrameData &         aFrameData,
-                     uint16_t            aDatagramLength);
+    Error Decompress(Message &             aMessage,
+                     const Mac::Addresses &aMacAddrs,
+                     FrameData &           aFrameData,
+                     uint16_t              aDatagramLength);
 
     /**
      * This method decompresses a LOWPAN_IPHC header.
@@ -168,19 +162,17 @@ public:
      *
      * @param[out]    aIp6Header             A reference where the IPv6 header will be placed.
      * @param[out]    aCompressedNextHeader  A boolean reference to output whether next header is compressed or not.
-     * @param[in]     aMacSource             The MAC source address.
-     * @param[in]     aMacDest               The MAC destination address.
+     * @param[in]     aMacAddrs              The MAC source and destination addresses
      * @param[in,out] aFrameData             A frame data containing the LOWPAN_IPHC header.
      *
      * @retval kErrorNone    The header was decompressed successfully. @p aIp6Headre and @p aFrameData are updated.
      * @retval kErrorParse   Failed to parse the lowpan header.
      *
      */
-    Error DecompressBaseHeader(Ip6::Header &       aIp6Header,
-                               bool &              aCompressedNextHeader,
-                               const Mac::Address &aMacSource,
-                               const Mac::Address &aMacDest,
-                               FrameData &         aFrameData);
+    Error DecompressBaseHeader(Ip6::Header &         aIp6Header,
+                               bool &                aCompressedNextHeader,
+                               const Mac::Addresses &aMacAddrs,
+                               FrameData &           aFrameData);
 
     /**
      * This method decompresses a LOWPAN_NHC UDP header.
@@ -272,11 +264,10 @@ private:
 
     void  FindContextForId(uint8_t aContextId, Context &aContext) const;
     void  FindContextToCompressAddress(const Ip6::Address &aIp6Address, Context &aContext) const;
-    Error Compress(Message &           aMessage,
-                   const Mac::Address &aMacSource,
-                   const Mac::Address &aMacDest,
-                   FrameBuilder &      aFrameBuilder,
-                   uint8_t &           aHeaderDepth);
+    Error Compress(Message &             aMessage,
+                   const Mac::Addresses &aMacAddrs,
+                   FrameBuilder &        aFrameBuilder,
+                   uint8_t &             aHeaderDepth);
 
     Error CompressExtensionHeader(Message &aMessage, FrameBuilder &aFrameBuilder, uint8_t &aNextHeader);
     Error CompressSourceIid(const Mac::Address &aMacAddr,

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -426,38 +426,26 @@ private:
     };
 #endif // OPENTHREAD_FTD
 
-    void     SendIcmpErrorIfDstUnreach(const Message &     aMessage,
-                                       const Mac::Address &aMacSource,
-                                       const Mac::Address &aMacDest);
-    Error    CheckReachability(const FrameData &   aFrameData,
-                               const Mac::Address &aMeshSource,
-                               const Mac::Address &aMeshDest);
-    void     UpdateRoutes(const FrameData &aFrameData, const Mac::Address &aMeshSource, const Mac::Address &aMeshDest);
-    Error    FrameToMessage(const FrameData &   aFrameData,
-                            uint16_t            aDatagramSize,
-                            const Mac::Address &aMacSource,
-                            const Mac::Address &aMacDest,
-                            Message *&          aMessage);
+    void     SendIcmpErrorIfDstUnreach(const Message &aMessage, const Mac::Addresses &aMacAddrs);
+    Error    CheckReachability(const FrameData &aFrameData, const Mac::Addresses &aMeshAddrs);
+    void     UpdateRoutes(const FrameData &aFrameData, const Mac::Addresses &aMeshAddrs);
+    Error    FrameToMessage(const FrameData &     aFrameData,
+                            uint16_t              aDatagramSize,
+                            const Mac::Addresses &aMacAddrs,
+                            Message *&            aMessage);
     void     GetMacDestinationAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
     void     GetMacSourceAddress(const Ip6::Address &aIp6Addr, Mac::Address &aMacAddr);
     Message *PrepareNextDirectTransmission(void);
     void     HandleMesh(FrameData &aFrameData, const Mac::Address &aMacSource, const ThreadLinkInfo &aLinkInfo);
-    void     HandleFragment(FrameData &           aFrameData,
-                            const Mac::Address &  aMacSource,
-                            const Mac::Address &  aMacDest,
-                            const ThreadLinkInfo &aLinkInfo);
-    void     HandleLowpanHC(const FrameData &     aFrameData,
-                            const Mac::Address &  aMacSource,
-                            const Mac::Address &  aMacDest,
-                            const ThreadLinkInfo &aLinkInfo);
-    uint16_t PrepareDataFrame(Mac::TxFrame &      aFrame,
-                              Message &           aMessage,
-                              const Mac::Address &aMacSource,
-                              const Mac::Address &aMacDest,
-                              bool                aAddMeshHeader = false,
-                              uint16_t            aMeshSource    = 0xffff,
-                              uint16_t            aMeshDest      = 0xffff,
-                              bool                aAddFragHeader = false);
+    void     HandleFragment(FrameData &aFrameData, const Mac::Addresses &aMacAddrs, const ThreadLinkInfo &aLinkInfo);
+    void HandleLowpanHC(const FrameData &aFrameData, const Mac::Addresses &aMacAddrs, const ThreadLinkInfo &aLinkInfo);
+    uint16_t PrepareDataFrame(Mac::TxFrame &        aFrame,
+                              Message &             aMessage,
+                              const Mac::Addresses &aMacAddrs,
+                              bool                  aAddMeshHeader = false,
+                              uint16_t              aMeshSource    = 0xffff,
+                              uint16_t              aMeshDest      = 0xffff,
+                              bool                  aAddFragHeader = false);
     void     PrepareEmptyFrame(Mac::TxFrame &aFrame, const Mac::Address &aMacDest, bool aAckRequest);
 
 #if OPENTHREAD_CONFIG_DELAY_AWARE_QUEUE_MANAGEMENT_ENABLE
@@ -503,17 +491,13 @@ private:
     static void ScheduleTransmissionTask(Tasklet &aTasklet);
     void        ScheduleTransmissionTask(void);
 
-    Error GetFramePriority(const FrameData &   aFrameData,
-                           const Mac::Address &aMacSource,
-                           const Mac::Address &aMacDest,
-                           Message::Priority & aPriority);
+    Error GetFramePriority(const FrameData &aFrameData, const Mac::Addresses &aMacAddrs, Message::Priority &aPriority);
     Error GetFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader,
                               uint16_t                aSrcRloc16,
                               Message::Priority &     aPriority);
-    void  GetForwardFramePriority(const FrameData &   aFrameData,
-                                  const Mac::Address &aMeshSource,
-                                  const Mac::Address &aMeshDest,
-                                  Message::Priority & aPriority);
+    void  GetForwardFramePriority(const FrameData &     aFrameData,
+                                  const Mac::Addresses &aMeshAddrs,
+                                  Message::Priority &   aPriority);
 
     bool     CalcIePresent(const Message *aMessage);
     uint16_t CalcFrameVersion(const Neighbor *aNeighbor, bool aIePresent);
@@ -536,15 +520,10 @@ private:
     void LogFrame(const char *aActionText, const Mac::Frame &aFrame, Error aError);
     void LogFragmentFrameDrop(Error                         aError,
                               uint16_t                      aFrameLength,
-                              const Mac::Address &          aMacSource,
-                              const Mac::Address &          aMacDest,
+                              const Mac::Addresses &        aMacAddrs,
                               const Lowpan::FragmentHeader &aFragmentHeader,
                               bool                          aIsSecure);
-    void LogLowpanHcFrameDrop(Error               aError,
-                              uint16_t            aFrameLength,
-                              const Mac::Address &aMacSource,
-                              const Mac::Address &aMacDest,
-                              bool                aIsSecure);
+    void LogLowpanHcFrameDrop(Error aError, uint16_t aFrameLength, const Mac::Addresses &aMacAddrs, bool aIsSecure);
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
     const char *MessageActionToString(MessageAction aAction, Error aError);
@@ -556,14 +535,12 @@ private:
                                 const Mac::Address *aMacAddress,
                                 Error               aError,
                                 uint16_t &          aOffset,
-                                Mac::Address &      aMeshSource,
-                                Mac::Address &      aMeshDest,
+                                Mac::Addresses &    aMeshAddrs,
                                 LogLevel            aLogLevel);
-    void  LogMeshIpHeader(const Message &     aMessage,
-                          uint16_t            aOffset,
-                          const Mac::Address &aMeshSource,
-                          const Mac::Address &aMeshDest,
-                          LogLevel            aLogLevel);
+    void  LogMeshIpHeader(const Message &       aMessage,
+                          uint16_t              aOffset,
+                          const Mac::Addresses &aMeshAddrs,
+                          LogLevel              aLogLevel);
     void  LogMeshMessage(MessageAction       aAction,
                          const Message &     aMessage,
                          const Mac::Address *aAddress,
@@ -585,14 +562,13 @@ private:
 
     Message *mSendMessage;
 
-    Mac::Address mMacSource;
-    Mac::Address mMacDest;
-    uint16_t     mMeshSource;
-    uint16_t     mMeshDest;
-    bool         mAddMeshHeader : 1;
-    bool         mEnabled : 1;
-    bool         mTxPaused : 1;
-    bool         mSendBusy : 1;
+    Mac::Addresses mMacAddrs;
+    uint16_t       mMeshSource;
+    uint16_t       mMeshDest;
+    bool           mAddMeshHeader : 1;
+    bool           mEnabled : 1;
+    bool           mTxPaused : 1;
+    bool           mSendBusy : 1;
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_COLLISION_AVOIDANCE_DELAY_ENABLE
     bool       mDelayNextTx : 1;
     TimerMilli mTxDelayTimer;

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -181,8 +181,7 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
 
         aVector.GetUncompressedStream(*message);
 
-        VerifyOrQuit(sLowpan->Compress(*message, aVector.mMacSource, aVector.mMacDestination, frameBuilder) ==
-                     aVector.mError);
+        VerifyOrQuit(sLowpan->Compress(*message, aVector.mMacAddrs, frameBuilder) == aVector.mError);
 
         if (aVector.mError == kErrorNone)
         {
@@ -229,7 +228,7 @@ static void Test(TestIphcVector &aVector, bool aCompress, bool aDecompress)
 
         frameData.Init(iphc, iphcLength);
 
-        error = sLowpan->Decompress(*message, aVector.mMacSource, aVector.mMacDestination, frameData, 0);
+        error = sLowpan->Decompress(*message, aVector.mMacAddrs, frameData, 0);
 
         message->ReadBytes(0, result, message->GetLength());
 

--- a/tests/unit/test_lowpan.hpp
+++ b/tests/unit/test_lowpan.hpp
@@ -73,7 +73,7 @@ public:
      * @param aAddress Pointer to the long MAC address.
      *
      */
-    void SetMacSource(const uint8_t *aAddress) { mMacSource.SetExtended(aAddress); }
+    void SetMacSource(const uint8_t *aAddress) { mMacAddrs.mSource.SetExtended(aAddress); }
 
     /**
      * This method sets short MAC source address.
@@ -81,7 +81,7 @@ public:
      * @param aAddress Short MAC address.
      *
      */
-    void SetMacSource(uint16_t aAddress) { mMacSource.SetShort(aAddress); }
+    void SetMacSource(uint16_t aAddress) { mMacAddrs.mSource.SetShort(aAddress); }
 
     /**
      * This method sets long MAC destination address.
@@ -89,7 +89,7 @@ public:
      * @param aAddress Pointer to the long MAC address.
      *
      */
-    void SetMacDestination(const uint8_t *aAddress) { mMacDestination.SetExtended(aAddress); }
+    void SetMacDestination(const uint8_t *aAddress) { mMacAddrs.mDestination.SetExtended(aAddress); }
 
     /**
      * This method sets short MAC destination address.
@@ -97,7 +97,7 @@ public:
      * @param aAddress Short MAC address.
      *
      */
-    void SetMacDestination(uint16_t aAddress) { mMacDestination.SetShort(aAddress); }
+    void SetMacDestination(uint16_t aAddress) { mMacAddrs.mDestination.SetShort(aAddress); }
 
     /**
      * This method gets the IPv6 header
@@ -261,8 +261,7 @@ public:
      * This fields represent uncompressed IPv6 packet.
      *
      */
-    Mac::Address     mMacSource;
-    Mac::Address     mMacDestination;
+    Mac::Addresses   mMacAddrs;
     Ip6::Header      mIpHeader;
     Payload          mExtHeader;
     Ip6::Header      mIpTunneledHeader;


### PR DESCRIPTION
This commit adds a new struct `Mac::Addresses` which represents two
MAC addresses corresponding to source and destination. This type
is then used in `MeshForwarder` and `Lowpan` methods allowing us
to pass both source and destination addresses as one parameter.