### PR TITLE
[core] remove `OT_UNREACHABLE_CODE(break)`

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -455,7 +455,6 @@ Error CoapBase::SendHeaderResponse(Message::Code aCode, const Message &aRequest,
 
     default:
         ExitNow(error = kErrorInvalidArgs);
-        OT_UNREACHABLE_CODE(break);
     }
 
     SuccessOrExit(error = message->SetTokenFromMessage(aRequest));

--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -291,7 +291,6 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, 
 
     default:
         OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
     }
 
     mCallbacks.HandleSentFrameToChild(aFrame, mFrameContext, aError, aChild);

--- a/src/core/mac/sub_mac.cpp
+++ b/src/core/mac/sub_mac.cpp
@@ -338,16 +338,15 @@ Error SubMac::Send(void)
 #if OPENTHREAD_CONFIG_MAC_ADD_DELAY_ON_NO_ACK_ERROR_BEFORE_RETRY
     case kStateDelayBeforeRetx:
 #endif
-    case kStateEnergyScan:
-        ExitNow(error = kErrorInvalidState);
-        OT_UNREACHABLE_CODE(break);
-
     case kStateSleep:
     case kStateReceive:
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
     case kStateCslSample:
 #endif
         break;
+
+    case kStateEnergyScan:
+        ExitNow(error = kErrorInvalidState);
     }
 
 #if OPENTHREAD_CONFIG_MAC_FILTER_ENABLE

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -614,12 +614,6 @@ void Joiner::HandleTimer(void)
 
     switch (mState)
     {
-    case kStateIdle:
-    case kStateDiscover:
-    case kStateConnect:
-        OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
-
     case kStateConnected:
     case kStateEntrust:
         error = kErrorResponseTimeout;
@@ -634,6 +628,11 @@ void Joiner::HandleTimer(void)
 
         error = kErrorNone;
         break;
+
+    case kStateIdle:
+    case kStateDiscover:
+    case kStateConnect:
+        OT_ASSERT(false);
     }
 
     Finish(error);

--- a/src/core/thread/indirect_sender.cpp
+++ b/src/core/thread/indirect_sender.cpp
@@ -351,7 +351,6 @@ Error IndirectSender::PrepareFrameForChild(Mac::TxFrame &aFrame, FrameContext &a
 
     default:
         OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
     }
 
 exit:
@@ -465,7 +464,6 @@ void IndirectSender::HandleSentFrameToChild(const Mac::TxFrame &aFrame,
 
     default:
         OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
     }
 
     if ((message != nullptr) && (nextOffset < message->GetLength()))

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -2015,7 +2015,6 @@ Error Mle::SendChildUpdateRequest(bool aAppendChallenge, uint32_t aTimeout)
     case kRoleRouter:
     case kRoleLeader:
         OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
     }
 
     if (!IsFullThreadDevice())
@@ -3513,7 +3512,6 @@ void Mle::HandleChildUpdateResponse(RxInfo &aRxInfo)
 
     default:
         OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
     }
 
     // Status
@@ -3607,7 +3605,6 @@ void Mle::HandleChildUpdateResponse(RxInfo &aRxInfo)
 
     default:
         OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
     }
 
     aRxInfo.mClass = (response.mLength == 0) ? RxInfo::kPeerMessage : RxInfo::kAuthoritativeMessage;

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -212,7 +212,6 @@ Error MleRouter::BecomeRouter(ThreadStatusTlv::Status aStatus)
 
     default:
         OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
     }
 
 exit:
@@ -509,11 +508,6 @@ void MleRouter::SendAdvertisement(void)
 
     switch (mRole)
     {
-    case kRoleDisabled:
-    case kRoleDetached:
-        OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
-
     case kRoleChild:
         break;
 
@@ -521,6 +515,10 @@ void MleRouter::SendAdvertisement(void)
     case kRoleLeader:
         SuccessOrExit(error = message->AppendRouteTlv());
         break;
+
+    case kRoleDisabled:
+    case kRoleDetached:
+        OT_ASSERT(false);
     }
 
     destination.SetToLinkLocalAllNodesMulticast();
@@ -552,10 +550,6 @@ Error MleRouter::SendLinkRequest(Neighbor *aNeighbor)
 
     switch (mRole)
     {
-    case kRoleDisabled:
-        OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
-
     case kRoleDetached:
         SuccessOrExit(error = message->AppendTlvRequestTlv(kDetachedTlvs));
         break;
@@ -579,6 +573,9 @@ Error MleRouter::SendLinkRequest(Neighbor *aNeighbor)
         SuccessOrExit(error = message->AppendSourceAddressTlv());
         SuccessOrExit(error = message->AppendLeaderDataTlv());
         break;
+
+    case kRoleDisabled:
+        OT_ASSERT(false);
     }
 
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
@@ -916,10 +913,6 @@ Error MleRouter::HandleLinkAccept(RxInfo &aRxInfo, bool aRequest)
 
     switch (mRole)
     {
-    case kRoleDisabled:
-        OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
-
     case kRoleDetached:
         // Address16
         SuccessOrExit(error = Tlv::Find<Address16Tlv>(aRxInfo.mMessage, address16));
@@ -996,6 +989,9 @@ Error MleRouter::HandleLinkAccept(RxInfo &aRxInfo, bool aRequest)
         }
 
         break;
+
+    case kRoleDisabled:
+        OT_ASSERT(false);
     }
 
     // finish link synchronization
@@ -1837,10 +1833,6 @@ void MleRouter::HandleTimeTick(void)
 
     switch (mRole)
     {
-    case kRoleDisabled:
-        OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
-
     case kRoleDetached:
         if (mChallengeTimeout == 0)
         {
@@ -1897,6 +1889,9 @@ void MleRouter::HandleTimeTick(void)
 
     case kRoleLeader:
         break;
+
+    case kRoleDisabled:
+        OT_ASSERT(false);
     }
 
     // update children state
@@ -1920,7 +1915,6 @@ void MleRouter::HandleTimeTick(void)
         case Neighbor::kStateParentResponse:
         case Neighbor::kStateLinkRequest:
             OT_ASSERT(false);
-            OT_UNREACHABLE_CODE(break);
         }
 
 #if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
@@ -2463,11 +2457,6 @@ void MleRouter::HandleChildIdRequest(RxInfo &aRxInfo)
 
     switch (mRole)
     {
-    case kRoleDisabled:
-    case kRoleDetached:
-        OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
-
     case kRoleChild:
         child->SetState(Neighbor::kStateChildIdRequest);
         IgnoreError(BecomeRouter(ThreadStatusTlv::kHaveChildIdRequest));
@@ -2477,6 +2466,10 @@ void MleRouter::HandleChildIdRequest(RxInfo &aRxInfo)
     case kRoleLeader:
         SuccessOrExit(error = SendChildIdResponse(*child));
         break;
+
+    case kRoleDisabled:
+    case kRoleDetached:
+        OT_ASSERT(false);
     }
 
 exit:

--- a/src/core/thread/network_data_local.cpp
+++ b/src/core/thread/network_data_local.cpp
@@ -168,7 +168,6 @@ void Local::UpdateRloc(PrefixTlv &aPrefixTlv)
 
         default:
             OT_ASSERT(false);
-            OT_UNREACHABLE_CODE(break);
         }
     }
 }
@@ -243,7 +242,6 @@ void Local::UpdateRloc(ServiceTlv &aService)
 
         default:
             OT_ASSERT(false);
-            OT_UNREACHABLE_CODE(break);
         }
     }
 }
@@ -271,7 +269,6 @@ void Local::UpdateRloc(void)
 
         default:
             OT_ASSERT(false);
-            OT_UNREACHABLE_CODE(break);
         }
     }
 }

--- a/src/core/thread/network_data_notifier.cpp
+++ b/src/core/thread/network_data_notifier.cpp
@@ -109,7 +109,6 @@ exit:
         break;
     default:
         OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
     }
 }
 
@@ -168,7 +167,6 @@ void Notifier::HandleCoapResponse(Error aResult)
 
     default:
         OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
     }
 }
 

--- a/src/ncp/ncp_base.cpp
+++ b/src/ncp/ncp_base.cpp
@@ -1075,7 +1075,6 @@ otError NcpBase::HandleCommandPropertyInsertRemove(uint8_t aHeader, spinel_prop_
 
     default:
         OT_ASSERT(false);
-        OT_UNREACHABLE_CODE(break);
     }
 
     VerifyOrExit(handler != nullptr, error = PrepareLastStatusResponse(aHeader, SPINEL_STATUS_PROP_NOT_FOUND));
@@ -2445,7 +2444,6 @@ template <> otError NcpBase::HandlePropertySet<SPINEL_PROP_DEBUG_NCP_LOG_LEVEL>(
 
     default:
         ExitNow(error = OT_ERROR_INVALID_ARGS);
-        OT_UNREACHABLE_CODE(break);
     }
 
     IgnoreError(otLoggingSetLevel(logLevel));


### PR DESCRIPTION
This commit removes `OT_UNREACHABLE_CODE(break)` which is used in `case` statements performing an `OT_ASSERT()` in a `switch` block. If the `case` is the last one in the `switch` we can skip the `break` and therefore we don't need to use `OT_UNREACHABLE_CODE()`.