### PR TITLE
[docs] Doxygen formatting updates

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (250)
+#define OPENTHREAD_API_VERSION (251)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/ip6.h
+++ b/include/openthread/ip6.h
@@ -638,8 +638,9 @@ void otIp6AddressToString(const otIp6Address *aAddress, char *aBuffer, uint16_t 
 /**
  * This function converts a given IPv6 socket address to a human-readable string.
  *
- * The IPv6 socket address string is formatted as "[<address>]:<port>" where `<address> is shown as 16 hex values
- * separated by ':' and `<port>` is the port number in decimal format (i.e., "[%x:%x:...:%x]:%u")
+ * The IPv6 socket address string is formatted as [`address`]:`port` where `address` is shown
+ * as 16 hex values separated by `:` and `port` is the port number in decimal format,
+ * for example "[%x:%x:...:%x]:%u".
  *
  * If the resulting string does not fit in @p aBuffer (within its @p aSize characters), the string will be truncated
  * but the outputted string is always null-terminated.


### PR DESCRIPTION
For various reasons, we're not able to use `<` and `>` in our Doxygen descriptions. I made some minor edits, LMKWYT. In the HTML, it renders similar to this:

The IPv6 socket address string is formatted as [`address`]:`port` where `address` is shown as 16 hex values separated by `:` and `port` is the port number in decimal format, for example "[%x:%x:...:%x]:%u".