### PR TITLE
[routing-manager] fix prefix comparison in `EvaluateOnLinkPrefix()`

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -533,7 +533,7 @@ void RoutingManager::EvaluateOnLinkPrefix(void)
         // converge to the same smallest/favored on-link prefix and the
         // application-specific prefix is not used.
 
-        if (!(mLocalOmrPrefix.GetPrefix() < mFavoredDiscoveredOnLinkPrefix))
+        if (!(mLocalOnLinkPrefix.GetPrefix() < mFavoredDiscoveredOnLinkPrefix))
         {
             LogInfo("EvaluateOnLinkPrefix: There is already favored on-link prefix %s on %s",
                     mFavoredDiscoveredOnLinkPrefix.ToString().AsCString(), mInfraIf.ToString().AsCString());


### PR DESCRIPTION
This commit fixes `EvaluateOnLinkPrefix()` to use local on-link 
prefix (instead of OMR prefix).

----

Marked as P3 since it does not seem to be critical (worse-case we keep adv
the local on-link prefix and won't deprecate it).

It is interesting that none of our CI tests detected this. I guess/think in our tests the 
discovered on-link prefix is often smaller than both local OMR and  local on-link 
prefix. Should later consider adding a test case to maybe check this specific 
situation.