### PR TITLE
[tcplp, cli-tcp] fix illegal memory access when refusing incoming TCP connection

### DIFF
--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -213,7 +213,7 @@ template <> otError TcpExample::Process<Cmd("connect")>(Arg aArgs[])
     VerifyOrExit(aArgs[2].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
 
     SuccessOrExit(error = otTcpConnect(&mEndpoint, &sockaddr, OT_TCP_CONNECT_NO_FAST_OPEN));
-    mEndpointConnected = false;
+    mEndpointConnected = true;
 
 exit:
     return error;
@@ -596,6 +596,7 @@ void TcpExample::HandleTcpAcceptDone(otTcpListener *aListener, otTcpEndpoint *aE
     OT_UNUSED_VARIABLE(aListener);
     OT_UNUSED_VARIABLE(aEndpoint);
 
+    mEndpointConnected = true;
     OutputFormat("Accepted connection from ");
     OutputSockAddrLine(*aPeer);
 }

--- a/third_party/tcplp/bsdtcp/tcp_input.c
+++ b/third_party/tcplp/bsdtcp/tcp_input.c
@@ -773,6 +773,7 @@ tcp_input(struct ip6_hdr* ip6, struct tcphdr* th, otMessage* msg, struct tcpcb* 
 		}
 		if (tp == (struct tcpcb *) -1) {
 			rstreason = ECONNREFUSED;
+			tp = NULL;
 			goto dropwithreset;
 		}
 		tcp_state_change(tp, TCPS_SYN_RECEIVED);


### PR DESCRIPTION
This pull request fixes a bug in TCPlp that causes an illegal memory access when refusing an incoming TCP connection using the `OT_TCP_INCOMING_CONNECTION_ACTION_REFUSE` action in the `otTcpAcceptReady` callback. It also fixes a bug in the TCP CLI tool that causes it to attempt to accept every incoming TCP connection (which should not normally be a problem, but in this case was triggering the above bug). Since there are really two separate bugs here, I separated their fixes into separate commits.

This fixes #8281.