### PR TITLE
[test] increase wait time after `ether` re-enable

### DIFF
--- a/tests/scripts/thread-cert/border_router/test_single_border_router.py
+++ b/tests/scripts/thread-cert/border_router/test_single_border_router.py
@@ -270,7 +270,7 @@ class SingleBorderRouter(thread_cert.TestCase):
 
         # The routing manager may fail to send RS and will wait for 4 seconds
         # before retrying.
-        self.simulator.go(20)
+        self.simulator.go(40)
         self.collect_ipaddrs()
 
         logging.info("BR     addrs: %r", br.get_addrs())
@@ -297,8 +297,8 @@ class SingleBorderRouter(thread_cert.TestCase):
         self.assertEqual(host.get_ip6_address(config.ADDRESS_TYPE.ONLINK_ULA), [host_ula_address])
 
         # Router1 can ping to/from the Host on infra link.
-        self.assertTrue(router.ping(host.get_ip6_address(config.ADDRESS_TYPE.ONLINK_ULA)[0]))
         self.assertTrue(host.ping(router.get_ip6_address(config.ADDRESS_TYPE.OMR)[0], backbone=True))
+        self.assertTrue(router.ping(host.get_ip6_address(config.ADDRESS_TYPE.ONLINK_ULA)[0]))
 
         #
         # Case 5. Test if the linux host is still reachable if rejoin the network.


### PR DESCRIPTION
This commit increases the wait time in `test_single_border_router` 
after re-enabling `ether` link. It also changes the order of pings in the
test (first ping from host to Thread router and the opposite direction).