### PR TITLE
[srp-server] update validation of instance and service names

### DIFF
--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -931,10 +931,8 @@ Error Server::ProcessServiceDiscoveryInstructions(Host &                 aHost,
         }
 
         // Verify that instance name and service name are related.
-
-        VerifyOrExit(
-            StringEndsWith(instanceName, isSubType ? subServiceName : serviceName, kStringCaseInsensitiveMatch),
-            error = kErrorFailed);
+        VerifyOrExit(Dns::Name::IsSubDomainOf(instanceName, isSubType ? subServiceName : serviceName),
+                     error = kErrorFailed);
 
         // Ensure the same service does not exist already.
         VerifyOrExit(aHost.FindService(serviceName, instanceName) == nullptr, error = kErrorFailed);


### PR DESCRIPTION
This commit updates `ProcessServiceDiscoveryInstructions()` method
to use `Dns::Name::IsSubDomainOf()` to validate the relation between
service instance name and the base service name.

---
Background:
- See https://github.com/openthread/ot-br-posix/issues/1425
- Using `IsSubDomainOf()` since it will check the label boundary

Fixes https://github.com/openthread/openthread/issues/8037
Fixes https://github.com/openthread/ot-br-posix/issues/1425