### PR TITLE
[cli] update `OutputSpaces()` to use literal format string

### DIFF
--- a/src/cli/cli_output.cpp
+++ b/src/cli/cli_output.cpp
@@ -111,11 +111,7 @@ void Output::OutputNewLine(void)
 
 void Output::OutputSpaces(uint8_t aCount)
 {
-    char format[sizeof("%256s")];
-
-    snprintf(format, sizeof(format), "%%%us", aCount);
-
-    OutputFormat(format, "");
+    OutputFormat("%*s", aCount, "");
 }
 
 void Output::OutputBytes(const uint8_t *aBytes, uint16_t aLength)


### PR DESCRIPTION
This commit updates `OutputSpaces()` to use literal format string. 

----

This should help address build-time checks which require string literal with `__attribute__((format(printf,x,y))` (related to `Werror=format-nonliteral`).
