### PR TITLE
[link-metrics] add blocking CLI query command and enhance tests

### DIFF
--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -547,6 +547,10 @@ private:
 #if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE
     bool mLocateInProgress : 1;
 #endif
+
+#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE
+    bool mLinkMetricsQueryInProgress : 1;
+#endif
 };
 
 // Specializations of `FormatStringFor<ValueType>()`

--- a/tests/scripts/thread-cert/v1_2_LowPower_7_2_01_ForwardTrackingSeries.py
+++ b/tests/scripts/thread-cert/v1_2_LowPower_7_2_01_ForwardTrackingSeries.py
@@ -111,9 +111,10 @@ class LowPower_7_2_01_ForwardTrackingSeries(thread_cert.TestCase):
         self.simulator.go(30)
 
         # Step 7 - SED_1 sends an MLE Data Request to retrieve aggregated Forward Series Results
-        self.nodes[SED_1].link_metrics_query_forward_tracking_series(leader_addr, SERIES_ID)
+        result = self.nodes[SED_1].link_metrics_query_forward_tracking_series(leader_addr, SERIES_ID, 'block')
+        self.assertIn("PDU Counter", result)
 
-        self.simulator.go(5)
+        #self.simulator.go(5)
 
         # Step 9 - SED_1 clears the Forward Tracking Series
         # Forward Series Flags = 0x00:
@@ -144,9 +145,8 @@ class LowPower_7_2_01_ForwardTrackingSeries(thread_cert.TestCase):
             self.simulator.go(1)
 
         # Step 19 - SSED_1 sends an MLE Data Request to retrieve aggregated Forward Series Results
-        self.nodes[SSED_1].link_metrics_query_forward_tracking_series(leader_addr, SERIES_ID_2)
-
-        self.simulator.go(5)
+        result = self.nodes[SSED_1].link_metrics_query_forward_tracking_series(leader_addr, SERIES_ID_2, 'block')
+        self.assertIn("Margin", result)
 
         # Step 21 - SSED_1 clears the Forward Series Link Metrics
         # Forward Series Flags = 0x00:
@@ -157,9 +157,9 @@ class LowPower_7_2_01_ForwardTrackingSeries(thread_cert.TestCase):
         self.simulator.go(5)
 
         # Step 23 - SSED_1 sends an MLE Data Request to retrieve aggregated Forward Series Results
-        self.nodes[SSED_1].link_metrics_query_forward_tracking_series(leader_addr, SERIES_ID_2)
-
-        self.simulator.go(5)
+        result = self.nodes[SSED_1].link_metrics_query_forward_tracking_series(leader_addr, SERIES_ID_2, 'block')
+        self.assertIn('Status', result)
+        self.assertEqual(result['Status'], 'Series ID not recognized')
 
     def verify(self, pv):
         pkts = pv.pkts

--- a/tests/scripts/thread-cert/v1_2_test_single_probe.py
+++ b/tests/scripts/thread-cert/v1_2_test_single_probe.py
@@ -70,40 +70,48 @@ class SSED_SingleProbe(thread_cert.TestCase):
         leader_messages = self.simulator.get_messages_sent_by(LEADER)
 
         # SSED_1 sends a Single Probe Link Metrics for L2 PDU count using MLE Data Request
-        self.nodes[SSED_1].link_metrics_query_single_probe(leader_addr, 'p')
-        self.simulator.go(5)
+        result = self.nodes[SSED_1].link_metrics_query_single_probe(leader_addr, 'p', 'block')
+        self.assertIn('PDU Counter', result)
+        self.assertEqual(len(result), 1)
 
         leader_messages = self.simulator.get_messages_sent_by(LEADER)
         msg = leader_messages.next_mle_message(mle.CommandType.DATA_RESPONSE)
         msg.assertMleMessageContainsTlv(mle.LinkMetricsReport)
 
         # SSED_1 sends a Single Probe Link Metrics for L2 LQI using MLE Data Request
-        self.nodes[SSED_1].link_metrics_query_single_probe(leader_addr, 'q')
-        self.simulator.go(5)
+        result = self.nodes[SSED_1].link_metrics_query_single_probe(leader_addr, 'q', 'block')
+        self.assertIn('LQI', result)
+        self.assertEqual(len(result), 1)
 
         leader_messages = self.simulator.get_messages_sent_by(LEADER)
         msg = leader_messages.next_mle_message(mle.CommandType.DATA_RESPONSE)
         msg.assertMleMessageContainsTlv(mle.LinkMetricsReport)
 
         # SSED_1 sends a Single Probe Link Metrics for Link Margin using MLE Data Request
-        self.nodes[SSED_1].link_metrics_query_single_probe(leader_addr, 'm')
-        self.simulator.go(5)
+        result = self.nodes[SSED_1].link_metrics_query_single_probe(leader_addr, 'm', 'block')
+        self.assertIn('Margin', result)
+        self.assertEqual(len(result), 1)
 
         leader_messages = self.simulator.get_messages_sent_by(LEADER)
         msg = leader_messages.next_mle_message(mle.CommandType.DATA_RESPONSE)
         msg.assertMleMessageContainsTlv(mle.LinkMetricsReport)
 
         # SSED_1 sends a Single Probe Link Metrics for Link Margin using MLE Data Request
-        self.nodes[SSED_1].link_metrics_query_single_probe(leader_addr, 'r')
-        self.simulator.go(5)
+        result = self.nodes[SSED_1].link_metrics_query_single_probe(leader_addr, 'r', 'block')
+        self.assertIn('RSSI', result)
+        self.assertEqual(len(result), 1)
 
         leader_messages = self.simulator.get_messages_sent_by(LEADER)
         msg = leader_messages.next_mle_message(mle.CommandType.DATA_RESPONSE)
         msg.assertMleMessageContainsTlv(mle.LinkMetricsReport)
 
         # SSED_1 sends a Single Probe Link Metrics for all metrics using MLE Data Request
-        self.nodes[SSED_1].link_metrics_query_single_probe(leader_addr, 'pqmr')
-        self.simulator.go(5)
+        result = self.nodes[SSED_1].link_metrics_query_single_probe(leader_addr, 'pqmr', 'block')
+        self.assertIn('PDU Counter', result)
+        self.assertIn('LQI', result)
+        self.assertIn('Margin', result)
+        self.assertIn('RSSI', result)
+        self.assertEqual(len(result), 4)
 
         leader_messages = self.simulator.get_messages_sent_by(LEADER)
         msg = leader_messages.next_mle_message(mle.CommandType.DATA_RESPONSE)


### PR DESCRIPTION
This commit updates CLI `linkmetrics query` command to allow it
to be used in blocking mode (wait for response to query). This
is then used in different tests to validate the `LinkMetrics`
module behavior. In particular, `v1_2_test_single_probe` and
`v1_2_LowPower_7_2_01_ForwardTrackingSeries` are updated to
validate that the received query report message is correctly
parsed.