### PR TITLE
[tlv] `ReadTlvValue()` to handle regular or extended TLVs

### DIFF
--- a/src/core/common/tlvs.cpp
+++ b/src/core/common/tlvs.cpp
@@ -194,14 +194,34 @@ template Error Tlv::ReadUintTlv<uint32_t>(const Message &aMessage, uint16_t aOff
 
 Error Tlv::ReadTlvValue(const Message &aMessage, uint16_t aOffset, void *aValue, uint8_t aMinLength)
 {
-    Error error = kErrorNone;
-    Tlv   tlv;
+    Error    error = kErrorNone;
+    Tlv      tlv;
+    uint16_t valueOffset;
+    uint16_t length;
+    uint32_t size;
 
     SuccessOrExit(error = aMessage.Read(aOffset, tlv));
-    VerifyOrExit(!tlv.IsExtended() && (tlv.GetLength() >= aMinLength), error = kErrorParse);
-    VerifyOrExit(tlv.GetSize() + aOffset <= aMessage.GetLength(), error = kErrorParse);
 
-    aMessage.ReadBytes(aOffset + sizeof(Tlv), aValue, aMinLength);
+    if (!tlv.IsExtended())
+    {
+        valueOffset = aOffset + sizeof(Tlv);
+        length      = tlv.GetLength();
+        size        = sizeof(Tlv) + length;
+    }
+    else
+    {
+        ExtendedTlv extTlv;
+
+        SuccessOrExit(error = aMessage.Read(aOffset, extTlv));
+        valueOffset = aOffset + sizeof(ExtendedTlv);
+        length      = extTlv.GetLength();
+        size        = sizeof(ExtendedTlv) + length;
+    }
+
+    VerifyOrExit(length >= aMinLength, error = kErrorParse);
+    VerifyOrExit(aOffset + size <= aMessage.GetLength(), error = kErrorParse);
+
+    aMessage.ReadBytes(valueOffset, aValue, aMinLength);
 
 exit:
     return error;

--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -177,6 +177,8 @@ public:
     /**
      * This static method reads a TLV's value in a message at a given offset expecting a minimum length for the value.
      *
+     * This method can be used independent of whether the read TLV (from the message) is an Extended TLV or not.
+     *
      * @param[in]   aMessage    The message to read from.
      * @param[in]   aOffset     The offset into the message pointing to the start of the TLV.
      * @param[out]  aValue      A buffer to output the TLV's value, must contain (at least) @p aMinLength bytes.


### PR DESCRIPTION
This commit changes `ReadTlv()` methods so that they can be used independent of whether the read TLV is an Extended TLV or not. This makes them similar to `FindTlv()` methods.