### PR TITLE
[ip6] add `MessageOrigin` to indicate origin or IPv6 message

### DIFF
--- a/src/core/api/ip6_api.cpp
+++ b/src/core/api/ip6_api.cpp
@@ -133,7 +133,7 @@ void otIp6SetReceiveFilterEnabled(otInstance *aInstance, bool aEnabled)
 otError otIp6Send(otInstance *aInstance, otMessage *aMessage)
 {
     return AsCoreType(aInstance).Get<Ip6::Ip6>().SendRaw(AsCoreType(aMessage),
-                                                         !OPENTHREAD_CONFIG_IP6_ALLOW_LOOP_BACK_HOST_DATAGRAMS);
+                                                         OPENTHREAD_CONFIG_IP6_ALLOW_LOOP_BACK_HOST_DATAGRAMS);
 }
 
 otMessage *otIp6NewMessage(otInstance *aInstance, const otMessageSettings *aSettings)

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -309,7 +309,7 @@ Error Ip6::InsertMplOption(Message &aMessage, Header &aHeader, MessageInfo &aMes
 
             if ((messageCopy = aMessage.Clone()) != nullptr)
             {
-                IgnoreError(HandleDatagram(*messageCopy, nullptr, nullptr, /* aFromHost */ true));
+                IgnoreError(HandleDatagram(*messageCopy, kFromHostDisallowLoopBack));
                 LogInfo("Message copy for indirect transmission to sleepy children");
             }
             else
@@ -542,7 +542,7 @@ void Ip6::HandleSendQueue(void)
     while ((message = mSendQueue.GetHead()) != nullptr)
     {
         mSendQueue.Dequeue(*message);
-        IgnoreError(HandleDatagram(*message, nullptr, nullptr, /* aFromHost */ false));
+        IgnoreError(HandleDatagram(*message, kFromHostAllowLoopBack));
     }
 }
 
@@ -686,7 +686,7 @@ exit:
     return error;
 }
 
-Error Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMessageInfo, bool aFromHost)
+Error Ip6::HandleFragment(Message &aMessage, MessageOrigin aOrigin, MessageInfo &aMessageInfo)
 {
     Error          error = kErrorNone;
     Header         header, headerBuffer;
@@ -778,7 +778,7 @@ Error Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMessag
 
         mReassemblyList.Dequeue(*message);
 
-        IgnoreError(HandleDatagram(*message, aNetif, aMessageInfo.mLinkInfo, aFromHost));
+        IgnoreError(HandleDatagram(*message, aOrigin, aMessageInfo.mLinkInfo));
     }
 
 exit:
@@ -865,11 +865,10 @@ Error Ip6::FragmentDatagram(Message &aMessage, uint8_t aIpProto)
     return kErrorNone;
 }
 
-Error Ip6::HandleFragment(Message &aMessage, Netif *aNetif, MessageInfo &aMessageInfo, bool aFromHost)
+Error Ip6::HandleFragment(Message &aMessage, MessageOrigin aOrigin, MessageInfo &aMessageInfo)
 {
-    OT_UNUSED_VARIABLE(aNetif);
+    OT_UNUSED_VARIABLE(aOrigin);
     OT_UNUSED_VARIABLE(aMessageInfo);
-    OT_UNUSED_VARIABLE(aFromHost);
 
     Error          error = kErrorNone;
     FragmentHeader fragmentHeader;
@@ -885,16 +884,15 @@ exit:
 }
 #endif // OPENTHREAD_CONFIG_IP6_FRAGMENTATION_ENABLE
 
-Error Ip6::HandleExtensionHeaders(Message &    aMessage,
-                                  Netif *      aNetif,
-                                  MessageInfo &aMessageInfo,
-                                  Header &     aHeader,
-                                  uint8_t &    aNextHeader,
-                                  bool         aFromHost,
-                                  bool &       aReceive)
+Error Ip6::HandleExtensionHeaders(Message &     aMessage,
+                                  MessageOrigin aOrigin,
+                                  MessageInfo & aMessageInfo,
+                                  Header &      aHeader,
+                                  uint8_t &     aNextHeader,
+                                  bool &        aReceive)
 {
     Error           error      = kErrorNone;
-    bool            isOutbound = (aNetif == nullptr);
+    bool            isOutbound = (aOrigin != kFromThreadNetif);
     ExtensionHeader extHeader;
 
     while (aReceive || aNextHeader == kProtoHopOpts)
@@ -909,10 +907,10 @@ Error Ip6::HandleExtensionHeaders(Message &    aMessage,
 
         case kProtoFragment:
 #if !OPENTHREAD_CONFIG_IP6_FRAGMENTATION_ENABLE
-            IgnoreError(ProcessReceiveCallback(aMessage, aMessageInfo, aNextHeader, aFromHost,
+            IgnoreError(ProcessReceiveCallback(aMessage, aOrigin, aMessageInfo, aNextHeader,
                                                /* aAllowReceiveFilter */ false, Message::kCopyToUse));
 #endif
-            SuccessOrExit(error = HandleFragment(aMessage, aNetif, aMessageInfo, aFromHost));
+            SuccessOrExit(error = HandleFragment(aMessage, aOrigin, aMessageInfo));
             break;
 
         case kProtoDstOpts:
@@ -1007,16 +1005,17 @@ exit:
 }
 
 Error Ip6::ProcessReceiveCallback(Message &          aMessage,
+                                  MessageOrigin      aOrigin,
                                   const MessageInfo &aMessageInfo,
                                   uint8_t            aIpProto,
-                                  bool               aFromHost,
                                   bool               aAllowReceiveFilter,
                                   Message::Ownership aMessageOwnership)
 {
     Error    error   = kErrorNone;
     Message *message = &aMessage;
 
-    VerifyOrExit(!aFromHost, error = kErrorNoRoute);
+    VerifyOrExit(aOrigin != kFromHostDisallowLoopBack, error = kErrorNoRoute);
+
     VerifyOrExit(mReceiveIp6DatagramCallback != nullptr, error = kErrorNoRoute);
 
     // Do not forward reassembled IPv6 packets.
@@ -1093,7 +1092,7 @@ exit:
     return error;
 }
 
-Error Ip6::SendRaw(Message &aMessage, bool aFromHost)
+Error Ip6::SendRaw(Message &aMessage, bool aAllowLoopBackToHost)
 {
     Error       error = kErrorNone;
     Header      header;
@@ -1112,7 +1111,7 @@ Error Ip6::SendRaw(Message &aMessage, bool aFromHost)
         SuccessOrExit(error = InsertMplOption(aMessage, header, messageInfo));
     }
 
-    error = HandleDatagram(aMessage, nullptr, nullptr, aFromHost);
+    error = HandleDatagram(aMessage, aAllowLoopBackToHost ? kFromHostAllowLoopBack : kFromHostDisallowLoopBack);
     freed = true;
 
 exit:
@@ -1125,7 +1124,7 @@ exit:
     return error;
 }
 
-Error Ip6::HandleDatagram(Message &aMessage, Netif *aNetif, const void *aLinkMessageInfo, bool aFromHost)
+Error Ip6::HandleDatagram(Message &aMessage, MessageOrigin aOrigin, const void *aLinkMessageInfo)
 {
     Error       error;
     MessageInfo messageInfo;
@@ -1154,7 +1153,7 @@ start:
     // determine destination of packet
     if (header.GetDestination().IsMulticast())
     {
-        if (aNetif != nullptr)
+        if (aOrigin == kFromThreadNetif)
         {
 #if OPENTHREAD_FTD
             if (header.GetDestination().IsMulticastLargerThanRealmLocal() &&
@@ -1171,7 +1170,7 @@ start:
 
         forwardHost = header.GetDestination().IsMulticastLargerThanRealmLocal();
 
-        if ((aNetif != nullptr || aMessage.GetMulticastLoop()) &&
+        if (((aOrigin == kFromThreadNetif) || aMessage.GetMulticastLoop()) &&
             Get<ThreadNetif>().IsMulticastSubscribed(header.GetDestination()))
         {
             receive = true;
@@ -1192,12 +1191,12 @@ start:
         {
             forwardThread = true;
         }
-        else if (aNetif == nullptr)
+        else if (aOrigin != kFromThreadNetif)
         {
             forwardThread = true;
         }
 
-        if (forwardThread && !ShouldForwardToThread(messageInfo, aFromHost))
+        if (forwardThread && !ShouldForwardToThread(messageInfo, aOrigin))
         {
             forwardThread = false;
             forwardHost   = true;
@@ -1208,8 +1207,7 @@ start:
 
     // process IPv6 Extension Headers
     nextHeader = static_cast<uint8_t>(header.GetNextHeader());
-    SuccessOrExit(error =
-                      HandleExtensionHeaders(aMessage, aNetif, messageInfo, header, nextHeader, aFromHost, receive));
+    SuccessOrExit(error = HandleExtensionHeaders(aMessage, aOrigin, messageInfo, header, nextHeader, receive));
 
     // process IPv6 Payload
     if (receive)
@@ -1222,7 +1220,7 @@ start:
             goto start;
         }
 
-        error = ProcessReceiveCallback(aMessage, messageInfo, nextHeader, aFromHost,
+        error = ProcessReceiveCallback(aMessage, aOrigin, messageInfo, nextHeader,
                                        /* aAllowReceiveFilter */ !forwardHost, Message::kCopyToUse);
 
         if ((error == kErrorNone || error == kErrorNoRoute) && forwardHost)
@@ -1238,7 +1236,7 @@ start:
     if (forwardHost)
     {
         // try passing to host
-        error = ProcessReceiveCallback(aMessage, messageInfo, nextHeader, aFromHost, /* aAllowReceiveFilter */ false,
+        error = ProcessReceiveCallback(aMessage, aOrigin, messageInfo, nextHeader, /* aAllowReceiveFilter */ false,
                                        forwardThread ? Message::kCopyToUse : Message::kTakeCustody);
         shouldFreeMessage = forwardThread;
     }
@@ -1247,7 +1245,7 @@ start:
     {
         uint8_t hopLimit;
 
-        if (aNetif != nullptr)
+        if (aOrigin == kFromThreadNetif)
         {
             VerifyOrExit(mForwardingEnabled);
             header.SetHopLimit(header.GetHopLimit() - 1);
@@ -1276,7 +1274,7 @@ start:
         }
 
 #if !OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-        if (aFromHost && (nextHeader == kProtoUdp))
+        if ((aOrigin == kFromHostDisallowLoopBack) && (nextHeader == kProtoUdp))
         {
             uint16_t destPort;
 
@@ -1313,7 +1311,7 @@ exit:
     return error;
 }
 
-bool Ip6::ShouldForwardToThread(const MessageInfo &aMessageInfo, bool aFromHost) const
+bool Ip6::ShouldForwardToThread(const MessageInfo &aMessageInfo, MessageOrigin aOrigin) const
 {
     bool shouldForward = false;
 
@@ -1324,10 +1322,10 @@ bool Ip6::ShouldForwardToThread(const MessageInfo &aMessageInfo, bool aFromHost)
     else if (IsOnLink(aMessageInfo.GetSockAddr()))
     {
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
-        shouldForward =
-            (aFromHost || !Get<BackboneRouter::Manager>().ShouldForwardDuaToBackbone(aMessageInfo.GetSockAddr()));
+        shouldForward = ((aOrigin == kFromHostDisallowLoopBack) ||
+                         !Get<BackboneRouter::Manager>().ShouldForwardDuaToBackbone(aMessageInfo.GetSockAddr()));
 #else
-        OT_UNUSED_VARIABLE(aFromHost);
+        OT_UNUSED_VARIABLE(aOrigin);
         shouldForward = true;
 #endif
     }

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1708,8 +1708,6 @@ exit:
 
 Error MeshForwarder::HandleDatagram(Message &aMessage, const ThreadLinkInfo &aLinkInfo, const Mac::Address &aMacSource)
 {
-    ThreadNetif &netif = Get<ThreadNetif>();
-
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
     Get<Utils::HistoryTracker>().RecordRxMessage(aMessage, aMacSource);
 #endif
@@ -1721,7 +1719,7 @@ Error MeshForwarder::HandleDatagram(Message &aMessage, const ThreadLinkInfo &aLi
         mIpCounters.mRxSuccess++;
     }
 
-    return Get<Ip6::Ip6>().HandleDatagram(aMessage, &netif, &aLinkInfo, false);
+    return Get<Ip6::Ip6>().HandleDatagram(aMessage, Ip6::Ip6::kFromThreadNetif, &aLinkInfo);
 }
 
 Error MeshForwarder::GetFramePriority(const FrameData &     aFrameData,

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -185,7 +185,7 @@ void MeshForwarder::HandleResolved(const Ip6::Address &aEid, Error aError)
             hopLimit++;
             message.Write(Ip6::Header::kHopLimitFieldOffset, hopLimit);
 
-            IgnoreError(Get<Ip6::Ip6>().HandleDatagram(message, nullptr, nullptr, /* aFromHost */ false));
+            IgnoreError(Get<Ip6::Ip6>().HandleDatagram(message, Ip6::Ip6::kFromHostAllowLoopBack));
             continue;
         }
 #endif


### PR DESCRIPTION
This commit adds a new enum `Ip6::MessageOrigin` which indicates the
origin of the message: From Thread Netif or from host. In case the
message is originating from host, it also indicates whether or not it
is allowed to pass back the message to the host.

----

The new `MessageOrigin` replaces two inputs: `aNetif` and `aFromHost`:
```
 - kFromThreadNetif          --> aNetif = &ThreadNetif, aFromHost = false
 - kFromHostDisallowLoopBack --> aNetif = nullptr,      aFromHost = true
 - kFromHostAllowLoopBack    --> aNetif = nullptr,      aFromHost = false
```

The combination of `aNetif = &ThreadNetif` and `aFromHost = true` is not possible/used.

For example `if (aNetif != nullptr)` becomes `if (aOrigin == kFromThreadNetif)`

This PR currently contains commit from https://github.com/openthread/openthread/pull/8035. 
