### PR TITLE
[meshcop] simplify `StateTlv`

### DIFF
--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -322,13 +322,13 @@ void DatasetManager::HandleMgmtSetResponse(Coap::Message *aMessage, const Ip6::M
 {
     OT_UNUSED_VARIABLE(aMessageInfo);
 
-    Error    error;
-    StateTlv stateTlv;
+    Error   error;
+    uint8_t state;
 
     SuccessOrExit(error = aError);
-    VerifyOrExit(Tlv::FindTlv(*aMessage, stateTlv) == kErrorNone, error = kErrorParse);
+    VerifyOrExit(Tlv::Find<StateTlv>(*aMessage, state) == kErrorNone, error = kErrorParse);
 
-    switch (stateTlv.GetState())
+    switch (state)
     {
     case StateTlv::kReject:
         error = kErrorRejected;

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -1061,28 +1061,10 @@ private:
  * This class implements State TLV generation and parsing.
  *
  */
-OT_TOOL_PACKED_BEGIN
-class StateTlv : public Tlv, public UintTlvInfo<Tlv::kState, uint8_t>
+class StateTlv : public UintTlvInfo<Tlv::kState, uint8_t>
 {
 public:
-    /**
-     * This method initializes the TLV.
-     *
-     */
-    void Init(void)
-    {
-        SetType(kState);
-        SetLength(sizeof(*this) - sizeof(Tlv));
-    }
-
-    /**
-     * This method indicates whether or not the TLV appears to be well-formed.
-     *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     *
-     */
-    bool IsValid(void) const { return GetLength() >= sizeof(*this) - sizeof(Tlv); }
+    StateTlv(void) = delete;
 
     /**
      * State values.
@@ -1094,26 +1076,7 @@ public:
         kPending = 0,    ///< Pending
         kAccept  = 1,    ///< Accept
     };
-
-    /**
-     * This method returns the State value.
-     *
-     * @returns The State value.
-     *
-     */
-    State GetState(void) const { return static_cast<State>(mState); }
-
-    /**
-     * This method sets the State value.
-     *
-     * @param[in]  aState  The State value.
-     *
-     */
-    void SetState(State aState) { mState = static_cast<uint8_t>(aState); }
-
-private:
-    uint8_t mState;
-} OT_TOOL_PACKED_END;
+};
 
 /**
  * This class implements Joiner UDP Port TLV generation and parsing.


### PR DESCRIPTION
This commit simplifies `StateTlv` and updates the reading of TLV in `DatasetManager::HandleMgmtSetResponse()` (which could previously allow a TLV with empty value).