### PR TITLE
[ip6-address] move more complex `Prefix` methods to `cpp` file

### DIFF
--- a/src/core/net/ip6_address.cpp
+++ b/src/core/net/ip6_address.cpp
@@ -69,9 +69,41 @@ void Prefix::Set(const uint8_t *aPrefix, uint8_t aLength)
     mLength = aLength;
 }
 
+bool Prefix::IsLinkLocal(void) const
+{
+    return (mLength >= 10) && ((mPrefix.mFields.m16[0] & HostSwap16(0xffc0)) == HostSwap16(0xfe80));
+}
+
+bool Prefix::IsMulticast(void) const
+{
+    return (mLength >= 8) && (mPrefix.mFields.m8[0] == 0xff);
+}
+
+bool Prefix::IsUniqueLocal(void) const
+{
+    return (mLength >= 7) && ((mPrefix.mFields.m8[0] & 0xfe) == 0xfc);
+}
+
 bool Prefix::IsEqual(const uint8_t *aPrefixBytes, uint8_t aPrefixLength) const
 {
     return (mLength == aPrefixLength) && (MatchLength(GetBytes(), aPrefixBytes, GetBytesSize()) >= mLength);
+}
+
+bool Prefix::ContainsPrefix(const Prefix &aSubPrefix) const
+{
+    return (mLength >= aSubPrefix.mLength) &&
+           (MatchLength(GetBytes(), aSubPrefix.GetBytes(), aSubPrefix.GetBytesSize()) >= aSubPrefix.GetLength());
+}
+
+bool Prefix::ContainsPrefix(const NetworkPrefix &aSubPrefix) const
+{
+    return (mLength >= NetworkPrefix::kLength) &&
+           (MatchLength(GetBytes(), aSubPrefix.m8, NetworkPrefix::kSize) >= NetworkPrefix::kLength);
+}
+
+bool Prefix::operator==(const Prefix &aOther) const
+{
+    return (mLength == aOther.mLength) && (MatchLength(GetBytes(), aOther.GetBytes(), GetBytesSize()) >= GetLength());
 }
 
 bool Prefix::operator<(const Prefix &aOther) const

--- a/src/core/net/ip6_address.hpp
+++ b/src/core/net/ip6_address.hpp
@@ -188,10 +188,7 @@ public:
      * @retval FALSE  The prefix is not a Link-Local prefix.
      *
      */
-    bool IsLinkLocal(void) const
-    {
-        return mLength >= 10 && mPrefix.mFields.m8[0] == 0xfe && (mPrefix.mFields.m8[1] & 0xc0) == 0x80;
-    }
+    bool IsLinkLocal(void) const;
 
     /**
      * This method indicates whether the prefix is a Multicast prefix.
@@ -200,7 +197,7 @@ public:
      * @retval FALSE  The prefix is not a Multicast prefix.
      *
      */
-    bool IsMulticast(void) const { return mLength >= 8 && mPrefix.mFields.m8[0] == 0xff; }
+    bool IsMulticast(void) const;
 
     /**
      * This method indicates whether the prefix is a Unique-Local prefix.
@@ -209,7 +206,7 @@ public:
      * @retval FALSE  The prefix is not a Unique-Local prefix.
      *
      */
-    bool IsUniqueLocal(void) const { return mLength >= 7 && (mPrefix.mFields.m8[0] & 0xfe) == 0xfc; }
+    bool IsUniqueLocal(void) const;
 
     /**
      * This method indicates whether the prefix is equal to a given prefix.
@@ -232,11 +229,7 @@ public:
      * @retval FALSE  The prefix does not contains the @p aSubPrefix.
      *
      */
-    bool ContainsPrefix(const Prefix &aSubPrefix) const
-    {
-        return (mLength >= aSubPrefix.mLength) &&
-               (MatchLength(GetBytes(), aSubPrefix.GetBytes(), aSubPrefix.GetBytesSize()) >= aSubPrefix.GetLength());
-    }
+    bool ContainsPrefix(const Prefix &aSubPrefix) const;
 
     /**
      * This method indicates whether the prefix contains a sub-prefix (given as a `NetworkPrefix`).
@@ -247,11 +240,7 @@ public:
      * @retval FALSE  The prefix does not contains the @p aSubPrefix.
      *
      */
-    bool ContainsPrefix(const NetworkPrefix &aSubPrefix) const
-    {
-        return (mLength >= NetworkPrefix::kLength) &&
-               (MatchLength(GetBytes(), aSubPrefix.m8, NetworkPrefix::kSize) >= NetworkPrefix::kLength);
-    }
+    bool ContainsPrefix(const NetworkPrefix &aSubPrefix) const;
 
     /**
      * This method overloads operator `==` to evaluate whether or not two prefixes are equal.
@@ -262,11 +251,7 @@ public:
      * @retval FALSE  If the two prefixes are not equal.
      *
      */
-    bool operator==(const Prefix &aOther) const
-    {
-        return (mLength == aOther.mLength) &&
-               (MatchLength(GetBytes(), aOther.GetBytes(), GetBytesSize()) >= GetLength());
-    }
+    bool operator==(const Prefix &aOther) const;
 
     /**
      * This method overloads operator `<` to compare two prefixes.

--- a/tests/unit/test_ip_address.cpp
+++ b/tests/unit/test_ip_address.cpp
@@ -432,6 +432,30 @@ void TestIp6Prefix(void)
             VerifyOrQuit(!(testCase.mPrefixB < testCase.mPrefixA));
         }
     }
+
+    // `IsLinkLocal()` - should contain `fe80::/10`.
+    VerifyOrQuit(PrefixFrom("fe80::", 10).IsLinkLocal());
+    VerifyOrQuit(PrefixFrom("fe80::", 11).IsLinkLocal());
+    VerifyOrQuit(PrefixFrom("fea0::", 16).IsLinkLocal());
+    VerifyOrQuit(!PrefixFrom("fe80::", 9).IsLinkLocal());
+    VerifyOrQuit(!PrefixFrom("ff80::", 10).IsLinkLocal());
+    VerifyOrQuit(!PrefixFrom("fe00::", 10).IsLinkLocal());
+    VerifyOrQuit(!PrefixFrom("fec0::", 10).IsLinkLocal());
+
+    // `IsMulticast()` - should contain `ff00::/8`.
+    VerifyOrQuit(PrefixFrom("ff00::", 8).IsMulticast());
+    VerifyOrQuit(PrefixFrom("ff80::", 9).IsMulticast());
+    VerifyOrQuit(PrefixFrom("ffff::", 16).IsMulticast());
+    VerifyOrQuit(!PrefixFrom("ff00::", 7).IsMulticast());
+    VerifyOrQuit(!PrefixFrom("fe00::", 8).IsMulticast());
+
+    // `IsUniqueLocal()` - should contain `fc00::/7`.
+    VerifyOrQuit(PrefixFrom("fc00::", 7).IsUniqueLocal());
+    VerifyOrQuit(PrefixFrom("fd00::", 8).IsUniqueLocal());
+    VerifyOrQuit(PrefixFrom("fc10::", 16).IsUniqueLocal());
+    VerifyOrQuit(!PrefixFrom("fc00::", 6).IsUniqueLocal());
+    VerifyOrQuit(!PrefixFrom("f800::", 7).IsUniqueLocal());
+    VerifyOrQuit(!PrefixFrom("fe00::", 7).IsUniqueLocal());
 }
 
 void TestIp4Ip6Translation(void)


### PR DESCRIPTION
This commit moves more complex methods of `Ip6::Prefix` class to the
`cpp` file. It also simplifies the `IsLinkLocal()` implementation. It
also updates unit test `test_ip_address` to validate `IsLinkLocal()`,
`IsMulticast()`, and `IsUniqueLocal()` methods.