### PR TITLE
[examples] make built-in otPlatCalloc and otPlatFree definitions weak

### DIFF
--- a/examples/apps/cli/main.c
+++ b/examples/apps/cli/main.c
@@ -50,12 +50,12 @@
 extern void otAppCliInit(otInstance *aInstance);
 
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-void *otPlatCAlloc(size_t aNum, size_t aSize)
+OT_TOOL_WEAK void *otPlatCAlloc(size_t aNum, size_t aSize)
 {
     return calloc(aNum, aSize);
 }
 
-void otPlatFree(void *aPtr)
+OT_TOOL_WEAK void otPlatFree(void *aPtr)
 {
     free(aPtr);
 }

--- a/examples/apps/ncp/main.c
+++ b/examples/apps/ncp/main.c
@@ -46,12 +46,12 @@
 extern void otAppNcpInit(otInstance *aInstance);
 
 #if OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-void *otPlatCAlloc(size_t aNum, size_t aSize)
+OT_TOOL_WEAK void *otPlatCAlloc(size_t aNum, size_t aSize)
 {
     return calloc(aNum, aSize);
 }
 
-void otPlatFree(void *aPtr)
+OT_TOOL_WEAK void otPlatFree(void *aPtr)
 {
     free(aPtr);
 }


### PR DESCRIPTION
This will allow platforms to define their own `otPlatCalloc` and `otPlatFree` functions which may not map directly to `calloc()` and `free()`

See https://github.com/SiliconLabs/ot-efr32/blob/main/src/src/memory.c#L37-L45 for example