### PR TITLE
[link-metrics] update method finding neighbor to validate its version

### DIFF
--- a/src/core/thread/link_metrics.hpp
+++ b/src/core/thread/link_metrics.hpp
@@ -307,7 +307,7 @@ private:
 
     Status ConfigureEnhAckProbing(EnhAckFlags aEnhAckFlags, const Metrics &aMetrics, Neighbor &aNeighbor);
 
-    Neighbor *GetNeighborFromLinkLocalAddr(const Ip6::Address &aDestination);
+    Error FindNeighbor(const Ip6::Address &aDestination, Neighbor *&aNeighbor) const;
 
     static Error ReadTypeIdsFromMessage(const Message &aMessage,
                                         uint16_t       aStartOffset,


### PR DESCRIPTION
This commit renames and updates the `LinkMetrics::FindNeighbor()`
helper method which finds the neighbor for a given link-local address
for use in `LinkMetrics` class. This method now also validates that the
neighbor's Thread version is 1.2 or higher.