### PR TITLE
[log] add arg format check to `otLog{Level}Plat()` functions

### DIFF
--- a/examples/platforms/utils/soft_source_match_table.c
+++ b/examples/platforms/utils/soft_source_match_table.c
@@ -148,7 +148,7 @@ void otPlatRadioClearSrcMatchShortEntries(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    otLogDebgPlat("Clear ShortAddr entries", NULL);
+    otLogDebgPlat("Clear ShortAddr entries");
 
     memset(srcMatchShortEntry, 0, sizeof(srcMatchShortEntry));
 }
@@ -260,7 +260,7 @@ void otPlatRadioClearSrcMatchExtEntries(otInstance *aInstance)
 {
     OT_UNUSED_VARIABLE(aInstance);
 
-    otLogDebgPlat("Clear ExtAddr entries", NULL);
+    otLogDebgPlat("Clear ExtAddr entries");
 
     memset(srcMatchExtEntry, 0, sizeof(srcMatchExtEntry));
 }

--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (257)
+#define OPENTHREAD_API_VERSION (258)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/logging.h
+++ b/include/openthread/logging.h
@@ -86,7 +86,7 @@ otError otLoggingSetLevel(otLogLevel aLogLevel);
  * @param[in]  ...      Arguments for the format specification.
  *
  */
-void otLogCritPlat(const char *aFormat, ...);
+void otLogCritPlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
 
 /**
  * This function emits a log message at warning log level.
@@ -98,7 +98,7 @@ void otLogCritPlat(const char *aFormat, ...);
  * @param[in]  ...      Arguments for the format specification.
  *
  */
-void otLogWarnPlat(const char *aFormat, ...);
+void otLogWarnPlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
 
 /**
  * This function emits a log message at note log level.
@@ -110,7 +110,7 @@ void otLogWarnPlat(const char *aFormat, ...);
  * @param[in]  ...      Arguments for the format specification.
  *
  */
-void otLogNotePlat(const char *aFormat, ...);
+void otLogNotePlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
 
 /**
  * This function emits a log message at info log level.
@@ -122,7 +122,7 @@ void otLogNotePlat(const char *aFormat, ...);
  * @param[in]  ...      Arguments for the format specification.
  *
  */
-void otLogInfoPlat(const char *aFormat, ...);
+void otLogInfoPlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
 
 /**
  * This function emits a log message at debug log level.
@@ -134,7 +134,7 @@ void otLogInfoPlat(const char *aFormat, ...);
  * @param[in]  ...      Arguments for the format specification.
  *
  */
-void otLogDebgPlat(const char *aFormat, ...);
+void otLogDebgPlat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(1, 2);
 
 /**
  * This function generates a memory dump at critical log level.
@@ -212,7 +212,7 @@ void otDumpDebgPlat(const char *aText, const void *aData, uint16_t aDataLength);
  * @param[in]  ...       Arguments for the format specification.
  *
  */
-void otLogCli(otLogLevel aLogLevel, const char *aFormat, ...);
+void otLogCli(otLogLevel aLogLevel, const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 3);
 
 /**
  * @}

--- a/src/posix/platform/daemon.cpp
+++ b/src/posix/platform/daemon.cpp
@@ -145,7 +145,7 @@ exit:
     }
     else
     {
-        otLogInfoPlat("Session socket is ready", strerror(errno));
+        otLogInfoPlat("Session socket is ready");
     }
 }
 

--- a/src/posix/platform/netif.cpp
+++ b/src/posix/platform/netif.cpp
@@ -1008,7 +1008,7 @@ exit:
     {
         if (error == OT_ERROR_DROP)
         {
-            otLogInfoPlat("[netif] Message dropped by Thread", otThreadErrorToString(error));
+            otLogInfoPlat("[netif] Message dropped by Thread");
         }
         else
         {


### PR DESCRIPTION
---

This should help find issues like https://github.com/openthread/openthread/pull/8353 in future.
This may impact platform implemenations and require fixes.