### PR TITLE
[nat64] disable discovering NAT64 AIL prefix for OpenWRT

### DIFF
--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -125,8 +125,15 @@ target_link_libraries(openthread-posix
         ot-posix-config
         util
         $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Linux>:rt>
-        $<$<STREQUAL:${CMAKE_SYSTEM_NAME},Linux>:anl>
 )
+
+option(OT_TARGET_OPENWRT "enable openthread posix for OpenWRT" OFF)
+if(${CMAKE_SYSTEM_NAME} STREQUAL "Linux" AND NOT OT_TARGET_OPENWRT)
+    target_compile_definitions(ot-posix-config
+        INTERFACE "OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE=1"
+    )
+    target_link_libraries(openthread-posix PRIVATE anl)
+endif()
 
 target_compile_definitions(openthread-posix
     PUBLIC

--- a/src/posix/platform/infra_if.cpp
+++ b/src/posix/platform/infra_if.cpp
@@ -102,7 +102,13 @@ otError otPlatInfraIfSendIcmp6Nd(uint32_t            aInfraIfIndex,
 
 otError otPlatInfraIfDiscoverNat64Prefix(uint32_t aInfraIfIndex)
 {
+    OT_UNUSED_VARIABLE(aInfraIfIndex);
+
+#if OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE
     return ot::Posix::InfraNetif::Get().DiscoverNat64Prefix(aInfraIfIndex);
+#else
+    return OT_ERROR_DROP;
+#endif
 }
 
 bool platformInfraIfIsRunning(void)
@@ -524,6 +530,7 @@ exit:
     }
 }
 
+#if OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE
 const char         InfraNetif::kWellKnownIpv4OnlyName[]   = "ipv4only.arpa";
 const otIp4Address InfraNetif::kWellKnownIpv4OnlyAddress1 = {{{192, 0, 0, 170}}};
 const otIp4Address InfraNetif::kWellKnownIpv4OnlyAddress2 = {{{192, 0, 0, 171}}};
@@ -614,7 +621,6 @@ otError InfraNetif::DiscoverNat64Prefix(uint32_t aInfraIfIndex)
     int              status;
 
     VerifyOrExit(aInfraIfIndex == mInfraIfIndex, error = OT_ERROR_DROP);
-
     hints = (struct addrinfo *)malloc(sizeof(struct addrinfo));
     VerifyOrExit(hints != nullptr, error = OT_ERROR_NO_BUFS);
     memset(hints, 0, sizeof(struct addrinfo));
@@ -640,7 +646,6 @@ otError InfraNetif::DiscoverNat64Prefix(uint32_t aInfraIfIndex)
         ExitNow(error = OT_ERROR_FAILED);
     }
     otLogInfoPlat("getaddrinfo_a requested for %s", kWellKnownIpv4OnlyName);
-
 exit:
     if (error != OT_ERROR_NONE)
     {
@@ -649,6 +654,7 @@ exit:
     }
     return error;
 }
+#endif // OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE
 
 void InfraNetif::Process(const otSysMainloopContext &aContext)
 {

--- a/src/posix/platform/openthread-posix-config.h
+++ b/src/posix/platform/openthread-posix-config.h
@@ -215,6 +215,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE
+ *
+ * Define as 1 to enable discovering NAT64 posix on adjacent infrastructure link.
+ *
+ */
+#ifndef OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE
+#define OPENTHREAD_POSIX_CONFIG_NAT64_AIL_PREFIX_ENABLE 0
+#endif
+
+/**
  * @def OPENTHREAD_POSIX_CONFIG_FIREWALL_ENABLE
  *
  * Define as 1 to enable firewall.


### PR DESCRIPTION
This commit is to mitigate the OTBR compile error in [ot-br-posix/tests/scripts/openwrt](https://github.com/openthread/ot-br-posix/blob/main/tests/scripts/openwrt). This test uses the `openwrtorg/sdk` docker, which depends on the `musl` toolchain and lacks the `libanl` library. We can re-enable it for OpenWRT if `libanl` can be linked in the sdk (e.g. import the library, or build an sdk with `glibc`).

The ot-br-posix PR is: https://github.com/openthread/ot-br-posix/pull/1512.