### PR TITLE
[mle] add array bound check to avoid overflow in `HandleDataRequest()`

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2881,7 +2881,10 @@ void MleRouter::HandleDataRequest(RxInfo &aRxInfo)
         OT_FALL_THROUGH;
 
     case kErrorNotFound:
-        tlvs[numTlvs++] = Tlv::kActiveDataset;
+        if (numTlvs < sizeof(tlvs))
+        {
+            tlvs[numTlvs++] = Tlv::kActiveDataset;
+        }
         break;
 
     default:
@@ -2900,7 +2903,10 @@ void MleRouter::HandleDataRequest(RxInfo &aRxInfo)
         OT_FALL_THROUGH;
 
     case kErrorNotFound:
-        tlvs[numTlvs++] = Tlv::kPendingDataset;
+        if (numTlvs < sizeof(tlvs))
+        {
+            tlvs[numTlvs++] = Tlv::kPendingDataset;
+        }
         break;
 
     default:


### PR DESCRIPTION

---

The overflow issue is very unlikely since "Data Request" message can only contain `Tlv::kNetworkData` (today).

Quick overview:
- We have a fixes array of `tlvs[4]`
- We parse the "TLV Request" TLV from request message and populate `tlvs[]` array
```c++
    SuccessOrExit(error = aRxInfo.mMessage.ReadTlvRequestTlv(requestedTlvs));
    VerifyOrExit(requestedTlvs.mNumTlvs <= sizeof(tlvs), error = kErrorParse);
    memset(tlvs, Tlv::kInvalid, sizeof(tlvs));
    memcpy(tlvs, requestedTlvs.mTlvs, requestedTlvs.mNumTlvs);
    numTlvs = requestedTlvs.mNumTlvs;
```
- Afterwards, we may add more elements to this array (which may be already full).
