### PR TITLE
[topology] add `Router::GetTwoWayLinkQuality()` method

### DIFF
--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -449,7 +449,7 @@ void MeshForwarder::EvaluateRoutingCost(uint16_t aDest, uint8_t &aBestCost, uint
         {
             // Cost calculated only from Link Quality In as the parent only maintains
             // one-direction link info.
-            cost = Mle::MleRouter::LinkQualityToCost(neighbor->GetLinkInfo().GetLinkQuality());
+            cost = Mle::MleRouter::LinkQualityToCost(neighbor->GetLinkQualityIn());
         }
         else
         {

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -1347,7 +1347,6 @@ exit:
 bool Mle::HasAcceptableParentCandidate(void) const
 {
     bool              hasAcceptableParent = false;
-    LinkQuality       linkQuality;
     ParentRequestType parentReqType;
 
     VerifyOrExit(mParentCandidate.IsStateParentResponse());
@@ -1367,8 +1366,7 @@ bool Mle::HasAcceptableParentCandidate(void) const
             // in Parent Request was sent to routers, we will keep the
             // candidate and forward to REED stage to potentially find a
             // better parent.
-            linkQuality = Min(mParentCandidate.GetLinkInfo().GetLinkQuality(), mParentCandidate.GetLinkQualityOut());
-            VerifyOrExit(linkQuality == kLinkQuality3);
+            VerifyOrExit(mParentCandidate.GetTwoWayLinkQuality() == kLinkQuality3);
         }
 
         break;
@@ -2992,8 +2990,7 @@ bool Mle::IsBetterParent(uint16_t                aRloc16,
                          const Mac::CslAccuracy &aCslAccuracy)
 {
     bool        rval                       = false;
-    LinkQuality candidateLinkQualityIn     = mParentCandidate.GetLinkInfo().GetLinkQuality();
-    LinkQuality candidateTwoWayLinkQuality = Min(candidateLinkQualityIn, mParentCandidate.GetLinkQualityOut());
+    LinkQuality candidateTwoWayLinkQuality = mParentCandidate.GetTwoWayLinkQuality();
 
     // Mesh Impacting Criteria
     if (aLinkQuality != candidateTwoWayLinkQuality)

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1617,7 +1617,7 @@ void MleRouter::UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId)
     {
         LogInfo("    %04x -> %04x, cost:%d %d, lqin:%d, lqout:%d, link:%s", router.GetRloc16(),
                 (router.GetNextHop() == kInvalidRouterId) ? 0xffff : Rloc16FromRouterId(router.GetNextHop()),
-                router.GetCost(), mRouterTable.GetLinkCost(router), router.GetLinkInfo().GetLinkQuality(),
+                router.GetCost(), mRouterTable.GetLinkCost(router), router.GetLinkQualityIn(),
                 router.GetLinkQualityOut(),
                 router.GetRloc16() == GetRloc16() ? "device" : ToYesNo(router.IsStateValid()));
     }
@@ -4122,7 +4122,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
         break;
 
     case kRoleChild:
-        switch (mParent.GetLinkInfo().GetLinkQuality())
+        switch (mParent.GetLinkQualityIn())
         {
         case kLinkQuality0:
             break;
@@ -4140,7 +4140,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
             break;
         }
 
-        cost += LinkQualityToCost(mParent.GetLinkInfo().GetLinkQuality());
+        cost += LinkQualityToCost(mParent.GetLinkQualityIn());
         break;
 
     case kRoleRouter:
@@ -4165,8 +4165,6 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
 
     for (Router &router : Get<RouterTable>().Iterate())
     {
-        LinkQuality linkQuality;
-
         if (router.GetRloc16() == GetRloc16())
         {
             // skip self
@@ -4179,14 +4177,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
             continue;
         }
 
-        linkQuality = router.GetLinkInfo().GetLinkQuality();
-
-        if (linkQuality > router.GetLinkQualityOut())
-        {
-            linkQuality = router.GetLinkQualityOut();
-        }
-
-        switch (linkQuality)
+        switch (router.GetTwoWayLinkQuality())
         {
         case kLinkQuality0:
             break;
@@ -4303,7 +4294,7 @@ void MleRouter::FillRouteTlv(RouteTlv &aTlv, Neighbor *aNeighbor)
 
             aTlv.SetRouteCost(routerCount, routeCost);
             aTlv.SetLinkQualityOut(routerCount, router.GetLinkQualityOut());
-            aTlv.SetLinkQualityIn(routerCount, router.GetLinkInfo().GetLinkQuality());
+            aTlv.SetLinkQualityIn(routerCount, router.GetLinkQualityIn());
         }
 
         routerCount++;
@@ -4314,7 +4305,6 @@ void MleRouter::FillRouteTlv(RouteTlv &aTlv, Neighbor *aNeighbor)
 
 bool MleRouter::HasMinDowngradeNeighborRouters(void)
 {
-    uint8_t linkQuality;
     uint8_t routerCount = 0;
 
     for (Router &router : Get<RouterTable>().Iterate())
@@ -4324,14 +4314,7 @@ bool MleRouter::HasMinDowngradeNeighborRouters(void)
             continue;
         }
 
-        linkQuality = router.GetLinkInfo().GetLinkQuality();
-
-        if (linkQuality > router.GetLinkQualityOut())
-        {
-            linkQuality = router.GetLinkQualityOut();
-        }
-
-        if (linkQuality >= 2)
+        if (router.GetTwoWayLinkQuality() >= kLinkQuality2)
         {
             routerCount++;
         }
@@ -4348,8 +4331,8 @@ bool MleRouter::HasOneNeighborWithComparableConnectivity(const RouteTlv &aRoute,
     // process local neighbor routers
     for (Router &router : Get<RouterTable>().Iterate())
     {
-        uint8_t localLinkQuality;
-        uint8_t peerLinkQuality;
+        LinkQuality localLinkQuality;
+        LinkQuality peerLinkQuality;
 
         if (!router.IsStateValid() || router.GetRouterId() == mRouterId || router.GetRouterId() == aRouterId)
         {
@@ -4357,14 +4340,9 @@ bool MleRouter::HasOneNeighborWithComparableConnectivity(const RouteTlv &aRoute,
             continue;
         }
 
-        localLinkQuality = router.GetLinkInfo().GetLinkQuality();
+        localLinkQuality = router.GetTwoWayLinkQuality();
 
-        if (localLinkQuality > router.GetLinkQualityOut())
-        {
-            localLinkQuality = router.GetLinkQualityOut();
-        }
-
-        if (localLinkQuality < 2)
+        if (localLinkQuality < kLinkQuality2)
         {
             routerCount++;
             continue;
@@ -4377,12 +4355,7 @@ bool MleRouter::HasOneNeighborWithComparableConnectivity(const RouteTlv &aRoute,
         }
 
         // get the peer's two-way link quality to this router
-        peerLinkQuality = aRoute.GetLinkQualityIn(routerCount);
-
-        if (peerLinkQuality > aRoute.GetLinkQualityOut(routerCount))
-        {
-            peerLinkQuality = aRoute.GetLinkQualityOut(routerCount);
-        }
+        peerLinkQuality = Min(aRoute.GetLinkQualityIn(routerCount), aRoute.GetLinkQualityOut(routerCount));
 
         // compare local link quality to this router with peer's
         if (peerLinkQuality >= localLinkQuality)

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -313,7 +313,7 @@ exit:
 
 void RouterTable::RemoveRouterLink(Router &aRouter)
 {
-    if (aRouter.GetLinkQualityOut() != 0)
+    if (aRouter.GetLinkQualityOut() != kLinkQuality0)
     {
         aRouter.SetLinkQualityOut(kLinkQuality0);
         aRouter.SetLastHeard(TimerMilli::GetNow());
@@ -470,14 +470,7 @@ uint8_t RouterTable::GetLinkCost(Router &aRouter)
 
     VerifyOrExit(aRouter.GetRloc16() != Get<Mle::MleRouter>().GetRloc16() && aRouter.IsStateValid());
 
-    rval = aRouter.GetLinkInfo().GetLinkQuality();
-
-    if (rval > aRouter.GetLinkQualityOut())
-    {
-        rval = aRouter.GetLinkQualityOut();
-    }
-
-    rval = Mle::MleRouter::LinkQualityToCost(rval);
+    rval = Mle::MleRouter::LinkQualityToCost(aRouter.GetTwoWayLinkQuality());
 
 exit:
     return rval;

--- a/src/core/thread/topology.cpp
+++ b/src/core/thread/topology.cpp
@@ -73,7 +73,7 @@ void Neighbor::Info::SetFrom(const Neighbor &aNeighbor)
     mRloc16           = aNeighbor.GetRloc16();
     mLinkFrameCounter = aNeighbor.GetLinkFrameCounters().GetMaximum();
     mMleFrameCounter  = aNeighbor.GetMleFrameCounter();
-    mLinkQualityIn    = aNeighbor.GetLinkInfo().GetLinkQuality();
+    mLinkQualityIn    = aNeighbor.GetLinkQualityIn();
     mAverageRssi      = aNeighbor.GetLinkInfo().GetAverageRss();
     mLastRssi         = aNeighbor.GetLinkInfo().GetLastRss();
     mFrameErrorRate   = aNeighbor.GetLinkInfo().GetFrameErrorRate();
@@ -247,7 +247,7 @@ void Child::Info::SetFrom(const Child &aChild)
     mChildId            = Mle::Mle::ChildIdFromRloc16(aChild.GetRloc16());
     mNetworkDataVersion = aChild.GetNetworkDataVersion();
     mAge                = Time::MsecToSec(TimerMilli::GetNow() - aChild.GetLastHeard());
-    mLinkQualityIn      = aChild.GetLinkInfo().GetLinkQuality();
+    mLinkQualityIn      = aChild.GetLinkQualityIn();
     mAverageRssi        = aChild.GetLinkInfo().GetAverageRss();
     mLastRssi           = aChild.GetLinkInfo().GetLastRss();
     mFrameErrorRate     = aChild.GetLinkInfo().GetFrameErrorRate();
@@ -522,7 +522,7 @@ void Router::Info::SetFrom(const Router &aRouter)
     mNextHop         = aRouter.GetNextHop();
     mLinkEstablished = aRouter.IsStateValid();
     mPathCost        = aRouter.GetCost();
-    mLinkQualityIn   = aRouter.GetLinkInfo().GetLinkQuality();
+    mLinkQualityIn   = aRouter.GetLinkQualityIn();
     mLinkQualityOut  = aRouter.GetLinkQualityOut();
     mAge             = static_cast<uint8_t>(Time::MsecToSec(TimerMilli::GetNow() - aRouter.GetLastHeard()));
     mVersion         = ClampToUint8(aRouter.GetVersion());
@@ -543,6 +543,11 @@ void Router::Clear(void)
 
     memset(reinterpret_cast<void *>(this), 0, sizeof(Router));
     Init(instance);
+}
+
+LinkQuality Router::GetTwoWayLinkQuality(void) const
+{
+    return Min(GetLinkQualityIn(), GetLinkQualityOut());
 }
 
 void Router::SetFrom(const Parent &aParent)

--- a/src/core/thread/topology.hpp
+++ b/src/core/thread/topology.hpp
@@ -638,6 +638,14 @@ public:
     const LinkQualityInfo &GetLinkInfo(void) const { return mLinkInfo; }
 
     /**
+     * This method gets the link quality in value.
+     *
+     * @returns The link quality in value.
+     *
+     */
+    LinkQuality GetLinkQualityIn(void) const { return GetLinkInfo().GetLinkQuality(); }
+
+    /**
      * This method generates a new challenge value for MLE Link Request/Response exchanges.
      *
      */
@@ -1416,6 +1424,14 @@ public:
      *
      */
     void SetLinkQualityOut(LinkQuality aLinkQuality) { mLinkQualityOut = aLinkQuality; }
+
+    /**
+     * This method gets the two-way link quality value (minimum of link quality in and out).
+     *
+     * @returns The two-way link quality value.
+     *
+     */
+    LinkQuality GetTwoWayLinkQuality(void) const;
 
     /**
      * This method get the route cost to this router.


### PR DESCRIPTION
This commits add `GetTwoWayLinkQuality()` method to `Router` class
which returns the minimum of router's Link Quality In and Out
values. It also adds `GetLinkQualityIn()` to `Neighbor`. These
are used in `Mle` and `MeshForwarder`.