### PR TITLE
[link-metrics] fix reading of Report sub-tlv from message

### DIFF
--- a/src/core/thread/link_metrics.cpp
+++ b/src/core/thread/link_metrics.cpp
@@ -439,7 +439,7 @@ void LinkMetrics::HandleReport(const Message &     aMessage,
             VerifyOrExit(!hasStatus, error = kErrorDrop);
 
             // Read the report sub-TLV assuming minimum length
-            SuccessOrExit(error = Tlv::ReadTlv(aMessage, offset, &reportTlv, ReportSubTlv::kMinLength));
+            SuccessOrExit(error = aMessage.Read(offset, &reportTlv, sizeof(Tlv) + ReportSubTlv::kMinLength));
             VerifyOrExit(reportTlv.IsValid(), error = kErrorParse);
             hasReport = true;
 


### PR DESCRIPTION

---

- Unlike `Tlv::FindTlv()` methods, `Tlv::ReadTlv()` only reads the TLV value (not the full TLV).
- May be safer to rename this to `ReadTlvValue()`. 
