### PR TITLE
[mpl] reset seed entry lifetime on rx/tx

### DIFF
--- a/src/core/net/ip6_mpl.cpp
+++ b/src/core/net/ip6_mpl.cpp
@@ -191,6 +191,8 @@ Error Mpl::UpdateSeedSet(uint16_t aSeedId, uint8_t aSequence)
             if (aSequence == mSeedSet[i].mSequence)
             {
                 // already received, drop message
+
+                mSeedSet[i].mLifetime = kSeedEntryLifetime;
                 ExitNow(error = kErrorDrop);
             }
             else if (insert == nullptr && SerialNumber::IsLess(aSequence, mSeedSet[i].mSequence))


### PR DESCRIPTION
This commit updates `Mpl::UpdateSeedSet()` to reset the `SeedEntry` lifetime to `kSeedEntryLifetime` if we rx/tx a message with same ID and sequence. This ensures that the entry is kept in the array while other routers are forwarding the same message.