### PR TITLE
[csl] add `CslAccuracy` type

### DIFF
--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -643,42 +643,24 @@ public:
     bool IsCslSupported(void) const;
 
     /**
-     * This method returns CSL parent clock accuracy, in ± ppm.
+     * This method returns parent CSL accuracy (clock accuracy and uncertainty).
      *
-     * @retval CSL parent clock accuracy, in ± ppm.
+     * @returns The parent CSL accuracy.
      *
      */
-    uint8_t GetCslParentClockAccuracy(void) const { return mLinks.GetSubMac().GetCslParentClockAccuracy(); }
+    const CslAccuracy &GetCslParentAccuracy(void) const { return mLinks.GetSubMac().GetCslParentAccuracy(); }
 
     /**
-     * This method sets CSL parent clock accuracy, in ± ppm.
+     * This method sets parent CSL accuracy.
      *
-     * @param[in] aCslParentAccuracy CSL parent clock accuracy, in ± ppm.
+     * @param[in] aCslAccuracy  The parent CSL accuracy.
      *
      */
-    void SetCslParentClockAccuracy(uint8_t aCslParentAccuracy)
+    void SetCslParentAccuracy(const CslAccuracy &aCslAccuracy)
     {
-        mLinks.GetSubMac().SetCslParentClockAccuracy(aCslParentAccuracy);
+        mLinks.GetSubMac().SetCslParentAccuracy(aCslAccuracy);
     }
 
-    /**
-     * This method returns CSL parent uncertainty, in ±10 us units.
-     *
-     * @retval CSL parent uncertainty, in ±10 us units.
-     *
-     */
-    uint8_t GetCslParentUncertainty(void) const { return mLinks.GetSubMac().GetCslParentUncertainty(); }
-
-    /**
-     * This method returns CSL parent uncertainty, in ±10 us units.
-     *
-     * @param[in] aCslParentUncert  CSL parent uncertainty, in ±10 us units.
-     *
-     */
-    void SetCslParentUncertainty(uint8_t aCslParentUncert)
-    {
-        mLinks.GetSubMac().SetCslParentUncertainty(aCslParentUncert);
-    }
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE && OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE

--- a/src/core/mac/mac_types.hpp
+++ b/src/core/mac/mac_types.hpp
@@ -867,6 +867,73 @@ private:
 };
 
 /**
+ * This class represents CSL accuracy.
+ *
+ */
+class CslAccuracy
+{
+public:
+    static constexpr uint8_t kWorstClockAccuracy = 255; ///< Worst possible crystal accuracy, in units of ± ppm.
+    static constexpr uint8_t kWorstUncertainty   = 255; ///< Worst possible uncertainty, in units of 10 microseconds.
+
+    /**
+     * This method initializes the CSL accuracy using `kWorstClockAccuracy` and `kWorstUncertainty` values.
+     *
+     */
+    void Init(void)
+    {
+        mClockAccuracy = kWorstClockAccuracy;
+        mUncertainty   = kWorstUncertainty;
+    }
+
+    /**
+     * This method returns the CSL clock accuracy.
+     *
+     * @returns The CSL clock accuracy in ± ppm.
+     *
+     */
+    uint8_t GetClockAccuracy(void) const { return mClockAccuracy; }
+
+    /**
+     * This method sets the CSL clock accuracy.
+     *
+     * @param[in]  aClockAccuracy  The CSL clock accuracy in ± ppm.
+     *
+     */
+    void SetClockAccuracy(uint8_t aClockAccuracy) { mClockAccuracy = aClockAccuracy; }
+
+    /**
+     * This method returns the CSL uncertainty.
+     *
+     * @returns The uncertainty in units 10 microseconds.
+     *
+     */
+    uint8_t GetUncertainty(void) const { return mUncertainty; }
+
+    /**
+     * This method gets the CLS uncertainty in microseconds.
+     *
+     * @returns the CLS uncertainty in microseconds.
+     *
+     */
+    uint16_t GetUncertaintyInMicrosec(void) const { return static_cast<uint16_t>(mUncertainty) * kUsPerUncertUnit; }
+
+    /**
+     * This method sets the CSL uncertainty.
+     *
+     * @param[in]  aUncertainty  The CSL uncertainty in units 10 microseconds.
+     *
+     */
+    void SetUncertainty(uint8_t aUncertainty) { mUncertainty = aUncertainty; }
+
+private:
+    static constexpr uint8_t kUsPerUncertUnit = 10;
+
+    uint8_t mClockAccuracy;
+    uint8_t mUncertainty;
+};
+
+/**
  * @}
  *
  */

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -418,36 +418,20 @@ public:
     void CslSample(void);
 
     /**
-     * This method returns CSL parent clock accuracy, in ± ppm.
+     * This method returns parent CSL accuracy (clock accuracy and uncertainty).
      *
-     * @retval CSL parent clock accuracy.
+     * @returns The parent CSL accuracy.
      *
      */
-    uint8_t GetCslParentClockAccuracy(void) const { return mCslParentAccuracy; }
+    const CslAccuracy &GetCslParentAccuracy(void) const { return mCslParentAccuracy; }
 
     /**
-     * This method sets CSL parent clock accuracy, in ± ppm.
+     * This method sets parent CSL accuracy.
      *
-     * @param[in] aCslParentAccuracy CSL parent clock accuracy, in ± ppm.
-     *
-     */
-    void SetCslParentClockAccuracy(uint8_t aCslParentAccuracy) { mCslParentAccuracy = aCslParentAccuracy; }
-
-    /**
-     * This method sets CSL parent uncertainty, in ±10 us units.
-     *
-     * @retval CSL parent uncertainty, in ±10 us units.
+     * @param[in] aCslAccuracy  The parent CSL accuracy.
      *
      */
-    uint8_t GetCslParentUncertainty(void) const { return mCslParentUncert; }
-
-    /**
-     * This method returns CSL parent uncertainty, in ±10 us units.
-     *
-     * @param[in] aCslParentUncert  CSL parent uncertainty, in ±10 us units.
-     *
-     */
-    void SetCslParentUncertainty(uint8_t aCslParentUncert) { mCslParentUncert = aCslParentUncert; }
+    void SetCslParentAccuracy(const CslAccuracy &aCslAccuracy) { mCslParentAccuracy = aCslAccuracy; }
 
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
@@ -662,12 +646,11 @@ private:
     uint8_t  mCslChannel : 7; // The CSL sample channel.
     bool mIsCslSampling : 1;  // Indicates that the radio is receiving in CSL state for platforms not supporting delayed
                               // reception.
-    uint16_t   mCslPeerShort; // The CSL peer short address.
-    TimeMicro  mCslSampleTime;     // The CSL sample time of the current period.
-    TimeMicro  mCslLastSync;       // The timestamp of the last successful CSL synchronization.
-    uint8_t    mCslParentAccuracy; // Drift of timer used for scheduling CSL tx by the parent, in ± ppm.
-    uint8_t    mCslParentUncert;   // Uncertainty of the scheduling CSL of tx by the parent, in ±10 us units.
-    TimerMicro mCslTimer;
+    uint16_t    mCslPeerShort;      // The CSL peer short address.
+    TimeMicro   mCslSampleTime;     // The CSL sample time of the current period.
+    TimeMicro   mCslLastSync;       // The timestamp of the last successful CSL synchronization.
+    CslAccuracy mCslParentAccuracy; // The parent's CSL accuracy (clock accuracy and uncertainty).
+    TimerMicro  mCslTimer;
 #endif
 };
 

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -56,12 +56,6 @@ static constexpr uint64_t kMinCslPeriod  = OPENTHREAD_CONFIG_MAC_CSL_MIN_PERIOD 
 static constexpr uint64_t kMaxCslTimeout = OPENTHREAD_CONFIG_MAC_CSL_MAX_TIMEOUT;
 #endif
 
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-static constexpr uint8_t kCslWorstCrystalPpm  = 255; ///< Worst possible crystal accuracy, in units of ± ppm.
-static constexpr uint8_t kCslWorstUncertainty = 255; ///< Worst possible scheduling uncertainty, in units of 10 us.
-static constexpr uint8_t kUsPerUncertUnit     = 10;  ///< Number of microseconds by uncertainty unit.
-#endif
-
 /**
  * @addtogroup core-radio
  *

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -773,12 +773,12 @@ public:
     /**
      * This method calculates CSL metric of parent.
      *
-     * @param[in] aCslClockAccuracy The CSL Clock Accuracy.
-     * @param[in] aCslUncertainty The CSL Uncertainty.
+     * @param[in] aCslAccuracy The CSL accuracy.
      *
      * @returns CSL metric.
+     *
      */
-    uint64_t CalcParentCslMetric(uint8_t aCslClockAccuracy, uint8_t aCslUncertainty);
+    uint64_t CalcParentCslMetric(const Mac::CslAccuracy &aCslAccuracy);
 
 #endif // OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
 
@@ -1424,6 +1424,20 @@ protected:
          */
         Error ReadLeaderDataTlv(LeaderData &aLeaderData) const;
 
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+        /**
+         * This method reads CSL Clock Accuracy TLV from a message.
+         *
+         * @param[out]      A reference to output the CSL accuracy.
+         *
+         * @retval kErrorNone       Successfully read the TLV.
+         * @retval kErrorNotFound   TLV was not found in the message.
+         * @retval kErrorParse      TLV was found but could not be parsed.
+         *
+         */
+        Error ReadCslClockAccuracyTlv(Mac::CslAccuracy &aCslAccuracy) const;
+#endif
+
     private:
         Error ReadChallengeOrResponse(uint8_t aTlvType, Challenge &aBuffer) const;
     };
@@ -2009,13 +2023,12 @@ private:
     bool     HasAcceptableParentCandidate(void) const;
     Error    DetermineParentRequestType(ParentRequestType &aType) const;
 
-    bool IsBetterParent(uint16_t               aRloc16,
-                        LinkQuality            aLinkQuality,
-                        uint8_t                aLinkMargin,
-                        const ConnectivityTlv &aConnectivityTlv,
-                        uint16_t               aVersion,
-                        uint8_t                aCslClockAccuracy,
-                        uint8_t                aCslUncertainty);
+    bool IsBetterParent(uint16_t                aRloc16,
+                        LinkQuality             aLinkQuality,
+                        uint8_t                 aLinkMargin,
+                        const ConnectivityTlv & aConnectivityTlv,
+                        uint16_t                aVersion,
+                        const Mac::CslAccuracy &aCslAccuracy);
     bool IsNetworkDataNewer(const LeaderData &aLeaderData);
 
     Error ProcessMessageSecurity(Crypto::AesCcm::Mode    aMode,

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -527,8 +527,8 @@ void Router::Info::SetFrom(const Router &aRouter)
     mAge             = static_cast<uint8_t>(Time::MsecToSec(TimerMilli::GetNow() - aRouter.GetLastHeard()));
     mVersion         = ClampToUint8(aRouter.GetVersion());
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    mCslClockAccuracy = aRouter.GetCslClockAccuracy();
-    mCslUncertainty   = aRouter.GetCslUncertainty();
+    mCslClockAccuracy = aRouter.GetCslAccuracy().GetClockAccuracy();
+    mCslUncertainty   = aRouter.GetCslAccuracy().GetUncertainty();
 #endif
 }
 

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -1365,8 +1365,7 @@ public:
     {
         Neighbor::Init(aInstance);
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-        SetCslClockAccuracy(kCslWorstCrystalPpm);
-        SetCslUncertainty(kCslWorstUncertainty);
+        mCslAccuracy.Init();
 #endif
     }
 
@@ -1426,36 +1425,20 @@ public:
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     /**
-     * This method get the CSL clock accuracy of this router.
+     * This method gets the CSL accuracy (clock accuracy and uncertainty).
      *
-     * @returns The CSL clock accuracy of this router.
+     * @returns The CSL accuracy.
      *
      */
-    uint8_t GetCslClockAccuracy(void) const { return mCslClockAccuracy; }
+    const Mac::CslAccuracy &GetCslAccuracy(void) const { return mCslAccuracy; }
 
     /**
-     * This method sets the CSL clock accuracy of this router.
+     * This method sets CSL accuracy.
      *
-     * @param[in]  aCslClockAccuracy  The CSL clock accuracy of this router.
-     *
-     */
-    void SetCslClockAccuracy(uint8_t aCslClockAccuracy) { mCslClockAccuracy = aCslClockAccuracy; }
-
-    /**
-     * This method get the CSL clock uncertainty of this router.
-     *
-     * @returns The CSL clock uncertainty of this router.
+     * @param[in] aCslAccuracy  The CSL accuracy.
      *
      */
-    uint8_t GetCslUncertainty(void) const { return mCslUncertainty; }
-
-    /**
-     * This method sets the CSL clock uncertainty of this router.
-     *
-     * @param[in]  aCslUncertainty  The CSL clock uncertainty of this router.
-     *
-     */
-    void SetCslUncertainty(uint8_t aCslUncertainty) { mCslUncertainty = aCslUncertainty; }
+    void SetCslAccuracy(const Mac::CslAccuracy &aCslAccuracy) { mCslAccuracy = aCslAccuracy; }
 #endif
 
 private:
@@ -1468,8 +1451,7 @@ private:
     uint8_t mCost : 4;     ///< The cost to this router via neighbor router
 #endif
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    uint8_t mCslClockAccuracy; ///< Crystal accuracy, in units of ± ppm.
-    uint8_t mCslUncertainty;   ///< Scheduling uncertainty, in units of 10 us.
+    Mac::CslAccuracy mCslAccuracy; // CSL accuracy (clock accuracy in ppm and uncertainty).
 #endif
 };
 


### PR DESCRIPTION
The CSL accuracy is represented as two parameters: clock accuracy in
ppm, and uncertainty in units of 10 microseconds. These two parameters
are often used together. This commit adds a new class `CslAccuracy`
encapsulating both. This new type is used in `Mac` and `Mle` methods
allowing us to pass both in one object.

This commit also adds `Mle::RxMessage::ReadCslClockAccuracyTlv()` to
read and parse the CSL Accuracy TLV value from a given received MLE
message.