### PR TITLE
[ip6] update `HandlePayload()` (avoid msg clone if not needed)

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -950,7 +950,18 @@ Error Ip6::HandlePayload(Header &           aIp6Header,
     Error    error   = kErrorNone;
     Message *message = (aMessageOwnership == Message::kTakeCustody) ? &aMessage : nullptr;
 
-    VerifyOrExit(aIpProto == kProtoTcp || aIpProto == kProtoUdp || aIpProto == kProtoIcmp6);
+    switch (aIpProto)
+    {
+    case kProtoUdp:
+    case kProtoIcmp6:
+        break;
+#if OPENTHREAD_CONFIG_TCP_ENABLE
+    case kProtoTcp:
+        break;
+#endif
+    default:
+        ExitNow();
+    }
 
     if (aMessageOwnership == Message::kCopyToUse)
     {


### PR DESCRIPTION
This commit adds a smaller enhancement in `Ip6::HandlePayload()`. If
support for TCP `OPENTHREAD_CONFIG_TCP_ENABLE` is not enabled, we
exits early from this method before potentially creating a clone of
the message (to free later).
