### PR TITLE
[cli] enhance parsing of flags for `route` commands

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -5539,6 +5539,9 @@ otError Interpreter::ParsePrefix(Arg aArgs[], otBorderRouterConfig &aConfig)
                     aConfig.mDp = true;
                     break;
 #endif
+                case '-':
+                    break;
+
                 default:
                     ExitNow(error = OT_ERROR_INVALID_ARGS);
                 }
@@ -5767,21 +5770,31 @@ otError Interpreter::ParseRoute(Arg aArgs[], otExternalRouteConfig &aConfig)
     {
         otRoutePreference preference;
 
-        if (*aArgs == "s")
-        {
-            aConfig.mStable = true;
-        }
-        else if (*aArgs == "n")
-        {
-            aConfig.mNat64 = true;
-        }
-        else if (ParsePreference(*aArgs, preference) == OT_ERROR_NONE)
+        if (ParsePreference(*aArgs, preference) == OT_ERROR_NONE)
         {
             aConfig.mPreference = preference;
         }
         else
         {
-            ExitNow(error = OT_ERROR_INVALID_ARGS);
+            for (char *arg = aArgs->GetCString(); *arg != '\0'; arg++)
+            {
+                switch (*arg)
+                {
+                case 's':
+                    aConfig.mStable = true;
+                    break;
+
+                case 'n':
+                    aConfig.mNat64 = true;
+                    break;
+
+                case '-':
+                    break;
+
+                default:
+                    ExitNow(error = OT_ERROR_INVALID_ARGS);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
This commit enhances `ParseRoute()` method allowing flags to be specified in one arg (sequence of char indicating different flags) or potentially over different args. This commit also allows `-` to be used in `route` or `prefix` commands to indicate empty flag.

---

Existing code only allowed:
`netdata publish prefix fd00:1234::/64 n s med`

New code still allows the previous model but also 
`netdata publish prefix fd00:1234::/64 ns med`

Just FYI: @gabekassel  


