### PR TITLE
[multicast-routing] block egress multicast packets from LLA

### DIFF
--- a/src/posix/platform/multicast_routing.cpp
+++ b/src/posix/platform/multicast_routing.cpp
@@ -309,6 +309,7 @@ otError MulticastRoutingManager::AddMulticastForwardingCache(const Ip6::Address 
     }
     else
     {
+        VerifyOrExit(!aSrcAddr.IsLinkLocal(), error = OT_ERROR_NONE);
         VerifyOrExit(aSrcAddr.GetPrefix() != AsCoreType(otThreadGetMeshLocalPrefix(gInstance)), error = OT_ERROR_NONE);
         // Forward multicast traffic from Thread to Backbone if multicast scope > kRealmLocalScope
         // TODO: (MLR) allow scope configuration of outbound multicast routing

--- a/tests/scripts/thread-cert/backbone/test_mlr_multicast_routing_across_thread_pans.py
+++ b/tests/scripts/thread-cert/backbone/test_mlr_multicast_routing_across_thread_pans.py
@@ -230,6 +230,17 @@ class TestMlr(thread_cert.TestCase):
         # PBBR1 shouldn't forward the multicast ping request to the Backbone link
         pkts.filter_eth_src(PBBR1_ETH).filter_ping_request(ping_ma2_2.icmpv6.echo.identifier).must_not_next()
 
+        #
+        # Verify pinging MA2 from R1's Link-Local address will not be forwarded to the Backbone link
+        #
+
+        # ROUTER1 should send the multicast ping request
+        ping_ma2_3 = pkts.filter_wpan_src64(ROUTER1).filter_AMPLFMA(mpl_seed_id=ROUTER1_RLOC16).filter_ping_request(
+            identifier=ping_ma2.icmpv6.echo.identifier + 1).must_next()
+
+        # PBBR1 shouldn't forward the multicast ping request to the Backbone link
+        pkts.filter_eth_src(PBBR1_ETH).filter_ping_request(ping_ma2_3.icmpv6.echo.identifier).must_not_next()
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
According to the Spec, egress packets from LLA should not be forwarded. Linux kernel doesn't automatically block such forwardings so that we need to check this before adding the MFC entry.