### PR TITLE
[netif] fix bug in print statement with no corresponding argument

### DIFF
--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -852,7 +852,7 @@ static void UpdateExternalRoutes(otInstance *aInstance)
         else
         {
             sAddedExternalRoutes[sAddedExternalRoutesNum++] = config.mPrefix;
-            otLogWarnPlat("[netif] Successfully added an external route %s in kernel: %s", prefixString);
+            otLogWarnPlat("[netif] Successfully added an external route %s in kernel", prefixString);
         }
     }
 exit:


### PR DESCRIPTION
Because there is no corresponding argument, a crash occurs when outputting the log.