### PR TITLE
[mle] send quick MLE Advisement on promotion to router role

### DIFF
--- a/tests/scripts/thread-cert/v1_2_router_5_1_1.py
+++ b/tests/scripts/thread-cert/v1_2_router_5_1_1.py
@@ -148,19 +148,7 @@ class Router_5_1_01(thread_cert.TestCase):
         tlv_request = msg.get_mle_message_tlv(mle.TlvRequest)
         self.assertIn(mle.TlvType.LINK_MARGIN, tlv_request.tlvs)
 
-        # 9 - Leader sends a Unicast Link Accept
-        msg = leader_messages.next_mle_message(mle.CommandType.LINK_ACCEPT_AND_REQUEST)
-        msg.assertMleMessageContainsTlv(mle.SourceAddress)
-        msg.assertMleMessageContainsTlv(mle.LeaderData)
-        msg.assertMleMessageContainsTlv(mle.Response)
-        msg.assertMleMessageContainsTlv(mle.LinkLayerFrameCounter)
-        msg.assertMleMessageContainsTlv(mle.Version)
-        msg.assertMleMessageContainsTlv(mle.LinkMargin)
-        msg.assertMleMessageContainsOptionalTlv(mle.MleFrameCounter)
-        msg.assertMleMessageContainsOptionalTlv(mle.Challenge)
-        assert msg.get_mle_message_tlv(mle.Version).version >= 3
-
-        # 10 - Router_1 Transmit MLE advertisements
+        # 9 - Router_1 Transmit MLE advertisements
         msg = router_messages.next_mle_message(mle.CommandType.ADVERTISEMENT)
         msg.assertSentWithHopLimit(255)
         msg.assertSentToDestinationAddress('ff02::1')
@@ -168,7 +156,7 @@ class Router_5_1_01(thread_cert.TestCase):
         msg.assertMleMessageContainsTlv(mle.LeaderData)
         msg.assertMleMessageContainsTlv(mle.Route64)
 
-        # 11 - Verify connectivity by sending an ICMPv6 Echo Request to the DUT link local address
+        # 10 - Verify connectivity by sending an ICMPv6 Echo Request to the DUT link local address
         self.assertTrue(self.nodes[LEADER].ping(self.nodes[ROUTER_1].get_linklocal()))
         self.assertTrue(self.nodes[ROUTER_1].ping(self.nodes[LEADER].get_linklocal()))
 


### PR DESCRIPTION
This commit updates `MleRouter` to send an immediate MLE Advertisement on promotion to router role and assignment of new Router ID. This helps inform our former parent of our newly allocated Router ID and cause it to reset it own advertisement trickle timer. This can help speed up the dissemination of new Router ID to other routers. It can also help with quicker link establishment with our former parent and other routers.

In particular,
- This commit removes the check in `SendAdvertisment()` allowing tx of MLE Advertisement message while delaying multicast Link Request.
- In `HandleAddressSolicitResponse()` when promoting to router role we send an immediate MLE Advertisement (on a new Router ID allocation).