### PR TITLE
[link-metrics] update the scaling of link margin and RSSI metrics

### DIFF
--- a/src/core/common/num_utils.hpp
+++ b/src/core/common/num_utils.hpp
@@ -171,6 +171,22 @@ template <> inline int ThreeWayCompare(bool aFirst, bool aSecond)
     return (aFirst == aSecond) ? 0 : (aFirst ? 1 : -1);
 }
 
+/**
+ * This template function divides two numbers and rounds the result to the closest integer.
+ *
+ * @tparam IntType   The integer type.
+ *
+ * @param[in] aDividend   The dividend value.
+ * @param[in] aDivisor    The divisor value.
+ *
+ * @return The result of division and rounding to the closest integer.
+ *
+ */
+template <typename IntType> inline IntType DivideAndRoundToClosest(IntType aDividend, IntType aDivisor)
+{
+    return (aDividend + (aDivisor / 2)) / aDivisor;
+}
+
 } // namespace ot
 
 #endif // NUM_UTILS_HPP_

--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -57,6 +57,7 @@
 
 namespace ot {
 class Neighbor;
+class UnitTester;
 
 namespace LinkMetrics {
 
@@ -76,6 +77,7 @@ namespace LinkMetrics {
 class LinkMetrics : public InstanceLocator, private NonCopyable
 {
     friend class ot::Neighbor;
+    friend class ot::UnitTester;
 
 public:
     typedef otLinkMetricsReportCallback                ReportCallback;
@@ -272,6 +274,11 @@ private:
     static constexpr uint8_t kSeriesIdAllSeries  = 255; // This series ID represents all series.
     static constexpr uint8_t kLinkProbeMaxLen    = 64;  // Max length of data payload in Link Probe TLV.
 
+    // Constants for scaling Link Margin and RSSI to raw value
+    static constexpr uint8_t kMaxLinkMargin = 130;
+    static constexpr int32_t kMinRssi       = -130;
+    static constexpr int32_t kMaxRssi       = 0;
+
     Error SendLinkMetricsQuery(const Ip6::Address &aDestination,
                                uint8_t             aSeriesId,
                                const TypeIdFlags * aTypeIdFlags,
@@ -291,6 +298,11 @@ private:
                                             uint16_t       aEndPos,
                                             Metrics &      aMetrics);
     static Error AppendReportSubTlvToMessage(Message &aMessage, const MetricsValues &aValues);
+
+    static uint8_t ScaleLinkMarginToRawValue(uint8_t aLinkMargin);
+    static uint8_t ScaleRawValueToLinkMargin(uint8_t aRawValue);
+    static uint8_t ScaleRssiToRawValue(int8_t aRssi);
+    static int8_t  ScaleRawValueToRssi(uint8_t aRawValue);
 
     ReportCallback                mReportCallback;
     void *                        mReportCallbackContext;

--- a/tests/unit/test_serial_number.cpp
+++ b/tests/unit/test_serial_number.cpp
@@ -118,6 +118,19 @@ void TestNumUtils(void)
     VerifyOrQuit(ThreeWayCompare<bool>(true, false) > 0);
     VerifyOrQuit(ThreeWayCompare<bool>(false, true) < 0);
 
+    VerifyOrQuit(DivideAndRoundToClosest<uint8_t>(2, 1) == 2);
+    VerifyOrQuit(DivideAndRoundToClosest<uint8_t>(1, 3) == 0);
+    VerifyOrQuit(DivideAndRoundToClosest<uint8_t>(1, 2) == 1);
+    VerifyOrQuit(DivideAndRoundToClosest<uint8_t>(2, 3) == 1);
+    VerifyOrQuit(DivideAndRoundToClosest<uint8_t>(3, 2) == 2);
+    VerifyOrQuit(DivideAndRoundToClosest<uint8_t>(4, 2) == 2);
+
+    VerifyOrQuit(DivideAndRoundToClosest<uint8_t>(0, 10) == 0);
+    VerifyOrQuit(DivideAndRoundToClosest<uint8_t>(4, 10) == 0);
+    VerifyOrQuit(DivideAndRoundToClosest<uint8_t>(5, 10) == 1);
+    VerifyOrQuit(DivideAndRoundToClosest<uint8_t>(9, 10) == 1);
+    VerifyOrQuit(DivideAndRoundToClosest<uint8_t>(10, 10) == 1);
+
     printf("TestNumUtils() passed\n");
 }
 


### PR DESCRIPTION
This commit updates the scaling of the link margin and RSSI metrics.
The metric values are scaled when appended in the message (in a
Report sub-TLV) or when they are read back from received message. The
stored value in `MetricsValues` are changed to be always the actual
metric value (not the scaled value). This ensures that the value are
stored in proper int type (e.g., RSSI is `int8` vs the scaled value
which is `[0,255]`). Methods are added to perform the scaling which
now rounds to closest integer ensuring the reverse scaling gives back
the original value. Unit test is added to validate the scaling
methods.