### PR TITLE
[Energy] Add reports of radio state to the OTNS - Part 4 of RTEA

### DIFF
--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -75,7 +75,7 @@ extern int          sSockFd;
 extern uint16_t     sPortOffset;
 static otRadioState sLastReportedState   = OT_RADIO_STATE_DISABLED;
 static uint8_t      sLastReportedChannel = 0;
-#else // OPENTHREAD_SIMULATION_VIRTUAL_TIME
+#else  // OPENTHREAD_SIMULATION_VIRTUAL_TIME
 static int      sTxFd       = -1;
 static int      sRxFd       = -1;
 static uint16_t sPortOffset = 0;
@@ -168,9 +168,9 @@ static otMacKeyMaterial sNextKey;
 static otRadioKeyType   sKeyType;
 
 static int8_t GetRssi(uint16_t aChannel);
-static void radioReceive(otInstance *aInstance);
-void radioSendMessage(otInstance *aInstance);
-void setRadioState(otRadioState aState);
+static void   radioReceive(otInstance *aInstance);
+void          radioSendMessage(otInstance *aInstance);
+void          setRadioState(otRadioState aState);
 
 static bool IsTimeAfterOrEqual(uint32_t aTimeA, uint32_t aTimeB)
 {
@@ -954,8 +954,6 @@ exit:
     return error;
 }
 
-
-
 // Definition of virtual and non-virtual functions
 #if OPENTHREAD_SIMULATION_VIRTUAL_TIME
 const char *radioStateToString(otRadioState aState)
@@ -1010,7 +1008,6 @@ void setRadioState(otRadioState aState)
     reportRadioStatusToOtns(aState);
     sState = aState;
 }
-
 
 void platformRadioInit(void)
 {
@@ -1161,8 +1158,8 @@ void radioTransmit(struct RadioMessage *aMessage, const struct otRadioFrame *aFr
     reportRadioStatusToOtns(OT_RADIO_STATE_TRANSMIT);
 
     event.mDelay      = 1; // 1us for now. This will change soon in the next PR
-    event.mEvent       = OT_SIM_EVENT_RADIO_RECEIVED;
-    event.mDataLength  = 1 + aFrame->mLength; // include channel in first byte
+    event.mEvent      = OT_SIM_EVENT_RADIO_RECEIVED;
+    event.mDataLength = 1 + aFrame->mLength; // include channel in first byte
     memcpy(event.mData, aMessage, event.mDataLength);
 
     otSimSendEvent(&event);
@@ -1256,9 +1253,9 @@ void platformRadioInit(void)
 
     initFds();
 
-    sReceiveFrame.mPsdu  = sReceiveMessage.mPsdu;
-    sTransmitFrame.mPsdu = sTransmitMessage.mPsdu;
-    sAckFrame.mPsdu      = sAckMessage.mPsdu;
+    sReceiveFrame.mPsdu                  = sReceiveMessage.mPsdu;
+    sTransmitFrame.mPsdu                 = sTransmitMessage.mPsdu;
+    sAckFrame.mPsdu                      = sAckMessage.mPsdu;
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
     sTransmitFrame.mInfo.mTxInfo.mIeInfo = &sTransmitIeInfo;


### PR DESCRIPTION
# Contribution description
This PR is part of the process of breaking PR #7500 into small steps, a process nominated "Road to Energy Analysis" (RTEA). These small modifications will lead to the whole improvement started on March 2022. At the end of these steps, OT devices will be capable to precisely simulate a real-device's event duration, allowing the OT-NS simulator to simulate collisions, energy consumption, and more ([PR #235](https://github.com/openthread/ot-ns/pull/235)).

At the moment, OT **simulated** devices have an instantaneous msg transmission event. Although it allows testing part of this protocol's features, it also hides many of the real-device's problems and solutions.

# Main modifications
This PR adds functions to allow simulated devices to report their radio state to the OTNS. It still keeps compatibility with the current version of the OTNS, but reports will only be actually computed after PR [#359](https://github.com/openthread/ot-ns/pull/359) gets merged into OTNS.

This PR keeps all previous commits to reduce future rebase efforts. However, relative to the timeline of RTEA, it addresses only the following file:
- /examples/platforms/simulation/radio.c

#### Important notice
The values collect until this point are still not precise, because the timings are not yet correctly controlled. The timing is going to be implemented in the next PRs (already created as part of the [PR #235](https://github.com/openthread/ot-ns/pull/235)).

# Roadmap
This is part 4 of the RTEA (Road to Energy Analysis) steps to [PR #235](https://github.com/openthread/ot-ns/pull/235) and [PR #7500](https://github.com/openthread/openthread/pull/7500).

Part 1: [PR #357](https://github.com/openthread/ot-ns/pull/357);
Part 2: [PR #8144](https://github.com/openthread/openthread/pull/8144);
Part 3: [PR #359](https://github.com/openthread/ot-ns/pull/359);
Part 4: This PR;
Part 5:  [PR #362](https://github.com/openthread/ot-ns/pull/362);
Part 6:  [PR #8165](https://github.com/openthread/openthread/pull/8165);
Part 7:  [PR #363](https://github.com/openthread/ot-ns/pull/363);
Part 8:  [PR #8173](https://github.com/openthread/openthread/pull/8173);
Part 9:  [PR #365](https://github.com/openthread/ot-ns/pull/365);
Part 10:  [PR #366](https://github.com/openthread/ot-ns/pull/366);
Part 11: [PR #367](https://github.com/openthread/ot-ns/pull/367).