### PR TITLE
[tlv] helper methods to read/find/append TLVs with UTF8 string value

### DIFF
--- a/src/core/backbone_router/bbr_manager.cpp
+++ b/src/core/backbone_router/bbr_manager.cpp
@@ -664,11 +664,8 @@ Error Manager::SendBackboneAnswer(const Ip6::Address &            aDstAddr,
 
     SuccessOrExit(error = Tlv::Append<ThreadLastTransactionTimeTlv>(*message, aTimeSinceLastTransaction));
 
-    {
-        const MeshCoP::NameData nameData = Get<MeshCoP::NetworkNameManager>().GetNetworkName().GetAsData();
-
-        SuccessOrExit(error = Tlv::Append<ThreadNetworkNameTlv>(*message, nameData.GetBuffer(), nameData.GetLength()));
-    }
+    SuccessOrExit(error = Tlv::Append<ThreadNetworkNameTlv>(
+                      *message, Get<MeshCoP::NetworkNameManager>().GetNetworkName().GetAsCString()));
 
     if (aSrcRloc16 != Mac::kShortAddrInvalid)
     {

--- a/src/core/meshcop/joiner.cpp
+++ b/src/core/meshcop/joiner.cpp
@@ -434,11 +434,7 @@ Error Joiner::PrepareJoinerFinalizeMessage(const char *aProvisioningUrl,
                                            const char *aVendorData)
 {
     Error                 error = kErrorNone;
-    VendorNameTlv         vendorNameTlv;
-    VendorModelTlv        vendorModelTlv;
-    VendorSwVersionTlv    vendorSwVersionTlv;
     VendorStackVersionTlv vendorStackVersionTlv;
-    ProvisioningUrlTlv    provisioningUrlTlv;
 
     mFinalizeMessage = Get<Tmf::SecureAgent>().NewPriorityConfirmablePostMessage(kUriJoinerFinalize);
     VerifyOrExit(mFinalizeMessage != nullptr, error = kErrorNoBufs);
@@ -447,17 +443,9 @@ Error Joiner::PrepareJoinerFinalizeMessage(const char *aProvisioningUrl,
 
     SuccessOrExit(error = Tlv::Append<StateTlv>(*mFinalizeMessage, StateTlv::kAccept));
 
-    vendorNameTlv.Init();
-    vendorNameTlv.SetVendorName(aVendorName);
-    SuccessOrExit(error = vendorNameTlv.AppendTo(*mFinalizeMessage));
-
-    vendorModelTlv.Init();
-    vendorModelTlv.SetVendorModel(aVendorModel);
-    SuccessOrExit(error = vendorModelTlv.AppendTo(*mFinalizeMessage));
-
-    vendorSwVersionTlv.Init();
-    vendorSwVersionTlv.SetVendorSwVersion(aVendorSwVersion);
-    SuccessOrExit(error = vendorSwVersionTlv.AppendTo(*mFinalizeMessage));
+    SuccessOrExit(error = Tlv::Append<VendorNameTlv>(*mFinalizeMessage, aVendorName));
+    SuccessOrExit(error = Tlv::Append<VendorModelTlv>(*mFinalizeMessage, aVendorModel));
+    SuccessOrExit(error = Tlv::Append<VendorSwVersionTlv>(*mFinalizeMessage, aVendorSwVersion));
 
     vendorStackVersionTlv.Init();
     vendorStackVersionTlv.SetOui(OPENTHREAD_CONFIG_STACK_VENDOR_OUI);
@@ -468,18 +456,12 @@ Error Joiner::PrepareJoinerFinalizeMessage(const char *aProvisioningUrl,
 
     if (aVendorData != nullptr)
     {
-        VendorDataTlv vendorDataTlv;
-        vendorDataTlv.Init();
-        vendorDataTlv.SetVendorData(aVendorData);
-        SuccessOrExit(error = vendorDataTlv.AppendTo(*mFinalizeMessage));
+        SuccessOrExit(error = Tlv::Append<VendorDataTlv>(*mFinalizeMessage, aVendorData));
     }
 
-    provisioningUrlTlv.Init();
-    provisioningUrlTlv.SetProvisioningUrl(aProvisioningUrl);
-
-    if (provisioningUrlTlv.GetLength() > 0)
+    if (aProvisioningUrl != nullptr)
     {
-        SuccessOrExit(error = provisioningUrlTlv.AppendTo(*mFinalizeMessage));
+        SuccessOrExit(error = Tlv::Append<ProvisioningUrlTlv>(*mFinalizeMessage, aProvisioningUrl));
     }
 
 exit:

--- a/src/core/meshcop/meshcop_tlvs.hpp
+++ b/src/core/meshcop/meshcop_tlvs.hpp
@@ -121,6 +121,17 @@ public:
     };
 
     /**
+     * Max length of Provisioning URL TLV.
+     *
+     */
+    static constexpr uint8_t kMaxkProvisioningUrlLength = OT_PROVISIONING_URL_MAX_SIZE;
+
+    static constexpr uint8_t kMaxVendorNameLength      = 32; ///< Max length of Vendor Name TLV.
+    static constexpr uint8_t kMaxVendorModelLength     = 32; ///< Max length of Vendor Model TLV.
+    static constexpr uint8_t kMaxVendorSwVersionLength = 16; ///< Max length of Vendor SW Version TLV.
+    static constexpr uint8_t kMaxVendorDataLength      = 64; ///< Max length of Vendor Data TLV.
+
+    /**
      * This method returns the Type value.
      *
      * @returns The Type value.
@@ -1545,325 +1556,34 @@ private:
 } OT_TOOL_PACKED_END;
 
 /**
- * This class implements Provisioning URL TLV generation and parsing.
+ * This class defines Provisioning TLV constants and types.
  *
  */
-OT_TOOL_PACKED_BEGIN
-class ProvisioningUrlTlv : public Tlv, public TlvInfo<Tlv::kProvisioningUrl>
-{
-public:
-    /**
-     * Maximum number of chars in the Provisioning URL string.
-     *
-     */
-    static constexpr uint16_t kMaxLength = OT_PROVISIONING_URL_MAX_SIZE;
-
-    /**
-     * This method initializes the TLV.
-     *
-     */
-    void Init(void)
-    {
-        SetType(kProvisioningUrl);
-        SetLength(0);
-    }
-
-    /*
-     * This method returns the Provisioning URL length.
-     *
-     * @returns The Provisioning URL length.
-     *
-     */
-    uint8_t GetProvisioningUrlLength(void) const
-    {
-        return GetLength() <= sizeof(mProvisioningUrl) ? GetLength() : sizeof(mProvisioningUrl);
-    }
-
-    /**
-     * This method indicates whether or not the TLV appears to be well-formed.
-     *
-     * @retval TRUE   If the TLV appears to be well-formed.
-     * @retval FALSE  If the TLV does not appear to be well-formed.
-     *
-     */
-    bool IsValid(void) const
-    {
-        return GetType() == kProvisioningUrl && mProvisioningUrl[GetProvisioningUrlLength()] == '\0';
-    }
-
-    /**
-     * This method returns the Provisioning URL value.
-     *
-     * @returns The Provisioning URL value.
-     *
-     */
-    const char *GetProvisioningUrl(void) const { return mProvisioningUrl; }
-
-    /**
-     * This method sets the Provisioning URL value.
-     *
-     * @param[in]  aProvisioningUrl  A pointer to the Provisioning URL value.
-     *
-     */
-    void SetProvisioningUrl(const char *aProvisioningUrl)
-    {
-        uint16_t len = aProvisioningUrl ? StringLength(aProvisioningUrl, kMaxLength) : 0;
-
-        SetLength(static_cast<uint8_t>(len));
-
-        if (len > 0)
-        {
-            memcpy(mProvisioningUrl, aProvisioningUrl, len);
-        }
-    }
-
-private:
-    char mProvisioningUrl[kMaxLength];
-} OT_TOOL_PACKED_END;
+typedef StringTlvInfo<Tlv::kProvisioningUrl, Tlv::kMaxkProvisioningUrlLength> ProvisioningUrlTlv;
 
 /**
- * This class implements Vendor Name TLV generation and parsing.
+ * This class defines Vendor Name TLV constants and types.
  *
  */
-OT_TOOL_PACKED_BEGIN
-class VendorNameTlv : public Tlv, public TlvInfo<Tlv::kVendorName>
-{
-public:
-    /**
-     * This method initializes the TLV.
-     *
-     */
-    void Init(void)
-    {
-        SetType(kVendorName);
-        SetLength(0);
-    }
-
-    /**
-     * This method returns the Vendor Name length.
-     *
-     * @returns The Vendor Name length.
-     *
-     */
-    uint8_t GetVendorNameLength(void) const
-    {
-        return GetLength() <= sizeof(mVendorName) ? GetLength() : sizeof(mVendorName);
-    }
-
-    /**
-     * This method returns the Vendor Name value.
-     *
-     * @returns The Vendor Name value.
-     *
-     */
-    const char *GetVendorName(void) const { return mVendorName; }
-
-    /**
-     * This method sets the Vendor Name value.
-     *
-     * @param[in]  aVendorName  A pointer to the Vendor Name value.
-     *
-     */
-    void SetVendorName(const char *aVendorName)
-    {
-        uint16_t len = (aVendorName == nullptr) ? 0 : StringLength(aVendorName, sizeof(mVendorName));
-
-        SetLength(static_cast<uint8_t>(len));
-
-        if (len > 0)
-        {
-            memcpy(mVendorName, aVendorName, len);
-        }
-    }
-
-private:
-    static constexpr uint8_t kMaxLength = 32;
-
-    char mVendorName[kMaxLength];
-} OT_TOOL_PACKED_END;
+typedef StringTlvInfo<Tlv::kVendorName, Tlv::kMaxVendorNameLength> VendorNameTlv;
 
 /**
- * This class implements Vendor Model TLV generation and parsing.
+ * This class defines Vendor Model TLV constants and types.
  *
  */
-OT_TOOL_PACKED_BEGIN
-class VendorModelTlv : public Tlv, public TlvInfo<Tlv::kVendorModel>
-{
-public:
-    /**
-     * This method initializes the TLV.
-     *
-     */
-    void Init(void)
-    {
-        SetType(kVendorModel);
-        SetLength(0);
-    }
-
-    /**
-     * This method returns the Vendor Model length.
-     *
-     * @returns The Vendor Model length.
-     *
-     */
-    uint8_t GetVendorModelLength(void) const
-    {
-        return GetLength() <= sizeof(mVendorModel) ? GetLength() : sizeof(mVendorModel);
-    }
-
-    /**
-     * This method returns the Vendor Model value.
-     *
-     * @returns The Vendor Model value.
-     *
-     */
-    const char *GetVendorModel(void) const { return mVendorModel; }
-
-    /**
-     * This method sets the Vendor Model value.
-     *
-     * @param[in]  aVendorModel  A pointer to the Vendor Model value.
-     *
-     */
-    void SetVendorModel(const char *aVendorModel)
-    {
-        uint16_t len = (aVendorModel == nullptr) ? 0 : StringLength(aVendorModel, sizeof(mVendorModel));
-
-        SetLength(static_cast<uint8_t>(len));
-
-        if (len > 0)
-        {
-            memcpy(mVendorModel, aVendorModel, len);
-        }
-    }
-
-private:
-    static constexpr uint8_t kMaxLength = 32;
-
-    char mVendorModel[kMaxLength];
-} OT_TOOL_PACKED_END;
+typedef StringTlvInfo<Tlv::kVendorModel, Tlv::kMaxVendorModelLength> VendorModelTlv;
 
 /**
- * This class implements Vendor SW Version TLV generation and parsing.
+ * This class defines Vendor SW Version TLV constants and types.
  *
  */
-OT_TOOL_PACKED_BEGIN
-class VendorSwVersionTlv : public Tlv, public TlvInfo<Tlv::kVendorSwVersion>
-{
-public:
-    /**
-     * This method initializes the TLV.
-     *
-     */
-    void Init(void)
-    {
-        SetType(kVendorSwVersion);
-        SetLength(0);
-    }
-
-    /**
-     * This method returns the Vendor SW Version length.
-     *
-     * @returns The Vendor SW Version length.
-     *
-     */
-    uint8_t GetVendorSwVersionLength(void) const
-    {
-        return GetLength() <= sizeof(mVendorSwVersion) ? GetLength() : sizeof(mVendorSwVersion);
-    }
-
-    /**
-     * This method returns the Vendor SW Version value.
-     *
-     * @returns The Vendor SW Version value.
-     *
-     */
-    const char *GetVendorSwVersion(void) const { return mVendorSwVersion; }
-
-    /**
-     * This method sets the Vendor SW Version value.
-     *
-     * @param[in]  aVendorSwVersion  A pointer to the Vendor SW Version value.
-     *
-     */
-    void SetVendorSwVersion(const char *aVendorSwVersion)
-    {
-        uint16_t len = (aVendorSwVersion == nullptr) ? 0 : StringLength(aVendorSwVersion, sizeof(mVendorSwVersion));
-
-        SetLength(static_cast<uint8_t>(len));
-
-        if (len > 0)
-        {
-            memcpy(mVendorSwVersion, aVendorSwVersion, len);
-        }
-    }
-
-private:
-    static constexpr uint8_t kMaxLength = 16;
-
-    char mVendorSwVersion[kMaxLength];
-} OT_TOOL_PACKED_END;
+typedef StringTlvInfo<Tlv::kVendorSwVersion, Tlv::kMaxVendorSwVersionLength> VendorSwVersionTlv;
 
 /**
- * This class implements Vendor Data TLV generation and parsing.
+ * This class defines Vendor Data TLV constants and types.
  *
  */
-OT_TOOL_PACKED_BEGIN
-class VendorDataTlv : public Tlv, public TlvInfo<Tlv::kVendorData>
-{
-public:
-    /**
-     * This method initializes the TLV.
-     *
-     */
-    void Init(void)
-    {
-        SetType(kVendorData);
-        SetLength(0);
-    }
-
-    /**
-     * This method returns the Vendor Data length.
-     *
-     * @returns The Vendor Data length.
-     *
-     */
-    uint8_t GetVendorDataLength(void) const
-    {
-        return GetLength() <= sizeof(mVendorData) ? GetLength() : sizeof(mVendorData);
-    }
-
-    /**
-     * This method returns the Vendor Data value.
-     *
-     * @returns The Vendor Data value.
-     *
-     */
-    const char *GetVendorData(void) const { return mVendorData; }
-
-    /**
-     * This method sets the Vendor Data value.
-     *
-     * @param[in]  aVendorData  A pointer to the Vendor Data value.
-     *
-     */
-    void SetVendorData(const char *aVendorData)
-    {
-        uint16_t len = (aVendorData == nullptr) ? 0 : StringLength(aVendorData, sizeof(mVendorData));
-
-        SetLength(static_cast<uint8_t>(len));
-
-        if (len > 0)
-        {
-            memcpy(mVendorData, aVendorData, len);
-        }
-    }
-
-private:
-    static constexpr uint8_t kMaxLength = 64;
-
-    char mVendorData[kMaxLength];
-} OT_TOOL_PACKED_END;
+typedef StringTlvInfo<Tlv::kVendorData, Tlv::kMaxVendorDataLength> VendorDataTlv;
 
 /**
  * This class implements Vendor Stack Version TLV generation and parsing.

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -39,6 +39,7 @@
 #include "common/encoding.hpp"
 #include "common/message.hpp"
 #include "common/tlvs.hpp"
+#include "meshcop/network_name.hpp"
 #include "net/ip6_address.hpp"
 #include "thread/mle.hpp"
 #include "thread/mle_types.hpp"
@@ -136,7 +137,7 @@ typedef UintTlvInfo<ThreadTlv::kTimeout, uint32_t> ThreadTimeoutTlv;
  * This class defines Network Name TLV constants and types.
  *
  */
-typedef TlvInfo<ThreadTlv::kNetworkName> ThreadNetworkNameTlv;
+typedef StringTlvInfo<ThreadTlv::kNetworkName, MeshCoP::NetworkName::kMaxSize> ThreadNetworkNameTlv;
 
 /**
  * This class defines Commissioner Session ID TLV constants and types.


### PR DESCRIPTION
This commit adds new methods in `Tlv` to read, find, or append simple TLVs with a UTF8 string value. `StringTlvInfo<Type, kMaxStringLen>` can be used to define constants and types for such TLVs. This helps simplify implementation of many such TLVs, e.g., Vendor Name TLV, Provisioning URL TLV, Network Name TLV, etc.