### PR TITLE
[mac] add `ComputeLinkMargin()`

### DIFF
--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -275,7 +275,8 @@ bool otLinkIsRadioFilterEnabled(otInstance *aInstance)
 
 uint8_t otLinkConvertRssToLinkQuality(otInstance *aInstance, int8_t aRss)
 {
-    return LinkQualityInfo::ConvertRssToLinkQuality(AsCoreType(aInstance).Get<Mac::Mac>().GetNoiseFloor(), aRss);
+    return LinkQualityInfo::ConvertLinkMarginToLinkQuality(
+        AsCoreType(aInstance).Get<Mac::Mac>().ComputeLinkMargin(aRss));
 }
 
 int8_t otLinkConvertLinkQualityToRss(otInstance *aInstance, uint8_t aLinkQuality)

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2134,6 +2134,11 @@ void Mac::ResetRetrySuccessHistogram()
 }
 #endif // OPENTHREAD_CONFIG_MAC_RETRY_SUCCESS_HISTOGRAM_ENABLE
 
+uint8_t Mac::ComputeLinkMargin(int8_t aRss) const
+{
+    return LinkQualityInfo::ConvertRssToLinkMargin(GetNoiseFloor(), aRss);
+}
+
 // LCOV_EXCL_START
 
 #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_INFO)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -546,7 +546,17 @@ public:
      * @returns The noise floor value in dBm.
      *
      */
-    int8_t GetNoiseFloor(void) { return mLinks.GetNoiseFloor(); }
+    int8_t GetNoiseFloor(void) const { return mLinks.GetNoiseFloor(); }
+
+    /**
+     * This method computes the link margin for a given a received signal strength value using noise floor.
+     *
+     * @param[in] aRss The received signal strength in dBm.
+     *
+     * @returns The link margin for @p aRss in dB based on noise floor.
+     *
+     */
+    uint8_t ComputeLinkMargin(int8_t aRss) const;
 
     /**
      * This method returns the current CCA (Clear Channel Assessment) failure rate.

--- a/src/core/mac/mac_links.hpp
+++ b/src/core/mac/mac_links.hpp
@@ -620,7 +620,7 @@ public:
      * @returns The noise floor value in dBm.
      *
      */
-    int8_t GetNoiseFloor(void)
+    int8_t GetNoiseFloor(void) const
     {
         return
 #if OPENTHREAD_CONFIG_RADIO_LINK_IEEE_802_15_4_ENABLE

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -684,7 +684,7 @@ int8_t SubMac::GetRssi(void) const
     return rssi;
 }
 
-int8_t SubMac::GetNoiseFloor(void)
+int8_t SubMac::GetNoiseFloor(void) const
 {
     return Get<Radio>().GetReceiveSensitivity();
 }

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -392,7 +392,7 @@ public:
      * @returns The noise floor value in dBm.
      *
      */
-    int8_t GetNoiseFloor(void);
+    int8_t GetNoiseFloor(void) const;
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     /**

--- a/src/core/radio/radio.hpp
+++ b/src/core/radio/radio.hpp
@@ -236,7 +236,7 @@ public:
      * @returns The radio receive sensitivity value in dBm.
      *
      */
-    int8_t GetReceiveSensitivity(void);
+    int8_t GetReceiveSensitivity(void) const;
 
 #if OPENTHREAD_RADIO
     /**
@@ -656,7 +656,7 @@ public:
     }
 
 private:
-    otInstance *GetInstancePtr(void) { return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance()); }
+    otInstance *GetInstancePtr(void) const { return reinterpret_cast<otInstance *>(&InstanceLocator::GetInstance()); }
 
     Callbacks mCallbacks;
 };
@@ -695,7 +695,7 @@ inline otRadioCaps Radio::GetCaps(void)
     return otPlatRadioGetCaps(GetInstancePtr());
 }
 
-inline int8_t Radio::GetReceiveSensitivity(void)
+inline int8_t Radio::GetReceiveSensitivity(void) const
 {
     return otPlatRadioGetReceiveSensitivity(GetInstancePtr());
 }
@@ -870,7 +870,7 @@ inline otRadioCaps Radio::GetCaps(void)
     return OT_RADIO_CAPS_ACK_TIMEOUT | OT_RADIO_CAPS_CSMA_BACKOFF | OT_RADIO_CAPS_TRANSMIT_RETRIES;
 }
 
-inline int8_t Radio::GetReceiveSensitivity(void)
+inline int8_t Radio::GetReceiveSensitivity(void) const
 {
     return -110;
 }

--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -250,9 +250,7 @@ Error LinkMetrics::AppendReport(Message &aMessage, const Message &aRequestMessag
         values.mPduCountValue = aRequestMessage.GetPsduCount();
         values.mLqiValue      = aRequestMessage.GetAverageLqi();
         // Linearly scale Link Margin from [0, 130] to [0, 255]
-        values.mLinkMarginValue =
-            LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), aRequestMessage.GetAverageRss()) *
-            255 / 130;
+        values.mLinkMarginValue = Get<Mac::Mac>().ComputeLinkMargin(aRequestMessage.GetAverageRss()) * 255 / 130;
         // Linearly scale rss from [-130, 0] to [0, 255]
         values.mRssiValue = (aRequestMessage.GetAverageRss() + 130) * 255 / 130;
 
@@ -276,9 +274,7 @@ Error LinkMetrics::AppendReport(Message &aMessage, const Message &aRequestMessag
             values.mPduCountValue = seriesInfo->GetPduCount();
             values.mLqiValue      = seriesInfo->GetAverageLqi();
             // Linearly scale Link Margin from [0, 130] to [0, 255]
-            values.mLinkMarginValue =
-                LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), seriesInfo->GetAverageRss()) *
-                255 / 130;
+            values.mLinkMarginValue = Get<Mac::Mac>().ComputeLinkMargin(seriesInfo->GetAverageRss()) * 255 / 130;
             // Linearly scale RSSI from [-130, 0] to [0, 255]
             values.mRssiValue = (seriesInfo->GetAverageRss() + 130) * 255 / 130;
             SuccessOrExit(error = AppendReportSubTlvToMessage(aMessage, length, values));

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3112,7 +3112,7 @@ void Mle::HandleParentResponse(RxInfo &aRxInfo)
     // Link Margin
     SuccessOrExit(error = Tlv::Find<LinkMarginTlv>(aRxInfo.mMessage, linkMarginFromTlv));
 
-    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->GetRss());
+    linkMargin = Get<Mac::Mac>().ComputeLinkMargin(linkInfo->GetRss());
 
     if (linkMargin > linkMarginFromTlv)
     {

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -762,8 +762,7 @@ Error MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo,
     SuccessOrExit(error = message->AppendMleFrameCounterTlv());
 
     // always append a link margin, regardless of whether or not it was requested
-    linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(),
-                                                         aMessageInfo.GetThreadLinkInfo()->GetRss());
+    linkMargin = Get<Mac::Mac>().ComputeLinkMargin(aMessageInfo.GetThreadLinkInfo()->GetRss());
 
     SuccessOrExit(error = message->AppendLinkMarginTlv(linkMargin));
 
@@ -1229,17 +1228,17 @@ exit:
 
 Error MleRouter::HandleAdvertisement(RxInfo &aRxInfo)
 {
-    Error                 error    = kErrorNone;
-    const ThreadLinkInfo *linkInfo = aRxInfo.mMessageInfo.GetThreadLinkInfo();
-    uint8_t linkMargin = LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), linkInfo->GetRss());
-    Mac::ExtAddress extAddr;
-    uint16_t        sourceAddress = Mac::kShortAddrInvalid;
-    LeaderData      leaderData;
-    RouteTlv        route;
-    uint32_t        partitionId;
-    Router *        router;
-    uint8_t         routerId;
-    uint8_t         routerCount;
+    Error                 error      = kErrorNone;
+    const ThreadLinkInfo *linkInfo   = aRxInfo.mMessageInfo.GetThreadLinkInfo();
+    uint8_t               linkMargin = Get<Mac::Mac>().ComputeLinkMargin(linkInfo->GetRss());
+    Mac::ExtAddress       extAddr;
+    uint16_t              sourceAddress = Mac::kShortAddrInvalid;
+    LeaderData            leaderData;
+    RouteTlv              route;
+    uint32_t              partitionId;
+    Router *              router;
+    uint8_t               routerId;
+    uint8_t               routerCount;
 
     aRxInfo.mMessageInfo.GetPeerAddr().GetIid().ConvertToExtAddress(extAddr);
 
@@ -1785,8 +1784,7 @@ bool MleRouter::HasNeighborWithGoodLinkQuality(void) const
     bool    haveNeighbor = true;
     uint8_t linkMargin;
 
-    linkMargin =
-        LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), mParent.GetLinkInfo().GetLastRss());
+    linkMargin = Get<Mac::Mac>().ComputeLinkMargin(mParent.GetLinkInfo().GetLastRss());
 
     if (linkMargin >= OPENTHREAD_CONFIG_MLE_LINK_REQUEST_MARGIN_MIN)
     {
@@ -1800,8 +1798,7 @@ bool MleRouter::HasNeighborWithGoodLinkQuality(void) const
             continue;
         }
 
-        linkMargin =
-            LinkQualityInfo::ConvertRssToLinkMargin(Get<Mac::Mac>().GetNoiseFloor(), router.GetLinkInfo().GetLastRss());
+        linkMargin = Get<Mac::Mac>().ComputeLinkMargin(router.GetLinkInfo().GetLastRss());
 
         if (linkMargin >= OPENTHREAD_CONFIG_MLE_LINK_REQUEST_MARGIN_MIN)
         {


### PR DESCRIPTION
This commit adds a helper method in `Mac` to compute link margin
from a given received signal strength (in dBm) using the radio
noise floor.