### PR TITLE
[cli] add compile-time `printf` style arg check in CLI

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -163,7 +163,7 @@ void Interpreter::OutputResult(otError aError)
     }
     else
     {
-        OutputLine("Error %d: %s", aError, otThreadErrorToString(aError));
+        OutputLine("Error %u: %s", aError, otThreadErrorToString(aError));
     }
 
     mCommandIsPending = false;
@@ -231,7 +231,7 @@ template <> otError Interpreter::Process<Cmd("version")>(Arg aArgs[])
     }
     else if (aArgs[0] == "api")
     {
-        OutputLine("%d", OPENTHREAD_API_VERSION);
+        OutputLine("%u", OPENTHREAD_API_VERSION);
     }
     else
     {
@@ -895,7 +895,7 @@ template <> otError Interpreter::Process<Cmd("nat64")>(Arg aArgs[])
 
             OutputLine("|");
 
-            OutputFormat("| %016s ", "");
+            OutputFormat("| %16s ", "");
             OutputFormat("| %68s ", "TCP");
             OutputFormat("| %8s ", Uint64ToString(mapping.mCounters.mTcp.m4To6Packets, u64StringBuffer));
             OutputFormat("| %12s ", Uint64ToString(mapping.mCounters.mTcp.m4To6Bytes, u64StringBuffer));
@@ -903,7 +903,7 @@ template <> otError Interpreter::Process<Cmd("nat64")>(Arg aArgs[])
             OutputFormat("| %12s ", Uint64ToString(mapping.mCounters.mTcp.m6To4Bytes, u64StringBuffer));
             OutputLine("|");
 
-            OutputFormat("| %016s ", "");
+            OutputFormat("| %16s ", "");
             OutputFormat("| %68s ", "UDP");
             OutputFormat("| %8s ", Uint64ToString(mapping.mCounters.mUdp.m4To6Packets, u64StringBuffer));
             OutputFormat("| %12s ", Uint64ToString(mapping.mCounters.mUdp.m4To6Bytes, u64StringBuffer));
@@ -911,7 +911,7 @@ template <> otError Interpreter::Process<Cmd("nat64")>(Arg aArgs[])
             OutputFormat("| %12s ", Uint64ToString(mapping.mCounters.mUdp.m6To4Bytes, u64StringBuffer));
             OutputLine("|");
 
-            OutputFormat("| %016s ", "");
+            OutputFormat("| %16s ", "");
             OutputFormat("| %68s ", "ICMP");
             OutputFormat("| %8s ", Uint64ToString(mapping.mCounters.mIcmp.m4To6Packets, u64StringBuffer));
             OutputFormat("| %12s ", Uint64ToString(mapping.mCounters.mIcmp.m4To6Bytes, u64StringBuffer));
@@ -1063,9 +1063,9 @@ template <> otError Interpreter::Process<Cmd("bbr")>(Arg aArgs[])
         {
             OutputLine("BBR Primary:");
             OutputLine("server16: 0x%04X", config.mServer16);
-            OutputLine("seqno:    %d", config.mSequenceNumber);
-            OutputLine("delay:    %d secs", config.mReregistrationDelay);
-            OutputLine("timeout:  %d secs", config.mMlrTimeout);
+            OutputLine("seqno:    %u", config.mSequenceNumber);
+            OutputLine("delay:    %u secs", config.mReregistrationDelay);
+            OutputLine("timeout:  %lu secs", ToUlong(config.mMlrTimeout));
         }
         else
         {
@@ -1258,7 +1258,7 @@ void Interpreter::PrintMulticastListenersTable(void)
     while (otBackboneRouterMulticastListenerGetNext(GetInstancePtr(), &iter, &listenerInfo) == OT_ERROR_NONE)
     {
         OutputIp6Address(listenerInfo.mAddress);
-        OutputLine(" %u", listenerInfo.mTimeout);
+        OutputLine(" %lu", ToUlong(listenerInfo.mTimeout));
     }
 }
 
@@ -1377,9 +1377,9 @@ otError Interpreter::ProcessBackboneRouterLocal(Arg aArgs[])
 
         if (aArgs[1].IsEmpty())
         {
-            OutputLine("seqno:    %d", config.mSequenceNumber);
-            OutputLine("delay:    %d secs", config.mReregistrationDelay);
-            OutputLine("timeout:  %d secs", config.mMlrTimeout);
+            OutputLine("seqno:    %u", config.mSequenceNumber);
+            OutputLine("delay:    %u secs", config.mReregistrationDelay);
+            OutputLine("timeout:  %lu secs", ToUlong(config.mMlrTimeout));
         }
         else
         {
@@ -1590,13 +1590,13 @@ template <> otError Interpreter::Process<Cmd("bufferinfo")>(Arg aArgs[])
 
     otMessageGetBufferInfo(GetInstancePtr(), &bufferInfo);
 
-    OutputLine("total: %d", bufferInfo.mTotalBuffers);
-    OutputLine("free: %d", bufferInfo.mFreeBuffers);
+    OutputLine("total: %u", bufferInfo.mTotalBuffers);
+    OutputLine("free: %u", bufferInfo.mFreeBuffers);
 
     for (const BufferInfoName &info : kBufferInfoNames)
     {
-        OutputLine("%s: %u %u %u", info.mName, (bufferInfo.*info.mQueuePtr).mNumMessages,
-                   (bufferInfo.*info.mQueuePtr).mNumBuffers, (bufferInfo.*info.mQueuePtr).mTotalBytes);
+        OutputLine("%s: %u %u %lu", info.mName, (bufferInfo.*info.mQueuePtr).mNumMessages,
+                   (bufferInfo.*info.mQueuePtr).mNumBuffers, ToUlong((bufferInfo.*info.mQueuePtr).mTotalBytes));
     }
 
     return OT_ERROR_NONE;
@@ -1704,7 +1704,7 @@ template <> otError Interpreter::Process<Cmd("channel")>(Arg aArgs[])
      */
     if (aArgs[0] == "supported")
     {
-        OutputLine("0x%x", otPlatRadioGetSupportedChannelMask(GetInstancePtr()));
+        OutputLine("0x%lx", ToUlong(otPlatRadioGetSupportedChannelMask(GetInstancePtr())));
     }
     /**
      * @cli channel preferred
@@ -1718,7 +1718,7 @@ template <> otError Interpreter::Process<Cmd("channel")>(Arg aArgs[])
      */
     else if (aArgs[0] == "preferred")
     {
-        OutputLine("0x%x", otPlatRadioGetPreferredChannelMask(GetInstancePtr()));
+        OutputLine("0x%lx", ToUlong(otPlatRadioGetPreferredChannelMask(GetInstancePtr())));
     }
 #if OPENTHREAD_CONFIG_CHANNEL_MONITOR_ENABLE
     /**
@@ -1763,10 +1763,10 @@ template <> otError Interpreter::Process<Cmd("channel")>(Arg aArgs[])
                 uint32_t channelMask = otLinkGetSupportedChannelMask(GetInstancePtr());
                 uint8_t  channelNum  = sizeof(channelMask) * CHAR_BIT;
 
-                OutputLine("interval: %u", otChannelMonitorGetSampleInterval(GetInstancePtr()));
+                OutputLine("interval: %lu", ToUlong(otChannelMonitorGetSampleInterval(GetInstancePtr())));
                 OutputLine("threshold: %d", otChannelMonitorGetRssiThreshold(GetInstancePtr()));
-                OutputLine("window: %u", otChannelMonitorGetSampleWindow(GetInstancePtr()));
-                OutputLine("count: %u", otChannelMonitorGetSampleCount(GetInstancePtr()));
+                OutputLine("window: %lu", ToUlong(otChannelMonitorGetSampleWindow(GetInstancePtr())));
+                OutputLine("count: %lu", ToUlong(otChannelMonitorGetSampleCount(GetInstancePtr())));
 
                 OutputLine("occupancies:");
                 for (uint8_t channel = 0; channel < channelNum; channel++)
@@ -1780,11 +1780,12 @@ template <> otError Interpreter::Process<Cmd("channel")>(Arg aArgs[])
 
                     occupancy = otChannelMonitorGetChannelOccupancy(GetInstancePtr(), channel);
 
-                    OutputFormat("ch %d (0x%04x) ", channel, occupancy);
+                    OutputFormat("ch %u (0x%04lx) ", channel, ToUlong(occupancy));
                     occupancy = (occupancy * 10000) / 0xffff;
-                    OutputLine("%2d.%02d%% busy", occupancy / 100, occupancy % 100);
+                    OutputLine("%2u.%02u%% busy", static_cast<uint16_t>(occupancy / 100),
+                               static_cast<uint16_t>(occupancy % 100));
                 }
-                OutputLine("");
+                OutputNewLine();
             }
         }
         /**
@@ -1849,7 +1850,7 @@ template <> otError Interpreter::Process<Cmd("channel")>(Arg aArgs[])
          */
         if (aArgs[1].IsEmpty())
         {
-            OutputLine("channel: %d", otChannelManagerGetRequestedChannel(GetInstancePtr()));
+            OutputLine("channel: %u", otChannelManagerGetRequestedChannel(GetInstancePtr()));
             OutputLine("auto: %d", otChannelManagerGetAutoChannelSelectionEnabled(GetInstancePtr()));
 
             if (otChannelManagerGetAutoChannelSelectionEnabled(GetInstancePtr()))
@@ -1857,8 +1858,8 @@ template <> otError Interpreter::Process<Cmd("channel")>(Arg aArgs[])
                 Mac::ChannelMask supportedMask(otChannelManagerGetSupportedChannels(GetInstancePtr()));
                 Mac::ChannelMask favoredMask(otChannelManagerGetFavoredChannels(GetInstancePtr()));
 
-                OutputLine("delay: %d", otChannelManagerGetDelay(GetInstancePtr()));
-                OutputLine("interval: %u", otChannelManagerGetAutoChannelSelectionInterval(GetInstancePtr()));
+                OutputLine("delay: %u", otChannelManagerGetDelay(GetInstancePtr()));
+                OutputLine("interval: %lu", ToUlong(otChannelManagerGetAutoChannelSelectionInterval(GetInstancePtr())));
                 OutputLine("cca threshold: 0x%04x", otChannelManagerGetCcaFailureRateThreshold(GetInstancePtr()));
                 OutputLine("supported: %s", supportedMask.ToString().AsCString());
                 OutputLine("favored: %s", supportedMask.ToString().AsCString());
@@ -2082,18 +2083,18 @@ template <> otError Interpreter::Process<Cmd("child")>(Arg aArgs[])
 
             if (isTable)
             {
-                OutputFormat("| %3d ", childInfo.mChildId);
+                OutputFormat("| %3u ", childInfo.mChildId);
                 OutputFormat("| 0x%04x ", childInfo.mRloc16);
-                OutputFormat("| %10d ", childInfo.mTimeout);
-                OutputFormat("| %10d ", childInfo.mAge);
-                OutputFormat("| %5d ", childInfo.mLinkQualityIn);
-                OutputFormat("| %4d ", childInfo.mNetworkDataVersion);
+                OutputFormat("| %10lu ", ToUlong(childInfo.mTimeout));
+                OutputFormat("| %10lu ", ToUlong(childInfo.mAge));
+                OutputFormat("| %5u ", childInfo.mLinkQualityIn);
+                OutputFormat("| %4u ", childInfo.mNetworkDataVersion);
                 OutputFormat("|%1d", childInfo.mRxOnWhenIdle);
                 OutputFormat("|%1d", childInfo.mFullThreadDevice);
                 OutputFormat("|%1d", childInfo.mFullNetworkData);
-                OutputFormat("|%3d", childInfo.mVersion);
+                OutputFormat("|%3u", childInfo.mVersion);
                 OutputFormat("| %1d ", childInfo.mIsCslSynced);
-                OutputFormat("| %5d ", childInfo.mQueuedMessageCnt);
+                OutputFormat("| %5u ", childInfo.mQueuedMessageCnt);
                 OutputFormat("| ");
                 OutputExtAddress(childInfo.mExtAddress);
                 OutputLine(" |");
@@ -2111,11 +2112,11 @@ template <> otError Interpreter::Process<Cmd("child")>(Arg aArgs[])
              */
             else
             {
-                OutputFormat("%d ", childInfo.mChildId);
+                OutputFormat("%u ", childInfo.mChildId);
             }
         }
 
-        OutputLine("");
+        OutputNewLine();
         ExitNow();
     }
 
@@ -2141,7 +2142,7 @@ template <> otError Interpreter::Process<Cmd("child")>(Arg aArgs[])
      * @par api_copy
      * #otThreadGetChildInfoById
      */
-    OutputLine("Child ID: %d", childInfo.mChildId);
+    OutputLine("Child ID: %u", childInfo.mChildId);
     OutputLine("Rloc: %04x", childInfo.mRloc16);
     OutputFormat("Ext Addr: ");
     OutputExtAddressLine(childInfo.mExtAddress);
@@ -2149,10 +2150,10 @@ template <> otError Interpreter::Process<Cmd("child")>(Arg aArgs[])
     linkMode.mDeviceType   = childInfo.mFullThreadDevice;
     linkMode.mNetworkData  = childInfo.mFullThreadDevice;
     OutputLine("Mode: %s", LinkModeToString(linkMode, linkModeString));
-    OutputLine("Net Data: %d", childInfo.mNetworkDataVersion);
-    OutputLine("Timeout: %d", childInfo.mTimeout);
-    OutputLine("Age: %d", childInfo.mAge);
-    OutputLine("Link Quality In: %d", childInfo.mLinkQualityIn);
+    OutputLine("Net Data: %u", childInfo.mNetworkDataVersion);
+    OutputLine("Timeout: %lu", ToUlong(childInfo.mTimeout));
+    OutputLine("Age: %lu", ToUlong(childInfo.mAge));
+    OutputLine("Link Quality In: %u", childInfo.mLinkQualityIn);
     OutputLine("RSSI: %d", childInfo.mAverageRssi);
 
 exit:
@@ -2424,7 +2425,7 @@ template <> otError Interpreter::Process<Cmd("coex")>(Arg aArgs[])
 
         for (const RadioCoexMetricName &metric : kRxMetricNames)
         {
-            OutputLine(kIndentSize, "%s: %u", metric.mName, metrics.*metric.mValuePtr);
+            OutputLine(kIndentSize, "%s: %lu", metric.mName, ToUlong(metrics.*metric.mValuePtr));
         }
     }
     else
@@ -2575,18 +2576,18 @@ template <> otError Interpreter::Process<Cmd("counters")>(Arg aArgs[])
 
             const otMacCounters *macCounters = otLinkGetCounters(GetInstancePtr());
 
-            OutputLine("TxTotal: %d", macCounters->mTxTotal);
+            OutputLine("TxTotal: %lu", ToUlong(macCounters->mTxTotal));
 
             for (const MacCounterName &counter : kTxCounterNames)
             {
-                OutputLine(kIndentSize, "%s: %u", counter.mName, macCounters->*counter.mValuePtr);
+                OutputLine(kIndentSize, "%s: %lu", counter.mName, ToUlong(macCounters->*counter.mValuePtr));
             }
 
-            OutputLine("RxTotal: %d", macCounters->mRxTotal);
+            OutputLine("RxTotal: %lu", ToUlong(macCounters->mRxTotal));
 
             for (const MacCounterName &counter : kRxCounterNames)
             {
-                OutputLine(kIndentSize, "%s: %u", counter.mName, macCounters->*counter.mValuePtr);
+                OutputLine(kIndentSize, "%s: %lu", counter.mName, ToUlong(macCounters->*counter.mValuePtr));
             }
         }
         /**
@@ -2653,7 +2654,7 @@ template <> otError Interpreter::Process<Cmd("counters")>(Arg aArgs[])
 
             for (const MleCounterName &counter : kCounterNames)
             {
-                OutputLine("%s: %d", counter.mName, mleCounters->*counter.mValuePtr);
+                OutputLine("%s: %u", counter.mName, mleCounters->*counter.mValuePtr);
             }
 #if OPENTHREAD_CONFIG_UPTIME_ENABLE
             {
@@ -2734,7 +2735,7 @@ template <> otError Interpreter::Process<Cmd("counters")>(Arg aArgs[])
 
             for (const IpCounterName &counter : kCounterNames)
             {
-                OutputLine("%s: %d", counter.mName, ipCounters->*counter.mValuePtr);
+                OutputLine("%s: %lu", counter.mName, ToUlong(ipCounters->*counter.mValuePtr));
             }
         }
         /**
@@ -2788,9 +2789,9 @@ template <> otError Interpreter::Process<Cmd("csl")>(Arg aArgs[])
     if (aArgs[0].IsEmpty())
     {
         OutputLine("Channel: %u", otLinkCslGetChannel(GetInstancePtr()));
-        OutputLine("Period: %u(in units of 10 symbols), %ums", otLinkCslGetPeriod(GetInstancePtr()),
-                   otLinkCslGetPeriod(GetInstancePtr()) * kUsPerTenSymbols / 1000);
-        OutputLine("Timeout: %us", otLinkCslGetTimeout(GetInstancePtr()));
+        OutputLine("Period: %u(in units of 10 symbols), %lums", otLinkCslGetPeriod(GetInstancePtr()),
+                   ToUlong(otLinkCslGetPeriod(GetInstancePtr()) * kUsPerTenSymbols / 1000));
+        OutputLine("Timeout: %lus", ToUlong(otLinkCslGetTimeout(GetInstancePtr())));
     }
     /**
      * @cli csl channel
@@ -2861,7 +2862,7 @@ template <> otError Interpreter::Process<Cmd("delaytimermin")>(Arg aArgs[])
      */
     if (aArgs[0].IsEmpty())
     {
-        OutputLine("%d", (otDatasetGetDelayTimerMinimal(GetInstancePtr()) / 1000));
+        OutputLine("%lu", ToUlong((otDatasetGetDelayTimerMinimal(GetInstancePtr()) / 1000)));
     }
     /**
      * @cli delaytimermin (set)
@@ -2997,7 +2998,7 @@ template <> otError Interpreter::Process<Cmd("dns")>(Arg aArgs[])
 
             OutputFormat("Server: ");
             OutputSockAddrLine(defaultConfig->mServerSockAddr);
-            OutputLine("ResponseTimeout: %u ms", defaultConfig->mResponseTimeout);
+            OutputLine("ResponseTimeout: %lu ms", ToUlong(defaultConfig->mResponseTimeout));
             OutputLine("MaxTxAttempts: %u", defaultConfig->mMaxTxAttempts);
             OutputLine("RecursionDesired: %s",
                        (defaultConfig->mRecursionFlag == OT_DNS_FLAG_RECURSION_DESIRED) ? "yes" : "no");
@@ -3117,12 +3118,12 @@ void Interpreter::HandleDnsAddressResponse(otError aError, const otDnsAddressRes
         while (otDnsAddressResponseGetAddress(aResponse, index, &address, &ttl) == OT_ERROR_NONE)
         {
             OutputIp6Address(address);
-            OutputFormat(" TTL:%u ", ttl);
+            OutputFormat(" TTL:%lu ", ToUlong(ttl));
             index++;
         }
     }
 
-    OutputLine("");
+    OutputNewLine();
     OutputResult(aError);
 }
 
@@ -3130,12 +3131,12 @@ void Interpreter::HandleDnsAddressResponse(otError aError, const otDnsAddressRes
 
 void Interpreter::OutputDnsServiceInfo(uint8_t aIndentSize, const otDnsServiceInfo &aServiceInfo)
 {
-    OutputLine(aIndentSize, "Port:%d, Priority:%d, Weight:%d, TTL:%u", aServiceInfo.mPort, aServiceInfo.mPriority,
-               aServiceInfo.mWeight, aServiceInfo.mTtl);
+    OutputLine(aIndentSize, "Port:%d, Priority:%d, Weight:%d, TTL:%lu", aServiceInfo.mPort, aServiceInfo.mPriority,
+               aServiceInfo.mWeight, ToUlong(aServiceInfo.mTtl));
     OutputLine(aIndentSize, "Host:%s", aServiceInfo.mHostNameBuffer);
     OutputFormat(aIndentSize, "HostAddress:");
     OutputIp6Address(aServiceInfo.mHostAddress);
-    OutputLine(" TTL:%u", aServiceInfo.mHostAddressTtl);
+    OutputLine(" TTL:%lu", ToUlong(aServiceInfo.mHostAddressTtl));
     OutputFormat(aIndentSize, "TXT:");
 
     if (!aServiceInfo.mTxtDataTruncated)
@@ -3149,7 +3150,7 @@ void Interpreter::OutputDnsServiceInfo(uint8_t aIndentSize, const otDnsServiceIn
         OutputFormat("...]");
     }
 
-    OutputLine(" TTL:%u", aServiceInfo.mTxtDataTtl);
+    OutputLine(" TTL:%lu", ToUlong(aServiceInfo.mTxtDataTtl));
 }
 
 void Interpreter::HandleDnsBrowseResponse(otError aError, const otDnsBrowseResponse *aResponse, void *aContext)
@@ -3187,7 +3188,7 @@ void Interpreter::HandleDnsBrowseResponse(otError aError, const otDnsBrowseRespo
                 OutputDnsServiceInfo(kIndentSize, serviceInfo);
             }
 
-            OutputLine("");
+            OutputNewLine();
         }
     }
 
@@ -3220,7 +3221,7 @@ void Interpreter::HandleDnsServiceResponse(otError aError, const otDnsServiceRes
         if (otDnsServiceResponseGetServiceInfo(aResponse, &serviceInfo) == OT_ERROR_NONE)
         {
             OutputDnsServiceInfo(/* aIndetSize */ 0, serviceInfo);
-            OutputLine("");
+            OutputNewLine();
         }
     }
 
@@ -3254,7 +3255,7 @@ void Interpreter::OutputEidCacheEntry(const otCacheEntryInfo &aEntry)
     {
         if (aEntry.mValidLastTrans)
         {
-            OutputFormat(" transTime=%u eid=", aEntry.mLastTransTime);
+            OutputFormat(" transTime=%lu eid=", ToUlong(aEntry.mLastTransTime));
             OutputIp6Address(aEntry.mMeshLocalEid);
         }
     }
@@ -3268,7 +3269,7 @@ void Interpreter::OutputEidCacheEntry(const otCacheEntryInfo &aEntry)
         OutputFormat(" retryDelay=%u", aEntry.mRetryDelay);
     }
 
-    OutputLine("");
+    OutputNewLine();
 }
 
 /**
@@ -3707,7 +3708,7 @@ template <> otError Interpreter::Process<Cmd("ipaddr")>(Arg aArgs[])
                 OutputFormat(" origin:%s", AddressOriginToString(addr->mAddressOrigin));
             }
 
-            OutputLine("");
+            OutputNewLine();
         }
     }
     /**
@@ -4024,11 +4025,11 @@ template <> otError Interpreter::Process<Cmd("leaderdata")>(Arg aArgs[])
 
     SuccessOrExit(error = otThreadGetLeaderData(GetInstancePtr(), &leaderData));
 
-    OutputLine("Partition ID: %u", leaderData.mPartitionId);
-    OutputLine("Weighting: %d", leaderData.mWeighting);
-    OutputLine("Data Version: %d", leaderData.mDataVersion);
-    OutputLine("Stable Data Version: %d", leaderData.mStableDataVersion);
-    OutputLine("Leader Router ID: %d", leaderData.mLeaderRouterId);
+    OutputLine("Partition ID: %lu", ToUlong(leaderData.mPartitionId));
+    OutputLine("Weighting: %u", leaderData.mWeighting);
+    OutputLine("Data Version: %u", leaderData.mDataVersion);
+    OutputLine("Stable Data Version: %u", leaderData.mStableDataVersion);
+    OutputLine("Leader Router ID: %u", leaderData.mLeaderRouterId);
 
 exit:
     return error;
@@ -4041,7 +4042,7 @@ template <> otError Interpreter::Process<Cmd("partitionid")>(Arg aArgs[])
 
     if (aArgs[0].IsEmpty())
     {
-        OutputLine("%u", otThreadGetPartitionId(GetInstancePtr()));
+        OutputLine("%lu", ToUlong(otThreadGetPartitionId(GetInstancePtr())));
         error = OT_ERROR_NONE;
     }
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
@@ -4095,17 +4096,17 @@ void Interpreter::PrintLinkMetricsValue(const otLinkMetricsValues *aMetricsValue
 
     if (aMetricsValues->mMetrics.mPduCount)
     {
-        OutputLine(" - PDU Counter: %d (Count/Summation)", aMetricsValues->mPduCountValue);
+        OutputLine(" - PDU Counter: %lu (Count/Summation)", ToUlong(aMetricsValues->mPduCountValue));
     }
 
     if (aMetricsValues->mMetrics.mLqi)
     {
-        OutputLine(" - LQI: %d %s", aMetricsValues->mLqiValue, kLinkMetricsTypeAverage);
+        OutputLine(" - LQI: %u %s", aMetricsValues->mLqiValue, kLinkMetricsTypeAverage);
     }
 
     if (aMetricsValues->mMetrics.mLinkMargin)
     {
-        OutputLine(" - Margin: %d (dB) %s", aMetricsValues->mLinkMarginValue, kLinkMetricsTypeAverage);
+        OutputLine(" - Margin: %u (dB) %s", aMetricsValues->mLinkMarginValue, kLinkMetricsTypeAverage);
     }
 
     if (aMetricsValues->mMetrics.mRssi)
@@ -4852,13 +4853,13 @@ void Interpreter::OutputMultiRadioInfo(const otMultiRadioNeighborInfo &aMultiRad
 
     if (aMultiRadioInfo.mSupportsIeee802154)
     {
-        OutputFormat("15.4(%d)", aMultiRadioInfo.mIeee802154Info.mPreference);
+        OutputFormat("15.4(%u)", aMultiRadioInfo.mIeee802154Info.mPreference);
         isFirst = false;
     }
 
     if (aMultiRadioInfo.mSupportsTrelUdp6)
     {
-        OutputFormat("%sTREL(%d)", isFirst ? "" : ", ", aMultiRadioInfo.mTrelUdp6Info.mPreference);
+        OutputFormat("%sTREL(%u)", isFirst ? "" : ", ", aMultiRadioInfo.mTrelUdp6Info.mPreference);
     }
 
     OutputLine("]");
@@ -4896,7 +4897,7 @@ template <> otError Interpreter::Process<Cmd("neighbor")>(Arg aArgs[])
             {
                 OutputFormat("| %3c  ", neighborInfo.mIsChild ? 'C' : 'R');
                 OutputFormat("| 0x%04x ", neighborInfo.mRloc16);
-                OutputFormat("| %3d ", neighborInfo.mAge);
+                OutputFormat("| %3lu ", ToUlong(neighborInfo.mAge));
                 OutputFormat("| %8d ", neighborInfo.mAverageRssi);
                 OutputFormat("| %9d ", neighborInfo.mLastRssi);
                 OutputFormat("|%1d", neighborInfo.mRxOnWhenIdle);
@@ -4912,7 +4913,7 @@ template <> otError Interpreter::Process<Cmd("neighbor")>(Arg aArgs[])
             }
         }
 
-        OutputLine("");
+        OutputNewLine();
     }
     else
     {
@@ -5120,8 +5121,8 @@ template <> otError Interpreter::Process<Cmd("networktime")>(Arg aArgs[])
             break;
         }
 
-        OutputLine("Time Sync Period: %ds", otNetworkTimeGetSyncPeriod(GetInstancePtr()));
-        OutputLine("XTAL Threshold:   %dppm", otNetworkTimeGetXtalThreshold(GetInstancePtr()));
+        OutputLine("Time Sync Period: %us", otNetworkTimeGetSyncPeriod(GetInstancePtr()));
+        OutputLine("XTAL Threshold:   %uppm", otNetworkTimeGetXtalThreshold(GetInstancePtr()));
     }
     /**
      * @cli networktime (set)
@@ -5181,13 +5182,13 @@ template <> otError Interpreter::Process<Cmd("parent")>(Arg aArgs[])
         OutputFormat("Ext Addr: ");
         OutputExtAddressLine(parentInfo.mExtAddress);
         OutputLine("Rloc: %x", parentInfo.mRloc16);
-        OutputLine("Link Quality In: %d", parentInfo.mLinkQualityIn);
-        OutputLine("Link Quality Out: %d", parentInfo.mLinkQualityOut);
-        OutputLine("Age: %d", parentInfo.mAge);
-        OutputLine("Version: %d", parentInfo.mVersion);
+        OutputLine("Link Quality In: %u", parentInfo.mLinkQualityIn);
+        OutputLine("Link Quality Out: %u", parentInfo.mLinkQualityOut);
+        OutputLine("Age: %lu", ToUlong(parentInfo.mAge));
+        OutputLine("Version: %u", parentInfo.mVersion);
 #if OPENTHREAD_CONFIG_MAC_CSL_RECEIVER_ENABLE
-        OutputLine("CSL clock accuracy: %d", parentInfo.mCslClockAccuracy);
-        OutputLine("CSL uncertainty: %d", parentInfo.mCslUncertainty);
+        OutputLine("CSL clock accuracy: %u", parentInfo.mCslClockAccuracy);
+        OutputLine("CSL uncertainty: %u", parentInfo.mCslUncertainty);
 #endif
     }
     /**
@@ -5229,7 +5230,7 @@ template <> otError Interpreter::Process<Cmd("routeridrange")>(Arg *aArgs)
     if (aArgs[0].IsEmpty())
     {
         otThreadGetRouterIdRange(GetInstancePtr(), &minRouterId, &maxRouterId);
-        OutputLine("%d %d", minRouterId, maxRouterId);
+        OutputLine("%u %u", minRouterId, maxRouterId);
     }
     else
     {
@@ -5255,7 +5256,7 @@ void Interpreter::HandlePingReply(const otPingSenderReply *aReply)
 {
     OutputFormat("%u bytes from ", static_cast<uint16_t>(aReply->mSize + sizeof(otIcmp6Header)));
     OutputIp6Address(aReply->mSenderAddress);
-    OutputLine(": icmp_seq=%d hlim=%d time=%dms", aReply->mSequenceNumber, aReply->mHopLimit, aReply->mRoundTripTime);
+    OutputLine(": icmp_seq=%u hlim=%u time=%ums", aReply->mSequenceNumber, aReply->mHopLimit, aReply->mRoundTripTime);
 }
 
 void Interpreter::HandlePingStatistics(const otPingSenderStatistics *aStatistics, void *aContext)
@@ -5272,17 +5273,21 @@ void Interpreter::HandlePingStatistics(const otPingSenderStatistics *aStatistics
     {
         uint32_t packetLossRate =
             1000 * (aStatistics->mSentCount - aStatistics->mReceivedCount) / aStatistics->mSentCount;
-        OutputFormat(" Packet loss = %u.%u%%.", packetLossRate / 10, packetLossRate % 10);
+
+        OutputFormat(" Packet loss = %lu.%u%%.", ToUlong(packetLossRate / 10),
+                     static_cast<uint16_t>(packetLossRate % 10));
     }
 
     if (aStatistics->mReceivedCount != 0)
     {
         uint32_t avgRoundTripTime = 1000 * aStatistics->mTotalRoundTripTime / aStatistics->mReceivedCount;
+
         OutputFormat(" Round-trip min/avg/max = %u/%u.%u/%u ms.", aStatistics->mMinRoundTripTime,
-                     avgRoundTripTime / 1000, avgRoundTripTime % 1000, aStatistics->mMaxRoundTripTime);
+                     static_cast<uint16_t>(avgRoundTripTime / 1000), static_cast<uint16_t>(avgRoundTripTime % 1000),
+                     aStatistics->mMaxRoundTripTime);
     }
 
-    OutputLine("");
+    OutputNewLine();
 
     if (!mPingIsAsync)
     {
@@ -5439,7 +5444,7 @@ void Interpreter::HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx)
 {
     OT_UNUSED_VARIABLE(aIsTx);
 
-    OutputLine("");
+    OutputNewLine();
 
     for (size_t i = 0; i < 44; i++)
     {
@@ -5453,7 +5458,7 @@ void Interpreter::HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx)
         OutputFormat("=");
     }
 
-    OutputLine("");
+    OutputNewLine();
 
     for (size_t i = 0; i < aFrame->mLength; i += 16)
     {
@@ -5500,7 +5505,7 @@ void Interpreter::HandleLinkPcapReceive(const otRadioFrame *aFrame, bool aIsTx)
         OutputFormat("-");
     }
 
-    OutputLine("");
+    OutputNewLine();
 }
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTER_ENABLE
@@ -5903,24 +5908,24 @@ template <> otError Interpreter::Process<Cmd("router")>(Arg aArgs[])
 
             if (isTable)
             {
-                OutputFormat("| %2d ", routerInfo.mRouterId);
+                OutputFormat("| %2u ", routerInfo.mRouterId);
                 OutputFormat("| 0x%04x ", routerInfo.mRloc16);
-                OutputFormat("| %8d ", routerInfo.mNextHop);
-                OutputFormat("| %9d ", routerInfo.mPathCost);
-                OutputFormat("| %5d ", routerInfo.mLinkQualityIn);
-                OutputFormat("| %6d ", routerInfo.mLinkQualityOut);
-                OutputFormat("| %3d ", routerInfo.mAge);
+                OutputFormat("| %8u ", routerInfo.mNextHop);
+                OutputFormat("| %9u ", routerInfo.mPathCost);
+                OutputFormat("| %5u ", routerInfo.mLinkQualityIn);
+                OutputFormat("| %6u ", routerInfo.mLinkQualityOut);
+                OutputFormat("| %3u ", routerInfo.mAge);
                 OutputFormat("| ");
                 OutputExtAddress(routerInfo.mExtAddress);
                 OutputLine(" | %4d |", routerInfo.mLinkEstablished);
             }
             else
             {
-                OutputFormat("%d ", i);
+                OutputFormat("%u ", i);
             }
         }
 
-        OutputLine("");
+        OutputNewLine();
         ExitNow();
     }
 
@@ -5931,7 +5936,7 @@ template <> otError Interpreter::Process<Cmd("router")>(Arg aArgs[])
 
     if (routerInfo.mAllocated)
     {
-        OutputLine("Router ID: %d", routerInfo.mRouterId);
+        OutputLine("Router ID: %u", routerInfo.mRouterId);
         OutputLine("Rloc: %04x", routerInfo.mRloc16);
         OutputLine("Next Hop: %04x", static_cast<uint16_t>(routerInfo.mNextHop) << 10);
         OutputLine("Link: %d", routerInfo.mLinkEstablished);
@@ -5940,10 +5945,10 @@ template <> otError Interpreter::Process<Cmd("router")>(Arg aArgs[])
         {
             OutputFormat("Ext Addr: ");
             OutputExtAddressLine(routerInfo.mExtAddress);
-            OutputLine("Cost: %d", routerInfo.mPathCost);
-            OutputLine("Link Quality In: %d", routerInfo.mLinkQualityIn);
-            OutputLine("Link Quality Out: %d", routerInfo.mLinkQualityOut);
-            OutputLine("Age: %d", routerInfo.mAge);
+            OutputLine("Cost: %u", routerInfo.mPathCost);
+            OutputLine("Link Quality In: %u", routerInfo.mLinkQualityIn);
+            OutputLine("Link Quality Out: %u", routerInfo.mLinkQualityOut);
+            OutputLine("Age: %u", routerInfo.mAge);
         }
     }
 
@@ -6065,9 +6070,9 @@ void Interpreter::HandleActiveScanResult(otActiveScanResult *aResult)
 
     OutputFormat("| %04x | ", aResult->mPanId);
     OutputExtAddress(aResult->mExtAddress);
-    OutputFormat(" | %2d ", aResult->mChannel);
+    OutputFormat(" | %2u ", aResult->mChannel);
     OutputFormat("| %3d ", aResult->mRssi);
-    OutputLine("| %3d |", aResult->mLqi);
+    OutputLine("| %3u |", aResult->mLqi);
 
 exit:
     return;
@@ -6086,7 +6091,7 @@ void Interpreter::HandleEnergyScanResult(otEnergyScanResult *aResult)
         ExitNow();
     }
 
-    OutputLine("| %2d | %4d |", aResult->mChannel, aResult->mMaxRssi);
+    OutputLine("| %2u | %4d |", aResult->mChannel, aResult->mMaxRssi);
 
 exit:
     return;
@@ -6157,8 +6162,8 @@ void Interpreter::HandleSntpResponse(uint64_t aTime, otError aResult)
     {
         // Some Embedded C libraries do not support printing of 64-bit unsigned integers.
         // To simplify, unix epoch time and era number are printed separately.
-        OutputLine("SNTP response - Unix time: %u (era: %u)", static_cast<uint32_t>(aTime),
-                   static_cast<uint32_t>(aTime >> 32));
+        OutputLine("SNTP response - Unix time: %lu (era: %lu)", ToUlong(static_cast<uint32_t>(aTime)),
+                   ToUlong(static_cast<uint32_t>(aTime >> 32)));
     }
     else
     {
@@ -6332,11 +6337,11 @@ template <> otError Interpreter::Process<Cmd("unsecureport")>(Arg aArgs[])
         {
             for (uint8_t i = 0; i < numPorts; i++)
             {
-                OutputFormat("%d ", ports[i]);
+                OutputFormat("%u ", ports[i]);
             }
         }
 
-        OutputLine("");
+        OutputNewLine();
     }
     else
     {
@@ -6466,7 +6471,7 @@ void Interpreter::PrintMacFilter(void)
 
         if (i == OT_EXT_ADDRESS_SIZE)
         {
-            OutputLine("Default rss : %d (lqi %d)", entry.mRssIn,
+            OutputLine("Default rss : %d (lqi %u)", entry.mRssIn,
                        otLinkConvertRssToLinkQuality(GetInstancePtr(), entry.mRssIn));
         }
         else
@@ -6565,7 +6570,7 @@ otError Interpreter::ProcessMacFilterRss(Arg aArgs[])
 
             if (i == OT_EXT_ADDRESS_SIZE)
             {
-                OutputLine("Default rss: %d (lqi %d)", entry.mRssIn,
+                OutputLine("Default rss: %d (lqi %u)", entry.mRssIn,
                            otLinkConvertRssToLinkQuality(GetInstancePtr(), entry.mRssIn));
             }
             else
@@ -6641,7 +6646,7 @@ void Interpreter::OutputMacFilterEntry(const otMacFilterEntry &aEntry)
                      otLinkConvertRssToLinkQuality(GetInstancePtr(), aEntry.mRssIn));
     }
 
-    OutputLine("");
+    OutputNewLine();
 }
 
 const char *Interpreter::MacFilterAddressModeToString(otMacFilterAddressMode aMode)
@@ -6881,7 +6886,7 @@ void Interpreter::HandleDiagnosticGetResponse(otError                 aError,
         bytesPrinted += bytesToPrint;
     }
 
-    OutputLine("");
+    OutputNewLine();
 
     // Output Network Diagnostic TLV values in standard YAML format.
     while (otThreadGetNextDiagnosticTlv(aMessage, &iterator, &diagTlv) == OT_ERROR_NONE)
@@ -6900,7 +6905,7 @@ void Interpreter::HandleDiagnosticGetResponse(otError                 aError,
             OutputMode(kIndentSize, diagTlv.mData.mMode);
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_TIMEOUT:
-            OutputLine("Timeout: %u", diagTlv.mData.mTimeout);
+            OutputLine("Timeout: %lu", ToUlong(diagTlv.mData.mTimeout));
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_CONNECTIVITY:
             OutputLine("Connectivity:");
@@ -6950,7 +6955,7 @@ void Interpreter::HandleDiagnosticGetResponse(otError                 aError,
             OutputLine("'");
             break;
         case OT_NETWORK_DIAGNOSTIC_TLV_MAX_CHILD_TIMEOUT:
-            OutputLine("Max Child Timeout: %u", diagTlv.mData.mMaxChildTimeout);
+            OutputLine("Max Child Timeout: %lu", ToUlong(diagTlv.mData.mMaxChildTimeout));
             break;
         }
     }
@@ -7002,7 +7007,7 @@ void Interpreter::OutputRouteData(uint8_t aIndentSize, const otNetworkDiagRouteD
 
 void Interpreter::OutputLeaderData(uint8_t aIndentSize, const otLeaderData &aLeaderData)
 {
-    OutputLine(aIndentSize, "PartitionId: 0x%08x", aLeaderData.mPartitionId);
+    OutputLine(aIndentSize, "PartitionId: 0x%08lx", ToUlong(aLeaderData.mPartitionId));
     OutputLine(aIndentSize, "Weighting: %u", aLeaderData.mWeighting);
     OutputLine(aIndentSize, "DataVersion: %u", aLeaderData.mDataVersion);
     OutputLine(aIndentSize, "StableDataVersion: %u", aLeaderData.mStableDataVersion);
@@ -7011,15 +7016,15 @@ void Interpreter::OutputLeaderData(uint8_t aIndentSize, const otLeaderData &aLea
 
 void Interpreter::OutputNetworkDiagMacCounters(uint8_t aIndentSize, const otNetworkDiagMacCounters &aMacCounters)
 {
-    OutputLine(aIndentSize, "IfInUnknownProtos: %u", aMacCounters.mIfInUnknownProtos);
-    OutputLine(aIndentSize, "IfInErrors: %u", aMacCounters.mIfInErrors);
-    OutputLine(aIndentSize, "IfOutErrors: %u", aMacCounters.mIfOutErrors);
-    OutputLine(aIndentSize, "IfInUcastPkts: %u", aMacCounters.mIfInUcastPkts);
-    OutputLine(aIndentSize, "IfInBroadcastPkts: %u", aMacCounters.mIfInBroadcastPkts);
-    OutputLine(aIndentSize, "IfInDiscards: %u", aMacCounters.mIfInDiscards);
-    OutputLine(aIndentSize, "IfOutUcastPkts: %u", aMacCounters.mIfOutUcastPkts);
-    OutputLine(aIndentSize, "IfOutBroadcastPkts: %u", aMacCounters.mIfOutBroadcastPkts);
-    OutputLine(aIndentSize, "IfOutDiscards: %u", aMacCounters.mIfOutDiscards);
+    OutputLine(aIndentSize, "IfInUnknownProtos: %lu", ToUlong(aMacCounters.mIfInUnknownProtos));
+    OutputLine(aIndentSize, "IfInErrors: %lu", ToUlong(aMacCounters.mIfInErrors));
+    OutputLine(aIndentSize, "IfOutErrors: %lu", ToUlong(aMacCounters.mIfOutErrors));
+    OutputLine(aIndentSize, "IfInUcastPkts: %lu", ToUlong(aMacCounters.mIfInUcastPkts));
+    OutputLine(aIndentSize, "IfInBroadcastPkts: %lu", ToUlong(aMacCounters.mIfInBroadcastPkts));
+    OutputLine(aIndentSize, "IfInDiscards: %lu", ToUlong(aMacCounters.mIfInDiscards));
+    OutputLine(aIndentSize, "IfOutUcastPkts: %lu", ToUlong(aMacCounters.mIfOutUcastPkts));
+    OutputLine(aIndentSize, "IfOutBroadcastPkts: %lu", ToUlong(aMacCounters.mIfOutBroadcastPkts));
+    OutputLine(aIndentSize, "IfOutDiscards: %lu", ToUlong(aMacCounters.mIfOutDiscards));
 }
 
 void Interpreter::OutputChildTableEntry(uint8_t aIndentSize, const otNetworkDiagChildEntry &aChildEntry)
@@ -7394,7 +7399,7 @@ extern "C" void otCliPlatLogv(otLogLevel aLogLevel, otLogRegion aLogRegion, cons
     // `EmittingCommandOutput` to false indicate this.
     Interpreter::GetInterpreter().SetEmittingCommandOutput(false);
     Interpreter::GetInterpreter().OutputFormatV(aFormat, aArgs);
-    Interpreter::GetInterpreter().OutputLine("");
+    Interpreter::GetInterpreter().OutputNewLine();
     Interpreter::GetInterpreter().SetEmittingCommandOutput(true);
 
 exit:

--- a/src/cli/cli.hpp
+++ b/src/cli/cli.hpp
@@ -282,13 +282,14 @@ private:
     // Returns format string to output a `ValueType` (e.g., "%u" for `uint16_t`).
     template <typename ValueType> static constexpr const char *FormatStringFor(void);
 
+    // General temaplate implementaion.
+    // Specializations for `uint32_t` and `int32_t` are added at the end.
     template <typename ValueType> otError ProcessGet(Arg aArgs[], GetHandler<ValueType> aGetHandler)
     {
         static_assert(
             TypeTraits::IsSame<ValueType, uint8_t>::kValue || TypeTraits::IsSame<ValueType, uint16_t>::kValue ||
-                TypeTraits::IsSame<ValueType, uint32_t>::kValue || TypeTraits::IsSame<ValueType, int8_t>::kValue ||
-                TypeTraits::IsSame<ValueType, int16_t>::kValue || TypeTraits::IsSame<ValueType, int32_t>::kValue,
-            "ValueType must be an  8, 16, or 32 bit `int` or `uint` type");
+                TypeTraits::IsSame<ValueType, int8_t>::kValue || TypeTraits::IsSame<ValueType, int16_t>::kValue,
+            "ValueType must be an  8, 16 `int` or `uint` type");
 
         otError error = OT_ERROR_NONE;
 
@@ -590,7 +591,7 @@ template <> inline constexpr const char *Interpreter::FormatStringFor<uint16_t>(
 
 template <> inline constexpr const char *Interpreter::FormatStringFor<uint32_t>(void)
 {
-    return "%u";
+    return "%lu";
 }
 
 template <> inline constexpr const char *Interpreter::FormatStringFor<int8_t>(void)
@@ -605,7 +606,31 @@ template <> inline constexpr const char *Interpreter::FormatStringFor<int16_t>(v
 
 template <> inline constexpr const char *Interpreter::FormatStringFor<int32_t>(void)
 {
-    return "%d";
+    return "%ld";
+}
+
+// Specialization of ProcessGet<> for `uint32_t` and `int32_t`
+
+template <> inline otError Interpreter::ProcessGet<uint32_t>(Arg aArgs[], GetHandler<uint32_t> aGetHandler)
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    OutputLine(FormatStringFor<uint32_t>(), ToUlong(aGetHandler(GetInstancePtr())));
+
+exit:
+    return error;
+}
+
+template <> inline otError Interpreter::ProcessGet<int32_t>(Arg aArgs[], GetHandler<int32_t> aGetHandler)
+{
+    otError error = OT_ERROR_NONE;
+
+    VerifyOrExit(aArgs[0].IsEmpty(), error = OT_ERROR_INVALID_ARGS);
+    OutputLine(FormatStringFor<int32_t>(), static_cast<long int>(aGetHandler(GetInstancePtr())));
+
+exit:
+    return error;
 }
 
 } // namespace Cli

--- a/src/cli/cli_coap.cpp
+++ b/src/cli/cli_coap.cpp
@@ -138,7 +138,7 @@ void Coap::PrintPayload(otMessage *aMessage)
         }
     }
 
-    OutputLine("");
+    OutputNewLine();
 }
 
 #if OPENTHREAD_CONFIG_COAP_OBSERVE_API_ENABLE
@@ -319,7 +319,7 @@ template <> otError Coap::Process<Cmd("parameters")>(Arg aArgs[])
     }
     else
     {
-        OutputLine("ACK_TIMEOUT=%u ms, ACK_RANDOM_FACTOR=%u/%u, MAX_RETRANSMIT=%u", txParameters->mAckTimeout,
+        OutputLine("ACK_TIMEOUT=%lu ms, ACK_RANDOM_FACTOR=%u/%u, MAX_RETRANSMIT=%u", ToUlong(txParameters->mAckTimeout),
                    txParameters->mAckRandomFactorNumerator, txParameters->mAckRandomFactorDenominator,
                    txParameters->mMaxRetransmit);
     }
@@ -647,7 +647,8 @@ void Coap::HandleRequest(otMessage *aMessage, const otMessageInfo *aMessageInfo)
             SuccessOrExit(error = otCoapOptionIteratorGetOptionUintValue(&iterator, &observe));
             observePresent = true;
 
-            OutputFormat(" OBS=%lu", static_cast<uint32_t>(observe));
+            OutputFormat(" OBS=");
+            OutputUint64(observe);
         }
 #endif
 #if OPENTHREAD_CONFIG_COAP_BLOCKWISE_TRANSFER_ENABLE
@@ -862,7 +863,8 @@ void Coap::HandleResponse(otMessage *aMessage, const otMessageInfo *aMessageInfo
 
                 if (error == OT_ERROR_NONE)
                 {
-                    OutputFormat(" OBS=%u", observeVal);
+                    OutputFormat(" OBS=");
+                    OutputUint64(observeVal);
                 }
             }
         }

--- a/src/cli/cli_coap_secure.cpp
+++ b/src/cli/cli_coap_secure.cpp
@@ -87,7 +87,7 @@ void CoapSecure::PrintPayload(otMessage *aMessage)
         }
     }
 
-    OutputLine("");
+    OutputNewLine();
 }
 
 template <> otError CoapSecure::Process<Cmd("resource")>(Arg aArgs[])

--- a/src/cli/cli_commissioner.cpp
+++ b/src/cli/cli_commissioner.cpp
@@ -124,8 +124,8 @@ template <> otError Commissioner::Process<Cmd("joiner")>(Arg aArgs[])
                 break;
             }
 
-            OutputFormat(" | %32s | %10d |", joinerInfo.mPskd.m8, joinerInfo.mExpirationTime);
-            OutputLine("");
+            OutputFormat(" | %32s | %10lu |", joinerInfo.mPskd.m8, ToUlong(joinerInfo.mExpirationTime));
+            OutputNewLine();
         }
 
         ExitNow(error = OT_ERROR_NONE);
@@ -419,7 +419,7 @@ void Commissioner::HandleJoinerEvent(otCommissionerJoinerEvent aEvent,
         OutputExtAddress(*aJoinerId);
     }
 
-    OutputLine("");
+    OutputNewLine();
 }
 
 template <> otError Commissioner::Process<Cmd("stop")>(Arg aArgs[])
@@ -433,7 +433,7 @@ template <> otError Commissioner::Process<Cmd("state")>(Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);
 
-    OutputLine(StateToString(otCommissionerGetState(GetInstancePtr())));
+    OutputLine("%s", StateToString(otCommissionerGetState(GetInstancePtr())));
 
     return OT_ERROR_NONE;
 }
@@ -483,14 +483,14 @@ void Commissioner::HandleEnergyReport(uint32_t       aChannelMask,
 
 void Commissioner::HandleEnergyReport(uint32_t aChannelMask, const uint8_t *aEnergyList, uint8_t aEnergyListLength)
 {
-    OutputFormat("Energy: %08x ", aChannelMask);
+    OutputFormat("Energy: %08lx ", ToUlong(aChannelMask));
 
     for (uint8_t i = 0; i < aEnergyListLength; i++)
     {
         OutputFormat("%d ", static_cast<int8_t>(aEnergyList[i]));
     }
 
-    OutputLine("");
+    OutputNewLine();
 }
 
 void Commissioner::HandlePanIdConflict(uint16_t aPanId, uint32_t aChannelMask, void *aContext)
@@ -500,7 +500,7 @@ void Commissioner::HandlePanIdConflict(uint16_t aPanId, uint32_t aChannelMask, v
 
 void Commissioner::HandlePanIdConflict(uint16_t aPanId, uint32_t aChannelMask)
 {
-    OutputLine("Conflict: %04x, %08x", aPanId, aChannelMask);
+    OutputLine("Conflict: %04x, %08lx", aPanId, ToUlong(aChannelMask));
 }
 
 } // namespace Cli

--- a/src/cli/cli_dataset.cpp
+++ b/src/cli/cli_dataset.cpp
@@ -68,12 +68,12 @@ otError Dataset::Print(otOperationalDataset &aDataset)
 
     if (aDataset.mComponents.mIsChannelMaskPresent)
     {
-        OutputLine("Channel Mask: 0x%08x", aDataset.mChannelMask);
+        OutputLine("Channel Mask: 0x%08lx", ToUlong(aDataset.mChannelMask));
     }
 
     if (aDataset.mComponents.mIsDelayPresent)
     {
-        OutputLine("Delay: %d", aDataset.mDelay);
+        OutputLine("Delay: %lu", ToUlong(aDataset.mDelay));
     }
 
     if (aDataset.mComponents.mIsExtendedPanIdPresent)
@@ -342,7 +342,7 @@ template <> otError Dataset::Process<Cmd("channelmask")>(Arg aArgs[])
     {
         if (sDataset.mComponents.mIsChannelMaskPresent)
         {
-            OutputLine("0x%08x", sDataset.mChannelMask);
+            OutputLine("0x%08lx", ToUlong(sDataset.mChannelMask));
         }
     }
     else
@@ -435,7 +435,7 @@ template <> otError Dataset::Process<Cmd("delay")>(Arg aArgs[])
     {
         if (sDataset.mComponents.mIsDelayPresent)
         {
-            OutputLine("%d", sDataset.mDelay);
+            OutputLine("%lu", ToUlong(sDataset.mDelay));
         }
     }
     else
@@ -1083,7 +1083,7 @@ void Dataset::OutputSecurityPolicy(const otSecurityPolicy &aSecurityPolicy)
         OutputFormat("R");
     }
 
-    OutputLine("");
+    OutputNewLine();
 }
 
 otError Dataset::ParseSecurityPolicy(otSecurityPolicy &aSecurityPolicy, Arg *&aArgs)

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -146,7 +146,7 @@ void NetworkData::OutputRoute(const otExternalRouteConfig &aConfig)
 
 void NetworkData::OutputService(const otServiceConfig &aConfig)
 {
-    OutputFormat("%u ", aConfig.mEnterpriseNumber);
+    OutputFormat("%lu ", ToUlong(aConfig.mEnterpriseNumber));
     OutputBytes(aConfig.mServiceData, aConfig.mServiceDataLength);
     OutputFormat(" ");
     OutputBytes(aConfig.mServerConfig.mServerData, aConfig.mServerConfig.mServerDataLength);

--- a/src/cli/cli_output.cpp
+++ b/src/cli/cli_output.cpp
@@ -88,7 +88,7 @@ void Output::OutputLine(const char *aFormat, ...)
     OutputFormatV(aFormat, args);
     va_end(args);
 
-    OutputFormat("\r\n");
+    OutputNewLine();
 }
 
 void Output::OutputLine(uint8_t aIndentSize, const char *aFormat, ...)
@@ -101,6 +101,11 @@ void Output::OutputLine(uint8_t aIndentSize, const char *aFormat, ...)
     OutputFormatV(aFormat, args);
     va_end(args);
 
+    OutputNewLine();
+}
+
+void Output::OutputNewLine(void)
+{
     OutputFormat("\r\n");
 }
 
@@ -124,7 +129,7 @@ void Output::OutputBytes(const uint8_t *aBytes, uint16_t aLength)
 void Output::OutputBytesLine(const uint8_t *aBytes, uint16_t aLength)
 {
     OutputBytes(aBytes, aLength);
-    OutputLine("");
+    OutputNewLine();
 }
 
 const char *Output::Uint64ToString(uint64_t aUint64, Uint64StringBuffer &aBuffer)
@@ -158,7 +163,7 @@ void Output::OutputUint64(uint64_t aUint64)
 void Output::OutputUint64Line(uint64_t aUint64)
 {
     OutputUint64(aUint64);
-    OutputLine("");
+    OutputNewLine();
 }
 
 void Output::OutputEnabledDisabledStatus(bool aEnabled)
@@ -180,7 +185,7 @@ void Output::OutputIp6Address(const otIp6Address &aAddress)
 void Output::OutputIp6AddressLine(const otIp6Address &aAddress)
 {
     OutputIp6Address(aAddress);
-    OutputLine("");
+    OutputNewLine();
 }
 
 void Output::OutputIp6Prefix(const otIp6Prefix &aPrefix)
@@ -195,7 +200,7 @@ void Output::OutputIp6Prefix(const otIp6Prefix &aPrefix)
 void Output::OutputIp6PrefixLine(const otIp6Prefix &aPrefix)
 {
     OutputIp6Prefix(aPrefix);
-    OutputLine("");
+    OutputNewLine();
 }
 
 void Output::OutputIp6Prefix(const otIp6NetworkPrefix &aPrefix)
@@ -207,7 +212,7 @@ void Output::OutputIp6Prefix(const otIp6NetworkPrefix &aPrefix)
 void Output::OutputIp6PrefixLine(const otIp6NetworkPrefix &aPrefix)
 {
     OutputIp6Prefix(aPrefix);
-    OutputLine("");
+    OutputNewLine();
 }
 
 void Output::OutputSockAddr(const otSockAddr &aSockAddr)
@@ -222,7 +227,7 @@ void Output::OutputSockAddr(const otSockAddr &aSockAddr)
 void Output::OutputSockAddrLine(const otSockAddr &aSockAddr)
 {
     OutputSockAddr(aSockAddr);
-    OutputLine("");
+    OutputNewLine();
 }
 
 void Output::OutputDnsTxtData(const uint8_t *aTxtData, uint16_t aTxtDataLength)

--- a/src/cli/cli_output.hpp
+++ b/src/cli/cli_output.hpp
@@ -43,6 +43,7 @@
 #include "cli_config.h"
 
 #include "common/binary_search.hpp"
+#include "common/num_utils.hpp"
 #include "common/string.hpp"
 #include "utils/parse_cmdline.hpp"
 
@@ -231,7 +232,7 @@ public:
      * @param[in]  ...      A variable list of arguments to format.
      *
      */
-    void OutputFormat(const char *aFormat, ...);
+    void OutputFormat(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 3);
 
     /**
      * This method delivers a formatted output string to the CLI console (to which it prepends a given number
@@ -242,7 +243,7 @@ public:
      * @param[in]  ...           A variable list of arguments to format.
      *
      */
-    void OutputFormat(uint8_t aIndentSize, const char *aFormat, ...);
+    void OutputFormat(uint8_t aIndentSize, const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(3, 4);
 
     /**
      * This method delivers a formatted output string to the CLI console (to which it also appends newline "\r\n").
@@ -251,7 +252,7 @@ public:
      * @param[in]  ...      A variable list of arguments to format.
      *
      */
-    void OutputLine(const char *aFormat, ...);
+    void OutputLine(const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(2, 3);
 
     /**
      * This method delivers a formatted output string to the CLI console (to which it prepends a given number
@@ -262,7 +263,13 @@ public:
      * @param[in]  ...           A variable list of arguments to format.
      *
      */
-    void OutputLine(uint8_t aIndentSize, const char *aFormat, ...);
+    void OutputLine(uint8_t aIndentSize, const char *aFormat, ...) OT_TOOL_PRINTF_STYLE_FORMAT_ARG_CHECK(3, 4);
+
+    /**
+     * This method delivered newline "\r\n" to the CLI console.
+     *
+     */
+    void OutputNewLine(void);
 
     /**
      * This method outputs a given number of space chars to the CLI console.

--- a/src/cli/cli_srp_server.cpp
+++ b/src/cli/cli_srp_server.cpp
@@ -176,8 +176,8 @@ template <> otError SrpServer::Process<Cmd("ttl")>(Arg aArgs[])
     if (aArgs[0].IsEmpty())
     {
         otSrpServerGetTtlConfig(GetInstancePtr(), &ttlConfig);
-        OutputLine("min ttl: %u", ttlConfig.mMinTtl);
-        OutputLine("max ttl: %u", ttlConfig.mMaxTtl);
+        OutputLine("min ttl: %lu", ToUlong(ttlConfig.mMinTtl));
+        OutputLine("max ttl: %lu", ToUlong(ttlConfig.mMaxTtl));
     }
     else
     {
@@ -200,10 +200,10 @@ template <> otError SrpServer::Process<Cmd("lease")>(Arg aArgs[])
     if (aArgs[0].IsEmpty())
     {
         otSrpServerGetLeaseConfig(GetInstancePtr(), &leaseConfig);
-        OutputLine("min lease: %u", leaseConfig.mMinLease);
-        OutputLine("max lease: %u", leaseConfig.mMaxLease);
-        OutputLine("min key-lease: %u", leaseConfig.mMinKeyLease);
-        OutputLine("max key-lease: %u", leaseConfig.mMaxKeyLease);
+        OutputLine("min lease: %lu", ToUlong(leaseConfig.mMinLease));
+        OutputLine("max lease: %lu", ToUlong(leaseConfig.mMaxLease));
+        OutputLine("min key-lease: %lu", ToUlong(leaseConfig.mMinKeyLease));
+        OutputLine("max key-lease: %lu", ToUlong(leaseConfig.mMaxKeyLease));
     }
     else
     {
@@ -332,23 +332,23 @@ template <> otError SrpServer::Process<Cmd("service")>(Arg aArgs[])
 
             OutputLine(hasSubType ? "" : "(null)");
 
-            OutputLine(kIndentSize, "port: %hu", otSrpServerServiceGetPort(service));
-            OutputLine(kIndentSize, "priority: %hu", otSrpServerServiceGetPriority(service));
-            OutputLine(kIndentSize, "weight: %hu", otSrpServerServiceGetWeight(service));
-            OutputLine(kIndentSize, "ttl: %u", otSrpServerServiceGetTtl(service));
-            OutputLine(kIndentSize, "lease: %u", leaseInfo.mLease / 1000);
-            OutputLine(kIndentSize, "key-lease: %u", leaseInfo.mKeyLease / 1000);
+            OutputLine(kIndentSize, "port: %u", otSrpServerServiceGetPort(service));
+            OutputLine(kIndentSize, "priority: %u", otSrpServerServiceGetPriority(service));
+            OutputLine(kIndentSize, "weight: %u", otSrpServerServiceGetWeight(service));
+            OutputLine(kIndentSize, "ttl: %lu", ToUlong(otSrpServerServiceGetTtl(service)));
+            OutputLine(kIndentSize, "lease: %lu", ToUlong(leaseInfo.mLease / 1000));
+            OutputLine(kIndentSize, "key-lease: %lu", ToUlong(leaseInfo.mKeyLease / 1000));
 
             txtData = otSrpServerServiceGetTxtData(service, &txtDataLength);
             OutputFormat(kIndentSize, "TXT: ");
             OutputDnsTxtData(txtData, txtDataLength);
-            OutputLine("");
+            OutputNewLine();
 
             OutputLine(kIndentSize, "host: %s", otSrpServerHostGetFullName(host));
 
             OutputFormat(kIndentSize, "addresses: ");
             OutputHostAddresses(host);
-            OutputLine("");
+            OutputNewLine();
         }
     }
 

--- a/src/cli/cli_tcp.cpp
+++ b/src/cli/cli_tcp.cpp
@@ -520,8 +520,8 @@ void TcpExample::HandleTcpReceiveAvailable(otTcpEndpoint *aEndpoint,
         IgnoreError(otTcpReceiveByReference(aEndpoint, &data));
         for (; data != nullptr; data = data->mNext)
         {
-            OutputLine("TCP: Received %u bytes: %.*s", data->mLength, data->mLength,
-                       reinterpret_cast<const char *>(data->mData));
+            OutputLine("TCP: Received %u bytes: %.*s", static_cast<unsigned>(data->mLength),
+                       static_cast<unsigned>(data->mLength), reinterpret_cast<const char *>(data->mData));
             totalReceived += data->mLength;
         }
         OT_ASSERT(aBytesAvailable == totalReceived);
@@ -635,8 +635,10 @@ void TcpExample::CompleteBenchmark(void)
     uint32_t milliseconds         = TimerMilli::GetNow() - mBenchmarkStart;
     uint32_t thousandTimesGoodput = (1000 * (mBenchmarkBytesTotal << 3) + (milliseconds >> 1)) / milliseconds;
 
-    OutputLine("TCP Benchmark Complete: Transferred %u bytes in %u milliseconds", mBenchmarkBytesTotal, milliseconds);
-    OutputLine("TCP Goodput: %u.%03u kb/s", thousandTimesGoodput / 1000, thousandTimesGoodput % 1000);
+    OutputLine("TCP Benchmark Complete: Transferred %lu bytes in %lu milliseconds", ToUlong(mBenchmarkBytesTotal),
+               ToUlong(milliseconds));
+    OutputLine("TCP Goodput: %lu.%03u kb/s", ToUlong(thousandTimesGoodput / 1000),
+               static_cast<uint16_t>(thousandTimesGoodput % 1000));
     mBenchmarkBytesTotal = 0;
 }
 


### PR DESCRIPTION
This commit adds compile-time check of format string to all CLI
`Output` methods. It also updates CLI module to  make arg string
formats consistent. In particular we use `'%lu` for `uint32_t`
arguments and they are explicitly cast to `unsigned long` using
`ToUlong()`.

-----

This PR contains the commit from 
- https://github.com/openthread/openthread/pull/8354