### PR TITLE
[clearable] update `Clearable` to ensure CRTP-style use

### DIFF
--- a/src/core/backbone_router/ndproxy_table.hpp
+++ b/src/core/backbone_router/ndproxy_table.hpp
@@ -65,6 +65,7 @@ public:
     class NdProxy : private Clearable<NdProxy>
     {
         friend class NdProxyTable;
+        friend class Clearable<NdProxy>;
 
     public:
         /**

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -433,6 +433,7 @@ private:
         class Entry : public LinkedListEntry<Entry>, public Unequatable<Entry>, private Clearable<Entry>
         {
             friend class LinkedListEntry<Entry>;
+            friend class Clearable<Entry>;
 
         public:
             enum Type : uint8_t

--- a/src/core/common/clearable.hpp
+++ b/src/core/common/clearable.hpp
@@ -41,7 +41,7 @@
 namespace ot {
 
 /**
- * This template class defines a Clearable object which provides `Clear()` method.
+ * This template class defines a `Clearable` object which provides `Clear()` method.
  *
  * The `Clear` implementation simply sets all the bytes of a `Type` instance to zero.
  *
@@ -52,7 +52,7 @@ namespace ot {
 template <typename Type> class Clearable
 {
 public:
-    void Clear(void) { memset(reinterpret_cast<void *>(this), 0, sizeof(Type)); }
+    void Clear(void) { memset(reinterpret_cast<void *>(static_cast<Type *>(this)), 0, sizeof(Type)); }
 };
 
 } // namespace ot

--- a/src/core/common/message.hpp
+++ b/src/core/common/message.hpp
@@ -1506,6 +1506,7 @@ class PriorityQueue : private Clearable<PriorityQueue>
     friend class Message;
     friend class MessageQueue;
     friend class MessagePool;
+    friend class Clearable<PriorityQueue>;
 
 public:
     typedef otMessageQueueInfo Info; ///< This struct represents info (number of messages/buffers) about a queue.

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -133,6 +133,7 @@ public:
     class NetworkInfo : private Clearable<NetworkInfo>
     {
         friend class Settings;
+        friend class Clearable<NetworkInfo>;
 
     public:
         static constexpr Key kKey = kKeyNetworkInfo; ///< The associated key.
@@ -339,6 +340,7 @@ public:
     class ParentInfo : private Clearable<ParentInfo>
     {
         friend class Settings;
+        friend class Clearable<ParentInfo>;
 
     public:
         static constexpr Key kKey = kKeyParentInfo; ///< The associated key.
@@ -532,6 +534,7 @@ public:
     class DadInfo : private Clearable<DadInfo>
     {
         friend class Settings;
+        friend class Clearable<DadInfo>;
 
     public:
         static constexpr Key kKey = kKeyDadInfo; ///< The associated key.
@@ -607,6 +610,7 @@ public:
     class SrpClientInfo : private Clearable<SrpClientInfo>
     {
         friend class Settings;
+        friend class Clearable<SrpClientInfo>;
 
     public:
         static constexpr Key kKey = kKeySrpClientInfo; ///< The associated key.
@@ -667,6 +671,7 @@ public:
     class SrpServerInfo : private Clearable<SrpServerInfo>
     {
         friend class Settings;
+        friend class Clearable<SrpServerInfo>;
 
     public:
         static constexpr Key kKey = kKeySrpServerInfo; ///< The associated key.

--- a/src/core/net/ip6.hpp
+++ b/src/core/net/ip6.hpp
@@ -416,6 +416,8 @@ private:
  */
 class Headers : private Clearable<Headers>
 {
+    friend class Clearable<Headers>;
+
 public:
     /**
      * This method parses the IPv6 and UDP/TCP/ICMP6 headers from a given message.

--- a/src/core/net/nd6.hpp
+++ b/src/core/net/nd6.hpp
@@ -175,6 +175,8 @@ private:
 OT_TOOL_PACKED_BEGIN
 class PrefixInfoOption : public Option, private Clearable<PrefixInfoOption>
 {
+    friend class Clearable<PrefixInfoOption>;
+
 public:
     static constexpr Type kType = kTypePrefixInfo; ///< Prefix Information Option Type.
 
@@ -330,6 +332,8 @@ static_assert(sizeof(PrefixInfoOption) == 32, "invalid PrefixInfoOption structur
 OT_TOOL_PACKED_BEGIN
 class RouteInfoOption : public Option, private Clearable<RouteInfoOption>
 {
+    friend class Clearable<RouteInfoOption>;
+
 public:
     static constexpr uint16_t kMinSize = kLengthUnit;    ///< Minimum size (in bytes) of a Route Info Option
     static constexpr Type     kType    = kTypeRouteInfo; ///< Route Information Option Type.
@@ -470,6 +474,8 @@ public:
     OT_TOOL_PACKED_BEGIN
     class Header : public Equatable<Header>, private Clearable<Header>
     {
+        friend class Clearable<Header>;
+
     public:
         /**
          * This constructor initializes the Router Advertisement message with

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -106,6 +106,7 @@ public:
     class HostInfo : public otSrpClientHostInfo, private Clearable<HostInfo>
     {
         friend class Client;
+        friend class Clearable<HostInfo>;
 
     public:
         /**
@@ -890,7 +891,7 @@ private:
     };
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
-    class AutoStart : Clearable<AutoStart>
+    class AutoStart : public Clearable<AutoStart>
     {
     public:
         enum State : uint8_t{


### PR DESCRIPTION
This commit updates `Clearable<Type>::Clear()` method to perform `static_cast<Type *>(this)`. This ensures CRTP-style use and also allows the `Clearable` to be used for types that may not be a standard layout type (and/or more generally in cases where empty base optimization may not be applied).