### PR TITLE
[mac] add reserved value to source address parsing

### DIFF
--- a/src/core/mac/mac_frame.cpp
+++ b/src/core/mac/mac_frame.cpp
@@ -378,8 +378,13 @@ Error Frame::GetSrcAddr(Address &aAddress) const
         aAddress.SetExtended(&mPsdu[index], ExtAddress::kReverseByteOrder);
         break;
 
-    default:
+    case kFcfSrcAddrNone:
         aAddress.SetNone();
+        break;
+
+    default:
+        // reserved value
+        error = kErrorParse;
         break;
     }
 


### PR DESCRIPTION
Fails parsing of an IEEE 802.15.4 frame if the source addressing field is set to a reserved value.