### PR TITLE
[link-metrics] fix the endian-ness of `mPduCountValue`

### DIFF
--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -292,7 +292,7 @@ Error LinkMetrics::AppendReport(Message &aMessage, const Message &aRequestMessag
 
     if (queryId == kQueryIdSingleProbe)
     {
-        values.mPduCountValue = HostSwap32(aRequestMessage.GetPsduCount());
+        values.mPduCountValue = aRequestMessage.GetPsduCount();
         values.mLqiValue      = aRequestMessage.GetAverageLqi();
         // Linearly scale Link Margin from [0, 130] to [0, 255]
         values.mLinkMarginValue =
@@ -318,7 +318,7 @@ Error LinkMetrics::AppendReport(Message &aMessage, const Message &aRequestMessag
         else
         {
             values.SetMetrics(seriesInfo->GetLinkMetrics());
-            values.mPduCountValue = HostSwap32(seriesInfo->GetPduCount());
+            values.mPduCountValue = seriesInfo->GetPduCount();
             values.mLqiValue      = seriesInfo->GetAverageLqi();
             // Linearly scale Link Margin from [0, 130] to [0, 255]
             values.mLinkMarginValue =


### PR DESCRIPTION
This commit updates `LinkMetrics::AppendReport()` to ensure
the `values.mPduCountValue` (which is a `uint32_t`) is stored in
the host MCU encoding and not in big-endian encoding.

This was originally added in #7046 as a fix (basically saving the
value in local variable in the encoding we expect to later include
in the Report TLV), however #8006 updates the `ReportSubTlv` methods
to do the encoding change in the `Get/SetMetricsValue32()` (similar
to other OT `Tlv` definitions).

----

Adding a note on the change. There are 3 places in https://github.com/openthread/openthread/pull/7046 where `HostSwap32()` was added:
- The first two are now removed in new PR.
- The last one is when we read the value directly from message which is fine/correct.
```c++
            case TypeIdFlags::kPdu:
                values.GetMetrics().mPduCount = true;
                SuccessOrExit(aMessage.Read(pos, values.mPduCountValue));
                values.mPduCountValue = HostSwap32(values.mPduCountValue);
                pos += sizeof(uint32_t);

```
- I think there may be some room for optimization/simplification here for later.
  - It  would be good to read/write the TLV directly (instead of reading the values from message)