### PR TITLE
[cli] add `platform` command which returns current platform

### DIFF
--- a/src/cli/README.md
+++ b/src/cli/README.md
@@ -84,6 +84,7 @@ Done
 - [parentpriority](#parentpriority)
 - [partitionid](#partitionid)
 - [ping](#ping-async--i-source-ipaddr-size-count-interval-hoplimit-timeout)
+- [platform](#platform)
 - [pollperiod](#pollperiod-pollperiod)
 - [preferrouterid](#preferrouterid-routerid)
 - [prefix](#prefix)
@@ -2260,6 +2261,16 @@ Stop sending ICMPv6 Echo Requests.
 
 ```bash
 > ping stop
+Done
+```
+
+### platform
+
+Print the current platform
+
+```bash
+> platform
+NRF52840
 Done
 ```
 

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -5463,6 +5463,13 @@ exit:
 }
 
 #endif // OPENTHREAD_CONFIG_PING_SENDER_ENABLE
+       //
+template <> otError Interpreter::Process<Cmd("platform")>(Arg aArgs[])
+{
+    OT_UNUSED_VARIABLE(aArgs);
+    OutputLine("%s", OPENTHREAD_CONFIG_PLATFORM_INFO);
+    return OT_ERROR_NONE;
+}
 
 template <> otError Interpreter::Process<Cmd("pollperiod")>(Arg aArgs[])
 {
@@ -7322,6 +7329,7 @@ otError Interpreter::ProcessCommand(Arg aArgs[])
 #if OPENTHREAD_CONFIG_PING_SENDER_ENABLE
         CmdEntry("ping"),
 #endif
+        CmdEntry("platform"),
         CmdEntry("pollperiod"),
 #if OPENTHREAD_FTD
         CmdEntry("preferrouterid"),

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -5463,7 +5463,7 @@ exit:
 }
 
 #endif // OPENTHREAD_CONFIG_PING_SENDER_ENABLE
-       //
+
 template <> otError Interpreter::Process<Cmd("platform")>(Arg aArgs[])
 {
     OT_UNUSED_VARIABLE(aArgs);


### PR DESCRIPTION
Sometime we need to identify which platform we are currently using, especially in a test cases, where a unified interface is provided to control devices, the test cases have no idea about current platform.