### PR TITLE
[link-metrics] simplify `HandleReport()`

### DIFF
--- a/src/core/thread/link_metrics_tlvs.hpp
+++ b/src/core/thread/link_metrics_tlvs.hpp
@@ -94,6 +94,8 @@ OT_TOOL_PACKED_BEGIN
 class ReportSubTlv : public Tlv, public TlvInfo<SubTlv::kReport>
 {
 public:
+    static constexpr uint8_t kMinLength = sizeof(TypeIdFlags) + sizeof(uint8_t); ///< Minimum expected TLV length.
+
     /**
      * This method initializes the TLV.
      *
@@ -111,7 +113,7 @@ public:
      * @retval false  The TLV does not appear to be well-formed.
      *
      */
-    bool IsValid(void) const { return GetLength() >= sizeof(TypeIdFlags) + sizeof(uint8_t); }
+    bool IsValid(void) const { return GetLength() >= kMinLength; }
 
     /**
      * This method returns the Link Metrics Type ID.

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2769,21 +2769,21 @@ exit:
 void Mle::HandleDataResponse(RxInfo &aRxInfo)
 {
     Error error;
-#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
-    uint16_t metricsReportValueOffset;
-    uint16_t length;
-#endif
 
     Log(kMessageReceive, kTypeDataResponse, aRxInfo.mMessageInfo.GetPeerAddr());
 
     VerifyOrExit(aRxInfo.mNeighbor && aRxInfo.mNeighbor->IsStateValid(), error = kErrorDrop);
 
 #if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
-    if (Tlv::FindTlvValueOffset(aRxInfo.mMessage, Tlv::kLinkMetricsReport, metricsReportValueOffset, length) ==
-        kErrorNone)
     {
-        Get<LinkMetrics::LinkMetrics>().HandleReport(aRxInfo.mMessage, metricsReportValueOffset, length,
-                                                     aRxInfo.mMessageInfo.GetPeerAddr());
+        uint16_t offset;
+        uint16_t length;
+
+        if (Tlv::FindTlvValueOffset(aRxInfo.mMessage, Tlv::kLinkMetricsReport, offset, length) == kErrorNone)
+        {
+            Get<LinkMetrics::LinkMetrics>().HandleReport(aRxInfo.mMessage, offset, length,
+                                                         aRxInfo.mMessageInfo.GetPeerAddr());
+        }
     }
 #endif
 


### PR DESCRIPTION
This commit updates `LinkMetrics::HandleReport()` method:
- Fixes issue where `Status` sub-TLV would not be read.
- Uses `Tlv` helper methods to read the sub-TLVs.
- Reads `ReportSubTlv` directly from message and uses its methods
  to get the metrics values.
- Fixes issue where we would not skip over unknown sub-TLVs
  correctly.

---

~~This PR contains commits from https://github.com/openthread/openthread/pull/8051 and https://github.com/openthread/openthread/pull/8042. Please check the last commit.~~