### PR TITLE
[message] extend the message buffer size and its checks

### DIFF
--- a/etc/cmake/options.cmake
+++ b/etc/cmake/options.cmake
@@ -402,6 +402,11 @@ endif()
 
 option(OT_EXCLUDE_TCPLP_LIB "exclude TCPlp library from build")
 
+option(OT_EXTRA_DEFS "extend the list of compile definitions with a list of ; separated definitions")
+if(OT_EXTRA_DEFS)
+    target_compile_definitions(ot-config INTERFACE ${OT_EXTRA_DEFS})
+endif()
+
 # Checks
 if(OT_PLATFORM_UDP AND OT_UDP_FORWARD)
     message(FATAL_ERROR "OT_PLATFORM_UDP and OT_UDP_FORWARD are exclusive")

--- a/script/check-size
+++ b/script/check-size
@@ -147,6 +147,7 @@ size_nrf52840_version()
         "-DOT_TIME_SYNC=ON"
         "-DOT_UDP_FORWARD=ON"
         "-DOT_UPTIME=ON"
+        "-DOT_EXTRA_DEFS=OPENTHREAD_CONFIG_MLE_MAX_CHILDREN=511"
     )
 
     local thread_version=$1

--- a/src/core/config/misc.h
+++ b/src/core/config/misc.h
@@ -172,7 +172,7 @@
  *
  */
 #ifndef OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE
-#define OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE (sizeof(void *) * 32)
+#define OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE (sizeof(void *) * 35)
 #endif
 
 /**


### PR DESCRIPTION
With changes in #7554 the `Metadata` stuct size in `Message` increased,
leading to unsufficient message buffer size when the maximum number
of children is configured, due to the variable size of `ChildMask`.

Furthermore, enabling CoAP Blockwise option also extends the message
buffer size requirements.

Since building with the maximum number of children configured is not
covered for 32-bit architectures, this commit also extends the `check-size`
test using nRF52840 platform to do so.