### PR TITLE
[mle] add method to get parent info

### DIFF
--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -346,38 +346,7 @@ uint16_t otThreadGetRloc16(otInstance *aInstance)
 
 otError otThreadGetParentInfo(otInstance *aInstance, otRouterInfo *aParentInfo)
 {
-    Error   error = kErrorNone;
-    Router *parent;
-
-    OT_ASSERT(aParentInfo != nullptr);
-
-    // Reference device needs get the original parent's info even after the node state changed.
-#if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    VerifyOrExit(AsCoreType(aInstance).Get<Mle::MleRouter>().IsChild(), error = kErrorInvalidState);
-#endif
-
-    parent = &AsCoreType(aInstance).Get<Mle::MleRouter>().GetParent();
-
-    aParentInfo->mExtAddress     = parent->GetExtAddress();
-    aParentInfo->mRloc16         = parent->GetRloc16();
-    aParentInfo->mRouterId       = Mle::Mle::RouterIdFromRloc16(parent->GetRloc16());
-    aParentInfo->mNextHop        = parent->GetNextHop();
-    aParentInfo->mPathCost       = parent->GetCost();
-    aParentInfo->mLinkQualityIn  = parent->GetLinkInfo().GetLinkQuality();
-    aParentInfo->mLinkQualityOut = parent->GetLinkQualityOut();
-    aParentInfo->mAge            = static_cast<uint8_t>(Time::MsecToSec(TimerMilli::GetNow() - parent->GetLastHeard()));
-    aParentInfo->mAllocated      = true;
-    aParentInfo->mLinkEstablished = parent->IsStateValid();
-    aParentInfo->mVersion         = parent->GetVersion();
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    aParentInfo->mCslClockAccuracy = parent->GetCslClockAccuracy();
-    aParentInfo->mCslUncertainty   = parent->GetCslUncertainty();
-#endif
-
-#if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-exit:
-#endif
-    return error;
+    return AsCoreType(aInstance).Get<Mle::Mle>().GetParentInfo(AsCoreType(aParentInfo));
 }
 
 otError otThreadGetParentAverageRssi(otInstance *aInstance, int8_t *aParentRssi)

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3818,6 +3818,24 @@ uint16_t Mle::GetNextHop(uint16_t aDestination) const
     return (mParent.IsStateValid()) ? mParent.GetRloc16() : static_cast<uint16_t>(Mac::kShortAddrInvalid);
 }
 
+Error Mle::GetParentInfo(Router::Info &aParentInfo) const
+{
+    Error error = kErrorNone;
+
+    // Skip the check for reference device since it needs to get the
+    // original parent's info even after role change.
+
+#if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
+    VerifyOrExit(IsChild(), error = kErrorInvalidState);
+#endif
+
+    aParentInfo.SetFrom(mParent);
+    ExitNow();
+
+exit:
+    return error;
+}
+
 bool Mle::IsRoutingLocator(const Ip6::Address &aAddress) const
 {
     return IsMeshLocalAddress(aAddress) && aAddress.GetIid().IsRoutingLocator();

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -418,6 +418,17 @@ public:
     Router &GetParent(void) { return mParent; }
 
     /**
+     * The method retrieves information about the parent.
+     *
+     * @param[out] aParentInfo     Reference to a parent information structure.
+     *
+     * @retval kErrorNone          Successfully retrieved the parent info and updated @p aParentInfo.
+     * @retval kErrorInvalidState  Device role is not child.
+     *
+     */
+    Error GetParentInfo(Router::Info &aParentInfo) const;
+
+    /**
      * This method get the parent candidate.
      *
      * The parent candidate is valid when attempting to attach to a new parent.

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -524,6 +524,11 @@ void Router::Info::SetFrom(const Router &aRouter)
     mLinkQualityIn   = aRouter.GetLinkInfo().GetLinkQuality();
     mLinkQualityOut  = aRouter.GetLinkQualityOut();
     mAge             = static_cast<uint8_t>(Time::MsecToSec(TimerMilli::GetNow() - aRouter.GetLastHeard()));
+    mVersion         = aRouter.GetVersion();
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+    mCslClockAccuracy = aRouter.GetCslClockAccuracy();
+    mCslUncertainty   = aRouter.GetCslUncertainty();
+#endif
 }
 
 void Router::Clear(void)


### PR DESCRIPTION
This commit moves the code for getting the parent info from the
`thread_api.cpp` to `Mle` class `GetParentInfo()` method. It also
updates the `Router::Info::SetFrom()` to populate the `mVersion` and
the newly added CSL related fields. This allows us to re-use the
same code for both router or parent info.