### PR TITLE
[nat64] update counter types from uint64_t to int64_t

### DIFF
--- a/include/openthread/instance.h
+++ b/include/openthread/instance.h
@@ -53,7 +53,7 @@ extern "C" {
  * @note This number versions both OpenThread platform and user APIs.
  *
  */
-#define OPENTHREAD_API_VERSION (265)
+#define OPENTHREAD_API_VERSION (266)
 
 /**
  * @addtogroup api-instance

--- a/include/openthread/nat64.h
+++ b/include/openthread/nat64.h
@@ -94,10 +94,10 @@ typedef struct otIp4Cidr
  */
 typedef struct otNat64Counters
 {
-    uint64_t m4To6Packets; ///< Number of packets translated from IPv4 to IPv6.
-    uint64_t m4To6Bytes;   ///< Sum of size of packets translated from IPv4 to IPv6.
-    uint64_t m6To4Packets; ///< Number of packets translated from IPv6 to IPv4.
-    uint64_t m6To4Bytes;   ///< Sum of size of packets translated from IPv6 to IPv4.
+    int64_t m4To6Packets; ///< Number of packets translated from IPv4 to IPv6.
+    int64_t m4To6Bytes;   ///< Sum of size of packets translated from IPv4 to IPv6.
+    int64_t m6To4Packets; ///< Number of packets translated from IPv6 to IPv4.
+    int64_t m6To4Bytes;   ///< Sum of size of packets translated from IPv6 to IPv4.
 } otNat64Counters;
 
 /**
@@ -132,8 +132,8 @@ typedef enum otNat64DropReason
  */
 typedef struct otNat64ErrorCounters
 {
-    uint64_t mCount4To6[OT_NAT64_DROP_REASON_COUNT]; ///< Errors translating IPv4 packets.
-    uint64_t mCount6To4[OT_NAT64_DROP_REASON_COUNT]; ///< Errors translating IPv6 packets.
+    int64_t mCount4To6[OT_NAT64_DROP_REASON_COUNT]; ///< Errors translating IPv4 packets.
+    int64_t mCount6To4[OT_NAT64_DROP_REASON_COUNT]; ///< Errors translating IPv6 packets.
 } otNat64ErrorCounters;
 
 /**
@@ -173,7 +173,7 @@ typedef struct otNat64AddressMapping
 
     otIp4Address mIp4;             ///< The IPv4 address of the mapping.
     otIp6Address mIp6;             ///< The IPv6 address of the mapping.
-    uint32_t     mRemainingTimeMs; ///< Remaining time before expiry in milliseconds.
+    int64_t      mRemainingTimeMs; ///< Remaining time before expiry in milliseconds.
 
     otNat64ProtocolCounters mCounters;
 } otNat64AddressMapping;

--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -887,36 +887,36 @@ template <> otError Interpreter::Process<Cmd("nat64")>(Arg aArgs[])
                          ToUlong(static_cast<uint32_t>(mapping.mId & 0xffffffff)));
             OutputFormat("| %40s ", ip6AddressString);
             OutputFormat("| %16s ", ip4AddressString);
-            OutputFormat("| %5lus ", ToUlong(mapping.mRemainingTimeMs / 1000));
-            OutputFormat("| %8s ", Uint64ToString(mapping.mCounters.mTotal.m4To6Packets, u64StringBuffer));
-            OutputFormat("| %12s ", Uint64ToString(mapping.mCounters.mTotal.m4To6Bytes, u64StringBuffer));
-            OutputFormat("| %8s ", Uint64ToString(mapping.mCounters.mTotal.m6To4Packets, u64StringBuffer));
-            OutputFormat("| %12s ", Uint64ToString(mapping.mCounters.mTotal.m6To4Bytes, u64StringBuffer));
+            OutputFormat("| %5ss ", Int64ToString(mapping.mRemainingTimeMs, u64StringBuffer));
+            OutputFormat("| %8s ", Int64ToString(mapping.mCounters.mTotal.m4To6Packets, u64StringBuffer));
+            OutputFormat("| %12s ", Int64ToString(mapping.mCounters.mTotal.m4To6Bytes, u64StringBuffer));
+            OutputFormat("| %8s ", Int64ToString(mapping.mCounters.mTotal.m6To4Packets, u64StringBuffer));
+            OutputFormat("| %12s ", Int64ToString(mapping.mCounters.mTotal.m6To4Bytes, u64StringBuffer));
 
             OutputLine("|");
 
             OutputFormat("| %16s ", "");
             OutputFormat("| %68s ", "TCP");
-            OutputFormat("| %8s ", Uint64ToString(mapping.mCounters.mTcp.m4To6Packets, u64StringBuffer));
-            OutputFormat("| %12s ", Uint64ToString(mapping.mCounters.mTcp.m4To6Bytes, u64StringBuffer));
-            OutputFormat("| %8s ", Uint64ToString(mapping.mCounters.mTcp.m6To4Packets, u64StringBuffer));
-            OutputFormat("| %12s ", Uint64ToString(mapping.mCounters.mTcp.m6To4Bytes, u64StringBuffer));
+            OutputFormat("| %8s ", Int64ToString(mapping.mCounters.mTcp.m4To6Packets, u64StringBuffer));
+            OutputFormat("| %12s ", Int64ToString(mapping.mCounters.mTcp.m4To6Bytes, u64StringBuffer));
+            OutputFormat("| %8s ", Int64ToString(mapping.mCounters.mTcp.m6To4Packets, u64StringBuffer));
+            OutputFormat("| %12s ", Int64ToString(mapping.mCounters.mTcp.m6To4Bytes, u64StringBuffer));
             OutputLine("|");
 
             OutputFormat("| %16s ", "");
             OutputFormat("| %68s ", "UDP");
-            OutputFormat("| %8s ", Uint64ToString(mapping.mCounters.mUdp.m4To6Packets, u64StringBuffer));
-            OutputFormat("| %12s ", Uint64ToString(mapping.mCounters.mUdp.m4To6Bytes, u64StringBuffer));
-            OutputFormat("| %8s ", Uint64ToString(mapping.mCounters.mUdp.m6To4Packets, u64StringBuffer));
-            OutputFormat("| %12s ", Uint64ToString(mapping.mCounters.mUdp.m6To4Bytes, u64StringBuffer));
+            OutputFormat("| %8s ", Int64ToString(mapping.mCounters.mUdp.m4To6Packets, u64StringBuffer));
+            OutputFormat("| %12s ", Int64ToString(mapping.mCounters.mUdp.m4To6Bytes, u64StringBuffer));
+            OutputFormat("| %8s ", Int64ToString(mapping.mCounters.mUdp.m6To4Packets, u64StringBuffer));
+            OutputFormat("| %12s ", Int64ToString(mapping.mCounters.mUdp.m6To4Bytes, u64StringBuffer));
             OutputLine("|");
 
             OutputFormat("| %16s ", "");
             OutputFormat("| %68s ", "ICMP");
-            OutputFormat("| %8s ", Uint64ToString(mapping.mCounters.mIcmp.m4To6Packets, u64StringBuffer));
-            OutputFormat("| %12s ", Uint64ToString(mapping.mCounters.mIcmp.m4To6Bytes, u64StringBuffer));
-            OutputFormat("| %8s ", Uint64ToString(mapping.mCounters.mIcmp.m6To4Packets, u64StringBuffer));
-            OutputFormat("| %12s ", Uint64ToString(mapping.mCounters.mIcmp.m6To4Bytes, u64StringBuffer));
+            OutputFormat("| %8s ", Int64ToString(mapping.mCounters.mIcmp.m4To6Packets, u64StringBuffer));
+            OutputFormat("| %12s ", Int64ToString(mapping.mCounters.mIcmp.m4To6Bytes, u64StringBuffer));
+            OutputFormat("| %8s ", Int64ToString(mapping.mCounters.mIcmp.m6To4Packets, u64StringBuffer));
+            OutputFormat("| %12s ", Int64ToString(mapping.mCounters.mIcmp.m6To4Bytes, u64StringBuffer));
             OutputLine("|");
         }
     }
@@ -990,35 +990,35 @@ template <> otError Interpreter::Process<Cmd("nat64")>(Arg aArgs[])
         otNat64GetErrorCounters(GetInstancePtr(), &errorCounters);
 
         OutputFormat("| %13s ", "Total");
-        OutputFormat("| %8s ", Uint64ToString(counters.mTotal.m4To6Packets, u64StringBuffer));
-        OutputFormat("| %12s ", Uint64ToString(counters.mTotal.m4To6Bytes, u64StringBuffer));
-        OutputFormat("| %8s ", Uint64ToString(counters.mTotal.m6To4Packets, u64StringBuffer));
-        OutputLine("| %12s |", Uint64ToString(counters.mTotal.m6To4Bytes, u64StringBuffer));
+        OutputFormat("| %8s ", Int64ToString(counters.mTotal.m4To6Packets, u64StringBuffer));
+        OutputFormat("| %12s ", Int64ToString(counters.mTotal.m4To6Bytes, u64StringBuffer));
+        OutputFormat("| %8s ", Int64ToString(counters.mTotal.m6To4Packets, u64StringBuffer));
+        OutputLine("| %12s |", Int64ToString(counters.mTotal.m6To4Bytes, u64StringBuffer));
 
         OutputFormat("| %13s ", "TCP");
-        OutputFormat("| %8s ", Uint64ToString(counters.mTcp.m4To6Packets, u64StringBuffer));
-        OutputFormat("| %12s ", Uint64ToString(counters.mTcp.m4To6Bytes, u64StringBuffer));
-        OutputFormat("| %8s ", Uint64ToString(counters.mTcp.m6To4Packets, u64StringBuffer));
-        OutputLine("| %12s |", Uint64ToString(counters.mTcp.m6To4Bytes, u64StringBuffer));
+        OutputFormat("| %8s ", Int64ToString(counters.mTcp.m4To6Packets, u64StringBuffer));
+        OutputFormat("| %12s ", Int64ToString(counters.mTcp.m4To6Bytes, u64StringBuffer));
+        OutputFormat("| %8s ", Int64ToString(counters.mTcp.m6To4Packets, u64StringBuffer));
+        OutputLine("| %12s |", Int64ToString(counters.mTcp.m6To4Bytes, u64StringBuffer));
 
         OutputFormat("| %13s ", "UDP");
-        OutputFormat("| %8s ", Uint64ToString(counters.mUdp.m4To6Packets, u64StringBuffer));
-        OutputFormat("| %12s ", Uint64ToString(counters.mUdp.m4To6Bytes, u64StringBuffer));
-        OutputFormat("| %8s ", Uint64ToString(counters.mUdp.m6To4Packets, u64StringBuffer));
-        OutputLine("| %12s |", Uint64ToString(counters.mUdp.m6To4Bytes, u64StringBuffer));
+        OutputFormat("| %8s ", Int64ToString(counters.mUdp.m4To6Packets, u64StringBuffer));
+        OutputFormat("| %12s ", Int64ToString(counters.mUdp.m4To6Bytes, u64StringBuffer));
+        OutputFormat("| %8s ", Int64ToString(counters.mUdp.m6To4Packets, u64StringBuffer));
+        OutputLine("| %12s |", Int64ToString(counters.mUdp.m6To4Bytes, u64StringBuffer));
 
         OutputFormat("| %13s ", "ICMP");
-        OutputFormat("| %8s ", Uint64ToString(counters.mIcmp.m4To6Packets, u64StringBuffer));
-        OutputFormat("| %12s ", Uint64ToString(counters.mIcmp.m4To6Bytes, u64StringBuffer));
-        OutputFormat("| %8s ", Uint64ToString(counters.mIcmp.m6To4Packets, u64StringBuffer));
-        OutputLine("| %12s |", Uint64ToString(counters.mIcmp.m6To4Bytes, u64StringBuffer));
+        OutputFormat("| %8s ", Int64ToString(counters.mIcmp.m4To6Packets, u64StringBuffer));
+        OutputFormat("| %12s ", Int64ToString(counters.mIcmp.m4To6Bytes, u64StringBuffer));
+        OutputFormat("| %8s ", Int64ToString(counters.mIcmp.m6To4Packets, u64StringBuffer));
+        OutputLine("| %12s |", Int64ToString(counters.mIcmp.m6To4Bytes, u64StringBuffer));
 
         OutputTableHeader(kNat64CounterTableErrorSubHeader, kNat64CounterTableErrorSubHeaderColumns);
         for (uint8_t i = 0; i < OT_NAT64_DROP_REASON_COUNT; i++)
         {
             OutputFormat("| %13s | %23s ", kNat64CounterErrorType[i],
-                         Uint64ToString(errorCounters.mCount4To6[i], u64StringBuffer));
-            OutputLine("| %23s |", Uint64ToString(errorCounters.mCount6To4[i], u64StringBuffer));
+                         Int64ToString(errorCounters.mCount4To6[i], u64StringBuffer));
+            OutputLine("| %23s |", Int64ToString(errorCounters.mCount6To4[i], u64StringBuffer));
         }
     }
 #endif // OPENTHREAD_CONFIG_NAT64_TRANSLATOR_ENABLE

--- a/src/cli/cli_output.cpp
+++ b/src/cli/cli_output.cpp
@@ -122,6 +122,47 @@ void Output::OutputBytes(const uint8_t *aBytes, uint16_t aLength)
     }
 }
 
+const char *Output::Int64ToString(int64_t aInt64, Int64StringBuffer &aBuffer)
+{
+    char *   cur        = &aBuffer.mChars[ot::Cli::Output::Int64StringBuffer::kSize - 1];
+    bool     isNegative = (aInt64 < 0);
+    uint64_t absValue   = static_cast<uint64_t>(isNegative ? -aInt64 : aInt64);
+
+    *cur = '\0';
+
+    if (absValue == 0)
+    {
+        *(--cur) = '0';
+    }
+    else
+    {
+        for (; absValue != 0; absValue /= 10)
+        {
+            *(--cur) = static_cast<char>('0' + static_cast<uint8_t>(absValue % 10));
+        }
+
+        if (isNegative)
+        {
+            *(--cur) = '-';
+        }
+    }
+
+    return cur;
+}
+
+void Output::OutputInt64(int64_t aInt64)
+{
+    Int64StringBuffer buffer;
+
+    OutputFormat("%s", Int64ToString(aInt64, buffer));
+}
+
+void Output::OutputInt64Line(int64_t aInt64)
+{
+    OutputInt64(aInt64);
+    OutputNewLine();
+}
+
 void Output::OutputBytesLine(const uint8_t *aBytes, uint16_t aLength)
 {
     OutputBytes(aBytes, aLength);

--- a/src/cli/cli_output.hpp
+++ b/src/cli/cli_output.hpp
@@ -215,6 +215,25 @@ public:
     };
 
     /**
+     * Int64 string buffer can share the same buffer type as uint64.
+     *
+     * Note: `-9223372036854775808` (`INT64_MIN`) contains exactly 20 bytes.
+     *
+     */
+    typedef Uint64StringBuffer Int64StringBuffer;
+
+    /**
+     * This static method converts a `int64_t` value to a decimal format string.
+     *
+     * @param[in] aInt64  The `int64_t` value to convert.
+     * @param[in] aBuffer  A buffer to allocate the string from.
+     *
+     * @returns A pointer to the start of the string (null-terminated) representation of @p aInt64.
+     *
+     */
+    static const char *Int64ToString(int64_t aInt64, Int64StringBuffer &aBuffer);
+
+    /**
      * This static method converts a `uint64_t` value to a decimal format string.
      *
      * @param[in] aUint64  The `uint64_t` value to convert.
@@ -340,6 +359,22 @@ public:
      *
      */
     void OutputExtAddressLine(const otExtAddress &aExtAddress) { OutputBytesLine(aExtAddress.m8); }
+
+    /**
+     * This method outputs a `int64_t` value in decimal format.
+     *
+     * @param[in] aInt64   The `int64_t` value to output.
+     *
+     */
+    void OutputInt64(int64_t aInt64);
+
+    /**
+     * This method outputs a `int64_t` value in decimal format and at the end it also outputs newline "\r\n".
+     *
+     * @param[in] aInt64   The `int64_t` value to output.
+     *
+     */
+    void OutputInt64Line(int64_t aInt64);
 
     /**
      * This method outputs a `uint64_t` value in decimal format.


### PR DESCRIPTION
We may want to avoid the use of uint64_t types as int64_t won't overflow for most cases.

This PR update the type of counters for nat64 to int64_t.

Some considerations: almost every existing API is using uint32_t / uint64_t for counters, should we still follow the existing pattern?