### PR TITLE
[net-diags] include link quality in child table entry

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (279)
+#define OPENTHREAD_API_VERSION (280)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/netdiag.h
+++ b/include/openthread/netdiag.h
@@ -203,6 +203,14 @@ typedef struct otNetworkDiagChildEntry
     uint16_t mTimeout : 5;
 
     /**
+     * Link Quality In value in [0,3].
+     *
+     * Value 0 indicates that sender does not support the feature to provide link quality info.
+     *
+     */
+    uint8_t mLinkQuality : 2;
+
+    /**
      * Child ID from which an RLOC can be generated.
      */
     uint16_t mChildId : 9;

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -7202,6 +7202,7 @@ void Interpreter::OutputChildTableEntry(uint8_t aIndentSize, const otNetworkDiag
     OutputLine("ChildId: 0x%04x", aChildEntry.mChildId);
 
     OutputLine(aIndentSize, "Timeout: %u", aChildEntry.mTimeout);
+    OutputLine(aIndentSize, "Link Quality: %u", aChildEntry.mLinkQuality);
     OutputLine(aIndentSize, "Mode:");
     OutputMode(aIndentSize + kIndentSize, aChildEntry.mMode);
 }

--- a/src/core/thread/network_diagnostic.cpp
+++ b/src/core/thread/network_diagnostic.cpp
@@ -256,6 +256,7 @@ Error NetworkDiagnostic::AppendChildTable(Message &aMessage)
 
         entry.Clear();
         entry.SetTimeout(timeout + 4);
+        entry.SetLinkQuality(child.GetLinkQualityIn());
         entry.SetChildId(Mle::ChildIdFromRloc16(child.GetRloc16()));
         entry.SetMode(child.GetDeviceMode());
 
@@ -780,8 +781,9 @@ Error NetworkDiagnostic::GetNextDiagTlv(const Coap::Message &aMessage, Iterator 
 
                 SuccessOrExit(error = aMessage.Read(valueOffset, entry));
 
-                childInfo->mTimeout = entry.GetTimeout();
-                childInfo->mChildId = entry.GetChildId();
+                childInfo->mTimeout     = entry.GetTimeout();
+                childInfo->mLinkQuality = entry.GetLinkQuality();
+                childInfo->mChildId     = entry.GetChildId();
                 entry.GetMode().Get(childInfo->mMode);
 
                 childCount++;

--- a/src/core/thread/network_diagnostic_tlvs.hpp
+++ b/src/core/thread/network_diagnostic_tlvs.hpp
@@ -45,6 +45,7 @@
 #include "common/tlvs.hpp"
 #include "net/ip6_address.hpp"
 #include "radio/radio.hpp"
+#include "thread/link_quality.hpp"
 #include "thread/mle_tlvs.hpp"
 #include "thread/mle_types.hpp"
 
@@ -468,6 +469,28 @@ public:
     }
 
     /**
+     * This method the Link Quality value.
+     *
+     * @returns The Link Quality value.
+     *
+     */
+    LinkQuality GetLinkQuality(void) const
+    {
+        return static_cast<LinkQuality>((GetTimeoutChildId() & kLqiMask) >> kLqiOffset);
+    }
+
+    /**
+     * This method set the Link Quality value.
+     *
+     * @param[in] aLinkQuality  The Link Quality value.
+     *
+     */
+    void SetLinkQuality(LinkQuality aLinkQuality)
+    {
+        SetTimeoutChildId((GetTimeoutChildId() & ~kLqiMask) | ((aLinkQuality << kLqiOffset) & kLqiMask));
+    }
+
+    /**
      * This method returns the Child ID value.
      *
      * @returns The Child ID value.
@@ -506,12 +529,14 @@ private:
     //             1                   0
     //   5 4 3 2 1 0 9 8 7 6 5 4 3 2 1 0
     //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
-    //  | Timeout |RSV|     Child ID    |
+    //  | Timeout |LQI|     Child ID    |
     //  +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
 
     static constexpr uint8_t  kTimeoutOffset = 11;
+    static constexpr uint8_t  kLqiOffset     = 9;
     static constexpr uint8_t  kChildIdOffset = 0;
     static constexpr uint16_t kTimeoutMask   = 0x1f << kTimeoutOffset;
+    static constexpr uint16_t kLqiMask       = 0x3 << kLqiOffset;
     static constexpr uint16_t kChildIdMask   = 0x1ff << kChildIdOffset;
 
     uint16_t GetTimeoutChildId(void) const { return HostSwap16(mTimeoutChildId); }


### PR DESCRIPTION
This commit updates the `ChildTableEntry` which is included in Network Diagnostic "Child Table TLV" to also provide the Link Quality In info for the child (using the unused two-bit field in the existing entry format).

-----

This is prototype PR as a proposal to update TLV entry definition in Thread spec.
Related to [SPEC-1128](https://threadgroup.atlassian.net/browse/SPEC-1128)