### PR TITLE
[logging] fix print format using `%lu` for `uint32_t` variables

### DIFF
--- a/src/cli/cli.cpp
+++ b/src/cli/cli.cpp
@@ -44,6 +44,7 @@
 #include <openthread/logging.h>
 #include <openthread/ncp.h>
 #include <openthread/thread.h>
+#include "common/num_utils.hpp"
 #if OPENTHREAD_CONFIG_TIME_SYNC_ENABLE
 #include <openthread/network_time.h>
 #endif
@@ -710,12 +711,13 @@ template <> otError Interpreter::Process<Cmd("br")>(Arg aArgs[])
             char string[OT_IP6_PREFIX_STRING_SIZE];
 
             otIp6PrefixToString(&entry.mPrefix, string, sizeof(string));
-            OutputFormat("prefix:%s, on-link:%s, ms-since-rx:%u, lifetime:%u, ", string, entry.mIsOnLink ? "yes" : "no",
-                         entry.mMsecSinceLastUpdate, entry.mValidLifetime);
+            OutputFormat("prefix:%s, on-link:%s, ms-since-rx:%lu, lifetime:%lu, ", string,
+                         entry.mIsOnLink ? "yes" : "no", ToUlong(entry.mMsecSinceLastUpdate),
+                         ToUlong(entry.mValidLifetime));
 
             if (entry.mIsOnLink)
             {
-                OutputFormat("preferred:%u, ", entry.mPreferredLifetime);
+                OutputFormat("preferred:%lu, ", ToUlong(entry.mPreferredLifetime));
             }
             else
             {
@@ -2538,12 +2540,12 @@ template <> otError Interpreter::Process<Cmd("counters")>(Arg aArgs[])
                 OutputNewLine();
             }
 
-            OutputLine("RA Rx: %u", brCounters->mRaRx);
-            OutputLine("RA TxSuccess: %u", brCounters->mRaTxSuccess);
-            OutputLine("RA TxFailed: %u", brCounters->mRaTxFailure);
-            OutputLine("RS Rx: %u", brCounters->mRsRx);
-            OutputLine("RS TxSuccess: %u", brCounters->mRsTxSuccess);
-            OutputLine("RS TxFailed: %u", brCounters->mRsTxFailure);
+            OutputLine("RA Rx: %lu", ToUlong(brCounters->mRaRx));
+            OutputLine("RA TxSuccess: %lu", ToUlong(brCounters->mRaTxSuccess));
+            OutputLine("RA TxFailed: %lu", ToUlong(brCounters->mRaTxFailure));
+            OutputLine("RS Rx: %lu", ToUlong(brCounters->mRsRx));
+            OutputLine("RS TxSuccess: %lu", ToUlong(brCounters->mRsTxSuccess));
+            OutputLine("RS TxFailed: %lu", ToUlong(brCounters->mRsTxFailure));
         }
         /**
          * @cli counters br reset

--- a/src/core/border_router/infra_if.cpp
+++ b/src/core/border_router/infra_if.cpp
@@ -31,6 +31,7 @@
  */
 
 #include "infra_if.hpp"
+#include "common/num_utils.hpp"
 
 #if OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE
 
@@ -160,7 +161,7 @@ InfraIf::InfoString InfraIf::ToString(void) const
 {
     InfoString string;
 
-    string.Append("infra netif %u", mIfIndex);
+    string.Append("infra netif %lu", ToUlong(mIfIndex));
     return string;
 }
 

--- a/src/core/border_router/routing_manager.cpp
+++ b/src/core/border_router/routing_manager.cpp
@@ -2097,7 +2097,7 @@ void RoutingManager::OnLinkPrefixManager::Init(void)
         entry->mPrefix     = savedPrefix.GetPrefix();
         entry->mExpireTime = now + Time::SecToMsec(lifetime);
 
-        LogInfo("Restored old prefix %s, lifetime:%u", entry->mPrefix.ToString().AsCString(), lifetime);
+        LogInfo("Restored old prefix %s, lifetime:%lu", entry->mPrefix.ToString().AsCString(), ToUlong(lifetime));
 
         mTimer.FireAtIfEarlier(entry->mExpireTime);
     }

--- a/src/core/common/settings.cpp
+++ b/src/core/common/settings.cpp
@@ -37,6 +37,7 @@
 #include "common/code_utils.hpp"
 #include "common/instance.hpp"
 #include "common/locator_getters.hpp"
+#include "common/num_utils.hpp"
 #include "meshcop/dataset.hpp"
 #include "thread/mle.hpp"
 
@@ -381,8 +382,8 @@ void Settings::BrOnLinkPrefix::Log(const char *aActionText) const
 {
     OT_UNUSED_VARIABLE(aActionText);
 
-    LogInfo("%s %s entry {prefix:%s,lifetime:%u}", aActionText, KeyToString(kKeyBrOnLinkPrefixes),
-            GetPrefix().ToString().AsCString(), GetLifetime());
+    LogInfo("%s %s entry {prefix:%s,lifetime:%lu}", aActionText, KeyToString(kKeyBrOnLinkPrefixes),
+            GetPrefix().ToString().AsCString(), ToUlong(GetLifetime()));
 }
 
 #endif // OPENTHREAD_CONFIG_BORDER_ROUTING_ENABLE


### PR DESCRIPTION
Fix some `uint32_t` variables using `%u` format.

related: [[log] add compile-time check for printf style arg check to log functions](https://github.com/openthread/openthread/pull/8339)