### PR TITLE
[cmake-build] allow specify multiple targets

### DIFF
--- a/script/cmake-build
+++ b/script/cmake-build
@@ -122,11 +122,11 @@ build()
     cd "${builddir}"
 
     cmake -GNinja -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DOT_COMPILE_WARNING_AS_ERROR=ON "$@" "${OT_SRCDIR}"
-
-    if [[ -n ${OT_CMAKE_NINJA_TARGET[*]} ]]; then
-        ninja "${OT_CMAKE_NINJA_TARGET[@]}"
-    else
+    if [[ -z ${OT_CMAKE_NINJA_TARGET// /} ]]; then
         ninja
+    else
+        IFS=' ' read -r -a OT_CMAKE_NINJA_TARGET <<<"${OT_CMAKE_NINJA_TARGET}"
+        ninja "${OT_CMAKE_NINJA_TARGET[@]}"
     fi
 
     cd "${OT_SRCDIR}"

--- a/script/cmake-build
+++ b/script/cmake-build
@@ -45,6 +45,7 @@
 #  Compile with the specified ninja build target:
 #
 #      OT_CMAKE_NINJA_TARGET="ot-cli-ftd" script/cmake-build ${platform}
+#      OT_CMAKE_NINJA_TARGET="ot-cli-ftd ot-cli-mtd" script/cmake-build ${platform}
 #
 #  Compile with the specified build directory:
 #


### PR DESCRIPTION
This commit allows using OT_CMAKE_NINJA_TARGET to specify multiple targets.

Verified by running the following commands:

```bash
./script/cmake-build simulation
OT_CMAKE_NINJA_TARGET="ot-cli-ftd ot-cli-mtd" ./script/cmake-build simulation
```