### PR TITLE
[tasklet] add template `TaskletIn` to simplify handler functions

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -1288,7 +1288,7 @@ void RoutingManager::ResetDiscoveredPrefixStaleTimer(void)
 RoutingManager::DiscoveredPrefixTable::DiscoveredPrefixTable(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mTimer(aInstance, HandleTimer)
-    , mSignalTask(aInstance, HandleSignalTask)
+    , mSignalTask(aInstance)
     , mAllowDefaultRouteInNetData(false)
 {
 }
@@ -1821,11 +1821,6 @@ void RoutingManager::DiscoveredPrefixTable::RemoveExpiredEntries(void)
 void RoutingManager::DiscoveredPrefixTable::SignalTableChanged(void)
 {
     mSignalTask.Post();
-}
-
-void RoutingManager::DiscoveredPrefixTable::HandleSignalTask(Tasklet &aTasklet)
-{
-    aTasklet.Get<RoutingManager>().HandleDiscoveredPrefixTableChanged();
 }
 
 void RoutingManager::DiscoveredPrefixTable::InitIterator(PrefixTableIterator &aIterator) const

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -349,6 +349,8 @@ private:
         kAdvPrefixesFromNetData,
     };
 
+    void HandleDiscoveredPrefixTableChanged(void); // Declare early so we can use in `mSignalTask`
+
     class DiscoveredPrefixTable : public InstanceLocator
     {
         // This class maintains the discovered on-link and route prefixes
@@ -517,12 +519,13 @@ private:
         void        HandleTimer(void);
         void        RemoveExpiredEntries(void);
         void        SignalTableChanged(void);
-        static void HandleSignalTask(Tasklet &aTasklet);
+
+        using SignalTask = TaskletIn<RoutingManager, &RoutingManager::HandleDiscoveredPrefixTableChanged>;
 
         Array<Router, kMaxRouters> mRouters;
         Pool<Entry, kMaxEntries>   mEntryPool;
         TimerMilli                 mTimer;
-        Tasklet                    mSignalTask;
+        SignalTask                 mSignalTask;
         bool                       mAllowDefaultRouteInNetData;
     };
 
@@ -672,7 +675,6 @@ private:
     bool ShouldProcessPrefixInfoOption(const Ip6::Nd::PrefixInfoOption &aPio, const Ip6::Prefix &aPrefix);
     bool ShouldProcessRouteInfoOption(const Ip6::Nd::RouteInfoOption &aRio, const Ip6::Prefix &aPrefix);
     void UpdateDiscoveredPrefixTableOnNetDataChange(void);
-    void HandleDiscoveredPrefixTableChanged(void);
     bool NetworkDataContainsOmrPrefix(const Ip6::Prefix &aPrefix) const;
     void UpdateRouterAdvertHeader(const Ip6::Nd::RouterAdvertMessage *aRouterAdvertMessage);
     bool IsReceivedRouterAdvertFromManager(const Ip6::Nd::RouterAdvertMessage &aRaMessage) const;

--- a/src/core/common/locator_getters.hpp
+++ b/src/core/common/locator_getters.hpp
@@ -39,6 +39,7 @@
 
 #include "common/instance.hpp"
 #include "common/locator.hpp"
+#include "common/tasklet.hpp"
 
 namespace ot {
 
@@ -47,6 +48,12 @@ template <typename Type>
 inline Type &GetProvider<InstanceGetProvider>::Get(void) const
 {
     return static_cast<const InstanceGetProvider *>(this)->GetInstance().template Get<Type>();
+}
+
+template <typename Owner, void (Owner::*HandleTaskletPtr)(void)>
+void TaskletIn<Owner, HandleTaskletPtr>::HandleTasklet(Tasklet &aTasklet)
+{
+    (aTasklet.Get<Owner>().*HandleTaskletPtr)();
 }
 
 } // namespace ot

--- a/src/core/common/notifier.cpp
+++ b/src/core/common/notifier.cpp
@@ -46,7 +46,7 @@ RegisterLogModule("Notifier");
 
 Notifier::Notifier(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mTask(aInstance, Notifier::EmitEvents)
+    , mTask(aInstance)
 {
     for (ExternalCallback &callback : mExternalCallbacks)
     {
@@ -116,11 +116,6 @@ void Notifier::SignalIfFirst(Event aEvent)
     {
         Signal(aEvent);
     }
-}
-
-void Notifier::EmitEvents(Tasklet &aTasklet)
-{
-    aTasklet.Get<Notifier>().EmitEvents();
 }
 
 void Notifier::EmitEvents(void)

--- a/src/core/common/notifier.hpp
+++ b/src/core/common/notifier.hpp
@@ -313,15 +313,16 @@ private:
         void *                 mContext;
     };
 
-    static void EmitEvents(Tasklet &aTasklet);
-    void        EmitEvents(void);
+    void EmitEvents(void);
 
     void        LogEvents(Events aEvents) const;
     const char *EventToString(Event aEvent) const;
 
+    using EmitEventsTask = TaskletIn<Notifier, &Notifier::EmitEvents>;
+
     Events           mEventsToSignal;
     Events           mSignaledEvents;
-    Tasklet          mTask;
+    EmitEventsTask   mTask;
     ExternalCallback mExternalCallbacks[kMaxExternalHandlers];
 };
 

--- a/src/core/common/tasklet.hpp
+++ b/src/core/common/tasklet.hpp
@@ -150,6 +150,33 @@ private:
 };
 
 /**
+ * This template class defines a tasklet owned by specific type and using a method on owner type as the callback.
+ *
+ * @tparam Owner              The type of owner of this tasklet.
+ * @tparam HandleTaskletPtr   A pointer to a non-static member method of `Owner` to use as tasklet handler.
+ *
+ * The `Owner` MUST be a type that is accessible using `InstanceLocator::Get<Owner>()`.
+ *
+ */
+template <typename Owner, void (Owner::*HandleTaskletPtr)(void)> class TaskletIn : public Tasklet
+{
+public:
+    /**
+     * This constructor initializes the tasklet.
+     *
+     * @param[in]  aInstance   The OpenThread instance.
+     *
+     */
+    explicit TaskletIn(Instance &aInstance)
+        : Tasklet(aInstance, HandleTasklet)
+    {
+    }
+
+private:
+    static void HandleTasklet(Tasklet &aTasklet); // Implemented in `locator_getters.hpp`
+};
+
+/**
  * This class defines a tasklet that also maintains a user context pointer.
  *
  * In typical `Tasklet` use, in the handler callback, the owner of the tasklet is determined using `GetOwner<Type>`

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -100,7 +100,7 @@ Mac::Mac(Instance &aInstance)
     , mActiveScanHandler(nullptr) // Initialize `mActiveScanHandler` and `mEnergyScanHandler` union
     , mScanHandlerContext(nullptr)
     , mLinks(aInstance)
-    , mOperationTask(aInstance, Mac::HandleOperationTask)
+    , mOperationTask(aInstance)
     , mTimer(aInstance, Mac::HandleTimer)
     , mKeyIdMode2FrameCounter(0)
     , mCcaSampleCount(0)
@@ -606,11 +606,6 @@ void Mac::StartOperation(Operation aOperation)
     {
         mOperationTask.Post();
     }
-}
-
-void Mac::HandleOperationTask(Tasklet &aTasklet)
-{
-    aTasklet.Get<Mac>().PerformNextOperation();
 }
 
 void Mac::PerformNextOperation(void)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -763,7 +763,6 @@ private:
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
-    static void HandleOperationTask(Tasklet &aTasklet);
 
     void  Scan(Operation aScanOperation, uint32_t aScanChannels, uint16_t aScanDuration);
     Error UpdateScanChannel(void);
@@ -788,6 +787,8 @@ private:
     void ProcessEnhAckProbing(const RxFrame &aFrame, const Neighbor &aNeighbor);
 #endif
     static const char *OperationToString(Operation aOperation);
+
+    using OperationTask = TaskletIn<Mac, &Mac::PerformNextOperation>;
 
     static const otExtAddress sMode2ExtAddress;
 
@@ -835,7 +836,7 @@ private:
     void *mScanHandlerContext;
 
     Links              mLinks;
-    Tasklet            mOperationTask;
+    OperationTask      mOperationTask;
     TimerMilli         mTimer;
     otMacCounters      mCounters;
     uint32_t           mKeyIdMode2FrameCounter;

--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -75,7 +75,7 @@ Ip6::Ip6(Instance &aInstance)
     , mReceiveIp4DatagramCallback(nullptr)
     , mReceiveIp4DatagramCallbackContext(nullptr)
 #endif
-    , mSendQueueTask(aInstance, Ip6::HandleSendQueue)
+    , mSendQueueTask(aInstance)
     , mIcmp(aInstance)
     , mUdp(aInstance)
     , mMpl(aInstance)
@@ -541,11 +541,6 @@ Error Ip6::SendDatagram(Message &aMessage, MessageInfo &aMessageInfo, uint8_t aI
 exit:
 
     return error;
-}
-
-void Ip6::HandleSendQueue(Tasklet &aTasklet)
-{
-    aTasklet.Get<Ip6>().HandleSendQueue();
 }
 
 void Ip6::HandleSendQueue(void)

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -343,8 +343,7 @@ private:
 
     static constexpr uint16_t kMinimalMtu = 1280;
 
-    static void HandleSendQueue(Tasklet &aTasklet);
-    void        HandleSendQueue(void);
+    void HandleSendQueue(void);
 
     static uint8_t PriorityToDscp(Message::Priority aPriority);
     static Error   GetDatagramPriority(const uint8_t *aData, uint16_t aDataLen, Message::Priority &aPriority);
@@ -383,6 +382,8 @@ private:
     bool  ShouldForwardToThread(const MessageInfo &aMessageInfo, MessageOrigin aOrigin) const;
     bool  IsOnLink(const Address &aAddress) const;
 
+    using SendQueueTask = TaskletIn<Ip6, &Ip6::HandleSendQueue>;
+
     bool                 mForwardingEnabled;
     bool                 mIsReceiveIp6FilterEnabled;
     otIp6ReceiveCallback mReceiveIp6DatagramCallback;
@@ -394,7 +395,7 @@ private:
 #endif
 
     PriorityQueue mSendQueue;
-    Tasklet       mSendQueueTask;
+    SendQueueTask mSendQueueTask;
 
     Icmp mIcmp;
     Udp  mUdp;

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -73,7 +73,7 @@ static_assert(offsetof(Tcp::Listener, mTcbListen) == 0, "mTcbListen field in otT
 Tcp::Tcp(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mTimer(aInstance, Tcp::HandleTimer)
-    , mTasklet(aInstance, Tcp::HandleTasklet)
+    , mTasklet(aInstance)
     , mEphemeralPort(kDynamicPortMin)
 {
     OT_UNUSED_VARIABLE(mEphemeralPort);
@@ -916,13 +916,6 @@ restart:
     {
         LogDebg("Did not reset main TCP timer");
     }
-}
-
-void Tcp::HandleTasklet(Tasklet &aTasklet)
-{
-    OT_ASSERT(&aTasklet == &aTasklet.Get<Tcp>().mTasklet);
-    LogDebg("TCP tasklet invoked");
-    aTasklet.Get<Tcp>().ProcessCallbacks();
 }
 
 void Tcp::ProcessCallbacks(void)

--- a/src/core/net/tcp6.hpp
+++ b/src/core/net/tcp6.hpp
@@ -680,11 +680,12 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        ProcessTimers(void);
 
-    static void HandleTasklet(Tasklet &aTasklet);
-    void        ProcessCallbacks(void);
+    void ProcessCallbacks(void);
+
+    using TcpTasklet = TaskletIn<Tcp, &Tcp::ProcessCallbacks>;
 
     TimerMilli mTimer;
-    Tasklet    mTasklet;
+    TcpTasklet mTasklet;
 
     LinkedList<Endpoint> mEndpoints;
     LinkedList<Listener> mListeners;

--- a/src/core/radio/trel_interface.cpp
+++ b/src/core/radio/trel_interface.cpp
@@ -59,7 +59,7 @@ Interface::Interface(Instance &aInstance)
     , mInitialized(false)
     , mEnabled(false)
     , mFiltered(false)
-    , mRegisterServiceTask(aInstance, HandleRegisterServiceTask)
+    , mRegisterServiceTask(aInstance)
 {
 }
 
@@ -125,11 +125,6 @@ void Interface::HandleExtPanIdChange(void)
 
 exit:
     return;
-}
-
-void Interface::HandleRegisterServiceTask(Tasklet &aTasklet)
-{
-    aTasklet.Get<Interface>().RegisterService();
 }
 
 void Interface::RegisterService(void)

--- a/src/core/radio/trel_interface.hpp
+++ b/src/core/radio/trel_interface.hpp
@@ -242,21 +242,22 @@ private:
     void HandleReceived(uint8_t *aBuffer, uint16_t aLength);
     void HandleDiscoveredPeerInfo(const Peer::Info &aInfo);
 
-    static void HandleRegisterServiceTask(Tasklet &aTasklet);
-    void        RegisterService(void);
-    Error       ParsePeerInfoTxtData(const Peer::Info &      aInfo,
-                                     Mac::ExtAddress &       aExtAddress,
-                                     MeshCoP::ExtendedPanId &aExtPanId) const;
-    Peer *      GetNewPeerEntry(void);
-    void        RemovePeerEntry(Peer &aEntry);
+    void  RegisterService(void);
+    Error ParsePeerInfoTxtData(const Peer::Info &      aInfo,
+                               Mac::ExtAddress &       aExtAddress,
+                               MeshCoP::ExtendedPanId &aExtPanId) const;
+    Peer *GetNewPeerEntry(void);
+    void  RemovePeerEntry(Peer &aEntry);
 
-    bool      mInitialized : 1;
-    bool      mEnabled : 1;
-    bool      mFiltered : 1;
-    Tasklet   mRegisterServiceTask;
-    uint16_t  mUdpPort;
-    Packet    mRxPacket;
-    PeerTable mPeerTable;
+    using RegsiterServiceTask = TaskletIn<Interface, &Interface::RegisterService>;
+
+    bool                mInitialized : 1;
+    bool                mEnabled : 1;
+    bool                mFiltered : 1;
+    RegsiterServiceTask mRegisterServiceTask;
+    uint16_t            mUdpPort;
+    Packet              mRxPacket;
+    PeerTable           mPeerTable;
 };
 
 } // namespace Trel

--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -51,7 +51,7 @@ Link::Link(Instance &aInstance)
     , mRxChannel(0)
     , mPanId(Mac::kPanIdBroadcast)
     , mTxPacketNumber(0)
-    , mTxTasklet(aInstance, HandleTxTasklet)
+    , mTxTasklet(aInstance)
     , mTimer(aInstance, HandleTimer)
     , mInterface(aInstance)
 {
@@ -114,11 +114,6 @@ void Link::Send(void)
 
     SetState(kStateTransmit);
     mTxTasklet.Post();
-}
-
-void Link::HandleTxTasklet(Tasklet &aTasklet)
-{
-    aTasklet.Get<Link>().HandleTxTasklet();
 }
 
 void Link::HandleTxTasklet(void)

--- a/src/core/radio/trel_link.hpp
+++ b/src/core/radio/trel_link.hpp
@@ -174,19 +174,20 @@ private:
     void HandleTimer(Neighbor &aNeighbor);
     void HandleNotifierEvents(Events aEvents);
 
-    static void HandleTxTasklet(Tasklet &aTasklet);
-    void        HandleTxTasklet(void);
+    void HandleTxTasklet(void);
 
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 
     static const char *StateToString(State aState);
 
+    using TxTasklet = TaskletIn<Link, &Link::HandleTxTasklet>;
+
     State        mState;
     uint8_t      mRxChannel;
     Mac::PanId   mPanId;
     uint32_t     mTxPacketNumber;
-    Tasklet      mTxTasklet;
+    TxTasklet    mTxTasklet;
     TimerMilli   mTimer;
     Interface    mInterface;
     Mac::RxFrame mRxFrame;

--- a/src/core/thread/dua_manager.cpp
+++ b/src/core/thread/dua_manager.cpp
@@ -54,7 +54,7 @@ RegisterLogModule("DuaManager");
 
 DuaManager::DuaManager(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mRegistrationTask(aInstance, DuaManager::HandleRegistrationTask)
+    , mRegistrationTask(aInstance)
     , mDuaNotification(UriPath::kDuaRegistrationNotify, &DuaManager::HandleDuaNotification, this)
     , mIsDuaPending(false)
 #if OPENTHREAD_CONFIG_DUA_ENABLE
@@ -400,11 +400,6 @@ void DuaManager::HandleTimeTick(void)
     }
 
     UpdateTimeTickerRegistration();
-}
-
-void DuaManager::HandleRegistrationTask(Tasklet &aTasklet)
-{
-    aTasklet.Get<DuaManager>().PerformNextRegistration();
 }
 
 void DuaManager::UpdateTimeTickerRegistration(void)

--- a/src/core/thread/dua_manager.hpp
+++ b/src/core/thread/dua_manager.hpp
@@ -195,8 +195,6 @@ private:
 
     void HandleTimeTick(void);
 
-    static void HandleRegistrationTask(Tasklet &aTasklet);
-
     void UpdateTimeTickerRegistration(void);
 
     static void HandleDuaResponse(void *               aContext,
@@ -214,10 +212,12 @@ private:
     void UpdateReregistrationDelay(void);
     void UpdateCheckDelay(uint8_t aDelay);
 
-    Tasklet        mRegistrationTask;
-    Coap::Resource mDuaNotification;
-    Ip6::Address   mRegisteringDua;
-    bool           mIsDuaPending : 1;
+    using RegistrationTask = TaskletIn<DuaManager, &DuaManager::PerformNextRegistration>;
+
+    RegistrationTask mRegistrationTask;
+    Coap::Resource   mDuaNotification;
+    Ip6::Address     mRegisteringDua;
+    bool             mIsDuaPending : 1;
 
 #if OPENTHREAD_CONFIG_DUA_ENABLE
     enum DuaState : uint8_t

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -105,7 +105,7 @@ MeshForwarder::MeshForwarder(Instance &aInstance)
     , mDelayNextTx(false)
     , mTxDelayTimer(aInstance, HandleTxDelayTimer)
 #endif
-    , mScheduleTransmissionTask(aInstance, MeshForwarder::ScheduleTransmissionTask)
+    , mScheduleTransmissionTask(aInstance)
 #if OPENTHREAD_FTD
     , mIndirectSender(aInstance)
 #endif
@@ -520,11 +520,6 @@ exit:
 }
 
 #endif // (OPENTHREAD_CONFIG_MAX_FRAMES_IN_DIRECT_TX_QUEUE > 0)
-
-void MeshForwarder::ScheduleTransmissionTask(Tasklet &aTasklet)
-{
-    aTasklet.Get<MeshForwarder>().ScheduleTransmissionTask();
-}
 
 void MeshForwarder::ScheduleTransmissionTask(void)
 {

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -487,9 +487,8 @@ private:
     void          UpdateSendMessage(Error aFrameTxError, Mac::Address &aMacDest, Neighbor *aNeighbor);
     void          RemoveMessageIfNoPendingTx(Message &aMessage);
 
-    void        HandleTimeTick(void);
-    static void ScheduleTransmissionTask(Tasklet &aTasklet);
-    void        ScheduleTransmissionTask(void);
+    void HandleTimeTick(void);
+    void ScheduleTransmissionTask(void);
 
     Error GetFramePriority(const FrameData &aFrameData, const Mac::Addresses &aMacAddrs, Message::Priority &aPriority);
     Error GetFragmentPriority(Lowpan::FragmentHeader &aFragmentHeader,
@@ -555,6 +554,8 @@ private:
                        LogLevel            aLogLevel);
 #endif // #if OT_SHOULD_LOG_AT(OT_LOG_LEVEL_NOTE)
 
+    using TxTask = TaskletIn<MeshForwarder, &MeshForwarder::ScheduleTransmissionTask>;
+
     PriorityQueue mSendQueue;
     MessageQueue  mReassemblyList;
     uint16_t      mFragTag;
@@ -574,7 +575,7 @@ private:
     TimerMilli mTxDelayTimer;
 #endif
 
-    Tasklet mScheduleTransmissionTask;
+    TxTask mScheduleTransmissionTask;
 
     otIpCounters mIpCounters;
 

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -50,7 +50,7 @@ RegisterLogModule("NetworkData");
 Notifier::Notifier(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mTimer(aInstance, HandleTimer)
-    , mSynchronizeDataTask(aInstance, HandleSynchronizeDataTask)
+    , mSynchronizeDataTask(aInstance)
     , mNextDelay(0)
     , mWaitingForResponse(false)
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTER_REQUEST_ROUTER_ROLE
@@ -69,11 +69,6 @@ void Notifier::HandleServerDataUpdated(void)
 
     mNextDelay = 0;
     mSynchronizeDataTask.Post();
-}
-
-void Notifier::HandleSynchronizeDataTask(Tasklet &aTasklet)
-{
-    aTasklet.Get<Notifier>().SynchronizeServerData();
 }
 
 void Notifier::SynchronizeServerData(void)

--- a/src/core/thread/network_data_notifier.hpp
+++ b/src/core/thread/network_data_notifier.hpp
@@ -115,18 +115,18 @@ private:
                                    Error                aResult);
     void        HandleCoapResponse(Error aResult);
 
-    static void HandleSynchronizeDataTask(Tasklet &aTasklet);
-
     void SynchronizeServerData(void);
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTER_REQUEST_ROUTER_ROLE
     void ScheduleRouterRoleUpgradeIfEligible(void);
     void HandleTimeTick(void);
 #endif
 
-    TimerMilli mTimer;
-    Tasklet    mSynchronizeDataTask;
-    uint32_t   mNextDelay;
-    bool       mWaitingForResponse : 1;
+    using SynchronizeDataTask = TaskletIn<Notifier, &Notifier::SynchronizeServerData>;
+
+    TimerMilli          mTimer;
+    SynchronizeDataTask mSynchronizeDataTask;
+    uint32_t            mNextDelay;
+    bool                mWaitingForResponse : 1;
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE && OPENTHREAD_CONFIG_BORDER_ROUTER_REQUEST_ROUTER_ROLE
     bool    mDidRequestRouterRoleUpgrade : 1;


### PR DESCRIPTION
This class adds a template sub-class of `Tasklet` which allows
us to directly specify an `Owner` of tasklet along with handler
callback as a member method of `Owner`. This helps simplify the
use of `Tasklet` in core module.

---

This change helps simplify how we use `Tasklet`. 
- Today we need to define a `static` member function (e.g. `HandleTasklet`) to use as callback of `Tasklet`.
- Then from this callback, we call a method on the owner of `Tasklet` to process/handle it.
- With the new `template` model, there is no need to define the `static` member function and we can directly specify the method.
- And the `template` definition takes care of defining a function callback and hooking it to the method for us.

We should be able to do the same for `Timer` classes (can do in a follow-up next PR).