### PR TITLE
[heap] move static heap construction to singleton accessor

### DIFF
--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -51,6 +51,7 @@ OT_DEFINE_ALIGNED_VAR(gInstanceRaw, sizeof(Instance), uint64_t);
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
 #if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 OT_DEFINE_ALIGNED_VAR(sHeapRaw, sizeof(Utils::Heap), uint64_t);
+Utils::Heap *Instance::sHeap{nullptr};
 #endif
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 bool Instance::sDnsNameCompressionEnabled = true;
@@ -240,14 +241,16 @@ Instance::Instance(void)
 {
 }
 
-#if OPENTHREAD_MTD || OPENTHREAD_FTD
-#if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+#if (OPENTHREAD_MTD || OPENTHREAD_FTD) && !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
 Utils::Heap &Instance::GetHeap(void)
 {
-    static Utils::Heap *sHeap = new (&sHeapRaw) Utils::Heap();
+    if (nullptr == sHeap)
+    {
+        sHeap = new (&sHeapRaw) Utils::Heap();
+    }
+
     return *sHeap;
 }
-#endif
 #endif
 
 #if !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE

--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -50,7 +50,7 @@ OT_DEFINE_ALIGNED_VAR(gInstanceRaw, sizeof(Instance), uint64_t);
 
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
 #if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-Utils::Heap Instance::sHeap;
+OT_DEFINE_ALIGNED_VAR(sHeapRaw, sizeof(Utils::Heap), uint64_t);
 #endif
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
 bool Instance::sDnsNameCompressionEnabled = true;
@@ -239,6 +239,16 @@ Instance::Instance(void)
     , mIsInitialized(false)
 {
 }
+
+#if OPENTHREAD_MTD || OPENTHREAD_FTD
+#if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+Utils::Heap &Instance::GetHeap(void)
+{
+    static Utils::Heap *sHeap = new (&sHeapRaw) Utils::Heap();
+    return *sHeap;
+}
+#endif
+#endif
 
 #if !OPENTHREAD_CONFIG_MULTIPLE_INSTANCE_ENABLE
 

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -290,7 +290,7 @@ public:
      * @returns A reference to the Heap object.
      *
      */
-    static Utils::Heap &GetHeap(void) { return sHeap; }
+    static Utils::Heap &GetHeap(void);
 #endif
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
@@ -380,9 +380,6 @@ private:
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
     // Random::Manager is initialized before other objects. Note that it
     // requires MbedTls which itself may use Heap.
-#if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
-    static Utils::Heap sHeap;
-#endif
     Crypto::MbedTls mMbedTls;
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -380,6 +380,9 @@ private:
 #if OPENTHREAD_MTD || OPENTHREAD_FTD
     // Random::Manager is initialized before other objects. Note that it
     // requires MbedTls which itself may use Heap.
+#if !OPENTHREAD_CONFIG_HEAP_EXTERNAL_ENABLE
+    static Utils::Heap *sHeap;
+#endif
     Crypto::MbedTls mMbedTls;
 #endif // OPENTHREAD_MTD || OPENTHREAD_FTD
 


### PR DESCRIPTION
Move static heap construction to singleton accessor to avoid non-trivial construction at global scope, which has an unpredictable ordering.