### PR TITLE
[link-metrics] simplify preparation of MLE Data Request

### DIFF
--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -85,6 +85,17 @@ public:
     typedef otLinkMetricsEnhAckProbingIeReportCallback EnhAckProbingIeReportCallback;
 
     /**
+     * This structure provides the info used for appending MLE Link Metric Query TLV.
+     *
+     */
+    struct QueryInfo : public Clearable<QueryInfo>
+    {
+        uint8_t     mSeriesId;                 ///< Series ID.
+        TypeIdFlags mTypeIds[kMaxTypeIdFlags]; ///< Type ID flags.
+        uint8_t     mTypeIdCount;              ///< Number of entries in `mTypeIds[]`.
+    };
+
+    /**
      * This constructor initializes an instance of the LinkMetrics class.
      *
      * @param[in]  aInstance  A reference to the OpenThread interface.
@@ -264,6 +275,18 @@ public:
      */
     void ProcessEnhAckIeData(const uint8_t *aData, uint8_t aLength, const Neighbor &aNeighbor);
 
+    /**
+     * This method appends MLE Link Metrics Query TLV to a given message.
+     *
+     * @param[in] aMessage     The message to append to.
+     * @param[in] aInfo        The link metrics query info to use to prepare the message.
+     *
+     * @retval kErrorNone     Successfully appended the TLV to the message.
+     * @retval kErrorNoBufs   Insufficient buffers available to append the TLV.
+     *
+     */
+    Error AppendLinkMetricsQueryTlv(Message &aMessage, const QueryInfo &aInfo);
+
 private:
     // Max number of SeriesInfo that could be allocated by the pool.
     static constexpr uint16_t kMaxSeriesSupported = OPENTHREAD_CONFIG_MLE_LINK_METRICS_MAX_SERIES_SUPPORTED;
@@ -276,11 +299,6 @@ private:
     static constexpr uint8_t kMaxLinkMargin = 130;
     static constexpr int32_t kMinRssi       = -130;
     static constexpr int32_t kMaxRssi       = 0;
-
-    Error SendLinkMetricsQuery(const Ip6::Address &aDestination,
-                               uint8_t             aSeriesId,
-                               const TypeIdFlags * aTypeIdFlags,
-                               uint8_t             aTypeIdFlagsCount);
 
     Status ConfigureForwardTrackingSeries(uint8_t        aSeriesId,
                                           uint8_t        aSeriesFlags,

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1447,26 +1447,29 @@ protected:
      */
     Mac::ShortAddress GetNextHop(uint16_t aDestination) const;
 
+#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
     /**
-     * This method generates an MLE Data Request message.
+     * This method generates an MLE Data Request message which includes a Link Metrics Query TLV.
      *
      * @param[in]  aDestination      A reference to the IPv6 address of the destination.
      * @param[in]  aTlvs             A pointer to requested TLV types.
      * @param[in]  aTlvsLength       The number of TLV types in @p aTlvs.
      * @param[in]  aDelay            Delay in milliseconds before the Data Request message is sent.
-     * @param[in]  aExtraTlvs        A pointer to extra TLVs.
-     * @param[in]  aExtraTlvsLength  Length of extra TLVs.
+     * @param[in]  aQueryInfo        A Link Metrics query info.
      *
      * @retval kErrorNone     Successfully generated an MLE Data Request message.
      * @retval kErrorNoBufs   Insufficient buffers to generate the MLE Data Request message.
      *
      */
-    Error SendDataRequest(const Ip6::Address &aDestination,
-                          const uint8_t *     aTlvs,
-                          uint8_t             aTlvsLength,
-                          uint16_t            aDelay,
-                          const uint8_t *     aExtraTlvs,
-                          uint8_t             aExtraTlvsLength);
+    Error SendDataRequest(const Ip6::Address &                       aDestination,
+                          const uint8_t *                            aTlvs,
+                          uint8_t                                    aTlvsLength,
+                          uint16_t                                   aDelay,
+                          const LinkMetrics::LinkMetrics::QueryInfo &aQueryInfo)
+    {
+        return SendDataRequest(aDestination, aTlvs, aTlvsLength, aDelay, &aQueryInfo);
+    }
+#endif
 
     /**
      * This method generates an MLE Data Request message.
@@ -1484,7 +1487,7 @@ protected:
     template <uint8_t kArrayLength>
     Error SendDataRequest(const Ip6::Address &aDestination, const uint8_t (&aTlvs)[kArrayLength], uint16_t aDelay = 0)
     {
-        return SendDataRequest(aDestination, aTlvs, kArrayLength, aDelay, nullptr, 0);
+        return SendDataRequest(aDestination, aTlvs, kArrayLength, aDelay);
     }
 
     /**
@@ -1887,6 +1890,16 @@ private:
     void        HandleDetachGracefullyTimer(void);
     bool        IsDetachingGracefully(void) { return mDetachGracefullyTimer.IsRunning(); }
     Error       SendChildUpdateRequest(bool aAppendChallenge, uint32_t aTimeout);
+
+#if OPENTHREAD_CONFIG_MLE_LINK_METRICS_INITIATOR_ENABLE || OPENTHREAD_CONFIG_MLE_LINK_METRICS_SUBJECT_ENABLE
+    Error SendDataRequest(const Ip6::Address &                       aDestination,
+                          const uint8_t *                            aTlvs,
+                          uint8_t                                    aTlvsLength,
+                          uint16_t                                   aDelay,
+                          const LinkMetrics::LinkMetrics::QueryInfo *aQueryInfo = nullptr);
+#else
+    Error SendDataRequest(const Ip6::Address &aDestination, const uint8_t *aTlvs, uint8_t aTlvsLength, uint16_t aDelay);
+#endif
 
 #if OPENTHREAD_FTD
     static void HandleDetachGracefullyAddressReleaseResponse(void *               aContext,


### PR DESCRIPTION
This commit simplifies the preparation of MLE Data Request message
which include a Link Metrics Query TLV and its sub-TLVs.