### PR TITLE
[cli] update CLI `Output` class

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -99,7 +99,8 @@ Interpreter *Interpreter::sInterpreter = nullptr;
 static OT_DEFINE_ALIGNED_VAR(sInterpreterRaw, sizeof(Interpreter), uint64_t);
 
 Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, void *aContext)
-    : Output(aInstance, aCallback, aContext)
+    : OutputImplementer(aCallback, aContext)
+    , Output(aInstance, *this)
     , mUserCommands(nullptr)
     , mUserCommandsLength(0)
     , mCommandIsPending(false)
@@ -108,32 +109,32 @@ Interpreter::Interpreter(Instance *aInstance, otCliOutputCallback aCallback, voi
 #if OPENTHREAD_CONFIG_SNTP_CLIENT_ENABLE
     , mSntpQueryingInProgress(false)
 #endif
-    , mDataset(*this)
-    , mNetworkData(*this)
-    , mUdp(*this)
+    , mDataset(aInstance, *this)
+    , mNetworkData(aInstance, *this)
+    , mUdp(aInstance, *this)
 #if OPENTHREAD_CONFIG_TCP_ENABLE && OPENTHREAD_CONFIG_CLI_TCP_ENABLE
-    , mTcp(*this)
+    , mTcp(aInstance, *this)
 #endif
 #if OPENTHREAD_CONFIG_COAP_API_ENABLE
-    , mCoap(*this)
+    , mCoap(aInstance, *this)
 #endif
 #if OPENTHREAD_CONFIG_COAP_SECURE_API_ENABLE
-    , mCoapSecure(*this)
+    , mCoapSecure(aInstance, *this)
 #endif
 #if OPENTHREAD_CONFIG_COMMISSIONER_ENABLE && OPENTHREAD_FTD
-    , mCommissioner(*this)
+    , mCommissioner(aInstance, *this)
 #endif
 #if OPENTHREAD_CONFIG_JOINER_ENABLE
-    , mJoiner(*this)
+    , mJoiner(aInstance, *this)
 #endif
 #if OPENTHREAD_CONFIG_SRP_CLIENT_ENABLE
-    , mSrpClient(*this)
+    , mSrpClient(aInstance, *this)
 #endif
 #if OPENTHREAD_CONFIG_SRP_SERVER_ENABLE
-    , mSrpServer(*this)
+    , mSrpServer(aInstance, *this)
 #endif
 #if OPENTHREAD_CONFIG_HISTORY_TRACKER_ENABLE
-    , mHistory(*this)
+    , mHistory(aInstance, *this)
 #endif
 #if OPENTHREAD_CONFIG_TMF_ANYCAST_LOCATOR_ENABLE
     , mLocateInProgress(false)

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -99,7 +99,7 @@ extern "C" void otCliOutputFormat(const char *aFmt, ...);
  * This class implements the CLI interpreter.
  *
  */
-class Interpreter : public Output
+class Interpreter : public OutputImplementer, public Output
 {
 #if OPENTHREAD_FTD || OPENTHREAD_MTD
     friend class Commissioner;

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -44,8 +44,8 @@
 namespace ot {
 namespace Cli {
 
-Coap::Coap(Output &aOutput)
-    : OutputWrapper(aOutput)
+Coap::Coap(otInstance *aInstance, OutputImplementer &aOutputImplementer)
+    : Output(aInstance, aOutputImplementer)
     , mUseDefaultRequestTxParameters(true)
     , mUseDefaultResponseTxParameters(true)
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE

--- a/src/cli/cli_coap.hpp
+++ b/src/cli/cli_coap.hpp
@@ -49,7 +49,7 @@ namespace Cli {
  * This class implements the CLI CoAP server and client.
  *
  */
-class Coap : private OutputWrapper
+class Coap : private Output
 {
 public:
     typedef Utils::CmdLineParser::Arg Arg;
@@ -57,10 +57,11 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aOutput The CLI console output context
+     * @param[in]  aInstance            The OpenThread Instance.
+     * @param[in]  aOutputImplementer   An `OutputImplementer`.
      *
      */
-    explicit Coap(Output &aOutput);
+    Coap(otInstance *aInstance, OutputImplementer &aOutputImplementer);
 
     /**
      * This method interprets a list of CLI arguments.

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -46,8 +46,8 @@
 namespace ot {
 namespace Cli {
 
-CoapSecure::CoapSecure(Output &aOutput)
-    : OutputWrapper(aOutput)
+CoapSecure::CoapSecure(otInstance *aInstance, OutputImplementer &aOutputImplementer)
+    : Output(aInstance, aOutputImplementer)
     , mShutdownFlag(false)
     , mUseCertificate(false)
     , mPskLength(0)

--- a/src/cli/cli_coap_secure.hpp
+++ b/src/cli/cli_coap_secure.hpp
@@ -55,7 +55,7 @@ namespace Cli {
  * This class implements the CLI CoAP Secure server and client.
  *
  */
-class CoapSecure : private OutputWrapper
+class CoapSecure : private Output
 {
 public:
     typedef Utils::CmdLineParser::Arg Arg;
@@ -63,10 +63,11 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aOutput The CLI console output context
+     * @param[in]  aInstance            The OpenThread Instance.
+     * @param[in]  aOutputImplementer   An `OutputImplementer`.
      *
      */
-    explicit CoapSecure(Output &aOutput);
+    CoapSecure(otInstance *aInstance, OutputImplementer &aOutputImplementer);
 
     /**
      * This method interprets a list of CLI arguments.

--- a/src/cli/cli_commissioner.hpp
+++ b/src/cli/cli_commissioner.hpp
@@ -49,7 +49,7 @@ namespace Cli {
  * This class implements the Commissioner CLI interpreter.
  *
  */
-class Commissioner : private OutputWrapper
+class Commissioner : private Output
 {
 public:
     typedef Utils::CmdLineParser::Arg Arg;
@@ -57,11 +57,12 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aOutput The CLI console output context
+     * @param[in]  aInstance            The OpenThread Instance.
+     * @param[in]  aOutputImplementer   An `OutputImplementer`.
      *
      */
-    explicit Commissioner(Output &aOutput)
-        : OutputWrapper(aOutput)
+    Commissioner(otInstance *aInstance, OutputImplementer &aOutputImplementer)
+        : Output(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_dataset.hpp
+++ b/src/cli/cli_dataset.hpp
@@ -49,13 +49,13 @@ namespace Cli {
  * This class implements the Dataset CLI interpreter.
  *
  */
-class Dataset : private OutputWrapper
+class Dataset : private Output
 {
 public:
     typedef Utils::CmdLineParser::Arg Arg;
 
-    explicit Dataset(Output &aOutput)
-        : OutputWrapper(aOutput)
+    Dataset(otInstance *aInstance, OutputImplementer &aOutputImplementer)
+        : Output(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_history.hpp
+++ b/src/cli/cli_history.hpp
@@ -50,7 +50,7 @@ namespace Cli {
  * This class implements the History Tracker CLI interpreter.
  *
  */
-class History : private OutputWrapper
+class History : private Output
 {
 public:
     typedef Utils::CmdLineParser::Arg Arg;
@@ -58,11 +58,12 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aOutput The CLI console output context
+     * @param[in]  aInstance            The OpenThread Instance.
+     * @param[in]  aOutputImplementer   An `OutputImplementer`.
      *
      */
-    explicit History(Output &aOutput)
-        : OutputWrapper(aOutput)
+    History(otInstance *aInstance, OutputImplementer &aOutputImplementer)
+        : Output(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_joiner.hpp
+++ b/src/cli/cli_joiner.hpp
@@ -49,7 +49,7 @@ namespace Cli {
  * This class implements the Joiner CLI interpreter.
  *
  */
-class Joiner : private OutputWrapper
+class Joiner : private Output
 {
 public:
     typedef Utils::CmdLineParser::Arg Arg;
@@ -57,11 +57,12 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aOutput The CLI console output context
+     * @param[in]  aInstance            The OpenThread Instance.
+     * @param[in]  aOutputImplementer   An `OutputImplementer`.
      *
      */
-    explicit Joiner(Output &aOutput)
-        : OutputWrapper(aOutput)
+    Joiner(otInstance *aInstance, OutputImplementer &aOutputImplementer)
+        : Output(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_network_data.hpp
+++ b/src/cli/cli_network_data.hpp
@@ -47,7 +47,7 @@ namespace Cli {
  * This class implements the Network Data CLI.
  *
  */
-class NetworkData : private OutputWrapper
+class NetworkData : private Output
 {
 public:
     typedef Utils::CmdLineParser::Arg Arg;
@@ -67,11 +67,12 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aOutput The CLI console output context
+     * @param[in]  aInstance            The OpenThread Instance.
+     * @param[in]  aOutputImplementer   An `OutputImplementer`.
      *
      */
-    explicit NetworkData(Output &aOutput)
-        : OutputWrapper(aOutput)
+    NetworkData(otInstance *aInstance, OutputImplementer &aOutputImplementer)
+        : Output(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_output.cpp
+++ b/src/cli/cli_output.cpp
@@ -42,16 +42,16 @@
 #endif
 #include <openthread/logging.h>
 
+#include "cli/cli.hpp"
 #include "common/string.hpp"
 
 namespace ot {
 namespace Cli {
 
-const char OutputBase::kUnknownString[] = "unknown";
+const char Output::kUnknownString[] = "unknown";
 
-Output::Output(otInstance *aInstance, otCliOutputCallback aCallback, void *aCallbackContext)
-    : mInstance(aInstance)
-    , mCallback(aCallback)
+OutputImplementer::OutputImplementer(otCliOutputCallback aCallback, void *aCallbackContext)
+    : mCallback(aCallback)
     , mCallbackContext(aCallbackContext)
 #if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
     , mOutputLength(0)
@@ -238,6 +238,11 @@ void Output::OutputDnsTxtData(const uint8_t *aTxtData, uint16_t aTxtDataLength)
 #endif // OPENTHREAD_FTD || OPENTHREAD_MTD
 
 void Output::OutputFormatV(const char *aFormat, va_list aArguments)
+{
+    mImplementer.OutputV(aFormat, aArguments);
+}
+
+void OutputImplementer::OutputV(const char *aFormat, va_list aArguments)
 {
 #if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
     va_list args;

--- a/src/cli/cli_output.hpp
+++ b/src/cli/cli_output.hpp
@@ -68,11 +68,51 @@ constexpr static CommandId Cmd(const char *aString)
     return (aString[0] == '\0') ? 0 : (static_cast<uint8_t>(aString[0]) + Cmd(aString + 1) * 255u);
 }
 
+class Output;
+
 /**
- * This class is the base class for `Output` and `OutputWrapper` providing common helper methods.
+ * This class implements the basic output functions.
  *
  */
-class OutputBase
+class OutputImplementer
+{
+    friend class Output;
+
+public:
+    /**
+     * This constructor initializes the `OutputImplementer` object.
+     *
+     * @param[in] aCallback           A pointer to an `otCliOutputCallback` to deliver strings to the CLI console.
+     * @param[in] aCallbackContext    An arbitrary context to pass in when invoking @p aCallback.
+     *
+     */
+    OutputImplementer(otCliOutputCallback aCallback, void *aCallbackContext);
+
+#if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
+    void SetEmittingCommandOutput(bool aEmittingOutput) { mEmittingCommandOutput = aEmittingOutput; }
+#else
+    void SetEmittingCommandOutput(bool) {}
+#endif
+
+private:
+    static constexpr uint16_t kInputOutputLogStringSize = OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_LOG_STRING_SIZE;
+
+    void OutputV(const char *aFormat, va_list aArguments);
+
+    otCliOutputCallback mCallback;
+    void *              mCallbackContext;
+#if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
+    char     mOutputString[kInputOutputLogStringSize];
+    uint16_t mOutputLength;
+    bool     mEmittingCommandOutput;
+#endif
+};
+
+/**
+ * This class provides CLI output helper methods.
+ *
+ */
+class Output
 {
 public:
     typedef Utils::CmdLineParser::Arg Arg; ///< An argument
@@ -141,26 +181,18 @@ public:
         return (static_cast<uint16_t>(aEnum) < kLength) ? aTable[static_cast<uint16_t>(aEnum)] : aNotFound;
     }
 
-protected:
-    OutputBase(void) = default;
-};
-
-/**
- * This class provides CLI output helper methods.
- *
- */
-class Output : public OutputBase
-{
-public:
     /**
      * This constructor initializes the `Output` object.
      *
      * @param[in] aInstance           A pointer to OpenThread instance.
-     * @param[in] aCallback           A pointer to an `otCliOutputCallback` to deliver strings to the CLI console.
-     * @param[in] aCallbackContext    An arbitrary context to pass in when invoking @p aCallback.
+     * @param[in] aImplementer        An `OutputImplementer`.
      *
      */
-    Output(otInstance *aInstance, otCliOutputCallback aCallback, void *aCallbackContext);
+    Output(otInstance *aInstance, OutputImplementer &aImplementer)
+        : mInstance(aInstance)
+        , mImplementer(aImplementer)
+    {
+    }
 
     /**
      * This method returns the pointer to OpenThread instance.
@@ -429,10 +461,8 @@ protected:
 
 #if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
     void LogInput(const Arg *aArgs);
-    void SetEmittingCommandOutput(bool aEmittingOutput) { mEmittingCommandOutput = aEmittingOutput; }
 #else
     void LogInput(const Arg *) {}
-    void SetEmittingCommandOutput(bool) {}
 #endif
 
 private:
@@ -441,96 +471,8 @@ private:
     void OutputTableHeader(uint8_t aNumColumns, const char *const aTitles[], const uint8_t aWidths[]);
     void OutputTableSeparator(uint8_t aNumColumns, const uint8_t aWidths[]);
 
-    otInstance *        mInstance;
-    otCliOutputCallback mCallback;
-    void *              mCallbackContext;
-#if OPENTHREAD_CONFIG_CLI_LOG_INPUT_OUTPUT_ENABLE
-    char     mOutputString[kInputOutputLogStringSize];
-    uint16_t mOutputLength;
-    bool     mEmittingCommandOutput;
-#endif
-};
-
-class OutputWrapper : public OutputBase
-{
-protected:
-    explicit OutputWrapper(Output &aOutput)
-        : mOutput(aOutput)
-    {
-    }
-
-    otInstance *GetInstancePtr(void) { return mOutput.GetInstancePtr(); }
-
-    template <typename... Args> void OutputFormat(const char *aFormat, Args... aArgs)
-    {
-        mOutput.OutputFormat(aFormat, aArgs...);
-    }
-
-    template <typename... Args> void OutputFormat(uint8_t aIndentSize, const char *aFormat, Args... aArgs)
-    {
-        mOutput.OutputFormat(aIndentSize, aFormat, aArgs...);
-    }
-
-    template <typename... Args> void OutputLine(const char *aFormat, Args... aArgs)
-    {
-        return mOutput.OutputLine(aFormat, aArgs...);
-    }
-
-    template <typename... Args> void OutputLine(uint8_t aIndentSize, const char *aFormat, Args... aArgs)
-    {
-        return mOutput.OutputLine(aIndentSize, aFormat, aArgs...);
-    }
-
-    template <uint8_t kBytesLength> void OutputBytes(const uint8_t (&aBytes)[kBytesLength])
-    {
-        mOutput.OutputBytes(aBytes, kBytesLength);
-    }
-
-    template <uint8_t kBytesLength> void OutputBytesLine(const uint8_t (&aBytes)[kBytesLength])
-    {
-        mOutput.OutputBytesLine(aBytes, kBytesLength);
-    }
-
-    void OutputSpaces(uint8_t aCount) { return mOutput.OutputSpaces(aCount); }
-    void OutputBytes(const uint8_t *aBytes, uint16_t aLength) { return mOutput.OutputBytes(aBytes, aLength); }
-    void OutputBytesLine(const uint8_t *aBytes, uint16_t aLength) { return mOutput.OutputBytesLine(aBytes, aLength); }
-    void OutputExtAddress(const otExtAddress &aExtAddress) { mOutput.OutputExtAddress(aExtAddress); }
-    void OutputExtAddressLine(const otExtAddress &aExtAddress) { mOutput.OutputExtAddressLine(aExtAddress); }
-    void OutputEnabledDisabledStatus(bool aEnabled) { mOutput.OutputEnabledDisabledStatus(aEnabled); }
-
-#if OPENTHREAD_FTD || OPENTHREAD_MTD
-    void OutputIp6Address(const otIp6Address &aAddress) { mOutput.OutputIp6Address(aAddress); }
-    void OutputIp6AddressLine(const otIp6Address &aAddress) { mOutput.OutputIp6AddressLine(aAddress); }
-    void OutputIp6Prefix(const otIp6Prefix &aPrefix) { mOutput.OutputIp6Prefix(aPrefix); }
-    void OutputIp6PrefixLine(const otIp6Prefix &aPrefix) { mOutput.OutputIp6PrefixLine(aPrefix); }
-    void OutputIp6Prefix(const otIp6NetworkPrefix &aPrefix) { mOutput.OutputIp6Prefix(aPrefix); }
-    void OutputIp6PrefixLine(const otIp6NetworkPrefix &aPrefix) { mOutput.OutputIp6PrefixLine(aPrefix); }
-    void OutputSockAddr(const otSockAddr &aSockAddr) { mOutput.OutputSockAddr(aSockAddr); }
-    void OutputSockAddrLine(const otSockAddr &aSockAddr) { mOutput.OutputSockAddrLine(aSockAddr); }
-    void OutputDnsTxtData(const uint8_t *aTxtData, uint16_t aTxtDataLength)
-    {
-        mOutput.OutputDnsTxtData(aTxtData, aTxtDataLength);
-    }
-#endif
-
-    template <uint8_t kTableNumColumns>
-    void OutputTableHeader(const char *const (&aTitles)[kTableNumColumns], const uint8_t (&aWidths)[kTableNumColumns])
-    {
-        mOutput.OutputTableHeader(aTitles, aWidths);
-    }
-
-    template <uint8_t kTableNumColumns> void OutputTableSeparator(const uint8_t (&aWidths)[kTableNumColumns])
-    {
-        mOutput.OutputTableSeparator(aWidths);
-    }
-
-    template <typename Cli, uint16_t kLength> void OutputCommandTable(const CommandEntry<Cli> (&aCommandTable)[kLength])
-    {
-        mOutput.OutputCommandTable(aCommandTable);
-    }
-
-private:
-    Output &mOutput;
+    otInstance *       mInstance;
+    OutputImplementer &mImplementer;
 };
 
 } // namespace Cli

--- a/src/cli/cli_srp_client.cpp
+++ b/src/cli/cli_srp_client.cpp
@@ -57,8 +57,8 @@ exit:
     return error;
 }
 
-SrpClient::SrpClient(Output &aOutput)
-    : OutputWrapper(aOutput)
+SrpClient::SrpClient(otInstance *aInstance, OutputImplementer &aOutputImplementer)
+    : Output(aInstance, aOutputImplementer)
     , mCallbackEnabled(false)
 {
     otSrpClientSetCallback(GetInstancePtr(), SrpClient::HandleCallback, this);

--- a/src/cli/cli_srp_client.hpp
+++ b/src/cli/cli_srp_client.hpp
@@ -51,7 +51,7 @@ namespace Cli {
  * This class implements the SRP Client CLI interpreter.
  *
  */
-class SrpClient : private OutputWrapper
+class SrpClient : private Output
 {
 public:
     typedef Utils::CmdLineParser::Arg Arg;
@@ -59,10 +59,11 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aOutput  The CLI console output context.
+     * @param[in]  aInstance            The OpenThread Instance.
+     * @param[in]  aOutputImplementer   An `OutputImplementer`.
      *
      */
-    explicit SrpClient(Output &aOutput);
+    SrpClient(otInstance *aInstance, OutputImplementer &aOutputImplementer);
 
     /**
      * This method interprets a list of CLI arguments.

--- a/src/cli/cli_srp_server.hpp
+++ b/src/cli/cli_srp_server.hpp
@@ -49,7 +49,7 @@ namespace Cli {
  * This class implements the SRP Server CLI interpreter.
  *
  */
-class SrpServer : private OutputWrapper
+class SrpServer : private Output
 {
 public:
     typedef Utils::CmdLineParser::Arg Arg;
@@ -57,11 +57,12 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aOutput  The CLI console output context.
+     * @param[in]  aInstance            The OpenThread Instance.
+     * @param[in]  aOutputImplementer   An `OutputImplementer`.
      *
      */
-    explicit SrpServer(Output &aOutput)
-        : OutputWrapper(aOutput)
+    SrpServer(otInstance *aInstance, OutputImplementer &aOutputImplementer)
+        : Output(aInstance, aOutputImplementer)
     {
     }
 

--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -49,8 +49,8 @@
 namespace ot {
 namespace Cli {
 
-TcpExample::TcpExample(Output &aOutput)
-    : OutputWrapper(aOutput)
+TcpExample::TcpExample(otInstance *aInstance, OutputImplementer &aOutputImplementer)
+    : Output(aInstance, aOutputImplementer)
     , mInitialized(false)
     , mEndpointConnected(false)
     , mSendBusy(false)

--- a/src/cli/cli_tcp.hpp
+++ b/src/cli/cli_tcp.hpp
@@ -50,7 +50,7 @@ namespace Cli {
  * This class implements a CLI-based TCP example.
  *
  */
-class TcpExample : private OutputWrapper
+class TcpExample : private Output
 {
 public:
     using Arg = Utils::CmdLineParser::Arg;
@@ -58,10 +58,11 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aOutput  The CLI console output context.
+     * @param[in]  aInstance            The OpenThread Instance.
+     * @param[in]  aOutputImplementer   An `OutputImplementer`.
      *
      */
-    explicit TcpExample(Output &aOutput);
+    TcpExample(otInstance *aInstance, OutputImplementer &aOutputImplementer);
 
     /**
      * This method interprets a list of CLI arguments.

--- a/src/cli/cli_udp.cpp
+++ b/src/cli/cli_udp.cpp
@@ -43,8 +43,8 @@
 namespace ot {
 namespace Cli {
 
-UdpExample::UdpExample(Output &aOutput)
-    : OutputWrapper(aOutput)
+UdpExample::UdpExample(otInstance *aInstance, OutputImplementer &aOutputImplementer)
+    : Output(aInstance, aOutputImplementer)
     , mLinkSecurityEnabled(true)
 {
     memset(&mSocket, 0, sizeof(mSocket));

--- a/src/cli/cli_udp.hpp
+++ b/src/cli/cli_udp.hpp
@@ -47,7 +47,7 @@ namespace Cli {
  * This class implements a CLI-based UDP example.
  *
  */
-class UdpExample : private OutputWrapper
+class UdpExample : private Output
 {
 public:
     typedef Utils::CmdLineParser::Arg Arg;
@@ -55,10 +55,11 @@ public:
     /**
      * Constructor
      *
-     * @param[in]  aOutput The CLI console output context.
+     * @param[in]  aInstance            The OpenThread Instance.
+     * @param[in]  aOutputImplementer   An `OutputImplementer`.
      *
      */
-    explicit UdpExample(Output &aOutput);
+    UdpExample(otInstance *aInstance, OutputImplementer &aOutputImplementer);
 
     /**
      * This method interprets a list of CLI arguments.


### PR DESCRIPTION
This commit updates the `Cli::Output` class and the related types. A new type `OutputImplementer` is added which provides the basic output functionality, i.e., method `OutputV()`. `Output` class requires a reference to an `OutputImplementer` which it then uses to provide all the different `Output{}()` method flavors. The new model allows all CLI sub-modules to directly inherit `Output` class while reusing a single and common underlying `OutputImplementer` provided by the `Cli::Interpreter`.

----

This PR is in preparation of adding `OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK` (build-time printf style arg check) to CLI `Output{}()` methods.
