### PR TITLE
[fuzz] declare `otPlatLog` as weak

### DIFF
--- a/tests/fuzz/fuzzer_platform.cpp
+++ b/tests/fuzz/fuzzer_platform.cpp
@@ -228,7 +228,7 @@ otPlatResetReason otPlatGetResetReason(otInstance *aInstance)
     return OT_PLAT_RESET_REASON_POWER_ON;
 }
 
-void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
+OT_TOOL_WEAK void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
 {
     OT_UNUSED_VARIABLE(aLogLevel);
     OT_UNUSED_VARIABLE(aLogRegion);


### PR DESCRIPTION
Fixes the following build error:
```
src/ncp/libopenthread-ncp-ftd.a(ncp_base.cpp.o): in function `otPlatLog':
ncp_base.cpp:(.text.otPlatLog[otPlatLog]+0x0): multiple definition of `otPlatLog'; /usr/bin/ld: DWARF error: invalid or unhandled FORM value: 0x25
tests/fuzz/CMakeFiles/ot-ncp-hdlc-received-fuzzer.dir/fuzzer_platform.cpp.o:fuzzer_platform.cpp:(.text.otPlatLog[otPlatLog]+0x0): first defined here
clang-15: error: linker command failed with exit code 1 (use -v to see invocation)
ninja: build stopped: subcommand failed.
```