### PR TITLE
[csl] update CSL Channel TLV process to allow for unspecified case

### DIFF
--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -4792,23 +4792,16 @@ exit:
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 Error Mle::TxMessage::AppendCslChannelTlv(void)
 {
-    Error         error = kErrorNone;
     CslChannelTlv cslChannel;
 
-    // In current implementation, it's allowed to set CSL Channel unspecified. As `0` is not valid for Channel value
-    // in CSL Channel TLV, if CSL channel is not specified, we don't append CSL Channel TLV.
-    // And on transmitter side, it would also set CSL Channel for the child to `0` if it doesn't find a CSL Channel
-    // TLV.
-    VerifyOrExit(Get<Mac::Mac>().GetCslChannel());
+    // CSL channel value of zero indicates that the CSL channel is not
+    // specified. We can use this value in the TLV as well.
 
     cslChannel.Init();
     cslChannel.SetChannelPage(0);
     cslChannel.SetChannel(Get<Mac::Mac>().GetCslChannel());
 
-    SuccessOrExit(error = Append(cslChannel));
-
-exit:
-    return error;
+    return Append(cslChannel);
 }
 
 Error Mle::TxMessage::AppendCslTimeoutTlv(void)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -2663,12 +2663,10 @@ void MleRouter::HandleChildUpdateRequest(RxInfo &aRxInfo)
         if (Tlv::FindTlv(aRxInfo.mMessage, cslChannel) == kErrorNone)
         {
             VerifyOrExit(cslChannel.IsValid(), error = kErrorParse);
+
+            // Special value of zero is used to indicate that
+            // CSL channel is not specified.
             child->SetCslChannel(static_cast<uint8_t>(cslChannel.GetChannel()));
-        }
-        else
-        {
-            // Set CSL Channel unspecified.
-            child->SetCslChannel(0);
         }
     }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE

--- a/tests/scripts/thread-cert/v1_2_test_csl_transmission.py
+++ b/tests/scripts/thread-cert/v1_2_test_csl_transmission.py
@@ -72,7 +72,6 @@ class SSED_CslTransmission(thread_cert.TestCase):
 
         ssed_messages = self.simulator.get_messages_sent_by(SSED_1)
         msg = ssed_messages.next_mle_message(mle.CommandType.CHILD_UPDATE_REQUEST)
-        msg.assertMleMessageDoesNotContainTlv(mle.CslChannel)
 
         self.nodes[SSED_1].set_csl_channel(consts.CSL_DEFAULT_CHANNEL)
         self.simulator.go(1)
@@ -89,7 +88,6 @@ class SSED_CslTransmission(thread_cert.TestCase):
 
         ssed_messages = self.simulator.get_messages_sent_by(SSED_1)
         msg = ssed_messages.next_mle_message(mle.CommandType.CHILD_UPDATE_REQUEST)
-        msg.assertMleMessageDoesNotContainTlv(mle.CslChannel)
 
         self.nodes[SSED_1].set_csl_period(0)
         self.assertFalse(self.nodes[LEADER].ping(self.nodes[SSED_1].get_rloc()))


### PR DESCRIPTION
This commit updates how unspecified CSL channel is conveyed in MLE
messages. Special value of zero in CSL Channel TLV is used to
indicate that the CSL channel is unspecified. The exclusion of the
TLV keeps the CSL channel as before (no change to the previously
set CSL channel).

-----

- This PR contains commit from https://github.com/openthread/openthread/pull/8004.
- This is related to [SPEC-1095](https://threadgroup.atlassian.net/browse/SPEC-1095). 
- FYI: @Irving-cl 