### PR TITLE
[netdata] update `Publisher` to reserve entries for `RoutingManager`

### DIFF
--- a/src/core/api/netdata_publisher_api.cpp
+++ b/src/core/api/netdata_publisher_api.cpp
@@ -82,12 +82,14 @@ void otNetDataUnpublishDnsSrpService(otInstance *aInstance)
 
 otError otNetDataPublishOnMeshPrefix(otInstance *aInstance, const otBorderRouterConfig *aConfig)
 {
-    return AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishOnMeshPrefix(AsCoreType(aConfig));
+    return AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishOnMeshPrefix(AsCoreType(aConfig),
+                                                                                   NetworkData::Publisher::kFromUser);
 }
 
 otError otNetDataPublishExternalRoute(otInstance *aInstance, const otExternalRouteConfig *aConfig)
 {
-    return AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishExternalRoute(AsCoreType(aConfig));
+    return AsCoreType(aInstance).Get<NetworkData::Publisher>().PublishExternalRoute(AsCoreType(aConfig),
+                                                                                    NetworkData::Publisher::kFromUser);
 }
 
 bool otNetDataIsPrefixAdded(otInstance *aInstance, const otIp6Prefix *aPrefix)

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -86,6 +86,20 @@ public:
     typedef otBorderRoutingPrefixTableEntry    PrefixTableEntry;    ///< Prefix Table Entry.
 
     /**
+     * This constant specifies the maximum number of route prefixes that may be published by `RoutingManager`
+     * in Thread Network Data.
+     *
+     * This is used by `NetworkData::Publisher` to reserve entries for use by `RoutingManager`.
+     *
+     * The number of published entries accounts for:
+     * - Max number of discovered prefix entries,
+     * - Two entries for local on-link prefixes (current prefix and old one deprecating on extended PAN ID change),
+     * - One entry for NAT64 published prefix.
+     *
+     */
+    static constexpr uint16_t kMaxPublishedPrefixes = OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_PREFIXES + 3;
+
+    /**
      * This constructor initializes the routing manager.
      *
      * @param[in]  aInstance  A OpenThread instance.
@@ -605,7 +619,7 @@ private:
         void               Generate(void);
         void               Start(void);
         void               Stop(void);
-        Error              Advertise(void);
+        void               Advertise(void);
         void               Deprecate(void);
         void               AppendAsPiosTo(Ip6::Nd::RouterAdvertMessage &aRaMessage);
         const Ip6::Prefix &GetPrefix(void) const { return mPrefix; }
@@ -747,15 +761,15 @@ private:
     bool  IsEnabled(void) const { return mIsEnabled; }
     Error LoadOrGenerateRandomBrUlaPrefix(void);
 
-    void  EvaluateOnLinkPrefix(void);
-    void  EvaluateRoutingPolicy(void);
-    bool  IsInitalPolicyEvaluationDone(void) const;
-    void  ScheduleRoutingPolicyEvaluation(ScheduleMode aMode);
-    void  EvaluateOmrPrefix(void);
-    Error PublishExternalRoute(const Ip6::Prefix &aPrefix, RoutePreference aRoutePreference, bool aNat64 = false);
-    void  UnpublishExternalRoute(const Ip6::Prefix &aPrefix);
-    void  HandleRsSenderFinished(TimeMilli aStartTime);
-    void  SendRouterAdvertisement(RouterAdvTxMode aRaTxMode);
+    void EvaluateOnLinkPrefix(void);
+    void EvaluateRoutingPolicy(void);
+    bool IsInitalPolicyEvaluationDone(void) const;
+    void ScheduleRoutingPolicyEvaluation(ScheduleMode aMode);
+    void EvaluateOmrPrefix(void);
+    void PublishExternalRoute(const Ip6::Prefix &aPrefix, RoutePreference aRoutePreference, bool aNat64 = false);
+    void UnpublishExternalRoute(const Ip6::Prefix &aPrefix);
+    void HandleRsSenderFinished(TimeMilli aStartTime);
+    void SendRouterAdvertisement(RouterAdvTxMode aRaTxMode);
 
     void HandleDiscoveredPrefixStaleTimer(void);
 

--- a/src/core/config/netdata_publisher.h
+++ b/src/core/config/netdata_publisher.h
@@ -148,17 +148,12 @@
 /**
  * @def OPENTHREAD_CONFIG_NETDATA_PUBLISHER_MAX_PREFIX_ENTRIES
  *
- * Specifies maximum number of prefix (on-mesh prefix or external route) entries supported by Publisher.
+ * Specifies maximum number of prefix (on-mesh prefix or external route) entries reserved by Publisher for use by
+ * user (through OT public APIs).
  *
  */
 #ifndef OPENTHREAD_CONFIG_NETDATA_PUBLISHER_MAX_PREFIX_ENTRIES
-
-#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
-#define OPENTHREAD_CONFIG_NETDATA_PUBLISHER_MAX_PREFIX_ENTRIES \
-    (OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_PREFIXES + 5)
-#else
 #define OPENTHREAD_CONFIG_NETDATA_PUBLISHER_MAX_PREFIX_ENTRIES 3
-#endif
 #endif
 
 #endif // CONFIG_NETDATA_PUBLISHER_H_

--- a/src/core/thread/network_data_publisher.cpp
+++ b/src/core/thread/network_data_publisher.cpp
@@ -87,7 +87,7 @@ void Publisher::SetPrefixCallback(PrefixCallback aCallback, void *aContext)
     mPrefixCallbackContext = aContext;
 }
 
-Error Publisher::PublishOnMeshPrefix(const OnMeshPrefixConfig &aConfig)
+Error Publisher::PublishOnMeshPrefix(const OnMeshPrefixConfig &aConfig, Requester aRequester)
 {
     Error        error = kErrorNone;
     PrefixEntry *entry;
@@ -95,16 +95,16 @@ Error Publisher::PublishOnMeshPrefix(const OnMeshPrefixConfig &aConfig)
     VerifyOrExit(aConfig.IsValid(GetInstance()), error = kErrorInvalidArgs);
     VerifyOrExit(aConfig.mStable, error = kErrorInvalidArgs);
 
-    entry = FindOrAllocatePrefixEntry(aConfig.GetPrefix());
+    entry = FindOrAllocatePrefixEntry(aConfig.GetPrefix(), aRequester);
     VerifyOrExit(entry != nullptr, error = kErrorNoBufs);
 
-    entry->Publish(aConfig);
+    entry->Publish(aConfig, aRequester);
 
 exit:
     return error;
 }
 
-Error Publisher::PublishExternalRoute(const ExternalRouteConfig &aConfig)
+Error Publisher::PublishExternalRoute(const ExternalRouteConfig &aConfig, Requester aRequester)
 {
     Error        error = kErrorNone;
     PrefixEntry *entry;
@@ -112,10 +112,10 @@ Error Publisher::PublishExternalRoute(const ExternalRouteConfig &aConfig)
     VerifyOrExit(aConfig.IsValid(GetInstance()), error = kErrorInvalidArgs);
     VerifyOrExit(aConfig.mStable, error = kErrorInvalidArgs);
 
-    entry = FindOrAllocatePrefixEntry(aConfig.GetPrefix());
+    entry = FindOrAllocatePrefixEntry(aConfig.GetPrefix(), aRequester);
     VerifyOrExit(entry != nullptr, error = kErrorNoBufs);
 
-    entry->Publish(aConfig);
+    entry->Publish(aConfig, aRequester);
 
 exit:
     return error;
@@ -149,23 +149,47 @@ exit:
     return error;
 }
 
-Publisher::PrefixEntry *Publisher::FindOrAllocatePrefixEntry(const Ip6::Prefix &aPrefix)
+Publisher::PrefixEntry *Publisher::FindOrAllocatePrefixEntry(const Ip6::Prefix &aPrefix, Requester aRequester)
 {
     // Returns a matching prefix entry if found, otherwise tries
     // to allocate a new entry.
 
-    PrefixEntry *prefixEntry = FindMatchingPrefixEntry(aPrefix);
-
-    VerifyOrExit(prefixEntry == nullptr);
+    PrefixEntry *prefixEntry = nullptr;
+    uint16_t     numEntries  = 0;
+    uint8_t      maxEntries  = 0;
 
     for (PrefixEntry &entry : mPrefixEntries)
     {
-        if (!entry.IsInUse())
+        if (entry.IsInUse())
+        {
+            if (entry.GetRequester() == aRequester)
+            {
+                numEntries++;
+            }
+
+            if (entry.Matches(aPrefix))
+            {
+                prefixEntry = &entry;
+                ExitNow();
+            }
+        }
+        else if (prefixEntry == nullptr)
         {
             prefixEntry = &entry;
-            ExitNow();
         }
     }
+
+    switch (aRequester)
+    {
+    case kFromUser:
+        maxEntries = kMaxUserPrefixEntries;
+        break;
+    case kFromRoutingManager:
+        maxEntries = kMaxRoutingManagerPrefixEntries;
+        break;
+    }
+
+    VerifyOrExit(numEntries < maxEntries, prefixEntry = nullptr);
 
 exit:
     return prefixEntry;
@@ -786,22 +810,27 @@ Publisher::DnsSrpServiceEntry::Info::Info(Type aType, uint16_t aPortOrSeqNumber,
 //---------------------------------------------------------------------------------------------------------------------
 // Publisher::PrefixEntry
 
-void Publisher::PrefixEntry::Publish(const OnMeshPrefixConfig &aConfig)
+void Publisher::PrefixEntry::Publish(const OnMeshPrefixConfig &aConfig, Requester aRequester)
 {
     LogInfo("Publishing OnMeshPrefix %s", aConfig.GetPrefix().ToString().AsCString());
 
-    Publish(aConfig.GetPrefix(), aConfig.ConvertToTlvFlags(), kTypeOnMeshPrefix);
+    Publish(aConfig.GetPrefix(), aConfig.ConvertToTlvFlags(), kTypeOnMeshPrefix, aRequester);
 }
 
-void Publisher::PrefixEntry::Publish(const ExternalRouteConfig &aConfig)
+void Publisher::PrefixEntry::Publish(const ExternalRouteConfig &aConfig, Requester aRequester)
 {
     LogInfo("Publishing ExternalRoute %s", aConfig.GetPrefix().ToString().AsCString());
 
-    Publish(aConfig.GetPrefix(), aConfig.ConvertToTlvFlags(), kTypeExternalRoute);
+    Publish(aConfig.GetPrefix(), aConfig.ConvertToTlvFlags(), kTypeExternalRoute, aRequester);
 }
 
-void Publisher::PrefixEntry::Publish(const Ip6::Prefix &aPrefix, uint16_t aNewFlags, Type aNewType)
+void Publisher::PrefixEntry::Publish(const Ip6::Prefix &aPrefix,
+                                     uint16_t           aNewFlags,
+                                     Type               aNewType,
+                                     Requester          aRequester)
 {
+    mRequester = aRequester;
+
     if (GetState() != kNoEntry)
     {
         // If this is an existing entry, first we check that there is


### PR DESCRIPTION
This commit updates `NetworkData::Publisher` to reserve a set of
prefix entries for use by `RoutingManager` only. This allow us to
simplify how `RoutingManager` publishes route prefixes in Network
Data (assert on failure). In particular, this commit defines a new
enum `Requester` which specifies the requester (`kFromUser` or
`kFromRoutingManager`) associated with a published prefix. This is
used by methods `PublishExternalRoute()`/`PublishOnMeshPrefix()`.
When allocating new entries, we ensure that each requester is
limited to its maximum number of entries.