### PR TITLE
[thci] wait for connection reset in `powerDown`

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -1248,13 +1248,7 @@ class OpenThreadTHCI(object):
     @API
     def powerDown(self):
         """power down the Thread device"""
-        self.__sendCommand('reset', expectEcho=False)
-
-        if not self.IsBorderRouter:
-            self._disconnect()
-            self._connect()
-
-        self.isPowerDown = True
+        self._reset()
 
     @API
     def powerUp(self):
@@ -1266,7 +1260,8 @@ class OpenThreadTHCI(object):
                 self.__setPollPeriod(self.__sedPollPeriod)
             self.__startOpenThread()
 
-    def reset_and_wait_for_connection(self, timeout=3):
+    @watched
+    def _reset(self, timeout=3):
         print("Waiting after reset timeout: {} s".format(timeout))
         start_time = time.time()
         self.__sendCommand('reset', expectEcho=False)
@@ -1285,6 +1280,8 @@ class OpenThreadTHCI(object):
         else:
             raise AssertionError("Could not connect with OT device {} after reset.".format(self))
 
+    def reset_and_wait_for_connection(self, timeout=3):
+        self._reset(timeout=timeout)
         if self.deviceRole == Thread_Device_Role.SED:
             self.__setPollPeriod(self.__sedPollPeriod)
 


### PR DESCRIPTION
This commit fixes `powerDown` to wait for connection reset after issuing `reset` command.