### PR TITLE
[routing-manager] ensure local prefix is changed on xpanid change

### DIFF
--- a/tests/unit/test_routing_manager.cpp
+++ b/tests/unit/test_routing_manager.cpp
@@ -829,7 +829,7 @@ void VerifyPrefixTable(const OnLinkPrefix *aOnLinkPrefixes,
     VerifyOrQuit(routePrefixCount == aNumRoutePrefixes);
 }
 
-void InitTest(void)
+void InitTest(bool aEnablBorderRouting = false)
 {
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Initialize OT instance.
@@ -843,13 +843,14 @@ void InitTest(void)
     SuccessOrQuit(sInfraIfAddress.FromString(kInfraIfAddress));
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    // Initialize Border Router and start Thread operation.
+    // Initialize and start Border Router and Thread operation.
 
     SuccessOrQuit(otBorderRoutingInit(sInstance, kInfraIfIndex, /* aInfraIfIsRunning */ true));
 
     SuccessOrQuit(otLinkSetPanId(sInstance, 0x1234));
     SuccessOrQuit(otIp6SetEnabled(sInstance, true));
     SuccessOrQuit(otThreadSetEnabled(sInstance, true));
+    SuccessOrQuit(otBorderRoutingSetEnabled(sInstance, aEnablBorderRouting));
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
     // Ensure device starts as leader.
@@ -2514,17 +2515,15 @@ void TestSavedOnLinkPrefixes(void)
     Log("--------------------------------------------------------------------------------------------");
     Log("TestSavedOnLinkPrefixes");
 
-    InitTest();
+    InitTest(/* aEnablBorderRouting */ true);
 
     //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    // Start Routing Manager. Check emitted RS and RA messages.
+    // Check emitted RS and RA messages.
 
     sRsEmitted   = false;
     sRaValidated = false;
     sExpectedPio = kPioAdvertisingLocalOnLink;
     sExpectedRios.Clear();
-
-    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(true));
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().GetOnLinkPrefix(localOnLink));
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().GetOmrPrefix(localOmr));
@@ -2553,10 +2552,7 @@ void TestSavedOnLinkPrefixes(void)
 
     testFreeInstance(sInstance);
 
-    InitTest();
-
-    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    // Start Routing Manager.
+    InitTest(/* aEnablBorderRouting */ true);
 
     SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(true));
 
@@ -2594,12 +2590,7 @@ void TestSavedOnLinkPrefixes(void)
 
     testFreeInstance(sInstance);
 
-    InitTest();
-
-    //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
-    // Start Routing Manager.
-
-    SuccessOrQuit(sInstance->Get<BorderRouter::RoutingManager>().SetEnabled(true));
+    InitTest(/* aEnablBorderRouting */ true);
 
     sExpectedPio = kPioAdvertisingLocalOnLink;
 


### PR DESCRIPTION
This commit updates `RoutingManager` to check if a change to xpanid does impact the generated local on-link prefix. This can address two situations: (1) when BR is started before Thread/MLE operation where we can get a signal that xpanid is changed on MLE start (without it actually changing), (2) if the xpanid does change but since not all the xpanid bytes are used in the derivation of the local prefix, it can remain as before.

This commit also updates the unit test to start the BR early (along with MLE operation) under the `TestSavedOnLinkPrefixes()` case.