### PR TITLE
[link-metrics] define `StatusSubTlv` to simplify appending/parsing it

### DIFF
--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -291,7 +291,6 @@ private:
                                             uint16_t       aEndPos,
                                             Metrics &      aMetrics);
     static Error AppendReportSubTlvToMessage(Message &aMessage, const MetricsValues &aValues);
-    static Error AppendStatusSubTlvToMessage(Message &aMessage, Status aStatus);
 
     ReportCallback                mReportCallback;
     void *                        mReportCallbackContext;

--- a/src/core/thread/link_metrics_tlvs.hpp
+++ b/src/core/thread/link_metrics_tlvs.hpp
@@ -81,6 +81,12 @@ public:
 typedef UintTlvInfo<SubTlv::kQueryId, uint8_t> QueryIdSubTlv;
 
 /**
+ * This type defines a Link Metrics Status Sub-Tlv.
+ *
+ */
+typedef UintTlvInfo<SubTlv::kStatus, uint8_t> StatusSubTlv;
+
+/**
  * This class implements Link Metrics Report Sub-TLV generation and parsing.
  *
  */


### PR DESCRIPTION
Status sub-TLV has a single `uint8_t` status value so we can use
declare it as `UintTlvInfo<SubTlv::kStatus, uint8_t>` and then use
helper `Append<StatusSubTlv>` and `Read<StatusSubTlv>` to append
and read it.

---

~~This PR contains commit from https://github.com/openthread/openthread/pull/8042.~~