### PR TITLE
[thci] fix `setBbrDataset`

### DIFF
--- a/tools/harness-thci/OpenThread.py
+++ b/tools/harness-thci/OpenThread.py
@@ -2870,8 +2870,7 @@ class OpenThreadTHCI(object):
                 self.bbrSeqNum = 128
             else:
                 self.bbrSeqNum = (self.bbrSeqNum + 1) % 256
-
-        if SeqNum:
+        elif SeqNum is not None:
             self.bbrSeqNum = SeqNum
 
         return self.__configBbrDataset(SeqNum=self.bbrSeqNum, MlrTimeout=MlrTimeout, ReRegDelay=ReRegDelay)


### PR DESCRIPTION
Cover the case when neither `MlrTimeout` or `ReRegDelay` are being modifyed.