### PR TITLE
[harness-simulation] add support for RF enclosure simulation

### DIFF
--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -76,13 +76,13 @@ static otError ProcessExit(void *aContext, uint8_t aArgsLength, char *aArgs[])
     exit(EXIT_SUCCESS);
 }
 
-#if OPENTHREAD_EXAMPLES_SIMULATION && OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0
+#if OPENTHREAD_EXAMPLES_SIMULATION
 extern otError ProcessNodeIdFilter(void *aContext, uint8_t aArgsLength, char *aArgs[]);
 #endif
 
 static const otCliCommand kCommands[] = {
     {"exit", ProcessExit},
-#if OPENTHREAD_EXAMPLES_SIMULATION && OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0
+#if OPENTHREAD_EXAMPLES_SIMULATION
     {"nodeidfilter", ProcessNodeIdFilter},
 #endif
 };

--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -27,8 +27,6 @@
  */
 
 #include <assert.h>
-#include <string.h>
-
 #include <openthread-core-config.h>
 #include <openthread/config.h>
 
@@ -79,52 +77,8 @@ static otError ProcessExit(void *aContext, uint8_t aArgsLength, char *aArgs[])
 }
 
 #if OPENTHREAD_EXAMPLES_SIMULATION && OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0
-extern otError  NodeIdFilterDeny(uint16_t aNodeId);
-extern void     NodeIdFilterClear(void);
-extern uint16_t NodeIdFilterGetNext(uint16_t aNodeId);
-
-static otError ProcessNodeIdFilter(void *aContext, uint8_t aArgsLength, char *aArgs[])
-{
-    OT_UNUSED_VARIABLE(aContext);
-
-    otError error = OT_ERROR_NONE;
-
-    if (aArgsLength == 0)
-    {
-        otCliOutputFormat("Denied Node ID List:\r\n");
-
-        for (uint16_t nodeId = 0; (nodeId = NodeIdFilterGetNext(nodeId));)
-        {
-            otCliOutputFormat("%d\r\n", nodeId);
-        }
-    }
-    else if (!strcmp(aArgs[0], "clear"))
-    {
-        VerifyOrExit(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
-
-        NodeIdFilterClear();
-    }
-    else if (!strcmp(aArgs[0], "deny"))
-    {
-        uint16_t nodeId;
-        char *   endptr;
-
-        VerifyOrExit(aArgsLength == 2, error = OT_ERROR_INVALID_ARGS);
-
-        nodeId = (uint16_t)strtol(aArgs[1], &endptr, 0);
-
-        VerifyOrExit(*endptr == '\0', error = OT_ERROR_INVALID_ARGS);
-        SuccessOrExit(error = NodeIdFilterDeny(nodeId));
-    }
-    else
-    {
-        error = OT_ERROR_INVALID_COMMAND;
-    }
-
-exit:
-    return error;
-}
-#endif // OPENTHREAD_EXAMPLES_SIMULATION && OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0
+extern otError ProcessNodeIdFilter(void *aContext, uint8_t aArgsLength, char *aArgs[]);
+#endif
 
 static const otCliCommand kCommands[] = {
     {"exit", ProcessExit},

--- a/examples/platforms/simulation/platform-simulation.h
+++ b/examples/platforms/simulation/platform-simulation.h
@@ -233,13 +233,15 @@ void otSimSendUartWriteEvent(const uint8_t *aData, uint16_t aLength);
 bool platformRadioIsTransmitPending(void);
 
 /**
- * This function parses an environment variable as an unsigned 16-bit integer if the environment variable exists.
+ * This function parses an environment variable as an unsigned 16-bit integer.
+ * If the environment variable does not exist, this function does nothing.
+ * If it is not a valid integer, this function will terminate the process with an error message.
  *
  * @param[in]   aEnvName  The name of the environment variable.
  * @param[out]  aValue    A pointer to the unsigned 16-bit integer.
  *
  */
-void parseFromEnvAsUInt16(const char *aEnvName, uint16_t *aValue);
+void parseFromEnvAsUint16(const char *aEnvName, uint16_t *aValue);
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 

--- a/examples/platforms/simulation/platform-simulation.h
+++ b/examples/platforms/simulation/platform-simulation.h
@@ -234,6 +234,7 @@ bool platformRadioIsTransmitPending(void);
 
 /**
  * This function parses an environment variable as an unsigned 16-bit integer.
+ *
  * If the environment variable does not exist, this function does nothing.
  * If it is not a valid integer, this function will terminate the process with an error message.
  *

--- a/examples/platforms/simulation/platform-simulation.h
+++ b/examples/platforms/simulation/platform-simulation.h
@@ -232,6 +232,15 @@ void otSimSendUartWriteEvent(const uint8_t *aData, uint16_t aLength);
  */
 bool platformRadioIsTransmitPending(void);
 
+/**
+ * This function parses an environment variable as an unsigned 16-bit integer if the environment variable exists.
+ *
+ * @param[in]   aEnvName  The name of the environment variable.
+ * @param[out]  aValue    A pointer to the unsigned 16-bit integer.
+ *
+ */
+void parseFromEnvAsUInt16(const char *aEnvName, uint16_t *aValue);
+
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 
 /**

--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -174,12 +174,14 @@ static uint8_t sDeniedNodeIdsBitVector[(MAX_NETWORK_SIZE + 7) / 8];
 static bool NodeIdFilterIsConnectable(uint16_t aNodeId)
 {
     uint16_t index = aNodeId - 1;
+
     return (sDeniedNodeIdsBitVector[index / 8] & (0x80 >> (index % 8))) == 0;
 }
 
 static void NodeIdFilterDeny(uint16_t aNodeId)
 {
     uint16_t index = aNodeId - 1;
+
     sDeniedNodeIdsBitVector[index / 8] |= 0x80 >> (index % 8);
 }
 
@@ -194,19 +196,9 @@ otError ProcessNodeIdFilter(void *aContext, uint8_t aArgsLength, char *aArgs[])
 
     otError error = OT_ERROR_NONE;
 
-    if (aArgsLength == 0)
-    {
-        printf("\r\nDenied Node ID List:\r\n");
+    otEXPECT_ACTION(aArgsLength > 0, error = OT_ERROR_INVALID_COMMAND);
 
-        for (uint16_t nodeId = 1; nodeId <= MAX_NETWORK_SIZE; nodeId++)
-        {
-            if (!NodeIdFilterIsConnectable(nodeId))
-            {
-                printf("%d\r\n", nodeId);
-            }
-        }
-    }
-    else if (!strcmp(aArgs[0], "clear"))
+    if (!strcmp(aArgs[0], "clear"))
     {
         otEXPECT_ACTION(aArgsLength == 1, error = OT_ERROR_INVALID_ARGS);
 
@@ -241,7 +233,7 @@ otError ProcessNodeIdFilter(void *aContext, uint8_t aArgsLength, char *aArgs[])
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
-    return OT_ERROR_INVALID_COMMAND;
+    return OT_ERROR_NOT_IMPLEMENTED;
 }
 #endif // OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0
 
@@ -435,9 +427,9 @@ exit:
 void platformRadioInit(void)
 {
 #if OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0
-    parseFromEnvAsUInt16("PORT_BASE", &sPortBase);
+    parseFromEnvAsUint16("PORT_BASE", &sPortBase);
 
-    parseFromEnvAsUInt16("PORT_OFFSET", &sPortOffset);
+    parseFromEnvAsUint16("PORT_OFFSET", &sPortOffset);
     sPortOffset *= (MAX_NETWORK_SIZE + 1);
 
     initFds();
@@ -1390,7 +1382,7 @@ exit:
     return error;
 }
 
-void parseFromEnvAsUInt16(const char *aEnvName, uint16_t *aValue)
+void parseFromEnvAsUint16(const char *aEnvName, uint16_t *aValue)
 {
     char *env = getenv(aEnvName);
 

--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -71,10 +71,12 @@ enum
 
 #if OPENTHREAD_SIMULATION_VIRTUAL_TIME
 extern int      sSockFd;
+extern uint16_t sPortBase;
 extern uint16_t sPortOffset;
 #else
 static int      sTxFd       = -1;
 static int      sRxFd       = -1;
+static uint16_t sPortBase   = 9000;
 static uint16_t sPortOffset = 0;
 static uint16_t sPort       = 0;
 #endif
@@ -165,6 +167,52 @@ static otMacKeyMaterial sNextKey;
 static otRadioKeyType   sKeyType;
 
 static int8_t GetRssi(uint16_t aChannel);
+
+#if OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0
+static uint8_t sDeniedNodeIdsBitVector[(MAX_NETWORK_SIZE + 7) / 8];
+
+static bool NodeIdFilterIsConnectable(uint16_t aNodeId)
+{
+    uint16_t index = aNodeId - 1;
+    return (sDeniedNodeIdsBitVector[index / 8] & (0x80 >> (index % 8))) == 0;
+}
+
+otError NodeIdFilterDeny(uint16_t aNodeId)
+{
+    otError error = OT_ERROR_NONE;
+
+    if (1 <= aNodeId && aNodeId <= MAX_NETWORK_SIZE)
+    {
+        uint16_t index = aNodeId - 1;
+        sDeniedNodeIdsBitVector[index / 8] |= 0x80 >> (index % 8);
+    }
+    else
+    {
+        error = OT_ERROR_INVALID_ARGS;
+    }
+
+    return error;
+}
+
+void NodeIdFilterClear(void)
+{
+    memset(sDeniedNodeIdsBitVector, 0, sizeof(sDeniedNodeIdsBitVector));
+}
+
+uint16_t NodeIdFilterGetNext(uint16_t aNodeId)
+{
+    uint16_t nextNodeId = 0;
+    for (uint16_t i = aNodeId + 1; i <= MAX_NETWORK_SIZE; i++)
+    {
+        if (!NodeIdFilterIsConnectable(i))
+        {
+            nextNodeId = i;
+            break;
+        }
+    }
+    return nextNodeId;
+}
+#endif
 
 static bool IsTimeAfterOrEqual(uint32_t aTimeA, uint32_t aTimeB)
 {
@@ -298,7 +346,7 @@ static void initFds(void)
 
     otEXPECT_ACTION((fd = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP)) != -1, perror("socket(sTxFd)"));
 
-    sPort                    = (uint16_t)(9000 + sPortOffset + gNodeId);
+    sPort                    = (uint16_t)(sPortBase + sPortOffset + gNodeId);
     sockaddr.sin_family      = AF_INET;
     sockaddr.sin_port        = htons(sPort);
     sockaddr.sin_addr.s_addr = inet_addr("127.0.0.1");
@@ -337,7 +385,7 @@ static void initFds(void)
     }
 
     sockaddr.sin_family      = AF_INET;
-    sockaddr.sin_port        = htons((uint16_t)(9000 + sPortOffset));
+    sockaddr.sin_port        = htons((uint16_t)(sPortBase + sPortOffset));
     sockaddr.sin_addr.s_addr = inet_addr(OT_RADIO_GROUP);
 
     otEXPECT_ACTION(bind(fd, (struct sockaddr *)&sockaddr, sizeof(sockaddr)) != -1, perror("bind(sRxFd)"));
@@ -356,24 +404,10 @@ exit:
 void platformRadioInit(void)
 {
 #if OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0
-    char *offset;
+    parseFromEnvAsUInt16("PORT_BASE", &sPortBase);
 
-    offset = getenv("PORT_OFFSET");
-
-    if (offset)
-    {
-        char *endptr;
-
-        sPortOffset = (uint16_t)strtol(offset, &endptr, 0);
-
-        if (*endptr != '\0')
-        {
-            fprintf(stderr, "Invalid PORT_OFFSET: %s\n", offset);
-            exit(EXIT_FAILURE);
-        }
-
-        sPortOffset *= (MAX_NETWORK_SIZE + 1);
-    }
+    parseFromEnvAsUInt16("PORT_OFFSET", &sPortOffset);
+    sPortOffset *= (MAX_NETWORK_SIZE + 1);
 
     initFds();
 #endif // OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0
@@ -829,7 +863,10 @@ void platformRadioProcess(otInstance *aInstance, const fd_set *aReadFdSet, const
 
         if (rval > 0)
         {
-            if (sockaddr.sin_port != htons(sPort))
+            uint16_t srcPort   = ntohs(sockaddr.sin_port);
+            uint16_t srcNodeId = srcPort - sPortOffset - sPortBase;
+
+            if (NodeIdFilterIsConnectable(srcNodeId) && srcPort != sPort)
             {
                 sReceiveFrame.mLength = (uint16_t)(rval - 1);
 
@@ -847,7 +884,7 @@ void platformRadioProcess(otInstance *aInstance, const fd_set *aReadFdSet, const
             exit(EXIT_FAILURE);
         }
     }
-#endif
+#endif // OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0
     if (platformRadioIsTransmitPending())
     {
         radioSendMessage(aInstance);
@@ -870,7 +907,7 @@ void radioTransmit(struct RadioMessage *aMessage, const struct otRadioFrame *aFr
     sockaddr.sin_family = AF_INET;
     inet_pton(AF_INET, OT_RADIO_GROUP, &sockaddr.sin_addr);
 
-    sockaddr.sin_port = htons((uint16_t)(9000 + sPortOffset));
+    sockaddr.sin_port = htons((uint16_t)(sPortBase + sPortOffset));
     rval =
         sendto(sTxFd, (const char *)aMessage, 1 + aFrame->mLength, 0, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
 
@@ -1320,4 +1357,22 @@ otError otPlatRadioGetRegion(otInstance *aInstance, uint16_t *aRegionCode)
     *aRegionCode = sRegionCode;
 exit:
     return error;
+}
+
+void parseFromEnvAsUInt16(const char *aEnvName, uint16_t *aValue)
+{
+    char *env = getenv(aEnvName);
+
+    if (env)
+    {
+        char *endptr;
+
+        *aValue = (uint16_t)strtol(env, &endptr, 0);
+
+        if (*endptr != '\0')
+        {
+            fprintf(stderr, "Invalid %s: %s\n", aEnvName, env);
+            exit(EXIT_FAILURE);
+        }
+    }
 }

--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -234,6 +234,15 @@ otError ProcessNodeIdFilter(void *aContext, uint8_t aArgsLength, char *aArgs[])
 exit:
     return error;
 }
+#else
+otError ProcessNodeIdFilter(void *aContext, uint8_t aArgsLength, char *aArgs[])
+{
+    OT_UNUSED_VARIABLE(aContext);
+    OT_UNUSED_VARIABLE(aArgsLength);
+    OT_UNUSED_VARIABLE(aArgs);
+
+    return OT_ERROR_INVALID_COMMAND;
+}
 #endif // OPENTHREAD_SIMULATION_VIRTUAL_TIME == 0
 
 static bool IsTimeAfterOrEqual(uint32_t aTimeA, uint32_t aTimeB)

--- a/examples/platforms/simulation/virtual_time/platform-sim.c
+++ b/examples/platforms/simulation/virtual_time/platform-sim.c
@@ -180,9 +180,9 @@ static void socket_init(void)
     memset(&sockaddr, 0, sizeof(sockaddr));
     sockaddr.sin_family = AF_INET;
 
-    parseFromEnvAsUInt16("PORT_BASE", &sPortBase);
+    parseFromEnvAsUint16("PORT_BASE", &sPortBase);
 
-    parseFromEnvAsUInt16("PORT_OFFSET", &sPortOffset);
+    parseFromEnvAsUint16("PORT_OFFSET", &sPortOffset);
     sPortOffset *= (MAX_NETWORK_SIZE + 1);
 
     sockaddr.sin_port        = htons((uint16_t)(sPortBase + sPortOffset + gNodeId));

--- a/include/openthread/cli.h
+++ b/include/openthread/cli.h
@@ -52,9 +52,9 @@ extern "C" {
 typedef struct otCliCommand
 {
     const char *mName; ///< A pointer to the command string.
-    void (*mCommand)(void *  aContext,
-                     uint8_t aArgsLength,
-                     char *  aArgs[]); ///< A function pointer to process the command.
+    otError (*mCommand)(void *  aContext,
+                        uint8_t aArgsLength,
+                        char *  aArgs[]); ///< A function pointer to process the command.
 } otCliCommand;
 
 /**

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (242)
+#define OPENTHREAD_API_VERSION (243)
 
 /**
  * @addtogroup api-instance

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -299,8 +299,7 @@ otError Interpreter::ProcessUserCommands(Arg aArgs[])
             char *args[kMaxArgs];
 
             Arg::CopyArgsToStringArray(aArgs, args);
-            mUserCommands[i].mCommand(mUserCommandsContext, Arg::GetArgsLength(aArgs) - 1, args + 1);
-            error = OT_ERROR_NONE;
+            error = mUserCommands[i].mCommand(mUserCommandsContext, Arg::GetArgsLength(aArgs) - 1, args + 1);
             break;
         }
     }

--- a/src/posix/main.c
+++ b/src/posix/main.c
@@ -325,17 +325,19 @@ void otPlatReset(otInstance *aInstance)
     assert(false);
 }
 
-static void ProcessNetif(void *aContext, uint8_t aArgsLength, char *aArgs[])
+static otError ProcessNetif(void *aContext, uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aContext);
     OT_UNUSED_VARIABLE(aArgsLength);
     OT_UNUSED_VARIABLE(aArgs);
 
     otCliOutputFormat("%s:%u\r\n", otSysGetThreadNetifName(), otSysGetThreadNetifIndex());
+
+    return OT_ERROR_NONE;
 }
 
 #if !OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE
-static void ProcessExit(void *aContext, uint8_t aArgsLength, char *aArgs[])
+static otError ProcessExit(void *aContext, uint8_t aArgsLength, char *aArgs[])
 {
     OT_UNUSED_VARIABLE(aContext);
     OT_UNUSED_VARIABLE(aArgsLength);

--- a/src/posix/platform/virtual_time.cpp
+++ b/src/posix/platform/virtual_time.cpp
@@ -48,37 +48,17 @@ static const int kMaxNetworkSize = 33;      ///< Well-known ID used by a simulat
 static const int kBasePort       = 18000;   ///< This base port for posix app simulation.
 static const int kUsPerSecond    = 1000000; ///< Number of microseconds per second.
 
-static uint64_t sNow        = 0;    ///< Time of simulation.
-static int      sSockFd     = -1;   ///< Socket used to communicating with simulator.
-static uint16_t sPortBase   = 9000; ///< Port base for simulation.
-static uint16_t sPortOffset = 0;    ///< Port offset for simulation.
+static uint64_t sNow        = 0;  ///< Time of simulation.
+static int      sSockFd     = -1; ///< Socket used to communicating with simulator.
+static uint16_t sPortOffset = 0;  ///< Port offset for simulation.
 
 void virtualTimeInit(uint16_t aNodeId)
 {
     struct sockaddr_in sockaddr;
-    char *             base;
     char *             offset;
 
     memset(&sockaddr, 0, sizeof(sockaddr));
     sockaddr.sin_family = AF_INET;
-
-    base = getenv("PORT_BASE");
-
-    if (base)
-    {
-        char *endptr;
-
-        sPortBase = (uint16_t)strtol(base, &endptr, 0);
-
-        if (*endptr != '\0')
-        {
-            const uint8_t kMsgSize = 40;
-            char          msg[kMsgSize];
-
-            snprintf(msg, sizeof(msg), "Invalid PORT_BASE: %s", base);
-            DieNowWithMessage(msg, OT_EXIT_INVALID_ARGUMENTS);
-        }
-    }
 
     offset = getenv("PORT_OFFSET");
 
@@ -133,7 +113,7 @@ static void virtualTimeSendEvent(struct VirtualTimeEvent *aEvent, size_t aLength
     memset(&sockaddr, 0, sizeof(sockaddr));
     sockaddr.sin_family = AF_INET;
     inet_pton(AF_INET, "127.0.0.1", &sockaddr.sin_addr);
-    sockaddr.sin_port = htons(sPortBase + sPortOffset);
+    sockaddr.sin_port = htons(9000 + sPortOffset);
 
     rval = sendto(sSockFd, aEvent, aLength, 0, (struct sockaddr *)&sockaddr, sizeof(sockaddr));
 

--- a/tools/harness-simulation/harness/Thread_Harness/Sniffer/SimSniffer.py
+++ b/tools/harness-simulation/harness/Thread_Harness/Sniffer/SimSniffer.py
@@ -29,6 +29,7 @@
 
 import grpc
 import ipaddress
+import itertools
 import json
 import netifaces
 import select
@@ -38,6 +39,9 @@ import time
 import win32api
 import winreg as wr
 
+from GRLLibs.UtilityModules.ModuleHelper import ModuleHelper
+from GRLLibs.UtilityModules.SnifferManager import SnifferManager
+from GRLLibs.UtilityModules.TopologyManager import TopologyManager
 from Sniffer.ISniffer import ISniffer
 from THCI.OpenThread import watched
 from simulation.Sniffer.proto import sniffer_pb2
@@ -56,7 +60,79 @@ IPPROTO_IPV6 = 41
 WINREG_KEY = r'SYSTEM\CurrentControlSet\Control\Network\{4d36e972-e325-11ce-bfc1-08002be10318}'
 
 
+# When Harness requires an RF shield box, it will pop up a message box via `ModuleHelper.UIMsgBox`
+# Replace the function to add and remove an RF enclosure simulation automatically without popping up a window
+def UIMsgBoxDecorator(UIMsgBox, replaceFuncs):
+
+    @staticmethod
+    def UIMsgBoxWrapper(msg='Confirm ??',
+                        title='User Input Required',
+                        inputRequired=False,
+                        default='',
+                        choices=None,
+                        timeout=None,
+                        isPrompt=False):
+        func = replaceFuncs.get((msg, title))
+        if func is None:
+            return UIMsgBox(msg, title, inputRequired, default, choices, timeout, isPrompt)
+        else:
+            return func()
+
+    return UIMsgBoxWrapper
+
+
+class DeviceManager:
+
+    def __init__(self):
+        deviceManager = TopologyManager.m_DeviceManager
+        self._devices = {'DUT': deviceManager.AutoDUTDeviceObject.THCI_Object}
+        for device_obj in deviceManager.DeviceList.values():
+            if device_obj.IsDeviceUsed:
+                self._devices[device_obj.DeviceTopologyInfo] = device_obj.THCI_Object
+
+    def __getitem__(self, deviceName):
+        device = self._devices.get(deviceName)
+        if device is None:
+            raise KeyError('Device Name "%s" not found' % deviceName)
+        return device
+
+
+class RFEnclosureManager:
+
+    def __init__(self, deviceNames1, deviceNames2, snifferPartitionId):
+        self.deviceNames1 = deviceNames1
+        self.deviceNames2 = deviceNames2
+        self.snifferPartitionId = snifferPartitionId
+
+    def placeRFEnclosure(self):
+        devices = DeviceManager()
+        self._partition1 = [devices[role] for role in self.deviceNames1]
+        self._partition2 = [devices[role] for role in self.deviceNames2]
+        sniffer_denied_partition = self._partition1 if self.snifferPartitionId == 2 else self._partition2
+
+        for device1 in self._partition1:
+            for device2 in self._partition2:
+                device1.addBlockedNodeId(device2.node_id)
+                device2.addBlockedNodeId(device1.node_id)
+
+        for sniffer in SnifferManager.SnifferObjects.values():
+            if sniffer.isSnifferCapturing():
+                sniffer.filterNodes(device.node_id for device in sniffer_denied_partition)
+
+    def removeRFEnclosure(self):
+        for device in itertools.chain(self._partition1, self._partition2):
+            device.clearBlockedNodeIds()
+
+        for sniffer in SnifferManager.SnifferObjects.values():
+            if sniffer.isSnifferCapturing():
+                sniffer.filterNodes(())
+
+        self._partition1 = None
+        self._partition2 = None
+
+
 class SimSniffer(ISniffer):
+    replaced_msgbox = False
 
     @watched
     def __init__(self, **kwargs):
@@ -66,11 +142,46 @@ class SimSniffer(ISniffer):
         self._local_pcapng_location = None
 
         if self.addr_port is not None:
+            # Replace `ModuleHelper.UIMsgBox` only when simulation devices exist
+            self._replaceMsgBox()
+
             self._sniffer = grpc.insecure_channel(self.addr_port)
             self._stub = sniffer_pb2_grpc.SnifferStub(self._sniffer)
 
             # Close the sniffer only when Harness exits
             win32api.SetConsoleCtrlHandler(self.__disconnect, True)
+
+    @watched
+    def _replaceMsgBox(self):
+        # Replace the function only once
+        if SimSniffer.replaced_msgbox:
+            return
+        SimSniffer.replaced_msgbox = True
+
+        test_9_2_9_leader = RFEnclosureManager(['Router_1', 'Router_2'], ['DUT', 'Commissioner'], 1)
+        test_9_2_9_router = RFEnclosureManager(['DUT', 'Router_2'], ['Leader', 'Commissioner'], 1)
+        test_9_2_10_router = RFEnclosureManager(['Leader', 'Commissioner'], ['DUT', 'MED_1', 'SED_1'], 2)
+
+        # Alter the behavior of `ModuleHelper.UIMsgBox` only when it comes to the following test cases:
+        #   - Leader 9.2.9
+        #   - Router 9.2.9
+        #   - Router 9.2.10
+        ModuleHelper.UIMsgBox = UIMsgBoxDecorator(
+            ModuleHelper.UIMsgBox,
+            replaceFuncs={
+                ("Place [Router1, Router2 and Sniffer] <br/> or <br/>[DUT and Commissioner] <br/>in an RF enclosure ", "Shield Devices"):
+                    test_9_2_9_leader.placeRFEnclosure,
+                ("Remove [Router1, Router2 and Sniffer] <br/> or <br/>[DUT and Commissioner] <br/>from RF enclosure ", "Unshield Devices"):
+                    test_9_2_9_leader.removeRFEnclosure,
+                ("Place [DUT,Router2 and sniffer] <br/> or <br/>[Leader and Commissioner] <br/>in an RF enclosure ", "Shield Devices"):
+                    test_9_2_9_router.placeRFEnclosure,
+                ("Remove [DUT, Router2 and sniffer] <br/> or <br/>[Leader and Commissioner] <br/>from RF enclosure ", "Unshield Devices"):
+                    test_9_2_9_router.removeRFEnclosure,
+                ("Place the <br/> [Leader and Commissioner] devices <br/> in an RF enclosure ", "Shield Devices"):
+                    test_9_2_10_router.placeRFEnclosure,
+                ("Remove <br/>[Leader and Commissioner] <br/>from RF enclosure ", "Unshield Devices"):
+                    test_9_2_10_router.removeRFEnclosure,
+            })
 
     def __repr__(self):
         return '%r' % self.__dict__
@@ -163,6 +274,18 @@ class SimSniffer(ISniffer):
             f.write(response.pcap_content)
 
         self.is_active = False
+
+    @watched
+    def filterNodes(self, nodeids):
+        if not self.is_active:
+            return
+
+        request = sniffer_pb2.FilterNodesRequest()
+        request.nodeids.extend(nodeids)
+
+        response = self._stub.FilterNodes(request)
+        if response.status != sniffer_pb2.OK:
+            raise RuntimeError('filterNodes error: %s' % sniffer_pb2.Status.Name(response.status))
 
     def __disconnect(self, dwCtrlType):
         if self._sniffer is not None:

--- a/tools/harness-simulation/harness/Thread_Harness/THCI/OpenThread_BR_Sim.py
+++ b/tools/harness-simulation/harness/Thread_Harness/THCI/OpenThread_BR_Sim.py
@@ -123,6 +123,7 @@ class OpenThread_BR_Sim(OpenThread_BR):
 
         self.docker_name, self.ssh_ip = discovery_add.split('@')
         self.tag, self.node_id = self.docker_name.split('_')
+        self.node_id = int(self.node_id)
         # Let it crash if it is an invalid IP address
         ipaddress.ip_address(self.ssh_ip)
 

--- a/tools/harness-simulation/harness/Thread_Harness/THCI/OpenThread_Sim.py
+++ b/tools/harness-simulation/harness/Thread_Harness/THCI/OpenThread_Sim.py
@@ -155,16 +155,17 @@ class OpenThread_Sim(OpenThreadTHCI, IThci):
 
         prefix, self.ssh_ip = discovery_add.split('@')
         self.tag, self.node_id = prefix.split('_')
+        self.node_id = int(self.node_id)
         # Let it crash if it is an invalid IP address
         ipaddress.ip_address(self.ssh_ip)
 
         # Do not use `os.path.join` as it uses backslash as the separator on Windows
+        global config
         self.device = '/'.join([config['ot_path'], ot_subpath[self.tag], 'examples/apps/cli/ot-cli-ftd'])
 
         self.connectType = 'ip'
         self.telnetIp = self.port = discovery_add
 
-        global config
         ssh = config['ssh']
         self.telnetPort = ssh['port']
         self.telnetUsername = ssh['username']

--- a/tools/harness-simulation/posix/launch_testbed.py
+++ b/tools/harness-simulation/posix/launch_testbed.py
@@ -109,7 +109,7 @@ def advertise_sniffers(s: socket.socket, dst, add: str, ports: Iterable[int]):
         _advertise(s, dst, info)
 
 
-def start_sniffer(addr: str, port: int, ot_path: str) -> subprocess.Popen:
+def start_sniffer(addr: str, port: int, ot_path: str, max_nodes_num: int) -> subprocess.Popen:
     if isinstance(ipaddress.ip_address(addr), ipaddress.IPv6Address):
         server = f'[{addr}]:{port}'
     else:
@@ -117,7 +117,11 @@ def start_sniffer(addr: str, port: int, ot_path: str) -> subprocess.Popen:
 
     cmd = [
         'python3',
-        os.path.join(ot_path, 'tools/harness-simulation/posix/sniffer_sim/sniffer.py'), '--grpc-server', server
+        os.path.join(ot_path, 'tools/harness-simulation/posix/sniffer_sim/sniffer.py'),
+        '--grpc-server',
+        server,
+        '--max-nodes-num',
+        str(max_nodes_num),
     ]
     logging.info('Executing command:  %s', ' '.join(cmd))
     return subprocess.Popen(cmd)
@@ -172,7 +176,7 @@ def main():
     sniffer_server_port_base = config['sniffer']['server_port_base']
     sniffer_procs = []
     for i in range(sniffer_num):
-        sniffer_procs.append(start_sniffer(addr, i + sniffer_server_port_base, ot_path))
+        sniffer_procs.append(start_sniffer(addr, i + sniffer_server_port_base, ot_path, max_nodes_num))
 
     # OTBR firewall scripts create rules inside the Docker container
     # Run modprobe to load the kernel modules for iptables

--- a/tools/harness-simulation/posix/simulation.conf
+++ b/tools/harness-simulation/posix/simulation.conf
@@ -1,5 +1,5 @@
 {
-    "ot_path": "/home/pi/work/src/openthread-pr",
+    "ot_path": "/home/pi/repo/openthread",
     "ot_build": {
         "max_number": 64,
         "ot": [

--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -3259,6 +3259,16 @@ class OpenThreadTHCI(object):
     def setVrCheckSkip(self):
         self.__executeCommand("tvcheck disable")
 
+    @API
+    def addBlockedNodeId(self, node_id):
+        cmd = 'nodeidfilter deny %d' % node_id
+        self.__executeCommand(cmd)
+
+    @API
+    def clearBlockedNodeIds(self):
+        cmd = 'nodeidfilter clear'
+        self.__executeCommand(cmd)
+
 
 class OpenThread(OpenThreadTHCI, IThci):
 


### PR DESCRIPTION
This commit adds support for RF enclosure simulation. It can pass *Leader 9.2.9*, *Router 9.2.9* and *Router 9.2.10* in *Thread Test Harness v56.0* now.