### PR TITLE
[cli] fix `printf` style output

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -4620,7 +4620,7 @@ template <> otError Interpreter::Process<Cmd("pskcref")>(Arg aArgs[])
 
     if (aArgs[0].IsEmpty())
     {
-        OutputLine("0x%04x", otThreadGetPskcRef(GetInstancePtr()));
+        OutputLine("0x%08lx", ToUlong(otThreadGetPskcRef(GetInstancePtr())));
     }
     else
     {
@@ -5040,7 +5040,7 @@ template <> otError Interpreter::Process<Cmd("networkkeyref")>(Arg aArgs[])
 
     if (aArgs[0].IsEmpty())
     {
-        OutputLine("0x%04x", otThreadGetNetworkKeyRef(GetInstancePtr()));
+        OutputLine("0x%08lx", ToUlong(otThreadGetNetworkKeyRef(GetInstancePtr())));
     }
     else
     {


### PR DESCRIPTION
When `OPENTHREAD_CONFIG_PLATFORM_KEY_REFERENCES_ENABLE` is enabled.