### PR TITLE
[netdata] ensure to update version on leader if there is any change

### DIFF
--- a/src/core/thread/network_data_leader_ftd.cpp
+++ b/src/core/thread/network_data_leader_ftd.cpp
@@ -712,11 +712,10 @@ void Leader::RegisterNetworkData(uint16_t aRloc16, const NetworkData &aNetworkDa
         }
     }
 
-    IncrementVersions(flags);
-
     DumpDebg("Register", GetBytes(), GetLength());
 
 exit:
+    IncrementVersions(flags);
 
     if (error != kErrorNone)
     {


### PR DESCRIPTION
This commit updates `RegisterNetdataData()` to ensure that versions are updated if there is any change even if there is an error during integration of new entries (e.g., running out of space in Network Data, or failing to allocate new service ID).

