### PR TITLE
[mle] add time tracking to mle roles

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (253)
+#define OPENTHREAD_API_VERSION (254)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -174,12 +174,20 @@ typedef struct otMleCounters
     uint16_t mAttachAttempts;                ///< Number of attach attempts while device was detached.
     uint16_t mPartitionIdChanges;            ///< Number of changes to partition ID.
     uint16_t mBetterPartitionAttachAttempts; ///< Number of attempts to attach to a better partition.
+
+    /**
+     * Role time tracking.
+     *
+     * When uptime feature is enabled (OPENTHREAD_CONFIG_UPTIME_ENABLE = 1) time spent in each MLE role is tracked.
+     *
+     */
     uint64_t mDisabledTime; ///< Number of milliseconds device has been in OT_DEVICE_ROLE_DISABLED role.
     uint64_t mDetachedTime; ///< Number of milliseconds device has been in OT_DEVICE_ROLE_DETACHED role.
     uint64_t mChildTime;    ///< Number of milliseconds device has been in OT_DEVICE_ROLE_CHILD role.
     uint64_t mRouterTime;   ///< Number of milliseconds device has been in OT_DEVICE_ROLE_ROUTER role.
     uint64_t mLeaderTime;   ///< Number of milliseconds device has been in OT_DEVICE_ROLE_LEADER role.
-    uint64_t mTrackedTime;  ///< Total number of milliseconds tracked by previous counters.
+    uint64_t mTrackedTime;  ///< Number of milliseconds tracked by previous counters.
+
     /**
      * Number of times device changed its parent.
      *

--- a/include/openthread/thread.h
+++ b/include/openthread/thread.h
@@ -174,7 +174,12 @@ typedef struct otMleCounters
     uint16_t mAttachAttempts;                ///< Number of attach attempts while device was detached.
     uint16_t mPartitionIdChanges;            ///< Number of changes to partition ID.
     uint16_t mBetterPartitionAttachAttempts; ///< Number of attempts to attach to a better partition.
-
+    uint64_t mDisabledTime; ///< Number of milliseconds device has been in OT_DEVICE_ROLE_DISABLED role.
+    uint64_t mDetachedTime; ///< Number of milliseconds device has been in OT_DEVICE_ROLE_DETACHED role.
+    uint64_t mChildTime;    ///< Number of milliseconds device has been in OT_DEVICE_ROLE_CHILD role.
+    uint64_t mRouterTime;   ///< Number of milliseconds device has been in OT_DEVICE_ROLE_ROUTER role.
+    uint64_t mLeaderTime;   ///< Number of milliseconds device has been in OT_DEVICE_ROLE_LEADER role.
+    uint64_t mTrackedTime;  ///< Total number of milliseconds tracked by previous counters.
     /**
      * Number of times device changed its parent.
      *

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -844,6 +844,8 @@ Done
 
 Get the counter value.
 
+Note: `OPENTHREAD_CONFIG_UPTIME_ENABLE` is required for MLE role time tracking in `counters mle`
+
 ```bash
 > counters mac
 TxTotal: 10

--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -888,6 +888,12 @@ Attach Attempts: 1
 Partition Id Changes: 1
 Better Partition Attach Attempts: 0
 Parent Changes: 0
+Time Disabled Milli: 10026
+Time Detached Milli: 6852
+Time Child Milli: 0
+Time Router Milli: 0
+Time Leader Milli: 16195
+Time Tracked Milli: 33073
 Done
 > counters ip
 TxSuccess: 10

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2644,14 +2644,14 @@ template <> otError Interpreter::Process<Cmd("counters")>(Arg aArgs[])
                 };
 
                 static const MleTimeCounterName kTimeCounterNames[] = {
-                    {&otMleCounters::mDisabledTime, "Time Disabled"}, {&otMleCounters::mDetachedTime, "Time Detached"},
-                    {&otMleCounters::mChildTime, "Time Child"},       {&otMleCounters::mRouterTime, "Time Router"},
-                    {&otMleCounters::mLeaderTime, "Time Leader"},
+                    {&otMleCounters::mDisabledTime, "Disabled"}, {&otMleCounters::mDetachedTime, "Detached"},
+                    {&otMleCounters::mChildTime, "Child"},       {&otMleCounters::mRouterTime, "Router"},
+                    {&otMleCounters::mLeaderTime, "Leader"},
                 };
 
                 for (const MleTimeCounterName &counter : kTimeCounterNames)
                 {
-                    OutputLine("%s Milli: %lu", counter.mName, mleCounters->*counter.mValuePtr);
+                    OutputLine("Time %s Milli: %lu", counter.mName, mleCounters->*counter.mValuePtr);
                 }
                 OutputLine("Time Tracked Milli: %lu", mleCounters->mTrackedTime);
             }

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2636,25 +2636,25 @@ template <> otError Interpreter::Process<Cmd("counters")>(Arg aArgs[])
                 OutputLine("%s: %d", counter.mName, mleCounters->*counter.mValuePtr);
             }
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
-            struct MleTimeCounterName
             {
-                const uint64_t otMleCounters::*mValuePtr;
-                const char *                   mName;
-            };
+                struct MleTimeCounterName
+                {
+                    const uint64_t otMleCounters::*mValuePtr;
+                    const char *                   mName;
+                };
 
-            static const MleTimeCounterName kTimeCounterNames[] = {
-                {&otMleCounters::mDisabledTime, "Time Disabled"}, {&otMleCounters::mDetachedTime, "Time Detached"},
-                {&otMleCounters::mChildTime, "Time Child"},       {&otMleCounters::mRouterTime, "Time Router"},
-                {&otMleCounters::mLeaderTime, "Time Leader"},
-            };
+                static const MleTimeCounterName kTimeCounterNames[] = {
+                    {&otMleCounters::mDisabledTime, "Time Disabled"}, {&otMleCounters::mDetachedTime, "Time Detached"},
+                    {&otMleCounters::mChildTime, "Time Child"},       {&otMleCounters::mRouterTime, "Time Router"},
+                    {&otMleCounters::mLeaderTime, "Time Leader"},
+                };
 
-            const uint64_t trackedTime = mleCounters->mTrackedTime;
-            for (const MleTimeCounterName &counter : kTimeCounterNames)
-            {
-                uint64_t time = mleCounters->*counter.mValuePtr;
-                OutputLine("%s Milli: %lu", counter.mName, time);
+                for (const MleTimeCounterName &counter : kTimeCounterNames)
+                {
+                    OutputLine("%s Milli: %lu", counter.mName, mleCounters->*counter.mValuePtr);
+                }
+                OutputLine("Time Tracked Milli: %lu", mleCounters->mTrackedTime);
             }
-            OutputLine("Time Tracked Milli: %lu", trackedTime);
 #endif
         }
         /**

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -2635,6 +2635,27 @@ template <> otError Interpreter::Process<Cmd("counters")>(Arg aArgs[])
             {
                 OutputLine("%s: %d", counter.mName, mleCounters->*counter.mValuePtr);
             }
+#if OPENTHREAD_CONFIG_UPTIME_ENABLE
+            struct MleTimeCounterName
+            {
+                const uint64_t otMleCounters::*mValuePtr;
+                const char *                   mName;
+            };
+
+            static const MleTimeCounterName kTimeCounterNames[] = {
+                {&otMleCounters::mDisabledTime, "Time Disabled"}, {&otMleCounters::mDetachedTime, "Time Detached"},
+                {&otMleCounters::mChildTime, "Time Child"},       {&otMleCounters::mRouterTime, "Time Router"},
+                {&otMleCounters::mLeaderTime, "Time Leader"},
+            };
+
+            const uint64_t trackedTime = mleCounters->mTrackedTime;
+            for (const MleTimeCounterName &counter : kTimeCounterNames)
+            {
+                uint64_t time = mleCounters->*counter.mValuePtr;
+                OutputLine("%s Milli: %lu", counter.mName, time);
+            }
+            OutputLine("Time Tracked Milli: %lu", trackedTime);
+#endif
         }
         /**
          * @cli counters mle reset

--- a/src/core/thread/mle.cpp
+++ b/src/core/thread/mle.cpp
@@ -265,11 +265,12 @@ exit:
 }
 
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
-void Mle::UpdateTimeCounter(DeviceRole aRole)
+void Mle::UpdateRoleTimeCounters(DeviceRole aRole)
 {
     uint64_t currentUptimeMsec = Get<Uptime>().GetUptime();
     uint64_t durationMsec      = currentUptimeMsec - mLastUpdatedTimestamp;
-    mLastUpdatedTimestamp      = currentUptimeMsec;
+
+    mLastUpdatedTimestamp = currentUptimeMsec;
 
     mCounters.mTrackedTime += durationMsec;
 
@@ -303,7 +304,7 @@ void Mle::SetRole(DeviceRole aRole)
     LogNote("Role %s -> %s", RoleToString(oldRole), RoleToString(mRole));
 
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
-    UpdateTimeCounter(oldRole);
+    UpdateRoleTimeCounters(oldRole);
 #endif
 
     switch (mRole)

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -601,7 +601,7 @@ public:
     const otMleCounters &GetCounters(void)
     {
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
-        UpdateTimeCounter(mRole);
+        UpdateRoleTimeCounters(mRole);
 #endif
         return mCounters;
     }
@@ -1989,6 +1989,10 @@ private:
     static const char *MessageTypeActionToSuffixString(MessageType aType, MessageAction aAction);
 #endif
 
+#if OPENTHREAD_CONFIG_UPTIME_ENABLE
+    void UpdateRoleTimeCounters(DeviceRole aRole);
+#endif
+
     using DetachGracefullyTimer = TimerMilliIn<Mle, &Mle::HandleDetachGracefullyTimer>;
 
     MessageQueue mDelayedResponses;
@@ -2031,7 +2035,6 @@ private:
 
     otMleCounters mCounters;
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
-    void     UpdateTimeCounter(DeviceRole aRole);
     uint64_t mLastUpdatedTimestamp;
 #endif
     static const otMeshLocalPrefix sMeshLocalPrefixInit;

--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -598,7 +598,13 @@ public:
      * @returns A reference to the MLE counters.
      *
      */
-    const otMleCounters &GetCounters(void) const { return mCounters; }
+    const otMleCounters &GetCounters(void)
+    {
+#if OPENTHREAD_CONFIG_UPTIME_ENABLE
+        UpdateTimeCounter(mRole);
+#endif
+        return mCounters;
+    }
 
     /**
      * This method resets the MLE counters.
@@ -2024,7 +2030,10 @@ private:
 #endif
 
     otMleCounters mCounters;
-
+#if OPENTHREAD_CONFIG_UPTIME_ENABLE
+    void     UpdateTimeCounter(DeviceRole aRole);
+    uint64_t mLastUpdatedTimestamp;
+#endif
     static const otMeshLocalPrefix sMeshLocalPrefixInit;
 
     Ip6::Netif::UnicastAddress   mLinkLocal64;

--- a/tools/otci/tests/test_otci.py
+++ b/tools/otci/tests/test_otci.py
@@ -243,7 +243,7 @@ class TestOTCI(unittest.TestCase):
         for counter_name in leader.counter_names:
             logging.info('counter %s: %r', counter_name, leader.get_counter(counter_name))
             leader.reset_counter(counter_name)
-            self.assertTrue(all(x == 0 for x in leader.get_counter(counter_name).values()))
+            self.assertTrue(all(x == 0 for name, x in leader.get_counter(counter_name).items() if "Time" not in name))
 
         logging.info("CSL config: %r", leader.get_csl_config())
         leader.config_csl(channel=13, period=100, timeout=200)


### PR DESCRIPTION
A useful metric for a device is the amount of time it spends in each mle role. This could help to identify connectivity issues on SED with weak signal and frequent detaches by checking the time spent in detached mode. It would also be useful to know the time spent in leader state when having multiple FTDs frequently joining and splitting in different partitions.

This information is not available from the role counters, since time spent in each state is not related to the number of entries to that state.

This commit adds mle counters to track time spent in each role, when uptime feature is enabled (`OPENTHREAD_CONFIG_UPTIME_ENABLE=1`).

Some notes:

- With this changes `Mle::GetCounters` is no longer const since time counters must be updated.
- Time will not be all zero after resetting the counters, so Otci test must not check them.
- These counters could have been added in a separate function `Mle::GetTimeCounters` and a different cli command such as `counters mle time`. Is this alternative prefered?