### PR TITLE
[mle] log sending of "Link Accept and Request"

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -802,13 +802,15 @@ Error MleRouter::SendLinkAccept(const Ip6::MessageInfo &aMessageInfo,
         SuccessOrExit(error = message->SendAfterDelay(aMessageInfo.GetPeerAddr(),
                                                       1 + Random::NonCrypto::GetUint16InRange(0, kMaxResponseDelay)));
 
-        Log(kMessageDelay, kTypeLinkAccept, aMessageInfo.GetPeerAddr());
+        Log(kMessageDelay, (command == kCommandLinkAccept) ? kTypeLinkAccept : kTypeLinkAcceptAndRequest,
+            aMessageInfo.GetPeerAddr());
     }
     else
     {
         SuccessOrExit(error = message->SendTo(aMessageInfo.GetPeerAddr()));
 
-        Log(kMessageSend, kTypeLinkAccept, aMessageInfo.GetPeerAddr());
+        Log(kMessageSend, (command == kCommandLinkAccept) ? kTypeLinkAccept : kTypeLinkAcceptAndRequest,
+            aMessageInfo.GetPeerAddr());
     }
 
 exit:


### PR DESCRIPTION
This commit updates `SendLinkAccept()` method so to log the message 
type (whether we send "Link Accept and Request" or "Link Accept").