### PR TITLE
[mesh-forwarder] fix random ieee frame version 2015 while attaching

### DIFF
--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -1840,7 +1840,7 @@ uint16_t MeshForwarder::CalcFrameVersion(const Neighbor *aNeighbor, bool aIePres
     }
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
     else if (aNeighbor != nullptr && !Mle::MleRouter::IsActiveRouter(aNeighbor->GetRloc16()) &&
-             static_cast<const Child *>(aNeighbor)->IsCslSynchronized())
+             Get<Mle::MleRouter>().IsRouterOrLeader() && static_cast<const Child *>(aNeighbor)->IsCslSynchronized())
     {
         version = Mac::Frame::kFcfFrameVersion2015;
     }


### PR DESCRIPTION
This commit fixes random 2015 frame version issue while attaching to
REED. the problem was caused by unconditionally casting Router structure
to Child structure and making out of original structure memory access.

