### PR TITLE
[discover-scanner] invoke handler when scan is done from a tasklet

### DIFF
--- a/src/core/thread/discover_scanner.hpp
+++ b/src/core/thread/discover_scanner.hpp
@@ -38,6 +38,7 @@
 
 #include "common/locator.hpp"
 #include "common/non_copyable.hpp"
+#include "common/tasklet.hpp"
 #include "common/timer.hpp"
 #include "mac/channel_mask.hpp"
 #include "mac/mac.hpp"
@@ -169,13 +170,18 @@ private:
     // Methods used from `Mle`
     void HandleDiscoveryResponse(Mle::RxInfo &aRxInfo) const;
 
-    void        HandleDiscoverComplete(void);
+    void HandleDiscoverComplete(void);
+    void HandleScanDoneTask(void);
+
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
+
+    using ScanDoneTask = TaskletIn<DiscoverScanner, &DiscoverScanner::HandleScanDoneTask>;
 
     Handler          mHandler;
     void *           mHandlerContext;
     TimerMilli       mTimer;
+    ScanDoneTask     mScanDoneTask;
     FilterIndexes    mFilterIndexes;
     Mac::ChannelMask mScanChannels;
     State            mState;


### PR DESCRIPTION
This commit updates `DiscoverScanner` so when scan operation is
finished it uses a `Tasklet` to clear the state and invoke the
callback. This allows users to safely call OT APIs from the
callback.

---

Should resolve https://github.com/openthread/openthread/issues/8110