### PR TITLE
[util] remove default RTT include dir

### DIFF
--- a/examples/platforms/utils/CMakeLists.txt
+++ b/examples/platforms/utils/CMakeLists.txt
@@ -45,7 +45,6 @@ target_include_directories(openthread-platform-utils PRIVATE
     $<TARGET_PROPERTY:ot-config,INTERFACE_INCLUDE_DIRECTORIES>
     ${PROJECT_SOURCE_DIR}/examples/platforms
     ${PROJECT_SOURCE_DIR}/examples/platforms/utils
-    ${PROJECT_SOURCE_DIR}/third_party/jlink/SEGGER_RTT_V640/RTT
 )
 
 # Provide a static library implementation of platform-utils for non-cmake platforms

--- a/third_party/jlink/CMakeLists.txt
+++ b/third_party/jlink/CMakeLists.txt
@@ -34,3 +34,7 @@ add_library(jlinkrtt
 target_include_directories(jlinkrtt PRIVATE
     ${PROJECT_SOURCE_DIR}/include
 )
+
+target_include_directories(openthread-platform-utils PRIVATE
+    ${PROJECT_SOURCE_DIR}/third_party/jlink/SEGGER_RTT_V640/RTT
+)


### PR DESCRIPTION
For users with their own RTT libs/configs, this change allows users to include their own RTT config header by adding it to the `openthread-platform-utils`
```cmake
target_include_directories(openthread-platform-utils PUBLIC <path_to_my_SEGGER_RTT_Conf.h>)
```

To users of the `jlinkrtt` target, nothing will change.

Without this change, users don't have flexibility to define their own configs. Example: https://github.com/openthread/ot-efr32/runs/7967166697?check_suite_focus=true#step:8:359
```shell
[4/246] Building C object openthread/examples/platforms/utils/CMakeFiles/openthread-platform-utils.dir/logging_rtt.c.obj
In file included from /home/runner/work/ot-efr32/ot-efr32/third_party/silabs/gecko_sdk/util/third_party/segger/systemview/SEGGER/SEGGER_RTT.h:60,
                 from /home/runner/work/ot-efr32/ot-efr32/openthread/examples/platforms/utils/logging_rtt.c:42:
/home/runner/work/ot-efr32/ot-efr32/openthread/third_party/jlink/SEGGER_RTT_V640/RTT/SEGGER_RTT_Conf.h:80: warning: "BUFFER_SIZE_UP" redefined
   80 | #define BUFFER_SIZE_UP                            (1024)  // Size of the buffer for terminal output of target, up to host (Default: 1k)
      | 
<command-line>: note: this is the location of the previous definition
In file included from /home/runner/work/ot-efr32/ot-efr32/third_party/silabs/gecko_sdk/util/third_party/segger/systemview/SEGGER/SEGGER_RTT.h:60,
                 from /home/runner/work/ot-efr32/ot-efr32/openthread/examples/platforms/utils/logging_rtt.c:42:
/home/runner/work/ot-efr32/ot-efr32/openthread/third_party/jlink/SEGGER_RTT_V640/RTT/SEGGER_RTT_Conf.h:81: warning: "BUFFER_SIZE_DOWN" redefined
   81 | #define BUFFER_SIZE_DOWN                          (16)    // Size of the buffer for terminal input to target from host (Usually keyboard input) (Default: 16)
      | 
<command-line>: note: this is the location of the previous definition

```