### PR TITLE
[otci] wait for 2 seconds before retrying a command

### DIFF
--- a/tools/otci/otci/otci.py
+++ b/tools/otci/otci/otci.py
@@ -101,6 +101,7 @@ class OTCI(object):
             try:
                 return self.__execute_command(cmd, timeout, silent, already_is_ok=already_is_ok)
             except Exception:
+                self.wait(2)
                 if i == self.__exec_command_retry:
                     raise
 


### PR DESCRIPTION
After a factoryreset the `ot-ctl` may fail to connect to the socket for a while. In such a situation, if OTCI sends a new command, `execute_command` will receive an exception and will retry the same command for several times. Such retries will be immediately fail because `ot-ctl` connection is still down and there's no time gap between two retries.  Hence we should add some wait time before retrying so that it gives `ot-ctl` some time to recover the connection.