### PR TITLE
[tmf] add `SecureAgent` and simplify URI resource processing

### DIFF
--- a/src/core/common/instance.cpp
+++ b/src/core/common/instance.cpp
@@ -145,7 +145,7 @@ Instance::Instance(void)
     , mCommissioner(*this)
 #endif
 #if OPENTHREAD_CONFIG_DTLS_ENABLE
-    , mCoapSecure(*this)
+    , mTmfSecureAgent(*this)
 #endif
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
     , mJoiner(*this)
@@ -390,8 +390,8 @@ void Instance::GetBufferInfo(BufferInfo &aInfo)
     Get<Tmf::Agent>().GetCachedResponses().GetInfo(aInfo.mCoapQueue);
 
 #if OPENTHREAD_CONFIG_DTLS_ENABLE
-    Get<Coap::CoapSecure>().GetRequestMessages().GetInfo(aInfo.mCoapSecureQueue);
-    Get<Coap::CoapSecure>().GetCachedResponses().GetInfo(aInfo.mCoapSecureQueue);
+    Get<Tmf::SecureAgent>().GetRequestMessages().GetInfo(aInfo.mCoapSecureQueue);
+    Get<Tmf::SecureAgent>().GetCachedResponses().GetInfo(aInfo.mCoapSecureQueue);
 #endif
 
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE

--- a/src/core/common/instance.hpp
+++ b/src/core/common/instance.hpp
@@ -497,7 +497,7 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_DTLS_ENABLE
-    Coap::CoapSecure mCoapSecure;
+    Tmf::SecureAgent mTmfSecureAgent;
 #endif
 
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
@@ -903,9 +903,9 @@ template <> inline Tmf::Agent &Instance::Get(void)
 }
 
 #if OPENTHREAD_CONFIG_DTLS_ENABLE
-template <> inline Coap::CoapSecure &Instance::Get(void)
+template <> inline Tmf::SecureAgent &Instance::Get(void)
 {
-    return mCoapSecure;
+    return mTmfSecureAgent;
 }
 #endif
 

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -56,6 +56,7 @@ class BorderAgent : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
     friend class Tmf::Agent;
+    friend class Tmf::SecureAgent;
 
 public:
     /**
@@ -149,9 +150,6 @@ private:
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
-    template <Coap::Resource BorderAgent::*aResource>
-    static void HandleRequest(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
-
     void HandleTimeout(void);
 
     static void HandleCoapResponse(void *               aContext,
@@ -166,9 +164,6 @@ private:
                                 bool                    aPetition,
                                 bool                    aSeparate);
     Error       ForwardToCommissioner(Coap::Message &aForwardMessage, const Message &aMessage);
-    void        HandleKeepAlive(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    void        HandleRelayTransmit(const Coap::Message &aMessage);
-    void        HandleProxyTransmit(const Coap::Message &aMessage);
     static bool HandleUdpReceive(void *aContext, const otMessage *aMessage, const otMessageInfo *aMessageInfo)
     {
         return static_cast<BorderAgent *>(aContext)->HandleUdpReceive(AsCoreType(aMessage), AsCoreType(aMessageInfo));
@@ -181,17 +176,6 @@ private:
 
     Ip6::MessageInfo mMessageInfo;
 
-    Coap::Resource mCommissionerPetition;
-    Coap::Resource mCommissionerKeepAlive;
-    Coap::Resource mRelayTransmit;
-    Coap::Resource mCommissionerGet;
-    Coap::Resource mCommissionerSet;
-    Coap::Resource mActiveGet;
-    Coap::Resource mActiveSet;
-    Coap::Resource mPendingGet;
-    Coap::Resource mPendingSet;
-    Coap::Resource mProxyTransmit;
-
     Ip6::Udp::Receiver         mUdpReceiver; ///< The UDP receiver to receive packets from external commissioner
     Ip6::Netif::UnicastAddress mCommissionerAloc;
 
@@ -201,6 +185,16 @@ private:
 };
 
 DeclareTmfHandler(BorderAgent, kUriRelayRx);
+DeclareTmfHandler(BorderAgent, kUriCommissionerPetition);
+DeclareTmfHandler(BorderAgent, kUriCommissionerKeepAlive);
+DeclareTmfHandler(BorderAgent, kUriRelayTx);
+DeclareTmfHandler(BorderAgent, kUriCommissionerGet);
+DeclareTmfHandler(BorderAgent, kUriCommissionerSet);
+DeclareTmfHandler(BorderAgent, kUriActiveGet);
+DeclareTmfHandler(BorderAgent, kUriActiveSet);
+DeclareTmfHandler(BorderAgent, kUriPendingGet);
+DeclareTmfHandler(BorderAgent, kUriPendingSet);
+DeclareTmfHandler(BorderAgent, kUriProxyTx);
 
 } // namespace MeshCoP
 

--- a/src/core/meshcop/border_agent.hpp
+++ b/src/core/meshcop/border_agent.hpp
@@ -158,11 +158,7 @@ private:
                                    Error                aResult);
     void        HandleCoapResponse(ForwardContext &aForwardContext, const Coap::Message *aResponse, Error aResult);
 
-    Error       ForwardToLeader(const Coap::Message &   aMessage,
-                                const Ip6::MessageInfo &aMessageInfo,
-                                Uri                     aUri,
-                                bool                    aPetition,
-                                bool                    aSeparate);
+    Error       ForwardToLeader(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, Uri aUri);
     Error       ForwardToCommissioner(Coap::Message &aForwardMessage, const Message &aMessage);
     static bool HandleUdpReceive(void *aContext, const otMessage *aMessage, const otMessageInfo *aMessageInfo)
     {

--- a/src/core/meshcop/commissioner.hpp
+++ b/src/core/meshcop/commissioner.hpp
@@ -65,6 +65,7 @@ namespace MeshCoP {
 class Commissioner : public InstanceLocator, private NonCopyable
 {
     friend class Tmf::Agent;
+    friend class Tmf::SecureAgent;
 
 public:
     /**
@@ -541,9 +542,6 @@ private:
     Error RemoveJoiner(const Mac::ExtAddress *aEui64, const JoinerDiscerner *aDiscerner, uint32_t aDelay);
     void  RemoveJoiner(Joiner &aJoiner, uint32_t aDelay);
 
-    void AddCoapResources(void);
-    void RemoveCoapResources(void);
-
     void HandleTimer(void);
     void HandleJoinerExpirationTimer(void);
 
@@ -574,15 +572,12 @@ private:
                                               Error                aResult);
     void HandleLeaderKeepAliveResponse(Coap::Message *aMessage, const Ip6::MessageInfo *aMessageInfo, Error aResult);
 
-    static void HandleCoapsConnected(bool aConnected, void *aContext);
-    void        HandleCoapsConnected(bool aConnected);
+    static void HandleSecureAgentConnected(bool aConnected, void *aContext);
+    void        HandleSecureAgentConnected(bool aConnected);
 
     template <Uri kUri> void HandleTmf(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     void HandleRelayReceive(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-
-    static void HandleJoinerFinalize(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
-    void        HandleJoinerFinalize(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
 
     void SendJoinFinalizeResponse(const Coap::Message &aRequest, StateTlv::State aState);
 
@@ -615,8 +610,6 @@ private:
     JoinerExpirationTimer    mJoinerExpirationTimer;
     CommissionerTimer        mTimer;
 
-    Coap::Resource mJoinerFinalize;
-
     AnnounceBeginClient mAnnounceBegin;
     EnergyScanClient    mEnergyScan;
     PanIdQueryClient    mPanIdQuery;
@@ -635,6 +628,7 @@ private:
 
 DeclareTmfHandler(Commissioner, kUriDatasetChanged);
 DeclareTmfHandler(Commissioner, kUriRelayRx);
+DeclareTmfHandler(Commissioner, kUriJoinerFinalize);
 
 } // namespace MeshCoP
 

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -98,7 +98,7 @@ void ThreadNetif::Down(void)
     Get<Dns::ServiceDiscovery::Server>().Stop();
 #endif
 #if OPENTHREAD_CONFIG_DTLS_ENABLE
-    Get<Coap::CoapSecure>().Stop();
+    Get<Tmf::SecureAgent>().Stop();
 #endif
     IgnoreError(Get<Tmf::Agent>().Stop());
     IgnoreError(Get<Mle::MleRouter>().Disable());

--- a/src/core/thread/tmf.hpp
+++ b/src/core/thread/tmf.hpp
@@ -37,6 +37,7 @@
 #include "openthread-core-config.h"
 
 #include "coap/coap.hpp"
+#include "coap/coap_secure.hpp"
 #include "common/locator.hpp"
 
 namespace ot {
@@ -192,6 +193,33 @@ private:
 
     static Error Filter(const Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);
 };
+
+#if OPENTHREAD_CONFIG_DTLS_ENABLE
+
+/**
+ * This class implements functionality of the secure TMF agent.
+ *
+ */
+class SecureAgent : public Coap::CoapSecure
+{
+public:
+    /**
+     * This constructor initializes the object.
+     *
+     * @param[in] aInstance      A reference to the OpenThread instance.
+     *
+     */
+    explicit SecureAgent(Instance &aInstance);
+
+private:
+    static bool HandleResource(CoapBase &              aCoapBase,
+                               const char *            aUriPath,
+                               Message &               aMessage,
+                               const Ip6::MessageInfo &aMessageInfo);
+    bool        HandleResource(const char *aUriPath, Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+};
+
+#endif
 
 } // namespace Tmf
 } // namespace ot


### PR DESCRIPTION
This PR contains two related commits:

**[tmf] add `SecureAgent` and simplify URI resource processing**

This commit adds a new class `Tmf::SecureAgent` as a sub-class of
`Coap::CoapSecure`. It also simplifies the handling of TMF URI
resources by secure agent (similar model as in `Tmf::Agent` added
in #8233.


**[border-agent] simplify `ForwardToLeader()`**
    
This commit updates `BorderAgent::ForwardToLeader()` to determine the
`petition` and `separate` boolean flags from the passed-in `aUri`.

    

