### PR TITLE
[tlvs] rename method to `ReadTlvValue()` from `ReadTlv()`

### DIFF
--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -180,7 +180,7 @@ template <typename UintType> Error Tlv::ReadUintTlv(const Message &aMessage, uin
 {
     Error error;
 
-    SuccessOrExit(error = ReadTlv(aMessage, aOffset, &aValue, sizeof(aValue)));
+    SuccessOrExit(error = ReadTlvValue(aMessage, aOffset, &aValue, sizeof(aValue)));
     aValue = Encoding::BigEndian::HostSwap<UintType>(aValue);
 
 exit:
@@ -192,7 +192,7 @@ template Error Tlv::ReadUintTlv<uint8_t>(const Message &aMessage, uint16_t aOffs
 template Error Tlv::ReadUintTlv<uint16_t>(const Message &aMessage, uint16_t aOffset, uint16_t &aValue);
 template Error Tlv::ReadUintTlv<uint32_t>(const Message &aMessage, uint16_t aOffset, uint32_t &aValue);
 
-Error Tlv::ReadTlv(const Message &aMessage, uint16_t aOffset, void *aValue, uint8_t aMinLength)
+Error Tlv::ReadTlvValue(const Message &aMessage, uint16_t aOffset, void *aValue, uint8_t aMinLength)
 {
     Error error = kErrorNone;
     Tlv   tlv;

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -175,7 +175,7 @@ public:
     Error AppendTo(Message &aMessage) const;
 
     /**
-     * This static method reads a TLV in a message at a given offset expecting a minimum length for the value.
+     * This static method reads a TLV's value in a message at a given offset expecting a minimum length for the value.
      *
      * @param[in]   aMessage    The message to read from.
      * @param[in]   aOffset     The offset into the message pointing to the start of the TLV.
@@ -186,7 +186,7 @@ public:
      * @retval kErrorParse       The TLV was not well-formed and could not be parsed.
      *
      */
-    static Error ReadTlv(const Message &aMessage, uint16_t aOffset, void *aValue, uint8_t aMinLength);
+    static Error ReadTlvValue(const Message &aMessage, uint16_t aOffset, void *aValue, uint8_t aMinLength);
 
     /**
      * This static method reads a simple TLV with a single non-integral value in a message at a given offset.
@@ -204,7 +204,7 @@ public:
     template <typename SimpleTlvType>
     static Error Read(const Message &aMessage, uint16_t aOffset, typename SimpleTlvType::ValueType &aValue)
     {
-        return ReadTlv(aMessage, aOffset, &aValue, sizeof(aValue));
+        return ReadTlvValue(aMessage, aOffset, &aValue, sizeof(aValue));
     }
 
     /**

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -358,7 +358,7 @@ void DiscoverScanner::HandleDiscoveryResponse(Mle::RxInfo &aRxInfo) const
 
                 steeringData.Init(dataLength);
 
-                SuccessOrExit(error = Tlv::ReadTlv(aRxInfo.mMessage, offset, steeringData.GetData(), dataLength));
+                SuccessOrExit(error = Tlv::ReadTlvValue(aRxInfo.mMessage, offset, steeringData.GetData(), dataLength));
 
                 if (mEnableFiltering)
                 {


### PR DESCRIPTION
This commit renames the method from `ReadTlv()` to `ReadTlvValue()`
to emphasize that it read the TLV value only (unlike `FindTlv()` helper
methods which find and read the whole TLV).

----

Follow up from https://github.com/openthread/openthread/pull/8099 and contains its commit.
