### PR TITLE
[nat64] use DBus API for NAT64 tests

### DIFF
--- a/tests/scripts/thread-cert/border_router/nat64/test_single_border_router.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_single_border_router.py
@@ -193,13 +193,13 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         host_ip = self.get_host_ip()
         self.assertTrue(router.ping(ipaddr=host_ip))
 
-        mappings = br.get_nat64_mappings()
+        mappings = br.nat64_mappings
         self.assertEqual(mappings[0]['counters']['ICMP']['4to6']['packets'], 1)
         self.assertEqual(mappings[0]['counters']['ICMP']['6to4']['packets'], 1)
         self.assertEqual(mappings[0]['counters']['total']['4to6']['packets'], 1)
         self.assertEqual(mappings[0]['counters']['total']['6to4']['packets'], 1)
 
-        counters = br.get_nat64_counters()
+        counters = br.nat64_counters
         self.assertEqual(counters['protocol']['ICMP']['4to6']['packets'], 1)
         self.assertEqual(counters['protocol']['ICMP']['6to4']['packets'], 1)
 
@@ -212,9 +212,9 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
 
         sock.close()
 
-        counters = br.get_nat64_counters()
+        counters = br.nat64_counters
         self.assertEqual(counters['protocol']['UDP']['6to4']['packets'], 1)
-        mappings = br.get_nat64_mappings()
+        mappings = br.nat64_mappings
         self.assertEqual(mappings[0]['counters']['UDP']['6to4']['packets'], 1)
 
         # We should be able to get a IPv4 mapped IPv6 address.
@@ -223,13 +223,13 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
             ipv6.synthesize_ip6_address(ipaddress.IPv6Network(nat64_prefix), ipaddress.IPv4Address('203.0.113.1')))
         self.assertFalse(router.ping(ipaddr=mapped_ip6_address))
 
-        mappings = br.get_nat64_mappings()
+        mappings = br.nat64_mappings
         self.assertEqual(mappings[0]['counters']['ICMP']['4to6']['packets'], 1)
         self.assertEqual(mappings[0]['counters']['ICMP']['6to4']['packets'], 2)
         self.assertEqual(mappings[0]['counters']['total']['4to6']['packets'], 1)
         self.assertEqual(mappings[0]['counters']['total']['6to4']['packets'], 3)
 
-        counters = br.get_nat64_counters()
+        counters = br.nat64_counters
         self.assertEqual(counters['protocol']['ICMP']['4to6']['packets'], 1)
         self.assertEqual(counters['protocol']['ICMP']['6to4']['packets'], 2)
 

--- a/tests/scripts/thread-cert/call_dbus_method.py
+++ b/tests/scripts/thread-cert/call_dbus_method.py
@@ -34,7 +34,7 @@ import sys
 def main():
     args = sys.argv[1:]
     bus = dbus.SystemBus()
-    interface, method_name, arguments = args[0], args[1], args[2:]
+    interface, method_name, arguments = args[0], args[1], json.loads(args[2])
     obj = bus.get_object('io.openthread.BorderRouter.wpan0', '/io/openthread/BorderRouter/wpan0')
     iface = dbus.Interface(obj, interface)
     method = getattr(iface, method_name)


### PR DESCRIPTION
Replace the CLI commands used in NAT64 tests by DBus API introduced in openthread/ot-br-posix#1598

The functions:
- nat64_state
- nat64_mappings
- nat64_counters
- nat64_traffic_counters

Are simple wrappers for corresponding DBus methods and properties.