### PR TITLE
[routing-manager] use `Ip6::Prefix::IsUniqeLocal()` to check OMR prefix

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -891,11 +891,10 @@ bool RoutingManager::IsValidOmrPrefix(const NetworkData::OnMeshPrefixConfig &aOn
            aOnMeshPrefixConfig.mSlaac && aOnMeshPrefixConfig.mStable && !aOnMeshPrefixConfig.mDp;
 }
 
-bool RoutingManager::IsValidOmrPrefix(const Ip6::Prefix &aOmrPrefix)
+bool RoutingManager::IsValidOmrPrefix(const Ip6::Prefix &aPrefix)
 {
-    // Accept ULA prefix with length of 64 bits and GUA prefix.
-    return (aOmrPrefix.mLength == kOmrPrefixLength && aOmrPrefix.mPrefix.mFields.m8[0] == 0xfd) ||
-           (aOmrPrefix.mLength >= 3 && (aOmrPrefix.GetBytes()[0] & 0xE0) == 0x20);
+    // Accept ULA prefix and GUA prefix.
+    return (aPrefix.IsUniqueLocal() || (aPrefix.mLength >= 3 && (aPrefix.GetBytes()[0] & 0xE0) == 0x20));
 }
 
 bool RoutingManager::IsValidOnLinkPrefix(const Ip6::Nd::PrefixInfoOption &aPio)

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -220,23 +220,26 @@ public:
     void HandleInfraIfStateChanged(void) { EvaluateState(); }
 
     /**
-     * This method checks if the on-mesh prefix configuration is a valid OMR prefix.
+     * This method checks whether the on-mesh prefix configuration is a valid OMR prefix.
      *
      * @param[in] aOnMeshPrefixConfig  The on-mesh prefix configuration to check.
      *
-     * @returns  Whether the on-mesh prefix configuration is a valid OMR prefix.
+     * @retval   TRUE    The prefix is a valid OMR prefix.
+     * @retval   FALE    The prefix is not a valid OMR prefix.
      *
      */
     static bool IsValidOmrPrefix(const NetworkData::OnMeshPrefixConfig &aOnMeshPrefixConfig);
 
     /**
-     * This method checks if the OMR prefix is valid (i.e. GUA/ULA prefix with length being 64).
+     * This method checks whether a given prefix is a valid OMR prefix.
      *
-     * @param[in]  aOmrPrefix  The OMR prefix to check.
-     * @returns    Whether the OMR prefix is valid.
+     * @param[in]  aPrefix  The prefix to check.
+     *
+     * @retval   TRUE    The prefix is a valid OMR prefix.
+     * @retval   FALE    The prefix is not a valid OMR prefix.
      *
      */
-    static bool IsValidOmrPrefix(const Ip6::Prefix &aOmrPrefix);
+    static bool IsValidOmrPrefix(const Ip6::Prefix &aPrefix);
 
     /**
      * This method initializes a `PrefixTableIterator`.


### PR DESCRIPTION
This commit updates `IsValidOmrPrefix()` to use `IsUniqeLocal()`
method of `Ip6::Prefix`. This relaxes the check to allow any ULA
prefix and not necessarily with 64 bits prefix length.