### PR TITLE
[harness-simulation] keep capture files in sync at runtime

### DIFF
--- a/tools/harness-simulation/harness/Thread_Harness/Sniffer/SimSniffer.py
+++ b/tools/harness-simulation/harness/Thread_Harness/Sniffer/SimSniffer.py
@@ -261,14 +261,15 @@ class SimSniffer(ISniffer):
             raise RuntimeError('startSniffer error: %s' % sniffer_pb2.Status.Name(response.status))
 
         self._thread = threading.Thread(target=self._file_sync_main_loop)
+        self._thread.setDaemon(True)
         self._thread.start()
 
         self.is_active = True
 
     @watched
     def _file_sync_main_loop(self):
-        with open(self._local_pcapng_location, 'w+b') as f:
-            for response in self._stub.TransferFile(sniffer_pb2.TransferFileRequest()):
+        with open(self._local_pcapng_location, 'wb') as f:
+            for response in self._stub.TransferPcapng(sniffer_pb2.TransferPcapngRequest()):
                 f.write(response.content)
                 f.flush()
 

--- a/tools/harness-simulation/posix/sniffer_sim/proto/sniffer.proto
+++ b/tools/harness-simulation/posix/sniffer_sim/proto/sniffer.proto
@@ -7,6 +7,9 @@ service Sniffer {
     // Start the sniffer
     rpc Start(StartRequest) returns (StartResponse) {}
 
+    // Transfer the capture file
+    rpc TransferFile(TransferFileRequest) returns (stream TransferFileResponse) {}
+
     // Let the sniffer sniff these nodes only
     rpc FilterNodes(FilterNodesRequest) returns (FilterNodesResponse) {}
 
@@ -41,6 +44,13 @@ message StartResponse {
     Status status = 1;
 }
 
+message TransferFileRequest {
+}
+
+message TransferFileResponse {
+    bytes content = 1;
+}
+
 message FilterNodesRequest {
     repeated int32 nodeids = 1;
 }
@@ -54,5 +64,4 @@ message StopRequest {
 
 message StopResponse {
     Status status = 1;
-    bytes pcap_content = 2;
 }

--- a/tools/harness-simulation/posix/sniffer_sim/proto/sniffer.proto
+++ b/tools/harness-simulation/posix/sniffer_sim/proto/sniffer.proto
@@ -8,7 +8,7 @@ service Sniffer {
     rpc Start(StartRequest) returns (StartResponse) {}
 
     // Transfer the capture file
-    rpc TransferFile(TransferFileRequest) returns (stream TransferFileResponse) {}
+    rpc TransferPcapng(TransferPcapngRequest) returns (stream TransferPcapngResponse) {}
 
     // Let the sniffer sniff these nodes only
     rpc FilterNodes(FilterNodesRequest) returns (FilterNodesResponse) {}
@@ -44,10 +44,10 @@ message StartResponse {
     Status status = 1;
 }
 
-message TransferFileRequest {
+message TransferPcapngRequest {
 }
 
-message TransferFileResponse {
+message TransferPcapngResponse {
     bytes content = 1;
 }
 


### PR DESCRIPTION
This commit keeps capture files in sync at runtime. Therefore, Harness can obtain the addresses directly from the capture files in manual DUT mode without having to enter the addresses manually.