### PR TITLE
[indirect-sender] reset CSL Tx attempts in `DataPollHandler`

### DIFF
--- a/src/core/mac/data_poll_handler.cpp
+++ b/src/core/mac/data_poll_handler.cpp
@@ -240,6 +240,9 @@ void DataPollHandler::HandleSentFrame(const Mac::TxFrame &aFrame, Error aError, 
     {
     case kErrorNone:
         aChild.ResetIndirectTxAttempts();
+#if OPENTHREAD_CONFIG_MAC_CSL_TRANSMITTER_ENABLE
+        aChild.ResetCslTxAttempts();
+#endif
         aChild.SetFrameReplacePending(false);
         break;
 


### PR DESCRIPTION
Fix an issue in which a CSL Transmitter would start to send malformed frames to the radio in the occasion of a data poll arriving while a delayed CSL transmission was already scheduled.

Notice that `CslTxScheduler::HandleSentFrame` is resetting both CSL Tx attempts and Indirect Tx attempts, so it makes sense to do the same in `DataPollHandler::HandleSentFrame`.