### PR TITLE
[script] update make-pretty to use clang-tidy-11 and clang-format-11

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
     - name: Bootstrap
       run: |
         sudo rm /etc/apt/sources.list.d/* && sudo apt-get update
-        sudo apt-get --no-install-recommends install -y clang-format-9 clang-tidy-9 shellcheck
+        sudo apt-get --no-install-recommends install -y clang-format-11 clang-tidy-11 shellcheck
         python3 -m pip install yapf==0.31.0
         sudo snap install shfmt
     - name: Check

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,7 +109,7 @@ This will open up a text editor where you can specify which commits to squash.
 
 #### Coding Conventions and Style
 
-OpenThread uses and enforces the [OpenThread Coding Conventions and Style](STYLE_GUIDE.md) on all code, except for code located in [third_party](third_party). Use `script/make-pretty` and `script/make-pretty check` to automatically reformat code and check for code-style compliance, respectively. OpenThread currently requires [clang-format v9.0.0](https://releases.llvm.org/download.html#9.0.0) for C/C++ and [yapf v0.31.0](https://github.com/google/yapf) for Python.
+OpenThread uses and enforces the [OpenThread Coding Conventions and Style](STYLE_GUIDE.md) on all code, except for code located in [third_party](third_party). Use `script/make-pretty` and `script/make-pretty check` to automatically reformat code and check for code-style compliance, respectively. OpenThread currently requires [clang-format v11.x.x](https://releases.llvm.org/download.html#11.1.0) for C/C++ and [yapf v0.31.0](https://github.com/google/yapf) for Python.
 
 As part of the cleanup process, you should also run `script/make-pretty check` to ensure that your code passes the baseline code style checks.
 

--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -116,7 +116,7 @@
 
 - OpenThread uses `script/make-pretty` to reformat code and enforce code format and style. `script/make-pretty check` build target is included in OpenThread's continuous integration and must pass before a pull request is merged.
 
-- `script/make-pretty` requires [clang-format v9.0.0](https://releases.llvm.org/download.html#9.0.0) for C/C++ and [yapf v0.31.0](https://github.com/google/yapf) for Python.
+- `script/make-pretty` requires [clang-format v11.x.x](https://releases.llvm.org/download.html#11.1.0) for C/C++ and [yapf v0.31.0](https://github.com/google/yapf) for Python.
 
 ### File Names
 

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -38,7 +38,7 @@ install_packages_pretty_format()
     echo 'Installing pretty tools useful for code contributions...'
 
     # add clang-format and clang-tidy for pretty
-    sudo apt-get --no-install-recommends install -y clang-format-9 clang-tidy-9 || echo 'WARNING: could not install clang-format-9 and clang-tidy-9, which is useful if you plan to contribute C/C++ code to the OpenThread project.'
+    sudo apt-get --no-install-recommends install -y clang-format-11 clang-tidy-11 || echo 'WARNING: could not install clang-format-11 and clang-tidy-11, which is useful if you plan to contribute C/C++ code to the OpenThread project.'
 
     # add yapf for pretty
     python3 -m pip install yapf==0.31.0 || echo 'WARNING: could not install yapf, which is useful if you plan to contribute python code to the OpenThread project.'
@@ -111,10 +111,10 @@ install_packages_brew()
     echo 'Installing pretty tools useful for code contributions...'
 
     # add clang-format for pretty
-    CLANG_FORMAT_VERSION="clang-format version 9"
-    command -v clang-format-9 || (command -v clang-format && (clang-format --version | grep -q "${CLANG_FORMAT_VERSION}")) || {
+    CLANG_FORMAT_VERSION="clang-format version 11"
+    command -v clang-format-11 || (command -v clang-format && (clang-format --version | grep -q "${CLANG_FORMAT_VERSION}")) || {
         brew install llvm@9
-        sudo ln -s "$(brew --prefix llvm@9)/bin/clang-format" /usr/local/bin/clang-format-9
+        sudo ln -s "$(brew --prefix llvm@9)/bin/clang-format" /usr/local/bin/clang-format-11
     } || echo 'WARNING: could not install llvm@9, which is useful if you plan to contribute C/C++ code to the OpenThread project.'
 
     # add yapf for pretty

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -56,7 +56,7 @@ install_packages_apt()
 
     # apt-get update and install dependencies
     sudo apt-get update
-    sudo apt-get --no-install-recommends install -y automake g++ libtool lsb-release make cmake ninja-build shellcheck
+    sudo apt-get --no-install-recommends install -y automake g++ libtool lsb-release make cmake ninja-build shellcheck bzip2
 
     echo 'Installing GNU Arm Embedded Toolchain...'
 

--- a/script/clang-format
+++ b/script/clang-format
@@ -26,8 +26,8 @@
 #  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 #  POSSIBILITY OF SUCH DAMAGE.
 #
-
-CLANG_FORMAT_VERSION="clang-format version 9.0"
+CLANG_FORMAT_VERSION_NUMBER=11
+CLANG_FORMAT_VERSION="clang-format version ${CLANG_FORMAT_VERSION_NUMBER}"
 
 die()
 {
@@ -39,18 +39,18 @@ die()
 # expand_aliases shell option is set using shopt.
 shopt -s expand_aliases
 
-if command -v clang-format-9 >/dev/null; then
-    alias clang-format=clang-format-9
+if command -v clang-format-${CLANG_FORMAT_VERSION_NUMBER} >/dev/null; then
+    alias clang-format=clang-format-${CLANG_FORMAT_VERSION_NUMBER}
 elif command -v clang-format >/dev/null; then
     case "$(clang-format --version)" in
         "$CLANG_FORMAT_VERSION"*) ;;
 
         *)
-            die "$(clang-format --version); clang-format 9.0 required"
+            die "$(clang-format --version); clang-format ${CLANG_FORMAT_VERSION_NUMBER} required"
             ;;
     esac
 else
-    die "clang-format 9.0 required"
+    die "clang-format ${CLANG_FORMAT_VERSION_NUMBER} required"
 fi
 
 clang-format "$@" || die

--- a/script/clang-tidy
+++ b/script/clang-tidy
@@ -27,8 +27,9 @@
 #  POSSIBILITY OF SUCH DAMAGE.
 #
 
-CLANG_TIDY_VERSION="LLVM version 9.0"
-CLANG_APPLY_REPLACEMENTS_VERSION="clang-apply-replacements version 9.0"
+CLANG_TIDY_VERSION_NUMBER=11
+CLANG_TIDY_VERSION="LLVM version ${CLANG_TIDY_VERSION_NUMBER}"
+CLANG_APPLY_REPLACEMENTS_VERSION="clang-apply-replacements version ${CLANG_TIDY_VERSION_NUMBER}"
 
 die()
 {
@@ -36,9 +37,9 @@ die()
     exit 1
 }
 
-# Search for clang-tidy-9
-if command -v clang-tidy-9 >/dev/null; then
-    clang_tidy=$(command -v clang-tidy-9)
+# Search for clang-tidy
+if command -v clang-tidy-${CLANG_TIDY_VERSION_NUMBER} >/dev/null; then
+    clang_tidy=$(command -v clang-tidy-${CLANG_TIDY_VERSION_NUMBER})
 elif command -v clang-tidy >/dev/null; then
     clang_tidy=$(command -v clang-tidy)
     case "$($clang_tidy --version)" in
@@ -49,12 +50,12 @@ elif command -v clang-tidy >/dev/null; then
             ;;
     esac
 else
-    die "clang-tidy 9.0 required"
+    die "clang-tidy ${CLANG_TIDY_VERSION_NUMBER} required"
 fi
 
-# Search for clang-apply-replacements-9
-if command -v clang-apply-replacements-9 >/dev/null; then
-    clang_apply_replacements=$(command -v clang-apply-replacements-9)
+# Search for clang-apply-replacements
+if command -v clang-apply-replacements-${CLANG_TIDY_VERSION_NUMBER} >/dev/null; then
+    clang_apply_replacements=$(command -v clang-apply-replacements-${CLANG_TIDY_VERSION_NUMBER})
 elif command -v clang-apply-replacements >/dev/null; then
     clang_apply_replacements=$(command -v clang-apply-replacements)
     case "$($clang_apply_replacements --version)" in
@@ -65,20 +66,20 @@ elif command -v clang-apply-replacements >/dev/null; then
             ;;
     esac
 else
-    die "clang-apply-replacements 9.0 required"
+    die "clang-apply-replacements ${CLANG_TIDY_VERSION_NUMBER} required"
 fi
 
-# Search for run-clang-tidy-9.py
-if command -v run-clang-tidy-9.py >/dev/null; then
-    run_clang_tidy=$(command -v run-clang-tidy-9.py)
-elif command -v run-clang-tidy-9 >/dev/null; then
-    run_clang_tidy=$(command -v run-clang-tidy-9)
+# Search for run-clang-tidy-${CLANG_TIDY_VERSION_NUMBER}.py
+if command -v run-clang-tidy-${CLANG_TIDY_VERSION_NUMBER}.py >/dev/null; then
+    run_clang_tidy=$(command -v run-clang-tidy-${CLANG_TIDY_VERSION_NUMBER}.py)
+elif command -v run-clang-tidy-${CLANG_TIDY_VERSION_NUMBER} >/dev/null; then
+    run_clang_tidy=$(command -v run-clang-tidy-${CLANG_TIDY_VERSION_NUMBER})
 elif command -v run-clang-tidy.py >/dev/null; then
     run_clang_tidy=$(command -v run-clang-tidy.py)
 elif command -v run-clang-tidy >/dev/null; then
     run_clang_tidy=$(command -v run-clang-tidy)
 else
-    die "run-clang-tidy.py 9.0 required"
+    die "run-clang-tidy.py ${CLANG_TIDY_VERSION_NUMBER} required"
 fi
 
 $run_clang_tidy -clang-tidy-binary "$clang_tidy" -clang-apply-replacements-binary "$clang_apply_replacements" "$@" || die


### PR DESCRIPTION
This updates `clang-tidy` and `clang-format` to version 11.

[`llvm@9`](https://formulae.brew.sh/formula/llvm@9) is not available to Apple M1 Macs using `brew` 
[`llvm@11`](https://formulae.brew.sh/formula/llvm@11) is available across all platforms in `brew`.
Both `clang-tidy-11` and `clang-format-11` are also available via apt-get for Ubuntu 