### PR TITLE
Add feature experiment flag API to OpenThread

### DIFF
--- a/include/openthread/feature_experiment_flag.h
+++ b/include/openthread/feature_experiment_flag.h
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief
+ *   This file includes OpenThread feature experiment flag definition.
+ */
+
+#ifndef OPENTHREAD_FEATURE_EXPERIMENT_FLAG_H_
+#define OPENTHREAD_FEATURE_EXPERIMENT_FLAG_H_
+
+/**
+ * This enumeration represents the experiment features.
+ *
+ */
+enum OtFeature
+{
+    OT_FEATURE_NAT64_TRANSLATOR = 1, ///< NAT64_TRANSLATOR
+};
+
+#endif // #define OPENTHREAD_FEATURE_EXPERIMENT_FLAG_H_

--- a/include/openthread/platform/feature_experiment_flag.h
+++ b/include/openthread/platform/feature_experiment_flag.h
@@ -1,0 +1,76 @@
+/*
+ *  Copyright (c) 2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ * @brief
+ *   This file includes the platform abstraction for the feature experiment flag.
+ */
+#ifndef OPENTHREAD_PLATFORM_FEATURE_EXPERIMENT_FLAG_H_
+#define OPENTHREAD_PLATFORM_FEATURE_EXPERIMENT_FLAG_H_
+
+#include <stdint.h>
+
+#include <openthread/feature_experiment_flag.h>
+#include <openthread/platform/toolchain.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @addtogroup plat-feature-experiment
+ *
+ * @brief
+ *   This module includes the platform integration point for the experiment system.
+ *
+ * @{
+ *
+ */
+
+/**
+ * This function pulls the feature experiment flag value from the experiment system.
+ *
+ * @param[in]  aFeature   The feature to be checked.
+ *
+ */
+OT_TOOL_WEAK bool otPlatIsFeatureEnabled(uint16_t aFeature) {
+  OT_UNUSED_VARIABLE(aFeature);
+  return true;
+};
+
+/**
+ * @}
+ *
+ */
+
+#ifdef __cplusplus
+} // extern "C"
+#endif
+
+#endif // OPENTHREAD_PLATFORM_FEATURE_EXPERIMENT_FLAG_H_

--- a/src/core/common/feature_experiment_flag.hpp
+++ b/src/core/common/feature_experiment_flag.hpp
@@ -1,0 +1,73 @@
+/*
+ *  Copyright (c) 2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes feature runtime flag related definitions.
+ */
+
+#ifndef RUNTIME_FLAG_HPP_
+#define RUNTIME_FLAG_HPP_
+
+#include "openthread-core-config.h"
+
+#include "common/log.hpp"
+#include <openthread/feature_experiment_flag.h>
+#include <openthread/platform/feature_experiment_flag.h>
+
+namespace ot {
+
+#define IS_FEATURE_ENABLED_IN_COMPILE(FEATURE) OPENTHREAD_CONFIG_##FEATURE##_ENABLE
+
+/**
+ *  Define the feature flag, and use IS_FEATURE_ENABLED to guard your feature logic.
+ *  We assume that the compile and experiment flag have the same feature name.
+ *  Sample usage:
+ *   // Use IS_FEATURE_ENABLED MACRO to guard new feature logic.
+ *   if (IS_FEATURE_ENABLED(feature)) {
+ *     // Add new feature logic.
+ *   }
+ */
+#if OPENTHREAD_CONFIG_FEATURE_EXPERIMENT_FLAG_ENABLE
+#define IS_FEATURE_ENABLED(FEATURE) FeatureExperimentFlag::IsFeatureEnabled(OT_FEATURE_##FEATURE)
+#else
+#define IS_FEATURE_ENABLED(FEATURE) 1
+#endif
+
+#if OPENTHREAD_CONFIG_FEATURE_EXPERIMENT_FLAG_ENABLE
+class FeatureExperimentFlag {
+  public:
+  static bool IsFeatureEnabled(uint16_t aFeature) {
+    return otPlatIsFeatureEnabled(aFeature);
+  };
+};
+
+#endif
+}
+
+#endif // RUNTIME_FLAG_HPP_

--- a/src/core/config/feature_experiment_flag.h
+++ b/src/core/config/feature_experiment_flag.h
@@ -1,0 +1,49 @@
+/*
+ *  Copyright (c) 2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+/**
+ * @file
+ *   This file includes compile-time configurations for the feature experiment flag support.
+ *
+ */
+
+#ifndef CONFIG_FEATURE_EXPERIMENT_FLAG_H_
+#define CONFIG_FEATURE_EXPERIMENT_FLAG_H_
+
+/**
+ * @def OPENTHREAD_CONFIG_FEATURE_EXPERIMENT_FLAG_ENABLE
+ *
+ * Whether to enable the feature experiment flag or not. On SOC compilation use
+ * cases, users may turn off the runtime flag to minimize the memory usage, and
+ * the feature's experiment flag will be treated as enabled.
+ */
+#ifndef OPENTHREAD_CONFIG_FEATURE_EXPERIMENT_FLAG_ENABLE
+#define OPENTHREAD_CONFIG_FEATURE_EXPERIMENT_FLAG_ENABLE 0
+#endif
+
+#endif // CONFIG_FEATURE_EXPERIMENT_FLAG_H_

--- a/src/core/openthread-core-config.h
+++ b/src/core/openthread-core-config.h
@@ -75,6 +75,7 @@
 #include "config/dns_dso.h"
 #include "config/dnssd_server.h"
 #include "config/dtls.h"
+#include "config/feature_experiment_flag.h"
 #include "config/history_tracker.h"
 #include "config/ip6.h"
 #include "config/joiner.h"


### PR DESCRIPTION
Feature experiment flag API helps to do feature experiments on OpenThread.

The main benefits of feature experiments are:
- Support faster feature iteration & safer feature release by experiment roll out process.
- Utilize A/B testing to understand the impact of the feature.

To use the API, define the feature flag, and use IS_FEATURE_ENABLED MACRO to guard new feature invocation logic. For example:
Error Ip6::ProcessReceiveCallback(...) {
  ...
  #if OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE
  // Use IS_FEATURE_ENABLED to guard new feature invocation logic.
  if (IS_FEATURE_ENABLED(NAT64_TRANSLATOR)) {
      // Add new feature invocation logic.
  }
  #endif
  ...
}
