### PR TITLE
[thread] add version consts & use `uint16_t` for `Neighbor::mVersion`

### DIFF
--- a/src/core/BUILD.gn
+++ b/src/core/BUILD.gn
@@ -681,6 +681,7 @@ openthread_core_files = [
   "thread/topology.hpp",
   "thread/uri_paths.cpp",
   "thread/uri_paths.hpp",
+  "thread/version.hpp",
   "utils/channel_manager.cpp",
   "utils/channel_manager.hpp",
   "utils/channel_monitor.cpp",

--- a/src/core/Makefile.am
+++ b/src/core/Makefile.am
@@ -633,6 +633,7 @@ HEADERS_COMMON                                  = \
     thread/tmf.hpp                                \
     thread/topology.hpp                           \
     thread/uri_paths.hpp                          \
+    thread/version.hpp                            \
     utils/channel_manager.hpp                     \
     utils/channel_monitor.hpp                     \
     utils/child_supervision.hpp                   \

--- a/src/core/api/thread_api.cpp
+++ b/src/core/api/thread_api.cpp
@@ -40,6 +40,7 @@
 #include "common/as_core_type.hpp"
 #include "common/debug.hpp"
 #include "common/locator_getters.hpp"
+#include "thread/version.hpp"
 
 using namespace ot;
 
@@ -400,7 +401,7 @@ otError otThreadSetEnabled(otInstance *aInstance, bool aEnabled)
 
 uint16_t otThreadGetVersion(void)
 {
-    return OPENTHREAD_CONFIG_THREAD_VERSION;
+    return kThreadVersion;
 }
 
 bool otThreadIsSingleton(otInstance *aInstance)

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -49,6 +49,7 @@
 #include "mac/mac_types.hpp"
 #include "meshcop/dataset.hpp"
 #include "net/ip6_address.hpp"
+#include "thread/version.hpp"
 #include "utils/flash.hpp"
 #include "utils/slaac_address.hpp"
 
@@ -143,7 +144,7 @@ public:
         void Init(void)
         {
             Clear();
-            SetVersion(OT_THREAD_VERSION_1_1);
+            SetVersion(kThreadVersion1p1);
         }
 
         /**
@@ -349,7 +350,7 @@ public:
         void Init(void)
         {
             Clear();
-            SetVersion(OT_THREAD_VERSION_1_1);
+            SetVersion(kThreadVersion1p1);
         }
 
         /**
@@ -411,7 +412,7 @@ public:
         void Init(void)
         {
             memset(this, 0, sizeof(*this));
-            SetVersion(OT_THREAD_VERSION_1_1);
+            SetVersion(kThreadVersion1p1);
         }
 
         /**

--- a/src/core/thread/child_table.cpp
+++ b/src/core/thread/child_table.cpp
@@ -246,7 +246,7 @@ void ChildTable::Restore(void)
         child->SetDeviceMode(Mle::DeviceMode(childInfo.GetMode()));
         child->SetState(Neighbor::kStateRestored);
         child->SetLastHeard(TimerMilli::GetNow());
-        child->SetVersion(static_cast<uint8_t>(childInfo.GetVersion()));
+        child->SetVersion(childInfo.GetVersion());
         Get<IndirectSender>().SetChildUseShortAddress(*child, true);
         Get<NeighborTable>().Signal(NeighborTable::kChildAdded, *child);
         numChildren++;

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -40,6 +40,7 @@
 #include "thread/mesh_forwarder.hpp"
 #include "thread/mle.hpp"
 #include "thread/mle_router.hpp"
+#include "thread/version.hpp"
 
 namespace ot {
 namespace Mle {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -57,6 +57,7 @@
 #include "thread/mle_router.hpp"
 #include "thread/thread_netif.hpp"
 #include "thread/time_sync_service.hpp"
+#include "thread/version.hpp"
 
 using ot::Encoding::BigEndian::HostSwap16;
 
@@ -394,7 +395,7 @@ void Mle::Restore(void)
 
         mParent.Clear();
         mParent.SetExtAddress(parentInfo.GetExtAddress());
-        mParent.SetVersion(static_cast<uint8_t>(parentInfo.GetVersion()));
+        mParent.SetVersion(parentInfo.GetVersion());
         mParent.SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                          DeviceMode::kModeFullNetworkData));
         mParent.SetRloc16(Rloc16FromRouterId(RouterIdFromRloc16(networkInfo.GetRloc16())));
@@ -2991,7 +2992,7 @@ bool Mle::IsBetterParent(uint16_t               aRloc16,
                          LinkQuality            aLinkQuality,
                          uint8_t                aLinkMargin,
                          const ConnectivityTlv &aConnectivityTlv,
-                         uint8_t                aVersion,
+                         uint16_t               aVersion,
                          uint8_t                aCslClockAccuracy,
                          uint8_t                aCslUncertainty)
 {
@@ -3226,11 +3227,11 @@ void Mle::HandleParentResponse(RxInfo &aRxInfo)
         // only consider better parents if the partitions are the same
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
         VerifyOrExit(compare != 0 ||
-                     IsBetterParent(sourceAddress, linkQuality, linkMargin, connectivity, static_cast<uint8_t>(version),
+                     IsBetterParent(sourceAddress, linkQuality, linkMargin, connectivity, version,
                                     clockAccuracy.GetCslClockAccuracy(), clockAccuracy.GetCslUncertainty()));
 #else
-        VerifyOrExit(compare != 0 || IsBetterParent(sourceAddress, linkQuality, linkMargin, connectivity,
-                                                    static_cast<uint8_t>(version), 0, 0));
+        VerifyOrExit(compare != 0 ||
+                     IsBetterParent(sourceAddress, linkQuality, linkMargin, connectivity, version, 0, 0));
 #endif
     }
 
@@ -3266,7 +3267,7 @@ void Mle::HandleParentResponse(RxInfo &aRxInfo)
     mParentCandidate.GetLinkFrameCounters().SetAll(linkFrameCounter);
     mParentCandidate.SetLinkAckFrameCounter(linkFrameCounter);
     mParentCandidate.SetMleFrameCounter(mleFrameCounter);
-    mParentCandidate.SetVersion(static_cast<uint8_t>(version));
+    mParentCandidate.SetVersion(version);
     mParentCandidate.SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                               DeviceMode::kModeFullNetworkData));
     mParentCandidate.GetLinkInfo().Clear();

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1984,7 +1984,7 @@ private:
                         LinkQuality            aLinkQuality,
                         uint8_t                aLinkMargin,
                         const ConnectivityTlv &aConnectivityTlv,
-                        uint8_t                aVersion,
+                        uint16_t               aVersion,
                         uint8_t                aCslClockAccuracy,
                         uint8_t                aCslUncertainty);
     bool IsNetworkDataNewer(const LeaderData &aLeaderData);

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -51,6 +51,7 @@
 #include "thread/thread_tlvs.hpp"
 #include "thread/time_sync_service.hpp"
 #include "thread/uri_paths.hpp"
+#include "thread/version.hpp"
 #include "utils/otns.hpp"
 
 namespace ot {
@@ -1015,7 +1016,7 @@ Error MleRouter::HandleLinkAccept(RxInfo &aRxInfo, bool aRequest)
     router->SetLinkAckFrameCounter(linkFrameCounter);
     router->SetMleFrameCounter(mleFrameCounter);
     router->SetLastHeard(TimerMilli::GetNow());
-    router->SetVersion(static_cast<uint8_t>(version));
+    router->SetVersion(version);
     router->SetDeviceMode(DeviceMode(DeviceMode::kModeFullThreadDevice | DeviceMode::kModeRxOnWhenIdle |
                                      DeviceMode::kModeFullNetworkData));
     router->GetLinkInfo().Clear();
@@ -1757,7 +1758,7 @@ void MleRouter::HandleParentRequest(RxInfo &aRxInfo)
         {
             mode.Set(modeBitmask);
             child->SetDeviceMode(mode);
-            child->SetVersion(static_cast<uint8_t>(version));
+            child->SetVersion(version);
         }
     }
     else if (TimerMilli::GetNow() - child->GetLastHeard() < kParentRequestRouterTimeout - kParentRequestDuplicateMargin)
@@ -2464,7 +2465,7 @@ void MleRouter::HandleChildIdRequest(RxInfo &aRxInfo)
     child->SetMleFrameCounter(mleFrameCounter);
     child->SetKeySequence(aRxInfo.mKeySequence);
     child->SetDeviceMode(mode);
-    child->SetVersion(static_cast<uint8_t>(version));
+    child->SetVersion(version);
     child->GetLinkInfo().AddRss(aRxInfo.mMessageInfo.GetThreadLinkInfo()->GetRss());
     child->SetTimeout(timeout);
 #if OPENTHREAD_CONFIG_MULTI_RADIO

--- a/src/core/thread/mle_types.hpp
+++ b/src/core/thread/mle_types.hpp
@@ -77,8 +77,7 @@ constexpr uint8_t kMaxServiceAlocs = OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_MAX_A
 constexpr uint8_t  kMaxServiceAlocs      = OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_MAX_ALOCS;
 #endif
 
-constexpr uint8_t  kThreadVersion = OPENTHREAD_CONFIG_THREAD_VERSION; ///< Thread Version
-constexpr uint16_t kUdpPort       = 19788;                            ///< MLE UDP Port
+constexpr uint16_t kUdpPort = 19788; ///< MLE UDP Port
 
 /*
  * MLE Protocol delays and timeouts.

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -38,6 +38,7 @@
 #include "common/debug.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
+#include "common/min_max.hpp"
 
 namespace ot {
 
@@ -252,7 +253,7 @@ void Child::Info::SetFrom(const Child &aChild)
     mFrameErrorRate     = aChild.GetLinkInfo().GetFrameErrorRate();
     mMessageErrorRate   = aChild.GetLinkInfo().GetMessageErrorRate();
     mQueuedMessageCnt   = aChild.GetIndirectMessageCount();
-    mVersion            = aChild.GetVersion();
+    mVersion            = ClampToUint8(aChild.GetVersion());
     mRxOnWhenIdle       = aChild.IsRxOnWhenIdle();
     mFullThreadDevice   = aChild.IsFullThreadDevice();
     mFullNetworkData    = (aChild.GetNetworkDataType() == NetworkData::kFullSet);
@@ -524,7 +525,7 @@ void Router::Info::SetFrom(const Router &aRouter)
     mLinkQualityIn   = aRouter.GetLinkInfo().GetLinkQuality();
     mLinkQualityOut  = aRouter.GetLinkQualityOut();
     mAge             = static_cast<uint8_t>(Time::MsecToSec(TimerMilli::GetNow() - aRouter.GetLastHeard()));
-    mVersion         = aRouter.GetVersion();
+    mVersion         = ClampToUint8(aRouter.GetVersion());
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     mCslClockAccuracy = aRouter.GetCslClockAccuracy();
     mCslUncertainty   = aRouter.GetCslUncertainty();

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -59,6 +59,7 @@
 #include "thread/mle_types.hpp"
 #include "thread/network_data_types.hpp"
 #include "thread/radio_selector.hpp"
+#include "thread/version.hpp"
 
 namespace ot {
 
@@ -557,7 +558,7 @@ public:
      * @returns TRUE if neighbors is Thread 1.1, FALSE otherwise.
      *
      */
-    bool IsThreadVersion1p1(void) const { return mState != kStateInvalid && mVersion == OT_THREAD_VERSION_1_1; }
+    bool IsThreadVersion1p1(void) const { return mState != kStateInvalid && mVersion == kThreadVersion1p1; }
 
     /**
      * This method indicates whether or not neighbor is Thread 1.2 or higher..
@@ -565,7 +566,7 @@ public:
      * @returns TRUE if neighbor is Thread 1.2 or higher, FALSE otherwise.
      *
      */
-    bool IsThreadVersion1p2OrHigher(void) const { return mState != kStateInvalid && mVersion >= OT_THREAD_VERSION_1_2; }
+    bool IsThreadVersion1p2OrHigher(void) const { return mState != kStateInvalid && mVersion >= kThreadVersion1p2; }
 
     /**
      * This method indicates whether Thread version supports CSL.
@@ -590,7 +591,7 @@ public:
      * This method gets the device MLE version.
      *
      */
-    uint8_t GetVersion(void) const { return mVersion; }
+    uint16_t GetVersion(void) const { return mVersion; }
 
     /**
      * This method sets the device MLE version.
@@ -598,7 +599,7 @@ public:
      * @param[in]  aVersion  The device MLE version.
      *
      */
-    void SetVersion(uint8_t aVersion) { mVersion = aVersion; }
+    void SetVersion(uint16_t aVersion) { mVersion = aVersion; }
 
     /**
      * This method gets the number of consecutive link failures.
@@ -816,7 +817,7 @@ private:
 #else
     uint8_t mLinkFailures; ///< Consecutive link failure count
 #endif
-    uint8_t         mVersion;  ///< The MLE version
+    uint16_t        mVersion;  ///< The MLE version
     LinkQualityInfo mLinkInfo; ///< Link quality info (contains average RSS, link margin and link quality)
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
     // A list of Link Metrics Forward Tracking Series that is being

--- a/src/core/thread/version.hpp
+++ b/src/core/thread/version.hpp
@@ -1,0 +1,51 @@
+/*
+ *  Copyright (c) 2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes definitions for Thread Version.
+ */
+
+#ifndef VERSION_HPP_
+#define VERSION_HPP_
+
+#include "openthread-core-config.h"
+
+#include <stdint.h>
+
+namespace ot {
+
+constexpr uint16_t kThreadVersion = OPENTHREAD_CONFIG_THREAD_VERSION; ///< Thread Version of this device.
+
+constexpr uint16_t kThreadVersion1p1 = OT_THREAD_VERSION_1_1; ///< Thread Version 1.1
+constexpr uint16_t kThreadVersion1p2 = OT_THREAD_VERSION_1_2; ///< Thread Version 1.2
+constexpr uint16_t kThreadVersion1p3 = OT_THREAD_VERSION_1_3; ///< Thread Version 1.3
+
+} // namespace ot
+
+#endif // VERSION_HPP_


### PR DESCRIPTION
This commit adds `thread/version.hpp` which defile Thread Version
constants. It also changes the `mVersion` in `Neighbor` class to
use `uint16_t` to track the version. This help harmonize it with
the MLE Version TLV and and version in `Settings`. Due to memory
alignment of existing member variables the change (from `u8` to
`u16`) does not increase the memory requirement for child or router
table.