### PR TITLE
[netdata] add helper method to compare two BR entries

### DIFF
--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -288,6 +288,12 @@ private:
 
     void RemoveCommissioningData(void);
 
+    template <typename EntryType> int CompareRouteEntries(const EntryType &aFirst, const EntryType &aSecond) const;
+    int                               CompareRouteEntries(int8_t   aFirstPreference,
+                                                          uint16_t aFirstRloc,
+                                                          int8_t   aSecondPreference,
+                                                          uint16_t aSecondRloc) const;
+
     Error ExternalRouteLookup(uint8_t aDomainId, const Ip6::Address &aDestination, uint16_t &aRloc16) const;
     Error DefaultRouteLookup(const PrefixTlv &aPrefix, uint16_t &aRloc16) const;
     Error SteeringDataCheck(const FilterIndexes &aFilterIndexes) const;


### PR DESCRIPTION
This commit adds `CompareRouteEntries()` which performs a three-way comparison between two network data BR route entries:
- Entry with higher preference is selected first.
- If the same preference, prefer BR that is this device itself.
- If all same, prefer the one with lower mesh path cost.