### PR TITLE
[test] update `AdvanceTime()` in unit tests to handle overflow

### DIFF
--- a/tests/unit/test_dso.cpp
+++ b/tests/unit/test_dso.cpp
@@ -35,6 +35,7 @@
 #include "common/array.hpp"
 #include "common/as_core_type.hpp"
 #include "common/instance.hpp"
+#include "common/time.hpp"
 #include "net/dns_dso.hpp"
 
 #if OPENTHREAD_CONFIG_DNS_DSO_ENABLE
@@ -78,7 +79,7 @@ void AdvanceTime(uint32_t aDuration)
 
     Log(" AdvanceTime for %u.%03u", aDuration / 1000, aDuration % 1000);
 
-    while (sAlarmTime <= time)
+    while (ot::TimeMilli(sAlarmTime) <= ot::TimeMilli(time))
     {
         sNow = sAlarmTime;
         otPlatAlarmMilliFired(sInstance);

--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -37,6 +37,7 @@
 #include "common/arg_macros.hpp"
 #include "common/array.hpp"
 #include "common/instance.hpp"
+#include "common/time.hpp"
 #include "net/icmp6.hpp"
 #include "net/nd6.hpp"
 
@@ -245,7 +246,7 @@ void AdvanceTime(uint32_t aDuration)
 
     Log("AdvanceTime for %u.%03u", aDuration / 1000, aDuration % 1000);
 
-    while (sAlarmTime <= time)
+    while (TimeMilli(sAlarmTime) <= TimeMilli(time))
     {
         ProcessRadioTxAndTasklets();
         sNow = sAlarmTime;

--- a/tests/unit/test_srp_server.cpp
+++ b/tests/unit/test_srp_server.cpp
@@ -39,6 +39,7 @@
 #include "common/array.hpp"
 #include "common/instance.hpp"
 #include "common/string.hpp"
+#include "common/time.hpp"
 
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE && OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE && \
     !OPENTHREAD_CONFIG_TIME_SYNC_ENABLE && !OPENTHREAD_PLATFORM_POSIX
@@ -179,7 +180,7 @@ void AdvanceTime(uint32_t aDuration)
 
     Log("AdvanceTime for %u.%03u", aDuration / 1000, aDuration % 1000);
 
-    while (sAlarmTime <= time)
+    while (TimeMilli(sAlarmTime) <= TimeMilli(time))
     {
         ProcessRadioTxAndTasklets();
         sNow = sAlarmTime;


### PR DESCRIPTION
---

Though it is unlikely that we ever need to run a test for more 24 days (for 
overflow to happen) but no harm in handling it (and be safe).