### PR TITLE
[posix] use __GLIBC__ instead of __linux__ in backtrace

### DIFF
--- a/src/posix/platform/backtrace.cpp
+++ b/src/posix/platform/backtrace.cpp
@@ -44,8 +44,7 @@
 #include "common/logging.hpp"
 
 #if OPENTHREAD_POSIX_CONFIG_BACKTRACE_ENABLE
-
-#if defined(__linux__) && !OPENTHREAD_ENABLE_ANDROID_NDK
+#if OPENTHREAD_POSIX_CONFIG_ANDROID_ENABLE || defined(__GLIBC__)
 #if OPENTHREAD_POSIX_CONFIG_ANDROID_ENABLE
 #include <log/log.h>
 #include <utils/CallStack.h>
@@ -162,9 +161,9 @@ void platformBacktraceInit(void)
     sigaction(SIGTRAP, &sigact, (struct sigaction *)nullptr);
     sigaction(SIGFPE, &sigact, (struct sigaction *)nullptr);
 }
-#else  // defined(__linux__) && !OPENTHREAD_ENABLE_ANDROID_NDK
+#else  // OPENTHREAD_POSIX_CONFIG_ANDROID_ENABLE || defined(__GLIBC__)
 void platformBacktraceInit(void)
 {
 }
-#endif // defined(__linux__) && !OPENTHREAD_ENABLE_ANDROID_NDK
+#endif // OPENTHREAD_POSIX_CONFIG_ANDROID_ENABLE || defined(__GLIBC__)
 #endif // OPENTHREAD_POSIX_CONFIG_BACKTRACE_ENABLE


### PR DESCRIPTION
The `execinfo.h` is a glibc specific header, and the glibc doesn't exist under openwrt. It causes the compile errors under openwrt in ot-br-posix. This commit uses __GLIBC__ instead of __linux__ to avoid the compile errors when the OS doesn't contain the glibc.