### PR TITLE
[ip6] smaller enhancements

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1154,8 +1154,6 @@ start:
     // determine destination of packet
     if (header.GetDestination().IsMulticast())
     {
-        Netif *netif;
-
         if (aNetif != nullptr)
         {
 #if OPENTHREAD_FTD
@@ -1165,23 +1163,20 @@ start:
                 forwardThread = true;
             }
 #endif
-
-            netif = aNetif;
         }
         else
         {
             forwardThread = true;
-
-            netif = &Get<ThreadNetif>();
         }
 
         forwardHost = header.GetDestination().IsMulticastLargerThanRealmLocal();
 
-        if ((aNetif != nullptr || aMessage.GetMulticastLoop()) && netif->IsMulticastSubscribed(header.GetDestination()))
+        if ((aNetif != nullptr || aMessage.GetMulticastLoop()) &&
+            Get<ThreadNetif>().IsMulticastSubscribed(header.GetDestination()))
         {
             receive = true;
         }
-        else if (netif->IsMulticastPromiscuousEnabled())
+        else if (Get<ThreadNetif>().IsMulticastPromiscuousEnabled())
         {
             forwardHost = true;
         }

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -890,11 +890,11 @@ Error Ip6::HandleExtensionHeaders(Message &    aMessage,
                                   MessageInfo &aMessageInfo,
                                   Header &     aHeader,
                                   uint8_t &    aNextHeader,
-                                  bool         aIsOutbound,
                                   bool         aFromHost,
                                   bool &       aReceive)
 {
-    Error           error = kErrorNone;
+    Error           error      = kErrorNone;
+    bool            isOutbound = (aNetif == nullptr);
     ExtensionHeader extHeader;
 
     while (aReceive || aNextHeader == kProtoHopOpts)
@@ -904,7 +904,7 @@ Error Ip6::HandleExtensionHeaders(Message &    aMessage,
         switch (aNextHeader)
         {
         case kProtoHopOpts:
-            SuccessOrExit(error = HandleOptions(aMessage, aHeader, aIsOutbound, aReceive));
+            SuccessOrExit(error = HandleOptions(aMessage, aHeader, isOutbound, aReceive));
             break;
 
         case kProtoFragment:
@@ -916,7 +916,7 @@ Error Ip6::HandleExtensionHeaders(Message &    aMessage,
             break;
 
         case kProtoDstOpts:
-            SuccessOrExit(error = HandleOptions(aMessage, aHeader, aIsOutbound, aReceive));
+            SuccessOrExit(error = HandleOptions(aMessage, aHeader, isOutbound, aReceive));
             break;
 
         case kProtoIp6:
@@ -1213,8 +1213,8 @@ start:
 
     // process IPv6 Extension Headers
     nextHeader = static_cast<uint8_t>(header.GetNextHeader());
-    SuccessOrExit(error = HandleExtensionHeaders(aMessage, aNetif, messageInfo, header, nextHeader, aNetif == nullptr,
-                                                 aFromHost, receive));
+    SuccessOrExit(error =
+                      HandleExtensionHeaders(aMessage, aNetif, messageInfo, header, nextHeader, aFromHost, receive));
 
     // process IPv6 Payload
     if (receive)

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -333,7 +333,6 @@ private:
                                  MessageInfo &aMessageInfo,
                                  Header &     aHeader,
                                  uint8_t &    aNextHeader,
-                                 bool         aIsOutbound,
                                  bool         aFromHost,
                                  bool &       aReceive);
     Error FragmentDatagram(Message &aMessage, uint8_t aIpProto);


### PR DESCRIPTION
This PR contains two smaller enhancements in `Ip6`:

**[ip6] remove extra param from `Ip6::HandleExtensionHeaders()`**
    
This commit updates `Ip6::HandleExtensionHeaders()` removing
`aIsOutbound` input and instead using `(aNetif == nullptr)` to
determine this.

**[ip6] simplify `Ip6::HandleDatagram()` - remove `netif` local var**
    
This commit updates `Ip6::HandleDatagram()` and removes the local
`netif` variable and directly uses `ThreadNetif` instead. Note that
the input parameter `aNetif` is either `nullptr` or points to
`ThreadNetif`, and in both cases the local variable `netif` will be
set to point to `ThreadNetif`.

----

Kept the commits separate to help with review of the change.


