### PR TITLE
[timer] add template `TimerMilliIn` to simplify handler functions

### DIFF
--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -67,7 +67,7 @@ Manager::Manager(Instance &aInstance)
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
     , mMulticastListenersTable(aInstance)
 #endif
-    , mTimer(aInstance, Manager::HandleTimer)
+    , mTimer(aInstance)
     , mBackboneTmfAgent(aInstance)
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
@@ -136,11 +136,6 @@ void Manager::HandleNotifierEvents(Events aEvents)
             LogError("Start Backbone TMF agent", error);
         }
     }
-}
-
-void Manager::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Manager>().HandleTimer();
 }
 
 void Manager::HandleTimer(void)

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -226,10 +226,11 @@ private:
 #endif
     void HandleNotifierEvents(Events aEvents);
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimer(void);
 
     void LogError(const char *aText, Error aError) const;
+
+    using BbrTimer = TimerMilliIn<Manager, &Manager::HandleTimer>;
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
     Coap::Resource mMulticastListenerRegistration;
@@ -244,7 +245,7 @@ private:
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
     MulticastListenersTable mMulticastListenersTable;
 #endif
-    TimerMilli mTimer;
+    BbrTimer mTimer;
 
     BackboneTmfAgent mBackboneTmfAgent;
 

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -75,8 +75,8 @@ RoutingManager::RoutingManager(Instance &aInstance)
     , mNat64PrefixManager(aInstance)
 #endif
     , mRsSender(aInstance)
-    , mDiscoveredPrefixStaleTimer(aInstance, HandleDiscoveredPrefixStaleTimer)
-    , mRoutingPolicyTimer(aInstance, HandleRoutingPolicyTimer)
+    , mDiscoveredPrefixStaleTimer(aInstance)
+    , mRoutingPolicyTimer(aInstance)
 {
     mFavoredDiscoveredOnLinkPrefix.Clear();
 
@@ -913,20 +913,10 @@ void RoutingManager::HandleRsSenderFinished(TimeMilli aStartTime)
     ScheduleRoutingPolicyEvaluation(kImmediately);
 }
 
-void RoutingManager::HandleDiscoveredPrefixStaleTimer(Timer &aTimer)
-{
-    aTimer.Get<RoutingManager>().HandleDiscoveredPrefixStaleTimer();
-}
-
 void RoutingManager::HandleDiscoveredPrefixStaleTimer(void)
 {
     LogInfo("Stale On-Link or OMR Prefixes or RA messages are detected");
     mRsSender.Start();
-}
-
-void RoutingManager::HandleRoutingPolicyTimer(Timer &aTimer)
-{
-    aTimer.Get<RoutingManager>().EvaluateRoutingPolicy();
 }
 
 void RoutingManager::HandleRouterSolicit(const InfraIf::Icmp6Packet &aPacket, const Ip6::Address &aSrcAddress)
@@ -1166,7 +1156,7 @@ void RoutingManager::ResetDiscoveredPrefixStaleTimer(void)
 
 RoutingManager::DiscoveredPrefixTable::DiscoveredPrefixTable(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mTimer(aInstance, HandleTimer)
+    , mTimer(aInstance)
     , mSignalTask(aInstance)
     , mAllowDefaultRouteInNetData(false)
 {
@@ -1634,11 +1624,6 @@ void RoutingManager::DiscoveredPrefixTable::UnpublishEntry(const Entry &aEntry)
     Get<RoutingManager>().UnpublishExternalRoute(aEntry.GetPrefix());
 }
 
-void RoutingManager::DiscoveredPrefixTable::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<RoutingManager>().mDiscoveredPrefixTable.HandleTimer();
-}
-
 void RoutingManager::DiscoveredPrefixTable::HandleTimer(void)
 {
     RemoveExpiredEntries();
@@ -1981,7 +1966,7 @@ exit:
 RoutingManager::LocalOnLinkPrefix::LocalOnLinkPrefix(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mState(kIdle)
-    , mTimer(aInstance, HandleTimer)
+    , mTimer(aInstance)
 {
     mPrefix.Clear();
     mOldPrefix.Clear();
@@ -2160,11 +2145,6 @@ void RoutingManager::LocalOnLinkPrefix::HandleExtPanIdChange(void)
     Generate();
 }
 
-void RoutingManager::LocalOnLinkPrefix::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<RoutingManager>().mLocalOnLinkPrefix.HandleTimer();
-}
-
 void RoutingManager::LocalOnLinkPrefix::HandleTimer(void)
 {
     TimeMilli now = TimerMilli::GetNow();
@@ -2247,7 +2227,7 @@ void RoutingManager::OnMeshPrefixArray::MarkAsDeleted(const OnMeshPrefix &aPrefi
 
 RoutingManager::Nat64PrefixManager::Nat64PrefixManager(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mTimer(aInstance, HandleTimer)
+    , mTimer(aInstance)
 {
     mInfraIfPrefix.Clear();
     mLocalPrefix.Clear();
@@ -2347,11 +2327,6 @@ void RoutingManager::Nat64PrefixManager::Evaluate(void)
 #endif
 }
 
-void RoutingManager::Nat64PrefixManager::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<RoutingManager>().mNat64PrefixManager.HandleTimer();
-}
-
 void RoutingManager::Nat64PrefixManager::HandleTimer(void)
 {
     Discover();
@@ -2394,7 +2369,7 @@ void RoutingManager::Nat64PrefixManager::HandleDiscoverDone(const Ip6::Prefix &a
 RoutingManager::RsSender::RsSender(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mTxCount(0)
-    , mTimer(aInstance, HandleTimer)
+    , mTimer(aInstance)
 {
 }
 
@@ -2430,11 +2405,6 @@ Error RoutingManager::RsSender::SendRs(void)
     destAddress.SetToLinkLocalAllRoutersMulticast();
 
     return Get<RoutingManager>().mInfraIf.Send(packet, destAddress);
-}
-
-void RoutingManager::RsSender::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<RoutingManager>().mRsSender.HandleTimer();
 }
 
 void RoutingManager::RsSender::HandleTimer(void)

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -376,6 +376,7 @@ private:
     };
 
     void HandleDiscoveredPrefixTableChanged(void); // Declare early so we can use in `mSignalTask`
+    void HandleDiscoveredPrefixTableTimer(void) { mDiscoveredPrefixTable.HandleTimer(); }
 
     class DiscoveredPrefixTable : public InstanceLocator
     {
@@ -425,6 +426,8 @@ private:
 
         void  InitIterator(PrefixTableIterator &aIterator) const;
         Error GetNextEntry(PrefixTableIterator &aIterator, PrefixTableEntry &aEntry) const;
+
+        void HandleTimer(void);
 
     private:
         static constexpr uint16_t kMaxRouters = OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_DISCOVERED_ROUTERS;
@@ -529,29 +532,28 @@ private:
             void          SetInitTime(void) { mData32 = TimerMilli::GetNow().GetValue(); }
         };
 
-        void        ProcessDefaultRoute(const Ip6::Nd::RouterAdvertMessage::Header &aRaHeader, Router &aRouter);
-        void        ProcessPrefixInfoOption(const Ip6::Nd::PrefixInfoOption &aPio, Router &aRouter);
-        void        ProcessRouteInfoOption(const Ip6::Nd::RouteInfoOption &aRio, Router &aRouter);
-        bool        ContainsPrefix(const Entry::Matcher &aMatcher) const;
-        void        RemovePrefix(const Entry::Matcher &aMatcher, NetDataMode aNetDataMode);
-        void        RemoveRoutersWithNoEntries(void);
-        Entry *     AllocateEntry(void) { return mEntryPool.Allocate(); }
-        void        FreeEntry(Entry &aEntry) { mEntryPool.Free(aEntry); }
-        void        FreeEntries(LinkedList<Entry> &aEntries);
-        void        UpdateNetworkDataOnChangeTo(Entry &aEntry);
-        Entry *     FindFavoredEntryToPublish(const Ip6::Prefix &aPrefix);
-        void        PublishEntry(const Entry &aEntry);
-        void        UnpublishEntry(const Entry &aEntry);
-        static void HandleTimer(Timer &aTimer);
-        void        HandleTimer(void);
-        void        RemoveExpiredEntries(void);
-        void        SignalTableChanged(void);
+        void   ProcessDefaultRoute(const Ip6::Nd::RouterAdvertMessage::Header &aRaHeader, Router &aRouter);
+        void   ProcessPrefixInfoOption(const Ip6::Nd::PrefixInfoOption &aPio, Router &aRouter);
+        void   ProcessRouteInfoOption(const Ip6::Nd::RouteInfoOption &aRio, Router &aRouter);
+        bool   ContainsPrefix(const Entry::Matcher &aMatcher) const;
+        void   RemovePrefix(const Entry::Matcher &aMatcher, NetDataMode aNetDataMode);
+        void   RemoveRoutersWithNoEntries(void);
+        Entry *AllocateEntry(void) { return mEntryPool.Allocate(); }
+        void   FreeEntry(Entry &aEntry) { mEntryPool.Free(aEntry); }
+        void   FreeEntries(LinkedList<Entry> &aEntries);
+        void   UpdateNetworkDataOnChangeTo(Entry &aEntry);
+        Entry *FindFavoredEntryToPublish(const Ip6::Prefix &aPrefix);
+        void   PublishEntry(const Entry &aEntry);
+        void   UnpublishEntry(const Entry &aEntry);
+        void   RemoveExpiredEntries(void);
+        void   SignalTableChanged(void);
 
         using SignalTask = TaskletIn<RoutingManager, &RoutingManager::HandleDiscoveredPrefixTableChanged>;
+        using TableTimer = TimerMilliIn<RoutingManager, &RoutingManager::HandleDiscoveredPrefixTableTimer>;
 
         Array<Router, kMaxRouters> mRouters;
         Pool<Entry, kMaxEntries>   mEntryPool;
-        TimerMilli                 mTimer;
+        TableTimer                 mTimer;
         SignalTask                 mSignalTask;
         bool                       mAllowDefaultRouteInNetData;
     };
@@ -593,6 +595,8 @@ private:
         bool        mIsAddedInNetData;
     };
 
+    void HandleLocalOnLinkPrefixTimer(void) { mLocalOnLinkPrefix.HandleTimer(); }
+
     class LocalOnLinkPrefix : public InstanceLocator
     {
     public:
@@ -607,6 +611,7 @@ private:
         const Ip6::Prefix &GetPrefix(void) const { return mPrefix; }
         bool               IsAdvertising(void) const { return (mState == kAdvertising); }
         void               HandleExtPanIdChange(void);
+        void               HandleTimer(void);
 
     private:
         enum State : uint8_t
@@ -620,15 +625,14 @@ private:
         void AppendOldPrefix(Ip6::Nd::RouterAdvertMessage &aRaMessage);
         void Unpublish(const Ip6::Prefix &aPrefix);
 
-        static void HandleTimer(Timer &aTimer);
-        void        HandleTimer(void);
+        using ExpireTimer = TimerMilliIn<RoutingManager, &RoutingManager::HandleLocalOnLinkPrefixTimer>;
 
         Ip6::Prefix mPrefix;
         State       mState;
         TimeMilli   mExpireTime;
         Ip6::Prefix mOldPrefix;
         TimeMilli   mOldExpireTime;
-        TimerMilli  mTimer;
+        ExpireTimer mTimer;
     };
 
     typedef Ip6::Prefix OnMeshPrefix;
@@ -641,6 +645,8 @@ private:
     };
 
 #if OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
+    void HandleNat64PrefixManagerTimer(void) { mNat64PrefixManager.HandleTimer(); }
+
     class Nat64PrefixManager : public InstanceLocator
     {
     public:
@@ -659,16 +665,17 @@ private:
         const Ip6::Prefix &GetFavoredPrefix(RoutePreference &aPreference) const;
         void               Evaluate(void);
         void               HandleDiscoverDone(const Ip6::Prefix &aPrefix);
+        void               HandleTimer(void);
 
     private:
-        void        Discover(void);
-        static void HandleTimer(Timer &aTimer);
-        void        HandleTimer(void);
+        void Discover(void);
+
+        using Nat64Timer = TimerMilliIn<RoutingManager, &RoutingManager::HandleNat64PrefixManagerTimer>;
 
         Ip6::Prefix mInfraIfPrefix;   // The latest NAT64 prefix discovered on the infrastructure interface.
         Ip6::Prefix mLocalPrefix;     // The local prefix (from BR ULA prefix).
         Ip6::Prefix mPublishedPrefix; // The prefix published in Network Data (may be empty or local or from infra-if).
-        TimerMilli  mTimer;
+        Nat64Timer  mTimer;
     };
 #endif // OPENTHREAD_CONFIG_NAT64_BORDER_ROUTING_ENABLE
 
@@ -696,6 +703,8 @@ private:
         TimeMilli                            mLastTxTime;
     };
 
+    void HandleRsSenderTimer(void) { mRsSender.HandleTimer(); }
+
     class RsSender : public InstanceLocator
     {
     public:
@@ -711,6 +720,7 @@ private:
         bool IsInProgress(void) const { return mTimer.IsRunning(); }
         void Start(void);
         void Stop(void);
+        void HandleTimer(void);
 
     private:
         // All time intervals are in msec.
@@ -720,13 +730,13 @@ private:
         static constexpr uint32_t kWaitOnLastAttempt = 1000;        // Wait interval after last RS tx.
         static constexpr uint8_t  kMaxTxCount        = 3;           // Number of RS tx in one cycle.
 
-        Error       SendRs(void);
-        static void HandleTimer(Timer &aTimer);
-        void        HandleTimer(void);
+        Error SendRs(void);
 
-        uint8_t    mTxCount;
-        TimerMilli mTimer;
-        TimeMilli  mStartTime;
+        using RsTimer = TimerMilliIn<RoutingManager, &RoutingManager::HandleRsSenderTimer>;
+
+        uint8_t   mTxCount;
+        RsTimer   mTimer;
+        TimeMilli mStartTime;
     };
 
     void  EvaluateState(void);
@@ -747,11 +757,7 @@ private:
     void  HandleRsSenderFinished(TimeMilli aStartTime);
     void  SendRouterAdvertisement(RouterAdvTxMode aRaTxMode);
 
-    static void HandleDiscoveredPrefixInvalidTimer(Timer &aTimer);
-    void        HandleDiscoveredPrefixInvalidTimer(void);
-    static void HandleDiscoveredPrefixStaleTimer(Timer &aTimer);
-    void        HandleDiscoveredPrefixStaleTimer(void);
-    static void HandleRoutingPolicyTimer(Timer &aTimer);
+    void HandleDiscoveredPrefixStaleTimer(void);
 
     void HandleRouterSolicit(const InfraIf::Icmp6Packet &aPacket, const Ip6::Address &aSrcAddress);
     void HandleRouterAdvertisement(const InfraIf::Icmp6Packet &aPacket, const Ip6::Address &aSrcAddress);
@@ -766,6 +772,9 @@ private:
     static bool IsValidBrUlaPrefix(const Ip6::Prefix &aBrUlaPrefix);
     static bool IsValidOnLinkPrefix(const Ip6::Nd::PrefixInfoOption &aPio);
     static bool IsValidOnLinkPrefix(const Ip6::Prefix &aOnLinkPrefix);
+
+    using RoutingPolicyTimer         = TimerMilliIn<RoutingManager, &RoutingManager::EvaluateRoutingPolicy>;
+    using DiscoveredPrefixStaleTimer = TimerMilliIn<RoutingManager, &RoutingManager::HandleDiscoveredPrefixStaleTimer>;
 
     // Indicates whether the Routing Manager is running (started).
     bool mIsRunning;
@@ -804,8 +813,8 @@ private:
     RaInfo   mRaInfo;
     RsSender mRsSender;
 
-    TimerMilli mDiscoveredPrefixStaleTimer;
-    TimerMilli mRoutingPolicyTimer;
+    DiscoveredPrefixStaleTimer mDiscoveredPrefixStaleTimer;
+    RoutingPolicyTimer         mRoutingPolicyTimer;
 };
 
 } // namespace BorderRouter

--- a/src/core/common/locator_getters.hpp
+++ b/src/core/common/locator_getters.hpp
@@ -56,6 +56,20 @@ void TaskletIn<Owner, HandleTaskletPtr>::HandleTasklet(Tasklet &aTasklet)
     (aTasklet.Get<Owner>().*HandleTaskletPtr)();
 }
 
+template <typename Owner, void (Owner::*HandleTimertPtr)(void)>
+void TimerMilliIn<Owner, HandleTimertPtr>::HandleTimer(Timer &aTimer)
+{
+    (aTimer.Get<Owner>().*HandleTimertPtr)();
+}
+
+#if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+template <typename Owner, void (Owner::*HandleTimertPtr)(void)>
+void TimerMicroIn<Owner, HandleTimertPtr>::HandleTimer(Timer &aTimer)
+{
+    (aTimer.Get<Owner>().*HandleTimertPtr)();
+}
+#endif
+
 } // namespace ot
 
 #endif // LOCATOR_GETTERS_HPP_

--- a/src/core/common/time_ticker.cpp
+++ b/src/core/common/time_ticker.cpp
@@ -45,7 +45,7 @@ namespace ot {
 TimeTicker::TimeTicker(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mReceivers(0)
-    , mTimer(aInstance, HandleTimer)
+    , mTimer(aInstance)
 {
 }
 
@@ -67,11 +67,6 @@ void TimeTicker::UnregisterReceiver(Receiver aReceiver)
     {
         mTimer.Stop();
     }
-}
-
-void TimeTicker::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<TimeTicker>().HandleTimer();
 }
 
 void TimeTicker::HandleTimer(void)

--- a/src/core/common/time_ticker.hpp
+++ b/src/core/common/time_ticker.hpp
@@ -115,11 +115,12 @@ private:
 
     constexpr static uint32_t Mask(Receiver aReceiver) { return static_cast<uint32_t>(1U) << aReceiver; }
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimer(void);
 
-    uint32_t   mReceivers;
-    TimerMilli mTimer;
+    using TickerTimer = TimerMilliIn<TimeTicker, &TimeTicker::HandleTimer>;
+
+    uint32_t    mReceivers;
+    TickerTimer mTimer;
 
     static_assert(kNumReceivers < sizeof(mReceivers) * CHAR_BIT, "Too many `Receiver`s - does not fit in a bit mask");
 };

--- a/src/core/common/timer.hpp
+++ b/src/core/common/timer.hpp
@@ -247,6 +247,33 @@ protected:
 };
 
 /**
+ * This template class defines a timer owned by a specific type and using a method on owner type as the callback.
+ *
+ * @tparam Owner              The type of the owner of this timer.
+ * @tparam HandleTimerPtr     A pointer to a non-static member method of `Owner` to use as timer handler.
+ *
+ * The `Owner` MUST be a type that is accessible using `InstanceLocator::Get<Owner>()`.
+ *
+ */
+template <typename Owner, void (Owner::*HandleTimerPtr)(void)> class TimerMilliIn : public TimerMilli
+{
+public:
+    /**
+     * This constructor initializes the timer.
+     *
+     * @param[in]  aInstance   The OpenThread instance.
+     *
+     */
+    explicit TimerMilliIn(Instance &aInstance)
+        : TimerMilli(aInstance, HandleTimer)
+    {
+    }
+
+private:
+    static void HandleTimer(Timer &aTimer); // Implemented in `locator_getters.hpp`
+};
+
+/**
  * This class implements a millisecond timer that also maintains a user context pointer.
  *
  * In typical `TimerMilli`/`TimerMicro` use, in the timer callback handler, the owner of the timer is determined using
@@ -379,6 +406,34 @@ public:
 protected:
     static void RemoveAll(Instance &aInstance);
 };
+
+/**
+ * This template class defines a timer owned by a specific type and using a method on owner type as the callback.
+ *
+ * @tparam Owner              The type of the owner of this timer.
+ * @tparam HandleTimerPtr     A pointer to a non-static member method of `Owner` to use as timer handler.
+ *
+ * The `Owner` MUST be a type that is accessible using `InstanceLocator::Get<Owner>()`.
+ *
+ */
+template <typename Owner, void (Owner::*HandleTimerPtr)(void)> class TimerMicroIn : public TimerMicro
+{
+public:
+    /**
+     * This constructor initializes the timer.
+     *
+     * @param[in]  aInstance   The OpenThread instance.
+     *
+     */
+    explicit TimerMicroIn(Instance &aInstance)
+        : TimerMicro(aInstance, HandleTimer)
+    {
+    }
+
+private:
+    static void HandleTimer(Timer &aTimer); // Implemented in `locator_getters.hpp`
+};
+
 #endif // OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
 
 /**

--- a/src/core/common/uptime.cpp
+++ b/src/core/common/uptime.cpp
@@ -46,7 +46,7 @@ Uptime::Uptime(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mStartTime(TimerMilli::GetNow())
     , mOverflowCount(0)
-    , mTimer(aInstance, HandleTimer)
+    , mTimer(aInstance)
 {
     mTimer.FireAt(mStartTime + kTimerInterval);
 }
@@ -86,11 +86,6 @@ void Uptime::GetUptime(char *aBuffer, uint16_t aSize) const
     StringWriter writer(aBuffer, aSize);
 
     UptimeToString(GetUptime(), writer);
-}
-
-void Uptime::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Uptime>().HandleTimer();
 }
 
 void Uptime::HandleTimer(void)

--- a/src/core/common/uptime.hpp
+++ b/src/core/common/uptime.hpp
@@ -103,12 +103,13 @@ private:
 
     static_assert(static_cast<uint32_t>(4 * kTimerInterval) == 0, "kTimerInterval is not correct");
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimer(void);
 
-    TimeMilli  mStartTime;
-    uint32_t   mOverflowCount;
-    TimerMilli mTimer;
+    using UptimeTimer = TimerMilliIn<Uptime, &Uptime::HandleTimer>;
+
+    TimeMilli   mStartTime;
+    uint32_t    mOverflowCount;
+    UptimeTimer mTimer;
 };
 
 } // namespace ot

--- a/src/core/mac/data_poll_sender.cpp
+++ b/src/core/mac/data_poll_sender.cpp
@@ -55,7 +55,7 @@ DataPollSender::DataPollSender(Instance &aInstance)
     , mPollPeriod(0)
     , mExternalPollPeriod(0)
     , mFastPollsUsers(0)
-    , mTimer(aInstance, DataPollSender::HandlePollTimer)
+    , mTimer(aInstance)
     , mEnabled(false)
     , mAttachMode(false)
     , mRetxMode(false)
@@ -531,11 +531,6 @@ uint32_t DataPollSender::CalculatePollPeriod(void) const
     }
 
     return period;
-}
-
-void DataPollSender::HandlePollTimer(Timer &aTimer)
-{
-    IgnoreError(aTimer.Get<DataPollSender>().SendDataPoll());
 }
 
 uint32_t DataPollSender::GetDefaultPollPeriod(void) const

--- a/src/core/mac/data_poll_sender.hpp
+++ b/src/core/mac/data_poll_sender.hpp
@@ -276,19 +276,21 @@ private:
     void            ScheduleNextPoll(PollPeriodSelector aPollPeriodSelector);
     uint32_t        CalculatePollPeriod(void) const;
     const Neighbor &GetParent(void) const;
-    static void     HandlePollTimer(Timer &aTimer);
+    void            HandlePollTimer(void) { IgnoreError(SendDataPoll()); }
 #if OPENTHREAD_CONFIG_MULTI_RADIO
     Error GetPollDestinationAddress(Mac::Address &aDest, Mac::RadioType &aRadioType) const;
 #else
     Error GetPollDestinationAddress(Mac::Address &aDest) const;
 #endif
 
+    using PollTimer = TimerMilliIn<DataPollSender, &DataPollSender::HandlePollTimer>;
+
     TimeMilli mTimerStartTime;
     uint32_t  mPollPeriod;
     uint32_t  mExternalPollPeriod : 26; // In milliseconds.
     uint8_t   mFastPollsUsers : 6;      // Number of callers which request fast polls.
 
-    TimerMilli mTimer;
+    PollTimer mTimer;
 
     bool    mEnabled : 1;              // Indicates whether data polling is enabled/started.
     bool    mAttachMode : 1;           // Indicates whether in attach mode (to use attach poll period).

--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -101,7 +101,7 @@ Mac::Mac(Instance &aInstance)
     , mScanHandlerContext(nullptr)
     , mLinks(aInstance)
     , mOperationTask(aInstance)
-    , mTimer(aInstance, Mac::HandleTimer)
+    , mTimer(aInstance)
     , mKeyIdMode2FrameCounter(0)
     , mCcaSampleCount(0)
 #if OPENTHREAD_CONFIG_MULTI_RADIO
@@ -1446,11 +1446,6 @@ void Mac::HandleTransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, Error aError)
 
 exit:
     return;
-}
-
-void Mac::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Mac>().HandleTimer();
 }
 
 void Mac::HandleTimer(void)

--- a/src/core/mac/mac.hpp
+++ b/src/core/mac/mac.hpp
@@ -759,9 +759,7 @@ private:
     bool     IsJoinable(void) const;
     void     BeginTransmit(void);
     bool     HandleMacCommand(RxFrame &aFrame);
-
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void     HandleTimer(void);
 
     void  Scan(Operation aScanOperation, uint32_t aScanChannels, uint16_t aScanDuration);
     Error UpdateScanChannel(void);
@@ -788,6 +786,7 @@ private:
     static const char *OperationToString(Operation aOperation);
 
     using OperationTask = TaskletIn<Mac, &Mac::PerformNextOperation>;
+    using MacTimer      = TimerMilliIn<Mac, &Mac::HandleTimer>;
 
     static const otExtAddress sMode2ExtAddress;
 
@@ -836,7 +835,7 @@ private:
 
     Links              mLinks;
     OperationTask      mOperationTask;
-    TimerMilli         mTimer;
+    MacTimer           mTimer;
     otMacCounters      mCounters;
     uint32_t           mKeyIdMode2FrameCounter;
     SuccessRateTracker mCcaSuccessRateTracker;

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -59,7 +59,7 @@ SubMac::SubMac(Instance &aInstance)
     , mCallbacks(aInstance)
     , mPcapCallback(nullptr)
     , mPcapCallbackContext(nullptr)
-    , mTimer(aInstance, SubMac::HandleTimer)
+    , mTimer(aInstance)
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     , mCslTimer(aInstance, SubMac::HandleCslTimer)
 #endif
@@ -774,11 +774,6 @@ void SubMac::HandleEnergyScanDone(int8_t aMaxRssi)
 {
     SetState(kStateReceive);
     mCallbacks.EnergyScanDone(aMaxRssi);
-}
-
-void SubMac::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<SubMac>().HandleTimer();
 }
 
 void SubMac::HandleTimer(void)

--- a/src/core/mac/sub_mac.hpp
+++ b/src/core/mac/sub_mac.hpp
@@ -602,12 +602,17 @@ private:
     void HandleTransmitDone(TxFrame &aFrame, RxFrame *aAckFrame, Error aError);
     void SignalFrameCounterUsedOnTxDone(const TxFrame &aFrame);
     void HandleEnergyScanDone(int8_t aMaxRssi);
-
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimer(void);
 
     void               SetState(State aState);
     static const char *StateToString(State aState);
+
+    using SubMacTimer =
+#if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
+        TimerMicroIn<SubMac, &SubMac::HandleTimer>;
+#else
+        TimerMilliIn<SubMac, &SubMac::HandleTimer>;
+#endif
 
     otRadioCaps  mRadioCaps;
     State        mState;
@@ -633,11 +638,7 @@ private:
 #if OPENTHREAD_CONFIG_MAC_ADD_DELAY_ON_NO_ACK_ERROR_BEFORE_RETRY
     uint8_t mRetxDelayBackOffExponent;
 #endif
-#if OPENTHREAD_CONFIG_PLATFORM_USEC_TIMER_ENABLE
-    TimerMicro mTimer;
-#else
-    TimerMilli                mTimer;
-#endif
+    SubMacTimer mTimer;
 
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     uint16_t mCslPeriod;      // The CSL sample period, in units of 10 symbols (160 microseconds).

--- a/src/core/meshcop/border_agent.cpp
+++ b/src/core/meshcop/border_agent.cpp
@@ -291,7 +291,7 @@ BorderAgent::BorderAgent(Instance &aInstance)
     , mPendingSet(UriPath::kPendingSet, BorderAgent::HandleRequest<&BorderAgent::mPendingSet>, this)
     , mProxyTransmit(UriPath::kProxyTx, BorderAgent::HandleRequest<&BorderAgent::mProxyTransmit>, this)
     , mUdpReceiver(BorderAgent::HandleUdpReceive, this)
-    , mTimer(aInstance, HandleTimeout)
+    , mTimer(aInstance)
     , mState(kStateStopped)
     , mUdpProxyPort(0)
 {
@@ -603,11 +603,6 @@ exit:
     {
         LogWarn("failed to start Border Agent on port %d: %s", kBorderAgentUdpPort, ErrorToString(error));
     }
-}
-
-void BorderAgent::HandleTimeout(Timer &aTimer)
-{
-    aTimer.Get<BorderAgent>().HandleTimeout();
 }
 
 void BorderAgent::HandleTimeout(void)

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -175,6 +175,8 @@ private:
 
     static constexpr uint32_t kKeepAliveTimeout = 50 * 1000; // Timeout to reject a commissioner.
 
+    using TimeoutTimer = TimerMilliIn<BorderAgent, &BorderAgent::HandleTimeout>;
+
     Ip6::MessageInfo mMessageInfo;
 
     Coap::Resource mCommissionerPetition;
@@ -192,9 +194,9 @@ private:
     Ip6::Udp::Receiver         mUdpReceiver; ///< The UDP receiver to receive packets from external commissioner
     Ip6::Netif::UnicastAddress mCommissionerAloc;
 
-    TimerMilli mTimer;
-    State      mState;
-    uint16_t   mUdpProxyPort;
+    TimeoutTimer mTimer;
+    State        mState;
+    uint16_t     mUdpProxyPort;
 };
 
 } // namespace MeshCoP

--- a/src/core/meshcop/commissioner.cpp
+++ b/src/core/meshcop/commissioner.cpp
@@ -64,8 +64,8 @@ Commissioner::Commissioner(Instance &aInstance)
     , mJoinerRloc(0)
     , mSessionId(0)
     , mTransmitAttempts(0)
-    , mJoinerExpirationTimer(aInstance, HandleJoinerExpirationTimer)
-    , mTimer(aInstance, HandleTimer)
+    , mJoinerExpirationTimer(aInstance)
+    , mTimer(aInstance)
     , mRelayReceive(UriPath::kRelayRx, &Commissioner::HandleRelayReceive, this)
     , mDatasetChanged(UriPath::kDatasetChanged, &Commissioner::HandleDatasetChanged, this)
     , mJoinerFinalize(UriPath::kJoinerFinalize, &Commissioner::HandleJoinerFinalize, this)
@@ -628,11 +628,6 @@ exit:
     return error;
 }
 
-void Commissioner::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Commissioner>().HandleTimer();
-}
-
 void Commissioner::HandleTimer(void)
 {
     switch (mState)
@@ -648,11 +643,6 @@ void Commissioner::HandleTimer(void)
         SendKeepAlive();
         break;
     }
-}
-
-void Commissioner::HandleJoinerExpirationTimer(Timer &aTimer)
-{
-    aTimer.Get<Commissioner>().HandleJoinerExpirationTimer();
 }
 
 void Commissioner::HandleJoinerExpirationTimer(void)

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -542,11 +542,8 @@ private:
     void AddCoapResources(void);
     void RemoveCoapResources(void);
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
-
-    static void HandleJoinerExpirationTimer(Timer &aTimer);
-    void        HandleJoinerExpirationTimer(void);
+    void HandleTimer(void);
+    void HandleJoinerExpirationTimer(void);
 
     void UpdateJoinerExpirationTimer(void);
 
@@ -604,6 +601,9 @@ private:
 
     static const char *StateToString(State aState);
 
+    using JoinerExpirationTimer = TimerMilliIn<Commissioner, &Commissioner::HandleJoinerExpirationTimer>;
+    using CommissionerTimer     = TimerMilliIn<Commissioner, &Commissioner::HandleTimer>;
+
     Joiner mJoiners[OPENTHREAD_CONFIG_COMMISSIONER_MAX_JOINER_ENTRIES];
 
     Joiner *                 mActiveJoiner;
@@ -612,8 +612,8 @@ private:
     uint16_t                 mJoinerRloc;
     uint16_t                 mSessionId;
     uint8_t                  mTransmitAttempts;
-    TimerMilli               mJoinerExpirationTimer;
-    TimerMilli               mTimer;
+    JoinerExpirationTimer    mJoinerExpirationTimer;
+    CommissionerTimer        mTimer;
 
     Coap::Resource mRelayReceive;
     Coap::Resource mDatasetChanged;

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -706,7 +706,7 @@ void ActiveDatasetManager::HandleTimer(Timer &aTimer)
 
 PendingDatasetManager::PendingDatasetManager(Instance &aInstance)
     : DatasetManager(aInstance, Dataset::kPending, PendingDatasetManager::HandleTimer)
-    , mDelayTimer(aInstance, PendingDatasetManager::HandleDelayTimer)
+    , mDelayTimer(aInstance)
     , mResourceGet(UriPath::kPendingGet, &PendingDatasetManager::HandleGet, this)
 #if OPENTHREAD_FTD
     , mResourceSet(UriPath::kPendingSet, &PendingDatasetManager::HandleSet, this)
@@ -802,11 +802,6 @@ void PendingDatasetManager::StartDelayTimer(void)
         mDelayTimer.StartAt(dataset.GetUpdateTime(), delay);
         LogInfo("delay timer started %d", delay);
     }
-}
-
-void PendingDatasetManager::HandleDelayTimer(Timer &aTimer)
-{
-    aTimer.Get<PendingDatasetManager>().HandleDelayTimer();
 }
 
 void PendingDatasetManager::HandleDelayTimer(void)

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -613,8 +613,7 @@ private:
     static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void) { DatasetManager::HandleTimer(); }
 
-    static void HandleDelayTimer(Timer &aTimer);
-    void        HandleDelayTimer(void);
+    void HandleDelayTimer(void);
 
     static void HandleGet(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleGet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo) const;
@@ -624,7 +623,9 @@ private:
     void        HandleSet(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 #endif
 
-    TimerMilli mDelayTimer;
+    using DelayTimer = TimerMilliIn<PendingDatasetManager, &PendingDatasetManager::HandleDelayTimer>;
+
+    DelayTimer mDelayTimer;
 
     Coap::Resource mResourceGet;
 

--- a/src/core/meshcop/dataset_updater.cpp
+++ b/src/core/meshcop/dataset_updater.cpp
@@ -50,7 +50,7 @@ DatasetUpdater::DatasetUpdater(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mCallback(nullptr)
     , mCallbackContext(nullptr)
-    , mTimer(aInstance, DatasetUpdater::HandleTimer)
+    , mTimer(aInstance)
     , mDataset(nullptr)
 {
 }
@@ -92,11 +92,6 @@ void DatasetUpdater::CancelUpdate(void)
 
 exit:
     return;
-}
-
-void DatasetUpdater::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<DatasetUpdater>().HandleTimer();
 }
 
 void DatasetUpdater::HandleTimer(void)

--- a/src/core/meshcop/dataset_updater.hpp
+++ b/src/core/meshcop/dataset_updater.hpp
@@ -118,16 +118,17 @@ private:
     // Retry interval (in ms) when preparing and/or sending Pending Dataset fails.
     static constexpr uint32_t kRetryInterval = 1000;
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
-    void        PreparePendingDataset(void);
-    void        Finish(Error aError);
-    void        HandleNotifierEvents(Events aEvents);
+    void HandleTimer(void);
+    void PreparePendingDataset(void);
+    void Finish(Error aError);
+    void HandleNotifierEvents(Events aEvents);
 
-    Callback   mCallback;
-    void *     mCallbackContext;
-    TimerMilli mTimer;
-    Message *  mDataset;
+    using UpdaterTimer = TimerMilliIn<DatasetUpdater, &DatasetUpdater::HandleTimer>;
+
+    Callback     mCallback;
+    void *       mCallbackContext;
+    UpdaterTimer mTimer;
+    Message *    mDataset;
 };
 
 } // namespace MeshCoP

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -66,7 +66,7 @@ Joiner::Joiner(Instance &aInstance)
     , mContext(nullptr)
     , mJoinerRouterIndex(0)
     , mFinalizeMessage(nullptr)
-    , mTimer(aInstance, Joiner::HandleTimer)
+    , mTimer(aInstance)
     , mJoinerEntrust(UriPath::kJoinerEntrust, &Joiner::HandleJoinerEntrust, this)
 {
     SetIdFromIeeeEui64();
@@ -613,11 +613,6 @@ void Joiner::SendJoinerEntrustResponse(const Coap::Message &aRequest, const Ip6:
 
 exit:
     FreeMessageOnError(message, error);
-}
-
-void Joiner::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Joiner>().HandleTimer();
 }
 
 void Joiner::HandleTimer(void)

--- a/src/core/meshcop/joiner.hpp
+++ b/src/core/meshcop/joiner.hpp
@@ -208,8 +208,7 @@ private:
     static void HandleJoinerEntrust(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleJoinerEntrust(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimer(void);
 
     void    SetState(State aState);
     void    SetIdFromIeeeEui64(void);
@@ -232,6 +231,8 @@ private:
     void LogCertMessage(const char *aText, const Coap::Message &aMessage) const;
 #endif
 
+    using JoinerTimer = TimerMilliIn<Joiner, &Joiner::HandleTimer>;
+
     Mac::ExtAddress mId;
     JoinerDiscerner mDiscerner;
 
@@ -245,7 +246,7 @@ private:
 
     Coap::Message *mFinalizeMessage;
 
-    TimerMilli     mTimer;
+    JoinerTimer    mTimer;
     Coap::Resource mJoinerEntrust;
 };
 

--- a/src/core/meshcop/joiner_router.cpp
+++ b/src/core/meshcop/joiner_router.cpp
@@ -58,7 +58,7 @@ JoinerRouter::JoinerRouter(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mSocket(aInstance)
     , mRelayTransmit(UriPath::kRelayTx, &JoinerRouter::HandleRelayTransmit, this)
-    , mTimer(aInstance, JoinerRouter::HandleTimer)
+    , mTimer(aInstance)
     , mJoinerUdpPort(0)
     , mIsJoinerPortConfigured(false)
 {
@@ -240,11 +240,6 @@ void JoinerRouter::DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessageInf
 exit:
     FreeMessageOnError(message, error);
     LogError("schedule joiner entrust", error);
-}
-
-void JoinerRouter::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<JoinerRouter>().HandleTimer();
 }
 
 void JoinerRouter::HandleTimer(void)

--- a/src/core/meshcop/joiner_router.hpp
+++ b/src/core/meshcop/joiner_router.hpp
@@ -110,8 +110,7 @@ private:
                                             Error                aResult);
     void HandleJoinerEntrustResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimer(void);
 
     void           Start(void);
     void           DelaySendingJoinerEntrust(const Ip6::MessageInfo &aMessageInfo, const Kek &aKek);
@@ -119,11 +118,13 @@ private:
     Error          SendJoinerEntrust(const Ip6::MessageInfo &aMessageInfo);
     Coap::Message *PrepareJoinerEntrustMessage(void);
 
+    using JoinerRouterTimer = TimerMilliIn<JoinerRouter, &JoinerRouter::HandleTimer>;
+
     Ip6::Udp::Socket mSocket;
     Coap::Resource   mRelayTransmit;
 
-    TimerMilli   mTimer;
-    MessageQueue mDelayedJoinEnts;
+    JoinerRouterTimer mTimer;
+    MessageQueue      mDelayedJoinEnts;
 
     uint16_t mJoinerUdpPort;
 

--- a/src/core/meshcop/meshcop_leader.cpp
+++ b/src/core/meshcop/meshcop_leader.cpp
@@ -59,7 +59,7 @@ Leader::Leader(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mPetition(UriPath::kLeaderPetition, Leader::HandlePetition, this)
     , mKeepAlive(UriPath::kLeaderKeepAlive, Leader::HandleKeepAlive, this)
-    , mTimer(aInstance, HandleTimer)
+    , mTimer(aInstance)
     , mDelayTimerMinimal(DelayTimerTlv::kDelayTimerMinimal)
     , mSessionId(Random::NonCrypto::GetUint16())
 {
@@ -256,11 +256,6 @@ exit:
 uint32_t Leader::GetDelayTimerMinimal(void) const
 {
     return mDelayTimerMinimal;
-}
-
-void Leader::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Leader>().HandleTimer();
 }
 
 void Leader::HandleTimer(void)

--- a/src/core/meshcop/meshcop_leader.hpp
+++ b/src/core/meshcop/meshcop_leader.hpp
@@ -111,8 +111,7 @@ public:
 private:
     static constexpr uint32_t kTimeoutLeaderPetition = 50; // TIMEOUT_LEAD_PET (seconds)
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimer(void);
 
     static void HandlePetition(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandlePetition(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
@@ -130,9 +129,11 @@ private:
 
     void ResignCommissioner(void);
 
+    using LeaderTimer = TimerMilliIn<Leader, &Leader::HandleTimer>;
+
     Coap::Resource mPetition;
     Coap::Resource mKeepAlive;
-    TimerMilli     mTimer;
+    LeaderTimer    mTimer;
 
     uint32_t mDelayTimerMinimal;
 

--- a/src/core/net/dns_client.cpp
+++ b/src/core/net/dns_client.cpp
@@ -530,7 +530,7 @@ const uint16_t *Client::kQuestionRecordTypes[] = {
 Client::Client(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mSocket(aInstance)
-    , mTimer(aInstance, Client::HandleTimer)
+    , mTimer(aInstance)
     , mDefaultConfig(QueryConfig::kInitFromDefaults)
 #if OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_SERVER_ADDRESS_AUTO_SET_ENABLE
     , mUserDidSetDefaultAddress(false)
@@ -1060,11 +1060,6 @@ exit:
     }
 
     return error;
-}
-
-void Client::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Client>().HandleTimer();
 }
 
 void Client::HandleTimer(void)

--- a/src/core/net/dns_client.hpp
+++ b/src/core/net/dns_client.hpp
@@ -743,7 +743,6 @@ private:
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMsgInfo);
     void        ProcessResponse(const Message &aMessage);
     Error       ParseResponse(Response &aResponse, QueryType &aType, Error &aResponseError);
-    static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
 #if OPENTHREAD_CONFIG_DNS_CLIENT_NAT64_ENABLE
     Error CheckAddressResponse(Response &aResponse, Error aResponseError) const;
@@ -764,9 +763,11 @@ private:
     static const uint16_t kServiceQueryRecordTypes[];
 #endif
 
+    using RetryTimer = TimerMilliIn<Client, &Client::HandleTimer>;
+
     Ip6::Udp::Socket mSocket;
     QueryList        mQueries;
-    TimerMilli       mTimer;
+    RetryTimer       mTimer;
     QueryConfig      mDefaultConfig;
 #if OPENTHREAD_CONFIG_DNS_CLIENT_DEFAULT_SERVER_ADDRESS_AUTO_SET_ENABLE
     bool mUserDidSetDefaultAddress;

--- a/src/core/net/dns_dso.cpp
+++ b/src/core/net/dns_dso.cpp
@@ -1449,7 +1449,7 @@ exit:
 Dso::Dso(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mAcceptHandler(nullptr)
-    , mTimer(aInstance, HandleTimer)
+    , mTimer(aInstance)
 {
 }
 
@@ -1486,11 +1486,6 @@ Dso::Connection *Dso::AcceptConnection(const Ip6::SockAddr &aPeerSockAddr)
 
 exit:
     return connection;
-}
-
-void Dso::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Dso>().HandleTimer();
 }
 
 void Dso::HandleTimer(void)

--- a/src/core/net/dns_dso.hpp
+++ b/src/core/net/dns_dso.hpp
@@ -953,13 +953,14 @@ private:
 
     Connection *AcceptConnection(const Ip6::SockAddr &aPeerSockAddr);
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimer(void);
+
+    using DsoTimer = TimerMilliIn<Dso, &Dso::HandleTimer>;
 
     AcceptHandler          mAcceptHandler;
     LinkedList<Connection> mClientConnections;
     LinkedList<Connection> mServerConnections;
-    TimerMilli             mTimer;
+    DsoTimer               mTimer;
 };
 
 } // namespace Dns

--- a/src/core/net/dnssd_server.cpp
+++ b/src/core/net/dnssd_server.cpp
@@ -63,7 +63,7 @@ Server::Server(Instance &aInstance)
     , mQueryCallbackContext(nullptr)
     , mQuerySubscribe(nullptr)
     , mQueryUnsubscribe(nullptr)
-    , mTimer(aInstance, Server::HandleTimer)
+    , mTimer(aInstance)
 {
     mCounters.Clear();
 }
@@ -1121,11 +1121,6 @@ bool Server::HasQuestion(const Header &aHeader, const Message &aMessage, const c
 
 exit:
     return found;
-}
-
-void Server::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Server>().HandleTimer();
 }
 
 void Server::HandleTimer(void)

--- a/src/core/net/dnssd_server.hpp
+++ b/src/core/net/dnssd_server.hpp
@@ -405,23 +405,26 @@ private:
                                             const Message &aMessage,
                                             char (&aName)[Name::kMaxNameSize]);
     static bool HasQuestion(const Header &aHeader, const Message &aMessage, const char *aName, uint16_t aQuestionType);
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
-    void        ResetTimer(void);
+
+    void HandleTimer(void);
+    void ResetTimer(void);
 
     void UpdateResponseCounters(Header::Response aResponseCode);
+
+    using ServerTimer = TimerMilliIn<Server, &Server::HandleTimer>;
 
     static const char kDnssdProtocolUdp[];
     static const char kDnssdProtocolTcp[];
     static const char kDnssdSubTypeLabel[];
     static const char kDefaultDomainName[];
-    Ip6::Udp::Socket  mSocket;
+
+    Ip6::Udp::Socket mSocket;
 
     QueryTransaction                mQueryTransactions[kMaxConcurrentQueries];
     void *                          mQueryCallbackContext;
     otDnssdQuerySubscribeCallback   mQuerySubscribe;
     otDnssdQueryUnsubscribeCallback mQueryUnsubscribe;
-    TimerMilli                      mTimer;
+    ServerTimer                     mTimer;
 
     Counters mCounters;
 };

--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -47,11 +47,11 @@ namespace Ip6 {
 Mpl::Mpl(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mMatchingAddress(nullptr)
-    , mSeedSetTimer(aInstance, Mpl::HandleSeedSetTimer)
+    , mSeedSetTimer(aInstance)
     , mSeedId(0)
     , mSequence(0)
 #if OPENTHREAD_FTD
-    , mRetransmissionTimer(aInstance, Mpl::HandleRetransmissionTimer)
+    , mRetransmissionTimer(aInstance)
     , mTimerExpirations(0)
 #endif
 {
@@ -261,11 +261,6 @@ exit:
     return error;
 }
 
-void Mpl::HandleSeedSetTimer(Timer &aTimer)
-{
-    aTimer.Get<Mpl>().HandleSeedSetTimer();
-}
-
 void Mpl::HandleSeedSetTimer(void)
 {
     bool startTimer = false;
@@ -332,11 +327,6 @@ void Mpl::AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSeque
 
 exit:
     FreeMessageOnError(messageCopy, error);
-}
-
-void Mpl::HandleRetransmissionTimer(Timer &aTimer)
-{
-    aTimer.Get<Mpl>().HandleRetransmissionTimer();
 }
 
 void Mpl::HandleRetransmissionTimer(void)

--- a/src/core/net/ip6_mpl.hpp
+++ b/src/core/net/ip6_mpl.hpp
@@ -286,14 +286,15 @@ private:
         uint8_t  mLifetime;
     };
 
-    static void HandleSeedSetTimer(Timer &aTimer);
-    void        HandleSeedSetTimer(void);
+    void HandleSeedSetTimer(void);
 
     Error UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence);
 
+    using SeedSetTimer = TimerMilliIn<Mpl, &Mpl::HandleSeedSetTimer>;
+
     SeedEntry      mSeedSet[kNumSeedEntries];
     const Address *mMatchingAddress;
-    TimerMilli     mSeedSetTimer;
+    SeedSetTimer   mSeedSetTimer;
     uint16_t       mSeedId;
     uint8_t        mSequence;
 
@@ -313,13 +314,14 @@ private:
         uint8_t   mIntervalOffset;
     };
 
-    static void HandleRetransmissionTimer(Timer &aTimer);
-    void        HandleRetransmissionTimer(void);
+    void HandleRetransmissionTimer(void);
 
     void AddBufferedMessage(Message &aMessage, uint16_t aSeedId, uint8_t aSequence, bool aIsOutbound);
 
+    using RetxTimer = TimerMilliIn<Mpl, &Mpl::HandleRetransmissionTimer>;
+
     MessageQueue mBufferedMessageSet;
-    TimerMilli   mRetransmissionTimer;
+    RetxTimer    mRetransmissionTimer;
     uint8_t      mTimerExpirations;
 #endif // OPENTHREAD_FTD
 };

--- a/src/core/net/nat64_translator.cpp
+++ b/src/core/net/nat64_translator.cpp
@@ -50,13 +50,13 @@ RegisterLogModule("Nat64");
 
 Translator::Translator(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mMappingExpirer(aInstance, MappingExpirerHandler)
+    , mMappingExpirerTimer(aInstance)
 {
     Random::NonCrypto::FillBuffer(reinterpret_cast<uint8_t *>(&mNextMappingId), sizeof(mNextMappingId));
 
     mNat64Prefix.Clear();
     mIp4Cidr.Clear();
-    mMappingExpirer.Start(kAddressMappingIdleTimeoutMsec);
+    mMappingExpirerTimer.Start(kAddressMappingIdleTimeoutMsec);
 }
 
 Message *Translator::NewIp4Message(const Message::Settings &aSettings)
@@ -497,10 +497,10 @@ void Translator::SetNat64Prefix(const Ip6::Prefix &aNat64Prefix)
     }
 }
 
-void Translator::MappingExpirerHandler(Timer &aTimer)
+void Translator::HandleMappingExpirerTimer(void)
 {
-    LogInfo("Released %d expired mappings", aTimer.Get<Translator>().ReleaseExpiredMappings());
-    aTimer.Get<Translator>().mMappingExpirer.Start(kAddressMappingIdleTimeoutMsec);
+    LogInfo("Released %d expired mappings", ReleaseExpiredMappings());
+    mMappingExpirerTimer.Start(kAddressMappingIdleTimeoutMsec);
 }
 
 void Translator::InitAddressMappingIterator(AddressMappingIterator &aIterator)

--- a/src/core/net/nat64_translator.hpp
+++ b/src/core/net/nat64_translator.hpp
@@ -331,7 +331,9 @@ private:
     AddressMapping *FindOrAllocateMapping(const Ip6::Address &aIp6Addr);
     AddressMapping *FindMapping(const Ip4::Address &aIp4Addr);
 
-    static void MappingExpirerHandler(Timer &aTimer);
+    void HandleMappingExpirerTimer(void);
+
+    using MappingTimer = TimerMilliIn<Translator, &Translator::HandleMappingExpirerTimer>;
 
     uint64_t mNextMappingId;
 
@@ -342,7 +344,7 @@ private:
     Ip6::Prefix mNat64Prefix;
     Ip4::Cidr   mIp4Cidr;
 
-    TimerMilli mMappingExpirer;
+    MappingTimer mMappingExpirerTimer;
 
     ProtocolCounters mCounters;
     ErrorCounters    mErrorCounters;

--- a/src/core/net/sntp_client.cpp
+++ b/src/core/net/sntp_client.cpp
@@ -95,7 +95,7 @@ QueryMetadata::QueryMetadata(otSntpResponseHandler aHandler, void *aContext)
 
 Client::Client(Instance &aInstance)
     : mSocket(aInstance)
-    , mRetransmissionTimer(aInstance, Client::HandleRetransmissionTimer)
+    , mRetransmissionTimer(aInstance)
     , mUnixEra(0)
 {
 }
@@ -267,11 +267,6 @@ void Client::FinalizeSntpTransaction(Message &            aQuery,
     {
         aQueryMetadata.mResponseHandler(aQueryMetadata.mResponseContext, aTime, aResult);
     }
-}
-
-void Client::HandleRetransmissionTimer(Timer &aTimer)
-{
-    aTimer.Get<Client>().HandleRetransmissionTimer();
 }
 
 void Client::HandleRetransmissionTimer(void)

--- a/src/core/net/sntp_client.hpp
+++ b/src/core/net/sntp_client.hpp
@@ -524,16 +524,17 @@ private:
     Message *FindRelatedQuery(const Header &aResponseHeader, QueryMetadata &aQueryMetadata);
     void FinalizeSntpTransaction(Message &aQuery, const QueryMetadata &aQueryMetadata, uint64_t aTime, Error aResult);
 
-    static void HandleRetransmissionTimer(Timer &aTimer);
-    void        HandleRetransmissionTimer(void);
+    void HandleRetransmissionTimer(void);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
+    using RetxTimer = TimerMilliIn<Client, &Client::HandleRetransmissionTimer>;
+
     Ip6::Udp::Socket mSocket;
 
     MessageQueue mPendingQueries;
-    TimerMilli   mRetransmissionTimer;
+    RetxTimer    mRetransmissionTimer;
 
     uint32_t mUnixEra;
 };

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -264,7 +264,7 @@ Client::Client(Instance &aInstance)
     , mCallback(nullptr)
     , mCallbackContext(nullptr)
     , mDomainName(kDefaultDomainName)
-    , mTimer(aInstance, Client::HandleTimer)
+    , mTimer(aInstance)
 {
     mHostInfo.Init();
 
@@ -1755,11 +1755,6 @@ bool Client::ShouldRenewEarly(const Service &aService) const
 #endif
 
     return shouldRenew;
-}
-
-void Client::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Client>().HandleTimer();
 }
 
 void Client::HandleTimer(void)

--- a/src/core/net/srp_client.hpp
+++ b/src/core/net/srp_client.hpp
@@ -986,7 +986,6 @@ private:
     void         GrowRetryWaitInterval(void);
     uint32_t     GetBoundedLeaseInterval(uint32_t aInterval, uint32_t aDefaultInterval) const;
     bool         ShouldRenewEarly(const Service &aService) const;
-    static void  HandleTimer(Timer &aTimer);
     void         HandleTimer(void);
 #if OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
     void  ProcessAutoStart(void);
@@ -1006,6 +1005,8 @@ private:
     static const char kDefaultDomainName[];
 
     static_assert(kMaxTxFailureRetries < 16, "kMaxTxFailureRetries exceed the range of mTxFailureRetryCount (4-bit)");
+
+    using DelayTimer = TimerMilliIn<Client, &Client::HandleTimer>;
 
     State   mState;
     uint8_t mTxFailureRetryCount : 4;
@@ -1032,7 +1033,7 @@ private:
     HostInfo            mHostInfo;
     LinkedList<Service> mServices;
     SingleServiceMode   mSingleServiceMode;
-    TimerMilli          mTimer;
+    DelayTimer          mTimer;
 #if OPENTHREAD_CONFIG_SRP_CLIENT_AUTO_START_API_ENABLE
     AutoStart mAutoStart;
 #endif

--- a/src/core/net/srp_server.cpp
+++ b/src/core/net/srp_server.cpp
@@ -88,8 +88,8 @@ Server::Server(Instance &aInstance)
     , mSocket(aInstance)
     , mServiceUpdateHandler(nullptr)
     , mServiceUpdateHandlerContext(nullptr)
-    , mLeaseTimer(aInstance, HandleLeaseTimer)
-    , mOutstandingUpdatesTimer(aInstance, HandleOutstandingUpdatesTimer)
+    , mLeaseTimer(aInstance)
+    , mOutstandingUpdatesTimer(aInstance)
     , mServiceUpdateId(Random::NonCrypto::GetUint32())
     , mPort(kUdpPortMin)
     , mState(kStateDisabled)
@@ -1528,11 +1528,6 @@ exit:
     return error;
 }
 
-void Server::HandleLeaseTimer(Timer &aTimer)
-{
-    aTimer.Get<Server>().HandleLeaseTimer();
-}
-
 void Server::HandleLeaseTimer(void)
 {
     TimeMilli now                = TimerMilli::GetNow();
@@ -1645,11 +1640,6 @@ void Server::HandleLeaseTimer(void)
         LogInfo("Lease timer is stopped");
         mLeaseTimer.Stop();
     }
-}
-
-void Server::HandleOutstandingUpdatesTimer(Timer &aTimer)
-{
-    aTimer.Get<Server>().HandleOutstandingUpdatesTimer();
 }
 
 void Server::HandleOutstandingUpdatesTimer(void)

--- a/src/core/net/srp_server.hpp
+++ b/src/core/net/srp_server.hpp
@@ -1043,7 +1043,6 @@ private:
                              const Ip6::MessageInfo & aMessageInfo);
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    static void HandleLeaseTimer(Timer &aTimer);
     void        HandleLeaseTimer(void);
     static void HandleOutstandingUpdatesTimer(Timer &aTimer);
     void        HandleOutstandingUpdatesTimer(void);
@@ -1053,6 +1052,9 @@ private:
     static const char *   AddressModeToString(AddressMode aMode);
 
     void UpdateResponseCounters(Dns::Header::Response aResponseCode);
+
+    using LeaseTimer  = TimerMilliIn<Server, &Server::HandleLeaseTimer>;
+    using UpdateTimer = TimerMilliIn<Server, &Server::HandleOutstandingUpdatesTimer>;
 
     Ip6::Udp::Socket                mSocket;
     otSrpServerServiceUpdateHandler mServiceUpdateHandler;
@@ -1064,9 +1066,9 @@ private:
     LeaseConfig mLeaseConfig;
 
     LinkedList<Host> mHosts;
-    TimerMilli       mLeaseTimer;
+    LeaseTimer       mLeaseTimer;
 
-    TimerMilli                 mOutstandingUpdatesTimer;
+    UpdateTimer                mOutstandingUpdatesTimer;
     LinkedList<UpdateMetadata> mOutstandingUpdates;
 
     ServiceUpdateId mServiceUpdateId;

--- a/src/core/net/tcp6.cpp
+++ b/src/core/net/tcp6.cpp
@@ -72,7 +72,7 @@ static_assert(offsetof(Tcp::Listener, mTcbListen) == 0, "mTcbListen field in otT
 
 Tcp::Tcp(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mTimer(aInstance, Tcp::HandleTimer)
+    , mTimer(aInstance)
     , mTasklet(aInstance)
     , mEphemeralPort(kDynamicPortMin)
 {
@@ -849,20 +849,13 @@ exit:
     return success;
 }
 
-void Tcp::HandleTimer(Timer &aTimer)
-{
-    OT_ASSERT(&aTimer == &aTimer.Get<Tcp>().mTimer);
-    LogDebg("Main TCP timer expired");
-    aTimer.Get<Tcp>().ProcessTimers();
-}
-
-void Tcp::ProcessTimers(void)
+void Tcp::HandleTimer(void)
 {
     TimeMilli now = TimerMilli::GetNow();
     bool      pendingTimer;
     TimeMilli earliestPendingTimerExpiry;
 
-    OT_ASSERT(!mTimer.IsRunning());
+    LogDebg("Main TCP timer expired");
 
     /*
      * The timer callbacks could potentially set/reset/cancel timers.

--- a/src/core/net/tcp6.hpp
+++ b/src/core/net/tcp6.hpp
@@ -686,14 +686,14 @@ private:
     static Error BsdErrorToOtError(int aBsdError);
     bool         CanBind(const SockAddr &aSockName);
 
-    static void HandleTimer(Timer &aTimer);
-    void        ProcessTimers(void);
+    void HandleTimer(void);
 
     void ProcessCallbacks(void);
 
     using TcpTasklet = TaskletIn<Tcp, &Tcp::ProcessCallbacks>;
+    using TcpTimer   = TimerMilliIn<Tcp, &Tcp::HandleTimer>;
 
-    TimerMilli mTimer;
+    TcpTimer   mTimer;
     TcpTasklet mTasklet;
 
     LinkedList<Endpoint> mEndpoints;

--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -52,7 +52,7 @@ Link::Link(Instance &aInstance)
     , mPanId(Mac::kPanIdBroadcast)
     , mTxPacketNumber(0)
     , mTxTasklet(aInstance)
-    , mTimer(aInstance, HandleTimer)
+    , mTimer(aInstance)
     , mInterface(aInstance)
 {
     memset(&mTxFrame, 0, sizeof(mTxFrame));
@@ -259,11 +259,6 @@ void Link::InvokeSendDone(Error aError, Mac::RxFrame *aAckFrame)
 
     Get<Mac::Mac>().RecordFrameTransmitStatus(mTxFrame, aAckFrame, aError, /* aRetryCount */ 0, /* aWillRetx */ false);
     Get<Mac::Mac>().HandleTransmitDone(mTxFrame, aAckFrame, aError);
-}
-
-void Link::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Link>().HandleTimer();
 }
 
 void Link::HandleTimer(void)

--- a/src/core/radio/trel_link.hpp
+++ b/src/core/radio/trel_link.hpp
@@ -173,22 +173,20 @@ private:
     void ReportDeferredAckStatus(Neighbor &aNeighbor, Error aError);
     void HandleTimer(Neighbor &aNeighbor);
     void HandleNotifierEvents(Events aEvents);
-
     void HandleTxTasklet(void);
-
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimer(void);
 
     static const char *StateToString(State aState);
 
-    using TxTasklet = TaskletIn<Link, &Link::HandleTxTasklet>;
+    using TxTasklet    = TaskletIn<Link, &Link::HandleTxTasklet>;
+    using TimeoutTimer = TimerMilliIn<Link, &Link::HandleTimer>;
 
     State        mState;
     uint8_t      mRxChannel;
     Mac::PanId   mPanId;
     uint32_t     mTxPacketNumber;
     TxTasklet    mTxTasklet;
-    TimerMilli   mTimer;
+    TimeoutTimer mTimer;
     Interface    mInterface;
     Mac::RxFrame mRxFrame;
     Mac::TxFrame mTxFrame;

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -49,8 +49,8 @@ DiscoverScanner::DiscoverScanner(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mHandler(nullptr)
     , mHandlerContext(nullptr)
-    , mTimer(aInstance, DiscoverScanner::HandleTimer)
     , mScanDoneTask(aInstance)
+    , mTimer(aInstance)
     , mFilterIndexes()
     , mState(kStateIdle)
     , mScanChannel(0)
@@ -264,11 +264,6 @@ void DiscoverScanner::HandleScanDoneTask(void)
     {
         mHandler(nullptr, mHandlerContext);
     }
-}
-
-void DiscoverScanner::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<DiscoverScanner>().HandleTimer();
 }
 
 void DiscoverScanner::HandleTimer(void)

--- a/src/core/thread/discover_scanner.hpp
+++ b/src/core/thread/discover_scanner.hpp
@@ -172,16 +172,15 @@ private:
 
     void HandleDiscoverComplete(void);
     void HandleScanDoneTask(void);
+    void HandleTimer(void);
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
-
+    using ScanTimer    = TimerMilliIn<DiscoverScanner, &DiscoverScanner::HandleTimer>;
     using ScanDoneTask = TaskletIn<DiscoverScanner, &DiscoverScanner::HandleScanDoneTask>;
 
     Handler          mHandler;
     void *           mHandlerContext;
-    TimerMilli       mTimer;
     ScanDoneTask     mScanDoneTask;
+    ScanTimer        mTimer;
     FilterIndexes    mFilterIndexes;
     Mac::ChannelMask mScanChannels;
     State            mState;

--- a/src/core/thread/energy_scan_server.cpp
+++ b/src/core/thread/energy_scan_server.cpp
@@ -58,7 +58,7 @@ EnergyScanServer::EnergyScanServer(Instance &aInstance)
     , mCount(0)
     , mActive(false)
     , mScanResultsLength(0)
-    , mTimer(aInstance, EnergyScanServer::HandleTimer)
+    , mTimer(aInstance)
     , mEnergyScan(UriPath::kEnergyScan, &EnergyScanServer::HandleRequest, this)
 {
     Get<Tmf::Agent>().AddResource(mEnergyScan);
@@ -104,11 +104,6 @@ void EnergyScanServer::HandleRequest(Coap::Message &aMessage, const Ip6::Message
 
 exit:
     return;
-}
-
-void EnergyScanServer::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<EnergyScanServer>().HandleTimer();
 }
 
 void EnergyScanServer::HandleTimer(void)

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -72,12 +72,13 @@ private:
     static void HandleScanResult(Mac::EnergyScanResult *aResult, void *aContext);
     void        HandleScanResult(Mac::EnergyScanResult *aResult);
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimer(void);
 
     void HandleNotifierEvents(Events aEvents);
 
     void SendReport(void);
+
+    using ScanTimer = TimerMilliIn<EnergyScanServer, &EnergyScanServer::HandleTimer>;
 
     Ip6::Address mCommissioner;
     uint32_t     mChannelMask;
@@ -90,7 +91,7 @@ private:
     int8_t  mScanResults[OPENTHREAD_CONFIG_TMF_ENERGY_SCAN_MAX_RESULTS];
     uint8_t mScanResultsLength;
 
-    TimerMilli mTimer;
+    ScanTimer mTimer;
 
     Coap::Resource mEnergyScan;
 };

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -172,7 +172,7 @@ KeyManager::KeyManager(Instance &aInstance)
     , mHoursSinceKeyRotation(0)
     , mKeySwitchGuardTime(kDefaultKeySwitchGuardTime)
     , mKeySwitchGuardEnabled(false)
-    , mKeyRotationTimer(aInstance, KeyManager::HandleKeyRotationTimer)
+    , mKeyRotationTimer(aInstance)
     , mKekFrameCounter(0)
     , mIsPskcSet(false)
 {
@@ -495,11 +495,6 @@ void KeyManager::StartKeyRotationTimer(void)
 {
     mHoursSinceKeyRotation = 0;
     mKeyRotationTimer.Start(kOneHourIntervalInMsec);
-}
-
-void KeyManager::HandleKeyRotationTimer(Timer &aTimer)
-{
-    aTimer.Get<KeyManager>().HandleKeyRotationTimer();
 }
 
 void KeyManager::HandleKeyRotationTimer(void)

--- a/src/core/thread/key_manager.hpp
+++ b/src/core/thread/key_manager.hpp
@@ -575,9 +575,8 @@ private:
     void ComputeTrelKey(uint32_t aKeySequence, Mac::Key &aKey);
 #endif
 
-    void        StartKeyRotationTimer(void);
-    static void HandleKeyRotationTimer(Timer &aTimer);
-    void        HandleKeyRotationTimer(void);
+    void StartKeyRotationTimer(void);
+    void HandleKeyRotationTimer(void);
 
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
     void StoreNetworkKey(const NetworkKey &aNetworkKey, bool aOverWriteExisting);
@@ -585,6 +584,8 @@ private:
 #endif
 
     void ResetFrameCounters(void);
+
+    using RotationTimer = TimerMilliIn<KeyManager, &KeyManager::HandleKeyRotationTimer>;
 
     static const uint8_t kThreadString[];
 
@@ -613,10 +614,10 @@ private:
     uint32_t               mStoredMacFrameCounter;
     uint32_t               mStoredMleFrameCounter;
 
-    uint32_t   mHoursSinceKeyRotation;
-    uint32_t   mKeySwitchGuardTime;
-    bool       mKeySwitchGuardEnabled;
-    TimerMilli mKeyRotationTimer;
+    uint32_t      mHoursSinceKeyRotation;
+    uint32_t      mKeySwitchGuardTime;
+    bool          mKeySwitchGuardEnabled;
+    RotationTimer mKeyRotationTimer;
 
 #if OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE
     PskcRef mPskcRef;

--- a/src/core/thread/mesh_forwarder.cpp
+++ b/src/core/thread/mesh_forwarder.cpp
@@ -103,7 +103,7 @@ MeshForwarder::MeshForwarder(Instance &aInstance)
     , mSendBusy(false)
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_COLLISION_AVOIDANCE_DELAY_ENABLE
     , mDelayNextTx(false)
-    , mTxDelayTimer(aInstance, HandleTxDelayTimer)
+    , mTxDelayTimer(aInstance)
 #endif
     , mScheduleTransmissionTask(aInstance)
 #if OPENTHREAD_FTD
@@ -247,11 +247,6 @@ void MeshForwarder::ResumeMessageTransmissions(void)
 }
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_COLLISION_AVOIDANCE_DELAY_ENABLE
-void MeshForwarder::HandleTxDelayTimer(Timer &aTimer)
-{
-    aTimer.Get<MeshForwarder>().HandleTxDelayTimer();
-}
-
 void MeshForwarder::HandleTxDelayTimer(void)
 {
     mDelayNextTx = false;

--- a/src/core/thread/mesh_forwarder.hpp
+++ b/src/core/thread/mesh_forwarder.hpp
@@ -508,8 +508,7 @@ private:
     void ResumeMessageTransmissions(void);
 
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_COLLISION_AVOIDANCE_DELAY_ENABLE
-    static void HandleTxDelayTimer(Timer &aTimer);
-    void        HandleTxDelayTimer(void);
+    void HandleTxDelayTimer(void);
 #endif
 
     void LogMessage(MessageAction       aAction,
@@ -556,6 +555,10 @@ private:
 
     using TxTask = TaskletIn<MeshForwarder, &MeshForwarder::ScheduleTransmissionTask>;
 
+#if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_COLLISION_AVOIDANCE_DELAY_ENABLE
+    using TxDelayTimer = TimerMilliIn<MeshForwarder, &MeshForwarder::HandleTxDelayTimer>;
+#endif
+
     PriorityQueue mSendQueue;
     MessageQueue  mReassemblyList;
     uint16_t      mFragTag;
@@ -571,8 +574,8 @@ private:
     bool           mTxPaused : 1;
     bool           mSendBusy : 1;
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_MAC_COLLISION_AVOIDANCE_DELAY_ENABLE
-    bool       mDelayNextTx : 1;
-    TimerMilli mTxDelayTimer;
+    bool         mDelayNextTx : 1;
+    TxDelayTimer mTxDelayTimer;
 #endif
 
     TxTask mScheduleTransmissionTask;

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -80,9 +80,9 @@ Mle::Mle(Instance &aInstance)
     , mReattachState(kReattachStop)
     , mAttachCounter(0)
     , mAnnounceDelay(kAnnounceTimeout)
-    , mAttachTimer(aInstance, Mle::HandleAttachTimer)
-    , mDelayedResponseTimer(aInstance, Mle::HandleDelayedResponseTimer)
-    , mMessageTransmissionTimer(aInstance, Mle::HandleMessageTransmissionTimer)
+    , mAttachTimer(aInstance)
+    , mDelayedResponseTimer(aInstance)
+    , mMessageTransmissionTimer(aInstance)
     , mAttachMode(kAnyPartition)
     , mChildUpdateAttempts(0)
     , mChildUpdateRequestState(kChildUpdateRequestNone)
@@ -104,7 +104,7 @@ Mle::Mle(Instance &aInstance)
     , mAlternateChannel(0)
     , mAlternatePanId(Mac::kPanIdBroadcast)
     , mAlternateTimestamp(0)
-    , mDetachGracefullyTimer(aInstance, Mle::HandleDetachGracefullyTimer)
+    , mDetachGracefullyTimer(aInstance)
     , mDetachGracefullyCallback(nullptr)
     , mDetachGracefullyContext(nullptr)
     , mParentResponseCb(nullptr)
@@ -1276,11 +1276,6 @@ exit:
 
 #endif // OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
 
-void Mle::HandleAttachTimer(Timer &aTimer)
-{
-    aTimer.Get<Mle>().HandleAttachTimer();
-}
-
 Error Mle::DetermineParentRequestType(ParentRequestType &aType) const
 {
     // This method determines the Parent Request type to use during an
@@ -1576,11 +1571,6 @@ uint32_t Mle::Reattach(void)
 
 exit:
     return delay;
-}
-
-void Mle::HandleDelayedResponseTimer(Timer &aTimer)
-{
-    aTimer.Get<Mle>().HandleDelayedResponseTimer();
 }
 
 void Mle::HandleDelayedResponseTimer(void)
@@ -1907,11 +1897,6 @@ exit:
     {
         mMessageTransmissionTimer.Stop();
     }
-}
-
-void Mle::HandleMessageTransmissionTimer(Timer &aTimer)
-{
-    aTimer.Get<Mle>().HandleMessageTransmissionTimer();
 }
 
 void Mle::HandleMessageTransmissionTimer(void)
@@ -3880,11 +3865,6 @@ exit:
 #endif // OPENTHREAD_CONFIG_MLE_INFORM_PREVIOUS_PARENT_ON_REATTACH
 
 #if OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE
-void Mle::ParentSearch::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Mle>().mParentSearch.HandleTimer();
-}
-
 void Mle::ParentSearch::HandleTimer(void)
 {
     int8_t parentRss;
@@ -4347,11 +4327,6 @@ Error Mle::DetachGracefully(otDetachGracefullyCallback aCallback, void *aContext
 
 exit:
     return error;
-}
-
-void Mle::HandleDetachGracefullyTimer(Timer &aTimer)
-{
-    aTimer.Get<Mle>().HandleDetachGracefullyTimer();
 }
 
 void Mle::HandleDetachGracefullyTimer(void)

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -1678,6 +1678,17 @@ protected:
 
 #endif
 
+private:
+    // Declare early so we can use in as `TimerMilli` callbacks.
+    void HandleAttachTimer(void);
+    void HandleDelayedResponseTimer(void);
+    void HandleMessageTransmissionTimer(void);
+
+protected:
+    using AttachTimer = TimerMilliIn<Mle, &Mle::HandleAttachTimer>;
+    using DelayTimer  = TimerMilliIn<Mle, &Mle::HandleDelayedResponseTimer>;
+    using MsgTxTimer  = TimerMilliIn<Mle, &Mle::HandleMessageTransmissionTimer>;
+
     Ip6::Netif::UnicastAddress mLeaderAloc; ///< Leader anycast locator
 
     LeaderData    mLeaderData;               ///< Last received Leader Data TLV.
@@ -1691,9 +1702,9 @@ protected:
     ReattachState mReattachState;            ///< Reattach state
     uint16_t      mAttachCounter;            ///< Attach attempt counter.
     uint16_t      mAnnounceDelay;            ///< Delay in between sending Announce messages during attach.
-    TimerMilli    mAttachTimer;              ///< The timer for driving the attach process.
-    TimerMilli    mDelayedResponseTimer;     ///< The timer to delay MLE responses.
-    TimerMilli    mMessageTransmissionTimer; ///< The timer for (re-)sending of MLE messages (e.g. Child Update).
+    AttachTimer   mAttachTimer;              ///< The timer for driving the attach process.
+    DelayTimer    mDelayedResponseTimer;     ///< The timer to delay MLE responses.
+    MsgTxTimer    mMessageTransmissionTimer; ///< The timer for (re-)sending of MLE messages (e.g. Child Update).
 
 private:
     static constexpr uint8_t kMleHopLimit        = 255;
@@ -1837,6 +1848,8 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE
+    void HandleParentSearchTimer(void) { mParentSearch.HandleTimer(); }
+
     class ParentSearch : public InstanceLocator
     {
     public:
@@ -1846,13 +1859,14 @@ private:
             , mBackoffWasCanceled(false)
             , mRecentlyDetached(false)
             , mBackoffCancelTime(0)
-            , mTimer(aInstance, HandleTimer)
+            , mTimer(aInstance)
         {
         }
 
         void StartTimer(void);
         void UpdateState(void);
         void SetRecentlyDetached(void) { mRecentlyDetached = true; }
+        void HandleTimer(void);
 
     private:
         // All timer intervals are converted to milliseconds.
@@ -1861,27 +1875,20 @@ private:
         static constexpr uint32_t kJitterInterval  = (15 * 1000u);
         static constexpr int8_t   kRssThreadhold   = OPENTHREAD_CONFIG_PARENT_SEARCH_RSS_THRESHOLD;
 
-        static void HandleTimer(Timer &aTimer);
-        void        HandleTimer(void);
+        using SearchTimer = TimerMilliIn<Mle, &Mle::HandleParentSearchTimer>;
 
-        bool       mIsInBackoff : 1;
-        bool       mBackoffWasCanceled : 1;
-        bool       mRecentlyDetached : 1;
-        TimeMilli  mBackoffCancelTime;
-        TimerMilli mTimer;
+        bool        mIsInBackoff : 1;
+        bool        mBackoffWasCanceled : 1;
+        bool        mRecentlyDetached : 1;
+        TimeMilli   mBackoffCancelTime;
+        SearchTimer mTimer;
     };
 #endif // OPENTHREAD_CONFIG_PARENT_SEARCH_ENABLE
 
     Error       Start(StartMode aMode);
     void        Stop(StopMode aMode);
     void        HandleNotifierEvents(Events aEvents);
-    static void HandleAttachTimer(Timer &aTimer);
-    void        HandleAttachTimer(void);
-    static void HandleDelayedResponseTimer(Timer &aTimer);
-    void        HandleDelayedResponseTimer(void);
     void        SendDelayedResponse(TxMessage &aMessage, const DelayedResponseMetadata &aMetadata);
-    static void HandleMessageTransmissionTimer(Timer &aTimer);
-    void        HandleMessageTransmissionTimer(void);
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleUdpReceive(Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
     void        ScheduleMessageTransmissionTimer(void);
@@ -1976,6 +1983,8 @@ private:
     static const char *MessageTypeActionToSuffixString(MessageType aType, MessageAction aAction);
 #endif
 
+    using DetachGracefullyTimer = TimerMilliIn<Mle, &Mle::HandleDetachGracefullyTimer>;
+
     MessageQueue mDelayedResponses;
 
     Challenge mParentRequestChallenge;
@@ -2024,7 +2033,7 @@ private:
     Ip6::Netif::MulticastAddress mLinkLocalAllThreadNodes;
     Ip6::Netif::MulticastAddress mRealmLocalAllThreadNodes;
 
-    TimerMilli                 mDetachGracefullyTimer;
+    DetachGracefullyTimer      mDetachGracefullyTimer;
     otDetachGracefullyCallback mDetachGracefullyCallback;
     void *                     mDetachGracefullyContext;
 

--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -61,7 +61,7 @@ RegisterLogModule("NetworkData");
 Leader::Leader(Instance &aInstance)
     : LeaderBase(aInstance)
     , mWaitingForNetDataSync(false)
-    , mTimer(aInstance, Leader::HandleTimer)
+    , mTimer(aInstance)
     , mServerData(UriPath::kServerData, &Leader::HandleServerData, this)
     , mCommissioningDataGet(UriPath::kCommissionerGet, &Leader::HandleCommissioningGet, this)
     , mCommissioningDataSet(UriPath::kCommissionerSet, &Leader::HandleCommissioningSet, this)
@@ -1336,11 +1336,6 @@ void Leader::HandleNetworkDataRestoredAfterReset(void)
             StartContextReuseTimer(context->GetContextId());
         }
     }
-}
-
-void Leader::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Leader>().HandleTimer();
 }
 
 void Leader::HandleTimer(void)

--- a/src/core/thread/network_data_leader_ftd.hpp
+++ b/src/core/thread/network_data_leader_ftd.hpp
@@ -226,8 +226,7 @@ private:
     static void HandleServerData(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleServerData(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimer(void);
 
     void RegisterNetworkData(uint16_t aRloc16, const NetworkData &aNetworkData);
 
@@ -308,17 +307,19 @@ private:
     void IncrementVersions(bool aIncludeStable);
     void IncrementVersions(const ChangedFlags &aFlags);
 
+    using UpdateTimer = TimerMilliIn<Leader, &Leader::HandleTimer>;
+
     static constexpr uint8_t  kMinContextId        = 1;            // Minimum Context ID (0 is used for Mesh Local)
     static constexpr uint8_t  kNumContextIds       = 15;           // Maximum Context ID
     static constexpr uint32_t kContextIdReuseDelay = 48 * 60 * 60; // in seconds
     static constexpr uint32_t kStateUpdatePeriod   = 60 * 1000;    // State update period in milliseconds
     static constexpr uint32_t kMaxNetDataSyncWait  = 60 * 1000;    // Maximum time to wait for netdata sync.
 
-    bool       mWaitingForNetDataSync;
-    uint16_t   mContextUsed;
-    TimeMilli  mContextLastUsed[kNumContextIds];
-    uint32_t   mContextIdReuseDelay;
-    TimerMilli mTimer;
+    bool        mWaitingForNetDataSync;
+    uint16_t    mContextUsed;
+    TimeMilli   mContextLastUsed[kNumContextIds];
+    uint32_t    mContextIdReuseDelay;
+    UpdateTimer mTimer;
 
     Coap::Resource mServerData;
 

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -49,7 +49,7 @@ RegisterLogModule("NetworkData");
 
 Notifier::Notifier(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mTimer(aInstance, HandleTimer)
+    , mTimer(aInstance)
     , mSynchronizeDataTask(aInstance)
     , mNextDelay(0)
     , mWaitingForResponse(false)
@@ -136,11 +136,6 @@ void Notifier::HandleNotifierEvents(Events aEvents)
     {
         SynchronizeServerData();
     }
-}
-
-void Notifier::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Notifier>().HandleTimer();
 }
 
 void Notifier::HandleTimer(void)

--- a/src/core/thread/network_data_notifier.hpp
+++ b/src/core/thread/network_data_notifier.hpp
@@ -106,8 +106,7 @@ private:
 
     void HandleNotifierEvents(Events aEvents);
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimer(void);
 
     static void HandleCoapResponse(void *               aContext,
                                    otMessage *          aMessage,
@@ -122,8 +121,9 @@ private:
 #endif
 
     using SynchronizeDataTask = TaskletIn<Notifier, &Notifier::SynchronizeServerData>;
+    using DelayTimer          = TimerMilliIn<Notifier, &Notifier::HandleTimer>;
 
-    TimerMilli          mTimer;
+    DelayTimer          mTimer;
     SynchronizeDataTask mSynchronizeDataTask;
     uint32_t            mNextDelay;
     bool                mWaitingForResponse : 1;

--- a/src/core/thread/network_data_publisher.cpp
+++ b/src/core/thread/network_data_publisher.cpp
@@ -63,7 +63,7 @@ Publisher::Publisher(Instance &aInstance)
     , mPrefixCallback(nullptr)
     , mPrefixCallbackContext(nullptr)
 #endif
-    , mTimer(aInstance, Publisher::HandleTimer)
+    , mTimer(aInstance)
 {
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
     // Since the `PrefixEntry` type is used in an array,
@@ -219,11 +219,6 @@ void Publisher::HandleNotifierEvents(Events aEvents)
         entry.HandleNotifierEvents(aEvents);
     }
 #endif
-}
-
-void Publisher::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<Publisher>().HandleTimer();
 }
 
 void Publisher::HandleTimer(void)

--- a/src/core/thread/network_data_publisher.hpp
+++ b/src/core/thread/network_data_publisher.hpp
@@ -460,8 +460,9 @@ private:
 
     TimerMilli &GetTimer(void) { return mTimer; }
     void        HandleNotifierEvents(Events aEvents);
-    static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
+
+    using PublisherTimer = TimerMilliIn<Publisher, &Publisher::HandleTimer>;
 
 #if OPENTHREAD_CONFIG_TMF_NETDATA_SERVICE_ENABLE
     DnsSrpServiceEntry mDnsSrpServiceEntry;
@@ -473,7 +474,7 @@ private:
     void *         mPrefixCallbackContext;
 #endif
 
-    TimerMilli mTimer;
+    PublisherTimer mTimer;
 };
 
 } // namespace NetworkData

--- a/src/core/thread/panid_query_server.cpp
+++ b/src/core/thread/panid_query_server.cpp
@@ -53,7 +53,7 @@ PanIdQueryServer::PanIdQueryServer(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mChannelMask(0)
     , mPanId(Mac::kPanIdBroadcast)
-    , mTimer(aInstance, PanIdQueryServer::HandleTimer)
+    , mTimer(aInstance)
     , mPanIdQuery(UriPath::kPanIdQuery, &PanIdQueryServer::HandleQuery, this)
 {
     Get<Tmf::Agent>().AddResource(mPanIdQuery);
@@ -135,11 +135,6 @@ void PanIdQueryServer::SendConflict(void)
 exit:
     FreeMessageOnError(message, error);
     MeshCoP::LogError("send panid conflict", error);
-}
-
-void PanIdQueryServer::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<PanIdQueryServer>().HandleTimer();
 }
 
 void PanIdQueryServer::HandleTimer(void)

--- a/src/core/thread/panid_query_server.hpp
+++ b/src/core/thread/panid_query_server.hpp
@@ -68,18 +68,19 @@ private:
     static void HandleScanResult(Mac::ActiveScanResult *aScanResult, void *aContext);
     void        HandleScanResult(Mac::ActiveScanResult *aScanResult);
 
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void HandleTimer(void);
 
     static void HandleUdpReceive(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
 
     void SendConflict(void);
 
+    using DelayTimer = TimerMilliIn<PanIdQueryServer, &PanIdQueryServer::HandleTimer>;
+
     Ip6::Address mCommissioner;
     uint32_t     mChannelMask;
     uint16_t     mPanId;
 
-    TimerMilli mTimer;
+    DelayTimer mTimer;
 
     Coap::Resource mPanIdQuery;
 };

--- a/src/core/thread/time_sync_service.cpp
+++ b/src/core/thread/time_sync_service.cpp
@@ -64,7 +64,7 @@ TimeSync::TimeSync(Instance &aInstance)
     , mNetworkTimeOffset(0)
     , mTimeSyncCallback(nullptr)
     , mTimeSyncCallbackContext(nullptr)
-    , mTimer(aInstance, HandleTimeout)
+    , mTimer(aInstance)
     , mCurrentStatus(OT_NETWORK_TIME_UNSYNCHRONIZED)
 {
     CheckAndHandleChanges(false);
@@ -207,11 +207,6 @@ void TimeSync::HandleNotifierEvents(Events aEvents)
 void TimeSync::HandleTimeout(void)
 {
     CheckAndHandleChanges(false);
-}
-
-void TimeSync::HandleTimeout(Timer &aTimer)
-{
-    aTimer.Get<TimeSync>().HandleTimeout();
 }
 
 void TimeSync::CheckAndHandleChanges(bool aTimeUpdated)

--- a/src/core/thread/time_sync_service.hpp
+++ b/src/core/thread/time_sync_service.hpp
@@ -171,14 +171,6 @@ private:
     void HandleNotifierEvents(Events aEvents);
 
     /**
-     * Callback to be called when timer expires.
-     *
-     * @param[in] aTimer The corresponding timer.
-     *
-     */
-    static void HandleTimeout(Timer &aTimer);
-
-    /**
      * Check and handle any status change, and notify observers if applicable.
      *
      * @param[in] aNotifyTimeUpdated True to denote that observers should be notified due to a time change, false
@@ -199,6 +191,8 @@ private:
      */
     void NotifyTimeSyncCallback(void);
 
+    using SyncTimer = TimerMilliIn<TimeSync, &TimeSync::HandleTimeout>;
+
     bool     mTimeSyncRequired; ///< Indicate whether or not a time synchronization message is required.
     uint8_t  mTimeSyncSeq;      ///< The time synchronization sequence.
     uint16_t mTimeSyncPeriod;   ///< The time synchronization period.
@@ -211,7 +205,7 @@ private:
     otNetworkTimeSyncCallbackFn
                         mTimeSyncCallback; ///< The callback to be called when time sync is handled or status updated.
     void *              mTimeSyncCallbackContext; ///< The context to be passed to callback.
-    TimerMilli          mTimer;                   ///< Timer for checking if a resync is required.
+    SyncTimer           mTimer;                   ///< Timer for checking if a resync is required.
     otNetworkTimeStatus mCurrentStatus;           ///< Current network time status.
 };
 

--- a/src/core/utils/channel_manager.cpp
+++ b/src/core/utils/channel_manager.cpp
@@ -57,7 +57,7 @@ ChannelManager::ChannelManager(Instance &aInstance)
     , mDelay(kMinimumDelay)
     , mChannel(0)
     , mState(kStateIdle)
-    , mTimer(aInstance, ChannelManager::HandleTimer)
+    , mTimer(aInstance)
     , mAutoSelectInterval(kDefaultAutoSelectInterval)
     , mAutoSelectEnabled(false)
     , mCcaFailureRateThreshold(kCcaFailureRateThreshold)
@@ -152,11 +152,6 @@ void ChannelManager::HandleDatasetUpdateDone(Error aError)
 
     mState = kStateIdle;
     StartAutoSelectTimer();
-}
-
-void ChannelManager::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<ChannelManager>().HandleTimer();
 }
 
 void ChannelManager::HandleTimer(void)

--- a/src/core/utils/channel_manager.hpp
+++ b/src/core/utils/channel_manager.hpp
@@ -276,7 +276,6 @@ private:
     void        StartDatasetUpdate(void);
     static void HandleDatasetUpdateDone(Error aError, void *aContext);
     void        HandleDatasetUpdateDone(Error aError);
-    static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
     void        StartAutoSelectTimer(void);
 
@@ -285,12 +284,14 @@ private:
     bool  ShouldAttemptChannelChange(void);
 #endif
 
+    using ManagerTimer = TimerMilliIn<ChannelManager, &ChannelManager::HandleTimer>;
+
     Mac::ChannelMask mSupportedChannelMask;
     Mac::ChannelMask mFavoredChannelMask;
     uint16_t         mDelay;
     uint8_t          mChannel;
     State            mState;
-    TimerMilli       mTimer;
+    ManagerTimer     mTimer;
     uint32_t         mAutoSelectInterval;
     bool             mAutoSelectEnabled;
     uint16_t         mCcaFailureRateThreshold;

--- a/src/core/utils/channel_monitor.cpp
+++ b/src/core/utils/channel_monitor.cpp
@@ -64,7 +64,7 @@ ChannelMonitor::ChannelMonitor(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mChannelMaskIndex(0)
     , mSampleCount(0)
-    , mTimer(aInstance, ChannelMonitor::HandleTimer)
+    , mTimer(aInstance)
 {
     memset(mChannelOccupancy, 0, sizeof(mChannelOccupancy));
 }
@@ -112,11 +112,6 @@ uint16_t ChannelMonitor::GetChannelOccupancy(uint8_t aChannel) const
 
 exit:
     return occupancy;
-}
-
-void ChannelMonitor::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<ChannelMonitor>().HandleTimer();
 }
 
 void ChannelMonitor::HandleTimer(void)

--- a/src/core/utils/channel_monitor.hpp
+++ b/src/core/utils/channel_monitor.hpp
@@ -193,18 +193,19 @@ private:
     static constexpr uint16_t kMaxJitterInterval = 4096;
     static constexpr uint32_t kMaxOccupancy      = 0xffff;
 
-    static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
     static void HandleEnergyScanResult(Mac::EnergyScanResult *aResult, void *aContext);
     void        HandleEnergyScanResult(Mac::EnergyScanResult *aResult);
     void        LogResults(void);
 
+    using ScanTimer = TimerMilliIn<ChannelMonitor, &ChannelMonitor::HandleTimer>;
+
     static const uint32_t mScanChannelMasks[kNumChannelMasks];
 
-    uint8_t    mChannelMaskIndex : 3;
-    uint32_t   mSampleCount : 29;
-    uint16_t   mChannelOccupancy[kNumChannels];
-    TimerMilli mTimer;
+    uint8_t   mChannelMaskIndex : 3;
+    uint32_t  mSampleCount : 29;
+    uint16_t  mChannelOccupancy[kNumChannels];
+    ScanTimer mTimer;
 };
 
 /**

--- a/src/core/utils/child_supervision.cpp
+++ b/src/core/utils/child_supervision.cpp
@@ -157,7 +157,7 @@ void ChildSupervisor::HandleNotifierEvents(Events aEvents)
 SupervisionListener::SupervisionListener(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mTimeout(0)
-    , mTimer(aInstance, SupervisionListener::HandleTimer)
+    , mTimer(aInstance)
 {
     SetTimeout(kDefaultTimeout);
 }
@@ -204,11 +204,6 @@ void SupervisionListener::RestartTimer(void)
     {
         mTimer.Stop();
     }
-}
-
-void SupervisionListener::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<SupervisionListener>().HandleTimer();
 }
 
 void SupervisionListener::HandleTimer(void)

--- a/src/core/utils/child_supervision.hpp
+++ b/src/core/utils/child_supervision.hpp
@@ -233,12 +233,13 @@ public:
 private:
     static constexpr uint16_t kDefaultTimeout = OPENTHREAD_CONFIG_CHILD_SUPERVISION_CHECK_TIMEOUT; // (seconds)
 
-    void        RestartTimer(void);
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void RestartTimer(void);
+    void HandleTimer(void);
 
-    uint16_t   mTimeout;
-    TimerMilli mTimer;
+    using ListenerTimer = TimerMilliIn<SupervisionListener, &SupervisionListener::HandleTimer>;
+
+    uint16_t      mTimeout;
+    ListenerTimer mTimer;
 };
 
 #endif // #if OPENTHREAD_CONFIG_CHILD_SUPERVISION_ENABLE

--- a/src/core/utils/history_tracker.cpp
+++ b/src/core/utils/history_tracker.cpp
@@ -53,7 +53,7 @@ namespace Utils {
 
 HistoryTracker::HistoryTracker(Instance &aInstance)
     : InstanceLocator(aInstance)
-    , mTimer(aInstance, HandleTimer)
+    , mTimer(aInstance)
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_NET_DATA
     , mPreviousNetworkData(aInstance, mNetworkDataTlvBuffer, 0, sizeof(mNetworkDataTlvBuffer))
 #endif
@@ -373,11 +373,6 @@ void HistoryTracker::HandleNotifierEvents(Events aEvents)
         RecordNetworkDataChange();
     }
 #endif
-}
-
-void HistoryTracker::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<HistoryTracker>().HandleTimer();
 }
 
 void HistoryTracker::HandleTimer(void)

--- a/src/core/utils/history_tracker.hpp
+++ b/src/core/utils/history_tracker.hpp
@@ -378,21 +378,22 @@ private:
         RecordMessage(aMessage, aMacDest, kTxMessage);
     }
 
-    void        RecordNetworkInfo(void);
-    void        RecordMessage(const Message &aMessage, const Mac::Address &aMacAddress, MessageType aType);
-    void        RecordNeighborEvent(NeighborTable::Event aEvent, const NeighborTable::EntryInfo &aInfo);
-    void        RecordAddressEvent(Ip6::Netif::AddressEvent aEvent, const Ip6::Netif::UnicastAddress &aUnicastAddress);
-    void        RecordAddressEvent(Ip6::Netif::AddressEvent            aEvent,
-                                   const Ip6::Netif::MulticastAddress &aMulticastAddress,
-                                   Ip6::Netif::AddressOrigin           aAddressOrigin);
-    void        HandleNotifierEvents(Events aEvents);
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
+    void RecordNetworkInfo(void);
+    void RecordMessage(const Message &aMessage, const Mac::Address &aMacAddress, MessageType aType);
+    void RecordNeighborEvent(NeighborTable::Event aEvent, const NeighborTable::EntryInfo &aInfo);
+    void RecordAddressEvent(Ip6::Netif::AddressEvent aEvent, const Ip6::Netif::UnicastAddress &aUnicastAddress);
+    void RecordAddressEvent(Ip6::Netif::AddressEvent            aEvent,
+                            const Ip6::Netif::MulticastAddress &aMulticastAddress,
+                            Ip6::Netif::AddressOrigin           aAddressOrigin);
+    void HandleNotifierEvents(Events aEvents);
+    void HandleTimer(void);
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_NET_DATA
     void RecordNetworkDataChange(void);
     void RecordOnMeshPrefixEvent(NetDataEvent aEvent, const NetworkData::OnMeshPrefixConfig &aPrefix);
     void RecordExternalRouteEvent(NetDataEvent aEvent, const NetworkData::ExternalRouteConfig &aRoute);
 #endif
+
+    using TrackerTimer = TimerMilliIn<HistoryTracker, &HistoryTracker::HandleTimer>;
 
     EntryList<NetworkInfo, kNetInfoListSize>                mNetInfoHistory;
     EntryList<UnicastAddressInfo, kUnicastAddrListSize>     mUnicastAddressHistory;
@@ -403,7 +404,7 @@ private:
     EntryList<OnMeshPrefixInfo, kOnMeshPrefixListSize>      mOnMeshPrefixHistory;
     EntryList<ExternalRouteInfo, kExternalRouteListSize>    mExternalRouteHistory;
 
-    TimerMilli mTimer;
+    TrackerTimer mTimer;
 
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_NET_DATA
     NetworkData::MutableNetworkData mPreviousNetworkData;

--- a/src/core/utils/jam_detector.cpp
+++ b/src/core/utils/jam_detector.cpp
@@ -51,7 +51,7 @@ JamDetector::JamDetector(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mHandler(nullptr)
     , mContext(nullptr)
-    , mTimer(aInstance, JamDetector::HandleTimer)
+    , mTimer(aInstance)
     , mHistoryBitmap(0)
     , mCurSecondStartTime(0)
     , mSampleInterval(0)
@@ -159,11 +159,6 @@ Error JamDetector::SetBusyPeriod(uint8_t aBusyPeriod)
 
 exit:
     return error;
-}
-
-void JamDetector::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<JamDetector>().HandleTimer();
 }
 
 void JamDetector::HandleTimer(void)

--- a/src/core/utils/jam_detector.hpp
+++ b/src/core/utils/jam_detector.hpp
@@ -185,26 +185,27 @@ private:
     static constexpr uint16_t kMinSampleInterval = 2;   // in ms
     static constexpr uint32_t kMaxRandomDelay    = 4;   // in ms
 
-    void        CheckState(void);
-    void        SetJamState(bool aNewState);
-    static void HandleTimer(Timer &aTimer);
-    void        HandleTimer(void);
-    void        UpdateHistory(bool aDidExceedThreshold);
-    void        UpdateJamState(void);
-    void        HandleNotifierEvents(Events aEvents);
+    void CheckState(void);
+    void SetJamState(bool aNewState);
+    void HandleTimer(void);
+    void UpdateHistory(bool aDidExceedThreshold);
+    void UpdateJamState(void);
+    void HandleNotifierEvents(Events aEvents);
 
-    Handler    mHandler;                  // Handler/callback to inform about jamming state
-    void *     mContext;                  // Context for handler/callback
-    TimerMilli mTimer;                    // RSSI sample timer
-    uint64_t   mHistoryBitmap;            // History bitmap, each bit correspond to 1 sec interval
-    TimeMilli  mCurSecondStartTime;       // Start time for current 1 sec interval
-    uint16_t   mSampleInterval;           // Current sample interval
-    uint8_t    mWindow : 6;               // Window (in sec) to monitor jamming
-    uint8_t    mBusyPeriod : 6;           // BusyPeriod (in sec) with mWindow to alert jamming
-    bool       mEnabled : 1;              // If jam detection is enabled
-    bool       mAlwaysAboveThreshold : 1; // State for current 1 sec interval
-    bool       mJamState : 1;             // Current jam state
-    int8_t     mRssiThreshold;            // RSSI threshold for jam detection
+    using SampleTimer = TimerMilliIn<JamDetector, &JamDetector::HandleTimer>;
+
+    Handler     mHandler;                  // Handler/callback to inform about jamming state
+    void *      mContext;                  // Context for handler/callback
+    SampleTimer mTimer;                    // RSSI sample timer
+    uint64_t    mHistoryBitmap;            // History bitmap, each bit correspond to 1 sec interval
+    TimeMilli   mCurSecondStartTime;       // Start time for current 1 sec interval
+    uint16_t    mSampleInterval;           // Current sample interval
+    uint8_t     mWindow : 6;               // Window (in sec) to monitor jamming
+    uint8_t     mBusyPeriod : 6;           // BusyPeriod (in sec) with mWindow to alert jamming
+    bool        mEnabled : 1;              // If jam detection is enabled
+    bool        mAlwaysAboveThreshold : 1; // State for current 1 sec interval
+    bool        mJamState : 1;             // Current jam state
+    int8_t      mRssiThreshold;            // RSSI threshold for jam detection
 };
 
 /**

--- a/src/core/utils/ping_sender.cpp
+++ b/src/core/utils/ping_sender.cpp
@@ -91,7 +91,7 @@ PingSender::PingSender(Instance &aInstance)
     : InstanceLocator(aInstance)
     , mIdentifier(0)
     , mTargetEchoSequence(0)
-    , mTimer(aInstance, PingSender::HandleTimer)
+    , mTimer(aInstance)
     , mIcmpHandler(PingSender::HandleIcmpReceive, this)
 {
     IgnoreError(Get<Ip6::Icmp>().RegisterHandler(mIcmpHandler));
@@ -167,11 +167,6 @@ exit:
     {
         mTimer.Start(mConfig.mTimeout);
     }
-}
-
-void PingSender::HandleTimer(Timer &aTimer)
-{
-    aTimer.Get<PingSender>().HandleTimer();
 }
 
 void PingSender::HandleTimer(void)

--- a/src/core/utils/ping_sender.hpp
+++ b/src/core/utils/ping_sender.hpp
@@ -166,7 +166,6 @@ public:
 
 private:
     void        SendPing(void);
-    static void HandleTimer(Timer &aTimer);
     void        HandleTimer(void);
     static void HandleIcmpReceive(void *               aContext,
                                   otMessage *          aMessage,
@@ -176,11 +175,13 @@ private:
                                   const Ip6::MessageInfo & aMessageInfo,
                                   const Ip6::Icmp::Header &aIcmpHeader);
 
+    using PingTimer = TimerMilliIn<PingSender, &PingSender::HandleTimer>;
+
     Config             mConfig;
     Statistics         mStatistics;
     uint16_t           mIdentifier;
     uint16_t           mTargetEchoSequence;
-    TimerMilli         mTimer;
+    PingTimer          mTimer;
     Ip6::Icmp::Handler mIcmpHandler;
 };
 


### PR DESCRIPTION
This class adds a template sub-classes of `TimerMilli/Micro` which
allows us to directly specify an `Owner` for timer along with handler
callback as a member method of `Owner`. This helps simplify the
use of `Timer` in core module.

----

- Similar to #8064.

