### PR TITLE
[mle] add `Parent` class (tracking CSL accuracy info)

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -415,7 +415,7 @@ public:
      * @returns A reference to the parent.
      *
      */
-    Router &GetParent(void) { return mParent; }
+    Parent &GetParent(void) { return mParent; }
 
     /**
      * The method retrieves information about the parent.
@@ -434,7 +434,7 @@ public:
      * The parent candidate is valid when attempting to attach to a new parent.
      *
      */
-    Router &GetParentCandidate(void) { return mParentCandidate; }
+    Parent &GetParentCandidate(void) { return mParentCandidate; }
 
     /**
      * This method starts the process for child to search for a better parent while staying attached to its current
@@ -1784,8 +1784,8 @@ protected:
     LeaderData    mLeaderData;               ///< Last received Leader Data TLV.
     bool          mRetrieveNewNetworkData;   ///< Indicating new Network Data is needed if set.
     DeviceRole    mRole;                     ///< Current Thread role.
-    Router        mParent;                   ///< Parent information.
-    Router        mParentCandidate;          ///< Parent candidate information.
+    Parent        mParent;                   ///< Parent information.
+    Parent        mParentCandidate;          ///< Parent candidate information.
     NeighborTable mNeighborTable;            ///< The neighbor table.
     DeviceMode    mDeviceMode;               ///< Device mode setting.
     AttachState   mAttachState;              ///< The attach state.

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -3864,7 +3864,8 @@ void MleRouter::HandleAddressSolicitResponse(Coap::Message *         aMessage,
     VerifyOrExit(router != nullptr);
 
     // Keep link to the parent in order to respond to Parent Requests before new link is established.
-    *router = mParent;
+    router->SetFrom(mParent);
+
     router->SetState(Neighbor::kStateValid);
     router->SetNextHop(kInvalidRouterId);
     router->SetCost(0);

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -526,9 +526,14 @@ void Router::Info::SetFrom(const Router &aRouter)
     mLinkQualityOut  = aRouter.GetLinkQualityOut();
     mAge             = static_cast<uint8_t>(Time::MsecToSec(TimerMilli::GetNow() - aRouter.GetLastHeard()));
     mVersion         = ClampToUint8(aRouter.GetVersion());
+}
+
+void Router::Info::SetFrom(const Parent &aParent)
+{
+    SetFrom(static_cast<const Router &>(aParent));
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-    mCslClockAccuracy = aRouter.GetCslAccuracy().GetClockAccuracy();
-    mCslUncertainty   = aRouter.GetCslAccuracy().GetUncertainty();
+    mCslClockAccuracy = aParent.GetCslAccuracy().GetClockAccuracy();
+    mCslUncertainty   = aParent.GetCslAccuracy().GetUncertainty();
 #endif
 }
 
@@ -537,6 +542,25 @@ void Router::Clear(void)
     Instance &instance = GetInstance();
 
     memset(reinterpret_cast<void *>(this), 0, sizeof(Router));
+    Init(instance);
+}
+
+void Router::SetFrom(const Parent &aParent)
+{
+    // We use an intermediate pointer to copy `aParent` to silence
+    // code checkers warning about object slicing (assigning a
+    // sub-class to base class instance).
+
+    const Router *parentAsRouter = &aParent;
+
+    *this = *parentAsRouter;
+}
+
+void Parent::Clear(void)
+{
+    Instance &instance = GetInstance();
+
+    memset(reinterpret_cast<void *>(this), 0, sizeof(Parent));
     Init(instance);
 }
 

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -1332,6 +1332,8 @@ private:
 
 #endif // OPENTHREAD_FTD
 
+class Parent;
+
 /**
  * This class represents a Thread Router
  *
@@ -1353,6 +1355,14 @@ public:
          *
          */
         void SetFrom(const Router &aRouter);
+
+        /**
+         * This method sets the `Info` instance from a given `Parent`.
+         *
+         * @param[in] aParent   A parent.
+         *
+         */
+        void SetFrom(const Parent &aParent);
     };
 
     /**
@@ -1361,19 +1371,19 @@ public:
      * @param[in] aInstance  A reference to OpenThread instance.
      *
      */
-    void Init(Instance &aInstance)
-    {
-        Neighbor::Init(aInstance);
-#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-        mCslAccuracy.Init();
-#endif
-    }
+    void Init(Instance &aInstance) { Neighbor::Init(aInstance); }
 
     /**
      * This method clears the router entry.
      *
      */
     void Clear(void);
+
+    /**
+     * This method sets the `Router` entry from a `Parent`
+     *
+     */
+    void SetFrom(const Parent &aParent);
 
     /**
      * This method gets the router ID of the next hop to this router.
@@ -1423,6 +1433,44 @@ public:
      */
     void SetCost(uint8_t aCost) { mCost = aCost; }
 
+private:
+    uint8_t mNextHop;            ///< The next hop towards this router
+    uint8_t mLinkQualityOut : 2; ///< The link quality out for this router
+
+#if OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
+    uint8_t mCost; ///< The cost to this router via neighbor router
+#else
+    uint8_t mCost : 4;     ///< The cost to this router via neighbor router
+#endif
+};
+
+/**
+ * This class represent parent of a child node.
+ *
+ */
+class Parent : public Router
+{
+public:
+    /**
+     * This method initializes the `Parent`.
+     *
+     * @param[in] aInstance  A reference to OpenThread instance.
+     *
+     */
+    void Init(Instance &aInstance)
+    {
+        Neighbor::Init(aInstance);
+#if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
+        mCslAccuracy.Init();
+#endif
+    }
+
+    /**
+     * This method clears the parent entry.
+     *
+     */
+    void Clear(void);
+
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     /**
      * This method gets the CSL accuracy (clock accuracy and uncertainty).
@@ -1442,14 +1490,6 @@ public:
 #endif
 
 private:
-    uint8_t mNextHop;            ///< The next hop towards this router
-    uint8_t mLinkQualityOut : 2; ///< The link quality out for this router
-
-#if OPENTHREAD_CONFIG_MLE_LONG_ROUTES_ENABLE
-    uint8_t mCost; ///< The cost to this router via neighbor router
-#else
-    uint8_t mCost : 4;     ///< The cost to this router via neighbor router
-#endif
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     Mac::CslAccuracy mCslAccuracy; // CSL accuracy (clock accuracy in ppm and uncertainty).
 #endif


### PR DESCRIPTION
This commit adds `Parent` class as a sub-class of `Router` and moves
the CSL accuracy definitions in `Parent` class (from `Router`) since
we need to track CSL info only for the parent and not other entries
in the router table. This helps reduce the memory/RAM used by router
table.