### PR TITLE
[mac] Bugfix: Messages without a source address handled incorrectly

### DIFF
--- a/src/core/mac/mac.cpp
+++ b/src/core/mac/mac.cpp
@@ -1740,7 +1740,7 @@ void Mac::HandleReceivedFrame(RxFrame *aFrame, Error aError)
 
     IgnoreError(aFrame->GetSrcAddr(srcaddr));
     IgnoreError(aFrame->GetDstAddr(dstaddr));
-    neighbor = Get<NeighborTable>().FindNeighbor(srcaddr);
+    neighbor = !srcaddr.IsNone() ? Get<NeighborTable>().FindNeighbor(srcaddr) : nullptr;
 
     // Destination Address Filtering
     switch (dstaddr.GetType())


### PR DESCRIPTION
When a message is received that does not contain a source address (ex: IEEE 802.15.4 Beacon Request) find neighbor should not be called to attribute the message to a particular device in the network.

The bug was found in the following scenario:
* Network operating with REED devices.
* Other non-Thread IOT devices in the space periodically sending beacon requests.
* Note that the REED devices have unexpectedly low average RSSI values for their parents.

When the child processes the beacon request, it calls FindNeighbor(), which defaults to returning the parent of the device if srcaddr is none. The RSSI of the beacon request is then averaged into the value for the device's parent.

Fix: Do not look up the neighbor if there is no source address in the message, because there's no way to know who the message came from.