### PR TITLE
[mle] allow rx-on/off with no re-attach based on initial attach mode

### DIFF
--- a/src/core/thread/mle.hpp
+++ b/src/core/thread/mle.hpp
@@ -2011,6 +2011,7 @@ private:
 
     bool mHasRestored;
     bool mReceivedResponseFromParent;
+    bool mInitiallyAttachedAsSleepy;
 
     Ip6::Udp::Socket mSocket;
     uint32_t         mTimeout;


### PR DESCRIPTION
This commit adds a new variable `mInitiallyAttachedAsSleepy` which tracks whether or not device was initially attached as a sleepy child. This is then used to determine whether or not we need to re-attach on mode changes between rx-on and sleepy (rx-off). If we initially attach as sleepy, then rx-on/off mode changes are allowed without re-attach (device sends "Child Update Request" to its parent to update its mode). Otherwise mode transition from rx-on to sleepy requires a re-attach.

----

Follow up on https://github.com/openthread/openthread/pull/8484.