### PR TITLE
[build] fix `LOCAL_EXPORT_CFLAGS` 

### DIFF
--- a/Android.mk
+++ b/Android.mk
@@ -140,7 +140,6 @@ LOCAL_CFLAGS                                                                := \
 
 LOCAL_EXPORT_CFLAGS                                        := \
     $(OPENTHREAD_PUBLIC_CFLAGS)                               \
-    $(OPENTHREAD_PROJECT_CFLAGS)                              \
     $(NULL)
 
 LOCAL_EXPORT_C_INCLUDE_DIRS     := \
@@ -603,7 +602,6 @@ LOCAL_C_INCLUDES                                         := \
     $(NULL)
 
 LOCAL_CFLAGS                                                                := \
-    $(OPENTHREAD_PUBLIC_CFLAGS)                                                \
     $(OPENTHREAD_PRIVATE_CFLAGS)                                               \
     $(OPENTHREAD_PROJECT_CFLAGS)                                               \
     $(NULL)


### PR DESCRIPTION
`LOCAL_EXPORT_CFLAGS` is exporting `OPENTHREAD_PROJECT_CFLAGS` which contains quotes. This sometimes can cause compile errors due to limitation of Android build system.

Also, `ot-cli` is repeating the flags in `LOCAL_CFLAGS`, which can cause macro redefinition error. Since `ot-cli` depends on `ot-core`, it already gets the flags from `LOCAL_EXPORT_CFLAGS`.