### PR TITLE
[Energy] Add CCA support to simulated devices of OTNS - Part 8 of RTEA

### DIFF
--- a/examples/platforms/simulation/platform-config.h
+++ b/examples/platforms/simulation/platform-config.h
@@ -53,6 +53,16 @@
 #endif
 
 /**
+ * @def OPENTHREAD_SIMULATION_CCA
+ *
+ * This setting configures whether to use virtual CAA (provided by the simulator) in simulation platform.
+ *
+ */
+#ifndef OPENTHREAD_SIMULATION_CCA
+#define OPENTHREAD_SIMULATION_CCA 1
+#endif
+
+/**
  * @def OPENTHREAD_SIMULATION_VIRTUAL_TIME_UART
  *
  * This setting configures whether to use virtual time for UART.

--- a/examples/platforms/simulation/platform-simulation.h
+++ b/examples/platforms/simulation/platform-simulation.h
@@ -69,6 +69,7 @@ enum
     OT_SIM_EVENT_OTNS_STATUS_PUSH   = 5,
     OT_SIM_EVENT_RADIO_COMM         = 6,
     OT_SIM_EVENT_RADIO_TX_DONE      = 7,
+    OT_SIM_EVENT_CHANNEL_ACTIVITY   = 8,
     OT_EVENT_DATA_MAX_SIZE          = 1024,
 };
 
@@ -168,6 +169,16 @@ void platformRadioReceive(otInstance *aInstance, uint8_t *aBuf, uint16_t aBufLen
  *
  */
 void platformRadioTxDone(otInstance *aInstance, uint8_t pktSeq);
+
+/**
+ * This function inputs the parameter used to simulate a CCA procedure.
+ *
+ * @param[in]  aInstance  A pointer to the OpenThread instance.
+ * @param[in]  channel    Channel number in use.
+ * @param[in]  value      CCA result (-128 for no activity, 127 busy or invalid).
+ *
+ */
+void platformChannelActivity(otInstance *aInstance, uint8_t channel, int8_t value);
 
 /**
  * This function updates the file descriptor sets with file descriptors used by the radio driver.

--- a/examples/platforms/simulation/platform-simulation.h
+++ b/examples/platforms/simulation/platform-simulation.h
@@ -67,6 +67,8 @@ enum
     OT_SIM_EVENT_UART_WRITE         = 2,
     OT_SIM_EVENT_RADIO_SPINEL_WRITE = 3,
     OT_SIM_EVENT_OTNS_STATUS_PUSH   = 5,
+    OT_SIM_EVENT_RADIO_COMM         = 6,
+    OT_SIM_EVENT_RADIO_TX_DONE      = 7,
     OT_EVENT_DATA_MAX_SIZE          = 1024,
 };
 
@@ -159,6 +161,15 @@ void platformRadioDeinit(void);
 void platformRadioReceive(otInstance *aInstance, uint8_t *aBuf, uint16_t aBufLength);
 
 /**
+ * This function signals Tx Done to the radio (instead of echo frames).
+ *
+ * @param[in]  aInstance  A pointer to the OpenThread instance.
+ * @param[in]  pktSeq     Packet sequence number to be confirmed as sent.
+ *
+ */
+void platformRadioTxDone(otInstance *aInstance, uint8_t pktSeq);
+
+/**
  * This function updates the file descriptor sets with file descriptors used by the radio driver.
  *
  * @param[in,out]  aReadFdSet   A pointer to the read file descriptors.
@@ -231,6 +242,14 @@ void otSimSendUartWriteEvent(const uint8_t *aData, uint16_t aLength);
  *
  */
 bool platformRadioIsTransmitPending(void);
+
+/**
+ * This function checks if radio is waiting for a Tx Done signal from the simulator.
+ *
+ * @returns Whether radio TxDone signal is pending.
+ *
+ */
+bool platformRadioTaskPending(void);
 
 #if OPENTHREAD_CONFIG_RADIO_LINK_TREL_ENABLE
 

--- a/examples/platforms/simulation/platform-simulation.h
+++ b/examples/platforms/simulation/platform-simulation.h
@@ -236,7 +236,7 @@ void otSimSendEvent(const struct Event *aEvent);
 void otSimSendUartWriteEvent(const uint8_t *aData, uint16_t aLength);
 
 /**
- * This function checks if radio transmitting is pending.
+ * This function checks if radio is still transmitting a message to be confirmed by a TxDone signal.
  *
  * @returns Whether radio transmitting is pending.
  *
@@ -244,7 +244,7 @@ void otSimSendUartWriteEvent(const uint8_t *aData, uint16_t aLength);
 bool platformRadioIsTransmitPending(void);
 
 /**
- * This function checks if radio is waiting for a Tx Done signal from the simulator.
+ * This function checks if the radio is performing part of a task, such as returning an ACK or doing a CCA.
  *
  * @returns Whether radio TxDone signal is pending.
  *

--- a/examples/platforms/simulation/radio.c
+++ b/examples/platforms/simulation/radio.c
@@ -75,7 +75,7 @@ extern int          sSockFd;
 extern uint16_t     sPortOffset;
 static otRadioState sLastReportedState   = OT_RADIO_STATE_DISABLED;
 static uint8_t      sLastReportedChannel = 0;
-#else // OPENTHREAD_SIMULATION_VIRTUAL_TIME
+#else  // OPENTHREAD_SIMULATION_VIRTUAL_TIME
 static int      sTxFd       = -1;
 static int      sRxFd       = -1;
 static uint16_t sPortOffset = 0;
@@ -168,9 +168,9 @@ static otMacKeyMaterial sNextKey;
 static otRadioKeyType   sKeyType;
 
 static int8_t GetRssi(uint16_t aChannel);
-static void radioReceive(otInstance *aInstance);
-void radioSendMessage(otInstance *aInstance);
-void setRadioState(otRadioState aState);
+static void   radioReceive(otInstance *aInstance);
+void          radioSendMessage(otInstance *aInstance);
+void          setRadioState(otRadioState aState);
 
 static bool IsTimeAfterOrEqual(uint32_t aTimeA, uint32_t aTimeB)
 {
@@ -954,8 +954,6 @@ exit:
     return error;
 }
 
-
-
 // Definition of virtual and non-virtual functions
 #if OPENTHREAD_SIMULATION_VIRTUAL_TIME
 const char *radioStateToString(otRadioState aState)
@@ -1010,7 +1008,6 @@ void setRadioState(otRadioState aState)
     reportRadioStatusToOtns(aState);
     sState = aState;
 }
-
 
 void platformRadioInit(void)
 {
@@ -1161,8 +1158,8 @@ void radioTransmit(struct RadioMessage *aMessage, const struct otRadioFrame *aFr
     reportRadioStatusToOtns(OT_RADIO_STATE_TRANSMIT);
 
     event.mDelay      = 1; // 1us for now. This will change soon in the next PR
-    event.mEvent       = OT_SIM_EVENT_RADIO_RECEIVED;
-    event.mDataLength  = 1 + aFrame->mLength; // include channel in first byte
+    event.mEvent      = OT_SIM_EVENT_RADIO_RECEIVED;
+    event.mDataLength = 1 + aFrame->mLength; // include channel in first byte
     memcpy(event.mData, aMessage, event.mDataLength);
 
     otSimSendEvent(&event);
@@ -1256,9 +1253,9 @@ void platformRadioInit(void)
 
     initFds();
 
-    sReceiveFrame.mPsdu  = sReceiveMessage.mPsdu;
-    sTransmitFrame.mPsdu = sTransmitMessage.mPsdu;
-    sAckFrame.mPsdu      = sAckMessage.mPsdu;
+    sReceiveFrame.mPsdu                  = sReceiveMessage.mPsdu;
+    sTransmitFrame.mPsdu                 = sTransmitMessage.mPsdu;
+    sAckFrame.mPsdu                      = sAckMessage.mPsdu;
 
 #if OPENTHREAD_CONFIG_MAC_HEADER_IE_SUPPORT
     sTransmitFrame.mInfo.mTxInfo.mIeInfo = &sTransmitIeInfo;

--- a/examples/platforms/simulation/virtual_time/platform-sim.c
+++ b/examples/platforms/simulation/virtual_time/platform-sim.c
@@ -108,12 +108,16 @@ static void receiveEvent(otInstance *aInstance)
     case OT_SIM_EVENT_ALARM_FIRED:
         break;
 
-    case OT_SIM_EVENT_RADIO_RECEIVED:
+    case OT_SIM_EVENT_RADIO_COMM:
         platformRadioReceive(aInstance, event.mData, event.mDataLength);
         break;
 
     case OT_SIM_EVENT_UART_WRITE:
         otPlatUartReceived(event.mData, event.mDataLength);
+        break;
+
+    case OT_SIM_EVENT_RADIO_TX_DONE:
+        platformRadioTxDone(aInstance, event.mData[0]);
         break;
 
     default:
@@ -288,7 +292,8 @@ void otSysProcessDrivers(otInstance *aInstance)
     platformUartUpdateFdSet(&read_fds, &write_fds, &error_fds, &max_fd);
 #endif
 
-    if (!otTaskletsArePending(aInstance) && platformAlarmGetNext() > 0 && !platformRadioIsTransmitPending())
+    if (!otTaskletsArePending(aInstance) && platformAlarmGetNext() > 0 &&
+        (!platformRadioIsTransmitPending() || platformRadioTaskPending()))
     {
         platformSendSleepEvent();
 

--- a/examples/platforms/simulation/virtual_time/platform-sim.c
+++ b/examples/platforms/simulation/virtual_time/platform-sim.c
@@ -120,6 +120,13 @@ static void receiveEvent(otInstance *aInstance)
         platformRadioTxDone(aInstance, event.mData[0]);
         break;
 
+    case OT_SIM_EVENT_CHANNEL_ACTIVITY:
+#if OPENTHREAD_SIMULATION_CCA
+        // Data[0] is the channel, Data[1] is the CCA value (0-255)
+        platformChannelActivity(aInstance, event.mData[0], (int8_t)event.mData[1]);
+#endif
+        break;
+
     default:
         assert(false);
     }


### PR DESCRIPTION
# Contribution description
This PR is part of the process of breaking PR #7500 into small steps, a process nominated "Road to Energy Analysis" (RTEA). These small modifications will lead to the whole improvement started on March 2022. At the end of these steps, OT devices will be capable to precisely simulate a real-device's event duration, allowing the OT-NS simulator to simulate collisions, energy consumption, and more ([PR #235](https://github.com/openthread/ot-ns/pull/235)).

At the moment, OT **simulated** devices have an instantaneous msg transmission event. Although it allows testing part of this protocol's features, it also hides many of the real-device's problems and solutions.

# Main modifications
This PR adds signals and functions to allow devices to perform Clear Channel Assessment (CCA) when simulated by OTNS.

This PR keeps all previous commits to reduce future rebase efforts. However, relative to the timeline of RTEA, it addresses only the following files:
- /examples/platforms/simulation/platform-config.h
- /examples/platforms/simulation/platform-simulation.h
- /examples/platforms/simulation/radio.c
- /examples/platforms/simulation/virtual_time/platform-sim.c

# Roadmap
This is part 8 of the RTEA (Road to Energy Analysis) steps to [PR #235](https://github.com/openthread/ot-ns/pull/235) and [PR #7500](https://github.com/openthread/openthread/pull/7500).

Part 1:  [PR #357](https://github.com/openthread/ot-ns/pull/357);
Part 2:  [PR #8144](https://github.com/openthread/openthread/pull/8144);
Part 3:  [PR #359](https://github.com/openthread/ot-ns/pull/359);
Part 4:  [PR #8152](https://github.com/openthread/openthread/pull/8152);
Part 5:  [PR #362](https://github.com/openthread/ot-ns/pull/362);
Part 6:  [PR #8165](https://github.com/openthread/openthread/pull/8165);
Part 7:  [PR #363](https://github.com/openthread/ot-ns/pull/363);
Part 8:  This PR;
Part 9:  [PR #365](https://github.com/openthread/ot-ns/pull/365);
Part 10:  [PR #366](https://github.com/openthread/ot-ns/pull/366);
Part 11: [PR #367](https://github.com/openthread/ot-ns/pull/367).