### PR TITLE
[link-metrics] simplify handling of Type IDs

### DIFF
--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -90,9 +90,9 @@ public:
      */
     struct QueryInfo : public Clearable<QueryInfo>
     {
-        uint8_t     mSeriesId;                 ///< Series ID.
-        TypeIdFlags mTypeIds[kMaxTypeIdFlags]; ///< Type ID flags.
-        uint8_t     mTypeIdCount;              ///< Number of entries in `mTypeIds[]`.
+        uint8_t mSeriesId;             ///< Series ID.
+        uint8_t mTypeIds[kMaxTypeIds]; ///< Type IDs.
+        uint8_t mTypeIdCount;          ///< Number of entries in `mTypeIds[]`.
     };
 
     /**
@@ -114,7 +114,7 @@ public:
      *
      * @retval kErrorNone             Successfully sent a Link Metrics query message.
      * @retval kErrorNoBufs           Insufficient buffers to generate the MLE Data Request message.
-     * @retval kErrorInvalidArgs      TypeIdFlags are not valid or exceed the count limit.
+     * @retval kErrorInvalidArgs      Type IDs are not valid or exceed the count limit.
      * @retval kErrorUnknownNeighbor  @p aDestination is not link-local or the neighbor is not found.
      *
      */
@@ -309,10 +309,10 @@ private:
 
     Neighbor *GetNeighborFromLinkLocalAddr(const Ip6::Address &aDestination);
 
-    static Error ReadTypeIdFlagsFromMessage(const Message &aMessage,
-                                            uint16_t       aStartPos,
-                                            uint16_t       aEndPos,
-                                            Metrics &      aMetrics);
+    static Error ReadTypeIdsFromMessage(const Message &aMessage,
+                                        uint16_t       aStartOffset,
+                                        uint16_t       aEndOffset,
+                                        Metrics &      aMetrics);
     static Error AppendReportSubTlvToMessage(Message &aMessage, const MetricsValues &aValues);
 
     static uint8_t ScaleLinkMarginToRawValue(uint8_t aLinkMargin);

--- a/src/core/thread/link_metrics_tlvs.hpp
+++ b/src/core/thread/link_metrics_tlvs.hpp
@@ -94,17 +94,13 @@ OT_TOOL_PACKED_BEGIN
 class ReportSubTlv : public Tlv, public TlvInfo<SubTlv::kReport>
 {
 public:
-    static constexpr uint8_t kMinLength = sizeof(TypeIdFlags) + sizeof(uint8_t); ///< Minimum expected TLV length.
+    static constexpr uint8_t kMinLength = 2; ///< Minimum expected TLV length (type ID and u8 value).
 
     /**
      * This method initializes the TLV.
      *
      */
-    void Init(void)
-    {
-        SetType(SubTlv::kReport);
-        SetLength(sizeof(*this) - sizeof(Tlv));
-    }
+    void Init(void) { SetType(SubTlv::kReport); }
 
     /**
      * This method indicates whether or not the TLV appears to be well-formed.
@@ -121,7 +117,7 @@ public:
      * @returns The Link Metrics Type ID.
      *
      */
-    TypeIdFlags GetMetricsTypeId(void) const { return mMetricsTypeId; }
+    uint8_t GetMetricsTypeId(void) const { return mMetricsTypeId; }
 
     /**
      * This method sets the Link Metrics Type ID.
@@ -129,15 +125,7 @@ public:
      * @param[in]  aMetricsTypeId  The Link Metrics Type ID to set.
      *
      */
-    void SetMetricsTypeId(TypeIdFlags aMetricsTypeId)
-    {
-        mMetricsTypeId = aMetricsTypeId;
-
-        if (!aMetricsTypeId.IsLengthFlagSet())
-        {
-            SetLength(sizeof(*this) - sizeof(Tlv) - sizeof(uint32_t) + sizeof(uint8_t)); // The value is 1 byte long
-        }
-    }
+    void SetMetricsTypeId(uint8_t aMetricsTypeId) { mMetricsTypeId = aMetricsTypeId; }
 
     /**
      * This method returns the metric value in 8 bits.
@@ -161,7 +149,11 @@ public:
      * @param[in]  aMetricsValue  Metrics value.
      *
      */
-    void SetMetricsValue8(uint8_t aMetricsValue) { mMetricsValue.m8 = aMetricsValue; }
+    void SetMetricsValue8(uint8_t aMetricsValue)
+    {
+        mMetricsValue.m8 = aMetricsValue;
+        SetLength(kMinLength);
+    }
 
     /**
      * This method sets the metric value (32 bits).
@@ -169,10 +161,14 @@ public:
      * @param[in]  aMetricsValue  Metrics value.
      *
      */
-    void SetMetricsValue32(uint32_t aMetricsValue) { mMetricsValue.m32 = HostSwap32(aMetricsValue); }
+    void SetMetricsValue32(uint32_t aMetricsValue)
+    {
+        mMetricsValue.m32 = HostSwap32(aMetricsValue);
+        SetLength(sizeof(*this) - sizeof(Tlv));
+    }
 
 private:
-    TypeIdFlags mMetricsTypeId;
+    uint8_t mMetricsTypeId;
     union
     {
         uint8_t  m8;
@@ -205,7 +201,7 @@ public:
      * @retval FALSE  If the TLV does not appear to be well-formed.
      *
      */
-    bool IsValid(void) const { return GetLength() >= sizeof(TypeIdFlags); }
+    bool IsValid(void) const { return GetLength() >= sizeof(uint8_t); }
 
 } OT_TOOL_PACKED_END;
 
@@ -271,17 +267,17 @@ public:
     void SetSeriesFlagsMask(uint8_t aSeriesFlagsMask) { mSeriesFlagsMask = aSeriesFlagsMask; }
 
     /**
-     * This method gets the start of Type ID Flags array.
+     * This method gets the start of Type ID array.
      *
-     * @returns The start of Type ID Flags array. Array has `kMaxTypeIdFlags` max length.
+     * @returns The start of Type ID array. Array has `kMaxTypeIds` max length.
      *
      */
-    TypeIdFlags *GetTypeIds(void) { return mTypeIds; }
+    uint8_t *GetTypeIds(void) { return mTypeIds; }
 
 private:
-    uint8_t     mSeriesId;
-    uint8_t     mSeriesFlagsMask;
-    TypeIdFlags mTypeIds[kMaxTypeIdFlags];
+    uint8_t mSeriesId;
+    uint8_t mSeriesFlagsMask;
+    uint8_t mTypeIds[kMaxTypeIds];
 } OT_TOOL_PACKED_END;
 
 OT_TOOL_PACKED_BEGIN
@@ -326,16 +322,16 @@ public:
     void SetEnhAckFlags(EnhAckFlags aEnhAckFlags) { mEnhAckFlags = aEnhAckFlags; }
 
     /**
-     * This method gets the start of Type ID Flags array.
+     * This method gets the start of Type ID array.
      *
-     * @returns The start of Type ID Flags array. Array has `kMaxTypeIdFlags` max length.
+     * @returns The start of Type ID array. Array has `kMaxTypeIds` max length.
      *
      */
-    TypeIdFlags *GetTypeIds(void) { return mTypeIds; }
+    uint8_t *GetTypeIds(void) { return mTypeIds; }
 
 private:
-    uint8_t     mEnhAckFlags;
-    TypeIdFlags mTypeIds[kMaxTypeIdFlags];
+    uint8_t mEnhAckFlags;
+    uint8_t mTypeIds[kMaxTypeIds];
 } OT_TOOL_PACKED_END;
 
 } // namespace LinkMetrics

--- a/src/core/thread/link_metrics_types.cpp
+++ b/src/core/thread/link_metrics_types.cpp
@@ -41,36 +41,39 @@
 namespace ot {
 namespace LinkMetrics {
 
-uint8_t TypeIdFlagsFromMetrics(TypeIdFlags aTypeIdFlags[], const Metrics &aMetrics)
+//----------------------------------------------------------------------------------------------------------------------
+// Metrics
+
+uint8_t Metrics::ConvertToTypeIds(uint8_t aTypeIds[]) const
 {
     uint8_t count = 0;
 
-    if (aMetrics.mPduCount)
+    if (mPduCount)
     {
-        aTypeIdFlags[count++].SetRawValue(TypeIdFlags::kPdu);
+        aTypeIds[count++] = TypeId::kPdu;
     }
 
-    if (aMetrics.mLqi)
+    if (mLqi)
     {
-        aTypeIdFlags[count++].SetRawValue(TypeIdFlags::kLqi);
+        aTypeIds[count++] = TypeId::kLqi;
     }
 
-    if (aMetrics.mLinkMargin)
+    if (mLinkMargin)
     {
-        aTypeIdFlags[count++].SetRawValue(TypeIdFlags::kLinkMargin);
+        aTypeIds[count++] = TypeId::kLinkMargin;
     }
 
-    if (aMetrics.mRssi)
+    if (mRssi)
     {
-        aTypeIdFlags[count++].SetRawValue(TypeIdFlags::kRssi);
+        aTypeIds[count++] = TypeId::kRssi;
     }
 
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
-    if (aMetrics.mReserved)
+    if (mReserved)
     {
         for (uint8_t i = 0; i < count; i++)
         {
-            aTypeIdFlags[i].SetTypeEnum(TypeIdFlags::kTypeReserved);
+            TypeId::MarkAsReserverd(aTypeIds[i]);
         }
     }
 #endif


### PR DESCRIPTION
This commit simplifies the handling of Type IDs in `LinkMetrics` modules.