### PR TITLE
[slaac] only allow SLAAC for prefixes with 64-bit length

### DIFF
--- a/src/core/utils/slaac_address.cpp
+++ b/src/core/utils/slaac_address.cpp
@@ -204,7 +204,8 @@ void Slaac::Update(UpdateMode aMode)
         {
             Ip6::Prefix &prefix = config.GetPrefix();
 
-            if (config.mDp || !config.mSlaac || ShouldFilter(prefix))
+            if (config.mDp || !config.mSlaac || (prefix.GetLength() != Ip6::NetworkPrefix::kLength) ||
+                ShouldFilter(prefix))
             {
                 continue;
             }


### PR DESCRIPTION
This commit updates `Slaac` module to only allow prefixes with
64-bit length.

----

Related to 
- discussion in https://github.com/openthread/openthread/issues/8010 
- and [RFC 4944 Section 6](https://www.rfc-editor.org/rfc/rfc4944#section-6).