### PR TITLE
[link-metrics] simplify `AddReport()`

### DIFF
--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -290,8 +290,8 @@ private:
                                             uint16_t       aStartPos,
                                             uint16_t       aEndPos,
                                             Metrics &      aMetrics);
-    static Error AppendReportSubTlvToMessage(Message &aMessage, uint8_t &aLength, const MetricsValues &aValues);
-    static Error AppendStatusSubTlvToMessage(Message &aMessage, uint8_t &aLength, Status aStatus);
+    static Error AppendReportSubTlvToMessage(Message &aMessage, const MetricsValues &aValues);
+    static Error AppendStatusSubTlvToMessage(Message &aMessage, Status aStatus);
 
     ReportCallback                mReportCallback;
     void *                        mReportCallbackContext;


### PR DESCRIPTION
This commit simplifies the `LinkMetrics::AddReport()` method so that
when preparing the MLE Link Metrics Report TLV (and its sub-TLVs) we
determine the TLV length after all sub-TLVs are appended to the
message from the number of written bytes in the message (difference
between `aMessage.GetLength()` and initial offset of the TLV). This
allows to simplify methods `AppendReportSubTlvToMessage()` and
`AppendStatusSubTlvToMessage()` as well.