### PR TITLE
[message] document buffer size needs

### DIFF
--- a/src/core/coap/coap_message.hpp
+++ b/src/core/coap/coap_message.hpp
@@ -951,7 +951,7 @@ private:
     const HelpData &GetHelpData(void) const
     {
         static_assert(sizeof(HelpData) + kHelpDataAlignment <= kHeadBufferDataSize,
-                      "Insufficient buffer size for CoAP processing!");
+                      "Insufficient buffer size for CoAP processing! Increase OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE.");
 
         return *static_cast<const HelpData *>(OT_ALIGN(GetFirstData(), kHelpDataAlignment));
     }

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -252,7 +252,8 @@ private:
     } mBuffer;
 };
 
-static_assert(sizeof(Buffer) >= kBufferSize, "Buffer size if not valid");
+static_assert(sizeof(Buffer) >= kBufferSize,
+              "Buffer size is not valid. Increase OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE.");
 
 /**
  * This class represents a message.

--- a/src/core/config/misc.h
+++ b/src/core/config/misc.h
@@ -170,6 +170,9 @@
  * to that on 32bit system. As a result, the first message always have some
  * bytes left for small packets.
  *
+ * Some configuration options can increase the buffer size requirments, including
+ * OPENTHREAD_CONFIG_MLE_MAX_CHILDREN and OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE.
+ *
  */
 #ifndef OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE
 #define OPENTHREAD_CONFIG_MESSAGE_BUFFER_SIZE (sizeof(void *) * 32)


### PR DESCRIPTION
With changes in #7554 the `Metadata` stuct size in `Message` increased,
leading to unsufficient message buffer size when the maximum number
of children is configured, due to the variable size of `ChildMask`.

Furthermore, enabling CoAP Blockwise option also extends the message
buffer size requirements.

This commit documents those cases and makes it clearer
for users how to overcome the possible building issues.