### PR TITLE
[tlv] add private helper methods to parse and find TLVs in a message

### DIFF
--- a/src/core/common/tlvs.hpp
+++ b/src/core/common/tlvs.hpp
@@ -501,8 +501,18 @@ protected:
     static const uint8_t kExtendedLength = 255; // Extended Length value.
 
 private:
-    static Error ReadTlv(const Message &aMessage, uint16_t aOffset, uint16_t &aLength, uint16_t &aValueOffset);
-    static Error Find(const Message &aMessage, uint8_t aType, uint16_t *aOffset, uint16_t *aSize, bool *aIsExtendedTlv);
+    struct ParsedInfo
+    {
+        Error ParseFrom(const Message &aMessage, uint16_t aOffset);
+        Error FindIn(const Message &aMessage, uint8_t aType);
+
+        uint8_t  mType;
+        uint16_t mLength;
+        uint16_t mOffset;
+        uint16_t mValueOffset;
+        uint16_t mSize;
+    };
+
     static Error FindTlv(const Message &aMessage, uint8_t aType, void *aValue, uint8_t aLength);
     static Error AppendTlv(Message &aMessage, uint8_t aType, const void *aValue, uint8_t aLength);
     static Error ReadStringTlv(const Message &aMessage, uint16_t aOffset, uint8_t aMaxStringLength, char *aValue);

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1001,3 +1001,24 @@ target_link_libraries(ot-test-timer
 )
 
 add_test(NAME ot-test-timer COMMAND ot-test-timer)
+
+add_executable(ot-test-tlv
+    test_tlv.cpp
+)
+
+target_include_directories(ot-test-tlv
+    PRIVATE
+        ${COMMON_INCLUDES}
+)
+
+target_compile_options(ot-test-tlv
+    PRIVATE
+        ${COMMON_COMPILE_OPTIONS}
+)
+
+target_link_libraries(ot-test-tlv
+    PRIVATE
+        ${COMMON_LIBS}
+)
+
+add_test(NAME ot-test-tlv COMMAND ot-test-tlv)

--- a/tests/unit/Makefile.am
+++ b/tests/unit/Makefile.am
@@ -155,6 +155,7 @@ check_PROGRAMS                                                     += \
     ot-test-srp-server                                                \
     ot-test-string                                                    \
     ot-test-timer                                                     \
+    ot-test-tlv                                                       \
     $(NULL)
 
 if OPENTHREAD_ENABLE_NCP
@@ -386,6 +387,10 @@ ot_test_spinel_encoder_SOURCES      = $(COMMON_SOURCES) test_spinel_encoder.cpp
 ot_test_timer_LDADD                 = $(COMMON_LDADD)
 ot_test_timer_LIBTOOLFLAGS          = $(COMMON_LIBTOOLFLAGS)
 ot_test_timer_SOURCES               = $(COMMON_SOURCES) test_timer.cpp
+
+ot_test_tlv_LDADD                   = $(COMMON_LDADD)
+ot_test_tlv_LIBTOOLFLAGS            = $(COMMON_LIBTOOLFLAGS)
+ot_test_tlv_SOURCES                 = $(COMMON_SOURCES) test_tlv.cpp
 
 ot_test_toolchain_LDADD             = $(NULL)
 ot_test_toolchain_SOURCES           = test_toolchain.cpp test_toolchain_c.c

--- a/tests/unit/test_tlv.cpp
+++ b/tests/unit/test_tlv.cpp
@@ -1,0 +1,194 @@
+/*
+ *  Copyright (c) 2022, The OpenThread Authors.
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *  1. Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *  2. Redistributions in binary form must reproduce the above copyright
+ *     notice, this list of conditions and the following disclaimer in the
+ *     documentation and/or other materials provided with the distribution.
+ *  3. Neither the name of the copyright holder nor the
+ *     names of its contributors may be used to endorse or promote products
+ *     derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ *  AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ *  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ *  ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+ *  LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ *  CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ *  SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ *  INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ *  CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ *  ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "test_platform.h"
+
+#include <openthread/config.h>
+
+#include "common/instance.hpp"
+#include "common/message.hpp"
+#include "common/tlvs.hpp"
+
+#include "test_util.h"
+
+namespace ot {
+
+void TestTlv(void)
+{
+    Instance *  instance = testInitInstance();
+    Message *   message;
+    Tlv         tlv;
+    ExtendedTlv extTlv;
+    uint16_t    offset;
+    uint16_t    valueOffset;
+    uint16_t    length;
+    uint8_t     buffer[4];
+
+    VerifyOrQuit(instance != nullptr);
+
+    VerifyOrQuit((message = instance->Get<MessagePool>().Allocate(Message::kTypeIp6)) != nullptr);
+    VerifyOrQuit(message != nullptr);
+
+    VerifyOrQuit(message->GetOffset() == 0);
+    VerifyOrQuit(message->GetLength() == 0);
+
+    VerifyOrQuit(Tlv::FindTlvValueOffset(*message, /* aType */ 1, valueOffset, length) == kErrorNotFound);
+    VerifyOrQuit(Tlv::ReadTlvValue(*message, 0, buffer, 1) == kErrorParse);
+
+    // Add an empty TLV with type 1 and check that we can find it
+
+    offset = message->GetLength();
+
+    tlv.SetType(1);
+    tlv.SetLength(0);
+    SuccessOrQuit(message->Append(tlv));
+
+    SuccessOrQuit(Tlv::FindTlvValueOffset(*message, /* aType */ 1, valueOffset, length));
+    VerifyOrQuit(valueOffset == sizeof(Tlv));
+    VerifyOrQuit(length == 0);
+    SuccessOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 0));
+    VerifyOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 1) == kErrorParse);
+
+    // Add an empty extended TLV (type 2), and check that we can find it.
+
+    offset = message->GetLength();
+
+    extTlv.SetType(2);
+    extTlv.SetLength(0);
+    SuccessOrQuit(message->Append(extTlv));
+
+    SuccessOrQuit(Tlv::FindTlvValueOffset(*message, /* aType */ 2, valueOffset, length));
+    VerifyOrQuit(valueOffset == offset + sizeof(ExtendedTlv));
+    VerifyOrQuit(length == 0);
+    SuccessOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 0));
+    VerifyOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 1) == kErrorParse);
+
+    // Add a TLV with type 3 with one byte value and check if we can find it.
+
+    offset = message->GetLength();
+
+    tlv.SetType(3);
+    tlv.SetLength(1);
+    SuccessOrQuit(message->Append(tlv));
+    SuccessOrQuit(message->Append<uint8_t>(0xff));
+
+    SuccessOrQuit(Tlv::FindTlvValueOffset(*message, /* aType */ 3, valueOffset, length));
+    VerifyOrQuit(valueOffset == offset + sizeof(Tlv));
+    VerifyOrQuit(length == 1);
+    SuccessOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 1));
+    VerifyOrQuit(buffer[0] == 0x0ff);
+    VerifyOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 2) == kErrorParse);
+
+    // Add an extended TLV with type 4 with two byte value and check if we can find it.
+
+    offset = message->GetLength();
+
+    extTlv.SetType(4);
+    extTlv.SetLength(2);
+    SuccessOrQuit(message->Append(extTlv));
+    SuccessOrQuit(message->Append<uint8_t>(0x12));
+    SuccessOrQuit(message->Append<uint8_t>(0x34));
+
+    SuccessOrQuit(Tlv::FindTlvValueOffset(*message, /* aType */ 4, valueOffset, length));
+    VerifyOrQuit(valueOffset == offset + sizeof(ExtendedTlv));
+    VerifyOrQuit(length == 2);
+    SuccessOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 1));
+    VerifyOrQuit(buffer[0] == 0x12);
+    SuccessOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 2));
+    VerifyOrQuit(buffer[0] == 0x12);
+    VerifyOrQuit(buffer[1] == 0x34);
+    VerifyOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 3) == kErrorParse);
+
+    // Add a TLV with missing value.
+
+    offset = message->GetLength();
+
+    tlv.SetType(5);
+    tlv.SetLength(1);
+    SuccessOrQuit(message->Append(tlv));
+
+    VerifyOrQuit(Tlv::FindTlvValueOffset(*message, /* aType */ 5, valueOffset, length) != kErrorNone);
+    VerifyOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 0) == kErrorParse);
+
+    // Add the missing value.
+    SuccessOrQuit(message->Append<uint8_t>(0xaa));
+
+    SuccessOrQuit(Tlv::FindTlvValueOffset(*message, /* aType */ 5, valueOffset, length));
+    VerifyOrQuit(valueOffset == offset + sizeof(Tlv));
+    VerifyOrQuit(length == 1);
+    SuccessOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 1));
+    VerifyOrQuit(buffer[0] == 0xaa);
+    VerifyOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 2) == kErrorParse);
+
+    // Add an extended TLV with missing value.
+
+    offset = message->GetLength();
+
+    extTlv.SetType(6);
+    extTlv.SetLength(2);
+    SuccessOrQuit(message->Append(extTlv));
+    SuccessOrQuit(message->Append<uint8_t>(0xbb));
+
+    VerifyOrQuit(Tlv::FindTlvValueOffset(*message, /* aType */ 6, valueOffset, length) != kErrorNone);
+    VerifyOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 1) == kErrorParse);
+
+    SuccessOrQuit(message->Append<uint8_t>(0xcc));
+
+    SuccessOrQuit(Tlv::FindTlvValueOffset(*message, /* aType */ 6, valueOffset, length) != kErrorNone);
+    VerifyOrQuit(valueOffset == offset + sizeof(ExtendedTlv));
+    VerifyOrQuit(length == 2);
+    SuccessOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 2));
+    VerifyOrQuit(buffer[0] == 0xbb);
+    VerifyOrQuit(buffer[1] == 0xcc);
+    VerifyOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 3) == kErrorParse);
+
+    // Add an extended TLV with overflow length.
+
+    offset = message->GetLength();
+
+    extTlv.SetType(7);
+    extTlv.SetLength(0xffff);
+    SuccessOrQuit(message->Append(extTlv));
+    SuccessOrQuit(message->Append<uint8_t>(0x11));
+
+    VerifyOrQuit(Tlv::FindTlvValueOffset(*message, /* aType */ 7, valueOffset, length) != kErrorNone);
+    VerifyOrQuit(Tlv::ReadTlvValue(*message, offset, buffer, 1) == kErrorParse);
+
+    message->Free();
+
+    testFreeInstance(instance);
+}
+
+} // namespace ot
+
+int main(void)
+{
+    ot::TestTlv();
+    printf("All tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
This commit adds new private type `ParsedInfo` in `Tlv` class which contains parsed TLV info such as TLV type, length, size, value offset. This class provides `ParseFrom()` and `FindIn()` methods to parse or find a TLV from a message.

This commit also adds a unit test `test_tlv` to validate the TLV methods.