### PR TITLE
[util] remove default RTT include dir

### DIFF
--- a/examples/platforms/utils/logging_rtt.c
+++ b/examples/platforms/utils/logging_rtt.c
@@ -39,7 +39,11 @@
 #include <openthread/platform/alarm-milli.h>
 #include <openthread/platform/logging.h>
 
+#ifdef SEGGER_RTT_CONFIG_FILE
+#include SEGGER_RTT_CONFIG_FILE
+#else
 #include "SEGGER_RTT.h"
+#endif
 #include "logging_rtt.h"
 
 #if (OPENTHREAD_CONFIG_LOG_OUTPUT == OPENTHREAD_CONFIG_LOG_OUTPUT_PLATFORM_DEFINED)


### PR DESCRIPTION
For users with their own RTT libs/configs, this change allows users to include their own RTT config header.