### PR TITLE
[netdata] increase `kInfoStringSize`

### DIFF
--- a/src/core/thread/network_data_publisher.hpp
+++ b/src/core/thread/network_data_publisher.hpp
@@ -308,7 +308,7 @@ private:
         static constexpr uint32_t kExtraDelayToRemovePeferred =
             OPENTHREAD_CONFIG_NETDATA_PUBLISHER_EXTRA_DELAY_TIME_TO_REMOVE_PREFERRED;
 
-        static constexpr uint16_t kInfoStringSize = 50;
+        static constexpr uint16_t kInfoStringSize = 60;
 
         typedef String<kInfoStringSize> InfoString;
 


### PR DESCRIPTION
I recently saw a log line:
```
ExternalRoute fdde:ad00:beef:cafe::/64 (state:Add in netdata - total:1, preferred:0, desired:10
```
The string `(state:Add` is truncated. The actual string should be `(state:Added)`.

The info string of a prefix entry can be as long as 55 characters excluding the 
`\0`.

Example:
```
ExternalRoute fdde:ad00:beef:cafe::/64 (state:Removing)
```