### PR TITLE
[routing-manager] remove old deprecating prefix on multiple xpanid change

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -2200,6 +2200,11 @@ void RoutingManager::LocalOnLinkPrefix::HandleExtPanIdChange(void)
 
     case kAdvertising:
     case kDeprecating:
+        if (mOldPrefix.GetLength() != 0)
+        {
+            Unpublish(mOldPrefix);
+        }
+
         mOldPrefix     = mPrefix;
         mOldExpireTime = mExpireTime;
         mTimer.FireAtIfEarlier(mOldExpireTime);


### PR DESCRIPTION
This commit updates `RoutingManager` to ensure to unpublish the old
local on-link prefix being deprecated on ext PAN ID change if the ext
PAN ID happens to change again before the previous deprecating prefix
is expired. Note that the code supports retaining one old deprecating
prefix entry since back-to-back ext pan ID change is not expected as
a typical use-case. This commit also updates `test_routing_manager`
to cover and test this scenario.