### PR TITLE
[mle] use `Tlv::FindTlvValueOffset()` instead of `FindTlvOffset()`

### DIFF
--- a/src/core/meshcop/dataset.cpp
+++ b/src/core/meshcop/dataset.cpp
@@ -436,9 +436,11 @@ Error Dataset::SetTlv(const Tlv &aTlv)
     return SetTlv(aTlv.GetType(), aTlv.GetValue(), aTlv.GetLength());
 }
 
-Error Dataset::ReadFromMessage(const Message &aMessage, uint16_t aOffset, uint8_t aLength)
+Error Dataset::ReadFromMessage(const Message &aMessage, uint16_t aOffset, uint16_t aLength)
 {
     Error error = kErrorParse;
+
+    VerifyOrExit(aLength <= kMaxSize);
 
     SuccessOrExit(aMessage.Read(aOffset, mTlvs, aLength));
     mLength = aLength;

--- a/src/core/meshcop/dataset.hpp
+++ b/src/core/meshcop/dataset.hpp
@@ -795,7 +795,7 @@ public:
      * @retval kErrorParse   Could not read or parse the dataset from @p aMessage.
      *
      */
-    Error ReadFromMessage(const Message &aMessage, uint16_t aOffset, uint8_t aLength);
+    Error ReadFromMessage(const Message &aMessage, uint16_t aOffset, uint16_t aLength);
 
     /**
      * This method sets the Dataset using an existing Dataset.

--- a/src/core/meshcop/dataset_manager.cpp
+++ b/src/core/meshcop/dataset_manager.cpp
@@ -668,7 +668,7 @@ exit:
 Error ActiveDatasetManager::Save(const Timestamp &aTimestamp,
                                  const Message &  aMessage,
                                  uint16_t         aOffset,
-                                 uint8_t          aLength)
+                                 uint16_t         aLength)
 {
     Error   error = kErrorNone;
     Dataset dataset;
@@ -749,7 +749,7 @@ exit:
 Error PendingDatasetManager::Save(const Timestamp &aTimestamp,
                                   const Message &  aMessage,
                                   uint16_t         aOffset,
-                                  uint8_t          aLength)
+                                  uint16_t         aLength)
 {
     Error   error = kErrorNone;
     Dataset dataset;

--- a/src/core/meshcop/dataset_manager.hpp
+++ b/src/core/meshcop/dataset_manager.hpp
@@ -428,7 +428,7 @@ public:
      * @retval kErrorParse    Could not parse the Dataset from @p aMessage.
      *
      */
-    Error Save(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
+    Error Save(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint16_t aLength);
 
     /**
      * This method sets the Operational Dataset in non-volatile memory.
@@ -562,7 +562,7 @@ public:
      * @param[in]  aLength     The length of the Operational Dataset.
      *
      */
-    Error Save(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint8_t aLength);
+    Error Save(const Timestamp &aTimestamp, const Message &aMessage, uint16_t aOffset, uint16_t aLength);
 
     /**
      * This method saves the Operational Dataset in non-volatile memory.

--- a/src/core/thread/discover_scanner.cpp
+++ b/src/core/thread/discover_scanner.cpp
@@ -292,12 +292,12 @@ void DiscoverScanner::HandleDiscoveryResponse(Mle::RxInfo &aRxInfo) const
 {
     Error                         error    = kErrorNone;
     const ThreadLinkInfo *        linkInfo = aRxInfo.mMessageInfo.GetThreadLinkInfo();
-    Tlv                           tlv;
     MeshCoP::Tlv                  meshcopTlv;
     MeshCoP::DiscoveryResponseTlv discoveryResponse;
     MeshCoP::NetworkNameTlv       networkName;
     ScanResult                    result;
     uint16_t                      offset;
+    uint16_t                      length;
     uint16_t                      end;
     bool                          didCheckSteeringData = false;
 
@@ -306,11 +306,8 @@ void DiscoverScanner::HandleDiscoveryResponse(Mle::RxInfo &aRxInfo) const
     VerifyOrExit(mState == kStateScanning, error = kErrorDrop);
 
     // Find MLE Discovery TLV
-    VerifyOrExit(Tlv::FindTlvOffset(aRxInfo.mMessage, Tlv::kDiscovery, offset) == kErrorNone, error = kErrorParse);
-    IgnoreError(aRxInfo.mMessage.Read(offset, tlv));
-
-    offset += sizeof(tlv);
-    end = offset + tlv.GetLength();
+    SuccessOrExit(error = Tlv::FindTlvValueOffset(aRxInfo.mMessage, Tlv::kDiscovery, offset, length));
+    end = offset + length;
 
     memset(&result, 0, sizeof(result));
     result.mDiscover = true;

--- a/src/core/thread/mle_router.hpp
+++ b/src/core/thread/mle_router.hpp
@@ -629,7 +629,7 @@ private:
     void  SetStateLeader(uint16_t aRloc16, LeaderStartMode aStartMode);
     void  StopLeader(void);
     void  SynchronizeChildNetworkData(void);
-    Error UpdateChildAddresses(const Message &aMessage, uint16_t aOffset, Child &aChild);
+    Error UpdateChildAddresses(const Message &aMessage, uint16_t aOffset, uint16_t aLength, Child &aChild);
     void  UpdateRoutes(const RouteTlv &aRoute, uint8_t aRouterId);
     bool  UpdateLinkQualityOut(const RouteTlv &aRoute, Router &aNeighbor, bool &aResetAdvInterval);
     bool  HasNeighborWithGoodLinkQuality(void) const;

--- a/src/core/thread/network_data_leader.cpp
+++ b/src/core/thread/network_data_leader.cpp
@@ -389,18 +389,15 @@ Error LeaderBase::SetNetworkData(uint8_t        aVersion,
                                  uint8_t        aStableVersion,
                                  Type           aType,
                                  const Message &aMessage,
-                                 uint16_t       aMessageOffset)
+                                 uint16_t       aOffset,
+                                 uint16_t       aLength)
 {
-    Error    error = kErrorNone;
-    Mle::Tlv tlv;
-    uint16_t length;
+    Error error = kErrorNone;
 
-    SuccessOrExit(error = aMessage.Read(aMessageOffset, tlv));
+    VerifyOrExit(aLength <= kMaxSize, error = kErrorParse);
+    SuccessOrExit(error = aMessage.Read(aOffset, GetBytes(), aLength));
 
-    length = aMessage.ReadBytes(aMessageOffset + sizeof(tlv), GetBytes(), tlv.GetLength());
-    VerifyOrExit(length == tlv.GetLength(), error = kErrorParse);
-
-    SetLength(tlv.GetLength());
+    SetLength(static_cast<uint8_t>(aLength));
     mVersion       = aVersion;
     mStableVersion = aStableVersion;
 

--- a/src/core/thread/network_data_leader.hpp
+++ b/src/core/thread/network_data_leader.hpp
@@ -143,23 +143,25 @@ public:
     Error RouteLookup(const Ip6::Address &aSource, const Ip6::Address &aDestination, uint16_t &aRloc16) const;
 
     /**
-     * This method is used by non-Leader devices to set newly received Network Data from the Leader.
+     * This method is used by non-Leader devices to set Network Data by reading it from a message from Leader.
      *
      * @param[in]  aVersion        The Version value.
      * @param[in]  aStableVersion  The Stable Version value.
      * @param[in]  aType           The Network Data type to set, the full set or stable subset.
-     * @param[in]  aMessage        A reference to the MLE message.
-     * @param[in]  aMessageOffset  The offset in @p aMessage for the Network Data TLV.
+     * @param[in]  aMessage        A reference to the message.
+     * @param[in]  aOffset         The offset in @p aMessage pointing to start of Network Data.
+     * @param[in]  aLength         The length of Network Data.
      *
      * @retval kErrorNone   Successfully set the network data.
-     * @retval kErrorParse  Network Data TLV in @p aMessage is not valid.
+     * @retval kErrorParse  Network Data in @p aMessage is not valid.
      *
      */
     Error SetNetworkData(uint8_t        aVersion,
                          uint8_t        aStableVersion,
                          Type           aType,
                          const Message &aMessage,
-                         uint16_t       aMessageOffset);
+                         uint16_t       aOffset,
+                         uint16_t       aLength);
 
     /**
      * This method returns a pointer to the Commissioning Data.

--- a/tests/unit/test_lowpan.cpp
+++ b/tests/unit/test_lowpan.cpp
@@ -129,7 +129,8 @@ static void Init(void)
 
     SuccessOrQuit(message->AppendBytes(mockNetworkData, sizeof(mockNetworkData)));
 
-    IgnoreError(sInstance->Get<NetworkData::Leader>().SetNetworkData(0, 0, NetworkData::kStableSubset, *message, 0));
+    IgnoreError(
+        sInstance->Get<NetworkData::Leader>().SetNetworkData(0, 0, NetworkData::kStableSubset, *message, 2, 0x20));
 }
 
 /**


### PR DESCRIPTION
This commit updates `Mle` modules to use `FindTlvValueOffset()` instead of `FindTlvOffset()` when trying to find a variable length TLV (e.g., Network Data TLV or Address Registration TLV). This helps simplify the code (we avoid reading the TLV again and can directly read and process the TLV's value).

----

The goal is later to remove `Tlv::FindTlvOffset()`.