### PR TITLE
[routing-manager] rename published NAT64 prefix

### DIFF
--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -719,11 +719,11 @@ private:
     Ip6::Prefix mInfraIfNat64Prefix;
     // The NAT64 prefix allocated from the /48 BR ULA prefix.
     Ip6::Prefix mLocalNat64Prefix;
-    // The NAT64 prefix advertised in Network Data. It can have the following value:
-    // - empty: no NAT64 prefix is advertised from this BR
+    // The NAT64 prefix published in Network Data. It can have the following value:
+    // - empty: no NAT64 prefix is published from this BR
     // - the local NAT64 prefix
-    // - the latest advertised infrastructure NAT64 prefix, which might differs from mInfraIfNat64Prefix
-    Ip6::Prefix mAdvertisedNat64Prefix;
+    // - the latest published infrastructure NAT64 prefix, which might differs from mInfraIfNat64Prefix
+    Ip6::Prefix mPublishedNat64Prefix;
 
     TimerMilli mInfraIfNat64PrefixStaleTimer;
 #endif


### PR DESCRIPTION
This commit renames the variable representing the NAT64 prefix
which is published in Network Data to `mPublishedNat64Prefix`.

---

This change has no code/logic change here. Just a rename to make the used terms consistent:
- Let's use the term "advertise" for infra if side (entries we include in emitted RA messages),
    -  e.g. `mAdvertisedPrefixes` (on-mesh prefixes advertised as RIO in the last sent RA message)
- On Thread side and for entries in Network Data, we can use "publish" or "add":
    -  e.g., we have `PublishExternalRoute()`.