### PR TITLE
[meshcop] simplify energy scan client and server

### DIFF
--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -44,6 +44,7 @@
 #include "common/const_cast.hpp"
 #include "common/encoding.hpp"
 #include "common/message.hpp"
+#include "common/num_utils.hpp"
 #include "common/string.hpp"
 #include "common/tlvs.hpp"
 #include "mac/mac_types.hpp"
@@ -1557,6 +1558,27 @@ public:
      *
      */
     bool IsValid(void) const { return true; }
+
+    /**
+     * This method returns a pointer to the start of energy measurement list.
+     *
+     * @returns A pointer to the start start of energy energy measurement list.
+     *
+     */
+    const uint8_t *GetEnergyList(void) const { return mEnergyList; }
+
+    /**
+     * This method returns the length of energy measurement list.
+     *
+     * @returns The length of energy measurement list.
+     *
+     */
+    uint8_t GetEnergyListLength(void) const { return Min(kMaxListLength, GetLength()); }
+
+private:
+    static constexpr uint8_t kMaxListLength = OPENTHREAD_CONFIG_TMF_ENERGY_SCAN_MAX_RESULTS;
+
+    uint8_t mEnergyList[kMaxListLength];
 } OT_TOOL_PACKED_END;
 
 /**

--- a/src/core/thread/energy_scan_server.hpp
+++ b/src/core/thread/energy_scan_server.hpp
@@ -63,8 +63,8 @@ public:
     explicit EnergyScanServer(Instance &aInstance);
 
 private:
-    static constexpr uint32_t kScanDelay   = 1000; ///< SCAN_DELAY (milliseconds)
-    static constexpr uint32_t kReportDelay = 500;  ///< Delay before sending a report (milliseconds)
+    static constexpr uint32_t kScanDelay   = 1000; // SCAN_DELAY (milliseconds)
+    static constexpr uint32_t kReportDelay = 500;  // Delay before sending a report (milliseconds)
 
     static void HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
     void        HandleRequest(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
@@ -80,18 +80,15 @@ private:
 
     using ScanTimer = TimerMilliIn<EnergyScanServer, &EnergyScanServer::HandleTimer>;
 
-    Ip6::Address mCommissioner;
-    uint32_t     mChannelMask;
-    uint32_t     mChannelMaskCurrent;
-    uint16_t     mPeriod;
-    uint16_t     mScanDuration;
-    uint8_t      mCount;
-    bool         mActive;
-
-    int8_t  mScanResults[OPENTHREAD_CONFIG_TMF_ENERGY_SCAN_MAX_RESULTS];
-    uint8_t mScanResultsLength;
-
-    ScanTimer mTimer;
+    Ip6::Address   mCommissioner;
+    uint32_t       mChannelMask;
+    uint32_t       mChannelMaskCurrent;
+    uint16_t       mPeriod;
+    uint16_t       mScanDuration;
+    uint8_t        mCount;
+    uint8_t        mNumScanResults;
+    Coap::Message *mReportMessage;
+    ScanTimer      mTimer;
 
     Coap::Resource mEnergyScan;
 };


### PR DESCRIPTION
This commit updates `EnergyScanClient` and `EnergyScanServer`.
On server side, we prepare the report message after we parse the
request and directly append the results in the report message as
energy scans are performed. Client side is also updated to
correctly handle the case where the report message contains
greater number of results that can be supported on the client
based on its configuration.