### PR TITLE
[ip6] fix packets not being forwarded outside of Thread

### DIFF
--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -227,7 +227,10 @@ public:
      * @retval kErrorParse    Encountered a malformed header when processing the message.
      *
      */
-    Error HandleDatagram(Message &aMessage, MessageOrigin aOrigin, const void *aLinkMessageInfo = nullptr);
+    Error HandleDatagram(Message &     aMessage,
+                         MessageOrigin aOrigin,
+                         const void *  aLinkMessageInfo = nullptr,
+                         bool          aIsReassembled   = false);
 
     /**
      * This method registers a callback to provide received raw IPv6 datagrams.


### PR DESCRIPTION
Two changes made together broke fragmented packets handling:
Some time ago forwarding packets outside of thread was limited to 1280 bytes
Recently forwarding IP packet fragments was disabled.
This makes it not forward packet fragments nor fully assembled packets.
According to later change author this was to prevent packets from being handled
twice.
To fix this, forwarding of IP fragments was restored and instead forwarding of
reassembled frames was disabled regardless of the frame size. This approach
should save the need of fragmenting already reassembled packets to fit
into the OPENTHREAD_CONFIG_IP6_MAX_DATAGRAM_LENGTH.

Signed-off-by: Marek Porwisz <marek.porwisz@nordicsemi.no>