### PR TITLE
[link-quality] helper fn to convert link margin, link quality, RSS

### DIFF
--- a/examples/platforms/utils/link_metrics.cpp
+++ b/examples/platforms/utils/link_metrics.cpp
@@ -134,7 +134,7 @@ public:
     otLinkMetrics GetLinkMetrics(void) const { return mLinkMetrics; }
 
 private:
-    uint8_t GetLinkMargin(int8_t aRssi) const { return LinkQualityInfo::ConvertRssToLinkMargin(sNoiseFloor, aRssi); }
+    uint8_t GetLinkMargin(int8_t aRssi) const { return ComputeLinkMargin(sNoiseFloor, aRssi); }
 
     bool Matches(const otShortAddress &aShortAddress) const { return mShortAddress == aShortAddress; };
 

--- a/src/core/api/link_api.cpp
+++ b/src/core/api/link_api.cpp
@@ -275,14 +275,13 @@ bool otLinkIsRadioFilterEnabled(otInstance *aInstance)
 
 uint8_t otLinkConvertRssToLinkQuality(otInstance *aInstance, int8_t aRss)
 {
-    return LinkQualityInfo::ConvertLinkMarginToLinkQuality(
-        AsCoreType(aInstance).Get<Mac::Mac>().ComputeLinkMargin(aRss));
+    return LinkQualityForLinkMargin(AsCoreType(aInstance).Get<Mac::Mac>().ComputeLinkMargin(aRss));
 }
 
 int8_t otLinkConvertLinkQualityToRss(otInstance *aInstance, uint8_t aLinkQuality)
 {
-    return LinkQualityInfo::ConvertLinkQualityToRss(AsCoreType(aInstance).Get<Mac::Mac>().GetNoiseFloor(),
-                                                    static_cast<LinkQuality>(aLinkQuality));
+    return GetTypicalRssForLinkQuality(AsCoreType(aInstance).Get<Mac::Mac>().GetNoiseFloor(),
+                                       static_cast<LinkQuality>(aLinkQuality));
 }
 
 #if OPENTHREAD_CONFIG_MAC_RETRY_SUCCESS_HISTOGRAM_ENABLE

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -2131,7 +2131,7 @@ void Mac::ResetRetrySuccessHistogram()
 
 uint8_t Mac::ComputeLinkMargin(int8_t aRss) const
 {
-    return LinkQualityInfo::ConvertRssToLinkMargin(GetNoiseFloor(), aRss);
+    return ot::ComputeLinkMargin(GetNoiseFloor(), aRss);
 }
 
 // LCOV_EXCL_START

--- a/src/core/thread/link_quality.cpp
+++ b/src/core/thread/link_quality.cpp
@@ -163,7 +163,7 @@ exit:
 
 uint8_t LinkQualityInfo::GetLinkMargin(void) const
 {
-    return ConvertRssToLinkMargin(Get<Mac::SubMac>().GetNoiseFloor(), GetAverageRss());
+    return ComputeLinkMargin(Get<Mac::SubMac>().GetNoiseFloor(), GetAverageRss());
 }
 
 LinkQualityInfo::InfoString LinkQualityInfo::ToInfoString(void) const
@@ -176,7 +176,7 @@ LinkQualityInfo::InfoString LinkQualityInfo::ToInfoString(void) const
     return string;
 }
 
-uint8_t LinkQualityInfo::ConvertRssToLinkMargin(int8_t aNoiseFloor, int8_t aRss)
+uint8_t ComputeLinkMargin(int8_t aNoiseFloor, int8_t aRss)
 {
     int8_t linkMargin = aRss - aNoiseFloor;
 
@@ -188,40 +188,35 @@ uint8_t LinkQualityInfo::ConvertRssToLinkMargin(int8_t aNoiseFloor, int8_t aRss)
     return static_cast<uint8_t>(linkMargin);
 }
 
-LinkQuality LinkQualityInfo::ConvertLinkMarginToLinkQuality(uint8_t aLinkMargin)
+LinkQuality LinkQualityForLinkMargin(uint8_t aLinkMargin)
 {
-    return CalculateLinkQuality(aLinkMargin, kNoLinkQuality);
+    return LinkQualityInfo::CalculateLinkQuality(aLinkMargin, LinkQualityInfo::kNoLinkQuality);
 }
 
-LinkQuality LinkQualityInfo::ConvertRssToLinkQuality(int8_t aNoiseFloor, int8_t aRss)
+int8_t GetTypicalRssForLinkQuality(int8_t aNoiseFloor, LinkQuality aLinkQuality)
 {
-    return ConvertLinkMarginToLinkQuality(ConvertRssToLinkMargin(aNoiseFloor, aRss));
-}
-
-int8_t LinkQualityInfo::ConvertLinkQualityToRss(int8_t aNoiseFloor, LinkQuality aLinkQuality)
-{
-    int8_t linkmargin = 0;
+    int8_t linkMargin = 0;
 
     switch (aLinkQuality)
     {
     case kLinkQuality3:
-        linkmargin = kLinkQuality3LinkMargin;
+        linkMargin = LinkQualityInfo::kLinkQuality3LinkMargin;
         break;
 
     case kLinkQuality2:
-        linkmargin = kLinkQuality2LinkMargin;
+        linkMargin = LinkQualityInfo::kLinkQuality2LinkMargin;
         break;
 
     case kLinkQuality1:
-        linkmargin = kLinkQuality1LinkMargin;
+        linkMargin = LinkQualityInfo::kLinkQuality1LinkMargin;
         break;
 
     default:
-        linkmargin = kLinkQuality0LinkMargin;
+        linkMargin = LinkQualityInfo::kLinkQuality0LinkMargin;
         break;
     }
 
-    return linkmargin + aNoiseFloor;
+    return linkMargin + aNoiseFloor;
 }
 
 LinkQuality LinkQualityInfo::CalculateLinkQuality(uint8_t aLinkMargin, uint8_t aLastLinkQuality)

--- a/src/core/thread/link_quality.hpp
+++ b/src/core/thread/link_quality.hpp
@@ -242,12 +242,47 @@ enum LinkQuality : uint8_t
 };
 
 /**
+ * This function computes the link margin from a given noise floor and received signal strength.
+ *
+ * @param[in]  aNoiseFloor  The noise floor value (in dBm).
+ * @param[in]  aRss         The received signal strength value (in dBm).
+ *
+ * @returns The link margin value in dB.
+ *
+ */
+uint8_t ComputeLinkMargin(int8_t aNoiseFloor, int8_t aRss);
+
+/**
+ * This function converts a link margin value to a link quality value.
+ *
+ * @param[in]  aLinkMargin  The Link Margin in dB.
+ *
+ * @returns The link quality value (0-3).
+ *
+ */
+LinkQuality LinkQualityForLinkMargin(uint8_t aLinkMargin);
+
+/**
+ * This function gets the typical received signal strength value for a given link quality.
+ *
+ * @param[in]  aNoiseFloor   The noise floor value (in dBm).
+ * @param[in]  aLinkQuality  The link quality value in [0, 3].
+ *
+ * @returns The typical platform RSSI in dBm.
+ *
+ */
+int8_t GetTypicalRssForLinkQuality(int8_t aNoiseFloor, LinkQuality aLinkQuality);
+
+/**
  * This class encapsulates/stores all relevant information about quality of a link, including average received signal
  * strength (RSS), last RSS, link margin, and link quality.
  *
  */
 class LinkQualityInfo : public InstanceLocatorInit
 {
+    friend LinkQuality LinkQualityForLinkMargin(uint8_t aLinkMargin);
+    friend int8_t      GetTypicalRssForLinkQuality(int8_t aNoiseFloor, LinkQuality aLinkQuality);
+
 public:
     static constexpr uint16_t kInfoStringSize = 50; ///< `InfoString` size (@sa ToInfoString()).
 
@@ -386,51 +421,6 @@ public:
      *
      */
     uint16_t GetMessageErrorRate(void) const { return mMessageErrorRate.GetFailureRate(); }
-
-    /**
-     * This method converts a received signal strength value to a link margin value.
-     *
-     * @param[in]  aNoiseFloor  The noise floor value (in dBm).
-     * @param[in]  aRss         The received signal strength value (in dBm).
-     *
-     * @returns The link margin value.
-     *
-     */
-    static uint8_t ConvertRssToLinkMargin(int8_t aNoiseFloor, int8_t aRss);
-
-    /**
-     * This method converts a link margin value to a link quality value.
-     *
-     * @param[in]  aLinkMargin  The Link Margin in dB.
-     *
-     * @returns The link quality value (0-3).
-     *
-     */
-    static LinkQuality ConvertLinkMarginToLinkQuality(uint8_t aLinkMargin);
-
-    /**
-     * This method converts a received signal strength value to a link quality value.
-     *
-     * @param[in]  aNoiseFloor  The noise floor value (in dBm).
-     * @param[in]  aRss         The received signal strength value (in dBm).
-     *
-     * @returns The link quality value (0-3).
-     *
-     */
-    static LinkQuality ConvertRssToLinkQuality(int8_t aNoiseFloor, int8_t aRss);
-
-    /**
-     * This method converts a link quality value to a typical received signal strength value.
-     *
-     * @note only for test.
-     *
-     * @param[in]  aNoiseFloor   The noise floor value (in dBm).
-     * @param[in]  aLinkQuality  The link quality value in [0, 3].
-     *
-     * @returns The typical platform RSSI.
-     *
-     */
-    static int8_t ConvertLinkQualityToRss(int8_t aNoiseFloor, LinkQuality aLinkQuality);
 
 private:
     // Constants for obtaining link quality from link margin:

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -3088,7 +3088,7 @@ void Mle::HandleParentResponse(RxInfo &aRxInfo)
         linkMargin = linkMarginFromTlv;
     }
 
-    linkQuality = LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMargin);
+    linkQuality = LinkQualityForLinkMargin(linkMargin);
 
     // Connectivity
     SuccessOrExit(error = Tlv::FindTlv(aRxInfo.mMessage, connectivity));
@@ -3228,7 +3228,7 @@ void Mle::HandleParentResponse(RxInfo &aRxInfo)
     mParentCandidate.GetLinkInfo().Clear();
     mParentCandidate.GetLinkInfo().AddRss(linkInfo->GetRss());
     mParentCandidate.ResetLinkFailures();
-    mParentCandidate.SetLinkQualityOut(LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMarginFromTlv));
+    mParentCandidate.SetLinkQualityOut(LinkQualityForLinkMargin(linkMarginFromTlv));
     mParentCandidate.SetState(Neighbor::kStateParentResponse);
     mParentCandidate.SetKeySequence(aRxInfo.mKeySequence);
     mParentCandidate.SetLeaderCost(connectivity.GetLeaderCost());

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1021,7 +1021,7 @@ Error MleRouter::HandleLinkAccept(RxInfo &aRxInfo, bool aRequest)
                                      DeviceMode::kModeFullNetworkData));
     router->GetLinkInfo().Clear();
     router->GetLinkInfo().AddRss(aRxInfo.mMessageInfo.GetThreadLinkInfo()->GetRss());
-    router->SetLinkQualityOut(LinkQualityInfo::ConvertLinkMarginToLinkQuality(linkMargin));
+    router->SetLinkQualityOut(LinkQualityForLinkMargin(linkMargin));
     router->ResetLinkFailures();
     router->SetState(Neighbor::kStateValid);
     router->SetKeySequence(aRxInfo.mKeySequence);


### PR DESCRIPTION
This commit simplifies the helper functions that convert between
link margin, link quality and RSS (replacing the `static` methods
in `LinkQualityInfo`).