### PR TITLE
[build] include `OPENTHREAD_PROJECT_ANDROID_MK` earlier in `Android.mk`

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -104,6 +104,10 @@ OPENTHREAD_PUBLIC_CFLAGS                                         += \
     $(NULL)
 endif
 
+ifneq ($(OPENTHREAD_PROJECT_ANDROID_MK),)
+include $(OPENTHREAD_PROJECT_ANDROID_MK)
+endif
+
 include $(CLEAR_VARS)
 
 LOCAL_MODULE := spi-hdlc-adapter
@@ -658,9 +662,5 @@ LOCAL_SRC_FILES := src/posix/client.cpp
 
 include $(BUILD_EXECUTABLE)
 endif # ($(USE_OTBR_DAEMON), 1)
-
-ifneq ($(OPENTHREAD_PROJECT_ANDROID_MK),)
-include $(OPENTHREAD_PROJECT_ANDROID_MK)
-endif
 
 endif # ($(OPENTHREAD_ENABLE_ANDROID_MK),1)


### PR DESCRIPTION
Sometimes a vendor may want to override the compile options in `openthread/Android.mk` in another file instead of `openthread/Android.mk`. This PR moves `include $(OPENTHREAD_PROJECT_ANDROID_MK)` higher in the file so that a vendor can override the OpenThread compile options in the `$(OPENTHREAD_PROJECT_ANDROID_MK)` file.