### PR TITLE
[backbone-router] simplify TMF URI resource handling

### DIFF
--- a/src/core/backbone_router/backbone_tmf.hpp
+++ b/src/core/backbone_router/backbone_tmf.hpp
@@ -39,6 +39,7 @@
 #if OPENTHREAD_FTD && OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
 
 #include "coap/coap.hpp"
+#include "thread/tmf.hpp"
 
 namespace ot {
 namespace BackboneRouter {
@@ -58,11 +59,7 @@ public:
      * @param[in] aInstance      A reference to the OpenThread instance.
      *
      */
-    explicit BackboneTmfAgent(Instance &aInstance)
-        : Coap::Coap(aInstance)
-    {
-        SetInterceptor(&Filter, this);
-    }
+    explicit BackboneTmfAgent(Instance &aInstance);
 
     /**
      * This method starts the Backbone TMF agent.
@@ -99,7 +96,12 @@ public:
     void UnsubscribeMulticast(const Ip6::Address &aAddress);
 
 private:
-    void         LogError(const char *aText, const Ip6::Address &aAddress, Error aError) const;
+    static bool HandleResource(CoapBase &              aCoapBase,
+                               const char *            aUriPath,
+                               ot::Coap::Message &     aMessage,
+                               const Ip6::MessageInfo &aMessageInfo);
+    bool        HandleResource(const char *aUriPath, ot::Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    void        LogError(const char *aText, const Ip6::Address &aAddress, Error aError) const;
     static Error Filter(const ot::Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo, void *aContext);
 };
 

--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -56,8 +56,6 @@ RegisterLogModule("BbrManager");
 Manager::Manager(Instance &aInstance)
     : InstanceLocator(aInstance)
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
-    , mBackboneQuery(kUriBackboneQuery, Manager::HandleBackboneQuery, this)
-    , mBackboneAnswer(kUriBackboneAnswer, Manager::HandleBackboneAnswer, this)
     , mNdProxyTable(aInstance)
 #endif
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
@@ -80,10 +78,6 @@ Manager::Manager(Instance &aInstance)
 #endif
 #endif
 {
-#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
-    mBackboneTmfAgent.AddResource(mBackboneQuery);
-    mBackboneTmfAgent.AddResource(mBackboneAnswer);
-#endif
 }
 
 void Manager::HandleNotifierEvents(Events aEvents)
@@ -555,12 +549,7 @@ exit:
     return error;
 }
 
-void Manager::HandleBackboneQuery(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
-{
-    static_cast<Manager *>(aContext)->HandleBackboneQuery(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
-}
-
-void Manager::HandleBackboneQuery(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Manager::HandleTmf<kUriBackboneQuery>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     Error                  error = kErrorNone;
     Ip6::Address           dua;
@@ -589,12 +578,7 @@ exit:
     LogInfo("HandleBackboneQuery: %s", ErrorToString(error));
 }
 
-void Manager::HandleBackboneAnswer(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo)
-{
-    static_cast<Manager *>(aContext)->HandleBackboneAnswer(AsCoapMessage(aMessage), AsCoreType(aMessageInfo));
-}
-
-void Manager::HandleBackboneAnswer(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
+template <> void Manager::HandleTmf<kUriBackboneAnswer>(Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo)
 {
     Error                    error = kErrorNone;
     bool                     proactive;

--- a/src/core/backbone_router/bbr_manager.hpp
+++ b/src/core/backbone_router/bbr_manager.hpp
@@ -63,6 +63,7 @@ class Manager : public InstanceLocator, private NonCopyable
 {
     friend class ot::Notifier;
     friend class Tmf::Agent;
+    friend class BackboneTmfAgent;
 
 public:
     /**
@@ -189,32 +190,28 @@ private:
 #endif
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
-    void        HandleDuaRegistration(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    static void HandleBackboneQuery(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
-    void        HandleBackboneQuery(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    static void HandleBackboneAnswer(void *aContext, otMessage *aMessage, const otMessageInfo *aMessageInfo);
-    void        HandleBackboneAnswer(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
-    Error       SendBackboneAnswer(const Ip6::MessageInfo &     aQueryMessageInfo,
-                                   const Ip6::Address &         aDua,
-                                   uint16_t                     aSrcRloc16,
-                                   const NdProxyTable::NdProxy &aNdProxy);
-    Error       SendBackboneAnswer(const Ip6::Address &            aDstAddr,
-                                   const Ip6::Address &            aDua,
-                                   const Ip6::InterfaceIdentifier &aMeshLocalIid,
-                                   uint32_t                        aTimeSinceLastTransaction,
-                                   uint16_t                        aSrcRloc16);
-    void        HandleDadBackboneAnswer(const Ip6::Address &aDua, const Ip6::InterfaceIdentifier &aMeshLocalIid);
-    void        HandleExtendedBackboneAnswer(const Ip6::Address &            aDua,
-                                             const Ip6::InterfaceIdentifier &aMeshLocalIid,
-                                             uint32_t                        aTimeSinceLastTransaction,
-                                             uint16_t                        aSrcRloc16);
-    void        HandleProactiveBackboneNotification(const Ip6::Address &            aDua,
-                                                    const Ip6::InterfaceIdentifier &aMeshLocalIid,
-                                                    uint32_t                        aTimeSinceLastTransaction);
-    void        SendDuaRegistrationResponse(const Coap::Message &      aMessage,
-                                            const Ip6::MessageInfo &   aMessageInfo,
-                                            const Ip6::Address &       aTarget,
-                                            ThreadStatusTlv::DuaStatus aStatus);
+    void  HandleDuaRegistration(const Coap::Message &aMessage, const Ip6::MessageInfo &aMessageInfo);
+    Error SendBackboneAnswer(const Ip6::MessageInfo &     aQueryMessageInfo,
+                             const Ip6::Address &         aDua,
+                             uint16_t                     aSrcRloc16,
+                             const NdProxyTable::NdProxy &aNdProxy);
+    Error SendBackboneAnswer(const Ip6::Address &            aDstAddr,
+                             const Ip6::Address &            aDua,
+                             const Ip6::InterfaceIdentifier &aMeshLocalIid,
+                             uint32_t                        aTimeSinceLastTransaction,
+                             uint16_t                        aSrcRloc16);
+    void  HandleDadBackboneAnswer(const Ip6::Address &aDua, const Ip6::InterfaceIdentifier &aMeshLocalIid);
+    void  HandleExtendedBackboneAnswer(const Ip6::Address &            aDua,
+                                       const Ip6::InterfaceIdentifier &aMeshLocalIid,
+                                       uint32_t                        aTimeSinceLastTransaction,
+                                       uint16_t                        aSrcRloc16);
+    void  HandleProactiveBackboneNotification(const Ip6::Address &            aDua,
+                                              const Ip6::InterfaceIdentifier &aMeshLocalIid,
+                                              uint32_t                        aTimeSinceLastTransaction);
+    void  SendDuaRegistrationResponse(const Coap::Message &      aMessage,
+                                      const Ip6::MessageInfo &   aMessageInfo,
+                                      const Ip6::Address &       aTarget,
+                                      ThreadStatusTlv::DuaStatus aStatus);
 #endif
     void HandleNotifierEvents(Events aEvents);
 
@@ -225,9 +222,7 @@ private:
     using BbrTimer = TimerMilliIn<Manager, &Manager::HandleTimer>;
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
-    Coap::Resource mBackboneQuery;
-    Coap::Resource mBackboneAnswer;
-    NdProxyTable   mNdProxyTable;
+    NdProxyTable mNdProxyTable;
 #endif
 
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
@@ -253,6 +248,15 @@ private:
 #endif
 #endif
 };
+
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_MULTICAST_ROUTING_ENABLE
+DeclareTmfHandler(Manager, kUriMlr);
+#endif
+#if OPENTHREAD_CONFIG_BACKBONE_ROUTER_DUA_NDPROXYING_ENABLE
+DeclareTmfHandler(Manager, kUriDuaRegistrationRequest);
+DeclareTmfHandler(Manager, kUriBackboneQuery);
+DeclareTmfHandler(Manager, kUriBackboneAnswer);
+#endif
 
 } // namespace BackboneRouter
 


### PR DESCRIPTION
This commit updates `BackboneTmfAgent` to handle TMF URI resources 
(similar to the model used by `Tmf::Agent` added in #8233).