### PR TITLE
[csl] ensure current window is not missed when preparing CSL frame

### DIFF
--- a/src/core/thread/csl_tx_scheduler.hpp
+++ b/src/core/thread/csl_tx_scheduler.hpp
@@ -187,10 +187,13 @@ public:
     void Clear(void);
 
 private:
+    // Guard time in usec to add when checking delay while preparaing the CSL frame for tx.
+    static constexpr uint32_t kFramePreparationGuardInterval = 1500;
+
     void InitFrameRequestAhead(void);
     void RescheduleCslTx(void);
 
-    uint32_t GetNextCslTransmissionDelay(const Child &aChild, uint32_t &aDelayFromLastRx) const;
+    uint32_t GetNextCslTransmissionDelay(const Child &aChild, uint32_t &aDelayFromLastRx, uint32_t aAheadUs) const;
 
     // Callbacks from `Mac`
     Mac::TxFrame *HandleFrameRequest(Mac::TxFrames &aTxFrames);


### PR DESCRIPTION
This commit fixes how we determine the CSL timings when preparing a
frame for CSL transmission. When scheduling the next CSL, we use
`mCslFrameRequestAheadUs` time in `GetNextCslTransmissionDelay()`. We
basically schedule `Mac` to start the CSL tx operation a bit earlier
than the desired CSL tx time. In `HandleFrameRequest()` (when we are
preparing the frame to be sent) we should be already within
`mCslFrameRequestAheadUs` time from the tx time. So this commit changes
the code such that we invoke `GetNextCslTransmissionDelay()` with zero
`aAheadUs` interval when preparing the frame. This ensures that we do not
skip the current CSL window and move to the next.

This commit also adds a check in `HandleFrameRequest()` to ensure that
we did not miss the current CSL window. This situation can happen if
`Mac` happens to be busy with some other operation and therefore late
to start CSL tx and invoke `HandleFrameRequest()`. In such a case we
don't want to use delay tx time for next CSL window (which may be way
later) and instead we abort the current CSL tx operation by returning
a `nullptr` frame.

----

Here is the detailed description of the issue:
- From `CslTxScheduler::RescheduleCslTx()` we request MAC to perfom CSL and pass it a delay time.
- We calculate the delay calling `GetNextCslTransmissionDelay()`.
  - This calculation uses `mCslFrameRequestAheadUs` to schedule earlier (~`2 msec`) from the start of CSL window.
  - The CSL timings (delays) are all calculated in `usec` unit.
  - But when we schedule `Mac` we convert the delay to `msec` and divide by `1000`.
  - This basically rounds down the value (meaning the `Mac` may start CSL tx operation a bit earlier (the `usec` amount that was rounded down)).
-  When the time comes, `Mac` starts the CSL operation. It will ask `CslTxScheduler` to prepare the frame, calling its `HandleFrameRequest()` method.
   - The current code (without this PR) calls `GetNextCslTransmissionDelay()` to determine CSL window and tx time and it would still use the `mCslFrameRequestAheadUs` in its calculation.
   - But at this point we should be already within `mCslFrameRequestAheadUs` of the CSL tx time.
   - So depending on the timing, the calculation can assume we missed current CSL window and go to next.
   - We then end up requesting `Mac` to send a frame at much later tx time (whatever the next CSL window is).
   - This can then cause `Mac` to be blocked for this tx for a long time.
      - In case of RCP model, this can trigger a spinel timeout (which is 5 seconds) if the next CSL window is more than 5 second. We wait for 5 seconds for "tx done" response for the last tx request.
- Things worked before by basically relying on the amount that was rounded down when converting to `msec` (divide by `1000`).
   - If `Mac` started CSL operation quickly enough that we were within the rounded down range, the `GetNextCslTransmissionDelay()` would stay in current CSL window
   - Otherwise it would schedule for the next window.
