### PR TITLE
[config] include `misc.h` in `srp_client.h`

### DIFF
--- a/src/core/config/srp_client.h
+++ b/src/core/config/srp_client.h
@@ -35,6 +35,8 @@
 #ifndef CONFIG_SRP_CLIENT_H_
 #define CONFIG_SRP_CLIENT_H_
 
+#include "config/misc.h"
+
 /**
  * @def OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
  *


### PR DESCRIPTION
This ensures that `OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE`  is 
defined in `config/srp_client.h` and can be safely used for defining `OPENTHREAD_CONFIG_SRP_CLIENT_BUFFERS_MAX_HOST_ADDRESSES`.

----

This should help address errors such as 
- https://github.com/openthread/openthread/actions/runs/3029810959/jobs/4875470037