### PR TITLE
[srp-server] add `AutoEnableMode` to give control to BR

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (245)
+#define OPENTHREAD_API_VERSION (246)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/srp_server.h
+++ b/include/openthread/srp_server.h
@@ -132,14 +132,14 @@ enum
 };
 
 /**
- * Represents the state of an SRP server
+ * This enumeration represents the state of the SRP server.
  *
  */
 typedef enum
 {
     OT_SRP_SERVER_STATE_DISABLED = 0, ///< The SRP server is disabled.
-    OT_SRP_SERVER_STATE_RUNNING  = 1, ///< The SRP server is running.
-    OT_SRP_SERVER_STATE_STOPPED  = 2, ///< The SRP server is stopped.
+    OT_SRP_SERVER_STATE_RUNNING  = 1, ///< The SRP server is enabled and running.
+    OT_SRP_SERVER_STATE_STOPPED  = 2, ///< The SRP server is enabled but stopped.
 } otSrpServerState;
 
 /**
@@ -302,11 +302,48 @@ otError otSrpServerSetAnycastModeSequenceNumber(otInstance *aInstance, uint8_t a
 /**
  * This function enables/disables the SRP server.
  *
+ * On a Border Router, it is recommended to use `otSrpServerSetAutoEnableMode()` instead.
+ *
  * @param[in]  aInstance  A pointer to an OpenThread instance.
  * @param[in]  aEnabled   A boolean to enable/disable the SRP server.
  *
  */
 void otSrpServerSetEnabled(otInstance *aInstance, bool aEnabled);
+
+/**
+ * This function enables/disables the auto-enable mode on SRP server.
+ *
+ * This function requires `OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE` feature.
+ *
+ * When this mode is enabled, the Border Routing Manager controls if/when to enable or disable the SRP server.
+ * SRP sever is auto-enabled if/when Border Routing is started and it is done with the initial prefix and route
+ * configurations (when the OMR and on-link prefixes are determined, advertised in emitted Router Advertisement message
+ * on infrastructure side and published in the Thread Network Data). The SRP server is auto-disabled if/when BR is
+ * stopped (e.g., if the infrastructure network interface is brought down or if BR gets detached).
+ *
+ * This mode can be disabled by a `otSrpServerSetAutoEnableMode()` call with @p aEnabled set to `false` or if the SRP
+ * server is explicitly enabled or disabled by a call to `otSrpServerSetEnabled()` function. Disabling auto-enable mode
+ * using `otSrpServerSetAutoEnableMode(false)` will not change the current state of SRP sever (e.g., if it is enabled
+ * it stays enabled).
+ *
+ * @param[in] aInstance   A pointer to an OpenThread instance.
+ * @param[in] aEnbaled    A boolean to enable/disable the auto-enable mode.
+ *
+ */
+void otSrpServerSetAutoEnableMode(otInstance *aInstance, bool aEnabled);
+
+/**
+ * This function indicates whether the auto-enable mode is enabled or disabled.
+ *
+ * This function requires `OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE` feature.
+ *
+ * @param[in]  aInstance  A pointer to an OpenThread instance.
+ *
+ * @retval TRUE   The auto-enable mode is enabled.
+ * @retval FALSE  The auto-enable mode is disabled.
+ *
+ */
+bool otSrpServerIsAutoEnableMode(otInstance *aInstance);
 
 /**
  * This function returns SRP server TTL configuration.

--- a/src/cli/cli_srp_server.cpp
+++ b/src/cli/cli_srp_server.cpp
@@ -96,6 +96,47 @@ otError SrpServer::ProcessAddrMode(Arg aArgs[])
     return error;
 }
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+otError SrpServer::ProcessAuto(Arg aArgs[])
+{
+    otError error = OT_ERROR_NONE;
+
+    /**
+     * @cli srp server auto
+     * @code
+     * srp server auto
+     * Disabled
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otSrpServerIsAutoEnableMode
+     */
+    if (aArgs[0].IsEmpty())
+    {
+        OutputEnabledDisabledStatus(otSrpServerIsAutoEnableMode(GetInstancePtr()));
+    }
+    /**
+     * @cli srp server auto enable
+     * @code
+     * srp server auto enable
+     * Done
+     * @endcode
+     * @par api_copy
+     * #otSrpServerSetAutoEnableMode
+     */
+    else
+    {
+        bool enable;
+
+        SuccessOrExit(error = Interpreter::ParseEnableOrDisable(aArgs[0], enable));
+        otSrpServerSetAutoEnableMode(GetInstancePtr(), enable);
+    }
+
+exit:
+    return error;
+}
+#endif
+
 otError SrpServer::ProcessDomain(Arg aArgs[])
 {
     otError error = OT_ERROR_NONE;

--- a/src/cli/cli_srp_server.hpp
+++ b/src/cli/cli_srp_server.hpp
@@ -82,6 +82,9 @@ private:
     using Command = CommandEntry<SrpServer>;
 
     otError ProcessAddrMode(Arg aArgs[]);
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    otError ProcessAuto(Arg aArgs[]);
+#endif
     otError ProcessDomain(Arg aArgs[]);
     otError ProcessState(Arg aArgs[]);
     otError ProcessEnable(Arg aArgs[]);
@@ -96,11 +99,19 @@ private:
     void OutputHostAddresses(const otSrpServerHost *aHost);
 
     static constexpr Command sCommands[] = {
-        {"addrmode", &SrpServer::ProcessAddrMode}, {"disable", &SrpServer::ProcessDisable},
-        {"domain", &SrpServer::ProcessDomain},     {"enable", &SrpServer::ProcessEnable},
-        {"help", &SrpServer::ProcessHelp},         {"host", &SrpServer::ProcessHost},
-        {"lease", &SrpServer::ProcessLease},       {"seqnum", &SrpServer::ProcessSeqNum},
-        {"service", &SrpServer::ProcessService},   {"state", &SrpServer::ProcessState},
+        {"addrmode", &SrpServer::ProcessAddrMode},
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+        {"auto", &SrpServer::ProcessAuto},
+#endif
+        {"disable", &SrpServer::ProcessDisable},
+        {"domain", &SrpServer::ProcessDomain},
+        {"enable", &SrpServer::ProcessEnable},
+        {"help", &SrpServer::ProcessHelp},
+        {"host", &SrpServer::ProcessHost},
+        {"lease", &SrpServer::ProcessLease},
+        {"seqnum", &SrpServer::ProcessSeqNum},
+        {"service", &SrpServer::ProcessService},
+        {"state", &SrpServer::ProcessState},
         {"ttl", &SrpServer::ProcessTtl},
     };
 

--- a/src/core/api/srp_server_api.cpp
+++ b/src/core/api/srp_server_api.cpp
@@ -87,6 +87,18 @@ void otSrpServerSetEnabled(otInstance *aInstance, bool aEnabled)
     AsCoreType(aInstance).Get<Srp::Server>().SetEnabled(aEnabled);
 }
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+void otSrpServerSetAutoEnableMode(otInstance *aInstance, bool aEnabled)
+{
+    AsCoreType(aInstance).Get<Srp::Server>().SetAutoEnableMode(aEnabled);
+}
+
+bool otSrpServerIsAutoEnableMode(otInstance *aInstance)
+{
+    return AsCoreType(aInstance).Get<Srp::Server>().IsAutoEnableMode();
+}
+#endif
+
 void otSrpServerGetTtlConfig(otInstance *aInstance, otSrpServerTtlConfig *aTtlConfig)
 {
     AsCoreType(aInstance).Get<Srp::Server>().GetTtlConfig(AsCoreType(aTtlConfig));

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -310,6 +310,16 @@ public:
         return mDiscoveredPrefixTable.GetNextEntry(aIterator, aEntry);
     }
 
+#if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
+    /**
+     * This method determines whether to enable/disable SRP server when the auto-enable mode is changed on SRP server.
+     *
+     * This should be called from `Srp::Server` when auto-enable mode is changed.
+     *
+     */
+    void HandleSrpServerAutoEnableMode(void);
+#endif
+
 private:
     static constexpr uint8_t kMaxOnMeshPrefixes = OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_ON_MESH_PREFIXES;
 
@@ -728,6 +738,7 @@ private:
 
     void  EvaluateOnLinkPrefix(void);
     void  EvaluateRoutingPolicy(void);
+    bool  IsInitalPolicyEvaluationDone(void) const;
     void  ScheduleRoutingPolicyEvaluation(ScheduleMode aMode);
     void  EvaluateOmrPrefix(void);
     Error PublishExternalRoute(const Ip6::Prefix &aPrefix, RoutePreference aRoutePreference, bool aNat64 = false);
@@ -741,7 +752,6 @@ private:
     void        HandleDiscoveredPrefixStaleTimer(void);
     static void HandleRoutingPolicyTimer(Timer &aTimer);
 
-    void DeprecateOnLinkPrefix(void);
     void HandleRouterSolicit(const InfraIf::Icmp6Packet &aPacket, const Ip6::Address &aSrcAddress);
     void HandleRouterAdvertisement(const InfraIf::Icmp6Packet &aPacket, const Ip6::Address &aSrcAddress);
     bool ShouldProcessPrefixInfoOption(const Ip6::Nd::PrefixInfoOption &aPio, const Ip6::Prefix &aPrefix);

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -92,6 +92,12 @@ class Server;
 }
 } // namespace Dns
 
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+namespace BorderRouter {
+class RoutingManager;
+}
+#endif
+
 namespace Srp {
 
 /**
@@ -105,6 +111,9 @@ class Server : public InstanceLocator, private NonCopyable
     friend class Service;
     friend class Host;
     friend class Dns::ServiceDiscovery::Server;
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    friend class BorderRouter::RoutingManager;
+#endif
 
     enum RetainName : bool
     {
@@ -151,11 +160,15 @@ public:
 
     class Host;
 
+    /**
+     * This enumeration represents the state of SRP server.
+     *
+     */
     enum State : uint8_t
     {
-        kStateDisabled = OT_SRP_SERVER_STATE_DISABLED,
-        kStateRunning  = OT_SRP_SERVER_STATE_RUNNING,
-        kStateStopped  = OT_SRP_SERVER_STATE_STOPPED,
+        kStateDisabled = OT_SRP_SERVER_STATE_DISABLED, ///< Server is disabled.
+        kStateRunning  = OT_SRP_SERVER_STATE_RUNNING,  ///< Server is enabled and running.
+        kStateStopped  = OT_SRP_SERVER_STATE_STOPPED,  ///< Server is enabled but stopped.
     };
 
     /**
@@ -775,17 +788,9 @@ public:
     Error SetAnycastModeSequenceNumber(uint8_t aSequenceNumber);
 
     /**
-     * This method tells whether the SRP server is currently running.
+     * This method returns the state of the SRP server.
      *
-     * @returns  A boolean that indicates whether the server is running.
-     *
-     */
-    bool IsRunning(void) const { return (mState == kStateRunning); }
-
-    /**
-     * This method tells the state of the SRP server.
-     *
-     * @returns  An enum that represents the state of the server.
+     * @returns  The state of the server.
      *
      */
     State GetState(void) const { return mState; }
@@ -793,10 +798,10 @@ public:
     /**
      * This method tells the port the SRP server is listening to.
      *
-     * @returns  An integer that represents the port of the server. It returns 0 if the SRP server is not running.
+     * @returns  The port of the server or 0 if the SRP server is not running.
      *
      */
-    uint16_t GetPort(void) const { return IsRunning() ? mPort : 0; }
+    uint16_t GetPort(void) const { return (mState == kStateRunning) ? mPort : 0; }
 
     /**
      * This method enables/disables the SRP server.
@@ -805,6 +810,35 @@ public:
      *
      */
     void SetEnabled(bool aEnabled);
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    /**
+     * This method enables/disables the auto-enable mode on SRP server.
+     *
+     * When this mode is enabled, the Border Routing Manager controls if/when to enable or disable the SRP server.
+     * SRP sever is auto-enabled if/when Border Routing is started it is done with the initial prefix and route
+     * configurations (when the OMR and on-link prefixes are determined, advertised in emitted Router Advert message on
+     * infrastructure side and published in the Thread Network Data). The SRP server is auto-disabled when BR is
+     * stopped (e.g., if the infrastructure network interface is brought down or if BR gets detached).
+     *
+     * This mode can be disabled by a `SetAutoEnableMode(false)` call or if the SRP server is explicitly enabled or
+     * disabled by a call to `SetEnabled()` method. Disabling auto-enable mode using `SetAutoEnableMode(false` call
+     * will not change the current state of SRP sever (e.g., if it is enabled it stays enabled).
+     *
+     * @param[in] aEnbaled    A boolean to enable/disable the auto-enable mode.
+     *
+     */
+    void SetAutoEnableMode(bool aEnabled);
+
+    /**
+     * This method indicates whether the auto-enable mode is enabled or disabled.
+     *
+     * @retval TRUE   The auto-enable mode is enabled.
+     * @retval FALSE  The auto-enable mode is disabled.
+     *
+     */
+    bool IsAutoEnableMode(void) const { return mAutoEnable; }
+#endif
 
     /**
      * This method returns the TTL configuration.
@@ -942,6 +976,8 @@ private:
         bool              mIsDirectRxFromClient;
     };
 
+    void              Enable(void);
+    void              Disable(void);
     void              Start(void);
     void              Stop(void);
     void              SelectPort(void);
@@ -1039,6 +1075,9 @@ private:
     AddressMode     mAddressMode;
     uint8_t         mAnycastSequenceNumber;
     bool            mHasRegisteredAnyService : 1;
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    bool mAutoEnable : 1;
+#endif
 
     otSrpServerResponseCounters mResponseCounters;
 };


### PR DESCRIPTION
This commit adds new APIs and mechanisms to support `AutoEnableMode`
in SRP server. This mode allows us to delegate the control of SRP
server (when it is enabled or disabled) to the Border Routing
Manager.

Under this mode, SRP sever is auto-enabled after `RoutingManager` is
done with the initial prefix and route setup, i.e., when the OMR and
on-link prefixes are determined, advertised in the emitted Router
Advert message on infrastructure side and published in the Thread
Network Data. This ensures that bi-directional connectivity is set up
before allowing service registration and discovery to start. The SRP
server is auto-disabled when BR is stopped, for example, when the
infrastructure network interface is brought down or when the BR gets
detached.

This commit also adds CLI commands for the new APIs and adds a
test-case in `test_routing_manager` to test and validate the newly
added mechanism.

----

Related to disc https://github.com/openthread/openthread/discussions/7872.