### PR TITLE
[tcp] extend test to cover `otTcpStopListening` API

### DIFF
--- a/tests/scripts/expect/cli-tcp.exp
+++ b/tests/scripts/expect/cli-tcp.exp
@@ -42,6 +42,17 @@ expect_line "Done"
 set addr_2 [get_ipaddr mleid]
 send "tcp listen :: 30000\n"
 expect_line "Done"
+send "tcp stoplistening\n"
+expect_line "Done"
+
+switch_node 1
+send "tcp connect $addr_2 30000\n"
+expect_line "Done"
+expect "TCP: Connection refused"
+
+switch_node 2
+send "tcp listen :: 30000\n"
+expect_line "Done"
 
 switch_node 1
 set addr_1 [get_ipaddr mleid]


### PR DESCRIPTION
Make sure `otTcpStopListening` is verified.