### PR TITLE
[routing-manager] new mechanism for deprecating old on-link prefixes

### DIFF
--- a/src/core/config/border_routing.h
+++ b/src/core/config/border_routing.h
@@ -68,7 +68,7 @@
 /**
  * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_ON_MESH_PREFIXES
  *
- * Specified maximum number of on-mesh prefixes (discovered from Thread Network Data) that are included as Route Info
+ * Specifies maximum number of on-mesh prefixes (discovered from Thread Network Data) that are included as Route Info
  * Option in emitted Router Advertisement messages.
  *
  */
@@ -76,4 +76,13 @@
 #define OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_ON_MESH_PREFIXES 16
 #endif
 
+/**
+ * @def OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_OLD_ON_LINK_PREFIXES
+ *
+ * Specifies maximum number of old local on-link prefixes (being deprecated) maintained by routing manager.
+ *
+ */
+#ifndef OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_OLD_ON_LINK_PREFIXES
+#define OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_OLD_ON_LINK_PREFIXES 3
+#endif
 #endif // CONFIG_BORDER_ROUTING_H_


### PR DESCRIPTION
This commit updates how `OnLinkPrefixManager` retains and deprecates old local on-link prefixes. Instead of remembering a single old prefix, a list of old prefixes are remembered (number of entries in the list is configurable using an OT build-time config).

If the BR is stopped the deprecating prefixes are still remembered and the the expire timer keeps running. They are removed from the list when they expire. If the BR is started again the deprecating old prefixes are again included as PIO in the emitted RA and also published in Network Data.

The changes in this commit also ensure we can correctly handle the situation where the extended PAN ID is changed to a previous value before the corresponding on-link prefix expires, i.e. when a currently deprecating prefix becomes the current local on-link prefix again.

This commit also updates the unit test case validating the behavior of newly added mechanism under different situations.