### PR TITLE
[routing-manager] fix call to `StartRoutingPolicyEvaluationJitter()`

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -258,7 +258,7 @@ void RoutingManager::UpdateInfraIfNat64Prefix(const Ip6::Prefix &aPrefix)
 
     if (mIsRunning)
     {
-        StartRoutingPolicyEvaluationJitter(kRoutingPolicyEvaluationJitter);
+        StartRoutingPolicyEvaluationJitter(kRoutingPolicyEvaluationJitterMin, kRoutingPolicyEvaluationJitterMax);
     }
 }
 


### PR DESCRIPTION
Fixes issue introduced with merging #7982 
```
../../third_party/openthread/repo/src/core/border_router/routing_manager.cpp:261:44: error: 'kRoutingPolicyEvaluationJitter' was not declared in this scope
         StartRoutingPolicyEvaluationJitter(kRoutingPolicyEvaluationJitter);
                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
compilation terminated due to -Wfatal-errors.
```