### PR TITLE
[net-diag] simplify processing of TLVs, allow extended TLV

### DIFF
--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -188,11 +188,8 @@ exit:
 
 Error NetworkDiagnostic::AppendIp6AddressList(Message &aMessage)
 {
-    Error             error = kErrorNone;
-    Ip6AddressListTlv tlv;
-    uint8_t           count = 0;
-
-    tlv.Init();
+    Error    error = kErrorNone;
+    uint16_t count = 0;
 
     for (const Ip6::Netif::UnicastAddress &addr : Get<ThreadNetif>().GetUnicastAddresses())
     {
@@ -200,8 +197,22 @@ Error NetworkDiagnostic::AppendIp6AddressList(Message &aMessage)
         count++;
     }
 
-    tlv.SetLength(count * sizeof(Ip6::Address));
-    SuccessOrExit(error = aMessage.Append(tlv));
+    if (count * Ip6::Address::kSize <= Tlv::kBaseTlvMaxLength)
+    {
+        Tlv tlv;
+
+        tlv.SetType(NetworkDiagnosticTlv::kIp6AddressList);
+        tlv.SetLength(static_cast<uint8_t>(count * Ip6::Address::kSize));
+        SuccessOrExit(error = aMessage.Append(tlv));
+    }
+    else
+    {
+        ExtendedTlv extTlv;
+
+        extTlv.SetType(NetworkDiagnosticTlv::kIp6AddressList);
+        extTlv.SetLength(count * Ip6::Address::kSize);
+        SuccessOrExit(error = aMessage.Append(extTlv));
+    }
 
     for (const Ip6::Netif::UnicastAddress &addr : Get<ThreadNetif>().GetUnicastAddresses())
     {
@@ -209,50 +220,48 @@ Error NetworkDiagnostic::AppendIp6AddressList(Message &aMessage)
     }
 
 exit:
-
     return error;
 }
 
 #if OPENTHREAD_FTD
 Error NetworkDiagnostic::AppendChildTable(Message &aMessage)
 {
-    Error           error   = kErrorNone;
-    uint16_t        count   = 0;
-    uint8_t         timeout = 0;
-    ChildTableTlv   tlv;
-    ChildTableEntry entry;
+    Error    error = kErrorNone;
+    uint16_t count = 0;
 
-    tlv.Init();
+    count = Min(Get<ChildTable>().GetNumChildren(Child::kInStateValid), kMaxChildEntries);
 
-    count = Get<ChildTable>().GetNumChildren(Child::kInStateValid);
-
-    // The length of the Child Table TLV may exceed the outgoing link's MTU (1280B).
-    // As a workaround we limit the number of entries in the Child Table TLV,
-    // also to avoid using extended TLV format. The issue is processed by the
-    // Thread Group (SPEC-894).
-    if (count > (Tlv::kBaseTlvMaxLength / sizeof(ChildTableEntry)))
+    if (count * sizeof(ChildTableEntry) <= Tlv::kBaseTlvMaxLength)
     {
-        count = Tlv::kBaseTlvMaxLength / sizeof(ChildTableEntry);
+        Tlv tlv;
+
+        tlv.SetType(NetworkDiagnosticTlv::kChildTable);
+        tlv.SetLength(static_cast<uint8_t>(count * sizeof(ChildTableEntry)));
+        SuccessOrExit(error = aMessage.Append(tlv));
     }
+    else
+    {
+        ExtendedTlv extTlv;
 
-    tlv.SetLength(static_cast<uint8_t>(count * sizeof(ChildTableEntry)));
-
-    SuccessOrExit(error = aMessage.Append(tlv));
+        extTlv.SetType(NetworkDiagnosticTlv::kChildTable);
+        extTlv.SetLength(count * sizeof(ChildTableEntry));
+        SuccessOrExit(error = aMessage.Append(extTlv));
+    }
 
     for (Child &child : Get<ChildTable>().Iterate(Child::kInStateValid))
     {
-        VerifyOrExit(count--);
+        uint8_t         timeout = 0;
+        ChildTableEntry entry;
 
-        timeout = 0;
+        VerifyOrExit(count--);
 
         while (static_cast<uint32_t>(1 << timeout) < child.GetTimeout())
         {
             timeout++;
         }
 
-        entry.SetReserved(0);
+        entry.Clear();
         entry.SetTimeout(timeout + 4);
-
         entry.SetChildId(Mle::ChildIdFromRloc16(child.GetRloc16()));
         entry.SetMode(child.GetDeviceMode());
 
@@ -260,7 +269,6 @@ Error NetworkDiagnostic::AppendChildTable(Message &aMessage)
     }
 
 exit:
-
     return error;
 }
 #endif // OPENTHREAD_FTD
@@ -296,8 +304,6 @@ Error NetworkDiagnostic::FillRequestedTlvs(const Message &       aRequest,
     for (uint32_t i = 0; i < aNetworkDiagnosticTlv.GetLength(); i++)
     {
         SuccessOrExit(error = aRequest.Read(offset, type));
-
-        LogInfo("Type %d", type);
 
         switch (type)
         {
@@ -362,10 +368,8 @@ Error NetworkDiagnostic::FillRequestedTlvs(const Message &       aRequest,
         }
 
         case NetworkDiagnosticTlv::kIp6AddressList:
-        {
             SuccessOrExit(error = AppendIp6AddressList(aResponse));
             break;
-        }
 
         case NetworkDiagnosticTlv::kMacCounters:
         {
@@ -619,36 +623,47 @@ static inline void ParseMacCounters(const MacCountersTlv &aMacCountersTlv, otNet
     aMacCounters.mIfOutDiscards      = aMacCountersTlv.GetIfOutDiscards();
 }
 
-static inline void ParseChildEntry(const ChildTableEntry &aChildTableTlvEntry, otNetworkDiagChildEntry &aChildEntry)
+Error NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator, TlvInfo &aTlvInfo)
 {
-    aChildEntry.mTimeout = aChildTableTlvEntry.GetTimeout();
-    aChildEntry.mChildId = aChildTableTlvEntry.GetChildId();
-    aChildTableTlvEntry.GetMode().Get(aChildEntry.mMode);
-}
+    Error    error  = kErrorNotFound;
+    uint16_t offset = (aIterator == 0) ? aMessage.GetOffset() : aIterator;
 
-Error NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
-                                        Iterator &           aIterator,
-                                        otNetworkDiagTlv &   aNetworkDiagTlv)
-{
-    Error                error  = kErrorNone;
-    uint16_t             offset = aMessage.GetOffset() + aIterator;
-    NetworkDiagnosticTlv tlv;
-
-    while (true)
+    while (offset < aMessage.GetLength())
     {
-        uint16_t tlvTotalLength;
+        bool     skipTlv = false;
+        uint16_t valueOffset;
+        uint16_t tlvLength;
+        union
+        {
+            Tlv         tlv;
+            ExtendedTlv extTlv;
+        };
 
-        VerifyOrExit(aMessage.Read(offset, tlv) == kErrorNone, error = kErrorNotFound);
+        SuccessOrExit(error = aMessage.Read(offset, tlv));
+
+        if (tlv.IsExtended())
+        {
+            SuccessOrExit(error = aMessage.Read(offset, extTlv));
+            valueOffset = offset + sizeof(ExtendedTlv);
+            tlvLength   = extTlv.GetLength();
+        }
+        else
+        {
+            valueOffset = offset + sizeof(Tlv);
+            tlvLength   = tlv.GetLength();
+        }
+
+        VerifyOrExit(offset + tlv.GetSize() <= aMessage.GetLength(), error = kErrorParse);
 
         switch (tlv.GetType())
         {
         case NetworkDiagnosticTlv::kExtMacAddress:
-            SuccessOrExit(
-                error = Tlv::Read<ExtMacAddressTlv>(aMessage, offset, AsCoreType(&aNetworkDiagTlv.mData.mExtAddress)));
+            SuccessOrExit(error =
+                              Tlv::Read<ExtMacAddressTlv>(aMessage, offset, AsCoreType(&aTlvInfo.mData.mExtAddress)));
             break;
 
         case NetworkDiagnosticTlv::kAddress16:
-            SuccessOrExit(error = Tlv::Read<Address16Tlv>(aMessage, offset, aNetworkDiagTlv.mData.mAddr16));
+            SuccessOrExit(error = Tlv::Read<Address16Tlv>(aMessage, offset, aTlvInfo.mData.mAddr16));
             break;
 
         case NetworkDiagnosticTlv::kMode:
@@ -656,137 +671,159 @@ Error NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage,
             uint8_t mode;
 
             SuccessOrExit(error = Tlv::Read<ModeTlv>(aMessage, offset, mode));
-            Mle::DeviceMode(mode).Get(aNetworkDiagTlv.mData.mMode);
+            Mle::DeviceMode(mode).Get(aTlvInfo.mData.mMode);
             break;
         }
 
         case NetworkDiagnosticTlv::kTimeout:
-            SuccessOrExit(error = Tlv::Read<TimeoutTlv>(aMessage, offset, aNetworkDiagTlv.mData.mTimeout));
+            SuccessOrExit(error = Tlv::Read<TimeoutTlv>(aMessage, offset, aTlvInfo.mData.mTimeout));
             break;
 
         case NetworkDiagnosticTlv::kConnectivity:
         {
-            ConnectivityTlv connectivity;
+            ConnectivityTlv connectivityTlv;
 
-            SuccessOrExit(error = aMessage.Read(offset, connectivity));
-            VerifyOrExit(connectivity.IsValid(), error = kErrorParse);
-            connectivity.GetConnectivity(aNetworkDiagTlv.mData.mConnectivity);
+            VerifyOrExit(!tlv.IsExtended(), error = kErrorParse);
+            SuccessOrExit(error = aMessage.Read(offset, connectivityTlv));
+            VerifyOrExit(connectivityTlv.IsValid(), error = kErrorParse);
+            connectivityTlv.GetConnectivity(aTlvInfo.mData.mConnectivity);
             break;
         }
 
         case NetworkDiagnosticTlv::kRoute:
         {
-            RouteTlv route;
+            RouteTlv routeTlv;
+            uint16_t bytesToRead = static_cast<uint16_t>(Min(tlv.GetSize(), static_cast<uint32_t>(sizeof(routeTlv))));
 
-            tlvTotalLength = sizeof(tlv) + tlv.GetLength();
-            VerifyOrExit(tlvTotalLength <= sizeof(route), error = kErrorParse);
-            SuccessOrExit(error = aMessage.Read(offset, &route, tlvTotalLength));
-            VerifyOrExit(route.IsValid(), error = kErrorParse);
-
-            ParseRoute(route, aNetworkDiagTlv.mData.mRoute);
+            VerifyOrExit(!tlv.IsExtended(), error = kErrorParse);
+            SuccessOrExit(error = aMessage.Read(offset, &routeTlv, bytesToRead));
+            VerifyOrExit(routeTlv.IsValid(), error = kErrorParse);
+            ParseRoute(routeTlv, aTlvInfo.mData.mRoute);
             break;
         }
 
         case NetworkDiagnosticTlv::kLeaderData:
         {
-            LeaderDataTlv leaderData;
+            LeaderDataTlv leaderDataTlv;
 
-            SuccessOrExit(error = aMessage.Read(offset, leaderData));
-            VerifyOrExit(leaderData.IsValid(), error = kErrorParse);
-            leaderData.Get(AsCoreType(&aNetworkDiagTlv.mData.mLeaderData));
+            VerifyOrExit(!tlv.IsExtended(), error = kErrorParse);
+            SuccessOrExit(error = aMessage.Read(offset, leaderDataTlv));
+            VerifyOrExit(leaderDataTlv.IsValid(), error = kErrorParse);
+            leaderDataTlv.Get(AsCoreType(&aTlvInfo.mData.mLeaderData));
             break;
         }
 
         case NetworkDiagnosticTlv::kNetworkData:
-        {
-            NetworkDataTlv networkData;
+            static_assert(sizeof(aTlvInfo.mData.mNetworkData.m8) >= NetworkData::NetworkData::kMaxSize,
+                          "NetworkData array in `otNetworkDiagTlv` is too small");
 
-            tlvTotalLength = sizeof(tlv) + tlv.GetLength();
-            VerifyOrExit(tlvTotalLength <= sizeof(networkData), error = kErrorParse);
-            SuccessOrExit(error = aMessage.Read(offset, &networkData, tlvTotalLength));
-            VerifyOrExit(networkData.IsValid(), error = kErrorParse);
-            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mNetworkData.m8) >= networkData.GetLength(), error = kErrorParse);
-
-            memcpy(aNetworkDiagTlv.mData.mNetworkData.m8, networkData.GetNetworkData(), networkData.GetLength());
-            aNetworkDiagTlv.mData.mNetworkData.mCount = networkData.GetLength();
+            VerifyOrExit(tlvLength <= NetworkData::NetworkData::kMaxSize, error = kErrorParse);
+            aTlvInfo.mData.mNetworkData.mCount = static_cast<uint8_t>(tlvLength);
+            aMessage.ReadBytes(valueOffset, aTlvInfo.mData.mNetworkData.m8, tlvLength);
             break;
-        }
 
         case NetworkDiagnosticTlv::kIp6AddressList:
         {
-            Ip6AddressListTlv &ip6AddrList = As<Ip6AddressListTlv>(tlv);
+            uint16_t      addrListLength = GetArrayLength(aTlvInfo.mData.mIp6AddrList.mList);
+            Ip6::Address *addrEntry      = AsCoreTypePtr(&aTlvInfo.mData.mIp6AddrList.mList[0]);
+            uint8_t &     addrCount      = aTlvInfo.mData.mIp6AddrList.mCount;
 
-            VerifyOrExit(ip6AddrList.IsValid(), error = kErrorParse);
-            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mIp6AddrList.mList) >= ip6AddrList.GetLength(),
-                         error = kErrorParse);
-            SuccessOrExit(error = aMessage.Read(offset + sizeof(ip6AddrList), aNetworkDiagTlv.mData.mIp6AddrList.mList,
-                                                ip6AddrList.GetLength()));
-            aNetworkDiagTlv.mData.mIp6AddrList.mCount = ip6AddrList.GetLength() / OT_IP6_ADDRESS_SIZE;
+            VerifyOrExit((tlvLength % Ip6::Address::kSize) == 0, error = kErrorParse);
+
+            // `TlvInfo` has a fixed array for IPv6 addresses. If there
+            // are more addresses in the message, we read and return as
+            // many as can fit in array and ignore the rest.
+
+            addrCount = 0;
+
+            while ((tlvLength > 0) && (addrCount < addrListLength))
+            {
+                SuccessOrExit(error = aMessage.Read(valueOffset, *addrEntry));
+                addrCount++;
+                addrEntry++;
+                valueOffset += Ip6::Address::kSize;
+                tlvLength -= Ip6::Address::kSize;
+            }
+
             break;
         }
 
         case NetworkDiagnosticTlv::kMacCounters:
         {
-            MacCountersTlv macCounters;
+            MacCountersTlv macCountersTlv;
 
-            SuccessOrExit(error = aMessage.Read(offset, macCounters));
-            VerifyOrExit(macCounters.IsValid(), error = kErrorParse);
-
-            ParseMacCounters(macCounters, aNetworkDiagTlv.mData.mMacCounters);
+            SuccessOrExit(error = aMessage.Read(offset, macCountersTlv));
+            VerifyOrExit(macCountersTlv.IsValid(), error = kErrorParse);
+            ParseMacCounters(macCountersTlv, aTlvInfo.mData.mMacCounters);
             break;
         }
 
         case NetworkDiagnosticTlv::kBatteryLevel:
-            SuccessOrExit(error = Tlv::Read<BatteryLevelTlv>(aMessage, offset, aNetworkDiagTlv.mData.mBatteryLevel));
+            SuccessOrExit(error = Tlv::Read<BatteryLevelTlv>(aMessage, offset, aTlvInfo.mData.mBatteryLevel));
             break;
 
         case NetworkDiagnosticTlv::kSupplyVoltage:
-            SuccessOrExit(error = Tlv::Read<SupplyVoltageTlv>(aMessage, offset, aNetworkDiagTlv.mData.mSupplyVoltage));
+            SuccessOrExit(error = Tlv::Read<SupplyVoltageTlv>(aMessage, offset, aTlvInfo.mData.mSupplyVoltage));
             break;
 
         case NetworkDiagnosticTlv::kChildTable:
         {
-            ChildTableTlv &childTable = As<ChildTableTlv>(tlv);
+            uint16_t   childInfoLength = GetArrayLength(aTlvInfo.mData.mChildTable.mTable);
+            ChildInfo *childInfo       = &aTlvInfo.mData.mChildTable.mTable[0];
+            uint8_t &  childCount      = aTlvInfo.mData.mChildTable.mCount;
 
-            VerifyOrExit(childTable.IsValid(), error = kErrorParse);
-            VerifyOrExit(childTable.GetNumEntries() <= GetArrayLength(aNetworkDiagTlv.mData.mChildTable.mTable),
-                         error = kErrorParse);
+            VerifyOrExit((tlvLength % sizeof(ChildTableEntry)) == 0, error = kErrorParse);
 
-            for (uint8_t i = 0; i < childTable.GetNumEntries(); ++i)
+            // `TlvInfo` has a fixed array Child Table entries. If there
+            // are more entries in the message, we read and return as
+            // many as can fit in array and ignore the rest.
+
+            childCount = 0;
+
+            while ((tlvLength > 0) && (childCount < childInfoLength))
             {
-                ChildTableEntry childEntry;
-                VerifyOrExit(childTable.ReadEntry(childEntry, aMessage, offset, i) == kErrorNone, error = kErrorParse);
-                ParseChildEntry(childEntry, aNetworkDiagTlv.mData.mChildTable.mTable[i]);
+                ChildTableEntry entry;
+
+                SuccessOrExit(error = aMessage.Read(valueOffset, entry));
+
+                childInfo->mTimeout = entry.GetTimeout();
+                childInfo->mChildId = entry.GetChildId();
+                entry.GetMode().Get(childInfo->mMode);
+
+                childCount++;
+                childInfo++;
+                tlvLength -= sizeof(ChildTableEntry);
+                valueOffset += sizeof(ChildTableEntry);
             }
-            aNetworkDiagTlv.mData.mChildTable.mCount = childTable.GetNumEntries();
+
             break;
         }
 
         case NetworkDiagnosticTlv::kChannelPages:
-        {
-            VerifyOrExit(sizeof(aNetworkDiagTlv.mData.mChannelPages.m8) >= tlv.GetLength(), error = kErrorParse);
-            SuccessOrExit(
-                error = aMessage.Read(offset + sizeof(tlv), aNetworkDiagTlv.mData.mChannelPages.m8, tlv.GetLength()));
-            aNetworkDiagTlv.mData.mChannelPages.mCount = tlv.GetLength();
+            aTlvInfo.mData.mChannelPages.mCount =
+                static_cast<uint8_t>(Min(tlvLength, GetArrayLength(aTlvInfo.mData.mChannelPages.m8)));
+            aMessage.ReadBytes(valueOffset, aTlvInfo.mData.mChannelPages.m8, aTlvInfo.mData.mChannelPages.mCount);
             break;
-        }
 
         case NetworkDiagnosticTlv::kMaxChildTimeout:
-            SuccessOrExit(error =
-                              Tlv::Read<MaxChildTimeoutTlv>(aMessage, offset, aNetworkDiagTlv.mData.mMaxChildTimeout));
+            SuccessOrExit(error = Tlv::Read<MaxChildTimeoutTlv>(aMessage, offset, aTlvInfo.mData.mMaxChildTimeout));
             break;
 
         default:
-            // Ignore unrecognized Network Diagnostic TLV silently and
-            // continue to top of the `while(true)` loop.
-            offset += tlv.GetSize();
-            continue;
+            // Skip unrecognized TLVs.
+            skipTlv = true;
+            break;
         }
 
-        // Exit if a TLV is recognized and parsed successfully.
-        aNetworkDiagTlv.mType = tlv.GetType();
-        aIterator             = static_cast<uint16_t>(offset - aMessage.GetOffset() + tlv.GetSize());
-        ExitNow();
+        offset += tlv.GetSize();
+
+        if (!skipTlv)
+        {
+            // Exit if a TLV is recognized and parsed successfully.
+            aTlvInfo.mType = tlv.GetType();
+            aIterator      = offset;
+            ExitNow();
+        }
     }
 
 exit:

--- a/src/core/thread/network_diagnostic.hpp
+++ b/src/core/thread/network_diagnostic.hpp
@@ -77,6 +77,18 @@ public:
     static constexpr Iterator kIteratorInit = OT_NETWORK_DIAGNOSTIC_ITERATOR_INIT; ///< Initializer for Iterator.
 
     /**
+     * This type represents parsed information from a Network Diagnostic TLV.
+     *
+     */
+    typedef otNetworkDiagTlv TlvInfo;
+
+    /**
+     * This structure represents parsed information from Network Diagnostic Child Table entry.
+     *
+     */
+    typedef otNetworkDiagChildEntry ChildInfo;
+
+    /**
      * This constructor initializes the object.
      *
      */
@@ -116,16 +128,18 @@ public:
      * @param[in]      aMessage         A message.
      * @param[in,out]  aIterator        The Network Diagnostic iterator. To get the first TLV set it to
      *                                  `kIteratorInit`.
-     * @param[out]     aNetworkDiagTlv  A reference to a Network Diagnostic TLV to output the next TLV.
+     * @param[out]     aTlvInfo         A reference to a `TlvInfo` to output the next TLV data.
      *
      * @retval kErrorNone       Successfully found the next Network Diagnostic TLV.
      * @retval kErrorNotFound   No subsequent Network Diagnostic TLV exists in the message.
      * @retval kErrorParse      Parsing the next Network Diagnostic failed.
      *
      */
-    static Error GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator, otNetworkDiagTlv &aNetworkDiagTlv);
+    static Error GetNextDiagTlv(const Coap::Message &aMessage, Iterator &aIterator, TlvInfo &aTlvInfo);
 
 private:
+    static constexpr uint16_t kMaxChildEntries = 398;
+
     enum CommandType : uint8_t
     {
         kDiagnosticGet,


### PR DESCRIPTION
This commit updates `NetworkDiagnostic` class's generation and processing of TLVs. When appending list based TLVs (IPv6 Address List TLV or Child Table TLV) depending on the number of entries we use regular or extended TLV. When processing the message and reading the TLVs, this commit updates the code to handle extended TLVs as well.

This commit changes the behavior of `GetNextDiagTlv()`. The `otNetworkDiagTlv` data structure defines limited-size arrays for IPv6 address list and child table. When processing a received message if the number of entries is larger than the array size, the first set entries (as many as fits in the array) are read and the rest are ignored. This changes the existing behavior which returned a `kErrorPrase` error in such a case.