### PR TITLE
[posix] fix OT_DAEMON flag definitions

### DIFF
--- a/src/posix/platform/CMakeLists.txt
+++ b/src/posix/platform/CMakeLists.txt
@@ -35,6 +35,14 @@ if(OT_DAEMON)
     target_compile_definitions(ot-posix-config
         INTERFACE "OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE=1"
     )
+
+    # We have to add this definition to `ot-config` because openthread core
+    # libraries will set config file to "openthrad-core-posix-config.h" which
+    # depends on `OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE` to correctly enable
+    # PLATFORM_NETIF and PLATFORM_UDP features. Otherwise, openthread core and
+    # posix libraries will use different feature definitions.
+    list(APPEND OT_PLATFORM_DEFINES "OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE=1")
+    set(OT_PLATFORM_DEFINES ${OT_PLATFORM_DEFINES} PARENT_SCOPE)
 endif()
 
 option(OT_POSIX_INSTALL_EXTERNAL_ROUTES "Install External Routes as IPv6 routes" ON)


### PR DESCRIPTION
We have to add the `OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE` definition
to `ot-config` because openthread core libraries will set config file to "openthrad-core-posix-config.h"
which depends on `OPENTHREAD_POSIX_CONFIG_DAEMON_ENABLE` to correctly enable
PLATFORM_NETIF and PLATFORM_UDP features. Otherwise, openthread core and
posix libraries will use different feature definitions.

------
 help fix https://github.com/openthread/openthread/discussions/8200