### PR TITLE
[routing-manager] add Neighbor Solicit probe mechanism

### DIFF
--- a/include/openthread/icmp6.h
+++ b/include/openthread/icmp6.h
@@ -66,6 +66,8 @@ typedef enum otIcmp6Type
     OT_ICMP6_TYPE_ECHO_REPLY        = 129, ///< Echo Reply
     OT_ICMP6_TYPE_ROUTER_SOLICIT    = 133, ///< Router Solicitation
     OT_ICMP6_TYPE_ROUTER_ADVERT     = 134, ///< Router Advertisement
+    OT_ICMP6_TYPE_NEIGHBOR_SOLICIT  = 135, ///< Neighbor Solicitation
+    OT_ICMP6_TYPE_NEIGHBOR_ADVERT   = 136, ///< Neighbor Advertisement
 } otIcmp6Type;
 
 /**

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (254)
+#define OPENTHREAD_API_VERSION (255)
 
 /**
  * @addtogroup api-instance

--- a/src/core/config/border_routing.h
+++ b/src/core/config/border_routing.h
@@ -85,4 +85,23 @@
 #ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_OLD_ON_LINK_PREFIXES
 #define OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_OLD_ON_LINK_PREFIXES 3
 #endif
+
+/**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_ROUTER_ACTIVE_CHECK_TIMEOUT
+ *
+ * Specifies the timeout in msec for a discovered router on infra link side.
+ *
+ * This parameter is related to mechanism to check that a discovered router is still active.
+ *
+ * After this timeout elapses since the last received message (a Router or Neighbor Advertisement) from the router,
+ * routing manager will start sending Neighbor Solidification (NS) probes to the router to check that it is still
+ * active.
+ *
+ * This parameter can be considered to large value to practically disable this behavior.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_ROUTER_ACTIVE_CHECK_TIMEOUT
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_ROUTER_ACTIVE_CHECK_TIMEOUT (60 * 1000) // (in msec).
+#endif
+
 #endif // CONFIG_BORDER_ROUTING_H_

--- a/src/core/net/icmp6.hpp
+++ b/src/core/net/icmp6.hpp
@@ -92,6 +92,8 @@ public:
             kTypeEchoReply        = OT_ICMP6_TYPE_ECHO_REPLY,        ///< Echo Reply
             kTypeRouterSolicit    = OT_ICMP6_TYPE_ROUTER_SOLICIT,    ///< Router Solicitation
             kTypeRouterAdvert     = OT_ICMP6_TYPE_ROUTER_ADVERT,     ///< Router Advertisement
+            kTypeNeighborSolicit  = OT_ICMP6_TYPE_NEIGHBOR_SOLICIT,  ///< Neighbor Solicitation
+            kTypeNeighborAdvert   = OT_ICMP6_TYPE_NEIGHBOR_ADVERT,   ///< Neighbor Advertisement
         };
 
         /**

--- a/src/core/net/nd6.cpp
+++ b/src/core/net/nd6.cpp
@@ -269,12 +269,36 @@ exit:
 }
 
 //----------------------------------------------------------------------------------------------------------------------
-// RouterAdvMessage
+// RouterSolicitMessage
 
 RouterSolicitMessage::RouterSolicitMessage(void)
 {
     mHeader.Clear();
     mHeader.SetType(Icmp::Header::kTypeRouterSolicit);
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// NeighborSolicitMessage
+
+NeighborSolicitMessage::NeighborSolicitMessage(void)
+{
+    OT_UNUSED_VARIABLE(mChecksum);
+    OT_UNUSED_VARIABLE(mReserved);
+
+    Clear();
+    mType = Icmp::Header::kTypeNeighborSolicit;
+}
+
+//----------------------------------------------------------------------------------------------------------------------
+// NeighborAdvertMessage
+
+NeighborAdvertMessage::NeighborAdvertMessage(void)
+{
+    OT_UNUSED_VARIABLE(mChecksum);
+    OT_UNUSED_VARIABLE(mReserved);
+
+    Clear();
+    mType = Icmp::Header::kTypeNeighborAdvert;
 }
 
 } // namespace Nd

--- a/src/core/net/nd6.hpp
+++ b/src/core/net/nd6.hpp
@@ -698,6 +698,190 @@ private:
 
 static_assert(sizeof(RouterSolicitMessage) == 8, "invalid RouterSolicitMessage structure");
 
+/**
+ * This class represents a Neighbor Solicitation (NS) message.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class NeighborSolicitMessage : public Clearable<NeighborSolicitMessage>
+{
+public:
+    /**
+     * This constructor initializes the Neighbor Solicitation message.
+     *
+     */
+    NeighborSolicitMessage(void);
+
+    /**
+     * This method indicates whether the Neighbor Solicitation message is valid (proper Type and Code).
+     *
+     * @retval TRUE  If the message is valid.
+     * @retval FALSE If the message is not valid.
+     *
+     */
+    bool IsValid(void) const { return (mType == Icmp::Header::kTypeNeighborSolicit) && (mCode == 0); }
+
+    /**
+     * This method gets the Target Address field.
+     *
+     * @returns The Target Address.
+     *
+     */
+    const Address &GetTargetAddress(void) const { return mTargetAddress; }
+
+    /**
+     * This method sets the Target Address field.
+     *
+     * @param[in] aTargetAddress  The Target Address.
+     *
+     */
+    void SetTargetAddress(const Address &aTargetAddress) { mTargetAddress = aTargetAddress; }
+
+private:
+    // Neighbor Solicitation Message (RFC 4861)
+    //
+    //   0                   1                   2                   3
+    //   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    //  |     Type      |     Code      |          Checksum             |
+    //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    //  |                           Reserved                            |
+    //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    //  |                                                               |
+    //  +                                                               +
+    //  |                                                               |
+    //  +                       Target Address                          +
+    //  |                                                               |
+    //  +                                                               +
+    //  |                                                               |
+    //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    //  |   Options ...
+    //  +-+-+-+-+-+-+-+-+-+-+-+-
+
+    uint8_t  mType;
+    uint8_t  mCode;
+    uint16_t mChecksum;
+    uint32_t mReserved;
+    Address  mTargetAddress;
+} OT_TOOL_PACKED_END;
+
+static_assert(sizeof(NeighborSolicitMessage) == 24, "Invalid NeighborSolicitMessage definition");
+
+/**
+ * This class represents a Neighbor Advertisement (NA) message.
+ *
+ */
+OT_TOOL_PACKED_BEGIN
+class NeighborAdvertMessage : public Clearable<NeighborAdvertMessage>
+{
+public:
+    NeighborAdvertMessage(void);
+
+    /**
+     * This method indicates whether the Neighbor Advertisement message is valid (proper Type and Code).
+     *
+     * @retval TRUE  If the message is valid.
+     * @retval FALSE If the message is not valid.
+     *
+     */
+    bool IsValid(void) const { return (mType == Icmp::Header::kTypeNeighborAdvert) && (mCode == 0); }
+
+    /**
+     * This method indicates whether or not the Router Flag is set in the NA message.
+     *
+     * @retval TRUE   The Router Flag is set.
+     * @retval FALSE  The Router Flag is not set.
+     *
+     */
+    bool IsRouterFlagSet(void) const { return (mFlags & kRouterFlag) != 0; }
+
+    /**
+     * This method sets the Router Flag in the NA message.
+     *
+     */
+    void SetRouterFlag(void) { mFlags |= kRouterFlag; }
+
+    /**
+     * This method indicates whether or not the Solicited Flag is set in the NA message.
+     *
+     * @retval TRUE   The Solicited Flag is set.
+     * @retval FALSE  The Solicited Flag is not set.
+     *
+     */
+    bool IsSolicitedFlagSet(void) const { return (mFlags & kSolicitedFlag) != 0; }
+
+    /**
+     * This method sets the Solicited Flag in the NA message.
+     *
+     */
+    void SetSolicitedFlag(void) { mFlags |= kSolicitedFlag; }
+
+    /**
+     * This method indicates whether or not the Override Flag is set in the NA message.
+     *
+     * @retval TRUE   The Override Flag is set.
+     * @retval FALSE  The Override Flag is not set.
+     *
+     */
+    bool IsOverrideFlagSet(void) const { return (mFlags & kOverrideFlag) != 0; }
+
+    /**
+     * This method sets the Override Flag in the NA message.
+     *
+     */
+    void SetOverrideFlag(void) { mFlags |= kOverrideFlag; }
+
+    /**
+     * This method gets the Target Address field.
+     *
+     * @returns The Target Address.
+     *
+     */
+    const Address &GetTargetAddress(void) const { return mTargetAddress; }
+
+    /**
+     * This method sets the Target Address field.
+     *
+     * @param[in] aTargetAddress  The Target Address.
+     *
+     */
+    void SetTargetAddress(const Address &aTargetAddress) { mTargetAddress = aTargetAddress; }
+
+private:
+    // Neighbor Advertisement Message (RFC 4861)
+    //
+    //   0                   1                   2                   3
+    //   0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+    //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    //  |     Type      |     Code      |          Checksum             |
+    //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    //  |R|S|O|                     Reserved                            |
+    //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    //  |                                                               |
+    //  +                                                               +
+    //  |                                                               |
+    //  +                       Target Address                          +
+    //  |                                                               |
+    //  +                                                               +
+    //  |                                                               |
+    //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+    //  |   Options ...
+    //  +-+-+-+-+-+-+-+-+-+-+-+-
+
+    static constexpr uint8_t kRouterFlag    = (1 << 7);
+    static constexpr uint8_t kSolicitedFlag = (1 << 6);
+    static constexpr uint8_t kOverrideFlag  = (1 << 5);
+
+    uint8_t  mType;
+    uint8_t  mCode;
+    uint16_t mChecksum;
+    uint8_t  mFlags;
+    uint8_t  mReserved[3];
+    Address  mTargetAddress;
+} OT_TOOL_PACKED_END;
+
+static_assert(sizeof(NeighborAdvertMessage) == 24, "Invalid NeighborAdvertMessage definition");
+
 } // namespace Nd
 } // namespace Ip6
 } // namespace ot


### PR DESCRIPTION
This commit adds a new mechanism in `RoutingManager` to periodically
check that discovered routers are still active and operational, so
that if the router providing the favored on-link prefix becomes
offline, we can detect it more quickly (instead of waiting for the
prefix lifetime to expire) and then the BR can start advertising its
own on-link prefix.

Receiving a Router or Neighbor Advertisement message from a router
indicates that it is active. After a timeout interval passes from the
last receive from a router we start sending Neighbor Solidification
(NS) probes to it. This timeout interval can be specified by
newly added build-time OT config parameter (default value is set to
2 minutes). If no response is received after multiple NS attempts, the
router is considered to be inactive and the discovered prefix entries
associated with the router are removed or deprecated.

This commit also updates the unit test for routing manager to validate
the behavior of the newly added mechanism.