### PR TITLE
[nat64] delete nat64_set_enabled() when starting BR in tests

### DIFF
--- a/tests/scripts/thread-cert/border_router/nat64/test_multi_border_routers.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_multi_border_routers.py
@@ -34,11 +34,8 @@ import thread_cert
 import enum
 
 # Test description:
-#   This test verifies that a single NAT64 prefix is advertised when there are
+#   This test verifies that a single NAT64 prefix is published when there are
 #   multiple Border Routers in the same Thread and infrastructure network.
-#
-#   TODO: add checks for outbound connectivity from Thread device to IPv4 host
-#         after OTBR change is ready.
 #
 # Topology:
 #    ----------------(eth)--------------------------
@@ -110,8 +107,8 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         host.start(start_radvd=False)
         self.simulator.go(5)
 
+        # NAT64 is enabled by default when starting BR1.
         br1.start()
-        br1.nat64_set_enabled(True)
         self.simulator.go(config.LEADER_STARTUP_DELAY)
         br1.bash("service bind9 stop")
         self.simulator.go(NAT64_PREFIX_REFRESH_DELAY)
@@ -125,8 +122,8 @@ class Nat64MultiBorderRouter(thread_cert.TestCase):
         # Case 1. BR2 with an infrastructure prefix joins the network later and
         #         it will add the infrastructure nat64 prefix to Network Data.
         #
+        # NAT64 is enabled by default when starting BR2.
         br2.start()
-        br2.nat64_set_enabled(True)
         self.simulator.go(config.BORDER_ROUTER_STARTUP_DELAY)
         self.assertEqual('router', br2.get_state())
 

--- a/tests/scripts/thread-cert/border_router/nat64/test_single_border_router.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_single_border_router.py
@@ -39,11 +39,10 @@ import socket
 import select
 
 # Test description:
-#   This test verifies the advertisement of local NAT64 prefix in Thread network
+#   This test verifies publishing the local NAT64 prefix in Thread network
 #   when no NAT64 prefix found on infrastructure interface.
-#
-#   TODO: add checks for outbound connectivity from Thread device to IPv4 host
-#         after OTBR change is ready.
+#   It also verifies the outbound connectivity from a Thread device to
+#   an IPv4 host address.
 #
 # Topology:
 #    ----------------(eth)--------------------
@@ -116,8 +115,8 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         host.start(start_radvd=False)
         self.simulator.go(5)
 
+        # NAT64 is enabled by default when starting BR.
         br.start()
-        br.enable_nat64()
         self.simulator.go(config.LEADER_STARTUP_DELAY)
         br.bash("service bind9 stop")
         self.simulator.go(330)

--- a/tests/scripts/thread-cert/border_router/nat64/test_with_infrastructure_prefix.py
+++ b/tests/scripts/thread-cert/border_router/nat64/test_with_infrastructure_prefix.py
@@ -32,7 +32,7 @@ import config
 import thread_cert
 
 # Test description:
-#   This test verifies the advertisement of infrastructure NAT64 prefix in Thread network.
+#   This test verifies publishing infrastructure NAT64 prefix in Thread network.
 #
 #
 # Topology:
@@ -74,8 +74,8 @@ class Nat64SingleBorderRouter(thread_cert.TestCase):
         br = self.nodes[BR]
         router = self.nodes[ROUTER]
 
+        # NAT64 is enabled by default when starting BR.
         br.start()
-        br.enable_nat64()
         self.simulator.go(config.LEADER_STARTUP_DELAY)
         self.assertEqual('leader', br.get_state())
 


### PR DESCRIPTION
This PR deletes calling nat64_set_enabled() when starting BR in tests. NAT64 is enabled by default.