### PR TITLE
[routing-manager] persist deprecating old prefixes in `Settings`

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (255)
+#define OPENTHREAD_API_VERSION (256)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/settings.h
+++ b/include/openthread/platform/settings.h
@@ -72,6 +72,7 @@ enum
     OT_SETTINGS_KEY_SRP_CLIENT_INFO      = 0x000c, ///< The SRP client info (selected SRP server address).
     OT_SETTINGS_KEY_SRP_SERVER_INFO      = 0x000d, ///< The SRP server info (UDP port).
     OT_SETTINGS_KEY_BR_ULA_PREFIX        = 0x000f, ///< BR ULA prefix.
+    OT_SETTINGS_KEY_BR_ON_LINK_PREFIXES  = 0x0010, ///< BR local on-link prefixes.
 
     // Deprecated and reserved key values:
     //

--- a/src/core/border_router/routing_manager.hpp
+++ b/src/core/border_router/routing_manager.hpp
@@ -666,7 +666,7 @@ private:
         // Max number of old on-link prefixes to retain to deprecate.
         static constexpr uint16_t kMaxOldPrefixes = OPENTHREAD_CONFIG_BORDER_ROUTING_MAX_OLD_ON_LINK_PREFIXES;
 
-        void               GenerateLocalPrefix(void);
+        void               Init(void);
         void               Start(void);
         void               Stop(void);
         void               Evaluate(void);
@@ -697,6 +697,7 @@ private:
             TimeMilli   mExpireTime;
         };
 
+        void GenerateLocalPrefix(void);
         void PublishAndAdvertise(void);
         void Deprecate(void);
         void ResetExpireTime(TimeMilli aNow);
@@ -704,6 +705,7 @@ private:
         void AppendCurPrefix(Ip6::Nd::RouterAdvertMessage &aRaMessage);
         void AppendOldPrefixes(Ip6::Nd::RouterAdvertMessage &aRaMessage);
         void DeprecateOldPrefix(const Ip6::Prefix &aPrefix, TimeMilli aExpireTime);
+        void SavePrefix(const Ip6::Prefix &aPrefix, TimeMilli aExpireTime);
 
         using ExpireTimer = TimerMilliIn<RoutingManager, &RoutingManager::HandleOnLinkPrefixManagerTimer>;
 

--- a/src/core/common/settings.hpp
+++ b/src/core/common/settings.hpp
@@ -119,9 +119,11 @@ public:
         kKeySrpClientInfo     = OT_SETTINGS_KEY_SRP_CLIENT_INFO,
         kKeySrpServerInfo     = OT_SETTINGS_KEY_SRP_SERVER_INFO,
         kKeyBrUlaPrefix       = OT_SETTINGS_KEY_BR_ULA_PREFIX,
+        kKeyBrOnLinkPrefixes  = OT_SETTINGS_KEY_BR_ON_LINK_PREFIXES,
     };
 
-    static constexpr Key kLastKey = kKeyBrUlaPrefix; ///< The last (numerically) enumerator value in `Key`.
+    static constexpr Key kLastKey = kKeyBrOnLinkPrefixes; ///< The last (numerically) enumerator value in `Key`.
+
     static_assert(static_cast<uint16_t>(kLastKey) < static_cast<uint16_t>(OT_SETTINGS_KEY_VENDOR_RESERVED_MIN),
                   "Core settings keys overlap with vendor reserved keys");
 
@@ -583,7 +585,65 @@ public:
     private:
         BrUlaPrefix(void) = default;
     };
-#endif
+
+    /**
+     * This class represents a BR on-link prefix entry for settings storage.
+     *
+     */
+    OT_TOOL_PACKED_BEGIN
+    class BrOnLinkPrefix : public Clearable<BrOnLinkPrefix>
+    {
+        friend class Settings;
+
+    public:
+        static constexpr Key kKey = kKeyBrOnLinkPrefixes; ///< The associated key.
+
+        /**
+         * This method initializes the `BrOnLinkPrefix` object.
+         *
+         */
+        void Init(void) { Clear(); }
+
+        /**
+         * This method gets the prefix.
+         *
+         * @returns The prefix.
+         *
+         */
+        const Ip6::Prefix &GetPrefix(void) const { return mPrefix; }
+
+        /**
+         * This method set the prefix.
+         *
+         * @param[in] aPrefix   The prefix.
+         *
+         */
+        void SetPrefix(const Ip6::Prefix &aPrefix) { mPrefix = aPrefix; }
+
+        /**
+         * This method gets the remaining prefix lifetime in seconds.
+         *
+         * @returns The prefix lifetime in seconds.
+         *
+         */
+        uint32_t GetLifetime(void) const { return mLifetime; }
+
+        /**
+         * This method sets the the prefix lifetime.
+         *
+         * @param[in] aLifetime  The prefix lifetime in seconds.
+         *
+         */
+        void SetLifetime(uint32_t aLifetime) { mLifetime = aLifetime; }
+
+    private:
+        void Log(const char *aActionText) const;
+
+        Ip6::Prefix mPrefix;
+        uint32_t    mLifetime;
+    } OT_TOOL_PACKED_END;
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
     /**
@@ -1067,6 +1127,56 @@ public:
         bool      mIsDone;
     };
 #endif // OPENTHREAD_FTD
+
+#if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
+    /**
+     * This method adds or updates an on-link prefix.
+     *
+     * If there is no matching entry (matching the same `GetPrefix()`) saved in `Settings`, the new entry will be added.
+     * If there is matching entry, it will be updated to the new @p aPrefix.
+     *
+     * @param[in] aBrOnLinkPrefix    The on-link prefix to save (add or updated).
+     *
+     * @retval kErrorNone             Successfully added or updated the entry in settings.
+     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
+     *
+     */
+    Error AddOrUpdateBrOnLinkPrefix(const BrOnLinkPrefix &aBrOnLinkPrefix);
+
+    /**
+     * This method removes an on-link prefix entry matching a given prefix.
+     *
+     * @param[in] aPrefix            The prefix to remove
+     *
+     * @retval kErrorNone            Successfully removed the matching entry in settings.
+     * @retval kErrorNotImplemented  The platform does not implement settings functionality.
+     *
+     */
+    Error RemoveBrOnLinkPrefix(const Ip6::Prefix &aPrefix);
+
+    /**
+     * This method deletes all on-link prefix entries from the settings.
+     *
+     * @retval kErrorNone            Successfully deleted the entries.
+     * @retval kErrorNotImplemented  The platform does not implement settings functionality.
+     *
+     */
+    Error DeleteAllBrOnLinkPrefixes(void);
+
+    /**
+     * This method retrieves an entry from on-link prefixes list at a given index.
+     *
+     * @param[in]  aIndex            The index to read.
+     * @param[out] aBrOnLinkPrefix   A reference to `BrOnLinkPrefix` to output the read value.
+     *
+     * @retval kErrorNone             Successfully read the value.
+     * @retval kErrorNotFound         No corresponding value in the setting store.
+     * @retval kErrorNotImplemented   The platform does not implement settings functionality.
+     *
+     */
+    Error ReadBrOnLinkPrefix(int aIndex, BrOnLinkPrefix &aBrOnLinkPrefix);
+
+#endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 
 private:
 #if OPENTHREAD_FTD

--- a/tests/unit/test_platform.cpp
+++ b/tests/unit/test_platform.cpp
@@ -37,8 +37,6 @@ enum
     FLASH_SWAP_NUM  = 2,
 };
 
-static uint8_t sFlash[FLASH_SWAP_SIZE * FLASH_SWAP_NUM];
-
 ot::Instance *testInitInstance(void)
 {
     otInstance *instance = nullptr;
@@ -362,9 +360,22 @@ OT_TOOL_WEAK void otPlatSettingsWipe(otInstance *)
 {
 }
 
+uint8_t *GetFlash(void)
+{
+    static uint8_t sFlash[FLASH_SWAP_SIZE * FLASH_SWAP_NUM];
+    static bool    sInitialized;
+
+    if (!sInitialized)
+    {
+        memset(sFlash, 0xff, sizeof(sFlash));
+        sInitialized = true;
+    }
+
+    return sFlash;
+}
+
 OT_TOOL_WEAK void otPlatFlashInit(otInstance *)
 {
-    memset(sFlash, 0xff, sizeof(sFlash));
 }
 
 OT_TOOL_WEAK uint32_t otPlatFlashGetSwapSize(otInstance *)
@@ -380,7 +391,7 @@ OT_TOOL_WEAK void otPlatFlashErase(otInstance *, uint8_t aSwapIndex)
 
     address = aSwapIndex ? FLASH_SWAP_SIZE : 0;
 
-    memset(sFlash + address, 0xff, FLASH_SWAP_SIZE);
+    memset(GetFlash() + address, 0xff, FLASH_SWAP_SIZE);
 }
 
 OT_TOOL_WEAK void otPlatFlashRead(otInstance *, uint8_t aSwapIndex, uint32_t aOffset, void *aData, uint32_t aSize)
@@ -393,7 +404,7 @@ OT_TOOL_WEAK void otPlatFlashRead(otInstance *, uint8_t aSwapIndex, uint32_t aOf
 
     address = aSwapIndex ? FLASH_SWAP_SIZE : 0;
 
-    memcpy(aData, sFlash + address + aOffset, aSize);
+    memcpy(aData, GetFlash() + address + aOffset, aSize);
 }
 
 OT_TOOL_WEAK void otPlatFlashWrite(otInstance *,
@@ -412,7 +423,7 @@ OT_TOOL_WEAK void otPlatFlashWrite(otInstance *,
 
     for (uint32_t index = 0; index < aSize; index++)
     {
-        sFlash[address + aOffset + index] &= ((uint8_t *)aData)[index];
+        GetFlash()[address + aOffset + index] &= ((uint8_t *)aData)[index];
     }
 }
 


### PR DESCRIPTION
This commit adds mechanism to save deprecating old on-link prefixes
in non-volatile `Settings`. With this, if the BR is restarted, it
will remember the old prefixes and keep deprecating them (advertising
them in emitted RA and publish them in Thread Network Data).

This commit also adds `TestSavedOnLinkPrefixes()` test case in
`test_routing_manager` to cover the behavior of the newly added
mechanism.