### PR TITLE
[cmake] disable `OPENTHREAD_CONFIG_NCP_HDLC_ENABLE` when `OT_NCP_SPI` is set

### DIFF
--- a/src/lib/spinel/CMakeLists.txt
+++ b/src/lib/spinel/CMakeLists.txt
@@ -31,13 +31,19 @@ add_library(openthread-spinel-rcp)
 
 target_compile_definitions(openthread-spinel-ncp PRIVATE
     OPENTHREAD_FTD=1
-    OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=1
     PUBLIC OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE=1
 )
 
+if (OT_NCP_SPI)
+    target_compile_definitions(openthread-spinel-ncp PRIVATE OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=0)
+    target_compile_definitions(openthread-spinel-rcp PRIVATE OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=0)
+else()
+    target_compile_definitions(openthread-spinel-ncp PRIVATE OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=1)
+    target_compile_definitions(openthread-spinel-rcp PRIVATE OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=1)
+endif()
+
 target_compile_definitions(openthread-spinel-rcp PRIVATE
     OPENTHREAD_RADIO=1
-    OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=1
     PUBLIC OPENTHREAD_SPINEL_CONFIG_OPENTHREAD_MESSAGE_ENABLE=0
 )
 

--- a/src/ncp/radio.cmake
+++ b/src/ncp/radio.cmake
@@ -31,8 +31,13 @@ add_library(openthread-rcp)
 target_compile_definitions(openthread-rcp PRIVATE
     OPENTHREAD_RADIO=1
     OPENTHREAD_RADIO_CLI=0
-    OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=1
 )
+
+if (OT_NCP_SPI)
+    target_compile_definitions(openthread-rcp PRIVATE OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=0)
+else()
+    target_compile_definitions(openthread-rcp PRIVATE OPENTHREAD_CONFIG_NCP_HDLC_ENABLE=1)
+endif()
 
 target_compile_options(openthread-rcp PRIVATE
     ${OT_CFLAGS}
@@ -47,8 +52,11 @@ target_link_libraries(openthread-rcp
     PUBLIC
         openthread-radio
     PRIVATE
-        openthread-hdlc
         openthread-spinel-rcp
         ot-config-radio
         ot-config
 )
+
+if(NOT OT_NCP_SPI)
+    target_link_libraries(openthread-rcp PRIVATE openthread-hdlc)
+endif()


### PR DESCRIPTION
This change is needed to enable SPI vs UART NCP interface.