### PR TITLE
[srp-client] update "single service mode" to handle many removes

### DIFF
--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -976,6 +976,11 @@ Error Client::AppendServiceInstructions(Service &aService, Message &aMessage, In
 
     removing = ((aService.GetState() == kToRemove) || (aService.GetState() == kRemoving));
 
+    if (mSingleServiceMode.IsEnabled())
+    {
+        mSingleServiceMode.SetService(aService);
+    }
+
     //----------------------------------
     // Service Discovery Instruction
 
@@ -1081,11 +1086,6 @@ Error Client::AppendServiceInstructions(Service &aService, Message &aMessage, In
         SuccessOrExit(error = AppendKeyRecord(aMessage, aInfo));
     }
 #endif
-
-    if (mSingleServiceMode.IsEnabled())
-    {
-        mSingleServiceMode.SetService(aService);
-    }
 
 exit:
     return error;

--- a/tests/scripts/thread-cert/test_srp_many_services_mtu_check.py
+++ b/tests/scripts/thread-cert/test_srp_many_services_mtu_check.py
@@ -101,7 +101,7 @@ class SrpManyServicesMtuCheck(thread_cert.TestCase):
             name = chr(ord('a') + num) * 63
             client.srp_client_add_service(
                 name,
-                '_longsrvname._udp,_subtype1,_subtype2,_subtype3,_subtype4,_subtype5,_subtype6',
+                '_longlongsrvname._udp,_subtype1,_subtype2,_subtype3,_subtype4,_subtype5,_subtype6',
                 1977,
                 txt_entries=txt_info)
 
@@ -118,6 +118,23 @@ class SrpManyServicesMtuCheck(thread_cert.TestCase):
 
         server_services = server.srp_server_get_services()
         self.assertEqual(len(server_services), num_services)
+
+        # Remove all 8 services.
+
+        for num in range(num_services):
+            name = chr(ord('a') + num) * 63
+            client.srp_client_remove_service(name, '_longlongsrvname._udp')
+
+        self.simulator.go(10)
+
+        client_services = client.srp_client_get_services()
+        self.assertEqual(len(client_services), 0)
+
+        server_services = server.srp_server_get_services()
+        self.assertEqual(len(server_services), num_services)
+
+        for service in server_services:
+            self.assertEqual(service['deleted'], 'true')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This commit fixes the "single service mode" behavior to handle
if there are many simultaneous service removes. It also updates the
test to cover this situation.