### PR TITLE
[routing-manager] allow old deprecating PIOs when checking RA is from router

### DIFF
--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -810,14 +810,19 @@ bool RoutingManager::IsReceivedRouterAdvertFromManager(const Ip6::Nd::RouterAdve
         {
         case Ip6::Nd::Option::kTypePrefixInfo:
         {
-            // PIO should match `mLocalOnLinkPrefix`.
-
             const Ip6::Nd::PrefixInfoOption &pio = static_cast<const Ip6::Nd::PrefixInfoOption &>(option);
 
             VerifyOrExit(pio.IsValid());
             pio.GetPrefix(prefix);
 
-            VerifyOrExit(prefix == mLocalOnLinkPrefix.GetPrefix());
+            // If it is a non-deprecated PIO, it should match the
+            // local on-link prefix.
+
+            if (pio.GetPreferredLifetime() > 0)
+            {
+                VerifyOrExit(prefix == mLocalOnLinkPrefix.GetPrefix());
+            }
+
             break;
         }
 


### PR DESCRIPTION
This commit updates `IsReceivedRouterAdvertFromManager()` which checks
if a received RA message was prepared by the `RoutingManager module
itself to allow deprecating PIOs in the RA message. These will handle
the case when old on-link prefix(es) (e.g., on extended PAN ID change)
are being deprecated.
