### PR TITLE
[netdata] simplify `RouteLookup()` methods

### DIFF
--- a/src/core/net/ip6.cpp
+++ b/src/core/net/ip6.cpp
@@ -1369,8 +1369,7 @@ bool Ip6::ShouldForwardToThread(const MessageInfo &aMessageInfo, MessageOrigin a
         shouldForward = true;
 #endif
     }
-    else if (Get<ThreadNetif>().RouteLookup(aMessageInfo.GetPeerAddr(), aMessageInfo.GetSockAddr(), nullptr) ==
-             kErrorNone)
+    else if (Get<ThreadNetif>().RouteLookup(aMessageInfo.GetPeerAddr(), aMessageInfo.GetSockAddr()) == kErrorNone)
     {
         shouldForward = true;
     }

--- a/src/core/thread/mesh_forwarder_ftd.cpp
+++ b/src/core/thread/mesh_forwarder_ftd.cpp
@@ -617,8 +617,8 @@ Error MeshForwarder::UpdateIp6RouteFtd(Ip6::Header &ip6Header, Message &aMessage
     }
     else
     {
-        IgnoreError(Get<NetworkData::Leader>().RouteLookup(ip6Header.GetSource(), ip6Header.GetDestination(), nullptr,
-                                                           &mMeshDest));
+        IgnoreError(
+            Get<NetworkData::Leader>().RouteLookup(ip6Header.GetSource(), ip6Header.GetDestination(), mMeshDest));
     }
 
     VerifyOrExit(mMeshDest != Mac::kShortAddrInvalid, error = kErrorDrop);

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -134,17 +134,13 @@ public:
      *
      * @param[in]   aSource             A reference to the IPv6 source address.
      * @param[in]   aDestination        A reference to the IPv6 destination address.
-     * @param[out]  aPrefixMatchLength  A pointer to output the longest prefix match length in bits.
-     * @param[out]  aRloc16             A pointer to the RLOC16 for the selected route.
+     * @param[out]  aRloc16             A reference to return the RLOC16 for the selected route.
      *
-     * @retval kErrorNone      Successfully found a route.
+     * @retval kErrorNone      Successfully found a route. @p aRloc16 is updated.
      * @retval kErrorNoRoute   No valid route was found.
      *
      */
-    Error RouteLookup(const Ip6::Address &aSource,
-                      const Ip6::Address &aDestination,
-                      uint8_t *           aPrefixMatchLength,
-                      uint16_t *          aRloc16) const;
+    Error RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination, uint16_t &aRloc16) const;
 
     /**
      * This method is used by non-Leader devices to set newly received Network Data from the Leader.
@@ -292,11 +288,8 @@ private:
 
     void RemoveCommissioningData(void);
 
-    Error ExternalRouteLookup(uint8_t             aDomainId,
-                              const Ip6::Address &aDestination,
-                              uint8_t *           aPrefixMatchLength,
-                              uint16_t *          aRloc16) const;
-    Error DefaultRouteLookup(const PrefixTlv &aPrefix, uint16_t *aRloc16) const;
+    Error ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &aDestination, uint16_t &aRloc16) const;
+    Error DefaultRouteLookup(const PrefixTlv &aPrefix, uint16_t &aRloc16) const;
     Error SteeringDataCheck(const FilterIndexes &aFilterIndexes) const;
     void  GetContextForMeshLocalPrefix(Lowpan::Context &aContext) const;
 

--- a/src/core/thread/thread_netif.cpp
+++ b/src/core/thread/thread_netif.cpp
@@ -123,12 +123,12 @@ Error ThreadNetif::SendMessage(Message &aMessage)
     return Get<MeshForwarder>().SendMessage(aMessage);
 }
 
-Error ThreadNetif::RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination, uint8_t *aPrefixMatch)
+Error ThreadNetif::RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination)
 {
     Error    error;
     uint16_t rloc;
 
-    SuccessOrExit(error = Get<NetworkData::Leader>().RouteLookup(aSource, aDestination, aPrefixMatch, &rloc));
+    SuccessOrExit(error = Get<NetworkData::Leader>().RouteLookup(aSource, aDestination, rloc));
 
     if (rloc == Get<Mle::MleRouter>().GetRloc16())
     {

--- a/src/core/thread/thread_netif.hpp
+++ b/src/core/thread/thread_netif.hpp
@@ -97,13 +97,12 @@ public:
      *
      * @param[in]   aSource       A reference to the IPv6 source address.
      * @param[in]   aDestination  A reference to the IPv6 destination address.
-     * @param[out]  aPrefixMatch  A pointer where the number of prefix match bits for the chosen route is stored.
      *
      * @retval kErrorNone      Successfully found a route.
      * @retval kErrorNoRoute   Could not find a valid route.
      *
      */
-    Error RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination, uint8_t *aPrefixMatch);
+    Error RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination);
 
     /**
      * This method indicates whether @p aAddress matches an on-mesh prefix.


### PR DESCRIPTION
This commit updates the `RouteLookup()` methods in `NetworkData` and `ThreadNetif`:
- Removes the unused `aPrefixMatchLength` parameter.
- Requires `aRloc` to be a reference instead of a pointer.