### PR TITLE
[bbr] reduce the default reregistration delay

### DIFF
--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -236,7 +236,7 @@ enum LeaderStartMode : uint8_t
  * Backbone Router / DUA / MLR constants
  *
  */
-constexpr uint16_t kRegistrationDelayDefault         = 1200;              ///< In seconds.
+constexpr uint16_t kRegistrationDelayDefault         = 5;                 ///< In seconds.
 constexpr uint32_t kMlrTimeoutDefault                = 3600;              ///< In seconds.
 constexpr uint32_t kMlrTimeoutMin                    = 300;               ///< In seconds.
 constexpr uint32_t kMlrTimeoutMax                    = 0x7fffffff / 1000; ///< In seconds (about 24 days).


### PR DESCRIPTION
After BBR restarting, in order to receive the packets from multicast group, the devices, which have registered multicast group addresses to that BBR, needs to re-register these groups. In current logic, the default max reregisteration delay is too large(1200 seconds).