### PR TITLE
[routing-manager] deprecate previous local on-link prefix on xpanid change

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -597,7 +597,7 @@ private:
         void               Stop(void);
         Error              Advertise(void);
         void               Deprecate(void);
-        void               AppendAsPioTo(Ip6::Nd::RouterAdvertMessage &aRaMessage);
+        void               AppendAsPiosTo(Ip6::Nd::RouterAdvertMessage &aRaMessage);
         const Ip6::Prefix &GetPrefix(void) const { return mPrefix; }
         bool               IsAdvertising(void) const { return (mState == kAdvertising); }
         void               HandleExtPanIdChange(void);
@@ -610,11 +610,18 @@ private:
             kDeprecating,
         };
 
+        void AppendCurPrefix(Ip6::Nd::RouterAdvertMessage &aRaMessage);
+        void AppendOldPrefix(Ip6::Nd::RouterAdvertMessage &aRaMessage);
+        void Unpublish(const Ip6::Prefix &aPrefix);
+
         static void HandleTimer(Timer &aTimer);
         void        HandleTimer(void);
 
         Ip6::Prefix mPrefix;
         State       mState;
+        TimeMilli   mExpireTime;
+        Ip6::Prefix mOldPrefix;
+        TimeMilli   mOldExpireTime;
         TimerMilli  mTimer;
     };
 


### PR DESCRIPTION
This commit updates `RoutingManager` to deprecate a previously
advertised local on-link prefix when extended PAN ID gets changed.
The local on-link prefix is derived from Thread network extended PAN
ID.  On extended PAN ID change, we continue to include the the old
prefix (if it was being advertised) in the emitted RAs as PIO (with
zero preferred lifetime) and continue to publish it in Network Data
up to its lifetime. This ensures that any device on infrastructure
link side that may be using an IPv6 address based on this old prefix
can continue to communicate with the Thread mesh devices.

This commit also adds a test-case in `test_routing_manager` to
validate the behavior of the newly added mechanism when ext PAN ID
changes while the local on-link is being advertised and also while
it was being deprecated.