### PR TITLE
[router-table] simplify tracking of routers and allocated IDs

### DIFF
--- a/src/core/common/array.hpp
+++ b/src/core/common/array.hpp
@@ -39,6 +39,7 @@
 #include "common/code_utils.hpp"
 #include "common/const_cast.hpp"
 #include "common/error.hpp"
+#include "common/locator.hpp"
 #include "common/numeric_limits.hpp"
 #include "common/type_traits.hpp"
 
@@ -145,6 +146,24 @@ public:
      *
      */
     Array(const Array &aOtherArray) { *this = aOtherArray; }
+
+    /**
+     * This constructor initializes the array as empty and initializes its elements by calling `Init(Instance &)`
+     * method on every element.
+     *
+     * This constructor uses method `Init(Instance &aInstance)` on `Type`.
+     *
+     * @param[in] aInstance  The OpenThread instance.
+     *
+     */
+    explicit Array(Instance &aInstance)
+        : mLength(0)
+    {
+        for (Type &element : mElements)
+        {
+            element.Init(aInstance);
+        }
+    }
 
     /**
      * This method clears the array.
@@ -556,6 +575,23 @@ public:
         }
 
         return *this;
+    }
+
+    /**
+     * This method indicates whether a given entry pointer is from the array buffer.
+     *
+     * This method does not check the current length of array and only checks that @p aEntry is pointing to an address
+     * contained within underlying C array buffer.
+     *
+     * @param[in] aEntry   A pointer to an entry to check.
+     *
+     * @retval TRUE  The @p aEntry is from the array.
+     * @retval FALSE The @p aEntry is not from the array.
+     *
+     */
+    bool IsInArrayBuffer(const Type *aEntry) const
+    {
+        return (&mElements[0] <= aEntry) && (aEntry < GetArrayEnd(mElements));
     }
 
     // The following methods are intended to support range-based `for`

--- a/src/core/radio/trel_link.cpp
+++ b/src/core/radio/trel_link.cpp
@@ -265,7 +265,7 @@ void Link::HandleTimer(void)
         HandleTimer(child);
     }
 
-    for (Router &router : Get<RouterTable>().Iterate())
+    for (Router &router : Get<RouterTable>())
     {
         HandleTimer(router);
     }

--- a/src/core/thread/key_manager.cpp
+++ b/src/core/thread/key_manager.cpp
@@ -238,7 +238,7 @@ void KeyManager::ResetFrameCounters(void)
 
 #if OPENTHREAD_FTD
     // reset router frame counters
-    for (Router &router : Get<RouterTable>().Iterate())
+    for (Router &router : Get<RouterTable>())
     {
         router.SetKeySequence(0);
         router.GetLinkFrameCounters().Reset();

--- a/src/core/thread/mle_router.cpp
+++ b/src/core/thread/mle_router.cpp
@@ -1755,7 +1755,7 @@ bool MleRouter::HasNeighborWithGoodLinkQuality(void) const
         ExitNow();
     }
 
-    for (Router &router : Get<RouterTable>().Iterate())
+    for (const Router &router : Get<RouterTable>())
     {
         if (!router.IsStateValid())
         {
@@ -1935,7 +1935,7 @@ void MleRouter::HandleTimeTick(void)
     }
 
     // update router state
-    for (Router &router : Get<RouterTable>().Iterate())
+    for (Router &router : Get<RouterTable>())
     {
         uint32_t age;
 
@@ -3978,7 +3978,7 @@ void MleRouter::SendAddressSolicitResponse(const Coap::Message    &aRequest,
 
         routerMaskTlv.Init();
         routerMaskTlv.SetIdSequence(mRouterTable.GetRouterIdSequence());
-        routerMaskTlv.SetAssignedRouterIdMask(mRouterTable.GetRouterIdSet());
+        mRouterTable.GetRouterIdSet(routerMaskTlv.GetAssignedRouterIdMask());
 
         SuccessOrExit(routerMaskTlv.AppendTo(*message));
     }
@@ -4107,7 +4107,7 @@ void MleRouter::FillConnectivityTlv(ConnectivityTlv &aTlv)
 
     aTlv.SetActiveRouters(mRouterTable.GetActiveRouterCount());
 
-    for (Router &router : Get<RouterTable>().Iterate())
+    for (const Router &router : Get<RouterTable>())
     {
         if (router.GetRloc16() == GetRloc16())
         {
@@ -4150,7 +4150,7 @@ bool MleRouter::HasMinDowngradeNeighborRouters(void)
 {
     uint8_t routerCount = 0;
 
-    for (Router &router : Get<RouterTable>().Iterate())
+    for (const Router &router : Get<RouterTable>())
     {
         if (!router.IsStateValid())
         {
@@ -4172,7 +4172,7 @@ bool MleRouter::HasOneNeighborWithComparableConnectivity(const RouteTlv &aRouteT
     bool    rval        = true;
 
     // process local neighbor routers
-    for (Router &router : Get<RouterTable>().Iterate())
+    for (const Router &router : Get<RouterTable>())
     {
         LinkQuality localLinkQuality;
         LinkQuality peerLinkQuality;

--- a/src/core/thread/router_table.hpp
+++ b/src/core/thread/router_table.hpp
@@ -33,6 +33,7 @@
 
 #if OPENTHREAD_FTD
 
+#include "common/array.hpp"
 #include "common/const_cast.hpp"
 #include "common/encoding.hpp"
 #include "common/iterator_utils.hpp"
@@ -49,41 +50,8 @@ namespace ot {
 class RouterTable : public InstanceLocator, private NonCopyable
 {
     friend class NeighborTable;
-    class IteratorBuilder;
 
 public:
-    /**
-     * This class represents an iterator for iterating through entries in the router table.
-     *
-     */
-    class Iterator : public InstanceLocator, public ItemPtrIterator<Router, Iterator>
-    {
-        friend class ItemPtrIterator<Router, Iterator>;
-        friend class IteratorBuilder;
-
-    public:
-        /**
-         * This constructor initializes an `Iterator` instance to start from beginning of the router table.
-         *
-         * @param[in] aInstance  A reference to the OpenThread instance.
-         *
-         */
-        explicit Iterator(Instance &aInstance);
-
-    private:
-        enum IteratorType : uint8_t
-        {
-            kEndIterator,
-        };
-
-        Iterator(Instance &aInstance, IteratorType)
-            : InstanceLocator(aInstance)
-        {
-        }
-
-        void Advance(void);
-    };
-
     /**
      * Constructor.
      *
@@ -148,7 +116,7 @@ public:
      * @returns The number of active routers in the Thread network.
      *
      */
-    uint8_t GetActiveRouterCount(void) const { return mActiveRouterCount; }
+    uint8_t GetActiveRouterCount(void) const { return mRouters.GetLength(); }
 
     /**
      * This method returns the leader in the Thread network.
@@ -258,8 +226,7 @@ public:
      */
     bool Contains(const Neighbor &aNeighbor) const
     {
-        return mRouters <= &static_cast<const Router &>(aNeighbor) &&
-               &static_cast<const Router &>(aNeighbor) < mRouters + Mle::kMaxRouters;
+        return mRouters.IsInArrayBuffer(&static_cast<const Router &>(aNeighbor));
     }
 
     /**
@@ -308,7 +275,7 @@ public:
      * @retval FALSE if @p aRouterId is not allocated.
      *
      */
-    bool IsAllocated(uint8_t aRouterId) const;
+    bool IsAllocated(uint8_t aRouterId) const { return mRouterIdMap.IsAllocated(aRouterId); }
 
     /**
      * This method updates the Router ID allocation set.
@@ -325,7 +292,7 @@ public:
      * @returns The allocated Router ID set.
      *
      */
-    const Mle::RouterIdSet &GetRouterIdSet(void) const { return mAllocatedRouterIds; }
+    void GetRouterIdSet(Mle::RouterIdSet &aRouterIdSet) const { return mRouterIdMap.GetAsRouterIdSet(aRouterIdSet); }
 
     /**
      * This method fills a Route TLV.
@@ -346,18 +313,6 @@ public:
      */
     void HandleTimeTick(void);
 
-    /**
-     * This method enables range-based `for` loop iteration over all Router entries in the Router table.
-     *
-     * This method should be used as follows:
-     *
-     *     for (Router &router : Get<RouterTable>().Iterate()) { ... }
-     *
-     * @returns An `IteratorBuilder` instance.
-     *
-     */
-    IteratorBuilder Iterate(void) { return IteratorBuilder(GetInstance()); }
-
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     void GetRouterIdRange(uint8_t &aMinRouterId, uint8_t &aMaxRouterId) const;
 
@@ -369,30 +324,23 @@ public:
      * This method logs the route table.
      *
      */
-    void LogRouteTable(void);
+    void LogRouteTable(void) const;
 #else
-    void LogRouteTable(void) {}
+    void LogRouteTable(void) const {}
 #endif
 
+    // The following methods are intended to support range-based `for`
+    // loop iteration over the router and should not be used
+    // directly.
+
+    Router       *begin(void) { return mRouters.begin(); }
+    Router       *end(void) { return mRouters.end(); }
+    const Router *begin(void) const { return mRouters.begin(); }
+    const Router *end(void) const { return mRouters.end(); }
+
 private:
-    class IteratorBuilder : public InstanceLocator
-    {
-    public:
-        explicit IteratorBuilder(Instance &aInstance)
-            : InstanceLocator(aInstance)
-        {
-        }
-
-        Iterator begin(void) { return Iterator(GetInstance()); }
-        Iterator end(void) { return Iterator(GetInstance(), Iterator::kEndIterator); }
-    };
-
-    void          UpdateAllocation(void);
-    const Router *GetFirstEntry(void) const;
-    const Router *GetNextEntry(const Router *aRouter) const;
-    Router       *GetFirstEntry(void) { return AsNonConst(AsConst(this)->GetFirstEntry()); }
-    Router       *GetNextEntry(Router *aRouter) { return AsNonConst(AsConst(this)->GetNextEntry(aRouter)); }
-
+    Router       *AddRouter(uint8_t aRouterId);
+    void          RemoveRouter(Router &aRouter);
     Router       *FindNeighbor(uint16_t aRloc16);
     Router       *FindNeighbor(const Mac::ExtAddress &aExtAddress);
     Router       *FindNeighbor(const Mac::Address &aMacAddress);
@@ -402,12 +350,41 @@ private:
         return AsNonConst(AsConst(this)->FindRouter(aMatcher));
     }
 
-    Router           mRouters[Mle::kMaxRouters];
-    Mle::RouterIdSet mAllocatedRouterIds;
-    uint8_t          mRouterIdReuseDelay[Mle::kMaxRouterId + 1];
-    TimeMilli        mRouterIdSequenceLastUpdated;
-    uint8_t          mRouterIdSequence;
-    uint8_t          mActiveRouterCount;
+    class RouterIdMap
+    {
+    public:
+        // The `RouterIdMap` tracks which Router IDs are allocated.
+        // For allocated IDs, tracks the index of the `Router` entry
+        // in `mRouters` array. For unallocated IDs, tracks the
+        // remaining reuse delay time (in seconds).
+
+        RouterIdMap(void) { Clear(); }
+        void    Clear(void) { memset(mIndexes, 0, sizeof(mIndexes)); }
+        bool    IsAllocated(uint8_t aRouterId) const { return (mIndexes[aRouterId] & kAllocatedFlag); }
+        uint8_t GetIndex(uint8_t aRouterId) const { return (mIndexes[aRouterId] & kIndexMask); }
+        void    SetIndex(uint8_t aRouterId, uint8_t aIndex) { mIndexes[aRouterId] = kAllocatedFlag | aIndex; }
+        bool    CanAllocate(uint8_t aRouterId) const { return (mIndexes[aRouterId] == 0); }
+        void    Release(uint8_t aRouterId) { mIndexes[aRouterId] = Mle::kRouterIdReuseDelay; }
+        void    GetAsRouterIdSet(Mle::RouterIdSet &aRouterIdSet) const;
+        void    HandleTimeTick(void);
+
+    private:
+        // The high bit in `mIndexes[aRouterId]` indicates whether or
+        // not the router ID is allocated. The lower 7 bits give either
+        // the index in `mRouter` array or remaining reuse delay time.
+
+        static constexpr uint8_t kAllocatedFlag = 1 << 7;
+        static constexpr uint8_t kIndexMask     = 0x7f;
+
+        static_assert(Mle::kRouterIdReuseDelay <= kIndexMask, "Mle::kRouterIdReuseDelay does not fit in 7 bits");
+
+        uint8_t mIndexes[Mle::kMaxRouterId + 1];
+    };
+
+    Array<Router, Mle::kMaxRouters> mRouters;
+    RouterIdMap                     mRouterIdMap;
+    TimeMilli                       mRouterIdSequenceLastUpdated;
+    uint8_t                         mRouterIdSequence;
 #if OPENTHREAD_CONFIG_REFERENCE_DEVICE_ENABLE
     uint8_t mMinRouterId;
     uint8_t mMaxRouterId;

--- a/src/core/thread/thread_tlvs.hpp
+++ b/src/core/thread/thread_tlvs.hpp
@@ -250,6 +250,14 @@ public:
     const Mle::RouterIdSet &GetAssignedRouterIdMask(void) const { return mAssignedRouterIdMask; }
 
     /**
+     * This method gets the Assigned Router ID Mask.
+     *
+     * @returns The Assigned Router ID Mask.
+     *
+     */
+    Mle::RouterIdSet &GetAssignedRouterIdMask(void) { return mAssignedRouterIdMask; }
+
+    /**
      * This method sets the Assigned Router ID Mask.
      *
      * @param[in]  aRouterIdSet A reference to the Assigned Router ID Mask.


### PR DESCRIPTION
This commit simplifies how `RouterTable` tracks the allocated Router IDs and the `Router` entries. A new class `RouterIdMap` is added which tracks the currently allocated Router IDs. For allocated IDs, it also tracks the index of the `Router` entry in `mRouters` array. For unallocated IDs, it tracks the remaining reuse delay time in seconds (using the same underlying `uint8_t` per Router ID). This new class makes it easier to find a `Router` by its ID. With this change, we no longer need to keep the `mRouters` array sorted based on Router ID (this was used when populating `RouteTlv`).

This commit also changes the `mRouters` to use `Array<Router>` which will then tracks its length and also simplify range-based `for` iteration over `RouterTable` entries.