### PR TITLE
[coap] Bugfix: CoAP not sending 4.04 when URI handler is not found

### DIFF
--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1302,7 +1302,7 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
 {
     char     uriPath[Message::kMaxReceivedUriPath + 1];
     Message *cachedResponse = nullptr;
-    Error    error          = kErrorNotFound;
+    Error    error          = kErrorNone;
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
     Option::Iterator iterator;
     char *           curUriPath         = uriPath;
@@ -1453,7 +1453,10 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
     {
         mDefaultHandler(mDefaultHandlerContext, &aMessage, &aMessageInfo);
         error = kErrorNone;
+        ExitNow();
     }
+
+    error = kErrorNotFound;
 
 exit:
 

--- a/src/core/coap/coap.cpp
+++ b/src/core/coap/coap.cpp
@@ -1320,10 +1320,10 @@ void CoapBase::ProcessReceivedRequest(Message &aMessage, const Ip6::MessageInfo 
     case kErrorNone:
         cachedResponse->Finish();
         error = Send(*cachedResponse, aMessageInfo);
-
-        OT_FALL_THROUGH;
+        ExitNow();
 
     case kErrorNoBufs:
+        error = kErrorNoBufs;
         ExitNow();
 
     case kErrorNotFound:


### PR DESCRIPTION
Update CoAP base handler to correctly detect when a handler is not found and send a 4.04 response.

Prior to this change, the error code would be overridden in the case where a URI handler was not found to kErrorNone. This meant that when the exit code was reached, no 4.04 message was generated. This fixes the logical flow to ensure the error message is sent on the link.