### PR TITLE
[mle] send MLE Link Request and Advisement on promotion to router role

### DIFF
--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -690,8 +690,6 @@ private:
     uint8_t mRouterSelectionJitter;        ///< The variable to save the assigned jitter value.
     uint8_t mRouterSelectionJitterTimeout; ///< The Timeout prior to request/release Router ID.
 
-    uint8_t mLinkRequestDelay;
-
     int8_t mParentPriority; ///< The assigned parent priority value, -2 means not assigned.
 #if OPENTHREAD_CONFIG_BACKBONE_ROUTER_ENABLE
     uint8_t mBackboneRouterRegistrationDelay; ///< Delay before registering Backbone Router service.

--- a/tests/scripts/thread-cert/Cert_5_3_06_RouterIdMask.py
+++ b/tests/scripts/thread-cert/Cert_5_3_06_RouterIdMask.py
@@ -190,12 +190,8 @@ class Cert_5_3_6_RouterIdMask(thread_cert.TestCase):
                 filter_mle_cmd(MLE_ADVERTISEMENT).\
                 filter(lambda p: p.sniff_timestamp - _pkt.sniff_timestamp <= 4).\
                 must_next()
-        # check router cost before and after the re-attach
-        pkts.filter_wpan_src64(LEADER).\
-            filter_LLANMA().\
-            filter_mle_cmd(MLE_ADVERTISEMENT).\
-            filter(lambda p: {1,0,1} == set(p.mle.tlv.route64.cost)).\
-            must_next()
+
+        # check router cost after the re-attach
         pkts.filter_wpan_src64(LEADER).\
             filter_LLANMA().\
             filter_mle_cmd(MLE_ADVERTISEMENT).\


### PR DESCRIPTION
This commit updates `MleRouter` to send an immediate MLE Advertisement on promotion to router role and assignment of new Router ID. This helps inform our former parent of our newly allocated Router ID and cause it to reset it own advertisement trickle timer. This can help speed up the dissemination of new Router ID to other routers. It can also help with quicker link establishment with our former parent and other routers.

In particular,
- This commit removes the delay mechanism for sending multicast Link Request sending it quickly and also allowing MLE Link Advertisement to be sent more quickly (upon reset of trickle timer).
- In `HandleAddressSolicitResponse()` when promoting to router role we send an immediate MLE Advertisement (on a new Router ID allocation).

--------

This change requires us to modify two tests:
- `Cert_5_3_06_RouterIdMask.py` is updated.
   -  In the test we expected to see `{1,0,1}` cost pattern in an MLE Adv from leader after router re-attaches.
   - But this may not always happen and depends on order/timing of emitted Adv by the leader and the other routers (including new router). 
       - Note that all routers use trickle timers to schedule their Avd tx which adds randomness to when the Adv is emitted
        - If leader sends its adv first then we should see `{1,0,1}` route cost
        - But if other routers send first, the leader may update its path cost towards the new router and we no longer see `{1,0,1}` in adv from leader
        - This PR addresses this by removing this check
    - This check seems to be added in our implementation and reading the Thread testplan this is not explicitly required in cert test.
- `test_router_multicast_link_request` 
   - This test expcted to certain flow of "Link Request and Link Accept" messages between routers.
   - However, with having new router start advertising immediately, the order may be different (depending again on order o/timing of emitted Avd)
   - This PR updates the test to validate that all the links between routers are established, but does not check explict msgs (do not expect certain nodes should always be the one to send Link Request).