### PR TITLE
[cli] add command to get network data versions

### DIFF
--- a/src/cli/README_NETDATA.md
+++ b/src/cli/README_NETDATA.md
@@ -147,6 +147,7 @@ After the device successfully attaches to a Thread network, the device will retr
 - [show](#show)
 - [steeringdata](#steeringdata-check-eui64discerner)
 - [unpublish](#unpublish)
+- [version](#version)
 
 ## Command Details
 
@@ -164,6 +165,7 @@ register
 show
 steeringdata
 unpublish
+version
 Done
 ```
 
@@ -323,5 +325,15 @@ Unpublishes a previously published on-mesh prefix or external route entry.
 
 ```bash
 > netdata unpublish fd00:1234:5678::/64
+Done
+```
+
+### version
+
+Gets the Network Data Version and Stable Version.
+
+```bash
+> netdata version
+version:42, stable:105
 Done
 ```

--- a/src/cli/cli_network_data.cpp
+++ b/src/cli/cli_network_data.cpp
@@ -661,6 +661,25 @@ exit:
     return error;
 }
 
+/**
+ * @cli netdata version
+ * @code
+ * netdata version
+ * version:42, stable:105
+ * Done
+ * @endcode
+ * @par api_copy
+ * #otNetDataGetVersion
+ */
+template <> otError NetworkData::Process<Cmd("version")>(Arg aArgs[])
+{
+    OT_UNUSED_VARIABLE(aArgs);
+    OutputLine("version:%u, stable:%u", otNetDataGetVersion(GetInstancePtr()),
+               otNetDataGetStableVersion(GetInstancePtr()));
+
+    return OT_ERROR_NONE;
+}
+
 otError NetworkData::Process(Arg aArgs[])
 {
 #define CmdEntry(aCommandString)                                   \
@@ -680,6 +699,7 @@ otError NetworkData::Process(Arg aArgs[])
 #if OPENTHREAD_CONFIG_NETDATA_PUBLISHER_ENABLE
         CmdEntry("unpublish"),
 #endif
+        CmdEntry("version"),
     };
 
 #undef CmdEntry


### PR DESCRIPTION
This commit adds new CLI command `netdata version` to get the current Network Data's version and stable version.