### PR TITLE
[crypto] extend ECDSA public key size

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (262)
+#define OPENTHREAD_API_VERSION (263)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/platform/crypto.h
+++ b/include/openthread/platform/crypto.h
@@ -185,12 +185,17 @@ typedef struct otPlatCryptoEcdsaKeyPair
  *
  * This struct represents a ECDSA public key.
  *
- * The public key is stored as a byte sequence representation of an uncompressed curve point (RFC 6605 - sec 4).
+ * The public key is stored differently depending on the crypto backend library being used
+ * (OPENTHREAD_CONFIG_CRYPTO_LIB):
+ * - By default, as a byte sequence representation of an uncompressed curve point (RFC 6605 - sec 4).
+ * - When ARM PSA crypto backend is enabled, as the uncompressed representation defined by SEC1 &sect;2.3.3 as the
+ * content of an ECPoint.
  *
  */
 OT_TOOL_PACKED_BEGIN
 struct otPlatCryptoEcdsaPublicKey
 {
+    uint8_t m04[1];
     uint8_t m8[OT_CRYPTO_ECDSA_PUBLIC_KEY_SIZE];
 } OT_TOOL_PACKED_END;
 

--- a/src/core/net/srp_client.cpp
+++ b/src/core/net/srp_client.cpp
@@ -1302,10 +1302,10 @@ Error Client::AppendKeyRecord(Message &aMessage, Info &aInfo) const
                  Dns::KeyRecord::kSignatoryFlagGeneral);
     key.SetProtocol(Dns::KeyRecord::kProtocolDnsSec);
     key.SetAlgorithm(Dns::KeyRecord::kAlgorithmEcdsaP256Sha256);
-    key.SetLength(sizeof(Dns::KeyRecord) - sizeof(Dns::ResourceRecord) + sizeof(Crypto::Ecdsa::P256::PublicKey));
+    key.SetLength(sizeof(Dns::KeyRecord) - sizeof(Dns::ResourceRecord) + Crypto::Ecdsa::P256::PublicKey::kSize);
     SuccessOrExit(error = aMessage.Append(key));
     SuccessOrExit(error = aInfo.mKeyPair.GetPublicKey(publicKey));
-    SuccessOrExit(error = aMessage.Append(publicKey));
+    SuccessOrExit(error = aMessage.Append(publicKey.m8));
     aInfo.mRecordCount++;
 
 exit:


### PR DESCRIPTION
`psa_export_public_key()` uses an extra initial byte (`0x04`) for storing the exported binary public key.

This commits adds an extra parameter to the public key struct to avoid intermediate buffers when handling `otPlatCryptoEcdsaGetPublicKey()`.