### PR TITLE
[router-table] remove duplicate method

### DIFF
--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1406,7 +1406,7 @@ Error MleRouter::HandleAdvertisement(RxInfo &aRxInfo)
             VerifyOrExit(router != nullptr);
 
             if (IsFullThreadDevice() && !router->IsStateValid() && !router->IsStateLinkRequest() &&
-                (mRouterTable.GetActiveLinkCount() < OPENTHREAD_CONFIG_MLE_CHILD_ROUTER_LINKS))
+                (mRouterTable.GetNeighborCount() < OPENTHREAD_CONFIG_MLE_CHILD_ROUTER_LINKS))
             {
                 router->SetExtAddress(extAddr);
                 router->GetLinkInfo().Clear();

--- a/src/core/thread/router_table.cpp
+++ b/src/core/thread/router_table.cpp
@@ -342,21 +342,6 @@ void RouterTable::RemoveRouterLink(Router &aRouter)
     }
 }
 
-uint8_t RouterTable::GetActiveLinkCount(void) const
-{
-    uint8_t activeLinks = 0;
-
-    for (const Router *router = GetFirstEntry(); router != nullptr; router = GetNextEntry(router))
-    {
-        if (router->IsStateValid())
-        {
-            activeLinks++;
-        }
-    }
-
-    return activeLinks;
-}
-
 const Router *RouterTable::FindRouter(const Router::AddressMatcher &aMatcher) const
 {
     const Router *router;

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -148,14 +148,6 @@ public:
     uint8_t GetActiveRouterCount(void) const { return mActiveRouterCount; }
 
     /**
-     * This method returns the number of active links with neighboring routers.
-     *
-     * @returns The number of active links with neighboring routers.
-     *
-     */
-    uint8_t GetActiveLinkCount(void) const;
-
-    /**
      * This method returns the leader in the Thread network.
      *
      * @returns A pointer to the Leader in the Thread network.


### PR DESCRIPTION
This commit removes `RouterTable::GetActiveLinkCount()` and uses `GetNeighborCount()` instead (which does the same).

