### PR TITLE
[thci] fix `mdns_query` incorrect `ip6tables` rules

### DIFF
--- a/tools/harness-thci/OpenThread_BR.py
+++ b/tools/harness-thci/OpenThread_BR.py
@@ -663,6 +663,7 @@ class OpenThread_BR(OpenThreadTHCI, IThci):
         finally:
             self.bash('ip6tables -L INPUT -v')
             self.bash('ip6tables -F INPUT')
+            time.sleep(1)
 
     def _mdns_query_impl(self, service, find_active):
         # For BBR-TC-03 or DH test cases (empty arguments) just send a query


### PR DESCRIPTION
This commit fixes the bug that `mdns_query` inserts `ip6tables` rules in an incorrect order.
It also uses `ip6tables -F INPUT` to flush the `INPUT` chain after mDNS query is done.